### PR TITLE
Fix documentation on ORBIT_START_ASYNC/ORBIT_STOP_ASYNC id uniqueness

### DIFF
--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -140,13 +140,13 @@
 //
 // Parameters of ORBIT_START_ASYNC:
 // name: [const char*] Name of the *track* that will display the async events in Orbit.
-// id: [uint64_t] User-provided *unique* id for the time slice. This unique id is used to match the
-//     ORBIT_START_ASYNC and ORBIT_STOP_ASYNC calls. An id needs to be unique for the current track.
+// id: [uint64_t] User-provided globally *unique* id for the time slice. This id is used to match
+//     the ORBIT_START_ASYNC and ORBIT_STOP_ASYNC calls. An id needs to be unique across all tracks.
 // col: [orbit_api_color] User-defined color for the current time slice (see orbit_api_color below).
 //
 // Parameters of ORBIT_STOP_ASYNC:
-// id: [uint64_t] User-provided *unique* id for the time slice. This unique id is used to match the
-//     ORBIT_START_ASYNC and ORBIT_STOP_ASYNC calls. An id needs to be unique for the current track.
+// id: [uint64_t] User-provided globally *unique* id for the time slice. This id is used to match
+//     the ORBIT_START_ASYNC and ORBIT_STOP_ASYNC calls. An id needs to be unique across all tracks.
 //
 //
 // =================================================================================================


### PR DESCRIPTION
It would be nice to have (track name, id) as the unique key but that's not
possible because `ORBIT_STOP_ASYNC` doesn't receive the track name. We would
otherwise transmit the string twice for every async time range.

Bug: http://b/210580292