### PR TITLE
Add ConnectToTargetDialog

### DIFF
--- a/src/SessionSetup/CMakeLists.txt
+++ b/src/SessionSetup/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
   SessionSetup
   PUBLIC  include/SessionSetup/Connections.h
           include/SessionSetup/ConnectToStadiaWidget.h
+          include/SessionSetup/ConnectToTargetDialog.h
           include/SessionSetup/DeploymentConfigurations.h
           include/SessionSetup/DoubleClickableLabel.h
           include/SessionSetup/Error.h
@@ -31,6 +32,8 @@ target_sources(
   SessionSetup
   PRIVATE ConnectToStadiaWidget.cpp
           ConnectToStadiaWidget.ui
+          ConnectToTargetDialog.cpp
+          ConnectToTargetDialog.ui
           DeploymentConfigurations.cpp
           Error.cpp
           OverlayWidget.cpp

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -1,0 +1,190 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SessionSetup/ConnectToTargetDialog.h"
+
+#include <QApplication>
+#include <QMessageBox>
+#include <memory>
+
+#include "ClientServices/ProcessClient.h"
+#include "OrbitBase/Logging.h"
+#include "SessionSetup/ConnectToTargetDialog.h"
+#include "SessionSetup/ServiceDeployManager.h"
+#include "SessionSetup/SessionSetupUtils.h"
+#include "ui_ConnectToTargetDialog.h"
+
+namespace orbit_session_setup {
+
+ConnectToTargetDialog::ConnectToTargetDialog(
+    SshConnectionArtifacts* ssh_connection_artifacts, const QString& instance_id,
+    uint32_t process_id, orbit_metrics_uploader::MetricsUploader* metrics_uploader, QWidget* parent)
+    : QDialog{parent, Qt::Window},
+      ui_(std::make_unique<Ui::ConnectToTargetDialog>()),
+      ssh_connection_artifacts_(ssh_connection_artifacts),
+      instance_id_(instance_id),
+      process_id_(process_id),
+      metrics_uploader_(metrics_uploader),
+      main_thread_executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()) {
+  CHECK(ssh_connection_artifacts != nullptr);
+
+  ui_->setupUi(this);
+  ui_->instanceIdLabel->setText(instance_id);
+  ui_->processIdLabel->setText(QString("%1").arg(process_id));
+}
+
+ConnectToTargetDialog::~ConnectToTargetDialog() {}
+
+std::optional<TargetConfiguration> ConnectToTargetDialog::Exec() {
+  int rc = QDialog::DialogCode::Rejected;
+
+  if (StartConnection()) {
+    LoadInstanceDetailsAsync();
+    rc = QDialog::exec();
+  }
+
+  if (rc != QDialog::Accepted) {
+    if (!result_data_.error_message_.isEmpty()) {
+      QString error =
+          QString("Error connecting to specified target: %1.").arg(result_data_.error_message_);
+      ERROR("%s", error.toStdString().c_str());
+      QMessageBox::critical(nullptr, QApplication::applicationName(), error);
+    }
+    return std::nullopt;
+  }
+
+  return CreateTargetFromResult();
+}
+
+StadiaTarget ConnectToTargetDialog::CreateTargetFromResult() {
+  CHECK(result_data_.maybe_instance_.has_value());
+  CHECK(result_data_.grpc_channel_ != nullptr);
+  CHECK(result_data_.service_deploy_manager_ != nullptr);
+  CHECK(result_data_.process_data_ != nullptr);
+
+  auto process_manager = orbit_client_services::ProcessManager::Create(result_data_.grpc_channel_,
+                                                                       absl::Milliseconds(1000));
+  auto stadia_connection = orbit_session_setup::StadiaConnection(
+      std::move(result_data_.maybe_instance_.value()),
+      std::move(result_data_.service_deploy_manager_), std::move(result_data_.grpc_channel_));
+  return orbit_session_setup::StadiaTarget(std::move(stadia_connection), std::move(process_manager),
+                                           std::move(result_data_.process_data_));
+}
+
+bool ConnectToTargetDialog::StartConnection() {
+  LOG("Establishing connection to specified target %s:%d", instance_id_.toStdString().c_str(),
+      process_id_);
+  result_data_ = ResultData();
+
+  auto ggp_client_result = orbit_ggp::CreateClient();
+  if (ggp_client_result.has_error()) {
+    result_data_.error_message_ = QString::fromStdString(ggp_client_result.error().message());
+    return false;
+  }
+
+  ggp_client_ = std::move(ggp_client_result.value());
+
+  SetStatusMessage("Loading encryption credentials for instance...");
+  auto future = ggp_client_->GetSshInfoAsync(instance_id_, std::nullopt);
+  future.Then(main_thread_executor_.get(),
+              [this](ErrorMessageOr<orbit_ggp::SshInfo> ssh_info_result) {
+                OnSshInfoAvailable(std::move(ssh_info_result));
+              });
+
+  return true;
+}
+
+void ConnectToTargetDialog::OnSshInfoAvailable(ErrorMessageOr<orbit_ggp::SshInfo> ssh_info_result) {
+  if (!ssh_info_result.has_error()) {
+    LOG("Received ssh info for instance with id: %s", instance_id_.toStdString());
+
+    auto ssh_info = ssh_info_result.value();
+    auto deployment_result = DeployOrbitService(ssh_info);
+    if (deployment_result.has_value()) {
+      result_data_.grpc_channel_ = CreateGrpcChannel(deployment_result.value().grpc_port);
+      ListProcessesAndSaveProcess(result_data_.grpc_channel_);
+    }
+  } else {
+    result_data_.error_message_ =
+        QString("Error receiving ssh info for instance with id %1:%2")
+            .arg(instance_id_, QString::fromStdString(ssh_info_result.error().message()));
+  }
+
+  CloseDialogIfResultIsReady();
+}
+
+void ConnectToTargetDialog::LoadInstanceDetailsAsync() {
+  ggp_client_->DescribeInstanceAsync(instance_id_)
+      .Then(main_thread_executor_.get(),
+            [this](ErrorMessageOr<orbit_ggp::Instance> instance_result) {
+              if (instance_result.has_error()) {
+                result_data_.maybe_instance_ = std::nullopt;
+                result_data_.error_message_ =
+                    QString::fromStdString(instance_result.error().message());
+              } else {
+                result_data_.maybe_instance_ = instance_result.value();
+              }
+              CloseDialogIfResultIsReady();
+            });
+}
+
+std::optional<ServiceDeployManager::GrpcPort> ConnectToTargetDialog::DeployOrbitService(
+    orbit_ggp::SshInfo& ssh_info) {
+  result_data_.service_deploy_manager_ =
+      std::make_unique<orbit_session_setup::ServiceDeployManager>(
+          ssh_connection_artifacts_->GetDeploymentConfiguration(),
+          ssh_connection_artifacts_->GetSshContext(), CredentialsFromSshInfo(ssh_info),
+          ssh_connection_artifacts_->GetGrpcPort());
+
+  orbit_ssh_qt::ScopedConnection label_connection{QObject::connect(
+      result_data_.service_deploy_manager_.get(), &ServiceDeployManager::statusMessage, this,
+      &ConnectToTargetDialog::SetStatusMessage)};
+  orbit_ssh_qt::ScopedConnection cancel_connection{
+      QObject::connect(ui_->abortButton, &QPushButton::clicked,
+                       result_data_.service_deploy_manager_.get(), &ServiceDeployManager::Cancel)};
+
+  auto deployment_result = result_data_.service_deploy_manager_->Exec();
+  if (deployment_result.has_error()) {
+    result_data_.error_message_ = QString::fromStdString(deployment_result.error().message());
+    return std::nullopt;
+  } else {
+    return deployment_result.value();
+  }
+}
+
+void ConnectToTargetDialog::ListProcessesAndSaveProcess(
+    std::shared_ptr<grpc_impl::Channel> grpc_channel) {
+  CHECK(grpc_channel != nullptr);
+
+  orbit_client_services::ProcessClient client(grpc_channel);
+  auto process_list = client.GetProcessList();
+  if (!process_list.has_value()) return;
+
+  for (auto& process : process_list.value()) {
+    if (process.pid() == process_id_) {
+      result_data_.process_data_ = std::make_unique<orbit_client_data::ProcessData>(process);
+      return;
+    }
+  }
+
+  result_data_.error_message_ =
+      QString("PID %1 was not found in the list of running processes.").arg(process_id_);
+}
+
+void ConnectToTargetDialog::CloseDialogIfResultIsReady() {
+  if (!result_data_.error_message_.isEmpty()) {
+    reject();
+  }
+
+  if (result_data_.maybe_instance_.has_value() && result_data_.grpc_channel_ != nullptr &&
+      result_data_.process_data_ != nullptr) {
+    accept();
+  }
+}
+
+void ConnectToTargetDialog::SetStatusMessage(const QString& message) {
+  ui_->statusLabel->setText(QString("<b>Status:</b> ") + message);
+}
+
+}  // namespace orbit_session_setup

