### PR TITLE
Limit the maximum granularity of the time interval

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -172,11 +172,12 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_normalized_y_position
 }
 
 void TimeGraph::SetMinMax(double min_time_us, double max_time_us) {
-  const double kTimeGraphMinTimeWindowsUs = 0.1; /* 100 ns */
-  double desired_time_window = std::max(max_time_us - min_time_us, kTimeGraphMinTimeWindowsUs);
+  constexpr double kTimeGraphMinTimeWindowsUs = 0.1; /* 100 ns */
+  const double desired_time_window =
+      std::max(max_time_us - min_time_us, kTimeGraphMinTimeWindowsUs);
 
   // Centering the interval in screen.
-  double center_time_us = (max_time_us + min_time_us) / 2.;
+  const double center_time_us = (max_time_us + min_time_us) / 2.;
 
   min_time_us_ = std::max(center_time_us - desired_time_window / 2, 0.0);
   max_time_us_ = std::min(min_time_us_ + desired_time_window, GetCaptureTimeSpanUs());

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -148,10 +148,6 @@ void TimeGraph::ZoomTime(float zoom_value, double mouse_ratio) {
   double min_time_us = ref_time_us_ - scale * time_left;
   double max_time_us = ref_time_us_ + scale * time_right;
 
-  if (max_time_us - min_time_us < 0.001 /*1 ns*/) {
-    return;
-  }
-
   SetMinMax(min_time_us, max_time_us);
 }
 
@@ -176,8 +172,13 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_normalized_y_position
 }
 
 void TimeGraph::SetMinMax(double min_time_us, double max_time_us) {
-  double desired_time_window = max_time_us - min_time_us;
-  min_time_us_ = std::max(min_time_us, 0.0);
+  const double kTimeGraphMinTimeWindowsUs = 0.1; /* 100 ns */
+  double desired_time_window = std::max(max_time_us - min_time_us, kTimeGraphMinTimeWindowsUs);
+
+  // Centering the interval in screen.
+  double center_time_us = (max_time_us + min_time_us) / 2.;
+
+  min_time_us_ = std::max(center_time_us - desired_time_window / 2, 0.0);
   max_time_us_ = std::min(min_time_us_ + desired_time_window, GetCaptureTimeSpanUs());
 
   RequestUpdate();


### PR DESCRIPTION
Discussed once in the daily meeting. We agreed to have minimum 1 ns per
pixel to avoid visual issues but after seeing that we could have some
function calls of 50ns duration and some discussions, I decided to limit
100ns to the whole visible capture. If we try to zoom to a smaller
interval, we will center that interval in the minimum time range.

This PR is moving that new limit to the SetMinMax function to be
consistent. Before we had:

- 1 ns limit for zooming with mouse wheel
- no limit with ctrl + mouse right click

We have some issues when zooming-in a lot (Timers: http://b/168283058,
ThreadStates: http://b/200905941, and I even have a crash with ctrl + mouse
right click). They won't appear anymore after this PR.

PS: As a limitation, the overlay who is generated when holding mouse right
click is still rounded to an integer nanoseconds and this rounded is still
visible with 100ns total time range, as we can see in the screenshot:
http://screen/3x9qPTZWJsjnEQo. Anyway, it's not too drastic with 100ns and
I will consider that expected behaviour.

Test: several interactions in a loaded capture.