### PR TITLE
Rendering performance optimization

### DIFF
--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -275,7 +275,7 @@ void Batcher::AddTriangle(const Triangle& triangle, const std::array<Color, 3>& 
   user_data_.push_back(std::move(user_data));
 }
 
-Vec3 Batcher::TransformVertex(const Vec3 input) const {
+Vec3 Batcher::TransformVertex(const Vec3& input) const {
   const Vec3 result = input + current_translation_;
   return Vec3(floorf(result[0]), floorf(result[1]), result[2]);
 }

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -196,7 +196,7 @@ class Batcher {
                    const Color& picking_color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
 
-  [[nodiscard]] Vec3 TransformVertex(const Vec3 input) const;
+  [[nodiscard]] Vec3 TransformVertex(const Vec3& input) const;
 
   BatcherId batcher_id_;
   PickingManager* picking_manager_;

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -381,6 +381,8 @@ std::unique_ptr<AccessibleInterface> CaptureWindow::CreateAccessibleInterface() 
 void CaptureWindow::Draw() {
   ORBIT_SCOPE("CaptureWindow::Draw");
 
+  text_renderer_.Init();
+
   if (ShouldSkipRendering()) {
     return;
   }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -497,7 +497,7 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
 
       auto timer_duration = timer_info.end() - timer_info.start();
       if (timer_duration > draw_data.ns_per_pixel) {
-        if (!collapse_toggle_->IsCollapsed()) {
+        if (!collapse_toggle_->IsCollapsed() && BoxHasRoomForText(size[0])) {
           DrawTimesliceText(timer_info, draw_data.track_start_x, z_offset, pos, size);
         }
         batcher->AddShadedBox(pos, size, draw_data.z, color, std::move(user_data));

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -68,6 +68,7 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
       manual_instrumentation_manager_{app->GetManualInstrumentationManager()},
       capture_data_{capture_data},
       app_{app} {
+  text_renderer_static_.Init();
   text_renderer_static_.SetViewport(viewport);
   batcher_.SetPickingManager(picking_manager);
   track_manager_ = std::make_unique<TrackManager>(this, viewport_, &GetLayout(), app, capture_data);

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -167,13 +167,10 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
     double text_x_start_us = start_or_prev_end_us - (.25 * left_overlap_width_us);
     double right_overlap_width_us = end_us - end_or_next_start_us;
     double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
-
-    bool is_visible_width = ((text_x_end_us - text_x_start_us) * draw_data.inv_time_window *
-                             viewport_->WorldToScreenWidth(draw_data.track_width)) > 1;
     WorldXInfo world_x_info = ToWorldX(text_x_start_us, text_x_end_us, draw_data.inv_time_window,
                                        draw_data.track_start_x, draw_data.track_width);
 
-    if (is_visible_width) {
+    if (BoxHasRoomForText(world_x_info.world_x_width)) {
       Vec2 pos{world_x_info.world_x_start, world_timer_y};
       Vec2 size{world_x_info.world_x_width, GetDynamicBoxHeight(*current_timer_info)};
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -146,6 +146,10 @@ class TimerTrack : public Track {
         &timer_info, [this, &batcher](PickingId id) { return this->GetBoxTooltip(batcher, id); });
   }
 
+  [[nodiscard]] inline bool BoxHasRoomForText(const float width) {
+    return text_renderer_->GetStringWidth("w", layout_->CalculateZoomedFontSize()) < width;
+  }
+
   static const Color kHighlightColor;
   TextRenderer* text_renderer_ = nullptr;
   int visible_timer_count_ = 0;


### PR DESCRIPTION
I was doing a quick analysis of Orbit's rendering performance and found that, when zooming out a bit, we're wasting a lot of time processing text that is never rendered. In my example, this improved the rendering speed by more than 50% (down from ~130ms to 80ms).

I'll share the document with my analysis seperately.