### PR TITLE
Add DataView::OnExportToCsvRequested

### DIFF
--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -126,13 +126,13 @@ class DataView {
   virtual void LinkDataView(DataView* /*data_view*/) {}
   virtual bool ScrollToBottom() { return false; }
   virtual bool SkipTimer() { return false; }
-  virtual ErrorMessageOr<void> ExportCsv(const std::filesystem::path& file_path);
 
   int GetUpdatePeriodMs() const { return update_period_ms_; }
   [[nodiscard]] DataViewType GetType() const { return type_; }
   [[nodiscard]] virtual bool ResetOnRefresh() const { return true; }
 
   void OnCopySelectionRequested(const std::vector<int>& selection);
+  void OnExportToCsvRequested();
 
  protected:
   void InitSortingOrders();


### PR DESCRIPTION
We will define action behavior inside DataView.h, and name the action
method in the format of "On${action_name}Requested".

We refactor`DataView::ExportCsv` as `DataView::OnExportToCsvRequested`
in this change.

Bug: http://b/205676296