### PR TITLE
Fix error handling in service deployment

### DIFF
--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -575,8 +575,10 @@ outcome::result<ServiceDeployManager::GrpcPort> ServiceDeployManager::Exec(
       LOG("OrbitService deployment has been aborted by the user");
     } else {
       connect_metric.SetStatusCode(orbit_metrics_uploader::OrbitLogEvent::INTERNAL_ERROR);
-      LOG("Deployment successful, grpc_port: %d", result.value().grpc_port);
+      ERROR("Error deploying OrbitService: %s", result.error().message());
     }
+  } else {
+    LOG("Deployment successful, grpc_port: %d", result.value().grpc_port);
   }
 
   return result;


### PR DESCRIPTION
This was introduced in https://github.com/google/orbit/pull/2994 and results in an exception when a deployment error is encountered - result.value() should not be accessed in this error case.