### PR TITLE
Revert "Move some methods down to TrheadTrack (#2820)"

### DIFF
--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -21,6 +21,7 @@
 #include "DisplayFormats/DisplayFormats.h"
 #include "GlUtils.h"
 #include "Introspection/Introspection.h"
+#include "ManualInstrumentationManager.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/ThreadUtils.h"
@@ -34,6 +35,7 @@
 using orbit_client_data::CaptureData;
 using orbit_client_data::TimerChain;
 
+using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
 using orbit_grpc_protos::InstrumentedFunction;
@@ -55,6 +57,10 @@ ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
 
   tracepoint_bar_ = std::make_shared<orbit_gl::TracepointThreadBar>(
       this, app_, time_graph, viewport, layout, capture_data, thread_id, color);
+}
+
+std::string ThreadTrack::GetThreadNameFromTid(uint32_t thread_id) {
+  return capture_data_->GetThreadName(thread_id);
 }
 
 std::string ThreadTrack::GetName() const {
@@ -228,7 +234,7 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
 
   std::optional<Color> user_color = GetUserColor(timer_info);
 
-  Color color;
+  Color color = kInactiveColor;
   if (user_color.has_value()) {
     color = user_color.value();
   } else {
@@ -236,7 +242,7 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
   }
 
   constexpr uint8_t kOddAlpha = 210;
-  if ((timer_info.depth() & 0x1) == 0) {
+  if (!(timer_info.depth() & 0x1)) {
     color[3] = kOddAlpha;
   }
 
@@ -485,6 +491,7 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
     timer_data_->UpdateMaxDepth(depth);
 
     float world_timer_y = GetYFromDepth(depth - 1);
+    uint64_t next_pixel_start_time_ns = min_tick;
 
     const orbit_client_protos::TimerInfo* timer_info =
         scope_tree_.FindFirstScopeAtOrAfterTime(depth, min_tick);
@@ -511,7 +518,7 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
       }
 
       // Use the time at boundary of the next pixel as a threshold to avoid overdraw.
-      uint64_t next_pixel_start_time_ns = GetNextPixelBoundaryTimeNs(timer_info->end(), draw_data);
+      next_pixel_start_time_ns = GetNextPixelBoundaryTimeNs(timer_info->end(), draw_data);
       timer_info = scope_tree_.FindFirstScopeAtOrAfterTime(depth, next_pixel_start_time_ns);
     }
   }

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -33,6 +33,8 @@ class ThreadTrack final : public TimerTrack {
                        orbit_client_data::TimerData* timer_data,
                        ScopeTreeUpdateType scope_tree_update_type);
 
+  void InitializeNameAndLabel();
+
   [[nodiscard]] std::string GetName() const override;
   [[nodiscard]] std::string GetLabel() const override;
   [[nodiscard]] int GetNumberOfPrioritizedTrailingCharacters() const override;
@@ -59,18 +61,13 @@ class ThreadTrack final : public TimerTrack {
 
   [[nodiscard]] bool IsEmpty() const override;
 
-  [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetChains() const {
-    return timer_data_->GetChains();
-  }
-
-  [[nodiscard]] bool IsCollapsible() const override { return timer_data_->GetMaxDepth() > 1; }
-
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
 
   void OnCaptureComplete();
 
  protected:
+  [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
   [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] bool IsTrackSelected() const override;
@@ -90,6 +87,7 @@ class ThreadTrack final : public TimerTrack {
   void UpdatePositionOfSubtracks() override;
   void UpdatePrimitivesOfSubtracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                    PickingMode picking_mode, float z_offset);
+  void UpdateMinMaxTimestamps();
 
   int64_t thread_id_;
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -77,6 +77,8 @@ class TimerTrack : public Track {
       uint64_t start_ns, uint64_t end_ns) const;
   [[nodiscard]] bool IsEmpty() const override;
 
+  [[nodiscard]] bool IsCollapsible() const override { return timer_data_->GetMaxDepth() > 1; }
+
   [[nodiscard]] virtual float GetDefaultBoxHeight() const { return layout_->GetTextBoxHeight(); }
   [[nodiscard]] virtual float GetDynamicBoxHeight(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
@@ -90,6 +92,10 @@ class TimerTrack : public Track {
   [[nodiscard]] int GetVisiblePrimitiveCount() const override { return visible_timer_count_; }
 
   float GetHeight() const override;
+
+  [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetChains() const {
+    return timer_data_->GetChains();
+  }
 
   [[nodiscard]] size_t GetNumberOfTimers() const;
   [[nodiscard]] uint64_t GetMinTime() const override;


### PR DESCRIPTION
This reverts commit b9eb5f857f468291aee8f1e9c4c30143641b4709.

This change was premature because moved methods in Track class
are not pure virtual and return nullptr by default.

Test: builds