### PR TITLE
Remove support for building MESA as part of Orbit

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,8 +23,7 @@ class OrbitConan(ConanFile):
     description = "C/C++ Performance Profiler"
     settings = "os", "compiler", "build_type", "arch"
     generators = ["cmake_multi"]
-    options = {"system_mesa": [True, False],
-               "system_qt": [True, False], "with_gui": [True, False],
+    options = {"system_qt": [True, False], "with_gui": [True, False],
                "debian_packaging": [True, False],
                "fPIC": [True, False],
                "crashdump_server": "ANY",
@@ -33,8 +32,7 @@ class OrbitConan(ConanFile):
                "run_python_tests": [True, False],
                "build_target": "ANY",
                "deploy_opengl_software_renderer": [True, False]}
-    default_options = {"system_mesa": True,
-                       "system_qt": True, "with_gui": True,
+    default_options = {"system_qt": True, "with_gui": True,
                        "debian_packaging": False,
                        "fPIC": True,
                        "crashdump_server": "",
@@ -71,10 +69,6 @@ class OrbitConan(ConanFile):
         self.build_requires('gtest/1.11.0', force_host_context=True)
 
     def requirements(self):
-        if self.settings.os != "Windows" and self.options.with_gui and not self.options.system_qt and self.options.system_mesa:
-            raise ConanInvalidConfiguration("When disabling system_qt, you also have to "
-                                            "disable system mesa.")
-
         if self.options.deploy_opengl_software_renderer and self.settings.os != "Windows":
             raise ConanInvalidConfiguration("The OpenGL software renderer can only be deployed on Windows")
         if self.options.deploy_opengl_software_renderer and not self.options.with_gui:
@@ -110,9 +104,6 @@ class OrbitConan(ConanFile):
             self.requires("imgui/1.69@bincrafters/stable#0")
             self.requires("libpng/1.6.37@bincrafters/stable#0")
             self.requires("libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf")
-
-            if not self.options.system_mesa:
-                self.requires("libxi/1.7.10@bincrafters/stable#0")
 
             if not self.options.system_qt:
                 self.requires("qt/5.15.1@{}#e659e981368e4baba1a201b75ddb89b6".format(self._orbit_channel))

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -25,13 +25,12 @@
      "21",
      "18",
      "22",
-     "23",
-     "36"
+     "23"
     ],
     "build_requires": [
-     "58",
-     "60",
-     "61"
+     "45",
+     "47",
+     "48"
     ],
     "path": "../../../conanfile.py",
     "context": "host"
@@ -58,8 +57,8 @@
      "8"
     ],
     "build_requires": [
-     "55",
-     "57"
+     "42",
+     "44"
     ],
     "context": "host"
    },
@@ -168,108 +167,28 @@
     "context": "host"
    },
    "23": {
-    "ref": "libxi/1.7.10@bincrafters/stable#0",
-    "requires": [
-     "24",
-     "35"
-    ],
-    "context": "host"
-   },
-   "24": {
-    "ref": "libxext/1.3.4@bincrafters/stable#0",
-    "requires": [
-     "25"
-    ],
-    "context": "host"
-   },
-   "25": {
-    "ref": "libx11/1.6.8@bincrafters/stable#0",
-    "requires": [
-     "26",
-     "27",
-     "28"
-    ],
-    "context": "host"
-   },
-   "26": {
-    "ref": "xorgproto/2019.1@bincrafters/stable#0",
-    "context": "host"
-   },
-   "27": {
-    "ref": "xtrans/1.4.0@bincrafters/stable#0",
-    "context": "host"
-   },
-   "28": {
-    "ref": "libxcb/1.13.1@bincrafters/stable#0",
-    "requires": [
-     "29",
-     "30",
-     "31",
-     "32",
-     "33"
-    ],
-    "context": "host"
-   },
-   "29": {
-    "ref": "xcb-proto/1.13@bincrafters/stable#0",
-    "context": "host"
-   },
-   "30": {
-    "ref": "util-macros/1.19.2@bincrafters/stable#0",
-    "context": "host"
-   },
-   "31": {
-    "ref": "libxau/1.0.9@bincrafters/stable#0",
-    "requires": [
-     "26"
-    ],
-    "context": "host"
-   },
-   "32": {
-    "ref": "libpthread-stubs/0.1@bincrafters/stable#0",
-    "context": "host"
-   },
-   "33": {
-    "ref": "libxdmcp/1.1.3@bincrafters/stable#0",
-    "requires": [
-     "34"
-    ],
-    "context": "host"
-   },
-   "34": {
-    "ref": "xproto/7.0.31@bincrafters/stable#0",
-    "context": "host"
-   },
-   "35": {
-    "ref": "libxfixes/5.0.3@bincrafters/stable#0",
-    "requires": [
-     "25"
-    ],
-    "context": "host"
-   },
-   "36": {
     "ref": "qt/5.15.1@orbitdeps/stable#e659e981368e4baba1a201b75ddb89b6",
     "requires": [
      "5",
      "6",
-     "37",
-     "38",
-     "44",
+     "24",
+     "25",
+     "31",
      "17",
-     "45",
-     "48",
-     "49",
-     "50",
+     "32",
+     "35",
+     "36",
+     "37",
      "18",
-     "51",
-     "52",
-     "46",
-     "53",
-     "54"
+     "38",
+     "39",
+     "33",
+     "40",
+     "41"
     ],
     "context": "host"
    },
