### PR TITLE
Add Bazel BUILD files to Orbit

### DIFF
--- a/src/Api/BUILD
+++ b/src/Api/BUILD
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "Api",
+    deps = [
+        "//src/ApiInterface",
+        "//src/ApiUtils",
+        "//src/CaptureEventProducer",
+        "//src/OrbitBase",
+        "//src/ProducerSideChannel",
+        "@com_google_absl//absl/base",
+    ],
+)
+
+orbit_cc_test(
+    name = "ApiTests",
+    deps = [
+        ":Api",
+    ],
+)

--- a/src/ApiInterface/BUILD
+++ b/src/ApiInterface/BUILD
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = [
+    "//:__subpackages__",
+    "//:users",
+])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "ApiInterface",
+)
+
+orbit_cc_test(
+    name = "ApiInterfaceTests",
+    deps = [
+        ":ApiInterface",
+    ],
+)

--- a/src/ApiLoader/BUILD
+++ b/src/ApiLoader/BUILD
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "ApiLoader",
+    deps = [
+        "//src/ApiUtils",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "//src/UserSpaceInstrumentation",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+orbit_cc_test(
+    name = "ApiLoaderTests",
+    deps = [
+        ":ApiLoader",
+    ],
+)

--- a/src/ApiUtils/BUILD
+++ b/src/ApiUtils/BUILD
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "ApiUtils",
+    deps = [
+        "//src/ApiInterface",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/OrbitBase",
+        "@com_google_absl//absl/base",
+    ],
+)
+
+orbit_cc_test(
+    name = "ApiUtilsTests",
+    deps = [
+        ":ApiUtils",
+        "//src/GrpcProtos:capture_cc_proto",
+        "@com_google_protobuf//:differencer",
+    ],
+)

--- a/src/CaptureEventProducer/BUILD
+++ b/src/CaptureEventProducer/BUILD
@@ -1,0 +1,37 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "CaptureEventProducer",
+    deps = [
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/GrpcProtos:producer_side_services_cc_grpc_proto",
+        "//src/GrpcProtos:producer_side_services_cc_proto",
+        "//src/OrbitBase",
+        "@com_github_cameron314_concurrentqueue//concurrentqueue",
+        "@com_github_grpc_grpc//:grpc",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_protobuf//:arena",
+    ],
+)
+
+orbit_cc_test(
+    name = "CaptureEventProducerTests",
+    deps = [
+        ":CaptureEventProducer",
+        "//src/FakeProducerSideService",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/GrpcProtos:producer_side_services_cc_proto",
+        "@com_github_grpc_grpc//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:arena",
+    ],
+)

--- a/src/CaptureFile/BUILD
+++ b/src/CaptureFile/BUILD
@@ -1,0 +1,32 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "CaptureFile",
+    deps = [
+        "//src/ClientProtos:user_defined_capture_info_cc_proto",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/OrbitBase",
+        "@com_google_absl//absl/base",
+        "@com_google_protobuf//:io_lite",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+orbit_cc_test(
+    name = "CaptureFileTests",
+    deps = [
+        ":CaptureFile",
+        "//src/OrbitBase",
+        "//src/TestUtils",
+        "@com_google_absl//absl/base",
+        "@com_google_protobuf//:io_lite",
+    ],
+)

--- a/src/CaptureService/BUILD
+++ b/src/CaptureService/BUILD
@@ -1,0 +1,39 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "CaptureService",
+    deps = [
+        "//src/ApiLoader",
+        "//src/ApiUtils",
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/GrpcProtos:services_cc_grpc_proto",
+        "//src/Introspection",
+        "//src/LinuxTracing",
+        "//src/MemoryTracing",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "//src/OrbitVersion",
+        "//src/ProducerEventProcessor",
+        "//src/UserSpaceInstrumentation",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+    ],
+)
+
+orbit_cc_test(
+    name = "CaptureServiceTests",
+    deps = [
+        ":CaptureService",
+    ],
+)

