### PR TITLE
Add DataView::OnEnableFrameTrackRequested and OnDisableFrameTrackRequested

### DIFF
--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -91,6 +91,10 @@ void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,
     OnSelectRequested(item_indices);
   } else if (action == kMenuActionUnselect) {
     OnUnselectRequested(item_indices);
+  } else if (action == kMenuActionEnableFrameTrack) {
+    OnEnableFrameTrackRequested(item_indices);
+  } else if (action == kMenuActionDisableFrameTrack) {
+    OnDisableFrameTrackRequested(item_indices);
   } else if (action == kMenuActionExportToCsv) {
     OnExportToCsvRequested();
   } else if (action == kMenuActionCopySelection) {
@@ -143,6 +147,30 @@ void DataView::OnUnselectRequested(const std::vector<int>& selection) {
       app_->DisableFrameTrack(*function);
       app_->RemoveFrameTrack(*function);
     }
+  }
+}
+
+void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
+  for (int i : selection) {
+    const FunctionInfo& function = *GetFunctionInfoFromRow(i);
+    // Functions used as frame tracks must be hooked (selected), otherwise the
+    // data to produce the frame track will not be captured.
+    if (app_->IsCaptureConnected(app_->GetCaptureData())) {
+      app_->SelectFunction(function);
+    }
+    app_->EnableFrameTrack(function);
+    app_->AddFrameTrack(function);
+  }
+}
+
+void DataView::OnDisableFrameTrackRequested(const std::vector<int>& selection) {
+  for (int i : selection) {
+    const FunctionInfo& function = *GetFunctionInfoFromRow(i);
+    // When we remove a frame track, we do not unhook (deselect) the function as
+    // it may have been selected manually (not as part of adding a frame track).
+    // However, disable the frame track, so it is not recreated on the next capture.
+    app_->DisableFrameTrack(function);
+    app_->RemoveFrameTrack(function);
   }
 }
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -198,24 +198,7 @@ std::vector<std::vector<std::string>> FunctionsDataView::GetContextMenuWithGroup
 
 void FunctionsDataView::OnContextMenu(const std::string& action, int menu_index,
                                       const std::vector<int>& item_indices) {
-  if (action == kMenuActionEnableFrameTrack) {
-    for (int i : item_indices) {
-      const FunctionInfo& function = *GetFunctionInfoFromRow(i);
-      // Functions used as frame tracks must be hooked (selected), otherwise the
-      // data to produce the frame track will not be captured.
-      app_->SelectFunction(function);
-      app_->EnableFrameTrack(function);
-      app_->AddFrameTrack(function);
-    }
-  } else if (action == kMenuActionDisableFrameTrack) {
-    for (int i : item_indices) {
-      // When we remove a frame track, we do not unhook (deselect) the function as
-      // it may have been selected manually (not as part of adding a frame track).
-      // However, disable the frame track, so it is not recreated on the next capture.
-      app_->DisableFrameTrack(*GetFunctionInfoFromRow(i));
-      app_->RemoveFrameTrack(*GetFunctionInfoFromRow(i));
-    }
-  } else if (action == kMenuActionDisassembly) {
+  if (action == kMenuActionDisassembly) {
     for (int i : item_indices) {
       app_->Disassemble(app_->GetTargetProcess()->pid(), *GetFunctionInfoFromRow(i));
     }

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -577,9 +577,11 @@ TEST_F(FunctionsDataViewTest, ContextMenuActionsCallCorrespondingFunctionsInAppI
   EXPECT_CALL(app_, IsFrameTrackEnabled)
       .Times(testing::AnyNumber())
       .WillRepeatedly(testing::Return(false));
-  EXPECT_CALL(app_, HasCaptureData)
-      .Times(testing::AnyNumber())
-      .WillRepeatedly(testing::Return(false));
+
+  orbit_client_data::CaptureData capture_data{
+      nullptr, {}, std::nullopt, {}, CaptureData::DataSource::kLiveCapture};
+  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnPointee(&capture_data));
+  EXPECT_CALL(app_, IsCaptureConnected).WillRepeatedly(testing::Return(true));
 
   view_.AddFunctions({&functions_[0]});
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -368,20 +368,6 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
         metrics_uploader_->SendLogEvent(orbit_metrics_uploader::OrbitLogEvent::ORBIT_ITERATOR_ADD);
       }
     }
-  } else if (action == kMenuActionEnableFrameTrack) {
-    for (int i : item_indices) {
-      const FunctionInfo& function = *GetFunctionInfoFromRow(i);
-      if (app_->IsCaptureConnected(capture_data)) {
-        app_->SelectFunction(function);
-      }
-      app_->EnableFrameTrack(function);
-      app_->AddFrameTrack(GetInstrumentedFunctionId(i));
-    }
-  } else if (action == kMenuActionDisableFrameTrack) {
-    for (int i : item_indices) {
-      app_->DisableFrameTrack(*GetFunctionInfoFromRow(i));
-      app_->RemoveFrameTrack(GetInstrumentedFunctionId(i));
-    }
   } else if (action == kMenuActionExportEventsToCsv) {
     std::string save_file = app_->GetSaveFile(".csv");
     if (!save_file.empty()) {

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -572,9 +572,9 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
       EXPECT_EQ(function.name(), kNames[0]);
     });
     EXPECT_CALL(app_, EnableFrameTrack).Times(1);
-    EXPECT_CALL(app_, AddFrameTrack(testing::An<uint64_t>()))
+    EXPECT_CALL(app_, AddFrameTrack(testing::A<const orbit_client_protos::FunctionInfo&>()))
         .Times(1)
-        .WillOnce([&](uint64_t function_id) { EXPECT_EQ(function_id, kFunctionIds[0]); });
+        .WillOnce([&](const FunctionInfo& function) { EXPECT_EQ(function.name(), kNames[0]); });
     view_.OnContextMenu(std::string{kMenuActionEnableFrameTrack},
                         static_cast<int>(enable_frame_track_index), {0});
   }
@@ -612,9 +612,9 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, DisableFrameTrack).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kNames[0]);
     });
-    EXPECT_CALL(app_, RemoveFrameTrack(testing::An<uint64_t>()))
+    EXPECT_CALL(app_, RemoveFrameTrack(testing::An<const FunctionInfo&>()))
         .Times(1)
-        .WillOnce([&](uint64_t function_id) { EXPECT_EQ(function_id, kFunctionIds[0]); });
+        .WillOnce([&](const FunctionInfo& function) { EXPECT_EQ(function.name(), kNames[0]); });
     view_.OnContextMenu(std::string{kMenuActionDisableFrameTrack},
                         static_cast<int>(disable_frame_track_index), {0});
   }

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -135,6 +135,8 @@ class DataView {
   void OnLoadSymbolsRequested(const std::vector<int>& selection);
   virtual void OnSelectRequested(const std::vector<int>& selection);
   virtual void OnUnselectRequested(const std::vector<int>& selection);
+  void OnEnableFrameTrackRequested(const std::vector<int>& selection);
+  void OnDisableFrameTrackRequested(const std::vector<int>& selection);
   void OnCopySelectionRequested(const std::vector<int>& selection);
   void OnExportToCsvRequested();
 


### PR DESCRIPTION
We changed data views to use `DataView::OnEnableFrameTrackRequested` and
`DataView::OnDisableFrameTrackRequested` for adding and removing frame
tracks.

Bug: http://b/205676296