### PR TITLE
Unify CaptureViewElement child rendering code

### DIFF
--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -70,9 +70,9 @@ void BasicPageFaultsTrack::AddValuesAndUpdateAnnotations(
   }
 }
 
-void BasicPageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                                const DrawContext& draw_context) {
-  LineGraphTrack<kBasicPageFaultsTrackDimension>::Draw(batcher, text_renderer, draw_context);
+void BasicPageFaultsTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                                  const DrawContext& draw_context) {
+  LineGraphTrack<kBasicPageFaultsTrackDimension>::DoDraw(batcher, text_renderer, draw_context);
 
   if (draw_context.picking_mode != PickingMode::kNone || IsCollapsed()) return;
   AnnotationTrack::DrawAnnotation(batcher, text_renderer, layout_, draw_context.indentation_level,

--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -37,12 +37,12 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
   void AddValuesAndUpdateAnnotations(
       uint64_t timestamp_ns, const std::array<double, kBasicPageFaultsTrackDimension>& values);
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-
   enum class SeriesIndex { kProcess = 0, kCGroup = 1, kSystem = 2 };
 
  protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+
   void DrawSingleSeriesEntry(
       Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
       const std::array<float, kBasicPageFaultsTrackDimension>& current_normalized_values,

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -47,9 +47,9 @@ std::string CallstackThreadBar::GetTooltip() const {
   return "Left-click and drag to select samples";
 }
 
-void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                              const DrawContext& draw_context) {
-  ThreadBar::Draw(batcher, text_renderer, draw_context);
+void CallstackThreadBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                                const DrawContext& draw_context) {
+  ThreadBar::DoDraw(batcher, text_renderer, draw_context);
 
   if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
     return;
@@ -96,9 +96,9 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
   }
 }
 
-void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                          PickingMode picking_mode, float z_offset) {
-  ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+void CallstackThreadBar::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                            PickingMode picking_mode, float z_offset) {
+  ThreadBar::DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   float z = GlCanvas::kZValueEvent + z_offset;
   float track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -31,10 +31,6 @@ class CallstackThreadBar : public ThreadBar {
 
   std::string GetTooltip() const override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] float GetHeight() const override {
     return layout_->GetEventTrackHeightFromTid(GetThreadId());
   }
@@ -43,6 +39,12 @@ class CallstackThreadBar : public ThreadBar {
   void OnRelease() override;
 
   [[nodiscard]] bool IsEmpty() const override;
+
+ protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode picking_mode, float z_offset = 0) override;
 
  private:
   void SelectCallstacks();

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -26,6 +26,13 @@ void CaptureViewElement::SetWidth(float width) {
   }
 }
 
+void CaptureViewElement::SetVisible(bool value) {
+  if (visible_ == value) return;
+
+  visible_ = value;
+  RequestUpdate();
+}
+
 void CaptureViewElement::OnPick(int x, int y) {
   mouse_pos_last_click_ = viewport_->ScreenToWorldPos(Vec2i(x, y));
   picking_offset_ = mouse_pos_last_click_ - pos_;

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -15,6 +15,28 @@ CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, TimeGraph* ti
   CHECK(layout != nullptr);
 }
 
+void CaptureViewElement::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                              const DrawContext& draw_context) {
+  DoDraw(batcher, text_renderer, draw_context);
+
+  const DrawContext inner_draw_context = draw_context.IncreasedIndentationLevel();
+  for (auto& child : GetChildren()) {
+    if (child->ShouldBeRendered()) {
+      child->Draw(batcher, text_renderer, inner_draw_context);
+    }
+  }
+}
+
+void CaptureViewElement::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                          PickingMode picking_mode, float z_offset) {
+  DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+  for (auto& child : GetChildren()) {
+    if (child->ShouldBeRendered()) {
+      child->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+    }
+  }
+}
+
 void CaptureViewElement::SetWidth(float width) {
   if (width != width_) {
     width_ = width;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -42,11 +42,14 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
       return copy;
     }
   };
-  virtual void Draw(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
-                    const DrawContext& /*draw_context*/) {}
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context) {
+    DoDraw(batcher, text_renderer, draw_context);
+  }
 
-  virtual void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
-                                PickingMode /*picking_mode*/, float /*z_offset*/ = 0){};
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode, float z_offset = 0) {
+    DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+  };
 
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
 
@@ -84,6 +87,13 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   Vec2 mouse_pos_cur_;
   Vec2 picking_offset_ = Vec2(0, 0);
   bool picked_ = false;
+
+  virtual void DoDraw(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
+                      const DrawContext& /*draw_context*/) {}
+
+  virtual void DoUpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/,
+                                  uint64_t /*max_tick*/, PickingMode /*picking_mode*/,
+                                  float /*z_offset*/ = 0){};
 
  private:
   float width_ = 0.;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -42,14 +42,11 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
       return copy;
     }
   };
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context) {
-    DoDraw(batcher, text_renderer, draw_context);
-  }
+
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context);
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) {
-    DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  };
+                        PickingMode picking_mode, float z_offset = 0);
 
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
 
