### PR TITLE
Simplify VerifyHelloGgp{TopDown,BottomUp}Contents by using Table

### DIFF
--- a/contrib/automation_tests/test_cases/bottom_up_tab.py
+++ b/contrib/automation_tests/test_cases/bottom_up_tab.py
@@ -5,43 +5,37 @@ found in the LICENSE file.
 """
 import logging
 
+from core.common_controls import Table
 from core.orbit_e2e import E2ETestCase, find_control
 
 
 class VerifyHelloGgpBottomUpContents(E2ETestCase):
     """
-    TODO: This could be updated to check the contents more thoroughly and dynamically
-    react to the amount of columns in the treeview - see common_controls.DataViewPanel
-    on how to access the required fields.
+    Verify that the first rows of the bottom-up view are in line with hello_ggp.
+    In particular, we expect the first row to be "ioctl", the second row to be "drm*",
+    and a reasonable total number of rows.
     """
 
     def _execute(self):
         self.find_control("TabItem", "Bottom-Up").click_input()
         logging.info('Switched to Bottom-Up tab')
 
-        # main_wnd.TreeView.children(control_type='TreeItem') returns
-        # every cell in the bottom-up view, in order by row and then column.
-        # It can take a few seconds.
-        logging.info('Listing items of the bottom-up view...')
-        tree_view = find_control(self.find_control('Group', 'bottomUpTab'), 'Tree')
-        tree_items = tree_view.children(control_type='TreeItem')
-        BOTTOM_UP_ROW_CELL_COUNT = 5
-        row_count = len(tree_items) / BOTTOM_UP_ROW_CELL_COUNT
+        tree_view_table = Table(find_control(self.find_control('Group', 'bottomUpTab'), 'Tree'))
 
-        if row_count < 10:
+        logging.info('Counting rows of the bottom-up view...')
+        if tree_view_table.get_row_count() < 10:
             raise RuntimeError('Less than 10 rows in the bottom-up view')
 
-        if tree_items[0].window_text() != 'ioctl':
+        first_row_tree_item = tree_view_table.get_item_at(0, 0)
+        if first_row_tree_item.window_text() != 'ioctl':
             raise RuntimeError('First item of the bottom-up view is not "ioctl"')
         logging.info('Verified that first item is "ioctl"')
 
-        tree_items[0].double_click_input()
+        first_row_tree_item.double_click_input()
         logging.info('Expanded the first item')
 
-        logging.info('Re-listing items of the bottom-up view...')
-        tree_items = tree_view.children(control_type='TreeItem')
-
-        if not tree_items[BOTTOM_UP_ROW_CELL_COUNT].window_text().startswith('drm'):
+        second_row_tree_item = tree_view_table.get_item_at(1, 0)
+        if not second_row_tree_item.window_text().startswith('drm'):
             raise RuntimeError('First child of the first item ("ioctl") '
                                'of the bottom-up view doesn\'t start with "drm"')
         logging.info('Verified that first child of the first item starts with "drm"')

--- a/contrib/automation_tests/test_cases/top_down_tab.py
+++ b/contrib/automation_tests/test_cases/top_down_tab.py
@@ -5,58 +5,57 @@ found in the LICENSE file.
 """
 import logging
 
+from core.common_controls import Table
 from core.orbit_e2e import E2ETestCase, find_control
 
 
 class VerifyHelloGgpTopDownContents(E2ETestCase):
     """
-    TODO: This could be updated to check the contents more thoroughly and dynamically
-    react to the amount of columns in the treeview - see common_controls.DataViewPanel
-    on how to access the required fields.
+    Verify that the first rows of the top-down view are in line with hello_ggp.
+    In particular, we expect the first row to be "hello_* (all threads)", with children "*clone" and "_start",
+    and the second row to be "hello_*]" or "Ggp*]".
     """
 
     def _execute(self):
         self.find_control("TabItem", "Top-Down").click_input()
         logging.info('Switched to Top-Down tab')
 
