### PR TITLE
Make Time Series value_decimal_digits_ non-optional

### DIFF
--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -18,22 +18,21 @@ static std::array<std::string, kBasicPageFaultsTrackDimension> CreateSeriesName(
 
 }  // namespace
 
+static constexpr uint8_t kTrackValueDecimalDigits = 0;
 BasicPageFaultsTrack::BasicPageFaultsTrack(Track* parent, TimeGraph* time_graph,
                                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                           const std::string& cgroup_name,
+                                           std::string cgroup_name,
                                            uint64_t memory_sampling_period_ms,
                                            const orbit_client_data::CaptureData* capture_data)
     : LineGraphTrack<kBasicPageFaultsTrackDimension>(
           parent, time_graph, viewport, layout,
-          CreateSeriesName(cgroup_name, capture_data->process_name()), capture_data),
+          CreateSeriesName(cgroup_name, capture_data->process_name()), kTrackValueDecimalDigits,
+          capture_data),
       AnnotationTrack(),
-      cgroup_name_(cgroup_name),
+      cgroup_name_(std::move(cgroup_name)),
       memory_sampling_period_ms_(memory_sampling_period_ms),
       parent_(parent) {
   draw_background_ = false;
-
-  constexpr uint8_t kTrackValueDecimalDigits = 0;
-  SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
 }
 
 void BasicPageFaultsTrack::AddValues(

--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -23,7 +23,7 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
                              public AnnotationTrack {
  public:
   explicit BasicPageFaultsTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                                TimeGraphLayout* layout, const std::string& cgroup_name,
+                                TimeGraphLayout* layout, std::string cgroup_name,
                                 uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::CaptureData* capture_data);
 

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -30,18 +30,18 @@ static std::array<std::string, kCGroupAndProcessMemoryTrackDimension> CreateSeri
 
 }  // namespace
 
+static constexpr uint8_t kTrackValueDecimalDigits = 2;
+
 CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
     CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
     TimeGraphLayout* layout, const std::string& cgroup_name,
     const orbit_client_data::CaptureData* capture_data)
     : MemoryTrack<kCGroupAndProcessMemoryTrackDimension>(
           parent, time_graph, viewport, layout,
-          CreateSeriesName(cgroup_name, capture_data->process_name()), capture_data),
+          CreateSeriesName(cgroup_name, capture_data->process_name()), kTrackValueDecimalDigits,
+          capture_data),
       cgroup_name_(cgroup_name) {
   SetLabelUnit(kTrackValueLabelUnit);
-
-  constexpr uint8_t kTrackValueDecimalDigits = 2;
-  SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
 
   // Colors are selected from https://convertingcolors.com/list/avery.html.
   // Use reddish colors for different used memories, yellowish colors for different cached memories

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -29,9 +29,10 @@ template <size_t Dimension>
 GraphTrack<Dimension>::GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                   orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                   std::array<std::string, Dimension> series_names,
+                                  uint8_t series_value_decimal_digits,
                                   const orbit_client_data::CaptureData* capture_data)
     : Track(parent, time_graph, viewport, layout, capture_data),
-      series_(MultivariateTimeSeries<Dimension>(series_names)) {}
+      series_{series_names, series_value_decimal_digits} {}
 
 template <size_t Dimension>
 float GraphTrack<Dimension>::GetHeight() const {
@@ -133,9 +134,7 @@ std::string GraphTrack<Dimension>::GetLabelTextFromValues(
     std::string formatted_name =
         series_names[i].empty() ? "" : absl::StrFormat("%s: ", series_names[i]);
     std::string formatted_value =
-        value_decimal_digits.has_value()
-            ? absl::StrFormat("%.*f", value_decimal_digits.value(), values[i])
-            : std::to_string(values[i]);
+        absl::StrFormat("%.*f", value_decimal_digits.value_or(6), values[i]);
     absl::StrAppend(&text, delimiter, formatted_name, formatted_value, value_unit);
     delimiter = "\n";
   }

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -24,14 +24,13 @@ class GraphTrack : public Track {
   explicit GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       std::array<std::string, Dimension> series_names,
+                      uint8_t series_value_decimal_digits,
                       const orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return Type::kGraphTrack; }
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] float GetLegendHeight() const;
-  [[nodiscard]] std::optional<uint8_t> GetNumberOfDecimalDigits() const {
-    return series_.GetValueDecimalDigits();
-  }
+  [[nodiscard]] uint8_t GetNumberOfDecimalDigits() const { return series_.GetValueDecimalDigits(); }
 
   [[nodiscard]] bool IsCollapsible() const override { return true; }
   [[nodiscard]] bool IsEmpty() const override { return series_.IsEmpty(); }
