### PR TITLE
Update to orbit_api_start_async_v1 (and orbit_api_v2)

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define ORBIT_API_INTERNAL_IMPL
 #include "ApiInterface/Orbit.h"
 
 #include <absl/base/casts.h>
@@ -40,21 +39,29 @@ void orbit_api_start_v1(const char* name, orbit_api_color color, uint64_t group_
   EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, group_id, caller_address);
 }
 
-void orbit_api_start(const char* name, orbit_api_color color) {
+[[deprecated]] void orbit_api_start(const char* name, orbit_api_color color) {
   uint64_t return_address = ORBIT_GET_CALLER_PC();
   EnqueueApiEvent<orbit_api::ApiScopeStart>(name, color, kOrbitDefaultGroupId, return_address);
 }
 
 void orbit_api_stop() { EnqueueApiEvent<orbit_api::ApiScopeStop>(); }
 
-void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
+void orbit_api_start_async_v1(const char* name, uint64_t id, orbit_api_color color,
+                              uint64_t caller_address) {
+  if (caller_address == kOrbitCallerAddressAuto) {
+    caller_address = ORBIT_GET_CALLER_PC();
+  }
+  EnqueueApiEvent<orbit_api::ApiScopeStartAsync>(name, id, color, caller_address);
+}
+
+[[deprecated]] void orbit_api_start_async(const char* name, uint64_t id, orbit_api_color color) {
   uint64_t return_address = ORBIT_GET_CALLER_PC();
   EnqueueApiEvent<orbit_api::ApiScopeStartAsync>(name, id, color, return_address);
 }
 
 void orbit_api_stop_async(uint64_t id) { EnqueueApiEvent<orbit_api::ApiScopeStopAsync>(id); }
 
-void orbit_api_track_int(const char* name, int value, orbit_api_color color) {
+void orbit_api_track_int(const char* name, int32_t value, orbit_api_color color) {
   EnqueueApiEvent<orbit_api::ApiTrackInt>(name, value, color);
 }
 
@@ -137,6 +144,20 @@ void orbit_api_initialize_v1(orbit_api_v1* api) {
   api->track_double = &orbit_api_track_double;
 }
 
+void orbit_api_initialize_v2(orbit_api_v2* api) {
+  api->start = &orbit_api_start_v1;
+  api->stop = &orbit_api_stop;
+  api->start_async = &orbit_api_start_async_v1;
+  api->stop_async = &orbit_api_stop_async;
+  api->async_string = &orbit_api_async_string;
+  api->track_int = &orbit_api_track_int;
+  api->track_int64 = &orbit_api_track_int64;
+  api->track_uint = &orbit_api_track_uint;
+  api->track_uint64 = &orbit_api_track_uint64;
+  api->track_float = &orbit_api_track_float;
+  api->track_double = &orbit_api_track_double;
+}
+
 }  // namespace
 
 extern "C" {
@@ -162,6 +183,10 @@ void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled)
     case 1: {
       auto* api_v1 = absl::bit_cast<orbit_api_v1*>(address);
       orbit_api_initialize_and_set_enabled(api_v1, &orbit_api_initialize_v1, enabled);
+    } break;
+    case 2: {
+      auto* api_v2 = absl::bit_cast<orbit_api_v2*>(address);
+      orbit_api_initialize_and_set_enabled(api_v2, &orbit_api_initialize_v2, enabled);
     } break;
     default:
       UNREACHABLE();

--- a/src/Api/OrbitApiVersions.h
+++ b/src/Api/OrbitApiVersions.h
@@ -2,19 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_API_ORBIT_V0_H_
-#define ORBIT_API_ORBIT_V0_H_
+#ifndef ORBIT_API_ORBIT_API_VERSIONS_H_
+#define ORBIT_API_ORBIT_API_VERSIONS_H_
 
-#include <stdbool.h>
 #include <stdint.h>
-
-// =================================================================================================
-// Orbit Manual Instrumentation API.
-// =================================================================================================
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 struct orbit_api_v0 {
   uint32_t enabled;
@@ -32,9 +23,21 @@ struct orbit_api_v0 {
   void (*track_double)(const char* name, double value, orbit_api_color color);
 };
 
-#ifdef __cplusplus
-}  // extern "C"
+struct orbit_api_v1 {
+  uint32_t enabled;
+  uint32_t initialized;
+  void (*start)(const char* name, orbit_api_color color, uint64_t group_id,
+                uint64_t caller_address);
+  void (*stop)();
+  void (*start_async)(const char* name, uint64_t id, orbit_api_color color);
+  void (*stop_async)(uint64_t id);
+  void (*async_string)(const char* str, uint64_t id, orbit_api_color color);
+  void (*track_int)(const char* name, int value, orbit_api_color color);
+  void (*track_int64)(const char* name, int64_t value, orbit_api_color color);
+  void (*track_uint)(const char* name, uint32_t value, orbit_api_color color);
+  void (*track_uint64)(const char* name, uint64_t value, orbit_api_color color);
+  void (*track_float)(const char* name, float value, orbit_api_color color);
+  void (*track_double)(const char* name, double value, orbit_api_color color);
+};
 
-#endif  // __cplusplus
-
-#endif  // ORBIT_API_ORBIT_V0_H_
+#endif  // ORBIT_API_ORBIT_API_VERSIONS_H_

--- a/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.cpp
@@ -22,9 +22,9 @@
 // This executable is used by LinuxTracingIntegrationTest to test the generation of specific
 // perf_event_open events. The behavior is controlled by commands sent on standard input.
 
-// Hack: Don't use ORBIT_API_INSTANTIATE as it would redefine `struct orbit_api_v1 g_orbit_api_v1`,
+// Hack: Don't use ORBIT_API_INSTANTIATE as it would redefine `struct orbit_api_v2 g_orbit_api_v2`,
 // which is already defined by the Introspection target.
-void* orbit_api_get_function_table_address_v1() { return &g_orbit_api_v1; }
+void* orbit_api_get_function_table_address_v2() { return &g_orbit_api_v2; }
 
 namespace orbit_linux_tracing_integration_tests {
 

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -127,7 +127,7 @@ static void ExecuteTask(uint32_t id) {
 void OrbitTestImpl::OutputOrbitApiState() {
   while (!exit_requested_) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-    LOG("g_orbit_api_v1.enabled = %u", g_orbit_api_v1.enabled);
+    LOG("g_orbit_api_v2.enabled = %u", g_orbit_api_v2.enabled);
   }
 }
 


### PR DESCRIPTION
This brings `orbit_api_start_async` in line with `orbit_api_start_v1`, where we
can distinguish between the program counter being passed from the outside or it
being retrieved as the function's caller (when `kOrbitCallerAddressAuto` is
passed).

There are no changes in how `Orbit.h` and its macros are used.

This will make things a bit cleaner in the implementation of Orbit API for Wine,
where functions for one platform forward calls to functions for the other
platform.
But consistency with `orbit_api_start_v1` is also a desired effect.

The version numbers of `struct orbit_api_v#` and of the individual functions are
kept independent. Viceversa, names of all functions would have to be changed for
every version bump of `struct orbit_api_v#`. A similar example is LibGGP.

Test: Tested that OrbitTest compiled with `orbit_api_v1` still produces correct
data, in particular regarding async scopes. Tested that OrbitTest with the new
version produces correct data. Also tested as part of the prototype for Orbit
API on Wine.