### PR TITLE
Add pywinauto script for end-to-end testing loading of PE/COFF symbols

### DIFF
--- a/contrib/automation_tests/orbit_load_symbols_pecoff.py
+++ b/contrib/automation_tests/orbit_load_symbols_pecoff.py
@@ -1,0 +1,43 @@
+"""
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.symbols_tab import LoadSymbols
+from test_cases.symbols_tab import VerifySymbolsLoaded
+"""Load symbols for PE/COFF modules.
+
+Before this script is run there needs to be a gamelet reserved and
+our "triangle application" has to be started.
+
+The script requires absl and pywinauto. Since pywinauto requires the bitness of
+the python installation to match the bitness of the program under test it needs
+to by run from 64 bit python.
+
+This automation script covers a basic workflow:
+ - start Orbit
+ - connect to a gamelet
+ - select a process and load debug symbols for a binary and a shared object
+"""
+
+
+def main(argv):
+    test_cases = [
+        ConnectToStadiaInstance(),
+        FilterAndSelectFirstProcess(process_filter='triangle'),
+        LoadSymbols(module_search_string="triangle.exe"),
+        VerifySymbolsLoaded(symbol_search_string="wWinMain"),
+        LoadSymbols(module_search_string="d3d11.dll"),
+        VerifySymbolsLoaded(symbol_search_string="Present")
+    ]
+    suite = E2ETestSuite(test_name="Load Symbols PE/COFF", test_cases=test_cases)
+    suite.execute()
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -58,6 +58,21 @@ class LoadSymbols(E2ETestCase):
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0)
 
 
+class VerifySymbolsLoaded(E2ETestCase):
+
+    def _execute(self, symbol_search_string: str):
+        logging.info('Start verifying symbols with substring %s are loaded', symbol_search_string)
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+
+        logging.info('Filtering symbols')
+        functions_dataview.filter.set_focus()
+        functions_dataview.filter.set_edit_text('')
+        send_keys(symbol_search_string)
+        logging.info('Verifying at least one symbol with substring %s has been loaded',
+                     symbol_search_string)
+        self.expect_true(functions_dataview.get_row_count() > 1, "Found expected symbol(s)")
+
+
 class FilterAndHookFunction(E2ETestCase):
     """
     Hook a function based on a search string, and verify it is indicated as Hooked in the UI.


### PR DESCRIPTION
This change adds a pywinauto script for end-to-end testing loading of
PE/COFF symbols, by checking if debug symbols for a binary and for a
shared object file can be loaded correctly.

Tested: Ran script locally on workstation.
Bug: http://b/192645176