### PR TITLE
Tell CMake to use Windows 10 SDK

### DIFF
--- a/third_party/conan/configs/windows/profiles/msvc2019_common
+++ b/third_party/conan/configs/windows/profiles/msvc2019_common
@@ -18,6 +18,6 @@ gtest:compiler.cppstd=17
 OrbitProfiler:system_qt=False
 
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=8.1
+CONAN_CMAKE_SYSTEM_VERSION=10
 LDFLAGS=$LD_FLAGS
 gtest:CXXFLAGS=-std=c++17


### PR DESCRIPTION
KrabsETW seems not to support the Windows 8.1 SDK despite having
promised that on their GitHub page (probably an oversight).

So we will start linking against the Windows 10 SDK which will also have
other benefits in the future.