### PR TITLE
Fix crash in recursive instrumentation.

### DIFF
--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
@@ -12,8 +12,10 @@ extern "C" void StartNewCapture();
 
 // Payload called on entry of an instrumented function. Needs to record the return address of the
 // function (in order to have it available in `ExitPayload`) and the stack pointer (i.e., the
-// address of the return address). `function_id` is the id of the instrumented function.
-extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer);
+// address of the return address). `function_id` is the id of the instrumented function. Also needs
+// to overwrite the return address stored at `stack_pointer` with the `return_trampoline_address`.
+extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer,
+                             uint64_t return_trampoline_address);
 
 // Payload called on exit of an instrumented function. Needs to return the actual return address of
 // the function such that the execution can be continued there.

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -117,7 +117,7 @@ struct RelocatedInstruction {
 // Creates a trampoline for the function at `function_address`. The trampoline is built at
 // `trampoline_address`. The trampoline will call `entry_payload_function_address` with the
 // function's return address, a function id, the address on the stack where the return address is
-// stored and and the address of the return trampoline as parameters. The function id is written
+// stored, and the address of the return trampoline as parameters. The function id is written
 // into the trampoline by `InstrumentFunction`. This is necessary since the function id is not
 // stable across multiple profiling runs. `function` contains the beginning of the function
 // (kMaxFunctionPrologueBackupSize bytes or less if the function shorter). `capstone_handle` is a

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -116,18 +116,19 @@ struct RelocatedInstruction {
 
 // Creates a trampoline for the function at `function_address`. The trampoline is built at
 // `trampoline_address`. The trampoline will call `entry_payload_function_address` with the
-// function's return address, a function id and the address on the stack where the return address is
-// stored as parameters. The function id is written into the trampoline by `InstrumentFunction`.
-// This is necessary since the function id is not stable across multiple profiling runs.
-// `function` contains the beginning of the function (kMaxFunctionPrologueBackupSize bytes or less
-// if the function shorter). `capstone_handle` is a handle to the capstone disassembler library
-// returned by cs_open. The function returns an error if it was not possible to instrument the
-// function. For details on that see the comments at AppendRelocatedPrologueCode. If the function is
-// successful it will insert an address pair into `relocation_map` for each instruction it relocated
-// from the beginning of the function into the trampoline (needed for moving instruction pointers
-// away from the overwritten bytes at the beginning of the function, compare
-// MoveInstructionPointersOutOfOverwrittenCode below). The return value is the address of the first
-// instruction not relocated into the trampoline (i.e. the address the trampoline jump back to).
+// function's return address, a function id, the address on the stack where the return address is
+// stored and and the address of the return trampoline as parameters. The function id is written
+// into the trampoline by `InstrumentFunction`. This is necessary since the function id is not
+// stable across multiple profiling runs. `function` contains the beginning of the function
+// (kMaxFunctionPrologueBackupSize bytes or less if the function shorter). `capstone_handle` is a
+// handle to the capstone disassembler library returned by cs_open. The function returns an error if
+// it was not possible to instrument the function. For details on that see the comments at
+// AppendRelocatedPrologueCode. If the function is successful it will insert an address pair into
+// `relocation_map` for each instruction it relocated from the beginning of the function into the
+// trampoline (needed for moving instruction pointers away from the overwritten bytes at the
+// beginning of the function, compare MoveInstructionPointersOutOfOverwrittenCode below). The return
+// value is the address of the first instruction not relocated into the trampoline (i.e. the address
+// the trampoline jump back to).
 [[nodiscard]] ErrorMessageOr<uint64_t> CreateTrampoline(
     pid_t pid, uint64_t function_address, const std::vector<uint8_t>& function,
     uint64_t trampoline_address, uint64_t entry_payload_function_address,


### PR DESCRIPTION
The previous "fix" restored the return address in the entry payload. But
the return address was altered *after* the call to the entry payload. So
this never worked.

Removed the overwriting of the return address from the trampoline and
shifted it into the entry payload. This way we can decide if it is
appropriate to do the instrumentation or not depending on wether we are
re-entering the payload.

Bug: http://b/207361417
Test: Ran locally. Multiple times.