### PR TITLE
Coordinate systems rework

### DIFF
--- a/src/OrbitGl/AnnotationTrack.cpp
+++ b/src/OrbitGl/AnnotationTrack.cpp
@@ -19,7 +19,7 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
   Vec2 track_pos = GetAnnotatedTrackPosition();
 
   float content_right_x = track_pos[0] + track_size[0];
-  float content_bottom_y = track_pos[1] - track_size[1] + layout->GetTrackBottomMargin();
+  float content_bottom_y = track_pos[1] + track_size[1] - layout->GetTrackContentBottomMargin();
   float content_height = GetAnnotatedTrackContentHeight();
 
   // Add value upper bound text box (e.g., the "System Memory Total" text box for memory tracks).
@@ -27,10 +27,8 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     std::string text = value_upper_bound_.value().first;
     float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
     Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
-    Vec2 text_box_position(content_right_x - text_box_size[0],
-                           content_bottom_y + content_height - text_box_size[1]);
-    text_renderer.AddText(text.c_str(), text_box_position[0],
-                          text_box_position[1] + layout->GetTextOffset(), z,
+    Vec2 text_box_position(content_right_x - text_box_size[0], content_bottom_y - content_height);
+    text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z,
                           {font_size, kWhite, text_box_size[0]});
 
     if (!GetValueUpperBoundTooltip().empty()) {
@@ -47,9 +45,10 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
     Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
     Vec2 text_box_position(content_right_x - text_box_size[0], content_bottom_y);
-    text_renderer.AddText(text.c_str(), text_box_position[0],
-                          text_box_position[1] + layout->GetTextOffset(), z,
-                          {font_size, kWhite, text_box_size[0]});
+
+    TextRenderer::TextFormatting formatting{font_size, kWhite, text_box_size[0]};
+    formatting.valign = TextRenderer::VAlign::Bottom;
+    text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z, formatting);
   }
 
   // Add warning threshold text box and line.
@@ -67,13 +66,12 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
     Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
     Vec2 text_box_position(track_pos[0] + layout->GetRightMargin(), y - text_box_size[1] / 2.f);
-    text_renderer.AddText(text.c_str(), text_box_position[0],
-                          text_box_position[1] + layout->GetTextOffset(), z,
+    text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z,
                           {font_size, kThresholdColor, text_box_size[0]});
 
     Vec2 from(track_pos[0], y);
     Vec2 to(track_pos[0] + track_size[0], y);
     batcher.AddLine(from, from + Vec2(layout->GetRightMargin() / 2.f, 0), z, kThresholdColor);
-    batcher.AddLine(Vec2(text_box_position[0] + text_box_size[0], y), to, z, kThresholdColor);
+    batcher.AddLine(Vec2(text_box_position[0] - text_box_size[0], y), to, z, kThresholdColor);
   }
 }

--- a/src/OrbitGl/AnnotationTrack.cpp
+++ b/src/OrbitGl/AnnotationTrack.cpp
@@ -30,8 +30,8 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     Vec2 text_box_position(content_right_x - text_box_size[0],
                            content_bottom_y + content_height - text_box_size[1]);
     text_renderer.AddText(text.c_str(), text_box_position[0],
-                          text_box_position[1] + layout->GetTextOffset(), z, kWhite, font_size,
-                          text_box_size[0]);
+                          text_box_position[1] + layout->GetTextOffset(), z,
+                          {font_size, kWhite, text_box_size[0]});
 
     if (!GetValueUpperBoundTooltip().empty()) {
       auto user_data = std::make_unique<PickingUserData>(
@@ -48,8 +48,8 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
     Vec2 text_box_position(content_right_x - text_box_size[0], content_bottom_y);
     text_renderer.AddText(text.c_str(), text_box_position[0],
-                          text_box_position[1] + layout->GetTextOffset(), z, kWhite, font_size,
-                          text_box_size[0]);
+                          text_box_position[1] + layout->GetTextOffset(), z,
+                          {font_size, kWhite, text_box_size[0]});
   }
 
   // Add warning threshold text box and line.
@@ -68,8 +68,8 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
     Vec2 text_box_position(track_pos[0] + layout->GetRightMargin(), y - text_box_size[1] / 2.f);
     text_renderer.AddText(text.c_str(), text_box_position[0],
-                          text_box_position[1] + layout->GetTextOffset(), z, kThresholdColor,
-                          font_size, text_box_size[0]);
+                          text_box_position[1] + layout->GetTextOffset(), z,
+                          {font_size, kThresholdColor, text_box_size[0]});
 
     Vec2 from(track_pos[0], y);
     Vec2 to(track_pos[0] + track_size[0], y);

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -93,7 +93,7 @@ void BasicPageFaultsTrack::DrawSingleSeriesEntry(
   float x0 = time_graph_->GetWorldFromTick(start_tick);
   float width = time_graph_->GetWorldFromTick(end_tick) - x0;
   float content_height = GetGraphContentHeight();
-  float y0 = pos_[1] - GetHeight() + layout_->GetTrackBottomMargin();
+  float y0 = GetGraphContentBottomY() - GetGraphContentHeight();
   batcher->AddShadedBox(Vec2(x0, y0), Vec2(width, content_height), z, kHightlightingColor);
 }
 

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -117,6 +117,9 @@ class Batcher {
   Batcher(const Batcher&) = delete;
   Batcher(Batcher&&) = delete;
 
+  void PushTranslation(float x, float y, float z = 0.f);
+  void PopTranslation();
+
   void AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
@@ -157,7 +160,7 @@ class Batcher {
   void AddTriangle(const Triangle& triangle, const Color& color,
                    std::shared_ptr<Pickable> pickable);
 
-  void AddCircle(Vec2 position, float radius, float z, Color color);
+  void AddCircle(const Vec2& position, float radius, float z, Color color);
   [[nodiscard]] std::vector<float> GetLayers() const;
   void DrawLayer(float layer, bool picking = false) const;
   virtual void Draw(bool picking = false) const;
@@ -193,6 +196,8 @@ class Batcher {
                    const Color& picking_color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
 
+  [[nodiscard]] Vec3 TransformVertex(const Vec3 input) const;
+
   BatcherId batcher_id_;
   PickingManager* picking_manager_;
   std::unordered_map<float, PrimitiveBuffers> primitive_buffers_by_layer_;
@@ -200,6 +205,9 @@ class Batcher {
   std::vector<std::unique_ptr<PickingUserData>> user_data_;
 
   std::vector<Vec2> circle_points;
+
+  std::vector<Vec3> translation_stack_;
+  Vec3 current_translation_ = Vec3(0.f, 0.f, 0.f);
 };
 
 #endif

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -64,7 +64,7 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           : GlCanvas::kZValueEventBar;
   event_bar_z += draw_context.z_offset;
   Color color = GetColor();
-  Box box(pos_, Vec2(GetWidth(), -GetHeight()), event_bar_z);
+  Box box(pos_, Vec2(GetWidth(), GetHeight()), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
 
   if (batcher.GetPickingManager()->IsThisElementPicked(this)) {
@@ -74,7 +74,7 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
   float x0 = pos_[0];
   float y0 = pos_[1];
   float x1 = x0 + GetWidth();
-  float y1 = y0 - GetHeight();
+  float y1 = y0 + GetHeight();
 
   batcher.AddLine(pos_, Vec2(x1, y0), event_bar_z, color, shared_from_this());
   batcher.AddLine(Vec2(x1, y1), Vec2(x0, y1), event_bar_z, color, shared_from_this());
@@ -86,10 +86,10 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
     x0 = from[0];
     y0 = pos_[1];
     x1 = to[0];
-    y1 = y0 - GetHeight();
+    y1 = y0 + GetHeight();
 
     Color picked_color(0, 128, 255, 128);
-    Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, -GetHeight()),
+    Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, GetHeight()),
                    GlCanvas::kZValueUi + draw_context.z_offset);
     batcher.AddBox(picked_box, picked_color, shared_from_this());
   }
@@ -119,7 +119,7 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
           CallstackInfo::kComplete) {
         color = kGreyError;
       }
