### PR TITLE
Silently update Orbit's manual instrumentation to collect group id.

### DIFF
--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -13,7 +13,8 @@ set_target_properties(Api PROPERTIES OUTPUT_NAME "orbit")
 target_sources(Api PRIVATE
         LockFreeApiEventProducer.h
         LockFreeApiEventProducer.cpp
-        Orbit.cpp)
+        Orbit.cpp
+        OrbitV0.h)
 
 target_link_libraries(Api PUBLIC
         ApiInterface

--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -14,7 +14,7 @@ target_sources(Api PRIVATE
         LockFreeApiEventProducer.h
         LockFreeApiEventProducer.cpp
         Orbit.cpp
-        OrbitV0.h)
+        OrbitApiVersions.h)
 
 target_link_libraries(Api PUBLIC
         ApiInterface

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -11,6 +11,7 @@
 #include "LockFreeApiEventProducer.h"
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
+#include "OrbitV0.h"
 
 namespace {
 orbit_api::LockFreeApiEventProducer& GetEventProducer() {
@@ -34,14 +35,24 @@ void EnqueueApiEvent(Types... args) {
 
 extern "C" {
 
-void orbit_api_start(const char* name, orbit_api_color color) {
+void orbit_api_start(const char* name, orbit_api_color color, uint64_t group_id) {
   // `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
   // current function (level "0" refers to this frame, "1" would be the callers return address and
   // so on).
   // To decode the return address, we call `__builtin_extract_return_addr`.
   auto return_address =
       absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
-  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, 0LU /*group_id*/, return_address);
+  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, group_id, return_address);
+}
+
+void orbit_api_start_v0(const char* name, orbit_api_color color) {
+  // `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
+  // current function (level "0" refers to this frame, "1" would be the callers return address and
+  // so on).
+  // To decode the return address, we call `__builtin_extract_return_addr`.
+  auto return_address =
+      absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
+  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, 0LU, return_address);
 }
 
 void orbit_api_stop() { EnqueueApiEvent<orbit_api::ApiScopeStop>(); }
@@ -87,7 +98,7 @@ void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color)
   EnqueueApiEvent<orbit_api::ApiStringEvent>(str, id, color);
 }
 
-static void orbit_api_initialize_v0(orbit_api_v0* api) {
+static void orbit_api_initialize_v1(orbit_api_v1* api) {
   // The api function table is accessed by user code using this pattern:
   //
   // bool initialized = api.initialized;
@@ -97,6 +108,30 @@ static void orbit_api_initialize_v0(orbit_api_v0* api) {
   // We use acquire and release semantics to make sure that when api->initialized is set, all the
   // function pointers have been assigned and are visible to other cores.
   api->start = &orbit_api_start;
+  api->stop = &orbit_api_stop;
+  api->start_async = &orbit_api_start_async;
+  api->stop_async = &orbit_api_stop_async;
+  api->async_string = &orbit_api_async_string;
+  api->track_int = &orbit_api_track_int;
+  api->track_int64 = &orbit_api_track_int64;
+  api->track_uint = &orbit_api_track_uint;
+  api->track_uint64 = &orbit_api_track_uint64;
+  api->track_float = &orbit_api_track_float;
+  api->track_double = &orbit_api_track_double;
+  std::atomic_thread_fence(std::memory_order_release);
+  api->initialized = 1;
+}
+
+static void orbit_api_initialize_v0(orbit_api_v0* api) {
+  // The api function table is accessed by user code using this pattern:
+  //
+  // bool initialized = api.initialized;
+  // std::atomic_thread_fence(std::memory_order_acquire)
+  // if (initialized && api->enabled && api->orbit_api_function_name) api->orbit_api_function_name()
+  //
+  // We use acquire and release semantics to make sure that when api->initialized is set, all the
+  // function pointers have been assigned and are visible to other cores.
+  api->start = &orbit_api_start_v0;
   api->stop = &orbit_api_stop;
   api->start_async = &orbit_api_start_async;
   api->stop_async = &orbit_api_stop_async;
@@ -124,10 +159,25 @@ void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled)
         api_version, kOrbitApiVersion);
   }
 
-  orbit_api_v0* api_v0 = absl::bit_cast<orbit_api_v0*>(address);
-  if (!api_v0->initialized) {
-    // Note: initialize any newer api version before v0, which sets "initialized" to 1.
-    orbit_api_initialize_v0(api_v0);
+  if (api_version == 0) {
+    orbit_api_v0* api_v0 = absl::bit_cast<orbit_api_v0*>(address);
+    if (!api_v0->initialized) {
+      // Note: initialize any newer api version before v1, which sets "initialized" to 1.
+      orbit_api_initialize_v0(api_v0);
+    }
+
+    // By the time we reach this, the "initialized" guard variable has been set to 1 and we know
+    // that all function pointers have been written to and published to other cores by the use of
+    // acquire/release fences. The "enabled" flag serves as a global toggle which is always used in
+    // conjunction with the "initialized" flag to determine if the Api is active. See
+    // orbit_api_active() in Orbit.h.
+    api_v0->enabled = enabled;
+  }
+
+  orbit_api_v1* api_v1 = absl::bit_cast<orbit_api_v1*>(address);
+  if (!api_v1->initialized) {
+    // Note: initialize any newer api version before v1, which sets "initialized" to 1.
+    orbit_api_initialize_v1(api_v1);
   }
 
   // By the time we reach this, the "initialized" guard variable has been set to 1 and we know that
@@ -135,6 +185,6 @@ void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled)
   // acquire/release fences. The "enabled" flag serves as a global toggle which is always used in
   // conjunction with the "initialized" flag to determine if the Api is active. See
   // orbit_api_active() in Orbit.h.
-  api_v0->enabled = enabled;
+  api_v1->enabled = enabled;
 }
 }

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -87,10 +87,10 @@ void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color)
   EnqueueApiEvent<orbit_api::ApiStringEvent>(str, id, color);
 }
 
