### PR TITLE
Remove non-existing variable from conan profile

### DIFF
--- a/third_party/conan/configs/windows/profiles/msvc2019_common
+++ b/third_party/conan/configs/windows/profiles/msvc2019_common
@@ -20,4 +20,4 @@ OrbitProfiler:system_qt=False
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LD_FLAGS
-gtest:CXXFLAGS=$CXX_FLAGS -std=c++17
+gtest:CXXFLAGS=-std=c++17


### PR DESCRIPTION
This was a copy-and-paste error from adding the `-std=c++17` option for
the gtest build.

The $CXX_FLAGS conan variable does not exist in the Windows build - we
only need that on Linux builds.