### PR TITLE
Generalize MapInfo to use Object instead of Elf and rename appropriately

### DIFF
--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(libunwindstack_common PRIVATE
   MemoryRemote.h
   MemoryXz.cpp
   MemoryXz.h
+  Object.cpp
   RegsArm64.cpp
   RegsArm.cpp
   Regs.cpp
@@ -110,6 +111,7 @@ target_sources(libunwindstack_common PUBLIC
   include/unwindstack/MapInfo.h
   include/unwindstack/Maps.h
   include/unwindstack/Memory.h
+  include/unwindstack/Object.h
   include/unwindstack/Regs.h
   include/unwindstack/RegsArm.h
   include/unwindstack/RegsArm64.h
@@ -198,7 +200,6 @@ target_sources(libunwindstack_tests PRIVATE
   tests/DwarfOpTest.cpp
   tests/DwarfSectionImplTest.cpp
   tests/DwarfSectionTest.cpp
-  tests/ElfCacheTest.cpp
   tests/ElfFake.cpp
   tests/ElfInterfaceArmTest.cpp
   tests/ElfInterfaceTest.cpp
@@ -221,8 +222,8 @@ target_sources(libunwindstack_tests PRIVATE
   tests/LogFake.cpp
   tests/MapInfoCreateMemoryTest.cpp
   tests/MapInfoGetBuildIDTest.cpp
-  tests/MapInfoGetElfTest.cpp
   tests/MapInfoGetLoadBiasTest.cpp
+  tests/MapInfoGetObjectTest.cpp
   tests/MapInfoTest.cpp
   tests/MapsTest.cpp
   tests/MemoryBufferTest.cpp
@@ -241,6 +242,7 @@ target_sources(libunwindstack_tests PRIVATE
   tests/MemoryTest.cpp
   tests/MemoryThreadCacheTest.cpp
   tests/MemoryXzTest.cpp
+  tests/ObjectCacheTest.cpp
   tests/RegsInfoTest.cpp
   tests/RegsIterateTest.cpp
   tests/RegsStepIfSignalHandlerTest.cpp

--- a/third_party/libunwindstack/Global.cpp
+++ b/third_party/libunwindstack/Global.cpp
@@ -81,9 +81,9 @@ void Global::FindAndReadVariable(Maps* maps, const char* var_str) {
   for (const auto& info : *maps) {
     if ((info->flags() & (PROT_READ | PROT_WRITE)) == (PROT_READ | PROT_WRITE) &&
         map_zero != nullptr && Searchable(info->name()) && info->name() == map_zero->name()) {
-      Elf* elf = map_zero->GetElf(memory_, arch());
+      Object* object = map_zero->GetObject(memory_, arch());
       uint64_t ptr;
-      if (elf->GetGlobalVariableOffset(variable, &ptr) && ptr != 0) {
+      if (object->GetGlobalVariableOffset(variable, &ptr) && ptr != 0) {
         uint64_t offset_end = info->offset() + info->end() - info->start();
         if (ptr >= info->offset() && ptr < offset_end) {
           ptr = info->start() + ptr - info->offset();

--- a/third_party/libunwindstack/Object.cpp
+++ b/third_party/libunwindstack/Object.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unwindstack/MapInfo.h>
+#include <unwindstack/Object.h>
+
+namespace unwindstack {
+
+bool Object::cache_enabled_;
+std::unordered_map<std::string, std::pair<std::shared_ptr<Object>, bool>>* Object::cache_;
+std::mutex* Object::cache_lock_;
+
+void Object::SetCachingEnabled(bool enable) {
+  if (!cache_enabled_ && enable) {
+    cache_enabled_ = true;
+    cache_ = new std::unordered_map<std::string, std::pair<std::shared_ptr<Object>, bool>>;
+    cache_lock_ = new std::mutex;
+  } else if (cache_enabled_ && !enable) {
+    cache_enabled_ = false;
+    delete cache_;
+    delete cache_lock_;
+  }
+}
+
+void Object::CacheLock() {
+  cache_lock_->lock();
+}
+
+void Object::CacheUnlock() {
+  cache_lock_->unlock();
+}
+
+void Object::CacheAdd(MapInfo* info) {
+  // If object_offset != 0, then cache both name:offset and name.
+  // The cached name is used to do lookups if multiple maps for the same
+  // named object file exist.
+  // For example, if there are two maps boot.odex:1000 and boot.odex:2000
+  // where each reference the entire boot.odex, the cache will properly
+  // use the same cached object.
+
+  if (info->offset() == 0 || info->object_offset() != 0) {
+    (*cache_)[info->name()] = std::make_pair(info->object(), true);
+  }
+
+  if (info->offset() != 0) {
+    // The second element in the pair indicates whether object_offset should
+    // be set to offset when getting out of the cache.
+    std::string key = std::string(info->name()) + ':' + std::to_string(info->offset());
+    (*cache_)[key] = std::make_pair(info->object(), info->object_offset() != 0);
+  }
+}
+
+bool Object::CacheAfterCreateMemory(MapInfo* info) {
+  if (info->name().empty() || info->offset() == 0 || info->object_offset() == 0) {
+    return false;
+  }
+
+  auto entry = cache_->find(info->name());
+  if (entry == cache_->end()) {
+    return false;
+  }
+
+  // In this case, the whole file is the object, and the name has already
+  // been cached. Add an entry at name:offset to get this directly out
+  // of the cache next time.
+  info->set_object(entry->second.first);
+  std::string key = std::string(info->name()) + ':' + std::to_string(info->offset());
+  (*cache_)[key] = std::make_pair(info->object(), true);
+  return true;
+}
+
+bool Object::CacheGet(MapInfo* info) {
+  std::string name(info->name());
+  if (info->offset() != 0) {
+    name += ':' + std::to_string(info->offset());
+  }
+  auto entry = cache_->find(name);
+  if (entry != cache_->end()) {
+    info->set_object(entry->second.first);
+    if (entry->second.second) {
+      info->set_object_offset(info->offset());
+    }
+    return true;
+  }
+  return false;
+}
+
+}  // namespace unwindstack

--- a/third_party/libunwindstack/Regs.cpp
+++ b/third_party/libunwindstack/Regs.cpp
@@ -20,8 +20,8 @@
 
 #include <vector>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MapInfo.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/Regs.h>
 #include <unwindstack/RegsArm.h>
 #include <unwindstack/RegsArm64.h>
@@ -121,14 +121,14 @@ Regs* Regs::CreateFromLocal() {
   return regs;
 }
 
-uint64_t GetPcAdjustment(uint64_t rel_pc, Elf* elf, ArchEnum arch) {
+uint64_t GetPcAdjustment(uint64_t rel_pc, Object* object, ArchEnum arch) {
   switch (arch) {
     case ARCH_ARM: {
-      if (!elf->valid()) {
+      if (!object->valid()) {
         return 2;
       }
 
-      uint64_t load_bias = elf->GetLoadBias();
+      uint64_t load_bias = object->GetLoadBias();
       if (rel_pc < load_bias) {
         if (rel_pc < 2) {
           return 0;
@@ -146,7 +146,7 @@ uint64_t GetPcAdjustment(uint64_t rel_pc, Elf* elf, ArchEnum arch) {
       if (adjusted_rel_pc & 1) {
         // This is a thumb instruction, it could be 2 or 4 bytes.
         uint32_t value;
-        if (!elf->memory()->ReadFully(adjusted_rel_pc - 5, &value, sizeof(value)) ||
+        if (!object->memory()->ReadFully(adjusted_rel_pc - 5, &value, sizeof(value)) ||
             (value & 0xe000f000) != 0xe000f000) {
           return 2;
         }

--- a/third_party/libunwindstack/RegsArm.cpp
+++ b/third_party/libunwindstack/RegsArm.cpp
@@ -19,10 +19,10 @@
 
 #include <functional>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MachineArm.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/RegsArm.h>
 #include <unwindstack/UcontextArm.h>
 #include <unwindstack/UserArm.h>
@@ -96,12 +96,12 @@ Regs* RegsArm::CreateFromUcontext(void* ucontext) {
   return regs;
 }
 
-bool RegsArm::StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) {
+bool RegsArm::StepIfSignalHandler(uint64_t object_offset, Object* object, Memory* process_memory) {
   uint32_t data;
-  Memory* elf_memory = elf->memory();
-  // Read from elf memory since it is usually more expensive to read from
+  Memory* object_memory = object->memory();
+  // Read from object memory since it is usually more expensive to read from
   // process memory.
-  if (!elf_memory->ReadFully(elf_offset, &data, sizeof(data))) {
+  if (!object_memory->ReadFully(object_offset, &data, sizeof(data))) {
     return false;
   }
 

--- a/third_party/libunwindstack/RegsArm64.cpp
+++ b/third_party/libunwindstack/RegsArm64.cpp
@@ -23,10 +23,10 @@
 #include <bionic/pac.h>
 #endif
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MachineArm64.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/RegsArm64.h>
 #include <unwindstack/UcontextArm64.h>
 #include <unwindstack/UserArm64.h>
@@ -151,12 +151,13 @@ Regs* RegsArm64::CreateFromUcontext(void* ucontext) {
   return regs;
 }
 
-bool RegsArm64::StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) {
+bool RegsArm64::StepIfSignalHandler(uint64_t object_offset, Object* object,
+                                    Memory* process_memory) {
   uint64_t data;
-  Memory* elf_memory = elf->memory();
-  // Read from elf memory since it is usually more expensive to read from
+  Memory* object_memory = object->memory();
+  // Read from object memory since it is usually more expensive to read from
   // process memory.
-  if (!elf_memory->ReadFully(elf_offset, &data, sizeof(data))) {
+  if (!object_memory->ReadFully(object_offset, &data, sizeof(data))) {
     return false;
   }
 

--- a/third_party/libunwindstack/RegsMips.cpp
+++ b/third_party/libunwindstack/RegsMips.cpp
@@ -19,10 +19,10 @@
 
 #include <functional>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MachineMips.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/RegsMips.h>
 #include <unwindstack/UcontextMips.h>
 #include <unwindstack/UserMips.h>
@@ -115,19 +115,19 @@ Regs* RegsMips::CreateFromUcontext(void* ucontext) {
   RegsMips* regs = new RegsMips();
   // Copy 64 bit sc_regs over to 32 bit regs
   for (int i = 0; i < 32; i++) {
-      (*regs)[MIPS_REG_R0 + i] = mips_ucontext->uc_mcontext.sc_regs[i];
+    (*regs)[MIPS_REG_R0 + i] = mips_ucontext->uc_mcontext.sc_regs[i];
   }
   (*regs)[MIPS_REG_PC] = mips_ucontext->uc_mcontext.sc_pc;
   return regs;
 }
 
-bool RegsMips::StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) {
+bool RegsMips::StepIfSignalHandler(uint64_t object_offset, Object* object, Memory* process_memory) {
   uint64_t data;
   uint64_t offset = 0;
-  Memory* elf_memory = elf->memory();
-  // Read from elf memory since it is usually more expensive to read from
+  Memory* object_memory = object->memory();
+  // Read from object memory since it is usually more expensive to read from
   // process memory.
-  if (!elf_memory->ReadFully(elf_offset, &data, sizeof(data))) {
+  if (!object_memory->ReadFully(object_offset, &data, sizeof(data))) {
     return false;
   }
 

--- a/third_party/libunwindstack/RegsMips64.cpp
+++ b/third_party/libunwindstack/RegsMips64.cpp
@@ -19,10 +19,10 @@
 
 #include <functional>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MachineMips64.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/RegsMips64.h>
 #include <unwindstack/UcontextMips64.h>
 #include <unwindstack/UserMips64.h>
@@ -119,12 +119,13 @@ Regs* RegsMips64::CreateFromUcontext(void* ucontext) {
   return regs;
 }
 
-bool RegsMips64::StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) {
+bool RegsMips64::StepIfSignalHandler(uint64_t object_offset, Object* object,
+                                     Memory* process_memory) {
   uint64_t data;
-  Memory* elf_memory = elf->memory();
-  // Read from elf memory since it is usually more expensive to read from
+  Memory* object_memory = object->memory();
+  // Read from object memory since it is usually more expensive to read from
   // process memory.
-  if (!elf_memory->Read(elf_offset, &data, sizeof(data))) {
+  if (!object_memory->Read(object_offset, &data, sizeof(data))) {
     return false;
   }
 

--- a/third_party/libunwindstack/RegsX86.cpp
+++ b/third_party/libunwindstack/RegsX86.cpp
@@ -18,10 +18,10 @@
 
 #include <functional>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MachineX86.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/RegsX86.h>
 #include <unwindstack/UcontextX86.h>
 #include <unwindstack/UserX86.h>
@@ -112,12 +112,12 @@ Regs* RegsX86::CreateFromUcontext(void* ucontext) {
   return regs;
 }
 
-bool RegsX86::StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) {
+bool RegsX86::StepIfSignalHandler(uint64_t object_offset, Object* object, Memory* process_memory) {
   uint64_t data;
-  Memory* elf_memory = elf->memory();
-  // Read from elf memory since it is usually more expensive to read from
+  Memory* object_memory = object->memory();
+  // Read from object memory since it is usually more expensive to read from
   // process memory.
-  if (!elf_memory->ReadFully(elf_offset, &data, sizeof(data))) {
+  if (!object_memory->ReadFully(object_offset, &data, sizeof(data))) {
     return false;
   }
 

--- a/third_party/libunwindstack/RegsX86_64.cpp
+++ b/third_party/libunwindstack/RegsX86_64.cpp
@@ -19,10 +19,10 @@
 
 #include <functional>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MachineX86_64.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/RegsX86_64.h>
 #include <unwindstack/UcontextX86_64.h>
 #include <unwindstack/UserX86_64.h>
@@ -132,17 +132,18 @@ Regs* RegsX86_64::CreateFromUcontext(void* ucontext) {
   return regs;
 }
 
-bool RegsX86_64::StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) {
+bool RegsX86_64::StepIfSignalHandler(uint64_t object_offset, Object* object,
+                                     Memory* process_memory) {
   uint64_t data;
-  Memory* elf_memory = elf->memory();
-  // Read from elf memory since it is usually more expensive to read from
+  Memory* object_memory = object->memory();
+  // Read from object memory since it is usually more expensive to read from
   // process memory.
-  if (!elf_memory->ReadFully(elf_offset, &data, sizeof(data)) || data != 0x0f0000000fc0c748) {
+  if (!object_memory->ReadFully(object_offset, &data, sizeof(data)) || data != 0x0f0000000fc0c748) {
     return false;
   }
 
   uint8_t data2;
-  if (!elf_memory->ReadFully(elf_offset + 8, &data2, sizeof(data2)) || data2 != 0x05) {
+  if (!object_memory->ReadFully(object_offset + 8, &data2, sizeof(data2)) || data2 != 0x05) {
     return false;
   }
 

--- a/third_party/libunwindstack/include/unwindstack/Elf.h
+++ b/third_party/libunwindstack/include/unwindstack/Elf.h
@@ -57,6 +57,8 @@ class Elf : public Object {
   bool GetFunctionName(uint64_t addr, SharedString* name, uint64_t* func_offset) override;
   bool GetGlobalVariableOffset(const std::string& name, uint64_t* memory_offset) override;
 
+  ArchEnum arch() override { return arch_; }
+
   uint64_t GetRelPc(uint64_t pc, MapInfo* map_info) override;
 
   bool StepIfSignalHandler(uint64_t rel_pc, Regs* regs, Memory* process_memory) override;
@@ -81,8 +83,6 @@ class Elf : public Object {
 
   uint8_t class_type() { return class_type_; }
 
-  ArchEnum arch() { return arch_; }
-
   ElfInterface* interface() { return interface_.get(); }
 
   ElfInterface* gnu_debugdata_interface() { return gnu_debugdata_interface_.get(); }
@@ -94,15 +94,6 @@ class Elf : public Object {
   static int64_t GetLoadBias(Memory* memory);
 
   static std::string GetBuildID(Memory* memory);
-
-  static void SetCachingEnabled(bool enable);
-  static bool CachingEnabled() { return cache_enabled_; }
-
-  static void CacheLock();
-  static void CacheUnlock();
-  static void CacheAdd(MapInfo* info);
-  static bool CacheGet(MapInfo* info);
-  static bool CacheAfterCreateMemory(MapInfo* info);
 
  protected:
   bool valid_ = false;
@@ -117,10 +108,6 @@ class Elf : public Object {
 
   std::unique_ptr<Memory> gnu_debugdata_memory_;
   std::unique_ptr<ElfInterface> gnu_debugdata_interface_;
-
-  static bool cache_enabled_;
-  static std::unordered_map<std::string, std::pair<std::shared_ptr<Elf>, bool>>* cache_;
-  static std::mutex* cache_lock_;
 };
 
 }  // namespace unwindstack

--- a/third_party/libunwindstack/include/unwindstack/Regs.h
+++ b/third_party/libunwindstack/include/unwindstack/Regs.h
@@ -29,7 +29,7 @@
 namespace unwindstack {
 
 // Forward declarations.
-class Elf;
+class Object;
 class Memory;
 
 class Regs {
@@ -71,7 +71,8 @@ class Regs {
   virtual bool SetPseudoRegister(uint16_t, uint64_t) { return false; }
   virtual bool GetPseudoRegister(uint16_t, uint64_t*) { return false; }
 
-  virtual bool StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) = 0;
+  virtual bool StepIfSignalHandler(uint64_t object_offset, Object* object,
+                                   Memory* process_memory) = 0;
 
   virtual bool SetPcFromReturnAddress(Memory* process_memory) = 0;
 
@@ -113,7 +114,7 @@ class RegsImpl : public Regs {
   std::vector<AddressType> regs_;
 };
 
-uint64_t GetPcAdjustment(uint64_t rel_pc, Elf* elf, ArchEnum arch);
+uint64_t GetPcAdjustment(uint64_t rel_pc, Object* object, ArchEnum arch);
 
 }  // namespace unwindstack
 

--- a/third_party/libunwindstack/include/unwindstack/RegsArm.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsArm.h
@@ -38,7 +38,7 @@ class RegsArm : public RegsImpl<uint32_t> {
 
   bool SetPcFromReturnAddress(Memory* process_memory) override;
 
-  bool StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) override;
+  bool StepIfSignalHandler(uint64_t object_offset, Object* elf, Memory* process_memory) override;
 
   void IterateRegisters(std::function<void(const char*, uint64_t)>) override final;
 

--- a/third_party/libunwindstack/include/unwindstack/RegsArm64.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsArm64.h
@@ -39,7 +39,7 @@ class RegsArm64 : public RegsImpl<uint64_t> {
 
   bool SetPcFromReturnAddress(Memory* process_memory) override;
 
-  bool StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) override;
+  bool StepIfSignalHandler(uint64_t object_offset, Object* object, Memory* process_memory) override;
 
   void IterateRegisters(std::function<void(const char*, uint64_t)>) override final;
 

--- a/third_party/libunwindstack/include/unwindstack/RegsMips.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsMips.h
@@ -38,7 +38,7 @@ class RegsMips : public RegsImpl<uint32_t> {
 
   bool SetPcFromReturnAddress(Memory* process_memory) override;
 
-  bool StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) override;
+  bool StepIfSignalHandler(uint64_t object_offset, Object* object, Memory* process_memory) override;
 
   void IterateRegisters(std::function<void(const char*, uint64_t)>) override final;
 

--- a/third_party/libunwindstack/include/unwindstack/RegsMips64.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsMips64.h
@@ -38,7 +38,7 @@ class RegsMips64 : public RegsImpl<uint64_t> {
 
   bool SetPcFromReturnAddress(Memory* process_memory) override;
 
-  bool StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) override;
+  bool StepIfSignalHandler(uint64_t object_offset, Object* object, Memory* process_memory) override;
 
   void IterateRegisters(std::function<void(const char*, uint64_t)>) override final;
 

--- a/third_party/libunwindstack/include/unwindstack/RegsX86.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsX86.h
@@ -39,7 +39,7 @@ class RegsX86 : public RegsImpl<uint32_t> {
 
   bool SetPcFromReturnAddress(Memory* process_memory) override;
 
-  bool StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) override;
+  bool StepIfSignalHandler(uint64_t object_offset, Object* object, Memory* process_memory) override;
 
   void SetFromUcontext(x86_ucontext_t* ucontext);
 

--- a/third_party/libunwindstack/include/unwindstack/RegsX86_64.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsX86_64.h
@@ -39,7 +39,7 @@ class RegsX86_64 : public RegsImpl<uint64_t> {
 
   bool SetPcFromReturnAddress(Memory* process_memory) override;
 
-  bool StepIfSignalHandler(uint64_t elf_offset, Elf* elf, Memory* process_memory) override;
+  bool StepIfSignalHandler(uint64_t object_offset, Object* object, Memory* process_memory) override;
 
   void SetFromUcontext(x86_64_ucontext_t* ucontext);
 

--- a/third_party/libunwindstack/include/unwindstack/Unwinder.h
+++ b/third_party/libunwindstack/include/unwindstack/Unwinder.h
@@ -36,7 +36,7 @@
 namespace unwindstack {
 
 // Forward declarations.
-class Elf;
+class Object;
 class ThreadEntry;
 
 struct FrameData {
@@ -54,7 +54,7 @@ struct FrameData {
   // two maps (read-only and read-execute) this will be the offset from
   // the read-only map. When there is only one map, this will be the
   // same as the actual offset of the map and match map_exact_offset.
-  uint64_t map_elf_start_offset = 0;
+  uint64_t map_object_start_offset = 0;
   // The actual offset from the map where the pc lies.
   uint64_t map_exact_offset = 0;
   uint64_t map_start = 0;
@@ -118,7 +118,7 @@ class Unwinder {
 
   void SetDexFiles(DexFiles* dex_files);
 
-  bool elf_from_memory_not_file() { return elf_from_memory_not_file_; }
+  bool object_from_memory_not_file() { return object_from_memory_not_file_; }
 
   ErrorCode LastErrorCode() { return last_error_.code; }
   const char* LastErrorCodeString() { return GetErrorCodeString(last_error_.code); }
@@ -146,7 +146,8 @@ class Unwinder {
   }
 
   void FillInDexFrame();
-  FrameData* FillInFrame(MapInfo* map_info, Elf* elf, uint64_t rel_pc, uint64_t pc_adjustment);
+  FrameData* FillInFrame(MapInfo* map_info, Object* object, uint64_t rel_pc,
+                         uint64_t pc_adjustment);
 
   size_t max_frames_;
   Maps* maps_;
@@ -158,9 +159,9 @@ class Unwinder {
   bool resolve_names_ = true;
   bool embedded_soname_ = true;
   bool display_build_id_ = false;
-  // True if at least one elf file is coming from memory and not the related
-  // file. This is only true if there is an actual file backing up the elf.
-  bool elf_from_memory_not_file_ = false;
+  // True if at least one object file is coming from memory and not the related
+  // file. This is only true if there is an actual file backing up the object.
+  bool object_from_memory_not_file_ = false;
   ErrorData last_error_;
   uint64_t warnings_;
   ArchEnum arch_ = ARCH_UNKNOWN;

--- a/third_party/libunwindstack/tests/GlobalTest.cpp
+++ b/third_party/libunwindstack/tests/GlobalTest.cpp
@@ -85,7 +85,7 @@ class GlobalTest : public ::testing::Test {
     elf_fakes_[0]->FakeSetDataVaddrEnd(0x3000);
     elf_fakes_[0]->FakeSetDataOffset(0x2000);
     auto map_info = maps_->Find(0x10000);
-    map_info->GetElfFields().elf_.reset(elf_fake);
+    map_info->GetObjectFields().object_.reset(elf_fake);
 
     elf_fake = new ElfFake(nullptr);
     elf_fake->FakeSetValid(true);
@@ -94,7 +94,7 @@ class GlobalTest : public ::testing::Test {
     elf_fakes_[1]->FakeSetDataVaddrEnd(0x3000);
     elf_fakes_[1]->FakeSetDataOffset(0x2000);
     map_info = maps_->Find(0x20000);
-    map_info->GetElfFields().elf_.reset(elf_fake);
+    map_info->GetObjectFields().object_.reset(static_cast<Object*>(elf_fake));
 
     elf_fake = new ElfFake(nullptr);
     elf_fake->FakeSetValid(true);
@@ -103,7 +103,7 @@ class GlobalTest : public ::testing::Test {
     elf_fakes_[2]->FakeSetDataVaddrEnd(0x3000);
     elf_fakes_[2]->FakeSetDataOffset(0x2000);
     map_info = maps_->Find(0x30000);
-    map_info->GetElfFields().elf_.reset(elf_fake);
+    map_info->GetObjectFields().object_.reset(static_cast<Object*>(elf_fake));
 
     elf_fake = new ElfFake(nullptr);
     elf_fake->FakeSetValid(true);
@@ -112,7 +112,7 @@ class GlobalTest : public ::testing::Test {
     elf_fakes_[3]->FakeSetDataVaddrEnd(0x1000);
     elf_fakes_[3]->FakeSetDataOffset(0);
     map_info = maps_->Find(0x40000);
-    map_info->GetElfFields().elf_.reset(elf_fake);
+    map_info->GetObjectFields().object_.reset(static_cast<Object*>(elf_fake));
 
     global_.reset(new GlobalMock(empty_));
   }

--- a/third_party/libunwindstack/tests/JitDebugTest.cpp
+++ b/third_party/libunwindstack/tests/JitDebugTest.cpp
@@ -27,6 +27,7 @@
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Maps.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 
 #include "ElfFake.h"
 #include "utils/MemoryFake.h"
@@ -46,7 +47,7 @@ class JitDebugTest : public ::testing::Test {
     interface->FakeSetDataOffset(data_offset);
     interface->FakeSetDataVaddrStart(data_vaddr);
     interface->FakeSetDataVaddrEnd(data_vaddr + data_size);
-    map_info->set_elf(elf);
+    map_info->set_object(elf);
   }
 
   void Init(ArchEnum arch) {

--- a/third_party/libunwindstack/tests/MapInfoGetBuildIDTest.cpp
+++ b/third_party/libunwindstack/tests/MapInfoGetBuildIDTest.cpp
@@ -29,10 +29,10 @@
 
 #include <gtest/gtest.h>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Maps.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 
 #include "ElfFake.h"
 #include "ElfTestUtils.h"
@@ -75,7 +75,7 @@ TEST_F(MapInfoGetBuildIDTest, no_elf_and_no_valid_elf_in_memory) {
 }
 
 TEST_F(MapInfoGetBuildIDTest, from_elf) {
-  map_info_->set_elf(elf_container_.release());
+  map_info_->set_object(elf_container_.release());
   elf_interface_->FakeSetBuildID("FAKE_BUILD_ID");
 
   EXPECT_EQ("FAKE_BUILD_ID", map_info_->GetBuildID());
@@ -83,7 +83,7 @@ TEST_F(MapInfoGetBuildIDTest, from_elf) {
 }
 
 TEST_F(MapInfoGetBuildIDTest, from_elf_no_sign_extension) {
-  map_info_->set_elf(elf_container_.release());
+  map_info_->set_object(elf_container_.release());
 
   std::string build_id = {static_cast<char>(0xfa), static_cast<char>(0xab), static_cast<char>(0x12),
                           static_cast<char>(0x02)};
@@ -126,7 +126,7 @@ void MapInfoGetBuildIDTest::MultipleThreadTest(std::string expected_build_id) {
 }
 
 TEST_F(MapInfoGetBuildIDTest, multiple_thread_elf_exists) {
-  map_info_->set_elf(elf_container_.release());
+  map_info_->set_object(elf_container_.release());
   elf_interface_->FakeSetBuildID("FAKE_BUILD_ID");
 
   MultipleThreadTest("FAKE_BUILD_ID");

--- a/third_party/libunwindstack/tests/MapInfoGetLoadBiasTest.cpp
+++ b/third_party/libunwindstack/tests/MapInfoGetLoadBiasTest.cpp
@@ -32,10 +32,10 @@
 #include <android-base/test_utils.h>
 #include <gtest/gtest.h>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Maps.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 
 #include "ElfFake.h"
 #include "ElfTestUtils.h"
@@ -69,7 +69,7 @@ TEST_F(MapInfoGetLoadBiasTest, no_elf_and_no_valid_elf_in_memory) {
 }
 
 TEST_F(MapInfoGetLoadBiasTest, load_bias_cached_from_elf) {
-  map_info_->set_elf(elf_container_.release());
+  map_info_->set_object(elf_container_.release());
 
   elf_->FakeSetLoadBias(0);
   EXPECT_EQ(0U, map_info_->GetLoadBias(process_memory_));
@@ -79,7 +79,7 @@ TEST_F(MapInfoGetLoadBiasTest, load_bias_cached_from_elf) {
 }
 
 TEST_F(MapInfoGetLoadBiasTest, elf_exists) {
-  map_info_->set_elf(elf_container_.release());
+  map_info_->set_object(elf_container_.release());
 
   elf_->FakeSetLoadBias(0);
   EXPECT_EQ(0U, map_info_->GetLoadBias(process_memory_));
@@ -122,7 +122,7 @@ void MapInfoGetLoadBiasTest::MultipleThreadTest(uint64_t expected_load_bias) {
 }
 
 TEST_F(MapInfoGetLoadBiasTest, multiple_thread_elf_exists) {
-  map_info_->set_elf(elf_container_.release());
+  map_info_->set_object(elf_container_.release());
   elf_->FakeSetLoadBias(0x1000);
 
   MultipleThreadTest(0x1000);

--- a/third_party/libunwindstack/tests/MapsTest.cpp
+++ b/third_party/libunwindstack/tests/MapsTest.cpp
@@ -39,7 +39,7 @@ static void VerifyLine(std::string line, MapInfo* info) {
     info->set_offset(element->offset());
     info->set_flags(element->flags());
     info->set_name(element->name());
-    info->set_elf_offset(element->elf_offset());
+    info->set_object_offset(element->object_offset());
   }
 }
 
@@ -57,7 +57,7 @@ TEST(MapsTest, map_add) {
   ASSERT_EQ(0U, info->offset());
   ASSERT_EQ(PROT_READ, info->flags());
   ASSERT_EQ("fake_map", info->name());
-  ASSERT_EQ(0U, info->elf_offset());
+  ASSERT_EQ(0U, info->object_offset());
   ASSERT_EQ(0U, info->load_bias().load());
 }
 
@@ -77,7 +77,7 @@ TEST(MapsTest, map_move) {
   ASSERT_EQ(0U, info->offset());
   ASSERT_EQ(PROT_READ, info->flags());
   ASSERT_EQ("fake_map", info->name());
-  ASSERT_EQ(0U, info->elf_offset());
+  ASSERT_EQ(0U, info->object_offset());
   ASSERT_EQ(0U, info->load_bias().load());
 }
 

--- a/third_party/libunwindstack/tests/RegsTest.cpp
+++ b/third_party/libunwindstack/tests/RegsTest.cpp
@@ -21,12 +21,13 @@
 #include <unwindstack/Elf.h>
 #include <unwindstack/ElfInterface.h>
 #include <unwindstack/MapInfo.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/RegsArm.h>
 #include <unwindstack/RegsArm64.h>
-#include <unwindstack/RegsX86.h>
-#include <unwindstack/RegsX86_64.h>
 #include <unwindstack/RegsMips.h>
 #include <unwindstack/RegsMips64.h>
+#include <unwindstack/RegsX86.h>
+#include <unwindstack/RegsX86_64.h>
 
 #include "ElfFake.h"
 #include "RegsFake.h"
@@ -171,7 +172,7 @@ TEST_F(RegsTest, rel_pc_arm) {
 TEST_F(RegsTest, elf_invalid) {
   MapInfo map_info(nullptr, nullptr, 0x1000, 0x2000, 0, 0, "");
   Elf* invalid_elf = new Elf(nullptr);
-  map_info.set_elf(invalid_elf);
+  map_info.set_object(invalid_elf);
 
   EXPECT_EQ(0x500U, invalid_elf->GetRelPc(0x1500, &map_info));
   EXPECT_EQ(2U, GetPcAdjustment(0x500U, invalid_elf, ARCH_ARM));

--- a/third_party/libunwindstack/utils/RegsFake.h
+++ b/third_party/libunwindstack/utils/RegsFake.h
@@ -19,8 +19,8 @@
 
 #include <stdint.h>
 
-#include <unwindstack/Elf.h>
 #include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
 #include <unwindstack/Regs.h>
 
 #include "Check.h"
@@ -54,7 +54,7 @@ class RegsFake : public Regs {
     return fake_arch_ == ARCH_ARM || fake_arch_ == ARCH_X86 || fake_arch_ == ARCH_MIPS;
   }
 
-  bool StepIfSignalHandler(uint64_t, Elf*, Memory*) override { return false; }
+  bool StepIfSignalHandler(uint64_t, Object*, Memory*) override { return false; }
 
   void FakeSetArch(ArchEnum arch) { fake_arch_ = arch; }
   void FakeSetDexPc(uint64_t dex_pc) { dex_pc_ = dex_pc; }
@@ -86,7 +86,7 @@ class RegsImplFake : public RegsImpl<TypeParam> {
   void set_pseudo_reg(uint64_t reg) { fake_pseudo_reg_ = reg; }
 
   bool SetPcFromReturnAddress(Memory*) override { return false; }
-  bool StepIfSignalHandler(uint64_t, Elf*, Memory*) override { return false; }
+  bool StepIfSignalHandler(uint64_t, Object*, Memory*) override { return false; }
 
   bool SetPseudoRegister(uint16_t reg, uint64_t value) override {
     if (fake_pseudo_reg_ != reg) {


### PR DESCRIPTION
In order to use different types of object files we have already
introduced an more general `Object` class. This class is now also
used in `MapInfo`, which is generalized to general object file types.
This unfortunately triggers a large number of required renaming and
changes throughout the library.

* The main changes are in `MapInfo` and `Unwinder`, using `Object` and
renaming a couple of fields from "elf" to "object" to generalize.
* The `Elf` cache is moved up to the `Object` class. This is mainly
moving code from Elf.cpp to Object.cpp. This could probably be its own
change, but it felt inconsistent without this step.
* Remaining changes (in tests and Regs* classes) are just changes
triggered by renaming.

Tested: Unit tests; built version and ran on a sample application.
Bug: http://b/192514457