### PR TITLE
Avoid redefining action names in data view tests

### DIFF
--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -36,6 +36,13 @@ using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::kMenuActionCopySelection;
+using orbit_data_views::kMenuActionDisassembly;
+using orbit_data_views::kMenuActionExportToCsv;
+using orbit_data_views::kMenuActionLoadSymbols;
+using orbit_data_views::kMenuActionSelect;
+using orbit_data_views::kMenuActionSourceCode;
+using orbit_data_views::kMenuActionUnselect;
 using orbit_data_views::MockAppInterface;
 using orbit_grpc_protos::ModuleInfo;
 
@@ -316,8 +323,8 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
-    CheckSingleAction(context_menu, "Copy Selection", ContextMenuEntry::kEnabled);
-    CheckSingleAction(context_menu, "Export to CSV", ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionExportToCsv, ContextMenuEntry::kEnabled);
 
     ContextMenuEntry source_code_or_disassembly = ContextMenuEntry::kDisabled;
     ContextMenuEntry load_symbols = ContextMenuEntry::kDisabled;
@@ -344,11 +351,11 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         load_symbols = ContextMenuEntry::kEnabled;
       }
     }
-    CheckSingleAction(context_menu, "Go to Disassembly", source_code_or_disassembly);
-    CheckSingleAction(context_menu, "Go to Source code", source_code_or_disassembly);
-    CheckSingleAction(context_menu, "Load Symbols", load_symbols);
-    CheckSingleAction(context_menu, "Hook", select);
-    CheckSingleAction(context_menu, "Unhook", unselect);
+    CheckSingleAction(context_menu, kMenuActionDisassembly, source_code_or_disassembly);
+    CheckSingleAction(context_menu, kMenuActionSourceCode, source_code_or_disassembly);
+    CheckSingleAction(context_menu, kMenuActionLoadSymbols, load_symbols);
+    CheckSingleAction(context_menu, kMenuActionSelect, select);
+    CheckSingleAction(context_menu, kMenuActionUnselect, unselect);
   };
 
   SetCallstackFromFrames(kCallstackFrameAddresses);
@@ -412,7 +419,7 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
   // Go to Disassembly
   {
     const auto disassembly_index =
-        std::find(context_menu.begin(), context_menu.end(), "Go to Disassembly") -
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionDisassembly) -
         context_menu.begin();
     ASSERT_LT(disassembly_index, context_menu.size());
 
@@ -421,32 +428,34 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
         .WillOnce([&](int32_t /*pid*/, const FunctionInfo& function) {
           EXPECT_EQ(function.name(), kFunctionNames[0]);
         });
