### PR TITLE
Update krabsetw to latest version

### DIFF
--- a/third_party/krabsetw/krabs/krabs/errors.hpp
+++ b/third_party/krabsetw/krabs/krabs/errors.hpp
@@ -42,6 +42,10 @@ namespace krabs {
         could_not_find_schema()
         : std::runtime_error("Could not find the schema")
         {}
+
+        could_not_find_schema(const std::string& context)
+            : std::runtime_error(std::string("Could not find the schema: ") + context)
+        {}
     };
 
     class type_mismatch_assert : public std::runtime_error {
@@ -61,6 +65,38 @@ namespace krabs {
             : std::runtime_error("No more trace sessions available.")
         {}
     };
+
+    class function_not_supported : public std::runtime_error {
+    public:
+        function_not_supported()
+            : std::runtime_error("This function is not supported on this system.")
+        {}
+    };
+
+    class unexpected_error : public std::runtime_error {
+    public:
+        unexpected_error(ULONG status)
+            : std::runtime_error(std::string("An unexpected error occurred: status_code=") +
+                std::to_string(status))
+        {}
+
+        unexpected_error(const std::string &context)
+            : std::runtime_error(std::string("An unexpected error occurred: ") + context)
+        {}
+    };
+
+    inline std::string get_status_and_record_context(ULONG status, const EVENT_RECORD& record)
+    {
+        std::stringstream message;
+        message << "status_code="
+            << status
+            << " provider_id="
+            << std::to_string(record.EventHeader.ProviderId)
+            << " event_id="
+            << record.EventHeader.EventDescriptor.Id;
+
+        return message.str();
+    }
 
     /**
      * <summary>Checks for common ETW API error codes.</summary>
@@ -83,9 +119,38 @@ namespace krabs {
             case ERROR_NO_SYSTEM_RESOURCES:
                 throw krabs::no_trace_sessions_remaining();
             case ERROR_NOT_SUPPORTED:
-                throw std::runtime_error("This function is not supported on this system");
+                throw krabs::function_not_supported();
             default:
-                throw std::runtime_error("Unexpected error");
+                throw krabs::unexpected_error(status);
+        }
+    }
+
+    /**
+     * <summary>Checks for common ETW API error codes and includes properties from the event record.</summary>
+     */
+    inline void error_check_common_conditions(ULONG status, const EVENT_RECORD &record)
+    {
+        if (status == ERROR_SUCCESS) {
+            return;
+        }
+
+        auto context = get_status_and_record_context(status, record);
+
+        switch (status) {
+        case ERROR_ALREADY_EXISTS:
+            throw krabs::trace_already_registered();
+        case ERROR_INVALID_PARAMETER:
+            throw krabs::invalid_parameter();
+        case ERROR_ACCESS_DENIED:
+            throw krabs::need_to_be_admin_failure();
+        case ERROR_NOT_FOUND:
+            throw krabs::could_not_find_schema(context);
+        case ERROR_NO_SYSTEM_RESOURCES:
+            throw krabs::no_trace_sessions_remaining();
+        case ERROR_NOT_SUPPORTED:
+            throw krabs::function_not_supported();
+        default:
+            throw krabs::unexpected_error(context);
         }
     }
 }

