### PR TITLE
Fix initial dataview column width

### DIFF
--- a/src/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/orbittreeview.h
@@ -68,7 +68,8 @@ class OrbitTreeView : public QTreeView {
   std::unique_ptr<OrbitTableModel> model_;
   std::unique_ptr<QTimer> timer_;
   std::vector<OrbitTreeView*> links_;
-  bool auto_resize_;
+  std::vector<float> column_ratios_;
+  bool maintain_user_column_ratios_ = false;
   bool is_internal_refresh_ = false;
   bool is_multi_selection_ = false;
 };


### PR DESCRIPTION
When launching the main window by double-clicking on the target process, 
as opposed to pressing the "start session" button, the data view columns were
not properly sized. (b/195992183)

This comes from what seems to be a bug in Qt where 
`QApplication::mouseButtons() == Qt::LeftButton` returns true after a double-click 
even if the left mouse button was not pressed. We used the mouse state as a way 
to determine if a resize event came from a user input or from the initial 
"showMaximized" call. This method is not robust even without the Qt bug as a user 
could click on the left button as the initial resize occurs.

With this change, we apply the column ratios on a table resize operation. A direct
column resize works. However, there is a discontinuity if the user resizes the table
after a direct column resize, the initial ratios will then be reapplied. To fix this issue, 
we would need a robust way of differentiating between a table resize and a direct 
column resize.

