### PR TITLE
Make Orbit API work on Silenus

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -218,18 +218,18 @@ __attribute__((ms_abi)) void orbit_api_track_double_wine(const char* name, doubl
   orbit_api_track_double(name, value, color);
 }
 
-void orbit_api_initialize_wine_v2(orbit_api_win_v2* api_wine_v2) {
-  api_wine_v2->start = &orbit_api_start_wine_v1;
-  api_wine_v2->stop = &orbit_api_stop_wine;
-  api_wine_v2->start_async = &orbit_api_start_async_wine_v1;
-  api_wine_v2->stop_async = &orbit_api_stop_async_wine;
-  api_wine_v2->async_string = &orbit_api_async_string_wine;
-  api_wine_v2->track_int = &orbit_api_track_int_wine;
-  api_wine_v2->track_int64 = &orbit_api_track_int64_wine;
-  api_wine_v2->track_uint = &orbit_api_track_uint_wine;
-  api_wine_v2->track_uint64 = &orbit_api_track_uint64_wine;
-  api_wine_v2->track_float = &orbit_api_track_float_wine;
-  api_wine_v2->track_double = &orbit_api_track_double_wine;
+void orbit_api_initialize_wine_v2(orbit_api_win_v2* api_win_v2) {
+  api_win_v2->start = &orbit_api_start_wine_v1;
+  api_win_v2->stop = &orbit_api_stop_wine;
+  api_win_v2->start_async = &orbit_api_start_async_wine_v1;
+  api_win_v2->stop_async = &orbit_api_stop_async_wine;
+  api_win_v2->async_string = &orbit_api_async_string_wine;
+  api_win_v2->track_int = &orbit_api_track_int_wine;
+  api_win_v2->track_int64 = &orbit_api_track_int64_wine;
+  api_win_v2->track_uint = &orbit_api_track_uint_wine;
+  api_win_v2->track_uint64 = &orbit_api_track_uint64_wine;
+  api_win_v2->track_float = &orbit_api_track_float_wine;
+  api_win_v2->track_double = &orbit_api_track_double_wine;
 }
 
 }  // namespace
