### PR TITLE
Fix Height of Thread Track

### DIFF
--- a/src/ClientData/include/ClientData/TrackData.h
+++ b/src/ClientData/include/ClientData/TrackData.h
@@ -64,9 +64,9 @@ class TrackData final {
     }
   }
 
- private:
   void UpdateMaxDepth(uint32_t depth) { max_depth_ = std::max(max_depth_, depth); }
 
+ private:
   [[nodiscard]] TimerChain* GetOrCreateTimerChain(uint64_t depth) {
     absl::MutexLock lock(&mutex_);
     auto it = timers_.find(depth);

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -469,6 +469,8 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
     auto first_node_to_draw = ordered_nodes.lower_bound(min_tick);
     if (first_node_to_draw != ordered_nodes.begin()) --first_node_to_draw;
 
+    track_data_->UpdateMaxDepth(depth);
+
     float world_timer_y = GetYFromDepth(depth - 1);
     uint64_t next_pixel_start_time_ns = min_tick;
 


### PR DESCRIPTION
We need to put this call to UpdateMaxDepth back as timers in ThreadTrack
may not have the correct depth when mixing manual and dynamic
instrumentation. This call updates the max depth to what the scopetree
has which is sure to be accurate.

Before: http://screen/8ufHK3rxqV86TEY