### PR TITLE
Bump grpc_codegen revision

### DIFF
--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -383,7 +383,7 @@
     "context": "host"
    },
    "57": {
-    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#8728b94e133a18e7454c14a28959a148",
+    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
     "requires": [
      "1",
      "8",
@@ -406,7 +406,7 @@
     "context": "host"
    },
    "60": {
-    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#8728b94e133a18e7454c14a28959a148",
+    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
     "requires": [
      "1",
      "8",


### PR DESCRIPTION
This bumps the grpc_codegen revision to a revision which requires
openssl/1.1.1k. This should avoid the openssl build conflict.

It's the first step to fix the CLion build issues. The second step will
be making this revision the latest revision on the servers.

Bug: http://b/196204443