@@ -296,8 +296,8 @@ void orbit_api_set_enabled_wine(uint64_t address, uint64_t api_version, bool ena
 
   switch (api_version) {
     case 2: {
-      auto* api_wine = absl::bit_cast<orbit_api_win_v2*>(address);
-      orbit_api_initialize_and_set_enabled(api_wine, &orbit_api_initialize_wine_v2, enabled);
+      auto* api_win = absl::bit_cast<orbit_api_win_v2*>(address);
+      orbit_api_initialize_and_set_enabled(api_win, &orbit_api_initialize_wine_v2, enabled);
     } break;
     default:
       UNREACHABLE();

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -159,7 +159,9 @@ void orbit_api_initialize_v2(orbit_api_v2* api_v2) {
 }
 
 // The functions that follow, with `__attribute__((ms_abi))`, are used to fill the function table
-// `g_orbit_api_v#` when the target was built for Windows and is running on Wine.
+// `g_orbit_api_v#` when the target was built for Windows and is running on Wine. They simply
+// forward to the Linux versions, and the compiler takes care of converting between calling
+// conventions.
 
 __attribute__((ms_abi)) void orbit_api_start_wine_v1(const char* name, orbit_api_color color,
                                                      uint64_t group_id, uint64_t caller_address) {

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -108,7 +108,7 @@ void orbit_api_initialize_and_set_enabled(OrbitApiT* api,
     std::atomic_thread_fence(std::memory_order_release);
     api->initialized = 1;
   }
-  // By the time we reach this, the "initialized" guard variable has been set to 1 and we know
+  // By the time we reach this, the "initialized" guard variable has been set to 1, and we know
   // that all function pointers have been written to and published to other cores by the use of
   // acquire/release fences. The "enabled" flag serves as a global toggle which is always used in
   // conjunction with the "initialized" flag to determine if the Api is active. See
@@ -116,46 +116,116 @@ void orbit_api_initialize_and_set_enabled(OrbitApiT* api,
   api->enabled = static_cast<uint32_t>(enabled);
 }
 
-void orbit_api_initialize_v0(orbit_api_v0* api) {
-  api->start = &orbit_api_start;
-  api->stop = &orbit_api_stop;
-  api->start_async = &orbit_api_start_async;
-  api->stop_async = &orbit_api_stop_async;
-  api->async_string = &orbit_api_async_string;
-  api->track_int = &orbit_api_track_int;
-  api->track_int64 = &orbit_api_track_int64;
-  api->track_uint = &orbit_api_track_uint;
-  api->track_uint64 = &orbit_api_track_uint64;
-  api->track_float = &orbit_api_track_float;
-  api->track_double = &orbit_api_track_double;
+void orbit_api_initialize_v0(orbit_api_v0* api_v0) {
+  api_v0->start = &orbit_api_start;
+  api_v0->stop = &orbit_api_stop;
+  api_v0->start_async = &orbit_api_start_async;
+  api_v0->stop_async = &orbit_api_stop_async;
+  api_v0->async_string = &orbit_api_async_string;
+  api_v0->track_int = &orbit_api_track_int;
+  api_v0->track_int64 = &orbit_api_track_int64;
+  api_v0->track_uint = &orbit_api_track_uint;
+  api_v0->track_uint64 = &orbit_api_track_uint64;
+  api_v0->track_float = &orbit_api_track_float;
+  api_v0->track_double = &orbit_api_track_double;
 }
 
-void orbit_api_initialize_v1(orbit_api_v1* api) {
-  api->start = &orbit_api_start_v1;
-  api->stop = &orbit_api_stop;
-  api->start_async = &orbit_api_start_async;
-  api->stop_async = &orbit_api_stop_async;
-  api->async_string = &orbit_api_async_string;
-  api->track_int = &orbit_api_track_int;
-  api->track_int64 = &orbit_api_track_int64;
-  api->track_uint = &orbit_api_track_uint;
-  api->track_uint64 = &orbit_api_track_uint64;
-  api->track_float = &orbit_api_track_float;
-  api->track_double = &orbit_api_track_double;
+void orbit_api_initialize_v1(orbit_api_v1* api_v1) {
+  api_v1->start = &orbit_api_start_v1;
+  api_v1->stop = &orbit_api_stop;
+  api_v1->start_async = &orbit_api_start_async;
+  api_v1->stop_async = &orbit_api_stop_async;
+  api_v1->async_string = &orbit_api_async_string;
+  api_v1->track_int = &orbit_api_track_int;
+  api_v1->track_int64 = &orbit_api_track_int64;
+  api_v1->track_uint = &orbit_api_track_uint;
+  api_v1->track_uint64 = &orbit_api_track_uint64;
+  api_v1->track_float = &orbit_api_track_float;
+  api_v1->track_double = &orbit_api_track_double;
 }
 
-void orbit_api_initialize_v2(orbit_api_v2* api) {
-  api->start = &orbit_api_start_v1;
-  api->stop = &orbit_api_stop;
-  api->start_async = &orbit_api_start_async_v1;
-  api->stop_async = &orbit_api_stop_async;
-  api->async_string = &orbit_api_async_string;
-  api->track_int = &orbit_api_track_int;
-  api->track_int64 = &orbit_api_track_int64;
-  api->track_uint = &orbit_api_track_uint;
-  api->track_uint64 = &orbit_api_track_uint64;
-  api->track_float = &orbit_api_track_float;
-  api->track_double = &orbit_api_track_double;
+void orbit_api_initialize_v2(orbit_api_v2* api_v2) {
+  api_v2->start = &orbit_api_start_v1;
+  api_v2->stop = &orbit_api_stop;
+  api_v2->start_async = &orbit_api_start_async_v1;
+  api_v2->stop_async = &orbit_api_stop_async;
+  api_v2->async_string = &orbit_api_async_string;
+  api_v2->track_int = &orbit_api_track_int;
+  api_v2->track_int64 = &orbit_api_track_int64;
+  api_v2->track_uint = &orbit_api_track_uint;
+  api_v2->track_uint64 = &orbit_api_track_uint64;
+  api_v2->track_float = &orbit_api_track_float;
+  api_v2->track_double = &orbit_api_track_double;
+}
+
+__attribute__((ms_abi)) void orbit_api_start_wine_v1(const char* name, orbit_api_color color,
+                                                     uint64_t group_id, uint64_t caller_address) {
+  if (caller_address == kOrbitCallerAddressAuto) {
+    caller_address = ORBIT_GET_CALLER_PC();
+  }
+  orbit_api_start_v1(name, color, group_id, caller_address);
+}
+
+__attribute__((ms_abi)) void orbit_api_stop_wine() { orbit_api_stop(); }
+
+__attribute__((ms_abi)) void orbit_api_start_async_wine_v1(const char* name, uint64_t id,
+                                                           orbit_api_color color,
+                                                           uint64_t caller_address) {
+  if (caller_address == kOrbitCallerAddressAuto) {
+    caller_address = ORBIT_GET_CALLER_PC();
+  }
+  orbit_api_start_async_v1(name, id, color, caller_address);
+}
+
+__attribute__((ms_abi)) void orbit_api_stop_async_wine(uint64_t id) { orbit_api_stop_async(id); }
+
+__attribute__((ms_abi)) void orbit_api_async_string_wine(const char* str, uint64_t id,
+                                                         orbit_api_color color) {
+  orbit_api_async_string(str, id, color);
+}
+
+__attribute__((ms_abi)) void orbit_api_track_int_wine(const char* name, int32_t value,
+                                                      orbit_api_color color) {
+  orbit_api_track_int(name, value, color);
+}
+
+__attribute__((ms_abi)) void orbit_api_track_int64_wine(const char* name, int64_t value,
+                                                        orbit_api_color color) {
+  orbit_api_track_int64(name, value, color);
+}
+
+__attribute__((ms_abi)) void orbit_api_track_uint_wine(const char* name, uint32_t value,
+                                                       orbit_api_color color) {
+  orbit_api_track_uint(name, value, color);
+}
+
+__attribute__((ms_abi)) void orbit_api_track_uint64_wine(const char* name, uint64_t value,
+                                                         orbit_api_color color) {
+  orbit_api_track_uint64(name, value, color);
+}
+
+__attribute__((ms_abi)) void orbit_api_track_float_wine(const char* name, float value,
+                                                        orbit_api_color color) {
+  orbit_api_track_float(name, value, color);
+}
+
+__attribute__((ms_abi)) void orbit_api_track_double_wine(const char* name, double value,
+                                                         orbit_api_color color) {
+  orbit_api_track_double(name, value, color);
+}
+
+void orbit_api_initialize_wine_v2(orbit_api_win_v2* api_wine_v2) {
+  api_wine_v2->start = &orbit_api_start_wine_v1;
+  api_wine_v2->stop = &orbit_api_stop_wine;
+  api_wine_v2->start_async = &orbit_api_start_async_wine_v1;
+  api_wine_v2->stop_async = &orbit_api_stop_async_wine;
+  api_wine_v2->async_string = &orbit_api_async_string_wine;
+  api_wine_v2->track_int = &orbit_api_track_int_wine;
+  api_wine_v2->track_int64 = &orbit_api_track_int64_wine;
+  api_wine_v2->track_uint = &orbit_api_track_uint_wine;
+  api_wine_v2->track_uint64 = &orbit_api_track_uint64_wine;
+  api_wine_v2->track_float = &orbit_api_track_float_wine;
+  api_wine_v2->track_double = &orbit_api_track_double_wine;
 }
 
 }  // namespace
@@ -197,6 +267,38 @@ void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled)
   // connection, `producer.IsCapturing()` would otherwise always be false with at least the first
   // event (but possibly more), causing it to be missed even if it comes a long time after calling
   // `orbit_api_set_enabled`.
+  GetEventProducer();
+}
+
+void orbit_api_set_enabled_wine(uint64_t address, uint64_t api_version, bool enabled) {
+  LOG("%s Orbit API at address %#x, for Windows", enabled ? "Enabling" : "Disabling", address);
+  static constexpr uint64_t kOrbitApiForWineMinVersion = 2;
+  if (api_version < kOrbitApiForWineMinVersion) {
+    // This is unexpected because `orbit_api_get_function_table_address_win_v#` wasn't present in
+    // Orbit.h before v2.
+    ERROR(
+        "Orbit API version in tracee (%u) is older than the min supported version (%u) for "
+        "Wine.",
+        api_version, kOrbitApiForWineMinVersion);
+    return;
+  }
+
+  if (api_version > kOrbitApiVersion) {
+    ERROR(
+        "Orbit API version in tracee (%u) is newer than the max supported version (%u). "
+        "Some features will be unavailable.",
+        api_version, kOrbitApiVersion);
+  }
+
+  switch (api_version) {
+    case 2: {
+      auto* api_wine = absl::bit_cast<orbit_api_win_v2*>(address);
+      orbit_api_initialize_and_set_enabled(api_wine, &orbit_api_initialize_wine_v2, enabled);
+    } break;
+    default:
+      UNREACHABLE();
+  }
+
   GetEventProducer();
 }
 

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -158,6 +158,9 @@ void orbit_api_initialize_v2(orbit_api_v2* api_v2) {
   api_v2->track_double = &orbit_api_track_double;
 }
 
+// The functions that follow, with `__attribute__((ms_abi))`, are used to fill the function table
+// `g_orbit_api_v#` when the target was built for Windows and is running on Wine.
+
 __attribute__((ms_abi)) void orbit_api_start_wine_v1(const char* name, orbit_api_color color,
                                                      uint64_t group_id, uint64_t caller_address) {
   if (caller_address == kOrbitCallerAddressAuto) {

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -159,9 +159,8 @@ void orbit_api_initialize_v2(orbit_api_v2* api_v2) {
 }
 
 // The functions that follow, with `__attribute__((ms_abi))`, are used to fill the function table
-// `g_orbit_api_v#` when the target was built for Windows and is running on Wine. They simply
-// forward to the Linux versions, and the compiler takes care of converting between calling
-// conventions.
+// `g_orbit_api` when the target was built for Windows and is running on Wine. They simply forward
+// to the Linux versions, and the compiler takes care of converting between calling conventions.
 
 __attribute__((ms_abi)) void orbit_api_start_wine_v1(const char* name, orbit_api_color color,
                                                      uint64_t group_id, uint64_t caller_address) {

--- a/src/Api/OrbitApiVersions.h
+++ b/src/Api/OrbitApiVersions.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+// These are versions of `struct orbit_api_..._v#` different than the one defined in Orbit.h.
+
 struct orbit_api_v0 {
   uint32_t enabled;
   uint32_t initialized;
@@ -38,6 +40,28 @@ struct orbit_api_v1 {
   void (*track_uint64)(const char* name, uint64_t value, orbit_api_color color);
   void (*track_float)(const char* name, float value, orbit_api_color color);
   void (*track_double)(const char* name, double value, orbit_api_color color);
+};
+
+struct orbit_api_win_v2 {
+  uint32_t enabled;
+  uint32_t initialized;
+  __attribute__((ms_abi)) void (*start)(const char* name, orbit_api_color color, uint64_t group_id,
+                                        uint64_t caller_address);
+  __attribute__((ms_abi)) void (*stop)();
+  __attribute__((ms_abi)) void (*start_async)(const char* name, uint64_t id, orbit_api_color color,
+                                              uint64_t caller_address);
+  __attribute__((ms_abi)) void (*stop_async)(uint64_t id);
+  __attribute__((ms_abi)) void (*async_string)(const char* str, uint64_t id, orbit_api_color color);
+  __attribute__((ms_abi)) void (*track_int)(const char* name, int value, orbit_api_color color);
+  __attribute__((ms_abi)) void (*track_int64)(const char* name, int64_t value,
+                                              orbit_api_color color);
+  __attribute__((ms_abi)) void (*track_uint)(const char* name, uint32_t value,
+                                             orbit_api_color color);
+  __attribute__((ms_abi)) void (*track_uint64)(const char* name, uint64_t value,
+                                               orbit_api_color color);
+  __attribute__((ms_abi)) void (*track_float)(const char* name, float value, orbit_api_color color);
+  __attribute__((ms_abi)) void (*track_double)(const char* name, double value,
+                                               orbit_api_color color);
 };
 
 #endif  // ORBIT_API_ORBIT_API_VERSIONS_H_

--- a/src/Api/OrbitApiVersions.h
+++ b/src/Api/OrbitApiVersions.h
@@ -7,7 +7,10 @@
 
 #include <stdint.h>
 
-// These are versions of `struct orbit_api_..._v#` different than the one defined in Orbit.h.
+// This file contains versions of `struct orbit_api_..._v#` different from the one defined in
+// Orbit.h.
+
+// In particular, these are the versions for Linux older than the current one.
 
 struct orbit_api_v0 {
   uint32_t enabled;
@@ -41,6 +44,9 @@ struct orbit_api_v1 {
   void (*track_float)(const char* name, float value, orbit_api_color color);
   void (*track_double)(const char* name, double value, orbit_api_color color);
 };
+
+// And these are the equivalents built on Linux of the result of building Orbit.h on Windows. They
+// include previous versions, but also the current version.
 
 struct orbit_api_win_v2 {
   uint32_t enabled;

--- a/src/Api/OrbitApiVersions.h
+++ b/src/Api/OrbitApiVersions.h
@@ -45,8 +45,10 @@ struct orbit_api_v1 {
   void (*track_double)(const char* name, double value, orbit_api_color color);
 };
 
-// And these are the equivalents built on Linux of the result of building Orbit.h on Windows. They
-// include previous versions, but also the current version.
+// And these are the versions that resulted from building Orbit.h on Windows, but defined on Linux
+// in a way that yields the same result. They include previous versions, but also the current
+// version, because we want the Windows layout to be available to us in liborbit.so when dealing
+// with a Windows binary running on Wine.
 
 struct orbit_api_win_v2 {
   uint32_t enabled;

--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -358,29 +358,10 @@ struct orbit_api_v2 {
 };
 
 #if __cplusplus >= 201103L  // C++11
-#define ORBIT_ASSERT_API_LAYOUT(expression) \
-  static_assert(expression, "struct orbit_api_v2 has an unexpected layout")
+static_assert(sizeof(struct orbit_api_v2) == 96, "struct orbit_api_v2 has an unexpected layout");
 #elif __STDC_VERSION__ >= 201112L  // C11
-#define ORBIT_ASSERT_API_LAYOUT(expression) \
-  _Static_assert(expression, "struct orbit_api_v2 has an unexpected layout")
-#else
-#define ORBIT_ASSERT_API_LAYOUT(expression)
+_Static_assert(sizeof(struct orbit_api_v2) == 96, "struct orbit_api_v2 has an unexpected layout");
 #endif
-
-ORBIT_ASSERT_API_LAYOUT(sizeof(struct orbit_api_v2) == 96);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, enabled) == 0);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, initialized) == 4);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, start) == 8);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, stop) == 16);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, start_async) == 24);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, stop_async) == 32);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, async_string) == 40);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_int) == 48);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_int64) == 56);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_uint) == 64);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_uint64) == 72);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_float) == 80);
-ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_double) == 88);
 
 extern struct orbit_api_v2 g_orbit_api;
 
