### PR TITLE
Add the "Date Modified" column to preset view

### DIFF
--- a/src/DataViews/CMakeLists.txt
+++ b/src/DataViews/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(DataViews STATIC)
 target_sources(DataViews PRIVATE
         CompareAscendingOrDescending.h
         DataView.cpp
+        DataViewUtils.h
+        DataViewUtils.cpp
         FunctionsDataView.cpp
         PresetsDataView.cpp)
 
@@ -34,6 +36,7 @@ target_link_libraries(DataViews PUBLIC
 add_executable(DataViewsTests)
 target_compile_options(DataViewsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(DataViewsTests PRIVATE DataViewTest.cpp
+                                      DataViewUtilsTest.cpp
                                       FunctionsDataViewTest.cpp
                                       MockAppInterface.h
                                       PresetsDataViewTest.cpp)

--- a/src/DataViews/DataViewUtils.cpp
+++ b/src/DataViews/DataViewUtils.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "DataViewUtils.h"
+
+namespace orbit_data_views {
+
+std::string FormatShortDatetime(absl::Time time) {
+  return absl::FormatTime("%m/%d/%Y %H:%M %p", time, absl::LocalTimeZone());
+}
+
+}  // namespace orbit_data_views

--- a/src/DataViews/DataViewUtils.h
+++ b/src/DataViews/DataViewUtils.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef DATA_VIEWS_DATA_VIEW_UTILS_H_
+#define DATA_VIEWS_DATA_VIEW_UTILS_H_
+
+#include <absl/time/time.h>
+
+#include <string>
+
+namespace orbit_data_views {
+std::string FormatShortDatetime(absl::Time time);
+}  // namespace orbit_data_views
+
+#endif  // DATA_VIEWS_DATA_VIEW_UTILS_H_

--- a/src/DataViews/DataViewUtilsTest.cpp
+++ b/src/DataViews/DataViewUtilsTest.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/time/time.h>
+#include <gtest/gtest.h>
+
+#include "DataViewUtils.h"
+
+namespace orbit_data_views {
+
+TEST(DataViewUtils, FormatShortDatetime) {
+  absl::Time datetime = absl::FromTimeT(0);
+  std::string result = FormatShortDatetime(datetime);
+  EXPECT_EQ(result, "01/01/1970 00:00 AM");
+}
+
+}  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -66,6 +66,7 @@ class PresetsDataView : public DataView {
     kColumnPresetName,
     kColumnModules,
     kColumnFunctionCount,
+    kColumnDateModified,
     kNumColumns
   };
 

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -385,4 +385,15 @@ TEST(File, ListFilesInDirectory) {
          });
 }
 
+TEST(File, GetFileDateModified) {
+  absl::Time now = absl::Now();
+  auto tmp_file_or_error = TemporaryFile::Create();
+  ASSERT_THAT(tmp_file_or_error, HasNoError());
+  auto tmp_file = std::move(tmp_file_or_error.value());
+
+  auto file_time_or_error = GetFileDateModified(tmp_file.file_path());
+  ASSERT_THAT(file_time_or_error, HasNoError());
+  EXPECT_LE(file_time_or_error.value() - now, absl::Seconds(1));
+}
+
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -6,6 +6,7 @@
 #define ORBIT_BASE_FILE_H_
 
 #include <absl/strings/str_format.h>
+#include <absl/time/time.h>
 #include <fcntl.h>
 
 #include <filesystem>
@@ -126,6 +127,7 @@ ErrorMessageOr<void> ResizeFile(const std::filesystem::path& file_path, uint64_t
 // Returns all files in directory; non recursively.
 ErrorMessageOr<std::vector<std::filesystem::path>> ListFilesInDirectory(
     const std::filesystem::path& directory);
+ErrorMessageOr<absl::Time> GetFileDateModified(const std::filesystem::path& path);
 
 }  // namespace orbit_base
 


### PR DESCRIPTION
Add the "Date Modified" column to the preset view. The time format is the same as the time format in capture file list.

Bug: http://b/187410705
Test: Unit test added.

After the change: https://screen/42q7jBEeoL4RbFz