### PR TITLE
Fix race condition bug in ExecuteProcess

### DIFF
--- a/src/QtUtils/ExecuteProcessTest.cpp
+++ b/src/QtUtils/ExecuteProcessTest.cpp
@@ -260,4 +260,119 @@ TEST(QtUtilsExecuteProcess, ParentGetsDeletedWhileExecuting) {
   EXPECT_TRUE(lambda_was_called);
 }
 
+TEST(QtUtilsExecuteProcess, ProcessFinishAndTimeoutRace) {
+  AssertNoQtLogWarnings message_handler{};
+  std::shared_ptr<MainThreadExecutor> mte = MainThreadExecutorImpl::Create();
+
+  QString program =
+      QString::fromStdString((orbit_base::GetExecutableDir() / "FakeCliProgram").string());
+
+  // Note the sleep for the process and the timer timeout are both 100ms. This means the outcome can
+  // be either a success or timeout.
+  Future<ErrorMessageOr<QByteArray>> future =
+      ExecuteProcess(program, QStringList{"--sleep_for_ms", "100"}, QApplication::instance(),
+                     absl::Milliseconds(100));
+
+  bool lambda_was_called = false;
+  future.Then(mte.get(), [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
+    EXPECT_FALSE(lambda_was_called);
+    lambda_was_called = true;
+
+    if (result.has_error()) {
+      EXPECT_THAT(result, HasError("timed out after 100ms"));
+    } else {
+      ASSERT_THAT(result, HasValue());
+      EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Some example output"));
+      EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Slept for 100ms"));
+    }
+
+    // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
+    // process), which is queued in the event loop.
+    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+  });
+
+  QApplication::exec();
+
+  EXPECT_TRUE(lambda_was_called);
+}
+
+TEST(QtUtilsExecuteProcess, ProcessFinishAndParentGetsDeletedRace) {
+  AssertNoQtLogWarnings message_handler{};
+  std::shared_ptr<MainThreadExecutor> mte = MainThreadExecutorImpl::Create();
+
+  QString program =
+      QString::fromStdString((orbit_base::GetExecutableDir() / "FakeCliProgram").string());
+
+  QObject* parent_object = new QObject{};
+
+  // Note the sleep for the process is 100ms and the parent is also deleted after 100ms. This means
+  // the outcome can be either a success or a parent deleted error.
+  Future<ErrorMessageOr<QByteArray>> future =
+      ExecuteProcess(program, QStringList{"--sleep_for_ms", "100"}, parent_object);
+
+  bool lambda_was_called = false;
+  future.Then(mte.get(), [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
+    EXPECT_FALSE(lambda_was_called);
+    lambda_was_called = true;
+
+    if (result.has_error()) {
+      EXPECT_THAT(result, HasError("killed because the parent object was destroyed"));
+    } else {
+      ASSERT_THAT(result, HasValue());
+      EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Some example output"));
+      EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Slept for 100ms"));
+    }
+
+    // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
+    // process), which is queued in the event loop.
+    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+  });
+
+  QTimer::singleShot(100, parent_object, &QObject::deleteLater);
+
+  QApplication::exec();
+
+  EXPECT_TRUE(lambda_was_called);
+}
+
+TEST(QtUtilsExecuteProcess, TimeoutAndParentGetsDeletedRace) {
+  AssertNoQtLogWarnings message_handler{};
+  std::shared_ptr<MainThreadExecutor> mte = MainThreadExecutorImpl::Create();
+
+  QString program =
+      QString::fromStdString((orbit_base::GetExecutableDir() / "FakeCliProgram").string());
+
+  QObject* parent_object = new QObject{};
+
+  // Note the timeout is 100ms and the parent is also deleted after 100ms. This means the outcome
+  // can be either error
+  Future<ErrorMessageOr<QByteArray>> future = ExecuteProcess(
+      program, QStringList{"--sleep_for_ms", "500"}, parent_object, absl::Milliseconds(100));
+
+  bool lambda_was_called = false;
+  future.Then(mte.get(), [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
+    EXPECT_FALSE(lambda_was_called);
+    lambda_was_called = true;
+
+    ASSERT_TRUE(result.has_error());
+
+    const std::string& error_message = result.error().message();
+    bool timeout_error_occurred = absl::StrContains(error_message, "timed out after 100ms");
+    bool parent_deleted_error_occurred =
+        absl::StrContains(error_message, "killed because the parent object was destroyed");
+
+    EXPECT_TRUE(timeout_error_occurred || parent_deleted_error_occurred);
+
+    // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
+    // process), which is queued in the event loop.
+    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+  });
+
+  QTimer::singleShot(100, parent_object, &QObject::deleteLater);
+
+  QApplication::exec();
+
+  EXPECT_TRUE(lambda_was_called);
+}
+
 }  // namespace orbit_qt_utils


### PR DESCRIPTION
This gracefully handles situations in ExecuteProcess, when things
happen at a similar time. This can be the process finishing, the parent
getting deleted and the timout occurring. It also adds tests for this.

http://b/203371077