### PR TITLE
Fix number of visible primitives

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -662,7 +662,7 @@ void CaptureWindow::RenderImGuiDebugUI() {
     IMGUI_VAR_TO_TEXT(mouse_move_pos_screen_[0]);
     IMGUI_VAR_TO_TEXT(mouse_move_pos_screen_[1]);
     if (time_graph_ != nullptr) {
-      IMGUI_VAR_TO_TEXT(time_graph_->GetNumDrawnTextBoxes());
+      IMGUI_VAR_TO_TEXT(time_graph_->GetNumVisiblePrimitives());
       IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetAllTracks().size());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMinTimeUs());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMaxTimeUs());

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -408,6 +408,14 @@ std::vector<const TimerChain*> TimeGraph::GetAllThreadTrackTimerChains() const {
   return chains;
 }
 
+int TimeGraph::GetNumVisiblePrimitives() const {
+  int num_visible_primitives = 0;
+  for (auto track : track_manager_->GetAllTracks()) {
+    num_visible_primitives += track->GetVisiblePrimitiveCount();
+  }
+  return num_visible_primitives;
+}
+
 float TimeGraph::GetWorldFromTick(uint64_t time) const {
   if (time_window_us_ > 0) {
     double start = TicksToMicroseconds(capture_min_timestamp_, time) - min_time_us_;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -123,11 +123,11 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] bool IsPartlyVisible(uint64_t min, uint64_t max) const;
   [[nodiscard]] bool IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) const;
 
-  [[nodiscard]] int GetNumDrawnTextBoxes() const { return num_drawn_text_boxes_; }
   [[nodiscard]] TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
   [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetAllThreadTrackTimerChains()
       const;
+  [[nodiscard]] int GetNumVisiblePrimitives() const;
 
   void UpdateHorizontalScroll(float ratio);
   [[nodiscard]] double GetMinTimeUs() const { return min_time_us_; }
@@ -199,7 +199,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
  private:
   AccessibleInterfaceProvider* accessible_parent_;
   TextRenderer text_renderer_static_;
-  int num_drawn_text_boxes_ = 0;
 
   // First member is id.
   absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*> iterator_timer_info_;


### PR DESCRIPTION
We used to count the number of visible text boxes, but it currently says
0, so in this PR we renamed it (as TextBox don't exist anymore) and
counted using the number of visible primitives in every track.

Clarification: We are counting primitives of all the visible tracks
(including the ones which are not visible because are being drawn
outside the visible area), but this is a bug that should be fixed in
another PR).