### PR TITLE
Retrieve instances widget metrics

### DIFF
--- a/src/SessionSetup/RetrieveInstances.cpp
+++ b/src/SessionSetup/RetrieveInstances.cpp
@@ -52,14 +52,14 @@ class RetrieveInstancesImpl : public RetrieveInstances {
   }
 
  private:
-  orbit_ggp::Client* ggp_client_;
+  orbit_ggp::Client* ggp_client_ = nullptr;
   // To avoid race conditions to the instance_cache_, the main thread is used.
-  MainThreadExecutor* main_thread_executor_;
+  MainThreadExecutor* main_thread_executor_ = nullptr;
   absl::flat_hash_map<
       std::pair<std::optional<orbit_ggp::Project>, orbit_ggp::Client::InstanceListScope>,
       QVector<orbit_ggp::Instance>>
       instance_cache_;
-  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_ = nullptr;
 };
 
 std::unique_ptr<RetrieveInstances> RetrieveInstances::Create(

--- a/src/SessionSetup/RetrieveInstancesWidget.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidget.cpp
@@ -21,6 +21,7 @@
 #include "QtUtils/MainThreadExecutorImpl.h"
 #include "SessionSetup/PersistentStorage.h"
 #include "SessionSetup/RetrieveInstances.h"
+#include "orbit_log_event.pb.h"
 #include "ui_RetrieveInstancesWidget.h"
 
 namespace orbit_session_setup {
@@ -207,6 +208,10 @@ std::optional<orbit_ggp::Project> RetrieveInstancesWidget::GetSelectedProject() 
 
 void RetrieveInstancesWidget::OnProjectComboBoxCurrentIndexChanged() {
   std::optional<Project> selected_project = GetSelectedProject();
+
+  if (metrics_uploader_ != nullptr) {
+    metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_PROJECT_CHANGED);
+  }
 
   emit LoadingStarted();
   retrieve_instances_->LoadInstances(selected_project, GetSelectedInstanceListScope())

--- a/src/SessionSetup/RetrieveInstancesWidget.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidget.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <optional>
 
+#include "MetricsUploader/ScopedMetric.h"
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/Client.h"
 #include "QtUtils/MainThreadExecutorImpl.h"
@@ -28,6 +29,8 @@ using orbit_ggp::Instance;
 using orbit_ggp::Project;
 using LoadProjectsAndInstancesResult = RetrieveInstances::LoadProjectsAndInstancesResult;
 using InstanceListScope = orbit_ggp::Client::InstanceListScope;
+using orbit_metrics_uploader::OrbitLogEvent;
+using orbit_metrics_uploader::ScopedMetric;
 
 RetrieveInstancesWidget::~RetrieveInstancesWidget() = default;
 
@@ -93,7 +96,15 @@ InstanceListScope RetrieveInstancesWidget::GetSelectedInstanceListScope() const 
 void RetrieveInstancesWidget::InitialLoad(const std::optional<Project>& remembered_project) {
   CHECK(ui_->projectComboBox->count() == 0);
   emit LoadingStarted();
+  ScopedMetric metric{metrics_uploader_, OrbitLogEvent::ORBIT_INSTANCES_INITIAL_LOAD};
   retrieve_instances_->LoadProjectsAndInstances(remembered_project, GetSelectedInstanceListScope())
+      .Then(main_thread_executor_.get(),
+            // The metric gets its own future continuation, so the time measured is only the
+            // time that the call took.
+            [metric = std::move(metric)](auto loading_result) mutable {
+              if (loading_result.has_error()) metric.SetStatusCode(OrbitLogEvent::INTERNAL_ERROR);
+              return loading_result;
+            })
       .Then(main_thread_executor_.get(),
             [this](ErrorMessageOr<LoadProjectsAndInstancesResult> loading_result) {
               // `this` still exists when this lambda is executed. This is enforced, because

--- a/src/SessionSetup/RetrieveInstancesWidget.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidget.cpp
@@ -31,17 +31,13 @@ using InstanceListScope = orbit_ggp::Client::InstanceListScope;
 
 RetrieveInstancesWidget::~RetrieveInstancesWidget() = default;
 
-RetrieveInstancesWidget::RetrieveInstancesWidget(RetrieveInstances* retrieve_instances,
-                                                 QWidget* parent)
+RetrieveInstancesWidget::RetrieveInstancesWidget(QWidget* parent)
     : QWidget(parent),
       ui_(std::make_unique<Ui::RetrieveInstancesWidget>()),
       main_thread_executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()),
-      retrieve_instances_(retrieve_instances),
       s_idle_(&state_machine_),
       s_loading_(&state_machine_),
       s_initial_loading_failed_(&state_machine_) {
-  CHECK(retrieve_instances != nullptr);
-
   ui_->setupUi(this);
 
   SetupStateMachine();
@@ -78,6 +74,7 @@ void RetrieveInstancesWidget::SetupStateMachine() {
 }
 
 void RetrieveInstancesWidget::Start() {
+  CHECK(retrieve_instances_ != nullptr);
   state_machine_.setInitialState(&s_loading_);
   state_machine_.start();
 

--- a/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
@@ -35,7 +35,9 @@ int main(int argc, char* argv[]) {
 
   RetrieveInstancesWidget widget{};
 
-  widget.SetRetrieveInstances(RetrieveInstances::Create(client_ptr, executor.get()));
+  std::unique_ptr<RetrieveInstances> retrieve_instances =
+      RetrieveInstances::Create(client_ptr, executor.get());
+  widget.SetRetrieveInstances(retrieve_instances.get());
 
   QObject::connect(&widget, &RetrieveInstancesWidget::LoadingSuccessful, &widget,
                    [&widget](const QVector<orbit_ggp::Instance>& instances) {

--- a/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
@@ -33,10 +33,9 @@ int main(int argc, char* argv[]) {
   std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor{
       orbit_qt_utils::MainThreadExecutorImpl::Create()};
 
-  std::unique_ptr<RetrieveInstances> retrieve_instances =
-      RetrieveInstances::Create(client_ptr, executor.get());
+  RetrieveInstancesWidget widget{};
 
-  RetrieveInstancesWidget widget{retrieve_instances.get()};
+  widget.SetRetrieveInstances(RetrieveInstances::Create(client_ptr, executor.get()));
 
   QObject::connect(&widget, &RetrieveInstancesWidget::LoadingSuccessful, &widget,
                    [&widget](const QVector<orbit_ggp::Instance>& instances) {

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -292,6 +292,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulDefault) {
 
   widget_.Start();
   QCoreApplication::processEvents();
+  QCoreApplication::processEvents();
 
   VerifySuccessfulLoadAndUIState(kInitialTestDataDefault.instances);
   VerifyProjectComboBoxHoldsData(kInitialTestDataDefault);

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -123,7 +123,9 @@ const RetrieveInstances::LoadProjectsAndInstancesResult kInitialTestDataWithProj
 
 class RetrieveInstancesWidgetTest : public testing::Test {
  public:
-  RetrieveInstancesWidgetTest() : widget_(&mock_retrieve_instances_) {
+  RetrieveInstancesWidgetTest()
+      : mock_retrieve_instances_(std::make_shared<MockRetrieveInstances>()) {
+    widget_.SetRetrieveInstances(mock_retrieve_instances_);
     filter_line_edit_ = widget_.findChild<QLineEdit*>("filterLineEdit");
     all_check_box_ = widget_.findChild<QCheckBox*>("allCheckBox");
     project_combo_box_ = widget_.findChild<QComboBox*>("projectComboBox");
@@ -230,7 +232,7 @@ class RetrieveInstancesWidgetTest : public testing::Test {
     VerifyAllElementsAreEnabled();
   }
 
-  MockRetrieveInstances mock_retrieve_instances_;
+  std::shared_ptr<MockRetrieveInstances> mock_retrieve_instances_;
   RetrieveInstancesWidget widget_;
   QLineEdit* filter_line_edit_ = nullptr;
   QCheckBox* all_check_box_ = nullptr;
@@ -247,7 +249,7 @@ class RetrieveInstancesWidgetTestStarted : public RetrieveInstancesWidgetTest {
   void SetUp() override {
     RetrieveInstancesWidgetTest::SetUp();
 
-    EXPECT_CALL(mock_retrieve_instances_,
+    EXPECT_CALL(*mock_retrieve_instances_,
                 LoadProjectsAndInstances(std::optional<Project>(std::nullopt),
                                          InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
         .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
@@ -279,7 +281,7 @@ TEST_F(RetrieveInstancesWidgetTest, FilterTextChanged) {
 }
 
 TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulDefault) {
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadProjectsAndInstances(std::optional<Project>(std::nullopt),
                                        InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
@@ -294,7 +296,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulDefault) {
 
 TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulWithRememberedSettings) {
   EXPECT_CALL(
-      mock_retrieve_instances_,
+      *mock_retrieve_instances_,
       LoadProjectsAndInstances(
           std::optional<Project>(kInitialTestDataWithProjectOfInstances.project_of_instances),
           InstanceListScope(InstanceListScope::kAllReservedInstances)))
@@ -314,7 +316,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulWithRememberedSettings) {
 }
 
 TEST_F(RetrieveInstancesWidgetTest, StartFailed) {
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadProjectsAndInstances(std::optional<Project>(std::nullopt),
                                        InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
@@ -335,7 +337,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartFailed) {
 }
 
 TEST_F(RetrieveInstancesWidgetTestStarted, ReloadSucceeds) {
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstancesWithoutCache(std::optional<Project>(std::nullopt),
                                         InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1)))
@@ -352,7 +354,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ReloadSucceeds) {
 }
 
 TEST_F(RetrieveInstancesWidgetTestStarted, ReloadFails) {
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstancesWithoutCache(std::optional<Project>(std::nullopt),
                                         InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(ErrorMessage{"error"})));
@@ -376,7 +378,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeSuccessful) {
   // "Test Project 1 (default)"
   // "Test Project 2"
 
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(kTestProject1),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1)));
@@ -393,7 +395,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeSuccessful) {
   // > "Test Project 1 (default)"
   // "Test Project 2"
 
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(std::nullopt),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1)));
@@ -410,7 +412,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeSuccessful) {
   // "Test Project 1 (default)"
   // "Test Project 2"
 
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(kTestProject2),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject2)));
@@ -437,7 +439,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeFailed) {
   // "Test Project 1 (default)"
   // "Test Project 2"
 
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(kTestProject1),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(ErrorMessage{"error"})));
@@ -462,11 +464,11 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeFailed) {
 }
 
 TEST_F(RetrieveInstancesWidgetTestStarted, AllCheckboxSuccessful) {
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(std::nullopt),
                             InstanceListScope(InstanceListScope::kAllReservedInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1All)));
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(std::nullopt),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1)));
@@ -487,7 +489,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, AllCheckboxSuccessful) {
 }
 
 TEST_F(RetrieveInstancesWidgetTestStarted, AllCheckboxFail) {
-  EXPECT_CALL(mock_retrieve_instances_,
+  EXPECT_CALL(*mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(std::nullopt),
                             InstanceListScope(InstanceListScope::kAllReservedInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(ErrorMessage{"error"})));

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -260,6 +260,7 @@ class RetrieveInstancesWidgetTestStarted : public RetrieveInstancesWidgetTest {
 
     widget_.Start();
     QCoreApplication::processEvents();
+    QCoreApplication::processEvents();
 
     VerifyAndClearSignalsOfSuccessfulLoadingCycle();
     VerifyAllElementsAreEnabled();
@@ -312,6 +313,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulWithRememberedSettings) {
 
   widget_.Start();
   QCoreApplication::processEvents();
+  QCoreApplication::processEvents();
 
   VerifySuccessfulLoadAndUIState(kInitialTestDataWithProjectOfInstances.instances);
   VerifyProjectComboBoxHoldsData(kInitialTestDataWithProjectOfInstances);
@@ -327,6 +329,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartFailed) {
           ErrorMessage{"error message"}}));
 
   widget_.Start();
+  QCoreApplication::processEvents();
 
   QMetaObject::invokeMethod(
       &widget_, []() { QCoreApplication::exit(); }, Qt::QueuedConnection);

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -259,6 +259,9 @@ class RetrieveInstancesWidgetTestStarted : public RetrieveInstancesWidgetTest {
             kInitialTestDataDefault}));
 
     widget_.Start();
