### PR TITLE
Add orbit_ggp::Client::GetProjectsAsync

### DIFF
--- a/src/OrbitGgp/MockGgp/Working.cpp
+++ b/src/OrbitGgp/MockGgp/Working.cpp
@@ -71,6 +71,37 @@ int GgpSshInit(char* argv[]) {
   return 0;
 }
 
+int GgpProjectList(char* argv[]) {
+  if (std::string_view{argv[1]} != "project" || std::string_view{argv[2]} != "list" ||
+      std::string_view{argv[3]} != "-s") {
+    std::cout << "arguments are formatted wrong" << std::endl;
+    return 1;
+  }
+  std::cout << R"([
+ {
+  "displayName": "displayName-1",
+  "id": "id/of/project1"
+ },
+ {
+  "displayName": "displayName-2",
+  "id": "id/of/project2"
+ }
+])" << std::endl;
+  return 0;
+}
+
+int GgpWithFourParameters(char* argv[]) {
+  if (std::string_view{argv[1]} == "instance") {
+    return GgpInstanceList(argv);
+  }
+  if (std::string_view{argv[1]} == "project") {
+    return GgpProjectList(argv);
+  }
+
+  std::cout << "arguments are formatted wrong" << std::endl;
+  return 1;
+}
+
 int main(int argc, char* argv[]) {
   // This sleep is here for 2 reasons:
   // 1. The ggp cli which this program is mocking, does have quite a bit of delay, hence having a
@@ -82,7 +113,7 @@ int main(int argc, char* argv[]) {
     case 2:
       return GgpVersion(argv);
     case 4:
-      return GgpInstanceList(argv);
+      return GgpWithFourParameters(argv);
     case 5:
       return GgpInstanceListAllReserved(argv);
     case 6:

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -15,6 +15,7 @@
 
 #include "Instance.h"
 #include "OrbitBase/Result.h"
+#include "OrbitGgp/Project.h"
 #include "SshInfo.h"
 
 namespace orbit_ggp {
@@ -33,6 +34,7 @@ class Client : public QObject {
                          bool all_reserved = false, int retry = 3);
   void GetSshInfoAsync(const Instance& ggp_instance,
                        const std::function<void(ErrorMessageOr<SshInfo>)>& callback);
+  void GetProjectsAsync(const std::function<void(ErrorMessageOr<QVector<Project>>)>& callback);
 
  private:
   explicit Client(QObject* parent, QString ggp_program, std::chrono::milliseconds timeout)


### PR DESCRIPTION
http://b/197603266

This adds the code for calling `ggp projects list -s`. It is done along the lines of the other ggp calls. I decided against refactoring that code right now, because of timing and priorities. This should ideally not use callbacks but futures. I filed http://b/199723550 for this refactor. 