-template <typename OrbitApiCurrentT>
-void orbit_api_initialize_and_set_enabled(
-    OrbitApiCurrentT* api, void (*orbit_api_initialize_function_table)(OrbitApiCurrentT*),
-    bool enabled) {
+template <typename OrbitApiT>
+void orbit_api_initialize_and_set_enabled(OrbitApiT* api,
+                                          void (*orbit_api_initialize_function_table)(OrbitApiT*),
+                                          bool enabled) {
   if (api->initialized == 0u) {
     // The api function table is accessed by user code using this pattern:
     //

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -9,9 +9,16 @@
 
 #include "ApiUtils/Event.h"
 #include "LockFreeApiEventProducer.h"
+#include "OrbitApiVersions.h"
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
-#include "OrbitV0.h"
+
+// `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
+// current function (level "0" refers to this frame, "1" would be the callers return address and
+// so on).
+// To decode the return address, we call `__builtin_extract_return_addr`.
+#define ORBIT_GET_CALLER_PC() \
+  absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)))
 
 namespace {
 orbit_api::LockFreeApiEventProducer& GetEventProducer() {
@@ -31,39 +38,21 @@ void EnqueueApiEvent(Types... args) {
   Event event{pid, tid, timestamp_ns, args...};
   producer.EnqueueIntermediateEvent(event);
 }
-}  // namespace
 
-extern "C" {
-
-void orbit_api_start(const char* name, orbit_api_color color, uint64_t group_id) {
-  // `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
-  // current function (level "0" refers to this frame, "1" would be the callers return address and
-  // so on).
-  // To decode the return address, we call `__builtin_extract_return_addr`.
-  auto return_address =
-      absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
+void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_id) {
+  auto return_address = ORBIT_GET_CALLER_PC();
   EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, group_id, return_address);
 }
 
-void orbit_api_start_v0(const char* name, orbit_api_color color) {
-  // `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
-  // current function (level "0" refers to this frame, "1" would be the callers return address and
-  // so on).
-  // To decode the return address, we call `__builtin_extract_return_addr`.
-  auto return_address =
-      absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
-  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, 0LU, return_address);
+void orbit_api_start(const char* name, orbit_api_color color) {
+  auto return_address = ORBIT_GET_CALLER_PC();
+  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, kOrbitDefaultGroupId, return_address);
 }
 
 void orbit_api_stop() { EnqueueApiEvent<orbit_api::ApiScopeStop>(); }
 
 void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
-  // `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
-  // current function (level "0" refers to this frame, "1" would be the callers return address and
-  // so on).
-  // To decode the return address, we call `__builtin_extract_return_addr`.
-  auto return_address =
-      absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)));
+  auto return_address = ORBIT_GET_CALLER_PC();
   EnqueueApiEvent<orbit_api::ApiScopeStartAsync>(name, id, color, return_address);
 }
 
