### PR TITLE
Add parameter to specify additional symbol locations

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 
@@ -58,6 +59,8 @@ ABSL_FLAG(std::string, connection_target, "",
           "connection setup and open the main window instead. If either the instance or the "
           "process ID can't be found or deployment is aborted by the user Orbit will exit "
           "with return code -1 immediately.");
+ABSL_FLAG(std::vector<std::string>, additional_symbol_paths, {},
+          "Additional local symbol locations (comma-separated)");
 
 // Clears QSettings. This is intended for e2e tests.
 ABSL_FLAG(bool, clear_settings, false,

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 ABSL_DECLARE_FLAG(bool, devmode);
 
@@ -54,6 +55,7 @@ ABSL_DECLARE_FLAG(bool, enforce_full_redraw);
 
 // VSI
 ABSL_DECLARE_FLAG(std::string, connection_target);
+ABSL_DECLARE_FLAG(std::vector<std::string>, additional_symbol_paths);
 
 // Clears QSettings. This is intended for e2e tests.
 ABSL_DECLARE_FLAG(bool, clear_settings);


### PR DESCRIPTION
Symbol paths added via "--additional_symbol_paths" do not show up in the symbol path editor and are never stored. This is mainly meant to be used with the Visual Studio Integration.

Bug: b/202262474
Test: Manually tested, will be covered by an E2E test later.