### PR TITLE
Rename kUprobesPatchingFailed to kCallstackPatchingFailed

### DIFF
--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -621,8 +621,8 @@ void CaptureEventProcessorForListener::SendCallstackToListenerIfNecessary(
     case orbit_grpc_protos::Callstack::kInUprobes:
       callstack_info.set_type(CallstackInfo::kInUprobes);
       break;
-    case orbit_grpc_protos::Callstack::kUprobesPatchingFailed:
-      callstack_info.set_type(CallstackInfo::kUprobesPatchingFailed);
+    case orbit_grpc_protos::Callstack::kCallstackPatchingFailed:
+      callstack_info.set_type(CallstackInfo::kCallstackPatchingFailed);
       break;
     case orbit_grpc_protos::Callstack::kStackTopForDwarfUnwindingTooSmall:
       callstack_info.set_type(CallstackInfo::kStackTopForDwarfUnwindingTooSmall);

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -192,8 +192,8 @@ static void ExpectCallstackSamplesEqual(const CallstackEvent& actual_callstack_e
     case Callstack::kInUprobes:
       EXPECT_EQ(actual_callstack.type(), CallstackInfo::kInUprobes);
       break;
-    case Callstack::kUprobesPatchingFailed:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kUprobesPatchingFailed);
+    case Callstack::kCallstackPatchingFailed:
+      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kCallstackPatchingFailed);
       break;
     case Callstack::kStackTopDwarfUnwindingError:
       EXPECT_EQ(actual_callstack.type(), CallstackInfo::kStackTopDwarfUnwindingError);
@@ -248,7 +248,7 @@ TEST(CaptureEventProcessor, CanHandleOneNonCompleteCallstackSample) {
   CanHandleOneCallstackSampleOfType(Callstack::kDwarfUnwindingError);
   CanHandleOneCallstackSampleOfType(Callstack::kFramePointerUnwindingError);
   CanHandleOneCallstackSampleOfType(Callstack::kInUprobes);
-  CanHandleOneCallstackSampleOfType(Callstack::kUprobesPatchingFailed);
+  CanHandleOneCallstackSampleOfType(Callstack::kCallstackPatchingFailed);
   CanHandleOneCallstackSampleOfType(Callstack::kStackTopDwarfUnwindingError);
   CanHandleOneCallstackSampleOfType(Callstack::kStackTopForDwarfUnwindingTooSmall);
 }

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -62,7 +62,7 @@ message CallstackInfo {
     kDwarfUnwindingError = 1;
     kFramePointerUnwindingError = 2;
     kInUprobes = 3;
-    kUprobesPatchingFailed = 4;
+    kCallstackPatchingFailed = 4;
     kStackTopForDwarfUnwindingTooSmall = 5;
     kStackTopDwarfUnwindingError = 6;
     // These are set by the client and are in addition to the ones in

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -355,7 +355,7 @@ message Callstack {
     kDwarfUnwindingError = 1;
     kFramePointerUnwindingError = 2;
     kInUprobes = 3;
-    kUprobesPatchingFailed = 4;
+    kCallstackPatchingFailed = 4;
     kStackTopForDwarfUnwindingTooSmall = 5;
     kStackTopDwarfUnwindingError = 6;
   }

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -109,7 +109,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
     if (unwind_error_counter_ != nullptr) {
       ++(*unwind_error_counter_);
     }
-    callstack->set_type(Callstack::kUprobesPatchingFailed);
+    callstack->set_type(Callstack::kCallstackPatchingFailed);
     SendFullAddressInfoToListener(listener_, libunwindstack_result.frames().front());
     callstack->add_pcs(libunwindstack_result.frames().front().pc);
 
@@ -223,7 +223,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
     if (unwind_error_counter_ != nullptr) {
       ++(*unwind_error_counter_);
     }
-    callstack->set_type(Callstack::kUprobesPatchingFailed);
+    callstack->set_type(Callstack::kCallstackPatchingFailed);
     callstack->add_pcs(top_ip);
     listener_->OnCallstackSample(std::move(sample));
     return;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -824,7 +824,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
-            orbit_grpc_protos::Callstack::kUprobesPatchingFailed);
+            orbit_grpc_protos::Callstack::kCallstackPatchingFailed);
 
   EXPECT_EQ(unwinding_errors, 1);
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);


### PR DESCRIPTION
We will use this error also in the case of user space instrumentation so I want
to move away from a name that contains "uprobes".
I'm not creating a new error only for user space instrumentation because in the
general case of both uprobes and user space instrumentation it wouldn't be
trivial (or possible at all) to "blame" one or the other.

Bug: http://b/194704608

Test: Build.