### PR TITLE
Support ThreadTrack optimization in ScopeTreeTimerData

### DIFF
--- a/src/ClientData/ScopeTreeTimerDataTest.cpp
+++ b/src/ClientData/ScopeTreeTimerDataTest.cpp
@@ -153,23 +153,23 @@ TEST(ScopeTreeTimerData, GetTimersAtDepthOptimized) {
 
   // We should see both timers with a normal resolution.
   EXPECT_EQ(
-      scope_tree_timer_data.GetTimersAtDepthOptimized(0, 1000, kLeftTimerStart, kRightTimerEnd)
+      scope_tree_timer_data.GetTimersAtDepthDiscretized(0, 1000, kLeftTimerStart, kRightTimerEnd)
           .size(),
       2);
 
   // We should only see 1 if we zoom-out a lot even with a normal resolution.
-  EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthOptimized(0, 1000, 0, 10000000).size(), 1);
+  EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthDiscretized(0, 1000, 0, 10000000).size(), 1);
 
   // If there is a timer in the range, we should see it in any resolution.
   EXPECT_EQ(
-      scope_tree_timer_data.GetTimersAtDepthOptimized(0, 1, kLeftTimerStart, kLeftTimerStart + 1)
+      scope_tree_timer_data.GetTimersAtDepthDiscretized(0, 1, kLeftTimerStart, kLeftTimerStart + 1)
           .size(),
       1);  // Left
-  EXPECT_EQ(
-      scope_tree_timer_data.GetTimersAtDepthOptimized(0, 1000, kLeftTimerStart, kLeftTimerStart + 1)
-          .size(),
-      1);  // Left
-  EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthOptimized(1, 1000, 0, 10000000).size(),
+  EXPECT_EQ(scope_tree_timer_data
+                .GetTimersAtDepthDiscretized(0, 1000, kLeftTimerStart, kLeftTimerStart + 1)
+                .size(),
+            1);  // Left
+  EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthDiscretized(1, 1000, 0, 10000000).size(),
             1);  // Down
 }
 

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -41,17 +41,17 @@ class ScopeTreeTimerData final {
   void OnCaptureComplete();
 
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
-      uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
-      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
+      uint64_t start_ns = std::numeric_limits<uint64_t>::min(),
+      uint64_t end_ns = std::numeric_limits<uint64_t>::max()) const;
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepth(
-      uint32_t depth, uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
-      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
-  // This method avoids returning two timers that map to the same pixels in the screen, so is
+      uint32_t depth, uint64_t start_ns = std::numeric_limits<uint64_t>::min(),
+      uint64_t end_ns = std::numeric_limits<uint64_t>::max()) const;
+  // This method avoids returning two timers that map to the same pixel in the screen, so is
   // especially useful when there are many timers in the screen (zooming-out for example).
   // The overall complexity is O(log(num_timers) * resolution). Resolution should be the number
   // of pixels-width where timers will be drawn.
-  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthOptimized(
-      uint32_t depth, uint32_t resolution, uint64_t min_tick, uint64_t max_tick) const;
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthDiscretized(
+      uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
       const orbit_client_protos::TimerInfo& timer) const;


### PR DESCRIPTION
In this PR we are extending ScopeTreeTimerData to allow the optimization
made in https://github.com/google/orbit/pull/2780. In that PR, we
optimized ThreadTracks to no go through all the timers in a range if
after we were not going to draw them (we don't draw 2 different timer if
they occupt the same pixels).

So, here we add 2 methods to ScopeTreeTimerData class:

- GetTimersAtDepth (depth, min_timestamp, max_timestamp) : Get the timers
in one particular depth level.

- GetTimersAtDepthOptimized: (depth, resolution, min_timestamp,
max_timestamp): Get Timers in a range that after will be draw having
certain resolution.

This last method will be used by ThreadTrackDataProvider. The other method 
(as well as the general GetTimers) shouldn't be used because performance, by 
I'm not sure if I want to remove it. I'm open to opinions.

This PR is a puzzle piece of making ThreadTracks to use the provider
instead of their own data (https://github.com/google/orbit/pull/2891)
which aims to solve http://b/202110929.