### PR TITLE
Add OrbitServiceIntegrationTests with a couple of initial tests

### DIFF
--- a/src/LinuxTracingIntegrationTests/CMakeLists.txt
+++ b/src/LinuxTracingIntegrationTests/CMakeLists.txt
@@ -24,13 +24,19 @@ target_include_directories(IntegrationTestCommons PUBLIC ${CMAKE_CURRENT_SOURCE_
 
 target_sources(IntegrationTestCommons PRIVATE
         IntegrationTestChildProcess.h
+        IntegrationTestCommons.cpp
+        IntegrationTestCommons.h
         IntegrationTestPuppet.cpp
         IntegrationTestPuppet.h
+        IntegrationTestUtils.cpp
         IntegrationTestUtils.h)
 
 target_link_libraries(IntegrationTestCommons PUBLIC
+        GrpcProtos
+        ObjectUtils
         OrbitBase
         OffscreenRenderingVulkanTutorialLib
+        GTest::GTest
         CONAN_PKG::abseil)
 
 
@@ -52,3 +58,26 @@ target_link_libraries(LinuxTracingIntegrationTests PRIVATE
 strip_symbols(LinuxTracingIntegrationTests)
 
 register_test(LinuxTracingIntegrationTests)
+
+
+add_executable(OrbitServiceIntegrationTests)
+
+target_sources(OrbitServiceIntegrationTests PRIVATE
+        OrbitServiceIntegrationTest.cpp
+        IntegrationTestPuppet.cpp
+        IntegrationTestPuppet.h)
+
+target_link_libraries(OrbitServiceIntegrationTests PRIVATE
+        GrpcProtos
+        IntegrationTestCommons
+        ObjectUtils
+        OrbitBase
+        OrbitVersion
+        ServiceLib
+        GTest::GTest
+        GTest::Main
+        CONAN_PKG::abseil)
+
+strip_symbols(OrbitServiceIntegrationTests)
+
+register_test(OrbitServiceIntegrationTests)

--- a/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "IntegrationTestPuppet.h"
+#include "IntegrationTestUtils.h"
+#include "OrbitBase/Logging.h"
+#include "capture.pb.h"
+#include "symbol.pb.h"
+
+namespace orbit_linux_tracing_integration_tests {
+
+using PuppetConstants = IntegrationTestPuppetConstants;
+
+void AddPuppetOuterAndInnerFunctionToCaptureOptions(
+    orbit_grpc_protos::CaptureOptions* capture_options, pid_t pid, uint64_t outer_function_id,
+    uint64_t inner_function_id) {
+  // Find the offset in the ELF file of the "outer" function and the "inner" function and add those
+  // functions to the CaptureOptions to be instrumented.
+  const orbit_grpc_protos::ModuleSymbols& module_symbols = GetExecutableBinaryModuleSymbols(pid);
+  const std::filesystem::path& executable_path = GetExecutableBinaryPath(pid);
+
+  bool outer_function_symbol_found = false;
+  bool inner_function_symbol_found = false;
+  for (const orbit_grpc_protos::SymbolInfo& symbol : module_symbols.symbol_infos()) {
+    if (symbol.name() == PuppetConstants::kOuterFunctionName) {
+      CHECK(!outer_function_symbol_found);
+      outer_function_symbol_found = true;
+      orbit_grpc_protos::InstrumentedFunction instrumented_function;
+      instrumented_function.set_file_path(executable_path);
+      instrumented_function.set_file_offset(symbol.address() - module_symbols.load_bias());
+      instrumented_function.set_function_id(outer_function_id);
+      instrumented_function.set_function_size(symbol.size());
+      instrumented_function.set_function_name(symbol.name());
+      instrumented_function.set_record_return_value(true);
+      capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
+    }
+
+    if (symbol.name() == PuppetConstants::kInnerFunctionName) {
+      CHECK(!inner_function_symbol_found);
+      inner_function_symbol_found = true;
+      orbit_grpc_protos::InstrumentedFunction instrumented_function;
+      instrumented_function.set_file_path(executable_path);
+      instrumented_function.set_file_offset(symbol.address() - module_symbols.load_bias());
+      instrumented_function.set_function_id(inner_function_id);
+      instrumented_function.set_function_size(symbol.size());
+      instrumented_function.set_function_name(symbol.name());
+      instrumented_function.set_record_arguments(true);
+      capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
+    }
+  }
+  CHECK(outer_function_symbol_found);
+  CHECK(inner_function_symbol_found);
+}
+
+void VerifyFunctionCallsOfPuppetOuterAndInnerFunction(
+    const std::vector<orbit_grpc_protos::FunctionCall>& function_calls, uint32_t pid,
+    uint64_t outer_function_id, uint64_t inner_function_id,
+    bool expect_return_value_and_registers) {
+  for (const orbit_grpc_protos::FunctionCall& function_call : function_calls) {
+    ASSERT_EQ(function_call.pid(), pid);
+    ASSERT_EQ(function_call.tid(), pid);
+  }
+
+  // We expect an ordered sequence of kInnerFunctionCallCount calls to the "inner" function followed
+  // by one call to the "outer" function, repeated kOuterFunctionCallCount times.
+  ASSERT_EQ(function_calls.size(), PuppetConstants::kOuterFunctionCallCount +
+                                       PuppetConstants::kOuterFunctionCallCount *
+                                           PuppetConstants::kInnerFunctionCallCount);
+  size_t function_call_index = 0;
+  for (size_t outer_index = 0; outer_index < PuppetConstants::kOuterFunctionCallCount;
+       ++outer_index) {
+    uint64_t inner_calls_duration_ns_sum = 0;
+    for (size_t inner_index = 0; inner_index < PuppetConstants::kInnerFunctionCallCount;
+         ++inner_index) {
+      const orbit_grpc_protos::FunctionCall& function_call = function_calls[function_call_index];
+      EXPECT_EQ(function_call.function_id(), inner_function_id);
+      EXPECT_GT(function_call.duration_ns(), 0);
+      inner_calls_duration_ns_sum += function_call.duration_ns();
+      if (function_call_index > 0) {
+        EXPECT_GT(function_call.end_timestamp_ns(),
+                  function_calls[function_call_index - 1].end_timestamp_ns());
+      }
+      EXPECT_EQ(function_call.depth(), 1);
+      if (expect_return_value_and_registers) {
+        EXPECT_EQ(function_call.return_value(), 0);
+        EXPECT_THAT(function_call.registers(), testing::ElementsAre(1, 2, 3, 4, 5, 6));
+      } else {
+        EXPECT_EQ(function_call.return_value(), 0);
+        EXPECT_THAT(function_call.registers(), testing::ElementsAre());
+      }
+      ++function_call_index;
+    }
+
+    {
+      const orbit_grpc_protos::FunctionCall& function_call = function_calls[function_call_index];
+      EXPECT_EQ(function_call.function_id(), outer_function_id);
+      EXPECT_GT(function_call.duration_ns(), inner_calls_duration_ns_sum);
+      if (function_call_index > 0) {
+        EXPECT_GT(function_call.end_timestamp_ns(),
+                  function_calls[function_call_index - 1].end_timestamp_ns());
+      }
+      EXPECT_EQ(function_call.depth(), 0);
+      if (expect_return_value_and_registers) {
+        EXPECT_EQ(function_call.return_value(), PuppetConstants::kOuterFunctionReturnValue);
+        EXPECT_THAT(function_call.registers(), testing::ElementsAre());
+      } else {
+        EXPECT_EQ(function_call.return_value(), 0);
+        EXPECT_THAT(function_call.registers(), testing::ElementsAre());
+      }
+      ++function_call_index;
+    }
+  }
+}
+
+}  // namespace orbit_linux_tracing_integration_tests

--- a/src/LinuxTracingIntegrationTests/IntegrationTestCommons.h
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestCommons.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LINUX_TRACING_INTEGRATION_TESTS_INTEGRATION_TEST_COMMONS_H_
+#define LINUX_TRACING_INTEGRATION_TESTS_INTEGRATION_TEST_COMMONS_H_
+
+#include <sys/types.h>
+
+#include "capture.pb.h"
+
+namespace orbit_linux_tracing_integration_tests {
+
+// Adds `IntegrationTestPuppet`'s functions `OuterFunctionToInstrument` and
+// `InnerFunctionToInstrument` to the `CaptureOptions` as functions to dynamically instrument.
+// The details of the functions are retrieved by searching the debug symbols of the binary.
+void AddPuppetOuterAndInnerFunctionToCaptureOptions(
+    orbit_grpc_protos::CaptureOptions* capture_options, pid_t pid, uint64_t outer_function_id,
+    uint64_t inner_function_id);
+
+// Verifies the expectations on the number and content of the `FunctionCall` events produced when
+// dynamically instrumenting `IntegrationTestPuppet`'s functions `OuterFunctionToInstrument` and
+// `InnerFunctionToInstrument`.
+void VerifyFunctionCallsOfPuppetOuterAndInnerFunction(
+    const std::vector<orbit_grpc_protos::FunctionCall>& function_calls, uint32_t pid,
+    uint64_t outer_function_id, uint64_t inner_function_id, bool expect_return_value_and_registers);
+
+}  // namespace orbit_linux_tracing_integration_tests
+
+#endif  // LINUX_TRACING_INTEGRATION_TESTS_INTEGRATION_TEST_COMMONS_H_

--- a/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.cpp
@@ -101,6 +101,7 @@ static void RunVulkanTutorial() {
 }
 
 int IntegrationTestPuppetMain() {
+  LOG("Puppet started");
   while (!!std::cin && !std::cin.eof()) {
     std::string command;
     std::getline(std::cin, command);
@@ -126,6 +127,7 @@ int IntegrationTestPuppetMain() {
 
     std::cout << PuppetConstants::kDoneResponse << std::endl;
   }
+  LOG("Puppet finished");
   return 0;
 }
 

--- a/src/LinuxTracingIntegrationTests/IntegrationTestUtils.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestUtils.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "IntegrationTestUtils.h"
+
+#include <filesystem>
+
+#include "ObjectUtils/ElfFile.h"
+#include "ObjectUtils/LinuxMap.h"
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/ThreadUtils.h"
+#include "module.pb.h"
+#include "symbol.pb.h"
+
+namespace orbit_linux_tracing_integration_tests {
+
+std::filesystem::path GetExecutableBinaryPath(pid_t pid) {
+  auto error_or_executable_path =
+      orbit_base::GetExecutablePath(orbit_base::FromNativeProcessId(pid));
+  CHECK(error_or_executable_path.has_value());
+  return error_or_executable_path.value();
+}
+
+orbit_grpc_protos::ModuleSymbols GetExecutableBinaryModuleSymbols(pid_t pid) {
+  const std::filesystem::path& executable_path = GetExecutableBinaryPath(pid);
+
+  auto error_or_elf_file = orbit_object_utils::CreateElfFile(executable_path.string());
+  CHECK(error_or_elf_file.has_value());
+  const std::unique_ptr<orbit_object_utils::ElfFile>& elf_file = error_or_elf_file.value();
+
+  auto error_or_module = elf_file->LoadDebugSymbols();
+  CHECK(error_or_module.has_value());
+  return error_or_module.value();
+}
+
+orbit_grpc_protos::ModuleInfo GetExecutableBinaryModuleInfo(pid_t pid) {
+  auto error_or_module_infos = orbit_object_utils::ReadModules(pid);
+  CHECK(error_or_module_infos.has_value());
+  const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos = error_or_module_infos.value();
+
+  const std::filesystem::path& executable_path = GetExecutableBinaryPath(pid);
+
+  const orbit_grpc_protos::ModuleInfo* executable_module_info = nullptr;
+  for (const auto& module_info : module_infos) {
+    if (module_info.file_path() == executable_path) {
+      executable_module_info = &module_info;
+      break;
+    }
+  }
+  CHECK(executable_module_info != nullptr);
+  return *executable_module_info;
+}
+
+}  // namespace orbit_linux_tracing_integration_tests

--- a/src/LinuxTracingIntegrationTests/IntegrationTestUtils.h
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestUtils.h
@@ -6,12 +6,14 @@
 #define LINUX_TRACING_INTEGRATION_TESTS_INTEGRATION_TEST_UTILS_H_
 
 #include <absl/strings/match.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <string>
 
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/ReadFileToString.h"
+#include "module.pb.h"
+#include "symbol.pb.h"
 
 namespace orbit_linux_tracing_integration_tests {
 
@@ -25,6 +27,12 @@ namespace orbit_linux_tracing_integration_tests {
   ERROR("Root required for this test");
   return false;
 }
+
+[[nodiscard]] std::filesystem::path GetExecutableBinaryPath(pid_t pid);
+
+[[nodiscard]] orbit_grpc_protos::ModuleSymbols GetExecutableBinaryModuleSymbols(pid_t pid);
+
+[[nodiscard]] orbit_grpc_protos::ModuleInfo GetExecutableBinaryModuleInfo(pid_t pid);
 
 }  // namespace orbit_linux_tracing_integration_tests
 

--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -1,0 +1,291 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/synchronization/mutex.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/create_channel.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "IntegrationTestChildProcess.h"
+#include "IntegrationTestCommons.h"
+#include "IntegrationTestPuppet.h"
+#include "IntegrationTestUtils.h"
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/ThreadUtils.h"
+#include "OrbitService.h"
+#include "OrbitVersion/OrbitVersion.h"
+#include "capture.pb.h"
+#include "services.grpc.pb.h"
+
+using orbit_grpc_protos::CaptureOptions;
+using orbit_grpc_protos::ClientCaptureEvent;
+
+namespace orbit_linux_tracing_integration_tests {
+
+namespace {
+
+// Note that the tests will behave unexpectedly if another instance of OrbitService is running on
+// the system.
+constexpr uint16_t kOrbitServicePort = 44765;
+
+int OrbitServiceMain() {
+  LOG("OrbitService started");
+  std::atomic<bool> exit_requested = false;
+  // OrbitService's loop terminates when EOF is received, no need to manipulate exit_requested.
+  orbit_service::OrbitService{kOrbitServicePort, /*dev_mode=*/false}.Run(&exit_requested);
+  LOG("OrbitService finished");
+  return 0;
+}
+
+class OrbitServiceIntegrationTestFixture {
+ public:
+  OrbitServiceIntegrationTestFixture()
+      : puppet_{&IntegrationTestPuppetMain}, orbit_service_{&OrbitServiceMain} {
+    std::this_thread::sleep_for(std::chrono::milliseconds{1000});
+  }
+
+  [[nodiscard]] pid_t GetPuppetPidNative() const { return puppet_.GetChildPidNative(); }
+  [[nodiscard]] uint32_t GetPuppetPid() const {
+    return orbit_base::FromNativeProcessId(GetPuppetPidNative());
+  }
+
+  [[nodiscard]] CaptureOptions BuildDefaultCaptureOptions() const {
+    CaptureOptions capture_options;
+    capture_options.set_trace_context_switches(true);
+    capture_options.set_pid(GetPuppetPid());
+    capture_options.set_samples_per_second(1000.0);
+    capture_options.set_stack_dump_size(65000);
+    capture_options.set_unwinding_method(CaptureOptions::kDwarf);
+    capture_options.set_dynamic_instrumentation_method(CaptureOptions::kKernelUprobes);
+    capture_options.set_trace_thread_state(true);
+    capture_options.set_trace_gpu_driver(true);
+    return capture_options;
+  }
+
+  [[nodiscard]] std::vector<ClientCaptureEvent> CaptureAndGetEvents(
+      std::string_view command_for_puppet, CaptureOptions capture_options) {
+    StartCapture(std::move(capture_options));
+    WaitForFirstEvent();
+
+    // We don't have a signal from OrbitService that all internal producers have started, and we
+    // can't have one for external producers, so let's sleep after CaptureStarted has been received.
+    constexpr std::chrono::milliseconds kSleepAfterFirstEvent{1000};
+    std::this_thread::sleep_for(kSleepAfterFirstEvent);
+
+    puppet_.WriteLine(command_for_puppet);
+    while (puppet_.ReadLine() != IntegrationTestPuppetConstants::kDoneResponse) continue;
+
+    // Some producers might miss some of the final data if we stop the capture immediately after the
+    // puppet is done.
+    constexpr std::chrono::milliseconds kSleepBeforeStopCapture{100};
+    std::this_thread::sleep_for(kSleepBeforeStopCapture);
+    return StopCaptureAndGetEvents();
+  }
+
+ private:
+  void StartCapture(CaptureOptions capture_options) {
+    CHECK(!capture_thread_.joinable());
+    capture_thread_ = std::thread(&OrbitServiceIntegrationTestFixture::CaptureThread, this,
+                                  std::move(capture_options));
+  }
+
+  [[nodiscard]] std::vector<ClientCaptureEvent> StopCaptureAndGetEvents() {
+    CHECK(capture_thread_.joinable());
+
+    {
+      absl::ReaderMutexLock lock{&capture_reader_writer_mutex_};
+      LOG("Stopping capture");
+      bool writes_done_succeeded = capture_reader_writer_->WritesDone();
+      CHECK(writes_done_succeeded);
+    }
+
+    capture_thread_.join();
+
+    std::vector<ClientCaptureEvent> events;
+    {
+      absl::MutexLock lock{&capture_events_mutex_};
+      events = std::move(capture_events_);
+      capture_events_.clear();
+    }
+    return events;
+  }
+
+  void CaptureThread(CaptureOptions capture_options) {
+    std::string address = absl::StrFormat("localhost:%u", kOrbitServicePort);
+    std::shared_ptr<grpc::Channel> channel =
+        grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
+    grpc::ClientContext context;
+    std::unique_ptr<orbit_grpc_protos::CaptureService::Stub> capture_service =
+        orbit_grpc_protos::CaptureService::NewStub(channel);
+
+    {
+      absl::WriterMutexLock lock{&capture_reader_writer_mutex_};
+      CHECK(capture_reader_writer_ == nullptr);
+      LOG("Starting capture");
+      capture_reader_writer_ = capture_service->Capture(&context);
+    }
+    {
+      absl::ReaderMutexLock lock{&capture_reader_writer_mutex_};
+      orbit_grpc_protos::CaptureRequest capture_request;
+      *capture_request.mutable_capture_options() = std::move(capture_options);
+      bool write_capture_request_result = capture_reader_writer_->Write(capture_request);
+      CHECK(write_capture_request_result);
+    }
+
+    LOG("Receiving events");
+    while (true) {
+      orbit_grpc_protos::CaptureResponse capture_response;
+      bool read_capture_response_result;
+      {
+        absl::ReaderMutexLock lock{&capture_reader_writer_mutex_};
+        read_capture_response_result = capture_reader_writer_->Read(&capture_response);
+      }
+
+      if (!read_capture_response_result) {
+        // This signals that CaptureService::Capture has returned.
+        break;
+      }
+      for (ClientCaptureEvent& event : *capture_response.mutable_capture_events()) {
+        absl::MutexLock lock{&capture_events_mutex_};
+        capture_events_.emplace_back(std::move(event));
+      }
+    }
+
+    LOG("Capture finished");
+    {
+      absl::WriterMutexLock lock{&capture_reader_writer_mutex_};
+      CHECK(capture_reader_writer_ != nullptr);
+      capture_reader_writer_ = nullptr;
+    }
+  }
+
+  void WaitForFirstEvent() {
+    absl::MutexLock lock{&capture_events_mutex_};
+    capture_events_mutex_.Await(absl::Condition(
+        +[](std::vector<ClientCaptureEvent>* capture_events) { return !capture_events->empty(); },
+        &capture_events_));
+    LOG("First ClientCaptureEvent received");
+  }
+
+  ChildProcess puppet_;
+  ChildProcess orbit_service_;
+
+  std::thread capture_thread_;
+  absl::Mutex capture_reader_writer_mutex_;
+  std::unique_ptr<grpc::ClientReaderWriter<orbit_grpc_protos::CaptureRequest,
+                                           orbit_grpc_protos::CaptureResponse>>
+      capture_reader_writer_ ABSL_GUARDED_BY(capture_reader_writer_mutex_);
+  absl::Mutex capture_events_mutex_;
+  std::vector<ClientCaptureEvent> capture_events_ ABSL_GUARDED_BY(capture_events_mutex_);
+};
+
+}  // namespace
+
+static void VerifyCaptureStartedEvent(const ClientCaptureEvent& event,
+                                      const CaptureOptions& original_capture_options) {
+  ASSERT_EQ(event.event_case(), ClientCaptureEvent::kCaptureStarted);
+  const orbit_grpc_protos::CaptureStarted& capture_started = event.capture_started();
+  EXPECT_EQ(capture_started.process_id(), original_capture_options.pid());
+  EXPECT_EQ(capture_started.executable_path(),
+            GetExecutableBinaryPath(original_capture_options.pid()));
+  EXPECT_NE(capture_started.capture_start_timestamp_ns(), 0);
+  EXPECT_NE(capture_started.capture_start_unix_time_ns(), 0);
+  EXPECT_EQ(capture_started.orbit_version_major(), orbit_version::GetVersion().major_version);
+  EXPECT_EQ(capture_started.orbit_version_minor(), orbit_version::GetVersion().minor_version);
+  EXPECT_EQ(capture_started.capture_options().SerializeAsString(),
+            original_capture_options.SerializeAsString());
+}
+
+static void VerifyClockResolutionEvent(const ClientCaptureEvent& event) {
+  ASSERT_EQ(event.event_case(), ClientCaptureEvent::kClockResolutionEvent);
+  const orbit_grpc_protos::ClockResolutionEvent& clock_resolution_event =
+      event.clock_resolution_event();
+  EXPECT_GT(clock_resolution_event.clock_resolution_ns(), 0);
+}
+
+static void VerifyCaptureFinishedEvent(const ClientCaptureEvent& event) {
+  ASSERT_EQ(event.event_case(), ClientCaptureEvent::kCaptureFinished);
+  const orbit_grpc_protos::CaptureFinished& capture_finished = event.capture_finished();
+  EXPECT_EQ(capture_finished.status(), orbit_grpc_protos::CaptureFinished::kSuccessful);
+  EXPECT_EQ(capture_finished.error_message(), "");
+}
+
+static void VerifyInitialAndFinalEvents(const std::vector<ClientCaptureEvent>& events,
+                                        const CaptureOptions& original_capture_options) {
+  ASSERT_GE(events.size(), 3);
+  VerifyCaptureStartedEvent(events.front(), original_capture_options);
+  VerifyClockResolutionEvent(events[1]);
+  VerifyCaptureFinishedEvent(events.back());
+}
+
+static void VerifyErrorEvents(const std::vector<ClientCaptureEvent>& events) {
+  bool errors_with_perf_event_open_event_found = false;
+  for (const ClientCaptureEvent& event : events) {
+    EXPECT_NE(event.event_case(), ClientCaptureEvent::kErrorEnablingOrbitApiEvent);
+    EXPECT_NE(event.event_case(), ClientCaptureEvent::kErrorEnablingUserSpaceInstrumentationEvent);
+    if (event.event_case() == ClientCaptureEvent::kErrorsWithPerfEventOpenEvent) {
+      errors_with_perf_event_open_event_found = true;
+    }
+    EXPECT_NE(event.event_case(), ClientCaptureEvent::kLostPerfRecordsEvent);
+    EXPECT_NE(event.event_case(), ClientCaptureEvent::kOutOfOrderEventsDiscardedEvent);
+    EXPECT_NE(event.event_case(),
+              ClientCaptureEvent::kWarningInstrumentingWithUserSpaceInstrumentationEvent);
+  }
+  EXPECT_EQ(errors_with_perf_event_open_event_found, !IsRunningAsRoot());
+}
+
+TEST(OrbitServiceIntegrationTest, CaptureSmoke) {
+  OrbitServiceIntegrationTestFixture fixture;
+  CaptureOptions capture_options = fixture.BuildDefaultCaptureOptions();
+  std::vector<ClientCaptureEvent> events =
+      fixture.CaptureAndGetEvents(IntegrationTestPuppetConstants::kSleepCommand, capture_options);
+
+  VerifyInitialAndFinalEvents(events, capture_options);
+  VerifyErrorEvents(events);
+}
+
+static void VerifyFunctionCallsOfOuterAndInnerFunction(
+    const std::vector<ClientCaptureEvent>& events, uint32_t pid, uint64_t outer_function_id,
+    uint64_t inner_function_id) {
+  std::vector<orbit_grpc_protos::FunctionCall> function_calls;
+  for (const ClientCaptureEvent& event : events) {
+    if (!event.has_function_call()) {
+      continue;
+    }
+    function_calls.emplace_back(event.function_call());
+  }
+
+  VerifyFunctionCallsOfPuppetOuterAndInnerFunction(function_calls, pid, outer_function_id,
+                                                   inner_function_id,
+                                                   /*expect_return_value_and_registers=*/false);
+}
+
+TEST(OrbitServiceIntegrationTest, FunctionCallsWithUserSpaceInstrumentation) {
+  if (!CheckIsRunningAsRoot()) {
+    GTEST_SKIP();
+  }
+
+  OrbitServiceIntegrationTestFixture fixture;
+  CaptureOptions capture_options = fixture.BuildDefaultCaptureOptions();
+  capture_options.set_dynamic_instrumentation_method(CaptureOptions::kUserSpaceInstrumentation);
+  constexpr uint64_t kOuterFunctionId = 1;
+  constexpr uint64_t kInnerFunctionId = 2;
+  AddPuppetOuterAndInnerFunctionToCaptureOptions(&capture_options, fixture.GetPuppetPidNative(),
+                                                 kOuterFunctionId, kInnerFunctionId);
+  std::vector<ClientCaptureEvent> events = fixture.CaptureAndGetEvents(
+      IntegrationTestPuppetConstants::kCallOuterFunctionCommand, capture_options);
+
+  VerifyInitialAndFinalEvents(events, capture_options);
+  VerifyErrorEvents(events);
+  VerifyFunctionCallsOfOuterAndInnerFunction(events, fixture.GetPuppetPid(), kOuterFunctionId,
+                                             kInnerFunctionId);
+}
+
+}  // namespace orbit_linux_tracing_integration_tests


### PR DESCRIPTION
The idea is similar to `LinuxTracingIntegrationTests` but covering
`OrbitService` as a whole from the gRPC `CaptureService` level.
We start with a basic smoke test and a simple test for user space
instrumentation.
Some code from `LinuxTracingIntegrationTests` is factored out and reused.
I'm not renaming the module (directory name and namespace) for now.

Bug: http://b/206081462

Test: Run `OrbitServiceIntegrationTests` a hundred times. Also run
`LinuxTracingIntegrationTests`.