### PR TITLE
Make internal library path absolute

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -34,6 +34,12 @@ namespace {
 using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::ModuleInfo;
 
+/* copybara:insert(In internal tests the library path depends on the current path)
+// Since some part could potentially change the current working directory we store
+// the initial value here.
+const std::filesystem::path initial_current_path = std::filesystem::current_path();
+*/
+
 ErrorMessageOr<std::filesystem::path> GetLibraryPath() {
   // When packaged, liborbituserspaceinstrumentation.so is found alongside OrbitService. In
   // development, it is found in "../lib", relative to OrbitService.
@@ -42,7 +48,8 @@ ErrorMessageOr<std::filesystem::path> GetLibraryPath() {
   std::vector<std::filesystem::path> potential_paths = {exe_dir / kLibName,
                                                         exe_dir / ".." / "lib" / kLibName};
   /* copybara:insert(In internal tests the library is in a different place)
-  potential_paths.emplace_back("@@LIB_ORBIT_USER_SPACE_INSTRUMENTATION_PATH@@");
+  potential_paths.emplace_back(initial_current_path /
+  "@@LIB_ORBIT_USER_SPACE_INSTRUMENTATION_PATH@@");
   */
   for (const auto& path : potential_paths) {
     if (std::filesystem::exists(path)) {


### PR DESCRIPTION
A recent PR (#2984) introduced the requirement that the path returned by
GetLibraryPath needs to be absolute (which is a good thing). The
internal handling didn't take this into account, so this change ensures
that also in the internal case an absolute path is returned.

Unfortunately this absolute path will still be based on the current
working directory. It is possible to determine the location of the
library based on the test executable location but that changes between
test executables and can't be determined in general here.

The best solution is probably to make the list of checked paths
changeable by the tests instead of being hard-coded. But that's a little
more effort, hence this quick fix.