### PR TITLE
Remove unneeded includes

### DIFF
--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include <gmock/gmock.h>
-#include <google/protobuf/stubs/port.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/LinuxTracing/SwitchesStatesNamesVisitorTest.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitorTest.cpp
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include <gmock/gmock.h>
-#include <google/protobuf/stubs/port.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -4,7 +4,6 @@
 
 #include <asm/perf_regs.h>
 #include <gmock/gmock.h>
-#include <google/protobuf/stubs/port.h>
 #include <gtest/gtest.h>
 #include <sys/mman.h>
 #include <unwindstack/Error.h>


### PR DESCRIPTION
These were probably added automatically and are actually not used in
these tests.