### PR TITLE
Add capture option (devmode) for frame-pointer unwinding

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -31,9 +31,6 @@ ABSL_FLAG(bool, enable_tutorials_feature, false, "Enable tutorials");
 ABSL_FLAG(uint16_t, stack_dump_size, 65000,
           "Number of bytes to copy from the stack per sample. Max: 65000");
 
-// TODO(b/160549506): Remove this flag once it can be specified in the ui.
-ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
-
 // TODO(kuebler): remove this once we have the validator complete
 ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
 

--- a/src/GrpcProtos/include/GrpcProtos/Constants.h
+++ b/src/GrpcProtos/include/GrpcProtos/Constants.h
@@ -20,7 +20,7 @@ constexpr uint64_t kMemoryInfoProducerId = 2;
 constexpr uint64_t kIntrospectionProducerId = 3;
 constexpr uint64_t kExternalProducerStartingId = 1024;
 
-enum class UnwindingMethod { kDwarfUnwinding, kFramePointerUnwinding };
+enum UnwindingMethod { kDwarfUnwinding = 0, kFramePointerUnwinding = 1 };
 }  // namespace orbit_grpc_protos
 
 #endif  // GRPC_PROTOS_CONSTANTS_H_

--- a/src/GrpcProtos/include/GrpcProtos/Constants.h
+++ b/src/GrpcProtos/include/GrpcProtos/Constants.h
@@ -20,7 +20,7 @@ constexpr uint64_t kMemoryInfoProducerId = 2;
 constexpr uint64_t kIntrospectionProducerId = 3;
 constexpr uint64_t kExternalProducerStartingId = 1024;
 
-enum UnwindingMethod { kDwarfUnwinding = 0, kFramePointerUnwinding = 1 };
+enum class UnwindingMethod { kDwarfUnwinding = 0, kFramePointerUnwinding = 1 };
 }  // namespace orbit_grpc_protos
 
 #endif  // GRPC_PROTOS_CONSTANTS_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1337,7 +1337,8 @@ void OrbitApp::StartCapture() {
       IsDevMode() && data_manager_->enable_user_space_instrumentation();
   double samples_per_second = data_manager_->samples_per_second();
   uint16_t stack_dump_size = data_manager_->stack_dump_size();
-  UnwindingMethod unwinding_method = data_manager_->unwinding_method();
+  UnwindingMethod unwinding_method =
+      IsDevMode() ? data_manager_->unwinding_method() : UnwindingMethod::kDwarfUnwinding;
   uint64_t max_local_marker_depth_per_command_buffer =
       data_manager_->max_local_marker_depth_per_command_buffer();
 

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -24,9 +24,15 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
+  ui_->unwindingMethodComboBox->addItem("DWARF",
+                                        orbit_grpc_protos::UnwindingMethod::kDwarfUnwinding);
+  ui_->unwindingMethodComboBox->addItem("Frame pointers",
+                                        orbit_grpc_protos::UnwindingMethod::kFramePointerUnwinding);
+
   if (!absl::GetFlag(FLAGS_devmode)) {
     // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
     ui_->samplingCheckBox->hide();
+    ui_->unwindingMethodWidget->hide();
     ui_->schedulerCheckBox->hide();
     ui_->gpuSubmissionsCheckBox->hide();
     ui_->userspaceCheckBox->hide();
@@ -55,6 +61,17 @@ void CaptureOptionsDialog::SetSamplingPeriodMs(double sampling_period_ms) {
 
 double CaptureOptionsDialog::GetSamplingPeriodMs() const {
   return ui_->samplingPeriodMsDoubleSpinBox->value();
+}
+
+void CaptureOptionsDialog::SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method) {
+  int index = ui_->unwindingMethodComboBox->findData(unwinding_method);
+  CHECK(index >= 0);
+  return ui_->unwindingMethodComboBox->setCurrentIndex(index);
+}
+
+orbit_grpc_protos::UnwindingMethod CaptureOptionsDialog::GetUnwindingMethod() const {
+  return static_cast<orbit_grpc_protos::UnwindingMethod>(
+      ui_->unwindingMethodComboBox->currentData().toInt());
 }
 
 void CaptureOptionsDialog::SetCollectSchedulerInfo(bool collect_scheduler_info) {

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -24,10 +24,11 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
-  ui_->unwindingMethodComboBox->addItem("DWARF",
-                                        orbit_grpc_protos::UnwindingMethod::kDwarfUnwinding);
-  ui_->unwindingMethodComboBox->addItem("Frame pointers",
-                                        orbit_grpc_protos::UnwindingMethod::kFramePointerUnwinding);
+  ui_->unwindingMethodComboBox->addItem(
+      "DWARF", static_cast<int>(orbit_grpc_protos::UnwindingMethod::kDwarfUnwinding));
+  ui_->unwindingMethodComboBox->addItem(
+      "Frame pointers",
+      static_cast<int>(orbit_grpc_protos::UnwindingMethod::kFramePointerUnwinding));
 
   if (!absl::GetFlag(FLAGS_devmode)) {
     // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
@@ -64,7 +65,7 @@ double CaptureOptionsDialog::GetSamplingPeriodMs() const {
 }
 
 void CaptureOptionsDialog::SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method) {
-  int index = ui_->unwindingMethodComboBox->findData(unwinding_method);
+  int index = ui_->unwindingMethodComboBox->findData(static_cast<int>(unwinding_method));
   CHECK(index >= 0);
   return ui_->unwindingMethodComboBox->setCurrentIndex(index);
 }

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -12,6 +12,7 @@
 #include <QWidget>
 #include <memory>
 
+#include "GrpcProtos/Constants.h"
 #include "OrbitBase/Logging.h"
 #include "ui_CaptureOptionsDialog.h"
 
@@ -48,6 +49,8 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] bool GetEnableSampling() const;
   void SetSamplingPeriodMs(double sampling_period_ms);
   [[nodiscard]] double GetSamplingPeriodMs() const;
+  void SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method);
+  [[nodiscard]] orbit_grpc_protos::UnwindingMethod GetUnwindingMethod() const;
   void SetCollectSchedulerInfo(bool collect_scheduler_info);
   [[nodiscard]] bool GetCollectSchedulerInfo() const;
   void SetCollectThreadStates(bool collect_thread_state);

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>478</width>
-    <height>523</height>
+    <height>553</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -86,6 +86,50 @@
            </spacer>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QWidget" name="unwindingMethodWidget" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="unwindingMethodLabel">