@@ -70,7 +67,6 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   void SetVisible(bool value);
   [[nodiscard]] bool GetVisible() const { return visible_; }
-
 
   // Pickable
   void OnPick(int x, int y) override;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -66,6 +66,11 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   // Height should be defined in every particular capture view element.
   [[nodiscard]] virtual float GetHeight() const = 0;
   [[nodiscard]] Vec2 GetSize() const { return Vec2(GetWidth(), GetHeight()); }
+  [[nodiscard]] virtual bool ShouldBeRendered() const { return GetVisible(); }
+
+  void SetVisible(bool value);
+  [[nodiscard]] bool GetVisible() const { return visible_; }
+
 
   // Pickable
   void OnPick(int x, int y) override;
@@ -87,6 +92,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   Vec2 mouse_pos_cur_;
   Vec2 picking_offset_ = Vec2(0, 0);
   bool picked_ = false;
+  bool visible_ = true;
 
   virtual void DoDraw(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
                       const DrawContext& /*draw_context*/) {}

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -206,9 +206,9 @@ std::string FrameTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) cons
           TicksToDuration(timer_info->start(), timer_info->end())));
 }
 
-void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                      const DrawContext& draw_context) {
-  TimerTrack::Draw(batcher, text_renderer, draw_context);
+void FrameTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                        const DrawContext& draw_context) {
+  TimerTrack::DoDraw(batcher, text_renderer, draw_context);
 
   const Color kWhiteColor(255, 255, 255, 255);
   const Color kBlackColor(0, 0, 0, 255);

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -52,10 +52,10 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-
  protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected, bool is_highlighted,
                                     const internal::DrawData& draw_data) const override;

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -125,40 +125,6 @@ std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetChildren() const {
   return {submission_track_.get(), marker_track_.get()};
 }
 
-void GpuTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-                      const DrawContext& draw_context) {
-  Track::DoDraw(batcher, text_renderer, draw_context);
-
-  if (collapse_toggle_->IsCollapsed()) {
-    return;
-  }
-  const DrawContext sub_track_draw_context = draw_context.IncreasedIndentationLevel();
-  if (!submission_track_->IsEmpty()) {
-    submission_track_->Draw(batcher, text_renderer, sub_track_draw_context);
-  }
-
-  if (!marker_track_->IsEmpty()) {
-    marker_track_->Draw(batcher, text_renderer, sub_track_draw_context);
-  }
-}
-
-void GpuTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                  PickingMode picking_mode, float z_offset) {
-  const bool is_collapsed = collapse_toggle_->IsCollapsed();
-
-  if (!submission_track_->IsEmpty()) {
-    submission_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  }
-
-  if (is_collapsed) {
-    return;
-  }
-
-  if (!marker_track_->IsEmpty()) {
-    marker_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  }
-}
-
 std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetVisibleChildren() {
   std::vector<CaptureViewElement*> result;
 

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -120,9 +120,9 @@ std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetChildren() const {
   return {submission_track_.get(), marker_track_.get()};
 }
 
-void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                    const DrawContext& draw_context) {
-  Track::Draw(batcher, text_renderer, draw_context);
+void GpuTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                      const DrawContext& draw_context) {
+  Track::DoDraw(batcher, text_renderer, draw_context);
 
   if (collapse_toggle_->IsCollapsed()) {
     return;
@@ -137,8 +137,8 @@ void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   }
 }
 
