### PR TITLE
Highlight Timers with the same Group Id.

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -5,7 +5,7 @@
 project(ClientData)
 add_library(ClientData STATIC)
 
-target_include_directories(ClientData PUBLIC 
+target_include_directories(ClientData PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
 target_include_directories(ClientData PRIVATE
@@ -45,9 +45,10 @@ target_sources(ClientData PRIVATE
         UserDefinedCaptureData.cpp)
 
 target_link_libraries(ClientData PUBLIC
+        ApiInterface
         ClientProtos
         GrpcProtos
-         # TODO(b/191248550): Remove ObjectUtils once GetAbsoluteAddress is removed
+        # TODO(b/191248550): Remove ObjectUtils once GetAbsoluteAddress is removed
         ObjectUtils
         OrbitBase
         xxHash::xxHash)
@@ -73,5 +74,5 @@ register_test(ClientDataTests)
 
 add_fuzzer(ModuleLoadSymbolsFuzzer ModuleLoadSymbolsFuzzer.cpp)
 target_link_libraries(
-  ModuleLoadSymbolsFuzzer PRIVATE ClientData
-                                  CONAN_PKG::libprotobuf-mutator)
+        ModuleLoadSymbolsFuzzer PRIVATE ClientData
+        CONAN_PKG::libprotobuf-mutator)

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -39,6 +39,11 @@ void DataManager::set_highlighted_function_id(uint64_t highlighted_function_id) 
   highlighted_function_id_ = highlighted_function_id;
 }
 
+void DataManager::set_highlighted_group_id(uint64_t highlighted_group_id) {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  highlighted_function_id_ = highlighted_group_id;
+}
+
 void DataManager::set_selected_thread_id(int32_t thread_id) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_thread_id_ = thread_id;
@@ -52,6 +57,11 @@ bool DataManager::IsFunctionVisible(uint64_t function_id) const {
 uint64_t DataManager::highlighted_function_id() const {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   return highlighted_function_id_;
+}
+
+uint64_t DataManager::highlighted_group_id() const {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  return highlighted_group_id_;
 }
 
 int32_t DataManager::selected_thread_id() const {

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -12,6 +12,7 @@
 #include <thread>
 #include <vector>
 
+#include "ApiInterface/Orbit.h"
 #include "ClientData/FunctionInfoSet.h"
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/UserDefinedCaptureData.h"
@@ -35,6 +36,7 @@ class DataManager final {
   void ClearSelectedFunctions();
   void set_visible_function_ids(absl::flat_hash_set<uint64_t> visible_function_ids);
   void set_highlighted_function_id(uint64_t highlighted_function_id);
+  void set_highlighted_group_id(uint64_t highlighted_function_id);
   void set_selected_thread_id(int32_t thread_id);
   void set_selected_timer(const orbit_client_protos::TimerInfo* timer_info);
 
@@ -42,6 +44,7 @@ class DataManager final {
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetSelectedFunctions() const;
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
   [[nodiscard]] uint64_t highlighted_function_id() const;
+  [[nodiscard]] uint64_t highlighted_group_id() const;
   [[nodiscard]] int32_t selected_thread_id() const;
   [[nodiscard]] const orbit_client_protos::TimerInfo* selected_timer() const;
 
@@ -131,6 +134,7 @@ class DataManager final {
   FunctionInfoSet selected_functions_;
   absl::flat_hash_set<uint64_t> visible_function_ids_;
   uint64_t highlighted_function_id_ = orbit_grpc_protos::kInvalidFunctionId;
+  uint64_t highlighted_group_id_ = kOrbitDefaultGroupId;
 
   TracepointInfoSet selected_tracepoints_;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2239,8 +2239,12 @@ const orbit_client_protos::TimerInfo* OrbitApp::selected_timer() const {
 void OrbitApp::SelectTimer(const orbit_client_protos::TimerInfo* timer_info) {
   data_manager_->set_selected_timer(timer_info);
   uint64_t function_id =
-      timer_info ? timer_info->function_id() : orbit_grpc_protos::kInvalidFunctionId;
+      timer_info != nullptr ? timer_info->function_id() : orbit_grpc_protos::kInvalidFunctionId;
   data_manager_->set_highlighted_function_id(function_id);
+
+  uint64_t group_id = timer_info != nullptr ? timer_info->group_id() : kOrbitDefaultGroupId;
+  data_manager_->set_highlighted_group_id(group_id);
+
   CHECK(timer_selected_callback_);
   timer_selected_callback_(timer_info);
   RequestUpdatePrimitives();
@@ -2264,6 +2268,15 @@ uint64_t OrbitApp::GetFunctionIdToHighlight() const {
   }
 
   return selected_function_id;
+}
+
+uint64_t OrbitApp::GetGroupIdToHighlight() const {
+  const orbit_client_protos::TimerInfo* timer_info = selected_timer();
+
+  uint64_t selected_group_id =
+      timer_info != nullptr ? timer_info->group_id() : data_manager_->highlighted_group_id();
+
+  return selected_group_id;
 }
 
 void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -435,6 +435,7 @@ class OrbitApp final : public DataViewFactory,
   void DeselectTimer();
 
   [[nodiscard]] uint64_t GetFunctionIdToHighlight() const;
+  [[nodiscard]] uint64_t GetGroupIdToHighlight() const;
 
   void SelectCallstackEvents(
       const std::vector<orbit_client_protos::CallstackEvent>& selected_callstack_events,

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -35,6 +35,7 @@ struct DrawData {
   uint64_t min_tick;
   uint64_t max_tick;
   uint64_t highlighted_function_id;
+  uint64_t highlighted_group_id;
   uint64_t ns_per_pixel;
   uint64_t min_timegraph_tick;
   Batcher* batcher;
@@ -146,7 +147,8 @@ class TimerTrack : public Track {
   [[nodiscard]] static internal::DrawData GetDrawData(
       uint64_t min_tick, uint64_t max_tick, float track_width, float z_offset, Batcher* batcher,
       TimeGraph* time_graph, orbit_gl::Viewport* viewport, bool is_collapsed,
-      const orbit_client_protos::TimerInfo* selected_timer, uint64_t highlighted_function_id);
+      const orbit_client_protos::TimerInfo* selected_timer, uint64_t highlighted_function_id,
+      uint64_t highlighted_group_id);
 
   [[nodiscard]] virtual std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const;
   [[nodiscard]] std::unique_ptr<PickingUserData> CreatePickingUserData(


### PR DESCRIPTION
Similar to how we highlight all timers with the same function
id, we want to highlight all timers with the same group
id.

Test: Profile OrbitTest, click on a Timer with group id.
Bug: http://b/193779952