### PR TITLE
Remove usage of internal gRPC API

### DIFF
--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -14,6 +14,7 @@
 #include "SessionSetup/ConnectToTargetDialog.h"
 #include "SessionSetup/ServiceDeployManager.h"
 #include "SessionSetup/SessionSetupUtils.h"
+#include "grpcpp/channel.h"
 #include "ui_ConnectToTargetDialog.h"
 
 namespace orbit_session_setup {
@@ -134,7 +135,7 @@ ConnectToTargetDialog::DeployOrbitService(
 }
 
 ErrorMessageOr<std::unique_ptr<orbit_client_data::ProcessData>>
-ConnectToTargetDialog::FindSpecifiedProcess(std::shared_ptr<grpc_impl::Channel> grpc_channel,
+ConnectToTargetDialog::FindSpecifiedProcess(std::shared_ptr<grpc::Channel> grpc_channel,
                                             uint32_t process_id) {
   CHECK(grpc_channel != nullptr);
 

--- a/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
@@ -16,6 +16,7 @@
 #include "OrbitGgp/SshInfo.h"
 #include "QtUtils/MainThreadExecutorImpl.h"
 #include "TargetConfiguration.h"
+#include "grpcpp/channel.h"
 
 namespace Ui {
 class ConnectToTargetDialog;  // IWYU pragma: keep
@@ -50,7 +51,7 @@ class ConnectToTargetDialog : public QDialog {
   struct ConnectionData {
     std::unique_ptr<orbit_client_data::ProcessData> process_data_;
     std::unique_ptr<orbit_session_setup::ServiceDeployManager> service_deploy_manager_;
-    std::shared_ptr<grpc_impl::Channel> grpc_channel_;
+    std::shared_ptr<grpc::Channel> grpc_channel_;
   };
 
   using MaybeSshAndInstanceData =
@@ -66,7 +67,7 @@ class ConnectToTargetDialog : public QDialog {
   [[nodiscard]] ErrorMessageOr<orbit_session_setup::ServiceDeployManager::GrpcPort>
   DeployOrbitService(orbit_session_setup::ServiceDeployManager* service_deploy_manager);
   [[nodiscard]] ErrorMessageOr<std::unique_ptr<orbit_client_data::ProcessData>>
-  FindSpecifiedProcess(std::shared_ptr<grpc_impl::Channel> grpc_channel, uint32_t process_id);
+  FindSpecifiedProcess(std::shared_ptr<grpc::Channel> grpc_channel, uint32_t process_id);
 
   void SetStatusMessage(const QString& message);
   void LogAndDisplayError(const ErrorMessage& message);


### PR DESCRIPTION
Everything in the `grpc_impl` namespace is not part of the public API
and prone to change.

In this particular case `grpc_impl::Channel` can simply be replaced by
`grpc::Channel`.

I discovered this while trying to update gRPC to a newer version which -
of course - made changes to this part of the code.