### PR TITLE
Replace `int ordered_in_file_descriptor` with `PerfEventOrderedStream`

### DIFF
--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -38,6 +38,8 @@ target_sources(LinuxTracing PRIVATE
         PerfEvent.h
         PerfEventOpen.cpp
         PerfEventOpen.h
+        PerfEventOrderedStream.cpp
+        PerfEventOrderedStream.h
         PerfEventProcessor.cpp
         PerfEventProcessor.h
         PerfEventQueue.cpp

--- a/src/LinuxTracing/PerfEventOrderedStream.cpp
+++ b/src/LinuxTracing/PerfEventOrderedStream.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "PerfEventOrderedStream.h"
+
+namespace orbit_linux_tracing {
+
+const PerfEventOrderedStream PerfEventOrderedStream::kNone{OrderType::kNotOrdered, 0};
+
+}  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/PerfEventOrderedStream.h
+++ b/src/LinuxTracing/PerfEventOrderedStream.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LINUX_TRACING_PERF_EVENT_ORDERED_STREAM_H_
+#define LINUX_TRACING_PERF_EVENT_ORDERED_STREAM_H_
+
+#include <absl/hash/hash.h>
+#include <sys/types.h>
+
+namespace orbit_linux_tracing {
+
+// This class holds information on streams on which `PerfEvent`s can be assumed in relative order of
+// timestamp. The information is used by `PerfEventQueue`.
+// In addition to the lack of order, the supported ordered streams are perf_event_open ring buffers
+// (identified by file descriptor) and threads (identified by thread id).
+class PerfEventOrderedStream {
+ public:
+  static const PerfEventOrderedStream kNone;
+
+  static PerfEventOrderedStream FileDescriptor(int fd) {
+    return PerfEventOrderedStream{OrderType::kOrderedInFileDescriptor, fd};
+  }
+
+  static PerfEventOrderedStream ThreadId(pid_t tid) {
+    return PerfEventOrderedStream{OrderType::kOrderedInThreadId, tid};
+  }
+
+  // Make this class hashable for use as key in an absl::flat_hash_map.
+  template <typename H>
+  friend H AbslHashValue(H state, const PerfEventOrderedStream& order) {
+    return H::combine(std::move(state), order.order_type_, order.order_value_);
+  }
+
+  friend bool operator==(const PerfEventOrderedStream& lhs, const PerfEventOrderedStream& rhs) {
+    return lhs.order_type_ == rhs.order_type_ && lhs.order_value_ == rhs.order_value_;
+  }
+
+  friend bool operator!=(const PerfEventOrderedStream& lhs, const PerfEventOrderedStream& rhs) {
+    return !(lhs == rhs);
+  }
+
+ private:
+  enum class OrderType {
+    kNotOrdered = 0,
+    kOrderedInFileDescriptor,
+    kOrderedInThreadId,
+  };
+
+  // The internal representation need not and should not be externally accessible. From the outside,
+  // the only information that should be used is whether two instances of this class indicate the
+  // same stream of ordered events.
+  OrderType order_type_;
+  // Conveniently, both file descriptors and thread ids are signed 32-bit integers.
+  int32_t order_value_;
+
+  PerfEventOrderedStream(OrderType order_type, int32_t order_value)
+      : order_type_{order_type}, order_value_{order_value} {}
+};
+
+}  // namespace orbit_linux_tracing
+
+#endif  // LINUX_TRACING_PERF_EVENT_ORDERED_STREAM_H_

--- a/src/LinuxTracing/PerfEventQueue.cpp
+++ b/src/LinuxTracing/PerfEventQueue.cpp
@@ -4,22 +4,23 @@
 
 #include "PerfEventQueue.h"
 
-#include <absl/meta/type_traits.h>
 #include <stddef.h>
 
 #include <algorithm>
 #include <utility>
 
 #include "OrbitBase/Logging.h"
+#include "PerfEvent.h"
+#include "PerfEventOrderedStream.h"
 
 namespace orbit_linux_tracing {
 
 void PerfEventQueue::PushEvent(PerfEvent&& event) {
-  const int origin_fd = event.ordered_in_file_descriptor;
-  if (origin_fd == kNotOrderedInAnyFileDescriptor) {
-    priority_queue_of_events_not_ordered_by_fd_.push(std::move(event));
-  } else if (auto queue_it = queues_of_events_ordered_by_fd_.find(origin_fd);
-             queue_it != queues_of_events_ordered_by_fd_.end()) {
+  const PerfEventOrderedStream order = event.ordered_stream;
+  if (order == PerfEventOrderedStream::kNone) {
+    priority_queue_of_events_not_ordered_in_stream_.push(std::move(event));
+  } else if (auto queue_it = queues_of_events_ordered_in_stream_.find(order);
+             queue_it != queues_of_events_ordered_in_stream_.end()) {
     const std::unique_ptr<std::queue<PerfEvent>>& queue = queue_it->second;
 
     CHECK(!queue->empty());
@@ -27,70 +28,70 @@ void PerfEventQueue::PushEvent(PerfEvent&& event) {
     CHECK(event.timestamp >= queue->back().timestamp);
     queue->push(std::move(event));
   } else {
-    queue_it = queues_of_events_ordered_by_fd_
-                   .emplace(origin_fd, std::make_unique<std::queue<PerfEvent>>())
+    queue_it = queues_of_events_ordered_in_stream_
+                   .emplace(order, std::make_unique<std::queue<PerfEvent>>())
                    .first;
     const std::unique_ptr<std::queue<PerfEvent>>& queue = queue_it->second;
 
     queue->push(std::move(event));
-    heap_of_queues_of_events_ordered_by_fd_.emplace_back(queue.get());
+    heap_of_queues_of_events_ordered_in_stream_.emplace_back(queue.get());
     MoveUpBackOfHeapOfQueues();
   }
 }
 
 bool PerfEventQueue::HasEvent() const {
-  return !heap_of_queues_of_events_ordered_by_fd_.empty() ||
-         !priority_queue_of_events_not_ordered_by_fd_.empty();
+  return !heap_of_queues_of_events_ordered_in_stream_.empty() ||
+         !priority_queue_of_events_not_ordered_in_stream_.empty();
 }
 
 const PerfEvent& PerfEventQueue::TopEvent() {
   // As we effectively have two priority queues, get the older event between the two events at the
   // top of the two queues. In case those two events have the exact same timestamp, return the one
-  // at the top of priority_queue_of_events_not_ordered_by_fd_ (and do the same in PopEvent).
-  if (priority_queue_of_events_not_ordered_by_fd_.empty()) {
-    CHECK(!heap_of_queues_of_events_ordered_by_fd_.empty());
-    CHECK(!heap_of_queues_of_events_ordered_by_fd_.front()->empty());
-    return heap_of_queues_of_events_ordered_by_fd_.front()->front();
+  // at the top of priority_queue_of_events_not_ordered_in_stream_ (and do the same in PopEvent).
+  if (priority_queue_of_events_not_ordered_in_stream_.empty()) {
+    CHECK(!heap_of_queues_of_events_ordered_in_stream_.empty());
+    CHECK(!heap_of_queues_of_events_ordered_in_stream_.front()->empty());
+    return heap_of_queues_of_events_ordered_in_stream_.front()->front();
   }
-  if (heap_of_queues_of_events_ordered_by_fd_.empty()) {
-    CHECK(!priority_queue_of_events_not_ordered_by_fd_.empty());
-    return priority_queue_of_events_not_ordered_by_fd_.top();
+  if (heap_of_queues_of_events_ordered_in_stream_.empty()) {
+    CHECK(!priority_queue_of_events_not_ordered_in_stream_.empty());
+    return priority_queue_of_events_not_ordered_in_stream_.top();
   }
-  return (heap_of_queues_of_events_ordered_by_fd_.front()->front().timestamp <
-          priority_queue_of_events_not_ordered_by_fd_.top().timestamp)
-             ? heap_of_queues_of_events_ordered_by_fd_.front()->front()
-             : priority_queue_of_events_not_ordered_by_fd_.top();
+  return (heap_of_queues_of_events_ordered_in_stream_.front()->front().timestamp <
+          priority_queue_of_events_not_ordered_in_stream_.top().timestamp)
+             ? heap_of_queues_of_events_ordered_in_stream_.front()->front()
+             : priority_queue_of_events_not_ordered_in_stream_.top();
 }
 
 void PerfEventQueue::PopEvent() {
-  if (!priority_queue_of_events_not_ordered_by_fd_.empty() &&
-      (heap_of_queues_of_events_ordered_by_fd_.empty() ||
-       priority_queue_of_events_not_ordered_by_fd_.top().timestamp <=
-           heap_of_queues_of_events_ordered_by_fd_.front()->front().timestamp)) {
+  if (!priority_queue_of_events_not_ordered_in_stream_.empty() &&
+      (heap_of_queues_of_events_ordered_in_stream_.empty() ||
+       priority_queue_of_events_not_ordered_in_stream_.top().timestamp <=
+           heap_of_queues_of_events_ordered_in_stream_.front()->front().timestamp)) {
     // The oldest event is at the top of the priority queue holding the events that cannot be
-    // assumed sorted in any ring buffer. Note in particular that we return and pop this event even
-    // if the event at the top of heap_of_queues_of_events_ordered_by_fd_ has the exact same
-    // timestamp, as we need to be consistent with TopEvent.
-    priority_queue_of_events_not_ordered_by_fd_.pop();
+    // assumed sorted in any stream. Note in particular that we pop this event even if the event at
+    // the top of heap_of_queues_of_events_ordered_in_stream_ has the exact same timestamp, as we
+    // need to be consistent with TopEvent.
+    priority_queue_of_events_not_ordered_in_stream_.pop();
     return;
   }
 
-  std::queue<PerfEvent>* top_queue = heap_of_queues_of_events_ordered_by_fd_.front();
-  const int top_fd = top_queue->front().ordered_in_file_descriptor;
+  std::queue<PerfEvent>* top_queue = heap_of_queues_of_events_ordered_in_stream_.front();
+  const PerfEventOrderedStream top_order = top_queue->front().ordered_stream;
   top_queue->pop();
 
   if (top_queue->empty()) {
-    queues_of_events_ordered_by_fd_.erase(top_fd);
-    std::swap(heap_of_queues_of_events_ordered_by_fd_.front(),
-              heap_of_queues_of_events_ordered_by_fd_.back());
-    heap_of_queues_of_events_ordered_by_fd_.pop_back();
+    queues_of_events_ordered_in_stream_.erase(top_order);
+    std::swap(heap_of_queues_of_events_ordered_in_stream_.front(),
+              heap_of_queues_of_events_ordered_in_stream_.back());
+    heap_of_queues_of_events_ordered_in_stream_.pop_back();
   }
 
   MoveDownFrontOfHeapOfQueues();
 }
 
 void PerfEventQueue::MoveDownFrontOfHeapOfQueues() {
-  if (heap_of_queues_of_events_ordered_by_fd_.empty()) {
+  if (heap_of_queues_of_events_ordered_in_stream_.empty()) {
     return;
   }
 
@@ -100,19 +101,19 @@ void PerfEventQueue::MoveDownFrontOfHeapOfQueues() {
     new_index = current_index;
     size_t left_index = current_index * 2 + 1;
     size_t right_index = current_index * 2 + 2;
-    if (left_index < heap_of_queues_of_events_ordered_by_fd_.size() &&
-        heap_of_queues_of_events_ordered_by_fd_[left_index]->front().timestamp <
-            heap_of_queues_of_events_ordered_by_fd_[new_index]->front().timestamp) {
+    if (left_index < heap_of_queues_of_events_ordered_in_stream_.size() &&
+        heap_of_queues_of_events_ordered_in_stream_[left_index]->front().timestamp <
+            heap_of_queues_of_events_ordered_in_stream_[new_index]->front().timestamp) {
       new_index = left_index;
     }
-    if (right_index < heap_of_queues_of_events_ordered_by_fd_.size() &&
-        heap_of_queues_of_events_ordered_by_fd_[right_index]->front().timestamp <
-            heap_of_queues_of_events_ordered_by_fd_[new_index]->front().timestamp) {
+    if (right_index < heap_of_queues_of_events_ordered_in_stream_.size() &&
+        heap_of_queues_of_events_ordered_in_stream_[right_index]->front().timestamp <
+            heap_of_queues_of_events_ordered_in_stream_[new_index]->front().timestamp) {
       new_index = right_index;
     }
     if (new_index != current_index) {
-      std::swap(heap_of_queues_of_events_ordered_by_fd_[new_index],
-                heap_of_queues_of_events_ordered_by_fd_[current_index]);
+      std::swap(heap_of_queues_of_events_ordered_in_stream_[new_index],
+                heap_of_queues_of_events_ordered_in_stream_[current_index]);
       current_index = new_index;
     } else {
       break;
@@ -121,19 +122,19 @@ void PerfEventQueue::MoveDownFrontOfHeapOfQueues() {
 }
 
 void PerfEventQueue::MoveUpBackOfHeapOfQueues() {
-  if (heap_of_queues_of_events_ordered_by_fd_.empty()) {
+  if (heap_of_queues_of_events_ordered_in_stream_.empty()) {
     return;
   }
 
-  size_t current_index = heap_of_queues_of_events_ordered_by_fd_.size() - 1;
+  size_t current_index = heap_of_queues_of_events_ordered_in_stream_.size() - 1;
   while (current_index > 0) {
     size_t parent_index = (current_index - 1) / 2;
-    if (heap_of_queues_of_events_ordered_by_fd_[parent_index]->front().timestamp <=
-        heap_of_queues_of_events_ordered_by_fd_[current_index]->front().timestamp) {
+    if (heap_of_queues_of_events_ordered_in_stream_[parent_index]->front().timestamp <=
+        heap_of_queues_of_events_ordered_in_stream_[current_index]->front().timestamp) {
       break;
     }
-    std::swap(heap_of_queues_of_events_ordered_by_fd_[parent_index],
-              heap_of_queues_of_events_ordered_by_fd_[current_index]);
+    std::swap(heap_of_queues_of_events_ordered_in_stream_[parent_index],
+              heap_of_queues_of_events_ordered_in_stream_[current_index]);
     current_index = parent_index;
   }
 }

--- a/src/LinuxTracing/PerfEventQueueTest.cpp
+++ b/src/LinuxTracing/PerfEventQueueTest.cpp
@@ -15,11 +15,25 @@ namespace orbit_linux_tracing {
 
 namespace {
 
-// We do the testing with ForkPerfEvent's - that is just an arbitrary choice.
-PerfEvent MakeTestEvent(int origin_fd, uint64_t timestamp) {
+// We do the testing with `ForkPerfEvent`s - that is just an arbitrary choice.
+PerfEvent MakeTestEventNotOrdered(uint64_t timestamp) {
   return ForkPerfEvent{
       .timestamp = timestamp,
-      .ordered_in_file_descriptor = origin_fd,
+      .ordered_stream = PerfEventOrderedStream::kNone,
+  };
+}
+
+PerfEvent MakeTestEventOrderedInFd(int origin_fd, uint64_t timestamp) {
+  return ForkPerfEvent{
+      .timestamp = timestamp,
+      .ordered_stream = PerfEventOrderedStream::FileDescriptor(origin_fd),
+  };
+}
+
+PerfEvent MakeTestEventOrderedInTid(pid_t tid, uint64_t timestamp) {
+  return ForkPerfEvent{
+      .timestamp = timestamp,
+      .ordered_stream = PerfEventOrderedStream::ThreadId(tid),
   };
 }
 
@@ -32,16 +46,16 @@ TEST(PerfEventQueue, SingleFd) {
 
   EXPECT_FALSE(event_queue.HasEvent());
 
-  event_queue.PushEvent(MakeTestEvent(kOriginFd, 100));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(kOriginFd, 100));
 
-  event_queue.PushEvent(MakeTestEvent(kOriginFd, 101));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(kOriginFd, 101));
 
   ASSERT_TRUE(event_queue.HasEvent());
   current_oldest_timestamp = 100;
   EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
   event_queue.PopEvent();
 
-  event_queue.PushEvent(MakeTestEvent(kOriginFd, 102));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(kOriginFd, 102));
 
   ASSERT_TRUE(event_queue.HasEvent());
   current_oldest_timestamp = 101;
@@ -55,7 +69,7 @@ TEST(PerfEventQueue, SingleFd) {
 
   EXPECT_FALSE(event_queue.HasEvent());
 
-  event_queue.PushEvent(MakeTestEvent(kOriginFd, 103));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(kOriginFd, 103));
 
   ASSERT_TRUE(event_queue.HasEvent());
   current_oldest_timestamp = 103;
@@ -68,9 +82,17 @@ TEST(PerfEventQueue, SingleFd) {
 TEST(PerfEventQueue, FdWithDecreasingTimestamps) {
   PerfEventQueue event_queue;
 
-  event_queue.PushEvent(MakeTestEvent(11, 101));
-  event_queue.PushEvent(MakeTestEvent(11, 103));
-  EXPECT_DEATH(event_queue.PushEvent(MakeTestEvent(11, 102)), "");
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 101));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 103));
+  EXPECT_DEATH(event_queue.PushEvent(MakeTestEventOrderedInFd(11, 102)), "");
+}
+
+TEST(PerfEventQueue, TidWithDecreasingTimestamps) {
+  PerfEventQueue event_queue;
+
+  event_queue.PushEvent(MakeTestEventOrderedInTid(11, 101));
+  event_queue.PushEvent(MakeTestEventOrderedInTid(11, 103));
+  EXPECT_DEATH(event_queue.PushEvent(MakeTestEventOrderedInTid(11, 102)), "");
 }
 
 TEST(PerfEventQueue, MultipleFd) {
@@ -79,11 +101,11 @@ TEST(PerfEventQueue, MultipleFd) {
 
   EXPECT_FALSE(event_queue.HasEvent());
 
-  event_queue.PushEvent(MakeTestEvent(11, 103));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 103));
 
-  event_queue.PushEvent(MakeTestEvent(22, 101));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(22, 101));
 
-  event_queue.PushEvent(MakeTestEvent(22, 102));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(22, 102));
 
   ASSERT_TRUE(event_queue.HasEvent());
   current_oldest_timestamp = 101;
@@ -95,9 +117,53 @@ TEST(PerfEventQueue, MultipleFd) {
   EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
   event_queue.PopEvent();
 
-  event_queue.PushEvent(MakeTestEvent(33, 100));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(33, 100));
 
-  event_queue.PushEvent(MakeTestEvent(11, 104));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 104));
+
+  ASSERT_TRUE(event_queue.HasEvent());
+  current_oldest_timestamp = 100;
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
+  event_queue.PopEvent();
+
+  ASSERT_TRUE(event_queue.HasEvent());
+  current_oldest_timestamp = 103;
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
+  event_queue.PopEvent();
+
+  ASSERT_TRUE(event_queue.HasEvent());
+  current_oldest_timestamp = 104;
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
+  event_queue.PopEvent();
+
+  EXPECT_FALSE(event_queue.HasEvent());
+}
+
+TEST(PerfEventQueue, MultipleTids) {
+  PerfEventQueue event_queue;
+  uint64_t current_oldest_timestamp;
+
+  EXPECT_FALSE(event_queue.HasEvent());
+
+  event_queue.PushEvent(MakeTestEventOrderedInTid(11, 103));
+
+  event_queue.PushEvent(MakeTestEventOrderedInTid(22, 101));
+
+  event_queue.PushEvent(MakeTestEventOrderedInTid(22, 102));
+
+  ASSERT_TRUE(event_queue.HasEvent());
+  current_oldest_timestamp = 101;
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
+  event_queue.PopEvent();
+
+  ASSERT_TRUE(event_queue.HasEvent());
+  current_oldest_timestamp = 102;
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
+  event_queue.PopEvent();
+
+  event_queue.PushEvent(MakeTestEventOrderedInTid(33, 100));
+
+  event_queue.PushEvent(MakeTestEventOrderedInTid(11, 104));
 
   ASSERT_TRUE(event_queue.HasEvent());
   current_oldest_timestamp = 100;
@@ -122,31 +188,31 @@ TEST(PerfEventQueue, FdWithOldestAndNewestEvent) {
 
   EXPECT_FALSE(event_queue.HasEvent());
 
-  event_queue.PushEvent(MakeTestEvent(11, 101));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 101));
   ASSERT_TRUE(event_queue.HasEvent());
   EXPECT_EQ(event_queue.TopEvent().timestamp, 101);
 
-  event_queue.PushEvent(MakeTestEvent(22, 102));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(22, 102));
   ASSERT_TRUE(event_queue.HasEvent());
   EXPECT_EQ(event_queue.TopEvent().timestamp, 101);
 
-  event_queue.PushEvent(MakeTestEvent(33, 103));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(33, 103));
   ASSERT_TRUE(event_queue.HasEvent());
   EXPECT_EQ(event_queue.TopEvent().timestamp, 101);
 
-  event_queue.PushEvent(MakeTestEvent(44, 104));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(44, 104));
   ASSERT_TRUE(event_queue.HasEvent());
   EXPECT_EQ(event_queue.TopEvent().timestamp, 101);
 
-  event_queue.PushEvent(MakeTestEvent(55, 105));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(55, 105));
   ASSERT_TRUE(event_queue.HasEvent());
   EXPECT_EQ(event_queue.TopEvent().timestamp, 101);
 
-  event_queue.PushEvent(MakeTestEvent(66, 106));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(66, 106));
   ASSERT_TRUE(event_queue.HasEvent());
   EXPECT_EQ(event_queue.TopEvent().timestamp, 101);
 
-  event_queue.PushEvent(MakeTestEvent(11, 999));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 999));
   ASSERT_TRUE(event_queue.HasEvent());
   EXPECT_EQ(event_queue.TopEvent().timestamp, 101);
 
@@ -178,22 +244,22 @@ TEST(PerfEventQueue, FdWithOldestAndNewestEvent) {
   EXPECT_FALSE(event_queue.HasEvent());
 }
 
-TEST(PerfEventQueue, NotOrderedInAnyFileDescriptor) {
+TEST(PerfEventQueue, NoOrder) {
   PerfEventQueue event_queue;
   uint64_t current_oldest_timestamp = 0;
 
   EXPECT_FALSE(event_queue.HasEvent());
 
-  event_queue.PushEvent(MakeTestEvent(kNotOrderedInAnyFileDescriptor, 104));
+  event_queue.PushEvent(MakeTestEventNotOrdered(104));
   current_oldest_timestamp = 104;
   EXPECT_TRUE(event_queue.HasEvent());
   EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
 
-  event_queue.PushEvent(MakeTestEvent(kNotOrderedInAnyFileDescriptor, 101));
+  event_queue.PushEvent(MakeTestEventNotOrdered(101));
   current_oldest_timestamp = 101;
   EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
 
-  event_queue.PushEvent(MakeTestEvent(kNotOrderedInAnyFileDescriptor, 102));
+  event_queue.PushEvent(MakeTestEventNotOrdered(102));
 
   EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
   event_queue.PopEvent();
@@ -208,7 +274,7 @@ TEST(PerfEventQueue, NotOrderedInAnyFileDescriptor) {
   EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
   ASSERT_TRUE(event_queue.HasEvent());
 
-  event_queue.PushEvent(MakeTestEvent(kNotOrderedInAnyFileDescriptor, 103));
+  event_queue.PushEvent(MakeTestEventNotOrdered(103));
   current_oldest_timestamp = 103;
 
   EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp);
@@ -223,18 +289,54 @@ TEST(PerfEventQueue, NotOrderedInAnyFileDescriptor) {
   EXPECT_DEATH(event_queue.PopEvent(), "");
 }
 
-TEST(PerfEventQueue, OrderedFdsAndNotOrderedInAnyFileDescriptor) {
+TEST(PerfEventQueue, OrderedInFdAndNoOrderTogether) {
   PerfEventQueue event_queue;
 
-  event_queue.PushEvent(MakeTestEvent(11, 103));
-  event_queue.PushEvent(MakeTestEvent(11, 105));
-  event_queue.PushEvent(MakeTestEvent(22, 102));
-  event_queue.PushEvent(MakeTestEvent(kNotOrderedInAnyFileDescriptor, 108));
-  event_queue.PushEvent(MakeTestEvent(11, 107));
-  event_queue.PushEvent(MakeTestEvent(22, 106));
-  event_queue.PushEvent(MakeTestEvent(kNotOrderedInAnyFileDescriptor, 101));
-  event_queue.PushEvent(MakeTestEvent(kNotOrderedInAnyFileDescriptor, 104));
-  event_queue.PushEvent(MakeTestEvent(22, 109));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 103));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 105));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(22, 102));
+  event_queue.PushEvent(MakeTestEventNotOrdered(108));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 107));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(22, 106));
+  event_queue.PushEvent(MakeTestEventNotOrdered(101));
+  event_queue.PushEvent(MakeTestEventNotOrdered(104));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(22, 109));
+
+  uint64_t current_oldest_timestamp = 101;
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
+  event_queue.PopEvent();
+  EXPECT_FALSE(event_queue.HasEvent());
+  EXPECT_DEATH(event_queue.PopEvent(), "");
+}
+
+TEST(PerfEventQueue, AllOrderTypesTogether) {
+  PerfEventQueue event_queue;
+
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 103));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 105));
+  event_queue.PushEvent(MakeTestEventOrderedInTid(11, 102));
+  event_queue.PushEvent(MakeTestEventNotOrdered(108));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, 107));
+  event_queue.PushEvent(MakeTestEventOrderedInTid(11, 106));
+  event_queue.PushEvent(MakeTestEventNotOrdered(101));
+  event_queue.PushEvent(MakeTestEventNotOrdered(104));
+  event_queue.PushEvent(MakeTestEventOrderedInTid(11, 109));
 
   uint64_t current_oldest_timestamp = 101;
   EXPECT_EQ(event_queue.TopEvent().timestamp, current_oldest_timestamp++);
