### PR TITLE
Add ability to join arbitrary futures

### DIFF
--- a/src/OrbitBase/include/OrbitBase/JoinFutures.h
+++ b/src/OrbitBase/include/OrbitBase/JoinFutures.h
@@ -5,6 +5,10 @@
 #ifndef ORBIT_BASE_JOIN_FUTURES_H_
 #define ORBIT_BASE_JOIN_FUTURES_H_
 
+#include <absl/base/thread_annotations.h>
+
+#include <utility>
+
 #include "OrbitBase/Future.h"
 #include "OrbitBase/FutureHelpers.h"
 #include "OrbitBase/Promise.h"
@@ -59,6 +63,62 @@ struct SharedStateJoin<void> {
   absl::Mutex mutex;
   size_t incomplete_futures;
 };
+
+template <typename... Ts>
+class SharedStateJoinTuple {
+  orbit_base::Promise<std::tuple<Ts...>> promise;
+  absl::Mutex mutex;
+  size_t incomplete_futures ABSL_GUARDED_BY(mutex) = sizeof...(Ts);
+  std::tuple<std::optional<Ts>...> results ABSL_GUARDED_BY(mutex);
+
+  template <std::size_t... Indexes>
+  void SetResultsInPromiseImpl(std::index_sequence<Indexes...> /* indexes */)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) {
+    CHECK(std::get<Indexes>(results) && ...);
+    auto finished_tuple = std::make_tuple(std::move(std::get<Indexes>(results).value())...);
+    (std::get<Indexes>(results).reset(), ...);
+    promise.SetResult(std::move(finished_tuple));
+  }
+
+  void SetResultsInPromise() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) {
+    SetResultsInPromiseImpl(std::make_index_sequence<sizeof...(Ts)>());
+  }
+
+ public:
+  template <size_t index>
+  void SetResult(const typename std::tuple_element<index, std::tuple<Ts...>>::type& argument)
+      ABSL_LOCKS_EXCLUDED(mutex) {
+    absl::MutexLock lock{&mutex};
+    if (!std::get<index>(results).has_value()) {
+      std::get<index>(results) = argument;
+      --incomplete_futures;
+    }
+
+    if (incomplete_futures == 0) {
+      SetResultsInPromise();
+    }
+  }
+
+  [[nodiscard]] orbit_base::Future<std::tuple<Ts...>> GetFuture() const {
+    return promise.GetFuture();
+  }
+};
+
+template <typename... Args, std::size_t... Indexes>
+orbit_base::Future<std::tuple<Args...>> JoinFuturesTupleImpl(
+    orbit_base::Future<Args>... futures, std::index_sequence<Indexes...> /* indexes */) {
+  CHECK(futures.IsValid() && ...);
+
+  auto shared_state = std::make_shared<orbit_base_internal::SharedStateJoinTuple<Args...>>();
+
+  (RegisterContinuationOrCallDirectly(futures,
+                                      [shared_state](const auto& argument) {
+                                        shared_state->template SetResult<Indexes>(argument);
+                                      }),
+   ...);
+
+  return shared_state->GetFuture();
+}
 }  // namespace orbit_base_internal
 
 namespace orbit_base {
@@ -90,6 +150,18 @@ Future<std::vector<T>> JoinFutures(absl::Span<const Future<T>> futures) {
 
   return shared_state->GetFuture();
 }
+
+// Returns a future which completes when all given futures have completed.
+// The returning future will contain a tuple of all the given future's values.
+// Note that a future of type `Future<void>` is not supported as an argument.
+template <typename Arg0, typename... Args>
+[[nodiscard]] Future<std::tuple<Arg0, Args...>> JoinFutures(Future<Arg0> future0,
+                                                            Future<Args>... futures) {
+  return orbit_base_internal::JoinFuturesTupleImpl<Arg0, Args...>(
+      std::move(future0), std::move(futures)...,
+      std::make_index_sequence<1 + sizeof...(futures)>());
+}
+
 }  // namespace orbit_base
 
 #endif  // ORBIT_BASE_JOIN_FUTURES_H_


### PR DESCRIPTION
This extends `orbit_base::JoinFuture` to allow joining a fixed number of
futures with different value types. Previously only `void` and a range
of futures of the same type has been supported.

`JoinFuture` will return a future with a `std::tuple` as its value type.
The tuple will contain all the values from each given future.

There is one limitation though: `void` is not supported as a value type
as this would require special handling in `std::tuple` which does not
allow `void` as a value type.