### PR TITLE
Split UpdatePrimitives with size calculation

### DIFF
--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -30,12 +30,14 @@ class FakeTrackTab : public CaptureViewElement {
         track_(track) {
     // Compute and set the size (which would usually be done by the parent). As the position may
     // change, we override the GetPos() function.
-    SetSize(layout_->GetTrackTabWidth(), layout_->GetTrackTabHeight());
+    SetWidth(layout_->GetTrackTabWidth());
   }
 
   [[nodiscard]] std::unique_ptr<AccessibleInterface> CreateAccessibleInterface() override {
     return std::make_unique<AccessibleTrackTab>(this, track_);
   }
+
+  [[nodiscard]] float GetHeight() const override { return layout_->GetTrackTabHeight(); }
 
   [[nodiscard]] Vec2 GetPos() const override {
     Vec2 track_pos = track_->GetPos();
@@ -72,11 +74,11 @@ class FakeTimerPane : public CaptureViewElement {
     return pos;
   }
 
-  [[nodiscard]] Vec2 GetSize() const override {
-    Vec2 size = track_->GetSize();
+  [[nodiscard]] float GetHeight() const override {
+    float height = track_->GetHeight();
     float track_header_height = track_->GetPos()[1] - GetPos()[1];
-    size[1] -= track_header_height;
-    return size;
+    height -= track_header_height;
+    return height;
   }
 
  private:

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -98,8 +98,8 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 
 float AsyncTrack::GetDefaultBoxHeight() const {
   auto box_height = layout_->GetTextBoxHeight();
-  if (collapse_toggle_->IsCollapsed() && GetDepth() > 0) {
-    return box_height / static_cast<float>(GetDepth());
+  if (collapse_toggle_->IsCollapsed() && track_data_->GetMaxDepth() > 0) {
+    return box_height / static_cast<float>(track_data_->GetMaxDepth());
   }
   return box_height;
 }

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -93,7 +93,7 @@ void BasicPageFaultsTrack::DrawSingleSeriesEntry(
   float x0 = time_graph_->GetWorldFromTick(start_tick);
   float width = time_graph_->GetWorldFromTick(end_tick) - x0;
   float content_height = GetGraphContentHeight();
-  float y0 = pos_[1] - size_[1] + layout_->GetTrackBottomMargin();
+  float y0 = pos_[1] - GetHeight() + layout_->GetTrackBottomMargin();
   batcher->AddShadedBox(Vec2(x0, y0), Vec2(width, content_height), z, kHightlightingColor);
 }
 

--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -60,7 +60,7 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
   [[nodiscard]] bool IsCollapsed() const override;
   [[nodiscard]] float GetAnnotatedTrackContentHeight() const override;
   [[nodiscard]] Vec2 GetAnnotatedTrackPosition() const override { return pos_; };
-  [[nodiscard]] Vec2 GetAnnotatedTrackSize() const override { return size_; };
+  [[nodiscard]] Vec2 GetAnnotatedTrackSize() const override { return GetSize(); };
   [[nodiscard]] uint32_t GetAnnotationFontSize(int indentation_level) const override {
     return GetLegendFontSize(indentation_level);
   }

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -64,7 +64,7 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           : GlCanvas::kZValueEventBar;
   event_bar_z += draw_context.z_offset;
   Color color = GetColor();
-  Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
+  Box box(pos_, Vec2(GetWidth(), -GetHeight()), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
 
   if (batcher.GetPickingManager()->IsThisElementPicked(this)) {
@@ -73,8 +73,8 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
 
   float x0 = pos_[0];
   float y0 = pos_[1];
-  float x1 = x0 + size_[0];
-  float y1 = y0 - size_[1];
+  float x1 = x0 + GetWidth();
+  float y1 = y0 - GetHeight();
 
   batcher.AddLine(pos_, Vec2(x1, y0), event_bar_z, color, shared_from_this());
   batcher.AddLine(Vec2(x1, y1), Vec2(x0, y1), event_bar_z, color, shared_from_this());
@@ -86,10 +86,10 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
     x0 = from[0];
     y0 = pos_[1];
     x1 = to[0];
-    y1 = y0 - size_[1];
+    y1 = y0 - GetHeight();
 
     Color picked_color(0, 128, 255, 128);
-    Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, -size_[1]),
+    Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, -GetHeight()),
                    GlCanvas::kZValueUi + draw_context.z_offset);
     batcher.AddBox(picked_box, picked_color, shared_from_this());
   }

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -35,6 +35,9 @@ class CallstackThreadBar : public ThreadBar {
             const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
+  [[nodiscard]] float GetHeight() const override {
+    return layout_->GetEventTrackHeightFromTid(GetThreadId());
+  }
 
   void OnPick(int x, int y) override;
   void OnRelease() override;

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -15,6 +15,13 @@ CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, TimeGraph* ti
   CHECK(layout != nullptr);
 }
 
+void CaptureViewElement::SetWidth(float width) {
+  if (width != width_) {
+    width_ = width;
+    RequestUpdate();
+  }
+}
+
 void CaptureViewElement::OnPick(int x, int y) {
   mouse_pos_last_click_ = viewport_->ScreenToWorldPos(Vec2i(x, y));
   picking_offset_ = mouse_pos_last_click_ - pos_;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -55,9 +55,12 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void SetPos(float x, float y) { pos_ = Vec2(x, y); }
   // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
   [[nodiscard]] virtual Vec2 GetPos() const { return pos_; }
-  void SetSize(float width, float height) { size_ = Vec2(width, height); }
   // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
-  [[nodiscard]] virtual Vec2 GetSize() const { return size_; }
+  virtual void SetWidth(float width);
+  [[nodiscard]] float GetWidth() const { return width_; }
+  // Height should be defined in every particular capture view element.
+  [[nodiscard]] virtual float GetHeight() const = 0;
+  [[nodiscard]] Vec2 GetSize() const { return Vec2(GetWidth(), GetHeight()); }
 
   // Pickable
   void OnPick(int x, int y) override;
@@ -74,7 +77,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   TimeGraph* time_graph_;
   Vec2 pos_ = Vec2(0, 0);
-  Vec2 size_ = Vec2(0, 0);
+  float width_ = 0.;
 
   Vec2 mouse_pos_last_click_;
   Vec2 mouse_pos_cur_;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -52,7 +52,8 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   [[nodiscard]] orbit_gl::Viewport* GetViewport() const { return viewport_; }
 
-  void SetPos(float x, float y) { pos_ = Vec2(x, y); }
+  // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
+  virtual void SetPos(float x, float y) { pos_ = Vec2(x, y); }
   // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
   [[nodiscard]] virtual Vec2 GetPos() const { return pos_; }
   // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -392,7 +392,7 @@ void CaptureWindow::Draw(bool viewport_was_dirty) {
   if (time_graph_ != nullptr) {
     if (viewport_was_dirty) {
       time_graph_->SetPos(0, 0);
-      time_graph_->SetSize(viewport_.GetWorldExtents()[0], viewport_.GetWorldExtents()[1]);
+      time_graph_->SetWidth(viewport_.GetWorldExtents()[0]);
 
       time_graph_->RequestUpdate();
     }
@@ -401,7 +401,7 @@ void CaptureWindow::Draw(bool viewport_was_dirty) {
     time_graph_->Draw(GetBatcher(), GetTextRenderer(),
                       {timegraph_current_mouse_time_ns, picking_mode_, 0, 0});
     viewport_.SetWorldExtents(viewport_.GetScreenWidth(),
-                              time_graph_->GetTrackManager()->GetTracksTotalHeight());
+                              time_graph_->GetTrackManager()->GetVisibleTracksTotalHeight());
   }
 
   RenderSelectionOverlay();

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -58,9 +58,12 @@ class CaptureWindow : public GlCanvas {
   Batcher& GetBatcherById(BatcherId batcher_id);
 
  protected:
-  void Draw(bool viewport_was_dirty) override;
+  void Draw() override;
+  void UpdateChildrenPosAndSize();
 
   virtual void DrawScreenSpace();
+  [[nodiscard]] float GetRightMargin() const { return right_margin_; }
+  void UpdateRightMargin(float margin) { right_margin_ = margin; }
   virtual void RenderText(float layer);
   virtual bool ShouldSkipRendering() const;
 
@@ -89,6 +92,7 @@ class CaptureWindow : public GlCanvas {
   bool draw_help_;
   std::shared_ptr<orbit_gl::GlSlider> slider_;
   std::shared_ptr<orbit_gl::GlSlider> vertical_slider_;
+  float right_margin_ = 0;
   orbit_gl::GlSlider* last_mouseover_slider_ = nullptr;
 
   uint64_t select_start_time_ = 0;

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -216,7 +216,7 @@ void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   float y = pos_[1] - GetHeaderHeight() - GetMaximumBoxHeight() + GetAverageBoxHeight();
   float x = pos_[0];
   Vec2 from(x, y);
-  Vec2 to(x + size_[0], y);
+  Vec2 to(x + GetWidth(), y);
   float text_z = GlCanvas::kZValueTrackText + draw_context.z_offset;
 
   std::string avg_time =

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -290,10 +290,7 @@ void GlCanvas::Render(int width, int height) {
   // Reset picking manager before each draw.
   picking_manager_.Reset();
 
-  bool viewport_was_dirty = viewport_.IsDirty();
-  // Clear viewport dirty flag so it can be set again during rendering if needed
-  viewport_.ClearDirtyFlag();
-  Draw(viewport_was_dirty);
+  Draw();
 
   if (picking_mode_ == PickingMode::kNone) {
     for (const auto& render_callback : render_callbacks_) {
@@ -307,6 +304,7 @@ void GlCanvas::Render(int width, int height) {
   PostRender();
 
   double_clicking_ = false;
+  viewport_.ClearDirtyFlag();
 }
 
 void GlCanvas::PreRender() {

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -128,7 +128,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   static const Color kTabTextColorSelected;
 
  protected:
-  virtual void Draw(bool /*viewport_was_dirty*/) {}
+  virtual void Draw() {}
 
   void UpdateSpecialKeys(bool ctrl, bool shift, bool alt);
   bool ControlPressed();

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -21,6 +21,7 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   ~GlSlider() override = default;
 
   [[nodiscard]] bool Draggable() override { return true; }
+  [[nodiscard]] virtual bool IsVisible() const { return true; }
   virtual void Draw(Batcher& batcher, bool is_picked) = 0;
 
   void SetNormalizedPosition(float start_ratio);  // [0,1]
@@ -126,6 +127,7 @@ class GlVerticalSlider : public GlSlider {
   GlVerticalSlider(Viewport& viewport) : GlSlider(viewport, true) {}
 
   void Draw(Batcher& batcher, bool is_picked) override;
+  [[nodiscard]] bool IsVisible() const override { return GetLengthRatio() < 1.f; }
 
  protected:
   [[nodiscard]] int GetBarPixelLength() const override;

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -116,7 +116,8 @@ float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 
 float GpuDebugMarkerTrack::GetHeight() const {
   bool collapsed = collapse_toggle_->IsCollapsed();
-  uint32_t depth = collapsed ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
+  uint32_t depth =
+      collapsed ? std::min<uint32_t>(1, track_data_->GetMaxDepth()) : track_data_->GetMaxDepth();
   return layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth +
          layout_->GetTrackBottomMargin();
 }

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -175,7 +175,7 @@ std::string GpuSubmissionTrack::GetTimesliceText(const TimerInfo& timer_info) co
 
 float GpuSubmissionTrack::GetHeight() const {
   bool collapsed = IsCollapsed();
-  uint32_t depth = collapsed ? 1 : GetDepth();
+  uint32_t depth = collapsed ? 1 : track_data_->GetMaxDepth();
   uint32_t num_gaps = depth > 0 ? depth - 1 : 0;
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
     depth *= 2;

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -57,7 +57,7 @@ class GpuSubmissionTrack : public TimerTrack {
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] bool IsCollapsible() const override {
-    return GetDepth() > 1 || has_vulkan_layer_command_buffer_timers_;
+    return track_data_->GetMaxDepth() > 1 || has_vulkan_layer_command_buffer_timers_;
   }
   [[nodiscard]] bool IsCollapsed() const override {
     return Track::IsCollapsed() || GetParent()->IsCollapsed();

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -125,8 +125,6 @@ void GpuTrack::SetWidth(float width) {
 
 void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                     const DrawContext& draw_context) {
-  UpdatePositionOfSubtracks();
-
   Track::Draw(batcher, text_renderer, draw_context);
 
   if (collapse_toggle_->IsCollapsed()) {
@@ -144,8 +142,6 @@ void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
 
 void GpuTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                 PickingMode picking_mode, float z_offset) {
-  UpdatePositionOfSubtracks();
-
   const bool is_collapsed = collapse_toggle_->IsCollapsed();
 
   if (!submission_track_->IsEmpty()) {

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -115,15 +115,17 @@ float GpuTrack::GetHeight() const {
   return height;
 }
 
+// TODO(b/176216022): Make a general interface for capture view elements for setting the width to
+// every child.
+void GpuTrack::SetWidth(float width) {
+  Track::SetWidth(width);
+  submission_track_->SetWidth(width);
+  marker_track_->SetWidth(width);
+}
+
 void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                     const DrawContext& draw_context) {
   UpdatePositionOfSubtracks();
-  // If being collapsed, the gpu track will show a collapsed version of the submission subtrack.
-  // Hence, the height of submission subtrack should always be updated as long as the subtrack is
-  // not empty.
-  if (!submission_track_->IsEmpty()) {
-    submission_track_->SetSize(size_[0], submission_track_->GetHeight());
-  }
 
   Track::Draw(batcher, text_renderer, draw_context);
 
@@ -136,7 +138,6 @@ void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   }
 
   if (!marker_track_->IsEmpty()) {
-    marker_track_->SetSize(size_[0], marker_track_->GetHeight());
     marker_track_->Draw(batcher, text_renderer, sub_track_draw_context);
   }
 }

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -85,7 +85,7 @@ class GpuTrack : public Track {
   }
 
  private:
-  void UpdatePositionOfSubtracks();
+  void UpdatePositionOfSubtracks() override;
   orbit_string_manager::StringManager* string_manager_;
   const std::shared_ptr<GpuSubmissionTrack> submission_track_;
   const std::shared_ptr<GpuDebugMarkerTrack> marker_track_;

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -68,6 +68,7 @@ class GpuTrack : public Track {
             const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
+  void SetWidth(float width) override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
 
   [[nodiscard]] bool IsEmpty() const override {

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -83,7 +83,7 @@ void GraphTrack<Dimension>::UpdatePrimitives(Batcher* batcher, uint64_t min_tick
   float content_height = GetGraphContentHeight();
   Vec2 content_pos = pos_;
   content_pos[1] -= layout_->GetTrackTabHeight();
-  Box box(content_pos, Vec2(size_[0], -content_height - GetLegendHeight()), track_z);
+  Box box(content_pos, Vec2(GetWidth(), -content_height - GetLegendHeight()), track_z);
   batcher->AddBox(box, GetTrackBackgroundColor(), shared_from_this());
 
   const bool picking = picking_mode != PickingMode::kNone;

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -66,10 +66,10 @@ class GraphTrack : public Track {
   }
 
   [[nodiscard]] float GetGraphContentBaseY() const {
-    return pos_[1] - size_[1] + layout_->GetTrackBottomMargin();
+    return pos_[1] - GetSize()[1] + layout_->GetTrackBottomMargin();
   }
   [[nodiscard]] float GetGraphContentHeight() const {
-    return size_[1] - layout_->GetTrackTabHeight() - GetLegendHeight() -
+    return GetSize()[1] - layout_->GetTrackTabHeight() - GetLegendHeight() -
            layout_->GetTrackBottomMargin();
   }
 

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -59,9 +59,9 @@ void IntrospectionWindow::StartIntrospection() {
 }
 void IntrospectionWindow::StopIntrospection() { introspection_listener_ = nullptr; }
 
-void IntrospectionWindow::Draw(bool viewport_was_dirty) {
+void IntrospectionWindow::Draw() {
   ORBIT_SCOPE_FUNCTION;
-  CaptureWindow::Draw(viewport_was_dirty);
+  CaptureWindow::Draw();
 }
 
 void IntrospectionWindow::DrawScreenSpace() {

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -29,7 +29,7 @@ class IntrospectionWindow : public CaptureWindow {
   void StopIntrospection();
 
  protected:
-  void Draw(bool viewport_was_dirty) override;
+  void Draw() override;
   void DrawScreenSpace() override;
   void RenderText(float layer) override;
   bool ShouldSkipRendering() const override { return false; };

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -46,7 +46,7 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
     return this->GetGraphContentHeight();
   }
   [[nodiscard]] Vec2 GetAnnotatedTrackPosition() const override { return this->pos_; };
-  [[nodiscard]] Vec2 GetAnnotatedTrackSize() const override { return this->size_; };
+  [[nodiscard]] Vec2 GetAnnotatedTrackSize() const override { return this->GetSize(); };
   [[nodiscard]] uint32_t GetAnnotationFontSize(int indentation_level) const override {
     return this->GetLegendFontSize(indentation_level);
   }

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -55,6 +55,14 @@ float PageFaultsTrack::GetHeight() const {
   return height;
 }
 
+// TODO(b/176216022): Make a general interface for capture view elements for setting the width to
+// every child.
+void PageFaultsTrack::SetWidth(float width) {
+  Track::SetWidth(width);
+  minor_page_faults_track_->SetWidth(width);
+  major_page_faults_track_->SetWidth(width);
+}
+
 std::vector<orbit_gl::CaptureViewElement*> PageFaultsTrack::GetVisibleChildren() {
   std::vector<CaptureViewElement*> result;
   if (collapse_toggle_->IsCollapsed()) return result;
@@ -71,8 +79,6 @@ std::string PageFaultsTrack::GetTooltip() const {
 
 void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                            const DrawContext& draw_context) {
-  UpdatePositionOfSubtracks();
-
   Track::Draw(batcher, text_renderer, draw_context);
 
   if (collapse_toggle_->IsCollapsed()) return;
@@ -89,8 +95,6 @@ void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
 
 void PageFaultsTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                        PickingMode picking_mode, float z_offset) {
-  UpdatePositionOfSubtracks();
-
   if (!major_page_faults_track_->IsEmpty()) {
     major_page_faults_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -72,12 +72,6 @@ std::string PageFaultsTrack::GetTooltip() const {
 void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                            const DrawContext& draw_context) {
   UpdatePositionOfSubtracks();
-  // If being collapsed, the page faults track will show a collapsed version of the major page
-  // faults subtrack. Hence, the height of major page faults subtrack should always be updated as
-  // long as the subtrack is not empty.
-  if (!major_page_faults_track_->IsEmpty()) {
-    major_page_faults_track_->SetSize(size_[0], major_page_faults_track_->GetHeight());
-  }
 
   Track::Draw(batcher, text_renderer, draw_context);
 
@@ -89,7 +83,6 @@ void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   }
 
   if (!minor_page_faults_track_->IsEmpty()) {
-    minor_page_faults_track_->SetSize(size_[0], minor_page_faults_track_->GetHeight());
     minor_page_faults_track_->Draw(batcher, text_renderer, sub_track_draw_context);
   }
 }

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -40,6 +40,7 @@ class PageFaultsTrack : public Track {
             const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
+  void SetWidth(float width) override;
 
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
@@ -57,7 +58,7 @@ class PageFaultsTrack : public Track {
   [[nodiscard]] uint64_t GetMaxTime() const override;
 
  private:
-  void UpdatePositionOfSubtracks();
+  void UpdatePositionOfSubtracks() override;
 
   std::shared_ptr<MajorPageFaultsTrack> major_page_faults_track_;
   std::shared_ptr<MinorPageFaultsTrack> minor_page_faults_track_;

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -39,8 +39,8 @@ void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 }
 
 float SchedulerTrack::GetHeight() const {
-  uint32_t num_gaps = std::max(GetDepth() - 1, 0u);
-  return GetHeaderHeight() + (GetDepth() * layout_->GetTextCoresHeight()) +
+  uint32_t num_gaps = std::max(track_data_->GetMaxDepth() - 1, 0u);
+  return GetHeaderHeight() + (track_data_->GetMaxDepth() * layout_->GetTextCoresHeight()) +
          (num_gaps * layout_->GetSpaceBetweenCores()) + layout_->GetTrackBottomMargin();
 }
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -49,7 +49,7 @@ void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
   thread_state_bar_z += draw_context.z_offset;
 
   // Draw a transparent track just for clicking.
-  Box box(pos_, Vec2(size_[0], -size_[1]), thread_state_bar_z);
+  Box box(pos_, Vec2(GetWidth(), -GetHeight()), thread_state_bar_z);
   static const Color kTransparent{0, 0, 0, 0};
   batcher.AddBox(box, kTransparent, shared_from_this());
 }
@@ -188,7 +188,7 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
         const float width = x1 - x0;
 
         const Vec2 pos{x0, pos_[1]};
-        const Vec2 size{width, -size_[1]};
+        const Vec2 size{width, -GetHeight()};
 
         const Color color = GetThreadStateColor(slice.thread_state());
 

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -33,6 +33,7 @@ class ThreadStateBar final : public ThreadBar {
             const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset) override;
+  [[nodiscard]] float GetHeight() const override { return layout_->GetThreadStateTrackHeight(); }
 
   void OnPick(int x, int y) override;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -271,17 +271,9 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   tracepoint_bar_->SetPos(pos_[0], current_y);
 }
 
-void ThreadTrack::UpdateMinMaxTimestamps() {
-  track_data_->UpdateMinTime(capture_data_->GetCallstackData().min_time());
-  track_data_->UpdateMaxTime(capture_data_->GetCallstackData().max_time());
-}
-
 void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                        const DrawContext& draw_context) {
   TimerTrack::Draw(batcher, text_renderer, draw_context);
-
-  UpdateMinMaxTimestamps();
-  UpdatePositionOfSubtracks();
 
   DrawContext inner_draw_context = draw_context.IncreasedIndentationLevel();
 
@@ -519,8 +511,6 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
 void ThreadTrack::UpdatePrimitivesOfSubtracks(Batcher* batcher, uint64_t min_tick,
                                               uint64_t max_tick, PickingMode picking_mode,
                                               float z_offset) {
-  UpdatePositionOfSubtracks();
-
   if (!thread_state_bar_->IsEmpty()) {
     thread_state_bar_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -197,8 +197,8 @@ bool ThreadTrack::IsTrackSelected() const {
 
 float ThreadTrack::GetDefaultBoxHeight() const {
   auto box_height = layout_->GetTextBoxHeight();
-  if (collapse_toggle_->IsCollapsed() && GetDepth() > 0) {
-    return box_height / static_cast<float>(GetDepth());
+  if (collapse_toggle_->IsCollapsed() && track_data_->GetMaxDepth() > 0) {
+    return box_height / static_cast<float>(track_data_->GetMaxDepth());
   }
   return box_height;
 }
@@ -361,8 +361,9 @@ std::string ThreadTrack::GetTooltip() const {
 }
 
 float ThreadTrack::GetHeight() const {
-  const uint32_t depth =
-      collapse_toggle_->IsCollapsed() ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
+  const uint32_t depth = collapse_toggle_->IsCollapsed()
+                             ? std::min<uint32_t>(1, track_data_->GetMaxDepth())
+                             : track_data_->GetMaxDepth();
 
   bool gap_between_tracks_and_timers =
       (!thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty()) &&
@@ -408,8 +409,6 @@ float ThreadTrack::GetYFromDepth(uint32_t depth) const {
 }
 
 void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
-  UpdateMaxDepth(timer_info.depth() + 1);
-
   if (process_id_ == -1) {
     process_id_ = timer_info.process_id();
   }
@@ -484,7 +483,6 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
     auto first_node_to_draw = ordered_nodes.lower_bound(min_tick);
     if (first_node_to_draw != ordered_nodes.begin()) --first_node_to_draw;
 
-    UpdateMaxDepth(depth);
     float world_timer_y = GetYFromDepth(depth - 1);
     uint64_t next_pixel_start_time_ns = min_tick;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -283,25 +283,17 @@ void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   UpdateMinMaxTimestamps();
   UpdatePositionOfSubtracks();
 
-  const float thread_state_track_height = layout_->GetThreadStateTrackHeight();
-  const float event_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
-  const float tracepoint_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
-  const float track_width = size_[0];
-
   DrawContext inner_draw_context = draw_context.IncreasedIndentationLevel();
 
   if (!thread_state_bar_->IsEmpty()) {
-    thread_state_bar_->SetSize(track_width, thread_state_track_height);
     thread_state_bar_->Draw(batcher, text_renderer, inner_draw_context);
   }
 
   if (!event_bar_->IsEmpty()) {
-    event_bar_->SetSize(track_width, event_track_height);
     event_bar_->Draw(batcher, text_renderer, inner_draw_context);
   }
 
   if (!tracepoint_bar_->IsEmpty()) {
-    tracepoint_bar_->SetSize(track_width, tracepoint_track_height);
     tracepoint_bar_->Draw(batcher, text_renderer, inner_draw_context);
   }
 }
@@ -371,6 +363,15 @@ float ThreadTrack::GetHeight() const {
   return GetHeaderHeight() +
          (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
          layout_->GetTextBoxHeight() * depth + layout_->GetTrackBottomMargin();
+}
+
+// TODO(b/176216022): Make a general interface for capture view elements for setting the width to
+// every child.
+void ThreadTrack::SetWidth(float width) {
+  Track::SetWidth(width);
+  thread_state_bar_->SetWidth(width);
+  event_bar_->SetWidth(width);
+  tracepoint_bar_->SetWidth(width);
 }
 
 float ThreadTrack::GetHeaderHeight() const {
@@ -474,7 +475,7 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
   UpdatePrimitivesOfSubtracks(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   const internal::DrawData draw_data = GetDrawData(
-      min_tick, max_tick, size_[0], z_offset, batcher, time_graph_, viewport_,
+      min_tick, max_tick, GetWidth(), z_offset, batcher, time_graph_, viewport_,
       collapse_toggle_->IsCollapsed(), app_->selected_timer(), app_->GetFunctionIdToHighlight());
 
   absl::MutexLock lock(&scope_tree_mutex_);

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -84,7 +84,7 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] float GetHeaderHeight() const override;
 
-  void UpdatePositionOfSubtracks();
+  void UpdatePositionOfSubtracks() override;
   void UpdatePrimitivesOfSubtracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                    PickingMode picking_mode, float z_offset);
   void UpdateMinMaxTimestamps();

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -54,6 +54,7 @@ class ThreadTrack final : public TimerTrack {
             const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
+  void SetWidth(float width) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -869,7 +869,7 @@ void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
   float track_width = GetVisibleWidth();
   float track_pos_x = viewport_->GetWorldTopLeft()[0];
   for (auto& track : track_manager_->GetVisibleTracks()) {
-    track->SetSize(track_width, track->GetHeight());
+    track->SetWidth(track_width);
     track->SetPos(track_pos_x, track->GetPos()[1]);
 
     float z_offset = 0;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -217,8 +217,6 @@ void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, uint64_t min, 
   }
 
   SetMinMax(mid - current_time_window_us * (1 - distance), mid + current_time_window_us * distance);
-
-  RequestUpdate();
 }
 
 void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, const TimerInfo& timer_info,
@@ -483,7 +481,7 @@ float TimeGraph::GetWorldFromTick(uint64_t time) const {
   if (time_window_us_ > 0) {
     double start = TicksToMicroseconds(capture_min_timestamp_, time) - min_time_us_;
     double normalized_start = start / time_window_us_;
-    auto pos = float(world_start_x_ + normalized_start * (world_width_ - right_margin_));
+    auto pos = float(world_start_x_ + normalized_start * world_width_);
     return pos;
   }
 
@@ -499,7 +497,7 @@ double TimeGraph::GetUsFromTick(uint64_t time) const {
 }
 
 uint64_t TimeGraph::GetTickFromWorld(float world_x) const {
-  float visible_width = world_width_ - right_margin_;
+  float visible_width = world_width_;
   double ratio =
       visible_width > 0 ? static_cast<double>((world_x - world_start_x_) / visible_width) : 0;
   auto time_span_ns = static_cast<uint64_t>(1000 * GetTime(ratio));
@@ -593,10 +591,25 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
-  track_manager_->UpdateTracksForRendering();
   track_manager_->UpdateTrackPrimitives(&batcher_, min_tick, max_tick, picking_mode);
 
   update_primitives_requested_ = false;
+}
+
+void TimeGraph::UpdateTracksPosition() {
+  // Update position of a track which is currently being moved.
+  const float track_pos_x = pos_[0];
+
+  float current_y = layout_.GetSchedulerTrackOffset();
+
+  // Track height including space between them
+  for (auto& track : track_manager_->GetVisibleTracks()) {
+    if (!track->IsMoving()) {
+      track->SetPos(track_pos_x, -current_y);
+    }
+    track->SetWidth(GetWidth());
+    current_y += (track->GetHeight() + layout_.GetSpaceBetweenTracks());
+  }
 }
 
 void TimeGraph::SelectCallstacks(float world_start, float world_end, int32_t thread_id) {
@@ -631,6 +644,9 @@ const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(int32_t
 void TimeGraph::Draw(Batcher& batcher, TextRenderer& text_renderer,
                      const DrawContext& draw_context) {
   ORBIT_SCOPE("TimeGraph::Draw");
+
+  track_manager_->UpdateTracksForRendering();
+  UpdateTracksPosition();
 
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
   if ((!picking && update_primitives_requested_) || picking) {
@@ -866,12 +882,7 @@ void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode pickin
 
 void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
                            const DrawContext& draw_context) {
-  float track_width = GetVisibleWidth();
-  float track_pos_x = viewport_->GetWorldTopLeft()[0];
   for (auto& track : track_manager_->GetVisibleTracks()) {
-    track->SetWidth(track_width);
-    track->SetPos(track_pos_x, track->GetPos()[1]);
-
     float z_offset = 0;
     if (track->IsPinned()) {
       z_offset = GlCanvas::kZOffsetPinnedTrack;
@@ -943,15 +954,6 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
   }
   if (goal != nullptr) {
     SelectAndMakeVisible(goal);
-  }
-}
-
-void TimeGraph::UpdateRightMargin(float margin) {
-  {
-    if (right_margin_ != margin) {
-      right_margin_ = margin;
-      RequestUpdate();
-    }
   }
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -58,6 +58,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void RequestUpdate() override;
   void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                         PickingMode /*picking_mode*/, float /*z_offset*/ = 0) override;
+  void UpdateTracksPosition();
   void SelectCallstacks(float world_start, float world_end, int32_t thread_id);
   const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(int32_t tid);
 
@@ -133,11 +134,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] double GetMaxTimeUs() const { return max_time_us_; }
   [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
   [[nodiscard]] TimeGraphLayout& GetLayout() { return layout_; }
-  [[nodiscard]] float GetRightMargin() const { return right_margin_; }
-  void UpdateRightMargin(float margin);
-  [[nodiscard]] float GetVisibleWidth() const {
-    return viewport_->GetScreenWidth() - GetRightMargin();
-  }
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindPrevious(
       const orbit_client_protos::TimerInfo& from);
@@ -221,7 +217,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   double time_window_us_ = 0;
   float world_start_x_ = 0;
   float world_width_ = 0;
-  float right_margin_ = 0;
 
   TimeGraphLayout layout_;
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -42,6 +42,9 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
                      PickingManager* picking_manager);
   ~TimeGraph() override;
 
+  [[nodiscard]] float GetHeight() const override {
+    return track_manager_->GetVisibleTracksTotalHeight();
+  }
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const DrawContext& draw_context) override;
   void DrawTracks(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context);

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -164,8 +164,8 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
     double right_overlap_width_us = end_us - end_or_next_start_us;
     double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
 
-    bool is_visible_width = ((text_x_end_us - text_x_start_us) * draw_data.inv_time_window *
-                             draw_data.viewport->GetScreenWidth()) > 1;
+    bool is_visible_width =
+        ((text_x_end_us - text_x_start_us) * draw_data.inv_time_window * draw_data.track_width) > 1;
     WorldXInfo world_x_info = ToWorldX(text_x_start_us, text_x_end_us, draw_data.inv_time_window,
                                        draw_data.track_start_x, draw_data.track_width);
 
@@ -186,8 +186,7 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
 
   Color color = GetTimerColor(*current_timer_info, is_selected, is_highlighted);
 
-  bool is_visible_width =
-      elapsed_us * draw_data.inv_time_window * draw_data.viewport->GetScreenWidth() > 1;
+  bool is_visible_width = elapsed_us * draw_data.inv_time_window * draw_data.track_width > 1;
 
   if (is_visible_width) {
     WorldXInfo world_x_info_left_overlap =
@@ -252,7 +251,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   draw_data.viewport = viewport_;
 
   draw_data.track_start_x = viewport_->GetWorldTopLeft()[0];
-  draw_data.track_width = size_[0];
+  draw_data.track_width = GetWidth();
   draw_data.inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
   draw_data.is_collapsed = IsCollapsed();
 
@@ -267,7 +266,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   // enough that all events are drawn as boxes, this has no effect. When zoomed
   // out, many events will be discarded quickly.
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
-  draw_data.ns_per_pixel = time_window_ns / viewport_->GetScreenWidth();
+  draw_data.ns_per_pixel = static_cast<uint64_t>(time_window_ns / GetWidth());
   draw_data.min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (const TimerChain* chain : chains) {
@@ -424,7 +423,7 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   draw_data.highlighted_function_id = highlighted_function_id;
 
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph->GetTimeWindowUs());
-  draw_data.ns_per_pixel = time_window_ns / viewport->GetScreenWidth();
+  draw_data.ns_per_pixel = static_cast<uint64_t>(time_window_ns / track_width);
   draw_data.min_timegraph_tick = time_graph->GetTickFromUs(time_graph->GetMinTimeUs());
   return draw_data;
 }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -111,7 +111,6 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
     return false;
   if (!TimerFilter(*current_timer_info)) return false;
 
-  UpdateMaxDepth(current_timer_info->depth() + 1);
   double start_us = time_graph_->GetUsFromTick(current_timer_info->start());
   double start_or_prev_end_us = start_us;
   double end_us = time_graph_->GetUsFromTick(current_timer_info->end());
@@ -315,10 +314,6 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
 }
 
 void TimerTrack::OnTimer(const TimerInfo& timer_info) {
-  if (timer_info.type() != TimerInfo::kCoreActivity) {
-    UpdateMaxDepth(timer_info.depth() + 1);
-  }
-
   if (process_id_ == -1) {
     process_id_ = timer_info.process_id();
   }
@@ -327,8 +322,8 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
 }
 
 float TimerTrack::GetHeight() const {
-  uint32_t collapsed_depth = std::min<uint32_t>(1, GetDepth());
-  uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : GetDepth();
+  uint32_t collapsed_depth = std::min<uint32_t>(1, track_data_->GetMaxDepth());
+  uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : track_data_->GetMaxDepth();
   return GetHeaderHeight() + layout_->GetTextBoxHeight() * depth +
          (depth > 0 ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
          layout_->GetTrackBottomMargin();

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -92,7 +92,7 @@ class TimerTrack : public Track {
       uint64_t start_ns, uint64_t end_ns) const;
   [[nodiscard]] bool IsEmpty() const override;
 
-  [[nodiscard]] bool IsCollapsible() const override { return GetDepth() > 1; }
+  [[nodiscard]] bool IsCollapsible() const override { return track_data_->GetMaxDepth() > 1; }
 
   [[nodiscard]] virtual float GetDefaultBoxHeight() const { return layout_->GetTextBoxHeight(); }
   [[nodiscard]] virtual float GetDynamicBoxHeight(
@@ -134,9 +134,6 @@ class TimerTrack : public Track {
                                const orbit_client_protos::TimerInfo* current_timer_info,
                                uint64_t* min_ignore, uint64_t* max_ignore);
 
-  [[nodiscard]] uint32_t GetDepth() const { return depth_; }
-  void UpdateMaxDepth(uint32_t depth) { depth_ = std::max(depth_, depth); }
-
   [[nodiscard]] virtual std::string GetTimesliceText(
       const orbit_client_protos::TimerInfo& /*timer*/) const {
     return "";
@@ -151,10 +148,6 @@ class TimerTrack : public Track {
       TimeGraph* time_graph, orbit_gl::Viewport* viewport, bool is_collapsed,
       const orbit_client_protos::TimerInfo* selected_timer, uint64_t highlighted_function_id);
 
-  TextRenderer* text_renderer_ = nullptr;
-  uint32_t depth_ = 0;
-  int visible_timer_count_ = 0;
-
   [[nodiscard]] virtual std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const;
   [[nodiscard]] std::unique_ptr<PickingUserData> CreatePickingUserData(
       const Batcher& batcher, const orbit_client_protos::TimerInfo& timer_info) {
@@ -163,7 +156,8 @@ class TimerTrack : public Track {
   }
 
   static const Color kHighlightColor;
-
+  TextRenderer* text_renderer_ = nullptr;
+  int visible_timer_count_ = 0;
   OrbitApp* app_ = nullptr;
 
   orbit_client_data::TrackData* track_data_;

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -49,7 +49,7 @@ void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           : GlCanvas::kZValueEventBar;
   event_bar_z += draw_context.z_offset;
   Color color = GetColor();
-  Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
+  Box box(pos_, Vec2(GetWidth(), -GetHeight()), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
 }
 

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -27,6 +27,9 @@ class TracepointThreadBar : public ThreadBar {
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
+  [[nodiscard]] float GetHeight() const override {
+    return layout_->GetEventTrackHeightFromTid(GetThreadId());
+  }
 
   [[nodiscard]] bool IsEmpty() const override;
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -114,6 +114,8 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContex
   Box box(Vec2(indentation_x0, y0), Vec2(label_width, -label_height), track_z);
   batcher.AddBox(box, track_background_color, shared_from_this());
 
+  Vec2 track_size = GetSize();
+
   // Draw rounded corners.
   if (!picking && draw_background_) {
     float radius = std::min(layout_->GetRoundingRadius(), half_label_height);
@@ -131,9 +133,9 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContex
     Vec2 top_left(indentation_x0, y0);
     Vec2 tab_top_right(top_left[0] + label_width, top_left[1]);
     Vec2 tab_bottom_right(top_left[0] + label_width, top_left[1] - label_height + top_margin);
-    Vec2 content_bottom_left(top_left[0] - tab_x0, top_left[1] - size_[1]);
-    Vec2 content_bottom_right(top_left[0] + size_[0], top_left[1] - size_[1]);
-    Vec2 content_top_right(top_left[0] + size_[0], top_left[1] - label_height + top_margin);
+    Vec2 content_bottom_left(top_left[0] - tab_x0, top_left[1] - track_size[1]);
+    Vec2 content_bottom_right(top_left[0] + track_size[0], top_left[1] - track_size[1]);
+    Vec2 content_top_right(top_left[0] + track_size[0], top_left[1] - label_height + top_margin);
 
     DrawTriangleFan(batcher, rounded_corner, top_left, GlCanvas::kBackgroundColor, -90.f, track_z);
     DrawTriangleFan(batcher, rounded_corner, tab_top_right, GlCanvas::kBackgroundColor, 180.f,
@@ -178,7 +180,7 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContex
   if (!picking) {
     if (layout_->GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 - label_height + top_margin),
-              Vec2(size_[0], -size_[1] + label_height - top_margin), track_z);
+              Vec2(track_size[0], -track_size[1] + label_height - top_margin), track_z);
       batcher.AddBox(box, track_background_color, shared_from_this());
     }
   }

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -205,6 +205,11 @@ float Track::DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_rendere
 void Track::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*t_min*/, uint64_t /*t_max*/,
                              PickingMode /*  picking_mode*/, float /*z_offset*/) {}
 
+void Track::SetPos(float x, float y) {
+  pos_ = Vec2(x, y);
+  UpdatePositionOfSubtracks();
+}
+
 void Track::SetPinned(bool value) { pinned_ = value; }
 
 Color Track::GetTrackBackgroundColor() const {

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -58,6 +58,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
+  void SetPos(float x, float y) override;
   void OnDrag(int x, int y) override;
 
   [[nodiscard]] virtual Type GetType() const = 0;
@@ -99,6 +100,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
                                const DrawContext& draw_context);
   void DrawTriangleFan(Batcher& batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
+  virtual void UpdatePositionOfSubtracks() {}
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -62,7 +62,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] virtual Type GetType() const = 0;
 
-  [[nodiscard]] virtual float GetHeight() const = 0;
   [[nodiscard]] bool GetVisible() const { return visible_; }
   void SetVisible(bool value) { visible_ = value; }
 

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -50,10 +50,10 @@ class TrackManager {
   void RequestTrackSorting() { sorting_invalidated_ = true; };
   void SetFilter(const std::string& filter);
 
+  [[nodiscard]] float GetVisibleTracksTotalHeight() const;
   void UpdateTracksForRendering();
   void UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                              PickingMode picking_mode);
-  [[nodiscard]] float GetVisibleTracksTotalHeight() const { return tracks_total_height_; }
 
   [[nodiscard]] std::pair<uint64_t, uint64_t> GetTracksMinMaxTimestamps() const;
 
@@ -124,7 +124,6 @@ class TrackManager {
   std::string filter_;
   std::vector<Track*> visible_tracks_;
 
-  float tracks_total_height_ = 0.0f;
   orbit_client_data::CaptureData* capture_data_ = nullptr;
 
   OrbitApp* app_ = nullptr;

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -53,7 +53,7 @@ class TrackManager {
   void UpdateTracksForRendering();
   void UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                              PickingMode picking_mode);
-  [[nodiscard]] float GetTracksTotalHeight() const { return tracks_total_height_; }
+  [[nodiscard]] float GetVisibleTracksTotalHeight() const { return tracks_total_height_; }
 
   [[nodiscard]] std::pair<uint64_t, uint64_t> GetTracksMinMaxTimestamps() const;
 

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -114,6 +114,7 @@ TEST_F(TrackManagerTest, FiltersAndTrackTypeVisibilityWorkTogether) {
   EXPECT_EQ(kNumThreadTracks, track_manager_.GetVisibleTracks().size());
 
   track_manager_.SetFilter("");
+  track_manager_.UpdateTracksForRendering();
   EXPECT_EQ(kNumTracks, track_manager_.GetVisibleTracks().size());
 
   track_manager_.SetFilter("thread");

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -35,7 +35,8 @@ void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
 
   // Set the size such that the triangle toggle can be selected in the E2E test.
   float size = layout_->GetCollapseButtonSize(draw_context.indentation_level);
-  SetSize(size, size);
+  SetWidth(size);
+  SetHeight(size);
 
   // Draw triangle.
   static float half_sqrt_three = 0.5f * sqrtf(3.f);

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -31,6 +31,9 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const DrawContext& draw_context) override;
 
+  [[nodiscard]] float GetHeight() const override { return height_; }
+  void SetHeight(float height) { height_ = height; }
+
   // Pickable
   void OnRelease() override;
 
@@ -48,6 +51,7 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   // We require explicit knowledge about the parent.
   Track* track_;
 
+  float height_;
   bool is_collapsed_ = false;
   bool is_collapsible_ = true;
 


### PR DESCRIPTION
In this PR we are:

- Moving depth_ calculation to TrackData (last step for http://b/194504762).

- Unifying Track::GetHeight and GetSize (http://b/184245377)
Before this commit, we used to have both methods and we needed to sync
them before every draw call. Now, GetSize returns a pair of width and
height using GetHeight().

In addition, SetWidth/SetPos now also set width of each children in Gpu,
ThreadTrack and PageFaultTrack. In a future PR, we will want to make this generic.

There were a few bug related with the syncing, a current one is
(http://b/196198708) about VerticalZoom and Collapsing/Expanding Tracks.

- Reverting the hack for drawing twice when needed (viewport_was_dirty -
#2209). Not needed anymore.

- Splitting GetSize/GetPos with drawing methods. First update, after draw.
(http://b/187502610).

- Moving right_margin from TimeGraph to CaptureWindows.
(http://b/192070555). Also simplify how we update it.

- Refactor in TrackManager/CaptureWindows (we had several issues here with
visible_tracks). This is motivated with the long list of problems here.
Now we have a clear order with sorting the tracks and update the visible
track list. Every function ask and it is updated in the first step
before starting to draw neither calculating positions.

- Fix a test in TrackManager

Plus several small things listed in the third commit.

Test: running capture, loaded capture.

As a future plan we will want:
- Generalize SetWidth/SetPos to include childrens (with the future interface of
tracks and panes).
