### PR TITLE
Change and rename GetFirstExecutableMemoryRegion to return the last

### DIFF
--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -64,8 +64,8 @@ using orbit_base::ReadFileToString;
     const std::string& line = *line_it;
     const std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipWhitespace());
     if (tokens.size() < 2 || tokens[1].size() != 4 || tokens[1][2] != 'x') continue;
-    // Writing to [vsyscall] fails with EIO (Input/output error).
-    if (tokens.size() >= 6 && tokens[5] == "[vsyscall]") continue;
+    // Writing to [vsyscall] or [uprobes] fails with EIO (Input/output error).
+    if (tokens.size() >= 6 && (tokens[5] == "[vsyscall]" || tokens[5] == "[uprobes]")) continue;
     const std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
     if (addresses.size() != 2) continue;
     AddressRange result;

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -26,13 +26,13 @@ namespace orbit_user_space_instrumentation {
 [[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t start_address,
                                                       const std::vector<uint8_t>& bytes);
 
-// Returns the address range of the first executable memory region. In every case I encountered this
-// was the second line in the `maps` file corresponding to the code of the process we look at.
-// However we don't really care. So keeping it general and just searching for an executable region
-// is probably helping stability.
+// Returns the address range of an executable memory region. One options is usually the second line
+// in the `maps` file corresponding to the code of the process we look at. However we don't really
+// care. So keeping it general and just searching for an executable region is probably helping
+// stability.
 // Optionally one can specify `exclude_address`. This prevents the method from returning an address
 // range containing `exclude_address`.
-[[nodiscard]] ErrorMessageOr<AddressRange> GetFirstExecutableMemoryRegion(
+[[nodiscard]] ErrorMessageOr<AddressRange> GetExistingExecutableMemoryRegion(
     pid_t pid, uint64_t exclude_address = 0);
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -205,7 +205,7 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   // Stop the child process using our tooling.
   CHECK(!AttachAndStopProcess(pid).has_error());
 
-  auto memory_region_or_error = GetFirstExecutableMemoryRegion(pid);
+  auto memory_region_or_error = GetExistingExecutableMemoryRegion(pid);
   CHECK(memory_region_or_error.has_value());
   const uint64_t address = memory_region_or_error.value().start;
 

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -49,7 +49,7 @@ namespace {
   }
 
   // Get an executable memory region.
-  auto memory_region_or_error = GetFirstExecutableMemoryRegion(pid, exclude_address);
+  auto memory_region_or_error = GetExistingExecutableMemoryRegion(pid, exclude_address);
   if (memory_region_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to find executable memory region: \"%s\"",
                                         memory_region_or_error.error().message()));


### PR DESCRIPTION
This is to work around a seccomp filter when running on Proton that traps all
syscalls coming from low instruction pointers. Refer to the bug for all the
details.

Bug: http://b/214052981

Test: Capture `triangle.exe` with Orbit API previously failing. Capture Trata
with user space instrumentation.