### PR TITLE
Add missing dependency to LinuxCaptureService BUILD

### DIFF
--- a/src/LinuxCaptureService/BUILD
+++ b/src/LinuxCaptureService/BUILD
@@ -27,6 +27,7 @@ orbit_cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
     ],


### PR DESCRIPTION
This is adding the Abseil str_format dependency to the
LinuxCaptureService target. Not sure why this wasn't reported by copybara.
I have to investigate.