### PR TITLE
Add RetrieveInstancesWidget start functionality

### DIFF
--- a/src/OrbitGgp/include/OrbitGgp/Project.h
+++ b/src/OrbitGgp/include/OrbitGgp/Project.h
@@ -6,6 +6,7 @@
 #define ORBIT_GPP_PROJECT_H_
 
 #include <QByteArray>
+#include <QMetaType>
 #include <QString>
 #include <QVector>
 #include <tuple>
@@ -32,5 +33,7 @@ struct Project {
 };
 
 }  // namespace orbit_ggp
+
+Q_DECLARE_METATYPE(orbit_ggp::Project);
 
 #endif  // ORBIT_GPP_PROJECT_H_

--- a/src/SessionSetup/RetrieveInstancesWidget.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidget.cpp
@@ -4,27 +4,160 @@
 
 #include "SessionSetup/RetrieveInstancesWidget.h"
 
+#include <QCoreApplication>
 #include <QLineEdit>
+#include <QMessageBox>
+#include <QObject>
+#include <QPointer>
+#include <QPushButton>
+#include <QSettings>
+#include <QVariant>
 #include <memory>
+#include <optional>
 
+#include "OrbitBase/Result.h"
 #include "OrbitGgp/Client.h"
+#include "SessionSetup/RetrieveInstances.h"
 #include "ui_RetrieveInstancesWidget.h"
