### PR TITLE
Increase timeout.

### DIFF
--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -41,7 +41,7 @@ class ConnectToStadiaInstance(E2ETestCase):
 
         # In the new UI, use small waits until the process list is active, and then some more for the
         # semi-transparent "loading" Overlay of the tables to disappear
-        wait_for_condition(lambda: self.find_control('Custom', 'ProcessesFrame').is_enabled() is True, 15)
+        wait_for_condition(lambda: self.find_control('Custom', 'ProcessesFrame').is_enabled() is True, 25)
         wait_for_condition(lambda: self.find_control('Table', 'ProcessList').is_active(), 10)
         # This is a bit annoying, but since the overlay is invisible when loading is done, we need to check for
         # absence of the overlay... not sure if there is a better way


### PR DESCRIPTION
This triggered for test runs without any obvious problems.