### PR TITLE
Save and restore main window geometry

### DIFF
--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -122,10 +122,7 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
 
       OrbitMainWindow w(std::move(target_config.value()), crash_handler, metrics_uploader.get(),
                         command_line_flags);
-
-      // "resize" is required to make "showMaximized" work properly.
-      w.resize(1280, 720);
-      w.showMaximized();
+      w.show();
 
       application_return_code = QApplication::exec();
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -257,6 +257,7 @@ void OrbitMainWindow::SetupMainWindow() {
   DataViewFactory* data_view_factory = app_.get();
 
   ui->setupUi(this);
+  RestoreMainWindowGeometry();
 
   ui->splitter_2->setSizes({5000, 5000});
 
@@ -573,6 +574,18 @@ void OrbitMainWindow::SaveCurrentTabLayoutAsDefaultInMemory() {
     layout.current_index = tab_widget->currentIndex();
     default_tab_layout_[tab_widget] = layout;
   }
+}
+
+void OrbitMainWindow::SaveMainWindowGeometry() {
+  QSettings settings;
+  settings.setValue(kMainWindowGeometrySettingKey, saveGeometry());
+  settings.setValue(kMainWindowStateSettingKey, saveState());
+}
+
+void OrbitMainWindow::RestoreMainWindowGeometry() {
+  QSettings settings;
+  restoreGeometry(settings.value(kMainWindowGeometrySettingKey).toByteArray());
+  restoreState(settings.value(kMainWindowStateSettingKey).toByteArray());
 }
 
 void OrbitMainWindow::CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_index,
@@ -1065,6 +1078,8 @@ const QString OrbitMainWindow::kLimitLocalMarkerDepthPerCommandBufferSettingsKey
     "LimitLocalMarkerDepthPerCommandBuffer"};
 const QString OrbitMainWindow::kMaxLocalMarkerDepthPerCommandBufferSettingsKey{
     "MaxLocalMarkerDepthPerCommandBuffer"};
+const QString OrbitMainWindow::kMainWindowGeometrySettingKey{"MainWindowGeometry"};
+const QString OrbitMainWindow::kMainWindowStateSettingKey{"MainWindowState"};
 
 constexpr double kCallstackSamplingPeriodMsDefaultValue = 1.0;
 constexpr UnwindingMethod kCallstackUnwindingMethodDefaultValue = CaptureOptions::kDwarf;
@@ -1425,6 +1440,8 @@ bool OrbitMainWindow::ConfirmExit() {
 }
 
 void OrbitMainWindow::Exit(int return_code) {
+  SaveMainWindowGeometry();
+
   if (app_->IsCapturing() || app_->IsLoadingCapture()) {
     // We need for the capture to clean up - exit as soon as this is done
     app_->SetCaptureFailedCallback([this, return_code] { Exit(return_code); });

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -168,6 +168,9 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   void SaveCurrentTabLayoutAsDefaultInMemory();
 
+  void SaveMainWindowGeometry();
+  void RestoreMainWindowGeometry();
+
   void CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_index, const QPoint& pos);
   void UpdateCaptureStateDependentWidgets();
   void UpdateProcessConnectionStateDependentWidgets();
@@ -197,6 +200,9 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kMemoryWarningThresholdKbSettingKey;
   static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;
   static const QString kMaxLocalMarkerDepthPerCommandBufferSettingsKey;
+  static const QString kMainWindowGeometrySettingKey;
+  static const QString kMainWindowStateSettingKey;
+
   void LoadCaptureOptionsIntoApp();
 
   [[nodiscard]] bool ConfirmExit();


### PR DESCRIPTION
With this change, we save and restore the main window layout.

Bug: http://b/173773647
Test: 1) run Orbit, open the main window and change the size and position; 2) close the main window by clicking the close windows button / the "End Session" button / the "Quit" item on the main menu; 3) open the main window again and check the size and position of the main window.