### PR TITLE
Detach Unwinding Method from Sampling

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -144,14 +144,10 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
   CaptureOptions* capture_options = request.mutable_capture_options();
   capture_options->set_trace_context_switches(collect_scheduling_info);
   capture_options->set_pid(process_id);
-  if (samples_per_second == 0) {
-    capture_options->set_unwinding_method(CaptureOptions::kUndefined);
-  } else {
-    capture_options->set_samples_per_second(samples_per_second);
-    capture_options->set_stack_dump_size(stack_dump_size);
-    CHECK(unwinding_method != CaptureOptions::kUndefined);
-    capture_options->set_unwinding_method(unwinding_method);
-  }
+  CHECK(unwinding_method != CaptureOptions::kUndefined);
+  capture_options->set_unwinding_method(unwinding_method);
+  capture_options->set_stack_dump_size(stack_dump_size);
+  capture_options->set_samples_per_second(samples_per_second);
 
   capture_options->set_collect_memory_info(collect_memory_info);
   constexpr const uint64_t kMsToNs = 1'000'000;

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -107,6 +107,7 @@ static constexpr uint16_t SAMPLE_STACK_USER_SIZE_8BYTES = 8;
 // a lower value. For the current layout of perf_event_stack_sample_fixed, the maximum
 // size is 65312. We leave some extra room with our flag (see `ClientFlags.cpp`).
 static constexpr uint16_t kMaxStackSampleUserSize = 65000;
+static constexpr uint16_t kMaxStackSampleUserSizeFramePointer = 512;
 
 // perf_event_open for context switches.
 int context_switch_event_open(pid_t pid, int32_t cpu);

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -105,9 +105,9 @@ static constexpr uint16_t SAMPLE_STACK_USER_SIZE_8BYTES = 8;
 // of the entire record the kernel is willing to return is (1u << 16u) - 8.
 // If we want the size we pass to coincide with the size we get, we need to pass
 // a lower value. For the current layout of perf_event_stack_sample_fixed, the maximum
-// size is 65312. We leave some extra room with our flag (see `ClientFlags.cpp`).
+// size is 65312. However, we leave some extra room here.
+// See also `ClientFlags.cpp`.
 static constexpr uint16_t kMaxStackSampleUserSize = 65000;
-static constexpr uint16_t kMaxStackSampleUserSizeFramePointer = 512;
 
 // perf_event_open for context switches.
 int context_switch_event_open(pid_t pid, int32_t cpu);

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -78,10 +78,11 @@ TracerImpl::TracerImpl(
     stack_dump_size = (unwinding_method_ == CaptureOptions::kDwarf)
                           ? kMaxStackSampleUserSize
                           : kDefaultStackSampleUserSizeFramePointer;
-    LOG("No sample stack dump size was set; Assigning to default: %u", stack_dump_size);
-  } else if (stack_dump_size > kMaxStackSampleUserSize ||
-             stack_dump_size == 0 /*TODO(b/210439638)*/) {
-    ERROR("Invalid sample stack dump size: %u; Reassigning to default: %u", stack_dump_size,
+    LOG("No sample stack dump size was set; assigning to default: %u", stack_dump_size);
+  } else if (stack_dump_size > kMaxStackSampleUserSize || stack_dump_size == 0) {
+    // TODO(b/210439638): Support a stack_dump_size of 0. It might be valid for frame pointer
+    //  sampling without leaf function patching.
+    ERROR("Invalid sample stack dump size: %u; reassigning to default: %u", stack_dump_size,
           kMaxStackSampleUserSize);
     stack_dump_size = kMaxStackSampleUserSize;
   }

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -136,9 +136,6 @@ class TracerImpl : public Tracer {
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 5000;
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 5000;
 
-  // If sampling is disabled, we set `sampling_period_ns` to this constant.
-  static constexpr uint64_t kNoSamplingPeriodNs = 0;
-
   bool trace_context_switches_;
   pid_t target_pid_;
   std::optional<uint64_t> sampling_period_ns_;

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -136,9 +136,12 @@ class TracerImpl : public Tracer {
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 5000;
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 5000;
 
+  // If sampling is disabled, we set `sampling_period_ns` to this constant.
+  static constexpr uint64_t kNoSamplingPeriodNs = 0;
+
   bool trace_context_switches_;
   pid_t target_pid_;
-  uint64_t sampling_period_ns_;
+  std::optional<uint64_t> sampling_period_ns_;
   uint16_t stack_dump_size_;
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_;
   std::vector<Function> instrumented_functions_;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -188,7 +188,7 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
 
   if (FLAGS_stack_dump_size.IsSpecifiedOnCommandLine()) {
     uint16_t stack_dump_size = absl::GetFlag(FLAGS_stack_dump_size);
-    CHECK(stack_dump_size <= 65000 && stack_dump_size > 0);
+    CHECK(stack_dump_size != std::numeric_limits<uint16_t>::max());
     app_->SetStackDumpSize(stack_dump_size);
   } else {
     app_->SetStackDumpSize(std::numeric_limits<uint16_t>::max());
@@ -1113,16 +1113,20 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
     app_->SetSamplesPerSecond(0.0);
   }
 
-  UnwindingMethod unwinding_method = static_cast<UnwindingMethod>(
-      settings
-          .value(kCallstackUnwindingMethodSettingKey,
-                 static_cast<int>(kCallstackUnwindingMethodDefaultValue))
-          .toInt());
-  if (!app_->IsDevMode() || (unwinding_method != CaptureOptions::kDwarf &&
-                             unwinding_method != CaptureOptions::kFramePointers)) {
-    unwinding_method = kCallstackUnwindingMethodDefaultValue;
+  if (!app_->IsDevMode()) {
+    app_->SetUnwindingMethod(kCallstackUnwindingMethodDefaultValue);
+  } else {
+    UnwindingMethod unwinding_method = static_cast<UnwindingMethod>(
+        settings
+            .value(kCallstackUnwindingMethodSettingKey,
+                   static_cast<int>(kCallstackUnwindingMethodDefaultValue))
+            .toInt());
+    if (unwinding_method != CaptureOptions::kDwarf &&
+        unwinding_method != CaptureOptions::kFramePointers) {
+      ERROR("Unknown unwinding method specified; Using default unwinding method");
+      app_->SetUnwindingMethod(kCallstackUnwindingMethodDefaultValue);
+    }
   }
-  app_->SetUnwindingMethod(unwinding_method);
 
   app_->SetCollectSchedulerInfo(settings.value(kCollectSchedulerInfoSettingKey, true).toBool());
   app_->SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());


### PR DESCRIPTION
Before this change, "no sampling" was represented by
setting the unwinding method to "undefined". However,
in the future, we also want to do callstack collection
and unwinding on different triggers (such as uprobes).
Therefore, we want to set the unwinding method even
when not sampling. We use sampling period of "0" as
a new way to disable sampling.

Further, this change reduces the default stack dump
collection size when frame pointer unwinding.
std::numeric_limits<uint16_t>::max() is used
when the stack size is not defined, and the new
defaults should be used.

Test:
Take captures with and without frame pointers.
Run Tests.