### PR TITLE
Remove --devmode flag for OrbitService

### DIFF
--- a/src/Service/OrbitGrpcServer.cpp
+++ b/src/Service/OrbitGrpcServer.cpp
@@ -30,7 +30,7 @@ class OrbitGrpcServerImpl final : public OrbitGrpcServer {
   OrbitGrpcServerImpl(const OrbitGrpcServerImpl&) = delete;
   OrbitGrpcServerImpl& operator=(OrbitGrpcServerImpl&) = delete;
 
-  [[nodiscard]] bool Init(std::string_view server_address, bool dev_mode);
+  [[nodiscard]] bool Init(std::string_view server_address);
 
   void Shutdown() override;
   void Wait() override;
@@ -47,7 +47,7 @@ class OrbitGrpcServerImpl final : public OrbitGrpcServer {
   std::unique_ptr<grpc::Server> server_;
 };
 
-bool OrbitGrpcServerImpl::Init(std::string_view server_address, bool dev_mode) {
+bool OrbitGrpcServerImpl::Init(std::string_view server_address) {
   grpc::EnableDefaultHealthCheckService(true);
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 
@@ -58,9 +58,7 @@ bool OrbitGrpcServerImpl::Init(std::string_view server_address, bool dev_mode) {
   builder.RegisterService(&process_service_);
   builder.RegisterService(&tracepoint_service_);
   builder.RegisterService(&frame_pointer_validator_service_);
-  if (dev_mode) {
-    builder.RegisterService(&crash_service_);
-  }
+  builder.RegisterService(&crash_service_);
 
   server_ = builder.BuildAndStart();
 
@@ -81,11 +79,10 @@ void OrbitGrpcServerImpl::RemoveCaptureStartStopListener(CaptureStartStopListene
 
 }  // namespace
 
-std::unique_ptr<OrbitGrpcServer> OrbitGrpcServer::Create(std::string_view server_address,
-                                                         bool dev_mode) {
+std::unique_ptr<OrbitGrpcServer> OrbitGrpcServer::Create(std::string_view server_address) {
   std::unique_ptr<OrbitGrpcServerImpl> server_impl = std::make_unique<OrbitGrpcServerImpl>();
 
-  if (!server_impl->Init(server_address, dev_mode)) {
+  if (!server_impl->Init(server_address)) {
     return nullptr;
   }
 

--- a/src/Service/OrbitGrpcServer.h
+++ b/src/Service/OrbitGrpcServer.h
@@ -31,10 +31,8 @@ class OrbitGrpcServer {
   virtual void AddCaptureStartStopListener(CaptureStartStopListener* listener) = 0;
   virtual void RemoveCaptureStartStopListener(CaptureStartStopListener* listener) = 0;
 
-  // Creates a server listening specified address and registers all
-  // necessary services.
-  [[nodiscard]] static std::unique_ptr<OrbitGrpcServer> Create(std::string_view server_address,
-                                                               bool dev_mode);
+  // Creates a server listening specified address and registers all necessary services.
+  [[nodiscard]] static std::unique_ptr<OrbitGrpcServer> Create(std::string_view server_address);
 };
 
 }  // namespace orbit_service

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -105,10 +105,10 @@ static bool IsSshConnectionAlive(
              .count() < timeout_in_seconds;
 }
 
-static std::unique_ptr<OrbitGrpcServer> CreateGrpcServer(uint16_t grpc_port, bool dev_mode) {
+static std::unique_ptr<OrbitGrpcServer> CreateGrpcServer(uint16_t grpc_port) {
   std::string grpc_address = absl::StrFormat("127.0.0.1:%d", grpc_port);
   LOG("Starting gRPC server at %s", grpc_address);
-  std::unique_ptr<OrbitGrpcServer> grpc_server = OrbitGrpcServer::Create(grpc_address, dev_mode);
+  std::unique_ptr<OrbitGrpcServer> grpc_server = OrbitGrpcServer::Create(grpc_address);
   if (grpc_server == nullptr) {
     ERROR("Unable to start gRPC server");
     return nullptr;
@@ -150,7 +150,7 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
   LOG("**********************************");
 #endif
 
-  std::unique_ptr<OrbitGrpcServer> grpc_server = CreateGrpcServer(grpc_port_, dev_mode_);
+  std::unique_ptr<OrbitGrpcServer> grpc_server = CreateGrpcServer(grpc_port_);
   if (grpc_server == nullptr) {
     return;
   }

--- a/src/Service/OrbitService.h
+++ b/src/Service/OrbitService.h
@@ -20,8 +20,7 @@ namespace orbit_service {
 
 class OrbitService {
  public:
-  explicit OrbitService(uint16_t grpc_port, bool dev_mode)
-      : grpc_port_{grpc_port}, dev_mode_{dev_mode} {}
+  explicit OrbitService(uint16_t grpc_port) : grpc_port_{grpc_port} {}
 
   void Run(std::atomic<bool>* exit_requested);
 
@@ -29,7 +28,6 @@ class OrbitService {
   [[nodiscard]] bool IsSshWatchdogActive() { return last_stdin_message_ != std::nullopt; }
 
   uint16_t grpc_port_;
-  bool dev_mode_;
 
   std::optional<std::chrono::time_point<std::chrono::steady_clock>> last_stdin_message_ =
       std::nullopt;

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -19,8 +19,6 @@
 
 ABSL_FLAG(uint64_t, grpc_port, 44765, "gRPC server port");
 
-ABSL_FLAG(bool, devmode, false, "Enable developer mode");
-
 namespace {
 std::atomic<bool> exit_requested;
 
@@ -58,9 +56,8 @@ int main(int argc, char** argv) {
   InstallSigintHandler();
 
   uint16_t grpc_port = absl::GetFlag(FLAGS_grpc_port);
-  bool dev_mode = absl::GetFlag(FLAGS_devmode);
 
   exit_requested = false;
-  orbit_service::OrbitService service{grpc_port, dev_mode};
+  orbit_service::OrbitService service{grpc_port};
   service.Run(&exit_requested);
 }

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -395,11 +395,8 @@ outcome::result<void> ServiceDeployManager::StartOrbitService() {
   CHECK(QThread::currentThread() == thread());
   emit statusMessage("Starting OrbitService on the remote instance...");
 
-  std::string task_string = "/opt/developer/tools/OrbitService";
-  if (absl::GetFlag(FLAGS_devmode)) {
-    task_string += " --devmode";
-  }
-  orbit_service_task_.emplace(&session_.value(), task_string);
+  static const std::string kTaskString = "/opt/developer/tools/OrbitService";
+  orbit_service_task_.emplace(&session_.value(), kTaskString);
 
   orbit_qt_utils::EventLoop loop{};
 
@@ -436,11 +433,8 @@ outcome::result<void> ServiceDeployManager::StartOrbitServicePrivileged(
   // implemented in OrbitSshQt::Task.
   emit statusMessage("Starting OrbitService on the remote instance...");
 
-  std::string task_string = "sudo --stdin /tmp/OrbitService";
-  if (absl::GetFlag(FLAGS_devmode)) {
-    task_string += " --devmode";
-  }
-  orbit_service_task_.emplace(&session_.value(), task_string);
+  static const std::string kTaskString = "sudo --stdin /tmp/OrbitService";
+  orbit_service_task_.emplace(&session_.value(), kTaskString);
 
   orbit_service_task_->Write(absl::StrFormat("%s\n", config.root_password));
 


### PR DESCRIPTION
This was basically a leftover, so let's remove it for simplicity reasons.
Its only remaining usage was to register `CrashService`. But we can just always
register it, similarly to how we always register `TracepointService` and
`FramePointerValidatorService`. It will still only be possible to interact with
`CrashService` if the client was started in `--devmode`.

Test: Deploy `OrbitService` with `BareExecutableAndRootPasswordDeployment`,
start client in `--devmode`, verify it's still possible to crash `OrbitService`.