### PR TITLE
Use "correct" return address for Scopes

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -32,13 +32,11 @@ void EnqueueApiEvent(Types... args) {
   producer.EnqueueIntermediateEvent(event);
 }
 
-void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_id) {
-  uint64_t return_address = ORBIT_GET_CALLER_PC();
-  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, group_id, return_address);
-}
-
-void orbit_api_start_with_explicit_caller_v1(const char* name, orbit_api_color color,
-                                             uint64_t group_id, uint64_t caller_address) {
+void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_id,
+                        uint64_t caller_address) {
+  if (caller_address == kOrbitCallerAddressAuto) {
+    caller_address = ORBIT_GET_CALLER_PC();
+  }
   EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, group_id, caller_address);
 }
 
@@ -127,7 +125,6 @@ void orbit_api_initialize_v0(orbit_api_v0* api) {
 
 void orbit_api_initialize_v1(orbit_api_v1* api) {
   api->start = &orbit_api_start_v1;
-  api->start_with_explicit_caller = &orbit_api_start_with_explicit_caller_v1;
   api->stop = &orbit_api_stop;
   api->start_async = &orbit_api_start_async;
   api->stop_async = &orbit_api_stop_async;

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -13,13 +13,6 @@
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 
-// `__builtin_return_address(0)` will return us the (possibly encoded) return address of the
-// current function (level "0" refers to this frame, "1" would be the callers return address and
-// so on).
-// To decode the return address, we call `__builtin_extract_return_addr`.
-#define ORBIT_GET_CALLER_PC() \
-  absl::bit_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)))
-
 namespace {
 orbit_api::LockFreeApiEventProducer& GetEventProducer() {
   static orbit_api::LockFreeApiEventProducer producer;
@@ -42,6 +35,11 @@ void EnqueueApiEvent(Types... args) {
 void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_id) {
   uint64_t return_address = ORBIT_GET_CALLER_PC();
   EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, group_id, return_address);
+}
+
+void orbit_api_start_with_explicit_caller_v1(const char* name, orbit_api_color color,
+                                             uint64_t group_id, uint64_t caller_address) {
+  EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, group_id, caller_address);
 }
 
 void orbit_api_start(const char* name, orbit_api_color color) {
@@ -129,6 +127,7 @@ void orbit_api_initialize_v0(orbit_api_v0* api) {
 
 void orbit_api_initialize_v1(orbit_api_v1* api) {
   api->start = &orbit_api_start_v1;
+  api->start_with_explicit_caller = &orbit_api_start_with_explicit_caller_v1;
   api->stop = &orbit_api_stop;
   api->start_async = &orbit_api_start_async;
   api->stop_async = &orbit_api_stop_async;

--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -198,6 +198,10 @@
 #ifdef __cplusplus
 
 #ifdef WIN32
+#include <intrin.h>
+
+#pragma intrinsic(_ReturnAddress)
+
 #define ORBIT_GET_CALLER_PC() reinterpret_cast<uint64_t>(_ReturnAddress())
 #else
 // `__builtin_return_address(0)` will return us the (possibly encoded) return address of the

--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -195,8 +195,6 @@
 #define ORBIT_API_ENABLED 1
 #if ORBIT_API_ENABLED
 
-#ifdef __cplusplus
-
 #ifdef WIN32
 #include <intrin.h>
 
@@ -212,6 +210,8 @@
   reinterpret_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)))
 #endif
 
+#ifdef __cplusplus
+
 #define ORBIT_SCOPE(name) ORBIT_SCOPE_WITH_COLOR(name, kOrbitColorAuto)
 #define ORBIT_SCOPE_WITH_COLOR(name, col) \
   ORBIT_SCOPE_WITH_COLOR_AND_GROUP_ID(name, col, kOrbitDefaultGroupId)
@@ -221,7 +221,8 @@
   orbit_api::Scope ORBIT_VAR(name, col, group_id)
 #endif
 
-#define ORBIT_START(name) ORBIT_CALL(start, name, kOrbitColorAuto, kOrbitDefaultGroupId)
+#define ORBIT_START(name) \
+  ORBIT_CALL(start, name, kOrbitColorAuto, kOrbitDefaultGroupId, kOrbitCallerAddressAuto)
 #define ORBIT_STOP() ORBIT_CALL(stop, )
 #define ORBIT_START_ASYNC(name, id) ORBIT_CALL(start_async, name, id, kOrbitColorAuto)
 #define ORBIT_STOP_ASYNC(id) ORBIT_CALL(stop_async, id)
