### PR TITLE
Look for dlopen in more places

### DIFF
--- a/src/UserSpaceInstrumentation/BUILD
+++ b/src/UserSpaceInstrumentation/BUILD
@@ -25,6 +25,7 @@ orbit_cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
     ],
 )
 


### PR DESCRIPTION
Starting with glibc-2.34 all symbols from auxiliary libraries like
libpthread, libdl, libutil, libanl have been moved into the main
libc.so.6.

That means when looking for dlopen and other linker related function we
need to look into the libc module as well.

Ref: https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html
Bug: http://b/211756973