### PR TITLE
Revert "Update Qt to version 5.15.2 (#3130)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ set(CRASHDUMP_SERVER "" CACHE STRING "Setting this option will enable uploading 
 set(CMAKE_CXX_STANDARD 17)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo_multi.cmake)
 conan_basic_setup(TARGETS)
@@ -101,7 +100,11 @@ if(WITH_GUI)
     COMPONENTS Core
                Network
                Test
-               Widgets)
+               Widgets
+               WebEngine
+               WebEngineWidgets
+               WebSockets
+               WebChannel)
   find_package(qtpropertybrowser REQUIRED)
 endif()
 

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -16,14 +16,14 @@
      "15",
      "16",
      "17",
+     "21",
      "22",
-     "23",
-     "24"
+     "23"
     ],
     "build_requires": [
-     "44",
-     "46",
-     "47"
+     "45",
+     "47",
+     "48"
     ],
     "path": "../../../conanfile.py",
     "context": "host"
@@ -46,8 +46,8 @@
      "7"
     ],
     "build_requires": [
-     "41",
-     "43"
+     "42",
+     "44"
     ],
     "context": "host"
    },
@@ -128,17 +128,16 @@
     "context": "host"
    },
    "18": {
-    "ref": "freetype/2.10.4#6e66ba2a68a458a4cbb60077e45ee139",
+    "ref": "freetype/2.10.0@bincrafters/stable#0",
     "requires": [
      "19",
      "4",
-     "20",
-     "21"
+     "20"
     ],
     "context": "host"
    },
    "19": {
-    "ref": "libpng/1.6.37#08b5607052686860a2e40d5db6166d9f",
+    "ref": "libpng/1.6.37@bincrafters/stable#0",
     "requires": [
      "4"
     ],
@@ -149,14 +148,10 @@
     "context": "host"
    },
    "21": {
-    "ref": "brotli/1.0.9#802b2457f7a7a509ed80e7e45adf960e",
-    "context": "host"
-   },
-   "22": {
     "ref": "imgui/1.85#ef38dd84c1c9e1c4467c579cc5aba6bb",
     "context": "host"
    },
