### PR TITLE
Fix E2E tests that query track data

### DIFF
--- a/src/OrbitGl/AccessibleCaptureViewElement.cpp
+++ b/src/OrbitGl/AccessibleCaptureViewElement.cpp
@@ -4,6 +4,7 @@
 
 #include "AccessibleCaptureViewElement.h"
 
+#include "TimeGraph.h"
 #include "Viewport.h"
 
 namespace orbit_gl {
@@ -20,6 +21,7 @@ orbit_accessibility::AccessibilityRect AccessibleCaptureViewElement::AccessibleR
   const Viewport* viewport = capture_view_element_->GetViewport();
 
   Vec2 pos = capture_view_element_->GetPos();
+  pos[1] -= capture_view_element_->GetTimeGraph()->GetVerticalScrollingOffset();
   Vec2 size = capture_view_element_->GetSize();
 
   Vec2i screen_pos = viewport->WorldToScreen(pos);

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -54,7 +54,9 @@ class FakeTimerPane : public CaptureViewElement {
   explicit FakeTimerPane(Track* track, TimeGraphLayout* layout, CaptureViewElement* track_tab)
       : CaptureViewElement(track, track->GetTimeGraph(), track->GetViewport(), layout),
         track_(track),
-        track_tab_(track_tab) {}
+        track_tab_(track_tab) {
+    SetWidth(track->GetWidth());
+  }
 
   std::unique_ptr<AccessibleInterface> CreateAccessibleInterface() override {
     return std::make_unique<AccessibleTimerPane>(this);
@@ -70,13 +72,13 @@ class FakeTimerPane : public CaptureViewElement {
       predecessor = track_children[track_children.size() - 1];
     }
 
-    Vec2 pos{track_->GetPos()[0], predecessor->GetPos()[1] - predecessor->GetSize()[1]};
+    Vec2 pos{track_->GetPos()[0], predecessor->GetPos()[1] + predecessor->GetSize()[1]};
     return pos;
   }
 
   [[nodiscard]] float GetHeight() const override {
     float height = track_->GetHeight();
-    float track_header_height = track_->GetPos()[1] - GetPos()[1];
+    float track_header_height = GetPos()[1] - track_->GetPos()[1];
     height -= track_header_height;
     return height;
   }
@@ -91,12 +93,7 @@ class FakeTimerPane : public CaptureViewElement {
 AccessibleTrackTab::AccessibleTrackTab(CaptureViewElement* fake_track_tab, Track* track)
     : AccessibleCaptureViewElement(fake_track_tab), track_(track) {}
 
-const AccessibleInterface* AccessibleTrackTab::AccessibleChild(int index) const {
-  if (index == 0) {
-    return track_->GetTriangleToggle()->GetOrCreateAccessibleInterface();
-  }
-  return nullptr;
-}
+const AccessibleInterface* AccessibleTrackTab::AccessibleChild(int index) const { return nullptr; }
 
 std::string AccessibleTrackTab::AccessibleName() const {
   CHECK(track_ != nullptr);

--- a/src/OrbitGl/AccessibleTrack.h
+++ b/src/OrbitGl/AccessibleTrack.h
@@ -24,7 +24,7 @@ class AccessibleTrackTab : public AccessibleCaptureViewElement {
  public:
   AccessibleTrackTab(CaptureViewElement* fake_track_tab, Track* track);
 
-  [[nodiscard]] int AccessibleChildCount() const override { return 1; }
+  [[nodiscard]] int AccessibleChildCount() const override { return 0; }
   [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override;
 
   [[nodiscard]] std::string AccessibleName() const override;

--- a/src/OrbitGl/AccessibleTriangleToggle.cpp
+++ b/src/OrbitGl/AccessibleTriangleToggle.cpp
@@ -21,11 +21,4 @@ orbit_accessibility::AccessibilityState AccessibleTriangleToggle::AccessibleStat
   return orbit_accessibility::AccessibilityState::Disabled;
 }
 
-const orbit_accessibility::AccessibleInterface* AccessibleTriangleToggle::AccessibleParent() const {
-  // Hack: The toggle's parent is the track tab, not the track itself.
-  // As the tab is virtual only, we expose it's accessibility interface here
-  // directly.
-  return parent_->GetOrCreateAccessibleInterface()->AccessibleChild(0);
-}
-
 }  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleTriangleToggle.h
+++ b/src/OrbitGl/AccessibleTriangleToggle.h
@@ -27,8 +27,6 @@ class AccessibleTriangleToggle : public AccessibleCaptureViewElement {
     return nullptr;
   }
 
-  [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleParent() const override;
-
   [[nodiscard]] std::string AccessibleName() const override { return "TriangleToggle"; }
 
   [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -26,6 +26,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void UpdateLayout();
 
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
+  [[nodiscard]] const TimeGraph* GetTimeGraph() const { return time_graph_; }
 
   [[nodiscard]] orbit_gl::Viewport* GetViewport() const { return viewport_; }
 


### PR DESCRIPTION
Changes to the CaptureViewElement hierachy broke the accessibility, which in turn broke E2E tests that query the contents of tracks: The triangle toggle reported the fake capture tab as parent, but it was actually located underneath the track itself.

Bug: b/205529781