### PR TITLE
Remove active waiting from the CopyFileToLocal routine

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -303,7 +303,7 @@ class OrbitApp final : public DataViewFactory,
     clipboard_callback_ = std::move(callback);
   }
   using SecureCopyCallback =
-      std::function<ErrorMessageOr<void>(std::string_view, std::string_view)>;
+      std::function<orbit_base::Future<ErrorMessageOr<void>>(std::string_view, std::string_view)>;
   void SetSecureCopyCallback(SecureCopyCallback callback) {
     secure_copy_callback_ = std::move(callback);
   }

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -300,20 +300,18 @@ outcome::result<void> ServiceDeployManager::CopyOrbitServicePackage() {
   return outcome::success();
 }
 
-ErrorMessageOr<void> ServiceDeployManager::CopyFileToLocal(std::string source,
-                                                           std::string destination) {
+orbit_base::Future<ErrorMessageOr<void>> ServiceDeployManager::CopyFileToLocal(
+    std::string source, std::string destination) {
   orbit_base::Promise<ErrorMessageOr<void>> promise;
   auto future = promise.GetFuture();
 
-  DeferToBackgroundThreadAndWait(
-      this, [this, source = std::move(source), destination = std::move(destination),
-             promise = std::move(promise)]() mutable {
-        promise.SetResult(CopyFileToLocalImpl(source, destination));
-      });
+  QMetaObject::invokeMethod(this,
+                            [this, source = std::move(source), destination = std::move(destination),
+                             promise = std::move(promise)]() mutable {
+                              promise.SetResult(CopyFileToLocalImpl(source, destination));
+                            });
 
-  if (!future.IsFinished()) return ErrorMessage{"Copy operation was aborted."};
-
-  return future.Get();
+  return future;
 }
 
 ErrorMessageOr<void> ServiceDeployManager::CopyFileToLocalImpl(std::string_view source,

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -20,6 +20,7 @@
 
 #include "DeploymentConfigurations.h"
 #include "MetricsUploader/MetricsUploader.h"
+#include "OrbitBase/Future.h"
 #include "OrbitBase/Result.h"
 #include "OrbitSsh/Context.h"
 #include "OrbitSsh/Credentials.h"
@@ -49,7 +50,8 @@ class ServiceDeployManager : public QObject {
       orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
 
   // This method copies remote source file to local destination.
-  ErrorMessageOr<void> CopyFileToLocal(std::string source, std::string destination);
+  orbit_base::Future<ErrorMessageOr<void>> CopyFileToLocal(std::string source,
+                                                           std::string destination);
 
   void Shutdown();
   void Cancel();


### PR DESCRIPTION
Active waiting means the waiting function will not end but rather
execute other waiting events on the event loop.

But this will increase the stack size with every actively waiting
function and eventually leads to a stack overflow.

So this commit removes active waiting and instead returns a future. That
means the caller needs to take care of waiting. In this case waiting is
actually not needed and the caller will just chain up a couple of
futures and be done.

Bug: http://b/209461845
Test: Tested manually on Windows. Also checked the callstacks with the debugger.