### PR TITLE
Fix issues when setting ORBIT_API_ENABLED to 0

### DIFF
--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -193,21 +193,8 @@
 
 // To disable manual instrumentation macros, define ORBIT_API_ENABLED as 0.
 #define ORBIT_API_ENABLED 1
+
 #if ORBIT_API_ENABLED
-
-#ifdef WIN32
-#include <intrin.h>
-
-#pragma intrinsic(_ReturnAddress)
-
-#define ORBIT_GET_CALLER_PC() reinterpret_cast<uint64_t>(_ReturnAddress())
-#else
-// `__builtin_return_address(0)` will return us the (possibly encoded) return address of the current
-// function (level "0" refers to this frame, "1" would be the caller's return address and so on).
-// To decode the return address, we call `__builtin_extract_return_addr`.
-#define ORBIT_GET_CALLER_PC() \
-  reinterpret_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)))
-#endif
 
 #ifdef __cplusplus
 
@@ -260,6 +247,8 @@
 #ifdef __cplusplus
 #define ORBIT_SCOPE(name)
 #define ORBIT_SCOPE_WITH_COLOR(name, color)
+#define ORBIT_SCOPE_WITH_GROUP_ID(name, group_id)
+#define ORBIT_SCOPE_WITH_COLOR_AND_GROUP_ID(name, col, group_id)
 #endif
 
 #define ORBIT_START(name)
@@ -283,6 +272,9 @@
 #define ORBIT_UINT64_WITH_COLOR(name, value, color)
 #define ORBIT_FLOAT_WITH_COLOR(name, value, color)
 #define ORBIT_DOUBLE_WITH_COLOR(name, value, color)
+
+#define ORBIT_START_WITH_GROUP_ID(name, group_id)
+#define ORBIT_START_WITH_COLOR_AND_GROUP_ID(name, color, group_id)
 
 #endif  // ORBIT_API_ENABLED
 
