### PR TITLE
Add support for manual instrumentation to FakeClient

### DIFF
--- a/src/ApiLoader/CMakeLists.txt
+++ b/src/ApiLoader/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(ApiLoader PRIVATE
         EnableInTracee.cpp)
 
 target_link_libraries(ApiLoader PUBLIC
+        ApiUtils
         GrpcProtos
         ObjectUtils
         OrbitBase

--- a/src/ApiLoader/EnableInTracee.cpp
+++ b/src/ApiLoader/EnableInTracee.cpp
@@ -10,6 +10,7 @@
 
 #include <functional>
 
+#include "ApiUtils/GetFunctionTableAddressPrefix.h"
 #include "ObjectUtils/Address.h"
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/ExecutablePath.h"
@@ -102,8 +103,8 @@ ErrorMessageOr<void> SetApiEnabledInTracee(const CaptureOptions& capture_options
   OUTCOME_TRY(auto&& modules_by_path, GetModulesByPathForPid(pid));
   for (const ApiFunction& api_function : capture_options.api_functions()) {
     // Filter api functions.
-    constexpr const char* kOrbitApiGetAddressPrefix = "orbit_api_get_function_table_address_v";
-    CHECK(absl::StartsWith(api_function.name(), kOrbitApiGetAddressPrefix));
+    CHECK(absl::StartsWith(api_function.name(),
+                           orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix));
 
     // Get ModuleInfo associated with function.
     const ModuleInfo* module_info = FindModuleInfoForApiFunction(api_function, modules_by_path);

--- a/src/ApiUtils/CMakeLists.txt
+++ b/src/ApiUtils/CMakeLists.txt
@@ -3,17 +3,22 @@
 # found in the LICENSE file.
 
 add_library(ApiUtils STATIC)
+
 target_sources(ApiUtils PUBLIC
         include/ApiUtils/Event.h
         include/ApiUtils/EncodedEvent.h
-        include/ApiUtils/EncodedString.h)
+        include/ApiUtils/EncodedString.h
+        include/ApiUtils/GetFunctionTableAddressPrefix.h)
+
 target_sources(ApiUtils PRIVATE
         EncodedString.cpp
         Event.cpp)
+
 target_link_libraries(ApiUtils PUBLIC
         ApiInterface
         GrpcProtos
         OrbitBase)
+
 target_include_directories(ApiUtils PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 add_executable(ApiUtilsTests)

--- a/src/ApiUtils/include/ApiUtils/GetFunctionTableAddressPrefix.h
+++ b/src/ApiUtils/include/ApiUtils/GetFunctionTableAddressPrefix.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef API_UTILS_GET_FUNCTION_TABLE_ADDRESS_PREFIX_H_
+#define API_UTILS_GET_FUNCTION_TABLE_ADDRESS_PREFIX_H_
+
+#include <string>
+
+namespace orbit_api_utils {
+
+// This is the prefix of the function declared in Orbit.h that we need to call in the tracee after
+// having loaded liborbit.so into it.
+static const std::string kOrbitApiGetFunctionTableAddressPrefix{
+    "orbit_api_get_function_table_address_v"};
+
+}  // namespace orbit_api_utils
+
+#endif  // API_UTILS_GET_FUNCTION_TABLE_ADDRESS_PREFIX_H_

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -15,6 +15,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "ApiUtils/GetFunctionTableAddressPrefix.h"
 #include "CaptureClient/CaptureEventProcessor.h"
 #include "CaptureClient/CaptureListener.h"
 #include "ClientData/FunctionUtils.h"
@@ -93,9 +94,9 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
     const orbit_client_data::ModuleManager& module_manager) {
   std::vector<ApiFunction> api_functions;
   for (const ModuleData* module_data : module_manager.GetAllModuleData()) {
-    constexpr const char* kOrbitApiGetAddressPrefix = "orbit_api_get_function_table_address_v";
     for (size_t i = 0; i <= kOrbitApiVersion; ++i) {
-      std::string function_name = absl::StrFormat("%s%u", kOrbitApiGetAddressPrefix, i);
+      std::string function_name =
+          absl::StrFormat("%s%u", orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix, i);
       const FunctionInfo* function_info = module_data->FindFunctionFromPrettyName(function_name);
       if (function_info == nullptr) continue;
       ApiFunction api_function;

--- a/src/FakeClient/CMakeLists.txt
+++ b/src/FakeClient/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(OrbitFakeClient PRIVATE
 
 target_link_libraries(OrbitFakeClient PRIVATE
         CONAN_PKG::abseil
+        ApiUtils
         CaptureClient
         ClientData
         ClientProtos

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <thread>
 
+#include "ApiUtils/GetFunctionTableAddressPrefix.h"
 #include "CaptureClient/CaptureClient.h"
 #include "CaptureClient/CaptureListener.h"
 #include "ClientData/ModuleManager.h"
@@ -341,10 +342,10 @@ int main(int argc, char* argv[]) {
     ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
         orbit_object_utils::ReadModules(process_id);
     FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
-    static const std::string kOrbitApiGetAddressPrefix{"orbit_api_get_function_table_address_v"};
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
       ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
-          &module_manager, module.file_path(), kOrbitApiGetAddressPrefix);
+          &module_manager, module.file_path(),
+          orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix);
     }
   }
 


### PR DESCRIPTION
We need to add a bit of simplified symbol loading logic as we need to look for
`orbit_api_get_function_table_address_v#` in all modules.

Bug: http://b/187911919

Test: Try it on manually instrumented Infiltrator and manually instrumented
AdventureUnity, verifying that events are coming from the number of events
received and the CPU utilization of the threads involved.