### PR TITLE
Compare inodes instead of file paths in tests

### DIFF
--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -5,13 +5,18 @@
 #include <absl/base/casts.h>
 #include <absl/strings/match.h>
 #include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
 #include <dlfcn.h>
 #include <gtest/gtest.h>
+#include <sys/sysmacros.h>
 #include <sys/wait.h>
 
+#include <charconv>
 #include <chrono>
 #include <csignal>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <thread>
 
 #include "AllocateInTracee.h"
@@ -32,6 +37,69 @@ namespace {
 
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;
+using testing::Eq;
+
+// The device ID and the inode ID together uniquely identify a file on a single machine.
+// Ref: https://www.gnu.org/software/libc/manual/html_node/Attribute-Meanings.html
+struct DeviceInodePair {
+  dev_t device;
+  ino_t inode;
+};
+
+ErrorMessageOr<bool> IsDeviceInodePairInMapsFile(DeviceInodePair device_inode, pid_t pid) {
+  OUTCOME_TRY(auto&& maps_contents,
+              orbit_base::ReadFileToString(absl::StrFormat("/proc/%d/maps", pid)));
+
+  std::vector<std::string_view> lines = absl::StrSplit(maps_contents, '\n');
+
+  for (const auto& line : lines) {
+    std::vector<std::string_view> fields = absl::StrSplit(line, ' ', absl::SkipEmpty{});
+    constexpr int kInodeFieldIndex = 4;
+    if (fields.size() <= kInodeFieldIndex) continue;
+
+    ino_t current_inode{};
+    if (!absl::SimpleAtoi(fields[kInodeFieldIndex], &current_inode)) continue;
+    if (current_inode != device_inode.inode) continue;
+
+    // The device field is formatted as `AA:BB` where `AA` is a single hex byte representing the
+    // major number and `BB` being a single hex byte representing the minor number. Both numbers
+    // are always two digits wide.
+    constexpr int kDeviceFieldIndex = 3;
+    std::vector<std::string_view> device_number_fields =
+        absl::StrSplit(fields[kDeviceFieldIndex], ':');
+    if (device_number_fields.size() != 2) continue;
+
+    constexpr int kMajorFieldIndex = 0;
+    if (device_number_fields[kMajorFieldIndex].size() != 2) continue;
+    uint32_t major_number{};
+    if (std::from_chars(device_number_fields[kMajorFieldIndex].begin(),
+                        device_number_fields[kMajorFieldIndex].end(), major_number, 16)
+            .ec != std::errc{}) {
+      continue;
+    }
+
+    constexpr int kMinorFieldIndex = 1;
+    if (device_number_fields[kMinorFieldIndex].size() != 2) continue;
+    uint32_t minor_number{};
+    if (std::from_chars(device_number_fields[kMinorFieldIndex].begin(),
+                        device_number_fields[kMinorFieldIndex].end(), minor_number, 16)
+            .ec != std::errc{}) {
+      continue;
+    }
+
+    if (makedev(major_number, minor_number) == device_inode.device) return true;
+  }
+
+  return false;
+}
+
+ErrorMessageOr<DeviceInodePair> GetDeviceInodePairFromFilePath(const std::string& file_path) {
+  struct stat stat_buf {};
+  if (stat(file_path.c_str(), &stat_buf) != 0) {
+    return ErrorMessage{absl::StrFormat("Failed to obtain inode of '%s'", file_path)};
+  }
+  return DeviceInodePair{stat_buf.st_dev, stat_buf.st_ino};
+}
 
 void OpenUseAndCloseLibrary(pid_t pid) {
   // Stop the child process using our tooling.
@@ -41,18 +109,20 @@ void OpenUseAndCloseLibrary(pid_t pid) {
   ASSERT_THAT(library_path_or_error, HasNoError());
   std::filesystem::path library_path = std::move(library_path_or_error.value());
 
+  ErrorMessageOr<DeviceInodePair> device_inode_pair_of_library =
+      GetDeviceInodePairFromFilePath(library_path);
+  ASSERT_THAT(device_inode_pair_of_library, HasNoError());
+
   // Tracee does not have the dynamic lib loaded, obviously.
-  auto maps_before = orbit_base::ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
-  CHECK(maps_before.has_value());
-  EXPECT_FALSE(absl::StrContains(maps_before.value(), library_path.filename().string()));
+  EXPECT_THAT(IsDeviceInodePairInMapsFile(device_inode_pair_of_library.value(), pid),
+              orbit_test_utils::HasValue(Eq(false)));
 
   auto library_handle_or_error = DlopenInTracee(pid, library_path, RTLD_NOW);
   ASSERT_TRUE(library_handle_or_error.has_value());
 
   // Tracee now does have the dynamic lib loaded.
-  auto maps_after_open = orbit_base::ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
-  CHECK(maps_after_open.has_value());
-  EXPECT_TRUE(absl::StrContains(maps_after_open.value(), library_path.filename().string()));
+  EXPECT_THAT(IsDeviceInodePairInMapsFile(device_inode_pair_of_library.value(), pid),
+              orbit_test_utils::HasValue(Eq(true)));
 
   // Look up symbol for "TrivialFunction" in the dynamic lib.
   auto dlsym_or_error = DlsymInTracee(pid, library_handle_or_error.value(), "TrivialFunction");
@@ -84,9 +154,8 @@ void OpenUseAndCloseLibrary(pid_t pid) {
   ASSERT_THAT(result_dlclose, HasNoError());
 
   // Now, again, the lib is absent from the tracee.
-  auto maps_after_close = orbit_base::ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
-  CHECK(maps_after_close.has_value());
-  EXPECT_FALSE(absl::StrContains(maps_after_close.value(), library_path.filename().string()));
+  EXPECT_THAT(IsDeviceInodePairInMapsFile(device_inode_pair_of_library.value(), pid),
+              orbit_test_utils::HasValue(Eq(false)));
 
   CHECK(!DetachAndContinueProcess(pid).has_error());
 }


### PR DESCRIPTION
When mapped files are symlinks (as it is the case in the internal
testing environment) or hardlinks the path that appears in the maps
file might be different and all the tests comparing file paths will
fail.

To avoid that problem this commit moves to comparing inodes and device ids
instead of file paths which is much more robust.

I also tried to fix the problem with `realpath` but that didn't help in
all cases. I'm not a 100% sure why but have been moving to inode
comparison anyway.