### PR TITLE
Implement PE/COFF equivalent of Elf class in libunwindstack

### DIFF
--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -40,7 +40,6 @@ target_sources(libunwindstack_common PRIVATE
   ElfInterfaceArm.cpp
   ElfInterfaceArm.h
   ElfInterface.cpp
-  PeCoffInterface.cpp
   Global.cpp
   GlobalDebugImpl.h
   JitDebug.cpp
@@ -66,6 +65,8 @@ target_sources(libunwindstack_common PRIVATE
   MemoryXz.cpp
   MemoryXz.h
   Object.cpp
+  PeCoff.cpp
+  PeCoffInterface.cpp
   RegsArm64.cpp
   RegsArm.cpp
   Regs.cpp
@@ -113,6 +114,7 @@ target_sources(libunwindstack_common PUBLIC
   include/unwindstack/Maps.h
   include/unwindstack/Memory.h
   include/unwindstack/Object.h
+  include/unwindstack/PeCoff.h
   include/unwindstack/PeCoffInterface.h
   include/unwindstack/Regs.h
   include/unwindstack/RegsArm.h
@@ -246,6 +248,8 @@ target_sources(libunwindstack_tests PRIVATE
   tests/MemoryXzTest.cpp
   tests/ObjectCacheTest.cpp
   tests/PeCoffInterfaceTest.cpp
+  tests/PeCoffFake.cpp
+  tests/PeCoffTest.cpp
   tests/RegsInfoTest.cpp
   tests/RegsIterateTest.cpp
   tests/RegsStepIfSignalHandlerTest.cpp

--- a/third_party/libunwindstack/PeCoff.cpp
+++ b/third_party/libunwindstack/PeCoff.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unwindstack/PeCoff.h>
+
+#include <string>
+
+#include <unwindstack/Log.h>
+#include <unwindstack/MapInfo.h>
+#include <unwindstack/Memory.h>
+#include <unwindstack/Object.h>
+#include <unwindstack/PeCoffInterface.h>
+#include <unwindstack/Regs.h>
+
+#include "Check.h"
+
+namespace unwindstack {
+
+PeCoffInterface* PeCoff::CreateInterfaceFromMemory(Memory* memory) {
+  int64_t unused_load_bias;
+
+  PeCoffInterface32 interface32(memory);
+  if (interface32.Init(&unused_load_bias)) {
+    arch_ = ARCH_X86;
+    return new PeCoffInterface32(memory);
+  }
+
+  PeCoffInterface64 interface64(memory);
+  if (interface64.Init(&unused_load_bias)) {
+    arch_ = ARCH_X86_64;
+    return new PeCoffInterface64(memory);
+  }
+
+  return nullptr;
+}
+
+bool PeCoff::Init() {
+  load_bias_ = 0;
+  if (!memory_) {
+    return false;
+  }
+
+  interface_.reset(CreateInterfaceFromMemory(memory_.get()));
+  if (!interface_) {
+    return false;
+  }
+
+  valid_ = interface_->Init(&load_bias_);
+
+  if (!valid_) {
+    interface_.reset(nullptr);
+  }
+  return valid_;
+}
+
+void PeCoff::Invalidate() {
+  interface_.reset(nullptr);
+  valid_ = false;
+}
+
+std::string PeCoff::GetBuildID() {
+  // Not implemented, don't use.
+  CHECK(false);
+  return "";
+}
+
+std::string PeCoff::GetSoname() {
+  // Not implemented, don't use.
+  CHECK(false);
+  return "";
+}
+
+bool PeCoff::GetFunctionName(uint64_t, SharedString*, uint64_t*) {
+  // Not implemented, don't use.
+  CHECK(false);
+  return false;
+}
+
+bool PeCoff::GetGlobalVariableOffset(const std::string&, uint64_t*) {
+  // Not implemented, don't use.
+  CHECK(false);
+  return false;
+}
+
+uint64_t PeCoff::GetRelPc(uint64_t pc, MapInfo* map_info) {
+  if (!valid_) {
+    return 0;
+  }
+  return interface_->GetRelPc(pc, map_info->start());
+}
+
+bool PeCoff::StepIfSignalHandler(uint64_t, Regs*, Memory*) {
+  return false;
+}
+
+bool PeCoff::Step(uint64_t rel_pc, Regs* regs, Memory* process_memory, bool* finished,
+                  bool* is_signal_frame) {
+  // Lock during the step which can update information in the object.
+  std::lock_guard<std::mutex> guard(lock_);
+  return interface_->Step(rel_pc, regs, process_memory, finished, is_signal_frame);
+}
+
+void PeCoff::GetLastError(ErrorData* data) {
+  if (valid_) {
+    *data = interface_->last_error();
+  } else {
+    data->code = ERROR_INVALID_COFF;
+    data->address = 0;
+  }
+}
+
+ErrorCode PeCoff::GetLastErrorCode() {
+  if (valid_) {
+    return interface_->LastErrorCode();
+  }
+  return ERROR_INVALID_COFF;
+}
+
+uint64_t PeCoff::GetLastErrorAddress() {
+  if (valid_) {
+    return interface_->LastErrorAddress();
+  }
+  return 0;
+}
+
+}  // namespace unwindstack

--- a/third_party/libunwindstack/include/unwindstack/DwarfSection.h
+++ b/third_party/libunwindstack/include/unwindstack/DwarfSection.h
@@ -107,7 +107,8 @@ class DwarfSection {
 
   virtual uint64_t AdjustPcFromFde(uint64_t pc) = 0;
 
-  bool Step(uint64_t pc, Regs* regs, Memory* process_memory, bool* finished, bool* is_signal_frame);
+  virtual bool Step(uint64_t pc, Regs* regs, Memory* process_memory, bool* finished,
+                    bool* is_signal_frame);
 
  protected:
   DwarfMemory memory_;

--- a/third_party/libunwindstack/include/unwindstack/PeCoff.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoff.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBUNWINDSTACK_PE_COFF_H
+#define _LIBUNWINDSTACK_PE_COFF_H
+
+#include <string>
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#include <unwindstack/Arch.h>
+#include <unwindstack/Error.h>
+#include <unwindstack/Object.h>
+#include <unwindstack/PeCoffInterface.h>
+#include <unwindstack/SharedString.h>
+
+namespace unwindstack {
+
+class MapInfo;
+class Regs;
+class Memory;
+struct ErrorData;
+
+class PeCoff : public Object {
+ public:
+  explicit PeCoff(Memory* memory) : memory_(memory) {}
+  virtual ~PeCoff() = default;
+
+  bool Init() override;
+  bool valid() override { return valid_; }
+  void Invalidate() override;
+
+  int64_t GetLoadBias() override { return load_bias_; };
+
+  std::string GetBuildID() override;
+  std::string GetSoname() override;
+  bool GetFunctionName(uint64_t, SharedString*, uint64_t*) override;
+  bool GetGlobalVariableOffset(const std::string&, uint64_t*) override;
+
+  ArchEnum arch() override { return arch_; }
+
+  uint64_t GetRelPc(uint64_t pc, MapInfo* map_info) override;
+
+  bool StepIfSignalHandler(uint64_t rel_pc, Regs* regs, Memory* process_memory) override;
+  bool Step(uint64_t rel_pc, Regs* regs, Memory* process_memory, bool* finished,
+            bool* is_signal_frame) override;
+
+  Memory* memory() override { return memory_.get(); }
+
+  void GetLastError(ErrorData* data) override;
+  ErrorCode GetLastErrorCode() override;
+  uint64_t GetLastErrorAddress() override;
+
+ protected:
+  PeCoffInterface* CreateInterfaceFromMemory(Memory* memory);
+
+  bool valid_ = false;
+  int64_t load_bias_ = 0;
+  std::unique_ptr<PeCoffInterface> interface_;
+  std::unique_ptr<Memory> memory_;
+
+  ArchEnum arch_;
+
+  // Protect calls that can modify internal state of the interface object.
+  std::mutex lock_;
+};
+
+}  // namespace unwindstack
+
+#endif  // _LIBUNWINDSTACK_OBJECT_H

--- a/third_party/libunwindstack/tests/PeCoffFake.cpp
+++ b/third_party/libunwindstack/tests/PeCoffFake.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PeCoffFake.h"
+
+#include <memory>
+#include <vector>
+
+#include <unwindstack/PeCoffInterface.h>
+
+namespace unwindstack {
+
+// Needed for static_asserts that depend on the template parameter. Just a
+// plain `false` in the static_assert will cause compilation to fail.
+template <class>
+inline constexpr bool kDependentFalse = false;
+
+template <typename PeCoffInterfaceType>
+void PeCoffFake<PeCoffInterfaceType>::Init() {
+  memory_->Clear();
+  uint64_t offset = SetDosHeader(0x1000);
+  offset = SetNewHeaderAtOffset(offset);
+  offset = SetCoffHeaderAtOffset(offset);
+  offset = SetOptionalHeaderAtOffset(offset);
+  offset = SetSectionHeadersAtOffset(offset);
+
+  SetDebugFrameSectionAtOffset(kDebugFrameSectionFileOffset);
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::InitNoSectionHeaders() {
+  CHECK(memory_);
+  memory_->Clear();
+  uint64_t offset = SetDosHeader(0x1000);
+  offset = SetNewHeaderAtOffset(offset);
+  offset = SetCoffHeaderAtOffset(offset);
+  offset = SetOptionalHeaderAtOffset(offset);
+  return offset;
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetData8(uint64_t offset, uint8_t value) {
+  CHECK(memory_);
+  memory_->SetData8(offset, value);
+  return offset + sizeof(uint8_t);
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetData16(uint64_t offset, uint16_t value) {
+  CHECK(memory_);
+  memory_->SetData16(offset, value);
+  return offset + sizeof(uint16_t);
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetData32(uint64_t offset, uint32_t value) {
+  CHECK(memory_);
+  memory_->SetData32(offset, value);
+  return offset + sizeof(uint32_t);
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetData64(uint64_t offset, uint64_t value) {
+  CHECK(memory_);
+  memory_->SetData64(offset, value);
+  return offset + sizeof(uint64_t);
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetMax64(uint64_t offset, uint64_t value, uint64_t size) {
+  switch (size) {
+    case 1:
+      return SetData8(offset, static_cast<uint8_t>(value));
+    case 2:
+      return SetData16(offset, static_cast<uint16_t>(value));
+    case 4:
+      return SetData32(offset, static_cast<uint32_t>(value));
+    case 8:
+      return SetData64(offset, value);
+    default:
+      return offset;
+  }
+  return offset;
+}
+
+template <typename PeCoffInterfaceType>
+void PeCoffFake<PeCoffInterfaceType>::SetDosHeaderMagicValue() {
+  // This must be at offset 0.
+  SetData16(0x0, 0x5a4d);
+}
+
+template <typename PeCoffInterfaceType>
+void PeCoffFake<PeCoffInterfaceType>::SetDosHeaderOffsetToNewHeader(uint32_t offset_value) {
+  // This must be at offset 0x3c.
+  CHECK(memory_);
+  memory_->SetMemory(0x3c, &offset_value, sizeof(uint32_t));
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetDosHeader(uint32_t new_header_offset_value) {
+  CHECK(memory_);
+  std::vector<uint8_t> zero_data(kDosHeaderSizeInBytes, 0);
+  memory_->SetMemory(0, zero_data);
+
+  SetDosHeaderMagicValue();
+  SetDosHeaderOffsetToNewHeader(new_header_offset_value);
+  return new_header_offset_value;
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetNewHeaderAtOffset(uint64_t offset) {
+  return SetData32(offset, 0x00004550);
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetCoffHeaderAtOffset(uint64_t offset) {
+  offset = SetData16(offset, 0);  // machine
+
+  // We remember the location of the number of sections here, so we can set it correctly later
+  // when we initialize the sections.
+  coff_header_nsects_offset_ = offset;
+  offset = SetData16(offset, 0);  // nsects
+
+  offset = SetData32(offset, 0);  // modtime
+
+  coff_header_symoff_offset_ = offset;
+  offset = SetData32(offset, 0);  // symoff
+
+  offset = SetData32(offset, 0);  // nsyms
+
+  // We remember the location of the header size (which is actually the size of the optional
+  // header) here so that we can set it correctly later when we know the size of the optional
+  // header (which depends on target address size and the number of directory entries).
+  optional_header_size_offset_ = offset;
+  offset = SetData16(offset, 0);  // hdrsize, to be set correctly later
+
+  offset = SetData16(offset, 0);  // flags
+  return offset;
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetOptionalHeaderMagicPE32AtOffset(uint64_t offset) {
+  constexpr uint16_t kOptionalHeaderMagicPE32 = 0x010b;
+  return SetData16(offset, kOptionalHeaderMagicPE32);
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetOptionalHeaderMagicPE32PlusAtOffset(uint64_t offset) {
+  constexpr uint16_t kOptionalHeaderMagicPE32Plus = 0x020b;
+  return SetData16(offset, kOptionalHeaderMagicPE32Plus);
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetOptionalHeaderAtOffset(uint64_t offset) {
+  optional_header_start_offset_ = offset;
+
+  if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 4) {
+    offset = SetOptionalHeaderMagicPE32AtOffset(offset);
+  } else if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 8) {
+    offset = SetOptionalHeaderMagicPE32PlusAtOffset(offset);
+  } else {
+    static_assert(kDependentFalse<PeCoffInterfaceType>, "AddressType size must be 4 or 8 bytes");
+  }
+  offset = SetData8(offset, 0);   // major_linker_version
+  offset = SetData8(offset, 0);   // minor_linker_version
+  offset = SetData32(offset, 0);  // code_size
+  offset = SetData32(offset, 0);  // data_size
+  offset = SetData32(offset, 0);  // bss_size
+  offset = SetData32(offset, 0);  // entry
+  offset = SetData32(offset, 0);  // code_offset
+
+  if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 4) {
+    // Data offset only exists in 32-bit PE/COFF.
+    offset = SetData32(offset, 0);
+  }
+
+  // image_base
+  offset = SetMax64(offset, kLoadBiasFake, sizeof(typename PeCoffInterfaceType::AddressType));
+
+  offset = SetData32(offset, 0x1000);  // sect_alignment
+  offset = SetData32(offset, 0x200);   // file_alignment
+  offset = SetData16(offset, 0);       // major_os_system_version
+  offset = SetData16(offset, 0);       // minor_os_system_version
+  offset = SetData16(offset, 0);       // major_image_version
+  offset = SetData16(offset, 0);       // minor_image_version
+  offset = SetData16(offset, 0);       // major_subsystem_version
+  offset = SetData16(offset, 0);       // minor_subsystem_version
+  offset = SetData32(offset, 0);       // reserved1
+  offset = SetData32(offset, 0);       // image_size
+  offset = SetData32(offset, 0);       // header_size
+  offset = SetData32(offset, 0);       // checksum
+  offset = SetData16(offset, 0);       // subsystem
+  offset = SetData16(offset, 0);       // dll_flags
+
+  // stack_reserve_size
+  offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));
+  // stack_commit_size
+  offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));
+  // heap_reserve_size
+  offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));
+  // heap_commit_size
+  offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));
+
+  offset = SetData32(offset, 0);  // loader_flags
+
+  optional_header_num_data_dirs_offset_ = offset;
+  constexpr uint32_t kNumDirDataEntries = 10;
+  offset = SetData32(offset, kNumDirDataEntries);  // num_dir_data_entries
+
+  for (uint32_t i = 0; i < kNumDirDataEntries; ++i) {
+    offset = SetData32(offset, 0);
+    offset = SetData32(offset, 0);
+  }
+
+  SetData16(optional_header_size_offset_, offset - optional_header_start_offset_);
+
+  return offset;
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetSectionHeaderAtOffset(uint64_t offset,
+                                                                   std::string section_name,
+                                                                   uint64_t vmsize, uint64_t vmaddr,
+                                                                   uint64_t size,
+                                                                   uint64_t file_offset) {
+  CHECK(memory_);
+  std::string name_in_header = section_name;
+  if (section_name.size() > kSectionNameInHeaderSize) {
+    const uint64_t previous_offset =
+        section_names_in_string_table_.empty() ? 0 : section_names_in_string_table_.back().first;
+    const uint64_t previous_size = section_names_in_string_table_.empty()
+                                       ? 0
+                                       // The +1 is for null-termination of the string when written
+                                       // to the string table in the fake file.
+                                       : (section_names_in_string_table_.back().second.size() + 1);
+    const uint64_t current_offset = previous_offset + previous_size;
+    name_in_header = std::string("/") + std::to_string(current_offset);
+    section_names_in_string_table_.emplace_back(current_offset, section_name);
+  }
+
+  std::vector<uint8_t> zeros(kSectionNameInHeaderSize, 0);
+  memory_->SetMemory(offset, zeros.data(), zeros.size());
+  memory_->SetMemory(offset, name_in_header);
+  offset += kSectionNameInHeaderSize;
+  offset = SetData32(offset, vmsize);
+  offset = SetData32(offset, vmaddr);
+  offset = SetData32(offset, size);
+  offset = SetData32(offset, file_offset);
+  offset = SetData32(offset, 0);  // reloff
+  offset = SetData32(offset, 0);  // lineoff
+  offset = SetData16(offset, 0);  // nrel
+  offset = SetData16(offset, 0);  // nline
+  offset = SetData32(offset, 0);  // flagsd
+  return offset;
+};
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetSectionStringsAtOffset(uint64_t offset) {
+  CHECK(memory_);
+  const uint64_t string_table_base_offset = offset;
+  for (const auto& [string_table_offset, name] : section_names_in_string_table_) {
+    memory_->SetMemory(string_table_base_offset + string_table_offset, name);
+
+    // Strings written to memory are null-terminated, so we need to add "1" to the size.
+    offset += name.size() + 1;
+  }
+  return offset;
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetSectionHeadersAtOffset(uint64_t offset) {
+  // Shorter than kSectionNameInHeaderSize (== 8) characters
+  offset = SetSectionHeaderAtOffset(offset, ".text", 0, kTextSectionOffsetFake, 0, 0);
+  // Longer than kSectionNameInHeaderSize (== 8) characters
+  offset = SetSectionHeaderAtOffset(offset, ".debug_frame", kDebugFrameSectionSize,
+                                    kDebugFrameSectionFileOffset, kDebugFrameSectionSize,
+                                    kDebugFrameSectionFileOffset);
+  SetData16(coff_header_nsects_offset_, 2);
+
+  CHECK(offset <= std::numeric_limits<uint32_t>::max());
+  const uint32_t actual_symoff = static_cast<uint32_t>(offset);
+  SetData32(coff_header_symoff_offset_, actual_symoff);
+
+  offset = SetSectionStringsAtOffset(offset);
+
+  return offset;
+}
+
+template <typename PeCoffInterfaceType>
+uint64_t PeCoffFake<PeCoffInterfaceType>::SetDebugFrameSectionAtOffset(uint64_t offset) {
+  CHECK(memory_);
+  uint64_t initial_offset = offset;
+  // CIE 32
+  offset = SetData32(offset, 0xfc);        // length
+  offset = SetData32(offset, 0xffffffff);  // CIE_id
+  memory_->SetMemory(offset, std::vector<uint8_t>{1, '\0', 0, 0, 1});
+
+  // FDE 32
+  offset = initial_offset + 0x100;
+  offset = SetData32(offset, 0xfc);
+  offset = SetData32(offset, 0);
+  offset = SetData32(offset, 0x2100);
+  offset = SetData32(offset, 0x400);
+  return offset;
+}
+
+// Instantiate all of the needed template functions.
+template class PeCoffFake<PeCoffInterface32>;
+template class PeCoffFake<PeCoffInterface64>;
+
+}  // namespace unwindstack

--- a/third_party/libunwindstack/tests/PeCoffFake.h
+++ b/third_party/libunwindstack/tests/PeCoffFake.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBUNWINDSTACK_PE_COFF_FAKE_H
+#define _LIBUNWINDSTACK_PE_COFF_FAKE_H
+
+#include <MemoryBuffer.h>
+#include "utils/MemoryFake.h"
+
+#include <android-base/file.h>
+#include "Check.h"
+
+namespace unwindstack {
+
+template <typename PeCoffInterfaceType>
+class PeCoffFake {
+ public:
+  static constexpr size_t kDosHeaderSizeInBytes = 0x40;
+  static constexpr uint64_t kDebugFrameSectionFileOffset = 0x2000;
+  static constexpr uint64_t kDebugFrameSectionSize = 0x200;
+  static constexpr int64_t kLoadBiasFake = 0x3100;
+  static constexpr uint64_t kTextSectionOffsetFake = 0x200;
+
+  PeCoffFake() : memory_(new MemoryFake) {}
+  ~PeCoffFake() = default;
+  MemoryFake* GetMemoryFake() { return memory_.get(); }
+
+  // Some tests require to take ownership over the memory object. Calls to set anything
+  // on the memory, which will then be a nullptr, will segfault.
+  MemoryFake* ReleaseMemoryFake() { return memory_.release(); };
+
+  void Init();
+
+  // Returns the offset where the section *would* go, so tests can add data there as desired.
+  uint64_t InitNoSectionHeaders();
+  uint64_t SetSectionHeaderAtOffset(uint64_t offset, std::string section_name, uint64_t vmsize = 0,
+                                    uint64_t vmaddr = 0, uint64_t size = 0,
+                                    uint64_t file_offset = 0);
+
+  uint64_t coff_header_nsects_offset() const { return coff_header_nsects_offset_; };
+  uint64_t coff_header_symoff_offset() const { return coff_header_symoff_offset_; };
+  uint64_t optional_header_size_offset() const { return optional_header_size_offset_; };
+  uint64_t optional_header_start_offset() const { return optional_header_start_offset_; };
+  uint64_t optional_header_num_data_dirs_offset() const {
+    return optional_header_num_data_dirs_offset_;
+  };
+  uint64_t executable_section_offset() const { return executable_section_offset_; };
+
+ private:
+  uint64_t coff_header_nsects_offset_;
+  uint64_t coff_header_symoff_offset_;
+  uint64_t optional_header_size_offset_;
+  uint64_t optional_header_start_offset_;
+  uint64_t optional_header_num_data_dirs_offset_;
+  uint64_t executable_section_offset_;
+  std::unique_ptr<MemoryFake> memory_;
+
+  uint64_t InitPeCoffInterfaceFakeNoSectionHeaders();
+  uint64_t SetData8(uint64_t offset, uint8_t value);
+  uint64_t SetData16(uint64_t offset, uint16_t value);
+  uint64_t SetData32(uint64_t offset, uint32_t value);
+  uint64_t SetData64(uint64_t offset, uint64_t value);
+  uint64_t SetMax64(uint64_t offset, uint64_t value, uint64_t size);
+  void SetDosHeaderMagicValue();
+  void SetDosHeaderOffsetToNewHeader(uint32_t offset_value);
+  uint64_t SetDosHeader(uint32_t new_header_offset_value);
+  uint64_t SetNewHeaderAtOffset(uint64_t offset);
+  uint64_t SetCoffHeaderAtOffset(uint64_t offset);
+  uint64_t SetOptionalHeaderMagicPE32AtOffset(uint64_t offset);
+  uint64_t SetOptionalHeaderMagicPE32PlusAtOffset(uint64_t offset);
+  uint64_t SetOptionalHeaderAtOffset(uint64_t offset);
+  uint64_t SetSectionStringsAtOffset(uint64_t offset);
+  uint64_t SetSectionHeadersAtOffset(uint64_t offset);
+  uint64_t SetDebugFrameSectionAtOffset(uint64_t offset);
+
+  std::unique_ptr<MemoryFake> memory_fake_;
+  std::vector<std::pair<uint64_t, std::string>> section_names_in_string_table_;
+};
+
+}  // namespace unwindstack
+
+#endif  // _LIBUNWINDSTACK_PE_COFF_FAKE_H

--- a/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
@@ -19,8 +19,7 @@
 #include <cstring>
 #include <limits>
 
-#include <android-base/file.h>
-
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <Check.h>
@@ -29,12 +28,23 @@
 
 #include <unwindstack/Log.h>
 
+#include "DwarfDebugFrame.h"
+#include "PeCoffFake.h"
+
 namespace unwindstack {
 
-constexpr size_t kDosHeaderSizeInBytes = 0x40;
-constexpr uint64_t kDebugFrameSectionFileOffset = 0x2000;
-constexpr uint64_t kDebugFrameSectionSize = 0x200;
-constexpr int64_t kLoadBiasFake = 0x3100;
+template <typename PeCoffInterfaceType>
+class PeCoffInterfaceTest : public ::testing::Test {
+ public:
+  PeCoffInterfaceTest() : fake_(new PeCoffFake<PeCoffInterfaceType>) {}
+  ~PeCoffInterfaceTest() {}
+
+  PeCoffFake<PeCoffInterfaceType>* GetFake() { return fake_.get(); }
+  MemoryFake* GetMemory() { return fake_->GetMemoryFake(); }
+
+ private:
+  std::unique_ptr<PeCoffFake<PeCoffInterfaceType>> fake_;
+};
 
 // Needed for static_asserts that depend on the template parameter. Just a
 // plain `false` in the static_assert will cause compilation to fail.
@@ -42,10 +52,10 @@ template <class>
 inline constexpr bool kDependentFalse = false;
 
 template <typename PeCoffInterfaceType>
-class PeCoffInterfaceTest : public ::testing::Test {
+class PeCoffInterfaceFileTest : public ::testing::Test {
  public:
-  PeCoffInterfaceTest() : memory_(nullptr) {}
-  ~PeCoffInterfaceTest() {}
+  PeCoffInterfaceFileTest() : memory_(nullptr) {}
+  ~PeCoffInterfaceFileTest() {}
 
   static std::unique_ptr<MemoryBuffer> ReadFile(const char* filename) {
     std::string dir = android::base::GetExecutableDirectory() + "/tests/files/";
@@ -58,494 +68,238 @@ class PeCoffInterfaceTest : public ::testing::Test {
     return memory;
   }
 
-  void InitPeCoffInterfaceFromFile() {
+  void Init() {
     if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 8) {
       memory_ = ReadFile("libtest.dll");
-      expected_load_bias_in_file_ = 0x62640000;
+      expected_load_bias_ = 0x62640000;
     } else if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 4) {
       memory_ = ReadFile("libtest32.dll");
-      expected_load_bias_in_file_ = 0x67b40000;
+      expected_load_bias_ = 0x67b40000;
     } else {
       static_assert(kDependentFalse<PeCoffInterfaceType>, "AddressType size must be 4 or 8 bytes");
     }
   }
+  Memory* GetMemory() { return memory_.get(); };
+  int64_t expected_load_bias() { return expected_load_bias_; }
 
-  void InitPeCoffInterfaceFake() {
-    memory_fake_.Clear();
-    uint64_t offset = SetDosHeader(0x1000);
-    offset = SetNewHeaderAtOffset(offset);
-    offset = SetCoffHeaderAtOffset(offset);
-    offset = SetOptionalHeaderAtOffset(offset);
-    offset = SetSectionHeadersAtOffset(offset);
-
-    SetDebugFrameSectionAtOffset(kDebugFrameSectionFileOffset);
-  }
-
-  uint64_t InitPeCoffInterfaceFakeNoSectionHeaders() {
-    memory_fake_.Clear();
-    uint64_t offset = SetDosHeader(0x1000);
-    offset = SetNewHeaderAtOffset(offset);
-    offset = SetCoffHeaderAtOffset(offset);
-    offset = SetOptionalHeaderAtOffset(offset);
-    return offset;
-  }
-
-  uint64_t SetData8(uint64_t offset, uint8_t value) {
-    memory_fake_.SetData8(offset, value);
-    return offset + sizeof(uint8_t);
-  }
-  uint64_t SetData16(uint64_t offset, uint16_t value) {
-    memory_fake_.SetData16(offset, value);
-    return offset + sizeof(uint16_t);
-  }
-  uint64_t SetData32(uint64_t offset, uint32_t value) {
-    memory_fake_.SetData32(offset, value);
-    return offset + sizeof(uint32_t);
-  }
-  uint64_t SetData64(uint64_t offset, uint64_t value) {
-    memory_fake_.SetData64(offset, value);
-    return offset + sizeof(uint64_t);
-  }
-
-  uint64_t SetMax64(uint64_t offset, uint64_t value, uint64_t size) {
-    switch (size) {
-      case 1:
-        return SetData8(offset, static_cast<uint8_t>(value));
-      case 2:
-        return SetData16(offset, static_cast<uint16_t>(value));
-      case 4:
-        return SetData32(offset, static_cast<uint32_t>(value));
-      case 8:
-        return SetData64(offset, value);
-      default:
-        return offset;
-    }
-    return offset;
-  }
-
-  void SetDosHeaderMagicValue() {
-    // This must be at offset 0.
-    SetData16(0x0, 0x5a4d);
-  }
-
-  void SetDosHeaderOffsetToNewHeader(uint32_t offset_value) {
-    // This must be at offset 0x3c.
-    memory_fake_.SetMemory(0x3c, &offset_value, sizeof(uint32_t));
-  }
-
-  uint64_t SetDosHeader(uint32_t new_header_offset_value) {
-    std::vector<uint8_t> zero_data(kDosHeaderSizeInBytes, 0);
-    memory_fake_.SetMemory(0, zero_data);
-
-    SetDosHeaderMagicValue();
-    SetDosHeaderOffsetToNewHeader(new_header_offset_value);
-    return new_header_offset_value;
-  }
-
-  uint64_t SetNewHeaderAtOffset(uint64_t offset) { return SetData32(offset, 0x00004550); }
-
-  uint64_t SetCoffHeaderAtOffset(uint64_t offset) {
-    offset = SetData16(offset, 0);  // machine
-
-    // We remember the location of the number of sections here, so we can set it correctly later
-    // when we initialize the sections.
-    coff_header_nsects_offset_ = offset;
-    offset = SetData16(offset, 0);  // nsects
-
-    offset = SetData32(offset, 0);  // modtime
-
-    coff_header_symoff_offset_ = offset;
-    offset = SetData32(offset, 0);  // symoff
-
-    offset = SetData32(offset, 0);  // nsyms
-
-    // We remember the location of the header size (which is actually the size of the optional
-    // header) here so that we can set it correctly later when we know the size of the optional
-    // header (which depends on target address size and the number of directory entries).
-    optional_header_size_offset_ = offset;
-    offset = SetData16(offset, 0);  // hdrsize, to be set correctly later
-
-    offset = SetData16(offset, 0);  // flags
-    return offset;
-  }
-
-  uint64_t SetOptionalHeaderMagicPE32AtOffset(uint64_t offset) {
-    constexpr uint16_t kOptionalHeaderMagicPE32 = 0x010b;
-    return SetData16(offset, kOptionalHeaderMagicPE32);
-  }
-
-  uint64_t SetOptionalHeaderMagicPE32PlusAtOffset(uint64_t offset) {
-    constexpr uint16_t kOptionalHeaderMagicPE32Plus = 0x020b;
-    return SetData16(offset, kOptionalHeaderMagicPE32Plus);
-  }
-
-  uint64_t SetOptionalHeaderAtOffset(uint64_t offset) {
-    optional_header_start_offset_ = offset;
-
-    if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 4) {
-      offset = SetOptionalHeaderMagicPE32AtOffset(offset);
-    } else if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 8) {
-      offset = SetOptionalHeaderMagicPE32PlusAtOffset(offset);
-    } else {
-      static_assert(kDependentFalse<PeCoffInterfaceType>, "AddressType size must be 4 or 8 bytes");
-    }
-    offset = SetData8(offset, 0);   // major_linker_version
-    offset = SetData8(offset, 0);   // minor_linker_version
-    offset = SetData32(offset, 0);  // code_size
-    offset = SetData32(offset, 0);  // data_size
-    offset = SetData32(offset, 0);  // bss_size
-    offset = SetData32(offset, 0);  // entry
-    offset = SetData32(offset, 0);  // code_offset
-
-    if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 4) {
-      // Data offset only exists in 32-bit PE/COFF.
-      offset = SetData32(offset, 0);
-    }
-
-    // image_base
-    offset = SetMax64(offset, kLoadBiasFake, sizeof(typename PeCoffInterfaceType::AddressType));
-
-    offset = SetData32(offset, 0x1000);  // sect_alignment
-    offset = SetData32(offset, 0x200);   // file_alignment
-    offset = SetData16(offset, 0);       // major_os_system_version
-    offset = SetData16(offset, 0);       // minor_os_system_version
-    offset = SetData16(offset, 0);       // major_image_version
-    offset = SetData16(offset, 0);       // minor_image_version
-    offset = SetData16(offset, 0);       // major_subsystem_version
-    offset = SetData16(offset, 0);       // minor_subsystem_version
-    offset = SetData32(offset, 0);       // reserved1
-    offset = SetData32(offset, 0);       // image_size
-    offset = SetData32(offset, 0);       // header_size
-    offset = SetData32(offset, 0);       // checksum
-    offset = SetData16(offset, 0);       // subsystem
-    offset = SetData16(offset, 0);       // dll_flags
-
-    // stack_reserve_size
-    offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));
-    // stack_commit_size
-    offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));
-    // heap_reserve_size
-    offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));
-    // heap_commit_size
-    offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));
-
-    offset = SetData32(offset, 0);  // loader_flags
-
-    optional_header_num_data_dirs_offset_ = offset;
-    constexpr uint32_t kNumDirDataEntries = 10;
-    offset = SetData32(offset, kNumDirDataEntries);  // num_dir_data_entries
-
-    for (uint32_t i = 0; i < kNumDirDataEntries; ++i) {
-      offset = SetData32(offset, 0);
-      offset = SetData32(offset, 0);
-    }
-
-    SetData16(optional_header_size_offset_, offset - optional_header_start_offset_);
-
-    return offset;
-  }
-
-  uint64_t SetSectionHeaderAtOffset(uint64_t offset, std::string section_name, uint64_t vmsize = 0,
-                                    uint64_t vmaddr = 0, uint64_t size = 0,
-                                    uint64_t file_offset = 0) {
-    std::string name_in_header = section_name;
-    if (section_name.size() > kSectionNameInHeaderSize) {
-      const uint64_t previous_offset =
-          section_names_in_string_table_.empty() ? 0 : section_names_in_string_table_.back().first;
-      const uint64_t previous_size = section_names_in_string_table_.empty()
-                                         ? 0
-                                         : section_names_in_string_table_.back().second.size() + 1;
-      const uint64_t current_offset = previous_offset + previous_size;
-      name_in_header = std::string("/") + std::to_string(current_offset);
-      section_names_in_string_table_.emplace_back(current_offset, section_name);
-    }
-
-    std::vector<uint8_t> zeros(kSectionNameInHeaderSize, 0);
-    memory_fake_.SetMemory(offset, zeros.data(), zeros.size());
-    memory_fake_.SetMemory(offset, name_in_header);
-    offset += kSectionNameInHeaderSize;
-    offset = SetData32(offset, vmsize);
-    offset = SetData32(offset, vmaddr);
-    offset = SetData32(offset, size);
-    offset = SetData32(offset, file_offset);
-    offset = SetData32(offset, 0);  // reloff
-    offset = SetData32(offset, 0);  // lineoff
-    offset = SetData16(offset, 0);  // nrel
-    offset = SetData16(offset, 0);  // nline
-    offset = SetData32(offset, 0);  // flagsd
-    return offset;
-  };
-
-  uint64_t SetSectionStringsAtOffset(uint64_t offset) {
-    const uint64_t string_table_base_offset = offset;
-    for (const auto& [string_table_offset, name] : section_names_in_string_table_) {
-      memory_fake_.SetMemory(string_table_base_offset + string_table_offset, name);
-
-      // Strings written to memory are null-terminated, so we need to add "1" to the size.
-      offset += name.size() + 1;
-    }
-    return offset;
-  }
-
-  uint64_t SetSectionHeadersAtOffset(uint64_t offset) {
-    // Shorter than kSectionNameInHeaderSize (== 8) characters
-    offset = SetSectionHeaderAtOffset(offset, ".text", 0, 0, 0, 0);
-    // Longer than kSectionNameInHeaderSize (== 8) characters
-    offset = SetSectionHeaderAtOffset(offset, ".debug_frame", kDebugFrameSectionSize,
-                                      kDebugFrameSectionFileOffset, kDebugFrameSectionSize,
-                                      kDebugFrameSectionFileOffset);
-    SetData16(coff_header_nsects_offset_, 2);
-
-    CHECK(offset <= std::numeric_limits<uint32_t>::max());
-    const uint32_t actual_symoff = static_cast<uint32_t>(offset);
-    SetData32(coff_header_symoff_offset_, actual_symoff);
-
-    offset = SetSectionStringsAtOffset(offset);
-
-    return offset;
-  }
-
-  uint64_t SetDebugFrameSectionAtOffset(uint64_t offset) {
-    uint64_t initial_offset = offset;
-    // CIE 32
-    offset = SetData32(offset, 0xfc);        // length
-    offset = SetData32(offset, 0xffffffff);  // CIE_id
-    memory_fake_.SetMemory(offset, std::vector<uint8_t>{1, '\0', 0, 0, 1});
-
-    // FDE 32
-    offset = initial_offset + 0x100;
-    offset = SetData32(offset, 0xfc);
-    offset = SetData32(offset, 0);
-    offset = SetData32(offset, 0x2100);
-    offset = SetData32(offset, 0x400);
-    return offset;
-  }
-
+ private:
   std::unique_ptr<Memory> memory_;
