### PR TITLE
Fix handling of NInja in CI builds

### DIFF
--- a/third_party/conan/configs/windows_ci/profiles/msvc2019_debug
+++ b/third_party/conan/configs/windows_ci/profiles/msvc2019_debug
@@ -8,4 +8,4 @@ ninja:build_type=Release
 &: ninja/1.10.2
 
 [env]
-CONAN_CMAKE_GENERATOR=Ninja
+&: CONAN_CMAKE_GENERATOR=Ninja

--- a/third_party/conan/configs/windows_ci/profiles/msvc2019_release
+++ b/third_party/conan/configs/windows_ci/profiles/msvc2019_release
@@ -7,4 +7,4 @@ build_type=Release
 &: ninja/1.10.2
 
 [env]
-CONAN_CMAKE_GENERATOR=Ninja
+&: CONAN_CMAKE_GENERATOR=Ninja

--- a/third_party/conan/configs/windows_ci/profiles/msvc2019_relwithdebinfo
+++ b/third_party/conan/configs/windows_ci/profiles/msvc2019_relwithdebinfo
@@ -15,4 +15,4 @@ OrbitProfiler:deploy_opengl_software_renderer=True
 &: ninja/1.10.2
 
 [env]
-CONAN_CMAKE_GENERATOR=Ninja
+&: CONAN_CMAKE_GENERATOR=Ninja


### PR DESCRIPTION
We use Ninja in Windows CI builds because it's faster and we don't need
CMake generate Visual Studio Solution files.

But there was a small bug: Ninja was declared as a build dependency with
`&: ninja/1.10.2`. The ampersand means it only applies to the root
package, not to transitive dependencies.

Later in the profile we tell CMake to use Ninja by setting an
environment variable. But this env variable applies to all package
builds and that leads to compilation errors because CMake is trying to
use Ninja which is not available.

The fix: We also add the ampersand to the definition of the environment
variable.