### PR TITLE
Fixed target label size when just changing the folder

### DIFF
--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -88,16 +88,19 @@ void TargetLabel::ChangeToFileTarget(const FileTarget& file_target) {
 }
 
 void TargetLabel::SetFile(const std::filesystem::path& file_path) {
-  // Without this, the size of the target label is not correctly updated when a capture is opened
-  // directly from the connection window. It's unclear why this happens, might be related to
-  // multiple `SizeChanged` signals being emitted while the main window is still being shown.
-  if (file_path_ == file_path) return;
+  std::optional<std::filesystem::path> old_path = file_path_;
 
   file_path_ = file_path;
   ui_->fileLabel->setText(QString::fromStdString(file_path.filename().string()));
   ui_->fileLabel->setToolTip(QString::fromStdString(file_path.string()));
   ui_->fileLabel->setVisible(true);
-  emit SizeChanged();
+
+  // Without this, the size of the target label is not correctly updated when a capture is opened
+  // directly from the connection window. It's unclear why this happens, might be related to
+  // multiple `SizeChanged` signals being emitted while the main window is still being shown.
+  if (!old_path.has_value() || (old_path->filename() != file_path.filename())) {
+    emit SizeChanged();
+  }
 }
 
 void TargetLabel::ChangeToFileTarget(const fs::path& path) {


### PR DESCRIPTION
Bug: b/200796899

Test: Move a capture file to a different folder without changing the name (using "Rename / Move Capture File") -> Target label looks correct