### PR TITLE
Add MemoryTracing test case to OrbitServiceIntegrationTests

### DIFF
--- a/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.cpp
@@ -164,6 +164,15 @@ extern "C" __attribute__((noinline)) void UseOrbitApi() {
   }
 }
 
+void IncreaseRssCommand() {
+  void* ptr = malloc(PuppetConstants::kRssIncreaseB);  // NOLINT
+  ORBIT_CHECK(ptr != nullptr);
+  auto* typed_ptr = static_cast<volatile uint64_t*>(ptr);
+  for (uint64_t i = 0; i < PuppetConstants::kRssIncreaseB / sizeof(uint64_t); ++i) {
+    typed_ptr[i] = i;
+  }
+}
+
 int IntegrationTestPuppetMain() {
   ORBIT_LOG("Puppet started");
   while (!!std::cin && !std::cin.eof()) {
@@ -186,6 +195,8 @@ int IntegrationTestPuppetMain() {
       RunVulkanTutorial();
     } else if (command == PuppetConstants::kOrbitApiCommand) {
       UseOrbitApi();
+    } else if (command == PuppetConstants::kIncreaseRssCommand) {
+      IncreaseRssCommand();
     } else {
       ORBIT_ERROR("Unknown command: %s", command);
       continue;

--- a/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.h
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.h
@@ -30,6 +30,7 @@ struct IntegrationTestPuppetConstants {
 
   constexpr static uint64_t kFrameCount = 60;
 
+  // Large enough to be well measurable.
   constexpr static uint64_t kRssIncreaseB = 100ULL * 1024 * 1024;
 
   constexpr static const char* kUseOrbitApiFunctionName = "UseOrbitApi";

--- a/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.h
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestPuppet.h
@@ -30,6 +30,8 @@ struct IntegrationTestPuppetConstants {
 
   constexpr static uint64_t kFrameCount = 60;
 
+  constexpr static uint64_t kRssIncreaseB = 100ULL * 1024 * 1024;
+
   constexpr static const char* kUseOrbitApiFunctionName = "UseOrbitApi";
   constexpr static uint64_t kOrbitApiUsageCount = 5;
   constexpr static const char* kOrbitApiScopeName = "Scope";
@@ -68,6 +70,7 @@ struct IntegrationTestPuppetConstants {
   constexpr static const char* kDlopenCommand = "dlopen";
   constexpr static const char* kVulkanTutorialCommand = "VulkanTutorial";
   constexpr static const char* kOrbitApiCommand = "OrbitApi";
+  constexpr static const char* kIncreaseRssCommand = "AllocateMemory";
 
   constexpr static const char* kDoneResponse = "DONE";
 };

--- a/src/LinuxTracingIntegrationTests/IntegrationTestUtils.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestUtils.cpp
@@ -15,6 +15,23 @@
 
 namespace orbit_linux_tracing_integration_tests {
 
+[[nodiscard]] static std::string ReadUnameKernelRelease() {
+  utsname utsname{};
+  int uname_result = uname(&utsname);
+  ORBIT_CHECK(uname_result == 0);
+  return utsname.release;
+}
+
+bool CheckIsStadiaInstance() {
+  std::string release = ReadUnameKernelRelease();
+  if (absl::StrContains(release, "-ggp-")) {
+    return true;
+  }
+
+  ORBIT_ERROR("Stadia instance required for this test (but kernel release is \"%s\")", release);
+  return false;
+}
+
 std::filesystem::path GetExecutableBinaryPath(pid_t pid) {
   auto error_or_executable_path =
       orbit_base::GetExecutablePath(orbit_base::FromNativeProcessId(pid));

--- a/src/LinuxTracingIntegrationTests/IntegrationTestUtils.h
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestUtils.h
@@ -7,6 +7,7 @@
 
 #include <absl/strings/match.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <unistd.h>
 
 #include <string>
@@ -27,6 +28,8 @@ namespace orbit_linux_tracing_integration_tests {
   ORBIT_ERROR("Root required for this test");
   return false;
 }
+
+[[nodiscard]] bool CheckIsStadiaInstance();
 
 [[nodiscard]] std::filesystem::path GetExecutableBinaryPath(pid_t pid);
 

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -11,7 +11,6 @@
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <sys/types.h>
-#include <sys/utsname.h>
 #include <unistd.h>
 
 #include <array>
@@ -57,23 +56,6 @@ namespace {
 
   ORBIT_ERROR("Root or max perf_event_paranoid %d (actual is %d) required for this test",
               max_perf_event_paranoid, perf_event_paranoid);
-  return false;
-}
-
-[[nodiscard]] std::string ReadUnameKernelRelease() {
-  utsname utsname{};
-  int uname_result = uname(&utsname);
-  ORBIT_CHECK(uname_result == 0);
-  return utsname.release;
-}
-
-[[nodiscard]] bool CheckIsStadiaInstance() {
-  std::string release = ReadUnameKernelRelease();
-  if (absl::StrContains(release, "-ggp-")) {
-    return true;
-  }
-
-  ORBIT_ERROR("Stadia instance required for this test (but kernel release is \"%s\")", release);
   return false;
 }
 

--- a/src/MemoryTracing/MemoryInfoListener.cpp
+++ b/src/MemoryTracing/MemoryInfoListener.cpp
@@ -13,7 +13,7 @@ namespace orbit_memory_tracing {
          sampling_period_ns;
 }
 
-// This method compute the arithmetic mean of input timestamps.
+// This method computes the arithmetic mean of input timestamps.
 [[nodiscard]] static uint64_t GetSynchronizedSamplingTimestamp(
     const std::vector<uint64_t>& sampling_timestamps) {
   uint64_t offset = *std::min_element(sampling_timestamps.begin(), sampling_timestamps.end());

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -24,7 +24,6 @@ namespace orbit_memory_tracing {
 namespace {
 
 using orbit_grpc_protos::CGroupMemoryUsage;
-using orbit_grpc_protos::kMissingInfo;
 using orbit_grpc_protos::MemoryUsageEvent;
 using orbit_grpc_protos::ProcessMemoryUsage;
 using orbit_grpc_protos::ProducerCaptureEvent;
@@ -126,7 +125,7 @@ class MemoryTracingIntegrationTestFixture {
 
 void VerifyOrderAndContentOfEvents(const std::vector<ProducerCaptureEvent>& events,
                                    uint64_t sampling_period_ns) {
-  const uint64_t kMemoryEventsTimeDifferenceTolerace =
+  const uint64_t kMemoryEventsTimeDifferenceTolerance =
       static_cast<uint64_t>(sampling_period_ns * 0.2);
   uint64_t previous_memory_usage_event_timestamp_ns = 0;
 
@@ -179,7 +178,7 @@ void VerifyOrderAndContentOfEvents(const std::vector<ProducerCaptureEvent>& even
     // Verify that the memory events in the same memory_usage_event are sampled at very close time.
     uint64_t max_timestamp = *std::max_element(timestamps.begin(), timestamps.end());
     uint64_t min_timestamp = *std::min_element(timestamps.begin(), timestamps.end());
-    EXPECT_LE(max_timestamp - min_timestamp, kMemoryEventsTimeDifferenceTolerace);
+    EXPECT_LE(max_timestamp - min_timestamp, kMemoryEventsTimeDifferenceTolerance);
   }
 }
 

--- a/src/MemoryTracing/MemoryTracingUtils.cpp
+++ b/src/MemoryTracing/MemoryTracingUtils.cpp
@@ -129,8 +129,8 @@ ErrorMessageOr<SystemMemoryUsage> GetSystemMemoryUsage() {
   ErrorMessageOr<void> updating_result =
       UpdateSystemMemoryUsageFromMemInfo(reading_result.value(), &system_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Error while updating SystemMemoryUsage from %s: %s", kSystemMemoryUsageFilename,
-                updating_result.error().message());
+    ORBIT_ERROR("Updating SystemMemoryUsage from %s: %s", kSystemMemoryUsageFilename,
+          updating_result.error().message());
   }
 
   const std::string kSystemPageFaultsFilename = "/proc/vmstat";
@@ -141,8 +141,8 @@ ErrorMessageOr<SystemMemoryUsage> GetSystemMemoryUsage() {
   }
   updating_result = UpdateSystemMemoryUsageFromVmStat(reading_result.value(), &system_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Error while updating SystemMemoryUsage from %s: %s", kSystemPageFaultsFilename,
-                updating_result.error().message());
+    ORBIT_ERROR("Updating SystemMemoryUsage from %s: %s", kSystemPageFaultsFilename,
+          updating_result.error().message());
   }
 
   return system_memory_usage;
@@ -229,8 +229,8 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) {
   ErrorMessageOr<void> updating_result =
       UpdateProcessMemoryUsageFromProcessStat(reading_result.value(), &process_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Error while updating ProcessMemoryUsage from %s: %s", kProcessPageFaultsFilename,
-                updating_result.error().message());
+    ORBIT_ERROR("Updating ProcessMemoryUsage from %s: %s", kProcessPageFaultsFilename,
+          updating_result.error().message());
   }
 
   const std::string kProcessMemoryUsageFilename = absl::StrFormat("/proc/%u/status", pid);
@@ -242,8 +242,8 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) {
   ErrorMessageOr<int64_t> extracting_result =
       ExtractRssAnonFromProcessStatus(reading_result.value());
   if (extracting_result.has_error()) {
-    ORBIT_ERROR("Error while extracting process RssAnon from %s: %s", kProcessMemoryUsageFilename,
-                extracting_result.error().message());
+    ORBIT_ERROR("Extracting process RssAnon from %s: %s", kProcessMemoryUsageFilename,
+          extracting_result.error().message());
   } else {
     process_memory_usage.set_rss_anon_kb(extracting_result.value());
   }
@@ -272,7 +272,7 @@ std::string GetProcessMemoryCGroupName(std::string_view cgroup_content) {
   std::vector<std::string> lines = absl::StrSplit(cgroup_content, '\n', absl::SkipEmpty());
   for (std::string_view line : lines) {
     std::vector<std::string> splits = absl::StrSplit(line, absl::MaxSplits(':', 2));
-    // If find the memory cgroup, return the cgroup name without the leading "/".
+    // If we find the memory cgroup, return the cgroup name without the leading "/".
     if (splits.size() == 3 && splits[1] == "memory") return splits[2].substr(1);
   }
 
@@ -373,8 +373,8 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
   ErrorMessageOr<void> updating_result =
       UpdateCGroupMemoryUsageFromMemoryLimitInBytes(reading_result.value(), &cgroup_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Error while updating CGroupMemoryUsage from %s: %s", kCGroupMemoryLimitFilename,
-                updating_result.error().message());
+    ORBIT_ERROR("Updating CGroupMemoryUsage from %s: %s", kCGroupMemoryLimitFilename,
+          updating_result.error().message());
   }
 
   const std::string kCGroupMemoryUsageAndPageFaultsFilename =
@@ -387,8 +387,8 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
   updating_result =
       UpdateCGroupMemoryUsageFromMemoryStat(reading_result.value(), &cgroup_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Error while updating CGroupMemoryUsage from %s: %s",
-                kCGroupMemoryUsageAndPageFaultsFilename, updating_result.error().message());
+    ORBIT_ERROR("Updating CGroupMemoryUsage from %s: %s", kCGroupMemoryUsageAndPageFaultsFilename,
+          updating_result.error().message());
   }
 
   return cgroup_memory_usage;

--- a/src/MemoryTracing/MemoryTracingUtils.cpp
+++ b/src/MemoryTracing/MemoryTracingUtils.cpp
@@ -130,7 +130,7 @@ ErrorMessageOr<SystemMemoryUsage> GetSystemMemoryUsage() {
       UpdateSystemMemoryUsageFromMemInfo(reading_result.value(), &system_memory_usage);
   if (updating_result.has_error()) {
     ORBIT_ERROR("Updating SystemMemoryUsage from %s: %s", kSystemMemoryUsageFilename,
-          updating_result.error().message());
+                updating_result.error().message());
   }
 
   const std::string kSystemPageFaultsFilename = "/proc/vmstat";
@@ -142,7 +142,7 @@ ErrorMessageOr<SystemMemoryUsage> GetSystemMemoryUsage() {
   updating_result = UpdateSystemMemoryUsageFromVmStat(reading_result.value(), &system_memory_usage);
   if (updating_result.has_error()) {
     ORBIT_ERROR("Updating SystemMemoryUsage from %s: %s", kSystemPageFaultsFilename,
-          updating_result.error().message());
+                updating_result.error().message());
   }
 
   return system_memory_usage;
@@ -230,7 +230,7 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) {
       UpdateProcessMemoryUsageFromProcessStat(reading_result.value(), &process_memory_usage);
   if (updating_result.has_error()) {
     ORBIT_ERROR("Updating ProcessMemoryUsage from %s: %s", kProcessPageFaultsFilename,
-          updating_result.error().message());
+                updating_result.error().message());
   }
 
   const std::string kProcessMemoryUsageFilename = absl::StrFormat("/proc/%u/status", pid);
@@ -243,7 +243,7 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) {
       ExtractRssAnonFromProcessStatus(reading_result.value());
   if (extracting_result.has_error()) {
     ORBIT_ERROR("Extracting process RssAnon from %s: %s", kProcessMemoryUsageFilename,
-          extracting_result.error().message());
+                extracting_result.error().message());
   } else {
     process_memory_usage.set_rss_anon_kb(extracting_result.value());
   }
@@ -374,7 +374,7 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
       UpdateCGroupMemoryUsageFromMemoryLimitInBytes(reading_result.value(), &cgroup_memory_usage);
   if (updating_result.has_error()) {
     ORBIT_ERROR("Updating CGroupMemoryUsage from %s: %s", kCGroupMemoryLimitFilename,
-          updating_result.error().message());
+                updating_result.error().message());
   }
 
   const std::string kCGroupMemoryUsageAndPageFaultsFilename =
@@ -388,7 +388,7 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
       UpdateCGroupMemoryUsageFromMemoryStat(reading_result.value(), &cgroup_memory_usage);
   if (updating_result.has_error()) {
     ORBIT_ERROR("Updating CGroupMemoryUsage from %s: %s", kCGroupMemoryUsageAndPageFaultsFilename,
-          updating_result.error().message());
+                updating_result.error().message());
   }
 
   return cgroup_memory_usage;


### PR DESCRIPTION
Compared to `MemoryTracingIntegrationTest`:
- It tests `MemoryTracing` from through `OrbitService` (that's what tests in
  `OrbitServiceIntegrationTests` do);
- It sets stricter expectations on various fields;
- It sets expectations on the resident set size of the target and the cgroup
  while this is allocating memory;
- It is aimed at YHITI.

Test: Ran on YHITI a hundred times.