-    view_.OnContextMenu("Go to Disassembly", static_cast<int>(disassembly_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionDisassembly}, static_cast<int>(disassembly_index),
+                        {0});
   }
 
   // Go to Source code
   {
     const auto source_code_index =
-        std::find(context_menu.begin(), context_menu.end(), "Go to Source code") -
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionSourceCode) -
         context_menu.begin();
     ASSERT_LT(source_code_index, context_menu.size());
 
     EXPECT_CALL(app_, ShowSourceCode).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu("Go to Source code", static_cast<int>(source_code_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSourceCode}, static_cast<int>(source_code_index),
+                        {0});
   }
 
   // Hook
   {
-    const auto hook_index =
-        std::find(context_menu.begin(), context_menu.end(), "Hook") - context_menu.begin();
+    const auto hook_index = std::find(context_menu.begin(), context_menu.end(), kMenuActionSelect) -
+                            context_menu.begin();
     ASSERT_LT(hook_index, context_menu.size());
 
     EXPECT_CALL(app_, SelectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu("Hook", static_cast<int>(hook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSelect}, static_cast<int>(hook_index), {0});
   }
 
   function_selected = true;
@@ -456,13 +465,14 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
   // Unhook
   {
     const auto unhook_index =
-        std::find(context_menu.begin(), context_menu.end(), "Unhook") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionUnselect) -
+        context_menu.begin();
     ASSERT_LT(unhook_index, context_menu.size());
 
     EXPECT_CALL(app_, DeselectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu("Unhook", static_cast<int>(unhook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionUnselect}, static_cast<int>(unhook_index), {0});
   }
 }
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -87,7 +87,7 @@ void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,
     if (!save_file.empty()) {
       auto result = ExportCsv(save_file);
       if (result.has_error()) {
-        app_->SendErrorToUi("Export to CSV", result.error().message());
+        app_->SendErrorToUi(std::string{kMenuActionExportToCsv}, result.error().message());
       }
     }
   } else if (action == kMenuActionCopySelection) {

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -15,7 +15,7 @@
 
 namespace orbit_data_views {
 
-void CheckSingleAction(const std::vector<std::string>& context_menu, const std::string& action,
+void CheckSingleAction(const std::vector<std::string>& context_menu, std::string_view action,
                        ContextMenuEntry menu_entry) {
   switch (menu_entry) {
     case ContextMenuEntry::kEnabled:
@@ -33,19 +33,20 @@ void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
                                  const MockAppInterface& app, DataView& view,
                                  const std::string& expected_clipboard) {
   const auto copy_selection_index =
-      std::find(context_menu.begin(), context_menu.end(), "Copy Selection") - context_menu.begin();
+      std::find(context_menu.begin(), context_menu.end(), kMenuActionCopySelection) -
+      context_menu.begin();
   ASSERT_LT(copy_selection_index, context_menu.size());
 
   std::string clipboard;
   EXPECT_CALL(app, SetClipboard).Times(1).WillOnce(testing::SaveArg<0>(&clipboard));
-  view.OnContextMenu("Copy Selection", static_cast<int>(copy_selection_index), {0});
+  view.OnContextMenu(std::string{kMenuActionCopySelection}, static_cast<int>(copy_selection_index),
+                     {0});
   EXPECT_EQ(clipboard, expected_clipboard);
 }
 
 void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
                                const MockAppInterface& app, DataView& view,
-                               const std::string& expected_contents,
-                               const std::string& action_name) {
+                               const std::string& expected_contents, std::string_view action_name) {
   const auto action_index =
       std::find(context_menu.begin(), context_menu.end(), action_name) - context_menu.begin();
   ASSERT_LT(action_index, context_menu.size());
@@ -61,7 +62,7 @@ void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
   temporary_file_or_error.value().CloseAndRemove();
 
   EXPECT_CALL(app, GetSaveFile).Times(1).WillOnce(testing::Return(temporary_file_path.string()));
-  view.OnContextMenu(action_name, static_cast<int>(action_index), {0});
+  view.OnContextMenu(std::string{action_name}, static_cast<int>(action_index), {0});
 
   ErrorMessageOr<std::string> contents_or_error = orbit_base::ReadFileToString(temporary_file_path);
   ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -15,7 +15,7 @@ namespace orbit_data_views {
 
 enum class ContextMenuEntry { kEnabled, kDisabled };
 
-void CheckSingleAction(const std::vector<std::string>& context_menu, const std::string& action,
+void CheckSingleAction(const std::vector<std::string>& context_menu, std::string_view action,
                        ContextMenuEntry menu_entry);
 
 void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
@@ -25,7 +25,7 @@ void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
 void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
                                const MockAppInterface& app, DataView& view,
                                const std::string& expected_contents,
-                               const std::string& action_name = "Export to CSV");
+                               std::string_view action_name = kMenuActionExportToCsv);
 
 std::vector<std::string> FlattenContextMenuWithGrouping(
     const std::vector<std::vector<std::string>>& menu_with_grouping);

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -28,6 +28,14 @@ using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::kMenuActionCopySelection;
+using orbit_data_views::kMenuActionDisableFrameTrack;
+using orbit_data_views::kMenuActionDisassembly;
+using orbit_data_views::kMenuActionEnableFrameTrack;
+using orbit_data_views::kMenuActionExportToCsv;
+using orbit_data_views::kMenuActionSelect;
+using orbit_data_views::kMenuActionSourceCode;
+using orbit_data_views::kMenuActionUnselect;
 
 namespace {
 struct FunctionsDataViewTest : public testing::Test {
@@ -384,12 +392,12 @@ TEST_F(FunctionsDataViewTest, ContextMenuEntriesChangeOnFunctionState) {
         FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
-    CheckSingleAction(context_menu, "Copy Selection", ContextMenuEntry::kEnabled);
-    CheckSingleAction(context_menu, "Export to CSV", ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionExportToCsv, ContextMenuEntry::kEnabled);
 
     // Source code and disassembly actions are also always available.
-    CheckSingleAction(context_menu, "Go to Source code", ContextMenuEntry::kEnabled);
-    CheckSingleAction(context_menu, "Go to Disassembly", ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionSourceCode, ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionDisassembly, ContextMenuEntry::kEnabled);
 
     // Hook action is available if and only if there is an unselected function. Unhook action is
     // available if and only if there is a selected instrumented function.
@@ -413,10 +421,10 @@ TEST_F(FunctionsDataViewTest, ContextMenuEntriesChangeOnFunctionState) {
         enable_frametrack = ContextMenuEntry::kEnabled;
       }
     }
-    CheckSingleAction(context_menu, "Hook", select);
-    CheckSingleAction(context_menu, "Unhook", unselect);
-    CheckSingleAction(context_menu, "Enable frame track(s)", enable_frametrack);
-    CheckSingleAction(context_menu, "Disable frame track(s)", disable_frametrack);
+    CheckSingleAction(context_menu, kMenuActionSelect, select);
+    CheckSingleAction(context_menu, kMenuActionUnselect, unselect);
+    CheckSingleAction(context_menu, kMenuActionEnableFrameTrack, enable_frametrack);
+    CheckSingleAction(context_menu, kMenuActionDisableFrameTrack, disable_frametrack);
   };
 
   verify_context_menu_action_availability({0});
@@ -581,27 +589,27 @@ TEST_F(FunctionsDataViewTest, ContextMenuActionsCallCorrespondingFunctionsInAppI
   };
 
   EXPECT_CALL(app_, SelectFunction).Times(1).WillRepeatedly(match_function);
-  view_.OnContextMenu("Hook", 0, {0});
+  view_.OnContextMenu(std::string{kMenuActionSelect}, 0, {0});
 
   EXPECT_CALL(app_, DeselectFunction).Times(1).WillRepeatedly(match_function);
   EXPECT_CALL(app_, DisableFrameTrack).Times(1).WillRepeatedly(match_function);
   EXPECT_CALL(app_, RemoveFrameTrack(testing::A<const orbit_client_protos::FunctionInfo&>()))
       .Times(1)
       .WillRepeatedly(match_function);
-  view_.OnContextMenu("Unhook", 0, {0});
+  view_.OnContextMenu(std::string{kMenuActionUnselect}, 0, {0});
 
   EXPECT_CALL(app_, SelectFunction).Times(1).WillRepeatedly(match_function);
   EXPECT_CALL(app_, EnableFrameTrack).Times(1).WillRepeatedly(match_function);
   EXPECT_CALL(app_, AddFrameTrack(testing::A<const orbit_client_protos::FunctionInfo&>()))
       .Times(1)
       .WillRepeatedly(match_function);
-  view_.OnContextMenu("Enable frame track(s)", 0, {0});
+  view_.OnContextMenu(std::string{kMenuActionEnableFrameTrack}, 0, {0});
 
   EXPECT_CALL(app_, DisableFrameTrack).Times(1).WillRepeatedly(match_function);
   EXPECT_CALL(app_, RemoveFrameTrack(testing::A<const orbit_client_protos::FunctionInfo&>()))
       .Times(1)
       .WillRepeatedly(match_function);
-  view_.OnContextMenu("Disable frame track(s)", 0, {0});
+  view_.OnContextMenu(std::string{kMenuActionDisableFrameTrack}, 0, {0});
 
   constexpr int kRandomPid = 4242;
   orbit_grpc_protos::ProcessInfo process_info{};
@@ -615,10 +623,10 @@ TEST_F(FunctionsDataViewTest, ContextMenuActionsCallCorrespondingFunctionsInAppI
         EXPECT_EQ(pid, kRandomPid);
         match_function(function);
       });
-  view_.OnContextMenu("Go to Disassembly", 0, {0});
+  view_.OnContextMenu(std::string{kMenuActionDisassembly}, 0, {0});
 
   EXPECT_CALL(app_, ShowSourceCode).Times(1).WillRepeatedly(match_function);
-  view_.OnContextMenu("Go to Source code", 0, {0});
+  view_.OnContextMenu(std::string{kMenuActionSourceCode}, 0, {0});
 }
 
 TEST_F(FunctionsDataViewTest, FilteringByFunctionName) {

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -35,6 +35,20 @@ using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::kMenuActionCopySelection;
+using orbit_data_views::kMenuActionDisableFrameTrack;
+using orbit_data_views::kMenuActionDisassembly;
+using orbit_data_views::kMenuActionEnableFrameTrack;
+using orbit_data_views::kMenuActionExportEventsToCsv;
+using orbit_data_views::kMenuActionExportToCsv;
+using orbit_data_views::kMenuActionIterate;
+using orbit_data_views::kMenuActionJumpToFirst;
+using orbit_data_views::kMenuActionJumpToLast;
+using orbit_data_views::kMenuActionJumpToMax;
+using orbit_data_views::kMenuActionJumpToMin;
+using orbit_data_views::kMenuActionSelect;
+using orbit_data_views::kMenuActionSourceCode;
+using orbit_data_views::kMenuActionUnselect;
 using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::ModuleInfo;
 
@@ -268,15 +282,15 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
-    CheckSingleAction(context_menu, "Copy Selection", ContextMenuEntry::kEnabled);
-    CheckSingleAction(context_menu, "Export to CSV", ContextMenuEntry::kEnabled);
-    CheckSingleAction(context_menu, "Export events to CSV", ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionExportToCsv, ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionExportEventsToCsv, ContextMenuEntry::kEnabled);
 
     // Source code and disassembly actions are availble if and only if capture is connected.
     ContextMenuEntry source_code_or_disassembly =
         capture_connected ? ContextMenuEntry::kEnabled : ContextMenuEntry::kDisabled;
-    CheckSingleAction(context_menu, "Go to Source code", source_code_or_disassembly);
-    CheckSingleAction(context_menu, "Go to Disassembly", source_code_or_disassembly);
+    CheckSingleAction(context_menu, kMenuActionSourceCode, source_code_or_disassembly);
+    CheckSingleAction(context_menu, kMenuActionDisassembly, source_code_or_disassembly);
 
     // Add iterators action is only available if some function has non-zero counts.
     int total_counts = 0;
@@ -285,16 +299,16 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     }
     ContextMenuEntry add_iterators =
         total_counts > 0 ? ContextMenuEntry::kEnabled : ContextMenuEntry::kDisabled;
-    CheckSingleAction(context_menu, "Add iterator(s)", add_iterators);
+    CheckSingleAction(context_menu, kMenuActionIterate, add_iterators);
 
     // Jump actions are only available for single selection with non-zero counts.
     ContextMenuEntry jump_to_direction = selected_indices.size() == 1 && total_counts > 0
                                              ? ContextMenuEntry::kEnabled
                                              : ContextMenuEntry::kDisabled;
-    CheckSingleAction(context_menu, "Jump to first", jump_to_direction);
-    CheckSingleAction(context_menu, "Jump to last", jump_to_direction);
-    CheckSingleAction(context_menu, "Jump to min", jump_to_direction);
-    CheckSingleAction(context_menu, "Jump to max", jump_to_direction);
+    CheckSingleAction(context_menu, kMenuActionJumpToFirst, jump_to_direction);
+    CheckSingleAction(context_menu, kMenuActionJumpToLast, jump_to_direction);
+    CheckSingleAction(context_menu, kMenuActionJumpToMin, jump_to_direction);
+    CheckSingleAction(context_menu, kMenuActionJumpToMax, jump_to_direction);
 
     // Hook action is available if and only if 1) capture is connected and 2) there is an unselected
     // instrumented function. Unhook action is available if and only if 1) capture is connected and
@@ -310,8 +324,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         }
       }
     }
