### PR TITLE
Extract repeated definitions of MockTracerListener to a single .h file

### DIFF
--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -76,6 +76,7 @@ target_sources(LinuxTracingTests PRIVATE
         LeafFunctionCallManagerTest.cpp
         LinuxTracingUtilsTest.cpp
         LostAndDiscardedEventVisitorTest.cpp
+        MockTracerListener.h
         PerfEventProcessorTest.cpp
         PerfEventQueueTest.cpp
         SwitchesStatesNamesVisitorTest.cpp

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -14,35 +14,15 @@
 
 #include "GpuTracepointVisitor.h"
 #include "KernelTracepoints.h"
+#include "MockTracerListener.h"
 #include "OrbitBase/Logging.h"
 #include "PerfEvent.h"
 #include "PerfEventRecords.h"
-#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 
 namespace orbit_linux_tracing {
 
 namespace {
-
-class MockTracerListener : public orbit_tracing_interface::TracerListener {
- public:
-  MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
-  MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));
-  MOCK_METHOD(void, OnFunctionCall, (orbit_grpc_protos::FunctionCall), (override));
-  MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::FullGpuJob full_gpu_job), (override));
-  MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
-  MOCK_METHOD(void, OnThreadNamesSnapshot, (orbit_grpc_protos::ThreadNamesSnapshot), (override));
-  MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
-  MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::FullAddressInfo), (override));
-  MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::FullTracepointEvent), (override));
-  MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
-  MOCK_METHOD(void, OnModulesSnapshot, (orbit_grpc_protos::ModulesSnapshot), (override));
-  MOCK_METHOD(void, OnErrorsWithPerfEventOpenEvent,
-              (orbit_grpc_protos::ErrorsWithPerfEventOpenEvent), (override));
-  MOCK_METHOD(void, OnLostPerfRecordsEvent, (orbit_grpc_protos::LostPerfRecordsEvent), (override));
-  MOCK_METHOD(void, OnOutOfOrderEventsDiscardedEvent,
-              (orbit_grpc_protos::OutOfOrderEventsDiscardedEvent), (override));
-};
 
 class GpuTracepointVisitorTest : public ::testing::Test {
  protected:

--- a/src/LinuxTracing/LostAndDiscardedEventVisitorTest.cpp
+++ b/src/LinuxTracing/LostAndDiscardedEventVisitorTest.cpp
@@ -11,34 +11,14 @@
 #include <utility>
 
 #include "LostAndDiscardedEventVisitor.h"
+#include "MockTracerListener.h"
 #include "OrbitBase/Logging.h"
 #include "PerfEvent.h"
-#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 
 namespace orbit_linux_tracing {
 
 namespace {
-
-class MockTracerListener : public orbit_tracing_interface::TracerListener {
- public:
-  MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
-  MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));
-  MOCK_METHOD(void, OnFunctionCall, (orbit_grpc_protos::FunctionCall), (override));
-  MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::FullGpuJob full_gpu_job), (override));
-  MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
-  MOCK_METHOD(void, OnThreadNamesSnapshot, (orbit_grpc_protos::ThreadNamesSnapshot), (override));
-  MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
-  MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::FullAddressInfo), (override));
-  MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::FullTracepointEvent), (override));
-  MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
-  MOCK_METHOD(void, OnModulesSnapshot, (orbit_grpc_protos::ModulesSnapshot), (override));
-  MOCK_METHOD(void, OnErrorsWithPerfEventOpenEvent,
-              (orbit_grpc_protos::ErrorsWithPerfEventOpenEvent), (override));
-  MOCK_METHOD(void, OnLostPerfRecordsEvent, (orbit_grpc_protos::LostPerfRecordsEvent), (override));
-  MOCK_METHOD(void, OnOutOfOrderEventsDiscardedEvent,
-              (orbit_grpc_protos::OutOfOrderEventsDiscardedEvent), (override));
-};
 
 [[nodiscard]] std::unique_ptr<LostPerfEvent> MakeFakeLostPerfEvent(uint64_t previous_timestamp_ns,
                                                                    uint64_t timestamp_ns) {

--- a/src/LinuxTracing/MockTracerListener.h
+++ b/src/LinuxTracing/MockTracerListener.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LINUX_TRACING_MOCK_TRACER_LISTENER_H_
+#define LINUX_TRACING_MOCK_TRACER_LISTENER_H_
+
+#include "TracingInterface/TracerListener.h"
+
+namespace orbit_linux_tracing {
+
+class MockTracerListener : public orbit_tracing_interface::TracerListener {
+ public:
+  MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
+  MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));
+  MOCK_METHOD(void, OnFunctionCall, (orbit_grpc_protos::FunctionCall), (override));
+  MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::FullGpuJob full_gpu_job), (override));
+  MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
+  MOCK_METHOD(void, OnThreadNamesSnapshot, (orbit_grpc_protos::ThreadNamesSnapshot), (override));
+  MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
+  MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::FullAddressInfo), (override));
+  MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::FullTracepointEvent), (override));
+  MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
+  MOCK_METHOD(void, OnModulesSnapshot, (orbit_grpc_protos::ModulesSnapshot), (override));
+  MOCK_METHOD(void, OnErrorsWithPerfEventOpenEvent,
+              (orbit_grpc_protos::ErrorsWithPerfEventOpenEvent), (override));
+  MOCK_METHOD(void, OnLostPerfRecordsEvent, (orbit_grpc_protos::LostPerfRecordsEvent), (override));
+  MOCK_METHOD(void, OnOutOfOrderEventsDiscardedEvent,
+              (orbit_grpc_protos::OutOfOrderEventsDiscardedEvent), (override));
+};
+
+}  // namespace orbit_linux_tracing
+
+#endif  // LINUX_TRACING_MOCK_TRACER_LISTENER_H_

