### PR TITLE
Erase a CHECK in UpdateVisibleTrackList

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -198,7 +198,6 @@ void TrackManager::UpdateVisibleTrackList() {
   // This function assumes we asked before for a update for the visible track list and that tracks
   // are already sorted (in sorted_tracks_).
   CHECK(visible_track_list_needs_update_);
-  CHECK(!sorting_invalidated_);
 
   visible_track_list_needs_update_ = false;
   visible_tracks_.clear();

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -195,8 +195,6 @@ float TrackManager::GetVisibleTracksTotalHeight() const {
 }
 
 void TrackManager::UpdateVisibleTrackList() {
-  // This function assumes we asked before for a update for the visible track list and that tracks
-  // are already sorted (in sorted_tracks_).
   CHECK(visible_track_list_needs_update_);
 
   visible_track_list_needs_update_ = false;

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -94,6 +94,7 @@ class TrackManager {
   void UpdateMovingTrackPositionInVisibleTracks();
   void SortTracks();
   [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
+  // Filter tracks that are already sorted in sorted_tracks_.
   void UpdateVisibleTrackList();
 
   void AddTrack(const std::shared_ptr<Track>& track);


### PR DESCRIPTION
Solving this crash: http://b/208391403.
This CHECK doesn't have a guarantee to be true, since a track could be
added between SortTracks and UpdateVisibleTrackList. Another option is
to lock that method but it's not needed, because we still can insert new
Tracks to be sorted in the next Draw call.

This is still an issue because we have two threads running in
TrackManager (http://b/177200020), and we are aiming to solve this by
making TrackManager to only work with main_thread.