### PR TITLE
Move TrackData ownership to CaptureData

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(ClientData PUBLIC
         include/ClientData/TimestampIntervalSet.h
         include/ClientData/TracepointCustom.h
         include/ClientData/TracepointData.h
+        include/ClientData/TrackDataManager.h
         include/ClientData/TrackData.h
         include/ClientData/UserDefinedCaptureData.h)
 

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -30,6 +30,8 @@
 #include "ClientData/TimestampIntervalSet.h"
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/TracepointData.h"
+#include "ClientData/TrackData.h"
+#include "ClientData/TrackDataManager.h"
 #include "OrbitBase/Logging.h"
 #include "capture.pb.h"
 #include "capture_data.pb.h"
@@ -231,6 +233,10 @@ class CaptureData {
     return frame_track_function_ids_;
   }
 
+  [[nodiscard]] std::pair<uint64_t, TrackData*> CreateTrackData() {
+    return track_data_manager_.CreateTrackData();
+  }
+
  private:
   [[nodiscard]] std::optional<uint64_t>
   FindFunctionAbsoluteAddressByInstructionAbsoluteAddressUsingModulesInMemory(
@@ -243,7 +249,6 @@ class CaptureData {
   orbit_client_data::ModuleManager* module_manager_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions_;
 
-  orbit_client_data::TracepointInfoSet selected_tracepoints_;
   orbit_client_data::CallstackData callstack_data_;
   // selection_callstack_data_ is subset of callstack_data_
   std::unique_ptr<orbit_client_data::CallstackData> selection_callstack_data_;
@@ -271,6 +276,8 @@ class CaptureData {
   absl::flat_hash_set<uint64_t> frame_track_function_ids_;
 
   std::optional<std::filesystem::path> file_path_;
+
+  TrackDataManager track_data_manager_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/TrackData.h
+++ b/src/ClientData/include/ClientData/TrackData.h
@@ -13,7 +13,7 @@
 
 namespace orbit_client_data {
 
-class TrackData {
+class TrackData final {
  public:
   [[nodiscard]] bool IsEmpty() const { return num_timers_ == 0; }
   [[nodiscard]] size_t GetNumberOfTimers() const { return num_timers_; }

--- a/src/ClientData/include/ClientData/TrackDataManager.h
+++ b/src/ClientData/include/ClientData/TrackDataManager.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_TRACK_DATA_MANAGER_H_
+#define CLIENT_DATA_TRACK_DATA_MANAGER_H_
+
+#include <absl/synchronization/mutex.h>
+
+#include <vector>
+
+#include "ClientData/TrackData.h"
+
+namespace orbit_client_data {
+
+// Creates and stores TrackData in a thread-safe way.
+// Note that this class does not provide thread-safe access to ThreadData itself.
+class TrackDataManager final {
+ public:
+  TrackDataManager() = default;
+
+  [[nodiscard]] std::pair<uint64_t, TrackData*> CreateTrackData() {
+    absl::MutexLock lock(&mutex_);
+    uint64_t id = track_data_.size();
+    track_data_.emplace_back(std::make_unique<TrackData>());
+    return std::make_pair(id, track_data_.at(id).get());
+  }
+
+ private:
+  mutable absl::Mutex mutex_;
+  std::vector<std::unique_ptr<TrackData>> track_data_ GUARDED_BY(mutex_);
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_TRACK_DATA_MANAGER_H_

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -31,10 +31,11 @@ using orbit_client_protos::TimerInfo;
 using orbit_grpc_protos::InstrumentedFunction;
 
 AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
-                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                       const std::string& name, OrbitApp* app,
-                       const orbit_client_data::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data), name_(name) {}
+                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
+                       OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
+                       orbit_client_data::TrackData* track_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, track_data),
+      name_(std::move(name)) {}
 
 [[nodiscard]] std::string AsyncTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
   const TimerInfo* timer_info = batcher.GetTimerInfo(id);

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -25,9 +25,9 @@ class OrbitApp;
 class AsyncTrack final : public TimerTrack {
  public:
   explicit AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
-                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                      const std::string& name, OrbitApp* app,
-                      const orbit_client_data::CaptureData* capture_data);
+                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
+                      OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
+                      orbit_client_data::TrackData* track_data);
 
   [[nodiscard]] std::string GetName() const override { return name_; };
   [[nodiscard]] Type GetType() const override { return Type::kAsyncTrack; };
@@ -35,7 +35,7 @@ class AsyncTrack final : public TimerTrack {
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
  protected:
-  [[nodiscard]] virtual float GetDefaultBoxHeight() const override;
+  [[nodiscard]] float GetDefaultBoxHeight() const override;
   [[nodiscard]] std::string GetTimesliceText(
       const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -601,7 +601,7 @@ void CaptureWindow::set_draw_help(bool draw_help) {
   RequestRedraw();
 }
 
-void CaptureWindow::CreateTimeGraph(const CaptureData* capture_data) {
+void CaptureWindow::CreateTimeGraph(CaptureData* capture_data) {
   time_graph_ =
       std::make_unique<TimeGraph>(this, app_, &viewport_, capture_data, &GetPickingManager());
 }

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -52,7 +52,7 @@ class CaptureWindow : public GlCanvas {
   [[nodiscard]] bool get_draw_help() const { return draw_help_; }
 
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_.get(); }
-  void CreateTimeGraph(const orbit_client_data::CaptureData* capture_data);
+  void CreateTimeGraph(orbit_client_data::CaptureData* capture_data);
   void ClearTimeGraph() { time_graph_.reset(nullptr); }
 
   Batcher& GetBatcherById(BatcherId batcher_id);

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -60,8 +60,8 @@ float FrameTrack::GetAverageBoxHeight() const {
 FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        InstrumentedFunction function, OrbitApp* app,
-                       const CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
+                       const CaptureData* capture_data, orbit_client_data::TrackData* track_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, track_data),
       function_(std::move(function)) {
   // TODO(b/169554463): Support manual instrumentation.
 

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -27,7 +27,8 @@ class FrameTrack : public TimerTrack {
   explicit FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
-                      const orbit_client_data::CaptureData* capture_data);
+                      const orbit_client_data::CaptureData* capture_data,
+                      orbit_client_data::TrackData* track_data);
 
   [[nodiscard]] std::string GetName() const override {
     return absl::StrFormat("Frame track based on %s", function_.function_name());

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -27,11 +27,12 @@ using orbit_client_protos::TimerInfo;
 GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                          uint64_t timeline_hash, OrbitApp* app,
-                                         const orbit_client_data::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
+                                         const orbit_client_data::CaptureData* capture_data,
+                                         orbit_client_data::TrackData* track_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, track_data),
+      string_manager_{app->GetStringManager()},
       timeline_hash_{timeline_hash} {
   draw_background_ = false;
-  string_manager_ = app->GetStringManager();
 }
 
 std::string GpuDebugMarkerTrack::GetName() const {

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -29,7 +29,8 @@ class GpuDebugMarkerTrack : public TimerTrack {
   explicit GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                uint64_t timeline_hash, OrbitApp* app,
-                               const orbit_client_data::CaptureData* capture_data);
+                               const orbit_client_data::CaptureData* capture_data,
+                               orbit_client_data::TrackData* track_data);
 
   ~GpuDebugMarkerTrack() override = default;
 

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -32,13 +32,14 @@ constexpr const char* kCmdBufferString = "command buffer";
 GpuSubmissionTrack::GpuSubmissionTrack(Track* parent, TimeGraph* time_graph,
                                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                        uint64_t timeline_hash, OrbitApp* app,
-                                       const orbit_client_data::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
+                                       const orbit_client_data::CaptureData* capture_data,
+                                       orbit_client_data::TrackData* track_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, track_data),
+      timeline_hash_{timeline_hash},
+      string_manager_{app->GetStringManager()},
+      parent_{parent} {
   draw_background_ = false;
   text_renderer_ = time_graph->GetTextRenderer();
-  timeline_hash_ = timeline_hash;
-  string_manager_ = app->GetStringManager();
-  parent_ = parent;
 }
 
 std::string GpuSubmissionTrack::GetName() const {

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -31,7 +31,8 @@ class GpuSubmissionTrack : public TimerTrack {
  public:
   explicit GpuSubmissionTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                               TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
-                              const orbit_client_data::CaptureData* capture_data);
+                              const orbit_client_data::CaptureData* capture_data,
+                              orbit_client_data::TrackData* track_data);
   ~GpuSubmissionTrack() override = default;
 
   [[nodiscard]] Track* GetParent() const override { return parent_; }

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -51,14 +51,17 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 
 GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                    TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
-                   const orbit_client_data::CaptureData* capture_data)
+                   const orbit_client_data::CaptureData* capture_data,
+                   orbit_client_data::TrackData* submission_track_data,
+                   orbit_client_data::TrackData* marker_track_data)
     : Track(parent, time_graph, viewport, layout, capture_data),
       string_manager_{app->GetStringManager()},
       submission_track_{std::make_shared<GpuSubmissionTrack>(this, time_graph, viewport, layout,
-                                                             timeline_hash, app, capture_data)},
-      marker_track_{std::make_shared<GpuDebugMarkerTrack>(this, time_graph, viewport, layout,
-                                                          timeline_hash, app, capture_data)},
-      timeline_hash_(timeline_hash) {
+                                                             timeline_hash, app, capture_data,
+                                                             submission_track_data)},
+      marker_track_{std::make_shared<GpuDebugMarkerTrack>(
+          this, time_graph, viewport, layout, timeline_hash, app, capture_data, marker_track_data)},
+      timeline_hash_{timeline_hash} {
   // Gpu are collapsed by default. Their subtracks are expanded by default, but are however not
   // shown while the Gpu track is collapsed.
   collapse_toggle_->SetCollapsed(true);

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -38,7 +38,9 @@ class GpuTrack : public Track {
  public:
   explicit GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                     TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
-                    const orbit_client_data::CaptureData* capture_data);
+                    const orbit_client_data::CaptureData* capture_data,
+                    orbit_client_data::TrackData* submission_track_data,
+                    orbit_client_data::TrackData* marker_track_data);
 
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -24,10 +24,11 @@ const Color kSelectionColor(0, 128, 255, 255);
 
 SchedulerTrack::SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                               const orbit_client_data::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
+                               const orbit_client_data::CaptureData* capture_data,
+                               orbit_client_data::TrackData* track_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, track_data),
+      num_cores_{0} {
   SetPinned(false);
-  num_cores_ = 0;
 }
 
 void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -21,7 +21,8 @@ class SchedulerTrack final : public TimerTrack {
  public:
   explicit SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                          const orbit_client_data::CaptureData* capture_data);
+                          const orbit_client_data::CaptureData* capture_data,
+                          orbit_client_data::TrackData* track_data);
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -41,8 +41,11 @@ using orbit_grpc_protos::InstrumentedFunction;
 ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
                          OrbitApp* app, const CaptureData* capture_data,
+                         orbit_client_data::TrackData* track_data,
                          ScopeTreeUpdateType scope_tree_update_type)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data), thread_id_{thread_id} {
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, track_data),
+      thread_id_{thread_id},
+      scope_tree_update_type_{scope_tree_update_type} {
   Color color = TimeGraph::GetThreadColor(thread_id);
   thread_state_bar_ = std::make_shared<orbit_gl::ThreadStateBar>(
       this, app_, time_graph, viewport, layout, capture_data, thread_id, color);
@@ -52,7 +55,6 @@ ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
 
   tracepoint_bar_ = std::make_shared<orbit_gl::TracepointThreadBar>(
       this, app_, time_graph, viewport, layout, capture_data, thread_id, color);
-  scope_tree_update_type_ = scope_tree_update_type;
 }
 
 std::string ThreadTrack::GetThreadNameFromTid(uint32_t thread_id) {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -30,6 +30,7 @@ class ThreadTrack final : public TimerTrack {
   explicit ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
                        OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
+                       orbit_client_data::TrackData* track_data,
                        ScopeTreeUpdateType scope_tree_update_type);
 
   void InitializeNameAndLabel();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -57,7 +57,7 @@ using orbit_gl::VariableTrack;
 using orbit_grpc_protos::InstrumentedFunction;
 
 TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
-                     orbit_gl::Viewport* viewport, const CaptureData* capture_data,
+                     orbit_gl::Viewport* viewport, CaptureData* capture_data,
                      PickingManager* picking_manager)
     // Note that `GlCanvas` and `TimeGraph` span the bridge to OpenGl content, and `TimeGraph`'s
     // parent needs special handling for accessibility. Thus, we use `nullptr` here and we save the

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -38,8 +38,7 @@ class OrbitApp;
 class TimeGraph : public orbit_gl::CaptureViewElement {
  public:
   explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
-                     orbit_gl::Viewport* viewport,
-                     const orbit_client_data::CaptureData* capture_data,
+                     orbit_gl::Viewport* viewport, orbit_client_data::CaptureData* capture_data,
                      PickingManager* picking_manager);
   ~TimeGraph() override;
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -34,11 +34,11 @@ const Color TimerTrack::kHighlightColor = Color(100, 181, 246, 255);
 
 TimerTrack::TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                       const orbit_client_data::CaptureData* capture_data)