+             <property name="text">
+              <string>Callstack unwinding method:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="unwindingMethodComboBox"/>
+           </item>
+           <item>
+            <spacer name="unwindingMethodHorizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Expanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>112</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="schedulerCheckBox">
@@ -419,6 +463,22 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
     <hint type="destinationlabel">
      <x>202</x>
      <y>80</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>samplingCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>unwindingMethodComboBox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>238</x>
+     <y>50</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>259</x>
+     <y>110</y>
     </hint>
    </hints>
   </connection>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1088,7 +1088,8 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
     orbit_grpc_protos::UnwindingMethod unwinding_method =
         static_cast<orbit_grpc_protos::UnwindingMethod>(
             settings
-                .value(kCallstackUnwindingMethodSettingKey, kCallstackUnwindingMethodDefaultValue)
+                .value(kCallstackUnwindingMethodSettingKey,
+                       static_cast<int>(kCallstackUnwindingMethodDefaultValue))
                 .toInt());
     app_->SetUnwindingMethod(unwinding_method);
   } else {
@@ -1138,7 +1139,9 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
       settings.value(kCallstackSamplingPeriodMsSettingKey, kCallstackSamplingPeriodMsDefaultValue)
           .toDouble());
   dialog.SetUnwindingMethod(static_cast<orbit_grpc_protos::UnwindingMethod>(
-      settings.value(kCallstackUnwindingMethodSettingKey, kCallstackUnwindingMethodDefaultValue)
+      settings
+          .value(kCallstackUnwindingMethodSettingKey,
+                 static_cast<int>(kCallstackUnwindingMethodDefaultValue))
           .toInt()));
   dialog.SetCollectSchedulerInfo(settings.value(kCollectSchedulerInfoSettingKey, true).toBool());
   dialog.SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
@@ -1170,7 +1173,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
 
   settings.setValue(kEnableCallstackSamplingSettingKey, dialog.GetEnableSampling());
   settings.setValue(kCallstackSamplingPeriodMsSettingKey, dialog.GetSamplingPeriodMs());
-  settings.setValue(kCallstackUnwindingMethodSettingKey, dialog.GetUnwindingMethod());
+  settings.setValue(kCallstackUnwindingMethodSettingKey,
+                    static_cast<int>(dialog.GetUnwindingMethod()));
   settings.setValue(kCollectSchedulerInfoSettingKey, dialog.GetCollectSchedulerInfo());
   settings.setValue(kCollectThreadStatesSettingKey, dialog.GetCollectThreadStates());
   settings.setValue(kTraceGpuSubmissionsSettingKey, dialog.GetTraceGpuSubmissions());

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -185,6 +185,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   static const QString kEnableCallstackSamplingSettingKey;
   static const QString kCallstackSamplingPeriodMsSettingKey;
+  static const QString kCallstackUnwindingMethodSettingKey;
   static const QString kCollectSchedulerInfoSettingKey;
   static const QString kCollectThreadStatesSettingKey;
   static const QString kTraceGpuSubmissionsSettingKey;


### PR DESCRIPTION
This adds a capture option to set the unwinding method, and thus
exposes frame-pointer based unwinding. Currently, this option
is visible only in devmode.

Test: Set capture option. Check unwinding. Check persistency.