### PR TITLE
Enable Conan Tracing in CI builds

### DIFF
--- a/kokoro/builds/linux/clang7_relwithdebinfo/common.cfg
+++ b/kokoro/builds/linux/clang7_relwithdebinfo/common.cfg
@@ -10,3 +10,10 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/conan_trace.log"
+    strip_prefix: "github/orbitprofiler/build"
+  }
+}

--- a/kokoro/builds/linux/clang9_debug/common.cfg
+++ b/kokoro/builds/linux/clang9_debug/common.cfg
@@ -10,3 +10,10 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/conan_trace.log"
+    strip_prefix: "github/orbitprofiler/build"
+  }
+}

--- a/kokoro/builds/linux/coverage_clang9/common.cfg
+++ b/kokoro/builds/linux/coverage_clang9/common.cfg
@@ -10,3 +10,10 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/conan_trace.log"
+    strip_prefix: "github/orbitprofiler/build"
+  }
+}

--- a/kokoro/builds/linux/gcc10_release/common.cfg
+++ b/kokoro/builds/linux/gcc10_release/common.cfg
@@ -10,3 +10,10 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/conan_trace.log"
+    strip_prefix: "github/orbitprofiler/build"
+  }
+}

--- a/kokoro/builds/linux/gcc9_relwithdebinfo/common.cfg
+++ b/kokoro/builds/linux/gcc9_relwithdebinfo/common.cfg
@@ -10,3 +10,10 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/conan_trace.log"
+    strip_prefix: "github/orbitprofiler/build"
+  }
+}

--- a/kokoro/builds/linux/ggp_relwithdebinfo/common.cfg
+++ b/kokoro/builds/linux/ggp_relwithdebinfo/common.cfg
@@ -10,3 +10,10 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/conan_trace.log"
+    strip_prefix: "github/orbitprofiler/build"
+  }
+}

--- a/kokoro/builds/windows/msvc2019_relwithdebinfo/common.cfg
+++ b/kokoro/builds/windows/msvc2019_relwithdebinfo/common.cfg
@@ -10,3 +10,10 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/conan_trace.log"
+    strip_prefix: "github/orbitprofiler/build"
+  }
+}


### PR DESCRIPTION
This enables Conan's [tracing feature](https://docs.conan.io/en/latest/mastering/logging.html#how-to-log-and-debug-a-conan-execution) on the CI.

It will hopefully allow to detect the root cause of the failing presubmit builds.