-      batcher->AddVerticalLine(pos, -track_height, z, color);
+      batcher->AddVerticalLine(pos, track_height, z, color);
     };
 
     if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
@@ -135,7 +135,7 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
     selected_color.fill(kGreenSelection);
     for (const CallstackEvent& event : time_graph_->GetSelectedCallstackEvents(GetThreadId())) {
       Vec2 pos(time_graph_->GetWorldFromTick(event.time()), pos_[1]);
-      batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection);
+      batcher->AddVerticalLine(pos, track_height, z, kGreenSelection);
     }
   } else {
     // Draw boxes instead of lines to make picking easier, even if this may
@@ -146,7 +146,7 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
     auto action_on_callstack_events = [=](const CallstackEvent& event) {
       const uint64_t time = event.time();
       CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset, pos_[1] - track_height + 1);
+      Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset, pos_[1] + track_height - 1);
       Vec2 size(kPickingBoxWidth, track_height);
       auto user_data = std::make_unique<PickingUserData>(
           nullptr,

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -233,6 +233,6 @@ void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                   kWhiteColor);
 
   text_renderer.AddText(label.c_str(), white_text_box_position[0],
-                        white_text_box_position[1] + layout_->GetTextOffset(), text_z, kWhiteColor,
-                        font_size, white_text_box_size[0]);
+                        white_text_box_position[1] + layout_->GetTextOffset(), text_z,
+                        {font_size, kWhiteColor, white_text_box_size[0]});
 }

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -46,7 +46,6 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] float GetDefaultBoxHeight() const override;
   [[nodiscard]] float GetDynamicBoxHeight(
       const orbit_client_protos::TimerInfo& timer_info) const override;
