### PR TITLE
Integrate project selection

### DIFF
--- a/src/OrbitGgp/ProjectTest.cpp
+++ b/src/OrbitGgp/ProjectTest.cpp
@@ -82,4 +82,21 @@ TEST(OrbitGgpProject, GetListFromJson) {
   }
 }
 
+TEST(OrbitGgpProject, EqualToOperator) {
+  Project project_0;
+  Project project_1;
+
+  project_0.display_name = "a display name";
+  project_0.id = "an id";
+  project_1.display_name = "a different display name";
+  project_1.id = "a different id";
+
+  EXPECT_FALSE(project_0 == project_1);
+
+  project_1.display_name = "a display name";
+  project_1.id = "an id";
+
+  EXPECT_EQ(project_0, project_1);
+}
+
 }  // namespace orbit_ggp

--- a/src/OrbitGgp/include/OrbitGgp/Project.h
+++ b/src/OrbitGgp/include/OrbitGgp/Project.h
@@ -8,6 +8,7 @@
 #include <QByteArray>
 #include <QString>
 #include <QVector>
+#include <tuple>
 
 #include "OrbitBase/Result.h"
 
@@ -18,6 +19,10 @@ struct Project {
   QString id;
 
   static ErrorMessageOr<QVector<Project>> GetListFromJson(const QByteArray& json);
+
+  friend bool operator==(const Project& lhs, const Project& rhs) {
+    return std::tie(lhs.display_name, lhs.id) == std::tie(rhs.display_name, rhs.id);
+  }
 };
 
 }  // namespace orbit_ggp

--- a/src/SessionSetup/ConnectToStadiaWidget.ui
+++ b/src/SessionSetup/ConnectToStadiaWidget.ui
@@ -151,22 +151,28 @@
              </property>
              <item>
               <widget class="QWidget" name="instancesSettingsWidget" native="true">
-               <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,1,0,0">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1,0,0">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
                 <item>
-                 <widget class="QComboBox" name="comboBox"/>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_2">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                 <widget class="QComboBox" name="comboBox">
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToContents</enum>
                   </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
+                 </widget>
                 </item>
                 <item>
                  <widget class="QLineEdit" name="instancesFilterLineEdit">
@@ -187,9 +193,6 @@
                 </item>
                 <item>
                  <widget class="QPushButton" name="refreshButton_2">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
                   <property name="minimumSize">
                    <size>
                     <width>23</width>

--- a/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
@@ -27,6 +27,7 @@
 #include "OrbitGgp/Client.h"
 #include "OrbitGgp/Instance.h"
 #include "OrbitGgp/InstanceItemModel.h"
+#include "OrbitGgp/Project.h"
 #include "OrbitGgp/SshInfo.h"
 #include "OrbitSsh/Credentials.h"
 #include "SessionSetup/ServiceDeployManager.h"
@@ -67,6 +68,7 @@ class ConnectToStadiaWidget : public QWidget {
   void OnErrorOccurred(const QString& message);
   void OnSelectionChanged(const QModelIndex& current);
   void UpdateRememberInstance(bool value);
+  void ProjectComboBoxActivated(int index);
 
  signals:
   void ErrorOccurred(const QString& message);
@@ -93,6 +95,8 @@ class ConnectToStadiaWidget : public QWidget {
   std::shared_ptr<grpc::Channel> grpc_channel_;
   QPointer<orbit_ggp::Client> ggp_client_ = nullptr;
   std::optional<QString> remembered_instance_id_;
+  QVector<orbit_ggp::Project> projects_;
+  std::optional<orbit_ggp::Project> selected_project_;
 
   // State Machine & States
   QStateMachine state_machine_;
@@ -109,8 +113,11 @@ class ConnectToStadiaWidget : public QWidget {
   void DetachRadioButton();
   void SetupStateMachine();
   void OnInstancesLoaded(ErrorMessageOr<QVector<orbit_ggp::Instance>> instances);
+  void OnProjectsLoaded(ErrorMessageOr<QVector<orbit_ggp::Project>> projects);
   void OnSshInfoLoaded(ErrorMessageOr<orbit_ggp::SshInfo> ssh_info_result, std::string instance_id);
   void TrySelectRememberedInstance();
+  void SetProject(const std::optional<orbit_ggp::Project>& project);
+  void SetupProjectSelectionFlagContent();
 };
 
 }  // namespace orbit_session_setup


### PR DESCRIPTION
This is the integration of the project selection UI with ConnectToStadia widget. For testing use flag `--enable_project_selection`.

Main bug http://b/197603125

This current implementation works, but its missing the caching of previously loaded instance lists (on project change). It also reloads the project list unnecessarily often (every time the instance list is refreshed). This will be improved together with a refactor that extracts the new functionality into a separate widget. I filed http://b/200010742 for that. 