### PR TITLE
Create abstract base class for object files such as ELF and COFF files

### DIFF
--- a/third_party/libunwindstack/include/unwindstack/Object.h
+++ b/third_party/libunwindstack/include/unwindstack/Object.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBUNWINDSTACK_OBJECT_H
+#define _LIBUNWINDSTACK_OBJECT_H
+
+#include <string>
+
+#include "unwindstack/Error.h"
+
+namespace unwindstack {
+
+class MapInfo;
+class Regs;
+class Memory;
+struct ErrorData;
+
+class Object {
+ public:
+  Object() = default;
+  virtual ~Object() = default;
+
+  virtual bool Init() = 0;
+  virtual bool valid() = 0;
+  virtual void Invalidate() = 0;
+
+  virtual int64_t GetLoadBias() = 0;
+  virtual std::string GetBuildID() = 0;
+
+  virtual std::string GetSoname() = 0;
+  virtual bool GetFunctionName(uint64_t addr, SharedString* name, uint64_t* func_offset) = 0;
+  virtual bool GetGlobalVariableOffset(const std::string& name, uint64_t* memory_address) = 0;
+
+  virtual uint64_t GetRelPc(uint64_t pc, MapInfo* map_info) = 0;
+
+  virtual bool StepIfSignalHandler(uint64_t rel_pc, Regs* regs, Memory* process_memory) = 0;
+  virtual bool Step(uint64_t rel_pc, Regs* regs, Memory* process_memory, bool* finished,
+                    bool* is_signal_frame) = 0;
+
+  virtual Memory* memory() = 0;
+
+  virtual void GetLastError(ErrorData* data) = 0;
+  virtual ErrorCode GetLastErrorCode() = 0;
+  virtual uint64_t GetLastErrorAddress() = 0;
+};
+
+}  // namespace unwindstack
+
+#endif  // _LIBUNWINDSTACK_OBJECT_H


### PR DESCRIPTION
As a prerequisite for implementing unwinding for PE/COFF frames, we
create an abstract base class that is implemented by the `Elf` class
(and will be implemented by `Coff` in a future commit).

This is a purely mechanical change that declares all methods needed to
be implemented by a class that is returned from a `MapInfo` instance in
the `Object` base class.

Tested: No new code implemented, only interface changes. Nevertheless,
I built the service and tested on a sample application if all works.
Bug: http://b/192514457