+    // processEvents is needed twice here, because the events that are worked on by the first call,
+    // schedule more events onto the queue (via Future.Then(main_thread_executor, ...)). The second
+    // call then processes these additional events.
     QCoreApplication::processEvents();
     QCoreApplication::processEvents();
 
@@ -292,6 +295,9 @@ TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulDefault) {
           kInitialTestDataDefault}));
 
   widget_.Start();
+  // processEvents is needed twice here, because the events that are worked on by the first call,
+  // schedule more events onto the queue (via Future.Then(main_thread_executor, ...)). The second
+  // call then processes these additional events.
   QCoreApplication::processEvents();
   QCoreApplication::processEvents();
 
@@ -312,6 +318,9 @@ TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulWithRememberedSettings) {
   SaveInstancesScopeToPersistentStorage(InstanceListScope::kAllReservedInstances);
 
   widget_.Start();
+  // processEvents is needed twice here, because the events that are worked on by the first call,
+  // schedule more events onto the queue (via Future.Then(main_thread_executor, ...)). The second
+  // call then processes these additional events.
   QCoreApplication::processEvents();
   QCoreApplication::processEvents();
 

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -126,9 +126,8 @@ const RetrieveInstances::LoadProjectsAndInstancesResult kInitialTestDataWithProj
 
 class RetrieveInstancesWidgetTest : public testing::Test {
  public:
-  RetrieveInstancesWidgetTest()
-      : mock_retrieve_instances_(std::make_shared<MockRetrieveInstances>()) {
-    widget_.SetRetrieveInstances(mock_retrieve_instances_);
+  RetrieveInstancesWidgetTest() {
+    widget_.SetRetrieveInstances(&mock_retrieve_instances_);
     filter_line_edit_ = widget_.findChild<QLineEdit*>("filterLineEdit");
     all_check_box_ = widget_.findChild<QCheckBox*>("allCheckBox");
     project_combo_box_ = widget_.findChild<QComboBox*>("projectComboBox");
@@ -235,7 +234,7 @@ class RetrieveInstancesWidgetTest : public testing::Test {
     VerifyAllElementsAreEnabled();
   }
 
-  std::shared_ptr<MockRetrieveInstances> mock_retrieve_instances_;
+  MockRetrieveInstances mock_retrieve_instances_;
   RetrieveInstancesWidget widget_;
   QLineEdit* filter_line_edit_ = nullptr;
   QCheckBox* all_check_box_ = nullptr;
@@ -252,7 +251,7 @@ class RetrieveInstancesWidgetTestStarted : public RetrieveInstancesWidgetTest {
   void SetUp() override {
     RetrieveInstancesWidgetTest::SetUp();
 
-    EXPECT_CALL(*mock_retrieve_instances_,
+    EXPECT_CALL(mock_retrieve_instances_,
                 LoadProjectsAndInstances(std::optional<Project>(std::nullopt),
                                          InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
         .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
@@ -288,7 +287,7 @@ TEST_F(RetrieveInstancesWidgetTest, FilterTextChanged) {
 }
 
 TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulDefault) {
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadProjectsAndInstances(std::optional<Project>(std::nullopt),
                                        InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
@@ -307,7 +306,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulDefault) {
 
 TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulWithRememberedSettings) {
   EXPECT_CALL(
-      *mock_retrieve_instances_,
+      mock_retrieve_instances_,
       LoadProjectsAndInstances(
           std::optional<Project>(kInitialTestDataWithProjectOfInstances.project_of_instances),
           InstanceListScope(InstanceListScope::kAllReservedInstances)))
@@ -331,7 +330,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartSuccessfulWithRememberedSettings) {
 }
 
 TEST_F(RetrieveInstancesWidgetTest, StartFailed) {
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadProjectsAndInstances(std::optional<Project>(std::nullopt),
                                        InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<RetrieveInstances::LoadProjectsAndInstancesResult>>{
@@ -353,7 +352,7 @@ TEST_F(RetrieveInstancesWidgetTest, StartFailed) {
 }
 
 TEST_F(RetrieveInstancesWidgetTestStarted, ReloadSucceeds) {
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstancesWithoutCache(std::optional<Project>(std::nullopt),
                                         InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1)))
@@ -370,7 +369,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ReloadSucceeds) {
 }
 
 TEST_F(RetrieveInstancesWidgetTestStarted, ReloadFails) {
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstancesWithoutCache(std::optional<Project>(std::nullopt),
                                         InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(ErrorMessage{"error"})));
@@ -394,7 +393,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeSuccessful) {
   // "Test Project 1 (default)"
   // "Test Project 2"
 
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(kTestProject1),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1)));
@@ -411,7 +410,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeSuccessful) {
   // > "Test Project 1 (default)"
   // "Test Project 2"
 
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(std::nullopt),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1)));
@@ -428,7 +427,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeSuccessful) {
   // "Test Project 1 (default)"
   // "Test Project 2"
 
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(kTestProject2),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject2)));
@@ -455,7 +454,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeFailed) {
   // "Test Project 1 (default)"
   // "Test Project 2"
 
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(kTestProject1),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(ErrorMessage{"error"})));
@@ -480,11 +479,11 @@ TEST_F(RetrieveInstancesWidgetTestStarted, ProjectChangeFailed) {
 }
 
 TEST_F(RetrieveInstancesWidgetTestStarted, AllCheckboxSuccessful) {
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(std::nullopt),
                             InstanceListScope(InstanceListScope::kAllReservedInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1All)));
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(std::nullopt),
                             InstanceListScope(InstanceListScope::kOnlyOwnInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(kTestInstancesProject1)));
