### PR TITLE
Make Gpu Debug Marker Track collapsable

### DIFF
--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -44,6 +44,7 @@ class GpuDebugMarkerTrack final : public TimerTrack {
   [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] float GetHeight() const override;
+  [[nodiscard]] bool IsCollapsible() const override { return GetDepth() > 1; }
 
   [[nodiscard]] float GetYFromTimer(
       const orbit_client_protos::TimerInfo& timer_info) const override;


### PR DESCRIPTION
In PR#2820, the TimerTrack::IsCollapsible() method was pushed down
to ThreadTrack, breaking collapsibility of the debug marker track.

This adds the implementation in GpuDebugMarkerTrack, to make the
track collapsible again.

Test: Load OrbitCapture.orbit and check collapsibility of the track.
Bug: http://b/209763779