### PR TITLE
Add frame track mutex to `TrackManager::GetAllTracks()`

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -59,9 +59,8 @@ std::vector<Track*> TrackManager::GetAllTracks() const {
     tracks.push_back(track.get());
   }
 
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
-  for (const auto& track : frame_tracks_) {
-    tracks.push_back(track.second.get());
+  for (const auto track : GetFrameTracks()) {
+    tracks.push_back(track);
   }
   return tracks;
 }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -58,6 +58,8 @@ std::vector<Track*> TrackManager::GetAllTracks() const {
   for (const auto& track : all_tracks_) {
     tracks.push_back(track.get());
   }
+
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
   for (const auto& track : frame_tracks_) {
     tracks.push_back(track.second.get());
   }


### PR DESCRIPTION
This may be a fix for b/208768988.

In any case, it's a bug since the behavior is inconsistent with `GetFrameTracks`.