### PR TITLE
Vulkan layer test collapses the submission track

### DIFF
--- a/contrib/automation_tests/orbit_vulkan_layer.py
+++ b/contrib/automation_tests/orbit_vulkan_layer.py
@@ -34,8 +34,10 @@ def main(argv):
         VerifyTracksExist(track_names=["gfx"]),
         ExpandTrack(expected_name="gfx"),
         CheckTimers(track_name_filter='gfx_submissions', recursive=True),
+        CollapseTrack(expected_name='gfx_submissions', recursive=True),
         CheckTimers(track_name_filter='gfx_marker', recursive=True),
-        CollapseTrack(expected_name="gfx")]
+        CollapseTrack(expected_name="gfx")
+    ]
     suite = E2ETestSuite(test_name="Vulkan Layer", test_cases=test_cases)
     suite.execute()
 

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -182,13 +182,13 @@ class CollapsingTrackBase(CaptureWindowE2ETestCaseBase):
     Clicks on a track's triangle toggle and compares the track's height by calling `_verify_height`.
     """
 
-    def _execute(self, expected_name: str):
+    def _execute(self, expected_name: str, recursive: bool = False):
         """
         :param expected_name: The exact name of the track to be collapsed. "*" is allowed as placeholder.
         """
         assert (expected_name != "")
 
-        tracks = self._find_tracks(expected_name)
+        tracks = self._find_tracks(expected_name, recursive=recursive)
 
         self.expect_true(len(tracks) == 1, 'Found track {}'.format(expected_name))
         track = Track(tracks[0])


### PR DESCRIPTION
Previously, the large submission track left the marker track
off-screen. To work around this, the submission track is now collapsed
after verifying timer existence.

Bug: b/206901238