### PR TITLE
Move TrackManager to orbit_gl namespace

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -345,7 +345,7 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
             std::make_unique<CaptureData>(module_manager_.get(), capture_started, file_path,
                                           std::move(frame_track_function_ids), data_source_);
         capture_window_->CreateTimeGraph(capture_data_.get());
-        TrackManager* track_manager = GetMutableTimeGraph()->GetTrackManager();
+        orbit_gl::TrackManager* track_manager = GetMutableTimeGraph()->GetTrackManager();
         track_manager->SetIsDataFromSavedCapture(data_source_ ==
                                                  CaptureData::DataSource::kLoadedCapture);
         if (had_capture) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -52,6 +52,7 @@ using orbit_client_protos::TimerInfo;
 using orbit_gl::CGroupAndProcessMemoryTrack;
 using orbit_gl::PageFaultsTrack;
 using orbit_gl::SystemMemoryTrack;
+using orbit_gl::TrackManager;
 using orbit_gl::VariableTrack;
 
 using orbit_grpc_protos::InstrumentedFunction;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -58,7 +58,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] const orbit_client_data::CaptureData* GetCaptureData() const {
     return capture_data_;
   }
-  [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
+  [[nodiscard]] orbit_gl::TrackManager* GetTrackManager() { return track_manager_.get(); }
 
   [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
   [[nodiscard]] float GetWorldFromTick(uint64_t time) const override;
@@ -228,7 +228,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   Batcher batcher_;
 
-  std::unique_ptr<TrackManager> track_manager_;
+  std::unique_ptr<orbit_gl::TrackManager> track_manager_;
 
   ManualInstrumentationManager* manual_instrumentation_manager_;
   const orbit_client_data::CaptureData* capture_data_ = nullptr;

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -34,14 +34,11 @@
 
 using orbit_client_data::CallstackData;
 using orbit_client_protos::TimerInfo;
-using orbit_gl::CGroupAndProcessMemoryTrack;
-using orbit_gl::PageFaultsTrack;
-using orbit_gl::SystemMemoryTrack;
-using orbit_gl::VariableTrack;
 
-TrackManager::TrackManager(TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                           TimeGraphLayout* layout, OrbitApp* app,
-                           orbit_client_data::CaptureData* capture_data)
+namespace orbit_gl {
+
+TrackManager::TrackManager(TimeGraph* time_graph, Viewport* viewport, TimeGraphLayout* layout,
+                           OrbitApp* app, orbit_client_data::CaptureData* capture_data)
     : time_graph_(time_graph),
       viewport_(viewport),
       layout_(layout),
@@ -569,3 +566,5 @@ std::pair<uint64_t, uint64_t> TrackManager::GetTracksMinMaxTimestamps() const {
   }
   return std::make_pair(min_time, max_time);
 }
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -34,13 +34,14 @@
 class OrbitApp;
 class TimeGraph;
 
+namespace orbit_gl {
+
 // TrackManager is in charge of the active Tracks in Timegraph (their creation, searching, erasing
 // and sorting).
 class TrackManager {
  public:
-  explicit TrackManager(TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                        TimeGraphLayout* layout, OrbitApp* app,
-                        orbit_client_data::CaptureData* capture_data);
+  explicit TrackManager(TimeGraph* time_graph, Viewport* viewport, TimeGraphLayout* layout,
+                        OrbitApp* app, orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
   [[nodiscard]] std::vector<Track*> GetVisibleTracks() const { return visible_tracks_; }
@@ -61,21 +62,21 @@ class TrackManager {
   SchedulerTrack* GetOrCreateSchedulerTrack();
   ThreadTrack* GetOrCreateThreadTrack(uint32_t tid);
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
-  orbit_gl::VariableTrack* GetOrCreateVariableTrack(const std::string& name);
+  VariableTrack* GetOrCreateVariableTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
   FrameTrack* GetOrCreateFrameTrack(const orbit_grpc_protos::InstrumentedFunction& function);
-  [[nodiscard]] orbit_gl::SystemMemoryTrack* GetSystemMemoryTrack() const {
+  [[nodiscard]] SystemMemoryTrack* GetSystemMemoryTrack() const {
     return system_memory_track_.get();
   }
-  [[nodiscard]] orbit_gl::SystemMemoryTrack* CreateAndGetSystemMemoryTrack();
-  [[nodiscard]] orbit_gl::CGroupAndProcessMemoryTrack* GetCGroupAndProcessMemoryTrack() const {
+  [[nodiscard]] SystemMemoryTrack* CreateAndGetSystemMemoryTrack();
+  [[nodiscard]] CGroupAndProcessMemoryTrack* GetCGroupAndProcessMemoryTrack() const {
     return cgroup_and_process_memory_track_.get();
   }
-  [[nodiscard]] orbit_gl::CGroupAndProcessMemoryTrack* CreateAndGetCGroupAndProcessMemoryTrack(
+  [[nodiscard]] CGroupAndProcessMemoryTrack* CreateAndGetCGroupAndProcessMemoryTrack(
       const std::string& cgroup_name);
-  orbit_gl::PageFaultsTrack* GetPageFaultsTrack() const { return page_faults_track_.get(); }
-  orbit_gl::PageFaultsTrack* CreateAndGetPageFaultsTrack(const std::string& cgroup_name,
-                                                         uint64_t memory_sampling_period_ms);
+  PageFaultsTrack* GetPageFaultsTrack() const { return page_faults_track_.get(); }
+  PageFaultsTrack* CreateAndGetPageFaultsTrack(const std::string& cgroup_name,
+                                               uint64_t memory_sampling_period_ms);
 
   [[nodiscard]] bool GetIsDataFromSavedCapture() const { return data_from_saved_capture_; }
   void SetIsDataFromSavedCapture(bool value) { data_from_saved_capture_ = value; }
@@ -105,7 +106,7 @@ class TrackManager {
   std::vector<std::shared_ptr<Track>> all_tracks_;
   absl::flat_hash_map<uint32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
   std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
-  std::map<std::string, std::shared_ptr<orbit_gl::VariableTrack>> variable_tracks_;
+  std::map<std::string, std::shared_ptr<VariableTrack>> variable_tracks_;
   // Mapping from timeline to GPU tracks. Timeline name is used for stable ordering. In particular
   // we want the marker tracks next to their queue track. E.g. "gfx" and "gfx_markers" should appear
   // next to each other.
@@ -113,12 +114,12 @@ class TrackManager {
   // Mapping from function address to frame tracks.
   std::map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
   std::shared_ptr<SchedulerTrack> scheduler_track_;
-  std::shared_ptr<orbit_gl::SystemMemoryTrack> system_memory_track_;
-  std::shared_ptr<orbit_gl::CGroupAndProcessMemoryTrack> cgroup_and_process_memory_track_;
-  std::shared_ptr<orbit_gl::PageFaultsTrack> page_faults_track_;
+  std::shared_ptr<SystemMemoryTrack> system_memory_track_;
+  std::shared_ptr<CGroupAndProcessMemoryTrack> cgroup_and_process_memory_track_;
+  std::shared_ptr<PageFaultsTrack> page_faults_track_;
 
   TimeGraph* time_graph_;
-  orbit_gl::Viewport* viewport_;
+  Viewport* viewport_;
   TimeGraphLayout* layout_;
 
   std::vector<Track*> sorted_tracks_;
@@ -136,5 +137,7 @@ class TrackManager {
   bool data_from_saved_capture_ = false;
   absl::flat_hash_map<Track::Type, bool> track_type_visibility_;
 };
+
+}  // namespace orbit_gl
 
 #endif  // ORBIT_GL_TRACK_MANAGER_H_

--- a/src/OrbitQt/TrackConfigurationWidget.cpp
+++ b/src/OrbitQt/TrackConfigurationWidget.cpp
@@ -20,7 +20,7 @@ TrackConfigurationWidget::TrackConfigurationWidget(QWidget* parent)
 
 TrackConfigurationWidget::~TrackConfigurationWidget() = default;
 
-void TrackConfigurationWidget::SetTrackManager(TrackManager* track_manager) {
+void TrackConfigurationWidget::SetTrackManager(orbit_gl::TrackManager* track_manager) {
   track_type_item_model_.SetTrackManager(track_manager);
 }
 

--- a/src/OrbitQt/TrackConfigurationWidget.h
+++ b/src/OrbitQt/TrackConfigurationWidget.h
@@ -23,7 +23,7 @@ class TrackConfigurationWidget : public QWidget {
  public:
   explicit TrackConfigurationWidget(QWidget* parent = nullptr);
   ~TrackConfigurationWidget() override;
-  void SetTrackManager(TrackManager* track_manager);
+  void SetTrackManager(orbit_gl::TrackManager* track_manager);
 
  private:
   std::unique_ptr<Ui::TrackConfigurationWidget> ui_;

--- a/src/OrbitQt/TrackTypeItemModel.cpp
+++ b/src/OrbitQt/TrackTypeItemModel.cpp
@@ -104,7 +104,7 @@ Qt::ItemFlags TrackTypeItemModel::flags(const QModelIndex& index) const {
   return flags;
 }
 
-void TrackTypeItemModel::SetTrackManager(TrackManager* track_manager) {
+void TrackTypeItemModel::SetTrackManager(orbit_gl::TrackManager* track_manager) {
   int row_count = rowCount();
   if (row_count > 0) {
     beginRemoveRows({}, 0, rowCount() - 1);

--- a/src/OrbitQt/TrackTypeItemModel.h
+++ b/src/OrbitQt/TrackTypeItemModel.h
@@ -38,10 +38,10 @@ class TrackTypeItemModel : public QAbstractTableModel {
   [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override;
   [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-  void SetTrackManager(TrackManager* track_manager);
+  void SetTrackManager(orbit_gl::TrackManager* track_manager);
 
  private:
-  TrackManager* track_manager_ = nullptr;
+  orbit_gl::TrackManager* track_manager_ = nullptr;
   std::vector<Track::Type> known_track_types_;
 
   QString GetTrackTypeDisplayName(Track::Type track_type) const;

--- a/src/OrbitQt/TrackTypeItemModelTest.cpp
+++ b/src/OrbitQt/TrackTypeItemModelTest.cpp
@@ -46,8 +46,8 @@ class TrackTypeItemModelTest : public ::testing::Test {
   TimeGraphLayout layout_;
   std::unique_ptr<orbit_client_data::CaptureData> capture_data_ =
       orbit_gl::TrackTestData::GenerateTestCaptureData();
-  TrackManager track_manager_ =
-      TrackManager(nullptr, nullptr, &layout_, nullptr, capture_data_.get());
+  orbit_gl::TrackManager track_manager_ =
+      orbit_gl::TrackManager(nullptr, nullptr, &layout_, nullptr, capture_data_.get());
 };
 
 TEST_F(TrackTypeItemModelTest, QtBasicTests) {

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -680,9 +680,10 @@ void OrbitMainWindow::UpdateCaptureStateDependentWidgets() {
   }
 
   if (has_data) {
-    TrackManager* track_manager = dynamic_cast<CaptureWindow*>(ui->CaptureGLWidget->GetCanvas())
-                                      ->GetTimeGraph()
-                                      ->GetTrackManager();
+    orbit_gl::TrackManager* track_manager =
+        dynamic_cast<CaptureWindow*>(ui->CaptureGLWidget->GetCanvas())
+            ->GetTimeGraph()
+            ->GetTrackManager();
     ui->trackConfig->SetTrackManager(track_manager);
   }
 }


### PR DESCRIPTION
Part of the refactor where we create TrackContainer
(https://github.com/google/orbit/pull/3236).

I needed it because we still need to have a forward reference.

Bug: http://b/208446487.