@@ -98,53 +87,75 @@ void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color)
   EnqueueApiEvent<orbit_api::ApiStringEvent>(str, id, color);
 }
 
-static void orbit_api_initialize_v1(orbit_api_v1* api) {
-  // The api function table is accessed by user code using this pattern:
-  //
-  // bool initialized = api.initialized;
-  // std::atomic_thread_fence(std::memory_order_acquire)
-  // if (initialized && api->enabled && api->orbit_api_function_name) api->orbit_api_function_name()
-  //
-  // We use acquire and release semantics to make sure that when api->initialized is set, all the
-  // function pointers have been assigned and are visible to other cores.
-  api->start = &orbit_api_start;
-  api->stop = &orbit_api_stop;
-  api->start_async = &orbit_api_start_async;
-  api->stop_async = &orbit_api_stop_async;
-  api->async_string = &orbit_api_async_string;
-  api->track_int = &orbit_api_track_int;
-  api->track_int64 = &orbit_api_track_int64;
-  api->track_uint = &orbit_api_track_uint;
-  api->track_uint64 = &orbit_api_track_uint64;
-  api->track_float = &orbit_api_track_float;
-  api->track_double = &orbit_api_track_double;
-  std::atomic_thread_fence(std::memory_order_release);
-  api->initialized = 1;
+void orbit_api_initialize_and_set_enabled_v0(orbit_api_v0* api, bool enabled) {
+  if (api->initialized == 0u) {
+    // The api function table is accessed by user code using this pattern:
+    //
+    // bool initialized = api.initialized;
+    // std::atomic_thread_fence(std::memory_order_acquire)
+    // if (initialized && api->enabled && api->orbit_api_function_name)
+    // api->orbit_api_function_name()
+    //
+    // We use acquire and release semantics to make sure that when api->initialized is set, all the
+    // function pointers have been assigned and are visible to other cores.
+    api->start = &orbit_api_start;
+    api->stop = &orbit_api_stop;
+    api->start_async = &orbit_api_start_async;
+    api->stop_async = &orbit_api_stop_async;
+    api->async_string = &orbit_api_async_string;
+    api->track_int = &orbit_api_track_int;
+    api->track_int64 = &orbit_api_track_int64;
+    api->track_uint = &orbit_api_track_uint;
+    api->track_uint64 = &orbit_api_track_uint64;
+    api->track_float = &orbit_api_track_float;
+    api->track_double = &orbit_api_track_double;
+    std::atomic_thread_fence(std::memory_order_release);
+    api->initialized = 1;
+  }
+  // By the time we reach this, the "initialized" guard variable has been set to 1 and we know
+  // that all function pointers have been written to and published to other cores by the use of
+  // acquire/release fences. The "enabled" flag serves as a global toggle which is always used in
+  // conjunction with the "initialized" flag to determine if the Api is active. See
+  // orbit_api_active() in Orbit.h.
+  api->enabled = static_cast<uint32_t>(enabled);
 }
 
-static void orbit_api_initialize_v0(orbit_api_v0* api) {
-  // The api function table is accessed by user code using this pattern:
-  //
-  // bool initialized = api.initialized;
-  // std::atomic_thread_fence(std::memory_order_acquire)
-  // if (initialized && api->enabled && api->orbit_api_function_name) api->orbit_api_function_name()
-  //
-  // We use acquire and release semantics to make sure that when api->initialized is set, all the
-  // function pointers have been assigned and are visible to other cores.
-  api->start = &orbit_api_start_v0;
-  api->stop = &orbit_api_stop;
-  api->start_async = &orbit_api_start_async;
-  api->stop_async = &orbit_api_stop_async;
-  api->async_string = &orbit_api_async_string;
-  api->track_int = &orbit_api_track_int;
-  api->track_int64 = &orbit_api_track_int64;
-  api->track_uint = &orbit_api_track_uint;
-  api->track_uint64 = &orbit_api_track_uint64;
-  api->track_float = &orbit_api_track_float;
-  api->track_double = &orbit_api_track_double;
-  std::atomic_thread_fence(std::memory_order_release);
-  api->initialized = 1;
+void orbit_api_initialize_and_set_enabled_v1(orbit_api_v1* api, bool enabled) {
+  if (api->initialized == 0u) {
+    // The api function table is accessed by user code using this pattern:
+    //
+    // bool initialized = api.initialized;
+    // std::atomic_thread_fence(std::memory_order_acquire)
+    // if (initialized && api->enabled && api->orbit_api_function_name)
+    // api->orbit_api_function_name()
+    //
+    // We use acquire and release semantics to make sure that when api->initialized is set, all the
+    // function pointers have been assigned and are visible to other cores.
+    api->start = &orbit_api_start_v1;
+    api->stop = &orbit_api_stop;
+    api->start_async = &orbit_api_start_async;
+    api->stop_async = &orbit_api_stop_async;
+    api->async_string = &orbit_api_async_string;
+    api->track_int = &orbit_api_track_int;
+    api->track_int64 = &orbit_api_track_int64;
+    api->track_uint = &orbit_api_track_uint;
+    api->track_uint64 = &orbit_api_track_uint64;
+    api->track_float = &orbit_api_track_float;
+    api->track_double = &orbit_api_track_double;
+    std::atomic_thread_fence(std::memory_order_release);
+    api->initialized = 1;
+  }
+  // By the time we reach this, the "initialized" guard variable has been set to 1 and we know
+  // that all function pointers have been written to and published to other cores by the use of
+  // acquire/release fences. The "enabled" flag serves as a global toggle which is always used in
+  // conjunction with the "initialized" flag to determine if the Api is active. See
+  // orbit_api_active() in Orbit.h.
+  api->enabled = static_cast<uint32_t>(enabled);
 }
+
+}  // namespace
+
+extern "C" {
 
 // The "orbit_api_set_enabled" function is called remotely by OrbitService on every capture start
 // for all api function tables. It is also called on every capture stop to disable the api so that
@@ -159,32 +170,19 @@ void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled)
         api_version, kOrbitApiVersion);
   }
 
