### PR TITLE
Extend E2E test to also load latest capture

### DIFF
--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -226,7 +226,8 @@ def wait_for_condition(any_callable: Callable,
             else:
                 pass
         time.sleep(interval)
-    raise OrbitE2EError('Wait time exceeded')
+    if raise_exceptions:
+        raise OrbitE2EError('Wait time exceeded')
 
 
 def find_control(parent: BaseWrapper,

--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -226,8 +226,7 @@ def wait_for_condition(any_callable: Callable,
             else:
                 pass
         time.sleep(interval)
-    if raise_exceptions:
-        raise OrbitE2EError('Wait time exceeded')
+    raise OrbitE2EError('Wait time exceeded')
 
 
 def find_control(parent: BaseWrapper,

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -90,7 +90,7 @@ class LoadLatestCapture(E2ETestCase):
     It raises an exception if no capture was found at all.
     """
 
-    def _execute(self, filter_strings: str or List[str] or Iterable[str]):
+    def _execute(self, filter_strings: str or Iterable[str]):
         if isinstance(filter_strings, str):
             filter_strings = [filter_strings]
         connect_radio = self.find_control('RadioButton', 'LoadCapture')
@@ -102,8 +102,9 @@ class LoadLatestCapture(E2ETestCase):
             filter_capture_files.set_edit_text(filter_string)
 
             capture_file_list = self.find_control('Table', 'CaptureFileList')
-            wait_for_condition(lambda: capture_file_list.item_count() > 0, 30, raise_exceptions=False)
-            if capture_file_list.item_count() == 0:
+            try:
+                wait_for_condition(lambda: capture_file_list.item_count() > 0, 30)
+            except OrbitE2EError:
                 continue
             succeeded = True
             capture_file_list.children(control_type='DataItem')[0].double_click_input()

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -7,11 +7,11 @@ found in the LICENSE file.
 import logging
 import os
 
-import pywinauto
+from typing import List, Iterable
 from pywinauto.application import Application
 from pywinauto.keyboard import send_keys
 
-from core.orbit_e2e import E2ETestCase, wait_for_condition
+from core.orbit_e2e import E2ETestCase, OrbitE2EError, wait_for_condition
 
 
 def _wait_for_main_window(application: Application):
@@ -79,6 +79,43 @@ class LoadCapture(E2ETestCase):
             self.find_control('Window', 'Error while loading capture')
             ok_button = self.find_control('Button', 'OK')
             ok_button.click_input()
+
+
+class LoadLatestCapture(E2ETestCase):
+    """
+    Opens the most recent capture that matches the first given `filter_strings`. The filter strings get processed in
+    order, and the next filter string is used if no capture was found for a particular string. Also it waits until the
+    capture is loaded.
+
+    It raises an exception if no capture was found at all.
+    """
+
+    def _execute(self, filter_strings: str or List[str] or Iterable[str]):
+        if isinstance(filter_strings, str):
+            filter_strings = [filter_strings]
+        connect_radio = self.find_control('RadioButton', 'LoadCapture')
+        connect_radio.click_input()
+
+        filter_capture_files = self.find_control('Edit', 'FilterCaptureFiles')
+        succeeded = False
+        for filter_string in filter_strings:
+            filter_capture_files.set_edit_text(filter_string)
+
+            capture_file_list = self.find_control('Table', 'CaptureFileList')
+            wait_for_condition(lambda: capture_file_list.item_count() > 0, 30, raise_exceptions=False)
+            if capture_file_list.item_count() == 0:
+                continue
+            succeeded = True
+            capture_file_list.children(control_type='DataItem')[0].double_click_input()
+
+            # Unless the file does not exist, Orbit's main window will open and contain the "Loading capture" dialog.
+            _wait_for_main_window(self.suite.application)
+            # As there is a new top window (Orbit main window), we need to update the top window.
+            self.suite.top_window(force_update=True)
+            break
+
+        if not succeeded:
+            raise OrbitE2EError(f'Did not find any capture in filter strings: "{filter_strings}"')
 
 
 class ConnectToStadiaInstance(E2ETestCase):


### PR DESCRIPTION
This adds additional steps to the capture loading E2E test, that verify
taking a capture automatically saves a capture and that this capture
shows up in the list of latest captures.

To do so, the test takes a capture of hello_ggp and afterwards filters
in the recent captures list for the target name and the current date.
And loads the most recent match.

Note, as in theory the test could be run arround midnight, and the
capture might get actually taken on the next day, the test also checks
for captures on the next day (if non is found for today).

Test: Start hello_ggp and run the E2E test locally.
Bug: http://b/192222100