### PR TITLE
Add UserSpaceFunction{Entry,Exit}PerfEvent to LinuxTracing

### DIFF
--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -142,6 +142,25 @@ struct UretprobesWithReturnValuePerfEventData {
 };
 using UretprobesWithReturnValuePerfEvent = TypedPerfEvent<UretprobesWithReturnValuePerfEventData>;
 
+// UserSpaceFunctionEntryPerfEvent and UserSpaceFunctionExitPerfEvent don't correspond to records
+// produced by perf_event_open, but rather to the FunctionEntry and FunctionExit protos emitted by
+// user space instrumentation. They are processed in LinuxTracing because, just like with uprobes,
+// unwinding and dynamic instrumentation need to work together.
+struct UserSpaceFunctionEntryPerfEventData {
+  pid_t pid;
+  pid_t tid;
+  uint64_t function_id = orbit_grpc_protos::kInvalidFunctionId;
+  uint64_t sp;
+  uint64_t return_address;
+};
+using UserSpaceFunctionEntryPerfEvent = TypedPerfEvent<UserSpaceFunctionEntryPerfEventData>;
+
+struct UserSpaceFunctionExitPerfEventData {
+  pid_t pid;
+  pid_t tid;
+};
+using UserSpaceFunctionExitPerfEvent = TypedPerfEvent<UserSpaceFunctionExitPerfEventData>;
+
 struct MmapPerfEventData {
   uint64_t address;
   uint64_t length;
@@ -239,7 +258,8 @@ struct PerfEvent {
   std::variant<ForkPerfEventData, ExitPerfEventData, LostPerfEventData, DiscardedPerfEventData,
                StackSamplePerfEventData, CallchainSamplePerfEventData, UprobesPerfEventData,
                UprobesWithArgumentsPerfEventData, UretprobesPerfEventData,
-               UretprobesWithReturnValuePerfEventData, MmapPerfEventData,
+               UretprobesWithReturnValuePerfEventData, UserSpaceFunctionEntryPerfEventData,
+               UserSpaceFunctionExitPerfEventData, MmapPerfEventData,
                GenericTracepointPerfEventData, TaskNewtaskPerfEventData, TaskRenamePerfEventData,
                SchedSwitchPerfEventData, SchedWakeupPerfEventData, AmdgpuCsIoctlPerfEventData,
                AmdgpuSchedRunJobPerfEventData, DmaFenceSignaledPerfEventData>

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -9,9 +9,8 @@
 
 namespace orbit_linux_tracing {
 
-// This struct must be in sync with the SAMPLE_TYPE_TID_TIME_STREAMID_CPU in
-// PerfEventOpen.h, as the bits set in perf_event_attr::sample_type determine
-// the fields this struct should have.
+// This struct must be in sync with the SAMPLE_TYPE_TID_TIME_STREAMID_CPU in PerfEventOpen.h, as the
+// bits set in perf_event_attr::sample_type determine the fields this struct should have.
 struct __attribute__((__packed__)) perf_event_sample_id_tid_time_streamid_cpu {
   uint32_t pid, tid;  /* if PERF_SAMPLE_TID */
   uint64_t time;      /* if PERF_SAMPLE_TIME */
@@ -39,8 +38,7 @@ struct __attribute__((__packed__)) perf_event_fork_exit {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_ALL in
-// PerfEventOpen.h.
+// This struct must be in sync with the SAMPLE_REGS_USER_ALL in PerfEventOpen.h.
 struct __attribute__((__packed__)) perf_event_sample_regs_user_all {
   uint64_t abi;
   uint64_t ax;
@@ -65,23 +63,20 @@ struct __attribute__((__packed__)) perf_event_sample_regs_user_all {
   uint64_t r15;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_AX in
-// PerfEventOpen.h.
+// This struct must be in sync with the SAMPLE_REGS_USER_AX in PerfEventOpen.h.
 struct __attribute__((__packed__)) perf_event_sample_regs_user_ax {
   uint64_t abi;
   uint64_t ax;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_SP_IP in
-// PerfEventOpen.h.
+// This struct must be in sync with the SAMPLE_REGS_USER_SP_IP in PerfEventOpen.h.
 struct __attribute__((__packed__)) perf_event_sample_regs_user_sp_ip {
   uint64_t abi;
   uint64_t sp;
   uint64_t ip;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_SP_IP_ARGUMENTS in
-// PerfEventOpen.h.
+// This struct must be in sync with the SAMPLE_REGS_USER_SP_IP_ARGUMENTS in PerfEventOpen.h.
 struct __attribute__((__packed__)) perf_event_sample_regs_user_sp_ip_arguments {
   uint64_t abi;
   uint64_t cx;

--- a/src/LinuxTracing/PerfEventVisitor.h
+++ b/src/LinuxTracing/PerfEventVisitor.h
@@ -25,6 +25,10 @@ class PerfEventVisitor {
   virtual void Visit(uint64_t /*event_timestamp*/, const UretprobesPerfEventData& /*event_data*/) {}
   virtual void Visit(uint64_t /*event_timestamp*/,
                      const UretprobesWithReturnValuePerfEventData& /*event_data*/) {}
+  virtual void Visit(uint64_t /*event_timestamp*/,
+                     const UserSpaceFunctionEntryPerfEventData& /*event_data*/) {}
+  virtual void Visit(uint64_t /*event_timestamp*/,
+                     const UserSpaceFunctionExitPerfEventData& /*event_data*/) {}
   virtual void Visit(uint64_t /*event_timestamp*/, const LostPerfEventData& /*event_data*/) {}
   virtual void Visit(uint64_t /*event_timestamp*/, const DiscardedPerfEventData& /*event_data*/) {}
   virtual void Visit(uint64_t /*event_timestamp*/, const MmapPerfEventData& /*event_data*/) {}

--- a/src/LinuxTracing/UprobesFunctionCallManager.h
+++ b/src/LinuxTracing/UprobesFunctionCallManager.h
@@ -15,8 +15,9 @@
 
 namespace orbit_linux_tracing {
 
-// Keeps a stack, for every thread, of the open uprobes and matches them with
-// the uretprobes to produce FunctionCall objects.
+// Keeps a stack, for every thread, of the dynamically instrumented functions that have been entered
+// (e.g., open uprobes) and matches them with the exits from those functions (e.g., uretprobes) to
+// produce FunctionCall objects.
 class UprobesFunctionCallManager {
  public:
   UprobesFunctionCallManager() = default;
@@ -27,54 +28,54 @@ class UprobesFunctionCallManager {
   UprobesFunctionCallManager(UprobesFunctionCallManager&&) = default;
   UprobesFunctionCallManager& operator=(UprobesFunctionCallManager&&) = default;
 
-  void ProcessUprobes(pid_t tid, uint64_t function_id, uint64_t begin_timestamp,
-                      std::optional<perf_event_sample_regs_user_sp_ip_arguments> regs) {
-    auto& tid_uprobes_stack = tid_uprobes_stacks_[tid];
-    tid_uprobes_stack.emplace(function_id, begin_timestamp, regs);
+  void ProcessFunctionEntry(pid_t tid, uint64_t function_id, uint64_t begin_timestamp,
+                            std::optional<perf_event_sample_regs_user_sp_ip_arguments> regs) {
+    std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_[tid];
+    stack_of_open_functions.emplace_back(function_id, begin_timestamp, regs);
   }
 
-  std::optional<orbit_grpc_protos::FunctionCall> ProcessUretprobes(
+  std::optional<orbit_grpc_protos::FunctionCall> ProcessFunctionExit(
       pid_t pid, pid_t tid, uint64_t end_timestamp, std::optional<uint64_t> return_value) {
-    if (!tid_uprobes_stacks_.contains(tid)) {
-      return std::optional<orbit_grpc_protos::FunctionCall>{};
+    if (!tid_to_stack_of_open_functions_.contains(tid)) {
+      return std::nullopt;
     }
 
-    auto& tid_uprobes_stack = tid_uprobes_stacks_.at(tid);
+    std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_.at(tid);
 
     // As we erase the stack for this thread as soon as it becomes empty.
-    CHECK(!tid_uprobes_stack.empty());
-    auto& tid_uprobe = tid_uprobes_stack.top();
+    CHECK(!stack_of_open_functions.empty());
+    OpenFunction& open_function = stack_of_open_functions.back();
 
     orbit_grpc_protos::FunctionCall function_call;
     function_call.set_pid(pid);
     function_call.set_tid(tid);
-    function_call.set_function_id(tid_uprobe.function_id);
-    function_call.set_duration_ns(end_timestamp - tid_uprobe.begin_timestamp);
+    function_call.set_function_id(open_function.function_id);
+    function_call.set_duration_ns(end_timestamp - open_function.begin_timestamp);
     function_call.set_end_timestamp_ns(end_timestamp);
-    function_call.set_depth(tid_uprobes_stack.size() - 1);
+    function_call.set_depth(static_cast<int32_t>(stack_of_open_functions.size() - 1));
     if (return_value.has_value()) {
       function_call.set_return_value(return_value.value());
     }
-    if (tid_uprobe.registers.has_value()) {
-      function_call.add_registers(tid_uprobe.registers.value().di);
-      function_call.add_registers(tid_uprobe.registers.value().si);
-      function_call.add_registers(tid_uprobe.registers.value().dx);
-      function_call.add_registers(tid_uprobe.registers.value().cx);
-      function_call.add_registers(tid_uprobe.registers.value().r8);
-      function_call.add_registers(tid_uprobe.registers.value().r9);
+    if (open_function.registers.has_value()) {
+      function_call.add_registers(open_function.registers.value().di);
+      function_call.add_registers(open_function.registers.value().si);
+      function_call.add_registers(open_function.registers.value().dx);
+      function_call.add_registers(open_function.registers.value().cx);
+      function_call.add_registers(open_function.registers.value().r8);
+      function_call.add_registers(open_function.registers.value().r9);
     }
 
-    tid_uprobes_stack.pop();
-    if (tid_uprobes_stack.empty()) {
-      tid_uprobes_stacks_.erase(tid);
+    stack_of_open_functions.pop_back();
+    if (stack_of_open_functions.empty()) {
+      tid_to_stack_of_open_functions_.erase(tid);
     }
     return function_call;
   }
 
  private:
-  struct OpenUprobes {
-    OpenUprobes(uint64_t function_id, uint64_t begin_timestamp,
-                std::optional<perf_event_sample_regs_user_sp_ip_arguments> regs)
+  struct OpenFunction {
+    OpenFunction(uint64_t function_id, uint64_t begin_timestamp,
+                 std::optional<perf_event_sample_regs_user_sp_ip_arguments> regs)
         : function_id{function_id}, begin_timestamp{begin_timestamp}, registers{regs} {}
     uint64_t function_id;
     uint64_t begin_timestamp;
@@ -82,8 +83,7 @@ class UprobesFunctionCallManager {
   };
 
   // This map keeps the stack of the dynamically-instrumented functions entered.
-  absl::flat_hash_map<pid_t, std::stack<OpenUprobes, std::vector<OpenUprobes>>>
-      tid_uprobes_stacks_{};
+  absl::flat_hash_map<pid_t, std::vector<OpenFunction>> tid_to_stack_of_open_functions_{};
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -36,9 +36,9 @@ TEST(UprobesFunctionCallManager, OneFunctionCallWithoutArgumentsAndWithoutReturn
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  function_call_manager.ProcessUprobes(kTid, 100, 1, std::nullopt);
+  function_call_manager.ProcessFunctionEntry(kTid, 100, 1, std::nullopt);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid, 2, std::nullopt);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid, 2, std::nullopt);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid);
@@ -56,9 +56,9 @@ TEST(UprobesFunctionCallManager, OneFunctionCallWithArgumentsAndWithoutReturnVal
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  function_call_manager.ProcessUprobes(kTid, 100, 1, kRegisters);
+  function_call_manager.ProcessFunctionEntry(kTid, 100, 1, kRegisters);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid, 2, std::nullopt);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid, 2, std::nullopt);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid);
@@ -76,9 +76,9 @@ TEST(UprobesFunctionCallManager, OneFunctionCallWithoutArgumentsAndWithReturnVal
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  function_call_manager.ProcessUprobes(kTid, 100, 1, std::nullopt);
+  function_call_manager.ProcessFunctionEntry(kTid, 100, 1, std::nullopt);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid, 2, 1234);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid, 2, 1234);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid);
@@ -96,9 +96,9 @@ TEST(UprobesFunctionCallManager, OneFunctionCallWithArgumentsAndWithReturnValue)
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  function_call_manager.ProcessUprobes(kTid, 100, 1, kRegisters);
+  function_call_manager.ProcessFunctionEntry(kTid, 100, 1, kRegisters);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid, 2, 1234);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid, 2, 1234);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid);
@@ -116,11 +116,11 @@ TEST(UprobesFunctionCallManager, TwoNestedFunctionCallsAndAnotherFunctionCall) {
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  function_call_manager.ProcessUprobes(kTid, 100, 1, kRegisters);
+  function_call_manager.ProcessFunctionEntry(kTid, 100, 1, kRegisters);
 
-  function_call_manager.ProcessUprobes(kTid, 200, 2, kRegisters);
+  function_call_manager.ProcessFunctionEntry(kTid, 200, 2, kRegisters);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid, 3, 1234);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid, 3, 1234);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid);
@@ -131,7 +131,7 @@ TEST(UprobesFunctionCallManager, TwoNestedFunctionCallsAndAnotherFunctionCall) {
   EXPECT_EQ(processed_function_call.value().return_value(), 1234);
   EXPECT_THAT(processed_function_call.value().registers(), ElementsAre(1, 2, 3, 4, 5, 6));
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid, 4, 1235);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid, 4, 1235);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid);
@@ -142,9 +142,9 @@ TEST(UprobesFunctionCallManager, TwoNestedFunctionCallsAndAnotherFunctionCall) {
   EXPECT_EQ(processed_function_call.value().return_value(), 1235);
   EXPECT_THAT(processed_function_call.value().registers(), ElementsAre(1, 2, 3, 4, 5, 6));
 
-  function_call_manager.ProcessUprobes(kTid, 300, 5, std::nullopt);
+  function_call_manager.ProcessFunctionEntry(kTid, 300, 5, std::nullopt);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid, 6, std::nullopt);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid, 6, std::nullopt);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid);
@@ -163,11 +163,11 @@ TEST(UprobesFunctionCallManager, TwoFunctionCallsOnDifferentThreads) {
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  function_call_manager.ProcessUprobes(kTid1, 100, 1, kRegisters);
+  function_call_manager.ProcessFunctionEntry(kTid1, 100, 1, kRegisters);
 
-  function_call_manager.ProcessUprobes(kTid2, 200, 2, std::nullopt);
+  function_call_manager.ProcessFunctionEntry(kTid2, 200, 2, std::nullopt);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid1, 3, std::nullopt);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid1, 3, std::nullopt);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid1);
@@ -178,7 +178,7 @@ TEST(UprobesFunctionCallManager, TwoFunctionCallsOnDifferentThreads) {
   EXPECT_EQ(processed_function_call.value().return_value(), 0);
   EXPECT_THAT(processed_function_call.value().registers(), ElementsAre(1, 2, 3, 4, 5, 6));
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid2, 4, 1234);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid2, 4, 1234);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), kPid);
   EXPECT_EQ(processed_function_call.value().tid(), kTid2);
@@ -196,7 +196,7 @@ TEST(UprobesFunctionCallManager, OnlyUretprobeNoFunctionCall) {
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  processed_function_call = function_call_manager.ProcessUretprobes(kPid, kTid, 2, 1234);
+  processed_function_call = function_call_manager.ProcessFunctionExit(kPid, kTid, 2, 1234);
   ASSERT_FALSE(processed_function_call.has_value());
 }
 

--- a/src/LinuxTracing/UprobesReturnAddressManager.h
+++ b/src/LinuxTracing/UprobesReturnAddressManager.h
@@ -18,10 +18,10 @@
 
 namespace orbit_linux_tracing {
 
-// Keeps a stack, for every thread, of the return addresses at the top of the
-// stack when uprobes are hit, before they are hijacked by uretprobes. Patches
-// them into samples so that unwinding can continue past
-// dynamically-instrumented functions.
+// Keeps a stack, for every thread, of the return addresses at the top of the stack when dynamically
+// instrumented functions are entered (e.g., when uprobes are hit), before they are hijacked to
+// record the exits (e.g., by uretprobes). Patches them into samples so that unwinding can continue
+// past dynamically instrumented functions.
 class UprobesReturnAddressManager {
  public:
   UprobesReturnAddressManager() = default;
@@ -33,36 +33,49 @@ class UprobesReturnAddressManager {
   UprobesReturnAddressManager(UprobesReturnAddressManager&&) = default;
   UprobesReturnAddressManager& operator=(UprobesReturnAddressManager&&) = default;
 
-  virtual void ProcessUprobes(pid_t tid, uint64_t stack_pointer, uint64_t return_address) {
-    auto& tid_uprobes_stack = tid_uprobes_stacks_[tid];
-    tid_uprobes_stack.emplace_back(stack_pointer, return_address);
+  virtual void ProcessFunctionEntry(pid_t tid, uint64_t stack_pointer, uint64_t return_address) {
+    std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_[tid];
+    stack_of_open_functions.emplace_back(stack_pointer, return_address);
+  }
+
+  virtual void ProcessFunctionExit(pid_t tid) {
+    if (!tid_to_stack_of_open_functions_.contains(tid)) {
+      return;
+    }
+
+    std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_.at(tid);
+    CHECK(!stack_of_open_functions.empty());
+    stack_of_open_functions.pop_back();
+    if (stack_of_open_functions.empty()) {
+      tid_to_stack_of_open_functions_.erase(tid);
+    }
   }
 
   virtual void PatchSample(pid_t tid, uint64_t stack_pointer, void* stack_data,
                            uint64_t stack_size) {
-    if (!tid_uprobes_stacks_.contains(tid)) {
+    if (!tid_to_stack_of_open_functions_.contains(tid)) {
       return;
     }
 
-    auto& tid_uprobes_stack = tid_uprobes_stacks_.at(tid);
-    CHECK(!tid_uprobes_stack.empty());
+    std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_.at(tid);
+    CHECK(!stack_of_open_functions.empty());
 
-    // Apply saved return addresses in reverse order, from the last called
-    // function. In case two uretprobes hijacked an address at the same stack
-    // pointer (e.g., in case of tail-call optimization), this results in the
-    // correct original return address to end up in the patched stack.
-    for (auto it = tid_uprobes_stack.rbegin(); it != tid_uprobes_stack.rend(); it++) {
-      const OpenUprobes& uprobes = *it;
-      if (uprobes.stack_pointer < stack_pointer) {
+    // Apply saved return addresses in reverse order, from the last called function. In case two
+    // return addresses are hijacked at the same stack pointer (e.g., in case of tail-call
+    // optimization), this results in the correct original return address to end up in the patched
+    // stack.
+    for (auto it = stack_of_open_functions.rbegin(); it != stack_of_open_functions.rend(); it++) {
+      const OpenFunction& open_function = *it;
+      if (open_function.stack_pointer < stack_pointer) {
         continue;
       }
-      const uint64_t& offset = uprobes.stack_pointer - stack_pointer;
+      const uint64_t& offset = open_function.stack_pointer - stack_pointer;
       if (offset >= stack_size) {
         continue;
       }
 
-      memcpy(static_cast<uint8_t*>(stack_data) + offset, &uprobes.return_address,
-             sizeof(uprobes.return_address));
+      memcpy(static_cast<uint8_t*>(stack_data) + offset, &open_function.return_address,
+             sizeof(open_function.return_address));
     }
   }
 
@@ -72,6 +85,7 @@ class UprobesReturnAddressManager {
   // This function patches the callchain, using the maps information to identify
   // instruction pointers of uprobe code and using the return address saved in
   // the uprobes.
+  // TODO(b/204404077): Extend this algorithm to also support user space instrumentation.
   virtual bool PatchCallchain(pid_t tid, uint64_t* callchain, uint64_t callchain_size,
                               LibunwindstackMaps* maps) {
     CHECK(callchain_size > 0);
@@ -83,6 +97,8 @@ class UprobesReturnAddressManager {
       uint64_t ip = callchain[i];
       unwindstack::MapInfo* map_info = maps->Find(ip);
 
+      // TODO(b/204404077): We need to be able to detect whether an address belongs to a return
+      //  trampoline created by user space instrumentation.
       if (map_info == nullptr || map_info->name() != "[uprobes]") {
         continue;
       }
@@ -90,7 +106,7 @@ class UprobesReturnAddressManager {
       frames_to_patch.push_back(i);
     }
 
-    if (!tid_uprobes_stacks_.contains(tid)) {
+    if (!tid_to_stack_of_open_functions_.contains(tid)) {
       // If there are no uprobes, but the callchain needs to be patched, we need
       // to discard the sample.
       // There are two situations where this may happen:
@@ -103,12 +119,12 @@ class UprobesReturnAddressManager {
       return true;
     }
 
-    auto& tid_uprobes_stack = tid_uprobes_stacks_.at(tid);
+    std::vector<OpenFunction>& tid_uprobes_stack = tid_to_stack_of_open_functions_.at(tid);
     CHECK(!tid_uprobes_stack.empty());
 
     size_t num_unique_uprobes = 0;
     uint64_t prev_uprobe_stack_pointer = -1;
-    for (const auto& uprobe : tid_uprobes_stack) {
+    for (const OpenFunction& uprobe : tid_uprobes_stack) {
       if (uprobe.stack_pointer != prev_uprobe_stack_pointer) {
         num_unique_uprobes++;
       }
@@ -159,7 +175,7 @@ class UprobesReturnAddressManager {
       if (skip_last_uprobes && unique_uprobes_so_far + 1 == num_unique_uprobes) {
         break;
       }
-      const OpenUprobes& uprobe = tid_uprobes_stack[uprobe_i];
+      const OpenFunction& uprobe = tid_uprobes_stack[uprobe_i];
       // In tail-call case, we already have process the uprobe with the correct
       // return address and are done with that frame.
       if (uprobe.stack_pointer == prev_uprobe_stack_pointer) {
@@ -176,28 +192,15 @@ class UprobesReturnAddressManager {
     return true;
   }
 
-  virtual void ProcessUretprobes(pid_t tid) {
-    if (!tid_uprobes_stacks_.contains(tid)) {
-      return;
-    }
-
-    auto& tid_uprobes_stack = tid_uprobes_stacks_.at(tid);
-    CHECK(!tid_uprobes_stack.empty());
-    tid_uprobes_stack.pop_back();
-    if (tid_uprobes_stack.empty()) {
-      tid_uprobes_stacks_.erase(tid);
-    }
-  }
-
  private:
-  struct OpenUprobes {
-    OpenUprobes(uint64_t stack_pointer, uint64_t return_address)
+  struct OpenFunction {
+    OpenFunction(uint64_t stack_pointer, uint64_t return_address)
         : stack_pointer{stack_pointer}, return_address{return_address} {}
     uint64_t stack_pointer;
     uint64_t return_address;
   };
 
-  absl::flat_hash_map<pid_t, std::vector<OpenUprobes>> tid_uprobes_stacks_{};
+  absl::flat_hash_map<pid_t, std::vector<OpenFunction>> tid_to_stack_of_open_functions_{};
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InstrumentProcess.h
@@ -20,8 +20,8 @@ namespace orbit_user_space_instrumentation {
 class InstrumentedProcess;
 
 // `InstrumentationManager` is a globally unique object containing the bookkeeping for all user
-// space instrumentaion (in the `process_map_` member). Its lifetime is pretty much identical to the
-// lifetime of the profiling service.
+// space instrumentation (in the `process_map_` member). Its lifetime is pretty much identical to
+// the lifetime of the profiling service.
 class InstrumentationManager {
  public:
   InstrumentationManager(const InstrumentationManager&) = delete;


### PR DESCRIPTION
We are going to process function entries and exits (`FunctionEntry`,
`FunctionExit` protos) emitted by user space instrumentation in `LinuxTracing`,
in the same way we process uprobes. See the prototype of the integration of user
space instrumentation and unwinding as per
http://go/stadia-orbit-user-space-instrumentation-and-unwinding#heading=h.a3i5cfh8pexm
These `struct`s represent those function entries and exits.

Notes:

These events are not actually produced yet, as the actual integration with user
space instrumentation will come as a later change.

I'm renaming variables, fields, comments to generalize from uprobes to any
dynamic instrumentation (uprobes or user space), but I'm not renaming the
classes that start with `Uprobes` just yet, mostly because we need to come up
with good names.

Detection of whether a sample fell inside a user space instrumentation
trampoline, or whether an address is inside a user space instrumentation return
trampoline for frame pointer callchain patching, is another matter (and quite
more complex) and will come as a later change.

Bug: http://b/194704608

Test: Unit tests. Tried as part of the integration of user space instrumentation
and unwinding.