-  if (api_version == 0) {
-    orbit_api_v0* api_v0 = absl::bit_cast<orbit_api_v0*>(address);
-    if (!api_v0->initialized) {
-      // Note: initialize any newer api version before v1, which sets "initialized" to 1.
-      orbit_api_initialize_v0(api_v0);
+  switch (api_version) {
+    case 0: {
+      auto* api_v0 = absl::bit_cast<orbit_api_v0*>(address);
+      orbit_api_initialize_and_set_enabled_v0(api_v0, enabled);
+      return;
     }
-
-    // By the time we reach this, the "initialized" guard variable has been set to 1 and we know
-    // that all function pointers have been written to and published to other cores by the use of
-    // acquire/release fences. The "enabled" flag serves as a global toggle which is always used in
-    // conjunction with the "initialized" flag to determine if the Api is active. See
-    // orbit_api_active() in Orbit.h.
-    api_v0->enabled = enabled;
+    case 1: {
+      auto* api_v1 = absl::bit_cast<orbit_api_v1*>(address);
+      orbit_api_initialize_and_set_enabled_v1(api_v1, enabled);
+      return;
+    }
+    default:
+      UNREACHABLE();
   }
-
-  orbit_api_v1* api_v1 = absl::bit_cast<orbit_api_v1*>(address);
-  if (!api_v1->initialized) {
-    // Note: initialize any newer api version before v1, which sets "initialized" to 1.
-    orbit_api_initialize_v1(api_v1);
-  }
-
-  // By the time we reach this, the "initialized" guard variable has been set to 1 and we know that
-  // all function pointers have been written to and published to other cores by the use of
-  // acquire/release fences. The "enabled" flag serves as a global toggle which is always used in
-  // conjunction with the "initialized" flag to determine if the Api is active. See
-  // orbit_api_active() in Orbit.h.
-  api_v1->enabled = enabled;
 }
 }

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -40,19 +40,19 @@ void EnqueueApiEvent(Types... args) {
 }
 
 void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_id) {
-  auto return_address = ORBIT_GET_CALLER_PC();
+  uint64_t return_address = ORBIT_GET_CALLER_PC();
   EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, group_id, return_address);
 }
 
 void orbit_api_start(const char* name, orbit_api_color color) {
-  auto return_address = ORBIT_GET_CALLER_PC();
+  uint64_t return_address = ORBIT_GET_CALLER_PC();
   EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, kOrbitDefaultGroupId, return_address);
 }
 
 void orbit_api_stop() { EnqueueApiEvent<orbit_api::ApiScopeStop>(); }
 
 void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
