### PR TITLE
Position bugs in TimeGraph

### DIFF
--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -23,7 +23,7 @@ AccessibilityRect TimeGraphAccessibility::AccessibleRect() const {
   const Viewport* viewport = time_graph_->GetViewport();
 
   return AccessibilityRect(0, 0, viewport->WorldToScreenWidth(time_graph_->GetWidth()),
-                           viewport->GetScreenHeight());
+                           viewport->WorldToScreenHeight(time_graph_->GetHeight()));
 }
 
 AccessibilityState TimeGraphAccessibility::AccessibleState() const {

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -173,8 +173,7 @@ void GraphTrack<Dimension>::DrawLabel(Batcher& batcher, TextRenderer& text_rende
   float arrow_width = text_box_size[1] / 2.f;
   Vec2 arrow_box_size(text_box_size[0] + kTextLeftMargin + kTextRightMargin,
                       text_box_size[1] + kTextTopMargin + kTextBottomMargin);
-  bool arrow_is_left_directed =
-      target_pos[0] < viewport_->GetWorldTopLeft()[0] + arrow_box_size[0] + arrow_width;
+  bool arrow_is_left_directed = target_pos[0] < GetPos()[0] + arrow_box_size[0] + arrow_width;
   Vec2 text_box_position(
       target_pos[0] + (arrow_is_left_directed ? arrow_width + kTextLeftMargin
                                               : -arrow_width - kTextRightMargin - text_box_size[0]),

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -169,8 +169,7 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
   const auto time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
   const uint64_t pixel_delta_ns = time_window_ns / viewport_->WorldToScreenWidth(GetWidth());
   const uint64_t min_time_graph_ns = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
-  const float pixel_width_in_world_coords =
-      viewport_->GetVisibleWorldWidth() / viewport_->WorldToScreenWidth(GetWidth());
+  const float pixel_width_in_world_coords = viewport_->ScreenToWorldWidth(1);
 
   uint64_t ignore_until_ns = 0;
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -162,10 +162,8 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
   // We are limiting the maximum and minimum zoom-level, so the real ratio could be different.
   const float capped_ratio = old_scale / layout_.GetScale();
 
-  const float world_height = viewport_->GetVisibleWorldHeight();
-  const float y_mouse_position =
-      viewport_->GetWorldTopLeft()[1] - mouse_relative_position * world_height;
-  const float top_distance = viewport_->GetWorldTopLeft()[1] - y_mouse_position;
+  const float y_mouse_position = GetPos()[1] - mouse_relative_position * GetHeight();
+  const float top_distance = GetPos()[1] - y_mouse_position;
 
   const float new_y_mouse_position = y_mouse_position / capped_ratio;
 
@@ -233,11 +231,10 @@ void TimeGraph::VerticallyMoveIntoView(const TimerInfo& timer_info) {
 void TimeGraph::VerticallyMoveIntoView(Track& track) {
   float pos = track.GetPos()[1];
   float height = track.GetHeight();
-  float world_top_left_y = viewport_->GetWorldTopLeft()[1];
+  float world_top_left_y = GetPos()[1];
 
   float max_world_top_left_y = pos;
-  float min_world_top_left_y =
-      pos + height - viewport_->GetVisibleWorldHeight() + layout_.GetBottomMargin();
+  float min_world_top_left_y = pos + height - GetHeight() + layout_.GetBottomMargin();
   viewport_->SetWorldTopLeftY(
       std::clamp(world_top_left_y, min_world_top_left_y, max_world_top_left_y));
 }
@@ -515,7 +512,7 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
       std::max(capture_max_timestamp_, capture_data_->GetCallstackData().max_time());
 
   time_window_us_ = max_time_us_ - min_time_us_;
-  world_start_x_ = viewport_->GetWorldTopLeft()[0];
+  world_start_x_ = GetPos()[0];
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
@@ -663,11 +660,11 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
   std::vector<float> x_coords;
   x_coords.reserve(timers.size());
 
-  float world_start_x = viewport_->GetWorldTopLeft()[0];
+  float world_start_x = GetPos()[0];
   float world_width = GetWidth();
 
-  float world_start_y = viewport_->GetWorldTopLeft()[1];
-  float world_height = viewport_->GetVisibleWorldHeight();
+  float world_start_y = GetPos()[1];
+  float world_height = GetHeight();
 
   double inv_time_window = 1.0 / GetTimeWindowUs();
 
@@ -682,7 +679,7 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
     Vec2 pos(world_timer_x, world_start_y);
     x_coords.push_back(pos[0]);
 
-    batcher.AddVerticalLine(pos, world_height, GlCanvas::kZValueOverlay,
+    batcher.AddVerticalLine(pos, GetHeight(), GlCanvas::kZValueOverlay,
                             GetThreadColor(timer_info->thread_id()));
   }
 
@@ -783,13 +780,10 @@ void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode pickin
     }
   }
 
-  const float world_start_y = viewport_->GetWorldTopLeft()[1];
-  const float world_height = viewport_->GetVisibleWorldHeight();
-
   // Actually draw the ranges.
   for (const auto& [start_x, end_x] : x_ranges) {
-    const Vec2 pos{start_x, world_start_y};
-    const Vec2 size{end_x - start_x, world_height};
+    const Vec2 pos{start_x, GetPos()[1]};
+    const Vec2 size{end_x - start_x, GetHeight()};
     float z_value = GlCanvas::kZValueIncompleteDataOverlay;
 
     std::unique_ptr<PickingUserData> user_data = nullptr;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -412,7 +412,7 @@ float TimeGraph::GetWorldFromTick(uint64_t time) const {
   if (time_window_us_ > 0) {
     double start = TicksToMicroseconds(capture_min_timestamp_, time) - min_time_us_;
     double normalized_start = start / time_window_us_;
-    auto pos = float(world_start_x_ + normalized_start * world_width_);
+    auto pos = float(world_start_x_ + normalized_start * GetWidth());
     return pos;
   }
 
@@ -428,9 +428,7 @@ double TimeGraph::GetUsFromTick(uint64_t time) const {
 }
 
 uint64_t TimeGraph::GetTickFromWorld(float world_x) const {
-  float visible_width = world_width_;
-  double ratio =
-      visible_width > 0 ? static_cast<double>((world_x - world_start_x_) / visible_width) : 0;
+  double ratio = GetWidth() > 0 ? static_cast<double>((world_x - world_start_x_) / GetWidth()) : 0;
   auto time_span_ns = static_cast<uint64_t>(1000 * GetTime(ratio));
   return capture_min_timestamp_ + time_span_ns;
 }
@@ -518,7 +516,6 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
 
   time_window_us_ = max_time_us_ - min_time_us_;
   world_start_x_ = viewport_->GetWorldTopLeft()[0];
-  world_width_ = GetWidth();
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -518,7 +518,7 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
 
   time_window_us_ = max_time_us_ - min_time_us_;
   world_start_x_ = viewport_->GetWorldTopLeft()[0];
-  world_width_ = viewport_->GetVisibleWorldWidth();
+  world_width_ = GetWidth();
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
@@ -667,7 +667,7 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
   x_coords.reserve(timers.size());
 
   float world_start_x = viewport_->GetWorldTopLeft()[0];
-  float world_width = viewport_->GetVisibleWorldWidth();
+  float world_width = GetWidth();
 
   float world_start_y = viewport_->GetWorldTopLeft()[1];
   float world_height = viewport_->GetVisibleWorldHeight();

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -212,7 +212,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   uint64_t capture_max_timestamp_ = 0;
   double time_window_us_ = 0;
   float world_start_x_ = 0;
-  float world_width_ = 0;
 
   TimeGraphLayout layout_;
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -256,7 +256,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   draw_data.batcher = batcher;
   draw_data.viewport = viewport_;
 
-  draw_data.track_start_x = viewport_->GetWorldTopLeft()[0];
+  draw_data.track_start_x = GetPos()[0];
   draw_data.track_width = GetWidth();
   draw_data.inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
   draw_data.is_collapsed = IsCollapsed();
@@ -425,7 +425,7 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   draw_data.z_offset = z_offset;
   draw_data.batcher = batcher;
   draw_data.viewport = viewport;
-  draw_data.track_start_x = viewport->GetWorldTopLeft()[0];
+  draw_data.track_start_x = time_graph->GetPos()[0];
   draw_data.track_width = track_width;
   draw_data.inv_time_window = 1.0 / time_graph->GetTimeWindowUs();
   draw_data.is_collapsed = is_collapsed;


### PR DESCRIPTION
In this PR we are fixing 2 issues and refactorizing CaptureViewElements to stop using Size and Position from Viewport and replacing them by GetPos and GetSize (which since last week are updated values in all Capture View Elements).

In particular we are solving http://b/197204311, inconsistency between world-related elements and screen ones and http://b/197845628, an inconsistency with thread-states.

Test: Load a Capture. Start/stop a new one