### PR TITLE
Add scheduler info and GPU executions to "Capture Options" in --devmode

### DIFF
--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -70,10 +70,20 @@ class DataManager final {
     return user_defined_capture_data_;
   }
 
+  void set_collect_scheduler_info(bool collect_scheduler_info) {
+    collect_scheduler_info_ = collect_scheduler_info;
+  }
+  [[nodiscard]] bool collect_scheduler_info() const { return collect_scheduler_info_; }
+
   void set_collect_thread_states(bool collect_thread_states) {
     collect_thread_states_ = collect_thread_states;
   }
   [[nodiscard]] bool collect_thread_states() const { return collect_thread_states_; }
+
+  void set_trace_gpu_executions(bool trace_gpu_executions) {
+    trace_gpu_executions_ = trace_gpu_executions;
+  }
+  [[nodiscard]] bool trace_gpu_executions() const { return trace_gpu_executions_; }
 
   void set_enable_api(bool enable_api) { enable_api_ = enable_api; }
   [[nodiscard]] bool get_enable_api() const { return enable_api_; }
@@ -145,7 +155,9 @@ class DataManager final {
   // captures.
   UserDefinedCaptureData user_defined_capture_data_;
 
+  bool collect_scheduler_info_ = false;
   bool collect_thread_states_ = false;
+  bool trace_gpu_executions_ = false;
   bool enable_api_ = false;
   bool enable_introspection_ = false;
   bool enable_user_space_instrumentation_ = false;

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -80,10 +80,10 @@ class DataManager final {
   }
   [[nodiscard]] bool collect_thread_states() const { return collect_thread_states_; }
 
-  void set_trace_gpu_executions(bool trace_gpu_executions) {
-    trace_gpu_executions_ = trace_gpu_executions;
+  void set_trace_gpu_submissions(bool trace_gpu_submissions) {
+    trace_gpu_submissions_ = trace_gpu_submissions;
   }
-  [[nodiscard]] bool trace_gpu_executions() const { return trace_gpu_executions_; }
+  [[nodiscard]] bool trace_gpu_submissions() const { return trace_gpu_submissions_; }
 
   void set_enable_api(bool enable_api) { enable_api_ = enable_api; }
   [[nodiscard]] bool get_enable_api() const { return enable_api_; }
@@ -157,7 +157,7 @@ class DataManager final {
 
   bool collect_scheduler_info_ = false;
   bool collect_thread_states_ = false;
-  bool trace_gpu_executions_ = false;
+  bool trace_gpu_submissions_ = false;
   bool enable_api_ = false;
   bool enable_introspection_ = false;
   bool enable_user_space_instrumentation_ = false;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1329,9 +1329,9 @@ void OrbitApp::StartCapture() {
   }
 
   TracepointInfoSet selected_tracepoints = data_manager_->selected_tracepoints();
-  bool collect_scheduling_info = true;
+  bool collect_scheduling_info = !IsDevMode() || data_manager_->collect_scheduler_info();
   bool collect_thread_states = data_manager_->collect_thread_states();
-  bool collect_gpu_jobs = true;
+  bool collect_gpu_jobs = !IsDevMode() || data_manager_->trace_gpu_executions();
   bool enable_api = data_manager_->get_enable_api();
   bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
   bool enable_user_space_instrumentation =
@@ -2162,8 +2162,16 @@ orbit_base::Future<std::vector<ErrorMessageOr<void>>> OrbitApp::ReloadModules(
   return orbit_base::JoinFutures(absl::MakeConstSpan(reloaded_modules));
 }
 
+void OrbitApp::SetCollectSchedulerInfo(bool collect_scheduler_info) {
+  data_manager_->set_collect_scheduler_info(collect_scheduler_info);
+}
+
 void OrbitApp::SetCollectThreadStates(bool collect_thread_states) {
   data_manager_->set_collect_thread_states(collect_thread_states);
+}
+
+void OrbitApp::SetTraceGpuExecutions(bool trace_gpu_executions) {
+  data_manager_->set_trace_gpu_executions(trace_gpu_executions);
 }
 
 void OrbitApp::SetEnableApi(bool enable_api) { data_manager_->set_enable_api(enable_api); }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1331,7 +1331,7 @@ void OrbitApp::StartCapture() {
   TracepointInfoSet selected_tracepoints = data_manager_->selected_tracepoints();
   bool collect_scheduling_info = !IsDevMode() || data_manager_->collect_scheduler_info();
   bool collect_thread_states = data_manager_->collect_thread_states();
-  bool collect_gpu_jobs = !IsDevMode() || data_manager_->trace_gpu_executions();
+  bool collect_gpu_jobs = !IsDevMode() || data_manager_->trace_gpu_submissions();
   bool enable_api = data_manager_->get_enable_api();
   bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
   bool enable_user_space_instrumentation =
@@ -2170,8 +2170,8 @@ void OrbitApp::SetCollectThreadStates(bool collect_thread_states) {
   data_manager_->set_collect_thread_states(collect_thread_states);
 }
 
-void OrbitApp::SetTraceGpuExecutions(bool trace_gpu_executions) {
-  data_manager_->set_trace_gpu_executions(trace_gpu_executions);
+void OrbitApp::SetTraceGpuSubmissions(bool trace_gpu_submissions) {
+  data_manager_->set_trace_gpu_submissions(trace_gpu_submissions);
 }
 
 void OrbitApp::SetEnableApi(bool enable_api) { data_manager_->set_enable_api(enable_api); }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -391,7 +391,7 @@ class OrbitApp final : public DataViewFactory,
 
   void SetCollectSchedulerInfo(bool collect_scheduler_info);
   void SetCollectThreadStates(bool collect_thread_states);
-  void SetTraceGpuExecutions(bool trace_gpu_executions);
+  void SetTraceGpuSubmissions(bool trace_gpu_submissions);
   void SetEnableApi(bool enable_api);
   void SetEnableIntrospection(bool enable_introspection);
   void SetEnableUserSpaceInstrumentation(bool enable);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -389,7 +389,9 @@ class OrbitApp final : public DataViewFactory,
     return module_manager_->GetModuleByPathAndBuildId(path, build_id);
   }
 
+  void SetCollectSchedulerInfo(bool collect_scheduler_info);
   void SetCollectThreadStates(bool collect_thread_states);
+  void SetTraceGpuExecutions(bool trace_gpu_executions);
   void SetEnableApi(bool enable_api);
   void SetEnableIntrospection(bool enable_introspection);
   void SetEnableUserSpaceInstrumentation(bool enable);

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -28,7 +28,7 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
     // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
     ui_->samplingCheckBox->hide();
     ui_->schedulerCheckBox->hide();
-    ui_->gpuExecutionsCheckBox->hide();
+    ui_->gpuSubmissionsCheckBox->hide();
     ui_->userspaceCheckBox->hide();
     ui_->introspectionCheckBox->hide();
   }
@@ -73,12 +73,12 @@ bool CaptureOptionsDialog::GetCollectThreadStates() const {
   return ui_->threadStateCheckBox->isChecked();
 }
 
-void CaptureOptionsDialog::SetTraceGpuExecutions(bool trace_gpu_executions) {
-  ui_->gpuExecutionsCheckBox->setChecked(trace_gpu_executions);
+void CaptureOptionsDialog::SetTraceGpuSubmissions(bool trace_gpu_submissions) {
+  ui_->gpuSubmissionsCheckBox->setChecked(trace_gpu_submissions);
 }
 
-bool CaptureOptionsDialog::GetTraceGpuExecutions() const {
-  return ui_->gpuExecutionsCheckBox->isChecked();
+bool CaptureOptionsDialog::GetTraceGpuSubmissions() const {
+  return ui_->gpuSubmissionsCheckBox->isChecked();
 }
 
 void CaptureOptionsDialog::SetEnableApi(bool enable_api) {

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -27,6 +27,10 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   if (!absl::GetFlag(FLAGS_devmode)) {
     // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
     ui_->samplingCheckBox->hide();
+    ui_->schedulerCheckBox->hide();
+    ui_->gpuExecutionsCheckBox->hide();
+    ui_->userspaceCheckBox->hide();
+    ui_->introspectionCheckBox->hide();
   }
 
   ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);
@@ -36,14 +40,6 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   if (!absl::GetFlag(FLAGS_enable_warning_threshold)) {
     ui_->memoryWarningThresholdKbLabel->hide();
     ui_->memoryWarningThresholdKbLineEdit->hide();
-  }
-
-  if (!absl::GetFlag(FLAGS_devmode)) {
-    ui_->introspectionCheckBox->hide();
-  }
-
-  if (!absl::GetFlag(FLAGS_devmode)) {
-    ui_->userspaceCheckBox->hide();
   }
 }
 
@@ -61,6 +57,14 @@ double CaptureOptionsDialog::GetSamplingPeriodMs() const {
   return ui_->samplingPeriodMsDoubleSpinBox->value();
 }
 
+void CaptureOptionsDialog::SetCollectSchedulerInfo(bool collect_scheduler_info) {
+  ui_->schedulerCheckBox->setChecked(collect_scheduler_info);
+}
+
+bool CaptureOptionsDialog::GetCollectSchedulerInfo() const {
+  return ui_->schedulerCheckBox->isChecked();
+}
+
 void CaptureOptionsDialog::SetCollectThreadStates(bool collect_thread_state) {
   ui_->threadStateCheckBox->setChecked(collect_thread_state);
 }
@@ -69,19 +73,19 @@ bool CaptureOptionsDialog::GetCollectThreadStates() const {
   return ui_->threadStateCheckBox->isChecked();
 }
 
+void CaptureOptionsDialog::SetTraceGpuExecutions(bool trace_gpu_executions) {
+  ui_->gpuExecutionsCheckBox->setChecked(trace_gpu_executions);
+}
+
+bool CaptureOptionsDialog::GetTraceGpuExecutions() const {
+  return ui_->gpuExecutionsCheckBox->isChecked();
+}
+
 void CaptureOptionsDialog::SetEnableApi(bool enable_api) {
   ui_->apiCheckBox->setChecked(enable_api);
 }
 
 bool CaptureOptionsDialog::GetEnableApi() const { return ui_->apiCheckBox->isChecked(); }
-
-void CaptureOptionsDialog::SetEnableIntrospection(bool enable_introspection) {
-  ui_->introspectionCheckBox->setChecked(enable_introspection);
-}
-
-bool CaptureOptionsDialog::GetEnableIntrospection() const {
-  return ui_->introspectionCheckBox->isChecked();
-}
 
 void CaptureOptionsDialog::SetEnableUserSpaceInstrumentation(bool enable) {
   ui_->userspaceCheckBox->setChecked(enable);
@@ -89,6 +93,14 @@ void CaptureOptionsDialog::SetEnableUserSpaceInstrumentation(bool enable) {
 
 bool CaptureOptionsDialog::GetEnableUserSpaceInstrumentation() const {
   return ui_->userspaceCheckBox->isChecked();
+}
+
+void CaptureOptionsDialog::SetEnableIntrospection(bool enable_introspection) {
+  ui_->introspectionCheckBox->setChecked(enable_introspection);
+}
+
+bool CaptureOptionsDialog::GetEnableIntrospection() const {
+  return ui_->introspectionCheckBox->isChecked();
 }
 
 void CaptureOptionsDialog::SetLimitLocalMarkerDepthPerCommandBuffer(

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -52,8 +52,8 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] bool GetCollectSchedulerInfo() const;
   void SetCollectThreadStates(bool collect_thread_state);
   [[nodiscard]] bool GetCollectThreadStates() const;
-  void SetTraceGpuExecutions(bool trace_gpu_executions);
-  [[nodiscard]] bool GetTraceGpuExecutions() const;
+  void SetTraceGpuSubmissions(bool trace_gpu_submissions);
+  [[nodiscard]] bool GetTraceGpuSubmissions() const;
   void SetEnableApi(bool enable_api);
   [[nodiscard]] bool GetEnableApi() const;
   void SetEnableUserSpaceInstrumentation(bool enable);

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -48,14 +48,18 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] bool GetEnableSampling() const;
   void SetSamplingPeriodMs(double sampling_period_ms);
   [[nodiscard]] double GetSamplingPeriodMs() const;
+  void SetCollectSchedulerInfo(bool collect_scheduler_info);
+  [[nodiscard]] bool GetCollectSchedulerInfo() const;
   void SetCollectThreadStates(bool collect_thread_state);
   [[nodiscard]] bool GetCollectThreadStates() const;
+  void SetTraceGpuExecutions(bool trace_gpu_executions);
+  [[nodiscard]] bool GetTraceGpuExecutions() const;
   void SetEnableApi(bool enable_api);
   [[nodiscard]] bool GetEnableApi() const;
-  void SetEnableIntrospection(bool enable_introspection);
-  [[nodiscard]] bool GetEnableIntrospection() const;
   void SetEnableUserSpaceInstrumentation(bool enable);
   [[nodiscard]] bool GetEnableUserSpaceInstrumentation() const;
+  void SetEnableIntrospection(bool enable_introspection);
+  [[nodiscard]] bool GetEnableIntrospection() const;
 
   void SetLimitLocalMarkerDepthPerCommandBuffer(bool limit_local_marker_depth_per_command_buffer);
   [[nodiscard]] bool GetLimitLocalMarkerDepthPerCommandBuffer() const;

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>478</width>
-    <height>469</height>
+    <height>523</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -88,9 +88,29 @@
          </layout>
         </item>
         <item>
+         <widget class="QCheckBox" name="schedulerCheckBox">
+          <property name="text">
+           <string>Collect scheduler information</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="threadStateCheckBox">
           <property name="text">
            <string>Collect thread states</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="gpuExecutionsCheckBox">
+          <property name="text">
+           <string>Trace GPU command buffer executions</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -102,19 +122,19 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="introspectionCheckBox">
-          <property name="text">
-           <string>Enable introspection</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QCheckBox" name="userspaceCheckBox">
           <property name="visible">
            <bool>true</bool>
           </property>
           <property name="text">
            <string>Enable user space instrumentation</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="introspectionCheckBox">
+          <property name="text">
+           <string>Enable introspection</string>
           </property>
          </widget>
         </item>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -105,9 +105,9 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="gpuExecutionsCheckBox">
+         <widget class="QCheckBox" name="gpuSubmissionsCheckBox">
           <property name="text">
-           <string>Trace GPU command buffer executions</string>
+           <string>Trace GPU queue submissions</string>
           </property>
           <property name="checked">
            <bool>true</bool>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1049,7 +1049,9 @@ void OrbitMainWindow::on_actionToggle_Capture_triggered() { app_->ToggleCapture(
 
 const QString OrbitMainWindow::kEnableCallstackSamplingSettingKey{"EnableCallstackSampling"};
 const QString OrbitMainWindow::kCallstackSamplingPeriodMsSettingKey{"CallstackSamplingPeriodMs"};
+const QString OrbitMainWindow::kCollectSchedulerInfoSettingKey{"CollectSchedulerInfo"};
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
+const QString OrbitMainWindow::kTraceGpuExecutionsSettingKey{"TraceGpuExecutions"};
 const QString OrbitMainWindow::kCollectMemoryInfoSettingKey{"CollectMemoryInfo"};
 const QString OrbitMainWindow::kEnableApiSettingKey{"EnableApi"};
 const QString OrbitMainWindow::kEnableIntrospectionSettingKey{"EnableIntrospection"};
@@ -1086,7 +1088,9 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
     app_->SetSamplesPerSecond(0.0);
   }
 
+  app_->SetCollectSchedulerInfo(settings.value(kCollectSchedulerInfoSettingKey, true).toBool());
   app_->SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
+  app_->SetTraceGpuExecutions(settings.value(kTraceGpuExecutionsSettingKey, true).toBool());
   app_->SetEnableApi(settings.value(kEnableApiSettingKey, true).toBool());
   app_->SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, false).toBool());
   app_->SetEnableUserSpaceInstrumentation(
@@ -1126,7 +1130,9 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   dialog.SetSamplingPeriodMs(
       settings.value(kCallstackSamplingPeriodMsSettingKey, kCallstackSamplingPeriodMsDefaultValue)
           .toDouble());
+  dialog.SetCollectSchedulerInfo(settings.value(kCollectSchedulerInfoSettingKey, true).toBool());
   dialog.SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
+  dialog.SetTraceGpuExecutions(settings.value(kTraceGpuExecutionsSettingKey, true).toBool());
   dialog.SetEnableApi(settings.value(kEnableApiSettingKey, true).toBool());
   dialog.SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, true).toBool());
   dialog.SetEnableUserSpaceInstrumentation(
@@ -1154,7 +1160,9 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
 
   settings.setValue(kEnableCallstackSamplingSettingKey, dialog.GetEnableSampling());
   settings.setValue(kCallstackSamplingPeriodMsSettingKey, dialog.GetSamplingPeriodMs());
+  settings.setValue(kCollectSchedulerInfoSettingKey, dialog.GetCollectSchedulerInfo());
   settings.setValue(kCollectThreadStatesSettingKey, dialog.GetCollectThreadStates());
+  settings.setValue(kTraceGpuExecutionsSettingKey, dialog.GetTraceGpuExecutions());
   settings.setValue(kEnableApiSettingKey, dialog.GetEnableApi());
   settings.setValue(kEnableIntrospectionSettingKey, dialog.GetEnableIntrospection());
   settings.setValue(kEnableUserSpaceInstrumentationSettingKey,

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1051,7 +1051,7 @@ const QString OrbitMainWindow::kEnableCallstackSamplingSettingKey{"EnableCallsta
 const QString OrbitMainWindow::kCallstackSamplingPeriodMsSettingKey{"CallstackSamplingPeriodMs"};
 const QString OrbitMainWindow::kCollectSchedulerInfoSettingKey{"CollectSchedulerInfo"};
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
-const QString OrbitMainWindow::kTraceGpuExecutionsSettingKey{"TraceGpuExecutions"};
+const QString OrbitMainWindow::kTraceGpuSubmissionsSettingKey{"TraceGpuSubmissions"};
 const QString OrbitMainWindow::kCollectMemoryInfoSettingKey{"CollectMemoryInfo"};
 const QString OrbitMainWindow::kEnableApiSettingKey{"EnableApi"};
 const QString OrbitMainWindow::kEnableIntrospectionSettingKey{"EnableIntrospection"};
@@ -1090,7 +1090,7 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
 
   app_->SetCollectSchedulerInfo(settings.value(kCollectSchedulerInfoSettingKey, true).toBool());
   app_->SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
-  app_->SetTraceGpuExecutions(settings.value(kTraceGpuExecutionsSettingKey, true).toBool());
+  app_->SetTraceGpuSubmissions(settings.value(kTraceGpuSubmissionsSettingKey, true).toBool());
   app_->SetEnableApi(settings.value(kEnableApiSettingKey, true).toBool());
   app_->SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, false).toBool());
   app_->SetEnableUserSpaceInstrumentation(
@@ -1132,7 +1132,7 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
           .toDouble());
   dialog.SetCollectSchedulerInfo(settings.value(kCollectSchedulerInfoSettingKey, true).toBool());
   dialog.SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
-  dialog.SetTraceGpuExecutions(settings.value(kTraceGpuExecutionsSettingKey, true).toBool());
+  dialog.SetTraceGpuSubmissions(settings.value(kTraceGpuSubmissionsSettingKey, true).toBool());
   dialog.SetEnableApi(settings.value(kEnableApiSettingKey, true).toBool());
   dialog.SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, true).toBool());
   dialog.SetEnableUserSpaceInstrumentation(
@@ -1162,7 +1162,7 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   settings.setValue(kCallstackSamplingPeriodMsSettingKey, dialog.GetSamplingPeriodMs());
   settings.setValue(kCollectSchedulerInfoSettingKey, dialog.GetCollectSchedulerInfo());
   settings.setValue(kCollectThreadStatesSettingKey, dialog.GetCollectThreadStates());
-  settings.setValue(kTraceGpuExecutionsSettingKey, dialog.GetTraceGpuExecutions());
+  settings.setValue(kTraceGpuSubmissionsSettingKey, dialog.GetTraceGpuSubmissions());
   settings.setValue(kEnableApiSettingKey, dialog.GetEnableApi());
   settings.setValue(kEnableIntrospectionSettingKey, dialog.GetEnableIntrospection());
   settings.setValue(kEnableUserSpaceInstrumentationSettingKey,

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -185,7 +185,9 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   static const QString kEnableCallstackSamplingSettingKey;
   static const QString kCallstackSamplingPeriodMsSettingKey;
+  static const QString kCollectSchedulerInfoSettingKey;
   static const QString kCollectThreadStatesSettingKey;
+  static const QString kTraceGpuExecutionsSettingKey;
   static const QString kCollectMemoryInfoSettingKey;
   static const QString kEnableApiSettingKey;
   static const QString kEnableIntrospectionSettingKey;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -187,7 +187,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kCallstackSamplingPeriodMsSettingKey;
   static const QString kCollectSchedulerInfoSettingKey;
   static const QString kCollectThreadStatesSettingKey;
-  static const QString kTraceGpuExecutionsSettingKey;
+  static const QString kTraceGpuSubmissionsSettingKey;
   static const QString kCollectMemoryInfoSettingKey;
   static const QString kEnableApiSettingKey;
   static const QString kEnableIntrospectionSettingKey;


### PR DESCRIPTION
This simplifies changing these capture options during development, for example
for performance experiments.

Eventually we might want to expose disabling the collection of scheduler
information even outside of `--devmode` but this requires for work. For example,
it's affected by http://b/176962090.

Also move "Enable user space instrumentation" next to "Enable Orbit Api".

Linux screenshot: http://screen/774qXGrwHi5PCJi

Test: Start Orbit with and without `--devmode` with the two options enabled and
disabled in different combinations and verify received data.