### PR TITLE
Move GetLastError.h/.cpp to OrbitBase

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -61,7 +61,11 @@ target_sources(OrbitBase PRIVATE
 
 if (WIN32)
 target_sources(OrbitBase PRIVATE
+        include/OrbitBase/GetLastError.h)
+
+target_sources(OrbitBase PRIVATE
         ExecutablePathWindows.cpp
+        GetLastError.cpp
         ThreadUtilsWindows.cpp)
 else()
 target_sources(OrbitBase PRIVATE

--- a/src/OrbitBase/ExecutablePathWindows.cpp
+++ b/src/OrbitBase/ExecutablePathWindows.cpp
@@ -10,6 +10,7 @@
 // clang-format on
 
 #include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/GetLastError.h"
 #include "OrbitBase/Logging.h"
 #include "absl/strings/str_replace.h"
 
@@ -19,13 +20,13 @@ std::filesystem::path GetExecutablePath() {
   constexpr uint32_t kMaxPath = 2048;
   char exe_file_name[kMaxPath] = {0};
   if (!GetModuleFileNameA(/*hModule=*/nullptr, exe_file_name, kMaxPath)) {
-    FATAL("GetModuleFileName failed with: %u", GetLastError());
+    FATAL("GetModuleFileName failed with: %s", GetLastErrorAsString());
   }
 
   // Clean up "../" inside full path
   char exe_full_path[kMaxPath] = {0};
   if (!GetFullPathNameA(exe_file_name, kMaxPath, exe_full_path, nullptr)) {
-    FATAL("GetFullPathNameA failed with: %u", GetLastError());
+    FATAL("GetFullPathNameA failed with: %s", GetLastErrorAsString());
   }
 
   return std::filesystem::path(exe_full_path);
@@ -41,13 +42,15 @@ ErrorMessageOr<std::filesystem::path> GetExecutablePath(uint32_t pid) {
   char exe_file_name[kMaxPath] = {0};
 
   if (!GetModuleFileNameExA(handle, /*hModule=*/nullptr, exe_file_name, kMaxPath)) {
-    return ErrorMessage(absl::StrFormat("GetModuleFileNameExA failed with: %u", GetLastError()));
+    return ErrorMessage(
+        absl::StrFormat("GetModuleFileNameExA failed with: %s", GetLastErrorAsString()));
   }
 
   // Clean up "../" inside full path
   char exe_full_path[kMaxPath] = {0};
   if (!GetFullPathNameA(exe_file_name, kMaxPath, exe_full_path, nullptr)) {
-    return ErrorMessage(absl::StrFormat("GetFullPathNameA failed with: %u", GetLastError()));
+    return ErrorMessage(
+        absl::StrFormat("GetFullPathNameA failed with: %s", GetLastErrorAsString()));
   }
 
   return std::filesystem::path(exe_full_path);

--- a/src/OrbitBase/GetLastError.cpp
+++ b/src/OrbitBase/GetLastError.cpp
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "WindowsUtils/GetLastError.h"
+#include "OrbitBase/GetLastError.h"
 
 #include <absl/base/casts.h>
 #include <absl/strings/ascii.h>
 #include <windows.h>
 
-namespace orbit_windows_utils {
+namespace orbit_base {
 
 std::string GetLastErrorAsString() {
   DWORD error = ::GetLastError();
@@ -39,4 +39,4 @@ std::string GetLastErrorAsString() {
   return std::string(absl::StripAsciiWhitespace(error_as_string));
 }
 
-}  // namespace orbit_windows_utils
+}  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/GetLastError.h
+++ b/src/OrbitBase/include/OrbitBase/GetLastError.h
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef WINDOWS_UTILS_GET_LAST_ERROR_H_
-#define WINDOWS_UTILS_GET_LAST_ERROR_H_
+#ifndef ORBIT_BASE_GET_LAST_ERROR_H_
+#define ORBIT_BASE_GET_LAST_ERROR_H_
 
 #include <string>
 
-namespace orbit_windows_utils {
+namespace orbit_base {
 
 [[nodiscard]] std::string GetLastErrorAsString();
 
-}  // namespace orbit_windows_utils
+}  // namespace orbit_base
 
-#endif  // WINDOWS_UTILS_GET_LAST_ERROR_H_
+#endif  // ORBIT_BASE_GET_LAST_ERROR_H_

--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -22,7 +22,6 @@ target_include_directories(WindowsUtils PRIVATE
 target_sources(WindowsUtils PUBLIC
         include/WindowsUtils/AdjustTokenPrivilege.h
         include/WindowsUtils/FindDebugSymbols.h
-        include/WindowsUtils/GetLastError.h
         include/WindowsUtils/ListModules.h
         include/WindowsUtils/ListThreads.h
         include/WindowsUtils/PerformanceCounter.h
@@ -32,7 +31,6 @@ target_sources(WindowsUtils PUBLIC
 target_sources(WindowsUtils PRIVATE
         AdjustTokenPrivilege.cpp
         FindDebugSymbols.cpp
-        GetLastError.cpp
         ListModules.cpp
         ListThreads.cpp
         ProcessList.cpp


### PR DESCRIPTION
Move the GetLastErrorAsString() function to OrbitBase and use it for
better error logging in orbit_base::GetExecutablePath.