### PR TITLE
Align stack to 16 bytes before calling EntryPayload

### DIFF
--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
@@ -57,6 +57,11 @@ uint64_t ExitPayload() {
   return current_return_address.return_address;
 }
 
+void EntryPayloadAlignedCopy(uint64_t return_address, uint64_t function_id) {
+  return_addresses.emplace(return_address, function_id);
+  __asm__ __volatile__("movaps -0x10(%%rbp), %%xmm0\n\t" : : :);
+}
+
 // rdi, rsi, rdx, rcx, r8, r9, rax, r10
 void EntryPayloadClobberParameterRegisters(uint64_t return_address, uint64_t function_id) {
   return_addresses.emplace(return_address, function_id);

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
@@ -26,6 +26,13 @@ extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id);
 // the function such that the execution can be continued there.
 extern "C" uint64_t ExitPayload();
 
+// Performs a MOVAPS from an address at a distance multiple of 16 from RBP. As the 128-bit memory
+// operands must be 16-byte aligned (SIGSEGV is raised otherwise), this verifies that the stack was
+// aligned to 16 bytes before calling this EntryPayload.
+// We are assuming that this function updates the frame pointer, i.e., that it starts with
+// `push rbp; mov rbp, rsp`.
+extern "C" void EntryPayloadAlignedCopy(uint64_t return_address, uint64_t function_id);
+
 // Overwrites rdi, rsi, rdx, rcx, r8, r9, rax, r10. These registers are used to hand over parameters
 // to a called function. This function is used to assert our backup of these registers works
 // properly. The two functions below do the same thing for SSE/AVX registers that can be used to


### PR DESCRIPTION
The calling convention requires that the stack be aligned to 16 bytes before
calling a function, but `push rax` before calling
`entry_payload_function_address` was violating that.

Test: Add `InstrumentFunctionTest.CheckStackAlignedTo16Bytes`.
Run it before fix: hangs or fails. Run it after fix: passes.