### PR TITLE
Enable live tab to export all function calls to CSV

### DIFF
--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -44,10 +44,10 @@ void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
 
 void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
                                const MockAppInterface& app, DataView& view,
-                               const std::string& expected_contents, bool is_exporting_events) {
-  std::string action = is_exporting_events ? "Export events to CSV" : "Export to CSV";
+                               const std::string& expected_contents,
+                               const std::string& action_name) {
   const auto action_index =
-      std::find(context_menu.begin(), context_menu.end(), action) - context_menu.begin();
+      std::find(context_menu.begin(), context_menu.end(), action_name) - context_menu.begin();
   ASSERT_LT(action_index, context_menu.size());
 
   ErrorMessageOr<orbit_base::TemporaryFile> temporary_file_or_error =
@@ -61,7 +61,7 @@ void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
   temporary_file_or_error.value().CloseAndRemove();
 
   EXPECT_CALL(app, GetSaveFile).Times(1).WillOnce(testing::Return(temporary_file_path.string()));
-  view.OnContextMenu(action, static_cast<int>(action_index), {0});
+  view.OnContextMenu(action_name, static_cast<int>(action_index), {0});
 
   ErrorMessageOr<std::string> contents_or_error = orbit_base::ReadFileToString(temporary_file_path);
   ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -44,10 +44,11 @@ void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
 
 void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
                                const MockAppInterface& app, DataView& view,
-                               const std::string& expected_contents) {
-  const auto export_to_csv_index =
-      std::find(context_menu.begin(), context_menu.end(), "Copy Selection") - context_menu.begin();
-  ASSERT_LT(export_to_csv_index, context_menu.size());
+                               const std::string& expected_contents, bool is_exporting_events) {
+  std::string action = is_exporting_events ? "Export events to CSV" : "Export to CSV";
+  const auto action_index =
+      std::find(context_menu.begin(), context_menu.end(), action) - context_menu.begin();
+  ASSERT_LT(action_index, context_menu.size());
 
   ErrorMessageOr<orbit_base::TemporaryFile> temporary_file_or_error =
       orbit_base::TemporaryFile::Create();
@@ -60,7 +61,7 @@ void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
   temporary_file_or_error.value().CloseAndRemove();
 
   EXPECT_CALL(app, GetSaveFile).Times(1).WillOnce(testing::Return(temporary_file_path.string()));
-  view.OnContextMenu("Export to CSV", static_cast<int>(export_to_csv_index), {0});
+  view.OnContextMenu(action, static_cast<int>(action_index), {0});
 
   ErrorMessageOr<std::string> contents_or_error = orbit_base::ReadFileToString(temporary_file_path);
   ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -25,7 +25,7 @@ void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
 void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
                                const MockAppInterface& app, DataView& view,
                                const std::string& expected_contents,
-                               bool is_exporting_events = false);
+                               const std::string& action_name = "Export to CSV");
 
 std::vector<std::string> FlattenContextMenuWithGrouping(
     const std::vector<std::vector<std::string>>& menu_with_grouping);

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -24,7 +24,8 @@ void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
 
 void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
                                const MockAppInterface& app, DataView& view,
