### PR TITLE
Integrate connection target dialog

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -59,4 +59,5 @@ ABSL_FLAG(bool, enforce_full_redraw, false,
 ABSL_FLAG(std::string, connection_target, "",
           "Instance and process in the form <pid>@<instance_id>. Specify this to skip the "
           "connection setup and open the main window instead. If either the instance or the "
-          "process ID can't be found, Orbit will exit with return code -1 immediately.");
+          "process ID can't be found or deployment is aborted by the user Orbit will exit "
+          "with return code -1 immediately.");

--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -54,3 +54,9 @@ ABSL_FLAG(bool, enable_project_selection, false, "Enable project selection durin
 
 ABSL_FLAG(bool, enforce_full_redraw, false,
           "Enforce full redraw every frame (used for performance measurements)");
+
+// VSI
+ABSL_FLAG(std::string, connection_target, "",
+          "Instance and process in the form <pid>@<instance_id>. Specify this to skip the "
+          "connection setup and open the main window instead. If either the instance or the "
+          "process ID can't be found, Orbit will exit with return code -1 immediately.");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -55,4 +55,7 @@ ABSL_DECLARE_FLAG(bool, enable_project_selection);
 
 ABSL_DECLARE_FLAG(bool, enforce_full_redraw);
 
+// VSI
+ABSL_DECLARE_FLAG(std::string, connection_target);
+
 #endif  // CLIENT_FLAGS_CLIENT_FLAGS_H_

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -82,7 +82,8 @@ static std::optional<orbit_session_setup::TargetConfiguration> ConnectToSpecifie
   auto connection_target_result =
       orbit_session_setup::ConnectionTarget::FromString(connection_target_string);
   if (!connection_target_result.has_value()) {
-    LOG("Invalid connection target parameter was specified. Expected format: pid@instance_id, got "
+    ERROR(
+        "Invalid connection target parameter was specified. Expected format: pid@instance_id, got "
         "\"%s\"",
         connection_target_string.toStdString());
     return std::nullopt;

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -45,10 +45,12 @@
 #include "OrbitSsh/Context.h"
 #include "OrbitSshQt/ScopedConnection.h"
 #include "OrbitVersion/OrbitVersion.h"
+#include "SessionSetup/ConnectToTargetDialog.h"
 #include "SessionSetup/Connections.h"
 #include "SessionSetup/DeploymentConfigurations.h"
 #include "SessionSetup/ServiceDeployManager.h"
 #include "SessionSetup/SessionSetupDialog.h"
+#include "SessionSetup/SessionSetupUtils.h"
 #include "SessionSetup/TargetConfiguration.h"
 #include "SourcePathsMapping/MappingManager.h"
 #include "Style/Style.h"
@@ -73,10 +75,31 @@ using orbit_ssh::Context;
 
 Q_DECLARE_METATYPE(std::error_code);
 
-void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
-                   const Context* ssh_context, const QStringList& command_line_flags,
-                   const orbit_base::CrashHandler* crash_handler,
-                   const std::filesystem::path& capture_file_path) {
+static std::optional<orbit_session_setup::TargetConfiguration> ConnectToSpecifiedTarget(
+    orbit_session_setup::SshConnectionArtifacts& connection_artifacts,
+    const QString& connection_target_string,
+    orbit_metrics_uploader::MetricsUploader* metrics_uploader) {
+  auto connection_target_result =
+      orbit_session_setup::ConnectionTarget::FromString(connection_target_string);
+  if (!connection_target_result.has_value()) {
+    LOG("Invalid connection target parameter was specified. Expected format: pid@instance_id, got "
+        "\"%s\"",
+        connection_target_string.toStdString());
+    return std::nullopt;
+  }
+
+  auto connection_target = connection_target_result.value();
+  orbit_session_setup::ConnectToTargetDialog dialog(
+      &connection_artifacts, connection_target.instance_id_, connection_target.process_id_,
+      metrics_uploader);
+  return dialog.Exec();
+}
+
+int RunUiInstance(const DeploymentConfiguration& deployment_configuration,
+                  const Context* ssh_context, const QStringList& command_line_flags,
+                  const orbit_base::CrashHandler* crash_handler,
+                  const std::filesystem::path& capture_file_path,
+                  const QString& connection_target) {
   qRegisterMetaType<std::error_code>();
 
   const GrpcPort grpc_port{/*.grpc_port =*/absl::GetFlag(FLAGS_grpc_port)};
@@ -96,14 +119,23 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
 
   // If Orbit starts with loading a capture file, we skip SessionSetupDialog and create a
   // FileTarget from capture_file_path. After creating the FileTarget, we reset
-  // skip_profiling_target_dialog as false such that if a user ends the previous session, Orbit
+  // has_file_parameter as false such that if a user ends the previous session, Orbit
   // will return to a SessionSetupDialog.
-  bool skip_profiling_target_dialog = !capture_file_path.empty();
+  bool has_file_parameter = !capture_file_path.empty();
+  bool has_connection_target = !connection_target.isEmpty();
+
   while (true) {
     {
-      if (skip_profiling_target_dialog) {
+      if (has_connection_target) {
+        target_config = ConnectToSpecifiedTarget(ssh_connection_artifacts, connection_target,
+                                                 metrics_uploader.get());
+        if (!target_config.has_value()) {
+          // User closed dialog, or an error occured.
+          return -1;
+        }
+      } else if (has_file_parameter) {
         target_config = orbit_session_setup::FileTarget(capture_file_path);
-        skip_profiling_target_dialog = false;
+        has_file_parameter = false;
       } else {
         orbit_session_setup::SessionSetupDialog target_dialog{
             &ssh_connection_artifacts, std::move(target_config), metrics_uploader.get()};
@@ -130,7 +162,8 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
       target_config = w.ClearTargetConfiguration();
     }
 
-    if (application_return_code == OrbitMainWindow::kQuitOrbitReturnCode) {
+    // If a connection target was specified, ending the session will also end Orbit
+    if (has_connection_target || application_return_code == OrbitMainWindow::kQuitOrbitReturnCode) {
       // User closed window
       break;
     }
@@ -142,6 +175,8 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
 
     UNREACHABLE();
   }
+
+  return 0;
 }
 
 static void DisplayErrorToUser(const QString& message) {
@@ -311,6 +346,17 @@ int main(int argc, char* argv[]) {
     return -1;
   }
 
+  const std::string& connection_target = absl::GetFlag(FLAGS_connection_target);
+
+  if (capture_file_paths.size() > 0 && !connection_target.empty()) {
+    LOG("Aborting startup: User specified a connection target and one or multiple capture files at "
+        "the same time.");
+    DisplayErrorToUser(
+        QString("Invalid combination of startup flags: Specify either one or multiple capture "
+                "files to open or a connection target (--connection_target), but not both."));
+    return -1;
+  }
+
   // If more than one capture files are provided, start multiple Orbit instances.
   for (size_t i = 1; i < capture_file_paths.size(); ++i) {
     QStringList arguments;
@@ -321,7 +367,7 @@ int main(int argc, char* argv[]) {
   command_line_flags =
       orbit_command_line_utils::RemoveFlagsNotPassedToMainWindow(command_line_flags);
 
-  RunUiInstance(deployment_configuration, &context.value(), command_line_flags, crash_handler.get(),
-                capture_file_paths.empty() ? "" : capture_file_paths[0]);
-  return 0;
+  return RunUiInstance(deployment_configuration, &context.value(), command_line_flags,
+                       crash_handler.get(), capture_file_paths.empty() ? "" : capture_file_paths[0],
+                       QString::fromStdString(connection_target));
 }

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -127,7 +127,7 @@ ConnectToTargetDialog::DeployOrbitService(
 
   auto deployment_result = service_deploy_manager->Exec();
   if (deployment_result.has_error()) {
-    return ErrorMessage{"Error during service deployment"};
+    return ErrorMessage{deployment_result.error().message()};
   } else {
     return deployment_result.value();
   }


### PR DESCRIPTION
This PR finally integrated the "ConnectToTarget" dialog into Orbit, and adds a command line parameter to specify both the instance- and process-ID in the format "<pid>@<process>".

Bug: b/202262468
Test: Manual testing - specify a valid connection target, Orbit shows the ConnectToTarget dialog and starts a session. When the parameter is malformed, the instance cannot be found, or the process does not exist, an error is shown and Orbit closes.

Additional behavior to observe:
- When clicking "End Session" on an Instance started with a connection target, Orbit will close
- When opening a capture file, the "connection_target" flag is not passed to the new Orbit instance.

https://screenshot.googleplex.com/3jRQUvx5KitdTns