### PR TITLE
Add additional timings to measure full frame time

### DIFF
--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -102,6 +102,8 @@ class CaptureWindow : public GlCanvas {
   uint64_t select_start_time_ = 0;
   uint64_t select_stop_time_ = 0;
 
+  uint64_t last_frame_start_time_ = 0;
+
   bool click_was_drag_ = false;
   bool background_clicked_ = false;
 


### PR DESCRIPTION
This splits the frame times into two parts:
* Time spent to `Draw` and `UpdatePrimitives` inside `CaptureWindow::Draw`
* Time from one `CaptureWindow::Draw` call to the next to include everything that is happening outside of our control (QT events, async GPU work etc)