### PR TITLE
Extend EventLoop functionality

### DIFF
--- a/src/QtUtils/EventLoopTest.cpp
+++ b/src/QtUtils/EventLoopTest.cpp
@@ -172,7 +172,7 @@ TEST(EventLoop, reuseLoop) {
     EXPECT_EQ(result.value(), 0);
   }
 
-  // 3. premature error
+  // 4. premature error
   loop.error(std::make_error_code(std::errc::bad_message));
   {
     const auto result = loop.exec();

--- a/src/QtUtils/EventLoopTest.cpp
+++ b/src/QtUtils/EventLoopTest.cpp
@@ -71,6 +71,26 @@ TEST(EventLoop, exec) {
       ASSERT_EQ(result.error(), std::errc::bad_message);
     }
   }
+
+  // Case 4: The event loop immediately returns due to a queued result (quit).
+  {
+    orbit_qt_utils::EventLoop loop{};
+    ASSERT_FALSE(loop.isRunning());
+    loop.quit();
+
+    QMetaObject::invokeMethod(
+        &loop,
+        []() {
+          FAIL();  // This task will be queued but never executes since the event loop is supposed
+                   // to return early.
+        },
+        Qt::QueuedConnection);
+    {
+      const auto result = loop.exec();
+      ASSERT_FALSE(result.has_error());
+      EXPECT_EQ(result.value(), 0);
+    }
+  }
 }
 
 TEST(EventLoop, exit) {
@@ -101,4 +121,62 @@ TEST(EventLoop, processEvents) {
 
   loop.processEvents();
   EXPECT_TRUE(called);
+}
+
+TEST(EventLoop, reuseLoop) {
+  // Testing whether Eventloop can be reused, similar to QEventloop
+
+  orbit_qt_utils::EventLoop loop{};
+  ASSERT_FALSE(loop.isRunning());
+
+  // 1. normal quit
+  QMetaObject::invokeMethod(
+      &loop,
+      [&]() {
+        ASSERT_TRUE(loop.isRunning());
+        loop.quit();
+      },
+      Qt::QueuedConnection);
+  {
+    const auto result = loop.exec();
+    ASSERT_FALSE(result.has_error());
+    EXPECT_EQ(result.value(), 0);
+  }
+
+  // 2. normal error
+  QMetaObject::invokeMethod(
+      &loop,
+      [&]() {
+        ASSERT_TRUE(loop.isRunning());
+        loop.error(std::make_error_code(std::errc::bad_message));
+      },
+      Qt::QueuedConnection);
+  {
+    const auto result = loop.exec();
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), std::errc::bad_message);
+  }
+
+  // 3. premature quit
+  loop.quit();
+  QMetaObject::invokeMethod(
+      &loop,
+      []() {
+        FAIL();  // This task will be queued but never executes since the event loop is supposed
+                 // to return early.
+      },
+      Qt::QueuedConnection);
+  {
+    const auto result = loop.exec();
+    ASSERT_FALSE(result.has_error());
+    EXPECT_EQ(result.value(), 0);
+  }
+
+  // 3. premature error
+  loop.error(std::make_error_code(std::errc::bad_message));
+  {
+    const auto result = loop.exec();
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), std::errc::bad_message);
+  }
 }


### PR DESCRIPTION
This changes the EventLoop::exec functionality to not just allow and
error before its running, but also a non error result (integer value).

It also slightly tweaks the behaviour if Eventloop so it can be
restarted (exec called again), to resemble the behaviour of QEventLoop.

Part of http://b/174561221
Test: Unit test + starting & connecting of Orbit to manually check
that everything still works