### PR TITLE
Ensure infinite loops have side effects

### DIFF
--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -76,7 +76,10 @@ TEST(AccessTraceesMemoryTest, ReadFailures) {
   CHECK(pid != -1);
   if (pid == 0) {
     // Child just runs an endless loop.
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 
@@ -119,7 +122,10 @@ TEST(AccessTraceesMemoryTest, WriteFailures) {
   CHECK(pid != -1);
   if (pid == 0) {
     // Child just runs an endless loop.
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 
@@ -170,7 +176,10 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   CHECK(pid != -1);
   if (pid == 0) {
     // Child just runs an endless loop.
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -73,7 +73,10 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
   CHECK(pid != -1);
   if (pid == 0) {
     // Child just runs an endless loop.
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 
@@ -135,7 +138,10 @@ TEST(AllocateInTraceeTest, AutomaticAllocateAndFree) {
   CHECK(pid != -1);
   if (pid == 0) {
     // Child just runs an endless loop.
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 

--- a/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
@@ -26,7 +26,10 @@ TEST(ExecuteInProcessTest, ExecuteInProcess) {
   pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 

--- a/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
@@ -25,7 +25,10 @@ TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
   pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 

--- a/src/UserSpaceInstrumentation/FindFunctionAddressTest.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddressTest.cpp
@@ -18,7 +18,10 @@ TEST(FindFunctionAddressTest, FindFunctionAddress) {
   pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -95,7 +95,10 @@ TEST(InjectLibraryInTraceeTest, OpenUseAndCloseLibraryInUserCode) {
   pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -72,7 +72,10 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
   const pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
 
@@ -81,7 +84,10 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
   CHECK(pid_tracer != -1);
   if (pid_tracer == 0) {
     ptrace(PTRACE_ATTACH, pid, nullptr, nullptr);
+    volatile uint64_t counter = 0;
     while (true) {
+      ++counter;  // Endless loops without side effects are UB and recent versions of clang optimize
+                  // it away.
     }
   }
   bool already_tracing = false;
@@ -129,7 +135,9 @@ TEST(InstrumentProcessTest, Instrument) {
   const pid_t pid_process_1 = fork();
   CHECK(pid_process_1 != -1);
   if (pid_process_1 == 0) {
-    int sum = 0;
+    // Endless loops without side effects are UB and recent versions of clang optimize
+    // it away. Making `sum` volatile avoids that problem.
+    volatile int sum = 0;
     while (true) {
       sum += SomethingToInstrument();
     }
@@ -152,7 +160,9 @@ TEST(InstrumentProcessTest, Instrument) {
   const pid_t pid_process_2 = fork();
   CHECK(pid_process_2 != -1);
   if (pid_process_2 == 0) {
-    int sum = 0;
+    // Endless loops without side effects are UB and recent versions of clang optimize
+    // it away. Making `sum` volatile avoids that problem.
+    volatile int sum = 0;
     while (true) {
       sum += SomethingToInstrument();
     }

--- a/src/UserSpaceInstrumentation/TestUtilsTest.cpp
+++ b/src/UserSpaceInstrumentation/TestUtilsTest.cpp
@@ -34,7 +34,9 @@ TEST(TestUtilTest, Disassemble) {
   pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {
-    int sum = 0;
+    // Endless loops without side effects are UB and recent versions of clang optimize
+    // it away. Making `sum` volatile avoids that problem.
+    volatile int sum = 0;
     while (true) {
       sum += SomethingToDisassemble();
     }

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -269,7 +269,9 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
   CHECK(pid != -1);
   if (pid == 0) {
     uint64_t sum = 0;
-    int i = 0;
+    // Endless loops without side effects are UB and recent versions of clang optimize
+    // it away. Making `i` volatile avoids that problem.
+    volatile int i = 0;
     while (true) {
       i = (i + 1) & 3;
       sum += DoubleAndIncrement(i);
@@ -560,7 +562,9 @@ class InstrumentFunctionTest : public testing::Test {
     pid_ = fork();
     CHECK(pid_ != -1);
     if (pid_ == 0) {
-      uint64_t sum = 0;
+      // Endless loops without side effects are UB and recent versions of clang optimize
+      // it away. Making `sum` volatile avoids that problem.
+      volatile uint64_t sum = 0;
       while (true) {
         sum += (*function_pointer)();
       }
@@ -959,9 +963,11 @@ TEST_F(InstrumentFunctionTest, CheckIntParameters) {
   pid_ = fork();
   CHECK(pid_ != -1);
   if (pid_ == 0) {
-    uint64_t sum = 0;
+    volatile uint64_t sum = 0;
     while (true) {
       sum += CheckIntParameters(0, 0, 0, 0, 0, 0, 0, 0);
+      // Endless loops without side effects are UB and recent versions of clang optimize
+      // it away.
     }
   }
   PrepareInstrumentation("EntryPayloadClobberParameterRegisters", kExitPayloadFunctionName);
@@ -989,7 +995,9 @@ TEST_F(InstrumentFunctionTest, CheckFloatParameters) {
   pid_ = fork();
   CHECK(pid_ != -1);
   if (pid_ == 0) {
-    uint64_t sum = 0;
+    // Endless loops without side effects are UB and recent versions of clang optimize
+    // it away. Making `sum` volatile avoids that problem.
+    volatile uint64_t sum = 0;
     while (true) {
       sum += CheckFloatParameters(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
     }
@@ -1021,7 +1029,9 @@ TEST_F(InstrumentFunctionTest, CheckM256iParameters) {
   pid_ = fork();
   CHECK(pid_ != -1);
   if (pid_ == 0) {
-    uint64_t sum = 0;
+    // Endless loops without side effects are UB and recent versions of clang optimize
+    // it away. Making `sum` volatile avoids that problem.
+    volatile uint64_t sum = 0;
     while (true) {
       sum +=
           CheckM256iParameters(_mm256_set1_epi64x(0), _mm256_set1_epi64x(0), _mm256_set1_epi64x(0),


### PR DESCRIPTION
Infinite loops without any side effects invoke undefined behaviour
(see https://en.cppreference.com/w/cpp/language/ub for details).

So this introduces some side effects in the inifinite loops of the
user space instrumentation tests.

This came up because clang-trunk started to optimize the whole
loop away.