### PR TITLE
Add stack_pointer parameter to user space instrumentation's EntryPayload

### DIFF
--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -89,10 +89,11 @@ class LockFreeUserSpaceInstrumentationEventProducer
 
 void StartNewCapture() { start_current_capture_timestamp = CaptureTimestampNs(); }
 
-void EntryPayload(uint64_t return_address, uint64_t function_id) {
+void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t /*stack_pointer*/) {
   const uint64_t timestamp_on_entry_ns = CaptureTimestampNs();
   auto& open_function_call_stack = GetOpenFunctionCallStack();
   open_function_call_stack.emplace(return_address, function_id, timestamp_on_entry_ns);
+  // TODO(b/194704608): Communicate stack_pointer to OrbitService for DWARF unwinding.
 }
 
 uint64_t ExitPayload() {

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
@@ -11,9 +11,9 @@
 extern "C" void StartNewCapture();
 
 // Payload called on entry of an instrumented function. Needs to record the return address of the
-// function (in order to have it available in `ExitPayload`). `function_id` is the id of the
-// instrumented function.
-extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id);
+// function (in order to have it available in `ExitPayload`) and the stack pointer (i.e., the
+// address of the return address). `function_id` is the id of the instrumented function.
+extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer);
 
 // Payload called on exit of an instrumented function. Needs to return the actual return address of
 // the function such that the execution can be continued there.

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
@@ -18,9 +18,9 @@ extern "C" uint64_t TrivialSum(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p
                                uint64_t p5);
 
 // Payload called on entry of an instrumented function. Needs to record the return address of the
-// function (in order to have it available in `ExitPayload`). `function_id` is the id of the
-// instrumented function.
-extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id);
+// function (in order to have it available in `ExitPayload`) and the stack pointer (i.e., the
+// address of the return address). `function_id` is the id of the instrumented function.
+extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer);
 
 // Payload called on exit of an instrumented function. Needs to return the actual return address of
 // the function such that the execution can be continued there.
@@ -31,15 +31,18 @@ extern "C" uint64_t ExitPayload();
 // aligned to 16 bytes before calling this EntryPayload.
 // We are assuming that this function updates the frame pointer, i.e., that it starts with
 // `push rbp; mov rbp, rsp`.
-extern "C" void EntryPayloadAlignedCopy(uint64_t return_address, uint64_t function_id);
+extern "C" void EntryPayloadAlignedCopy(uint64_t return_address, uint64_t function_id,
+                                        uint64_t stack_pointer);
 
 // Overwrites rdi, rsi, rdx, rcx, r8, r9, rax, r10. These registers are used to hand over parameters
 // to a called function. This function is used to assert our backup of these registers works
 // properly. The two functions below do the same thing for SSE/AVX registers that can be used to
 // hand over floating point parameters.
-extern "C" void EntryPayloadClobberParameterRegisters(uint64_t return_address,
-                                                      uint64_t function_id);
-extern "C" void EntryPayloadClobberXmmRegisters(uint64_t return_address, uint64_t function_id);
-extern "C" void EntryPayloadClobberYmmRegisters(uint64_t return_address, uint64_t function_id);
+extern "C" void EntryPayloadClobberParameterRegisters(uint64_t return_address, uint64_t function_id,
+                                                      uint64_t stack_pointer);
+extern "C" void EntryPayloadClobberXmmRegisters(uint64_t return_address, uint64_t function_id,
+                                                uint64_t stack_pointer);
+extern "C" void EntryPayloadClobberYmmRegisters(uint64_t return_address, uint64_t function_id,
+                                                uint64_t stack_pointer);
 
 #endif  // USER_SPACE_INSTRUMENTATION_TEST_LIB_H_


### PR DESCRIPTION
Now unused, the plan is to somehow send it to OrbitService so that it can be
used to insert the original return address in the right position in a stack
sample before DWARF unwinding.

Bug: http://b/194704608

Test: Run unit tests. Tried as part of the full prototype for integration of
user space instrumentation and unwinding as per
http://b/go/stadia-orbit-user-space-instrumentation-and-unwinding#heading=h.a3i5cfh8pexm