### PR TITLE
Make NsPerPixel a double instead of truncate it

### DIFF
--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -450,7 +450,7 @@ void ThreadTrack::OnCaptureComplete() {
   float normalized_x = (world_x - draw_data.track_start_x) / draw_data.track_width;
   int pixel_x = static_cast<int>(
       ceil(normalized_x * draw_data.viewport->WorldToScreenWidth(draw_data.track_width)));
-  return draw_data.min_tick + pixel_x * draw_data.ns_per_pixel;
+  return draw_data.min_tick + static_cast<uint64_t>(pixel_x * draw_data.ns_per_pixel);
 }
 
 // We minimize overdraw when drawing lines for small events by discarding events that would just

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -35,7 +35,7 @@ struct DrawData {
   uint64_t max_tick;
   uint64_t highlighted_function_id;
   uint64_t highlighted_group_id;
-  uint64_t ns_per_pixel;
+  double ns_per_pixel;
   uint64_t min_timegraph_tick;
   Batcher* batcher;
   orbit_gl::Viewport* viewport;


### PR DESCRIPTION
As mentioned in https://github.com/google/orbit/pull/2795, we are using
an integer value for ns_per_pixel, which leads us to a problem because
if we multiply the number of pixels with ns_per_pixel we have a
different value than the total number of pixels.

In this PR, we are switching it to double and we cast to an int for
getting the correct timestamp.

Test: Load a capture, see than the image is the same than the current
main.