### PR TITLE
Reporting of status info from user space instrumentation.

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -73,9 +73,10 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnErrorEnablingUserSpaceInstrumentationEvent,
               (orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/),
               (override));
-  MOCK_METHOD(void, OnWarningInstrumentingWithUserSpaceInstrumentationEvent,
-              (orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent /*warning_event*/),
-              (override));
+  MOCK_METHOD(
+      void, OnWarningInstrumentingWithUserSpaceInstrumentationEvent,
+      (orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent /*warning_event*/),
+      (override));
   MOCK_METHOD(void, OnLostPerfRecordsEvent,
               (orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/), (override));
   MOCK_METHOD(

--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -73,8 +73,8 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnErrorEnablingUserSpaceInstrumentationEvent,
               (orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/),
               (override));
-  MOCK_METHOD(void, OnInfoEnablingUserSpaceInstrumentationEvent,
-              (orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent /*info_event*/),
+  MOCK_METHOD(void, OnWarningInstrumentingWithUserSpaceInstrumentationEvent,
+              (orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent /*warning_event*/),
               (override));
   MOCK_METHOD(void, OnLostPerfRecordsEvent,
               (orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/), (override));

--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -73,6 +73,9 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnErrorEnablingUserSpaceInstrumentationEvent,
               (orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/),
               (override));
