### PR TITLE
Add fuzzing for 32-bit PE/COFF files

### DIFF
--- a/third_party/libunwindstack/tests/fuzz/PeCoffInterfaceFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffInterfaceFuzzer.cpp
@@ -21,12 +21,19 @@
 #include <unwindstack/Memory.h>
 #include <unwindstack/PeCoffInterface.h>
 
-// The most basic fuzzer for PE/COFF parsing. Generates really poor coverage as
-// it is not PE/COFF file structure aware.
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+namespace {
+template <typename AddressType>
+void FuzzPeCoffInterface(const uint8_t* data, size_t size) {
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(data, 0, size);
-  unwindstack::PeCoffInterface<uint64_t> pe_coff_interface(memory.get());
+  unwindstack::PeCoffInterface<AddressType> pe_coff_interface(memory.get());
   pe_coff_interface.Init();
+}
+}  // namespace
+
+// The most basic fuzzer for PE/COFF parsing, not PE/COFF structure aware.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  FuzzPeCoffInterface<uint32_t>(data, size);
+  FuzzPeCoffInterface<uint64_t>(data, size);
   return 0;
 }


### PR DESCRIPTION
The initial fuzzer implementation for PE/COFF only worked on 64-bit
files, this is now fixed to also include 32-bit.

I have also removed a comment that says that the basic fuzzer
generated poor coverage because the coverage on oss-fuzz actually
seems quite good.

It is unclear to me whether the 32-bit and 64-bit versions should
run in the same fuzzer target or whether we should have two targets.
The current version (both in the same fuzzer) is favored so far,
as the corpus (which is generated incrementally by oss-fuzz) is
actually quite similar for 32-bit and 64-bit, so this should benefit
coverage. In addition, reading the code coverage report with both
versions in the same fuzzer is easier: Without one version, the
coverage reports contains large parts indicating that the other
version wasn't instantiated.

Tested: Built & ran fuzzer locally.
Bug: http://b/208200278