### PR TITLE
Implement GetModuleByModuleInMemoryAndAbsoluteAddress

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -236,12 +236,11 @@ CaptureData::FindFunctionAbsoluteAddressByInstructionAbsoluteAddressUsingModules
     uint64_t absolute_address) const {
   const auto module_or_error = process_.FindModuleByAddress(absolute_address);
   if (module_or_error.has_error()) return std::nullopt;
-  const std::string& module_path = module_or_error.value().file_path();
-  const std::string& module_build_id = module_or_error.value().build_id();
-  const uint64_t module_base_address = module_or_error.value().start();
+  const auto& module_in_memory = module_or_error.value();
+  const uint64_t module_base_address = module_in_memory.start();
 
-  const ModuleData* module =
-      module_manager_->GetModuleByPathAndBuildId(module_path, module_build_id);
+  const ModuleData* module = module_manager_->GetModuleByModuleInMemoryAndAbsoluteAddress(
+      module_in_memory, absolute_address);
   if (module == nullptr) return std::nullopt;
 
   const uint64_t offset = orbit_object_utils::SymbolAbsoluteAddressToOffset(
@@ -297,12 +296,10 @@ const FunctionInfo* CaptureData::FindFunctionByAddress(uint64_t absolute_address
   const auto module_or_error = process_.FindModuleByAddress(absolute_address);
   if (module_or_error.has_error()) return nullptr;
   const auto& module_in_memory = module_or_error.value();
-  const std::string& module_path = module_in_memory.file_path();
-  const std::string& module_build_id = module_in_memory.build_id();
   const uint64_t module_base_address = module_in_memory.start();
 
-  const ModuleData* module =
-      module_manager_->GetModuleByPathAndBuildId(module_path, module_build_id);
+  const ModuleData* module = module_manager_->GetModuleByModuleInMemoryAndAbsoluteAddress(
+      module_in_memory, absolute_address);
   if (module == nullptr) return nullptr;
 
   const uint64_t offset = orbit_object_utils::SymbolAbsoluteAddressToOffset(
@@ -313,15 +310,15 @@ const FunctionInfo* CaptureData::FindFunctionByAddress(uint64_t absolute_address
 [[nodiscard]] const ModuleData* CaptureData::FindModuleByAddress(uint64_t absolute_address) const {
   const auto result = process_.FindModuleByAddress(absolute_address);
   if (result.has_error()) return nullptr;
-  return module_manager_->GetModuleByPathAndBuildId(result.value().file_path(),
-                                                    result.value().build_id());
+  return module_manager_->GetModuleByModuleInMemoryAndAbsoluteAddress(result.value(),
+                                                                      absolute_address);
 }
 
 [[nodiscard]] ModuleData* CaptureData::FindMutableModuleByAddress(uint64_t absolute_address) {
   const auto result = process_.FindModuleByAddress(absolute_address);
   if (result.has_error()) return nullptr;
-  return module_manager_->GetMutableModuleByPathAndBuildId(result.value().file_path(),
-                                                           result.value().build_id());
+  return module_manager_->GetMutableModuleByModuleInMemoryAndAbsoluteAddress(result.value(),
+                                                                             absolute_address);
 }
 
 uint32_t CaptureData::process_id() const { return process_.pid(); }

--- a/src/ClientData/ModuleManager.cpp
+++ b/src/ClientData/ModuleManager.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "ClientData/ModuleData.h"
+#include "ObjectUtils/Address.h"
 #include "OrbitBase/Logging.h"
 #include "absl/synchronization/mutex.h"
 #include "capture_data.pb.h"
@@ -65,6 +66,40 @@ std::vector<ModuleData*> ModuleManager::AddOrUpdateNotLoadedModules(
   }
 
   return not_updated_modules;
+}
+
+const ModuleData* ModuleManager::GetModuleByModuleInMemoryAndAbsoluteAddress(
+    const ModuleInMemory& module_in_memory, uint64_t absolute_address) const {
+  absl::MutexLock lock(&mutex_);
+  auto it =
+      module_map_.find(std::make_pair(module_in_memory.file_path(), module_in_memory.build_id()));
+  if (it == module_map_.end()) return nullptr;
+
+  // The valid absolute address should be >=
+  // module_base_address + (executable_segment_offset % kPageSize)
+  if (absolute_address < module_in_memory.start() + (it->second.executable_segment_offset() %
+                                                     orbit_object_utils::kPageSize)) {
+    return nullptr;
+  }
+
+  return &it->second;
+}
+
+ModuleData* ModuleManager::GetMutableModuleByModuleInMemoryAndAbsoluteAddress(
+    const ModuleInMemory& module_in_memory, uint64_t absolute_address) {
+  absl::MutexLock lock(&mutex_);
+  auto it =
+      module_map_.find(std::make_pair(module_in_memory.file_path(), module_in_memory.build_id()));
+  if (it == module_map_.end()) return nullptr;
+
+  // The valid absolute address should be >=
+  // module_base_address + (executable_segment_offset % kPageSize)
+  if (absolute_address < module_in_memory.start() + (it->second.executable_segment_offset() %
+                                                     orbit_object_utils::kPageSize)) {
+    return nullptr;
+  }
+
+  return &it->second;
 }
 
 const ModuleData* ModuleManager::GetModuleByPathAndBuildId(const std::string& path,

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -90,10 +90,6 @@ class CaptureData {
   [[nodiscard]] const std::string& GetModulePathByAddress(uint64_t absolute_address) const;
   [[nodiscard]] std::optional<std::string> FindModuleBuildIdByAddress(
       uint64_t absolute_address) const;
-  [[nodiscard]] const orbit_client_data::ModuleData* GetModuleByPathAndBuildId(
-      const std::string& module_path, const std::string& build_id) const {
-    return module_manager_->GetModuleByPathAndBuildId(module_path, build_id);
-  }
 
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
       uint64_t absolute_address, bool is_exact) const;

--- a/src/ClientData/include/ClientData/ModuleManager.h
+++ b/src/ClientData/include/ClientData/ModuleManager.h
@@ -21,6 +21,12 @@ class ModuleManager final {
  public:
   explicit ModuleManager() = default;
 
+  [[nodiscard]] const ModuleData* GetModuleByModuleInMemoryAndAbsoluteAddress(
+      const ModuleInMemory& module_in_memory, uint64_t absolute_address) const;
+
+  [[nodiscard]] ModuleData* GetMutableModuleByModuleInMemoryAndAbsoluteAddress(
+      const ModuleInMemory& module_in_memory, uint64_t absolute_address);
+
   [[nodiscard]] const ModuleData* GetModuleByPathAndBuildId(const std::string& path,
                                                             const std::string& build_id) const;
   [[nodiscard]] ModuleData* GetMutableModuleByPathAndBuildId(const std::string& path,

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -59,7 +59,7 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(const orbit_client_data::ModuleData*, GetModuleByPathAndBuildId,
               (const std::string&, const std::string&), (const));
   MOCK_METHOD(orbit_client_data::ModuleData*, GetMutableModuleByPathAndBuildId,
-              (const std::string&, const std::string&), (const));
+              (const std::string&, const std::string&));
   MOCK_METHOD(orbit_base::Future<void>, RetrieveModulesAndLoadSymbols,
               (absl::Span<const orbit_client_data::ModuleData* const>));
 

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -214,7 +214,7 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
     ModuleData* module = app_->GetMutableModuleByPathAndBuildId(module_in_memory.file_path(),
                                                                 module_in_memory.build_id());
     if (module != nullptr) {
-      AddModule(start_address, std::move(module), module_in_memory);
+      AddModule(start_address, module, module_in_memory);
     }
   }
 

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -70,7 +70,7 @@ class AppInterface {
   [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleByPathAndBuildId(
       const std::string& path, const std::string& build_id) const = 0;
   [[nodiscard]] virtual orbit_client_data::ModuleData* GetMutableModuleByPathAndBuildId(
-      const std::string& path, const std::string& build_id) const = 0;
+      const std::string& path, const std::string& build_id) = 0;
   virtual orbit_base::Future<void> RetrieveModulesAndLoadSymbols(
       absl::Span<const orbit_client_data::ModuleData* const> modules) = 0;
 

--- a/src/ObjectUtils/Address.cpp
+++ b/src/ObjectUtils/Address.cpp
@@ -16,10 +16,6 @@
 
 namespace orbit_object_utils {
 
-// Since this module is used on the client and on the service side and we do not currently
-// report page size in capture this is hardcoded here.
-static constexpr uint64_t kPageSize = 0x1000;
-
 uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
                                                uint64_t module_base_address,
                                                uint64_t module_load_bias,

--- a/src/ObjectUtils/include/ObjectUtils/Address.h
+++ b/src/ObjectUtils/include/ObjectUtils/Address.h
@@ -9,6 +9,10 @@
 
 namespace orbit_object_utils {
 
+// Since this module is used on the client and on the service side and we do not currently
+// report page size in capture this is hardcoded here.
+static constexpr uint64_t kPageSize = 0x1000;
+
 [[nodiscard]] uint64_t SymbolVirtualAddressToAbsoluteAddress(
     uint64_t symbol_address, uint64_t module_base_address, uint64_t module_load_bias,
     uint64_t module_executable_section_offset);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -381,7 +381,7 @@ class OrbitApp final : public DataViewFactory,
     return manual_instrumentation_manager_.get();
   }
   [[nodiscard]] orbit_client_data::ModuleData* GetMutableModuleByPathAndBuildId(
-      const std::string& path, const std::string& build_id) const override {
+      const std::string& path, const std::string& build_id) override {
     return module_manager_->GetMutableModuleByPathAndBuildId(path, build_id);
   }
   [[nodiscard]] const orbit_client_data::ModuleData* GetModuleByPathAndBuildId(


### PR DESCRIPTION
and use it where appropriate. This method performs additional checks
on absolute address so it does not fall in the range between
module base address and module_base_address + executable_segment_offset
% PAGE_SIZE.

Bug: http://b/199493533
Test: load capture file from the bug, run OrbitDataUnitTests