### PR TITLE
Work with close/open intervals in GetTimers

### DIFF
--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -49,6 +49,9 @@ void ScopeTreeTimerData::OnCaptureComplete() {
 
 std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers(
     uint64_t start_ns, uint64_t end_ns) const {
+  // The query is for the interval [start_ns, end_ns], but it's easier to work with the close-open
+  // interval [start_ns, end_ns+1). We have to be careful with overflowing.
+  end_ns = std::max(end_ns, end_ns + 1);
   std::vector<const orbit_client_protos::TimerInfo*> all_timers;
 
   for (uint32_t depth = 0; depth < GetTimerMetadata().depth; ++depth) {
@@ -108,6 +111,9 @@ std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers
 
 std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimersAtDepthDiscretized(
     uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const {
+  // The query is for the interval [start_ns, end_ns], but it's easier to work with the close-open
+  // interval [start_ns, end_ns+1). We have to be careful with overflowing.
+  end_ns = std::max(end_ns, end_ns + 1);
   std::vector<const orbit_client_protos::TimerInfo*> all_timers_at_depth;
   absl::MutexLock lock(&scope_tree_mutex_);
 

--- a/src/ClientData/ScopeTreeTimerDataTest.cpp
+++ b/src/ClientData/ScopeTreeTimerDataTest.cpp
@@ -157,6 +157,11 @@ TEST(ScopeTreeTimerData, GetTimersAtDepthOptimized) {
           .size(),
       2);
 
+  // We should see only one timer if we have 1 pixel resolution.
+  EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthDiscretized(0, 1, kLeftTimerStart, kRightTimerEnd)
+                .size(),
+            1);
+
   // We should only see 1 if we zoom-out a lot even with a normal resolution.
   EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthDiscretized(0, 1000, 0, 10000000).size(), 1);
 


### PR DESCRIPTION
We are assuming that intervals in GetTimers functions are close-open
[start-end) but it's more natural to ask for an open-open interval (all
timers inside the time-range), so now we change the internal methods to
adjust it.

Found when making new ScopeTreeTimerData tests but didn't want to mix
with that PR. Not a big issue because after will be filtered, so I
didn't change it in ThreadTracks, as we are changing this in a following
PR anyways.

The test was failing because the nextPixelBoundary was wrong, and
FindFirstScopeAtTimer was taking a previous pixel and therefore we were
getting an extra timer we shouldn't have got.