--- a/src/SessionSetup/ConnectToTargetDialog.ui
+++ b/src/SessionSetup/ConnectToTargetDialog.ui
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConnectToTargetDialog</class>
+ <widget class="QDialog" name="ConnectToTargetDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>598</width>
+    <height>260</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Connecting to Stadia Target...</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
+   <item>
+    <widget class="QWidget" name="widget_3" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../../icons/orbiticons.qrc">:/actions/connected</pixmap>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Please wait while Orbit is connecting to the specified process. This may take several seconds.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget_2" native="true">
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Instance ID:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="instanceIdLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Process ID:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="processIdLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="statusLabel">
+     <property name="text">
+      <string>&lt;b&gt;Status:&lt;/b&gt; Initializing</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="maximum">
+      <number>0</number>
+     </property>
+     <property name="value">
+      <number>-1</number>
+     </property>
+     <property name="textVisible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget_1" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="abortButton">
+        <property name="text">
+         <string>Abort</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../icons/orbiticons.qrc">
+          <normaloff>:/actions/clear</normaloff>:/actions/clear</iconset>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../icons/orbiticons.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>abortButton</sender>
+   <signal>clicked()</signal>
+   <receiver>ConnectToTargetDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>529</x>
+     <y>200</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>298</x>
+     <y>118</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SESSION_SETUP_CONNECT_TO_TARGET_DIALOG_H_
+#define SESSION_SETUP_CONNECT_TO_TARGET_DIALOG_H_
+
+#include <QDialog>
+#include <QString>
+#include <optional>
+
+#include "Connections.h"
+#include "MetricsUploader/MetricsUploader.h"
+#include "OrbitGgp/Client.h"
+#include "OrbitGgp/SshInfo.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
+#include "TargetConfiguration.h"
+
+namespace Ui {
+class ConnectToTargetDialog;  // IWYU pragma: keep
+}
+namespace orbit_session_setup {
+
+// Simple dialog to show progress while connecting to a specified instance id and process id.
+// This takes care of establishing the connection and deploying Orbit service, and will either
+// return a TargetConfiguration or nullopt on Exec. If a nullopt is returned, an error was
+// displayed to the user and has been logged.
+class ConnectToTargetDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  explicit ConnectToTargetDialog(SshConnectionArtifacts* ssh_connection_artifacts,
+                                 const QString& instance_id, uint32_t process_id,
+                                 orbit_metrics_uploader::MetricsUploader* metrics_uploader,
+                                 QWidget* parent = nullptr);
+  ~ConnectToTargetDialog() override;
+
+  [[nodiscard]] std::optional<TargetConfiguration> Exec();
+
+ private:
+  std::unique_ptr<Ui::ConnectToTargetDialog> ui_;
+
+  SshConnectionArtifacts* ssh_connection_artifacts_;
+
+  QString instance_id_;
+  uint32_t process_id_;
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
+
+  struct ResultData {
+    QString error_message_ = "";
+    std::optional<orbit_ggp::Instance> maybe_instance_ = std::nullopt;
+    std::unique_ptr<orbit_client_data::ProcessData> process_data_ = nullptr;
+    std::unique_ptr<orbit_session_setup::ServiceDeployManager> service_deploy_manager_ = nullptr;
+    std::shared_ptr<grpc_impl::Channel> grpc_channel_ = nullptr;
+  };
+
+  ResultData result_data_;
+
+  std::unique_ptr<orbit_ggp::Client> ggp_client_;
+  std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> main_thread_executor_;
+
+  [[nodiscard]] StadiaTarget CreateTargetFromResult();
+
+  [[nodiscard]] bool StartConnection();
+  [[nodiscard]] std::optional<ServiceDeployManager::GrpcPort> DeployOrbitService(
+      orbit_ggp::SshInfo& ssh_info);
+  void ListProcessesAndSaveProcess(std::shared_ptr<grpc_impl::Channel> grpc_channel);
+  void LoadInstanceDetailsAsync();
+  void OnSshInfoAvailable(ErrorMessageOr<orbit_ggp::SshInfo> ssh_info_result);
+
+  void CloseDialogIfResultIsReady();
+  void SetStatusMessage(const QString& message);
+};
+
+}  // namespace orbit_session_setup
+
+#endif

--- a/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
@@ -69,7 +69,7 @@ class ConnectToTargetDialog : public QDialog {
   FindSpecifiedProcess(std::shared_ptr<grpc_impl::Channel> grpc_channel, uint32_t process_id);
 
   void SetStatusMessage(const QString& message);
-  void LogAndDisplayError(const QString& message);
+  void LogAndDisplayError(const ErrorMessage& message);
 };
 
 }  // namespace orbit_session_setup


### PR DESCRIPTION
Add the ConnectToTarget Dialog. This dialog encapsulates all functionality required to directly connect to a specified instance- and process-ID, displays connection progress and allows the user to cancel the deployment.

https://screenshot.googleplex.com/3jRQUvx5KitdTns

Bug: b/202262468
Test: Only manual tests so far, unit and E2E tests TBD.