### PR TITLE
Move stored callstack selection out of TimeGraph

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(ClientData PUBLIC
 add_executable(ClientDataTests)
 target_sources(ClientDataTests PRIVATE
         CallstackDataTest.cpp
+        DataManagerTest.cpp
         FunctionInfoSetTest.cpp
         ModuleDataTest.cpp
         ModuleManagerTest.cpp

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -11,6 +11,7 @@
 #include "ClientData/FunctionUtils.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadUtils.h"
 
 using orbit_client_data::TracepointInfoSet;
 using orbit_client_protos::FunctionInfo;
@@ -103,6 +104,23 @@ void DataManager::SelectTracepoint(const TracepointInfo& info) {
 void DataManager::DeselectTracepoint(const TracepointInfo& info) {
   CHECK(IsTracepointSelected(info));
   selected_tracepoints_.erase(info);
+}
+
+void DataManager::SelectCallstackEvents(
+    const std::vector<orbit_client_protos::CallstackEvent>& selected_callstack_events) {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  selected_callstack_events_by_thread_id_.clear();
+
+  for (auto& event : selected_callstack_events) {
+    selected_callstack_events_by_thread_id_[event.thread_id()].emplace_back(event);
+    selected_callstack_events_by_thread_id_[orbit_base::kAllProcessThreadsTid].emplace_back(event);
+  }
+}
+
+const std::vector<orbit_client_protos::CallstackEvent>& DataManager::GetSelectedCallstackEvents(
+    uint32_t thread_id) {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  return selected_callstack_events_by_thread_id_[thread_id];
 }
 
 bool DataManager::IsTracepointSelected(const TracepointInfo& info) const {

--- a/src/ClientData/DataManagerTest.cpp
+++ b/src/ClientData/DataManagerTest.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+#include "ClientData/DataManager.h"
+#include "OrbitBase/ThreadUtils.h"
+
+namespace orbit_client_protos {
+static bool operator==(const CallstackEvent& lhs, const CallstackEvent& rhs) {
+  return lhs.thread_id() == rhs.thread_id() && lhs.callstack_id() == rhs.callstack_id();
+}
+}  // namespace orbit_client_protos
+
+namespace orbit_client_data {
+
+using orbit_client_protos::CallstackEvent;
+using std::vector;
+
+TEST(DataManager, CallstackEventSelection) {
+  DataManager manager;
+  EXPECT_EQ(0, manager.GetSelectedCallstackEvents(orbit_base::kAllProcessThreadsTid).size());
+
+  const uint32_t t0_id = 0, t1_id = 1, e0_id = 0, e1_id = 1;
+
+  CallstackEvent e0, e1;
+  e0.set_callstack_id(e0_id);
+  e0.set_thread_id(t0_id);
+
+  e1.set_callstack_id(e1_id);
+  e1.set_thread_id(t1_id);
+
+  const vector<CallstackEvent> t0_events{e0};
+  const vector<CallstackEvent> t1_events{e1};
+
+  manager.SelectCallstackEvents(t0_events);
+  EXPECT_EQ(t0_events, manager.GetSelectedCallstackEvents(t0_id));
+  EXPECT_EQ(t0_events, manager.GetSelectedCallstackEvents(orbit_base::kAllProcessThreadsTid));
+
+  manager.SelectCallstackEvents(t1_events);
+  EXPECT_EQ(t1_events, manager.GetSelectedCallstackEvents(t1_id));
+  EXPECT_EQ(0, manager.GetSelectedCallstackEvents(t0_id).size());
+  EXPECT_EQ(t1_events, manager.GetSelectedCallstackEvents(orbit_base::kAllProcessThreadsTid));
+}
+
+TEST(DataManager, CallstackEventSelectionCanOnlyBeUsedFromMainThread) {
+  DataManager manager;
+  EXPECT_DEATH(
+      {
+        std::thread will_die([&]() { manager.SelectCallstackEvents({CallstackEvent()}); });
+        will_die.join();
+      },
+      "Check failed");
+}
+}  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -52,6 +52,11 @@ class DataManager final {
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info);
   void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& info);
 
+  void SelectCallstackEvents(
+      const std::vector<orbit_client_protos::CallstackEvent>& selected_callstack_events);
+  [[nodiscard]] const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(
+      uint32_t thread_id);
+
   [[nodiscard]] bool IsTracepointSelected(const orbit_grpc_protos::TracepointInfo& info) const;
 
   [[nodiscard]] const TracepointInfoSet& selected_tracepoints() const;
@@ -174,6 +179,9 @@ class DataManager final {
   bool collect_memory_info_ = false;
   uint64_t memory_sampling_period_ms_ = 10;
   uint64_t memory_warning_threshold_kb_ = 1024 * 1024 * 8;
+
+  absl::flat_hash_map<uint32_t, std::vector<orbit_client_protos::CallstackEvent>>
+      selected_callstack_events_by_thread_id_;
 };
 
 }  // namespace orbit_client_data

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2391,7 +2391,9 @@ uint64_t OrbitApp::GetGroupIdToHighlight() const {
 }
 
 void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
-                                     uint32_t thread_id) {
+                                     bool origin_is_multiple_threads) {
+  data_manager_->SelectCallstackEvents(selected_callstack_events);
+
   const CallstackData& callstack_data = GetCaptureData().GetCallstackData();
   std::unique_ptr<CallstackData> selection_callstack_data = std::make_unique<CallstackData>();
   for (const CallstackEvent& event : selected_callstack_events) {
@@ -2401,7 +2403,7 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
   GetMutableCaptureData().set_selection_callstack_data(std::move(selection_callstack_data));
 
   // Generate selection report.
-  bool generate_summary = thread_id == orbit_base::kAllProcessThreadsTid;
+  bool generate_summary = origin_is_multiple_threads;
   PostProcessedSamplingData processed_sampling_data =
       orbit_client_model::CreatePostProcessedSamplingData(
           *GetCaptureData().GetSelectionCallstackData(), GetCaptureData(), generate_summary);
@@ -2412,6 +2414,11 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
   SetSelectionReport(std::move(processed_sampling_data),
                      GetCaptureData().GetSelectionCallstackData()->GetUniqueCallstacksCopy(),
                      generate_summary);
+}
+
+const std::vector<orbit_client_protos::CallstackEvent>& OrbitApp::GetSelectedCallstackEvents(
+    uint32_t thread_id) {
+  return data_manager_->GetSelectedCallstackEvents(thread_id);
 }
 
 void OrbitApp::UpdateAfterSymbolLoading() {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -449,8 +449,12 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] uint64_t GetFunctionIdToHighlight() const;
   [[nodiscard]] uint64_t GetGroupIdToHighlight() const;
 
+  // origin_is_multiple_threads defines if the selection is specific to a single thread,
+  // or spans across multiple threads.
   void SelectCallstackEvents(
       const std::vector<orbit_client_protos::CallstackEvent>& selected_callstack_events,
+      bool origin_is_multiple_threads);
+  [[nodiscard]] const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(
       uint32_t thread_id);
 
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info) override;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -576,35 +576,6 @@ void TimeGraph::UpdateTracksPosition() {
   }
 }
 
