### PR TITLE
Reduce max callstack sampling period in CaptureOptions to 10 ms

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -77,10 +77,10 @@
                 <double>0.100000000000000</double>
                </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>10.000000000000000</double>
                </property>
-               <property name="stepType">
-                <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
                </property>
                <property name="value">
                 <double>1.000000000000000</double>


### PR DESCRIPTION
I'm not happy with the maximum of one second I set with #2727.
The user might generally want to reduce from the default 1 ms. Still, let's
leave some room for increasing it. But no need to span several orders of
magnitude, I don't see a reason for that.

This has the additional desired effect of avoiding only very few threads showing
up if the sampling period is set to an unnecessarily high value.

We can also replace `AdaptiveDecimalStepType` with a clearer `singleStep` of 0.1
now as they have the same effect in the new range.

Test: Run Orbit, verify the `SpinBox` in the `CaptureOptions` dialog.