### PR TITLE
Minor cleanup of CaptureService module

### DIFF
--- a/src/CaptureService/CaptureService.cpp
+++ b/src/CaptureService/CaptureService.cpp
@@ -5,21 +5,16 @@
 #include "CaptureService/CaptureService.h"
 
 #include <absl/time/time.h>
-#include <stdint.h>
 
 #include "CaptureService/CommonProducerCaptureEventBuilders.h"
 #include "GrpcProtos/Constants.h"
 #include "GrpcProtos/capture.pb.h"
-#include "Introspection/Introspection.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Profiling.h"
 
-using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::CaptureRequest;
 using orbit_grpc_protos::CaptureResponse;
-using orbit_grpc_protos::CaptureStarted;
-using orbit_grpc_protos::ProducerCaptureEvent;
 
 using orbit_producer_event_processor::GrpcClientCaptureEventCollector;
 using orbit_producer_event_processor::ProducerEventProcessor;
@@ -81,7 +76,7 @@ CaptureRequest CaptureService::WaitForStartCaptureRequestFromClient(
   return request;
 }
 
-void CaptureService::WaitForEndCaptureRequestFromClient(
+void CaptureService::WaitForStopCaptureRequestFromClient(
     grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse, orbit_grpc_protos::CaptureRequest>*
         reader_writer) {
   orbit_grpc_protos::CaptureRequest request;

--- a/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
@@ -8,7 +8,6 @@
 
 #include "GrpcProtos/capture.pb.h"
 #include "GrpcProtos/services.grpc.pb.h"
-#include "Introspection/Introspection.h"
 #include "ObjectUtils/CoffFile.h"
 #include "ObjectUtils/ElfFile.h"
 #include "OrbitBase/ExecutablePath.h"
@@ -19,8 +18,6 @@
 
 using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::CaptureOptions;
-using orbit_grpc_protos::CaptureRequest;
-using orbit_grpc_protos::CaptureResponse;
 using orbit_grpc_protos::CaptureStarted;
 using orbit_grpc_protos::ProducerCaptureEvent;
 

--- a/src/CaptureService/include/CaptureService/CaptureService.h
+++ b/src/CaptureService/include/CaptureService/CaptureService.h
@@ -24,13 +24,7 @@ namespace orbit_capture_service {
 // functionality shared by the platform-specific capture services.
 class CaptureService : public orbit_grpc_protos::CaptureService::Service {
  public:
-  virtual ~CaptureService() = default;
   CaptureService();
-
-  virtual grpc::Status Capture(
-      grpc::ServerContext* context,
-      grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse,
-                               orbit_grpc_protos::CaptureRequest>* reader_writer) = 0;
 
   void AddCaptureStartStopListener(CaptureStartStopListener* listener);
   void RemoveCaptureStartStopListener(CaptureStartStopListener* listener);
@@ -41,11 +35,11 @@ class CaptureService : public orbit_grpc_protos::CaptureService::Service {
                                orbit_grpc_protos::CaptureRequest>* reader_writer);
   void TerminateCapture();
 
-  orbit_grpc_protos::CaptureRequest WaitForStartCaptureRequestFromClient(
+  static orbit_grpc_protos::CaptureRequest WaitForStartCaptureRequestFromClient(
       grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse,
                                orbit_grpc_protos::CaptureRequest>* reader_writer);
 
-  void WaitForEndCaptureRequestFromClient(
+  static void WaitForStopCaptureRequestFromClient(
       grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse,
                                orbit_grpc_protos::CaptureRequest>* reader_writer);
 
@@ -60,8 +54,6 @@ class CaptureService : public orbit_grpc_protos::CaptureService::Service {
   uint64_t capture_start_timestamp_ns_ = 0;
 
  private:
-  void EstimateAndLogClockResolution();
-
   uint64_t clock_resolution_ns_ = 0;
   absl::Mutex capture_mutex_;
   bool is_capturing ABSL_GUARDED_BY(capture_mutex_) = false;

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -34,14 +34,11 @@
 #include "TracingHandler.h"
 #include "UserSpaceInstrumentationAddressesImpl.h"
 
-using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::CaptureRequest;
 using orbit_grpc_protos::CaptureResponse;
-using orbit_grpc_protos::CaptureStarted;
 using orbit_grpc_protos::ProducerCaptureEvent;
 
-using orbit_producer_event_processor::GrpcClientCaptureEventCollector;
 using orbit_producer_event_processor::ProducerEventProcessor;
 
 using orbit_capture_service::CaptureStartStopListener;

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -5,13 +5,12 @@
 #include "LinuxCaptureService/LinuxCaptureService.h"
 
 #include <absl/container/flat_hash_set.h>
-#include <absl/strings/str_cat.h>
+#include <absl/strings/str_format.h>
 #include <absl/synchronization/mutex.h>
 #include <absl/time/time.h>
 #include <stdint.h>
 
 #include <algorithm>
-#include <limits>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -23,7 +22,6 @@
 #include "GrpcProtos/capture.pb.h"
 #include "Introspection/Introspection.h"
 #include "MemoryInfoHandler.h"
-#include "ObjectUtils/ElfFile.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/MakeUniqueForOverwrite.h"

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -257,7 +257,7 @@ grpc::Status LinuxCaptureService::Capture(
     listener->OnCaptureStartRequested(request.capture_options(), &function_entry_exit_hijacker);
   }
 
-  WaitForEndCaptureRequestFromClient(reader_writer);
+  WaitForStopCaptureRequestFromClient(reader_writer);
 
   // Disable Orbit API in tracee.
   if (capture_options.enable_api()) {

--- a/src/LinuxCaptureService/MemoryInfoHandler.h
+++ b/src/LinuxCaptureService/MemoryInfoHandler.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef CAPTURE_SERVICE_MEMORY_INFO_HANDLER_H_
-#define CAPTURE_SERVICE_MEMORY_INFO_HANDLER_H_
+#ifndef LINUX_CAPTURE_SERVICE_MEMORY_INFO_HANDLER_H_
+#define LINUX_CAPTURE_SERVICE_MEMORY_INFO_HANDLER_H_
 
 #include "GrpcProtos/capture.pb.h"
 #include "MemoryTracing/MemoryInfoListener.h"
@@ -45,4 +45,4 @@ class MemoryInfoHandler : public orbit_memory_tracing::MemoryInfoListener {
 
 }  // namespace orbit_linux_capture_service
 
-#endif  // CAPTURE_SERVICE_MEMORY_INFO_HANDLER_H_
+#endif  // LINUX_CAPTURE_SERVICE_MEMORY_INFO_HANDLER_H_

--- a/src/LinuxCaptureService/TracingHandler.h
+++ b/src/LinuxCaptureService/TracingHandler.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef CAPTURE_SERVICE_LINUX_TRACING_HANDLER_H_
-#define CAPTURE_SERVICE_LINUX_TRACING_HANDLER_H_
+#ifndef LINUX_CAPTURE_SERVICE_LINUX_TRACING_HANDLER_H_
+#define LINUX_CAPTURE_SERVICE_LINUX_TRACING_HANDLER_H_
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
@@ -76,4 +76,4 @@ class TracingHandler : public orbit_linux_tracing::TracerListener {
 
 }  // namespace orbit_linux_capture_service
 
-#endif  // CAPTURE_SERVICE_LINUX_TRACING_HANDLER_H_
+#endif  // LINUX_CAPTURE_SERVICE_LINUX_TRACING_HANDLER_H_

--- a/src/LinuxCaptureService/UserSpaceInstrumentationAddressesImpl.h
+++ b/src/LinuxCaptureService/UserSpaceInstrumentationAddressesImpl.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef CAPTURE_SERVICE_USER_SPACE_INSTRUMENTATION_ADDRESSES_IMPL_H_
-#define CAPTURE_SERVICE_USER_SPACE_INSTRUMENTATION_ADDRESSES_IMPL_H_
+#ifndef LINUX_CAPTURE_SERVICE_USER_SPACE_INSTRUMENTATION_ADDRESSES_IMPL_H_
+#define LINUX_CAPTURE_SERVICE_USER_SPACE_INSTRUMENTATION_ADDRESSES_IMPL_H_
 
 #include <algorithm>
 #include <vector>
@@ -52,4 +52,4 @@ class UserSpaceInstrumentationAddressesImpl final
 
 }  // namespace orbit_linux_capture_service
 
-#endif  // CAPTURE_SERVICE_USER_SPACE_INSTRUMENTATION_ADDRESSES_IMPL_H_
+#endif  // LINUX_CAPTURE_SERVICE_USER_SPACE_INSTRUMENTATION_ADDRESSES_IMPL_H_

--- a/src/MemoryTracing/MemoryInfoProducer.cpp
+++ b/src/MemoryTracing/MemoryInfoProducer.cpp
@@ -54,13 +54,6 @@ void MemoryInfoProducer::Run() {
   }
 }
 
-void SystemMemoryInfoProducerRunFn(MemoryInfoListener* listener, int32_t /*pid*/) {
-  ErrorMessageOr<SystemMemoryUsage> system_memory_usage = GetSystemMemoryUsage();
-  if (system_memory_usage.has_value()) {
-    listener->OnSystemMemoryUsage(system_memory_usage.value());
-  }
-}
-
 std::unique_ptr<MemoryInfoProducer> CreateSystemMemoryInfoProducer(MemoryInfoListener* listener,
                                                                    uint64_t sampling_period_ns,
                                                                    int32_t pid) {

--- a/src/WindowsCaptureService/WindowsCaptureService.cpp
+++ b/src/WindowsCaptureService/WindowsCaptureService.cpp
@@ -31,7 +31,7 @@ grpc::Status WindowsCaptureService::Capture(
   StartEventProcessing(request.capture_options());
   TracingHandler tracing_handler{producer_event_processor_.get()};
   tracing_handler.Start(request.capture_options());
-  WaitForEndCaptureRequestFromClient(reader_writer);
+  WaitForStopCaptureRequestFromClient(reader_writer);
   tracing_handler.Stop();
   FinalizeEventProcessing();
 


### PR DESCRIPTION
Most are lint warnings and self-explanatory.
The rename of `WaitForEndCaptureRequestFromClient` to
`WaitForStopCaptureRequestFromClient` is to follow our "start/stop capture"
nomenclature.

Test: Build.