### PR TITLE
[REBASE TO MAIN] Fix regression with horizontal zoom

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -249,8 +249,8 @@ void CaptureWindow::Zoom(ZoomDirection dir, int delta) {
   if (time_graph_ != nullptr) {
     switch (dir) {
       case ZoomDirection::kHorizontal: {
-        double mouse_ratio = static_cast<double>(mouse_move_pos_screen_[0]) /
-                             (viewport_.GetScreenWidth() - time_graph_->GetRightMargin());
+        double mouse_ratio =
+            static_cast<double>(mouse_move_pos_screen_[0]) / time_graph_->GetVisibleWidth();
         time_graph_->ZoomTime(delta_float, mouse_ratio);
         break;
       }

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -249,8 +249,8 @@ void CaptureWindow::Zoom(ZoomDirection dir, int delta) {
   if (time_graph_ != nullptr) {
     switch (dir) {
       case ZoomDirection::kHorizontal: {
-        double mouse_ratio =
-            static_cast<double>(mouse_move_pos_screen_[0]) / viewport_.GetScreenWidth();
+        double mouse_ratio = static_cast<double>(mouse_move_pos_screen_[0]) /
+                             (viewport_.GetScreenWidth() - time_graph_->GetRightMargin());
         time_graph_->ZoomTime(delta_float, mouse_ratio);
         break;
       }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -900,7 +900,7 @@ void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode pickin
 
 void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
                            const DrawContext& draw_context) {
-  float track_width = viewport_->GetVisibleWorldWidth() - GetRightMargin();
+  float track_width = GetVisibleWidth();
   float track_pos_x = viewport_->GetWorldTopLeft()[0];
   for (auto& track : track_manager_->GetVisibleTracks()) {
     track->SetSize(track_width, track->GetHeight());

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -131,6 +131,9 @@ double TimeGraph::GetCurrentTimeSpanUs() const { return max_time_us_ - min_time_
 void TimeGraph::ZoomTime(float zoom_value, double mouse_ratio) {
   static double increment_ratio = 0.1;
   double scale = (zoom_value > 0) ? (1 + increment_ratio) : (1 / (1 + increment_ratio));
+  // The horizontal zoom could have been triggered from the margin of TimeGraph, so we clamp the
+  // mouse_ratio to ensure it is between 0 and 1.
+  mouse_ratio = std::clamp(mouse_ratio, 0., 1.);
 
   double current_time_window_us = max_time_us_ - min_time_us_;
   ref_time_us_ = min_time_us_ + mouse_ratio * current_time_window_us;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -133,6 +133,9 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] TimeGraphLayout& GetLayout() { return layout_; }
   [[nodiscard]] float GetRightMargin() const { return right_margin_; }
   void UpdateRightMargin(float margin);
+  [[nodiscard]] float GetVisibleWidth() const {
+    return viewport_->GetScreenWidth() - GetRightMargin();
+  }
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindPrevious(
       const orbit_client_protos::TimerInfo& from);


### PR DESCRIPTION
With the change of not including the Timegraph's right margin in the
time range, but including them to calculate the mouse_ratio we are
having an inconsistency every time we zoom (http://b/195652915).

In this change, we are including it and also clamped the max and min
ratio for the zoom triggered in the margin.

We also create a method GetVisibleWidth in TimeGraph.