### PR TITLE
Change some more int32_t to uint32_t for pids on the client

### DIFF
--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -101,7 +101,7 @@ class CaptureData {
 
   static const std::string kUnknownFunctionOrModuleName;
 
-  [[nodiscard]] const absl::flat_hash_map<int32_t, std::string>& thread_names() const {
+  [[nodiscard]] const absl::flat_hash_map<uint32_t, std::string>& thread_names() const {
     return thread_names_;
   }
 
@@ -115,7 +115,7 @@ class CaptureData {
     thread_names_.insert_or_assign(thread_id, std::move(thread_name));
   }
 
-  [[nodiscard]] const absl::flat_hash_map<int32_t,
+  [[nodiscard]] const absl::flat_hash_map<uint32_t,
                                           std::vector<orbit_client_protos::ThreadStateSliceInfo>>&
   thread_state_slices() const {
     return thread_state_slices_;
@@ -263,10 +263,10 @@ class CaptureData {
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats> functions_stats_;
 
-  absl::flat_hash_map<int32_t, std::string> thread_names_;
+  absl::flat_hash_map<uint32_t, std::string> thread_names_;
 
   // For each thread, assume sorted by timestamp and not overlapping.
-  absl::flat_hash_map<int32_t, std::vector<orbit_client_protos::ThreadStateSliceInfo>>
+  absl::flat_hash_map<uint32_t, std::vector<orbit_client_protos::ThreadStateSliceInfo>>
       thread_state_slices_ GUARDED_BY(thread_state_slices_mutex_);
   mutable absl::Mutex thread_state_slices_mutex_;
 

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -149,7 +149,7 @@ static void AddUnwindErrorToTopDownThread(CallTreeThread* thread_node,
 
 [[nodiscard]] static CallTreeThread* GetOrCreateThreadNode(
     CallTreeNode* current_node, uint32_t tid, const std::string& process_name,
-    const absl::flat_hash_map<int32_t, std::string>& thread_names) {
+    const absl::flat_hash_map<uint32_t, std::string>& thread_names) {
   CallTreeThread* thread_node = current_node->GetThreadOrNull(tid);
   if (thread_node == nullptr) {
     std::string thread_name;
@@ -168,7 +168,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
     const CaptureData& capture_data) {
   auto top_down_view = std::make_unique<CallTreeView>();
   const std::string& process_name = capture_data.process_name();
-  const absl::flat_hash_map<int32_t, std::string>& thread_names = capture_data.thread_names();
+  const absl::flat_hash_map<uint32_t, std::string>& thread_names = capture_data.thread_names();
 
   for (const ThreadSampleData& thread_sample_data :
        post_processed_sampling_data.GetThreadSampleData()) {
@@ -240,7 +240,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedS
     const CaptureData& capture_data) {
   auto bottom_up_view = std::make_unique<CallTreeView>();
   const std::string& process_name = capture_data.process_name();
-  const absl::flat_hash_map<int32_t, std::string>& thread_names = capture_data.thread_names();
+  const absl::flat_hash_map<uint32_t, std::string>& thread_names = capture_data.thread_names();
 
   for (const ThreadSampleData& thread_sample_data :
        post_processed_sampling_data.GetThreadSampleData()) {

--- a/src/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/CallTreeView.h
@@ -77,7 +77,7 @@ class CallTreeNode {
  protected:
   // absl::node_hash_map instead of absl::flat_hash_map as pointer stability is
   // needed for the CallTreeNode::parent_ field.
-  absl::node_hash_map<int32_t, CallTreeThread> thread_children_;
+  absl::node_hash_map<uint32_t, CallTreeThread> thread_children_;
   absl::node_hash_map<uint64_t, CallTreeFunction> function_children_;
   // std::shared_ptr instead of std::unique_ptr because absl::node_hash_map
   // needs the copy constructor (even for try_emplace).


### PR DESCRIPTION
Some leftovers from the big transition from `int32_t` to `uint32_t`, as
correctly pointed out by the IDE.

Test: Take a capture (with thread state enabled), check that things look in
order.