### PR TITLE
Fix retry ssh credential loading bug

### DIFF
--- a/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
@@ -111,7 +111,7 @@ class ConnectToStadiaWidget : public QWidget {
   QState s_connected_;
 
   absl::flat_hash_set<std::string> instance_credentials_loading_;
-  absl::flat_hash_map<std::string, ErrorMessageOr<orbit_ssh::Credentials>> instance_credentials_;
+  absl::flat_hash_map<std::string, orbit_ssh::Credentials> instance_credentials_;
 
   void DetachRadioButton();
   void SetupStateMachine();


### PR DESCRIPTION
Beforehand, ConnectToStadiaWidget saved the result of loading ssh
credentials, even when a error occured. This meant retrying to load the
credentials was not possible. This is now fixed, by only displaying the
error and not saving it.

http://b/201073283