### PR TITLE
Create LockFreeApiEventProducer in orbit_api_set_enabled

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -158,15 +158,21 @@ void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled)
     case 0: {
       auto* api_v0 = absl::bit_cast<orbit_api_v0*>(address);
       orbit_api_initialize_and_set_enabled(api_v0, &orbit_api_initialize_v0, enabled);
-      return;
-    }
+    } break;
     case 1: {
       auto* api_v1 = absl::bit_cast<orbit_api_v1*>(address);
       orbit_api_initialize_and_set_enabled(api_v1, &orbit_api_initialize_v1, enabled);
-      return;
-    }
+    } break;
     default:
       UNREACHABLE();
   }
+
+  // Initialize `LockFreeApiEventProducer` and establish the connection to OrbitService now instead
+  // of waiting for the first call to `EnqueueApiEvent`. As it takes some time to establish the
+  // connection, `producer.IsCapturing()` would otherwise always be false with at least the first
+  // event (but possibly more), causing it to be missed even if it comes a long time after calling
+  // `orbit_api_set_enabled`.
+  GetEventProducer();
 }
-}
+
+}  // extern "C"


### PR DESCRIPTION
Orbit Api missed at least the first event even if this came a long time after
`liborbit.so` was injected and `orbit_api_set_enabled` was called for the first
time. This is because the connection to `OrbitService` was opened on the first
event, at which point it was not yet ready to send data.
We solve this by establishing the connection in `orbit_api_set_enabled`, which
is called at the very beginning of a capture.
As this call happens while the target is stopped, but that call will now cause
gRPC to spawn new threads, these now also need to be stopped.

This is very similar to 72a078994335b8af3be7bfcc687045a9553f2ed5 fixing
http://b/205939288.

Bug: http://b/206359125

Test: Run the upcoming Orbit Api test from the upcoming
`OrbitServiceIntegrationTests`, during whose implementation this issue was
discovered. Capture OrbitTest with Orbit Api enabled.