### PR TITLE
Add ggp project parameter

### DIFF
--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -13,6 +13,7 @@
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/Client.h"
 #include "OrbitGgp/Instance.h"
+#include "OrbitGgp/Project.h"
 #include "OrbitGgp/SshInfo.h"
 #include "TestUtils/TestUtils.h"
 
@@ -74,6 +75,54 @@ TEST(OrbitGgpClient, GetInstancesAsyncWorkingAllReserved) {
         EXPECT_EQ(instances.value().size(), 2);
       },
       true);
+
+  QCoreApplication::exec();
+
+  EXPECT_TRUE(callback_was_called);
+}
+
+TEST(OrbitGgpClient, GetInstancesAsyncWorkingWithProject) {
+  const std::filesystem::path mock_ggp_working =
+      orbit_base::GetExecutableDir() / "OrbitMockGgpWorking";
+
+  auto client = Client::Create(nullptr, QString::fromStdString(mock_ggp_working.string()));
+  ASSERT_THAT(client, HasValue());
+
+  Project project{"display name", "project/test/id"};
+
+  bool callback_was_called = false;
+  client.value()->GetInstancesAsync(
+      [&callback_was_called](ErrorMessageOr<QVector<Instance>> instances) {
+        QCoreApplication::exit();
+        callback_was_called = true;
+        ASSERT_TRUE(instances.has_value());
+        EXPECT_EQ(instances.value().size(), 2);
+      },
+      false, project);
+
+  QCoreApplication::exec();
+
+  EXPECT_TRUE(callback_was_called);
+}
+
+TEST(OrbitGgpClient, GetInstancesAsyncWorkingAllReservedWithProject) {
+  const std::filesystem::path mock_ggp_working =
+      orbit_base::GetExecutableDir() / "OrbitMockGgpWorking";
+
+  auto client = Client::Create(nullptr, QString::fromStdString(mock_ggp_working.string()));
+  ASSERT_THAT(client, HasValue());
+
+  Project project{"display name", "project/test/id"};
+
+  bool callback_was_called = false;
+  client.value()->GetInstancesAsync(
+      [&callback_was_called](ErrorMessageOr<QVector<Instance>> instances) {
+        QCoreApplication::exit();
+        callback_was_called = true;
+        ASSERT_TRUE(instances.has_value());
+        EXPECT_EQ(instances.value().size(), 2);
+      },
+      true, project);
 
   QCoreApplication::exec();
 

--- a/src/OrbitGgp/MockGgp/Working.cpp
+++ b/src/OrbitGgp/MockGgp/Working.cpp
@@ -22,7 +22,7 @@ int GgpVersion(int argc, char* argv[]) {
 }
 
 int GgpInstanceList(int argc, char* argv[]) {
-  if (argc < 4 || argc > 5) {
+  if (argc < 4 || argc > 7) {
     std::cout << "Wrong amount of arguments" << std::endl;
     return 1;
   }
@@ -33,6 +33,19 @@ int GgpInstanceList(int argc, char* argv[]) {
   }
 
   if (argc == 5 && std::string_view{argv[4]} != "--all-reserved") {
+    std::cout << "arguments are formatted wrong" << std::endl;
+    return 1;
+  }
+
+  if (argc == 6 && (std::string_view{argv[4]} != "--project" ||
+                    std::string_view{argv[5]} != "project/test/id")) {
+    std::cout << "arguments are formatted wrong" << std::endl;
+    return 1;
+  }
+
+  if (argc == 7 &&
+      (std::string_view{argv[4]} != "--all-reserved" || std::string_view{argv[5]} != "--project" ||
+       std::string_view{argv[6]} != "project/test/id")) {
     std::cout << "arguments are formatted wrong" << std::endl;
     return 1;
   }

--- a/src/OrbitGgp/MockGgp/Working.cpp
+++ b/src/OrbitGgp/MockGgp/Working.cpp
@@ -7,7 +7,11 @@
 #include <string_view>
 #include <thread>
 
-int GgpVersion(char* argv[]) {
+int GgpVersion(int argc, char* argv[]) {
+  if (argc != 2) {
+    std::cout << "Wrong amount of arguments" << std::endl;
+    return 1;
+  }
   if (std::string_view{argv[1]} != "version") {
     std::cout << "arguments are formatted wrong" << std::endl;
     return 1;
@@ -17,12 +21,22 @@ int GgpVersion(char* argv[]) {
   return 0;
 }
 
-int GgpInstanceList(char* argv[]) {
+int GgpInstanceList(int argc, char* argv[]) {
+  if (argc < 4 || argc > 5) {
+    std::cout << "Wrong amount of arguments" << std::endl;
+    return 1;
+  }
   if (std::string_view{argv[1]} != "instance" || std::string_view{argv[2]} != "list" ||
       std::string_view{argv[3]} != "-s") {
     std::cout << "arguments are formatted wrong" << std::endl;
     return 1;
   }
+
+  if (argc == 5 && std::string_view{argv[4]} != "--all-reserved") {
+    std::cout << "arguments are formatted wrong" << std::endl;
+    return 1;
+  }
+
   std::cout << R"([
  {
   "displayName": "displayName-1",
@@ -46,15 +60,11 @@ int GgpInstanceList(char* argv[]) {
   return 0;
 }
 
-int GgpInstanceListAllReserved(char* argv[]) {
-  if (std::string_view{argv[4]} != "--all-reserved") {
-    std::cout << "arguments are formatted wrong" << std::endl;
+int GgpSshInit(int argc, char* argv[]) {
+  if (argc != 6) {
+    std::cout << "Wrong amount of arguments" << std::endl;
     return 1;
   }
-  return GgpInstanceList(argv);
-}
-
-int GgpSshInit(char* argv[]) {
   if (std::string_view{argv[1]} != "ssh" || std::string_view{argv[2]} != "init" ||
       std::string_view{argv[3]} != "-s" || std::string_view{argv[4]} != "--instance" ||
       std::string_view{argv[5]} != "instance/test/id") {
@@ -71,7 +81,11 @@ int GgpSshInit(char* argv[]) {
   return 0;
 }
 
-int GgpProjectList(char* argv[]) {
+int GgpProjectList(int argc, char* argv[]) {
+  if (argc != 4) {
+    std::cout << "Wrong amount of arguments" << std::endl;
+    return 1;
+  }
   if (std::string_view{argv[1]} != "project" || std::string_view{argv[2]} != "list" ||
       std::string_view{argv[3]} != "-s") {
     std::cout << "arguments are formatted wrong" << std::endl;
@@ -90,18 +104,6 @@ int GgpProjectList(char* argv[]) {
   return 0;
 }
 
-int GgpWithFourParameters(char* argv[]) {
-  if (std::string_view{argv[1]} == "instance") {
-    return GgpInstanceList(argv);
-  }
-  if (std::string_view{argv[1]} == "project") {
-    return GgpProjectList(argv);
-  }
-
-  std::cout << "arguments are formatted wrong" << std::endl;
-  return 1;
-}
-
 int main(int argc, char* argv[]) {
   // This sleep is here for 2 reasons:
   // 1. The ggp cli which this program is mocking, does have quite a bit of delay, hence having a
@@ -109,17 +111,27 @@ int main(int argc, char* argv[]) {
   // 2. To test the timeout functionaliy in OrbitGgp::Client
   std::this_thread::sleep_for(std::chrono::milliseconds{50});
 
-  switch (argc) {
-    case 2:
-      return GgpVersion(argv);
-    case 4:
-      return GgpWithFourParameters(argv);
-    case 5:
-      return GgpInstanceListAllReserved(argv);
-    case 6:
-      return GgpSshInit(argv);
-    default:
-      std::cout << "Wrong amount of arguments" << std::endl;
-      return 1;
+  if (argc <= 1) {
+    std::cout << "Wrong amount of arguments" << std::endl;
+    return 1;
   }
+
+  if (std::string_view{argv[1]} == "version") {
+    return GgpVersion(argc, argv);
+  }
+
+  if (std::string_view{argv[1]} == "ssh") {
+    return GgpSshInit(argc, argv);
+  }
+
+  if (std::string_view{argv[1]} == "instance") {
+    return GgpInstanceList(argc, argv);
+  }
+
+  if (std::string_view{argv[1]} == "project") {
+    return GgpProjectList(argc, argv);
+  }
+
+  std::cout << "arguments are formatted wrong" << std::endl;
+  return 1;
 }

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -11,6 +11,7 @@
 #include <QVector>
 #include <chrono>
 #include <functional>
+#include <optional>
 #include <string>
 
 #include "Instance.h"
@@ -31,7 +32,8 @@ class Client : public QObject {
       std::chrono::milliseconds timeout = GetDefaultTimeoutMs());
 
   void GetInstancesAsync(const std::function<void(ErrorMessageOr<QVector<Instance>>)>& callback,
-                         bool all_reserved = false, int retry = 3);
+                         bool all_reserved = false, std::optional<Project> project = std::nullopt,
+                         int retry = 3);
   void GetSshInfoAsync(const Instance& ggp_instance,
                        const std::function<void(ErrorMessageOr<SshInfo>)>& callback);
   void GetProjectsAsync(const std::function<void(ErrorMessageOr<QVector<Project>>)>& callback);


### PR DESCRIPTION
This first refactors Working.cpp, which is the basis for the Mock ggp client. 

Then the main addition here is: Add project parameter to GgpInstanceList. This adds the possibility to list instances from other than the default project. (http://b/197602754). The way calls are made to the ggp cli is not touched here and I leave a refactor for this part as http://b/199723550

Also adds tests for the new project parameter and the needed additions in Working.cpp (MockGgp)