### PR TITLE
Add utilities to read RSS and MemTotal to LinuxCaptureService

### DIFF
--- a/src/LinuxCaptureService/CMakeLists.txt
+++ b/src/LinuxCaptureService/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources(LinuxCaptureService PRIVATE
         LinuxCaptureService.cpp
         MemoryInfoHandler.cpp
         MemoryInfoHandler.h
+        MemoryWatchdog.cpp
+        MemoryWatchdog.h
         TracingHandler.cpp
         TracingHandler.h
         UserSpaceInstrumentationAddressesImpl.h)
@@ -38,6 +40,7 @@ target_link_libraries(LinuxCaptureService PUBLIC
 add_executable(LinuxCaptureServiceTests)
 
 target_sources(LinuxCaptureServiceTests PRIVATE
+        MemoryWatchdogTest.cpp
         UserSpaceInstrumentationAddressesImplTest.cpp)
 
 target_link_libraries(LinuxCaptureServiceTests PRIVATE

--- a/src/LinuxCaptureService/MemoryWatchdog.cpp
+++ b/src/LinuxCaptureService/MemoryWatchdog.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MemoryWatchdog.h"
+
+#include <absl/strings/match.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_split.h>
+#include <unistd.h>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ReadFileToString.h"
+
+namespace orbit_linux_capture_service {
+
+std::optional<uint64_t> ExtractMemTotalInKbFromProcMeminfo(std::string_view proc_meminfo) {
+  std::string line;
+  for (size_t i = 0; i <= proc_meminfo.size(); ++i) {
+    if (i == proc_meminfo.size() || proc_meminfo[i] == '\n') {
+      if (!absl::StartsWith(line, "MemTotal:")) {
+        line.clear();
+        continue;
+      }
+
+      std::vector<std::string_view> splits = absl::StrSplit(line, ' ', absl::SkipWhitespace{});
+      if (splits.size() < 3 || splits[2] != "kB") {
+        ERROR("Extracting MemTotal from \"%s\"", line);
+        return std::nullopt;
+      }
+
+      uint64_t mem_total_kb;
+      if (!absl::SimpleAtoi(splits[1], &mem_total_kb)) {
+        ERROR("Parsing MemTotal \"%s\"", splits[1]);
+        return std::nullopt;
+      }
+
+      return mem_total_kb;
+    }
+
+    line.push_back(proc_meminfo[i]);
+  }
+
+  ERROR("Could not find MemTotal in file");
+  return std::nullopt;
+}
+
+std::optional<uint64_t> ReadMemTotalInBytesFromProcMeminfo() {
+  static constexpr std::string_view kProcMeminfoFilename = "/proc/meminfo";
+
+  ErrorMessageOr<std::string> error_or_meminfo = orbit_base::ReadFileToString(kProcMeminfoFilename);
+  if (error_or_meminfo.has_error()) {
+    ERROR("Reading \"%s\": %s", kProcMeminfoFilename, error_or_meminfo.error().message());
+    return std::nullopt;
+  }
+
+  std::optional<uint64_t> mem_total_kb =
+      ExtractMemTotalInKbFromProcMeminfo(error_or_meminfo.value());
+  if (!mem_total_kb.has_value()) {
+    ERROR("Extracting MemTotal from \"%s\"", kProcMeminfoFilename);
+    return std::nullopt;
+  }
+
+  return mem_total_kb.value() * 1024;
+}
+
+std::optional<uint64_t> ExtractRssInPagesFromProcPidStat(std::string_view proc_pid_stat) {
+  static constexpr int kRssFieldIndex = 23;
+  std::string rss_string;
+  int spaces_found = 0;
+  for (char c : proc_pid_stat) {
+    if (c == ' ') {
+      ++spaces_found;
+      if (spaces_found > kRssFieldIndex) {
+        break;
+      }
+      continue;
+    }
+    if (spaces_found == kRssFieldIndex) {
+      rss_string.push_back(c);
+    }
+  }
+
+  uint64_t rss_pages;
+  if (!absl::SimpleAtoi(rss_string, &rss_pages)) {
+    ERROR_ONCE("Parsing rss \"%s\"", rss_string);
+    return std::nullopt;
+  }
+  return rss_pages;
+}
+
+std::optional<uint64_t> ReadRssInBytesFromProcPidStat() {
+  static const pid_t pid = getpid();
+  static const std::string proc_pid_stat_filename = absl::StrFormat("/proc/%d/stat", pid);
+
+  ErrorMessageOr<std::string> error_or_stat = orbit_base::ReadFileToString(proc_pid_stat_filename);
+  if (error_or_stat.has_error()) {
+    ERROR_ONCE("Reading \"%s\": %s", proc_pid_stat_filename, error_or_stat.error().message());
+    return std::nullopt;
+  }
+
+  std::optional<uint64_t> rss_pages = ExtractRssInPagesFromProcPidStat(error_or_stat.value());
+  if (!rss_pages.has_value()) {
+    ERROR_ONCE("Extracting rss from \"%s\"", proc_pid_stat_filename);
+    return std::nullopt;
+  }
+
+  static uint64_t page_size_bytes = sysconf(_SC_PAGESIZE);
+  return rss_pages.value() * page_size_bytes;
+}
+
+}  // namespace orbit_linux_capture_service

--- a/src/LinuxCaptureService/MemoryWatchdog.h
+++ b/src/LinuxCaptureService/MemoryWatchdog.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LINUX_CAPTURE_SERVICE_MEMORY_WATCHDOG_H_
+#define LINUX_CAPTURE_SERVICE_MEMORY_WATCHDOG_H_
+
+#include <optional>
+#include <string_view>
+#include <thread>
+
+namespace orbit_linux_capture_service {
+
+// In header file for testing.
+[[nodiscard]] std::optional<uint64_t> ExtractRssInPagesFromProcPidStat(
+    std::string_view proc_pid_stat);
+
+[[nodiscard]] std::optional<uint64_t> ReadRssInBytesFromProcPidStat();
+
+// In header file for testing.
+[[nodiscard]] std::optional<uint64_t> ExtractMemTotalInKbFromProcMeminfo(
+    std::string_view proc_meminfo);
+
+[[nodiscard]] std::optional<uint64_t> ReadMemTotalInBytesFromProcMeminfo();
+
+}  // namespace orbit_linux_capture_service
+
+#endif  // LINUX_CAPTURE_SERVICE_MEMORY_WATCHDOG_H_

--- a/src/LinuxCaptureService/MemoryWatchdog.h
+++ b/src/LinuxCaptureService/MemoryWatchdog.h
@@ -5,9 +5,10 @@
 #ifndef LINUX_CAPTURE_SERVICE_MEMORY_WATCHDOG_H_
 #define LINUX_CAPTURE_SERVICE_MEMORY_WATCHDOG_H_
 
+#include <stdint.h>
+
 #include <optional>
 #include <string_view>
-#include <thread>
 
 namespace orbit_linux_capture_service {
 

--- a/src/LinuxCaptureService/MemoryWatchdog.h
+++ b/src/LinuxCaptureService/MemoryWatchdog.h
@@ -12,17 +12,13 @@
 
 namespace orbit_linux_capture_service {
 
+[[nodiscard]] uint64_t GetPhysicalMemoryInBytes();
+
 // In header file for testing.
 [[nodiscard]] std::optional<uint64_t> ExtractRssInPagesFromProcPidStat(
     std::string_view proc_pid_stat);
 
 [[nodiscard]] std::optional<uint64_t> ReadRssInBytesFromProcPidStat();
-
-// In header file for testing.
-[[nodiscard]] std::optional<uint64_t> ExtractMemTotalInKbFromProcMeminfo(
-    std::string_view proc_meminfo);
-
-[[nodiscard]] std::optional<uint64_t> ReadMemTotalInBytesFromProcMeminfo();
 
 }  // namespace orbit_linux_capture_service
 

--- a/src/LinuxCaptureService/MemoryWatchdogTest.cpp
+++ b/src/LinuxCaptureService/MemoryWatchdogTest.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <absl/time/time.h>
 #include <gtest/gtest.h>
 
 #include <optional>

--- a/src/LinuxCaptureService/MemoryWatchdogTest.cpp
+++ b/src/LinuxCaptureService/MemoryWatchdogTest.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/time/time.h>
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include "MemoryWatchdog.h"
+
+namespace orbit_linux_capture_service {
+
+TEST(MemoryWatchdog, ExtractMemTotalInKbFromProcMeminfoReturnsValueWhenMemTotalIsWellFormed) {
+  std::optional<uint64_t> mem_total_kb;
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234 kB");
+  ASSERT_TRUE(mem_total_kb.has_value());
+  EXPECT_EQ(mem_total_kb, 1234);
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234 kB\n");
+  ASSERT_TRUE(mem_total_kb.has_value());
+  EXPECT_EQ(mem_total_kb, 1234);
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("\nMemTotal: 1234 kB");
+  ASSERT_TRUE(mem_total_kb.has_value());
+  EXPECT_EQ(mem_total_kb, 1234);
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("NOISE\nMemTotal: 1234 kB");
+  ASSERT_TRUE(mem_total_kb.has_value());
+  EXPECT_EQ(mem_total_kb, 1234);
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234 kB\nNOISE");
+  ASSERT_TRUE(mem_total_kb.has_value());
+  EXPECT_EQ(mem_total_kb, 1234);
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("NOISE\nMemTotal: 1234 kB\nNOISE");
+  ASSERT_TRUE(mem_total_kb.has_value());
+  EXPECT_EQ(mem_total_kb, 1234);
+}
+
+TEST(MemoryWatchdog, ExtractMemTotalInKbFromProcMeminfoReturnsNulloptWhenMemTotalIsMalformed) {
+  std::optional<uint64_t> mem_total_kb;
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal:");
+  EXPECT_FALSE(mem_total_kb.has_value());
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234");
+  EXPECT_FALSE(mem_total_kb.has_value());
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234 MB");
+  EXPECT_FALSE(mem_total_kb.has_value());
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: abc kB");
+  EXPECT_FALSE(mem_total_kb.has_value());
+}
+
+TEST(MemoryWatchdog, ExtractMemTotalInKbFromProcMeminfoReturnsNulloptWhenMemTotalIsNotPresent) {
+  std::optional<uint64_t> mem_total_kb;
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("");
+  EXPECT_FALSE(mem_total_kb.has_value());
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("\n");
+  EXPECT_FALSE(mem_total_kb.has_value());
+
+  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemFree: 1234 kB");
+  EXPECT_FALSE(mem_total_kb.has_value());
+}
+
+TEST(MemoryWatchdog, ReadMemTotalInBytesFromProcMeminfoReturnsReasonableValues) {
+  std::optional<uint64_t> mem_total = ReadMemTotalInBytesFromProcMeminfo();
+  ASSERT_TRUE(mem_total.has_value());
+  EXPECT_GE(mem_total.value(), 1024ULL * 1024 * 1024);
+
+  std::optional<uint64_t> mem_total2 = ReadMemTotalInBytesFromProcMeminfo();
+  ASSERT_TRUE(mem_total2.has_value());
+  EXPECT_EQ(mem_total2.value(), mem_total.value());
+}
+
+TEST(MemoryWatchdog, ExtractRssInPagesFromProcPidStatReturnsValueWhenRssIsWellFormed) {
+  static constexpr std::string_view kProcPidStat{
+      "2495075 (LinuxCaptureSer) S 321797 2495075 321797 34823 2495075 1077936128 208 0 0 0 0 0 0 "
+      "0 20 0 2 0 185687468 82644992 454 18446744073709551615 93904073928704 93904074590349 "
+      "140722755556992 0 0 0 0 0 0 0 0 0 17 46 0 0 0 0 0 93904074765696 93904074778896 "
+      "93904095248384 140722755562685 140722755562793 140722755562793 140722755567550 0"};
+  std::optional<uint64_t> rss_pages = ExtractRssInPagesFromProcPidStat(kProcPidStat);
+  ASSERT_TRUE(rss_pages.has_value());
+  EXPECT_EQ(rss_pages, 454);
+}
+
+TEST(MemoryWatchdog, ExtractRssInPagesFromProcPidStatReturnsNulloptWhenRssIsMalformed) {
+  static constexpr std::string_view kProcPidStat{
+      "2495075 (LinuxCaptureSer) S 321797 2495075 321797 34823 2495075 1077936128 208 0 0 0 0 0 0 "
+      "0 20 0 2 0 185687468 82644992 abc 18446744073709551615 93904073928704 93904074590349 "
+      "140722755556992 0 0 0 0 0 0 0 0 0 17 46 0 0 0 0 0 93904074765696 93904074778896 "
+      "93904095248384 140722755562685 140722755562793 140722755562793 140722755567550 0"};
+  EXPECT_FALSE(ExtractRssInPagesFromProcPidStat(kProcPidStat).has_value());
+}
+
+TEST(MemoryWatchdog, ExtractRssInPagesFromProcPidStatReturnsNulloptWhenRssIsNotPresent) {
+  static constexpr std::string_view kProcPidStat{
+      "2495075 (LinuxCaptureSer) S 321797 2495075 321797 34823 2495075 1077936128 208 0 0 0 0 0 0 "
+      "0 20 0 2 0 185687468 82644992"};
+  EXPECT_FALSE(ExtractRssInPagesFromProcPidStat(kProcPidStat).has_value());
+}
+
+static void IncreaseRss(uint64_t amount_bytes) {
+  // The memory leak is intended: if the test is run again in the same process (e.g., with
+  // --gtest_repeat) we want new memory to be allocated, not the previous one to be reused.
+  void* ptr = malloc(amount_bytes);  // NOLINT
+  auto* typed_ptr = static_cast<volatile uint64_t*>(ptr);
+  for (uint64_t i = 0; i < amount_bytes / sizeof(uint64_t); ++i) {
+    typed_ptr[i] = i;
+  }
+}
+
+TEST(MemoryWatchdog, ReadRssInBytesFromProcPidStatReturnsIncreasingValuesOnRssIncrease) {
+  std::optional<uint64_t> rss = ReadRssInBytesFromProcPidStat();
+  ASSERT_TRUE(rss.has_value());
+  EXPECT_GT(rss.value(), 0);
+
+  static constexpr uint64_t kRssIncrease = 8ULL * 1024 * 1024;
+  static constexpr uint64_t kRssIncreaseTolerance = kRssIncrease / 8;
+  IncreaseRss(kRssIncrease);
+  std::optional<uint64_t> new_rss = ReadRssInBytesFromProcPidStat();
+  ASSERT_TRUE(new_rss.has_value());
+  EXPECT_GT(new_rss.value(), 0);
+  EXPECT_GE(new_rss.value(), rss.value() + kRssIncrease - kRssIncreaseTolerance);
+}
+
+}  // namespace orbit_linux_capture_service

--- a/src/LinuxCaptureService/MemoryWatchdogTest.cpp
+++ b/src/LinuxCaptureService/MemoryWatchdogTest.cpp
@@ -11,71 +11,9 @@
 
 namespace orbit_linux_capture_service {
 
-TEST(MemoryWatchdog, ExtractMemTotalInKbFromProcMeminfoReturnsValueWhenMemTotalIsWellFormed) {
-  std::optional<uint64_t> mem_total_kb;
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234 kB");
-  ASSERT_TRUE(mem_total_kb.has_value());
-  EXPECT_EQ(mem_total_kb, 1234);
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234 kB\n");
-  ASSERT_TRUE(mem_total_kb.has_value());
-  EXPECT_EQ(mem_total_kb, 1234);
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("\nMemTotal: 1234 kB");
-  ASSERT_TRUE(mem_total_kb.has_value());
-  EXPECT_EQ(mem_total_kb, 1234);
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("NOISE\nMemTotal: 1234 kB");
-  ASSERT_TRUE(mem_total_kb.has_value());
-  EXPECT_EQ(mem_total_kb, 1234);
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234 kB\nNOISE");
-  ASSERT_TRUE(mem_total_kb.has_value());
-  EXPECT_EQ(mem_total_kb, 1234);
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("NOISE\nMemTotal: 1234 kB\nNOISE");
-  ASSERT_TRUE(mem_total_kb.has_value());
-  EXPECT_EQ(mem_total_kb, 1234);
-}
-
-TEST(MemoryWatchdog, ExtractMemTotalInKbFromProcMeminfoReturnsNulloptWhenMemTotalIsMalformed) {
-  std::optional<uint64_t> mem_total_kb;
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal:");
-  EXPECT_FALSE(mem_total_kb.has_value());
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234");
-  EXPECT_FALSE(mem_total_kb.has_value());
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: 1234 MB");
-  EXPECT_FALSE(mem_total_kb.has_value());
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemTotal: abc kB");
-  EXPECT_FALSE(mem_total_kb.has_value());
-}
-
-TEST(MemoryWatchdog, ExtractMemTotalInKbFromProcMeminfoReturnsNulloptWhenMemTotalIsNotPresent) {
-  std::optional<uint64_t> mem_total_kb;
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("");
-  EXPECT_FALSE(mem_total_kb.has_value());
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("\n");
-  EXPECT_FALSE(mem_total_kb.has_value());
-
-  mem_total_kb = ExtractMemTotalInKbFromProcMeminfo("MemFree: 1234 kB");
-  EXPECT_FALSE(mem_total_kb.has_value());
-}
-
-TEST(MemoryWatchdog, ReadMemTotalInBytesFromProcMeminfoReturnsReasonableValues) {
-  std::optional<uint64_t> mem_total = ReadMemTotalInBytesFromProcMeminfo();
-  ASSERT_TRUE(mem_total.has_value());
-  EXPECT_GE(mem_total.value(), 1024ULL * 1024 * 1024);
-
-  std::optional<uint64_t> mem_total2 = ReadMemTotalInBytesFromProcMeminfo();
-  ASSERT_TRUE(mem_total2.has_value());
-  EXPECT_EQ(mem_total2.value(), mem_total.value());
+TEST(MemoryWatchdog, GetPhysicalMemoryInBytesReturnsReasonableValues) {
+  uint64_t mem_total = GetPhysicalMemoryInBytes();
+  EXPECT_GE(mem_total, 1024ULL * 1024 * 1024);
 }
 
 TEST(MemoryWatchdog, ExtractRssInPagesFromProcPidStatReturnsValueWhenRssIsWellFormed) {

--- a/src/LinuxCaptureService/MemoryWatchdogTest.cpp
+++ b/src/LinuxCaptureService/MemoryWatchdogTest.cpp
@@ -12,8 +12,7 @@
 namespace orbit_linux_capture_service {
 
 TEST(MemoryWatchdog, GetPhysicalMemoryInBytesReturnsReasonableValues) {
-  uint64_t mem_total = GetPhysicalMemoryInBytes();
-  EXPECT_GE(mem_total, 1024ULL * 1024 * 1024);
+  EXPECT_GE(GetPhysicalMemoryInBytes(), 1024ULL * 1024 * 1024);
 }
 
 TEST(MemoryWatchdog, ExtractRssInPagesFromProcPidStatReturnsValueWhenRssIsWellFormed) {


### PR DESCRIPTION
These will be used to make the `CaptureService` stop the capture when
`OrbitService` is using too much memory (e.g., before it is killed because the
system is out of memory).

Bug: http://b/209364229

Test: Ran the new unit tests a few thousand times.