### PR TITLE
Replace Batcher* with Batcher& in UpdatePrimitives

### DIFF
--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -80,7 +80,7 @@ void BasicPageFaultsTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
 }
 
 void BasicPageFaultsTrack::DrawSingleSeriesEntry(
-    Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
+    Batcher& batcher, uint64_t start_tick, uint64_t end_tick,
     const std::array<float, kBasicPageFaultsTrackDimension>& current_normalized_values,
     const std::array<float, kBasicPageFaultsTrackDimension>& next_normalized_values, float z,
     bool is_last) {
@@ -95,7 +95,7 @@ void BasicPageFaultsTrack::DrawSingleSeriesEntry(
   float width = time_graph_->GetWorldFromTick(end_tick) - x0;
   float content_height = GetGraphContentHeight();
   float y0 = GetGraphContentBottomY() - GetGraphContentHeight();
-  batcher->AddShadedBox(Vec2(x0, y0), Vec2(width, content_height), z, kHightlightingColor);
+  batcher.AddShadedBox(Vec2(x0, y0), Vec2(width, content_height), z, kHightlightingColor);
 }
 
 bool BasicPageFaultsTrack::IsCollapsed() const {

--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -44,7 +44,7 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
               const DrawContext& draw_context) override;
 
   void DrawSingleSeriesEntry(
-      Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
+      Batcher& batcher, uint64_t start_tick, uint64_t end_tick,
       const std::array<float, kBasicPageFaultsTrackDimension>& current_normalized_values,
       const std::array<float, kBasicPageFaultsTrackDimension>& next_normalized_values, float z,
       bool is_last) override;

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -43,7 +43,7 @@ class CallstackThreadBar : public ThreadBar {
  protected:
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
-  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+  void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                           uint64_t max_tick, PickingMode picking_mode) override;
 
  private:

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -32,12 +32,12 @@ void CaptureViewElement::Draw(Batcher& batcher, TextRenderer& text_renderer,
   batcher.PopTranslation();
 }
 
-void CaptureViewElement::UpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+void CaptureViewElement::UpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer,
                                           uint64_t min_tick, uint64_t max_tick,
                                           PickingMode picking_mode) {
   ORBIT_SCOPE_FUNCTION;
 
-  batcher->PushTranslation(0, 0, DetermineZOffset());
+  batcher.PushTranslation(0, 0, DetermineZOffset());
   text_renderer.PushTranslation(0, 0, DetermineZOffset());
 
   DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
@@ -49,7 +49,7 @@ void CaptureViewElement::UpdatePrimitives(Batcher* batcher, TextRenderer& text_r
   }
 
   text_renderer.PopTranslation();
-  batcher->PopTranslation();
+  batcher.PopTranslation();
 }
 
 void CaptureViewElement::UpdateLayout() {

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -82,13 +82,13 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   bool visible_ = true;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context);
-  void UpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+  void UpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                         uint64_t max_tick, PickingMode picking_mode);
 
   virtual void DoDraw(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
                       const DrawContext& /*draw_context*/) {}
 