-  auto return_address = ORBIT_GET_CALLER_PC();
+  uint64_t return_address = ORBIT_GET_CALLER_PC();
   EnqueueApiEvent<orbit_api::ApiScopeStartAsync>(name, id, color, return_address);
 }
 
@@ -87,9 +87,9 @@ void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color)
   EnqueueApiEvent<orbit_api::ApiStringEvent>(str, id, color);
 }
 
-template <typename orbit_api_current>
+template <typename OrbitApiCurrentT>
 void orbit_api_initialize_and_set_enabled(
-    orbit_api_current* api, void (*orbit_api_initialize_function_table)(orbit_api_current*),
+    OrbitApiCurrentT* api, void (*orbit_api_initialize_function_table)(OrbitApiCurrentT*),
     bool enabled) {
   if (api->initialized == 0u) {
     // The api function table is accessed by user code using this pattern:

--- a/src/Api/OrbitApiVersions.h
+++ b/src/Api/OrbitApiVersions.h
@@ -11,11 +11,6 @@
 // =================================================================================================
 // Orbit Manual Instrumentation API.
 // =================================================================================================
-#ifdef __linux
-#define ORBIT_EXPORT __attribute__((visibility("default")))
-#else
-#define ORBIT_EXPORT __declspec(dllexport)
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/Api/OrbitV0.h
+++ b/src/Api/OrbitV0.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_API_ORBIT_V0_H_
+#define ORBIT_API_ORBIT_V0_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// =================================================================================================
+// Orbit Manual Instrumentation API.
+// =================================================================================================
+#ifdef __linux
+#define ORBIT_EXPORT __attribute__((visibility("default")))
+#else
+#define ORBIT_EXPORT __declspec(dllexport)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct orbit_api_v0 {
+  uint32_t enabled;
+  uint32_t initialized;
+  void (*start)(const char* name, orbit_api_color color);
+  void (*stop)();
+  void (*start_async)(const char* name, uint64_t id, orbit_api_color color);
+  void (*stop_async)(uint64_t id);
+  void (*async_string)(const char* str, uint64_t id, orbit_api_color color);
+  void (*track_int)(const char* name, int value, orbit_api_color color);
+  void (*track_int64)(const char* name, int64_t value, orbit_api_color color);
+  void (*track_uint)(const char* name, uint32_t value, orbit_api_color color);
+  void (*track_uint64)(const char* name, uint64_t value, orbit_api_color color);
+  void (*track_float)(const char* name, float value, orbit_api_color color);
+  void (*track_double)(const char* name, double value, orbit_api_color color);
+};
+
+#ifdef __cplusplus
+}  // extern "C"
+
+#endif  // __cplusplus
+
+#endif  // ORBIT_API_ORBIT_V0_H_

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -33,7 +33,7 @@ ABSL_CONST_INIT static absl::Mutex global_tracing_mutex(absl::kConstInit);
 ABSL_CONST_INIT static TracingListener* global_tracing_listener = nullptr;
 
 // Tracing uses the same function table used by the Orbit API, but specifies its own functions.
-orbit_api_v0 g_orbit_api_v0;
+orbit_api_v1 g_orbit_api_v1;
 
 namespace orbit_introspection {
 
@@ -102,7 +102,7 @@ void TracingListener::DeferApiEventProcessing(const orbit_api::ApiEventVariant& 
   });
 }
 
