### PR TITLE
Make vertical zoom point to the same element again

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -163,15 +163,19 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
   const float capped_ratio = old_scale / layout_.GetScale();
 
   const float world_height = viewport_->GetVisibleWorldHeight();
-  const float y_mouse_position =
-      viewport_->GetScreenTopLeftInWorld()[1] - mouse_relative_position * world_height;
-  const float top_distance = viewport_->GetScreenTopLeftInWorld()[1] - y_mouse_position;
+  const float mouse_position_in_world_y =
+      viewport_->GetScreenTopLeftInWorld()[1] + mouse_relative_position * world_height;
+  const float mouse_position_in_screen =
+      mouse_position_in_world_y - viewport_->GetScreenTopLeftInWorld()[1];
 
-  const float new_y_mouse_position = y_mouse_position / capped_ratio;
+  // We define world system coordinates in relation of the screen. As we are zooming on the screen,
+  // the world is being expanded or collapsed. Therefore the mouse position in world should be
+  // adapted in the same way.
+  const float new_mouse_position_in_world_y = mouse_position_in_world_y / capped_ratio;
 
-  float new_world_top_left_y = new_y_mouse_position + top_distance;
+  float new_screen_top_left_in_world_y = new_mouse_position_in_world_y - mouse_position_in_screen;
 
-  viewport_->SetScreenTopLeftInWorldY(new_world_top_left_y);
+  viewport_->SetScreenTopLeftInWorldY(new_screen_top_left_in_world_y);
 }
 
 void TimeGraph::SetMinMax(double min_time_us, double max_time_us) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -150,7 +150,7 @@ void TimeGraph::ZoomTime(float zoom_value, double mouse_ratio) {
   SetMinMax(min_time_us, max_time_us);
 }
 
-void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
+void TimeGraph::VerticalZoom(float zoom_value, float mouse_normalized_y_position) {
   constexpr float kIncrementRatio = 0.1f;
 
   const float ratio = (zoom_value > 0) ? (1 + kIncrementRatio) : (1 / (1 + kIncrementRatio));
@@ -164,8 +164,8 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
 
   const float world_height = viewport_->GetVisibleWorldHeight();
   const float mouse_position_in_world_y =
-      viewport_->GetScreenTopLeftInWorld()[1] + mouse_relative_position * world_height;
-  const float mouse_position_in_screen =
+      viewport_->GetScreenTopLeftInWorld()[1] + mouse_normalized_y_position * world_height;
+  const float relative_mouse_position_in_world_y =
       mouse_position_in_world_y - viewport_->GetScreenTopLeftInWorld()[1];
 
   // We define world system coordinates in relation of the screen. As we are zooming on the screen,
@@ -173,7 +173,8 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
   // adapted in the same way.
   const float new_mouse_position_in_world_y = mouse_position_in_world_y / capped_ratio;
 
-  float new_screen_top_left_in_world_y = new_mouse_position_in_world_y - mouse_position_in_screen;
+  float new_screen_top_left_in_world_y =
+      new_mouse_position_in_world_y - relative_mouse_position_in_world_y;
 
   viewport_->SetScreenTopLeftInWorldY(new_screen_top_left_in_world_y);
 }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -85,7 +85,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void Zoom(const orbit_client_protos::TimerInfo& timer_info);
   void Zoom(uint64_t min, uint64_t max);
   void ZoomTime(float zoom_value, double mouse_ratio);
-  void VerticalZoom(float zoom_value, float mouse_ratio);
+  void VerticalZoom(float zoom_value, float mouse_normalized_y_position);
   void SetMinMax(double min_time_us, double max_time_us);
   void PanTime(int initial_x, int current_x, int width, double initial_time);
   enum class VisibilityType {


### PR DESCRIPTION
Regression from 1.67 (https://github.com/google/orbit/pull/2670). The
function is not commented properly, name of the variables is not clear
enough, so wasn't updated during that refactoring.

The element being pointed with the mouse shouldn't change during
vertical-zooming. So, in this PR we are adapting the vertical zoom to
the new coordinate system and renaming some variables + adding a comment
to make that function easier to understand.

Fixing http://b/200505756.

Test: Load a capture and making a vertical zoom there.