### PR TITLE
Fix failing unit test BackupModifyRestore.

### DIFF
--- a/src/UserSpaceInstrumentation/RegisterStateTest.cpp
+++ b/src/UserSpaceInstrumentation/RegisterStateTest.cpp
@@ -35,6 +35,7 @@ void Child() {
   // breakpoint. The parent does "waitpid" for that. Line four and five move the registers back into
   // memory so they are available for verification below.
   __asm__ __volatile__(
+      "flds -0x10(%%rsp)\n\t"
       "mov (%0), %%rax\n\t"
       "vmovups (%1), %%ymm0\n\t"
       "int3\n\t"

--- a/src/UserSpaceInstrumentation/RegisterStateTest.cpp
+++ b/src/UserSpaceInstrumentation/RegisterStateTest.cpp
@@ -30,10 +30,10 @@ void Child() {
   for (size_t i = 0; i < avx_bytes.size(); ++i) {
     avx_bytes[i] = i;
   }
-  // The first two lines move the memory to the registers. The "%0" and "%1" refer to the addresses
-  // of "rax" and "avx_bytes" given in the second line from the bottom. "int3" just is the
-  // breakpoint. The parent does "waitpid" for that. Line four and five move the registers back into
-  // memory so they are available for verification below.
+  // The first three touch the fpu and move the memory to the registers. The "%0" and "%1" refer to
+  // the addresses of "rax" and "avx_bytes" given in the second line from the bottom. "int3" just is
+  // the breakpoint. The parent does "waitpid" for that. Line four and five move the registers back
+  // into memory so they are available for verification below.
   __asm__ __volatile__(
       "flds -0x10(%%rsp)\n\t"
       "mov (%0), %%rax\n\t"


### PR DESCRIPTION
The xsave command is only saving state components that have been
initialized. Registers in uninitilized state are not backed up.

Looks like the fpu has previoulsly been used by something linked into
the tests and now this does not happen anymore. The fix explicitly
touches the fpu registers such that they get backed up.