### PR TITLE
Fix e2e test by exposing user space instrumentation in capture options.

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1339,8 +1339,7 @@ void OrbitApp::StartCapture() {
   bool enable_api = data_manager_->get_enable_api();
   bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
   const DynamicInstrumentationMethod dynamic_instrumentation_method =
-      IsDevMode() ? data_manager_->dynamic_instrumentation_method()
-                  : CaptureOptions::kKernelUprobes;
+      data_manager_->dynamic_instrumentation_method();
   double samples_per_second = data_manager_->samples_per_second();
   uint16_t stack_dump_size = data_manager_->stack_dump_size();
   const UnwindingMethod unwinding_method =

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -44,7 +44,6 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
     ui_->unwindingMethodWidget->hide();
     ui_->schedulerCheckBox->hide();
     ui_->gpuSubmissionsCheckBox->hide();
-    ui_->dynamicInstrumentationMethodWidget->hide();
     ui_->introspectionCheckBox->hide();
   }
 


### PR DESCRIPTION
The dynamic instrumentation combo box was still behind the devmode switch.
Forward fix the test by exposing the feature.

Test: Local run of user space instrumentation test and also an old test.