### PR TITLE
Cleanup CaptureData

### DIFF
--- a/src/ClientData/CallstackData.cpp
+++ b/src/ClientData/CallstackData.cpp
@@ -146,11 +146,11 @@ void CallstackData::ForEachCallstackEventOfTidInTimeRange(
 }
 
 void CallstackData::AddCallstackFromKnownCallstackData(const CallstackEvent& event,
-                                                       const CallstackData* known_callstack_data) {
+                                                       const CallstackData& known_callstack_data) {
   std::lock_guard lock(mutex_);
   uint64_t callstack_id = event.callstack_id();
   std::shared_ptr<orbit_client_protos::CallstackInfo> unique_callstack =
-      known_callstack_data->GetCallstackPtr(callstack_id);
+      known_callstack_data.GetCallstackPtr(callstack_id);
   if (unique_callstack == nullptr) {
     return;
   }

--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -30,9 +30,7 @@ CaptureData::CaptureData(ModuleManager* module_manager, const CaptureStarted& ca
                          std::optional<std::filesystem::path> file_path,
                          absl::flat_hash_set<uint64_t> frame_track_function_ids)
     : module_manager_{module_manager},
-      callstack_data_(std::make_unique<CallstackData>()),
       selection_callstack_data_(std::make_unique<CallstackData>()),
-      tracepoint_data_(std::make_unique<TracepointData>()),
       frame_track_function_ids_{std::move(frame_track_function_ids)},
       file_path_{std::move(file_path)} {
   ProcessInfo process_info;
@@ -55,7 +53,7 @@ CaptureData::CaptureData(ModuleManager* module_manager, const CaptureStarted& ca
 void CaptureData::ForEachThreadStateSliceIntersectingTimeRange(
     int32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
     const std::function<void(const ThreadStateSliceInfo&)>& action) const {
-  absl::MutexLock lock{thread_state_slices_mutex_.get()};
+  absl::MutexLock lock{&thread_state_slices_mutex_};
   auto tid_thread_state_slices_it = thread_state_slices_.find(thread_id);
   if (tid_thread_state_slices_it == thread_state_slices_.end()) {
     return;

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -36,7 +36,7 @@ class CallstackData {
   void AddCallstackEvent(orbit_client_protos::CallstackEvent callstack_event);
   void AddUniqueCallstack(uint64_t callstack_id, orbit_client_protos::CallstackInfo callstack);
   void AddCallstackFromKnownCallstackData(const orbit_client_protos::CallstackEvent& event,
-                                          const CallstackData* known_callstack_data);
+                                          const CallstackData& known_callstack_data);
 
   [[nodiscard]] const absl::flat_hash_map<int32_t,
                                           std::map<uint64_t, orbit_client_protos::CallstackEvent>>&

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -120,12 +120,12 @@ class CaptureData {
   }
 
   [[nodiscard]] bool HasThreadStatesForThread(int32_t tid) const {
-    absl::MutexLock lock{thread_state_slices_mutex_.get()};
+    absl::MutexLock lock{&thread_state_slices_mutex_};
     return thread_state_slices_.count(tid) > 0;
   }
 
   void AddThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo state_slice) {
-    absl::MutexLock lock{thread_state_slices_mutex_.get()};
+    absl::MutexLock lock{&thread_state_slices_mutex_};
     thread_state_slices_[state_slice.tid()].emplace_back(std::move(state_slice));
   }
 
@@ -147,51 +147,45 @@ class CaptureData {
 
   void OnCaptureComplete(const std::vector<const orbit_client_data::TimerChain*>& chains);
 
-  [[nodiscard]] const orbit_client_data::CallstackData* GetCallstackData() const {
-    return callstack_data_.get();
-  };
+  [[nodiscard]] const CallstackData& GetCallstackData() const { return callstack_data_; };
 
   [[nodiscard]] orbit_grpc_protos::TracepointInfo GetTracepointInfo(uint64_t key) const {
-    return tracepoint_data_->GetTracepointInfo(key);
-  }
-
-  [[nodiscard]] const orbit_client_data::TracepointData* GetTracepointData() const {
-    return tracepoint_data_.get();
+    return tracepoint_data_.GetTracepointInfo(key);
   }
 
   void ForEachTracepointEventOfThreadInTimeRange(
       int32_t thread_id, uint64_t min_tick, uint64_t max_tick,
       const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
-    return tracepoint_data_->ForEachTracepointEventOfThreadInTimeRange(thread_id, min_tick,
-                                                                       max_tick, action);
+    return tracepoint_data_.ForEachTracepointEventOfThreadInTimeRange(thread_id, min_tick, max_tick,
+                                                                      action);
   }
 
   uint32_t GetNumTracepointsForThreadId(int32_t thread_id) const {
-    return tracepoint_data_->GetNumTracepointEventsForThreadId(thread_id);
+    return tracepoint_data_.GetNumTracepointEventsForThreadId(thread_id);
   }
 
   void reset_file_path() { file_path_.reset(); }
 
   void AddUniqueCallstack(uint64_t callstack_id, orbit_client_protos::CallstackInfo callstack) {
-    callstack_data_->AddUniqueCallstack(callstack_id, std::move(callstack));
+    callstack_data_.AddUniqueCallstack(callstack_id, std::move(callstack));
   }
 
   void AddCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) {
-    callstack_data_->AddCallstackEvent(std::move(callstack_event));
+    callstack_data_.AddCallstackEvent(std::move(callstack_event));
   }
 
-  void FilterBrokenCallstacks() { callstack_data_->UpdateCallstackTypeBasedOnMajorityStart(); }
+  void FilterBrokenCallstacks() { callstack_data_.UpdateCallstackTypeBasedOnMajorityStart(); }
 
   void AddUniqueTracepointEventInfo(uint64_t key,
                                     orbit_grpc_protos::TracepointInfo tracepoint_info) {
-    tracepoint_data_->AddUniqueTracepointInfo(key, std::move(tracepoint_info));
+    tracepoint_data_.AddUniqueTracepointInfo(key, std::move(tracepoint_info));
   }
 
   void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash,
                                          int32_t process_id, int32_t thread_id, int32_t cpu,
                                          bool is_same_pid_as_target) {
-    tracepoint_data_->EmplaceTracepointEvent(time, tracepoint_hash, process_id, thread_id, cpu,
-                                             is_same_pid_as_target);
+    tracepoint_data_.EmplaceTracepointEvent(time, tracepoint_hash, process_id, thread_id, cpu,
+                                            is_same_pid_as_target);
   }
 
   [[nodiscard]] const orbit_client_data::CallstackData* GetSelectionCallstackData() const {
@@ -250,15 +244,13 @@ class CaptureData {
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions_;
 
   orbit_client_data::TracepointInfoSet selected_tracepoints_;
-  // std::unique_ptr<> allows to move and copy CallstackData easier
-  // (as CallstackData stores an absl::Mutex inside)
-  std::unique_ptr<orbit_client_data::CallstackData> callstack_data_;
+  orbit_client_data::CallstackData callstack_data_;
   // selection_callstack_data_ is subset of callstack_data_
   std::unique_ptr<orbit_client_data::CallstackData> selection_callstack_data_;
 
-  std::unique_ptr<orbit_client_data::TracepointData> tracepoint_data_;
+  TracepointData tracepoint_data_;
 
-  std::optional<orbit_client_data::PostProcessedSamplingData> post_processed_sampling_data_;
+  std::optional<PostProcessedSamplingData> post_processed_sampling_data_;
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::LinuxAddressInfo> address_infos_;
 
@@ -266,9 +258,10 @@ class CaptureData {
 
   absl::flat_hash_map<int32_t, std::string> thread_names_;
 
+  // For each thread, assume sorted by timestamp and not overlapping.
   absl::flat_hash_map<int32_t, std::vector<orbit_client_protos::ThreadStateSliceInfo>>
-      thread_state_slices_;  // For each thread, assume sorted by timestamp and not overlapping.
-  mutable std::unique_ptr<absl::Mutex> thread_state_slices_mutex_ = std::make_unique<absl::Mutex>();
+      thread_state_slices_ GUARDED_BY(thread_state_slices_mutex_);
+  mutable absl::Mutex thread_state_slices_mutex_;
 
   // Only access this field from the main thread.
   orbit_client_data::TimestampIntervalSet incomplete_data_intervals_;

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -344,12 +344,12 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   }
 
   void CreatePostProcessedSamplingDataWithoutSummary() {
-    ppsd_ = CreatePostProcessedSamplingData(*capture_data_.GetCallstackData(), capture_data_,
+    ppsd_ = CreatePostProcessedSamplingData(capture_data_.GetCallstackData(), capture_data_,
                                             /*generate_summary=*/false);
   }
 
   void CreatePostProcessedSamplingDataWithSummary() {
-    ppsd_ = CreatePostProcessedSamplingData(*capture_data_.GetCallstackData(), capture_data_,
+    ppsd_ = CreatePostProcessedSamplingData(capture_data_.GetCallstackData(), capture_data_,
                                             /*generate_summary=*/true);
   }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -344,7 +344,7 @@ Future<void> OrbitApp::OnCaptureComplete() {
 
   GetMutableCaptureData().FilterBrokenCallstacks();
   PostProcessedSamplingData post_processed_sampling_data =
-      orbit_client_model::CreatePostProcessedSamplingData(*GetCaptureData().GetCallstackData(),
+      orbit_client_model::CreatePostProcessedSamplingData(GetCaptureData().GetCallstackData(),
                                                           GetCaptureData());
 
   LOG("The capture contains %u intervals with incomplete data",
@@ -359,7 +359,7 @@ Future<void> OrbitApp::OnCaptureComplete() {
         RefreshCaptureView();
 
         SetSamplingReport(std::move(sampling_profiler),
-                          GetCaptureData().GetCallstackData()->GetUniqueCallstacksCopy());
+                          GetCaptureData().GetCallstackData().GetUniqueCallstacksCopy());
         SetTopDownView(GetCaptureData());
         SetBottomUpView(GetCaptureData());
 
@@ -843,7 +843,7 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
     orbit_code_report::DisassemblyReport report(
         disasm, absolute_address, *thread_sample_data,
         post_processed_sampling_data.GetCountOfFunction(absolute_address),
-        capture_data.GetCallstackData()->GetCallstackEventsCount());
+        capture_data.GetCallstackData().GetCallstackEventsCount());
     SendDisassemblyToUi(function, disasm.GetResult(), std::move(report));
   });
 }
@@ -891,7 +891,7 @@ void OrbitApp::ShowSourceCode(const orbit_client_protos::FunctionInfo& function)
                 code_report = std::make_unique<orbit_code_report::SourceCodeReport>(
                     line_info.source_file(), function, absolute_address.value(),
                     elf_file.value().get(), *summary,
-                    GetCaptureData().GetCallstackData()->GetCallstackEventsCount());
+                    GetCaptureData().GetCallstackData().GetCallstackEventsCount());
               }
             }
 
@@ -2265,7 +2265,7 @@ uint64_t OrbitApp::GetFunctionIdToHighlight() const {
 
 void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
                                      int32_t thread_id) {
-  const CallstackData* callstack_data = GetCaptureData().GetCallstackData();
+  const CallstackData& callstack_data = GetCaptureData().GetCallstackData();
   std::unique_ptr<CallstackData> selection_callstack_data = std::make_unique<CallstackData>();
   for (const CallstackEvent& event : selected_callstack_events) {
     selection_callstack_data->AddCallstackFromKnownCallstackData(event, callstack_data);
@@ -2295,10 +2295,10 @@ void OrbitApp::UpdateAfterSymbolLoading() {
 
   if (sampling_report_ != nullptr) {
     PostProcessedSamplingData post_processed_sampling_data =
-        orbit_client_model::CreatePostProcessedSamplingData(*capture_data.GetCallstackData(),
+        orbit_client_model::CreatePostProcessedSamplingData(capture_data.GetCallstackData(),
                                                             capture_data);
     sampling_report_->UpdateReport(post_processed_sampling_data,
-                                   capture_data.GetCallstackData()->GetUniqueCallstacksCopy());
+                                   capture_data.GetCallstackData().GetUniqueCallstacksCopy());
     GetMutableCaptureData().set_post_processed_sampling_data(post_processed_sampling_data);
     SetTopDownView(capture_data);
     SetBottomUpView(capture_data);

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -115,7 +115,7 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
       CHECK(time >= min_tick && time <= max_tick);
       Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
       Color color = kWhite;
-      if (capture_data_->GetCallstackData()->GetCallstack(event.callstack_id())->type() !=
+      if (capture_data_->GetCallstackData().GetCallstack(event.callstack_id())->type() !=
           CallstackInfo::kComplete) {
         color = kGreyError;
       }
@@ -123,10 +123,10 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
     };
 
     if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
-      capture_data_->GetCallstackData()->ForEachCallstackEventInTimeRange(
+      capture_data_->GetCallstackData().ForEachCallstackEventInTimeRange(
           min_tick, max_tick, action_on_callstack_events);
     } else {
-      capture_data_->GetCallstackData()->ForEachCallstackEventOfTidInTimeRange(
+      capture_data_->GetCallstackData().ForEachCallstackEventOfTidInTimeRange(
           GetThreadId(), min_tick, max_tick, action_on_callstack_events);
     }
 
@@ -155,10 +155,10 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
       batcher->AddShadedBox(pos, size, z, kGreenSelection, std::move(user_data));
     };
     if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
-      capture_data_->GetCallstackData()->ForEachCallstackEventInTimeRange(
+      capture_data_->GetCallstackData().ForEachCallstackEventInTimeRange(
           min_tick, max_tick, action_on_callstack_events);
     } else {
-      capture_data_->GetCallstackData()->ForEachCallstackEventOfTidInTimeRange(
+      capture_data_->GetCallstackData().ForEachCallstackEventOfTidInTimeRange(
           GetThreadId(), min_tick, max_tick, action_on_callstack_events);
     }
   }
@@ -188,8 +188,8 @@ bool CallstackThreadBar::IsEmpty() const {
 
   const uint32_t callstack_count =
       (GetThreadId() == orbit_base::kAllProcessThreadsTid)
-          ? capture_data_->GetCallstackData()->GetCallstackEventsCount()
-          : capture_data_->GetCallstackData()->GetCallstackEventsOfTidCount(GetThreadId());
+          ? capture_data_->GetCallstackData().GetCallstackEventsCount()
+          : capture_data_->GetCallstackData().GetCallstackEventsOfTidCount(GetThreadId());
   return callstack_count == 0;
 }
 
@@ -248,11 +248,11 @@ std::string CallstackThreadBar::GetSampleTooltip(const Batcher& batcher, Picking
   }
 
   CHECK(capture_data_ != nullptr);
-  const CallstackData* callstack_data = capture_data_->GetCallstackData();
+  const CallstackData& callstack_data = capture_data_->GetCallstackData();
   const auto* callstack_event = static_cast<const CallstackEvent*>(user_data->custom_data_);
 
   uint64_t callstack_id = callstack_event->callstack_id();
-  const CallstackInfo* callstack = callstack_data->GetCallstack(callstack_id);
+  const CallstackInfo* callstack = callstack_data.GetCallstack(callstack_id);
   if (callstack == nullptr) {
     return unknown_return_text;
   }

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -662,8 +662,8 @@ void CaptureWindow::RenderImGuiDebugUI() {
       IMGUI_VAR_TO_TEXT(time_graph_->GetTimeWindowUs());
       const CaptureData* capture_data = time_graph_->GetCaptureData();
       if (capture_data != nullptr) {
-        IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData()->callstack_events_by_tid().size());
-        IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData()->GetCallstackEventsCount());
+        IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData().callstack_events_by_tid().size());
+        IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData().GetCallstackEventsCount());
       }
     }
   }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -242,8 +242,8 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
 }
 
 void ThreadTrack::UpdateMinMaxTimestamps() {
-  track_data_->UpdateMinTime(capture_data_->GetCallstackData()->min_time());
-  track_data_->UpdateMaxTime(capture_data_->GetCallstackData()->max_time());
+  track_data_->UpdateMinTime(capture_data_->GetCallstackData().min_time());
+  track_data_->UpdateMaxTime(capture_data_->GetCallstackData().max_time());
 }
 
 void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -572,9 +572,9 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
   text_renderer_static_.Clear();
 
   capture_min_timestamp_ =
-      std::min(capture_min_timestamp_, capture_data_->GetCallstackData()->min_time());
+      std::min(capture_min_timestamp_, capture_data_->GetCallstackData().min_time());
   capture_max_timestamp_ =
-      std::max(capture_max_timestamp_, capture_data_->GetCallstackData()->max_time());
+      std::max(capture_max_timestamp_, capture_data_->GetCallstackData().max_time());
 
   time_window_us_ = max_time_us_ - min_time_us_;
   world_start_x_ = viewport_->GetWorldTopLeft()[0];
@@ -599,9 +599,8 @@ void TimeGraph::SelectCallstacks(float world_start, float world_end, int32_t thr
   CHECK(capture_data_);
   std::vector<CallstackEvent> selected_callstack_events =
       (thread_id == orbit_base::kAllProcessThreadsTid)
-          ? capture_data_->GetCallstackData()->GetCallstackEventsInTimeRange(t0, t1)
-          : capture_data_->GetCallstackData()->GetCallstackEventsOfTidInTimeRange(thread_id, t0,
-                                                                                  t1);
+          ? capture_data_->GetCallstackData().GetCallstackEventsInTimeRange(t0, t1)
+          : capture_data_->GetCallstackData().GetCallstackEventsOfTidInTimeRange(thread_id, t0, t1);
 
   selected_callstack_events_per_thread_.clear();
   for (CallstackEvent& event : selected_callstack_events) {

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -213,15 +213,14 @@ void TrackManager::UpdateVisibleTrackList() {
 std::vector<ThreadTrack*> TrackManager::GetSortedThreadTracks() {
   std::vector<ThreadTrack*> sorted_tracks;
   absl::flat_hash_map<ThreadTrack*, uint32_t> num_events_by_track;
-  const CallstackData* callstack_data = capture_data_->GetCallstackData();
+  const CallstackData& callstack_data = capture_data_->GetCallstackData();
 
   for (auto& [tid, track] : thread_tracks_) {
     if (tid == orbit_base::kAllProcessThreadsTid) {
       continue;  // "kAllProcessThreadsTid" is handled separately.
     }
     sorted_tracks.push_back(track.get());
-    uint32_t num_events = callstack_data ? callstack_data->GetCallstackEventsOfTidCount(tid) : 0;
-    num_events_by_track[track.get()] = num_events;
+    num_events_by_track[track.get()] = callstack_data.GetCallstackEventsOfTidCount(tid);
   }
 
   // Tracks with instrumented timers appear first, ordered by descending order of timers.

--- a/src/OrbitQt/CallTreeViewItemModelTest.cpp
+++ b/src/OrbitQt/CallTreeViewItemModelTest.cpp
@@ -74,7 +74,7 @@ TEST(CallTreeViewItemModel, AbstractItemModelTesterFilledModel) {
 
   std::unique_ptr<CaptureData> capture_data = GenerateTestCaptureData();
   orbit_client_data::PostProcessedSamplingData sampling_data =
-      orbit_client_model::CreatePostProcessedSamplingData(*capture_data->GetCallstackData(),
+      orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
                                                           *capture_data);
 
   auto call_tree_view =
@@ -92,7 +92,7 @@ TEST(CallTreeViewItemModel, SummaryItem) {
     bool generate_summary = false;
 
     orbit_client_data::PostProcessedSamplingData sampling_data =
-        orbit_client_model::CreatePostProcessedSamplingData(*capture_data->GetCallstackData(),
+        orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
                                                             *capture_data, generate_summary);
     auto call_tree_view =
         CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(sampling_data, *capture_data);
@@ -105,7 +105,7 @@ TEST(CallTreeViewItemModel, SummaryItem) {
   {
     bool generate_summary = true;
     orbit_client_data::PostProcessedSamplingData sampling_data =
-        orbit_client_model::CreatePostProcessedSamplingData(*capture_data->GetCallstackData(),
+        orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
                                                             *capture_data, generate_summary);
     auto call_tree_view =
         CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(sampling_data, *capture_data);
@@ -121,7 +121,7 @@ TEST(CallTreeViewItemModel, GetDisplayRoleData) {
   // do not create summary, because this creates an additional top level row (all threads) and this
   // is not tested here
   orbit_client_data::PostProcessedSamplingData sampling_data =
-      orbit_client_model::CreatePostProcessedSamplingData(*capture_data->GetCallstackData(),
+      orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
                                                           *capture_data, false);
 
   auto call_tree_view =
@@ -206,7 +206,7 @@ TEST(CallTreeViewItemModel, GetEditRoleData) {
   // do not create summary, because this creates an additional top level row (all threads) and this
   // is not tested here
   orbit_client_data::PostProcessedSamplingData sampling_data =
-      orbit_client_model::CreatePostProcessedSamplingData(*capture_data->GetCallstackData(),
+      orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
                                                           *capture_data, false);
 
   auto call_tree_view =


### PR DESCRIPTION
Since CaptureData is not movable remove all unique_ptrs
which were there for this reason. Also remove some unused
functions and fields.

Test: builds