### PR TITLE
Service shutdown improvements

### DIFF
--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -44,9 +44,10 @@ int OrbitServiceMain() {
   LOG("OrbitService started");
   std::atomic<bool> exit_requested = false;
   // OrbitService's loop terminates when EOF is received, no need to manipulate exit_requested.
-  int rc = orbit_service::OrbitService{kOrbitServicePort, /*dev_mode=*/false}.Run(&exit_requested);
-  LOG("OrbitService finished with return code %d", rc);
-  return rc;
+  int exit_code =
+      orbit_service::OrbitService{kOrbitServicePort, /*dev_mode=*/false}.Run(&exit_requested);
+  LOG("OrbitService finished with exit code %d", exit_code);
+  return exit_code;
 }
 
 using PuppetConstants = IntegrationTestPuppetConstants;

--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -44,9 +44,9 @@ int OrbitServiceMain() {
   LOG("OrbitService started");
   std::atomic<bool> exit_requested = false;
   // OrbitService's loop terminates when EOF is received, no need to manipulate exit_requested.
-  orbit_service::OrbitService{kOrbitServicePort, /*dev_mode=*/false}.Run(&exit_requested);
-  LOG("OrbitService finished");
-  return 0;
+  int rc = orbit_service::OrbitService{kOrbitServicePort, /*dev_mode=*/false}.Run(&exit_requested);
+  LOG("OrbitService finished with return code %d", rc);
+  return rc;
 }
 
 using PuppetConstants = IntegrationTestPuppetConstants;

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -152,13 +152,13 @@ int OrbitService::Run(std::atomic<bool>* exit_requested) {
 
   std::unique_ptr<OrbitGrpcServer> grpc_server = CreateGrpcServer(grpc_port_, dev_mode_);
   if (grpc_server == nullptr) {
-    ERROR("Unable to create grpc server.");
+    ERROR("Unable to create gRPC server.");
     return -1;
   }
 
   std::unique_ptr<ProducerSideServer> producer_side_server = BuildAndStartProducerSideServer();
   if (producer_side_server == nullptr) {
-    ERROR("Unable to build and start producer side server.");
+    ERROR("Unable to build and start ProducerSideServer.");
     return -1;
   }
   grpc_server->AddCaptureStartStopListener(producer_side_server.get());

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -189,7 +189,7 @@ int OrbitService::Run(std::atomic<bool>* exit_requested) {
       }
     }
 
-    std::this_thread::sleep_for(std::chrono::seconds{1});
+    std::this_thread::sleep_for(std::chrono::milliseconds{200});
   }
 
   producer_side_server->ShutdownAndWait();

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -141,7 +141,7 @@ static std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServer() {
   return producer_side_server;
 }
 
-void OrbitService::Run(std::atomic<bool>* exit_requested) {
+int OrbitService::Run(std::atomic<bool>* exit_requested) {
   PrintInstanceVersions();
   LOG("Running Orbit Service version %s", orbit_version::GetVersionString());
 #ifndef NDEBUG
@@ -152,23 +152,30 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
 
   std::unique_ptr<OrbitGrpcServer> grpc_server = CreateGrpcServer(grpc_port_, dev_mode_);
   if (grpc_server == nullptr) {
-    return;
+    ERROR("Unable to create grpc server.");
+    return -1;
   }
 
   std::unique_ptr<ProducerSideServer> producer_side_server = BuildAndStartProducerSideServer();
   if (producer_side_server == nullptr) {
-    return;
+    ERROR("Unable to build and start producer side server.");
+    return -1;
   }
   grpc_server->AddCaptureStartStopListener(producer_side_server.get());
 
   // Make stdin non-blocking.
   fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
 
+  int return_code = 0;
+
   // Wait for exit_request or for the watchdog to expire.
   while (!(*exit_requested)) {
     std::string stdin_data = ReadStdIn();
     // If ssh sends EOF, end main loop.
-    if (feof(stdin) != 0) break;
+    if (feof(stdin) != 0) {
+      LOG("Received EOF on stdin. Exiting main loop.");
+      break;
+    }
 
     if (IsSshWatchdogActive() || absl::StrContains(stdin_data, kStartWatchdogPassphrase)) {
       if (!stdin_data.empty()) {
@@ -176,6 +183,8 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
       }
 
       if (!IsSshConnectionAlive(last_stdin_message_.value(), kWatchdogTimeoutInSeconds)) {
+        ERROR("Connection is not alive (watchdog timed out). Exiting main loop.");
+        return_code = -1;
         break;
       }
     }
@@ -188,6 +197,8 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
 
   grpc_server->Shutdown();
   grpc_server->Wait();
+
+  return return_code;
 }
 
 }  // namespace orbit_service

--- a/src/Service/OrbitService.h
+++ b/src/Service/OrbitService.h
@@ -23,7 +23,7 @@ class OrbitService {
   explicit OrbitService(uint16_t grpc_port, bool dev_mode)
       : grpc_port_{grpc_port}, dev_mode_{dev_mode} {}
 
-  void Run(std::atomic<bool>* exit_requested);
+  [[nodiscard]] int Run(std::atomic<bool>* exit_requested);
 
  private:
   [[nodiscard]] bool IsSshWatchdogActive() { return last_stdin_message_ != std::nullopt; }

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -62,5 +62,5 @@ int main(int argc, char** argv) {
 
   exit_requested = false;
   orbit_service::OrbitService service{grpc_port, dev_mode};
-  service.Run(&exit_requested);
+  return service.Run(&exit_requested);
 }


### PR DESCRIPTION
Small change mainly adding a returning -1 when OrbitService quits after a problem and logging for those cases. 

Also reduces the sleep time in the OrbitService main loop from 1s to 200ms. This is mainly so OrbitService reacts quickly when the user triggers a disconnect (upcoming PR)