@@ -49,9 +48,6 @@ class GraphTrack : public Track {
   [[nodiscard]] uint64_t GetMaxTime() const override;
 
   void SetLabelUnit(std::string label_unit) { series_.SetValueUnit(label_unit); }
-  void SetNumberOfDecimalDigits(uint8_t value_decimal_digits) {
-    series_.SetNumberOfDecimalDigits(value_decimal_digits);
-  }
   void SetSeriesColors(const std::array<Color, Dimension>& series_colors) {
     series_colors_ = series_colors;
   }
@@ -86,9 +82,8 @@ class GraphTrack : public Track {
   virtual void DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick, float z);
 
   [[nodiscard]] double RoundPrecision(double value) {
-    CHECK(GetNumberOfDecimalDigits().has_value());
-    return std::round(value * std::pow(10, GetNumberOfDecimalDigits().value())) /
-           std::pow(10, GetNumberOfDecimalDigits().value());
+    return std::round(value * std::pow(10, GetNumberOfDecimalDigits())) /
+           std::pow(10, GetNumberOfDecimalDigits());
   }
 
   MultivariateTimeSeries<Dimension> series_;

--- a/src/OrbitGl/LineGraphTrack.h
+++ b/src/OrbitGl/LineGraphTrack.h
@@ -20,8 +20,10 @@ class LineGraphTrack : public GraphTrack<Dimension> {
   explicit LineGraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                           std::array<std::string, Dimension> series_names,
+                          uint8_t series_value_decimal_digits,
                           const orbit_client_data::CaptureData* capture_data)
-      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, series_names, capture_data) {}
+      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, series_names,
+                              series_value_decimal_digits, capture_data) {}
   ~LineGraphTrack() override = default;
 
  protected:

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -22,8 +22,10 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
   explicit MemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        std::array<std::string, Dimension> series_names,
+                       uint8_t series_value_decimal_digits,
                        const orbit_client_data::CaptureData* capture_data)
