### PR TITLE
Forward error messages from instrumentation.

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -265,7 +265,7 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
           const std::string message = absl::StrFormat(
               "Failed to create trampoline: %s", address_after_prologue_or_error.error().message());
           ERROR("%s", message);
-          result.error_messages[function_id] = message;
+          result.function_ids_to_error_messages[function_id] = message;
           OUTCOME_TRY(ReleaseMostRecentlyAllocatedTrampolineMemory(module_address_range));
           continue;
         }
@@ -286,7 +286,7 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
             absl::StrFormat("Unable to instrument \"%s\": %s", function.function_name(),
                             result_or_error.error().message());
         ERROR("%s", message);
-        result.error_messages[function_id] = message;
+        result.function_ids_to_error_messages[function_id] = message;
       } else {
         addresses_of_instrumented_functions_.insert(function_address);
         result.instrumented_function_ids.insert(function_id);

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -265,7 +265,7 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
           const std::string message = absl::StrFormat(
               "Failed to create trampoline: %s", address_after_prologue_or_error.error().message());
           ERROR("%s", message);
-          result.error_messages.push_back(message);
+          result.error_messages[function_id] = message;
           OUTCOME_TRY(ReleaseMostRecentlyAllocatedTrampolineMemory(module_address_range));
           continue;
         }
@@ -286,7 +286,7 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
             absl::StrFormat("Unable to instrument \"%s\": %s", function.function_name(),
                             result_or_error.error().message());
         ERROR("%s", message);