-    CheckSingleAction(context_menu, "Hook", select);
-    CheckSingleAction(context_menu, "Unhook", unselect);
+    CheckSingleAction(context_menu, kMenuActionSelect, select);
+    CheckSingleAction(context_menu, kMenuActionUnselect, unselect);
 
     // Enable frametrack action is available if and only if there is an instrumented function with
     // frametrack not yet enabled, disable frametrack action is available if and only if there is an
@@ -325,8 +339,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         enable_frametrack = ContextMenuEntry::kEnabled;
       }
     }
-    CheckSingleAction(context_menu, "Enable frame track(s)", enable_frametrack);
-    CheckSingleAction(context_menu, "Disable frame track(s)", disable_frametrack);
+    CheckSingleAction(context_menu, kMenuActionEnableFrameTrack, enable_frametrack);
+    CheckSingleAction(context_menu, kMenuActionDisableFrameTrack, disable_frametrack);
   };
 
   capture_connected = false;
@@ -420,13 +434,14 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
                                            kThreadIds[kThreadIndices[i]], kStarts[i], kEnds[i],
                                            kEnds[i] - kStarts[i]);
     }
-    CheckExportToCsvIsInvoked(context_menu, app_, view_, expected_contents, "Export events to CSV");
+    CheckExportToCsvIsInvoked(context_menu, app_, view_, expected_contents,
+                              kMenuActionExportEventsToCsv);
   }
 
   // Go to Disassembly
   {
     const auto disassembly_index =
-        std::find(context_menu.begin(), context_menu.end(), "Go to Disassembly") -
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionDisassembly) -
         context_menu.begin();
     ASSERT_LT(disassembly_index, context_menu.size());
 
