### PR TITLE
Update Qt to version 5.15.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(CRASHDUMP_SERVER "" CACHE STRING "Setting this option will enable uploading 
 set(CMAKE_CXX_STANDARD 17)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo_multi.cmake)
 conan_basic_setup(TARGETS)
@@ -100,11 +101,7 @@ if(WITH_GUI)
     COMPONENTS Core
                Network
                Test
-               Widgets
-               WebEngine
-               WebEngineWidgets
-               WebSockets
-               WebChannel)
+               Widgets)
   find_package(qtpropertybrowser REQUIRED)
 endif()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,9 +11,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
 from io import StringIO
-from contrib.python import conan_helpers
 from contrib.jupyter import build as build_python
-import csv
 
 
 class OrbitConan(ConanFile):
@@ -22,7 +20,7 @@ class OrbitConan(ConanFile):
     url = "https://github.com/pierricgimmig/orbitprofiler.git"
     description = "C/C++ Performance Profiler"
     settings = "os", "compiler", "build_type", "arch"
-    generators = ["cmake_multi"]
+    generators = ["cmake_multi", "cmake_find_package_multi"]
     options = {"system_qt": [True, False], "with_gui": [True, False],
                "debian_packaging": [True, False],
                "fPIC": [True, False],
@@ -98,15 +96,15 @@ class OrbitConan(ConanFile):
             self.requires("crashpad/20200624@{}".format(self._orbit_channel))
 
         if self.options.with_gui:
-            self.requires("freetype/2.10.0@bincrafters/stable#0", override=True)
+            self.requires("freetype/2.10.4", override=True)
             self.requires("freetype-gl/79b03d9@{}".format(self._orbit_channel))
             self.requires("glad/0.1.34")
             self.requires("imgui/1.85")
-            self.requires("libpng/1.6.37@bincrafters/stable#0", override=True)
+            self.requires("libpng/1.6.37", override=True)
             self.requires("libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf")
 
             if not self.options.system_qt:
-                self.requires("qt/5.15.1@{}#e659e981368e4baba1a201b75ddb89b6".format(self._orbit_channel))
+                self.requires("qt/5.15.2")
 
         if self.options.deploy_opengl_software_renderer:
             self.requires("llvmpipe/21.0.3@{}#fd5932d6a7fa5fb0af5045eb53c02d18".format(self._orbit_channel))
@@ -133,22 +131,14 @@ class OrbitConan(ConanFile):
         if self.options.with_gui:
 
             if not self.options.system_qt:
-                self.options["qt"].qtwebengine = True
-                self.options["qt"].qtwebchannel = True
-                self.options["qt"].qtwebsockets = True
                 self.options["qt"].shared = True
                 self.options["qt"].with_sqlite3 = False
                 self.options["qt"].with_mysql = False
                 self.options["qt"].with_pq = False
                 self.options["qt"].with_odbc = False
-                self.options["qt"].with_sdl2 = False
-                self.options["qt"].with_openal = False
 
                 if self.settings.os == "Windows":
                     self.options["qt"].qttools = True
-                    self.options["qt"].with_glib = False
-                    self.options["qt"].with_harfbuzz = False
-                    self.options["qt"].opengl = "dynamic"
 
 
     def build(self):
@@ -209,28 +199,6 @@ class OrbitConan(ConanFile):
         self.copy("LICENSE*", dst="licenses", folder=True, ignore_case=True, excludes=excludes)
         self.copy("LICENCE*", dst="licenses", folder=True, ignore_case=True, excludes=excludes)
 
-        if not self.options.system_qt:
-            chromium_licenses = conan_helpers.gather_chromium_licenses(self.deps_cpp_info["qt"].rootpath)
-            chromium_licenses.sort(key=lambda license_info: license_info["name"].lower())
-
-            with open(os.path.join(self.install_folder, "NOTICE.Chromium.csv"), "w") as fd:
-                writer = csv.DictWriter(fd, fieldnames=["name", "url", "license"], extrasaction='ignore')
-                writer.writeheader()
-
-                for license in chromium_licenses:
-                    writer.writerow(license)
-
-            with open(os.path.join(self.install_folder, "NOTICE.Chromium"), "w") as fd:
-                for license in chromium_licenses:
-                    fd.write("================================================================================\n")
-                    fd.write("Name: {}\n".format(license["name"]))
-                    fd.write("URL: {}\n\n".format(license.get("url", "")))
-                    fd.write(open(license["license file"], 'r').read())
-                    fd.write("\n\n")
-
-                fd.write("================================================================================\n")
-
-
 
     def package(self):
         if self.options.debian_packaging:
@@ -287,8 +255,6 @@ chmod -v 4775 /opt/developer/tools/OrbitService
         self.copy("crashpad_handler", src="bin/", dst="bin")
         self.copy("crashpad_handler.exe", src="bin/", dst="bin")
         self.copy("NOTICE")
-        self.copy("NOTICE.Chromium")
-        self.copy("NOTICE.Chromium.csv")
         self.copy("LICENSE")
         self.copy("liborbit.so", src="lib/", dst="lib")
         self.copy("liborbituserspaceinstrumentation.so", src="lib/", dst="lib")

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -16,14 +16,14 @@
      "15",
      "16",
      "17",
-     "21",
      "22",
-     "23"
+     "23",
+     "24"
     ],
     "build_requires": [
-     "45",
-     "47",
-     "48"
+     "44",
+     "46",
+     "47"
     ],
     "path": "../../../conanfile.py",
     "context": "host"
