### PR TITLE
Highlight scheduling slices of same pid

### DIFF
--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -99,8 +99,8 @@ std::string AsyncTrack::GetTimesliceText(const TimerInfo& timer_info) const {
   return absl::StrFormat("%s %s", name, time);
 }
 
-Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
-                                bool is_highlighted) const {
+Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, bool is_highlighted,
+                                const internal::DrawData& /*draw_data*/) const {
   CHECK(timer_info.type() == TimerInfo::kApiScopeAsync);
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -39,7 +39,8 @@ class AsyncTrack final : public TimerTrack {
   [[nodiscard]] std::string GetTimesliceText(
       const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                    bool is_selected, bool is_highlighted) const override;
+                                    bool is_selected, bool is_highlighted,
+                                    const internal::DrawData& draw_data) const override;
 
   std::string name_;
   // Used for determining what row can receive a new timer with no overlap.

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -94,7 +94,8 @@ float FrameTrack::GetDynamicBoxHeight(const TimerInfo& timer_info) const {
 }
 
 Color FrameTrack::GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                bool /*is_selected*/, bool /*is_highlighted*/) const {
+                                bool /*is_selected*/, bool /*is_highlighted*/,
+                                const internal::DrawData& /*draw_data*/) const {
   Vec4 min_color(76.f, 175.f, 80.f, 255.f);
   Vec4 max_color(63.f, 81.f, 181.f, 255.f);
   Vec4 warn_color(244.f, 67.f, 54.f, 255.f);

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -57,7 +57,8 @@ class FrameTrack : public TimerTrack {
 
  protected:
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                    bool is_selected, bool is_highlighted) const override;
+                                    bool is_selected, bool is_highlighted,
+                                    const internal::DrawData& draw_data) const override;
   [[nodiscard]] float GetHeight() const override;
 
  private:

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -46,7 +46,7 @@ std::string GpuDebugMarkerTrack::GetTooltip() const {
 
 Color GpuDebugMarkerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
                                          bool is_highlighted,
-                                         const internal::DrawData& draw_data) const {
+                                         const internal::DrawData& /*draw_data*/) const {
   CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -45,7 +45,8 @@ std::string GpuDebugMarkerTrack::GetTooltip() const {
 }
 
 Color GpuDebugMarkerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
-                                         bool is_highlighted) const {
+                                         bool is_highlighted,
+                                         const internal::DrawData& draw_data) const {
   CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -48,7 +48,8 @@ class GpuDebugMarkerTrack : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
-                                    bool is_highlighted) const override;
+                                    bool is_highlighted,
+                                    const internal::DrawData& draw_data) const override;
   [[nodiscard]] std::string GetTimesliceText(
       const orbit_client_protos::TimerInfo& timer) const override;
 

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -74,7 +74,8 @@ bool GpuSubmissionTrack::IsTimerActive(const TimerInfo& timer_info) const {
 }
 
 Color GpuSubmissionTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
-                                        bool is_highlighted) const {
+                                        bool is_highlighted,
+                                        const internal::DrawData& /*draw_data*/) const {
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
   if (is_highlighted) {

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -66,7 +66,8 @@ class GpuSubmissionTrack : public TimerTrack {
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
-                                    bool is_highlighted) const override;
+                                    bool is_highlighted,
+                                    const internal::DrawData& draw_data) const override;
   [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
 
   [[nodiscard]] std::string GetTimesliceText(

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -21,6 +21,7 @@
 using orbit_client_protos::TimerInfo;
 
 const Color kInactiveColor(100, 100, 100, 255);
+const Color kSamePidColor(140, 140, 140, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
 SchedulerTrack::SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
@@ -58,7 +59,8 @@ bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
 }
 
 Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
-                                    bool is_highlighted) const {
+                                    bool is_highlighted,
+                                    const internal::DrawData& draw_data) const {
   if (is_highlighted) {
     return TimerTrack::kHighlightColor;
   }
@@ -66,7 +68,9 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
     return kSelectionColor;
   }
   if (!IsTimerActive(timer_info)) {
-    return kInactiveColor;
+    const TimerInfo* selected_timer = draw_data.selected_timer;
+    bool is_same_pid = selected_timer && timer_info.process_id() == selected_timer->process_id();
+    return is_same_pid ? kSamePidColor : kInactiveColor;
   }
   return TimeGraph::GetThreadColor(timer_info.thread_id());
 }

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -43,7 +43,8 @@ class SchedulerTrack final : public TimerTrack {
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                    bool is_selected, bool is_highlighted) const override;
+                                    bool is_selected, bool is_highlighted,
+                                    const internal::DrawData& draw_data) const override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
  private:

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -215,11 +215,11 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, const internal::Dr
   bool is_group_id_highlighted =
       group_id != kOrbitDefaultGroupId && group_id == draw_data.highlighted_group_id;
   bool is_highlighted = !is_selected && (is_function_id_highlighted || is_group_id_highlighted);
-  return GetTimerColor(timer_info, is_selected, is_highlighted);
+  return GetTimerColor(timer_info, is_selected, is_highlighted, draw_data);
 }
 
-Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
-                                 bool is_highlighted) const {
+Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, bool is_highlighted,
+                                 const internal::DrawData& /*draw_data*/) const {
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
   if (is_highlighted) {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -74,7 +74,8 @@ class ThreadTrack final : public TimerTrack {
 
   [[nodiscard]] float GetDefaultBoxHeight() const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
-                                    bool is_highlighted) const override;
+                                    bool is_highlighted,
+                                    const internal::DrawData& draw_data) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     const internal::DrawData& draw_data);
   [[nodiscard]] std::string GetTimesliceText(

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -189,7 +189,7 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
       group_id != kOrbitDefaultGroupId && group_id == draw_data.highlighted_group_id;
   bool is_highlighted = !is_selected && (is_function_id_highlighted || is_group_id_highlighted);
 
-  Color color = GetTimerColor(*current_timer_info, is_selected, is_highlighted);
+  Color color = GetTimerColor(*current_timer_info, is_selected, is_highlighted, draw_data);
 
   bool is_visible_width = elapsed_us * draw_data.inv_time_window *
                               viewport_->WorldToScreenWidth(draw_data.track_width) >

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -112,7 +112,8 @@ class TimerTrack : public Track {
     return true;
   }
   [[nodiscard]] virtual Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                            bool is_selected, bool is_highlighted) const = 0;
+                                            bool is_selected, bool is_highlighted,
+                                            const internal::DrawData& draw_data) const = 0;
   [[nodiscard]] virtual bool TimerFilter(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
     return true;


### PR DESCRIPTION
When clicking on a scheduling slice, we now highlight all other slices
of the same process in a slightly brighter grey than the "inactive"
timers. The slices of the same thread id are still colored as before.

https://screenshot.googleplex.com/3T2ZF7Yx7fNH3Hq