@@ -435,26 +450,29 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         .WillOnce([&](int32_t /*pid*/, const FunctionInfo& function) {
           EXPECT_EQ(function.name(), kNames[0]);
         });
-    view_.OnContextMenu("Go to Disassembly", static_cast<int>(disassembly_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionDisassembly}, static_cast<int>(disassembly_index),
+                        {0});
   }
 
   // Go to Source code
   {
     const auto source_code_index =
-        std::find(context_menu.begin(), context_menu.end(), "Go to Source code") -
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionSourceCode) -
         context_menu.begin();
     ASSERT_LT(source_code_index, context_menu.size());
 
     EXPECT_CALL(app_, ShowSourceCode).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kNames[0]);
     });
-    view_.OnContextMenu("Go to Source code", static_cast<int>(source_code_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSourceCode}, static_cast<int>(source_code_index),
+                        {0});
   }
 
   // Jump to first
   {
     const auto jump_to_first_index =
-        std::find(context_menu.begin(), context_menu.end(), "Jump to first") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionJumpToFirst) -
+        context_menu.begin();
     ASSERT_LT(jump_to_first_index, context_menu.size());
 
     EXPECT_CALL(app_, JumpToTimerAndZoom)
@@ -462,13 +480,15 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         .WillOnce([](uint64_t /*function_id*/, JumpToTimerMode selection_mode) {
           EXPECT_EQ(selection_mode, JumpToTimerMode::kFirst);
         });
