### PR TITLE
Add FindMutableModuleByAddress

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -310,7 +310,14 @@ const FunctionInfo* CaptureData::FindFunctionByAddress(uint64_t absolute_address
   return module->FindFunctionByOffset(offset, is_exact);
 }
 
-[[nodiscard]] ModuleData* CaptureData::FindModuleByAddress(uint64_t absolute_address) const {
+[[nodiscard]] const ModuleData* CaptureData::FindModuleByAddress(uint64_t absolute_address) const {
+  const auto result = process_.FindModuleByAddress(absolute_address);
+  if (result.has_error()) return nullptr;
+  return module_manager_->GetModuleByPathAndBuildId(result.value().file_path(),
+                                                    result.value().build_id());
+}
+
+[[nodiscard]] ModuleData* CaptureData::FindMutableModuleByAddress(uint64_t absolute_address) {
   const auto result = process_.FindModuleByAddress(absolute_address);
   if (result.has_error()) return nullptr;
   return module_manager_->GetMutableModuleByPathAndBuildId(result.value().file_path(),

--- a/src/ClientData/ModuleManagerTest.cpp
+++ b/src/ClientData/ModuleManagerTest.cpp
@@ -43,21 +43,42 @@ TEST(ModuleManager, GetModuleByPathAndBuildId) {
   ModuleManager module_manager;
   EXPECT_TRUE(module_manager.AddOrUpdateModules({module_info}).empty());
 
-  const ModuleData* module = module_manager.GetModuleByPathAndBuildId(file_path, build_id);
-  ASSERT_NE(module, nullptr);
-  EXPECT_EQ(module->name(), name);
-  EXPECT_EQ(module->file_path(), file_path);
-  EXPECT_EQ(module->file_size(), file_size);
-  EXPECT_EQ(module->build_id(), build_id);
-  EXPECT_EQ(module->load_bias(), load_bias);
+  {
+    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(file_path, build_id);
+    const ModuleData* mutable_module =
+        module_manager.GetMutableModuleByPathAndBuildId(file_path, build_id);
+    ASSERT_NE(module, nullptr);
+    EXPECT_EQ(module, mutable_module);
+    EXPECT_EQ(module->name(), name);
+    EXPECT_EQ(module->file_path(), file_path);
+    EXPECT_EQ(module->file_size(), file_size);
+    EXPECT_EQ(module->build_id(), build_id);
+    EXPECT_EQ(module->load_bias(), load_bias);
+  }
 
-  const ModuleData* module_invalid_path =
-      module_manager.GetModuleByPathAndBuildId("wrong/path", build_id);
-  EXPECT_EQ(module_invalid_path, nullptr);
+  {
+    const ModuleData* module_invalid_path =
+        module_manager.GetModuleByPathAndBuildId("wrong/path", build_id);
+    EXPECT_EQ(module_invalid_path, nullptr);
+  }
 
-  const ModuleData* module_invalid_build_id =
-      module_manager.GetModuleByPathAndBuildId(file_path, "wrong buildid");
-  EXPECT_EQ(module_invalid_build_id, nullptr);
+  {
+    const ModuleData* mutable_module_invalid_path =
+        module_manager.GetModuleByPathAndBuildId("wrong/path", build_id);
+    EXPECT_EQ(mutable_module_invalid_path, nullptr);
+  }
+
+  {
+    const ModuleData* module_invalid_build_id =
+        module_manager.GetModuleByPathAndBuildId(file_path, "wrong buildid");
+    EXPECT_EQ(module_invalid_build_id, nullptr);
+  }
+
+  {
+    const ModuleData* module_invalid_build_id =
+        module_manager.GetMutableModuleByPathAndBuildId(file_path, "wrong buildid");
+    EXPECT_EQ(module_invalid_build_id, nullptr);
+  }
 }
 
 TEST(ModuleManager, GetMutableModuleByPathAndBuildId) {

--- a/src/ClientData/ModuleManagerTest.cpp
+++ b/src/ClientData/ModuleManagerTest.cpp
@@ -64,7 +64,7 @@ TEST(ModuleManager, GetModuleByPathAndBuildId) {
 
   {
     const ModuleData* mutable_module_invalid_path =
-        module_manager.GetModuleByPathAndBuildId("wrong/path", build_id);
+        module_manager.GetMutableModuleByPathAndBuildId("wrong/path", build_id);
     EXPECT_EQ(mutable_module_invalid_path, nullptr);
   }
 

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -97,7 +97,10 @@ class CaptureData {
 
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
       uint64_t absolute_address, bool is_exact) const;
-  [[nodiscard]] orbit_client_data::ModuleData* FindModuleByAddress(uint64_t absolute_address) const;
+  [[nodiscard]] const orbit_client_data::ModuleData* FindModuleByAddress(
+      uint64_t absolute_address) const;
+  [[nodiscard]] orbit_client_data::ModuleData* FindMutableModuleByAddress(
+      uint64_t absolute_address);
 
   static const std::string kUnknownFunctionOrModuleName;
 

--- a/src/OrbitGl/CallstackDataView.cpp
+++ b/src/OrbitGl/CallstackDataView.cpp
@@ -262,9 +262,9 @@ CallstackDataView::CallstackDataViewFrame CallstackDataView::GetFrameFromIndex(
   CHECK(index_in_callstack < callstack_.frames_size());
   uint64_t address = callstack_.frames(index_in_callstack);
 
-  const CaptureData& capture_data = app_->GetCaptureData();
+  CaptureData& capture_data = app_->GetMutableCaptureData();
   const FunctionInfo* function = capture_data.FindFunctionByAddress(address, false);
-  ModuleData* module = capture_data.FindModuleByAddress(address);
+  ModuleData* module = capture_data.FindMutableModuleByAddress(address);
 
   if (function != nullptr) {
     return CallstackDataViewFrame(address, function, module);


### PR DESCRIPTION
FindMutableModuleByAddress is a non-const function that reuturns
non-const ModuleData. FindModuleByAddress changed to return
const ModuleData.

Test: builds