### PR TITLE
Remove ${STRICT_COMPILE_FLAGS} and enable warnings as errors globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,34 +25,34 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  set(STRICT_COMPILE_FLAGS -Werror=all
-                           -Werror=float-conversion
-                           -Werror=format=2
-                           -Werror=ignored-attributes
-                           -Werror=implicit-fallthrough
-                           -Werror=inconsistent-missing-override
-                           -Werror=old-style-cast
-                           -Werror=unused-parameter
-                           -Werror=unused-variable
-                           -Werror=writable-strings
-                           -Werror=sign-compare)
+  add_compile_options(-Werror=all
+                      -Werror=float-conversion
+                      -Werror=format=2
+                      -Werror=ignored-attributes
+                      -Werror=implicit-fallthrough
+                      -Werror=inconsistent-missing-override
+                      -Werror=old-style-cast
+                      -Werror=unused-parameter
+                      -Werror=unused-variable
+                      -Werror=writable-strings
+                      -Werror=sign-compare)
 
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
-    list(APPEND STRICT_COMPILE_FLAGS -Werror=defaulted-function-deleted)
+    add_compile_options(-Werror=defaulted-function-deleted)
   endif()
 
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(STRICT_COMPILE_FLAGS -Werror=all
-                           # gcc does not behave consistently here; what is fine with gcc9 fails with gcc10
-                           # and vice versa, see https://github.com/google/orbit/issues/1624 for details.
-                           -Wno-stringop-truncation
-                           -Werror=float-conversion
-                           -Werror=format=2
-                           -Werror=ignored-attributes
-                           -Werror=old-style-cast
-                           -Werror=unused-parameter
-                           -Werror=unused-variable
-                           -Werror=sign-compare)
+  add_compile_options(-Werror=all
+                      # gcc does not behave consistently here; what is fine with gcc9 fails with gcc10
+                      # and vice versa, see https://github.com/google/orbit/issues/1624 for details.
+                      -Wno-stringop-truncation
+                      -Werror=float-conversion
+                      -Werror=format=2
+                      -Werror=ignored-attributes
+                      -Werror=old-style-cast
+                      -Werror=unused-parameter
+                      -Werror=unused-variable
+                      -Werror=sign-compare)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/fuzzing.cmake
+++ b/cmake/fuzzing.cmake
@@ -10,7 +10,6 @@ function(add_fuzzer target_name)
   # the code to a static library on other compilers instead.
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     add_executable(${target_name} ${ARGN})
-    target_compile_options(${target_name} PRIVATE ${STRICT_COMPILE_FLAGS})
 
     if (ENV{LIB_FUZZING_ENGINE})
       message(STATUS "Adding linker flags according to LIB_FUZZING_ENGINE env variable: $ENV{LIB_FUZZING_ENGINE}")
@@ -26,7 +25,6 @@ function(add_fuzzer target_name)
       PROPERTY LINK_OPTIONS ${FUZZING_OPTION})
   else()
     add_library(${target_name} STATIC ${ARGN})
-    target_compile_options(${target_name} PRIVATE ${STRICT_COMPILE_FLAGS})
   endif()
 endfunction()
 

--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -10,8 +10,6 @@ add_library(Api SHARED)
 
 set_target_properties(Api PROPERTIES OUTPUT_NAME "orbit")
 
