### PR TITLE
Increase readability of metrics OrbitLogEvent

### DIFF
--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -383,8 +383,7 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
           app_->GetCaptureData().GetFunctionStatsOrDefault(instrumented_function_id);
       if (stats.count() > 0) {
         live_functions_->AddIterator(instrumented_function_id, &instrumented_function);
-        metrics_uploader_->SendLogEvent(
-            orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_ITERATOR_ADD);
+        metrics_uploader_->SendLogEvent(orbit_metrics_uploader::OrbitLogEvent::ORBIT_ITERATOR_ADD);
       }
     }
   } else if (action == kMenuActionEnableFrameTrack) {

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -183,7 +183,7 @@ void PresetsDataView::OnContextMenu(const std::string& action, int menu_index,
 
   } else if (action == kMenuActionDelete) {
     orbit_metrics_uploader::ScopedMetric metric{
-        metrics_uploader_, orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_PRESET_DELETE};
+        metrics_uploader_, orbit_metrics_uploader::OrbitLogEvent::ORBIT_PRESET_DELETE};
     int row = item_indices[0];
     const PresetFile& preset = GetPreset(row);
     const std::string& filename = preset.file_path().string();

--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -250,7 +250,7 @@ bool MetricsUploaderImpl::SendLogEvent(OrbitLogEvent_LogEventType log_event_type
 bool MetricsUploaderImpl::SendCaptureEvent(OrbitCaptureData capture_data,
                                            OrbitLogEvent_StatusCode status_code) {
   OrbitLogEvent log_event;
-  log_event.set_log_event_type(OrbitLogEvent_LogEventType_ORBIT_CAPTURE_END);
+  log_event.set_log_event_type(OrbitLogEvent::ORBIT_CAPTURE_END);
   *log_event.mutable_orbit_capture_data() = std::move(capture_data);
   log_event.set_status_code(status_code);
   return FillAndSendLogEvent(log_event);

--- a/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
@@ -48,14 +48,14 @@ TEST(MetricsUploader, SetupMetricsUploaderWithError) {
 TEST(MetricsUploader, SendLogEvent) {
   auto metrics_uploader = MetricsUploader::CreateMetricsUploader("MetricsUploaderCompleteClient");
   EXPECT_FALSE(IsMetricsUploaderStub(metrics_uploader));
-  bool result = metrics_uploader->SendLogEvent(OrbitLogEvent_LogEventType_UNKNOWN_EVENT_TYPE);
+  bool result = metrics_uploader->SendLogEvent(OrbitLogEvent::UNKNOWN_EVENT_TYPE);
   EXPECT_FALSE(result);
-  result = metrics_uploader->SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN);
+  result = metrics_uploader->SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN);
   EXPECT_TRUE(result);
-  result = metrics_uploader->SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_CAPTURE_DURATION,
+  result = metrics_uploader->SendLogEvent(OrbitLogEvent::ORBIT_CAPTURE_DURATION,
                                           std::chrono::milliseconds(100));
   EXPECT_TRUE(result);
-  result = metrics_uploader->SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN,
+  result = metrics_uploader->SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN,
                                           std::chrono::milliseconds(0),
                                           OrbitLogEvent_StatusCode_SUCCESS);
   EXPECT_TRUE(result);

--- a/src/MetricsUploader/ScopedMetricTest.cpp
+++ b/src/MetricsUploader/ScopedMetricTest.cpp
@@ -34,26 +34,26 @@ class MockUploader : public MetricsUploader {
 };
 
 TEST(ScopedMetric, Constructor) {
-  { ScopedMetric metric{nullptr, OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN}; }
+  { ScopedMetric metric{nullptr, OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN}; }
 
   MockUploader uploader{};
 
-  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN, _,
+  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN, _,
                                      OrbitLogEvent_StatusCode_SUCCESS))
       .Times(1);
 
-  { ScopedMetric metric{&uploader, OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN}; }
+  { ScopedMetric metric{&uploader, OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN}; }
 }
 
 TEST(ScopedMetric, SetStatusCode) {
   MockUploader uploader{};
 
-  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN, _,
+  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN, _,
                                      OrbitLogEvent_StatusCode_CANCELLED))
       .Times(1);
 
   {
-    ScopedMetric metric{&uploader, OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN};
+    ScopedMetric metric{&uploader, OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN};
     metric.SetStatusCode(OrbitLogEvent_StatusCode_CANCELLED);
   }
 }
