### PR TITLE
Optimize going through timers in ThreadTrack

### DIFF
--- a/src/Containers/include/Containers/ScopeTree.h
+++ b/src/Containers/include/Containers/ScopeTree.h
@@ -160,12 +160,8 @@ const ScopeT* ScopeTree<ScopeT>::FindFirstVisibleScopeAfterTime(uint32_t depth,
 
   // Previous nodes could also be partially visible if their ending is after min_visible_time.
   auto previous_node_it = node_it;
-  while (node_it != ordered_nodes.begin()) {
-    --previous_node_it;
-
-    if (previous_node_it->second->GetScope()->end() < min_visible_time) {
-      break;
-    }
+  while (node_it != ordered_nodes.begin() &&
+         (--previous_node_it)->second->GetScope()->end() >= min_visible_time) {
     node_it = previous_node_it;
   }
 

--- a/src/Containers/include/Containers/ScopeTree.h
+++ b/src/Containers/include/Containers/ScopeTree.h
@@ -91,6 +91,8 @@ class ScopeTree {
   GetOrderedNodesByDepth() const {
     return ordered_nodes_by_depth_;
   }
+  [[nodiscard]] const ScopeT* FindFirstVisibleScopeAfterTime(uint32_t depth,
+                                                             uint64_t min_visible_time) const;
   [[nodiscard]] const ScopeT* FindNextScopeAtDepth(const ScopeT& scope) const;
   [[nodiscard]] const ScopeT* FindPreviousScopeAtDepth(const ScopeT& scope) const;
   [[nodiscard]] const ScopeT* FindParent(const ScopeT& scope) const;
@@ -146,6 +148,31 @@ const ScopeT* ScopeTree<ScopeT>::FindFirstChild(const ScopeT& scope) const {
   const auto children = node->GetChildrenByStartTime();
   if (children.empty()) return nullptr;
   return children.begin()->second->GetScope();
+}
+
+template <typename ScopeT>
+const ScopeT* ScopeTree<ScopeT>::FindFirstVisibleScopeAfterTime(uint32_t depth,
+                                                                uint64_t min_visible_time) const {
+  auto& ordered_nodes = ordered_nodes_by_depth_.at(depth);
+
+  // First we get the first node who is fully after the provided time.
+  auto node_it = ordered_nodes.upper_bound(min_visible_time);
+
+  // Previous nodes could also be partially visible if their ending is after min_visible_time.
+  auto previous_node_it = node_it;
+  while (node_it != ordered_nodes.begin()) {
+    --previous_node_it;
+
+    if (previous_node_it->second->GetScope()->end() < min_visible_time) {
+      break;
+    }
+    node_it = previous_node_it;
+  }
+
+  if (node_it == ordered_nodes.end()) {
+    return nullptr;
+  }
+  return node_it->second->GetScope();
 }
 
 template <typename ScopeT>

--- a/src/Containers/include/Containers/ScopeTree.h
+++ b/src/Containers/include/Containers/ScopeTree.h
@@ -157,6 +157,8 @@ const ScopeT* ScopeTree<ScopeT>::FindFirstScopeAtOrAfterTime(uint32_t depth, uin
   auto node_it = ordered_nodes.upper_bound(time);
 
   // The previous node could also have its ending after the provided time.
+  // TODO(http://b/200692451): If we want to use ScopeTree with overlapping timers we are missing
+  // some of them.
   auto previous_node_it = node_it;
   if (node_it != ordered_nodes.begin() && (--previous_node_it)->second->GetScope()->end() >= time) {
     node_it = previous_node_it;

--- a/src/Containers/include/Containers/ScopeTree.h
+++ b/src/Containers/include/Containers/ScopeTree.h
@@ -91,8 +91,7 @@ class ScopeTree {
   GetOrderedNodesByDepth() const {
     return ordered_nodes_by_depth_;
   }
-  [[nodiscard]] const ScopeT* FindFirstVisibleScopeAfterTime(uint32_t depth,
-                                                             uint64_t min_visible_time) const;
+  [[nodiscard]] const ScopeT* FindFirstScopeAtOrAfterTime(uint32_t depth, uint64_t time) const;
   [[nodiscard]] const ScopeT* FindNextScopeAtDepth(const ScopeT& scope) const;
   [[nodiscard]] const ScopeT* FindPreviousScopeAtDepth(const ScopeT& scope) const;
   [[nodiscard]] const ScopeT* FindParent(const ScopeT& scope) const;
@@ -151,17 +150,15 @@ const ScopeT* ScopeTree<ScopeT>::FindFirstChild(const ScopeT& scope) const {
 }
 
 template <typename ScopeT>
-const ScopeT* ScopeTree<ScopeT>::FindFirstVisibleScopeAfterTime(uint32_t depth,
-                                                                uint64_t min_visible_time) const {
+const ScopeT* ScopeTree<ScopeT>::FindFirstScopeAtOrAfterTime(uint32_t depth, uint64_t time) const {
   auto& ordered_nodes = ordered_nodes_by_depth_.at(depth);
 
-  // First we get the first node who is fully after the provided time.
-  auto node_it = ordered_nodes.upper_bound(min_visible_time);
+  // Find the first node after the provided time.
+  auto node_it = ordered_nodes.upper_bound(time);
 
-  // Previous nodes could also be partially visible if their ending is after min_visible_time.
+  // The previous node could also have its ending after the provided time.
   auto previous_node_it = node_it;
-  while (node_it != ordered_nodes.begin() &&
-         (--previous_node_it)->second->GetScope()->end() >= min_visible_time) {
+  if (node_it != ordered_nodes.begin() && (--previous_node_it)->second->GetScope()->end() >= time) {
     node_it = previous_node_it;
   }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -494,7 +494,7 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
     uint64_t next_pixel_start_time_ns = min_tick;
 
     const orbit_client_protos::TimerInfo* timer_info =
-        scope_tree_.FindFirstVisibleScopeAfterTime(depth, min_tick);
+        scope_tree_.FindFirstScopeAtOrAfterTime(depth, min_tick);
 
     while (timer_info != nullptr && timer_info->start() < max_tick) {
       ++visible_timer_count_;
@@ -519,7 +519,7 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
 
       // Use the time at boundary of the next pixel as a threshold to avoid overdraw.
       next_pixel_start_time_ns = GetNextPixelBoundaryTimeNs(timer_info->end(), draw_data);
-      timer_info = scope_tree_.FindFirstVisibleScopeAfterTime(depth, next_pixel_start_time_ns);
+      timer_info = scope_tree_.FindFirstScopeAtOrAfterTime(depth, next_pixel_start_time_ns);
     }
   }
 }


### PR DESCRIPTION
Here we are optimizing UpdatePrimitives in ThreadTracks by not going
through timers that will be drawn in the same pixel of another
previously drawn. We weren't drawing them anyways, but we were going
through all of them, making orbit very slow when there were a lot
of timers to draw.

I made 2 experiments, both using instrospection. In the future a better experiment should be done, Pierric suggested to make it with Orbit itself in Windows.

The First one is the ideal case we want to tackle of having millions of timers in a few tracks. For that I hooked the Dot function for 17 seconds producing 38 million timers. There are only 11707 elements to draw.
In that case we saw an improvement of 3843.97% when drawing everything again after filtering before and a 1614.13% while navigating vertically in the capture.

The second case is a capture generated with Orbit Test where there are a lot of tracks and depths (a total of 380 different depths), so only an average of 3000 elements per list. I didn't expect to have a big optimization in this kind of case (we are limited for the amount of lists instead of the number of elements in the lists) but we still have an improvement of 63.88% when drawing everything again after filtering before and a 29.39% while navigating vertically in the capture.
https://docs.google.com/spreadsheets/d/1Dm8HeCvVH1pMM7gk5oPJOLKyh3wNFj1T_tTSC-PjLf0/edit?resourcekey=0-4gLk_6bz1SXnBnKP4l-NTA#gid=0

Speaking of complexity, where N is the number of timers in a certain depth level and D the number of drawn timers, the complexity of UpdatePrimitives should be:

Before: O(N) 
Now: O(lg(N)) * O(D)

So, having a screen of 2000 pixels width and if we are drawing in each pixel (worst case), the optimization seems to be an improvement theoretically since having 30k visible timers in certain depth.

Orbit is being too slow anyways (far away from 30fps) and we are only drawing
ThreadTracks, so a future analysis should be made. Also neither of both captures is closely using all pixels in the screen.

Next Step: Motivated in Pierric's capture, I will make the simple optimization of only updating tracks if they are visible, this simple if should mean a big improvement in Captures where we have a lot of tracks.

Test: Load a capture. Counted the number of timers drawn, the number doesn't
decrease with current state. Start a new capture.