### PR TITLE
Adapt space_between_gpu_track to the new coordinate system

### DIFF
--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -151,7 +151,7 @@ float GpuSubmissionTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
     adjusted_depth += 1.f;
   }
-  return GetPos()[1] + GetHeaderHeight() + layout_->GetTextBoxHeight() * adjusted_depth - gap_space;
+  return GetPos()[1] + GetHeaderHeight() + layout_->GetTextBoxHeight() * adjusted_depth + gap_space;
 }
 
 // When track or its parent is collapsed, only draw "hardware execution" timers.


### PR DESCRIPTION
Now that y-coordinate grows from top to bottom we have to add the space
instead of erasing it.

Regression from 1.67. http://b/200510588.

Test: Load a capture, see the spaces between Gpu submission subtrack.