### PR TITLE
Clean up iterating through timers

### DIFF
--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -45,14 +45,14 @@ class GpuTrack : public Track {
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
-      const orbit_client_protos::TimerInfo& timer_info) const;
+      const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetRight(
-      const orbit_client_protos::TimerInfo& timer_info) const;
+      const orbit_client_protos::TimerInfo& timer_info) const override;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetUp(
-      const orbit_client_protos::TimerInfo& timer_info) const;
+      const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
-      const orbit_client_protos::TimerInfo& timer_info) const;
+      const orbit_client_protos::TimerInfo& timer_info) const override;
 
   [[nodiscard]] std::string GetName() const override {
     return string_manager_->Get(timeline_hash_).value_or(std::to_string(timeline_hash_));

--- a/src/OrbitGl/ScopeTree.h
+++ b/src/OrbitGl/ScopeTree.h
@@ -132,7 +132,7 @@ const ScopeNode<ScopeT>* ScopeTree<ScopeT>::FindScopeNode(const ScopeT& scope) c
 template <typename ScopeT>
 const ScopeT* ScopeTree<ScopeT>::FindParent(const ScopeT& scope) const {
   const ScopeNode<ScopeT>* node = FindScopeNode(scope);
-  if (node == nullptr) return nullptr;
+  CHECK(node != nullptr);
   if (node->Parent() == root_) return nullptr;
   return node->Parent()->GetScope();
 }
@@ -140,7 +140,7 @@ const ScopeT* ScopeTree<ScopeT>::FindParent(const ScopeT& scope) const {
 template <typename ScopeT>
 const ScopeT* ScopeTree<ScopeT>::FindFirstChild(const ScopeT& scope) const {
   const ScopeNode<ScopeT>* node = FindScopeNode(scope);
-  if (node == nullptr) return nullptr;
+  CHECK(node != nullptr);
   const auto children = node->GetChildrenByStartTime();
   if (children.empty()) return nullptr;
   return children.begin()->second->GetScope();
@@ -149,7 +149,7 @@ const ScopeT* ScopeTree<ScopeT>::FindFirstChild(const ScopeT& scope) const {
 template <typename ScopeT>
 const ScopeT* ScopeTree<ScopeT>::FindNextScopeAtDepth(const ScopeT& scope) const {
   const ScopeNode<ScopeT>* node = FindScopeNode(scope);
-  if (node == nullptr) return nullptr;
+  CHECK(node != nullptr);
   auto nodes_at_depth = GetOrderedNodesByDepth().at(node->Depth());
   auto node_it = nodes_at_depth.upper_bound(node->Start());
   if (node_it == nodes_at_depth.end()) return nullptr;
@@ -159,7 +159,7 @@ const ScopeT* ScopeTree<ScopeT>::FindNextScopeAtDepth(const ScopeT& scope) const
 template <typename ScopeT>
 const ScopeT* ScopeTree<ScopeT>::FindPreviousScopeAtDepth(const ScopeT& scope) const {
   const ScopeNode<ScopeT>* node = FindScopeNode(scope);
-  if (node == nullptr) return nullptr;
+  CHECK(node != nullptr);
   auto nodes_at_depth = GetOrderedNodesByDepth().at(node->Depth());
   auto node_it = nodes_at_depth.lower_bound(node->Start());
   if (node_it == nodes_at_depth.begin()) return nullptr;

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -72,21 +72,10 @@ class TimerTrack : public Track {
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetFirstBeforeTime(uint64_t time,
                                                                          uint32_t depth) const;
 
-  // Must be overriden by child class for sensible behavior.
-  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetLeft(
-      const orbit_client_protos::TimerInfo& timer_info) const {
-    return &timer_info;
-  };
-  // Must be overriden by child class for sensible behavior.
-  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetRight(
-      const orbit_client_protos::TimerInfo& timer_info) const {
-    return &timer_info;
-  };
-
-  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetUp(
-      const orbit_client_protos::TimerInfo& timer_info) const;
-  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetDown(
-      const orbit_client_protos::TimerInfo& timer_info) const;
+  [[nodiscard]] const orbit_client_protos::TimerInfo* GetUp(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
 
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetScopesInRange(
       uint64_t start_ns, uint64_t end_ns) const;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -94,6 +94,27 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
+  // Must be overriden by child class for sensible behavior.
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetLeft(
+      const orbit_client_protos::TimerInfo& /*timer_info*/) const {
+    return nullptr;
+  };
+  // Must be overriden by child class for sensible behavior.
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetRight(
+      const orbit_client_protos::TimerInfo& /*timer_info*/) const {
+    return nullptr;
+  };
+  // Must be overriden by child class for sensible behavior.
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetUp(
+      const orbit_client_protos::TimerInfo& /*timer_info*/) const {
+    return nullptr;
+  };
+  // Must be overriden by child class for sensible behavior.
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetDown(
+      const orbit_client_protos::TimerInfo& /*timer_info*/) const {
+    return nullptr;
+  };
+
  protected:
   void DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
                               const DrawContext& draw_context);

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -57,6 +57,10 @@ class TrackManager {
 
   [[nodiscard]] std::pair<uint64_t, uint64_t> GetTracksMinMaxTimestamps() const;
 
+  [[nodiscard]] static bool IteratableType(orbit_client_protos::TimerInfo_Type type);
+  [[nodiscard]] static bool FunctionIteratableType(orbit_client_protos::TimerInfo_Type type);
+
+  Track* GetOrCreateTrackFromTimerInfo(const TimerInfo& timer_info);
   SchedulerTrack* GetOrCreateSchedulerTrack();
   ThreadTrack* GetOrCreateThreadTrack(int32_t tid);
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);


### PR DESCRIPTION
This change prevents trying to iterate through timers on tracks where it
doesn't make sense or it hasn't been implemented. It also implements a
method to easily go from timer to track.