### PR TITLE
Prevent long repeated strings with repeated ORBIT_ASYNC_STRINGs

### DIFF
--- a/src/CaptureClient/ApiEventProcessor.cpp
+++ b/src/CaptureClient/ApiEventProcessor.cpp
@@ -158,11 +158,9 @@ void ApiEventProcessor::ProcessAsyncStopEventLegacy(const orbit_api::ApiEvent& a
 
 void ApiEventProcessor::ProcessStringEventLegacy(const orbit_api::ApiEvent& api_event) {
   ApiStringEvent api_string_event;
-  api_string_event.set_process_id(api_event.pid);
-  api_string_event.set_thread_id(api_event.tid);
-  api_string_event.set_timestamp_ns(api_event.timestamp_ns);
   api_string_event.set_async_scope_id(api_event.encoded_event.event.data);
   api_string_event.set_name(api_event.encoded_event.event.name);
+  api_string_event.set_should_concatenate(true);
   capture_listener_->OnApiStringEvent(api_string_event);
 }
 
@@ -288,11 +286,9 @@ void ApiEventProcessor::ProcessApiScopeStopAsync(
 void ApiEventProcessor::ProcessApiStringEvent(
     const orbit_grpc_protos::ApiStringEvent& grpc_api_string_event) {
   ApiStringEvent api_string_event;
-  api_string_event.set_process_id(grpc_api_string_event.pid());
-  api_string_event.set_thread_id(grpc_api_string_event.tid());
-  api_string_event.set_timestamp_ns(grpc_api_string_event.timestamp_ns());
   api_string_event.set_async_scope_id(grpc_api_string_event.id());
   api_string_event.set_name(DecodeString(grpc_api_string_event));
+  api_string_event.set_should_concatenate(false);
   capture_listener_->OnApiStringEvent(api_string_event);
 }
 

--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -161,17 +161,12 @@ class ApiEventProcessorTest : public ::testing::Test {
     return result;
   }
 
-  static orbit_client_protos::ApiStringEvent CreateClientStringEvent(uint64_t timestamp_ns,
-                                                                     int32_t process_id,
-                                                                     int32_t thread_id, uint64_t id,
-                                                                     const char* name) {
+  static orbit_client_protos::ApiStringEvent CreateClientStringEvent(uint64_t id, const char* name,
+                                                                     bool should_concatenate) {
     orbit_client_protos::ApiStringEvent result;
-    result.set_timestamp_ns(timestamp_ns);
-    result.set_process_id(process_id);
-    result.set_thread_id(thread_id);
     result.set_async_scope_id(id);
     result.set_name(name);
-
+    result.set_should_concatenate(should_concatenate);
     return result;
   }
 
@@ -436,7 +431,7 @@ TEST_F(ApiEventProcessorTest, StringEvent) {
   auto string_event = CreateStringEvent(1, kProcessId, kThreadId1, kId1, "Some string for this id");
 
   auto expected_string_event =
-      CreateClientStringEvent(1, kProcessId, kThreadId1, kId1, "Some string for this id");
+      CreateClientStringEvent(kId1, "Some string for this id", /*should_concatenate=*/false);
 
   orbit_client_protos::ApiStringEvent actual_string_event;
   EXPECT_CALL(capture_listener_, OnApiStringEvent)
@@ -689,7 +684,7 @@ TEST_F(ApiEventProcessorTest, StringEventLegacy) {
                                            "Some string for this id", kId1);
 
   auto expected_string_event =
-      CreateClientStringEvent(1, kProcessId, kThreadId1, kId1, "Some string for this id");
+      CreateClientStringEvent(kId1, "Some string for this id", /*should_concatenate=*/true);
 
   orbit_client_protos::ApiStringEvent actual_string_event;
   EXPECT_CALL(capture_listener_, OnApiStringEvent)

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -175,12 +175,16 @@ message TimerInfo {
 }
 
 message ApiStringEvent {
-  uint32 process_id = 1;
-  uint32 thread_id = 2;
-  uint64 timestamp_ns = 3;
+  reserved 1, 2, 3;
 
   uint64 async_scope_id = 4;
   string name = 5;
+  // The old manual instrumentation (orbit_grpc_protos::ApiEvent) allowed
+  // arbitrarily long strings by concatenating strings associated with the same
+  // async_scope_id. This is no longer the case because
+  // orbit_grpc_protos::ApiStringEvent already supports arbitrarily long
+  // strings.
+  bool should_concatenate = 6;
 }
 
 message ApiTrackValue {


### PR DESCRIPTION
When we used `ApiEvent` to carry manual instrumentation data, we allowed long
strings by concatenation. This is no longer the case and can lead to a very long
repeated string if `ORBIT_ASYNC_STRING` is called multiple times with the same
id. This is somewhat easy as the API is not too easy to use, and can also tank
the performance of the client. Let's handle this case gracefully, while still
allowing concatenation for the old format.

Bug: http://b/207483525

Test:
- Put together a binary that sends async scopes with a string reusing the
  same id. Capture it and verify the string displayed in the capture view is now
  not repeated.
- Take a capture on the same binary using Orbit.h 1.66 with an Orbit 1.66, using
  `ApiEvent` for manual instrumentation. Load it with the current version of
  Orbit and verify the string is still repeated.