@@ -261,22 +363,62 @@ TEST(PerfEventQueue, OrderedFdsAndNotOrderedInAnyFileDescriptor) {
 
 TEST(
     PerfEventQueue,
-    TopEventAndPopEventReturnTheSameWhenAnEventOrderedByFdAndAnEventNotOrderedInAnyFdHaveTheSameTimestamp) {
+    TopEventAndPopEventReturnTheSameWhenAnEventOrderedByFdAndAnEventWithNoOrderHaveTheSameTimestamp) {
   PerfEventQueue event_queue;
   constexpr uint64_t kCommonTimestamp = 100;
 
-  event_queue.PushEvent(MakeTestEvent(11, kCommonTimestamp));
-  event_queue.PushEvent(MakeTestEvent(kNotOrderedInAnyFileDescriptor, kCommonTimestamp));
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, kCommonTimestamp));
+  event_queue.PushEvent(MakeTestEventNotOrdered(kCommonTimestamp));
 
   const uint64_t top_timestamp = event_queue.TopEvent().timestamp;
-  const uint64_t top_fd = event_queue.TopEvent().ordered_in_file_descriptor;
+  const PerfEventOrderedStream top_order = event_queue.TopEvent().ordered_stream;
   event_queue.PopEvent();
 
   const uint64_t remaining_timestamp = event_queue.TopEvent().timestamp;
