### PR TITLE
[REBASE] Fix regression with memory legend size

### DIFF
--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -133,7 +133,7 @@ std::string GraphTrack<Dimension>::GetLabelTextFromValues(
 template <size_t Dimension>
 uint32_t GraphTrack<Dimension>::GetLegendFontSize(uint32_t indentation_level) const {
   constexpr uint32_t kMinIndentationLevel = 1;
-  int capped_indentation_level = std::min(indentation_level, kMinIndentationLevel);
+  int capped_indentation_level = std::max(indentation_level, kMinIndentationLevel);
 
   uint32_t font_size = layout_->CalculateZoomedFontSize();
   return (font_size * (10 - capped_indentation_level)) / 10;


### PR DESCRIPTION
In a refactor I made a mistake within std::min and std::max.