### PR TITLE
Cache CallTreeView::children

### DIFF
--- a/src/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/CallTreeView.h
@@ -34,7 +34,7 @@ class CallTreeNode {
            (unwind_errors_child_ != nullptr ? 1 : 0);
   }
 
-  [[nodiscard]] std::vector<const CallTreeNode*> children() const;
+  [[nodiscard]] const std::vector<const CallTreeNode*>& children() const;
 
   [[nodiscard]] CallTreeThread* GetThreadOrNull(uint32_t thread_id);
 
@@ -74,7 +74,7 @@ class CallTreeNode {
     return 100.0f * GetExclusiveSampleCount() / total_sample_count;
   }
 
- protected:
+ private:
   // absl::node_hash_map instead of absl::flat_hash_map as pointer stability is
   // needed for the CallTreeNode::parent_ field.
   absl::node_hash_map<uint32_t, CallTreeThread> thread_children_;
@@ -83,9 +83,11 @@ class CallTreeNode {
   // needs the copy constructor (even for try_emplace).
   std::shared_ptr<CallTreeUnwindErrors> unwind_errors_child_;
 
- private:
   CallTreeNode* parent_;
   uint64_t sample_count_ = 0;
+
+  // Filled lazily when children() is called, invalidated when children are invalidated.
+  mutable std::optional<std::vector<const CallTreeNode*>> children_cache_;
 };
 
 class CallTreeFunction : public CallTreeNode {

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -28,10 +28,8 @@ SamplingReport::SamplingReport(
       unique_callstacks_{std::move(unique_callstacks)},
       has_summary_{has_summary},
       app_{app} {
-  selected_thread_id_ = 0;
-  callstack_data_view_ = nullptr;
-  selected_sorted_callstack_report_ = nullptr;
-  selected_callstack_index_ = 0;
+  ORBIT_SCOPE_FUNCTION;
+  SCOPED_TIMED_LOG("SamplingReport::SamplingReport");
   FillReport();
 }
 

--- a/src/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/SamplingReport.h
@@ -58,12 +58,13 @@ class SamplingReport {
   absl::flat_hash_map<uint64_t, std::shared_ptr<orbit_client_protos::CallstackInfo>>
       unique_callstacks_;
   std::vector<SamplingReportDataView> thread_reports_;
-  CallstackDataView* callstack_data_view_;
+  CallstackDataView* callstack_data_view_ = nullptr;
 
   absl::flat_hash_set<uint64_t> selected_addresses_;
-  orbit_client_data::ThreadID selected_thread_id_;
-  std::unique_ptr<orbit_client_data::SortedCallstackReport> selected_sorted_callstack_report_;
-  size_t selected_callstack_index_;
+  orbit_client_data::ThreadID selected_thread_id_ = 0;
+  std::unique_ptr<orbit_client_data::SortedCallstackReport> selected_sorted_callstack_report_ =
+      nullptr;
+  size_t selected_callstack_index_ = 0;
   std::function<void()> ui_refresh_func_;
   bool has_summary_;
   OrbitApp* app_ = nullptr;


### PR DESCRIPTION
This is a huge speedup in both building and searching top-down and bottom-up
views, in particular the bottom-up view, and in particular when symbols for a
lot of functions are missing, which prevents grouping addresses belonging to the
same function together (which is a completely separate problem).

All credits to Nikita!

Also add a couple of `ORBIT_SCOPE_FUNCTION`+`SCOPED_TIMED_LOG`s, and fix a minor
clang-tidy warning in `SamplingReport`.

Bug: http://b/199712443

Test: Load the capture linked in the bug before and after and verify the huge
speedup. Take some more captures and verify the speedup and that top-down and
bottom-up views look good.