@@ -505,7 +504,7 @@ TEST_F(RetrieveInstancesWidgetTestStarted, AllCheckboxSuccessful) {
 }
 
 TEST_F(RetrieveInstancesWidgetTestStarted, AllCheckboxFail) {
-  EXPECT_CALL(*mock_retrieve_instances_,
+  EXPECT_CALL(mock_retrieve_instances_,
               LoadInstances(std::optional<Project>(std::nullopt),
                             InstanceListScope(InstanceListScope::kAllReservedInstances)))
       .WillOnce(Return(Future<ErrorMessageOr<QVector<Instance>>>(ErrorMessage{"error"})));

--- a/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetTest.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <optional>
 
+#include "MetricsUploader/MetricsUploader.h"
 #include "OrbitGgp/Client.h"
 #include "OrbitGgp/Project.h"
 #include "QtUtils/MainThreadExecutorImpl.h"
@@ -47,6 +48,8 @@ class MockRetrieveInstances : public RetrieveInstances {
   MOCK_METHOD(orbit_base::Future<ErrorMessageOr<LoadProjectsAndInstancesResult>>,
               LoadProjectsAndInstances,
               (const std::optional<Project>& project, InstanceListScope scope), (override));
+  MOCK_METHOD(void, SetMetricsUploader,
+              (orbit_metrics_uploader::MetricsUploader * metrics_uploader), (override));
 };
 
 namespace {

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstances.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstances.h
@@ -10,6 +10,7 @@
 #include <optional>
 
 #include "MainThreadExecutor.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/Client.h"
@@ -52,6 +53,7 @@ class RetrieveInstances {
   virtual orbit_base::Future<ErrorMessageOr<LoadProjectsAndInstancesResult>>
   LoadProjectsAndInstances(const std::optional<orbit_ggp::Project>& project,
                            orbit_ggp::Client::InstanceListScope scope) = 0;
+  virtual void SetMetricsUploader(orbit_metrics_uploader::MetricsUploader* metrics_uploader) = 0;
 
   [[nodiscard]] static std::unique_ptr<RetrieveInstances> Create(
       orbit_ggp::Client* ggp_client, MainThreadExecutor* main_thread_executor);

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
@@ -63,7 +63,7 @@ class RetrieveInstancesWidget : public QWidget {
   std::unique_ptr<Ui::RetrieveInstancesWidget> ui_;
   std::shared_ptr<MainThreadExecutor> main_thread_executor_;
   std::shared_ptr<RetrieveInstances> retrieve_instances_;
-  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_ = nullptr;
   QStateMachine state_machine_;
   QState s_idle_;
   QState s_loading_;

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
@@ -31,8 +31,8 @@ class RetrieveInstancesWidget : public QWidget {
   ~RetrieveInstancesWidget() override;
 
   void Start();
-  void SetRetrieveInstances(std::shared_ptr<RetrieveInstances> retrieve_instances) {
-    retrieve_instances_ = std::move(retrieve_instances);
+  void SetRetrieveInstances(RetrieveInstances* retrieve_instances) {
+    retrieve_instances_ = retrieve_instances;
   }
   void SetMetricsUploader(orbit_metrics_uploader::MetricsUploader* metrics_uploader) {
     metrics_uploader_ = metrics_uploader;
@@ -62,7 +62,7 @@ class RetrieveInstancesWidget : public QWidget {
 
   std::unique_ptr<Ui::RetrieveInstancesWidget> ui_;
   std::shared_ptr<MainThreadExecutor> main_thread_executor_;
-  std::shared_ptr<RetrieveInstances> retrieve_instances_;
+  RetrieveInstances* retrieve_instances_;
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_ = nullptr;
   QStateMachine state_machine_;
   QState s_idle_;

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
@@ -12,6 +12,7 @@
 #include <memory>
 
 #include "MainThreadExecutor.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "OrbitGgp/Client.h"
 #include "OrbitGgp/Project.h"
 #include "SessionSetup/RetrieveInstances.h"
@@ -32,6 +33,9 @@ class RetrieveInstancesWidget : public QWidget {
   void Start();
   void SetRetrieveInstances(std::shared_ptr<RetrieveInstances> retrieve_instances) {
     retrieve_instances_ = std::move(retrieve_instances);
+  }
+  void SetMetricsUploader(orbit_metrics_uploader::MetricsUploader* metrics_uploader) {
+    metrics_uploader_ = metrics_uploader;
   }
 
  signals:
@@ -57,6 +61,7 @@ class RetrieveInstancesWidget : public QWidget {
   std::unique_ptr<Ui::RetrieveInstancesWidget> ui_;
   std::shared_ptr<MainThreadExecutor> main_thread_executor_;
   std::shared_ptr<RetrieveInstances> retrieve_instances_;
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
   QStateMachine state_machine_;
   QState s_idle_;
   QState s_loading_;

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
@@ -36,6 +36,8 @@ class RetrieveInstancesWidget : public QWidget {
   }
   void SetMetricsUploader(orbit_metrics_uploader::MetricsUploader* metrics_uploader) {
     metrics_uploader_ = metrics_uploader;
+    CHECK(retrieve_instances_ != nullptr);
+    retrieve_instances_->SetMetricsUploader(metrics_uploader);
   }
 
  signals:

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
@@ -26,11 +26,13 @@ class RetrieveInstancesWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit RetrieveInstancesWidget(RetrieveInstances* retrieve_instances,
-                                   QWidget* parent = nullptr);
+  explicit RetrieveInstancesWidget(QWidget* parent = nullptr);
   ~RetrieveInstancesWidget() override;
 
   void Start();
+  void SetRetrieveInstances(std::shared_ptr<RetrieveInstances> retrieve_instances) {
+    retrieve_instances_ = std::move(retrieve_instances);
+  }
 
  signals:
   void LoadingStarted();
@@ -54,7 +56,7 @@ class RetrieveInstancesWidget : public QWidget {
 
   std::unique_ptr<Ui::RetrieveInstancesWidget> ui_;
   std::shared_ptr<MainThreadExecutor> main_thread_executor_;
-  RetrieveInstances* retrieve_instances_;
+  std::shared_ptr<RetrieveInstances> retrieve_instances_;
   QStateMachine state_machine_;
   QState s_idle_;
   QState s_loading_;


### PR DESCRIPTION
This first makes RetrieveInstancesWidget default constructible, which is unrelated to the metrics, but later on needed for using the widget in .ui files

Afterwards it adds the 4 metrics