### PR TITLE
Add GetTestLibLibraryPath function

### DIFF
--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -93,6 +93,8 @@ target_sources(UserSpaceInstrumentationTests PRIVATE
         ExecuteInProcessTest.cpp
         ExecuteMachineCodeTest.cpp
         FindFunctionAddressTest.cpp
+        GetTestLibLibraryPath.cpp
+        GetTestLibLibraryPath.h
         InjectLibraryInTraceeTest.cpp
         InstrumentProcessTest.cpp
         MachineCodeTest.cpp

--- a/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
@@ -7,8 +7,10 @@
 #include <sys/wait.h>
 
 #include <csignal>
+#include <filesystem>
 #include <string>
 
+#include "GetTestLibLibraryPath.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
@@ -35,9 +37,11 @@ TEST(ExecuteInProcessTest, ExecuteInProcess) {
 
   CHECK(!AttachAndStopProcess(pid).has_error());
 
+  auto library_path_or_error = GetTestLibLibraryPath();
+  ASSERT_THAT(library_path_or_error, HasNoError());
+  std::filesystem::path library_path = std::move(library_path_or_error.value());
+
   // Load dynamic lib into tracee.
-  const std::string kLibName = "libUserSpaceInstrumentationTestLib.so";
-  const std::string library_path = orbit_base::GetExecutableDir() / ".." / "lib" / kLibName;
   auto library_handle_or_error = DlopenInTracee(pid, library_path, RTLD_NOW);
   CHECK(library_handle_or_error.has_value());
   void* library_handle = library_handle_or_error.value();

--- a/src/UserSpaceInstrumentation/GetTestLibLibraryPath.cpp
+++ b/src/UserSpaceInstrumentation/GetTestLibLibraryPath.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <filesystem>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/File.h"
+#include "OrbitBase/Result.h"
+
+namespace orbit_user_space_instrumentation {
+
+ErrorMessageOr<std::filesystem::path> GetTestLibLibraryPath() {
+  // copybara:strip_begin(The library is in a different place internally)
+  constexpr std::string_view kLibName = "libUserSpaceInstrumentationTestLib.so";
+  const std::string library_path = orbit_base::GetExecutableDir() / ".." / "lib" / kLibName;
+  /* copybara:strip_end_and_replace
+  const std::string library_path = "@@LIB_USER_SPACE_INSTRUMENTATION_TEST_LIB_PATH@@";
+  */
+
+  OUTCOME_TRY(orbit_base::OpenFileForReading(library_path));
+
+  return library_path;
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/GetTestLibLibraryPath.h
+++ b/src/UserSpaceInstrumentation/GetTestLibLibraryPath.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef USER_SPACE_INSTRUMENTATION_GET_TEST_LIB_LIBRARY_PATH
+#define USER_SPACE_INSTRUMENTATION_GET_TEST_LIB_LIBRARY_PATH
+
+#include <filesystem>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_user_space_instrumentation {
+
+ErrorMessageOr<std::filesystem::path> GetTestLibLibraryPath();
+
+}  // namespace orbit_user_space_instrumentation
+
+#endif  // USER_SPACE_INSTRUMENTATION_GET_TEST_LIB_LIBRARY_PATH

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -27,6 +27,7 @@
 #include "AccessTraceesMemory.h"
 #include "AddressRange.h"
 #include "AllocateInTracee.h"
+#include "GetTestLibLibraryPath.h"
 #include "MachineCode.h"
 #include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
@@ -582,9 +583,11 @@ class InstrumentFunctionTest : public testing::Test {
     // Stop the child process using our tooling.
     CHECK(AttachAndStopProcess(pid_).has_value());
 
+    auto library_path_or_error = GetTestLibLibraryPath();
+    ASSERT_THAT(library_path_or_error, HasNoError());
+    std::filesystem::path library_path = std::move(library_path_or_error.value());
+
     // Inject the payload for the instrumentation.
-    constexpr std::string_view kLibName = "libUserSpaceInstrumentationTestLib.so";
-    const std::string library_path = orbit_base::GetExecutableDir() / ".." / "lib" / kLibName;
     auto library_handle_or_error = DlopenInTracee(pid_, library_path, RTLD_NOW);
     CHECK(library_handle_or_error.has_value());
     void* library_handle = library_handle_or_error.value();


### PR DESCRIPTION
This adds a common function that can be used in all
UserSpaceInstrumentation tests to obtain the location of the TestLib.

That's needed because the location and name is different in internal
builds. So this also introduces a copybara variable that will be
replaced for internal builds and allows to adjust the location.