### PR TITLE
Replace GetTimerMetadata for several queries

### DIFF
--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -6,16 +6,6 @@
 
 namespace orbit_client_data {
 
-TimerMetadata ScopeTreeTimerData::GetTimerMetadata() const {
-  absl::MutexLock lock(&scope_tree_mutex_);
-  TimerMetadata timer_metadata = timer_data_.GetTimerMetadata();
-  // Special case. ScopeTree has a root node in depth 0 which shouldn't be considered.
-  timer_metadata.number_of_timers = scope_tree_.Size() - 1;
-  timer_metadata.is_empty = timer_metadata.number_of_timers == 0;
-  timer_metadata.depth = scope_tree_.Depth();
-  return timer_metadata;
-}
-
 const orbit_client_protos::TimerInfo& ScopeTreeTimerData::AddTimer(
     orbit_client_protos::TimerInfo timer_info, uint32_t /*depth*/) {
   // We don't need to have one TimerChain per depth because it's managed by ScopeTree.
@@ -51,7 +41,7 @@ std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers
   end_ns = std::max(end_ns, end_ns + 1);
   std::vector<const orbit_client_protos::TimerInfo*> all_timers;
 
-  for (uint32_t depth = 0; depth < GetTimerMetadata().depth; ++depth) {
+  for (uint32_t depth = 0; depth < GetDepth(); ++depth) {
     std::vector<const orbit_client_protos::TimerInfo*> timers_at_depth =
         GetTimersAtDepth(depth, start_ns, end_ns);
     all_timers.insert(all_timers.end(), timers_at_depth.begin(), timers_at_depth.end());

--- a/src/ClientData/ScopeTreeTimerDataTest.cpp
+++ b/src/ClientData/ScopeTreeTimerDataTest.cpp
@@ -57,7 +57,7 @@ TimersInTest AddTimersInScopeTreeTimerDataTest(ScopeTreeTimerData& scope_tree_ti
 
 TEST(ScopeTreeTimerData, EmptyWhenCreated) {
   ScopeTreeTimerData scope_tree_timer_data;
-  EXPECT_TRUE(scope_tree_timer_data.GetTimerMetadata().is_empty);
+  EXPECT_TRUE(scope_tree_timer_data.IsEmpty());
   EXPECT_TRUE(scope_tree_timer_data.GetTimers().empty());
   EXPECT_TRUE(scope_tree_timer_data.GetChains().empty());
 }
@@ -68,7 +68,7 @@ TEST(ScopeTreeTimerData, AddTimer) {
   orbit_client_protos::TimerInfo timer_info;
 
   scope_tree_timer_data.AddTimer(timer_info);
-  EXPECT_FALSE(scope_tree_timer_data.GetTimerMetadata().is_empty);
+  EXPECT_FALSE(scope_tree_timer_data.IsEmpty());
   EXPECT_EQ(scope_tree_timer_data.GetTimers().size(), 1);
   EXPECT_EQ(scope_tree_timer_data.GetThreadId(), kThreadId);
   EXPECT_EQ(scope_tree_timer_data.GetChains().size(), 1);
@@ -92,14 +92,12 @@ TEST(ScopeTreeTimerData, GetTimerMetadata) {
   ScopeTreeTimerData scope_tree_timer_data;
   AddTimersInScopeTreeTimerDataTest(scope_tree_timer_data);
 
-  const TimerMetadata timer_metadata = scope_tree_timer_data.GetTimerMetadata();
-
-  EXPECT_FALSE(timer_metadata.is_empty);
-  EXPECT_EQ(timer_metadata.number_of_timers, kNumTimers);
-  EXPECT_EQ(timer_metadata.depth, kDepth);
-  EXPECT_EQ(timer_metadata.min_time, kMinTimestamp);
-  EXPECT_EQ(timer_metadata.max_time, kMaxTimestamp);
-  EXPECT_EQ(timer_metadata.process_id, kProcessId);
+  EXPECT_FALSE(scope_tree_timer_data.IsEmpty());
+  EXPECT_EQ(scope_tree_timer_data.GetNumberOfTimers(), kNumTimers);
+  EXPECT_EQ(scope_tree_timer_data.GetDepth(), kDepth);
+  EXPECT_EQ(scope_tree_timer_data.GetMinTime(), kMinTimestamp);
+  EXPECT_EQ(scope_tree_timer_data.GetMaxTime(), kMaxTimestamp);
+  EXPECT_EQ(scope_tree_timer_data.GetProcessId(), kProcessId);
 }
 
 TEST(ScopeTreeTimerData, GetTimers) {

--- a/src/ClientData/ThreadTrackDataManagerTest.cpp
+++ b/src/ClientData/ThreadTrackDataManagerTest.cpp
@@ -26,8 +26,7 @@ TEST(ThreadTrackDataManager, CreateScopeTreeTimerData) {
   thread_track_data_manager.CreateScopeTreeTimerData(kThreadId1);
   // One ScopeTreeTimerData, no timers.
   EXPECT_EQ(thread_track_data_manager.GetAllScopeTreeTimerData().size(), 1);
-  EXPECT_TRUE(
-      thread_track_data_manager.GetScopeTreeTimerData(kThreadId1)->GetTimerMetadata().is_empty);
+  EXPECT_TRUE(thread_track_data_manager.GetScopeTreeTimerData(kThreadId1)->IsEmpty());
 }
 
 TEST(ThreadTrackDataManager, AddTimer) {
@@ -41,16 +40,14 @@ TEST(ThreadTrackDataManager, AddTimer) {
   thread_track_data_manager.AddTimer(timer_info);
 
   EXPECT_EQ(thread_track_data_manager.GetAllScopeTreeTimerData().size(), 1);
-  EXPECT_FALSE(
-      thread_track_data_manager.GetScopeTreeTimerData(kThreadId1)->GetTimerMetadata().is_empty);
+  EXPECT_FALSE(thread_track_data_manager.GetScopeTreeTimerData(kThreadId1)->IsEmpty());
 
   timer_info.set_thread_id(kThreadId2);
   // Adding a timer without creating the data before should also work.
   thread_track_data_manager.AddTimer(timer_info);
 
   EXPECT_EQ(thread_track_data_manager.GetAllScopeTreeTimerData().size(), 2);
-  EXPECT_FALSE(
-      thread_track_data_manager.GetScopeTreeTimerData(kThreadId2)->GetTimerMetadata().is_empty);
+  EXPECT_FALSE(thread_track_data_manager.GetScopeTreeTimerData(kThreadId2)->IsEmpty());
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/ThreadTrackDataProviderTest.cpp
+++ b/src/ClientData/ThreadTrackDataProviderTest.cpp
@@ -28,9 +28,7 @@ TEST(ThreadTrackDataProvider, EmptyWhenCreated) {
   // One ScopeTreeTimerData, still no timers
   EXPECT_FALSE(thread_track_data_provider.GetAllThreadIds().empty());
   EXPECT_TRUE(thread_track_data_provider.GetAllThreadTimerChains().empty());
-
-  // Therefore, TimerMetadata of kThreadId1 is still empty.
-  EXPECT_TRUE(thread_track_data_provider.GetTimerMetadata(kThreadId1).is_empty);
+  EXPECT_TRUE(thread_track_data_provider.IsEmpty(kThreadId1));
 }
 
 TEST(ThreadTrackDataProvider, InsertAndGetTimer) {
@@ -44,7 +42,7 @@ TEST(ThreadTrackDataProvider, InsertAndGetTimer) {
   timer_info.set_end(kTimerEnd);
   thread_track_data_provider.AddTimer(timer_info);
 
-  EXPECT_FALSE(thread_track_data_provider.GetTimerMetadata(kThreadId1).is_empty);
+  EXPECT_FALSE(thread_track_data_provider.IsEmpty(kThreadId1));
 
   std::vector<const TimerInfo*> all_timers = thread_track_data_provider.GetTimers(kThreadId1);
   EXPECT_EQ(all_timers.size(), 1);
@@ -212,22 +210,23 @@ TEST(ThreadTrackDataProvider, GetStatsFromThreadId) {
   ThreadTrackDataProvider thread_track_data_provider;
   InsertTimersForTesting(thread_track_data_provider);
 
-  const TimerMetadata timer_metadata_thread_1 =
-      thread_track_data_provider.GetTimerMetadata(kThreadId1);
-  const TimerMetadata timer_metadata_thread_2 =
-      thread_track_data_provider.GetTimerMetadata(kThreadId2);
+  EXPECT_EQ(thread_track_data_provider.GetNumberOfTimers(kThreadId1),
+            TimersInTest::kNumTimersInThread1);
+  EXPECT_EQ(thread_track_data_provider.GetMinTime(kThreadId1),
+            TimersInTest::kMinTimestampinThread1);
+  EXPECT_EQ(thread_track_data_provider.GetMaxTime(kThreadId1),
+            TimersInTest::kMaxTimestampinThread1);
+  EXPECT_EQ(thread_track_data_provider.GetDepth(kThreadId1), TimersInTest::kDepthThread1);
+  EXPECT_EQ(thread_track_data_provider.GetProcessId(kThreadId1), kProcessId);
 
-  EXPECT_EQ(timer_metadata_thread_1.number_of_timers, TimersInTest::kNumTimersInThread1);
-  EXPECT_EQ(timer_metadata_thread_1.min_time, TimersInTest::kMinTimestampinThread1);
-  EXPECT_EQ(timer_metadata_thread_1.max_time, TimersInTest::kMaxTimestampinThread1);
-  EXPECT_EQ(timer_metadata_thread_1.depth, TimersInTest::kDepthThread1);
-  EXPECT_EQ(timer_metadata_thread_1.process_id, kProcessId);
-
-  EXPECT_EQ(timer_metadata_thread_2.number_of_timers, TimersInTest::kNumTimersInThread2);
-  EXPECT_EQ(timer_metadata_thread_2.min_time, TimersInTest::kOtherThreadIdTimerStart);
-  EXPECT_EQ(timer_metadata_thread_2.max_time, TimersInTest::kOtherThreadIdTimerEnd);
-  EXPECT_EQ(timer_metadata_thread_2.depth, TimersInTest::kDepthThread2);
-  EXPECT_EQ(timer_metadata_thread_2.process_id, kProcessId);
+  EXPECT_EQ(thread_track_data_provider.GetNumberOfTimers(kThreadId2),
+            TimersInTest::kNumTimersInThread2);
+  EXPECT_EQ(thread_track_data_provider.GetMinTime(kThreadId2),
+            TimersInTest::kOtherThreadIdTimerStart);
+  EXPECT_EQ(thread_track_data_provider.GetMaxTime(kThreadId2),
+            TimersInTest::kOtherThreadIdTimerEnd);
+  EXPECT_EQ(thread_track_data_provider.GetDepth(kThreadId2), TimersInTest::kDepthThread2);
+  EXPECT_EQ(thread_track_data_provider.GetProcessId(kThreadId2), kProcessId);
 }
 
 TEST(ThreadTrackDataProvider, GetLeftRightUpDown) {

--- a/src/ClientData/TimerData.cpp
+++ b/src/ClientData/TimerData.cpp
@@ -19,20 +19,9 @@ const TimerInfo& TimerData::AddTimer(TimerInfo timer_info, uint32_t depth) {
   UpdateMinTime(timer_info.start());
   UpdateMaxTime(timer_info.end());
   ++num_timers_;
-  UpdateMaxDepth(timer_info.depth() + 1);
+  UpdateDepth(timer_info.depth() + 1);
 
   return timer_chain->emplace_back(std::move(timer_info));
-}
-
-TimerMetadata TimerData::GetTimerMetadata() const {
-  TimerMetadata timer_metadata;
-  timer_metadata.number_of_timers = num_timers_;
-  timer_metadata.is_empty = num_timers_ == 0;
-  timer_metadata.min_time = min_time_;
-  timer_metadata.max_time = max_time_;
-  timer_metadata.depth = max_depth_;
-  timer_metadata.process_id = process_id_;
-  return timer_metadata;
 }
 
 std::vector<const TimerChain*> TimerData::GetChains() const {

--- a/src/ClientData/TimerDataTest.cpp
+++ b/src/ClientData/TimerDataTest.cpp
@@ -12,14 +12,13 @@ using orbit_client_protos::TimerInfo;
 
 TEST(TimerData, IsEmpty) {
   TimerData timer_data;
-  TimerMetadata timer_metadata = timer_data.GetTimerMetadata();
   EXPECT_TRUE(timer_data.GetChains().empty());
   EXPECT_EQ(timer_data.GetChain(0), nullptr);
   EXPECT_EQ(timer_data.GetChain(7), nullptr);
-  EXPECT_TRUE(timer_metadata.is_empty);
-  EXPECT_EQ(timer_metadata.number_of_timers, 0);
-  EXPECT_EQ(timer_metadata.max_time, std::numeric_limits<uint64_t>::min());
-  EXPECT_EQ(timer_metadata.min_time, std::numeric_limits<uint64_t>::max());
+  EXPECT_TRUE(timer_data.IsEmpty());
+  EXPECT_EQ(timer_data.GetNumberOfTimers(), 0);
+  EXPECT_EQ(timer_data.GetMaxTime(), std::numeric_limits<uint64_t>::min());
+  EXPECT_EQ(timer_data.GetMinTime(), std::numeric_limits<uint64_t>::max());
 }
 
 TEST(TimerData, AddTimers) {
@@ -30,43 +29,43 @@ TEST(TimerData, AddTimers) {
 
   timer_data.AddTimer(timer_info, 0);
 
-  EXPECT_FALSE(timer_data.GetTimerMetadata().is_empty);
-  EXPECT_EQ(timer_data.GetTimerMetadata().number_of_timers, 1);
+  EXPECT_FALSE(timer_data.IsEmpty());
+  EXPECT_EQ(timer_data.GetNumberOfTimers(), 1);
   ASSERT_NE(timer_data.GetChain(0), nullptr);
   EXPECT_EQ(timer_data.GetChain(1), nullptr);
   EXPECT_EQ(timer_data.GetChain(0)->size(), 1);
 
-  EXPECT_EQ(timer_data.GetTimerMetadata().max_time, 5);
-  EXPECT_EQ(timer_data.GetTimerMetadata().min_time, 2);
+  EXPECT_EQ(timer_data.GetMaxTime(), 5);
+  EXPECT_EQ(timer_data.GetMinTime(), 2);
 
   timer_info.set_start(8);
   timer_info.set_end(11);
 
   timer_data.AddTimer(timer_info, 0);
 
-  EXPECT_FALSE(timer_data.GetTimerMetadata().is_empty);
-  EXPECT_EQ(timer_data.GetTimerMetadata().number_of_timers, 2);
+  EXPECT_FALSE(timer_data.IsEmpty());
+  EXPECT_EQ(timer_data.GetNumberOfTimers(), 2);
   ASSERT_NE(timer_data.GetChain(0), nullptr);
   EXPECT_EQ(timer_data.GetChain(1), nullptr);
   EXPECT_EQ(timer_data.GetChain(0)->size(), 2);
 
-  EXPECT_EQ(timer_data.GetTimerMetadata().max_time, 11);
-  EXPECT_EQ(timer_data.GetTimerMetadata().min_time, 2);
+  EXPECT_EQ(timer_data.GetMaxTime(), 11);
+  EXPECT_EQ(timer_data.GetMinTime(), 2);
 
   timer_info.set_start(10);
   timer_info.set_end(11);
 
   timer_data.AddTimer(timer_info, 1);
 
-  EXPECT_EQ(timer_data.GetTimerMetadata().number_of_timers, 3);
-  EXPECT_FALSE(timer_data.GetTimerMetadata().is_empty);
+  EXPECT_EQ(timer_data.GetNumberOfTimers(), 3);
+  EXPECT_FALSE(timer_data.IsEmpty());
   ASSERT_NE(timer_data.GetChain(0), nullptr);
   ASSERT_NE(timer_data.GetChain(1), nullptr);
   EXPECT_EQ(timer_data.GetChain(0)->size(), 2);
   EXPECT_EQ(timer_data.GetChain(1)->size(), 1);
 
-  EXPECT_EQ(timer_data.GetTimerMetadata().max_time, 11);
-  EXPECT_EQ(timer_data.GetTimerMetadata().min_time, 2);
+  EXPECT_EQ(timer_data.GetMaxTime(), 11);
+  EXPECT_EQ(timer_data.GetMinTime(), 2);
 }
 
 // TODO(b/204173036): Make GetFirstAfterStartTime private and test GetLeft/Right/Top/Down instead.

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -24,18 +24,14 @@ class ScopeTreeTimerData final : public TimerDataInterface {
                                                           ScopeTreeUpdateType::kAlways)
       : thread_id_(thread_id), scope_tree_update_type_(scope_tree_update_type){};
 
-  [[nodiscard]] int64_t GetThreadId() const override { return thread_id_; }
-  [[nodiscard]] TimerMetadata GetTimerMetadata() const override;
-
-  [[nodiscard]] std::vector<const TimerChain*> GetChains() const override {
-    return timer_data_.GetChains();
-  }
-
   // We are using a ScopeTree to automatically manage timers and their depth, no need to set it
   // here.
   const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info,
                                                  uint32_t /*unused_depth*/ = 0) override;
-  void OnCaptureComplete() override;
+  // Timers queries
+  [[nodiscard]] std::vector<const TimerChain*> GetChains() const override {
+    return timer_data_.GetChains();
+  }
 
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t start_ns = std::numeric_limits<uint64_t>::min(),
@@ -50,6 +46,23 @@ class ScopeTreeTimerData final : public TimerDataInterface {
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthDiscretized(
       uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const;
 
+  // Metadata queries
+  [[nodiscard]] bool IsEmpty() const override { return GetNumberOfTimers() == 0; };
+  // Special case. ScopeTree has a root node in depth 0 which shouldn't be considered.
+  [[nodiscard]] size_t GetNumberOfTimers() const override {
+    absl::MutexLock lock(&scope_tree_mutex_);
+    return scope_tree_.Size() - 1;
+  }
+  [[nodiscard]] uint64_t GetMinTime() const override { return timer_data_.GetMinTime(); }
+  [[nodiscard]] uint64_t GetMaxTime() const override { return timer_data_.GetMaxTime(); }
+  [[nodiscard]] uint32_t GetDepth() const override {
+    absl::MutexLock lock(&scope_tree_mutex_);
+    return scope_tree_.Depth();
+  }
+  [[nodiscard]] uint32_t GetProcessId() const override { return timer_data_.GetProcessId(); }
+  [[nodiscard]] int64_t GetThreadId() const override { return thread_id_; }
+
+  // Relative timers queries
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
       const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetRight(
@@ -58,6 +71,8 @@ class ScopeTreeTimerData final : public TimerDataInterface {
       const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
       const orbit_client_protos::TimerInfo& timer) const override;
+
+  void OnCaptureComplete() override;
 
  private:
   const int64_t thread_id_;

--- a/src/ClientData/include/ClientData/ThreadTrackDataProvider.h
+++ b/src/ClientData/include/ClientData/ThreadTrackDataProvider.h
@@ -52,10 +52,27 @@ class ThreadTrackDataProvider final {
                                                                          start_ns, end_ns);
   }
 
-  [[nodiscard]] const TimerMetadata GetTimerMetadata(uint32_t thread_id) const {
-    return GetScopeTreeTimerData(thread_id)->GetTimerMetadata();
+  // Metadata queries
+  [[nodiscard]] bool IsEmpty(uint32_t thread_id) const {
+    return GetScopeTreeTimerData(thread_id)->IsEmpty();
+  };
+  [[nodiscard]] size_t GetNumberOfTimers(uint32_t thread_id) const {
+    return GetScopeTreeTimerData(thread_id)->GetNumberOfTimers();
+  };
+  [[nodiscard]] uint64_t GetMinTime(uint32_t thread_id) const {
+    return GetScopeTreeTimerData(thread_id)->GetMinTime();
+  };
+  [[nodiscard]] uint64_t GetMaxTime(uint32_t thread_id) const {
+    return GetScopeTreeTimerData(thread_id)->GetMaxTime();
+  };
+  [[nodiscard]] uint32_t GetDepth(uint32_t thread_id) const {
+    return GetScopeTreeTimerData(thread_id)->GetDepth();
+  };
+  [[nodiscard]] uint32_t GetProcessId(uint32_t thread_id) const {
+    return GetScopeTreeTimerData(thread_id)->GetProcessId();
   };
 
+  // Relative Timers query
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
       const orbit_client_protos::TimerInfo& timer) const;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetRight(

--- a/src/ClientData/include/ClientData/TimerDataInterface.h
+++ b/src/ClientData/include/ClientData/TimerDataInterface.h
@@ -26,10 +26,21 @@ class TimerDataInterface {
 
   virtual const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info,
                                                          uint32_t depth) = 0;
-  [[nodiscard]] virtual TimerMetadata GetTimerMetadata() const = 0;
+
+  // Timers queries
   [[nodiscard]] virtual std::vector<const TimerChain*> GetChains() const = 0;
   [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t min_tick, uint64_t max_tick) const = 0;
+
+  // Metadata queries
+  [[nodiscard]] virtual bool IsEmpty() const = 0;
+  [[nodiscard]] virtual size_t GetNumberOfTimers() const = 0;
+  [[nodiscard]] virtual uint64_t GetMinTime() const = 0;
+  [[nodiscard]] virtual uint64_t GetMaxTime() const = 0;
+  [[nodiscard]] virtual uint32_t GetDepth() const = 0;
+  [[nodiscard]] virtual uint32_t GetProcessId() const = 0;
+
+  // Relative timers queries
   [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetLeft(
       const orbit_client_protos::TimerInfo& timer) const = 0;
   [[nodiscard]] virtual const orbit_client_protos::TimerInfo* GetRight(

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -245,7 +245,7 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, 
 
 bool ThreadTrack::IsEmpty() const {
   return thread_state_bar_->IsEmpty() && event_bar_->IsEmpty() && tracepoint_bar_->IsEmpty() &&
-         timer_data_->GetTimerMetadata().is_empty;
+         TimerTrack::IsEmpty();
 }
 
 void ThreadTrack::UpdatePositionOfSubtracks() {

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -351,7 +351,7 @@ const TimerInfo* TimerTrack::GetDown(const TimerInfo& timer_info) const {
   return timer_data_->GetFirstAfterStartTime(timer_info.start(), timer_info.depth() + 1);
 }
 
-bool TimerTrack::IsEmpty() const { return timer_data_->GetTimerMetadata().is_empty; }
+bool TimerTrack::IsEmpty() const { return timer_data_->IsEmpty(); }
 
 std::string TimerTrack::GetBoxTooltip(const Batcher& /*batcher*/, PickingId /*id*/) const {
   return "";
@@ -390,8 +390,6 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   return draw_data;
 }
 
-size_t TimerTrack::GetNumberOfTimers() const {
-  return timer_data_->GetTimerMetadata().number_of_timers;
-}
-uint64_t TimerTrack::GetMinTime() const { return timer_data_->GetTimerMetadata().min_time; }
-uint64_t TimerTrack::GetMaxTime() const { return timer_data_->GetTimerMetadata().max_time; }
+size_t TimerTrack::GetNumberOfTimers() const { return timer_data_->GetNumberOfTimers(); }
+uint64_t TimerTrack::GetMinTime() const { return timer_data_->GetMinTime(); }
+uint64_t TimerTrack::GetMaxTime() const { return timer_data_->GetMaxTime(); }

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -64,9 +64,7 @@ class TimerTrack : public Track {
   // Track
   [[nodiscard]] Type GetType() const override { return Type::kTimerTrack; }
 
-  [[nodiscard]] uint32_t GetProcessId() const override {
-    return timer_data_->GetTimerMetadata().process_id;
-  }
+  [[nodiscard]] uint32_t GetProcessId() const override { return timer_data_->GetProcessId(); }
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer) const;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
@@ -94,7 +92,7 @@ class TimerTrack : public Track {
   [[nodiscard]] int GetVisiblePrimitiveCount() const override { return visible_timer_count_; }
 
   [[nodiscard]] float GetHeight() const override;
-  [[nodiscard]] uint32_t GetDepth() const { return timer_data_->GetTimerMetadata().depth; }
+  [[nodiscard]] uint32_t GetDepth() const { return timer_data_->GetDepth(); }
 
   [[nodiscard]] size_t GetNumberOfTimers() const;
   [[nodiscard]] uint64_t GetMinTime() const override;


### PR DESCRIPTION
**My plan to make chained PRs didn't work. Please consider only the second commit.**

Discussed in https://github.com/google/orbit/pull/2951#discussion_r738241849

We agree on replace GetTimerMetadata by proper simple queries (IsEmpty,
GetNumberOfTimers, GetMinTime, GetMaxTime, GetDepth, GetProcessId).

In addition, we arrange methods to make the three interfaces similar.

- Adding Timers
- Getting Timers
- Getting Metadata
- Getting Neighbors

http://b/202110356