### PR TITLE
Timegraph interface

### DIFF
--- a/src/OrbitGl/AccessibleCaptureViewElement.cpp
+++ b/src/OrbitGl/AccessibleCaptureViewElement.cpp
@@ -4,7 +4,6 @@
 
 #include "AccessibleCaptureViewElement.h"
 
-#include "TimeGraph.h"
 #include "Viewport.h"
 
 namespace orbit_gl {

--- a/src/OrbitGl/AccessibleTimeGraph.h
+++ b/src/OrbitGl/AccessibleTimeGraph.h
@@ -9,8 +9,7 @@
 
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "OrbitBase/Logging.h"
-
-class TimeGraph;
+#include "TimeGraph.h"
 
 namespace orbit_gl {
 

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -12,7 +12,6 @@
 #include "AccessibleTimeGraph.h"
 #include "CoreMath.h"
 #include "OrbitBase/Logging.h"
-#include "TimeGraph.h"
 #include "Track.h"
 #include "Viewport.h"
 
@@ -26,8 +25,7 @@ namespace {
 class FakeTrackTab : public CaptureViewElement {
  public:
   explicit FakeTrackTab(Track* track, TimeGraphLayout* layout)
-      : CaptureViewElement(track, track->GetTimeGraph(), track->GetViewport(), layout),
-        track_(track) {
+      : CaptureViewElement(track, track->GetViewport(), layout), track_(track) {
     // Compute and set the size (which would usually be done by the parent). As the position may
     // change, we override the GetPos() function.
     SetWidth(layout_->GetTrackTabWidth());
@@ -52,7 +50,7 @@ class FakeTrackTab : public CaptureViewElement {
 class FakeTimerPane : public CaptureViewElement {
  public:
   explicit FakeTimerPane(Track* track, TimeGraphLayout* layout, CaptureViewElement* track_tab)
-      : CaptureViewElement(track, track->GetTimeGraph(), track->GetViewport(), layout),
+      : CaptureViewElement(track, track->GetViewport(), layout),
         track_(track),
         track_tab_(track_tab) {
     SetWidth(track->GetWidth());

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -22,7 +22,6 @@
 #include "ManualInstrumentationManager.h"
 #include "OrbitBase/Logging.h"
 #include "TextRenderer.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "TriangleToggle.h"
 #include "Viewport.h"
@@ -30,11 +29,12 @@
 using orbit_client_protos::TimerInfo;
 using orbit_grpc_protos::InstrumentedFunction;
 
-AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+AsyncTrack::AsyncTrack(CaptureViewElement* parent,
+                       const orbit_gl::TimelineInfoInterface* timeline_info,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
                        OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
                        orbit_client_data::TimerData* timer_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, timer_data),
+    : TimerTrack(parent, timeline_info, viewport, layout, app, capture_data, timer_data),
       name_(std::move(name)) {}
 
 [[nodiscard]] std::string AsyncTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -24,7 +24,8 @@ class OrbitApp;
 
 class AsyncTrack final : public TimerTrack {
  public:
-  explicit AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit AsyncTrack(CaptureViewElement* parent,
+                      const orbit_gl::TimelineInfoInterface* timeline_info,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
                       OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
                       orbit_client_data::TimerData* timer_data);

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -21,13 +21,14 @@ static std::array<std::string, kBasicPageFaultsTrackDimension> CreateSeriesName(
 static constexpr uint8_t kTrackValueDecimalDigits = 0;
 static constexpr const char* kTrackValueUnits = "";
 
-BasicPageFaultsTrack::BasicPageFaultsTrack(Track* parent, TimeGraph* time_graph,
+BasicPageFaultsTrack::BasicPageFaultsTrack(Track* parent,
+                                           const orbit_gl::TimelineInfoInterface* timeline_info,
                                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                            std::string cgroup_name,
                                            uint64_t memory_sampling_period_ms,
                                            const orbit_client_data::CaptureData* capture_data)
     : LineGraphTrack<kBasicPageFaultsTrackDimension>(
-          parent, time_graph, viewport, layout,
+          parent, timeline_info, viewport, layout,
           CreateSeriesName(cgroup_name, capture_data->process_name()), kTrackValueDecimalDigits,
           kTrackValueUnits, capture_data),
       AnnotationTrack(),
@@ -91,8 +92,8 @@ void BasicPageFaultsTrack::DrawSingleSeriesEntry(
   if (current_normalized_values[index_of_series_to_highlight_.value()] == 0) return;
 
   const Color kHightlightingColor(231, 68, 53, 100);
-  float x0 = time_graph_->GetWorldFromTick(start_tick);
-  float width = time_graph_->GetWorldFromTick(end_tick) - x0;
+  float x0 = timeline_info_->GetWorldFromTick(start_tick);
+  float width = timeline_info_->GetWorldFromTick(end_tick) - x0;
   float content_height = GetGraphContentHeight();
   float y0 = GetGraphContentBottomY() - GetGraphContentHeight();
   batcher.AddShadedBox(Vec2(x0, y0), Vec2(width, content_height), z, kHightlightingColor);

--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -22,9 +22,9 @@ constexpr size_t kBasicPageFaultsTrackDimension = 3;
 class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimension>,
                              public AnnotationTrack {
  public:
-  explicit BasicPageFaultsTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                                TimeGraphLayout* layout, std::string cgroup_name,
-                                uint64_t memory_sampling_period_ms,
+  explicit BasicPageFaultsTrack(Track* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
+                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                                std::string cgroup_name, uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] Track* GetParent() const override { return parent_; }

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -33,11 +33,11 @@ static std::array<std::string, kCGroupAndProcessMemoryTrackDimension> CreateSeri
 static constexpr uint8_t kTrackValueDecimalDigits = 2;
 
 CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
-    CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-    TimeGraphLayout* layout, const std::string& cgroup_name,
+    CaptureViewElement* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
+    orbit_gl::Viewport* viewport, TimeGraphLayout* layout, const std::string& cgroup_name,
     const orbit_client_data::CaptureData* capture_data)
     : MemoryTrack<kCGroupAndProcessMemoryTrackDimension>(
-          parent, time_graph, viewport, layout,
+          parent, timeline_info, viewport, layout,
           CreateSeriesName(cgroup_name, capture_data->process_name()), kTrackValueDecimalDigits,
           kTrackValueLabelUnit, capture_data),
       cgroup_name_(cgroup_name) {

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.h
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.h
@@ -17,7 +17,8 @@ constexpr size_t kCGroupAndProcessMemoryTrackDimension = 4;
 class CGroupAndProcessMemoryTrack final
     : public MemoryTrack<kCGroupAndProcessMemoryTrackDimension> {
  public:
-  explicit CGroupAndProcessMemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit CGroupAndProcessMemoryTrack(CaptureViewElement* parent,
+                                       const orbit_gl::TimelineInfoInterface* timeline_info,
                                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                        const std::string& cgroup_name,
                                        const orbit_client_data::CaptureData* capture_data);

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -63,6 +63,7 @@ target_sources(
          ThreadTrack.h
          TimeGraph.h
          TimeGraphLayout.h
+         TimelineInfoInterface.h
          Timer.h
          TimerInfosIterator.h
          TimerTrack.h

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -24,7 +24,8 @@ namespace orbit_gl {
 
 class CallstackThreadBar : public ThreadBar {
  public:
-  explicit CallstackThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
+  explicit CallstackThreadBar(CaptureViewElement* parent, OrbitApp* app,
+                              const orbit_gl::TimelineInfoInterface* timeline_info,
                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                               const orbit_client_data::CaptureData* capture_data,
                               orbit_client_data::ThreadID thread_id, const Color& color);

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -4,14 +4,14 @@
 
 #include "CaptureViewElement.h"
 
-#include "TimeGraph.h"
+#include "Introspection/Introspection.h"
 #include "Viewport.h"
 
 namespace orbit_gl {
 
-CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
-                                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout)
-    : viewport_(viewport), layout_(layout), time_graph_(time_graph), parent_(parent) {
+CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, Viewport* viewport,
+                                       TimeGraphLayout* layout)
+    : viewport_(viewport), layout_(layout), parent_(parent) {
   CHECK(layout != nullptr);
 }
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -11,22 +11,18 @@
 #include "PickingManager.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
+#include "TimelineInfoInterface.h"
 #include "Viewport.h"
-
-class TimeGraph;
 
 namespace orbit_gl {
 
 /* Base class for UI elements drawn underneath the capture window. */
 class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
  public:
-  explicit CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
-                              orbit_gl::Viewport* viewport, TimeGraphLayout* layout);
+  explicit CaptureViewElement(CaptureViewElement* parent, Viewport* viewport,
+                              TimeGraphLayout* layout);
 
   void UpdateLayout();
-
-  [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
-  [[nodiscard]] const TimeGraph* GetTimeGraph() const { return time_graph_; }
 
   [[nodiscard]] orbit_gl::Viewport* GetViewport() const { return viewport_; }
 
@@ -72,8 +68,6 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   orbit_gl::Viewport* viewport_;
   TimeGraphLayout* layout_;
-
-  TimeGraph* time_graph_;
 
   Vec2 mouse_pos_last_click_;
   Vec2 mouse_pos_cur_;

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -10,9 +10,9 @@ namespace orbit_gl {
 
 class UnitTestCaptureViewLeafElement : public CaptureViewElement {
  public:
-  explicit UnitTestCaptureViewLeafElement(CaptureViewElement* parent, TimeGraph* time_graph,
-                                          Viewport* viewport, TimeGraphLayout* layout)
-      : CaptureViewElement(parent, time_graph, viewport, layout) {}
+  explicit UnitTestCaptureViewLeafElement(CaptureViewElement* parent, Viewport* viewport,
+                                          TimeGraphLayout* layout)
+      : CaptureViewElement(parent, viewport, layout) {}
 
   [[nodiscard]] float GetHeight() const override { return 10; }
 
@@ -25,13 +25,12 @@ class UnitTestCaptureViewLeafElement : public CaptureViewElement {
 
 class UnitTestCaptureViewContainerElement : public CaptureViewElement {
  public:
-  explicit UnitTestCaptureViewContainerElement(CaptureViewElement* parent, TimeGraph* time_graph,
-                                               Viewport* viewport, TimeGraphLayout* layout,
-                                               int children_to_create = 0)
-      : CaptureViewElement(parent, time_graph, viewport, layout) {
+  explicit UnitTestCaptureViewContainerElement(CaptureViewElement* parent, Viewport* viewport,
+                                               TimeGraphLayout* layout, int children_to_create = 0)
+      : CaptureViewElement(parent, viewport, layout) {
     for (int i = 0; i < children_to_create; ++i) {
       children_.emplace_back(
-          std::make_unique<UnitTestCaptureViewLeafElement>(this, time_graph, viewport, layout));
+          std::make_unique<UnitTestCaptureViewLeafElement>(this, viewport, layout));
     }
   }
 
@@ -63,7 +62,7 @@ class UnitTestCaptureViewContainerElement : public CaptureViewElement {
 TEST(CaptureViewElementTesterTest, PassesAllTestsOnExistingElement) {
   const int kChildCount = 2;
   CaptureViewElementTester tester;
-  UnitTestCaptureViewContainerElement container_elem(nullptr, nullptr, tester.GetViewport(),
+  UnitTestCaptureViewContainerElement container_elem(nullptr, tester.GetViewport(),
                                                      tester.GetLayout(), kChildCount);
   tester.RunTests(&container_elem);
 }

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -35,7 +35,6 @@
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "TextRenderer.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "absl/base/casts.h"
 

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -18,7 +18,6 @@
 #include "GlCanvas.h"
 #include "GlUtils.h"
 #include "TextRenderer.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "TriangleToggle.h"
 
@@ -56,11 +55,12 @@ float FrameTrack::GetAverageBoxHeight() const {
   return GetMaximumBoxHeight() / GetCappedMaximumToAverageRatio();
 }
 
-FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+FrameTrack::FrameTrack(CaptureViewElement* parent,
+                       const orbit_gl::TimelineInfoInterface* timeline_info,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        InstrumentedFunction function, OrbitApp* app,
                        const CaptureData* capture_data, orbit_client_data::TimerData* timer_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, timer_data),
+    : TimerTrack(parent, timeline_info, viewport, layout, app, capture_data, timer_data),
       function_(std::move(function)) {
   // TODO(b/169554463): Support manual instrumentation.
 

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -24,7 +24,8 @@ class OrbitApp;
 
 class FrameTrack : public TimerTrack {
  public:
-  explicit FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit FrameTrack(CaptureViewElement* parent,
+                      const orbit_gl::TimelineInfoInterface* timeline_info,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
                       const orbit_client_data::CaptureData* capture_data,

--- a/src/OrbitGl/FrameTrackOnlineProcessor.h
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.h
@@ -10,10 +10,9 @@
 #include "ClientData/CaptureData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/capture.pb.h"
+#include "TimeGraph.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
-
-class TimeGraph;
 
 namespace orbit_gl {
 

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -25,7 +25,6 @@
 #include "OrbitAccessibility/AccessibleWidgetBridge.h"
 #include "PickingManager.h"
 #include "TextRenderer.h"
-#include "TimeGraph.h"
 #include "Timer.h"
 #include "Viewport.h"
 

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -17,19 +17,19 @@
 #include "GlUtils.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "TriangleToggle.h"
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::TimerInfo;
 
-GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent,
+                                         const orbit_gl::TimelineInfoInterface* timeline_info,
                                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                          uint64_t timeline_hash, OrbitApp* app,
                                          const orbit_client_data::CaptureData* capture_data,
                                          orbit_client_data::TimerData* timer_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, timer_data),
+    : TimerTrack(parent, timeline_info, viewport, layout, app, capture_data, timer_data),
       string_manager_{app->GetStringManager()},
       timeline_hash_{timeline_hash} {
   draw_background_ = false;

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -26,7 +26,8 @@ class TextRenderer;
 // `GpuTrack`.
 class GpuDebugMarkerTrack final : public TimerTrack {
  public:
-  explicit GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit GpuDebugMarkerTrack(CaptureViewElement* parent,
+                               const orbit_gl::TimelineInfoInterface* timeline_info,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                uint64_t timeline_hash, OrbitApp* app,
                                const orbit_client_data::CaptureData* capture_data,

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -16,7 +16,6 @@
 #include "GlUtils.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "TriangleToggle.h"
 #include "absl/strings/str_format.h"
@@ -29,12 +28,13 @@ constexpr const char* kHwQueueString = "hw queue";
 constexpr const char* kHwExecutionString = "hw execution";
 constexpr const char* kCmdBufferString = "command buffer";
 
-GpuSubmissionTrack::GpuSubmissionTrack(Track* parent, TimeGraph* time_graph,
+GpuSubmissionTrack::GpuSubmissionTrack(Track* parent,
+                                       const orbit_gl::TimelineInfoInterface* timeline_info,
                                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                        uint64_t timeline_hash, OrbitApp* app,
                                        const orbit_client_data::CaptureData* capture_data,
                                        orbit_client_data::TimerData* timer_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, timer_data),
+    : TimerTrack(parent, timeline_info, viewport, layout, app, capture_data, timer_data),
       timeline_hash_{timeline_hash},
       string_manager_{app->GetStringManager()},
       parent_{parent} {

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -29,8 +29,9 @@ class TextRenderer;
 // This track is meant to be used as a subtrack of `GpuTrack`.
 class GpuSubmissionTrack : public TimerTrack {
  public:
-  explicit GpuSubmissionTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                              TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
+  explicit GpuSubmissionTrack(Track* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
+                              orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                              uint64_t timeline_hash, OrbitApp* app,
                               const orbit_client_data::CaptureData* capture_data,
                               orbit_client_data::TimerData* timer_data);
   ~GpuSubmissionTrack() override = default;

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -16,7 +16,6 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "TriangleToggle.h"
 #include "Viewport.h"
@@ -49,18 +48,19 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 
 }  // namespace orbit_gl
 
-GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                   TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
-                   const orbit_client_data::CaptureData* capture_data,
+GpuTrack::GpuTrack(CaptureViewElement* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
+                   orbit_gl::Viewport* viewport, TimeGraphLayout* layout, uint64_t timeline_hash,
+                   OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
                    orbit_client_data::TimerData* submission_timer_data,
                    orbit_client_data::TimerData* marker_timer_data)
-    : Track(parent, time_graph, viewport, layout, capture_data),
+    : Track(parent, timeline_info, viewport, layout, capture_data),
       string_manager_{app->GetStringManager()},
-      submission_track_{std::make_shared<GpuSubmissionTrack>(this, time_graph, viewport, layout,
+      submission_track_{std::make_shared<GpuSubmissionTrack>(this, timeline_info, viewport, layout,
                                                              timeline_hash, app, capture_data,
                                                              submission_timer_data)},
-      marker_track_{std::make_shared<GpuDebugMarkerTrack>(
-          this, time_graph, viewport, layout, timeline_hash, app, capture_data, marker_timer_data)},
+      marker_track_{std::make_shared<GpuDebugMarkerTrack>(this, timeline_info, viewport, layout,
+                                                          timeline_hash, app, capture_data,
+                                                          marker_timer_data)},
       timeline_hash_{timeline_hash} {
   // Gpu are collapsed by default. Their subtracks are expanded by default, but are however not
   // shown while the Gpu track is collapsed.

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -36,9 +36,10 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 // subtracks to display "submission" related information, as well as "debug markers" (if present).
 class GpuTrack : public Track {
  public:
-  explicit GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                    TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
-                    const orbit_client_data::CaptureData* capture_data,
+  explicit GpuTrack(CaptureViewElement* parent,
+                    const orbit_gl::TimelineInfoInterface* timeline_info,
+                    orbit_gl::Viewport* viewport, TimeGraphLayout* layout, uint64_t timeline_hash,
+                    OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
                     orbit_client_data::TimerData* submission_timer_data,
                     orbit_client_data::TimerData* marker_timer_data);
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -26,13 +26,14 @@ constexpr const float kBoxHeightMultiplier = 1.5f;
 }  // namespace
 
 template <size_t Dimension>
-GraphTrack<Dimension>::GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+GraphTrack<Dimension>::GraphTrack(CaptureViewElement* parent,
+                                  const orbit_gl::TimelineInfoInterface* timeline_info,
                                   orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                   std::array<std::string, Dimension> series_names,
                                   uint8_t series_value_decimal_digits,
                                   std::string series_value_units,
                                   const orbit_client_data::CaptureData* capture_data)
-    : Track(parent, time_graph, viewport, layout, capture_data),
+    : Track(parent, timeline_info, viewport, layout, capture_data),
       series_{series_names, series_value_decimal_digits, std::move(series_value_units)} {}
 
 template <size_t Dimension>
@@ -66,7 +67,7 @@ void GraphTrack<Dimension>::DoDraw(Batcher& batcher, TextRenderer& text_renderer
       series_.GetPreviousOrFirstEntry(draw_context.current_mouse_time_ns);
   uint64_t first_time = series_.StartTimeInNs();
   uint64_t label_time = std::max(draw_context.current_mouse_time_ns, first_time);
-  float point_x = time_graph_->GetWorldFromTick(label_time);
+  float point_x = timeline_info_->GetWorldFromTick(label_time);
   float point_y = GetLabelYFromValues(values);
   std::string text = GetLabelTextFromValues(values);
   const Color kBlack(0, 0, 0, 255);
@@ -275,8 +276,8 @@ template <size_t Dimension>
 void GraphTrack<Dimension>::DrawSingleSeriesEntry(
     Batcher& batcher, uint64_t start_tick, uint64_t end_tick,
     const std::array<float, Dimension>& normalized_cumulative_values, float z) {
-  const float x0 = time_graph_->GetWorldFromTick(start_tick);
-  const float width = time_graph_->GetWorldFromTick(end_tick) - x0;
+  const float x0 = timeline_info_->GetWorldFromTick(start_tick);
+  const float width = timeline_info_->GetWorldFromTick(end_tick) - x0;
   const float content_height = GetGraphContentHeight();
   const float base_y = GetGraphContentBottomY();
   float y0 = base_y;

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -21,7 +21,8 @@
 template <size_t Dimension>
 class GraphTrack : public Track {
  public:
-  explicit GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit GraphTrack(CaptureViewElement* parent,
+                      const orbit_gl::TimelineInfoInterface* timeline_info,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       std::array<std::string, Dimension> series_names,
                       uint8_t series_value_decimal_digits, std::string series_value_unit,

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -7,7 +7,6 @@
 #include "App.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/Logging.h"
-#include "TimeGraph.h"
 
 using orbit_client_data::CaptureData;
 using orbit_client_protos::TimerInfo;

--- a/src/OrbitGl/LineGraphTrack.cpp
+++ b/src/OrbitGl/LineGraphTrack.cpp
@@ -12,7 +12,6 @@
 
 #include "Geometry.h"
 #include "TextRenderer.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 
 namespace orbit_gl {
@@ -93,8 +92,8 @@ void LineGraphTrack<Dimension>::DrawSingleSeriesEntry(
     const std::array<float, Dimension>& current_normalized_values,
     const std::array<float, Dimension>& next_normalized_values, float z, bool is_last) {
   constexpr float kDotRadius = 2.f;
-  float x0 = this->time_graph_->GetWorldFromTick(start_tick);
-  float x1 = this->time_graph_->GetWorldFromTick(end_tick);
+  float x0 = this->timeline_info_->GetWorldFromTick(start_tick);
+  float x1 = this->timeline_info_->GetWorldFromTick(end_tick);
   float content_height = this->GetGraphContentHeight();
   float base_y = this->GetGraphContentBottomY();
 

--- a/src/OrbitGl/MajorPageFaultsTrack.cpp
+++ b/src/OrbitGl/MajorPageFaultsTrack.cpp
@@ -7,12 +7,13 @@
 #include <absl/strings/substitute.h>
 
 namespace orbit_gl {
-MajorPageFaultsTrack::MajorPageFaultsTrack(Track* parent, TimeGraph* time_graph,
+MajorPageFaultsTrack::MajorPageFaultsTrack(Track* parent,
+                                           const orbit_gl::TimelineInfoInterface* timeline_info,
                                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                            const std::string& cgroup_name,
                                            uint64_t memory_sampling_period_ms,
                                            const orbit_client_data::CaptureData* capture_data)
-    : BasicPageFaultsTrack(parent, time_graph, viewport, layout, cgroup_name,
+    : BasicPageFaultsTrack(parent, timeline_info, viewport, layout, cgroup_name,
                            memory_sampling_period_ms, capture_data) {
   index_of_series_to_highlight_ = static_cast<size_t>(SeriesIndex::kProcess);
 }

--- a/src/OrbitGl/MajorPageFaultsTrack.h
+++ b/src/OrbitGl/MajorPageFaultsTrack.h
@@ -14,9 +14,9 @@ namespace orbit_gl {
 
 class MajorPageFaultsTrack final : public BasicPageFaultsTrack {
  public:
-  explicit MajorPageFaultsTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                                TimeGraphLayout* layout, const std::string& cgroup_name,
-                                uint64_t memory_sampling_period_ms,
+  explicit MajorPageFaultsTrack(Track* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
+                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                                const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] std::string GetName() const override { return "Page Faults: Major"; }

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -19,12 +19,13 @@ namespace orbit_gl {
 template <size_t Dimension>
 class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
  public:
-  explicit MemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit MemoryTrack(CaptureViewElement* parent,
+                       const orbit_gl::TimelineInfoInterface* timeline_info,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        std::array<std::string, Dimension> series_names,
                        uint8_t series_value_decimal_digits, std::string series_value_units,
                        const orbit_client_data::CaptureData* capture_data)
-      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, series_names,
+      : GraphTrack<Dimension>(parent, timeline_info, viewport, layout, series_names,
                               series_value_decimal_digits, std::move(series_value_units),
                               capture_data),
         AnnotationTrack() {

--- a/src/OrbitGl/MinorPageFaultsTrack.h
+++ b/src/OrbitGl/MinorPageFaultsTrack.h
@@ -14,11 +14,11 @@ namespace orbit_gl {
 
 class MinorPageFaultsTrack final : public BasicPageFaultsTrack {
  public:
-  explicit MinorPageFaultsTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                                TimeGraphLayout* layout, const std::string& cgroup_name,
-                                uint64_t memory_sampling_period_ms,
+  explicit MinorPageFaultsTrack(Track* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
+                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                                const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::CaptureData* capture_data)
-      : BasicPageFaultsTrack(parent, time_graph, viewport, layout, cgroup_name,
+      : BasicPageFaultsTrack(parent, timeline_info, viewport, layout, cgroup_name,
                              memory_sampling_period_ms, capture_data) {}
 
   [[nodiscard]] std::string GetName() const override { return "Page Faults: Minor"; }

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -9,7 +9,6 @@
 #include "Geometry.h"
 #include "GrpcProtos/Constants.h"
 #include "TextRenderer.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "Viewport.h"
 
@@ -20,16 +19,17 @@ using orbit_capture_client::CaptureEventProcessor;
 using orbit_grpc_protos::kMissingInfo;
 }  // namespace
 
-PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent,
+                                 const orbit_gl::TimelineInfoInterface* timeline_info,
                                  orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                  const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
                                  const orbit_client_data::CaptureData* capture_data)
-    : Track(parent, time_graph, viewport, layout, capture_data),
+    : Track(parent, timeline_info, viewport, layout, capture_data),
       major_page_faults_track_{
-          std::make_shared<MajorPageFaultsTrack>(this, time_graph, viewport, layout, cgroup_name,
+          std::make_shared<MajorPageFaultsTrack>(this, timeline_info, viewport, layout, cgroup_name,
                                                  memory_sampling_period_ms, capture_data)},
       minor_page_faults_track_{
-          std::make_shared<MinorPageFaultsTrack>(this, time_graph, viewport, layout, cgroup_name,
+          std::make_shared<MinorPageFaultsTrack>(this, timeline_info, viewport, layout, cgroup_name,
                                                  memory_sampling_period_ms, capture_data)} {
   // PageFaults track is collapsed by default. The major and minor page faults subtracks are
   // expanded by default, but not shown while the page faults track is collapsed.

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -19,7 +19,8 @@ namespace orbit_gl {
 // minor page faults related information.
 class PageFaultsTrack : public Track {
  public:
-  explicit PageFaultsTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit PageFaultsTrack(CaptureViewElement* parent,
+                           const orbit_gl::TimelineInfoInterface* timeline_info,
                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                            const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
                            const orbit_client_data::CaptureData* capture_data);

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -14,7 +14,6 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "Viewport.h"
 
@@ -24,11 +23,12 @@ const Color kInactiveColor(100, 100, 100, 255);
 const Color kSamePidColor(140, 140, 140, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-SchedulerTrack::SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+SchedulerTrack::SchedulerTrack(CaptureViewElement* parent,
+                               const orbit_gl::TimelineInfoInterface* timeline_info,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
                                const orbit_client_data::CaptureData* capture_data,
                                orbit_client_data::TimerData* timer_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, timer_data),
+    : TimerTrack(parent, timeline_info, viewport, layout, app, capture_data, timer_data),
       num_cores_{0} {
   SetPinned(false);
 }

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -19,7 +19,8 @@ class OrbitApp;
 
 class SchedulerTrack final : public TimerTrack {
  public:
-  explicit SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit SchedulerTrack(CaptureViewElement* parent,
+                          const orbit_gl::TimelineInfoInterface* timeline_info,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
                           const orbit_client_data::CaptureData* capture_data,
                           orbit_client_data::TimerData* timer_data);

--- a/src/OrbitGl/SystemMemoryTrack.cpp
+++ b/src/OrbitGl/SystemMemoryTrack.cpp
@@ -26,10 +26,11 @@ constexpr uint64_t kMegabytesToBytes = 1024 * 1024;
 }  // namespace
 
 constexpr uint8_t kTrackValueDecimalDigits = 2;
-SystemMemoryTrack::SystemMemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+SystemMemoryTrack::SystemMemoryTrack(CaptureViewElement* parent,
+                                     const orbit_gl::TimelineInfoInterface* timeline_info,
                                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                      const orbit_client_data::CaptureData* capture_data)
-    : MemoryTrack<kSystemMemoryTrackDimension>(parent, time_graph, viewport, layout, kSeriesName,
+    : MemoryTrack<kSystemMemoryTrackDimension>(parent, timeline_info, viewport, layout, kSeriesName,
                                                kTrackValueDecimalDigits, kTrackValueLabelUnit,
                                                capture_data) {
   // Colors are selected from https://convertingcolors.com/list/avery.html.

--- a/src/OrbitGl/SystemMemoryTrack.h
+++ b/src/OrbitGl/SystemMemoryTrack.h
@@ -16,7 +16,8 @@ constexpr size_t kSystemMemoryTrackDimension = 3;
 
 class SystemMemoryTrack final : public MemoryTrack<kSystemMemoryTrackDimension> {
  public:
-  explicit SystemMemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit SystemMemoryTrack(CaptureViewElement* parent,
+                             const orbit_gl::TimelineInfoInterface* timeline_info,
                              orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                              const orbit_client_data::CaptureData* capture_data);
 

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -12,6 +12,7 @@
 #include "CaptureViewElement.h"
 #include "ClientData/CaptureData.h"
 #include "TimeGraphLayout.h"
+#include "TimelineInfoInterface.h"
 
 class OrbitApp;
 
@@ -19,12 +20,14 @@ namespace orbit_gl {
 
 class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this<ThreadBar> {
  public:
-  explicit ThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
+  explicit ThreadBar(CaptureViewElement* parent, OrbitApp* app,
+                     const orbit_gl::TimelineInfoInterface* timeline_info,
                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                      const orbit_client_data::CaptureData* capture_data, int64_t thread_id,
                      std::string name, const Color& color)
-      : CaptureViewElement(parent, time_graph, viewport, layout),
+      : CaptureViewElement(parent, viewport, layout),
         app_(app),
+        timeline_info_(timeline_info),
         capture_data_(capture_data),
         thread_id_(thread_id),
         name_(std::move(name)),
@@ -44,6 +47,7 @@ class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this
   [[nodiscard]] virtual Color GetColor() const { return color_; }
 
   OrbitApp* app_;
+  const orbit_gl::TimelineInfoInterface* timeline_info_;
   const orbit_client_data::CaptureData* capture_data_;
 
  private:

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -24,7 +24,8 @@ namespace orbit_gl {
 // The colors are determined only by the states, not by the color assigned to the thread.
 class ThreadStateBar final : public ThreadBar {
  public:
-  explicit ThreadStateBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
+  explicit ThreadStateBar(CaptureViewElement* parent, OrbitApp* app,
+                          const orbit_gl::TimelineInfoInterface* timeline_info,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                           const orbit_client_data::CaptureData* capture_data,
                           orbit_client_data::ThreadID thread_id, const Color& color);

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -28,7 +28,8 @@ class OrbitApp;
 class ThreadTrack final : public TimerTrack {
  public:
   enum class ScopeTreeUpdateType { kAlways, kOnCaptureComplete, kNever };
-  explicit ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit ThreadTrack(CaptureViewElement* parent,
+                       const orbit_gl::TimelineInfoInterface* timeline_info,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, uint32_t thread_id,
                        OrbitApp* app, const orbit_client_data::CaptureData* capture_data,
                        orbit_client_data::ThreadTrackDataProvider* thread_track_data_provider);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -62,7 +62,7 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
     // Note that `GlCanvas` and `TimeGraph` span the bridge to OpenGl content, and `TimeGraph`'s
     // parent needs special handling for accessibility. Thus, we use `nullptr` here and we save the
     // parent in accessible_parent_ which doesn't need to be a CaptureViewElement.
-    : orbit_gl::CaptureViewElement(nullptr, this, viewport, &layout_),
+    : orbit_gl::CaptureViewElement(nullptr, viewport, &layout_),
       accessible_parent_{parent},
       batcher_(BatcherId::kTimeGraph),
       manual_instrumentation_manager_{app->GetManualInstrumentationManager()},

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -35,7 +35,8 @@
 
 class OrbitApp;
 
-class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::TimelineInfoInterface {
+class TimeGraph final : public orbit_gl::CaptureViewElement,
+                        public orbit_gl::TimelineInfoInterface {
  public:
   explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
                      orbit_gl::Viewport* viewport, orbit_client_data::CaptureData* capture_data,

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "AccessibleInterfaceProvider.h"
-#include "AccessibleTimeGraph.h"
 #include "Batcher.h"
 #include "CallstackThreadBar.h"
 #include "CaptureViewElement.h"
@@ -28,6 +27,7 @@
 #include "PickingManager.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
+#include "TimelineInfoInterface.h"
 #include "Track.h"
 #include "TrackManager.h"
 #include "Viewport.h"
@@ -35,7 +35,7 @@
 
 class OrbitApp;
 
-class TimeGraph : public orbit_gl::CaptureViewElement {
+class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::TimelineInfoInterface {
  public:
   explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
                      orbit_gl::Viewport* viewport, orbit_client_data::CaptureData* capture_data,
@@ -61,12 +61,12 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
 
   [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
-  [[nodiscard]] float GetWorldFromTick(uint64_t time) const;
-  [[nodiscard]] float GetWorldFromUs(double micros) const;
-  [[nodiscard]] uint64_t GetTickFromWorld(float world_x) const;
-  [[nodiscard]] uint64_t GetTickFromUs(double micros) const;
-  [[nodiscard]] double GetUsFromTick(uint64_t time) const;
-  [[nodiscard]] double GetTimeWindowUs() const { return time_window_us_; }
+  [[nodiscard]] float GetWorldFromTick(uint64_t time) const override;
+  [[nodiscard]] float GetWorldFromUs(double micros) const override;
+  [[nodiscard]] uint64_t GetTickFromWorld(float world_x) const override;
+  [[nodiscard]] uint64_t GetTickFromUs(double micros) const override;
+  [[nodiscard]] double GetUsFromTick(uint64_t time) const override;
+  [[nodiscard]] double GetTimeWindowUs() const override { return time_window_us_; }
   void UpdateCaptureMinMaxTimestamps();
 
   void ZoomAll();

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -68,6 +68,9 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] uint64_t GetTickFromUs(double micros) const override;
   [[nodiscard]] double GetUsFromTick(uint64_t time) const override;
   [[nodiscard]] double GetTimeWindowUs() const override { return time_window_us_; }
+  [[nodiscard]] double GetMinTimeUs() const override { return min_time_us_; }
+  [[nodiscard]] double GetMaxTimeUs() const override { return max_time_us_; }
+
   void UpdateCaptureMinMaxTimestamps();
 
   void ZoomAll();
@@ -121,8 +124,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] int GetNumVisiblePrimitives() const;
 
   void UpdateHorizontalScroll(float ratio);
-  [[nodiscard]] double GetMinTimeUs() const { return min_time_us_; }
-  [[nodiscard]] double GetMaxTimeUs() const { return max_time_us_; }
   [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
   [[nodiscard]] TimeGraphLayout& GetLayout() { return layout_; }
 

--- a/src/OrbitGl/TimelineInfoInterface.h
+++ b/src/OrbitGl/TimelineInfoInterface.h
@@ -11,6 +11,8 @@ namespace orbit_gl {
 
 class TimelineInfoInterface {
  public:
+  virtual ~TimelineInfoInterface() = default;
+
   [[nodiscard]] virtual float GetWorldFromTick(uint64_t time) const = 0;
   [[nodiscard]] virtual float GetWorldFromUs(double micros) const = 0;
   [[nodiscard]] virtual uint64_t GetTickFromWorld(float world_x) const = 0;

--- a/src/OrbitGl/TimelineInfoInterface.h
+++ b/src/OrbitGl/TimelineInfoInterface.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TIMELINE_INFO_INTERFACE_H_
+#define ORBIT_GL_TIMELINE_INFO_INTERFACE_H_
+
+#include <stdint.h>
+
+namespace orbit_gl {
+
+class TimelineInfoInterface {
+ public:
+  [[nodiscard]] virtual float GetWorldFromTick(uint64_t time) const = 0;
+  [[nodiscard]] virtual float GetWorldFromUs(double micros) const = 0;
+  [[nodiscard]] virtual uint64_t GetTickFromWorld(float world_x) const = 0;
+  [[nodiscard]] virtual uint64_t GetTickFromUs(double micros) const = 0;
+  [[nodiscard]] virtual double GetUsFromTick(uint64_t time) const = 0;
+  [[nodiscard]] virtual double GetTimeWindowUs() const = 0;
+
+  [[nodiscard]] virtual double GetMinTimeUs() const = 0;
+  [[nodiscard]] virtual double GetMaxTimeUs() const = 0;
+};
+
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -50,7 +50,8 @@ struct DrawData {
 
 class TimerTrack : public Track {
  public:
-  explicit TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit TimerTrack(CaptureViewElement* parent,
+                      const orbit_gl::TimelineInfoInterface* timeline_info,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
                       const orbit_client_data::CaptureData* capture_data,
                       orbit_client_data::TimerData* timer_data);
@@ -131,9 +132,9 @@ class TimerTrack : public Track {
 
   [[nodiscard]] static internal::DrawData GetDrawData(
       uint64_t min_tick, uint64_t max_tick, float track_pos_x, float track_width, Batcher* batcher,
-      TimeGraph* time_graph, orbit_gl::Viewport* viewport, bool is_collapsed,
-      const orbit_client_protos::TimerInfo* selected_timer, uint64_t highlighted_function_id,
-      uint64_t highlighted_group_id);
+      const orbit_gl::TimelineInfoInterface* timeline_info, orbit_gl::Viewport* viewport,
+      bool is_collapsed, const orbit_client_protos::TimerInfo* selected_timer,
+      uint64_t highlighted_function_id, uint64_t highlighted_group_id);
 
   [[nodiscard]] virtual std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const;
   [[nodiscard]] std::unique_ptr<PickingUserData> CreatePickingUserData(

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -22,19 +22,18 @@
 #include "GrpcProtos/tracepoint.pb.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "Viewport.h"
 
 namespace orbit_gl {
 
 TracepointThreadBar::TracepointThreadBar(CaptureViewElement* parent, OrbitApp* app,
-                                         TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                                         TimeGraphLayout* layout,
+                                         const orbit_gl::TimelineInfoInterface* timeline_info,
+                                         orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                          const orbit_client_data::CaptureData* capture_data,
                                          uint32_t thread_id, const Color& color)
-    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Tracepoints",
-                color) {}
+    : ThreadBar(parent, app, timeline_info, viewport, layout, capture_data, thread_id,
+                "Tracepoints", color) {}
 
 void TracepointThreadBar::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
                                  const DrawContext& draw_context) {
@@ -73,7 +72,7 @@ void TracepointThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& tex
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
           float radius = track_height / 4;
-          const Vec2 pos(time_graph_->GetWorldFromTick(time), GetPos()[1]);
+          const Vec2 pos(timeline_info_->GetWorldFromTick(time), GetPos()[1]);
           if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
             const Color color = tracepoint.pid() == capture_data_->process_id() ? kGrey : kWhite;
             batcher.AddVerticalLine(pos, -track_height, z, color);
@@ -94,7 +93,7 @@ void TracepointThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& tex
         GetThreadId(), min_tick, max_tick,
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
-          Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset,
+          Vec2 pos(timeline_info_->GetWorldFromTick(time) - kPickingBoxOffset,
                    GetPos()[1] - track_height + 1);
           Vec2 size(kPickingBoxWidth, track_height);
           auto user_data = std::make_unique<PickingUserData>(

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -17,7 +17,8 @@ namespace orbit_gl {
 
 class TracepointThreadBar : public ThreadBar {
  public:
-  explicit TracepointThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
+  explicit TracepointThreadBar(CaptureViewElement* parent, OrbitApp* app,
+                               const orbit_gl::TimelineInfoInterface* timeline_info,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                const orbit_client_data::CaptureData* capture_data,
                                uint32_t thread_id, const Color& color);

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -14,24 +14,21 @@
 #include "GlCanvas.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "TextRenderer.h"
-#include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "Viewport.h"
 
 using orbit_client_data::TimerData;
 
-Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-             TimeGraphLayout* layout, const orbit_client_data::CaptureData* capture_data)
-    : CaptureViewElement(parent, time_graph, viewport, layout),
+Track::Track(CaptureViewElement* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
+             orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+             const orbit_client_data::CaptureData* capture_data)
+    : CaptureViewElement(parent, viewport, layout),
       pinned_{false},
       layout_(layout),
+      timeline_info_(timeline_info),
       capture_data_(capture_data) {
-  // We decrease the size of the collapse toggle per indentation, but as it becomes too small after
-  // 5 indentations, we cap the size here.
-
   collapse_toggle_ = std::make_shared<TriangleToggle>(
-      [this](bool is_collapsed) { OnCollapseToggle(is_collapsed); }, time_graph, viewport, layout,
-      this);
+      [this](bool is_collapsed) { OnCollapseToggle(is_collapsed); }, viewport, layout, this);
 }
 
 std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
@@ -257,5 +254,4 @@ void Track::OnDrag(int x, int y) {
   CaptureViewElement::OnDrag(x, y);
 
   SetPos(GetPos()[0], mouse_pos_cur_[1] - picking_offset_[1]);
-  time_graph_->VerticallyMoveIntoView(*this);
 }

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -25,6 +25,7 @@
 #include "OrbitBase/Profiling.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
+#include "TimelineInfoInterface.h"
 #include "TriangleToggle.h"
 #include "Viewport.h"
 
@@ -49,8 +50,9 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
       Type::kGpuTrack,    Type::kGraphTrack,      Type::kSchedulerTrack, Type::kAsyncTrack,
       Type::kMemoryTrack, Type::kPageFaultsTrack, Type::kUnknown};
 
-  explicit Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                 TimeGraphLayout* layout, const orbit_client_data::CaptureData* capture_data);
+  explicit Track(CaptureViewElement* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
+                 orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                 const orbit_client_data::CaptureData* capture_data);
   ~Track() override = default;
 
   void OnDrag(int x, int y) override;
@@ -129,7 +131,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   std::shared_ptr<TriangleToggle> collapse_toggle_;
 
   TimeGraphLayout* layout_;
-
+  const orbit_gl::TimelineInfoInterface* timeline_info_;
   const orbit_client_data::CaptureData* capture_data_ = nullptr;
 };
 

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -257,6 +257,8 @@ void TrackManager::UpdateMovingTrackPositionInVisibleTracks() {
 
   if (moving_track_previous_position != -1) {
     Track* moving_track = visible_tracks_[moving_track_previous_position];
+    time_graph_->VerticallyMoveIntoView(*moving_track);
+
     visible_tracks_.erase(visible_tracks_.begin() + moving_track_previous_position);
 
     int moving_track_current_position = -1;

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -32,7 +32,7 @@
 #include "Viewport.h"
 
 class OrbitApp;
-class Timegraph;
+class TimeGraph;
 
 // TrackManager is in charge of the active Tracks in Timegraph (their creation, searching, erasing
 // and sorting).

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -13,12 +13,11 @@
 #include "Batcher.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
-#include "TimeGraph.h"
 #include "Track.h"
 
-TriangleToggle::TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph,
-                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track)
-    : CaptureViewElement(track, time_graph, viewport, layout), handler_(std::move(handler)) {}
+TriangleToggle::TriangleToggle(StateChangeHandler handler, orbit_gl::Viewport* viewport,
+                               TimeGraphLayout* layout, Track* track)
+    : CaptureViewElement(track, viewport, layout), handler_(std::move(handler)) {}
 
 void TriangleToggle::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
                             const DrawContext& draw_context) {

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -18,8 +18,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
                        public std::enable_shared_from_this<TriangleToggle> {
  public:
   using StateChangeHandler = std::function<void(bool)>;
-  explicit TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph,
-                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track);
+  explicit TriangleToggle(StateChangeHandler handler, orbit_gl::Viewport* viewport,
+                          TimeGraphLayout* layout, Track* track);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;

--- a/src/OrbitGl/VariableTrack.h
+++ b/src/OrbitGl/VariableTrack.h
@@ -22,10 +22,11 @@ class VariableTrack final : public LineGraphTrack<kVariableTrackDimension> {
   static constexpr const char* kTrackValueUnits = "";
 
  public:
-  explicit VariableTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+  explicit VariableTrack(CaptureViewElement* parent,
+                         const orbit_gl::TimelineInfoInterface* timeline_info,
                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
                          const orbit_client_data::CaptureData* capture_data)
-      : LineGraphTrack<kVariableTrackDimension>(parent, time_graph, viewport, layout,
+      : LineGraphTrack<kVariableTrackDimension>(parent, timeline_info, viewport, layout,
                                                 std::array<std::string, kVariableTrackDimension>{},
                                                 kTrackValueDecimalDigits, kTrackValueUnits,
                                                 capture_data),


### PR DESCRIPTION
This moves all read-only functionality related to time / world conversion
into a separate interface and passes this to `Track`. This removes the
dependency to `TimeGraph` from most of OrbitGl.

The `TrackManager` still has a `TimeGraph` dependency as it requires
`TimeGraph::VerticallyMoveIntoView`. We can get rid of this in the future.