-  [[nodiscard]] float GetHeaderHeight() const override;
 
   [[nodiscard]] std::string GetTimesliceText(
       const orbit_client_protos::TimerInfo& timer) const override;

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -238,7 +238,7 @@ void GlCanvas::PrepareScreenSpaceViewport() {
   glViewport(0, 0, viewport_.GetScreenWidth(), viewport_.GetScreenHeight());
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
-  glOrtho(0, viewport_.GetScreenWidth(), 0, viewport_.GetScreenHeight(), -1, 1);
+  glOrtho(0, viewport_.GetScreenWidth(), viewport_.GetScreenHeight(), 0.f, -1, 1);
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
 }

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -126,7 +126,7 @@ void GlCanvas::MouseMoved(int x, int y, bool left, bool /*right*/, bool /*middle
   // Pan
   if (left && !picking_manager_.IsDragging()) {
     viewport_.SetWorldTopLeftX(mouse_click_pos_world_[0] - viewport_.ScreenToWorldWidth(x));
-    viewport_.SetWorldTopLeftY(mouse_click_pos_world_[1] + viewport_.ScreenToWorldHeight(y));
+    viewport_.SetWorldTopLeftY(mouse_click_pos_world_[1] - viewport_.ScreenToWorldHeight(y));
   }
 
   if (left) {
@@ -218,23 +218,17 @@ bool GlCanvas::ControlPressed() { return control_key_; }
 
 /** Inits the OpenGL viewport for drawing in 2D. */
 void GlCanvas::PrepareWorldSpaceViewport() {
-  const int top_left_x = 0, top_left_y = 0, bottom_right_x = viewport_.GetScreenWidth(),
-            bottom_right_y = viewport_.GetScreenHeight();
-  glViewport(top_left_x, top_left_y, bottom_right_x - top_left_x, bottom_right_y - top_left_y);
+  Vec2 top_left = viewport_.GetWorldTopLeft();
+  glViewport(0, 0, viewport_.GetScreenWidth(), viewport_.GetScreenHeight());
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
-
-  Vec2 top_left = viewport_.GetWorldTopLeft();
-  float width = viewport_.GetVisibleWorldWidth();
-  float height = viewport_.GetVisibleWorldHeight();
-
-  glOrtho(top_left[0], top_left[0] + width, top_left[1] - height, top_left[1], -1, 1);
+  glOrtho(top_left[0], top_left[0] + viewport_.GetScreenWidth(),
+          viewport_.GetScreenHeight() + top_left[1], top_left[1], -1, 1);
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
 }
 
 void GlCanvas::PrepareScreenSpaceViewport() {
-  ORBIT_SCOPE_FUNCTION;
   glViewport(0, 0, viewport_.GetScreenWidth(), viewport_.GetScreenHeight());
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -259,7 +259,7 @@ bool GlSlider::HandlePageScroll(float click_value) {
 }
 
 void GlVerticalSlider::Draw(Batcher& batcher, bool is_picked) {
-  float x = viewport_.GetScreenWidth() - GetPixelHeight();
+  batcher.PushTranslation(static_cast<int>(GetPos()[0]), static_cast<int>(GetPos()[1]));
 
   float bar_pixel_len = GetBarPixelLength();
   float slider_height = ceilf(length_ratio_ * bar_pixel_len);
@@ -268,12 +268,14 @@ void GlVerticalSlider::Draw(Batcher& batcher, bool is_picked) {
   const Color dark_border_color = GetDarkerColor(bar_color_);
 
   // Background
-  DrawBackground(batcher, x, GetOrthogonalSliderSize(), GetPixelHeight(), bar_pixel_len);
+  DrawBackground(batcher, 0, 0, GetPixelHeight(), bar_pixel_len);
 
-  float start = ceilf((1.0f - pos_ratio_) * non_slider_height + GetOrthogonalSliderSize());
+  float start = ceilf(pos_ratio_ * non_slider_height);
 
   ShadingDirection shading_direction = ShadingDirection::kRightToLeft;
-  DrawSlider(batcher, x, start, GetPixelHeight(), slider_height, shading_direction, is_picked);
+  DrawSlider(batcher, 0, start, GetPixelHeight(), slider_height, shading_direction, is_picked);
+
+  batcher.PopTranslation();
 }
 
 int GlVerticalSlider::GetBarPixelLength() const {
@@ -281,18 +283,18 @@ int GlVerticalSlider::GetBarPixelLength() const {
 }
 
 void GlHorizontalSlider::Draw(Batcher& batcher, bool is_picked) {
-  static float y = 0;
+  batcher.PushTranslation(static_cast<int>(GetPos()[0]), static_cast<int>(GetPos()[1]));
 
   float bar_pixel_len = GetBarPixelLength();
   float slider_width = ceilf(length_ratio_ * bar_pixel_len);
   float non_slider_width = bar_pixel_len - slider_width;
 
-  DrawBackground(batcher, 0, y, bar_pixel_len, GetPixelHeight());
+  DrawBackground(batcher, 0, 0, bar_pixel_len, GetPixelHeight());
 
   float start = floorf(pos_ratio_ * non_slider_width);
 
   ShadingDirection shading_direction = ShadingDirection::kTopToBottom;
-  DrawSlider(batcher, start, y, slider_width, GetPixelHeight(), shading_direction, is_picked);
+  DrawSlider(batcher, start, 0, slider_width, GetPixelHeight(), shading_direction, is_picked);
 
   const float kEpsilon = 0.0001f;
 
@@ -337,6 +339,8 @@ void GlHorizontalSlider::Draw(Batcher& batcher, bool is_picked) {
                            ShadingDirection::kTopToBottom);
     }
   }
+
+  batcher.PopTranslation();
 }
 
 int GlHorizontalSlider::GetBarPixelLength() const {

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -111,15 +111,15 @@ float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (collapse_toggle_->IsCollapsed()) {
     depth = 0;
   }
-  return pos_[1] - layout_->GetTrackTabHeight() - layout_->GetTextBoxHeight() * (depth + 1.f);
+  return pos_[1] + layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth;
 }
 
 float GpuDebugMarkerTrack::GetHeight() const {
   bool collapsed = collapse_toggle_->IsCollapsed();
   uint32_t depth =
       collapsed ? std::min<uint32_t>(1, track_data_->GetMaxDepth()) : track_data_->GetMaxDepth();
-  return layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth +
-         layout_->GetTrackBottomMargin();
+  return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
+         layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
 }
 
 bool GpuDebugMarkerTrack::TimerFilter(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -151,8 +151,7 @@ float GpuSubmissionTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
     adjusted_depth += 1.f;
   }
-  return pos_[1] - layout_->GetTrackTabHeight() -
-         layout_->GetTextBoxHeight() * (adjusted_depth + 1.f) - gap_space;
+  return pos_[1] + GetHeaderHeight() + layout_->GetTextBoxHeight() * adjusted_depth - gap_space;
 }
 
 // When track or its parent is collapsed, only draw "hardware execution" timers.
@@ -180,8 +179,9 @@ float GpuSubmissionTrack::GetHeight() const {
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
     depth *= 2;
   }
-  return layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth +
-         (num_gaps * layout_->GetSpaceBetweenGpuDepths()) + layout_->GetTrackBottomMargin();
+  return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
+         layout_->GetTextBoxHeight() * depth + (num_gaps * layout_->GetSpaceBetweenGpuDepths()) +
+         layout_->GetTrackContentBottomMargin();
 }
 
 const TimerInfo* GpuSubmissionTrack::GetLeft(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -87,13 +87,13 @@ void GpuTrack::UpdatePositionOfSubtracks() {
     submission_track_->SetPos(pos_[0], pos_[1]);
     return;
   }
-  float current_y = pos_[1] - layout_->GetTrackTabHeight();
+  float current_y = pos_[1] + layout_->GetTrackTabHeight();
   if (!submission_track_->IsEmpty()) {
-    current_y -= layout_->GetSpaceBetweenSubtracks();
+    current_y += layout_->GetSpaceBetweenSubtracks();
   }
   submission_track_->SetPos(pos_[0], current_y);
   if (!marker_track_->IsEmpty()) {
-    current_y -= (layout_->GetSpaceBetweenSubtracks() + submission_track_->GetHeight());
+    current_y += (layout_->GetSpaceBetweenSubtracks() + submission_track_->GetHeight());
   }
 
   marker_track_->SetPos(pos_[0], current_y);

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -169,7 +169,7 @@ void GraphTrack<Dimension>::DrawLabel(Batcher& batcher, TextRenderer& text_rende
   float label_z = GlCanvas::kZValueTrackLabel + draw_context.z_offset;
   float bottom_y_of_top_line = text_box_position[1] + text_box_size[1] - single_line_height;
   text_renderer.AddText(text.c_str(), text_box_position[0], bottom_y_of_top_line, label_z,
-                        text_color, font_size, text_box_size[0]);
+                        {font_size, text_color, text_box_size[0]});
 
   Vec2 arrow_box_position(text_box_position[0] - kTextLeftMargin,
                           text_box_position[1] - kTextBottomMargin);
@@ -213,7 +213,7 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
     Vec2 legend_text_box_position(x0, y0 - layout_->GetTextBoxHeight() / 2.f);
     text_renderer.AddText(series_names[i].c_str(), legend_text_box_position[0],
                           legend_text_box_position[1] + layout_->GetTextOffset(), text_z,
-                          legend_text_color, font_size, legend_text_box_size[0]);
+                          {font_size, legend_text_color, legend_text_box_size[0]});
     x0 += legend_text_width + kSpaceBetweenLegendEntries;
 
     auto user_data = std::make_unique<PickingUserData>(

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -65,13 +65,10 @@ class GraphTrack : public Track {
     return 1.0 / (GetGraphMaxValue() - GetGraphMinValue());
   }
 
-  [[nodiscard]] float GetGraphContentBaseY() const {
-    return pos_[1] - GetSize()[1] + layout_->GetTrackBottomMargin();
+  [[nodiscard]] float GetGraphContentBottomY() const {
+    return pos_[1] + GetSize()[1] - layout_->GetTrackContentBottomMargin();
   }
-  [[nodiscard]] float GetGraphContentHeight() const {
-    return GetSize()[1] - layout_->GetTrackTabHeight() - GetLegendHeight() -
-           layout_->GetTrackBottomMargin();
-  }
+  [[nodiscard]] float GetGraphContentHeight() const;
 
   [[nodiscard]] virtual float GetLabelYFromValues(
       const std::array<double, Dimension>& values) const;

--- a/src/OrbitGl/LineGraphTrack.cpp
+++ b/src/OrbitGl/LineGraphTrack.cpp
@@ -32,16 +32,16 @@ template <size_t Dimension>
 float LineGraphTrack<Dimension>::GetLabelYFromValues(
     const std::array<double, Dimension>& values) const {
   float content_height = this->GetGraphContentHeight();
-  float base_y = this->GetGraphContentBaseY();
+  float base_y = this->GetGraphContentBottomY();
   double min = this->GetGraphMinValue();
   double inverse_value_range = this->GetInverseOfGraphValueRange();
   std::array<float, Dimension> normalized_values =
       GetNormalizedValues(values, min, inverse_value_range);
   // The label will point to the only value.
-  if (Dimension == 1) return base_y + normalized_values[0] * content_height;
+  if (Dimension == 1) return base_y - normalized_values[0] * content_height;
 
   // The label will be centred on the track.
-  return base_y + content_height / 2.0f;
+  return base_y - content_height / 2.0f;
 }
 
 template <size_t Dimension>
@@ -98,14 +98,14 @@ void LineGraphTrack<Dimension>::DrawSingleSeriesEntry(
   float x0 = this->time_graph_->GetWorldFromTick(start_tick);
   float x1 = this->time_graph_->GetWorldFromTick(end_tick);
   float content_height = this->GetGraphContentHeight();
-  float base_y = this->GetGraphContentBaseY();
+  float base_y = this->GetGraphContentBottomY();
 
   for (size_t i = Dimension; i-- > 0;) {
-    float y0 = base_y + current_normalized_values[i] * content_height;
+    float y0 = base_y - current_normalized_values[i] * content_height;
     DrawSquareDot(batcher, Vec2(x0, y0), kDotRadius, z, this->GetColor(i));
     batcher->AddLine(Vec2(x0, y0), Vec2(x1, y0), z, this->GetColor(i));
     if (!is_last) {
-      float y1 = base_y + next_normalized_values[i] * content_height;
+      float y1 = base_y - next_normalized_values[i] * content_height;
       batcher->AddLine(Vec2(x1, y0), Vec2(x1, y1), z, this->GetColor(i));
     }
   }

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -112,14 +112,14 @@ void PageFaultsTrack::UpdatePositionOfSubtracks() {
     return;
   }
 
-  float current_y = pos_[1] - layout_->GetTrackTabHeight();
+  float current_y = pos_[1] + layout_->GetTrackTabHeight();
   if (!major_page_faults_track_->IsEmpty()) {
-    current_y -= layout_->GetSpaceBetweenSubtracks();
+    current_y += layout_->GetSpaceBetweenSubtracks();
   }
   major_page_faults_track_->SetPos(pos_[0], current_y);
 
   if (!minor_page_faults_track_->IsEmpty()) {
-    current_y -= (layout_->GetSpaceBetweenSubtracks() + major_page_faults_track_->GetHeight());
+    current_y += (layout_->GetSpaceBetweenSubtracks() + major_page_faults_track_->GetHeight());
   }
   minor_page_faults_track_->SetPos(pos_[0], current_y);
 }

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -41,7 +41,7 @@ void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 float SchedulerTrack::GetHeight() const {
   uint32_t num_gaps = std::max(track_data_->GetMaxDepth() - 1, 0u);
   return GetHeaderHeight() + (track_data_->GetMaxDepth() * layout_->GetTextCoresHeight()) +
-         (num_gaps * layout_->GetSpaceBetweenCores()) + layout_->GetTrackBottomMargin();
+         (num_gaps * layout_->GetSpaceBetweenCores()) + layout_->GetTrackContentBottomMargin();
 }
 
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
@@ -70,8 +70,8 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
 
 float SchedulerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   uint32_t num_gaps = timer_info.depth();
-  return pos_[1] - GetHeaderHeight() -
-         (layout_->GetTextCoresHeight() * static_cast<float>(timer_info.depth() + 1)) -
+  return pos_[1] + GetHeaderHeight() +
+         (layout_->GetTextCoresHeight() * static_cast<float>(timer_info.depth())) +
          num_gaps * layout_->GetSpaceBetweenCores();
 }
 

--- a/src/OrbitGl/TextRenderer.cpp
+++ b/src/OrbitGl/TextRenderer.cpp
@@ -25,11 +25,25 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 
+namespace {
+
 struct vertex_t {
   float x, y, z;     // position
   float s, t;        // texture
   float r, g, b, a;  // color
 };
+
+int GetStringLineCount(const char* string) {
+  int result = 1;
+  for (size_t i = 0; i < strlen(string); ++i) {
+    if (string[i] == '\n') {
+      ++result;
+    }
+  }
+  return result;
+}
+
+}  // namespace
 
 bool TextRenderer::draw_outline_ = false;
 
@@ -208,15 +222,18 @@ void TextRenderer::DrawOutline(Batcher* batcher, ftgl::vertex_buffer_t* vertex_b
   }
 }
 
