### PR TITLE
Integrate Project Selection

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -49,9 +49,6 @@ ABSL_FLAG(bool, enable_warning_threshold, false,
 ABSL_FLAG(std::string, instance_symbols_folder, "",
           "Additional folder in which OrbitService will look for symbols");
 
-// while project selection is in beta
-ABSL_FLAG(bool, enable_project_selection, false, "Enable project selection during Session Setup");
-
 ABSL_FLAG(bool, enforce_full_redraw, false,
           "Enforce full redraw every frame (used for performance measurements)");
 

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -50,9 +50,6 @@ ABSL_DECLARE_FLAG(bool, enable_warning_threshold);
 // additional folder in which OrbitService will look for symbols
 ABSL_DECLARE_FLAG(std::string, instance_symbols_folder);
 
-// while project selection is in beta
-ABSL_DECLARE_FLAG(bool, enable_project_selection);
-
 ABSL_DECLARE_FLAG(bool, enforce_full_redraw);
 
 // VSI

--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -379,9 +379,6 @@ void ConnectToStadiaWidget::LoadCredentials() {
     return;
   }
 
-  if (instance_credentials_loading_.contains(instance_id)) return;
-
-  instance_credentials_loading_.emplace(instance_id);
   auto future = ggp_client_->GetSshInfoAsync(selected_instance_.value().id, selected_project_);
   future.Then(main_thread_executor_.get(),
               [this, instance_id](ErrorMessageOr<orbit_ggp::SshInfo> ssh_info_result) {
@@ -527,8 +524,6 @@ void ConnectToStadiaWidget::OnProjectsLoaded(ErrorMessageOr<QVector<Project>> pr
 
 void ConnectToStadiaWidget::OnSshInfoLoaded(ErrorMessageOr<orbit_ggp::SshInfo> ssh_info_result,
                                             std::string instance_id) {
-  instance_credentials_loading_.erase(instance_id);
-
   if (ssh_info_result.has_error()) {
     std::string error_message =
         absl::StrFormat("Unable to load encryption credentials for instance with id %s: %s",

--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -107,11 +107,11 @@ ConnectToStadiaWidget::ConnectToStadiaWidget(QWidget* parent)
   QObject::connect(ui_->rememberCheckBox, &QCheckBox::toggled, this,
                    &ConnectToStadiaWidget::UpdateRememberInstance);
   QObject::connect(ui_->refreshButton, &QPushButton::clicked, this,
-                   [this]() { emit InstanceReloadRequested(); });
+                   [this]() { emit InstancesLoading(); });
   QObject::connect(ui_->instancesFilterLineEdit, &QLineEdit::textChanged, &instance_proxy_model_,
                    &QSortFilterProxyModel::setFilterFixedString);
   QObject::connect(ui_->refreshButton_2, &QPushButton::clicked, this,
-                   [this]() { emit InstanceReloadRequested(); });
+                   [this]() { emit InstancesLoading(); });
   QObject::connect(ui_->comboBox, QOverload<int>::of(&QComboBox::activated), this,
                    &ConnectToStadiaWidget::ProjectComboBoxActivated);
   QObject::connect(ui_->allInstancesCheckBox, &QCheckBox::stateChanged, this, [this]() {
@@ -287,8 +287,7 @@ void ConnectToStadiaWidget::SetupStateMachine() {
   // STATE s_idle_
   s_idle_.addTransition(ui_->refreshButton, &QPushButton::clicked, &s_instances_loading_);
   s_idle_.addTransition(ui_->refreshButton_2, &QPushButton::clicked, &s_instances_loading_);
-  s_idle_.addTransition(this, &ConnectToStadiaWidget::InstanceReloadRequested,
-                        &s_instances_loading_);
+  s_idle_.addTransition(this, &ConnectToStadiaWidget::InstancesLoading, &s_instances_loading_);
   s_idle_.addTransition(ui_->allInstancesCheckBox, &QCheckBox::stateChanged, &s_instances_loading_);
   s_idle_.addTransition(this, &ConnectToStadiaWidget::InstanceSelected, &s_instance_selected_);
 
@@ -300,7 +299,7 @@ void ConnectToStadiaWidget::SetupStateMachine() {
   s_instances_loading_.addTransition(this, &ConnectToStadiaWidget::ReceivedInstances, &s_idle_);
 
   // STATE s_instance_selected_
-  s_instance_selected_.addTransition(this, &ConnectToStadiaWidget::InstanceReloadRequested,
+  s_instance_selected_.addTransition(this, &ConnectToStadiaWidget::InstancesLoading,
                                      &s_instances_loading_);
   s_instance_selected_.addTransition(ui_->allInstancesCheckBox, &QCheckBox::stateChanged,
                                      &s_instances_loading_);
@@ -312,7 +311,7 @@ void ConnectToStadiaWidget::SetupStateMachine() {
                                      &s_loading_credentials_);
   QObject::connect(&s_instance_selected_, &QState::entered, this, [this]() {
     if (instance_model_.rowCount() == 0) {
-      emit InstanceReloadRequested();
+      emit InstancesLoading();
     }
   });
 
@@ -580,7 +579,7 @@ void ConnectToStadiaWidget::SetProject(const std::optional<orbit_ggp::Project>& 
   }
 
   selected_project_ = project;
-  emit InstanceReloadRequested();
+  emit InstancesLoading();
 }
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -4,6 +4,7 @@
 
 #include "SessionSetup/ConnectToStadiaWidget.h"
 
+#include <absl/strings/match.h>
 #include <absl/strings/str_format.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
@@ -271,7 +272,7 @@ void ConnectToStadiaWidget::SetupStateMachine() {
 void ConnectToStadiaWidget::LoadCredentials() {
   CHECK(selected_instance_.has_value());
 
-  const std::string& instance_id{selected_instance_->id.toStdString()};
+  const std::string instance_id{selected_instance_->id.toStdString()};
 
   if (instance_credentials_.contains(instance_id)) {
     emit CredentialsLoaded();
@@ -433,7 +434,8 @@ void ConnectToStadiaWidget::Connect() {
     return;
   }
 
-  if (!account_result.value().email.contains(selected_instance_->owner)) {
+  if (!absl::StartsWith(account_result.value().email.toStdString(),
+                        selected_instance_->owner.toStdString())) {
     OtherUserDialog dialog{selected_instance_->owner, this};
     auto dialog_result = dialog.Exec();
     if (dialog_result.has_error()) return;

--- a/src/SessionSetup/ConnectToStadiaWidget.ui
+++ b/src/SessionSetup/ConnectToStadiaWidget.ui
@@ -37,11 +37,32 @@
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <property name="lineWidth">
-      <number>1</number>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QRadioButton" name="radioButton">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="accessibleName">
+         <string>ConnectToStadia</string>
+        </property>
+        <property name="text">
+         <string>Connect to a Stadia instance</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QFrame" name="contentFrame">
         <property name="lineWidth">
          <number>0</number>
@@ -60,76 +81,6 @@
           <number>0</number>
          </property>
          <item>
-          <layout class="QHBoxLayout" name="titleBarLayout">
-           <item>
-            <widget class="QRadioButton" name="radioButton">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="font">
-              <font>
-               <pointsize>12</pointsize>
-              </font>
-             </property>
-             <property name="accessibleName">
-              <string>ConnectToStadia</string>
-             </property>
-             <property name="text">
-              <string>Connect to a Stadia instance</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_1">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>24</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="refreshButton">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>23</width>
-               <height>23</height>
-              </size>
-             </property>
-             <property name="baseSize">
-              <size>
-               <width>23</width>
-               <height>23</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Refresh Instance list</string>
-             </property>
-             <property name="accessibleName">
-              <string>RefreshInstanceList</string>
-             </property>
-             <property name="icon">
-              <iconset resource="../../icons/orbiticons.qrc">
-               <normaloff>:/actions/refresh</normaloff>:/actions/refresh</iconset>
-             </property>
-             <property name="autoDefault">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
           <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
            <item>
             <spacer name="horizontalSpacer">
@@ -146,81 +97,11 @@
            </item>
            <item>
             <layout class="QVBoxLayout" name="verticalLayout">
-             <property name="spacing">
-              <number>7</number>
-             </property>
              <item>
-              <widget class="QWidget" name="instancesSettingsWidget" native="true">
+              <widget class="orbit_session_setup::RetrieveInstancesWidget" name="retrieveInstancesWidget" native="true">
                <property name="enabled">
                 <bool>false</bool>
                </property>
-               <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,1,0,0">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>5</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QComboBox" name="comboBox">
-                  <property name="sizeAdjustPolicy">
-                   <enum>QComboBox::AdjustToContents</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="instancesFilterLineEdit">
-                  <property name="placeholderText">
-                   <string>Filter Instances</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="allInstancesCheckBox">
-                  <property name="toolTip">
-                   <string>Enable the --all-reserved argument for the list of instances. This shows also instances owned by others.</string>
-                  </property>
-                  <property name="text">
-                   <string>All instances</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="refreshButton_2">
-                  <property name="minimumSize">
-                   <size>
-                    <width>23</width>
-                    <height>23</height>
-                   </size>
-                  </property>
-                  <property name="baseSize">
-                   <size>
-                    <width>23</width>
-                    <height>23</height>
-                   </size>
-                  </property>
-                  <property name="toolTip">
-                   <string>Refresh instance list and projects</string>
-                  </property>
-                  <property name="accessibleName">
-                   <string>RefreshInstanceList</string>
-                  </property>
-                  <property name="icon">
-                   <iconset resource="../../icons/orbiticons.qrc">
-                    <normaloff>:/actions/refresh</normaloff>:/actions/refresh</iconset>
-                  </property>
-                  <property name="autoDefault">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
               </widget>
              </item>
              <item>
@@ -299,9 +180,6 @@
              </item>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
-               <property name="spacing">
-                <number>7</number>
-               </property>
                <item>
                 <widget class="QCheckBox" name="rememberCheckBox">
                  <property name="enabled">
@@ -350,6 +228,12 @@
    <class>orbit_session_setup::OverlayWidget</class>
    <extends>QWidget</extends>
    <header>SessionSetup/OverlayWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>orbit_session_setup::RetrieveInstancesWidget</class>
+   <extends>QWidget</extends>
+   <header>SessionSetup/RetrieveInstancesWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/SessionSetup/RetrieveInstancesWidget.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidget.cpp
@@ -59,6 +59,10 @@ RetrieveInstancesWidget::RetrieveInstancesWidget(QWidget* parent)
 void RetrieveInstancesWidget::SetupStateMachine() {
   state_machine_.setGlobalRestorePolicy(QStateMachine::RestoreProperties);
 
+  s_idle_.assignProperty(ui_->projectComboBox, "enabled", true);
+  s_idle_.assignProperty(ui_->filterLineEdit, "enabled", true);
+  s_idle_.assignProperty(ui_->allCheckBox, "enabled", true);
+  s_idle_.assignProperty(ui_->reloadButton, "enabled", true);
   s_idle_.addTransition(this, &RetrieveInstancesWidget::LoadingStarted, &s_loading_);
 
   s_loading_.assignProperty(ui_->projectComboBox, "enabled", false);
@@ -73,6 +77,7 @@ void RetrieveInstancesWidget::SetupStateMachine() {
   s_initial_loading_failed_.assignProperty(ui_->projectComboBox, "enabled", false);
   s_initial_loading_failed_.assignProperty(ui_->filterLineEdit, "enabled", false);
   s_initial_loading_failed_.assignProperty(ui_->allCheckBox, "enabled", false);
+  s_initial_loading_failed_.assignProperty(ui_->reloadButton, "enabled", true);
   s_initial_loading_failed_.addTransition(this, &RetrieveInstancesWidget::LoadingStarted,
                                           &s_loading_);
 }
@@ -82,7 +87,6 @@ void RetrieveInstancesWidget::Start() {
   state_machine_.setInitialState(&s_loading_);
   state_machine_.start();
 
-  QSettings settings;
   ui_->allCheckBox->setChecked(LoadInstancesScopeFromPersistentStorage() ==
                                InstanceListScope::kAllReservedInstances);
 

--- a/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
@@ -86,7 +86,7 @@ class ConnectToStadiaWidget : public QWidget {
   void Activated();
   void Connected();
   void Disconnected();
-  void InstanceReloadRequested();
+  void InstancesLoading();
 
  private:
   void showEvent(QShowEvent* event) override;

--- a/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToStadiaWidget.h
@@ -115,7 +115,6 @@ class ConnectToStadiaWidget : public QWidget {
   QState s_deploying_;
   QState s_connected_;
 
-  absl::flat_hash_set<std::string> instance_credentials_loading_;
   absl::flat_hash_map<std::string, orbit_ssh::Credentials> instance_credentials_;
 
   void DetachRadioButton();


### PR DESCRIPTION
This integrates project selection into the ConnectToStadiaWidget. This also removes the --enable_project_selection flag, so its default now. ConnectToOrbitWidget does not have unit tests, so this also does not have any unit tests. I tested this quite extensively by hand, but it would still be appreciated if someone else also tests by hand. An e2e test is upcoming.