### PR TITLE
Always expose callstack sampling period (previously only in --devmode)

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1325,9 +1325,7 @@ void OrbitApp::StartCapture() {
   bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
   bool enable_user_space_instrumentation =
       IsDevMode() && data_manager_->enable_user_space_instrumentation();
-  constexpr double kSamplesPerSecondDefault = 1000.0;
-  double samples_per_second =
-      IsDevMode() ? data_manager_->samples_per_second() : kSamplesPerSecondDefault;
+  double samples_per_second = data_manager_->samples_per_second();
   uint16_t stack_dump_size = data_manager_->stack_dump_size();
   UnwindingMethod unwinding_method = data_manager_->unwinding_method();
   uint64_t max_local_marker_depth_per_command_buffer =

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -25,7 +25,7 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
   if (!absl::GetFlag(FLAGS_devmode)) {
-    ui_->samplingWidget->hide();
+    ui_->samplingCheckBox->hide();
   }
 
   ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -25,6 +25,7 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
   if (!absl::GetFlag(FLAGS_devmode)) {
+    // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
     ui_->samplingCheckBox->hide();
   }
 

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -35,75 +35,57 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
-         <widget class="QWidget" name="samplingWidget" native="true">
-          <layout class="QVBoxLayout" name="samplingVerticalLayout">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QCheckBox" name="samplingCheckBox">
-             <property name="text">
-              <string>Enable callstack sampling</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="samplingPeriodMsHorizontalLayout">
-             <item>
-              <widget class="QLabel" name="samplingPeriodMsLabel">
-               <property name="text">
-                <string>Callstack sampling period (ms):</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QDoubleSpinBox" name="samplingPeriodMsDoubleSpinBox">
-               <property name="decimals">
-                <number>1</number>
-               </property>
-               <property name="minimum">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>10.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>1.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="samplingPeriodMsHorizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-          </layout>
+         <widget class="QCheckBox" name="samplingCheckBox">
+          <property name="text">
+           <string>Enable callstack sampling</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
          </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="samplingPeriodMsHorizontalLayout">
+          <item>
+           <widget class="QLabel" name="samplingPeriodMsLabel">
+            <property name="text">
+             <string>Callstack sampling period (ms):</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="samplingPeriodMsDoubleSpinBox">
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>10.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="samplingPeriodMsHorizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QCheckBox" name="threadStateCheckBox">

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1068,7 +1068,7 @@ constexpr uint64_t kMemoryWarningThresholdKbDefaultValue = 1024 * 1024 * 8;  // 
 
 void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
   QSettings settings;
-  if (settings.value(kEnableCallstackSamplingSettingKey, true).toBool()) {
+  if (!app_->IsDevMode() || settings.value(kEnableCallstackSamplingSettingKey, true).toBool()) {
     bool conversion_succeeded = false;
     double sampling_period_ms =
         settings.value(kCallstackSamplingPeriodMsSettingKey, kCallstackSamplingPeriodMsDefaultValue)
@@ -1121,7 +1121,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   QSettings settings;
 
   orbit_qt::CaptureOptionsDialog dialog{this};
-  dialog.SetEnableSampling(settings.value(kEnableCallstackSamplingSettingKey, true).toBool());
+  dialog.SetEnableSampling(!app_->IsDevMode() ||
+                           settings.value(kEnableCallstackSamplingSettingKey, true).toBool());
   dialog.SetSamplingPeriodMs(
       settings.value(kCallstackSamplingPeriodMsSettingKey, kCallstackSamplingPeriodMsDefaultValue)
           .toDouble());


### PR DESCRIPTION
Don't expose the possibility of disabling sampling altogether as a bit more UI
work might be necessary. See comments in http://b/198748597 and
http://b/199857201 for more details.

Bug: http://b/199857201

Test: Run with and without `--devmode` and verify `CaptureOptions` dialog.
Capture Honolulu (up to 400% CPU utilization) with sampling period 0.1 ms to
verify that `OrbitService` can handle it.