### PR TITLE
Add crashpad_handler to Linux package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -293,6 +293,7 @@ chmod -v 4775 /opt/developer/tools/OrbitService
         self.copy("OrbitClientGgp", src="bin/", dst="bin")
         self.copy("OrbitClientGgp.exe", src="bin/", dst="bin")
         self.copy("OrbitClientGgp.debug", src="bin/", dst="bin")
+        self.copy("crashpad_handler", src="bin/", dst="bin")
         self.copy("crashpad_handler.exe", src="bin/", dst="bin")
         self.copy("NOTICE")
         self.copy("NOTICE.Chromium")


### PR DESCRIPTION
Make sure we add the crashpad_handler executable when packaging Linux
binaries through `conan package -bf build_clang9_relwithdebinfo .`.