### PR TITLE
Add fallback for determining the location of a function from debug information

### DIFF
--- a/src/CodeReport/SourceCodeReportTest.cpp
+++ b/src/CodeReport/SourceCodeReportTest.cpp
@@ -30,6 +30,8 @@ class MockElfFile : public orbit_object_utils::ElfFile {
               (uint64_t), (override));
   MOCK_METHOD(std::optional<orbit_object_utils::GnuDebugLinkInfo>, GetGnuDebugLinkInfo, (),
               (const, override));
+  MOCK_METHOD(ErrorMessageOr<orbit_grpc_protos::LineInfo>, GetLocationOfFunction, (uint64_t),
+              (override));
 
   MOCK_METHOD(ErrorMessageOr<orbit_grpc_protos::ModuleSymbols>, LoadDebugSymbols, (), (override));
   MOCK_METHOD(bool, HasDebugSymbols, (), (const, override));

--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -379,3 +379,38 @@ TEST(ElfFile, GetDeclarationLocationOfFunctionLibc) {
   EXPECT_EQ(std::filesystem::path{decl_line_info.value().source_file()}.filename().string(),
             "gconv_open.c");
 }
+
+TEST(ElfFile, GetLocationOfFunctionLibc) {
+  const std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libc.debug";
+
+  auto program = CreateElfFile(file_path);
+  ASSERT_THAT(program, HasNoError());
+
+  constexpr uint64_t kAddressOfFunction = 0x20b20;
+  ErrorMessageOr<orbit_grpc_protos::LineInfo> decl_line_info =
+      program.value()->GetDeclarationLocationOfFunction(kAddressOfFunction);
+  ASSERT_THAT(decl_line_info, HasNoError());
+
+  EXPECT_EQ(decl_line_info.value().source_line(), 31);
+  EXPECT_EQ(std::filesystem::path{decl_line_info.value().source_file()}.filename().string(),
+            "gconv_open.c");
+}
+
+TEST(ElfFile, GetLocationOfFunctionNoSubroutine) {
+  const std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libc.debug";
+
+  auto program = CreateElfFile(file_path);
+  ASSERT_THAT(program, HasNoError());
+
+  constexpr uint64_t kAddressOfFunction = 0x10a0e0;
+  EXPECT_THAT(program.value()->GetDeclarationLocationOfFunction(kAddressOfFunction),
+              orbit_base::HasError("Address not associated with any subroutine"));
+
+  ErrorMessageOr<orbit_grpc_protos::LineInfo> function_location =
+      program.value()->GetLocationOfFunction(kAddressOfFunction);
+  ASSERT_THAT(function_location, HasNoError());
+
+  EXPECT_EQ(function_location.value().source_line(), 90);
+  EXPECT_EQ(std::filesystem::path{function_location.value().source_file()}.filename().string(),
+            "auth_none.c");
+}

--- a/src/ObjectUtils/include/ObjectUtils/ElfFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ElfFile.h
@@ -46,12 +46,20 @@ class ElfFile : public ObjectFile {
   [[nodiscard]] virtual std::string GetSoname() const = 0;
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::LineInfo> GetLineInfo(
       uint64_t address) = 0;
+
+  // Returns the declaration location of the given function (subprogram) address
+  // if available in the DWARF debug information.
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::LineInfo>
   GetDeclarationLocationOfFunction(uint64_t address) = 0;
   [[nodiscard]] virtual std::optional<GnuDebugLinkInfo> GetGnuDebugLinkInfo() const = 0;
 
   [[nodiscard]] static ErrorMessageOr<uint32_t> CalculateDebuglinkChecksum(
       const std::filesystem::path& file_path);
+
+  // Returns GetDeclarationLocationOfFunction(address) if available. If not, it falls back to
+  // returning the source code location of the first instruction.
+  [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::LineInfo> GetLocationOfFunction(
+      uint64_t address) = 0;
 };
 
 [[nodiscard]] ErrorMessageOr<std::unique_ptr<ElfFile>> CreateElfFile(

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -865,7 +865,7 @@ void OrbitApp::ShowSourceCode(const orbit_client_protos::FunctionInfo& function)
            function](const std::filesystem::path& local_file_path) -> ErrorMessageOr<void> {
             const auto elf_file = orbit_object_utils::CreateElfFile(local_file_path);
             const auto decl_line_info_or_error =
-                elf_file.value()->GetDeclarationLocationOfFunction(function.address());
+                elf_file.value()->GetLocationOfFunction(function.address());
 
             if (decl_line_info_or_error.has_error()) {
               return ErrorMessage{absl::StrFormat(

--- a/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
@@ -70,7 +70,7 @@ bool AnnotatingSourceCodeDialog::LoadElfFile(const std::filesystem::path& local_
 }
 bool AnnotatingSourceCodeDialog::LoadLocationInformationFromElf() {
   ErrorMessageOr<orbit_grpc_protos::LineInfo> location_or_error =
-      elf_file_->GetDeclarationLocationOfFunction(function_info_.address());
+      elf_file_->GetLocationOfFunction(function_info_.address());
   if (location_or_error.has_error()) {
     SetStatusMessage(QString::fromStdString(location_or_error.error().message()), "Hide");
     awaited_button_action_ = ButtonAction::kHide;

--- a/src/OrbitQt/AnnotatingSourceCodeDialogTest.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialogTest.cpp
@@ -48,7 +48,7 @@ TEST(AnnotatingSourceCodeDialog, SmokeTest) {
 
   constexpr uint64_t kAddressOfMainFunction = 0x401140;
   ErrorMessageOr<orbit_grpc_protos::LineInfo> decl_line_info =
-      program.value()->GetDeclarationLocationOfFunction(kAddressOfMainFunction);
+      program.value()->GetLocationOfFunction(kAddressOfMainFunction);
   ASSERT_TRUE(decl_line_info.has_value()) << decl_line_info.error().message();
 
   const std::filesystem::path source_file_path =


### PR DESCRIPTION
Some compile units do not provide declaration locations for their functions in DWARF debug information. In that case we should fall back to using the source location of the first instruction to determine the location of the function.

This is done in this PR.

Bug: http://b/197318872