@@ -46,8 +46,8 @@
      "7"
     ],
     "build_requires": [
-     "42",
-     "44"
+     "41",
+     "43"
     ],
     "context": "host"
    },
@@ -128,16 +128,17 @@
     "context": "host"
    },
    "18": {
-    "ref": "freetype/2.10.0@bincrafters/stable#0",
+    "ref": "freetype/2.10.4#6e66ba2a68a458a4cbb60077e45ee139",
     "requires": [
      "19",
      "4",
-     "20"
+     "20",
+     "21"
     ],
     "context": "host"
    },
    "19": {
-    "ref": "libpng/1.6.37@bincrafters/stable#0",
+    "ref": "libpng/1.6.37#08b5607052686860a2e40d5db6166d9f",
     "requires": [
      "4"
     ],
@@ -148,10 +149,14 @@
     "context": "host"
    },
    "21": {
-    "ref": "imgui/1.85#ef38dd84c1c9e1c4467c579cc5aba6bb",
+    "ref": "brotli/1.0.9#802b2457f7a7a509ed80e7e45adf960e",
     "context": "host"
    },
    "22": {
+    "ref": "imgui/1.85#ef38dd84c1c9e1c4467c579cc5aba6bb",
+    "context": "host"
+   },
+   "23": {
     "ref": "libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf",
     "requires": [
      "4",
@@ -159,174 +164,160 @@
     ],
     "context": "host"
    },
