### PR TITLE
Add thread annotations to orbit_base::SharedState

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -88,9 +88,8 @@ class InternalFutureBase {
     CHECK(IsValid());
     absl::MutexLock lock{&this->shared_state_->mutex};
     this->shared_state_->mutex.Await(absl::Condition(
-        +[](const std::shared_ptr<SharedState<T>>* shared_state) {
-          return shared_state->get()->IsFinished();
-        },
+        +[](const std::shared_ptr<SharedState<T>>* shared_state) ABSL_EXCLUSIVE_LOCKS_REQUIRED(
+             shared_state->get()->mutex) { return shared_state->get()->IsFinished(); },
         &this->shared_state_));
   }
 


### PR DESCRIPTION
orbit_base::SharedState is heavily used in threaded contexts. To make
sure the synchronization is solid I added threading annotations.

So far no problem was found.