### PR TITLE
Add ggp default account retrieval

### DIFF
--- a/src/OrbitGgp/Account.cpp
+++ b/src/OrbitGgp/Account.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitGgp/Account.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_ggp {
+
+ErrorMessageOr<Account> Account::GetDefaultAccountFromJson(const QByteArray& json) {
+  const QJsonDocument doc = QJsonDocument::fromJson(json);
+
+  if (!doc.isArray()) return ErrorMessage{"Unable to parse JSON: Array expected."};
+
+  for (const auto& array_entry : doc.array()) {
+    if (!array_entry.isObject()) return ErrorMessage{"Unable to parse JSON: Object expected."};
+
+    const QJsonObject obj{array_entry.toObject()};
+
+    if (!obj.contains("default")) {
+      return ErrorMessage{"Unable to parse JSON: \"default\" key missing."};
+    }
+
+    if (obj.value("default").toString() != "yes") continue;
+
+    if (!obj.contains("account")) {
+      return ErrorMessage{"Unable to parse JSON: \"account\" key missing."};
+    }
+
+    return Account{obj.value("account").toString()};
+  }
+  return ErrorMessage{"Failed to find default ggp account."};
+}
+
+}  // namespace orbit_ggp

--- a/src/OrbitGgp/AccountTest.cpp
+++ b/src/OrbitGgp/AccountTest.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitGgp/Account.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_ggp {
+
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasValue;
+
+TEST(OrbitGgpProject, GetDefaultAccountFromJson) {
+  {  // invalid json
+    const auto json = QString("json").toUtf8();
+    EXPECT_THAT(Account::GetDefaultAccountFromJson(json), HasError("Unable to parse JSON"));
+  }
+
+  {  // empty array
+    const auto json = QString("[]").toUtf8();
+    EXPECT_THAT(Account::GetDefaultAccountFromJson(json),
+                HasError("Failed to find default ggp account."));
+  }
+
+  {  // not an object in array
+    const auto json = QString("[5]").toUtf8();
+    EXPECT_THAT(Account::GetDefaultAccountFromJson(json),
+                HasError("Unable to parse JSON: Object expected."));
+  }
+
+  {  // object does not contain default key
+    const auto json = QString("[{}]").toUtf8();
+    EXPECT_THAT(Account::GetDefaultAccountFromJson(json),
+                HasError("Unable to parse JSON: \"default\" key missing."));
+  }
+
+  {  // object does not contain account key
+    const auto json = QString(R"([{"default": "yes"}])").toUtf8();
+    EXPECT_THAT(Account::GetDefaultAccountFromJson(json),
+                HasError("Unable to parse JSON: \"account\" key missing."));
+  }
+
+  {  // object does not contain a default account
+    const auto json = QString(R"([{"default": "no", "account": "username@email.com"}])").toUtf8();
+    EXPECT_THAT(Account::GetDefaultAccountFromJson(json),
+                HasError("Failed to find default ggp account."));
+  }
+
+  {  // object does contain a default account
+    const auto json = QString(R"([{"default": "yes", "account": "username@email.com"}])").toUtf8();
+    const auto result = Account::GetDefaultAccountFromJson(json);
+    ASSERT_THAT(result, HasValue());
+    EXPECT_EQ(result.value().email, "username@email.com");
+  }
+
+  {  // object does contain mutliple accounts
+    const auto json =
+        QString(
+            R"([{"default": "no", "account": "wrongaccount@email.com"},{"default": "yes", "account": "username@email.com"}])")
+            .toUtf8();
+    const auto result = Account::GetDefaultAccountFromJson(json);
+    ASSERT_THAT(result, HasValue());
+    EXPECT_EQ(result.value().email, "username@email.com");
+  }
+}
+
+}  // namespace orbit_ggp

