### PR TITLE
Fix DiaSymbol leak

### DIFF
--- a/src/ObjectUtils/PdbFileDia.cpp
+++ b/src/ObjectUtils/PdbFileDia.cpp
@@ -93,10 +93,11 @@ ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> PdbFileDia::LoadDebugSymbols() 
   ModuleSymbols module_symbols;
   module_symbols.set_load_bias(object_file_info_.load_bias);
   module_symbols.set_symbols_file_path(file_path_.string());
-  CComPtr<IDiaSymbol> dia_symbol;
+  IDiaSymbol* dia_symbol = nullptr;
   ULONG celt = 0;
 
   while (SUCCEEDED(dia_enum_symbols->Next(1, &dia_symbol, &celt)) && (celt == 1)) {
+    CComPtr<IDiaSymbol> dia_symbol_com_ptr = dia_symbol;
     SymbolInfo symbol_info;
 
     BSTR function_name = {};


### PR DESCRIPTION
Running Orbit in debug made this issue pop up. We were overwriting the
object address in a smart pointer, so only the last object would get
released. Fix by creating a new smart pointer for each DiaSymbol.