### PR TITLE
Use AppInterface in CallstackDataView

### DIFF
--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -46,6 +46,7 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(bool, HasFrameTrackInCaptureData, (uint64_t), (const));
 
   MOCK_METHOD(bool, HasCaptureData, (), (const));
+  MOCK_METHOD(orbit_client_data::CaptureData&, GetMutableCaptureData, ());
   MOCK_METHOD(const orbit_client_data::CaptureData&, GetCaptureData, (), (const));
 
   MOCK_METHOD(void, OnValidateFramePointers, (std::vector<const orbit_client_data::ModuleData*>));

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -48,6 +48,9 @@ class AppInterface {
   virtual void DeselectTimer() = 0;
   [[nodiscard]] virtual bool IsCapturing() const = 0;
 
+  // Function needed by CallstackDataView
+  [[nodiscard]] virtual orbit_client_data::CaptureData& GetMutableCaptureData() = 0;
+
   [[nodiscard]] virtual bool IsFrameTrackEnabled(
       const orbit_client_protos::FunctionInfo& function) const = 0;
   [[nodiscard]] virtual bool HasFrameTrackInCaptureData(

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -121,7 +121,7 @@ class OrbitApp final : public DataViewFactory,
   void AbortCapture();
   void ClearCapture();
   [[nodiscard]] bool HasCaptureData() const override { return capture_data_ != nullptr; }
-  [[nodiscard]] orbit_client_data::CaptureData& GetMutableCaptureData() {
+  [[nodiscard]] orbit_client_data::CaptureData& GetMutableCaptureData() override {
     CHECK(capture_data_ != nullptr);
     return *capture_data_;
   }

--- a/src/OrbitGl/CallstackDataView.cpp
+++ b/src/OrbitGl/CallstackDataView.cpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <filesystem>
 
-#include "App.h"
 #include "ClientData/CaptureData.h"
 #include "ClientData/FunctionUtils.h"
 #include "DataViews/DataViewType.h"
@@ -28,8 +27,8 @@ using orbit_client_data::ModuleData;
 using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::FunctionInfo;
 
-CallstackDataView::CallstackDataView(OrbitApp* app)
-    : orbit_data_views::DataView(orbit_data_views::DataViewType::kCallstack, app), app_{app} {}
+CallstackDataView::CallstackDataView(orbit_data_views::AppInterface* app)
+    : orbit_data_views::DataView(orbit_data_views::DataViewType::kCallstack, app) {}
 
 void CallstackDataView::SetAsMainInstance() {}
 

--- a/src/OrbitGl/CallstackDataView.h
+++ b/src/OrbitGl/CallstackDataView.h
@@ -12,13 +12,13 @@
 #include <vector>
 
 #include "ClientData/ModuleData.h"
+#include "DataViews/AppInterface.h"
 #include "DataViews/DataView.h"
 #include "capture_data.pb.h"
 
-class OrbitApp;
 class CallstackDataView : public orbit_data_views::DataView {
  public:
-  explicit CallstackDataView(OrbitApp* app);
+  explicit CallstackDataView(orbit_data_views::AppInterface* app);
 
   void SetAsMainInstance() override;
   const std::vector<Column>& GetColumns() override;
@@ -88,10 +88,6 @@ class CallstackDataView : public orbit_data_views::DataView {
 
  private:
   absl::flat_hash_set<uint64_t> functions_to_highlight_;
-
-  // TODO(b/185090791): This is temporary and will be removed once this data view has been ported
-  // and move to orbit_data_views.
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_CALLSTACK_DATA_VIEW_H_


### PR DESCRIPTION
With this change, we made `CallstackDataView` independent of `OrbitApp`
by changing to use `AppInterface`.

Bug: http://b/185090791
Test: builds