### PR TITLE
Fix address computation for symbols loaded from PDB files

### DIFF
--- a/src/ObjectUtils/PdbFileTest.cpp
+++ b/src/ObjectUtils/PdbFileTest.cpp
@@ -15,6 +15,7 @@
 
 using orbit_grpc_protos::SymbolInfo;
 using orbit_object_utils::CreateCoffFile;
+using orbit_object_utils::ObjectFileInfo;
 using orbit_object_utils::PdbDebugInfo;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;
@@ -24,7 +25,7 @@ TEST(PdbFile, LoadDebugSymbols) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
-      orbit_object_utils::CreatePdbFile(file_path_pdb);
+      orbit_object_utils::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
   ASSERT_THAT(pdb_file_result, HasNoError());
   std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
   auto symbols_result = pdb_file->LoadDebugSymbols();
@@ -39,13 +40,13 @@ TEST(PdbFile, LoadDebugSymbols) {
   SymbolInfo symbol = symbol_infos[0];
   EXPECT_EQ(symbol.name(), "PrintHelloWorldInternal");
   EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorldInternal");
-  EXPECT_EQ(symbol.address(), 0xdf90);
+  EXPECT_EQ(symbol.address(), 0x18000ef90);
   EXPECT_EQ(symbol.size(), 0x2b);
 
   symbol = symbol_infos[1];
   EXPECT_EQ(symbol.name(), "PrintHelloWorld");
   EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorld");
-  EXPECT_EQ(symbol.address(), 0xdfd0);
+  EXPECT_EQ(symbol.address(), 0x18000efd0);
   EXPECT_EQ(symbol.size(), 0xe);
 }
 
@@ -53,7 +54,7 @@ TEST(PdbFile, CanObtainGuidAndAgeFromPdbAndDll) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
-      orbit_object_utils::CreatePdbFile(file_path_pdb);
+      orbit_object_utils::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
   ASSERT_THAT(pdb_file_result, HasNoError());
   std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
 
@@ -77,6 +78,6 @@ TEST(PdbFile, CreatePdbFailsOnNonPdbFile) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.dll";
 
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
-      orbit_object_utils::CreatePdbFile(file_path_pdb);
+      orbit_object_utils::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
   EXPECT_THAT(pdb_file_result, HasError("Unable to load PDB file"));
 }

