### PR TITLE
Make Tracer an interface; TracerThread, now TracerImpl, implements it

### DIFF
--- a/src/CaptureService/TracingHandler.cpp
+++ b/src/CaptureService/TracingHandler.cpp
@@ -26,10 +26,9 @@ using orbit_grpc_protos::ThreadStateSlice;
 
 using orbit_grpc_protos::kLinuxTracingProducerId;
 
-void TracingHandler::Start(CaptureOptions capture_options) {
+void TracingHandler::Start(const CaptureOptions& capture_options) {
   CHECK(tracer_ == nullptr);
-  tracer_ = std::make_unique<orbit_linux_tracing::Tracer>(std::move(capture_options));
-  tracer_->SetListener(this);
+  tracer_ = orbit_linux_tracing::Tracer::Create(capture_options, this);
   tracer_->Start();
 }
 

--- a/src/CaptureService/TracingHandler.h
+++ b/src/CaptureService/TracingHandler.h
@@ -33,7 +33,7 @@ class TracingHandler : public orbit_linux_tracing::TracerListener {
   TracingHandler(TracingHandler&&) = delete;
   TracingHandler& operator=(TracingHandler&&) = delete;
 
-  void Start(orbit_grpc_protos::CaptureOptions capture_options);
+  void Start(const orbit_grpc_protos::CaptureOptions& capture_options);
   void Stop();
 
   void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) override;

--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -53,8 +53,8 @@ target_sources(LinuxTracing PRIVATE
         ThreadStateManager.cpp
         ThreadStateManager.h
         Tracer.cpp
-        TracerThread.cpp
-        TracerThread.h
+        TracerImpl.cpp
+        TracerImpl.h
         UprobesFunctionCallManager.h
         UprobesReturnAddressManager.h
         UprobesUnwindingVisitor.cpp

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -234,8 +234,7 @@ inline uint64_t GetTimestamp(const PerfEvent& event) {
 }
 
 inline int GetOrderedInFileDescriptor(const PerfEvent& event) {
-  return std::visit([](const auto& arg) -> uint64_t { return arg.ordered_in_file_descriptor; },
-                    event);
+  return std::visit([](const auto& arg) -> int { return arg.ordered_in_file_descriptor; }, event);
 }
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/Tracer.cpp
+++ b/src/LinuxTracing/Tracer.cpp
@@ -4,16 +4,15 @@
 
 #include "LinuxTracing/Tracer.h"
 
-#include "OrbitBase/ThreadUtils.h"
-#include "TracerThread.h"
+#include <memory>
+
+#include "TracerImpl.h"
 
 namespace orbit_linux_tracing {
 
-void Tracer::Run() {
-  orbit_base::SetCurrentThreadName("Tracer::Run");
-  TracerThread session{capture_options_};
-  session.SetListener(listener_);
-  session.Run(exit_requested_);
+std::unique_ptr<Tracer> Tracer::Create(const orbit_grpc_protos::CaptureOptions& capture_options,
+                                       TracerListener* listener) {
+  return std::make_unique<TracerImpl>(capture_options, listener);
 }
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/include/LinuxTracing/Tracer.h
+++ b/src/LinuxTracing/include/LinuxTracing/Tracer.h
@@ -17,43 +17,13 @@ namespace orbit_linux_tracing {
 
 class Tracer {
  public:
-  explicit Tracer(orbit_grpc_protos::CaptureOptions capture_options)
-      : capture_options_{std::move(capture_options)} {}
+  virtual void Start() = 0;
+  virtual void Stop() = 0;
 
-  ~Tracer() { Stop(); }
+  virtual ~Tracer() = default;
 
-  Tracer(const Tracer&) = delete;
-  Tracer& operator=(const Tracer&) = delete;
-  Tracer(Tracer&&) = default;
-  Tracer& operator=(Tracer&&) = default;
-
-  void SetListener(TracerListener* listener) { listener_ = listener; }
-
-  void Start() {
-    *exit_requested_ = false;
-    thread_ = std::make_shared<std::thread>(&Tracer::Run, this);
-  }
-
-  void Stop() {
-    *exit_requested_ = true;
-    if (thread_ != nullptr && thread_->joinable()) {
-      thread_->join();
-    }
-    thread_.reset();
-  }
-
- private:
-  orbit_grpc_protos::CaptureOptions capture_options_;
-
-  TracerListener* listener_ = nullptr;
-
-  // exit_requested_ must outlive this object because it is used by thread_.
-  // The control block of shared_ptr is thread safe (i.e., reference counting
-  // and pointee's lifetime management are atomic and thread safe).
-  std::shared_ptr<std::atomic<bool>> exit_requested_ = std::make_unique<std::atomic<bool>>(true);
-  std::shared_ptr<std::thread> thread_;
-
-  void Run();
+  [[nodiscard]] static std::unique_ptr<Tracer> Create(
+      const orbit_grpc_protos::CaptureOptions& capture_options, TracerListener* listener);
 };
 
 }  // namespace orbit_linux_tracing


### PR DESCRIPTION
Previously, `Tracer` and `TracerThread` were two distinct components, with the
former containing some initialization code and the latter containing the
remaining of the code.
This change moves also the initialization code to `TracerThread`, which is now
`TracerImpl`. `Tracer` is now only the interface that `TracerImpl` implements.
This is now a bit easier to understand and makes it slightly cleaner to add
methods to `Tracer`/`TracerImpl` that might be called during a capture (e.g., in
the context of
http://go/stadia-orbit-user-space-instrumentation-and-unwinding#heading=h.a3i5cfh8pexm).
The structure is also now more similar to `WindowsTracing`.

Test: Run `LinuxTracingIntegrationTests`. Take some captures on Trata.