-        tree_view = find_control(self.find_control('Group', 'topDownTab'), 'Tree')
+        tree_view_table = Table(find_control(self.find_control('Group', 'topDownTab'), 'Tree'))
 
-        # tree_view.children(control_type='TreeItem') returns
-        # every cell in the top-down view, in order by row and then column.
-        # It can take a few seconds.
-        logging.info('Listing items of the top-down view...')
-        tree_items = tree_view.children(control_type='TreeItem')
-        TOP_DOWN_ROW_CELL_COUNT = 6
-        row_count_before_expansion = len(tree_items) / TOP_DOWN_ROW_CELL_COUNT
+        logging.info('Counting rows of the top-down view...')
+        row_count_before_expansion = tree_view_table.get_row_count()
 
         if row_count_before_expansion < 3:
             raise RuntimeError('Less than 3 rows in the top-down view')
 
-        if (not tree_items[0].window_text().startswith('hello_') or
-                not tree_items[0].window_text().endswith(' (all threads)')):
+        first_row_tree_item = tree_view_table.get_item_at(0, 0)
+        if (not first_row_tree_item.window_text().startswith('hello_') or
+                not first_row_tree_item.window_text().endswith(' (all threads)')):
             raise RuntimeError('First item of the top-down view is not "hello_* (all threads)"')
         logging.info('Verified that first item is "hello_* (all threads)"')
 
-        if ((not tree_items[TOP_DOWN_ROW_CELL_COUNT].window_text().startswith('hello_') and
-             not tree_items[TOP_DOWN_ROW_CELL_COUNT].window_text().startswith('Ggp')) or
-                not tree_items[TOP_DOWN_ROW_CELL_COUNT].window_text().endswith(']')):
+        second_row_tree_item = tree_view_table.get_item_at(1, 0)
+        if ((not second_row_tree_item.window_text().startswith('hello_') and
+             not second_row_tree_item.window_text().startswith('Ggp')) or
+                not second_row_tree_item.window_text().endswith(']')):
             raise RuntimeError('Second item of the top-down view is not "hello_*]" nor "Ggp*]"')
         logging.info('Verified that second item is "hello_*]" or "Ggp*]"')
 
-        tree_items[0].double_click_input()
+        first_row_tree_item.double_click_input()
         logging.info('Expanded the first item')
 
-        logging.info('Re-listing items of the top-down view...')
-        tree_items = tree_view.children(control_type='TreeItem')
-        row_count_after_expansion = len(tree_items) / TOP_DOWN_ROW_CELL_COUNT
+        logging.info('Re-counting rows of the top-down view...')
+        row_count_after_expansion = tree_view_table.get_row_count()
 
         if row_count_after_expansion < row_count_before_expansion + 2:
             raise RuntimeError(
                 'First item of the top-down view doesn\'t have at least two children')
-        if (not ((tree_items[TOP_DOWN_ROW_CELL_COUNT].window_text().endswith('clone') and
-                  tree_items[2 * TOP_DOWN_ROW_CELL_COUNT].window_text() == '_start') or
-                 (tree_items[TOP_DOWN_ROW_CELL_COUNT].window_text() == '_start') and
-                 tree_items[2 * TOP_DOWN_ROW_CELL_COUNT].window_text().endswith('clone'))):
+        second_row_tree_item = tree_view_table.get_item_at(1, 0)
+        third_row_tree_item = tree_view_table.get_item_at(2, 0)
+        if (not ((second_row_tree_item.window_text().endswith('clone') and
+                  third_row_tree_item.window_text() == '_start') or
+                 (second_row_tree_item.window_text() == '_start') and
+                 third_row_tree_item.window_text().endswith('clone'))):
             raise RuntimeError('Children of the first item of the top-down view '
                                'are not "*clone" and "_start"')
         logging.info('Verified that children of the first item are "*clone" and "_start"')


### PR DESCRIPTION
This also makes the tests run faster because we no longer need to list all the
children of the tree, which was taking pywinauto a relatively long time.

Test: Ran `orbit_top_down.py` and `orbit_bottom_up.py` locally.