### PR TITLE
Fix conan version  in bootstrap scripts

### DIFF
--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -4,6 +4,36 @@
 
 $conan_version_required = "1.40.3"
 
+function Check-Conan-Version-Sufficient {
+  $version = $args[0]
+  $required = $args[1]
+
+  $version_major = $version.split(".")[0] -as [int]
+  $required_major = $required.split(".")[0] -as [int]
+  if ($required_major -gt $version_major) {
+    return 1
+  }
+  if ($required_major -lt $version_major) {
+    return 0
+  }
+
+  $version_minor = $version.split(".")[1] -as [int]
+  $required_minor = $required.split(".")[1] -as [int]
+  if ($required_minor -gt $version_minor) {
+    return 1
+  }
+  if ($required_minor -lt $version_minor) {
+    return 0
+  }
+
+  $version_patch = $version.split(".")[2] -as [int]
+  $required_patch = $required.split(".")[2] -as [int]
+  if ($required_patch -gt $version_patch) {
+    return 1
+  }
+  return 0
+}
+
 $conan = Get-Command -ErrorAction Ignore conan
 
 if (!$conan) {
@@ -39,9 +69,9 @@ You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
 
   $conan_version = (& $conan.Path --version).split(" ")[2]
 
-  if ($conan_version -lt $conan_version_required) {
+  $sufficient = Check-Conan-Version-Sufficient $conan_version $conan_version_required
+  if ($sufficient -ne 0) {
     Write-Host "Your conan version $conan_version is too old. Let's try to update it."
-
     Try {
       $pip3 = Get-Command pip3
       & $pip3.Path install --upgrade conan==$conan_version_required

--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+$conan_version_required = "1.40.3"
+
 $conan = Get-Command -ErrorAction Ignore conan
 
 if (!$conan) {
@@ -18,7 +20,7 @@ it available in the path.
 "@
   }
 
-  & $pip3.Path install conan==1.40.3
+  & $pip3.Path install conan==$conan_version_required
   if ($LastExitCode -ne 0) {
     Throw "Error while installing conan via pip3."
   }
@@ -36,21 +38,16 @@ You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
   Write-Host "Conan found. Checking version..."
 
   $conan_version = (& $conan.Path --version).split(" ")[2]
-  $conan_version_major = $conan_version.split(".")[0] -as [int]
-  $conan_version_minor = $conan_version.split(".")[1] -as [int]
 
-  $conan_version_major_required = 1
-  $conan_version_minor_min = 36
-
-  if ($conan_version_major -eq $conan_version_major_required -and $conan_version_minor -lt $conan_version_minor_min) {
+  if ($conan_version -lt $conan_version_required) {
     Write-Host "Your conan version $conan_version is too old. Let's try to update it."
 
     Try {
       $pip3 = Get-Command pip3
-      & $pip3.Path install --upgrade conan==1.40.3
+      & $pip3.Path install --upgrade conan==$conan_version_required
     } Catch {
       Throw "Error while upgrading conan via pip3. Probably you have conan installed differently." + 
-            " Please manually update conan to a at least version $conan_version_major_required.$conan_version_minor_min."
+            " Please manually update conan to a at least version $conan_version_required"
     }
 
     Write-Host "Successfully updated conan!"

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -78,11 +78,11 @@ EOF
 fi # IGNORE_SYS_REQ
 
 function check_conan_version_sufficient() {
-  VERSION=$1
-  REQUIRED=$2
+  local VERSION=$1
+  local REQUIRED=$2
 
-  VERSION_MAJOR="$(echo "$VERSION" | cut -d'.' -f1)"
-  REQUIRED_MAJOR="$(echo "$REQUIRED" | cut -d'.' -f1)"
+  local VERSION_MAJOR="$(echo "$VERSION" | cut -d'.' -f1)"
+  local REQUIRED_MAJOR="$(echo "$REQUIRED" | cut -d'.' -f1)"
   if [ "$REQUIRED_MAJOR" -gt "$VERSION_MAJOR" ]; then
     return 1
   fi
@@ -90,8 +90,8 @@ function check_conan_version_sufficient() {
     return 0
   fi
 
-  VERSION_MINOR="$(echo "$VERSION" | cut -d'.' -f2)"
-  REQUIRED_MINOR="$(echo "$REQUIRED" | cut -d'.' -f2)"
+  local VERSION_MINOR="$(echo "$VERSION" | cut -d'.' -f2)"
+  local REQUIRED_MINOR="$(echo "$REQUIRED" | cut -d'.' -f2)"
   if [ "$REQUIRED_MINOR" -gt "$VERSION_MINOR" ]; then
     return 1
   fi
@@ -99,8 +99,8 @@ function check_conan_version_sufficient() {
     return 0
   fi
 
-  VERSION_PATCH="$(echo "$VERSION" | cut -d'.' -f3)"
-  REQUIRED_PATCH="$(echo "$REQUIRED" | cut -d'.' -f3)"
+  local VERSION_PATCH="$(echo "$VERSION" | cut -d'.' -f3)"
+  local REQUIRED_PATCH="$(echo "$REQUIRED" | cut -d'.' -f3)"
   if [ "$REQUIRED_PATCH" -gt "$VERSION_PATCH" ]; then
     return 1
   fi

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -128,8 +128,7 @@ else
   echo "Found conan. Checking version..."
   CONAN_VERSION="$(conan --version | cut -d' ' -f3)"
   
-  check_conan_version_sufficient "$CONAN_VERSION" "$CONAN_VERSION_REQUIRED"
-  if [ $? -ne 0 ]; then
+  if ! check_conan_version_sufficient "$CONAN_VERSION" "$CONAN_VERSION_REQUIRED"; then
     echo "Your conan version $CONAN_VERSION is too old. I will try to update..."
     pip3 install --upgrade --user conan=="$CONAN_VERSION_REQUIRED"
     if [ $? -ne 0 ]; then

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -77,6 +77,36 @@ EOF
   fi # which dpkg-query
 fi # IGNORE_SYS_REQ
 
+function check_conan_version_sufficient() {
+  VERSION=$1
+  REQUIRED=$2
+
+  VERSION_MAJOR="$(echo "$VERSION" | cut -d'.' -f1)"
+  REQUIRED_MAJOR="$(echo "$REQUIRED" | cut -d'.' -f1)"
+  if [ "$REQUIRED_MAJOR" -gt "$VERSION_MAJOR" ]; then
+    return 1
+  fi
+  if [ "$REQUIRED_MAJOR" -lt "$VERSION_MAJOR" ]; then
+    return 0
+  fi
+
+  VERSION_MINOR="$(echo "$VERSION" | cut -d'.' -f2)"
+  REQUIRED_MINOR="$(echo "$REQUIRED" | cut -d'.' -f2)"
+  if [ "$REQUIRED_MINOR" -gt "$VERSION_MINOR" ]; then
+    return 1
+  fi
+  if [ "$REQUIRED_MINOR" -lt "$VERSION_MINOR" ]; then
+    return 0
+  fi
+
+  VERSION_PATCH="$(echo "$VERSION" | cut -d'.' -f3)"
+  REQUIRED_PATCH="$(echo "$REQUIRED" | cut -d'.' -f3)"
+  if [ "$REQUIRED_PATCH" -gt "$VERSION_PATCH" ]; then
+    return 1
+  fi
+  return 0
+}
+
 echo "Checking if conan is available..."
 which conan >/dev/null
 if [ $? -ne 0 ]; then
@@ -98,7 +128,8 @@ else
   echo "Found conan. Checking version..."
   CONAN_VERSION="$(conan --version | cut -d' ' -f3)"
   
-  if [[ "$CONAN_VERSION" < "$CONAN_VERSION_REQUIRED" ]]; then
+  check_conan_version_sufficient "$CONAN_VERSION" "$CONAN_VERSION_REQUIRED"
+  if [ $? -ne 0 ]; then
     echo "Your conan version $CONAN_VERSION is too old. I will try to update..."
     pip3 install --upgrade --user conan=="$CONAN_VERSION_REQUIRED"
     if [ $? -ne 0 ]; then
@@ -108,7 +139,7 @@ else
     fi
     echo "Conan updated finished."
   else
-    echo "Conan's version fulfills the requirements. Continuing..."
+    echo "Conan's version $CONAN_VERSION fulfills the requirements. Continuing..."
   fi
 fi
 

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -4,6 +4,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+CONAN_VERSION_REQUIRED="1.40.3"
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 OPTIONS=$(getopt -o "" -l "force-public-remotes,assume-linux,assume-windows,ignore-system-requirements,dont-compile" -- "$@")
@@ -79,7 +81,7 @@ echo "Checking if conan is available..."
 which conan >/dev/null
 if [ $? -ne 0 ]; then
   echo "Couldn't find conan. Trying to install via pip..."
-  pip3 install --user conan==1.40.3 || exit $?
+  pip3 install --user conan=="$CONAN_VERSION_REQUIRED" || exit $?
 
   which conan >/dev/null
   if [ $? -ne 0 ]; then
@@ -95,18 +97,13 @@ if [ $? -ne 0 ]; then
 else
   echo "Found conan. Checking version..."
   CONAN_VERSION="$(conan --version | cut -d' ' -f3)"
-  CONAN_VERSION_MAJOR="$(echo "$CONAN_VERSION" | cut -d'.' -f1)"
-  CONAN_VERSION_MINOR="$(echo "$CONAN_VERSION" | cut -d'.' -f2)"
-
-  CONAN_VERSION_MAJOR_REQUIRED=1
-  CONAN_VERSION_MINOR_MIN=36
-
-  if [ "$CONAN_VERSION_MAJOR" -eq $CONAN_VERSION_MAJOR_REQUIRED -a "$CONAN_VERSION_MINOR" -lt $CONAN_VERSION_MINOR_MIN ]; then
+  
+  if [[ "$CONAN_VERSION" < "$CONAN_VERSION_REQUIRED" ]]; then
     echo "Your conan version $CONAN_VERSION is too old. I will try to update..."
-    pip3 install --upgrade --user conan==1.40.3
+    pip3 install --upgrade --user conan=="$CONAN_VERSION_REQUIRED"
     if [ $? -ne 0 ]; then
       echo "The upgrade of your conan installation failed. Probably because conan was not installed by this script."
-      echo "Please manually update conan to at least version $CONAN_VERSION_MAJOR_REQUIRED.$CONAN_VERSION_MINOR_MIN."
+      echo "Please manually update conan to at least version $CONAN_VERSION_REQUIRED."
       exit 2
     fi
     echo "Conan updated finished."


### PR DESCRIPTION
See also commit messages, but the conan version checking was not updated properly in the past, because the required version needed to be changed in multiple places. I redid this so its more sustainable going forward. 

This uses now lexicographic comparison of two version strings. (eg "1.36.0" < "1.40.3"). I tested this manually and it should work, but I am neither a powershell nor bash expert, ptal.