### PR TITLE
Unify Depth, Height and MaxDepth in ScopeTree

### DIFF
--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -12,9 +12,9 @@ size_t ScopeTreeTimerData::GetNumberOfTimers() const {
   return scope_tree_.Size() - 1;
 }
 
-uint32_t ScopeTreeTimerData::GetMaxDepth() const {
+uint32_t ScopeTreeTimerData::GetDepth() const {
   absl::MutexLock lock(&scope_tree_mutex_);
-  return scope_tree_.Height() - 1;
+  return scope_tree_.Depth();
 }
 
 const orbit_client_protos::TimerInfo& ScopeTreeTimerData::AddTimer(

--- a/src/ClientData/ScopeTreeTimerDataTest.cpp
+++ b/src/ClientData/ScopeTreeTimerDataTest.cpp
@@ -24,7 +24,7 @@ TEST(ScopeTreeTimerData, AddTimers) {
 
   EXPECT_FALSE(scope_tree_timer_data.IsEmpty());
   EXPECT_EQ(scope_tree_timer_data.GetNumberOfTimers(), 1);
-  EXPECT_EQ(scope_tree_timer_data.GetMaxDepth(), 0);
+  EXPECT_EQ(scope_tree_timer_data.GetDepth(), 1);
   EXPECT_EQ(scope_tree_timer_data.GetMinTime(), 2);
   EXPECT_EQ(scope_tree_timer_data.GetMaxTime(), 5);
 
@@ -34,7 +34,7 @@ TEST(ScopeTreeTimerData, AddTimers) {
   scope_tree_timer_data.AddTimer(timer_info);
 
   EXPECT_EQ(scope_tree_timer_data.GetNumberOfTimers(), 2);
-  EXPECT_EQ(scope_tree_timer_data.GetMaxDepth(), 0);
+  EXPECT_EQ(scope_tree_timer_data.GetDepth(), 1);
   EXPECT_EQ(scope_tree_timer_data.GetMinTime(), 2);
   EXPECT_EQ(scope_tree_timer_data.GetMaxTime(), 11);
 
@@ -44,7 +44,7 @@ TEST(ScopeTreeTimerData, AddTimers) {
   scope_tree_timer_data.AddTimer(timer_info);
 
   EXPECT_EQ(scope_tree_timer_data.GetNumberOfTimers(), 3);
-  EXPECT_EQ(scope_tree_timer_data.GetMaxDepth(), 1);
+  EXPECT_EQ(scope_tree_timer_data.GetDepth(), 2);
   EXPECT_EQ(scope_tree_timer_data.GetMinTime(), 2);
   EXPECT_EQ(scope_tree_timer_data.GetMaxTime(), 11);
 }

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -28,7 +28,7 @@ class ScopeTreeTimerData final {
   [[nodiscard]] size_t GetNumberOfTimers() const;
   [[nodiscard]] uint64_t GetMinTime() const { return timer_data_.GetMinTime(); }
   [[nodiscard]] uint64_t GetMaxTime() const { return timer_data_.GetMaxTime(); }
-  [[nodiscard]] uint32_t GetMaxDepth() const;
+  [[nodiscard]] uint32_t GetDepth() const;
 
   const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info);
   // Build ScopeTree from timer chains, when we are loading a capture.

--- a/src/Containers/ScopeTreeTest.cpp
+++ b/src/Containers/ScopeTreeTest.cpp
@@ -91,7 +91,7 @@ TEST(ScopeTree, TreeCreation) {
   tree.Insert(CreateScope(5, 8));
   tree.Insert(CreateScope(0, 200));
   tree.Insert(CreateScope(1, 100));
-  EXPECT_EQ(tree.Height(), 6);
+  EXPECT_EQ(tree.Depth(), 6);
   EXPECT_EQ(tree.Size(), 9);
   ValidateTree(tree);
 }
@@ -101,7 +101,7 @@ TEST(ScopeTree, SameTimestamps) {
   tree.Insert(CreateScope(1, 10));
   tree.Insert(CreateScope(1, 10));
   tree.Insert(CreateScope(1, 10));
-  EXPECT_EQ(tree.Height(), 3);
+  EXPECT_EQ(tree.Depth(), 3);
   EXPECT_EQ(tree.Size(), 4);
   ValidateTree(tree);
 }
@@ -113,7 +113,7 @@ TEST(ScopeTree, SameStartTimestamps) {
   tree.Insert(CreateScope(1, 100));
   ValidateTree(tree);
   tree.Insert(CreateScope(1, 50));
-  EXPECT_EQ(tree.Height(), 3);
+  EXPECT_EQ(tree.Depth(), 3);
   ValidateTree(tree);
 }
 
@@ -122,7 +122,7 @@ TEST(ScopeTree, SameEndTimestamps) {
   tree.Insert(CreateScope(3, 10));
   tree.Insert(CreateScope(1, 10));
   tree.Insert(CreateScope(2, 10));
-  EXPECT_EQ(tree.Height(), 3);
+  EXPECT_EQ(tree.Depth(), 3);
   EXPECT_EQ(tree.Size(), 4);
   ValidateTree(tree);
 }
@@ -134,7 +134,7 @@ TEST(ScopeTree, OverlappingTimers) {
   tree.Insert(CreateScope(1, 10));   // node 1 fits in node 0
   tree.Insert(CreateScope(5, 100));  // node 2 overlaps node 1, fits in node 0
   tree.Insert(CreateScope(2, 50));   // node 3 overlaps nodes 1 and 2, fits in node 0
-  EXPECT_EQ(tree.Height(), 2);
+  EXPECT_EQ(tree.Depth(), 2);
   EXPECT_EQ(tree.Size(), 5);
 
   const auto& ordered_nodes_by_depth = tree.GetOrderedNodesByDepth();

--- a/src/Containers/include/Containers/ScopeTree.h
+++ b/src/Containers/include/Containers/ScopeTree.h
@@ -45,7 +45,6 @@ class ScopeNode {
 
   [[nodiscard]] uint64_t Start() const { return scope_->start(); }
   [[nodiscard]] uint64_t End() const { return scope_->end(); }
-  [[nodiscard]] uint32_t Height() const;
   [[nodiscard]] uint32_t Depth() const { return depth_; }
   [[nodiscard]] ScopeNode* Parent() const { return parent_; }
   [[nodiscard]] size_t CountNodesInSubtree() const;
@@ -57,7 +56,6 @@ class ScopeNode {
  private:
   [[nodiscard]] ScopeNode* FindDeepestParentForNode(const ScopeNode* node);
   static void ToString(const ScopeNode* node, std::string* str, uint32_t depth = 0);
-  static void FindHeight(const ScopeNode* node, uint32_t* height, uint32_t current_height = 0);
   static void CountNodesInSubtree(const ScopeNode* node, size_t* count);
   static void GetAllNodesInSubtree(const ScopeNode* node, std::set<const ScopeNode*>* node_set);
 
@@ -85,7 +83,7 @@ class ScopeTree {
   [[nodiscard]] const ScopeNodeT* Root() const { return root_; }
   [[nodiscard]] size_t Size() const { return nodes_.size(); }
   [[nodiscard]] size_t CountOrderedNodesByDepth() const;
-  [[nodiscard]] uint32_t Height() const;
+  [[nodiscard]] uint32_t Depth() const;
   [[nodiscard]] const absl::btree_map<uint32_t,
                                       absl::btree_map<uint64_t /*start time*/, ScopeNodeT*>>&
   GetOrderedNodesByDepth() const {
@@ -228,7 +226,7 @@ size_t ScopeTree<ScopeT>::CountOrderedNodesByDepth() const {
 }
 
 template <typename ScopeT>
-uint32_t ScopeTree<ScopeT>::Height() const {
+uint32_t ScopeTree<ScopeT>::Depth() const {
   if (ordered_nodes_by_depth_.empty()) return 0;
 
   // Since `ordered_nodes_by_depth` is an ordered map, we return the depth of the last level. It
@@ -240,7 +238,7 @@ uint32_t ScopeTree<ScopeT>::Height() const {
 template <typename ScopeT>
 std::string ScopeTree<ScopeT>::ToString() const {
   std::string result =
-      absl::StrFormat("ScopeTree %u nodes height=%u:\n%s\n", Size(), Height(), root_->ToString());
+      absl::StrFormat("ScopeTree %u nodes depth=%u:\n%s\n", Size(), Depth(), root_->ToString());
   return result;
 }
 
@@ -251,23 +249,6 @@ void ScopeNode<ScopeT>::ToString(const ScopeNode* node, std::string* str, uint32
                            std::string(depth, ' '), node->scope_, node->Start(), node->End()));
   for (auto& [unused_time, child_node] : node->GetChildrenByStartTime()) {
     ToString(child_node, str, depth + 1);
-  }
-}
-
-template <typename ScopeT>
-uint32_t ScopeNode<ScopeT>::Height() const {
-  uint32_t max_height = 0;
-  FindHeight(this, &max_height);
-  return max_height;
-}
-
-template <typename ScopeT>
-void ScopeNode<ScopeT>::FindHeight(const ScopeNode* node, uint32_t* height,
-                                   uint32_t current_height) {
-  ORBIT_SCOPE_FUNCTION;
-  *height = std::max(*height, current_height);
-  for (auto& [unused_time, child_node] : node->GetChildrenByStartTime()) {
-    FindHeight(child_node, height, current_height + 1);
   }
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -194,8 +194,8 @@ bool ThreadTrack::IsTrackSelected() const {
 
 float ThreadTrack::GetDefaultBoxHeight() const {
   auto box_height = layout_->GetTextBoxHeight();
-  if (collapse_toggle_->IsCollapsed() && scope_tree_.Height() > 0) {
-    return box_height / static_cast<float>(scope_tree_.Height());
+  if (collapse_toggle_->IsCollapsed() && scope_tree_.Depth() > 0) {
+    return box_height / static_cast<float>(scope_tree_.Depth());
   }
   return box_height;
 }
@@ -325,8 +325,8 @@ std::string ThreadTrack::GetTooltip() const {
 
 float ThreadTrack::GetHeight() const {
   const uint32_t depth = collapse_toggle_->IsCollapsed()
-                             ? std::min<uint32_t>(1, scope_tree_.Height())
-                             : scope_tree_.Height();
+                             ? std::min<uint32_t>(1, scope_tree_.Depth())
+                             : scope_tree_.Depth();
 
   bool gap_between_tracks_and_timers =
       (!thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty()) &&


### PR DESCRIPTION
In this PR we are unifying all this 3 methods with Depth(). So, depth in
a ScopeTree is 0-indexed, and the function Depth() will return 0 only if
there are no timers. MaxDepth was misleading.

This is a puzzle piece inside https://github.com/google/orbit/pull/2860,
aiming to solve http://b/202110929.