### PR TITLE
LinuxCaptureService stops the capture when it detects high memory usage

### DIFF
--- a/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
@@ -82,10 +82,18 @@ ProducerCaptureEvent CreateCaptureStartedEvent(const CaptureOptions& capture_opt
   return event;
 }
 
-ProducerCaptureEvent CreateCaptureFinishedEvent() {
+ProducerCaptureEvent CreateSuccessfulCaptureFinishedEvent() {
   ProducerCaptureEvent event;
   CaptureFinished* capture_finished = event.mutable_capture_finished();
   capture_finished->set_status(CaptureFinished::kSuccessful);
+  return event;
+}
+
+ProducerCaptureEvent CreateMemoryThresholdExceededCaptureFinishedEvent() {
+  ProducerCaptureEvent event;
+  CaptureFinished* capture_finished = event.mutable_capture_finished();
+  capture_finished->set_status(CaptureFinished::kInterruptedByService);
+  capture_finished->set_error_message("OrbitService was using too much memory.");
   return event;
 }
 

--- a/src/CaptureService/include/CaptureService/CaptureService.h
+++ b/src/CaptureService/include/CaptureService/CaptureService.h
@@ -20,7 +20,7 @@
 
 namespace orbit_capture_service {
 
-// CaptureService is an abstract class derived from the grpc capture service. It holds common
+// CaptureService is an abstract class derived from the gRPC capture service. It holds common
 // functionality shared by the platform-specific capture services.
 class CaptureService : public orbit_grpc_protos::CaptureService::Service {
  public:
@@ -44,7 +44,8 @@ class CaptureService : public orbit_grpc_protos::CaptureService::Service {
                                orbit_grpc_protos::CaptureRequest>* reader_writer);
 
   void StartEventProcessing(const orbit_grpc_protos::CaptureOptions& capture_options);
-  void FinalizeEventProcessing();
+  enum class StopCaptureReason { kClientStop, kMemoryWatchdog };
+  void FinalizeEventProcessing(StopCaptureReason stop_capture_reason);
 
   std::unique_ptr<orbit_producer_event_processor::GrpcClientCaptureEventCollector>
       grpc_client_capture_event_collector_;
@@ -56,7 +57,7 @@ class CaptureService : public orbit_grpc_protos::CaptureService::Service {
  private:
   uint64_t clock_resolution_ns_ = 0;
   absl::Mutex capture_mutex_;
-  bool is_capturing ABSL_GUARDED_BY(capture_mutex_) = false;
+  bool is_capturing_ ABSL_GUARDED_BY(capture_mutex_) = false;
 };
 
 }  // namespace orbit_capture_service

--- a/src/CaptureService/include/CaptureService/CommonProducerCaptureEventBuilders.h
+++ b/src/CaptureService/include/CaptureService/CommonProducerCaptureEventBuilders.h
@@ -19,7 +19,10 @@ namespace orbit_capture_service {
     const orbit_grpc_protos::CaptureOptions& capture_options, absl::Time capture_start_time,
     uint64_t capture_start_timestamp_ns);
 
-[[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateCaptureFinishedEvent();
+[[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateSuccessfulCaptureFinishedEvent();
+
+[[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
+CreateMemoryThresholdExceededCaptureFinishedEvent();
 
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateClockResolutionEvent(
     uint64_t timestamp_ns, uint64_t resolution_ns);

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -640,6 +640,7 @@ message ThreadNamesSnapshot {
 message CaptureFinished {
   enum Status {
     kSuccessful = 0;
+    kInterruptedByService = 2;
     kFailed = 1;
   };
 

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -180,7 +180,7 @@ LinuxCaptureService::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
           // process.
           std::optional<uint64_t> rss_bytes = ReadRssInBytesFromProcPidStat();
           if (!rss_bytes.has_value()) {
-            ERROR_ONCE("Reading resident set size of the current process");
+            ERROR_ONCE("Reading resident set size of OrbitService");
             continue;
           }
           if (rss_bytes.value() > watchdog_threshold_bytes) {

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -161,7 +161,6 @@ LinuxCaptureService::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
   static const uint64_t mem_total_bytes = GetPhysicalMemoryInBytes();
   std::thread memory_watchdog_thread;
   uint64_t watchdog_threshold_bytes = mem_total_bytes / 2;
-  static constexpr absl::Duration kWatchdogPollInterval = absl::Seconds(1);
   LOG("Starting memory watchdog with threshold %u B because total physical memory is %u B",
       watchdog_threshold_bytes, mem_total_bytes);
   memory_watchdog_thread = std::thread{
@@ -169,6 +168,7 @@ LinuxCaptureService::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
         while (true) {
           {
             absl::MutexLock lock{&*stop_capture_mutex};
+            static constexpr absl::Duration kWatchdogPollInterval = absl::Seconds(1);
             if (stop_capture_mutex->AwaitWithTimeout(absl::Condition(&*stop_capture),
                                                      kWatchdogPollInterval)) {
               LOG("Stopping memory watchdog as the capture was stopped");

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -183,7 +183,7 @@ LinuxCaptureService::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
       }};
 
   static const uint64_t mem_total_bytes = GetPhysicalMemoryInBytes();
-  uint64_t watchdog_threshold_bytes = mem_total_bytes / 2;
+  static const uint64_t watchdog_threshold_bytes = mem_total_bytes / 2;
   LOG("Starting memory watchdog with threshold %u B because total physical memory is %u B",
       watchdog_threshold_bytes, mem_total_bytes);
   while (true) {

--- a/src/WindowsCaptureService/WindowsCaptureService.cpp
+++ b/src/WindowsCaptureService/WindowsCaptureService.cpp
@@ -33,7 +33,7 @@ grpc::Status WindowsCaptureService::Capture(
   tracing_handler.Start(request.capture_options());
   WaitForStopCaptureRequestFromClient(reader_writer);
   tracing_handler.Stop();
-  FinalizeEventProcessing();
+  FinalizeEventProcessing(StopCaptureReason::kClientStop);
 
   TerminateCapture();
 


### PR DESCRIPTION
A thread polls the resident set size during the capture and verifies it stays
below half the total physical memory. I just picked a simple threshold, we can
adjust the value.

The client needs basically no change. `CaptureClient` will simply transition
from `State::kStarted` to `State::kStopped`. That is, unless the client also
stops the capture after the service has interrupted it but before
`CaptureFinished` has been sent; but this also works as expected.

The new `CaptureFinished::Status::kInterruptedByService` is added to
`CaptureFinished`, to signal that the capture was stopped by the service and not
by the client.

The trickier part was to make this work with the streaming Capture gRPC. In the
synchronous version that we use, when we stop the capture on the service side,
and hence the client doesn't call `WritesDone`, `ServerReaderWriter::Read`
blocks until the RPC finishes, i.e., until `CaptureService::Service::Capture`
returns. So we need to move the `Read` to a different thread and join it later.
I also tried switching to a callback-based async gRPC service, but the code was
more complicated, and it would require updating to gRPC v1.39.0, which is
complex.

Bug: http://b/209364229

Test: Taken a large number of captures instrumenting functions that caused
OrbitService to be unable to send data quickly enough, hence eventually hitting
the memory threshold. These cases saw OrbitService being killed before this
change.