-void GpuTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                PickingMode picking_mode, float z_offset) {
+void GpuTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                  PickingMode picking_mode, float z_offset) {
   const bool is_collapsed = collapse_toggle_->IsCollapsed();
 
   if (!submission_track_->IsEmpty()) {

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -87,9 +87,12 @@ void GpuTrack::UpdatePositionOfSubtracks() {
   if (collapse_toggle_->IsCollapsed()) {
     submission_track_->SetPos(pos[0], pos[1]);
     marker_track_->SetVisible(false);
+    submission_track_->SetHeadless(true);
     return;
   }
   marker_track_->SetVisible(true);
+  submission_track_->SetHeadless(false);
+
   float current_y = pos[1] + layout_->GetTrackTabHeight();
   if (submission_track_->ShouldBeRendered()) {
     current_y += layout_->GetSpaceBetweenSubtracks();

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -86,14 +86,16 @@ void GpuTrack::UpdatePositionOfSubtracks() {
   const Vec2 pos = GetPos();
   if (collapse_toggle_->IsCollapsed()) {
     submission_track_->SetPos(pos[0], pos[1]);
+    marker_track_->SetVisible(false);
     return;
   }
+  marker_track_->SetVisible(true);
   float current_y = pos[1] + layout_->GetTrackTabHeight();
-  if (!submission_track_->IsEmpty()) {
+  if (submission_track_->ShouldBeRendered()) {
     current_y += layout_->GetSpaceBetweenSubtracks();
   }
   submission_track_->SetPos(pos[0], current_y);
-  if (!marker_track_->IsEmpty()) {
+  if (marker_track_->ShouldBeRendered()) {
     current_y += (layout_->GetSpaceBetweenSubtracks() + submission_track_->GetHeight());
   }
 
@@ -105,11 +107,11 @@ float GpuTrack::GetHeight() const {
     return submission_track_->GetHeight();
   }
   float height = layout_->GetTrackTabHeight();
-  if (!submission_track_->IsEmpty()) {
+  if (submission_track_->ShouldBeRendered()) {
     height += submission_track_->GetHeight();
     height += layout_->GetSpaceBetweenSubtracks();
   }
-  if (!marker_track_->IsEmpty()) {
+  if (marker_track_->ShouldBeRendered()) {
     height += marker_track_->GetHeight();
     height += layout_->GetSpaceBetweenSubtracks();
   }
@@ -161,11 +163,11 @@ std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetVisibleChildren() {
     return result;
   }
 
-  if (!submission_track_->IsEmpty()) {
+  if (submission_track_->ShouldBeRendered()) {
     result.push_back(submission_track_.get());
   }
 
-  if (!marker_track_->IsEmpty()) {
+  if (marker_track_->ShouldBeRendered()) {
     result.push_back(marker_track_.get());
   }
   return result;

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -65,11 +65,6 @@ class GpuTrack : public Track {
   [[nodiscard]] float GetHeight() const override;
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
-
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
 
   [[nodiscard]] bool IsEmpty() const override {
@@ -84,6 +79,12 @@ class GpuTrack : public Track {
   [[nodiscard]] uint64_t GetMaxTime() const override {
     return std::max(submission_track_->GetMaxTime(), marker_track_->GetMaxTime());
   }
+
+ protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode picking_mode, float z_offset = 0) override;
 
  private:
   void UpdatePositionOfSubtracks() override;

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -80,12 +80,6 @@ class GpuTrack : public Track {
     return std::max(submission_track_->GetMaxTime(), marker_track_->GetMaxTime());
   }
 
- protected:
-  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-              const DrawContext& draw_context) override;
-  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode, float z_offset = 0) override;
-
  private:
   void UpdatePositionOfSubtracks() override;
   orbit_string_manager::StringManager* string_manager_;

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -56,9 +56,9 @@ float GraphTrack<Dimension>::GetLegendHeight() const {
 }
 
 template <size_t Dimension>
-void GraphTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                                 const DrawContext& draw_context) {
-  Track::Draw(batcher, text_renderer, draw_context);
+void GraphTrack<Dimension>::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                                   const DrawContext& draw_context) {
+  Track::DoDraw(batcher, text_renderer, draw_context);
   if (IsEmpty() || IsCollapsed()) return;
 
   // Draw label
@@ -82,8 +82,9 @@ void GraphTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
 }
 
 template <size_t Dimension>
-void GraphTrack<Dimension>::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                             PickingMode picking_mode, float z_offset) {
+void GraphTrack<Dimension>::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick,
+                                               uint64_t max_tick, PickingMode picking_mode,
+                                               float z_offset) {
   float track_z = GlCanvas::kZValueTrack + z_offset;
   float graph_z = GlCanvas::kZValueEventBar + z_offset;
 

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -35,11 +35,6 @@ class GraphTrack : public Track {
   [[nodiscard]] bool IsCollapsible() const override { return true; }
   [[nodiscard]] bool IsEmpty() const override { return series_.IsEmpty(); }
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) override;
-
   virtual void AddValues(uint64_t timestamp_ns, const std::array<double, Dimension>& values) {
     series_.AddValues(timestamp_ns, values);
   }
@@ -70,6 +65,12 @@ class GraphTrack : public Track {
   }
 
  protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode picking_mode, float z_offset = 0) override;
+
   [[nodiscard]] virtual Color GetColor(size_t index) const;
   [[nodiscard]] virtual double GetGraphMaxValue() const { return series_.GetMax(); }
   [[nodiscard]] virtual double GetGraphMinValue() const { return series_.GetMin(); }

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -12,9 +12,9 @@
 namespace orbit_gl {
 
 template <size_t Dimension>
-void MemoryTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                                  const CaptureViewElement::DrawContext& draw_context) {
-  GraphTrack<Dimension>::Draw(batcher, text_renderer, draw_context);
+void MemoryTrack<Dimension>::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                                    const CaptureViewElement::DrawContext& draw_context) {
+  GraphTrack<Dimension>::DoDraw(batcher, text_renderer, draw_context);
 
   if (this->collapse_toggle_->IsCollapsed()) return;
   AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_,

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -34,13 +34,14 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
   ~MemoryTrack() override = default;
 
   [[nodiscard]] Track::Type GetType() const override { return Track::Type::kMemoryTrack; }
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const CaptureViewElement::DrawContext& draw_context) override;
 
   void TrySetValueUpperBound(const std::string& pretty_label, double raw_value);
   void TrySetValueLowerBound(const std::string& pretty_label, double raw_value);
 
  protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const CaptureViewElement::DrawContext& draw_context) override;
+
   [[nodiscard]] double GetGraphMaxValue() const override;
   [[nodiscard]] double GetGraphMinValue() const override;
 

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -46,10 +46,10 @@ float PageFaultsTrack::GetHeight() const {
   }
 
   float height = layout_->GetTrackTabHeight();
-  if (!major_page_faults_track_->IsEmpty()) {
+  if (major_page_faults_track_->ShouldBeRendered()) {
     height += major_page_faults_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
   }
-  if (!minor_page_faults_track_->IsEmpty()) {
+  if (minor_page_faults_track_->ShouldBeRendered()) {
     height += minor_page_faults_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
   }
   return height;
@@ -106,16 +106,18 @@ void PageFaultsTrack::UpdatePositionOfSubtracks() {
   const Vec2 pos = GetPos();
   if (collapse_toggle_->IsCollapsed()) {
     major_page_faults_track_->SetPos(pos[0], pos[1]);
+    minor_page_faults_track_->SetVisible(false);
     return;
   }
 
+  minor_page_faults_track_->SetVisible(true);
   float current_y = pos[1] + layout_->GetTrackTabHeight();
-  if (!major_page_faults_track_->IsEmpty()) {
+  if (major_page_faults_track_->ShouldBeRendered()) {
     current_y += layout_->GetSpaceBetweenSubtracks();
   }
   major_page_faults_track_->SetPos(pos[0], current_y);
 
-  if (!minor_page_faults_track_->IsEmpty()) {
+  if (minor_page_faults_track_->ShouldBeRendered()) {
     current_y += (layout_->GetSpaceBetweenSubtracks() + major_page_faults_track_->GetHeight());
   }
   minor_page_faults_track_->SetPos(pos[0], current_y);

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -73,9 +73,9 @@ std::vector<CaptureViewElement*> PageFaultsTrack::GetChildren() const {
   return {major_page_faults_track_.get(), minor_page_faults_track_.get()};
 }
 
-void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                           const DrawContext& draw_context) {
-  Track::Draw(batcher, text_renderer, draw_context);
+void PageFaultsTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                             const DrawContext& draw_context) {
+  Track::DoDraw(batcher, text_renderer, draw_context);
 
   if (collapse_toggle_->IsCollapsed()) return;
 
@@ -89,8 +89,8 @@ void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   }
 }
 
-void PageFaultsTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                       PickingMode picking_mode, float z_offset) {
+void PageFaultsTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                         PickingMode picking_mode, float z_offset) {
   if (!major_page_faults_track_->IsEmpty()) {
     major_page_faults_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -59,8 +59,10 @@ std::vector<orbit_gl::CaptureViewElement*> PageFaultsTrack::GetVisibleChildren()
   std::vector<CaptureViewElement*> result;
   if (collapse_toggle_->IsCollapsed()) return result;
 
-  if (!major_page_faults_track_->IsEmpty()) result.push_back(major_page_faults_track_.get());
-  if (!minor_page_faults_track_->IsEmpty()) result.push_back(minor_page_faults_track_.get());
+  if (major_page_faults_track_->ShouldBeRendered())
+    result.push_back(major_page_faults_track_.get());
+  if (minor_page_faults_track_->ShouldBeRendered())
+    result.push_back(minor_page_faults_track_.get());
   return result;
 }
 
@@ -107,8 +109,11 @@ void PageFaultsTrack::UpdatePositionOfSubtracks() {
   if (collapse_toggle_->IsCollapsed()) {
     major_page_faults_track_->SetPos(pos[0], pos[1]);
     minor_page_faults_track_->SetVisible(false);
+    major_page_faults_track_->SetHeadless(true);
     return;
   }
+
+  major_page_faults_track_->SetHeadless(false);
 
   minor_page_faults_track_->SetVisible(true);
   float current_y = pos[1] + layout_->GetTrackTabHeight();

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -75,35 +75,6 @@ std::vector<CaptureViewElement*> PageFaultsTrack::GetChildren() const {
   return {major_page_faults_track_.get(), minor_page_faults_track_.get()};
 }
 
-void PageFaultsTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-                             const DrawContext& draw_context) {
-  Track::DoDraw(batcher, text_renderer, draw_context);
-
-  if (collapse_toggle_->IsCollapsed()) return;
-
-  const DrawContext sub_track_draw_context = draw_context.IncreasedIndentationLevel();
-  if (!major_page_faults_track_->IsEmpty()) {
-    major_page_faults_track_->Draw(batcher, text_renderer, sub_track_draw_context);
-  }
-
-  if (!minor_page_faults_track_->IsEmpty()) {
-    minor_page_faults_track_->Draw(batcher, text_renderer, sub_track_draw_context);
-  }
-}
-
-void PageFaultsTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                         PickingMode picking_mode, float z_offset) {
-  if (!major_page_faults_track_->IsEmpty()) {
-    major_page_faults_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  }
-
-  if (collapse_toggle_->IsCollapsed()) return;
-
-  if (!minor_page_faults_track_->IsEmpty()) {
-    minor_page_faults_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  }
-}
-
 void PageFaultsTrack::UpdatePositionOfSubtracks() {
   const Vec2 pos = GetPos();
   if (collapse_toggle_->IsCollapsed()) {

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -68,13 +68,6 @@ class PageFaultsTrack : public Track {
   [[nodiscard]] uint64_t GetMinTime() const override;
   [[nodiscard]] uint64_t GetMaxTime() const override;
 
- protected:
-  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-              const DrawContext& draw_context) override;
-
-  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode, float z_offset = 0) override;
-
  private:
   void UpdatePositionOfSubtracks() override;
 

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -37,11 +37,6 @@ class PageFaultsTrack : public Track {
   [[nodiscard]] bool IsCollapsible() const override { return true; }
   [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) override;
-
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   void AddValuesAndUpdateAnnotationsForMajorPageFaultsSubtrack(
@@ -72,6 +67,13 @@ class PageFaultsTrack : public Track {
   }
   [[nodiscard]] uint64_t GetMinTime() const override;
   [[nodiscard]] uint64_t GetMaxTime() const override;
+
+ protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode picking_mode, float z_offset = 0) override;
 
  private:
   void UpdatePositionOfSubtracks() override;

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -31,6 +31,9 @@ class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this
         color_(color) {}
 
   [[nodiscard]] virtual bool IsEmpty() const { return false; }
+  [[nodiscard]] bool ShouldBeRendered() const override {
+    return CaptureViewElement::ShouldBeRendered() && !IsEmpty();
+  }
 
   [[nodiscard]] virtual const std::string& GetName() const { return name_; }
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -36,11 +36,11 @@ bool ThreadStateBar::IsEmpty() const {
   return capture_data_ == nullptr || !capture_data_->HasThreadStatesForThread(GetThreadId());
 }
 
-void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                          const DrawContext& draw_context) {
-  ThreadBar::Draw(batcher, text_renderer, draw_context);
+void ThreadStateBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                            const DrawContext& draw_context) {
+  ThreadBar::DoDraw(batcher, text_renderer, draw_context);
 
-  // Similarly to CallstackThreadBar::Draw, the thread state slices don't respond to clicks, but
+  // Similarly to CallstackThreadBar::DoDraw, the thread state slices don't respond to clicks, but
   // have a tooltip. For picking, we want to draw the event bar over them if handling a click, and
   // underneath otherwise. This simulates "click-through" behavior.
   float thread_state_bar_z = draw_context.picking_mode == PickingMode::kClick
@@ -162,9 +162,9 @@ std::string ThreadStateBar::GetThreadStateSliceTooltip(Batcher* batcher, Picking
       GetThreadStateDescription(thread_state_slice->thread_state()));
 }
 
-void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                      PickingMode picking_mode, float z_offset) {
-  ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+void ThreadStateBar::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                        PickingMode picking_mode, float z_offset) {
+  ThreadBar::DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   const auto time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
   const uint64_t pixel_delta_ns = time_window_ns / viewport_->WorldToScreenWidth(GetWidth());

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -29,15 +29,18 @@ class ThreadStateBar final : public ThreadBar {
                           const orbit_client_data::CaptureData* capture_data,
                           orbit_client_data::ThreadID thread_id, const Color& color);
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset) override;
   [[nodiscard]] float GetHeight() const override { return layout_->GetThreadStateTrackHeight(); }
 
   void OnPick(int x, int y) override;
 
   [[nodiscard]] bool IsEmpty() const override;
+
+ protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode picking_mode, float z_offset) override;
 
  private:
   std::string GetThreadStateSliceTooltip(Batcher* batcher, PickingId id) const;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -269,25 +269,6 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   tracepoint_bar_->SetPos(pos[0], current_y);
 }
 
-void ThreadTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-                         const DrawContext& draw_context) {
-  TimerTrack::DoDraw(batcher, text_renderer, draw_context);
-
-  DrawContext inner_draw_context = draw_context.IncreasedIndentationLevel();
-
-  if (!thread_state_bar_->IsEmpty()) {
-    thread_state_bar_->Draw(batcher, text_renderer, inner_draw_context);
-  }
-
-  if (!event_bar_->IsEmpty()) {
-    event_bar_->Draw(batcher, text_renderer, inner_draw_context);
-  }
-
-  if (!tracepoint_bar_->IsEmpty()) {
-    tracepoint_bar_->Draw(batcher, text_renderer, inner_draw_context);
-  }
-}
-
 void ThreadTrack::OnPick(int x, int y) {
   Track::OnPick(x, y);
   app_->set_selected_thread_id(GetThreadId());
@@ -467,10 +448,9 @@ void ThreadTrack::OnCaptureComplete() {
 // draw over an already drawn pixel line. When zoomed in enough that all events are drawn as boxes,
 // this has no effect. When zoomed  out, many events will be discarded quickly.
 void ThreadTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                     PickingMode picking_mode, float z_offset) {
+                                     PickingMode /*picking_mode*/, float z_offset) {
   CHECK(batcher);
   visible_timer_count_ = 0;
-  UpdatePrimitivesOfSubtracks(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   const internal::DrawData draw_data =
       GetDrawData(min_tick, max_tick, GetPos()[0], GetWidth(), z_offset, batcher, time_graph_,
@@ -514,19 +494,5 @@ void ThreadTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64
       uint64_t next_pixel_start_time_ns = GetNextPixelBoundaryTimeNs(timer_info->end(), draw_data);
       timer_info = scope_tree_.FindFirstScopeAtOrAfterTime(depth, next_pixel_start_time_ns);
     }
-  }
-}
-
-void ThreadTrack::UpdatePrimitivesOfSubtracks(Batcher* batcher, uint64_t min_tick,
-                                              uint64_t max_tick, PickingMode picking_mode,
-                                              float z_offset) {
-  if (!thread_state_bar_->IsEmpty()) {
-    thread_state_bar_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  }
-  if (!event_bar_->IsEmpty()) {
-    event_bar_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  }
-  if (!tracepoint_bar_->IsEmpty()) {
-    tracepoint_bar_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }
 }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -257,12 +257,12 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   float current_y = pos[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
 
   thread_state_bar_->SetPos(pos[0], current_y);
-  if (!thread_state_bar_->IsEmpty()) {
+  if (thread_state_bar_->ShouldBeRendered()) {
     current_y += (space_between_subtracks + thread_state_track_height);
   }
 
   event_bar_->SetPos(pos[0], current_y);
-  if (!event_bar_->IsEmpty()) {
+  if (event_bar_->ShouldBeRendered()) {
     current_y += (space_between_subtracks + event_track_height);
   }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -269,9 +269,9 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   tracepoint_bar_->SetPos(pos[0], current_y);
 }
 
-void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                       const DrawContext& draw_context) {
-  TimerTrack::Draw(batcher, text_renderer, draw_context);
+void ThreadTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                         const DrawContext& draw_context) {
+  TimerTrack::DoDraw(batcher, text_renderer, draw_context);
 
   DrawContext inner_draw_context = draw_context.IncreasedIndentationLevel();
 
@@ -466,8 +466,8 @@ void ThreadTrack::OnCaptureComplete() {
 // We minimize overdraw when drawing lines for small events by discarding events that would just
 // draw over an already drawn pixel line. When zoomed in enough that all events are drawn as boxes,
 // this has no effect. When zoomed  out, many events will be discarded quickly.
-void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                   PickingMode picking_mode, float z_offset) {
+void ThreadTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                     PickingMode picking_mode, float z_offset) {
   CHECK(batcher);
   visible_timer_count_ = 0;
   UpdatePrimitivesOfSubtracks(batcher, min_tick, max_tick, picking_mode, z_offset);

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -48,10 +48,6 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
       const orbit_client_protos::TimerInfo& timer_info) const override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
 
@@ -71,6 +67,11 @@ class ThreadTrack final : public TimerTrack {
   void OnCaptureComplete();
 
  protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode picking_mode, float z_offset = 0) override;
+
   [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] bool IsTrackSelected() const override;

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -67,8 +67,6 @@ class ThreadTrack final : public TimerTrack {
   void OnCaptureComplete();
 
  protected:
-  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-              const DrawContext& draw_context) override;
   void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                           PickingMode picking_mode, float z_offset = 0) override;
 
@@ -90,8 +88,6 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] float GetHeaderHeight() const override;
 
   void UpdatePositionOfSubtracks() override;
-  void UpdatePrimitivesOfSubtracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                   PickingMode picking_mode, float z_offset);
 
   int64_t thread_id_;
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -518,8 +518,9 @@ void TimeGraph::RequestUpdate() {
 }
 
 // UpdatePrimitives updates all the drawable track timers in the timegraph's batcher
-void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
-                                 PickingMode picking_mode, float /*z_offset*/) {
+void TimeGraph::DoUpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/,
+                                   uint64_t /*max_tick*/, PickingMode picking_mode,
+                                   float /*z_offset*/) {
   ORBIT_SCOPE_FUNCTION;
   CHECK(app_->GetStringManager() != nullptr);
 
@@ -585,9 +586,9 @@ const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(uint32_
   return selected_callstack_events_per_thread_[tid];
 }
 
-void TimeGraph::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                     const DrawContext& draw_context) {
-  ORBIT_SCOPE("TimeGraph::Draw");
+void TimeGraph::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                       const DrawContext& draw_context) {
+  ORBIT_SCOPE_FUNCTION;
 
   track_manager_->UpdateTracksForRendering();
   UpdateTracksPosition();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -512,8 +512,9 @@ const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint
 }
 
 void TimeGraph::RequestUpdate() {
+  CaptureViewElement::RequestUpdate();
   update_primitives_requested_ = true;
-  RequestRedraw();
+  redraw_requested_ = true;
 }
 
 // UpdatePrimitives updates all the drawable track timers in the timegraph's batcher

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -45,8 +45,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] float GetHeight() const override {
     return track_manager_->GetVisibleTracksTotalHeight();
   }
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
   void DrawTracks(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context);
   void DrawOverlay(Batcher& batcher, TextRenderer& text_renderer, PickingMode picking_mode);
   void DrawIteratorBox(Batcher& batcher, TextRenderer& text_renderer, Vec2 pos, Vec2 size,
@@ -56,8 +54,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void DrawText(float layer);
 
   void RequestUpdate() override;
-  void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
-                        PickingMode /*picking_mode*/, float /*z_offset*/ = 0) override;
+
   void UpdateTracksPosition();
   void SelectCallstacks(float world_start, float world_end, uint32_t thread_id);
   const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(uint32_t tid);
@@ -187,6 +184,11 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   }
 
  protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode picking_mode, float z_offset = 0) override;
+
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
   void ProcessAsyncTimer(const std::string& track_name,

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -115,7 +115,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void SelectAndZoom(const orbit_client_protos::TimerInfo* timer_info);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
   [[nodiscard]] double GetCurrentTimeSpanUs() const;
-  void RequestRedraw() { redraw_requested_ = true; }
   [[nodiscard]] bool IsRedrawNeeded() const { return redraw_requested_; }
   void SetThreadFilter(const std::string& filter);
 
@@ -174,7 +173,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
       const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id) {
     iterator_timer_info_ = iterator_timer_info;
     iterator_id_to_function_id_ = iterator_id_to_function_id;
-    RequestRedraw();
+    RequestUpdate();
   }
 
   [[nodiscard]] uint64_t GetCaptureMin() const { return capture_min_timestamp_; }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -241,8 +241,8 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
   return true;
 }
 
-void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                  PickingMode /*picking_mode*/, float z_offset) {
+void TimerTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                    PickingMode /*picking_mode*/, float z_offset) {
   visible_timer_count_ = 0;
 
   internal::DrawData draw_data{};

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -62,8 +62,6 @@ class TimerTrack : public Track {
   [[nodiscard]] std::string GetTooltip() const override;
 
   // Track
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode /*picking_mode*/, float z_offset = 0) override;
   [[nodiscard]] Type GetType() const override { return Type::kTimerTrack; }
 
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer) const;
@@ -100,6 +98,9 @@ class TimerTrack : public Track {
   [[nodiscard]] uint64_t GetMaxTime() const override;
 
  protected:
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode /*picking_mode*/, float z_offset = 0) override;
+
   [[nodiscard]] virtual bool IsTimerActive(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
     return true;

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -36,9 +36,9 @@ TracepointThreadBar::TracepointThreadBar(CaptureViewElement* parent, OrbitApp* a
     : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Tracepoints",
                 color) {}
 
-void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                               const DrawContext& draw_context) {
-  ThreadBar::Draw(batcher, text_renderer, draw_context);
+void TracepointThreadBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                                 const DrawContext& draw_context) {
+  ThreadBar::DoDraw(batcher, text_renderer, draw_context);
 
   if (IsEmpty()) {
     return;
@@ -53,9 +53,9 @@ void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
   batcher.AddBox(box, color, shared_from_this());
 }
 
-void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                           PickingMode picking_mode, float z_offset) {
-  ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+void TracepointThreadBar::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                             PickingMode picking_mode, float z_offset) {
+  ThreadBar::DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   float z = GlCanvas::kZValueEvent + z_offset;
   float track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -22,16 +22,17 @@ class TracepointThreadBar : public ThreadBar {
                                const orbit_client_data::CaptureData* capture_data,
                                uint32_t thread_id, const Color& color);
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] float GetHeight() const override {
     return layout_->GetEventTrackHeightFromTid(GetThreadId());
   }
 
   [[nodiscard]] bool IsEmpty() const override;
+
+ protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                          PickingMode picking_mode, float z_offset = 0) override;
 
  private:
   std::string GetTracepointTooltip(Batcher* batcher, PickingId id) const;

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -86,8 +86,8 @@ std::unique_ptr<orbit_accessibility::AccessibleInterface> Track::CreateAccessibl
   return std::make_unique<orbit_gl::AccessibleTrack>(this, layout_);
 }
 
