### PR TITLE
Add E2ETestCase's for capture loading

### DIFF
--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -5,7 +5,6 @@ found in the LICENSE file.
 """
 
 import logging
-import time
 
 from pywinauto.application import Application
 from pywinauto.keyboard import send_keys
@@ -13,12 +12,13 @@ from pywinauto.keyboard import send_keys
 from core.orbit_e2e import E2ETestCase, wait_for_condition
 
 
-def wait_for_main_window(application: Application):
-    wait_for_condition(lambda: application.top_window().class_name() == "OrbitMainWindow", 30)
+def _wait_for_main_window(application: Application):
+    wait_for_condition(lambda: application.top_window().class_name() == "OrbitMainWindow", max_seconds=30)
 
 
-def wait_for_connection_window(application: Application):
-    wait_for_condition(lambda: application.top_window().class_name() == "orbit_session_setup::SessionSetupDialog", 30)
+def _wait_for_connection_window(application: Application):
+    wait_for_condition(lambda: application.top_window().class_name() == "orbit_session_setup::SessionSetupDialog",
+                       max_seconds=30)
 
 
 def _get_number_of_instances_in_list(test_case: E2ETestCase) -> int:
@@ -37,9 +37,9 @@ class LoadCapture(E2ETestCase):
     def _execute(self, capture_file_path: str):
         # Lets ensure that we are actually in the connection window, as this test might also be executed after the
         # main window has been opened.
-        wait_for_connection_window(self.suite.application)
+        _wait_for_connection_window(self.suite.application)
         self.suite.top_window(force_update=True)
-        logging.info('Start loading to a capture.')
+        logging.info('Starting to load a capture.')
         connect_radio = self.find_control('RadioButton', 'LoadCapture')
         connect_radio.click_input()
 
@@ -49,12 +49,12 @@ class LoadCapture(E2ETestCase):
         file_name_edit = self.find_control('Edit', 'File name:')
         file_name_edit.set_edit_text(capture_file_path)
 
-        logging.info(f'Trying to loading to load capture file: {capture_file_path}')
+        logging.info(f'Trying to load capture file: {capture_file_path}')
         start_session_button = self.find_control('Button', 'Start Session')
         start_session_button.click_input()
 
         # Unless the file does not exist, Orbit's main window will open next and contain the "Loading capture" dialog.
-        wait_for_main_window(self.suite.application)
+        _wait_for_main_window(self.suite.application)
         # As there is a new top window (Orbit main window), we need to update the top window.
         self.suite.top_window(force_update=True)
 
@@ -261,7 +261,7 @@ class FilterAndSelectFirstProcess(E2ETestCase):
 
         logging.info('Process selected, continuing to main window...')
         process_list.children(control_type='DataItem')[0].double_click_input()
-        wait_for_main_window(self.suite.application)
+        _wait_for_main_window(self.suite.application)
         window = self.suite.top_window(True)
         self.expect_eq(window.class_name(), "OrbitMainWindow", 'Main window is visible')
         window.maximize()

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
@@ -17,11 +17,52 @@ def wait_for_main_window(application: Application):
     wait_for_condition(lambda: application.top_window().class_name() == "OrbitMainWindow", 30)
 
 
+def wait_for_connection_window(application: Application):
+    wait_for_condition(lambda: application.top_window().class_name() == "orbit_session_setup::SessionSetupDialog", 30)
+
+
 def _get_number_of_instances_in_list(test_case: E2ETestCase) -> int:
     instance_list = test_case.find_control('Table', 'InstanceList')
     instance_count = instance_list.item_count()
     logging.info('Found %s rows in the instance list', instance_count)
     return instance_count
+
+
+class LoadCapture(E2ETestCase):
+    """
+    Opens a given capture file. The argument `capture_file_path` specifies the full path to the capture file.
+    It raises an exception if the capture does not exists. Also waits until the capture is loaded.
+    """
+
+    def _execute(self, capture_file_path: str):
+        # Lets ensure that we are actually in the connection window, as this test might also be executed after the
+        # main window has been opened.
+        wait_for_connection_window(self.suite.application)
+        self.suite.top_window(force_update=True)
+        logging.info('Start loading to a capture.')
+        connect_radio = self.find_control('RadioButton', 'LoadCapture')
+        connect_radio.click_input()
+
+        others_button = self.find_control('Button', '...')
+        others_button.click_input()
+
+        file_name_edit = self.find_control('Edit', 'File name:')
+        file_name_edit.set_edit_text(capture_file_path)
+
+        logging.info(f'Trying to loading to load capture file: {capture_file_path}')
+        start_session_button = self.find_control('Button', 'Start Session')
+        start_session_button.click_input()
+
+        # Unless the file does not exist, Orbit's main window will open next and contain the "Loading capture" dialog.
+        wait_for_main_window(self.suite.application)
+        # As there is a new top window (Orbit main window), we need to update the top window.
+        self.suite.top_window(force_update=True)
+
+        logging.info("Waiting for capture to load...")
+        wait_for_condition(lambda: self.find_control(
+            'Window', 'Loading capture', raise_on_failure=False) is None,
+                           max_seconds=120)
+        logging.info("Capture Loading finished")
 
 
 class ConnectToStadiaInstance(E2ETestCase):

--- a/contrib/automation_tests/test_cases/main_window.py
+++ b/contrib/automation_tests/test_cases/main_window.py
@@ -11,6 +11,17 @@ from pywinauto.base_wrapper import BaseWrapper
 from core.orbit_e2e import E2ETestCase
 
 
+class VerifyModalWindowExistsAndClickOkay(E2ETestCase):
+    """
+     Looks for a window called `window_name` and click on the "OK" button. Fails if the window does not exists.
+     """
+
+    def _execute(self, window_name: str):
+        self.find_control('Window', window_name)
+        ok_button = self.find_control('Button', 'OK')
+        ok_button.click_input()
+
+
 class MoveTab(E2ETestCase):
     """
     Move a tab from the right widget to the left, and back again. Verify the position after each move.


### PR DESCRIPTION
This change adds an E2ETestCase that attemps to load a capture of
a given file. It waits until the main window opens.

Further, it adds an E2ETestCase to verify that a model window exists and
to click on the "OK" button. This will be used, to verify loading of
old captures will raise an error.

Test: Wrote an E2E test and run it locally (will be a different PR)
Bug: http://b/192222100