### PR TITLE
Add utils to parse connection target arguments

### DIFF
--- a/src/SessionSetup/SessionSetupUtils.cpp
+++ b/src/SessionSetup/SessionSetupUtils.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port) {
   return result;
 }
 
-std::optional<std::pair<QString, uint32_t>> SplitInstanceAndProcessIdFromConnectionTarget(
+std::optional<ConnectionTarget> orbit_session_setup::ConnectionTarget::FromString(
     const QString& connection_target) {
   auto parts = connection_target.split('@', QString::SplitBehavior::KeepEmptyParts);
 
@@ -43,7 +43,7 @@ std::optional<std::pair<QString, uint32_t>> SplitInstanceAndProcessIdFromConnect
     return std::nullopt;
   }
 
-  return std::pair<QString, uint32_t>{parts[1], pid};
+  return ConnectionTarget{parts[1], pid};
 }
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/SessionSetupUtils.cpp
+++ b/src/SessionSetup/SessionSetupUtils.cpp
@@ -4,6 +4,8 @@
 
 #include "SessionSetup/SessionSetupUtils.h"
 
+#include <QStringList>
+
 #include "OrbitBase/Logging.h"
 
 namespace orbit_session_setup {
@@ -25,6 +27,23 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port) {
       grpc_server_address, grpc::InsecureChannelCredentials(), grpc::ChannelArguments());
   CHECK(result != nullptr);
   return result;
+}
+
+std::optional<std::pair<QString, uint32_t>> SplitInstanceAndProcessIdFromConnectionTarget(
+    const QString& connection_target) {
+  auto parts = connection_target.split('@', QString::SplitBehavior::KeepEmptyParts);
+
+  if (parts.size() != 2) {
+    return std::nullopt;
+  }
+
+  bool ok = false;
+  uint pid = parts[0].toUInt(&ok);
+  if (!ok) {
+    return std::nullopt;
+  }
+
+  return std::pair<QString, uint32_t>{parts[1], pid};
 }
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/SessionSetupUtilsTest.cpp
+++ b/src/SessionSetup/SessionSetupUtilsTest.cpp
@@ -31,27 +31,25 @@ TEST(SessionSetupUtils, CredentialsFromSshInfoWorksCorrectly) {
   EXPECT_EQ(info.user.toStdString(), credentials.user);
 }
 
-TEST(SessionSetupUtils, SplitInstanceAndProcessId) {
+TEST(SessionSetupUtils, ConnectionTargetFromString) {
   const QString instance = "some/i-nstanc-3/id123";
   const uint32_t pid = 1234;
 
   // Correct format: "pid@instance_id", where PID is a uint32_t
   const QString target_string = QString("%1@%2").arg(QString::number(pid), instance);
-  auto result = SplitInstanceAndProcessIdFromConnectionTarget(target_string);
+  auto result = ConnectionTarget::FromString(target_string);
   EXPECT_TRUE(result.has_value());
   if (result.has_value()) {
-    EXPECT_EQ(result.value().first.toStdString(), instance.toStdString());
-    EXPECT_EQ(result.value().second, pid);
+    EXPECT_EQ(result.value().instance_id_.toStdString(), instance.toStdString());
+    EXPECT_EQ(result.value().process_id_, pid);
   }
 
   // Fail-tests for multiple incorrect formats
-  EXPECT_FALSE(SplitInstanceAndProcessIdFromConnectionTarget("no/id/found").has_value());
-  EXPECT_FALSE(
-      SplitInstanceAndProcessIdFromConnectionTarget("invalid_pid@valid/i-nstanc-3/id").has_value());
-  EXPECT_FALSE(SplitInstanceAndProcessIdFromConnectionTarget("").has_value());
+  EXPECT_FALSE(ConnectionTarget::FromString("no/id/found").has_value());
+  EXPECT_FALSE(ConnectionTarget::FromString("invalid_pid@valid/i-nstanc-3/id").has_value());
+  EXPECT_FALSE(ConnectionTarget::FromString("").has_value());
   // Double "@" results in failure as it's ambiguous
-  EXPECT_FALSE(
-      SplitInstanceAndProcessIdFromConnectionTarget("1234@invalid@i-nstanc-3/id").has_value());
+  EXPECT_FALSE(ConnectionTarget::FromString("1234@invalid@i-nstanc-3/id").has_value());
 }
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
@@ -8,6 +8,7 @@
 #include <grpcpp/create_channel.h>
 
 #include <memory>
+#include <optional>
 
 #include "OrbitGgp/SshInfo.h"
 #include "OrbitSsh/Credentials.h"
@@ -16,6 +17,10 @@ namespace orbit_session_setup {
 
 [[nodiscard]] orbit_ssh::Credentials CredentialsFromSshInfo(const orbit_ggp::SshInfo& ssh_info);
 [[nodiscard]] std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port);
+
+// Split a target given as "<pid>@<instance_id>" into its components
+[[nodiscard]] std::optional<std::pair<QString, uint32_t>>
+SplitInstanceAndProcessIdFromConnectionTarget(const QString& connection_target);
 
 }  // namespace orbit_session_setup
 

--- a/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
@@ -18,9 +18,13 @@ namespace orbit_session_setup {
 [[nodiscard]] orbit_ssh::Credentials CredentialsFromSshInfo(const orbit_ggp::SshInfo& ssh_info);
 [[nodiscard]] std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port);
 
-// Split a target given as "<pid>@<instance_id>" into its components
-[[nodiscard]] std::optional<std::pair<QString, uint32_t>>
-SplitInstanceAndProcessIdFromConnectionTarget(const QString& connection_target);
+struct ConnectionTarget {
+  QString instance_id_;
+  uint32_t process_id_;
+
+  // Split a target given as "<pid>@<instance_id>" into its components
+  [[nodiscard]] static std::optional<ConnectionTarget> FromString(const QString& connection_target);
+};
 
 }  // namespace orbit_session_setup
 


### PR DESCRIPTION
Bug: b/202262468
Utilities to split the connection target parameter (added in a later PR). The parameter will come in the form of <pid>@<instance_id>.
Test: Unit tests added with this PR.