### PR TITLE
Activate parallel builds under Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ add_definitions(-DUNICODE -D_UNICODE)
 
 if(WIN32)
   add_definitions(-DWIN32)
+  add_definitions(/MP)
 else()
   add_subdirectory(src/Api)
   add_subdirectory(src/ApiLoader)


### PR DESCRIPTION
With this flag I get a decent number cl.exe's running in parallel.
It seems to be disabled by default since it is incompatible with
some esoteric stuff we don't use.

I triggered an entire rebuild and things work fine.