-      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, series_names, capture_data),
+      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, series_names,
+                              series_value_decimal_digits, capture_data),
         AnnotationTrack() {
     // Memory tracks are collapsed by default.
     this->collapse_toggle_->SetCollapsed(true);

--- a/src/OrbitGl/MultivariateTimeSeries.h
+++ b/src/OrbitGl/MultivariateTimeSeries.h
@@ -17,8 +17,9 @@ class MultivariateTimeSeries {
   static_assert(Dimension >= 1, "Dimension must be at least 1");
 
  public:
-  explicit MultivariateTimeSeries(std::array<std::string, Dimension> series_names)
-      : series_names_(std::move(series_names)) {}
+  explicit MultivariateTimeSeries(std::array<std::string, Dimension> series_names,
+                                  uint8_t value_decimal_digits)
+      : series_names_(std::move(series_names)), value_decimal_digits_{value_decimal_digits} {}
 
   [[nodiscard]] const std::array<std::string, Dimension>& GetSeriesNames() const {
     return series_names_;
@@ -29,9 +30,7 @@ class MultivariateTimeSeries {
   }
   [[nodiscard]] double GetMin() const { return min_; }
   [[nodiscard]] double GetMax() const { return max_; }
-  [[nodiscard]] std::optional<uint8_t> GetValueDecimalDigits() const {
-    return value_decimal_digits_;
-  }
+  [[nodiscard]] uint8_t GetValueDecimalDigits() const { return value_decimal_digits_; }
   [[nodiscard]] std::string GetValueUnit() const { return value_unit_; }
 
   void AddValues(uint64_t timestamp_ns, const std::array<double, Dimension>& values) {
@@ -41,9 +40,6 @@ class MultivariateTimeSeries {
     }
   }
   void SetValueUnit(std::string value_unit) { value_unit_ = std::move(value_unit); }
-  void SetNumberOfDecimalDigits(uint8_t value_decimal_digits) {
-    value_decimal_digits_ = value_decimal_digits;
-  }
 
   [[nodiscard]] bool IsEmpty() const { return time_to_series_values_.empty(); }
 
@@ -102,11 +98,11 @@ class MultivariateTimeSeries {
     min_ = std::min(min_, value);
   }
 
-  std::array<std::string, Dimension> series_names_;
+  const std::array<std::string, Dimension> series_names_;
   std::map<uint64_t, std::array<double, Dimension>> time_to_series_values_;
   double min_ = std::numeric_limits<double>::max();
   double max_ = std::numeric_limits<double>::lowest();
-  std::optional<uint8_t> value_decimal_digits_ = std::nullopt;
+  const uint8_t value_decimal_digits_;
   std::string value_unit_;
 };
 

--- a/src/OrbitGl/MultivariateTimeSeriesTest.cpp
+++ b/src/OrbitGl/MultivariateTimeSeriesTest.cpp
@@ -8,9 +8,12 @@
 
 namespace orbit_gl {
 
+static constexpr uint8_t kDefaultValueDesimalDigits = 6;
+
 TEST(MultivariateTimeSeries, BasicSetAndGet) {
   std::array<std::string, 3> series_names = {"Series A", "Series B", "Series C"};
-  MultivariateTimeSeries<3> series = MultivariateTimeSeries<3>(series_names);
+  MultivariateTimeSeries<3> series =
+      MultivariateTimeSeries<3>(series_names, kDefaultValueDesimalDigits);
   EXPECT_EQ(series.GetSeriesNames(), series_names);
   EXPECT_TRUE(series.IsEmpty());
 
@@ -32,7 +35,7 @@ TEST(MultivariateTimeSeries, BasicSetAndGet) {
 
 TEST(MultivariateTimeSeries, GetPreviousOrFirstEntry) {
   MultivariateTimeSeries<3> series =
-      MultivariateTimeSeries<3>({"Series A", "Series B", "Series C"});
+      MultivariateTimeSeries<3>({"Series A", "Series B", "Series C"}, kDefaultValueDesimalDigits);
   uint64_t timestamp_1 = 100;
   std::array<double, 3> values_1 = {1.1, 1.2, 1.3};
   uint64_t timestamp_2 = 200;
@@ -64,7 +67,7 @@ TEST(MultivariateTimeSeries, GetPreviousOrFirstEntry) {
 
 TEST(MultivariateTimeSeries, GetNextOrLastEntry) {
   MultivariateTimeSeries<3> series =
-      MultivariateTimeSeries<3>({"Series A", "Series B", "Series C"});
+      MultivariateTimeSeries<3>({"Series A", "Series B", "Series C"}, kDefaultValueDesimalDigits);
   uint64_t timestamp_1 = 100;
   std::array<double, 3> values_1 = {1.1, 1.2, 1.3};
   uint64_t timestamp_2 = 200;
@@ -96,7 +99,7 @@ TEST(MultivariateTimeSeries, GetNextOrLastEntry) {
 
 TEST(MultivariateTimeSeries, GetEntriesAffectedByTimeRange) {
   MultivariateTimeSeries<3> series =
-      MultivariateTimeSeries<3>({"Series A", "Series B", "Series C"});
+      MultivariateTimeSeries<3>({"Series A", "Series B", "Series C"}, kDefaultValueDesimalDigits);
   uint64_t timestamp_1 = 100;
   std::array<double, 3> values_1 = {1.1, 1.2, 1.3};
   uint64_t timestamp_2 = 200;
@@ -132,5 +135,9 @@ TEST(MultivariateTimeSeries, GetEntriesAffectedByTimeRange) {
     EXPECT_EQ(range.value().end_inclusive->first, timestamp_3);
   }
 }
-
+TEST(MultivariateTimeSeries, GetValueDecimalDigits) {
+  MultivariateTimeSeries<3> series =
+      MultivariateTimeSeries<3>({"Series A", "Series B", "Series C"}, 42);
+  EXPECT_EQ(series.GetValueDecimalDigits(), 42);
+}
 }  // namespace orbit_gl

--- a/src/OrbitGl/SystemMemoryTrack.cpp
+++ b/src/OrbitGl/SystemMemoryTrack.cpp
@@ -25,15 +25,13 @@ constexpr uint64_t kMegabytesToBytes = 1024 * 1024;
 
 }  // namespace
 
+constexpr uint8_t kTrackValueDecimalDigits = 2;
 SystemMemoryTrack::SystemMemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                      const orbit_client_data::CaptureData* capture_data)
     : MemoryTrack<kSystemMemoryTrackDimension>(parent, time_graph, viewport, layout, kSeriesName,
-                                               capture_data) {
+                                               kTrackValueDecimalDigits, capture_data) {
   SetLabelUnit(kTrackValueLabelUnit);
-
-  constexpr uint8_t kTrackValueDecimalDigits = 2;
-  SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
 
   // Colors are selected from https://convertingcolors.com/list/avery.html.
   // Use reddish colors for different used memories, yellowish colors for different cached memories

--- a/src/OrbitGl/VariableTrack.h
+++ b/src/OrbitGl/VariableTrack.h
@@ -18,6 +18,8 @@ constexpr size_t kVariableTrackDimension = 1;
 const std::array<Color, kVariableTrackDimension> kVariableTrackColor{Color(0, 128, 255, 128)};
 
 class VariableTrack final : public LineGraphTrack<kVariableTrackDimension> {
+  static constexpr uint8_t kTrackValueDecimalDigits = 6;
+
  public:
   explicit VariableTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
@@ -25,7 +27,7 @@ class VariableTrack final : public LineGraphTrack<kVariableTrackDimension> {
                          const orbit_client_data::CaptureData* capture_data)
       : LineGraphTrack<kVariableTrackDimension>(parent, time_graph, viewport, layout,
                                                 std::array<std::string, kVariableTrackDimension>{},
-                                                capture_data),
+                                                kTrackValueDecimalDigits, capture_data),
         name_(name) {
     SetSeriesColors(kVariableTrackColor);
   }


### PR DESCRIPTION
And const, also make series_names_ const. These fields are
only assigned in c-tor now. That makes them thread-safe.

Test: builds