### PR TITLE
Remove ModuleData::AddFunctionInfoWithBuildId

### DIFF
--- a/src/ClientData/ModuleData.cpp
+++ b/src/ClientData/ModuleData.cpp
@@ -103,16 +103,6 @@ const FunctionInfo* ModuleData::FindFunctionByElfAddress(uint64_t elf_address,
   return function;
 }
 
-void ModuleData::AddFunctionInfoWithBuildId(const FunctionInfo& function_info,
-                                            const std::string& module_build_id) {
-  absl::MutexLock lock(&mutex_);
-  CHECK(functions_.find(function_info.address()) == functions_.end());
-  auto value = std::make_unique<FunctionInfo>(function_info);
-  value->set_module_build_id(module_build_id);
-  functions_.insert_or_assign(function_info.address(), std::move(value));
-  is_loaded_ = true;
-}
-
 void ModuleData::AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols) {
   absl::MutexLock lock(&mutex_);
   CHECK(!is_loaded_);

--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -53,13 +53,10 @@ class ModuleData final {
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByElfAddress(
       uint64_t elf_address, bool is_exact) const;
   void AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols);
-  void AddFunctionInfoWithBuildId(const orbit_client_protos::FunctionInfo& function_info,
-                                  const std::string& module_build_id);
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionFromHash(uint64_t hash) const;
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionFromPrettyName(
       std::string_view pretty_name) const;
   [[nodiscard]] std::vector<const orbit_client_protos::FunctionInfo*> GetFunctions() const;
-  [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctions() const;
 
  private:
   [[nodiscard]] bool NeedsUpdate(const orbit_grpc_protos::ModuleInfo& info) const;

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -267,9 +267,18 @@ TEST_F(FunctionsDataViewTest, FrameTrackSelectionAppearsInFirstColumnWhenACaptur
   (void)module_manager.AddOrUpdateModules({module_infos_[0]});
   ASSERT_EQ(module_manager.GetAllModuleData().size(), 1);
 
+  orbit_grpc_protos::SymbolInfo symbol_info;
+  symbol_info.set_name(functions_[0].name());
+  symbol_info.set_demangled_name(functions_[0].pretty_name());
+  symbol_info.set_address(functions_[0].address());
+  symbol_info.set_size(functions_[0].size());
+  orbit_grpc_protos::ModuleSymbols module_symbols;
+  module_symbols.set_load_bias(module_infos_[0].load_bias());
+  module_symbols.set_symbols_file_path(module_infos_[0].file_path());
+  module_symbols.mutable_symbol_infos()->Add(std::move(symbol_info));
   orbit_client_data::ModuleData* module_data = module_manager.GetMutableModuleByPathAndBuildId(
       functions_[0].module_path(), functions_[0].module_build_id());
-  module_data->AddFunctionInfoWithBuildId(functions_[0], functions_[0].module_build_id());
+  module_data->AddSymbols(module_symbols);
 
   orbit_grpc_protos::CaptureStarted capture_started{};
 


### PR DESCRIPTION
This method is a leftover from an old fix to capture loading from the old
format, code that is now gone.
It "pollutes" the interface of `ModuleData` as it adds a different way of
adding functions in addition to `AddSymbols`. Indeed, by bypassing `AddSymbols`,
it has the problem that it doesn't update `name_to_function_info_map_` and
`hash_to_function_map_`.
It's only used in a couple of tests as a shortcut, so let's just remove it.

Test: Run affected unit tests.