### PR TITLE
Support instance name in connection_target

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -56,9 +56,9 @@ ABSL_FLAG(bool, enforce_full_redraw, false,
 // VSI
 ABSL_FLAG(std::string, connection_target, "",
           "Instance and process in the form <pid>@<instance>, where <instance> is either an "
-          "instance ID or display name. Specify this to skip the connection setup and open the "
-          "main window instead. If either the instance or the process ID can't be found or "
-          "deployment is aborted by the user Orbit will exit with return code -1 immediately.");
+          "instance ID or an instance display name. Specify this to skip the connection setup and "
+          "open the main window instead. If either the instance or the process ID can't be found "
+          "or deployment is aborted by the user Orbit will exit with return code -1 immediately.");
 ABSL_FLAG(std::vector<std::string>, additional_symbol_paths, {},
           "Additional local symbol locations (comma-separated)");
 

--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -55,7 +55,8 @@ ABSL_FLAG(bool, enforce_full_redraw, false,
 
 // VSI
 ABSL_FLAG(std::string, connection_target, "",
-          "Instance and process in the form <pid>@<instance_id>. Specify this to skip the "
+          "Instance and process in the form <pid>@<instance>, where <instance> is either an "
+          "instance ID or display name. Specify this to skip the "
           "connection setup and open the main window instead. If either the instance or the "
           "process ID can't be found or deployment is aborted by the user Orbit will exit "
           "with return code -1 immediately.");

--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -56,10 +56,9 @@ ABSL_FLAG(bool, enforce_full_redraw, false,
 // VSI
 ABSL_FLAG(std::string, connection_target, "",
           "Instance and process in the form <pid>@<instance>, where <instance> is either an "
-          "instance ID or display name. Specify this to skip the "
-          "connection setup and open the main window instead. If either the instance or the "
-          "process ID can't be found or deployment is aborted by the user Orbit will exit "
-          "with return code -1 immediately.");
+          "instance ID or display name. Specify this to skip the connection setup and open the "
+          "main window instead. If either the instance or the process ID can't be found or "
+          "deployment is aborted by the user Orbit will exit with return code -1 immediately.");
 ABSL_FLAG(std::vector<std::string>, additional_symbol_paths, {},
           "Additional local symbol locations (comma-separated)");
 

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -91,7 +91,7 @@ static std::optional<orbit_session_setup::TargetConfiguration> ConnectToSpecifie
 
   auto connection_target = connection_target_result.value();
   orbit_session_setup::ConnectToTargetDialog dialog(
-      &connection_artifacts, connection_target.instance_id_, connection_target.process_id_,
+      &connection_artifacts, connection_target.instance_id_or_name_, connection_target.process_id_,
       metrics_uploader);
   return dialog.Exec();
 }

--- a/src/SessionSetup/ConnectToTargetDialog.ui
+++ b/src/SessionSetup/ConnectToTargetDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>598</width>
-    <height>260</height>
+    <width>600</width>
+    <height>261</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -24,7 +24,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="sizeConstraint">
-    <enum>QLayout::SetFixedSize</enum>
+    <enum>QLayout::SetDefaultConstraint</enum>
    </property>
    <item>
     <widget class="QWidget" name="widget_3" native="true">
@@ -76,7 +76,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Instance ID:</string>
+         <string>Instance:</string>
         </property>
        </widget>
       </item>

--- a/src/SessionSetup/SessionSetupUtilsTest.cpp
+++ b/src/SessionSetup/SessionSetupUtilsTest.cpp
@@ -31,7 +31,7 @@ TEST(SessionSetupUtils, CredentialsFromSshInfoWorksCorrectly) {
   EXPECT_EQ(info.user.toStdString(), credentials.user);
 }
 
-TEST(SessionSetupUtils, ConnectionTargetFromValidInstanceID) {
+TEST(SessionSetupUtils, ConnectionTargetFromValidInstanceId) {
   const QString instance_id = "some/i-nstanc-3/id123";
   const uint32_t pid = 1234;
 

--- a/src/SessionSetup/SessionSetupUtilsTest.cpp
+++ b/src/SessionSetup/SessionSetupUtilsTest.cpp
@@ -31,19 +31,35 @@ TEST(SessionSetupUtils, CredentialsFromSshInfoWorksCorrectly) {
   EXPECT_EQ(info.user.toStdString(), credentials.user);
 }
 
-TEST(SessionSetupUtils, ConnectionTargetFromString) {
-  const QString instance = "some/i-nstanc-3/id123";
+TEST(SessionSetupUtils, ConnectionTargetFromValidInstanceID) {
+  const QString instance_id = "some/i-nstanc-3/id123";
   const uint32_t pid = 1234;
 
   // Correct format: "pid@instance_id", where PID is a uint32_t
-  const QString target_string = QString("%1@%2").arg(QString::number(pid), instance);
+  QString target_string = QString("%1@%2").arg(QString::number(pid), instance_id);
+  const auto result = ConnectionTarget::FromString(target_string);
+  EXPECT_TRUE(result.has_value());
+  if (result.has_value()) {
+    EXPECT_EQ(result.value().instance_id_or_name_.toStdString(), instance_id.toStdString());
+    EXPECT_EQ(result.value().process_id_, pid);
+  }
+}
+
+TEST(SessionSetupUtils, ConnectionTargetFromValidInstanceName) {
+  const QString instance_name = "somename-1";
+  const uint32_t pid = 1234;
+
+  // Correct format: "pid@instance_name", where PID is a uint32_t
+  const QString target_string = QString("%1@%2").arg(QString::number(pid), instance_name);
   auto result = ConnectionTarget::FromString(target_string);
   EXPECT_TRUE(result.has_value());
   if (result.has_value()) {
-    EXPECT_EQ(result.value().instance_id_.toStdString(), instance.toStdString());
+    EXPECT_EQ(result.value().instance_id_or_name_.toStdString(), instance_name.toStdString());
     EXPECT_EQ(result.value().process_id_, pid);
   }
+}
 
+TEST(SessionSetupUtils, ErrorRaisedOnInvalidTarget) {
   // Fail-tests for multiple incorrect formats
   EXPECT_FALSE(ConnectionTarget::FromString("no/id/found").has_value());
   EXPECT_FALSE(ConnectionTarget::FromString("invalid_pid@valid/i-nstanc-3/id").has_value());

--- a/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
@@ -44,7 +44,7 @@ class ConnectToTargetDialog : public QDialog {
 
   SshConnectionArtifacts* ssh_connection_artifacts_;
 
-  QString instance_id_;
+  QString instance_id_or_name_;
   uint32_t process_id_;
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 

--- a/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
@@ -19,10 +19,10 @@ namespace orbit_session_setup {
 [[nodiscard]] std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port);
 
 struct ConnectionTarget {
-  QString instance_id_;
+  QString instance_id_or_name_;
   uint32_t process_id_;
 
-  // Split a target given as "<pid>@<instance_id>" into its components
+  // Split a target given as "<pid>@<instance>" into its components
   [[nodiscard]] static std::optional<ConnectionTarget> FromString(const QString& connection_target);
 };
 


### PR DESCRIPTION
ggp supports identification of instances by display name instead of id,
so this was already silently supported by the connection_target
parameter except for a single CHECK. It's now more explicitly
supported, the CHECK was adjusted and namings make this clearer.

Bug: b/211846963
Test: Adjusted unit tests, manually tested the changes. E2E test TBD.