### PR TITLE
Define PeCoffInterface base class to be in line with ELF code

### DIFF
--- a/third_party/libunwindstack/tests/fuzz/PeCoffInterfaceFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffInterfaceFuzzer.cpp
@@ -26,8 +26,9 @@ template <typename AddressType>
 void FuzzPeCoffInterface(const uint8_t* data, size_t size) {
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(data, 0, size);
-  unwindstack::PeCoffInterface<AddressType> pe_coff_interface(memory.get());
-  pe_coff_interface.Init();
+  unwindstack::PeCoffInterfaceImpl<AddressType> pe_coff_interface(memory.get());
+  int64_t load_bias;
+  pe_coff_interface.Init(&load_bias);
 }
 }  // namespace
 


### PR DESCRIPTION
This is in preparation for properly integrating the PE/COFF unwinding
by adadpting the PeCoffInterface interface to match what is required,
mainly so that the PE/COFF implementation can simply follow the ELF
implementation. The main changes are to separate out a base class to
allow interfacing with both the 32-bit and 64-bit case, and to add
a load_bias in/out parameter to Init, following the ELF implementation.
(Note that using the image_base value for load_bias is not a precise
one-to-one mapping, but works for our purposes and our address
computations. I'm not sure this is the best approach, but it works.)

Tested: Unit tests.
Bug: http://b/192514457