### PR TITLE
Replace `Track::SetWidth` with base class functionality

### DIFF
--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -18,6 +18,10 @@ CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, TimeGraph* ti
 void CaptureViewElement::SetWidth(float width) {
   if (width != width_) {
     width_ = width;
+
+    for (auto& child : GetChildren()) {
+      child->SetWidth(width);
+    }
     RequestUpdate();
   }
 }

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -56,8 +56,9 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   virtual void SetPos(float x, float y) { pos_ = Vec2(x, y); }
   // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
   [[nodiscard]] virtual Vec2 GetPos() const { return pos_; }
-  // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
-  virtual void SetWidth(float width);
+
+  // This will set the width of all child elements to 100% by default
+  void SetWidth(float width);
   [[nodiscard]] float GetWidth() const { return width_; }
   // Height should be defined in every particular capture view element.
   [[nodiscard]] virtual float GetHeight() const = 0;
@@ -70,6 +71,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] bool Draggable() override { return true; }
 
   [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
+  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetChildren() const { return {}; }
   virtual void RequestUpdate();
 
  protected:

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -116,12 +116,8 @@ float GpuTrack::GetHeight() const {
   return height;
 }
 
-// TODO(b/176216022): Make a general interface for capture view elements for setting the width to
-// every child.
-void GpuTrack::SetWidth(float width) {
-  Track::SetWidth(width);
-  submission_track_->SetWidth(width);
-  marker_track_->SetWidth(width);
+std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetChildren() const {
+  return {submission_track_.get(), marker_track_.get()};
 }
 
 void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -64,11 +64,12 @@ class GpuTrack : public Track {
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] float GetHeight() const override;
 
+  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
+
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
-  void SetWidth(float width) override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
 
   [[nodiscard]] bool IsEmpty() const override {

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -55,14 +55,6 @@ float PageFaultsTrack::GetHeight() const {
   return height;
 }
 
-// TODO(b/176216022): Make a general interface for capture view elements for setting the width to
-// every child.
-void PageFaultsTrack::SetWidth(float width) {
-  Track::SetWidth(width);
-  minor_page_faults_track_->SetWidth(width);
-  major_page_faults_track_->SetWidth(width);
-}
-
 std::vector<orbit_gl::CaptureViewElement*> PageFaultsTrack::GetVisibleChildren() {
   std::vector<CaptureViewElement*> result;
   if (collapse_toggle_->IsCollapsed()) return result;
@@ -75,6 +67,10 @@ std::vector<orbit_gl::CaptureViewElement*> PageFaultsTrack::GetVisibleChildren()
 std::string PageFaultsTrack::GetTooltip() const {
   if (collapse_toggle_->IsCollapsed()) return major_page_faults_track_->GetTooltip();
   return "Shows the minor and major page faults statistics.";
+}
+
+std::vector<CaptureViewElement*> PageFaultsTrack::GetChildren() const {
+  return {major_page_faults_track_.get(), minor_page_faults_track_.get()};
 }
 
 void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -35,12 +35,12 @@ class PageFaultsTrack : public Track {
     return major_page_faults_track_->IsEmpty() && minor_page_faults_track_->IsEmpty();
   }
   [[nodiscard]] bool IsCollapsible() const override { return true; }
+  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
-  void SetWidth(float width) override;
 
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -316,6 +316,10 @@ std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetVisibleChildren() {
   return result;
 }
 
+std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetChildren() const {
+  return {thread_state_bar_.get(), event_bar_.get(), tracepoint_bar_.get()};
+}
+
 std::string ThreadTrack::GetTimesliceText(const TimerInfo& timer_info) const {
   std::string time = GetDisplayTime(timer_info);
 
@@ -355,15 +359,6 @@ float ThreadTrack::GetHeight() const {
   return GetHeaderHeight() +
          (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
          layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
-}
-
-// TODO(b/176216022): Make a general interface for capture view elements for setting the width to
-// every child.
-void ThreadTrack::SetWidth(float width) {
-  Track::SetWidth(width);
-  thread_state_bar_->SetWidth(width);
-  event_bar_->SetWidth(width);
-  tracepoint_bar_->SetWidth(width);
 }
 
 float ThreadTrack::GetHeaderHeight() const {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -54,7 +54,6 @@ class ThreadTrack final : public TimerTrack {
             const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
-  void SetWidth(float width) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
 
@@ -63,6 +62,7 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] bool IsEmpty() const override;
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
 
   void OnCaptureComplete();
 


### PR DESCRIPTION
Part of b/176216022 to gradually pull functionality from the track
children into more generic base classes.