### PR TITLE
Clean shutdown

### DIFF
--- a/src/OrbitSshQt/Error.cpp
+++ b/src/OrbitSshQt/Error.cpp
@@ -24,6 +24,8 @@ std::string ErrorCategory::message(int condition) const {
       return "The local socket was closed.";
     case Error::kCouldNotOpenFile:
       return "Could not open file.";
+    case Error::kOrbitServiceShutdownTimedout:
+      return "Shut down of OrbitService timed out.";
   }
 
   return absl::StrFormat("Unkown error condition: %i.", condition);

--- a/src/OrbitSshQt/Task.cpp
+++ b/src/OrbitSshQt/Task.cpp
@@ -7,6 +7,7 @@
 #include <absl/base/macros.h>
 
 #include <QTimer>
+#include <chrono>
 #include <type_traits>
 #include <utility>
 
@@ -15,7 +16,7 @@
 #include "OrbitSshQt/Error.h"
 
 // Maximum time that the shutdown is allowed to take.
-constexpr const int kShutdownTimeoutMs{2000};
+constexpr const std::chrono::milliseconds kShutdownTimeoutMs{2000};
 
 namespace orbit_ssh_qt {
 

--- a/src/OrbitSshQt/Task.cpp
+++ b/src/OrbitSshQt/Task.cpp
@@ -178,7 +178,7 @@ outcome::result<void> Task::shutdown() {
     case State::kSignalEOF: {
       OUTCOME_TRY(channel_->SendEOF());
       SetState(State::kWaitRemoteEOF);
-      break;
+      ABSL_FALLTHROUGH_INTENDED;
     }
     case State::kWaitRemoteEOF: {
       OUTCOME_TRY(channel_->WaitRemoteEOF());

--- a/src/OrbitSshQt/Tunnel.cpp
+++ b/src/OrbitSshQt/Tunnel.cpp
@@ -56,7 +56,13 @@ void Tunnel::Start() {
 }
 
 void Tunnel::Stop() {
+  // Tunnel::Stop is currently called from 2 different locations. 1. When the local_socket_ signals
+  // a disconnect and 2. from ServiceDeployManager::ShutdownTunnel. If 1. happens before 2.,
+  // ShutdownTunnel will wait forever for a stopped signal. This is here solved by emitting
+  // stopped() when the Tunnel is already stopped.
+
   if (CurrentState() == State::kError || CurrentState() == State::kDone) {
+    // TODO (b/208613682) Tunnel::Stop should return a future and not use the stopped signal anymore
     emit stopped();
     return;
   }
@@ -65,6 +71,7 @@ void Tunnel::Stop() {
     SetState(State::kDone);
     deleteByEventLoop(this, &local_server_);
     channel_ = std::nullopt;
+    // TODO (b/208613682) Tunnel::Stop should return a future and not use the stopped signal anymore
     emit stopped();
     return;
   }

--- a/src/OrbitSshQt/Tunnel.cpp
+++ b/src/OrbitSshQt/Tunnel.cpp
@@ -56,7 +56,8 @@ void Tunnel::Start() {
 }
 
 void Tunnel::Stop() {
-  if (CurrentState() == State::kError) {
+  if (CurrentState() == State::kError || CurrentState() == State::kDone) {
+    emit stopped();
     return;
   }
 
@@ -64,6 +65,8 @@ void Tunnel::Stop() {
     SetState(State::kDone);
     deleteByEventLoop(this, &local_server_);
     channel_ = std::nullopt;
+    emit stopped();
+    return;
   }
 
   if (CurrentState() == State::kServerListening) {

--- a/src/OrbitSshQt/Tunnel.cpp
+++ b/src/OrbitSshQt/Tunnel.cpp
@@ -114,6 +114,7 @@ outcome::result<void> Tunnel::startup() {
     case State::kShutdown:
     case State::kFlushing:
     case State::kSendEOF:
+    case State::kWaitRemoteEOF:
     case State::kClosingChannel:
     case State::kWaitRemoteClosed:
     case State::kDone:
@@ -142,6 +143,11 @@ outcome::result<void> Tunnel::shutdown() {
     }
     case State::kSendEOF: {
       OUTCOME_TRY(channel_->SendEOF());
+      SetState(State::kWaitRemoteEOF);
+      ABSL_FALLTHROUGH_INTENDED;
+    }
+    case State::kWaitRemoteEOF: {
+      OUTCOME_TRY(channel_->WaitRemoteEOF());
       SetState(State::kClosingChannel);
       ABSL_FALLTHROUGH_INTENDED;
     }

--- a/src/OrbitSshQt/include/OrbitSshQt/Error.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Error.h
@@ -18,7 +18,8 @@ enum class Error {
   kCouldNotListen,
   kRemoteSocketClosed,
   kLocalSocketClosed,
-  kCouldNotOpenFile
+  kCouldNotOpenFile,
+  kOrbitServiceShutdownTimedout
 };
 
 struct ErrorCategory : std::error_category {

--- a/src/OrbitSshQt/include/OrbitSshQt/Tunnel.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Tunnel.h
@@ -35,6 +35,7 @@ enum class TunnelState {
   kShutdown,
   kFlushing,
   kSendEOF,
+  kWaitRemoteEOF,
   kClosingChannel,
   kWaitRemoteClosed,
   kDone,

--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -338,11 +338,6 @@ void ConnectToStadiaWidget::DeployOrbitService() {
 
 void ConnectToStadiaWidget::Disconnect() {
   grpc_channel_ = nullptr;
-
-  // TODO(b/174561221) currently does not work
-  // if (service_deploy_manager_ != nullptr) {
-  //   service_deploy_manager_->Shutdown();
-  // }
   service_deploy_manager_ = nullptr;
   ui_->rememberCheckBox->setChecked(false);
 

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -136,10 +136,7 @@ ServiceDeployManager::ServiceDeployManager(const DeploymentConfiguration* deploy
 }
 
 ServiceDeployManager::~ServiceDeployManager() {
-  // ssh_watchdog_timer is registered in background_thread_, so it has to be stopped there to
-  // not trigger a race condition.
-  QMetaObject::invokeMethod(
-      this, [this]() { ssh_watchdog_timer_.stop(); }, Qt::BlockingQueuedConnection);
+  Shutdown();
   background_thread_.quit();
   background_thread_.wait();
 }
@@ -695,6 +692,7 @@ outcome::result<void> ServiceDeployManager::ShutdownSession(orbit_ssh_qt::Sessio
 }
 
 void ServiceDeployManager::Shutdown() {
+  SCOPED_TIMED_LOG("ServiceDeployManager::Shutdown");
   DeferToBackgroundThreadAndWait(this, [this]() {
     if (sftp_channel_ != nullptr) {
       (void)ShutdownSftpChannel(sftp_channel_.get());

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -657,7 +657,7 @@ void ServiceDeployManager::ShutdownTunnel(std::optional<orbit_ssh_qt::Tunnel>* t
   }
 
   orbit_qt_utils::EventLoop loop{};
-  auto quit_handler = ConnectQuitHandler(&loop, &tunnel->value(), &orbit_ssh_qt::Tunnel::started);
+  auto quit_handler = ConnectQuitHandler(&loop, &tunnel->value(), &orbit_ssh_qt::Tunnel::stopped);
   auto error_handler =
       ConnectQuitHandler(&loop, &tunnel->value(), &orbit_ssh_qt::Tunnel::errorOccurred);
   auto cancel_handler = ConnectCancelHandler(&loop, this);

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -551,11 +551,8 @@ void ServiceDeployManager::StartWatchdog() {
   orbit_service_task_->Write(kSshWatchdogPassphrase);
 
   QObject::connect(&ssh_watchdog_timer_, &QTimer::timeout, [this]() {
-    if (orbit_service_task_) {
-      orbit_service_task_->Write(".");
-    } else {
-      ssh_watchdog_timer_.stop();
-    }
+    CHECK(orbit_service_task_.has_value());
+    orbit_service_task_->Write(".");
   });
 
   ssh_watchdog_timer_.start(kSshWatchdogInterval);
@@ -711,6 +708,7 @@ void ServiceDeployManager::Shutdown() {
       (void)ShutdownTunnel(&grpc_tunnel_.value());
       grpc_tunnel_ = std::nullopt;
     }
+    ssh_watchdog_timer_.stop();
     ShutdownOrbitService();
     ShutdownSession();
   });

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -89,6 +89,7 @@ class ServiceDeployManager : public QObject {
   outcome::result<void> ShutdownSftpChannel(orbit_ssh_qt::SftpChannel* sftp_channel);
   outcome::result<void> ShutdownTunnel(orbit_ssh_qt::Tunnel* tunnel);
   outcome::result<void> ShutdownTask(orbit_ssh_qt::Task* task);
+  outcome::result<void> ShutdownSession(orbit_ssh_qt::Session* session);
   outcome::result<void> CopyFileToRemote(
       const std::string& source, const std::string& dest,
       orbit_ssh_qt::SftpCopyToRemoteOperation::FileMode dest_mode);
@@ -97,7 +98,6 @@ class ServiceDeployManager : public QObject {
   outcome::result<GrpcPort> ExecImpl();
 
   void StartWatchdog();
-  void ShutdownSession();
 
   void handleSocketError(std::error_code);
 };

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -87,6 +87,7 @@ class ServiceDeployManager : public QObject {
   outcome::result<uint16_t> StartTunnel(std::optional<orbit_ssh_qt::Tunnel>* tunnel, uint16_t port);
   outcome::result<std::unique_ptr<orbit_ssh_qt::SftpChannel>> StartSftpChannel();
   outcome::result<void> ShutdownSftpChannel(orbit_ssh_qt::SftpChannel* sftp_channel);
+  outcome::result<void> ShutdownTunnel(orbit_ssh_qt::Tunnel* tunnel);
   outcome::result<void> CopyFileToRemote(
       const std::string& source, const std::string& dest,
       orbit_ssh_qt::SftpCopyToRemoteOperation::FileMode dest_mode);
@@ -97,7 +98,6 @@ class ServiceDeployManager : public QObject {
   void StartWatchdog();
   void ShutdownSession();
   void ShutdownOrbitService();
-  void ShutdownTunnel(std::optional<orbit_ssh_qt::Tunnel>*);
 
   void handleSocketError(std::error_code);
 };

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -86,7 +86,7 @@ class ServiceDeployManager : public QObject {
       const BareExecutableAndRootPasswordDeployment& config);
   outcome::result<uint16_t> StartTunnel(std::optional<orbit_ssh_qt::Tunnel>* tunnel, uint16_t port);
   outcome::result<std::unique_ptr<orbit_ssh_qt::SftpChannel>> StartSftpChannel();
-  outcome::result<void> StopSftpChannel(orbit_ssh_qt::SftpChannel* sftp_channel);
+  outcome::result<void> ShutdownSftpChannel(orbit_ssh_qt::SftpChannel* sftp_channel);
   outcome::result<void> CopyFileToRemote(
       const std::string& source, const std::string& dest,
       orbit_ssh_qt::SftpCopyToRemoteOperation::FileMode dest_mode);
@@ -95,7 +95,6 @@ class ServiceDeployManager : public QObject {
   outcome::result<GrpcPort> ExecImpl();
 
   void StartWatchdog();
-  void StopSftpChannel();
   void ShutdownSession();
   void ShutdownOrbitService();
   void ShutdownTunnel(std::optional<orbit_ssh_qt::Tunnel>*);

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -88,6 +88,7 @@ class ServiceDeployManager : public QObject {
   outcome::result<std::unique_ptr<orbit_ssh_qt::SftpChannel>> StartSftpChannel();
   outcome::result<void> ShutdownSftpChannel(orbit_ssh_qt::SftpChannel* sftp_channel);
   outcome::result<void> ShutdownTunnel(orbit_ssh_qt::Tunnel* tunnel);
+  outcome::result<void> ShutdownTask(orbit_ssh_qt::Task* task);
   outcome::result<void> CopyFileToRemote(
       const std::string& source, const std::string& dest,
       orbit_ssh_qt::SftpCopyToRemoteOperation::FileMode dest_mode);
@@ -97,7 +98,6 @@ class ServiceDeployManager : public QObject {
 
   void StartWatchdog();
   void ShutdownSession();
-  void ShutdownOrbitService();
 
   void handleSocketError(std::error_code);
 };


### PR DESCRIPTION
This is a draft of how a clean shutdown of ServiceDeployManager could look like. 

It is sadly rather a pile of fixes than a clean PR, mainly because the `Stop()` of different classes does not behave nicely. 