-void TextRenderer::AddTextInternal(ftgl::texture_font_t* font, const char* text,
-                                   const ftgl::vec4& color, ftgl::vec2* pen, float max_size,
-                                   float z, ftgl::vec2* out_text_pos, ftgl::vec2* out_text_size) {
+void TextRenderer::AddTextInternal(const char* text, ftgl::vec2* pen,
+                                   const TextFormatting& formatting, float z,
+                                   ftgl::vec2* out_text_pos, ftgl::vec2* out_text_size) {
+  ftgl::texture_font_t* font = GetFont(formatting.font_size);
+  ftgl::vec4 color = ColorToVec4(formatting.color);
   float r = color.red;
   float g = color.green;
   float b = color.blue;
   float a = color.alpha;
 
-  float max_width = max_size == -1.f ? FLT_MAX : ToScreenSpace(max_size);
+  float max_width =
+      formatting.max_size == -1.f ? FLT_MAX : viewport_->WorldToScreenWidth(formatting.max_size);
   float str_width = 0.f;
   float min_x = FLT_MAX;
   float max_x = -FLT_MAX;
@@ -228,7 +245,7 @@ void TextRenderer::AddTextInternal(ftgl::texture_font_t* font, const char* text,
   for (size_t i = 0; i < strlen(text); ++i) {
     if (text[i] == '\n') {
       pen->x = initial_pen.x;
-      pen->y -= font->height;
+      pen->y += font->height;
       continue;
     }
 
@@ -238,9 +255,9 @@ void TextRenderer::AddTextInternal(ftgl::texture_font_t* font, const char* text,
       pen->x += kerning;
 
       float x0 = floorf(pen->x + glyph->offset_x);
-      float y0 = floorf(pen->y + glyph->offset_y);
+      float y0 = floorf(pen->y - glyph->offset_y);
       float x1 = floorf(x0 + glyph->width);
-      float y1 = floorf(y0 - glyph->height);
+      float y1 = floorf(y0 + glyph->height);
 
       float s0 = glyph->s0;
       float t0 = glyph->t0;
@@ -254,8 +271,8 @@ void TextRenderer::AddTextInternal(ftgl::texture_font_t* font, const char* text,
 
       min_x = std::min(min_x, x0);
       max_x = std::max(max_x, x1);
-      min_y = std::min(min_y, y1);
-      max_y = std::max(max_y, y0);
+      min_y = std::min(min_y, y0);
+      max_y = std::max(max_y, y1);
 
       str_width = max_x - min_x;
 
@@ -281,27 +298,45 @@ void TextRenderer::AddTextInternal(ftgl::texture_font_t* font, const char* text,
   }
 }
 
-void TextRenderer::AddText(const char* text, float x, float y, float z, const Color& color,
-                           uint32_t font_size, float max_size, bool right_justified,
+void TextRenderer::AddText(const char* text, float x, float y, float z, TextFormatting formatting,
                            Vec2* out_text_pos, Vec2* out_text_size) {
-  if (!font_size) return;
-  ToScreenSpace(x, y, pen_.x, pen_.y);
+  Vec2i pen_pos = viewport_->WorldToScreenPos(Vec2(x, y));
+  pen_.x = pen_pos[0];
+  pen_.y = pen_pos[1];
 
-  if (right_justified) {
-    max_size = FLT_MAX;
-    int string_width = GetStringWidthScreenSpace(text, font_size);
-    pen_.x -= string_width;
+  if (formatting.halign == HAlign::Right) {
+    int string_width = GetStringWidthScreenSpace(text, formatting.font_size);
+    pen_.x -= std::min(static_cast<float>(string_width),
+                       formatting.max_size > 0 ? formatting.max_size : FLT_MAX);
   }
 
   ftgl::vec2 out_screen_pos;
   ftgl::vec2 out_screen_size;
-  AddTextInternal(GetFont(font_size), text, ColorToVec4(color), &pen_, max_size, z, &out_screen_pos,
-                  &out_screen_size);
+  ftgl::texture_font_t* font = GetFont(formatting.font_size);
+  if (font == nullptr) {
+    return;
+  }
+
+  int line_count = GetStringLineCount(text);
+  int first_line_height = GetStringHeightScreenSpace(text, formatting.font_size);
+  float total_height = line_count == 1 ? first_line_height : font->height * line_count;
+
+  switch (formatting.valign) {
+    case VAlign::Top:
+      pen_.y += GetStringHeightScreenSpace(text, formatting.font_size);
+      break;
+    case VAlign::Bottom:
+      pen_.y = pen_.y + total_height - first_line_height;
+      break;
+    case VAlign::Middle:
+      pen_.y += total_height / 2;
+      break;
+  }
+  AddTextInternal(text, &pen_, formatting, z, &out_screen_pos, &out_screen_size);
 
   if (out_text_pos) {
-    float inv_y = viewport_->GetScreenHeight() - out_screen_pos.y;
     (*out_text_pos) = viewport_->ScreenToWorldPos(
-        Vec2i(static_cast<int>(out_screen_pos.x), static_cast<int>(inv_y)));
+        Vec2i(static_cast<int>(out_screen_pos.x), static_cast<int>(out_screen_pos.y)));
   }
 
   if (out_text_size) {
@@ -311,21 +346,21 @@ void TextRenderer::AddText(const char* text, float x, float y, float z, const Co
 }
 
 float TextRenderer::AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
-                                                    const Color& color,
-                                                    size_t trailing_chars_length,
-                                                    uint32_t font_size, float max_size) {
+                                                    TextFormatting formatting,
+                                                    size_t trailing_chars_length) {
   if (!initialized_) {
     Init();
   }
 
-  float temp_pen_x = ToScreenSpace(x);
-  float max_width = max_size == -1.f ? FLT_MAX : ToScreenSpace(max_size);
+  float temp_pen_x = viewport_->WorldToScreenPos(Vec2(x, y))[0];
+  float max_width =
+      formatting.max_size == -1.f ? FLT_MAX : viewport_->WorldToScreenWidth(formatting.max_size);
   float string_width = 0.f;
   int min_x = INT_MAX;
   int max_x = -INT_MAX;
 
   const size_t text_length = strlen(text);
-  ftgl::texture_font_t* font = GetFont(font_size);
+  ftgl::texture_font_t* font = GetFont(formatting.font_size);
   size_t i;
   for (i = 0; i < text_length; ++i) {
     ftgl::texture_glyph_t* glyph = MaybeLoadAndGetGlyph(font, text + i);
@@ -364,8 +399,8 @@ float TextRenderer::AddTextTrailingCharsPrioritized(const char* text, float x, f
                            (fitting_chars_count > (trailing_chars_length + kEllipsisBufferSize));
 
   if (!use_ellipsis_text) {
-    AddText(text, x, y, z, color, font_size, max_size);
-    return GetStringWidth(text, font_size);
+    AddText(text, x, y, z, formatting);
+    return GetStringWidth(text, formatting.font_size);
   }
 
   auto leading_char_count = fitting_chars_count - (trailing_chars_length + kEllipsisTextLen);
@@ -376,8 +411,8 @@ float TextRenderer::AddTextTrailingCharsPrioritized(const char* text, float x, f
   auto time_position = text_length - trailing_chars_length;
   modified_text.append(&text[time_position], trailing_chars_length);
 
-  AddText(modified_text.c_str(), x, y, z, color, font_size, max_size);
-  return GetStringWidth(modified_text.c_str(), font_size);
+  AddText(modified_text.c_str(), x, y, z, formatting);
+  return GetStringWidth(modified_text.c_str(), formatting.font_size);
 }
 
 float TextRenderer::GetStringWidth(const char* text, uint32_t font_size) {
@@ -434,20 +469,6 @@ std::vector<float> TextRenderer::GetLayers() const {
   }
   return layers;
 };
-
-void TextRenderer::ToScreenSpace(float x, float y, float& o_x, float& o_y) {
-  float world_width = viewport_->GetVisibleWorldWidth();
-  float world_height = viewport_->GetVisibleWorldHeight();
-  float world_top_left_x = viewport_->GetWorldTopLeft()[0];
-  float world_min_left_y = viewport_->GetWorldTopLeft()[1] - world_height;
-
-  o_x = ((x - world_top_left_x) / world_width) * viewport_->GetScreenWidth();
-  o_y = ((y - world_min_left_y) / world_height) * viewport_->GetScreenHeight();
-}
-
-float TextRenderer::ToScreenSpace(float width) {
-  return (width / viewport_->GetVisibleWorldWidth()) * viewport_->GetScreenWidth();
-}
 
 void TextRenderer::Clear() {
   pen_.x = 0.f;

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -30,6 +30,17 @@ struct texture_font_t;
 
 class TextRenderer {
  public:
+  enum class HAlign { Left, Right };
+  enum class VAlign { Top, Middle, Bottom };
+
+  struct TextFormatting {
+    uint32_t font_size = 14;
+    Color color = Color(255, 255, 255, 255);
+    float max_size = -1.f;
+    HAlign halign = HAlign::Left;
+    VAlign valign = VAlign::Top;
+  };
+
   explicit TextRenderer();
   ~TextRenderer();
 
@@ -41,13 +52,11 @@ class TextRenderer {
   void RenderDebug(Batcher* batcher);
   [[nodiscard]] std::vector<float> GetLayers() const;
 
-  void AddText(const char* text, float x, float y, float z, const Color& color, uint32_t font_size,
-               float max_size = -1.f, bool right_justified = false, Vec2* out_text_pos = nullptr,
-               Vec2* out_text_size = nullptr);
+  void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
+               Vec2* out_text_pos = nullptr, Vec2* out_text_size = nullptr);
 
   float AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
-                                        const Color& color, size_t trailing_chars_length,
-                                        uint32_t font_size, float max_size);
+                                        TextFormatting formatting, size_t trailing_chars_length);
 
   [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size);
   [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size);
@@ -55,12 +64,9 @@ class TextRenderer {
   static void SetDrawOutline(bool value) { draw_outline_ = value; }
 
  protected:
-  void AddTextInternal(ftgl::texture_font_t* font, const char* text, const ftgl::vec4& color,
-                       ftgl::vec2* pen, float max_size = -1.f, float z = -0.01f,
+  void AddTextInternal(const char* text, ftgl::vec2* pen, const TextFormatting& formatting, float z,
                        ftgl::vec2* out_text_pos = nullptr, ftgl::vec2* out_text_size = nullptr);
 
-  void ToScreenSpace(float x, float y, float& o_x, float& o_y);
-  [[nodiscard]] float ToScreenSpace(float width);
   [[nodiscard]] int GetStringWidthScreenSpace(const char* text, uint32_t font_size);
   [[nodiscard]] int GetStringHeightScreenSpace(const char* text, uint32_t font_size);
   [[nodiscard]] ftgl::texture_font_t* GetFont(uint32_t size);

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -49,7 +49,7 @@ void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
   thread_state_bar_z += draw_context.z_offset;
 
   // Draw a transparent track just for clicking.
-  Box box(pos_, Vec2(GetWidth(), -GetHeight()), thread_state_bar_z);
+  Box box(pos_, Vec2(GetWidth(), GetHeight()), thread_state_bar_z);
   static const Color kTransparent{0, 0, 0, 0};
   batcher.AddBox(box, kTransparent, shared_from_this());
 }
@@ -188,7 +188,7 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
         const float width = x1 - x0;
 
         const Vec2 pos{x0, pos_[1]};
-        const Vec2 size{width, -GetHeight()};
+        const Vec2 size{width, GetHeight()};
 
         const Color color = GetThreadStateColor(slice.thread_state());
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -247,16 +247,16 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   const float event_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
 
-  float current_y = pos_[1] - layout_->GetTrackTabHeight();
+  float current_y = pos_[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
 
   thread_state_bar_->SetPos(pos_[0], current_y);
   if (!thread_state_bar_->IsEmpty()) {
-    current_y -= (space_between_subtracks + thread_state_track_height);
+    current_y += (space_between_subtracks + thread_state_track_height);
   }
 
   event_bar_->SetPos(pos_[0], current_y);
   if (!event_bar_->IsEmpty()) {
-    current_y -= (space_between_subtracks + event_track_height);
+    current_y += (space_between_subtracks + event_track_height);
   }
 
   tracepoint_bar_->SetPos(pos_[0], current_y);
@@ -341,7 +341,7 @@ float ThreadTrack::GetHeight() const {
       (depth > 0);
   return GetHeaderHeight() +
          (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
-         layout_->GetTextBoxHeight() * depth + layout_->GetTrackBottomMargin();
+         layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
 }
 
 // TODO(b/176216022): Make a general interface for capture view elements for setting the width to
@@ -359,7 +359,7 @@ float ThreadTrack::GetHeaderHeight() const {
   const float tracepoint_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
 
-  float header_height = layout_->GetTrackTabHeight();
+  float header_height = layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
   int track_count = 0;
   if (!thread_state_bar_->IsEmpty()) {
     header_height += thread_state_track_height;
@@ -383,9 +383,9 @@ float ThreadTrack::GetHeaderHeight() const {
 float ThreadTrack::GetYFromDepth(uint32_t depth) const {
   bool gap_between_tracks_and_timers =
       !thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty();
-  return pos_[1] - GetHeaderHeight() -
-         (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) -
-         GetDefaultBoxHeight() * static_cast<float>(depth + 1);
+  return pos_[1] + GetHeaderHeight() +
+         (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
+         GetDefaultBoxHeight() * static_cast<float>(depth);
 }
 
 void ThreadTrack::OnTimer(const TimerInfo& timer_info) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -627,8 +627,8 @@ void TimeGraph::DrawIteratorBox(Batcher& batcher, TextRenderer& text_renderer, V
 
   const Color kBlack(0, 0, 0, 255);
   float text_width = text_renderer.AddTextTrailingCharsPrioritized(
-      text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueTextUi, kBlack,
-      time.length(), GetLayout().GetFontSize(), max_size);
+      text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueTextUi,
+      {GetLayout().GetFontSize(), kBlack, max_size}, time.length());
 
   Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), GetTextBoxHeight());
   Vec2 white_box_position(pos[0], text_box_y);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -684,13 +684,13 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
     Vec2 pos(world_timer_x, world_start_y);
     x_coords.push_back(pos[0]);
 
-    batcher.AddVerticalLine(pos, -world_height, GlCanvas::kZValueOverlay,
+    batcher.AddVerticalLine(pos, world_height, GlCanvas::kZValueOverlay,
                             GetThreadColor(timer_info->thread_id()));
   }
 
   // Draw timers with timings between iterators.
   for (size_t k = 1; k < timers.size(); ++k) {
-    Vec2 pos(x_coords[k - 1], world_start_y - world_height);
+    Vec2 pos(x_coords[k - 1], world_start_y);
     float size_x = x_coords[k] - pos[0];
     Vec2 size(size_x, world_height);
     Color color = GetIteratorBoxColor(k - 1);
@@ -720,7 +720,8 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
     // / 2.f), corresponding to the case k == 0 in the formula for 'text_y'.
     float height_per_text = ((world_height / 2.f) - bottom_margin) /
                             static_cast<float>(iterator_timer_info_.size() - 1);
-    float text_y = pos[1] + (world_height / 2.f) - static_cast<float>(k) * height_per_text;
+    float text_y = pos[1] + (world_height / 2.f) + static_cast<float>(k) * height_per_text -
+                   layout_.GetTextBoxHeight();
 
     DrawIteratorBox(batcher, text_renderer, pos, size, color, label, time, text_y);
   }
@@ -730,7 +731,7 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
   if (timers.size() > 2) {
     size_t last_index = timers.size() - 1;
 
-    Vec2 pos(x_coords[0], world_start_y - world_height);
+    Vec2 pos(x_coords[0], world_start_y);
     float size_x = x_coords[last_index] - pos[0];
     Vec2 size(size_x, world_height);
 
@@ -790,7 +791,7 @@ void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode pickin
   // Actually draw the ranges.
   for (const auto& [start_x, end_x] : x_ranges) {
     const Vec2 pos{start_x, world_start_y};
-    const Vec2 size{end_x - start_x, -world_height};
+    const Vec2 size{end_x - start_x, world_height};
     float z_value = GlCanvas::kZValueIncompleteDataOverlay;
 
     std::unique_ptr<PickingUserData> user_data = nullptr;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -234,9 +234,9 @@ void TimeGraph::VerticallyMoveIntoView(Track& track) {
   float height = track.GetHeight();
   float world_top_left_y = viewport_->GetWorldTopLeft()[1];
 
-  float min_world_top_left_y = pos;
-  float max_world_top_left_y =
-      pos + viewport_->GetVisibleWorldHeight() - height - layout_.GetBottomMargin();
+  float max_world_top_left_y = pos;
+  float min_world_top_left_y =
+      pos + height - viewport_->GetVisibleWorldHeight() + layout_.GetBottomMargin();
   viewport_->SetWorldTopLeftY(
       std::clamp(world_top_left_y, min_world_top_left_y, max_world_top_left_y));
 }
@@ -535,7 +535,7 @@ void TimeGraph::UpdateTracksPosition() {
   // Track height including space between them
   for (auto& track : track_manager_->GetVisibleTracks()) {
     if (!track->IsMoving()) {
-      track->SetPos(track_pos_x, -current_y);
+      track->SetPos(track_pos_x, current_y);
     }
     track->SetWidth(GetWidth());
     current_y += (track->GetHeight() + layout_.GetSpaceBetweenTracks());

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -15,8 +15,8 @@ TimeGraphLayout::TimeGraphLayout() {
   event_track_height_ = 10.f;
   all_threads_event_track_scale_ = 2.f;
   variable_track_height_ = 20.f;
-  track_bottom_margin_ = 5.f;
-  track_top_margin_ = 5.f;
+  track_content_bottom_margin_ = 5.f;
+  track_content_top_margin_ = 5.f;
   space_between_cores_ = 2.f;
   space_between_gpu_depths_ = 2.f;
   space_between_tracks_ = 10.f;
@@ -26,7 +26,7 @@ TimeGraphLayout::TimeGraphLayout() {
   track_label_offset_x_ = 30.f;
   slider_width_ = 15.f;
   track_tab_width_ = 350.f;
-  track_tab_height_ = 30.f;
+  track_tab_height_ = 25.f;
   track_tab_offset_ = 0.f;
   track_intent_offset_ = 5.f;
   collapse_button_offset_ = 15.f;
@@ -80,8 +80,8 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(right_margin_);
   FLOAT_SLIDER(scheduler_track_offset_);
   FLOAT_SLIDER_MIN_MAX(track_tab_width_, 0, 1000.f);
-  FLOAT_SLIDER_MIN_MAX(track_bottom_margin_, 0, 20.f);
-  FLOAT_SLIDER_MIN_MAX(track_top_margin_, 0, 20.f);
+  FLOAT_SLIDER_MIN_MAX(track_content_bottom_margin_, 0, 20.f);
+  FLOAT_SLIDER_MIN_MAX(track_content_top_margin_, 0, 20.f);
   FLOAT_SLIDER(toolbar_icon_height_);
   FLOAT_SLIDER(generic_fixed_spacer_width_);
   FLOAT_SLIDER_MIN_MAX(scale_, kMinScale, kMaxScale);

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -24,8 +24,8 @@ class TimeGraphLayout {
   float GetThreadStateTrackHeight() const { return thread_state_track_height_ * scale_; }
   float GetEventTrackHeightFromTid(int32_t tid = orbit_base::kInvalidThreadTid) const;
   float GetVariableTrackHeight() const { return variable_track_height_ * scale_; }
-  float GetTrackBottomMargin() const { return track_bottom_margin_ * scale_; }
-  float GetTrackTopMargin() const { return track_top_margin_ * scale_; }
+  float GetTrackContentBottomMargin() const { return track_content_bottom_margin_ * scale_; }
+  float GetTrackContentTopMargin() const { return track_content_top_margin_ * scale_; }
   float GetTrackLabelOffsetX() const { return track_label_offset_x_; }
   float GetSliderWidth() const { return slider_width_; }
   float GetTimeBarHeight() const { return time_bar_height_; }
@@ -66,8 +66,8 @@ class TimeGraphLayout {
   float event_track_height_;
   float all_threads_event_track_scale_;
   float variable_track_height_;
-  float track_bottom_margin_;
-  float track_top_margin_;
+  float track_content_bottom_margin_;
+  float track_content_top_margin_;
   float track_label_offset_x_;
   float slider_width_;
   float time_bar_height_;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -93,8 +93,8 @@ void TimerTrack::DrawTimesliceText(const orbit_client_protos::TimerInfo& timer, 
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       timeslice_text.c_str(), pos_x, box_pos[1] + layout_->GetTextOffset(),
-      GlCanvas::kZValueBox + z_offset, kTextWhite, elapsed_time_length,
-      layout_->CalculateZoomedFontSize(), max_size);
+      GlCanvas::kZValueBox + z_offset, {layout_->CalculateZoomedFontSize(), kTextWhite, max_size},
+      elapsed_time_length);
 }
 
 bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* next_timer_info,

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -172,8 +172,8 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContex
 
     text_renderer.AddTextTrailingCharsPrioritized(
         GetLabel().c_str(), indentation_x0 + label_offset_x, toggle_y_pos - label_offset_y, text_z,
-        kColor, GetNumberOfPrioritizedTrailingCharacters(), font_size,
-        label_width - label_offset_x);
+        {font_size, kColor, label_width - label_offset_x},
+        GetNumberOfPrioritizedTrailingCharacters());
   }
 
   // Draw track's content background.

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -95,9 +95,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
  protected:
-  // Returns the y-position of the triangle.
-  float DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
-                               const DrawContext& draw_context);
+  void DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
+                              const DrawContext& draw_context);
   void DrawTriangleFan(Batcher& batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
   virtual void UpdatePositionOfSubtracks() {}

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -268,7 +268,7 @@ void TrackManager::UpdateMovingTrackPositionInVisibleTracks() {
 
     int moving_track_current_position = -1;
     for (auto track_it = visible_tracks_.begin(); track_it != visible_tracks_.end(); ++track_it) {
-      if (moving_track->GetPos()[1] >= (*track_it)->GetPos()[1]) {
+      if (moving_track->GetPos()[1] <= (*track_it)->GetPos()[1]) {
         auto inserted_it = visible_tracks_.insert(track_it, moving_track);
         moving_track_current_position = inserted_it - visible_tracks_.begin();
         break;

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -51,8 +51,8 @@ void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
       triangle = Triangle(position + Vec3(-half_h, half_w, z), position + Vec3(-half_h, -half_w, z),
                           position + Vec3(half_w, 0.f, z));
     } else {
-      triangle = Triangle(position + Vec3(half_w, half_h, z), position + Vec3(-half_w, half_h, z),
-                          position + Vec3(0.f, -half_w, z));
+      triangle = Triangle(position + Vec3(half_w, -half_h, z), position + Vec3(-half_w, -half_h, z),
+                          position + Vec3(0.f, half_w, z));
     }
     batcher.AddTriangle(triangle, color, shared_from_this());
   } else {

--- a/src/OrbitGl/Viewport.cpp
+++ b/src/OrbitGl/Viewport.cpp
@@ -79,7 +79,7 @@ void Viewport::SetWorldMin(const Vec2& value) {
 const Vec2& Viewport::GetWorldMin() const { return world_min_; }
 
 void Viewport::SetWorldTopLeftY(float y) {
-  float clamped = std::min(std::max(y, visible_world_height_ - world_extents_[1] + world_min_[1]),
+  float clamped = std::max(std::min(y, world_extents_[1] - visible_world_height_ + world_min_[1]),
                            world_min_[1]);
   if (world_top_left_[1] == clamped) return;
 
@@ -102,7 +102,7 @@ Vec2 Viewport::ScreenToWorldPos(const Vec2i& screen_pos) const {
   Vec2 world_pos;
   world_pos[0] =
       world_top_left_[0] + screen_pos[0] / static_cast<float>(screen_width_) * visible_world_width_;
-  world_pos[1] = world_top_left_[1] -
+  world_pos[1] = world_top_left_[1] +
                  screen_pos[1] / static_cast<float>(screen_height_) * visible_world_height_;
   return world_pos;
 }
@@ -120,7 +120,7 @@ Vec2i Viewport::WorldToScreenPos(const Vec2& world_pos) const {
   screen_pos[0] = static_cast<int>(
       floorf((world_pos[0] - world_top_left_[0]) / visible_world_width_ * GetScreenWidth()));
   screen_pos[1] = static_cast<int>(
-      floorf((world_top_left_[1] - world_pos[1]) / visible_world_height_ * GetScreenHeight()));
+      floorf((world_pos[1] - world_top_left_[1]) / visible_world_height_ * GetScreenHeight()));
   return screen_pos;
 }
 
@@ -130,14 +130,6 @@ int Viewport::WorldToScreenHeight(float height) const {
 
 int Viewport::WorldToScreenWidth(float width) const {
   return static_cast<int>(width / visible_world_width_ * GetScreenWidth());
-}
-
-// TODO(b/177350599): Unify QtScreen and GlScreen
-// QtScreen(x,y) --> GlScreen(x,height-y)
-Vec2i Viewport::QtToGlScreenPos(const Vec2i& qt_pos) const {
-  Vec2i gl_pos = qt_pos;
-  gl_pos[1] = screen_height_ - qt_pos[1];
-  return gl_pos;
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/Viewport.h
+++ b/src/OrbitGl/Viewport.h
@@ -15,11 +15,12 @@ namespace orbit_gl {
 // Uses the following coordinate systems:
 //
 // World:
-//    +y
-//    ^
-//    |
-//    |
 //  (0, 0) ----> +x
+//    |
+//    |
+//    v
+//    +y
+//
 //
 // Screen:
 //  (0, 0) ----> +x
@@ -28,15 +29,11 @@ namespace orbit_gl {
 //    v
 //    +y
 //
-// where world(0, 0) is initially anchored at screen(0, 0), i.e. top left (meaning basically all
-// world y coordinates are negative). Viewport clamps scrolling X values to be >= world_min, and
-// scrollingY values to be <= world_min.
+// where world(0, 0) is initially anchored at screen(0, 0), i.e. top left. Viewport clamps scrolling
+// X values to be >= world_min, and scrollingY values to be <= world_min.
 //
 // Viewport will indicate if any changes happened that require redraw of the contents in between
 // frames. See Viewport::IsDirty() for usage.
-//
-// NOTE: The screen coordinate system is different from what is referred to as "ScreenSpaceViewport"
-// in GlCanvas! See TODO(b/177350599): Unify QtScreen and GlScreen
 
 class Viewport {
  public:
@@ -80,8 +77,6 @@ class Viewport {
   // to convert sizes instead of positions.
   [[nodiscard]] int WorldToScreenWidth(float width) const;
   [[nodiscard]] int WorldToScreenHeight(float height) const;
-
-  [[nodiscard]] Vec2i QtToGlScreenPos(const Vec2i& qt_pos) const;
 
   // "Dirty" indicates that any action has been performed that requires redraw of
   // the viewport contents. The flag must explicitely be cleared in each frame.

--- a/src/OrbitGl/ViewportTest.cpp
+++ b/src/OrbitGl/ViewportTest.cpp
@@ -69,18 +69,18 @@ TEST(Viewport, ResizingAndDirty) {
   EXPECT_TRUE(viewport.IsDirty());
   viewport.ClearDirtyFlag();
 
-  viewport.SetWorldTopLeftY(-50.f);
+  viewport.SetWorldTopLeftY(50.f);
   EXPECT_TRUE(viewport.IsDirty());
   viewport.ClearDirtyFlag();
 
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -50.f));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, 50.f));
 
   // Setting everything to the same values again should not mark the viewport as dirty.
   viewport.Resize(100, 200);
   viewport.SetVisibleWorldWidth(500.f);
   viewport.SetVisibleWorldHeight(600.f);
   viewport.SetWorldTopLeftX(100.f);
-  viewport.SetWorldTopLeftY(-50.f);
+  viewport.SetWorldTopLeftY(50.f);
   viewport.SetWorldExtents(1000, 2000);
   EXPECT_FALSE(viewport.IsDirty());
 }
@@ -90,38 +90,38 @@ TEST(Viewport, ScrollingWithoutZoom) {
   viewport.SetWorldExtents(200, 300);
 
   viewport.SetWorldTopLeftX(100.f);
-  viewport.SetWorldTopLeftY(-50.f);
+  viewport.SetWorldTopLeftY(50.f);
 
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -50.f));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, 50.f));
 
   viewport.SetWorldTopLeftX(150.f);
-  viewport.SetWorldTopLeftY(-150.f);
+  viewport.SetWorldTopLeftY(150.f);
 
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -100.f));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, 100.f));
   EXPECT_EQ(viewport.IsDirty(), true);
   viewport.ClearDirtyFlag();
 
   // Scrolling further after clamping should not result in a dirty flag.
   viewport.SetWorldTopLeftX(200.f);
-  viewport.SetWorldTopLeftY(-200.f);
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -100.f));
+  viewport.SetWorldTopLeftY(200.f);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, 100.f));
   EXPECT_EQ(viewport.IsDirty(), false);
 
   // Resizing should clamp.
   viewport.SetWorldExtents(150, 250);
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(50.f, -50.f));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(50.f, 50.f));
 
   // Changing world min should adjust current top left...
-  viewport.SetWorldMin(Vec2(100, -100));
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100, -100));
+  viewport.SetWorldMin(Vec2(100, 100));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100, 100));
   viewport.SetWorldTopLeftX(0);
   viewport.SetWorldTopLeftY(0);
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100, -100));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100, 100));
 
   // ... and is taken into account when scrolling.
   viewport.SetWorldTopLeftX(500);
-  viewport.SetWorldTopLeftY(-500);
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(150, -150));
+  viewport.SetWorldTopLeftY(500);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(150, 150));
 }
 
 TEST(Viewport, ScrollingWithZoom) {
@@ -131,26 +131,26 @@ TEST(Viewport, ScrollingWithZoom) {
   viewport.SetWorldExtents(400, 800);
 
   viewport.SetWorldTopLeftX(250.f);
-  viewport.SetWorldTopLeftY(-350.f);
+  viewport.SetWorldTopLeftY(350.f);
 
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, -350.f));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, 350.f));
 
   viewport.SetWorldTopLeftX(300.f);
