### PR TITLE
Add ExecuteInProcessWithMicrosoftCallingConvention

### DIFF
--- a/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
@@ -69,4 +69,39 @@ ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* library_handle,
                           param_5);
 }
 
+ErrorMessageOr<uint64_t> ExecuteInProcessWithMicrosoftCallingConvention(
+    pid_t pid, void* function_address, uint64_t param_0, uint64_t param_1, uint64_t param_2,
+    uint64_t param_3) {
+  // In the Microsoft x64 ABI, if the first four parameters are integer they go in RCX, RDX, R8, R9.
+  // See https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention#parameter-passing
+  // The return value is in RAX.
+  // See https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention#return-values
+  // movabsq rcx, param_0             48 b9 param_0
+  // movabsq rdx, param_1             48 ba param_1
+  // movabsq r8,  param_2             49 b8 param_2
+  // movabsq r9,  param_3             49 b9 param_3
+  // movabsq rax, function_address    48 b8 function_address
+  // call rax                         ff d0
+  // int3                             cc
+  MachineCode code;
+  code.AppendBytes({0x48, 0xb9})
+      .AppendImmediate64(param_0)
+      .AppendBytes({0x48, 0xba})
+      .AppendImmediate64(param_1)
+      .AppendBytes({0x49, 0xb8})
+      .AppendImmediate64(param_2)
+      .AppendBytes({0x49, 0xb9})
+      .AppendImmediate64(param_3)
+      .AppendBytes({0x48, 0xb8})
+      .AppendImmediate64(absl::bit_cast<uint64_t>(function_address))
+      .AppendBytes({0xff, 0xd0})
+      .AppendBytes({0xcc});
+
+  OUTCOME_TRY(auto&& memory, AutomaticMemoryInTracee::Create(pid, 0, kCodeScratchPadSize));
+
+  OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(*memory, code));
+
+  return return_value;
+}
+
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
@@ -25,55 +25,78 @@ namespace orbit_user_space_instrumentation {
 using orbit_test_utils::HasNoError;
 using orbit_test_utils::HasValue;
 
-TEST(ExecuteInProcessTest, ExecuteInProcess) {
-  pid_t pid = fork();
-  CHECK(pid != -1);
-  if (pid == 0) {
-    prctl(PR_SET_PDEATHSIG, SIGTERM);
+namespace {
 
-    volatile uint64_t counter = 0;
-    while (true) {
-      // Endless loops without side effects are UB and recent versions of clang optimize it away.
-      ++counter;
+class ExecuteInProcessTest : public testing::Test {
+ protected:
+  ExecuteInProcessTest() {
+    pid_ = fork();
+    CHECK(pid_ != -1);
+    if (pid_ == 0) {
+      prctl(PR_SET_PDEATHSIG, SIGTERM);
+
+      volatile uint64_t counter = 0;
+      while (true) {
+        // Endless loops without side effects are UB and recent versions of clang optimize it away.
+        ++counter;
+      }
     }
+
+    CHECK(!AttachAndStopProcess(pid_).has_error());
+
+    auto library_path_or_error = GetTestLibLibraryPath();
+    CHECK(library_path_or_error.has_value());
+    std::filesystem::path library_path = std::move(library_path_or_error.value());
+
+    // Load dynamic lib into tracee.
+    auto library_handle_or_error = DlopenInTracee(pid_, library_path, RTLD_NOW);
+    CHECK(library_handle_or_error.has_value());
+    library_handle_ = library_handle_or_error.value();
   }
 
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ~ExecuteInProcessTest() override {
+    // Cleanup, detach and end child.
+    CHECK(!DlcloseInTracee(pid_, library_handle_).has_error());
+    CHECK(!DetachAndContinueProcess(pid_).has_error());
+    kill(pid_, SIGKILL);
+    waitpid(pid_, nullptr, 0);
+  }
 
-  auto library_path_or_error = GetTestLibLibraryPath();
-  ASSERT_THAT(library_path_or_error, HasNoError());
-  std::filesystem::path library_path = std::move(library_path_or_error.value());
+  pid_t pid_ = 0;
+  void* library_handle_ = nullptr;
+};
 
-  // Load dynamic lib into tracee.
-  auto library_handle_or_error = DlopenInTracee(pid, library_path, RTLD_NOW);
-  CHECK(library_handle_or_error.has_value());
-  void* library_handle = library_handle_or_error.value();
+}  // namespace
 
-  auto result_or_error = ExecuteInProcess(pid, library_handle, "TrivialFunction");
+TEST_F(ExecuteInProcessTest, ExecuteInProcess) {
+  auto result_or_error = ExecuteInProcess(pid_, library_handle_, "TrivialFunction");
   ASSERT_THAT(result_or_error, HasNoError());
   EXPECT_EQ(42, result_or_error.value());
 
-  result_or_error = ExecuteInProcess(pid, library_handle, "TrivialSum", 2, 4, 6, 8, 10, 12);
+  result_or_error = ExecuteInProcess(pid_, library_handle_, "TrivialSum", 2, 4, 6, 8, 10, 12);
   ASSERT_THAT(result_or_error, HasNoError());
   EXPECT_EQ(42, result_or_error.value());
 
-  auto function_address_or_error = DlsymInTracee(pid, library_handle, "TrivialFunction");
+  auto function_address_or_error = DlsymInTracee(pid_, library_handle_, "TrivialFunction");
   ASSERT_THAT(result_or_error, HasValue());
-  result_or_error = ExecuteInProcess(pid, function_address_or_error.value());
+  result_or_error = ExecuteInProcess(pid_, function_address_or_error.value());
   ASSERT_THAT(result_or_error, HasValue());
   EXPECT_EQ(42, result_or_error.value());
 
-  function_address_or_error = DlsymInTracee(pid, library_handle, "TrivialSum");
+  function_address_or_error = DlsymInTracee(pid_, library_handle_, "TrivialSum");
   ASSERT_TRUE(function_address_or_error.has_value());
-  result_or_error = ExecuteInProcess(pid, function_address_or_error.value(), 2, 4, 6, 8, 10, 12);
+  result_or_error = ExecuteInProcess(pid_, function_address_or_error.value(), 2, 4, 6, 8, 10, 12);
   ASSERT_THAT(result_or_error, HasValue());
   EXPECT_EQ(42, result_or_error.value());
+}
 
-  // Cleanup, detach and end child.
-  CHECK(!DlcloseInTracee(pid, library_handle).has_error());
-  CHECK(!DetachAndContinueProcess(pid).has_error());
-  kill(pid, SIGKILL);
-  waitpid(pid, nullptr, 0);
+TEST_F(ExecuteInProcessTest, ExecuteInProcessWithMicrosoftCallingConvention) {
+  auto function_address_or_error = DlsymInTracee(pid_, library_handle_, "TrivialSumWithMsAbi");
+  ASSERT_TRUE(function_address_or_error.has_value());
+  auto result_or_error = ExecuteInProcessWithMicrosoftCallingConvention(
+      pid_, function_address_or_error.value(), 2, 4, 6, 8);
+  ASSERT_THAT(result_or_error, HasValue());
+  EXPECT_EQ(20, result_or_error.value());
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
@@ -49,18 +49,25 @@ ErrorMessageOr<uint64_t> ExecuteMachineCode(MemoryInTracee& code_memory, const M
 
   RegisterState registers_for_execution = original_registers;
   registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rip = code_memory.GetAddress();
-  // The calling convention for x64 assumes the 128 bytes below rsp to be usable as a scratch pad
-  // for the current function. This area is called the 'red zone'. The function we interrupted might
-  // have stored temporary data in the red zone and the function we are about to execute might do
-  // the same. To keep them separated we decrement rsp by 128 bytes.
-  // The calling convention also asks for rsp being to be aligned to 16 bytes so we additionally
-  // round down to the previous multiple of 16.
   const uint64_t old_rsp = original_registers.GetGeneralPurposeRegisters()->x86_64.rsp;
-  constexpr int kSizeRedZone = 128;
+  // The System V calling convention (Linux x64) assumes the 128 bytes below rsp to be usable as a
+  // scratch pad for the current function. This area is called the 'red zone'. The function we
+  // interrupted might have stored temporary data in the red zone. To keep the frame of the function
+  // we are about to execute separate, we decrement rsp by 128 bytes.
+  constexpr int kRedZoneSize = 128;
+  // We might also be executing a function with Microsoft x64 calling convention (e.g., under Wine).
+  // There is no red zone in this calling convention, however we have the "shadow space", 32 bytes
+  // *before* the 8 bytes of the return address that are owned by the current function and can also
+  // be used as scratch space. This must not intersect with the red zone of the function we
+  // interrupted.
+  constexpr int kShadowSpaceSize = 32;
+  // The calling conventions on both Linux and Windows also ask for rsp to be aligned to 16 bytes,
+  // so we additionally round down to the previous multiple of 16.
   constexpr int kStackAlignment = 16;
-  const uint64_t aligned_rsp_below_red_zone =
-      ((old_rsp - kSizeRedZone) / kStackAlignment) * kStackAlignment;
-  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rsp = aligned_rsp_below_red_zone;
+  const uint64_t aligned_rsp_below_red_zone_and_shadow_space =
+      ((old_rsp - kRedZoneSize - kShadowSpaceSize) / kStackAlignment) * kStackAlignment;
+  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rsp =
+      aligned_rsp_below_red_zone_and_shadow_space;
   // In case we stopped the process in the middle of a syscall orig_rax holds the number of that
   // syscall. The kernel uses that to trigger the restart of the interrupted syscall. By setting
   // orig_rax to -1 we bypass this logic for the PTRACE_CONT below.

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
@@ -31,6 +31,10 @@ uint64_t TrivialSum(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p3, uint64_t
   return p0 + p1 + p2 + p3 + p4 + p5;
 }
 
+uint64_t TrivialSumWithMsAbi(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p3) {
+  return p0 + p1 + p2 + p3;
+}
+
 void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer) {
   // Verify that the return address and the stack pointer (location of the return address) are
   // coherent. If not, the tests that use trampolines that call this EntryPayload will not succeed.

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
@@ -17,6 +17,10 @@ extern "C" int TrivialFunction();
 extern "C" uint64_t TrivialSum(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p3, uint64_t p4,
                                uint64_t p5);
 
+// Also returns the sum of the parameters, but it uses the Microsoft x64 calling convention.
+extern "C" __attribute__((ms_abi)) uint64_t TrivialSumWithMsAbi(uint64_t p0, uint64_t p1,
+                                                                uint64_t p2, uint64_t p3);
+
 // Payload called on entry of an instrumented function. Needs to record the return address of the
 // function (in order to have it available in `ExitPayload`) and the stack pointer (i.e., the
 // address of the return address). `function_id` is the id of the instrumented function.

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/ExecuteInProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/ExecuteInProcess.h
@@ -32,6 +32,14 @@ namespace orbit_user_space_instrumentation {
                                                         uint64_t param_3 = 0, uint64_t param_4 = 0,
                                                         uint64_t param_5 = 0, uint64_t param_6 = 0);
 
+// Like ExecuteInProcess, but the function is assumed to have Microsoft x64 calling convention. This
+// can be used when the target process was built for Windows (e.g., it is running under Wine).
+// We only allow four parameters for now as the Microsoft x64 calling convention only passes four in
+// registers, and none of the functions that we are going to call accept more than four.
+[[nodiscard]] ErrorMessageOr<uint64_t> ExecuteInProcessWithMicrosoftCallingConvention(
+    pid_t pid, void* function_address, uint64_t param_1 = 0, uint64_t param_2 = 0,
+    uint64_t param_3 = 0, uint64_t param_4 = 0);
+
 }  // namespace orbit_user_space_instrumentation
 
 #endif  // USER_SPACE_INSTRUMENTATION_EXECUTE_IN_PROCESS_H_


### PR DESCRIPTION
Assign different registers compared to `ExecuteInProcess` and consider the
shadow space in `ExecuteMachineCode`.

Bug: http://b/193778733

Test: Unit test. Tried as part of prototype for Orbit API on Wine.