### PR TITLE
Use proto enums to represent unwinding method.

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -24,7 +24,6 @@
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
-#include "capture.pb.h"
 #include "tracepoint.pb.h"
 
 namespace orbit_capture_client {
@@ -41,7 +40,7 @@ using orbit_grpc_protos::CaptureResponse;
 using orbit_grpc_protos::ClientCaptureEvent;
 using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::TracepointInfo;
-using orbit_grpc_protos::UnwindingMethod;
+using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
 
 using orbit_base::Future;
 
@@ -140,11 +139,8 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
   } else {
     capture_options->set_samples_per_second(samples_per_second);
     capture_options->set_stack_dump_size(stack_dump_size);
-    if (unwinding_method == UnwindingMethod::kFramePointerUnwinding) {
-      capture_options->set_unwinding_method(CaptureOptions::kFramePointers);
-    } else {
-      capture_options->set_unwinding_method(CaptureOptions::kDwarf);
-    }
+    CHECK(unwinding_method != CaptureOptions::kUndefined);
+    capture_options->set_unwinding_method(unwinding_method);
   }
 
   capture_options->set_collect_memory_info(collect_memory_info);

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -25,6 +25,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadPool.h"
+#include "capture.pb.h"
 #include "capture_data.pb.h"
 #include "services.grpc.pb.h"
 #include "services.pb.h"
