### PR TITLE
FIx instance connection bug

### DIFF
--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -388,6 +388,10 @@ void ConnectToStadiaWidget::OnInstancesLoaded(QVector<orbit_ggp::Instance> insta
 
 void ConnectToStadiaWidget::OnSshInfoLoaded(ErrorMessageOr<orbit_ggp::SshInfo> ssh_info_result,
                                             std::string instance_id) {
+  if (!selected_instance_.has_value() ||
+      selected_instance_.value().id.toStdString() != instance_id) {
+    return;
+  }
   if (ssh_info_result.has_error()) {
     std::string error_message =
         absl::StrFormat("Unable to load encryption credentials for instance with id %s: %s",


### PR DESCRIPTION
Beforehand, when the user started a connection to one instance and
while the call to GetSshInfoAsync was running selected a different
instance and connect to it, Orbit would crash. This happened because
when the first GetSshInfoAsync returned,
ConnectToStadiaWidget::OnSshInfoLoaded was fully executed and did not
take into account that the selected instance could have changed in the
mean time. This is now fixed

Test: Start connection to instance, immediately cancel and start a
connection to a different instance.

http://b/209430645