--- a/src/CaptureUploader/BUILD
+++ b/src/CaptureUploader/BUILD
@@ -1,0 +1,22 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "CaptureUploader",
+    deps = [
+    ],
+)
+
+orbit_cc_test(
+    name = "CaptureUploaderTests",
+    deps = [
+        ":CaptureUploader",
+    ],
+)

--- a/src/ClientProtos/BUILD
+++ b/src/ClientProtos/BUILD
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("@rules_cc/cc:defs.bzl", "cc_proto_library")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+# Proto Library targets
+
+proto_library(
+    name = "user_defined_capture_info_proto",
+    srcs = ["user_defined_capture_info.proto"],
+)
+
+# CC Proto and GRPC Library targets
+
+cc_proto_library(
+    name = "user_defined_capture_info_cc_proto",
+    deps = [
+        ":user_defined_capture_info_proto",
+    ],
+)

--- a/src/CrashService/BUILD
+++ b/src/CrashService/BUILD
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "CrashService",
+    deps = [
+        "//src/GrpcProtos:services_cc_grpc_proto",
+        "//src/GrpcProtos:services_cc_proto",
+        "//src/OrbitBase",
+        "@com_github_grpc_grpc//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+    ],
+)
+
+orbit_cc_test(
+    name = "CrashServiceTest",
+    deps = [
+        ":CrashService",
+    ],
+)

--- a/src/FakeProducerSideService/BUILD
+++ b/src/FakeProducerSideService/BUILD
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "FakeProducerSideService",
+    testonly = True,
+)
+
+orbit_cc_test(
+    name = "FakeProducerSideServiceTests",
+    deps = [
+        ":FakeProducerSideService",
+    ],
+)

--- a/src/FramePointerValidator/BUILD
+++ b/src/FramePointerValidator/BUILD
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "FramePointerValidator",
+    deps = [
+        "//src/GrpcProtos:code_block_cc_proto",
+        "//src/OrbitBase",
+        "@com_github_capstone-engine_capstone//capstone",
+    ],
+)
+
+orbit_cc_test(
+    name = "FramePointerValidatorTests",
+    deps = [
+        ":FramePointerValidator",
+        "//src/GrpcProtos:code_block_cc_proto",
+        "//src/GrpcProtos:symbol_cc_proto",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "@com_github_capstone-engine_capstone//capstone",
+    ],
+)

--- a/src/FramePointerValidatorService/BUILD
+++ b/src/FramePointerValidatorService/BUILD
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "FramePointerValidatorService",
+    deps = [
+        "//src/FramePointerValidator",
+        "//src/GrpcProtos:code_block_cc_proto",
+        "//src/GrpcProtos:services_cc_grpc_proto",
+        "//src/GrpcProtos:services_cc_proto",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "@com_github_grpc_grpc//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+orbit_cc_test(
+    name = "FramePointerValidatorServiceTests",
+    deps = [
+        ":FramePointerValidatorService",
+    ],
+)

