### PR TITLE
Rename load / delete action in PresetsDataView

### DIFF
--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -148,8 +148,8 @@ void PresetsDataView::DoSort() {
   }
 }
 
-const std::string PresetsDataView::kMenuActionLoad = "Load Preset";
-const std::string PresetsDataView::kMenuActionDelete = "Delete Preset";
+const std::string PresetsDataView::kMenuActionLoadPreset = "Load Preset";
+const std::string PresetsDataView::kMenuActionDeletePreset = "Delete Preset";
 const std::string PresetsDataView::kMenuActionShowInExplorer = "Show in Explorer";
 
 std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGrouping(
@@ -160,9 +160,9 @@ std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGroupin
   std::vector<std::string> action_group;
   const PresetFile& preset = GetPreset(selected_indices[0]);
   if (app_->GetPresetLoadState(preset).state != PresetLoadState::kNotLoadable) {
-    action_group.emplace_back(kMenuActionLoad);
+    action_group.emplace_back(kMenuActionLoadPreset);
   }
-  action_group.emplace_back(kMenuActionDelete);
+  action_group.emplace_back(kMenuActionDeletePreset);
   action_group.emplace_back(kMenuActionShowInExplorer);
 
   std::vector<std::vector<std::string>> menu =
@@ -177,11 +177,11 @@ void PresetsDataView::OnContextMenu(const std::string& action, int menu_index,
   // Note that the UI already enforces a single selection.
   CHECK(item_indices.size() == 1);
 
-  if (action == kMenuActionLoad) {
+  if (action == kMenuActionLoadPreset) {
     const PresetFile& preset = GetPreset(item_indices[0]);
     app_->LoadPreset(preset);
 
-  } else if (action == kMenuActionDelete) {
+  } else if (action == kMenuActionDeletePreset) {
     orbit_metrics_uploader::ScopedMetric metric{
         metrics_uploader_, orbit_metrics_uploader::OrbitLogEvent::ORBIT_PRESET_DELETE};
     int row = item_indices[0];

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -70,8 +70,8 @@ class PresetsDataView : public DataView {
     kNumColumns
   };
 
-  static const std::string kMenuActionLoad;
-  static const std::string kMenuActionDelete;
+  static const std::string kMenuActionLoadPreset;
+  static const std::string kMenuActionDeletePreset;
   static const std::string kMenuActionShowInExplorer;
 
  private:


### PR DESCRIPTION
We would like to have action display names defined in `DataView` to
avoid the redefinition of names in different views and the
inconsistencies of action display names.

Hence, we rename the `kMenuActionLoad` as `kMenuActionLoadPreset` and
`kMenuActionDelete` as `kMenuActionDeletePreset` to reduce the ambiguity
of the names.

Bug: http://b/205676296