### PR TITLE
Identify module by file path instead of hard-coded name

### DIFF
--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -289,7 +289,7 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
 
   auto& modules = modules_or_error.value();
   const auto module = std::find_if(modules.begin(), modules.end(), [&](const auto& module) {
-    return module.name() == "UserSpaceInstrumentationTests";
+    return module.file_path() == orbit_base::GetExecutablePath();
   });
 
   ASSERT_NE(module, modules.end());


### PR DESCRIPTION
In the internal build the test executables have different file names
which makes the trampoline tests fail due to a hardcoded executable
name.

Let's make the test more portable by determining the main module from
the dynamically read executable path.