### PR TITLE
Exclude third_party changes from clang-format check

### DIFF
--- a/kokoro/checks/clang_format/check.sh
+++ b/kokoro/checks/clang_format/check.sh
@@ -6,6 +6,7 @@
 
 # Fail on any error.
 set -euo pipefail
+shopt -s extglob
 
 readonly REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" >/dev/null 2>&1 && pwd )"
 readonly SCRIPT="/mnt/kokoro/checks/clang_format/check.sh"
@@ -30,7 +31,7 @@ if [ "$0" == "$SCRIPT" ]; then
   # Use origin/main as reference branch, if not specified by kokoro
   REFERENCE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-main}"
   MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on main this PR was branched from.
-  FORMATTING_DIFF="$(git diff -U0 --no-color --relative --diff-filter=r $MERGE_BASE | clang-format-diff-9 -p1)"
+  FORMATTING_DIFF="$(git diff -U0 --no-color --relative --diff-filter=r $MERGE_BASE -- !(third_party|build*) | clang-format-diff-9 -p1)"
 
   if [ -n "$FORMATTING_DIFF" ]; then
     echo "clang-format determined the following necessary changes to your PR:"


### PR DESCRIPTION
This was a bug introduced when we moved to clang-format-diff.

I tested this by adding temporary commits to this PR. Works as expected - third_party is ignore while format errors in src/ are still detected.