### PR TITLE
Use new JoinFuture overload in RetrieveInstances

### DIFF
--- a/src/SessionSetup/RetrieveInstancesTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesTest.cpp
@@ -289,62 +289,66 @@ TEST_F(RetrieveInstancesTest, LoadProjectsAndInstancesError) {
 TEST_F(RetrieveInstancesTest, LoadProjectsAndInstancesSuccess) {
   Project default_project{"Test Project 1 - default", "proj_id_1"};
   Project project_of_instances{"Test Project 2 - instances project", "proj_id_2"};
-  Project test_project_3{"Project Display Name", "project_id"};
-  Instance test_instance_1{"Test Instance 1", "instance_id_1"};
-  Instance test_instance_2{"Test Instance 2", "instance_id_2"};
+  Project test_project{"Project Display Name", "project_id"};
+  QVector<Project> projects = {default_project, project_of_instances, test_project};
 
-  RetrieveInstances::LoadProjectsAndInstancesResult test_data;
-  test_data.default_project = default_project;
-  test_data.project_of_instances = project_of_instances;
-  test_data.projects = {default_project, project_of_instances, test_project_3};
-  test_data.instances = {test_instance_1, test_instance_2};
+  Instance test_instance_of_default_1{"Test Instance Default 1", "instance_default_id_1"};
+  Instance test_instance_of_default_2{"Test Instance Default 2", "instance_default_id_2"};
+  QVector<Instance> instances_of_default_project = {test_instance_of_default_1,
+                                                    test_instance_of_default_2};
+
+  Instance test_instance_of_project_1{"Test Instance Project 1", "instance_project_id_1"};
+  Instance test_instance_of_project_2{"Test Instance Project 2", "instance_project_id_2"};
+  QVector<Instance> instances_of_project = {test_instance_of_project_1, test_instance_of_project_2};
 
   {  // all succeed
     EXPECT_CALL(mock_ggp_, GetProjectsAsync())
-        .WillOnce(Return(Future<ErrorMessageOr<QVector<Project>>>(test_data.projects)));
+        .WillOnce(Return(Future<ErrorMessageOr<QVector<Project>>>(projects)));
     EXPECT_CALL(mock_ggp_, GetDefaultProjectAsync())
-        .WillOnce(Return(Future<ErrorMessageOr<Project>>(test_data.default_project)));
-    EXPECT_CALL(mock_ggp_,
-                GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances,
-                                  std::optional<Project>(test_data.project_of_instances)))
-        .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(test_data.instances)));
+        .WillOnce(Return(Future<ErrorMessageOr<Project>>(default_project)));
+    EXPECT_CALL(mock_ggp_, GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances,
+                                             std::optional<Project>(project_of_instances)))
+        .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(instances_of_project)));
+    EXPECT_CALL(mock_ggp_, GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances,
+                                             std::optional<Project>(std::nullopt)))
+        .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(instances_of_default_project)));
 
     auto future = retrieve_instances_->LoadProjectsAndInstances(
-        test_data.project_of_instances, Client::InstanceListScope::kOnlyOwnInstances);
+        project_of_instances, Client::InstanceListScope::kOnlyOwnInstances);
 
     VerifySuccessResult<RetrieveInstances::LoadProjectsAndInstancesResult>(
-        future, [test_data](auto result) {
-          EXPECT_EQ(result.default_project, test_data.default_project);
-          EXPECT_EQ(result.project_of_instances, test_data.project_of_instances);
-          EXPECT_EQ(result.projects, test_data.projects);
-          EXPECT_EQ(result.instances, test_data.instances);
+        future,
+        [default_project, project_of_instances, projects, instances_of_project](auto result) {
+          EXPECT_EQ(result.default_project, default_project);
+          EXPECT_EQ(result.project_of_instances, project_of_instances);
+          EXPECT_EQ(result.projects, projects);
+          EXPECT_EQ(result.instances, instances_of_project);
         });
   }
 
   {
-    // If project is not nullopt and the call has and error containing "it may not exist", there
-    // will be a retry (second call to GetInstancesAsync with nullopt). If that one succeeds, the
-    // whole call is successful.
+    // If project is not nullopt and the call has and error containing "it may not exist", the
+    // result of the call with the default will be used (second call to GetInstancesAsync with
+    // nullopt). If that one succeeds, the whole call is successful.
     EXPECT_CALL(mock_ggp_, GetProjectsAsync())
-        .WillOnce(Return(Future<ErrorMessageOr<QVector<Project>>>(test_data.projects)));
+        .WillOnce(Return(Future<ErrorMessageOr<QVector<Project>>>(projects)));
     EXPECT_CALL(mock_ggp_, GetDefaultProjectAsync())
-        .WillOnce(Return(Future<ErrorMessageOr<Project>>(test_data.default_project)));
-    EXPECT_CALL(mock_ggp_,
-                GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances,
-                                  std::optional<Project>(test_data.project_of_instances)))
+        .WillOnce(Return(Future<ErrorMessageOr<Project>>(default_project)));
+    EXPECT_CALL(mock_ggp_, GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances,
+                                             std::optional<Project>(project_of_instances)))
         .WillOnce(Return(ErrorMessage("it may not exist")));
     EXPECT_CALL(mock_ggp_, GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances,
                                              std::optional<Project>(std::nullopt)))
-        .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(test_data.instances)));
+        .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(instances_of_default_project)));
 
     auto future = retrieve_instances_->LoadProjectsAndInstances(
-        test_data.project_of_instances, Client::InstanceListScope::kOnlyOwnInstances);
+        project_of_instances, Client::InstanceListScope::kOnlyOwnInstances);
     VerifySuccessResult<RetrieveInstances::LoadProjectsAndInstancesResult>(
-        future, [test_data](auto result) {
-          EXPECT_EQ(result.default_project, test_data.default_project);
+        future, [default_project, projects, instances_of_default_project](auto result) {
+          EXPECT_EQ(result.default_project, default_project);
           EXPECT_EQ(result.project_of_instances, std::nullopt);
-          EXPECT_EQ(result.projects, test_data.projects);
-          EXPECT_EQ(result.instances, test_data.instances);
+          EXPECT_EQ(result.projects, projects);
+          EXPECT_EQ(result.instances, instances_of_default_project);
         });
   }
 }


### PR DESCRIPTION
This uses the new JoinFuture overload that works with pack expansion in
RetrieveInstances. This simplifies the code in LoadProjectsAndInstances.
Test: run unit rests