### PR TITLE
Make libunwindstack GCC-compatible

### DIFF
--- a/third_party/libunwindstack/ThreadUnwinder.cpp
+++ b/third_party/libunwindstack/ThreadUnwinder.cpp
@@ -87,8 +87,9 @@ ThreadEntry* ThreadUnwinder::SendSignalToThread(int signal, pid_t tid) {
 
   ThreadEntry* entry = ThreadEntry::Get(tid);
   entry->Lock();
-  struct sigaction new_action = {.sa_sigaction = SignalHandler,
-                                 .sa_flags = SA_RESTART | SA_SIGINFO | SA_ONSTACK};
+  struct sigaction new_action = {};
+  new_action.sa_sigaction = SignalHandler;
+  new_action.sa_flags = SA_RESTART | SA_SIGINFO | SA_ONSTACK;
   struct sigaction old_action = {};
   sigemptyset(&new_action.sa_mask);
   if (sigaction(signal, &new_action, &old_action) != 0) {
@@ -124,8 +125,9 @@ ThreadEntry* ThreadUnwinder::SendSignalToThread(int signal, pid_t tid) {
     // within the timeout. Add a signal handler that's simply going to log
     // something so that we don't crash if the signal eventually gets
     // delivered. Only do this if there isn't already an action set up.
-    struct sigaction log_action = {.sa_sigaction = SignalLogOnly,
-                                   .sa_flags = SA_RESTART | SA_SIGINFO | SA_ONSTACK};
+    struct sigaction log_action = {};
+    log_action.sa_sigaction = SignalLogOnly;
+    log_action.sa_flags = SA_RESTART | SA_SIGINFO | SA_ONSTACK;
     sigemptyset(&log_action.sa_mask);
     sigaction(signal, &log_action, nullptr);
   } else {

--- a/third_party/libunwindstack/tests/ElfInterfaceTest.cpp
+++ b/third_party/libunwindstack/tests/ElfInterfaceTest.cpp
@@ -36,7 +36,7 @@
 #define EM_AARCH64 183
 #endif
 
-#if __has_feature(address_sanitizer)
+#if 0
 // There is a test that tries to allocate a large value, allow it to fail
 // if asan is enabled.
 extern "C" const char* __asan_default_options() {

--- a/third_party/libunwindstack/tests/UnwinderTest.cpp
+++ b/third_party/libunwindstack/tests/UnwinderTest.cpp
@@ -1772,6 +1772,9 @@ TEST_F(UnwinderDeathTest, set_jit_debug_error) {
 }
 
 TEST_F(UnwinderDeathTest, set_dex_files_error) {
+#ifndef DEXFILE_SUPPORT
+  GTEST_SKIP();
+#endif
   Maps maps;
   std::shared_ptr<Memory> process_memory(new MemoryFake);
   Unwinder unwinder(10, &maps, process_memory);

--- a/third_party/libunwindstack/utils/MemoryFake.h
+++ b/third_party/libunwindstack/utils/MemoryFake.h
@@ -18,6 +18,7 @@
 #define _LIBUNWINDSTACK_UTILS_MEMORY_FAKE_H
 
 #include <stdint.h>
+#include <string.h>
 
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
This commit applies the patches that we used to have in the
libunwindstack conan recipe to the fork.

`libunwindstack` only promises to compile with the Android standard
compiler which is clang and that results in a couple of compilation
errors when compiled with GCC.

Just to be clear: All the changes made here are making the code more C++
standard compliant. It's not that we have to introduce workarounds to
make GCC work.