### PR TITLE
Add pull request and commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Commit messages must follow the following rules:
 * Separated from subject line by blank line
 * Wrapped to 72 characters
 * Explain *what* and *why* rather than *how*
-* Add a `Test:` stanza describing how to test the change. Examples may be `Test: run OrbitBaseUnitTests` or `Test: start orbit, capture, save, restart orbit, load capture, see that it did not crash`.
+* Add a Test: stanza describing how the change was tested. Examples may be `Test: run OrbitBaseUnitTests` or `Test: start orbit, capture, save, restart orbit, load capture, see that it did not crash`.
 * If possible add a `Bug:` stanza at the end of the commit message to link to existing bugs/issues. Make sure to include http:// - it helps tools recognize the link and let git log reader open it without copy and pasting it first. Example: `Bug: http://b/42`
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,31 @@ information on using pull requests.
 
 This project follows [Google's Open Source Community
 Guidelines](https://opensource.google/conduct/).
+
+## Pull Request Guidelines
+
+We have the following guidelines for pull requests:
+
+* Each pull request must contain exactly **one** commit (excluding fixup commits) and must be submitted using **squash merges**.
+* Each pull request (and per above each commit) must **logically make a single change**. Note that the boundary of this is fuzzy and it’s up to authors to decide whether they combine multiple commits into a single commit for review. Reviewers should point out obvious violations (such as, medium to large scale renaming as part of a functionality change), but smaller violations should be allowed (such as, renaming a function as part of a functionality change).
+* Every pull request (and per above every commit) must include a *what* and a *why* in the change description. The “why” can be a link to a bug/issue (in which case the bug should contain enough context).
+
+## Commit message Guidelines
+
+Commit messages must follow the following rules:
+
+### Commit header (subject line)
+* One line, 72 characters max, but aim for 50
+* Capitalized (starts with a capital letter)
+* Doesn’t end with a period
+* Imperative style (“Fix bug” rather than “Fixed bug” or “Fixes bug”)
+
+### Commit body
+* Separated from subject line by blank line
+* Wrapped to 72 characters
+* Explain *what* and *why* rather than *how*
+* Add a `Test:` stanza describing how to test the change. Examples may be `Test: run OrbitBaseUnitTests` or `Test: start orbit, capture, save, restart orbit, load capture, see that it did not crash`.
+* If possible add a `Bug:` stanza at the end of the commit message to link to existing bugs/issues. Make sure to include http:// - it helps tools recognize the link and let git log reader open it without copy and pasting it first. Example: `Bug: http://b/42`
+
+
+


### PR DESCRIPTION
Internally, we decided on guidelines on pull requests
(http://go/stadia-orbit-one-commit-one-pr-policy) and
and commit messages (http://go/stadia-orbit-commit).
Those should be also exposed to public contributors.

This change, adds the essentials from the documents
mentioned above to the CONTRIBUTING.md