### PR TITLE
Replacing PRIx64 by x specifier

### DIFF
--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -130,15 +130,14 @@ void ProcessData::AddOrUpdateModuleInfo(const ModuleInfo& module_info) {
 ErrorMessageOr<ModuleInMemory> ProcessData::FindModuleByAddress(uint64_t absolute_address) const {
   absl::MutexLock lock(&mutex_);
   if (start_address_to_module_in_memory_.empty()) {
-    return ErrorMessage(absl::StrFormat("Unable to find module for address %016" PRIx64
-                                        ": No modules loaded by process %s",
-                                        absolute_address, process_info_.name()));
+    return ErrorMessage(
+        absl::StrFormat("Unable to find module for address %016x: No modules loaded by process %s",
+                        absolute_address, process_info_.name()));
   }
 
-  ErrorMessage not_found_error =
-      ErrorMessage(absl::StrFormat("Unable to find module for address %016" PRIx64
-                                   ": No module loaded at this address by process %s",
-                                   absolute_address, process_info_.name()));
+  ErrorMessage not_found_error = ErrorMessage(absl::StrFormat(
+      "Unable to find module for address %016x: No module loaded at this address by process %s",
+      absolute_address, process_info_.name()));
 
   auto it = start_address_to_module_in_memory_.upper_bound(absolute_address);
   if (it == start_address_to_module_in_memory_.begin()) return not_found_error;

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -40,7 +40,7 @@ class ModuleInMemory {
   [[nodiscard]] const std::string& file_path() const { return file_path_; }
   [[nodiscard]] const std::string& build_id() const { return build_id_; }
   [[nodiscard]] std::string FormattedAddressRange() const {
-    return absl::StrFormat("[%016" PRIx64 " - %016" PRIx64 "]", start_, end_);
+    return absl::StrFormat("[%016x - %016x]", start_, end_);
   }
 
  private:

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2163,8 +2163,8 @@ void OrbitApp::SetMaxLocalMarkerDepthPerCommandBuffer(
 }
 
 void OrbitApp::SelectFunction(const orbit_client_protos::FunctionInfo& func) {
-  LOG("Selected %s (address_=0x%" PRIx64 ", loaded_module_path_=%s)", func.pretty_name(),
-      func.address(), func.module_path());
+  LOG("Selected %s (address_=%#x, loaded_module_path_=%s)", func.pretty_name(), func.address(),
+      func.module_path());
   data_manager_->SelectFunction(func);
 }
 

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -100,7 +100,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
     case kColumnModule:
       return function.module_path();
     case kColumnAddress:
-      return absl::StrFormat("%#" PRIx64, function.address());
+      return absl::StrFormat("%#x", function.address());
     default:
       return "";
   }


### PR DESCRIPTION
Replace `PRIx64` by the `x` specifier as `PRIx64` is not required in abseil.