### PR TITLE
Change if != nullptr to CHECK

### DIFF
--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -213,9 +213,14 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
   for (const auto& [start_address, module_in_memory] : memory_map) {
     ModuleData* module = app_->GetMutableModuleByPathAndBuildId(module_in_memory.file_path(),
                                                                 module_in_memory.build_id());
-    if (module != nullptr) {
-      AddModule(start_address, module, module_in_memory);
-    }
+
+    // The module here cannot be a nullptr, because the call
+    // `app_->GetMutableModuleByPathAndBuildId` is relaying the call to
+    // `ModuleManager::GetMutableModuleByPathAndBuildId` and ModuleManager never deletes modules,
+    // only changes modules or adds new modules. And the memory_map cannot contain modules that are
+    // not yet in ModuleManager, since these two locations get updated simultaneously.
+    CHECK(module != nullptr);
+    AddModule(start_address, module, module_in_memory);
   }
 
   OnDataChanged();


### PR DESCRIPTION
The if was initially added to fix http://b/199123516 and
http://b/199119088 (PR2766). Further investigation resulted in the
insight that the problem was not caused by module being a nullptr. In
fact it can be guaranteed that it is not a nullptr, hence the if is
converted into a CHECK.
The initial nullptr dereference that caused the crashes has been
resolved in PR2406