### PR TITLE
Don't mark as errors samples in injected library not from trampolines

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -102,7 +102,7 @@ class UprobesUnwindingVisitorTest : public ::testing::Test {
         .WillRepeatedly(Return(&kTargetMapInfo));
 
     EXPECT_CALL(maps_, Find(AllOf(Ge(kNonExecutableMapsStart), Lt(kNonExecutableMapsEnd))))
-        .WillRepeatedly(Return(&non_executable_map_info_));
+        .WillRepeatedly(Return(&kNonExecutableMapInfo));
   }
 
   static constexpr uint32_t kStackDumpSize = 128;
@@ -113,13 +113,9 @@ class UprobesUnwindingVisitorTest : public ::testing::Test {
   MockLibunwindstackUnwinder unwinder_;
   MockLeafFunctionCallManager leaf_function_call_manager_{kStackDumpSize};
 
-  static constexpr uint64_t kEntryTrampolineAddress = 0xAAAAAAAAAAAAAA00LU;
-  static constexpr uint64_t kReturnTrampolineAddress = 0xBBBBBBBBBBBBBB00LU;
-
+  static inline const std::string kUserSpaceLibraryName = "/path/to/library.so";
   static constexpr uint64_t kUserSpaceLibraryMapsStart = 0xCCCCCCCCCCCCCC00LU;
   static constexpr uint64_t kUserSpaceLibraryMapsEnd = 0xCCCCCCCCCCCCCCFFLU;
-  static constexpr uint64_t kUserSpaceLibraryAddress = kUserSpaceLibraryMapsStart;
-  static inline const std::string kUserSpaceLibraryName = "/path/to/library.so";
   static inline unwindstack::MapInfo kUserSpaceLibraryMapInfo{nullptr,
                                                               nullptr,
                                                               kUserSpaceLibraryMapsStart,
@@ -128,13 +124,42 @@ class UprobesUnwindingVisitorTest : public ::testing::Test {
                                                               PROT_EXEC | PROT_READ,
                                                               kUserSpaceLibraryName};
 
+  static constexpr uint64_t kUserSpaceLibraryAddress = kUserSpaceLibraryMapsStart;
+  static inline const std::string kUserSpaceLibraryFunctionName = "payload";
+  static inline const unwindstack::FrameData kUserSpaceLibraryFrame{
+      .pc = kUserSpaceLibraryAddress,
+      .function_name = kUserSpaceLibraryFunctionName,
+      .function_offset = 0,
+      .map_name = kUserSpaceLibraryName,
+      .map_start = kUserSpaceLibraryMapsStart,
+  };
+
+  static constexpr uint64_t kEntryTrampolineAddress = 0xAAAAAAAAAAAAAA00LU;
+  static constexpr uint64_t kReturnTrampolineAddress = 0xBBBBBBBBBBBBBB00LU;
+  static inline const std::string kEntryTrampolineFunctionName = "entry_trampoline";
+  static inline const std::string kReturnTrampolineFunctionName = "return_trampoline";
+  static inline const unwindstack::FrameData kEntryTrampolineFrame{
+      .pc = kEntryTrampolineAddress,
+      .function_name = kEntryTrampolineFunctionName,
+      .function_offset = 0,
+      .map_name = "",
+      .map_start = kEntryTrampolineAddress,
+  };
+  static inline const unwindstack::FrameData kReturnTrampolineFrame{
+      .pc = kReturnTrampolineAddress,
+      .function_name = kReturnTrampolineFunctionName,
+      .function_offset = 0,
+      .map_name = "",
+      .map_start = kReturnTrampolineAddress,
+  };
+
   class FakeUserSpaceInstrumentationAddresses : public UserSpaceInstrumentationAddresses {
    public:
     [[nodiscard]] bool IsInEntryTrampoline(uint64_t address) const override {
-      return address == kEntryTrampolineAddress;
+      return address == kEntryTrampolineAddress || address == kEntryTrampolineAddress + 1;
     }
     [[nodiscard]] bool IsInReturnTrampoline(uint64_t address) const override {
-      return address == kReturnTrampolineAddress;
+      return address == kReturnTrampolineAddress || address == kReturnTrampolineAddress + 1;
     }
     [[nodiscard]] std::string_view GetInjectedLibraryMapName() const override {
       return kUserSpaceLibraryName;
@@ -149,16 +174,27 @@ class UprobesUnwindingVisitorTest : public ::testing::Test {
                                    &leaf_function_call_manager_,
                                    &user_space_instrumentation_addresses_};
 
+  static constexpr uint64_t kKernelAddress = 0xFFFFFFFFFFFFFE00;
+
+  static inline const std::string kUprobesName = "[uprobes]";
   static constexpr uint64_t kUprobesMapsStart = 0x7FFFFFFFE000;
   static constexpr uint64_t kUprobesMapsEnd = 0x7FFFFFFFE001;
+  static inline unwindstack::MapInfo kUprobesMapInfo{
+      nullptr, nullptr, kUprobesMapsStart, kUprobesMapsEnd, 0, PROT_EXEC | PROT_READ, kUprobesName};
 
+  static inline const unwindstack::FrameData kUprobesFrame{
+      .pc = kUprobesMapsStart,
+      .function_name = "uprobe",
+      .function_offset = 0,
+      .map_name = kUprobesName,
+      .map_start = kUprobesMapsStart,
+  };
+
+  static inline const std::string kTargetName = "target";
   static constexpr uint64_t kTargetMapsStart = 100;
   static constexpr uint64_t kTargetMapsEnd = 400;
-
-  static constexpr uint64_t kNonExecutableMapsStart = 500;
-  static constexpr uint64_t kNonExecutableMapsEnd = 600;
-
-  static constexpr uint64_t kKernelAddress = 0xFFFFFFFFFFFFFE00;
+  static inline unwindstack::MapInfo kTargetMapInfo{
+      nullptr, nullptr, kTargetMapsStart, kTargetMapsEnd, 0, PROT_EXEC | PROT_READ, kTargetName};
 
   static constexpr uint64_t kTargetAddress1 = 100;
   static constexpr uint64_t kTargetAddress2 = 200;
@@ -168,44 +204,38 @@ class UprobesUnwindingVisitorTest : public ::testing::Test {
   static inline const std::string kFunctionName2 = "bar";
   static inline const std::string kFunctionName3 = "baz";
 
-  static inline const std::string kUprobesName = "[uprobes]";
-  static inline const std::string kTargetName = "target";
-  static inline const std::string kNonExecutableName = "data";
-
-  static inline unwindstack::MapInfo kUprobesMapInfo{
-      nullptr, nullptr, kUprobesMapsStart, kUprobesMapsEnd, 0, PROT_EXEC | PROT_READ, kUprobesName};
-
-  static inline unwindstack::MapInfo kTargetMapInfo{
-      nullptr, nullptr, kTargetMapsStart, kTargetMapsEnd, 0, PROT_EXEC | PROT_READ, kTargetName};
-
-  static inline unwindstack::MapInfo non_executable_map_info_{nullptr,
-                                                              nullptr,
-                                                              kNonExecutableMapsStart,
-                                                              kNonExecutableMapsEnd,
-                                                              0,
-                                                              PROT_EXEC | PROT_READ,
-                                                              kNonExecutableName};
-
-  static inline unwindstack::FrameData kFrame1{
+  static inline const unwindstack::FrameData kFrame1{
       .pc = kTargetAddress1,
       .function_name = kFunctionName1,
       .function_offset = 0,
       .map_name = kTargetName,
   };
 
-  static inline unwindstack::FrameData kFrame2{
+  static inline const unwindstack::FrameData kFrame2{
       .pc = kTargetAddress2,
       .function_name = kFunctionName2,
       .function_offset = 0,
       .map_name = kTargetName,
   };
 
-  static inline unwindstack::FrameData kFrame3{
+  static inline const unwindstack::FrameData kFrame3{
       .pc = kTargetAddress3,
       .function_name = kFunctionName3,
       .function_offset = 0,
       .map_name = kTargetName,
   };
+
+  static constexpr uint64_t kNonExecutableMapsStart = 500;
+  static constexpr uint64_t kNonExecutableMapsEnd = 600;
+  static inline const std::string kNonExecutableName = "data";
+
+  static inline unwindstack::MapInfo kNonExecutableMapInfo{nullptr,
+                                                           nullptr,
+                                                           kNonExecutableMapsStart,
+                                                           kNonExecutableMapsEnd,
+                                                           0,
+                                                           PROT_EXEC | PROT_READ,
+                                                           kNonExecutableName};
 };
 
 StackSamplePerfEvent BuildFakeStackSamplePerfEvent() {
@@ -507,11 +537,7 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> libunwindstack_callstack;
-
-  libunwindstack_callstack.push_back(kFrame1);
-  libunwindstack_callstack.push_back(kFrame2);
-  libunwindstack_callstack.push_back(kFrame3);
+  std::vector<unwindstack::FrameData> libunwindstack_callstack{kFrame1, kFrame2, kFrame3};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -593,9 +619,7 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillRepeatedly(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> libunwindstack_callstack;
-  libunwindstack_callstack.push_back(kFrame1);
-  libunwindstack_callstack.push_back(kFrame2);
+  std::vector<unwindstack::FrameData> libunwindstack_callstack{kFrame1, kFrame2};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -641,8 +665,7 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> incomplete_callstack;
-  incomplete_callstack.push_back(kFrame1);
+  std::vector<unwindstack::FrameData> incomplete_callstack{kFrame1};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -686,16 +709,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleWithinUprobeSendsInUprobesCa
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> callstack;
-  unwindstack::FrameData frame_1{
-      .pc = kUprobesMapsStart,
-      .function_name = "uprobe",
-      .function_offset = 0,
-      .map_name = kUprobesName,
-      .map_start = kUprobesMapsStart,
-  };
-  callstack.push_back(frame_1);
-  callstack.push_back(kFrame2);
+  std::vector<unwindstack::FrameData> callstack{kUprobesFrame, kFrame2};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -740,16 +754,7 @@ TEST_F(
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> callstack;
-  unwindstack::FrameData frame_1{
-      .pc = kEntryTrampolineAddress,
-      .function_name = "entry_trampoline",
-      .function_offset = 0,
-      .map_name = "",
-      .map_start = kEntryTrampolineAddress,
-  };
-  callstack.push_back(frame_1);
-  callstack.push_back(kFrame2);
+  std::vector<unwindstack::FrameData> callstack{kEntryTrampolineFrame, kFrame2};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -777,23 +782,14 @@ TEST_F(
 
 TEST_F(
     UprobesUnwindingVisitorTest,
-    VisitStackSampleWithinUserSpaceInstrumentationLibrarySendsInUserSpaceInstrumentationCallstack) {
+    VisitStackSampleWithinUserSpaceInstrumentationTrampolineAndLibrarySendsInUserSpaceInstrumentationCallstack) {
   StackSamplePerfEvent event = BuildFakeStackSamplePerfEvent();
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> callstack;
-  unwindstack::FrameData frame_2{
-      .pc = kUserSpaceLibraryAddress,
-      .function_name = "payload",
-      .function_offset = 0,
-      .map_name = kUserSpaceLibraryName,
-      .map_start = kUserSpaceLibraryMapsStart,
-  };
-  callstack.push_back(kFrame1);
-  callstack.push_back(frame_2);
-  callstack.push_back(kFrame3);
+  std::vector<unwindstack::FrameData> callstack{kFrame1, kUserSpaceLibraryFrame, kFrame3,
+                                                kEntryTrampolineFrame};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -832,22 +828,69 @@ TEST_F(
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
 }
 
+TEST_F(
+    UprobesUnwindingVisitorTest,
+    VisitStackSampleWithinUserSpaceInstrumentationLibraryButNotTrampolineSendsCompleteCallstack) {
+  StackSamplePerfEvent event = BuildFakeStackSamplePerfEvent();
+
+  EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
+  EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
+
+  std::vector<unwindstack::FrameData> callstack{kFrame1, kUserSpaceLibraryFrame, kFrame3};
+
+  EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
+      .Times(1)
+      .WillOnce(Return(LibunwindstackResult{callstack, unwindstack::ErrorCode::ERROR_NONE}));
+
+  orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
+  EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
+
+  std::vector<orbit_grpc_protos::FullAddressInfo> actual_address_infos;
+  auto save_address_info =
+      [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
+        actual_address_infos.push_back(std::move(actual_address_info));
+      };
+  EXPECT_CALL(listener_, OnAddressInfo).Times(3).WillRepeatedly(Invoke(save_address_info));
+
+  std::atomic<uint64_t> unwinding_errors = 0;
+  std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
+  visitor_.SetUnwindErrorsAndDiscardedSamplesCounters(&unwinding_errors,
+                                                      &discarded_samples_in_uretprobes_counter);
+
+  PerfEvent{std::move(event)}.Accept(&visitor_);
+
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kUserSpaceLibraryAddress, kTargetAddress3));
+  EXPECT_EQ(actual_callstack_sample.callstack().type(), orbit_grpc_protos::Callstack::kComplete);
+  EXPECT_THAT(
+      actual_address_infos,
+      UnorderedElementsAre(
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address,
+                         kUserSpaceLibraryAddress),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name,
+                         kUserSpaceLibraryFunctionName),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kUserSpaceLibraryName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress3),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName3),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
+
+  EXPECT_EQ(unwinding_errors, 0);
+  EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
+}
+
 TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleStoppedAtUprobesSendsPatchingFailedCallstack) {
   StackSamplePerfEvent event = BuildFakeStackSamplePerfEvent();
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> callstack;
-  unwindstack::FrameData frame_2{
-      .pc = kUprobesMapsStart,
-      .function_name = "uprobe",
-      .function_offset = 0,
-      .map_name = kUprobesName,
-      .map_start = kUprobesMapsStart,
-  };
-  callstack.push_back(kFrame1);
-  callstack.push_back(frame_2);
+  std::vector<unwindstack::FrameData> callstack{kFrame1, kUprobesFrame};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -891,16 +934,7 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> callstack;
-  unwindstack::FrameData frame_2{
-      .pc = kReturnTrampolineAddress,
-      .function_name = "return_trampoline",
-      .function_offset = 0,
-      .map_name = "",
-      .map_start = kReturnTrampolineAddress,
-  };
-  callstack.push_back(kFrame1);
-  callstack.push_back(frame_2);
+  std::vector<unwindstack::FrameData> callstack{kFrame1, kReturnTrampolineFrame};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -942,12 +976,13 @@ TEST_F(UprobesUnwindingVisitorTest,
 //-----------------------------------//
 
 TEST_F(UprobesUnwindingVisitorTest, VisitValidCallchainSampleWithoutUprobesSendsCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kTargetAddress1);
-  // Increment by one as the return address is the next address.
-  callchain.push_back(kTargetAddress2 + 1);
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kTargetAddress1,
+      // Increment by one as the return address is the next address.
+      kTargetAddress2 + 1,
+      kTargetAddress3 + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -975,8 +1010,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitValidCallchainSampleWithoutUprobesSends
 }
 
 TEST_F(UprobesUnwindingVisitorTest, VisitSingleFrameCallchainSampleDoesNothing) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
+  std::vector<uint64_t> callchain{kKernelAddress};
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -1000,12 +1034,13 @@ TEST_F(UprobesUnwindingVisitorTest, VisitSingleFrameCallchainSampleDoesNothing) 
 }
 
 TEST_F(UprobesUnwindingVisitorTest, VisitCallchainSampleInsideUprobeCodeSendsInUprobesCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kUprobesMapsStart);
-  // Increment by one as the return address is the next address.
-  callchain.push_back(kTargetAddress2 + 1);
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kUprobesMapsStart,
+      // Increment by one as the return address is the next address.
+      kTargetAddress2 + 1,
+      kTargetAddress3 + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -1036,12 +1071,13 @@ TEST_F(UprobesUnwindingVisitorTest, VisitCallchainSampleInsideUprobeCodeSendsInU
 TEST_F(
     UprobesUnwindingVisitorTest,
     VisitCallchainSampleInsideUserSpaceInstrumentationTrampolineSendsInUserSpaceInstrumentationCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kEntryTrampolineAddress);
-  // Increment by one as the return address is the next address.
-  callchain.push_back(kTargetAddress2 + 1);
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kEntryTrampolineAddress,
+      // Increment by one as the return address is the next address.
+      kTargetAddress2 + 1,
+      kTargetAddress3 + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -1073,12 +1109,14 @@ TEST_F(
 TEST_F(
     UprobesUnwindingVisitorTest,
     VisitCallchainSampleInsideUserSpaceInstrumentationLibrarySendsInUserSpaceInstrumentationCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kTargetAddress1);
-  // Increment by one as the return address is the next address.
-  callchain.push_back(kUserSpaceLibraryAddress + 1);
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kTargetAddress1,
+      // Increment by one as the return address is the next address.
+      kUserSpaceLibraryAddress + 1,
+      kTargetAddress3 + 1,
+      kEntryTrampolineAddress + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -1113,12 +1151,14 @@ TEST_F(
 TEST_F(
     UprobesUnwindingVisitorTest,
     VisitCallchainSampleInsideUserSpaceInstrumentationLibraryAfterLeafFunctionPatchingSendsInUserSpaceInstrumentationCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kTargetAddress1);
-  // Increment by one as the return address is the next address.
-  // `kUserSpaceLibraryAddress + 1` is the missing frame.
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kTargetAddress1,
+      // Increment by one as the return address is the next address.
+      // `kUserSpaceLibraryAddress + 1` is the missing frame.
+      kTargetAddress3 + 1,
+      kEntryTrampolineAddress + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -1130,8 +1170,13 @@ TEST_F(
       .Times(1)
       .WillOnce([](const CallchainSamplePerfEventData* event_data,
                    LibunwindstackMaps* /*current_maps*/, LibunwindstackUnwinder* /*unwinder*/) {
-        event_data->SetIps(
-            {kKernelAddress, kTargetAddress1, kUserSpaceLibraryAddress + 1, kTargetAddress3 + 1});
+        event_data->SetIps({
+            kKernelAddress,
+            kTargetAddress1,
+            kUserSpaceLibraryAddress + 1,  // This was the missing frame.
+            kTargetAddress3 + 1,
+            kEntryTrampolineAddress + 1,
+        });
         return Callstack::kComplete;
       });
 
@@ -1158,12 +1203,13 @@ TEST_F(
 }
 
 TEST_F(UprobesUnwindingVisitorTest, VisitPatchableCallchainSampleSendsCompleteCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kTargetAddress1);
-  // Increment by one as the return address is the next address.
-  callchain.push_back(kUprobesMapsStart + 1);
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kTargetAddress1,
+      // Increment by one as the return address is the next address.
+      kUprobesMapsStart + 1,
+      kTargetAddress3 + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -1205,12 +1251,13 @@ TEST_F(UprobesUnwindingVisitorTest, VisitPatchableCallchainSampleSendsCompleteCa
 }
 
 TEST_F(UprobesUnwindingVisitorTest, VisitUnpatchableCallchainSampleSendsPatchingFailedCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kTargetAddress1);
-  // Increment by one as the return address is the next address.
-  callchain.push_back(kUprobesMapsStart + 1);
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kTargetAddress1,
+      // Increment by one as the return address is the next address.
+      kUprobesMapsStart + 1,
+      kTargetAddress3 + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -1242,11 +1289,12 @@ TEST_F(UprobesUnwindingVisitorTest, VisitUnpatchableCallchainSampleSendsPatching
 
 TEST_F(UprobesUnwindingVisitorTest,
        VisitLeafCallOptimizedCallchainSampleWithoutUprobesSendsCompleteCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kTargetAddress1);
-  // Increment by one as the return address is the next address.
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kTargetAddress1,
+      // Increment by one as the return address is the next address.
+      kTargetAddress3 + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 
@@ -1293,11 +1341,12 @@ TEST_F(UprobesUnwindingVisitorTest,
 TEST_F(
     UprobesUnwindingVisitorTest,
     VisitLeafCallOptimizedCallchainSampleWherePatchingLeafFunctionCallerFailsSendsFramePointerUnwindingErrorCallstack) {
-  std::vector<uint64_t> callchain;
-  callchain.push_back(kKernelAddress);
-  callchain.push_back(kTargetAddress1);
-  // Increment by one as the return address is the next address.
-  callchain.push_back(kTargetAddress3 + 1);
+  std::vector<uint64_t> callchain{
+      kKernelAddress,
+      kTargetAddress1,
+      // Increment by one as the return address is the next address.
+      kTargetAddress3 + 1,
+  };
 
   CallchainSamplePerfEvent event = BuildFakeCallchainSamplePerfEvent(callchain);
 

--- a/src/LinuxTracing/include/LinuxTracing/UserSpaceInstrumentationAddresses.h
+++ b/src/LinuxTracing/include/LinuxTracing/UserSpaceInstrumentationAddresses.h
@@ -17,6 +17,10 @@ class UserSpaceInstrumentationAddresses {
   [[nodiscard]] virtual bool IsInEntryTrampoline(uint64_t address) const = 0;
   [[nodiscard]] virtual bool IsInReturnTrampoline(uint64_t address) const = 0;
   [[nodiscard]] virtual std::string_view GetInjectedLibraryMapName() const = 0;
+
+  [[nodiscard]] bool IsInEntryOrReturnTrampoline(uint64_t address) const {
+    return IsInEntryTrampoline(address) || IsInReturnTrampoline(address);
+  }
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -265,6 +265,9 @@ std::string CallstackThreadBar::GetSampleTooltip(const Batcher& batcher, Picking
   } else {
     // TODO(b/188756080): Show a specific explanation for each CallstackType.
     result += "Callstack not available: the stack could not be unwound successfully";
+    if (app_->IsDevMode()) {
+      result += absl::StrFormat(" (%s)", CallstackInfo::CallstackType_Name(callstack->type()));
+    }
   }
   return result +
          "<br/><br/><i>To select samples, click the bar & drag across multiple samples</i>";


### PR DESCRIPTION
With https://github.com/google/orbit/pull/2985 we were using the fact that a
sample has at least one frame in `liborbituserspaceinstrumentation.so` as an
indication that the sample fell in code called by a trampoline (and would fail
to unwind anyway). That sample would be marked as of type
`kInUserSpaceInstrumentation`.

But that didn't consider that `ForwarderThread` (the thread that sends the data
to OrbitService) also runs code in that library. Those threads were reported as
`kInUserSpaceInstrumentation` but they are perfectly fine samples.

We now detect if a sample is in code called by a trampoline if it has at least
one frame in `liborbituserspaceinstrumentation.so` AND one preceding frame
(usually the outermost where unwinding stops) in a trampoline.

Also, in `--devmode` we now show the error type of a callstack in the tooltip in
the capture view (very useful for this kind of investigations).

Bug: http://b/206783021

Test:
- Update unit tests.
- Capture Trata with sampling and user space instrumentation and have a look at
  samples; in particular:
  - verify that samples in `ForwarderThread` are ok;
  - use tooltips to verify that the type of errors is
    `kInUserSpaceInstrumentation` where it makes sense;
- Capture custom target with sampling (both DWARF and frame pointer unwinding)
  and have a look at samples.