### PR TITLE
Set up introspection in CaptureServiceImpl, not TracingHandler

### DIFF
--- a/src/Api/LockFreeApiEventProducer.cpp
+++ b/src/Api/LockFreeApiEventProducer.cpp
@@ -5,90 +5,19 @@
 #include "LockFreeApiEventProducer.h"
 
 namespace orbit_api {
-namespace {
-
-inline void CreateCaptureEvent(const ApiScopeStart& scope_start,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_scope_start();
-  scope_start.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiScopeStop& scope_stop,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_scope_stop();
-  scope_stop.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiScopeStartAsync& scope_start_async,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_scope_start_async();
-  scope_start_async.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiScopeStopAsync& scope_stop_async,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_scope_stop_async();
-  scope_stop_async.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiStringEvent& string_event,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_string_event();
-  string_event.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiTrackDouble& track_double,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_track_double();
-  track_double.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiTrackFloat& track_float,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_track_float();
-  track_float.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiTrackInt& track_int,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_track_int();
-  track_int.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiTrackInt64& track_int64,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_track_int64();
-  track_int64.CopyToGrpcProto(api_event);
-}
-
-inline void CreateCaptureEvent(const ApiTrackUint& track_uint,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_track_uint();
-  track_uint.CopyToGrpcProto(api_event);
-}
-inline void CreateCaptureEvent(const ApiTrackUint64& track_uint64,
-                               orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
-  auto* api_event = capture_event->mutable_api_track_uint64();
-  track_uint64.CopyToGrpcProto(api_event);
-}
-
-// The variant type `ApiEventVariant` requires to contain `std::monostate` in order to be default-
-// constructable. However, that state is never expected to be called in the visitor.
-inline void CreateCaptureEvent(const std::monostate& /*unused*/,
-                               orbit_grpc_protos::ProducerCaptureEvent* /*unused*/) {
-  UNREACHABLE();
-}
-
-}  // namespace
 
 orbit_grpc_protos::ProducerCaptureEvent* LockFreeApiEventProducer::TranslateIntermediateEvent(
     ApiEventVariant&& raw_api_event, google::protobuf::Arena* arena) {
   auto* capture_event =
       google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
 
-  std::visit([capture_event](const auto& event) { CreateCaptureEvent(event, capture_event); },
-             raw_api_event);
+  std::visit(
+      [capture_event](const auto& event) {
+        orbit_api::FillProducerCaptureEventFromApiEvent(event, capture_event);
+      },
+      raw_api_event);
 
   return capture_event;
 }
+
 }  // namespace orbit_api

--- a/src/ApiUtils/Event.cpp
+++ b/src/ApiUtils/Event.cpp
@@ -105,4 +105,77 @@ void ApiTrackFloat::CopyToGrpcProto(orbit_grpc_protos::ApiTrackFloat* grpc_proto
   grpc_proto->set_data(data);
   grpc_proto->set_color_rgba(color_rgba);
 }
+
+void FillProducerCaptureEventFromApiEvent(const ApiScopeStart& scope_start,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_scope_start();
+  scope_start.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiScopeStop& scope_stop,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_scope_stop();
+  scope_stop.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiScopeStartAsync& scope_start_async,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_scope_start_async();
+  scope_start_async.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiScopeStopAsync& scope_stop_async,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_scope_stop_async();
+  scope_stop_async.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiStringEvent& string_event,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_string_event();
+  string_event.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackDouble& track_double,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_double();
+  track_double.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackFloat& track_float,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_float();
+  track_float.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackInt& track_int,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_int();
+  track_int.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackInt64& track_int64,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_int64();
+  track_int64.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackUint& track_uint,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_uint();
+  track_uint.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackUint64& track_uint64,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_api_track_uint64();
+  track_uint64.CopyToGrpcProto(api_event);
+}
+
+void FillProducerCaptureEventFromApiEvent(
+    const std::monostate& /*monostate*/,
+    orbit_grpc_protos::ProducerCaptureEvent* /*capture_event*/) {
+  UNREACHABLE();
+}
+
 }  // namespace orbit_api

--- a/src/ApiUtils/include/ApiUtils/Event.h
+++ b/src/ApiUtils/include/ApiUtils/Event.h
@@ -205,6 +205,45 @@ using ApiEventVariant =
                  ApiStringEvent, ApiTrackDouble, ApiTrackFloat, ApiTrackInt, ApiTrackInt64,
                  ApiTrackUint, ApiTrackUint64>;
 