-    view_.OnContextMenu("Jump to first", static_cast<int>(jump_to_first_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionJumpToFirst}, static_cast<int>(jump_to_first_index),
+                        {0});
   }
 
   // Jump to last
   {
     const auto jump_to_last_index =
-        std::find(context_menu.begin(), context_menu.end(), "Jump to last") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionJumpToLast) -
+        context_menu.begin();
     ASSERT_LT(jump_to_last_index, context_menu.size());
 
     EXPECT_CALL(app_, JumpToTimerAndZoom)
@@ -476,13 +496,15 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         .WillOnce([](uint64_t /*function_id*/, JumpToTimerMode selection_mode) {
           EXPECT_EQ(selection_mode, JumpToTimerMode::kLast);
         });
-    view_.OnContextMenu("Jump to last", static_cast<int>(jump_to_last_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionJumpToLast}, static_cast<int>(jump_to_last_index),
+                        {0});
   }
 
   // Jump to min
   {
     const auto jump_to_min_index =
-        std::find(context_menu.begin(), context_menu.end(), "Jump to min") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionJumpToMin) -
+        context_menu.begin();
     ASSERT_LT(jump_to_min_index, context_menu.size());
 
     EXPECT_CALL(app_, JumpToTimerAndZoom)
@@ -490,13 +512,15 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         .WillOnce([](uint64_t /*function_id*/, JumpToTimerMode selection_mode) {
           EXPECT_EQ(selection_mode, JumpToTimerMode::kMin);
         });
-    view_.OnContextMenu("Jump to min", static_cast<int>(jump_to_min_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionJumpToMin}, static_cast<int>(jump_to_min_index),
+                        {0});
   }
 
   // Jump to max
   {
     const auto jump_to_max_index =
-        std::find(context_menu.begin(), context_menu.end(), "Jump to max") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionJumpToMax) -
+        context_menu.begin();
     ASSERT_LT(jump_to_max_index, context_menu.size());
 
     EXPECT_CALL(app_, JumpToTimerAndZoom)
@@ -504,13 +528,14 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         .WillOnce([](uint64_t /*function_id*/, JumpToTimerMode selection_mode) {
           EXPECT_EQ(selection_mode, JumpToTimerMode::kMax);
         });
