### PR TITLE
Replace google::protobuf::int64 by int64_t

### DIFF
--- a/src/CaptureFile/FileFragmentInputStream.cpp
+++ b/src/CaptureFile/FileFragmentInputStream.cpp
@@ -56,7 +56,7 @@ bool FileFragmentInputStream::Skip(int count) {
   return current_position_ < file_fragments_end_;
 }
 
-google::protobuf::int64 FileFragmentInputStream::ByteCount() const {
+int64_t FileFragmentInputStream::ByteCount() const {
   return current_position_ - file_fragments_start_;
 }
 

--- a/src/CaptureFile/FileFragmentInputStream.h
+++ b/src/CaptureFile/FileFragmentInputStream.h
@@ -6,6 +6,7 @@
 #define FILE_FRAGMENT_INPUT_STREAM_H_
 
 #include <google/protobuf/io/zero_copy_stream.h>
+#include <stdint.h>
 
 #include <optional>
 
@@ -39,7 +40,7 @@ class FileFragmentInputStream : public google::protobuf::io::ZeroCopyInputStream
   // Skips a number of bytes.
   // https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream#ZeroCopyInputStream.Skip.details
   bool Skip(int count) override;
-  google::protobuf::int64 ByteCount() const override;
+  int64_t ByteCount() const override;
 
   [[nodiscard]] std::optional<ErrorMessage> GetLastError() const { return last_error_; }
 


### PR DESCRIPTION
The former makes problems in the internal build.
`int64_t` is also the type used in the base class.