### PR TITLE
Use uint32_t as cross-platform thread and process id type

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -32,8 +32,8 @@ void EnqueueApiEvent(Types... args) {
 
   if (!producer.IsCapturing()) return;
 
-  static pid_t pid = orbit_base::GetCurrentProcessId();
-  thread_local pid_t tid = orbit_base::GetCurrentThreadId();
+  static uint32_t pid = orbit_base::GetCurrentProcessId();
+  thread_local uint32_t tid = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   Event event{pid, tid, timestamp_ns, args...};
   producer.EnqueueIntermediateEvent(event);

--- a/src/ApiLoader/EnableInTracee.cpp
+++ b/src/ApiLoader/EnableInTracee.cpp
@@ -30,7 +30,7 @@ using orbit_user_space_instrumentation::ExecuteInProcess;
 
 namespace {
 
-ErrorMessageOr<absl::flat_hash_map<std::string, ModuleInfo>> GetModulesByPathForPid(int32_t pid) {
+ErrorMessageOr<absl::flat_hash_map<std::string, ModuleInfo>> GetModulesByPathForPid(uint32_t pid) {
   OUTCOME_TRY(auto&& module_infos, orbit_object_utils::ReadModules(pid));
   absl::flat_hash_map<std::string, ModuleInfo> result;
   for (ModuleInfo& module_info : module_infos) {
@@ -79,12 +79,12 @@ ErrorMessageOr<void> SetApiEnabledInTracee(const CaptureOptions& capture_options
     return outcome::success();
   }
 
-  int32_t pid = capture_options.pid();
+  uint32_t pid = capture_options.pid();
 
   OUTCOME_TRY(AttachAndStopProcess(pid));
 
   // Make sure we resume the target process, even on early-outs.
-  orbit_base::unique_resource scope_exit{pid, [](int32_t pid) {
+  orbit_base::unique_resource scope_exit{pid, [](uint32_t pid) {
                                            if (DetachAndContinueProcess(pid).has_error()) {
                                              ERROR("Detaching from %i", pid);
                                            }

--- a/src/ApiLoader/EnableInTracee.cpp
+++ b/src/ApiLoader/EnableInTracee.cpp
@@ -14,6 +14,7 @@
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "OrbitBase/UniqueResource.h"
 #include "UserSpaceInstrumentation/Attach.h"
 #include "UserSpaceInstrumentation/ExecuteInProcess.h"
@@ -30,7 +31,7 @@ using orbit_user_space_instrumentation::ExecuteInProcess;
 
 namespace {
 
-ErrorMessageOr<absl::flat_hash_map<std::string, ModuleInfo>> GetModulesByPathForPid(uint32_t pid) {
+ErrorMessageOr<absl::flat_hash_map<std::string, ModuleInfo>> GetModulesByPathForPid(int32_t pid) {
   OUTCOME_TRY(auto&& module_infos, orbit_object_utils::ReadModules(pid));
   absl::flat_hash_map<std::string, ModuleInfo> result;
   for (ModuleInfo& module_info : module_infos) {
@@ -79,12 +80,12 @@ ErrorMessageOr<void> SetApiEnabledInTracee(const CaptureOptions& capture_options
     return outcome::success();
   }
 
-  uint32_t pid = capture_options.pid();
+  int32_t pid = orbit_base::GetNativeProcessId(capture_options.pid());
 
   OUTCOME_TRY(AttachAndStopProcess(pid));
 
   // Make sure we resume the target process, even on early-outs.
-  orbit_base::unique_resource scope_exit{pid, [](uint32_t pid) {
+  orbit_base::unique_resource scope_exit{pid, [](int32_t pid) {
                                            if (DetachAndContinueProcess(pid).has_error()) {
                                              ERROR("Detaching from %i", pid);
                                            }

--- a/src/ApiLoader/EnableInTracee.cpp
+++ b/src/ApiLoader/EnableInTracee.cpp
@@ -80,7 +80,7 @@ ErrorMessageOr<void> SetApiEnabledInTracee(const CaptureOptions& capture_options
     return outcome::success();
   }
 
-  int32_t pid = orbit_base::GetNativeProcessId(capture_options.pid());
+  int32_t pid = orbit_base::ToNativeProcessId(capture_options.pid());
 
   OUTCOME_TRY(AttachAndStopProcess(pid));
 

--- a/src/ApiUtils/include/ApiUtils/EncodedEvent.h
+++ b/src/ApiUtils/include/ApiUtils/EncodedEvent.h
@@ -76,7 +76,7 @@ union EncodedEvent {
 // It reuses existing EncodedEvent logic but adds information otherwise retrieved through uprobes.
 struct ApiEvent {
   ApiEvent() = default;
-  ApiEvent(int32_t pid, int32_t tid, uint64_t timestamp_ns, orbit_api::EventType type,
+  ApiEvent(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, orbit_api::EventType type,
            const char* name = nullptr, uint64_t data = 0, orbit_api_color color = kOrbitColorAuto)
       : encoded_event(type, name, data, color), pid(pid), tid(tid), timestamp_ns(timestamp_ns) {
     static_assert(sizeof(ApiEvent) == 64, "orbit_api::ApiEvent should be 64 bytes.");
@@ -84,8 +84,8 @@ struct ApiEvent {
   orbit_api::EventType Type() const { return encoded_event.Type(); }
 
   EncodedEvent encoded_event;
-  int32_t pid;
-  int32_t tid;
+  uint32_t pid;
+  uint32_t tid;
   uint64_t timestamp_ns;
 };
 

--- a/src/ApiUtils/include/ApiUtils/Event.h
+++ b/src/ApiUtils/include/ApiUtils/Event.h
@@ -21,10 +21,10 @@
 namespace orbit_api {
 
 struct ApiEventMetaData {
-  ApiEventMetaData(int32_t pid, int32_t tid, uint64_t timestamp_ns)
+  ApiEventMetaData(uint32_t pid, uint32_t tid, uint64_t timestamp_ns)
       : pid(pid), tid(tid), timestamp_ns(timestamp_ns) {}
-  int32_t pid = 0;
-  int32_t tid = 0;
+  uint32_t pid = 0;
+  uint32_t tid = 0;
   uint64_t timestamp_ns = 0;
 };
 
@@ -51,7 +51,7 @@ struct ApiEncodedString {
 };
 
 struct ApiScopeStart {
-  ApiScopeStart(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name,
+  ApiScopeStart(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name,
                 orbit_api_color color_rgba = kOrbitColorAuto, uint64_t group_id = 0,
                 uint64_t address_in_function = 0)
       : meta_data(pid, tid, timestamp_ns),
@@ -70,7 +70,7 @@ struct ApiScopeStart {
 };
 
 struct ApiScopeStop {
-  ApiScopeStop(int32_t pid, int32_t tid, uint64_t timestamp_ns)
+  ApiScopeStop(uint32_t pid, uint32_t tid, uint64_t timestamp_ns)
       : meta_data(pid, tid, timestamp_ns) {}
 
   void CopyToGrpcProto(orbit_grpc_protos::ApiScopeStop* grpc_proto) const;
@@ -79,8 +79,9 @@ struct ApiScopeStop {
 };
 
 struct ApiScopeStartAsync {
-  ApiScopeStartAsync(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint64_t id,
-                     orbit_api_color color_rgba = kOrbitColorAuto, uint64_t address_in_function = 0)
+  ApiScopeStartAsync(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name,
+                     uint64_t id, orbit_api_color color_rgba = kOrbitColorAuto,
+                     uint64_t address_in_function = 0)
       : meta_data(pid, tid, timestamp_ns),
         encoded_name(name),
         id(id),
@@ -97,7 +98,7 @@ struct ApiScopeStartAsync {
 };
 
 struct ApiScopeStopAsync {
-  ApiScopeStopAsync(int32_t pid, int32_t tid, uint64_t timestamp_ns, uint64_t id)
+  ApiScopeStopAsync(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, uint64_t id)
       : meta_data(pid, tid, timestamp_ns), id(id) {}
 
   void CopyToGrpcProto(orbit_grpc_protos::ApiScopeStopAsync* grpc_proto) const;
@@ -107,7 +108,7 @@ struct ApiScopeStopAsync {
 };
 
 struct ApiStringEvent {
-  ApiStringEvent(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint64_t id,
+  ApiStringEvent(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name, uint64_t id,
                  orbit_api_color color_rgba = kOrbitColorAuto)
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), id(id), color_rgba(color_rgba) {}
 
@@ -120,7 +121,7 @@ struct ApiStringEvent {
 };
 
 struct ApiTrackInt {
-  ApiTrackInt(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, int32_t data,
+  ApiTrackInt(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name, int32_t data,
               orbit_api_color color_rgba = kOrbitColorAuto)
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
@@ -133,7 +134,7 @@ struct ApiTrackInt {
 };
 
 struct ApiTrackInt64 {
-  ApiTrackInt64(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, int64_t data,
+  ApiTrackInt64(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name, int64_t data,
                 orbit_api_color color_rgba = kOrbitColorAuto)
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
@@ -146,7 +147,7 @@ struct ApiTrackInt64 {
 };
 
 struct ApiTrackUint {
-  ApiTrackUint(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint32_t data,
+  ApiTrackUint(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name, uint32_t data,
                orbit_api_color color_rgba = kOrbitColorAuto)
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
@@ -159,7 +160,7 @@ struct ApiTrackUint {
 };
 
 struct ApiTrackUint64 {
-  ApiTrackUint64(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, uint64_t data,
+  ApiTrackUint64(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name, uint64_t data,
                  orbit_api_color color_rgba = kOrbitColorAuto)
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
@@ -172,7 +173,7 @@ struct ApiTrackUint64 {
 };
 
 struct ApiTrackDouble {
-  ApiTrackDouble(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, double data,
+  ApiTrackDouble(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name, double data,
                  orbit_api_color color_rgba = kOrbitColorAuto)
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 
@@ -185,7 +186,7 @@ struct ApiTrackDouble {
 };
 
 struct ApiTrackFloat {
-  ApiTrackFloat(int32_t pid, int32_t tid, uint64_t timestamp_ns, const char* name, float data,
+  ApiTrackFloat(uint32_t pid, uint32_t tid, uint64_t timestamp_ns, const char* name, float data,
                 orbit_api_color color_rgba = kOrbitColorAuto)
       : meta_data(pid, tid, timestamp_ns), encoded_name(name), data(data), color_rgba(color_rgba) {}
 

--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -42,7 +42,8 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnUniqueCallstack, (uint64_t /*callstack_id*/, CallstackInfo /*callstack*/),
               (override));
   MOCK_METHOD(void, OnCallstackEvent, (orbit_client_protos::CallstackEvent), (override));
-  MOCK_METHOD(void, OnThreadName, (int32_t /*thread_id*/, std::string /*thread_name*/), (override));
+  MOCK_METHOD(void, OnThreadName, (uint32_t /*thread_id*/, std::string /*thread_name*/),
+              (override));
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_client_protos::ThreadStateSliceInfo), (override));
   MOCK_METHOD(void, OnAddressInfo, (orbit_client_protos::LinuxAddressInfo), (override));
   MOCK_METHOD(void, OnUniqueTracepointInfo,

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -46,7 +46,7 @@ using orbit_base::Future;
 
 // TODO(b/187170164): This method contains a lot of arguments. Consider making it more structured.
 Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
-    orbit_base::ThreadPool* thread_pool, int32_t process_id,
+    orbit_base::ThreadPool* thread_pool, uint32_t process_id,
     const orbit_client_data::ModuleManager& module_manager,
     absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions, bool record_arguments,
     bool record_return_values, TracepointInfoSet selected_tracepoints, double samples_per_second,
@@ -111,7 +111,7 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
 }
 
 ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
-    int32_t process_id, const orbit_client_data::ModuleManager& module_manager,
+    uint32_t process_id, const orbit_client_data::ModuleManager& module_manager,
     const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions, bool record_arguments,
     bool record_return_values, const TracepointInfoSet& selected_tracepoints,
     double samples_per_second, uint16_t stack_dump_size, UnwindingMethod unwinding_method,

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -338,8 +338,8 @@ void CaptureEventProcessorForListener::ProcessModulesSnapshot(
 void CaptureEventProcessorForListener::ProcessGpuJob(const GpuJob& gpu_job) {
   uint64_t timeline_key = gpu_job.timeline_key();
 
-  int32_t process_id = gpu_job.pid();
-  int32_t thread_id = gpu_job.tid();
+  uint32_t process_id = gpu_job.pid();
+  uint32_t thread_id = gpu_job.tid();
   uint64_t amdgpu_cs_ioctl_time_ns = gpu_job.amdgpu_cs_ioctl_time_ns();
 
   constexpr const char* kSwQueue = "sw queue";

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -43,7 +43,7 @@ class MyCaptureListener : public CaptureListener {
   void OnKeyAndString(uint64_t /*key*/, std::string /*str*/) override {}
   void OnUniqueCallstack(uint64_t /*callstack_id*/, CallstackInfo /*callstack*/) override {}
   void OnCallstackEvent(CallstackEvent /*callstack_event*/) override {}
-  void OnThreadName(int32_t /*thread_id*/, std::string /*thread_name*/) override {}
+  void OnThreadName(uint32_t /*thread_id*/, std::string /*thread_name*/) override {}
   void OnThreadStateSlice(
       orbit_client_protos::ThreadStateSliceInfo /*thread_state_slice*/) override {}
   void OnAddressInfo(LinuxAddressInfo /*address_info*/) override {}

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -84,7 +84,8 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnUniqueCallstack, (uint64_t /*callstack_id*/, CallstackInfo /*callstack*/),
               (override));
   MOCK_METHOD(void, OnCallstackEvent, (CallstackEvent), (override));
-  MOCK_METHOD(void, OnThreadName, (int32_t /*thread_id*/, std::string /*thread_name*/), (override));
+  MOCK_METHOD(void, OnThreadName, (uint32_t /*thread_id*/, std::string /*thread_name*/),
+              (override));
   MOCK_METHOD(void, OnThreadStateSlice, (ThreadStateSliceInfo), (override));
   MOCK_METHOD(void, OnAddressInfo, (LinuxAddressInfo), (override));
   MOCK_METHOD(void, OnUniqueTracepointInfo, (uint64_t /*key*/, TracepointInfo /*tracepoint_info*/),
@@ -754,7 +755,7 @@ void ExpectCommandBufferTimerEq(const TimerInfo& actual_timer, const GpuJob& gpu
 }
 
 void ExpectDebugMarkerTimerEq(const TimerInfo& actual_timer, uint64_t cpu_begin, uint64_t cpu_end,
-                              int32_t thread_id, int32_t process_id, uint32_t depth,
+                              uint32_t thread_id, uint32_t process_id, uint32_t depth,
                               uint64_t timeline_key, uint64_t marker_key) {
   EXPECT_EQ(actual_timer.start(), cpu_begin);
   EXPECT_EQ(actual_timer.end(), cpu_end);

--- a/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -20,7 +20,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmission(
     const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
     const std::function<uint64_t(const std::string& str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
-  int32_t thread_id = gpu_queue_submission.meta_info().tid();
+  uint32_t thread_id = gpu_queue_submission.meta_info().tid();
   uint64_t pre_submission_cpu_timestamp =
       gpu_queue_submission.meta_info().pre_submission_cpu_timestamp();
   uint64_t post_submission_cpu_timestamp =
@@ -61,7 +61,7 @@ std::vector<orbit_client_protos::TimerInfo> GpuQueueSubmissionProcessor::Process
     const GpuJob& gpu_job, const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
     const std::function<uint64_t(const std::string& str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
-  int32_t thread_id = gpu_job.tid();
+  uint32_t thread_id = gpu_job.tid();
   uint64_t amdgpu_cs_ioctl_time_ns = gpu_job.amdgpu_cs_ioctl_time_ns();
   const GpuQueueSubmission* matching_gpu_submission =
       FindMatchingGpuQueueSubmission(thread_id, amdgpu_cs_ioctl_time_ns);
@@ -91,7 +91,7 @@ std::vector<orbit_client_protos::TimerInfo> GpuQueueSubmissionProcessor::Process
 }
 
 const GpuQueueSubmission* GpuQueueSubmissionProcessor::FindMatchingGpuQueueSubmission(
-    int32_t thread_id, uint64_t submit_time) {
+    uint32_t thread_id, uint64_t submit_time) {
   const auto& post_submission_time_to_gpu_submission_it =
       tid_to_post_submission_time_to_gpu_submission_.find(thread_id);
   if (post_submission_time_to_gpu_submission_it ==
@@ -120,7 +120,7 @@ const GpuQueueSubmission* GpuQueueSubmissionProcessor::FindMatchingGpuQueueSubmi
 }
 
 const GpuJob* GpuQueueSubmissionProcessor::FindMatchingGpuJob(
-    int32_t thread_id, uint64_t pre_submission_cpu_timestamp,
+    uint32_t thread_id, uint64_t pre_submission_cpu_timestamp,
     uint64_t post_submission_cpu_timestamp) {
   const auto& submission_time_to_gpu_job_it = tid_to_submission_time_to_gpu_job_.find(thread_id);
   if (submission_time_to_gpu_job_it == tid_to_submission_time_to_gpu_job_.end()) {
@@ -187,7 +187,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmissionWit
 }
 
 bool GpuQueueSubmissionProcessor::HasUnprocessedBeginMarkers(
-    int32_t thread_id, uint64_t post_submission_timestamp) const {
+    uint32_t thread_id, uint64_t post_submission_timestamp) const {
   if (!tid_to_post_submission_time_to_num_begin_markers_.contains(thread_id)) {
     return false;
   }
@@ -201,7 +201,7 @@ bool GpuQueueSubmissionProcessor::HasUnprocessedBeginMarkers(
 }
 
 void GpuQueueSubmissionProcessor::DecrementUnprocessedBeginMarkers(
-    int32_t thread_id, uint64_t submission_timestamp, uint64_t post_submission_timestamp) {
+    uint32_t thread_id, uint64_t submission_timestamp, uint64_t post_submission_timestamp) {
   CHECK(tid_to_post_submission_time_to_num_begin_markers_.contains(thread_id));
   auto& post_submission_time_to_num_begin_markers =
       tid_to_post_submission_time_to_num_begin_markers_.at(thread_id);
@@ -218,7 +218,7 @@ void GpuQueueSubmissionProcessor::DecrementUnprocessedBeginMarkers(
   }
 }
 
-void GpuQueueSubmissionProcessor::DeleteSavedGpuJob(int32_t thread_id,
+void GpuQueueSubmissionProcessor::DeleteSavedGpuJob(uint32_t thread_id,
                                                     uint64_t submission_timestamp) {
   if (!tid_to_submission_time_to_gpu_job_.contains(thread_id)) {
     return;
@@ -232,7 +232,7 @@ void GpuQueueSubmissionProcessor::DeleteSavedGpuJob(int32_t thread_id,
     tid_to_submission_time_to_gpu_job_.erase(thread_id);
   }
 }
-void GpuQueueSubmissionProcessor::DeleteSavedGpuSubmission(int32_t thread_id,
+void GpuQueueSubmissionProcessor::DeleteSavedGpuSubmission(uint32_t thread_id,
                                                            uint64_t post_submission_timestamp) {
   if (!tid_to_post_submission_time_to_gpu_submission_.contains(thread_id)) {
     return;
@@ -254,8 +254,8 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuCommandBuffers(
   uint64_t command_buffer_text_key =
       get_string_hash_and_send_to_listener_if_necessary(kCommandBufferLabel);
 
-  int32_t thread_id = gpu_queue_submission.meta_info().tid();
-  int32_t process_id = gpu_queue_submission.meta_info().pid();
+  uint32_t thread_id = gpu_queue_submission.meta_info().tid();
+  uint32_t process_id = gpu_queue_submission.meta_info().pid();
 
   std::vector<TimerInfo> result;
 
@@ -296,8 +296,8 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
   std::vector<TimerInfo> result;
 
   const auto& submission_meta_info = gpu_queue_submission.meta_info();
-  const int32_t submission_thread_id = submission_meta_info.tid();
-  const int32_t submission_process_id = submission_meta_info.pid();
+  const uint32_t submission_thread_id = submission_meta_info.tid();
+  const uint32_t submission_process_id = submission_meta_info.pid();
   uint64_t submission_pre_submission_cpu_timestamp =
       submission_meta_info.pre_submission_cpu_timestamp();
   uint64_t submission_post_submission_cpu_timestamp =
@@ -327,7 +327,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
     if (completed_marker.has_begin_marker()) {
       const auto& begin_marker_info = completed_marker.begin_marker();
       const auto& begin_marker_meta_info = begin_marker_info.meta_info();
-      const int32_t begin_marker_thread_id = begin_marker_meta_info.tid();
+      const uint32_t begin_marker_thread_id = begin_marker_meta_info.tid();
       uint64_t begin_marker_post_submission_cpu_timestamp =
           begin_marker_meta_info.post_submission_cpu_timestamp();
       uint64_t begin_marker_pre_submission_cpu_timestamp =

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -39,7 +39,7 @@ class CaptureClient {
       : capture_service_{orbit_grpc_protos::CaptureService::NewStub(channel)} {}
 
   orbit_base::Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> Capture(
-      orbit_base::ThreadPool* thread_pool, int32_t process_id,
+      orbit_base::ThreadPool* thread_pool, uint32_t process_id,
       const orbit_client_data::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       bool record_arguments, bool record_return_values,
@@ -73,7 +73,7 @@ class CaptureClient {
 
  private:
   ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureSync(
-      int32_t process_id, const orbit_client_data::ModuleManager& module_manager,
+      uint32_t process_id, const orbit_client_data::ModuleManager& module_manager,
       const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions,
       bool record_arguments, bool record_return_values,
       const orbit_client_data::TracepointInfoSet& selected_tracepoints, double samples_per_second,

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -31,7 +31,7 @@ class CaptureListener {
   virtual void OnUniqueCallstack(uint64_t callstack_id,
                                  orbit_client_protos::CallstackInfo callstack) = 0;
   virtual void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) = 0;
-  virtual void OnThreadName(int32_t thread_id, std::string thread_name) = 0;
+  virtual void OnThreadName(uint32_t thread_id, std::string thread_name) = 0;
   virtual void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) = 0;
   virtual void OnModulesSnapshot(uint64_t timestamp_ns,
                                  std::vector<orbit_grpc_protos::ModuleInfo> module_infos) = 0;

--- a/src/CaptureClient/include/CaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/GpuQueueSubmissionProcessor.h
@@ -87,23 +87,23 @@ class GpuQueueSubmissionProcessor {
   // Finds the GpuJob that is fully inside the given timestamps and happened on the given thread id.
   // Returns `nullptr` if there is no such job.
   [[nodiscard]] const orbit_grpc_protos::GpuJob* FindMatchingGpuJob(
-      int32_t thread_id, uint64_t pre_submission_cpu_timestamp,
+      uint32_t thread_id, uint64_t pre_submission_cpu_timestamp,
       uint64_t post_submission_cpu_timestamp);
 
   // Finds the GpuQueueSubmission that fully contains the given timestamp and happened on the given
   // thread id. Returns `nullptr` if there is no such submission.
   [[nodiscard]] const orbit_grpc_protos::GpuQueueSubmission* FindMatchingGpuQueueSubmission(
-      int32_t thread_id, uint64_t submit_time);
+      uint32_t thread_id, uint64_t submit_time);
 
-  [[nodiscard]] bool HasUnprocessedBeginMarkers(int32_t thread_id,
+  [[nodiscard]] bool HasUnprocessedBeginMarkers(uint32_t thread_id,
                                                 uint64_t post_submission_timestamp) const;
 
-  void DecrementUnprocessedBeginMarkers(int32_t thread_id, uint64_t submission_timestamp,
+  void DecrementUnprocessedBeginMarkers(uint32_t thread_id, uint64_t submission_timestamp,
                                         uint64_t post_submission_timestamp);
 
-  void DeleteSavedGpuJob(int32_t thread_id, uint64_t submission_timestamp);
+  void DeleteSavedGpuJob(uint32_t thread_id, uint64_t submission_timestamp);
 
-  void DeleteSavedGpuSubmission(int32_t thread_id, uint64_t post_submission_timestamp);
+  void DeleteSavedGpuSubmission(uint32_t thread_id, uint64_t post_submission_timestamp);
 
   absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuJob>>
       tid_to_submission_time_to_gpu_job_;

--- a/src/ClientData/CallstackData.cpp
+++ b/src/ClientData/CallstackData.cpp
@@ -65,7 +65,7 @@ std::vector<orbit_client_protos::CallstackEvent> CallstackData::GetCallstackEven
   return callstack_events;
 }
 
-uint32_t CallstackData::GetCallstackEventsOfTidCount(int32_t thread_id) const {
+uint32_t CallstackData::GetCallstackEventsOfTidCount(uint32_t thread_id) const {
   std::lock_guard lock(mutex_);
   const auto& tid_and_events_it = callstack_events_by_tid_.find(thread_id);
   if (tid_and_events_it == callstack_events_by_tid_.end()) {
@@ -75,7 +75,7 @@ uint32_t CallstackData::GetCallstackEventsOfTidCount(int32_t thread_id) const {
 }
 
 std::vector<CallstackEvent> CallstackData::GetCallstackEventsOfTidInTimeRange(
-    int32_t tid, uint64_t time_begin, uint64_t time_end) const {
+    uint32_t tid, uint64_t time_begin, uint64_t time_end) const {
   std::lock_guard lock(mutex_);
   std::vector<CallstackEvent> callstack_events;
 
@@ -120,7 +120,7 @@ void CallstackData::ForEachCallstackEventInTimeRange(
 }
 
 void CallstackData::ForEachCallstackEventOfTidInTimeRange(
-    int32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
+    uint32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
     const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const {
   std::lock_guard lock(mutex_);
   CHECK(min_timestamp <= max_timestamp);

--- a/src/ClientData/CallstackDataTest.cpp
+++ b/src/ClientData/CallstackDataTest.cpp
@@ -28,9 +28,9 @@ MATCHER(CallstackEventEq, "") {
 TEST(CallstackData, FilterCallstackEventsBasedOnMajorityStart) {
   CallstackData callstack_data;
 
-  const int32_t tid = 42;
-  const int32_t tid_with_no_complete = 43;
-  const int32_t tid_without_supermajority = 44;
+  const uint32_t tid = 42;
+  const uint32_t tid_with_no_complete = 43;
+  const uint32_t tid_without_supermajority = 44;
 
   const uint64_t cs1_id = 12;
   const uint64_t cs1_outer = 0x10;

--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -51,7 +51,7 @@ CaptureData::CaptureData(ModuleManager* module_manager, const CaptureStarted& ca
 }
 
 void CaptureData::ForEachThreadStateSliceIntersectingTimeRange(
-    int32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
+    uint32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
     const std::function<void(const ThreadStateSliceInfo&)>& action) const {
   absl::MutexLock lock{&thread_state_slices_mutex_};
   auto tid_thread_state_slices_it = thread_state_slices_.find(thread_id);
@@ -318,7 +318,7 @@ const FunctionInfo* CaptureData::FindFunctionByAddress(uint64_t absolute_address
                                                            result.value().build_id());
 }
 
-int32_t CaptureData::process_id() const { return process_.pid(); }
+uint32_t CaptureData::process_id() const { return process_.pid(); }
 
 std::string CaptureData::process_name() const { return process_.name(); }
 

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -44,7 +44,7 @@ void DataManager::set_highlighted_group_id(uint64_t highlighted_group_id) {
   highlighted_function_id_ = highlighted_group_id;
 }
 
-void DataManager::set_selected_thread_id(int32_t thread_id) {
+void DataManager::set_selected_thread_id(uint32_t thread_id) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_thread_id_ = thread_id;
 }

--- a/src/ClientData/PostProcessedSamplingData.cpp
+++ b/src/ClientData/PostProcessedSamplingData.cpp
@@ -89,7 +89,7 @@ PostProcessedSamplingData::GetSortedCallstackReportFromFunctionAddresses(
 }
 
 const ThreadSampleData* PostProcessedSamplingData::GetThreadSampleDataByThreadId(
-    int32_t thread_id) const {
+    uint32_t thread_id) const {
   auto it = thread_id_to_sample_data_.find(thread_id);
   if (it == thread_id_to_sample_data_.end()) {
     return nullptr;

--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -24,7 +24,7 @@ void ProcessData::SetProcessInfo(const orbit_grpc_protos::ProcessInfo& process_i
   process_info_ = process_info;
 }
 
-int32_t ProcessData::pid() const {
+uint32_t ProcessData::pid() const {
   absl::MutexLock lock(&mutex_);
   return process_info_.pid();
 }

--- a/src/ClientData/ProcessDataTest.cpp
+++ b/src/ClientData/ProcessDataTest.cpp
@@ -28,7 +28,7 @@ using testing::ElementsAre;
 namespace orbit_client_data {
 
 TEST(ProcessData, Constructor) {
-  int32_t pid = 10;
+  uint32_t pid = 10;
   const std::string name = "Process name";
   const double cpu_usage = 55.5;
   const std::string full_path = "/example/path";

--- a/src/ClientData/TracepointData.cpp
+++ b/src/ClientData/TracepointData.cpp
@@ -16,7 +16,7 @@ using orbit_client_protos::TracepointEventInfo;
 namespace orbit_client_data {
 
 void TracepointData::EmplaceTracepointEvent(uint64_t time, uint64_t tracepoint_hash,
-                                            int32_t process_id, int32_t thread_id, int32_t cpu,
+                                            uint32_t process_id, uint32_t thread_id, int32_t cpu,
                                             bool is_same_pid_as_target) {
   absl::MutexLock lock(&mutex_);
   num_total_tracepoint_events_++;
@@ -68,7 +68,7 @@ void ForEachTracepointEventInRange(
 }  // namespace
 
 void TracepointData::ForEachTracepointEventOfThreadInTimeRange(
-    int32_t thread_id, uint64_t min_tick, uint64_t max_tick_exclusive,
+    uint32_t thread_id, uint64_t min_tick, uint64_t max_tick_exclusive,
     const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
   absl::MutexLock lock(&mutex_);
   if (thread_id == orbit_base::kAllThreadsOfAllProcessesTid) {
@@ -91,7 +91,7 @@ void TracepointData::ForEachTracepointEventOfThreadInTimeRange(
   }
 }
 
-uint32_t TracepointData::GetNumTracepointEventsForThreadId(int32_t thread_id) const {
+uint32_t TracepointData::GetNumTracepointEventsForThreadId(uint32_t thread_id) const {
   absl::MutexLock lock(&mutex_);
   if (thread_id == orbit_base::kAllThreadsOfAllProcessesTid) {
     return num_total_tracepoint_events_;

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -43,10 +43,10 @@ class CallstackData {
   [[nodiscard]] std::vector<orbit_client_protos::CallstackEvent> GetCallstackEventsInTimeRange(
       uint64_t time_begin, uint64_t time_end) const;
 
-  [[nodiscard]] uint32_t GetCallstackEventsOfTidCount(int32_t thread_id) const;
+  [[nodiscard]] uint32_t GetCallstackEventsOfTidCount(uint32_t thread_id) const;
 
   [[nodiscard]] std::vector<orbit_client_protos::CallstackEvent> GetCallstackEventsOfTidInTimeRange(
-      int32_t tid, uint64_t time_begin, uint64_t time_end) const;
+      uint32_t tid, uint64_t time_begin, uint64_t time_end) const;
 
   void ForEachCallstackEvent(
       const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
@@ -56,7 +56,7 @@ class CallstackData {
       const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
 
   void ForEachCallstackEventOfTidInTimeRange(
-      int32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
+      uint32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
       const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
 
   [[nodiscard]] uint64_t max_time() const {

--- a/src/ClientData/include/ClientData/CallstackTypes.h
+++ b/src/ClientData/include/ClientData/CallstackTypes.h
@@ -9,7 +9,7 @@
 
 namespace orbit_client_data {
 
-using ThreadID = int32_t;
+using ThreadID = uint32_t;
 
 }  // namespace orbit_client_data
 

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -64,7 +64,7 @@ class CaptureData {
   [[nodiscard]] std::optional<uint64_t> FindInstrumentedFunctionIdSlow(
       const orbit_client_protos::FunctionInfo& function) const;
 
-  [[nodiscard]] int32_t process_id() const;
+  [[nodiscard]] uint32_t process_id() const;
 
   [[nodiscard]] std::string process_name() const;
 
@@ -105,13 +105,13 @@ class CaptureData {
     return thread_names_;
   }
 
-  [[nodiscard]] const std::string& GetThreadName(int32_t thread_id) const {
+  [[nodiscard]] const std::string& GetThreadName(uint32_t thread_id) const {
     static const std::string kEmptyString;
     auto it = thread_names_.find(thread_id);
     return it != thread_names_.end() ? it->second : kEmptyString;
   }
 
-  void AddOrAssignThreadName(int32_t thread_id, std::string thread_name) {
+  void AddOrAssignThreadName(uint32_t thread_id, std::string thread_name) {
     thread_names_.insert_or_assign(thread_id, std::move(thread_name));
   }
 
@@ -121,7 +121,7 @@ class CaptureData {
     return thread_state_slices_;
   }
 
-  [[nodiscard]] bool HasThreadStatesForThread(int32_t tid) const {
+  [[nodiscard]] bool HasThreadStatesForThread(uint32_t tid) const {
     absl::MutexLock lock{&thread_state_slices_mutex_};
     return thread_state_slices_.count(tid) > 0;
   }
@@ -134,7 +134,7 @@ class CaptureData {
   // Allows the caller to iterate `action` over all the thread state slices of the specified thread
   // in the time range while holding for the whole time the internal mutex, acquired only once.
   void ForEachThreadStateSliceIntersectingTimeRange(
-      int32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
+      uint32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
       const std::function<void(const orbit_client_protos::ThreadStateSliceInfo&)>& action) const;
 
   [[nodiscard]] const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats>&
@@ -158,13 +158,13 @@ class CaptureData {
   }
 
   void ForEachTracepointEventOfThreadInTimeRange(
-      int32_t thread_id, uint64_t min_tick, uint64_t max_tick,
+      uint32_t thread_id, uint64_t min_tick, uint64_t max_tick,
       const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
     return tracepoint_data_.ForEachTracepointEventOfThreadInTimeRange(thread_id, min_tick, max_tick,
                                                                       action);
   }
 
-  uint32_t GetNumTracepointsForThreadId(int32_t thread_id) const {
+  uint32_t GetNumTracepointsForThreadId(uint32_t thread_id) const {
     return tracepoint_data_.GetNumTracepointEventsForThreadId(thread_id);
   }
 
@@ -186,7 +186,7 @@ class CaptureData {
   }
 
   void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash,
-                                         int32_t process_id, int32_t thread_id, int32_t cpu,
+                                         uint32_t process_id, uint32_t thread_id, int32_t cpu,
                                          bool is_same_pid_as_target) {
     tracepoint_data_.EmplaceTracepointEvent(time, tracepoint_hash, process_id, thread_id, cpu,
                                             is_same_pid_as_target);

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -37,7 +37,7 @@ class DataManager final {
   void set_visible_function_ids(absl::flat_hash_set<uint64_t> visible_function_ids);
   void set_highlighted_function_id(uint64_t highlighted_function_id);
   void set_highlighted_group_id(uint64_t highlighted_function_id);
-  void set_selected_thread_id(int32_t thread_id);
+  void set_selected_thread_id(uint32_t thread_id);
   void set_selected_timer(const orbit_client_protos::TimerInfo* timer_info);
 
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& function) const;

--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -99,7 +99,7 @@ class PostProcessedSamplingData {
   [[nodiscard]] const std::vector<ThreadSampleData>& GetThreadSampleData() const {
     return sorted_thread_sample_data_;
   }
-  [[nodiscard]] const ThreadSampleData* GetThreadSampleDataByThreadId(int32_t thread_id) const;
+  [[nodiscard]] const ThreadSampleData* GetThreadSampleDataByThreadId(uint32_t thread_id) const;
 
   [[nodiscard]] const ThreadSampleData* GetSummary() const;
   [[nodiscard]] uint32_t GetCountOfFunction(uint64_t function_address) const;

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -60,7 +60,7 @@ class ProcessData final {
 
   void SetProcessInfo(const orbit_grpc_protos::ProcessInfo& process_info);
 
-  [[nodiscard]] int32_t pid() const;
+  [[nodiscard]] uint32_t pid() const;
   [[nodiscard]] const std::string& name() const;
   [[nodiscard]] double cpu_usage() const;
   [[nodiscard]] const std::string& full_path() const;

--- a/src/ClientData/include/ClientData/TracepointData.h
+++ b/src/ClientData/include/ClientData/TracepointData.h
@@ -37,17 +37,17 @@ namespace orbit_client_data {
 class TracepointData {
  public:
   // Assume that the corresponding tracepoint of tracepoint_hash is already in unique_tracepoints_
-  void EmplaceTracepointEvent(uint64_t time, uint64_t tracepoint_hash, int32_t process_id,
-                              int32_t thread_id, int32_t cpu, bool is_same_pid_as_target);
+  void EmplaceTracepointEvent(uint64_t time, uint64_t tracepoint_hash, uint32_t process_id,
+                              uint32_t thread_id, int32_t cpu, bool is_same_pid_as_target);
 
   void ForEachTracepointEventOfThreadInTimeRange(
-      int32_t thread_id, uint64_t min_tick, uint64_t max_tick_exclusive,
+      uint32_t thread_id, uint64_t min_tick, uint64_t max_tick_exclusive,
       const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const;
 
   void ForEachTracepointEvent(
       const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const;
 
-  uint32_t GetNumTracepointEventsForThreadId(int32_t thread_id) const;
+  uint32_t GetNumTracepointEventsForThreadId(uint32_t thread_id) const;
 
   bool AddUniqueTracepointInfo(uint64_t key, orbit_grpc_protos::TracepointInfo tracepoint);
 
@@ -63,7 +63,7 @@ class TracepointData {
   mutable absl::Mutex mutex_;
   mutable absl::Mutex unique_tracepoints_mutex_;
 
-  absl::flat_hash_map<int32_t, std::map<uint64_t, orbit_client_protos::TracepointEventInfo> >
+  absl::flat_hash_map<uint32_t, std::map<uint64_t, orbit_client_protos::TracepointEventInfo> >
       thread_id_to_time_to_tracepoint_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::TracepointInfo> unique_tracepoints_;
 };

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -146,7 +146,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
     capture_data_.AddUniqueCallstack(callstack_id, std::move(callstack_info));
   }
 
-  void AddCallstackEvent(uint64_t callstack_id, int32_t thread_id) {
+  void AddCallstackEvent(uint64_t callstack_id, uint32_t thread_id) {
     current_callstack_timestamp_ns_ += 100;
     CallstackEvent callstack_event;
     callstack_event.set_time(current_callstack_timestamp_ns_);
@@ -805,7 +805,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
     EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction4Instruction1AbsoluteAddress), 1);
   }
 
-  void VerifyEmptySortedCallstackReport(int32_t thread_id) {
+  void VerifyEmptySortedCallstackReport(uint32_t thread_id) {
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
 
@@ -853,7 +853,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
   }
 
-  void VerifySortedCallstackReportForCallstackEventsAllInTheSameThread(int32_t thread_id) {
+  void VerifySortedCallstackReportForCallstackEventsAllInTheSameThread(uint32_t thread_id) {
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
 
@@ -910,7 +910,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
 
   void
   VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithOnlyNonCompleteCallstackInfos(
-      int32_t thread_id) {
+      uint32_t thread_id) {
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
 
@@ -962,7 +962,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   }
 
   void VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
-      int32_t thread_id) {
+      uint32_t thread_id) {
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
 
@@ -1016,7 +1016,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   }
 
   void VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithoutAddressInfo(
-      int32_t thread_id) {
+      uint32_t thread_id) {
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
 
@@ -1072,7 +1072,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   }
 
   void VerifySortedCallstackReportForCallstackEventsInThreadId1() {
-    int32_t thread_id = kThreadId1;
+    uint32_t thread_id = kThreadId1;
 
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
@@ -1126,7 +1126,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   }
 
   void VerifySortedCallstackReportForCallstackEventsInThreadId2() {
-    int32_t thread_id = kThreadId2;
+    uint32_t thread_id = kThreadId2;
 
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
@@ -1179,7 +1179,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   }
 
   void VerifySortedCallstackReportForCallstackEventsInThreadId1WithMixedCallstackTypes() {
-    int32_t thread_id = kThreadId1;
+    uint32_t thread_id = kThreadId1;
 
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
@@ -1231,7 +1231,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   }
 
   void VerifySortedCallstackReportForCallstackEventsInThreadId2WithMixedCallstackTypes() {
-    int32_t thread_id = kThreadId2;
+    uint32_t thread_id = kThreadId2;
 
     EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -19,7 +19,7 @@ message FunctionStats {
 }
 
 message ProcessInfo {
-  int32 pid = 1;
+  uint32 pid = 1;
   string name = 2;
   double cpu_usage = 3;
   string full_path = 4;
@@ -50,7 +50,7 @@ message FunctionInfo {
 message CallstackEvent {
   uint64 time = 1;
   uint64 callstack_id = 2;
-  int32 thread_id = 3;
+  uint32 thread_id = 3;
 }
 
 message CallstackInfo {
@@ -74,7 +74,7 @@ message CallstackInfo {
 
 message ThreadStateSliceInfo {
   // pid is absent as we don't yet get that information from the service.
-  int32 tid = 1;
+  uint32 tid = 1;
   enum ThreadState {
     kRunning = 0;
     kRunnable = 1;
@@ -99,8 +99,8 @@ message TracepointInfo {
 }
 
 message TracepointEventInfo {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   int64 time = 3;
   int32 cpu = 4;
   uint64 tracepoint_info_key = 5;
@@ -139,8 +139,8 @@ message TimerInfo {
   // NextID: 18
   uint64 start = 1;
   uint64 end = 2;
-  int32 process_id = 3;
-  int32 thread_id = 4;
+  uint32 process_id = 3;
+  uint32 thread_id = 4;
   uint32 depth = 5;
 
   enum Type {
@@ -174,8 +174,8 @@ message TimerInfo {
 }
 
 message ApiStringEvent {
-  int32 process_id = 1;
-  int32 thread_id = 2;
+  uint32 process_id = 1;
+  uint32 thread_id = 2;
   uint64 timestamp_ns = 3;
 
   uint64 async_scope_id = 4;
@@ -184,8 +184,8 @@ message ApiStringEvent {
 
 message ApiTrackValue {
   // NextID: 11
-  int32 process_id = 1;
-  int32 thread_id = 2;
+  uint32 process_id = 1;
+  uint32 thread_id = 2;
   uint64 timestamp_ns = 3;
   string name = 4;
 

--- a/src/ClientServices/ProcessClient.cpp
+++ b/src/ClientServices/ProcessClient.cpp
@@ -63,7 +63,7 @@ ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> ProcessClient::GetPr
   return std::vector<ProcessInfo>(processes.begin(), processes.end());
 }
 
-ErrorMessageOr<std::vector<ModuleInfo>> ProcessClient::LoadModuleList(int32_t pid) {
+ErrorMessageOr<std::vector<ModuleInfo>> ProcessClient::LoadModuleList(uint32_t pid) {
   ORBIT_SCOPE_FUNCTION;
   GetModuleListRequest request;
   GetModuleListResponse response;
@@ -100,7 +100,7 @@ ErrorMessageOr<std::string> ProcessClient::FindDebugInfoFile(const std::string& 
   return response.debug_info_file_path();
 }
 
-ErrorMessageOr<std::string> ProcessClient::LoadProcessMemory(int32_t pid, uint64_t address,
+ErrorMessageOr<std::string> ProcessClient::LoadProcessMemory(uint32_t pid, uint64_t address,
                                                              uint64_t size) {
   ORBIT_SCOPE_FUNCTION;
   GetProcessMemoryRequest request;

--- a/src/ClientServices/ProcessManager.cpp
+++ b/src/ClientServices/ProcessManager.cpp
@@ -38,12 +38,12 @@ class ProcessManagerImpl final : public ProcessManager {
   void SetProcessListUpdateListener(
       const std::function<void(std::vector<orbit_grpc_protos::ProcessInfo>)>& listener) override;
 
-  ErrorMessageOr<std::vector<ModuleInfo>> LoadModuleList(int32_t pid) override;
+  ErrorMessageOr<std::vector<ModuleInfo>> LoadModuleList(uint32_t pid) override;
 
-  ErrorMessageOr<std::string> LoadProcessMemory(int32_t pid, uint64_t address,
+  ErrorMessageOr<std::string> LoadProcessMemory(uint32_t pid, uint64_t address,
                                                 uint64_t size) override;
 
-  ErrorMessageOr<std::string> LoadNullTerminatedString(int32_t pid, uint64_t address) override;
+  ErrorMessageOr<std::string> LoadNullTerminatedString(uint32_t pid, uint64_t address) override;
 
   ErrorMessageOr<std::string> FindDebugInfoFile(const std::string& module_path) override;
 
@@ -77,7 +77,7 @@ void ProcessManagerImpl::SetProcessListUpdateListener(
   process_list_update_listener_ = listener;
 }
 
-ErrorMessageOr<std::vector<ModuleInfo>> ProcessManagerImpl::LoadModuleList(int32_t pid) {
+ErrorMessageOr<std::vector<ModuleInfo>> ProcessManagerImpl::LoadModuleList(uint32_t pid) {
   return process_client_->LoadModuleList(pid);
 }
 
@@ -124,12 +124,12 @@ void ProcessManagerImpl::WorkerFunction() {
   }
 }
 
-ErrorMessageOr<std::string> ProcessManagerImpl::LoadProcessMemory(int32_t pid, uint64_t address,
+ErrorMessageOr<std::string> ProcessManagerImpl::LoadProcessMemory(uint32_t pid, uint64_t address,
                                                                   uint64_t size) {
   return process_client_->LoadProcessMemory(pid, address, size);
 }
 
-ErrorMessageOr<std::string> ProcessManagerImpl::LoadNullTerminatedString(int32_t pid,
+ErrorMessageOr<std::string> ProcessManagerImpl::LoadNullTerminatedString(uint32_t pid,
                                                                          uint64_t address) {
   constexpr uint64_t kMaxSize = 256;
   auto error_or_string = LoadProcessMemory(pid, address, kMaxSize);

--- a/src/ClientServices/include/ClientServices/ProcessClient.h
+++ b/src/ClientServices/include/ClientServices/ProcessClient.h
@@ -30,11 +30,11 @@ class ProcessClient {
   [[nodiscard]] ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> GetProcessList();
 
   [[nodiscard]] ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(
-      int32_t pid);
+      uint32_t pid);
 
   [[nodiscard]] ErrorMessageOr<std::string> FindDebugInfoFile(const std::string& module_path);
 
-  [[nodiscard]] ErrorMessageOr<std::string> LoadProcessMemory(int32_t pid, uint64_t address,
+  [[nodiscard]] ErrorMessageOr<std::string> LoadProcessMemory(uint32_t pid, uint64_t address,
                                                               uint64_t size);
 
  private:

--- a/src/ClientServices/include/ClientServices/ProcessManager.h
+++ b/src/ClientServices/include/ClientServices/ProcessManager.h
@@ -49,12 +49,12 @@ class ProcessManager {
       const std::function<void(std::vector<orbit_grpc_protos::ProcessInfo>)>& listener) = 0;
 
   virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(
-      int32_t pid) = 0;
+      uint32_t pid) = 0;
 
-  virtual ErrorMessageOr<std::string> LoadProcessMemory(int32_t pid, uint64_t address,
+  virtual ErrorMessageOr<std::string> LoadProcessMemory(uint32_t pid, uint64_t address,
                                                         uint64_t size) = 0;
 
-  virtual ErrorMessageOr<std::string> LoadNullTerminatedString(int32_t pid, uint64_t address) = 0;
+  virtual ErrorMessageOr<std::string> LoadNullTerminatedString(uint32_t pid, uint64_t address) = 0;
 
   virtual ErrorMessageOr<std::string> FindDebugInfoFile(const std::string& module_path) = 0;
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -291,7 +291,7 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
         app_->DisableFrameTrack(selected_function);
         app_->RemoveFrameTrack(selected_function);
       } else if (action == kMenuActionDisassembly) {
-        int32_t pid = capture_data.process_id();
+        uint32_t pid = capture_data.process_id();
         app_->Disassemble(pid, selected_function);
       } else if (action == kMenuActionSourceCode) {
         app_->ShowSourceCode(selected_function);

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -73,7 +73,7 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(void, RemoveFrameTrack, (const orbit_client_protos::FunctionInfo&));
   MOCK_METHOD(void, RemoveFrameTrack, (uint64_t instrumented_function_id));
 
-  MOCK_METHOD(void, Disassemble, (int32_t pid, const orbit_client_protos::FunctionInfo&));
+  MOCK_METHOD(void, Disassemble, (uint32_t pid, const orbit_client_protos::FunctionInfo&));
   MOCK_METHOD(void, ShowSourceCode, (const orbit_client_protos::FunctionInfo&));
 };
 

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -84,7 +84,7 @@ class AppInterface {
   virtual void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function) = 0;
   virtual void RemoveFrameTrack(uint64_t instrumented_function_id) = 0;
 
-  virtual void Disassemble(int32_t pid, const orbit_client_protos::FunctionInfo& function) = 0;
+  virtual void Disassemble(uint32_t pid, const orbit_client_protos::FunctionInfo& function) = 0;
   virtual void ShowSourceCode(const orbit_client_protos::FunctionInfo& function) = 0;
 };
 

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -154,7 +154,7 @@ int main(int argc, char* argv[]) {
               (absl::GetFlag(FLAGS_instrument_offset) == 0),
           "Binary path and offset of the function to instrument need to be specified together");
 
-  int32_t process_id = absl::GetFlag(FLAGS_pid);
+  uint32_t process_id = absl::GetFlag(FLAGS_pid);
   LOG("process_id=%d", process_id);
   uint16_t samples_per_second = absl::GetFlag(FLAGS_sampling_rate);
   LOG("samples_per_second=%u", samples_per_second);

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -41,7 +41,7 @@ message ApiFunction {
 // NextId: 18
 message CaptureOptions {
   bool trace_context_switches = 1;
-  int32 pid = 2;
+  uint32 pid = 2;
   double samples_per_second = 3;
   // Expected to be "uint16".
   uint32 stack_dump_size = 16;
@@ -88,8 +88,8 @@ message CaptureOptions {
 
 message SchedulingSlice {
   reserved 4;
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   int32 core = 3;
   uint64 duration_ns = 6;
   uint64 out_timestamp_ns = 5;
@@ -97,8 +97,8 @@ message SchedulingSlice {
 
 message FunctionCall {
   reserved 4;
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 function_id = 3;
   uint64 duration_ns = 9;
   uint64 end_timestamp_ns = 5;
@@ -108,8 +108,8 @@ message FunctionCall {
 }
 
 message ApiEvent {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   // The fields below are used to encode orbit_api::EncodedEvent events. This is
@@ -127,8 +127,8 @@ message ApiEvent {
 message ApiScopeStart {
   // NextID: 16
 
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   // We encode the first 64 characters of the scope's name/label using fixed64
@@ -155,16 +155,16 @@ message ApiScopeStart {
 }
 
 message ApiScopeStop {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 }
 
 message ApiScopeStartAsync {
   // NextID: 16
 
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   // Encoded for performance. See `ApiScopeStart` message for details.
@@ -184,8 +184,8 @@ message ApiScopeStartAsync {
 }
 
 message ApiScopeStopAsync {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
   uint64 id = 4;
 }
@@ -193,8 +193,8 @@ message ApiScopeStopAsync {
 message ApiStringEvent {
   // NextID: 15
 
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   // Encoded for performance. See `ApiScopeStart` message for details.
@@ -215,8 +215,8 @@ message ApiStringEvent {
 
 message ApiTrackInt {
   // NextID: 15
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   int32 data = 4;
@@ -237,8 +237,8 @@ message ApiTrackInt {
 
 message ApiTrackInt64 {
   // NextID: 15
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   int64 data = 4;
@@ -259,8 +259,8 @@ message ApiTrackInt64 {
 
 message ApiTrackUint {
   // NextID: 15
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   uint32 data = 4;
@@ -281,8 +281,8 @@ message ApiTrackUint {
 
 message ApiTrackUint64 {
   // NextID: 15
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   uint64 data = 4;
@@ -303,8 +303,8 @@ message ApiTrackUint64 {
 
 message ApiTrackFloat {
   // NextID: 15
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   float data = 4;
@@ -325,8 +325,8 @@ message ApiTrackFloat {
 
 message ApiTrackDouble {
   // NextID: 15
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
 
   double data = 4;
@@ -368,15 +368,15 @@ message InternedCallstack {
 }
 
 message CallstackSample {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 callstack_id = 3;
   uint64 timestamp_ns = 4;
 }
 
 message FullCallstackSample {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   Callstack callstack = 3;
   uint64 timestamp_ns = 4;
 }
@@ -393,24 +393,24 @@ message InternedTracepointInfo {
 }
 
 message TracepointEvent {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
   int32 cpu = 4;
   uint64 tracepoint_info_key = 5;
 }
 
 message FullTracepointEvent {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint64 timestamp_ns = 3;
   int32 cpu = 4;
   TracepointInfo tracepoint_info = 5;
 }
 
 message FullGpuJob {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint32 context = 3;
   uint32 seqno = 4;
   int32 depth = 5;
@@ -423,8 +423,8 @@ message FullGpuJob {
 }
 
 message GpuJob {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   uint32 context = 3;
   uint32 seqno = 4;
   int32 depth = 5;
@@ -444,8 +444,8 @@ message GpuQueueSubmission {
 }
 
 message GpuQueueSubmissionMetaInfo {
-  int32 tid = 1;
-  int32 pid = 4;
+  uint32 tid = 1;
+  uint32 pid = 4;
   uint64 pre_submission_cpu_timestamp = 2;
   uint64 post_submission_cpu_timestamp = 3;
 }
@@ -484,8 +484,8 @@ message Color {
 }
 
 message ThreadName {
-  int32 pid = 1;
-  int32 tid = 2;
+  uint32 pid = 1;
+  uint32 tid = 2;
   // This is a string, we use bytes to avoid UTF-8 validation.
   bytes name = 3;
   uint64 timestamp_ns = 4;
@@ -493,8 +493,8 @@ message ThreadName {
 
 message ThreadStateSlice {
   reserved 4;
-  int32 pid = 1;  // pid is currently not set as we don't have the information.
-  int32 tid = 2;
+  uint32 pid = 1;  // pid is currently not set as we don't have the information.
+  uint32 tid = 2;
 
   // These are the ones listed in
   // /sys/kernel/debug/tracing/events/sched/sched_switch/format and in
@@ -538,7 +538,7 @@ message FullAddressInfo {
 }
 
 message ModuleUpdateEvent {
-  int32 pid = 1;
+  uint32 pid = 1;
   uint64 timestamp_ns = 2;
   ModuleInfo module = 3;
 }
@@ -560,7 +560,7 @@ message SystemMemoryUsage {
 
 message ProcessMemoryUsage {
   reserved 3;
-  int32 pid = 1;
+  uint32 pid = 1;
   uint64 timestamp_ns = 2;
   // These fields are retrieved from /proc/<pid>/stat. See
   // https://man7.org/linux/man-pages/man5/proc.5.html for the documentation.
@@ -602,7 +602,7 @@ message MemoryUsageEvent {
 }
 
 message ModulesSnapshot {
-  int32 pid = 1;
+  uint32 pid = 1;
   uint64 timestamp_ns = 2;
   repeated ModuleInfo modules = 3;
 }
@@ -625,7 +625,7 @@ message CaptureFinished {
 
 message CaptureStarted {
   // NextID: 9
-  int32 process_id = 1;
+  uint32 process_id = 1;
   string executable_path = 2;
   string executable_build_id = 3;
   uint64 capture_start_timestamp_ns = 4;

--- a/src/GrpcProtos/process.proto
+++ b/src/GrpcProtos/process.proto
@@ -7,7 +7,7 @@ syntax = "proto3";
 package orbit_grpc_protos;
 
 message ProcessInfo {
-  int32 pid = 1;
+  uint32 pid = 1;
   string name = 2;
   double cpu_usage = 3;
   string full_path = 4;

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -32,7 +32,7 @@ message GetProcessListResponse {
 }
 
 message GetModuleListRequest {
-  int32 process_id = 1;
+  uint32 process_id = 1;
 }
 
 message GetModuleListResponse {
@@ -46,7 +46,7 @@ message GetTracepointListResponse {
 }
 
 message GetProcessMemoryRequest {
-  int32 pid = 1;
+  uint32 pid = 1;
   uint64 address = 2;
   uint64 size = 3;
 }

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -103,8 +103,8 @@ void TracingListener::DeferApiEventProcessing(const orbit_api::ApiEventVariant& 
 }
 
 void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_id) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
 #ifdef WIN32
   void* return_address = _ReturnAddress();
@@ -126,16 +126,16 @@ void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_
 }
 
 void orbit_api_stop() {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiScopeStop api_scope_stop{process_id, thread_id, timestamp_ns};
   TracingListener::DeferApiEventProcessing(api_scope_stop);
 }
 
 void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
 #ifdef WIN32
   void* return_address = _ReturnAddress();
@@ -158,64 +158,64 @@ void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color)
 }
 
 void orbit_api_stop_async(uint64_t id) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiScopeStopAsync api_scope_stop_async{process_id, thread_id, timestamp_ns, id};
   TracingListener::DeferApiEventProcessing(api_scope_stop_async);
 }
 
 void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiStringEvent api_string_event{process_id, thread_id, timestamp_ns, str, id, color};
   TracingListener::DeferApiEventProcessing(api_string_event);
 }
 
 void orbit_api_track_int(const char* name, int value, orbit_api_color color) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackInt api_track{process_id, thread_id, timestamp_ns, name, value, color};
   TracingListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_int64(const char* name, int64_t value, orbit_api_color color) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackInt64 api_track{process_id, thread_id, timestamp_ns, name, value, color};
   TracingListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_uint(const char* name, uint32_t value, orbit_api_color color) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackUint api_track{process_id, thread_id, timestamp_ns, name, value, color};
   TracingListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_uint64(const char* name, uint64_t value, orbit_api_color color) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackUint64 api_track{process_id, thread_id, timestamp_ns, name, value, color};
   TracingListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_float(const char* name, float value, orbit_api_color color) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackFloat api_track{process_id, thread_id, timestamp_ns, name, value, color};
   TracingListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_double(const char* name, double value, orbit_api_color color) {
-  int32_t process_id = orbit_base::GetCurrentProcessId();
-  int32_t thread_id = orbit_base::GetCurrentThreadId();
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackDouble api_track{process_id, thread_id, timestamp_ns, name, value, color};
   TracingListener::DeferApiEventProcessing(api_track);

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -112,8 +112,8 @@ std::unique_ptr<DmaFenceSignaledPerfEvent> MakeFakeDmaFenceSignaledPerfEvent(
   return event;
 }
 
-orbit_grpc_protos::FullGpuJob MakeGpuJob(int32_t pid, int32_t tid, uint32_t context, uint32_t seqno,
-                                         std::string timeline, int32_t depth,
+orbit_grpc_protos::FullGpuJob MakeGpuJob(uint32_t pid, uint32_t tid, uint32_t context,
+                                         uint32_t seqno, std::string timeline, int32_t depth,
                                          uint64_t amdgpu_cs_ioctl_time_ns,
                                          uint64_t amdgpu_sched_run_job_time_ns,
                                          uint64_t gpu_hardware_start_time_ns,

--- a/src/LinuxTracing/LinuxTracingUtilsTest.cpp
+++ b/src/LinuxTracing/LinuxTracingUtilsTest.cpp
@@ -28,7 +28,7 @@ namespace orbit_linux_tracing {
 TEST(GetThreadName, LinuxTracingTests) {
   // Thread names have a length limit of 15 characters.
   std::string expected_name = std::string{"LinuxTracingTests"}.substr(0, 15);
-  std::string returned_name = orbit_base::GetThreadName(getpid());
+  std::string returned_name = orbit_base::GetThreadNameNative(getpid());
   EXPECT_EQ(returned_name, expected_name);
 }
 

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -342,7 +342,7 @@ class UretprobesWithReturnValuePerfEvent : public UretprobesPerfEventBase<perf_e
 
 class MmapPerfEvent : public PerfEvent {
  public:
-  MmapPerfEvent(int32_t pid, uint64_t timestamp, const perf_event_mmap_up_to_pgoff& mmap_event,
+  MmapPerfEvent(pid_t pid, uint64_t timestamp, const perf_event_mmap_up_to_pgoff& mmap_event,
                 std::string filename)
       : pid_{pid}, timestamp_{timestamp}, mmap_event_{mmap_event}, filename_{std::move(filename)} {}
 
@@ -351,13 +351,13 @@ class MmapPerfEvent : public PerfEvent {
   void Accept(PerfEventVisitor* visitor) override;
 
   [[nodiscard]] const std::string& filename() const { return filename_; }
-  [[nodiscard]] int32_t pid() const { return pid_; }
+  [[nodiscard]] pid_t pid() const { return pid_; }
   [[nodiscard]] uint64_t address() const { return mmap_event_.address; }
   [[nodiscard]] uint64_t length() const { return mmap_event_.length; }
   [[nodiscard]] uint64_t page_offset() const { return mmap_event_.page_offset; }
 
  private:
-  int32_t pid_;
+  pid_t pid_;
   uint64_t timestamp_;
   perf_event_mmap_up_to_pgoff mmap_event_;
   std::string filename_;

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<MmapPerfEvent> ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_bu
 
   // Workaround for gcc's "cannot bind packed field ... to ‘long unsigned int&’"
   uint64_t timestamp = sample_id.time;
-  uint32_t pid = sample_id.pid;
+  int32_t pid = static_cast<int32_t>(sample_id.pid);
 
   // Consider moving this to MMAP2 event which has more information (like flags)
   return std::make_unique<MmapPerfEvent>(pid, timestamp, mmap_event, std::move(filename));

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<MmapPerfEvent> ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_bu
 
   // Workaround for gcc's "cannot bind packed field ... to ‘long unsigned int&’"
   uint64_t timestamp = sample_id.time;
-  int32_t pid = static_cast<int32_t>(sample_id.pid);
+  uint32_t pid = sample_id.pid;
 
   // Consider moving this to MMAP2 event which has more information (like flags)
   return std::make_unique<MmapPerfEvent>(pid, timestamp, mmap_event, std::move(filename));

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "TracingInterface/TracerListener.h"
 
 namespace orbit_linux_tracing {
@@ -121,7 +122,7 @@ void SwitchesStatesNamesVisitor::Visit(SchedSwitchPerfEvent* event) {
         prev_pid, event->GetPrevTid(), event->GetCpu(), event->GetTimestamp());
     if (scheduling_slice.has_value()) {
       CHECK(listener_ != nullptr);
-      if (scheduling_slice->pid() == -1) {
+      if (scheduling_slice->pid() == orbit_base::kInvalidProcessId) {
         ERROR("SchedulingSlice with unknown pid");
       }
       listener_->OnSchedulingSlice(std::move(scheduling_slice.value()));

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -51,7 +51,7 @@ using orbit_grpc_protos::ThreadNamesSnapshot;
 
 TracerThread::TracerThread(const CaptureOptions& capture_options)
     : trace_context_switches_{capture_options.trace_context_switches()},
-      target_pid_{orbit_base::GetNativeProcessId(capture_options.pid())},
+      target_pid_{orbit_base::ToNativeProcessId(capture_options.pid())},
       unwinding_method_{capture_options.unwinding_method()},
       trace_thread_state_{capture_options.trace_thread_state()},
       trace_gpu_driver_{capture_options.trace_gpu_driver()} {

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -51,7 +51,7 @@ using orbit_grpc_protos::ThreadNamesSnapshot;
 
 TracerThread::TracerThread(const CaptureOptions& capture_options)
     : trace_context_switches_{capture_options.trace_context_switches()},
-      target_pid_{capture_options.pid()},
+      target_pid_{orbit_base::GetNativeProcessId(capture_options.pid())},
       unwinding_method_{capture_options.unwinding_method()},
       trace_thread_state_{capture_options.trace_thread_state()},
       trace_gpu_driver_{capture_options.trace_gpu_driver()} {
@@ -526,7 +526,7 @@ static std::vector<ThreadName> RetrieveInitialThreadNamesSystemWide(uint64_t ini
   std::vector<ThreadName> thread_names;
   for (pid_t pid : GetAllPids()) {
     for (pid_t tid : GetTidsOfProcess(pid)) {
-      std::string name = orbit_base::GetThreadName(tid);
+      std::string name = orbit_base::GetThreadNameNative(tid);
       if (name.empty()) {
         continue;
       }

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -330,7 +330,7 @@ class LinuxTracingIntegrationTestFixture {
 
   [[nodiscard]] pid_t GetPuppetPidNative() const { return puppet_.GetChildPidNative(); }
   [[nodiscard]] uint32_t GetPuppetPid() const {
-    return orbit_base::GetThreadIdFromNative(GetPuppetPidNative());
+    return orbit_base::GetProcessIdFromNative(GetPuppetPidNative());
   }
 
   void WriteLineToPuppet(std::string_view str) { puppet_.WriteLine(str); }
@@ -340,7 +340,7 @@ class LinuxTracingIntegrationTestFixture {
   [[nodiscard]] orbit_grpc_protos::CaptureOptions BuildDefaultCaptureOptions() {
     orbit_grpc_protos::CaptureOptions capture_options;
     capture_options.set_trace_context_switches(true);
-    capture_options.set_pid(puppet_.GetChildPidNative());
+    capture_options.set_pid(orbit_base::GetProcessIdFromNative(puppet_.GetChildPidNative()));
     capture_options.set_samples_per_second(1000.0);
     capture_options.set_stack_dump_size(65000);
     capture_options.set_unwinding_method(orbit_grpc_protos::CaptureOptions::kDwarf);

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -330,7 +330,7 @@ class LinuxTracingIntegrationTestFixture {
 
   [[nodiscard]] pid_t GetPuppetPidNative() const { return puppet_.GetChildPidNative(); }
   [[nodiscard]] uint32_t GetPuppetPid() const {
-    return orbit_base::GetProcessIdFromNative(GetPuppetPidNative());
+    return orbit_base::FromNativeProcessId(GetPuppetPidNative());
   }
 
   void WriteLineToPuppet(std::string_view str) { puppet_.WriteLine(str); }
@@ -340,7 +340,7 @@ class LinuxTracingIntegrationTestFixture {
   [[nodiscard]] orbit_grpc_protos::CaptureOptions BuildDefaultCaptureOptions() {
     orbit_grpc_protos::CaptureOptions capture_options;
     capture_options.set_trace_context_switches(true);
-    capture_options.set_pid(orbit_base::GetProcessIdFromNative(puppet_.GetChildPidNative()));
+    capture_options.set_pid(orbit_base::FromNativeProcessId(puppet_.GetChildPidNative()));
     capture_options.set_samples_per_second(1000.0);
     capture_options.set_stack_dump_size(65000);
     capture_options.set_unwinding_method(orbit_grpc_protos::CaptureOptions::kDwarf);

--- a/src/MemoryTracing/MemoryInfoProducer.cpp
+++ b/src/MemoryTracing/MemoryInfoProducer.cpp
@@ -63,7 +63,7 @@ void SystemMemoryInfoProducerRunFn(MemoryInfoListener* listener, int32_t /*pid*/
 
 std::unique_ptr<MemoryInfoProducer> CreateSystemMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
-                                                                   int32_t pid) {
+                                                                   uint32_t pid) {
   std::unique_ptr<MemoryInfoProducer> system_memory_info_producer =
       std::make_unique<MemoryInfoProducer>(
           sampling_period_ns, pid, [](MemoryInfoListener* listener, int32_t /*pid*/) {
@@ -79,10 +79,10 @@ std::unique_ptr<MemoryInfoProducer> CreateSystemMemoryInfoProducer(MemoryInfoLis
 
 std::unique_ptr<MemoryInfoProducer> CreateCGroupMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
-                                                                   int32_t pid) {
+                                                                   uint32_t pid) {
   std::unique_ptr<MemoryInfoProducer> cgroup_memory_info_producer =
       std::make_unique<MemoryInfoProducer>(
-          sampling_period_ns, pid, [](MemoryInfoListener* listener, int32_t pid) {
+          sampling_period_ns, pid, [](MemoryInfoListener* listener, uint32_t pid) {
             ErrorMessageOr<CGroupMemoryUsage> cgroup_memory_usage = GetCGroupMemoryUsage(pid);
             if (cgroup_memory_usage.has_value()) {
               listener->OnCGroupMemoryUsage(cgroup_memory_usage.value());
@@ -95,10 +95,10 @@ std::unique_ptr<MemoryInfoProducer> CreateCGroupMemoryInfoProducer(MemoryInfoLis
 
 std::unique_ptr<MemoryInfoProducer> CreateProcessMemoryInfoProducer(MemoryInfoListener* listener,
                                                                     uint64_t sampling_period_ns,
-                                                                    int32_t pid) {
+                                                                    uint32_t pid) {
   std::unique_ptr<MemoryInfoProducer> process_memory_info_producer =
       std::make_unique<MemoryInfoProducer>(
-          sampling_period_ns, pid, [](MemoryInfoListener* listener, int32_t pid) {
+          sampling_period_ns, pid, [](MemoryInfoListener* listener, uint32_t pid) {
             ErrorMessageOr<ProcessMemoryUsage> process_memory_usage = GetProcessMemoryUsage(pid);
             if (process_memory_usage.has_value()) {
               listener->OnProcessMemoryUsage(process_memory_usage.value());

--- a/src/MemoryTracing/MemoryInfoProducer.cpp
+++ b/src/MemoryTracing/MemoryInfoProducer.cpp
@@ -63,7 +63,7 @@ void SystemMemoryInfoProducerRunFn(MemoryInfoListener* listener, int32_t /*pid*/
 
 std::unique_ptr<MemoryInfoProducer> CreateSystemMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
-                                                                   uint32_t pid) {
+                                                                   int32_t pid) {
   std::unique_ptr<MemoryInfoProducer> system_memory_info_producer =
       std::make_unique<MemoryInfoProducer>(
           sampling_period_ns, pid, [](MemoryInfoListener* listener, int32_t /*pid*/) {
@@ -79,10 +79,10 @@ std::unique_ptr<MemoryInfoProducer> CreateSystemMemoryInfoProducer(MemoryInfoLis
 
 std::unique_ptr<MemoryInfoProducer> CreateCGroupMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
-                                                                   uint32_t pid) {
+                                                                   int32_t pid) {
   std::unique_ptr<MemoryInfoProducer> cgroup_memory_info_producer =
       std::make_unique<MemoryInfoProducer>(
-          sampling_period_ns, pid, [](MemoryInfoListener* listener, uint32_t pid) {
+          sampling_period_ns, pid, [](MemoryInfoListener* listener, int32_t pid) {
             ErrorMessageOr<CGroupMemoryUsage> cgroup_memory_usage = GetCGroupMemoryUsage(pid);
             if (cgroup_memory_usage.has_value()) {
               listener->OnCGroupMemoryUsage(cgroup_memory_usage.value());
@@ -95,10 +95,10 @@ std::unique_ptr<MemoryInfoProducer> CreateCGroupMemoryInfoProducer(MemoryInfoLis
 
 std::unique_ptr<MemoryInfoProducer> CreateProcessMemoryInfoProducer(MemoryInfoListener* listener,
                                                                     uint64_t sampling_period_ns,
-                                                                    uint32_t pid) {
+                                                                    int32_t pid) {
   std::unique_ptr<MemoryInfoProducer> process_memory_info_producer =
       std::make_unique<MemoryInfoProducer>(
-          sampling_period_ns, pid, [](MemoryInfoListener* listener, uint32_t pid) {
+          sampling_period_ns, pid, [](MemoryInfoListener* listener, int32_t pid) {
             ErrorMessageOr<ProcessMemoryUsage> process_memory_usage = GetProcessMemoryUsage(pid);
             if (process_memory_usage.has_value()) {
               listener->OnProcessMemoryUsage(process_memory_usage.value());

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -70,7 +70,7 @@ class MemoryTracingIntegrationTestFixture {
     listener_->SetSamplingPeriodNs(memory_sampling_period_ns_);
     // Collect the cgroup memory information only if the process's memory cgroup and the cgroup
     // memory.stat file can be found successfully
-    uint32_t pid = orbit_base::GetCurrentProcessId();
+    pid_t pid = orbit_base::GetCurrentProcessIdNative();
     listener_->SetEnableCGroupMemory(GetCGroupMemoryUsage(pid).has_value());
     listener_->SetEnableProcessMemory(true);
 

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -70,7 +70,7 @@ class MemoryTracingIntegrationTestFixture {
     listener_->SetSamplingPeriodNs(memory_sampling_period_ns_);
     // Collect the cgroup memory information only if the process's memory cgroup and the cgroup
     // memory.stat file can be found successfully
-    int32_t pid = static_cast<int32_t>(orbit_base::GetCurrentProcessId());
+    uint32_t pid = orbit_base::GetCurrentProcessId();
     listener_->SetEnableCGroupMemory(GetCGroupMemoryUsage(pid).has_value());
     listener_->SetEnableProcessMemory(true);
 

--- a/src/MemoryTracing/MemoryTracingUtils.cpp
+++ b/src/MemoryTracing/MemoryTracingUtils.cpp
@@ -214,12 +214,12 @@ ErrorMessageOr<int64_t> ExtractRssAnonFromProcessStatus(std::string_view status_
   return ErrorMessage("RssAnon value not found in the file content.");
 }
 
-ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(int32_t pid) noexcept {
+ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(uint32_t pid) noexcept {
   ProcessMemoryUsage process_memory_usage = CreateAndInitializeProcessMemoryUsage();
   process_memory_usage.set_pid(pid);
   process_memory_usage.set_timestamp_ns(orbit_base::CaptureTimestampNs());
 
-  const std::string kProcessPageFaultsFilename = absl::StrFormat("/proc/%d/stat", pid);
+  const std::string kProcessPageFaultsFilename = absl::StrFormat("/proc/%u/stat", pid);
   ErrorMessageOr<std::string> reading_result =
       orbit_base::ReadFileToString(kProcessPageFaultsFilename);
   if (reading_result.has_error()) {
@@ -233,7 +233,7 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(int32_t pid) noexcept {
           updating_result.error().message());
   }
 
-  const std::string kProcessMemoryUsageFilename = absl::StrFormat("/proc/%d/status", pid);
+  const std::string kProcessMemoryUsageFilename = absl::StrFormat("/proc/%u/status", pid);
   reading_result = orbit_base::ReadFileToString(kProcessMemoryUsageFilename);
   if (reading_result.has_error()) {
     ERROR("%s", reading_result.error().message());
@@ -341,10 +341,10 @@ ErrorMessageOr<void> UpdateCGroupMemoryUsageFromMemoryStat(std::string_view memo
   return outcome::success();
 }
 
-ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(int32_t pid) noexcept {
+ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(uint32_t pid) noexcept {
   uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
 
-  const std::string kProcessCGroupsFilename = absl::StrFormat("/proc/%d/cgroup", pid);
+  const std::string kProcessCGroupsFilename = absl::StrFormat("/proc/%u/cgroup", pid);
   ErrorMessageOr<std::string> reading_result =
       orbit_base::ReadFileToString(kProcessCGroupsFilename);
   if (reading_result.has_error()) {
@@ -354,7 +354,7 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(int32_t pid) noexcept {
   std::string cgroup_name = GetProcessMemoryCGroupName(reading_result.value());
   if (cgroup_name.empty()) {
     std::string error_message =
-        absl::StrFormat("Fail to extract the cgroup name of the target process %d.", pid);
+        absl::StrFormat("Fail to extract the cgroup name of the target process %u.", pid);
     ERROR("%s", error_message);
     return ErrorMessage{std::move(error_message)};
   }

--- a/src/MemoryTracing/MemoryTracingUtils.cpp
+++ b/src/MemoryTracing/MemoryTracingUtils.cpp
@@ -214,12 +214,12 @@ ErrorMessageOr<int64_t> ExtractRssAnonFromProcessStatus(std::string_view status_
   return ErrorMessage("RssAnon value not found in the file content.");
 }
 
-ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(uint32_t pid) noexcept {
+ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) noexcept {
   ProcessMemoryUsage process_memory_usage = CreateAndInitializeProcessMemoryUsage();
   process_memory_usage.set_pid(pid);
   process_memory_usage.set_timestamp_ns(orbit_base::CaptureTimestampNs());
 
-  const std::string kProcessPageFaultsFilename = absl::StrFormat("/proc/%u/stat", pid);
+  const std::string kProcessPageFaultsFilename = absl::StrFormat("/proc/%d/stat", pid);
   ErrorMessageOr<std::string> reading_result =
       orbit_base::ReadFileToString(kProcessPageFaultsFilename);
   if (reading_result.has_error()) {
@@ -341,10 +341,10 @@ ErrorMessageOr<void> UpdateCGroupMemoryUsageFromMemoryStat(std::string_view memo
   return outcome::success();
 }
 
-ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(uint32_t pid) noexcept {
+ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) noexcept {
   uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
 
-  const std::string kProcessCGroupsFilename = absl::StrFormat("/proc/%u/cgroup", pid);
+  const std::string kProcessCGroupsFilename = absl::StrFormat("/proc/%d/cgroup", pid);
   ErrorMessageOr<std::string> reading_result =
       orbit_base::ReadFileToString(kProcessCGroupsFilename);
   if (reading_result.has_error()) {

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -29,7 +29,7 @@ namespace orbit_memory_tracing {
 [[nodiscard]] ErrorMessageOr<int64_t> ExtractRssAnonFromProcessStatus(
     std::string_view status_content);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ProcessMemoryUsage> GetProcessMemoryUsage(
-    int32_t pid) noexcept;
+    uint32_t pid) noexcept;
 
 [[nodiscard]] orbit_grpc_protos::CGroupMemoryUsage CreateAndInitializeCGroupMemoryUsage();
 [[nodiscard]] std::string GetProcessMemoryCGroupName(std::string_view cgroup_content);
@@ -40,7 +40,7 @@ namespace orbit_memory_tracing {
     std::string_view memory_stat_content,
     orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::CGroupMemoryUsage> GetCGroupMemoryUsage(
-    int32_t pid) noexcept;
+    uint32_t pid) noexcept;
 
 }  // namespace orbit_memory_tracing
 

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -29,7 +29,7 @@ namespace orbit_memory_tracing {
 [[nodiscard]] ErrorMessageOr<int64_t> ExtractRssAnonFromProcessStatus(
     std::string_view status_content);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ProcessMemoryUsage> GetProcessMemoryUsage(
-    uint32_t pid) noexcept;
+    pid_t pid) noexcept;
 
 [[nodiscard]] orbit_grpc_protos::CGroupMemoryUsage CreateAndInitializeCGroupMemoryUsage();
 [[nodiscard]] std::string GetProcessMemoryCGroupName(std::string_view cgroup_content);
@@ -40,7 +40,7 @@ namespace orbit_memory_tracing {
     std::string_view memory_stat_content,
     orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::CGroupMemoryUsage> GetCGroupMemoryUsage(
-    uint32_t pid) noexcept;
+    pid_t pid) noexcept;
 
 }  // namespace orbit_memory_tracing
 

--- a/src/MemoryTracing/include/MemoryTracing/MemoryInfoProducer.h
+++ b/src/MemoryTracing/include/MemoryTracing/MemoryInfoProducer.h
@@ -20,7 +20,7 @@ using MemoryInfoProducerRunFn = std::function<void(MemoryInfoListener*, int32_t)
 // specified in sampling_period_ns_, and send the extracted information to the listener.
 class MemoryInfoProducer {
  public:
-  explicit MemoryInfoProducer(uint64_t sampling_period_ns, uint32_t pid, MemoryInfoProducerRunFn fn)
+  explicit MemoryInfoProducer(uint64_t sampling_period_ns, int32_t pid, MemoryInfoProducerRunFn fn)
       : sampling_period_ns_(sampling_period_ns), pid_(pid), producer_run_fn_(std::move(fn)) {}
 
   MemoryInfoProducer(const MemoryInfoProducer&) = delete;

--- a/src/MemoryTracing/include/MemoryTracing/MemoryInfoProducer.h
+++ b/src/MemoryTracing/include/MemoryTracing/MemoryInfoProducer.h
@@ -20,7 +20,7 @@ using MemoryInfoProducerRunFn = std::function<void(MemoryInfoListener*, int32_t)
 // specified in sampling_period_ns_, and send the extracted information to the listener.
 class MemoryInfoProducer {
  public:
-  explicit MemoryInfoProducer(uint64_t sampling_period_ns, int32_t pid, MemoryInfoProducerRunFn fn)
+  explicit MemoryInfoProducer(uint64_t sampling_period_ns, uint32_t pid, MemoryInfoProducerRunFn fn)
       : sampling_period_ns_(sampling_period_ns), pid_(pid), producer_run_fn_(std::move(fn)) {}
 
   MemoryInfoProducer(const MemoryInfoProducer&) = delete;
@@ -50,13 +50,13 @@ class MemoryInfoProducer {
 
 std::unique_ptr<MemoryInfoProducer> CreateSystemMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
-                                                                   int32_t pid);
+                                                                   uint32_t pid);
 std::unique_ptr<MemoryInfoProducer> CreateCGroupMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
-                                                                   int32_t pid);
+                                                                   uint32_t pid);
 std::unique_ptr<MemoryInfoProducer> CreateProcessMemoryInfoProducer(MemoryInfoListener* listener,
                                                                     uint64_t sampling_period_ns,
-                                                                    int32_t pid);
+                                                                    uint32_t pid);
 
 }  // namespace orbit_memory_tracing
 

--- a/src/MemoryTracing/include/MemoryTracing/MemoryInfoProducer.h
+++ b/src/MemoryTracing/include/MemoryTracing/MemoryInfoProducer.h
@@ -50,13 +50,13 @@ class MemoryInfoProducer {
 
 std::unique_ptr<MemoryInfoProducer> CreateSystemMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
-                                                                   uint32_t pid);
+                                                                   int32_t pid);
 std::unique_ptr<MemoryInfoProducer> CreateCGroupMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
-                                                                   uint32_t pid);
+                                                                   int32_t pid);
 std::unique_ptr<MemoryInfoProducer> CreateProcessMemoryInfoProducer(MemoryInfoListener* listener,
                                                                     uint64_t sampling_period_ns,
-                                                                    uint32_t pid);
+                                                                    int32_t pid);
 
 }  // namespace orbit_memory_tracing
 

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -78,8 +78,8 @@ ErrorMessageOr<ModuleInfo> CreateModule(const std::filesystem::path& module_path
   return module_info;
 }
 
-ErrorMessageOr<std::vector<ModuleInfo>> ReadModules(int32_t pid) {
-  std::filesystem::path proc_maps_path{absl::StrFormat("/proc/%d/maps", pid)};
+ErrorMessageOr<std::vector<ModuleInfo>> ReadModules(uint32_t pid) {
+  std::filesystem::path proc_maps_path{absl::StrFormat("/proc/%u/maps", pid)};
   OUTCOME_TRY(auto&& proc_maps_data, orbit_base::ReadFileToString(proc_maps_path));
   return ParseMaps(proc_maps_data);
 }

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -78,8 +78,8 @@ ErrorMessageOr<ModuleInfo> CreateModule(const std::filesystem::path& module_path
   return module_info;
 }
 
-ErrorMessageOr<std::vector<ModuleInfo>> ReadModules(uint32_t pid) {
-  std::filesystem::path proc_maps_path{absl::StrFormat("/proc/%u/maps", pid)};
+ErrorMessageOr<std::vector<ModuleInfo>> ReadModules(int32_t pid) {
+  std::filesystem::path proc_maps_path{absl::StrFormat("/proc/%i/maps", pid)};
   OUTCOME_TRY(auto&& proc_maps_data, orbit_base::ReadFileToString(proc_maps_path));
   return ParseMaps(proc_maps_data);
 }

--- a/src/ObjectUtils/include/ObjectUtils/LinuxMap.h
+++ b/src/ObjectUtils/include/ObjectUtils/LinuxMap.h
@@ -22,7 +22,7 @@ namespace orbit_object_utils {
 ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModule(const std::filesystem::path& module_path,
                                                            uint64_t start_address,
                                                            uint64_t end_address);
-ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(int32_t pid);
+ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(uint32_t pid);
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ParseMaps(
     std::string_view proc_maps_data);
 

--- a/src/ObjectUtils/include/ObjectUtils/LinuxMap.h
+++ b/src/ObjectUtils/include/ObjectUtils/LinuxMap.h
@@ -22,7 +22,7 @@ namespace orbit_object_utils {
 ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModule(const std::filesystem::path& module_path,
                                                            uint64_t start_address,
                                                            uint64_t end_address);
-ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(uint32_t pid);
+ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(int32_t pid);
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ParseMaps(
     std::string_view proc_maps_data);
 

--- a/src/OrbitBase/ExecutablePathLinux.cpp
+++ b/src/OrbitBase/ExecutablePathLinux.cpp
@@ -27,7 +27,7 @@ std::filesystem::path GetExecutablePath() {
   return std::filesystem::path(std::string(buffer, length));
 }
 
-ErrorMessageOr<std::filesystem::path> GetExecutablePath(int32_t pid) {
+ErrorMessageOr<std::filesystem::path> GetExecutablePath(uint32_t pid) {
   char buffer[PATH_MAX];
 
   ssize_t length = readlink(absl::StrFormat("/proc/%d/exe", pid).c_str(), buffer, sizeof(buffer));

--- a/src/OrbitBase/ExecutablePathLinux.cpp
+++ b/src/OrbitBase/ExecutablePathLinux.cpp
@@ -27,10 +27,10 @@ std::filesystem::path GetExecutablePath() {
   return std::filesystem::path(std::string(buffer, length));
 }
 
-ErrorMessageOr<std::filesystem::path> GetExecutablePath(uint32_t pid) {
+ErrorMessageOr<std::filesystem::path> GetExecutablePath(int32_t pid) {
   char buffer[PATH_MAX];
 
-  ssize_t length = readlink(absl::StrFormat("/proc/%d/exe", pid).c_str(), buffer, sizeof(buffer));
+  ssize_t length = readlink(absl::StrFormat("/proc/%i/exe", pid).c_str(), buffer, sizeof(buffer));
   if (length == -1) {
     return ErrorMessage(absl::StrFormat("Unable to get executable path of process with pid %d: %s",
                                         pid, SafeStrerror(errno)));

--- a/src/OrbitBase/ExecutablePathLinux.cpp
+++ b/src/OrbitBase/ExecutablePathLinux.cpp
@@ -27,7 +27,7 @@ std::filesystem::path GetExecutablePath() {
   return std::filesystem::path(std::string(buffer, length));
 }
 
-ErrorMessageOr<std::filesystem::path> GetExecutablePath(int32_t pid) {
+ErrorMessageOr<std::filesystem::path> GetExecutablePath(pid_t pid) {
   char buffer[PATH_MAX];
 
   ssize_t length = readlink(absl::StrFormat("/proc/%i/exe", pid).c_str(), buffer, sizeof(buffer));

--- a/src/OrbitBase/GetProcessIdsLinuxTest.cpp
+++ b/src/OrbitBase/GetProcessIdsLinuxTest.cpp
@@ -68,7 +68,7 @@ TEST(GetProcessIdsLinux, GetTidsOfProcess) {
 }
 
 TEST(GetProcessIdsLinux, GetTracerPidOfProcess) {
-  pid_t current_pid = orbit_base::GetCurrentProcessId();
+  pid_t current_pid = orbit_base::GetCurrentProcessIdNative();
   auto pid_or_error = orbit_base::GetTracerPidOfProcess(current_pid);
   EXPECT_FALSE(pid_or_error.has_error()) << pid_or_error.error().message();
   constexpr int kNoTracerPid = 0;

--- a/src/OrbitBase/Logging.cpp
+++ b/src/OrbitBase/Logging.cpp
@@ -35,7 +35,7 @@ std::string GetLogFileName() {
   std::string timestamp_string = absl::FormatTime(orbit_base_internal::kLogFileNameTimeFormat,
                                                   absl::Now(), absl::UTCTimeZone());
   return absl::StrFormat(orbit_base_internal::kLogFileNameDelimiter, timestamp_string,
-                         static_cast<uint32_t>(orbit_base::GetCurrentProcessId()));
+                         orbit_base::GetCurrentProcessId());
 }
 
 ErrorMessageOr<void> TryRemoveOldLogFiles(const std::filesystem::path& log_dir) {

--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -53,10 +53,12 @@ uint32_t FromNativeProcessId(pid_t pid) {
 }
 
 pid_t ToNativeThreadId(uint32_t tid) {
+  CHECK(tid <= kIntMax || tid == kInvalidThreadId);
   return IsValidThreadId(tid) ? static_cast<pid_t>(tid) : kInvalidLinuxThreadId;
 }
 
 pid_t ToNativeProcessId(uint32_t pid) {
+  CHECK(pid <= kIntMax || pid == kInvalidProcessId);
   return IsValidProcessId(pid) ? static_cast<pid_t>(pid) : kInvalidLinuxProcessId;
 }
 

--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -25,9 +25,15 @@ static constexpr size_t kMaxThreadNameLength = 16;
 static constexpr int32_t kInvalidLinuxThreadId = -1;
 static constexpr int32_t kInvalidLinuxProcessId = -1;
 
+static constexpr uint32_t kIntMax = static_cast<uint32_t>(INT_MAX);
+
 uint32_t GetCurrentThreadId() { return GetThreadIdFromNative(GetCurrentThreadIdNative()); }
 
 uint32_t GetCurrentProcessId() { return GetProcessIdFromNative(GetCurrentProcessIdNative()); }
+
+bool IsValidThreadId(uint32_t tid) { return tid <= kIntMax && tid != kInvalidThreadId; }
+
+bool IsValidProcessId(uint32_t pid) { return pid <= kIntMax && pid != kInvalidProcessId; }
 
 pid_t GetCurrentThreadIdNative() {
   thread_local pid_t current_tid = syscall(__NR_gettid);
@@ -37,19 +43,19 @@ pid_t GetCurrentThreadIdNative() {
 pid_t GetCurrentProcessIdNative() { return getpid(); }
 
 uint32_t GetThreadIdFromNative(pid_t tid) {
-  return tid == kInvalidLinuxThreadId ? orbit_base::kInvalidThreadId : static_cast<uint32_t>(tid);
+  return tid >= 0 ? static_cast<uint32_t>(tid) : orbit_base::kInvalidThreadId;
 }
 
 uint32_t GetProcessIdFromNative(pid_t pid) {
-  return pid == kInvalidLinuxProcessId ? orbit_base::kInvalidProcessId : static_cast<uint32_t>(pid);
+  return pid >= 0 ? static_cast<uint32_t>(pid) : orbit_base::kInvalidProcessId;
 }
 
 pid_t GetNativeThreadId(uint32_t tid) {
-  return tid == kInvalidThreadId ? kInvalidLinuxThreadId : static_cast<pid_t>(tid);
+  return IsValidThreadId(tid) ? static_cast<pid_t>(tid) : kInvalidLinuxThreadId;
 }
 
 pid_t GetNativeProcessId(uint32_t pid) {
-  return pid == kInvalidProcessId ? kInvalidLinuxProcessId : static_cast<pid_t>(pid);
+  return IsValidProcessId(pid) ? static_cast<pid_t>(pid) : kInvalidLinuxProcessId;
 }
 
 std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(GetNativeThreadId(tid)); }

--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -54,12 +54,12 @@ uint32_t FromNativeProcessId(pid_t pid) {
 
 pid_t ToNativeThreadId(uint32_t tid) {
   CHECK(tid <= kIntMax || tid == kInvalidThreadId);
-  return IsValidThreadId(tid) ? static_cast<pid_t>(tid) : kInvalidLinuxThreadId;
+  return static_cast<pid_t>(tid);
 }
 
 pid_t ToNativeProcessId(uint32_t pid) {
   CHECK(pid <= kIntMax || pid == kInvalidProcessId);
-  return IsValidProcessId(pid) ? static_cast<pid_t>(pid) : kInvalidLinuxProcessId;
+  return static_cast<pid_t>(pid);
 }
 
 std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(ToNativeThreadId(tid)); }

--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -52,9 +52,7 @@ pid_t GetNativeProcessId(uint32_t pid) {
   return pid == kInvalidProcessId ? kInvalidLinuxProcessId : static_cast<pid_t>(pid);
 }
 
-[[nodiscard]] std::string GetThreadName(uint32_t tid) {
-  return GetThreadNameNative(GetNativeThreadId(tid));
-}
+std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(GetNativeThreadId(tid)); }
 
 std::string GetThreadNameNative(pid_t tid) {
   std::string comm_filename = absl::StrFormat("/proc/%d/comm", tid);

--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -27,9 +27,9 @@ static constexpr int32_t kInvalidLinuxProcessId = -1;
 
 static constexpr uint32_t kIntMax = static_cast<uint32_t>(INT_MAX);
 
-uint32_t GetCurrentThreadId() { return GetThreadIdFromNative(GetCurrentThreadIdNative()); }
+uint32_t GetCurrentThreadId() { return FromNativeThreadId(GetCurrentThreadIdNative()); }
 
-uint32_t GetCurrentProcessId() { return GetProcessIdFromNative(GetCurrentProcessIdNative()); }
+uint32_t GetCurrentProcessId() { return FromNativeProcessId(GetCurrentProcessIdNative()); }
 
 bool IsValidThreadId(uint32_t tid) { return tid <= kIntMax && tid != kInvalidThreadId; }
 
@@ -42,23 +42,25 @@ pid_t GetCurrentThreadIdNative() {
 
 pid_t GetCurrentProcessIdNative() { return getpid(); }
 
-uint32_t GetThreadIdFromNative(pid_t tid) {
-  return tid >= 0 ? static_cast<uint32_t>(tid) : orbit_base::kInvalidThreadId;
+uint32_t FromNativeThreadId(pid_t tid) {
+  CHECK(tid == kInvalidLinuxThreadId || tid >= 0);
+  return static_cast<uint32_t>(tid);
 }
 
-uint32_t GetProcessIdFromNative(pid_t pid) {
-  return pid >= 0 ? static_cast<uint32_t>(pid) : orbit_base::kInvalidProcessId;
+uint32_t FromNativeProcessId(pid_t pid) {
+  CHECK(pid == kInvalidLinuxProcessId || pid >= 0);
+  return static_cast<uint32_t>(pid);
 }
 
-pid_t GetNativeThreadId(uint32_t tid) {
+pid_t ToNativeThreadId(uint32_t tid) {
   return IsValidThreadId(tid) ? static_cast<pid_t>(tid) : kInvalidLinuxThreadId;
 }
 
-pid_t GetNativeProcessId(uint32_t pid) {
+pid_t ToNativeProcessId(uint32_t pid) {
   return IsValidProcessId(pid) ? static_cast<pid_t>(pid) : kInvalidLinuxProcessId;
 }
 
-std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(GetNativeThreadId(tid)); }
+std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(ToNativeThreadId(tid)); }
 
 std::string GetThreadNameNative(pid_t tid) {
   std::string comm_filename = absl::StrFormat("/proc/%d/comm", tid);

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -109,19 +109,19 @@ TEST(ThreadUtils, ValidIds) {
 #endif
 
   for (auto native_tid : valid_native_thread_ids) {
-    uint32_t tid = orbit_base::GetThreadIdFromNative(native_tid);
+    uint32_t tid = orbit_base::FromNativeThreadId(native_tid);
     EXPECT_TRUE(orbit_base::IsValidThreadId(tid)) << "tid == " << tid;
   }
 
   for (auto native_pid : valid_native_process_ids) {
-    uint32_t pid = orbit_base::GetProcessIdFromNative(native_pid);
+    uint32_t pid = orbit_base::FromNativeProcessId(native_pid);
     EXPECT_TRUE(orbit_base::IsValidProcessId(pid)) << "pid == " << pid;
   }
 }
 
 TEST(ThreadUtils, InvalidIds) {
 #ifdef __linux
-  std::vector<int32_t> invalid_native_thread_ids{-INT_MAX, -2, -1};
+  std::vector<int32_t> invalid_native_thread_ids{-1};
   const std::vector<int32_t>& invalid_native_process_ids = invalid_native_thread_ids;
 #else  // Windows
   std::vector<uint32_t> invalid_native_thread_ids{0, 1, 2, 3, 5};
@@ -129,12 +129,12 @@ TEST(ThreadUtils, InvalidIds) {
 #endif
 
   for (auto invalid_native_thread_id : invalid_native_thread_ids) {
-    uint32_t tid = orbit_base::GetThreadIdFromNative(invalid_native_thread_id);
+    uint32_t tid = orbit_base::FromNativeThreadId(invalid_native_thread_id);
     EXPECT_FALSE(orbit_base::IsValidThreadId(tid)) << "tid == " << tid;
   }
 
   for (auto invalid_native_process_id : invalid_native_process_ids) {
-    uint32_t pid = orbit_base::GetProcessIdFromNative(invalid_native_process_id);
+    uint32_t pid = orbit_base::FromNativeProcessId(invalid_native_process_id);
     EXPECT_FALSE(orbit_base::IsValidProcessId(pid)) << "pid == " << pid;
   }
 }

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -121,20 +121,19 @@ TEST(ThreadUtils, ValidIds) {
 
 TEST(ThreadUtils, InvalidIds) {
 #ifdef __linux
-  std::vector<int32_t> invalid_native_thread_ids{-1};
+  std::vector<int32_t> invalid_native_thread_ids{-INT_MAX, -2};
   const std::vector<int32_t>& invalid_native_process_ids = invalid_native_thread_ids;
 #else  // Windows
-  std::vector<uint32_t> invalid_native_thread_ids{0, 1, 2, 3, 5};
-  std::vector<uint32_t> invalid_native_process_ids = {0, 0xffffffff, 1, 2, 3, 5};
+  std::vector<uint32_t> invalid_native_thread_ids{1, 2, 3, 5};
+  std::vector<uint32_t> invalid_native_process_ids = {1, 2, 3, 5};
 #endif
 
-  for (auto invalid_native_thread_id : invalid_native_thread_ids) {
-    uint32_t tid = orbit_base::FromNativeThreadId(invalid_native_thread_id);
-    EXPECT_FALSE(orbit_base::IsValidThreadId(tid)) << "tid == " << tid;
+  for (auto tid : invalid_native_thread_ids) {
+    EXPECT_DEATH(orbit_base::FromNativeThreadId(tid), "Check failed") << "tid == " << tid;
   }
 
-  for (auto invalid_native_process_id : invalid_native_process_ids) {
-    uint32_t pid = orbit_base::FromNativeProcessId(invalid_native_process_id);
+  for (auto pid : invalid_native_process_ids) {
+    EXPECT_DEATH(orbit_base::FromNativeProcessId(pid), "Check failed") << "pid == " << pid;
     EXPECT_FALSE(orbit_base::IsValidProcessId(pid)) << "pid == " << pid;
   }
 }

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -18,13 +18,8 @@
 #include "OrbitBase/ThreadUtils.h"
 
 TEST(ThreadUtils, GetCurrentThreadId) {
-#ifdef _WIN32
   uint32_t current_tid = orbit_base::GetCurrentThreadId();
   uint32_t worker_tid = 0;
-#else
-  pid_t current_tid = orbit_base::GetCurrentThreadId();
-  pid_t worker_tid = 0;
-#endif
 
   std::thread t([&worker_tid]() { worker_tid = orbit_base::GetCurrentThreadId(); });
   t.join();
@@ -71,12 +66,7 @@ TEST(ThreadUtils, GetSetCurrentThreadEmptyName) {
 
 TEST(ThreadUtils, GetThreadName) {
   absl::Mutex mutex;
-#if _WIN32
-  using PidType = uint32_t;
-#else
-  using PidType = pid_t;
-#endif
-  PidType other_tid = 0;
+  uint32_t other_tid = 0;
   bool other_name_read = false;
   static const char* kThreadName = "OtherThread";
 
@@ -98,7 +88,7 @@ TEST(ThreadUtils, GetThreadName) {
     absl::MutexLock lock{&mutex};
     // Wait for other_thread to set its own name and communicate its pid.
     mutex.Await(absl::Condition(
-        +[](PidType* other_tid) { return *other_tid != 0; }, &other_tid));
+        +[](uint32_t* other_tid) { return *other_tid != 0; }, &other_tid));
   }
   std::string other_name = orbit_base::GetThreadName(other_tid);
   EXPECT_EQ(other_name, kThreadName);

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -98,3 +98,43 @@ TEST(ThreadUtils, GetThreadName) {
   }
   other_thread.join();
 }
+
+TEST(ThreadUtils, ValidIds) {
+#ifdef __linux
+  std::vector<int32_t> valid_native_thread_ids{0, 1, 2, 3, INT_MAX - 1, INT_MAX};
+  std::vector<int32_t>& valid_native_process_ids = valid_native_thread_ids;
+#else  // Windows
+  std::vector<uint32_t> valid_native_thread_ids{4, 8, UINT_MAX - 7, UINT_MAX - 3};
+  std::vector<uint32_t>& valid_native_process_ids = valid_native_thread_ids;
+#endif
+
+  for (auto native_tid : valid_native_thread_ids) {
+    uint32_t tid = orbit_base::GetThreadIdFromNative(native_tid);
+    EXPECT_TRUE(orbit_base::IsValidThreadId(tid)) << "tid == " << tid;
+  }
+
+  for (auto native_pid : valid_native_process_ids) {
+    uint32_t pid = orbit_base::GetProcessIdFromNative(native_pid);
+    EXPECT_TRUE(orbit_base::IsValidProcessId(pid)) << "pid == " << pid;
+  }
+}
+
+TEST(ThreadUtils, InvalidIds) {
+#ifdef __linux
+  std::vector<int32_t> invalid_native_thread_ids{-INT_MAX, -2, -1};
+  const std::vector<int32_t>& invalid_native_process_ids = invalid_native_thread_ids;
+#else  // Windows
+  std::vector<uint32_t> invalid_native_thread_ids{0, 1, 2, 3, 5};
+  std::vector<uint32_t> invalid_native_process_ids = {0, 0xffffffff, 1, 2, 3, 5};
+#endif
+
+  for (auto invalid_native_thread_id : invalid_native_thread_ids) {
+    uint32_t tid = orbit_base::GetThreadIdFromNative(invalid_native_thread_id);
+    EXPECT_FALSE(orbit_base::IsValidThreadId(tid)) << "tid == " << tid;
+  }
+
+  for (auto invalid_native_process_id : invalid_native_process_ids) {
+    uint32_t pid = orbit_base::GetProcessIdFromNative(invalid_native_process_id);
+    EXPECT_FALSE(orbit_base::IsValidProcessId(pid)) << "pid == " << pid;
+  }
+}

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -129,11 +129,10 @@ TEST(ThreadUtils, InvalidIds) {
 #endif
 
   for (auto tid : invalid_native_thread_ids) {
-    EXPECT_DEATH(orbit_base::FromNativeThreadId(tid), "Check failed") << "tid == " << tid;
+    EXPECT_DEATH((void)orbit_base::FromNativeThreadId(tid), "Check failed") << "tid == " << tid;
   }
 
   for (auto pid : invalid_native_process_ids) {
-    EXPECT_DEATH(orbit_base::FromNativeProcessId(pid), "Check failed") << "pid == " << pid;
-    EXPECT_FALSE(orbit_base::IsValidProcessId(pid)) << "pid == " << pid;
+    EXPECT_DEATH((void)orbit_base::FromNativeProcessId(pid), "Check failed") << "pid == " << pid;
   }
 }

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -52,11 +52,13 @@ uint32_t FromNativeProcessId(uint32_t pid) {
 }
 
 uint32_t ToNativeThreadId(uint32_t tid) {
-  return IsValidThreadId(tid) ? tid : kInvalidWindowsThreadId;
+  CHECK(IsMultipleOfFour(tid) || tid == orbit_base::kInvalidThreadId);
+  return tid != orbit_base::kInvalidThreadId ? tid : kInvalidWindowsThreadId;
 }
 
 uint32_t ToNativeProcessId(uint32_t pid) {
-  return IsValidProcessId(pid) ? pid : kInvalidWindowsProcessId_0;
+  CHECK(IsMultipleOfFour(tid) || pid == orbit_base::kInvalidProcessId);
+  return pid != orbit_base::kInvalidProcessId : kInvalidWindowsProcessId_0;
 }
 
 std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(ToNativeThreadId(tid)); }

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -57,8 +57,8 @@ uint32_t ToNativeThreadId(uint32_t tid) {
 }
 
 uint32_t ToNativeProcessId(uint32_t pid) {
-  CHECK(IsMultipleOfFour(tid) || pid == orbit_base::kInvalidProcessId);
-  return pid != orbit_base::kInvalidProcessId : kInvalidWindowsProcessId_0;
+  CHECK(IsMultipleOfFour(pid) || pid == orbit_base::kInvalidProcessId);
+  return pid != orbit_base::kInvalidProcessId ? pid : kInvalidWindowsProcessId_0;
 }
 
 std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(ToNativeThreadId(tid)); }

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -34,9 +34,9 @@ inline [[nodiscard]] bool IsMultipleOfFour(uint32_t value) { return (value & 3) 
 
 }  // namespace
 
-uint32_t GetCurrentThreadId() { return GetThreadIdFromNative(GetCurrentThreadIdNative()); }
+uint32_t GetCurrentThreadId() { return FromNativeThreadId(GetCurrentThreadIdNative()); }
 
-uint32_t GetCurrentProcessId() { return GetProcessIdFromNative(GetCurrentProcessIdNative()); }
+uint32_t GetCurrentProcessId() { return FromNativeProcessId(GetCurrentProcessIdNative()); }
 
 bool IsValidThreadId(uint32_t tid) {
   return tid != orbit_base::kInvalidThreadId && IsMultipleOfFour(tid);
@@ -53,23 +53,23 @@ uint32_t GetCurrentThreadIdNative() {
 
 uint32_t GetCurrentProcessIdNative() { return ::GetCurrentProcessId(); }
 
-uint32_t GetThreadIdFromNative(uint32_t tid) {
+uint32_t FromNativeThreadId(uint32_t tid) {
   return IsValidThreadIdNative(tid) ? tid : orbit_base::kInvalidThreadId;
 }
 
-uint32_t GetProcessIdFromNative(uint32_t pid) {
+uint32_t FromNativeProcessId(uint32_t pid) {
   return IsValidProcessIdNative(pid) ? pid : orbit_base::kInvalidProcessId;
 }
 
-uint32_t GetNativeThreadId(uint32_t tid) {
+uint32_t ToNativeThreadId(uint32_t tid) {
   return IsValidThreadId(tid) ? tid : kInvalidWindowsThreadId;
 }
 
-uint32_t GetNativeProcessId(uint32_t pid) {
+uint32_t ToNativeProcessId(uint32_t pid) {
   return IsValidProcessId(pid) ? pid : kInvalidWindowsProcessId_0;
 }
 
-std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(GetNativeThreadId(tid)); }
+std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(ToNativeThreadId(tid)); }
 
 template <typename FunctionPrototypeT>
 static FunctionPrototypeT GetProcAddress(const std::string& library, const std::string& procedure) {

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -16,14 +16,10 @@ static constexpr uint32_t kInvalidWindowsThreadId = 0;
 static constexpr uint32_t kInvalidWindowsProcessId_0 = 0;
 static constexpr uint32_t kInvalidWindowsProcessId_1 = 0xffffffff;
 
-namespace {
-
 // On Windows, thread and process ids are observed to be multiples of 4. Even though there is no
 // formal guarantee for this property, the current implementation of cross platform thread process
 // ids rely on it. https://devblogs.microsoft.com/oldnewthing/20080228-00/?p=23283
-inline [[nodiscard]] bool IsMultipleOfFour(uint32_t value) { return (value & 3) == 0; }
-
-}  // namespace
+static inline [[nodiscard]] bool IsMultipleOfFour(uint32_t value) { return (value & 3) == 0; }
 
 uint32_t GetCurrentThreadId() { return FromNativeThreadId(GetCurrentThreadIdNative()); }
 
@@ -45,14 +41,14 @@ uint32_t GetCurrentThreadIdNative() {
 uint32_t GetCurrentProcessIdNative() { return ::GetCurrentProcessId(); }
 
 uint32_t FromNativeThreadId(uint32_t tid) {
-  CHECK(IsMultipleOfFour(tid));
+  CHECK(IsMultipleOfFour(tid) || tid == kInvalidWindowsThreadId);
   return tid != kInvalidWindowsThreadId ? tid : orbit_base::kInvalidThreadId;
 }
 
 uint32_t FromNativeProcessId(uint32_t pid) {
-  CHECK(IsMultipleOfFour(pid));
-  bool is_invalid_id = (pid == kInvalidWindowsProcessId_0 || pid == kInvalidWindowsProcessId_1);
-  return !is_invalid_id ? pid : orbit_base::kInvalidProcessId;
+  bool is_invalid_pid = (pid == kInvalidWindowsProcessId_0 || pid == kInvalidWindowsProcessId_1);
+  CHECK(IsMultipleOfFour(pid) || is_invalid_pid);
+  return !is_invalid_pid ? pid : orbit_base::kInvalidProcessId;
 }
 
 uint32_t ToNativeThreadId(uint32_t tid) {

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -23,15 +23,6 @@ namespace {
 // ids rely on it. https://devblogs.microsoft.com/oldnewthing/20080228-00/?p=23283
 inline [[nodiscard]] bool IsMultipleOfFour(uint32_t value) { return (value & 3) == 0; }
 
-[[nodiscard]] bool IsValidThreadIdNative(uint32_t tid) {
-  return tid != kInvalidWindowsThreadId && IsMultipleOfFour(tid);
-}
-
-[[nodiscard]] bool IsValidProcessIdNative(uint32_t pid) {
-  return pid != kInvalidWindowsProcessId_0 && pid != kInvalidWindowsProcessId_1 &&
-         IsMultipleOfFour(pid);
-}
-
 }  // namespace
 
 uint32_t GetCurrentThreadId() { return FromNativeThreadId(GetCurrentThreadIdNative()); }
@@ -54,11 +45,14 @@ uint32_t GetCurrentThreadIdNative() {
 uint32_t GetCurrentProcessIdNative() { return ::GetCurrentProcessId(); }
 
 uint32_t FromNativeThreadId(uint32_t tid) {
-  return IsValidThreadIdNative(tid) ? tid : orbit_base::kInvalidThreadId;
+  CHECK(IsMultipleOfFour(tid));
+  return tid != kInvalidWindowsThreadId ? tid : orbit_base::kInvalidThreadId;
 }
 
 uint32_t FromNativeProcessId(uint32_t pid) {
-  return IsValidProcessIdNative(pid) ? pid : orbit_base::kInvalidProcessId;
+  CHECK(IsMultipleOfFour(pid));
+  bool is_invalid_id = (pid == kInvalidWindowsProcessId_0 || pid == kInvalidWindowsProcessId_1);
+  return !is_invalid_id ? pid : orbit_base::kInvalidProcessId;
 }
 
 uint32_t ToNativeThreadId(uint32_t tid) {

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -36,20 +36,22 @@ uint32_t GetCurrentThreadIdNative() {
 uint32_t GetCurrentProcessIdNative() { return ::GetCurrentProcessId(); }
 
 uint32_t GetThreadIdFromNative(uint32_t tid) {
-  return IsInvalidWindowsThreadId(tid)) ? orbit_base::kInvalidThreadId : tid;
+  return IsInvalidWindowsThreadId(tid) ? orbit_base::kInvalidThreadId : tid;
 }
 
 uint32_t GetProcessIdFromNative(uint32_t pid) {
-  return IsInvalidWindowsProcessId(pid)) ? orbit_base::kInvalidProcessId : pid;
+  return IsInvalidWindowsProcessId(pid) ? orbit_base::kInvalidProcessId : pid;
 }
 
 uint32_t GetNativeThreadId(uint32_t tid) {
-  return tid == orbit_base::kInvalidThreadId) ? kInvalidWindowsThreadId : tid;
+  return tid == orbit_base::kInvalidThreadId ? kInvalidWindowsThreadId : tid;
 }
 
 uint32_t GetNativeProcessId(uint32_t pid) {
   return pid == orbit_base::kInvalidProcessId ? kInvalidWindowsProcessId_0 : pid;
 }
+
+std::string GetThreadName(uint32_t tid) { return GetThreadNameNative(GetNativeThreadId(tid)); }
 
 template <typename FunctionPrototypeT>
 static FunctionPrototypeT GetProcAddress(const std::string& library, const std::string& procedure) {

--- a/src/OrbitBase/include/OrbitBase/ExecutablePath.h
+++ b/src/OrbitBase/include/OrbitBase/ExecutablePath.h
@@ -18,7 +18,7 @@ namespace orbit_base {
 [[nodiscard]] std::filesystem::path GetExecutableDir();
 
 #if defined(__linux)
-[[nodiscard]] ErrorMessageOr<std::filesystem::path> GetExecutablePath(int32_t pid);
+[[nodiscard]] ErrorMessageOr<std::filesystem::path> GetExecutablePath(pid_t pid);
 #endif
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/ExecutablePath.h
+++ b/src/OrbitBase/include/OrbitBase/ExecutablePath.h
@@ -18,7 +18,7 @@ namespace orbit_base {
 [[nodiscard]] std::filesystem::path GetExecutableDir();
 
 #if defined(__linux)
-[[nodiscard]] ErrorMessageOr<std::filesystem::path> GetExecutablePath(uint32_t pid);
+[[nodiscard]] ErrorMessageOr<std::filesystem::path> GetExecutablePath(int32_t pid);
 #endif
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/ExecutablePath.h
+++ b/src/OrbitBase/include/OrbitBase/ExecutablePath.h
@@ -18,7 +18,7 @@ namespace orbit_base {
 [[nodiscard]] std::filesystem::path GetExecutableDir();
 
 #if defined(__linux)
-[[nodiscard]] ErrorMessageOr<std::filesystem::path> GetExecutablePath(int32_t pid);
+[[nodiscard]] ErrorMessageOr<std::filesystem::path> GetExecutablePath(uint32_t pid);
 #endif
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/ThreadConstants.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadConstants.h
@@ -9,19 +9,18 @@
 
 namespace orbit_base {
 
+// Note that -1 is reserved kInvalidThreadId in OrbitBase/ThreadUtils.h. Any non-multiple of 4 in
+// the range [2^31+1, 2^32-1] won't clash with valid Linux or Windows thread ids.
+
 // Represents a fake thread id to specify the set of all thread ids of the current process.
-static constexpr int32_t kAllProcessThreadsTid = -1;
+static constexpr uint32_t kAllProcessThreadsTid = -5;
 
 // Represents a fake thread id to specify the set of all thread ids of all processes on the system.
-static constexpr int32_t kAllThreadsOfAllProcessesTid = -2;
+static constexpr uint32_t kAllThreadsOfAllProcessesTid = -2;
 
 // Represents a fake thread id to specify the set of all thread ids of all processes on the system
 // that are NOT in the current process.
-static constexpr int32_t kNotTargetProcessTid = -3;
-
-// Represents an invalid thread id.
-static constexpr int32_t kInvalidThreadTid = -4;
-
+static constexpr uint32_t kNotTargetProcessTid = -3;
 }  // namespace orbit_base
 
 #endif  // ORBIT_BASE_THREAD_CONSTANTS_H

--- a/src/OrbitBase/include/OrbitBase/ThreadConstants.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadConstants.h
@@ -9,8 +9,14 @@
 
 namespace orbit_base {
 
-// Note that -1 is reserved kInvalidThreadId in OrbitBase/ThreadUtils.h. Any non-multiple of 4 in
-// the range [2^31+1, 2^32-1] won't clash with valid Linux or Windows thread ids.
+// Note that any non-multiple of 4 in the range [2^31+1, 2^32-1] won't clash with valid Linux or
+// Windows thread ids. See table in ThreadUtils.h.
+
+// Cross-platform invalid thread id.
+static constexpr uint32_t kInvalidThreadId = -1;  // 0xffffffff
+
+// Cross-platform invalid process id.
+static constexpr uint32_t kInvalidProcessId = -1;  // 0xffffffff
 
 // Represents a fake thread id to specify the set of all thread ids of the current process.
 static constexpr uint32_t kAllProcessThreadsTid = -5;

--- a/src/OrbitBase/include/OrbitBase/ThreadUtils.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadUtils.h
@@ -14,10 +14,9 @@
 
 #include <string>
 
-namespace orbit_base {
+#include "OrbitBase/ThreadConstants.h"
 
-static constexpr uint32_t kInvalidThreadId = 0xffffffff;
-static constexpr uint32_t kInvalidProcessId = 0xffffffff;
+namespace orbit_base {
 
 // We use uint32_t as our cross-platform thread id and process id type. Platform-specific invalid
 // ids are converted into cross-platform kInvalidThreadId or kInvalidProcessId (both 0xffffffff):
@@ -54,8 +53,10 @@ static constexpr uint32_t kInvalidProcessId = 0xffffffff;
 // Cross-platform.
 [[nodiscard]] uint32_t GetCurrentThreadId();
 [[nodiscard]] uint32_t GetCurrentProcessId();
+
 [[nodiscard]] bool IsValidThreadId(uint32_t tid);
 [[nodiscard]] bool IsValidProcessId(uint32_t pid);
+
 void SetCurrentThreadName(const char* thread_name);
 [[nodiscard]] std::string GetThreadName(uint32_t tid);
 
@@ -65,19 +66,19 @@ void SetCurrentThreadName(const char* thread_name);
 [[nodiscard]] std::string GetThreadNameNative(uint32_t tid);
 [[nodiscard]] uint32_t GetCurrentProcessIdNative();
 
-[[nodiscard]] uint32_t GetThreadIdFromNative(uint32_t tid);
-[[nodiscard]] uint32_t GetProcessIdFromNative(uint32_t pid);
+[[nodiscard]] uint32_t FromNativeThreadId(uint32_t tid);
+[[nodiscard]] uint32_t FromNativeProcessId(uint32_t pid);
 
 #else
 [[nodiscard]] pid_t GetCurrentThreadIdNative();
 [[nodiscard]] std::string GetThreadNameNative(pid_t tid);
 [[nodiscard]] pid_t GetCurrentProcessIdNative();
 
-[[nodiscard]] uint32_t GetThreadIdFromNative(pid_t tid);
-[[nodiscard]] uint32_t GetProcessIdFromNative(pid_t pid);
+[[nodiscard]] uint32_t FromNativeThreadId(pid_t tid);
+[[nodiscard]] uint32_t FromNativeProcessId(pid_t pid);
 
-[[nodiscard]] pid_t GetNativeThreadId(uint32_t tid);
-[[nodiscard]] pid_t GetNativeProcessId(uint32_t tid);
+[[nodiscard]] pid_t ToNativeThreadId(uint32_t tid);
+[[nodiscard]] pid_t ToNativeProcessId(uint32_t tid);
 #endif
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/ThreadUtils.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadUtils.h
@@ -54,6 +54,8 @@ static constexpr uint32_t kInvalidProcessId = 0xffffffff;
 // Cross-platform.
 [[nodiscard]] uint32_t GetCurrentThreadId();
 [[nodiscard]] uint32_t GetCurrentProcessId();
+[[nodiscard]] bool IsValidThreadId(uint32_t tid);
+[[nodiscard]] bool IsValidProcessId(uint32_t pid);
 void SetCurrentThreadName(const char* thread_name);
 [[nodiscard]] std::string GetThreadName(uint32_t tid);
 

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -33,6 +33,7 @@
 #include "OrbitBase/ImmediateExecutor.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "Symbols/SymbolHelper.h"
 #include "capture_data.pb.h"
 #include "module.pb.h"
@@ -94,8 +95,8 @@ bool ClientGgp::InitClient() {
 
 // Client requests to start the capture
 ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thread_pool) {
-  int32_t pid = target_process_->pid();
-  if (pid == -1) {
+  uint32_t pid = target_process_->pid();
+  if (pid == orbit_base::kInvalidThreadId) {
     return ErrorMessage{
         "Error starting capture: "
         "No process selected. Please choose a target process for the capture."};
@@ -166,7 +167,7 @@ std::filesystem::path ClientGgp::GenerateFilePath() {
   return std::filesystem::path(options_.capture_file_directory) / file_name;
 }
 
-ErrorMessageOr<std::unique_ptr<ProcessData>> ClientGgp::GetOrbitProcessByPid(int32_t pid) {
+ErrorMessageOr<std::unique_ptr<ProcessData>> ClientGgp::GetOrbitProcessByPid(uint32_t pid) {
   // We retrieve the information of the process to later get the module corresponding to its binary
   OUTCOME_TRY(auto&& process_infos, process_client_->GetProcessList());
   LOG("List of processes:");

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -58,7 +58,8 @@ class ClientGgp {
   std::unique_ptr<orbit_capture_client::CaptureClient> capture_client_;
   std::unique_ptr<orbit_client_services::ProcessClient> process_client_;
 
-  ErrorMessageOr<std::unique_ptr<orbit_client_data::ProcessData>> GetOrbitProcessByPid(int32_t pid);
+  ErrorMessageOr<std::unique_ptr<orbit_client_data::ProcessData>> GetOrbitProcessByPid(
+      uint32_t pid);
   bool InitCapture();
   ErrorMessageOr<void> LoadModuleAndSymbols();
   void LoadSelectedFunctions();

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -426,7 +426,7 @@ void OrbitApp::OnCallstackEvent(CallstackEvent callstack_event) {
   GetMutableCaptureData().AddCallstackEvent(std::move(callstack_event));
 }
 
-void OrbitApp::OnThreadName(int32_t thread_id, std::string thread_name) {
+void OrbitApp::OnThreadName(uint32_t thread_id, std::string thread_name) {
   GetMutableCaptureData().AddOrAssignThreadName(thread_id, std::move(thread_name));
 }
 
@@ -444,7 +444,7 @@ void OrbitApp::OnUniqueTracepointInfo(uint64_t key,
 }
 
 void OrbitApp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) {
-  int32_t capture_process_id = GetCaptureData().process_id();
+  uint32_t capture_process_id = GetCaptureData().process_id();
   bool is_same_pid_as_target = capture_process_id == tracepoint_event_info.pid();
 
   GetMutableCaptureData().AddTracepointEventAndMapToThreads(
@@ -797,7 +797,7 @@ void OrbitApp::RenderImGuiDebugUI() {
   debug_canvas_->RequestRedraw();
 }
 
-void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
+void OrbitApp::Disassemble(uint32_t pid, const FunctionInfo& function) {
   CHECK(process_ != nullptr);
   const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(function.module_path(),
                                                                         function.module_build_id());
@@ -2280,7 +2280,7 @@ uint64_t OrbitApp::GetGroupIdToHighlight() const {
 }
 
 void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
-                                     int32_t thread_id) {
+                                     uint32_t thread_id) {
   const CallstackData& callstack_data = GetCaptureData().GetCallstackData();
   std::unique_ptr<CallstackData> selection_callstack_data = std::make_unique<CallstackData>();
   for (const CallstackEvent& event : selected_callstack_events) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -134,7 +134,7 @@ class OrbitApp final : public DataViewFactory,
   void ToggleCapture();
   void ListPresets();
   void RefreshCaptureView();
-  void Disassemble(int32_t pid, const orbit_client_protos::FunctionInfo& function) override;
+  void Disassemble(uint32_t pid, const orbit_client_protos::FunctionInfo& function) override;
   void ShowSourceCode(const orbit_client_protos::FunctionInfo& function) override;
 
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,
@@ -146,7 +146,7 @@ class OrbitApp final : public DataViewFactory,
   void OnUniqueCallstack(uint64_t callstack_id,
                          orbit_client_protos::CallstackInfo callstack) override;
   void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;
-  void OnThreadName(int32_t thread_id, std::string thread_name) override;
+  void OnThreadName(uint32_t thread_id, std::string thread_name) override;
   void OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo thread_state_slice) override;
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) override;
   void OnUniqueTracepointInfo(uint64_t key,
@@ -440,7 +440,7 @@ class OrbitApp final : public DataViewFactory,
 
   void SelectCallstackEvents(
       const std::vector<orbit_client_protos::CallstackEvent>& selected_callstack_events,
-      int32_t thread_id);
+      uint32_t thread_id);
 
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info);
   void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint);

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -34,7 +34,7 @@ std::vector<const CallTreeNode*> CallTreeNode::children() const {
   return children;
 }
 
-CallTreeThread* CallTreeNode::GetThreadOrNull(int32_t thread_id) {
+CallTreeThread* CallTreeNode::GetThreadOrNull(uint32_t thread_id) {
   auto thread_it = thread_children_.find(thread_id);
   if (thread_it == thread_children_.end()) {
     return nullptr;
@@ -42,7 +42,7 @@ CallTreeThread* CallTreeNode::GetThreadOrNull(int32_t thread_id) {
   return &thread_it->second;
 }
 
-CallTreeThread* CallTreeNode::AddAndGetThread(int32_t thread_id, std::string thread_name) {
+CallTreeThread* CallTreeNode::AddAndGetThread(uint32_t thread_id, std::string thread_name) {
   const auto& [it, inserted] = thread_children_.try_emplace(
       thread_id, CallTreeThread{thread_id, std::move(thread_name), this});
   CHECK(inserted);
@@ -148,7 +148,7 @@ static void AddUnwindErrorToTopDownThread(CallTreeThread* thread_node,
 }
 
 [[nodiscard]] static CallTreeThread* GetOrCreateThreadNode(
-    CallTreeNode* current_node, int32_t tid, const std::string& process_name,
+    CallTreeNode* current_node, uint32_t tid, const std::string& process_name,
     const absl::flat_hash_map<int32_t, std::string>& thread_names) {
   CallTreeThread* thread_node = current_node->GetThreadOrNull(tid);
   if (thread_node == nullptr) {
@@ -172,7 +172,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
 
   for (const ThreadSampleData& thread_sample_data :
        post_processed_sampling_data.GetThreadSampleData()) {
-    const int32_t tid = thread_sample_data.thread_id;
+    const uint32_t tid = thread_sample_data.thread_id;
 
     for (const auto& [callstack_id, sample_count] :
          thread_sample_data.sampled_callstack_id_to_count) {
@@ -244,7 +244,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedS
 
   for (const ThreadSampleData& thread_sample_data :
        post_processed_sampling_data.GetThreadSampleData()) {
-    const int32_t tid = thread_sample_data.thread_id;
+    const uint32_t tid = thread_sample_data.thread_id;
     if (tid == orbit_base::kAllProcessThreadsTid) {
       continue;
     }

--- a/src/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/CallTreeView.h
@@ -36,9 +36,9 @@ class CallTreeNode {
 
   [[nodiscard]] std::vector<const CallTreeNode*> children() const;
 
-  [[nodiscard]] CallTreeThread* GetThreadOrNull(int32_t thread_id);
+  [[nodiscard]] CallTreeThread* GetThreadOrNull(uint32_t thread_id);
 
-  [[nodiscard]] CallTreeThread* AddAndGetThread(int32_t thread_id, std::string thread_name);
+  [[nodiscard]] CallTreeThread* AddAndGetThread(uint32_t thread_id, std::string thread_name);
 
   [[nodiscard]] CallTreeFunction* GetFunctionOrNull(uint64_t function_absolute_address);
 
@@ -120,15 +120,15 @@ class CallTreeFunction : public CallTreeNode {
 
 class CallTreeThread : public CallTreeNode {
  public:
-  explicit CallTreeThread(int32_t thread_id, std::string thread_name, CallTreeNode* parent)
+  explicit CallTreeThread(uint32_t thread_id, std::string thread_name, CallTreeNode* parent)
       : CallTreeNode{parent}, thread_id_{thread_id}, thread_name_{std::move(thread_name)} {}
 
-  [[nodiscard]] int32_t thread_id() const { return thread_id_; }
+  [[nodiscard]] uint32_t thread_id() const { return thread_id_; }
 
   [[nodiscard]] const std::string& thread_name() const { return thread_name_; }
 
  private:
-  int32_t thread_id_;
+  uint32_t thread_id_;
   std::string thread_name_;
 };
 

--- a/src/OrbitGl/CallstackDataView.cpp
+++ b/src/OrbitGl/CallstackDataView.cpp
@@ -169,7 +169,7 @@ void CallstackDataView::OnContextMenu(const std::string& action, int menu_index,
     }
 
   } else if (action == kMenuActionDisassembly) {
-    const int32_t pid = app_->GetCaptureData().process_id();
+    const uint32_t pid = app_->GetCaptureData().process_id();
     for (int i : item_indices) {
       app_->Disassemble(pid, *GetFrameFromRow(i).function);
     }

--- a/src/OrbitGl/CaptureStats.cpp
+++ b/src/OrbitGl/CaptureStats.cpp
@@ -25,7 +25,7 @@ ErrorMessageOr<void> CaptureStats::Generate(CaptureWindow* capture_window, uint6
 
   std::vector<const orbit_client_protos::TimerInfo*> sched_scopes =
       scheduler_track->GetScopesInRange(start_ns, end_ns);
-  SchedulingStats::ThreadNameProvider thread_name_provider = [capture_data](int32_t thread_id) {
+  SchedulingStats::ThreadNameProvider thread_name_provider = [capture_data](uint32_t thread_id) {
     return capture_data->GetThreadName(thread_id);
   };
   SchedulingStats scheduling_stats(sched_scopes, thread_name_provider, start_ns, end_ns);

--- a/src/OrbitGl/CaptureStatsTest.cpp
+++ b/src/OrbitGl/CaptureStatsTest.cpp
@@ -18,7 +18,7 @@ TEST(CaptureStats, NullCaptureWindow) {
 
 TEST(SchedulingStats, ZeroSchedulingScopes) {
   std::vector<const orbit_client_protos::TimerInfo*> scheduling_scopes;
-  SchedulingStats::ThreadNameProvider thread_name_provider = [](int32_t thread_id) {
+  SchedulingStats::ThreadNameProvider thread_name_provider = [](uint32_t thread_id) {
     return std::to_string(thread_id);
   };
   SchedulingStats scheduling_stats(scheduling_scopes, thread_name_provider, 0, 0);
@@ -34,7 +34,7 @@ TEST(SchedulingStats, ZeroSchedulingScopes) {
 TEST(SchedulingStats, SchedulingStats) {
   std::list<orbit_client_protos::TimerInfo>
       scope_buffer;  // Use a list as we need pointer stability.
-  auto create_scope = [&scope_buffer](int32_t pid, int32_t tid, int32_t cpu, uint64_t start_ns,
+  auto create_scope = [&scope_buffer](uint32_t pid, uint32_t tid, int32_t cpu, uint64_t start_ns,
                                       uint64_t end_ns) {
     orbit_client_protos::TimerInfo timer_info;
     timer_info.set_start(start_ns);
@@ -46,7 +46,7 @@ TEST(SchedulingStats, SchedulingStats) {
   };
 
   std::vector<const orbit_client_protos::TimerInfo*> scopes;
-  SchedulingStats::ThreadNameProvider thread_name_provider = [](int32_t thread_id) {
+  SchedulingStats::ThreadNameProvider thread_name_provider = [](uint32_t thread_id) {
     return std::to_string(thread_id);
   };
 

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -134,7 +134,7 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
   void OnCallstackEvent(orbit_client_protos::CallstackEvent /*callstack_event*/) override {
     UNREACHABLE();
   }
-  void OnThreadName(int32_t /*thread_id*/, std::string /*thread_name*/) override { UNREACHABLE(); }
+  void OnThreadName(uint32_t /*thread_id*/, std::string /*thread_name*/) override { UNREACHABLE(); }
   void OnThreadStateSlice(
       orbit_client_protos::ThreadStateSliceInfo /*thread_state_slice*/) override {
     UNREACHABLE();

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -288,7 +288,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
     }
     app_->RetrieveModulesAndLoadSymbols(modules_to_load);
   } else if (action == kMenuActionDisassembly) {
-    int32_t pid = app_->GetCaptureData().process_id();
+    uint32_t pid = app_->GetCaptureData().process_id();
     for (const FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {
       app_->Disassemble(pid, *function);
     }

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -12,6 +12,7 @@
 #include "Batcher.h"
 #include "ClientData/CaptureData.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadConstants.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "Viewport.h"
@@ -46,12 +47,14 @@ float SchedulerTrack::GetHeight() const {
 
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
   bool is_same_tid_as_selected = timer_info.thread_id() == app_->selected_thread_id();
+
   CHECK(capture_data_ != nullptr);
-  int32_t capture_process_id = capture_data_->process_id();
+  uint32_t capture_process_id = capture_data_->process_id();
   bool is_same_pid_as_target =
       capture_process_id == 0 || capture_process_id == timer_info.process_id();
 
-  return is_same_tid_as_selected || (app_->selected_thread_id() == -1 && is_same_pid_as_target);
+  return is_same_tid_as_selected ||
+         (app_->selected_thread_id() == orbit_base::kAllProcessThreadsTid && is_same_pid_as_target);
 }
 
 Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,

--- a/src/OrbitGl/SchedulingStats.h
+++ b/src/OrbitGl/SchedulingStats.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "OrbitBase/ThreadUtils.h"
 #include "capture_data.pb.h"
 
 class CaptureData;
@@ -31,7 +32,7 @@ class SchedulingStats {
   [[nodiscard]] std::string ToString() const;
 
   struct ThreadStats {
-    int32_t tid = -1;
+    uint32_t tid = orbit_base::kInvalidThreadId;
     uint64_t time_on_core_ns = 0;
     std::string thread_name;
   };
@@ -39,7 +40,7 @@ class SchedulingStats {
   struct ProcessStats {
     std::map<int32_t, ThreadStats> thread_stats_by_tid;
     std::vector<ThreadStats*> thread_stats_sorted_by_time_on_core;
-    int32_t pid = -1;
+    uint32_t pid = orbit_base::kInvalidThreadId;
     uint64_t time_on_core_ns = 0;
     std::string process_name;
   };

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -24,6 +24,7 @@
 #include "ManualInstrumentationManager.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
@@ -40,7 +41,7 @@ using orbit_client_protos::TimerInfo;
 using orbit_grpc_protos::InstrumentedFunction;
 
 ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
-                         orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
+                         orbit_gl::Viewport* viewport, TimeGraphLayout* layout, uint32_t thread_id,
                          OrbitApp* app, const CaptureData* capture_data,
                          orbit_client_data::TrackData* track_data,
                          ScopeTreeUpdateType scope_tree_update_type)
@@ -400,7 +401,7 @@ float ThreadTrack::GetYFromDepth(uint32_t depth) const {
 }
 
 void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
-  if (process_id_ == -1) {
+  if (process_id_ == orbit_base::kInvalidProcessId) {
     process_id_ = timer_info.process_id();
   }
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -28,7 +28,7 @@ class ThreadTrack final : public TimerTrack {
  public:
   enum class ScopeTreeUpdateType { kAlways, kOnCaptureComplete, kNever };
   explicit ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
-                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
+                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, uint32_t thread_id,
                        OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
                        orbit_client_data::TrackData* track_data,
                        ScopeTreeUpdateType scope_tree_update_type);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -450,7 +450,7 @@ void TimeGraph::SelectAndMakeVisible(const TimerInfo* timer_info) {
 
 const TimerInfo* TimeGraph::FindPreviousFunctionCall(uint64_t function_address,
                                                      uint64_t current_time,
-                                                     std::optional<int32_t> thread_id) const {
+                                                     std::optional<uint32_t> thread_id) const {
   const orbit_client_protos::TimerInfo* previous_timer = nullptr;
   uint64_t goal_time = std::numeric_limits<uint64_t>::lowest();
   std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
@@ -473,7 +473,7 @@ const TimerInfo* TimeGraph::FindPreviousFunctionCall(uint64_t function_address,
 }
 
 const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint64_t current_time,
-                                                 std::optional<int32_t> thread_id) const {
+                                                 std::optional<uint32_t> thread_id) const {
   const orbit_client_protos::TimerInfo* next_timer = nullptr;
   uint64_t goal_time = std::numeric_limits<uint64_t>::max();
   std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
@@ -542,7 +542,7 @@ void TimeGraph::UpdateTracksPosition() {
   }
 }
 
-void TimeGraph::SelectCallstacks(float world_start, float world_end, int32_t thread_id) {
+void TimeGraph::SelectCallstacks(float world_start, float world_end, uint32_t thread_id) {
   if (world_start > world_end) {
     std::swap(world_end, world_start);
   }
@@ -567,7 +567,7 @@ void TimeGraph::SelectCallstacks(float world_start, float world_end, int32_t thr
   RequestUpdate();
 }
 
-const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(int32_t tid) {
+const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(uint32_t tid) {
   return selected_callstack_events_per_thread_[tid];
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -59,8 +59,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                         PickingMode /*picking_mode*/, float /*z_offset*/ = 0) override;
   void UpdateTracksPosition();
-  void SelectCallstacks(float world_start, float world_end, int32_t thread_id);
-  const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(int32_t tid);
+  void SelectCallstacks(float world_start, float world_end, uint32_t thread_id);
+  const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(uint32_t tid);
 
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_grpc_protos::InstrumentedFunction* function);
@@ -108,10 +108,10 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
                            JumpScope jump_scope);
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindPreviousFunctionCall(
       uint64_t function_address, uint64_t current_time,
-      std::optional<int32_t> thread_id = std::nullopt) const;
+      std::optional<uint32_t> thread_id = std::nullopt) const;
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindNextFunctionCall(
       uint64_t function_address, uint64_t current_time,
-      std::optional<int32_t> thread_id = std::nullopt) const;
+      std::optional<uint32_t> thread_id = std::nullopt) const;
   void SelectAndZoom(const orbit_client_protos::TimerInfo* timer_info);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
   [[nodiscard]] double GetCurrentTimeSpanUs() const;
@@ -164,7 +164,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] static Color GetColor(const std::string& str) {
     return GetColor(std::hash<std::string>{}(str));
   }
-  [[nodiscard]] static Color GetThreadColor(int32_t tid) {
+  [[nodiscard]] static Color GetThreadColor(uint32_t tid) {
     return GetColor(static_cast<uint32_t>(tid));
   }
 
@@ -232,7 +232,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
 
   std::unique_ptr<TrackManager> track_manager_;
 
-  absl::flat_hash_map<int32_t, std::vector<orbit_client_protos::CallstackEvent>>
+  absl::flat_hash_map<uint32_t, std::vector<orbit_client_protos::CallstackEvent>>
       selected_callstack_events_per_thread_;
 
   ManualInstrumentationManager* manual_instrumentation_manager_;

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -105,7 +105,7 @@ float TimeGraphLayout::GetBottomMargin() const {
   return GetSliderWidth() + GetTimeBarHeight();
 }
 
-float TimeGraphLayout::GetEventTrackHeightFromTid(int32_t tid) const {
+float TimeGraphLayout::GetEventTrackHeightFromTid(uint32_t tid) const {
   float height = GetEventTrackHeight();
   if (tid == orbit_base::kAllProcessThreadsTid) {
     height *= GetAllThreadsEventTrackScale();

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -10,7 +10,7 @@
 
 #include <algorithm>
 
-#include "OrbitBase/ThreadConstants.h"
+#include "OrbitBase/ThreadUtils.h"
 
 class TimeGraphLayout {
  public:
@@ -22,7 +22,7 @@ class TimeGraphLayout {
   float GetTextBoxHeight() const { return text_box_height_ * scale_; }
   float GetTextCoresHeight() const { return core_height_ * scale_; }
   float GetThreadStateTrackHeight() const { return thread_state_track_height_ * scale_; }
-  float GetEventTrackHeightFromTid(int32_t tid = orbit_base::kInvalidThreadTid) const;
+  float GetEventTrackHeightFromTid(uint32_t tid = orbit_base::kInvalidThreadId) const;
   float GetVariableTrackHeight() const { return variable_track_height_ * scale_; }
   float GetTrackContentBottomMargin() const { return track_content_bottom_margin_ * scale_; }
   float GetTrackContentTopMargin() const { return track_content_top_margin_ * scale_; }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -321,7 +321,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
 }
 
 void TimerTrack::OnTimer(const TimerInfo& timer_info) {
-  if (process_id_ == -1) {
+  if (process_id_ == orbit_base::kInvalidProcessId) {
     process_id_ = timer_info.process_id();
   }
 

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -32,7 +32,7 @@ TracepointThreadBar::TracepointThreadBar(CaptureViewElement* parent, OrbitApp* a
                                          TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                          TimeGraphLayout* layout,
                                          const orbit_client_data::CaptureData* capture_data,
-                                         int32_t thread_id, const Color& color)
+                                         uint32_t thread_id, const Color& color)
     : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Tracepoints",
                 color) {}
 

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -20,7 +20,7 @@ class TracepointThreadBar : public ThreadBar {
   explicit TracepointThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                const orbit_client_data::CaptureData* capture_data,
-                               int32_t thread_id, const Color& color);
+                               uint32_t thread_id, const Color& color);
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const DrawContext& draw_context) override;

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -12,7 +12,7 @@
 #include "CoreMath.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
-#include "OrbitBase/ThreadConstants.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
@@ -23,7 +23,7 @@ using orbit_client_data::TrackData;
 Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
              TimeGraphLayout* layout, const orbit_client_data::CaptureData* capture_data)
     : CaptureViewElement(parent, time_graph, viewport, layout),
-      process_id_{-1},
+      process_id_{orbit_base::kInvalidProcessId},
       pinned_{false},
       layout_(layout),
       capture_data_(capture_data) {
@@ -215,9 +215,9 @@ void Track::SetPos(float x, float y) {
 void Track::SetPinned(bool value) { pinned_ = value; }
 
 Color Track::GetTrackBackgroundColor() const {
-  int32_t capture_process_id = capture_data_->process_id();
+  uint32_t capture_process_id = capture_data_->process_id();
 
-  if (GetProcessId() != -1 && GetProcessId() != capture_process_id &&
+  if (GetProcessId() != orbit_base::kInvalidProcessId && GetProcessId() != capture_process_id &&
       GetType() != Type::kSchedulerTrack) {
     const Color kExternalProcessColor(30, 30, 40, 255);
     return kExternalProcessColor;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -83,7 +83,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   virtual void OnCollapseToggle(bool is_collapsed);
   [[nodiscard]] virtual bool IsCollapsible() const { return false; }
   TriangleToggle* GetTriangleToggle() const { return collapse_toggle_.get(); }
-  [[nodiscard]] int32_t GetProcessId() const { return process_id_; }
+  [[nodiscard]] uint32_t GetProcessId() const { return process_id_; }
   void SetProcessId(uint32_t pid) { process_id_ = pid; }
   [[nodiscard]] virtual bool IsEmpty() const = 0;
 
@@ -124,7 +124,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
-  int32_t process_id_;
+  uint32_t process_id_;
   bool draw_background_ = true;
   bool visible_ = true;
   bool pinned_ = false;

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -144,12 +144,12 @@ void TrackManager::SortTracks() {
   }
 
   // Separate "capture_pid" tracks from tracks that originate from other processes.
-  int32_t capture_pid = capture_data_->process_id();
+  uint32_t capture_pid = capture_data_->process_id();
   std::vector<Track*> capture_pid_tracks;
   std::vector<Track*> external_pid_tracks;
   for (auto& track : all_processes_sorted_tracks) {
-    int32_t pid = track->GetProcessId();
-    if (pid != -1 && pid != capture_pid) {
+    uint32_t pid = track->GetProcessId();
+    if (pid != orbit_base::kInvalidProcessId && pid != capture_pid) {
       external_pid_tracks.push_back(track);
     } else {
       capture_pid_tracks.push_back(track);
@@ -447,7 +447,7 @@ SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {
   return scheduler_track_.get();
 }
 
-ThreadTrack* TrackManager::GetOrCreateThreadTrack(int32_t tid) {
+ThreadTrack* TrackManager::GetOrCreateThreadTrack(uint32_t tid) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<ThreadTrack> track = thread_tracks_[tid];
   if (track == nullptr) {

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -62,7 +62,7 @@ class TrackManager {
 
   Track* GetOrCreateTrackFromTimerInfo(const orbit_client_protos::TimerInfo& timer_info);
   SchedulerTrack* GetOrCreateSchedulerTrack();
-  ThreadTrack* GetOrCreateThreadTrack(int32_t tid);
+  ThreadTrack* GetOrCreateThreadTrack(uint32_t tid);
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
   orbit_gl::VariableTrack* GetOrCreateVariableTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
@@ -102,7 +102,7 @@ class TrackManager {
   mutable std::recursive_mutex mutex_;
 
   std::vector<std::shared_ptr<Track>> all_tracks_;
-  absl::flat_hash_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
+  absl::flat_hash_map<uint32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
   std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
   std::map<std::string, std::shared_ptr<orbit_gl::VariableTrack>> variable_tracks_;
   // Mapping from timeline to GPU tracks. Timeline name is used for stable ordering. In particular

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -63,7 +63,7 @@ void OrbitTestImpl::Start() {
 }
 
 void OrbitTestImpl::Loop() {
-  auto tid = orbit_base::GetCurrentThreadId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
   orbit_base::SetCurrentThreadName(absl::StrFormat("OrbitThread_%s", std::to_string(tid)).c_str());
   uint32_t count = 0;
   while (!exit_requested_) {

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -57,8 +57,8 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   struct SubmissionMetaInformation {
     uint64_t pre_submission_cpu_timestamp;
     uint64_t post_submission_cpu_timestamp;
-    int32_t thread_id;
-    int32_t process_id;
+    uint32_t thread_id;
+    uint32_t process_id;
   };
 
   // A persistent version of a command buffer that was submitted and its begin/end slot in the

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -517,8 +517,8 @@ TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsForACompleteSubm
   tracker_.TrackCommandBuffers(device_, command_pool_, &command_buffer_, 1);
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -555,8 +555,8 @@ TEST_F(SubmissionTrackerTest,
   tracker_.TrackCommandBuffers(device_, command_pool_, &command_buffer_, 1);
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -627,8 +627,8 @@ TEST_F(SubmissionTrackerTest, WillRetryCompletingSubmissionsWhenTimestampQueryFa
                                                         .commandBufferCount = 1,
                                                         .pCommandBuffers = &command_buffers[1]}};
 
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   std::array<uint64_t, 2> pre_submit_times;
   std::array<uint64_t, 2> post_submit_times;
 
@@ -706,8 +706,8 @@ TEST_F(SubmissionTrackerTest,
   tracker_.TrackCommandBuffers(device_, command_pool_, &command_buffer_, 1);
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -743,8 +743,8 @@ TEST_F(SubmissionTrackerTest, StopCaptureDuringSubmissionWillStillYieldResults) 
   tracker_.TrackCommandBuffers(device_, command_pool_, &command_buffer_, 1);
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -914,8 +914,8 @@ TEST_F(SubmissionTrackerTest, ReusingCommandBufferWithoutResetInvalidatesSlot) {
   tracker_.TrackCommandBuffers(device_, command_pool_, &command_buffer_, 1);
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -1049,8 +1049,8 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmis
   tracker_.MarkDebugMarkerBegin(command_buffer_, text, expected_color);
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -1172,8 +1172,8 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNestedDebugMarkerTimestampsForAComplete
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -1251,8 +1251,8 @@ TEST_F(SubmissionTrackerTest,
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -1320,8 +1320,8 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
 
   Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
 
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
 
   producer_->StartCapture();
   tracker_.TrackCommandBuffers(device_, command_pool_, &command_buffer_, 1);
@@ -1599,8 +1599,8 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBuffer) {
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
   uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(queue_, 1, &submit_info_);
@@ -1672,8 +1672,8 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
 
   Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
 
-  pid_t tid = orbit_base::GetCurrentThreadId();
-  pid_t pid = orbit_base::GetCurrentProcessId();
+  uint32_t tid = orbit_base::GetCurrentThreadId();
+  uint32_t pid = orbit_base::GetCurrentProcessId();
 
   constexpr uint64_t kMaxDepth = 1;
   producer_->StartCapture(kMaxDepth);

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -236,7 +236,7 @@ static ProducerCaptureEvent CreateCaptureStartedEvent(const CaptureOptions& capt
   ProducerCaptureEvent event;
   CaptureStarted* capture_started = event.mutable_capture_started();
 
-  int32_t target_pid = capture_options.pid();
+  int32_t target_pid = orbit_base::GetNativeProcessId(capture_options.pid());
 
   capture_started->set_process_id(target_pid);
   auto executable_path_or_error = orbit_base::GetExecutablePath(target_pid);
@@ -422,7 +422,8 @@ grpc::Status CaptureServiceImpl::Capture(
 
   // Disable user space instrumentation.
   if (capture_options.enable_user_space_instrumentation()) {
-    auto result_tmp = instrumentation_manager_->UninstrumentProcess(capture_options.pid());
+    const pid_t target_process_id = orbit_base::GetNativeProcessId(capture_options.pid());
+    auto result_tmp = instrumentation_manager_->UninstrumentProcess(target_process_id);
     if (result_tmp.has_error()) {
       ERROR("Disabling user space instrumentation: %s", result_tmp.error().message());
       producer_event_processor->ProcessEvent(

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -236,7 +236,7 @@ static ProducerCaptureEvent CreateCaptureStartedEvent(const CaptureOptions& capt
   ProducerCaptureEvent event;
   CaptureStarted* capture_started = event.mutable_capture_started();
 
-  int32_t target_pid = orbit_base::GetNativeProcessId(capture_options.pid());
+  pid_t target_pid = orbit_base::ToNativeProcessId(capture_options.pid());
 
   capture_started->set_process_id(target_pid);
   auto executable_path_or_error = orbit_base::GetExecutablePath(target_pid);
@@ -422,7 +422,7 @@ grpc::Status CaptureServiceImpl::Capture(
 
   // Disable user space instrumentation.
   if (capture_options.enable_user_space_instrumentation()) {
-    const pid_t target_process_id = orbit_base::GetNativeProcessId(capture_options.pid());
+    const pid_t target_process_id = orbit_base::ToNativeProcessId(capture_options.pid());
     auto result_tmp = instrumentation_manager_->UninstrumentProcess(target_process_id);
     if (result_tmp.has_error()) {
       ERROR("Disabling user space instrumentation: %s", result_tmp.error().message());

--- a/src/Service/MemoryInfoHandler.cpp
+++ b/src/Service/MemoryInfoHandler.cpp
@@ -7,6 +7,7 @@
 #include "GrpcProtos/Constants.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Profiling.h"
+#include "OrbitBase/ThreadUtils.h"
 
 namespace orbit_service {
 
@@ -18,19 +19,21 @@ void MemoryInfoHandler::Start(orbit_grpc_protos::CaptureOptions capture_options)
   SetEnableCGroupMemory(true);
   SetEnableProcessMemory(true);
 
+  const int32_t pid = orbit_base::GetNativeProcessId(capture_options.pid());
+
   CHECK(system_memory_info_producer_ == nullptr);
   system_memory_info_producer_ = orbit_memory_tracing::CreateSystemMemoryInfoProducer(
-      this, capture_options.memory_sampling_period_ns(), capture_options.pid());
+      this, capture_options.memory_sampling_period_ns(), pid);
   system_memory_info_producer_->Start();
 
   CHECK(cgroup_memory_info_producer_ == nullptr);
   cgroup_memory_info_producer_ = orbit_memory_tracing::CreateCGroupMemoryInfoProducer(
-      this, capture_options.memory_sampling_period_ns(), capture_options.pid());
+      this, capture_options.memory_sampling_period_ns(), pid);
   cgroup_memory_info_producer_->Start();
 
   CHECK(process_memory_info_producer_ == nullptr);
   process_memory_info_producer_ = orbit_memory_tracing::CreateProcessMemoryInfoProducer(
-      this, capture_options.memory_sampling_period_ns(), capture_options.pid());
+      this, capture_options.memory_sampling_period_ns(), pid);
   process_memory_info_producer_->Start();
 }
 

--- a/src/Service/MemoryInfoHandler.cpp
+++ b/src/Service/MemoryInfoHandler.cpp
@@ -19,7 +19,7 @@ void MemoryInfoHandler::Start(orbit_grpc_protos::CaptureOptions capture_options)
   SetEnableCGroupMemory(true);
   SetEnableProcessMemory(true);
 
-  const int32_t pid = orbit_base::GetNativeProcessId(capture_options.pid());
+  const pid_t pid = orbit_base::ToNativeProcessId(capture_options.pid());
 
   CHECK(system_memory_info_producer_ == nullptr);
   system_memory_info_producer_ = orbit_memory_tracing::CreateSystemMemoryInfoProducer(

--- a/src/Service/ProcessList.cpp
+++ b/src/Service/ProcessList.cpp
@@ -46,7 +46,7 @@ ErrorMessageOr<void> ProcessList::Refresh() {
     const std::filesystem::path& path = it->path();
     std::string folder_name = path.filename().string();
 
-    int32_t pid;
+    uint32_t pid;
     if (!absl::SimpleAtoi(folder_name, &pid)) continue;
 
     const auto iter = processes_.find(pid);

--- a/src/Service/ProcessServiceImpl.cpp
+++ b/src/Service/ProcessServiceImpl.cpp
@@ -63,7 +63,7 @@ Status ProcessServiceImpl::GetProcessList(ServerContext*, const GetProcessListRe
 Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
                                          const GetModuleListRequest* request,
                                          GetModuleListResponse* response) {
-  uint32_t pid = request->process_id();
+  pid_t pid = orbit_base::ToNativeProcessId(request->process_id());
   LOG("Sending modules for process %d", pid);
 
   const auto module_infos = orbit_object_utils::ReadModules(pid);

--- a/src/Service/ProcessServiceImpl.cpp
+++ b/src/Service/ProcessServiceImpl.cpp
@@ -83,10 +83,8 @@ Status ProcessServiceImpl::GetProcessMemory(ServerContext*, const GetProcessMemo
   uint64_t size = std::min(request->size(), kMaxGetProcessMemoryResponseSize);
   response->mutable_memory()->resize(size);
   uint64_t num_bytes_read = 0;
-  uint32_t pid = request->pid();
-  CHECK(orbit_base::IsValidProcessId(pid));
-  if (utils::ReadProcessMemory(pid, request->address(), response->mutable_memory()->data(), size,
-                               &num_bytes_read)) {
+  if (utils::ReadProcessMemory(request->pid(), request->address(),
+                               response->mutable_memory()->data(), size, &num_bytes_read)) {
     response->mutable_memory()->resize(num_bytes_read);
     return Status::OK;
   }

--- a/src/Service/ProcessServiceImpl.cpp
+++ b/src/Service/ProcessServiceImpl.cpp
@@ -62,7 +62,7 @@ Status ProcessServiceImpl::GetProcessList(ServerContext*, const GetProcessListRe
 Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
                                          const GetModuleListRequest* request,
                                          GetModuleListResponse* response) {
-  int32_t pid = request->process_id();
+  uint32_t pid = request->process_id();
   LOG("Sending modules for process %d", pid);
 
   const auto module_infos = orbit_object_utils::ReadModules(pid);

--- a/src/Service/ProcessServiceImpl.cpp
+++ b/src/Service/ProcessServiceImpl.cpp
@@ -16,6 +16,7 @@
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "ServiceUtils.h"
 #include "module.pb.h"
 #include "process.pb.h"
@@ -82,8 +83,10 @@ Status ProcessServiceImpl::GetProcessMemory(ServerContext*, const GetProcessMemo
   uint64_t size = std::min(request->size(), kMaxGetProcessMemoryResponseSize);
   response->mutable_memory()->resize(size);
   uint64_t num_bytes_read = 0;
-  if (utils::ReadProcessMemory(request->pid(), request->address(),
-                               response->mutable_memory()->data(), size, &num_bytes_read)) {
+  uint32_t pid = request->pid();
+  CHECK(orbit_base::IsValidProcessId(pid));
+  if (utils::ReadProcessMemory(pid, request->address(), response->mutable_memory()->data(), size,
+                               &num_bytes_read)) {
     response->mutable_memory()->resize(num_bytes_read);
     return Status::OK;
   }

--- a/src/Service/ServiceUtils.cpp
+++ b/src/Service/ServiceUtils.cpp
@@ -31,6 +31,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "absl/strings/str_format.h"
 #include "module.pb.h"
 
@@ -414,7 +415,8 @@ bool ReadProcessMemory(uint32_t pid, uintptr_t address, void* buffer, uint64_t s
                        uint64_t* num_bytes_read) noexcept {
   iovec local_iov[] = {{buffer, size}};
   iovec remote_iov[] = {{absl::bit_cast<void*>(address), size}};
-  *num_bytes_read = process_vm_readv(pid, local_iov, ABSL_ARRAYSIZE(local_iov), remote_iov,
+  pid_t native_pid = orbit_base::ToNativeProcessId(pid);
+  *num_bytes_read = process_vm_readv(native_pid, local_iov, ABSL_ARRAYSIZE(local_iov), remote_iov,
                                      ABSL_ARRAYSIZE(remote_iov), 0);
   return *num_bytes_read == size;
 }

--- a/src/Service/ServiceUtils.cpp
+++ b/src/Service/ServiceUtils.cpp
@@ -410,7 +410,7 @@ ErrorMessageOr<fs::path> FindSymbolsFilePath(
   return ErrorMessage("Unknown object file type.");
 }
 
-bool ReadProcessMemory(int32_t pid, uintptr_t address, void* buffer, uint64_t size,
+bool ReadProcessMemory(uint32_t pid, uintptr_t address, void* buffer, uint64_t size,
                        uint64_t* num_bytes_read) noexcept {
   iovec local_iov[] = {{buffer, size}};
   iovec remote_iov[] = {{absl::bit_cast<void*>(address), size}};

--- a/src/Service/ServiceUtils.h
+++ b/src/Service/ServiceUtils.h
@@ -48,7 +48,7 @@ ErrorMessageOr<std::filesystem::path> FindSymbolsFilePath(
         "/home/cloudcast/", "/home/cloudcast/debug_symbols/", "/mnt/developer/",
         "/mnt/developer/debug_symbols/", "/srv/game/assets/",
         "/srv/game/assets/debug_symbols/"}) noexcept;
-bool ReadProcessMemory(int32_t pid, uintptr_t address, void* buffer, uint64_t size,
+bool ReadProcessMemory(uint32_t pid, uintptr_t address, void* buffer, uint64_t size,
                        uint64_t* num_bytes_read) noexcept;
 }  // namespace orbit_service::utils
 

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -439,11 +439,11 @@ void SessionSetupDialog::OnProcessListUpdate(
 
     // In case there is a selection already, do not change anything, only update the cpu usage
     if (ui_->processesTableView->selectionModel()->hasSelection()) {
-      const int32_t selected_process_id = ui_->processesTableView->selectionModel()
-                                              ->selectedRows()[0]
-                                              .data(Qt::UserRole)
-                                              .value<const ProcessInfo*>()
-                                              ->pid();
+      const uint32_t selected_process_id = ui_->processesTableView->selectionModel()
+                                               ->selectedRows()[0]
+                                               .data(Qt::UserRole)
+                                               .value<const ProcessInfo*>()
+                                               ->pid();
       const auto it =
           std::find_if(process_list.begin(), process_list.end(),
                        [&](const auto& process) { return process.pid() == selected_process_id; });

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -154,7 +154,7 @@ class InstrumentedProcess {
 ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create(
     const CaptureOptions& capture_options) {
   std::unique_ptr<InstrumentedProcess> process(new InstrumentedProcess());
-  const pid_t pid = orbit_base::GetNativeProcessId(capture_options.pid());
+  const pid_t pid = orbit_base::ToNativeProcessId(capture_options.pid());
   process->pid_ = pid;
   OUTCOME_TRY(AttachAndStopProcess(pid));
   orbit_base::unique_resource detach_on_exit{pid, [](int32_t pid) {
@@ -397,7 +397,7 @@ InstrumentationManager::~InstrumentationManager() {}
 
 ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentationManager::InstrumentProcess(
     const CaptureOptions& capture_options) {
-  const pid_t pid = orbit_base::GetNativeProcessId(capture_options.pid());
+  const pid_t pid = orbit_base::ToNativeProcessId(capture_options.pid());
 
   // If the user tries to instrument this instance of OrbitService we can't use user space
   // instrumentation: We would need to attach to / stop our own process.

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -19,6 +19,7 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "OrbitBase/UniqueResource.h"
 #include "Trampoline.h"
 #include "UserSpaceInstrumentation/Attach.h"
@@ -153,7 +154,7 @@ class InstrumentedProcess {
 ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create(
     const CaptureOptions& capture_options) {
   std::unique_ptr<InstrumentedProcess> process(new InstrumentedProcess());
-  const pid_t pid = capture_options.pid();
+  const pid_t pid = orbit_base::GetNativeProcessId(capture_options.pid());
   process->pid_ = pid;
   OUTCOME_TRY(AttachAndStopProcess(pid));
   orbit_base::unique_resource detach_on_exit{pid, [](int32_t pid) {
@@ -396,7 +397,7 @@ InstrumentationManager::~InstrumentationManager() {}
 
 ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentationManager::InstrumentProcess(
     const CaptureOptions& capture_options) {
-  const pid_t pid = capture_options.pid();
+  const pid_t pid = orbit_base::GetNativeProcessId(capture_options.pid());
 
   // If the user tries to instrument this instance of OrbitService we can't use user space
   // instrumentation: We would need to attach to / stop our own process.


### PR DESCRIPTION
Use uint32_t as the common type to represent platform-agnostic thread
and process ids. Define kInvalidThreadId and kInvalidProcessId as
platform-agnostic invalid ids. The native thread and process utils are still
available, but now have the "Native" suffix. Also, add conversion utils
to and from native id types.

See go/stadia-orbit-pids-tids for more info.

Tests:  loading old/new captures, navigating capture window, manual and 
dynamic instrumentation, sampling, thread names, selecting samples.

I suggest reviewing individual commits. It looks massive but the changes are
fairly small and are mainly in the first two commits. Thanks for your help!