### PR TITLE
Add a minimal test for CaptureViewElement

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -181,16 +181,20 @@ endif()
 add_executable(OrbitGlTests)
 
 target_sources(OrbitGlTests PRIVATE
+               CaptureViewElementTester.h
                PickingManagerTest.h
                UnitTestSlider.h)
 
 target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp
                CaptureStatsTest.cpp
+               CaptureViewElementTest.cpp
+               CaptureViewElementTester.cpp
                CaptureWindowTest.cpp
                GlUtilsTest.cpp
                GpuTrackTest.cpp
                MultivariateTimeSeriesTest.cpp
+               PageFaultsTrackTest.cpp
                PickingManagerTest.cpp
                ScopedStatusTest.cpp
                SliderTest.cpp

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -200,6 +200,7 @@ target_sources(OrbitGlTests PRIVATE
                SliderTest.cpp
                ShortenStringWithEllipsisTest.cpp
                TimerInfosIteratorTest.cpp
+               ThreadTrackTest.cpp
                TrackManagerTest.cpp
                ViewportTest.cpp)
 

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -35,7 +35,14 @@ class UnitTestCaptureViewContainerElement : public CaptureViewElement {
     }
   }
 
-  [[nodiscard]] float GetHeight() const override { return 0; }
+  [[nodiscard]] float GetHeight() const override {
+    float result = 0;
+    for (auto& child : GetChildren()) {
+      result += child->GetHeight();
+    }
+    return result;
+  }
+
   [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override {
     std::vector<CaptureViewElement*> result;
     for (auto& child : children_) {

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "CaptureViewElementTester.h"
+
+namespace orbit_gl {
+
+class UnitTestCaptureViewElement : public CaptureViewElement {
+ public:
+  explicit UnitTestCaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
+                                      Viewport* viewport, TimeGraphLayout* layout,
+                                      int child_count = 0)
+      : CaptureViewElement(parent, time_graph, viewport, layout) {
+    for (int i = 0; i < child_count; ++i) {
+      children_.emplace_back(
+          std::make_unique<UnitTestCaptureViewElement>(this, time_graph, viewport, layout));
+    }
+  }
+
+  [[nodiscard]] float GetHeight() const override { return 0; }
+  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetChildren() const {
+    std::vector<CaptureViewElement*> result;
+    for (auto& child : children_) {
+      result.push_back(child.get());
+    }
+    return result;
+  };
+
+ private:
+  std::vector<std::unique_ptr<UnitTestCaptureViewElement>> children_;
+
+  [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
+  CreateAccessibleInterface() override {
+    return nullptr;
+  }
+};
+
+TEST(CaptureViewElementTesterTest, PassesAllTestsOnExistingElement) {
+  CaptureViewElementTester tester;
+  UnitTestCaptureViewElement container_elem(nullptr, nullptr, tester.GetViewport(),
+                                            tester.GetLayout(), 2);
+  tester.RunTests(&container_elem);
+}
+}  // namespace orbit_gl

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CaptureViewElementTester.h"
+
+#include <gtest/gtest.h>
+
+void orbit_gl::CaptureViewElementTester::RunTests(CaptureViewElement* element) {
+  TestWidthPropagationToChildren(element);
+}
+
+void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(
+    CaptureViewElement* element) {
+  element->SetWidth(100);
+  for (auto& child : element->GetChildren()) {
+    EXPECT_EQ(100, child->GetWidth());
+  }
+
+  element->SetWidth(50);
+  for (auto& child : element->GetChildren()) {
+    EXPECT_EQ(50, child->GetWidth());
+  }
+}

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -12,13 +12,15 @@ void orbit_gl::CaptureViewElementTester::RunTests(CaptureViewElement* element) {
 
 void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(
     CaptureViewElement* element) {
-  element->SetWidth(100);
+  const float kWidth = 100, kUpdatedWidth = 50;
+
+  element->SetWidth(kWidth);
   for (auto& child : element->GetChildren()) {
-    EXPECT_EQ(100, child->GetWidth());
+    EXPECT_EQ(kWidth, child->GetWidth());
   }
 
-  element->SetWidth(50);
+  element->SetWidth(kUpdatedWidth);
   for (auto& child : element->GetChildren()) {
-    EXPECT_EQ(50, child->GetWidth());
+    EXPECT_EQ(kUpdatedWidth, child->GetWidth());
   }
 }

--- a/src/OrbitGl/CaptureViewElementTester.h
+++ b/src/OrbitGl/CaptureViewElementTester.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_CAPTURE_VIEW_ELEMENT_TESTER_H_
+#define ORBIT_GL_CAPTURE_VIEW_ELEMENT_TESTER_H_
+
+#include "CaptureViewElement.h"
+
+namespace orbit_gl {
+
+class CaptureViewElementTester {
+ public:
+  void RunTests(CaptureViewElement* element);
+
+  Viewport* GetViewport() { return &viewport_; }
+  TimeGraphLayout* GetLayout() { return &layout_; }
+
+ protected:
+  Viewport viewport_ = Viewport(100, 100);
+  TimeGraphLayout layout_;
+
+ private:
+  void TestWidthPropagationToChildren(CaptureViewElement* element);
+};
+
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/CaptureViewElementTester.h
+++ b/src/OrbitGl/CaptureViewElementTester.h
@@ -9,6 +9,9 @@
 
 namespace orbit_gl {
 
+// Can be used to test basic functionality of classes inheriting from CaptureViewElement to assure
+// all required methods are implemented / overriden correctly.
+// See CaptureViewElementTest.cpp for usage.
 class CaptureViewElementTester {
  public:
   void RunTests(CaptureViewElement* element);

--- a/src/OrbitGl/GpuTrackTest.cpp
+++ b/src/OrbitGl/GpuTrackTest.cpp
@@ -3,9 +3,18 @@
 // found in the LICENSE file.
 #include <gtest/gtest.h>
 
+#include "CaptureViewElementTester.h"
 #include "GpuTrack.h"
 
 using orbit_gl::MapGpuTimelineToTrackLabel;
+
+TEST(GpuTrack, CaptureViewElementWorksAsIntended) {
+  orbit_gl::CaptureViewElementTester tester;
+  GpuTrack track = GpuTrack(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), 0, nullptr,
+                            nullptr, nullptr, nullptr);
+  EXPECT_EQ(2ull, track.GetChildren().size());
+  tester.RunTests(&track);
+}
 
 TEST(GpuTrack, MapGpuTimelineToTrackLabelMapsRegularQueuesCorrectly) {
   EXPECT_EQ("Graphics queue (gfx)", MapGpuTimelineToTrackLabel("gfx"));

--- a/src/OrbitGl/PageFaultsTrackTest.cpp
+++ b/src/OrbitGl/PageFaultsTrackTest.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include <gtest/gtest.h>
+
+#include "CaptureViewElementTester.h"
+#include "PageFaultsTrack.h"
+#include "TrackTestData.h"
+
+namespace orbit_gl {
+
+TEST(PageFaultsTrack, CaptureViewElementWorksAsIntended) {
+  CaptureViewElementTester tester;
+  std::unique_ptr<orbit_client_data::CaptureData> test_data =
+      TrackTestData::GenerateTestCaptureData();
+  PageFaultsTrack track = PageFaultsTrack(nullptr, nullptr, tester.GetViewport(),
+                                          tester.GetLayout(), "", 100, test_data.get());
+  EXPECT_EQ(2ull, track.GetChildren().size());
+  tester.RunTests(&track);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/ThreadTrackTest.cpp
+++ b/src/OrbitGl/ThreadTrackTest.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include <gtest/gtest.h>
+
+#include "CaptureViewElementTester.h"
+#include "ThreadTrack.h"
+#include "TrackTestData.h"
+
+namespace orbit_gl {
+
+TEST(ThreadTrack, CaptureViewElementWorksAsIntended) {
+  CaptureViewElementTester tester;
+  std::unique_ptr<orbit_client_data::CaptureData> test_data =
+      TrackTestData::GenerateTestCaptureData();
+  ThreadTrack track =
+      ThreadTrack(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), -1, nullptr,
+                  test_data.get(), nullptr, ThreadTrack::ScopeTreeUpdateType::kNever);
+  EXPECT_EQ(3ull, track.GetChildren().size());
+  tester.RunTests(&track);
+}
+
+}  // namespace orbit_gl


### PR DESCRIPTION
The idea of this is that this can be used to test basic functionality
of classes deriving from CaptureViewElement to verify that they
keep the expected functionality when overriding.