### PR TITLE
Create TimerDataInterface

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -26,11 +26,12 @@ target_sources(ClientData PUBLIC
         include/ClientData/ThreadTrackDataManager.h
         include/ClientData/ThreadTrackDataProvider.h
         include/ClientData/TimerChain.h
+        include/ClientData/TimerData.h
+        include/ClientData/TimerDataInterface.h
+        include/ClientData/TimerDataManager.h
         include/ClientData/TimestampIntervalSet.h
         include/ClientData/TracepointCustom.h
         include/ClientData/TracepointData.h
-        include/ClientData/TimerDataManager.h
-        include/ClientData/TimerData.h
         include/ClientData/UserDefinedCaptureData.h)
 
 target_sources(ClientData PRIVATE

--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -8,21 +8,18 @@ namespace orbit_client_data {
 
 const TimerMetadata ScopeTreeTimerData::GetTimerMetadata() const {
   absl::MutexLock lock(&scope_tree_mutex_);
-  TimerMetadata timer_metadata;
+  TimerMetadata timer_metadata = timer_data_.GetTimerMetadata();
   // Special case. ScopeTree has a root node in depth 0 which shouldn't be considered.
   timer_metadata.number_of_timers = scope_tree_.Size() - 1;
   timer_metadata.is_empty = timer_metadata.number_of_timers == 0;
-  timer_metadata.min_time = timer_data_.GetMinTime();
-  timer_metadata.max_time = timer_data_.GetMaxTime();
   timer_metadata.depth = scope_tree_.Depth();
-  timer_metadata.process_id = timer_data_.GetProcessId();
   return timer_metadata;
 }
 
 const orbit_client_protos::TimerInfo& ScopeTreeTimerData::AddTimer(
-    orbit_client_protos::TimerInfo timer_info) {
+    orbit_client_protos::TimerInfo timer_info, uint32_t /*depth*/) {
   // Thread tracks use a ScopeTree so we don't need to create one TimerChain per depth.
-  const auto& timer_info_ref = timer_data_.AddTimer(/*depth=*/0, std::move(timer_info));
+  const auto& timer_info_ref = timer_data_.AddTimer(std::move(timer_info), /*depth=*/0);
 
   if (scope_tree_update_type_ == ScopeTreeUpdateType::kAlways) {
     absl::MutexLock lock(&scope_tree_mutex_);

--- a/src/ClientData/TimerDataTest.cpp
+++ b/src/ClientData/TimerDataTest.cpp
@@ -12,13 +12,14 @@ using orbit_client_protos::TimerInfo;
 
 TEST(TimerData, IsEmpty) {
   TimerData timer_data;
+  TimerMetadata timer_metadata = timer_data.GetTimerMetadata();
   EXPECT_TRUE(timer_data.GetChains().empty());
   EXPECT_EQ(timer_data.GetChain(0), nullptr);
   EXPECT_EQ(timer_data.GetChain(7), nullptr);
-  EXPECT_TRUE(timer_data.IsEmpty());
-  EXPECT_EQ(timer_data.GetNumberOfTimers(), 0);
-  EXPECT_EQ(timer_data.GetMaxTime(), std::numeric_limits<uint64_t>::min());
-  EXPECT_EQ(timer_data.GetMinTime(), std::numeric_limits<uint64_t>::max());
+  EXPECT_TRUE(timer_metadata.is_empty);
+  EXPECT_EQ(timer_metadata.number_of_timers, 0);
+  EXPECT_EQ(timer_metadata.max_time, std::numeric_limits<uint64_t>::min());
+  EXPECT_EQ(timer_metadata.min_time, std::numeric_limits<uint64_t>::max());
 }
 
 TEST(TimerData, AddTimers) {
@@ -27,47 +28,48 @@ TEST(TimerData, AddTimers) {
   timer_info.set_start(2);
   timer_info.set_end(5);
 
-  timer_data.AddTimer(0, timer_info);
+  timer_data.AddTimer(timer_info, 0);
 
-  EXPECT_FALSE(timer_data.IsEmpty());
-  EXPECT_EQ(timer_data.GetNumberOfTimers(), 1);
+  EXPECT_FALSE(timer_data.GetTimerMetadata().is_empty);
+  EXPECT_EQ(timer_data.GetTimerMetadata().number_of_timers, 1);
   ASSERT_NE(timer_data.GetChain(0), nullptr);
   EXPECT_EQ(timer_data.GetChain(1), nullptr);
   EXPECT_EQ(timer_data.GetChain(0)->size(), 1);
 
-  EXPECT_EQ(timer_data.GetMaxTime(), 5);
-  EXPECT_EQ(timer_data.GetMinTime(), 2);
+  EXPECT_EQ(timer_data.GetTimerMetadata().max_time, 5);
+  EXPECT_EQ(timer_data.GetTimerMetadata().min_time, 2);
 
   timer_info.set_start(8);
   timer_info.set_end(11);
 
-  timer_data.AddTimer(0, timer_info);
+  timer_data.AddTimer(timer_info, 0);
 
-  EXPECT_FALSE(timer_data.IsEmpty());
-  EXPECT_EQ(timer_data.GetNumberOfTimers(), 2);
+  EXPECT_FALSE(timer_data.GetTimerMetadata().is_empty);
+  EXPECT_EQ(timer_data.GetTimerMetadata().number_of_timers, 2);
   ASSERT_NE(timer_data.GetChain(0), nullptr);
   EXPECT_EQ(timer_data.GetChain(1), nullptr);
   EXPECT_EQ(timer_data.GetChain(0)->size(), 2);
 
-  EXPECT_EQ(timer_data.GetMaxTime(), 11);
-  EXPECT_EQ(timer_data.GetMinTime(), 2);
+  EXPECT_EQ(timer_data.GetTimerMetadata().max_time, 11);
+  EXPECT_EQ(timer_data.GetTimerMetadata().min_time, 2);
 
   timer_info.set_start(10);
   timer_info.set_end(11);
 
-  timer_data.AddTimer(1, timer_info);
+  timer_data.AddTimer(timer_info, 1);
 
-  EXPECT_EQ(timer_data.GetNumberOfTimers(), 3);
-  EXPECT_FALSE(timer_data.IsEmpty());
+  EXPECT_EQ(timer_data.GetTimerMetadata().number_of_timers, 3);
+  EXPECT_FALSE(timer_data.GetTimerMetadata().is_empty);
   ASSERT_NE(timer_data.GetChain(0), nullptr);
   ASSERT_NE(timer_data.GetChain(1), nullptr);
   EXPECT_EQ(timer_data.GetChain(0)->size(), 2);
   EXPECT_EQ(timer_data.GetChain(1)->size(), 1);
 
-  EXPECT_EQ(timer_data.GetMaxTime(), 11);
-  EXPECT_EQ(timer_data.GetMinTime(), 2);
+  EXPECT_EQ(timer_data.GetTimerMetadata().max_time, 11);
+  EXPECT_EQ(timer_data.GetTimerMetadata().min_time, 2);
 }
 
+// TODO(b/204173036): Make GetFirstAfterStartTime private and test GetLeft/Right/Top/Down instead.
 TEST(TimerData, FindTimers) {
   TimerData timer_data;
 
@@ -75,15 +77,15 @@ TEST(TimerData, FindTimers) {
     TimerInfo timer_info;
     timer_info.set_start(2);
     timer_info.set_end(5);
-    timer_data.AddTimer(0, timer_info);
+    timer_data.AddTimer(timer_info, 0);
 
     timer_info.set_start(8);
     timer_info.set_end(11);
-    timer_data.AddTimer(0, timer_info);
+    timer_data.AddTimer(timer_info, 0);
 
     timer_info.set_start(10);
     timer_info.set_end(12);
-    timer_data.AddTimer(0, timer_info);
+    timer_data.AddTimer(timer_info, 0);
   }
 
   {

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -11,46 +11,41 @@
 
 #include "Containers/ScopeTree.h"
 #include "TimerData.h"
+#include "TimerDataInterface.h"
 
 namespace orbit_client_data {
 
-struct TimerMetadata {
-  bool is_empty;
-  size_t number_of_timers;
-  uint64_t min_time;
-  uint64_t max_time;
-  uint32_t depth;
-  uint32_t process_id;
-};
-
 // Stores all the timers from a particular ThreadId. Provides queries to get timers in a certain
 // range as well as metadata from them.
-class ScopeTreeTimerData final {
+class ScopeTreeTimerData final : public TimerDataInterface {
  public:
   enum class ScopeTreeUpdateType { kAlways, kOnCaptureComplete, kNever };
   explicit ScopeTreeTimerData(int64_t thread_id = -1, ScopeTreeUpdateType scope_tree_update_type =
                                                           ScopeTreeUpdateType::kAlways)
       : thread_id_(thread_id), scope_tree_update_type_(scope_tree_update_type){};
 
-  [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
-  [[nodiscard]] const TimerMetadata GetTimerMetadata() const;
+  [[nodiscard]] int64_t GetThreadId() const override { return thread_id_; }
+  [[nodiscard]] const TimerMetadata GetTimerMetadata() const override;
 
-  [[nodiscard]] std::vector<const TimerChain*> GetChains() const { return timer_data_.GetChains(); }
+  [[nodiscard]] std::vector<const TimerChain*> GetChains() const override {
+    return timer_data_.GetChains();
+  }
 
-  const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info);
-  void OnCaptureComplete();
+  const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info,
+                                                 uint32_t /*depth*/ = 0) override;
+  void OnCaptureComplete() override;
 
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
-      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
-      const orbit_client_protos::TimerInfo& timer) const;
+      const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetRight(
-      const orbit_client_protos::TimerInfo& timer) const;
+      const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetUp(
-      const orbit_client_protos::TimerInfo& timer) const;
+      const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
-      const orbit_client_protos::TimerInfo& timer) const;
+      const orbit_client_protos::TimerInfo& timer) const override;
 
  private:
   const int64_t thread_id_;

--- a/src/ClientData/include/ClientData/TimerDataInterface.h
+++ b/src/ClientData/include/ClientData/TimerDataInterface.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_TIMER_DATA_INTERFACE_H_
+#define CLIENT_DATA_TIMER_DATA_INTERFACE_H_
+
+#include "TimerChain.h"
+#include "capture_data.pb.h"
+
+namespace orbit_client_data {
+
+struct TimerMetadata {
+  bool is_empty;
+  size_t number_of_timers;
+  uint64_t min_time;
+  uint64_t max_time;
+  uint32_t depth;
+  uint32_t process_id;
+};
+
+// Interface to be use by TimerDataProvider to access data from TimerTracks.
+class TimerDataInterface {
+ public:
+  virtual ~TimerDataInterface() = default;
+
+  virtual const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info,
+                                                         uint32_t depth = 0) = 0;
+  [[nodiscard]] virtual const TimerMetadata GetTimerMetadata() const = 0;
+  [[nodiscard]] virtual std::vector<const TimerChain*> GetChains() const = 0;
+  [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
+      uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const = 0;
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetLeft(
+      const orbit_client_protos::TimerInfo& timer) const = 0;
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetRight(
+      const orbit_client_protos::TimerInfo& timer) const = 0;
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetUp(
+      const orbit_client_protos::TimerInfo& timer) const = 0;
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetDown(
+      const orbit_client_protos::TimerInfo& timer) const = 0;
+
+  // Only used in ScopeTreeTimerData
+  [[nodiscard]] virtual int64_t GetThreadId() const = 0;
+  virtual void OnCaptureComplete() = 0;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_TIMER_DATA_INTERFACE_H_

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -85,8 +85,8 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 
 float AsyncTrack::GetDefaultBoxHeight() const {
   auto box_height = layout_->GetTextBoxHeight();
-  if (collapse_toggle_->IsCollapsed() && timer_data_->GetMaxDepth() > 0) {
-    return box_height / static_cast<float>(timer_data_->GetMaxDepth());
+  if (collapse_toggle_->IsCollapsed() && GetDepth() > 0) {
+    return box_height / static_cast<float>(GetDepth());
   }
   return box_height;
 }

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -117,8 +117,7 @@ float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 
 float GpuDebugMarkerTrack::GetHeight() const {
   bool collapsed = collapse_toggle_->IsCollapsed();
-  uint32_t depth =
-      collapsed ? std::min<uint32_t>(1, timer_data_->GetMaxDepth()) : timer_data_->GetMaxDepth();
+  uint32_t depth = collapsed ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
   return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
          layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
 }

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -175,7 +175,7 @@ std::string GpuSubmissionTrack::GetTimesliceText(const TimerInfo& timer_info) co
 
 float GpuSubmissionTrack::GetHeight() const {
   bool collapsed = IsCollapsed();
-  uint32_t depth = collapsed ? 1 : timer_data_->GetMaxDepth();
+  uint32_t depth = collapsed ? 1 : GetDepth();
   uint32_t num_gaps = depth > 0 ? depth - 1 : 0;
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
     depth *= 2;

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -57,7 +57,7 @@ class GpuSubmissionTrack : public TimerTrack {
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] bool IsCollapsible() const override {
-    return timer_data_->GetMaxDepth() > 1 || has_vulkan_layer_command_buffer_timers_;
+    return GetDepth() > 1 || has_vulkan_layer_command_buffer_timers_;
   }
   [[nodiscard]] bool IsCollapsed() const override {
     return Track::IsCollapsed() || GetParent()->IsCollapsed();

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -41,8 +41,8 @@ void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 }
 
 float SchedulerTrack::GetHeight() const {
-  uint32_t num_gaps = std::max(timer_data_->GetMaxDepth() - 1, 0u);
-  return GetHeaderHeight() + (timer_data_->GetMaxDepth() * layout_->GetTextCoresHeight()) +
+  uint32_t num_gaps = std::max(GetDepth() - 1, 0u);
+  return GetHeaderHeight() + (GetDepth() * layout_->GetTextCoresHeight()) +
          (num_gaps * layout_->GetSpaceBetweenCores()) + layout_->GetTrackContentBottomMargin();
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -245,7 +245,7 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, 
 
 bool ThreadTrack::IsEmpty() const {
   return thread_state_bar_->IsEmpty() && event_bar_->IsEmpty() && tracepoint_bar_->IsEmpty() &&
-         timer_data_->IsEmpty();
+         TimerTrack::IsEmpty();
 }
 
 void ThreadTrack::UpdatePositionOfSubtracks() {
@@ -377,7 +377,7 @@ void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
 
   // Pass ownership to timer_chain. TODO(b/194268477): Pass timer_info as a value instead of
   // reference to be able to move it.
-  const auto& timer_info_chain_ref = timer_data_->AddTimer(/*depth=*/0, timer_info);
+  const auto& timer_info_chain_ref = timer_data_->AddTimer(timer_info, /*depth=*/0);
 
   if (scope_tree_update_type_ == ScopeTreeUpdateType::kAlways) {
     absl::MutexLock lock(&scope_tree_mutex_);

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -59,7 +59,7 @@ class ThreadTrack final : public TimerTrack {
     return timer_data_->GetChains();
   }
 
-  [[nodiscard]] bool IsCollapsible() const override { return timer_data_->GetMaxDepth() > 1; }
+  [[nodiscard]] bool IsCollapsible() const override { return GetDepth() > 1; }
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetChildren() const override;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -318,12 +318,12 @@ void TimerTrack::DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_
 }
 
 void TimerTrack::OnTimer(const TimerInfo& timer_info) {
-  timer_data_->AddTimer(timer_info.depth(), timer_info);
+  timer_data_->AddTimer(timer_info, timer_info.depth());
 }
 
 float TimerTrack::GetHeight() const {
-  uint32_t collapsed_depth = std::min<uint32_t>(1, timer_data_->GetMaxDepth());
-  uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : timer_data_->GetMaxDepth();
+  uint32_t collapsed_depth = std::min<uint32_t>(1, GetDepth());
+  uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : GetDepth();
   return GetHeaderHeight() + layout_->GetTrackContentTopMargin() +
          layout_->GetTextBoxHeight() * depth +
          (depth > 0 ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
@@ -351,7 +351,7 @@ const TimerInfo* TimerTrack::GetDown(const TimerInfo& timer_info) const {
   return timer_data_->GetFirstAfterStartTime(timer_info.start(), timer_info.depth() + 1);
 }
 
-bool TimerTrack::IsEmpty() const { return timer_data_->IsEmpty(); }
+bool TimerTrack::IsEmpty() const { return timer_data_->GetTimerMetadata().is_empty; }
 
 std::string TimerTrack::GetBoxTooltip(const Batcher& /*batcher*/, PickingId /*id*/) const {
   return "";
@@ -390,6 +390,8 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   return draw_data;
 }
 
-size_t TimerTrack::GetNumberOfTimers() const { return timer_data_->GetNumberOfTimers(); }
-uint64_t TimerTrack::GetMinTime() const { return timer_data_->GetMinTime(); }
-uint64_t TimerTrack::GetMaxTime() const { return timer_data_->GetMaxTime(); }
+size_t TimerTrack::GetNumberOfTimers() const {
+  return timer_data_->GetTimerMetadata().number_of_timers;
+}
+uint64_t TimerTrack::GetMinTime() const { return timer_data_->GetTimerMetadata().min_time; }
+uint64_t TimerTrack::GetMaxTime() const { return timer_data_->GetTimerMetadata().max_time; }

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -64,7 +64,10 @@ class TimerTrack : public Track {
   // Track
   [[nodiscard]] Type GetType() const override { return Type::kTimerTrack; }
 
-  [[nodiscard]] uint32_t GetProcessId() const override { return timer_data_->GetProcessId(); }
+  [[nodiscard]] uint32_t GetDepth() const { return timer_data_->GetTimerMetadata().depth; }
+  [[nodiscard]] uint32_t GetProcessId() const override {
+    return timer_data_->GetTimerMetadata().process_id;
+  }
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer) const;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(


### PR DESCRIPTION
In this PR we are creating TimerDataInterface, a common interface
between TimerData and ScopeTreeTimerData (based on ScopeTree). This
interface will be used by TimerDataProvider to easily communicate with
both classes.

This PR adjusted both classes to the common interface:

ScopeTreeTimerData:
- AddTimer now includes also an unused depth.

TimerData:
- Refactorized to have GetTimerMetadata().

- Created but not implemented GetTimers(): Should include some
optimization to discard several timers who after will occupt same
position in screen to not produce a regression when zooming-out.

- Added GetLeft/Right/Top/Down methods.

- Added unused methods: GetThreadId and OnCaptureComplete.

- Make some methods private.

- TODO: Create TimerData.cpp because TimerData is too big.

Tracks:

- Adapted to use GetTimerMetadata instead of GetMaxDepth() and
IsEmpty(), etc. Also refactorized a bit to use internal methods when
possible.

This PR is part of the process to move all timer-related data outside
the UI (http://b/202110356).

TODO:
- Implement GetTimers in TimerData (http://b/204173236).
- Use Provider in each TimerTrack (http://b/204173236).
- Improve TimerDataTests (http://b/204173036).