### PR TITLE
Send new manual instrumentation events.

### DIFF
--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -27,7 +27,8 @@ target_sources(ApiBase PRIVATE
 target_link_libraries(ApiBase PUBLIC
         OrbitBase
         CaptureEventProducer
-        GrpcProtos)
+        GrpcProtos
+        ProducerSideChannel)
 
 add_executable(ApiInterfaceTests)
 

--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -19,16 +19,13 @@ target_compile_features(ApiBase PUBLIC cxx_std_17)
 
 target_sources(ApiBase PUBLIC
         include/Api/Event.h
-        include/Api/EncodedString.h
-        include/Api/LockFreeApiEventProducer.h)
+        include/Api/EncodedString.h)
 target_sources(ApiBase PRIVATE
-        EncodedString.cpp
-        LockFreeApiEventProducer.cpp)
+        EncodedString.cpp)
 target_link_libraries(ApiBase PUBLIC
-        OrbitBase
-        CaptureEventProducer
         GrpcProtos
-        ProducerSideChannel)
+        OrbitBase)
+target_include_directories(ApiBase PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 add_executable(ApiInterfaceTests)
 
@@ -57,6 +54,8 @@ target_compile_options(Api PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(Api PUBLIC cxx_std_17)
 
 target_sources(Api PRIVATE
+        LockFreeApiEventProducer.h
+        LockFreeApiEventProducer.cpp
         Orbit.cpp)
 
 target_link_libraries(Api PUBLIC

--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -8,22 +8,25 @@ add_library(ApiInterface INTERFACE)
 
 target_sources(ApiInterface INTERFACE
         include/Api/EncodedEvent.h
-        include/Api/LockFreeApiEventProducer.h
         include/Api/Orbit.h)
 
 target_include_directories(ApiInterface INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/include)
-
 
 add_library(ApiBase STATIC)
 target_compile_options(ApiBase PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(ApiBase PUBLIC cxx_std_17)
 
 target_sources(ApiBase PUBLIC
-        include/Api/EncodedString.h)
+        include/Api/Event.h
+        include/Api/EncodedString.h
+        include/Api/LockFreeApiEventProducer.h)
 target_sources(ApiBase PRIVATE
-        EncodedString.cpp)
+        EncodedString.cpp
+        LockFreeApiEventProducer.cpp)
 target_link_libraries(ApiBase PUBLIC
+        OrbitBase
+        CaptureEventProducer
         GrpcProtos)
 
 add_executable(ApiInterfaceTests)
@@ -57,6 +60,7 @@ target_sources(Api PRIVATE
 
 target_link_libraries(Api PUBLIC
         ApiInterface
+        ApiBase
         CaptureEventProducer
         GrpcProtos
         OrbitBase

--- a/src/Api/EncodedString.cpp
+++ b/src/Api/EncodedString.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 
 #include "capture.pb.h"
+#include "include/Api/Event.h"
 
 namespace orbit_api {
 
@@ -176,4 +177,6 @@ template void EncodeString<orbit_grpc_protos::ApiTrackUint>(const char* source,
 
 template void EncodeString<orbit_grpc_protos::ApiTrackUint64>(
     const char* source, orbit_grpc_protos::ApiTrackUint64* out);
+
+template void EncodeString<ApiEncodedString>(const char* source, ApiEncodedString* out);
 }  // namespace orbit_api

--- a/src/Api/LockFreeApiEventProducer.cpp
+++ b/src/Api/LockFreeApiEventProducer.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "include/Api/LockFreeApiEventProducer.h"
+
+namespace orbit_api {
+namespace {
+template <class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+overloaded(Ts...)->overloaded<Ts...>;
+
+template <typename CaptureEvent>
+inline void SetMetaData(const ApiEventMetaData& meta_data, CaptureEvent* out) {
+  out->set_pid(meta_data.pid);
+  out->set_tid(meta_data.tid);
+  out->set_timestamp_ns(meta_data.timestamp_ns);
+}
+
+template <typename CaptureEvent>
+inline void SetEncodedName(const ApiEncodedString& encoded_name, CaptureEvent* out) {
+  out->set_encoded_name_1(encoded_name.encoded_name_1);
+  out->set_encoded_name_2(encoded_name.encoded_name_2);
+  out->set_encoded_name_3(encoded_name.encoded_name_3);
+  out->set_encoded_name_4(encoded_name.encoded_name_4);
+  out->set_encoded_name_5(encoded_name.encoded_name_5);
+  out->set_encoded_name_6(encoded_name.encoded_name_6);
+  out->set_encoded_name_7(encoded_name.encoded_name_7);
+  out->set_encoded_name_8(encoded_name.encoded_name_8);
+  out->mutable_encoded_name_additional()->Add(encoded_name.encoded_name_additional.begin(),
+                                              encoded_name.encoded_name_additional.end());
+}
+}  // namespace
+
+orbit_grpc_protos::ProducerCaptureEvent* LockFreeApiEventProducer::TranslateIntermediateEvent(
+    ApiEventVariant&& raw_api_event, google::protobuf::Arena* arena) {
+  auto* capture_event =
+      google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
+
+  std::visit(overloaded{[](const std::monostate& /*unused*/) {},
+                        [capture_event](const ApiScopeStart& scope_start) {
+                          auto* api_event = capture_event->mutable_api_scope_start();
+                          SetMetaData(scope_start.meta_data, api_event);
+                          SetEncodedName(scope_start.encoded_name, api_event);
+                          api_event->set_color_rgba(scope_start.color_rgba);
+                          api_event->set_group_id(scope_start.group_id);
+                          api_event->set_address_in_function(scope_start.address_in_function);
+                        },
+                        [capture_event](const ApiScopeStop& scope_stop) {
+                          auto* api_event = capture_event->mutable_api_scope_stop();
+                          SetMetaData(scope_stop.meta_data, api_event);
+                        },
+                        [capture_event](const ApiScopeStartAsync& scope_start_async) {
+                          auto* api_event = capture_event->mutable_api_scope_start_async();
+                          SetMetaData(scope_start_async.meta_data, api_event);
+                          SetEncodedName(scope_start_async.encoded_name, api_event);
+                          api_event->set_color_rgba(scope_start_async.color_rgba);
+                          api_event->set_id(scope_start_async.id);
+                          api_event->set_address_in_function(scope_start_async.address_in_function);
+                        },
+                        [capture_event](const ApiScopeStopAsync& scope_stop_async) {
+                          auto* api_event = capture_event->mutable_api_scope_stop_async();
+                          SetMetaData(scope_stop_async.meta_data, api_event);
+                          api_event->set_id(scope_stop_async.id);
+                        },
+                        [capture_event](const ApiStringEvent& string_event) {
+                          auto* api_event = capture_event->mutable_api_string_event();
+                          SetMetaData(string_event.meta_data, api_event);
+                          SetEncodedName(string_event.encoded_name, api_event);
+                          api_event->set_id(string_event.id);
+                          api_event->set_color_rgba(string_event.color_rgba);
+                        },
+                        [capture_event](const ApiTrackDouble& track_double) {
+                          auto* api_event = capture_event->mutable_api_track_double();
+                          SetMetaData(track_double.meta_data, api_event);
+                          SetEncodedName(track_double.encoded_name, api_event);
+                          api_event->set_data(track_double.data);
+                          api_event->set_color_rgba(track_double.color_rgba);
+                        },
+                        [capture_event](const ApiTrackFloat& track_float) {
+                          auto* api_event = capture_event->mutable_api_track_float();
+                          SetMetaData(track_float.meta_data, api_event);
+                          SetEncodedName(track_float.encoded_name, api_event);
+                          api_event->set_data(track_float.data);
+                          api_event->set_color_rgba(track_float.color_rgba);
+                        },
+                        [capture_event](const ApiTrackInt& track_int) {
+                          auto* api_event = capture_event->mutable_api_track_int();
+                          SetMetaData(track_int.meta_data, api_event);
+                          SetEncodedName(track_int.encoded_name, api_event);
+                          api_event->set_data(track_int.data);
+                          api_event->set_color_rgba(track_int.color_rgba);
+                        },
+                        [capture_event](const ApiTrackInt64& track_int64) {
+                          auto* api_event = capture_event->mutable_api_track_int64();
+                          SetMetaData(track_int64.meta_data, api_event);
+                          SetEncodedName(track_int64.encoded_name, api_event);
+                          api_event->set_data(track_int64.data);
+                          api_event->set_color_rgba(track_int64.color_rgba);
+                        },
+                        [capture_event](const ApiTrackUint& track_uint) {
+                          auto* api_event = capture_event->mutable_api_track_uint();
+                          SetMetaData(track_uint.meta_data, api_event);
+                          SetEncodedName(track_uint.encoded_name, api_event);
+                          api_event->set_data(track_uint.data);
+                          api_event->set_color_rgba(track_uint.color_rgba);
+                        },
+                        [capture_event](const ApiTrackUint64& track_uint64) {
+                          auto* api_event = capture_event->mutable_api_track_uint64();
+                          SetMetaData(track_uint64.meta_data, api_event);
+                          SetEncodedName(track_uint64.encoded_name, api_event);
+                          api_event->set_data(track_uint64.data);
+                          api_event->set_color_rgba(track_uint64.color_rgba);
+                        }},
+             raw_api_event);
+
+  return capture_event;
+}
+}  // namespace orbit_api

--- a/src/Api/LockFreeApiEventProducer.cpp
+++ b/src/Api/LockFreeApiEventProducer.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "include/Api/LockFreeApiEventProducer.h"
+#include "LockFreeApiEventProducer.h"
 
 namespace orbit_api {
 namespace {

--- a/src/Api/LockFreeApiEventProducer.cpp
+++ b/src/Api/LockFreeApiEventProducer.cpp
@@ -6,12 +6,6 @@
 
 namespace orbit_api {
 namespace {
-template <class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-overloaded(Ts...)->overloaded<Ts...>;
 
 template <typename CaptureEvent>
 inline void SetMetaData(const ApiEventMetaData& meta_data, CaptureEvent* out) {
@@ -33,6 +27,109 @@ inline void SetEncodedName(const ApiEncodedString& encoded_name, CaptureEvent* o
   out->mutable_encoded_name_additional()->Add(encoded_name.encoded_name_additional.begin(),
                                               encoded_name.encoded_name_additional.end());
 }
+
+inline void CreateCaptureEvent(const ApiScopeStart& scope_start,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_scope_start();
+  SetMetaData(scope_start.meta_data, api_event);
+  SetEncodedName(scope_start.encoded_name, api_event);
+  api_event->set_color_rgba(scope_start.color_rgba);
+  api_event->set_group_id(scope_start.group_id);
+  api_event->set_address_in_function(scope_start.address_in_function);
+}
+
+inline void CreateCaptureEvent(const ApiScopeStop& scope_stop,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_scope_stop();
+  SetMetaData(scope_stop.meta_data, api_event);
+}
+
+inline void CreateCaptureEvent(const ApiScopeStartAsync& scope_start_async,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_scope_start_async();
+  SetMetaData(scope_start_async.meta_data, api_event);
+  SetEncodedName(scope_start_async.encoded_name, api_event);
+  api_event->set_color_rgba(scope_start_async.color_rgba);
+  api_event->set_id(scope_start_async.id);
+  api_event->set_address_in_function(scope_start_async.address_in_function);
+}
+
+inline void CreateCaptureEvent(const ApiScopeStopAsync& scope_stop_async,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_scope_stop_async();
+  SetMetaData(scope_stop_async.meta_data, api_event);
+  api_event->set_id(scope_stop_async.id);
+}
+
+inline void CreateCaptureEvent(const ApiStringEvent& string_event,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_string_event();
+  SetMetaData(string_event.meta_data, api_event);
+  SetEncodedName(string_event.encoded_name, api_event);
+  api_event->set_id(string_event.id);
+  api_event->set_color_rgba(string_event.color_rgba);
+}
+
+inline void CreateCaptureEvent(const ApiTrackDouble& track_double,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_double();
+  SetMetaData(track_double.meta_data, api_event);
+  SetEncodedName(track_double.encoded_name, api_event);
+  api_event->set_data(track_double.data);
+  api_event->set_color_rgba(track_double.color_rgba);
+}
+
+inline void CreateCaptureEvent(const ApiTrackFloat& track_float,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_float();
+  SetMetaData(track_float.meta_data, api_event);
+  SetEncodedName(track_float.encoded_name, api_event);
+  api_event->set_data(track_float.data);
+  api_event->set_color_rgba(track_float.color_rgba);
+}
+
+inline void CreateCaptureEvent(const ApiTrackInt& track_int,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_int();
+  SetMetaData(track_int.meta_data, api_event);
+  SetEncodedName(track_int.encoded_name, api_event);
+  api_event->set_data(track_int.data);
+  api_event->set_color_rgba(track_int.color_rgba);
+}
+
+inline void CreateCaptureEvent(const ApiTrackInt64& track_int64,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_int64();
+  SetMetaData(track_int64.meta_data, api_event);
+  SetEncodedName(track_int64.encoded_name, api_event);
+  api_event->set_data(track_int64.data);
+  api_event->set_color_rgba(track_int64.color_rgba);
+}
+
+inline void CreateCaptureEvent(const ApiTrackUint& track_uint,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_uint();
+  SetMetaData(track_uint.meta_data, api_event);
+  SetEncodedName(track_uint.encoded_name, api_event);
+  api_event->set_data(track_uint.data);
+  api_event->set_color_rgba(track_uint.color_rgba);
+}
+inline void CreateCaptureEvent(const ApiTrackUint64& track_uint64,
+                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_uint64();
+  SetMetaData(track_uint64.meta_data, api_event);
+  SetEncodedName(track_uint64.encoded_name, api_event);
+  api_event->set_data(track_uint64.data);
+  api_event->set_color_rgba(track_uint64.color_rgba);
+}
+
+// The variant type `ApiEventVariant` requires to contain `std::monostate` in order to be default-
+// constructable. However, that state is never expected to be called in the visitor.
+inline void CreateCaptureEvent(const std::monostate& /*unused*/,
+                               orbit_grpc_protos::ProducerCaptureEvent* /*unused*/) {
+  // UNREACHABLE();
+}
+
 }  // namespace
 
 orbit_grpc_protos::ProducerCaptureEvent* LockFreeApiEventProducer::TranslateIntermediateEvent(
@@ -40,81 +137,7 @@ orbit_grpc_protos::ProducerCaptureEvent* LockFreeApiEventProducer::TranslateInte
   auto* capture_event =
       google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
 
-  std::visit(overloaded{[](const std::monostate& /*unused*/) {},
-                        [capture_event](const ApiScopeStart& scope_start) {
-                          auto* api_event = capture_event->mutable_api_scope_start();
-                          SetMetaData(scope_start.meta_data, api_event);
-                          SetEncodedName(scope_start.encoded_name, api_event);
-                          api_event->set_color_rgba(scope_start.color_rgba);
-                          api_event->set_group_id(scope_start.group_id);
-                          api_event->set_address_in_function(scope_start.address_in_function);
-                        },
-                        [capture_event](const ApiScopeStop& scope_stop) {
-                          auto* api_event = capture_event->mutable_api_scope_stop();
-                          SetMetaData(scope_stop.meta_data, api_event);
-                        },
-                        [capture_event](const ApiScopeStartAsync& scope_start_async) {
-                          auto* api_event = capture_event->mutable_api_scope_start_async();
-                          SetMetaData(scope_start_async.meta_data, api_event);
-                          SetEncodedName(scope_start_async.encoded_name, api_event);
-                          api_event->set_color_rgba(scope_start_async.color_rgba);
-                          api_event->set_id(scope_start_async.id);
-                          api_event->set_address_in_function(scope_start_async.address_in_function);
-                        },
-                        [capture_event](const ApiScopeStopAsync& scope_stop_async) {
-                          auto* api_event = capture_event->mutable_api_scope_stop_async();
-                          SetMetaData(scope_stop_async.meta_data, api_event);
-                          api_event->set_id(scope_stop_async.id);
-                        },
-                        [capture_event](const ApiStringEvent& string_event) {
-                          auto* api_event = capture_event->mutable_api_string_event();
-                          SetMetaData(string_event.meta_data, api_event);
-                          SetEncodedName(string_event.encoded_name, api_event);
-                          api_event->set_id(string_event.id);
-                          api_event->set_color_rgba(string_event.color_rgba);
-                        },
-                        [capture_event](const ApiTrackDouble& track_double) {
-                          auto* api_event = capture_event->mutable_api_track_double();
-                          SetMetaData(track_double.meta_data, api_event);
-                          SetEncodedName(track_double.encoded_name, api_event);
-                          api_event->set_data(track_double.data);
-                          api_event->set_color_rgba(track_double.color_rgba);
-                        },
-                        [capture_event](const ApiTrackFloat& track_float) {
-                          auto* api_event = capture_event->mutable_api_track_float();
-                          SetMetaData(track_float.meta_data, api_event);
-                          SetEncodedName(track_float.encoded_name, api_event);
-                          api_event->set_data(track_float.data);
-                          api_event->set_color_rgba(track_float.color_rgba);
-                        },
-                        [capture_event](const ApiTrackInt& track_int) {
-                          auto* api_event = capture_event->mutable_api_track_int();
-                          SetMetaData(track_int.meta_data, api_event);
-                          SetEncodedName(track_int.encoded_name, api_event);
-                          api_event->set_data(track_int.data);
-                          api_event->set_color_rgba(track_int.color_rgba);
-                        },
-                        [capture_event](const ApiTrackInt64& track_int64) {
-                          auto* api_event = capture_event->mutable_api_track_int64();
-                          SetMetaData(track_int64.meta_data, api_event);
-                          SetEncodedName(track_int64.encoded_name, api_event);
-                          api_event->set_data(track_int64.data);
-                          api_event->set_color_rgba(track_int64.color_rgba);
-                        },
-                        [capture_event](const ApiTrackUint& track_uint) {
-                          auto* api_event = capture_event->mutable_api_track_uint();
-                          SetMetaData(track_uint.meta_data, api_event);
-                          SetEncodedName(track_uint.encoded_name, api_event);
-                          api_event->set_data(track_uint.data);
-                          api_event->set_color_rgba(track_uint.color_rgba);
-                        },
-                        [capture_event](const ApiTrackUint64& track_uint64) {
-                          auto* api_event = capture_event->mutable_api_track_uint64();
-                          SetMetaData(track_uint64.meta_data, api_event);
-                          SetEncodedName(track_uint64.encoded_name, api_event);
-                          api_event->set_data(track_uint64.data);
-                          api_event->set_color_rgba(track_uint64.color_rgba);
-                        }},
+  std::visit([capture_event](const auto& event) { CreateCaptureEvent(event, capture_event); },
              raw_api_event);
 
   return capture_event;

--- a/src/Api/LockFreeApiEventProducer.cpp
+++ b/src/Api/LockFreeApiEventProducer.cpp
@@ -7,15 +7,15 @@
 namespace orbit_api {
 namespace {
 
-template <typename CaptureEvent>
-inline void SetMetaData(const ApiEventMetaData& meta_data, CaptureEvent* out) {
+template <typename CaptureEventT>
+inline void SetMetaData(const ApiEventMetaData& meta_data, CaptureEventT* out) {
   out->set_pid(meta_data.pid);
   out->set_tid(meta_data.tid);
   out->set_timestamp_ns(meta_data.timestamp_ns);
 }
 
-template <typename CaptureEvent>
-inline void SetEncodedName(const ApiEncodedString& encoded_name, CaptureEvent* out) {
+template <typename CaptureEventT>
+inline void SetEncodedName(const ApiEncodedString& encoded_name, CaptureEventT* out) {
   out->set_encoded_name_1(encoded_name.encoded_name_1);
   out->set_encoded_name_2(encoded_name.encoded_name_2);
   out->set_encoded_name_3(encoded_name.encoded_name_3);
@@ -127,7 +127,7 @@ inline void CreateCaptureEvent(const ApiTrackUint64& track_uint64,
 // constructable. However, that state is never expected to be called in the visitor.
 inline void CreateCaptureEvent(const std::monostate& /*unused*/,
                                orbit_grpc_protos::ProducerCaptureEvent* /*unused*/) {
-  // UNREACHABLE();
+  UNREACHABLE();
 }
 
 }  // namespace

--- a/src/Api/LockFreeApiEventProducer.h
+++ b/src/Api/LockFreeApiEventProducer.h
@@ -7,8 +7,8 @@
 
 #include <variant>
 
+#include "Api/Event.h"
 #include "CaptureEventProducer/LockFreeBufferCaptureEventProducer.h"
-#include "Event.h"
 #include "ProducerSideChannel/ProducerSideChannel.h"
 
 namespace orbit_api {

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -14,7 +14,10 @@
 #include "OrbitBase/ThreadUtils.h"
 
 namespace {
-std::unique_ptr<orbit_api::LockFreeApiEventProducer> producer;
+orbit_api::LockFreeApiEventProducer& GetEventProducer() {
+  static orbit_api::LockFreeApiEventProducer producer;
+  return producer;
+}
 
 template <typename Event, typename... Types>
 void EnqueueApiEvent(Types... args) {

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -7,9 +7,8 @@
 
 #include <absl/base/casts.h>
 
-#include "Api/EncodedEvent.h"
 #include "Api/Event.h"
-#include "Api/LockFreeApiEventProducer.h"
+#include "LockFreeApiEventProducer.h"
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -8,74 +8,67 @@
 #include <absl/base/casts.h>
 
 #include "Api/EncodedEvent.h"
+#include "Api/Event.h"
 #include "Api/LockFreeApiEventProducer.h"
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 
-static void EnqueueApiEvent(orbit_api::EventType type, const char* name = nullptr,
-                            uint64_t data = 0, orbit_api_color color = kOrbitColorAuto) {
-  static orbit_api::LockFreeApiEventProducer producer;
+namespace {
+orbit_api::LockFreeApiEventProducer producer;
+
+template <typename Event, typename... Types>
+void EnqueueApiEvent(Types... args) {
   if (!producer.IsCapturing()) return;
 
   static pid_t pid = orbit_base::GetCurrentProcessId();
-  thread_local uint32_t tid = orbit_base::GetCurrentThreadId();
+  thread_local pid_t tid = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
-
-  orbit_api::ApiEvent api_event(pid, tid, timestamp_ns, type, name, data, color);
-  producer.EnqueueIntermediateEvent(api_event);
+  Event event{pid, tid, timestamp_ns, args...};
+  producer.EnqueueIntermediateEvent(event);
 }
+}  // namespace
 
 extern "C" {
 
 void orbit_api_start(const char* name, orbit_api_color color) {
-  EnqueueApiEvent(orbit_api::EventType::kScopeStart, name, /*data=*/0, color);
+  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color);
 }
 
-void orbit_api_stop() { EnqueueApiEvent(orbit_api::EventType::kScopeStop); }
+void orbit_api_stop() { EnqueueApiEvent<orbit_api::ApiScopeStop>(); }
 
 void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
-  EnqueueApiEvent(orbit_api::EventType::kScopeStartAsync, name, id, color);
+  EnqueueApiEvent<orbit_api::ApiScopeStartAsync>(name, id, color);
 }
 
-void orbit_api_stop_async(uint64_t id) {
-  EnqueueApiEvent(orbit_api::EventType::kScopeStopAsync, /*name=*/nullptr, id);
-}
+void orbit_api_stop_async(uint64_t id) { EnqueueApiEvent<orbit_api::ApiScopeStopAsync>(id); }
 
 void orbit_api_track_int(const char* name, int value, orbit_api_color color) {
-  EnqueueApiEvent(orbit_api::kTrackInt, name, orbit_api::Encode<uint64_t>(value), color);
+  EnqueueApiEvent<orbit_api::ApiTrackInt>(name, value, color);
 }
 
 void orbit_api_track_int64(const char* name, int64_t value, orbit_api_color color) {
-  EnqueueApiEvent(orbit_api::kTrackInt64, name, orbit_api::Encode<uint64_t>(value), color);
+  EnqueueApiEvent<orbit_api::ApiTrackInt64>(name, value, color);
 }
 
 void orbit_api_track_uint(const char* name, uint32_t value, orbit_api_color color) {
-  EnqueueApiEvent(orbit_api::kTrackUint, name, orbit_api::Encode<uint64_t>(value), color);
+  EnqueueApiEvent<orbit_api::ApiTrackUint>(name, value, color);
 }
 
 void orbit_api_track_uint64(const char* name, uint64_t value, orbit_api_color color) {
-  EnqueueApiEvent(orbit_api::kTrackUint64, name, orbit_api::Encode<uint64_t>(value), color);
+  EnqueueApiEvent<orbit_api::ApiTrackUint64>(name, value, color);
 }
 
 void orbit_api_track_float(const char* name, float value, orbit_api_color color) {
-  EnqueueApiEvent(orbit_api::kTrackFloat, name, orbit_api::Encode<uint64_t>(value), color);
+  EnqueueApiEvent<orbit_api::ApiTrackFloat>(name, value, color);
 }
 
 void orbit_api_track_double(const char* name, double value, orbit_api_color color) {
-  EnqueueApiEvent(orbit_api::kTrackDouble, name, orbit_api::Encode<uint64_t>(value), color);
+  EnqueueApiEvent<orbit_api::ApiTrackDouble>(name, value, color);
 }
 
 void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color) {
   if (str == nullptr) return;
-  char buffer[orbit_api::kMaxEventStringSize] = {};
-  constexpr size_t chunk_size = orbit_api::kMaxEventStringSize - 1;
-  const char* end = str + strlen(str);
-  while (str < end) {
-    std::strncpy(buffer, str, chunk_size);
-    buffer[chunk_size] = 0;
-    EnqueueApiEvent(orbit_api::EventType::kString, buffer, id, color);
-    str += chunk_size;
-  }
+  EnqueueApiEvent<orbit_api::ApiStringEvent>(str, id, color);
 }
 
 static void orbit_api_initialize_v0(orbit_api_v0* api) {

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -14,17 +14,20 @@
 #include "OrbitBase/ThreadUtils.h"
 
 namespace {
-orbit_api::LockFreeApiEventProducer producer;
+std::unique_ptr<orbit_api::LockFreeApiEventProducer> producer;
 
 template <typename Event, typename... Types>
 void EnqueueApiEvent(Types... args) {
-  if (!producer.IsCapturing()) return;
+  if (producer == nullptr) {
+    producer = std::make_unique<orbit_api::LockFreeApiEventProducer>();
+  }
+  if (!producer->IsCapturing()) return;
 
   static pid_t pid = orbit_base::GetCurrentProcessId();
   thread_local pid_t tid = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   Event event{pid, tid, timestamp_ns, args...};
-  producer.EnqueueIntermediateEvent(event);
+  producer->EnqueueIntermediateEvent(event);
 }
 }  // namespace
 

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -21,16 +21,15 @@ orbit_api::LockFreeApiEventProducer& GetEventProducer() {
 
 template <typename Event, typename... Types>
 void EnqueueApiEvent(Types... args) {
-  if (producer == nullptr) {
-    producer = std::make_unique<orbit_api::LockFreeApiEventProducer>();
-  }
-  if (!producer->IsCapturing()) return;
+  orbit_api::LockFreeApiEventProducer& producer = GetEventProducer();
+
+  if (!producer.IsCapturing()) return;
 
   static pid_t pid = orbit_base::GetCurrentProcessId();
   thread_local pid_t tid = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   Event event{pid, tid, timestamp_ns, args...};
-  producer->EnqueueIntermediateEvent(event);
+  producer.EnqueueIntermediateEvent(event);
 }
 }  // namespace
 

--- a/src/Api/include/Api/Event.h
+++ b/src/Api/include/Api/Event.h
@@ -197,6 +197,8 @@ struct ApiTrackFloat {
   uint32_t color_rgba{};
 };
 
+// Used in `LockFreeApiEventProducer`. The `std::monostate` is required make this variant default
+// constructable. However, real (fully instantiated) values will never be of type `std::monostate`.
 using ApiEventVariant =
     std::variant<std::monostate, ApiScopeStart, ApiScopeStop, ApiScopeStartAsync, ApiScopeStopAsync,
                  ApiStringEvent, ApiTrackDouble, ApiTrackFloat, ApiTrackInt, ApiTrackInt64,

--- a/src/Api/include/Api/Event.h
+++ b/src/Api/include/Api/Event.h
@@ -1,0 +1,207 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_API_EVENT_H_
+#define ORBIT_API_EVENT_H_
+
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+#include "EncodedString.h"
+#include "Orbit.h"
+#include "OrbitBase/Logging.h"
+#include "absl/base/casts.h"
+
+// We don't want to store protos in the LockFreeApiEventProducer's buffer, as they introduce
+// expensive and unnessesary indirections and allocations. Therefore, we use the a std::variant of
+// the following structs. The structs must be kept up-to-date with the protos in capture.proto.
+namespace orbit_api {
+
+struct ApiEventMetaData {
+  ApiEventMetaData(int32_t pid, int32_t tid, uint64_t timestamp_ns)
+      : pid(pid), tid(tid), timestamp_ns(timestamp_ns) {}
+  int32_t pid{};
+  int32_t tid{};
+  uint64_t timestamp_ns{};
+};
+
+struct ApiEncodedString {
+  ApiEncodedString(const char* name) { EncodeString(name, this); }
+  void set_encoded_name_1(uint64_t value) { encoded_name_1 = value; }
+  void set_encoded_name_2(uint64_t value) { encoded_name_2 = value; }
+  void set_encoded_name_3(uint64_t value) { encoded_name_3 = value; }
+  void set_encoded_name_4(uint64_t value) { encoded_name_4 = value; }
+  void set_encoded_name_5(uint64_t value) { encoded_name_5 = value; }
+  void set_encoded_name_6(uint64_t value) { encoded_name_6 = value; }
+  void set_encoded_name_7(uint64_t value) { encoded_name_7 = value; }
+  void set_encoded_name_8(uint64_t value) { encoded_name_8 = value; }
+  void add_encoded_name_additional(uint64_t value) { encoded_name_additional.push_back(value); }
+  uint64_t encoded_name_1{};
+  uint64_t encoded_name_2{};
+  uint64_t encoded_name_3{};
+  uint64_t encoded_name_4{};
+  uint64_t encoded_name_5{};
+  uint64_t encoded_name_6{};
+  uint64_t encoded_name_7{};
+  uint64_t encoded_name_8{};
+  std::vector<uint64_t> encoded_name_additional{};
+};
+
+struct ApiScopeStart {
+  ApiScopeStart(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name,
+                orbit_api_color color_rgba = kOrbitColorAuto, uint64_t group_id = 0,
+                uint64_t address_in_function = 0)
+      : meta_data(pid, tid, timestamp_ns),
+        group_id(group_id),
+        address_in_function(address_in_function),
+        encoded_name(name),
+        color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+  uint64_t group_id{};
+  uint64_t address_in_function{};
+
+  ApiEncodedString encoded_name;
+
+  uint32_t color_rgba{};
+};
+
+struct ApiScopeStop {
+  ApiScopeStop(int32_t pid, int32_t tid, uint64_t timestamp_ns)
+      : meta_data(pid, tid, timestamp_ns) {}
+
+  ApiEventMetaData meta_data;
+};
+
+struct ApiScopeStartAsync {
+  ApiScopeStartAsync(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint64_t id,
+                     orbit_api_color color_rgba = kOrbitColorAuto, uint64_t address_in_function = 0)
+      : meta_data(pid, tid, timestamp_ns),
+        id(id),
+        address_in_function(address_in_function),
+        encoded_name(name),
+        color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+  uint64_t id{};
+  uint64_t address_in_function{};
+
+  ApiEncodedString encoded_name;
+
+  uint32_t color_rgba{};
+};
+
+struct ApiScopeStopAsync {
+  ApiScopeStopAsync(int32_t pid, int32_t tid, uint64_t timestamp_ns, uint64_t id)
+      : meta_data(pid, tid, timestamp_ns), id(id) {}
+
+  ApiEventMetaData meta_data;
+  uint64_t id{};
+};
+
+struct ApiStringEvent {
+  ApiStringEvent(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint64_t id,
+                 orbit_api_color color_rgba = kOrbitColorAuto)
+      : meta_data(pid, tid, timestamp_ns), id(id), encoded_name(name), color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+  uint64_t id{};
+
+  ApiEncodedString encoded_name;
+  uint32_t color_rgba{};
+};
+
+struct ApiTrackInt {
+  ApiTrackInt(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, int32_t data,
+              orbit_api_color color_rgba = kOrbitColorAuto)
+      : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+
+  ApiEncodedString encoded_name;
+
+  int32_t data{};
+
+  uint32_t color_rgba{};
+};
+
+struct ApiTrackInt64 {
+  ApiTrackInt64(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, int64_t data,
+                orbit_api_color color_rgba = kOrbitColorAuto)
+      : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+
+  ApiEncodedString encoded_name;
+
+  int64_t data{};
+
+  uint32_t color_rgba{};
+};
+
+struct ApiTrackUint {
+  ApiTrackUint(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint32_t data,
+               orbit_api_color color_rgba = kOrbitColorAuto)
+      : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+
+  ApiEncodedString encoded_name;
+
+  uint32_t data{};
+
+  uint32_t color_rgba{};
+};
+
+struct ApiTrackUint64 {
+  ApiTrackUint64(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint64_t data,
+                 orbit_api_color color_rgba = kOrbitColorAuto)
+      : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+
+  ApiEncodedString encoded_name;
+
+  uint64_t data{};
+
+  uint32_t color_rgba{};
+};
+
+struct ApiTrackDouble {
+  ApiTrackDouble(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, double data,
+                 orbit_api_color color_rgba = kOrbitColorAuto)
+      : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+
+  ApiEncodedString encoded_name;
+
+  double data{};
+
+  uint32_t color_rgba{};
+};
+
+struct ApiTrackFloat {
+  ApiTrackFloat(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, float data,
+                orbit_api_color color_rgba = kOrbitColorAuto)
+      : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
+
+  ApiEventMetaData meta_data;
+
+  ApiEncodedString encoded_name;
+
+  float data{};
+
+  uint32_t color_rgba{};
+};
+
+using ApiEventVariant =
+    std::variant<std::monostate, ApiScopeStart, ApiScopeStop, ApiScopeStartAsync, ApiScopeStopAsync,
+                 ApiStringEvent, ApiTrackDouble, ApiTrackFloat, ApiTrackInt, ApiTrackInt64,
+                 ApiTrackUint, ApiTrackUint64>;
+
+}  // namespace orbit_api
+
+#endif  // ORBIT_API_EVENT_H_

--- a/src/Api/include/Api/Event.h
+++ b/src/Api/include/Api/Event.h
@@ -54,15 +54,15 @@ struct ApiScopeStart {
                 orbit_api_color color_rgba = kOrbitColorAuto, uint64_t group_id = 0,
                 uint64_t address_in_function = 0)
       : meta_data(pid, tid, timestamp_ns),
+        encoded_name(name),
         group_id(group_id),
         address_in_function(address_in_function),
-        encoded_name(name),
         color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
+  ApiEncodedString encoded_name;
   uint64_t group_id = 0;
   uint64_t address_in_function = 0;
-  ApiEncodedString encoded_name;
   uint32_t color_rgba = 0;
 };
 
@@ -77,15 +77,15 @@ struct ApiScopeStartAsync {
   ApiScopeStartAsync(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint64_t id,
                      orbit_api_color color_rgba = kOrbitColorAuto, uint64_t address_in_function = 0)
       : meta_data(pid, tid, timestamp_ns),
+        encoded_name(name),
         id(id),
         address_in_function(address_in_function),
-        encoded_name(name),
         color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
+  ApiEncodedString encoded_name;
   uint64_t id = 0;
   uint64_t address_in_function = 0;
-  ApiEncodedString encoded_name;
   uint32_t color_rgba = 0;
 };
 
@@ -100,11 +100,11 @@ struct ApiScopeStopAsync {
 struct ApiStringEvent {
   ApiStringEvent(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint64_t id,
                  orbit_api_color color_rgba = kOrbitColorAuto)
-      : meta_data(pid, tid, timestamp_ns), id(id), encoded_name(name), color_rgba(color_rgba) {}
+      : meta_data(pid, tid, timestamp_ns), encoded_name(name), id(id), color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-  uint64_t id = 0;
   ApiEncodedString encoded_name;
+  uint64_t id = 0;
   uint32_t color_rgba = 0;
 };
 

--- a/src/Api/include/Api/Event.h
+++ b/src/Api/include/Api/Event.h
@@ -22,9 +22,9 @@ namespace orbit_api {
 struct ApiEventMetaData {
   ApiEventMetaData(int32_t pid, int32_t tid, uint64_t timestamp_ns)
       : pid(pid), tid(tid), timestamp_ns(timestamp_ns) {}
-  int32_t pid{};
-  int32_t tid{};
-  uint64_t timestamp_ns{};
+  int32_t pid = 0;
+  int32_t tid = 0;
+  uint64_t timestamp_ns = 0;
 };
 
 struct ApiEncodedString {
@@ -38,14 +38,14 @@ struct ApiEncodedString {
   void set_encoded_name_7(uint64_t value) { encoded_name_7 = value; }
   void set_encoded_name_8(uint64_t value) { encoded_name_8 = value; }
   void add_encoded_name_additional(uint64_t value) { encoded_name_additional.push_back(value); }
-  uint64_t encoded_name_1{};
-  uint64_t encoded_name_2{};
-  uint64_t encoded_name_3{};
-  uint64_t encoded_name_4{};
-  uint64_t encoded_name_5{};
-  uint64_t encoded_name_6{};
-  uint64_t encoded_name_7{};
-  uint64_t encoded_name_8{};
+  uint64_t encoded_name_1 = 0;
+  uint64_t encoded_name_2 = 0;
+  uint64_t encoded_name_3 = 0;
+  uint64_t encoded_name_4 = 0;
+  uint64_t encoded_name_5 = 0;
+  uint64_t encoded_name_6 = 0;
+  uint64_t encoded_name_7 = 0;
+  uint64_t encoded_name_8 = 0;
   std::vector<uint64_t> encoded_name_additional{};
 };
 
@@ -60,12 +60,10 @@ struct ApiScopeStart {
         color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-  uint64_t group_id{};
-  uint64_t address_in_function{};
-
+  uint64_t group_id = 0;
+  uint64_t address_in_function = 0;
   ApiEncodedString encoded_name;
-
-  uint32_t color_rgba{};
+  uint32_t color_rgba = 0;
 };
 
 struct ApiScopeStop {
@@ -85,12 +83,10 @@ struct ApiScopeStartAsync {
         color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-  uint64_t id{};
-  uint64_t address_in_function{};
-
+  uint64_t id = 0;
+  uint64_t address_in_function = 0;
   ApiEncodedString encoded_name;
-
-  uint32_t color_rgba{};
+  uint32_t color_rgba = 0;
 };
 
 struct ApiScopeStopAsync {
@@ -98,7 +94,7 @@ struct ApiScopeStopAsync {
       : meta_data(pid, tid, timestamp_ns), id(id) {}
 
   ApiEventMetaData meta_data;
-  uint64_t id{};
+  uint64_t id = 0;
 };
 
 struct ApiStringEvent {
@@ -107,10 +103,9 @@ struct ApiStringEvent {
       : meta_data(pid, tid, timestamp_ns), id(id), encoded_name(name), color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-  uint64_t id{};
-
+  uint64_t id = 0;
   ApiEncodedString encoded_name;
-  uint32_t color_rgba{};
+  uint32_t color_rgba = 0;
 };
 
 struct ApiTrackInt {
@@ -119,12 +114,9 @@ struct ApiTrackInt {
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-
   ApiEncodedString encoded_name;
-
-  int32_t data{};
-
-  uint32_t color_rgba{};
+  int32_t data = 0;
+  uint32_t color_rgba = 0;
 };
 
 struct ApiTrackInt64 {
@@ -133,12 +125,9 @@ struct ApiTrackInt64 {
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-
   ApiEncodedString encoded_name;
-
-  int64_t data{};
-
-  uint32_t color_rgba{};
+  int64_t data = 0;
+  uint32_t color_rgba = 0;
 };
 
 struct ApiTrackUint {
@@ -147,12 +136,9 @@ struct ApiTrackUint {
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-
   ApiEncodedString encoded_name;
-
-  uint32_t data{};
-
-  uint32_t color_rgba{};
+  uint32_t data = 0;
+  uint32_t color_rgba = 0;
 };
 
 struct ApiTrackUint64 {
@@ -161,12 +147,9 @@ struct ApiTrackUint64 {
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-
   ApiEncodedString encoded_name;
-
-  uint64_t data{};
-
-  uint32_t color_rgba{};
+  uint64_t data = 0;
+  uint32_t color_rgba = 0;
 };
 
 struct ApiTrackDouble {
@@ -175,12 +158,9 @@ struct ApiTrackDouble {
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-
   ApiEncodedString encoded_name;
-
-  double data{};
-
-  uint32_t color_rgba{};
+  double data = 0.;
+  uint32_t color_rgba = 0;
 };
 
 struct ApiTrackFloat {
@@ -189,12 +169,9 @@ struct ApiTrackFloat {
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
   ApiEventMetaData meta_data;
-
   ApiEncodedString encoded_name;
-
-  float data{};
-
-  uint32_t color_rgba{};
+  float data = 0.f;
+  uint32_t color_rgba = 0;
 };
 
 // Used in `LockFreeApiEventProducer`. The `std::monostate` is required make this variant default

--- a/src/Api/include/Api/LockFreeApiEventProducer.h
+++ b/src/Api/include/Api/LockFreeApiEventProducer.h
@@ -25,7 +25,7 @@ class LockFreeApiEventProducer
   ~LockFreeApiEventProducer() { ShutdownAndWait(); }
 
  protected:
-  [[nodiscard]] virtual orbit_grpc_protos::ProducerCaptureEvent* TranslateIntermediateEvent(
+  [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent* TranslateIntermediateEvent(
       ApiEventVariant&& raw_api_event, google::protobuf::Arena* arena) override;
 };
 

--- a/src/Api/include/Api/LockFreeApiEventProducer.h
+++ b/src/Api/include/Api/LockFreeApiEventProducer.h
@@ -7,8 +7,8 @@
 
 #include <variant>
 
-#include "Api/Event.h"
 #include "CaptureEventProducer/LockFreeBufferCaptureEventProducer.h"
+#include "Event.h"
 #include "ProducerSideChannel/ProducerSideChannel.h"
 
 namespace orbit_api {

--- a/src/Api/include/Api/LockFreeApiEventProducer.h
+++ b/src/Api/include/Api/LockFreeApiEventProducer.h
@@ -5,7 +5,9 @@
 #ifndef API_LOCK_FREE_API_EVENT_PRODUCER_H_
 #define API_LOCK_FREE_API_EVENT_PRODUCER_H_
 
-#include "Api/EncodedEvent.h"
+#include <variant>
+
+#include "Api/Event.h"
 #include "CaptureEventProducer/LockFreeBufferCaptureEventProducer.h"
 #include "ProducerSideChannel/ProducerSideChannel.h"
 
@@ -14,7 +16,7 @@ namespace orbit_api {
 // This class is used to enqueue orbit_api::ApiEvent events from multiple threads and relay them to
 // OrbitService in the form of orbit_grpc_protos::ApiEvent events.
 class LockFreeApiEventProducer
-    : public orbit_capture_event_producer::LockFreeBufferCaptureEventProducer<orbit_api::ApiEvent> {
+    : public orbit_capture_event_producer::LockFreeBufferCaptureEventProducer<ApiEventVariant> {
  public:
   LockFreeApiEventProducer() {
     BuildAndStart(orbit_producer_side_channel::CreateProducerSideChannel());
@@ -24,21 +26,7 @@ class LockFreeApiEventProducer
 
  protected:
   [[nodiscard]] virtual orbit_grpc_protos::ProducerCaptureEvent* TranslateIntermediateEvent(
-      orbit_api::ApiEvent&& raw_api_event, google::protobuf::Arena* arena) override {
-    auto* capture_event =
-        google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
-    auto* api_event = capture_event->mutable_api_event();
-    api_event->set_timestamp_ns(raw_api_event.timestamp_ns);
-    api_event->set_pid(raw_api_event.pid);
-    api_event->set_tid(raw_api_event.tid);
-    api_event->set_r0(raw_api_event.encoded_event.args[0]);
-    api_event->set_r1(raw_api_event.encoded_event.args[1]);
-    api_event->set_r2(raw_api_event.encoded_event.args[2]);
-    api_event->set_r3(raw_api_event.encoded_event.args[3]);
-    api_event->set_r4(raw_api_event.encoded_event.args[4]);
-    api_event->set_r5(raw_api_event.encoded_event.args[5]);
-    return capture_event;
-  }
+      ApiEventVariant&& raw_api_event, google::protobuf::Arena* arena) override;
 };
 
 }  // namespace orbit_api

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -201,7 +201,7 @@ message ApiScopeStopAsync {
 }
 
 message ApiStringEvent {
-  // NextID: 14
+  // NextID: 15
 
   int32 pid = 1;
   int32 tid = 2;
@@ -219,10 +219,12 @@ message ApiStringEvent {
   repeated fixed64 encoded_name_additional = 12;
 
   uint64 id = 13;
+
+  uint32 color_rgba = 14;
 }
 
 message ApiTrackInt {
-  // NextID: 14
+  // NextID: 15
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
@@ -239,10 +241,12 @@ message ApiTrackInt {
   fixed64 encoded_name_7 = 11;
   fixed64 encoded_name_8 = 12;
   repeated fixed64 encoded_name_additional = 13;
+
+  uint32 color_rgba = 14;
 }
 
 message ApiTrackInt64 {
-  // NextID: 14
+  // NextID: 15
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
@@ -259,10 +263,12 @@ message ApiTrackInt64 {
   fixed64 encoded_name_7 = 11;
   fixed64 encoded_name_8 = 12;
   repeated fixed64 encoded_name_additional = 13;
+
+  uint32 color_rgba = 14;
 }
 
 message ApiTrackUint {
-  // NextID: 14
+  // NextID: 15
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
@@ -279,10 +285,12 @@ message ApiTrackUint {
   fixed64 encoded_name_7 = 11;
   fixed64 encoded_name_8 = 12;
   repeated fixed64 encoded_name_additional = 13;
+
+  uint32 color_rgba = 14;
 }
 
 message ApiTrackUint64 {
-  // NextID: 14
+  // NextID: 15
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
@@ -299,10 +307,12 @@ message ApiTrackUint64 {
   fixed64 encoded_name_7 = 11;
   fixed64 encoded_name_8 = 12;
   repeated fixed64 encoded_name_additional = 13;
+
+  uint32 color_rgba = 14;
 }
 
 message ApiTrackFloat {
-  // NextID: 14
+  // NextID: 15
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
@@ -319,10 +329,12 @@ message ApiTrackFloat {
   fixed64 encoded_name_7 = 11;
   fixed64 encoded_name_8 = 12;
   repeated fixed64 encoded_name_additional = 13;
+
+  uint32 color_rgba = 14;
 }
 
 message ApiTrackDouble {
-  // NextID: 14
+  // NextID: 15
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
@@ -339,6 +351,8 @@ message ApiTrackDouble {
   fixed64 encoded_name_7 = 11;
   fixed64 encoded_name_8 = 12;
   repeated fixed64 encoded_name_additional = 13;
+
+  uint32 color_rgba = 14;
 }
 
 message Callstack {


### PR DESCRIPTION
This changes the existing implementation of manual instrumentation
to send the new protos. Note, that this does not yet require the
version to be bumped up, as it does not change the header.

Some words about performance:
We measured the overhead of manual instrumentation induced to the
target per scope (start+stop). Before this change we induced about
235ns and after this change we are about 290ns.

The average message size send to the client dropped from 31 bytes
to 20 bytes.

Also the CPU utilization of the PSSI::RcvEvents thread (in game)
decreased by 10 percent points, while the SenderThread increased
by 5 percent points. The ForwarderThread remains at the same level.

Test: Run OrbitTest
Bug: http://b/194763537; http://b/194764373; http://b/194764259;