### PR TITLE
Various adjustments to the user space instrumentation tests

### DIFF
--- a/src/TestUtils/CMakeLists.txt
+++ b/src/TestUtils/CMakeLists.txt
@@ -8,3 +8,7 @@ add_library(TestUtils INTERFACE)
 target_sources(TestUtils INTERFACE include/TestUtils/TestUtils.h)
 target_include_directories(TestUtils INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 target_link_libraries(TestUtils INTERFACE CONAN_PKG::abseil GTest::GTest)
+
+add_executable(TestUtilsTests TestUtilsTest.cpp)
+target_link_libraries(TestUtilsTests PRIVATE TestUtils GTest::Main)
+register_test(TestUtilsTests)

--- a/src/TestUtils/TestUtilsTest.cpp
+++ b/src/TestUtils/TestUtilsTest.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/Logging.h"
+#include "TestUtils/TestUtils.h"
+
+static ErrorMessageOr<std::string> ReturnString() { return "This is fine."; }
+
+static ErrorMessageOr<std::string> ReturnError() { return ErrorMessage{"This is not fine."}; }
+
+namespace orbit_test_utils {
+
+TEST(TestUtils, HasValue) {
+  EXPECT_THAT(ReturnString(), HasValue());
+  EXPECT_THAT(ReturnString(), HasValue("This is fine."));
+  EXPECT_THAT(ReturnString(), HasValue(testing::Eq("This is fine.")));
+  EXPECT_THAT(ReturnString(), HasValue(testing::EndsWith("fine.")));
+
+  EXPECT_THAT(ReturnError(), testing::Not(HasValue()));
+  EXPECT_THAT(ReturnError(), testing::Not(HasValue(testing::Eq("This is fine."))));
+}
+
+TEST(TestUtils, HasError) {
+  EXPECT_THAT(ReturnString(), testing::Not(HasError("This is not fine")));
+  EXPECT_THAT(ReturnString(), HasValue("This is fine."));
+  EXPECT_THAT(ReturnString(), HasValue(testing::Eq("This is fine.")));
+  EXPECT_THAT(ReturnString(), HasValue(testing::EndsWith("fine.")));
+
+  EXPECT_THAT(ReturnError(), HasError("This is not fine."));
+  EXPECT_THAT(ReturnError(), HasError("not fine."));
+  EXPECT_THAT(ReturnError(), testing::Not(HasError("Other error message")));
+}
+
+TEST(TestUtils, HasNoError) {
+  EXPECT_THAT(ReturnString(), HasNoError());
+  EXPECT_THAT(ReturnError(), testing::Not(HasNoError()));
+}
+
+}  // namespace orbit_test_utils

--- a/src/TestUtils/include/TestUtils/TestUtils.h
+++ b/src/TestUtils/include/TestUtils/TestUtils.h
@@ -19,6 +19,13 @@ MATCHER(HasValue, absl::StrCat(negation ? "Has no" : "Has a", " value.")) {
   return arg.has_value();
 }
 
+MATCHER_P(HasValue, value_matcher, absl::StrCat(negation ? "Has no" : "Has a", " value.")) {
+  if (arg.has_error()) {
+    *result_listener << "Error: " << arg.error().message();
+  }
+  return arg.has_value() && ExplainMatchResult(value_matcher, arg.value(), result_listener);
+}
+
 MATCHER(HasNoError, absl::StrCat(negation ? "Has an" : "Has no", " error.")) {
   if (arg.has_error()) {
     *result_listener << "Error: " << arg.error().message();

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -93,6 +93,8 @@ target_sources(UserSpaceInstrumentationTests PRIVATE
         ExecuteInProcessTest.cpp
         ExecuteMachineCodeTest.cpp
         FindFunctionAddressTest.cpp
+        GetTestLibLibraryPath.cpp
+        GetTestLibLibraryPath.h
         InjectLibraryInTraceeTest.cpp
         InstrumentProcessTest.cpp
         MachineCodeTest.cpp

--- a/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
@@ -7,8 +7,10 @@
 #include <sys/wait.h>
 
 #include <csignal>
+#include <filesystem>
 #include <string>
 
+#include "GetTestLibLibraryPath.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
@@ -35,9 +37,11 @@ TEST(ExecuteInProcessTest, ExecuteInProcess) {
 
   CHECK(!AttachAndStopProcess(pid).has_error());
 
+  auto library_path_or_error = GetTestLibLibraryPath();
+  ASSERT_THAT(library_path_or_error, HasNoError());
+  std::filesystem::path library_path = std::move(library_path_or_error.value());
+
   // Load dynamic lib into tracee.
-  const std::string kLibName = "libUserSpaceInstrumentationTestLib.so";
-  const std::string library_path = orbit_base::GetExecutableDir() / ".." / "lib" / kLibName;
   auto library_handle_or_error = DlopenInTracee(pid, library_path, RTLD_NOW);
   CHECK(library_handle_or_error.has_value());
   void* library_handle = library_handle_or_error.value();

--- a/src/UserSpaceInstrumentation/GetTestLibLibraryPath.cpp
+++ b/src/UserSpaceInstrumentation/GetTestLibLibraryPath.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <filesystem>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/File.h"
+#include "OrbitBase/Result.h"
+
+namespace orbit_user_space_instrumentation {
+
+ErrorMessageOr<std::filesystem::path> GetTestLibLibraryPath() {
+  // copybara:strip_begin(The library is in a different place internally)
+  constexpr std::string_view kLibName = "libUserSpaceInstrumentationTestLib.so";
+  const std::string library_path = orbit_base::GetExecutableDir() / ".." / "lib" / kLibName;
+  /* copybara:strip_end_and_replace
+  const std::string library_path = "@@LIB_USER_SPACE_INSTRUMENTATION_TEST_LIB_PATH@@";
+  */
+
+  OUTCOME_TRY(orbit_base::OpenFileForReading(library_path));
+
+  return library_path;
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/GetTestLibLibraryPath.h
+++ b/src/UserSpaceInstrumentation/GetTestLibLibraryPath.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef USER_SPACE_INSTRUMENTATION_GET_TEST_LIB_LIBRARY_PATH
+#define USER_SPACE_INSTRUMENTATION_GET_TEST_LIB_LIBRARY_PATH
+
+#include <filesystem>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_user_space_instrumentation {
+
+ErrorMessageOr<std::filesystem::path> GetTestLibLibraryPath();
+
+}  // namespace orbit_user_space_instrumentation
+
+#endif  // USER_SPACE_INSTRUMENTATION_GET_TEST_LIB_LIBRARY_PATH

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -40,6 +40,9 @@ ErrorMessageOr<std::filesystem::path> GetLibraryPath() {
   const std::filesystem::path exe_dir = orbit_base::GetExecutableDir();
   std::vector<std::filesystem::path> potential_paths = {exe_dir / kLibName,
                                                         exe_dir / ".." / "lib" / kLibName};
+  /* copybara:insert(In internal tests the library is in a different place)
+  potential_paths.emplace_back("@@LIB_ORBIT_USER_SPACE_INSTRUMENTATION_PATH@@");
+  */
   for (const auto& path : potential_paths) {
     if (std::filesystem::exists(path)) {
       return path;

--- a/src/UserSpaceInstrumentation/TestUtils.cpp
+++ b/src/UserSpaceInstrumentation/TestUtils.cpp
@@ -45,7 +45,7 @@ AddressRange GetFunctionAbsoluteAddressRangeOrDie(std::string_view function_name
       return {address, address + size};
     }
   }
-  UNREACHABLE();
+  FATAL("GetFunctionAbsoluteAddressOrDie hasn't found a function '%s'", function_name);
 }
 
 AddressRange GetFunctionRelativeAddressRangeOrDie(std::string_view function_name) {

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -289,7 +289,7 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
 
   auto& modules = modules_or_error.value();
   const auto module = std::find_if(modules.begin(), modules.end(), [&](const auto& module) {
-    return module.name() == "UserSpaceInstrumentationTests";
+    return module.file_path() == orbit_base::GetExecutablePath();
   });
 
   ASSERT_NE(module, modules.end());

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -27,6 +27,7 @@
 #include "AccessTraceesMemory.h"
 #include "AddressRange.h"
 #include "AllocateInTracee.h"
+#include "GetTestLibLibraryPath.h"
 #include "MachineCode.h"
 #include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
@@ -581,9 +582,11 @@ class InstrumentFunctionTest : public testing::Test {
     // Stop the child process using our tooling.
     CHECK(AttachAndStopProcess(pid_).has_value());
 
+    auto library_path_or_error = GetTestLibLibraryPath();
+    ASSERT_THAT(library_path_or_error, HasNoError());
+    std::filesystem::path library_path = std::move(library_path_or_error.value());
+
     // Inject the payload for the instrumentation.
-    constexpr std::string_view kLibName = "libUserSpaceInstrumentationTestLib.so";
-    const std::string library_path = orbit_base::GetExecutableDir() / ".." / "lib" / kLibName;
     auto library_handle_or_error = DlopenInTracee(pid_, library_path, RTLD_NOW);
     CHECK(library_handle_or_error.has_value());
     void* library_handle = library_handle_or_error.value();

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "AccessTraceesMemory.h"
+#include "AddressRange.h"
 #include "AllocateInTracee.h"
 #include "MachineCode.h"
 #include "ObjectUtils/Address.h"
@@ -283,17 +284,17 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
 
   // Find the address range of the code for `DoubleAndIncrement`. For the purpose of this test we
   // just take the entire address space taken up by `UserSpaceInstrumentationTests`.
-  AddressRange code_range;
-  auto modules = orbit_object_utils::ReadModules(pid);
-  CHECK(!modules.has_error());
-  for (const auto& m : modules.value()) {
-    if (m.name() == "UserSpaceInstrumentationTests") {
-      code_range.start = m.address_start();
-      code_range.end = m.address_end();
-    }
-  }
+  auto modules_or_error = orbit_object_utils::ReadModules(pid);
+  CHECK(!modules_or_error.has_error());
 
-  // Allocate one megabyte in the tracee. The memory will be close to `code_range`.
+  auto& modules = modules_or_error.value();
+  const auto module = std::find_if(modules.begin(), modules.end(), [&](const auto& module) {
+    return module.name() == "UserSpaceInstrumentationTests";
+  });
+
+  ASSERT_NE(module, modules.end());
+  const AddressRange code_range{module->address_start(), module->address_end()};
+
   constexpr uint64_t kTrampolineSize = 1024 * 1024;
   auto memory_or_error = AllocateMemoryForTrampolines(pid, code_range, kTrampolineSize);
   ASSERT_FALSE(memory_or_error.has_error());


### PR DESCRIPTION
The user space instrumentation tests rely on build system specifics like file paths, file names and linking type.

With this PR I try to generalize some of these assumptions, ideally by relying less on hard coded constants but that's not always possible.