### PR TITLE
Compute capture section size correctly using also section list offset

### DIFF
--- a/src/CaptureFile/CaptureFile.cpp
+++ b/src/CaptureFile/CaptureFile.cpp
@@ -113,7 +113,7 @@ ErrorMessageOr<void> CaptureFileImpl::CalculateCaptureSectionSize() {
     return outcome::success();
   }
 
-  // Otherwise it ends at the start of the next section
+  // Otherwise it ends at the start of the next section or at the section list
   uint64_t min_section_offset = std::numeric_limits<uint64_t>::max();
 
   CHECK(!section_list_.empty());
@@ -122,6 +122,10 @@ ErrorMessageOr<void> CaptureFileImpl::CalculateCaptureSectionSize() {
     if (section.offset < min_section_offset) {
       min_section_offset = section.offset;
     }
+  }
+
+  if (header_.section_list_offset > header_.capture_section_offset) {
+    min_section_offset = std::min(min_section_offset, header_.section_list_offset);
   }
 
   CHECK(min_section_offset < std::numeric_limits<uint64_t>::max());

--- a/src/CaptureFile/ProtoSectionInputStreamImpl.cpp
+++ b/src/CaptureFile/ProtoSectionInputStreamImpl.cpp
@@ -47,6 +47,13 @@ ErrorMessageOr<void> ProtoSectionInputStreamImpl::ReadMessage(google::protobuf::
   }
 
   message->ParseFromArray(buf.get(), message_size);
+
+  if (message->ByteSizeLong() != message_size) {
+    return ErrorMessage{absl::StrFormat(
+        "The message size %d of the parsed message is different from the parsed size %d",
+        message->ByteSizeLong(), message_size)};
+  }
+
   return outcome::success();
 }
 

--- a/src/CaptureFile/include/CaptureFile/ProtoSectionInputStream.h
+++ b/src/CaptureFile/include/CaptureFile/ProtoSectionInputStream.h
@@ -18,15 +18,12 @@ class ProtoSectionInputStream {
   ProtoSectionInputStream() = default;
   virtual ~ProtoSectionInputStream() = default;
 
-  // Reads next message from the stream. Note that the caller must not read past
-  // orbit_grpc_protos::CaptureFinished message in the case of Capture Section. Doing so
-  // will result in undefined behavior.
-  //
-  // This is because the capture section does not have size and is bounded by the
-  // start of the next section and start of all sections are aligned to 8bytes.
-  // This means reading after CaptureFinished message sometimes end up reading
-  // padded zeros which yield an empty message, or it could generate end of section
-  // error.
+  // Reads next message from the stream. Note that the caller should not read past
+  // orbit_grpc_protos::CaptureFinished message in the case of Capture Section.
+  // This is because the capture section does not have a size and is bounded by the
+  // start of the next section or the section list and start of all sections are
+  // aligned to 8bytes. Reading beyond the CaptureFinished message will incorrectly
+  // read padded zeros as empty messages until finally causing an end of section error.
   virtual ErrorMessageOr<void> ReadMessage(google::protobuf::Message* message) = 0;
 };
 


### PR DESCRIPTION
The capture (main) section in our captures files extends from the
capture section offset to either the next section or to the section list
offset. So far, the section list offset was not considered when
computing the size of the capture section. This is now fixed.

The changed implementation does not change behavior for code that
does not read past the CaptureFinished event, however behavior for
reading past this event is now well specified: you get empty messages
until you hit the end of the capture section. Previously it was possible
to incorrectly parse data from the section list as proto messages.

Tested: Unit tests.