### PR TITLE
Add [[maybe_unused]] to write-only volatile vars

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -156,7 +156,7 @@ TEST(InstrumentProcessTest, Instrument) {
   if (pid_process_1 == 0) {
     // Endless loops without side effects are UB and recent versions of clang optimize
     // it away. Making `sum` volatile avoids that problem.
-    volatile int sum = 0;
+    [[maybe_unused]] volatile int sum = 0;
     while (true) {
       sum += SomethingToInstrument();
     }
@@ -181,7 +181,7 @@ TEST(InstrumentProcessTest, Instrument) {
   if (pid_process_2 == 0) {
     // Endless loops without side effects are UB and recent versions of clang optimize
     // it away. Making `sum` volatile avoids that problem.
-    volatile int sum = 0;
+    [[maybe_unused]] volatile int sum = 0;
     while (true) {
       sum += SomethingToInstrument();
     }
@@ -214,7 +214,7 @@ TEST(InstrumentProcessTest, GetErrorMessage) {
   if (pid == 0) {
     // Endless loops without side effects are UB and recent versions of clang optimize
     // it away. Making `sum` volatile avoids that problem.
-    volatile int sum = 0;
+    [[maybe_unused]] volatile int sum = 0;
     while (true) {
       sum += SomethingToInstrument();
     }

--- a/src/UserSpaceInstrumentation/TestUtilsTest.cpp
+++ b/src/UserSpaceInstrumentation/TestUtilsTest.cpp
@@ -36,7 +36,7 @@ TEST(TestUtilTest, Disassemble) {
   if (pid == 0) {
     // Endless loops without side effects are UB and recent versions of clang optimize
     // it away. Making `sum` volatile avoids that problem.
-    volatile int sum = 0;
+    [[maybe_unused]] volatile int sum = 0;
     while (true) {
       sum += SomethingToDisassemble();
     }

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -269,7 +269,7 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
   pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {
-    uint64_t sum = 0;
+    [[maybe_unused]] volatile uint64_t sum = 0;
     // Endless loops without side effects are UB and recent versions of clang optimize
     // it away. Making `i` volatile avoids that problem.
     volatile int i = 0;
@@ -566,7 +566,7 @@ class InstrumentFunctionTest : public testing::Test {
     if (pid_ == 0) {
       // Endless loops without side effects are UB and recent versions of clang optimize
       // it away. Making `sum` volatile avoids that problem.
-      volatile uint64_t sum = 0;
+      [[maybe_unused]] volatile uint64_t sum = 0;
       while (true) {
         sum += (*function_pointer)();
       }
@@ -979,7 +979,7 @@ TEST_F(InstrumentFunctionTest, CheckIntParameters) {
   pid_ = fork();
   CHECK(pid_ != -1);
   if (pid_ == 0) {
-    volatile uint64_t sum = 0;
+    [[maybe_unused]] volatile uint64_t sum = 0;
     while (true) {
       sum += CheckIntParameters(0, 0, 0, 0, 0, 0, 0, 0);
       // Endless loops without side effects are UB and recent versions of clang optimize
@@ -1013,7 +1013,7 @@ TEST_F(InstrumentFunctionTest, CheckFloatParameters) {
   if (pid_ == 0) {
     // Endless loops without side effects are UB and recent versions of clang optimize
     // it away. Making `sum` volatile avoids that problem.
-    volatile uint64_t sum = 0;
+    [[maybe_unused]] volatile uint64_t sum = 0;
     while (true) {
       sum += CheckFloatParameters(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
     }
@@ -1047,7 +1047,7 @@ TEST_F(InstrumentFunctionTest, CheckM256iParameters) {
   if (pid_ == 0) {
     // Endless loops without side effects are UB and recent versions of clang optimize
     // it away. Making `sum` volatile avoids that problem.
-    volatile uint64_t sum = 0;
+    [[maybe_unused]] volatile uint64_t sum = 0;
     while (true) {
       sum +=
           CheckM256iParameters(_mm256_set1_epi64x(0), _mm256_set1_epi64x(0), _mm256_set1_epi64x(0),


### PR DESCRIPTION
In the UserSpaceInstrumentation tests we use volatile variables to force
some code generation. But recent clang trunk started to complain about
these variables being written only despite them being volatile. Since
volatile is such a complicated topic it's hard to judge if clang is
acting here correctly or not. Anyway, adding a `[[maybe_unused]]`
silences the warning and the code generation remains correct, so I
believe that is a viable quick fix.

If it turns out that the compiler is allowed to optimize away local
volatile variables we might need to find a different way in the future.
Global variables would be one option for example.