--- a/src/GrpcProtos/BUILD
+++ b/src/GrpcProtos/BUILD
@@ -1,0 +1,165 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("@rules_cc/cc:defs.bzl", "cc_proto_library")
+load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+# This library target is needed because there is a header-file in include/.
+orbit_cc_library(
+    name = "GrpcProtos",
+)
+
+orbit_cc_test(
+    name = "GrpcProtosTests",
+    deps = [
+        ":GrpcProtos",
+    ],
+)
+
+# Proto Library targets
+
+proto_library(
+    name = "capture_proto",
+    srcs = ["capture.proto"],
+    deps = [
+        ":module_proto",
+        ":tracepoint_proto",
+    ],
+)
+
+proto_library(
+    name = "code_block_proto",
+    srcs = ["code_block.proto"],
+)
+
+proto_library(
+    name = "module_proto",
+    srcs = ["module.proto"],
+)
+
+proto_library(
+    name = "process_proto",
+    srcs = ["process.proto"],
+)
+
+proto_library(
+    name = "producer_side_services_proto",
+    srcs = ["producer_side_services.proto"],
+    has_services = True,
+    deps = [
+        ":capture_proto",
+    ],
+)
+
+proto_library(
+    name = "services_ggp_proto",
+    srcs = ["services_ggp.proto"],
+    has_services = True,
+)
+
+proto_library(
+    name = "services_proto",
+    srcs = ["services.proto"],
+    has_services = True,
+    deps = [
+        ":capture_proto",
+        ":code_block_proto",
+        ":module_proto",
+        ":process_proto",
+        ":tracepoint_proto",
+    ],
+)
+
+proto_library(
+    name = "symbol_proto",
+    srcs = ["symbol.proto"],
+)
+
+proto_library(
+    name = "tracepoint_proto",
+    srcs = ["tracepoint.proto"],
+)
+
+# CC Proto and GRPC Library targets
+
+cc_proto_library(
+    name = "code_block_cc_proto",
+    deps = [
+        ":code_block_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "capture_cc_proto",
+    deps = [
+        ":capture_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "module_cc_proto",
+    deps = [
+        ":module_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "symbol_cc_proto",
+    deps = [
+        ":symbol_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "tracepoint_cc_proto",
+    deps = [
+        ":tracepoint_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "producer_side_services_cc_proto",
+    deps = [
+        ":producer_side_services_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "process_cc_proto",
+    deps = [
+        ":process_proto",
+    ],
+)
+
+cc_grpc_library(
+    name = "producer_side_services_cc_grpc_proto",
+    srcs = [
+        ":producer_side_services_proto",
+    ],
+    deps = [
+        ":producer_side_services_cc_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "services_cc_proto",
+    deps = [
+        ":services_proto",
+    ],
+)
+
+cc_grpc_library(
+    name = "services_cc_grpc_proto",
+    srcs = [
+        ":services_proto",
+    ],
+    deps = [
+        ":services_cc_proto",
+    ],
+)

--- a/src/Introspection/BUILD
+++ b/src/Introspection/BUILD
@@ -1,0 +1,32 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "Introspection",
+    deps = [
+        "//src/ApiInterface",
+        "//src/ApiUtils",
+        "//src/OrbitBase",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+    ],
+)
+
+orbit_cc_test(
+    name = "IntrospectionTests",
+    deps = [
+        ":Introspection",
+        "//src/ApiUtils",
+        "//src/OrbitBase",
+        "@com_google_absl//absl/container:flat_hash_map",
+    ],
+)

--- a/src/LinuxCaptureService/BUILD
+++ b/src/LinuxCaptureService/BUILD
@@ -1,0 +1,40 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "LinuxCaptureService",
+    deps = [
+        "//src/ApiLoader",
+        "//src/ApiUtils",
+        "//src/CaptureService",
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/Introspection",
+        "//src/LinuxTracing",
+        "//src/MemoryTracing",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "//src/OrbitVersion",
+        "//src/ProducerEventProcessor",
+        "//src/UserSpaceInstrumentation",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+    ],
+)
+
+orbit_cc_test(
+    name = "LinuxCaptureServiceTest",
+    deps = [
+        ":LinuxCaptureService",
+    ],
+)

--- a/src/LinuxTracing/BUILD
+++ b/src/LinuxTracing/BUILD
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "LinuxTracing",
+    deps = [
+        "//src/ApiInterface",
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/GrpcProtos:module_cc_proto",
+        "//src/GrpcProtos:tracepoint_cc_proto",
+        "//src/Introspection",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "//third_party/libunwindstack",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/meta:type_traits",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+orbit_cc_test(
+    name = "LinuxTracingTests",
+    deps = [
+        ":LinuxTracing",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/OrbitBase",
+        "//third_party/libunwindstack",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/src/MemoryTracing/BUILD
+++ b/src/MemoryTracing/BUILD
@@ -1,0 +1,38 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "MemoryTracing",
+    deps = [
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/Introspection",
+        "//src/OrbitBase",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+    ],
+)
+
+orbit_cc_test(
+    name = "MemoryTracingTests",
+    deps = [
+        ":MemoryTracing",
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/OrbitBase",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+    ],
+)

--- a/src/ObjectUtils/BUILD
+++ b/src/ObjectUtils/BUILD
@@ -1,0 +1,50 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "ObjectUtils",
+    exclude = glob(["*Dia.*"]),
+    deps = [
+        "//src/GrpcProtos:module_cc_proto",
+        "//src/GrpcProtos:symbol_cc_proto",
+        "//src/OrbitBase",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@llvm-project//llvm:BinaryFormat",
+        "@llvm-project//llvm:DebugInfoCodeView",
+        "@llvm-project//llvm:DebugInfoDWARF",
+        "@llvm-project//llvm:DebugInfoMSF",
+        "@llvm-project//llvm:DebugInfoPDB",
+        "@llvm-project//llvm:Demangle",
+        "@llvm-project//llvm:Object",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//llvm:Symbolize",
+    ],
+)
+
+orbit_cc_test(
+    name = "ObjectUtilsTests",
+    exclude = glob(["*DiaTest.*"]),
+    deps = [
+        ":ObjectUtils",
+        "//src/GrpcProtos:module_cc_proto",
+        "//src/GrpcProtos:symbol_cc_proto",
+        "//src/OrbitBase",
+        "//src/TestUtils",
+        "@com_github_ned14_outcome//outcome",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
+    ],
+)

--- a/src/OrbitBase/BUILD
+++ b/src/OrbitBase/BUILD
@@ -1,0 +1,42 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "OrbitBase",
+    exclude = [
+        "GetLastError.cpp",  # Windows-only
+    ],
+    deps = [
+        "@com_github_ned14_outcome//outcome",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/debugging:stacktrace",
+        "@com_google_absl//absl/debugging:symbolize",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+orbit_cc_test(
+    name = "OrbitBaseTests",
+    deps = [
+        ":OrbitBase",
+        "//src/TestUtils",
+        "@com_github_ned14_outcome//outcome",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
+    ],
+)

--- a/src/OrbitVersion/BUILD
+++ b/src/OrbitVersion/BUILD
@@ -1,0 +1,24 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "OrbitVersion",
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+orbit_cc_test(
+    name = "OrbitVersionTests",
+    deps = [
+        ":OrbitVersion",
+    ],
+)

--- a/src/ProcessService/BUILD
+++ b/src/ProcessService/BUILD
@@ -1,0 +1,40 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "ProcessService",
+    deps = [
+        "//src/GrpcProtos:module_cc_proto",
+        "//src/GrpcProtos:process_cc_proto",
+        "//src/GrpcProtos:services_cc_grpc_proto",
+        "//src/GrpcProtos:services_cc_proto",
+        "//src/GrpcProtos:tracepoint_cc_proto",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "@com_github_grpc_grpc//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+orbit_cc_test(
+    name = "ProcessServiceTests",
+    deps = [
+        ":ProcessService",
+        "//src/GrpcProtos:services_cc_proto",
+        "//src/GrpcProtos:tracepoint_cc_proto",
+        "//src/OrbitBase",
+        "//src/TestUtils",
+    ],
+)

--- a/src/ProducerEventProcessor/BUILD
+++ b/src/ProducerEventProcessor/BUILD
@@ -1,0 +1,40 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "ProducerEventProcessor",
+    deps = [
+        "//src/CaptureFile",
+        "//src/CaptureUploader",
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/GrpcProtos:services_cc_grpc_proto",
+        "//src/Introspection",
+        "//src/OrbitBase",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_protobuf//:arena",
+    ],
+)
+
+orbit_cc_test(
+    name = "ProducerEventProcessorTests",
+    deps = [
+        ":ProducerEventProcessor",
+        "//src/CaptureFile",
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/GrpcProtos:services_cc_grpc_proto",
+        "//src/OrbitBase",
+        "@com_github_grpc_grpc//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:differencer",
+    ],
+)

--- a/src/ProducerSideChannel/BUILD
+++ b/src/ProducerSideChannel/BUILD
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "ProducerSideChannel",
+)
+
+orbit_cc_test(
+    name = "ProducerSideChannelTests",
+    deps = [
+        ":ProducerSideChannel",
+    ],
+)

--- a/src/Service/BUILD
+++ b/src/Service/BUILD
@@ -1,0 +1,89 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "Service",
+    exclude = [
+        "main.cpp",
+    ],
+    deps = [
+        "//src/ApiLoader",
+        "//src/ApiUtils",
+        "//src/CaptureService",
+        "//src/CrashService",
+        "//src/FramePointerValidator",
+        "//src/FramePointerValidatorService",
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/GrpcProtos:code_block_cc_proto",
+        "//src/GrpcProtos:module_cc_proto",
+        "//src/GrpcProtos:process_cc_proto",
+        "//src/GrpcProtos:producer_side_services_cc_proto",
+        "//src/GrpcProtos:services_cc_grpc_proto",
+        "//src/GrpcProtos:services_cc_proto",
+        "//src/GrpcProtos:tracepoint_cc_proto",
+        "//src/Introspection",
+        "//src/LinuxCaptureService",
+        "//src/LinuxTracing",
+        "//src/MemoryTracing",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "//src/OrbitVersion",
+        "//src/ProcessService",
+        "//src/ProducerSideChannel",
+        "//src/TracepointService",
+        "//src/UserSpaceInstrumentation",
+        "@com_github_grpc_grpc//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_protobuf//:arena",
+    ],
+)
+
+orbit_cc_test(
+    name = "ServiceTests",
+    deps = [
+        ":Service",
+        "//src/GrpcProtos",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/GrpcProtos:producer_side_services_cc_grpc_proto",
+        "//src/GrpcProtos:producer_side_services_cc_proto",
+        "//src/GrpcProtos:services_cc_proto",
+        "//src/GrpcProtos:tracepoint_cc_proto",
+        "//src/OrbitBase",
+        "//src/ProducerEventProcessor",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:differencer",
+    ],
+)
+
+cc_binary(
+    name = "OrbitService",
+    srcs = [
+        "main.cpp",
+    ],
+    deps = [
+        ":Service",
+        "//src/OrbitBase",
+        "//src/OrbitVersion",
+        "@com_google_absl//absl/flags:config",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/flags:usage",
+    ],
+)

--- a/src/Test/BUILD
+++ b/src/Test/BUILD
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "Test",
+    exclude = [
+        "test_*.cpp",
+    ],
+    deps = [
+        "//src/OrbitBase",
+    ],
+)
+
+orbit_cc_test(
+    name = "TestTests",
+)

--- a/src/TestUtils/BUILD
+++ b/src/TestUtils/BUILD
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "TestUtils",
+    testonly = True,
+    deps = [
+        "//src/OrbitBase",
+    ],
+)
+
+orbit_cc_test(
+    name = "TestUtilsTests",
+    deps = [
+        ":TestUtils",
+        "//src/OrbitBase",
+    ],
+)

--- a/src/TracepointService/BUILD
+++ b/src/TracepointService/BUILD
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "TracepointService",
+    deps = [
+        "//src/GrpcProtos:services_cc_grpc_proto",
+        "//src/GrpcProtos:services_cc_proto",
+        "//src/GrpcProtos:tracepoint_cc_proto",
+        "//src/OrbitBase",
+        "@com_github_grpc_grpc//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+orbit_cc_test(
+    name = "TracepointServiceTests",
+    deps = [
+        ":TracepointService",
+        "//src/GrpcProtos:tracepoint_cc_proto",
+        "//src/TestUtils",
+    ],
+)

--- a/src/UserSpaceInstrumentation/BUILD
+++ b/src/UserSpaceInstrumentation/BUILD
@@ -1,0 +1,119 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+orbit_cc_library(
+    name = "UserSpaceInstrumentation",
+    exclude = [
+        "OrbitUserSpaceInstrumentation.*",
+        "UserSpaceInstrumentationTestLib.*",
+    ],
+    deps = [
+        "//src/CaptureEventProducer",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "//src/ProducerSideChannel",
+        "@com_github_capstone-engine_capstone//capstone",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/time",
+    ],
+)
+
+cc_library(
+    name = "OrbitUserSpaceInstrumentation",
+    srcs = [
+        "OrbitUserSpaceInstrumentation.cpp",
+        "OrbitUserSpaceInstrumentation.h",
+    ],
+    deps = [
+        ":UserSpaceInstrumentation",
+        "//src/CaptureEventProducer",
+        "//src/OrbitBase",
+        "//src/ProducerSideChannel",
+    ],
+)
+
+cc_library(
+    name = "UserSpaceInstrumentationTestLib",
+    srcs = [
+        "UserSpaceInstrumentationTestLib.cpp",
+        "UserSpaceInstrumentationTestLib.h",
+    ],
+    deps = [
+        ":UserSpaceInstrumentation",
+        "//src/CaptureEventProducer",
+        "//src/OrbitBase",
+        "//src/ProducerSideChannel",
+    ],
+)
+
+genrule(
+    name = "UserSpaceInstrumentationTestLibRuntimeDependency",
+    srcs = [
+        ":UserSpaceInstrumentationTestLib",
+    ],
+    outs = [
+        "libUserSpaceInstrumentationTestLib.so",
+    ],
+    cmd = """
+    for file in $(execpaths :UserSpaceInstrumentationTestLib); do
+      if [[ $$file == *.so ]]; then
+        cp "$$file" "$@"
+        break
+      fi
+    done
+  """,
+)
+
+genrule(
+    name = "OrbitUserSpaceInstrumentationRuntimeDependency",
+    srcs = [
+        ":OrbitUserSpaceInstrumentation",
+    ],
+    outs = [
+        "libOrbitUserSpaceInstrumentation.so",
+    ],
+    cmd = """
+    for file in $(execpaths :OrbitUserSpaceInstrumentation); do
+      if [[ $$file == *.so ]]; then
+        cp "$$file" "$@"
+        break
+      fi
+    done
+  """,
+)
+
+orbit_cc_test(
+    name = "UserSpaceInstrumentationTests",
+    srcs = select({
+        # TrampolineTest requires AVX support
+        "//tools/target_cpu:haswell": ["TrampolineTest.cpp"],
+        "//conditions:default": [],
+    }),
+    data = [
+        ":OrbitUserSpaceInstrumentationRuntimeDependency",
+        ":UserSpaceInstrumentationTestLibRuntimeDependency",
+    ],
+    # TrampolineTest requires AVX and is added selectively depending on the target architecture.
+    exclude = ["TrampolineTest.cpp"],
+    deps = [
+        ":UserSpaceInstrumentation",
+        "//src/GrpcProtos:capture_cc_proto",
+        "//src/ObjectUtils",
+        "//src/OrbitBase",
+        "//src/TestUtils",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/time",
+    ],
+)

--- a/third_party/libunwindstack/BUILD
+++ b/third_party/libunwindstack/BUILD
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2021 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a (hopefully temporary) fork of libunwindstack
+# (https://android.googlesource.com/platform/system/unwinding/+/refs/heads/master/libunwindstack/)
+# with additional support for Windows and mixed callstack unwinding.
+# It is maintained by the Orbit profiler team in
+# https://github.com/google/orbit/tree/main/third_party/libunwindstack
+
+package_group(
+    name = "users",
+    packages = [
+        "//...",
+    ],
+)
+
+package(default_visibility = ["//third_party/libunwindstack:users"])
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "libunwindstack",
+    srcs = [
+        "ArmExidx.cpp",
+        "ArmExidx.h",
+        "AsmGetRegsX86_64.S",
+        "Check.h",
+        "DexFiles.cpp",
+        "DwarfCfa.cpp",
+        "DwarfCfa.h",
+        "DwarfDebugFrame.h",
+        "DwarfEhFrame.h",
+        "DwarfEhFrameWithHdr.cpp",
+        "DwarfEhFrameWithHdr.h",
+        "DwarfEncoding.h",
+        "DwarfMemory.cpp",
+        "DwarfOp.cpp",
+        "DwarfOp.h",
+        "DwarfSection.cpp",
+        "Elf.cpp",
+        "ElfInterface.cpp",
+        "ElfInterfaceArm.cpp",
+        "ElfInterfaceArm.h",
+        "Global.cpp",
+        "GlobalDebugImpl.h",
+        "JitDebug.cpp",
+        "LocalUnwinder.cpp",
+        "LogStdout.cpp",
+        "MapInfo.cpp",
+        "Maps.cpp",
+        "Memory.cpp",
+        "MemoryBuffer.h",
+        "MemoryCache.h",
+        "MemoryFileAtOffset.h",
+        "MemoryLocal.h",
+        "MemoryMte.cpp",
+        "MemoryOffline.h",
+        "MemoryOfflineBuffer.h",
+        "MemoryRange.h",
+        "MemoryRemote.h",
+        "MemoryXz.cpp",
+        "MemoryXz.h",
+        "Object.cpp",
+        "PeCoffInterface.cpp",
+        "Regs.cpp",
+        "RegsArm.cpp",
+        "RegsArm64.cpp",
+        "RegsInfo.h",
+        "RegsMips.cpp",
+        "RegsMips64.cpp",
+        "RegsX86.cpp",
+        "RegsX86_64.cpp",
+        "Symbols.cpp",
+        "ThreadEntry.cpp",
+        "ThreadEntry.h",
+        "Unwinder.cpp",
+    ],
+    hdrs = glob(
+        [
+            "include/unwindstack/*.h",
+            "include/*.h",
+        ],
+        exclude = [
+            # Dex-support is Android-specific
+            "include/unwindstack/DexFile.h",
+            # These headers aren't self-contained
+            "include/unwindstack/Arch.h",
+            "include/unwindstack/DwarfMemory.h",
+            "include/unwindstack/RegsGetLocal.h",
+            "include/unwindstack/User*.h",
+        ],
+    ),
+    copts = [
+        "-Wno-c99-designator",
+        "-Wno-ctad-maybe-unsupported",
+        "-Wno-logical-op-parentheses",
+    ],
+    includes = [
+        "include/",
+    ],
+    textual_hdrs = glob([
+        # These headers aren't self-contained
+        "include/unwindstack/User*.h",
+    ]) + [
+        "Symbols.h",
+        "include/unwindstack/Arch.h",
+        "include/unwindstack/DwarfMemory.h",
+        "include/unwindstack/RegsGetLocal.h",
+    ],
+    deps = [
+        "@android_platform_system_libbase//:libbase",
+        "@android_platform_system_libprocinfo//:libprocinfo",
+        "@com_7-zip_org_sdk//lzma",
+    ],
+)


### PR DESCRIPTION
This adds Bazel BUILD files for all modules needed to compile
OrbitService. The top level BUILD and WORKSPACE files are missing
because for now we will only use these internally. Proper Bazel BUILD
support might come at a later stage or never. The internal macro
definitions (`orbit_cc_library` and `orbit_cc_test`) are also not part
of this commit.

I created all build targets using glob-patterns which avoids the need to
explicitly list each file. This will lower the burden of maintaining two
buildsystem definitions at least a bit. Dependency changes though need
to be made explicitly for both CMake and Bazel/Blaze. I considered
writing some script that can translate from CMake dependency lists to Bazel
dependencies automatically, but that's not easily achievable due to
the different architecture of packages. Our Abseil CMake package for
example only has one dependency target (`CONAN_PKG::abseil`) while in
the Bazel world the package consists of multiple smaller modules
(i.e. `//absl//strings:str_format`). Hence a script would require
more semantic information than the CMakeLists.txt file can provide.

There is a draft CL (http://cl/412066606) which shows how these BUILD files look
like when imported and transformed by copybara. The CL also proves that
the build and the presubmit checks succeed.