### PR TITLE
Fix the behavior of tracks being moved outside of the screen

### DIFF
--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -67,7 +67,9 @@ void CaptureViewElement::SetVisible(bool value) {
 }
 
 void CaptureViewElement::OnPick(int x, int y) {
-  mouse_pos_last_click_ = viewport_->ScreenToWorld(Vec2i(x, y));
+  // TODO (b/204422745): Remove dependency to time_graph_->GetVerticalScrollingOffset()
+  mouse_pos_last_click_ =
+      viewport_->ScreenToWorld(Vec2i(x, y)) + Vec2(0, time_graph_->GetVerticalScrollingOffset());
   picking_offset_ = mouse_pos_last_click_ - pos_;
   mouse_pos_cur_ = mouse_pos_last_click_;
   picked_ = true;
@@ -79,7 +81,9 @@ void CaptureViewElement::OnRelease() {
 }
 
 void CaptureViewElement::OnDrag(int x, int y) {
-  mouse_pos_cur_ = viewport_->ScreenToWorld(Vec2i(x, y));
+  // TODO (b/204422745): Remove dependency to time_graph_->GetVerticalScrollingOffset()
+  mouse_pos_cur_ =
+      viewport_->ScreenToWorld(Vec2i(x, y)) + Vec2(0, time_graph_->GetVerticalScrollingOffset());
   RequestUpdate();
 }
 


### PR DESCRIPTION
Bug: b/204318669
Test: Move tracks outside of the screen, they behave as expected. Other dragging functionality (e.g. selection of samples) still works correctly.

Disclaimer, I am not super happy with this fix and it reveals a flaw in how scrolling is now designed... this would be solved by applying the more generalized solution of a `ScrollableContainer` and giving capture view elements the ability to query their position on screen. This was ditched because it seemed overengineered for what we are trying to achieve, but maybe I need to revisit this decision.