### PR TITLE
Add GetUp/Down functions for ThreadTrack

### DIFF
--- a/src/OrbitGl/ScopeTreeTest.cpp
+++ b/src/OrbitGl/ScopeTreeTest.cpp
@@ -181,7 +181,7 @@ TEST(ScopeTree, OutOfOrderScopes) {
   }
 }
 
-TEST(ScopeTree, FindNodesAtDepth) {
+TEST(ScopeTree, FindRelationships) {
   /* Create a tree to test edge cases:
       root
       /   \
@@ -216,6 +216,15 @@ TEST(ScopeTree, FindNodesAtDepth) {
       expect_prev = current;
     }
   }
+
+  // Test Up/Down Relationships.
+  EXPECT_EQ(tree.FindParent(*depth1.at(0)), nullptr);
+  EXPECT_EQ(tree.FindParent(*depth2.at(0)), depth1.at(0));
+  EXPECT_EQ(tree.FindParent(*depth2.at(1)), depth1.at(0));
+  EXPECT_EQ(tree.FindParent(*depth2.at(3)), depth1.at(1));
+  EXPECT_EQ(tree.FindFirstChild(*depth1.at(0)), depth2.at(0));
+  EXPECT_EQ(tree.FindFirstChild(*depth1.at(1)), depth2.at(3));
+  EXPECT_EQ(tree.FindFirstChild(*depth2.at(0)), nullptr);
 }
 
 }  // namespace

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -103,6 +103,14 @@ const TimerInfo* ThreadTrack::GetRight(const TimerInfo& timer_info) const {
   return scope_tree_.FindNextScopeAtDepth(timer_info);
 }
 
+const TimerInfo* ThreadTrack::GetUp(const TimerInfo& timer_info) const {
+  return scope_tree_.FindParent(timer_info);
+}
+
+const TimerInfo* ThreadTrack::GetDown(const TimerInfo& timer_info) const {
+  return scope_tree_.FindFirstChild(timer_info);
+}
+
 std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
   const TimerInfo* timer_info = batcher.GetTimerInfo(id);
   if (timer_info == nullptr || timer_info->type() == TimerInfo::kCoreActivity) {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -44,6 +44,10 @@ class ThreadTrack final : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetRight(
       const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] const orbit_client_protos::TimerInfo* GetUp(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const DrawContext& draw_context) override;


### PR DESCRIPTION
Currently, ThreadTrack is using TimerTrack's GetUp/Down functions which
uses TimerChain (and is broken). Override the functions in ThreadTrack
to use ScopeTree.
    
TimerChain GetUp/Down/Left/Right functions will be fixed in a future PR.


Bug: http://b/185461668