-   "23": {
-    "ref": "qt/5.15.1@orbitdeps/stable#e659e981368e4baba1a201b75ddb89b6",
+   "24": {
+    "ref": "qt/5.15.2#6fb4ea910de20ce044744178b7850003",
     "requires": [
      "4",
      "5",
-     "24",
      "25",
-     "31",
+     "26",
      "18",
-     "32",
-     "35",
-     "36",
-     "37",
+     "27",
+     "30",
+     "31",
      "19",
-     "38",
-     "39",
+     "32",
      "33",
-     "40",
-     "41"
+     "39",
+     "40"
     ],
     "context": "host"
    },
-   "24": {
-    "ref": "pcre2/10.33#54adea8f4f46f14720b65849988c274a",
+   "25": {
+    "ref": "pcre2/10.37#6f33d06f647f7db2844a0368d68a833a",
     "requires": [
      "4",
      "20"
     ],
     "context": "host"
    },
-   "25": {
-    "ref": "glib/2.64.0@bincrafters/stable#0",
-    "requires": [
-     "4",
-     "26",
-     "27",
-     "28",
-     "29",
-     "30"
-    ],
-    "context": "host"
-   },
    "26": {
-    "ref": "libffi/3.2.1#778fb4699ab6f90aed4141fddd75ca83",
+    "ref": "double-conversion/3.1.5#bf7fceaa33f97d13a341039f49a5ec8f",
     "context": "host"
    },
    "27": {
-    "ref": "pcre/8.41#b1c67efc54f003e2c0d15593ef5ee473",
+    "ref": "fontconfig/2.13.93#c094d96506decf69d0796b0d141ced75",
     "requires": [
-     "20",
-     "4"
+     "18",
+     "28",
+     "29"
     ],
     "context": "host"
    },
    "28": {
-    "ref": "libelf/0.8.13#db17656a3054ad46af79109ce012e28f",
+    "ref": "expat/2.4.1#cc3f22c9f7aa18e98f5b0bcd396d9596",
     "context": "host"
    },
    "29": {
-    "ref": "libmount/2.33.1#5208204d4209a8619cda0879ab3f95f8",
-    "context": "host"
-   },
-   "30": {
-    "ref": "libselinux/2.9@bincrafters/stable#0",
-    "requires": [
-     "24"
-    ],
-    "context": "host"
-   },
-   "31": {
-    "ref": "double-conversion/3.1.5#bf7fceaa33f97d13a341039f49a5ec8f",
-    "context": "host"
-   },
-   "32": {
-    "ref": "fontconfig/2.13.91#f352b873e84bdb407e9d26f10c4d5ace",
-    "requires": [
-     "18",
-     "33",
-     "34"
-    ],
-    "context": "host"
-   },
-   "33": {
-    "ref": "expat/2.2.9#9f476bdcbd34f15324d82b9bdfed2e99",
-    "context": "host"
-   },
-   "34": {
     "ref": "libuuid/1.0.3#840ba593f58e204662dc518dc9158ea6",
     "context": "host"
    },
+   "30": {
+    "ref": "icu/69.1#ed524f4c3276db980bb7cdac12c5e6fc",
+    "context": "host"
+   },
+   "31": {
+    "ref": "libjpeg/9d#9c2c46fd74c85f5e6058e14abcf985e4",
+    "context": "host"
+   },
+   "32": {
+    "ref": "xorg/system#313b5d45c4669424c20daa86289e0d2e",
+    "context": "host"
+   },
+   "33": {
+    "ref": "xkbcommon/1.3.0#5a5e6118850a036f1a6166fdaf16d379",
+    "requires": [
+     "32",
+     "34",
+     "36",
+     "38"
+    ],
+    "context": "host"
+   },
+   "34": {
+    "ref": "libxml2/2.9.12#66e51d2b651de2a1f9511ca62f467534",
+    "requires": [
+     "4",
+     "35"
+    ],
+    "context": "host"
+   },
    "35": {
-    "ref": "icu/64.2#8e5b14365280b23e74c951a6415bbef8",
+    "ref": "libiconv/1.16#b902d00f68f77c3c4f8ac251204fe2ae",
     "context": "host"
    },
    "36": {
-    "ref": "harfbuzz/2.6.8#5733395ae2752d74034dccb6a94e9be8",
+    "ref": "wayland/1.19.0#570f56879233ec420697c699025237c3",
     "requires": [
-     "18"
+     "37",
+     "34",
+     "28"
     ],
     "context": "host"
    },
    "37": {
-    "ref": "libjpeg/9d#9c2c46fd74c85f5e6058e14abcf985e4",
+    "ref": "libffi/3.4.2#9636e48aae05a63a098d80c187f3fab1",
     "context": "host"
    },
    "38": {
-    "ref": "xorg/system#313b5d45c4669424c20daa86289e0d2e",
+    "ref": "wayland-protocols/1.21#d73abececa586cfdba0e2a4e0d9fa612",
     "context": "host"
    },
    "39": {
-    "ref": "zstd/1.4.4#914f28f51eabce8d0120a09a7627376d",
-    "context": "host"
-   },
-   "40": {
-    "ref": "opus/1.3.1#bb9e103e40877d9a8123672d4fd7ae8d",
-    "context": "host"
-   },
-   "41": {
     "ref": "opengl/system#e59f5699a39ea3b426a4194bccd77fe9",
     "context": "host"
    },
-   "42": {
+   "40": {
+    "ref": "zstd/1.5.0#2b656cd7dbf50bdce021cf2214838ede",
+    "context": "host"
+   },
+   "41": {
     "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
     "requires": [
-     "43"
+     "42"
     ],
     "context": "host"
    },
-   "43": {
+   "42": {
     "ref": "protobuf/3.9.1@bincrafters/stable#0",
     "context": "host"
    },
-   "44": {
+   "43": {
     "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
     "requires": [
      "1",
      "7",
      "5",
      "6",
-     "42",
+     "41",
      "4"
+    ],
+    "context": "host"
+   },
+   "44": {
+    "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
+    "requires": [
+     "45"
     ],
     "context": "host"
    },
    "45": {
-    "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
-    "requires": [
-     "46"
-    ],
-    "context": "host"
-   },
-   "46": {
     "ref": "protobuf/3.9.1@bincrafters/stable#0",
     "context": "host"
    },
-   "47": {
+   "46": {
     "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
     "requires": [
      "1",
      "7",
      "5",
      "6",
-     "45",
+     "44",
      "4"
     ],
     "context": "host"
    },
-   "48": {
+   "47": {
     "ref": "gtest/1.11.0#088aa58a3c2115519f99667eee50d0a1",
     "context": "host"
    }


### PR DESCRIPTION
This transitions from our custom Qt 5.15.1 recipe to the official Qt
5.15.2 recipe from Conan Center. That reduces the recipe maintenance
burden and also saves us from manually updating all the dependencies
away from the deprecated bincrafters packages.

With this change I also removed the QtWebEngine support because that
saves us a couple of hours in compilation time (per build). It's a lot
more efficient to just enable it again when we need it instead of
keeping it around.

I conducted some manual tests on Windows and haven't seen a problem.