@@ -378,6 +370,20 @@ inline bool orbit_api_active() {
 #define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
 #define ORBIT_VAR ORBIT_UNIQUE(ORB)
+
+#ifdef WIN32
+#include <intrin.h>
+
+#pragma intrinsic(_ReturnAddress)
+
+#define ORBIT_GET_CALLER_PC() reinterpret_cast<uint64_t>(_ReturnAddress())
+#else
+// `__builtin_return_address(0)` will return us the (possibly encoded) return address of the current
+// function (level "0" refers to this frame, "1" would be the caller's return address and so on).
+// To decode the return address, we call `__builtin_extract_return_addr`.
+#define ORBIT_GET_CALLER_PC() \
+  reinterpret_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)))
+#endif
 
 #ifdef WIN32
 namespace orbit_api {

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -172,12 +172,12 @@ void OrbitTestImpl::ManualInstrumentationApiTest() {
     ORBIT_UINT64_WITH_COLOR("uint64_var", uint64_var, kOrbitColorIndigo);
 
     [[maybe_unused]] static float float_var = 0.f;
-    [[maybe_unused]] static float sinf_coeff = 0.1f;
-    ORBIT_FLOAT_WITH_COLOR("float_var", sinf((++float_var) * sinf_coeff), kOrbitColorPink);
+    [[maybe_unused]] static constexpr float kSinfCoeff = 0.1f;
+    ORBIT_FLOAT_WITH_COLOR("float_var", sinf((++float_var) * kSinfCoeff), kOrbitColorPink);
 
     [[maybe_unused]] static double double_var = 0.0;
-    [[maybe_unused]] static double cos_coeff = 0.1;
-    ORBIT_DOUBLE_WITH_COLOR("double_var", cos((++double_var) * cos_coeff), kOrbitColorPurple);
+    [[maybe_unused]] static constexpr double kCosCoeff = 0.1;
+    ORBIT_DOUBLE_WITH_COLOR("double_var", cos((++double_var) * kCosCoeff), kOrbitColorPurple);
 
     for (int i = 0; i < 5; ++i) {
       std::string track_name = absl::StrFormat("DynamicName_%u", i);
@@ -186,7 +186,7 @@ void OrbitTestImpl::ManualInstrumentationApiTest() {
 
     // Async spans.
     static uint32_t task_id = 0;
-    size_t kNumTasksToSchedule = 10;
+    static constexpr size_t kNumTasksToSchedule = 10;
     for (size_t i = 0; i < kNumTasksToSchedule; ++i) {
       uint32_t id = ++task_id;
       ORBIT_START_ASYNC("ORBIT_ASYNC_TASKS", id);

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -95,7 +95,6 @@ void NO_INLINE OrbitTestImpl::BusyWork(uint64_t microseconds) {
   }
 }
 
-#if ORBIT_API_ENABLED
 static void NO_INLINE SleepFor1Ms() { std::this_thread::sleep_for(std::chrono::milliseconds(1)); }
 
 static void NO_INLINE SleepFor2Ms() {
@@ -103,7 +102,8 @@ static void NO_INLINE SleepFor2Ms() {
   ORBIT_SCOPE_WITH_COLOR("Sleep for two milliseconds", kOrbitColorTeal);
   ORBIT_SCOPE_WITH_COLOR("Sleep for two milliseconds", kOrbitColorOrange);
   thread_local uint64_t group_id = 0;
-  uint64_t current_id = group_id++;
+  // [[maybe_unused]] prevents "unused variable" compilation error if ORBIT_API_ENABLED is set to 0.
+  [[maybe_unused]] uint64_t current_id = group_id++;
   ORBIT_SCOPE_WITH_GROUP_ID("Sleeping for two milliseconds with group id", current_id);
   ORBIT_SCOPE_WITH_COLOR_AND_GROUP_ID("Sleeping for two milliseconds with group id",
                                       kOrbitColorBlueGrey, current_id);
@@ -143,7 +143,7 @@ void OrbitTestImpl::ManualInstrumentationApiTest() {
     ORBIT_STOP();
 
     thread_local uint64_t group_id = 0;
-    uint64_t current_id = group_id++;
+    [[maybe_unused]] uint64_t current_id = group_id++;
     ORBIT_START_WITH_GROUP_ID("ORBIT_START_TEST with group id", current_id);
     ORBIT_START_WITH_COLOR_AND_GROUP_ID("ORBIT_START_TEST with group id", kOrbitColorBlueGrey,
                                         current_id);
@@ -171,12 +171,12 @@ void OrbitTestImpl::ManualInstrumentationApiTest() {
     if (++uint64_var > 100) uint64_var = 0;
     ORBIT_UINT64_WITH_COLOR("uint64_var", uint64_var, kOrbitColorIndigo);
 
-    static float float_var = 0.f;
-    static volatile float sinf_coeff = 0.1f;
+    [[maybe_unused]] static float float_var = 0.f;
+    [[maybe_unused]] static float sinf_coeff = 0.1f;
     ORBIT_FLOAT_WITH_COLOR("float_var", sinf((++float_var) * sinf_coeff), kOrbitColorPink);
 
-    static double double_var = 0.0;
-    static volatile double cos_coeff = 0.1;
+    [[maybe_unused]] static double double_var = 0.0;
+    [[maybe_unused]] static double cos_coeff = 0.1;
     ORBIT_DOUBLE_WITH_COLOR("double_var", cos((++double_var) * cos_coeff), kOrbitColorPurple);
 
     for (int i = 0; i < 5; ++i) {
@@ -195,6 +195,3 @@ void OrbitTestImpl::ManualInstrumentationApiTest() {
     }
   }
 }
-#else
-void OrbitTest::ManualInstrumentationApiTest() {}
-#endif  // ORBIT_API_ENABLED

--- a/src/ProducerEventProcessor/GrpcClientCaptureEventCollector.cpp
+++ b/src/ProducerEventProcessor/GrpcClientCaptureEventCollector.cpp
@@ -159,7 +159,7 @@ void GrpcClientCaptureEventCollector::SenderThread() {
       ORBIT_UINT64("Number of buffered CaptureEvents sent", number_of_events_sent);
 
       CHECK(number_of_events_sent > 0);
-      float average_bytes =
+      [[maybe_unused]] float average_bytes =
           static_cast<float>(number_of_bytes_sent) / static_cast<float>(number_of_events_sent);
       ORBIT_FLOAT("Average bytes per CaptureEvent", average_bytes);
 

--- a/src/ProducerEventProcessor/GrpcClientCaptureEventCollector.cpp
+++ b/src/ProducerEventProcessor/GrpcClientCaptureEventCollector.cpp
@@ -159,7 +159,7 @@ void GrpcClientCaptureEventCollector::SenderThread() {
       ORBIT_UINT64("Number of buffered CaptureEvents sent", number_of_events_sent);
 
       CHECK(number_of_events_sent > 0);
-      [[maybe_unused]] float average_bytes =
+      [[maybe_unused]] const float average_bytes =
           static_cast<float>(number_of_bytes_sent) / static_cast<float>(number_of_events_sent);
       ORBIT_FLOAT("Average bytes per CaptureEvent", average_bytes);
 

--- a/src/ProducerEventProcessor/UploaderClientCaptureEventCollector.cpp
+++ b/src/ProducerEventProcessor/UploaderClientCaptureEventCollector.cpp
@@ -95,7 +95,7 @@ void UploaderClientCaptureEventCollector::RefreshUploadDataBuffer() {
   ORBIT_UINT64("Number of CaptureEvents to upload", buffered_event_count_);
   ORBIT_UINT64("Bytes of CaptureEvents to upload", buffered_event_bytes_);
   if (buffered_event_count_ > 0) {
-    float average_bytes =
+    [[maybe_unused]] float average_bytes =
         static_cast<float>(buffered_event_bytes_) / static_cast<float>(buffered_event_count_);
     ORBIT_FLOAT("Average bytes per CaptureEvent", average_bytes);
   }

--- a/src/ProducerEventProcessor/UploaderClientCaptureEventCollector.cpp
+++ b/src/ProducerEventProcessor/UploaderClientCaptureEventCollector.cpp
@@ -95,7 +95,7 @@ void UploaderClientCaptureEventCollector::RefreshUploadDataBuffer() {
   ORBIT_UINT64("Number of CaptureEvents to upload", buffered_event_count_);
   ORBIT_UINT64("Bytes of CaptureEvents to upload", buffered_event_bytes_);
   if (buffered_event_count_ > 0) {
-    [[maybe_unused]] float average_bytes =
+    [[maybe_unused]] const float average_bytes =
         static_cast<float>(buffered_event_bytes_) / static_cast<float>(buffered_event_count_);
     ORBIT_FLOAT("Average bytes per CaptureEvent", average_bytes);
   }


### PR DESCRIPTION
The primary issue, visible externally, was that setting `ORBIT_API_ENABLED` to 0
caused all the new macros ending in `AND_GROUP_ID` to not be defined.

The secondary issue was that some variables in Orbit code ended up being unused,
causing build errors, so I added some `[[maybe_unused]]` in a few places.

Bug: http://b/206594767

Test: Build with `ORBIT_API_ENABLED` set to 1 and build with it set to 0.