### PR TITLE
Unify time graph

### DIFF
--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -61,7 +61,7 @@ class FakeTimerPane : public CaptureViewElement {
   }
 
   [[nodiscard]] Vec2 GetPos() const override {
-    std::vector<CaptureViewElement*> track_children = track_->GetVisibleChildren();
+    std::vector<CaptureViewElement*> track_children = track_->GetNonHiddenChildren();
 
     // We are looking for the track's child that is right above the timer pane.
     CaptureViewElement* predecessor = track_tab_;
@@ -117,10 +117,10 @@ int AccessibleTrack::AccessibleChildCount() const {
 
   // Only expose the "Timer" pane if any timers were rendered in the visible field
   if (track_->GetVisiblePrimitiveCount() > 0) {
-    return static_cast<int>(track_->GetVisibleChildren().size()) + 2;
+    return static_cast<int>(track_->GetNonHiddenChildren().size()) + 2;
   }
 
-  return static_cast<int>(track_->GetVisibleChildren().size()) + 1;
+  return static_cast<int>(track_->GetNonHiddenChildren().size()) + 1;
 }
 
 const AccessibleInterface* AccessibleTrack::AccessibleChild(int index) const {
@@ -131,7 +131,7 @@ const AccessibleInterface* AccessibleTrack::AccessibleChild(int index) const {
     return fake_tab_->GetOrCreateAccessibleInterface();
   }
 
-  const auto& children = track_->GetVisibleChildren();
+  const auto& children = track_->GetNonHiddenChildren();
   auto child_count = static_cast<int>(children.size());
 
   // The last child is the timer pane if it has timers.

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -75,8 +75,8 @@ void BasicPageFaultsTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
   LineGraphTrack<kBasicPageFaultsTrackDimension>::DoDraw(batcher, text_renderer, draw_context);
 
   if (draw_context.picking_mode != PickingMode::kNone || IsCollapsed()) return;
-  AnnotationTrack::DrawAnnotation(batcher, text_renderer, layout_, draw_context.indentation_level,
-                                  GlCanvas::kZValueTrackText + draw_context.z_offset);
+  AnnotationTrack::DrawAnnotation(batcher, text_renderer, layout_, indentation_level_,
+                                  GlCanvas::kZValueTrackText);
 }
 
 void BasicPageFaultsTrack::DrawSingleSeriesEntry(

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -62,7 +62,6 @@ void CallstackThreadBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
   float event_bar_z = draw_context.picking_mode == PickingMode::kClick
                           ? GlCanvas::kZValueEventBarPicking
                           : GlCanvas::kZValueEventBar;
-  event_bar_z += draw_context.z_offset;
   Color color = GetColor();
   const Vec2 pos = GetPos();
   Box box(pos, Vec2(GetWidth(), GetHeight()), event_bar_z);
@@ -90,17 +89,17 @@ void CallstackThreadBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
     y1 = y0 + GetHeight();
 
     Color picked_color(0, 128, 255, 128);
-    Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, GetHeight()),
-                   GlCanvas::kZValueUi + draw_context.z_offset);
+    Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, GetHeight()), GlCanvas::kZValueUi);
     batcher.AddBox(picked_box, picked_color, shared_from_this());
   }
 }
 