-  viewport.SetWorldTopLeftY(-450.f);
+  viewport.SetWorldTopLeftY(450.f);
 
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, -400.f));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, 400.f));
   EXPECT_EQ(viewport.IsDirty(), true);
   viewport.ClearDirtyFlag();
 
   // Scrolling further after clamping should not result in a dirty flag.
   viewport.SetWorldTopLeftX(350.f);
-  viewport.SetWorldTopLeftY(-600.f);
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, -400.f));
+  viewport.SetWorldTopLeftY(600.f);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, 400.f));
   EXPECT_EQ(viewport.IsDirty(), false);
 
   // Resizing should clamp.
   viewport.SetWorldExtents(250, 450);
-  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(50.f, -50.f));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(50.f, 50.f));
 }
 
 void VerifyConversion(Viewport& viewport, const Vec2i& screen_pos, const Vec2& world_pos,
@@ -162,9 +162,6 @@ void VerifyConversion(Viewport& viewport, const Vec2i& screen_pos, const Vec2& w
   EXPECT_EQ(viewport.WorldToScreenPos(world_pos), screen_pos);
   EXPECT_EQ(viewport.WorldToScreenHeight(world_size[1]), screen_pos[1]);
   EXPECT_EQ(viewport.WorldToScreenWidth(world_size[0]), screen_pos[0]);
-
-  EXPECT_EQ(viewport.QtToGlScreenPos(screen_pos),
-            Vec2i(screen_pos[0], viewport.GetScreenHeight() - screen_pos[1]));
 }
 
 TEST(Viewport, CoordinateConversion) {
@@ -173,7 +170,7 @@ TEST(Viewport, CoordinateConversion) {
   viewport.SetWorldExtents(500, 500);
 
   Vec2i screen_pos = Vec2i(8, 20);
-  Vec2 world_pos = Vec2(8.f, -20.f);
+  Vec2 world_pos = Vec2(8.f, 20.f);
   Vec2 world_size = Vec2(8.f, 20.f);
   VerifyConversion(viewport, screen_pos, world_pos, world_size);
 
@@ -182,13 +179,13 @@ TEST(Viewport, CoordinateConversion) {
   viewport.SetVisibleWorldHeight(50.f);
 
   screen_pos = Vec2i(8, 20);
-  world_pos = Vec2(16.f, -10.f);
+  world_pos = Vec2(16.f, 10.f);
   world_size = Vec2(16.f, 10.f);
   VerifyConversion(viewport, screen_pos, world_pos, world_size);
 
   viewport.SetWorldTopLeftX(10.f);
-  viewport.SetWorldTopLeftY(-100.f);
-  world_pos = Vec2(26.f, -110.f);
+  viewport.SetWorldTopLeftY(100.f);
+  world_pos = Vec2(26.f, 110.f);
   VerifyConversion(viewport, screen_pos, world_pos, world_size);
 }
 


### PR DESCRIPTION
This PR unifies the coordinate systems inside the capture window. It touches all of the rendering-related code, so naturally it's a larger PR that can't be broken into smaller ones without messing up parts of the visuals in between...

Main commit is the last one, everything before is preparational work.

Done in this PR:
* ScreenSpace and WorldSpace viewport are now both anchored top-left, with x pointing right and y pointing downwards (equivalent to QT coordinates)
* Updated TextRenderer to use the same space, and made the definition of alignments a bit more flexible to require less code being changed (before, all text position where specified as bottom-aligned, this is now dynamic)
* Updated all UI components to use the new coordinates
* Added a translation stack to the batcher to prepare for the change in scrolling behavior, but it is only used in `GlSlider` so far
* Slightly refactored some position calculation logic, especially in the memory tracks

Before / after comparison: https://screenshot.googleplex.com/5Psoz8oTxq5V4ov

Left to do:
* Remove the vertical scrolling from the world viewport, then remove the world viewport
* Remove the hack of switching viewports based on layers
* Use the batcher transform stack in all rendering calls to simplify the position calculation inside all elements