### PR TITLE
Move TestUtils into separate module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ add_subdirectory(src/StringManager)
 add_subdirectory(src/Symbols)
 add_subdirectory(src/TracingInterface)
 add_subdirectory(src/Test)
+add_subdirectory(src/TestUtils)
 
 if(WITH_GUI)
   add_subdirectory(src/CaptureFileInfo)

--- a/src/CaptureClient/CMakeLists.txt
+++ b/src/CaptureClient/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(CaptureClientTests PRIVATE
 target_link_libraries(
         CaptureClientTests PRIVATE
         CaptureClient
+        TestUtils
         GTest::Main)
 
 register_test(CaptureClientTests)

--- a/src/CaptureClient/SaveToFileEventProcessorTest.cpp
+++ b/src/CaptureClient/SaveToFileEventProcessorTest.cpp
@@ -12,16 +12,16 @@
 #include "CaptureFile/CaptureFile.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_capture_client {
 
-using orbit_base::HasNoError;
-using orbit_base::HasValue;
 using orbit_base::TemporaryFile;
 using orbit_capture_file::CaptureFile;
 using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::ClientCaptureEvent;
+using orbit_test_utils::HasNoError;
+using orbit_test_utils::HasValue;
 
 static ClientCaptureEvent CreateInternedStringEvent(uint64_t key, const char* intern) {
   ClientCaptureEvent event;

--- a/src/CaptureFile/CMakeLists.txt
+++ b/src/CaptureFile/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(CaptureFileTests PRIVATE
 target_link_libraries(
   CaptureFileTests
   PRIVATE CaptureFile
+          TestUtils
           GTest::Main
           CONAN_PKG::abseil)
 

--- a/src/CaptureFile/CaptureFileHelpersTest.cpp
+++ b/src/CaptureFile/CaptureFileHelpersTest.cpp
@@ -12,11 +12,11 @@
 #include "CaptureFile/CaptureFileOutputStream.h"
 #include "CaptureFileConstants.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_capture_file {
 
-using orbit_base::HasNoError;
+using orbit_test_utils::HasNoError;
 
 static constexpr const char* kAnswerString =
     "Answer to the Ultimate Question of Life, The Universe, and Everything";

--- a/src/CaptureFile/CaptureFileTest.cpp
+++ b/src/CaptureFile/CaptureFileTest.cpp
@@ -12,13 +12,13 @@
 #include "CaptureFile/CaptureFileOutputStream.h"
 #include "CaptureFileConstants.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_capture_file {
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
-using orbit_base::HasValue;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
+using orbit_test_utils::HasValue;
 
 static constexpr const char* kAnswerString =
     "Answer to the Ultimate Question of Life, The Universe, and Everything";

--- a/src/CaptureFileInfo/CMakeLists.txt
+++ b/src/CaptureFileInfo/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(
           ClientFlags
           GTest::QtGuiMain
           QtUtils
+          TestUtils
           Qt5::Test)
 
 if (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen")

--- a/src/CaptureFileInfo/ManagerTest.cpp
+++ b/src/CaptureFileInfo/ManagerTest.cpp
@@ -11,12 +11,12 @@
 #include <thread>
 
 #include "CaptureFileInfo/Manager.h"
-#include "OrbitBase/TestUtils.h"
 #include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_capture_file_info {
 
-using orbit_base::HasError;
+using orbit_test_utils::HasError;
 
 constexpr const char* kOrgName = "The Orbit Authors";
 

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(ClientDataTests PRIVATE
 
 target_link_libraries(ClientDataTests PRIVATE
         ClientData
+        TestUtils
         GTest::Main)
 
 register_test(ClientDataTests)

--- a/src/ClientData/ProcessDataTest.cpp
+++ b/src/ClientData/ProcessDataTest.cpp
@@ -14,14 +14,14 @@
 #include "ClientData/ModuleData.h"
 #include "ClientData/ProcessData.h"
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "module.pb.h"
 #include "process.pb.h"
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::ProcessInfo;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 
 using testing::ElementsAre;
 

--- a/src/DataViews/CMakeLists.txt
+++ b/src/DataViews/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(DataViewsTests PRIVATE DataViewTest.cpp
                                       PresetsDataViewTest.cpp)
 target_link_libraries(DataViewsTests PRIVATE
         DataViews
+        TestUtils
         GTest::Main)
 
 register_test(DataViewsTests)

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -22,8 +22,8 @@
 #include "MockAppInterface.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
 #include "OrbitBase/ThreadPool.h"
+#include "TestUtils/TestUtils.h"
 #include "capture.pb.h"
 #include "capture_data.pb.h"
 #include "process.pb.h"
@@ -512,7 +512,7 @@ TEST_F(FunctionsDataViewTest, GenericDataExportFunctionShowCorrectData) {
 
     ErrorMessageOr<orbit_base::TemporaryFile> temporary_file_or_error =
         orbit_base::TemporaryFile::Create();
-    ASSERT_THAT(temporary_file_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(temporary_file_or_error, orbit_test_utils::HasNoError());
     const std::filesystem::path temporary_file_path = temporary_file_or_error.value().file_path();
 
     // We actually only need a temporary file path, so let's call `CloseAndRemove` and reuse the
@@ -525,7 +525,7 @@ TEST_F(FunctionsDataViewTest, GenericDataExportFunctionShowCorrectData) {
 
     ErrorMessageOr<std::string> contents_or_error =
         orbit_base::ReadFileToString(temporary_file_path);
-    ASSERT_THAT(contents_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());
 
     EXPECT_EQ(
         contents_or_error.value(),

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -23,7 +23,7 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "capture.pb.h"
 #include "capture_data.pb.h"
 
@@ -391,7 +391,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
 
     ErrorMessageOr<orbit_base::TemporaryFile> temporary_file_or_error =
         orbit_base::TemporaryFile::Create();
-    ASSERT_THAT(temporary_file_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(temporary_file_or_error, orbit_test_utils::HasNoError());
     const std::filesystem::path temporary_file_path = temporary_file_or_error.value().file_path();
     temporary_file_or_error.value().CloseAndRemove();
 
@@ -400,7 +400,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
 
     ErrorMessageOr<std::string> contents_or_error =
         orbit_base::ReadFileToString(temporary_file_path);
-    ASSERT_THAT(contents_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());
 
     EXPECT_EQ(
         contents_or_error.value(),

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -17,7 +17,7 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "module.pb.h"
 
 using orbit_client_data::ModuleData;
@@ -161,7 +161,7 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
 
     ErrorMessageOr<orbit_base::TemporaryFile> temporary_file_or_error =
         orbit_base::TemporaryFile::Create();
-    ASSERT_THAT(temporary_file_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(temporary_file_or_error, orbit_test_utils::HasNoError());
     const std::filesystem::path temporary_file_path = temporary_file_or_error.value().file_path();
     temporary_file_or_error.value().CloseAndRemove();
 
@@ -170,7 +170,7 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
 
     ErrorMessageOr<std::string> contents_or_error =
         orbit_base::ReadFileToString(temporary_file_path);
-    ASSERT_THAT(contents_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());
 
     EXPECT_EQ(contents_or_error.value(),
               absl::StrFormat(R"("Name","Path","Address Range","File Size","Loaded")"

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -20,8 +20,8 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
 #include "PresetFile/PresetFile.h"
+#include "TestUtils/TestUtils.h"
 #include "preset.pb.h"
 
 namespace {
@@ -225,14 +225,14 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
       .WillRepeatedly(testing::Return(PresetLoadState::kLoadable));
 
   auto temporary_preset_file = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(temporary_preset_file, orbit_base::HasNoError());
+  ASSERT_THAT(temporary_preset_file, orbit_test_utils::HasNoError());
   temporary_preset_file.value().CloseAndRemove();
 
   const std::filesystem::path preset_filename0 = temporary_preset_file.value().file_path();
   orbit_preset_file::PresetFile preset_file0{preset_filename0, orbit_client_protos::PresetInfo{}};
-  ASSERT_THAT(preset_file0.SaveToFile(), orbit_base::HasNoError());
+  ASSERT_THAT(preset_file0.SaveToFile(), orbit_test_utils::HasNoError());
   auto date_modified = orbit_base::GetFileDateModified(preset_filename0);
-  ASSERT_THAT(date_modified, orbit_base::HasNoError());
+  ASSERT_THAT(date_modified, orbit_test_utils::HasNoError());
 
   view_.SetPresets({preset_file0});
   std::vector<std::string> context_menu = view_.GetContextMenu(0, {0});
@@ -264,7 +264,7 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
 
     ErrorMessageOr<orbit_base::TemporaryFile> temporary_file_or_error =
         orbit_base::TemporaryFile::Create();
-    ASSERT_THAT(temporary_file_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(temporary_file_or_error, orbit_test_utils::HasNoError());
     const std::filesystem::path temporary_file_path = temporary_file_or_error.value().file_path();
     temporary_file_or_error.value().CloseAndRemove();
 
@@ -273,7 +273,7 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
 
     ErrorMessageOr<std::string> contents_or_error =
         orbit_base::ReadFileToString(temporary_file_path);
-    ASSERT_THAT(contents_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());
 
     EXPECT_EQ(contents_or_error.value(),
               absl::StrFormat(R"("Loadable","Preset","Modules","Hooked Functions","Date Modified")"
@@ -307,7 +307,7 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
     view_.OnContextMenu("Delete Preset", static_cast<int>(delete_preset_idx), {0});
 
     const auto file_exists = orbit_base::FileExists(preset_filename0);
-    ASSERT_THAT(file_exists, orbit_base::HasNoError());
+    ASSERT_THAT(file_exists, orbit_test_utils::HasNoError());
     EXPECT_FALSE(file_exists.value());
 
     EXPECT_EQ(view_.GetNumElements(), 0);

--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -54,6 +54,7 @@ endif()
 target_link_libraries(
   ObjectUtilsTests
   PRIVATE ObjectUtils
+          TestUtils
           GTest::Main
           CONAN_PKG::llvm-core
           CONAN_PKG::abseil)

--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -10,17 +10,17 @@
 #include <vector>
 
 #include "ObjectUtils/CoffFile.h"
-#include "OrbitBase/TestUtils.h"
 #include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
 #include "absl/strings/ascii.h"
 #include "symbol.pb.h"
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
 using orbit_grpc_protos::SymbolInfo;
 using orbit_object_utils::CoffFile;
 using orbit_object_utils::CreateCoffFile;
 using orbit_object_utils::PdbDebugInfo;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 
 TEST(CoffFile, LoadDebugSymbols) {
   std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libtest.dll";

--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -15,18 +15,18 @@
 #include "ObjectUtils/ElfFile.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
 #include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_format.h"
 #include "symbol.pb.h"
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
 using orbit_grpc_protos::SymbolInfo;
 using orbit_object_utils::CreateElfFile;
 using orbit_object_utils::CreateElfFileFromBuffer;
 using orbit_object_utils::ElfFile;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 
 TEST(ElfFile, LoadDebugSymbols) {
   std::filesystem::path file_path =
@@ -404,7 +404,7 @@ TEST(ElfFile, GetLocationOfFunctionNoSubroutine) {
 
   constexpr uint64_t kAddressOfFunction = 0x10a0e0;
   EXPECT_THAT(program.value()->GetDeclarationLocationOfFunction(kAddressOfFunction),
-              orbit_base::HasError("Address not associated with any subroutine"));
+              orbit_test_utils::HasError("Address not associated with any subroutine"));
 
   ErrorMessageOr<orbit_grpc_protos::LineInfo> function_location =
       program.value()->GetLocationOfFunction(kAddressOfFunction);

--- a/src/ObjectUtils/LinuxMapTest.cpp
+++ b/src/ObjectUtils/LinuxMapTest.cpp
@@ -16,11 +16,11 @@
 
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
 #include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
 #include "module.pb.h"
 
-using orbit_base::HasNoError;
+using orbit_test_utils::HasNoError;
 
 namespace orbit_object_utils {
 

--- a/src/ObjectUtils/ObjectFileTest.cpp
+++ b/src/ObjectUtils/ObjectFileTest.cpp
@@ -6,11 +6,11 @@
 #include <gtest/gtest.h>
 
 #include "ObjectUtils/ObjectFile.h"
-#include "OrbitBase/TestUtils.h"
 #include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
 
-using ::orbit_base::HasNoError;
 using ::orbit_object_utils::CreateObjectFile;
+using ::orbit_test_utils::HasNoError;
 
 // Only tests methods that are in the interface for ObjectFile itself. More detailed tests
 // specific to ElfFile and CoffFile are in their own tests.

--- a/src/ObjectUtils/PdbFileTest.cpp
+++ b/src/ObjectUtils/PdbFileTest.cpp
@@ -10,14 +10,14 @@
 #include "ObjectUtils/CoffFile.h"
 #include "ObjectUtils/PdbFile.h"
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/TestUtils.h"
 #include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
 using orbit_grpc_protos::SymbolInfo;
 using orbit_object_utils::CreateCoffFile;
 using orbit_object_utils::PdbDebugInfo;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 using ::testing::ElementsAre;
 
 TEST(PdbFile, LoadDebugSymbols) {

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -120,6 +120,7 @@ endif()
 
 target_link_libraries(OrbitBaseTests PRIVATE
         OrbitBase
+        TestUtils
         GTest::GTest
         GTest::Main)
 

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -9,9 +9,13 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
 #include "OrbitBase/WriteStringToFile.h"
 #include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
+
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
+using orbit_test_utils::HasValue;
 
 namespace orbit_base {
 

--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(OrbitGgpTests PRIVATE
 target_link_libraries(OrbitGgpTests PRIVATE 
           OrbitGgp
           OrbitBase
+          TestUtils
           GTest::QtCoreMain
           Qt5::Core
 )

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -11,15 +11,15 @@
 
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
 #include "OrbitGgp/Client.h"
 #include "OrbitGgp/Instance.h"
 #include "OrbitGgp/SshInfo.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_ggp {
 
-using orbit_base::HasError;
-using orbit_base::HasValue;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasValue;
 
 TEST(OrbitGgpClient, CreateFailing) {
   {

--- a/src/OrbitGgp/InstanceTests.cpp
+++ b/src/OrbitGgp/InstanceTests.cpp
@@ -15,9 +15,9 @@
 #include <utility>
 
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
 #include "OrbitGgp/Error.h"
 #include "OrbitGgp/Instance.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_ggp {
 
@@ -25,21 +25,23 @@ TEST(InstanceTests, GetListFromJson) {
   {
     // invalid json
     const auto json = QString("json").toUtf8();
-    EXPECT_THAT(Instance::GetListFromJson(json), orbit_base::HasError("Unable to parse JSON"));
+    EXPECT_THAT(Instance::GetListFromJson(json),
+                orbit_test_utils::HasError("Unable to parse JSON"));
   }
 
   {
     // empty json
     const auto json = QString("[]").toUtf8();
     const auto empty_instances = Instance::GetListFromJson(json);
-    ASSERT_THAT(empty_instances, orbit_base::HasValue());
+    ASSERT_THAT(empty_instances, orbit_test_utils::HasValue());
     EXPECT_TRUE(empty_instances.value().empty());
   }
 
   {
     // one empty json object
     const auto json = QString("[{}]").toUtf8();
-    EXPECT_THAT(Instance::GetListFromJson(json), orbit_base::HasError("Unable to parse JSON"));
+    EXPECT_THAT(Instance::GetListFromJson(json),
+                orbit_test_utils::HasError("Unable to parse JSON"));
   }
 
   {
@@ -67,7 +69,7 @@ TEST(InstanceTests, GetListFromJson) {
                           "key\":\"object value\"}}]")
                           .toUtf8();
     const auto result = Instance::GetListFromJson(json);
-    EXPECT_THAT(result, orbit_base::HasError("Unable to parse JSON"));
+    EXPECT_THAT(result, orbit_test_utils::HasError("Unable to parse JSON"));
   }
 
   {
@@ -95,7 +97,7 @@ TEST(InstanceTests, GetListFromJson) {
                           "key\":\"object value\"}}]")
                           .toUtf8();
     auto result = Instance::GetListFromJson(json);
-    ASSERT_THAT(result, orbit_base::HasValue());
+    ASSERT_THAT(result, orbit_test_utils::HasValue());
     const QVector<Instance> instances = std::move(result.value());
     ASSERT_EQ(instances.size(), 1);
     const Instance instance = instances[0];

--- a/src/OrbitGgp/SshInfoTests.cpp
+++ b/src/OrbitGgp/SshInfoTests.cpp
@@ -10,8 +10,8 @@
 #include <utility>
 
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
 #include "OrbitGgp/SshInfo.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_ggp {
 
@@ -19,25 +19,25 @@ TEST(SshInfoTest, CreateFromJson) {
   // Empty json
   {
     QByteArray json = QString("").toUtf8();
-    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_base::HasError("Unable to parse JSON"));
+    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_test_utils::HasError("Unable to parse JSON"));
   }
 
   // invalid json
   {
     QByteArray json = QString("{..dfP}").toUtf8();
-    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_base::HasError("Unable to parse JSON"));
+    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_test_utils::HasError("Unable to parse JSON"));
   }
 
   // empty object
   {
     QByteArray json = QString("{}").toUtf8();
-    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_base::HasError("Unable to parse JSON"));
+    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_test_utils::HasError("Unable to parse JSON"));
   }
 
   // object without all necessary fields
   {
     QByteArray json = QString("{\"host\":\"0.0.0.1\"}").toUtf8();
-    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_base::HasError("Unable to parse JSON"));
+    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_test_utils::HasError("Unable to parse JSON"));
   }
 
   // valid object
@@ -57,7 +57,7 @@ TEST(SshInfoTest, CreateFromJson) {
                           "known_hosts\",\"port\":\"11123\",\"user\":\"a username\"}")
                           .toUtf8();
     const auto ssh_info_result = SshInfo::CreateFromJson(json);
-    ASSERT_THAT(ssh_info_result, orbit_base::HasValue());
+    ASSERT_THAT(ssh_info_result, orbit_test_utils::HasValue());
     const SshInfo ssh_info = std::move(ssh_info_result.value());
     EXPECT_EQ(ssh_info.host, "1.1.0.1");
     EXPECT_EQ(ssh_info.key_path,
@@ -78,7 +78,7 @@ TEST(SshInfoTest, CreateFromJson) {
                           "known_hosts\",\"port\":11123,\"user\":\"a username\"}")
                           .toUtf8();
     // This is supposed to fail, since its expected that the port is a string
-    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_base::HasError("Unable to parse JSON"));
+    EXPECT_THAT(SshInfo::CreateFromJson(json), orbit_test_utils::HasError("Unable to parse JSON"));
   }
 }
 

--- a/src/PresetFile/CMakeLists.txt
+++ b/src/PresetFile/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(PresetFileTests PRIVATE
 target_link_libraries(
   PresetFileTests
   PRIVATE PresetFile
+          TestUtils
           GTest::Main
           CONAN_PKG::abseil)
 

--- a/src/PresetFile/PresetFileTest.cpp
+++ b/src/PresetFile/PresetFileTest.cpp
@@ -6,8 +6,8 @@
 #include <gtest/gtest.h>
 
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
 #include "PresetFile/PresetFile.h"
+#include "TestUtils/TestUtils.h"
 #include "preset.pb.h"
 
 namespace orbit_preset_file {
@@ -95,13 +95,13 @@ TEST(PresetFile, SaveAndLoad) {
                      "/path/to/non/existing/module"),
                  "Check failed: IsLegacyFileFormat\\(\\)");
 
-    ASSERT_THAT(original_file.SaveToFile(), orbit_base::HasNoError());
+    ASSERT_THAT(original_file.SaveToFile(), orbit_test_utils::HasNoError());
   }
 
   // Load it
   {
     auto preset_file_or_error = orbit_preset_file::ReadPresetFromFile(temporary_file.file_path());
-    ASSERT_THAT(preset_file_or_error, orbit_base::HasNoError());
+    ASSERT_THAT(preset_file_or_error, orbit_test_utils::HasNoError());
     auto& preset_file = preset_file_or_error.value();
 
     EXPECT_FALSE(preset_file.IsLegacyFileFormat());

--- a/src/Symbols/CMakeLists.txt
+++ b/src/Symbols/CMakeLists.txt
@@ -22,5 +22,5 @@ target_link_libraries(Symbols PUBLIC
 
 add_executable(SymbolsTests)
 target_sources(SymbolsTests PRIVATE SymbolHelperTest.cpp)
-target_link_libraries(SymbolsTests PRIVATE Symbols GTest::Main)
+target_link_libraries(SymbolsTests PRIVATE Symbols TestUtils GTest::Main)
 register_test(SymbolsTests)

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -13,22 +13,22 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/TemporaryFile.h"
-#include "OrbitBase/TestUtils.h"
 #include "OrbitPaths/Paths.h"
 #include "Symbols/SymbolHelper.h"
 #include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
 #include "symbol.pb.h"
 
-using orbit_base::HasError;
 using orbit_grpc_protos::ModuleSymbols;
 using orbit_symbols::SymbolHelper;
+using orbit_test_utils::HasError;
 namespace fs = std::filesystem;
 
 static const std::filesystem::path testdata_directory = orbit_test::GetTestdataDir();
 
 TEST(ReadSymbolsFile, Empty) {
   auto temp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(temp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(temp_file_or_error, orbit_test_utils::HasNoError());
 
   std::vector<fs::path> paths =
       orbit_symbols::ReadSymbolsFile(temp_file_or_error.value().file_path());
@@ -38,14 +38,14 @@ TEST(ReadSymbolsFile, Empty) {
 
 TEST(ReadSymbolsFile, EmptyWithComments) {
   auto temp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(temp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(temp_file_or_error, orbit_test_utils::HasNoError());
 
   ASSERT_THAT(
       orbit_base::WriteFully(temp_file_or_error.value().fd(),
                              "// C:\\Users\\username - Looks like a path but is a comment.\n"
                              "\t// A comment with a sneaky whitespace at the beginning.\n"
                              "\n"),  // Empty line as well
-      orbit_base::HasNoError());
+      orbit_test_utils::HasNoError());
 
   std::vector<fs::path> paths =
       orbit_symbols::ReadSymbolsFile(temp_file_or_error.value().file_path());
@@ -55,11 +55,11 @@ TEST(ReadSymbolsFile, EmptyWithComments) {
 
 TEST(ReadSymbolsFile, OnePath) {
   auto temp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(temp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(temp_file_or_error, orbit_test_utils::HasNoError());
 
   ASSERT_THAT(orbit_base::WriteFully(temp_file_or_error.value().fd(),
                                      orbit_base::GetExecutableDir().string()),
-              orbit_base::HasNoError());
+              orbit_test_utils::HasNoError());
 
   std::vector<fs::path> paths =
       orbit_symbols::ReadSymbolsFile(temp_file_or_error.value().file_path());
@@ -69,14 +69,14 @@ TEST(ReadSymbolsFile, OnePath) {
 
 TEST(ReadSymbolsFile, TwoPaths) {
   auto temp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(temp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(temp_file_or_error, orbit_test_utils::HasNoError());
 
   ASSERT_THAT(orbit_base::WriteFully(temp_file_or_error.value().fd(),
                                      orbit_base::GetExecutableDir().string() + '\n'),
-              orbit_base::HasNoError());
+              orbit_test_utils::HasNoError());
   ASSERT_THAT(
       orbit_base::WriteFully(temp_file_or_error.value().fd(), testdata_directory.string() + '\n'),
-      orbit_base::HasNoError());
+      orbit_test_utils::HasNoError());
 
   std::vector<fs::path> paths =
       orbit_symbols::ReadSymbolsFile(temp_file_or_error.value().file_path());
@@ -86,12 +86,12 @@ TEST(ReadSymbolsFile, TwoPaths) {
 
 TEST(ReadSymbolsFile, OnePathInQuotes) {
   auto temp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(temp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(temp_file_or_error, orbit_test_utils::HasNoError());
 
   ASSERT_THAT(
       orbit_base::WriteFully(temp_file_or_error.value().fd(),
                              absl::StrFormat("\"%s\"\n", orbit_base::GetExecutableDir().string())),
-      orbit_base::HasNoError());
+      orbit_test_utils::HasNoError());
 
   std::vector<fs::path> paths =
       orbit_symbols::ReadSymbolsFile(temp_file_or_error.value().file_path());
@@ -101,12 +101,12 @@ TEST(ReadSymbolsFile, OnePathInQuotes) {
 
 TEST(ReadSymbolsFile, OnePathTrailingWhitespace) {
   auto temp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(temp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(temp_file_or_error, orbit_test_utils::HasNoError());
 
   ASSERT_THAT(
       orbit_base::WriteFully(temp_file_or_error.value().fd(),
                              absl::StrFormat("%s \t\n", orbit_base::GetExecutableDir().string())),
-      orbit_base::HasNoError());
+      orbit_test_utils::HasNoError());
 
   std::vector<fs::path> paths =
       orbit_symbols::ReadSymbolsFile(temp_file_or_error.value().file_path());
@@ -318,12 +318,12 @@ TEST(FileStartsWithDeprecationNote, FileDoesNotExist) {
   ErrorMessageOr<bool> error_result =
       orbit_symbols::FileStartsWithDeprecationNote("non/existing/path/");
 
-  EXPECT_THAT(error_result, orbit_base::HasError("Unable to open file"));
+  EXPECT_THAT(error_result, orbit_test_utils::HasError("Unable to open file"));
 }
 
 TEST(FileStartsWithDeprecationNote, EmptyFile) {
   auto tmp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(tmp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(tmp_file_or_error, orbit_test_utils::HasNoError());
 
   ErrorMessageOr<bool> result =
       orbit_symbols::FileStartsWithDeprecationNote(tmp_file_or_error.value().file_path());
@@ -334,11 +334,11 @@ TEST(FileStartsWithDeprecationNote, EmptyFile) {
 
 TEST(FileStartsWithDeprecationNote, NoDeprecationNote) {
   auto tmp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(tmp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(tmp_file_or_error, orbit_test_utils::HasNoError());
 
   ASSERT_THAT(orbit_base::WriteFully(tmp_file_or_error.value().fd(),
                                      "Some file content.\nC:\\path\n\\\\ This is a comment"),
-              orbit_base::HasNoError());
+              orbit_test_utils::HasNoError());
 
   ErrorMessageOr<bool> result =
       orbit_symbols::FileStartsWithDeprecationNote(tmp_file_or_error.value().file_path());
@@ -349,7 +349,7 @@ TEST(FileStartsWithDeprecationNote, NoDeprecationNote) {
 
 TEST(FileStartsWithDeprecationNote, HasDeprecationNote) {
   auto tmp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(tmp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(tmp_file_or_error, orbit_test_utils::HasNoError());
 
   ASSERT_THAT(orbit_base::WriteFully(
                   tmp_file_or_error.value().fd(),
@@ -357,10 +357,10 @@ TEST(FileStartsWithDeprecationNote, HasDeprecationNote) {
                   "1.68. Please use: Menu > Settings > Symbol Locations...\n// This file can still "
                   "used by Orbit versions prior to 1.68. If that is relevant to you, do not delete "
                   "this file.\n"),
-              orbit_base::HasNoError());
+              orbit_test_utils::HasNoError());
   ASSERT_THAT(
       orbit_base::WriteFully(tmp_file_or_error.value().fd(), "Some more content.\n// Comment"),
-      orbit_base::HasNoError());
+      orbit_test_utils::HasNoError());
 
   ErrorMessageOr<bool> result =
       orbit_symbols::FileStartsWithDeprecationNote(tmp_file_or_error.value().file_path());
@@ -372,16 +372,16 @@ TEST(FileStartsWithDeprecationNote, HasDeprecationNote) {
 TEST(AddDeprecationNoteToFile, FileDoesNotExist) {
   ErrorMessageOr<void> error_result = orbit_symbols::AddDeprecationNoteToFile("non/existing/path/");
 
-  EXPECT_THAT(error_result, orbit_base::HasError("Unable to open file"));
+  EXPECT_THAT(error_result, orbit_test_utils::HasError("Unable to open file"));
 }
 
 TEST(AddDeprecationNoteToFile, AddNote) {
   auto tmp_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_THAT(tmp_file_or_error, orbit_base::HasNoError());
+  ASSERT_THAT(tmp_file_or_error, orbit_test_utils::HasNoError());
   orbit_base::TemporaryFile& file{tmp_file_or_error.value()};
 
   constexpr std::string_view kFileContent = "Some file content.\nC:\\path\n\\\\ This is a comment";
-  ASSERT_THAT(orbit_base::WriteFully(file.fd(), kFileContent), orbit_base::HasNoError());
+  ASSERT_THAT(orbit_base::WriteFully(file.fd(), kFileContent), orbit_test_utils::HasNoError());
 
   {
     ErrorMessageOr<void> add_result = orbit_symbols::AddDeprecationNoteToFile(file.file_path());

--- a/src/TestUtils/CMakeLists.txt
+++ b/src/TestUtils/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+cmake_minimum_required(VERSION 3.15)
+
+add_library(TestUtils INTERFACE)
+target_sources(TestUtils INTERFACE include/TestUtils/TestUtils.h)
+target_include_directories(TestUtils INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_link_libraries(TestUtils INTERFACE CONAN_PKG::abseil GTest::GTest)

--- a/src/TestUtils/include/TestUtils/TestUtils.h
+++ b/src/TestUtils/include/TestUtils/TestUtils.h
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_BASE_TEST_UTILS_H_
-#define ORBIT_BASE_TEST_UTILS_H_
+#ifndef TEST_UTILS_TEST_UTILS_H_
+#define TEST_UTILS_TEST_UTILS_H_
 
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <gmock/gmock.h>
 
-namespace orbit_base {
+namespace orbit_test_utils {
 
 MATCHER(HasValue, absl::StrCat(negation ? "Has no" : "Has a", " value.")) {
   if (arg.has_error()) {
@@ -35,6 +35,6 @@ MATCHER_P(HasError, value,
   return arg.has_error() && absl::StrContains(arg.error().message(), value);
 }
 
-}  // namespace orbit_base
+}  // namespace orbit_test_utils
 
-#endif  // ORBIT_BASE_TEST_UTILS_H_
+#endif  // TEST_UTILS_TEST_UTILS_H_

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -22,15 +22,15 @@
 #include "AccessTraceesMemory.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
-#include "OrbitBase/TestUtils.h"
 #include "RegisterState.h"
+#include "TestUtils/TestUtils.h"
 #include "UserSpaceInstrumentation/Attach.h"
 
 namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_base::HasError;
+using orbit_test_utils::HasError;
 
 AddressRange AddressRangeFromString(const std::string& string_address) {
   AddressRange result;

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -19,16 +19,16 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "UserSpaceInstrumentation/Attach.h"
 
 namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
 using orbit_base::ReadFileToString;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 
 enum class ProtState { kWrite, kExec, kAny };
 

--- a/src/UserSpaceInstrumentation/AttachTest.cpp
+++ b/src/UserSpaceInstrumentation/AttachTest.cpp
@@ -10,13 +10,13 @@
 #include <vector>
 
 #include "OrbitBase/GetProcessIds.h"
-#include "OrbitBase/TestUtils.h"
 #include "TestProcess.h"
+#include "TestUtils/TestUtils.h"
 #include "UserSpaceInstrumentation/Attach.h"
 
 namespace orbit_user_space_instrumentation {
 
-using orbit_base::HasError;
+using orbit_test_utils::HasError;
 
 TEST(AttachTest, AttachAndStopProcess) {
   TestProcess test_process;

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -106,6 +106,7 @@ target_sources(UserSpaceInstrumentationTests PRIVATE
 
 target_link_libraries(UserSpaceInstrumentationTests PRIVATE
         LinuxTracing
+        TestUtils
         UserSpaceInstrumentation
         CONAN_PKG::abseil
         CONAN_PKG::capstone

--- a/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
@@ -12,15 +12,15 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "UserSpaceInstrumentation/Attach.h"
 #include "UserSpaceInstrumentation/ExecuteInProcess.h"
 #include "UserSpaceInstrumentation/InjectLibraryInTracee.h"
 
 namespace orbit_user_space_instrumentation {
 
-using orbit_base::HasNoError;
-using orbit_base::HasValue;
+using orbit_test_utils::HasNoError;
+using orbit_test_utils::HasValue;
 
 TEST(ExecuteInProcessTest, ExecuteInProcess) {
   pid_t pid = fork();

--- a/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
@@ -13,13 +13,13 @@
 #include "MachineCode.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "UserSpaceInstrumentation/Attach.h"
 
 namespace orbit_user_space_instrumentation {
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 
 TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
   pid_t pid = fork();

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -21,7 +21,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
-#include "OrbitBase/TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "UserSpaceInstrumentation/Attach.h"
 #include "UserSpaceInstrumentation/InjectLibraryInTracee.h"
 
@@ -29,8 +29,8 @@ namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 
 void OpenUseAndCloseLibrary(pid_t pid) {
   // Stop the child process using our tooling.

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -19,8 +19,8 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/GetProcessIds.h"
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/TestUtils.h"
 #include "TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "UserSpaceInstrumentation/Attach.h"
 #include "UserSpaceInstrumentation/InstrumentProcess.h"
 
@@ -28,8 +28,8 @@ namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 
 constexpr int kFunctionId = 42;
 

--- a/src/UserSpaceInstrumentation/RegisterStateTest.cpp
+++ b/src/UserSpaceInstrumentation/RegisterStateTest.cpp
@@ -9,14 +9,14 @@
 #include <sys/wait.h>
 
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/TestUtils.h"
 #include "RegisterState.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_base::HasError;
+using orbit_test_utils::HasError;
 
 // Let the parent trace us, write into rax and ymm0, then enter a breakpoint. While the child is
 // stopped the parent modifies the registers and continues the child. The child then reads back the

--- a/src/UserSpaceInstrumentation/TestUtilsTest.cpp
+++ b/src/UserSpaceInstrumentation/TestUtilsTest.cpp
@@ -17,8 +17,8 @@
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/TestUtils.h"
 #include "TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "UserSpaceInstrumentation/Attach.h"
 
 namespace orbit_user_space_instrumentation {

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -32,8 +32,8 @@
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/TestUtils.h"
 #include "TestUtils.h"
+#include "TestUtils/TestUtils.h"
 #include "Trampoline.h"
 #include "UserSpaceInstrumentation/Attach.h"
 #include "UserSpaceInstrumentation/InjectLibraryInTracee.h"
@@ -42,9 +42,9 @@ namespace orbit_user_space_instrumentation {
 
 namespace {
 
-using orbit_base::HasError;
-using orbit_base::HasNoError;
-using orbit_base::HasValue;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
+using orbit_test_utils::HasValue;
 using testing::ElementsAreArray;
 
 static constexpr const char* kEntryPayloadFunctionName = "EntryPayload";


### PR DESCRIPTION
TestUtils.h depends on GTest and hence shouldn't live in OrbitBase
because OrbitBase does not link against GTest. To properly reflect let's
move the header in its own module.

This is done as part of the effort of also using this code internally. That requires
being honest about the dependencies of headers, not only of compilation units.