### PR TITLE
Remove unused StateChangeHandler from TriangleToggle

### DIFF
--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -18,20 +18,15 @@
 #include "TimeGraphLayout.h"
 #include "Viewport.h"
 
-using orbit_client_data::TimerData;
-
 Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
              TimeGraphLayout* layout, const orbit_client_data::CaptureData* capture_data)
     : CaptureViewElement(parent, time_graph, viewport, layout),
-      pinned_{false},
       layout_(layout),
       capture_data_(capture_data) {
   // We decrease the size of the collapse toggle per indentation, but as it becomes too small after
   // 5 indentations, we cap the size here.
 
-  collapse_toggle_ = std::make_shared<TriangleToggle>(
-      [this](bool is_collapsed) { OnCollapseToggle(is_collapsed); }, time_graph, viewport, layout,
-      this);
+  collapse_toggle_ = std::make_shared<TriangleToggle>(time_graph, viewport, layout, this);
 }
 
 std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
@@ -224,8 +219,6 @@ Color Track::GetTrackBackgroundColor() const {
   const Color kDarkGrey(50, 50, 50, 255);
   return kDarkGrey;
 }
-
-void Track::OnCollapseToggle(bool /*is_collapsed*/) { RequestUpdate(); }
 
 void Track::SetHeadless(bool value) {
   if (headless_ == value) return;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -72,7 +72,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] virtual Color GetTrackBackgroundColor() const;
 
-  virtual void OnCollapseToggle(bool is_collapsed);
   [[nodiscard]] virtual bool IsCollapsible() const { return false; }
   TriangleToggle* GetTriangleToggle() const { return collapse_toggle_.get(); }
   [[nodiscard]] virtual uint32_t GetProcessId() const { return orbit_base::kInvalidProcessId; }
@@ -85,7 +84,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] virtual bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
 
-  [[nodiscard]] bool GetHeadless() const { return headless_; }
   void SetHeadless(bool value);
 
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -16,11 +16,9 @@
 #include "TimeGraph.h"
 #include "Track.h"
 
-TriangleToggle::TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph,
-                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track)
-    : CaptureViewElement(track, time_graph, viewport, layout),
-      track_(track),
-      handler_(std::move(handler)) {}
+TriangleToggle::TriangleToggle(TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                               TimeGraphLayout* layout, Track* track)
+    : CaptureViewElement(track, time_graph, viewport, layout), track_(track) {}
 
 void TriangleToggle::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
                             const DrawContext& draw_context) {
@@ -74,8 +72,6 @@ void TriangleToggle::OnRelease() {
 
   CaptureViewElement::OnRelease();
   is_collapsed_ = !is_collapsed_;
-
-  handler_(is_collapsed_);
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface>

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -18,8 +18,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
                        public std::enable_shared_from_this<TriangleToggle> {
  public:
   using StateChangeHandler = std::function<void(bool)>;
-  explicit TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph,
-                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track);
+  explicit TriangleToggle(TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                          TimeGraphLayout* layout, Track* track);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;
@@ -54,8 +54,6 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   float height_;
   bool is_collapsed_ = false;
   bool is_collapsible_ = true;
-
-  StateChangeHandler handler_;
 };
 
 #endif  // ORBIT_GL_TRIANGLE_TOGGLE_H_


### PR DESCRIPTION
The callback was a call to RequestUpdate(), which is already
done by CaptureViewElement::OnRelease() ->
CaptureViewElement::RequestUpdate() -> parent_->RequestUpdate(),
note that track_ is parent in CaptureViewElement.

Test: builds