### PR TITLE
Jump to correct track when jumping a timer

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -240,7 +240,7 @@ void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, const TimerInf
 }
 
 void TimeGraph::VerticallyMoveIntoView(const TimerInfo& timer_info) {
-  VerticallyMoveIntoView(*track_manager_->GetOrCreateThreadTrack(timer_info.thread_id()));
+  VerticallyMoveIntoView(*track_manager_->GetOrCreateTrackFromTimerInfo(timer_info));
 }
 
 // Move vertically the view to make a Track fully visible.


### PR DESCRIPTION
When jumping between timers, the screen gets moved vertically and
horizontally. The vertical movement was, however, based on the
thread id and always jumping to the corresponding thread track.

This change fixes this by jumping to the track that actually
holds that timer.

Bug: http://b/207473439
Test: Use OrbitCapture.orbit and jump on Gpu Markers