### PR TITLE
Balance CoInitialize() calls with CoUninitialize() for DIA SDK usage

### DIFF
--- a/src/ObjectUtils/PdbFileDiaTest.cpp
+++ b/src/ObjectUtils/PdbFileDiaTest.cpp
@@ -10,3 +10,29 @@
 using orbit_object_utils::PdbFileDia;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(PdbFileDiaTest, PdbFileTest, ::testing::Types<PdbFileDia>);
+
+// This test is specific to using the DIA SDK to load PDB files.
+TEST(PdbFileDiaTest, CreatePdbDoesNotFailOnCoInitializeWhenAlreadyInitialized) {
+  std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
+  HRESULT result = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+  ASSERT_TRUE(result == S_OK || result == S_FALSE);
+  ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result1 =
+      PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
+  ASSERT_THAT(pdb_file_result1, HasNoError());
+  CoUninitialize();
+}
+
+// This test is specific to using the DIA SDK to load PDB files.
+TEST(PdbFileDiaTest, PdbFileProperlyUninitializesComLibrary) {
+  std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
+  {
+    ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result =
+        PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
+    ASSERT_THAT(pdb_file_result, HasNoError());
+  }
+
+  HRESULT result = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+  // This would be S_FALSE if the PdbFileDia class didn't properly balance its CoInitialize() call.
+  ASSERT_EQ(result, S_OK);
+  CoUninitialize();
+}

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -4,6 +4,8 @@
 
 #include "PdbFileLlvm.h"
 
+#include <absl/memory/memory.h>
+
 #include <memory>
 
 #include "ObjectUtils/CoffFile.h"
@@ -130,7 +132,8 @@ ErrorMessageOr<std::unique_ptr<PdbFile>> PdbFileLlvm::CreatePdbFile(
     return ErrorMessage(absl::StrFormat("Unable to load PDB file %s with error: %s",
                                         file_path.string(), llvm::toString(std::move(error))));
   }
-  return std::make_unique<PdbFileLlvm>(file_path, object_file_info, std::move(session));
+  return absl::WrapUnique<PdbFileLlvm>(
+      new PdbFileLlvm(file_path, object_file_info, std::move(session)));
 }
 
 }  // namespace orbit_object_utils

--- a/src/ObjectUtils/PdbFileLlvm.h
+++ b/src/ObjectUtils/PdbFileLlvm.h
@@ -33,9 +33,6 @@ namespace orbit_object_utils {
 
 class PdbFileLlvm : public PdbFile {
  public:
-  PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& object_file_info,
-              std::unique_ptr<llvm::pdb::IPDBSession> session);
-
   [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadDebugSymbols() override;
   [[nodiscard]] const std::filesystem::path& GetFilePath() const override { return file_path_; }
 
@@ -58,6 +55,9 @@ class PdbFileLlvm : public PdbFile {
       const std::filesystem::path& file_path, const ObjectFileInfo& object_file_info);
 
  private:
+  PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& object_file_info,
+              std::unique_ptr<llvm::pdb::IPDBSession> session);
+
   std::filesystem::path file_path_;
   ObjectFileInfo object_file_info_;
   std::unique_ptr<llvm::pdb::IPDBSession> session_;


### PR DESCRIPTION
Every successful call (return value S_OK or S_FALSE) to CoInitialize()
has to be balanced with a corresponding call to CoUninitialize(). We use
an initialization member in PdbFileDia that on construction calls
CoInitialize() and on destruction calls CoUninitialize() if the original
initialization was successful. This, together with the right declaration
order of members of PdbFileDia, ensures that uninitialization happens
only after any COM data structures used by PdbFileDia have been
destructed.

Technique from:
https://devblogs.microsoft.com/oldnewthing/20040520-00/?p=39243

We also use CoInitializeEx() instead of CoInitialize() as recommended by
Microsoft documentation:
https://docs.microsoft.com/en-us/windows/win32/api/objbase/nf-objbase-coinitialize

Added tests for proper initialization handling.