-void orbit_api_start(const char* name, orbit_api_color color) {
+void orbit_api_start(const char* name, orbit_api_color color, uint64_t group_id) {
   int32_t process_id = orbit_base::GetCurrentProcessId();
   int32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
@@ -120,7 +120,7 @@ void orbit_api_start(const char* name, orbit_api_color color) {
                                            timestamp_ns,
                                            name,
                                            color,
-                                           0,
+                                           group_id,
                                            absl::bit_cast<uint64_t>(return_address)};
   TracingListener::DeferApiEventProcessing(api_scope_start);
 }
@@ -224,21 +224,21 @@ void orbit_api_track_double(const char* name, double value, orbit_api_color colo
 namespace orbit_introspection {
 
 void InitializeTracing() {
-  if (g_orbit_api_v0.initialized != 0) return;
-  g_orbit_api_v0.start = &orbit_api_start;
-  g_orbit_api_v0.stop = &orbit_api_stop;
-  g_orbit_api_v0.start_async = &orbit_api_start_async;
-  g_orbit_api_v0.stop_async = &orbit_api_stop_async;
-  g_orbit_api_v0.async_string = &orbit_api_async_string;
-  g_orbit_api_v0.track_int = &orbit_api_track_int;
-  g_orbit_api_v0.track_int64 = &orbit_api_track_int64;
-  g_orbit_api_v0.track_uint = &orbit_api_track_uint;
-  g_orbit_api_v0.track_uint64 = &orbit_api_track_uint64;
-  g_orbit_api_v0.track_float = &orbit_api_track_float;
-  g_orbit_api_v0.track_double = &orbit_api_track_double;
+  if (g_orbit_api_v1.initialized != 0) return;
+  g_orbit_api_v1.start = &orbit_api_start;
+  g_orbit_api_v1.stop = &orbit_api_stop;
+  g_orbit_api_v1.start_async = &orbit_api_start_async;
+  g_orbit_api_v1.stop_async = &orbit_api_stop_async;
+  g_orbit_api_v1.async_string = &orbit_api_async_string;
+  g_orbit_api_v1.track_int = &orbit_api_track_int;
+  g_orbit_api_v1.track_int64 = &orbit_api_track_int64;
+  g_orbit_api_v1.track_uint = &orbit_api_track_uint;
+  g_orbit_api_v1.track_uint64 = &orbit_api_track_uint64;
+  g_orbit_api_v1.track_float = &orbit_api_track_float;
+  g_orbit_api_v1.track_double = &orbit_api_track_double;
   std::atomic_thread_fence(std::memory_order_release);
-  g_orbit_api_v0.initialized = 1;
-  g_orbit_api_v0.enabled = 1;
+  g_orbit_api_v1.initialized = 1;
+  g_orbit_api_v1.enabled = 1;
 }
 
 }  // namespace orbit_introspection

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -102,7 +102,7 @@ void TracingListener::DeferApiEventProcessing(const orbit_api::ApiEventVariant& 
   });
 }
 
-void orbit_api_start(const char* name, orbit_api_color color, uint64_t group_id) {
+void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_id) {
   int32_t process_id = orbit_base::GetCurrentProcessId();
   int32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
@@ -225,7 +225,7 @@ namespace orbit_introspection {
 
 void InitializeTracing() {
   if (g_orbit_api_v1.initialized != 0) return;
-  g_orbit_api_v1.start = &orbit_api_start;
+  g_orbit_api_v1.start = &orbit_api_start_v1;
   g_orbit_api_v1.stop = &orbit_api_stop;
   g_orbit_api_v1.start_async = &orbit_api_start_async;
   g_orbit_api_v1.stop_async = &orbit_api_stop_async;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -149,7 +149,7 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
     function_name = capture_data_->GetFunctionNameByAddress(timer_info->address_in_function());
   }
 
-  return absl::StrFormat(
+  std::string result = absl::StrFormat(
       "<b>%s</b><br/>"
       "<i>Timing measured through %s instrumentation</i>"
       "<br/><br/>"
@@ -159,6 +159,12 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
       label, is_manual ? "manual" : "dynamic", function_name, module_name,
       orbit_display_formats::GetDisplayTime(
           TicksToDuration(timer_info->start(), timer_info->end())));
+
+  if (timer_info->group_id() != kOrbitDefaultGroupId) {
+    result += absl::StrFormat("<br/><b>Group Id:</b> %lu", timer_info->group_id());
+  }
+
+  return result;
 }
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -145,8 +145,8 @@ void OrbitTestImpl::ManualInstrumentationApiTest() {
     thread_local uint64_t group_id = 0;
     uint64_t current_id = group_id++;
     ORBIT_START_WITH_GROUP_ID("ORBIT_START_TEST with group id", current_id);
-    ORBIT_START_WITH_COLOR_AND_GROUP_ID("ORBIT_START_TEST with group id",
-                                        kOrbitColorBlueGrey, current_id);
+    ORBIT_START_WITH_COLOR_AND_GROUP_ID("ORBIT_START_TEST with group id", kOrbitColorBlueGrey,
+                                        current_id);
     std::this_thread::sleep_for(std::chrono::microseconds(500));
     ORBIT_STOP();
     ORBIT_STOP();


### PR DESCRIPTION
The group id will be used to associate different timers to each other.
Currently, the data will only be collected and shown in the tooltip.

Note, that this is silently upgrading the version of manual
instrumentation. The public documentation (in the header) is not
yet updated.

Test: Profile OrbitTest (compiled with v0 and v1).
Bug: http://b/194764373