### PR TITLE
Replace some `Function`s with `function_id`s in `LinuxTracing`

### DIFF
--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "Function.h"
+#include "GrpcProtos/Constants.h"
 #include "KernelTracepoints.h"
 #include "OrbitBase/MakeUniqueForOverwrite.h"
 #include "PerfEventRecords.h"
@@ -264,17 +265,17 @@ class CallchainSamplePerfEvent : public PerfEvent {
   [[nodiscard]] uint64_t GetStackSize() const { return stack.dyn_size; }
 };
 
-class PerfEventWithFunction : public PerfEvent {
+class PerfEventWithFunctionId : public PerfEvent {
  public:
-  const Function* GetFunction() const { return function_; }
-  void SetFunction(const Function* function) { function_ = function; }
+  [[nodiscard]] uint64_t GetFunctionId() const { return function_id_; }
+  void SetFunctionId(uint64_t function_id) { function_id_ = function_id; }
 
  private:
-  const Function* function_ = nullptr;
+  uint64_t function_id_ = orbit_grpc_protos::kInvalidFunctionId;
 };
 
 template <typename RingBufferRecordT>
-class UprobesPerfEventBase : public PerfEventWithFunction {
+class UprobesPerfEventBase : public PerfEventWithFunctionId {
  public:
   RingBufferRecordT ring_buffer_record;
 
@@ -312,7 +313,7 @@ class UprobesWithArgumentsPerfEvent
 };
 
 template <typename RingBufferRecordT>
-class UretprobesPerfEventBase : public PerfEventWithFunction {
+class UretprobesPerfEventBase : public PerfEventWithFunctionId {
  public:
   RingBufferRecordT ring_buffer_record;
 

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -170,7 +170,7 @@ void TracerThread::AddUprobesFileDescriptors(
   ORBIT_SCOPE_FUNCTION;
   for (const auto [cpu, fd] : uprobes_fds_per_cpu) {
     uint64_t stream_id = perf_event_get_id(fd);
-    uprobes_uretprobes_ids_to_function_.emplace(stream_id, &function);
+    uprobes_uretprobes_ids_to_function_id_.emplace(stream_id, function.function_id());
     if (function.record_arguments()) {
       uprobes_with_args_ids_.insert(stream_id);
     } else {
@@ -186,7 +186,7 @@ void TracerThread::AddUretprobesFileDescriptors(
   ORBIT_SCOPE_FUNCTION;
   for (const auto [cpu, fd] : uretprobes_fds_per_cpu) {
     uint64_t stream_id = perf_event_get_id(fd);
-    uprobes_uretprobes_ids_to_function_.emplace(stream_id, &function);
+    uprobes_uretprobes_ids_to_function_id_.emplace(stream_id, function.function_id());
     if (function.record_return_value()) {
       uretprobes_with_retval_ids_.insert(stream_id);
     } else {
@@ -924,7 +924,7 @@ uint64_t TracerThread::ProcessSampleEventAndReturnTimestamp(const perf_event_hea
     if (event->GetPid() != target_pid_) {
       return timestamp_ns;
     }
-    event->SetFunction(uprobes_uretprobes_ids_to_function_.at(event->GetStreamId()));
+    event->SetFunctionId(uprobes_uretprobes_ids_to_function_id_.at(event->GetStreamId()));
     event->SetOrderedInFileDescriptor(fd);
     DeferEvent(std::move(event));
     ++stats_.uprobes_count;
@@ -935,7 +935,7 @@ uint64_t TracerThread::ProcessSampleEventAndReturnTimestamp(const perf_event_hea
     if (event->GetPid() != target_pid_) {
       return timestamp_ns;
     }
-    event->SetFunction(uprobes_uretprobes_ids_to_function_.at(event->GetStreamId()));
+    event->SetFunctionId(uprobes_uretprobes_ids_to_function_id_.at(event->GetStreamId()));
     event->SetOrderedInFileDescriptor(fd);
     DeferEvent(std::move(event));
     ++stats_.uprobes_count;
@@ -947,7 +947,7 @@ uint64_t TracerThread::ProcessSampleEventAndReturnTimestamp(const perf_event_hea
     if (event->GetPid() != target_pid_) {
       return timestamp_ns;
     }
-    event->SetFunction(uprobes_uretprobes_ids_to_function_.at(event->GetStreamId()));
+    event->SetFunctionId(uprobes_uretprobes_ids_to_function_id_.at(event->GetStreamId()));
     event->SetOrderedInFileDescriptor(fd);
     DeferEvent(std::move(event));
     ++stats_.uprobes_count;
@@ -958,7 +958,7 @@ uint64_t TracerThread::ProcessSampleEventAndReturnTimestamp(const perf_event_hea
     if (event->GetPid() != target_pid_) {
       return timestamp_ns;
     }
-    event->SetFunction(uprobes_uretprobes_ids_to_function_.at(event->GetStreamId()));
+    event->SetFunctionId(uprobes_uretprobes_ids_to_function_id_.at(event->GetStreamId()));
     event->SetOrderedInFileDescriptor(fd);
     DeferEvent(std::move(event));
     ++stats_.uprobes_count;
@@ -1204,7 +1204,7 @@ void TracerThread::Reset() {
   ring_buffers_.clear();
   fds_to_last_timestamp_ns_.clear();
 
-  uprobes_uretprobes_ids_to_function_.clear();
+  uprobes_uretprobes_ids_to_function_id_.clear();
   uprobes_ids_.clear();
   uprobes_with_args_ids_.clear();
   uretprobes_ids_.clear();

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -148,7 +148,7 @@ class TracerThread {
   std::vector<PerfEventRingBuffer> ring_buffers_;
   absl::flat_hash_map<int, uint64_t> fds_to_last_timestamp_ns_;
 
-  absl::flat_hash_map<uint64_t, const Function*> uprobes_uretprobes_ids_to_function_;
+  absl::flat_hash_map<uint64_t, uint64_t> uprobes_uretprobes_ids_to_function_id_;
   absl::flat_hash_set<uint64_t> uprobes_ids_;
   absl::flat_hash_set<uint64_t> uprobes_with_args_ids_;
   absl::flat_hash_set<uint64_t> uretprobes_ids_;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -285,13 +285,12 @@ void UprobesUnwindingVisitor::OnUprobes(
 
 void UprobesUnwindingVisitor::Visit(UprobesPerfEvent* event) {
   OnUprobes(event->GetTimestamp(), event->GetTid(), event->GetCpu(), event->GetSp(), event->GetIp(),
-            event->GetReturnAddress(), /*registers=*/std::nullopt,
-            event->GetFunction()->function_id());
+            event->GetReturnAddress(), /*registers=*/std::nullopt, event->GetFunctionId());
 }
 
 void UprobesUnwindingVisitor::Visit(UprobesWithArgumentsPerfEvent* event) {
   OnUprobes(event->GetTimestamp(), event->GetTid(), event->GetCpu(), event->GetSp(), event->GetIp(),
-            event->GetReturnAddress(), event->GetRegisters(), event->GetFunction()->function_id());
+            event->GetReturnAddress(), event->GetRegisters(), event->GetFunctionId());
 }
 
 void UprobesUnwindingVisitor::OnUretprobes(uint64_t timestamp_ns, pid_t pid, pid_t tid,

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -157,7 +157,6 @@ TEST_F(UprobesUnwindingVisitorTest,
   constexpr uint32_t kCpu = 1;
 
   {
-    Function function1{1, "/path/to/module", 0x01, false, false};
     UprobesPerfEvent uprobe1;
     uprobe1.ring_buffer_record.sample_id.pid = kPid;
     uprobe1.ring_buffer_record.sample_id.tid = kTid;
@@ -166,7 +165,7 @@ TEST_F(UprobesUnwindingVisitorTest,
     uprobe1.ring_buffer_record.regs.sp = 0x40;
     uprobe1.ring_buffer_record.regs.ip = 0x01;
     uprobe1.ring_buffer_record.stack.top8bytes = 0x00;
-    uprobe1.SetFunction(&function1);
+    uprobe1.SetFunctionId(1);
 
     EXPECT_CALL(return_address_manager_, ProcessUprobes(kTid, 0x40, 0x00)).Times(1);
     visitor_->Visit(&uprobe1);
@@ -174,7 +173,6 @@ TEST_F(UprobesUnwindingVisitorTest,
   }
 
   {
-    Function function2{2, "/path/to/module", 0x02, true, false};
     UprobesWithArgumentsPerfEvent uprobe2;
     uprobe2.ring_buffer_record.sample_id.pid = kPid;
     uprobe2.ring_buffer_record.sample_id.tid = kTid;
@@ -189,7 +187,7 @@ TEST_F(UprobesUnwindingVisitorTest,
     uprobe2.ring_buffer_record.regs.cx = 4;
     uprobe2.ring_buffer_record.regs.r8 = 5;
     uprobe2.ring_buffer_record.regs.r9 = 6;
-    uprobe2.SetFunction(&function2);
+    uprobe2.SetFunctionId(2);
 
     EXPECT_CALL(return_address_manager_, ProcessUprobes(kTid, 0x30, 0x01)).Times(1);
     visitor_->Visit(&uprobe2);
@@ -197,7 +195,6 @@ TEST_F(UprobesUnwindingVisitorTest,
   }
 
   {
-    Function function3{3, "/path/to/module", 0x03, false, true};
     UprobesPerfEvent uprobe3;
     uprobe3.ring_buffer_record.sample_id.pid = kPid;
     uprobe3.ring_buffer_record.sample_id.tid = kTid;
@@ -206,7 +203,7 @@ TEST_F(UprobesUnwindingVisitorTest,
     uprobe3.ring_buffer_record.regs.sp = 0x20;
     uprobe3.ring_buffer_record.regs.ip = 0x03;
     uprobe3.ring_buffer_record.stack.top8bytes = 0x02;
-    uprobe3.SetFunction(&function3);
+    uprobe3.SetFunctionId(3);
 
     EXPECT_CALL(return_address_manager_, ProcessUprobes(kTid, 0x20, 0x02)).Times(1);
     visitor_->Visit(&uprobe3);
@@ -214,7 +211,6 @@ TEST_F(UprobesUnwindingVisitorTest,
   }
 
   {
-    Function function4{4, "/path/to/module", 0x04, true, true};
     UprobesWithArgumentsPerfEvent uprobe4;
     uprobe4.ring_buffer_record.sample_id.pid = kPid;
     uprobe4.ring_buffer_record.sample_id.tid = kTid;
@@ -229,7 +225,7 @@ TEST_F(UprobesUnwindingVisitorTest,
     uprobe4.ring_buffer_record.regs.cx = 4;
     uprobe4.ring_buffer_record.regs.r8 = 5;
     uprobe4.ring_buffer_record.regs.r9 = 6;
-    uprobe4.SetFunction(&function4);
+    uprobe4.SetFunctionId(4);
 
     EXPECT_CALL(return_address_manager_, ProcessUprobes(kTid, 0x10, 0x03)).Times(1);
     visitor_->Visit(&uprobe4);


### PR DESCRIPTION
In various cases pointers to `orbit_linux_tracing::Function` were carried around
just to access the function id.

Test: Unit tests, `LinuxTracingIntegrationTests`.