### PR TITLE
Revert "Stop using viewport values inside TimeGraph"

### DIFF
--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -23,7 +23,7 @@ AccessibilityRect TimeGraphAccessibility::AccessibleRect() const {
   const Viewport* viewport = time_graph_->GetViewport();
 
   return AccessibilityRect(0, 0, viewport->WorldToScreenWidth(time_graph_->GetWidth()),
-                           viewport->WorldToScreenHeight(time_graph_->GetHeight()));
+                           viewport->GetScreenHeight());
 }
 
 AccessibilityState TimeGraphAccessibility::AccessibleState() const {

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -173,7 +173,8 @@ void GraphTrack<Dimension>::DrawLabel(Batcher& batcher, TextRenderer& text_rende
   float arrow_width = text_box_size[1] / 2.f;
   Vec2 arrow_box_size(text_box_size[0] + kTextLeftMargin + kTextRightMargin,
                       text_box_size[1] + kTextTopMargin + kTextBottomMargin);
-  bool arrow_is_left_directed = target_pos[0] < GetPos()[0] + arrow_box_size[0] + arrow_width;
+  bool arrow_is_left_directed =
+      target_pos[0] < viewport_->GetWorldTopLeft()[0] + arrow_box_size[0] + arrow_width;
   Vec2 text_box_position(
       target_pos[0] + (arrow_is_left_directed ? arrow_width + kTextLeftMargin
                                               : -arrow_width - kTextRightMargin - text_box_size[0]),

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -162,8 +162,10 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
   // We are limiting the maximum and minimum zoom-level, so the real ratio could be different.
   const float capped_ratio = old_scale / layout_.GetScale();
 
-  const float y_mouse_position = GetPos()[1] - mouse_relative_position * GetHeight();
-  const float top_distance = GetPos()[1] - y_mouse_position;
+  const float world_height = viewport_->GetVisibleWorldHeight();
+  const float y_mouse_position =
+      viewport_->GetWorldTopLeft()[1] - mouse_relative_position * world_height;
+  const float top_distance = viewport_->GetWorldTopLeft()[1] - y_mouse_position;
 
   const float new_y_mouse_position = y_mouse_position / capped_ratio;
 
@@ -231,10 +233,11 @@ void TimeGraph::VerticallyMoveIntoView(const TimerInfo& timer_info) {
 void TimeGraph::VerticallyMoveIntoView(Track& track) {
   float pos = track.GetPos()[1];
   float height = track.GetHeight();
-  float world_top_left_y = GetPos()[1];
+  float world_top_left_y = viewport_->GetWorldTopLeft()[1];
 
   float max_world_top_left_y = pos;
-  float min_world_top_left_y = pos + height - GetHeight() + layout_.GetBottomMargin();
+  float min_world_top_left_y =
+      pos + height - viewport_->GetVisibleWorldHeight() + layout_.GetBottomMargin();
   viewport_->SetWorldTopLeftY(
       std::clamp(world_top_left_y, min_world_top_left_y, max_world_top_left_y));
 }
@@ -512,7 +515,7 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
       std::max(capture_max_timestamp_, capture_data_->GetCallstackData().max_time());
 
   time_window_us_ = max_time_us_ - min_time_us_;
-  world_start_x_ = GetPos()[0];
+  world_start_x_ = viewport_->GetWorldTopLeft()[0];
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
@@ -660,11 +663,11 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
   std::vector<float> x_coords;
   x_coords.reserve(timers.size());
 
-  float world_start_x = GetPos()[0];
+  float world_start_x = viewport_->GetWorldTopLeft()[0];
   float world_width = GetWidth();
 
-  float world_start_y = GetPos()[1];
-  float world_height = GetHeight();
+  float world_start_y = viewport_->GetWorldTopLeft()[1];
+  float world_height = viewport_->GetVisibleWorldHeight();
 
   double inv_time_window = 1.0 / GetTimeWindowUs();
 
@@ -679,7 +682,7 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
     Vec2 pos(world_timer_x, world_start_y);
     x_coords.push_back(pos[0]);
 
-    batcher.AddVerticalLine(pos, GetHeight(), GlCanvas::kZValueOverlay,
+    batcher.AddVerticalLine(pos, world_height, GlCanvas::kZValueOverlay,
                             GetThreadColor(timer_info->thread_id()));
   }
 
@@ -780,10 +783,13 @@ void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode pickin
     }
   }
 
+  const float world_start_y = viewport_->GetWorldTopLeft()[1];
+  const float world_height = viewport_->GetVisibleWorldHeight();
+
   // Actually draw the ranges.
   for (const auto& [start_x, end_x] : x_ranges) {
-    const Vec2 pos{start_x, GetPos()[1]};
-    const Vec2 size{end_x - start_x, GetHeight()};
+    const Vec2 pos{start_x, world_start_y};
+    const Vec2 size{end_x - start_x, world_height};
     float z_value = GlCanvas::kZValueIncompleteDataOverlay;
 
     std::unique_ptr<PickingUserData> user_data = nullptr;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -256,7 +256,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   draw_data.batcher = batcher;
   draw_data.viewport = viewport_;
 
-  draw_data.track_start_x = GetPos()[0];
+  draw_data.track_start_x = viewport_->GetWorldTopLeft()[0];
   draw_data.track_width = GetWidth();
   draw_data.inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
   draw_data.is_collapsed = IsCollapsed();
@@ -425,7 +425,7 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   draw_data.z_offset = z_offset;
   draw_data.batcher = batcher;
   draw_data.viewport = viewport;
-  draw_data.track_start_x = time_graph->GetPos()[0];
+  draw_data.track_start_x = viewport->GetWorldTopLeft()[0];
   draw_data.track_width = track_width;
   draw_data.inv_time_window = 1.0 / time_graph->GetTimeWindowUs();
   draw_data.is_collapsed = is_collapsed;


### PR DESCRIPTION
This reverts commit 6c92e87096bd6b516937f6b788785c9fa3324c88.

Issue found by @reichlfl. As it is only a refactor which is causing 2 issues in the release branch, we will revert it. The precondition written in the commit message is false, the values we are changing there aren't the same.

http://b/198269730

