### PR TITLE
Fix position in legend's tooltip

### DIFF
--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -230,12 +230,12 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
 
     text_renderer.AddText(series_names[i].c_str(), x0, y0 + legend_symbol_height / 2.f, text_z,
                           formatting);
-    x0 += legend_text_width + kSpaceBetweenLegendEntries;
-
     auto user_data = std::make_unique<PickingUserData>(
         nullptr, [this, i](PickingId /*id*/) { return GetLegendTooltips(i); });
     batcher.AddShadedBox(Vec2(x0, y0), legend_text_box_size, text_z, kFullyTransparent,
                          std::move(user_data));
+
+    x0 += legend_text_width + kSpaceBetweenLegendEntries;
   }
 }
 


### PR DESCRIPTION
Regression from https://github.com/google/orbit/pull/2670.

We changed the position of the transparent box where we were drawing
the legend, and as it wasn't aligned with the text drawn, we were
showing an incorrect tooltip there.

Fixed it by simply moving together the text and box before modifying the
position.

Screenshots when drawing the transparent boxes with color: 
Previous: http://screen/yMFX5G4NWpEUhVj
After: http://screen/56LMwASmj4Tj4c4

https://b/197844515