### PR TITLE
Simplify vertical zoom method

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -267,9 +267,7 @@ void CaptureWindow::Zoom(ZoomDirection dir, int delta) {
         break;
       }
       case ZoomDirection::kVertical: {
-        float mouse_ratio = static_cast<float>(mouse_move_pos_screen_[1]) /
-                            static_cast<float>(viewport_.GetScreenHeight());
-        time_graph_->VerticalZoom(delta_float, mouse_ratio);
+        time_graph_->VerticalZoom(delta_float, mouse_move_pos_screen_[1]);
       }
     }
   }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -76,7 +76,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   void Zoom(const orbit_client_protos::TimerInfo& timer_info);
   void Zoom(uint64_t min, uint64_t max);
   void ZoomTime(float zoom_value, double mouse_ratio);
-  void VerticalZoom(float zoom_value, float mouse_normalized_y_position);
+  void VerticalZoom(float zoom_value, float mouse_screen_y_position);
   void SetMinMax(double min_time_us, double max_time_us);
   void PanTime(int initial_x, int current_x, int width, double initial_time);
   enum class VisibilityType {


### PR DESCRIPTION
We are refactoring TimeGraph to also include the TimelineUI component.
This means that Timeline should react to Vertical Zoom as well. As it
was difficult to understand the part of proposed-ratio/real-ratio, I'm
simplifying here this method to make the refactor simpler later.

I hope that now this method will be easier to understand.

Test: Load a capture, test vertical zoom.