### PR TITLE
Remove underscore from "all_threads" track

### DIFF
--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -66,7 +66,7 @@ std::string ThreadTrack::GetName() const {
   return capture_data_->GetThreadName(thread_id);
 }
 
-constexpr std::string_view kAllThreads = " (all_threads)";
+constexpr std::string_view kAllThreads = " (all threads)";
 std::string ThreadTrack::GetLabel() const {
   auto thread_id = GetThreadId();
   auto name = GetName();


### PR DESCRIPTION
This is a regression from e682957f4d1d05f52c9cef88beea4623b6342e04 from October
2020. Either way, the underscore shouldn't be there. The "Sampling", "Top-Down"
and "Bottom-Up" view also don't have the underscore.

Test: Take a capture.