### PR TITLE
Fail on errors when uploading symbols

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -171,11 +171,9 @@ if [ -n "$1" ]; then
   if [ "${BUILD_TYPE}" == "release" ] \
      || [ "${BUILD_TYPE}" == "nightly" ] \
      || [ "${BUILD_TYPE}" == "continuous_on_release_branch" ]; then
-    set +e
     echo "Uploading symbols to the symbol server."
     api_key=$(get_api_key "${OAUTH_TOKEN_HEADER}")
     upload_debug_symbols "${api_key}" "${REPO_ROOT}/build/bin" "${REPO_ROOT}/build/lib"
-    set -e
   fi
 
   # Signing the debian package

--- a/kokoro/builds/upload_symbols.sh
+++ b/kokoro/builds/upload_symbols.sh
@@ -54,9 +54,6 @@ function install_breakpad_tools {
 }
 
 function upload_symbol_file {
-  # Fail on any error.
-  set -e
-
   local api_key=$1
   local symbol_file_path=$2
 
@@ -73,9 +70,6 @@ function upload_symbol_file {
 }
 
 function upload_debug_symbols {
-  # Fail on any error.
-  set -e
-
   local api_key=$1
   local bin_folder=$2
   local lib_folder=$3

--- a/kokoro/builds/upload_symbols.sh
+++ b/kokoro/builds/upload_symbols.sh
@@ -54,6 +54,9 @@ function install_breakpad_tools {
 }
 
 function upload_symbol_file {
+  # Fail on any error.
+  set -e
+
   local api_key=$1
   local symbol_file_path=$2
 
@@ -70,6 +73,9 @@ function upload_symbol_file {
 }
 
 function upload_debug_symbols {
+  # Fail on any error.
+  set -e
+
   local api_key=$1
   local bin_folder=$2
   local lib_folder=$3


### PR DESCRIPTION
There have been an undetected error while uploading the symbols
for OrbitService in the last releases.

In order to prevent future issues to be undetected, this change
makes the build fail, if the uploading itself failed.

Test: Manually trigger nightly build with an error in the upload.