### PR TITLE
Load instance credentials only on demand

### DIFF
--- a/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
@@ -60,7 +60,7 @@ class ConnectToStadiaWidget : public QWidget {
 
  private slots:
   void ReloadInstances();
-  void CheckCredentialsAvailable();
+  void CheckCredentialsAvailableOrLoad();
   void DeployOrbitService();
   void Disconnect();
   void OnConnectToStadiaRadioButtonClicked(bool checked);
@@ -103,6 +103,7 @@ class ConnectToStadiaWidget : public QWidget {
   QState s_deploying_;
   QState s_connected_;
 
+  absl::flat_hash_set<std::string> instance_credentials_loading_;
   absl::flat_hash_map<std::string, ErrorMessageOr<orbit_ssh::Credentials>> instance_credentials_;
 
   void DetachRadioButton();


### PR DESCRIPTION
The `ConnectToStadiaWidget` automatically loads the credentials for all listed instances after the list has been populated. This slightly speeds up the subsequent connection if you have a small number of instances, but if a high number of instances are reserved, this uses a *lot* of resources (network and CPU load is noticeable throughout the whole system!) and makes the session setup window completely unusable for minutes.

To reproduce: Append `--all` as a parameter in the ggp call inside `Client::GetInstancesAsync` and start Orbit.

On top of this, every time loading credentials fails, the session setup window tries to reload the instances. If there's instances in your list that you can't connect to (this may especially happen if we allow to list instances of other owners or projects later), every failed connection attempt forces the user to wait for the instances to be reloaded.

Changes in this PR:
1) Encryption credentials are loaded only when a user tries to connect to an instance. They are still stored in the internal map for the next connection attempt.
2) When the instance connection fails, the instance list is not automatically reloaded. This comes at the downside that released instances may remain in the list and the user needs to explicitly reload, but I feel this is less of an issue than the automatic reloading may cause.

Bug: b/195641213