### PR TITLE
Change GetSshInfoAsync to work with project ID

### DIFF
--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -11,6 +11,7 @@
 #include <QIODevice>
 #include <QObject>
 #include <QProcess>
+#include <QString>
 #include <QStringList>
 #include <QTimer>
 #include <chrono>
@@ -44,7 +45,7 @@ class ClientImpl : public Client, public QObject {
   Future<ErrorMessageOr<QVector<Instance>>> GetInstancesAsync(InstanceListScope scope,
                                                               std::optional<Project> project,
                                                               int retry) override;
-  Future<ErrorMessageOr<SshInfo>> GetSshInfoAsync(const Instance& ggp_instance,
+  Future<ErrorMessageOr<SshInfo>> GetSshInfoAsync(const QString& instance_id,
                                                   std::optional<Project> project) override;
   Future<ErrorMessageOr<QVector<Project>>> GetProjectsAsync() override;
   Future<ErrorMessageOr<Project>> GetDefaultProjectAsync() override;
@@ -121,9 +122,9 @@ Future<ErrorMessageOr<QVector<Instance>>> ClientImpl::GetInstancesAsync(
       }));
 }
 
-Future<ErrorMessageOr<SshInfo>> ClientImpl::GetSshInfoAsync(const Instance& ggp_instance,
+Future<ErrorMessageOr<SshInfo>> ClientImpl::GetSshInfoAsync(const QString& instance_id,
                                                             std::optional<Project> project) {
-  QStringList arguments{"ssh", "init", "-s", "--instance", ggp_instance.id};
+  QStringList arguments{"ssh", "init", "-s", "--instance", instance_id};
   if (project != std::nullopt) {
     arguments.append("--project");
     arguments.append(project.value().id);

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -203,11 +203,10 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncWorking) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  Instance test_instance;
-  test_instance.id = "instance/test/id";
+  QString test_instance_id = "instance/test/id";
 
   bool future_is_resolved = false;
-  auto future = client.value()->GetSshInfoAsync(test_instance, std::nullopt);
+  auto future = client.value()->GetSshInfoAsync(test_instance_id, std::nullopt);
   future.Then(main_thread_executor_.get(),
               [&future_is_resolved](const ErrorMessageOr<SshInfo>& ssh_info) {
                 EXPECT_FALSE(future_is_resolved);
@@ -224,13 +223,12 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncWorkingWithProject) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  Instance test_instance;
-  test_instance.id = "instance/test/id";
+  QString test_instance_id = "instance/test/id";
 
   Project project{"display name", "project/test/id"};
 
   bool future_is_resolved = false;
-  auto future = client.value()->GetSshInfoAsync(test_instance, project);
+  auto future = client.value()->GetSshInfoAsync(test_instance_id, project);
   future.Then(main_thread_executor_.get(),
               [&future_is_resolved](const ErrorMessageOr<SshInfo>& ssh_info) {
                 EXPECT_FALSE(future_is_resolved);
@@ -244,8 +242,7 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncWorkingWithProject) {
 }
 
 TEST_F(OrbitGgpClientTest, GetSshInfoAsyncTimeout) {
-  Instance test_instance;
-  test_instance.id = "instance/test/id";
+  QString test_instance_id = "instance/test/id";
 
   // mock_ggp_working_ has a 50ms sleep, hence waiting for only 5ms should result in a timeout
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()),
@@ -253,7 +250,7 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncTimeout) {
   ASSERT_THAT(client, HasValue());
 
   bool future_is_resolved = false;
-  auto future = client.value()->GetSshInfoAsync(test_instance, std::nullopt);
+  auto future = client.value()->GetSshInfoAsync(test_instance_id, std::nullopt);
   future.Then(main_thread_executor_.get(), [&future_is_resolved](
                                                const ErrorMessageOr<SshInfo>& ssh_info) {
     EXPECT_FALSE(future_is_resolved);
@@ -278,10 +275,9 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncClientGetsDestroyed) {
         CreateClient(QString::fromStdString(mock_ggp_working_.string()));
     ASSERT_THAT(client, HasValue());
 
-    Instance test_instance;
-    test_instance.id = "instance/test/id";
+    QString test_instance_id = "instance/test/id";
 
-    future = client.value()->GetSshInfoAsync(test_instance, std::nullopt);
+    future = client.value()->GetSshInfoAsync(test_instance_id, std::nullopt);
 
     future.Then(main_thread_executor_.get(), [&future_is_resolved](
                                                  const ErrorMessageOr<SshInfo>& ssh_info_result) {

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -40,7 +40,7 @@ class Client {
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<QVector<Instance>>> GetInstancesAsync(
       InstanceListScope scope, std::optional<Project> project, int retry) = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<SshInfo>> GetSshInfoAsync(
-      const Instance& ggp_instance, std::optional<Project> project) = 0;
+      const QString& instance_id, std::optional<Project> project) = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<QVector<Project>>> GetProjectsAsync() = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Project>> GetDefaultProjectAsync() = 0;
 };

--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -380,7 +380,7 @@ void ConnectToStadiaWidget::CheckCredentialsAvailableOrLoad() {
   if (instance_credentials_loading_.contains(instance_id)) return;
 
   instance_credentials_loading_.emplace(instance_id);
-  auto future = ggp_client_->GetSshInfoAsync(selected_instance_.value(), selected_project_);
+  auto future = ggp_client_->GetSshInfoAsync(selected_instance_.value().id, selected_project_);
   future.Then(main_thread_executor_.get(),
               [this, instance_id](ErrorMessageOr<orbit_ggp::SshInfo> ssh_info_result) {
                 OnSshInfoLoaded(std::move(ssh_info_result), instance_id);

--- a/src/SessionSetup/RetrieveInstancesTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesTest.cpp
@@ -41,7 +41,7 @@ class MockGgpClient : public orbit_ggp::Client {
                int /*retry*/),
               (override));
   MOCK_METHOD(Future<ErrorMessageOr<SshInfo>>, GetSshInfoAsync,
-              (const Instance& /*ggp_instance*/, std::optional<Project> /*project*/), (override));
+              (const QString& /*instance_id*/, std::optional<Project> /*project*/), (override));
   MOCK_METHOD(Future<ErrorMessageOr<QVector<Project>>>, GetProjectsAsync, (), (override));
   MOCK_METHOD(Future<ErrorMessageOr<Project>>, GetDefaultProjectAsync, (), (override));
 };

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -178,7 +178,6 @@ class RetrieveInstancesWidgetTest : public testing::Test {
     VerifyProjectComboBoxData(data.projects, data.default_project, data.project_of_instances);
   }
 
-  // MockGgpClient mock_ggp_;
   MockRetrieveInstances mock_retrieve_instances_;
   RetrieveInstancesWidget widget_;
   QLineEdit* filter_line_edit_ = nullptr;


### PR DESCRIPTION
Pre-work for b/202262468: SshInfo can be retrieved by specifying a project ID only.