### PR TITLE
Force local time zone to be UTC in Test

### DIFF
--- a/src/DataViews/DataViewUtilsTest.cpp
+++ b/src/DataViews/DataViewUtilsTest.cpp
@@ -7,9 +7,21 @@
 
 #include "DataViewUtils.h"
 
+#ifdef _WIN32
+#include <windows.h>
+static void SetEnv(const char* name, const char* value) { _putenv_s(name, value); }
+#else
+#include <stdlib.h>
+static void SetEnv(const char* name, const char* value) { setenv(name, value, 1); }
+#endif
+
 namespace orbit_data_views {
 
 TEST(DataViewUtils, FormatShortDatetime) {
+  // `FormatShortDateTime` outputs the time in local time zone.
+  // Setting `TZ` ensure the time zone will always be `UTC`.
+  SetEnv("TZ", "UTC");
+
   absl::Time datetime = absl::FromTimeT(0);
   std::string result = FormatShortDatetime(datetime);
   EXPECT_EQ(result, "01/01/1970 00:00 AM");


### PR DESCRIPTION
This ensures that `FormatShortDatetime` determines the local time zone
always to be UTC in tests. Otherwise the test can fail depending on the
environment variables.