### PR TITLE
Fix the resizing behavior in recent captures table and process list

### DIFF
--- a/src/CaptureFileInfo/LoadCaptureWidget.cpp
+++ b/src/CaptureFileInfo/LoadCaptureWidget.cpp
@@ -43,7 +43,12 @@ LoadCaptureWidget::LoadCaptureWidget(QWidget* parent)
   ui_->tableView->setSortingEnabled(true);
   ui_->tableView->sortByColumn(static_cast<int>(ItemModel::Column::kLastUsed),
                                Qt::SortOrder::DescendingOrder);
-  ui_->tableView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+  ui_->tableView->horizontalHeader()->setSectionResizeMode(
+      static_cast<int>(ItemModel::Column::kFilename), QHeaderView::Stretch);
+  ui_->tableView->horizontalHeader()->setSectionResizeMode(
+      static_cast<int>(ItemModel::Column::kLastUsed), QHeaderView::ResizeToContents);
+  ui_->tableView->horizontalHeader()->setSectionResizeMode(
+      static_cast<int>(ItemModel::Column::kCreated), QHeaderView::ResizeToContents);
   ui_->tableView->verticalHeader()->setDefaultSectionSize(kRowHeight);
 
   // The following is to make the radiobutton behave as if it was part of an exclusive button group

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -106,10 +106,10 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
   ui_->processesTableView->sortByColumn(static_cast<int>(ProcessItemModel::Column::kCpu),
                                         Qt::DescendingOrder);
 
-  ui_->processesTableView->horizontalHeader()->resizeSection(
-      static_cast<int>(ProcessItemModel::Column::kPid), 60);
-  ui_->processesTableView->horizontalHeader()->resizeSection(
-      static_cast<int>(ProcessItemModel::Column::kCpu), 60);
+  ui_->processesTableView->horizontalHeader()->setSectionResizeMode(
+      static_cast<int>(ProcessItemModel::Column::kPid), QHeaderView::ResizeToContents);
+  ui_->processesTableView->horizontalHeader()->setSectionResizeMode(
+      static_cast<int>(ProcessItemModel::Column::kCpu), QHeaderView::ResizeToContents);
   ui_->processesTableView->horizontalHeader()->setSectionResizeMode(
       static_cast<int>(ProcessItemModel::Column::kName), QHeaderView::Stretch);
   ui_->processesTableView->verticalHeader()->setDefaultSectionSize(kProcessesRowHeight);


### PR DESCRIPTION
With this change, we fix the resizing behavior in the recent captures table and the process list table.

Bug: http://b/205556055