### PR TITLE
Fix fuzzing build

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -46,8 +46,16 @@ function(DoGenerateVersionFile OUTPUT_FILE INPUT_FILE GIT_COMMIT_STATE_FILE
   string(REGEX MATCH "([0-9]+)\\." MAJOR_VERSION "${VERSION_STRING}")
   set(MAJOR_VERSION "${CMAKE_MATCH_1}")
 
+  if(NOT MAJOR_VERSION)
+    set(MAJOR_VERSION 0)
+  endif()
+
   string(REGEX MATCH "\\.([0-9]+)" MINOR_VERSION "${VERSION_STRING}")
   set(MINOR_VERSION "${CMAKE_MATCH_1}")
+
+  if(NOT MINOR_VERSION)
+    set(MINOR_VERSION 0)
+  endif()
 
   set(PATCH_VERSION "0")
 

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -383,7 +383,7 @@
     "context": "host"
    },
    "57": {
-    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
+    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#8728b94e133a18e7454c14a28959a148",
     "requires": [
      "1",
      "8",
@@ -406,7 +406,7 @@
     "context": "host"
    },
    "60": {
-    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
+    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#8728b94e133a18e7454c14a28959a148",
     "requires": [
      "1",
      "8",


### PR DESCRIPTION
2 things:

- Require the correct revision of `grpc_codegen`
- Add a fallback version number when the code is not compiled from a Git repository