### PR TITLE
Fix time measurement for symbol caching E2E

### DIFF
--- a/contrib/automation_tests/orbit_symbol_cache.py
+++ b/contrib/automation_tests/orbit_symbol_cache.py
@@ -43,7 +43,7 @@ def main(argv):
         LoadAllSymbolsAndVerifyCache(),
         EndSession(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        LoadAllSymbolsAndVerifyCache(expected_duration_difference=-30),
+        LoadAllSymbolsAndVerifyCache(expected_duration_difference=-15),
         EndSession(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
         LoadSymbols(module_search_string="libggp"),
@@ -51,7 +51,7 @@ def main(argv):
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
         ReplaceFileInSymbolCache(src="_mnt_developer_hello_ggp_standalone",
                                  file_to_replace="_usr_local_cloudcast_lib_libggp.so"),
-        LoadSymbols(module_search_string="libggp", expected_duration_difference=10)
+        LoadSymbols(module_search_string="libggp", expected_duration_difference=5)
 
     ]
     suite = E2ETestSuite(test_name="Symbol loading and caching", test_cases=test_cases)

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -33,7 +33,7 @@ def _show_symbols_and_functions_tabs(top_window):
 
 
 def _find_and_close_error_dialog(top_window) -> str or None:
-    window = find_control(top_window, 'Window', 'Error loading symbols', raise_on_failure=False)
+    window = find_control(top_window, 'Window', 'Error loading symbols', recurse=False, raise_on_failure=False)
     if window is None:
         return None
 
@@ -136,16 +136,15 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase, DurationDiffMixin):
         self._modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
         self._load_all_modules()
 
-        start_time = time.time()
         modules_loading_result = self._wait_for_loading_and_collect_errors()
-        total_duration = time.time() - start_time
 
-        self._check_and_update_duration("load_all_modules_duration", total_duration, expected_duration_difference)
+        self._check_and_update_duration("load_all_modules_duration", modules_loading_result.time,
+                                        expected_duration_difference)
 
         modules = self._gather_module_states()
         self._verify_all_modules_are_cached(modules)
         self._verify_all_errors_were_raised(modules, modules_loading_result.errors)
-        logging.info("Done. Loading time: {time}s, module errors: {errors}".format(
+        logging.info("Done. Loading time: {time:.2f}s, module errors: {errors}".format(
             time=modules_loading_result.time, errors=modules_loading_result.errors))
 
     def _load_all_modules(self):
@@ -199,7 +198,7 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase, DurationDiffMixin):
             # If not, try a few more times to make sure we didn't just accidentally query the UI while the status
             # message was being updated.
             error_module = _find_and_close_error_dialog(self.suite.top_window())
-            status_message = self.find_control('StatusBar').texts()[0]
+            status_message = self.find_control('StatusBar', recurse=False).texts()[0]
             if "Copying debug info file" not in status_message and "Loading symbols" not in status_message:
                 status_message = None
 


### PR DESCRIPTION
Symbol loading timing is measured more accurately by not taking the waiting time into account, and by speeding up the PyWinAuto lookup for required elements.