### PR TITLE
Disconnect bitness of DWARF and target architecture in libunwindstack

### DIFF
--- a/third_party/libunwindstack/DwarfEhFrameWithHdr.h
+++ b/third_party/libunwindstack/DwarfEhFrameWithHdr.h
@@ -45,10 +45,12 @@ class DwarfEhFrameWithHdr : public DwarfSectionImpl<AddressType> {
   virtual ~DwarfEhFrameWithHdr() = default;
 
   uint64_t GetCieOffsetFromFde32(uint32_t pointer) override {
+    // The "4" is the size of the CIE_id entry, which is 4 bytes for DWARF32.
     return memory_.cur_offset() - pointer - 4;
   }
 
   uint64_t GetCieOffsetFromFde64(uint64_t pointer) override {
+    // The "8" is the size of the CIE_id entry, which is 8 bytes for DWARF64.
     return memory_.cur_offset() - pointer - 8;
   }
 

--- a/third_party/libunwindstack/DwarfEncoding.h
+++ b/third_party/libunwindstack/DwarfEncoding.h
@@ -46,6 +46,27 @@ enum DwarfEncoding : uint8_t {
   DW_EH_PE_block = 0x0f,
 };
 
+// Needed for static_asserts that depend on the template parameter. Just a
+// plain `false` in the static_assert will cause compilation to fail.
+template <typename>
+inline constexpr bool kDependentFalse = false;
+
+template <typename AddressType>
+struct AddressEncodingType {
+  static_assert(kDependentFalse<AddressType>,
+                "You can only use either the uin32_t or uint64_t specializations.");
+};
+
+template <>
+struct AddressEncodingType<uint32_t> {
+  static constexpr DwarfEncoding kEncodingType = DW_EH_PE_udata4;
+};
+
+template <>
+struct AddressEncodingType<uint64_t> {
+  static constexpr DwarfEncoding kEncodingType = DW_EH_PE_udata8;
+};
+
 }  // namespace unwindstack
 
 #endif  // _LIBUNWINDSTACK_DWARF_ENCODING_H

--- a/third_party/libunwindstack/DwarfSection.cpp
+++ b/third_party/libunwindstack/DwarfSection.cpp
@@ -102,8 +102,7 @@ bool DwarfSectionImpl<AddressType>::FillInCieHeader(DwarfCie* cie) {
     }
 
     cie->cfa_instructions_end = memory_.cur_offset() + length64;