@@ -63,12 +63,12 @@ TEST(ScopedMetric, Sleep) {
 
   std::chrono::milliseconds sleep_time{1};
 
-  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN,
-                                     Ge(sleep_time), OrbitLogEvent_StatusCode_SUCCESS))
+  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN, Ge(sleep_time),
+                                     OrbitLogEvent_StatusCode_SUCCESS))
       .Times(1);
 
   {
-    ScopedMetric metric{&uploader, OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN};
+    ScopedMetric metric{&uploader, OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN};
     std::this_thread::sleep_for(sleep_time);
   }
 }
@@ -78,12 +78,12 @@ TEST(ScopedMetric, MoveAndSleep) {
 
   std::chrono::milliseconds sleep_time{1};
 
-  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN,
-                                     Ge(sleep_time * 2), OrbitLogEvent_StatusCode_SUCCESS))
+  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN, Ge(sleep_time * 2),
+                                     OrbitLogEvent_StatusCode_SUCCESS))
       .Times(1);
 
   {
-    ScopedMetric metric{&uploader, OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN};
+    ScopedMetric metric{&uploader, OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN};
     std::this_thread::sleep_for(sleep_time);
 
     [metric = std::move(metric), sleep_time]() { std::this_thread::sleep_for(sleep_time); }();

--- a/src/MetricsUploader/TestClients/CompleteClient.cpp
+++ b/src/MetricsUploader/TestClients/CompleteClient.cpp
@@ -8,8 +8,6 @@
 #include "orbit_log_event.pb.h"
 
 using orbit_metrics_uploader::OrbitLogEvent;
-using orbit_metrics_uploader::OrbitLogEvent::UNKNOWN_EVENT_TYPE;
-
 using orbit_metrics_uploader::Result;
 
 extern "C" {

--- a/src/MetricsUploader/TestClients/CompleteClient.cpp
+++ b/src/MetricsUploader/TestClients/CompleteClient.cpp
@@ -8,7 +8,7 @@
 #include "orbit_log_event.pb.h"
 
 using orbit_metrics_uploader::OrbitLogEvent;
-using orbit_metrics_uploader::OrbitLogEvent_LogEventType_UNKNOWN_EVENT_TYPE;
+using orbit_metrics_uploader::OrbitLogEvent::UNKNOWN_EVENT_TYPE;
 
 using orbit_metrics_uploader::Result;
 
@@ -21,7 +21,7 @@ __declspec(dllexport) enum Result SendOrbitLogEvent(uint8_t* serialized_proto, i
   if (!result) {
     return Result::kCannotUnmarshalLogEvent;
   }
-  if (log_event.log_event_type() == OrbitLogEvent_LogEventType_UNKNOWN_EVENT_TYPE) {
+  if (log_event.log_event_type() == OrbitLogEvent::UNKNOWN_EVENT_TYPE) {
     return Result::kCannotQueueLogEvent;
   }
   return Result::kNoError;

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -88,10 +88,10 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
   std::unique_ptr<orbit_metrics_uploader::MetricsUploader> metrics_uploader =
       orbit_metrics_uploader::MetricsUploader::CreateMetricsUploader();
   metrics_uploader->SendLogEvent(
-      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_METRICS_UPLOADER_START);
+      orbit_metrics_uploader::OrbitLogEvent::ORBIT_METRICS_UPLOADER_START);
 
-  orbit_metrics_uploader::ScopedMetric metric{
-      metrics_uploader.get(), orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_EXIT};
+  orbit_metrics_uploader::ScopedMetric metric{metrics_uploader.get(),
+                                              orbit_metrics_uploader::OrbitLogEvent::ORBIT_EXIT};
 
   // If Orbit starts with loading a capture file, we skip SessionSetupDialog and create a
   // FileTarget from capture_file_path. After creating the FileTarget, we reset

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1093,8 +1093,7 @@ void OrbitApp::SetClipboard(const std::string& text) {
 }
 
 ErrorMessageOr<void> OrbitApp::OnSavePreset(const std::string& filename) {
-  ScopedMetric metric{metrics_uploader_,
-                      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_PRESET_SAVE};
+  ScopedMetric metric{metrics_uploader_, orbit_metrics_uploader::OrbitLogEvent::ORBIT_PRESET_SAVE};
   auto save_result = SavePreset(filename);
   if (save_result.has_error()) {
     metric.SetStatusCode(orbit_metrics_uploader::OrbitLogEvent_StatusCode_INTERNAL_ERROR);
@@ -1441,8 +1440,8 @@ void OrbitApp::StopCapture() {
   auto capture_time_us =
       std::chrono::duration<double, std::micro>(GetTimeGraph()->GetCaptureTimeSpanUs());
   auto capture_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(capture_time_us);
-  metrics_uploader_->SendLogEvent(
-      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_CAPTURE_DURATION, capture_time_ms);
+  metrics_uploader_->SendLogEvent(orbit_metrics_uploader::OrbitLogEvent::ORBIT_CAPTURE_DURATION,
+                                  capture_time_ms);
 
   CHECK(capture_stop_requested_callback_);
   capture_stop_requested_callback_();
@@ -1615,8 +1614,7 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::RetrieveModuleAndLoadSymbols(
 
 orbit_base::Future<ErrorMessageOr<void>> OrbitApp::RetrieveModuleAndLoadSymbols(
     const std::string& module_path, const std::string& build_id) {
-  ScopedMetric metric(metrics_uploader_,
-                      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_SYMBOL_LOAD);
+  ScopedMetric metric(metrics_uploader_, orbit_metrics_uploader::OrbitLogEvent::ORBIT_SYMBOL_LOAD);
 
   const ModuleData* const module_data = GetModuleByPathAndBuildId(module_path, build_id);
   if (module_data == nullptr) {
@@ -1987,8 +1985,7 @@ void OrbitApp::EnableFrameTracksByName(const ModuleData* module,
 }
 
 void OrbitApp::LoadPreset(const PresetFile& preset_file) {
-  ScopedMetric metric{metrics_uploader_,
-                      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_PRESET_LOAD};
+  ScopedMetric metric{metrics_uploader_, orbit_metrics_uploader::OrbitLogEvent::ORBIT_PRESET_LOAD};
   std::vector<orbit_base::Future<std::string>> load_module_results{};
   auto module_paths = preset_file.GetModulePaths();
   load_module_results.reserve(module_paths.size());

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -196,8 +196,7 @@ void LiveFunctionsController::OnPreviousButton(uint64_t id) {
 void LiveFunctionsController::OnDeleteButton(uint64_t id) {
   current_timer_infos_.erase(id);
   iterator_id_to_function_id_.erase(id);
-  metrics_uploader_->SendLogEvent(
-      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_ITERATOR_REMOVE);
+  metrics_uploader_->SendLogEvent(orbit_metrics_uploader::OrbitLogEvent::ORBIT_ITERATOR_REMOVE);
 
   // If we erase the iterator that was last used by the user, then
   // we need to switch last_id_pressed_ to an existing id.

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -196,8 +196,7 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
 
   LoadCaptureOptionsIntoApp();
 
-  metrics_uploader_->SendLogEvent(
-      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN);
+  metrics_uploader_->SendLogEvent(orbit_metrics_uploader::OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN);
 
   // SymbolPaths.txt deprecation code
   // If file does not exist, do nothing. (It means the user never used an older Orbit version or
@@ -1475,8 +1474,7 @@ void OrbitMainWindow::Exit(int return_code) {
     introspection_widget_->close();
   }
 
-  metrics_uploader_->SendLogEvent(
-      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_CLOSE);
+  metrics_uploader_->SendLogEvent(orbit_metrics_uploader::OrbitLogEvent::ORBIT_MAIN_WINDOW_CLOSE);
 
   QApplication::exit(return_code);
 }

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -564,7 +564,7 @@ void ServiceDeployManager::StartWatchdog() {
 outcome::result<ServiceDeployManager::GrpcPort> ServiceDeployManager::Exec(
     orbit_metrics_uploader::MetricsUploader* metrics_uploader) {
   orbit_metrics_uploader::ScopedMetric connect_metric{
-      metrics_uploader, orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_INSTANCE_CONNECT};
+      metrics_uploader, orbit_metrics_uploader::OrbitLogEvent::ORBIT_INSTANCE_CONNECT};
 
   outcome::result<GrpcPort> result = outcome::success(GrpcPort{0});
   DeferToBackgroundThreadAndWait(this, [&]() { result = ExecImpl(); });

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -146,7 +146,7 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
   }
 
   metrics_uploader_->SendLogEvent(
-      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_SESSION_SETUP_WINDOW_OPEN);
+      orbit_metrics_uploader::OrbitLogEvent::ORBIT_SESSION_SETUP_WINDOW_OPEN);
 }
 
 void SessionSetupDialog::SetStateMachineInitialState() {
@@ -176,7 +176,7 @@ std::optional<TargetConfiguration> SessionSetupDialog::Exec() {
   state_machine_.stop();
 
   metrics_uploader_->SendLogEvent(
-      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_SESSION_SETUP_WINDOW_CLOSE);
+      orbit_metrics_uploader::OrbitLogEvent::ORBIT_SESSION_SETUP_WINDOW_CLOSE);
 
   if (rc != QDialog::Accepted) return std::nullopt;
 


### PR DESCRIPTION
This replaces all occurrences of OrbitLogEvent_LogEventType_ with
OrbitLogEvent:: to increase readability.

Its a simple refactoring. TEST: build and unit tests still work