### PR TITLE
Use libunwindstack library function to convert errors to strings

### DIFF
--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -4,6 +4,7 @@
 
 #include "LibunwindstackUnwinder.h"
 
+#include <unwindstack/Error.h>
 #include <unwindstack/Memory.h>
 #include <unwindstack/Regs.h>
 #include <unwindstack/RegsX86_64.h>
@@ -123,11 +124,7 @@ std::unique_ptr<LibunwindstackUnwinder> LibunwindstackUnwinder::Create() {
 }
 
 std::string LibunwindstackUnwinder::LibunwindstackErrorString(unwindstack::ErrorCode error_code) {
-  static const std::vector<const char*> kErrorNames{
-      "ERROR_NONE",           "ERROR_MEMORY_INVALID", "ERROR_UNWIND_INFO",
-      "ERROR_UNSUPPORTED",    "ERROR_INVALID_MAP",    "ERROR_MAX_FRAMES_EXCEEDED",
-      "ERROR_REPEATED_FRAME", "ERROR_INVALID_ELF"};
-  return kErrorNames[error_code];
+  return std::string(unwindstack::GetErrorCodeString(error_code));
 }
 
 }  // namespace orbit_linux_tracing

--- a/third_party/libunwindstack/include/unwindstack/Error.h
+++ b/third_party/libunwindstack/include/unwindstack/Error.h
@@ -69,6 +69,7 @@ static inline const char* GetErrorCodeString(ErrorCode error) {
     case ERROR_SYSTEM_CALL:
       return "System Call Failed";
   }
+  return "";
 }
 
 struct ErrorData {


### PR DESCRIPTION
In the recent libunwindstack version we are now using, additional
error codes have been added that cause issues for our own conversion
method to convert error codes to strings.

However there is now a library function in unwindstack/Error.h that we
can use to do the conversion. The converted strings are different from
what we had before, for example, "ERROR_NONE" is now "None".