### PR TITLE
Add missing includes to various files

### DIFF
--- a/src/ClientData/include/ClientData/TimestampIntervalSet.h
+++ b/src/ClientData/include/ClientData/TimestampIntervalSet.h
@@ -5,6 +5,7 @@
 #ifndef CLIENT_DATA_TIMESTAMP_INTERVAL_SET_H_
 #define CLIENT_DATA_TIMESTAMP_INTERVAL_SET_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <set>

--- a/src/OrbitGl/SimpleTimings.cpp
+++ b/src/OrbitGl/SimpleTimings.cpp
@@ -4,7 +4,10 @@
 
 #include "SimpleTimings.h"
 
+#include <stddef.h>
+
 #include <algorithm>
+#include <limits>
 
 namespace orbit_gl {
 SimpleTimings::SimpleTimings(size_t num_timings_to_store)

--- a/src/OrbitGl/SimpleTimings.h
+++ b/src/OrbitGl/SimpleTimings.h
@@ -5,8 +5,9 @@
 #ifndef ORBIT_GL_SIMPLE_TIMINGS_H_
 #define ORBIT_GL_SIMPLE_TIMINGS_H_
 
-#include <vector>
+#include <stddef.h>
 
+#include <vector>
 namespace orbit_gl {
 
 class SimpleTimings {

--- a/src/UserSpaceInstrumentation/TestProcess.h
+++ b/src/UserSpaceInstrumentation/TestProcess.h
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <filesystem>
+#include <optional>
 #include <set>
 #include <thread>
 

--- a/third_party/libunwindstack/include/unwindstack/DwarfMemory.h
+++ b/third_party/libunwindstack/include/unwindstack/DwarfMemory.h
@@ -17,6 +17,7 @@
 #ifndef _LIBUNWINDSTACK_DWARF_MEMORY_H
 #define _LIBUNWINDSTACK_DWARF_MEMORY_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace unwindstack {


### PR DESCRIPTION
They all lead to compilation errors when compiling with GCC-11 and its
libstdc++. Apparently the GC folks cleaned up their transitive includes
quite a bit.