-void TimeGraph::SelectCallstacks(float world_start, float world_end, uint32_t thread_id) {
-  if (world_start > world_end) {
-    std::swap(world_end, world_start);
-  }
-
-  uint64_t t0 = GetTickFromWorld(world_start);
-  uint64_t t1 = GetTickFromWorld(world_end);
-
-  CHECK(capture_data_);
-  std::vector<CallstackEvent> selected_callstack_events =
-      (thread_id == orbit_base::kAllProcessThreadsTid)
-          ? capture_data_->GetCallstackData().GetCallstackEventsInTimeRange(t0, t1)
-          : capture_data_->GetCallstackData().GetCallstackEventsOfTidInTimeRange(thread_id, t0, t1);
-
-  selected_callstack_events_per_thread_.clear();
-  for (CallstackEvent& event : selected_callstack_events) {
-    selected_callstack_events_per_thread_[event.thread_id()].emplace_back(event);
-    selected_callstack_events_per_thread_[orbit_base::kAllProcessThreadsTid].emplace_back(event);
-  }
-
-  app_->SelectCallstackEvents(selected_callstack_events, thread_id);
-
-  RequestUpdate();
-}
-
-const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(uint32_t tid) {
-  return selected_callstack_events_per_thread_[tid];
-}
-
 namespace {
 
 [[nodiscard]] std::string GetLabelBetweenIterators(const InstrumentedFunction& function_a,

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -52,9 +52,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
 
   void RequestUpdate() override;
 
-  void SelectCallstacks(float world_start, float world_end, uint32_t thread_id);
-  const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(uint32_t tid);
-
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_grpc_protos::InstrumentedFunction* function);
   void ProcessApiStringEvent(const orbit_client_protos::ApiStringEvent& string_event);
@@ -233,9 +230,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   Batcher batcher_;
 
   std::unique_ptr<TrackManager> track_manager_;
-
-  absl::flat_hash_map<uint32_t, std::vector<orbit_client_protos::CallstackEvent>>
-      selected_callstack_events_per_thread_;
 
   ManualInstrumentationManager* manual_instrumentation_manager_;
   std::unique_ptr<ManualInstrumentationManager::AsyncTimerInfoListener> async_timer_info_listener_;


### PR DESCRIPTION
This moves the selected callstacks by thread into the DataManager, and
provides access through OrbitApp.

Bug: Part of b/176086740
Test: Unit tests run, manual tests on sample selection across multiple threads.