### PR TITLE
Package instrumentation library with OrbitService.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -245,6 +245,8 @@ class OrbitConan(ConanFile):
                       dst="{}-{}/opt/developer/tools/".format(self.name, self._version()))
             self.copy("liborbit.so", src="lib/",
                       dst="{}-{}/opt/developer/tools/".format(self.name, self._version()))
+            self.copy("liborbituserspaceinstrumentation.so", src="lib/",
+                      dst="{}-{}/opt/developer/tools/".format(self.name, self._version()))
             self.copy("NOTICE",
                       dst="{}-{}/usr/share/doc/{}/".format(self.name, self._version(), self.name))
             self.copy("LICENSE",
@@ -294,6 +296,7 @@ chmod -v 4775 /opt/developer/tools/OrbitService
         self.copy("NOTICE.Chromium.csv")
         self.copy("LICENSE")
         self.copy("liborbit.so", src="lib/", dst="lib")
+        self.copy("liborbituserspaceinstrumentation.so", src="lib/", dst="lib")
         self.copy("libOrbitVulkanLayer.so", src="lib/", dst="lib")
         self.copy("VkLayer_Orbit_implicit.json", src="lib/", dst="lib")
         self.copy("LinuxTracingIntegrationTests", src="bin/", dst="bin")

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -76,6 +76,8 @@ class ServiceDeployManager : public QObject {
   outcome::result<void> CopyOrbitServiceExecutable(
       const BareExecutableAndRootPasswordDeployment& config);
   outcome::result<void> CopyOrbitApiLibrary(const BareExecutableAndRootPasswordDeployment& config);
+  outcome::result<void> CopyOrbitUserSpaceInstrumentationLibrary(
+      const BareExecutableAndRootPasswordDeployment& config);
   outcome::result<void> InstallOrbitServicePackage();
   outcome::result<void> StartOrbitService();
   outcome::result<void> StartOrbitServicePrivileged(

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -58,6 +58,8 @@ add_library(OrbitUserSpaceInstrumentation SHARED)
 
 target_compile_options(OrbitUserSpaceInstrumentation PRIVATE ${STRICT_COMPILE_FLAGS})
 
+set_target_properties(OrbitUserSpaceInstrumentation PROPERTIES OUTPUT_NAME "orbituserspaceinstrumentation")
+
 target_compile_features(OrbitUserSpaceInstrumentation PUBLIC cxx_std_17)
 
 target_include_directories(OrbitUserSpaceInstrumentation PRIVATE
@@ -71,6 +73,8 @@ target_link_libraries(OrbitUserSpaceInstrumentation PUBLIC
         CaptureEventProducer
         OrbitBase
         ProducerSideChannel)
+
+strip_symbols(OrbitUserSpaceInstrumentation)
 
 # This test lib is merely used in UserSpaceInstrumentationTests below. The
 # binary libUserSpaceInstrumentationTestLib.so created from this target is used

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -32,9 +32,9 @@ using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::ModuleInfo;
 
 ErrorMessageOr<std::filesystem::path> GetLibraryPath() {
-  // When packaged, libOrbitUserSpaceInstrumentation.so is found alongside OrbitService. In
+  // When packaged, liborbituserspaceinstrumentation.so is found alongside OrbitService. In
   // development, it is found in "../lib", relative to OrbitService.
-  constexpr const char* kLibName = "libOrbitUserSpaceInstrumentation.so";
+  constexpr const char* kLibName = "liborbituserspaceinstrumentation.so";
   const std::filesystem::path exe_dir = orbit_base::GetExecutableDir();
   std::vector<std::filesystem::path> potential_paths = {exe_dir / kLibName,
                                                         exe_dir / ".." / "lib" / kLibName};


### PR DESCRIPTION
The .so ends up next to OrbitService on the instance (in /opt/developer/tools/).
It is packaged into the .deb.

For the development workflow we copy the lib over via ServiceDeployManager.

Bug: http://b/195640198
Test: Tested dev workflow on Linux. For the .deb I'll check the nightly later.