### PR TITLE
Integrate user space instruemntation into OrbitService.

### DIFF
--- a/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
+++ b/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
@@ -34,13 +34,13 @@ namespace orbit_capture_event_producer {
 template <typename IntermediateEventT>
 class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
  public:
-  void BuildAndStart(const std::shared_ptr<grpc::Channel>& channel) override final {
+  void BuildAndStart(const std::shared_ptr<grpc::Channel>& channel) final {
     CaptureEventProducer::BuildAndStart(channel);
 
     forwarder_thread_ = std::thread{&LockFreeBufferCaptureEventProducer::ForwarderThread, this};
   }
 
-  void ShutdownAndWait() override final {
+  void ShutdownAndWait() final {
     shutdown_requested_ = true;
 
     CHECK(forwarder_thread_.joinable());

--- a/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
+++ b/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
@@ -34,13 +34,13 @@ namespace orbit_capture_event_producer {
 template <typename IntermediateEventT>
 class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
  public:
-  void BuildAndStart(const std::shared_ptr<grpc::Channel>& channel) override {
+  void BuildAndStart(const std::shared_ptr<grpc::Channel>& channel) override final {
     CaptureEventProducer::BuildAndStart(channel);
 
     forwarder_thread_ = std::thread{&LockFreeBufferCaptureEventProducer::ForwarderThread, this};
   }
 
-  void ShutdownAndWait() override {
+  void ShutdownAndWait() override final {
     shutdown_requested_ = true;
 
     CHECK(forwarder_thread_.joinable());

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -60,7 +60,8 @@ target_link_libraries(ServiceLib PUBLIC
         MemoryTracing
         ObjectUtils
         OrbitVersion
-        ProducerSideChannel)
+        ProducerSideChannel
+        UserSpaceInstrumentation)
 
 project(OrbitService)
 add_executable(OrbitService main.cpp)

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -286,8 +286,8 @@ static ProducerCaptureEvent CreateErrorEnablingOrbitApiEvent(uint64_t timestamp_
   return event;
 }
 
-static ProducerCaptureEvent CreateErrorEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns,
-                                                                             std::string message) {
+[[nodiscard]] static ProducerCaptureEvent CreateErrorEnablingUserSpaceInstrumentationEvent(
+    uint64_t timestamp_ns, std::string message) {
   ProducerCaptureEvent event;
   orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent*
       error_enabling_user_space_instrumentation_event =
@@ -356,9 +356,9 @@ grpc::Status CaptureServiceImpl::Capture(
   if (capture_options.enable_user_space_instrumentation()) {
     auto result = orbit_user_space_instrumentation::InstrumentProcess(capture_options);
     if (result.has_error()) {
-      ERROR("Could not enable user space instrumentation: %s", result.error().message());
       error_enabling_user_space_instrumentation = absl::StrFormat(
           "Could not enable user space instrumentation: %s", result.error().message());
+      ERROR("%s",error_enabling_user_space_instrumentation.value());
     } else {
       FilterOutInstrumentedFunctionsFromCaptureOptions(
           result.value(), capture_options_without_already_instrumented_functions);

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -30,6 +30,7 @@
 #include "OrbitVersion/OrbitVersion.h"
 #include "ProducerEventProcessor.h"
 #include "TracingHandler.h"
+#include "UserSpaceInstrumentation/InstrumentProcess.h"
 #include "capture.pb.h"
 
 namespace orbit_service {
@@ -176,6 +177,26 @@ class GrpcCaptureEventSender final : public CaptureEventSender {
   uint64_t total_number_of_bytes_sent_ = 0;
 };
 
+// Remove the functions with ids in `filter_function_ids` from instrumented_functions in
+// `capture_options`.
+void FilterOutInstrumentedFunctionsFromCaptureOptions(
+    const absl::flat_hash_set<uint64_t>& filter_function_ids, CaptureOptions& capture_options) {
+  // Move the entries that need to be deleted to the end of the repeated field and remove them with
+  // one single call to `DeleteSubrange`. This avoids quadratic complexity.
+  int first_to_delete = 0;
+  for (int i = 0; i < capture_options.instrumented_functions_size(); i++) {
+    const uint64_t function_id = capture_options.instrumented_functions(i).function_id();
+    if (!filter_function_ids.contains(function_id)) {
+      first_to_delete++;
+      if (i > first_to_delete - 1) {
+        capture_options.mutable_instrumented_functions()->SwapElements(i, first_to_delete - 1);
+      }
+    }
+  }
+  capture_options.mutable_instrumented_functions()->DeleteSubrange(
+      first_to_delete, capture_options.instrumented_functions_size() - first_to_delete);
+}
+
 }  // namespace
 
 // TracingHandler::Stop is blocking, until all perf_event_open events have been processed
@@ -265,6 +286,17 @@ static ProducerCaptureEvent CreateErrorEnablingOrbitApiEvent(uint64_t timestamp_
   return event;
 }
 
+static ProducerCaptureEvent CreateErrorEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns,
+                                                                             std::string message) {
+  ProducerCaptureEvent event;
+  orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent*
+      error_enabling_user_space_instrumentation_event =
+          event.mutable_error_enabling_user_space_instrumentation_event();
+  error_enabling_user_space_instrumentation_event->set_timestamp_ns(timestamp_ns);
+  error_enabling_user_space_instrumentation_event->set_message(std::move(message));
+  return event;
+}
+
 static ProducerCaptureEvent CreateWarningEvent(uint64_t timestamp_ns, std::string message) {
   ProducerCaptureEvent event;
   orbit_grpc_protos::WarningEvent* warning_event = event.mutable_warning_event();
@@ -315,6 +347,26 @@ grpc::Status CaptureServiceImpl::Capture(
     }
   }
 
+  // We need to filter out the functions instrumented by user space instrumentation.
+  CaptureOptions capture_options_without_already_instrumented_functions;
+  capture_options_without_already_instrumented_functions.CopyFrom(capture_options);
+
+  // Enable user space instrumentation.
+  std::optional<std::string> error_enabling_user_space_instrumentation;
+  if (capture_options.enable_user_space_instrumentation()) {
+    auto result = orbit_user_space_instrumentation::InstrumentProcess(capture_options);
+    if (result.has_error()) {
+      ERROR("Could not enable user space instrumentation: %s", result.error().message());
+      error_enabling_user_space_instrumentation = absl::StrFormat(
+          "Could not enable user space instrumentation: %s", result.error().message());
+    } else {
+      FilterOutInstrumentedFunctionsFromCaptureOptions(
+          result.value(), capture_options_without_already_instrumented_functions);
+      LOG("User space instrumentation enabled for %u out of %u instrumented functions.",
+          result.value().size(), capture_options.instrumented_functions_size());
+    }
+  }
+
   // These are not in precise sync but they do not have to be.
   absl::Time capture_start_time = absl::Now();
   uint64_t capture_start_timestamp_ns = orbit_base::CaptureTimestampNs();
@@ -334,7 +386,15 @@ grpc::Status CaptureServiceImpl::Capture(
                                          std::move(error_enabling_orbit_api.value())));
   }
 
-  tracing_handler.Start(capture_options);
+  if (error_enabling_user_space_instrumentation.has_value()) {
+    producer_event_processor->ProcessEvent(
+        orbit_grpc_protos::kRootProducerId,
+        CreateErrorEnablingUserSpaceInstrumentationEvent(
+            capture_start_timestamp_ns,
+            std::move(error_enabling_user_space_instrumentation.value())));
+  }
+
+  tracing_handler.Start(capture_options_without_already_instrumented_functions);
 
   memory_info_handler.Start(request.capture_options());
   for (CaptureStartStopListener* listener : capture_start_stop_listeners_) {
@@ -358,6 +418,19 @@ grpc::Status CaptureServiceImpl::Capture(
           CreateWarningEvent(
               orbit_base::CaptureTimestampNs(),
               absl::StrFormat("Could not disable Orbit API: %s", result.error().message())));
+    }
+  }
+
+  // Disable user space instrumentation.
+  if (capture_options.enable_user_space_instrumentation()) {
+    auto result_tmp = orbit_user_space_instrumentation::UninstrumentProcess(capture_options);
+    if (result_tmp.has_error()) {
+      ERROR("Disabling user space instrumentation: %s", result_tmp.error().message());
+      producer_event_processor->ProcessEvent(
+          orbit_grpc_protos::kRootProducerId,
+          CreateWarningEvent(orbit_base::CaptureTimestampNs(),
+                             absl::StrFormat("Could not disable user space instrumentation: %s",
+                                             result_tmp.error().message())));
     }
   }
 

--- a/src/Service/CaptureServiceImpl.h
+++ b/src/Service/CaptureServiceImpl.h
@@ -25,8 +25,7 @@ class CaptureServiceImpl final : public orbit_grpc_protos::CaptureService::Servi
   CaptureServiceImpl() {
     // We want to estimate clock resolution once, not at the beginning of every capture.
     EstimateAndLogClockResolution();
-    user_space_instrumentation_ =
-        orbit_user_space_instrumentation::UserSpaceInstrumentation::Create();
+    instrumentation_manager_ = orbit_user_space_instrumentation::InstrumentationManager::Create();
   }
 
   grpc::Status Capture(
@@ -41,8 +40,8 @@ class CaptureServiceImpl final : public orbit_grpc_protos::CaptureService::Servi
   std::atomic<bool> is_capturing = false;
   absl::flat_hash_set<CaptureStartStopListener*> capture_start_stop_listeners_;
 
-  std::unique_ptr<orbit_user_space_instrumentation::UserSpaceInstrumentation>
-      user_space_instrumentation_;
+  std::unique_ptr<orbit_user_space_instrumentation::InstrumentationManager>
+      instrumentation_manager_;
 
   uint64_t clock_resolution_ns_ = 0;
   void EstimateAndLogClockResolution();

--- a/src/Service/CaptureServiceImpl.h
+++ b/src/Service/CaptureServiceImpl.h
@@ -8,10 +8,12 @@
 #include <grpcpp/grpcpp.h>
 
 #include <atomic>
+#include <memory>
 
 #include "CaptureStartStopListener.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Profiling.h"
+#include "UserSpaceInstrumentation/InstrumentProcess.h"
 #include "absl/container/flat_hash_set.h"
 #include "services.grpc.pb.h"
 #include "services.pb.h"
@@ -23,6 +25,8 @@ class CaptureServiceImpl final : public orbit_grpc_protos::CaptureService::Servi
   CaptureServiceImpl() {
     // We want to estimate clock resolution once, not at the beginning of every capture.
     EstimateAndLogClockResolution();
+    user_space_instrumentation_ =
+        orbit_user_space_instrumentation::UserSpaceInstrumentation::Create();
   }
 
   grpc::Status Capture(
@@ -36,6 +40,9 @@ class CaptureServiceImpl final : public orbit_grpc_protos::CaptureService::Servi
  private:
   std::atomic<bool> is_capturing = false;
   absl::flat_hash_set<CaptureStartStopListener*> capture_start_stop_listeners_;
+
+  std::unique_ptr<orbit_user_space_instrumentation::UserSpaceInstrumentation>
+      user_space_instrumentation_;
 
   uint64_t clock_resolution_ns_ = 0;
   void EstimateAndLogClockResolution();

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -21,7 +21,8 @@ target_include_directories(UserSpaceInstrumentation PRIVATE
 target_sources(UserSpaceInstrumentation PUBLIC
         include/UserSpaceInstrumentation/Attach.h
         include/UserSpaceInstrumentation/ExecuteInProcess.h
-        include/UserSpaceInstrumentation/InjectLibraryInTracee.h)        
+        include/UserSpaceInstrumentation/InjectLibraryInTracee.h
+        include/UserSpaceInstrumentation/InstrumentProcess.h)
 
 target_sources(UserSpaceInstrumentation PRIVATE
         AccessTraceesMemory.cpp
@@ -36,6 +37,7 @@ target_sources(UserSpaceInstrumentation PRIVATE
         FindFunctionAddress.h
         FindFunctionAddress.cpp
         InjectLibraryInTracee.cpp
+        InstrumentProcess.cpp
         MachineCode.cpp
         MachineCode.h
         RegisterState.cpp
@@ -44,10 +46,31 @@ target_sources(UserSpaceInstrumentation PRIVATE
         Trampoline.h)
 
 target_link_libraries(UserSpaceInstrumentation PUBLIC
+        GrpcProtos
         LinuxTracing
         OrbitBase
         CONAN_PKG::abseil
         CONAN_PKG::capstone)
+
+# This lib is injected into the target process Orbit is profiling. It is providing the functions
+# executed on function entry/exit of an instrumented function.
+add_library(OrbitUserSpaceInstrumentation SHARED)
+
+target_compile_options(OrbitUserSpaceInstrumentation PRIVATE ${STRICT_COMPILE_FLAGS})
+
+target_compile_features(OrbitUserSpaceInstrumentation PUBLIC cxx_std_17)
+
+target_include_directories(OrbitUserSpaceInstrumentation PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR})
+
+target_sources(OrbitUserSpaceInstrumentation PRIVATE
+        OrbitUserSpaceInstrumentation.cpp
+        OrbitUserSpaceInstrumentation.h)
+
+target_link_libraries(OrbitUserSpaceInstrumentation PUBLIC
+        CaptureEventProducer
+        OrbitBase
+        ProducerSideChannel)
 
 # This test lib is merely used in UserSpaceInstrumentationTests below. The
 # binary libUserSpaceInstrumentationTestLib.so created from this target is used
@@ -81,6 +104,7 @@ target_sources(UserSpaceInstrumentationTests PRIVATE
         ExecuteMachineCodeTest.cpp
         FindFunctionAddressTest.cpp
         InjectLibraryInTraceeTest.cpp
+        InstrumentProcessTest.cpp
         MachineCodeTest.cpp
         RegisterStateTest.cpp
         TestProcess.cpp

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -1,0 +1,448 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "UserSpaceInstrumentation/InstrumentProcess.h"
+
+#include <absl/base/casts.h>
+#include <absl/container/flat_hash_map.h>
+#include <dlfcn.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+#include "AccessTraceesMemory.h"
+#include "AllocateInTracee.h"
+#include "ObjectUtils/LinuxMap.h"
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/File.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/UniqueResource.h"
+#include "Trampoline.h"
+#include "UserSpaceInstrumentation/Attach.h"
+#include "UserSpaceInstrumentation/ExecuteInProcess.h"
+#include "UserSpaceInstrumentation/InjectLibraryInTracee.h"
+
+namespace orbit_user_space_instrumentation {
+
+namespace {
+
+using orbit_grpc_protos::CaptureOptions;
+using orbit_grpc_protos::ModuleInfo;
+
+// Holds all the data necessary to keep track of a process we instrument.
+// Needs to be created via the static factory function `Create`. This will inject the shared library
+// with out instrumentaion code into the target process and create the return trampoline. Once
+// created we can instrument functions in the target process and deactiveate the instrumentation
+// again (see `InstrumentFunctions`, `UninstrumentFunctions` below).
+class InstrumentedProcess {
+ public:
+  InstrumentedProcess(const InstrumentedProcess&) = delete;
+  InstrumentedProcess(InstrumentedProcess&&) = delete;
+  InstrumentedProcess& operator=(const InstrumentedProcess&) = delete;
+  InstrumentedProcess& operator=(InstrumentedProcess&&) = delete;
+  ~InstrumentedProcess() = default;
+
+  [[nodiscard]] static ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> Create(
+      const CaptureOptions& capture_options);
+
+  // Instruments the functions capture_options.instrumented_functions and returns a set of
+  // function_id's of succefully instrumented functions.
+  [[nodiscard]] ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentFunctions(
+      const CaptureOptions& capture_options);
+
+  // Removes the instrumentation for all functions in capture_options.instrumented_functions that
+  // have been instrumented previously.
+  [[nodiscard]] ErrorMessageOr<void> UninstrumentFunctions(const CaptureOptions& capture_options);
+
+  // Returns the pid of the process.
+  [[nodiscard]] pid_t GetPid() const { return pid_; }
+
+ private:
+  InstrumentedProcess() = default;
+
+  // Returns an address where we can construct a new trampoline for some function in the module
+  // identified by `address_range`. Handles the allocation in the tracee and the tracks the
+  // allocated memory in `trampolines_for_modules_` below.
+  ErrorMessageOr<uint64_t> GetTrampolineMemory(AddressRange address_range);
+  // Releases the address priviously obtained by `GetTrampolineMemory` such that it can be reused.
+  // Note that this must only be called once for each call to `GetTrampolineMemory`.
+  ErrorMessageOr<void> ReleaseMostRecentlyAllocatedTrampolineMemory(AddressRange address_range);
+
+  [[nodiscard]] ErrorMessageOr<void> EnsureTrampolinesWritable();
+  [[nodiscard]] ErrorMessageOr<void> EnsureTrampolinesExecutable();
+
+  ErrorMessageOr<std::vector<ModuleInfo>> ModulesFromModulePath(std::string path);
+
+  pid_t pid_ = -1;
+
+  uint64_t start_new_capture_function_address_ = 0;
+  uint64_t entry_payload_function_address_ = 0;
+  uint64_t exit_payload_function_address_ = 0;
+
+  uint64_t return_trampoline_address_ = 0;
+
+  // Keep track of each relocted instruction that has been moved into a trampoline. Used to move the
+  // instruction pointers out of overwritten memory areas after the instrumentaion has been done.
+  absl::flat_hash_map<uint64_t, uint64_t> relocation_map_;
+
+  // Keep track of all trampolines we created for this process.
+  struct TrampolineData {
+    uint64_t trampoline_address;
+    uint64_t address_after_prologue;
+    std::vector<uint8_t> function_data;
+  };
+  // Maps function addresses to TrampolineData.
+  absl::flat_hash_map<uint64_t, TrampolineData> trampoline_map_;
+
+  // Trampolines are allocated in chunks of kTrampolinesPerChunk. Trampolines are fixed size
+  // (compare `GetMaxTrampolineSize`) and are never freed; we just allocate new chunks when that
+  // last one is filled up. Each module (identified by its address range) gets it own sequence of
+  // chunks (`trampolines_for_modules_`).
+  static constexpr int kTrampolinesPerChunk = 4096;
+  struct TrampolineMemoryChunk {
+    TrampolineMemoryChunk() = default;
+    TrampolineMemoryChunk(std::unique_ptr<MemoryInTracee>&& m, int first_available)
+        : first_available(first_available) {
+      memory = std::move(m);
+    }
+    std::unique_ptr<MemoryInTracee> memory;
+    int first_available = 0;
+  };
+  typedef std::vector<TrampolineMemoryChunk> TrampolineMemoryChunks;
+  absl::flat_hash_map<AddressRange, TrampolineMemoryChunks> trampolines_for_modules_;
+
+  // Map path of a module in the process to all loaded instances of that module (usually there will
+  // only be one, but a module can be loaded more than once).
+  absl::flat_hash_map<std::string, std::vector<ModuleInfo>> modules_from_path_;
+};
+
+typedef absl::flat_hash_map<pid_t, std::unique_ptr<InstrumentedProcess>> ProcessMap;
+
+ErrorMessageOr<std::filesystem::path> GetLibraryPath() {
+  // When packaged, libOrbitUserSpaceInstrumentation.so is found alongside OrbitService. In
+  // development, it is found in "../lib", relative to OrbitService.
+  constexpr const char* kLibName = "libOrbitUserSpaceInstrumentation.so";
+  const std::filesystem::path exe_dir = orbit_base::GetExecutableDir();
+  std::vector<std::filesystem::path> potential_paths = {exe_dir / kLibName,
+                                                        exe_dir / ".." / "lib" / kLibName};
+  for (const auto& path : potential_paths) {
+    if (std::filesystem::exists(path)) {
+      return path;
+    }
+  }
+  return ErrorMessage(absl::StrFormat("%s not found on system.", kLibName));
+}
+
+ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create(
+    const CaptureOptions& capture_options) {
+  std::unique_ptr<InstrumentedProcess> process(new InstrumentedProcess());
+  const pid_t pid = capture_options.pid();
+  process->pid_ = pid;
+  OUTCOME_TRY(AttachAndStopProcess(pid));
+  orbit_base::unique_resource detach_on_exit{pid, [](int32_t pid) {
+                                               if (DetachAndContinueProcess(pid).has_error()) {
+                                                 ERROR("Detaching from %i", pid);
+                                               }
+                                             }};
+
+  // Inject library into target process.
+  auto library_path_or_error = GetLibraryPath();
+  if (library_path_or_error.has_error()) {
+    return ErrorMessage(absl::StrFormat("Unable to get path to library: %s",
+                                        library_path_or_error.error().message()));
+  }
+  const std::filesystem::path library_path = library_path_or_error.value();
+
+  auto library_handle_or_error = DlopenInTracee(pid, library_path, RTLD_NOW);
+  if (library_handle_or_error.has_error()) {
+    return ErrorMessage(absl::StrFormat("Unable to open library in tracee: %s",
+                                        library_handle_or_error.error().message()));
+  }
+  void* library_handle = library_handle_or_error.value();
+
+  // Get function pointers into the injected library.
+  constexpr const char* kStartNewCaptureFunctionName = "StartNewCapture";
+  constexpr const char* kEntryPayloadFunctionName = "EntryPayload";
+  constexpr const char* kExitPayloadFunctionName = "ExitPayload";
+  OUTCOME_TRY(auto&& start_new_capture_function_address,
+              DlsymInTracee(pid, library_handle, kStartNewCaptureFunctionName));
+  process->start_new_capture_function_address_ =
+      absl::bit_cast<uint64_t>(start_new_capture_function_address);
+  OUTCOME_TRY(auto&& entry_payload_function_address,
+              DlsymInTracee(pid, library_handle, kEntryPayloadFunctionName));
+  process->entry_payload_function_address_ =
+      absl::bit_cast<uint64_t>(entry_payload_function_address);
+  OUTCOME_TRY(auto&& exit_payload_function_address,
+              DlsymInTracee(pid, library_handle, kExitPayloadFunctionName));
+  process->exit_payload_function_address_ = absl::bit_cast<uint64_t>(exit_payload_function_address);
+
+  // Get memory, create the return trampoline and make it executable.
+  OUTCOME_TRY(auto&& return_trampoline_memory,
+              MemoryInTracee::Create(pid, 0, GetReturnTrampolineSize()));
+  process->return_trampoline_address_ = return_trampoline_memory->GetAddress();
+  auto result = CreateReturnTrampoline(pid, process->exit_payload_function_address_,
+                                       process->return_trampoline_address_);
+  OUTCOME_TRY(return_trampoline_memory->EnsureMemoryExecutable());
+
+  return process;
+}
+
+ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentedProcess::InstrumentFunctions(
+    const CaptureOptions& capture_options) {
+  OUTCOME_TRY(AttachAndStopProcess(pid_));
+  orbit_base::unique_resource detach_on_exit{pid_, [](int32_t pid) {
+                                               if (DetachAndContinueProcess(pid).has_error()) {
+                                                 ERROR("Detaching from %i", pid);
+                                               }
+                                             }};
+  // Init Capstone disassembler.
+  csh capstone_handle = 0;
+  cs_err error_code = cs_open(CS_ARCH_X86, CS_MODE_64, &capstone_handle);
+  if (error_code != CS_ERR_OK) {
+    return ErrorMessage("Failed to open Capstone disassembler.");
+  }
+  error_code = cs_option(capstone_handle, CS_OPT_DETAIL, CS_OPT_ON);
+  if (error_code != CS_ERR_OK) {
+    return ErrorMessage("Failed to configure Capstone disassembler.");
+  }
+  orbit_base::unique_resource close_on_exit{
+      &capstone_handle, [](csh* capstone_handle) { cs_close(capstone_handle); }};
+
+  OUTCOME_TRY(ExecuteInProcess(pid_, absl::bit_cast<void*>(start_new_capture_function_address_)));
+
+  OUTCOME_TRY(EnsureTrampolinesWritable());
+
+  absl::flat_hash_set<uint64_t> instrumented_function_ids;
+  for (const auto& function : capture_options.instrumented_functions()) {
+    const uint64_t function_id = function.function_id();
+    constexpr uint64_t kMaxFunctionPrologueBackupSize = 20;
+    const uint64_t backup_size = std::min(kMaxFunctionPrologueBackupSize, function.function_size());
+    if (backup_size == 0) {
+      // Can't instrument function of size zero
+      continue;
+    }
+    // Get all modules with the right path (usually one, but might be more) and get a function
+    // address to instrument for each of them.
+    OUTCOME_TRY(auto&& modules, ModulesFromModulePath(function.file_path()));
+    for (const auto& module : modules) {
+      // TODO: there is a function for that now, right? The page alignment is not handled here...
+      const uint64_t function_address =
+          module.address_start() + function.file_offset() - module.executable_segment_offset();
+
+      if (!trampoline_map_.contains(function_address)) {
+        const AddressRange module_address_range(module.address_start(), module.address_end());
+        auto trampoline_address_or_error = GetTrampolineMemory(module_address_range);
+        if (trampoline_address_or_error.has_error()) {
+          LOG("Failed to allocate memory for trampoline: %s",
+              trampoline_address_or_error.error().message());
+          continue;
+        }
+        const uint64_t trampoline_address = trampoline_address_or_error.value();
+        TrampolineData trampoline_data;
+        trampoline_data.trampoline_address = trampoline_address;
+        OUTCOME_TRY(auto&& function_data, ReadTraceesMemory(pid_, function_address, backup_size));
+        trampoline_data.function_data = function_data;
+        auto address_after_prologue_or_error =
+            CreateTrampoline(pid_, function_address, function_data, trampoline_address,
+                             entry_payload_function_address_, return_trampoline_address_,
+                             capstone_handle, relocation_map_);
+        if (address_after_prologue_or_error.has_error()) {
+          LOG("Failed to create trampoline: %s", address_after_prologue_or_error.error().message());
+          OUTCOME_TRY(ReleaseMostRecentlyAllocatedTrampolineMemory(module_address_range));
+          continue;
+        }
+        trampoline_data.address_after_prologue = address_after_prologue_or_error.value();
+        trampoline_map_.emplace(function_address, trampoline_data);
+      }
+      auto it = trampoline_map_.find(function_address);
+      if (it == trampoline_map_.end()) {
+        continue;
+      }
+      const TrampolineData& trampoline_data = it->second;
+
+      auto result = InstrumentFunction(pid_, function_address, function_id,
+                                       trampoline_data.address_after_prologue,
+                                       trampoline_data.trampoline_address);
+      if (result.has_error()) {
+        LOG("Unable to instrument %s: %s", function.function_name(), result.error().message());
+      } else {
+        instrumented_function_ids.insert(function_id);
+      }
+    }
+  }
+
+  MoveInstructionPointersOutOfOverwrittenCode(pid_, relocation_map_);
+
+  OUTCOME_TRY(EnsureTrampolinesExecutable());
+
+  return instrumented_function_ids;
+}
+
+ErrorMessageOr<void> InstrumentedProcess::UninstrumentFunctions(
+    const CaptureOptions& capture_options) {
+  OUTCOME_TRY(AttachAndStopProcess(pid_));
+  orbit_base::unique_resource detach_on_exit{pid_, [](int32_t pid) {
+                                               if (DetachAndContinueProcess(pid).has_error()) {
+                                                 ERROR("Detaching from %i", pid);
+                                               }
+                                             }};
+
+  for (const auto& function : capture_options.instrumented_functions()) {
+    OUTCOME_TRY(auto&& modules, ModulesFromModulePath(function.file_path()));
+    for (const auto& module : modules) {
+      const uint64_t function_address =
+          module.address_start() + function.file_offset() - module.executable_segment_offset();
+      auto it = trampoline_map_.find(function_address);
+      // Skip if this function was not instrumented.
+      if (it == trampoline_map_.end()) continue;
+      const TrampolineData& trampoline_data = it->second;
+      std::vector<uint8_t> code(trampoline_data.function_data.begin(),
+                                trampoline_data.function_data.begin() +
+                                    (trampoline_data.address_after_prologue - function_address));
+      auto write_result_or_error = WriteTraceesMemory(pid_, function_address, code);
+      CHECK(!write_result_or_error.has_error());
+    }
+  }
+
+  return outcome::success();
+}
+
+ErrorMessageOr<uint64_t> InstrumentedProcess::GetTrampolineMemory(AddressRange address_range) {
+  if (!trampolines_for_modules_.contains(address_range)) {
+    trampolines_for_modules_.emplace(address_range, TrampolineMemoryChunks());
+  }
+  auto it = trampolines_for_modules_.find(address_range);
+  TrampolineMemoryChunks& trampoline_memory_chunks = it->second;
+  if (trampoline_memory_chunks.empty() ||
+      trampoline_memory_chunks.back().first_available == kTrampolinesPerChunk) {
+    OUTCOME_TRY(auto&& trampoline_memory,
+                AllocateMemoryForTrampolines(pid_, address_range,
+                                             kTrampolinesPerChunk * GetMaxTrampolineSize()));
+
+    trampoline_memory_chunks.emplace_back(std::move(trampoline_memory), 0);
+  }
+  const uint64_t result = trampoline_memory_chunks.back().memory->GetAddress() +
+                          trampoline_memory_chunks.back().first_available * GetMaxTrampolineSize();
+  trampoline_memory_chunks.back().first_available++;
+  return result;
+}
+
+ErrorMessageOr<void> InstrumentedProcess::ReleaseMostRecentlyAllocatedTrampolineMemory(
+    AddressRange address_range) {
+  if (!trampolines_for_modules_.contains(address_range)) {
+    return ErrorMessage("Tried to release trampoline memory for an non existent address range");
+  }
+  trampolines_for_modules_.find(address_range)->second.back().first_available--;
+  return outcome::success();
+}
+
+ErrorMessageOr<std::vector<ModuleInfo>> InstrumentedProcess::ModulesFromModulePath(
+    std::string path) {
+  if (!modules_from_path_.contains(path)) {
+    std::vector<ModuleInfo> result;
+    OUTCOME_TRY(auto&& modules, orbit_object_utils::ReadModules(pid_));
+    for (const ModuleInfo& module : modules) {
+      if (module.file_path() == path) {
+        result.push_back(module);
+      }
+    }
+    if (result.empty()) {
+      return ErrorMessage(absl::StrFormat("Unable to find module for path %s", path));
+    }
+    modules_from_path_.emplace(path, result);
+  }
+  return modules_from_path_.find(path)->second;
+}
+
+ErrorMessageOr<void> InstrumentedProcess::EnsureTrampolinesWritable() {
+  for (auto& trampoline_for_module : trampolines_for_modules_) {
+    for (auto& memory_chunk : trampoline_for_module.second) {
+      OUTCOME_TRY(memory_chunk.memory->EnsureMemoryWritable());
+    }
+  }
+  return outcome::success();
+}
+
+ErrorMessageOr<void> InstrumentedProcess::EnsureTrampolinesExecutable() {
+  for (auto& trampoline_for_module : trampolines_for_modules_) {
+    for (auto& memory_chunk : trampoline_for_module.second) {
+      OUTCOME_TRY(memory_chunk.memory->EnsureMemoryExecutable());
+    }
+  }
+  return outcome::success();
+}
+
+// Return the singleton map containing the instrumented processes.
+ProcessMap& GetInstrumentedProcesses() {
+  static ProcessMap instrumented_processes;
+  return instrumented_processes;
+}
+
+bool ProcessWithPidExists(pid_t pid) {
+  const std::string pid_dirname = absl::StrFormat("/proc/%d", pid);
+  auto result = orbit_base::FileExists(pid_dirname);
+  FAIL_IF(result.has_error(), "Accessing \"%s\" failed: %s", pid_dirname, result.error().message());
+  return result.value();
+}
+
+}  // namespace
+
+ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentProcess(
+    const CaptureOptions& capture_options) {
+  const pid_t pid = capture_options.pid();
+
+  // If the user tries to instrument this instance of OrbitService we can't use user space
+  // instrumentation: We would need to attach to / stop our own process.
+  if (pid == getpid()) {
+    return absl::flat_hash_set<uint64_t>();
+  }
+
+  ProcessMap& instrumented_processes = GetInstrumentedProcesses();
+  if (!instrumented_processes.contains(pid)) {
+    // Delete entries belonging to processes that are not running anymore.
+    auto it = instrumented_processes.begin();
+    while (it != instrumented_processes.end()) {
+      if (!ProcessWithPidExists(it->second->GetPid())) {
+        instrumented_processes.erase(it++);
+      } else {
+        it++;
+      }
+    }
+
+    // InstrumentedProcess process;
+    // auto init_result = process.Init(capture_options);
+    auto process_or_error = InstrumentedProcess::Create(capture_options);
+    if (process_or_error.has_error()) {
+      return ErrorMessage(absl::StrFormat("Unable to initialize process %d: %s", pid,
+                                          process_or_error.error().message()));
+    }
+    instrumented_processes.emplace(pid, std::move(process_or_error.value()));
+  }
+  OUTCOME_TRY(auto&& instrumented_function_ids,
+              instrumented_processes[pid]->InstrumentFunctions(capture_options));
+
+  return std::move(instrumented_function_ids);
+}
+
+ErrorMessageOr<void> UninstrumentProcess(const CaptureOptions& capture_options) {
+  const pid_t pid = capture_options.pid();
+
+  // If the user tries to instrument this instance of OrbitService we can't use user space
+  // instrumentation: We would need to attach to / stop our own process. Therefore nothing was
+  // instrumented in the first place and we can just return here.
+  if (pid == getpid()) {
+    return outcome::success();
+  }
+
+  ProcessMap& instrumented_processes = GetInstrumentedProcesses();
+  if (instrumented_processes.contains(pid)) {
+    OUTCOME_TRY(instrumented_processes[pid]->UninstrumentFunctions(capture_options));
+  }
+
+  return outcome::success();
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <string_view>
+
+#include "AddressRange.h"
+#include "FindFunctionAddress.h"
+#include "ObjectUtils/ElfFile.h"
+#include "ObjectUtils/LinuxMap.h"
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/GetProcessIds.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/TestUtils.h"
+#include "TestUtils.h"
+#include "UserSpaceInstrumentation/Attach.h"
+#include "UserSpaceInstrumentation/InstrumentProcess.h"
+
+namespace orbit_user_space_instrumentation {
+
+namespace {
+
+using orbit_base::HasError;
+using orbit_base::HasNoError;
+
+orbit_grpc_protos::CaptureOptions GetCaptureOptions() {
+  orbit_grpc_protos::CaptureOptions capture_options;
+  constexpr const char* kFunctionName = "SomethingToInstrument";
+  AddressRange range = GetFunctionRelativeAddressRangeOrDie(kFunctionName);
+  orbit_grpc_protos::InstrumentedFunction* my_function =
+      capture_options.add_instrumented_functions();
+  my_function->set_function_id(42);
+  my_function->set_file_offset(range.start);
+  my_function->set_function_size(range.end - range.start);
+  my_function->set_function_name(kFunctionName);
+  my_function->set_file_path(orbit_base::GetExecutablePath());
+  return capture_options;
+}
+
+}  // namespace
+
+extern "C" int SomethingToInstrument() {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(1, 6);
+  return dis(gen);
+}
+
+TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
+  // Skip if not running as root. We need to trace a child process.
+  if (geteuid() != 0) {
+    GTEST_SKIP();
+  }
+
+  const pid_t pid = fork();
+  CHECK(pid != -1);
+  if (pid == 0) {
+    while (true) {
+    }
+  }
+
+  // We spawn another child and wait for it to trace `pid`. Then we can't attach.
+  const pid_t pid_tracer = fork();
+  CHECK(pid_tracer != -1);
+  if (pid_tracer == 0) {
+    ptrace(PTRACE_ATTACH, pid, nullptr, nullptr);
+    while (true) {
+    }
+  }
+  bool already_tracing = false;
+  while (!already_tracing) {
+    auto tracer_pid_or_error = orbit_base::GetTracerPidOfProcess(pid);
+    CHECK(!tracer_pid_or_error.has_error());
+    already_tracing = tracer_pid_or_error.value() != 0;
+  }
+
+  orbit_grpc_protos::CaptureOptions capture_options;
+  capture_options.set_pid(pid);
+  auto function_ids_or_error = InstrumentProcess(capture_options);
+  ASSERT_THAT(function_ids_or_error, HasError("is already being traced by"));
+
+  // End tracer process, end child process.
+  kill(pid_tracer, SIGKILL);
+  waitpid(pid_tracer, NULL, 0);
+  kill(pid, SIGKILL);
+  waitpid(pid, NULL, 0);
+}
+
+TEST(InstrumentProcessTest, FailToInstrumentInvalidPid) {
+  orbit_grpc_protos::CaptureOptions capture_options;
+  capture_options.set_pid(-1);
+  auto function_ids_or_error = InstrumentProcess(capture_options);
+  ASSERT_THAT(function_ids_or_error, HasError("There is no process with pid"));
+}
+
+TEST(InstrumentProcessTest, FailToInstrumentThisProcess) {
+  orbit_grpc_protos::CaptureOptions capture_options;
+  capture_options.set_pid(getpid());
+  auto function_ids_or_error = InstrumentProcess(capture_options);
+  // We do not fail but just instrument nothing.
+  ASSERT_THAT(function_ids_or_error, HasNoError());
+  EXPECT_TRUE(function_ids_or_error.value().empty());
+}
+
+TEST(InstrumentProcessTest, Instrument) {
+  const pid_t pid_process_1 = fork();
+  CHECK(pid_process_1 != -1);
+  if (pid_process_1 == 0) {
+    int sum = 0;
+    while (true) {
+      sum += SomethingToInstrument();
+    }
+  }
+
+  orbit_grpc_protos::CaptureOptions capture_options = GetCaptureOptions();
+  capture_options.set_pid(pid_process_1);
+  auto function_ids_or_error = InstrumentProcess(capture_options);
+  ASSERT_THAT(function_ids_or_error, HasNoError());
+  EXPECT_TRUE(function_ids_or_error.value().contains(42));
+  auto result = UninstrumentProcess(capture_options);
+  ASSERT_THAT(result, HasNoError());
+
+  // End child pid_process_1.
+  kill(pid_process_1, SIGKILL);
+  waitpid(pid_process_1, NULL, 0);
+
+  // Just do the same thing with another process to trigger the code path deleting the data for the
+  // first. Also Instrument / Uninstrument repeatedly.
+  const pid_t pid_process_2 = fork();
+  CHECK(pid_process_2 != -1);
+  if (pid_process_2 == 0) {
+    int sum = 0;
+    while (true) {
+      sum += SomethingToInstrument();
+    }
+  }
+
+  capture_options.set_pid(pid_process_2);
+  for (int i = 0; i < 5; i++) {
+    function_ids_or_error = InstrumentProcess(capture_options);
+    ASSERT_THAT(function_ids_or_error, HasNoError());
+    EXPECT_TRUE(function_ids_or_error.value().contains(42));
+    result = UninstrumentProcess(capture_options);
+    ASSERT_THAT(result, HasNoError());
+  }
+
+  // End child pid_process_2.
+  kill(pid_process_2, SIGKILL);
+  waitpid(pid_process_2, NULL, 0);
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -31,18 +31,25 @@ namespace {
 using orbit_base::HasError;
 using orbit_base::HasNoError;
 
-orbit_grpc_protos::CaptureOptions GetCaptureOptions() {
+constexpr int kFunctionId = 42;
+
+orbit_grpc_protos::CaptureOptions BuildCaptureOptions() {
   orbit_grpc_protos::CaptureOptions capture_options;
   constexpr const char* kFunctionName = "SomethingToInstrument";
   AddressRange range = GetFunctionRelativeAddressRangeOrDie(kFunctionName);
   orbit_grpc_protos::InstrumentedFunction* my_function =
       capture_options.add_instrumented_functions();
-  my_function->set_function_id(42);
+  my_function->set_function_id(kFunctionId);
   my_function->set_file_offset(range.start);
   my_function->set_function_size(range.end - range.start);
   my_function->set_function_name(kFunctionName);
   my_function->set_file_path(orbit_base::GetExecutablePath());
   return capture_options;
+}
+
+[[nodiscard]] UserSpaceInstrumentation* GetUserSpaceInstrumentation() {
+  static std::unique_ptr<UserSpaceInstrumentation> u = UserSpaceInstrumentation::Create();
+  return u.get();
 }
 
 }  // namespace
@@ -55,6 +62,8 @@ extern "C" int SomethingToInstrument() {
 }
 
 TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
+  UserSpaceInstrumentation* user_space_instrumentation = GetUserSpaceInstrumentation();
+
   // Skip if not running as root. We need to trace a child process.
   if (geteuid() != 0) {
     GTEST_SKIP();
@@ -84,7 +93,7 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
 
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(pid);
-  auto function_ids_or_error = InstrumentProcess(capture_options);
+  auto function_ids_or_error = user_space_instrumentation->InstrumentProcess(capture_options);
   ASSERT_THAT(function_ids_or_error, HasError("is already being traced by"));
 
   // End tracer process, end child process.
@@ -95,22 +104,25 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
 }
 
 TEST(InstrumentProcessTest, FailToInstrumentInvalidPid) {
+  UserSpaceInstrumentation* user_space_instrumentation = GetUserSpaceInstrumentation();
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(-1);
-  auto function_ids_or_error = InstrumentProcess(capture_options);
+  auto function_ids_or_error = user_space_instrumentation->InstrumentProcess(capture_options);
   ASSERT_THAT(function_ids_or_error, HasError("There is no process with pid"));
 }
 
 TEST(InstrumentProcessTest, FailToInstrumentThisProcess) {
+  UserSpaceInstrumentation* user_space_instrumentation = GetUserSpaceInstrumentation();
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(getpid());
-  auto function_ids_or_error = InstrumentProcess(capture_options);
+  auto function_ids_or_error = user_space_instrumentation->InstrumentProcess(capture_options);
   // We do not fail but just instrument nothing.
   ASSERT_THAT(function_ids_or_error, HasNoError());
   EXPECT_TRUE(function_ids_or_error.value().empty());
 }
 
 TEST(InstrumentProcessTest, Instrument) {
+  UserSpaceInstrumentation* user_space_instrumentation = GetUserSpaceInstrumentation();
   const pid_t pid_process_1 = fork();
   CHECK(pid_process_1 != -1);
   if (pid_process_1 == 0) {
@@ -120,12 +132,12 @@ TEST(InstrumentProcessTest, Instrument) {
     }
   }
 
-  orbit_grpc_protos::CaptureOptions capture_options = GetCaptureOptions();
+  orbit_grpc_protos::CaptureOptions capture_options = BuildCaptureOptions();
   capture_options.set_pid(pid_process_1);
-  auto function_ids_or_error = InstrumentProcess(capture_options);
+  auto function_ids_or_error = user_space_instrumentation->InstrumentProcess(capture_options);
   ASSERT_THAT(function_ids_or_error, HasNoError());
-  EXPECT_TRUE(function_ids_or_error.value().contains(42));
-  auto result = UninstrumentProcess(capture_options);
+  EXPECT_TRUE(function_ids_or_error.value().contains(kFunctionId));
+  auto result = user_space_instrumentation->UninstrumentProcess(pid_process_1);
   ASSERT_THAT(result, HasNoError());
 
   // End child pid_process_1.
@@ -145,10 +157,10 @@ TEST(InstrumentProcessTest, Instrument) {
 
   capture_options.set_pid(pid_process_2);
   for (int i = 0; i < 5; i++) {
-    function_ids_or_error = InstrumentProcess(capture_options);
+    function_ids_or_error = user_space_instrumentation->InstrumentProcess(capture_options);
     ASSERT_THAT(function_ids_or_error, HasNoError());
-    EXPECT_TRUE(function_ids_or_error.value().contains(42));
-    result = UninstrumentProcess(capture_options);
+    EXPECT_TRUE(function_ids_or_error.value().contains(kFunctionId));
+    result = user_space_instrumentation->UninstrumentProcess(pid_process_2);
     ASSERT_THAT(result, HasNoError());
   }
 

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -19,25 +19,23 @@ namespace {
 
 using orbit_base::CaptureTimestampNs;
 
-struct ReturnAddressOfFunction {
-  ReturnAddressOfFunction(uint64_t return_address, uint64_t function_id,
-                          uint64_t timestamp_on_entry_ns)
+struct OpenFunctionCall {
+  OpenFunctionCall(uint64_t return_address, uint64_t function_id, uint64_t timestamp_on_entry_ns)
       : return_address(return_address),
         function_id(function_id),
-        timestamp_on_entry_ns(timestamp_on_entry_ns) {
-    // The amount of data we store for each call is relevant for the overall performance. The assert
-    // is here for awareness and to avoid packing issues in the struct.
-    static_assert(sizeof(ReturnAddressOfFunction) == 24,
-                  "ReturnAddressOfFunction should be 24 bytes.");
-  }
+        timestamp_on_entry_ns(timestamp_on_entry_ns) {}
   uint64_t return_address;
   uint64_t function_id;
   uint64_t timestamp_on_entry_ns;
 };
 
-std::stack<ReturnAddressOfFunction>& GetReturnAddressStack() {
-  thread_local std::stack<ReturnAddressOfFunction> return_addresses;
-  return return_addresses;
+// The amount of data we store for each call is relevant for the overall performance. The assert is
+// here for awareness and to avoid packing issues in the struct.
+static_assert(sizeof(OpenFunctionCall) == 24, "OpenFunctionCall should be 24 bytes.");
+
+std::stack<OpenFunctionCall>& GetOpenFunctionCallStack() {
+  thread_local std::stack<OpenFunctionCall> open_function_calls;
+  return open_function_calls;
 }
 
 uint64_t start_current_capture_timestamp = 0;
@@ -50,17 +48,17 @@ struct FunctionCallEvent {
         tid(tid),
         function_id(function_id),
         duration_ns(duration_ns),
-        end_timestamp_ns(end_timestamp_ns) {
-    // The amount of data we transmit for each call is relevant for the overall performance. The
-    // assert is here for awareness and to avoid packing issues in the struct.
-    static_assert(sizeof(FunctionCallEvent) == 32, "FunctionCallEvent should be 32 bytes.");
-  }
+        end_timestamp_ns(end_timestamp_ns) {}
   int32_t pid;
   int32_t tid;
   uint64_t function_id;
   uint64_t duration_ns;
   uint64_t end_timestamp_ns;
 };
+
+// The amount of data we transmit for each call is relevant for the overall performance. The assert
+// is here for awareness and to avoid packing issues in the struct.
+static_assert(sizeof(FunctionCallEvent) == 32, "FunctionCallEvent should be 32 bytes.");
 
 // This class is used to enqueue FunctionCallEvent events from multiple threads and relay them to
 // OrbitService in the form of orbit_grpc_protos::FunctionCall events.
@@ -94,22 +92,22 @@ void StartNewCapture() { start_current_capture_timestamp = CaptureTimestampNs();
 
 void EntryPayload(uint64_t return_address, uint64_t function_id) {
   const uint64_t timestamp_on_entry_ns = CaptureTimestampNs();
-  auto& return_address_stack = GetReturnAddressStack();
-  return_address_stack.emplace(return_address, function_id, timestamp_on_entry_ns);
+  auto& open_function_call_stack = GetOpenFunctionCallStack();
+  open_function_call_stack.emplace(return_address, function_id, timestamp_on_entry_ns);
 }
 
 uint64_t ExitPayload() {
   const uint64_t timestamp_on_exit_ns = CaptureTimestampNs();
-  auto& return_address_stack = GetReturnAddressStack();
-  ReturnAddressOfFunction current_return_address = return_address_stack.top();
-  return_address_stack.pop();
+  auto& open_function_call_stack = GetOpenFunctionCallStack();
+  OpenFunctionCall current_return_address = open_function_call_stack.top();
+  open_function_call_stack.pop();
 
   static LockFreeUserSpaceInstrumentationEventProducer producer;
   // Skip emitting an event if we are not capturing or the event belongs to a previous capture.
   if (producer.IsCapturing() &&
       start_current_capture_timestamp < current_return_address.timestamp_on_entry_ns) {
     static pid_t pid = orbit_base::GetCurrentProcessId();
-    thread_local int32_t tid = orbit_base::GetCurrentThreadId();
+    thread_local pid_t tid = orbit_base::GetCurrentThreadId();
     const uint64_t duration_ns =
         timestamp_on_exit_ns - current_return_address.timestamp_on_entry_ns;
     producer.EnqueueIntermediateEvent(FunctionCallEvent(

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitUserSpaceInstrumentation.h"
+
+#include <stdio.h>
+#include <sys/types.h>
+
+#include <cstdint>
+#include <stack>
+
+#include "CaptureEventProducer/LockFreeBufferCaptureEventProducer.h"
+#include "OrbitBase/Profiling.h"
+#include "OrbitBase/ThreadUtils.h"
+#include "ProducerSideChannel/ProducerSideChannel.h"
+
+namespace {
+
+using orbit_base::CaptureTimestampNs;
+
+struct ReturnAddressOfFunction {
+  ReturnAddressOfFunction(uint64_t return_address, uint64_t function_id,
+                          uint64_t timestamp_on_entry_ns)
+      : return_address(return_address),
+        function_id(function_id),
+        timestamp_on_entry_ns(timestamp_on_entry_ns) {
+    static_assert(sizeof(ReturnAddressOfFunction) == 24,
+                  "ReturnAddressOfFunction should be 24 bytes.");
+  }
+  uint64_t return_address;
+  uint64_t function_id;
+  uint64_t timestamp_on_entry_ns;
+};
+
+thread_local std::stack<ReturnAddressOfFunction> return_addresses;
+uint64_t start_current_capture_timestamp = 0;
+
+struct FunctionCallEvent {
+  FunctionCallEvent() = default;
+  FunctionCallEvent(int32_t pid, int32_t tid, uint64_t function_id, uint64_t duration_ns,
+                    uint64_t end_timestamp_ns)
+      : pid(pid),
+        tid(tid),
+        function_id(function_id),
+        duration_ns(duration_ns),
+        end_timestamp_ns(end_timestamp_ns) {
+    static_assert(sizeof(FunctionCallEvent) == 32, "FunctionCallEvent should be 32 bytes.");
+  }
+  int32_t pid;
+  int32_t tid;
+  uint64_t function_id;
+  uint64_t duration_ns;
+  uint64_t end_timestamp_ns;
+};
+
+// This class is used to enqueue FunctionCallEvent events from multiple threads and relay them to
+// OrbitService in the form of orbit_grpc_protos::FunctionCall events.
+class LockFreeUserSpaceInstrumentationEventProducer
+    : public orbit_capture_event_producer::LockFreeBufferCaptureEventProducer<FunctionCallEvent> {
+ public:
+  LockFreeUserSpaceInstrumentationEventProducer() {
+    BuildAndStart(orbit_producer_side_channel::CreateProducerSideChannel());
+  }
+
+  ~LockFreeUserSpaceInstrumentationEventProducer() { ShutdownAndWait(); }
+
+ protected:
+  [[nodiscard]] virtual orbit_grpc_protos::ProducerCaptureEvent* TranslateIntermediateEvent(
+      FunctionCallEvent&& raw_event, google::protobuf::Arena* arena) override {
+    auto* capture_event =
+        google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
+    auto* function_call = capture_event->mutable_function_call();
+    function_call->set_pid(raw_event.pid);
+    function_call->set_tid(raw_event.tid);
+    function_call->set_function_id(raw_event.function_id);
+    function_call->set_duration_ns(raw_event.duration_ns);
+    function_call->set_end_timestamp_ns(raw_event.end_timestamp_ns);
+    return capture_event;
+  }
+};
+
+}  // namespace
+
+void StartNewCapture() { start_current_capture_timestamp = CaptureTimestampNs(); }
+
+void EntryPayload(uint64_t return_address, uint64_t function_id) {
+  const uint64_t timestamp_on_entry_ns = CaptureTimestampNs();
+  return_addresses.emplace(return_address, function_id, timestamp_on_entry_ns);
+}
+
+uint64_t ExitPayload() {
+  const uint64_t timestamp_on_exit_ns = CaptureTimestampNs();
+  ReturnAddressOfFunction current_return_address = return_addresses.top();
+  return_addresses.pop();
+
+  static LockFreeUserSpaceInstrumentationEventProducer producer;
+  // Skip emitting an event if we are not capturing or the event belongs to a previous capture.
+  if (producer.IsCapturing() &&
+      start_current_capture_timestamp < current_return_address.timestamp_on_entry_ns) {
+    static pid_t pid = orbit_base::GetCurrentProcessId();
+    thread_local int32_t tid = orbit_base::GetCurrentThreadId();
+    const uint64_t duration_ns =
+        timestamp_on_exit_ns - current_return_address.timestamp_on_entry_ns;
+    producer.EnqueueIntermediateEvent(FunctionCallEvent(
+        pid, tid, current_return_address.function_id, duration_ns, timestamp_on_exit_ns));
+  }
+
+  return current_return_address.return_address;
+}

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_USER_SPACE_INSTRUMENTATION_H_
+#define ORBIT_USER_SPACE_INSTRUMENTATION_H_
+
+#include <cstdint>
+
+// Needs to be called when the capture starts.
+extern "C" void StartNewCapture();
+
+// Payload called on entry of an instrumented function. Needs to record the return address of the
+// function (in order to have it available in `ExitPayload`). `function_id` is the id of the
+// instrumented function.
+extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id);
+
+// Payload called on exit of an instrumented function. Needs to return the actual return address of
+// the function such that the execution can be continued there.
+extern "C" uint64_t ExitPayload();
+
+#endif  // ORBIT_USER_SPACE_INSTRUMENTATION_H_

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef USER_SPACE_INSTRUMENTATION_INSTRUMENT_PROCESS_H_
+#define USER_SPACE_INSTRUMENTATION_INSTRUMENT_PROCESS_H_
+
+#include <absl/container/flat_hash_set.h>
+
+#include <cstdint>
+
+#include "OrbitBase/Result.h"
+#include "capture.pb.h"
+
+namespace orbit_user_space_instrumentation {
+
+// On the first call to this function we inject OrbitUserSpaceInstrumentation.so into the target
+// process and create the return trampoline. On each call we create trampolines for functions that
+// were not instrumented before and instrument all functions by overwriting the prolog with a jump
+// into the trampoline.
+// Returns the function_id's of the instrumented functions. Note that there is no garantee that we
+// can instrument all the functions in a binary.
+[[nodiscard]] ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentProcess(
+    const orbit_grpc_protos::CaptureOptions& capture_options);
+
+// Undo the instrumentation of the functions. Leaves the library and trampolines in the target
+// process intact. We merely restore the function prologs that were overwritten
+[[nodiscard]] ErrorMessageOr<void> UninstrumentProcess(
+    const orbit_grpc_protos::CaptureOptions& capture_options);
+
+}  // namespace orbit_user_space_instrumentation
+
+#endif  // USER_SPACE_INSTRUMENTATION_INSTRUMENT_PROCESS_H_

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
@@ -19,18 +19,18 @@ namespace orbit_user_space_instrumentation {
 
 class InstrumentedProcess;
 
-// `UserSpaceInstrumentation` is a globally unique object containing the bookkeeping for all user
-// space instrumentaion (in the `process_map_` member). It's lifetime is pretty much identical with
-// the lifetime of the profiling service.
-class UserSpaceInstrumentation {
+// `InstrumentationManager` is a globally unique object containing the bookkeeping for all user
+// space instrumentaion (in the `process_map_` member). Its lifetime is pretty much identical to the
+// lifetime of the profiling service.
+class InstrumentationManager {
  public:
-  UserSpaceInstrumentation(const UserSpaceInstrumentation&) = delete;
-  UserSpaceInstrumentation(UserSpaceInstrumentation&&) = delete;
-  UserSpaceInstrumentation& operator=(const UserSpaceInstrumentation&) = delete;
-  UserSpaceInstrumentation& operator=(UserSpaceInstrumentation&&) = delete;
-  ~UserSpaceInstrumentation();
+  InstrumentationManager(const InstrumentationManager&) = delete;
+  InstrumentationManager(InstrumentationManager&&) = delete;
+  InstrumentationManager& operator=(const InstrumentationManager&) = delete;
+  InstrumentationManager& operator=(InstrumentationManager&&) = delete;
+  ~InstrumentationManager();
 
-  [[nodiscard]] static std::unique_ptr<UserSpaceInstrumentation> Create();
+  [[nodiscard]] static std::unique_ptr<InstrumentationManager> Create();
 
   // On the first call to this function we inject OrbitUserSpaceInstrumentation.so into the target
   // process and create the return trampoline. On each call we create trampolines for functions that
@@ -45,7 +45,7 @@ class UserSpaceInstrumentation {
   [[nodiscard]] ErrorMessageOr<void> UninstrumentProcess(pid_t pid);
 
  private:
-  UserSpaceInstrumentation() = default;
+  InstrumentationManager() = default;
 
   absl::flat_hash_map<pid_t, std::unique_ptr<InstrumentedProcess>> process_map_;
 };

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
@@ -5,28 +5,50 @@
 #ifndef USER_SPACE_INSTRUMENTATION_INSTRUMENT_PROCESS_H_
 #define USER_SPACE_INSTRUMENTATION_INSTRUMENT_PROCESS_H_
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <sys/types.h>
 
 #include <cstdint>
+#include <memory>
 
 #include "OrbitBase/Result.h"
 #include "capture.pb.h"
 
 namespace orbit_user_space_instrumentation {
 
-// On the first call to this function we inject OrbitUserSpaceInstrumentation.so into the target
-// process and create the return trampoline. On each call we create trampolines for functions that
-// were not instrumented before and instrument all functions by overwriting the prolog with a jump
-// into the trampoline.
-// Returns the function_id's of the instrumented functions. Note that there is no garantee that we
-// can instrument all the functions in a binary.
-[[nodiscard]] ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentProcess(
-    const orbit_grpc_protos::CaptureOptions& capture_options);
+class InstrumentedProcess;
 
-// Undo the instrumentation of the functions. Leaves the library and trampolines in the target
-// process intact. We merely restore the function prologs that were overwritten
-[[nodiscard]] ErrorMessageOr<void> UninstrumentProcess(
-    const orbit_grpc_protos::CaptureOptions& capture_options);
+// `UserSpaceInstrumentation` is a globally unique object containing the bookkeeping for all user
+// space instrumentaion (in the `process_map_` member). It's lifetime is pretty much identical with
+// the lifetime of the profiling service.
+class UserSpaceInstrumentation {
+ public:
+  UserSpaceInstrumentation(const UserSpaceInstrumentation&) = delete;
+  UserSpaceInstrumentation(UserSpaceInstrumentation&&) = delete;
+  UserSpaceInstrumentation& operator=(const UserSpaceInstrumentation&) = delete;
+  UserSpaceInstrumentation& operator=(UserSpaceInstrumentation&&) = delete;
+  ~UserSpaceInstrumentation();
+
+  [[nodiscard]] static std::unique_ptr<UserSpaceInstrumentation> Create();
+
+  // On the first call to this function we inject OrbitUserSpaceInstrumentation.so into the target
+  // process and create the return trampoline. On each call we create trampolines for functions that
+  // were not instrumented before and instrument all functions by overwriting the prologue with a
+  // jump into the trampoline. Returns the function_id's of the instrumented functions. Note that
+  // there is no guarantee that we can instrument all the functions in a binary.
+  [[nodiscard]] ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentProcess(
+      const orbit_grpc_protos::CaptureOptions& capture_options);
+
+  // Undo the instrumentation of the functions. Leaves the library and trampolines in the target
+  // process intact. We merely restore the function prologues that were overwritten.
+  [[nodiscard]] ErrorMessageOr<void> UninstrumentProcess(pid_t pid);
+
+ private:
+  UserSpaceInstrumentation() = default;
+
+  absl::flat_hash_map<pid_t, std::unique_ptr<InstrumentedProcess>> process_map_;
+};
 
 }  // namespace orbit_user_space_instrumentation
 


### PR DESCRIPTION
This PR constains
  * the library we need to inject into the tracee
    (OrbitUserSpaceInstrumentation.*)
  * the code injecting the library, tying together different step needed to
    instrument functions and the bookkeeping of the memory allocated in the
    target process.
    (InstrumentProcess.*)
  * actually using the code in CaptureServiceImpl.cpp

Bug: http://b/194703196
Test: Unit tests for now. This deserves an e2e test (later).