@@ -390,13 +371,13 @@ extern struct orbit_api_v2 g_orbit_api;
 #ifdef _WIN32
 extern ORBIT_EXPORT void* orbit_api_get_function_table_address_win_v2();
 
-#define ORBIT_API_INSTANTIATE         \
+#define ORBIT_API_INSTANTIATE      \
   struct orbit_api_v2 g_orbit_api; \
   void* orbit_api_get_function_table_address_win_v2() { return &g_orbit_api; }
 #else
 extern ORBIT_EXPORT void* orbit_api_get_function_table_address_v2();
 
-#define ORBIT_API_INSTANTIATE         \
+#define ORBIT_API_INSTANTIATE      \
   struct orbit_api_v2 g_orbit_api; \
   void* orbit_api_get_function_table_address_v2() { return &g_orbit_api; }
 #endif  // _WIN32

--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -6,6 +6,7 @@
 #define ORBIT_API_INTERFACE_ORBIT_H_
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 // =================================================================================================
@@ -356,13 +357,47 @@ struct orbit_api_v2 {
   void (*track_double)(const char* name, double value, orbit_api_color color);
 };
 
+#if __cplusplus >= 201103L  // C++11
+#define ORBIT_ASSERT_API_LAYOUT(expression) \
+  static_assert(expression, "struct orbit_api_v2 has an unexpected layout")
+#elif __STDC_VERSION__ >= 201112L  // C11
+#define ORBIT_ASSERT_API_LAYOUT(expression) \
+  _Static_assert(expression, "struct orbit_api_v2 has an unexpected layout")
+#else
+#define ORBIT_ASSERT_API_LAYOUT(expression)
+#endif
+
+ORBIT_ASSERT_API_LAYOUT(sizeof(struct orbit_api_v2) == 96);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, enabled) == 0);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, initialized) == 4);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, start) == 8);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, stop) == 16);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, start_async) == 24);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, stop_async) == 32);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, async_string) == 40);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_int) == 48);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_int64) == 56);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_uint) == 64);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_uint64) == 72);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_float) == 80);
+ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_double) == 88);
+
 extern struct orbit_api_v2 g_orbit_api;
