### PR TITLE
Rename g_orbit_api_v# to simply g_orbit_api

### DIFF
--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -38,7 +38,7 @@
 // To integrate the manual instrumentation API in your code base, simply include this header file
 // and place the ORBIT_API_INSTANTIATE macro in an implementation file. Orbit will automatically
 // deploy and dynamically load liborbit.so into the target process. Orbit will then write the proper
-// function addresses into the "g_orbit_api_v<N>" table.
+// function addresses into the "g_orbit_api" table.
 //
 // NOTE: To enable manual instrumentation, please make sure that:
 //       1. The "Enable Orbit Api in target" checkbox is ticked in the "Capture Options" dialog.
@@ -356,13 +356,13 @@ struct orbit_api_v2 {
   void (*track_double)(const char* name, double value, orbit_api_color color);
 };
 
-extern struct orbit_api_v2 g_orbit_api_v2;
+extern struct orbit_api_v2 g_orbit_api;
 extern ORBIT_EXPORT void* orbit_api_get_function_table_address_v2();
 
 // User needs to place "ORBIT_API_INSTANTIATE" in an implementation file.
-#define ORBIT_API_INSTANTIATE         \
-  struct orbit_api_v2 g_orbit_api_v2; \
-  void* orbit_api_get_function_table_address_v2() { return &g_orbit_api_v2; }
+#define ORBIT_API_INSTANTIATE      \
+  struct orbit_api_v2 g_orbit_api; \
+  void* orbit_api_get_function_table_address_v2() { return &g_orbit_api; }
 
 #ifndef __cplusplus
 // In C, `inline` alone doesn't generate an out-of-line definition, causing a linker error if the
@@ -371,15 +371,14 @@ static
 #endif
     inline bool
     orbit_api_active() {
-  bool initialized = g_orbit_api_v2.initialized;
+  bool initialized = g_orbit_api.initialized;
   ORBIT_THREAD_FENCE_ACQUIRE();
-  return initialized && g_orbit_api_v2.enabled;
+  return initialized && g_orbit_api.enabled;
 }
 
-#define ORBIT_CALL(function_name, ...)                      \
-  do {                                                      \
-    if (orbit_api_active() && g_orbit_api_v2.function_name) \
-      g_orbit_api_v2.function_name(__VA_ARGS__);            \
+#define ORBIT_CALL(function_name, ...)                                                           \
+  do {                                                                                           \
+    if (orbit_api_active() && g_orbit_api.function_name) g_orbit_api.function_name(__VA_ARGS__); \
   } while (0)
 
 #ifdef __cplusplus

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -27,8 +27,9 @@ ABSL_CONST_INIT static absl::Mutex global_introspection_mutex(absl::kConstInit);
 ABSL_CONST_INIT static IntrospectionListener* global_introspection_listener
     ABSL_GUARDED_BY(global_introspection_mutex) = nullptr;
 
-// Tracing uses the same function table used by the Orbit API, but specifies its own functions.
-orbit_api_v2 g_orbit_api_v2;
+// Introspection uses the same function table used by the Orbit API, but specifies its own
+// functions.
+orbit_api_v2 g_orbit_api;
 
 namespace orbit_introspection {
 
@@ -198,21 +199,21 @@ void orbit_api_track_double(const char* name, double value, orbit_api_color colo
 namespace orbit_introspection {
 
 void InitializeIntrospection() {
-  if (g_orbit_api_v2.initialized != 0) return;
-  g_orbit_api_v2.start = &orbit_api_start_v1;
-  g_orbit_api_v2.stop = &orbit_api_stop;
-  g_orbit_api_v2.start_async = &orbit_api_start_async_v1;
-  g_orbit_api_v2.stop_async = &orbit_api_stop_async;
-  g_orbit_api_v2.async_string = &orbit_api_async_string;
-  g_orbit_api_v2.track_int = &orbit_api_track_int;
-  g_orbit_api_v2.track_int64 = &orbit_api_track_int64;
-  g_orbit_api_v2.track_uint = &orbit_api_track_uint;
-  g_orbit_api_v2.track_uint64 = &orbit_api_track_uint64;
-  g_orbit_api_v2.track_float = &orbit_api_track_float;
-  g_orbit_api_v2.track_double = &orbit_api_track_double;
+  if (g_orbit_api.initialized != 0) return;
+  g_orbit_api.start = &orbit_api_start_v1;
+  g_orbit_api.stop = &orbit_api_stop;
+  g_orbit_api.start_async = &orbit_api_start_async_v1;
+  g_orbit_api.stop_async = &orbit_api_stop_async;
+  g_orbit_api.async_string = &orbit_api_async_string;
+  g_orbit_api.track_int = &orbit_api_track_int;
+  g_orbit_api.track_int64 = &orbit_api_track_int64;
+  g_orbit_api.track_uint = &orbit_api_track_uint;
+  g_orbit_api.track_uint64 = &orbit_api_track_uint64;
+  g_orbit_api.track_float = &orbit_api_track_float;
+  g_orbit_api.track_double = &orbit_api_track_double;
   std::atomic_thread_fence(std::memory_order_release);
-  g_orbit_api_v2.initialized = 1;
-  g_orbit_api_v2.enabled = 1;
+  g_orbit_api.initialized = 1;
+  g_orbit_api.enabled = 1;
 }
 
 }  // namespace orbit_introspection

--- a/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.cpp
@@ -22,9 +22,9 @@
 // This executable is used by LinuxTracingIntegrationTest to test the generation of specific
 // perf_event_open events. The behavior is controlled by commands sent on standard input.
 
-// Hack: Don't use ORBIT_API_INSTANTIATE as it would redefine `struct orbit_api_v2 g_orbit_api_v2`,
+// Hack: Don't use ORBIT_API_INSTANTIATE as it would redefine `struct orbit_api_v2 g_orbit_api`,
 // which is already defined by the Introspection target.
-void* orbit_api_get_function_table_address_v2() { return &g_orbit_api_v2; }
+void* orbit_api_get_function_table_address_v2() { return &g_orbit_api; }
 
 namespace orbit_linux_tracing_integration_tests {
 

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -127,7 +127,7 @@ static void ExecuteTask(uint32_t id) {
 void OrbitTestImpl::OutputOrbitApiState() {
   while (!exit_requested_) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-    LOG("g_orbit_api_v2.enabled = %u", g_orbit_api_v2.enabled);
+    LOG("g_orbit_api.enabled = %u", g_orbit_api.enabled);
   }
 }
 


### PR DESCRIPTION
This is a follow up from
https://github.com/google/orbit/pull/3153#discussion_r763448952

For our injection mechanism, the version number (and soon also the platform) is
determined by the function `orbit_api_get_function_table_address_v#`. We don't
need the version in the variable name.

Pros and cons in my view:
- Having `g_orbit_api_v#` always makes it clear what version we are dealing
  with.
- Having `g_orbit_api` saves some renaming when increasing the version number.

Test: Capture OrbitTest.