### PR TITLE
Add a better e2e test for presets.

### DIFF
--- a/contrib/automation_tests/orbit_load_presets.py
+++ b/contrib/automation_tests/orbit_load_presets.py
@@ -13,7 +13,7 @@ from test_cases.symbols_tab import LoadAndVerifyHelloGgpPreset
 
 Before this script is run there needs to be a gamelet reserved and
 "hello_ggp_standalone" has to be started. Two presets named
-draw_frame_in_hello_ggp_1_52.opr and ggp_issue_frame_token_in_hello_ggp_1_52
+draw_frame_in_hello_ggp_1_68.opr and ggp_issue_frame_token_in_hello_ggp_1_68.opr
 (hooking the functions DrawFrame and GgpIssueFrameToken) need to exist in the
 preset folder.
 

--- a/contrib/automation_tests/orbit_load_presets_2.py
+++ b/contrib/automation_tests/orbit_load_presets_2.py
@@ -12,7 +12,7 @@ from test_cases.symbols_tab import FilterAndHookFunction, SavePreset, UnhookAllF
 from test_cases.capture_window import Capture
 from test_cases.live_tab import VerifyFunctionCallCount
 from test_cases.main_window import EndSession
-"""Apply two presets in Orbit using pywinauto.
+"""Verify preset functionality in Orbit works as expected.
 
 Before this script is run there needs to be a gamelet reserved and
 "hello_ggp_standalone" has to be started. Four presets named:
@@ -23,7 +23,7 @@ Before this script is run there needs to be a gamelet reserved and
   not_loadable.opr
 
 need to exist in the preset folder. The first two are hooking the functions
-indicated by their name. THese are created with Orbit 1.68 so this is testing
+indicated by their name. These are created with Orbit 1.68 so this is testing
 compatibility as well. The two others are partially loadable and not loadable
 when hello_ggp is profiled. Details are in the inline comments below.
 

--- a/contrib/automation_tests/orbit_load_presets_2.py
+++ b/contrib/automation_tests/orbit_load_presets_2.py
@@ -1,0 +1,86 @@
+"""
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.symbols_tab import FilterAndHookFunction, SavePreset, UnhookAllFunctions, LoadPreset, VerifyFunctionHooked, VerifyPresetStatus, PresetStatus, VerifyModuleLoaded
+from test_cases.capture_window import Capture
+from test_cases.live_tab import VerifyFunctionCallCount
+from test_cases.main_window import EndSession
+"""Apply two presets in Orbit using pywinauto.
+
+Before this script is run there needs to be a gamelet reserved and
+"hello_ggp_standalone" has to be started. Four presets named:
+
+  draw_frame_in_hello_ggp_1_68.opr
+  ggp_issue_frame_token_in_hello_ggp_1_68.opr
+  partially_loadable.opr
+  not_loadable.opr
+
+need to exist in the preset folder. The first two are hooking the functions
+indicated by their name. THese are created with Orbit 1.68 so this is testing
+compatibility as well. The two others are partially loadable and not loadable
+when hello_ggp is profiled. Details are in the inline comments below.
+
+The script requires absl and pywinauto. Since pywinauto requires the bitness of
+the python installation to match the bitness of the program under test it needs
+to by run from  64 bit python.
+"""
+
+
+def main(argv):
+    test_cases = [
+        ConnectToStadiaInstance(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
+        # Load presets and verify the respective functions get hooked.
+        LoadPreset(preset_name='draw_frame_in_hello_ggp_1_68'),
+        VerifyFunctionHooked(function_search_string='DrawFrame'),
+        LoadPreset(preset_name='ggp_issue_frame_token_in_hello_ggp_1_68'),
+        VerifyFunctionHooked(function_search_string='GgpIssueFrameToken'),
+        # Verify that the functions from the presets end up in the capture.
+        Capture(),
+        VerifyFunctionCallCount(function_name='DrawFrame', min_calls=30, max_calls=3000),
+        VerifyFunctionCallCount(function_name='GgpIssueFrameToken', min_calls=30, max_calls=3000),
+        # Create a new preset. Unhooking and applying this preset results in the function being hooked.
+        UnhookAllFunctions(),
+        FilterAndHookFunction(function_search_string="ClockNowMicroSeconds"),
+        SavePreset(preset_name="clock_now_micro_seconds_in_hello_ggp.opr"),
+        UnhookAllFunctions(),
+        LoadPreset(preset_name='clock_now_micro_seconds_in_hello_ggp'),
+        VerifyFunctionHooked(function_search_string='ClockNowMicroSeconds'),
+        # Test the status of different presets.
+        UnhookAllFunctions(),
+        VerifyPresetStatus(preset_name='clock_now_micro_seconds_in_hello_ggp',
+                           expected_status=PresetStatus.LOADABLE),
+        VerifyPresetStatus(preset_name='partially_loadable',
+                           expected_status=PresetStatus.PARTIALLY_LOADABLE),
+        VerifyPresetStatus(preset_name='not_loadable', expected_status=PresetStatus.NOT_LOADABLE),
+        # Test proper warnings when applying partially loadable or not loadable presets.
+        LoadPreset(preset_name='partially_loadable'),
+        VerifyFunctionHooked(function_search_string='__GI___clock_gettime'),
+        UnhookAllFunctions(),
+        LoadPreset(preset_name='not_loadable'),
+        # Test for proper preset status when switching processes.
+        EndSession(),
+        FilterAndSelectFirstProcess(process_filter="OrbitService"),
+        VerifyPresetStatus(preset_name='clock_now_micro_seconds_in_hello_ggp',
+                           expected_status=PresetStatus.NOT_LOADABLE),
+        VerifyPresetStatus(preset_name='partially_loadable',
+                           expected_status=PresetStatus.PARTIALLY_LOADABLE),
+        VerifyPresetStatus(preset_name='not_loadable', expected_status=PresetStatus.NOT_LOADABLE),
+        # Load a partially loadable preset and check that the symbols for the module get loaded.
+        LoadPreset(preset_name='partially_loadable'),
+        VerifyFunctionHooked(function_search_string='__GI___clock_gettime'),
+        VerifyModuleLoaded(module_search_string="libc-"),
+    ]
+    suite = E2ETestSuite(test_name="Load Preset", test_cases=test_cases)
+    suite.execute()
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/contrib/automation_tests/test_cases/main_window.py
+++ b/contrib/automation_tests/test_cases/main_window.py
@@ -5,10 +5,11 @@ found in the LICENSE file.
 """
 
 import logging
