### PR TITLE
Add metrics collection for some capture options.

### DIFF
--- a/src/MetricsUploader/CaptureMetric.cpp
+++ b/src/MetricsUploader/CaptureMetric.cpp
@@ -27,6 +27,9 @@ CaptureMetric::CaptureMetric(MetricsUploader* uploader, const CaptureStartData& 
       start_data.local_marker_depth_per_command_buffer);
   capture_data_.set_max_local_marker_depth_per_command_buffer(
       start_data.max_local_marker_depth_per_command_buffer);
+  capture_data_.set_dynamic_instrumentation_method(start_data.dynamic_instrumentation_method);
+  capture_data_.set_callstack_samples_per_second(start_data.callstack_samples_per_second);
+  capture_data_.set_callstack_unwinding_method(start_data.callstack_unwinding_method);
 }
 
 void CaptureMetric::SetCaptureCompleteData(const CaptureCompleteData& complete_data) {

--- a/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
@@ -27,6 +27,13 @@ struct CaptureStartData {
       local_marker_depth_per_command_buffer = orbit_metrics_uploader::
           OrbitCaptureData_LocalMarkerDepthPerCommandBuffer_LOCAL_MARKER_DEPTH_PER_COMMAND_BUFFER_UNKNOWN;
   uint64_t max_local_marker_depth_per_command_buffer = 0;
+  orbit_metrics_uploader::OrbitCaptureData_DynamicInstrumentationMethod
+      dynamic_instrumentation_method = orbit_metrics_uploader::
+          OrbitCaptureData_DynamicInstrumentationMethod_DYNAMIC_INSTRUMENTATION_METHOD_UNKNOWN;
+  uint64_t callstack_samples_per_second = 0;
+  orbit_metrics_uploader::OrbitCaptureData_CallstackUnwindingMethod callstack_unwinding_method =
+      orbit_metrics_uploader::
+          OrbitCaptureData_CallstackUnwindingMethod_CALLSTACK_UNWINDING_METHOD_UNKNOWN;
 };
 
 struct CaptureCompleteData {

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -177,4 +177,24 @@ message OrbitCaptureData {
 
   // Size of the capture file in bytes.
   uint64 file_size = 23;
+
+  // Method for dynamic instrumentation.
+  enum DynamicInstrumentationMethod {
+    DYNAMIC_INSTRUMENTATION_METHOD_UNKNOWN = 0;
+    DYNAMIC_INSTRUMENTATION_METHOD_KERNEL = 1;
+    DYNAMIC_INSTRUMENTATION_METHOD_ORBIT = 2;
+  }
+  DynamicInstrumentationMethod dynamic_instrumentation_method = 24;
+
+  // Callstack samples per second. A value of 0 means memory callstack sampling
+  // was turned off.
+  uint64 callstack_samples_per_second = 25;
+
+  // Method used for callstack unwinding.
+  enum CallstackUnwindingMethod {
+    CALLSTACK_UNWINDING_METHOD_UNKNOWN = 0;
+    CALLSTACK_UNWINDING_METHOD_DWARF = 1;
+    CALLSTACK_UNWINDING_METHOD_FRAME_POINTER = 2;
+  }
+  CallstackUnwindingMethod callstack_unwinding_method = 26;
 }


### PR DESCRIPTION
Method of dynamic instrumentation, callstack samples per second and unwinding
method are added.

Bug: http://b/205856560
Test: Run Orbit locally, correct data turns up in metrics_uploader_client.dll, receiving data in clearcut is tbd