### PR TITLE
Use Integers in GetNextPixelBoundaryTimeNs

### DIFF
--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -457,12 +457,12 @@ void ThreadTrack::OnCaptureComplete() {
     return current_time + 1;
   }
 
-  // Making a ceiling with integers to not lose precision. Given a track width of 4000 pixels, we
-  // can capture for 53 days without overflowing.
-  int next_pixel = ((ns_from_min * num_pixels_on_track) + total_ns - 1) / total_ns;
+  // Given a track width of 4000 pixels, we can capture for 53 days without overflowing.
+  int current_pixel = (ns_from_min * num_pixels_on_track) / total_ns;
+  int next_pixel = current_pixel + 1;
 
-  // Calculate the timestamp of that pixel, rounded to the left similar to how it works in other
-  // parts of Orbit.
+  // To calculate the timestamp of a pixel boundary, we round to the left similar to how it works in
+  // other parts of Orbit.
   uint64_t next_pixel_ns_from_min = total_ns * next_pixel / num_pixels_on_track;
   return draw_data.min_tick + next_pixel_ns_from_min;
 }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -446,11 +446,25 @@ void ThreadTrack::OnCaptureComplete() {
 }
 
 [[nodiscard]] static inline uint64_t GetNextPixelBoundaryTimeNs(
-    float world_x, const internal::DrawData& draw_data) {
-  float normalized_x = (world_x - draw_data.track_start_x) / draw_data.track_width;
-  int pixel_x = static_cast<int>(
-      ceil(normalized_x * draw_data.viewport->WorldToScreenWidth(draw_data.track_width)));
-  return draw_data.min_tick + static_cast<uint64_t>(pixel_x * draw_data.ns_per_pixel);
+    uint64_t current_time, const internal::DrawData& draw_data) {
+  uint64_t ns_from_min = current_time - draw_data.min_tick;
+  uint64_t total_ns = draw_data.max_tick - draw_data.min_tick;
+  uint64_t num_pixels_on_track = draw_data.viewport->WorldToScreenWidth(draw_data.track_width);
+
+  // If max_tick and min_tick are the same, there is no way to calculate the next pixel, as every
+  // pixel has the same timestamp.
+  if (total_ns == 0) {
+    return current_time + 1;
+  }
+
+  // Making a ceiling with integers to not lose precision. Given a track width of 4000 pixels, we
+  // can capture for 53 days without overflowing.
+  int next_pixel = ((ns_from_min * num_pixels_on_track) + total_ns - 1) / total_ns;
+
+  // Calculate the timestamp of that pixel, rounded to the left similar to how it works in other
+  // parts of Orbit.
+  uint64_t next_pixel_ns_from_min = total_ns * next_pixel / num_pixels_on_track;
+  return draw_data.min_tick + next_pixel_ns_from_min;
 }
 
 // We minimize overdraw when drawing lines for small events by discarding events that would just
@@ -502,7 +516,7 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
       }
 
       // Use the time at boundary of the next pixel as a threshold to avoid overdraw.
-      next_pixel_start_time_ns = GetNextPixelBoundaryTimeNs(pos[0] + size[0], draw_data);
+      next_pixel_start_time_ns = GetNextPixelBoundaryTimeNs(timer_info.end(), draw_data);
     }
   }
 }


### PR DESCRIPTION
* Use Integers in GetNextPixelBoundaryTimeNs

We use the function GetNextPixelBoundaryTimeNs to get the next time to
draw, in order to not draw a timer which all its pixels have already
another element drawn.

This function have 2 issues which leads to return sometimes a previous
time (and therefore incorrect one), which is currently making us drawing
timers than otherwise we will skip.

The first issue is that we have an integer value for ns_per_pixel, which
leads us to a problem because if we multiply the number of pixel with
ns_per_pixel we don't have the total number of pixels. We will fix this
in a different PR. The second issue is that although we use a double
there, we will have precision issues. So, for that we will make all our
calculations using integers, to avoid that.

Addressing: http://b/199736246

Test: Navigate in a capture, confirm that always the function answer a
reasonable time. Load a capture, pixelwise we seem to draw more elements, so we seems to be more 
precise.

Before: https://screenshot.googleplex.com/76KYwkkjk7c3eup
After: https://screenshot.googleplex.com/4WEjtteXDethqMz