+  MOCK_METHOD(void, OnInfoEnablingUserSpaceInstrumentationEvent,
+              (orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent /*info_event*/),
+              (override));
   MOCK_METHOD(void, OnLostPerfRecordsEvent,
               (orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/), (override));
   MOCK_METHOD(

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -81,6 +81,8 @@ class CaptureEventProcessorForListener : public CaptureEventProcessor {
       const orbit_grpc_protos::ErrorEnablingOrbitApiEvent& error_enabling_orbit_api_event);
   void ProcessErrorEnablingUserSpaceInstrumentationEvent(
       const orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent& error_event);
+  void ProcessInfoEnablingUserSpaceInstrumentationEvent(
+      const orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent& info_event);
   void ProcessLostPerfRecordsEvent(
       const orbit_grpc_protos::LostPerfRecordsEvent& lost_perf_records_event);
   void ProcessOutOfOrderEventsDiscardedEvent(
@@ -220,6 +222,10 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
     case ClientCaptureEvent::kErrorEnablingUserSpaceInstrumentationEvent:
       ProcessErrorEnablingUserSpaceInstrumentationEvent(
           event.error_enabling_user_space_instrumentation_event());
+      break;
+    case ClientCaptureEvent::kInfoEnablingUserSpaceInstrumentationEvent:
+      ProcessInfoEnablingUserSpaceInstrumentationEvent(
+          event.info_enabling_user_space_instrumentation_event());
       break;
     case ClientCaptureEvent::kLostPerfRecordsEvent:
       ProcessLostPerfRecordsEvent(event.lost_perf_records_event());
@@ -688,6 +694,11 @@ void CaptureEventProcessorForListener::ProcessErrorEnablingOrbitApiEvent(
 void CaptureEventProcessorForListener::ProcessErrorEnablingUserSpaceInstrumentationEvent(
     const orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent& error_event) {
   capture_listener_->OnErrorEnablingUserSpaceInstrumentationEvent(error_event);
+}
+
+void CaptureEventProcessorForListener::ProcessInfoEnablingUserSpaceInstrumentationEvent(
+    const orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent& info_event) {
+  capture_listener_->OnInfoEnablingUserSpaceInstrumentationEvent(info_event);
 }
 
 void CaptureEventProcessorForListener::ProcessLostPerfRecordsEvent(

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -81,8 +81,9 @@ class CaptureEventProcessorForListener : public CaptureEventProcessor {
       const orbit_grpc_protos::ErrorEnablingOrbitApiEvent& error_enabling_orbit_api_event);
   void ProcessErrorEnablingUserSpaceInstrumentationEvent(
       const orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent& error_event);
-  void ProcessInfoEnablingUserSpaceInstrumentationEvent(
-      const orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent& info_event);
+  void ProcessWarningInstrumentingWithUserSpaceInstrumentationEvent(
+      const orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent&
+          warning_event);
   void ProcessLostPerfRecordsEvent(
       const orbit_grpc_protos::LostPerfRecordsEvent& lost_perf_records_event);
   void ProcessOutOfOrderEventsDiscardedEvent(
@@ -223,9 +224,9 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
       ProcessErrorEnablingUserSpaceInstrumentationEvent(
           event.error_enabling_user_space_instrumentation_event());
       break;
-    case ClientCaptureEvent::kInfoEnablingUserSpaceInstrumentationEvent:
-      ProcessInfoEnablingUserSpaceInstrumentationEvent(
-          event.info_enabling_user_space_instrumentation_event());
+    case ClientCaptureEvent::kWarningInstrumentingWithUserSpaceInstrumentationEvent:
+      ProcessWarningInstrumentingWithUserSpaceInstrumentationEvent(
+          event.warning_instrumenting_with_user_space_instrumentation_event());
       break;
     case ClientCaptureEvent::kLostPerfRecordsEvent:
       ProcessLostPerfRecordsEvent(event.lost_perf_records_event());
@@ -696,9 +697,9 @@ void CaptureEventProcessorForListener::ProcessErrorEnablingUserSpaceInstrumentat
   capture_listener_->OnErrorEnablingUserSpaceInstrumentationEvent(error_event);
 }
 
-void CaptureEventProcessorForListener::ProcessInfoEnablingUserSpaceInstrumentationEvent(
-    const orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent& info_event) {
-  capture_listener_->OnInfoEnablingUserSpaceInstrumentationEvent(info_event);
+void CaptureEventProcessorForListener::ProcessWarningInstrumentingWithUserSpaceInstrumentationEvent(
+    const orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent& warning_event) {
+  capture_listener_->OnWarningInstrumentingWithUserSpaceInstrumentationEvent(warning_event);
 }
 
 void CaptureEventProcessorForListener::ProcessLostPerfRecordsEvent(

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -64,8 +64,8 @@ class MyCaptureListener : public CaptureListener {
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {}
   void OnErrorEnablingUserSpaceInstrumentationEvent(
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/) override {}
-  void OnInfoEnablingUserSpaceInstrumentationEvent(
-      orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent /*info_event*/) override {}
+  void OnWarningInstrumentingWithUserSpaceInstrumentationEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent /*warning_event*/) override {}
   void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/) override {}
   void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -65,7 +65,8 @@ class MyCaptureListener : public CaptureListener {
   void OnErrorEnablingUserSpaceInstrumentationEvent(
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/) override {}
   void OnWarningInstrumentingWithUserSpaceInstrumentationEvent(
-      orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent /*warning_event*/) override {}
+      orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent /*warning_event*/)
+      override {}
   void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/) override {}
   void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -64,6 +64,8 @@ class MyCaptureListener : public CaptureListener {
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {}
   void OnErrorEnablingUserSpaceInstrumentationEvent(
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/) override {}
+  void OnInfoEnablingUserSpaceInstrumentationEvent(
+      orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent /*info_event*/) override {}
   void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/) override {}
   void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -1340,8 +1340,12 @@ TEST(CaptureEventProcessor, CanHandleInfoEnablingUserSpaceInstrumentationEvents)
       event.mutable_info_enabling_user_space_instrumentation_event();
   constexpr uint64_t kTimestampNs = 100;
   info_event->set_timestamp_ns(kTimestampNs);
-  constexpr const char* kMessage = "message";
-  info_event->set_message(kMessage);
+  constexpr uint64_t kFunctionId = 42;
+  constexpr const char* kErrorMessage = "error message";
+  orbit_grpc_protos::FunctionThatFailedToBeInstrumented* function =
+      info_event->add_functions_that_failed_to_instrument();
+  function->set_function_id(kFunctionId);
+  function->set_error_message(kErrorMessage);
 
   InfoEnablingUserSpaceInstrumentationEvent actual_info_event;
   EXPECT_CALL(listener, OnInfoEnablingUserSpaceInstrumentationEvent)
@@ -1351,7 +1355,9 @@ TEST(CaptureEventProcessor, CanHandleInfoEnablingUserSpaceInstrumentationEvents)
   event_processor->ProcessEvent(event);
 
   EXPECT_EQ(actual_info_event.timestamp_ns(), kTimestampNs);
-  EXPECT_EQ(actual_info_event.message(), kMessage);
+  EXPECT_EQ(actual_info_event.functions_that_failed_to_instrument(0).function_id(), kFunctionId);
+  EXPECT_EQ(actual_info_event.functions_that_failed_to_instrument(0).error_message(),
+            kErrorMessage);
 }
 
 TEST(CaptureEventProcessor, CanHandleLostPerfRecordsEvents) {

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -52,6 +52,8 @@ class CaptureListener {
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) = 0;
   virtual void OnErrorEnablingUserSpaceInstrumentationEvent(
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent error_event) = 0;
+  virtual void OnInfoEnablingUserSpaceInstrumentationEvent(
+      orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent info_event) = 0;
   virtual void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) = 0;
   virtual void OnOutOfOrderEventsDiscardedEvent(

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -52,8 +52,8 @@ class CaptureListener {
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) = 0;
   virtual void OnErrorEnablingUserSpaceInstrumentationEvent(
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent error_event) = 0;
-  virtual void OnInfoEnablingUserSpaceInstrumentationEvent(
-      orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent info_event) = 0;
+  virtual void OnWarningInstrumentingWithUserSpaceInstrumentationEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent warning_event) = 0;
   virtual void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) = 0;
   virtual void OnOutOfOrderEventsDiscardedEvent(

--- a/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
@@ -121,6 +121,17 @@ ProducerCaptureEvent CreateErrorEnablingUserSpaceInstrumentationEvent(uint64_t t
   return event;
 }
 
+ProducerCaptureEvent CreateInfoEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns,
+                                                                     std::string message) {
+  ProducerCaptureEvent event;
+  orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent*
+      info_enabling_user_space_instrumentation_event =
+          event.mutable_info_enabling_user_space_instrumentation_event();
+  info_enabling_user_space_instrumentation_event->set_timestamp_ns(timestamp_ns);
+  info_enabling_user_space_instrumentation_event->set_message(std::move(message));
+  return event;
+}
+
 ProducerCaptureEvent CreateWarningEvent(uint64_t timestamp_ns, std::string message) {
   ProducerCaptureEvent event;
   orbit_grpc_protos::WarningEvent* warning_event = event.mutable_warning_event();

--- a/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
@@ -121,15 +121,15 @@ ProducerCaptureEvent CreateErrorEnablingUserSpaceInstrumentationEvent(uint64_t t
   return event;
 }
 
-ProducerCaptureEvent CreateInfoEnablingUserSpaceInstrumentationEvent(
+ProducerCaptureEvent CreateWarningInstrumentingWithUserSpaceInstrumentationEvent(
     uint64_t timestamp_ns,
     const absl::flat_hash_map<uint64_t, std::string>& function_ids_to_error_messages) {
   ProducerCaptureEvent event;
-  orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent* info_event =
-      event.mutable_info_enabling_user_space_instrumentation_event();
-  info_event->set_timestamp_ns(timestamp_ns);
+  orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent* warning_event =
+      event.mutable_warning_instrumenting_with_user_space_instrumentation_event();
+  warning_event->set_timestamp_ns(timestamp_ns);
   for (auto const& [id, error_message] : function_ids_to_error_messages) {
-    auto function = info_event->add_functions_that_failed_to_instrument();
+    auto function = warning_event->add_functions_that_failed_to_instrument();
     function->set_function_id(id);
     function->set_error_message(error_message);
   }

--- a/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
@@ -121,14 +121,18 @@ ProducerCaptureEvent CreateErrorEnablingUserSpaceInstrumentationEvent(uint64_t t
   return event;
 }
 
-ProducerCaptureEvent CreateInfoEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns,
-                                                                     std::string message) {
+ProducerCaptureEvent CreateInfoEnablingUserSpaceInstrumentationEvent(
+    uint64_t timestamp_ns,
+    const absl::flat_hash_map<uint64_t, std::string>& function_ids_to_error_messages) {
   ProducerCaptureEvent event;
-  orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent*
-      info_enabling_user_space_instrumentation_event =
-          event.mutable_info_enabling_user_space_instrumentation_event();
-  info_enabling_user_space_instrumentation_event->set_timestamp_ns(timestamp_ns);
-  info_enabling_user_space_instrumentation_event->set_message(std::move(message));
+  orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent* info_event =
+      event.mutable_info_enabling_user_space_instrumentation_event();
+  info_event->set_timestamp_ns(timestamp_ns);
+  for (auto const& [id, error_message] : function_ids_to_error_messages) {
+    auto function = info_event->add_functions_that_failed_to_instrument();
+    function->set_function_id(id);
+    function->set_error_message(error_message);
+  }
   return event;
 }
 

--- a/src/CaptureService/include/CaptureService/CommonProducerCaptureEventBuilders.h
+++ b/src/CaptureService/include/CaptureService/CommonProducerCaptureEventBuilders.h
@@ -31,7 +31,7 @@ namespace orbit_capture_service {
 CreateErrorEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns, std::string message);
 
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
-CreateInfoEnablingUserSpaceInstrumentationEvent(
+CreateWarningInstrumentingWithUserSpaceInstrumentationEvent(
     uint64_t timestamp_ns,
     const absl::flat_hash_map<uint64_t, std::string>& function_ids_to_error_messages);
 

--- a/src/CaptureService/include/CaptureService/CommonProducerCaptureEventBuilders.h
+++ b/src/CaptureService/include/CaptureService/CommonProducerCaptureEventBuilders.h
@@ -5,6 +5,7 @@
 #ifndef CAPTURE_SERVICE_COMMON_PRODUCER_CAPTURE_EVENT_BUILDERS_H_
 #define CAPTURE_SERVICE_COMMON_PRODUCER_CAPTURE_EVENT_BUILDERS_H_
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/time/time.h>
 #include <stdint.h>
 
@@ -30,7 +31,9 @@ namespace orbit_capture_service {
 CreateErrorEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns, std::string message);
 
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
-CreateInfoEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns, std::string message);
+CreateInfoEnablingUserSpaceInstrumentationEvent(
+    uint64_t timestamp_ns,
+    const absl::flat_hash_map<uint64_t, std::string>& function_ids_to_error_messages);
 
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateWarningEvent(uint64_t timestamp_ns,
                                                                          std::string message);

--- a/src/CaptureService/include/CaptureService/CommonProducerCaptureEventBuilders.h
+++ b/src/CaptureService/include/CaptureService/CommonProducerCaptureEventBuilders.h
@@ -29,6 +29,9 @@ namespace orbit_capture_service {
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
 CreateErrorEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns, std::string message);
 
+[[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
+CreateInfoEnablingUserSpaceInstrumentationEvent(uint64_t timestamp_ns, std::string message);
+
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateWarningEvent(uint64_t timestamp_ns,
                                                                          std::string message);
 

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -683,7 +683,7 @@ message FunctionThatFailedToBeInstrumented {
   bytes error_message = 2;
 }
 
-message InfoEnablingUserSpaceInstrumentationEvent {
+message WarningInstrumentingWithUserSpaceInstrumentationEvent {
   uint64 timestamp_ns = 1;
   repeated FunctionThatFailedToBeInstrumented
       functions_that_failed_to_instrument = 2;
@@ -750,8 +750,8 @@ message ClientCaptureEvent {
     FunctionCall function_call = 2;
     GpuJob gpu_job = 3;
     GpuQueueSubmission gpu_queue_submission = 4;
-    InfoEnablingUserSpaceInstrumentationEvent
-        info_enabling_user_space_instrumentation_event = 48;
+    WarningInstrumentingWithUserSpaceInstrumentationEvent
+        warning_instrumenting_with_user_space_instrumentation_event = 48;
     InternedCallstack interned_callstack = 5;
     InternedString interned_string = 18;
     InternedTracepointInfo interned_tracepoint_info = 19;
@@ -813,8 +813,8 @@ message ProducerCaptureEvent {
     FunctionEntry function_entry = 13;
     FunctionExit function_exit = 14;
     GpuQueueSubmission gpu_queue_submission = 6;
-    InfoEnablingUserSpaceInstrumentationEvent
-        info_enabling_user_space_instrumentation_event = 47;
+    WarningInstrumentingWithUserSpaceInstrumentationEvent
+        warning_instrumenting_with_user_space_instrumentation_event = 47;
     InternedCallstack interned_callstack = 7;
     InternedString interned_string = 18;
     LostPerfRecordsEvent lost_perf_records_event = 34;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -750,8 +750,6 @@ message ClientCaptureEvent {
     FunctionCall function_call = 2;
     GpuJob gpu_job = 3;
     GpuQueueSubmission gpu_queue_submission = 4;
-    WarningInstrumentingWithUserSpaceInstrumentationEvent
-        warning_instrumenting_with_user_space_instrumentation_event = 48;
     InternedCallstack interned_callstack = 5;
     InternedString interned_string = 18;
     InternedTracepointInfo interned_tracepoint_info = 19;
@@ -766,6 +764,8 @@ message ClientCaptureEvent {
     ThreadStateSlice thread_state_slice = 7;
     TracepointEvent tracepoint_event = 8;
     WarningEvent warning_event = 32;
+    WarningInstrumentingWithUserSpaceInstrumentationEvent
+        warning_instrumenting_with_user_space_instrumentation_event = 48;
   }
 }
 
@@ -813,8 +813,6 @@ message ProducerCaptureEvent {
     FunctionEntry function_entry = 13;
     FunctionExit function_exit = 14;
     GpuQueueSubmission gpu_queue_submission = 6;
-    WarningInstrumentingWithUserSpaceInstrumentationEvent
-        warning_instrumenting_with_user_space_instrumentation_event = 47;
     InternedCallstack interned_callstack = 7;
     InternedString interned_string = 18;
     LostPerfRecordsEvent lost_perf_records_event = 34;
@@ -827,5 +825,7 @@ message ProducerCaptureEvent {
     ThreadNamesSnapshot thread_names_snapshot = 24;
     ThreadStateSlice thread_state_slice = 9;
     WarningEvent warning_event = 30;
+    WarningInstrumentingWithUserSpaceInstrumentationEvent
+        warning_instrumenting_with_user_space_instrumentation_event = 47;
   }
 }

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -677,6 +677,12 @@ message ErrorEnablingUserSpaceInstrumentationEvent {
   bytes message = 2;
 }
 
+message InfoEnablingUserSpaceInstrumentationEvent {
+  uint64 timestamp_ns = 1;
+  // This is a string, we use bytes to avoid UTF-8 validation.
+  bytes message = 2;
+}
+
 message ClockResolutionEvent {
   uint64 timestamp_ns = 1;
   uint64 clock_resolution_ns = 2;
@@ -708,7 +714,7 @@ message ClientCaptureEvent {
     // numbers starting with 16.
     //
     // Next high-frequency ID: 12
-    // Next lower-frequency ID: 48
+    // Next lower-frequency ID: 49
     // Please keep these alphabetically ordered.
 
     // Even though AddressInfo is a high-frequency event
@@ -738,6 +744,8 @@ message ClientCaptureEvent {
     FunctionCall function_call = 2;
     GpuJob gpu_job = 3;
     GpuQueueSubmission gpu_queue_submission = 4;
+    InfoEnablingUserSpaceInstrumentationEvent
+        info_enabling_user_space_instrumentation_event = 48;
     InternedCallstack interned_callstack = 5;
     InternedString interned_string = 18;
     InternedTracepointInfo interned_tracepoint_info = 19;
@@ -764,7 +772,7 @@ message ProducerCaptureEvent {
     // numbers starting with 16.
     //
     // Next high-frequency ID: 15
-    // Next lower-frequency ID: 47
+    // Next lower-frequency ID: 48
     //
     // Please keep these alphabetically ordered.
     ApiEvent api_event = 10;
@@ -799,6 +807,8 @@ message ProducerCaptureEvent {
     FunctionEntry function_entry = 13;
     FunctionExit function_exit = 14;
     GpuQueueSubmission gpu_queue_submission = 6;
+    InfoEnablingUserSpaceInstrumentationEvent
+        info_enabling_user_space_instrumentation_event = 47;
     InternedCallstack interned_callstack = 7;
     InternedString interned_string = 18;
     LostPerfRecordsEvent lost_perf_records_event = 34;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -685,7 +685,8 @@ message FunctionThatFailedToBeInstrumented {
 
 message InfoEnablingUserSpaceInstrumentationEvent {
   uint64 timestamp_ns = 1;
-  repeated FunctionThatFailedToBeInstrumented functions_that_failed_to_instrument = 2;
+  repeated FunctionThatFailedToBeInstrumented
+      functions_that_failed_to_instrument = 2;
 }
 
 message ClockResolutionEvent {

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -677,10 +677,15 @@ message ErrorEnablingUserSpaceInstrumentationEvent {
   bytes message = 2;
 }
 
+message FunctionThatFailedToBeInstrumented {
+  uint64 function_id = 1;
+  // This is a string, we use bytes to avoid UTF-8 validation.
+  bytes error_message = 2;
+}
+
 message InfoEnablingUserSpaceInstrumentationEvent {
   uint64 timestamp_ns = 1;
-  // This is a string, we use bytes to avoid UTF-8 validation.
-  bytes message = 2;
+  repeated FunctionThatFailedToBeInstrumented functions_that_failed_to_instrument = 2;
 }
 
 message ClockResolutionEvent {

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -202,9 +202,12 @@ grpc::Status LinuxCaptureService::Capture(
       FilterOutInstrumentedFunctionsFromCaptureOptions(
           result_or_error.value().instrumented_function_ids, linux_tracing_capture_options);
 
-      info_from_enabling_user_space_instrumentation =
-          orbit_capture_service::CreateInfoEnablingUserSpaceInstrumentationEvent(
-              capture_start_timestamp_ns_, result_or_error.value().function_ids_to_error_messages);
+      if (result_or_error.value().function_ids_to_error_messages.size()) {
+        info_from_enabling_user_space_instrumentation =
+            orbit_capture_service::CreateWarningInstrumentingWithUserSpaceInstrumentationEvent(
+                capture_start_timestamp_ns_,
+                result_or_error.value().function_ids_to_error_messages);
+      }
 
       user_space_instrumentation_addresses =
           std::make_unique<UserSpaceInstrumentationAddressesImpl>(

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -206,7 +206,7 @@ grpc::Status LinuxCaptureService::Capture(
           result_or_error.value().instrumented_function_ids.size(),
           capture_options.instrumented_functions_size());
 
-      if (result_or_error.value().function_ids_to_error_messages.size()) {
+      if (!result_or_error.value().function_ids_to_error_messages.empty()) {
         info_from_enabling_user_space_instrumentation =
             orbit_capture_service::CreateWarningInstrumentingWithUserSpaceInstrumentationEvent(
                 capture_start_timestamp_ns_,

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -5,6 +5,7 @@
 #include "LinuxCaptureService/LinuxCaptureService.h"
 
 #include <absl/container/flat_hash_set.h>
+#include <absl/strings/str_cat.h>
 #include <absl/synchronization/mutex.h>
 #include <absl/time/time.h>
 #include <stdint.h>
@@ -186,6 +187,7 @@ grpc::Status LinuxCaptureService::Capture(
 
   // Enable user space instrumentation.
   std::optional<std::string> error_enabling_user_space_instrumentation;
+  std::optional<std::string> info_from_enabling_user_space_instrumentation;
   std::unique_ptr<UserSpaceInstrumentationAddressesImpl> user_space_instrumentation_addresses;
   if (capture_options.dynamic_instrumentation_method() ==
           CaptureOptions::kUserSpaceInstrumentation &&
@@ -198,9 +200,28 @@ grpc::Status LinuxCaptureService::Capture(
     } else {
       FilterOutInstrumentedFunctionsFromCaptureOptions(
           result_or_error.value().instrumented_function_ids, linux_tracing_capture_options);
-      LOG("User space instrumentation enabled for %u out of %u instrumented functions.",
+
+      const std::string status_message = absl::StrFormat(
+          "User space instrumentation enabled for %u out of %u instrumented functions.",
           result_or_error.value().instrumented_function_ids.size(),
           capture_options.instrumented_functions_size());
+      LOG("%s", status_message);
+
+      // If at least one function was not instrumented we send a message to the capture log.
+      if (result_or_error.value().function_ids_to_error_messages.size()) {
+        info_from_enabling_user_space_instrumentation = "Failed to instrument some functions:\n";
+        for (auto const& [id, message] : result_or_error.value().function_ids_to_error_messages) {
+          info_from_enabling_user_space_instrumentation =
+              absl::StrCat(info_from_enabling_user_space_instrumentation.value(), message, "\n");
+        }
+        info_from_enabling_user_space_instrumentation =
+            absl::StrCat(info_from_enabling_user_space_instrumentation.value(),
+                         "\nThe functions above will be instrumented using the slower kernel "
+                         "(uprobe) functionality.\n");
+        info_from_enabling_user_space_instrumentation =
+            absl::StrCat(info_from_enabling_user_space_instrumentation.value(), status_message);
+      }
+
       user_space_instrumentation_addresses =
           std::make_unique<UserSpaceInstrumentationAddressesImpl>(
               result_or_error.value().entry_trampoline_address_ranges,
@@ -224,6 +245,14 @@ grpc::Status LinuxCaptureService::Capture(
         orbit_capture_service::CreateErrorEnablingUserSpaceInstrumentationEvent(
             capture_start_timestamp_ns_,
             std::move(error_enabling_user_space_instrumentation.value())));
+  }
+
+  if (info_from_enabling_user_space_instrumentation.has_value()) {
+    producer_event_processor_->ProcessEvent(
+        orbit_grpc_protos::kRootProducerId,
+        orbit_capture_service::CreateInfoEnablingUserSpaceInstrumentationEvent(
+            capture_start_timestamp_ns_,
+            std::move(info_from_enabling_user_space_instrumentation.value())));
   }
 
   std::unique_ptr<orbit_introspection::IntrospectionListener> introspection_listener;

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -187,7 +187,8 @@ grpc::Status LinuxCaptureService::Capture(
 
   // Enable user space instrumentation.
   std::optional<std::string> error_enabling_user_space_instrumentation;
-  std::optional<std::string> info_from_enabling_user_space_instrumentation;
+  std::optional<orbit_grpc_protos::ProducerCaptureEvent>
+      info_from_enabling_user_space_instrumentation;
   std::unique_ptr<UserSpaceInstrumentationAddressesImpl> user_space_instrumentation_addresses;
   if (capture_options.dynamic_instrumentation_method() ==
           CaptureOptions::kUserSpaceInstrumentation &&
@@ -201,26 +202,9 @@ grpc::Status LinuxCaptureService::Capture(
       FilterOutInstrumentedFunctionsFromCaptureOptions(
           result_or_error.value().instrumented_function_ids, linux_tracing_capture_options);
 
-      const std::string status_message = absl::StrFormat(
-          "User space instrumentation enabled for %u out of %u instrumented functions.",
-          result_or_error.value().instrumented_function_ids.size(),
-          capture_options.instrumented_functions_size());
-      LOG("%s", status_message);
-
-      // If at least one function was not instrumented we send a message to the capture log.
-      if (result_or_error.value().function_ids_to_error_messages.size()) {
-        info_from_enabling_user_space_instrumentation = "Failed to instrument some functions:\n";
-        for (auto const& [id, message] : result_or_error.value().function_ids_to_error_messages) {
-          info_from_enabling_user_space_instrumentation =
-              absl::StrCat(info_from_enabling_user_space_instrumentation.value(), message, "\n");
-        }
-        info_from_enabling_user_space_instrumentation =
-            absl::StrCat(info_from_enabling_user_space_instrumentation.value(),
-                         "\nThe functions above will be instrumented using the slower kernel "
-                         "(uprobe) functionality.\n");
-        info_from_enabling_user_space_instrumentation =
-            absl::StrCat(info_from_enabling_user_space_instrumentation.value(), status_message);
-      }
+      info_from_enabling_user_space_instrumentation =
+          orbit_capture_service::CreateInfoEnablingUserSpaceInstrumentationEvent(
+              capture_start_timestamp_ns_, result_or_error.value().function_ids_to_error_messages);
 
       user_space_instrumentation_addresses =
           std::make_unique<UserSpaceInstrumentationAddressesImpl>(
@@ -250,9 +234,7 @@ grpc::Status LinuxCaptureService::Capture(
   if (info_from_enabling_user_space_instrumentation.has_value()) {
     producer_event_processor_->ProcessEvent(
         orbit_grpc_protos::kRootProducerId,
-        orbit_capture_service::CreateInfoEnablingUserSpaceInstrumentationEvent(
-            capture_start_timestamp_ns_,
-            std::move(info_from_enabling_user_space_instrumentation.value())));
+        std::move(info_from_enabling_user_space_instrumentation.value()));
   }
 
   std::unique_ptr<orbit_introspection::IntrospectionListener> introspection_listener;

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -202,6 +202,10 @@ grpc::Status LinuxCaptureService::Capture(
       FilterOutInstrumentedFunctionsFromCaptureOptions(
           result_or_error.value().instrumented_function_ids, linux_tracing_capture_options);
 
+      LOG("User space instrumentation enabled for %u out of %u instrumented functions.",
+          result_or_error.value().instrumented_function_ids.size(),
+          capture_options.instrumented_functions_size());
+
       if (result_or_error.value().function_ids_to_error_messages.size()) {
         info_from_enabling_user_space_instrumentation =
             orbit_capture_service::CreateWarningInstrumentingWithUserSpaceInstrumentationEvent(

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -524,7 +524,8 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kGpuQueueSubmission:
         UNREACHABLE();
-      case orbit_grpc_protos::ProducerCaptureEvent::kInfoEnablingUserSpaceInstrumentationEvent:
+      case orbit_grpc_protos::ProducerCaptureEvent::
+          kWarningInstrumentingWithUserSpaceInstrumentationEvent:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedCallstack:
         UNREACHABLE();

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -524,6 +524,8 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kGpuQueueSubmission:
         UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kInfoEnablingUserSpaceInstrumentationEvent:
+        UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedCallstack:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedString:

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -524,9 +524,6 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kGpuQueueSubmission:
         UNREACHABLE();
-      case orbit_grpc_protos::ProducerCaptureEvent::
-          kWarningInstrumentingWithUserSpaceInstrumentationEvent:
-        UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedCallstack:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedString:
@@ -569,6 +566,9 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         previous_event_timestamp_ns = event.thread_state_slice().end_timestamp_ns();
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kWarningEvent:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::
+          kWarningInstrumentingWithUserSpaceInstrumentationEvent:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::EVENT_NOT_SET:
         UNREACHABLE();

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -594,7 +594,7 @@ void OrbitApp::OnErrorEnablingUserSpaceInstrumentationEvent(
   main_thread_executor_->Schedule([this, error_event = std::move(error_event)]() {
     const std::string message =
         absl::StrCat(error_event.message(),
-                     "\nAll functions will be instrumented using the slower kernel(uprobe) "
+                     "\nAll functions will be instrumented using the slower kernel (uprobe) "
                      "functionality.\n");
     main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kSevereWarning,
                                      GetCaptureTimeAt(error_event.timestamp_ns()), message);
@@ -608,19 +608,19 @@ void OrbitApp::OnErrorEnablingUserSpaceInstrumentationEvent(
   });
 }
 
-void OrbitApp::OnInfoEnablingUserSpaceInstrumentationEvent(
-    orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent info_event) {
-  main_thread_executor_->Schedule([this, info_event = std::move(info_event)]() {
+void OrbitApp::OnWarningInstrumentingWithUserSpaceInstrumentationEvent(
+    orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent warning_event) {
+  main_thread_executor_->Schedule([this, warning_event = std::move(warning_event)]() {
     std::string message = "Failed to instrument some functions:\n";
-    for (const auto& function : info_event.functions_that_failed_to_instrument()) {
+    for (const auto& function : warning_event.functions_that_failed_to_instrument()) {
       message = absl::StrCat(message, function.error_message(), "\n");
     }
     message = absl::StrCat(message,
                            "\nThe functions above will be instrumented using the slower kernel "
-                           "(uprobe) functionality.\n");
+                           "(uprobes) functionality.\n");
 
     main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kWarning,
-                                     GetCaptureTimeAt(info_event.timestamp_ns()), message);
+                                     GetCaptureTimeAt(warning_event.timestamp_ns()), message);
   });
 }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -600,7 +600,10 @@ void OrbitApp::OnErrorEnablingUserSpaceInstrumentationEvent(
       constexpr const char* kDontShowAgainErrorEnablingUserSpaceInstrumentationWarningKey =
           "DontShowAgainErrorEnablingUserSpaceInstrumentationWarning";
       main_window_->ShowWarningWithDontShowAgainCheckboxIfNeeded(
-          "Could not enable user space instrumentation", error_event.message(),
+          "Could not enable user space instrumentation",
+          absl::StrCat(error_event.message(),
+                       "\nAll functions will be instrumented using the slower kernel(uprobe) "
+                       "functionality.\n"),
           kDontShowAgainErrorEnablingUserSpaceInstrumentationWarningKey);
     }
   });

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -594,7 +594,7 @@ void OrbitApp::OnErrorEnablingUserSpaceInstrumentationEvent(
   main_thread_executor_->Schedule([this, error_event = std::move(error_event)]() {
     const std::string message =
         absl::StrCat(error_event.message(),
-                     "\nAll functions will be instrumented using the slower kernel (uprobe) "
+                     "\nAll functions will be instrumented using the slower kernel (uprobes) "
                      "functionality.\n");
     main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kSevereWarning,
                                      GetCaptureTimeAt(error_event.timestamp_ns()), message);

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -592,18 +592,17 @@ void OrbitApp::OnErrorEnablingOrbitApiEvent(
 void OrbitApp::OnErrorEnablingUserSpaceInstrumentationEvent(
     orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent error_event) {
   main_thread_executor_->Schedule([this, error_event = std::move(error_event)]() {
+    const std::string message =
+        absl::StrCat(error_event.message(),
+                     "\nAll functions will be instrumented using the slower kernel(uprobe) "
+                     "functionality.\n");
     main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kSevereWarning,
-                                     GetCaptureTimeAt(error_event.timestamp_ns()),
-                                     error_event.message());
-
+                                     GetCaptureTimeAt(error_event.timestamp_ns()), message);
     if (!IsLoadingCapture()) {
       constexpr const char* kDontShowAgainErrorEnablingUserSpaceInstrumentationWarningKey =
           "DontShowAgainErrorEnablingUserSpaceInstrumentationWarning";
       main_window_->ShowWarningWithDontShowAgainCheckboxIfNeeded(
-          "Could not enable user space instrumentation",
-          absl::StrCat(error_event.message(),
-                       "\nAll functions will be instrumented using the slower kernel(uprobe) "
-                       "functionality.\n"),
+          "Could not enable user space instrumentation", message,
           kDontShowAgainErrorEnablingUserSpaceInstrumentationWarningKey);
     }
   });

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -606,6 +606,15 @@ void OrbitApp::OnErrorEnablingUserSpaceInstrumentationEvent(
   });
 }
 
+void OrbitApp::OnInfoEnablingUserSpaceInstrumentationEvent(
+    orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent info_event) {
+  main_thread_executor_->Schedule([this, info_event = std::move(info_event)]() {
+    main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kSevereWarning,
+                                     GetCaptureTimeAt(info_event.timestamp_ns()),
+                                     info_event.message());
+  });
+}
+
 static constexpr const char* kIncompleteDataLogMessage =
     "The capture contains one or more time ranges with incomplete data. Some information might "
     "be inaccurate.";

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -169,6 +169,8 @@ class OrbitApp final : public DataViewFactory,
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) override;
   void OnErrorEnablingUserSpaceInstrumentationEvent(
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent error_event) override;
+  void OnInfoEnablingUserSpaceInstrumentationEvent(
+      orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent info_event) override;
   void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) override;
   void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -169,8 +169,9 @@ class OrbitApp final : public DataViewFactory,
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) override;
   void OnErrorEnablingUserSpaceInstrumentationEvent(
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent error_event) override;
-  void OnInfoEnablingUserSpaceInstrumentationEvent(
-      orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent info_event) override;
+  void OnWarningInstrumentingWithUserSpaceInstrumentationEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent warning_event)
+      override;
   void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) override;
   void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -176,8 +176,9 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/) override {
     UNREACHABLE();
   }
-  void OnInfoEnablingUserSpaceInstrumentationEvent(
-      orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent /*info_event*/) override {
+  void OnWarningInstrumentingWithUserSpaceInstrumentationEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent /*warning_event*/)
+      override {
     UNREACHABLE();
   }
   void OnLostPerfRecordsEvent(

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -176,6 +176,10 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/) override {
     UNREACHABLE();
   }
+  void OnInfoEnablingUserSpaceInstrumentationEvent(
+      orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent /*info_event*/) override {
+    UNREACHABLE();
+  }
   void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/) override {
     UNREACHABLE();

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -39,7 +39,6 @@ using orbit_grpc_protos::FunctionCall;
 using orbit_grpc_protos::GpuDebugMarker;
 using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::GpuQueueSubmission;
-using orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent;
 using orbit_grpc_protos::InternedCallstack;
 using orbit_grpc_protos::InternedString;
 using orbit_grpc_protos::InternedTracepointInfo;
@@ -55,6 +54,7 @@ using orbit_grpc_protos::ThreadNamesSnapshot;
 using orbit_grpc_protos::ThreadStateSlice;
 using orbit_grpc_protos::TracepointEvent;
 using orbit_grpc_protos::WarningEvent;
+using orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent;
 
 namespace orbit_producer_event_processor {
 
@@ -128,8 +128,8 @@ class ProducerEventProcessorImpl : public ProducerEventProcessor {
   void ProcessFunctionCallAndTransferOwnership(FunctionCall* function_call);
   void ProcessGpuQueueSubmissionAndTransferOwnership(uint64_t producer_id,
                                                      GpuQueueSubmission* gpu_queue_submission);
-  void ProcessInfoEnablingUserSpaceInstrumentationEventAndTransferOwnership(
-      InfoEnablingUserSpaceInstrumentationEvent* info_event);
+  void ProcessWarningInstrumentingWithUserSpaceInstrumentationEventAndTransferOwnership(
+      WarningInstrumentingWithUserSpaceInstrumentationEvent* warning_event);
   // ProcessInterned* functions remap producer intern_ids to the id space used in the client.
   // They keep track of these mappings in producer_interned_callstack_id_to_client_callstack_id_
   // and producer_interned_string_id_to_client_string_id_.
@@ -422,10 +422,10 @@ void ProducerEventProcessorImpl::ProcessGpuQueueSubmissionAndTransferOwnership(
 }
 
 void ProducerEventProcessorImpl::
-    ProcessInfoEnablingUserSpaceInstrumentationEventAndTransferOwnership(
-        InfoEnablingUserSpaceInstrumentationEvent* info_event) {
+    ProcessWarningInstrumentingWithUserSpaceInstrumentationEventAndTransferOwnership(
+        WarningInstrumentingWithUserSpaceInstrumentationEvent* warning_event) {
   ClientCaptureEvent event;
-  event.set_allocated_info_enabling_user_space_instrumentation_event(info_event);
+  event.set_allocated_warning_instrumenting_with_user_space_instrumentation_event(warning_event);
   client_capture_event_collector_->AddEvent(std::move(event));
 }
 
@@ -631,9 +631,9 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
       ProcessGpuQueueSubmissionAndTransferOwnership(producer_id,
                                                     event.release_gpu_queue_submission());
       break;
-    case ProducerCaptureEvent::kInfoEnablingUserSpaceInstrumentationEvent:
-      ProcessInfoEnablingUserSpaceInstrumentationEventAndTransferOwnership(
-          event.release_info_enabling_user_space_instrumentation_event());
+    case ProducerCaptureEvent::kWarningInstrumentingWithUserSpaceInstrumentationEvent:
+      ProcessWarningInstrumentingWithUserSpaceInstrumentationEventAndTransferOwnership(
+          event.release_warning_instrumenting_with_user_space_instrumentation_event());
       break;
     case ProducerCaptureEvent::kInternedCallstack:
       ProcessInternedCallstack(producer_id, event.mutable_interned_callstack());

--- a/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
@@ -44,6 +44,7 @@ using orbit_grpc_protos::GpuDebugMarker;
 using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::GpuQueueSubmission;
 using orbit_grpc_protos::GpuSubmitInfo;
+using orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent;
 using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::InternedCallstack;
 using orbit_grpc_protos::InternedString;
@@ -2076,6 +2077,30 @@ TEST(ProducerEventProcessor, ErrorEnablingUserSpaceInstrumentationEvent) {
       client_capture_event.error_enabling_user_space_instrumentation_event();
   EXPECT_EQ(actual_error_event.timestamp_ns(), kTimestampNs1);
   EXPECT_EQ(actual_error_event.message(), kMessage);
+}
+
+TEST(ProducerEventProcessor, InfoEnablingUserSpaceInstrumentationEvent) {
+  MockClientCaptureEventCollector collector;
+  auto producer_event_processor = ProducerEventProcessor::Create(&collector);
+
+  ProducerCaptureEvent producer_capture_event;
+  InfoEnablingUserSpaceInstrumentationEvent* info_event =
+      producer_capture_event.mutable_info_enabling_user_space_instrumentation_event();
+  info_event->set_timestamp_ns(kTimestampNs1);
+  constexpr const char* kMessage = "message";
+  info_event->set_message(kMessage);
+
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(collector, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, std::move(producer_capture_event));
+
+  ASSERT_EQ(client_capture_event.event_case(),
+            ClientCaptureEvent::kInfoEnablingUserSpaceInstrumentationEvent);
+  const InfoEnablingUserSpaceInstrumentationEvent& actual_info_event =
+      client_capture_event.info_enabling_user_space_instrumentation_event();
+  EXPECT_EQ(actual_info_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_info_event.message(), kMessage);
 }
 
 TEST(ProducerEventProcessor, LostPerfRecordsEvent) {

--- a/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
@@ -2103,6 +2103,7 @@ TEST(ProducerEventProcessor, WarningInstrumentingWithUserSpaceInstrumentationEve
   const WarningInstrumentingWithUserSpaceInstrumentationEvent& actual_warning_event =
       client_capture_event.warning_instrumenting_with_user_space_instrumentation_event();
   EXPECT_EQ(actual_warning_event.timestamp_ns(), kTimestampNs1);
+  ASSERT_EQ(actual_warning_event.functions_that_failed_to_instrument_size(), 1);
   EXPECT_EQ(actual_warning_event.functions_that_failed_to_instrument(0).function_id(), kFunctionId);
   EXPECT_EQ(actual_warning_event.functions_that_failed_to_instrument(0).error_message(),
             kErrorMessage);

--- a/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
@@ -44,7 +44,6 @@ using orbit_grpc_protos::GpuDebugMarker;
 using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::GpuQueueSubmission;
 using orbit_grpc_protos::GpuSubmitInfo;
-using orbit_grpc_protos::InfoEnablingUserSpaceInstrumentationEvent;
 using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::InternedCallstack;
 using orbit_grpc_protos::InternedString;
@@ -65,6 +64,7 @@ using orbit_grpc_protos::ThreadNamesSnapshot;
 using orbit_grpc_protos::ThreadStateSlice;
 using orbit_grpc_protos::TracepointEvent;
 using orbit_grpc_protos::WarningEvent;
+using orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent;
 
 using google::protobuf::util::MessageDifferencer;
 using ::testing::ElementsAre;
@@ -2079,17 +2079,17 @@ TEST(ProducerEventProcessor, ErrorEnablingUserSpaceInstrumentationEvent) {
   EXPECT_EQ(actual_error_event.message(), kMessage);
 }
 
-TEST(ProducerEventProcessor, InfoEnablingUserSpaceInstrumentationEvent) {
+TEST(ProducerEventProcessor, WarningInstrumentingWithUserSpaceInstrumentationEvent) {
   MockClientCaptureEventCollector collector;
   auto producer_event_processor = ProducerEventProcessor::Create(&collector);
 
   ProducerCaptureEvent producer_capture_event;
-  InfoEnablingUserSpaceInstrumentationEvent* info_event =
-      producer_capture_event.mutable_info_enabling_user_space_instrumentation_event();
-  info_event->set_timestamp_ns(kTimestampNs1);
+  WarningInstrumentingWithUserSpaceInstrumentationEvent* warning_event =
+      producer_capture_event.mutable_warning_instrumenting_with_user_space_instrumentation_event();
+  warning_event->set_timestamp_ns(kTimestampNs1);
   constexpr int kFunctionId = 42;
   constexpr const char* kErrorMessage = "error message";
-  auto function = info_event->add_functions_that_failed_to_instrument();
+  auto function = warning_event->add_functions_that_failed_to_instrument();
   function->set_function_id(kFunctionId);
   function->set_error_message(kErrorMessage);
 
@@ -2099,12 +2099,12 @@ TEST(ProducerEventProcessor, InfoEnablingUserSpaceInstrumentationEvent) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, std::move(producer_capture_event));
 
   ASSERT_EQ(client_capture_event.event_case(),
-            ClientCaptureEvent::kInfoEnablingUserSpaceInstrumentationEvent);
-  const InfoEnablingUserSpaceInstrumentationEvent& actual_info_event =
-      client_capture_event.info_enabling_user_space_instrumentation_event();
-  EXPECT_EQ(actual_info_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_info_event.functions_that_failed_to_instrument(0).function_id(), kFunctionId);
-  EXPECT_EQ(actual_info_event.functions_that_failed_to_instrument(0).error_message(),
+            ClientCaptureEvent::kWarningInstrumentingWithUserSpaceInstrumentationEvent);
+  const WarningInstrumentingWithUserSpaceInstrumentationEvent& actual_warning_event =
+      client_capture_event.warning_instrumenting_with_user_space_instrumentation_event();
+  EXPECT_EQ(actual_warning_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_warning_event.functions_that_failed_to_instrument(0).function_id(), kFunctionId);
+  EXPECT_EQ(actual_warning_event.functions_that_failed_to_instrument(0).error_message(),
             kErrorMessage);
 }
 

--- a/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
@@ -2087,8 +2087,11 @@ TEST(ProducerEventProcessor, InfoEnablingUserSpaceInstrumentationEvent) {
   InfoEnablingUserSpaceInstrumentationEvent* info_event =
       producer_capture_event.mutable_info_enabling_user_space_instrumentation_event();
   info_event->set_timestamp_ns(kTimestampNs1);
-  constexpr const char* kMessage = "message";
-  info_event->set_message(kMessage);
+  constexpr int kFunctionId = 42;
+  constexpr const char* kErrorMessage = "error message";
+  auto function = info_event->add_functions_that_failed_to_instrument();
+  function->set_function_id(kFunctionId);
+  function->set_error_message(kErrorMessage);
 
   ClientCaptureEvent client_capture_event;
   EXPECT_CALL(collector, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
@@ -2100,7 +2103,9 @@ TEST(ProducerEventProcessor, InfoEnablingUserSpaceInstrumentationEvent) {
   const InfoEnablingUserSpaceInstrumentationEvent& actual_info_event =
       client_capture_event.info_enabling_user_space_instrumentation_event();
   EXPECT_EQ(actual_info_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_info_event.message(), kMessage);
+  EXPECT_EQ(actual_info_event.functions_that_failed_to_instrument(0).function_id(), kFunctionId);
+  EXPECT_EQ(actual_info_event.functions_that_failed_to_instrument(0).error_message(),
+            kErrorMessage);
 }
 
 TEST(ProducerEventProcessor, LostPerfRecordsEvent) {

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -250,8 +250,10 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
     constexpr uint64_t kMaxFunctionPrologueBackupSize = 20;
     const uint64_t backup_size = std::min(kMaxFunctionPrologueBackupSize, function.function_size());
     if (backup_size == 0) {
-      // Can't instrument function of size zero
-      ERROR("Can't instrument function \"%s\" since it has size zero.", function.function_name());
+      const std::string message = absl::StrFormat(
+          "Can't instrument function \"%s\"  since it has size zero.", function.function_name());
+      ERROR("%s", message);
+      result.function_ids_to_error_messages[function_id] = message;
       continue;
     }
     // Get all modules with the right path (usually one, but might be more) and get a function
@@ -279,7 +281,8 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
                              capstone_handle, relocation_map_);
         if (address_after_prologue_or_error.has_error()) {
           const std::string message = absl::StrFormat(
-              "Failed to create trampoline: %s", address_after_prologue_or_error.error().message());
+              "Can't instrument function \"%s\". Failed to create trampoline: %s",
+              function.function_name(), address_after_prologue_or_error.error().message());
           ERROR("%s", message);
           result.function_ids_to_error_messages[function_id] = message;
           OUTCOME_TRY(ReleaseMostRecentlyAllocatedTrampolineMemory(module_address_range));
@@ -299,7 +302,7 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
                                                 trampoline_data.trampoline_address);
       if (result_or_error.has_error()) {
         const std::string message =
-            absl::StrFormat("Unable to instrument \"%s\": %s", function.function_name(),
+            absl::StrFormat("Can't instrument function \"%s\": %s", function.function_name(),
                             result_or_error.error().message());
         ERROR("%s", message);
         result.function_ids_to_error_messages[function_id] = message;

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -251,7 +251,7 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
     const uint64_t backup_size = std::min(kMaxFunctionPrologueBackupSize, function.function_size());
     if (backup_size == 0) {
       const std::string message = absl::StrFormat(
-          "Can't instrument function \"%s\"  since it has size zero.", function.function_name());
+          "Can't instrument function \"%s\" since it has size zero.", function.function_name());
       ERROR("%s", message);
       result.function_ids_to_error_messages[function_id] = message;
       continue;


### PR DESCRIPTION
Occationaly it is not possible to instrument a function with user space
instrumentation. We fall back to uprobes in that case.

Previously this was only reported into the log of OrbitService. Since
this has performance implications we'd like the user to see warnings in
this case. So this PR adds proper reporting into the capture log.

Bug: http://b/195543569
Test: Local runs, unit tests in the PR.