### PR TITLE
Add kokoro build config for clang11

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -13,6 +13,7 @@ if [ -z "${CONAN_PROFILE}" ]; then
   # Profile mappings. Use that for testing different profiles
   # without changing the Kokoro config.
   declare -A profile_mapping=( \
+    [clang9_debug]="clang11_release"
   )
 
   CONAN_PROFILE="${profile_mapping[${CONAN_PROFILE}]-${CONAN_PROFILE}}"

--- a/kokoro/builds/linux/clang11_debug/common.cfg
+++ b/kokoro/builds/linux/clang11_debug/common.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/builds/build.sh"
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/testresults/*.xml"
+    strip_prefix: "github/orbitprofiler/build/package"
+  }
+}
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/conan_trace.log"
+    strip_prefix: "github/orbitprofiler/build"
+  }
+}

--- a/kokoro/builds/linux/clang11_debug/presubmit.cfg
+++ b/kokoro/builds/linux/clang11_debug/presubmit.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto


### PR DESCRIPTION
The build config is an exact copy of the clang9 config. That allows us
to move to clang11 on the CI side and ensure that we don't break this
build.