### PR TITLE
Fix bugs in ApiEventProcessor

### DIFF
--- a/src/CaptureClient/ApiEventProcessor.cpp
+++ b/src/CaptureClient/ApiEventProcessor.cpp
@@ -86,11 +86,12 @@ void ApiEventProcessor::ProcessApiEventLegacy(const orbit_api::ApiEvent& api_eve
 }
 
 void ApiEventProcessor::ProcessStartEventLegacy(const orbit_api::ApiEvent& api_event) {
-  synchronous_event_stack_by_tid_[api_event.tid].emplace_back(api_event);
+  synchronous_legacy_event_stack_by_tid_[api_event.tid].emplace_back(api_event);
 }
 
 void ApiEventProcessor::ProcessStopEventLegacy(const orbit_api::ApiEvent& api_event) {
-  std::vector<orbit_api::ApiEvent>& event_stack = synchronous_event_stack_by_tid_[api_event.tid];
+  std::vector<orbit_api::ApiEvent>& event_stack =
+      synchronous_legacy_event_stack_by_tid_[api_event.tid];
   if (event_stack.empty()) {
     // We received a stop event with no matching start event, which is possible if the capture was
     // started between the event's start and stop times.
@@ -122,18 +123,18 @@ void ApiEventProcessor::ProcessStopEventLegacy(const orbit_api::ApiEvent& api_ev
 
 void ApiEventProcessor::ProcessAsyncStartEventLegacy(const orbit_api::ApiEvent& api_event) {
   const uint64_t event_id = api_event.encoded_event.event.data;
-  asynchronous_events_by_id_[event_id] = api_event;
+  asynchronous_legacy_events_by_id_[event_id] = api_event;
 }
 
 void ApiEventProcessor::ProcessAsyncStopEventLegacy(const orbit_api::ApiEvent& api_event) {
   const uint64_t event_id = api_event.encoded_event.event.data;
-  if (asynchronous_events_by_id_.count(event_id) == 0) {
+  if (asynchronous_legacy_events_by_id_.count(event_id) == 0) {
     // We received a stop event with no matching start event, which is possible if the capture was
     // started between the event's start and stop times.
     return;
   }
 
-  orbit_api::ApiEvent& start_event = asynchronous_events_by_id_[event_id];
+  orbit_api::ApiEvent& start_event = asynchronous_legacy_events_by_id_[event_id];
   TimerInfo timer_info;
   timer_info.set_start(start_event.timestamp_ns);
   timer_info.set_end(api_event.timestamp_ns);
@@ -152,7 +153,7 @@ void ApiEventProcessor::ProcessAsyncStopEventLegacy(const orbit_api::ApiEvent& a
 
   capture_listener_->OnTimer(timer_info);
 
-  asynchronous_events_by_id_.erase(event_id);
+  asynchronous_legacy_events_by_id_.erase(event_id);
 }
 
 void ApiEventProcessor::ProcessStringEventLegacy(const orbit_api::ApiEvent& api_event) {
@@ -281,7 +282,7 @@ void ApiEventProcessor::ProcessApiScopeStopAsync(
   timer_info.set_api_scope_name(DecodeString(start_event));
 
   capture_listener_->OnTimer(timer_info);
-  asynchronous_events_by_id_.erase(event_id);
+  asynchronous_scopes_by_id_.erase(event_id);
 }
 
 void ApiEventProcessor::ProcessApiStringEvent(

--- a/src/CaptureClient/include/CaptureClient/ApiEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/ApiEventProcessor.h
@@ -13,7 +13,7 @@
 
 namespace orbit_capture_client {
 
-// The ApiEventProcessor is responsible for processing orbit_grpc_protos::ApiEvent events and
+// The ApiEventProcessor is responsible for processing all the orbit_grpc_protos::Api... events and
 // transforming them into TimerInfo objects that are relayed to a CaptureListener. Internal state
 // is maintained to cache "start" events until a corresponding "stop" event is received. The pair
 // is then used to create a single TimerInfo object. "Tracking" events don't need to be cached
@@ -21,9 +21,11 @@ namespace orbit_capture_client {
 class ApiEventProcessor {
  public:
   explicit ApiEventProcessor(CaptureListener* listener);
+
   // The new manual instrumentation events (see below) could not use `ApiEvent`, so this is
   // deprecated. The methods for the concrete (new) events should be used instead.
   [[deprecated]] void ProcessApiEventLegacy(const orbit_grpc_protos::ApiEvent& grpc_api_event);
+
   void ProcessApiScopeStart(const orbit_grpc_protos::ApiScopeStart& api_scope_start);
   void ProcessApiScopeStartAsync(
       const orbit_grpc_protos::ApiScopeStartAsync& grpc_api_scope_start_async);
@@ -48,11 +50,12 @@ class ApiEventProcessor {
   [[deprecated]] void ProcessStringEventLegacy(const orbit_api::ApiEvent& api_event);
 
   CaptureListener* capture_listener_ = nullptr;
-  absl::flat_hash_map<int32_t, std::vector<orbit_api::ApiEvent>> synchronous_event_stack_by_tid_;
+  absl::flat_hash_map<int32_t, std::vector<orbit_api::ApiEvent>>
+      synchronous_legacy_event_stack_by_tid_;
   absl::flat_hash_map<int32_t, std::vector<orbit_grpc_protos::ApiScopeStart>>
       synchronous_scopes_stack_by_tid_;
-  absl::flat_hash_map<int32_t, orbit_api::ApiEvent> asynchronous_events_by_id_;
-  absl::flat_hash_map<int32_t, orbit_grpc_protos::ApiScopeStartAsync> asynchronous_scopes_by_id_;
+  absl::flat_hash_map<uint64_t, orbit_api::ApiEvent> asynchronous_legacy_events_by_id_;
+  absl::flat_hash_map<uint64_t, orbit_grpc_protos::ApiScopeStartAsync> asynchronous_scopes_by_id_;
 };
 
 }  // namespace orbit_capture_client


### PR DESCRIPTION
- `ProcessApiScopeStopAsync` was popping from `asynchronous_events_by_id_`. This
  one is also now renamed to `asynchronous_legacy_events_by_id_` to clarify the
  difference.
- `ApiEventProcessor was treating async ids as 32-bit: change relevant maps to
  use `uint64_t` as key.

Bug: http://b/210581465
Bug: http://b/210583680

Test: Added unit tests that were failing before the change.