### PR TITLE
Fix the crash caused by ModulesDataView

### DIFF
--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -213,7 +213,9 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
   for (const auto& [start_address, module_in_memory] : memory_map) {
     ModuleData* module = app_->GetMutableModuleByPathAndBuildId(module_in_memory.file_path(),
                                                                 module_in_memory.build_id());
-    AddModule(start_address, std::move(module), module_in_memory);
+    if (module != nullptr) {
+      AddModule(start_address, std::move(module), module_in_memory);
+    }
   }
 
   OnDataChanged();


### PR DESCRIPTION
This change fixes some recent crashes in the `ModulesDataView`.

Previously we allow to add a nullptr `ModuleData*` to `start_address_to_module_` and
a nullptr `ModuleInMemory*` to `start_address_to_module_in_memory_`.
Hence, while iterating `start_address_to_module_` and
`start_address_to_module_in_memory_`, we encountored some nullptr values
and so got the access violation crashes.

Bugs:  http://b/199123516, http://b/199119088