### PR TITLE
ON RELEASE: Fix target label

### DIFF
--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -88,6 +88,11 @@ void TargetLabel::ChangeToFileTarget(const FileTarget& file_target) {
 }
 
 void TargetLabel::SetFile(const std::filesystem::path& file_path) {
+  // Without this, the size of the target label is not correctly updated when a capture is opened
+  // directly from the connection window. It's unclear why this happens, might be related to
+  // multiple `SizeChanged` signals being emitted while the main window is still being shown.
+  if (file_path_ == file_path) return;
+
   file_path_ = file_path;
   ui_->fileLabel->setText(QString::fromStdString(file_path.filename().string()));
   ui_->fileLabel->setToolTip(QString::fromStdString(file_path.string()));


### PR DESCRIPTION
Bug: b/200796899

To be honest, I'm not sure why this fixes the problem, or rather why the problem exists in the first place. Seems to be some issue with `SizeChanged()` being emitted multiple times (during setup, we first change the label to a file target, and then set the file path when updating the window title).

Test: Load a capture from the connection window, check that the text of the target label is vertically centered. Rename the capture, check that the filename correctly updates.