### PR TITLE
Make CaptureFinished also a ProducerCaptureEvent for consistency

### DIFF
--- a/src/CaptureService/CaptureServiceImpl.cpp
+++ b/src/CaptureService/CaptureServiceImpl.cpp
@@ -322,8 +322,8 @@ static void StopInternalProducersAndCaptureStartStopListenersInParallel(
   return event;
 }
 
-[[nodiscard]] static ClientCaptureEvent CreateCaptureFinishedEvent() {
-  ClientCaptureEvent event;
+[[nodiscard]] static ProducerCaptureEvent CreateCaptureFinishedEvent() {
+  ProducerCaptureEvent event;
   CaptureFinished* capture_finished = event.mutable_capture_finished();
   capture_finished->set_status(CaptureFinished::kSuccessful);
   return event;
@@ -466,7 +466,8 @@ grpc::Status CaptureServiceImpl::Capture(
   // The destructor of IntrospectionListener takes care of actually disabling introspection.
   introspection_listener.reset();
 
-  capture_event_buffer.AddEvent(CreateCaptureFinishedEvent());
+  producer_event_processor->ProcessEvent(orbit_grpc_protos::kRootProducerId,
+                                         CreateCaptureFinishedEvent());
 
   capture_event_buffer.StopAndWait();
   LOG("Finished handling gRPC call to Capture: all capture data has been sent");

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -740,7 +740,7 @@ message ProducerCaptureEvent {
     // numbers starting with 16.
     //
     // Next high-frequency ID: 13
-    // Next lower-frequency ID: 46
+    // Next lower-frequency ID: 47
     //
     // Please keep these alphabetically ordered.
     ApiEvent api_event = 10;
@@ -756,6 +756,7 @@ message ProducerCaptureEvent {
     ApiTrackUint api_track_uint = 43;
     ApiTrackUint64 api_track_uint64 = 44;
     CallstackSample callstack_sample = 1;
+    CaptureFinished capture_finished = 46;
     CaptureStarted capture_started = 23;
     ClockResolutionEvent clock_resolution_event = 32;
     ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event = 31;

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -457,6 +457,8 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
       case orbit_grpc_protos::ProducerCaptureEvent::kCaptureStarted:
         // TracingHandler does not send this event.
         UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kCaptureFinished:
+        UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kSchedulingSlice:
         EXPECT_GE(event.scheduling_slice().out_timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.scheduling_slice().out_timestamp_ns();


### PR DESCRIPTION
Looking at `CaptureServiceImpl`, all events produced there (with
`kRootProducerId`) are `ProducerCaptureEvent`s, that then
`ProducerEventProcessor` makes `ClientCaptureEvent`s. The simplest example is
`CaptureStarted`.
But this wasn't the case for `CaptureFinished`, which was added directly to
`capture_event_buffer`, which is instead only supposed to be used by
`ProducerEventProcessor`. So we fix the inconsistency.

Test: Capture Trata.