### PR TITLE
Replace usages of WIN32 with _WIN32

### DIFF
--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -203,13 +203,13 @@
   ORBIT_SCOPE_WITH_COLOR_AND_GROUP_ID(name, col, kOrbitDefaultGroupId)
 #define ORBIT_SCOPE_WITH_GROUP_ID(name, group_id) \
   ORBIT_SCOPE_WITH_COLOR_AND_GROUP_ID(name, kOrbitColorAuto, group_id)
-#ifdef WIN32
+#ifdef _WIN32
 #define ORBIT_SCOPE_WITH_COLOR_AND_GROUP_ID(name, col, group_id) \
   orbit_api::Scope ORBIT_VAR(name, col, group_id)
 #else
 #define ORBIT_SCOPE_WITH_COLOR_AND_GROUP_ID(name, col, group_id) \
   ORBIT_SCOPE_WITH_COLOR_AND_GROUP_ID_INTERNAL(name, col, group_id, ORBIT_VAR)
-#endif  // WIN32
+#endif  // _WIN32
 
 #endif  // __cplusplus
 
@@ -371,7 +371,7 @@ inline bool orbit_api_active() {
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
 #define ORBIT_VAR ORBIT_UNIQUE(ORB)
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <intrin.h>
 
 #pragma intrinsic(_ReturnAddress)
@@ -383,9 +383,9 @@ inline bool orbit_api_active() {
 // To decode the return address, we call `__builtin_extract_return_addr`.
 #define ORBIT_GET_CALLER_PC() \
   reinterpret_cast<uint64_t>(__builtin_extract_return_addr(__builtin_return_address(0)))
-#endif
+#endif  // _WIN32
 
-#ifdef WIN32
+#ifdef _WIN32
 namespace orbit_api {
 struct Scope {
   __declspec(noinline) Scope(const char* name, orbit_api_color color, uint64_t group_id) {
@@ -411,7 +411,7 @@ struct Scope {
   ~Scope() { ORBIT_CALL(stop); }
 };
 }  // namespace orbit_api
-#endif  // WIN32
+#endif  // _WIN32
 
 #endif  // __cplusplus
 

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -7,7 +7,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#endif  // WIN32
+#endif  // _WIN32
 
 #include <chrono>
 #include <cstdint>

--- a/src/MoveFilesToDocuments/MoveFilesDialog.cpp
+++ b/src/MoveFilesToDocuments/MoveFilesDialog.cpp
@@ -14,7 +14,7 @@ namespace orbit_move_files_to_documents {
 
 MoveFilesDialog::MoveFilesDialog() : QDialog(nullptr), ui_(new Ui::MoveFilesDialog) {
   ui_->setupUi(this);
-#ifdef WIN32
+#ifdef _WIN32
   ui_->label->setText(
       "We are moving captures and presets from %APPDATA%\\OrbitProfiler to Documents\\Orbit. "
       "Please wait...");

--- a/src/OrbitGl/Images.h
+++ b/src/OrbitGl/Images.h
@@ -4,7 +4,7 @@
 
 /* GIMP RGBA C-Source image dump (inject.c) */
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning(push, 0)
 #endif
 
@@ -2859,6 +2859,6 @@ static const struct {
     "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
 };
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning(pop)
 #endif

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -12,7 +12,7 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <KnownFolders.h>
 #include <shlobj.h>
 #endif
@@ -84,7 +84,7 @@ std::filesystem::path CreateOrGetDumpDir() {
 }
 
 std::filesystem::path CreateOrGetOrbitAppDataDir() {
-#ifdef WIN32
+#ifdef _WIN32
   std::filesystem::path path = std::filesystem::path(GetEnvVar("APPDATA")) / "OrbitProfiler";
 #else
   std::filesystem::path path = std::filesystem::path(GetEnvVar("HOME")) / ".orbitprofiler";
@@ -94,7 +94,7 @@ std::filesystem::path CreateOrGetOrbitAppDataDir() {
 }
 
 static std::filesystem::path GetDocumentsPath() {
-#ifdef WIN32
+#ifdef _WIN32
   PWSTR ppszPath;
   HRESULT result = SHGetKnownFolderPath(FOLDERID_Documents, 0, nullptr, &ppszPath);
 

--- a/src/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
@@ -19,7 +19,7 @@
 // clang-format on
 
 #undef VK_LAYER_EXPORT
-#if defined(WIN32)
+#ifdef _WIN32
 #define VK_LAYER_EXPORT extern "C" __declspec(dllexport)
 #else
 #define VK_LAYER_EXPORT extern "C"


### PR DESCRIPTION
The predefined macro to use is `_WIN32`, documented in
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros.
`WIN32` also works because it's defined in `minwindef.h`, but that's not
necessarily guaranteed to be transitively included.

Bug: http://b/208206610

Test: Build on Linux and Windows.