### PR TITLE
Add interal path for libOrbitUserSpaceInstrumentation

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -40,6 +40,9 @@ ErrorMessageOr<std::filesystem::path> GetLibraryPath() {
   const std::filesystem::path exe_dir = orbit_base::GetExecutableDir();
   std::vector<std::filesystem::path> potential_paths = {exe_dir / kLibName,
                                                         exe_dir / ".." / "lib" / kLibName};
+  /* copybara:insert(In internal tests the library is in a different place)
+  potential_paths.emplace_back("@@LIB_ORBIT_USER_SPACE_INSTRUMENTATION_PATH@@");
+  */
   for (const auto& path : potential_paths) {
     if (std::filesystem::exists(path)) {
       return path;


### PR DESCRIPTION
The InstrumentProcess class looks into two locations
for the inject library. That's where the library can be found
during production and where it can be found when started from the build
directory (during development).

In internal builds the library is in a different place when tests run on
the CI so this commit is adding a third location when build internally.