### PR TITLE
Change `: \"%s\"` to `: %s` in UserSpaceInstrumentation's error messages

### DIFF
--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -40,7 +40,7 @@ namespace {
   RegisterState original_registers;
   auto register_backup_result = original_registers.BackupRegisters(pid);
   if (register_backup_result.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to backup original register state: \"%s\"",
+    return ErrorMessage(absl::StrFormat("Failed to backup original register state: %s",
                                         register_backup_result.error().message()));
   }
   if (original_registers.GetBitness() != RegisterState::Bitness::k64Bit) {
@@ -51,7 +51,7 @@ namespace {
   // Get an executable memory region.
   auto memory_region_or_error = GetFirstExecutableMemoryRegion(pid, exclude_address);
   if (memory_region_or_error.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to find executable memory region: \"%s\"",
+    return ErrorMessage(absl::StrFormat("Failed to find executable memory region: %s",
                                         memory_region_or_error.error().message()));
   }
   const uint64_t start_address = memory_region_or_error.value().start;
@@ -59,14 +59,14 @@ namespace {
   // Backup first 8 bytes.
   auto backup_or_error = ReadTraceesMemory(pid, start_address, 8);
   if (backup_or_error.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to read from tracee's memory: \"%s\"",
+    return ErrorMessage(absl::StrFormat("Failed to read from tracee's memory: %s",
                                         backup_or_error.error().message()));
   }
 
   // Write `syscall` into memory. Machine code is `0x0f05`.
   auto write_code_result = WriteTraceesMemory(pid, start_address, std::vector<uint8_t>{0x0f, 0x05});
   if (write_code_result.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to write to tracee's memory: \"%s\"",
+    return ErrorMessage(absl::StrFormat("Failed to write to tracee's memory: %s",
                                         write_code_result.error().message()));
   }
 
@@ -84,7 +84,7 @@ namespace {
   registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.r9 = arg_5;
   auto restore_registers_result = registers_for_syscall.RestoreRegisters();
   if (restore_registers_result.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to set registers with syscall parameters: \"%s\"",
+    return ErrorMessage(absl::StrFormat("Failed to set registers with syscall parameters: %s",
                                         restore_registers_result.error().message()));
   }
 
@@ -102,7 +102,7 @@ namespace {
   RegisterState return_value;
   auto return_value_result = return_value.BackupRegisters(pid);
   if (return_value_result.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to get registers with mmap result: \"%s\"",
+    return ErrorMessage(absl::StrFormat("Failed to get registers with mmap result: %s",
                                         return_value_result.error().message()));
   }
   const uint64_t result = return_value.GetGeneralPurposeRegisters()->x86_64.rax;
@@ -116,12 +116,11 @@ namespace {
   // Clean up memory and registers.
   auto restore_memory_result = WriteTraceesMemory(pid, start_address, backup_or_error.value());
   if (restore_memory_result.has_error()) {
-    FATAL("Unable to restore memory state of tracee: \"%s\"",
-          restore_memory_result.error().message());
+    FATAL("Unable to restore memory state of tracee: %s", restore_memory_result.error().message());
   }
   restore_registers_result = original_registers.RestoreRegisters();
   if (restore_registers_result.has_error()) {
-    FATAL("Unable to restore register state of tracee: \"%s\"",
+    FATAL("Unable to restore register state of tracee: %s",
           restore_registers_result.error().message());
   }
 
@@ -143,9 +142,9 @@ ErrorMessageOr<std::unique_ptr<MemoryInTracee>> MemoryInTracee::Create(pid_t pid
                                          MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0,
                                          /*exclude_address=*/0);
   if (result_or_error.has_error()) {
-    return ErrorMessage(absl::StrFormat(
-        "Failed to execute mmap syscall with parameters address=%#x size=%u: \"%s\"", address, size,
-        result_or_error.error().message()));
+    return ErrorMessage(
+        absl::StrFormat("Failed to execute mmap syscall with parameters address=%#x size=%u: %s",
+                        address, size, result_or_error.error().message()));
   }
 
   std::unique_ptr<MemoryInTracee> result(
@@ -153,11 +152,11 @@ ErrorMessageOr<std::unique_ptr<MemoryInTracee>> MemoryInTracee::Create(pid_t pid
 
   if (address != 0 && result->GetAddress() != address) {
     auto free_memory_result = result->Free();
-    FAIL_IF(free_memory_result.has_error(), "Unable to free proviously allocated memory: \"%s\"",
+    FAIL_IF(free_memory_result.has_error(), "Unable to free previously allocated memory: %s",
             free_memory_result.error().message());
     return ErrorMessage(
         absl::StrFormat("MemoryInTracee wanted to allocate memory at %#x but got memory at a "
-                        "different adress: %#x. The memory has been freed again.",
+                        "different address: %#x. The memory has been freed again.",
                         address, result->GetAddress()));
   }
 
@@ -171,8 +170,8 @@ ErrorMessageOr<void> MemoryInTracee::Free() {
   auto result_or_error =
       SyscallInTracee(pid_, kSyscallNumberMunmap, address_, size_, 0, 0, 0, 0, address_);
   if (result_or_error.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to execute munmap syscall: \"%s\"",
-                                        result_or_error.error().message()));
+    return ErrorMessage(
+        absl::StrFormat("Failed to execute munmap syscall: %s", result_or_error.error().message()));
   }
   pid_ = -1;
   address_ = 0;
@@ -191,7 +190,7 @@ ErrorMessageOr<void> MemoryInTracee::EnsureMemoryExecutable() {
       SyscallInTracee(pid_, kSyscallNumberMprotect, address_, size_, PROT_EXEC, 0, 0, 0, 0);
   if (result_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat(
-        "Failed to execute mprotect syscall with parameters address=%#x size=%u: \"%s\"", address_,
+        "Failed to execute mprotect syscall with parameters address=%#x size=%u: %s", address_,
         size_, result_or_error.error().message()));
   }
 
@@ -209,7 +208,7 @@ ErrorMessageOr<void> MemoryInTracee::EnsureMemoryWritable() {
       SyscallInTracee(pid_, kSyscallNumberMprotect, address_, size_, PROT_WRITE, 0, 0, 0, 0);
   if (result_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat(
-        "Failed to execute mprotect syscall with parameters address=%#x size=%u: \"%s\"", address_,
+        "Failed to execute mprotect syscall with parameters address=%#x size=%u: %s", address_,
         size_, result_or_error.error().message()));
   }
 
@@ -230,9 +229,9 @@ ErrorMessageOr<std::unique_ptr<AutomaticMemoryInTracee>> AutomaticMemoryInTracee
                                          MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0,
                                          /*exclude_address=*/0);
   if (result_or_error.has_error()) {
-    return ErrorMessage(absl::StrFormat(
-        "Failed to execute mmap syscall with parameters address=%#x size=%u: \"%s\"", address, size,
-        result_or_error.error().message()));
+    return ErrorMessage(
+        absl::StrFormat("Failed to execute mmap syscall with parameters address=%#x size=%u: %s",
+                        address, size, result_or_error.error().message()));
   }
 
   std::unique_ptr<AutomaticMemoryInTracee> result(new AutomaticMemoryInTracee(
@@ -240,11 +239,11 @@ ErrorMessageOr<std::unique_ptr<AutomaticMemoryInTracee>> AutomaticMemoryInTracee
 
   if (address != 0 && result->GetAddress() != address) {
     auto free_memory_result = result->Free();
-    FAIL_IF(free_memory_result.has_error(), "Unable to free proviously allocated memory: \"%s\"",
+    FAIL_IF(free_memory_result.has_error(), "Unable to free previously allocated memory: %s",
             free_memory_result.error().message());
     return ErrorMessage(absl::StrFormat(
         "AutomaticMemoryInTracee wanted to allocate memory at %#x but got memory at a "
-        "different adress: %#x. The memory has been freed again.",
+        "different address: %#x. The memory has been freed again.",
         address, result->GetAddress()));
   }
 

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -93,7 +93,7 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
 
   // Allocation fails for non page aligned address.
   my_memory_or_error = MemoryInTracee::Create(pid, 1, kMemorySize);
-  EXPECT_THAT(my_memory_or_error, HasError("but got memory at a different adress"));
+  EXPECT_THAT(my_memory_or_error, HasError("but got memory at a different address"));
 
   // Allocation fails for ridiculous size.
   my_memory_or_error = MemoryInTracee::Create(pid, 1, 1ull << 63);

--- a/src/UserSpaceInstrumentation/Attach.cpp
+++ b/src/UserSpaceInstrumentation/Attach.cpp
@@ -36,7 +36,7 @@ namespace {
       return false;
     }
     return ErrorMessage(
-        absl::StrFormat("PTRACE_ATTACH failed for %d: \"%s\"", tid, SafeStrerror(errno)));
+        absl::StrFormat("PTRACE_ATTACH failed for %d: %s", tid, SafeStrerror(errno)));
   }
   // Wait for the traced thread to stop. Timeout after one second.
   constexpr int kMaxAttempts = 1000;
@@ -44,7 +44,7 @@ namespace {
     int stat_val = 0;
     const int waitpid_result = waitpid(tid, &stat_val, WNOHANG);
     if (waitpid_result == -1) {
-      return ErrorMessage(absl::StrFormat("Wait for thread to get traced failed for tid %d: \"%s\"",
+      return ErrorMessage(absl::StrFormat("Wait for thread to get traced failed for tid %d: %s",
                                           tid, SafeStrerror(errno)));
     }
     if (waitpid_result > 0) {
@@ -122,8 +122,8 @@ ErrorMessageOr<void> DetachAndContinueProcess(pid_t pid) {
   auto tids = GetTidsOfProcess(pid);
   for (auto tid : tids) {
     if (ptrace(PTRACE_DETACH, tid, nullptr, nullptr) == -1) {
-      return ErrorMessage(absl::StrFormat("Error while detaching from thread %d: \"%s\"", tid,
-                                          SafeStrerror(errno)));
+      return ErrorMessage(
+          absl::StrFormat("Error while detaching from thread %d: %s", tid, SafeStrerror(errno)));
     }
   }
   return outcome::success();

--- a/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
@@ -22,14 +22,14 @@ namespace {
 // obviously. That's what the *OrDie methods below are for.
 void RestoreRegistersOrDie(RegisterState& register_state) {
   auto result = register_state.RestoreRegisters();
-  FAIL_IF(result.has_error(), "Unable to restore register state in tracee: \"%s\"",
+  FAIL_IF(result.has_error(), "Unable to restore register state in tracee: %s",
           result.error().message());
 }
 
 uint64_t GetReturnValueOrDie(pid_t pid) {
   RegisterState return_value_registers;
   auto result_return_value = return_value_registers.BackupRegisters(pid);
-  FAIL_IF(result_return_value.has_error(), "Unable to read registers after function called :\"%s\"",
+  FAIL_IF(result_return_value.has_error(), "Unable to read registers after function called: %s",
           result_return_value.error().message());
   return return_value_registers.GetGeneralPurposeRegisters()->x86_64.rax;
 }

--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -70,7 +70,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
                           address_or_error.error().message()));
     } else {
       error_message.append(absl::StrFormat(
-          "\nAlso failed to load fallback symbol \"%s\" from module \"%s\" with error: \"%s\"",
+          "\nAlso failed to load fallback symbol \"%s\" from module \"%s\" with error: %s",
           function_locator.function_name, function_locator.module_name,
           address_or_error.error().message()));
     }
@@ -86,11 +86,11 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
   // Make sure file exists.
   auto file_exists_or_error = orbit_base::FileExists(path);
   if (file_exists_or_error.has_error()) {
-    return ErrorMessage(absl::StrFormat("Unable to access library at: \"%s\": %s", path,
+    return ErrorMessage(absl::StrFormat("Unable to access library at \"%s\": %s", path,
                                         file_exists_or_error.error().message()));
   }
   if (!file_exists_or_error.value()) {
-    return ErrorMessage(absl::StrFormat("Library does not exist at: \"%s\"", path));
+    return ErrorMessage(absl::StrFormat("Library does not exist at \"%s\"", path));
   }
 
   // Figure out address of dlopen.

--- a/src/UserSpaceInstrumentation/RegisterState.cpp
+++ b/src/UserSpaceInstrumentation/RegisterState.cpp
@@ -84,7 +84,7 @@ ErrorMessageOr<void> RegisterState::BackupRegisters(pid_t tid) {
   iov.iov_len = sizeof(GeneralPurposeRegisters);
   auto result = ptrace(PTRACE_GETREGSET, tid, NT_PRSTATUS, &iov);
   if (result == -1) {
-    return ErrorMessage(absl::StrFormat("PTRACE_GETREGS, NT_PRSTATUS failed with errno: %d: \"%s\"",
+    return ErrorMessage(absl::StrFormat("PTRACE_GETREGS, NT_PRSTATUS failed with errno: %d: %s",
                                         errno, SafeStrerror(errno)));
   }
 
@@ -106,8 +106,8 @@ ErrorMessageOr<void> RegisterState::BackupRegisters(pid_t tid) {
   iov.iov_base = xsave_area_.data();
   result = ptrace(PTRACE_GETREGSET, tid, NT_X86_XSTATE, &iov);
   if (result == -1) {
-    return ErrorMessage(absl::StrFormat(
-        "PTRACE_GETREGS, NT_X86_XSTATE failed with errno: %d: \"%s\"", errno, SafeStrerror(errno)));
+    return ErrorMessage(absl::StrFormat("PTRACE_GETREGS, NT_X86_XSTATE failed with errno: %d: %s",
+                                        errno, SafeStrerror(errno)));
   }
 
   auto avx_offset = GetAvxOffset();
@@ -129,8 +129,8 @@ ErrorMessageOr<void> RegisterState::RestoreRegisters() {
   auto result = ptrace(PTRACE_SETREGSET, tid_, NT_PRSTATUS, &iov);
   if (result == -1) {
     return ErrorMessage(
-        absl::StrFormat("PTRACE_SETREGSET failed to write NT_PRSTATUS with errno: %d: \"%s\"",
-                        errno, SafeStrerror(errno)));
+        absl::StrFormat("PTRACE_SETREGSET failed to write NT_PRSTATUS with errno: %d: %s", errno,
+                        SafeStrerror(errno)));
   }
 
   iov.iov_len = xsave_area_.size();
@@ -138,8 +138,8 @@ ErrorMessageOr<void> RegisterState::RestoreRegisters() {
   result = ptrace(PTRACE_SETREGSET, tid_, NT_X86_XSTATE, &iov);
   if (result == -1) {
     return ErrorMessage(
-        absl::StrFormat("PTRACE_SETREGSET failed to write NT_X86_XSTATE with errno: %d: \"%s\"",
-                        errno, SafeStrerror(errno)));
+        absl::StrFormat("PTRACE_SETREGSET failed to write NT_X86_XSTATE with errno: %d: %s", errno,
+                        SafeStrerror(errno)));
   }
   return outcome::success();
 }

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -865,7 +865,7 @@ void MoveInstructionPointersOutOfOverwrittenCode(
     RegisterState registers;
     ErrorMessageOr<void> backup_or_error = registers.BackupRegisters(tid);
     FAIL_IF(backup_or_error.has_error(),
-            "Failed to read registers in MoveInstructionPointersOutOfOverwrittenCode: \"%s\"",
+            "Failed to read registers in MoveInstructionPointersOutOfOverwrittenCode: %s",
             backup_or_error.error().message());
     const uint64_t rip = registers.GetGeneralPurposeRegisters()->x86_64.rip;
     auto relocation = relocation_map.find(rip);
@@ -873,7 +873,7 @@ void MoveInstructionPointersOutOfOverwrittenCode(
       registers.GetGeneralPurposeRegisters()->x86_64.rip = relocation->second;
       ErrorMessageOr<void> restore_or_error = registers.RestoreRegisters();
       FAIL_IF(restore_or_error.has_error(),
-              "Failed to write registers in MoveInstructionPointersOutOfOverwrittenCode: \"%s\"",
+              "Failed to write registers in MoveInstructionPointersOutOfOverwrittenCode: %s",
               restore_or_error.error().message());
     }
   }


### PR DESCRIPTION
We want error messages to look like
```
Outer error: inner error: another error.
```
instead of
```
Outer error: "inner error: "another error.""
```