### PR TITLE
Add required psutil package to installation instructions for E2E tests

### DIFF
--- a/contrib/automation_tests/README.md
+++ b/contrib/automation_tests/README.md
@@ -26,6 +26,7 @@ Once you've activated the virtual environment, install the dependencies:
 
 ```
 pip install absl-py
+pip install psutil
 pip install pywinauto
 ```
 


### PR DESCRIPTION
The psutil package needs to be installed when one wants to run the
Orbit E2E tests locally, but the installation instructions don't
mention it so far. This is fixed by this change.