-    view_.OnContextMenu("Jump to max", static_cast<int>(jump_to_max_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionJumpToMax}, static_cast<int>(jump_to_max_index),
+                        {0});
   }
 
   // Add iterator(s)
   {
     const auto add_iterators_index =
-        std::find(context_menu.begin(), context_menu.end(), "Add iterator(s)") -
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionIterate) -
         context_menu.begin();
     ASSERT_LT(add_iterators_index, context_menu.size());
 
@@ -520,25 +545,26 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
           EXPECT_EQ(instrumented_function_id, kFunctionIds[0]);
           EXPECT_EQ(function->name(), kNames[0]);
         });
-    view_.OnContextMenu("Add iterator(s)", static_cast<int>(add_iterators_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionIterate}, static_cast<int>(add_iterators_index),
+                        {0});
   }
 
   // Hook
   {
-    const auto hook_index =
-        std::find(context_menu.begin(), context_menu.end(), "Hook") - context_menu.begin();
+    const auto hook_index = std::find(context_menu.begin(), context_menu.end(), kMenuActionSelect) -
+                            context_menu.begin();
     ASSERT_LT(hook_index, context_menu.size());
 
     EXPECT_CALL(app_, SelectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kNames[0]);
     });
-    view_.OnContextMenu("Hook", static_cast<int>(hook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSelect}, static_cast<int>(hook_index), {0});
   }
 
   // Enable frame track(s)
   {
     const auto enable_frame_track_index =
-        std::find(context_menu.begin(), context_menu.end(), "Enable frame track(s)") -
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionEnableFrameTrack) -
         context_menu.begin();
     ASSERT_LT(enable_frame_track_index, context_menu.size());
 
@@ -549,7 +575,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, AddFrameTrack(testing::An<uint64_t>()))
         .Times(1)
         .WillOnce([&](uint64_t function_id) { EXPECT_EQ(function_id, kFunctionIds[0]); });
-    view_.OnContextMenu("Enable frame track(s)", static_cast<int>(enable_frame_track_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionEnableFrameTrack},
+                        static_cast<int>(enable_frame_track_index), {0});
   }
 
   function_selected = true;
@@ -561,7 +588,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
   // Unhook
   {
     const auto unhook_index =
-        std::find(context_menu.begin(), context_menu.end(), "Unhook") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionUnselect) -
+        context_menu.begin();
     ASSERT_LT(unhook_index, context_menu.size());
 
     EXPECT_CALL(app_, DeselectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
@@ -571,13 +599,13 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, RemoveFrameTrack(testing::An<const FunctionInfo&>()))
         .Times(1)
         .WillOnce([&](const FunctionInfo& function) { EXPECT_EQ(function.name(), kNames[0]); });
-    view_.OnContextMenu("Unhook", static_cast<int>(unhook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionUnselect}, static_cast<int>(unhook_index), {0});
   }
 
   // Disable frame track(s)
   {
     const auto disable_frame_track_index =
-        std::find(context_menu.begin(), context_menu.end(), "Disable frame track(s)") -
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionDisableFrameTrack) -
         context_menu.begin();
     ASSERT_LT(disable_frame_track_index, context_menu.size());
 
@@ -587,7 +615,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, RemoveFrameTrack(testing::An<uint64_t>()))
         .Times(1)
         .WillOnce([&](uint64_t function_id) { EXPECT_EQ(function_id, kFunctionIds[0]); });
-    view_.OnContextMenu("Disable frame track(s)", static_cast<int>(disable_frame_track_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionDisableFrameTrack},
+                        static_cast<int>(disable_frame_track_index), {0});
   }
 }
 

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -23,6 +23,9 @@ using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::kMenuActionCopySelection;
+using orbit_data_views::kMenuActionExportToCsv;
+using orbit_data_views::kMenuActionLoadSymbols;
 using orbit_grpc_protos::ModuleInfo;
 
 namespace {
@@ -117,9 +120,9 @@ TEST_F(ModulesDataViewTest, ContextMenuEntriesArePresent) {
   std::vector<std::string> context_menu =
       FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
 
-  CheckSingleAction(context_menu, "Copy Selection", ContextMenuEntry::kEnabled);
-  CheckSingleAction(context_menu, "Export to CSV", ContextMenuEntry::kEnabled);
-  CheckSingleAction(context_menu, "Load Symbols", ContextMenuEntry::kEnabled);
+  CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
+  CheckSingleAction(context_menu, kMenuActionExportToCsv, ContextMenuEntry::kEnabled);
+  CheckSingleAction(context_menu, kMenuActionLoadSymbols, ContextMenuEntry::kEnabled);
 }
 
 TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
@@ -131,13 +134,15 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
   // Load Symbols
   {
     const auto load_symbols_index =
-        std::find(context_menu.begin(), context_menu.end(), "Load Symbols") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionLoadSymbols) -
+        context_menu.begin();
     ASSERT_LT(load_symbols_index, context_menu.size());
 
     EXPECT_CALL(app_, RetrieveModulesAndLoadSymbols)
         .Times(1)
         .WillOnce(testing::Return(orbit_base::Future<void>{}));
-    view_.OnContextMenu("Load Symbols", static_cast<int>(load_symbols_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionLoadSymbols}, static_cast<int>(load_symbols_index),
+                        {0});
   }
 
   // Copy Selection

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -28,6 +28,11 @@
 using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::kMenuActionCopySelection;