--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(OrbitGgp PUBLIC
           ${CMAKE_CURRENT_LIST_DIR}/include)
 
 target_sources(OrbitGgp PUBLIC
+          include/OrbitGgp/Account.h
           include/OrbitGgp/Client.h
           include/OrbitGgp/Error.h
           include/OrbitGgp/Instance.h
@@ -18,6 +19,7 @@ target_sources(OrbitGgp PUBLIC
           include/OrbitGgp/SshInfo.h)
 
 target_sources(OrbitGgp PRIVATE
+          Account.cpp
           Client.cpp
           Error.cpp
           Instance.cpp
@@ -46,6 +48,7 @@ target_sources(OrbitMockGgpWorking PRIVATE MockGgp/Working.cpp)
 add_executable(OrbitGgpTests)
 
 target_sources(OrbitGgpTests PRIVATE 
+          AccountTest.cpp
           ClientTest.cpp
           InstanceTests.cpp
           InstanceItemModelTests.cpp

--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -50,6 +50,7 @@ class ClientImpl : public Client, public QObject {
   Future<ErrorMessageOr<QVector<Project>>> GetProjectsAsync() override;
   Future<ErrorMessageOr<Project>> GetDefaultProjectAsync() override;
   Future<ErrorMessageOr<Instance>> DescribeInstanceAsync(const QString& instance_id) override;
+  Future<ErrorMessageOr<Account>> GetDefaultAccountAsync() override;
 
  private:
   const QString ggp_program_;
@@ -164,6 +165,16 @@ Future<ErrorMessageOr<Instance>> ClientImpl::DescribeInstanceAsync(const QString
   return orbit_qt_utils::ExecuteProcess(ggp_program_, arguments, this, absl::FromChrono(timeout_))
       .ThenIfSuccess(&executor, [](const QByteArray& json) -> ErrorMessageOr<Instance> {
         return Instance::CreateFromJson(json);
+      });
+}
+
+Future<ErrorMessageOr<Account>> ClientImpl::GetDefaultAccountAsync() {
+  QStringList arguments{"auth", "list", "-s"};
+
+  orbit_base::ImmediateExecutor executor;
+  return orbit_qt_utils::ExecuteProcess(ggp_program_, arguments, this, absl::FromChrono(timeout_))
+      .ThenIfSuccess(&executor, [](const QByteArray& json) -> ErrorMessageOr<Account> {
+        return Account::GetDefaultAccountFromJson(json);
       });
 }
 

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -15,6 +15,7 @@
 #include "OrbitBase/Future.h"
 #include "OrbitBase/ImmediateExecutor.h"
 #include "OrbitBase/Result.h"
+#include "OrbitGgp/Account.h"
 #include "OrbitGgp/Client.h"
 #include "OrbitGgp/Instance.h"
 #include "OrbitGgp/Project.h"
@@ -469,6 +470,26 @@ TEST_F(OrbitGgpClientTest, DescribeInstanceAsyncWorkingForInvalidInstance) {
                 ASSERT_THAT(instance, HasError("Unable to parse JSON"));
                 QCoreApplication::exit();
               });
+
+  QCoreApplication::exec();
+
+  EXPECT_TRUE(future_is_resolved);
+}
+
+TEST_F(OrbitGgpClientTest, GetAccountAsyncWorking) {
+  auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
+  ASSERT_THAT(client, HasValue());
+
+  bool future_is_resolved = false;
+
+  client.value()->GetDefaultAccountAsync().Then(
+      main_thread_executor_.get(), [&future_is_resolved](ErrorMessageOr<Account> account) {
+        EXPECT_FALSE(future_is_resolved);
+        future_is_resolved = true;
+        ASSERT_THAT(account, HasValue());
+        EXPECT_EQ(account.value().email, "username@email.com");
+        QCoreApplication::exit();
+      });
 
   QCoreApplication::exec();
 

--- a/src/OrbitGgp/MockGgp/Working.cpp
+++ b/src/OrbitGgp/MockGgp/Working.cpp
@@ -197,6 +197,21 @@ int GgpInstance(int argc, char* argv[]) {
   return 1;
 }
 
+int GgpAuth(int argc, char* argv[]) {
+  if (argc != 4) {
+    std::cout << "Wrong amount of arguments" << std::endl;
+    return 1;
+  }
+  if (std::string_view{argv[1]} != "auth" || std::string_view{argv[2]} != "list" ||
+      std::string_view{argv[3]} != "-s") {
+    std::cout << "arguments are formatted wrong" << std::endl;
+    return 1;
+  }
+
+  std::cout << R"([{"default":"yes", "account":"username@email.com"}])" << std::endl;
+  return 0;
+}
+
 int main(int argc, char* argv[]) {
   // This sleep is here for 2 reasons:
   // 1. The ggp cli which this program is mocking, does have quite a bit of delay, hence having a
@@ -227,6 +242,10 @@ int main(int argc, char* argv[]) {
 
   if (std::string_view{argv[1]} == "config") {
     return GgpConfig(argc, argv);
+  }
+
+  if (std::string_view{argv[1]} == "auth") {
+    return GgpAuth(argc, argv);
   }
 
   std::cout << "arguments are formatted wrong" << std::endl;

--- a/src/OrbitGgp/ProjectTest.cpp
+++ b/src/OrbitGgp/ProjectTest.cpp
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 #include <gtest/gtest.h>
-#include <qvector.h>
 
 #include <QString>
+#include <QVector>
 
 #include "OrbitGgp/Project.h"
 #include "TestUtils/TestUtils.h"

--- a/src/OrbitGgp/include/OrbitGgp/Account.h
+++ b/src/OrbitGgp/include/OrbitGgp/Account.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GPP_ACCOUNT_H_
+#define ORBIT_GPP_ACCOUNT_H_
+
+#include <QString>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_ggp {
+
+struct Account {
+  QString email;
+
+  static ErrorMessageOr<Account> GetDefaultAccountFromJson(const QByteArray& json);
+};
+
+}  // namespace orbit_ggp
+
+#endif  // ORBIT_GPP_ACCOUNT_H_

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 
+#include "Account.h"
 #include "Instance.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Result.h"
@@ -45,6 +46,7 @@ class Client {
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Project>> GetDefaultProjectAsync() = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Instance>> DescribeInstanceAsync(
       const QString& instance_id) = 0;
+  [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Account>> GetDefaultAccountAsync() = 0;
 };
 
 [[nodiscard]] std::chrono::milliseconds GetClientDefaultTimeoutInMs();

--- a/src/SessionSetup/RetrieveInstancesTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesTest.cpp
@@ -46,6 +46,7 @@ class MockGgpClient : public orbit_ggp::Client {
   MOCK_METHOD(Future<ErrorMessageOr<Project>>, GetDefaultProjectAsync, (), (override));
   MOCK_METHOD(Future<ErrorMessageOr<Instance>>, DescribeInstanceAsync,
               (const QString& /*instance_id*/), (override));
+  MOCK_METHOD(Future<ErrorMessageOr<orbit_ggp::Account>>, GetDefaultAccountAsync, (), (override));
 };
 
 namespace {


### PR DESCRIPTION
This adds orbit_ggp::Account and modifies the creation of orbit_ggp::Client to return the default user account. This will be later used to display a warning when the user connects to an instance of someone else. 

http://b/206103747