### PR TITLE
Adapt ScopeTreeTimerData to TimerDataInterface

### DIFF
--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -19,7 +19,7 @@ TimerMetadata ScopeTreeTimerData::GetTimerMetadata() const {
 const orbit_client_protos::TimerInfo& ScopeTreeTimerData::AddTimer(
     orbit_client_protos::TimerInfo timer_info, uint32_t /*depth*/) {
   // We don't need to have one TimerChain per depth because it's managed by ScopeTree.
-  const auto& timer_info_ref = timer_data_.AddTimer(std::move(timer_info), /*depth=*/0);
+  const auto& timer_info_ref = timer_data_.AddTimer(std::move(timer_info), /*unused_depth=*/0);
 
   if (scope_tree_update_type_ == ScopeTreeUpdateType::kAlways) {
     absl::MutexLock lock(&scope_tree_mutex_);

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -31,10 +31,10 @@ class ScopeTreeTimerData final : public TimerDataInterface {
     return timer_data_.GetChains();
   }
 
-  // We are using a ScopeTree to automatically manage timers and their depth, not need to set it
+  // We are using a ScopeTree to automatically manage timers and their depth, no need to set it
   // here.
   const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info,
-                                                 uint32_t /*depth*/ = 0) override;
+                                                 uint32_t /*unused_depth*/ = 0) override;
   void OnCaptureComplete() override;
 
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(


### PR DESCRIPTION
In this PR we are adapting ScopeTreeTimerData to TimerDataInterface,
the common interface between TimerData and ScopeTreeTimerData.

For that we only need to add an unused_depth argument to AddTimer() and
erase the const in GetTimerMetadata().

This is the last part of https://github.com/google/orbit/pull/2933,
which was already reviewed by Henning.