-   "23": {
+   "22": {
     "ref": "libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf",
     "requires": [
      "4",
@@ -164,160 +159,174 @@
     ],
     "context": "host"
    },
-   "24": {
-    "ref": "qt/5.15.2#6fb4ea910de20ce044744178b7850003",
+   "23": {
+    "ref": "qt/5.15.1@orbitdeps/stable#e659e981368e4baba1a201b75ddb89b6",
     "requires": [
      "4",
      "5",
+     "24",
      "25",
-     "26",
-     "18",
-     "27",
-     "30",
      "31",
-     "19",
+     "18",
      "32",
-     "33",
+     "35",
+     "36",
+     "37",
+     "19",
+     "38",
      "39",
-     "40"
+     "33",
+     "40",
+     "41"
     ],
     "context": "host"
    },
-   "25": {
-    "ref": "pcre2/10.37#6f33d06f647f7db2844a0368d68a833a",
+   "24": {
+    "ref": "pcre2/10.33#54adea8f4f46f14720b65849988c274a",
     "requires": [
      "4",
      "20"
     ],
     "context": "host"
    },
+   "25": {
+    "ref": "glib/2.64.0@bincrafters/stable#0",
+    "requires": [
+     "4",
+     "26",
+     "27",
+     "28",
+     "29",
+     "30"
+    ],
+    "context": "host"
+   },
    "26": {
-    "ref": "double-conversion/3.1.5#bf7fceaa33f97d13a341039f49a5ec8f",
+    "ref": "libffi/3.2.1#778fb4699ab6f90aed4141fddd75ca83",
     "context": "host"
    },
    "27": {
-    "ref": "fontconfig/2.13.93#c094d96506decf69d0796b0d141ced75",
+    "ref": "pcre/8.41#b1c67efc54f003e2c0d15593ef5ee473",
     "requires": [
-     "18",
-     "28",
-     "29"
+     "20",
+     "4"
     ],
     "context": "host"
    },
    "28": {
-    "ref": "expat/2.4.1#cc3f22c9f7aa18e98f5b0bcd396d9596",
+    "ref": "libelf/0.8.13#db17656a3054ad46af79109ce012e28f",
     "context": "host"
    },
    "29": {
-    "ref": "libuuid/1.0.3#840ba593f58e204662dc518dc9158ea6",
+    "ref": "libmount/2.33.1#5208204d4209a8619cda0879ab3f95f8",
     "context": "host"
    },
    "30": {
-    "ref": "icu/69.1#ed524f4c3276db980bb7cdac12c5e6fc",
+    "ref": "libselinux/2.9@bincrafters/stable#0",
+    "requires": [
+     "24"
+    ],
     "context": "host"
    },
    "31": {
-    "ref": "libjpeg/9d#9c2c46fd74c85f5e6058e14abcf985e4",
+    "ref": "double-conversion/3.1.5#bf7fceaa33f97d13a341039f49a5ec8f",
     "context": "host"
    },
    "32": {
-    "ref": "xorg/system#313b5d45c4669424c20daa86289e0d2e",
+    "ref": "fontconfig/2.13.91#f352b873e84bdb407e9d26f10c4d5ace",
+    "requires": [
+     "18",
+     "33",
+     "34"
+    ],
     "context": "host"
    },
    "33": {
-    "ref": "xkbcommon/1.3.0#5a5e6118850a036f1a6166fdaf16d379",
-    "requires": [
-     "32",
-     "34",
-     "36",
-     "38"
-    ],
+    "ref": "expat/2.2.9#9f476bdcbd34f15324d82b9bdfed2e99",
     "context": "host"
    },
    "34": {
-    "ref": "libxml2/2.9.12#66e51d2b651de2a1f9511ca62f467534",
-    "requires": [
-     "4",
-     "35"
-    ],
+    "ref": "libuuid/1.0.3#840ba593f58e204662dc518dc9158ea6",
     "context": "host"
    },
    "35": {
-    "ref": "libiconv/1.16#b902d00f68f77c3c4f8ac251204fe2ae",
+    "ref": "icu/64.2#8e5b14365280b23e74c951a6415bbef8",
     "context": "host"
    },
    "36": {
-    "ref": "wayland/1.19.0#570f56879233ec420697c699025237c3",
+    "ref": "harfbuzz/2.6.8#5733395ae2752d74034dccb6a94e9be8",
     "requires": [
-     "37",
-     "34",
-     "28"
+     "18"
     ],
     "context": "host"
    },
    "37": {
-    "ref": "libffi/3.4.2#9636e48aae05a63a098d80c187f3fab1",
+    "ref": "libjpeg/9d#9c2c46fd74c85f5e6058e14abcf985e4",
     "context": "host"
    },
    "38": {
-    "ref": "wayland-protocols/1.21#d73abececa586cfdba0e2a4e0d9fa612",
+    "ref": "xorg/system#313b5d45c4669424c20daa86289e0d2e",
     "context": "host"
    },
    "39": {
-    "ref": "opengl/system#e59f5699a39ea3b426a4194bccd77fe9",
+    "ref": "zstd/1.4.4#914f28f51eabce8d0120a09a7627376d",
     "context": "host"
    },
    "40": {
-    "ref": "zstd/1.5.0#2b656cd7dbf50bdce021cf2214838ede",
+    "ref": "opus/1.3.1#bb9e103e40877d9a8123672d4fd7ae8d",
     "context": "host"
    },
    "41": {
-    "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
-    "requires": [
-     "42"
-    ],
+    "ref": "opengl/system#e59f5699a39ea3b426a4194bccd77fe9",
     "context": "host"
    },
    "42": {
-    "ref": "protobuf/3.9.1@bincrafters/stable#0",
+    "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
+    "requires": [
+     "43"
+    ],
     "context": "host"
    },
    "43": {
+    "ref": "protobuf/3.9.1@bincrafters/stable#0",
+    "context": "host"
+   },
+   "44": {
     "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
     "requires": [
      "1",
      "7",
      "5",
      "6",
-     "41",
+     "42",
      "4"
-    ],
-    "context": "host"
-   },
-   "44": {
-    "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
-    "requires": [
-     "45"
     ],
     "context": "host"
    },
    "45": {
-    "ref": "protobuf/3.9.1@bincrafters/stable#0",
+    "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
+    "requires": [
+     "46"
+    ],
     "context": "host"
    },
    "46": {
+    "ref": "protobuf/3.9.1@bincrafters/stable#0",
+    "context": "host"
+   },
+   "47": {
     "ref": "grpc_codegen/1.27.3@orbitdeps/stable#a0b442cf66941a590b619c88b106f0e5",
     "requires": [
      "1",
      "7",
      "5",
      "6",
-     "44",
+     "45",
      "4"
     ],
     "context": "host"
    },
-   "47": {
+   "48": {
     "ref": "gtest/1.11.0#088aa58a3c2115519f99667eee50d0a1",
     "context": "host"
    }


### PR DESCRIPTION
This reverts commit cb9d5e7e0ad9eb649c65889f805e2718c2bf179e.

The new Qt package doesn't package PDB files and we need them for the
crash server. So let's revert this until we find a solution to the
problem.