### PR TITLE
Create TimerDataInterface

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -27,11 +27,12 @@ target_sources(ClientData PUBLIC
         include/ClientData/ThreadTrackDataProvider.h
         include/ClientData/TimerChain.h
         include/ClientData/TimerTrackDataIdManager.h
+        include/ClientData/TimerData.h
+        include/ClientData/TimerDataInterface.h
+        include/ClientData/TimerDataManager.h
         include/ClientData/TimestampIntervalSet.h
         include/ClientData/TracepointCustom.h
         include/ClientData/TracepointData.h
-        include/ClientData/TimerDataManager.h
-        include/ClientData/TimerData.h
         include/ClientData/UserDefinedCaptureData.h)
 
 target_sources(ClientData PRIVATE

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -11,17 +11,9 @@
 
 #include "Containers/ScopeTree.h"
 #include "TimerData.h"
+#include "TimerDataInterface.h"
 
 namespace orbit_client_data {
-
-struct TimerMetadata {
-  bool is_empty;
-  size_t number_of_timers;
-  uint64_t min_time;
-  uint64_t max_time;
-  uint32_t depth;
-  uint32_t process_id;
-};
 
 // Stores all the timers from a particular ThreadId. Provides queries to get timers in a certain
 // range as well as metadata from them.

--- a/src/ClientData/include/ClientData/TimerDataInterface.h
+++ b/src/ClientData/include/ClientData/TimerDataInterface.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_TIMER_DATA_INTERFACE_H_
+#define CLIENT_DATA_TIMER_DATA_INTERFACE_H_
+
+#include "TimerChain.h"
+#include "capture_data.pb.h"
+
+namespace orbit_client_data {
+
+struct TimerMetadata {
+  bool is_empty;
+  size_t number_of_timers;
+  uint64_t min_time;
+  uint64_t max_time;
+  uint32_t depth;
+  uint32_t process_id;
+};
+
+// Interface to be use by TimerDataProvider to access data from TimerTracks.
+class TimerDataInterface {
+ public:
+  virtual ~TimerDataInterface() = default;
+
+  virtual const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info,
+                                                         uint32_t depth = 0) = 0;
+  [[nodiscard]] virtual TimerMetadata GetTimerMetadata() const = 0;
+  [[nodiscard]] virtual std::vector<const TimerChain*> GetChains() const = 0;
+  [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
+      uint64_t min_tick, uint64_t max_tick) const = 0;
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetLeft(
+      const orbit_client_protos::TimerInfo& timer) const = 0;
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetRight(
+      const orbit_client_protos::TimerInfo& timer) const = 0;
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetUp(
+      const orbit_client_protos::TimerInfo& timer) const = 0;
+  [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetDown(
+      const orbit_client_protos::TimerInfo& timer) const = 0;
+
+  // Only used in ScopeTreeTimerData
+  [[nodiscard]] virtual int64_t GetThreadId() const = 0;
+  virtual void OnCaptureComplete() = 0;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_TIMER_DATA_INTERFACE_H_


### PR DESCRIPTION
In this PR we are creating TimerDataInterface, a common interface
between TimerData and ScopeTreeTimerData (based on ScopeTree). This
interface will be used by TimerDataProvider to easily communicate with
both classes.

In the future we might be interested in replace GetChains by proper
queries (to access specific timers of some function, and a few more
uses), but the main queries are already here.

This PR is part of the process to move all timer-related data outside
the UI (http://b/202110356).

Henning's already given LGTM in
(https://github.com/google/orbit/pull/2933)