### PR TITLE
[rebase onto main] Fix TracingHandler::ProcessFunction{Entry,Exit} after tracer_.reset()

### DIFF
--- a/src/LinuxCaptureService/TracingHandler.cpp
+++ b/src/LinuxCaptureService/TracingHandler.cpp
@@ -40,7 +40,10 @@ void TracingHandler::Start(
 void TracingHandler::Stop() {
   CHECK(tracer_ != nullptr);
   tracer_->Stop();
-  tracer_.reset();
+  // tracer_ is not reset as FunctionEntry and FunctionExit events could still arrive afterwards. In
+  // that case the Tracer will simply not process them.
+  // Leaving the reset to the destructor means that an object of this class cannot be reused by
+  // calling Start again.
 }
 
 void TracingHandler::OnSchedulingSlice(SchedulingSlice scheduling_slice) {

--- a/src/LinuxCaptureService/TracingHandler.h
+++ b/src/LinuxCaptureService/TracingHandler.h
@@ -23,6 +23,10 @@
 
 namespace orbit_linux_capture_service {
 
+// Wrapper around LinuxTracing and its orbit_linux_tracing::Tracer that forwards the received events
+// to the ProducerEventProcessor.
+// An instance of this class should not be reused for multiple captures, i.e., Start and Stop should
+// only be called once.
 class TracingHandler : public orbit_linux_tracing::TracerListener {
  public:
   explicit TracingHandler(


### PR DESCRIPTION
We leave the reset to the destructor.
I also tried the solution using a mutex, but the behavior at the end of a
capture with a very large number of event was different. In particular, a huge
gap in instrumentation data at the end of the capture could be observed. So I
think that this is a safer option.

Unfortunately I was never able to actually reproduce the crash so that makes it
harder to judge what the best solution is.

Bug: http://b/207480127

Test: I tried this on a synthetic benchmark with various functions to
instrument, including one called more than 10M times per second.