### PR TITLE
Use WorldToScreen conversion in the right line

### DIFF
--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -191,12 +191,14 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
 
   Color color = GetTimerColor(*current_timer_info, is_selected, is_highlighted);
 
-  bool is_visible_width = elapsed_us * draw_data.inv_time_window * draw_data.track_width > 1;
+  bool is_visible_width = elapsed_us * draw_data.inv_time_window *
+                              viewport_->WorldToScreenWidth(draw_data.track_width) >
+                          1;
 
   if (is_visible_width) {
     WorldXInfo world_x_info_left_overlap =
         ToWorldX(start_us, start_or_prev_end_us, draw_data.inv_time_window, draw_data.track_start_x,
-                 viewport_->WorldToScreenWidth(draw_data.track_width));
+                 draw_data.track_width);
 
     WorldXInfo world_x_info_right_overlap =
         ToWorldX(end_or_next_start_us, end_us, draw_data.inv_time_window, draw_data.track_start_x,


### PR DESCRIPTION
Caused by lack of attention. Thanks Florian for pointing
it. Explained better in  https://github.com/google/orbit/pull/2695. We
were using GetScreenWidth from viewport, we wanted to use instead
timegraph->GetWidth() and for that we had to convert to Screen.

Now we are doing that in the right line. By the way, still not sure
about if we have to add in ToWorldX(), but before it wasn't and I will
leave as it was before. There are 4 occurences of the function, the
other 3 are not using it.