### PR TITLE
Delay searching CallTreeWidget to prevent searching on every character

### DIFF
--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -58,13 +58,13 @@ CallTreeWidget::CallTreeWidget(QWidget* parent)
   search_typing_finished_timer_->setSingleShot(true);
 
   connect(ui_->callTreeTreeView, &CopyKeySequenceEnabledTreeView::copyKeySequencePressed, this,
-          &CallTreeWidget::onCopyKeySequencePressed);
+          &CallTreeWidget::OnCopyKeySequencePressed);
   connect(ui_->callTreeTreeView, &QTreeView::customContextMenuRequested, this,
-          &CallTreeWidget::onCustomContextMenuRequested);
+          &CallTreeWidget::OnCustomContextMenuRequested);
   connect(ui_->searchLineEdit, &QLineEdit::textEdited, this,
-          &CallTreeWidget::onSearchLineEditTextEdited);
+          &CallTreeWidget::OnSearchLineEditTextEdited);
   connect(search_typing_finished_timer_, &QTimer::timeout, this,
-          &CallTreeWidget::onSearchTypingFinishedTimerTimout);
+          &CallTreeWidget::OnSearchTypingFinishedTimerTimout);
 }
 
 void CallTreeWidget::SetCallTreeView(std::unique_ptr<CallTreeView> call_tree_view,
@@ -86,7 +86,7 @@ void CallTreeWidget::SetCallTreeView(std::unique_ptr<CallTreeView> call_tree_vie
   ui_->callTreeTreeView->setModel(hooked_proxy_model_.get());
   ui_->callTreeTreeView->sortByColumn(CallTreeViewItemModel::kInclusive, Qt::DescendingOrder);
 
-  onSearchLineEditTextEdited(ui_->searchLineEdit->text());
+  OnSearchLineEditTextEdited(ui_->searchLineEdit->text());
 
   ResizeColumnsIfNecessary();
 }
@@ -302,7 +302,7 @@ static std::string BuildStringFromIndices(QTreeView* tree_view, const QModelInde
   return buffer;
 }
 
-void CallTreeWidget::onCopyKeySequencePressed() {
+void CallTreeWidget::OnCopyKeySequencePressed() {
   app_->SetClipboard(BuildStringFromIndices(
       ui_->callTreeTreeView, ui_->callTreeTreeView->selectionModel()->selectedIndexes()));
 }
@@ -397,7 +397,7 @@ static std::vector<const FunctionInfo*> GetFunctionsFromIndices(
   return std::vector<const FunctionInfo*>(functions_set.begin(), functions_set.end());
 }
 
-void CallTreeWidget::onCustomContextMenuRequested(const QPoint& point) {
+void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
   if (app_ == nullptr) {
     return;
   }
@@ -544,12 +544,12 @@ static void ExpandCollapseBasedOnRole(QTreeView* tree_view, int role) {
   }
 }
 
-void CallTreeWidget::onSearchLineEditTextEdited(const QString& /*text*/) {
+void CallTreeWidget::OnSearchLineEditTextEdited(const QString& /*text*/) {
   static constexpr int kSearchTypingFinishedTimerTimeoutMs = 400;
   search_typing_finished_timer_->start(kSearchTypingFinishedTimerTimeoutMs);
 }
 
-void CallTreeWidget::onSearchTypingFinishedTimerTimout() {
+void CallTreeWidget::OnSearchTypingFinishedTimerTimout() {
   if (search_proxy_model_ == nullptr) {
     return;
   }

--- a/src/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/CallTreeWidget.h
@@ -18,6 +18,7 @@
 #include <QString>
 #include <QStyleOptionViewItem>
 #include <QStyledItemDelegate>
+#include <QTimer>
 #include <QVariant>
 #include <QWidget>
 #include <Qt>
@@ -56,6 +57,7 @@ class CallTreeWidget : public QWidget {
   void onCopyKeySequencePressed();
   void onCustomContextMenuRequested(const QPoint& point);
   void onSearchLineEditTextEdited(const QString& text);
+  void onSearchTypingFinishedTimerTimout();
 
  private:
   static const QString kActionExpandRecursively;
@@ -117,6 +119,7 @@ class CallTreeWidget : public QWidget {
   void ResizeColumnsIfNecessary();
 
   std::unique_ptr<Ui::CallTreeWidget> ui_;
+  QTimer* search_typing_finished_timer_ = new QTimer{this};
   OrbitApp* app_ = nullptr;
   std::unique_ptr<CallTreeViewItemModel> model_;
   std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model_;

--- a/src/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/CallTreeWidget.h
@@ -54,10 +54,10 @@ class CallTreeWidget : public QWidget {
   void resizeEvent(QResizeEvent* event) override;
 
  private slots:
-  void onCopyKeySequencePressed();
-  void onCustomContextMenuRequested(const QPoint& point);
-  void onSearchLineEditTextEdited(const QString& text);
-  void onSearchTypingFinishedTimerTimout();
+  void OnCopyKeySequencePressed();
+  void OnCustomContextMenuRequested(const QPoint& point);
+  void OnSearchLineEditTextEdited(const QString& text);
+  void OnSearchTypingFinishedTimerTimout();
 
  private:
   static const QString kActionExpandRecursively;


### PR DESCRIPTION
Only search top-down and bottom-up views when we detect that the user has
finished typing, based on a timeout. As the trees can be quite big and
displaying the result of the search involves expanding and collapsing nodes,
searching on every new character typed can be laggy and interfere with writing
the full search term.

Bug: http://b/197499003

Test: Play around with searching "Top-Down" and "Bottom-Up", also across
multiple captures and multiple selections.