-target_compile_options(Api PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(Api PUBLIC cxx_std_17)
 
 target_sources(Api PRIVATE

--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -10,8 +10,6 @@ add_library(Api SHARED)
 
 set_target_properties(Api PROPERTIES OUTPUT_NAME "orbit")
 
-target_compile_features(Api PUBLIC cxx_std_17)
-
 target_sources(Api PRIVATE
         LockFreeApiEventProducer.h
         LockFreeApiEventProducer.cpp

--- a/src/ApiLoader/CMakeLists.txt
+++ b/src/ApiLoader/CMakeLists.txt
@@ -8,8 +8,6 @@ project(ApiLoader)
 
 add_library(ApiLoader STATIC)
 
-target_compile_options(ApiLoader PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(ApiLoader PUBLIC cxx_std_17)
 
 target_include_directories(ApiLoader PUBLIC

--- a/src/ApiLoader/CMakeLists.txt
+++ b/src/ApiLoader/CMakeLists.txt
@@ -8,8 +8,6 @@ project(ApiLoader)
 
 add_library(ApiLoader STATIC)
 
-target_compile_features(ApiLoader PUBLIC cxx_std_17)
-
 target_include_directories(ApiLoader PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/ApiUtils/CMakeLists.txt
+++ b/src/ApiUtils/CMakeLists.txt
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 add_library(ApiUtils STATIC)
-target_compile_options(ApiUtils PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(ApiUtils PUBLIC cxx_std_17)
 
 target_sources(ApiUtils PUBLIC
@@ -19,8 +18,6 @@ target_link_libraries(ApiUtils PUBLIC
 target_include_directories(ApiUtils PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 add_executable(ApiUtilsTests)
-
-target_compile_options(ApiUtilsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(ApiUtilsTests PRIVATE
         EncodedEventTest.cpp

--- a/src/ApiUtils/CMakeLists.txt
+++ b/src/ApiUtils/CMakeLists.txt
@@ -3,8 +3,6 @@
 # found in the LICENSE file.
 
 add_library(ApiUtils STATIC)
-target_compile_features(ApiUtils PUBLIC cxx_std_17)
-
 target_sources(ApiUtils PUBLIC
         include/ApiUtils/Event.h
         include/ApiUtils/EncodedEvent.h

--- a/src/CaptureClient/CMakeLists.txt
+++ b/src/CaptureClient/CMakeLists.txt
@@ -5,8 +5,6 @@
 project(CaptureClient)
 add_library(CaptureClient STATIC)
 
-target_compile_options(CaptureClient PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(CaptureClient PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -42,8 +40,6 @@ target_link_libraries(
   PRIVATE CaptureClient CONAN_PKG::libprotobuf-mutator)
 
 add_executable(CaptureClientTests)
-
-target_compile_options(CaptureClientTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(CaptureClientTests PRIVATE
         ApiEventProcessorTest.cpp

--- a/src/CaptureEventProducer/CMakeLists.txt
+++ b/src/CaptureEventProducer/CMakeLists.txt
@@ -5,8 +5,6 @@
 project(CaptureEventProducer)
 
 add_library(CaptureEventProducer STATIC)
-target_compile_options(CaptureEventProducer PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(CaptureEventProducer PUBLIC
         include/CaptureEventProducer/CaptureEventProducer.h
         include/CaptureEventProducer/FakeProducerSideService.h
@@ -27,8 +25,6 @@ target_link_libraries(CaptureEventProducer PUBLIC
         CONAN_PKG::abseil)
 
 add_executable(CaptureEventProducerTests)
-
-target_compile_options(CaptureEventProducerTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(CaptureEventProducerTests PRIVATE
         CaptureEventProducerTest.cpp

--- a/src/CaptureFile/CMakeLists.txt
+++ b/src/CaptureFile/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(CaptureFile)
 add_library(CaptureFile STATIC)
 
-target_compile_options(CaptureFile PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(
   CaptureFile
   PUBLIC include/CaptureFile/CaptureFile.h
@@ -38,8 +36,6 @@ target_link_libraries(
          CONAN_PKG::protobuf)
 
 add_executable(CaptureFileTests)
-
-target_compile_options(CaptureFileTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(CaptureFileTests PRIVATE
   CaptureFileHelpersTest.cpp

--- a/src/CaptureFileInfo/CMakeLists.txt
+++ b/src/CaptureFileInfo/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(CaptureFileInfo)
 add_library(CaptureFileInfo STATIC)
 
-target_compile_options(CaptureFileInfo PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(
   CaptureFileInfo
   PUBLIC  include/CaptureFileInfo/CaptureFileInfo.h
@@ -38,8 +36,6 @@ set_target_properties(CaptureFileInfo PROPERTIES AUTOMOC ON)
 set_target_properties(CaptureFileInfo PROPERTIES AUTOUIC ON)
 
 add_executable(CaptureFileInfoTests)
-
-target_compile_options(CaptureFileInfoTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   CaptureFileInfoTests 

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -5,8 +5,6 @@
 project(ClientData)
 add_library(ClientData STATIC)
 
-target_compile_options(ClientData PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(ClientData PUBLIC 
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -55,8 +53,6 @@ target_link_libraries(ClientData PUBLIC
 
 
 add_executable(ClientDataTests)
-target_compile_options(ClientDataTests PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(ClientDataTests PRIVATE
         CallstackDataTest.cpp
         FunctionInfoSetTest.cpp

--- a/src/ClientModel/CMakeLists.txt
+++ b/src/ClientModel/CMakeLists.txt
@@ -5,8 +5,6 @@
 project(ClientModel)
 add_library(ClientModel STATIC)
 
-target_compile_options(ClientModel PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(ClientModel PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -29,8 +27,6 @@ target_link_libraries(ClientModel PUBLIC
         ClientProtos)
 
 add_executable(ClientModelTests)
-
-target_compile_options(ClientModelTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(ClientModelTests PRIVATE
         CaptureDeserializerTest.cpp

--- a/src/ClientServices/CMakeLists.txt
+++ b/src/ClientServices/CMakeLists.txt
@@ -5,8 +5,6 @@
 project(ClientServices)
 add_library(ClientServices STATIC)
 
-target_compile_options(ClientServices PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(ClientServices PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/CodeReport/CMakeLists.txt
+++ b/src/CodeReport/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(CodeReport)
 add_library(CodeReport OBJECT)
 
-target_compile_options(CodeReport PRIVATE ${STRICT_COMPILE_FLAGS})
 target_include_directories(CodeReport PUBLIC include/)
 target_link_libraries(CodeReport PUBLIC OrbitBase
                                         ClientData
@@ -29,7 +28,6 @@ target_sources(CodeReport PRIVATE AnnotateDisassembly.cpp
                                   SourceCodeReport.cpp)
 
 add_executable(CodeReportTests)
-target_compile_options(CodeReportTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(CodeReportTests PRIVATE AnnotateDisassemblyTest.cpp
                                        AssemblyTestLiterals.h
                                        DisassemblerTest.cpp

--- a/src/CodeViewer/CMakeLists.txt
+++ b/src/CodeViewer/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(CodeViewer)
 add_library(CodeViewer STATIC)
 
-target_compile_options(CodeViewer PRIVATE ${STRICT_COMPILE_FLAGS})
 target_include_directories(CodeViewer PUBLIC include/)
 target_link_libraries(CodeViewer PUBLIC CodeReport
                                         OrbitBase
@@ -31,7 +30,6 @@ target_sources(CodeViewer PRIVATE Dialog.cpp
 set_target_properties(CodeViewer PROPERTIES AUTOMOC ON AUTOUIC ON)
 
 add_executable(CodeViewerTests)
-target_compile_options(CodeViewerTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(CodeViewerTests PRIVATE FontSizeInEmTest.cpp ViewerTest.cpp)
 target_link_libraries(CodeViewerTests PRIVATE CodeViewer GTest::QtGuiMain)
 

--- a/src/CodeViewerDemo/CMakeLists.txt
+++ b/src/CodeViewerDemo/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(CodeViewerDemo)
 add_executable(CodeViewerDemo main.cpp CodeExamples.h)
 
-target_compile_options(CodeViewerDemo PRIVATE ${STRICT_COMPILE_FLAGS})
 target_link_libraries(CodeViewerDemo PRIVATE CodeViewer
                                              Style
                                              SyntaxHighlighter

--- a/src/ConfigWidgets/CMakeLists.txt
+++ b/src/ConfigWidgets/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(ConfigWidgets)
 add_library(ConfigWidgets STATIC)
 
-target_compile_options(ConfigWidgets PRIVATE ${STRICT_COMPILE_FLAGS})
 target_include_directories(ConfigWidgets PUBLIC include/)
 target_include_directories(ConfigWidgets PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(ConfigWidgets PUBLIC OrbitBase
@@ -28,8 +27,6 @@ set_target_properties(ConfigWidgets PROPERTIES AUTOMOC ON)
 set_target_properties(ConfigWidgets PROPERTIES AUTOUIC ON)
 
 add_executable(ConfigWidgetsTest)
-
-target_compile_options(ConfigWidgetsTest PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(ConfigWidgetsTest PRIVATE SymbolsDialogTest.cpp)
 

--- a/src/CrashHandler/CMakeLists.txt
+++ b/src/CrashHandler/CMakeLists.txt
@@ -8,8 +8,6 @@ project(CrashHandler)
 
 add_library(CrashHandler STATIC)
 
-target_compile_features(CrashHandler PUBLIC cxx_std_17)
-
 target_include_directories(CrashHandler PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include
                                         PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 

--- a/src/CrashHandler/CMakeLists.txt
+++ b/src/CrashHandler/CMakeLists.txt
@@ -8,8 +8,6 @@ project(CrashHandler)
 
 add_library(CrashHandler STATIC)
 
-target_compile_options(CrashHandler PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(CrashHandler PUBLIC cxx_std_17)
 
 target_include_directories(CrashHandler PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include

--- a/src/DataViews/CMakeLists.txt
+++ b/src/DataViews/CMakeLists.txt
@@ -26,7 +26,6 @@ target_sources(DataViews PUBLIC
         include/DataViews/PresetLoadState.h)
 
 target_include_directories(DataViews PUBLIC include/)
-target_compile_features(DataViews PUBLIC cxx_std_17)
 target_link_libraries(DataViews PUBLIC
         ClientData
         ClientModel

--- a/src/DataViews/CMakeLists.txt
+++ b/src/DataViews/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(DataViews PUBLIC
         CONAN_PKG::abseil)
 
 add_executable(DataViewsTests)
-target_compile_options(DataViewsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(DataViewsTests PRIVATE DataViewTest.cpp
                                       DataViewUtilsTest.cpp
                                       FunctionsDataViewTest.cpp

--- a/src/DisplayFormats/CMakeLists.txt
+++ b/src/DisplayFormats/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(DisplayFormats)
 add_library(DisplayFormats STATIC)
 
-target_compile_options(DisplayFormats PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(DisplayFormats PUBLIC cxx_std_17)
 
 target_include_directories(DisplayFormats PUBLIC
@@ -26,8 +24,6 @@ target_link_libraries(DisplayFormats PUBLIC
 
 
 add_executable(DisplayFormatsTests)
-
-target_compile_options(DisplayFormatsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(DisplayFormatsTests PRIVATE
         DisplayFormatsTest.cpp)

--- a/src/DisplayFormats/CMakeLists.txt
+++ b/src/DisplayFormats/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(DisplayFormats)
 add_library(DisplayFormats STATIC)
 
-target_compile_features(DisplayFormats PUBLIC cxx_std_17)
-
 target_include_directories(DisplayFormats PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/FakeClient/CMakeLists.txt
+++ b/src/FakeClient/CMakeLists.txt
@@ -8,8 +8,6 @@ project(FakeClient)
 
 add_executable(OrbitFakeClient)
 
-target_compile_options(OrbitFakeClient PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(OrbitFakeClient PRIVATE
         FakeCaptureEventProcessor.h
         FakeClientMain.cpp)

--- a/src/FramePointerValidator/CMakeLists.txt
+++ b/src/FramePointerValidator/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(FramePointerValidator)
 
 add_library(FramePointerValidator STATIC)
-target_compile_options(FramePointerValidator PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_include_directories(FramePointerValidator PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -30,8 +29,6 @@ target_link_libraries(FramePointerValidator PUBLIC
         CONAN_PKG::capstone)
 
 add_executable(FramePointerValidatorTests)
-
-target_compile_options(FramePointerValidatorTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(FramePointerValidatorTests PRIVATE
         FramePointerValidatorTest.cpp

--- a/src/GrpcProtos/CMakeLists.txt
+++ b/src/GrpcProtos/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(GrpcProtos)
 
 add_library(GrpcProtos STATIC)
-target_compile_options(GrpcProtos PRIVATE ${STRICT_COMPILE_FLAGS})
 
 if(WIN32)
     target_compile_definitions(GrpcProtos PUBLIC -D_WIN32_WINNT=0x0700)

--- a/src/Introspection/CMakeLists.txt
+++ b/src/Introspection/CMakeLists.txt
@@ -8,8 +8,6 @@ project(Introspection)
 
 add_library(Introspection STATIC)
 
-target_compile_features(Introspection PUBLIC cxx_std_17)
-
 target_include_directories(Introspection PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/Introspection/CMakeLists.txt
+++ b/src/Introspection/CMakeLists.txt
@@ -8,8 +8,6 @@ project(Introspection)
 
 add_library(Introspection STATIC)
 
-target_compile_options(Introspection PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(Introspection PUBLIC cxx_std_17)
 
 target_include_directories(Introspection PUBLIC
@@ -27,8 +25,6 @@ target_link_libraries(Introspection PUBLIC
         OrbitBase)
 
 add_executable(IntrospectionTests)
-
-target_compile_options(IntrospectionTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(IntrospectionTests PRIVATE
         IntrospectionTest.cpp)

--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -8,8 +8,6 @@ project(LinuxTracing)
 
 add_library(LinuxTracing STATIC)
 
-target_compile_options(LinuxTracing PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(LinuxTracing PUBLIC cxx_std_17)
 
 target_include_directories(LinuxTracing PUBLIC
@@ -73,8 +71,6 @@ target_link_libraries(LinuxTracing PUBLIC
         CONAN_PKG::libunwindstack)
 
 add_executable(LinuxTracingTests)
-
-target_compile_options(LinuxTracingTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(LinuxTracingTests PRIVATE
         ContextSwitchManagerTest.cpp

--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -8,8 +8,6 @@ project(LinuxTracing)
 
 add_library(LinuxTracing STATIC)
 
-target_compile_features(LinuxTracing PUBLIC cxx_std_17)
-
 target_include_directories(LinuxTracing PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/LinuxTracingIntegrationTests/CMakeLists.txt
+++ b/src/LinuxTracingIntegrationTests/CMakeLists.txt
@@ -8,8 +8,6 @@ project(LinuxTracingIntegrationTests)
 
 add_library(LinuxTracingIntegrationTestPuppetSharedObject SHARED)
 
-target_compile_options(LinuxTracingIntegrationTestPuppetSharedObject PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(LinuxTracingIntegrationTestPuppetSharedObject PRIVATE
         LinuxTracingIntegrationTestPuppetSharedObject.cpp)
 
@@ -20,8 +18,6 @@ target_link_libraries(LinuxTracingIntegrationTestPuppetSharedObject PUBLIC
 strip_symbols(LinuxTracingIntegrationTestPuppetSharedObject)
 
 add_executable(LinuxTracingIntegrationTests)
-
-target_compile_options(LinuxTracingIntegrationTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(LinuxTracingIntegrationTests PRIVATE
         LinuxTracingIntegrationTest.cpp

--- a/src/MemoryTracing/CMakeLists.txt
+++ b/src/MemoryTracing/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(MemoryTracing)
 add_library(MemoryTracing STATIC)
 
-target_compile_options(MemoryTracing PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(MemoryTracing PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -31,8 +29,6 @@ target_link_libraries(MemoryTracing PUBLIC
         CONAN_PKG::abseil)
 
 add_executable(MemoryTracingTests)
-
-target_compile_options(MemoryTracingTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(MemoryTracingTests PRIVATE 
         MemoryTracingIntegrationTest.cpp

--- a/src/MetricsUploader/CMakeLists.txt
+++ b/src/MetricsUploader/CMakeLists.txt
@@ -8,8 +8,6 @@ project(MetricsUploader)
 
 add_library(MetricsUploader STATIC)
 
-target_compile_options(MetricsUploader PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(MetricsUploader PUBLIC cxx_std_17)
 
 target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include
@@ -72,8 +70,6 @@ endif()
 
 # add tests
 add_executable(MetricsUploaderTests)
-
-target_compile_options(MetricsUploaderTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(MetricsUploaderTests PRIVATE CaptureMetricTest.cpp
                                             ScopedMetricTest.cpp)

--- a/src/MetricsUploader/CMakeLists.txt
+++ b/src/MetricsUploader/CMakeLists.txt
@@ -8,8 +8,6 @@ project(MetricsUploader)
 
 add_library(MetricsUploader STATIC)
 
-target_compile_features(MetricsUploader PUBLIC cxx_std_17)
-
 target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include
                                            PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 

--- a/src/MoveFilesToDocuments/CMakeLists.txt
+++ b/src/MoveFilesToDocuments/CMakeLists.txt
@@ -6,8 +6,6 @@ project(MoveFilesToDocuments CXX)
 
 add_library(MoveFilesToDocuments OBJECT)
 
-target_compile_options(MoveFilesToDocuments PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(MoveFilesToDocuments PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(ObjectUtils)
 add_library(ObjectUtils STATIC)
 
-target_compile_options(ObjectUtils PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(ObjectUtils PUBLIC cxx_std_17)
 
 target_sources(
@@ -41,8 +40,6 @@ target_link_libraries(
          CONAN_PKG::llvm-core)
 
 add_executable(ObjectUtilsTests)
-
-target_compile_options(ObjectUtilsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(ObjectUtilsTests PRIVATE
         AddressTest.cpp

--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(ObjectUtils)
 add_library(ObjectUtils STATIC)
 
-target_compile_features(ObjectUtils PUBLIC cxx_std_17)
-
 target_sources(
   ObjectUtils
   PUBLIC include/ObjectUtils/Address.h

--- a/src/Orbit/CMakeLists.txt
+++ b/src/Orbit/CMakeLists.txt
@@ -5,7 +5,6 @@
 project(Orbit CXX)
 
 add_executable(Orbit main.cpp)
-target_compile_options(Orbit PRIVATE ${STRICT_COMPILE_FLAGS})
 target_link_libraries(Orbit PRIVATE
         MoveFilesToDocuments
         OrbitQt

--- a/src/OrbitAccessibility/CMakeLists.txt
+++ b/src/OrbitAccessibility/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(OrbitAccessibility CXX)
 add_library(OrbitAccessibility STATIC)
 
-target_compile_options(OrbitAccessibility PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(OrbitAccessibility PUBLIC 
         ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
@@ -33,8 +31,6 @@ target_link_libraries(
   PUBLIC OrbitBase)
 
 add_executable(OrbitAccessibilityTests)
-
-target_compile_options(OrbitAccessibilityTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitAccessibilityTests PRIVATE)
 

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -8,8 +8,6 @@ project(OrbitBase)
 
 add_library(OrbitBase STATIC)
 
-target_compile_features(OrbitBase PUBLIC cxx_std_17)
-
 target_include_directories(OrbitBase PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -8,8 +8,6 @@ project(OrbitBase)
 
 add_library(OrbitBase STATIC)
 
-target_compile_options(OrbitBase PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(OrbitBase PUBLIC cxx_std_17)
 
 target_include_directories(OrbitBase PUBLIC
@@ -82,8 +80,6 @@ target_link_libraries(OrbitBase PUBLIC
 
 
 add_executable(OrbitBaseTests)
-
-target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitBaseTests PRIVATE
         AlignTest.cpp

--- a/src/OrbitCaptureGgpClient/CMakeLists.txt
+++ b/src/OrbitCaptureGgpClient/CMakeLists.txt
@@ -5,9 +5,6 @@
 project(OrbitCaptureGgpClientLib)
 add_library(OrbitCaptureGgpClientLib STATIC)
 
-target_compile_options(OrbitCaptureGgpClientLib PRIVATE 
-        ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(OrbitCaptureGgpClientLib PUBLIC 
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -29,8 +26,5 @@ add_executable(OrbitCaptureGgpClient main.cpp)
 
 target_link_libraries(OrbitCaptureGgpClient PRIVATE 
     OrbitCaptureGgpClientLib)
-
-target_compile_options(OrbitCaptureGgpClient PRIVATE 
-    ${STRICT_COMPILE_FLAGS})
 
 strip_symbols(OrbitCaptureGgpClient)

--- a/src/OrbitCaptureGgpService/CMakeLists.txt
+++ b/src/OrbitCaptureGgpService/CMakeLists.txt
@@ -6,9 +6,6 @@ project(OrbitCaptureGgpService)
 
 add_executable(OrbitCaptureGgpService main.cpp)
 
-target_compile_options(OrbitCaptureGgpService PRIVATE 
-        ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(OrbitCaptureGgpService PRIVATE 
         ${CMAKE_CURRENT_LIST_DIR})
 

--- a/src/OrbitClientGgp/CMakeLists.txt
+++ b/src/OrbitClientGgp/CMakeLists.txt
@@ -6,9 +6,6 @@ project(OrbitClientGgpLib)
 
 add_library(OrbitClientGgpLib STATIC)
 
-target_compile_options(OrbitClientGgpLib PRIVATE
-    ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(OrbitClientGgpLib PUBLIC 
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -37,8 +34,5 @@ add_executable(OrbitClientGgp main.cpp)
 
 target_link_libraries(OrbitClientGgp PRIVATE 
     OrbitClientGgpLib)
-
-target_compile_options(OrbitClientGgp PRIVATE 
-    ${STRICT_COMPILE_FLAGS})
 
 strip_symbols(OrbitClientGgp)

--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -6,8 +6,6 @@ project(OrbitGgp CXX)
 
 add_library(OrbitGgp)
 
-target_compile_options(OrbitGgp PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(OrbitBase PUBLIC cxx_std_17)
 
 target_include_directories(OrbitGgp PUBLIC
@@ -38,17 +36,13 @@ set_target_properties(OrbitGgp PROPERTIES AUTOUIC ON)
 
 # Mock ggp clients
 add_executable(OrbitMockGgpFailing)
-target_compile_options(OrbitMockGgpFailing PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitMockGgpFailing PRIVATE MockGgp/Failing.cpp)
 
 add_executable(OrbitMockGgpWorking)
-target_compile_options(OrbitMockGgpWorking PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitMockGgpWorking PRIVATE MockGgp/Working.cpp)
 
 # Tests
 add_executable(OrbitGgpTests)
-
-target_compile_options(OrbitGgpTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitGgpTests PRIVATE 
           ClientTest.cpp

--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -6,8 +6,6 @@ project(OrbitGgp CXX)
 
 add_library(OrbitGgp)
 
-target_compile_features(OrbitBase PUBLIC cxx_std_17)
-
 target_include_directories(OrbitGgp PUBLIC
           ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(OrbitGl CXX)
 add_library(OrbitGl STATIC)
 
-target_compile_options(OrbitGl PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(
   OrbitGl
   PUBLIC AccessibleCaptureViewElement.h
@@ -183,8 +181,6 @@ endif()
 
 
 add_executable(OrbitGlTests)
-
-target_compile_options(OrbitGlTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitGlTests PRIVATE
                PickingManagerTest.h

--- a/src/OrbitPaths/CMakeLists.txt
+++ b/src/OrbitPaths/CMakeLists.txt
@@ -8,8 +8,6 @@ project(OrbitPaths)
 
 add_library(OrbitPaths STATIC)
 
-target_compile_options(OrbitPaths PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(OrbitPaths PUBLIC cxx_std_17)
 
 target_include_directories(OrbitPaths PUBLIC
@@ -26,8 +24,6 @@ target_link_libraries(OrbitPaths PUBLIC
         CONAN_PKG::abseil)
 
 add_executable(OrbitPathsTests)
-
-target_compile_options(OrbitPathsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitPathsTests PRIVATE
         PathsTest.cpp)

--- a/src/OrbitPaths/CMakeLists.txt
+++ b/src/OrbitPaths/CMakeLists.txt
@@ -8,8 +8,6 @@ project(OrbitPaths)
 
 add_library(OrbitPaths STATIC)
 
-target_compile_features(OrbitPaths PUBLIC cxx_std_17)
-
 target_include_directories(OrbitPaths PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -6,8 +6,6 @@ project(OrbitQt CXX)
 
 add_library(OrbitQt OBJECT)
 
-target_compile_options(OrbitQt PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(
   OrbitQt
   PRIVATE AccessibilityAdapter.h
@@ -108,8 +106,6 @@ set_target_properties(OrbitQt PROPERTIES AUTORCC ON)
 iwyu_add_dependency(OrbitQt)
 
 add_executable(OrbitQtTests)
-
-target_compile_options(OrbitQtTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitQtTests
         PRIVATE AccessibilityAdapter.h

--- a/src/OrbitSsh/CMakeLists.txt
+++ b/src/OrbitSsh/CMakeLists.txt
@@ -8,8 +8,6 @@ project(OrbitSsh)
 
 add_library(OrbitSsh STATIC)
 
-target_compile_options(OrbitSsh PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(OrbitSsh PUBLIC cxx_std_17)
 
 target_include_directories(OrbitSsh PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -58,8 +56,6 @@ endif()
 
 # tests
 add_executable(OrbitSshTests)
-target_compile_options(OrbitSshTests PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(OrbitSshTests PRIVATE SocketTests.cpp ContextTests.cpp)
 
 target_link_libraries(OrbitSshTests PRIVATE OrbitSsh CONAN_PKG::libssh2

--- a/src/OrbitSsh/CMakeLists.txt
+++ b/src/OrbitSsh/CMakeLists.txt
@@ -8,8 +8,6 @@ project(OrbitSsh)
 
 add_library(OrbitSsh STATIC)
 
-target_compile_features(OrbitSsh PUBLIC cxx_std_17)
-
 target_include_directories(OrbitSsh PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 target_sources(

--- a/src/OrbitSshQt/CMakeLists.txt
+++ b/src/OrbitSshQt/CMakeLists.txt
@@ -8,7 +8,6 @@ project(OrbitSshQt)
 
 add_library(OrbitSshQt STATIC)
 
-target_compile_features(OrbitSshQt PUBLIC cxx_std_17)
 target_include_directories(OrbitSshQt PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 target_sources(

--- a/src/OrbitSshQt/CMakeLists.txt
+++ b/src/OrbitSshQt/CMakeLists.txt
@@ -8,7 +8,6 @@ project(OrbitSshQt)
 
 add_library(OrbitSshQt STATIC)
 
-target_compile_options(OrbitSshQt PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(OrbitSshQt PUBLIC cxx_std_17)
 target_include_directories(OrbitSshQt PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -44,13 +43,11 @@ target_link_libraries(OrbitSshQt PUBLIC
 set_target_properties(OrbitSshQt PROPERTIES AUTOMOC ON)
 
 add_executable(OrbitSshQtIntegrationTests)
-target_compile_options(OrbitSshQtIntegrationTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitSshQtIntegrationTests PRIVATE IntegrationTests.cpp)
 target_link_libraries(OrbitSshQtIntegrationTests PUBLIC OrbitSshQt GTest::GTest)
 
 # tests
 #add_executable(OrbitSshQtTests)
-#target_compile_options(OrbitSshQtTests PRIVATE ${STRICT_COMPILE_FLAGS})
 #target_sources(OrbitSshQtTests PRIVATE SocketTests.cpp ContextTests.cpp)
 #target_link_libraries(OrbitSshQtTests PRIVATE OrbitSshQt GTest::Main)
 

--- a/src/OrbitTest/CMakeLists.txt
+++ b/src/OrbitTest/CMakeLists.txt
@@ -6,8 +6,6 @@ project(OrbitTest)
 
 add_executable(OrbitTest)
 
-target_compile_options(OrbitTest PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(OrbitTest PRIVATE OrbitTest.cpp OrbitTestImpl.h OrbitTestImpl.cpp)
 
 target_include_directories(OrbitTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -18,6 +16,5 @@ target_link_libraries(OrbitTest PRIVATE dl)
 endif()
 
 add_executable(OrbitTestShortLivedThreads)
-target_compile_options(OrbitTestShortLivedThreads PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitTestShortLivedThreads PRIVATE OrbitTestShortLivedThreads.cpp)
 target_link_libraries(OrbitTestShortLivedThreads PRIVATE Threads::Threads)

--- a/src/OrbitTriggerCaptureVulkanLayer/CMakeLists.txt
+++ b/src/OrbitTriggerCaptureVulkanLayer/CMakeLists.txt
@@ -5,8 +5,6 @@
 project(OrbitTriggerCaptureVulkanLayer)
 add_library(OrbitTriggerCaptureVulkanLayer SHARED)
 
-target_compile_options(OrbitTriggerCaptureVulkanLayer PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_include_directories(OrbitTriggerCaptureVulkanLayer PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})
 

--- a/src/OrbitVersion/CMakeLists.txt
+++ b/src/OrbitVersion/CMakeLists.txt
@@ -8,8 +8,6 @@ project(OrbitVersion)
 
 add_library(OrbitVersion STATIC)
 
-target_compile_options(OrbitVersion PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(OrbitVersion PUBLIC cxx_std_17)
 
 target_include_directories(OrbitVersion PUBLIC
@@ -26,8 +24,6 @@ GenerateVersionFile("${CMAKE_CURRENT_BINARY_DIR}/OrbitVersion.cpp"
 target_sources(OrbitVersion PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/OrbitVersion.cpp")
 
 add_executable(OrbitVersionTests)
-
-target_compile_options(OrbitVersionTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitVersionTests PRIVATE OrbitVersionTest.cpp)
 

--- a/src/OrbitVersion/CMakeLists.txt
+++ b/src/OrbitVersion/CMakeLists.txt
@@ -8,8 +8,6 @@ project(OrbitVersion)
 
 add_library(OrbitVersion STATIC)
 
-target_compile_features(OrbitVersion PUBLIC cxx_std_17)
-
 target_include_directories(OrbitVersion PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/OrbitVulkanLayer/CMakeLists.txt
+++ b/src/OrbitVulkanLayer/CMakeLists.txt
@@ -6,8 +6,6 @@ project(OrbitVulkanLayer)
 
 add_library(OrbitVulkanLayerInterface STATIC)
 
-target_compile_options(OrbitVulkanLayerInterface PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(OrbitVulkanLayerInterface PRIVATE
         DeviceManager.h
         DispatchTable.cpp
@@ -32,8 +30,6 @@ target_link_libraries(OrbitVulkanLayerInterface PUBLIC
 
 add_library(OrbitVulkanLayer SHARED)
 
-target_compile_options(OrbitVulkanLayer PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(OrbitVulkanLayer PRIVATE
         EntryPoints.cpp)
 
@@ -47,8 +43,6 @@ target_link_libraries(OrbitVulkanLayer PRIVATE
 strip_symbols(OrbitVulkanLayer)
 
 add_executable(OrbitVulkanLayerTests)
-
-target_compile_options(OrbitVulkanLayerTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitVulkanLayerTests PRIVATE
         DeviceManagerTest.cpp

--- a/src/PresetFile/CMakeLists.txt
+++ b/src/PresetFile/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(PresetFile)
 add_library(PresetFile STATIC)
 
-target_compile_options(PresetFile PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(
   PresetFile
   PUBLIC include/PresetFile/PresetFile.h)
@@ -26,8 +24,6 @@ target_link_libraries(
          CONAN_PKG::protobuf)
 
 add_executable(PresetFileTests)
-
-target_compile_options(PresetFileTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(PresetFileTests PRIVATE
         PresetFileTest.cpp)

--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(QtUtils)
 add_library(QtUtils STATIC)
 
-target_compile_options(QtUtils PRIVATE ${STRICT_COMPILE_FLAGS})
 target_include_directories(QtUtils PUBLIC include/)
 target_link_libraries(QtUtils PUBLIC OrbitBase OrbitGl Qt5::Core CONAN_PKG::abseil GTest::GTest)
 
@@ -22,7 +21,6 @@ target_sources(QtUtils PRIVATE FutureWatcher.cpp
 set_target_properties(QtUtils PROPERTIES AUTOMOC ON)
 
 add_executable(QtUtilsTests)
-target_compile_options(QtUtilsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(QtUtilsTests PRIVATE EventLoopTest.cpp
                                     FutureWatcherTest.cpp
                                     MainThreadExecutorImplTest.cpp)

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -8,7 +8,6 @@
 project(ServiceLib)
 
 add_library(ServiceLib STATIC)
-target_compile_options(ServiceLib PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(ServiceLib PRIVATE
         CaptureEventBuffer.h
@@ -66,12 +65,10 @@ target_link_libraries(ServiceLib PUBLIC
 project(OrbitService)
 add_executable(OrbitService main.cpp)
 target_link_libraries(OrbitService PRIVATE ServiceLib)
-target_compile_options(OrbitService PRIVATE ${STRICT_COMPILE_FLAGS})
 
 strip_symbols(OrbitService)
 
 add_executable(ServiceTests)
-target_compile_options(ServiceTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(ServiceTests PRIVATE
         ProcessListTest.cpp

--- a/src/SessionSetup/CMakeLists.txt
+++ b/src/SessionSetup/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(SessionSetup)
 add_library(SessionSetup STATIC)
 
-target_compile_options(SessionSetup PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(
   SessionSetup
   PUBLIC  include/SessionSetup/Connections.h
@@ -60,8 +58,6 @@ set_target_properties(SessionSetup PROPERTIES AUTOMOC ON)
 set_target_properties(SessionSetup PROPERTIES AUTOUIC ON)
 
 add_executable(SessionSetupTest)
-
-target_compile_options(SessionSetupTest PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   SessionSetupTest

--- a/src/SourcePathsMapping/CMakeLists.txt
+++ b/src/SourcePathsMapping/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(SourcePathsMapping)
 add_library(SourcePathsMapping STATIC)
 
-target_compile_options(SourcePathsMapping PRIVATE ${STRICT_COMPILE_FLAGS})
 target_include_directories(SourcePathsMapping PUBLIC include/)
 target_link_libraries(SourcePathsMapping PUBLIC OrbitBase
                                                 QtUtils
@@ -25,7 +24,6 @@ target_sources(SourcePathsMapping PRIVATE Mapping.cpp
 set_target_properties(SourcePathsMapping PROPERTIES AUTOMOC ON)
 
 add_executable(SourcePathsMappingTests)
-target_compile_options(SourcePathsMappingTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(SourcePathsMappingTests PRIVATE MappingTest.cpp
                                                MappingItemModelTest.cpp
                                                MappingManagerTest.cpp)

--- a/src/SourcePathsMappingDialogDemo/CMakeLists.txt
+++ b/src/SourcePathsMappingDialogDemo/CMakeLists.txt
@@ -7,6 +7,4 @@ cmake_minimum_required(VERSION 3.15)
 project(SourcePathsMappingDialogDemo)
 add_executable(SourcePathsMappingDialogDemo main.cpp)
 
-target_compile_options(SourcePathsMappingDialogDemo
-                       PRIVATE ${STRICT_COMPILE_FLAGS})
 target_link_libraries(SourcePathsMappingDialogDemo PRIVATE ConfigWidgets Qt5::Widgets)

--- a/src/SourcePathsMappingUI/CMakeLists.txt
+++ b/src/SourcePathsMappingUI/CMakeLists.txt
@@ -13,5 +13,3 @@ target_include_directories(SourcePathsMappingUI PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
 target_link_libraries(SourcePathsMappingUI PUBLIC SourcePathsMapping Qt5::Widgets)
-
-target_compile_features(SourcePathsMappingUI PUBLIC cxx_std_17)

--- a/src/SourcePathsMappingUI/CMakeLists.txt
+++ b/src/SourcePathsMappingUI/CMakeLists.txt
@@ -14,5 +14,4 @@ target_include_directories(SourcePathsMappingUI PUBLIC
 
 target_link_libraries(SourcePathsMappingUI PUBLIC SourcePathsMapping Qt5::Widgets)
 
-target_compile_options(SourcePathsMappingUI PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(SourcePathsMappingUI PUBLIC cxx_std_17)

--- a/src/StringManager/CMakeLists.txt
+++ b/src/StringManager/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(StringManager)
 add_library(StringManager STATIC)
 
-target_compile_options(StringManager PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_sources(
   StringManager
   PUBLIC include/StringManager/StringManager.h)
@@ -24,8 +22,6 @@ target_link_libraries(
   PUBLIC OrbitBase)
 
 add_executable(StringManagerTests)
-
-target_compile_options(StringManagerTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(StringManagerTests PRIVATE
         StringManagerTest.cpp)

--- a/src/Style/CMakeLists.txt
+++ b/src/Style/CMakeLists.txt
@@ -13,5 +13,3 @@ target_include_directories(Style PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
 target_link_libraries(Style PUBLIC Qt5::Widgets)
-
-target_compile_features(Style PUBLIC cxx_std_17)

--- a/src/Style/CMakeLists.txt
+++ b/src/Style/CMakeLists.txt
@@ -14,5 +14,4 @@ target_include_directories(Style PUBLIC
 
 target_link_libraries(Style PUBLIC Qt5::Widgets)
 
-target_compile_options(Style PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(Style PUBLIC cxx_std_17)

--- a/src/SymbolPaths/CMakeLists.txt
+++ b/src/SymbolPaths/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(SymbolPaths)
 add_library(SymbolPaths STATIC)
 
-target_compile_options(SymbolPaths PRIVATE ${STRICT_COMPILE_FLAGS})
 target_include_directories(SymbolPaths PUBLIC include/)
 target_link_libraries(SymbolPaths PUBLIC Qt5::Core)
 
@@ -17,7 +16,6 @@ target_sources(
 target_sources(SymbolPaths PRIVATE QSettingsWrapper.cpp)
 
 add_executable(SymbolPathsTests)
-target_compile_options(SymbolPathsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(SymbolPathsTests PRIVATE QSettingsWrapperTest.cpp)
 
 target_link_libraries(SymbolPathsTests PRIVATE SymbolPaths

--- a/src/Symbols/CMakeLists.txt
+++ b/src/Symbols/CMakeLists.txt
@@ -12,8 +12,6 @@ target_sources(Symbols PUBLIC include/Symbols/SymbolHelper.h)
 target_include_directories(Symbols PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_compile_features(Symbols PUBLIC cxx_std_17)
-
 target_link_libraries(Symbols PUBLIC
         GrpcProtos
         Introspection

--- a/src/Symbols/CMakeLists.txt
+++ b/src/Symbols/CMakeLists.txt
@@ -12,7 +12,6 @@ target_sources(Symbols PUBLIC include/Symbols/SymbolHelper.h)
 target_include_directories(Symbols PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_compile_options(Symbols PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(Symbols PUBLIC cxx_std_17)
 
 target_link_libraries(Symbols PUBLIC
@@ -24,7 +23,6 @@ target_link_libraries(Symbols PUBLIC
 
 
 add_executable(SymbolsTests)
-target_compile_options(SymbolsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(SymbolsTests PRIVATE SymbolHelperTest.cpp)
 target_link_libraries(SymbolsTests PRIVATE Symbols GTest::Main)
 register_test(SymbolsTests)

--- a/src/SymbolsDialogDemo/CMakeLists.txt
+++ b/src/SymbolsDialogDemo/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(SymbolsDialogDemo)
 add_executable(SymbolsDialogDemo main.cpp)
 
-target_compile_options(SymbolsDialogDemo
-                       PRIVATE ${STRICT_COMPILE_FLAGS})
 target_link_libraries(SymbolsDialogDemo PRIVATE ConfigWidgets
                                                 Qt5::Widgets
                                                 SymbolPaths)

--- a/src/SyntaxHighlighter/CMakeLists.txt
+++ b/src/SyntaxHighlighter/CMakeLists.txt
@@ -7,7 +7,6 @@ cmake_minimum_required(VERSION 3.15)
 project(SyntaxHighlighter)
 add_library(SyntaxHighlighter STATIC)
 
-target_compile_options(SyntaxHighlighter PRIVATE ${STRICT_COMPILE_FLAGS})
 target_include_directories(SyntaxHighlighter PUBLIC include/)
 target_link_libraries(SyntaxHighlighter PUBLIC OrbitBase Qt5::Gui)
 set_target_properties(SyntaxHighlighter PROPERTIES AUTOMOC ON)

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -8,8 +8,6 @@ project(UserSpaceInstrumentation)
 
 add_library(UserSpaceInstrumentation STATIC)
 
-target_compile_options(UserSpaceInstrumentation PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(UserSpaceInstrumentation PUBLIC cxx_std_17)
 
 target_include_directories(UserSpaceInstrumentation PUBLIC
@@ -56,8 +54,6 @@ target_link_libraries(UserSpaceInstrumentation PUBLIC
 # executed on function entry/exit of an instrumented function.
 add_library(OrbitUserSpaceInstrumentation SHARED)
 
-target_compile_options(OrbitUserSpaceInstrumentation PRIVATE ${STRICT_COMPILE_FLAGS})
-
 set_target_properties(OrbitUserSpaceInstrumentation PROPERTIES OUTPUT_NAME "orbituserspaceinstrumentation")
 
 target_compile_features(OrbitUserSpaceInstrumentation PUBLIC cxx_std_17)
@@ -81,8 +77,6 @@ strip_symbols(OrbitUserSpaceInstrumentation)
 # to test the injection mechanism.
 add_library(UserSpaceInstrumentationTestLib SHARED)
 
-target_compile_options(UserSpaceInstrumentationTestLib PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(UserSpaceInstrumentationTestLib PUBLIC cxx_std_17)
 
 target_include_directories(UserSpaceInstrumentationTestLib PRIVATE
@@ -94,8 +88,6 @@ target_sources(UserSpaceInstrumentationTestLib PRIVATE
 
 # The tests for UserSpaceInstrumentation        
 add_executable(UserSpaceInstrumentationTests)
-
-target_compile_options(UserSpaceInstrumentationTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_include_directories(UserSpaceInstrumentationTests PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -8,8 +8,6 @@ project(UserSpaceInstrumentation)
 
 add_library(UserSpaceInstrumentation STATIC)
 
-target_compile_features(UserSpaceInstrumentation PUBLIC cxx_std_17)
-
 target_include_directories(UserSpaceInstrumentation PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -56,8 +54,6 @@ add_library(OrbitUserSpaceInstrumentation SHARED)
 
 set_target_properties(OrbitUserSpaceInstrumentation PROPERTIES OUTPUT_NAME "orbituserspaceinstrumentation")
 
-target_compile_features(OrbitUserSpaceInstrumentation PUBLIC cxx_std_17)
-
 target_include_directories(OrbitUserSpaceInstrumentation PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})
 
@@ -76,8 +72,6 @@ strip_symbols(OrbitUserSpaceInstrumentation)
 # binary libUserSpaceInstrumentationTestLib.so created from this target is used
 # to test the injection mechanism.
 add_library(UserSpaceInstrumentationTestLib SHARED)
-
-target_compile_features(UserSpaceInstrumentationTestLib PUBLIC cxx_std_17)
 
 target_include_directories(UserSpaceInstrumentationTestLib PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})

--- a/src/VulkanTutorial/CMakeLists.txt
+++ b/src/VulkanTutorial/CMakeLists.txt
@@ -9,8 +9,6 @@ project(VulkanTutorial)
 
 add_library(OffscreenRenderingVulkanTutorialLib STATIC)
 
-target_compile_features(OffscreenRenderingVulkanTutorialLib PUBLIC cxx_std_17)
-
 target_include_directories(OffscreenRenderingVulkanTutorialLib PUBLIC
         ${CMAKE_SOURCE_DIR}/third_party/VulkanTutorial/include)
 

--- a/src/VulkanTutorial/CMakeLists.txt
+++ b/src/VulkanTutorial/CMakeLists.txt
@@ -9,8 +9,6 @@ project(VulkanTutorial)
 
 add_library(OffscreenRenderingVulkanTutorialLib STATIC)
 
-target_compile_options(OffscreenRenderingVulkanTutorialLib PRIVATE ${STRICT_COMPILE_FLAGS})
-
 target_compile_features(OffscreenRenderingVulkanTutorialLib PUBLIC cxx_std_17)
 
 target_include_directories(OffscreenRenderingVulkanTutorialLib PUBLIC
@@ -30,8 +28,6 @@ target_link_libraries(OffscreenRenderingVulkanTutorialLib PUBLIC
 
 
 add_executable(OffscreenRenderingVulkanTutorial)
-
-target_compile_options(OffscreenRenderingVulkanTutorial PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OffscreenRenderingVulkanTutorial PRIVATE
         OffscreenRenderingVulkanTutorialMain.cpp)


### PR DESCRIPTION
All the code can now be compiled with warnings as errors, so enabling them an a per-taget basis is not needed anymore.