### PR TITLE
Update GGP SDK version to 1.70

### DIFF
--- a/third_party/conan/configs/linux/profiles/ggp_common
+++ b/third_party/conan/configs/linux/profiles/ggp_common
@@ -11,7 +11,7 @@ os_build=Linux
 arch=x86_64
 arch_build=x86_64
 compiler=clang
-compiler.version=7.0
+compiler.version=11
 compiler.libcxx=libc++
 compiler.fpo=False
 abseil:compiler=clang
@@ -25,7 +25,7 @@ ggp_sdk:extra_c_flags=$C_FLAGS
 ggp_sdk:extra_cxx_flags=$CXX_FLAGS
 
 [build_requires]
-ggp_sdk/1.43.0.14282@orbitdeps/stable#fd040bf6c348d57da36442df061faf4b
+ggp_sdk/1.70.0.23972@orbitdeps/stable#19ae63cc8ebcdc2f846f794474146190
 
 [env]
 LDFLAGS=$LD_FLAGS

--- a/third_party/conan/configs/windows/profiles/ggp_common
+++ b/third_party/conan/configs/windows/profiles/ggp_common
@@ -12,7 +12,7 @@ os_build=Windows
 arch=x86_64
 arch_build=x86_64
 compiler=clang
-compiler.version=7.0
+compiler.version=11
 compiler.libcxx=libc++
 compiler.fpo=False
 abseil:compiler=clang
@@ -26,7 +26,7 @@ ggp_sdk:extra_c_flags=$C_FLAGS
 ggp_sdk:extra_cxx_flags=$CXX_FLAGS
 
 [build_requires]
-ggp_sdk/1.43.0.14282@orbitdeps/stable#fd040bf6c348d57da36442df061faf4b
+ggp_sdk/1.70.0.23972@orbitdeps/stable#19ae63cc8ebcdc2f846f794474146190
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja


### PR DESCRIPTION
This includes an update of the toolchain to LLVM 11.

All the depedency packages have been recompiled with the new toolchain.

Additional manual tests:

- Build of ggp_release and ggp_debug on developer machines: works
- Cross build on Windows: works
- Manual startup of Orbit (Smoke test): works