### PR TITLE
Add automated test for top-down and bottom-up views on loaded capture

### DIFF
--- a/contrib/automation_tests/orbit_loaded_top_down_bottom_up.py
+++ b/contrib/automation_tests/orbit_loaded_top_down_bottom_up.py
@@ -1,0 +1,49 @@
+"""
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from test_cases.bottom_up_tab import VerifyBottomUpContentForLoadedCapture
+from test_cases.capture_window import FilterTracks, SelectAllCallstacks, ZoomOut
+from test_cases.connection_window import LoadCapture
+from test_cases.top_down_tab import VerifyTopDownContentForLoadedCapture
+"""Inspect the top-down view in Orbit using pywinauto.
+
+Before this script is run Orbit needs to be started.
+
+The script requires absl and pywinauto. Since pywinauto requires the bitness of
+the python installation to match the bitness of the program under test, it needs
+to be run from 64 bit python.
+
+This automation script covers a basic workflow:
+ - load a known capture
+ - verify the content of the top-down view
+ - verify the content of the bottom-up view
+ - select all callstacks using the "(all threads)" track
+ - verify the content of the top-down view for the selection
+ - verify the content of the bottom-up view for the selection
+"""
+
+
+def main(argv):
+    test_cases = [
+        LoadCapture(capture_file_path="testdata\\OrbitTest_1-72.orbit"),
+        VerifyTopDownContentForLoadedCapture(selection_tab=False),
+        VerifyBottomUpContentForLoadedCapture(selection_tab=False),
+
+        ZoomOut(),
+        FilterTracks(filter_string='threads{)}'),
+        SelectAllCallstacks(track_name_filter='All Threads'),
+        VerifyTopDownContentForLoadedCapture(selection_tab=True),
+        VerifyBottomUpContentForLoadedCapture(selection_tab=True),
+    ]
+    suite = E2ETestSuite(test_name="Top-Down and Bottom-Up view of loaded capture", test_cases=test_cases)
+    suite.execute()
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/contrib/automation_tests/test_cases/bottom_up_tab.py
+++ b/contrib/automation_tests/test_cases/bottom_up_tab.py
@@ -9,6 +9,7 @@ import time
 from core.common_controls import Table
 from core.orbit_e2e import E2ETestCase, find_control
 from pywinauto.keyboard import send_keys
+from typing import Sequence
 
 
 class VerifyHelloGgpBottomUpContents(E2ETestCase):
@@ -44,12 +45,17 @@ class VerifyHelloGgpBottomUpContents(E2ETestCase):
 
 
 class VerifyBottomUpContentForLoadedCapture(E2ETestCase):
+    """
+    Verify the content of the bottom-up view for the capture loaded from "OrbitTest_1-72.orbit".
+    In particular, we verify the number of rows and the content of the first rows when the tree is expanded in a few
+    different ways. Then we search for a function and verify that the tree is expanded to show it.
+    """
 
     def _verify_row_count(self, tree_view_table: Table, expected_rows: int):
         self.expect_eq(tree_view_table.get_row_count(), expected_rows,
                        "Bottom-up view has {} rows".format(expected_rows))
 
-    def _verify_first_rows(self, tree_view_table: Table, expectations: list[list[str]],
+    def _verify_first_rows(self, tree_view_table: Table, expectations: Sequence[Sequence[str]],
                            hidden_columns: set[int]):
         for i in range(len(expectations)):
             for j in range(len(expectations[i])):

--- a/contrib/automation_tests/test_cases/bottom_up_tab.py
+++ b/contrib/automation_tests/test_cases/bottom_up_tab.py
@@ -4,9 +4,11 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
 import logging
+import time
 
 from core.common_controls import Table
 from core.orbit_e2e import E2ETestCase, find_control
+from pywinauto.keyboard import send_keys
 
 
 class VerifyHelloGgpBottomUpContents(E2ETestCase):
@@ -39,3 +41,123 @@ class VerifyHelloGgpBottomUpContents(E2ETestCase):
             raise RuntimeError('First child of the first item ("ioctl") '
                                'of the bottom-up view doesn\'t start with "drm"')
         logging.info('Verified that first child of the first item starts with "drm"')
+
+
+class VerifyBottomUpContentForLoadedCapture(E2ETestCase):
+
+    def _verify_row_count(self, tree_view_table: Table, expected_rows: int):
+        self.expect_eq(tree_view_table.get_row_count(), expected_rows,
+                       "Bottom-up view has {} rows".format(expected_rows))
+
+    def _verify_first_rows(self, tree_view_table: Table, expectations: list[list[str]],
+                           hidden_columns: set[int]):
+        for i in range(len(expectations)):
+            for j in range(len(expectations[i])):
+                if j in hidden_columns:
+                    continue
+                expectation = expectations[i][j]
+                self.expect_eq(
+                    tree_view_table.get_item_at(i, j).window_text(), expectation,
+                    "Bottom-up view's cell ({}, {}) is '{}'".format(i, j, expectation))
+
+    def _execute(self, selection_tab: bool = False):
+        if not selection_tab:
+            self.find_control('TabItem', 'Bottom-Up').click_input()
+            logging.info("Switched to 'Bottom-Up' tab")
+            tab = self.find_control('Group', 'bottomUpTab')
+        else:
+            self.find_control('TabItem', 'Bottom-Up (selection)').click_input()
+            logging.info("Switched to 'Bottom-Up (selection)' tab")
+            tab = self.find_control('Group', 'selectionBottomUpTab')
+
+        tree_view_table = Table(find_control(tab, 'Tree'))
+
+        # Note that one column is hidden.
+        self.expect_eq(tree_view_table.get_column_count(), 6, "Bottom-up view has 6 columns")
+        hidden_columns = {2}
+
+        expected_leaf_count = 132
+        self._verify_row_count(tree_view_table, expected_leaf_count)
+
+        expectations = [
+            ["clock_gettime", "61.66% (976)", "", "", "[vdso]", "0x7fff627d1a00"],
+            [
+                "std::__1::chrono::system_clock::now()", "8.59% (136)", "", "", "libc++.so.1.0",
+                "0x7fe86ff978e0"
+            ],
+        ]
+        self._verify_first_rows(tree_view_table, expectations, hidden_columns)
+        logging.info("Verified content of bottom-up view when all leaves are collapsed")
+
+        logging.info("Expanding a leaf of the bottom-up view")
+        tree_view_table.get_item_at(0, 0).double_click_input()
+        expected_first_leaf_child = 1
+        self._verify_row_count(tree_view_table, expected_leaf_count + expected_first_leaf_child)
+
+        expectations = [
+            ["clock_gettime", "61.66% (976)", "", "", "[vdso]", "0x7fff627d1a00"],
+            ["__clock_gettime", "61.66% (976)", "", "100.00%", "libc-2.24.so", "0x7fe86f002940"],
+            [
+                "std::__1::chrono::system_clock::now()", "8.59% (136)", "", "", "libc++.so.1.0",
+                "0x7fe86ff978e0"
+            ],
+        ]
+        self._verify_first_rows(tree_view_table, expectations, hidden_columns)
+        logging.info("Verified content of bottom-up view when one leaf is expanded")
+
+        logging.info("Recursively expanding a leaf of the bottom-up view")
+        tree_view_table.get_item_at(0, 0).click_input(button='right')
+        self.find_context_menu_item('Expand recursively').click_input()
+        expected_first_leaf_descendant_count = 50
+        self._verify_row_count(tree_view_table,
+                               expected_leaf_count + expected_first_leaf_descendant_count)
+
+        expectations = [
+            ["clock_gettime", "61.66% (976)", "", "", "[vdso]", "0x7fff627d1a00"],
+            ["__clock_gettime", "61.66% (976)", "", "100.00%", "libc-2.24.so", "0x7fe86f002940"],
+            [
+                "std::__1::chrono::system_clock::now()", "61.53% (974)", "", "99.80%",
+                "libc++.so.1.0", "0x7fe86ff978e0"
+            ],
+            [
+                "OrbitTestImpl::BusyWork(unsigned long)", "61.53% (974)", "", "100.00%",
+                "OrbitTest", "0x55a44717b2c0"
+            ],
+        ]
+        self._verify_first_rows(tree_view_table, expectations, hidden_columns)
+        logging.info("Verified content of bottom-up view when one leaf is recursively expanded")
+
+        logging.info("Expanding the entire bottom-up view")
+        tree_view_table.get_item_at(0, 0).click_input(button='right')
+        self.find_context_menu_item('Expand all').click_input()
+        self._verify_row_count(tree_view_table, 1908)
+
+        # Previously we recursively expanded the first node, so the expectations on the first rows are still the same.
+        self._verify_first_rows(tree_view_table, expectations, hidden_columns)
+        logging.info("Verified content of bottom-up view when it is completely expanded")
+
+        search_term = 'eventfd_write'
+        logging.info("Searching bottom-up view for '{}'".format(search_term))
+        search_bar = find_control(parent=tab, control_type='Edit', name='filter')
+        search_bar.set_focus()
+        send_keys(search_term)
+        time.sleep(1)  # The bottom-up view waits for the user to stop typing before searching.
+        self._verify_row_count(tree_view_table, expected_leaf_count + 1)
+
+        search_item_count = 0
+        for i in range(tree_view_table.get_row_count()):
+            if tree_view_table.get_item_at(i, 0).window_text() == search_term:
+                search_item_count += 1
+                expectations = [
+                    "eventfd_write", "1.77% (28)", "", "100.00%", "libc-2.24.so", "0x7fe86eff5c30"
+                ]
+                for j in range(len(expectations)):
+                    if j in hidden_columns:
+                        continue
+                    expectation = expectations[j]
+                    self.expect_eq(
+                        tree_view_table.get_item_at(i, j).window_text(), expectation,
+                        "Bottom-up view's cell ({}, {}) is '{}'".format(i, j, expectation))
+        self.expect_eq(search_item_count, 1,
+                       "Searching bottom-up view for '{}' produces one result".format(search_term))
+        logging.info("Verified result of searching bottom-up view for '{}'".format(search_term))

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -259,13 +259,12 @@ class ToggleCollapsedStateOfAllTracks(CaptureWindowE2ETestCaseBase):
 class FilterTracks(CaptureWindowE2ETestCaseBase):
     """
     Set a filter in the capture tab.