+import time
 
 from pywinauto.base_wrapper import BaseWrapper
 
-from core.orbit_e2e import E2ETestCase
+from core.orbit_e2e import E2ETestCase, wait_for_condition
 
 
 class MoveTab(E2ETestCase):
@@ -68,3 +69,18 @@ class MoveTab(E2ETestCase):
         self.expect_eq(tab_item.parent(), right_tab_bar, "Tab is parented under the right pane")
         self.expect_true(
             self.find_control("Group", name=tab_name).is_visible(), "Functions tab is visible")
+
+
+class EndSession(E2ETestCase):
+    """
+    Click menu entry to end session.
+    """
+
+    def _execute(self):
+        time.sleep(1)
+        app_menu = self.suite.top_window().descendants(control_type="MenuBar")[1]
+        app_menu.item_by_path("File->End Session").click_input()
+        wait_for_condition(
+            lambda: self.suite.application.top_window().class_name() ==
+            "orbit_session_setup::SessionSetupDialog", 30)
+        self.suite.top_window(force_update=True)

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -158,7 +158,8 @@ class UnhookAllFunctions(E2ETestCase):
         functions_dataview.filter.set_focus()
         functions_dataview.filter.set_edit_text('')
         functions_dataview.get_item_at(0, 0).click_input('left')
-        send_keys('^a^c')
+        # Hit Ctrl+a to select all functions.
+        send_keys('^a')
         functions_dataview.get_item_at(0, 0).click_input('right')
         self.find_context_menu_item('Unhook').click_input()
 

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -4,6 +4,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
 
+import enum
 import logging
 import os
 
@@ -56,6 +57,25 @@ class LoadSymbols(E2ETestCase):
 
         functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0)
