### PR TITLE
Avoid Class template argument deduction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                       -Werror=thread-safety)
 
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
-    add_compile_options(-Werror=defaulted-function-deleted)
+    add_compile_options(-Werror=defaulted-function-deleted
+                        # Required by Google-internal builds
+                        -Werror=ctad-maybe-unsupported)
   endif()
 
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/src/CaptureEventProducer/CaptureEventProducerTest.cpp
+++ b/src/CaptureEventProducer/CaptureEventProducerTest.cpp
@@ -83,7 +83,7 @@ class CaptureEventProducerTest : public ::testing::Test {
   std::optional<CaptureEventProducerImpl> producer_;
 };
 
-constexpr std::chrono::duration kWaitMessagesSentDuration = std::chrono::milliseconds(25);
+constexpr std::chrono::milliseconds kWaitMessagesSentDuration{25};
 
 const orbit_grpc_protos::CaptureOptions kFakeCaptureOptions = [] {
   orbit_grpc_protos::CaptureOptions capture_options;

--- a/src/CaptureEventProducer/LockFreeBufferCaptureEventProducerTest.cpp
+++ b/src/CaptureEventProducer/LockFreeBufferCaptureEventProducerTest.cpp
@@ -73,7 +73,7 @@ class LockFreeBufferCaptureEventProducerTest : public ::testing::Test {
   std::optional<LockFreeBufferCaptureEventProducerImpl> buffer_producer_;
 };
 
-constexpr std::chrono::duration kWaitMessagesSentDuration = std::chrono::milliseconds(25);
+constexpr std::chrono::milliseconds kWaitMessagesSentDuration{25};
 
 }  // namespace
 

--- a/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
+++ b/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
@@ -164,7 +164,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
         }
       }
 
