### PR TITLE
Take module into account in BuildCaptureOptions

### DIFF
--- a/src/UserSpaceInstrumentation/TestUtils.h
+++ b/src/UserSpaceInstrumentation/TestUtils.h
@@ -6,6 +6,7 @@
 #define USER_SPACE_INSTRUMENTATION_TEST_UTILS_H_
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -13,8 +14,14 @@
 
 namespace orbit_user_space_instrumentation {
 
-// Returns the relative address of the function `function_name` in the test executable.
-AddressRange GetFunctionRelativeAddressRangeOrDie(std::string_view function_name);
+struct FunctionLocation {
+  std::string module_file_path;
+  AddressRange relative_address_range;
+};
+
+// Returns the relative address of the function `function_name` and the corresponding module
+// file path in the test process.
+[[nodiscard]] FunctionLocation FindFunctionOrDie(std::string_view function_name);
 
 // Returns the absolute virtual memory address range of function `function_name` in the test
 // executable.

--- a/src/UserSpaceInstrumentation/TestUtilsTest.cpp
+++ b/src/UserSpaceInstrumentation/TestUtilsTest.cpp
@@ -64,7 +64,7 @@ TEST(TestUtilTest, Disassemble) {
 
 TEST(TestUtilTest, GetFunctionAddressRangeInFile) {
   constexpr const char* kFunctionName = "SomethingToDisassemble";
-  AddressRange range = GetFunctionRelativeAddressRangeOrDie(kFunctionName);
+  AddressRange range = FindFunctionOrDie(kFunctionName).relative_address_range;
   EXPECT_NE(0, range.start);
   EXPECT_LT(range.start, range.end);
 }


### PR DESCRIPTION
BuildCaptureOptions used to assume that the added functions are part of the
module containing the `main` function. That's not the case when the tests
are built using shared linking and the main module only contains GTest's
main function while all the test cases are located in shared libraries.

This commit fixes that by also returning the module file path when
looking for the function's address.