### PR TITLE
Make menu separators in orbit main window visible

### DIFF
--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -33,6 +33,13 @@ QToolTip {
 	solid white;
 }
 
+QMenu::separator {
+  height: 1px; 
+  background-color: rgb(90, 90, 90); 
+  margin-left: 2px; 
+  margin-right: 2px;
+}
+
 QPushButton:disabled {
 	color: gray;
 }</string>


### PR DESCRIPTION
With this change, we changed the style for menu separators in the orbit
main window to make them visible.

Bug: http://b/204868786

Before the change: https://screenshot/8swjR4TfMqRsc94

After the change: https://screenshot/AVj7Tb4L5MHogRX