-        result.error_messages.push_back(message);
+        result.error_messages[function_id] = message;
       } else {
         addresses_of_instrumented_functions_.insert(function_address);
         result.instrumented_function_ids.insert(function_id);

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -30,20 +30,33 @@ namespace {
 
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;
+using ::testing::HasSubstr;
 
-constexpr int kFunctionId = 42;
+constexpr int kFunctionId1 = 42;
+constexpr int kFunctionId2 = 43;
 
 orbit_grpc_protos::CaptureOptions BuildCaptureOptions() {
   orbit_grpc_protos::CaptureOptions capture_options;
-  constexpr const char* kFunctionName = "SomethingToInstrument";
-  AddressRange range = GetFunctionRelativeAddressRangeOrDie(kFunctionName);
+
+  constexpr const char* kFunctionName1 = "SomethingToInstrument";
+  AddressRange range = GetFunctionRelativeAddressRangeOrDie(kFunctionName1);
   orbit_grpc_protos::InstrumentedFunction* my_function =
       capture_options.add_instrumented_functions();
-  my_function->set_function_id(kFunctionId);
+  my_function->set_function_id(kFunctionId1);
   my_function->set_file_offset(range.start);
   my_function->set_function_size(range.end - range.start);
-  my_function->set_function_name(kFunctionName);
+  my_function->set_function_name(kFunctionName1);
   my_function->set_file_path(orbit_base::GetExecutablePath());
+
+  constexpr const char* kFunctionName2 = "ReturnImmediately";
+  range = GetFunctionRelativeAddressRangeOrDie(kFunctionName2);
+  my_function = capture_options.add_instrumented_functions();
+  my_function->set_function_id(kFunctionId2);
+  my_function->set_file_offset(range.start);
+  my_function->set_function_size(range.end - range.start);
+  my_function->set_function_name(kFunctionName2);
+  my_function->set_file_path(orbit_base::GetExecutablePath());
+
   return capture_options;
 }
 
@@ -59,6 +72,12 @@ extern "C" int SomethingToInstrument() {
   std::mt19937 gen(rd());
   std::uniform_int_distribution<int> dis(1, 6);
   return dis(gen);
+}
+
+// We will not be able to instrument this - the function is just one byte long and we need five
+// bytes to write a jump.
+extern "C" __attribute__((naked)) int ReturnImmediately() {
+  __asm__ __volatile__("ret \n\t" : : :);
 }
 
 TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
@@ -99,8 +118,8 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
 
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(pid);
-  auto function_ids_or_error = instrumentation_manager->InstrumentProcess(capture_options);
-  ASSERT_THAT(function_ids_or_error, HasError("is already being traced by"));
+  auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
+  ASSERT_THAT(result_or_error, HasError("is already being traced by"));
 
   // End tracer process, end child process.
   kill(pid_tracer, SIGKILL);
@@ -114,8 +133,8 @@ TEST(InstrumentProcessTest, FailToInstrumentInvalidPid) {
 
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(-1);
-  auto function_ids_or_error = instrumentation_manager->InstrumentProcess(capture_options);
-  ASSERT_THAT(function_ids_or_error, HasError("There is no process with pid"));
+  auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
+  ASSERT_THAT(result_or_error, HasError("There is no process with pid"));
 }
 
 TEST(InstrumentProcessTest, FailToInstrumentThisProcess) {
@@ -123,10 +142,10 @@ TEST(InstrumentProcessTest, FailToInstrumentThisProcess) {
 
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(getpid());
-  auto function_ids_or_error = instrumentation_manager->InstrumentProcess(capture_options);
+  auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
   // We do not fail but just instrument nothing.
-  ASSERT_THAT(function_ids_or_error, HasNoError());
-  EXPECT_TRUE(function_ids_or_error.value().empty());
+  ASSERT_THAT(result_or_error, HasNoError());
+  EXPECT_TRUE(result_or_error.value().instrumented_function_ids.empty());
 }
 
 TEST(InstrumentProcessTest, Instrument) {
@@ -145,9 +164,14 @@ TEST(InstrumentProcessTest, Instrument) {
 
   orbit_grpc_protos::CaptureOptions capture_options = BuildCaptureOptions();
   capture_options.set_pid(pid_process_1);
-  auto function_ids_or_error = instrumentation_manager->InstrumentProcess(capture_options);
-  ASSERT_THAT(function_ids_or_error, HasNoError());
-  EXPECT_TRUE(function_ids_or_error.value().contains(kFunctionId));
+  auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
+  ASSERT_THAT(result_or_error, HasNoError());
+  EXPECT_TRUE(result_or_error.value().instrumented_function_ids.contains(kFunctionId1));
+  EXPECT_FALSE(result_or_error.value().instrumented_function_ids.contains(kFunctionId2));
+  ASSERT_EQ(result_or_error.value().error_messages.size(), 1);
+  EXPECT_THAT(result_or_error.value().error_messages[0],
+              HasSubstr("Failed to create trampoline: Unable to disassemble enough of the function "
+                        "to instrument it. Code: c3"));
   auto result = instrumentation_manager->UninstrumentProcess(pid_process_1);
   ASSERT_THAT(result, HasNoError());
 
@@ -170,9 +194,9 @@ TEST(InstrumentProcessTest, Instrument) {
 
   capture_options.set_pid(pid_process_2);
   for (int i = 0; i < 5; i++) {
-    function_ids_or_error = instrumentation_manager->InstrumentProcess(capture_options);
-    ASSERT_THAT(function_ids_or_error, HasNoError());
-    EXPECT_TRUE(function_ids_or_error.value().contains(kFunctionId));
+    result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
+    ASSERT_THAT(result_or_error, HasNoError());
+    EXPECT_TRUE(result_or_error.value().instrumented_function_ids.contains(kFunctionId1));
     result = instrumentation_manager->UninstrumentProcess(pid_process_2);
     ASSERT_THAT(result, HasNoError());
   }

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -225,8 +225,8 @@ TEST(InstrumentProcessTest, GetErrorMessage) {
   auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
   ASSERT_THAT(result_or_error, HasNoError());
   EXPECT_FALSE(result_or_error.value().instrumented_function_ids.contains(kFunctionId2));
-  ASSERT_EQ(result_or_error.value().error_messages.size(), 1);
-  EXPECT_THAT(result_or_error.value().error_messages[kFunctionId2],
+  ASSERT_EQ(result_or_error.value().function_ids_to_error_messages.size(), 1);
+  EXPECT_THAT(result_or_error.value().function_ids_to_error_messages[kFunctionId2],
               HasSubstr("Failed to create trampoline: Unable to disassemble enough of the function "
                         "to instrument it. Code: c3"));
   auto result = instrumentation_manager->UninstrumentProcess(pid);

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
@@ -34,7 +34,7 @@ class InstrumentationManager {
 
   struct InstrumentationResult {
     absl::flat_hash_set<uint64_t> instrumented_function_ids;
-    absl::flat_hash_map<uint64_t, std::string> error_messages;
+    absl::flat_hash_map<uint64_t, std::string> function_ids_to_error_messages;
   };
 
   // On the first call to this function we inject OrbitUserSpaceInstrumentation.so into the target

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
@@ -34,7 +34,7 @@ class InstrumentationManager {
 
   struct InstrumentationResult {
     absl::flat_hash_set<uint64_t> instrumented_function_ids;
-    std::vector<std::string> error_messages;
+    absl::flat_hash_map<uint64_t, std::string> error_messages;
   };
 
   // On the first call to this function we inject OrbitUserSpaceInstrumentation.so into the target

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
@@ -41,7 +41,7 @@ class InstrumentationManager {
   // process and create the return trampoline. On each call we create trampolines for functions that
   // were not instrumented before and instrument all functions by overwriting the prologue with a
   // jump into the trampoline. Returns the function_id's of the instrumented functions and -
-  // potentially - error message for functions where the instrumentation failed. Note that there is
+  // potentially - error messages for functions where the instrumentation failed. Note that there is
   // no guarantee that we can instrument all the functions in a binary.
   [[nodiscard]] ErrorMessageOr<InstrumentationResult> InstrumentProcess(
       const orbit_grpc_protos::CaptureOptions& capture_options);

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
@@ -32,12 +32,18 @@ class InstrumentationManager {
 
   [[nodiscard]] static std::unique_ptr<InstrumentationManager> Create();
 
+  struct InstrumentationResult {
+    absl::flat_hash_set<uint64_t> instrumented_function_ids;
+    std::vector<std::string> error_messages;
+  };
+
   // On the first call to this function we inject OrbitUserSpaceInstrumentation.so into the target
   // process and create the return trampoline. On each call we create trampolines for functions that
   // were not instrumented before and instrument all functions by overwriting the prologue with a
-  // jump into the trampoline. Returns the function_id's of the instrumented functions. Note that
-  // there is no guarantee that we can instrument all the functions in a binary.
-  [[nodiscard]] ErrorMessageOr<absl::flat_hash_set<uint64_t>> InstrumentProcess(
+  // jump into the trampoline. Returns the function_id's of the instrumented functions and -
+  // potentially - error message for functions where the instrumentation failed. Note that there is
+  // no guarantee that we can instrument all the functions in a binary.
+  [[nodiscard]] ErrorMessageOr<InstrumentationResult> InstrumentProcess(
       const orbit_grpc_protos::CaptureOptions& capture_options);
 
   // Undo the instrumentation of the functions. Leaves the library and trampolines in the target


### PR DESCRIPTION
Currently we are lacking proper error messages in the ui for the case
that a function can not be instrumented. First step is to pipe these
messages through to the CaptureService.

Bug: http://b/195543569