### PR TITLE
Correct dependencies for UserSpaceInstrumentation.

### DIFF
--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -43,7 +43,7 @@ target_sources(UserSpaceInstrumentation PRIVATE
 
 target_link_libraries(UserSpaceInstrumentation PUBLIC
         GrpcProtos
-        LinuxTracing
+        ObjectUtils
         OrbitBase
         CONAN_PKG::abseil
         CONAN_PKG::capstone)
@@ -107,7 +107,6 @@ target_sources(UserSpaceInstrumentationTests PRIVATE
         TrampolineTest.cpp)
 
 target_link_libraries(UserSpaceInstrumentationTests PRIVATE
-        LinuxTracing
         TestUtils
         UserSpaceInstrumentation
         CONAN_PKG::abseil


### PR DESCRIPTION
There is no dependency to LinuxTracing. The only thing this provided is
to transitivly drag in ObjectUtils which is actually needed.

Test: Build / Unit tests
Bug: http://b/205260881