-  MemoryFake memory_fake_;
-
-  uint64_t coff_header_nsects_offset_;
-  uint64_t coff_header_symoff_offset_;
-
-  uint64_t optional_header_size_offset_;
-  uint64_t optional_header_start_offset_;
-
-  uint64_t optional_header_num_data_dirs_offset_;
-
-  int64_t expected_load_bias_in_file_;
-
-  std::vector<std::pair<uint64_t, std::string>> section_names_in_string_table_;
+  int64_t expected_load_bias_;
 };
 
 // Many tests equally apply to the 32-bit and the 64-bit case, so we implement these
 // as TYPED_TESTs.
 typedef ::testing::Types<PeCoffInterface32, PeCoffInterface64> Implementations;
+TYPED_TEST_SUITE(PeCoffInterfaceFileTest, Implementations);
 TYPED_TEST_SUITE(PeCoffInterfaceTest, Implementations);
 
-TYPED_TEST(PeCoffInterfaceTest, init_for_coff_file) {
-  this->InitPeCoffInterfaceFromFile();
-  TypeParam coff(this->memory_.get());
+TYPED_TEST(PeCoffInterfaceFileTest, init_for_coff_file) {
+  this->Init();
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_TRUE(coff.Init(&load_bias));
-  EXPECT_EQ(load_bias, this->expected_load_bias_in_file_);
+  EXPECT_EQ(load_bias, this->expected_load_bias());
 }
 
 TYPED_TEST(PeCoffInterfaceTest, init_for_coff_file_fake) {
-  this->InitPeCoffInterfaceFake();
-  TypeParam coff(&this->memory_fake_);
+  this->GetFake()->Init();
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_TRUE(coff.Init(&load_bias));
-  EXPECT_EQ(load_bias, kLoadBiasFake);
+  EXPECT_EQ(load_bias, PeCoffFake<TypeParam>::kLoadBiasFake);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, dos_header_parsing_fails_empty_memory) {
-  TypeParam coff(&this->memory_fake_);
+  MemoryFake empty;
+  TypeParam coff(&empty);
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, dos_header_parsing_fails_invalid_memory_at_unused_data) {
-  this->InitPeCoffInterfaceFake();
-  this->memory_fake_.ClearMemory(0x30, 1);
-  TypeParam coff(&this->memory_fake_);
+  this->GetFake()->Init();
+  this->GetMemory()->ClearMemory(0x30, 1);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, dos_header_parsing_fails_invalid_memory_at_new_header_offset) {
-  this->InitPeCoffInterfaceFake();
-  this->memory_fake_.ClearMemory(0x3c, 1);
-  TypeParam coff(&this->memory_fake_);
+  this->GetFake()->Init();
+  this->GetMemory()->ClearMemory(0x3c, 1);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, dos_header_parsing_fails_wrong_magic_number) {
-  this->InitPeCoffInterfaceFake();
+  this->GetFake()->Init();
   // Correct magic number is 0x5a4d
-  this->memory_fake_.SetData16(0, 0x5a4c);
-  TypeParam coff(&this->memory_fake_);
+  this->GetMemory()->SetData16(0, 0x5a4c);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_INVALID_COFF, coff.LastError().code);
+  EXPECT_EQ(ERROR_INVALID_COFF, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, new_header_parsing_fails_invalid_memory) {
-  this->InitPeCoffInterfaceFake();
-  this->memory_fake_.ClearMemory(0x1000, 1);
-  TypeParam coff(&this->memory_fake_);
+  this->GetFake()->Init();
+  this->GetMemory()->ClearMemory(0x1000, 1);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, new_header_parsing_fails_wrong_pe_signature) {
-  this->InitPeCoffInterfaceFake();
+  this->GetFake()->Init();
   // Correct PE signature is 0x00004550
-  this->SetData32(0x1000, 0x00004551);
-  TypeParam coff(&this->memory_fake_);
+  this->GetMemory()->SetData32(0x1000, 0x00004551);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_INVALID_COFF, coff.LastError().code);
+  EXPECT_EQ(ERROR_INVALID_COFF, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, coff_header_parsing_fails_invalid_memory) {
-  this->InitPeCoffInterfaceFake();
+  this->GetFake()->Init();
   // COFF headers starts 4 bytes after the new header, which we have set at 0x1000.
   constexpr uint16_t kCoffHeaderStart = 0x1004;
-  this->memory_fake_.ClearMemory(kCoffHeaderStart, 1);
-  TypeParam coff(&this->memory_fake_);
+  this->GetMemory()->ClearMemory(kCoffHeaderStart, 1);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, optional_header_parsing_fails_wrong_magic_number) {
-  this->InitPeCoffInterfaceFake();
+  this->GetFake()->Init();
   // 0x010b would be a correct choice
-  this->SetData16(this->optional_header_start_offset_, 0x010a);
-  TypeParam coff(&this->memory_fake_);
+  this->GetMemory()->SetData16(this->GetFake()->optional_header_start_offset(), 0x010a);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_INVALID_COFF, coff.LastError().code);
+  EXPECT_EQ(ERROR_INVALID_COFF, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, optional_header_parsing_fails_invalid_memory_start) {
-  this->InitPeCoffInterfaceFake();
+  this->GetFake()->Init();
 
-  this->memory_fake_.ClearMemory(this->optional_header_start_offset_, 1);
+  this->GetMemory()->ClearMemory(this->GetFake()->optional_header_start_offset(), 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, optional_header_parsing_fails_invalid_memory_end) {
-  this->InitPeCoffInterfaceFake();
+  this->GetFake()->Init();
 
-  this->memory_fake_.ClearMemory(this->optional_header_start_offset_, 1);
+  this->GetMemory()->ClearMemory(this->GetFake()->optional_header_start_offset(), 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, optional_header_parsing_fails_incorrect_header_size) {
-  this->InitPeCoffInterfaceFake();
+  this->GetFake()->Init();
 
   uint16_t correct_header_size;
-  this->memory_fake_.Read16(this->optional_header_size_offset_, &correct_header_size);
-  this->SetData16(this->optional_header_size_offset_, correct_header_size + 1);
+  this->GetMemory()->Read16(this->GetFake()->optional_header_size_offset(), &correct_header_size);
+  this->GetMemory()->SetData16(this->GetFake()->optional_header_size_offset(),
+                               correct_header_size + 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_INVALID_COFF, coff.LastError().code);
+  EXPECT_EQ(ERROR_INVALID_COFF, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, optional_header_parsing_fails_incorrect_num_data_dir_entries) {
-  this->InitPeCoffInterfaceFake();
+  this->GetFake()->Init();
 
   uint32_t correct_num;
-  this->memory_fake_.Read32(this->optional_header_num_data_dirs_offset_, &correct_num);
-  this->SetData32(this->optional_header_num_data_dirs_offset_, correct_num + 1);
+  this->GetMemory()->Read32(this->GetFake()->optional_header_num_data_dirs_offset(), &correct_num);
+  this->GetMemory()->SetData32(this->GetFake()->optional_header_num_data_dirs_offset(),
+                               correct_num + 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_INVALID_COFF, coff.LastError().code);
+  EXPECT_EQ(ERROR_INVALID_COFF, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, section_headers_parsing_fails_invalid_memory) {
-  this->InitPeCoffInterfaceFakeNoSectionHeaders();
-  this->SetData16(this->coff_header_nsects_offset_, 1);
+  this->GetFake()->InitNoSectionHeaders();
+  this->GetMemory()->SetData16(this->GetFake()->coff_header_nsects_offset(), 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest,
            section_headers_parsing_fails_invalid_memory_middle_of_section_header) {
-  const uint64_t section_headers_offset = this->InitPeCoffInterfaceFakeNoSectionHeaders();
-  this->SetSectionHeaderAtOffset(section_headers_offset, ".text");
-  this->SetData16(this->coff_header_nsects_offset_, 1);
+  const uint64_t section_headers_offset = this->GetFake()->InitNoSectionHeaders();
+  this->GetFake()->SetSectionHeaderAtOffset(section_headers_offset, ".text");
+  this->GetMemory()->SetData16(this->GetFake()->coff_header_nsects_offset(), 1);
   // We want to catch the second failure case, which is after the initial section name string of
   // length kSectionNameInHeaderSize
-  this->memory_fake_.ClearMemory(section_headers_offset + kSectionNameInHeaderSize, 1);
+  this->GetMemory()->ClearMemory(section_headers_offset + kSectionNameInHeaderSize, 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest,
            section_headers_parsing_fails_section_string_name_offset_not_an_integer) {
-  const uint64_t section_headers_offset = this->InitPeCoffInterfaceFakeNoSectionHeaders();
-  this->SetSectionHeaderAtOffset(section_headers_offset, "/abc");
-  this->SetData16(this->coff_header_nsects_offset_, 1);
+  const uint64_t section_headers_offset = this->GetFake()->InitNoSectionHeaders();
+  this->GetFake()->SetSectionHeaderAtOffset(section_headers_offset, "/abc");
+  this->GetMemory()->SetData16(this->GetFake()->coff_header_nsects_offset(), 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_INVALID_COFF, coff.LastError().code);
+  EXPECT_EQ(ERROR_INVALID_COFF, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, section_headers_parsing_fails_missing_string_table) {
-  uint64_t offset = this->InitPeCoffInterfaceFakeNoSectionHeaders();
+  uint64_t offset = this->GetFake()->InitNoSectionHeaders();
   // The "/0" indicates that the section name has to be read at offset 0 in the string table,
   // however for this test, the string table is not set up at all, so it must fail.
-  offset = this->SetSectionHeaderAtOffset(offset, "/0");
-  this->SetData32(this->coff_header_symoff_offset_, offset);
-  this->SetData16(this->coff_header_nsects_offset_, 1);
+  offset = this->GetFake()->SetSectionHeaderAtOffset(offset, "/0");
+  this->GetMemory()->SetData32(this->GetFake()->coff_header_symoff_offset(), offset);
+  this->GetMemory()->SetData16(this->GetFake()->coff_header_nsects_offset(), 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, section_headers_parsing_fails_no_text_section) {
-  uint64_t offset = this->InitPeCoffInterfaceFakeNoSectionHeaders();
-  offset = this->SetSectionHeaderAtOffset(offset, ".no_text");
-  this->SetData16(this->coff_header_nsects_offset_, 1);
+  uint64_t offset = this->GetFake()->InitNoSectionHeaders();
+  offset = this->GetFake()->SetSectionHeaderAtOffset(offset, ".no_text");
+  this->GetMemory()->SetData16(this->GetFake()->coff_header_nsects_offset(), 1);
 
-  TypeParam coff(&this->memory_fake_);
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_INVALID_COFF, coff.LastError().code);
+  EXPECT_EQ(ERROR_INVALID_COFF, coff.last_error().code);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, debug_frame_section_parsed_correctly) {
-  this->InitPeCoffInterfaceFake();
-  TypeParam coff(&this->memory_fake_);
+  this->GetFake()->Init();
+  TypeParam coff(this->GetMemory());
   int64_t load_bias;
   ASSERT_TRUE(coff.Init(&load_bias));
 
@@ -553,6 +307,84 @@ TYPED_TEST(PeCoffInterfaceTest, debug_frame_section_parsed_correctly) {
   ASSERT_NE(dwarf_fde, nullptr);
   EXPECT_EQ(0x2100, dwarf_fde->pc_start);
   EXPECT_EQ(0x2500, dwarf_fde->pc_end);
+}
+
+TYPED_TEST(PeCoffInterfaceTest, get_correct_relative_pc) {
+  this->GetFake()->Init();
+  TypeParam coff(this->GetMemory());
+  int64_t load_bias;
+  ASSERT_TRUE(coff.Init(&load_bias));
+
+  const uint64_t expected_relative_pc = 0x2200 - 0x2000 + PeCoffFake<TypeParam>::kLoadBiasFake +
+                                        PeCoffFake<TypeParam>::kTextSectionOffsetFake;
+  EXPECT_EQ(expected_relative_pc, coff.GetRelPc(0x2200, 0x2000));
+}
+
+TYPED_TEST(PeCoffInterfaceTest, get_zero_as_relative_pc_if_no_text_section) {
+  uint64_t offset = this->GetFake()->InitNoSectionHeaders();
+  offset = this->GetFake()->SetSectionHeaderAtOffset(offset, ".no_text");
+  this->GetMemory()->SetData16(this->GetFake()->coff_header_nsects_offset(), 1);
+
+  TypeParam coff(this->GetMemory());
+  int64_t load_bias;
+  ASSERT_FALSE(coff.Init(&load_bias));
+  EXPECT_EQ(0, coff.GetRelPc(0x2200, 0x2000));
+}
+
+template <typename AddressType>
+class PeCoffInterfaceFake : public PeCoffInterfaceImpl<AddressType> {
+ public:
+  PeCoffInterfaceFake(Memory* memory) : PeCoffInterfaceImpl<AddressType>(memory) {}
+  void SetFakeDebugFrameSection(DwarfSection* debug_frame_section) {
+    this->debug_frame_.reset(debug_frame_section);
+  }
+};
+
+template <typename AddressType>
+class MockDwarfSection : public DwarfDebugFrame<AddressType> {
+ public:
+  MockDwarfSection(Memory* memory) : DwarfDebugFrame<AddressType>(memory) {}
+  virtual ~MockDwarfSection() = default;
+  MOCK_METHOD(bool, Init, (uint64_t, uint64_t, int64_t), (override));
+  MOCK_METHOD(bool, Step, (uint64_t, Regs*, Memory*, bool*, bool*), (override));
+};
+
+TYPED_TEST(PeCoffInterfaceTest, step_succeeds_when_debug_frame_step_succeeds) {
+  this->GetFake()->Init();
+  PeCoffInterfaceFake<typename TypeParam::AddressType> fake_coff(this->GetMemory());
+  int64_t load_bias;
+  ASSERT_TRUE(fake_coff.Init(&load_bias));
+
+  MockDwarfSection<typename TypeParam::AddressType>* mock_debug_frame_section =
+      new MockDwarfSection<typename TypeParam::AddressType>(nullptr);
+  fake_coff.SetFakeDebugFrameSection(mock_debug_frame_section);
+  EXPECT_CALL(*mock_debug_frame_section, Step(0x2000, nullptr, nullptr, nullptr, nullptr))
+      .WillOnce(::testing::Return(true));
+  EXPECT_TRUE(fake_coff.Step(0x2000, nullptr, nullptr, nullptr, nullptr));
+}
+
+TYPED_TEST(PeCoffInterfaceTest, step_fails_when_debug_frame_step_fails) {
+  this->GetFake()->Init();
+  PeCoffInterfaceFake<typename TypeParam::AddressType> fake_coff(this->GetMemory());
+  int64_t load_bias;
+  ASSERT_TRUE(fake_coff.Init(&load_bias));
+
+  MockDwarfSection<typename TypeParam::AddressType>* mock_debug_frame_section =
+      new MockDwarfSection<typename TypeParam::AddressType>(nullptr);
+  fake_coff.SetFakeDebugFrameSection(mock_debug_frame_section);
+  EXPECT_CALL(*mock_debug_frame_section, Step(0x2000, nullptr, nullptr, nullptr, nullptr))
+      .WillOnce(::testing::Return(false));
+  EXPECT_FALSE(fake_coff.Step(0x2000, nullptr, nullptr, nullptr, nullptr));
+}
+
+TYPED_TEST(PeCoffInterfaceTest, step_fails_when_debug_frame_is_nullptr) {
+  this->GetFake()->Init();
+  PeCoffInterfaceFake<typename TypeParam::AddressType> fake_coff(this->GetMemory());
+  int64_t load_bias;
+  ASSERT_TRUE(fake_coff.Init(&load_bias));
+
+  fake_coff.SetFakeDebugFrameSection(nullptr);
+  EXPECT_FALSE(fake_coff.Step(0x2000, nullptr, nullptr, nullptr, nullptr));
 }
 
 // The remaining tests are not TYPED_TESTs, because they are specific to either the 32-bit or 64-bit
@@ -564,74 +396,75 @@ using PeCoffInterface32Test = PeCoffInterfaceTest<PeCoffInterface32>;
 using PeCoffInterface64Test = PeCoffInterfaceTest<PeCoffInterface64>;
 
 TEST_F(PeCoffInterface32Test, init_64_fails_for_coff_32_fake) {
-  InitPeCoffInterfaceFake();
-  PeCoffInterface64 coff(&memory_fake_);
+  GetFake()->Init();
+  PeCoffInterface64 coff(GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_UNSUPPORTED, coff.LastError().code);
+  EXPECT_EQ(ERROR_UNSUPPORTED, coff.last_error().code);
 }
 
 TEST_F(PeCoffInterface64Test, init_32_fails_for_coff_64_fake) {
-  InitPeCoffInterfaceFake();
-  PeCoffInterface32 coff(&memory_fake_);
+  GetFake()->Init();
+  PeCoffInterface32 coff(GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_UNSUPPORTED, coff.LastError().code);
+  EXPECT_EQ(ERROR_UNSUPPORTED, coff.last_error().code);
 }
 
 TEST_F(PeCoffInterface32Test, optional_header_parsing_fails_invalid_memory_at_data_offset_32_only) {
-  InitPeCoffInterfaceFake();
-  const uint64_t kDataOffsetAddress = optional_header_start_offset_ + 0x0018;
-  this->memory_fake_.ClearMemory(kDataOffsetAddress, 1);
+  GetFake()->Init();
+  const uint64_t kDataOffsetAddress = GetFake()->optional_header_start_offset() + 0x0018;
+  this->GetMemory()->ClearMemory(kDataOffsetAddress, 1);
 
-  PeCoffInterface32 coff(&memory_fake_);
+  PeCoffInterface32 coff(GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TEST_F(PeCoffInterface32Test, optional_header_parsing_fails_invalid_memory_end_32) {
-  InitPeCoffInterfaceFake();
-  const uint64_t kAfterDataOffset = optional_header_start_offset_ + 0x0018 + 0x0004;
-  this->memory_fake_.ClearMemory(kAfterDataOffset, 1);
+  GetFake()->Init();
+  const uint64_t kAfterDataOffset = GetFake()->optional_header_start_offset() + 0x0018 + 0x0004;
+  this->GetMemory()->ClearMemory(kAfterDataOffset, 1);
 
-  PeCoffInterface32 coff(&memory_fake_);
+  PeCoffInterface32 coff(GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TEST_F(PeCoffInterface64Test, optional_header_parsing_fails_invalid_memory_end_64) {
-  InitPeCoffInterfaceFake();
-  const uint64_t kAfterDataOffset = optional_header_start_offset_ + 0x0018;
-  this->memory_fake_.ClearMemory(kAfterDataOffset, 1);
+  GetFake()->Init();
+  const uint64_t kAfterDataOffset = GetFake()->optional_header_start_offset() + 0x0018;
+  this->GetMemory()->ClearMemory(kAfterDataOffset, 1);
 
-  PeCoffInterface64 coff(&memory_fake_);
+  PeCoffInterface64 coff(GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TEST_F(PeCoffInterface32Test, optional_header_parsing_fails_invalid_memory_data_dirs_32) {
-  InitPeCoffInterfaceFake();
-  const uint64_t kDataDirOffset = optional_header_start_offset_ + 0x0018 + 0x0004 + 0x0044;
-  this->memory_fake_.ClearMemory(kDataDirOffset, 1);
+  GetFake()->Init();
+  const uint64_t kDataDirOffset =
+      GetFake()->optional_header_start_offset() + 0x0018 + 0x0004 + 0x0044;
+  this->GetMemory()->ClearMemory(kDataDirOffset, 1);
 
-  PeCoffInterface32 coff(&memory_fake_);
+  PeCoffInterface32 coff(GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 TEST_F(PeCoffInterface64Test, optional_header_parsing_fails_invalid_memory_data_dirs_64) {
-  InitPeCoffInterfaceFake();
-  const uint64_t kDataDirOffset = optional_header_start_offset_ + 0x0018 + 0x0058;
-  this->memory_fake_.ClearMemory(kDataDirOffset, 1);
+  GetFake()->Init();
+  const uint64_t kDataDirOffset = GetFake()->optional_header_start_offset() + 0x0018 + 0x0058;
+  this->GetMemory()->ClearMemory(kDataDirOffset, 1);
 
-  PeCoffInterface64 coff(&memory_fake_);
+  PeCoffInterface64 coff(GetMemory());
   int64_t load_bias;
   ASSERT_FALSE(coff.Init(&load_bias));
-  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.LastError().code);
+  EXPECT_EQ(ERROR_MEMORY_INVALID, coff.last_error().code);
 }
 
 }  // namespace unwindstack

--- a/third_party/libunwindstack/tests/PeCoffTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffTest.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unwindstack/PeCoff.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <unwindstack/MapInfo.h>
+#include <unwindstack/Memory.h>
+#include <unwindstack/PeCoffInterface.h>
+#include <unwindstack/Regs.h>
+
+#include "MemoryFake.h"
+#include "PeCoffFake.h"
+
+namespace unwindstack {
+
+class MockPeCoffInterface : public PeCoffInterface {
+ public:
+  MockPeCoffInterface() {}
+  MOCK_METHOD(bool, Init, (int64_t*), (override));
+  MOCK_METHOD(const ErrorData&, last_error, (), (override));
+  MOCK_METHOD(ErrorCode, LastErrorCode, (), (override));
+  MOCK_METHOD(uint64_t, LastErrorAddress, (), (override));
+  MOCK_METHOD(DwarfSection*, DebugFrameSection, (), (override));
+  MOCK_METHOD(uint64_t, GetRelPc, (uint64_t, uint64_t), (const override));
+  MOCK_METHOD(bool, Step, (uint64_t, Regs*, Memory*, bool*, bool*), (override));
+};
+
+class FakePeCoff : public PeCoff {
+ public:
+  FakePeCoff(Memory* memory) : PeCoff(memory) {}
+  void SetFakePeCoffInterface(PeCoffInterface* pe_coff_interface) {
+    this->interface_.reset(pe_coff_interface);
+  }
+};
+
+template <typename PeCoffInterfaceType>
+class PeCoffTest : public ::testing::Test {
+ public:
+  PeCoffTest() : fake_(new PeCoffFake<PeCoffInterfaceType>) {}
+  ~PeCoffTest() {}
+
+  PeCoffFake<PeCoffInterfaceType>* GetFake() { return fake_.get(); }
+  MemoryFake* ReleaseMemory() { return fake_->ReleaseMemoryFake(); }
+
+ private:
+  std::unique_ptr<PeCoffFake<PeCoffInterfaceType>> fake_;
+};
+
+// Many tests equally apply to the 32-bit and the 64-bit case, so we implement these
+// as TYPED_TESTs.
+typedef ::testing::Types<PeCoffInterface32, PeCoffInterface64> Implementations;
+TYPED_TEST_SUITE(PeCoffTest, Implementations);
+
+TYPED_TEST(PeCoffTest, init_succeeds_on_well_formed_file) {
+  this->GetFake()->Init();
+  PeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  EXPECT_TRUE(coff.valid());
+}
+
+TYPED_TEST(PeCoffTest, init_fails_on_bad_file) {
+  PeCoff coff(new MemoryFake);
+  EXPECT_FALSE(coff.Init());
+  EXPECT_FALSE(coff.valid());
+}
+
+TYPED_TEST(PeCoffTest, invalidate_works_on_valid_object) {
+  this->GetFake()->Init();
+  PeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  EXPECT_TRUE(coff.valid());
+  coff.Invalidate();
+  EXPECT_FALSE(coff.valid());
+}
+
+TYPED_TEST(PeCoffTest, returns_correct_load_bias_after_init_succeeds) {
+  this->GetFake()->Init();
+  PeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  EXPECT_EQ(PeCoffFake<TypeParam>::kLoadBiasFake, coff.GetLoadBias());
+}
+
+TYPED_TEST(PeCoffTest, retuns_zero_as_load_bias_on_invalid_object) {
+  PeCoff coff(new MemoryFake);
+  EXPECT_FALSE(coff.Init());
+  EXPECT_FALSE(coff.valid());
+  EXPECT_EQ(0, coff.GetLoadBias());
+}
+
+TYPED_TEST(PeCoffTest, getting_build_id_aborts) {
+  this->GetFake()->Init();
+  PeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  ASSERT_DEATH(coff.GetBuildID(), "");
+}
+
+TYPED_TEST(PeCoffTest, getting_soname_aborts) {
+  this->GetFake()->Init();
+  PeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  ASSERT_DEATH(coff.GetSoname(), "");
+}
+
+TYPED_TEST(PeCoffTest, getting_function_name_aborts) {
+  this->GetFake()->Init();
+  PeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  ASSERT_DEATH(coff.GetFunctionName(0, nullptr, nullptr), "");
+}
+
+TYPED_TEST(PeCoffTest, getting_global_variable_offset_aborts) {
+  this->GetFake()->Init();
+  PeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  ASSERT_DEATH(coff.GetGlobalVariableOffset("", nullptr), "");
+}
+
+TYPED_TEST(PeCoffTest, rel_pc_is_correctly_passed_through) {
+  this->GetFake()->Init();
+  FakePeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+
+  constexpr uint64_t kPcValue = 0x2000;
+  constexpr uint64_t kMapStart = 0x1000;
+  constexpr uint64_t kMapEnd = 0x4000;
+
+  // This test is not testing whether the GetRelPc computation is correct, only whether the
+  // return value from PeCoffInterface::GetRelPc is correctly passed through.
+  constexpr uint64_t kMockReturnValue = 0x3000;
+  MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
+  EXPECT_CALL(*mock_interface, GetRelPc(kPcValue, kMapStart))
+      .WillOnce(::testing::Return(kMockReturnValue));
+  coff.SetFakePeCoffInterface(mock_interface);
+
+  MapInfo map_info(nullptr, nullptr, /*start=*/kMapStart, /*end=*/kMapEnd, 0, 0, "no_name");
+  EXPECT_EQ(kMockReturnValue, coff.GetRelPc(kPcValue, &map_info));
+}
+
+TYPED_TEST(PeCoffTest, rel_pc_is_zero_for_invalid) {
+  PeCoff coff(new MemoryFake);
+  EXPECT_FALSE(coff.Init());
+  EXPECT_FALSE(coff.valid());
+  EXPECT_EQ(0, coff.GetRelPc(0, nullptr));
+}
+
+TYPED_TEST(PeCoffTest, step_if_signal_handler_returns_false) {
+  this->GetFake()->Init();
+  FakePeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  EXPECT_FALSE(coff.StepIfSignalHandler(0, nullptr, nullptr));
+}
+
+TYPED_TEST(PeCoffTest, step_succeeds_when_interface_step_succeeds) {
+  this->GetFake()->Init();
+  FakePeCoff coff(this->ReleaseMemory());
+  MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
+  EXPECT_CALL(*mock_interface, Step(0x2000, nullptr, nullptr, nullptr, nullptr))
+      .WillOnce(::testing::Return(true));
+  coff.SetFakePeCoffInterface(mock_interface);
+  EXPECT_TRUE(coff.Step(0x2000, nullptr, nullptr, nullptr, nullptr));
+}
+
+TYPED_TEST(PeCoffTest, steps_fails_when_interface_step_fails) {
+  this->GetFake()->Init();
+  FakePeCoff coff(this->ReleaseMemory());
+  MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
+  EXPECT_CALL(*mock_interface, Step(0x2000, nullptr, nullptr, nullptr, nullptr))
+      .WillOnce(::testing::Return(false));
+  coff.SetFakePeCoffInterface(mock_interface);
+  EXPECT_FALSE(coff.Step(0x2000, nullptr, nullptr, nullptr, nullptr));
+}
+
+TYPED_TEST(PeCoffTest, returns_correct_memory_ptr) {
+  this->GetFake()->Init();
+  Memory* memory = this->ReleaseMemory();
+  PeCoff coff(memory);
+  EXPECT_EQ(memory, coff.memory());
+}
+
+TYPED_TEST(PeCoffTest, errors_are_passed_through_from_interface) {
+  constexpr uint64_t kErrorAddress = 0x100;
+  constexpr ErrorCode kErrorCode = unwindstack::ErrorCode::ERROR_INVALID_COFF;
+
+  this->GetFake()->Init();
+  FakePeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  EXPECT_TRUE(coff.valid());
+
+  MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
+  coff.SetFakePeCoffInterface(mock_interface);
+
+  ErrorData mock_return_value{kErrorCode, kErrorAddress};
+  EXPECT_CALL(*mock_interface, last_error()).WillOnce(::testing::ReturnRef(mock_return_value));
+  ErrorData error_data;
+  coff.GetLastError(&error_data);
+  EXPECT_EQ(kErrorCode, error_data.code);
+  EXPECT_EQ(kErrorAddress, error_data.address);
+
+  EXPECT_CALL(*mock_interface, LastErrorCode()).WillOnce(::testing::Return(kErrorCode));
+  EXPECT_EQ(kErrorCode, coff.GetLastErrorCode());
+
+  EXPECT_CALL(*mock_interface, LastErrorAddress()).WillOnce(::testing::Return(kErrorAddress));
+  EXPECT_EQ(kErrorAddress, coff.GetLastErrorAddress());
+}
+
+// Tests that are specific to, or are easier to write specifically for, a single architecture.
+using PeCoff32Test = PeCoffTest<PeCoffInterface32>;
+using PeCoff64Test = PeCoffTest<PeCoffInterface64>;
+
+TEST_F(PeCoff32Test, returns_correct_arch_for_32bit_pe_coff) {
+  GetFake()->Init();
+  PeCoff coff(ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  EXPECT_EQ(ARCH_X86, coff.arch());
+}
+
+TEST_F(PeCoff64Test, returns_correct_arch_for_64bit_pe_coff) {
+  GetFake()->Init();
+  PeCoff coff(ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+  EXPECT_EQ(ARCH_X86_64, coff.arch());
+}
+
+}  // namespace unwindstack

--- a/third_party/libunwindstack/utils/MemoryFake.h
+++ b/third_party/libunwindstack/utils/MemoryFake.h
@@ -61,7 +61,7 @@ class MemoryFake : public Memory {
     }
   }
 
-  void Clear() { data_.clear(); }
+  void Clear() override { data_.clear(); }
 
  private:
   std::unordered_map<uint64_t, uint8_t> data_;


### PR DESCRIPTION
This change implements the class PeCoff, which is the PE/COFF equivalent
of the Elf class. Its main reponsibility is to correctly initialize
the PeCoffInterface based on the type of PE/COFF file (32-bit vs.
64-bit) and pass through calls to the PeCoffInterface.

To reuse fake PE/COFF test data for PeCoffTest, the existing
PeCoffInterfaceTest is refactored by extracting the PeCoffFake class
that can be initialized with fake PE/COFF data and also allows
manipulation of the fake data to trigger failure cases in the
parsing code. That said, the current code tries to avoid unit tests that
span multiple classes by often mocking classes to which calls are 
forwarded (for functions such as GetRelPc or Step). This mitigates the 
need for correct "end-to-end" initialization using fake data in some
cases. 

Tested: Unit tests.
Bug: http://b/192514457