-void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context) {
-  CaptureViewElement::Draw(batcher, text_renderer, draw_context);
+void Track::DoDraw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context) {
+  CaptureViewElement::DoDraw(batcher, text_renderer, draw_context);
 
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
 
@@ -203,9 +203,6 @@ void Track::DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer
   collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1]);
   collapse_toggle_->Draw(batcher, text_renderer, draw_context);
 }
-
-void Track::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*t_min*/, uint64_t /*t_max*/,
-                             PickingMode /*  picking_mode*/, float /*z_offset*/) {}
 
 void Track::SetPos(float x, float y) {
   CaptureViewElement::SetPos(x, y);

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -89,6 +89,8 @@ std::unique_ptr<orbit_accessibility::AccessibleInterface> Track::CreateAccessibl
 void Track::DoDraw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context) {
   CaptureViewElement::DoDraw(batcher, text_renderer, draw_context);
 
+  if (headless_) return;
+
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
 
   const float x0 = GetPos()[0];
@@ -225,6 +227,13 @@ Color Track::GetTrackBackgroundColor() const {
 }
 
 void Track::OnCollapseToggle(bool /*is_collapsed*/) { RequestUpdate(); }
+
+void Track::SetHeadless(bool value) {
+  if (headless_ == value) return;
+
+  headless_ = value;
+  RequestUpdate();
+}
 
 void Track::OnDrag(int x, int y) {
   CaptureViewElement::OnDrag(x, y);

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -53,11 +53,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
                  TimeGraphLayout* layout, const orbit_client_data::CaptureData* capture_data);
   ~Track() override = default;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) override;
   void SetPos(float x, float y) override;
   void OnDrag(int x, int y) override;
 
