### PR TITLE
Use AppInterface in TracepointsDataView

### DIFF
--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -77,6 +77,10 @@ class MockAppInterface : public AppInterface {
 
   MOCK_METHOD(void, Disassemble, (uint32_t pid, const orbit_client_protos::FunctionInfo&));
   MOCK_METHOD(void, ShowSourceCode, (const orbit_client_protos::FunctionInfo&));
+
+  MOCK_METHOD(bool, IsTracepointSelected, (const orbit_grpc_protos::TracepointInfo&), (const));
+  MOCK_METHOD(void, SelectTracepoint, (const orbit_grpc_protos::TracepointInfo&));
+  MOCK_METHOD(void, DeselectTracepoint, (const orbit_grpc_protos::TracepointInfo&));
 };
 
 }  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -18,6 +18,7 @@
 #include "OrbitBase/Future.h"
 #include "PresetFile/PresetFile.h"
 #include "capture_data.pb.h"
+#include "tracepoint.pb.h"
 
 namespace orbit_data_views {
 
@@ -68,6 +69,12 @@ class AppInterface {
   virtual void OnValidateFramePointers(
       std::vector<const orbit_client_data::ModuleData*> modules_to_validate) = 0;
   virtual void UpdateProcessAndModuleList() = 0;
+
+  // Functions needed by TracepointsDataView
+  virtual void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info) = 0;
+  virtual void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint) = 0;
+  [[nodiscard]] virtual bool IsTracepointSelected(
+      const orbit_grpc_protos::TracepointInfo& info) const = 0;
 
   // This needs to be called from the main thread.
   [[nodiscard]] virtual bool IsCaptureConnected(

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -448,10 +448,11 @@ class OrbitApp final : public DataViewFactory,
       const std::vector<orbit_client_protos::CallstackEvent>& selected_callstack_events,
       uint32_t thread_id);
 
-  void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info);
-  void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint);
+  void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info) override;
+  void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint) override;
 
-  [[nodiscard]] bool IsTracepointSelected(const orbit_grpc_protos::TracepointInfo& info) const;
+  [[nodiscard]] bool IsTracepointSelected(
+      const orbit_grpc_protos::TracepointInfo& info) const override;
 
   // Only enables the frame track in the capture settings (in DataManager) and does not
   // add a frame track to the current capture data.

--- a/src/OrbitGl/TracepointsDataView.cpp
+++ b/src/OrbitGl/TracepointsDataView.cpp
@@ -24,8 +24,8 @@ static const std::string kMenuActionSelect = "Hook";
 static const std::string kMenuActionUnselect = "Unhook";
 }  // namespace
 
-TracepointsDataView::TracepointsDataView(OrbitApp* app)
-    : orbit_data_views::DataView(orbit_data_views::DataViewType::kTracepoints, app), app_{app} {}
+TracepointsDataView::TracepointsDataView(orbit_data_views::AppInterface* app)
+    : orbit_data_views::DataView(orbit_data_views::DataViewType::kTracepoints, app) {}
 
 const std::vector<orbit_data_views::DataView::Column>& TracepointsDataView::GetColumns() {
   static const std::vector<Column>& columns = [] {

--- a/src/OrbitGl/TracepointsDataView.h
+++ b/src/OrbitGl/TracepointsDataView.h
@@ -11,14 +11,13 @@
 #include <string>
 #include <vector>
 
+#include "DataViews/AppInterface.h"
 #include "DataViews/DataView.h"
 #include "tracepoint.pb.h"
 
-class OrbitApp;
-
 class TracepointsDataView : public orbit_data_views::DataView {
  public:
-  explicit TracepointsDataView(OrbitApp* app);
+  explicit TracepointsDataView(orbit_data_views::AppInterface* app);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnCategory; }
@@ -41,10 +40,6 @@ class TracepointsDataView : public orbit_data_views::DataView {
   enum ColumnIndex { kColumnSelected, kColumnCategory, kColumnName, kNumColumns };
 
   const orbit_grpc_protos::TracepointInfo& GetTracepoint(uint32_t row) const;
-
-  // TODO(b/185090791): This is temporary and will be removed once this data view has been ported
-  // and move to orbit_data_views.
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_TRACEPOINTS_DATA_VIEW_H_


### PR DESCRIPTION
With this change, we made TracepointsDataView independent of OrbitApp by
changing it to use AppInterface.

Bug: http://b/185090791