### PR TITLE
Remove update flag from conan calls

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,8 +54,8 @@ for profile in ${profiles[@]}; do
   mkdir -p build_$profile/ || exit $?
   conan lock create "$DIR/conanfile.py" --user=orbitdeps --channel=stable \
     --build=outdated \
-    --lockfile="$DIR/third_party/conan/lockfiles/base.lock" -u -pr $profile \
+    --lockfile="$DIR/third_party/conan/lockfiles/base.lock" -pr $profile \
     --lockfile-out=build_$profile/conan.lock || exit $?
-  conan install -if build_$profile/ --build outdated --lockfile=build_$profile/conan.lock -u "$DIR" || exit $?
+  conan install -if build_$profile/ --build outdated --lockfile=build_$profile/conan.lock "$DIR" || exit $?
   conan build -bf build_$profile/ "$DIR" || exit $?
 done

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -159,7 +159,7 @@ if [ -n "$1" ]; then
   echo "Invoking conan lock."
   conan lock create "${REPO_ROOT}/conanfile.py" --user=orbitdeps --channel=stable \
     ${BUILD_OPTION} \
-    --lockfile="${REPO_ROOT}/third_party/conan/lockfiles/base.lock" -u -pr ${CONAN_PROFILE} \
+    --lockfile="${REPO_ROOT}/third_party/conan/lockfiles/base.lock" -pr ${CONAN_PROFILE} \
     -o crashdump_server="$CRASHDUMP_SERVER" $PACKAGING_OPTION \
     --lockfile-out="${REPO_ROOT}/build/conan.lock"
 


### PR DESCRIPTION
The `--update` or `-u` flag to conan commands makes conan check the
remote servers for updated recipes and packages. If updated ones
are found they will be downloaded. But that makes no sense in our
case because we use lockfiles which do not allow updating the packages
anyway. Nevertheless the flag has been in-place to work around a bug in
a previous conan version which has been fixed for a while now.

So this commit removes the flag which should also speed up the build a
bit because it avoids rountrips to the server.

I'm changing this now because I have the suspicion that this might be
related to our failing builds on the CI.