+
+
+class VerifyModuleLoaded(E2ETestCase):
+    """
+    Verifies wether a module with the give search string is loaded.
+    """
+
+    def _execute(self, module_search_string: str, expect_loaded: bool = True):
+        _show_symbols_and_functions_tabs(self.suite.top_window())
+
+        logging.info('Start verifying module %s is %s.', module_search_string,
+                     "loaded" if expect_loaded else "not loaded")
+        modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
+        wait_for_condition(lambda: modules_dataview.get_row_count() > 0, 100)
+        modules_dataview.filter.set_focus()
+        modules_dataview.filter.set_edit_text('')
+        send_keys(module_search_string)
+        wait_for_condition(lambda: modules_dataview.get_row_count() > 0)
+        self.expect_true('*' in modules_dataview.get_item_at(0, 0).texts()[0], 'Module is loaded.')
 
 
 class VerifySymbolsLoaded(E2ETestCase):
@@ -124,6 +144,25 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
         wait_for_condition(lambda: '✓ F' in functions_dataview.get_item_at(0, 0).texts()[0])
 
 
+class UnhookAllFunctions(E2ETestCase):
+    """
+    Unhook all functions.
+    """
+
+    def _execute(self):
+        _show_symbols_and_functions_tabs(self.suite.top_window())
+
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        logging.info('Waiting for function list to be populated...')
+        wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
+        functions_dataview.filter.set_focus()
+        functions_dataview.filter.set_edit_text('')
+        functions_dataview.get_item_at(0, 0).click_input('left')
+        send_keys('^a^c')
+        functions_dataview.get_item_at(0, 0).click_input('right')
+        self.find_context_menu_item('Unhook').click_input()
+
+
 class FilterAndHookMultipleFunctions(E2ETestCase):
     """
     Hook multiple functions based on a search string, and verify it is indicated as hooked in the UI.
@@ -153,7 +192,8 @@ class FilterAndHookMultipleFunctions(E2ETestCase):
 class LoadAndVerifyHelloGgpPreset(E2ETestCase):
     """
     Load the predefined E2E test preset and verify if has been applied correctly.
