### PR TITLE
Initialize debug frame section if present in PE/COFF files

### DIFF
--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -141,14 +141,17 @@ class PeCoffInterface {
                 "AddressTypeArg must be an unsigned integer and either 4-bytes or 8-bytes");
 
  public:
-  explicit PeCoffInterface(Memory* memory) : coff_memory_(memory) {}
+  explicit PeCoffInterface(Memory* memory) : memory_(memory), coff_memory_(memory) {}
   virtual ~PeCoffInterface() {}
   bool Init();
   ErrorData LastError() const { return last_error_; }
 
   using AddressType = AddressTypeArg;
 
+  DwarfSection* DebugFrameSection() { return debug_frame_.get(); }
+
  private:
+  Memory* memory_;
   PeCoffMemory coff_memory_;
 
   // Parsed data
@@ -188,6 +191,7 @@ class PeCoffInterface {
 
   bool GetSectionName(const std::string& parsed_section_name_string, std::string* result);
   bool InitSections();
+  bool InitDebugFrameSection();
 };
 
 using PeCoffInterface32 = PeCoffInterface<uint32_t>;


### PR DESCRIPTION
When a debug frame section is present in PE/COFF files, we initialize
it to use it as unwinding information. Added a unit test that validates
that the debug frame section is actually initialized correctly, as the
debug frame `Init()` method does no validation of data. 

Tested: Unit tests.
Bug: http://b/192514457