### PR TITLE
Simplify ManualInstrumentationManager

### DIFF
--- a/src/OrbitGl/ManualInstrumentationManager.cpp
+++ b/src/OrbitGl/ManualInstrumentationManager.cpp
@@ -4,25 +4,10 @@
 
 #include "ManualInstrumentationManager.h"
 
-#include <absl/container/flat_hash_map.h>
-#include <absl/container/flat_hash_set.h>
-#include <absl/meta/type_traits.h>
 #include <absl/synchronization/mutex.h>
-#include <stddef.h>
+#include <stdint.h>
 
-#include "OrbitBase/Logging.h"
-
-using orbit_client_protos::TimerInfo;
-
-void ManualInstrumentationManager::AddAsyncTimerListener(AsyncTimerInfoListener* listener) {
-  absl::MutexLock lock(&mutex_);
-  async_timer_info_listeners_.insert(listener);
-}
-
-void ManualInstrumentationManager::RemoveAsyncTimerListener(AsyncTimerInfoListener* listener) {
-  absl::MutexLock lock(&mutex_);
-  async_timer_info_listeners_.erase(listener);
-}
+#include "ClientProtos/capture_data.pb.h"
 
 void ManualInstrumentationManager::ProcessStringEvent(
     const orbit_client_protos::ApiStringEvent& string_event) {
@@ -34,12 +19,5 @@ void ManualInstrumentationManager::ProcessStringEvent(
     // in that case we append the current value to any existing one.
     std::string previous_string = string_manager_.Get(event_id).value_or("");
     string_manager_.AddOrReplace(event_id, previous_string + string_event.name());
-  }
-}
-
-void ManualInstrumentationManager::ProcessAsyncTimer(const TimerInfo& timer_info) {
-  absl::MutexLock lock(&mutex_);
-  for (auto* listener : async_timer_info_listeners_) {
-    (*listener)(timer_info.api_scope_name(), timer_info);
   }
 }

--- a/src/OrbitGl/ManualInstrumentationManager.h
+++ b/src/OrbitGl/ManualInstrumentationManager.h
@@ -18,25 +18,19 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
 
+// Wrapper around a StringManager that holds the association from the id of an async time span to
+// its string, as reported by ApiStringEvent protos.
 class ManualInstrumentationManager {
  public:
   ManualInstrumentationManager() = default;
 
-  using AsyncTimerInfoListener = std::function<void(
-      const std::string& name, const orbit_client_protos::TimerInfo& timer_info)>;
-
-  void AddAsyncTimerListener(AsyncTimerInfoListener* listener);
-  void RemoveAsyncTimerListener(AsyncTimerInfoListener* listener);
-  void ProcessAsyncTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessStringEvent(const orbit_client_protos::ApiStringEvent& string_event);
   [[nodiscard]] std::string GetString(uint32_t id) const {
     return string_manager_.Get(id).value_or("");
   }
 
  private:
-  absl::flat_hash_set<AsyncTimerInfoListener*> async_timer_info_listeners_;
   orbit_string_manager::StringManager string_manager_;
-  absl::Mutex mutex_;
 };
 
 #endif  // ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -41,7 +41,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
                      orbit_gl::Viewport* viewport, orbit_client_data::CaptureData* capture_data,
                      PickingManager* picking_manager);
-  ~TimeGraph() override;
 
   [[nodiscard]] float GetHeight() const override;
 
@@ -195,8 +194,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
-  void ProcessAsyncTimer(const std::string& track_name,
-                         const orbit_client_protos::TimerInfo& timer_info);
+  void ProcessAsyncTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessSystemMemoryTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessCGroupAndProcessMemoryTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessPageFaultsTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
@@ -232,7 +230,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   std::unique_ptr<TrackManager> track_manager_;
 
   ManualInstrumentationManager* manual_instrumentation_manager_;
-  std::unique_ptr<ManualInstrumentationManager::AsyncTimerInfoListener> async_timer_info_listener_;
   const orbit_client_data::CaptureData* capture_data_ = nullptr;
   orbit_client_data::ThreadTrackDataProvider* thread_track_data_provider_ = nullptr;
 


### PR DESCRIPTION
`TimerInfo`s were forwarded from `TimeGraph` to `ManualInstrumentationManager`
just to be sent back to `TimeGraph` with a callback mechanism.

Bug: http://b/210583690

Test: Capture `OrbitTest`. Use client instrospection (also involves the
`ManualInstrumentationManager`).