-    TODO: This may need to be updated
+    TODO: This can be removed when orbit_load_preset.py is removed (it is replaced by
+    orbit_load_preset_2.py).
     """
 
     def _execute(self):
@@ -208,6 +248,101 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
                          'GgpIssueFrameToken is marked as hooked')
 
         return True
+
+
+class VerifyFunctionHooked(E2ETestCase):
+    """
+    Verfify wether or not function is hooked in the functions table in the symbols tab.
+    """
+
+    def _execute(self, function_search_string: str, expect_hooked: bool = True):
+        _show_symbols_and_functions_tabs(self.suite.top_window())
+
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        functions_dataview.filter.set_focus()
+        functions_dataview.filter.set_edit_text('')
+        send_keys(function_search_string)
+        row = functions_dataview.find_first_item_row(function_search_string, 1)
+        if expect_hooked:
+            self.expect_true('✓' in functions_dataview.get_item_at(row, 0).texts()[0],
+                             'Function is marked as hooked.')
+        else:
+            self.expect_true('✓' not in functions_dataview.get_item_at(row, 0).texts()[0],
+                             'Function is not marked as hooked.')
+
+
+class PresetStatus(enum.Enum):
+    LOADABLE = "loadable"
+    PARTIALLY_LOADABLE = "partially loadable"
+    NOT_LOADABLE = "not loadable"
+
+
+class VerifyPresetStatus(E2ETestCase):
+    """
+    Verfify wether preset is loadable, partially loadable or not loadable.
+    """
+
+    def _execute(self, preset_name: str, expected_status: PresetStatus):
+        _show_symbols_and_functions_tabs(self.suite.top_window())
+
+        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
+        preset_row = presets_panel.find_first_item_row(preset_name, 1, True)
+        self.expect_true(preset_row is not None, 'Found preset.')
+        status_text = presets_panel.get_item_at(preset_row, 0).texts()[0]
+        if expected_status is PresetStatus.LOADABLE:
+            self.expect_true('Yes' in status_text, 'Preset is loadable.')
+        if expected_status is PresetStatus.PARTIALLY_LOADABLE:
+            self.expect_true('Partially' in status_text, 'Preset is partially loadable.')
+        if expected_status is PresetStatus.NOT_LOADABLE:
+            self.expect_true('No' in status_text, 'Preset is not loadable.')
+
+
+class LoadPreset(E2ETestCase):
+    """
+    Load preset with given name.
+    """
+
+    def _execute(self, preset_name: str):
+        _show_symbols_and_functions_tabs(self.suite.top_window())
+
+        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
+        preset_row = presets_panel.find_first_item_row(preset_name, 1, True)
+        self.expect_true(preset_row is not None, 'Found preset.')
+        status_text = presets_panel.get_item_at(preset_row, 0).texts()[0]
+
+        if 'No' in status_text:
+            app_menu = self.suite.top_window().descendants(control_type="MenuBar")[1]
+            app_menu.item_by_path("File->Open Preset...").click_input()
+            dialog = self.suite.top_window().child_window(title_re="Select a file*")
+            dialog.FileNameEdit.type_keys(preset_name)
+            dialog.FileNameEdit.type_keys('{DOWN}{ENTER}')
+
+            message_box = self.suite.top_window().child_window(title_re="Preset loading failed*")
+            self.expect_true(message_box is not None, 'Message box found.')
+            message_box.Ok.click()
+        else:
+            presets_panel.get_item_at(preset_row, 0).click_input(button='right')
+            self.find_context_menu_item('Load Preset').click_input()
+            logging.info('Loaded preset: %s', preset_name)
+
+            if 'Partially' in status_text:
+                message_box = self.suite.top_window().child_window(
+                    title_re="Preset only partially loaded*")
+                self.expect_true(message_box is not None, 'Message box found.')
+                message_box.Ok.click()
+
+
+class SavePreset(E2ETestCase):
+    """
+    Save current state in preset.
+    """
+
+    def _execute(self, preset_name: str):
+        app_menu = self.suite.top_window().descendants(control_type="MenuBar")[1]
+        app_menu.item_by_path("File->Save Preset As ...").click_input()
+        dialog = self.suite.top_window().child_window(title_re="Specify*")
+        dialog.FileNameCombo.type_keys(preset_name)
+        dialog.Save.click()
 
 
 class ShowSourceCode(E2ETestCase):

--- a/contrib/automation_tests/testdata/draw_frame_in_hello_ggp_1_68.opr
+++ b/contrib/automation_tests/testdata/draw_frame_in_hello_ggp_1_68.opr
@@ -1,0 +1,7 @@
+# ORBIT preset file
+modules {
+  key: "/mnt/developer/hello_ggp_standalone"
+  value {
+    function_names: "DrawFrame"
+  }
+}

--- a/contrib/automation_tests/testdata/ggp_issue_frame_token_in_hello_ggp_1_68.opr
+++ b/contrib/automation_tests/testdata/ggp_issue_frame_token_in_hello_ggp_1_68.opr
@@ -1,0 +1,7 @@
+# ORBIT preset file
+modules {
+  key: "/mnt/developer/hello_ggp_standalone"
+  value {
+    function_names: "GgpIssueFrameToken"
+  }
+}

--- a/contrib/automation_tests/testdata/not_loadable.opr
+++ b/contrib/automation_tests/testdata/not_loadable.opr
@@ -1,0 +1,7 @@
+# ORBIT preset file
+modules {
+  key: "/mnt/developer/hello_ggp_standalone_other_name"
+  value {
+    function_names: "DrawFrame"
+  }
+}

--- a/contrib/automation_tests/testdata/partially_loadable.opr
+++ b/contrib/automation_tests/testdata/partially_loadable.opr
@@ -1,0 +1,13 @@
+# ORBIT preset file
+modules {
+  key: "/mnt/developer/hello_ggp_standalone_other_name"
+  value {
+    function_names: "DrawFrame"
+  }
+}
+modules {
+  key: "/usr/local/cloudcast/lib/libc-2.24.so"
+  value {
+    function_names: "__GI___clock_gettime"
+  }
+}


### PR DESCRIPTION
This is a more exhaustive version of orbit_load_presets.py.
Also, compared to orbit_load_presets.py, this is split into more reusable
parts (e.g. for loading/saving presets). The old test will stay around for
testing old (pre 1.73) versions of Orbit.

The presets required for the test are moved into "testdata" directory.
The old presets need to stay around in until orbit_load_presets.py is finally
retired.

Bug: http://b/192221969
Test: Ran tests locally.