+using orbit_data_views::kMenuActionDeletePreset;
+using orbit_data_views::kMenuActionExportToCsv;
+using orbit_data_views::kMenuActionLoadPreset;
+using orbit_data_views::kMenuActionShowInExplorer;
 
 namespace {
 // This is just a helper type to handle colors. Note that Color from `OrbitGl/CoreMath.h` is not
@@ -208,20 +213,22 @@ TEST_F(PresetsDataViewTest, CheckPresenceOfContextMenuEntries) {
 
   // Loadable preset
   EXPECT_THAT(FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0})),
-              testing::ElementsAre("Load Preset", "Delete Preset", "Show in Explorer",
-                                   "Copy Selection", "Export to CSV"))
+              testing::ElementsAre(kMenuActionLoadPreset, kMenuActionDeletePreset,
+                                   kMenuActionShowInExplorer, kMenuActionCopySelection,
+                                   kMenuActionExportToCsv))
       << view_.GetValue(0, 1);
 
   // Not loadable preset
-  EXPECT_THAT(
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(1, {1})),
-      testing::ElementsAre("Delete Preset", "Show in Explorer", "Copy Selection", "Export to CSV"))
+  EXPECT_THAT(FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(1, {1})),
+              testing::ElementsAre(kMenuActionDeletePreset, kMenuActionShowInExplorer,
+                                   kMenuActionCopySelection, kMenuActionExportToCsv))
       << view_.GetValue(1, 1);
 
   // Partially loadable preset
   EXPECT_THAT(FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(2, {2})),
-              testing::ElementsAre("Load Preset", "Delete Preset", "Show in Explorer",
-                                   "Copy Selection", "Export to CSV"))
+              testing::ElementsAre(kMenuActionLoadPreset, kMenuActionDeletePreset,
+                                   kMenuActionShowInExplorer, kMenuActionCopySelection,
+                                   kMenuActionExportToCsv))
       << view_.GetValue(2, 1);
 }
 
@@ -268,7 +275,8 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
   // Load Preset
   {
     const auto load_preset_idx =
-        std::find(context_menu.begin(), context_menu.end(), "Load Preset") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionLoadPreset) -
+        context_menu.begin();
     ASSERT_LT(load_preset_idx, context_menu.size());
 
     EXPECT_CALL(app_, LoadPreset)
@@ -276,13 +284,13 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
         .WillOnce([&](const orbit_preset_file::PresetFile& preset_file) {
           EXPECT_EQ(preset_file.file_path(), preset_filename0);
         });
-    view_.OnContextMenu("Load Preset", static_cast<int>(load_preset_idx), {0});
+    view_.OnContextMenu(std::string{kMenuActionLoadPreset}, static_cast<int>(load_preset_idx), {0});
   }
 
   // Show In Explorer
   {
     const auto show_in_explorer_idx =
-        std::find(context_menu.begin(), context_menu.end(), "Show in Explorer") -
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionShowInExplorer) -
         context_menu.begin();
     ASSERT_LT(show_in_explorer_idx, context_menu.size());
 
@@ -291,16 +299,19 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
         .WillOnce([&](const orbit_preset_file::PresetFile& preset_file) {
           EXPECT_EQ(preset_file.file_path(), preset_filename0);
         });
