### PR TITLE
Remove includes of internal gmock headers

### DIFF
--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -6,10 +6,7 @@
 #include <absl/strings/str_split.h>
 #include <absl/time/time.h>
 #include <absl/types/span.h>
-#include <gmock/gmock-actions.h>
-#include <gmock/gmock-cardinalities.h>
-#include <gmock/gmock-matchers.h>
-#include <gmock/gmock-more-actions.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "ClientData/CaptureData.h"

--- a/src/Test/StringViewTest.cpp
+++ b/src/Test/StringViewTest.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
We are supposed to include gmock/gmock.h.