+                       const orbit_client_data::CaptureData* capture_data, TrackData* track_data)
     : Track(parent, time_graph, viewport, layout, capture_data),
       text_renderer_{time_graph->GetTextRenderer()},
       app_{app},
-      track_data_{std::make_unique<TrackData>()} {}
+      track_data_{track_data} {}
 
 std::string TimerTrack::GetExtraInfo(const TimerInfo& timer_info) const {
   std::string info;

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -53,7 +53,8 @@ class TimerTrack : public Track {
  public:
   explicit TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                      const orbit_client_data::CaptureData* capture_data);
+                      const orbit_client_data::CaptureData* capture_data,
+                      orbit_client_data::TrackData* track_data);
   ~TimerTrack() override = default;
 
   // Pickable
@@ -165,7 +166,7 @@ class TimerTrack : public Track {
 
   OrbitApp* app_ = nullptr;
 
-  std::unique_ptr<orbit_client_data::TrackData> track_data_;
+  orbit_client_data::TrackData* track_data_;
 };
 
 #endif  // ORBIT_GL_TIMER_TRACK_H_

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -40,7 +40,7 @@ class TrackManager {
  public:
   explicit TrackManager(TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                         TimeGraphLayout* layout, OrbitApp* app,
-                        const orbit_client_data::CaptureData* capture_data);
+                        orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
   [[nodiscard]] std::vector<Track*> GetVisibleTracks() const { return visible_tracks_; }
@@ -125,7 +125,7 @@ class TrackManager {
   std::vector<Track*> visible_tracks_;
 
   float tracks_total_height_ = 0.0f;
-  const orbit_client_data::CaptureData* capture_data_ = nullptr;
+  orbit_client_data::CaptureData* capture_data_ = nullptr;
 
   OrbitApp* app_ = nullptr;
 


### PR DESCRIPTION
CaptureData now owns all the TrackData objects

Test: Start Orbit instrument functions and take a capture