+
+namespace {
+constexpr const char* kAllInstancesKey{"kAllInstancesKey"};
+constexpr const char* kSelectedProjectIdKey{"kSelectedProjectIdKey"};
+constexpr const char* kSelectedProjectDisplayNameKey{"kSelectedProjectDisplayNameKey"};
+}  // namespace
 
 namespace orbit_session_setup {
 
+using orbit_ggp::Client;
+using orbit_ggp::Instance;
+using orbit_ggp::Project;
+
 RetrieveInstancesWidget::~RetrieveInstancesWidget() = default;
 
-RetrieveInstancesWidget::RetrieveInstancesWidget(orbit_ggp::Client* ggp_client, QWidget* parent)
+RetrieveInstancesWidget::RetrieveInstancesWidget(MainThreadExecutor* main_thread_executor,
+                                                 RetrieveInstances* retreive_instances,
+                                                 QWidget* parent)
     : QWidget(parent),
       ui_(std::make_unique<Ui::RetrieveInstancesWidget>()),
-      ggp_client_(ggp_client),
+      main_thread_executor_(main_thread_executor),
+      retreive_instances_(retreive_instances),
       s_idle_(&state_machine_),
       s_loading_(&state_machine_),
       s_initial_loading_failed_(&state_machine_) {
+  CHECK(main_thread_executor != nullptr);
+  CHECK(retreive_instances != nullptr);
+
   ui_->setupUi(this);
+
+  SetupStateMachine();
 
   QObject::connect(ui_->filterLineEdit, &QLineEdit::textChanged, this,
                    &RetrieveInstancesWidget::FilterTextChanged);
+}
+
+void RetrieveInstancesWidget::SetupStateMachine() {
+  state_machine_.setGlobalRestorePolicy(QStateMachine::RestoreProperties);
+
+  s_idle_.addTransition(this, &RetrieveInstancesWidget::LoadingStarted, &s_loading_);
+
+  s_loading_.assignProperty(ui_->projectComboBox, "enabled", false);
+  s_loading_.assignProperty(ui_->filterLineEdit, "enabled", false);
+  s_loading_.assignProperty(ui_->allCheckBox, "enabled", false);
+  s_loading_.assignProperty(ui_->reloadButton, "enabled", false);
+  s_loading_.addTransition(this, &RetrieveInstancesWidget::LoadingSuccessful, &s_idle_);
+  s_loading_.addTransition(this, &RetrieveInstancesWidget::LoadingFailed, &s_idle_);
+  s_loading_.addTransition(this, &RetrieveInstancesWidget::InitialLoadingFailed,
+                           &s_initial_loading_failed_);
+
+  s_initial_loading_failed_.assignProperty(ui_->projectComboBox, "enabled", false);
+  s_initial_loading_failed_.assignProperty(ui_->filterLineEdit, "enabled", false);
+  s_initial_loading_failed_.assignProperty(ui_->allCheckBox, "enabled", false);
+  s_initial_loading_failed_.addTransition(this, &RetrieveInstancesWidget::LoadingStarted,
+                                          &s_loading_);
+}
+
+std::optional<Project> RetrieveInstancesWidget::GetQSettingsProject() {
+  QSettings settings;
+
+  std::optional<Project> remembered_project;
+  if (settings.contains(kSelectedProjectIdKey)) {
+    remembered_project = Project{
+        settings.value(kSelectedProjectDisplayNameKey).toString() /* display_name */,
+        settings.value(kSelectedProjectIdKey).toString() /* id */
+    };
+  }
+  return remembered_project;
+}
+
+void RetrieveInstancesWidget::Start() {
+  state_machine_.setInitialState(&s_loading_);
+  state_machine_.start();
+
+  QSettings settings;
+  ui_->allCheckBox->setChecked(settings.value(kAllInstancesKey, false).toBool());
+
+  InitialLoad(GetQSettingsProject());
+}
+
+Client::InstanceListScope RetrieveInstancesWidget::GetInstanceListScope() {
+  return ui_->allCheckBox->isChecked() ? Client::InstanceListScope::kAllReservedInstances
+                                       : Client::InstanceListScope::kOnlyOwnInstances;
+}
+
+void RetrieveInstancesWidget::InitialLoad(const std::optional<Project>& remembered_project) {
+  emit LoadingStarted();
+  retreive_instances_->LoadProjectsAndInstances(remembered_project, GetInstanceListScope())
+      .Then(main_thread_executor_,
+            [widget = QPointer<RetrieveInstancesWidget>(this)](
+                ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult> loading_result) {
+              if (widget == nullptr) return;
+
+              if (loading_result.has_error()) {
+                emit widget->InitialLoadingFailed();
+                widget->OnInstancesLoadingReturned(loading_result.error());
+                return;
+              }
+
+              CHECK(widget->ui_->projectComboBox->count() == 0);
+
+              RetrieveInstances::LoadProjectsAndInstancesResult& data{loading_result.value()};
+
+              QString default_project_text =
+                  QString("Default Project (%1)").arg(data.default_project.display_name);
+              widget->ui_->projectComboBox->addItem(default_project_text);
+
+              QVector<Project>& projects{data.projects};
+              std::sort(projects.begin(), projects.end(), [](const Project& p1, const Project& p2) {
+                return p1.display_name.toLower() < p2.display_name.toLower();
+              });
+
+              for (const Project& project : data.projects) {
+                QString text = project.display_name;
+                if (project == data.default_project) {
+                  text.append(" (default)");
+                }
+                widget->ui_->projectComboBox->addItem(text, QVariant::fromValue(project));
+
+                if (project == data.project_of_instances) {
+                  // last added item
+                  widget->ui_->projectComboBox->setCurrentIndex(
+                      widget->ui_->projectComboBox->count() - 1);
+                }
+              }
+
+              widget->OnInstancesLoadingReturned(data.instances);
+            });
+}
+
+void RetrieveInstancesWidget::OnInstancesLoadingReturned(
+    const ErrorMessageOr<QVector<Instance>>& loading_result) {
+  if (loading_result.has_error()) {
+    QMessageBox::critical(this, QCoreApplication::applicationName(),
+                          QString::fromStdString(loading_result.error().message()));
+    emit LoadingFailed();
+    return;
+  }
+  emit LoadingSuccessful(loading_result.value());
 }
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/RetrieveInstancesWidget.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidget.cpp
@@ -36,7 +36,7 @@ using LoadProjectsAndInstancesResult = RetrieveInstances::LoadProjectsAndInstanc
 
 namespace {
 
-std::optional<Project> GetQSettingsProject() {
+[[nodiscard]] std::optional<Project> GetQSettingsProject() {
   QSettings settings;
 
   std::optional<Project> project;
@@ -145,7 +145,7 @@ void RetrieveInstancesWidget::OnInitialLoadingReturnedSuccess(
     }
     ui_->projectComboBox->addItem(text, QVariant::fromValue(project));
 
-    // initial_load_result.instance, is the list for a specific project, which is
+    // initial_load_result.instances is the list for a specific project, which is
     // initial_load_result.project_of_instances. (This can be different than the remembered project
     // which was used in InitialLoad.) Since the initial_load_result.instances will be shown by
     // ConnectToStadiaWidget, the combobox should have the project selected that belongs to this

--- a/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
@@ -36,11 +36,11 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<RetrieveInstances> retrieve_instances =
       RetrieveInstances::Create(client_ptr, executor.get());
 
-  RetrieveInstancesWidget widget{executor.get(), retrieve_instances.get()};
+  RetrieveInstancesWidget widget{retrieve_instances.get()};
 
   QObject::connect(&widget, &RetrieveInstancesWidget::LoadingSuccessful, &widget,
                    [&widget](const QVector<orbit_ggp::Instance>& instances) {
-                     auto message =
+                     QString message =
                          QString{"Retrieved %1 instance. This is the list (display name):\n"}.arg(
                              instances.count());
                      for (const auto& instance : instances) {

--- a/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
@@ -3,22 +3,55 @@
 // found in the LICENSE file.
 
 #include <QApplication>
+#include <QMessageBox>
 #include <memory>
 
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/Client.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
+#include "SessionSetup/RetrieveInstances.h"
 #include "SessionSetup/RetrieveInstancesWidget.h"
 
+namespace {
+constexpr const char* kOrganizationName = "The Orbit Authors";
+constexpr const char* kApplicationName = "RetrieveInstancesWidgetDemo";
+}  // namespace
+
 using orbit_ggp::Client;
+using orbit_session_setup::RetrieveInstances;
+using orbit_session_setup::RetrieveInstancesWidget;
 
 int main(int argc, char* argv[]) {
   QApplication app{argc, argv};
+  QCoreApplication::setOrganizationName(kOrganizationName);
+  QCoreApplication::setApplicationName(kApplicationName);
 
   ErrorMessageOr<std::unique_ptr<Client>> client_or_error = orbit_ggp::CreateClient();
   FAIL_IF(client_or_error.has_error(), "%s", client_or_error.error().message());
+  Client* client_ptr = client_or_error.value().get();
 
-  orbit_session_setup::RetrieveInstancesWidget widget{client_or_error.value().get()};
+  std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor{
+      orbit_qt_utils::MainThreadExecutorImpl::Create()};
+
+  std::unique_ptr<RetrieveInstances> retrieve_instances =
+      RetrieveInstances::Create(client_ptr, executor.get());
+
+  RetrieveInstancesWidget widget{executor.get(), retrieve_instances.get()};
+
+  QObject::connect(&widget, &RetrieveInstancesWidget::LoadingSuccessful, &widget,
+                   [&widget](const QVector<orbit_ggp::Instance>& instances) {
+                     auto message =
+                         QString{"Retrieved %1 instance. This is the list (display name):\n"}.arg(
+                             instances.count());
+                     for (const auto& instance : instances) {
+                       message.append(QString{"* %1\n"}.arg(instance.display_name));
+                     }
+
+                     QMessageBox::information(&widget, QApplication::applicationName(), message);
+                   });
+
   widget.show();
+  widget.Start();
 
   return QApplication::exec();
 }

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -2,47 +2,115 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock-spec-builders.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <QCheckBox>
 #include <QComboBox>
+#include <QCoreApplication>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QSettings>
 #include <QSignalSpy>
 #include <QTest>
+#include <QTimer>
+#include <memory>
+#include <optional>
 
 #include "OrbitGgp/Client.h"
 #include "OrbitGgp/Project.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
+#include "SessionSetup/RetrieveInstances.h"
 #include "SessionSetup/RetrieveInstancesWidget.h"
+
+namespace {
+constexpr const char* kOrganizationName = "The Orbit Authors";
+constexpr const char* kApplicationName{"RetrieveInstancesWidgetTest"};
+constexpr const char* kAllInstancesKey{"kAllInstancesKey"};
+constexpr const char* kSelectedProjectIdKey{"kSelectedProjectIdKey"};
+constexpr const char* kSelectedProjectDisplayNameKey{"kSelectedProjectDisplayNameKey"};
+}  // namespace
 
 namespace orbit_session_setup {
 
 using orbit_base::Future;
+using orbit_ggp::Client;
 using orbit_ggp::Instance;
 using orbit_ggp::Project;
-using orbit_ggp::SshInfo;
+using testing::Return;
 
-class MockGgpClient : public orbit_ggp::Client {
+class MockRetrieveInstances : public RetrieveInstances {
  public:
-  MOCK_METHOD(Future<ErrorMessageOr<QVector<Instance>>>, GetInstancesAsync,
-              (orbit_ggp::Client::InstanceListScope /*scope*/, std::optional<Project> /*project*/),
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<QVector<orbit_ggp::Instance>>>, LoadInstances,
+              (const std::optional<orbit_ggp::Project>& project,
+               orbit_ggp::Client::InstanceListScope scope),
               (override));
-  MOCK_METHOD(Future<ErrorMessageOr<QVector<Instance>>>, GetInstancesAsync,
-              (orbit_ggp::Client::InstanceListScope /*scope*/, std::optional<Project> /*project*/,
-               int /*retry*/),
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<QVector<orbit_ggp::Instance>>>,
+              LoadInstancesWithoutCache,
+              (const std::optional<orbit_ggp::Project>& project,
+               orbit_ggp::Client::InstanceListScope scope),
               (override));
-  MOCK_METHOD(Future<ErrorMessageOr<SshInfo>>, GetSshInfoAsync,
-              (const Instance& /*ggp_instance*/, std::optional<Project> /*project*/), (override));
-  MOCK_METHOD(Future<ErrorMessageOr<QVector<Project>>>, GetProjectsAsync, (), (override));
-  MOCK_METHOD(Future<ErrorMessageOr<Project>>, GetDefaultProjectAsync, (), (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<LoadProjectsAndInstancesResult>>,
+              LoadProjectsAndInstances,
+              (const std::optional<orbit_ggp::Project>& project,
+               orbit_ggp::Client::InstanceListScope scope),
+              (override));
 };
 
 namespace {
 
+const Project kTestProject1{
+    "Test Project 1",   /* display_name */
+    "test_project_1_id" /* id */
+};
+
+const Project kTestProject2{
+    "Test Project 2",   /* display_name */
+    "test_project_2_id" /* id */
+};
+
+const Instance kTestInstance1{
+    "Test Instance 1",                                          /* display_name */
+    "test_instance_1_id",                                       /* id */
+    "1.1.1.10",                                                 /* ip_address */
+    QDateTime::fromString("2020-01-01T00:42:42Z", Qt::ISODate), /* last_updated */
+    "test_owner_1@",                                            /* owner */
+    "foo-bar-pool-1",                                           /* pool */
+    "RESERVED",                                                 /* state */
+};
+
+const Instance kTestInstance2{
+    "Test Instance 2",                                          /* display_name */
+    "test_instance_2_id",                                       /* id */
+    "2.2.2.20",                                                 /* ip_address */
+    QDateTime::fromString("2020-02-02T00:42:42Z", Qt::ISODate), /* last_updated */
+    "test_owner_2@",                                            /* owner */
+    "foo-bar-pool-2",                                           /* pool */
+    "IN_USE",                                                   /* state */
+};
+
+const QVector<Instance> kTestInstances{kTestInstance1, kTestInstance2};
+
+const RetrieveInstances::LoadProjectsAndInstancesResult kInitialTestDataDefault{
+    QVector<Project>{kTestProject1, kTestProject2}, /* projects */
+    Project{kTestProject1},                         /* default_project */
+    QVector<Instance>{kTestInstances},              /* instances */
+    std::optional<Project>{std::nullopt},           /* project_of_instances */
+};
+
+const RetrieveInstances::LoadProjectsAndInstancesResult kInitialTestDataWithProjectOfInstances{
+    QVector<Project>{kTestProject1, kTestProject2}, /* projects */
+    Project{kTestProject1},                         /* default_project */
+    QVector<Instance>{kTestInstances},              /* instances */
+    std::optional<Project>{kTestProject1},          /* project_of_instances */
+};
+
 class RetrieveInstancesWidgetTest : public testing::Test {
  public:
-  RetrieveInstancesWidgetTest() : widget_(&mock_ggp_) {
+  RetrieveInstancesWidgetTest()
+      : executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()),
+        widget_(executor_.get(), &mock_retrieve_instances_) {
     filter_line_edit_ = widget_.findChild<QLineEdit*>("filterLineEdit");
     all_check_box_ = widget_.findChild<QCheckBox*>("allCheckBox");
     project_combo_box_ = widget_.findChild<QComboBox*>("projectComboBox");
@@ -51,17 +119,85 @@ class RetrieveInstancesWidgetTest : public testing::Test {
 
  protected:
   void SetUp() override {
+    QCoreApplication::setOrganizationName(kOrganizationName);
+    QCoreApplication::setApplicationName(kApplicationName);
+    QSettings settings;
+    settings.clear();
+
     ASSERT_NE(filter_line_edit_, nullptr);
     ASSERT_NE(all_check_box_, nullptr);
     ASSERT_NE(project_combo_box_, nullptr);
     ASSERT_NE(reload_button_, nullptr);
   }
-  MockGgpClient mock_ggp_;
+
+  void VerifyAllElementsAreEnabled() {
+    EXPECT_TRUE(filter_line_edit_->isEnabled());
+    EXPECT_TRUE(all_check_box_->isEnabled());
+    EXPECT_TRUE(project_combo_box_->isEnabled());
+    EXPECT_TRUE(reload_button_->isEnabled());
+  }
+
+  void VerifyOnlyReloadIsEnabled() {
+    EXPECT_FALSE(filter_line_edit_->isEnabled());
+    EXPECT_FALSE(all_check_box_->isEnabled());
+    EXPECT_FALSE(project_combo_box_->isEnabled());
+    EXPECT_TRUE(reload_button_->isEnabled());
+  }
+
+  void VerifyLastLoadingReturnedInstanceList(const QVector<Instance>& instances) {
+    QList<QVariant> arguments = loading_successful_spy_.last();
+    ASSERT_EQ(arguments.count(), 1);
+    ASSERT_TRUE(arguments.at(0).canConvert<QVector<Instance>>());
+
+    EXPECT_EQ(arguments.at(0).value<QVector<Instance>>(), instances);
+  }
+
+  void VerifyProjectComboBoxHoldsData(const QVector<Project>& projects,
+                                      const Project& default_project,
+                                      const std::optional<Project>& selected_project) {
+    // all projects + first default entry
+    EXPECT_EQ(project_combo_box_->count(), projects.count() + 1);
+
+    // The first entry is: Default Project (<project name>)
+    EXPECT_TRUE(project_combo_box_->itemText(0).contains("Default Project"));
+    EXPECT_TRUE(project_combo_box_->itemText(0).contains(default_project.display_name));
+    EXPECT_EQ(project_combo_box_->itemData(0), QVariant{});
+
+    // The default projects entry has the form: "<project name> (default)"
+    int index_of_default_project_in_full_list =
+        project_combo_box_->findData(QVariant::fromValue(default_project));
+    ASSERT_NE(index_of_default_project_in_full_list, -1);
+    EXPECT_EQ(project_combo_box_->itemText(index_of_default_project_in_full_list),
+              QString("%1 (default)").arg(default_project.display_name));
+
+    for (const auto& project : projects) {
+      EXPECT_NE(-1, project_combo_box_->findText(project.display_name, Qt::MatchContains));
+    }
+
+    if (selected_project.has_value()) {
+      EXPECT_EQ(project_combo_box_->currentData().value<Project>(), selected_project);
+    } else {
+      EXPECT_EQ(project_combo_box_->currentData(), QVariant());
+    }
+  }
+
+  void VerifyProjectComboBoxHoldsData(
+      const RetrieveInstances::LoadProjectsAndInstancesResult& data) {
+    VerifyProjectComboBoxHoldsData(data.projects, data.default_project, data.project_of_instances);
+  }
+
+  // MockGgpClient mock_ggp_;
+  MockRetrieveInstances mock_retrieve_instances_;
+  std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor_;
   RetrieveInstancesWidget widget_;
   QLineEdit* filter_line_edit_ = nullptr;
   QCheckBox* all_check_box_ = nullptr;
   QComboBox* project_combo_box_ = nullptr;
   QPushButton* reload_button_ = nullptr;
+  QSignalSpy loading_started_spy_{&widget_, &RetrieveInstancesWidget::LoadingStarted};
+  QSignalSpy loading_successful_spy_{&widget_, &RetrieveInstancesWidget::LoadingSuccessful};
+  QSignalSpy loading_failed_spy_{&widget_, &RetrieveInstancesWidget::LoadingFailed};
+  QSignalSpy initial_loading_failed_spy_{&widget_, &RetrieveInstancesWidget::InitialLoadingFailed};
 };
 
 }  // namespace
@@ -80,4 +216,80 @@ TEST_F(RetrieveInstancesWidgetTest, FilterTextChanged) {
   EXPECT_EQ(arguments.at(0).toString(), "test text");
 }
 
+TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulDefault) {
+  EXPECT_CALL(mock_retrieve_instances_,
+              LoadProjectsAndInstances(
+                  std::optional<Project>(std::nullopt),
+                  Client::InstanceListScope(Client::InstanceListScope::kOnlyOwnInstances)))
+      .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
+          kInitialTestDataDefault}));
+
+  widget_.Start();
+  QCoreApplication::processEvents();
+
+  EXPECT_EQ(loading_started_spy_.count(), 1);
+  EXPECT_EQ(loading_successful_spy_.count(), 1);
+  EXPECT_EQ(loading_failed_spy_.count(), 0);
+  EXPECT_EQ(initial_loading_failed_spy_.count(), 0);
+
+  VerifyLastLoadingReturnedInstanceList(kInitialTestDataDefault.instances);
+  VerifyAllElementsAreEnabled();
+  VerifyProjectComboBoxHoldsData(kInitialTestDataDefault);
+}
+
+TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulWithRememberedSettings) {
+  EXPECT_CALL(
+      mock_retrieve_instances_,
+      LoadProjectsAndInstances(
+          std::optional<Project>(kInitialTestDataWithProjectOfInstances.project_of_instances),
+          Client::InstanceListScope(Client::InstanceListScope::kAllReservedInstances)))
+      .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
+          kInitialTestDataWithProjectOfInstances}));
+
+  QSettings settings;
+  settings.setValue(kSelectedProjectIdKey,
+                    kInitialTestDataWithProjectOfInstances.project_of_instances->id);
+  settings.setValue(kSelectedProjectDisplayNameKey,
+                    kInitialTestDataWithProjectOfInstances.project_of_instances->display_name);
+  settings.setValue(kAllInstancesKey, true);
+
+  widget_.Start();
+  QCoreApplication::processEvents();
+
+  EXPECT_EQ(loading_started_spy_.count(), 1);
+  EXPECT_EQ(loading_successful_spy_.count(), 1);
+  EXPECT_EQ(loading_failed_spy_.count(), 0);
+  EXPECT_EQ(initial_loading_failed_spy_.count(), 0);
+
+  VerifyLastLoadingReturnedInstanceList(kInitialTestDataWithProjectOfInstances.instances);
+  VerifyAllElementsAreEnabled();
+  VerifyProjectComboBoxHoldsData(kInitialTestDataWithProjectOfInstances);
+
+  EXPECT_TRUE(all_check_box_->isChecked());
+}
+
+TEST_F(RetrieveInstancesWidgetTest, StartFailed) {
+  EXPECT_CALL(mock_retrieve_instances_,
+              LoadProjectsAndInstances(
+                  std::optional<Project>(std::nullopt),
+                  Client::InstanceListScope(Client::InstanceListScope::kOnlyOwnInstances)))
+      .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
+          ErrorMessage{"error message"}}));
+
+  // close the error message box
+  QTimer::singleShot(5, []() {
+    QApplication::activeModalWidget()->close();
+    QCoreApplication::exit();
+  });
+
+  widget_.Start();
+  QCoreApplication::exec();
+
+  EXPECT_EQ(loading_started_spy_.count(), 1);
+  EXPECT_EQ(loading_successful_spy_.count(), 0);
+  EXPECT_EQ(loading_failed_spy_.count(), 1);
+  EXPECT_EQ(initial_loading_failed_spy_.count(), 1);
+
+  VerifyOnlyReloadIsEnabled();
+}
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -108,9 +108,7 @@ const RetrieveInstances::LoadProjectsAndInstancesResult kInitialTestDataWithProj
 
 class RetrieveInstancesWidgetTest : public testing::Test {
  public:
-  RetrieveInstancesWidgetTest()
-      : executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()),
-        widget_(executor_.get(), &mock_retrieve_instances_) {
+  RetrieveInstancesWidgetTest() : widget_(&mock_retrieve_instances_) {
     filter_line_edit_ = widget_.findChild<QLineEdit*>("filterLineEdit");
     all_check_box_ = widget_.findChild<QCheckBox*>("allCheckBox");
     project_combo_box_ = widget_.findChild<QComboBox*>("projectComboBox");
@@ -152,9 +150,8 @@ class RetrieveInstancesWidgetTest : public testing::Test {
     EXPECT_EQ(arguments.at(0).value<QVector<Instance>>(), instances);
   }
 
-  void VerifyProjectComboBoxHoldsData(const QVector<Project>& projects,
-                                      const Project& default_project,
-                                      const std::optional<Project>& selected_project) {
+  void VerifyProjectComboBoxData(const QVector<Project>& projects, const Project& default_project,
+                                 const std::optional<Project>& selected_project) {
     // all projects + first default entry
     EXPECT_EQ(project_combo_box_->count(), projects.count() + 1);
 
@@ -183,12 +180,11 @@ class RetrieveInstancesWidgetTest : public testing::Test {
 
   void VerifyProjectComboBoxHoldsData(
       const RetrieveInstances::LoadProjectsAndInstancesResult& data) {
-    VerifyProjectComboBoxHoldsData(data.projects, data.default_project, data.project_of_instances);
+    VerifyProjectComboBoxData(data.projects, data.default_project, data.project_of_instances);
   }
 
   // MockGgpClient mock_ggp_;
   MockRetrieveInstances mock_retrieve_instances_;
-  std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor_;
   RetrieveInstancesWidget widget_;
   QLineEdit* filter_line_edit_ = nullptr;
   QCheckBox* all_check_box_ = nullptr;

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstances.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstances.h
@@ -18,6 +18,10 @@
 
 namespace orbit_session_setup {
 
+// RetrieveInstances manages calls to orbit_ggp::Client for retrieving the list of projects and
+// instances. It acts as an abstraction layer that can add functionality like caching and combines
+// calls to be executed in parallel. Its intended use is retrieving the data for
+// RetrieveInstancesWidget.
 class RetrieveInstances {
  public:
   // This struct holds the result of call to LoadProjectsAndInstances.

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstances.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstances.h
@@ -20,6 +20,11 @@ namespace orbit_session_setup {
 
 class RetrieveInstances {
  public:
+  // This struct holds the result of call to LoadProjectsAndInstances.
+  // * projects: List of projects.
+  // * default_project: Default project.
+  // * instances: list of instances.
+  // * project_of_instances: project of the list of instances.
   struct LoadProjectsAndInstancesResult {
     QVector<orbit_ggp::Project> projects;
     orbit_ggp::Project default_project;
@@ -35,6 +40,11 @@ class RetrieveInstances {
   virtual orbit_base::Future<ErrorMessageOr<QVector<orbit_ggp::Instance>>>
   LoadInstancesWithoutCache(const std::optional<orbit_ggp::Project>& project,
                             orbit_ggp::Client::InstanceListScope scope) = 0;
+  // LoadProjectsAndInstances always loads the project list and the default project. Additionally,it
+  // is attempted to load the list of instances for the input project. The later can fail, when the
+  // project does not exist anymore. Then the instance list of the default project is loaded and
+  // returned. To indicate to which project the list of instances belongs,
+  // LoadProjectsAndInstancesResult has the field project_of_instances.
   virtual orbit_base::Future<ErrorMessageOr<LoadProjectsAndInstancesResult>>
   LoadProjectsAndInstances(const std::optional<orbit_ggp::Project>& project,
                            orbit_ggp::Client::InstanceListScope scope) = 0;

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
@@ -26,8 +26,7 @@ class RetrieveInstancesWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit RetrieveInstancesWidget(MainThreadExecutor* main_thread_executor,
-                                   RetrieveInstances* retreive_instances,
+  explicit RetrieveInstancesWidget(RetrieveInstances* retrieve_instances,
                                    QWidget* parent = nullptr);
   ~RetrieveInstancesWidget() override;
 
@@ -42,15 +41,16 @@ class RetrieveInstancesWidget : public QWidget {
 
  private:
   void SetupStateMachine();
-  orbit_ggp::Client::InstanceListScope GetInstanceListScope();
+  [[nodiscard]] orbit_ggp::Client::InstanceListScope GetInstanceListScope() const;
   void InitialLoad(const std::optional<orbit_ggp::Project>& remembered_project);
-  std::optional<orbit_ggp::Project> GetQSettingsProject();
   void OnInstancesLoadingReturned(
       const ErrorMessageOr<QVector<orbit_ggp::Instance>>& loading_result);
+  void OnInitialLoadingReturnedSuccess(
+      RetrieveInstances::LoadProjectsAndInstancesResult initial_load_result);
 
   std::unique_ptr<Ui::RetrieveInstancesWidget> ui_;
-  MainThreadExecutor* main_thread_executor_;
-  RetrieveInstances* retreive_instances_;
+  std::shared_ptr<MainThreadExecutor> main_thread_executor_;
+  RetrieveInstances* retrieve_instances_;
   QStateMachine state_machine_;
   QState s_idle_;
   QState s_loading_;

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
@@ -11,7 +11,10 @@
 #include <QWidget>
 #include <memory>
 
+#include "MainThreadExecutor.h"
 #include "OrbitGgp/Client.h"
+#include "OrbitGgp/Project.h"
+#include "SessionSetup/RetrieveInstances.h"
 
 namespace Ui {
 class RetrieveInstancesWidget;
@@ -23,15 +26,31 @@ class RetrieveInstancesWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit RetrieveInstancesWidget(orbit_ggp::Client* ggp_client, QWidget* parent = nullptr);
+  explicit RetrieveInstancesWidget(MainThreadExecutor* main_thread_executor,
+                                   RetrieveInstances* retreive_instances,
+                                   QWidget* parent = nullptr);
   ~RetrieveInstancesWidget() override;
 
+  void Start();
+
  signals:
+  void LoadingStarted();
+  void LoadingSuccessful(QVector<orbit_ggp::Instance>);
+  void LoadingFailed();
+  void InitialLoadingFailed();
   void FilterTextChanged(const QString& text);
 
  private:
+  void SetupStateMachine();
+  orbit_ggp::Client::InstanceListScope GetInstanceListScope();
+  void InitialLoad(const std::optional<orbit_ggp::Project>& remembered_project);
+  std::optional<orbit_ggp::Project> GetQSettingsProject();
+  void OnInstancesLoadingReturned(
+      const ErrorMessageOr<QVector<orbit_ggp::Instance>>& loading_result);
+
   std::unique_ptr<Ui::RetrieveInstancesWidget> ui_;
-  orbit_ggp::Client* ggp_client_;
+  MainThreadExecutor* main_thread_executor_;
+  RetrieveInstances* retreive_instances_;
   QStateMachine state_machine_;
   QState s_idle_;
   QState s_loading_;


### PR DESCRIPTION
This adds the functionality to RetrieveInstancesWidget, which is used
right after the start of the widget. This includes things like reading
QSettings for the last selected project, setting up the UI state
machine, the initial call to RetrieveInstances for the projects and
instances and filling the project combobox.

http://b/200010742