### PR TITLE
Implement build id for PE/COFF

### DIFF
--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -104,3 +104,23 @@ TEST(CoffFile, FailsWithErrorIfPdbDataNotPresent) {
   auto pdb_debug_info_or_error = coff_file_or_error.value()->GetDebugPdbInfo();
   ASSERT_THAT(pdb_debug_info_or_error, HasError("Object file does not have debug PDB info."));
 }
+
+TEST(CoffFile, GetsCorrectBuildIdIfPdbInfoIsPresent) {
+  // Note that our test library libtest.dll does not have a PDB file path.
+  std::filesystem::path file_path = orbit_test::GetTestdataDir() / "dllmain.dll";
+
+  auto coff_file_or_error = CreateCoffFile(file_path);
+  ASSERT_THAT(coff_file_or_error, HasNoError());
+
+  EXPECT_EQ("efaecd92f773bb4ebcf213b84f43b322-3", coff_file_or_error.value()->GetBuildId());
+}
+
+TEST(CoffFile, GetsEmptyBuildIdIfPdbInfoIsNotPresent) {
+  // Note that our test library libtest.dll does not have a PDB file path.
+  std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libtest.dll";
+
+  auto coff_file_or_error = CreateCoffFile(file_path);
+  ASSERT_THAT(coff_file_or_error, HasNoError());
+
+  EXPECT_EQ("", coff_file_or_error.value()->GetBuildId());
+}

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -63,13 +63,13 @@ ErrorMessageOr<ModuleInfo> CreateModule(const std::filesystem::path& module_path
   module_info.set_address_end(end_address);
   module_info.set_name(object_file_or_error.value()->GetName());
   module_info.set_load_bias(object_file_or_error.value()->GetLoadBias());
+  module_info.set_build_id(object_file_or_error.value()->GetBuildId());
   module_info.set_executable_segment_offset(
       object_file_or_error.value()->GetExecutableSegmentOffset());
 
   if (object_file_or_error.value()->IsElf()) {
     auto* elf_file = dynamic_cast<ElfFile*>((object_file_or_error.value().get()));
     CHECK(elf_file != nullptr);
-    module_info.set_build_id(elf_file->GetBuildId());
     module_info.set_soname(elf_file->GetSoname());
   }
 

--- a/src/ObjectUtils/include/ObjectUtils/ElfFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ElfFile.h
@@ -44,7 +44,6 @@ class ElfFile : public ObjectFile {
   [[nodiscard]] virtual bool HasGnuDebuglink() const = 0;
   [[nodiscard]] virtual bool Is64Bit() const = 0;
   [[nodiscard]] virtual std::string GetSoname() const = 0;
-  [[nodiscard]] virtual std::string GetBuildId() const = 0;
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::LineInfo> GetLineInfo(
       uint64_t address) = 0;
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::LineInfo>

--- a/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
@@ -25,6 +25,13 @@ class ObjectFile {
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadDebugSymbols() = 0;
   [[nodiscard]] virtual bool HasDebugSymbols() const = 0;
   [[nodiscard]] virtual std::string GetName() const = 0;
+
+  // For ELF files, the string returned by GetBuildId() is the standard build id that can be found
+  // in the .note.gnu.build-id section, formatted as a human readable string.
+  // PE/COFF object files are uniquely identfied by the PDB debug info consisting of a GUID and age.
+  // The build id is formed from these to provide a string that uniquely identifies this object file
+  // and the corresponding PDB debug info.
+  [[nodiscard]] virtual std::string GetBuildId() const = 0;
   [[nodiscard]] virtual const std::filesystem::path& GetFilePath() const = 0;
 
   // Background and some terminology


### PR DESCRIPTION
PE/COFF object files and corresponding debug info in PDB files are
uniquely identifid by GUID and age in the PDB info found in object
and PDB files. We form a build id that we use to identify modules by
concatenating the GUID and age in a human readable string.

Tested: Unit test.
Bug: http://b/194497774