### PR TITLE
Move Subtracks with the track when dragging

### DIFF
--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -59,7 +59,7 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
  private:
   [[nodiscard]] bool IsCollapsed() const override;
   [[nodiscard]] float GetAnnotatedTrackContentHeight() const override;
-  [[nodiscard]] Vec2 GetAnnotatedTrackPosition() const override { return pos_; };
+  [[nodiscard]] Vec2 GetAnnotatedTrackPosition() const override { return GetPos(); };
   [[nodiscard]] Vec2 GetAnnotatedTrackSize() const override { return GetSize(); };
   [[nodiscard]] uint32_t GetAnnotationFontSize(int indentation_level) const override {
     return GetLegendFontSize(indentation_level);

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -64,19 +64,20 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           : GlCanvas::kZValueEventBar;
   event_bar_z += draw_context.z_offset;
   Color color = GetColor();
-  Box box(pos_, Vec2(GetWidth(), GetHeight()), event_bar_z);
+  const Vec2 pos = GetPos();
+  Box box(pos, Vec2(GetWidth(), GetHeight()), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
 
   if (batcher.GetPickingManager()->IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
   }
 
-  float x0 = pos_[0];
-  float y0 = pos_[1];
+  float x0 = pos[0];
+  float y0 = pos[1];
   float x1 = x0 + GetWidth();
   float y1 = y0 + GetHeight();
 
-  batcher.AddLine(pos_, Vec2(x1, y0), event_bar_z, color, shared_from_this());
+  batcher.AddLine(pos, Vec2(x1, y0), event_bar_z, color, shared_from_this());
   batcher.AddLine(Vec2(x1, y1), Vec2(x0, y1), event_bar_z, color, shared_from_this());
 
   if (picked_) {
@@ -84,7 +85,7 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
     Vec2& to = mouse_pos_cur_;
 
     x0 = from[0];
-    y0 = pos_[1];
+    y0 = pos[1];
     x1 = to[0];
     y1 = y0 + GetHeight();
 
@@ -113,7 +114,7 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
     auto action_on_callstack_events = [=](const CallstackEvent& event) {
       const uint64_t time = event.time();
       CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
+      Vec2 pos(time_graph_->GetWorldFromTick(time), GetPos()[1]);
       Color color = kWhite;
       if (capture_data_->GetCallstackData().GetCallstack(event.callstack_id())->type() !=
           CallstackInfo::kComplete) {
@@ -134,7 +135,7 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
     std::array<Color, 2> selected_color;
     selected_color.fill(kGreenSelection);
     for (const CallstackEvent& event : time_graph_->GetSelectedCallstackEvents(GetThreadId())) {
-      Vec2 pos(time_graph_->GetWorldFromTick(event.time()), pos_[1]);
+      Vec2 pos(time_graph_->GetWorldFromTick(event.time()), GetPos()[1]);
       batcher->AddVerticalLine(pos, track_height, z, kGreenSelection);
     }
   } else {
@@ -146,7 +147,8 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
     auto action_on_callstack_events = [=](const CallstackEvent& event) {
       const uint64_t time = event.time();
       CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset, pos_[1] + track_height - 1);
+      Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset,
+               GetPos()[1] + track_height - 1);
       Vec2 size(kPickingBoxWidth, track_height);
       auto user_data = std::make_unique<PickingUserData>(
           nullptr,

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -77,8 +77,6 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   TimeGraphLayout* layout_;
 
   TimeGraph* time_graph_;
-  Vec2 pos_ = Vec2(0, 0);
-  float width_ = 0.;
 
   Vec2 mouse_pos_last_click_;
   Vec2 mouse_pos_cur_;
@@ -86,6 +84,8 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   bool picked_ = false;
 
  private:
+  float width_ = 0.;
+  Vec2 pos_ = Vec2(0, 0);
   CaptureViewElement* parent_;
 };
 }  // namespace orbit_gl

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -74,7 +74,8 @@ float FrameTrack::GetHeight() const {
 }
 
 float FrameTrack::GetYFromTimer(const TimerInfo& timer_info) const {
-  return pos_[1] + GetHeaderHeight() + (GetMaximumBoxHeight() - GetDynamicBoxHeight(timer_info));
+  return GetPos()[1] + GetHeaderHeight() +
+         (GetMaximumBoxHeight() - GetDynamicBoxHeight(timer_info));
 }
 
 float FrameTrack::GetDefaultBoxHeight() const {
@@ -210,9 +211,10 @@ void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
 
   const Color kWhiteColor(255, 255, 255, 255);
   const Color kBlackColor(0, 0, 0, 255);
+  const Vec2 pos = GetPos();
 
-  float y = pos_[1] + GetHeaderHeight() + GetMaximumBoxHeight() - GetAverageBoxHeight();
-  float x = pos_[0];
+  const float x = pos[0];
+  const float y = pos[1] + GetHeaderHeight() + GetMaximumBoxHeight() - GetAverageBoxHeight();
   Vec2 from(x, y);
   Vec2 to(x + GetWidth(), y);
   float text_z = GlCanvas::kZValueTrackText + draw_context.z_offset;
@@ -222,7 +224,7 @@ void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   std::string label = absl::StrFormat("Avg: %s", avg_time);
   uint32_t font_size = layout_->CalculateZoomedFontSize();
   float string_width = text_renderer.GetStringWidth(label.c_str(), font_size);
-  Vec2 white_text_box_position(pos_[0] + layout_->GetRightMargin(), y);
+  Vec2 white_text_box_position(pos[0] + layout_->GetRightMargin(), y);
 
   batcher.AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z, kWhiteColor);
   batcher.AddLine(Vec2(white_text_box_position[0] + string_width, y), to, text_z, kWhiteColor);

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -111,7 +111,7 @@ float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (collapse_toggle_->IsCollapsed()) {
     depth = 0;
   }
-  return pos_[1] + layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth;
+  return GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth;
 }
 
 float GpuDebugMarkerTrack::GetHeight() const {

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -151,7 +151,7 @@ float GpuSubmissionTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
     adjusted_depth += 1.f;
   }
-  return pos_[1] + GetHeaderHeight() + layout_->GetTextBoxHeight() * adjusted_depth - gap_space;
+  return GetPos()[1] + GetHeaderHeight() + layout_->GetTextBoxHeight() * adjusted_depth - gap_space;
 }
 
 // When track or its parent is collapsed, only draw "hardware execution" timers.

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -83,20 +83,21 @@ void GpuTrack::OnTimer(const TimerInfo& timer_info) {
 }
 
 void GpuTrack::UpdatePositionOfSubtracks() {
+  const Vec2 pos = GetPos();
   if (collapse_toggle_->IsCollapsed()) {
-    submission_track_->SetPos(pos_[0], pos_[1]);
+    submission_track_->SetPos(pos[0], pos[1]);
     return;
   }
-  float current_y = pos_[1] + layout_->GetTrackTabHeight();
+  float current_y = pos[1] + layout_->GetTrackTabHeight();
   if (!submission_track_->IsEmpty()) {
     current_y += layout_->GetSpaceBetweenSubtracks();
   }
-  submission_track_->SetPos(pos_[0], current_y);
+  submission_track_->SetPos(pos[0], current_y);
   if (!marker_track_->IsEmpty()) {
     current_y += (layout_->GetSpaceBetweenSubtracks() + submission_track_->GetHeight());
   }
 
-  marker_track_->SetPos(pos_[0], current_y);
+  marker_track_->SetPos(pos[0], current_y);
 }
 
 float GpuTrack::GetHeight() const {

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -84,13 +84,11 @@ void GraphTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
 template <size_t Dimension>
 void GraphTrack<Dimension>::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                              PickingMode picking_mode, float z_offset) {
-  pos_[0] = viewport_->GetWorldTopLeft()[0];
-
   float track_z = GlCanvas::kZValueTrack + z_offset;
   float graph_z = GlCanvas::kZValueEventBar + z_offset;
 
   float content_height = GetGraphContentHeight();
-  Vec2 content_pos = pos_;
+  Vec2 content_pos = GetPos();
   content_pos[1] += layout_->GetTrackTabHeight();
   Box box(content_pos, Vec2(GetWidth(), content_height + GetLegendHeight()), track_z);
   batcher->AddBox(box, GetTrackBackgroundColor(), shared_from_this());
@@ -212,8 +210,8 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
   const float kSpaceBetweenLegendEntries = layout_->GetGenericFixedSpacerWidth() * 2;
   const float legend_symbol_height = GetLegendHeight();
   const float legend_symbol_width = legend_symbol_height;
-  float x0 = pos_[0] + layout_->GetRightMargin();
-  const float y0 = pos_[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
+  float x0 = GetPos()[0] + layout_->GetRightMargin();
+  const float y0 = GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
   uint32_t font_size = GetLegendFontSize(draw_context.indentation_level);
   const Color kFullyTransparent(255, 255, 255, 0);
 

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -61,7 +61,7 @@ class GraphTrack : public Track {
   }
 
   [[nodiscard]] float GetGraphContentBottomY() const {
-    return pos_[1] + GetSize()[1] - layout_->GetTrackContentBottomMargin();
+    return GetPos()[1] + GetSize()[1] - layout_->GetTrackContentBottomMargin();
   }
   [[nodiscard]] float GetGraphContentHeight() const;
 

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -48,7 +48,7 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
   [[nodiscard]] float GetAnnotatedTrackContentHeight() const override {
     return this->GetGraphContentHeight();
   }
-  [[nodiscard]] Vec2 GetAnnotatedTrackPosition() const override { return this->pos_; };
+  [[nodiscard]] Vec2 GetAnnotatedTrackPosition() const override { return this->GetPos(); };
   [[nodiscard]] Vec2 GetAnnotatedTrackSize() const override { return this->GetSize(); };
   [[nodiscard]] uint32_t GetAnnotationFontSize(int indentation_level) const override {
     return this->GetLegendFontSize(indentation_level);

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -107,21 +107,22 @@ void PageFaultsTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint
 }
 
 void PageFaultsTrack::UpdatePositionOfSubtracks() {
+  const Vec2 pos = GetPos();
   if (collapse_toggle_->IsCollapsed()) {
-    major_page_faults_track_->SetPos(pos_[0], pos_[1]);
+    major_page_faults_track_->SetPos(pos[0], pos[1]);
     return;
   }
 
-  float current_y = pos_[1] + layout_->GetTrackTabHeight();
+  float current_y = pos[1] + layout_->GetTrackTabHeight();
   if (!major_page_faults_track_->IsEmpty()) {
     current_y += layout_->GetSpaceBetweenSubtracks();
   }
-  major_page_faults_track_->SetPos(pos_[0], current_y);
+  major_page_faults_track_->SetPos(pos[0], current_y);
 
   if (!minor_page_faults_track_->IsEmpty()) {
     current_y += (layout_->GetSpaceBetweenSubtracks() + major_page_faults_track_->GetHeight());
   }
-  minor_page_faults_track_->SetPos(pos_[0], current_y);
+  minor_page_faults_track_->SetPos(pos[0], current_y);
 }
 
 void PageFaultsTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -73,7 +73,7 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
 
 float SchedulerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   uint32_t num_gaps = timer_info.depth();
-  return pos_[1] + GetHeaderHeight() +
+  return GetPos()[1] + GetHeaderHeight() +
          (layout_->GetTextCoresHeight() * static_cast<float>(timer_info.depth())) +
          num_gaps * layout_->GetSpaceBetweenCores();
 }

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -49,7 +49,7 @@ void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
   thread_state_bar_z += draw_context.z_offset;
 
   // Draw a transparent track just for clicking.
-  Box box(pos_, Vec2(GetWidth(), GetHeight()), thread_state_bar_z);
+  Box box(GetPos(), Vec2(GetWidth(), GetHeight()), thread_state_bar_z);
   static const Color kTransparent{0, 0, 0, 0};
   batcher.AddBox(box, kTransparent, shared_from_this());
 }
@@ -187,7 +187,7 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
         const float x1 = time_graph_->GetWorldFromTick(slice.end_timestamp_ns());
         const float width = x1 - x0;
 
-        const Vec2 pos{x0, pos_[1]};
+        const Vec2 pos{x0, GetPos()[1]};
         const Vec2 size{width, GetHeight()};
 
         const Color color = GetThreadStateColor(slice.thread_state());

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -259,19 +259,20 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   const float event_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
 
-  float current_y = pos_[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
+  const Vec2 pos = GetPos();
+  float current_y = pos[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
 
-  thread_state_bar_->SetPos(pos_[0], current_y);
+  thread_state_bar_->SetPos(pos[0], current_y);
   if (!thread_state_bar_->IsEmpty()) {
     current_y += (space_between_subtracks + thread_state_track_height);
   }
 
-  event_bar_->SetPos(pos_[0], current_y);
+  event_bar_->SetPos(pos[0], current_y);
   if (!event_bar_->IsEmpty()) {
     current_y += (space_between_subtracks + event_track_height);
   }
 
-  tracepoint_bar_->SetPos(pos_[0], current_y);
+  tracepoint_bar_->SetPos(pos[0], current_y);
 }
 
 void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
@@ -395,7 +396,7 @@ float ThreadTrack::GetHeaderHeight() const {
 float ThreadTrack::GetYFromDepth(uint32_t depth) const {
   bool gap_between_tracks_and_timers =
       !thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty();
-  return pos_[1] + GetHeaderHeight() +
+  return GetPos()[1] + GetHeaderHeight() +
          (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
          GetDefaultBoxHeight() * static_cast<float>(depth);
 }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -529,7 +529,7 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
 
 void TimeGraph::UpdateTracksPosition() {
   // Update position of a track which is currently being moved.
-  const float track_pos_x = pos_[0];
+  const float track_pos_x = GetPos()[0];
 
   float current_y = layout_.GetSchedulerTrackOffset();
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -55,7 +55,7 @@ float TimerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 }
 
 float TimerTrack::GetYFromDepth(uint32_t depth) const {
-  return pos_[1] + GetHeaderHeight() + GetDefaultBoxHeight() * static_cast<float>(depth);
+  return GetPos()[1] + GetHeaderHeight() + GetDefaultBoxHeight() * static_cast<float>(depth);
 }
 
 namespace {

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -49,7 +49,7 @@ void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           : GlCanvas::kZValueEventBar;
   event_bar_z += draw_context.z_offset;
   Color color = GetColor();
-  Box box(pos_, Vec2(GetWidth(), -GetHeight()), event_bar_z);
+  Box box(GetPos(), Vec2(GetWidth(), -GetHeight()), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
 }
 
@@ -73,7 +73,7 @@ void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, 
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
           float radius = track_height / 4;
-          Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
+          const Vec2 pos(time_graph_->GetWorldFromTick(time), GetPos()[1]);
           if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
             const Color color = tracepoint.pid() == capture_data_->process_id() ? kGrey : kWhite;
             batcher->AddVerticalLine(pos, -track_height, z, color);
@@ -95,7 +95,7 @@ void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, 
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
           Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset,
-                   pos_[1] - track_height + 1);
+                   GetPos()[1] - track_height + 1);
           Vec2 size(kPickingBoxWidth, track_height);
           auto user_data =
               std::make_unique<PickingUserData>(nullptr, [&, batcher](PickingId id) -> std::string {

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -91,8 +91,8 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContex
 
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
 
-  float x0 = pos_[0];
-  float y0 = pos_[1];
+  const float x0 = GetPos()[0];
+  const float y0 = GetPos()[1];
   float track_z = GlCanvas::kZValueTrack + draw_context.z_offset;
   float text_z = GlCanvas::kZValueTrackText + draw_context.z_offset;
 
@@ -193,12 +193,12 @@ void Track::DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer
                                    const DrawContext& draw_context) {
   const float label_height = layout_->GetTrackTabHeight();
   const float half_label_height = 0.5f * label_height;
-  const float x0 = pos_[0];
+  const float x0 = GetPos()[0];
   const float tab_x0 = x0 + layout_->GetTrackTabOffset();
   const float intent_x0 =
       tab_x0 + (draw_context.indentation_level * layout_->GetTrackIntentOffset());
   const float button_offset = layout_->GetCollapseButtonOffset();
-  const float toggle_y_pos = pos_[1] + half_label_height;
+  const float toggle_y_pos = GetPos()[1] + half_label_height;
   Vec2 toggle_pos = Vec2(intent_x0 + button_offset, toggle_y_pos);
   collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1]);
   collapse_toggle_->Draw(batcher, text_renderer, draw_context);
@@ -208,7 +208,7 @@ void Track::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*t_min*/, uint64_t 
                              PickingMode /*  picking_mode*/, float /*z_offset*/) {}
 
 void Track::SetPos(float x, float y) {
-  pos_ = Vec2(x, y);
+  CaptureViewElement::SetPos(x, y);
   UpdatePositionOfSubtracks();
 }
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -232,6 +232,6 @@ void Track::OnCollapseToggle(bool /*is_collapsed*/) { RequestUpdate(); }
 void Track::OnDrag(int x, int y) {
   CaptureViewElement::OnDrag(x, y);
 
-  pos_[1] = mouse_pos_cur_[1] - picking_offset_[1];
+  SetPos(GetPos()[0], mouse_pos_cur_[1] - picking_offset_[1]);
   time_graph_->VerticallyMoveIntoView(*this);
 }

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -43,8 +43,9 @@ void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
   float half_w = 0.5f * size;
   float half_h = half_sqrt_three * half_w;
 
+  const Vec2 pos = GetPos();
   if (!picking) {
-    Vec3 position(pos_[0], pos_[1], 0.0f);
+    Vec3 position(pos[0], pos[1], 0.0f);
 
     Triangle triangle;
     if (is_collapsed_) {
@@ -59,8 +60,8 @@ void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
     // When picking, draw a big square for easier picking.
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
-    Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
-            Vec2(large_width, large_width), z);
+    Box box(Vec2(pos[0] - original_width, pos[1] - original_width), Vec2(large_width, large_width),
+            z);
     batcher.AddBox(box, color, shared_from_this());
   }
 }


### PR DESCRIPTION
Regression. A previous issue hidden because we were updating the position while drawing. 
We were modifying pos in Track without changing also position of subtracks when dragging.

Test: Loaded a capture, moving tracks.

The first commit solved the issue (1 line)
The second commit made pos_ private in CaptureViewElement to assure is only modified with SetPos() methods
Bug: http://b/197122592