### PR TITLE
Rename temporary Orbit.zip to OrbitUI.zip

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -238,7 +238,7 @@ if [ -n "$1" ]; then
     cp -v LICENSE Orbit/LICENSE.txt
     cp -av "${REPO_ROOT}/contrib/automation_tests" Orbit
     cp -v "${REPO_ROOT}/src/ApiInterface/include/ApiInterface/Orbit.h" Orbit/
-    zip -r Orbit.zip Orbit/
+    zip -r OrbitUI.zip Orbit/
     rm -rf Orbit/
     popd > /dev/null
   fi

--- a/kokoro/builds/collect.sh
+++ b/kokoro/builds/collect.sh
@@ -4,6 +4,5 @@ set -e
 # Trivial repackaging of the build artefacts: The collector gets integrated into Orbit.zip.
 cd "$KOKORO_GFILE_DIR"
 unzip Collector.zip
-unzip Orbit.zip
-rm Orbit.zip
+unzip OrbitUI.zip
 zip -r Orbit.zip Orbit/


### PR DESCRIPTION
Our CI system compiles collector and UI in separate jobs and combines
both artifacts into a single ZIP archive called Orbit.zip.

It can come to problems when both the resulting artifact of the UI
compilation job and of the combiner job are both called Orbit.zip.

This fixes the glitch by renaming the output filename of the UI
compilation job.