-   "37": {
+   "24": {
     "ref": "pcre2/10.33#54adea8f4f46f14720b65849988c274a",
     "requires": [
      "5",
@@ -277,23 +196,23 @@
     ],
     "context": "host"
    },
-   "38": {
+   "25": {
     "ref": "glib/2.64.0@bincrafters/stable#0",
     "requires": [
      "5",
-     "39",
-     "40",
-     "41",
-     "42",
-     "43"
+     "26",
+     "27",
+     "28",
+     "29",
+     "30"
     ],
     "context": "host"
    },
-   "39": {
+   "26": {
     "ref": "libffi/3.2.1#778fb4699ab6f90aed4141fddd75ca83",
     "context": "host"
    },
-   "40": {
+   "27": {
     "ref": "pcre/8.41#b1c67efc54f003e2c0d15593ef5ee473",
     "requires": [
      "2",
@@ -301,120 +220,120 @@
     ],
     "context": "host"
    },
-   "41": {
+   "28": {
     "ref": "libelf/0.8.13#db17656a3054ad46af79109ce012e28f",
     "context": "host"
    },
-   "42": {
+   "29": {
     "ref": "libmount/2.33.1#5208204d4209a8619cda0879ab3f95f8",
     "context": "host"
    },
-   "43": {
+   "30": {
     "ref": "libselinux/2.9@bincrafters/stable#0",
     "requires": [
-     "37"
+     "24"
     ],
     "context": "host"
    },
-   "44": {
+   "31": {
     "ref": "double-conversion/3.1.5#bf7fceaa33f97d13a341039f49a5ec8f",
     "context": "host"
    },
-   "45": {
+   "32": {
     "ref": "fontconfig/2.13.91#f352b873e84bdb407e9d26f10c4d5ace",
     "requires": [
      "17",
-     "46",
-     "47"
+     "33",
+     "34"
     ],
     "context": "host"
    },
-   "46": {
+   "33": {
     "ref": "expat/2.2.9#9f476bdcbd34f15324d82b9bdfed2e99",
     "context": "host"
    },
-   "47": {
+   "34": {
     "ref": "libuuid/1.0.3#840ba593f58e204662dc518dc9158ea6",
     "context": "host"
    },
-   "48": {
+   "35": {
     "ref": "icu/64.2#8e5b14365280b23e74c951a6415bbef8",
     "context": "host"
    },
-   "49": {
+   "36": {
     "ref": "harfbuzz/2.6.8#5733395ae2752d74034dccb6a94e9be8",
     "requires": [
      "17"
     ],
     "context": "host"
    },
-   "50": {
+   "37": {
     "ref": "libjpeg/9d#9c2c46fd74c85f5e6058e14abcf985e4",
     "context": "host"
    },
-   "51": {
+   "38": {
     "ref": "xorg/system#313b5d45c4669424c20daa86289e0d2e",
     "context": "host"
    },
-   "52": {
+   "39": {
     "ref": "zstd/1.4.4#914f28f51eabce8d0120a09a7627376d",
     "context": "host"
    },
-   "53": {
+   "40": {
     "ref": "opus/1.3.1#bb9e103e40877d9a8123672d4fd7ae8d",
     "context": "host"
    },
-   "54": {
+   "41": {
     "ref": "opengl/system#e59f5699a39ea3b426a4194bccd77fe9",
     "context": "host"
    },
-   "55": {
+   "42": {
     "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
     "requires": [
-     "56"
+     "43"
     ],
     "context": "host"
    },
-   "56": {
+   "43": {
     "ref": "protobuf/3.9.1@bincrafters/stable#0",
     "context": "host"
    },
-   "57": {
+   "44": {
     "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
     "requires": [
      "1",
      "8",
      "6",
      "7",
-     "55",
+     "42",
      "5"
     ],
     "context": "host"
    },
-   "58": {
+   "45": {
     "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
     "requires": [
-     "59"
+     "46"
     ],
     "context": "host"
    },
-   "59": {
+   "46": {
     "ref": "protobuf/3.9.1@bincrafters/stable#0",
     "context": "host"
    },
-   "60": {
+   "47": {
     "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
     "requires": [
      "1",
      "8",
      "6",
      "7",
-     "58",
+     "45",
      "5"
     ],
     "context": "host"
    },
-   "61": {
+   "48": {
     "ref": "gtest/1.11.0#088aa58a3c2115519f99667eee50d0a1",
     "context": "host"
    }

--- a/third_party/conan/lockfiles/gen_lockfiles.sh
+++ b/third_party/conan/lockfiles/gen_lockfiles.sh
@@ -10,7 +10,7 @@ if [[ $(uname -s) != Linux ]]; then
 fi
 
 conan lock create ${REPO_ROOT}/conanfile.py \
-  -o system_qt=False -o system_mesa=False  \
+  -o system_qt=False \
   -s os=Linux \
   --build=grpc \
   --user=orbitdeps --channel=stable \


### PR DESCRIPTION
We don't use that and it has been broken for a while so I expect that
also nobody in the wild is using that. So let's just remove it.

It was only ever interesting when compiling Qt from source (which we
only do on Windows).