### PR TITLE
Update GTest to 1.11.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -68,7 +68,7 @@ class OrbitConan(ConanFile):
     def build_requirements(self):
         self.build_requires('protoc_installer/3.9.1@bincrafters/stable#0')
         self.build_requires('grpc_codegen/1.27.3@{}'.format(self._orbit_channel))
-        self.build_requires('gtest/1.10.0#ef88ba8e54f5ffad7d706062d0731a40', force_host_context=True)
+        self.build_requires('gtest/1.11.0', force_host_context=True)
 
     def requirements(self):
         if self.settings.os != "Windows" and self.options.with_gui and not self.options.system_qt and self.options.system_mesa:

--- a/src/Test/CMakeLists.txt
+++ b/src/Test/CMakeLists.txt
@@ -24,3 +24,8 @@ if(NOT TARGET GTest::QtGuiMain AND TARGET Qt5::Widgets)
   target_link_libraries(GTest_QtGuiMain PUBLIC OrbitBase GTest::GTest Qt5::Widgets CONAN_PKG::abseil)
   add_library(GTest::QtGuiMain ALIAS GTest_QtGuiMain)
 endif()
+
+add_executable(TestTests StringViewTest.cpp)
+target_link_libraries(TestTests PRIVATE GTest::Main)
+target_compile_options(TestTests PRIVATE ${STRICT_COMPILE_FLAGS})
+register_test(TestTests)

--- a/src/Test/StringViewTest.cpp
+++ b/src/Test/StringViewTest.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+namespace orbit_test {
+
+// Ensures that GTest was compiled with std::string_view support.
+TEST(Test, MatchersSupportStringView) {
+  std::string_view some_string = "Hello World!";
+  EXPECT_THAT(some_string, testing::HasSubstr("World!"));
+}
+}  // namespace orbit_test

--- a/third_party/conan/configs/linux/profiles/clang_common
+++ b/third_party/conan/configs/linux/profiles/clang_common
@@ -6,3 +6,8 @@ compiler.libcxx=libstdc++11
 compiler.fpo=False
 abseil:compiler=clang
 abseil:compiler.cppstd=17
+gtest:compiler=clang
+gtest:compiler.cppstd=17
+
+[env]
+gtest:CXXFLAGS=$CXX_FLAGS -std=c++17

--- a/third_party/conan/configs/linux/profiles/gcc_common
+++ b/third_party/conan/configs/linux/profiles/gcc_common
@@ -6,3 +6,8 @@ compiler.libcxx=libstdc++11
 compiler.fpo=False
 abseil:compiler=gcc
 abseil:compiler.cppstd=17
+gtest:compiler=gcc
+gtest:compiler.cppstd=17
+
+[env]
+gtest:CXXFLAGS=$CXX_FLAGS -std=c++17

--- a/third_party/conan/configs/linux/profiles/ggp_common
+++ b/third_party/conan/configs/linux/profiles/ggp_common
@@ -16,6 +16,8 @@ compiler.libcxx=libc++
 compiler.fpo=False
 abseil:compiler=clang
 abseil:compiler.cppstd=17
+gtest:compiler=clang
+gtest:compiler.cppstd=17
 
 [options]
 OrbitProfiler:with_gui=False

--- a/third_party/conan/configs/linux/profiles/libfuzzer_base
+++ b/third_party/conan/configs/linux/profiles/libfuzzer_base
@@ -4,9 +4,13 @@
 BASE_CFLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
 BASE_CXXFLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC -fno-exceptions
 BASE_LDFLAGS=-Wl,-z,relro,-z,now,-z,noexecstack -pthread
+
 [settings]
 abseil:compiler=clang
 abseil:compiler.cppstd=17
+gtest:compiler=clang
+gtest:compiler.cppstd=17
+
 [options]
 OrbitProfiler:with_gui=False
 OrbitProfiler:run_tests=False
@@ -14,3 +18,4 @@ OrbitProfiler:run_tests=False
 [build_requires]
 
 [env]
+gtest:CXXFLAGS=$CXX_FLAGS -std=c++17

--- a/third_party/conan/configs/windows/profiles/ggp_common
+++ b/third_party/conan/configs/windows/profiles/ggp_common
@@ -17,6 +17,8 @@ compiler.libcxx=libc++
 compiler.fpo=False
 abseil:compiler=clang
 abseil:compiler.cppstd=17
+gtest:compiler=clang
+gtest:compiler.cppstd=17
 
 [options]
 OrbitProfiler:with_gui=False
@@ -31,3 +33,4 @@ CONAN_CMAKE_GENERATOR=Ninja
 CFLAGS=$C_FLAGS
 CXXFLAGS=$CXX_FLAGS
 LDFLAGS=$LD_FLAGS
+gtest:CXXFLAGS=$CXX_FLAGS -std=c++17

--- a/third_party/conan/configs/windows/profiles/msvc2019_common
+++ b/third_party/conan/configs/windows/profiles/msvc2019_common
@@ -11,6 +11,8 @@ compiler=Visual Studio
 compiler.version=16
 abseil:compiler=Visual Studio
 abseil:compiler.cppstd=17
+gtest:compiler=Visual Studio
+gtest:compiler.cppstd=17
 
 [options]
 OrbitProfiler:system_qt=False
@@ -18,3 +20,4 @@ OrbitProfiler:system_qt=False
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LD_FLAGS
+gtest:CXXFLAGS=$CXX_FLAGS -std=c++17

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -418,7 +418,7 @@
     "context": "host"
    },
    "61": {
-    "ref": "gtest/1.10.0#ef88ba8e54f5ffad7d706062d0731a40",
+    "ref": "gtest/1.11.0#088aa58a3c2115519f99667eee50d0a1",
     "context": "host"
    }
   },


### PR DESCRIPTION
The latest version of GTest (1.11.0) supports C++17's std::string_view in GMock matchers. That's a requirement for interoperating with `absl::Status` since `absl::Status::message()` returns a `std::string_view` which we use often as a direct input to GMock's `EXPECT_THAT` macro.