### PR TITLE
Enable presets tab to show preset file in explorer

### DIFF
--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -30,8 +30,9 @@ class MockAppInterface : public AppInterface {
 
   MOCK_METHOD(void, SendErrorToUi, (const std::string& title, const std::string& text));
 
-  MOCK_METHOD(void, LoadPreset, (const orbit_preset_file::PresetFile& preset));
+  MOCK_METHOD(void, LoadPreset, (const orbit_preset_file::PresetFile&));
   MOCK_METHOD(PresetLoadState, GetPresetLoadState, (const orbit_preset_file::PresetFile&), (const));
+  MOCK_METHOD(void, ShowPresetInExplorer, (const orbit_preset_file::PresetFile&));
 
   MOCK_METHOD(bool, IsFunctionSelected, (const orbit_client_protos::FunctionInfo&), (const));
   MOCK_METHOD(bool, IsFunctionSelected, (const orbit_client_data::SampledFunction&), (const));

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -154,16 +154,16 @@ const std::string PresetsDataView::kMenuActionShowInExplorer = "Show in Explorer
 
 std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
-  std::vector<std::string> action_group;
   // Note that the UI already enforces a single selection.
-  if (selected_indices.size() == 1) {
-    const PresetFile& preset = GetPreset(selected_indices[0]);
-    if (app_->GetPresetLoadState(preset).state != PresetLoadState::kNotLoadable) {
-      action_group.emplace_back(kMenuActionLoad);
-    }
-    action_group.emplace_back(kMenuActionDelete);
-    action_group.emplace_back(kMenuActionShowInExplorer);
+  CHECK(selected_indices.size() == 1);
+
+  std::vector<std::string> action_group;
+  const PresetFile& preset = GetPreset(selected_indices[0]);
+  if (app_->GetPresetLoadState(preset).state != PresetLoadState::kNotLoadable) {
+    action_group.emplace_back(kMenuActionLoad);
   }
+  action_group.emplace_back(kMenuActionDelete);
+  action_group.emplace_back(kMenuActionShowInExplorer);
 
   std::vector<std::vector<std::string>> menu =
       DataView::GetContextMenuWithGrouping(clicked_index, selected_indices);
@@ -174,19 +174,16 @@ std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGroupin
 
 void PresetsDataView::OnContextMenu(const std::string& action, int menu_index,
                                     const std::vector<int>& item_indices) {
+  // Note that the UI already enforces a single selection.
+  CHECK(item_indices.size() == 1);
+
   if (action == kMenuActionLoad) {
-    if (item_indices.size() != 1) {
-      return;
-    }
     const PresetFile& preset = GetPreset(item_indices[0]);
     app_->LoadPreset(preset);
 
   } else if (action == kMenuActionDelete) {
     orbit_metrics_uploader::ScopedMetric metric{
         metrics_uploader_, orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_PRESET_DELETE};
-    if (item_indices.size() != 1) {
-      return;
-    }
     int row = item_indices[0];
     const PresetFile& preset = GetPreset(row);
     const std::string& filename = preset.file_path().string();
@@ -202,9 +199,6 @@ void PresetsDataView::OnContextMenu(const std::string& action, int menu_index,
     }
 
   } else if (action == kMenuActionShowInExplorer) {
-    if (item_indices.size() != 1) {
-      return;
-    }
     const PresetFile& preset = GetPreset(item_indices[0]);
     app_->ShowPresetInExplorer(preset);
 

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -150,6 +150,7 @@ void PresetsDataView::DoSort() {
 
 const std::string PresetsDataView::kMenuActionLoad = "Load Preset";
 const std::string PresetsDataView::kMenuActionDelete = "Delete Preset";
+const std::string PresetsDataView::kMenuActionShowInExplorer = "Show in Explorer";
 
 std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
@@ -161,6 +162,7 @@ std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGroupin
       action_group.emplace_back(kMenuActionLoad);
     }
     action_group.emplace_back(kMenuActionDelete);
+    action_group.emplace_back(kMenuActionShowInExplorer);
   }
 
   std::vector<std::vector<std::string>> menu =
@@ -198,6 +200,13 @@ void PresetsDataView::OnContextMenu(const std::string& action, int menu_index,
       app_->SendErrorToUi("Error deleting preset",
                           absl::StrFormat("Could not delete preset \"%s\".", filename));
     }
+
+  } else if (action == kMenuActionShowInExplorer) {
+    if (item_indices.size() != 1) {
+      return;
+    }
+    const PresetFile& preset = GetPreset(item_indices[0]);
+    app_->ShowPresetInExplorer(preset);
 
   } else {
     DataView::OnContextMenu(action, menu_index, item_indices);

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -208,19 +208,20 @@ TEST_F(PresetsDataViewTest, CheckPresenceOfContextMenuEntries) {
 
   // Loadable preset
   EXPECT_THAT(FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0})),
-              testing::UnorderedElementsAre("Copy Selection", "Export to CSV", "Load Preset",
-                                            "Delete Preset"))
+              testing::ElementsAre("Load Preset", "Delete Preset", "Show in Explorer",
+                                   "Copy Selection", "Export to CSV"))
       << view_.GetValue(0, 1);
 
   // Not loadable preset