-extern ORBIT_EXPORT void* orbit_api_get_function_table_address_v2();
 
 // User needs to place "ORBIT_API_INSTANTIATE" in an implementation file.
-#define ORBIT_API_INSTANTIATE      \
+#ifdef _WIN32
+extern ORBIT_EXPORT void* orbit_api_get_function_table_address_win_v2();
+
+#define ORBIT_API_INSTANTIATE         \
+  struct orbit_api_v2 g_orbit_api; \
+  void* orbit_api_get_function_table_address_win_v2() { return &g_orbit_api; }
+#else
+extern ORBIT_EXPORT void* orbit_api_get_function_table_address_v2();
+
+#define ORBIT_API_INSTANTIATE         \
   struct orbit_api_v2 g_orbit_api; \
   void* orbit_api_get_function_table_address_v2() { return &g_orbit_api; }
+#endif  // _WIN32
 
 #ifndef __cplusplus
 // In C, `inline` alone doesn't generate an out-of-line definition, causing a linker error if the

--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -385,6 +385,8 @@ ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_double) == 88);
 extern struct orbit_api_v2 g_orbit_api;
 
 // User needs to place "ORBIT_API_INSTANTIATE" in an implementation file.
+// We use a different name per platform for the "orbit_api_get_function_table_address..." function,
+// so that we can easily distinguish what platform the binary was built for.
 #ifdef _WIN32
 extern ORBIT_EXPORT void* orbit_api_get_function_table_address_win_v2();
 

