### PR TITLE
Move process_id to TimerData

### DIFF
--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -8,7 +8,8 @@
 #include <absl/base/thread_annotations.h>
 #include <absl/synchronization/mutex.h>
 
-#include "ClientData/TimerChain.h"
+#include "OrbitBase/ThreadConstants.h"
+#include "TimerChain.h"
 #include "capture_data.pb.h"
 
 namespace orbit_client_data {
@@ -20,9 +21,14 @@ class TimerData final {
   [[nodiscard]] uint64_t GetMinTime() const { return min_time_; }
   [[nodiscard]] uint64_t GetMaxTime() const { return max_time_; }
   [[nodiscard]] uint32_t GetMaxDepth() const { return max_depth_; }
+  [[nodiscard]] uint32_t GetProcessId() const { return process_id_; }
 
   const orbit_client_protos::TimerInfo& AddTimer(uint64_t depth,
                                                  orbit_client_protos::TimerInfo timer_info) {
+    if (process_id_ == orbit_base::kInvalidProcessId) {
+      process_id_ = timer_info.process_id();
+    }
+
     TimerChain* timer_chain = GetOrCreateTimerChain(depth);
     UpdateMinTime(timer_info.start());
     UpdateMaxTime(timer_info.end());
@@ -85,6 +91,8 @@ class TimerData final {
   std::atomic<size_t> num_timers_{0};
   std::atomic<uint64_t> min_time_{std::numeric_limits<uint64_t>::max()};
   std::atomic<uint64_t> max_time_{std::numeric_limits<uint64_t>::min()};
+
+  uint32_t process_id_ = orbit_base::kInvalidProcessId;
 };
 
 }  // namespace orbit_client_data

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -397,10 +397,6 @@ float ThreadTrack::GetYFromDepth(uint32_t depth) const {
 }
 
 void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
-  if (process_id_ == orbit_base::kInvalidProcessId) {
-    process_id_ = timer_info.process_id();
-  }
-
   // Thread tracks use a ScopeTree so we don't need to create one TimerChain per depth.
   // Allocate a single TimerChain into which all timers will be appended.
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -318,10 +318,6 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
 }
 
 void TimerTrack::OnTimer(const TimerInfo& timer_info) {
-  if (process_id_ == orbit_base::kInvalidProcessId) {
-    process_id_ = timer_info.process_id();
-  }
-
   timer_data_->AddTimer(timer_info.depth(), timer_info);
 }
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -66,6 +66,7 @@ class TimerTrack : public Track {
                         PickingMode /*picking_mode*/, float z_offset = 0) override;
   [[nodiscard]] Type GetType() const override { return Type::kTimerTrack; }
 
+  [[nodiscard]] uint32_t GetProcessId() const override { return timer_data_->GetProcessId(); }
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer) const;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetFirstAfterTime(uint64_t time,

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -23,7 +23,6 @@ using orbit_client_data::TimerData;
 Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
              TimeGraphLayout* layout, const orbit_client_data::CaptureData* capture_data)
     : CaptureViewElement(parent, time_graph, viewport, layout),
-      process_id_{orbit_base::kInvalidProcessId},
       pinned_{false},
       layout_(layout),
       capture_data_(capture_data) {

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -83,8 +83,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   virtual void OnCollapseToggle(bool is_collapsed);
   [[nodiscard]] virtual bool IsCollapsible() const { return false; }
   TriangleToggle* GetTriangleToggle() const { return collapse_toggle_.get(); }
-  [[nodiscard]] uint32_t GetProcessId() const { return process_id_; }
-  void SetProcessId(uint32_t pid) { process_id_ = pid; }
+  [[nodiscard]] virtual uint32_t GetProcessId() const { return orbit_base::kInvalidProcessId; }
   [[nodiscard]] virtual bool IsEmpty() const = 0;
 
   [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
@@ -124,7 +123,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
-  uint32_t process_id_;
   bool draw_background_ = true;
   bool visible_ = true;
   bool pinned_ = false;


### PR DESCRIPTION
Moving data from Tracks to TimerData (http://b/202110356)

We used to have process_id in Track but we only set in TimerTrack. Now
we move all that logic to TimerData and in a non-timer track we return
invalid_process_id.