### PR TITLE
Add DataView::OnLoadSymbolsRequested

### DIFF
--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -140,18 +140,7 @@ std::vector<std::vector<std::string>> CallstackDataView::GetContextMenuWithGroup
 
 void CallstackDataView::OnContextMenu(const std::string& action, int menu_index,
                                       const std::vector<int>& item_indices) {
-  if (action == kMenuActionLoadSymbols) {
-    std::vector<ModuleData*> modules_to_load;
-    for (int i : item_indices) {
-      CallstackDataViewFrame frame = GetFrameFromRow(i);
-      ModuleData* module = frame.module;
-      if (module != nullptr && !module->is_loaded()) {
-        modules_to_load.push_back(module);
-      }
-    }
-    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
-
-  } else if (action == kMenuActionSelect) {
+  if (action == kMenuActionSelect) {
     for (int i : item_indices) {
       CallstackDataViewFrame frame = GetFrameFromRow(i);
       const FunctionInfo* function = frame.function;
@@ -264,12 +253,12 @@ bool CallstackDataView::GetDisplayColor(int row, int /*column*/, unsigned char& 
   return false;
 }
 
-CallstackDataView::CallstackDataViewFrame CallstackDataView::GetFrameFromRow(int row) {
+CallstackDataView::CallstackDataViewFrame CallstackDataView::GetFrameFromRow(int row) const {
   return GetFrameFromIndex(indices_[row]);
 }
 
 CallstackDataView::CallstackDataViewFrame CallstackDataView::GetFrameFromIndex(
-    int index_in_callstack) {
+    int index_in_callstack) const {
   CHECK(index_in_callstack < callstack_.frames_size());
   uint64_t address = callstack_.frames(index_in_callstack);
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -11,6 +11,8 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
 
+using orbit_client_data::ModuleData;
+
 namespace orbit_data_views {
 
 std::string FormatValueForCsv(std::string_view value) {
@@ -82,7 +84,9 @@ std::vector<std::vector<std::string>> DataView::GetContextMenuWithGrouping(
 
 void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,
                              const std::vector<int>& item_indices) {
-  if (action == kMenuActionExportToCsv) {
+  if (action == kMenuActionLoadSymbols) {
+    OnLoadSymbolsRequested(item_indices);
+  } else if (action == kMenuActionExportToCsv) {
     OnExportToCsvRequested();
   } else if (action == kMenuActionCopySelection) {
     OnCopySelectionRequested(item_indices);
@@ -97,6 +101,17 @@ std::vector<int> DataView::GetVisibleSelectedIndices() {
     }
   }
   return visible_selected_indices;
+}
+
+void DataView::OnLoadSymbolsRequested(const std::vector<int>& selection) {
+  std::vector<ModuleData*> modules_to_load;
+  for (int index : selection) {
+    ModuleData* module_data = GetModuleDataFromRow(index);
+    if (module_data != nullptr && !module_data->is_loaded()) {
+      modules_to_load.push_back(module_data);
+    }
+  }
+  app_->RetrieveModulesAndLoadSymbols(modules_to_load);
 }
 
 void DataView::OnExportToCsvRequested() {

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -113,7 +113,7 @@ std::vector<std::vector<std::string>> ModulesDataView::GetContextMenuWithGroupin
   bool enable_load = false;
   bool enable_verify = false;
   for (int index : selected_indices) {
-    const ModuleData* module = GetModule(index);
+    const ModuleData* module = GetModuleDataFromRow(index);
     if (!module->is_loaded()) {
       enable_load = true;
     }
@@ -138,21 +138,11 @@ std::vector<std::vector<std::string>> ModulesDataView::GetContextMenuWithGroupin
 
 void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
                                     const std::vector<int>& item_indices) {
-  if (action == kMenuActionLoadSymbols) {
-    std::vector<ModuleData*> modules_to_load;
-    for (int index : item_indices) {
-      ModuleData* module_data = GetModule(index);
-      if (!module_data->is_loaded()) {
-        modules_to_load.push_back(module_data);
-      }
-    }
-    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
-
-  } else if (action == kMenuActionVerifyFramePointers) {
+  if (action == kMenuActionVerifyFramePointers) {
     std::vector<const ModuleData*> modules_to_validate;
     modules_to_validate.reserve(item_indices.size());
     for (int index : item_indices) {
-      const ModuleData* module = GetModule(index);
+      const ModuleData* module = GetModuleDataFromRow(index);
       modules_to_validate.push_back(module);
     }
 
@@ -165,7 +155,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
 }
 
 void ModulesDataView::OnDoubleClicked(int index) {
-  ModuleData* module_data = GetModule(index);
+  ModuleData* module_data = GetModuleDataFromRow(index);
   if (!module_data->is_loaded()) {
     std::vector<ModuleData*> modules_to_load = {module_data};
     app_->RetrieveModulesAndLoadSymbols(modules_to_load);
@@ -236,7 +226,7 @@ void ModulesDataView::OnRefreshButtonClicked() {
 
 bool ModulesDataView::GetDisplayColor(int row, int /*column*/, unsigned char& red,
                                       unsigned char& green, unsigned char& blue) {
-  const ModuleData* module = GetModule(row);
+  const ModuleData* module = GetModuleDataFromRow(row);
   if (module->is_loaded()) {
     red = 42;
     green = 218;

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -265,10 +265,10 @@ TEST_F(SamplingReportDataViewTest, ColumnSelectedShowsRightResults) {
 
 TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
   EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
-  EXPECT_CALL(app_, GetModuleByPathAndBuildId)
+  EXPECT_CALL(app_, GetMutableModuleByPathAndBuildId)
       .WillRepeatedly(
-          [&](const std::string& module_path, const std::string& build_id) -> const ModuleData* {
-            return module_manager_.GetModuleByPathAndBuildId(module_path, build_id);
+          [&](const std::string& module_path, const std::string& build_id) -> ModuleData* {
+            return module_manager_.GetMutableModuleByPathAndBuildId(module_path, build_id);
           });
 
   bool capture_connected;
@@ -348,8 +348,8 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     CheckSingleAction(context_menu, kMenuActionSelect, select);
     CheckSingleAction(context_menu, kMenuActionUnselect, unselect);
 
-    // Find indices that SamplingReportDataView::GetModulePathsAndBuildIdsFromIndices can find
-    // matching module path and build id pair.
+    // Find indices that SamplingReportDataView::GetModulePathAndBuildIdFromRow can find matching
+    // module path and build id pair.
     std::vector<int> selected_indices_with_matching_module;
     for (int index : selected_indices) {
       // Sampled function 3's absolute address does not match any module
@@ -357,7 +357,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     }
 
     // Load symbols action is available if and only if: in all the module path and build id pairs
-    // returned by SamplingReportDataView::GetModulePathsAndBuildIdsFromIndices, there is one pair
+    // returned by SamplingReportDataView::GetModulePathAndBuildIdFromRow, there is one pair
     // corresponds to a module that is not loaded yet.
     ContextMenuEntry load_symbols = ContextMenuEntry::kDisabled;
     for (int index : selected_indices_with_matching_module) {
@@ -392,10 +392,10 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
   EXPECT_CALL(app_, IsCaptureConnected).WillRepeatedly(testing::Return(true));
   EXPECT_CALL(app_, IsFunctionSelected(testing::A<const orbit_client_protos::FunctionInfo&>()))
       .WillRepeatedly(testing::ReturnPointee(&function_selected));
-  EXPECT_CALL(app_, GetModuleByPathAndBuildId)
+  EXPECT_CALL(app_, GetMutableModuleByPathAndBuildId)
       .WillRepeatedly(
-          [&](const std::string& module_path, const std::string& build_id) -> const ModuleData* {
-            return module_manager_.GetModuleByPathAndBuildId(module_path, build_id);
+          [&](const std::string& module_path, const std::string& build_id) -> ModuleData* {
+            return module_manager_.GetMutableModuleByPathAndBuildId(module_path, build_id);
           });
 
   AddFunctionsByIndices({0});

--- a/src/DataViews/include/DataViews/CallstackDataView.h
+++ b/src/DataViews/include/DataViews/CallstackDataView.h
@@ -70,8 +70,8 @@ class CallstackDataView : public DataView {
     orbit_client_data::ModuleData* module;
   };
 
-  CallstackDataViewFrame GetFrameFromRow(int row);
-  CallstackDataViewFrame GetFrameFromIndex(int index_in_callstack);
+  CallstackDataViewFrame GetFrameFromRow(int row) const;
+  CallstackDataViewFrame GetFrameFromIndex(int index_in_callstack) const;
 
   enum ColumnIndex {
     kColumnSelected,
@@ -83,6 +83,10 @@ class CallstackDataView : public DataView {
   };
 
  private:
+  [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {
+    return GetFrameFromRow(row).module;
+  }
+
   absl::flat_hash_set<uint64_t> functions_to_highlight_;
 };
 

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "ClientData/ModuleData.h"
 #include "DataViews/AppInterface.h"
 #include "DataViews/DataViewType.h"
 #include "OrbitBase/Logging.h"
@@ -131,10 +132,15 @@ class DataView {
   [[nodiscard]] DataViewType GetType() const { return type_; }
   [[nodiscard]] virtual bool ResetOnRefresh() const { return true; }
 
+  void OnLoadSymbolsRequested(const std::vector<int>& selection);
   void OnCopySelectionRequested(const std::vector<int>& selection);
   void OnExportToCsvRequested();
 
  protected:
+  [[nodiscard]] virtual orbit_client_data::ModuleData* GetModuleDataFromRow(int /*row*/) const {
+    return nullptr;
+  }
+
   void InitSortingOrders();
   virtual void DoSort() {}
   virtual void DoFilter() {}

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -46,7 +46,7 @@ class ModulesDataView : public DataView {
   void DoFilter() override;
 
  private:
-  [[nodiscard]] orbit_client_data::ModuleData* GetModule(uint32_t row) const {
+  [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {
     return start_address_to_module_.at(indices_[row]);
   }
 
@@ -62,7 +62,6 @@ class ModulesDataView : public DataView {
     kColumnFileSize,  // Default sorting column
     kNumColumns
   };
-
 };
 
 }  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -55,10 +55,12 @@ class SamplingReportDataView : public DataView {
   orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row);
   absl::flat_hash_set<const orbit_client_protos::FunctionInfo*> GetFunctionsFromIndices(
       const std::vector<int>& indices);
-  [[nodiscard]] absl::flat_hash_set<std::pair<std::string, std::string>>
-  GetModulePathsAndBuildIdsFromIndices(const std::vector<int>& indices) const;
+  [[nodiscard]] std::optional<std::pair<std::string, std::string>> GetModulePathAndBuildIdFromRow(
+      int row) const;
 
  private:
+  [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override;
+
   void UpdateSelectedIndicesAndFunctionIds(const std::vector<int>& selected_indices);
   void RestoreSelectedIndicesAfterFunctionsChanged();
   // The callstack view will be updated according to the visible selected addresses and thread id.


### PR DESCRIPTION
We change all views to use the `OnLoadSymbolsRequested` defined in
`DataView`.
Each individual views just need to implement `GetModuleDataFromRow`
which is needed in `OnLoadSymbolsRequested`.

Bug: http://b/205676296