### PR TITLE
Maximize main window for e2e tests

### DIFF
--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -130,3 +130,4 @@ class FilterAndSelectFirstProcess(E2ETestCase):
         wait_for_main_window(self.suite.application)
         window = self.suite.top_window(True)
         self.expect_eq(window.class_name(), "OrbitMainWindow", 'Main window is visible')
+        window.maximize()


### PR DESCRIPTION
Our recent change changes to restore the main window geometry from QSettings
rather than maximize the main window by default. But it would be better
if the main window is maximized when running E2E tests.

Bug: http://b/205806458