-void CallstackThreadBar::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                            PickingMode picking_mode, float z_offset) {
-  ThreadBar::DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+void CallstackThreadBar::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+                                            uint64_t min_tick, uint64_t max_tick,
+                                            PickingMode picking_mode) {
+  ThreadBar::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
 
-  float z = GlCanvas::kZValueEvent + z_offset;
+  float z = GlCanvas::kZValueEvent;
   float track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const bool picking = picking_mode != PickingMode::kNone;
 

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -43,8 +43,8 @@ class CallstackThreadBar : public ThreadBar {
  protected:
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
-  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode, float z_offset = 0) override;
+  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
 
  private:
   void SelectCallstacks();

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -24,10 +24,8 @@ void CaptureViewElement::Draw(Batcher& batcher, TextRenderer& text_renderer,
 
   DoDraw(batcher, text_renderer, draw_context);
 
-  for (CaptureViewElement* child : GetVisibleChildrenOnScreen()) {
-    if (child->ShouldBeRendered()) {
-      child->Draw(batcher, text_renderer, draw_context);
-    }
+  for (CaptureViewElement* child : GetChildrenVisibleInViewport()) {
+    child->Draw(batcher, text_renderer, draw_context);
   }
 
   text_renderer.PopTranslation();
@@ -44,7 +42,7 @@ void CaptureViewElement::UpdatePrimitives(Batcher* batcher, TextRenderer& text_r
 
   DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
 
-  for (CaptureViewElement* child : GetVisibleChildrenOnScreen()) {
+  for (CaptureViewElement* child : GetChildrenVisibleInViewport()) {
     if (child->ShouldBeRendered()) {
       child->UpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
     }
@@ -55,7 +53,7 @@ void CaptureViewElement::UpdatePrimitives(Batcher* batcher, TextRenderer& text_r
 }
 
 void CaptureViewElement::UpdateLayout() {
-  for (CaptureViewElement* child : GetChildren()) {
+  for (CaptureViewElement* child : GetAllChildren()) {
     child->UpdateLayout();
   }
   DoUpdateLayout();
@@ -73,7 +71,7 @@ void CaptureViewElement::SetWidth(float width) {
   if (width != width_) {
     width_ = width;
 
-    for (auto& child : GetChildren()) {
+    for (auto& child : GetAllChildren()) {
       if (child->GetLayoutFlags() & LayoutFlags::kScaleHorizontallyWithParent) {
         child->SetWidth(width);
       }
@@ -110,9 +108,9 @@ void CaptureViewElement::OnDrag(int x, int y) {
   RequestUpdate();
 }
 
-std::vector<CaptureViewElement*> CaptureViewElement::GetVisibleChildren() const {
+std::vector<CaptureViewElement*> CaptureViewElement::GetNonHiddenChildren() const {
   std::vector<CaptureViewElement*> result;
-  for (CaptureViewElement* child : GetChildren()) {
+  for (CaptureViewElement* child : GetAllChildren()) {
     if (child->ShouldBeRendered()) {
       result.push_back(child);
     }
@@ -121,9 +119,9 @@ std::vector<CaptureViewElement*> CaptureViewElement::GetVisibleChildren() const 
   return result;
 }
 
-std::vector<CaptureViewElement*> CaptureViewElement::GetVisibleChildrenOnScreen() const {
+std::vector<CaptureViewElement*> CaptureViewElement::GetChildrenVisibleInViewport() const {
   std::vector<CaptureViewElement*> result;
-  for (CaptureViewElement* child : GetVisibleChildren()) {
+  for (CaptureViewElement* child : GetNonHiddenChildren()) {
     float child_top_y = child->GetPos()[1];
     float child_bottom_y = child_top_y + child->GetHeight();
     float screen_top_y = time_graph_->GetVerticalScrollingOffset();

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -19,26 +19,39 @@ void CaptureViewElement::Draw(Batcher& batcher, TextRenderer& text_renderer,
                               const DrawContext& draw_context) {
   ORBIT_SCOPE_FUNCTION;
 
+  batcher.PushTranslation(0, 0, DetermineZOffset());
+  text_renderer.PushTranslation(0, 0, DetermineZOffset());
+
   DoDraw(batcher, text_renderer, draw_context);
 
-  const DrawContext inner_draw_context = draw_context.IncreasedIndentationLevel();
-  for (CaptureViewElement* child : GetChildren()) {
+  for (CaptureViewElement* child : GetVisibleChildrenOnScreen()) {
     if (child->ShouldBeRendered()) {
-      child->Draw(batcher, text_renderer, inner_draw_context);
+      child->Draw(batcher, text_renderer, draw_context);
     }
   }
+
+  text_renderer.PopTranslation();
+  batcher.PopTranslation();
 }
 
-void CaptureViewElement::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                          PickingMode picking_mode, float z_offset) {
+void CaptureViewElement::UpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+                                          uint64_t min_tick, uint64_t max_tick,
+                                          PickingMode picking_mode) {
   ORBIT_SCOPE_FUNCTION;
 
-  DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  for (CaptureViewElement* child : GetChildren()) {
+  batcher->PushTranslation(0, 0, DetermineZOffset());
+  text_renderer.PushTranslation(0, 0, DetermineZOffset());
+
+  DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
+
+  for (CaptureViewElement* child : GetVisibleChildrenOnScreen()) {
     if (child->ShouldBeRendered()) {
-      child->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+      child->UpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
     }
   }
+
+  text_renderer.PopTranslation();
+  batcher->PopTranslation();
 }
 
 void CaptureViewElement::UpdateLayout() {
@@ -48,12 +61,22 @@ void CaptureViewElement::UpdateLayout() {
   DoUpdateLayout();
 }
 
+void CaptureViewElement::SetPos(float x, float y) {
+  const Vec2 pos = Vec2(x, y);
+  if (pos == pos_) return;
+
+  pos_ = pos;
+  RequestUpdate();
+}
+
 void CaptureViewElement::SetWidth(float width) {
   if (width != width_) {
     width_ = width;
 
     for (auto& child : GetChildren()) {
-      child->SetWidth(width);
+      if (child->GetLayoutFlags() & LayoutFlags::kScaleHorizontallyWithParent) {
+        child->SetWidth(width);
+      }
     }
     RequestUpdate();
   }
@@ -85,6 +108,31 @@ void CaptureViewElement::OnDrag(int x, int y) {
   mouse_pos_cur_ =
       viewport_->ScreenToWorld(Vec2i(x, y)) + Vec2(0, time_graph_->GetVerticalScrollingOffset());
   RequestUpdate();
+}
+
+std::vector<CaptureViewElement*> CaptureViewElement::GetVisibleChildren() const {
+  std::vector<CaptureViewElement*> result;
+  for (CaptureViewElement* child : GetChildren()) {
+    if (child->ShouldBeRendered()) {
+      result.push_back(child);
+    }
+  }
+
+  return result;
+}
+
+std::vector<CaptureViewElement*> CaptureViewElement::GetVisibleChildrenOnScreen() const {
+  std::vector<CaptureViewElement*> result;
+  for (CaptureViewElement* child : GetVisibleChildren()) {
+    float child_top_y = child->GetPos()[1];
+    float child_bottom_y = child_top_y + child->GetHeight();
+    float screen_top_y = time_graph_->GetVerticalScrollingOffset();
+    float screen_bottom_y = screen_top_y + viewport_->GetWorldHeight();
+    if (child_top_y < screen_bottom_y && child_bottom_y > screen_top_y) {
+      result.push_back(child);
+    }
+  }
+  return result;
 }
 
 void CaptureViewElement::RequestUpdate() {

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -52,9 +52,9 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] bool Draggable() override { return true; }
 
   [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
-  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetChildren() const { return {}; }
-  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() const;
-  [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildrenOnScreen() const;
+  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetAllChildren() const { return {}; }
+  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetNonHiddenChildren() const;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetChildrenVisibleInViewport() const;
 
   virtual void RequestUpdate();
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -58,7 +58,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   virtual void RequestUpdate();
 
-  enum LayoutFlags : uint32_t { kScaleHorizontallyWithParent = 1 << 0 };
+  enum LayoutFlags : uint32_t { kNone = 0, kScaleHorizontallyWithParent = 1 << 0 };
 
   [[nodiscard]] virtual uint32_t GetLayoutFlags() const { return kScaleHorizontallyWithParent; }
   [[nodiscard]] virtual float DetermineZOffset() const { return 0.f; }

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -23,42 +23,17 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   explicit CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout);
 
-  struct DrawContext {
-    constexpr const static uint32_t kMaxIndentationLevel = 5;
-    uint64_t current_mouse_time_ns;
-    PickingMode picking_mode;
-    uint32_t indentation_level;
-    float z_offset = 0;
-
-    [[nodiscard]] DrawContext IncreasedIndentationLevel() const {
-      auto copy = *this;
-      copy.indentation_level = std::min(kMaxIndentationLevel, copy.indentation_level + 1);
-      return copy;
-    };
-
-    [[nodiscard]] DrawContext UpdatedZOffset(float z_offset) const {
-      auto copy = *this;
-      copy.z_offset = z_offset;
-      return copy;
-    }
-  };
-
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context);
-
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0);
   void UpdateLayout();
 
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
 
   [[nodiscard]] orbit_gl::Viewport* GetViewport() const { return viewport_; }
 
-  // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
-  virtual void SetPos(float x, float y) { pos_ = Vec2(x, y); }
+  void SetPos(float x, float y);
+
   // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
   [[nodiscard]] virtual Vec2 GetPos() const { return pos_; }
 
-  // This will set the width of all child elements to 100% by default
   void SetWidth(float width);
   [[nodiscard]] float GetWidth() const { return width_; }
 
@@ -78,9 +53,22 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetChildren() const { return {}; }
+  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() const;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildrenOnScreen() const;
+
   virtual void RequestUpdate();
 
+  enum LayoutFlags : uint32_t { kScaleHorizontallyWithParent = 1 << 0 };
+
+  [[nodiscard]] virtual uint32_t GetLayoutFlags() const { return kScaleHorizontallyWithParent; }
+  [[nodiscard]] virtual float DetermineZOffset() const { return 0.f; }
+
  protected:
+  struct DrawContext {
+    uint64_t current_mouse_time_ns = 0;
+    PickingMode picking_mode = PickingMode::kNone;
+  };
+
   orbit_gl::Viewport* viewport_;
   TimeGraphLayout* layout_;
 
@@ -92,12 +80,16 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   bool picked_ = false;
   bool visible_ = true;
 
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context);
+  void UpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+                        uint64_t max_tick, PickingMode picking_mode);
+
   virtual void DoDraw(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
                       const DrawContext& /*draw_context*/) {}
 
-  virtual void DoUpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/,
-                                  uint64_t /*max_tick*/, PickingMode /*picking_mode*/,
-                                  float /*z_offset*/ = 0) {}
+  virtual void DoUpdatePrimitives(Batcher* /*batcher*/, TextRenderer& /*text_renderer*/,
+                                  uint64_t /*min_tick*/, uint64_t /*max_tick*/,
+                                  PickingMode /*picking_mode*/) {}
 
   virtual void DoUpdateLayout() {}
 

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -37,13 +37,13 @@ class UnitTestCaptureViewContainerElement : public CaptureViewElement {
 
   [[nodiscard]] float GetHeight() const override {
     float result = 0;
-    for (auto& child : GetChildren()) {
+    for (auto& child : GetAllChildren()) {
       result += child->GetHeight();
     }
     return result;
   }
 
-  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override {
+  [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override {
     std::vector<CaptureViewElement*> result;
     for (auto& child : children_) {
       result.push_back(child.get());

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <unordered_map>
+
 void orbit_gl::CaptureViewElementTester::RunTests(CaptureViewElement* element) {
   TestWidthPropagationToChildren(element);
 }
@@ -13,11 +15,17 @@ void orbit_gl::CaptureViewElementTester::RunTests(CaptureViewElement* element) {
 void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(
     CaptureViewElement* element) {
   const float kWidth = 100, kUpdatedWidth = 50;
+  std::unordered_map<CaptureViewElement*, float> old_widths;
+  for (auto& child : element->GetAllChildren()) {
+    old_widths[child] = child->GetWidth();
+  }
 
   element->SetWidth(kWidth);
   for (auto& child : element->GetAllChildren()) {
     if (child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) {
       EXPECT_EQ(kWidth, child->GetWidth());
+    } else {
+      EXPECT_EQ(old_widths[child], child->GetWidth());
     }
   }
 
@@ -25,6 +33,8 @@ void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(
   for (auto& child : element->GetAllChildren()) {
     if (child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) {
       EXPECT_EQ(kUpdatedWidth, child->GetWidth());
+    } else {
+      EXPECT_EQ(old_widths[child], child->GetWidth());
     }
   }
 }

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -16,11 +16,15 @@ void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(
 
   element->SetWidth(kWidth);
   for (auto& child : element->GetChildren()) {
-    EXPECT_EQ(kWidth, child->GetWidth());
+    if (child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) {
+      EXPECT_EQ(kWidth, child->GetWidth());
+    }
   }
 
   element->SetWidth(kUpdatedWidth);
   for (auto& child : element->GetChildren()) {
-    EXPECT_EQ(kUpdatedWidth, child->GetWidth());
+    if (child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) {
+      EXPECT_EQ(kUpdatedWidth, child->GetWidth());
+    }
   }
 }

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -15,14 +15,14 @@ void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(
   const float kWidth = 100, kUpdatedWidth = 50;
 
   element->SetWidth(kWidth);
-  for (auto& child : element->GetChildren()) {
+  for (auto& child : element->GetAllChildren()) {
     if (child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) {
       EXPECT_EQ(kWidth, child->GetWidth());
     }
   }
 
   element->SetWidth(kUpdatedWidth);
-  for (auto& child : element->GetChildren()) {
+  for (auto& child : element->GetAllChildren()) {
     if (child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) {
       EXPECT_EQ(kUpdatedWidth, child->GetWidth());
     }

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -408,13 +408,14 @@ void CaptureWindow::Draw() {
     time_graph_->UpdateLayout();
     UpdateChildrenPosAndSize();
 
-    uint64_t timegraph_current_mouse_time_ns =
-        time_graph_->GetTickFromWorld(viewport_.ScreenToWorld(GetMouseScreenPos())[0]);
     if (time_graph_->IsRedrawNeeded()) {
       time_graph_was_redrawn = true;
     }
-    time_graph_->Draw(GetBatcher(), GetTextRenderer(),
-                      {timegraph_current_mouse_time_ns, picking_mode_, 0, 0});
+
+    uint64_t timegraph_current_mouse_time_ns =
+        time_graph_->GetTickFromWorld(viewport_.ScreenToWorld(GetMouseScreenPos())[0]);
+    time_graph_->DrawAllElements(GetBatcher(), GetTextRenderer(), picking_mode_,
+                                 timegraph_current_mouse_time_ns);
   }
 
   RenderSelectionOverlay();
@@ -680,7 +681,6 @@ void CaptureWindow::RenderImGuiDebugUI() {
     if (time_graph_ != nullptr) {
       IMGUI_VAR_TO_TEXT(time_graph_->GetNumVisiblePrimitives());
       IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetAllTracks().size());
-      IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetTracksOnScreen().size());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMinTimeUs());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMaxTimeUs());
       IMGUI_VAR_TO_TEXT(time_graph_->GetCaptureMin());

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -218,7 +218,7 @@ void FrameTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
   const float y = pos[1] + GetHeaderHeight() + GetMaximumBoxHeight() - GetAverageBoxHeight();
   Vec2 from(x, y);
   Vec2 to(x + GetWidth(), y);
-  float text_z = GlCanvas::kZValueTrackText + draw_context.z_offset;
+  float text_z = GlCanvas::kZValueTrackText;
 
   std::string avg_time =
       orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats_.average_time_ns()));

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -39,7 +39,6 @@ GpuSubmissionTrack::GpuSubmissionTrack(Track* parent, TimeGraph* time_graph,
       string_manager_{app->GetStringManager()},
       parent_{parent} {
   draw_background_ = false;
-  text_renderer_ = time_graph->GetTextRenderer();
 }
 
 std::string GpuSubmissionTrack::GetName() const {

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -123,8 +123,8 @@ float GpuTrack::GetHeight() const {
   return height;
 }
 
-std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetChildren() const {
-  auto result = Track::GetChildren();
+std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetAllChildren() const {
+  auto result = Track::GetAllChildren();
   result.insert(result.end(), {submission_track_.get(), marker_track_.get()});
   return result;
 }

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -91,7 +91,9 @@ void GpuTrack::UpdatePositionOfSubtracks() {
     return;
   }
   marker_track_->SetVisible(true);
+  marker_track_->SetIndentationLevel(indentation_level_ + 1);
   submission_track_->SetHeadless(false);
+  submission_track_->SetIndentationLevel(indentation_level_ + 1);
 
   float current_y = pos[1] + layout_->GetTrackTabHeight();
   if (submission_track_->ShouldBeRendered()) {
@@ -122,23 +124,8 @@ float GpuTrack::GetHeight() const {
 }
 
 std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetChildren() const {
-  return {submission_track_.get(), marker_track_.get()};
-}
-
-std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetVisibleChildren() {
-  std::vector<CaptureViewElement*> result;
-
-  if (collapse_toggle_->IsCollapsed()) {
-    return result;
-  }
-
-  if (submission_track_->ShouldBeRendered()) {
-    result.push_back(submission_track_.get());
-  }
-
-  if (marker_track_->ShouldBeRendered()) {
-    result.push_back(marker_track_.get());
-  }
+  auto result = Track::GetChildren();
+  result.insert(result.end(), {submission_track_.get(), marker_track_.get()});
   return result;
 }
 

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -64,7 +64,7 @@ class GpuTrack : public Track {
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] float GetHeight() const override;
 
-  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
 
   [[nodiscard]] bool IsEmpty() const override {
     return submission_track_->IsEmpty() && marker_track_->IsEmpty();

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -65,7 +65,6 @@ class GpuTrack : public Track {
   [[nodiscard]] float GetHeight() const override;
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
-  [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
 
   [[nodiscard]] bool IsEmpty() const override {
     return submission_track_->IsEmpty() && marker_track_->IsEmpty();

--- a/src/OrbitGl/GpuTrackTest.cpp
+++ b/src/OrbitGl/GpuTrackTest.cpp
@@ -12,6 +12,8 @@ TEST(GpuTrack, CaptureViewElementWorksAsIntended) {
   orbit_gl::CaptureViewElementTester tester;
   GpuTrack track = GpuTrack(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), 0, nullptr,
                             nullptr, nullptr, nullptr);
+  // Expect submission track, marker track, and collapse toggle
+  EXPECT_EQ(3ull, track.GetAllChildren().size());
   tester.RunTests(&track);
 }
 

--- a/src/OrbitGl/GpuTrackTest.cpp
+++ b/src/OrbitGl/GpuTrackTest.cpp
@@ -12,7 +12,6 @@ TEST(GpuTrack, CaptureViewElementWorksAsIntended) {
   orbit_gl::CaptureViewElementTester tester;
   GpuTrack track = GpuTrack(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), 0, nullptr,
                             nullptr, nullptr, nullptr);
-  EXPECT_EQ(2ull, track.GetChildren().size());
   tester.RunTests(&track);
 }
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -71,22 +71,23 @@ void GraphTrack<Dimension>::DoDraw(Batcher& batcher, TextRenderer& text_renderer
   std::string text = GetLabelTextFromValues(values);
   const Color kBlack(0, 0, 0, 255);
   const Color kTransparentWhite(255, 255, 255, 180);
-  DrawLabel(batcher, text_renderer, draw_context, Vec2(point_x, point_y), text, kBlack,
-            kTransparentWhite);
+  DrawLabel(batcher, text_renderer, Vec2(point_x, point_y), text, kBlack, kTransparentWhite);
 
   if (Dimension == 1) return;
 
   // Draw legends
   const Color kWhite(255, 255, 255, 255);
-  DrawLegend(batcher, text_renderer, draw_context, series_.GetSeriesNames(), kWhite);
+  DrawLegend(batcher, text_renderer, series_.GetSeriesNames(), kWhite);
 }
 
 template <size_t Dimension>
-void GraphTrack<Dimension>::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick,
-                                               uint64_t max_tick, PickingMode picking_mode,
-                                               float z_offset) {
-  float track_z = GlCanvas::kZValueTrack + z_offset;
-  float graph_z = GlCanvas::kZValueEventBar + z_offset;
+void GraphTrack<Dimension>::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+                                               uint64_t min_tick, uint64_t max_tick,
+                                               PickingMode picking_mode) {
+  Track::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
+
+  float track_z = GlCanvas::kZValueTrack;
+  float graph_z = GlCanvas::kZValueEventBar;
 
   float content_height = GetGraphContentHeight();
   Vec2 content_pos = GetPos();
@@ -152,10 +153,9 @@ uint32_t GraphTrack<Dimension>::GetLegendFontSize(uint32_t indentation_level) co
 
 template <size_t Dimension>
 void GraphTrack<Dimension>::DrawLabel(Batcher& batcher, TextRenderer& text_renderer,
-                                      const DrawContext& draw_context, Vec2 target_pos,
-                                      const std::string& text, const Color& text_color,
-                                      const Color& font_color) {
-  uint32_t font_size = GetLegendFontSize(draw_context.indentation_level);
+                                      Vec2 target_pos, const std::string& text,
+                                      const Color& text_color, const Color& font_color) {
+  uint32_t font_size = GetLegendFontSize(indentation_level_);
   const float kTextLeftMargin = 2.f;
   const float kTextRightMargin = kTextLeftMargin;
   const float kTextTopMargin = layout_->GetTextOffset();
@@ -180,7 +180,7 @@ void GraphTrack<Dimension>::DrawLabel(Batcher& batcher, TextRenderer& text_rende
                                               : -arrow_width - kTextRightMargin - text_box_size[0]),
       target_pos[1] - text_box_size[1] / 2.f);
 
-  float label_z = GlCanvas::kZValueTrackLabel + draw_context.z_offset;
+  float label_z = GlCanvas::kZValueTrackLabel;
   text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], label_z,
                         {font_size, text_color, text_box_size[0]});
 
@@ -203,7 +203,6 @@ void GraphTrack<Dimension>::DrawLabel(Batcher& batcher, TextRenderer& text_rende
 
 template <size_t Dimension>
 void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_renderer,
-                                       const DrawContext& draw_context,
                                        const std::array<std::string, Dimension>& series_names,
                                        const Color& legend_text_color) {
   const float kSpaceBetweenLegendSymbolAndText = layout_->GetGenericFixedSpacerWidth();
@@ -212,10 +211,10 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
   const float legend_symbol_width = legend_symbol_height;
   float x0 = GetPos()[0] + layout_->GetRightMargin();
   const float y0 = GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
-  uint32_t font_size = GetLegendFontSize(draw_context.indentation_level);
+  uint32_t font_size = GetLegendFontSize(indentation_level_);
   const Color kFullyTransparent(255, 255, 255, 0);
 
-  float text_z = GlCanvas::kZValueTrackText + draw_context.z_offset;
+  float text_z = GlCanvas::kZValueTrackText;
   for (size_t i = 0; i < Dimension; ++i) {
     batcher.AddShadedBox(Vec2(x0, y0), Vec2(legend_symbol_width, legend_symbol_height), text_z,
                          GetColor(i));

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -68,8 +68,8 @@ class GraphTrack : public Track {
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
 
-  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode, float z_offset = 0) override;
+  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
 
   [[nodiscard]] virtual Color GetColor(size_t index) const;
   [[nodiscard]] virtual double GetGraphMaxValue() const { return series_.GetMax(); }
@@ -90,11 +90,9 @@ class GraphTrack : public Track {
       const std::array<double, Dimension>& values) const;
   [[nodiscard]] uint32_t GetLegendFontSize(uint32_t indentation_level = 0) const;
 
-  virtual void DrawLabel(Batcher& batcher, TextRenderer& text_renderer,
-                         const DrawContext& draw_context, Vec2 target_pos, const std::string& text,
-                         const Color& text_color, const Color& font_color);
+  virtual void DrawLabel(Batcher& batcher, TextRenderer& text_renderer, Vec2 target_pos,
+                         const std::string& text, const Color& text_color, const Color& font_color);
   virtual void DrawLegend(Batcher& batcher, TextRenderer& text_renderer,
-                          const DrawContext& draw_context,
                           const std::array<std::string, Dimension>& series_names,
                           const Color& legend_text_color);
   virtual void DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick, float z);

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -17,9 +17,8 @@ void MemoryTrack<Dimension>::DoDraw(Batcher& batcher, TextRenderer& text_rendere
   GraphTrack<Dimension>::DoDraw(batcher, text_renderer, draw_context);
 
   if (this->collapse_toggle_->IsCollapsed()) return;
-  AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_,
-                                  draw_context.indentation_level,
-                                  GlCanvas::kZValueTrackText + draw_context.z_offset);
+  AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_, this->indentation_level_,
+                                  GlCanvas::kZValueTrackText);
 }
 
 template <size_t Dimension>

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -60,8 +60,8 @@ std::string PageFaultsTrack::GetTooltip() const {
   return "Shows the minor and major page faults statistics.";
 }
 
-std::vector<CaptureViewElement*> PageFaultsTrack::GetChildren() const {
-  auto result = Track::GetChildren();
+std::vector<CaptureViewElement*> PageFaultsTrack::GetAllChildren() const {
+  auto result = Track::GetAllChildren();
   result.insert(result.end(), {major_page_faults_track_.get(), minor_page_faults_track_.get()});
   return result;
 }

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -55,24 +55,15 @@ float PageFaultsTrack::GetHeight() const {
   return height;
 }
 
-std::vector<orbit_gl::CaptureViewElement*> PageFaultsTrack::GetVisibleChildren() {
-  std::vector<CaptureViewElement*> result;
-  if (collapse_toggle_->IsCollapsed()) return result;
-
-  if (major_page_faults_track_->ShouldBeRendered())
-    result.push_back(major_page_faults_track_.get());
-  if (minor_page_faults_track_->ShouldBeRendered())
-    result.push_back(minor_page_faults_track_.get());
-  return result;
-}
-
 std::string PageFaultsTrack::GetTooltip() const {
   if (collapse_toggle_->IsCollapsed()) return major_page_faults_track_->GetTooltip();
   return "Shows the minor and major page faults statistics.";
 }
 
 std::vector<CaptureViewElement*> PageFaultsTrack::GetChildren() const {
-  return {major_page_faults_track_.get(), minor_page_faults_track_.get()};
+  auto result = Track::GetChildren();
+  result.insert(result.end(), {major_page_faults_track_.get(), minor_page_faults_track_.get()});
+  return result;
 }
 
 void PageFaultsTrack::UpdatePositionOfSubtracks() {
@@ -85,8 +76,10 @@ void PageFaultsTrack::UpdatePositionOfSubtracks() {
   }
 
   major_page_faults_track_->SetHeadless(false);
-
+  major_page_faults_track_->SetIndentationLevel(indentation_level_ + 1);
   minor_page_faults_track_->SetVisible(true);
+  minor_page_faults_track_->SetIndentationLevel(indentation_level_ + 1);
+
   float current_y = pos[1] + layout_->GetTrackTabHeight();
   if (major_page_faults_track_->ShouldBeRendered()) {
     current_y += layout_->GetSpaceBetweenSubtracks();

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -34,7 +34,7 @@ class PageFaultsTrack : public Track {
     return major_page_faults_track_->IsEmpty() && minor_page_faults_track_->IsEmpty();
   }
   [[nodiscard]] bool IsCollapsible() const override { return true; }
-  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
 
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -28,7 +28,6 @@ class PageFaultsTrack : public Track {
   [[nodiscard]] std::string GetLabel() const override;
   [[nodiscard]] Type GetType() const override { return Type::kPageFaultsTrack; }
   [[nodiscard]] float GetHeight() const override;
-  [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
   [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] bool IsEmpty() const override {

--- a/src/OrbitGl/PageFaultsTrackTest.cpp
+++ b/src/OrbitGl/PageFaultsTrackTest.cpp
@@ -15,6 +15,8 @@ TEST(PageFaultsTrack, CaptureViewElementWorksAsIntended) {
       TrackTestData::GenerateTestCaptureData();
   PageFaultsTrack track = PageFaultsTrack(nullptr, nullptr, tester.GetViewport(),
                                           tester.GetLayout(), "", 100, test_data.get());
+  // Expect major pagefaults track, minor pagefaults track, and collapse toggle
+  EXPECT_EQ(3ull, track.GetAllChildren().size());
   tester.RunTests(&track);
 }
 

--- a/src/OrbitGl/PageFaultsTrackTest.cpp
+++ b/src/OrbitGl/PageFaultsTrackTest.cpp
@@ -15,7 +15,6 @@ TEST(PageFaultsTrack, CaptureViewElementWorksAsIntended) {
       TrackTestData::GenerateTestCaptureData();
   PageFaultsTrack track = PageFaultsTrack(nullptr, nullptr, tester.GetViewport(),
                                           tester.GetLayout(), "", 100, test_data.get());
-  EXPECT_EQ(2ull, track.GetChildren().size());
   tester.RunTests(&track);
 }
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -46,7 +46,6 @@ void ThreadStateBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
   float thread_state_bar_z = draw_context.picking_mode == PickingMode::kClick
                                  ? GlCanvas::kZValueEventBarPicking
                                  : GlCanvas::kZValueEventBar;
-  thread_state_bar_z += draw_context.z_offset;
 
   // Draw a transparent track just for clicking.
   Box box(GetPos(), Vec2(GetWidth(), GetHeight()), thread_state_bar_z);
@@ -162,9 +161,10 @@ std::string ThreadStateBar::GetThreadStateSliceTooltip(Batcher* batcher, Picking
       GetThreadStateDescription(thread_state_slice->thread_state()));
 }
 
-void ThreadStateBar::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                        PickingMode picking_mode, float z_offset) {
-  ThreadBar::DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+void ThreadStateBar::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+                                        uint64_t min_tick, uint64_t max_tick,
+                                        PickingMode picking_mode) {
+  ThreadBar::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
 
   const auto time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
   const uint64_t pixel_delta_ns = time_window_ns / viewport_->WorldToScreen(GetSize())[0];
@@ -197,14 +197,14 @@ void ThreadStateBar::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uin
         user_data->custom_data_ = &slice;
 
         if (slice.end_timestamp_ns() - slice.begin_timestamp_ns() > pixel_delta_ns) {
-          Box box(pos, size, GlCanvas::kZValueEvent + z_offset);
+          Box box(pos, size, GlCanvas::kZValueEvent);
           batcher->AddBox(box, color, std::move(user_data));
         } else {
           // Make this slice cover an entire pixel and don't draw subsequent slices that would
           // coincide with the same pixel.
           // Use AddBox instead of AddVerticalLine as otherwise the tops of Boxes and lines wouldn't
           // be properly aligned.
-          Box box(pos, {pixel_width_in_world_coords, size[1]}, GlCanvas::kZValueEvent + z_offset);
+          Box box(pos, {pixel_width_in_world_coords, size[1]}, GlCanvas::kZValueEvent);
           batcher->AddBox(box, color, std::move(user_data));
 
           if (pixel_delta_ns != 0) {

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -39,8 +39,8 @@ class ThreadStateBar final : public ThreadBar {
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
 
-  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode, float z_offset) override;
+  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
 
  private:
   std::string GetThreadStateSliceTooltip(Batcher* batcher, PickingId id) const;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -273,8 +273,8 @@ void ThreadTrack::OnPick(int x, int y) {
   app_->set_selected_thread_id(GetThreadId());
 }
 
-std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetChildren() const {
-  auto result = Track::GetChildren();
+std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetAllChildren() const {
+  auto result = Track::GetAllChildren();
   result.insert(result.end(), {thread_state_bar_.get(), event_bar_.get(), tracepoint_bar_.get()});
   return result;
 }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -380,7 +380,7 @@ void ThreadTrack::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_render
                                      uint64_t min_tick, uint64_t max_tick,
                                      PickingMode /*picking_mode*/) {
   // TODO(b/203181055): The parent class already provides an implementation, but this is completely
-  // ignored for optimization reasons.
+  // ignored because ThreadTrack uses the ScopeTree, and TimerTrack doesn't.
   // TimerTrack::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
 
   CHECK(batcher);

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -273,25 +273,10 @@ void ThreadTrack::OnPick(int x, int y) {
   app_->set_selected_thread_id(GetThreadId());
 }
 
-std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetVisibleChildren() {
-  std::vector<CaptureViewElement*> result;
-  if (!thread_state_bar_->IsEmpty()) {
-    result.push_back(thread_state_bar_.get());
-  }
-
-  if (!event_bar_->IsEmpty()) {
-    result.push_back(event_bar_.get());
-  }
-
-  if (!tracepoint_bar_->IsEmpty()) {
-    result.push_back(tracepoint_bar_.get());
-  }
-
-  return result;
-}
-
 std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetChildren() const {
-  return {thread_state_bar_.get(), event_bar_.get(), tracepoint_bar_.get()};
+  auto result = Track::GetChildren();
+  result.insert(result.end(), {thread_state_bar_.get(), event_bar_.get(), tracepoint_bar_.get()});
+  return result;
 }
 
 std::string ThreadTrack::GetTimesliceText(const TimerInfo& timer_info) const {
@@ -391,14 +376,19 @@ void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
 // We minimize overdraw when drawing lines for small events by discarding events that would just
 // draw over an already drawn pixel line. When zoomed in enough that all events are drawn as boxes,
 // this has no effect. When zoomed  out, many events will be discarded quickly.
-void ThreadTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                     PickingMode /*picking_mode*/, float z_offset) {
+void ThreadTrack::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+                                     uint64_t min_tick, uint64_t max_tick,
+                                     PickingMode /*picking_mode*/) {
+  // TODO(b/203181055): The parent class already provides an implementation, but this is completely
+  // ignored for optimization reasons.
+  // TimerTrack::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
+
   CHECK(batcher);
   visible_timer_count_ = 0;
 
   const internal::DrawData draw_data =
-      GetDrawData(min_tick, max_tick, GetPos()[0], GetWidth(), z_offset, batcher, time_graph_,
-                  viewport_, collapse_toggle_->IsCollapsed(), app_->selected_timer(),
+      GetDrawData(min_tick, max_tick, GetPos()[0], GetWidth(), batcher, time_graph_, viewport_,
+                  collapse_toggle_->IsCollapsed(), app_->selected_timer(),
                   app_->GetFunctionIdToHighlight(), app_->GetGroupIdToHighlight());
 
   uint64_t resolution_in_pixels = draw_data.viewport->WorldToScreen({draw_data.track_width, 0})[0];
@@ -419,8 +409,8 @@ void ThreadTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64
 
       auto timer_duration = timer_info->end() - timer_info->start();
       if (timer_duration > draw_data.ns_per_pixel) {
-        if (!collapse_toggle_->IsCollapsed() && BoxHasRoomForText(size[0])) {
-          DrawTimesliceText(*timer_info, draw_data.track_start_x, z_offset, pos, size);
+        if (!collapse_toggle_->IsCollapsed() && BoxHasRoomForText(text_renderer, size[0])) {
+          DrawTimesliceText(*timer_info, text_renderer, draw_data.track_start_x, pos, size);
         }
         batcher->AddShadedBox(pos, size, draw_data.z, color, std::move(user_data));
       } else {

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -410,7 +410,7 @@ void ThreadTrack::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_render
       auto timer_duration = timer_info->end() - timer_info->start();
       if (timer_duration > draw_data.ns_per_pixel) {
         if (!collapse_toggle_->IsCollapsed() && BoxHasRoomForText(text_renderer, size[0])) {
-          DrawTimesliceText(*timer_info, text_renderer, draw_data.track_start_x, pos, size);
+          DrawTimesliceText(text_renderer, *timer_info, draw_data.track_start_x, pos, size);
         }
         batcher->AddShadedBox(pos, size, draw_data.z, color, std::move(user_data));
       } else {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -77,12 +77,11 @@ class ThreadTrack final : public TimerTrack {
 
   [[nodiscard]] bool IsCollapsible() const override { return GetDepth() > 1; }
 
-  [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
 
  protected:
-  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode, float z_offset = 0) override;
+  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
 
   [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -77,7 +77,7 @@ class ThreadTrack final : public TimerTrack {
 
   [[nodiscard]] bool IsCollapsible() const override { return GetDepth() > 1; }
 
-  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
 
  protected:
   void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,

--- a/src/OrbitGl/ThreadTrackTest.cpp
+++ b/src/OrbitGl/ThreadTrackTest.cpp
@@ -15,6 +15,8 @@ TEST(ThreadTrack, CaptureViewElementWorksAsIntended) {
       TrackTestData::GenerateTestCaptureData();
   ThreadTrack track(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), -1, nullptr,
                     test_data.get(), nullptr);
+  // Expect thread states, samples, tracepoints, and collapse toggle
+  EXPECT_EQ(4ull, track.GetAllChildren().size());
   tester.RunTests(&track);
 }
 

--- a/src/OrbitGl/ThreadTrackTest.cpp
+++ b/src/OrbitGl/ThreadTrackTest.cpp
@@ -15,7 +15,6 @@ TEST(ThreadTrack, CaptureViewElementWorksAsIntended) {
       TrackTestData::GenerateTestCaptureData();
   ThreadTrack track(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), -1, nullptr,
                     test_data.get(), nullptr);
-  EXPECT_EQ(3ull, track.GetChildren().size());
   tester.RunTests(&track);
 }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -504,13 +504,9 @@ const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint
 void TimeGraph::RequestUpdate() {
   CaptureViewElement::RequestUpdate();
   update_primitives_requested_ = true;
-  redraw_requested_ = true;
 }
 
-// UpdatePrimitives updates all the drawable track timers in the timegraph's batcher
-void TimeGraph::DoUpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/,
-                                   uint64_t /*max_tick*/, PickingMode picking_mode,
-                                   float /*z_offset*/) {
+void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   ORBIT_SCOPE_FUNCTION;
   CHECK(app_->GetStringManager() != nullptr);
 
@@ -521,16 +517,11 @@ void TimeGraph::DoUpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/,
 
   text_renderer_static_.Clear();
 
-  capture_min_timestamp_ =
-      std::min(capture_min_timestamp_, capture_data_->GetCallstackData().min_time());
-  capture_max_timestamp_ =
-      std::max(capture_max_timestamp_, capture_data_->GetCallstackData().max_time());
-
-  time_window_us_ = max_time_us_ - min_time_us_;
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
-  track_manager_->UpdateTrackPrimitives(&batcher_, min_tick, max_tick, picking_mode);
+  CaptureViewElement::UpdatePrimitives(&batcher_, text_renderer_static_, min_tick, max_tick,
+                                       picking_mode);
 
   batcher_.PopTranslation();
   text_renderer_static_.PopTranslation();
@@ -543,6 +534,13 @@ void TimeGraph::DoUpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/,
 void TimeGraph::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 
+  capture_min_timestamp_ =
+      std::min(capture_min_timestamp_, capture_data_->GetCallstackData().min_time());
+  capture_max_timestamp_ =
+      std::max(capture_max_timestamp_, capture_data_->GetCallstackData().max_time());
+
+  time_window_us_ = max_time_us_ - min_time_us_;
+
   track_manager_->UpdateTracksForRendering();
   UpdateTracksPosition();
 
@@ -550,7 +548,6 @@ void TimeGraph::DoUpdateLayout() {
 }
 
 void TimeGraph::UpdateTracksPosition() {
-  // Update position of a track which is currently being moved.
   const float track_pos_x = GetPos()[0];
 
   float current_y = layout_.GetSchedulerTrackOffset();
@@ -592,30 +589,6 @@ void TimeGraph::SelectCallstacks(float world_start, float world_end, uint32_t th
 
 const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(uint32_t tid) {
   return selected_callstack_events_per_thread_[tid];
-}
-
-void TimeGraph::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-                       const DrawContext& draw_context) {
-  ORBIT_SCOPE_FUNCTION;
-
-  text_renderer.PushTranslation(0, -vertical_scrolling_offset_);
-  batcher.PushTranslation(0, -vertical_scrolling_offset_);
-
-  const bool picking = draw_context.picking_mode != PickingMode::kNone;
-  if ((!picking && update_primitives_requested_) || picking) {
-    UpdatePrimitives(nullptr, 0, 0, draw_context.picking_mode, draw_context.z_offset);
-  }
-
-  DrawTracks(batcher, text_renderer, draw_context);
-  DrawIncompleteDataIntervals(batcher, draw_context.picking_mode);
-  DrawOverlay(batcher, text_renderer, draw_context.picking_mode);
-
-  batcher.PopTranslation();
-  text_renderer.PopTranslation();
-
-  if (!absl::GetFlag(FLAGS_enforce_full_redraw)) {
-    redraw_requested_ = false;
-  }
 }
 
 namespace {
@@ -839,20 +812,6 @@ void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode pickin
   }
 }
 
-void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
-                           const DrawContext& draw_context) {
-  for (Track* track : track_manager_->GetTracksOnScreen()) {
-    float z_offset = 0;
-    if (track->IsPinned()) {
-      z_offset = GlCanvas::kZOffsetPinnedTrack;
-    } else if (track->IsMoving()) {
-      z_offset = GlCanvas::kZOffsetMovingTrack;
-    }
-    const DrawContext updated_draw_context = draw_context.UpdatedZOffset(z_offset);
-    track->Draw(batcher, text_renderer, updated_draw_context);
-  }
-}
-
 void TimeGraph::SetThreadFilter(const std::string& filter) {
   track_manager_->SetFilter(filter);
   RequestUpdate();
@@ -968,11 +927,33 @@ std::pair<const TimerInfo*, const TimerInfo*> TimeGraph::GetMinMaxTimerInfoForFu
   return std::make_pair(min_timer, max_timer);
 }
 
-void TimeGraph::DrawText(float layer) {
-  if (draw_text_) {
-    text_renderer_static_.RenderLayer(layer);
+void TimeGraph::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                       const DrawContext& draw_context) {
+  CaptureViewElement::DoDraw(batcher, text_renderer, draw_context);
+
+  DrawIncompleteDataIntervals(batcher, draw_context.picking_mode);
+  DrawOverlay(batcher, text_renderer, draw_context.picking_mode);
+}
+
+void TimeGraph::DrawAllElements(Batcher& batcher, TextRenderer& text_renderer,
+                                PickingMode& picking_mode, uint64_t current_mouse_time_ns) {
+  const bool picking = picking_mode != PickingMode::kNone;
+
+  text_renderer.PushTranslation(0, -vertical_scrolling_offset_);
+  batcher.PushTranslation(0, -vertical_scrolling_offset_);
+
+  DrawContext context{current_mouse_time_ns, picking_mode};
+  Draw(batcher, text_renderer, context);
+
+  batcher.PopTranslation();
+  text_renderer.PopTranslation();
+
+  if ((!picking && update_primitives_requested_) || picking) {
+    UpdatePrimitives(picking_mode);
   }
 }
+
+void TimeGraph::DrawText(float layer) { text_renderer_static_.RenderLayer(layer); }
 
 bool TimeGraph::IsFullyVisible(uint64_t min, uint64_t max) const {
   double start = TicksToMicroseconds(capture_min_timestamp_, min);
@@ -1017,6 +998,16 @@ bool TimeGraph::HasFrameTrack(uint64_t function_id) const {
 void TimeGraph::RemoveFrameTrack(uint64_t function_id) {
   track_manager_->RemoveFrameTrack(function_id);
   RequestUpdate();
+}
+
+std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetChildren() const {
+  std::vector<Track*> all_tracks = track_manager_->GetAllTracks();
+  return {all_tracks.begin(), all_tracks.end()};
+}
+
+std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetVisibleChildren() const {
+  std::vector<Track*> all_tracks = track_manager_->GetVisibleTracks();
+  return {all_tracks.begin(), all_tracks.end()};
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> TimeGraph::CreateAccessibleInterface() {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -1000,12 +1000,12 @@ void TimeGraph::RemoveFrameTrack(uint64_t function_id) {
   RequestUpdate();
 }
 
-std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetChildren() const {
+std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetAllChildren() const {
   std::vector<Track*> all_tracks = track_manager_->GetAllTracks();
   return {all_tracks.begin(), all_tracks.end()};
 }
 
-std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetVisibleChildren() const {
+std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetNonHiddenChildren() const {
   std::vector<Track*> all_tracks = track_manager_->GetVisibleTracks();
   return {all_tracks.begin(), all_tracks.end()};
 }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -506,7 +506,7 @@ void TimeGraph::RequestUpdate() {
   update_primitives_requested_ = true;
 }
 
-void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
+void TimeGraph::PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode) {
   ORBIT_SCOPE_FUNCTION;
   CHECK(app_->GetStringManager() != nullptr);
 
@@ -949,7 +949,7 @@ void TimeGraph::DrawAllElements(Batcher& batcher, TextRenderer& text_renderer,
   text_renderer.PopTranslation();
 
   if ((!picking && update_primitives_requested_) || picking) {
-    UpdatePrimitives(picking_mode);
+    PrepareBatcherAndUpdatePrimitives(picking_mode);
   }
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -186,7 +186,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   }
 
  protected:
-  void UpdatePrimitives(PickingMode picking_mode);
+  void PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode);
   void DoUpdateLayout() override;
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -178,8 +178,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] bool HasFrameTrack(uint64_t function_id) const;
   void RemoveFrameTrack(uint64_t function_id);
 
-  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;
-  [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() const override;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetNonHiddenChildren() const override;
 
   [[nodiscard]] AccessibleInterfaceProvider* GetAccessibleParent() const {
     return accessible_parent_;

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -28,7 +28,7 @@ TimeGraphLayout::TimeGraphLayout() {
   track_tab_width_ = 350.f;
   track_tab_height_ = 25.f;
   track_tab_offset_ = 0.f;
-  track_intent_offset_ = 5.f;
+  track_indent_offset_ = 5.f;
   collapse_button_offset_ = 15.f;
   collapse_button_size_ = 10.f;
   collapse_button_decrease_per_indentation_ = 2.f;
@@ -69,7 +69,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(time_bar_height_);
   FLOAT_SLIDER(track_tab_height_);
   FLOAT_SLIDER(track_tab_offset_);
-  FLOAT_SLIDER(track_intent_offset_);
+  FLOAT_SLIDER(track_indent_offset_);
   FLOAT_SLIDER(collapse_button_size_);
   FLOAT_SLIDER(collapse_button_decrease_per_indentation_);
 

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -32,7 +32,7 @@ class TimeGraphLayout {
   float GetTrackTabWidth() const { return track_tab_width_; }
   float GetTrackTabHeight() const { return track_tab_height_ * scale_; }
   float GetTrackTabOffset() const { return track_tab_offset_; }
-  float GetTrackIntentOffset() const { return track_intent_offset_; }
+  float GetTrackIndentOffset() const { return track_indent_offset_; }
   float GetCollapseButtonSize(int indentation_level) const;
   float GetCollapseButtonOffset() const { return collapse_button_offset_; }
   float GetRoundingRadius() const { return rounding_radius_ * scale_; }
@@ -74,7 +74,7 @@ class TimeGraphLayout {
   float track_tab_width_;
   float track_tab_height_;
   float track_tab_offset_;
-  float track_intent_offset_;
+  float track_indent_offset_;
   float collapse_button_offset_;
   float collapse_button_size_;
   float collapse_button_decrease_per_indentation_;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -82,9 +82,9 @@ std::string TimerTrack::GetDisplayTime(const TimerInfo& timer) const {
   return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(timer.end() - timer.start()));
 }
 
-void TimerTrack::DrawTimesliceText(const orbit_client_protos::TimerInfo& timer,
-                                   TextRenderer& text_renderer, float min_x, Vec2 box_pos,
-                                   Vec2 box_size) {
+void TimerTrack::DrawTimesliceText(TextRenderer& text_renderer,
+                                   const orbit_client_protos::TimerInfo& timer, float min_x,
+                                   Vec2 box_pos, Vec2 box_size) {
   std::string timeslice_text = GetTimesliceText(timer);
 
   const std::string elapsed_time = GetDisplayTime(timer);
@@ -101,8 +101,8 @@ void TimerTrack::DrawTimesliceText(const orbit_client_protos::TimerInfo& timer,
       GlCanvas::kZValueBox, formatting, elapsed_time_length);
 }
 
-bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* next_timer_info,
-                           const internal::DrawData& draw_data, TextRenderer& text_renderer,
+bool TimerTrack::DrawTimer(TextRenderer& text_renderer, const TimerInfo* prev_timer_info,
+                           const TimerInfo* next_timer_info, const internal::DrawData& draw_data,
                            const TimerInfo* current_timer_info, uint64_t* min_ignore,
                            uint64_t* max_ignore) {
   CHECK(min_ignore != nullptr);
@@ -175,7 +175,7 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
       Vec2 pos{world_x_info.world_x_start, world_timer_y};
       Vec2 size{world_x_info.world_x_width, GetDynamicBoxHeight(*current_timer_info)};
 
-      DrawTimesliceText(*current_timer_info, text_renderer, draw_data.track_start_x, pos, size);
+      DrawTimesliceText(text_renderer, *current_timer_info, draw_data.track_start_x, pos, size);
     }
   }
 
@@ -300,7 +300,7 @@ void TimerTrack::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_rendere
         // from the previous iteration ("current").
         next_timer_info = &block[k];
 
-        if (DrawTimer(prev_timer_info, next_timer_info, draw_data, text_renderer,
+        if (DrawTimer(text_renderer, prev_timer_info, next_timer_info, draw_data,
                       current_timer_info, &min_ignore, &max_ignore)) {
           ++visible_timer_count_;
         }
@@ -312,7 +312,7 @@ void TimerTrack::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_rendere
 
     // We still need to draw the last timer.
     next_timer_info = nullptr;
-    if (DrawTimer(prev_timer_info, next_timer_info, draw_data, text_renderer, current_timer_info,
+    if (DrawTimer(text_renderer, prev_timer_info, next_timer_info, draw_data, current_timer_info,
                   &min_ignore, &max_ignore)) {
       ++visible_timer_count_;
     }

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -43,7 +43,6 @@ struct DrawData {
   double inv_time_window;
   float track_start_x;
   float track_width;
-  float z_offset;
   float z;
   bool is_collapsed;
 };
@@ -99,8 +98,8 @@ class TimerTrack : public Track {
   [[nodiscard]] uint64_t GetMaxTime() const override;
 
  protected:
-  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode /*picking_mode*/, float z_offset = 0) override;
+  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode /*picking_mode*/) override;
 
   [[nodiscard]] virtual bool IsTimerActive(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
@@ -116,7 +115,7 @@ class TimerTrack : public Track {
 
   [[nodiscard]] bool DrawTimer(const orbit_client_protos::TimerInfo* prev_timer_info,
                                const orbit_client_protos::TimerInfo* next_timer_info,
-                               const internal::DrawData& draw_data,
+                               const internal::DrawData& draw_data, TextRenderer& text_renderer,
                                const orbit_client_protos::TimerInfo* current_timer_info,
                                uint64_t* min_ignore, uint64_t* max_ignore);
 
@@ -126,12 +125,12 @@ class TimerTrack : public Track {
   }
   [[nodiscard]] std::string GetDisplayTime(const orbit_client_protos::TimerInfo&) const;
 
-  void DrawTimesliceText(const orbit_client_protos::TimerInfo& timer, float min_x, float z_offset,
-                         Vec2 box_pos, Vec2 box_size);
+  void DrawTimesliceText(const orbit_client_protos::TimerInfo& timer, TextRenderer& text_renderer,
+                         float min_x, Vec2 box_pos, Vec2 box_size);
 
   [[nodiscard]] static internal::DrawData GetDrawData(
-      uint64_t min_tick, uint64_t max_tick, float track_pos_x, float track_width, float z_offset,
-      Batcher* batcher, TimeGraph* time_graph, orbit_gl::Viewport* viewport, bool is_collapsed,
+      uint64_t min_tick, uint64_t max_tick, float track_pos_x, float track_width, Batcher* batcher,
+      TimeGraph* time_graph, orbit_gl::Viewport* viewport, bool is_collapsed,
       const orbit_client_protos::TimerInfo* selected_timer, uint64_t highlighted_function_id,
       uint64_t highlighted_group_id);
 
@@ -142,12 +141,11 @@ class TimerTrack : public Track {
         &timer_info, [this, &batcher](PickingId id) { return this->GetBoxTooltip(batcher, id); });
   }
 
-  [[nodiscard]] inline bool BoxHasRoomForText(const float width) {
-    return text_renderer_->GetStringWidth("w", layout_->CalculateZoomedFontSize()) < width;
+  [[nodiscard]] inline bool BoxHasRoomForText(TextRenderer& text_renderer, const float width) {
+    return text_renderer.GetStringWidth("w", layout_->CalculateZoomedFontSize()) < width;
   }
 
   static const Color kHighlightColor;
-  TextRenderer* text_renderer_ = nullptr;
   int visible_timer_count_ = 0;
   OrbitApp* app_ = nullptr;
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -113,9 +113,10 @@ class TimerTrack : public Track {
     return true;
   }
 
-  [[nodiscard]] bool DrawTimer(const orbit_client_protos::TimerInfo* prev_timer_info,
+  [[nodiscard]] bool DrawTimer(TextRenderer& text_renderer,
+                               const orbit_client_protos::TimerInfo* prev_timer_info,
                                const orbit_client_protos::TimerInfo* next_timer_info,
-                               const internal::DrawData& draw_data, TextRenderer& text_renderer,
+                               const internal::DrawData& draw_data,
                                const orbit_client_protos::TimerInfo* current_timer_info,
                                uint64_t* min_ignore, uint64_t* max_ignore);
 
@@ -125,7 +126,7 @@ class TimerTrack : public Track {
   }
   [[nodiscard]] std::string GetDisplayTime(const orbit_client_protos::TimerInfo&) const;
 
-  void DrawTimesliceText(const orbit_client_protos::TimerInfo& timer, TextRenderer& text_renderer,
+  void DrawTimesliceText(TextRenderer& text_renderer, const orbit_client_protos::TimerInfo& timer,
                          float min_x, Vec2 box_pos, Vec2 box_size);
 
   [[nodiscard]] static internal::DrawData GetDrawData(

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -47,17 +47,17 @@ void TracepointThreadBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
   float event_bar_z = draw_context.picking_mode == PickingMode::kClick
                           ? GlCanvas::kZValueEventBarPicking
                           : GlCanvas::kZValueEventBar;
-  event_bar_z += draw_context.z_offset;
   Color color = GetColor();
   Box box(GetPos(), Vec2(GetWidth(), -GetHeight()), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
 }
 
-void TracepointThreadBar::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                             PickingMode picking_mode, float z_offset) {
-  ThreadBar::DoUpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+void TracepointThreadBar::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+                                             uint64_t min_tick, uint64_t max_tick,
+                                             PickingMode picking_mode) {
+  ThreadBar::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
 
-  float z = GlCanvas::kZValueEvent + z_offset;
+  float z = GlCanvas::kZValueEvent;
   float track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const bool picking = picking_mode != PickingMode::kNone;
 

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -31,8 +31,8 @@ class TracepointThreadBar : public ThreadBar {
  protected:
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
-  void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode, float z_offset = 0) override;
+  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
 
  private:
   std::string GetTracepointTooltip(Batcher* batcher, PickingId id) const;

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -1,7 +1,8 @@
-#include "Track.h"
 // Copyright (c) 2020 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+#include "Track.h"
 
 #include <math.h>
 #include <stddef.h>
@@ -15,7 +16,6 @@
 #include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
-#include "Track.h"
 #include "Viewport.h"
 
 using orbit_client_data::TimerData;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -90,7 +90,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   void SetIndentationLevel(uint32_t level);
   [[nodiscard]] uint32_t GetIndentationLevel() const { return indentation_level_; }
 
-  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override {
+  [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override {
     return {collapse_toggle_.get()};
   }
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -53,7 +53,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
                  TimeGraphLayout* layout, const orbit_client_data::CaptureData* capture_data);
   ~Track() override = default;
 
-  void SetPos(float x, float y) override;
   void OnDrag(int x, int y) override;
 
   [[nodiscard]] virtual Type GetType() const = 0;
@@ -77,9 +76,9 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   TriangleToggle* GetTriangleToggle() const { return collapse_toggle_.get(); }
   [[nodiscard]] virtual uint32_t GetProcessId() const { return orbit_base::kInvalidProcessId; }
   [[nodiscard]] virtual bool IsEmpty() const = 0;
-  [[nodiscard]] bool ShouldBeRendered() const override {
-    return CaptureViewElement::ShouldBeRendered() && !IsEmpty();
-  }
+  [[nodiscard]] bool ShouldBeRendered() const override;
+
+  [[nodiscard]] float DetermineZOffset() const override;
 
   [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
 
@@ -88,7 +87,13 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] bool GetHeadless() const { return headless_; }
   void SetHeadless(bool value);
 
-  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
+  void SetIndentationLevel(uint32_t level);
+  [[nodiscard]] uint32_t GetIndentationLevel() const { return indentation_level_; }
+
+  [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override {
+    return {collapse_toggle_.get()};
+  }
+
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
   // Must be overriden by child class for sensible behavior.
@@ -107,18 +112,19 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
  protected:
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
+  void DoUpdateLayout() override;
 
-  void DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
-                              const DrawContext& draw_context);
   void DrawTriangleFan(Batcher& batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
   virtual void UpdatePositionOfSubtracks() {}
+  void UpdatePositionOfCollapseToggle();
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
   bool draw_background_ = true;
   bool pinned_ = false;
   bool headless_ = false;
+  uint32_t indentation_level_ = 0;
   Type type_ = Type::kUnknown;
   std::shared_ptr<TriangleToggle> collapse_toggle_;
 

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -58,6 +58,9 @@ std::vector<Track*> TrackManager::GetAllTracks() const {
   for (const auto& track : all_tracks_) {
     tracks.push_back(track.get());
   }
+  for (const auto& track : frame_tracks_) {
+    tracks.push_back(track.second.get());
+  }
   return tracks;
 }
 

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -78,20 +78,6 @@ std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
   return tracks;
 }
 
-std::vector<Track*> TrackManager::GetTracksOnScreen() const {
-  std::vector<Track*> visible_tracks;
-  for (Track* track : GetVisibleTracks()) {
-    float track_top_y = track->GetPos()[1];
-    float track_bottom_y = track_top_y + track->GetHeight();
-    float screen_top_y = time_graph_->GetVerticalScrollingOffset();
-    float screen_bottom_y = screen_top_y + viewport_->GetWorldHeight();
-    if (track_top_y < screen_bottom_y && track_bottom_y > screen_top_y) {
-      visible_tracks.push_back(track);
-    }
-  }
-  return visible_tracks;
-}
-
 void TrackManager::SortTracks() {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   // Gather all tracks regardless of the process in sorted order
@@ -327,14 +313,6 @@ int TrackManager::FindMovingTrackIndex() {
     }
   }
   return -1;
-}
-
-void TrackManager::UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                         PickingMode picking_mode) {
-  for (Track* track : GetTracksOnScreen()) {
-    const float z_offset = track->IsMoving() ? GlCanvas::kZOffsetMovingTrack : 0.f;
-    track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-  }
 }
 
 void TrackManager::UpdateTracksForRendering() {

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -44,7 +44,6 @@ class TrackManager {
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
   [[nodiscard]] std::vector<Track*> GetVisibleTracks() const { return visible_tracks_; }
-  [[nodiscard]] std::vector<Track*> GetTracksOnScreen() const;
   [[nodiscard]] std::vector<ThreadTrack*> GetThreadTracks() const;
   [[nodiscard]] std::vector<FrameTrack*> GetFrameTracks() const;
 
@@ -53,8 +52,6 @@ class TrackManager {
 
   [[nodiscard]] float GetVisibleTracksTotalHeight() const;
   void UpdateTracksForRendering();
-  void UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                             PickingMode picking_mode);
 
   [[nodiscard]] std::pair<uint64_t, uint64_t> GetTracksMinMaxTimestamps() const;
 

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -65,6 +65,16 @@ TEST_F(TrackManagerTest, GetOrCreateCreatesTracks) {
   EXPECT_EQ(2ull, track_manager_.GetAllTracks().size());
 }
 
+TEST_F(TrackManagerTest, FrameTracksAreReportedWithAllTracks) {
+  EXPECT_EQ(0ull, track_manager_.GetAllTracks().size());
+
+  track_manager_.GetOrCreateSchedulerTrack();
+  EXPECT_EQ(1ull, track_manager_.GetAllTracks().size());
+  orbit_grpc_protos::InstrumentedFunction function;
+  track_manager_.GetOrCreateFrameTrack(function);
+  EXPECT_EQ(2ull, track_manager_.GetAllTracks().size());
+}
+
 TEST_F(TrackManagerTest, AllButEmptyTracksAreVisible) {
   CreateAndFillTracks();
   track_manager_.UpdateTracksForRendering();

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -26,22 +26,17 @@ void TriangleToggle::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
                             const DrawContext& draw_context) {
   CaptureViewElement::DoDraw(batcher, text_renderer, draw_context);
 
-  const float z = GlCanvas::kZValueTrack + draw_context.z_offset;
+  const float z = GlCanvas::kZValueTrack;
 
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
   const Color kWhite(255, 255, 255, 255);
   const Color kGrey(100, 100, 100, 255);
   Color color = is_collapsible_ ? kWhite : kGrey;
 
-  // Set the size such that the triangle toggle can be selected in the E2E test.
-  float size = layout_->GetCollapseButtonSize(draw_context.indentation_level);
-  SetWidth(size);
-  SetHeight(size);
-
   // Draw triangle.
   static float half_sqrt_three = 0.5f * sqrtf(3.f);
-  float half_w = 0.5f * size;
-  float half_h = half_sqrt_three * half_w;
+  float half_w = 0.5f * GetWidth();
+  float half_h = half_sqrt_three * 0.5f * GetHeight();
 
   const Vec2 pos = GetPos();
   if (!picking) {

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -35,8 +35,8 @@ void TriangleToggle::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
 
   // Draw triangle.
   static float half_sqrt_three = 0.5f * sqrtf(3.f);
-  float half_w = 0.5f * GetWidth();
-  float half_h = half_sqrt_three * 0.5f * GetHeight();
+  float half_triangle_base_width = 0.5f * GetWidth();
+  float half_triangle_height = half_sqrt_three * 0.5f * GetHeight();
 
   const Vec2 pos = GetPos();
   if (!picking) {
@@ -44,16 +44,18 @@ void TriangleToggle::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
 
     Triangle triangle;
     if (is_collapsed_) {
-      triangle = Triangle(position + Vec3(-half_h, half_w, z), position + Vec3(-half_h, -half_w, z),
-                          position + Vec3(half_w, 0.f, z));
+      triangle = Triangle(position + Vec3(-half_triangle_height, half_triangle_base_width, z),
+                          position + Vec3(-half_triangle_height, -half_triangle_base_width, z),
+                          position + Vec3(half_triangle_base_width, 0.f, z));
     } else {
-      triangle = Triangle(position + Vec3(half_w, -half_h, z), position + Vec3(-half_w, -half_h, z),
-                          position + Vec3(0.f, half_w, z));
+      triangle = Triangle(position + Vec3(half_triangle_base_width, -half_triangle_height, z),
+                          position + Vec3(-half_triangle_base_width, -half_triangle_height, z),
+                          position + Vec3(0.f, half_triangle_base_width, z));
     }
     batcher.AddTriangle(triangle, color, shared_from_this());
   } else {
     // When picking, draw a big square for easier picking.
-    float original_width = 2 * half_w;
+    float original_width = 2 * half_triangle_base_width;
     float large_width = 2 * original_width;
     Box box(Vec2(pos[0] - original_width, pos[1] - original_width), Vec2(large_width, large_width),
             z);

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -39,7 +39,7 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   void SetIsCollapsible(bool is_collapsible) { is_collapsible_ = is_collapsible; }
   [[nodiscard]] bool IsCollapsible() const { return is_collapsible_; }
 
-  [[nodiscard]] uint32_t GetLayoutFlags() const override { return 0; }
+  [[nodiscard]] uint32_t GetLayoutFlags() const override { return LayoutFlags::kNone; }
 
  protected:
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
@@ -53,7 +53,7 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   // We require explicit knowledge about the parent.
   Track* track_;
 
-  float height_;
+  float height_ = 20;
   bool is_collapsed_ = false;
   bool is_collapsible_ = true;
 

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -39,6 +39,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   void SetIsCollapsible(bool is_collapsible) { is_collapsible_ = is_collapsible; }
   [[nodiscard]] bool IsCollapsible() const { return is_collapsible_; }
 
+  [[nodiscard]] uint32_t GetLayoutFlags() const override { return 0; }
+
  protected:
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;


### PR DESCRIPTION
This finally makes the `TimeGraph` implement the `CaptureViewElement` API correctly: It exposes its children through `GetChildren` and `GetVisibleChildren`, and uses the shared implementation of the super class to update and draw all tracks.

A lot is happening in this PR as I needed to remove a bunch of special treatment from the `TimeGraph`:

- Some parameters that were formerly passed during rendering calls have been converted to UI element properties, must notably the z offset and indentation. This follows the reasoning that all layout-affecting changes should happen before `Draw`
- z-offset is now using the batcher transformation stack
- The `UpdatePrimitives` method of `CaptureViewElement` is now protected as it requires knowledge that should not be needed from outside. Only `Draw` needs to be called from outside, and it is the responsibility of `TimeGraph` to determine if `UpdatePrimitives` is needed as it also owns the Batcher in this case
- `CaptureViewElement::UpdatePrimitives` is optimized to only draw children on screen

Finally, the main change returns all tracks as result of `TimeGraph::GetChildren` and `TimeGraph::GetVisibleChildren`, and gets rid of the special treatment that tracks have received as implicit children of `TimeGraph`.

Next steps: Slowly, slowy we'll be able to add unit tests for this. I'm planning on removing most of the special handling for accessibility classes (exposing the track tab as an actual visual element). I should also add a doc that describes the status quo...

Bug: b/176216022
Test: Multiple manual tests to confirm all still works correctly: Opening a larger capture, expanding / collapsing tracks, making sure the rendering looks like before. Tested track reordering, filtering, track type visibility, iterators, right-click measurement for visual correctness, and for rendering performance regressions.