@@ -108,6 +103,9 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
       const orbit_client_protos::TimerInfo& /*timer_info*/) const = 0;
 
  protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+
   void DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
                               const DrawContext& draw_context);
   void DrawTriangleFan(Batcher& batcher, const std::vector<Vec2>& points, const Vec2& pos,

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -58,9 +58,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] virtual Type GetType() const = 0;
 
-  [[nodiscard]] bool GetVisible() const { return visible_; }
-  void SetVisible(bool value) { visible_ = value; }
-
   [[nodiscard]] virtual uint64_t GetMinTime() const = 0;
   [[nodiscard]] virtual uint64_t GetMaxTime() const = 0;
 
@@ -81,6 +78,10 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] uint32_t GetProcessId() const { return process_id_; }
   void SetProcessId(uint32_t pid) { process_id_ = pid; }
   [[nodiscard]] virtual bool IsEmpty() const = 0;
+  [[nodiscard]] bool ShouldBeRendered() const override {
+    return CaptureViewElement::ShouldBeRendered() && !IsEmpty();
+  }
+
 
   [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
 
@@ -116,7 +117,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   uint32_t process_id_;
   bool draw_background_ = true;
-  bool visible_ = true;
   bool pinned_ = false;
   Type type_ = Type::kUnknown;
   std::shared_ptr<TriangleToggle> collapse_toggle_;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -87,6 +87,9 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] virtual bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
 
