### PR TITLE
Consistently use GetWidth() to fix disappeared timers

### DIFF
--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -22,7 +22,8 @@ namespace orbit_gl {
 AccessibilityRect TimeGraphAccessibility::AccessibleRect() const {
   const Viewport* viewport = time_graph_->GetViewport();
 
-  return AccessibilityRect(0, 0, viewport->GetScreenWidth(), viewport->GetScreenHeight());
+  return AccessibilityRect(0, 0, viewport->WorldToScreenWidth(time_graph_->GetWidth()),
+                           viewport->GetScreenHeight());
 }
 
 AccessibilityState TimeGraphAccessibility::AccessibleState() const {

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -167,10 +167,10 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   const auto time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
-  const uint64_t pixel_delta_ns = time_window_ns / viewport_->GetScreenWidth();
+  const uint64_t pixel_delta_ns = time_window_ns / viewport_->WorldToScreenWidth(GetWidth());
   const uint64_t min_time_graph_ns = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
   const float pixel_width_in_world_coords =
-      viewport_->GetVisibleWorldWidth() / static_cast<float>(viewport_->GetScreenWidth());
+      viewport_->GetVisibleWorldWidth() / viewport_->WorldToScreenWidth(GetWidth());
 
   uint64_t ignore_until_ns = 0;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -451,7 +451,8 @@ void ThreadTrack::OnCaptureComplete() {
 [[nodiscard]] static inline uint64_t GetNextPixelBoundaryTimeNs(
     float world_x, const internal::DrawData& draw_data) {
   float normalized_x = (world_x - draw_data.track_start_x) / draw_data.track_width;
-  int pixel_x = static_cast<int>(ceil(normalized_x * draw_data.viewport->GetScreenWidth()));
+  int pixel_x = static_cast<int>(
+      ceil(normalized_x * draw_data.viewport->WorldToScreenWidth(draw_data.track_width)));
   return draw_data.min_tick + pixel_x * draw_data.ns_per_pixel;
 }
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -168,8 +168,8 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
     double right_overlap_width_us = end_us - end_or_next_start_us;
     double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
 
-    bool is_visible_width =
-        ((text_x_end_us - text_x_start_us) * draw_data.inv_time_window * draw_data.track_width) > 1;
+    bool is_visible_width = ((text_x_end_us - text_x_start_us) * draw_data.inv_time_window *
+                             viewport_->WorldToScreenWidth(draw_data.track_width)) > 1;
     WorldXInfo world_x_info = ToWorldX(text_x_start_us, text_x_end_us, draw_data.inv_time_window,
                                        draw_data.track_start_x, draw_data.track_width);
 
@@ -199,7 +199,7 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
   if (is_visible_width) {
     WorldXInfo world_x_info_left_overlap =
         ToWorldX(start_us, start_or_prev_end_us, draw_data.inv_time_window, draw_data.track_start_x,
-                 draw_data.track_width);
+                 viewport_->WorldToScreenWidth(draw_data.track_width));
 
     WorldXInfo world_x_info_right_overlap =
         ToWorldX(end_or_next_start_us, end_us, draw_data.inv_time_window, draw_data.track_start_x,
@@ -274,7 +274,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   // enough that all events are drawn as boxes, this has no effect. When zoomed
   // out, many events will be discarded quickly.
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
-  draw_data.ns_per_pixel = static_cast<uint64_t>(time_window_ns / GetWidth());
+  draw_data.ns_per_pixel = time_window_ns / viewport_->WorldToScreenWidth(GetWidth());
   draw_data.min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (const TimerChain* chain : chains) {
@@ -436,7 +436,7 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   draw_data.highlighted_group_id = highlighted_group_id;
 
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph->GetTimeWindowUs());
-  draw_data.ns_per_pixel = static_cast<uint64_t>(time_window_ns / track_width);
+  draw_data.ns_per_pixel = time_window_ns / viewport->WorldToScreenWidth(track_width);
   draw_data.min_timegraph_tick = time_graph->GetTickFromUs(time_graph->GetMinTimeUs());
   return draw_data;
 }


### PR DESCRIPTION
In https://github.com/google/orbit/commit/44ec55c7942ef1dae7a6f6363451c40e0ce3e85e, we started to use GetWidth() instead of viewport->ScreenWidth() for the width of the tracks, since we were no longer considering the vertical slider.

However there were still a few missing references we didn't change, which
caused a strange behaviour in ThreadTrack. So, in this PR we erase them.

Test: Load a capture.
Bug related: http://b/196873688.

Pd: There are still a few references in AccessibleCaptureViewElement
which I'm not sure how to solve it.