### PR TITLE
Move "Loaded" as the first column in modules tab

### DIFF
--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -35,11 +35,11 @@ const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
   static const std::vector<Column> columns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
+    columns[kColumnLoaded] = {"Loaded", .0f, SortingOrder::kDescending};
     columns[kColumnName] = {"Name", .2f, SortingOrder::kAscending};
     columns[kColumnPath] = {"Path", .5f, SortingOrder::kAscending};
     columns[kColumnAddressRange] = {"Address Range", .15f, SortingOrder::kAscending};
     columns[kColumnFileSize] = {"File Size", .0f, SortingOrder::kDescending};
-    columns[kColumnLoaded] = {"Loaded", .0f, SortingOrder::kDescending};
     return columns;
   }();
   return columns;
@@ -51,6 +51,8 @@ std::string ModulesDataView::GetValue(int row, int col) {
   const ModuleInMemory& memory_space = start_address_to_module_in_memory_.at(start_address);
 
   switch (col) {
+    case kColumnLoaded:
+      return module->is_loaded() ? "*" : "";
     case kColumnName:
       return module->name();
     case kColumnPath:
@@ -59,8 +61,6 @@ std::string ModulesDataView::GetValue(int row, int col) {
       return memory_space.FormattedAddressRange();
     case kColumnFileSize:
       return orbit_display_formats::GetDisplaySize(module->file_size());
-    case kColumnLoaded:
-      return module->is_loaded() ? "*" : "";
     default:
       return "";
   }
@@ -84,6 +84,9 @@ void ModulesDataView::DoSort() {
   std::function<bool(uint64_t, uint64_t)> sorter = nullptr;
 
   switch (sorting_column_) {
+    case kColumnLoaded:
+      sorter = ORBIT_PROC_SORT(is_loaded());
+      break;
     case kColumnName:
       sorter = ORBIT_PROC_SORT(name());
       break;
@@ -95,9 +98,6 @@ void ModulesDataView::DoSort() {
       break;
     case kColumnFileSize:
       sorter = ORBIT_PROC_SORT(file_size());
-      break;
-    case kColumnLoaded:
-      sorter = ORBIT_PROC_SORT(is_loaded());
       break;
     default:
       break;

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -35,11 +35,11 @@ const std::array<std::string, kNumModules> kFilePaths{
 const std::array<std::string, kNumModules> kBuildIds{"build_id_0", "build_id_1", "build_id_2"};
 
 // ModulesDataView also has column index constants defined, but they are declared as private.
-constexpr int kColumnName = 0;
-constexpr int kColumnPath = 1;
-constexpr int kColumnAddressRange = 2;
-constexpr int kColumnFileSize = 3;
-constexpr int kColumnLoaded = 4;
+constexpr int kColumnLoaded = 0;
+constexpr int kColumnName = 1;
+constexpr int kColumnPath = 2;
+constexpr int kColumnAddressRange = 3;
+constexpr int kColumnFileSize = 4;
 constexpr int kNumColumns = 5;
 
 std::string GetExpectedDisplayAddressRangeByIndex(size_t index) {
@@ -137,8 +137,8 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
   // Copy Selection
   {
     std::string expected_clipboard = absl::StrFormat(
-        "Name\tPath\tAddress Range\tFile Size\tLoaded\n"
-        "%s\t%s\t%s\t%s\t\n",
+        "Loaded\tName\tPath\tAddress Range\tFile Size\n"
+        "\t%s\t%s\t%s\t%s\n",
         kNames[0], kFilePaths[0], GetExpectedDisplayAddressRangeByIndex(0),
         GetExpectedDisplayFileSizeByIndex(0));
     CheckCopySelectionIsInvoked(context_menu, app_, view_, expected_clipboard);
@@ -147,9 +147,9 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
   // Export to CSV
   {
     std::string expected_contents =
-        absl::StrFormat(R"("Name","Path","Address Range","File Size","Loaded")"
+        absl::StrFormat(R"("Loaded","Name","Path","Address Range","File Size")"
                         "\r\n"
-                        R"("%s","%s","%s","%s","")"
+                        R"("","%s","%s","%s","%s")"
                         "\r\n",
                         kNames[0], kFilePaths[0], GetExpectedDisplayAddressRangeByIndex(0),
                         GetExpectedDisplayFileSizeByIndex(0));

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -55,11 +55,11 @@ class ModulesDataView : public DataView {
   absl::flat_hash_map<uint64_t, orbit_client_data::ModuleData*> start_address_to_module_;
 
   enum ColumnIndex {
+    kColumnLoaded,
     kColumnName,
     kColumnPath,
     kColumnAddressRange,
-    kColumnFileSize,
-    kColumnLoaded,
+    kColumnFileSize,  // Default sorting column
     kNumColumns
   };
 


### PR DESCRIPTION
With this change, we moved the "Loaded" column as the first (left most)
column in the modules tab.

The purpose is to keep the status column as the first one to keep
consistent with other data views.

Test: run unit tests
Bug: http://b/204027904