### PR TITLE
Change vertical scrolling

### DIFF
--- a/src/OrbitGl/AccessibleCaptureViewElement.cpp
+++ b/src/OrbitGl/AccessibleCaptureViewElement.cpp
@@ -21,7 +21,6 @@ orbit_accessibility::AccessibilityRect AccessibleCaptureViewElement::AccessibleR
   const Viewport* viewport = capture_view_element_->GetViewport();
 
   Vec2 pos = capture_view_element_->GetPos();
-  pos[1] -= capture_view_element_->GetTimeGraph()->GetVerticalScrollingOffset();
   Vec2 size = capture_view_element_->GetSize();
 
   Vec2i screen_pos = viewport->WorldToScreen(pos);

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -88,9 +88,7 @@ void CaptureViewElement::SetVisible(bool value) {
 }
 
 void CaptureViewElement::OnPick(int x, int y) {
-  // TODO (b/204422745): Remove dependency to time_graph_->GetVerticalScrollingOffset()
-  mouse_pos_last_click_ =
-      viewport_->ScreenToWorld(Vec2i(x, y)) + Vec2(0, time_graph_->GetVerticalScrollingOffset());
+  mouse_pos_last_click_ = viewport_->ScreenToWorld(Vec2i(x, y));
   picking_offset_ = mouse_pos_last_click_ - pos_;
   mouse_pos_cur_ = mouse_pos_last_click_;
   picked_ = true;
@@ -102,9 +100,7 @@ void CaptureViewElement::OnRelease() {
 }
 
 void CaptureViewElement::OnDrag(int x, int y) {
-  // TODO (b/204422745): Remove dependency to time_graph_->GetVerticalScrollingOffset()
-  mouse_pos_cur_ =
-      viewport_->ScreenToWorld(Vec2i(x, y)) + Vec2(0, time_graph_->GetVerticalScrollingOffset());
+  mouse_pos_cur_ = viewport_->ScreenToWorld(Vec2i(x, y));
   RequestUpdate();
 }
 
@@ -124,7 +120,7 @@ std::vector<CaptureViewElement*> CaptureViewElement::GetChildrenVisibleInViewpor
   for (CaptureViewElement* child : GetNonHiddenChildren()) {
     float child_top_y = child->GetPos()[1];
     float child_bottom_y = child_top_y + child->GetHeight();
-    float screen_top_y = time_graph_->GetVerticalScrollingOffset();
+    float screen_top_y = 0;
     float screen_bottom_y = screen_top_y + viewport_->GetWorldHeight();
     if (child_top_y < screen_bottom_y && child_bottom_y > screen_top_y) {
       result.push_back(child);


### PR DESCRIPTION
Vertical scrolling is now handled by adjusting the position of
`TimeGraph`. This removes the need for `CaptureViewElement` to
explicitly need to know about scrolling in `TimeGraph`.

Bug: Part of b/176086740 to remove the dependency of `TimeGraph` from `Track`.