### PR TITLE
Make ThreadTracks query data from DataProvider

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -113,12 +113,14 @@ void CaptureData::AddFunctionStats(uint64_t instrumented_function_id,
   functions_stats_.insert_or_assign(instrumented_function_id, std::move(stats));
 }
 
-void CaptureData::OnCaptureComplete(
-    const std::vector<const orbit_client_data::TimerChain*>& chains) {
+void CaptureData::OnCaptureComplete() {
+  thread_track_data_provider_->OnCaptureComplete();
+
   // Recalculate standard deviation as the running calculation may have introduced error.
   absl::flat_hash_map<int, unsigned long> id_to_sum_of_deviations_squared;
 
-  for (const orbit_client_data::TimerChain* chain : chains) {
+  for (const orbit_client_data::TimerChain* chain :
+       thread_track_data_provider_->GetAllThreadTimerChains()) {
     CHECK(chain);
     for (const orbit_client_data::TimerBlock& block : *chain) {
       for (uint64_t i = 0; i < block.size(); i++) {

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -151,7 +151,7 @@ class CaptureData {
   void AddFunctionStats(uint64_t instrumented_function_id,
                         orbit_client_protos::FunctionStats stats);
 
-  void OnCaptureComplete(const std::vector<const orbit_client_data::TimerChain*>& chains);
+  void OnCaptureComplete();
 
   [[nodiscard]] const CallstackData& GetCallstackData() const { return callstack_data_; };
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -348,10 +348,7 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
 }
 
 Future<void> OrbitApp::OnCaptureComplete() {
-  for (ThreadTrack* thread_track : GetMutableTimeGraph()->GetTrackManager()->GetThreadTracks()) {
-    thread_track->OnCaptureComplete();
-  }
-  capture_data_->OnCaptureComplete(GetMutableTimeGraph()->GetAllThreadTrackTimerChains());
+  capture_data_->OnCaptureComplete();
 
   GetMutableCaptureData().FilterBrokenCallstacks();
   PostProcessedSamplingData post_processed_sampling_data =

--- a/src/OrbitGl/ThreadTrackTest.cpp
+++ b/src/OrbitGl/ThreadTrackTest.cpp
@@ -13,9 +13,8 @@ TEST(ThreadTrack, CaptureViewElementWorksAsIntended) {
   CaptureViewElementTester tester;
   std::unique_ptr<orbit_client_data::CaptureData> test_data =
       TrackTestData::GenerateTestCaptureData();
-  ThreadTrack track =
-      ThreadTrack(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), -1, nullptr,
-                  test_data.get(), nullptr, ThreadTrack::ScopeTreeUpdateType::kNever);
+  ThreadTrack track = ThreadTrack(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), -1,
+                                  nullptr, test_data.get(), nullptr);
   EXPECT_EQ(3ull, track.GetChildren().size());
   tester.RunTests(&track);
 }

--- a/src/OrbitGl/ThreadTrackTest.cpp
+++ b/src/OrbitGl/ThreadTrackTest.cpp
@@ -13,8 +13,8 @@ TEST(ThreadTrack, CaptureViewElementWorksAsIntended) {
   CaptureViewElementTester tester;
   std::unique_ptr<orbit_client_data::CaptureData> test_data =
       TrackTestData::GenerateTestCaptureData();
-  ThreadTrack track = ThreadTrack(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), -1,
-                                  nullptr, test_data.get(), nullptr);
+  ThreadTrack track(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), -1, nullptr,
+                    test_data.get(), nullptr);
   EXPECT_EQ(3ull, track.GetChildren().size());
   tester.RunTests(&track);
 }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -67,6 +67,7 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
       batcher_(BatcherId::kTimeGraph),
       manual_instrumentation_manager_{app->GetManualInstrumentationManager()},
       capture_data_{capture_data},
+      thread_track_data_provider_(capture_data->GetThreadTrackDataProvider()),
       app_{app} {
   text_renderer_static_.Init();
   text_renderer_static_.SetViewport(viewport);
@@ -298,13 +299,15 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
       break;
     }
     case TimerInfo::kNone: {
-      ThreadTrack* track = track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
-      track->OnTimer(timer_info);
+      // TODO (http://b/198135618): Create tracks only before drawing.
+      track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
+      thread_track_data_provider_->AddTimer(timer_info);
       break;
     }
     case TimerInfo::kApiScope: {
-      ThreadTrack* track = track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
-      track->OnTimer(timer_info);
+      // TODO (http://b/198135618): Create tracks only before drawing.
+      track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
+      thread_track_data_provider_->AddTimer(timer_info);
       break;
     }
     case TimerInfo::kApiScopeAsync: {
@@ -400,11 +403,7 @@ void TimeGraph::ProcessAsyncTimer(const std::string& track_name, const TimerInfo
 }
 
 std::vector<const TimerChain*> TimeGraph::GetAllThreadTrackTimerChains() const {
-  std::vector<const TimerChain*> chains;
-  for (const auto& track : track_manager_->GetThreadTracks()) {
-    orbit_base::Append(chains, track->GetChains());
-  }
-  return chains;
+  return thread_track_data_provider_->GetAllThreadTimerChains();
 }
 
 int TimeGraph::GetNumVisiblePrimitives() const {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -242,6 +242,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   ManualInstrumentationManager* manual_instrumentation_manager_;
   std::unique_ptr<ManualInstrumentationManager::AsyncTimerInfoListener> async_timer_info_listener_;
   const orbit_client_data::CaptureData* capture_data_ = nullptr;
+  orbit_client_data::ThreadTrackDataProvider* thread_track_data_provider_ = nullptr;
 
   OrbitApp* app_ = nullptr;
 };

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -64,7 +64,9 @@ class TimerTrack : public Track {
   // Track
   [[nodiscard]] Type GetType() const override { return Type::kTimerTrack; }
 
-  [[nodiscard]] uint32_t GetProcessId() const override { return timer_data_->GetProcessId(); }
+  [[nodiscard]] virtual uint32_t GetProcessId() const override {
+    return timer_data_->GetProcessId();
+  }
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer) const;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
@@ -76,7 +78,7 @@ class TimerTrack : public Track {
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
       const orbit_client_protos::TimerInfo& timer_info) const override;
 
-  [[nodiscard]] bool IsEmpty() const override;
+  [[nodiscard]] virtual bool IsEmpty() const override;
 
   [[nodiscard]] virtual float GetDefaultBoxHeight() const { return layout_->GetTextBoxHeight(); }
   [[nodiscard]] virtual float GetDynamicBoxHeight(
@@ -92,11 +94,11 @@ class TimerTrack : public Track {
   [[nodiscard]] int GetVisiblePrimitiveCount() const override { return visible_timer_count_; }
 
   [[nodiscard]] float GetHeight() const override;
-  [[nodiscard]] uint32_t GetDepth() const { return timer_data_->GetDepth(); }
+  [[nodiscard]] virtual uint32_t GetDepth() const { return timer_data_->GetDepth(); }
 
-  [[nodiscard]] size_t GetNumberOfTimers() const;
-  [[nodiscard]] uint64_t GetMinTime() const override;
-  [[nodiscard]] uint64_t GetMaxTime() const override;
+  [[nodiscard]] virtual size_t GetNumberOfTimers() const;
+  [[nodiscard]] virtual uint64_t GetMinTime() const override;
+  [[nodiscard]] virtual uint64_t GetMaxTime() const override;
 
  protected:
   void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -64,9 +64,7 @@ class TimerTrack : public Track {
   // Track
   [[nodiscard]] Type GetType() const override { return Type::kTimerTrack; }
 
-  [[nodiscard]] virtual uint32_t GetProcessId() const override {
-    return timer_data_->GetProcessId();
-  }
+  [[nodiscard]] uint32_t GetProcessId() const override { return timer_data_->GetProcessId(); }
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer) const;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
@@ -78,7 +76,7 @@ class TimerTrack : public Track {
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
       const orbit_client_protos::TimerInfo& timer_info) const override;
 
-  [[nodiscard]] virtual bool IsEmpty() const override;
+  [[nodiscard]] bool IsEmpty() const override;
 
   [[nodiscard]] virtual float GetDefaultBoxHeight() const { return layout_->GetTextBoxHeight(); }
   [[nodiscard]] virtual float GetDynamicBoxHeight(
@@ -97,8 +95,8 @@ class TimerTrack : public Track {
   [[nodiscard]] virtual uint32_t GetDepth() const { return timer_data_->GetDepth(); }
 
   [[nodiscard]] virtual size_t GetNumberOfTimers() const;
-  [[nodiscard]] virtual uint64_t GetMinTime() const override;
-  [[nodiscard]] virtual uint64_t GetMaxTime() const override;
+  [[nodiscard]] uint64_t GetMinTime() const override;
+  [[nodiscard]] uint64_t GetMaxTime() const override;
 
  protected:
   void DoUpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -478,12 +478,10 @@ ThreadTrack* TrackManager::GetOrCreateThreadTrack(uint32_t tid) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<ThreadTrack> track = thread_tracks_[tid];
   if (track == nullptr) {
-    ThreadTrack::ScopeTreeUpdateType scope_tree_update_type =
-        GetIsDataFromSavedCapture() ? ThreadTrack::ScopeTreeUpdateType::kOnCaptureComplete
-                                    : ThreadTrack::ScopeTreeUpdateType::kAlways;
-    auto [unused, timer_data] = capture_data_->CreateTimerData();
+    auto thread_track_data_provider = capture_data_->GetThreadTrackDataProvider();
+    thread_track_data_provider->CreateScopeTreeTimerData(tid);
     track = std::make_shared<ThreadTrack>(time_graph_, time_graph_, viewport_, layout_, tid, app_,
-                                          capture_data_, timer_data, scope_tree_update_type);
+                                          capture_data_, thread_track_data_provider);
     thread_tracks_[tid] = track;
     AddTrack(track);
   }


### PR DESCRIPTION
This PR finally switch ThreadTracks to query data from
ThreadTrackDataProvider instead of owning it.

All the methods to query the data are already properly tested in previous
PRs (in ThreadTrackDataProviderTest and ScopeTreeTimerDataTests).

As a result we are solving http://b/202110929.

As a summary:
- We are replacing all references to TimerData and ScopeTree in
ThreadTracks by queries to the provider
- CaptureData doesn't need to have thread track chains anymore in
OnCaptureComplete().

A real analysis of performance is needed. Enforcing a full redraw is
every frame is showing me around 4%/5% improvement in time to 
Draw + UpdatePrimitives, but this is not very precise.

There are two big TODOs:
- Create ThreadTracks only before drawing and not when processing a
Timer (in capture thread). (http://b/198135618)
- Expand ThreadTrackDataProvider to TimerDataProvider which provides
timer queries to all TimerTracks. Work in progress, we are probably in
70%. (http://b/202110356)