### PR TITLE
Send function information in manual instrumentation.

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -35,13 +35,17 @@ void EnqueueApiEvent(Types... args) {
 extern "C" {
 
 void orbit_api_start(const char* name, orbit_api_color color) {
-  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color);
+  auto return_address =
+      absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
+  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, 0LU /*group_id*/, return_address);
 }
 
 void orbit_api_stop() { EnqueueApiEvent<orbit_api::ApiScopeStop>(); }
 
 void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
-  EnqueueApiEvent<orbit_api::ApiScopeStartAsync>(name, id, color);
+  auto return_address =
+      absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
+  EnqueueApiEvent<orbit_api::ApiScopeStartAsync>(name, id, color, return_address);
 }
 
 void orbit_api_stop_async(uint64_t id) { EnqueueApiEvent<orbit_api::ApiScopeStopAsync>(id); }

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -35,6 +35,10 @@ void EnqueueApiEvent(Types... args) {
 extern "C" {
 
 void orbit_api_start(const char* name, orbit_api_color color) {
+  // `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
+  // current function (level "0" refers to this frame, "1" would be the callers return address and
+  // so on).
+  // To decode the return address, we call `__builtin_extract_return_addr`.
   auto return_address =
       absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
   EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, 0LU /*group_id*/, return_address);
@@ -43,6 +47,10 @@ void orbit_api_start(const char* name, orbit_api_color color) {
 void orbit_api_stop() { EnqueueApiEvent<orbit_api::ApiScopeStop>(); }
 
 void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
+  // `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
+  // current function (level "0" refers to this frame, "1" would be the callers return address and
+  // so on).
+  // To decode the return address, we call `__builtin_extract_return_addr`.
   auto return_address =
       absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
   EnqueueApiEvent<orbit_api::ApiScopeStartAsync>(name, id, color, return_address);

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -64,7 +64,7 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
     if (function != nullptr) {
       function_name = function->pretty_name();
     }
-    const orbit_client_protos::ModuleInfo* module =
+    const orbit_client_data::ModuleData* module =
         capture_data_->FindModuleByAddress(timer_info->address_in_function());
     if (module != nullptr) {
       module_name = module->name();

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -59,12 +59,13 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
       capture_data_->GetFunctionNameByAddress(timer_info->address_in_function());
 
   if (timer_info->address_in_function() != 0) {
-    const auto* function =
+    const orbit_client_protos::FunctionInfo* function =
         capture_data_->FindFunctionByAddress(timer_info->address_in_function(), false);
     if (function != nullptr) {
       function_name = function->pretty_name();
     }
-    const auto* module = capture_data_->FindModuleByAddress(timer_info->address_in_function());
+    const orbit_client_protos::ModuleInfo* module =
+        capture_data_->FindModuleByAddress(timer_info->address_in_function());
     if (module != nullptr) {
       module_name = module->name();
     }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -120,7 +120,7 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
   const InstrumentedFunction* func =
       capture_data_->GetInstrumentedFunctionById(timer_info->function_id());
 
-  std::string function_name;
+  std::string label;
   bool is_manual = timer_info->type() == TimerInfo::kApiScope;
 
   if (func == nullptr && !is_manual) {
@@ -128,23 +128,33 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
   }
 
   if (is_manual) {
-    function_name = timer_info->api_scope_name();
+    label = timer_info->api_scope_name();
   } else {
-    function_name = func->function_name();
+    label = func->function_name();
   }
 
-  std::string module_name =
-      func != nullptr
-          ? orbit_client_data::function_utils::GetLoadedModuleNameByPath(func->file_path())
-          : "unknown";
+  std::string module_name = orbit_client_data::CaptureData::kUnknownFunctionOrModuleName;
+  std::string function_name = orbit_client_data::CaptureData::kUnknownFunctionOrModuleName;
+  if (func != nullptr) {
+    module_name = orbit_client_data::function_utils::GetLoadedModuleNameByPath(func->file_path());
+    function_name = label;
+  } else if (timer_info->address_in_function() != 0) {
+    function_name = capture_data_->GetFunctionNameByAddress(timer_info->address_in_function());
+
+    const auto* module = capture_data_->FindModuleByAddress(timer_info->address_in_function());
+    if (module != nullptr) {
+      module_name = module->name();
+    }
+  }
 
   return absl::StrFormat(
       "<b>%s</b><br/>"
       "<i>Timing measured through %s instrumentation</i>"
       "<br/><br/>"
+      "<b>Function:</b> %s<br/>"
       "<b>Module:</b> %s<br/>"
       "<b>Time:</b> %s",
-      function_name, is_manual ? "manual" : "dynamic", module_name,
+      label, is_manual ? "manual" : "dynamic", function_name, module_name,
       orbit_display_formats::GetDisplayTime(
           TicksToDuration(timer_info->start(), timer_info->end())));
 }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -139,12 +139,12 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
     module_name = orbit_client_data::function_utils::GetLoadedModuleNameByPath(func->file_path());
     function_name = label;
   } else if (timer_info->address_in_function() != 0) {
-    function_name = capture_data_->GetFunctionNameByAddress(timer_info->address_in_function());
-
     const auto* module = capture_data_->FindModuleByAddress(timer_info->address_in_function());
     if (module != nullptr) {
       module_name = module->name();
     }
+
+    function_name = capture_data_->GetFunctionNameByAddress(timer_info->address_in_function());
   }
 
   return absl::StrFormat(


### PR DESCRIPTION
This collects and sends information about the function
that contains the ORBIT_* macro, by collecting the
return address of the api functions.

Screenshots:
http://screen/ofPGwSrqCLPiG9L
http://screen/6kqNLh4Sy5v5CTQ

Bug: http://b/194764259
Test: Profile OrbitTest