--- a/third_party/krabsetw/krabs/krabs/etw.hpp
+++ b/third_party/krabsetw/krabs/krabs/etw.hpp
@@ -79,6 +79,17 @@ namespace krabs { namespace details {
 
         /**
          * <summary>
+         * Configures the ETW trace session settings.
+         * See https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-tracesetinformation.
+         * </summary>
+         */
+        void set_trace_information(
+            TRACE_INFO_CLASS information_class,
+            PVOID trace_information,
+            ULONG information_length);
+
+        /**
+         * <summary>
          * Notifies the underlying trace of the buffers that were processed.
          * </summary>
          */
@@ -183,6 +194,21 @@ namespace krabs { namespace details {
     EVENT_TRACE_PROPERTIES trace_manager<T>::query()
     {
         return query_trace();
+    }
+
+    template <typename T>
+    void trace_manager<T>::set_trace_information(
+        TRACE_INFO_CLASS information_class,
+        PVOID trace_information,
+        ULONG information_length)
+    {
+        ULONG status = TraceSetInformation(
+            trace_.registrationHandle_, 
+            information_class,
+            trace_information,
+            information_length);
+
+        error_check_common_conditions(status);
     }
 
     template <typename T>
@@ -343,9 +369,7 @@ namespace krabs { namespace details {
         // before ProcessTrace() in order for the rundown events to be generated.
         T::trace_type::enable_rundown(trace_);
 
-        ::FILETIME now;
-        GetSystemTimeAsFileTime(&now);
-        ULONG status = ProcessTrace(&trace_.sessionHandle_, 1, &now, NULL);
+        ULONG status = ProcessTrace(&trace_.sessionHandle_, 1, NULL, NULL);
         error_check_common_conditions(status);
     }
 

--- a/third_party/krabsetw/krabs/krabs/filtering/event_filter.hpp
+++ b/third_party/krabsetw/krabs/krabs/filtering/event_filter.hpp
@@ -23,7 +23,9 @@ namespace krabs { namespace details {
 namespace krabs {
 
     typedef void(*c_provider_callback)(const EVENT_RECORD &, const krabs::trace_context &);
-    typedef std::function<void(const EVENT_RECORD &, const krabs::trace_context &)> provider_callback;
+    typedef void(*c_provider_error_callback)(const EVENT_RECORD&, const std::string&);
+    typedef std::function<void(const EVENT_RECORD &, const krabs::trace_context &)> provider_event_callback;
+    typedef std::function<void(const EVENT_RECORD&, const std::string&)> provider_error_callback;
     typedef std::function<bool(const EVENT_RECORD &, const krabs::trace_context &)> filter_predicate;
 
     template <typename T> class provider;
@@ -84,6 +86,19 @@ namespace krabs {
         template <typename U>
         void add_on_event_callback(const U &callback);
 
+        /**
+         * <summary>
+         * Adds a function to call when an error occurs.
+         * </summary>
+         */
+        void add_on_error_callback(c_provider_error_callback callback);
+
+        template <typename U>
+        void add_on_error_callback(U& callback);
+
+        template <typename U>
+        void add_on_error_callback(const U& callback);
+
         const std::vector<unsigned short>& provider_filter_event_ids() const
         {
             return provider_filter_event_ids_;
@@ -99,8 +114,16 @@ namespace krabs {
          */
         void on_event(const EVENT_RECORD &record, const krabs::trace_context &trace_context) const;
 
+        /**
+         * <summary>
+         *   Called when an error occurs, forwards to the error callback
+         * </summary>
+         */
+        void on_error(const EVENT_RECORD& record, const std::string& error_message) const;
+
     private:
-        std::deque<provider_callback> callbacks_;
+        std::deque<provider_event_callback> event_callbacks_;
+        std::deque<provider_error_callback> error_callbacks_;
         filter_predicate predicate_{ nullptr };
         std::vector<unsigned short> provider_filter_event_ids_;
 
@@ -132,7 +155,7 @@ namespace krabs {
     {
         // C function pointers don't interact well with std::ref, so we
         // overload to take care of this scenario.
-        callbacks_.push_back(callback);
+        event_callbacks_.push_back(callback);
     }
 
     template <typename U>
@@ -143,7 +166,7 @@ namespace krabs {
         // intended for their particular instance to be called.
         // std::ref lets us get around this and point to a specific instance
         // that they handed us.
-        callbacks_.push_back(std::ref(callback));
+        event_callbacks_.push_back(std::ref(callback));
     }
 
     template <typename U>
@@ -152,21 +175,60 @@ namespace krabs {
         // This is where temporaries bind to. Temporaries can't be wrapped in
         // a std::ref because they'll go away very quickly. We are forced to
         // actually copy these.
-        callbacks_.push_back(callback);
+        event_callbacks_.push_back(callback);
+    }
+
+    inline void event_filter::add_on_error_callback(c_provider_error_callback callback)
+    {
+        // C function pointers don't interact well with std::ref, so we
+        // overload to take care of this scenario.
+        error_callbacks_.push_back(callback);
+    }
+
+    template <typename U>
+    void event_filter::add_on_error_callback(U& callback)
+    {
+        // std::function copies its argument -- because our callbacks list
+        // is a list of std::function, this causes problems when a user
+        // intended for their particular instance to be called.
+        // std::ref lets us get around this and point to a specific instance
+        // that they handed us.
+        error_callbacks_.push_back(std::ref(callback));
+    }
+
+    template <typename U>
+    void event_filter::add_on_error_callback(const U& callback)
+    {
+        // This is where temporaries bind to. Temporaries can't be wrapped in
+        // a std::ref because they'll go away very quickly. We are forced to
+        // actually copy these.
+        error_callbacks_.push_back(callback);
     }
 
     inline void event_filter::on_event(const EVENT_RECORD &record, const krabs::trace_context &trace_context) const
     {
-        if (callbacks_.empty()) {
+        if (event_callbacks_.empty()) {
             return;
         }
 
-        if (predicate_ != nullptr && !predicate_(record, trace_context)) {
-            return;
-        }
+        try
+        {
+            if (predicate_ != nullptr && !predicate_(record, trace_context)) {
+                return;
+            }
 
-        for (auto &callback : callbacks_) {
-            callback(record, trace_context);
+            for (auto& callback : event_callbacks_) {
+                callback(record, trace_context);
+            }
+        }
+        catch (const krabs::could_not_find_schema& ex)
+        {
+            // this occurs when a predicate is applied to an event for which
+            // no schema exists. instead of allowing the exception to halt
+            // the entire trace, send a notification to the filter's error callback
+            for (auto& error_callback : error_callbacks_) {
+                error_callback(record, ex.what());
+            }
         }
     }
 } /* namespace krabs */

--- a/third_party/krabsetw/krabs/krabs/guid.hpp
+++ b/third_party/krabsetw/krabs/krabs/guid.hpp
@@ -300,6 +300,9 @@ namespace krabs {
 
 namespace std
 {
+    /*
+    * Converts a krabs GUID to a wide string
+    */
     inline std::wstring to_wstring(const krabs::guid& guid)
     {
         wchar_t* guidString;
@@ -310,6 +313,22 @@ namespace std
         std::unique_ptr<wchar_t, krabs::CoTaskMemDeleter> managed(guidString);
 
         return { managed.get() };
+    }
+
+    /*
+    * Converts a Windows GUID to a C string
+    */
+    inline std::string to_string(const GUID& guid)
+    {
+        char guid_string[37]; // 32 hex chars + 4 hyphens + null terminator
+        snprintf(
+            guid_string, sizeof(guid_string),
+            "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+            guid.Data1, guid.Data2, guid.Data3,
+            guid.Data4[0], guid.Data4[1], guid.Data4[2],
+            guid.Data4[3], guid.Data4[4], guid.Data4[5],
+            guid.Data4[6], guid.Data4[7]);
+        return guid_string;
     }
 
     template<>

--- a/third_party/krabsetw/krabs/krabs/schema.hpp
+++ b/third_party/krabsetw/krabs/krabs/schema.hpp
@@ -311,9 +311,14 @@ namespace krabs {
 
     inline const wchar_t *schema::task_name() const
     {
-        return reinterpret_cast<const wchar_t*>(
-            reinterpret_cast<const char*>(pSchema_) +
-            pSchema_->TaskNameOffset);
+        if (pSchema_->TaskNameOffset != 0) {
+            return reinterpret_cast<const wchar_t*>(
+                reinterpret_cast<const char*>(pSchema_) +
+                pSchema_->TaskNameOffset);
+        }
+        else {
+            return L"";
+        }
     }
 
     inline DECODING_SOURCE schema::decoding_source() const

--- a/third_party/krabsetw/krabs/krabs/schema_locator.hpp
+++ b/third_party/krabsetw/krabs/krabs/schema_locator.hpp
@@ -143,7 +143,7 @@ namespace krabs {
             &bufferSize);
 
         if (status != ERROR_INSUFFICIENT_BUFFER) {
-            error_check_common_conditions(status);
+            error_check_common_conditions(status, record);
         }
 
         // allocate and fill the schema from TDH
@@ -155,7 +155,8 @@ namespace krabs {
             0,
             NULL,
             (PTRACE_EVENT_INFO)buffer.get(),
-            &bufferSize));
+            &bufferSize),
+            record);
 
         return buffer;
     }

--- a/third_party/krabsetw/krabs/krabs/trace.hpp
+++ b/third_party/krabsetw/krabs/krabs/trace.hpp
@@ -125,6 +125,32 @@ namespace krabs {
 
         /**
          * <summary>
+         * Configures trace session settings.
+         * Must be called after open().
+         * See https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-tracesetinformation
+         * for more information.
+         * </summary>
+         * <example>
+         *    krabs::trace trace;
+         *    // Adjust SE_SYSTEM_PROFILE_NAME token privilege through AdjustTokenPrivileges(...)
+         *    // to enable stack tracing (not done in this example). Then:
+         *    STACK_TRACING_EVENT_ID event_id = {0};
+         *    event_id.EventGuid = krabs::guids::perf_info;
+         *    event_id.Type = 46; // SampleProfile
+         *    trace_.open();
+         *    trace_.set_trace_information(TraceStackTracingInfo, &event_id, sizeof(STACK_TRACING_EVENT_ID));
+         *    krabs::kernel_provider stack_walk_provider(EVENT_TRACE_FLAG_PROFILE, krabs::guids::stack_walk);
+         *    trace_.enable(stack_walk_provider);
+         *    trace.process();
+         * </example>
+         */
+        void set_trace_information(
+            TRACE_INFO_CLASS information_class,
+            PVOID trace_information,
+            ULONG information_length);
+
+        /**
+         * <summary>
          * Enables the provider on the given user trace.
          * </summary>
          * <example>
@@ -317,6 +343,16 @@ namespace krabs {
         properties_.MaximumBuffers = properties->MaximumBuffers;
         properties_.FlushTimer = properties->FlushTimer;
         properties_.LogFileMode = properties->LogFileMode;
+    }
+
+    template <typename T>
+    void trace<T>::set_trace_information(
+        TRACE_INFO_CLASS information_class,
+        PVOID trace_information,
+        ULONG information_length)
+    {
+        details::trace_manager<trace> manager(*this);
+        manager.set_trace_information(information_class, trace_information, information_length);
     }
 
     template <typename T>


### PR DESCRIPTION
We need the new "trace::set_trace_information" method to setup sampling profiling.

This is a snapshot of https://github.com/microsoft/krabsetw.
Commit: 0409b3ecfad72c4d62cbd393287e109d9e869621