### PR TITLE
Create LockFreeUserSpaceInstrumentationEventProducer in StartNewCapture

### DIFF
--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -91,7 +91,17 @@ LockFreeUserSpaceInstrumentationEventProducer& GetCaptureEventProducer() {
 
 }  // namespace
 
-void StartNewCapture() { current_capture_start_timestamp_ns = CaptureTimestampNs(); }
+void StartNewCapture() {
+  current_capture_start_timestamp_ns = CaptureTimestampNs();
+
+  // If the library has just been injected, initialize the
+  // LockFreeUserSpaceInstrumentationEventProducer and establish the connection to OrbitService now
+  // instead of waiting for the first call to EntryPayload. As it takes a bit to
+  // establish the connection, GetCaptureEventProducer().IsCapturing() would otherwise always be
+  // false in the first call to EntryPayload, which would cause the first function call to be missed
+  // even if the time between StartNewCapture() and the first function call is large.
+  GetCaptureEventProducer();
+}
 
 void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer) {
   const uint64_t timestamp_on_entry_ns = CaptureTimestampNs();

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/Attach.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/Attach.h
@@ -17,9 +17,10 @@ namespace orbit_user_space_instrumentation {
 // Returns the set of thread ids of the threads that were stopped.
 [[nodiscard]] ErrorMessageOr<absl::flat_hash_set<pid_t>> AttachAndStopProcess(pid_t pid);
 
-// Attaches to and stop all threads of the process `pid` that are not already in
-// `already_halted_tids`. It is used to stop threads that spawned while already attached to a
-// process. Returns the set of thread ids of the threads that were stopped.
+// Attaches to and stops all threads of the process `pid` that are not already in
+// `already_halted_tids`. It can be used to stop threads that spawned while already attached to a
+// process.
+// Returns the new set of thread ids of all halted threads (old and new).
 [[nodiscard]] ErrorMessageOr<absl::flat_hash_set<pid_t>> AttachAndStopNewThreadsOfProcess(
     pid_t pid, absl::flat_hash_set<pid_t> already_halted_tids);
 

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/Attach.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/Attach.h
@@ -5,6 +5,7 @@
 #ifndef USER_SPACE_INSTRUMENTATION_ATTACH_H_
 #define USER_SPACE_INSTRUMENTATION_ATTACH_H_
 
+#include <absl/container/flat_hash_set.h>
 #include <sys/types.h>
 
 #include "OrbitBase/Result.h"
@@ -13,7 +14,14 @@ namespace orbit_user_space_instrumentation {
 
 // Attaches to and stops all threads of the process `pid` using `PTRACE_ATTACH`. Being attached to a
 // process using this function is a precondition for using any of the tooling provided here.
-[[nodiscard]] ErrorMessageOr<void> AttachAndStopProcess(pid_t pid);
+// Returns the set of thread ids of the threads that were stopped.
+[[nodiscard]] ErrorMessageOr<absl::flat_hash_set<pid_t>> AttachAndStopProcess(pid_t pid);
+
+// Attaches to and stop all threads of the process `pid` that are not already in
+// `already_halted_tids`. It is used to stop threads that spawned while already attached to a
+// process. Returns the set of thread ids of the threads that were stopped.
+[[nodiscard]] ErrorMessageOr<absl::flat_hash_set<pid_t>> AttachAndStopNewThreadsOfProcess(
+    pid_t pid, absl::flat_hash_set<pid_t> already_halted_tids);
 
 // Detaches from all threads of the process `pid` and continues the execution.
 [[nodiscard]] ErrorMessageOr<void> DetachAndContinueProcess(pid_t pid);


### PR DESCRIPTION
While it's normal that data at the beginning or end of a capture cannot be
perfectly accurate, user space instrumentation missed the first function call to
an instrumented function even when this happens long after the library has been
injected and the capture has started.
This is because the connection to OrbitService was opened on the first entry
trampoline, at which point it is not yet ready to send data.
We solve this by establishing the connection on the start of the first capture.
Some care needs to be taken because this happens while all threads of the target
process are stopped, but gRPC spawns new threads, which now need to also be
stopped.

Bug: http://b/205939288

Test: User space instrumentation's unit tests. Run upcoming
`OrbitServiceIntegrationTests`, during whose setup this was discovered. Capture
Trata when instrumenting with user space instrumentation.