### PR TITLE
Make ProcessInfo a member of Process

### DIFF
--- a/src/Service/Process.h
+++ b/src/Service/Process.h
@@ -13,19 +13,21 @@
 
 namespace orbit_service {
 
-class Process : public orbit_grpc_protos::ProcessInfo {
+class Process {
  public:
-  using orbit_grpc_protos::ProcessInfo::ProcessInfo;
-
   void UpdateCpuUsage(utils::Jiffies process_cpu_time, utils::TotalCpuTime total_cpu_time);
 
   // Creates a `Process` by reading details from the `/proc` filesystem.
   // This might fail due to a non existing pid or due to permission problems.
   static ErrorMessageOr<Process> FromPid(pid_t pid);
 
+  // NOLINTNEXTLINE
+  [[nodiscard]] const orbit_grpc_protos::ProcessInfo& process_info() const { return process_info_; }
+
  private:
   utils::Jiffies previous_process_cpu_time_ = {};
   utils::Jiffies previous_total_cpu_time_ = {};
+  orbit_grpc_protos::ProcessInfo process_info_;
 };
 
 }  // namespace orbit_service

--- a/src/Service/ProcessList.h
+++ b/src/Service/ProcessList.h
@@ -27,9 +27,8 @@ class ProcessList {
     std::vector<orbit_grpc_protos::ProcessInfo> processes;
     processes.reserve(processes_.size());
 
-    std::transform(
-        processes_.begin(), processes_.end(), std::back_inserter(processes),
-        [](const auto& pair) { return static_cast<orbit_grpc_protos::ProcessInfo>(pair.second); });
+    std::transform(processes_.begin(), processes_.end(), std::back_inserter(processes),
+                   [](const auto& pair) { return pair.second.process_info(); });
     return processes;
   }
 

--- a/src/Service/ProcessTest.cpp
+++ b/src/Service/ProcessTest.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string_view>
 
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Result.h"
 #include "Process.h"
 
@@ -21,8 +22,9 @@ TEST(Process, FromPid) {
 
   auto& process = potential_process.value();
 
-  EXPECT_EQ(process.pid(), getpid());
-  EXPECT_EQ(process.name(), std::string_view{"ServiceTests"}.substr(0, kTaskCommLength - 1));
+  EXPECT_EQ(process.process_info().pid(), getpid());
+  EXPECT_EQ(process.process_info().name(),
+            orbit_base::GetExecutablePath().filename().string().substr(0, kTaskCommLength - 1));
 }
 
 }  // namespace orbit_service


### PR DESCRIPTION
Process used to inherit from ProcessInfo which is now replaced by
Process having a member `process_info_` of type `ProcessInfo`.

`ProcessInfo` is a proto and newer version of the protobuf compiler
declare their generated classes `final` which prohibits inheritance.

Hence this change avoids problems on the next protobuf update.

In addition the test `Process.FromPid` does not hard code the test
executable name anymore.

Test: Builds and tests succeed
Bug: http://b/194279100