### PR TITLE
Update conan version to 1.40.3

### DIFF
--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -18,7 +18,7 @@ it available in the path.
 "@
   }
 
-  & $pip3.Path install conan==1.36.0
+  & $pip3.Path install conan==1.40.3
   if ($LastExitCode -ne 0) {
     Throw "Error while installing conan via pip3."
   }
@@ -47,7 +47,7 @@ You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
 
     Try {
       $pip3 = Get-Command pip3
-      & $pip3.Path install --upgrade conan==1.36.0
+      & $pip3.Path install --upgrade conan==1.40.3
     } Catch {
       Throw "Error while upgrading conan via pip3. Probably you have conan installed differently." + 
             " Please manually update conan to a at least version $conan_version_major_required.$conan_version_minor_min."

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -79,7 +79,7 @@ echo "Checking if conan is available..."
 which conan >/dev/null
 if [ $? -ne 0 ]; then
   echo "Couldn't find conan. Trying to install via pip..."
-  pip3 install --user conan==1.36.0 || exit $?
+  pip3 install --user conan==1.40.3 || exit $?
 
   which conan >/dev/null
   if [ $? -ne 0 ]; then
@@ -103,7 +103,7 @@ else
 
   if [ "$CONAN_VERSION_MAJOR" -eq $CONAN_VERSION_MAJOR_REQUIRED -a "$CONAN_VERSION_MINOR" -lt $CONAN_VERSION_MINOR_MIN ]; then
     echo "Your conan version $CONAN_VERSION is too old. I will try to update..."
-    pip3 install --upgrade --user conan==1.36.0
+    pip3 install --upgrade --user conan==1.40.3
     if [ $? -ne 0 ]; then
       echo "The upgrade of your conan installation failed. Probably because conan was not installed by this script."
       echo "Please manually update conan to at least version $CONAN_VERSION_MAJOR_REQUIRED.$CONAN_VERSION_MINOR_MIN."

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -110,7 +110,7 @@ if [ -n "$1" ]; then
   # That's a temporary solution. The docker containers should have the
   # correct version of conan already preinstalled. This step will be removed
   # when the docker containers are restructured and versioned.
-  pip3 install conan==1.36.0
+  pip3 install conan==1.40.3
 
   echo "Installing conan configuration (profiles, settings, etc.)..."
   ${REPO_ROOT}/third_party/conan/configs/install.sh ${PUBLIC_BUILD:+--force-public-remotes}

--- a/third_party/conan/scripts/build_and_upload_dependencies.sh
+++ b/third_party/conan/scripts/build_and_upload_dependencies.sh
@@ -19,7 +19,7 @@ readonly SCRIPT="/mnt/third_party/conan/scripts/build_and_upload_dependencies.sh
 export CONAN_USE_ALWAYS_SHORT_PATHS=1
 
 if [[ -v IN_DOCKER ]]; then
-  pip3 install conan==1.36.0
+  pip3 install conan==1.40.3
   export QT_QPA_PLATFORM=offscreen
 
   if [[ -v ORBIT_PUBLIC_BUILD ]]; then

--- a/third_party/conan/scripts/sync_dependencies.sh
+++ b/third_party/conan/scripts/sync_dependencies.sh
@@ -13,7 +13,7 @@ REPO_ROOT_WIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" >/dev/null 2>&
 SCRIPT="/mnt/third_party/conan/scripts/sync_dependencies.sh"
 
 if [ "$1" ]; then
-  pip3 install conan==1.36.0
+  pip3 install conan==1.40.3
   export QT_QPA_PLATFORM=offscreen
 
   $REPO_ROOT/third_party/conan/configs/install.sh || exit $?


### PR DESCRIPTION
There was some CA certificate trouble with Conan-Center that is fixed in
1.40. So let's update to make the public build work again.