### PR TITLE
Parse section headers of PE/COFF object files

### DIFF
--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -17,8 +17,11 @@
 #ifndef _LIBUNWINDSTACK_PE_COFF_INTERFACE_H
 #define _LIBUNWINDSTACK_PE_COFF_INTERFACE_H
 
+#include <array>
+#include <optional>
 #include <vector>
 
+#include <unwindstack/DwarfSection.h>
 #include <unwindstack/Error.h>
 #include <unwindstack/Memory.h>
 
@@ -80,6 +83,34 @@ struct CoffOptionalHeader {
   std::vector<DataDirectory> data_dirs;  // will contain `num_data_dir_entries` entries
 };
 
+constexpr size_t kSectionNameInHeaderSize = 8;
+
+// Represents data precisely as parsed from the file.
+struct SectionHeader {
+  std::array<char, kSectionNameInHeaderSize> name;
+  uint32_t vmsize;
+  uint32_t vmaddr;
+  uint32_t size;
+  uint32_t offset;
+  uint32_t reloff;
+  uint32_t lineoff;
+  uint16_t nrel;
+  uint16_t nline;
+  uint32_t flags;
+};
+
+// Represents preprocessed data of a section that we need for further processing. Section name
+// is already looked up in the string table.
+struct Section {
+  Section() : name(""), vmsize(0), vmaddr(0), size(0), offset(0) {}
+
+  std::string name;
+  uint32_t vmsize;
+  uint32_t vmaddr;
+  uint32_t size;    // Size in file
+  uint32_t offset;  // Offset in file
+};
+
 class PeCoffMemory {
  public:
   PeCoffMemory(Memory* memory) : memory_(memory), cur_offset_(0) {}
@@ -89,9 +120,10 @@ class PeCoffMemory {
   bool Get32(uint32_t* value);
   bool Get64(uint64_t* value);
   bool GetMax64(uint64_t* value, uint64_t size);
+  bool GetFully(void* dst, size_t size);
 
-  bool ReadFully(uint64_t addr, void* dst, size_t size) {
-    return memory_->ReadFully(addr, dst, size);
+  bool ReadString(uint64_t offset, std::string* dst, uint64_t max_read) {
+    return memory_->ReadString(offset, dst, max_read);
   }
 
   uint64_t cur_offset() { return cur_offset_; }
@@ -118,9 +150,31 @@ class PeCoffInterface {
 
  private:
   PeCoffMemory coff_memory_;
+
+  // Parsed data
   DosHeader dos_header_;
   CoffHeader coff_header_;
   CoffOptionalHeader optional_header_;
+  std::vector<SectionHeader> parsed_section_headers_;
+
+  // Initialized section data
+  std::vector<Section> sections_;
+
+  // Data about the .text section. Assumption: There is only a single .text section.
+  struct TextSectionData {
+    uint64_t executable_offset = 0;
+    size_t section_index = 0;
+  };
+  std::optional<TextSectionData> text_section_data_;
+
+  // If a .debug_frame section is present, these are initialized.
+  struct DebugFrameSectionData {
+    uint64_t file_offset = 0;
+    uint64_t size = 0;
+    int64_t section_bias = 0;
+  };
+  std::unique_ptr<DwarfSection> debug_frame_;
+  std::optional<DebugFrameSectionData> debug_frame_section_data_;
 
   ErrorData last_error_{ERROR_NONE, 0};
 
@@ -128,8 +182,12 @@ class PeCoffInterface {
   bool ParseNewHeader(uint64_t offset);
   bool ParseCoffHeader(uint64_t offset);
   bool ParseOptionalHeader(uint64_t offset);
+  bool ParseSectionHeaders(uint64_t offset);
 
   bool ParseAllHeaders();
+
+  bool GetSectionName(const std::string& parsed_section_name_string, std::string* result);
+  bool InitSections();
 };
 
 using PeCoffInterface32 = PeCoffInterface<uint32_t>;


### PR DESCRIPTION
We need to parse the section headers to find data about some specific
sections we need for unwinding, in particular the .text and a
potentially present .debug_frame section. With this change we are
adding parsing of these headers.

We also add looking up section names in the string table, which is
required for section names that are longer than 8 characters.

Tested: Unit tests.
Bug: http://b/192514457