-    Note that this uses pywinauto's `keyboard.send_keys`, so certain special characters need to be escaped by enclosing
-    them in {}.
     """
 
     def _execute(self, filter_string: str = "", expected_track_count=None):
         """
-        :param filter_string: The string to be entered in the filter edit
+        :param filter_string: The string to be entered in the filter edit. Note that pywinauto's `keyboard.send_keys` is
+            used, so certain special characters need to be escaped by enclosing them in {}.
         :param expected_track_count: If not None, this test will verify the amount of tracks after filtering
         """
         toolbar = self.find_control("ToolBar", "CaptureToolBar")

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -258,7 +258,9 @@ class ToggleCollapsedStateOfAllTracks(CaptureWindowE2ETestCaseBase):
 
 class FilterTracks(CaptureWindowE2ETestCaseBase):
     """
-    Set a filter in the capture tab
+    Set a filter in the capture tab.
+    Note that this uses pywinauto's `keyboard.send_keys`, so certain special characters need to be escaped by enclosing
+    them in {}.
     """
 
     def _execute(self, filter_string: str = "", expected_track_count=None):

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -489,6 +489,10 @@ class CheckCallstacks(CaptureWindowE2ETestCaseBase):
 
 
 class SelectAllCallstacks(CaptureWindowE2ETestCaseBase):
+    """
+    Select all currently visible callstacks (based on the current visible section of the capture) from the track with
+    the specified name.
+    """
 
     def _execute(self, track_name_filter: str):
         tracks = self._find_tracks(track_name_filter)
@@ -502,6 +506,17 @@ class SelectAllCallstacks(CaptureWindowE2ETestCaseBase):
         callstacks = track.callstacks
         rect = callstacks.rectangle()
         callstacks.drag_mouse_input(src=(rect.left, rect.top + 5), dst=(rect.right, rect.top + 5))
+
+        self.expect_true(
+            self.find_control('TabItem', 'Sampling (selection)').is_enabled(),
+            "'Sampling (selection)' tab is enabled")
+        self.expect_true(
+            self.find_control('TabItem', 'Top-Down (selection)').is_enabled(),
+            "'Top-Down (selection)' tab is enabled")
+        self.expect_true(
+            self.find_control('TabItem', 'Bottom-Up (selection)').is_enabled(),
+            "'Bottom-Up (selection)' tab is enabled")
+        logging.info("Verified that '(selection)' tabs are enabled")
 
 
 class SetAndCheckMemorySamplingPeriod(E2ETestCase):

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -279,6 +279,19 @@ class FilterTracks(CaptureWindowE2ETestCaseBase):
             wait_for_condition(lambda: len(self._find_tracks()) == expected_track_count)
 
 
+class ZoomOut(CaptureWindowE2ETestCaseBase):
+    """
+    Zooms the capture view out all the way so that the entire capture is visible.
+    """
+
+    def _execute(self):
+        logging.info('Zooming out the capture window')
+        self._time_graph.click_input()
+        # This should be enough so that we can zoom all the way out from any zoom level with any capture duration.
+        for i in range(200):
+            send_keys("s")
+
+
 class Capture(E2ETestCase):
 
     def _show_capture_window(self):
@@ -437,13 +450,18 @@ class CheckTimers(CaptureWindowE2ETestCaseBase):
             elif not expect_exists and track.timers is None:
                 satisfying_count += 1
         if expect_exists:
-            self.expect_true(satisfying_count > 0,
-                             'At least one track matching "{}" has timers pane'.format(track_name_filter))
+            self.expect_true(
+                satisfying_count > 0,
+                'At least one track matching "{}" has timers pane'.format(track_name_filter))
         else:
-            self.expect_true(satisfying_count > 0,
-                             'At least one track matching "{}" has no timers pane'.format(track_name_filter))
+            self.expect_true(
+                satisfying_count > 0,
+                'At least one track matching "{}" has no timers pane'.format(track_name_filter))
 
-    def _execute(self, track_name_filter: str, expect_exists: bool = True, require_all: bool = True,
+    def _execute(self,
+                 track_name_filter: str,
+                 expect_exists: bool = True,
+                 require_all: bool = True,
                  recursive: bool = False):
         tracks = self._find_tracks(track_name_filter, recursive)
         self.expect_true(len(tracks) > 0, 'Found tracks matching "{}"'.format(track_name_filter))
@@ -468,6 +486,22 @@ class CheckCallstacks(CaptureWindowE2ETestCaseBase):
             else:
                 self.expect_true(track.callstacks is None,
                                  'Track "{}" has no callstacks pane'.format(track.name))
+
+
+class SelectAllCallstacks(CaptureWindowE2ETestCaseBase):
+
+    def _execute(self, track_name_filter: str):
+        tracks = self._find_tracks(track_name_filter)
+        self.expect_true(
+            len(tracks) == 1, 'Found exactly one track matching "{}"'.format(track_name_filter))
+        track = Track(tracks[0])
+        self.expect_true(track.callstacks is not None,
+                         'Track "{}" has callstacks pane'.format(track.name))
+
+        logging.info('Selecting all visible callstacks in track "{}"'.format(track.name))
+        callstacks = track.callstacks
+        rect = callstacks.rectangle()
+        callstacks.drag_mouse_input(src=(rect.left, rect.top + 5), dst=(rect.right, rect.top + 5))
 
 
 class SetAndCheckMemorySamplingPeriod(E2ETestCase):

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -289,14 +289,14 @@ class FilterAndSelectFirstProcess(E2ETestCase):
     def _execute(self, process_filter):
         # Finding FilterProcesses/ProcessList occationally throws from within pywinauto. This is not
         # understood. The while loop with the try/except block is a workaround for that.
-        while (True):
+        while True:
             try:
                 filter_edit = self.find_control('Edit', 'FilterProcesses')
                 break
             except KeyError:
                 logging.info('Find FilterProcesses failed. Try again.')
 
-        while (True):
+        while True:
             try:
                 process_list = self.find_control('Table', 'ProcessList')
                 break

--- a/contrib/automation_tests/test_cases/top_down_tab.py
+++ b/contrib/automation_tests/test_cases/top_down_tab.py
@@ -9,6 +9,7 @@ import time
 from core.common_controls import Table
 from core.orbit_e2e import E2ETestCase, find_control
 from pywinauto.keyboard import send_keys
+from typing import Sequence
 
 
 class VerifyHelloGgpTopDownContents(E2ETestCase):
@@ -64,12 +65,17 @@ class VerifyHelloGgpTopDownContents(E2ETestCase):
 
 
 class VerifyTopDownContentForLoadedCapture(E2ETestCase):
+    """
+    Verify the content of the top-down view for the capture loaded from "OrbitTest_1-72.orbit".
+    In particular, we verify the number of rows and the content of the first rows when the tree is expanded in a few
+    different ways. Then we search for a function and verify that the tree is expanded to show it.
+    """
 
     def _verify_row_count(self, tree_view_table: Table, expected_rows: int):
         self.expect_eq(tree_view_table.get_row_count(), expected_rows,
                        "Top-down view has {} rows".format(expected_rows))
 
-    def _verify_first_rows(self, tree_view_table: Table, expectations: list[list[str]]):
+    def _verify_first_rows(self, tree_view_table: Table, expectations: Sequence[Sequence[str]]):
         for i in range(len(expectations)):
             for j in range(len(expectations[i])):
                 expectation = expectations[i][j]

--- a/contrib/automation_tests/test_cases/top_down_tab.py
+++ b/contrib/automation_tests/test_cases/top_down_tab.py
@@ -4,9 +4,11 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
 import logging
+import time
 
 from core.common_controls import Table
 from core.orbit_e2e import E2ETestCase, find_control
+from pywinauto.keyboard import send_keys
 
 
 class VerifyHelloGgpTopDownContents(E2ETestCase):
@@ -59,3 +61,128 @@ class VerifyHelloGgpTopDownContents(E2ETestCase):
             raise RuntimeError('Children of the first item of the top-down view '
                                'are not "*clone" and "_start"')
         logging.info('Verified that children of the first item are "*clone" and "_start"')
+
+
+class VerifyTopDownContentForLoadedCapture(E2ETestCase):
+
+    def _verify_row_count(self, tree_view_table: Table, expected_rows: int):
+        self.expect_eq(tree_view_table.get_row_count(), expected_rows,
+                       "Top-down view has {} rows".format(expected_rows))
+
+    def _verify_first_rows(self, tree_view_table: Table, expectations: list[list[str]]):
+        for i in range(len(expectations)):
+            for j in range(len(expectations[i])):
+                expectation = expectations[i][j]
+                self.expect_eq(
+                    tree_view_table.get_item_at(i, j).window_text(), expectation,
+                    "Top-down view's cell ({}, {}) is '{}'".format(i, j, expectation))
+
+    def _execute(self, selection_tab: bool = False):
+        if not selection_tab:
+            self.find_control('TabItem', 'Top-Down').click_input()
+            logging.info("Switched to 'Top-Down' tab")
+            tab = self.find_control('Group', 'topDownTab')
+        else:
+            self.find_control('TabItem', 'Top-Down (selection)').click_input()
+            logging.info("Switched to 'Top-Down (selection)' tab")
+            tab = self.find_control('Group', 'selectionTopDownTab')
+
+        tree_view_table = Table(find_control(tab, 'Tree'))
+
+        self.expect_eq(tree_view_table.get_column_count(), 6, "Top-down view has 6 columns")
+
+        expected_thread_count = 20
+        self._verify_row_count(tree_view_table, expected_thread_count)
+
+        expectations = [
+            ["OrbitTest (all threads)", "100.00% (1583)", "", "", "", ""],
+            ["OrbitThread_203 [20301]", "79.34% (1256)", "", "", "", ""],
+        ]
+        self._verify_first_rows(tree_view_table, expectations)
+        logging.info("Verified content of top-down view when all threads are collapsed")
+
+        logging.info("Expanding a thread of the top-down view")
+        tree_view_table.get_item_at(1, 0).double_click_input()
+        expected_first_thread_child_count = 2
+        self._verify_row_count(tree_view_table,
+                               expected_thread_count + expected_first_thread_child_count)
+
+        expectations = [
+            ["OrbitTest (all threads)", "100.00% (1583)", "", "", "", ""],
+            ["OrbitThread_203 [20301]", "79.34% (1256)", "", "", "", ""],
+            ["clone", "79.22% (1254)", "0.00% (0)", "99.84%", "libc-2.24.so", "0x7fe86eff5900"],
+            ["[unwind errors]", "0.13% (2)", "", "0.16%", "", ""],
+        ]
+        self._verify_first_rows(tree_view_table, expectations)
+        logging.info("Verified content of top-down view when one thread is expanded")
+
+        logging.info("Recursively expanding a thread of the top-down view")
+        tree_view_table.get_item_at(1, 0).click_input(button='right')
+        self.find_context_menu_item('Expand recursively').click_input()
+        expected_first_thread_descendant_count = 19
+        self._verify_row_count(tree_view_table,
+                               expected_thread_count + expected_first_thread_descendant_count)
+
+        expectations = [
+            ["OrbitTest (all threads)", "100.00% (1583)", "", "", "", ""],
+            ["OrbitThread_203 [20301]", "79.34% (1256)", "", "", "", ""],
+            ["clone", "79.22% (1254)", "0.00% (0)", "99.84%", "libc-2.24.so", "0x7fe86eff5900"],
+            [
+                "start_thread", "79.22% (1254)", "0.00% (0)", "100.00%", "libpthread-2.24.so",
+                "0x7fe86f9d0480"
+            ],
+            [
+                "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (OrbitTestImpl::*)(), OrbitTestImpl*> >(void*)",
+                "79.22% (1254)", "0.00% (0)", "100.00%", "OrbitTest", "0x55a44717c430"
+            ],
+        ]
+        self._verify_first_rows(tree_view_table, expectations)
+        logging.info("Verified content of top-down view when one thread is recursively expanded")
+
+        logging.info("Expanding the entire top-down view")
+        tree_view_table.get_item_at(0, 0).click_input(button='right')
+        self.find_context_menu_item('Expand all').click_input()
+        self._verify_row_count(tree_view_table, 827)
+
+        expectations = [
+            ["OrbitTest (all threads)", "100.00% (1583)", "", "", "", ""],
+            ["clone", "97.79% (1548)", "0.00% (0)", "97.79%", "libc-2.24.so", "0x7fe86eff5900"],
+            [
+                "start_thread", "97.79% (1548)", "0.00% (0)", "100.00%", "libpthread-2.24.so",
+                "0x7fe86f9d0480"
+            ],
+            [
+                "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (OrbitTestImpl::*)(), OrbitTestImpl*> >(void*)",
+                "79.72% (1262)", "0.00% (0)", "81.52%", "OrbitTest", "0x55a44717c430"
+            ],
+            [
+                "OrbitTestImpl::Loop()", "79.22% (1254)", "0.00% (0)", "99.37%", "OrbitTest",
+                "0x55a44717a950"
+            ],
+        ]
+        self._verify_first_rows(tree_view_table, expectations)
+        logging.info("Verified content of top-down view when it is completely expanded")
+
+        search_term = 'fputs'
+        logging.info("Searching top-down view for '{}'".format(search_term))
+        search_bar = find_control(parent=tab, control_type='Edit', name='filter')
+        search_bar.set_focus()
+        send_keys(search_term)
+        time.sleep(1)  # The top-down view waits for the user to stop typing before searching.
+        self._verify_row_count(tree_view_table, 42)
+
+        search_item_count = 0
+        for i in range(tree_view_table.get_row_count()):
+            if tree_view_table.get_item_at(i, 0).window_text() == search_term:
+                search_item_count += 1
+                expectations = [
+                    "fputs", "0.06% (1)", "0.06% (1)", "100.00%", "libc-2.24.so", "0x7fe86ef70f90"
+                ]
+                for j in range(len(expectations)):
+                    expectation = expectations[j]
+                    self.expect_eq(
+                        tree_view_table.get_item_at(i, j).window_text(), expectation,
+                        "Top-down view's cell ({}, {}) is '{}'".format(i, j, expectation))
+        self.expect_eq(search_item_count, 2,
+                       "Searching top-down view for '{}' produces two results".format(search_term))
+        logging.info("Verified result of searching top-down view for '{}'".format(search_term))


### PR DESCRIPTION
This uses the same capture as `orbit_capture_loading.py`.
A couple of utility classes are added to `capture_window.py`.

Bug: http://b/208239777
Bug: http://b/208240430

Test: Ran locally.