### PR TITLE
Only inject dynamic instrumentation when needed.

### DIFF
--- a/src/CaptureService/CaptureServiceImpl.cpp
+++ b/src/CaptureService/CaptureServiceImpl.cpp
@@ -445,7 +445,8 @@ grpc::Status CaptureServiceImpl::Capture(
   }
 
   // Disable user space instrumentation.
-  if (capture_options.enable_user_space_instrumentation()) {
+  if (capture_options.enable_user_space_instrumentation() &&
+      capture_options.instrumented_functions_size() != 0) {
     const pid_t target_process_id = orbit_base::ToNativeProcessId(capture_options.pid());
     auto result_tmp = instrumentation_manager_->UninstrumentProcess(target_process_id);
     if (result_tmp.has_error()) {

--- a/src/CaptureService/CaptureServiceImpl.cpp
+++ b/src/CaptureService/CaptureServiceImpl.cpp
@@ -370,7 +370,8 @@ grpc::Status CaptureServiceImpl::Capture(
 
   // Enable user space instrumentation.
   std::optional<std::string> error_enabling_user_space_instrumentation;
-  if (capture_options.enable_user_space_instrumentation()) {
+  if (capture_options.enable_user_space_instrumentation() &&
+      capture_options.instrumented_functions_size() != 0) {
     auto result = instrumentation_manager_->InstrumentProcess(capture_options);
     if (result.has_error()) {
       error_enabling_user_space_instrumentation = absl::StrFormat(


### PR DESCRIPTION
Previously the lib for dynamic instrumentation was injected even when no
functions were instrumented (but user space instrumentation was enabled).

Now we check if at least one function is instrumented before we inject.

Test: Unit tests still pass, checked manually that the lib only gets
injected when needed.
Bug: http://b/198613830