### PR TITLE
Make menu separators in call tree widget visible

### DIFF
--- a/src/Style/Style.cpp
+++ b/src/Style/Style.cpp
@@ -47,7 +47,9 @@ void ApplyStyle(QApplication* app) {
   QApplication::setPalette(darkPalette);
   app->setStyleSheet(
       "QToolTip { color: #ffffff; background-color: #2a82da; border: 1px "
-      "solid white; }");
+      "solid white; }"
+      "QMenu::separator { height: 1px; background-color: rgb(90, 90, 90); margin-left: 2px; "
+      "margin-right: 2px; }");
 }
 
 }  // namespace orbit_style

--- a/src/Style/include/Style/Style.h
+++ b/src/Style/include/Style/Style.h
@@ -9,6 +9,6 @@
 
 namespace orbit_style {
 void ApplyStyle(QApplication* app);
-}
+}  // namespace orbit_style
 
 #endif  // STYLE_STYLE_H_


### PR DESCRIPTION
With this change, we added a more visible style for menu separators and also
applied the new style on context menus in top-down and bottom-up tabs.

Bug: http://b/204868786

Before the change: https://screenshot/9Nu7TFs8ou8K26T
After the change: https://screenshot/7n4XPYjBhCp3XSF