### PR TITLE
Change the space between subtracks

### DIFF
--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -21,7 +21,7 @@ TimeGraphLayout::TimeGraphLayout() {
   space_between_gpu_depths_ = 2.f;
   space_between_tracks_ = 10.f;
   space_between_tracks_and_thread_ = 5.f;
-  space_between_subtracks_ = -5.f;
+  space_between_subtracks_ = 0.f;
   space_between_thread_blocks_ = 35.f;
   track_label_offset_x_ = 30.f;
   slider_width_ = 15.f;


### PR DESCRIPTION
Changed from -5 to 0 - not sure why the -5 made sense, but IMO we don't need any space in between subtracks (see screenshot), they line up nicely with a value of 0.

Bug: b/193018071
How it looks now: https://screenshot.googleplex.com/7kuUgMQ79ijBAAf