### PR TITLE
Re-hide "Enable user space instrumentation" outside of --devmode

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -41,8 +41,8 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
     ui_->introspectionCheckBox->hide();
   }
 
-  if (absl::GetFlag(FLAGS_devmode)) {
-    ui_->userspaceCheckBox->show();
+  if (!absl::GetFlag(FLAGS_devmode)) {
+    ui_->userspaceCheckBox->hide();
   }
 }
 


### PR DESCRIPTION
My mistake in #2727.
Instead of chanding back in the `.ui` file, change `CaptureOptionsDialog.cpp`,
for consistency with how the other checkboxes are hidden.

Bug: http://b/199392558

Test: Run Orbit with and without `--devmode`, verify the `CaptureOptions`
dialog.