### PR TITLE
Create TimerTrackDataIdManager

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(ClientData PUBLIC
         include/ClientData/ThreadTrackDataManager.h
         include/ClientData/ThreadTrackDataProvider.h
         include/ClientData/TimerChain.h
+        include/ClientData/TimerTrackDataIdManager.h
         include/ClientData/TimestampIntervalSet.h
         include/ClientData/TracepointCustom.h
         include/ClientData/TracepointData.h
@@ -45,6 +46,7 @@ target_sources(ClientData PRIVATE
         ScopeTreeTimerData.cpp
         ThreadTrackDataProvider.cpp
         TimerChain.cpp
+        TimerTrackDataIdManager.cpp
         TimestampIntervalSet.cpp
         TracepointData.cpp
         UserDefinedCaptureData.cpp)
@@ -70,6 +72,7 @@ target_sources(ClientDataTests PRIVATE
         ScopeTreeTimerDataTest.cpp
         ThreadTrackDataManagerTest.cpp
         ThreadTrackDataProviderTest.cpp
+        TimerTrackDataIdManagerTest.cpp
         TimestampIntervalSetTest.cpp
         TracepointDataTest.cpp
         TimerDataTest.cpp

--- a/src/ClientData/TimerTrackDataIdManager.cpp
+++ b/src/ClientData/TimerTrackDataIdManager.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ClientData/TimerTrackDataIdManager.h"
+
+#include "capture_data.pb.h"
+
+using orbit_client_protos::TimerInfo;
+
+namespace orbit_client_data {
+
+TimerTrackDataIdManager::TimerTrackDataIdManager() {
+  // Since there always will be an only scheduler track, we can assign it now.
+  scheduler_track_id_ = next_track_id_++;
+}
+
+uint32_t TimerTrackDataIdManager::GenerateTrackIdFromTimerInfo(const TimerInfo& timer_info) {
+  switch (timer_info.type()) {
+    case TimerInfo::kNone:
+    case TimerInfo::kApiScope:
+    case TimerInfo::kApiEvent:
+      return GenerateThreadTrackId(timer_info.thread_id());
+    case TimerInfo::kCoreActivity:
+      return GenerateSchedulerTrackId();
+    case TimerInfo::kFrame:
+      return GenerateFrameTrackId(timer_info.function_id());
+    case TimerInfo::kGpuActivity:
+    case TimerInfo::kGpuCommandBuffer:
+    case TimerInfo::kGpuDebugMarker:
+      return GenerateGpuTrackId(timer_info.timeline_hash());
+    case TimerInfo::kApiScopeAsync:
+      return GenerateAsyncTrackId(timer_info.api_scope_name());
+    case TimerInfo::kSystemMemoryUsage:
+    case TimerInfo::kCGroupAndProcessMemoryUsage:
+    case TimerInfo::kPageFaults:
+    case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MIN_SENTINEL_DO_NOT_USE_:
+    case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MAX_SENTINEL_DO_NOT_USE_:
+      UNREACHABLE();
+  }
+  return -1;
+}
+
+uint32_t TimerTrackDataIdManager::GenerateFrameTrackId(uint64_t function_id) {
+  absl::MutexLock lock(&mutex_);
+  auto [it, inserted] = frame_track_ids_.try_emplace(function_id, next_track_id_);
+  if (inserted) {
+    next_track_id_++;
+  }
+  return it->second;
+}
+
+uint32_t TimerTrackDataIdManager::GenerateGpuTrackId(uint64_t timeline_hash) {
+  absl::MutexLock lock(&mutex_);
+  auto [it, inserted] = gpu_track_ids_.try_emplace(timeline_hash, next_track_id_);
+  if (inserted) {
+    next_track_id_++;
+  }
+  return it->second;
+}
+
+uint32_t TimerTrackDataIdManager::GenerateAsyncTrackId(const std::string& name) {
+  absl::MutexLock lock(&mutex_);
+  auto [it, inserted] = async_track_ids_.try_emplace(name, next_track_id_);
+  if (inserted) {
+    next_track_id_++;
+  }
+  return it->second;
+}
+
+uint32_t TimerTrackDataIdManager::GenerateThreadTrackId(uint32_t thread_id) {
+  absl::MutexLock lock(&mutex_);
+  auto [it, inserted] = thread_track_ids_.try_emplace(thread_id, next_track_id_);
+  if (inserted) {
+    next_track_id_++;
+  }
+  return it->second;
+}
+
+}  // namespace orbit_client_data

--- a/src/ClientData/TimerTrackDataIdManagerTest.cpp
+++ b/src/ClientData/TimerTrackDataIdManagerTest.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "ClientData/TimerTrackDataIdManager.h"
+
+namespace orbit_client_data {
+
+TEST(TimerTrackDataIdManager, SchedulerTrack) {
+  TimerTrackDataIdManager timer_track_data_id_manager;
+  // SchedulerTrackId should always be the same
+  EXPECT_EQ(timer_track_data_id_manager.GenerateSchedulerTrackId(),
+            timer_track_data_id_manager.GenerateSchedulerTrackId());
+}
+
+TEST(ThreadTrackDataProvider, ThreadTracksDifferentId) {
+  TimerTrackDataIdManager timer_track_data_id_manager;
+  constexpr uint32_t kThreadId1 = 42;
+  constexpr uint32_t kThreadId2 = 27;
+
+  uint32_t track_id_thread_id_1 = timer_track_data_id_manager.GenerateThreadTrackId(kThreadId1);
+  uint32_t track_id_thread_id_2 = timer_track_data_id_manager.GenerateThreadTrackId(kThreadId2);
+
+  // Only asking for the same thread_id should produce the same id.
+  EXPECT_EQ(track_id_thread_id_1, timer_track_data_id_manager.GenerateThreadTrackId(kThreadId1));
+  EXPECT_NE(track_id_thread_id_1, track_id_thread_id_2);
+  EXPECT_NE(track_id_thread_id_1, timer_track_data_id_manager.GenerateSchedulerTrackId());
+  EXPECT_NE(track_id_thread_id_2, timer_track_data_id_manager.GenerateSchedulerTrackId());
+}
+
+TEST(ThreadTrackDataProvider, DifferentTypesDifferentIds) {
+  TimerTrackDataIdManager timer_track_data_id_manager;
+  constexpr uint64_t kSharedId = 42;
+  constexpr uint64_t kAnotherId = 43;
+  const std::string kAsyncTrackName = "Example Name";
+
+  uint32_t scheduler_track_id = timer_track_data_id_manager.GenerateSchedulerTrackId();
+  uint32_t thread_track_id = timer_track_data_id_manager.GenerateThreadTrackId(kSharedId);
+  uint32_t frame_track_id = timer_track_data_id_manager.GenerateFrameTrackId(kSharedId);
+  uint32_t gpu_track_id = timer_track_data_id_manager.GenerateGpuTrackId(kSharedId);
+  uint32_t async_track_id = timer_track_data_id_manager.GenerateAsyncTrackId(kAsyncTrackName);
+
+  std::set<uint32_t> used_ids;
+  used_ids.insert(scheduler_track_id);
+  used_ids.insert(thread_track_id);
+  used_ids.insert(frame_track_id);
+  used_ids.insert(gpu_track_id);
+  used_ids.insert(async_track_id);
+  // Each id should be unique.
+  EXPECT_EQ(used_ids.size(), 5);
+
+  // The requested id should be the same when it's the same type and key.
+  EXPECT_EQ(frame_track_id, timer_track_data_id_manager.GenerateFrameTrackId(kSharedId));
+  EXPECT_EQ(gpu_track_id, timer_track_data_id_manager.GenerateGpuTrackId(kSharedId));
+  EXPECT_NE(gpu_track_id, timer_track_data_id_manager.GenerateGpuTrackId(kAnotherId));
+}
+
+TEST(ThreadTrackDataProvider, GetTrackIdFromTimerInfo) {
+  TimerTrackDataIdManager timer_track_data_id_manager;
+  constexpr uint64_t kSharedId = 42;
+  constexpr uint64_t kAnotherId = 43;
+
+  std::set<uint32_t> used_tracks_ids;
+  TimerInfo timer_info;
+
+  // GetTrackId for different types of Timer Tracks.
+  timer_info.set_function_id(kSharedId);
+  timer_info.set_type(TimerInfo::kFrame);
+  used_tracks_ids.insert(timer_track_data_id_manager.GenerateTrackIdFromTimerInfo(timer_info));
+
+  timer_info.set_timeline_hash(kSharedId);
+  timer_info.set_type(TimerInfo::kGpuCommandBuffer);
+  used_tracks_ids.insert(timer_track_data_id_manager.GenerateTrackIdFromTimerInfo(timer_info));
+
+  timer_info.set_thread_id(kSharedId);
+  timer_info.set_type(TimerInfo::kNone);
+  uint32_t thread_track_id = timer_track_data_id_manager.GenerateTrackIdFromTimerInfo(timer_info);
+  used_tracks_ids.insert(thread_track_id);
+
+  timer_info.set_thread_id(kAnotherId);
+  used_tracks_ids.insert(timer_track_data_id_manager.GenerateTrackIdFromTimerInfo(timer_info));
+
+  timer_info.set_thread_id(kSharedId);
+  uint32_t initial_thread_track_id =
+      timer_track_data_id_manager.GenerateTrackIdFromTimerInfo(timer_info);
+  // This shoudln't insert a new id.
+  used_tracks_ids.insert(initial_thread_track_id);
+
+  EXPECT_EQ(thread_track_id, initial_thread_track_id);
+
+  // 2 ThreadTracks, 1 FrameTrack, 1 GpuTrack
+  EXPECT_EQ(used_tracks_ids.size(), 4);
+}
+
+}  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/TimerTrackDataIdManager.h
+++ b/src/ClientData/include/ClientData/TimerTrackDataIdManager.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_TIMER_TRACK_DATA_ID_MANAGER_H_
+#define CLIENT_DATA_TIMER_TRACK_DATA_ID_MANAGER_H_
+
+#include <OrbitBase/Logging.h>
+#include <absl/container/flat_hash_map.h>
+
+#include <mutex>
+
+#include "capture_data.pb.h"
+
+using orbit_client_protos::TimerInfo;
+
+namespace orbit_client_data {
+
+// Manages track_id for different types of track;
+class TimerTrackDataIdManager {
+ public:
+  TimerTrackDataIdManager();
+  [[nodiscard]] uint32_t GenerateTrackIdFromTimerInfo(const TimerInfo& timer_info);
+
+  [[nodiscard]] uint32_t GenerateSchedulerTrackId() const { return scheduler_track_id_; }
+  [[nodiscard]] uint32_t GenerateFrameTrackId(uint64_t function_id);
+  [[nodiscard]] uint32_t GenerateGpuTrackId(uint64_t timeline_hash);
+  [[nodiscard]] uint32_t GenerateAsyncTrackId(const std::string& name);
+  [[nodiscard]] uint32_t GenerateThreadTrackId(uint32_t thread_id);
+
+ private:
+  mutable absl::Mutex mutex_;
+  uint32_t next_track_id_ = 0;
+
+  uint32_t scheduler_track_id_;
+  absl::flat_hash_map<uint64_t, uint32_t> frame_track_ids_ ABSL_GUARDED_BY(mutex_);
+  absl::flat_hash_map<uint64_t, uint32_t> gpu_track_ids_ ABSL_GUARDED_BY(mutex_);
+  absl::flat_hash_map<std::string, uint32_t> async_track_ids_ ABSL_GUARDED_BY(mutex_);
+  absl::flat_hash_map<uint32_t, uint32_t> thread_track_ids_ ABSL_GUARDED_BY(mutex_);
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_TIMER_TRACK_DATA_ID_MANAGER_H_


### PR DESCRIPTION
In order to be able to expand ThreadTrackDataProvider to also work with
other TimerTracks (GpuTrack, SchedulerTrack and FrameTrack) and therefore
rename it to TimerTrackDataProvider, we need an unique identifier
track_id (or pane_id in the future, see
go/stadia-orbit-timers-outside-ui) to know which timers should belong to
the same container.

Currently all this logic is inside TrackManager (UI), where we have different
maps for each type of Track and we use different functions to get the
Track themselves. Now, we are aiming to have a provider to get this data
and we also need that identifier to allow the Tracks (UI) to get their
data.

In this context, we are creating TimerTrackDataIdManager, who owns all
the existente track_data_id and has the main responsibility of identify
which timers should belong to the same data.

The main function is GetTrackIdFromTimerInfo, who only return the same
track_data_id for timers who should belong to the same container. We
are also providing GetTrackTypeId(track_type_identifier) for all timer
tracks to allow the possibility of creating a track without any timer.
This is mostly legacy and these functions might be private in the
future.

This PR is a little piece inside http://b/202110356, aiming to have an
only provider for all kind of TimerTracks.