+void FillProducerCaptureEventFromApiEvent(const ApiScopeStart& scope_start,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiScopeStop& scope_stop,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiScopeStartAsync& scope_start_async,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiScopeStopAsync& scope_stop_async,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiStringEvent& string_event,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackDouble& track_double,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackFloat& track_float,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackInt& track_int,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackInt64& track_int64,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackUint& track_uint,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillProducerCaptureEventFromApiEvent(const ApiTrackUint64& track_uint64,
+                                          orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+// The variant type `ApiEventVariant` requires to contain `std::monostate` in order to be default-
+// constructable. However, that state is never expected to be called in the visitor.
+void FillProducerCaptureEventFromApiEvent(
+    const std::monostate& /*monostate*/,
+    orbit_grpc_protos::ProducerCaptureEvent* /*capture_event*/);
+
 }  // namespace orbit_api
 
 #endif  // ORBIT_API_UTILS_EVENT_H_

--- a/src/GrpcProtos/include/GrpcProtos/Constants.h
+++ b/src/GrpcProtos/include/GrpcProtos/Constants.h
@@ -17,6 +17,7 @@ constexpr int kMissingInfo = -1;
 constexpr uint64_t kRootProducerId = 0;
 constexpr uint64_t kLinuxTracingProducerId = 1;
 constexpr uint64_t kMemoryInfoProducerId = 2;
+constexpr uint64_t kIntrospectionProducerId = 3;
 constexpr uint64_t kExternalProducerStartingId = 1024;
 
 enum class UnwindingMethod { kDwarfUnwinding, kFramePointerUnwinding };

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -24,7 +24,8 @@ using orbit_introspection::IntrospectionEventCallback;
 using orbit_introspection::IntrospectionListener;
 
 ABSL_CONST_INIT static absl::Mutex global_introspection_mutex(absl::kConstInit);
-ABSL_CONST_INIT static IntrospectionListener* global_introspection_listener = nullptr;
+ABSL_CONST_INIT static IntrospectionListener* global_introspection_listener
+    ABSL_GUARDED_BY(global_introspection_mutex) = nullptr;
 
 // Tracing uses the same function table used by the Orbit API, but specifies its own functions.
 orbit_api_v1 g_orbit_api_v1;

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -20,20 +20,20 @@
 #include "OrbitBase/ThreadUtils.h"
 
 using orbit_api::ApiEventVariant;
-using orbit_introspection::TracingEventCallback;
-using orbit_introspection::TracingListener;
+using orbit_introspection::IntrospectionEventCallback;
+using orbit_introspection::IntrospectionListener;
 
-ABSL_CONST_INIT static absl::Mutex global_tracing_mutex(absl::kConstInit);
-ABSL_CONST_INIT static TracingListener* global_tracing_listener = nullptr;
+ABSL_CONST_INIT static absl::Mutex global_introspection_mutex(absl::kConstInit);
+ABSL_CONST_INIT static IntrospectionListener* global_introspection_listener = nullptr;
 
 // Tracing uses the same function table used by the Orbit API, but specifies its own functions.
 orbit_api_v1 g_orbit_api_v1;
 
 namespace orbit_introspection {
 
-void InitializeTracing();
+void InitializeIntrospection();
 
-TracingListener::TracingListener(TracingEventCallback callback)
+IntrospectionListener::IntrospectionListener(IntrospectionEventCallback callback)
     : user_callback_{std::move(callback)} {
   constexpr size_t kMinNumThreads = 1;
   constexpr size_t kMaxNumThreads = 1;
@@ -41,21 +41,21 @@ TracingListener::TracingListener(TracingEventCallback callback)
       orbit_base::ThreadPool::Create(kMinNumThreads, kMaxNumThreads, absl::Milliseconds(500));
 
   // Activate listener (only one listener instance is supported).
-  absl::MutexLock lock(&global_tracing_mutex);
+  absl::MutexLock lock(&global_introspection_mutex);
   CHECK(!IsActive());
-  InitializeTracing();
-  global_tracing_listener = this;
+  InitializeIntrospection();
+  global_introspection_listener = this;
   active_ = true;
   shutdown_initiated_ = false;
 }
 
-TracingListener::~TracingListener() {
+IntrospectionListener::~IntrospectionListener() {
   // Communicate that the thread pool will be shut down before shutting down
   // the thread pool itself.
   // Note that this is required, as otherwise, we might allow scheduling
   // new events on the already shut down thread pool.
   {
-    absl::MutexLock lock(&global_tracing_mutex);
+    absl::MutexLock lock(&global_introspection_mutex);
     CHECK(IsActive());
     shutdown_initiated_ = true;
   }
@@ -64,9 +64,9 @@ TracingListener::~TracingListener() {
   thread_pool_->Wait();
 
   // Deactivate and destroy the listener.
-  absl::MutexLock lock(&global_tracing_mutex);
+  absl::MutexLock lock(&global_introspection_mutex);
   active_ = false;
-  global_tracing_listener = nullptr;
+  global_introspection_listener = nullptr;
 }
 
 }  // namespace orbit_introspection
@@ -80,19 +80,19 @@ struct ScopeToggle {
 };
 }  // namespace
 
-void TracingListener::DeferApiEventProcessing(const orbit_api::ApiEventVariant& api_event) {
+void IntrospectionListener::DeferApiEventProcessing(const orbit_api::ApiEventVariant& api_event) {
   // Prevent reentry to avoid feedback loop.
   thread_local bool is_internal_update = false;
   if (is_internal_update) return;
 
   // User callback is called from a worker thread to minimize contention on instrumented threads.
-  absl::MutexLock lock(&global_tracing_mutex);
+  absl::MutexLock lock(&global_introspection_mutex);
   if (IsShutdownInitiated()) return;
-  global_tracing_listener->thread_pool_->Schedule([api_event]() {
+  global_introspection_listener->thread_pool_->Schedule([api_event]() {
     ScopeToggle scope_toggle(&is_internal_update, true);
-    absl::MutexLock lock(&global_tracing_mutex);
+    absl::MutexLock lock(&global_introspection_mutex);
     if (!IsActive()) return;
-    global_tracing_listener->user_callback_(api_event);
+    global_introspection_listener->user_callback_(api_event);
   });
 }
 
@@ -106,7 +106,7 @@ void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_
   }
   orbit_api::ApiScopeStart api_scope_start{process_id, thread_id, timestamp_ns,  name,
                                            color,      group_id,  caller_address};
-  TracingListener::DeferApiEventProcessing(api_scope_start);
+  IntrospectionListener::DeferApiEventProcessing(api_scope_start);
 }
 
 void orbit_api_stop() {
@@ -114,7 +114,7 @@ void orbit_api_stop() {
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiScopeStop api_scope_stop{process_id, thread_id, timestamp_ns};
-  TracingListener::DeferApiEventProcessing(api_scope_stop);
+  IntrospectionListener::DeferApiEventProcessing(api_scope_stop);
 }
 
 void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
@@ -125,7 +125,7 @@ void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color)
   orbit_api::ApiScopeStartAsync api_scope_start_async{process_id, thread_id, timestamp_ns,  name,
                                                       id,         color,     return_address};
 
-  TracingListener::DeferApiEventProcessing(api_scope_start_async);
+  IntrospectionListener::DeferApiEventProcessing(api_scope_start_async);
 }
 
 void orbit_api_stop_async(uint64_t id) {
@@ -133,7 +133,7 @@ void orbit_api_stop_async(uint64_t id) {
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiScopeStopAsync api_scope_stop_async{process_id, thread_id, timestamp_ns, id};
-  TracingListener::DeferApiEventProcessing(api_scope_stop_async);
+  IntrospectionListener::DeferApiEventProcessing(api_scope_stop_async);
 }
 
 void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color) {
@@ -141,7 +141,7 @@ void orbit_api_async_string(const char* str, uint64_t id, orbit_api_color color)
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiStringEvent api_string_event{process_id, thread_id, timestamp_ns, str, id, color};
-  TracingListener::DeferApiEventProcessing(api_string_event);
+  IntrospectionListener::DeferApiEventProcessing(api_string_event);
 }
 
 void orbit_api_track_int(const char* name, int value, orbit_api_color color) {
@@ -149,7 +149,7 @@ void orbit_api_track_int(const char* name, int value, orbit_api_color color) {
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackInt api_track{process_id, thread_id, timestamp_ns, name, value, color};
-  TracingListener::DeferApiEventProcessing(api_track);
+  IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_int64(const char* name, int64_t value, orbit_api_color color) {
@@ -157,7 +157,7 @@ void orbit_api_track_int64(const char* name, int64_t value, orbit_api_color colo
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackInt64 api_track{process_id, thread_id, timestamp_ns, name, value, color};
-  TracingListener::DeferApiEventProcessing(api_track);
+  IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_uint(const char* name, uint32_t value, orbit_api_color color) {
@@ -165,7 +165,7 @@ void orbit_api_track_uint(const char* name, uint32_t value, orbit_api_color colo
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackUint api_track{process_id, thread_id, timestamp_ns, name, value, color};
-  TracingListener::DeferApiEventProcessing(api_track);
+  IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_uint64(const char* name, uint64_t value, orbit_api_color color) {
@@ -173,7 +173,7 @@ void orbit_api_track_uint64(const char* name, uint64_t value, orbit_api_color co
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackUint64 api_track{process_id, thread_id, timestamp_ns, name, value, color};
-  TracingListener::DeferApiEventProcessing(api_track);
+  IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_float(const char* name, float value, orbit_api_color color) {
@@ -181,7 +181,7 @@ void orbit_api_track_float(const char* name, float value, orbit_api_color color)
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackFloat api_track{process_id, thread_id, timestamp_ns, name, value, color};
-  TracingListener::DeferApiEventProcessing(api_track);
+  IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 void orbit_api_track_double(const char* name, double value, orbit_api_color color) {
@@ -189,12 +189,12 @@ void orbit_api_track_double(const char* name, double value, orbit_api_color colo
   uint32_t thread_id = orbit_base::GetCurrentThreadId();
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiTrackDouble api_track{process_id, thread_id, timestamp_ns, name, value, color};
-  TracingListener::DeferApiEventProcessing(api_track);
+  IntrospectionListener::DeferApiEventProcessing(api_track);
 }
 
 namespace orbit_introspection {
 
-void InitializeTracing() {
+void InitializeIntrospection() {
   if (g_orbit_api_v1.initialized != 0) return;
   g_orbit_api_v1.start = &orbit_api_start_v1;
   g_orbit_api_v1.stop = &orbit_api_stop;

--- a/src/Introspection/IntrospectionSmokeTest.cpp
+++ b/src/Introspection/IntrospectionSmokeTest.cpp
@@ -65,7 +65,7 @@ TEST(Tracing, Scopes) {
   std::once_flag thread_id_set_flag;
   uint32_t callback_thread_id = 0;
   {
-    TracingListener tracing_listener(
+    IntrospectionListener tracing_listener(
         [&scopes_by_thread_id, &thread_id_set_flag,
          &callback_thread_id](const orbit_api::ApiEventVariant& api_event) {
           // Check that callback is called from a single thread.

--- a/src/Introspection/include/Introspection/Introspection.h
+++ b/src/Introspection/include/Introspection/Introspection.h
@@ -26,6 +26,11 @@ class IntrospectionListener {
   explicit IntrospectionListener(IntrospectionEventCallback callback);
   ~IntrospectionListener();
 
+  IntrospectionListener(const IntrospectionListener& other) = delete;
+  IntrospectionListener& operator=(const IntrospectionListener& other) = delete;
+  IntrospectionListener(IntrospectionListener&& other) = delete;
+  IntrospectionListener& operator=(IntrospectionListener&& other) = delete;
+
   static void DeferApiEventProcessing(const orbit_api::ApiEventVariant& api_event);
   [[nodiscard]] static bool IsActive() { return active_; }
   [[nodiscard]] static bool IsShutdownInitiated() { return shutdown_initiated_; }

--- a/src/Introspection/include/Introspection/Introspection.h
+++ b/src/Introspection/include/Introspection/Introspection.h
@@ -19,19 +19,19 @@
 
 namespace orbit_introspection {
 
-using TracingEventCallback = std::function<void(const orbit_api::ApiEventVariant& api_event)>;
+using IntrospectionEventCallback = std::function<void(const orbit_api::ApiEventVariant& api_event)>;
 
-class TracingListener {
+class IntrospectionListener {
  public:
-  explicit TracingListener(TracingEventCallback callback);
-  ~TracingListener();
+  explicit IntrospectionListener(IntrospectionEventCallback callback);
+  ~IntrospectionListener();
 
   static void DeferApiEventProcessing(const orbit_api::ApiEventVariant& api_event);
-  [[nodiscard]] inline static bool IsActive() { return active_; }
-  [[nodiscard]] inline static bool IsShutdownInitiated() { return shutdown_initiated_; }
+  [[nodiscard]] static bool IsActive() { return active_; }
+  [[nodiscard]] static bool IsShutdownInitiated() { return shutdown_initiated_; }
 
  private:
-  TracingEventCallback user_callback_ = nullptr;
+  IntrospectionEventCallback user_callback_ = nullptr;
   std::shared_ptr<orbit_base::ThreadPool> thread_pool_ = {};
   inline static bool active_ = false;
   inline static bool shutdown_initiated_ = true;

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -219,7 +219,7 @@ void IntrospectionWindow::StartIntrospection() {
   CHECK(!IsIntrospecting());
   set_draw_help(false);
   CreateTimeGraph(capture_data_.get());
-  introspection_listener_ = std::make_unique<orbit_introspection::TracingListener>(
+  introspection_listener_ = std::make_unique<orbit_introspection::IntrospectionListener>(
       [this](const orbit_api::ApiEventVariant& api_event_variant) {
         std::visit(
             [this](const auto& api_event) { HandleCaptureEvent(api_event, &api_event_processor_); },

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -39,7 +39,7 @@ class IntrospectionWindow : public CaptureWindow {
   [[nodiscard]] const char* GetHelpText() const override;
   [[nodiscard]] bool ShouldAutoZoom() const override;
 
-  std::unique_ptr<orbit_introspection::TracingListener> introspection_listener_;
+  std::unique_ptr<orbit_introspection::IntrospectionListener> introspection_listener_;
   std::unique_ptr<orbit_client_data::CaptureData> capture_data_;
 
   std::unique_ptr<orbit_capture_client::CaptureListener> capture_listener_;

--- a/src/Service/TracingHandler.cpp
+++ b/src/Service/TracingHandler.cpp
@@ -113,7 +113,7 @@ void CreateCaptureEvent(const std::monostate& /*unused*/, ProducerCaptureEvent* 
 }  // namespace
 
 void TracingHandler::SetupIntrospection() {
-  orbit_tracing_listener_ = std::make_unique<orbit_introspection::TracingListener>(
+  introspection_listener_ = std::make_unique<orbit_introspection::IntrospectionListener>(
       [this](const orbit_api::ApiEventVariant& api_event_variant) {
         ProducerCaptureEvent capture_event;
         std::visit([&capture_event](

--- a/src/Service/TracingHandler.h
+++ b/src/Service/TracingHandler.h
@@ -57,11 +57,6 @@ class TracingHandler : public orbit_tracing_interface::TracerListener {
  private:
   ProducerEventProcessor* producer_event_processor_;
   std::unique_ptr<orbit_tracing_interface::Tracer> tracer_;
-
-  // Manual instrumentation tracing listener.
-  std::unique_ptr<orbit_introspection::IntrospectionListener> introspection_listener_;
-
-  void SetupIntrospection();
 };
 
 }  // namespace orbit_service

--- a/src/Service/TracingHandler.h
+++ b/src/Service/TracingHandler.h
@@ -59,7 +59,7 @@ class TracingHandler : public orbit_tracing_interface::TracerListener {
   std::unique_ptr<orbit_tracing_interface::Tracer> tracer_;
 
   // Manual instrumentation tracing listener.
-  std::unique_ptr<orbit_introspection::TracingListener> orbit_tracing_listener_;
+  std::unique_ptr<orbit_introspection::IntrospectionListener> introspection_listener_;
 
   void SetupIntrospection();
 };


### PR DESCRIPTION
#### Minor tweaks to CaptureServiceImpl.cpp
#### Rename orbit_introspection::TracingListener to IntrospectionListener
For clarity, "tracing" being generic.
#### Remove duplication of CreateCaptureEvent (for ApiEvents) and rename
Extract to `ApiUtils`/`Event`, rename to `FillProducercaptureEventFromApiEvent`.
#### Set up introspection in CaptureServiceImpl, not TracingHandler
Introspection affects all parts of capture collection, not only specifically
`perf_event_open`, so it didn't belong in `TracingHandler`.

Test: Capture Trata with introspection. Capture `OrbitTest` with introspection
and manual instrumentation at the same time.
#### Add ABSL_GUARDED_BY to global_introspection_listener