### PR TITLE
Allow DWARF column numbers beyond actual registers in libunwindstack

### DIFF
--- a/third_party/libunwindstack/include/unwindstack/Regs.h
+++ b/third_party/libunwindstack/include/unwindstack/Regs.h
@@ -78,6 +78,7 @@ class Regs {
 
   virtual void IterateRegisters(std::function<void(const char*, uint64_t)>) = 0;
 
+  virtual void OverrideTotalRegs(uint16_t total_regs) = 0;
   uint16_t total_regs() { return total_regs_; }
 
   virtual Regs* Clone() = 0;
@@ -103,6 +104,11 @@ class RegsImpl : public Regs {
   inline AddressType& operator[](size_t reg) { return regs_[reg]; }
 
   void* RawData() override { return regs_.data(); }
+
+  void OverrideTotalRegs(uint16_t total_regs) override {
+    total_regs_ = total_regs;
+    regs_.resize(total_regs_);
+  }
 
   virtual void IterateRegisters(std::function<void(const char*, uint64_t)> fn) override {
     for (size_t i = 0; i < regs_.size(); ++i) {

--- a/third_party/libunwindstack/utils/RegsFake.h
+++ b/third_party/libunwindstack/utils/RegsFake.h
@@ -63,6 +63,8 @@ class RegsFake : public Regs {
 
   Regs* Clone() override { return nullptr; }
 
+  void OverrideTotalRegs(uint16_t total_regs) override { total_regs_ = total_regs; }
+
  private:
   ArchEnum fake_arch_ = ARCH_UNKNOWN;
   uint64_t fake_pc_ = 0;


### PR DESCRIPTION
DWARF allows column numbers for the DWARF table for unwinding frames
that are larger than actual (general purpose) register numbers
(sometimes these are called virtual registers). So far, libunwindstack
would reject such column numbers. We now allow column numbers up to a
certain limit by expanding the vector that is storing the registers
during evaluation of DWARF expressions when unwinding a frame.

Note that an alternative would be to simply increase the maximum
number of registers present for all architectures (or the architectures
we care about), and this was also how this was initially done in our
unwinding prototype. However, the "column number larger than general
purpose registers" feature is a feature of DWARF and thus should be
handled and controlled by code related to DWARF.

A possible (but potentially larger) refactoring would be to disconnect
the columns in the evaluated DWARF table from the registers (including
copying the subset of the table that belongs to actual registers into
the registers vector after evalution).

Tested: Unit test added.
Bug: http://b/194768602