### PR TITLE
Forward Function{Entry,Exit} from LinuxCaptureService to LinuxTracing

### DIFF
--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -155,11 +155,8 @@ grpc::Status LinuxCaptureService::Capture(
     grpc::ServerReaderWriter<CaptureResponse, CaptureRequest>* reader_writer) {
   orbit_base::SetCurrentThreadName("CSImpl::Capture");
 
-  {
-    grpc::Status result = InitializeCapture(reader_writer);
-    if (!result.ok()) {
-      return result;
-    }
+  if (grpc::Status result = InitializeCapture(reader_writer); !result.ok()) {
+    return result;
   }
 
   TracingHandler tracing_handler{producer_event_processor_.get()};

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -131,19 +131,10 @@ class ProducerEventProcessorHijackingFunctionEntryExitForLinuxTracing
                     orbit_grpc_protos::ProducerCaptureEvent&& event) override {
     switch (event.event_case()) {
       case ProducerCaptureEvent::kFunctionEntry:
-        // TODO(b/194704608): Forward to LinuxTracing through TracingHandler.
-        LOG("FunctionEntry: pid=%u, tid=%u, function_id=%u, stack_pointer=%#x, return_address=%#x, "
-            "timestamp_ns=%u",
-            event.function_entry().pid(), event.function_entry().tid(),
-            event.function_entry().function_id(), event.function_entry().stack_pointer(),
-            event.function_entry().return_address(), event.function_entry().timestamp_ns());
-        (void)tracing_handler_;
+        tracing_handler_->ProcessFunctionEntry(event.function_entry());
         break;
       case ProducerCaptureEvent::kFunctionExit:
-        // TODO(b/194704608): Forward to LinuxTracing through TracingHandler.
-        LOG("FunctionExit: pid=%u, tid=%u, timestamp_ns=%u", event.function_exit().pid(),
-            event.function_exit().tid(), event.function_exit().timestamp_ns());
-        (void)tracing_handler_;
+        tracing_handler_->ProcessFunctionExit(event.function_exit());
         break;
       case ProducerCaptureEvent::EVENT_NOT_SET:
         UNREACHABLE();

--- a/src/LinuxCaptureService/TracingHandler.h
+++ b/src/LinuxCaptureService/TracingHandler.h
@@ -55,6 +55,13 @@ class TracingHandler : public orbit_linux_tracing::TracerListener {
   void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent
                                             out_of_order_events_discarded_event) override;
 
+  void ProcessFunctionEntry(const orbit_grpc_protos::FunctionEntry& function_entry) {
+    tracer_->ProcessFunctionEntry(function_entry);
+  }
+  void ProcessFunctionExit(const orbit_grpc_protos::FunctionExit& function_exit) {
+    tracer_->ProcessFunctionExit(function_exit);
+  }
+
  private:
   orbit_producer_event_processor::ProducerEventProcessor* producer_event_processor_;
   std::unique_ptr<orbit_linux_tracing::Tracer> tracer_;

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -53,6 +53,21 @@ class TracerImpl : public Tracer {
   void Start() override;
   void Stop() override;
 
+  void ProcessFunctionEntry(const orbit_grpc_protos::FunctionEntry& function_entry) override {
+    // TODO(b/194704608): Create an event similar to UprobesPerfEvent and call DeferEvent.
+    LOG("FunctionEntry: pid=%u, tid=%u, function_id=%u, stack_pointer=%#x, return_address=%#x, "
+        "timestamp_ns=%u",
+        function_entry.pid(), function_entry.tid(), function_entry.function_id(),
+        function_entry.stack_pointer(), function_entry.return_address(),
+        function_entry.timestamp_ns());
+  }
+
+  void ProcessFunctionExit(const orbit_grpc_protos::FunctionExit& function_exit) override {
+    // TODO(b/194704608): Create an event similar to UretprobesPerfEvent and call DeferEvent.
+    LOG("FunctionExit: pid=%u, tid=%u, timestamp_ns=%u", function_exit.pid(), function_exit.tid(),
+        function_exit.timestamp_ns());
+  }
+
  private:
   void Run();
   void Startup();

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <tracepoint.pb.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <limits>
@@ -29,6 +30,7 @@
 #include "LinuxTracing/TracerListener.h"
 #include "LostAndDiscardedEventVisitor.h"
 #include "OrbitBase/Profiling.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "PerfEvent.h"
 #include "PerfEventProcessor.h"
 #include "PerfEventRingBuffer.h"
@@ -53,20 +55,8 @@ class TracerImpl : public Tracer {
   void Start() override;
   void Stop() override;
 
-  void ProcessFunctionEntry(const orbit_grpc_protos::FunctionEntry& function_entry) override {
-    // TODO(b/194704608): Create an event similar to UprobesPerfEvent and call DeferEvent.
-    LOG("FunctionEntry: pid=%u, tid=%u, function_id=%u, stack_pointer=%#x, return_address=%#x, "
-        "timestamp_ns=%u",
-        function_entry.pid(), function_entry.tid(), function_entry.function_id(),
-        function_entry.stack_pointer(), function_entry.return_address(),
-        function_entry.timestamp_ns());
-  }
-
-  void ProcessFunctionExit(const orbit_grpc_protos::FunctionExit& function_exit) override {
-    // TODO(b/194704608): Create an event similar to UretprobesPerfEvent and call DeferEvent.
-    LOG("FunctionExit: pid=%u, tid=%u, timestamp_ns=%u", function_exit.pid(), function_exit.tid(),
-        function_exit.timestamp_ns());
-  }
+  void ProcessFunctionEntry(const orbit_grpc_protos::FunctionEntry& function_entry) override;
+  void ProcessFunctionExit(const orbit_grpc_protos::FunctionExit& function_exit) override;
 
  private:
   void Run();

--- a/src/LinuxTracing/include/LinuxTracing/Tracer.h
+++ b/src/LinuxTracing/include/LinuxTracing/Tracer.h
@@ -20,6 +20,10 @@ class Tracer {
   virtual void Start() = 0;
   virtual void Stop() = 0;
 
+  // The `FunctionEntry` and `FunctionExit` events are received from user space instrumentation and
+  // piped back into `LinuxTracing` using these two methods. This way they can be processed together
+  // with stack samples, allowing us to correctly unwind the samples that fall inside one or more
+  // dynamically instrumented functions, just like we do with u(ret)probes.
   virtual void ProcessFunctionEntry(const orbit_grpc_protos::FunctionEntry& function_entry) = 0;
   virtual void ProcessFunctionExit(const orbit_grpc_protos::FunctionExit& function_exit) = 0;
 

--- a/src/LinuxTracing/include/LinuxTracing/Tracer.h
+++ b/src/LinuxTracing/include/LinuxTracing/Tracer.h
@@ -20,6 +20,9 @@ class Tracer {
   virtual void Start() = 0;
   virtual void Stop() = 0;
 
+  virtual void ProcessFunctionEntry(const orbit_grpc_protos::FunctionEntry& function_entry) = 0;
+  virtual void ProcessFunctionExit(const orbit_grpc_protos::FunctionExit& function_exit) = 0;
+
   virtual ~Tracer() = default;
 
   [[nodiscard]] static std::unique_ptr<Tracer> Create(

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -613,18 +613,9 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
       ProcessFunctionCallAndTransferOwnership(event.release_function_call());
       break;
     case ProducerCaptureEvent::kFunctionEntry:
-      // TODO(b/194704608): Forward to LinuxTracing before reaching here, then make UNREACHABLE();
-      LOG("FunctionEntry: pid=%u, tid=%u, function_id=%u, stack_pointer=%#x, return_address=%#x, "
-          "timestamp_ns=%u",
-          event.function_entry().pid(), event.function_entry().tid(),
-          event.function_entry().function_id(), event.function_entry().stack_pointer(),
-          event.function_entry().return_address(), event.function_entry().timestamp_ns());
-      break;
+      UNREACHABLE();
     case ProducerCaptureEvent::kFunctionExit:
-      // TODO(b/194704608): Forward to LinuxTracing before reaching here, then make UNREACHABLE();
-      LOG("FunctionExit: pid=%u, tid=%u, timestamp_ns=%u", event.function_exit().pid(),
-          event.function_exit().tid(), event.function_exit().timestamp_ns());
-      break;
+      UNREACHABLE();
     case ProducerCaptureEvent::kGpuQueueSubmission:
       ProcessGpuQueueSubmissionAndTransferOwnership(producer_id,
                                                     event.release_gpu_queue_submission());

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -613,11 +613,18 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
       ProcessFunctionCallAndTransferOwnership(event.release_function_call());
       break;
     case ProducerCaptureEvent::kFunctionEntry:
-      // TODO(b/194704608): Forward to LinuxTracing (before reaching here).
-      UNREACHABLE();
+      // TODO(b/194704608): Forward to LinuxTracing before reaching here, then make UNREACHABLE();
+      LOG("FunctionEntry: pid=%u, tid=%u, function_id=%u, stack_pointer=%#x, return_address=%#x, "
+          "timestamp_ns=%u",
+          event.function_entry().pid(), event.function_entry().tid(),
+          event.function_entry().function_id(), event.function_entry().stack_pointer(),
+          event.function_entry().return_address(), event.function_entry().timestamp_ns());
+      break;
     case ProducerCaptureEvent::kFunctionExit:
-      // TODO(b/194704608): Forward to LinuxTracing (before reaching here).
-      UNREACHABLE();
+      // TODO(b/194704608): Forward to LinuxTracing before reaching here, then make UNREACHABLE();
+      LOG("FunctionExit: pid=%u, tid=%u, timestamp_ns=%u", event.function_exit().pid(),
+          event.function_exit().tid(), event.function_exit().timestamp_ns());
+      break;
     case ProducerCaptureEvent::kGpuQueueSubmission:
       ProcessGpuQueueSubmissionAndTransferOwnership(producer_id,
                                                     event.release_gpu_queue_submission());

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -8,62 +8,45 @@
 
 #include <cstdint>
 #include <stack>
+#include <variant>
 
 #include "CaptureEventProducer/LockFreeBufferCaptureEventProducer.h"
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "ProducerSideChannel/ProducerSideChannel.h"
 
-namespace {
-
 using orbit_base::CaptureTimestampNs;
 
+namespace {
+
 struct OpenFunctionCall {
-  OpenFunctionCall(uint64_t return_address, uint64_t function_id, uint64_t timestamp_on_entry_ns)
-      : return_address(return_address),
-        function_id(function_id),
-        timestamp_on_entry_ns(timestamp_on_entry_ns) {}
+  OpenFunctionCall(uint64_t return_address, uint64_t timestamp_on_entry_ns)
+      : return_address(return_address), timestamp_on_entry_ns(timestamp_on_entry_ns) {}
   uint64_t return_address;
-  uint64_t function_id;
   uint64_t timestamp_on_entry_ns;
 };
 
 // The amount of data we store for each call is relevant for the overall performance. The assert is
 // here for awareness and to avoid packing issues in the struct.
-static_assert(sizeof(OpenFunctionCall) == 24, "OpenFunctionCall should be 24 bytes.");
+static_assert(sizeof(OpenFunctionCall) == 16, "OpenFunctionCall should be 16 bytes.");
 
 std::stack<OpenFunctionCall>& GetOpenFunctionCallStack() {
   thread_local std::stack<OpenFunctionCall> open_function_calls;
   return open_function_calls;
 }
 
-uint64_t start_current_capture_timestamp = 0;
+uint64_t current_capture_start_timestamp_ns = 0;
 
-struct FunctionCallEvent {
-  FunctionCallEvent() = default;
-  FunctionCallEvent(int32_t pid, int32_t tid, uint64_t function_id, uint64_t duration_ns,
-                    uint64_t end_timestamp_ns)
-      : pid(pid),
-        tid(tid),
-        function_id(function_id),
-        duration_ns(duration_ns),
-        end_timestamp_ns(end_timestamp_ns) {}
-  int32_t pid;
-  int32_t tid;
-  uint64_t function_id;
-  uint64_t duration_ns;
-  uint64_t end_timestamp_ns;
-};
+// We can use the protos directly: since their fields are all integer fields, they are basically
+// plain structs.
+using FunctionEntryExitVariant =
+    std::variant<orbit_grpc_protos::FunctionEntry, orbit_grpc_protos::FunctionExit>;
 
-// The amount of data we transmit for each call is relevant for the overall performance. The assert
-// is here for awareness and to avoid packing issues in the struct.
-static_assert(sizeof(FunctionCallEvent) == 32, "FunctionCallEvent should be 32 bytes.");
-
-// This class is used to enqueue FunctionCallEvent events from multiple threads and relay them to
-// OrbitService in the form of orbit_grpc_protos::FunctionCall events.
-// TODO(b/194704608): Emit individual FunctionEntry and FunctionExit events instead.
+// This class is used to enqueue FunctionEntry and FunctionExit events from multiple threads and
+// relay them to OrbitService.
 class LockFreeUserSpaceInstrumentationEventProducer
-    : public orbit_capture_event_producer::LockFreeBufferCaptureEventProducer<FunctionCallEvent> {
+    : public orbit_capture_event_producer::LockFreeBufferCaptureEventProducer<
+          FunctionEntryExitVariant> {
  public:
   LockFreeUserSpaceInstrumentationEventProducer() {
     BuildAndStart(orbit_producer_side_channel::CreateProducerSideChannel());
@@ -73,47 +56,80 @@ class LockFreeUserSpaceInstrumentationEventProducer
 
  protected:
   [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent* TranslateIntermediateEvent(
-      FunctionCallEvent&& raw_event, google::protobuf::Arena* arena) override {
+      FunctionEntryExitVariant&& raw_event, google::protobuf::Arena* arena) override {
     auto* capture_event =
         google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
-    auto* function_call = capture_event->mutable_function_call();
-    function_call->set_pid(raw_event.pid);
-    function_call->set_tid(raw_event.tid);
-    function_call->set_function_id(raw_event.function_id);
-    function_call->set_duration_ns(raw_event.duration_ns);
-    function_call->set_end_timestamp_ns(raw_event.end_timestamp_ns);
+
+    std::visit(
+        [capture_event](auto&& raw_event) {
+          using DecayedEventType = std::decay_t<decltype(raw_event)>;
+          if constexpr (std::is_same_v<DecayedEventType, orbit_grpc_protos::FunctionEntry>) {
+            orbit_grpc_protos::FunctionEntry* function_entry =
+                capture_event->mutable_function_entry();
+            *function_entry = std::forward<decltype(raw_event)>(raw_event);
+          } else if constexpr (std::is_same_v<DecayedEventType, orbit_grpc_protos::FunctionExit>) {
+            orbit_grpc_protos::FunctionExit* function_exit = capture_event->mutable_function_exit();
+            *function_exit = std::forward<decltype(raw_event)>(raw_event);
+          } else {
+            static_assert(always_false_v<DecayedEventType>, "Non-exhaustive visitor");
+          }
+        },
+        std::move(raw_event));
+
     return capture_event;
   }
+
+ private:
+  template <class>
+  [[maybe_unused]] static constexpr bool always_false_v = false;
 };
+
+LockFreeUserSpaceInstrumentationEventProducer& GetCaptureEventProducer() {
+  static LockFreeUserSpaceInstrumentationEventProducer producer;
+  return producer;
+}
 
 }  // namespace
 
-void StartNewCapture() { start_current_capture_timestamp = CaptureTimestampNs(); }
+void StartNewCapture() { current_capture_start_timestamp_ns = CaptureTimestampNs(); }
 
-void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t /*stack_pointer*/) {
+void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer) {
   const uint64_t timestamp_on_entry_ns = CaptureTimestampNs();
-  auto& open_function_call_stack = GetOpenFunctionCallStack();
-  open_function_call_stack.emplace(return_address, function_id, timestamp_on_entry_ns);
-  // TODO(b/194704608): Communicate stack_pointer to OrbitService for DWARF unwinding.
+  std::stack<OpenFunctionCall>& open_function_call_stack = GetOpenFunctionCallStack();
+  open_function_call_stack.emplace(return_address, timestamp_on_entry_ns);
+
+  if (GetCaptureEventProducer().IsCapturing()) {
+    static uint32_t pid = orbit_base::GetCurrentProcessId();
+    thread_local uint32_t tid = orbit_base::GetCurrentThreadId();
+    orbit_grpc_protos::FunctionEntry function_entry;
+    function_entry.set_pid(pid);
+    function_entry.set_tid(tid);
+    function_entry.set_function_id(function_id);
+    function_entry.set_stack_pointer(stack_pointer);
+    function_entry.set_return_address(return_address);
+    function_entry.set_timestamp_ns(timestamp_on_entry_ns);
+    GetCaptureEventProducer().EnqueueIntermediateEvent(std::move(function_entry));
+  }
 }
 
 uint64_t ExitPayload() {
   const uint64_t timestamp_on_exit_ns = CaptureTimestampNs();
-  auto& open_function_call_stack = GetOpenFunctionCallStack();
-  OpenFunctionCall current_return_address = open_function_call_stack.top();
+  std::stack<OpenFunctionCall>& open_function_call_stack = GetOpenFunctionCallStack();
+  OpenFunctionCall current_function_call = open_function_call_stack.top();
   open_function_call_stack.pop();
 
-  static LockFreeUserSpaceInstrumentationEventProducer producer;
-  // Skip emitting an event if we are not capturing or the event belongs to a previous capture.
-  if (producer.IsCapturing() &&
-      start_current_capture_timestamp < current_return_address.timestamp_on_entry_ns) {
-    static pid_t pid = orbit_base::GetCurrentProcessIdNative();
-    thread_local pid_t tid = orbit_base::GetCurrentThreadIdNative();
-    const uint64_t duration_ns =
-        timestamp_on_exit_ns - current_return_address.timestamp_on_entry_ns;
-    producer.EnqueueIntermediateEvent(FunctionCallEvent(
-        pid, tid, current_return_address.function_id, duration_ns, timestamp_on_exit_ns));
+  // Skip emitting an event if we are not capturing or if the function call doesn't fully belong to
+  // this capture.
+  if (GetCaptureEventProducer().IsCapturing() &&
+      current_capture_start_timestamp_ns < current_function_call.timestamp_on_entry_ns) {
+    static uint32_t pid = orbit_base::GetCurrentProcessId();
+    thread_local uint32_t tid = orbit_base::GetCurrentThreadId();
+    orbit_grpc_protos::FunctionExit function_exit;
+    function_exit.set_pid(pid);
+    function_exit.set_tid(tid);
+    function_exit.set_timestamp_ns(timestamp_on_exit_ns);
+    GetCaptureEventProducer().EnqueueIntermediateEvent(std::move(function_exit));
   }
 
-  return current_return_address.return_address;
+  return current_function_call.return_address;
 }


### PR DESCRIPTION
The `FunctionEntry` and `FunctionExit` `ProducerCaptureEvent`s emitted by user
space instrumentation are forwarded to `LinuxTracing` and transformed into
`UserSpaceFunctionEntryPerfEvent` and `UserSpaceFunctionExitPerfEvent`. Here
they will be assembled into `FunctionCall`s and used to fix unwinding when
samples fall inside one or more dynamically instrumented function, just like
with uprobes.

See the prototype of the integration of user space instrumentation and unwinding
as per
http://go/stadia-orbit-user-space-instrumentation-and-unwinding#heading=h.a3i5cfh8pexm

Normally, `ProducerCaptureEvent`s go through the `ProducerEventProcessor`. We
send them to `LinuxTracing` instead by introducing an implementation of
`ProducerEventProcessor`
(`ProducerEventProcessorHijackingFunctionEntryExitForLinuxTracing`) that hijacks
`FunctionEntry` and `FunctionExit` events, but forwards all the other ones to
the real `ProducerEventProcessor` as usual.

Note: Detection of whether a sample fell inside a user space instrumentation
trampoline, or whether a sample fell inside the library injected by user space
instrumentation, or whether an address is inside a user space instrumentation
return trampoline for frame pointer callchain patching, is quite a more complex
matter and will come as a later change.

Bug: http://b/194704608

Test: Tried as part of the integration of user space instrumentation
and unwinding.

---

Meta-notes:
- The first commit is https://github.com/google/orbit/pull/2977.
- The change is split into multiple commits but it's meant to be squashed (an intermediate state would stop user space instrumentation from working). The reason is that I started with separate commits and I just decided to keep them all the way to the review because why not. Let me know if you prefer me to squash right away.