### PR TITLE
Fix e2e test after ModulesDataView change

### DIFF
--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -50,7 +50,8 @@ class LoadSymbols(E2ETestCase):
 
         logging.info('Waiting for * to indicate loaded modules')
 
-        wait_for_condition(lambda: modules_dataview.get_item_at(0, 4).texts()[0] == "*", 100)
+        # The Loading column which should get filled with the "*" is the first column (0)
+        wait_for_condition(lambda: modules_dataview.get_item_at(0, 0).texts()[0] == "*", 100)
 
         functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0)


### PR DESCRIPTION
The column order of ModulesTab was changed in https://github.com/google/orbit/pull/2923 