+  [[nodiscard]] bool GetHeadless() const { return headless_; }
+  void SetHeadless(bool value);
+
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
@@ -118,6 +121,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   uint32_t process_id_;
   bool draw_background_ = true;
   bool pinned_ = false;
+  bool headless_ = false;
   Type type_ = Type::kUnknown;
   std::shared_ptr<TriangleToggle> collapse_toggle_;
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -82,7 +82,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
     return CaptureViewElement::ShouldBeRendered() && !IsEmpty();
   }
 
-
   [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
 
   [[nodiscard]] virtual bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -215,7 +215,7 @@ void TrackManager::UpdateVisibleTrackList() {
   visible_tracks_.clear();
 
   auto track_should_be_shown = [this](const Track* track) {
-    return track->GetVisible() && track_type_visibility_[track->GetType()];
+    return track->ShouldBeRendered() && track_type_visibility_[track->GetType()];
   };
 
   if (filter_.empty()) {

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -22,9 +22,9 @@ TriangleToggle::TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph
       track_(track),
       handler_(std::move(handler)) {}
 
-void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                          const DrawContext& draw_context) {
-  CaptureViewElement::Draw(batcher, text_renderer, draw_context);
+void TriangleToggle::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                            const DrawContext& draw_context) {
+  CaptureViewElement::DoDraw(batcher, text_renderer, draw_context);
 
   const float z = GlCanvas::kZValueTrack + draw_context.z_offset;
 

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -28,9 +28,6 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   TriangleToggle(TriangleToggle&&) = delete;
   TriangleToggle& operator=(TriangleToggle&&) = delete;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer,
-            const DrawContext& draw_context) override;
-
   [[nodiscard]] float GetHeight() const override { return height_; }
   void SetHeight(float height) { height_ = height; }
 
@@ -43,6 +40,9 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   [[nodiscard]] bool IsCollapsible() const { return is_collapsible_; }
 
  protected:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
  private:


### PR DESCRIPTION
This is a larger PR that I should probably split into several smaller ones, but IMO it is easier to review these changes commit by commit because some of them only make sense at the end. Each commit should nevertheless be buildable and result in a visually correct capture window.

This change pulls a lot of custom rendering functionality that was implemented in child classes of `CaptureViewElement` into the base class as follows:

- Each element reports its visibility (which is either explicitly set through `SetVisibility`, or implicit, e.g. if a track is considered empty)
- Each element (except `TimeGraph`, this will follow in a later PR) correctly reports a list of its children in `GetChildren()`, and `GetVisibleChildren()` is implemented on top of that
- `CaptureViewElement` will take care of rendering all children as needed