### PR TITLE
Restore track type visibility after TrackManager recreation

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -397,6 +397,19 @@ bool TrackManager::GetTrackTypeVisibility(Track::Type type) const {
   return track_type_visibility_.at(type);
 }
 
+const absl::flat_hash_map<Track::Type, bool> TrackManager::GetAllTrackTypesVisibility() const {
+  return track_type_visibility_;
+}
+
+void TrackManager::RestoreAllTrackTypesVisibility(
+    const absl::flat_hash_map<Track::Type, bool>& values) {
+  track_type_visibility_ = values;
+  if (time_graph_ != nullptr) {
+    time_graph_->RequestUpdate();
+  }
+  visible_track_list_needs_update_ = true;
+}
+
 bool TrackManager::IteratableType(orbit_client_protos::TimerInfo_Type type) {
   switch (type) {
     case TimerInfo::kNone:

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -89,6 +89,9 @@ class TrackManager {
   void SetTrackTypeVisibility(Track::Type type, bool value);
   [[nodiscard]] bool GetTrackTypeVisibility(Track::Type type) const;
 
+  const absl::flat_hash_map<Track::Type, bool> GetAllTrackTypesVisibility() const;
+  void RestoreAllTrackTypesVisibility(const absl::flat_hash_map<Track::Type, bool>& values);
+
  private:
   [[nodiscard]] int FindMovingTrackIndex();
   void UpdateMovingTrackPositionInVisibleTracks();

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -145,4 +145,41 @@ TEST_F(TrackManagerTest, TrackTypeVisibilityAffectsVisibleTrackList) {
   EXPECT_EQ(kNumTracks - 1, track_manager_.GetVisibleTracks().size());
 }
 
+TEST_F(TrackManagerTest, TrackTypeVisibilityIsRestored) {
+  CreateAndFillTracks();
+  auto match_visible_track_types = [&](std::set<Track::Type> types) -> bool {
+    bool result = true;
+
+    for (Track::Type type : Track::kAllTrackTypes) {
+      auto type_it = types.find(type);
+      if (type_it != types.end()) {
+        result = result && track_manager_.GetTrackTypeVisibility(type);
+      } else {
+        result = result && !track_manager_.GetTrackTypeVisibility(type);
+      }
+    }
+
+    return result;
+  };
+
+  EXPECT_TRUE(match_visible_track_types(Track::kAllTrackTypes));
+  auto visibility_prev = track_manager_.GetAllTrackTypesVisibility();
+
+  track_manager_.SetTrackTypeVisibility(Track::Type::kThreadTrack, false);
+  track_manager_.SetTrackTypeVisibility(Track::Type::kSchedulerTrack, false);
+
+  std::set<Track::Type> visible_tracks{Track::kAllTrackTypes};
+  visible_tracks.erase(Track::Type::kThreadTrack);
+  visible_tracks.erase(Track::Type::kSchedulerTrack);
+
+  EXPECT_TRUE(match_visible_track_types(visible_tracks));
+  auto visibility_after = track_manager_.GetAllTrackTypesVisibility();
+
+  track_manager_.RestoreAllTrackTypesVisibility(visibility_prev);
+  EXPECT_TRUE(match_visible_track_types(Track::kAllTrackTypes));
+
+  track_manager_.RestoreAllTrackTypesVisibility(visibility_after);
+  EXPECT_TRUE(match_visible_track_types(visible_tracks));
+}
+
 }  // namespace orbit_gl


### PR DESCRIPTION
Bug: b/199860711
Test: Take a capture, change visibility of track types, restart the
capture. Visibility of track types should stay the same.