@@ -233,7 +234,8 @@
 #define ORBIT_FLOAT(name, value) ORBIT_CALL(track_float, name, value, kOrbitColorAuto)
 #define ORBIT_DOUBLE(name, value) ORBIT_CALL(track_double, name, value, kOrbitColorAuto)
 
-#define ORBIT_START_WITH_COLOR(name, color) ORBIT_CALL(start, name, color, kOrbitDefaultGroupId)
+#define ORBIT_START_WITH_COLOR(name, color) \
+  ORBIT_CALL(start, name, color, kOrbitDefaultGroupId, kOrbitCallerAddressAuto)
 #define ORBIT_START_ASYNC_WITH_COLOR(name, id, color) ORBIT_CALL(start_async, name, id, color)
 #define ORBIT_ASYNC_STRING_WITH_COLOR(string, id, color) ORBIT_CALL(async_string, string, id, color)
 #define ORBIT_INT_WITH_COLOR(name, value, color) ORBIT_CALL(track_int, name, value, color)
@@ -243,9 +245,10 @@
 #define ORBIT_FLOAT_WITH_COLOR(name, value, color) ORBIT_CALL(track_float, name, value, color)
 #define ORBIT_DOUBLE_WITH_COLOR(name, value, color) ORBIT_CALL(track_double, name, value, color)
 
-#define ORBIT_START_WITH_GROUP_ID(name, group_id) ORBIT_CALL(start, name, kOrbitColorAuto, group_id)
+#define ORBIT_START_WITH_GROUP_ID(name, group_id) \
+  ORBIT_CALL(start, name, kOrbitColorAuto, group_id, kOrbitCallerAddressAuto)
 #define ORBIT_START_WITH_COLOR_AND_GROUP_ID(name, color, group_id) \
-  ORBIT_CALL(start, name, color, group_id)
+  ORBIT_CALL(start, name, color, group_id, kOrbitCallerAddressAuto)
 
 #else  // ORBIT_API_ENABLED
 
@@ -321,15 +324,15 @@ typedef enum {
 } orbit_api_color;
 
 constexpr uint64_t kOrbitDefaultGroupId = 0;
+constexpr uint64_t kOrbitCallerAddressAuto = 0;
 
 enum { kOrbitApiVersion = 1 };
 
 struct orbit_api_v1 {
   uint32_t enabled;
   uint32_t initialized;
-  void (*start)(const char* name, orbit_api_color color, uint64_t group_id);
-  void (*start_with_explicit_caller)(const char* name, orbit_api_color color, uint64_t group_id,
-                                     uint64_t caller_address);
+  void (*start)(const char* name, orbit_api_color color, uint64_t group_id,
+                uint64_t caller_address);
   void (*stop)();
   void (*start_async)(const char* name, uint64_t id, orbit_api_color color);
   void (*stop_async)(uint64_t id);
@@ -375,7 +378,7 @@ namespace orbit_api {
 struct Scope {
   Scope(const char* name, orbit_api_color color, uint64_t group_id) {
     uint64_t return_address = ORBIT_GET_CALLER_PC();
-    ORBIT_CALL(start_with_explicit_caller, name, color, group_id, return_address);
+    ORBIT_CALL(start, name, color, group_id, return_address);
   }
   ~Scope() { ORBIT_CALL(stop); }
 };

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -19,12 +19,6 @@
 #include "OrbitBase/ThreadPool.h"
 #include "OrbitBase/ThreadUtils.h"
 
-#ifdef WIN32
-#include <intrin.h>
-
-#pragma intrinsic(_ReturnAddress)
-#endif
-
 using orbit_api::ApiEventVariant;
 using orbit_introspection::TracingEventCallback;
 using orbit_introspection::TracingListener;


### PR DESCRIPTION
We collect the return address in Orbit Api "Start" functions.
Scopes add one layer of indirection, so the return address "might"
not be the expected one (we've seen it also being correct due to
inlining).

This fixes this, by explicitly asking for return address in the
Scope constructor and passing it to a specific "start" function
as an argument.

Test: Run on sample with scopes.