### PR TITLE
Add DataView::Init() method

### DIFF
--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -43,6 +43,7 @@ struct FunctionsDataViewTest : public testing::Test {
   explicit FunctionsDataViewTest()
       : thread_pool_{orbit_base::ThreadPool::Create(4, 4, absl::Milliseconds(50))},
         view_{&app_, thread_pool_.get()} {
+    view_.Init();
     orbit_client_protos::FunctionInfo function0;
     function0.set_name("foo");
     function0.set_pretty_name("void foo()");
@@ -66,7 +67,7 @@ struct FunctionsDataViewTest : public testing::Test {
     function2.set_pretty_name("operator==(A const&, A const&)");
     function2.set_module_path("/somewhere/else/module");
     function2.set_module_build_id("buildid3");
-    function2.set_address(0x33);
+    function2.set_address(0x330);
     function2.set_size(66);
     functions_.emplace_back(std::move(function2));
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -50,7 +50,6 @@ LiveFunctionsDataView::LiveFunctionsDataView(
       selected_function_id_(orbit_grpc_protos::kInvalidFunctionId),
       metrics_uploader_(metrics_uploader) {
   update_period_ms_ = 300;
-  LiveFunctionsDataView::OnDataChanged();
 }
 
 const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -156,6 +156,7 @@ class LiveFunctionsDataViewTest : public testing::Test {
   explicit LiveFunctionsDataViewTest()
       : view_{&live_functions_, &app_, &metrics_uploader_},
         capture_data_(GenerateTestCaptureData(&module_manager_)) {
+    view_.Init();
     for (size_t i = 0; i < kNumFunctions; i++) {
       FunctionInfo function;
       function.set_name(kNames[i]);

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -58,6 +58,7 @@ std::string GetExpectedDisplayFileSizeByIndex(size_t index) {
 class ModulesDataViewTest : public testing::Test {
  public:
   explicit ModulesDataViewTest() : view_{&app_} {
+    view_.Init();
     for (size_t i = 0; i < kNumModules; i++) {
       ModuleInMemory module_in_memory{kStartAddresses[i], kEndAddresses[i], kFilePaths[i],
                                       kBuildIds[i]};

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -50,7 +50,7 @@ namespace orbit_data_views {
 
 class PresetsDataViewTest : public testing::Test {
  public:
-  explicit PresetsDataViewTest() : view_{&app_, &metrics_uploader_} {}
+  explicit PresetsDataViewTest() : view_{&app_, &metrics_uploader_} { view_.Init(); }
 
  protected:
   orbit_metrics_uploader::MetricsUploaderStub metrics_uploader_;
@@ -146,8 +146,8 @@ TEST_F(PresetsDataViewTest, ViewIsUpdatedAfterSetPresets) {
 
   view_.SetPresets({preset_file1, preset_file0});
   EXPECT_EQ(view_.GetNumElements(), 2);
-  EXPECT_EQ(view_.GetValue(0, 1), preset_filename1.filename().string());
-  EXPECT_EQ(view_.GetValue(1, 1), preset_filename0.filename().string());
+  EXPECT_EQ(view_.GetValue(0, 1), preset_filename0.filename().string());
+  EXPECT_EQ(view_.GetValue(1, 1), preset_filename1.filename().string());
 }
 
 TEST_F(PresetsDataViewTest, CheckListingOfModulesPerPreset) {

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -119,6 +119,7 @@ std::string SamplingReportDataView::GetValueForCopy(int row, int column) {
   }
 
 void SamplingReportDataView::DoSort() {
+  ORBIT_SCOPE("SamplingReportDataView::DoSort");
   bool ascending = sorting_orders_[sorting_column_] == SortingOrder::kAscending;
   std::function<bool(int a, int b)> sorter = nullptr;
 

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -184,6 +184,7 @@ class SamplingReportDataViewTest : public testing::Test {
  public:
   explicit SamplingReportDataViewTest()
       : view_{&app_}, capture_data_(GenerateTestCaptureData(&module_manager_)) {
+    view_.Init();
     for (size_t i = 0; i < kNumFunctions; i++) {
       SampledFunction sampled_function;
       sampled_function.absolute_address = kSampledAbsoluteAddresses[i];

--- a/src/DataViews/TracepointsDataViewTest.cpp
+++ b/src/DataViews/TracepointsDataViewTest.cpp
@@ -41,6 +41,7 @@ const std::array<std::string, kNumTracepoints> kTracepointNames{"sys_enter_kill"
 class TracepointsDataViewTest : public testing::Test {
  public:
   explicit TracepointsDataViewTest() : view_{&app_} {
+    view_.Init();
     for (size_t i = 0; i < kNumTracepoints; i++) {
       TracepointInfo tracepoint;
       tracepoint.set_category(kTracepointCategories[i]);

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -81,6 +81,17 @@ class DataView {
   explicit DataView(DataViewType type, AppInterface* app)
       : update_period_ms_(-1), type_(type), app_{app} {}
 
+  // Calls virtual initialization methods, therefore cannot be called from the constructor.
+  void Init();
+
+  // Creates a DataView and calls the Init() method after construction.
+  template <typename DataViewT, typename... Args>
+  [[nodiscard]] static std::unique_ptr<DataViewT> CreateAndInit(Args&&... args) {
+    auto data_view = std::make_unique<DataViewT>(std::forward<Args>(args)...);
+    data_view->Init();
+    return data_view;
+  }
+
   virtual ~DataView() = default;
 
   virtual void SetAsMainInstance() {}

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -118,6 +118,13 @@ using orbit_client_protos::TimerInfo;
 using orbit_client_services::CrashManager;
 using orbit_client_services::TracepointServiceClient;
 
+using orbit_data_views::CallstackDataView;
+using orbit_data_views::DataView;
+using orbit_data_views::FunctionsDataView;
+using orbit_data_views::ModulesDataView;
+using orbit_data_views::PresetsDataView;
+using orbit_data_views::TracepointsDataView;
+
 using orbit_gl::MainWindowInterface;
 
 using orbit_grpc_protos::CaptureFinished;
@@ -2493,30 +2500,29 @@ orbit_data_views::DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
   switch (type) {
     case DataViewType::kFunctions:
       if (!functions_data_view_) {
-        functions_data_view_ = std::make_unique<orbit_data_views::FunctionsDataView>(
-            this, core_count_sized_thread_pool_.get());
+        functions_data_view_ =
+            DataView::CreateAndInit<FunctionsDataView>(this, core_count_sized_thread_pool_.get());
         panels_.push_back(functions_data_view_.get());
       }
       return functions_data_view_.get();
 
     case DataViewType::kCallstack:
       if (!callstack_data_view_) {
-        callstack_data_view_ = std::make_unique<orbit_data_views::CallstackDataView>(this);
+        callstack_data_view_ = DataView::CreateAndInit<CallstackDataView>(this);
         panels_.push_back(callstack_data_view_.get());
       }
       return callstack_data_view_.get();
 
     case DataViewType::kModules:
       if (!modules_data_view_) {
-        modules_data_view_ = std::make_unique<orbit_data_views::ModulesDataView>(this);
+        modules_data_view_ = DataView::CreateAndInit<ModulesDataView>(this);
         panels_.push_back(modules_data_view_.get());
       }
       return modules_data_view_.get();
 
     case DataViewType::kPresets:
       if (!presets_data_view_) {
-        presets_data_view_ =
-            std::make_unique<orbit_data_views::PresetsDataView>(this, metrics_uploader_);
+        presets_data_view_ = DataView::CreateAndInit<PresetsDataView>(this, metrics_uploader_);
         panels_.push_back(presets_data_view_.get());
       }
       return presets_data_view_.get();
@@ -2533,7 +2539,7 @@ orbit_data_views::DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kTracepoints:
       if (!tracepoints_data_view_) {
-        tracepoints_data_view_ = std::make_unique<orbit_data_views::TracepointsDataView>(this);
+        tracepoints_data_view_ = DataView::CreateAndInit<TracepointsDataView>(this);
         panels_.push_back(tracepoints_data_view_.get());
       }
       return tracepoints_data_view_.get();
@@ -2546,7 +2552,7 @@ orbit_data_views::DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
 orbit_data_views::DataView* OrbitApp::GetOrCreateSelectionCallstackDataView() {
   if (selection_callstack_data_view_ == nullptr) {
-    selection_callstack_data_view_ = std::make_unique<orbit_data_views::CallstackDataView>(this);
+    selection_callstack_data_view_ = DataView::CreateAndInit<CallstackDataView>(this);
     panels_.push_back(selection_callstack_data_view_.get());
   }
   return selection_callstack_data_view_.get();

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -103,7 +103,9 @@ LiveFunctionsController::LiveFunctionsController(
     OrbitApp* app, orbit_metrics_uploader::MetricsUploader* metrics_uploader)
     : live_functions_data_view_(this, app, metrics_uploader),
       app_{app},
-      metrics_uploader_(metrics_uploader) {}
+      metrics_uploader_(metrics_uploader) {
+  live_functions_data_view_.Init();
+}
 
 void LiveFunctionsController::Move() {
   if (!current_timer_infos_.empty()) {

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -45,6 +45,7 @@ void SamplingReport::FillReport() {
 
   for (const ThreadSampleData& thread_sample_data : sample_data) {
     orbit_data_views::SamplingReportDataView thread_report{app_};
+    thread_report.Init();
     thread_report.SetSampledFunctions(thread_sample_data.sampled_functions);
     thread_report.SetThreadID(thread_sample_data.thread_id);
     thread_report.SetSamplingReport(this);

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -57,6 +57,7 @@ void OrbitSamplingReport::Initialize(orbit_data_views::DataView* callstack_data_
   sampling_report_->SetUiRefreshFunc([&]() { this->RefreshCallstackView(); });
 
   for (orbit_data_views::SamplingReportDataView& report_data_view : report->GetThreadReports()) {
+    ORBIT_SCOPE("SamplingReportDataView tab creation");
     auto* tab = new QWidget();
     tab->setObjectName(QStringLiteral("tab"));
 
@@ -79,7 +80,10 @@ void OrbitSamplingReport::Initialize(orbit_data_views::DataView* callstack_data_
     treeView->setObjectName(QStringLiteral("treeView"));
     gridLayout_2->addWidget(treeView, 0, 0, 1, 1);
     treeView->Initialize(&report_data_view, SelectionType::kExtended, FontType::kDefault);
-    treeView->GetTreeView()->header()->resizeSections(QHeaderView::ResizeToContents);
+    {
+      ORBIT_SCOPE("resizeSections");
+      treeView->GetTreeView()->header()->resizeSections(QHeaderView::ResizeToContents);
+    }
     treeView->GetTreeView()->SetIsMultiSelection(true);
 
     treeView->Link(ui_->CallstackTreeView);

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -58,17 +58,22 @@ OrbitTreeView::OrbitTreeView(QWidget* parent) : QTreeView(parent) {
 void OrbitTreeView::Initialize(orbit_data_views::DataView* data_view, SelectionType selection_type,
                                FontType font_type, bool uniform_row_height,
                                QFlags<Qt::AlignmentFlag> text_alignment) {
+  ORBIT_SCOPE("OrbitTreeView::Initialize");
   setUniformRowHeights(uniform_row_height);
 
   model_ = std::make_unique<OrbitTableModel>(data_view, /*parent=*/nullptr, text_alignment);
   setModel(model_.get());
-  header()->resizeSections(QHeaderView::ResizeToContents);
+  {
+    ORBIT_SCOPE("resizeSections");
+    header()->resizeSections(QHeaderView::ResizeToContents);
+  }
 
   if (!model_->IsSortingAllowed()) {
     // Don't do setSortingEnabled(model_->IsSortingAllowed()); as with true it
     // forces a sort by the first column.
     setSortingEnabled(false);
   } else {
+    ORBIT_SCOPE("sortByColumn");
     std::pair<int, Qt::SortOrder> column_and_order = model_->GetDefaultSortingColumnAndOrder();
     sortByColumn(column_and_order.first, column_and_order.second);
   }


### PR DESCRIPTION
The "sorting_column_" member was not properly initialized which
resulted in first calls to "OnDataChanged" to always sort the
DataView by the first column. We can't initialize "sorting_column_"
in the "DataView" constructor since it requires a virtual function call.
We therefore introduce an "Init" method to be called after construction
of a "DataView".

Fix tests that assumed wrong row ordering.

Also, add introspection scopes in some DataView methods.

More info can be found in the bug below.

Bug: http://b/211912871
Test: Multiple captures and manual sorts of data views
