### PR TITLE
Add DataView::OnSelectRequested and OnUnselectRequested

### DIFF
--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -140,29 +140,7 @@ std::vector<std::vector<std::string>> CallstackDataView::GetContextMenuWithGroup
 
 void CallstackDataView::OnContextMenu(const std::string& action, int menu_index,
                                       const std::vector<int>& item_indices) {
-  if (action == kMenuActionSelect) {
-    for (int i : item_indices) {
-      CallstackDataViewFrame frame = GetFrameFromRow(i);
-      const FunctionInfo* function = frame.function;
-      // Only hook functions for which we have symbols loaded.
-      if (function != nullptr) {
-        app_->SelectFunction(*function);
-      }
-    }
-
-  } else if (action == kMenuActionUnselect) {
-    for (int i : item_indices) {
-      CallstackDataViewFrame frame = GetFrameFromRow(i);
-      const FunctionInfo* function = frame.function;
-      // If the frame belongs to a function for which no symbol is loaded 'function' is nullptr and
-      // we can skip it since it can't be instrumented.
-      if (function != nullptr) {
-        app_->DeselectFunction(*function);
-        app_->DisableFrameTrack(*function);
-      }
-    }
-
-  } else if (action == kMenuActionDisassembly) {
+  if (action == kMenuActionDisassembly) {
     const uint32_t pid = app_->GetCaptureData().process_id();
     for (int i : item_indices) {
       const FunctionInfo* function = GetFrameFromRow(i).function;

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -310,11 +310,10 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
     CheckSingleAction(context_menu, kMenuActionExportToCsv, ContextMenuEntry::kEnabled);
 
-    // Find indices that SamplingReportDataView::GetFunctionsFromIndices can find matching
-    // functions.
+    // Find indices that SamplingReportDataView::GetFunctionInfoFromRow can find matching functions.
     std::vector<int> selected_indices_with_matching_function;
     for (int index : selected_indices) {
-      // SamplingReportDataView::GetFunctionsFromIndices cannot find matching FunctionInfo for
+      // SamplingReportDataView::GetFunctionInfoFromRow cannot find matching FunctionInfo for
       // sampled function 2 & 3 as:
       // * sampled function 2's corresponding module is not loaded yet
       // * sampled function 3's absolute address does not match any module and function.
@@ -322,7 +321,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     }
 
     // Source code and disassembly actions are availble if and only if 1) capture is connected and
-    // 2) selected_functions = GetFunctionsFromIndices(selected_indices) is not empty.
+    // 2) exist an index that GetFunctionInfoFromRow can find matching function.
     ContextMenuEntry source_code_or_disassembly =
         capture_connected && !selected_indices_with_matching_function.empty()
             ? ContextMenuEntry::kEnabled
@@ -330,10 +329,10 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     CheckSingleAction(context_menu, kMenuActionSourceCode, source_code_or_disassembly);
     CheckSingleAction(context_menu, kMenuActionDisassembly, source_code_or_disassembly);
 
-    // Hook action is available if and only if 1) capture is connected and 2) selected_functions =
-    // GetFunctionsFromIndices(selected_indices) contains a unselected function.
-    // Unhook action is available if and only if 1) capture is connected and 2) selected_functions =
-    // GetFunctionsFromIndices(selected_indices) contains a selected function.
+    // Hook action is available if and only if 1) capture is connected and 2) exist an index so that
+    // the function returned by GetFunctionInfoFromRow(index) is selected.
+    // Unhook action is available if and only if 1) capture is connected and 2) exist an index so
+    // that the function returned by GetFunctionInfoFromRow(index) is selected.
     ContextMenuEntry select = ContextMenuEntry::kDisabled;
     ContextMenuEntry unselect = ContextMenuEntry::kDisabled;
     if (capture_connected) {

--- a/src/DataViews/TracepointsDataView.cpp
+++ b/src/DataViews/TracepointsDataView.cpp
@@ -122,18 +122,15 @@ std::vector<std::vector<std::string>> TracepointsDataView::GetContextMenuWithGro
   return menu;
 }
 
-void TracepointsDataView::OnContextMenu(const std::string& action, int menu_index,
-                                        const std::vector<int>& item_indices) {
-  if (action == kMenuActionSelect) {
-    for (int i : item_indices) {
-      app_->SelectTracepoint(GetTracepoint(i));
-    }
-  } else if (action == kMenuActionUnselect) {
-    for (int i : item_indices) {
-      app_->DeselectTracepoint(GetTracepoint(i));
-    }
-  } else {
-    DataView::OnContextMenu(action, menu_index, item_indices);
+void TracepointsDataView::OnSelectRequested(const std::vector<int>& selection) {
+  for (int i : selection) {
+    app_->SelectTracepoint(GetTracepoint(i));
+  }
+}
+
+void TracepointsDataView::OnUnselectRequested(const std::vector<int>& selection) {
+  for (int i : selection) {
+    app_->DeselectTracepoint(GetTracepoint(i));
   }
 }
 

--- a/src/DataViews/include/DataViews/CallstackDataView.h
+++ b/src/DataViews/include/DataViews/CallstackDataView.h
@@ -86,6 +86,9 @@ class CallstackDataView : public DataView {
   [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {
     return GetFrameFromRow(row).module;
   }
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetFunctionInfoFromRow(int row) override {
+    return GetFrameFromRow(row).function;
+  }
 
   absl::flat_hash_set<uint64_t> functions_to_highlight_;
 };

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -133,11 +133,17 @@ class DataView {
   [[nodiscard]] virtual bool ResetOnRefresh() const { return true; }
 
   void OnLoadSymbolsRequested(const std::vector<int>& selection);
+  void OnSelectRequested(const std::vector<int>& selection);
+  void OnUnselectRequested(const std::vector<int>& selection);
   void OnCopySelectionRequested(const std::vector<int>& selection);
   void OnExportToCsvRequested();
 
  protected:
   [[nodiscard]] virtual orbit_client_data::ModuleData* GetModuleDataFromRow(int /*row*/) const {
+    return nullptr;
+  }
+  [[nodiscard]] virtual const orbit_client_protos::FunctionInfo* GetFunctionInfoFromRow(
+      int /*row*/) {
     return nullptr;
   }
 

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -133,8 +133,8 @@ class DataView {
   [[nodiscard]] virtual bool ResetOnRefresh() const { return true; }
 
   void OnLoadSymbolsRequested(const std::vector<int>& selection);
-  void OnSelectRequested(const std::vector<int>& selection);
-  void OnUnselectRequested(const std::vector<int>& selection);
+  virtual void OnSelectRequested(const std::vector<int>& selection);
+  virtual void OnUnselectRequested(const std::vector<int>& selection);
   void OnCopySelectionRequested(const std::vector<int>& selection);
   void OnExportToCsvRequested();
 

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -39,9 +39,6 @@ class FunctionsDataView : public DataView {
  protected:
   void DoSort() override;
   void DoFilter() override;
-  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetFunction(int row) const {
-    return functions_[indices_[row]];
-  }
 
   std::vector<std::string> filter_tokens_;
 
@@ -55,6 +52,10 @@ class FunctionsDataView : public DataView {
   };
 
  private:
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetFunctionInfoFromRow(int row) override {
+    return functions_[indices_[row]];
+  }
+
   static bool ShouldShowSelectedFunctionIcon(AppInterface* app,
                                              const orbit_client_protos::FunctionInfo& function);
   static bool ShouldShowFrameTrackIcon(AppInterface* app,

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -58,8 +58,6 @@ class LiveFunctionsDataView : public DataView {
   void DoFilter() override;
   void DoSort() override;
   [[nodiscard]] uint64_t GetInstrumentedFunctionId(uint32_t row) const;
-  [[nodiscard]] const orbit_client_protos::FunctionInfo& GetInstrumentedFunction(
-      uint32_t row) const;
   [[nodiscard]] std::optional<orbit_client_protos::FunctionInfo>
   CreateFunctionInfoFromInstrumentedFunction(
       const orbit_grpc_protos::InstrumentedFunction& instrumented_function);
@@ -84,6 +82,8 @@ class LiveFunctionsDataView : public DataView {
   };
 
  private:
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetFunctionInfoFromRow(int row) override;
+
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 };
 

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -53,13 +53,12 @@ class SamplingReportDataView : public DataView {
   void DoFilter() override;
   const orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row) const;
   orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row);
-  absl::flat_hash_set<const orbit_client_protos::FunctionInfo*> GetFunctionsFromIndices(
-      const std::vector<int>& indices);
   [[nodiscard]] std::optional<std::pair<std::string, std::string>> GetModulePathAndBuildIdFromRow(
       int row) const;
 
  private:
   [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override;
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetFunctionInfoFromRow(int row) override;
 
   void UpdateSelectedIndicesAndFunctionIds(const std::vector<int>& selected_indices);
   void RestoreSelectedIndicesAfterFunctionsChanged();

--- a/src/DataViews/include/DataViews/TracepointsDataView.h
+++ b/src/DataViews/include/DataViews/TracepointsDataView.h
@@ -27,8 +27,8 @@ class TracepointsDataView : public DataView {
       int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
 
-  void OnContextMenu(const std::string& action, int menu_index,
-                     const std::vector<int>& item_indices) override;
+  void OnSelectRequested(const std::vector<int>& selection) override;
+  void OnUnselectRequested(const std::vector<int>& selection) override;
 
   void SetTracepoints(const std::vector<orbit_grpc_protos::TracepointInfo>& tracepoints);
 


### PR DESCRIPTION
We added `DataView::OnSelectRequested` and
`DataView::OnUnselectRequested` for the hooking function and unhooking
function actions.

Each individual views (including CallstacksDataView, FunctionsDataView,
LiveFunctionsDataView and SamplingReportDataView) need to implement the
`GetFunctionInfoFromRow` method which will be used in
`DataView::OnSelectRequested` and `DataView::OnUnselectRequested`.

We also override `TracepointDataView::OnSelectRequested` and
`TracepointDataView::OnUnselectRequested` for hooking and unhooking tracepoints.

Bug: http://b/205676296