### PR TITLE
"Remember" checkbox is unchecked after Disconnect

### DIFF
--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -342,6 +342,7 @@ void ConnectToStadiaWidget::Disconnect() {
   //   service_deploy_manager_->Shutdown();
   // }
   service_deploy_manager_ = nullptr;
+  ui_->rememberCheckBox->setChecked(false);
 
   emit Disconnected();
 }


### PR DESCRIPTION
This restores old behavior. The previous behavior resulted in a bug
where, after ending a session and disconnecting, the connection was
instantly restored.

Bug: b/195735727