-    view_.OnContextMenu("Show in Explorer", static_cast<int>(show_in_explorer_idx), {0});
+    view_.OnContextMenu(std::string{kMenuActionShowInExplorer},
+                        static_cast<int>(show_in_explorer_idx), {0});
   }
 
   // Delete Preset
   {
     const auto delete_preset_idx =
-        std::find(context_menu.begin(), context_menu.end(), "Delete Preset") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionDeletePreset) -
+        context_menu.begin();
     ASSERT_LT(delete_preset_idx, context_menu.size());
 
-    view_.OnContextMenu("Delete Preset", static_cast<int>(delete_preset_idx), {0});
+    view_.OnContextMenu(std::string{kMenuActionDeletePreset}, static_cast<int>(delete_preset_idx),
+                        {0});
 
     const auto file_exists = orbit_base::FileExists(preset_filename0);
     ASSERT_THAT(file_exists, orbit_test_utils::HasNoError());
@@ -315,7 +326,8 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
     view_.SetPresets({preset_file1});
 
     EXPECT_CALL(app_, SendErrorToUi).Times(1);
-    view_.OnContextMenu("Delete Preset", static_cast<int>(delete_preset_idx), {0});
+    view_.OnContextMenu(std::string{kMenuActionDeletePreset}, static_cast<int>(delete_preset_idx),
+                        {0});
 
     EXPECT_EQ(view_.GetNumElements(), 1);
   }

--- a/src/DataViews/TracepointsDataViewTest.cpp
+++ b/src/DataViews/TracepointsDataViewTest.cpp
@@ -16,6 +16,10 @@ using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::kMenuActionCopySelection;
+using orbit_data_views::kMenuActionExportToCsv;
+using orbit_data_views::kMenuActionSelect;
+using orbit_data_views::kMenuActionUnselect;
 using orbit_grpc_protos::TracepointInfo;
 
 namespace {
@@ -111,8 +115,8 @@ TEST_F(TracepointsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
-    CheckSingleAction(context_menu, "Copy Selection", ContextMenuEntry::kEnabled);
-    CheckSingleAction(context_menu, "Export to CSV", ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
+    CheckSingleAction(context_menu, kMenuActionExportToCsv, ContextMenuEntry::kEnabled);
 
     // Unhook action is available if and only if there are selected tracepoints.
     // Hook action is available if and only if there are unselected tracepoints.
@@ -125,8 +129,8 @@ TEST_F(TracepointsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         select = ContextMenuEntry::kEnabled;
       }
     }
-    CheckSingleAction(context_menu, "Unhook", unselect);
-    CheckSingleAction(context_menu, "Hook", select);
+    CheckSingleAction(context_menu, kMenuActionUnselect, unselect);
+    CheckSingleAction(context_menu, kMenuActionSelect, select);
   };
 
   SetTracepointsByIndices({0, 1, 2});
@@ -169,14 +173,14 @@ TEST_F(TracepointsDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Hook
   {
-    const auto hook_index =
-        std::find(context_menu.begin(), context_menu.end(), "Hook") - context_menu.begin();
+    const auto hook_index = std::find(context_menu.begin(), context_menu.end(), kMenuActionSelect) -
+                            context_menu.begin();
     ASSERT_LT(hook_index, context_menu.size());
 
     EXPECT_CALL(app_, SelectTracepoint).Times(1).WillOnce([&](const TracepointInfo& tracepoint) {
       EXPECT_EQ(tracepoint.name(), kTracepointNames[0]);
     });
-    view_.OnContextMenu("Hook", static_cast<int>(hook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSelect}, static_cast<int>(hook_index), {0});
   }
 
   tracepoint_selected = true;
@@ -186,13 +190,14 @@ TEST_F(TracepointsDataViewTest, ContextMenuActionsAreInvoked) {
   // Unhook
   {
     const auto unhook_index =
-        std::find(context_menu.begin(), context_menu.end(), "Unhook") - context_menu.begin();
+        std::find(context_menu.begin(), context_menu.end(), kMenuActionUnselect) -
+        context_menu.begin();
     ASSERT_LT(unhook_index, context_menu.size());
 
     EXPECT_CALL(app_, DeselectTracepoint).Times(1).WillOnce([&](const TracepointInfo& tracepoint) {
       EXPECT_EQ(tracepoint.name(), kTracepointNames[0]);
     });
-    view_.OnContextMenu("Unhook", static_cast<int>(unhook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionUnselect}, static_cast<int>(unhook_index), {0});
   }
 }
 


### PR DESCRIPTION
We changed the data view tests to use the action names defined in
`DataView.h` instead of redefining them.

Bug: http://b/205676296