-  virtual void DoUpdatePrimitives(Batcher* /*batcher*/, TextRenderer& /*text_renderer*/,
+  virtual void DoUpdatePrimitives(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
                                   uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                                   PickingMode /*picking_mode*/) {}
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -81,7 +81,7 @@ void GraphTrack<Dimension>::DoDraw(Batcher& batcher, TextRenderer& text_renderer
 }
 
 template <size_t Dimension>
-void GraphTrack<Dimension>::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+void GraphTrack<Dimension>::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer,
                                                uint64_t min_tick, uint64_t max_tick,
                                                PickingMode picking_mode) {
   Track::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
@@ -93,7 +93,7 @@ void GraphTrack<Dimension>::DoUpdatePrimitives(Batcher* batcher, TextRenderer& t
   Vec2 content_pos = GetPos();
   content_pos[1] += layout_->GetTrackTabHeight();
   Box box(content_pos, Vec2(GetWidth(), content_height + GetLegendHeight()), track_z);
-  batcher->AddBox(box, GetTrackBackgroundColor(), shared_from_this());
+  batcher.AddBox(box, GetTrackBackgroundColor(), shared_from_this());
 
   const bool picking = picking_mode != PickingMode::kNone;
   if (picking) return;
@@ -239,7 +239,7 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
 }
 
 template <size_t Dimension>
-void GraphTrack<Dimension>::DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+void GraphTrack<Dimension>::DrawSeries(Batcher& batcher, uint64_t min_tick, uint64_t max_tick,
                                        float z) {
   auto entries = series_.GetEntriesAffectedByTimeRange(min_tick, max_tick);
   if (entries.empty()) return;
@@ -273,7 +273,7 @@ void GraphTrack<Dimension>::DrawSeries(Batcher* batcher, uint64_t min_tick, uint
 
 template <size_t Dimension>
 void GraphTrack<Dimension>::DrawSingleSeriesEntry(
-    Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
+    Batcher& batcher, uint64_t start_tick, uint64_t end_tick,
     const std::array<float, Dimension>& normalized_cumulative_values, float z) {
   const float x0 = time_graph_->GetWorldFromTick(start_tick);
   const float width = time_graph_->GetWorldFromTick(end_tick) - x0;
@@ -284,7 +284,7 @@ void GraphTrack<Dimension>::DrawSingleSeriesEntry(
   for (size_t i = 0; i < Dimension; ++i) {
     float height = normalized_cumulative_values[i] * content_height - (base_y - y0);
     y0 -= height;
-    batcher->AddShadedBox(Vec2(x0, y0), Vec2(width, height), z, GetColor(i));
+    batcher.AddShadedBox(Vec2(x0, y0), Vec2(width, height), z, GetColor(i));
   }
 }
 

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -68,7 +68,7 @@ class GraphTrack : public Track {
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
 
-  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+  void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                           uint64_t max_tick, PickingMode picking_mode) override;
 
   [[nodiscard]] virtual Color GetColor(size_t index) const;
@@ -95,7 +95,7 @@ class GraphTrack : public Track {
   virtual void DrawLegend(Batcher& batcher, TextRenderer& text_renderer,
                           const std::array<std::string, Dimension>& series_names,
                           const Color& legend_text_color);
-  virtual void DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick, float z);
+  virtual void DrawSeries(Batcher& batcher, uint64_t min_tick, uint64_t max_tick, float z);
 
   [[nodiscard]] double RoundPrecision(double value) {
     return std::round(value * std::pow(10, GetNumberOfDecimalDigits())) /
@@ -106,7 +106,7 @@ class GraphTrack : public Track {
 
  private:
   [[nodiscard]] virtual std::string GetLegendTooltips(size_t legend_index) const = 0;
-  void DrawSingleSeriesEntry(Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
+  void DrawSingleSeriesEntry(Batcher& batcher, uint64_t start_tick, uint64_t end_tick,
                              const std::array<float, Dimension>& normalized_values, float z);
 
   std::optional<std::array<Color, Dimension>> series_colors_;

--- a/src/OrbitGl/LineGraphTrack.cpp
+++ b/src/OrbitGl/LineGraphTrack.cpp
@@ -45,7 +45,7 @@ float LineGraphTrack<Dimension>::GetLabelYFromValues(
 }
 
 template <size_t Dimension>
-void LineGraphTrack<Dimension>::DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+void LineGraphTrack<Dimension>::DrawSeries(Batcher& batcher, uint64_t min_tick, uint64_t max_tick,
                                            float z) {
   auto entries = this->series_.GetEntriesAffectedByTimeRange(min_tick, max_tick);
   if (entries.empty()) return;
@@ -80,16 +80,16 @@ void LineGraphTrack<Dimension>::DrawSeries(Batcher* batcher, uint64_t min_tick, 
   }
 }
 
-static void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z,
+static void DrawSquareDot(Batcher& batcher, Vec2 center, float radius, float z,
                           const Color& color) {
   Vec2 position(center[0] - radius, center[1] - radius);
   Vec2 size(2 * radius, 2 * radius);
-  batcher->AddBox(Box(position, size, z), color);
+  batcher.AddBox(Box(position, size, z), color);
 }
 
 template <size_t Dimension>
 void LineGraphTrack<Dimension>::DrawSingleSeriesEntry(
-    Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
+    Batcher& batcher, uint64_t start_tick, uint64_t end_tick,
     const std::array<float, Dimension>& current_normalized_values,
     const std::array<float, Dimension>& next_normalized_values, float z, bool is_last) {
   constexpr float kDotRadius = 2.f;
@@ -101,10 +101,10 @@ void LineGraphTrack<Dimension>::DrawSingleSeriesEntry(
   for (size_t i = Dimension; i-- > 0;) {
     float y0 = base_y - current_normalized_values[i] * content_height;
     DrawSquareDot(batcher, Vec2(x0, y0), kDotRadius, z, this->GetColor(i));
-    batcher->AddLine(Vec2(x0, y0), Vec2(x1, y0), z, this->GetColor(i));
+    batcher.AddLine(Vec2(x0, y0), Vec2(x1, y0), z, this->GetColor(i));
     if (!is_last) {
       float y1 = base_y - next_normalized_values[i] * content_height;
-      batcher->AddLine(Vec2(x1, y0), Vec2(x1, y1), z, this->GetColor(i));
+      batcher.AddLine(Vec2(x1, y0), Vec2(x1, y1), z, this->GetColor(i));
     }
   }
 }

--- a/src/OrbitGl/LineGraphTrack.h
+++ b/src/OrbitGl/LineGraphTrack.h
@@ -23,8 +23,8 @@ class LineGraphTrack : public GraphTrack<Dimension> {
  protected:
   [[nodiscard]] float GetLabelYFromValues(
       const std::array<double, Dimension>& values) const override;
-  void DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick, float z) override;
-  virtual void DrawSingleSeriesEntry(Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
+  void DrawSeries(Batcher& batcher, uint64_t min_tick, uint64_t max_tick, float z) override;
+  virtual void DrawSingleSeriesEntry(Batcher& batcher, uint64_t start_tick, uint64_t end_tick,
                                      const std::array<float, Dimension>& current_normalized_values,
                                      const std::array<float, Dimension>& next_normalized_values,
                                      float z, bool is_last);

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -39,11 +39,11 @@ class ThreadStateBar final : public ThreadBar {
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
 
-  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+  void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                           uint64_t max_tick, PickingMode picking_mode) override;
 
  private:
-  std::string GetThreadStateSliceTooltip(Batcher* batcher, PickingId id) const;
+  std::string GetThreadStateSliceTooltip(Batcher& batcher, PickingId id) const;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -80,7 +80,7 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
 
  protected:
-  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+  void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                           uint64_t max_tick, PickingMode picking_mode) override;
 
   [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -538,7 +538,7 @@ void TimeGraph::PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode) {
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
-  CaptureViewElement::UpdatePrimitives(&batcher_, text_renderer_static_, min_tick, max_tick,
+  CaptureViewElement::UpdatePrimitives(batcher_, text_renderer_static_, min_tick, max_tick,
                                        picking_mode);
 
   batcher_.PopTranslation();

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -241,7 +241,7 @@ bool TimerTrack::DrawTimer(TextRenderer& text_renderer, const TimerInfo* prev_ti
   return true;
 }
 
-void TimerTrack::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+void TimerTrack::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer,
                                     uint64_t min_tick, uint64_t max_tick,
                                     PickingMode picking_mode) {
   Track::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
@@ -252,7 +252,7 @@ void TimerTrack::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_rendere
   draw_data.min_tick = min_tick;
   draw_data.max_tick = max_tick;
 
-  draw_data.batcher = batcher;
+  draw_data.batcher = &batcher;
   draw_data.viewport = viewport_;
 
   draw_data.track_start_x = GetPos()[0];

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -98,7 +98,7 @@ class TimerTrack : public Track {
   [[nodiscard]] uint64_t GetMaxTime() const override;
 
  protected:
-  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+  void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                           uint64_t max_tick, PickingMode /*picking_mode*/) override;
 
   [[nodiscard]] virtual bool IsTimerActive(

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -52,7 +52,7 @@ void TracepointThreadBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
   batcher.AddBox(box, color, shared_from_this());
 }
 
-void TracepointThreadBar::DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer,
+void TracepointThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer,
                                              uint64_t min_tick, uint64_t max_tick,
                                              PickingMode picking_mode) {
   ThreadBar::DoUpdatePrimitives(batcher, text_renderer, min_tick, max_tick, picking_mode);
@@ -76,13 +76,13 @@ void TracepointThreadBar::DoUpdatePrimitives(Batcher* batcher, TextRenderer& tex
           const Vec2 pos(time_graph_->GetWorldFromTick(time), GetPos()[1]);
           if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
             const Color color = tracepoint.pid() == capture_data_->process_id() ? kGrey : kWhite;
-            batcher->AddVerticalLine(pos, -track_height, z, color);
+            batcher.AddVerticalLine(pos, -track_height, z, color);
           } else {
-            batcher->AddVerticalLine(pos, -radius, z, kWhiteTransparent);
-            batcher->AddVerticalLine(Vec2(pos[0], pos[1] - track_height), radius, z,
-                                     kWhiteTransparent);
-            batcher->AddCircle(Vec2(pos[0], pos[1] - track_height / 2), radius, z,
-                               kWhiteTransparent);
+            batcher.AddVerticalLine(pos, -radius, z, kWhiteTransparent);
+            batcher.AddVerticalLine(Vec2(pos[0], pos[1] - track_height), radius, z,
+                                    kWhiteTransparent);
+            batcher.AddCircle(Vec2(pos[0], pos[1] - track_height / 2), radius, z,
+                              kWhiteTransparent);
           }
         });
 
@@ -97,18 +97,17 @@ void TracepointThreadBar::DoUpdatePrimitives(Batcher* batcher, TextRenderer& tex
           Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset,
                    GetPos()[1] - track_height + 1);
           Vec2 size(kPickingBoxWidth, track_height);
-          auto user_data =
-              std::make_unique<PickingUserData>(nullptr, [&, batcher](PickingId id) -> std::string {
-                return GetTracepointTooltip(batcher, id);
-              });
+          auto user_data = std::make_unique<PickingUserData>(
+              nullptr,
+              [&](PickingId id) -> std::string { return GetTracepointTooltip(batcher, id); });
           user_data->custom_data_ = &tracepoint;
-          batcher->AddShadedBox(pos, size, z, kWhite, std::move(user_data));
+          batcher.AddShadedBox(pos, size, z, kWhite, std::move(user_data));
         });
   }
 }
 
-std::string TracepointThreadBar::GetTracepointTooltip(Batcher* batcher, PickingId id) const {
-  auto* user_data = batcher->GetUserData(id);
+std::string TracepointThreadBar::GetTracepointTooltip(Batcher& batcher, PickingId id) const {
+  auto* user_data = batcher.GetUserData(id);
   CHECK(user_data && user_data->custom_data_);
 
   const auto* tracepoint_event_info =

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -31,11 +31,11 @@ class TracepointThreadBar : public ThreadBar {
  protected:
   void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
-  void DoUpdatePrimitives(Batcher* batcher, TextRenderer& text_renderer, uint64_t min_tick,
+  void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                           uint64_t max_tick, PickingMode picking_mode) override;
 
  private:
-  std::string GetTracepointTooltip(Batcher* batcher, PickingId id) const;
+  std::string GetTracepointTooltip(Batcher& batcher, PickingId id) const;
 };
 
 }  // namespace orbit_gl


### PR DESCRIPTION
Other methods (such as Draw) already receive Batcher&, so this way
we're consistent across our drawing methods.