### PR TITLE
Add new clang conan profiles

### DIFF
--- a/third_party/conan/configs/linux/profiles/clang10_common
+++ b/third_party/conan/configs/linux/profiles/clang10_common
@@ -1,0 +1,8 @@
+include(clang_common)
+
+[settings]
+compiler.version=10
+
+[env]
+CC=clang-10
+CXX=clang++-10

--- a/third_party/conan/configs/linux/profiles/clang10_debug
+++ b/third_party/conan/configs/linux/profiles/clang10_debug
@@ -1,0 +1,4 @@
+include(clang10_common)
+
+[settings]
+build_type=Debug

--- a/third_party/conan/configs/linux/profiles/clang10_release
+++ b/third_party/conan/configs/linux/profiles/clang10_release
@@ -1,0 +1,4 @@
+include(clang10_common)
+
+[settings]
+build_type=Release

--- a/third_party/conan/configs/linux/profiles/clang10_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang10_relwithdebinfo
@@ -1,0 +1,4 @@
+include(clang10_common)
+
+[settings]
+build_type=RelWithDebInfo

--- a/third_party/conan/configs/linux/profiles/clang11_common
+++ b/third_party/conan/configs/linux/profiles/clang11_common
@@ -1,0 +1,8 @@
+include(clang_common)
+
+[settings]
+compiler.version=11
+
+[env]
+CC=clang-11
+CXX=clang++-11

--- a/third_party/conan/configs/linux/profiles/clang11_debug
+++ b/third_party/conan/configs/linux/profiles/clang11_debug
@@ -1,0 +1,4 @@
+include(clang11_common)
+
+[settings]
+build_type=Debug

--- a/third_party/conan/configs/linux/profiles/clang11_release
+++ b/third_party/conan/configs/linux/profiles/clang11_release
@@ -1,0 +1,4 @@
+include(clang11_common)
+
+[settings]
+build_type=Release

--- a/third_party/conan/configs/linux/profiles/clang11_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang11_relwithdebinfo
@@ -1,0 +1,4 @@
+include(clang11_common)
+
+[settings]
+build_type=RelWithDebInfo


### PR DESCRIPTION
This is adding additional Conan profiles for the Clang compiler versions
10 and 11.

They are all straight forward (copied from the clang-9 profiles). No
compiler flags need to be adjusted.