### PR TITLE
Add new HasValueThat matcher and tests for matchers

### DIFF
--- a/src/TestUtils/CMakeLists.txt
+++ b/src/TestUtils/CMakeLists.txt
@@ -8,3 +8,7 @@ add_library(TestUtils INTERFACE)
 target_sources(TestUtils INTERFACE include/TestUtils/TestUtils.h)
 target_include_directories(TestUtils INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 target_link_libraries(TestUtils INTERFACE CONAN_PKG::abseil GTest::GTest)
+
+add_executable(TestUtilsTests TestUtilsTest.cpp)
+target_link_libraries(TestUtilsTests PRIVATE TestUtils GTest::Main)
+register_test(TestUtilsTests)

--- a/src/TestUtils/TestUtilsTest.cpp
+++ b/src/TestUtils/TestUtilsTest.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/Logging.h"
+#include "TestUtils/TestUtils.h"
+
+static ErrorMessageOr<std::string> ReturnString() { return "This is fine."; }
+
+static ErrorMessageOr<std::string> ReturnError() { return ErrorMessage{"This is not fine."}; }
+
+namespace orbit_test_utils {
+
+TEST(TestUtils, HasValue) {
+  EXPECT_THAT(ReturnString(), HasValue());
+  EXPECT_THAT(ReturnString(), HasValue("This is fine."));
+  EXPECT_THAT(ReturnString(), HasValue(testing::Eq("This is fine.")));
+  EXPECT_THAT(ReturnString(), HasValue(testing::EndsWith("fine.")));
+
+  EXPECT_THAT(ReturnError(), testing::Not(HasValue()));
+  EXPECT_THAT(ReturnError(), testing::Not(HasValue(testing::Eq("This is fine."))));
+}
+
+TEST(TestUtils, HasError) {
+  EXPECT_THAT(ReturnString(), testing::Not(HasError("This is not fine")));
+  EXPECT_THAT(ReturnString(), HasValue("This is fine."));
+  EXPECT_THAT(ReturnString(), HasValue(testing::Eq("This is fine.")));
+  EXPECT_THAT(ReturnString(), HasValue(testing::EndsWith("fine.")));
+
+  EXPECT_THAT(ReturnError(), HasError("This is not fine."));
+  EXPECT_THAT(ReturnError(), HasError("not fine."));
+  EXPECT_THAT(ReturnError(), testing::Not(HasError("Other error message")));
+}
+
+TEST(TestUtils, HasNoError) {
+  EXPECT_THAT(ReturnString(), HasNoError());
+  EXPECT_THAT(ReturnError(), testing::Not(HasNoError()));
+}
+
+}  // namespace orbit_test_utils

--- a/src/TestUtils/include/TestUtils/TestUtils.h
+++ b/src/TestUtils/include/TestUtils/TestUtils.h
@@ -19,6 +19,13 @@ MATCHER(HasValue, absl::StrCat(negation ? "Has no" : "Has a", " value.")) {
   return arg.has_value();
 }
 
+MATCHER_P(HasValue, value_matcher, absl::StrCat(negation ? "Has no" : "Has a", " value.")) {
+  if (arg.has_error()) {
+    *result_listener << "Error: " << arg.error().message();
+  }
+  return arg.has_value() && ExplainMatchResult(value_matcher, arg.value(), result_listener);
+}
+
 MATCHER(HasNoError, absl::StrCat(negation ? "Has an" : "Has no", " error.")) {
   if (arg.has_error()) {
     *result_listener << "Error: " << arg.error().message();


### PR DESCRIPTION
This adds a matcher `HasValueThat` that takes a matcher for the stored
value as an argument.

This also adds an overload to the existing `HasValue` matcher which
behaves the same as the new `HasValueThat` matcher.

And since this is all getting more and more complex I added some tests
for the matchers.