-  const uint64_t remaining_fd = event_queue.TopEvent().ordered_in_file_descriptor;
+  const PerfEventOrderedStream remaining_order = event_queue.TopEvent().ordered_stream;
 
   EXPECT_EQ(top_timestamp, remaining_timestamp);
-  EXPECT_NE(top_fd, remaining_fd);
+  EXPECT_NE(top_order, remaining_order);
+}
+
+TEST(
+    PerfEventQueue,
+    TopEventAndPopEventReturnTheSameWhenAnEventOrderedByTidAndAnEventWithNoOrderHaveTheSameTimestamp) {
+  PerfEventQueue event_queue;
+  constexpr uint64_t kCommonTimestamp = 100;
+
+  event_queue.PushEvent(MakeTestEventOrderedInTid(11, kCommonTimestamp));
+  event_queue.PushEvent(MakeTestEventNotOrdered(kCommonTimestamp));
+
+  const uint64_t top_timestamp = event_queue.TopEvent().timestamp;
+  const PerfEventOrderedStream top_order = event_queue.TopEvent().ordered_stream;
+  event_queue.PopEvent();
+
+  const uint64_t remaining_timestamp = event_queue.TopEvent().timestamp;
+  const PerfEventOrderedStream remaining_order = event_queue.TopEvent().ordered_stream;
+
+  EXPECT_EQ(top_timestamp, remaining_timestamp);
+  EXPECT_NE(top_order, remaining_order);
+}
+
+TEST(
+    PerfEventQueue,
+    TopEventAndPopEventReturnTheSameWhenAnEventOrderedByFdAndAnEventOrderedByTidHaveTheSameTimestamp) {
+  PerfEventQueue event_queue;
+  constexpr uint64_t kCommonTimestamp = 100;
+
+  event_queue.PushEvent(MakeTestEventOrderedInFd(11, kCommonTimestamp));
+  event_queue.PushEvent(MakeTestEventOrderedInTid(22, kCommonTimestamp));
+
+  const uint64_t top_timestamp = event_queue.TopEvent().timestamp;
+  const PerfEventOrderedStream top_order = event_queue.TopEvent().ordered_stream;
+  event_queue.PopEvent();
+
+  const uint64_t remaining_timestamp = event_queue.TopEvent().timestamp;
+  const PerfEventOrderedStream remaining_order = event_queue.TopEvent().ordered_stream;
+
+  EXPECT_EQ(top_timestamp, remaining_timestamp);
+  EXPECT_NE(top_order, remaining_order);
 }
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -855,7 +855,7 @@ uint64_t TracerImpl::ProcessForkEventAndReturnTimestamp(const perf_event_header&
   ring_buffer->ConsumeRecord(header, &ring_buffer_record);
   ForkPerfEvent event{
       .timestamp = ring_buffer_record.time,
-      .ordered_in_file_descriptor = ring_buffer->GetFileDescriptor(),
+      .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
               .pid = static_cast<pid_t>(ring_buffer_record.pid),
@@ -877,7 +877,7 @@ uint64_t TracerImpl::ProcessExitEventAndReturnTimestamp(const perf_event_header&
   ring_buffer->ConsumeRecord(header, &ring_buffer_record);
   ExitPerfEvent event{
       .timestamp = ring_buffer_record.time,
-      .ordered_in_file_descriptor = ring_buffer->GetFileDescriptor(),
+      .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
               .pid = static_cast<pid_t>(ring_buffer_record.pid),
@@ -956,7 +956,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
 
     UprobesPerfEvent event{
         .timestamp = ring_buffer_record.sample_id.time,
-        .ordered_in_file_descriptor = fd,
+        .ordered_stream = PerfEventOrderedStream::FileDescriptor(fd),
         .data =
             {
                 .pid = static_cast<pid_t>(ring_buffer_record.sample_id.pid),
@@ -984,7 +984,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
 
     UprobesWithArgumentsPerfEvent event{
         .timestamp = ring_buffer_record.sample_id.time,
-        .ordered_in_file_descriptor = fd,
+        .ordered_stream = PerfEventOrderedStream::FileDescriptor(fd),
         .data =
             {
                 .pid = static_cast<pid_t>(ring_buffer_record.sample_id.pid),
@@ -1011,7 +1011,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
 
     UretprobesPerfEvent event{
         .timestamp = ring_buffer_record.sample_id.time,
-        .ordered_in_file_descriptor = fd,
+        .ordered_stream = PerfEventOrderedStream::FileDescriptor(fd),
         .data =
             {
                 .pid = static_cast<pid_t>(ring_buffer_record.sample_id.pid),
@@ -1033,7 +1033,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
 
     UretprobesWithReturnValuePerfEvent event{
         .timestamp = ring_buffer_record.sample_id.time,
-        .ordered_in_file_descriptor = fd,
+        .ordered_stream = PerfEventOrderedStream::FileDescriptor(fd),
         .data =
             {
                 .pid = static_cast<pid_t>(ring_buffer_record.sample_id.pid),
@@ -1090,7 +1090,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
     ring_buffer->ConsumeRecord(header, &ring_buffer_record);
     TaskNewtaskPerfEvent event{
         .timestamp = ring_buffer_record.sample_id.time,
-        .ordered_in_file_descriptor = fd,
+        .ordered_stream = PerfEventOrderedStream::FileDescriptor(fd),
         .data =
             {
                 // The tracepoint format calls the new tid "data.pid" but it's effectively the
@@ -1110,7 +1110,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
 
     TaskRenamePerfEvent event{
         .timestamp = ring_buffer_record.sample_id.time,
-        .ordered_in_file_descriptor = fd,
+        .ordered_stream = PerfEventOrderedStream::FileDescriptor(fd),
         .data =
             {
                 // The tracepoint format calls the renamed tid "data.pid" but it's effectively the
@@ -1128,7 +1128,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
 
     SchedSwitchPerfEvent event{
         .timestamp = ring_buffer_record.sample_id.time,
-        .ordered_in_file_descriptor = fd,
+        .ordered_stream = PerfEventOrderedStream::FileDescriptor(fd),
         .data =
             {
                 .cpu = ring_buffer_record.sample_id.cpu,
@@ -1153,7 +1153,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
 
     SchedWakeupPerfEvent event{
         .timestamp = ring_buffer_record.sample_id.time,
-        .ordered_in_file_descriptor = fd,
+        .ordered_stream = PerfEventOrderedStream::FileDescriptor(fd),
         .data =
             {
                 // The tracepoint format calls the woken tid "data.pid" but it's effectively the
@@ -1230,7 +1230,7 @@ uint64_t TracerImpl::ProcessLostEventAndReturnTimestamp(const perf_event_header&
 
   LostPerfEvent event{
       .timestamp = timestamp,
-      .ordered_in_file_descriptor = ring_buffer->GetFileDescriptor(),
+      .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
               .previous_timestamp = fd_previous_timestamp_ns,


### PR DESCRIPTION
In addition to `PerfEvent`s sorted in their perf_event_open ring buffer, we want
to support events sorted in their thread. This is for the integration of user
space instrumentation and unwinding as per
http://go/stadia-orbit-user-space-instrumentation-and-unwinding#heading=h.a3i5cfh8pexm

We add the `class PerfEventOrderedStream` that represents what stream
`PerfEvent`s are already ordered in (if any), and we update `PerfEvent` and
`PerfEventQueue` accordingly.

We compared performance with the current solution and couldn't note any
measurable difference.

Bug: http://b/194704608

Test: Expand unit tests. Run `LinuxTracingIntegrationTests`. Capture Trata with
all capture options enabled.