### PR TITLE
Only UpdatePrimitives and Draw tracks on screen

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -664,6 +664,7 @@ void CaptureWindow::RenderImGuiDebugUI() {
     if (time_graph_ != nullptr) {
       IMGUI_VAR_TO_TEXT(time_graph_->GetNumVisiblePrimitives());
       IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetAllTracks().size());
+      IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetTracksOnScreen().size());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMinTimeUs());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMaxTimeUs());
       IMGUI_VAR_TO_TEXT(time_graph_->GetCaptureMin());

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -821,7 +821,7 @@ void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode pickin
 
 void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
                            const DrawContext& draw_context) {
-  for (auto& track : track_manager_->GetTracksOnScreen()) {
+  for (Track* track : track_manager_->GetTracksOnScreen()) {
     float z_offset = 0;
     if (track->IsPinned()) {
       z_offset = GlCanvas::kZOffsetPinnedTrack;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -821,7 +821,7 @@ void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode pickin
 
 void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
                            const DrawContext& draw_context) {
-  for (auto& track : track_manager_->GetVisibleTracks()) {
+  for (auto& track : track_manager_->GetTracksOnScreen()) {
     float z_offset = 0;
     if (track->IsPinned()) {
       z_offset = GlCanvas::kZOffsetPinnedTrack;

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -80,11 +80,11 @@ std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
 
 std::vector<Track*> TrackManager::GetTracksOnScreen() const {
   std::vector<Track*> visible_tracks;
-  for (auto track : GetVisibleTracks()) {
-    auto track_top_y = track->GetPos()[1];
-    auto track_bottom_y = track_top_y + track->GetHeight();
-    auto screen_top_y = viewport_->GetScreenTopLeftInWorld()[1];
-    auto screen_bottom_y = screen_top_y + viewport_->GetVisibleWorldHeight();
+  for (Track* track : GetVisibleTracks()) {
+    float track_top_y = track->GetPos()[1];
+    float track_bottom_y = track_top_y + track->GetHeight();
+    float screen_top_y = viewport_->GetScreenTopLeftInWorld()[1];
+    float screen_bottom_y = screen_top_y + viewport_->GetVisibleWorldHeight();
     if (track_top_y < screen_bottom_y && track_bottom_y > screen_top_y) {
       visible_tracks.push_back(track);
     }
@@ -331,7 +331,7 @@ int TrackManager::FindMovingTrackIndex() {
 
 void TrackManager::UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                          PickingMode picking_mode) {
-  for (auto& track : GetTracksOnScreen()) {
+  for (Track* track : GetTracksOnScreen()) {
     const float z_offset = track->IsMoving() ? GlCanvas::kZOffsetMovingTrack : 0.f;
     track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -78,6 +78,20 @@ std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
   return tracks;
 }
 
+std::vector<Track*> TrackManager::GetTracksOnScreen() const {
+  std::vector<Track*> visible_tracks;
+  for (auto track : GetVisibleTracks()) {
+    auto track_top_y = track->GetPos()[1];
+    auto track_bottom_y = track_top_y + track->GetHeight();
+    auto screen_top_y = viewport_->GetScreenTopLeftInWorld()[1];
+    auto screen_bottom_y = screen_top_y + viewport_->GetVisibleWorldHeight();
+    if (track_top_y < screen_bottom_y && track_bottom_y > screen_top_y) {
+      visible_tracks.push_back(track);
+    }
+  }
+  return visible_tracks;
+}
+
 void TrackManager::SortTracks() {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   // Gather all tracks regardless of the process in sorted order
@@ -317,7 +331,7 @@ int TrackManager::FindMovingTrackIndex() {
 
 void TrackManager::UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                          PickingMode picking_mode) {
-  for (auto& track : visible_tracks_) {
+  for (auto& track : GetTracksOnScreen()) {
     const float z_offset = track->IsMoving() ? GlCanvas::kZOffsetMovingTrack : 0.f;
     track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -44,6 +44,7 @@ class TrackManager {
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
   [[nodiscard]] std::vector<Track*> GetVisibleTracks() const { return visible_tracks_; }
+  [[nodiscard]] std::vector<Track*> GetTracksOnScreen() const;
   [[nodiscard]] std::vector<ThreadTrack*> GetThreadTracks() const;
   [[nodiscard]] std::vector<FrameTrack*> GetFrameTracks() const;
 


### PR DESCRIPTION
Optimization easy to make now that we are not setting
positions neither sizes while drawing anymore.

After calculation all the positions in WorldSpace we only
UpdatePrimitives and Draw to the tracks which have some part visible in
screen.

As a result, in captures where we have a lot of Tracks with timers
in several depths, we are much more faster at Updating Primitives. For
example, in the capture generated by Pierric using OrbitTest, with the
initial zoom I'm seeing UpdatePrimitives being 5/6 times faster, but
maybe could vary based on the resolution.

Anyway, in addition with https://github.com/google/orbit/pull/2780,
which is an optimization only for thread tracks, we are aiming to be
only bounded by the number of pixels where we draw timers multiplied by
a log of the number of elements.

Test: Loaded a capture, start a new one.