### PR TITLE
Implement Rename Capture File

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1222,6 +1222,13 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> OrbitApp::LoadCaptureFro
   return load_future;
 }
 
+orbit_base::Future<ErrorMessageOr<void>> OrbitApp::MoveCaptureFile(
+    const std::filesystem::path& src, const std::filesystem::path& dest) {
+  return thread_pool_->Schedule([src, dest]() { return orbit_base::MoveFile(src, dest); })
+      .ThenIfSuccess(main_thread_executor_,
+                     [this, dest] { capture_file_info_manager_.AddOrTouchCaptureFile(dest); });
+}
+
 void OrbitApp::OnLoadCaptureCancelRequested() { capture_loading_cancellation_requested_ = true; }
 
 void OrbitApp::FireRefreshCallbacks(DataViewType type) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -107,6 +107,9 @@ class OrbitApp final : public DataViewFactory,
   ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
   orbit_base::Future<ErrorMessageOr<CaptureOutcome>> LoadCaptureFromFile(
       const std::filesystem::path& file_path);
+
+  orbit_base::Future<ErrorMessageOr<void>> MoveCaptureFile(const std::filesystem::path& src,
+                                                           const std::filesystem::path& dest);
   void OnLoadCaptureCancelRequested();
 
   [[nodiscard]] orbit_capture_client::CaptureClient::State GetCaptureState() const;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -138,6 +138,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   void on_actionToggle_Capture_triggered();
   void on_actionOpen_Capture_triggered();
+  void on_actionRename_Capture_File_triggered();
   void on_actionCaptureOptions_triggered();
   void on_actionHelp_toggled(bool checked);
   void on_actionIntrospection_triggered();

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -388,6 +388,7 @@ QPushButton:disabled {
      <string>File</string>
     </property>
     <addaction name="actionOpen_Capture"/>
+    <addaction name="actionRename_Capture_File"/>
     <addaction name="separator"/>
     <addaction name="actionOpen_Preset"/>
     <addaction name="actionSave_Preset_As"/>
@@ -697,6 +698,11 @@ It used to also contain captures and presets, but these were moved to the User D
    </property>
    <property name="toolTip">
     <string>Add or remove local symbol directories</string>
+   </property>
+  </action>
+  <action name="actionRename_Capture_File">
+   <property name="text">
+    <string>Rename/Move Capture File...</string>
    </property>
   </action>
  </widget>

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -92,6 +92,7 @@ void TargetLabel::SetFile(const std::filesystem::path& file_path) {
   ui_->fileLabel->setText(QString::fromStdString(file_path.filename().string()));
   ui_->fileLabel->setToolTip(QString::fromStdString(file_path.string()));
   ui_->fileLabel->setVisible(true);
+  emit SizeChanged();
 }
 
 void TargetLabel::ChangeToFileTarget(const fs::path& path) {


### PR DESCRIPTION
This adds a menu option to rename currently opened
capture file.

Bug: http://b/190473278
Test: Load file -> rename it -> close session, check that in the
      Startup UI we have it in the list.