### PR TITLE
Send new manual instrumentation client events for old events.

### DIFF
--- a/src/CaptureClient/ApiEventProcessor.cpp
+++ b/src/CaptureClient/ApiEventProcessor.cpp
@@ -214,8 +214,10 @@ void ApiEventProcessor::ProcessApiScopeStart(
   synchronous_scopes_stack_by_tid_[api_scope_start.tid()].emplace_back(api_scope_start);
 }
 
-void ApiEventProcessor::ProcessApiScopeStop(const orbit_grpc_protos::ApiScopeStop& api_scope_stop) {
-  std::vector<ApiScopeStart>& event_stack = synchronous_scopes_stack_by_tid_[api_scope_stop.tid()];
+void ApiEventProcessor::ProcessApiScopeStop(
+    const orbit_grpc_protos::ApiScopeStop& grpc_api_scope_stop) {
+  std::vector<ApiScopeStart>& event_stack =
+      synchronous_scopes_stack_by_tid_[grpc_api_scope_stop.tid()];
   if (event_stack.empty()) {
     // We received a stop event with no matching start event, which is possible if the capture was
     // started between the event's start and stop times.
@@ -226,9 +228,9 @@ void ApiEventProcessor::ProcessApiScopeStop(const orbit_grpc_protos::ApiScopeSto
   TimerInfo timer_info;
 
   timer_info.set_start(start_event.timestamp_ns());
-  timer_info.set_end(api_scope_stop.timestamp_ns());
-  timer_info.set_process_id(api_scope_stop.pid());
-  timer_info.set_thread_id(api_scope_stop.tid());
+  timer_info.set_end(grpc_api_scope_stop.timestamp_ns());
+  timer_info.set_process_id(grpc_api_scope_stop.pid());
+  timer_info.set_thread_id(grpc_api_scope_stop.tid());
   timer_info.set_depth(event_stack.size() - 1);
   timer_info.set_type(TimerInfo::kApiScope);
 
@@ -246,13 +248,13 @@ void ApiEventProcessor::ProcessApiScopeStop(const orbit_grpc_protos::ApiScopeSto
 }
 
 void ApiEventProcessor::ProcessApiScopeStartAsync(
-    const orbit_grpc_protos::ApiScopeStartAsync& api_scope_start_async) {
-  asynchronous_scopes_by_id_[api_scope_start_async.id()] = api_scope_start_async;
+    const orbit_grpc_protos::ApiScopeStartAsync& grpc_api_scope_start_async) {
+  asynchronous_scopes_by_id_[grpc_api_scope_start_async.id()] = grpc_api_scope_start_async;
 }
 
 void ApiEventProcessor::ProcessApiScopeStopAsync(
-    const orbit_grpc_protos::ApiScopeStopAsync& api_scope_stop_async) {
-  uint64_t event_id = api_scope_stop_async.id();
+    const orbit_grpc_protos::ApiScopeStopAsync& grpc_api_scope_stop_async) {
+  uint64_t event_id = grpc_api_scope_stop_async.id();
   if (!asynchronous_scopes_by_id_.contains(event_id)) {
     // We received a stop event with no matching start event, which is possible if the capture was
     // started between the event's start and stop times.
@@ -263,9 +265,9 @@ void ApiEventProcessor::ProcessApiScopeStopAsync(
   TimerInfo timer_info;
 
   timer_info.set_start(start_event.timestamp_ns());
-  timer_info.set_end(api_scope_stop_async.timestamp_ns());
-  timer_info.set_process_id(api_scope_stop_async.pid());
-  timer_info.set_thread_id(api_scope_stop_async.tid());
+  timer_info.set_end(grpc_api_scope_stop_async.timestamp_ns());
+  timer_info.set_process_id(grpc_api_scope_stop_async.pid());
+  timer_info.set_thread_id(grpc_api_scope_stop_async.tid());
   timer_info.set_depth(0);
   timer_info.set_type(TimerInfo::kApiScopeAsync);
 
@@ -283,88 +285,90 @@ void ApiEventProcessor::ProcessApiScopeStopAsync(
 }
 
 void ApiEventProcessor::ProcessApiStringEvent(
-    const orbit_grpc_protos::ApiStringEvent& api_string_event) {
+    const orbit_grpc_protos::ApiStringEvent& grpc_api_string_event) {
   ApiStringEvent api_string_event;
-  api_string_event.set_process_id(api_string_event.pid());
-  api_string_event.set_thread_id(api_string_event.tid());
-  api_string_event.set_timestamp_ns(api_string_event.timestamp_ns());
-  api_string_event.set_async_scope_id(api_string_event.id());
-  api_string_event.set_name(DecodeString(api_string_event));
+  api_string_event.set_process_id(grpc_api_string_event.pid());
+  api_string_event.set_thread_id(grpc_api_string_event.tid());
+  api_string_event.set_timestamp_ns(grpc_api_string_event.timestamp_ns());
+  api_string_event.set_async_scope_id(grpc_api_string_event.id());
+  api_string_event.set_name(DecodeString(grpc_api_string_event));
   capture_listener_->OnApiStringEvent(api_string_event);
 }
 
 void ApiEventProcessor::ProcessApiTrackDouble(
-    const orbit_grpc_protos::ApiTrackDouble& api_track_double) {
+    const orbit_grpc_protos::ApiTrackDouble& grpc_api_track_double) {
   ApiTrackValue api_track_value;
-  api_track_value.set_process_id(api_track_double.pid());
-  api_track_value.set_thread_id(api_track_double.tid());
-  api_track_value.set_timestamp_ns(api_track_double.timestamp_ns());
-  api_track_value.set_data_double(api_track_double.data());
+  api_track_value.set_process_id(grpc_api_track_double.pid());
+  api_track_value.set_thread_id(grpc_api_track_double.tid());
+  api_track_value.set_timestamp_ns(grpc_api_track_double.timestamp_ns());
+  api_track_value.set_data_double(grpc_api_track_double.data());
 
-  api_track_value.set_name(DecodeString(api_track_double));
+  api_track_value.set_name(DecodeString(grpc_api_track_double));
 
   capture_listener_->OnApiTrackValue(api_track_value);
 }
 
 void ApiEventProcessor::ProcessApiTrackFloat(
-    const orbit_grpc_protos::ApiTrackFloat& api_track_float) {
+    const orbit_grpc_protos::ApiTrackFloat& grpc_api_track_float) {
   ApiTrackValue api_track_value;
-  api_track_value.set_process_id(api_track_float.pid());
-  api_track_value.set_thread_id(api_track_float.tid());
-  api_track_value.set_timestamp_ns(api_track_float.timestamp_ns());
-  api_track_value.set_data_float(api_track_float.data());
+  api_track_value.set_process_id(grpc_api_track_float.pid());
+  api_track_value.set_thread_id(grpc_api_track_float.tid());
+  api_track_value.set_timestamp_ns(grpc_api_track_float.timestamp_ns());
+  api_track_value.set_data_float(grpc_api_track_float.data());
 
-  api_track_value.set_name(DecodeString(api_track_float));
+  api_track_value.set_name(DecodeString(grpc_api_track_float));
 
   capture_listener_->OnApiTrackValue(api_track_value);
 }
 
-void ApiEventProcessor::ProcessApiTrackInt(const orbit_grpc_protos::ApiTrackInt& api_track_int) {
+void ApiEventProcessor::ProcessApiTrackInt(
+    const orbit_grpc_protos::ApiTrackInt& grpc_api_track_int) {
   ApiTrackValue api_track_value;
-  api_track_value.set_process_id(api_track_int.pid());
-  api_track_value.set_thread_id(api_track_int.tid());
-  api_track_value.set_timestamp_ns(api_track_int.timestamp_ns());
-  api_track_value.set_data_int(api_track_int.data());
+  api_track_value.set_process_id(grpc_api_track_int.pid());
+  api_track_value.set_thread_id(grpc_api_track_int.tid());
+  api_track_value.set_timestamp_ns(grpc_api_track_int.timestamp_ns());
+  api_track_value.set_data_int(grpc_api_track_int.data());
 
-  api_track_value.set_name(DecodeString(api_track_int));
+  api_track_value.set_name(DecodeString(grpc_api_track_int));
 
   capture_listener_->OnApiTrackValue(api_track_value);
 }
 
 void ApiEventProcessor::ProcessApiTrackInt64(
-    const orbit_grpc_protos::ApiTrackInt64& api_track_int64) {
+    const orbit_grpc_protos::ApiTrackInt64& grpc_api_track_int64) {
   ApiTrackValue api_track_value;
-  api_track_value.set_process_id(api_track_int64.pid());
-  api_track_value.set_thread_id(api_track_int64.tid());
-  api_track_value.set_timestamp_ns(api_track_int64.timestamp_ns());
-  api_track_value.set_data_int64(api_track_int64.data());
+  api_track_value.set_process_id(grpc_api_track_int64.pid());
+  api_track_value.set_thread_id(grpc_api_track_int64.tid());
+  api_track_value.set_timestamp_ns(grpc_api_track_int64.timestamp_ns());
+  api_track_value.set_data_int64(grpc_api_track_int64.data());
 
-  api_track_value.set_name(DecodeString(api_track_int64));
+  api_track_value.set_name(DecodeString(grpc_api_track_int64));
 
   capture_listener_->OnApiTrackValue(api_track_value);
 }
 
-void ApiEventProcessor::ProcessApiTrackUint(const orbit_grpc_protos::ApiTrackUint& api_track_uint) {
+void ApiEventProcessor::ProcessApiTrackUint(
+    const orbit_grpc_protos::ApiTrackUint& grpc_api_track_uint) {
   ApiTrackValue api_track_value;
-  api_track_value.set_process_id(api_track_uint.pid());
-  api_track_value.set_thread_id(api_track_uint.tid());
-  api_track_value.set_timestamp_ns(api_track_uint.timestamp_ns());
-  api_track_value.set_data_uint(api_track_uint.data());
+  api_track_value.set_process_id(grpc_api_track_uint.pid());
+  api_track_value.set_thread_id(grpc_api_track_uint.tid());
+  api_track_value.set_timestamp_ns(grpc_api_track_uint.timestamp_ns());
+  api_track_value.set_data_uint(grpc_api_track_uint.data());
 
-  api_track_value.set_name(DecodeString(api_track_uint));
+  api_track_value.set_name(DecodeString(grpc_api_track_uint));
 
   capture_listener_->OnApiTrackValue(api_track_value);
 }
 
 void ApiEventProcessor::ProcessApiTrackUint64(
-    const orbit_grpc_protos::ApiTrackUint64& api_track_uint64) {
+    const orbit_grpc_protos::ApiTrackUint64& grpc_api_track_uint64) {
   ApiTrackValue api_track_value;
-  api_track_value.set_process_id(api_track_uint64.pid());
-  api_track_value.set_thread_id(api_track_uint64.tid());
-  api_track_value.set_timestamp_ns(api_track_uint64.timestamp_ns());
-  api_track_value.set_data_uint64(api_track_uint64.data());
+  api_track_value.set_process_id(grpc_api_track_uint64.pid());
+  api_track_value.set_thread_id(grpc_api_track_uint64.tid());
+  api_track_value.set_timestamp_ns(grpc_api_track_uint64.timestamp_ns());
+  api_track_value.set_data_uint64(grpc_api_track_uint64.data());
 
-  api_track_value.set_name(DecodeString(api_track_uint64));
+  api_track_value.set_name(DecodeString(grpc_api_track_uint64));
 
   capture_listener_->OnApiTrackValue(api_track_value);
 }

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -175,7 +175,7 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
       ProcessMemoryUsageEvent(event.memory_usage_event());
       break;
     case ClientCaptureEvent::kApiEvent:
-      api_event_processor_.ProcessApiEvent(event.api_event());
+      api_event_processor_.ProcessApiEventLegacy(event.api_event());
       break;
     case ClientCaptureEvent::kApiScopeStart:
       api_event_processor_.ProcessApiScopeStart(event.api_scope_start());

--- a/src/CaptureClient/include/CaptureClient/ApiEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/ApiEventProcessor.h
@@ -26,16 +26,17 @@ class ApiEventProcessor {
   [[deprecated]] void ProcessApiEventLegacy(const orbit_grpc_protos::ApiEvent& grpc_api_event);
   void ProcessApiScopeStart(const orbit_grpc_protos::ApiScopeStart& api_scope_start);
   void ProcessApiScopeStartAsync(
-      const orbit_grpc_protos::ApiScopeStartAsync& api_scope_start_async);
-  void ProcessApiScopeStop(const orbit_grpc_protos::ApiScopeStop& api_scope_stop);
-  void ProcessApiScopeStopAsync(const orbit_grpc_protos::ApiScopeStopAsync& api_scope_stop_async);
-  void ProcessApiStringEvent(const orbit_grpc_protos::ApiStringEvent& api_string_event);
-  void ProcessApiTrackDouble(const orbit_grpc_protos::ApiTrackDouble& api_track_double);
-  void ProcessApiTrackFloat(const orbit_grpc_protos::ApiTrackFloat& api_track_float);
-  void ProcessApiTrackInt(const orbit_grpc_protos::ApiTrackInt& api_track_int);
-  void ProcessApiTrackInt64(const orbit_grpc_protos::ApiTrackInt64& api_track_int64);
-  void ProcessApiTrackUint(const orbit_grpc_protos::ApiTrackUint& api_track_uint);
-  void ProcessApiTrackUint64(const orbit_grpc_protos::ApiTrackUint64& api_track_uint64);
+      const orbit_grpc_protos::ApiScopeStartAsync& grpc_api_scope_start_async);
+  void ProcessApiScopeStop(const orbit_grpc_protos::ApiScopeStop& grpc_api_scope_stop);
+  void ProcessApiScopeStopAsync(
+      const orbit_grpc_protos::ApiScopeStopAsync& grpc_api_scope_stop_async);
+  void ProcessApiStringEvent(const orbit_grpc_protos::ApiStringEvent& grpc_api_string_event);
+  void ProcessApiTrackDouble(const orbit_grpc_protos::ApiTrackDouble& grpc_api_track_double);
+  void ProcessApiTrackFloat(const orbit_grpc_protos::ApiTrackFloat& grpc_api_track_float);
+  void ProcessApiTrackInt(const orbit_grpc_protos::ApiTrackInt& grpc_api_track_int);
+  void ProcessApiTrackInt64(const orbit_grpc_protos::ApiTrackInt64& grpc_api_track_int64);
+  void ProcessApiTrackUint(const orbit_grpc_protos::ApiTrackUint& grpc_api_track_uint);
+  void ProcessApiTrackUint64(const orbit_grpc_protos::ApiTrackUint64& grpc_api_track_uint64);
 
  private:
   [[deprecated]] void ProcessApiEventLegacy(const orbit_api::ApiEvent& api_event);

--- a/src/CaptureClient/include/CaptureClient/ApiEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/ApiEventProcessor.h
@@ -23,18 +23,19 @@ class ApiEventProcessor {
   explicit ApiEventProcessor(CaptureListener* listener);
   // The new manual instrumentation events (see below) could not use `ApiEvent`, so this is
   // deprecated. The methods for the concrete (new) events should be used instead.
-  [[deprecated]] void ProcessApiEventLegacy(const orbit_grpc_protos::ApiEvent& event_buffer);
-  void ProcessApiScopeStart(const orbit_grpc_protos::ApiScopeStart& event_buffer);
-  void ProcessApiScopeStartAsync(const orbit_grpc_protos::ApiScopeStartAsync& event_buffer);
-  void ProcessApiScopeStop(const orbit_grpc_protos::ApiScopeStop& event_buffer);
-  void ProcessApiScopeStopAsync(const orbit_grpc_protos::ApiScopeStopAsync& event_buffer);
-  void ProcessApiStringEvent(const orbit_grpc_protos::ApiStringEvent& event_buffer);
-  void ProcessApiTrackDouble(const orbit_grpc_protos::ApiTrackDouble& event_buffer);
-  void ProcessApiTrackFloat(const orbit_grpc_protos::ApiTrackFloat& event_buffer);
-  void ProcessApiTrackInt(const orbit_grpc_protos::ApiTrackInt& event_buffer);
-  void ProcessApiTrackInt64(const orbit_grpc_protos::ApiTrackInt64& event_buffer);
-  void ProcessApiTrackUint(const orbit_grpc_protos::ApiTrackUint& event_buffer);
-  void ProcessApiTrackUint64(const orbit_grpc_protos::ApiTrackUint64& event_buffer);
+  [[deprecated]] void ProcessApiEventLegacy(const orbit_grpc_protos::ApiEvent& grpc_api_event);
+  void ProcessApiScopeStart(const orbit_grpc_protos::ApiScopeStart& api_scope_start);
+  void ProcessApiScopeStartAsync(
+      const orbit_grpc_protos::ApiScopeStartAsync& api_scope_start_async);
+  void ProcessApiScopeStop(const orbit_grpc_protos::ApiScopeStop& api_scope_stop);
+  void ProcessApiScopeStopAsync(const orbit_grpc_protos::ApiScopeStopAsync& api_scope_stop_async);
+  void ProcessApiStringEvent(const orbit_grpc_protos::ApiStringEvent& api_string_event);
+  void ProcessApiTrackDouble(const orbit_grpc_protos::ApiTrackDouble& api_track_double);
+  void ProcessApiTrackFloat(const orbit_grpc_protos::ApiTrackFloat& api_track_float);
+  void ProcessApiTrackInt(const orbit_grpc_protos::ApiTrackInt& api_track_int);
+  void ProcessApiTrackInt64(const orbit_grpc_protos::ApiTrackInt64& api_track_int64);
+  void ProcessApiTrackUint(const orbit_grpc_protos::ApiTrackUint& api_track_uint);
+  void ProcessApiTrackUint64(const orbit_grpc_protos::ApiTrackUint64& api_track_uint64);
 
  private:
   [[deprecated]] void ProcessApiEventLegacy(const orbit_api::ApiEvent& api_event);

--- a/src/CaptureClient/include/CaptureClient/ApiEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/ApiEventProcessor.h
@@ -23,7 +23,7 @@ class ApiEventProcessor {
   explicit ApiEventProcessor(CaptureListener* listener);
   // The new manual instrumentation events (see below) could not use `ApiEvent`, so this is
   // deprecated. The methods for the concrete (new) events should be used instead.
-  [[deprecated]] void ProcessApiEvent(const orbit_grpc_protos::ApiEvent& event_buffer);
+  [[deprecated]] void ProcessApiEventLegacy(const orbit_grpc_protos::ApiEvent& event_buffer);
   void ProcessApiScopeStart(const orbit_grpc_protos::ApiScopeStart& event_buffer);
   void ProcessApiScopeStartAsync(const orbit_grpc_protos::ApiScopeStartAsync& event_buffer);
   void ProcessApiScopeStop(const orbit_grpc_protos::ApiScopeStop& event_buffer);
@@ -37,12 +37,13 @@ class ApiEventProcessor {
   void ProcessApiTrackUint64(const orbit_grpc_protos::ApiTrackUint64& event_buffer);
 
  private:
-  [[deprecated]] void ProcessApiEvent(const orbit_api::ApiEvent& api_event);
-  [[deprecated]] void ProcessStartEvent(const orbit_api::ApiEvent& api_event);
-  [[deprecated]] void ProcessStopEvent(const orbit_api::ApiEvent& api_event);
-  [[deprecated]] void ProcessAsyncStartEvent(const orbit_api::ApiEvent& api_event);
-  [[deprecated]] void ProcessAsyncStopEvent(const orbit_api::ApiEvent& api_event);
-  [[deprecated]] void ProcessTrackingEvent(const orbit_api::ApiEvent& api_event);
+  [[deprecated]] void ProcessApiEventLegacy(const orbit_api::ApiEvent& api_event);
+  [[deprecated]] void ProcessStartEventLegacy(const orbit_api::ApiEvent& api_event);
+  [[deprecated]] void ProcessStopEventLegacy(const orbit_api::ApiEvent& api_event);
+  [[deprecated]] void ProcessAsyncStartEventLegacy(const orbit_api::ApiEvent& api_event);
+  [[deprecated]] void ProcessAsyncStopEventLegacy(const orbit_api::ApiEvent& api_event);
+  [[deprecated]] void ProcessTrackingEventLegacy(const orbit_api::ApiEvent& api_event);
+  [[deprecated]] void ProcessStringEventLegacy(const orbit_api::ApiEvent& api_event);
 
   CaptureListener* capture_listener_ = nullptr;
   absl::flat_hash_map<int32_t, std::vector<orbit_api::ApiEvent>> synchronous_event_stack_by_tid_;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2709,9 +2709,6 @@ void OrbitApp::CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& t
     case orbit_client_protos::TimerInfo_Type_kGpuDebugMarker:
       metrics_capture_complete_data_.number_of_vulkan_layer_gpu_debug_marker_timers++;
       break;
-    case orbit_client_protos::TimerInfo_Type_kApiEvent:
-      CaptureMetricProcessApiTimer(timer);
-      break;
     case orbit_client_protos::TimerInfo_Type_kApiScope:
       metrics_capture_complete_data_.number_of_manual_start_timers++;
       break;
@@ -2720,41 +2717,6 @@ void OrbitApp::CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& t
       break;
     default:
       break;
-  }
-}
-
-void OrbitApp::CaptureMetricProcessApiTimer(const orbit_client_protos::TimerInfo& timer) {
-  orbit_api::Event api_event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer);
-  switch (api_event.type) {
-    case orbit_api::kScopeStart:
-      metrics_capture_complete_data_.number_of_manual_start_timers++;
-      break;
-    case orbit_api::kScopeStop:
-      metrics_capture_complete_data_.number_of_manual_stop_timers++;
-      break;
-    case orbit_api::kScopeStartAsync:
-      metrics_capture_complete_data_.number_of_manual_start_async_timers++;
-      break;
-    case orbit_api::kScopeStopAsync:
-      metrics_capture_complete_data_.number_of_manual_stop_async_timers++;
-      break;
-    case orbit_api::kTrackInt:
-      [[fallthrough]];
-    case orbit_api::kTrackInt64:
-      [[fallthrough]];
-    case orbit_api::kTrackUint:
-      [[fallthrough]];
-    case orbit_api::kTrackUint64:
-      [[fallthrough]];
-    case orbit_api::kTrackFloat:
-      [[fallthrough]];
-    case orbit_api::kTrackDouble:
-      metrics_capture_complete_data_.number_of_manual_tracked_value_timers++;
-      break;
-    case orbit_api::kString:
-      break;
-    case orbit_api::kNone:
-      UNREACHABLE();
   }
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -518,8 +518,6 @@ class OrbitApp final : public DataViewFactory,
 
   // Only call from the capture thread
   void CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& timer);
-  // Only call from the capture thread
-  void CaptureMetricProcessApiTimer(const orbit_client_protos::TimerInfo& timer);
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<bool> is_loading_capture_{false};

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -48,7 +48,6 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
           ? capture_data_->GetInstrumentedFunctionById(timer_info->function_id())
           : nullptr;
   CHECK(func != nullptr || timer_info->type() == TimerInfo::kIntrospection ||
-        timer_info->type() == TimerInfo::kApiEvent ||
         timer_info->type() == TimerInfo::kApiScopeAsync);
 
   std::string module_name =
@@ -59,7 +58,7 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
   if (timer_info->type() == TimerInfo::kApiScopeAsync) {
     event_id = timer_info->api_async_scope_id();
   } else {
-    CHECK(timer_info->type() == TimerInfo::kApiEvent);
+    CHECK(timer_info->type() == TimerInfo::kIntrospection);
     orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(*timer_info);
     event_id = event.data;
   }
@@ -98,16 +97,15 @@ float AsyncTrack::GetDefaultBoxHeight() const {
 
 std::string AsyncTrack::GetTimesliceText(const TimerInfo& timer_info) const {
   std::string time = GetDisplayTime(timer_info);
-
-  std::string name{};
+  uint64_t event_id = 0;
   if (timer_info.type() == TimerInfo::kApiScopeAsync) {
-    name = timer_info.api_scope_name();
+    event_id = timer_info.api_async_scope_id();
   } else {
-    CHECK(timer_info.type() == TimerInfo::kApiEvent);
+    CHECK(timer_info.type() == TimerInfo::kIntrospection);
     orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-    const uint64_t event_id = event.data;
-    name = app_->GetManualInstrumentationManager()->GetString(event_id);
+    event_id = event.data;
   }
+  std::string name = app_->GetManualInstrumentationManager()->GetString(event_id);
   return absl::StrFormat("%s %s", name, time);
 }
 
@@ -140,7 +138,7 @@ Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
   if (timer_info.type() == TimerInfo::kApiScopeAsync) {
     event_id = timer_info.api_async_scope_id();
   } else {
-    CHECK(timer_info.type() == TimerInfo::kApiEvent);
+    CHECK(timer_info.type() == TimerInfo::kIntrospection);
     orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
     event_id = event.data;
   }

--- a/src/OrbitGl/ManualInstrumentationManager.cpp
+++ b/src/OrbitGl/ManualInstrumentationManager.cpp
@@ -63,7 +63,14 @@ void ManualInstrumentationManager::ProcessStringEventLegacy(const orbit_api::Eve
 
 void ManualInstrumentationManager::ProcessStringEvent(
     const orbit_client_protos::ApiStringEvent& string_event) {
-  string_manager_.AddOrReplace(string_event.async_scope_id(), string_event.name());
+  // A string can be sent in chunks so we append the current value to any existing one.
+  uint64_t event_id = string_event.async_scope_id();
+  auto result = string_manager_.Get(event_id);
+  if (result.has_value()) {
+    string_manager_.AddOrReplace(event_id, result.value() + string_event.name());
+  } else {
+    string_manager_.AddOrReplace(event_id, string_event.name());
+  }
 }
 
 void ManualInstrumentationManager::ProcessAsyncTimer(const TimerInfo& timer_info) {

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -31,7 +31,6 @@ PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent, TimeGraph* time_gra
       minor_page_faults_track_{
           std::make_shared<MinorPageFaultsTrack>(this, time_graph, viewport, layout, cgroup_name,
                                                  memory_sampling_period_ms, capture_data)} {
-
   // PageFaults track is collapsed by default. The major and minor page faults subtracks are
   // expanded by default, but not shown while the page faults track is collapsed.
   collapse_toggle_->SetCollapsed(true);

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -120,7 +120,6 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
   }
 
   if (is_manual) {
-    CHECK(timer_info->type() == TimerInfo::kApiScope);
     function_name = timer_info->api_scope_name();
   } else {
     function_name = func->function_name();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -310,10 +310,6 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
       track->OnTimer(timer_info);
       break;
     }
-    case TimerInfo::kApiEvent: {
-      ProcessApiEventTimerLegacy(timer_info);
-      break;
-    }
     case TimerInfo::kApiScope: {
       ThreadTrack* track = track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
       track->OnTimer(timer_info);
@@ -328,34 +324,6 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
   }
 
   RequestUpdate();
-}
-
-void TimeGraph::ProcessApiEventTimerLegacy(const TimerInfo& timer_info) {
-  orbit_api::Event api_event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-  switch (api_event.type) {
-    case orbit_api::kScopeStart:
-    case orbit_api::kScopeStop: {
-      ThreadTrack* track = track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
-      track->OnTimer(timer_info);
-      break;
-    }
-    case orbit_api::kScopeStartAsync:
-    case orbit_api::kScopeStopAsync:
-      manual_instrumentation_manager_->ProcessAsyncTimerLegacy(timer_info);
-      break;
-
-    case orbit_api::kTrackInt:
-    case orbit_api::kTrackInt64:
-    case orbit_api::kTrackUint:
-    case orbit_api::kTrackUint64:
-    case orbit_api::kTrackFloat:
-    case orbit_api::kTrackDouble:
-    case orbit_api::kString:
-      ProcessValueTrackingTimerLegacy(timer_info);
-      break;
-    case orbit_api::kNone:
-      UNREACHABLE();
-  }
 }
 
 void TimeGraph::ProcessIntrospectionTimer(const TimerInfo& timer_info) {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -193,9 +193,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
 
-  [[deprecated]] void ProcessApiEventTimerLegacy(const orbit_client_protos::TimerInfo& timer_info);
-  void ProcessApiScopeTimer(const orbit_client_protos::TimerInfo& timer_info);
-  void ProcessApiScopeAsyncTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessIntrospectionTimer(const orbit_client_protos::TimerInfo& timer_info);
   [[deprecated]] void ProcessValueTrackingTimerLegacy(
       const orbit_client_protos::TimerInfo& timer_info);


### PR DESCRIPTION
Let ApiEventProcessor also generate the new client events, so that
we can start dropping support for the old events in the client.

So far, some support is still needed as the introspection still
sends the old events.

Test: Run OrbitTest (with introspection). Run Tests.