-  EXPECT_THAT(FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(1, {1})),
-              testing::UnorderedElementsAre("Copy Selection", "Export to CSV", "Delete Preset"))
+  EXPECT_THAT(
+      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(1, {1})),
+      testing::ElementsAre("Delete Preset", "Show in Explorer", "Copy Selection", "Export to CSV"))
       << view_.GetValue(1, 1);
 
   // Partially loadable preset
   EXPECT_THAT(FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(2, {2})),
-              testing::UnorderedElementsAre("Copy Selection", "Export to CSV", "Load Preset",
-                                            "Delete Preset"))
+              testing::ElementsAre("Load Preset", "Delete Preset", "Show in Explorer",
+                                   "Copy Selection", "Export to CSV"))
       << view_.GetValue(2, 1);
 }
 
@@ -276,6 +277,21 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
           EXPECT_EQ(preset_file.file_path(), preset_filename0);
         });
     view_.OnContextMenu("Load Preset", static_cast<int>(load_preset_idx), {0});
+  }
+
+  // Show In Explorer
+  {
+    const auto show_in_explorer_idx =
+        std::find(context_menu.begin(), context_menu.end(), "Show in Explorer") -
+        context_menu.begin();
+    ASSERT_LT(show_in_explorer_idx, context_menu.size());
+
+    EXPECT_CALL(app_, ShowPresetInExplorer)
+        .Times(1)
+        .WillOnce([&](const orbit_preset_file::PresetFile& preset_file) {
+          EXPECT_EQ(preset_file.file_path(), preset_filename0);
+        });
+    view_.OnContextMenu("Show in Explorer", static_cast<int>(show_in_explorer_idx), {0});
   }
 
   // Delete Preset

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -36,6 +36,7 @@ class AppInterface {
   virtual void LoadPreset(const orbit_preset_file::PresetFile& preset) = 0;
   [[nodiscard]] virtual PresetLoadState GetPresetLoadState(
       const orbit_preset_file::PresetFile& preset) const = 0;
+  virtual void ShowPresetInExplorer(const orbit_preset_file::PresetFile& preset) = 0;
 
   // Functions needed by FunctionsDataView
   [[nodiscard]] virtual bool IsFunctionSelected(

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -72,6 +72,7 @@ class PresetsDataView : public DataView {
 
   static const std::string kMenuActionLoad;
   static const std::string kMenuActionDelete;
+  static const std::string kMenuActionShowInExplorer;
 
  private:
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2060,8 +2060,8 @@ void OrbitApp::ShowPresetInExplorer(const PresetFile& preset) {
                                  "/org/freedesktop/FileManager1",
                                  "org.freedesktop.FileManager1.ShowItems",
                                  QString::fromStdString(absl::StrFormat(
-                                     "array:string:\"file:///%s\"", preset.file_path().string())),
-                                 "string:\"\""};
+                                     "array:string:file:////%s", preset.file_path().string())),
+                                 "string:"};
 #elif defined(_WIN32)
   const QString program{"explorer.exe"};
   const QStringList arguments = {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -15,6 +15,7 @@
 #include <absl/synchronization/mutex.h>
 #include <absl/time/time.h>
 #include <imgui.h>
+#include <stdlib.h>
 
 #include <chrono>
 #include <cinttypes>
@@ -2040,6 +2041,19 @@ void OrbitApp::LoadPreset(const PresetFile& preset_file) {
 
     FireRefreshCallbacks();
   });
+}
+
+void OrbitApp::ShowPresetInExplorer(const PresetFile& preset) {
+  const auto file_exists = orbit_base::FileExists(preset.file_path());
+  if (file_exists.has_error()) {
+    ERROR("Unable to find preset file: %s", file_exists.error().message());
+    return;
+  }
+
+  std::string command = absl::StrFormat("explorer.exe /select,\"%s\"", preset.file_path().string());
+  if (system(command.c_str()) == 0) return;
+
+  ERROR("Unable to show preset file in explorer by running: %s", command);
 }
 
 void OrbitApp::UpdateProcessAndModuleList() {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -349,6 +349,7 @@ class OrbitApp final : public DataViewFactory,
   void LoadPreset(const orbit_preset_file::PresetFile& preset) override;
   [[nodiscard]] orbit_data_views::PresetLoadState GetPresetLoadState(
       const orbit_preset_file::PresetFile& preset) const override;
+  void ShowPresetInExplorer(const orbit_preset_file::PresetFile& preset) override;
   void FilterTracks(const std::string& filter);
 
   void CrashOrbitService(orbit_grpc_protos::CrashOrbitServiceRequest_CrashType crash_type);


### PR DESCRIPTION
With this change, we enabled the presets tab to support showing the
selected file in explorer when user select the "Show in Explorer" action
in the right-click menu.

Test: run unit test
Bug: http://b/187411020