### PR TITLE
Add initial fuzzing for PE/COFF parsing in libunwindstack

### DIFF
--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -361,3 +361,8 @@ set_target_properties(libunwindstack_local PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO $<TARGET_FILE_DIR:libunwindstack_tests>)
 set_target_properties(libunwindstack_local PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY_DEBUG $<TARGET_FILE_DIR:libunwindstack_tests>)
+
+# Fuzz testing for parsers
+add_fuzzer(PeCoffInterfaceFuzzer tests/fuzz/PeCoffInterfaceFuzzer.cpp)
+target_include_directories(PeCoffInterfaceFuzzer PRIVATE include/)
+target_link_libraries(PeCoffInterfaceFuzzer PRIVATE libunwindstack)

--- a/third_party/libunwindstack/tests/fuzz/PeCoffInterfaceFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffInterfaceFuzzer.cpp
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <inttypes.h>
+#include <cstddef>
+
+#include <unwindstack/Memory.h>
+#include <unwindstack/PeCoffInterface.h>
+
+// The most basic fuzzer for PE/COFF parsing. Generates really poor coverage as
+// it is not PE/COFF file structure aware.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  std::shared_ptr<unwindstack::Memory> memory =
+      unwindstack::Memory::CreateOfflineMemory(data, 0, size);
+  unwindstack::PeCoffInterface<uint64_t> pe_coff_interface(memory.get());
+  return 0;
+}

--- a/third_party/libunwindstack/tests/fuzz/PeCoffInterfaceFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffInterfaceFuzzer.cpp
@@ -27,5 +27,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(data, 0, size);
   unwindstack::PeCoffInterface<uint64_t> pe_coff_interface(memory.get());
+  pe_coff_interface.Init();
   return 0;
 }


### PR DESCRIPTION
This adds a first fuzzer for PE/COFF parsing. The fuzzer is extremely
basic and generates very poor coverage as it is not at all aware of
the structure of PE/COFF files. This will be fixed later. For now,
this is added to establish the structure of how we add fuzzing tests
for libunwindstack and to make sure it shows up in our oss-fuzz
integration. Next steps will be to add a custom mutator and/or add a
corpus of PE/COFF files to trigger more code paths.

Tested: Ran fuzzer locally.
Bug: http://b/192514457