### PR TITLE
Add FunctionEntry, FunctionExit to capture.proto's ProducerCaptureEvent

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -107,6 +107,22 @@ message FunctionCall {
   repeated uint64 registers = 8;
 }
 
+// FunctionEntry and FunctionExit are emitted by user space instrumentation.
+message FunctionEntry {
+  uint32 pid = 1;
+  uint32 tid = 2;
+  uint64 function_id = 3;
+  uint64 stack_pointer = 4;
+  uint64 return_address = 5;
+  uint64 timestamp_ns = 6;
+}
+
+message FunctionExit {
+  uint32 pid = 1;
+  uint32 tid = 2;
+  uint64 timestamp_ns = 3;
+}
+
 message ApiEvent {
   uint32 pid = 1;
   uint32 tid = 2;
@@ -739,7 +755,7 @@ message ProducerCaptureEvent {
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
-    // Next high-frequency ID: 13
+    // Next high-frequency ID: 15
     // Next lower-frequency ID: 47
     //
     // Please keep these alphabetically ordered.
@@ -772,6 +788,8 @@ message ProducerCaptureEvent {
     FullGpuJob full_gpu_job = 3;
     FullTracepointEvent full_tracepoint_event = 4;
     FunctionCall function_call = 5;
+    FunctionEntry function_entry = 13;
+    FunctionExit function_exit = 14;
     GpuQueueSubmission gpu_queue_submission = 6;
     InternedCallstack interned_callstack = 7;
     InternedString interned_string = 18;

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -516,6 +516,10 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         EXPECT_GE(event.function_call().end_timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.function_call().end_timestamp_ns();
         break;
+      case orbit_grpc_protos::ProducerCaptureEvent::kFunctionEntry:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kFunctionExit:
+        UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kGpuQueueSubmission:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedCallstack:

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -612,6 +612,12 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
     case ProducerCaptureEvent::kFunctionCall:
       ProcessFunctionCallAndTransferOwnership(event.release_function_call());
       break;
+    case ProducerCaptureEvent::kFunctionEntry:
+      // TODO(b/194704608): Forward to LinuxTracing (before reaching here).
+      UNREACHABLE();
+    case ProducerCaptureEvent::kFunctionExit:
+      // TODO(b/194704608): Forward to LinuxTracing (before reaching here).
+      UNREACHABLE();
     case ProducerCaptureEvent::kGpuQueueSubmission:
       ProcessGpuQueueSubmissionAndTransferOwnership(producer_id,
                                                     event.release_gpu_queue_submission());

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -61,6 +61,7 @@ static_assert(sizeof(FunctionCallEvent) == 32, "FunctionCallEvent should be 32 b
 
 // This class is used to enqueue FunctionCallEvent events from multiple threads and relay them to
 // OrbitService in the form of orbit_grpc_protos::FunctionCall events.
+// TODO(b/194704608): Emit individual FunctionEntry and FunctionExit events instead.
 class LockFreeUserSpaceInstrumentationEventProducer
     : public orbit_capture_event_producer::LockFreeBufferCaptureEventProducer<FunctionCallEvent> {
  public:


### PR DESCRIPTION
These will be emitted by user space instrumentation (later change, currently
unused).

Bug: http://b/194704608

Test: Build.