--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -385,8 +385,8 @@ ORBIT_ASSERT_API_LAYOUT(offsetof(struct orbit_api_v2, track_double) == 88);
 extern struct orbit_api_v2 g_orbit_api;
 
 // User needs to place "ORBIT_API_INSTANTIATE" in an implementation file.
-// We use a different name per platform for the "orbit_api_get_function_table_address..." function,
-// so that we can easily distinguish what platform the binary was built for.
+// We use a different name per platform for the "orbit_api_get_function_table_address_..._v#"
+// function, so that we can easily distinguish what platform the binary was built for.
 #ifdef _WIN32
 extern ORBIT_EXPORT void* orbit_api_get_function_table_address_win_v2();
 

--- a/src/ApiLoader/EnableInTracee.cpp
+++ b/src/ApiLoader/EnableInTracee.cpp
@@ -126,8 +126,10 @@ ErrorMessageOr<void> SetApiEnabledInTracee(const CaptureOptions& capture_options
             module_info->executable_segment_offset()));
     uint64_t function_table_address = 0;
     if (absl::StartsWith(api_function.name(), kOrbitApiGetFunctionTableAddressPrefix)) {
+      // The target is a native Linux binary.
       OUTCOME_TRY(function_table_address, ExecuteInProcess(pid, api_function_address));
     } else if (absl::StartsWith(api_function.name(), kOrbitApiGetFunctionTableAddressWinPrefix)) {
+      // The target is a Windows binary running on Wine.
       OUTCOME_TRY(function_table_address,
                   ExecuteInProcessWithMicrosoftCallingConvention(pid, api_function_address));
     } else {
@@ -136,14 +138,17 @@ ErrorMessageOr<void> SetApiEnabledInTracee(const CaptureOptions& capture_options
 
     // Call "orbit_api_set_enabled" in tracee.
     if (absl::StartsWith(api_function.name(), kOrbitApiGetFunctionTableAddressPrefix)) {
+      // Again, Linux binary.
       OUTCOME_TRY(ExecuteInProcess(pid, orbit_api_set_enabled_function, function_table_address,
                                    api_function.api_version(), enabled ? 1 : 0));
     } else if (absl::StartsWith(api_function.name(), kOrbitApiGetFunctionTableAddressWinPrefix)) {
+      // Windows binary running on Wine.
       OUTCOME_TRY(ExecuteInProcess(pid, orbit_api_set_enabled_wine_function, function_table_address,
                                    api_function.api_version(), enabled ? 1 : 0));
     } else {
       UNREACHABLE();
     }
+
     // `orbit_api_set_enabled` could spawn new threads (and will, the first time it's called). Stop
     // those too, as this loop could be executed again and the assumption is that the target process
     // is completely stopped.

--- a/src/ApiUtils/include/ApiUtils/GetFunctionTableAddressPrefix.h
+++ b/src/ApiUtils/include/ApiUtils/GetFunctionTableAddressPrefix.h
@@ -14,6 +14,9 @@ namespace orbit_api_utils {
 static const std::string kOrbitApiGetFunctionTableAddressPrefix{
     "orbit_api_get_function_table_address_v"};
 
+static const std::string kOrbitApiGetFunctionTableAddressWinPrefix{
+    "orbit_api_get_function_table_address_win_v"};
+
 }  // namespace orbit_api_utils
 
 #endif  // API_UTILS_GET_FUNCTION_TABLE_ADDRESS_PREFIX_H_

--- a/src/ApiUtils/include/ApiUtils/GetFunctionTableAddressPrefix.h
+++ b/src/ApiUtils/include/ApiUtils/GetFunctionTableAddressPrefix.h
@@ -9,11 +9,14 @@
 
 namespace orbit_api_utils {
 
-// This is the prefix of the function declared in Orbit.h that we need to call in the tracee after
-// having loaded liborbit.so into it.
+// These are the possible prefixes, depending on the platform, of the function declared in Orbit.h
+// that we need to call in the tracee after having loaded liborbit.so into it.
+
+// This is the prefix on Linux.
 static const std::string kOrbitApiGetFunctionTableAddressPrefix{
     "orbit_api_get_function_table_address_v"};
 
+// This is the prefix on Windows.
 static const std::string kOrbitApiGetFunctionTableAddressWinPrefix{
     "orbit_api_get_function_table_address_win_v"};
 

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -94,6 +94,7 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
 // the Api after having injected liborbit.so.
 [[nodiscard]] static std::vector<ApiFunction> FindApiFunctions(
     const orbit_client_data::ModuleManager& module_manager) {
+  // We have a different function name for each supported platform.
   static const std::vector<std::string> kOrbitApiGetFunctionTableAddressPrefixes{
       orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix,
       orbit_api_utils::kOrbitApiGetFunctionTableAddressWinPrefix};

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -94,20 +94,26 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
 // the Api after having injected liborbit.so.
 [[nodiscard]] static std::vector<ApiFunction> FindApiFunctions(
     const orbit_client_data::ModuleManager& module_manager) {
+  static const std::vector<std::string> kOrbitApiGetFunctionTableAddressPrefixes{
+      orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix,
+      orbit_api_utils::kOrbitApiGetFunctionTableAddressWinPrefix};
   std::vector<ApiFunction> api_functions;
   for (const ModuleData* module_data : module_manager.GetAllModuleData()) {
-    for (size_t i = 0; i <= kOrbitApiVersion; ++i) {
-      std::string function_name =
-          absl::StrFormat("%s%u", orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix, i);
-      const FunctionInfo* function_info = module_data->FindFunctionFromPrettyName(function_name);
-      if (function_info == nullptr) continue;
-      ApiFunction api_function;
-      api_function.set_module_path(function_info->module_path());
-      api_function.set_module_build_id(function_info->module_build_id());
-      api_function.set_address(function_info->address());
-      api_function.set_name(function_name);
-      api_function.set_api_version(i);
-      api_functions.emplace_back(api_function);
+    for (const std::string& orbit_api_get_function_table_address_prefix :
+         kOrbitApiGetFunctionTableAddressPrefixes) {
+      for (size_t i = 0; i <= kOrbitApiVersion; ++i) {
+        std::string function_name =
+            absl::StrFormat("%s%u", orbit_api_get_function_table_address_prefix, i);
+        const FunctionInfo* function_info = module_data->FindFunctionFromPrettyName(function_name);
+        if (function_info == nullptr) continue;
+        ApiFunction api_function;
+        api_function.set_module_path(function_info->module_path());
+        api_function.set_module_build_id(function_info->module_build_id());
+        api_function.set_address(function_info->address());
+        api_function.set_name(function_name);
+        api_function.set_api_version(i);
+        api_functions.emplace_back(api_function);
+      }
     }
   }
   return api_functions;


### PR DESCRIPTION
This implements http://go/stadia-orbit-api-for-silenus

We add a dedicated `orbit_api_get_function_table_address_win_v2` to retrieve the
address of `struct orbit_api_v2 g_orbit_api_v2`. If it's present, we call it
with the new `ExecuteInProcessWithMicrosoftCallingConvention`.
The existence of that function instead of
`orbit_api_get_function_table_address_v#` for Linux tells us that we need to
fill `g_orbit_api_v#` with the `__attribute__((ms_abi)) void orbit_api_..._wine`
functions. These follow the Microsoft calling convention. They simply forward to
the Linux versions, and the compiler takes care of converting between calling
conventions.

Bug: http://b/193778733

Test: Tested on a version of `triangle.exe` running on Silenus to which I added
all kinds of manual instrumentation. Also tested on a regular manually
instrumented native Linux binary.