### PR TITLE
Create TrackContainer

### DIFF
--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -31,13 +31,16 @@ AccessibilityState TimeGraphAccessibility::AccessibleState() const {
 }
 
 int TimeGraphAccessibility::AccessibleChildCount() const {
-  return time_graph_->GetTrackManager()->GetVisibleTracks().size();
+  // TODO(b/208431620): Include the Timeline as another children.
+  return 1;  // TrackContainer
 }
 
 const AccessibleInterface* TimeGraphAccessibility::AccessibleChild(int index) const {
-  return time_graph_->GetTrackManager()
-      ->GetVisibleTracks()[index]
-      ->GetOrCreateAccessibleInterface();
+  // TODO(b/208431620): Include the Timeline as another children.
+  if (index == 0) {
+    return time_graph_->GetTrackContainer()->GetOrCreateAccessibleInterface();
+  }
+  return nullptr;
 }
 
 const AccessibleInterface* TimeGraphAccessibility::AccessibleParent() const {

--- a/src/OrbitGl/AccessibleTrackContainer.cpp
+++ b/src/OrbitGl/AccessibleTrackContainer.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AccessibleTrackContainer.h"
+
+#include <vector>
+
+#include "AccessibleInterfaceProvider.h"
+#include "AccessibleTrack.h"
+#include "Track.h"
+#include "TrackContainer.h"
+#include "TrackManager.h"
+#include "Viewport.h"
+
+using orbit_accessibility::AccessibilityRect;
+using orbit_accessibility::AccessibilityState;
+using orbit_accessibility::AccessibleInterface;
+
+namespace orbit_gl {
+
+AccessibilityState AccessibleTrackContainer::AccessibleState() const {
+  return AccessibilityState::Focusable;
+}
+
+int AccessibleTrackContainer::AccessibleChildCount() const {
+  return track_container_->GetTrackManager()->GetVisibleTracks().size();
+}
+
+const AccessibleInterface* AccessibleTrackContainer::AccessibleChild(int index) const {
+  return track_container_->GetTrackManager()
+      ->GetVisibleTracks()[index]
+      ->GetOrCreateAccessibleInterface();
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleTrackContainer.h
+++ b/src/OrbitGl/AccessibleTrackContainer.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_ACCESSIBLE_TRACK_CONTAINER_H_
+#define ORBIT_GL_ACCESSIBLE_TRACK_CONTAINER_H_
+
+#include <string>
+
+#include "AccessibleCaptureViewElement.h"
+#include "OrbitAccessibility/AccessibleInterface.h"
+#include "TrackContainer.h"
+
+namespace orbit_gl {
+
+// Accessibility information for TrackContainer.
+class AccessibleTrackContainer : public AccessibleCaptureViewElement {
+ public:
+  explicit AccessibleTrackContainer(TrackContainer* track_container)
+      : AccessibleCaptureViewElement(track_container), track_container_(track_container){};
+
+  [[nodiscard]] int AccessibleChildCount() const override;
+  [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleChild(
+      int index) const override;
+
+  [[nodiscard]] std::string AccessibleName() const override { return "Track Container"; }
+  [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
+    return orbit_accessibility::AccessibilityRole::Grouping;  // TODO: FlorianR, is this correct?
+  }
+  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
+
+ private:
+  TrackContainer* track_container_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_ACCESSIBLE_TRACK_CONTAINER_H_

--- a/src/OrbitGl/AccessibleTrackContainer.h
+++ b/src/OrbitGl/AccessibleTrackContainer.h
@@ -25,7 +25,7 @@ class AccessibleTrackContainer : public AccessibleCaptureViewElement {
 
   [[nodiscard]] std::string AccessibleName() const override { return "Track Container"; }
   [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
-    return orbit_accessibility::AccessibilityRole::Grouping;  // TODO: FlorianR, is this correct?
+    return orbit_accessibility::AccessibilityRole::Pane;
   }
   [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2720,26 +2720,26 @@ bool OrbitApp::HasFrameTrackInCaptureData(uint64_t instrumented_function_id) con
 void OrbitApp::JumpToTimerAndZoom(uint64_t function_id, JumpToTimerMode selection_mode) {
   switch (selection_mode) {
     case JumpToTimerMode::kFirst: {
-      const auto* first_timer = GetMutableTimeGraph()->GetTrackContainer()->FindNextFunctionCall(
+      const auto* first_timer = GetMutableTimeGraph()->FindNextFunctionCall(
           function_id, std::numeric_limits<uint64_t>::lowest());
       if (first_timer != nullptr) GetMutableTimeGraph()->SelectAndZoom(first_timer);
       break;
     }
     case JumpToTimerMode::kLast: {
-      const auto* last_timer = GetMutableTimeGraph()->GetTrackContainer()->FindPreviousFunctionCall(
+      const auto* last_timer = GetMutableTimeGraph()->FindPreviousFunctionCall(
           function_id, std::numeric_limits<uint64_t>::max());
       if (last_timer != nullptr) GetMutableTimeGraph()->SelectAndZoom(last_timer);
       break;
     }
     case JumpToTimerMode::kMin: {
       auto [min_timer, unused_max_timer] =
-          GetMutableTimeGraph()->GetTrackContainer()->GetMinMaxTimerInfoForFunction(function_id);
+          GetMutableTimeGraph()->GetMinMaxTimerInfoForFunction(function_id);
       if (min_timer != nullptr) GetMutableTimeGraph()->SelectAndZoom(min_timer);
       break;
     }
     case JumpToTimerMode::kMax: {
       auto [unused_min_timer, max_timer] =
-          GetMutableTimeGraph()->GetTrackContainer()->GetMinMaxTimerInfoForFunction(function_id);
+          GetMutableTimeGraph()->GetMinMaxTimerInfoForFunction(function_id);
       if (max_timer != nullptr) GetMutableTimeGraph()->SelectAndZoom(max_timer);
       break;
     }
@@ -2747,7 +2747,7 @@ void OrbitApp::JumpToTimerAndZoom(uint64_t function_id, JumpToTimerMode selectio
 }
 
 std::vector<const TimerInfo*> OrbitApp::GetAllTimersForHookedFunction(uint64_t function_id) const {
-  return GetTimeGraph()->GetTrackContainer()->GetAllTimersForHookedFunction(function_id);
+  return GetTimeGraph()->GetAllTimersForHookedFunction(function_id);
 }
 
 void OrbitApp::RefreshFrameTracks() {
@@ -2767,8 +2767,7 @@ void OrbitApp::AddFrameTrackTimers(uint64_t instrumented_function_id) {
     return;
   }
 
-  std::vector<const TimerChain*> chains =
-      GetMutableTimeGraph()->GetTrackContainer()->GetAllThreadTrackTimerChains();
+  std::vector<const TimerChain*> chains = GetMutableTimeGraph()->GetAllThreadTrackTimerChains();
 
   std::vector<uint64_t> all_start_times;
 

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
          AccessibleTimeGraph.h
          AccessibleTimeline.h
          AccessibleTrack.h
+         AccessibleTrackContainer.h
          AccessibleTriangleToggle.h
          AnnotationTrack.h
          App.h
@@ -70,12 +71,13 @@ target_sources(
          Timer.h
          TimerInfosIterator.h
          TimerTrack.h
-         Track.h
-         TrackManager.h
-         TriangleToggle.h
          TracepointThreadBar.h
+         Track.h
+         TrackContainer.h
+         TrackManager.h
          TrackTestData.h
          TranslationStack.h
+         TriangleToggle.h
          VariableTrack.h
          Viewport.h)
 
@@ -86,6 +88,7 @@ target_sources(
           AccessibleThreadBar.cpp
           AccessibleTimeGraph.cpp
           AccessibleTrack.cpp
+          AccessibleTrackContainer.cpp
           AccessibleTriangleToggle.cpp
           AnnotationTrack.cpp
           App.cpp
@@ -133,12 +136,13 @@ target_sources(
           ThreadBar.cpp
           ThreadStateBar.cpp
           ThreadTrack.cpp
+          TracepointThreadBar.cpp
           Track.cpp
+          TrackContainer.cpp
           TrackManager.cpp
+          TrackTestData.cpp
           TranslationStack.cpp
           TriangleToggle.cpp
-          TracepointThreadBar.cpp
-          TrackTestData.cpp
           Viewport.cpp)
 
 target_include_directories(OrbitGl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -120,8 +120,8 @@ void CaptureWindow::MouseMoved(int x, int y, bool left, bool right, bool middle)
   if (left && !picking_manager_.IsDragging() && !app_->IsCapturing()) {
     Vec2i mouse_click_screen = viewport_.WorldToScreen(mouse_click_pos_world_);
     Vec2 mouse_pos_world = viewport_.ScreenToWorld({x, y});
-    time_graph_->SetVerticalScrollingOffset(timegraph_click_scrolling_offset_ +
-                                            mouse_click_pos_world_[1] - mouse_pos_world[1]);
+    time_graph_->GetTrackContainer()->SetVerticalScrollingOffset(
+        track_container_click_scrolling_offset_ + mouse_click_pos_world_[1] - mouse_pos_world[1]);
     time_graph_->PanTime(mouse_click_screen[0], x, viewport_.GetScreenWidth(), ref_time_click_);
 
     click_was_drag_ = true;
@@ -140,7 +140,8 @@ void CaptureWindow::LeftDown(int x, int y) {
 
   if (time_graph_ == nullptr) return;
   ref_time_click_ = time_graph_->GetTime(static_cast<double>(x) / viewport_.GetScreenWidth());
-  timegraph_click_scrolling_offset_ = time_graph_->GetVerticalScrollingOffset();
+  track_container_click_scrolling_offset_ =
+      time_graph_->GetTrackContainer()->GetVerticalScrollingOffset();
 }
 
 void CaptureWindow::LeftUp() {
@@ -558,7 +559,7 @@ void CaptureWindow::UpdateVerticalScroll(float ratio) {
   if (time_graph_ == nullptr) return;
   float range = std::max(0.f, time_graph_->GetHeight() - viewport_.GetWorldHeight());
   float new_scrolling_offset = ratio * range;
-  time_graph_->SetVerticalScrollingOffset(new_scrolling_offset);
+  time_graph_->GetTrackContainer()->SetVerticalScrollingOffset(new_scrolling_offset);
 }
 
 void CaptureWindow::UpdateHorizontalZoom(float normalized_start, float normalized_end) {
@@ -602,7 +603,8 @@ void CaptureWindow::ProcessSliderMouseMoveEvents(int x, int y) {
 void CaptureWindow::UpdateVerticalSliderFromWorld() {
   if (time_graph_ == nullptr) return;
   float max = std::max(0.f, time_graph_->GetHeight() - viewport_.GetWorldHeight());
-  float pos_ratio = max > 0 ? time_graph_->GetVerticalScrollingOffset() / max : 0.f;
+  float pos_ratio =
+      max > 0 ? time_graph_->GetTrackContainer()->GetVerticalScrollingOffset() / max : 0.f;
   float size_ratio =
       time_graph_->GetHeight() > 0 ? viewport_.GetWorldHeight() / time_graph_->GetHeight() : 1.f;
   int slider_width = static_cast<int>(time_graph_->GetLayout().GetSliderWidth());
@@ -688,7 +690,7 @@ void CaptureWindow::RenderImGuiDebugUI() {
     IMGUI_VAR_TO_TEXT(mouse_move_pos_screen_[0]);
     IMGUI_VAR_TO_TEXT(mouse_move_pos_screen_[1]);
     if (time_graph_ != nullptr) {
-      IMGUI_VAR_TO_TEXT(time_graph_->GetNumVisiblePrimitives());
+      IMGUI_VAR_TO_TEXT(time_graph_->GetTrackContainer()->GetNumVisiblePrimitives());
       IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetAllTracks().size());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMinTimeUs());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMaxTimeUs());

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -149,7 +149,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
 
   ImGuiContext* imgui_context_ = nullptr;
   double ref_time_click_;
-  float timegraph_click_scrolling_offset_ = 0;
+  float track_container_click_scrolling_offset_ = 0;
   TextRenderer text_renderer_;
   PickingManager picking_manager_;
   bool double_clicking_;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -25,7 +25,6 @@
 #include "GpuTrack.h"
 #include "GrpcProtos/Constants.h"
 #include "Introspection/Introspection.h"
-#include "ManualInstrumentationManager.h"
 #include "OrbitBase/Append.h"
 #include "OrbitBase/Logging.h"
 #include "PageFaultsTrack.h"

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -5,7 +5,6 @@
 #include "TimeGraph.h"
 
 #include <GteVector.h>
-#include <absl/container/flat_hash_map.h>
 #include <absl/flags/flag.h>
 #include <absl/strings/str_format.h>
 #include <absl/time/time.h>
@@ -13,7 +12,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <utility>
 
 #include "App.h"
 #include "AsyncTrack.h"
@@ -21,9 +19,7 @@
 #include "CaptureClient/CaptureEventProcessor.h"
 #include "ClientData/FunctionUtils.h"
 #include "ClientFlags/ClientFlags.h"
-#include "DisplayFormats/DisplayFormats.h"
 #include "FrameTrack.h"
-#include "Geometry.h"
 #include "GlCanvas.h"
 #include "GlUtils.h"
 #include "GpuTrack.h"
@@ -32,12 +28,10 @@
 #include "ManualInstrumentationManager.h"
 #include "OrbitBase/Append.h"
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/ThreadConstants.h"
 #include "PageFaultsTrack.h"
 #include "PickingManager.h"
 #include "SchedulerTrack.h"
 #include "SystemMemoryTrack.h"
-#include "ThreadTrack.h"
 #include "TrackManager.h"
 #include "VariableTrack.h"
 
@@ -68,13 +62,12 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
       batcher_(BatcherId::kTimeGraph),
       manual_instrumentation_manager_{app->GetManualInstrumentationManager()},
       capture_data_{capture_data},
-      thread_track_data_provider_(capture_data->GetThreadTrackDataProvider()),
       app_{app} {
   text_renderer_static_.Init();
   text_renderer_static_.SetViewport(viewport);
   batcher_.SetPickingManager(picking_manager);
-  track_manager_ = std::make_unique<TrackManager>(this, viewport_, &GetLayout(), app, capture_data);
-  track_manager_->GetOrCreateSchedulerTrack();
+  track_container_ =
+      std::make_unique<orbit_gl::TrackContainer>(this, this, viewport, &layout_, app, capture_data);
 
   if (absl::GetFlag(FLAGS_enforce_full_redraw)) {
     RequestUpdate();
@@ -82,18 +75,15 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
 }
 
 float TimeGraph::GetHeight() const {
-  // Top and Bottom Margin. TODO: Margins should be treated in a different way (http://b/192070555).
-  float total_height = layout_.GetSchedulerTrackOffset() + layout_.GetBottomMargin();
-
-  // Track height including space between them
-  for (auto& track : GetNonHiddenChildren()) {
-    total_height += (track->GetHeight() + layout_.GetSpaceBetweenTracks());
+  float total_height = 0.;
+  for (orbit_gl::CaptureViewElement* capture_view_element : GetNonHiddenChildren()) {
+    total_height += capture_view_element->GetHeight();
   }
   return total_height;
 }
 
 void TimeGraph::UpdateCaptureMinMaxTimestamps() {
-  auto [tracks_min_time, tracks_max_time] = track_manager_->GetTracksMinMaxTimestamps();
+  auto [tracks_min_time, tracks_max_time] = GetTrackManager()->GetTracksMinMaxTimestamps();
 
   capture_min_timestamp_ = std::min(capture_min_timestamp_, tracks_min_time);
   capture_max_timestamp_ = std::max(capture_max_timestamp_, tracks_max_time);
@@ -164,14 +154,8 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_world_y_pos) {
   // As we have maximum/minimum scale, the real ratio might be different than the proposed one.
   const float real_ratio = layout_.GetScale() / old_scale;
 
-  // Adjust the scrolling offset such that the point under the mouse stays the same if possible.
-  // For this, calculate the "global" position (including the scrolling offset) of the point
-  // underneath the mouse with the old and new scaling, and adjust the scrolling to have them match.
-  const float mouse_old_y_global_position = mouse_world_y_pos + vertical_scrolling_offset_;
-  // Everything scales.
-  const float mouse_new_y_global_position = mouse_old_y_global_position * real_ratio;
-
-  SetVerticalScrollingOffset(mouse_new_y_global_position - mouse_world_y_pos);
+  // TODO(b/214270440): Behave differently when the mouse is on top of the timeline.
+  track_container_->VerticalZoom(real_ratio, mouse_world_y_pos);
 }
 
 // TODO(b/214280802): include SetMinMax in the TimelineInfoInterface, so the scrollbar could call
@@ -233,22 +217,6 @@ void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, const TimerInf
   HorizontallyMoveIntoView(vis_type, timer_info.start(), timer_info.end(), distance);
 }
 
-void TimeGraph::VerticallyMoveIntoView(const TimerInfo& timer_info) {
-  VerticallyMoveIntoView(*track_manager_->GetOrCreateTrackFromTimerInfo(timer_info));
-}
-
-// Move vertically the view to make a Track fully visible.
-void TimeGraph::VerticallyMoveIntoView(Track& track) {
-  float pos = track.GetPos()[1] + vertical_scrolling_offset_;
-  float height = track.GetHeight();
-
-  float max_vertical_scrolling_offset = pos;
-  float min_vertical_scrolling_offset =
-      pos + height - viewport_->GetWorldHeight() + layout_.GetBottomMargin();
-  SetVerticalScrollingOffset(std::clamp(vertical_scrolling_offset_, min_vertical_scrolling_offset,
-                                        max_vertical_scrolling_offset));
-}
-
 void TimeGraph::UpdateHorizontalScroll(float ratio) {
   double time_span = GetCaptureTimeSpanUs();
   double time_window = max_time_us_ - min_time_us_;
@@ -266,6 +234,7 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
   capture_min_timestamp_ = std::min(capture_min_timestamp_, timer_info.start());
   capture_max_timestamp_ = std::max(capture_max_timestamp_, timer_info.end());
 
+  TrackManager* track_manager = GetTrackManager();
   // TODO(b/175869409): Change the way to create and get the tracks. Move this part to TrackManager.
   switch (timer_info.type()) {
     // All GPU timers are handled equally here.
@@ -273,7 +242,7 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
     case TimerInfo::kGpuCommandBuffer:
     case TimerInfo::kGpuDebugMarker: {
       uint64_t timeline_hash = timer_info.timeline_hash();
-      GpuTrack* track = track_manager_->GetOrCreateGpuTrack(timeline_hash);
+      GpuTrack* track = track_manager->GetOrCreateGpuTrack(timeline_hash);
       track->OnTimer(timer_info);
       break;
     }
@@ -281,15 +250,15 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
       if (function == nullptr) {
         break;
       }
-      FrameTrack* track = track_manager_->GetOrCreateFrameTrack(*function);
+      FrameTrack* track = track_manager->GetOrCreateFrameTrack(*function);
       track->OnTimer(timer_info);
       break;
     }
     case TimerInfo::kCoreActivity: {
       // TODO(b/176962090): We need to create the `ThreadTrack` here even we don't use it, as we
       //  don't create it on new callstack events, yet.
-      track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
-      SchedulerTrack* scheduler_track = track_manager_->GetOrCreateSchedulerTrack();
+      track_manager->GetOrCreateThreadTrack(timer_info.thread_id());
+      SchedulerTrack* scheduler_track = track_manager->GetOrCreateSchedulerTrack();
       scheduler_track->OnTimer(timer_info);
       break;
     }
@@ -307,14 +276,14 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
     }
     case TimerInfo::kNone: {
       // TODO (http://b/198135618): Create tracks only before drawing.
-      track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
-      thread_track_data_provider_->AddTimer(timer_info);
+      track_manager->GetOrCreateThreadTrack(timer_info.thread_id());
+      track_container_->GetCaptureDataProvider()->AddTimer(timer_info);
       break;
     }
     case TimerInfo::kApiScope: {
       // TODO (http://b/198135618): Create tracks only before drawing.
-      track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
-      thread_track_data_provider_->AddTimer(timer_info);
+      track_manager->GetOrCreateThreadTrack(timer_info.thread_id());
+      track_container_->GetCaptureDataProvider()->AddTimer(timer_info);
       break;
     }
     case TimerInfo::kApiScopeAsync: {
@@ -333,7 +302,7 @@ void TimeGraph::ProcessApiStringEvent(const orbit_client_protos::ApiStringEvent&
 }
 
 void TimeGraph::ProcessApiTrackValueEvent(const orbit_client_protos::ApiTrackValue& track_event) {
-  VariableTrack* track = track_manager_->GetOrCreateVariableTrack(track_event.name());
+  VariableTrack* track = GetTrackManager()->GetOrCreateVariableTrack(track_event.name());
 
   uint64_t time = track_event.timestamp_ns();
 
@@ -362,9 +331,9 @@ void TimeGraph::ProcessApiTrackValueEvent(const orbit_client_protos::ApiTrackVal
 }
 
 void TimeGraph::ProcessSystemMemoryTrackingTimer(const TimerInfo& timer_info) {
-  SystemMemoryTrack* track = track_manager_->GetSystemMemoryTrack();
+  SystemMemoryTrack* track = GetTrackManager()->GetSystemMemoryTrack();
   if (track == nullptr) {
-    track = track_manager_->CreateAndGetSystemMemoryTrack();
+    track = GetTrackManager()->CreateAndGetSystemMemoryTrack();
   }
   track->OnTimer(timer_info);
 
@@ -382,9 +351,9 @@ void TimeGraph::ProcessCGroupAndProcessMemoryTrackingTimer(const TimerInfo& time
   std::string cgroup_name = app_->GetStringManager()->Get(cgroup_name_hash).value_or("");
   if (cgroup_name.empty()) return;
 
-  CGroupAndProcessMemoryTrack* track = track_manager_->GetCGroupAndProcessMemoryTrack();
+  CGroupAndProcessMemoryTrack* track = GetTrackManager()->GetCGroupAndProcessMemoryTrack();
   if (track == nullptr) {
-    track = track_manager_->CreateAndGetCGroupAndProcessMemoryTrack(cgroup_name);
+    track = GetTrackManager()->CreateAndGetCGroupAndProcessMemoryTrack(cgroup_name);
   }
   track->OnTimer(timer_info);
 }
@@ -395,10 +364,10 @@ void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
   std::string cgroup_name = app_->GetStringManager()->Get(cgroup_name_hash).value_or("");
   if (cgroup_name.empty()) return;
 
-  PageFaultsTrack* track = track_manager_->GetPageFaultsTrack();
+  PageFaultsTrack* track = GetTrackManager()->GetPageFaultsTrack();
   if (track == nullptr) {
     uint64_t memory_sampling_period_ms = app_->GetMemorySamplingPeriodMs();
-    track = track_manager_->CreateAndGetPageFaultsTrack(cgroup_name, memory_sampling_period_ms);
+    track = GetTrackManager()->CreateAndGetPageFaultsTrack(cgroup_name, memory_sampling_period_ms);
   }
   ORBIT_CHECK(track != nullptr);
   track->OnTimer(timer_info);
@@ -406,20 +375,8 @@ void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
 
 void TimeGraph::ProcessAsyncTimer(const TimerInfo& timer_info) {
   const std::string& track_name = timer_info.api_scope_name();
-  AsyncTrack* track = track_manager_->GetOrCreateAsyncTrack(track_name);
+  AsyncTrack* track = GetTrackManager()->GetOrCreateAsyncTrack(track_name);
   track->OnTimer(timer_info);
-}
-
-std::vector<const TimerChain*> TimeGraph::GetAllThreadTrackTimerChains() const {
-  return thread_track_data_provider_->GetAllThreadTimerChains();
-}
-
-int TimeGraph::GetNumVisiblePrimitives() const {
-  int num_visible_primitives = 0;
-  for (auto track : track_manager_->GetAllTracks()) {
-    num_visible_primitives += track->GetVisiblePrimitiveCount();
-  }
-  return num_visible_primitives;
 }
 
 float TimeGraph::GetWorldFromTick(uint64_t time) const {
@@ -460,71 +417,7 @@ void TimeGraph::SelectAndMakeVisible(const TimerInfo* timer_info) {
   ORBIT_CHECK(timer_info != nullptr);
   app_->SelectTimer(timer_info);
   HorizontallyMoveIntoView(VisibilityType::kPartlyVisible, *timer_info);
-  VerticallyMoveIntoView(*timer_info);
-}
-
-const TimerInfo* TimeGraph::FindPreviousFunctionCall(uint64_t function_address,
-                                                     uint64_t current_time,
-                                                     std::optional<uint32_t> thread_id) const {
-  const TimerInfo* previous_timer = nullptr;
-  uint64_t goal_time = std::numeric_limits<uint64_t>::lowest();
-  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
-  for (const TimerChain* chain : chains) {
-    for (const auto& block : *chain) {
-      if (!block.Intersects(goal_time, current_time)) continue;
-      for (uint64_t i = 0; i < block.size(); i++) {
-        const TimerInfo& timer_info = block[i];
-        auto timer_end_time = timer_info.end();
-        if ((timer_info.function_id() == function_address) &&
-            (!thread_id || thread_id.value() == timer_info.thread_id()) &&
-            (timer_end_time < current_time) && (goal_time < timer_end_time)) {
-          previous_timer = &timer_info;
-          goal_time = timer_end_time;
-        }
-      }
-    }
-  }
-  return previous_timer;
-}
-
-const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint64_t current_time,
-                                                 std::optional<uint32_t> thread_id) const {
-  const TimerInfo* next_timer = nullptr;
-  uint64_t goal_time = std::numeric_limits<uint64_t>::max();
-  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
-  for (const TimerChain* chain : chains) {
-    ORBIT_CHECK(chain != nullptr);
-    for (const auto& block : *chain) {
-      if (!block.Intersects(current_time, goal_time)) continue;
-      for (uint64_t i = 0; i < block.size(); i++) {
-        const TimerInfo& timer_info = block[i];
-        auto timer_end_time = timer_info.end();
-        if ((timer_info.function_id() == function_address) &&
-            (!thread_id || thread_id.value() == timer_info.thread_id()) &&
-            (timer_end_time > current_time) && (goal_time > timer_end_time)) {
-          next_timer = &timer_info;
-          goal_time = timer_end_time;
-        }
-      }
-    }
-  }
-  return next_timer;
-}
-
-std::vector<const TimerInfo*> TimeGraph::GetAllTimersForHookedFunction(
-    uint64_t function_address) const {
-  std::vector<const TimerInfo*> timers;
-  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
-  for (const TimerChain* chain : chains) {
-    ORBIT_CHECK(chain != nullptr);
-    for (const auto& block : *chain) {
-      for (uint64_t i = 0; i < block.size(); i++) {
-        const TimerInfo& timer = block[i];
-        if (timer.function_id() == function_address) timers.push_back(&timer);
-      }
-    }
-  }
-  return timers;
+  track_container_->VerticallyMoveIntoView(*timer_info);
 }
 
 void TimeGraph::RequestUpdate() {
@@ -560,253 +453,6 @@ void TimeGraph::DoUpdateLayout() {
       std::max(capture_max_timestamp_, capture_data_->GetCallstackData().max_time());
 
   time_window_us_ = max_time_us_ - min_time_us_;
-
-  track_manager_->UpdateTrackListForRendering();
-  UpdateTracksPosition();
-
-  // This is called to make sure the current scrolling value is correctly clamped
-  // in case any changes in track visibility occured before
-  SetVerticalScrollingOffset(vertical_scrolling_offset_);
-}
-
-void TimeGraph::UpdateTracksPosition() {
-  const float track_pos_x = GetPos()[0];
-
-  float current_y = layout_.GetSchedulerTrackOffset() - vertical_scrolling_offset_;
-
-  // Track height including space between them
-  for (auto& track : track_manager_->GetVisibleTracks()) {
-    if (!track->IsMoving()) {
-      track->SetPos(track_pos_x, current_y);
-    }
-    track->SetWidth(GetWidth());
-    current_y += (track->GetHeight() + layout_.GetSpaceBetweenTracks());
-  }
-}
-
-namespace {
-
-[[nodiscard]] std::string GetLabelBetweenIterators(const InstrumentedFunction& function_a,
-                                                   const InstrumentedFunction& function_b) {
-  const std::string& function_from = function_a.function_name();
-  const std::string& function_to = function_b.function_name();
-  return absl::StrFormat("%s to %s", function_from, function_to);
-}
-
-std::string GetTimeString(const TimerInfo& timer_a, const TimerInfo& timer_b) {
-  absl::Duration duration = TicksToDuration(timer_a.start(), timer_b.start());
-
-  return orbit_display_formats::GetDisplayTime(duration);
-}
-
-[[nodiscard]] Color GetIteratorBoxColor(uint64_t index) {
-  constexpr uint64_t kNumColors = 2;
-  const Color kLightBlueGray = Color(177, 203, 250, 60);
-  const Color kMidBlueGray = Color(81, 102, 157, 60);
-  Color colors[kNumColors] = {kLightBlueGray, kMidBlueGray};
-  return colors[index % kNumColors];
-}
-
-}  // namespace
-
-void TimeGraph::DrawIteratorBox(Batcher& batcher, TextRenderer& text_renderer, Vec2 pos, Vec2 size,
-                                const Color& color, const std::string& label,
-                                const std::string& time, float text_box_y) {
-  Box box(pos, size, GlCanvas::kZValueOverlay);
-  batcher.AddBox(box, color);
-
-  std::string text = absl::StrFormat("%s: %s", label, time);
-
-  float max_size = size[0];
-
-  const Color kBlack(0, 0, 0, 255);
-  float text_width = text_renderer.AddTextTrailingCharsPrioritized(
-      text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueTextUi,
-      {GetLayout().GetFontSize(), kBlack, max_size}, time.length());
-
-  Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), GetTextBoxHeight());
-  Vec2 white_box_position(pos[0], text_box_y);
-
-  Box white_box(white_box_position, white_box_size, GlCanvas::kZValueOverlayTextBackground);
-
-  const Color kWhite(255, 255, 255, 255);
-  batcher.AddBox(white_box, kWhite);
-
-  Vec2 line_from(pos[0] + white_box_size[0], white_box_position[1] + GetTextBoxHeight() / 2.f);
-  Vec2 line_to(pos[0] + size[0], white_box_position[1] + GetTextBoxHeight() / 2.f);
-  batcher.AddLine(line_from, line_to, GlCanvas::kZValueOverlay, Color(255, 255, 255, 255));
-}
-
-void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
-                            PickingMode picking_mode) {
-  if (picking_mode != PickingMode::kNone || iterator_timer_info_.empty()) {
-    return;
-  }
-
-  std::vector<std::pair<uint64_t, const TimerInfo*>> timers(iterator_timer_info_.size());
-  std::copy(iterator_timer_info_.begin(), iterator_timer_info_.end(), timers.begin());
-
-  // Sort timers by start time.
-  std::sort(timers.begin(), timers.end(),
-            [](const std::pair<uint64_t, const TimerInfo*>& timer_a,
-               const std::pair<uint64_t, const TimerInfo*>& timer_b) -> bool {
-              return timer_a.second->start() < timer_b.second->start();
-            });
-
-  // We will need the world x coordinates for the timers multiple times, so
-  // we avoid recomputing them and just cache them here.
-  std::vector<float> x_coords;
-  x_coords.reserve(timers.size());
-
-  float world_start_x = 0;
-  float world_width = GetWidth();
-
-  float world_start_y = 0;
-  float world_height = viewport_->GetWorldHeight();
-
-  double inv_time_window = 1.0 / GetTimeWindowUs();
-
-  // Draw lines for iterators.
-  for (const auto& box : timers) {
-    const TimerInfo* timer_info = box.second;
-
-    double start_us = GetUsFromTick(timer_info->start());
-    double normalized_start = start_us * inv_time_window;
-    auto world_timer_x = static_cast<float>(world_start_x + normalized_start * world_width);
-
-    Vec2 pos(world_timer_x, world_start_y);
-    x_coords.push_back(pos[0]);
-
-    batcher.AddVerticalLine(pos, world_height, GlCanvas::kZValueOverlay,
-                            GetThreadColor(timer_info->thread_id()));
-  }
-
-  // Draw timers with timings between iterators.
-  for (size_t k = 1; k < timers.size(); ++k) {
-    Vec2 pos(x_coords[k - 1], world_start_y);
-    float size_x = x_coords[k] - pos[0];
-    Vec2 size(size_x, world_height);
-    Color color = GetIteratorBoxColor(k - 1);
-
-    uint64_t id_a = timers[k - 1].first;
-    uint64_t id_b = timers[k].first;
-    ORBIT_CHECK(iterator_id_to_function_id_.find(id_a) != iterator_id_to_function_id_.end());
-    ORBIT_CHECK(iterator_id_to_function_id_.find(id_b) != iterator_id_to_function_id_.end());
-    uint64_t function_a_id = iterator_id_to_function_id_.at(id_a);
-    uint64_t function_b_id = iterator_id_to_function_id_.at(id_b);
-    const CaptureData& capture_data = app_->GetCaptureData();
-    const InstrumentedFunction* function_a =
-        capture_data.GetInstrumentedFunctionById(function_a_id);
-    const InstrumentedFunction* function_b =
-        capture_data.GetInstrumentedFunctionById(function_b_id);
-    ORBIT_CHECK(function_a != nullptr);
-    ORBIT_CHECK(function_b != nullptr);
-    const std::string& label = GetLabelBetweenIterators(*function_a, *function_b);
-    const std::string& time = GetTimeString(*timers[k - 1].second, *timers[k].second);
-
-    // Distance from the bottom where we don't want to draw.
-    float bottom_margin = layout_.GetBottomMargin();
-
-    // The height of text is chosen such that the text of the last box drawn is
-    // at pos[1] + bottom_margin (lowest possible position) and the height of
-    // the box showing the overall time (see below) is at pos[1] + (world_height
-    // / 2.f), corresponding to the case k == 0 in the formula for 'text_y'.
-    float height_per_text = ((world_height / 2.f) - bottom_margin) /
-                            static_cast<float>(iterator_timer_info_.size() - 1);
-    float text_y = pos[1] + (world_height / 2.f) + static_cast<float>(k) * height_per_text -
-                   layout_.GetTextBoxHeight();
-
-    DrawIteratorBox(batcher, text_renderer, pos, size, color, label, time, text_y);
-  }
-
-  // When we have at least 3 boxes, we also draw the total time from the first
-  // to the last iterator.
-  if (timers.size() > 2) {
-    size_t last_index = timers.size() - 1;
-
-    Vec2 pos(x_coords[0], world_start_y);
-    float size_x = x_coords[last_index] - pos[0];
-    Vec2 size(size_x, world_height);
-
-    std::string time = GetTimeString(*timers[0].second, *timers[last_index].second);
-    std::string label("Total");
-
-    float text_y = pos[1] + (world_height / 2.f);
-
-    // We do not want the overall box to add any color, so we just set alpha to
-    // 0.
-    const Color kColorBlackTransparent(0, 0, 0, 0);
-    DrawIteratorBox(batcher, text_renderer, pos, size, kColorBlackTransparent, label, time, text_y);
-  }
-}
-
-void TimeGraph::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode picking_mode) {
-  if (picking_mode == PickingMode::kClick) return;  // Allow to click through.
-
-  auto min_visible_timestamp_ns =
-      capture_min_timestamp_ + static_cast<uint64_t>(GetMinTimeUs() * 1000L);
-  auto max_visible_timestamp_ns =
-      capture_min_timestamp_ + static_cast<uint64_t>(GetMaxTimeUs() * 1000L);
-
-  std::vector<std::pair<float, float>> x_ranges;
-  for (auto it = capture_data_->incomplete_data_intervals().LowerBound(min_visible_timestamp_ns);
-       it != capture_data_->incomplete_data_intervals().end() &&
-       it->start_inclusive() <= max_visible_timestamp_ns;
-       ++it) {
-    uint64_t start_timestamp_ns = it->start_inclusive();
-    uint64_t end_timestamp_ns = it->end_exclusive();
-
-    float start_x = GetWorldFromTick(start_timestamp_ns);
-    float end_x = GetWorldFromTick(end_timestamp_ns);
-    float width = end_x - start_x;
-    constexpr float kMinWidth = 9.0f;
-    // These intervals are very short, usually measurable in microseconds, but can have relatively
-    // large effects on the capture. Extend ranges in order to make them visible even when not
-    // zoomed very far in.
-    if (width < kMinWidth) {
-      const float center_x = (start_x + end_x) / 2;
-      start_x = center_x - kMinWidth / 2;
-      end_x = center_x + kMinWidth / 2;
-      width = end_x - start_x;
-    }
-
-    // Merge ranges that are now overlapping due to having been extended for visibility.
-    if (x_ranges.empty() || start_x > x_ranges.back().second) {
-      x_ranges.emplace_back(start_x, end_x);
-    } else {
-      x_ranges.back().second = end_x;
-    }
-  }
-
-  const float world_start_y = 0;
-  const float world_height = viewport_->GetWorldHeight();
-
-  // Actually draw the ranges.
-  for (const auto& [start_x, end_x] : x_ranges) {
-    const Vec2 pos{start_x, world_start_y};
-    const Vec2 size{end_x - start_x, world_height};
-    float z_value = GlCanvas::kZValueIncompleteDataOverlay;
-
-    std::unique_ptr<PickingUserData> user_data = nullptr;
-    // Show a tooltip when hovering.
-    if (picking_mode == PickingMode::kHover) {
-      // This overlay is placed in front of the tracks (with transparency), but when it comes to
-      // tooltips give it a much lower Z value, so that it's possible to "hover through" it.
-      z_value = GlCanvas::kZValueIncompleteDataOverlayPicking;
-      user_data = std::make_unique<PickingUserData>(nullptr, [](PickingId /*id*/) {
-        return std::string{
-            "Capture data is incomplete in this time range. Some information might be inaccurate."};
-      });
-    }
-
-    static const Color kIncompleteDataIntervalOrange{255, 128, 0, 32};
-    batcher.AddBox(Box{pos, size, z_value}, kIncompleteDataIntervalOrange, std::move(user_data));
-  }
-}
-
-void TimeGraph::SetThreadFilter(const std::string& filter) {
-  track_manager_->SetFilter(filter);
-  RequestUpdate();
 }
 
 void TimeGraph::SelectAndZoom(const TimerInfo* timer_info) {
@@ -832,13 +478,13 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
   if (jump_direction == JumpDirection::kPrevious) {
     switch (jump_scope) {
       case JumpScope::kSameDepth:
-        goal = FindPrevious(*from);
+        goal = track_container_->FindPrevious(*from);
         break;
       case JumpScope::kSameFunction:
-        goal = FindPreviousFunctionCall(function_id, current_time);
+        goal = track_container_->FindPreviousFunctionCall(function_id, current_time);
         break;
       case JumpScope::kSameThreadSameFunction:
-        goal = FindPreviousFunctionCall(function_id, current_time, thread_id);
+        goal = track_container_->FindPreviousFunctionCall(function_id, current_time, thread_id);
         break;
       default:
         // Other choices are not implemented.
@@ -848,83 +494,27 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
   if (jump_direction == JumpDirection::kNext) {
     switch (jump_scope) {
       case JumpScope::kSameDepth:
-        goal = FindNext(*from);
+        goal = track_container_->FindNext(*from);
         break;
       case JumpScope::kSameFunction:
-        goal = FindNextFunctionCall(function_id, current_time);
+        goal = track_container_->FindNextFunctionCall(function_id, current_time);
         break;
       case JumpScope::kSameThreadSameFunction:
-        goal = FindNextFunctionCall(function_id, current_time, thread_id);
+        goal = track_container_->FindNextFunctionCall(function_id, current_time, thread_id);
         break;
       default:
         ORBIT_UNREACHABLE();
     }
   }
   if (jump_direction == JumpDirection::kTop) {
-    goal = FindTop(*from);
+    goal = track_container_->FindTop(*from);
   }
   if (jump_direction == JumpDirection::kDown) {
-    goal = FindDown(*from);
+    goal = track_container_->FindDown(*from);
   }
   if (goal != nullptr) {
     SelectAndMakeVisible(goal);
   }
-}
-
-const TimerInfo* TimeGraph::FindPrevious(const TimerInfo& from) {
-  Track* track = track_manager_->GetOrCreateTrackFromTimerInfo(from);
-  if (track == nullptr) return nullptr;
-  return track->GetLeft(from);
-}
-
-const TimerInfo* TimeGraph::FindNext(const TimerInfo& from) {
-  Track* track = track_manager_->GetOrCreateTrackFromTimerInfo(from);
-  if (track == nullptr) return nullptr;
-  return track->GetRight(from);
-}
-
-const TimerInfo* TimeGraph::FindTop(const TimerInfo& from) {
-  Track* track = track_manager_->GetOrCreateTrackFromTimerInfo(from);
-  if (track == nullptr) return nullptr;
-  return track->GetUp(from);
-}
-
-const TimerInfo* TimeGraph::FindDown(const TimerInfo& from) {
-  Track* track = track_manager_->GetOrCreateTrackFromTimerInfo(from);
-  if (track == nullptr) return nullptr;
-  return track->GetDown(from);
-}
-
-std::pair<const TimerInfo*, const TimerInfo*> TimeGraph::GetMinMaxTimerInfoForFunction(
-    uint64_t function_id) const {
-  const TimerInfo* min_timer = nullptr;
-  const TimerInfo* max_timer = nullptr;
-  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
-  for (const TimerChain* chain : chains) {
-    for (const auto& block : *chain) {
-      for (size_t i = 0; i < block.size(); i++) {
-        const TimerInfo& timer_info = block[i];
-        if (timer_info.function_id() != function_id) continue;
-
-        uint64_t elapsed_nanos = timer_info.end() - timer_info.start();
-        if (min_timer == nullptr || elapsed_nanos < (min_timer->end() - min_timer->start())) {
-          min_timer = &timer_info;
-        }
-        if (max_timer == nullptr || elapsed_nanos > (max_timer->end() - max_timer->start())) {
-          max_timer = &timer_info;
-        }
-      }
-    }
-  }
-  return std::make_pair(min_timer, max_timer);
-}
-
-void TimeGraph::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-                       const DrawContext& draw_context) {
-  CaptureViewElement::DoDraw(batcher, text_renderer, draw_context);
-
-  DrawIncompleteDataIntervals(batcher, draw_context.picking_mode);
-  DrawOverlay(batcher, text_renderer, draw_context.picking_mode);
 }
 
 void TimeGraph::DrawAllElements(Batcher& batcher, TextRenderer& text_renderer,
@@ -966,34 +556,12 @@ bool TimeGraph::IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) c
   }
 }
 
-void TimeGraph::SetVerticalScrollingOffset(float value) {
-  float clamped_value = std::max(std::min(value, GetHeight() - viewport_->GetWorldHeight()), 0.f);
-  if (clamped_value == vertical_scrolling_offset_) return;
-
-  vertical_scrolling_offset_ = clamped_value;
-  RequestUpdate();
-}
-
-bool TimeGraph::HasFrameTrack(uint64_t function_id) const {
-  auto frame_tracks = track_manager_->GetFrameTracks();
-  return (std::find_if(frame_tracks.begin(), frame_tracks.end(), [&](auto frame_track) {
-            return frame_track->GetFunctionId() == function_id;
-          }) != frame_tracks.end());
-}
-
-void TimeGraph::RemoveFrameTrack(uint64_t function_id) {
-  track_manager_->RemoveFrameTrack(function_id);
-  RequestUpdate();
-}
-
 std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetAllChildren() const {
-  std::vector<Track*> all_tracks = track_manager_->GetAllTracks();
-  return {all_tracks.begin(), all_tracks.end()};
+  return {GetTrackContainer()};
 }
 
 std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetNonHiddenChildren() const {
-  std::vector<Track*> all_tracks = track_manager_->GetVisibleTracks();
-  return {all_tracks.begin(), all_tracks.end()};
+  return {GetTrackContainer()};
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> TimeGraph::CreateAccessibleInterface() {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -88,10 +88,24 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   [[nodiscard]] double GetTime(double ratio) const;
   void SelectAndMakeVisible(const orbit_client_protos::TimerInfo* timer_info);
+
   enum class JumpScope { kSameDepth, kSameThread, kSameFunction, kSameThreadSameFunction };
   enum class JumpDirection { kPrevious, kNext, kTop, kDown };
   void JumpToNeighborTimer(const orbit_client_protos::TimerInfo* from, JumpDirection jump_direction,
                            JumpScope jump_scope);
+  [[nodiscard]] const orbit_client_protos::TimerInfo* FindPreviousFunctionCall(
+      uint64_t function_address, uint64_t current_time,
+      std::optional<uint32_t> thread_id = std::nullopt) const;
+  [[nodiscard]] const orbit_client_protos::TimerInfo* FindNextFunctionCall(
+      uint64_t function_address, uint64_t current_time,
+      std::optional<uint32_t> thread_id = std::nullopt) const;
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllTimersForHookedFunction(
+      uint64_t function_address) const;
+  [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetAllThreadTrackTimerChains()
+      const;
+  [[nodiscard]] std::pair<const orbit_client_protos::TimerInfo*,
+                          const orbit_client_protos::TimerInfo*>
+  GetMinMaxTimerInfoForFunction(uint64_t function_id) const;
 
   void SelectAndZoom(const orbit_client_protos::TimerInfo* timer_info);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
@@ -171,6 +185,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   std::unique_ptr<orbit_gl::TrackContainer> track_container_;
 
   ManualInstrumentationManager* manual_instrumentation_manager_;
+  orbit_client_data::ThreadTrackDataProvider* thread_track_data_provider_ = nullptr;
   const orbit_client_data::CaptureData* capture_data_ = nullptr;
 
   OrbitApp* app_ = nullptr;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -5,21 +5,14 @@
 #ifndef ORBIT_GL_TIME_GRAPH_H_
 #define ORBIT_GL_TIME_GRAPH_H_
 
-#include <absl/container/flat_hash_map.h>
-
 #include <cstdint>
-#include <map>
 #include <memory>
-#include <optional>
-#include <string>
 #include <vector>
 
 #include "AccessibleInterfaceProvider.h"
 #include "Batcher.h"
-#include "CallstackThreadBar.h"
 #include "CaptureViewElement.h"
 #include "ClientData/CaptureData.h"
-#include "ClientData/TimerChain.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "CoreMath.h"
 #include "ManualInstrumentationManager.h"
@@ -28,10 +21,8 @@
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
 #include "TimelineInfoInterface.h"
-#include "Track.h"
-#include "TrackManager.h"
+#include "TrackContainer.h"
 #include "Viewport.h"
-#include "absl/container/flat_hash_map.h"
 
 class OrbitApp;
 
@@ -59,9 +50,13 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] const orbit_client_data::CaptureData* GetCaptureData() const {
     return capture_data_;
   }
-  [[nodiscard]] orbit_gl::TrackManager* GetTrackManager() { return track_manager_.get(); }
+  [[nodiscard]] orbit_gl::TrackContainer* GetTrackContainer() const {
+    return track_container_.get();
+  }
+  [[nodiscard]] orbit_gl::TrackManager* GetTrackManager() const {
+    return track_container_->GetTrackManager();
+  }
 
-  [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
   [[nodiscard]] float GetWorldFromTick(uint64_t time) const override;
   [[nodiscard]] float GetWorldFromUs(double micros) const override;
   [[nodiscard]] uint64_t GetTickFromWorld(float world_x) const override;
@@ -90,8 +85,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   void HorizontallyMoveIntoView(VisibilityType vis_type,
                                 const orbit_client_protos::TimerInfo& timer_info,
                                 double distance = 0.3);
-  void VerticallyMoveIntoView(const orbit_client_protos::TimerInfo& timer_info);
-  void VerticallyMoveIntoView(Track& track);
 
   [[nodiscard]] double GetTime(double ratio) const;
   void SelectAndMakeVisible(const orbit_client_protos::TimerInfo* timer_info);
@@ -99,20 +92,11 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   enum class JumpDirection { kPrevious, kNext, kTop, kDown };
   void JumpToNeighborTimer(const orbit_client_protos::TimerInfo* from, JumpDirection jump_direction,
                            JumpScope jump_scope);
-  [[nodiscard]] const orbit_client_protos::TimerInfo* FindPreviousFunctionCall(
-      uint64_t function_address, uint64_t current_time,
-      std::optional<uint32_t> thread_id = std::nullopt) const;
-  [[nodiscard]] const orbit_client_protos::TimerInfo* FindNextFunctionCall(
-      uint64_t function_address, uint64_t current_time,
-      std::optional<uint32_t> thread_id = std::nullopt) const;
-  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllTimersForHookedFunction(
-      uint64_t function_address) const;
 
   void SelectAndZoom(const orbit_client_protos::TimerInfo* timer_info);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
   [[nodiscard]] double GetCurrentTimeSpanUs() const;
   [[nodiscard]] bool IsRedrawNeeded() const { return update_primitives_requested_; }
-  void SetThreadFilter(const std::string& filter);
 
   [[nodiscard]] bool IsFullyVisible(uint64_t min, uint64_t max) const;
   [[nodiscard]] bool IsPartlyVisible(uint64_t min, uint64_t max) const;
@@ -120,25 +104,10 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   [[nodiscard]] TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
-  [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetAllThreadTrackTimerChains()
-      const;
-  [[nodiscard]] int GetNumVisiblePrimitives() const;
 
   void UpdateHorizontalScroll(float ratio);
   [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
   [[nodiscard]] TimeGraphLayout& GetLayout() { return layout_; }
-
-  [[nodiscard]] const orbit_client_protos::TimerInfo* FindPrevious(
-      const orbit_client_protos::TimerInfo& from);
-  [[nodiscard]] const orbit_client_protos::TimerInfo* FindNext(
-      const orbit_client_protos::TimerInfo& from);
-  [[nodiscard]] const orbit_client_protos::TimerInfo* FindTop(
-      const orbit_client_protos::TimerInfo& from);
-  [[nodiscard]] const orbit_client_protos::TimerInfo* FindDown(
-      const orbit_client_protos::TimerInfo& from);
-  [[nodiscard]] std::pair<const orbit_client_protos::TimerInfo*,
-                          const orbit_client_protos::TimerInfo*>
-  GetMinMaxTimerInfoForFunction(uint64_t function_id) const;
 
   // TODO(http://b/194777907): Move GetColor outside TimeGraph
   [[nodiscard]] static Color GetColor(uint32_t id) {
@@ -161,23 +130,8 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
     return GetColor(static_cast<uint32_t>(tid));
   }
 
-  void SetIteratorOverlayData(
-      const absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*>&
-          iterator_timer_info,
-      const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id) {
-    iterator_timer_info_ = iterator_timer_info;
-    iterator_id_to_function_id_ = iterator_id_to_function_id;
-    RequestUpdate();
-  }
-
-  [[nodiscard]] float GetVerticalScrollingOffset() const { return vertical_scrolling_offset_; }
-  void SetVerticalScrollingOffset(float value);
-
   [[nodiscard]] uint64_t GetCaptureMin() const { return capture_min_timestamp_; }
   [[nodiscard]] uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
-
-  [[nodiscard]] bool HasFrameTrack(uint64_t function_id) const;
-  void RemoveFrameTrack(uint64_t function_id);
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetNonHiddenChildren() const override;
@@ -189,10 +143,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
  protected:
   void PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode);
   void DoUpdateLayout() override;
-  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
-              const DrawContext& draw_context) override;
-
-  void UpdateTracksPosition();
 
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
@@ -202,18 +152,8 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   void ProcessPageFaultsTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
 
  private:
-  void DrawOverlay(Batcher& batcher, TextRenderer& text_renderer, PickingMode picking_mode);
-  void DrawIteratorBox(Batcher& batcher, TextRenderer& text_renderer, Vec2 pos, Vec2 size,
-                       const Color& color, const std::string& label, const std::string& time,
-                       float text_box_y);
-  void DrawIncompleteDataIntervals(Batcher& batcher, PickingMode picking_mode);
-
   AccessibleInterfaceProvider* accessible_parent_;
   TextRenderer text_renderer_static_;
-
-  // First member is id.
-  absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*> iterator_timer_info_;
-  absl::flat_hash_map<uint64_t, uint64_t> iterator_id_to_function_id_;
 
   double ref_time_us_ = 0;
   double min_time_us_ = 0;
@@ -221,7 +161,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   uint64_t capture_min_timestamp_ = std::numeric_limits<uint64_t>::max();
   uint64_t capture_max_timestamp_ = 0;
   double time_window_us_ = 0;
-  float vertical_scrolling_offset_ = 0;
 
   TimeGraphLayout layout_;
 
@@ -229,11 +168,10 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   Batcher batcher_;
 
-  std::unique_ptr<orbit_gl::TrackManager> track_manager_;
+  std::unique_ptr<orbit_gl::TrackContainer> track_container_;
 
   ManualInstrumentationManager* manual_instrumentation_manager_;
   const orbit_client_data::CaptureData* capture_data_ = nullptr;
-  orbit_client_data::ThreadTrackDataProvider* thread_track_data_provider_ = nullptr;
 
   OrbitApp* app_ = nullptr;
 };

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -50,11 +50,11 @@ TrackContainer::TrackContainer(CaptureViewElement* parent, TimelineInfoInterface
                                Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
                                CaptureData* capture_data)
     : CaptureViewElement(parent, viewport, &layout_),
+      track_manager_{
+          std::make_unique<TrackManager>(this, timeline_info, viewport, layout, app, capture_data)},
       capture_data_{capture_data},
       thread_track_data_provider_(capture_data->GetThreadTrackDataProvider()),
       timeline_info_(timeline_info) {
-  track_manager_ =
-      std::make_unique<TrackManager>(this, timeline_info, viewport, layout, app, capture_data);
   track_manager_->GetOrCreateSchedulerTrack();
 }
 
@@ -85,7 +85,7 @@ void TrackContainer::VerticallyMoveIntoView(const TimerInfo& timer_info) {
 }
 
 // Move vertically the view to make a Track fully visible.
-void TrackContainer::VerticallyMoveIntoView(Track& track) {
+void TrackContainer::VerticallyMoveIntoView(const Track& track) {
   float pos = track.GetPos()[1] + vertical_scrolling_offset_;
   float height = track.GetHeight();
 
@@ -235,9 +235,10 @@ void TrackContainer::DrawIteratorBox(Batcher& batcher, TextRenderer& text_render
   const Color kBlack(0, 0, 0, 255);
   float text_width = text_renderer.AddTextTrailingCharsPrioritized(
       text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueTextUi,
-      {GetLayout().GetFontSize(), kBlack, max_size}, time.length());
+      {layout_.GetFontSize(), kBlack, max_size}, time.length());
 
-  Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), GetTextBoxHeight());
+  float box_height = layout_.GetTextBoxHeight();
+  Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), box_height);
   Vec2 white_box_position(pos[0], text_box_y);
 
   Box white_box(white_box_position, white_box_size, GlCanvas::kZValueOverlayTextBackground);
@@ -245,8 +246,8 @@ void TrackContainer::DrawIteratorBox(Batcher& batcher, TextRenderer& text_render
   const Color kWhite(255, 255, 255, 255);
   batcher.AddBox(white_box, kWhite);
 
-  Vec2 line_from(pos[0] + white_box_size[0], white_box_position[1] + GetTextBoxHeight() / 2.f);
-  Vec2 line_to(pos[0] + size[0], white_box_position[1] + GetTextBoxHeight() / 2.f);
+  Vec2 line_from(pos[0] + white_box_size[0], white_box_position[1] + box_height / 2.f);
+  Vec2 line_to(pos[0] + size[0], white_box_position[1] + box_height / 2.f);
   batcher.AddLine(line_from, line_to, GlCanvas::kZValueOverlay, Color(255, 255, 255, 255));
 }
 

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -373,6 +373,14 @@ const TimerInfo* TrackContainer::FindDown(const TimerInfo& from) {
   return track->GetDown(from);
 }
 
+void TrackContainer::SetIteratorOverlayData(
+    const absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*>& iterator_timer_info,
+    const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id) {
+  iterator_timer_info_ = iterator_timer_info;
+  iterator_id_to_function_id_ = iterator_id_to_function_id;
+  RequestUpdate();
+}
+
 void TrackContainer::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
                             const DrawContext& draw_context) {
   CaptureViewElement::DoDraw(batcher, text_renderer, draw_context);

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "TrackContainer.h"
+
 #include <GteVector.h>
 #include <absl/container/flat_hash_map.h>
 #include <absl/flags/flag.h>
@@ -10,12 +12,10 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <limits>
 #include <utility>
 
 #include "AccessibleTrackContainer.h"
 #include "App.h"
-#include "CGroupAndProcessMemoryTrack.h"
 #include "CaptureClient/CaptureEventProcessor.h"
 #include "ClientData/FunctionUtils.h"
 #include "ClientFlags/ClientFlags.h"
@@ -27,10 +27,7 @@
 #include "Introspection/Introspection.h"
 #include "OrbitBase/Append.h"
 #include "OrbitBase/Logging.h"
-#include "PageFaultsTrack.h"
 #include "PickingManager.h"
-#include "SchedulerTrack.h"
-#include "SystemMemoryTrack.h"
 #include "TrackManager.h"
 #include "VariableTrack.h"
 

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -1,0 +1,515 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <GteVector.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/flags/flag.h>
+#include <absl/strings/str_format.h>
+#include <absl/time/time.h>
+#include <stddef.h>
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include "AccessibleTrackContainer.h"
+#include "App.h"
+#include "CGroupAndProcessMemoryTrack.h"
+#include "CaptureClient/CaptureEventProcessor.h"
+#include "ClientData/FunctionUtils.h"
+#include "ClientFlags/ClientFlags.h"
+#include "DisplayFormats/DisplayFormats.h"
+#include "Geometry.h"
+#include "GlCanvas.h"
+#include "GlUtils.h"
+#include "GrpcProtos/Constants.h"
+#include "Introspection/Introspection.h"
+#include "OrbitBase/Append.h"
+#include "OrbitBase/Logging.h"
+#include "PageFaultsTrack.h"
+#include "PickingManager.h"
+#include "SchedulerTrack.h"
+#include "SystemMemoryTrack.h"
+#include "TrackManager.h"
+#include "VariableTrack.h"
+
+namespace orbit_gl {
+
+using orbit_capture_client::CaptureEventProcessor;
+
+using orbit_client_data::CaptureData;
+using orbit_client_data::TimerChain;
+using orbit_client_protos::ApiTrackValue;
+using orbit_client_protos::CallstackEvent;
+using orbit_client_protos::TimerInfo;
+
+using orbit_grpc_protos::InstrumentedFunction;
+
+TrackContainer::TrackContainer(CaptureViewElement* parent, TimelineInfoInterface* timeline_info,
+                               Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
+                               CaptureData* capture_data)
+    : CaptureViewElement(parent, viewport, &layout_),
+      capture_data_{capture_data},
+      thread_track_data_provider_(capture_data->GetThreadTrackDataProvider()),
+      timeline_info_(timeline_info) {
+  track_manager_ =
+      std::make_unique<TrackManager>(this, timeline_info, viewport, layout, app, capture_data);
+  track_manager_->GetOrCreateSchedulerTrack();
+}
+
+float TrackContainer::GetHeight() const {
+  // Top and Bottom Margin. TODO: Margins should be treated in a different way (http://b/192070555).
+  float total_height = layout_.GetSchedulerTrackOffset() + layout_.GetBottomMargin();
+
+  // Track height including space between them
+  for (auto& track : GetNonHiddenChildren()) {
+    total_height += (track->GetHeight() + layout_.GetSpaceBetweenTracks());
+  }
+  return total_height;
+}
+
+void TrackContainer::VerticalZoom(float real_ratio, float mouse_screen_y_position) {
+  // Adjust the scrolling offset such that the point under the mouse stays the same if possible.
+  // For this, calculate the "global" position (including scaling and scrolling offset) of the point
+  // underneath the mouse with the old and new scaling, and adjust the scrolling to have them match.
+  const float mouse_old_y_world_position = mouse_screen_y_position + vertical_scrolling_offset_;
+  // Everything scales.
+  const float mouse_new_y_world_position = mouse_old_y_world_position * real_ratio;
+
+  SetVerticalScrollingOffset(mouse_new_y_world_position - mouse_screen_y_position);
+}
+
+void TrackContainer::VerticallyMoveIntoView(const TimerInfo& timer_info) {
+  VerticallyMoveIntoView(*track_manager_->GetOrCreateTrackFromTimerInfo(timer_info));
+}
+
+// Move vertically the view to make a Track fully visible.
+void TrackContainer::VerticallyMoveIntoView(Track& track) {
+  float pos = track.GetPos()[1] + vertical_scrolling_offset_;
+  float height = track.GetHeight();
+
+  float max_vertical_scrolling_offset = pos;
+  float min_vertical_scrolling_offset =
+      pos + height - viewport_->GetWorldHeight() + layout_.GetBottomMargin();
+  SetVerticalScrollingOffset(std::clamp(vertical_scrolling_offset_, min_vertical_scrolling_offset,
+                                        max_vertical_scrolling_offset));
+}
+
+std::vector<const TimerChain*> TrackContainer::GetAllThreadTrackTimerChains() const {
+  return thread_track_data_provider_->GetAllThreadTimerChains();
+}
+
+int TrackContainer::GetNumVisiblePrimitives() const {
+  int num_visible_primitives = 0;
+  for (auto track : track_manager_->GetAllTracks()) {
+    num_visible_primitives += track->GetVisiblePrimitiveCount();
+  }
+  return num_visible_primitives;
+}
+
+const TimerInfo* TrackContainer::FindPreviousFunctionCall(uint64_t function_address,
+                                                          uint64_t current_time,
+                                                          std::optional<uint32_t> thread_id) const {
+  const TimerInfo* previous_timer = nullptr;
+  uint64_t goal_time = std::numeric_limits<uint64_t>::lowest();
+  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
+  for (const TimerChain* chain : chains) {
+    for (const auto& block : *chain) {
+      if (!block.Intersects(goal_time, current_time)) continue;
+      for (uint64_t i = 0; i < block.size(); i++) {
+        const TimerInfo& timer_info = block[i];
+        auto timer_end_time = timer_info.end();
+        if ((timer_info.function_id() == function_address) &&
+            (!thread_id || thread_id.value() == timer_info.thread_id()) &&
+            (timer_end_time < current_time) && (goal_time < timer_end_time)) {
+          previous_timer = &timer_info;
+          goal_time = timer_end_time;
+        }
+      }
+    }
+  }
+  return previous_timer;
+}
+
+const TimerInfo* TrackContainer::FindNextFunctionCall(uint64_t function_address,
+                                                      uint64_t current_time,
+                                                      std::optional<uint32_t> thread_id) const {
+  const TimerInfo* next_timer = nullptr;
+  uint64_t goal_time = std::numeric_limits<uint64_t>::max();
+  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
+  for (const TimerChain* chain : chains) {
+    ORBIT_CHECK(chain != nullptr);
+    for (const auto& block : *chain) {
+      if (!block.Intersects(current_time, goal_time)) continue;
+      for (uint64_t i = 0; i < block.size(); i++) {
+        const TimerInfo& timer_info = block[i];
+        auto timer_end_time = timer_info.end();
+        if ((timer_info.function_id() == function_address) &&
+            (!thread_id || thread_id.value() == timer_info.thread_id()) &&
+            (timer_end_time > current_time) && (goal_time > timer_end_time)) {
+          next_timer = &timer_info;
+          goal_time = timer_end_time;
+        }
+      }
+    }
+  }
+  return next_timer;
+}
+
+std::vector<const TimerInfo*> TrackContainer::GetAllTimersForHookedFunction(
+    uint64_t function_address) const {
+  std::vector<const TimerInfo*> timers;
+  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
+  for (const TimerChain* chain : chains) {
+    ORBIT_CHECK(chain != nullptr);
+    for (const auto& block : *chain) {
+      for (uint64_t i = 0; i < block.size(); i++) {
+        const TimerInfo& timer = block[i];
+        if (timer.function_id() == function_address) timers.push_back(&timer);
+      }
+    }
+  }
+  return timers;
+}
+
+void TrackContainer::DoUpdateLayout() {
+  track_manager_->UpdateTrackListForRendering();
+  UpdateTracksPosition();
+
+  // This is called to make sure the current scrolling value is correctly clamped
+  // in case any changes in track visibility occured before
+  SetVerticalScrollingOffset(vertical_scrolling_offset_);
+}
+
+void TrackContainer::UpdateTracksPosition() {
+  const float track_pos_x = GetPos()[0];
+
+  float current_y = layout_.GetSchedulerTrackOffset() - vertical_scrolling_offset_;
+
+  // Track height including space between them
+  for (auto& track : track_manager_->GetVisibleTracks()) {
+    if (!track->IsMoving()) {
+      track->SetPos(track_pos_x, current_y);
+    }
+    track->SetWidth(GetWidth());
+    current_y += (track->GetHeight() + layout_.GetSpaceBetweenTracks());
+  }
+}
+
+namespace {
+
+[[nodiscard]] std::string GetLabelBetweenIterators(const InstrumentedFunction& function_a,
+                                                   const InstrumentedFunction& function_b) {
+  const std::string& function_from = function_a.function_name();
+  const std::string& function_to = function_b.function_name();
+  return absl::StrFormat("%s to %s", function_from, function_to);
+}
+
+std::string GetTimeString(const TimerInfo& timer_a, const TimerInfo& timer_b) {
+  absl::Duration duration = TicksToDuration(timer_a.start(), timer_b.start());
+
+  return orbit_display_formats::GetDisplayTime(duration);
+}
+
+[[nodiscard]] Color GetIteratorBoxColor(uint64_t index) {
+  constexpr uint64_t kNumColors = 2;
+  const Color kLightBlueGray = Color(177, 203, 250, 60);
+  const Color kMidBlueGray = Color(81, 102, 157, 60);
+  Color colors[kNumColors] = {kLightBlueGray, kMidBlueGray};
+  return colors[index % kNumColors];
+}
+
+}  // namespace
+
+void TrackContainer::DrawIteratorBox(Batcher& batcher, TextRenderer& text_renderer, Vec2 pos,
+                                     Vec2 size, const Color& color, const std::string& label,
+                                     const std::string& time, float text_box_y) {
+  Box box(pos, size, GlCanvas::kZValueOverlay);
+  batcher.AddBox(box, color);
+
+  std::string text = absl::StrFormat("%s: %s", label, time);
+
+  float max_size = size[0];
+
+  const Color kBlack(0, 0, 0, 255);
+  float text_width = text_renderer.AddTextTrailingCharsPrioritized(
+      text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueTextUi,
+      {GetLayout().GetFontSize(), kBlack, max_size}, time.length());
+
+  Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), GetTextBoxHeight());
+  Vec2 white_box_position(pos[0], text_box_y);
+
+  Box white_box(white_box_position, white_box_size, GlCanvas::kZValueOverlayTextBackground);
+
+  const Color kWhite(255, 255, 255, 255);
+  batcher.AddBox(white_box, kWhite);
+
+  Vec2 line_from(pos[0] + white_box_size[0], white_box_position[1] + GetTextBoxHeight() / 2.f);
+  Vec2 line_to(pos[0] + size[0], white_box_position[1] + GetTextBoxHeight() / 2.f);
+  batcher.AddLine(line_from, line_to, GlCanvas::kZValueOverlay, Color(255, 255, 255, 255));
+}
+
+void TrackContainer::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
+                                 PickingMode picking_mode) {
+  if (picking_mode != PickingMode::kNone || iterator_timer_info_.empty()) {
+    return;
+  }
+
+  std::vector<std::pair<uint64_t, const TimerInfo*>> timers(iterator_timer_info_.size());
+  std::copy(iterator_timer_info_.begin(), iterator_timer_info_.end(), timers.begin());
+
+  // Sort timers by start time.
+  std::sort(timers.begin(), timers.end(),
+            [](const std::pair<uint64_t, const TimerInfo*>& timer_a,
+               const std::pair<uint64_t, const TimerInfo*>& timer_b) -> bool {
+              return timer_a.second->start() < timer_b.second->start();
+            });
+
+  // We will need the world x coordinates for the timers multiple times, so
+  // we avoid recomputing them and just cache them here.
+  std::vector<float> x_coords;
+  x_coords.reserve(timers.size());
+
+  float world_start_x = 0;
+  float world_width = GetWidth();
+
+  float world_start_y = 0;
+  float world_height = viewport_->GetWorldHeight();
+
+  double inv_time_window = 1.0 / timeline_info_->GetTimeWindowUs();
+
+  // Draw lines for iterators.
+  for (const auto& box : timers) {
+    const TimerInfo* timer_info = box.second;
+
+    double start_us = timeline_info_->GetUsFromTick(timer_info->start());
+    double normalized_start = start_us * inv_time_window;
+    auto world_timer_x = static_cast<float>(world_start_x + normalized_start * world_width);
+
+    Vec2 pos(world_timer_x, world_start_y);
+    x_coords.push_back(pos[0]);
+
+    batcher.AddVerticalLine(pos, world_height, GlCanvas::kZValueOverlay,
+                            TimeGraph::GetThreadColor(timer_info->thread_id()));
+  }
+
+  // Draw timers with timings between iterators.
+  for (size_t k = 1; k < timers.size(); ++k) {
+    Vec2 pos(x_coords[k - 1], world_start_y);
+    float size_x = x_coords[k] - pos[0];
+    Vec2 size(size_x, world_height);
+    Color color = GetIteratorBoxColor(k - 1);
+
+    uint64_t id_a = timers[k - 1].first;
+    uint64_t id_b = timers[k].first;
+    ORBIT_CHECK(iterator_id_to_function_id_.find(id_a) != iterator_id_to_function_id_.end());
+    ORBIT_CHECK(iterator_id_to_function_id_.find(id_b) != iterator_id_to_function_id_.end());
+    uint64_t function_a_id = iterator_id_to_function_id_.at(id_a);
+    uint64_t function_b_id = iterator_id_to_function_id_.at(id_b);
+    const InstrumentedFunction* function_a =
+        capture_data_->GetInstrumentedFunctionById(function_a_id);
+    const InstrumentedFunction* function_b =
+        capture_data_->GetInstrumentedFunctionById(function_b_id);
+    ORBIT_CHECK(function_a != nullptr);
+    ORBIT_CHECK(function_b != nullptr);
+    const std::string& label = GetLabelBetweenIterators(*function_a, *function_b);
+    const std::string& time = GetTimeString(*timers[k - 1].second, *timers[k].second);
+
+    // Distance from the bottom where we don't want to draw.
+    float bottom_margin = layout_.GetBottomMargin();
+
+    // The height of text is chosen such that the text of the last box drawn is
+    // at pos[1] + bottom_margin (lowest possible position) and the height of
+    // the box showing the overall time (see below) is at pos[1] + (world_height
+    // / 2.f), corresponding to the case k == 0 in the formula for 'text_y'.
+    float height_per_text = ((world_height / 2.f) - bottom_margin) /
+                            static_cast<float>(iterator_timer_info_.size() - 1);
+    float text_y = pos[1] + (world_height / 2.f) + static_cast<float>(k) * height_per_text -
+                   layout_.GetTextBoxHeight();
+
+    DrawIteratorBox(batcher, text_renderer, pos, size, color, label, time, text_y);
+  }
+
+  // When we have at least 3 boxes, we also draw the total time from the first
+  // to the last iterator.
+  if (timers.size() > 2) {
+    size_t last_index = timers.size() - 1;
+
+    Vec2 pos(x_coords[0], world_start_y);
+    float size_x = x_coords[last_index] - pos[0];
+    Vec2 size(size_x, world_height);
+
+    std::string time = GetTimeString(*timers[0].second, *timers[last_index].second);
+    std::string label("Total");
+
+    float text_y = pos[1] + (world_height / 2.f);
+
+    // We do not want the overall box to add any color, so we just set alpha to
+    // 0.
+    const Color kColorBlackTransparent(0, 0, 0, 0);
+    DrawIteratorBox(batcher, text_renderer, pos, size, kColorBlackTransparent, label, time, text_y);
+  }
+}
+
+void TrackContainer::DrawIncompleteDataIntervals(Batcher& batcher, PickingMode picking_mode) {
+  if (picking_mode == PickingMode::kClick) return;  // Allow to click through.
+
+  auto min_visible_timestamp_ns = timeline_info_->GetNsSinceStart(
+      static_cast<uint64_t>(timeline_info_->GetMinTimeUs() * 1000L));
+  auto max_visible_timestamp_ns = timeline_info_->GetNsSinceStart(
+      static_cast<uint64_t>(timeline_info_->GetMaxTimeUs() * 1000L));
+
+  std::vector<std::pair<float, float>> x_ranges;
+  for (auto it = capture_data_->incomplete_data_intervals().LowerBound(min_visible_timestamp_ns);
+       it != capture_data_->incomplete_data_intervals().end() &&
+       it->start_inclusive() <= max_visible_timestamp_ns;
+       ++it) {
+    uint64_t start_timestamp_ns = it->start_inclusive();
+    uint64_t end_timestamp_ns = it->end_exclusive();
+
+    float start_x = timeline_info_->GetWorldFromTick(start_timestamp_ns);
+    float end_x = timeline_info_->GetWorldFromTick(end_timestamp_ns);
+    float width = end_x - start_x;
+    constexpr float kMinWidth = 9.0f;
+    // These intervals are very short, usually measurable in microseconds, but can have relatively
+    // large effects on the capture. Extend ranges in order to make them visible even when not
+    // zoomed very far in.
+    if (width < kMinWidth) {
+      const float center_x = (start_x + end_x) / 2;
+      start_x = center_x - kMinWidth / 2;
+      end_x = center_x + kMinWidth / 2;
+      width = end_x - start_x;
+    }
+
+    // Merge ranges that are now overlapping due to having been extended for visibility.
+    if (x_ranges.empty() || start_x > x_ranges.back().second) {
+      x_ranges.emplace_back(start_x, end_x);
+    } else {
+      x_ranges.back().second = end_x;
+    }
+  }
+
+  const float world_start_y = 0;
+  const float world_height = viewport_->GetWorldHeight();
+
+  // Actually draw the ranges.
+  for (const auto& [start_x, end_x] : x_ranges) {
+    const Vec2 pos{start_x, world_start_y};
+    const Vec2 size{end_x - start_x, world_height};
+    float z_value = GlCanvas::kZValueIncompleteDataOverlay;
+
+    std::unique_ptr<PickingUserData> user_data = nullptr;
+    // Show a tooltip when hovering.
+    if (picking_mode == PickingMode::kHover) {
+      // This overlay is placed in front of the tracks (with transparency), but when it comes to
+      // tooltips give it a much lower Z value, so that it's possible to "hover through" it.
+      z_value = GlCanvas::kZValueIncompleteDataOverlayPicking;
+      user_data = std::make_unique<PickingUserData>(nullptr, [](PickingId /*id*/) {
+        return std::string{
+            "Capture data is incomplete in this time range. Some information might be inaccurate."};
+      });
+    }
+
+    static const Color kIncompleteDataIntervalOrange{255, 128, 0, 32};
+    batcher.AddBox(Box{pos, size, z_value}, kIncompleteDataIntervalOrange, std::move(user_data));
+  }
+}
+
+void TrackContainer::SetThreadFilter(const std::string& filter) {
+  track_manager_->SetFilter(filter);
+  RequestUpdate();
+}
+
+const TimerInfo* TrackContainer::FindPrevious(const TimerInfo& from) {
+  Track* track = track_manager_->GetOrCreateTrackFromTimerInfo(from);
+  if (track == nullptr) return nullptr;
+  return track->GetLeft(from);
+}
+
+const TimerInfo* TrackContainer::FindNext(const TimerInfo& from) {
+  Track* track = track_manager_->GetOrCreateTrackFromTimerInfo(from);
+  if (track == nullptr) return nullptr;
+  return track->GetRight(from);
+}
+
+const TimerInfo* TrackContainer::FindTop(const TimerInfo& from) {
+  Track* track = track_manager_->GetOrCreateTrackFromTimerInfo(from);
+  if (track == nullptr) return nullptr;
+  return track->GetUp(from);
+}
+
+const TimerInfo* TrackContainer::FindDown(const TimerInfo& from) {
+  Track* track = track_manager_->GetOrCreateTrackFromTimerInfo(from);
+  if (track == nullptr) return nullptr;
+  return track->GetDown(from);
+}
+
+std::pair<const TimerInfo*, const TimerInfo*> TrackContainer::GetMinMaxTimerInfoForFunction(
+    uint64_t function_id) const {
+  const TimerInfo* min_timer = nullptr;
+  const TimerInfo* max_timer = nullptr;
+  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
+  for (const TimerChain* chain : chains) {
+    for (const auto& block : *chain) {
+      for (size_t i = 0; i < block.size(); i++) {
+        const TimerInfo& timer_info = block[i];
+        if (timer_info.function_id() != function_id) continue;
+
+        uint64_t elapsed_nanos = timer_info.end() - timer_info.start();
+        if (min_timer == nullptr || elapsed_nanos < (min_timer->end() - min_timer->start())) {
+          min_timer = &timer_info;
+        }
+        if (max_timer == nullptr || elapsed_nanos > (max_timer->end() - max_timer->start())) {
+          max_timer = &timer_info;
+        }
+      }
+    }
+  }
+  return std::make_pair(min_timer, max_timer);
+}
+
+void TrackContainer::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+                            const DrawContext& draw_context) {
+  CaptureViewElement::DoDraw(batcher, text_renderer, draw_context);
+
+  DrawIncompleteDataIntervals(batcher, draw_context.picking_mode);
+  DrawOverlay(batcher, text_renderer, draw_context.picking_mode);
+}
+
+void TrackContainer::SetVerticalScrollingOffset(float value) {
+  float clamped_value = std::max(std::min(value, GetHeight() - viewport_->GetWorldHeight()), 0.f);
+  if (clamped_value == vertical_scrolling_offset_) return;
+
+  vertical_scrolling_offset_ = clamped_value;
+  RequestUpdate();
+}
+
+bool TrackContainer::HasFrameTrack(uint64_t function_id) const {
+  auto frame_tracks = track_manager_->GetFrameTracks();
+  return (std::find_if(frame_tracks.begin(), frame_tracks.end(), [&](auto frame_track) {
+            return frame_track->GetFunctionId() == function_id;
+          }) != frame_tracks.end());
+}
+
+void TrackContainer::RemoveFrameTrack(uint64_t function_id) {
+  track_manager_->RemoveFrameTrack(function_id);
+  RequestUpdate();
+}
+
+std::vector<CaptureViewElement*> TrackContainer::GetAllChildren() const {
+  std::vector<Track*> all_tracks = track_manager_->GetAllTracks();
+  return {all_tracks.begin(), all_tracks.end()};
+}
+
+std::vector<CaptureViewElement*> TrackContainer::GetNonHiddenChildren() const {
+  std::vector<Track*> all_tracks = track_manager_->GetVisibleTracks();
+  return {all_tracks.begin(), all_tracks.end()};
+}
+
+std::unique_ptr<orbit_accessibility::AccessibleInterface>
+TrackContainer::CreateAccessibleInterface() {
+  return std::make_unique<AccessibleTrackContainer>(this);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -32,27 +32,13 @@ class TrackContainer final : public CaptureViewElement {
   [[nodiscard]] float GetHeight() const override;
 
   [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
-  [[nodiscard]] orbit_client_data::ThreadTrackDataProvider* GetCaptureDataProvider() {
-    return thread_track_data_provider_;
-  }
 
   void VerticalZoom(float real_ratio, float mouse_screen_y_position);
   void VerticallyMoveIntoView(const orbit_client_protos::TimerInfo& timer_info);
   void VerticallyMoveIntoView(const Track& track);
 
-  [[nodiscard]] const orbit_client_protos::TimerInfo* FindPreviousFunctionCall(
-      uint64_t function_address, uint64_t current_time,
-      std::optional<uint32_t> thread_id = std::nullopt) const;
-  [[nodiscard]] const orbit_client_protos::TimerInfo* FindNextFunctionCall(
-      uint64_t function_address, uint64_t current_time,
-      std::optional<uint32_t> thread_id = std::nullopt) const;
-  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllTimersForHookedFunction(
-      uint64_t function_address) const;
-
   void SetThreadFilter(const std::string& filter);
 
-  [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetAllThreadTrackTimerChains()
-      const;
   [[nodiscard]] int GetNumVisiblePrimitives() const;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindPrevious(
@@ -63,9 +49,6 @@ class TrackContainer final : public CaptureViewElement {
       const orbit_client_protos::TimerInfo& from);
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindDown(
       const orbit_client_protos::TimerInfo& from);
-  [[nodiscard]] std::pair<const orbit_client_protos::TimerInfo*,
-                          const orbit_client_protos::TimerInfo*>
-  GetMinMaxTimerInfoForFunction(uint64_t function_id) const;
 
   void SetIteratorOverlayData(
       const absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*>&
@@ -111,7 +94,6 @@ class TrackContainer final : public CaptureViewElement {
   std::unique_ptr<TrackManager> track_manager_;
 
   const orbit_client_data::CaptureData* capture_data_ = nullptr;
-  orbit_client_data::ThreadTrackDataProvider* thread_track_data_provider_ = nullptr;
 
   const TimelineInfoInterface* timeline_info_;
 };

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -1,0 +1,129 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TRACK_CONTAINER_H_
+#define ORBIT_GL_TRACK_CONTAINER_H_
+
+#include <ClientData/CaptureData.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "CaptureViewElement.h"
+#include "ClientData/CaptureData.h"
+#include "ClientData/TimerChain.h"
+#include "TimeGraphLayout.h"
+#include "Track.h"
+#include "TrackManager.h"
+#include "Viewport.h"
+#include "absl/container/flat_hash_map.h"
+
+namespace orbit_gl {
+
+// Represent the space where Tracks will be drawn.
+class TrackContainer final : public CaptureViewElement {
+ public:
+  explicit TrackContainer(CaptureViewElement* parent, TimelineInfoInterface* timeline_info,
+                          Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
+                          orbit_client_data::CaptureData* capture_data);
+
+  [[nodiscard]] float GetHeight() const override;
+
+  [[nodiscard]] const orbit_client_data::CaptureData* GetCaptureData() const {
+    return capture_data_;
+  }
+  [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
+  [[nodiscard]] orbit_client_data::ThreadTrackDataProvider* GetCaptureDataProvider() {
+    return thread_track_data_provider_;
+  }
+
+  [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
+
+  void VerticalZoom(float real_ratio, float mouse_screen_y_position);
+  void VerticallyMoveIntoView(const orbit_client_protos::TimerInfo& timer_info);
+  void VerticallyMoveIntoView(Track& track);
+
+  [[nodiscard]] const orbit_client_protos::TimerInfo* FindPreviousFunctionCall(
+      uint64_t function_address, uint64_t current_time,
+      std::optional<uint32_t> thread_id = std::nullopt) const;
+  [[nodiscard]] const orbit_client_protos::TimerInfo* FindNextFunctionCall(
+      uint64_t function_address, uint64_t current_time,
+      std::optional<uint32_t> thread_id = std::nullopt) const;
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllTimersForHookedFunction(
+      uint64_t function_address) const;
+
+  void SetThreadFilter(const std::string& filter);
+
+  [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetAllThreadTrackTimerChains()
+      const;
+  [[nodiscard]] int GetNumVisiblePrimitives() const;
+
+  [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
+  [[nodiscard]] TimeGraphLayout& GetLayout() { return layout_; }
+
+  [[nodiscard]] const orbit_client_protos::TimerInfo* FindPrevious(
+      const orbit_client_protos::TimerInfo& from);
+  [[nodiscard]] const orbit_client_protos::TimerInfo* FindNext(
+      const orbit_client_protos::TimerInfo& from);
+  [[nodiscard]] const orbit_client_protos::TimerInfo* FindTop(
+      const orbit_client_protos::TimerInfo& from);
+  [[nodiscard]] const orbit_client_protos::TimerInfo* FindDown(
+      const orbit_client_protos::TimerInfo& from);
+  [[nodiscard]] std::pair<const orbit_client_protos::TimerInfo*,
+                          const orbit_client_protos::TimerInfo*>
+  GetMinMaxTimerInfoForFunction(uint64_t function_id) const;
+
+  void SetIteratorOverlayData(
+      const absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*>&
+          iterator_timer_info,
+      const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id) {
+    iterator_timer_info_ = iterator_timer_info;
+    iterator_id_to_function_id_ = iterator_id_to_function_id;
+    RequestUpdate();
+  }
+  [[nodiscard]] float GetVerticalScrollingOffset() const { return vertical_scrolling_offset_; }
+  void SetVerticalScrollingOffset(float value);
+
+  [[nodiscard]] bool HasFrameTrack(uint64_t function_id) const;
+  void RemoveFrameTrack(uint64_t function_id);
+
+  [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
+  [[nodiscard]] std::vector<CaptureViewElement*> GetNonHiddenChildren() const override;
+
+ protected:
+  void DoUpdateLayout() override;
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+
+  void UpdateTracksPosition();
+
+  [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
+  CreateAccessibleInterface() override;
+
+ private:
+  void DrawOverlay(Batcher& batcher, TextRenderer& text_renderer, PickingMode picking_mode);
+  void DrawIteratorBox(Batcher& batcher, TextRenderer& text_renderer, Vec2 pos, Vec2 size,
+                       const Color& color, const std::string& label, const std::string& time,
+                       float text_box_y);
+  void DrawIncompleteDataIntervals(Batcher& batcher, PickingMode picking_mode);
+
+  // First member is id.
+  absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*> iterator_timer_info_;
+  absl::flat_hash_map<uint64_t, uint64_t> iterator_id_to_function_id_;
+
+  float vertical_scrolling_offset_ = 0;
+
+  TimeGraphLayout layout_;
+  std::unique_ptr<TrackManager> track_manager_;
+
+  const orbit_client_data::CaptureData* capture_data_ = nullptr;
+  orbit_client_data::ThreadTrackDataProvider* thread_track_data_provider_ = nullptr;
+
+  const TimelineInfoInterface* timeline_info_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_TRACK_CONTAINER_H_

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -31,19 +31,14 @@ class TrackContainer final : public CaptureViewElement {
 
   [[nodiscard]] float GetHeight() const override;
 
-  [[nodiscard]] const orbit_client_data::CaptureData* GetCaptureData() const {
-    return capture_data_;
-  }
   [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
   [[nodiscard]] orbit_client_data::ThreadTrackDataProvider* GetCaptureDataProvider() {
     return thread_track_data_provider_;
   }
 
-  [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
-
   void VerticalZoom(float real_ratio, float mouse_screen_y_position);
   void VerticallyMoveIntoView(const orbit_client_protos::TimerInfo& timer_info);
-  void VerticallyMoveIntoView(Track& track);
+  void VerticallyMoveIntoView(const Track& track);
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindPreviousFunctionCall(
       uint64_t function_address, uint64_t current_time,
@@ -59,9 +54,6 @@ class TrackContainer final : public CaptureViewElement {
   [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetAllThreadTrackTimerChains()
       const;
   [[nodiscard]] int GetNumVisiblePrimitives() const;
-
-  [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
-  [[nodiscard]] TimeGraphLayout& GetLayout() { return layout_; }
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindPrevious(
       const orbit_client_protos::TimerInfo& from);

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -53,11 +53,7 @@ class TrackContainer final : public CaptureViewElement {
   void SetIteratorOverlayData(
       const absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*>&
           iterator_timer_info,
-      const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id) {
-    iterator_timer_info_ = iterator_timer_info;
-    iterator_id_to_function_id_ = iterator_id_to_function_id;
-    RequestUpdate();
-  }
+      const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id);
   [[nodiscard]] float GetVerticalScrollingOffset() const { return vertical_scrolling_offset_; }
   void SetVerticalScrollingOffset(float value);
 

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -32,16 +32,18 @@
 #include "Viewport.h"
 
 class OrbitApp;
-class TimeGraph;
 
 namespace orbit_gl {
+
+class TrackContainer;
 
 // TrackManager is in charge of the active Tracks in Timegraph (their creation, searching, erasing
 // and sorting).
 class TrackManager {
  public:
-  explicit TrackManager(TimeGraph* time_graph, Viewport* viewport, TimeGraphLayout* layout,
-                        OrbitApp* app, orbit_client_data::CaptureData* capture_data);
+  explicit TrackManager(TrackContainer* track_container, TimelineInfoInterface* timeline_info,
+                        Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
+                        orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
   [[nodiscard]] std::vector<Track*> GetVisibleTracks() const { return visible_tracks_; }
@@ -118,7 +120,6 @@ class TrackManager {
   std::shared_ptr<CGroupAndProcessMemoryTrack> cgroup_and_process_memory_track_;
   std::shared_ptr<PageFaultsTrack> page_faults_track_;
 
-  TimeGraph* time_graph_;
   Viewport* viewport_;
   TimeGraphLayout* layout_;
 
@@ -133,6 +134,8 @@ class TrackManager {
   orbit_client_data::CaptureData* capture_data_ = nullptr;
 
   OrbitApp* app_ = nullptr;
+  TrackContainer* track_container_ = nullptr;
+  TimelineInfoInterface* timeline_info_ = nullptr;
 
   bool data_from_saved_capture_ = false;
   absl::flat_hash_map<Track::Type, bool> track_type_visibility_;

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -24,7 +24,7 @@ class TrackManagerTest : public ::testing::Test {
  public:
   explicit TrackManagerTest()
       : capture_data_(TrackTestData::GenerateTestCaptureData()),
-        track_manager_(nullptr, nullptr, &layout_, nullptr, capture_data_.get()) {}
+        track_manager_(nullptr, nullptr, nullptr, &layout_, nullptr, capture_data_.get()) {}
 
  protected:
   void CreateAndFillTracks() {

--- a/src/OrbitQt/TrackTypeItemModelTest.cpp
+++ b/src/OrbitQt/TrackTypeItemModelTest.cpp
@@ -47,7 +47,7 @@ class TrackTypeItemModelTest : public ::testing::Test {
   std::unique_ptr<orbit_client_data::CaptureData> capture_data_ =
       orbit_gl::TrackTestData::GenerateTestCaptureData();
   orbit_gl::TrackManager track_manager_ =
-      orbit_gl::TrackManager(nullptr, nullptr, &layout_, nullptr, capture_data_.get());
+      orbit_gl::TrackManager(nullptr, nullptr, nullptr, &layout_, nullptr, capture_data_.get());
 };
 
 TEST_F(TrackTypeItemModelTest, QtBasicTests) {


### PR DESCRIPTION
This PR creates the class which represent the space in the
CaptureWindows where Tracks will be drawn. See
go/stadia-orbit-timeline-improvements for more information.

Apart of a few minor changes, this PR is mostly moving function from
TimeGraph to the new TrackContainer class. Basically, TrackContainer
will manage all related with the vertical space and zooming that
previously was in the TimeGraph and all the logic related with Tracks.

Horizontal changes which affects the visible time are still managed
inside TimeGraph for now.

There are a few functions that have to be moved around:

 - ProcessTimer functions shouldn't be inside the UI, and Track creation
should be managed by previously querying CaptureDataProvider by
TrackManager. This is not a priority now, and meanwhile we can move
these functions to TrackManager, but is not a focus of this PR.
(http://b/214282122).

- SortedTracks should be managed inside TrackContainer instead of
TrackManager. This needs a few modifications that aren't either a
priority (http://b/214280810).

TODO:
1- I'm probably breaking E2E tests here. I will look at it in the
following days.
2- Next task is making TimelineUI a child of TimeGraph and
erasing the old timeline from CaptureWindows.

TEST: Load a capture. Start a capture, test some basic functionalities.

Bug: http://b/208446487