-                               const std::string& expected_contents);
+                               const std::string& expected_contents,
+                               bool is_exporting_events = false);
 
 std::vector<std::string> FlattenContextMenuWithGrouping(
     const std::vector<std::vector<std::string>>& menu_with_grouping);

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -309,7 +309,7 @@ ErrorMessageOr<void> LiveFunctionsDataView::ExportAllEventsToCsv(
 
     const uint64_t function_id = GetInstrumentedFunctionId(row);
     const CaptureData& capture_data = app_->GetCaptureData();
-    for (const TimerInfo* timer : app_->GetAllFunctionCalls(function_id)) {
+    for (const TimerInfo* timer : app_->GetAllTimersForHookedFunction(function_id)) {
       std::string line;
       line.append(FormatValueForCsv(function_name));
       line.append(kFieldSeparator);

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -409,7 +409,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
       timers[i].set_thread_id(kThreadIds[kThreadIndices[i]]);
       timers_for_instrumented_function.push_back(&timers[i]);
     }
-    EXPECT_CALL(app_, GetAllFunctionCalls)
+    EXPECT_CALL(app_, GetAllTimersForHookedFunction)
         .WillRepeatedly(testing::Return(timers_for_instrumented_function));
 
     std::string expected_contents("\"Name\",\"Thread\",\"Start\",\"End\",\"Duration (ns)\"\r\n");

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -43,6 +43,8 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(void, DeselectTimer, ());
   MOCK_METHOD(bool, IsCapturing, (), (const));
   MOCK_METHOD(void, JumpToTimerAndZoom, (uint64_t function_id, JumpToTimerMode selection_mode));
+  MOCK_METHOD(std::vector<const orbit_client_protos::TimerInfo*>, GetAllFunctionCalls, (uint64_t),
+              (const));
 
   MOCK_METHOD(bool, IsFrameTrackEnabled, (const orbit_client_protos::FunctionInfo&), (const));
   MOCK_METHOD(bool, HasFrameTrackInCaptureData, (uint64_t), (const));

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -43,8 +43,8 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(void, DeselectTimer, ());
   MOCK_METHOD(bool, IsCapturing, (), (const));
   MOCK_METHOD(void, JumpToTimerAndZoom, (uint64_t function_id, JumpToTimerMode selection_mode));
-  MOCK_METHOD(std::vector<const orbit_client_protos::TimerInfo*>, GetAllFunctionCalls, (uint64_t),
-              (const));
+  MOCK_METHOD(std::vector<const orbit_client_protos::TimerInfo*>, GetAllTimersForHookedFunction,
+              (uint64_t), (const));
 
   MOCK_METHOD(bool, IsFrameTrackEnabled, (const orbit_client_protos::FunctionInfo&), (const));
   MOCK_METHOD(bool, HasFrameTrackInCaptureData, (uint64_t), (const));

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -50,6 +50,8 @@ class AppInterface {
   virtual void SetVisibleFunctionIds(absl::flat_hash_set<uint64_t> visible_functions) = 0;
   virtual void DeselectTimer() = 0;
   [[nodiscard]] virtual bool IsCapturing() const = 0;
+  [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*> GetAllFunctionCalls(
+      uint64_t function_id) const = 0;
 
   // Function needed by CallstackDataView
   [[nodiscard]] virtual orbit_client_data::CaptureData& GetMutableCaptureData() = 0;

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -50,8 +50,8 @@ class AppInterface {
   virtual void SetVisibleFunctionIds(absl::flat_hash_set<uint64_t> visible_functions) = 0;
   virtual void DeselectTimer() = 0;
   [[nodiscard]] virtual bool IsCapturing() const = 0;
-  [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*> GetAllFunctionCalls(
-      uint64_t function_id) const = 0;
+  [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*>
+  GetAllTimersForHookedFunction(uint64_t function_id) const = 0;
 
   // Function needed by CallstackDataView
   [[nodiscard]] virtual orbit_client_data::CaptureData& GetMutableCaptureData() = 0;

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -49,6 +49,11 @@ class LiveFunctionsDataView : public DataView {
   std::optional<int> GetRowFromFunctionId(uint64_t function_id);
   void AddFunction(uint64_t function_id, orbit_client_protos::FunctionInfo function_info);
 
+  // Export all events (including the function name, thread name and id, start timestamp, end
+  // timestamp, and duration) associated with the selected rows in to a CSV file.
+  ErrorMessageOr<void> ExportAllEventsToCsv(const std::filesystem::path& file_path,
+                                            const std::vector<int>& item_indices);
+
  protected:
   void DoFilter() override;
   void DoSort() override;
@@ -89,6 +94,7 @@ class LiveFunctionsDataView : public DataView {
   static const std::string kMenuActionJumpToLast;
   static const std::string kMenuActionJumpToMin;
   static const std::string kMenuActionJumpToMax;
+  static const std::string kMenuActionExportEventsToCsv;
 
  private:
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2661,6 +2661,10 @@ void OrbitApp::JumpToTimerAndZoom(uint64_t function_id, JumpToTimerMode selectio
   }
 }
 
+std::vector<const TimerInfo*> OrbitApp::GetAllFunctionCalls(uint64_t function_id) const {
+  return GetTimeGraph()->GetAllFunctionCalls(function_id);
+}
+
 void OrbitApp::RefreshFrameTracks() {
   CHECK(HasCaptureData());
   CHECK(std::this_thread::get_id() == main_thread_id_);

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2661,8 +2661,8 @@ void OrbitApp::JumpToTimerAndZoom(uint64_t function_id, JumpToTimerMode selectio
   }
 }
 
-std::vector<const TimerInfo*> OrbitApp::GetAllFunctionCalls(uint64_t function_id) const {
-  return GetTimeGraph()->GetAllFunctionCalls(function_id);
+std::vector<const TimerInfo*> OrbitApp::GetAllTimersForHookedFunction(uint64_t function_id) const {
+  return GetTimeGraph()->GetAllTimersForHookedFunction(function_id);
 }
 
 void OrbitApp::RefreshFrameTracks() {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -481,6 +481,8 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] bool HasFrameTrackInCaptureData(uint64_t instrumented_function_id) const override;
 
   void JumpToTimerAndZoom(uint64_t function_id, JumpToTimerMode selection_mode) override;
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllFunctionCalls(
+      uint64_t function_id) const override;
 
  private:
   void UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -481,7 +481,7 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] bool HasFrameTrackInCaptureData(uint64_t instrumented_function_id) const override;
 
   void JumpToTimerAndZoom(uint64_t function_id, JumpToTimerMode selection_mode) override;
-  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllFunctionCalls(
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllTimersForHookedFunction(
       uint64_t function_id) const override;
 
  private:

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -382,7 +382,7 @@ void TimeGraph::ProcessCGroupAndProcessMemoryTrackingTimer(const TimerInfo& time
   track->OnTimer(timer_info);
 }
 
-void TimeGraph::ProcessPageFaultsTrackingTimer(const orbit_client_protos::TimerInfo& timer_info) {
+void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
   uint64_t cgroup_name_hash = timer_info.registers(
       static_cast<size_t>(CaptureEventProcessor::PageFaultsEncodingIndex::kCGroupNameHash));
   std::string cgroup_name = app_->GetStringManager()->Get(cgroup_name_hash).value_or("");
@@ -456,14 +456,14 @@ void TimeGraph::SelectAndMakeVisible(const TimerInfo* timer_info) {
 const TimerInfo* TimeGraph::FindPreviousFunctionCall(uint64_t function_address,
                                                      uint64_t current_time,
                                                      std::optional<uint32_t> thread_id) const {
-  const orbit_client_protos::TimerInfo* previous_timer = nullptr;
+  const TimerInfo* previous_timer = nullptr;
   uint64_t goal_time = std::numeric_limits<uint64_t>::lowest();
   std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
   for (const TimerChain* chain : chains) {
     for (const auto& block : *chain) {
       if (!block.Intersects(goal_time, current_time)) continue;
       for (uint64_t i = 0; i < block.size(); i++) {
-        const orbit_client_protos::TimerInfo& timer_info = block[i];
+        const TimerInfo& timer_info = block[i];
         auto timer_end_time = timer_info.end();
         if ((timer_info.function_id() == function_address) &&
             (!thread_id || thread_id.value() == timer_info.thread_id()) &&
@@ -479,7 +479,7 @@ const TimerInfo* TimeGraph::FindPreviousFunctionCall(uint64_t function_address,
 
 const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint64_t current_time,
                                                  std::optional<uint32_t> thread_id) const {
-  const orbit_client_protos::TimerInfo* next_timer = nullptr;
+  const TimerInfo* next_timer = nullptr;
   uint64_t goal_time = std::numeric_limits<uint64_t>::max();
   std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
   for (const TimerChain* chain : chains) {
@@ -487,7 +487,7 @@ const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint
     for (const auto& block : *chain) {
       if (!block.Intersects(current_time, goal_time)) continue;
       for (uint64_t i = 0; i < block.size(); i++) {
-        const orbit_client_protos::TimerInfo& timer_info = block[i];
+        const TimerInfo& timer_info = block[i];
         auto timer_end_time = timer_info.end();
         if ((timer_info.function_id() == function_address) &&
             (!thread_id || thread_id.value() == timer_info.thread_id()) &&
@@ -499,6 +499,21 @@ const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint
     }
   }
   return next_timer;
+}
+
+std::vector<const TimerInfo*> TimeGraph::GetAllFunctionCalls(uint64_t function_address) const {
+  std::vector<const TimerInfo*> timers;
+  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
+  for (const TimerChain* chain : chains) {
+    CHECK(chain != nullptr);
+    for (const auto& block : *chain) {
+      for (uint64_t i = 0; i < block.size(); i++) {
+        const TimerInfo& timer = block[i];
+        if (timer.function_id() == function_address) timers.push_back(&timer);
+      }
+    }
+  }
+  return timers;
 }
 
 void TimeGraph::RequestUpdate() {
@@ -650,14 +665,13 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
     return;
   }
 
-  std::vector<std::pair<uint64_t, const orbit_client_protos::TimerInfo*>> timers(
-      iterator_timer_info_.size());
+  std::vector<std::pair<uint64_t, const TimerInfo*>> timers(iterator_timer_info_.size());
   std::copy(iterator_timer_info_.begin(), iterator_timer_info_.end(), timers.begin());
 
   // Sort timers by start time.
   std::sort(timers.begin(), timers.end(),
-            [](const std::pair<uint64_t, const orbit_client_protos::TimerInfo*>& timer_a,
-               const std::pair<uint64_t, const orbit_client_protos::TimerInfo*>& timer_b) -> bool {
+            [](const std::pair<uint64_t, const TimerInfo*>& timer_a,
+               const std::pair<uint64_t, const TimerInfo*>& timer_b) -> bool {
               return timer_a.second->start() < timer_b.second->start();
             });
 
@@ -833,7 +847,7 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
       !TrackManager::FunctionIteratableType(from->type())) {
     jump_scope = JumpScope::kSameDepth;
   }
-  const orbit_client_protos::TimerInfo* goal = nullptr;
+  const TimerInfo* goal = nullptr;
   auto function_id = from->function_id();
   auto current_time = from->end();
   auto thread_id = from->thread_id();
@@ -905,13 +919,13 @@ const TimerInfo* TimeGraph::FindDown(const TimerInfo& from) {
 
 std::pair<const TimerInfo*, const TimerInfo*> TimeGraph::GetMinMaxTimerInfoForFunction(
     uint64_t function_id) const {
-  const orbit_client_protos::TimerInfo* min_timer = nullptr;
-  const orbit_client_protos::TimerInfo* max_timer = nullptr;
+  const TimerInfo* min_timer = nullptr;
+  const TimerInfo* max_timer = nullptr;
   std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
   for (const TimerChain* chain : chains) {
     for (const auto& block : *chain) {
       for (size_t i = 0; i < block.size(); i++) {
-        const orbit_client_protos::TimerInfo& timer_info = block[i];
+        const TimerInfo& timer_info = block[i];
         if (timer_info.function_id() != function_id) continue;
 
         uint64_t elapsed_nanos = timer_info.end() - timer_info.start();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -501,7 +501,8 @@ const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint
   return next_timer;
 }
 
-std::vector<const TimerInfo*> TimeGraph::GetAllFunctionCalls(uint64_t function_address) const {
+std::vector<const TimerInfo*> TimeGraph::GetAllTimersForHookedFunction(
+    uint64_t function_address) const {
   std::vector<const TimerInfo*> timers;
   std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
   for (const TimerChain* chain : chains) {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -105,6 +105,9 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindNextFunctionCall(
       uint64_t function_address, uint64_t current_time,
       std::optional<uint32_t> thread_id = std::nullopt) const;
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllFunctionCalls(
+      uint64_t function_address) const;
+
   void SelectAndZoom(const orbit_client_protos::TimerInfo* timer_info);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
   [[nodiscard]] double GetCurrentTimeSpanUs() const;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -105,7 +105,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindNextFunctionCall(
       uint64_t function_address, uint64_t current_time,
       std::optional<uint32_t> thread_id = std::nullopt) const;
-  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllFunctionCalls(
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllTimersForHookedFunction(
       uint64_t function_address) const;
 
   void SelectAndZoom(const orbit_client_protos::TimerInfo* timer_info);


### PR DESCRIPTION
With this change, we enable the live tab to support exporting all function call events associated with the selected functions into a CSV file.

The exported information contains the function name, thread name & id, start timestamp, end timestamp, duration. And this action "Export Events to CSV" is added to the same action group as "Copy Selection" and "Export to CSV".

Example output CSV file https://screenshot/4Yjm2XcDTJmzEgL

Bug: http://b/198126248
Test: run unit tests