-      static constexpr std::chrono::duration kSleepOnEmptyQueue = std::chrono::microseconds{1000};
+      constexpr std::chrono::microseconds kSleepOnEmptyQueue{1000};
       // Wait for lock_free_queue_ to fill up with new CaptureEvents.
       std::this_thread::sleep_for(kSleepOnEmptyQueue);
     }

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -60,12 +60,12 @@ class CallstackData {
       const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
 
   [[nodiscard]] uint64_t max_time() const {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
     return max_time_;
   }
 
   [[nodiscard]] uint64_t min_time() const {
-    std::lock_guard lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
     return min_time_;
   }
 

--- a/src/ClientServices/CrashManager.cpp
+++ b/src/ClientServices/CrashManager.cpp
@@ -40,7 +40,7 @@ void CrashManagerImpl::CrashOrbitService(CrashOrbitServiceRequest_CrashType cras
   request.set_crash_type(crash_type);
 
   grpc::ClientContext context;
-  std::chrono::time_point deadline =
+  std::chrono::system_clock::time_point deadline =
       std::chrono::system_clock::now() + std::chrono::milliseconds(kTimeoutMilliseconds);
   context.set_deadline(deadline);
 

--- a/src/ClientServices/ProcessClient.cpp
+++ b/src/ClientServices/ProcessClient.cpp
@@ -37,7 +37,7 @@ constexpr uint64_t kGrpcDefaultTimeoutMilliseconds = 3000;
 std::unique_ptr<grpc::ClientContext> CreateContext(
     uint64_t timeout_milliseconds = kGrpcDefaultTimeoutMilliseconds) {
   auto context = std::make_unique<grpc::ClientContext>();
-  std::chrono::time_point deadline =
+  std::chrono::system_clock::time_point deadline =
       std::chrono::system_clock::now() + std::chrono::milliseconds(timeout_milliseconds);
   context->set_deadline(deadline);
 

--- a/src/CodeViewer/OwningDialog.cpp
+++ b/src/CodeViewer/OwningDialog.cpp
@@ -29,7 +29,7 @@ void OwningDialog::ClearOwningHeatmap() {
 QPointer<OwningDialog> OpenAndDeleteOnClose(std::unique_ptr<OwningDialog> dialog) {
   dialog->open();
   dialog->setAttribute(Qt::WA_DeleteOnClose);
-  return QPointer{dialog.release()};
+  return QPointer<OwningDialog>{dialog.release()};
 }
 
 }  // namespace orbit_code_viewer

--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -30,11 +30,11 @@ namespace {
 void RunProcessWithTimeout(const QString& program, const QStringList& arguments,
                            std::chrono::milliseconds timeout, QObject* parent,
                            const std::function<void(ErrorMessageOr<QByteArray>)>& callback) {
-  const auto process = QPointer{new QProcess{parent}};
+  const auto process = QPointer<QProcess>{new QProcess{parent}};
   process->setProgram(program);
   process->setArguments(arguments);
 
-  const auto timeout_timer = QPointer{new QTimer{parent}};
+  const auto timeout_timer = QPointer<QTimer>{new QTimer{parent}};
 
   QObject::connect(timeout_timer, &QTimer::timeout, parent,
                    [process, timeout_timer, timeout, callback]() {

--- a/src/OrbitGl/FramePointerValidatorClient.cpp
+++ b/src/OrbitGl/FramePointerValidatorClient.cpp
@@ -55,7 +55,8 @@ void FramePointerValidatorClient::AnalyzeModules(const std::vector<const ModuleD
       function_info->set_size(function->size());
     }
     grpc::ClientContext context;
-    std::chrono::time_point deadline = std::chrono::system_clock::now() + std::chrono::minutes(1);
+    std::chrono::system_clock::time_point deadline =
+        std::chrono::system_clock::now() + std::chrono::minutes(1);
     context.set_deadline(deadline);
 
     // careful this is the synchronous call (maybe async is better)

--- a/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
@@ -196,7 +196,7 @@ QPointer<AnnotatingSourceCodeDialog> OpenAndDeleteOnClose(
     std::unique_ptr<AnnotatingSourceCodeDialog> dialog) {
   dialog->open();
   dialog->setAttribute(Qt::WA_DeleteOnClose);
-  return QPointer{dialog.release()};
+  return QPointer<AnnotatingSourceCodeDialog>{dialog.release()};
 }
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1203,7 +1203,7 @@ void OrbitMainWindow::OpenCapture(const std::string& filepath) {
       ~Qt::WindowCloseButtonHint & ~Qt::WindowSystemMenuHint);
   loading_capture_dialog->setFixedSize(loading_capture_dialog->size());
 
-  auto loading_capture_cancel_button = QPointer{new QPushButton{this}};
+  auto loading_capture_cancel_button = QPointer<QPushButton>{new QPushButton{this}};
   loading_capture_cancel_button->setText("Cancel");
   QObject::connect(loading_capture_dialog, &QProgressDialog::canceled, this,
                    [this]() { app_->OnLoadCaptureCancelRequested(); });

--- a/src/OrbitTest/OrbitTestShortLivedThreads.cpp
+++ b/src/OrbitTest/OrbitTestShortLivedThreads.cpp
@@ -24,7 +24,7 @@ void Worker(int ttl_ms) {
       break;
     }
   }
-  std::lock_guard lock(g_joinable_mutex);
+  std::lock_guard<std::mutex> lock(g_joinable_mutex);
   g_joinable_threads.emplace(std::this_thread::get_id());
 }
 
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
     // Join the finished threads.
     for (auto& t : ts) {
       auto id = t.get_id();
-      std::lock_guard lock(g_joinable_mutex);
+      std::lock_guard<std::mutex> lock(g_joinable_mutex);
       if (g_joinable_threads.count(id) != 0) {
         g_joinable_threads.erase(id);
         t.join();

--- a/src/OrbitVulkanLayer/DeviceManagerTest.cpp
+++ b/src/OrbitVulkanLayer/DeviceManagerTest.cpp
@@ -23,14 +23,14 @@ class MockDispatchTable {
 
 TEST(DeviceManager, AnUntrackedDeviceCannotBeQueried) {
   MockDispatchTable dispatch_table;
-  DeviceManager manager(&dispatch_table);
+  DeviceManager<MockDispatchTable> manager(&dispatch_table);
   VkDevice device = {};
   EXPECT_DEATH({ (void)manager.GetPhysicalDeviceOfLogicalDevice(device); }, "");
 }
 
 TEST(DeviceManager, DevicePropertiesCannotBeQueriedForUntrackedDevices) {
   MockDispatchTable dispatch_table;
-  DeviceManager manager(&dispatch_table);
+  DeviceManager<MockDispatchTable> manager(&dispatch_table);
   VkPhysicalDevice device = {};
   EXPECT_DEATH({ (void)manager.GetPhysicalDeviceProperties(device); }, "");
 }
@@ -44,7 +44,7 @@ static void MockGetPhysicalDeviceProperties(VkPhysicalDevice,
 
 TEST(DeviceManager, ATrackedDeviceCanBeQueried) {
   MockDispatchTable dispatch_table;
-  DeviceManager manager(&dispatch_table);
+  DeviceManager<MockDispatchTable> manager(&dispatch_table);
   VkDevice logical_device = {};
   VkPhysicalDevice physical_device = {};
 
@@ -64,7 +64,7 @@ TEST(DeviceManager, ATrackedDeviceCanBeQueried) {
 
 TEST(DeviceManager, UntrackingRemovesTrackedDevice) {
   MockDispatchTable dispatch_table;
-  DeviceManager manager(&dispatch_table);
+  DeviceManager<MockDispatchTable> manager(&dispatch_table);
   VkDevice logical_device = {};
   VkPhysicalDevice physical_device = {};
 
@@ -79,7 +79,7 @@ TEST(DeviceManager, UntrackingRemovesTrackedDevice) {
 
 TEST(DeviceManager, UntrackingRemovesDeviceProperties) {
   MockDispatchTable dispatch_table;
-  DeviceManager manager(&dispatch_table);
+  DeviceManager<MockDispatchTable> manager(&dispatch_table);
   VkDevice logical_device = {};
   VkPhysicalDevice physical_device = {};
 

--- a/src/OrbitVulkanLayer/TimerQueryPoolTest.cpp
+++ b/src/OrbitVulkanLayer/TimerQueryPoolTest.cpp
@@ -36,7 +36,7 @@ PFN_vkResetQueryPoolEXT dummy_reset_query_pool_function =
 TEST(TimerQueryPool, ATimerQueryPoolMustGetInitialized) {
   MockDispatchTable dispatch_table;
   uint32_t num_slots = 4;
-  TimerQueryPool query_pool(&dispatch_table, num_slots);
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, num_slots);
   VkDevice device = {};
 
   uint32_t slot_index = 32;

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
@@ -80,7 +80,7 @@ const std::string VulkanLayerProducerImplTest::kInternedString3 = "c";
 const uint64_t VulkanLayerProducerImplTest::kExpectedInternedString3Key =
     std::hash<std::string>{}(kInternedString3);
 
-constexpr std::chrono::duration kWaitMessagesSentDuration = std::chrono::milliseconds(25);
+constexpr std::chrono::milliseconds kWaitMessagesSentDuration{25};
 
 const orbit_grpc_protos::CaptureOptions kFakeCaptureOptions = [] {
   orbit_grpc_protos::CaptureOptions capture_options;

--- a/src/QtUtils/FutureWatcher.cpp
+++ b/src/QtUtils/FutureWatcher.cpp
@@ -38,7 +38,7 @@ FutureWatcher::Reason FutureWatcher::WaitFor(
   }
 
   const orbit_base::FutureRegisterContinuationResult result = future.RegisterContinuation(
-      [loop = QPointer{&loop}] { QMetaObject::invokeMethod(loop, &QEventLoop::quit); });
+      [loop = QPointer<QEventLoop>{&loop}] { QMetaObject::invokeMethod(loop, &QEventLoop::quit); });
 
   if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
     return Reason::kFutureCompleted;

--- a/src/Service/ProducerSideServiceImplTest.cpp
+++ b/src/Service/ProducerSideServiceImplTest.cpp
@@ -151,7 +151,7 @@ class ProducerSideServiceImplTest : public ::testing::Test {
   std::optional<FakeProducer> fake_producer_;
 };
 
-constexpr std::chrono::duration kWaitMessagesSentDuration = std::chrono::milliseconds(25);
+constexpr std::chrono::milliseconds kWaitMessagesSentDuration{25};
 
 void ExpectDurationBetweenMs(const std::function<void(void)>& action, uint64_t min_ms,
                              uint64_t max_ms) {

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -86,11 +86,13 @@ void DeferToBackgroundThreadAndWait(QObject* context, Func&& func) {
   QEventLoop waiting_loop;  // This event loop processes main thread events while we wait for the
                             // background thread to finish executing func();
 
-  QMetaObject::invokeMethod(
-      context, [func = std::forward<Func>(func), waiting_loop = QPointer{&waiting_loop}]() mutable {
-        func();
-        if (waiting_loop) QMetaObject::invokeMethod(waiting_loop, &QEventLoop::quit);
-      });
+  QMetaObject::invokeMethod(context,
+                            [func = std::forward<Func>(func),
+                             waiting_loop = QPointer<QEventLoop>{&waiting_loop}]() mutable {
+                              func();
+                              if (waiting_loop)
+                                QMetaObject::invokeMethod(waiting_loop, &QEventLoop::quit);
+                            });
 
   waiting_loop.exec();
 }


### PR DESCRIPTION
To make the code compile in environments that enable `-Werror=ctad-maybe-unsupported` I removed all the object constructions that need CTAD without deduction guides and added the flag to our build.

Please push back on this if you have arguments for not doing this.