--- a/src/ObjectUtils/SymbolsFile.cpp
+++ b/src/ObjectUtils/SymbolsFile.cpp
@@ -18,7 +18,7 @@
 namespace orbit_object_utils {
 
 ErrorMessageOr<std::unique_ptr<SymbolsFile>> CreateSymbolsFile(
-    const std::filesystem::path& file_path) {
+    const std::filesystem::path& file_path, const ObjectFileInfo& object_file_info) {
   std::string error_message{
       absl::StrFormat("Unable to create symbols file from \"%s\".", file_path.string())};
 
@@ -41,7 +41,8 @@ ErrorMessageOr<std::unique_ptr<SymbolsFile>> CreateSymbolsFile(
   error_message.append(absl::StrFormat("\n* File cannot be read as an object file, error: %s",
                                        object_file_or_error.error().message()));
 
-  ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_or_error = CreatePdbFile(file_path);
+  ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_or_error =
+      CreatePdbFile(file_path, object_file_info);
 
   if (pdb_file_or_error.has_value()) return std::move(pdb_file_or_error.value());
 

--- a/src/ObjectUtils/SymbolsFileTest.cpp
+++ b/src/ObjectUtils/SymbolsFileTest.cpp
@@ -18,13 +18,15 @@ TEST(SymbolsFile, CreateSymbolsFileFromElf) {
   const std::filesystem::path elf_with_symbols_path =
       orbit_test::GetTestdataDir() / "hello_world_elf";
 
-  auto valid_symbols_file = CreateSymbolsFile(elf_with_symbols_path);
+  auto valid_symbols_file =
+      CreateSymbolsFile(elf_with_symbols_path, ObjectFileInfo{0x10000, 0x1000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   const std::filesystem::path elf_without_symbols_path =
       orbit_test::GetTestdataDir() / "no_symbols_elf";
 
-  auto invalid_symbols_file = CreateSymbolsFile(elf_without_symbols_path);
+  auto invalid_symbols_file =
+      CreateSymbolsFile(elf_without_symbols_path, ObjectFileInfo{0x10000, 0x1000});
   EXPECT_THAT(invalid_symbols_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(invalid_symbols_file, HasError("File does not contain symbols."));
 }
@@ -32,13 +34,15 @@ TEST(SymbolsFile, CreateSymbolsFileFromElf) {
 TEST(SymbolsFile, CreateSymbolsFileFromCoff) {
   const std::filesystem::path coff_with_symbols_path = orbit_test::GetTestdataDir() / "libtest.dll";
 
-  auto valid_symbols_file = CreateSymbolsFile(coff_with_symbols_path);
+  auto valid_symbols_file =
+      CreateSymbolsFile(coff_with_symbols_path, ObjectFileInfo{0x10000, 0x1000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   const std::filesystem::path coff_without_symbols_path =
       orbit_test::GetTestdataDir() / "dllmain.dll";
 
-  auto invalid_symbols_file = CreateSymbolsFile(coff_without_symbols_path);
+  auto invalid_symbols_file =
+      CreateSymbolsFile(coff_without_symbols_path, ObjectFileInfo{0x10000, 0x1000});
   EXPECT_THAT(invalid_symbols_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(invalid_symbols_file, HasError("File does not contain symbols."));
 }
@@ -46,7 +50,8 @@ TEST(SymbolsFile, CreateSymbolsFileFromCoff) {
 TEST(SymbolsFile, CreateSymbolsFileFromPdb) {
   const std::filesystem::path pwd_with_symbols_path = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
-  auto valid_symbols_file = CreateSymbolsFile(pwd_with_symbols_path);
+  auto valid_symbols_file =
+      CreateSymbolsFile(pwd_with_symbols_path, ObjectFileInfo{0x10000, 0x1000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   // pdb file always contains symbols, so a test for not containing symbols is not necessary
@@ -55,13 +60,13 @@ TEST(SymbolsFile, CreateSymbolsFileFromPdb) {
 TEST(SymbolsFile, FailToCreateSymbolsFile) {
   const std::filesystem::path path_to_text_file = orbit_test::GetTestdataDir() / "textfile.txt";
 
-  auto text_file = CreateSymbolsFile(path_to_text_file);
+  auto text_file = CreateSymbolsFile(path_to_text_file, ObjectFileInfo{0x10000, 0x1000});
   EXPECT_THAT(text_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(text_file, HasError("File cannot be read as an object file"));
   EXPECT_THAT(text_file, HasError("File cannot be read as a pdb file"));
 
   const std::filesystem::path invalid_path = orbit_test::GetTestdataDir() / "non_existing_file";
-  auto invalid_file = CreateSymbolsFile(invalid_path);
+  auto invalid_file = CreateSymbolsFile(invalid_path, ObjectFileInfo{0x10000, 0x1000});
   EXPECT_THAT(invalid_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(invalid_file, HasError("File does not exist"));
 }

--- a/src/ObjectUtils/include/ObjectUtils/PdbFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/PdbFile.h
@@ -24,7 +24,8 @@ class PdbFile : public SymbolsFile {
   [[nodiscard]] virtual uint32_t GetAge() const = 0;
 };
 
-ErrorMessageOr<std::unique_ptr<PdbFile>> CreatePdbFile(const std::filesystem::path& file_path);
+ErrorMessageOr<std::unique_ptr<PdbFile>> CreatePdbFile(const std::filesystem::path& file_path,
+                                                       const ObjectFileInfo& object_file_info);
 
 }  // namespace orbit_object_utils
 

--- a/src/ObjectUtils/include/ObjectUtils/SymbolsFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/SymbolsFile.h
@@ -14,6 +14,15 @@
 
 namespace orbit_object_utils {
 
+struct ObjectFileInfo {
+  // This is the load bias for ELF, for COFF we use ImageBase here, so that our
+  // address computations are consistent between what we do we ELF and for COFF.
+  uint64_t load_bias = 0;
+  // File offset to the beginning of the executable segment. For COFF, this is
+  // the file offset to the beginning of the .text section.
+  uint64_t executable_segment_offset = 0;
+};
+
 class SymbolsFile {
  public:
   SymbolsFile() = default;
@@ -29,8 +38,12 @@ class SymbolsFile {
   [[nodiscard]] virtual const std::filesystem::path& GetFilePath() const = 0;
 };
 
+// Create a symbols file from the file at symbol_file_path. Additional info about the corresponding
+// module can be passed in via object_file_info. This is necessary for PDB files, where information
+// such as the load bias cannot be determined from the PDB file alone but is needed to compute the
+// right addresses for symbols.
 ErrorMessageOr<std::unique_ptr<SymbolsFile>> CreateSymbolsFile(
-    const std::filesystem::path& file_path);
+    const std::filesystem::path& symbol_file_path, const ObjectFileInfo& object_file_info);
 
 }  // namespace orbit_object_utils
 

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -226,8 +226,10 @@ ErrorMessageOr<void> ClientGgp::LoadModuleAndSymbols() {
               process_client_->FindDebugInfoFile(module_path, {}));
   LOG("Found file: %s", main_executable_debug_file);
   LOG("Loading symbols");
-  OUTCOME_TRY(auto&& symbols,
-              orbit_symbols::SymbolHelper::LoadSymbolsFromFile(main_executable_debug_file));
+  orbit_object_utils::ObjectFileInfo object_file_info{main_module_->load_bias(),
+                                                      main_module_->executable_segment_offset()};
+  OUTCOME_TRY(auto&& symbols, orbit_symbols::SymbolHelper::LoadSymbolsFromFile(
+                                  main_executable_debug_file, object_file_info));
   main_module_->AddSymbols(symbols);
   return outcome::success();
 }

--- a/src/ProcessService/ProcessServiceUtils.cpp
+++ b/src/ProcessService/ProcessServiceUtils.cpp
@@ -292,7 +292,10 @@ ErrorMessageOr<fs::path> FindSymbolsFilePath(
       continue;
     }
 
-    auto symbols_file_or_error = CreateSymbolsFile(search_path);
+    orbit_object_utils::ObjectFileInfo object_file_info{
+        object_file_or_error.value()->GetLoadBias(),
+        object_file_or_error.value()->GetExecutableSegmentOffset()};
+    auto symbols_file_or_error = CreateSymbolsFile(search_path, object_file_info);
     if (symbols_file_or_error.has_error()) {
       error_messages.push_back(symbols_file_or_error.error().message());
       continue;

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -39,6 +39,7 @@ namespace fs = std::filesystem;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_object_utils::CreateSymbolsFile;
 using orbit_object_utils::ElfFile;
+using orbit_object_utils::ObjectFileInfo;
 using orbit_object_utils::SymbolsFile;
 
 constexpr const char* kDeprecationNote =
@@ -146,7 +147,7 @@ static std::vector<fs::path> FindStructuredDebugDirectories() {
 
 ErrorMessageOr<void> SymbolHelper::VerifySymbolsFile(const fs::path& symbols_path,
                                                      const std::string& build_id) {
-  auto symbols_file_or_error = CreateSymbolsFile(symbols_path);
+  auto symbols_file_or_error = CreateSymbolsFile(symbols_path, ObjectFileInfo());
   if (symbols_file_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Unable to load symbols file \"%s\", error: %s",
                                         symbols_path.string(),
@@ -256,11 +257,12 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
   return cache_file_path;
 }
 
-ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsFromFile(const fs::path& file_path) {
+ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsFromFile(
+    const fs::path& file_path, const ObjectFileInfo& object_file_info) {
   ORBIT_SCOPE_FUNCTION;
   SCOPED_TIMED_LOG("LoadSymbolsFromFile: %s", file_path.string());
 
-  OUTCOME_TRY(auto symbols_file, CreateSymbolsFile(file_path));
+  OUTCOME_TRY(auto symbols_file, CreateSymbolsFile(file_path, object_file_info));
   return symbols_file->LoadDebugSymbols();
 }
 

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <string>
 
+#include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Result.h"
@@ -23,6 +24,7 @@
 
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::ModuleSymbols;
+using orbit_object_utils::ObjectFileInfo;
 using orbit_symbols::SymbolHelper;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;
@@ -247,7 +249,8 @@ TEST(SymbolHelper, LoadSymbolsFromFile) {
   // .debug contains symbols
   {
     const fs::path file_path = testdata_directory / "no_symbols_elf.debug";
-    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path);
+    const auto result =
+        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
 
     ASSERT_THAT(result, HasValue());
     const ModuleSymbols& symbols = result.value();
@@ -259,7 +262,8 @@ TEST(SymbolHelper, LoadSymbolsFromFile) {
   // .pdb contains symbols
   {
     const fs::path file_path = testdata_directory / "dllmain.pdb";
-    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path);
+    const auto result =
+        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
 
     ASSERT_THAT(result, HasValue());
     const ModuleSymbols& symbols = result.value();
@@ -271,21 +275,24 @@ TEST(SymbolHelper, LoadSymbolsFromFile) {
   // elf does not contain symbols
   {
     const fs::path file_path = testdata_directory / "no_symbols_elf";
-    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path);
+    const auto result =
+        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
     EXPECT_THAT(result, HasError("does not contain symbols"));
   }
 
   // coff does not contain symbols
   {
     const fs::path file_path = testdata_directory / "dllmain.dll";
-    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path);
+    const auto result =
+        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
     EXPECT_THAT(result, HasError("does not contain symbols"));
   }
 
   // invalid file
   {
     const fs::path file_path = testdata_directory / "file_does_not_exist";
-    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path);
+    const auto result =
+        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
     EXPECT_THAT(result, HasError("Unable to create symbols file"));
     EXPECT_THAT(result, HasError("File does not exist"));
   }

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/Result.h"
 #include "module.pb.h"
 #include "symbol.pb.h"
@@ -38,7 +39,7 @@ class SymbolHelper {
   [[nodiscard]] ErrorMessageOr<fs::path> FindSymbolsInCache(const fs::path& module_path,
                                                             const std::string& build_id) const;
   [[nodiscard]] static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
-      const fs::path& file_path);
+      const fs::path& file_path, const orbit_object_utils::ObjectFileInfo& object_file_info);
   [[nodiscard]] static ErrorMessageOr<void> VerifySymbolsFile(const fs::path& symbols_path,
                                                               const std::string& build_id);
 


### PR DESCRIPTION
Symbol addresses in PDB files are stored as so called "relative virtual
addresses", which is the offset from the start of the corresponding
.text section. Symbol addresses in ELF files however are stored as
"virtual addresses" which include the load bias and the executable
segment offset. To make all our address computations work consistently,
we pass in the load bias (ImageBase for COFF) and the executable
segment offset when loading the PDB file to adjust symbol address.

If the relative virtual addresses are desired when opening a PDB file,
one can simply pass 0, 0 as load bias and exec offset, respectively.

Bug: http://b/194497774
Tested: Unit test.