### PR TITLE
Package liborbit.so and liborbituserspaceinstrumentation.so in Orbit.zip

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -205,6 +205,8 @@ if [ -n "$1" ]; then
     cp -v bin/OrbitClientGgp Orbit/collector/
     cp -v lib/libOrbitVulkanLayer.so Orbit/collector/
     cp -v lib/VkLayer_Orbit_implicit.json Orbit/collector/
+    cp -v lib/liborbit.so Orbit/collector/
+    cp -v lib/liborbituserspaceinstrumentation.so Orbit/collector/
     cp -v bin/LinuxTracingIntegrationTests Orbit/collector/
     cp -v bin/OrbitServiceIntegrationTests Orbit/collector/
     cp -v lib/libIntegrationTestPuppetSharedObject.so Orbit/collector/


### PR DESCRIPTION
OrbitServiceIntegrationTests needs them to run.

Bug: http://b/206081462

Test: Manually triggered
http://fusion2/73ef212b-9634-4578-a697-7d50eba45e40
and verified the content of the final Orbit.zip at
http://fusion2/e9abe159-8306-4918-80ee-c7f2e97fe729. Run
`OrbitServiceIntegrationTests` from that archive on an instance.