@@ -44,7 +45,7 @@ class CaptureClient {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       bool record_arguments, bool record_return_values,
       orbit_client_data::TracepointInfoSet selected_tracepoints, double samples_per_second,
-      uint16_t stack_dump_size, orbit_grpc_protos::UnwindingMethod unwinding_method,
+      uint16_t stack_dump_size, orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method,
       bool collect_scheduling_info, bool collect_thread_state, bool collect_gpu_jobs,
       bool enable_api, bool enable_introspection, bool enable_user_space_instrumentation,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
@@ -77,7 +78,7 @@ class CaptureClient {
       const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions,
       bool record_arguments, bool record_return_values,
       const orbit_client_data::TracepointInfoSet& selected_tracepoints, double samples_per_second,
-      uint16_t stack_dump_size, orbit_grpc_protos::UnwindingMethod unwinding_method,
+      uint16_t stack_dump_size, orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method,
       bool collect_scheduling_info, bool collect_thread_state, bool collect_gpu_jobs,
       bool enable_api, bool enable_introspection, bool enable_user_space_instrumentation,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -17,6 +17,7 @@
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/UserDefinedCaptureData.h"
 #include "GrpcProtos/Constants.h"
+#include "capture.pb.h"
 #include "capture_data.pb.h"
 #include "tracepoint.pb.h"
 
@@ -108,10 +109,12 @@ class DataManager final {
   void set_stack_dump_size(uint16_t stack_dump_size) { stack_dump_size_ = stack_dump_size; }
   [[nodiscard]] uint16_t stack_dump_size() const { return stack_dump_size_; }
 
-  void set_unwinding_method(orbit_grpc_protos::UnwindingMethod method) {
+  void set_unwinding_method(orbit_grpc_protos::CaptureOptions::UnwindingMethod method) {
     unwinding_method_ = method;
   }
-  orbit_grpc_protos::UnwindingMethod unwinding_method() const { return unwinding_method_; }
+  orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method() const {
+    return unwinding_method_;
+  }
 
   void set_max_local_marker_depth_per_command_buffer(
       uint64_t max_local_marker_depth_per_command_buffer) {
@@ -164,7 +167,7 @@ class DataManager final {
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
   double samples_per_second_ = 0;
   uint16_t stack_dump_size_ = 0;
-  orbit_grpc_protos::UnwindingMethod unwinding_method_{};
+  orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_{};
 
   bool collect_memory_info_ = false;
   uint64_t memory_sampling_period_ms_ = 10;

--- a/src/GrpcProtos/include/GrpcProtos/Constants.h
+++ b/src/GrpcProtos/include/GrpcProtos/Constants.h
@@ -21,7 +21,6 @@ constexpr uint64_t kIntrospectionProducerId = 3;
 constexpr uint64_t kWindowsTracingProducerId = 4;
 constexpr uint64_t kExternalProducerStartingId = 1024;
 
-enum class UnwindingMethod { kDwarfUnwinding = 0, kFramePointerUnwinding = 1 };
 }  // namespace orbit_grpc_protos
 
 #endif  // GRPC_PROTOS_CONSTANTS_H_

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -60,10 +60,12 @@ using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::TimerInfo;
 
 using orbit_grpc_protos::CaptureFinished;
+using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::CaptureStarted;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::ProcessInfo;
-using orbit_grpc_protos::UnwindingMethod;
+
+using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
 
 bool ClientGgp::InitClient() {
   if (options_.grpc_server_address.empty()) {
@@ -105,9 +107,8 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
 
   LOG("Capture pid %d", pid);
   TracepointInfoSet selected_tracepoints;
-  UnwindingMethod unwinding_method = options_.use_framepointer_unwinding
-                                         ? UnwindingMethod::kFramePointerUnwinding
-                                         : UnwindingMethod::kDwarfUnwinding;
+  const UnwindingMethod unwinding_method =
+      options_.use_framepointer_unwinding ? CaptureOptions::kFramePointers : CaptureOptions::kDwarf;
   bool collect_scheduling_info = true;
   bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
   bool collect_gpu_jobs = true;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -119,13 +119,13 @@ using orbit_client_services::TracepointServiceClient;
 using orbit_gl::MainWindowInterface;
 
 using orbit_grpc_protos::CaptureFinished;
+using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::CaptureStarted;
 using orbit_grpc_protos::ClientCaptureEvent;
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType;
 using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::TracepointInfo;
-using orbit_grpc_protos::UnwindingMethod;
 
 using orbit_metrics_uploader::CaptureMetric;
 using orbit_metrics_uploader::ScopedMetric;
@@ -133,6 +133,8 @@ using orbit_metrics_uploader::ScopedMetric;
 using orbit_preset_file::PresetFile;
 
 using orbit_data_views::DataViewType;
+
+using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
 
 namespace {
 
@@ -1338,8 +1340,8 @@ void OrbitApp::StartCapture() {
       IsDevMode() && data_manager_->enable_user_space_instrumentation();
   double samples_per_second = data_manager_->samples_per_second();
   uint16_t stack_dump_size = data_manager_->stack_dump_size();
-  UnwindingMethod unwinding_method =
-      IsDevMode() ? data_manager_->unwinding_method() : UnwindingMethod::kDwarfUnwinding;
+  const UnwindingMethod unwinding_method =
+      IsDevMode() ? data_manager_->unwinding_method() : CaptureOptions::kDwarf;
   uint64_t max_local_marker_depth_per_command_buffer =
       data_manager_->max_local_marker_depth_per_command_buffer();
 
@@ -2197,7 +2199,7 @@ void OrbitApp::SetStackDumpSize(uint16_t stack_dump_size) {
   data_manager_->set_stack_dump_size(stack_dump_size);
 }
 
-void OrbitApp::SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method) {
+void OrbitApp::SetUnwindingMethod(UnwindingMethod unwinding_method) {
   data_manager_->set_unwinding_method(unwinding_method);
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -397,7 +397,7 @@ class OrbitApp final : public DataViewFactory,
   void SetEnableUserSpaceInstrumentation(bool enable);
   void SetSamplesPerSecond(double samples_per_second);
   void SetStackDumpSize(uint16_t stack_dump_size);
-  void SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method);
+  void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
 
   void SetCollectMemoryInfo(bool collect_memory_info) {

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -15,7 +15,12 @@
 
 #include "ClientFlags/ClientFlags.h"
 #include "ui_CaptureOptionsDialog.h"
+
 namespace orbit_qt {
+
+using orbit_grpc_protos::CaptureOptions;
+
+using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
 
 CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
     : QDialog{parent}, ui_(std::make_unique<Ui::CaptureOptionsDialog>()) {
@@ -24,11 +29,9 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
-  ui_->unwindingMethodComboBox->addItem(
-      "DWARF", static_cast<int>(orbit_grpc_protos::UnwindingMethod::kDwarfUnwinding));
-  ui_->unwindingMethodComboBox->addItem(
-      "Frame pointers",
-      static_cast<int>(orbit_grpc_protos::UnwindingMethod::kFramePointerUnwinding));
+  ui_->unwindingMethodComboBox->addItem("DWARF", static_cast<int>(CaptureOptions::kDwarf));
+  ui_->unwindingMethodComboBox->addItem("Frame pointers",
+                                        static_cast<int>(CaptureOptions::kFramePointers));
 
   if (!absl::GetFlag(FLAGS_devmode)) {
     // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
@@ -64,15 +67,14 @@ double CaptureOptionsDialog::GetSamplingPeriodMs() const {
   return ui_->samplingPeriodMsDoubleSpinBox->value();
 }
 
-void CaptureOptionsDialog::SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method) {
+void CaptureOptionsDialog::SetUnwindingMethod(UnwindingMethod unwinding_method) {
   int index = ui_->unwindingMethodComboBox->findData(static_cast<int>(unwinding_method));
   CHECK(index >= 0);
   return ui_->unwindingMethodComboBox->setCurrentIndex(index);
 }
 
-orbit_grpc_protos::UnwindingMethod CaptureOptionsDialog::GetUnwindingMethod() const {
-  return static_cast<orbit_grpc_protos::UnwindingMethod>(
-      ui_->unwindingMethodComboBox->currentData().toInt());
+UnwindingMethod CaptureOptionsDialog::GetUnwindingMethod() const {
+  return static_cast<UnwindingMethod>(ui_->unwindingMethodComboBox->currentData().toInt());
 }
 
 void CaptureOptionsDialog::SetCollectSchedulerInfo(bool collect_scheduler_info) {

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -12,8 +12,8 @@
 #include <QWidget>
 #include <memory>
 
-#include "GrpcProtos/Constants.h"
 #include "OrbitBase/Logging.h"
+#include "capture.pb.h"
 #include "ui_CaptureOptionsDialog.h"
 
 namespace orbit_qt {
@@ -49,8 +49,8 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] bool GetEnableSampling() const;
   void SetSamplingPeriodMs(double sampling_period_ms);
   [[nodiscard]] double GetSamplingPeriodMs() const;
-  void SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method);
-  [[nodiscard]] orbit_grpc_protos::UnwindingMethod GetUnwindingMethod() const;
+  void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod GetUnwindingMethod() const;
   void SetCollectSchedulerInfo(bool collect_scheduler_info);
   [[nodiscard]] bool GetCollectSchedulerInfo() const;
   void SetCollectThreadStates(bool collect_thread_state);


### PR DESCRIPTION
Previously there was a duplicated enum in Constants.h.