### PR TITLE
Enable Clang's thready safety analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                       -Werror=unused-parameter
                       -Werror=unused-variable
                       -Werror=writable-strings
-                      -Werror=sign-compare)
+                      -Werror=sign-compare
+                      -Werror=thread-safety)
 
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
     add_compile_options(-Werror=defaulted-function-deleted)

--- a/src/CaptureEventProducer/CaptureEventProducer.cpp
+++ b/src/CaptureEventProducer/CaptureEventProducer.cpp
@@ -107,7 +107,8 @@ bool CaptureEventProducer::NotifyAllEventsSent() {
   return write_succeeded;
 }
 
-void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
+// TODO(http://b/197310492): Fix the thread safety warning - more details in the bug.
+void CaptureEventProducer::ConnectAndReceiveCommandsThread() NO_THREAD_SAFETY_ANALYSIS {
   CHECK(producer_side_service_stub_ != nullptr);
 
   while (true) {

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -96,12 +96,12 @@ class CallstackData {
   // E.g., one might want to nest ForEachCallstackEvent and ForEachFrameInCallstack.
   mutable std::recursive_mutex mutex_;
   absl::flat_hash_map<uint64_t, std::shared_ptr<orbit_client_protos::CallstackInfo>>
-      unique_callstacks_ GUARDED_BY(mutex_);
+      unique_callstacks_;
   absl::flat_hash_map<int32_t, std::map<uint64_t, orbit_client_protos::CallstackEvent>>
-      callstack_events_by_tid_ GUARDED_BY(mutex_);
+      callstack_events_by_tid_;
 
-  uint64_t max_time_ GUARDED_BY(mutex_) = 0;
-  uint64_t min_time_ GUARDED_BY(mutex_) = std::numeric_limits<uint64_t>::max();
+  uint64_t max_time_ = 0;
+  uint64_t min_time_ = std::numeric_limits<uint64_t>::max();
 };
 
 }  // namespace orbit_client_data

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -9,6 +9,7 @@
 #include <absl/meta/type_traits.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
+#include <absl/synchronization/mutex.h>
 #include <pthread.h>
 #include <stddef.h>
 #include <unistd.h>
@@ -1222,7 +1223,10 @@ void TracerThread::Reset() {
   effective_capture_start_timestamp_ns_ = 0;
 
   stop_deferred_thread_ = false;
-  deferred_events_being_buffered_.clear();
+  {
+    absl::MutexLock lock{&deferred_events_being_buffered_mutex_};
+    deferred_events_being_buffered_.clear();
+  }
   deferred_events_to_process_.clear();
   uprobes_unwinding_visitor_.reset();
   switches_states_names_visitor_.reset();

--- a/src/MemoryTracing/include/MemoryTracing/MemoryInfoListener.h
+++ b/src/MemoryTracing/include/MemoryTracing/MemoryInfoListener.h
@@ -36,7 +36,8 @@ class MemoryInfoListener {
   void OnProcessMemoryUsage(orbit_grpc_protos::ProcessMemoryUsage process_memory_usage);
 
  private:
-  void ProcessMemoryUsageEventIfReady(uint64_t sampling_window_id);
+  void ProcessMemoryUsageEventIfReady(uint64_t sampling_window_id)
+      EXCLUSIVE_LOCKS_REQUIRED(in_progress_memory_usage_events_mutex_);
   virtual void OnMemoryUsageEvent(orbit_grpc_protos::MemoryUsageEvent memory_usage_event) = 0;
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::MemoryUsageEvent>

--- a/src/QtUtils/FutureWatcherTest.cpp
+++ b/src/QtUtils/FutureWatcherTest.cpp
@@ -60,7 +60,7 @@ TEST(FutureWatcher, WaitForWithAbort) {
             FutureWatcher::Reason::kAbortRequested);
 }
 
-TEST(FutureWatcher, WaitForWithThreadPool) {
+TEST(FutureWatcher, WaitForWithThreadPool) NO_THREAD_SAFETY_ANALYSIS {
   // One background job which is supposed to succeed. (No timeout, no abort)
 
   constexpr size_t kThreadPoolMinSize = 1;
@@ -78,7 +78,8 @@ TEST(FutureWatcher, WaitForWithThreadPool) {
   EXPECT_FALSE(future.IsFinished());
 
   // The lambda will be executed by the event loop, running inside of watcher.WaitFor.
-  QTimer::singleShot(std::chrono::milliseconds{5}, [&]() { mutex.Unlock(); });
+  QTimer::singleShot(std::chrono::milliseconds{5},
+                     [&]() NO_THREAD_SAFETY_ANALYSIS { mutex.Unlock(); });
 
   FutureWatcher watcher{};
   const auto reason = watcher.WaitFor(std::move(future), std::nullopt);
@@ -114,7 +115,7 @@ TEST(FutureWatcher, WaitForWithThreadPoolAndTimeout) {
   thread_pool->ShutdownAndWait();
 }
 
-TEST(FutureWatcher, WaitForAllWithThreadPool) {
+TEST(FutureWatcher, WaitForAllWithThreadPool) NO_THREAD_SAFETY_ANALYSIS {
   // Multiple background jobs which are all supposed to succeed.
 
   constexpr size_t kThreadPoolMinSize = 1;
@@ -136,7 +137,8 @@ TEST(FutureWatcher, WaitForAllWithThreadPool) {
   }
 
   // The lambda will be executed by the event loop, running inside of watcher.WaitFor.
-  QTimer::singleShot(std::chrono::milliseconds{5}, [&]() { mutex.Unlock(); });
+  QTimer::singleShot(std::chrono::milliseconds{5},
+                     [&]() NO_THREAD_SAFETY_ANALYSIS { mutex.Unlock(); });
 
   FutureWatcher watcher{};
   const auto reason = watcher.WaitForAll(absl::MakeSpan(futures), std::nullopt);
@@ -146,7 +148,7 @@ TEST(FutureWatcher, WaitForAllWithThreadPool) {
   thread_pool->ShutdownAndWait();
 }
 
-TEST(FutureWatcher, WaitForAllWithThreadPoolAndTimeout) {
+TEST(FutureWatcher, WaitForAllWithThreadPoolAndTimeout) NO_THREAD_SAFETY_ANALYSIS {
   // Multiple background jobs which are all supposed to time out.
 
   constexpr size_t kThreadPoolMinSize = 1;
@@ -171,7 +173,8 @@ TEST(FutureWatcher, WaitForAllWithThreadPoolAndTimeout) {
   }
 
   // The lambda will be executed by the event loop, running inside of watcher.WaitFor.
-  QTimer::singleShot(std::chrono::milliseconds{5}, [&]() { mutex.Unlock(); });
+  QTimer::singleShot(std::chrono::milliseconds{5},
+                     [&]() NO_THREAD_SAFETY_ANALYSIS { mutex.Unlock(); });
 
   // The timer starts execution of background jobs after 5ms. Every background job takes 1ms and
   // they can't run in parallel due to the mutex. That means in total 15ms of execution time is

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -88,7 +88,8 @@ class SenderThreadCaptureEventBuffer final : public CaptureEventBuffer {
 
       events_being_buffered_mutex_.LockWhenWithTimeout(
           absl::Condition(
-              +[](SenderThreadCaptureEventBuffer* self) {
+              +[](SenderThreadCaptureEventBuffer* self) EXCLUSIVE_LOCKS_REQUIRED(
+                   self->events_being_buffered_mutex_) {
                 return self->events_being_buffered_.size() >= kSendEventCountInterval ||
                        self->stop_requested_;
               },


### PR DESCRIPTION
This is enabling `-Werror=thread-safety` which allows to enforce `ABSL_GUARDED_BY` among other things.

But first we need to fix a couple of threading problems. Most of them are missing annotations or similar but there are
also some things that might be wrong and need proper fixing.