### PR TITLE
Create ScopeTreeTimerData

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(ClientData PUBLIC
         include/ClientData/ModuleManager.h
         include/ClientData/PostProcessedSamplingData.h
         include/ClientData/ProcessData.h
+        include/ClientData/ScopeTreeTimerData.h
         include/ClientData/TimerChain.h
         include/ClientData/TimestampIntervalSet.h
         include/ClientData/TracepointCustom.h
@@ -39,6 +40,7 @@ target_sources(ClientData PRIVATE
         ModuleManager.cpp
         PostProcessedSamplingData.cpp
         ProcessData.cpp
+        ScopeTreeTimerData.cpp
         TimerChain.cpp
         TimestampIntervalSet.cpp
         TracepointData.cpp
@@ -62,6 +64,7 @@ target_sources(ClientDataTests PRIVATE
         ModuleDataTest.cpp
         ModuleManagerTest.cpp
         ProcessDataTest.cpp
+        ScopeTreeTimerDataTest.cpp
         TimestampIntervalSetTest.cpp
         TracepointDataTest.cpp
         TrackDataTest.cpp

--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <ClientData/ScopeTreeTimerData.h>
+
+namespace orbit_client_data {
+
+size_t ScopeTreeTimerData::GetNumberOfTimers() const {
+  absl::MutexLock lock(&scope_tree_mutex_);
+  // Special case. ScopeTree has a root node in depth 0 which shouldn't be considered.
+  return scope_tree_.Size() - 1;
+}
+
+uint32_t ScopeTreeTimerData::GetMaxDepth() const {
+  absl::MutexLock lock(&scope_tree_mutex_);
+  return scope_tree_.Height() - 1;
+}
+
+const orbit_client_protos::TimerInfo& ScopeTreeTimerData::AddTimer(
+    orbit_client_protos::TimerInfo timer_info) {
+  const auto& timer_info_ref = track_pane_data_.AddTimer(/*depth=*/0, timer_info);
+
+  if (scope_tree_update_type_ == ScopeTreeUpdateType::kAlways) {
+    absl::MutexLock lock(&scope_tree_mutex_);
+    scope_tree_.Insert(&timer_info_ref);
+  }
+  return timer_info_ref;
+}
+
+void ScopeTreeTimerData::BuildScopeTreeFromTrackData() {
+  CHECK(scope_tree_update_type_ == ScopeTreeUpdateType::kOnCaptureComplete);
+  std::vector<const TimerChain*> timer_chains = track_pane_data_.GetChains();
+  for (const TimerChain* timer_chain : timer_chains) {
+    CHECK(timer_chain != nullptr);
+    absl::MutexLock lock(&scope_tree_mutex_);
+    for (const auto& block : *timer_chain) {
+      for (size_t k = 0; k < block.size(); ++k) {
+        scope_tree_.Insert(&block[k]);
+      }
+    }
+  }
+}
+
+std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers(
+    uint64_t min_tick, uint64_t max_tick) const {
+  std::vector<const orbit_client_protos::TimerInfo*> all_timers;
+  absl::MutexLock lock(&scope_tree_mutex_);
+
+  for (const auto& [depth, ordered_nodes] : scope_tree_.GetOrderedNodesByDepth()) {
+    // Special case. ScopeTree has a root node in depth 0 which shouldn't be considered.
+    if (depth == 0) continue;
+
+    auto first_node_to_draw = ordered_nodes.upper_bound(min_tick);
+    if (first_node_to_draw != ordered_nodes.begin()) --first_node_to_draw;
+
+    // If this node is strictly before the range, we shouldn't include it.
+    if (first_node_to_draw->second->GetScope()->end() < min_tick) ++first_node_to_draw;
+
+    for (auto it = first_node_to_draw; it != ordered_nodes.end() && it->first < max_tick; ++it) {
+      all_timers.push_back(it->second->GetScope());
+    }
+  }
+  return all_timers;
+}
+
+const orbit_client_protos::TimerInfo& ScopeTreeTimerData::GetLeft(
+    const orbit_client_protos::TimerInfo& timer) const {
+  absl::MutexLock lock(&scope_tree_mutex_);
+  return *scope_tree_.FindPreviousScopeAtDepth(timer);
+}
+
+const orbit_client_protos::TimerInfo& ScopeTreeTimerData::GetRight(
+    const orbit_client_protos::TimerInfo& timer) const {
+  absl::MutexLock lock(&scope_tree_mutex_);
+  return *scope_tree_.FindNextScopeAtDepth(timer);
+}
+
+const orbit_client_protos::TimerInfo& ScopeTreeTimerData::GetUp(
+    const orbit_client_protos::TimerInfo& timer) const {
+  absl::MutexLock lock(&scope_tree_mutex_);
+  return *scope_tree_.FindParent(timer);
+}
+
+const orbit_client_protos::TimerInfo& ScopeTreeTimerData::GetDown(
+    const orbit_client_protos::TimerInfo& timer) const {
+  absl::MutexLock lock(&scope_tree_mutex_);
+  return *scope_tree_.FindFirstChild(timer);
+}
+
+}  // namespace orbit_client_data

--- a/src/ClientData/ScopeTreeTimerDataTest.cpp
+++ b/src/ClientData/ScopeTreeTimerDataTest.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "ClientData/ScopeTreeTimerData.h"
+
+namespace orbit_client_data {
+
+TEST(ScopeTreeTimerData, IsEmpty) {
+  ScopeTreeTimerData scope_tree_timer_data;
+  EXPECT_TRUE(scope_tree_timer_data.IsEmpty());
+  EXPECT_TRUE(scope_tree_timer_data.GetTimers().empty());
+}
+
+TEST(ScopeTreeTimerData, AddTimers) {
+  ScopeTreeTimerData scope_tree_timer_data;
+  orbit_client_protos::TimerInfo timer_info;
+  timer_info.set_start(2);
+  timer_info.set_end(5);
+
+  scope_tree_timer_data.AddTimer(timer_info);
+
+  EXPECT_FALSE(scope_tree_timer_data.IsEmpty());
+  EXPECT_EQ(scope_tree_timer_data.GetNumberOfTimers(), 1);
+  EXPECT_EQ(scope_tree_timer_data.GetMaxDepth(), 0);
+  EXPECT_EQ(scope_tree_timer_data.GetMinTime(), 2);
+  EXPECT_EQ(scope_tree_timer_data.GetMaxTime(), 5);
+
+  timer_info.set_start(8);
+  timer_info.set_end(11);
+
+  scope_tree_timer_data.AddTimer(timer_info);
+
+  EXPECT_EQ(scope_tree_timer_data.GetNumberOfTimers(), 2);
+  EXPECT_EQ(scope_tree_timer_data.GetMaxDepth(), 0);
+  EXPECT_EQ(scope_tree_timer_data.GetMinTime(), 2);
+  EXPECT_EQ(scope_tree_timer_data.GetMaxTime(), 11);
+
+  timer_info.set_start(10);
+  timer_info.set_end(11);
+
+  scope_tree_timer_data.AddTimer(timer_info);
+
+  EXPECT_EQ(scope_tree_timer_data.GetNumberOfTimers(), 3);
+  EXPECT_EQ(scope_tree_timer_data.GetMaxDepth(), 1);
+  EXPECT_EQ(scope_tree_timer_data.GetMinTime(), 2);
+  EXPECT_EQ(scope_tree_timer_data.GetMaxTime(), 11);
+}
+
+TEST(ScopeTreeTimerData, GetTimers) {
+  ScopeTreeTimerData scope_tree_timer_data;
+  orbit_client_protos::TimerInfo timer_info;
+
+  timer_info.set_start(2);
+  timer_info.set_end(5);
+  scope_tree_timer_data.AddTimer(timer_info);
+
+  timer_info.set_start(8);
+  timer_info.set_end(11);
+  scope_tree_timer_data.AddTimer(timer_info);
+
+  timer_info.set_start(10);
+  timer_info.set_end(11);
+  scope_tree_timer_data.AddTimer(timer_info);
+
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(0, 1).size(), 0);
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(20, 30).size(), 0);
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(1, 3).size(), 1);   // (2,5)
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(8, 9).size(), 1);   // (8,11)
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(8, 11).size(), 2);  // (8,11) , (10,11)
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(4, 11).size(), 3);
+  EXPECT_EQ(scope_tree_timer_data.GetTimers().size(), 3);
+}
+
+bool AreSameTimer(const orbit_client_protos::TimerInfo& timer_1,
+                  const orbit_client_protos::TimerInfo& timer_2) {
+  return timer_1.start() == timer_2.start() && timer_1.end() && timer_2.end();
+}
+
+TEST(ScopeTreeTimerData, GetLeftRightUpDown) {
+  ScopeTreeTimerData scope_tree_timer_data;
+  orbit_client_protos::TimerInfo timer_info_left;
+  timer_info_left.set_start(2);
+  timer_info_left.set_end(5);
+  scope_tree_timer_data.AddTimer(timer_info_left);
+
+  orbit_client_protos::TimerInfo timer_info_middle;
+  timer_info_middle.set_start(8);
+  timer_info_middle.set_end(11);
+  scope_tree_timer_data.AddTimer(timer_info_middle);
+
+  orbit_client_protos::TimerInfo timer_info_down;
+  timer_info_down.set_start(10);
+  timer_info_down.set_end(11);
+  scope_tree_timer_data.AddTimer(timer_info_down);
+
+  orbit_client_protos::TimerInfo timer_info_right;
+  timer_info_right.set_start(13);
+  timer_info_right.set_end(15);
+  scope_tree_timer_data.AddTimer(timer_info_right);
+
+  AreSameTimer(scope_tree_timer_data.GetLeft(timer_info_middle), timer_info_left);
+  AreSameTimer(scope_tree_timer_data.GetLeft(timer_info_right), timer_info_middle);
+  AreSameTimer(scope_tree_timer_data.GetRight(timer_info_left), timer_info_middle);
+  AreSameTimer(scope_tree_timer_data.GetRight(timer_info_middle), timer_info_right);
+  AreSameTimer(scope_tree_timer_data.GetUp(timer_info_down), timer_info_middle);
+  AreSameTimer(scope_tree_timer_data.GetDown(timer_info_middle), timer_info_down);
+}
+
+}  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_SCOPE_TREE_TIMER_DATA_PROVIDER_H_
+#define CLIENT_DATA_SCOPE_TREE_TIMER_DATA_PROVIDER_H_
+
+#include <absl/synchronization/mutex.h>
+
+#include <vector>
+
+#include "Containers/ScopeTree.h"
+#include "TrackPaneData.h"
+
+namespace orbit_client_data {
+
+// Stores all the timers from a particular ThreadId. Provides queries to get timers in a certain
+// range as well as metadata from them.
+class ScopeTreeTimerData final {
+ public:
+  enum class ScopeTreeUpdateType { kAlways, kOnCaptureComplete, kNever };
+  explicit ScopeTreeTimerData(int64_t thread_id = -1, ScopeTreeUpdateType scope_tree_update_type =
+                                                          ScopeTreeUpdateType::kAlways)
+      : thread_id_(thread_id), scope_tree_update_type_(scope_tree_update_type){};
+
+  [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
+  [[nodiscard]] bool IsEmpty() const { return GetNumberOfTimers() == 0; }
+  [[nodiscard]] size_t GetNumberOfTimers() const;
+  [[nodiscard]] uint64_t GetMinTime() const { return track_pane_data_.GetMinTime(); }
+  [[nodiscard]] uint64_t GetMaxTime() const { return track_pane_data_.GetMaxTime(); }
+  [[nodiscard]] uint32_t GetMaxDepth() const;
+
+  const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info);
+  // Build ScopeTree from timer chains, when we are loading a capture.
+  void BuildScopeTreeFromTrackData();
+
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
+      uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
+  [[nodiscard]] const orbit_client_protos::TimerInfo& GetLeft(
+      const orbit_client_protos::TimerInfo& timer) const;
+  [[nodiscard]] const orbit_client_protos::TimerInfo& GetRight(
+      const orbit_client_protos::TimerInfo& timer) const;
+  [[nodiscard]] const orbit_client_protos::TimerInfo& GetUp(
+      const orbit_client_protos::TimerInfo& timer) const;
+  [[nodiscard]] const orbit_client_protos::TimerInfo& GetDown(
+      const orbit_client_protos::TimerInfo& timer) const;
+
+ private:
+  const int64_t thread_id_;
+  mutable absl::Mutex scope_tree_mutex_;
+  orbit_containers::ScopeTree<const orbit_client_protos::TimerInfo> scope_tree_
+      GUARDED_BY(scope_tree_mutex_);
+  ScopeTreeUpdateType scope_tree_update_type_;
+
+  TrackPaneData track_pane_data_;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_SCOPE_TREE_TIMER_DATA_PROVIDER_H_


### PR DESCRIPTION
We are creating ScopeTreeTimerData which will represent the timers inside
a ThreadTrack based on ScopeTree data structure. For now, it's a temporal
class because we are trying to query the timers for ThreadTrack. In the future
we will do the same for other TimerTracks and we might eventually merge it with 
TrackPaneData.

As currently, we are having two containers, TrackPaneData and ScopeTree.
In the future we might use ScopeTree while capturing (with some
modifications to erase bunch of timers), and the other container will be
used when stopping a capture.

The current functions are AddTimer(), which will replace OnTimer and
ProcessTimer for ThreadTrack, BuildScopeTreeFromTrackData(), which will
be used to construct the ScopeTree when loading a capture (legacy), and
GetAllTimers(min_tick, max_tick) which will return all timers in that
range. Aditionally we have the methods used in TrackPaneData and
GetLeft/Right/Top/Down.