--- a/src/LinuxTracing/SwitchesStatesNamesVisitorTest.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitorTest.cpp
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "MockTracerListener.h"
 #include "PerfEvent.h"
 #include "SwitchesStatesNamesVisitor.h"
 
@@ -21,26 +22,6 @@ TEST(SwitchesStatesNamesVisitor, NeedsTracerListener) {
 }
 
 namespace {
-
-class MockTracerListener : public orbit_tracing_interface::TracerListener {
- public:
-  MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
-  MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));
-  MOCK_METHOD(void, OnFunctionCall, (orbit_grpc_protos::FunctionCall), (override));
-  MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::FullGpuJob), (override));
-  MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
-  MOCK_METHOD(void, OnThreadNamesSnapshot, (orbit_grpc_protos::ThreadNamesSnapshot), (override));
-  MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
-  MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::FullAddressInfo), (override));
-  MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::FullTracepointEvent), (override));
-  MOCK_METHOD(void, OnModulesSnapshot, (orbit_grpc_protos::ModulesSnapshot), (override));
-  MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
-  MOCK_METHOD(void, OnErrorsWithPerfEventOpenEvent,
-              (orbit_grpc_protos::ErrorsWithPerfEventOpenEvent), (override));
-  MOCK_METHOD(void, OnLostPerfRecordsEvent, (orbit_grpc_protos::LostPerfRecordsEvent), (override));
-  MOCK_METHOD(void, OnOutOfOrderEventsDiscardedEvent,
-              (orbit_grpc_protos::OutOfOrderEventsDiscardedEvent), (override));
-};
 
 class SwitchesStatesNamesVisitorTest : public ::testing::Test {
  protected:

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -8,6 +8,7 @@
 
 #include "LibunwindstackMaps.h"
 #include "LibunwindstackUnwinder.h"
+#include "MockTracerListener.h"
 #include "UprobesUnwindingVisitor.h"
 
 using ::testing::_;
@@ -42,26 +43,6 @@ class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
               (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
                const void*, uint64_t, bool, size_t),
               (override));
-};
-
-class MockTracerListener : public orbit_tracing_interface::TracerListener {
- public:
-  MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
-  MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));
-  MOCK_METHOD(void, OnFunctionCall, (orbit_grpc_protos::FunctionCall), (override));
-  MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::FullGpuJob), (override));
-  MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
-  MOCK_METHOD(void, OnThreadNamesSnapshot, (orbit_grpc_protos::ThreadNamesSnapshot), (override));
-  MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
-  MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::FullAddressInfo), (override));
-  MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::FullTracepointEvent), (override));
-  MOCK_METHOD(void, OnModulesSnapshot, (orbit_grpc_protos::ModulesSnapshot), (override));
-  MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
-  MOCK_METHOD(void, OnErrorsWithPerfEventOpenEvent,
-              (orbit_grpc_protos::ErrorsWithPerfEventOpenEvent), (override));
-  MOCK_METHOD(void, OnLostPerfRecordsEvent, (orbit_grpc_protos::LostPerfRecordsEvent), (override));
-  MOCK_METHOD(void, OnOutOfOrderEventsDiscardedEvent,
-              (orbit_grpc_protos::OutOfOrderEventsDiscardedEvent), (override));
 };
 
 class MockUprobesReturnAddressManager : public UprobesReturnAddressManager {


### PR DESCRIPTION
These were identical across the tests of the four `PerfEventVisitors`.