### PR TITLE
Change UI for enableing user space instrumentation.

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -36,7 +36,7 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
     ui_->unwindingMethodWidget->hide();
     ui_->schedulerCheckBox->hide();
     ui_->gpuSubmissionsCheckBox->hide();
-    ui_->userspaceCheckBox->hide();
+    ui_->dynamicInstrumentationMethodWidget->hide();
     ui_->introspectionCheckBox->hide();
   }
 
@@ -106,11 +106,11 @@ void CaptureOptionsDialog::SetEnableApi(bool enable_api) {
 bool CaptureOptionsDialog::GetEnableApi() const { return ui_->apiCheckBox->isChecked(); }
 
 void CaptureOptionsDialog::SetEnableUserSpaceInstrumentation(bool enable) {
-  ui_->userspaceCheckBox->setChecked(enable);
+  ui_->dynamicInstrumentationMethodComboBox->setCurrentIndex(enable ? 1 : 0);
 }
 
 bool CaptureOptionsDialog::GetEnableUserSpaceInstrumentation() const {
-  return ui_->userspaceCheckBox->isChecked();
+  return ui_->dynamicInstrumentationMethodComboBox->currentIndex() == 1;
 }
 
 void CaptureOptionsDialog::SetEnableIntrospection(bool enable_introspection) {

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>478</width>
-    <height>553</height>
+    <width>609</width>
+    <height>610</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -166,20 +166,71 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="userspaceCheckBox">
-          <property name="visible">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Enable user space instrumentation</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QCheckBox" name="introspectionCheckBox">
           <property name="text">
            <string>Enable introspection</string>
           </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="dynamicInstrumentationMethodWidget" native="true">
+          <property name="toolTip">
+           <string>Method 'Orbit' has lower overhead but is still experimental.</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Dynamic Instrumentation Method:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="dynamicInstrumentationMethodComboBox">
+             <property name="minimumSize">
+              <size>
+               <width>170</width>
+               <height>0</height>
+              </size>
+             </property>
+             <item>
+              <property name="text">
+               <string>Kernel (uprobes)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Orbit</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </widget>
         </item>
        </layout>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>609</width>
+    <width>478</width>
     <height>610</height>
    </rect>
   </property>
@@ -193,7 +193,7 @@
            <item>
             <widget class="QLabel" name="label_2">
              <property name="text">
-              <string>Dynamic Instrumentation Method:</string>
+              <string>Dynamic Instrumentation method:</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Previously this was a checkbox "Enable user space instrumention".
Now it is a combo box labeled "Dynamic instrumentation method" with the two
methods "Kernel (uprobes)" and "Orbit". The tooltip reads:
"Method 'Orbit' has lower overhead but is currently still experimental."

The combo box is only visible in devmode.