-    // TODO(b/192012848): This is wrong. We need to propagate pointer size here.
-    cie->fde_address_encoding = DW_EH_PE_udata8;
+    cie->fde_address_encoding = AddressEncodingType<AddressType>::kEncodingType;
 
     uint64_t cie_id;
     if (!memory_.ReadBytes(&cie_id, sizeof(cie_id))) {
@@ -119,8 +118,7 @@ bool DwarfSectionImpl<AddressType>::FillInCieHeader(DwarfCie* cie) {
   } else {
     // 32 bit Cie
     cie->cfa_instructions_end = memory_.cur_offset() + length32;
-    // TODO(b/192012848): This is wrong. We need to propagate pointer size here.
-    cie->fde_address_encoding = DW_EH_PE_udata4;
+    cie->fde_address_encoding = AddressEncodingType<AddressType>::kEncodingType;
 
     uint32_t cie_id;
     if (!memory_.ReadBytes(&cie_id, sizeof(cie_id))) {
@@ -434,7 +432,8 @@ bool DwarfSectionImpl<AddressType>::EvalRegister(const DwarfLocation* loc, uint3
   Memory* regular_memory = eval_info->regular_memory;
   switch (loc->type) {
     case DWARF_LOCATION_OFFSET:
-      if (!regular_memory->ReadFully(eval_info->cfa + loc->values[0], reg_ptr, sizeof(AddressType))) {
+      if (!regular_memory->ReadFully(eval_info->cfa + loc->values[0], reg_ptr,
+                                     sizeof(AddressType))) {
         last_error_.code = DWARF_ERROR_MEMORY_INVALID;
         last_error_.address = eval_info->cfa + loc->values[0];
         return false;
@@ -674,7 +673,7 @@ bool DwarfSectionImpl<AddressType>::GetNextCieOrFde(uint64_t& next_entries_offse
 
     if (value64 == cie64_value_) {
       entry_is_cie = true;
-      cie_fde_encoding = DW_EH_PE_udata8;
+      cie_fde_encoding = AddressEncodingType<AddressType>::kEncodingType;
     } else {
       cie_offset = GetCieOffsetFromFde64(value64);
     }
@@ -690,7 +689,7 @@ bool DwarfSectionImpl<AddressType>::GetNextCieOrFde(uint64_t& next_entries_offse
 
     if (value32 == cie32_value_) {
       entry_is_cie = true;
-      cie_fde_encoding = DW_EH_PE_udata4;
+      cie_fde_encoding = AddressEncodingType<AddressType>::kEncodingType;
     } else {
       cie_offset = GetCieOffsetFromFde32(value32);
     }

--- a/third_party/libunwindstack/tests/DwarfEhFrameTest.cpp
+++ b/third_party/libunwindstack/tests/DwarfEhFrameTest.cpp
@@ -54,7 +54,23 @@ TYPED_TEST_P(DwarfEhFrameTest, GetFdeCieFromOffset32) {
   this->memory_.SetData32(0x5000, 0xfc);
   // Indicates this is a cie for eh_frame.
   this->memory_.SetData32(0x5004, 0);
-  this->memory_.SetMemory(0x5008, std::vector<uint8_t>{1, '\0', 16, 32, 1});
+  constexpr uint64_t kCieDataOffset = 0x5008;
+
+  // We force size of target address pointers to 4 bytes using augmentation data to avoid
+  // failures due to incorrect .eh_frame section parsing (which uses a fixed "4" as the
+  // value size), which is not easily fixed due to side effects for other cases. In practice,
+  // .eh_frame encoding typically (always?) is DW_EH_PE_pcrel | DW_EH_PE_sdata4 (0x1b), which
+  // thus uses a size of 4 bytes.
+  std::vector<uint8_t> data{
+      1,               // version
+      'z', 'R', '\0',  // augmentation string
+      16,              // code alignment factor
+      32,              // data alignment factor
+      2,               // return address register
+      1,               // augmentation data length, ULEB128
+      0x03             // augmentation data (DW_EH_PE_udata4)
+  };
+  this->memory_.SetMemory(kCieDataOffset, data);
 
   // FDE 32 information.
   this->memory_.SetData32(0x5100, 0xfc);
@@ -62,10 +78,18 @@ TYPED_TEST_P(DwarfEhFrameTest, GetFdeCieFromOffset32) {
   this->memory_.SetData32(0x5108, 0x1500);
   this->memory_.SetData32(0x510c, 0x200);
 
+  // Augmentation size, ULEB128 encoding, must be present as 'z' is presen in the
+  // augmentation string.
+  constexpr uint64_t kFdeAugmentationSizeOffset = 0x5110;
+  this->memory_.SetData8(0x5110, 0x0);
+
   const DwarfFde* fde = this->eh_frame_->GetFdeFromOffset(0x5100);
   ASSERT_TRUE(fde != nullptr);
   EXPECT_EQ(0x5000U, fde->cie_offset);
-  EXPECT_EQ(0x5110U, fde->cfa_instructions_offset);
+
+  // This is the offset of the augmentation size in the FDE (kFdeAugmentationSizeOffset) + 1, for
+  // the one byte that represents the size of the augmentation data.
+  EXPECT_EQ(kFdeAugmentationSizeOffset + 1, fde->cfa_instructions_offset);
   EXPECT_EQ(0x5200U, fde->cfa_instructions_end);
   EXPECT_EQ(0x6608U, fde->pc_start);
   EXPECT_EQ(0x6808U, fde->pc_end);
@@ -77,13 +101,15 @@ TYPED_TEST_P(DwarfEhFrameTest, GetFdeCieFromOffset32) {
   EXPECT_EQ(DW_EH_PE_udata4, cie->fde_address_encoding);
   EXPECT_EQ(DW_EH_PE_omit, cie->lsda_encoding);
   EXPECT_EQ(0U, cie->segment_size);
-  EXPECT_EQ('\0', cie->augmentation_string[0]);
+  EXPECT_EQ('z', cie->augmentation_string[0]);
+  EXPECT_EQ('R', cie->augmentation_string[1]);
+  EXPECT_EQ('\0', cie->augmentation_string[2]);
   EXPECT_EQ(0U, cie->personality_handler);
-  EXPECT_EQ(0x500dU, cie->cfa_instructions_offset);
+  EXPECT_EQ(kCieDataOffset + data.size(), cie->cfa_instructions_offset);
   EXPECT_EQ(0x5100U, cie->cfa_instructions_end);
   EXPECT_EQ(16U, cie->code_alignment_factor);
   EXPECT_EQ(32U, cie->data_alignment_factor);
-  EXPECT_EQ(1U, cie->return_address_register);
+  EXPECT_EQ(2U, cie->return_address_register);
 }
 
 TYPED_TEST_P(DwarfEhFrameTest, GetFdeCieFromOffset64) {
@@ -92,37 +118,62 @@ TYPED_TEST_P(DwarfEhFrameTest, GetFdeCieFromOffset64) {
   this->memory_.SetData64(0x5004, 0xfc);
   // Indicates this is a cie for eh_frame.
   this->memory_.SetData64(0x500c, 0);
-  this->memory_.SetMemory(0x5014, std::vector<uint8_t>{1, '\0', 16, 32, 1});
+
+  // We force size of target address pointers to 4 bytes using augmentation data to avoid
+  // failures due to incorrect .eh_frame section parsing (which uses a fixed "4" as the
+  // value size), which is not easily fixed due to side effects for other cases. In practice,
+  // .eh_frame encoding typically (always?) is DW_EH_PE_pcrel | DW_EH_PE_sdata4 (0x1b), which
+  // thus uses a size of 4 bytes.
+  constexpr uint64_t kCieDataOffset = 0x5014;
+  std::vector<uint8_t> data{
+      1,               // version
+      'z', 'R', '\0',  // augmentation string
+      16,              // code alignment factor
+      32,              // data alignment factor
+      2,               // return address register
+      1,               // augmentation data length, ULEB128
+      0x03             // augmentation data (DW_EH_PE_udata4)
+  };
+  this->memory_.SetMemory(kCieDataOffset, data);
 
   // FDE 64 information.
   this->memory_.SetData32(0x5100, 0xffffffff);
   this->memory_.SetData64(0x5104, 0xfc);
   this->memory_.SetData64(0x510c, 0x10c);
-  this->memory_.SetData64(0x5114, 0x1500);
-  this->memory_.SetData64(0x511c, 0x200);
+  constexpr uint64_t kPcStartOffsetInFile = 0x5114;
+  constexpr uint32_t kPcStartValueInFile = 0x1500;
+  this->memory_.SetData32(kPcStartOffsetInFile, kPcStartValueInFile);
+  this->memory_.SetData32(0x5118, 0x200);
+
+  // Augmentation size, ULEB128 encoding, must be present as 'z' is presen in the
+  // augmentation string.
+  constexpr uint64_t kFdeAugmentationSizeOffset = 0x511c;
+  this->memory_.SetData8(kFdeAugmentationSizeOffset, 0x0);
 
   const DwarfFde* fde = this->eh_frame_->GetFdeFromOffset(0x5100);
   ASSERT_TRUE(fde != nullptr);
   EXPECT_EQ(0x5000U, fde->cie_offset);
-  EXPECT_EQ(0x5124U, fde->cfa_instructions_offset);
+  EXPECT_EQ(kFdeAugmentationSizeOffset + 1, fde->cfa_instructions_offset);
   EXPECT_EQ(0x5208U, fde->cfa_instructions_end);
-  EXPECT_EQ(0x6618U, fde->pc_start);
-  EXPECT_EQ(0x6818U, fde->pc_end);
+  EXPECT_EQ(kPcStartOffsetInFile + kPcStartValueInFile, fde->pc_start);
+  EXPECT_EQ(kPcStartOffsetInFile + kPcStartValueInFile + 0x200, fde->pc_end);
   EXPECT_EQ(0U, fde->lsda_address);
 
   const DwarfCie* cie = fde->cie;
   ASSERT_TRUE(cie != nullptr);
   EXPECT_EQ(1U, cie->version);
-  EXPECT_EQ(DW_EH_PE_udata8, cie->fde_address_encoding);
+  EXPECT_EQ(DW_EH_PE_udata4, cie->fde_address_encoding);
   EXPECT_EQ(DW_EH_PE_omit, cie->lsda_encoding);
   EXPECT_EQ(0U, cie->segment_size);
-  EXPECT_EQ('\0', cie->augmentation_string[0]);
+  EXPECT_EQ('z', cie->augmentation_string[0]);
+  EXPECT_EQ('R', cie->augmentation_string[1]);
+  EXPECT_EQ('\0', cie->augmentation_string[2]);
   EXPECT_EQ(0U, cie->personality_handler);
-  EXPECT_EQ(0x5019U, cie->cfa_instructions_offset);
+  EXPECT_EQ(kCieDataOffset + data.size(), cie->cfa_instructions_offset);
   EXPECT_EQ(0x5108U, cie->cfa_instructions_end);
   EXPECT_EQ(16U, cie->code_alignment_factor);
   EXPECT_EQ(32U, cie->data_alignment_factor);
-  EXPECT_EQ(1U, cie->return_address_register);
+  EXPECT_EQ(2U, cie->return_address_register);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(DwarfEhFrameTest, GetFdeCieFromOffset32, GetFdeCieFromOffset64);


### PR DESCRIPTION
This change disconnects the bitness of DWARF (DWARF-32 or DWARF-64) 
from the bitness of the target architecture, which were (incorrectly)
connected in libunwindstack when no encoding was given explicitly. The
main change is only a few lines of code in DwarfSection.cpp that set the
encoding size to the size of the target address size when needed (this
is potentially overridden later by explicit choice in the augmentation string
or by the address size parameter in DWARF version 4 or 5). 

Relevant sections in the DWARF standard 4 and 5 (available
at https://dwarfstd.org/) are 7.4 and 7.5.2.

While the actual code change is small, multiple unit tests assumed the
original behavior and needed to be adapted. In detail:
* Fixed PeCoffInterfaceTest due to incorrect CIE/FDE setup (wrong type
sizes for the target address).
* Fixed DwarfEhFrameTest by enforcing encoding size using augmentation
string. The current code for .eh_frame parsing assumes a value size of
4 bytes for encoded target addresses. This is probably okay in practice,
as the encoding is typically (always?) given explicitly in the .eh_frame
case, but we need to work around this for unit testing.
* Fixed DwarfEhFrameWithHdrTest by enforcing encoding size using
augmentation string, for the same reason as stated above.
* Fixed DwarfDebugFrameTest by correcting the FDE setup and making it
depend on the chosen target address size.