### PR TITLE
Fix bug in ReadFullyAtOffset

### DIFF
--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -105,7 +105,7 @@ TEST(AccessTraceesMemoryTest, ReadFailures) {
 
   // Read past the end of the mappings.
   result = ReadTraceesMemory(pid, address, length + 1);
-  EXPECT_THAT(result, HasError("Only got"));
+  EXPECT_THAT(result, HasError("Input/output error"));
 
   // Read from bad address.
   result = ReadTraceesMemory(pid, 0, length);


### PR DESCRIPTION
`read` syscalls on Linux are limited to reading 0x7ffff000 bytes at a
time. That's why `ReadFullyAtOffset` calls `pread` in a loop until all
requested bytes are read, or we reachied the end of the file, or
an error occured.

The condition in this loop was wrong - probably because we never read
more than 0x7ffff000 bytes in a single call of `ReadFullyAtOffset`.

I tried to add a test for this but that's not so simple since 0x7ffff000
bytes is a little more than 2GiB which means we need to create a buffer
bigger than 2 GiB. That will be a problem on the CI. I tried to do some
`mmap` magic to at least get this tested on Linux but haven't found a
way to create a mapping that's not backed by anything.