### PR TITLE
Refactor: TimeGraph calculates its own height

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -91,6 +91,17 @@ TimeGraph::~TimeGraph() {
   manual_instrumentation_manager_->RemoveAsyncTimerListener(async_timer_info_listener_.get());
 }
 
+float TimeGraph::GetHeight() const {
+  // Top and Bottom Margin. TODO: Margins should be treated in a different way (http://b/192070555).
+  float total_height = layout_.GetSchedulerTrackOffset() + layout_.GetBottomMargin();
+
+  // Track height including space between them
+  for (auto& track : GetNonHiddenChildren()) {
+    total_height += (track->GetHeight() + layout_.GetSpaceBetweenTracks());
+  }
+  return total_height;
+}
+
 void TimeGraph::UpdateCaptureMinMaxTimestamps() {
   auto [tracks_min_time, tracks_max_time] = track_manager_->GetTracksMinMaxTimestamps();
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -42,9 +42,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
                      PickingManager* picking_manager);
   ~TimeGraph() override;
 
-  [[nodiscard]] float GetHeight() const override {
-    return track_manager_->GetVisibleTracksTotalHeight();
-  }
+  [[nodiscard]] float GetHeight() const override;
 
   void DrawAllElements(Batcher& batcher, TextRenderer& text_renderer, PickingMode& picking_mode,
                        uint64_t current_mouse_time_ns);

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -182,18 +182,6 @@ void TrackManager::SetFilter(const std::string& filter) {
   visible_track_list_needs_update_ = true;
 }
 
-// This function assumes visible track list is updated.
-float TrackManager::GetVisibleTracksTotalHeight() const {
-  // Top and Bottom Margin. TODO: Margins should be treated in a different way (http://b/192070555).
-  float total_height = layout_->GetSchedulerTrackOffset() + layout_->GetBottomMargin();
-
-  // Track height including space between them
-  for (auto& track : visible_tracks_) {
-    total_height += (track->GetHeight() + layout_->GetSpaceBetweenTracks());
-  }
-  return total_height;
-}
-
 void TrackManager::UpdateVisibleTrackList() {
   // This function assumes we asked before for a update for the visible track list and that tracks
   // are already sorted (in sorted_tracks_).

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -50,7 +50,6 @@ class TrackManager {
   void RequestTrackSorting() { sorting_invalidated_ = true; };
   void SetFilter(const std::string& filter);
 
-  [[nodiscard]] float GetVisibleTracksTotalHeight() const;
   void UpdateTrackListForRendering();
 
   [[nodiscard]] std::pair<uint64_t, uint64_t> GetTracksMinMaxTimestamps() const;


### PR DESCRIPTION
Currently in TrackManager, which seems to be confusing.

Test: Load a capture.