### PR TITLE
Set target pid in KrabsTracer

### DIFF
--- a/src/WindowsTracing/KrabsTracer.cpp
+++ b/src/WindowsTracing/KrabsTracer.cpp
@@ -25,6 +25,8 @@ KrabsTracer::KrabsTracer(orbit_grpc_protos::CaptureOptions capture_options,
                          TracerListener* listener)
     : capture_options_(std::move(capture_options)),
       listener_(listener),
+      target_pid_(capture_options_.pid()),
+
       trace_(KERNEL_LOGGER_NAME),
       stack_walk_provider_(EVENT_TRACE_FLAG_PROFILE, krabs::guids::stack_walk) {
   SetTraceProperties();


### PR DESCRIPTION
Make sure we filter incoming callstack events on Windows by properly
setting the target pid in the Windows tracer (KrabsTracer).