### PR TITLE
Add ORBIT_ prefix to logging-related macros

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -240,10 +240,10 @@ extern "C" {
 // for all api function tables. It is also called on every capture stop to disable the api so that
 // the api calls early out at the call site.
 void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled) {
-  LOG("%s Orbit API at address %#x, version %u", enabled ? "Enabling" : "Disabling", address,
-      api_version);
+  ORBIT_LOG("%s Orbit API at address %#x, version %u", enabled ? "Enabling" : "Disabling", address,
+            api_version);
   if (api_version > kOrbitApiVersion) {
-    ERROR(
+    ORBIT_ERROR(
         "Orbit API version in tracee (%u) is newer than the max supported version (%u). "
         "Some features will be unavailable.",
         api_version, kOrbitApiVersion);
@@ -263,7 +263,7 @@ void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled)
       orbit_api_initialize_and_set_enabled(api_v2, &orbit_api_initialize_v2, enabled);
     } break;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   // Initialize `LockFreeApiEventProducer` and establish the connection to OrbitService now instead
@@ -277,12 +277,13 @@ void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled)
 }
 
 void orbit_api_set_enabled_wine(uint64_t address, uint64_t api_version, bool enabled) {
-  LOG("%s Orbit API at address %#x, for Windows", enabled ? "Enabling" : "Disabling", address);
+  ORBIT_LOG("%s Orbit API at address %#x, for Windows", enabled ? "Enabling" : "Disabling",
+            address);
   static constexpr uint64_t kOrbitApiForWineMinVersion = 2;
   if (api_version < kOrbitApiForWineMinVersion) {
     // This is unexpected because `orbit_api_get_function_table_address_win_v#` wasn't present in
     // Orbit.h before v2.
-    ERROR(
+    ORBIT_ERROR(
         "Orbit API version in tracee (%u) is older than the min supported version (%u) for "
         "Wine.",
         api_version, kOrbitApiForWineMinVersion);
@@ -290,7 +291,7 @@ void orbit_api_set_enabled_wine(uint64_t address, uint64_t api_version, bool ena
   }
 
   if (api_version > kOrbitApiVersion) {
-    ERROR(
+    ORBIT_ERROR(
         "Orbit API version in tracee (%u) is newer than the max supported version (%u). "
         "Some features will be unavailable.",
         api_version, kOrbitApiVersion);
@@ -302,7 +303,7 @@ void orbit_api_set_enabled_wine(uint64_t address, uint64_t api_version, bool ena
       orbit_api_initialize_and_set_enabled(api_win, &orbit_api_initialize_wine_v2, enabled);
     } break;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   // TODO(b/206359125): Re-add GetCaptureEventProducer() once possible. See above.

--- a/src/ApiUtils/Event.cpp
+++ b/src/ApiUtils/Event.cpp
@@ -175,7 +175,7 @@ void FillProducerCaptureEventFromApiEvent(const ApiTrackUint64& track_uint64,
 void FillProducerCaptureEventFromApiEvent(
     const std::monostate& /*monostate*/,
     orbit_grpc_protos::ProducerCaptureEvent* /*capture_event*/) {
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 
 }  // namespace orbit_api

--- a/src/CaptureClient/ApiEventProcessor.cpp
+++ b/src/CaptureClient/ApiEventProcessor.cpp
@@ -36,7 +36,7 @@ void EncodedColorToColor(uint32_t encoded_color, orbit_client_protos::Color* col
 }  // namespace
 
 ApiEventProcessor::ApiEventProcessor(CaptureListener* listener) : capture_listener_(listener) {
-  CHECK(listener != nullptr);
+  ORBIT_CHECK(listener != nullptr);
 }
 
 void ApiEventProcessor::ProcessApiEventLegacy(const orbit_grpc_protos::ApiEvent& grpc_api_event) {
@@ -81,7 +81,7 @@ void ApiEventProcessor::ProcessApiEventLegacy(const orbit_api::ApiEvent& api_eve
       ProcessTrackingEventLegacy(api_event);
       break;
     case orbit_api::kNone:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -202,7 +202,7 @@ void ApiEventProcessor::ProcessTrackingEventLegacy(const orbit_api::ApiEvent& ap
     case orbit_api::kScopeStartAsync:
     case orbit_api::kScopeStopAsync:
     case orbit_api::kString:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   capture_listener_->OnApiTrackValue(api_track_value);

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -238,7 +238,7 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
       ProcessCaptureFinished(event.capture_finished());
       break;
     case ClientCaptureEvent::EVENT_NOT_SET:
-      ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");
+      ORBIT_ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");
       break;
     default:
       break;
@@ -275,7 +275,7 @@ void CaptureEventProcessorForListener::ProcessSchedulingSlice(
 void CaptureEventProcessorForListener::ProcessInternedCallstack(
     InternedCallstack interned_callstack) {
   if (callstack_intern_pool.contains(interned_callstack.key())) {
-    ERROR("Overwriting InternedCallstack with key %llu", interned_callstack.key());
+    ORBIT_ERROR("Overwriting InternedCallstack with key %llu", interned_callstack.key());
   }
   callstack_intern_pool.emplace(interned_callstack.key(),
                                 std::move(*interned_callstack.mutable_intern()));
@@ -323,7 +323,7 @@ void CaptureEventProcessorForListener::ProcessFunctionCall(const FunctionCall& f
 
 void CaptureEventProcessorForListener::ProcessInternedString(InternedString interned_string) {
   if (string_intern_pool_.contains(interned_string.key())) {
-    ERROR("Overwriting InternedString with key %llu", interned_string.key());
+    ORBIT_ERROR("Overwriting InternedString with key %llu", interned_string.key());
   }
   capture_listener_->OnKeyAndString(interned_string.key(), interned_string.intern());
   string_intern_pool_.emplace(interned_string.key(), std::move(*interned_string.mutable_intern()));
@@ -581,7 +581,7 @@ void CaptureEventProcessorForListener::ProcessThreadStateSlice(
       slice_info.set_thread_state(ThreadStateSliceInfo::kIdle);
       break;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
   slice_info.set_begin_timestamp_ns(thread_state_slice.end_timestamp_ns() -
                                     thread_state_slice.duration_ns());
@@ -593,8 +593,8 @@ void CaptureEventProcessorForListener::ProcessThreadStateSlice(
 }
 
 void CaptureEventProcessorForListener::ProcessAddressInfo(const AddressInfo& address_info) {
-  CHECK(string_intern_pool_.contains(address_info.function_name_key()));
-  CHECK(string_intern_pool_.contains(address_info.module_name_key()));
+  ORBIT_CHECK(string_intern_pool_.contains(address_info.function_name_key()));
+  ORBIT_CHECK(string_intern_pool_.contains(address_info.module_name_key()));
   std::string function_name = string_intern_pool_.at(address_info.function_name_key());
   std::string module_name = string_intern_pool_.at(address_info.module_name_key());
 
@@ -645,7 +645,7 @@ void CaptureEventProcessorForListener::SendCallstackToListenerIfNecessary(
       [[fallthrough]];
     case orbit_grpc_protos::
         Callstack_CallstackType_Callstack_CallstackType_INT_MAX_SENTINEL_DO_NOT_USE_:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   capture_listener_->OnUniqueCallstack(callstack_id, callstack_info);

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -214,7 +214,7 @@ static void ExpectCallstackSamplesEqual(const CallstackEvent& actual_callstack_e
       [[fallthrough]];
     case orbit_grpc_protos::
         Callstack_CallstackType_Callstack_CallstackType_INT_MAX_SENTINEL_DO_NOT_USE_:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 

--- a/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -159,7 +159,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmissionWit
         get_string_hash_and_send_to_listener_if_necessary) {
   std::vector<TimerInfo> result;
   uint64_t timeline_key = matching_gpu_job.timeline_key();
-  CHECK(string_intern_pool.contains(timeline_key));
+  ORBIT_CHECK(string_intern_pool.contains(timeline_key));
   std::string timeline = string_intern_pool.at(timeline_key);
 
   std::optional<GpuCommandBuffer> first_command_buffer =
@@ -195,17 +195,17 @@ bool GpuQueueSubmissionProcessor::HasUnprocessedBeginMarkers(
           post_submission_timestamp)) {
     return false;
   }
-  CHECK(tid_to_post_submission_time_to_num_begin_markers_.at(thread_id).at(
-            post_submission_timestamp) > 0);
+  ORBIT_CHECK(tid_to_post_submission_time_to_num_begin_markers_.at(thread_id).at(
+                  post_submission_timestamp) > 0);
   return true;
 }
 
 void GpuQueueSubmissionProcessor::DecrementUnprocessedBeginMarkers(
     uint32_t thread_id, uint64_t submission_timestamp, uint64_t post_submission_timestamp) {
-  CHECK(tid_to_post_submission_time_to_num_begin_markers_.contains(thread_id));
+  ORBIT_CHECK(tid_to_post_submission_time_to_num_begin_markers_.contains(thread_id));
   auto& post_submission_time_to_num_begin_markers =
       tid_to_post_submission_time_to_num_begin_markers_.at(thread_id);
-  CHECK(post_submission_time_to_num_begin_markers.contains(post_submission_timestamp));
+  ORBIT_CHECK(post_submission_time_to_num_begin_markers.contains(post_submission_timestamp));
   uint64_t new_num = post_submission_time_to_num_begin_markers.at(post_submission_timestamp) - 1;
   post_submission_time_to_num_begin_markers.at(post_submission_timestamp) = new_num;
   if (new_num == 0) {
@@ -261,7 +261,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuCommandBuffers(
 
   for (const auto& submit_info : gpu_queue_submission.submit_infos()) {
     for (const auto& command_buffer : submit_info.command_buffers()) {
-      CHECK(first_command_buffer != std::nullopt);
+      ORBIT_CHECK(first_command_buffer != std::nullopt);
       TimerInfo command_buffer_timer;
       if (command_buffer.begin_gpu_timestamp_ns() != 0) {
         command_buffer_timer.set_start(command_buffer.begin_gpu_timestamp_ns() -
@@ -319,7 +319,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
       begin_markers_to_decrement;
 
   for (const auto& completed_marker : gpu_queue_submission.completed_markers()) {
-    CHECK(first_command_buffer != std::nullopt);
+    ORBIT_CHECK(first_command_buffer != std::nullopt);
     TimerInfo marker_timer;
 
     // If we've recorded the submission that contains the begin marker, we'll retrieve this
@@ -354,13 +354,13 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
         // contains no command buffer timers). If we don't have a matching submission for the
         // "begin" marker, we have to discard the entire marker.
         if (matching_begin_submission == nullptr) {
-          ERROR("Discarding debug marker timer.");
+          ORBIT_ERROR("Discarding debug marker timer.");
           continue;
         }
         begin_submission_first_command_buffer =
             ExtractFirstCommandBuffer(*matching_begin_submission);
       }
-      CHECK(begin_submission_first_command_buffer.has_value());
+      ORBIT_CHECK(begin_submission_first_command_buffer.has_value());
 
       const GpuJob* matching_begin_job = FindMatchingGpuJob(
           begin_marker_thread_id, begin_marker_meta_info.pre_submission_cpu_timestamp(),
@@ -419,7 +419,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
 
     // We have special handling for DXVK instrumentation that have an encoded group_id in their
     // label.
-    CHECK(string_intern_pool.contains(text_key));
+    ORBIT_CHECK(string_intern_pool.contains(text_key));
     const std::string& text = string_intern_pool.at(text_key);
     uint64_t group_id = 0;
     if (TryExtractDXVKVulkanGroupIdFromDebugLabel(text, &group_id)) {

--- a/src/CaptureClient/SaveToFileEventProcessor.cpp
+++ b/src/CaptureClient/SaveToFileEventProcessor.cpp
@@ -62,7 +62,7 @@ void SaveToFileEventProcessor::ReportError(const ErrorMessage& error) {
 }
 
 void SaveToFileEventProcessor::ProcessEvent(const ClientCaptureEvent& event) {
-  CHECK(output_stream_ != nullptr);
+  ORBIT_CHECK(output_stream_ != nullptr);
 
   if (state_ == State::kCaptureFinished) {
     ReportError(ErrorMessage{"Unexpected event after CaptureFinished event"});
@@ -71,7 +71,7 @@ void SaveToFileEventProcessor::ProcessEvent(const ClientCaptureEvent& event) {
 
   if (state_ == State::kErrorReported) return;
 
-  CHECK(output_stream_->IsOpen());
+  ORBIT_CHECK(output_stream_->IsOpen());
 
   auto write_result = output_stream_->WriteCaptureEvent(event);
   if (write_result.has_error()) {

--- a/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
+++ b/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
@@ -43,7 +43,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
   void ShutdownAndWait() final {
     shutdown_requested_ = true;
 
-    CHECK(forwarder_thread_.joinable());
+    ORBIT_CHECK(forwarder_thread_.joinable());
     forwarder_thread_.join();
 
     CaptureEventProducer::ShutdownAndWait();
@@ -147,7 +147,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
           }
 
           if (!SendCaptureEvents(*send_request)) {
-            ERROR("Forwarding %lu CaptureEvents", dequeued_event_count);
+            ORBIT_ERROR("Forwarding %lu CaptureEvents", dequeued_event_count);
             break;
           }
         }
@@ -156,7 +156,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
           // lock_free_queue_ is now empty and status_ == kShouldNotifyAllEventsSent,
           // send AllEventsSent. status_ has already been changed to kShouldDropEvents.
           if (!NotifyAllEventsSent()) {
-            ERROR("Notifying that all CaptureEvents have been sent");
+            ORBIT_ERROR("Notifying that all CaptureEvents have been sent");
           }
           break;
         }

--- a/src/CaptureFile/BufferOutputStream.cpp
+++ b/src/CaptureFile/BufferOutputStream.cpp
@@ -12,13 +12,13 @@
 namespace orbit_capture_file {
 
 bool BufferOutputStream::Write(const void* data, int size) {
-  CHECK(data != nullptr);
-  CHECK(size >= 0);
+  ORBIT_CHECK(data != nullptr);
+  ORBIT_CHECK(size >= 0);
   absl::MutexLock lock{&mutex_};
 
   size_t old_size = buffer_.size();
   size_t new_size = old_size + size;
-  CHECK(new_size > old_size);
+  ORBIT_CHECK(new_size > old_size);
 
   buffer_.resize(new_size);
   std::memcpy(buffer_.data() + old_size, data, size);

--- a/src/CaptureFile/CaptureFile.cpp
+++ b/src/CaptureFile/CaptureFile.cpp
@@ -116,7 +116,7 @@ ErrorMessageOr<void> CaptureFileImpl::CalculateCaptureSectionSize() {
   // Otherwise it ends at the start of the next section or at the section list
   uint64_t min_section_offset = std::numeric_limits<uint64_t>::max();
 
-  CHECK(!section_list_.empty());
+  ORBIT_CHECK(!section_list_.empty());
 
   for (const auto& section : section_list_) {
     if (section.offset < min_section_offset) {
@@ -128,7 +128,7 @@ ErrorMessageOr<void> CaptureFileImpl::CalculateCaptureSectionSize() {
     min_section_offset = std::min(min_section_offset, header_.section_list_offset);
   }
 
-  CHECK(min_section_offset < std::numeric_limits<uint64_t>::max());
+  ORBIT_CHECK(min_section_offset < std::numeric_limits<uint64_t>::max());
 
   capture_section_size_ = min_section_offset - header_.capture_section_offset;
 
@@ -183,10 +183,10 @@ ErrorMessageOr<void> CaptureFileImpl::ReadHeader() {
 ErrorMessageOr<void> CaptureFileImpl::WriteToSection(uint64_t section_number,
                                                      uint64_t offset_in_section, const void* data,
                                                      size_t size) {
-  CHECK(section_number < section_list_.size());
+  ORBIT_CHECK(section_number < section_list_.size());
 
   const CaptureFileSection& section = section_list_[section_number];
-  CHECK(offset_in_section + size <= section.size);
+  ORBIT_CHECK(offset_in_section + size <= section.size);
 
   OUTCOME_TRY(orbit_base::WriteFullyAtOffset(fd_, data, size, section.offset + offset_in_section));
 
@@ -222,7 +222,7 @@ ErrorMessageOr<uint64_t> CaptureFileImpl::AddUserDataSection(uint64_t section_si
   // If we don't have any additional sections or if there are any sections starting after
   // section_list move section list to the end of the file.
   if (header_.section_list_offset == 0 || IsThereSectionWithOffsetAfterSectionList()) {
-    CHECK(section_list.empty());
+    ORBIT_CHECK(section_list.empty());
     OUTCOME_TRY(auto&& end_of_file, GetEndOfFileOffset(fd_));
     section_list_offset = orbit_base::AlignUp<8>(end_of_file);
   }
@@ -260,10 +260,10 @@ ErrorMessageOr<uint64_t> CaptureFileImpl::AddUserDataSection(uint64_t section_si
 ErrorMessageOr<void> CaptureFileImpl::ReadFromSection(uint64_t section_number,
                                                       uint64_t offset_in_section, void* data,
                                                       size_t size) {
-  CHECK(section_number < section_list_.size());
+  ORBIT_CHECK(section_number < section_list_.size());
 
   const CaptureFileSection& section = section_list_[section_number];
-  CHECK(offset_in_section + size <= section.size);
+  ORBIT_CHECK(offset_in_section + size <= section.size);
 
   OUTCOME_TRY(auto&& bytes_read,
               orbit_base::ReadFullyAtOffset(fd_, data, size, section.offset + offset_in_section));
@@ -287,7 +287,7 @@ std::unique_ptr<ProtoSectionInputStream> CaptureFileImpl::CreateCaptureSectionIn
 
 std::unique_ptr<ProtoSectionInputStream> CaptureFileImpl::CreateProtoSectionInputStream(
     uint64_t section_number) {
-  CHECK(section_number < section_list_.size());
+  ORBIT_CHECK(section_number < section_list_.size());
   const auto& section_info = section_list_[section_number];
 
   return std::make_unique<orbit_capture_file_internal::ProtoSectionInputStreamImpl>(
@@ -309,7 +309,7 @@ const std::filesystem::path& CaptureFileImpl::GetFilePath() const { return file_
 ErrorMessageOr<void> orbit_capture_file::CaptureFileImpl::ExtendSection(uint64_t section_number,
                                                                         size_t new_size) {
   // Currently we do it only for last section of the file.
-  CHECK(section_number < section_list_.size());
+  ORBIT_CHECK(section_number < section_list_.size());
 
   const CaptureFileSection& section = section_list_[section_number];
   if (section.size >= new_size) {

--- a/src/CaptureFile/CaptureFileHelpers.cpp
+++ b/src/CaptureFile/CaptureFileHelpers.cpp
@@ -24,7 +24,7 @@ ErrorMessageOr<void> WriteUserData(
   google::protobuf::io::CodedOutputStream coded_output_stream{&array_output_stream};
   coded_output_stream.WriteVarint32(message_size);
   // We do not expect any errors from CodedOutputStream backed by ArrayOutputStream of correct size
-  CHECK(user_defined_capture_info.SerializeToCodedStream(&coded_output_stream));
+  ORBIT_CHECK(user_defined_capture_info.SerializeToCodedStream(&coded_output_stream));
 
   auto section_index = capture_file->FindSectionByType(kSectionTypeUserData);
   if (section_index.has_value()) {

--- a/src/CaptureFile/FileFragmentInputStream.cpp
+++ b/src/CaptureFile/FileFragmentInputStream.cpp
@@ -9,8 +9,8 @@ namespace orbit_capture_file_internal {
 using orbit_base::ReadFullyAtOffset;
 
 bool FileFragmentInputStream::Next(const void** data, int* size) {
-  CHECK(data != nullptr);
-  CHECK(size != nullptr);
+  ORBIT_CHECK(data != nullptr);
+  ORBIT_CHECK(size != nullptr);
 
   if (last_error_.has_value()) return false;
 
@@ -38,7 +38,7 @@ bool FileFragmentInputStream::Next(const void** data, int* size) {
 }
 
 void FileFragmentInputStream::BackUp(int count) {
-  CHECK(count >= 0);
+  ORBIT_CHECK(count >= 0);
   if (static_cast<size_t>(count) > current_position_) {
     current_position_ = file_fragments_start_;
     return;
@@ -48,7 +48,7 @@ void FileFragmentInputStream::BackUp(int count) {
 }
 
 bool FileFragmentInputStream::Skip(int count) {
-  CHECK(count >= 0);
+  ORBIT_CHECK(count >= 0);
 
   if (last_error_.has_value()) return false;
 

--- a/src/CaptureFile/FileFragmentInputStream.h
+++ b/src/CaptureFile/FileFragmentInputStream.h
@@ -27,7 +27,7 @@ class FileFragmentInputStream : public google::protobuf::io::ZeroCopyInputStream
         file_fragments_end_{file_offset + size},
         buffer_(block_size),
         current_position_{file_offset} {
-    CHECK(size > 0);
+    ORBIT_CHECK(size > 0);
   }
 
   // Obtains a chunk of data from the stream.

--- a/src/CaptureFileInfo/ItemModel.cpp
+++ b/src/CaptureFileInfo/ItemModel.cpp
@@ -33,10 +33,10 @@ int ItemModel::rowCount(const QModelIndex& parent) const {
 }
 
 QVariant ItemModel::data(const QModelIndex& idx, int role) const {
-  CHECK(idx.isValid());
-  CHECK(idx.model() == this);
-  CHECK(idx.row() >= 0 && idx.row() < static_cast<int>(capture_files_.size()));
-  CHECK(idx.column() >= 0 && idx.column() < static_cast<int>(Column::kEnd));
+  ORBIT_CHECK(idx.isValid());
+  ORBIT_CHECK(idx.model() == this);
+  ORBIT_CHECK(idx.row() >= 0 && idx.row() < static_cast<int>(capture_files_.size()));
+  ORBIT_CHECK(idx.column() >= 0 && idx.column() < static_cast<int>(Column::kEnd));
 
   const CaptureFileInfo& capture_file_info = capture_files_.at(idx.row());
 
@@ -53,7 +53,7 @@ QVariant ItemModel::data(const QModelIndex& idx, int role) const {
       case Column::kCreated:
         return capture_file_info.Created();
       case Column::kEnd:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
 
@@ -80,9 +80,9 @@ QVariant ItemModel::headerData(int section, Qt::Orientation orientation, int rol
     case Column::kCreated:
       return "Created";
     case Column::kEnd:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 
 }  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/LoadCaptureWidget.cpp
+++ b/src/CaptureFileInfo/LoadCaptureWidget.cpp
@@ -77,7 +77,7 @@ LoadCaptureWidget::LoadCaptureWidget(QWidget* parent)
                      // column. The column does not matter, so column 0 is used.
                      const QModelIndex index = selected.indexes().at(0);
 
-                     CHECK(index.data(Qt::UserRole).canConvert<QString>());
+                     ORBIT_CHECK(index.data(Qt::UserRole).canConvert<QString>());
 
                      emit FileSelected(index.data(Qt::UserRole).value<QString>().toStdString());
                    });

--- a/src/CaptureService/CaptureService.cpp
+++ b/src/CaptureService/CaptureService.cpp
@@ -29,12 +29,12 @@ CaptureService::CaptureService() {
 
 void CaptureService::AddCaptureStartStopListener(CaptureStartStopListener* listener) {
   bool new_insertion = capture_start_stop_listeners_.insert(listener).second;
-  CHECK(new_insertion);
+  ORBIT_CHECK(new_insertion);
 }
 
 void CaptureService::RemoveCaptureStartStopListener(CaptureStartStopListener* listener) {
   bool was_removed = capture_start_stop_listeners_.erase(listener) > 0;
-  CHECK(was_removed);
+  ORBIT_CHECK(was_removed);
 }
 
 grpc::Status CaptureService::InitializeCapture(
@@ -73,7 +73,7 @@ CaptureRequest CaptureService::WaitForStartCaptureRequestFromClient(
   // This call is blocking.
   reader_writer->Read(&request);
 
-  LOG("Read CaptureRequest from Capture's gRPC stream: starting capture");
+  ORBIT_LOG("Read CaptureRequest from Capture's gRPC stream: starting capture");
   return request;
 }
 
@@ -85,7 +85,7 @@ void CaptureService::WaitForStopCaptureRequestFromClient(
   // to Read will return false. In the meantime, it blocks if no message is received.
   while (reader_writer->Read(&request)) {
   }
-  LOG("Client finished writing on Capture's gRPC stream: stopping capture");
+  ORBIT_LOG("Client finished writing on Capture's gRPC stream: stopping capture");
 }
 
 void CaptureService::StartEventProcessing(const CaptureOptions& capture_options) {
@@ -117,7 +117,7 @@ void CaptureService::FinalizeEventProcessing(StopCaptureReason stop_capture_reas
                                           std::move(capture_finished));
 
   grpc_client_capture_event_collector_->StopAndWait();
-  LOG("Finished handling gRPC call to Capture: all capture data has been sent");
+  ORBIT_LOG("Finished handling gRPC call to Capture: all capture data has been sent");
 }
 
 }  // namespace orbit_capture_service

--- a/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureService/CommonProducerCaptureEventBuilders.cpp
@@ -66,11 +66,11 @@ ProducerCaptureEvent CreateCaptureStartedEvent(const CaptureOptions& capture_opt
     if (build_id_or_error.has_value()) {
       capture_started->set_executable_build_id(build_id_or_error.value());
     } else {
-      ERROR("Unable to find build id for module \"%s\": %s", executable_path.string(),
-            build_id_or_error.error().message());
+      ORBIT_ERROR("Unable to find build id for module \"%s\": %s", executable_path.string(),
+                  build_id_or_error.error().message());
     }
   } else {
-    ERROR("%s", executable_path_or_error.error().message());
+    ORBIT_ERROR("%s", executable_path_or_error.error().message());
   }
 
   capture_started->set_capture_start_unix_time_ns(absl::ToUnixNanos(capture_start_time));

--- a/src/ClientData/CallstackData.cpp
+++ b/src/ClientData/CallstackData.cpp
@@ -21,7 +21,7 @@ namespace orbit_client_data {
 
 void CallstackData::AddCallstackEvent(CallstackEvent callstack_event) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  CHECK(unique_callstacks_.contains(callstack_event.callstack_id()));
+  ORBIT_CHECK(unique_callstacks_.contains(callstack_event.callstack_id()));
   RegisterTime(callstack_event.time());
   callstack_events_by_tid_[callstack_event.thread_id()][callstack_event.time()] =
       std::move(callstack_event);
@@ -111,7 +111,7 @@ void CallstackData::ForEachCallstackEventInTimeRange(
     uint64_t min_timestamp, uint64_t max_timestamp,
     const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  CHECK(min_timestamp <= max_timestamp);
+  ORBIT_CHECK(min_timestamp <= max_timestamp);
   for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
     for (auto event_it = events.lower_bound(min_timestamp);
          event_it != events.upper_bound(max_timestamp); ++event_it) {
@@ -124,7 +124,7 @@ void CallstackData::ForEachCallstackEventOfTidInTimeRange(
     uint32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
     const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  CHECK(min_timestamp <= max_timestamp);
+  ORBIT_CHECK(min_timestamp <= max_timestamp);
   const auto& tid_and_events_it = callstack_events_by_tid_.find(tid);
   if (tid_and_events_it == callstack_events_by_tid_.end()) {
     return;
@@ -201,14 +201,14 @@ void CallstackData::UpdateCallstackTypeBasedOnMajorityStart() {
     absl::flat_hash_map<uint64_t, uint64_t> count_by_outer_frame;
     for (const auto& [unused_timestamp_ns, event] : timestamps_and_callstack_events) {
       const CallstackInfo& callstack = *unique_callstacks_.at(event.callstack_id());
-      CHECK(callstack.type() != CallstackInfo::kFilteredByMajorityOutermostFrame);
+      ORBIT_CHECK(callstack.type() != CallstackInfo::kFilteredByMajorityOutermostFrame);
       if (callstack.type() != CallstackInfo::kComplete) {
         continue;
       }
       ++count_for_this_thread;
 
       const auto& frames = callstack.frames();
-      CHECK(!frames.empty());
+      ORBIT_CHECK(!frames.empty());
       uint64_t outer_frame = *frames.rbegin();
       ++count_by_outer_frame[outer_frame];
     }
@@ -220,7 +220,7 @@ void CallstackData::UpdateCallstackTypeBasedOnMajorityStart() {
     uint64_t majority_outer_frame = 0;
     uint64_t majority_outer_frame_count = 0;
     for (const auto& outer_frame_and_count : count_by_outer_frame) {
-      CHECK(outer_frame_and_count.second > 0);
+      ORBIT_CHECK(outer_frame_and_count.second > 0);
       if (outer_frame_and_count.second > majority_outer_frame_count) {
         majority_outer_frame = outer_frame_and_count.first;
         majority_outer_frame_count = outer_frame_and_count.second;
@@ -231,7 +231,8 @@ void CallstackData::UpdateCallstackTypeBasedOnMajorityStart() {
     // to agree on the "correct" outermost frame.
     static constexpr double kFilterSupermajorityThreshold = 0.75;
     if (majority_outer_frame_count < count_for_this_thread * kFilterSupermajorityThreshold) {
-      LOG("Skipping filtering CallstackEvents for tid %d: majority outer frame has only %lu "
+      ORBIT_LOG(
+          "Skipping filtering CallstackEvents for tid %d: majority outer frame has only %lu "
           "occurrences out of %lu",
           tid, majority_outer_frame_count, count_for_this_thread);
       continue;
@@ -243,13 +244,13 @@ void CallstackData::UpdateCallstackTypeBasedOnMajorityStart() {
     // CallstackEvent will also be affected.
     for (const auto& [unused_timestamp_ns, event] : timestamps_and_callstack_events) {
       const CallstackInfo& callstack = *unique_callstacks_.at(event.callstack_id());
-      CHECK(callstack.type() != CallstackInfo::kFilteredByMajorityOutermostFrame);
+      ORBIT_CHECK(callstack.type() != CallstackInfo::kFilteredByMajorityOutermostFrame);
       if (callstack.type() != CallstackInfo::kComplete) {
         continue;
       }
 
       const auto& frames = unique_callstacks_.at(event.callstack_id())->frames();
-      CHECK(!frames.empty());
+      ORBIT_CHECK(!frames.empty());
       if (*frames.rbegin() != majority_outer_frame) {
         callstack_ids_to_filter.insert(event.callstack_id());
       }
@@ -259,7 +260,7 @@ void CallstackData::UpdateCallstackTypeBasedOnMajorityStart() {
   // Change the type of the recorded CallstackInfos.
   for (uint64_t callstack_id_to_filter : callstack_ids_to_filter) {
     CallstackInfo* callstack = unique_callstacks_.at(callstack_id_to_filter).get();
-    CHECK(callstack->type() == CallstackInfo::kComplete);
+    ORBIT_CHECK(callstack->type() == CallstackInfo::kComplete);
     callstack->set_type(CallstackInfo::kFilteredByMajorityOutermostFrame);
   }
 
@@ -275,7 +276,8 @@ void CallstackData::UpdateCallstackTypeBasedOnMajorityStart() {
   }
 
   uint32_t callstack_event_count = GetCallstackEventsCount();
-  LOG("Filtered %u CallstackInfos of %u (%.2f%%), affecting %u CallstackEvents of %u (%.2f%%)",
+  ORBIT_LOG(
+      "Filtered %u CallstackInfos of %u (%.2f%%), affecting %u CallstackEvents of %u (%.2f%%)",
       callstack_ids_to_filter.size(), unique_callstacks_.size(),
       100.0f * callstack_ids_to_filter.size() / unique_callstacks_.size(), affected_event_count,
       callstack_event_count, 100.0f * affected_event_count / callstack_event_count);

--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -121,7 +121,7 @@ void CaptureData::OnCaptureComplete() {
 
   for (const orbit_client_data::TimerChain* chain :
        thread_track_data_provider_->GetAllThreadTimerChains()) {
-    CHECK(chain);
+    ORBIT_CHECK(chain);
     for (const orbit_client_data::TimerBlock& block : *chain) {
       for (uint64_t i = 0; i < block.size(); i++) {
         const orbit_client_protos::TimerInfo& timer_info = block[i];
@@ -333,9 +333,9 @@ std::string CaptureData::process_name() const { return process_.name(); }
 void CaptureData::EnableFrameTrack(uint64_t instrumented_function_id) {
   if (frame_track_function_ids_.contains(instrumented_function_id)) {
     const auto* function = GetInstrumentedFunctionById(instrumented_function_id);
-    CHECK(function != nullptr);
-    LOG("Warning: Frame track for instrumented function \"%s\" is already enabled",
-        function->function_name());
+    ORBIT_CHECK(function != nullptr);
+    ORBIT_LOG("Warning: Frame track for instrumented function \"%s\" is already enabled",
+              function->function_name());
     return;
   }
   frame_track_function_ids_.insert(instrumented_function_id);

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -20,7 +20,7 @@ using orbit_grpc_protos::TracepointInfo;
 namespace orbit_client_data {
 
 void DataManager::SelectFunction(const FunctionInfo& function) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   if (!selected_functions_.contains(function) &&
       orbit_client_data::function_utils::IsFunctionSelectable(function)) {
     selected_functions_.insert(function);
@@ -28,72 +28,72 @@ void DataManager::SelectFunction(const FunctionInfo& function) {
 }
 
 void DataManager::DeselectFunction(const FunctionInfo& function) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_functions_.erase(function);
 }
 
 void DataManager::set_visible_function_ids(absl::flat_hash_set<uint64_t> visible_function_ids) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   visible_function_ids_ = std::move(visible_function_ids);
 }
 
 void DataManager::set_highlighted_function_id(uint64_t highlighted_function_id) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   highlighted_function_id_ = highlighted_function_id;
 }
 
 void DataManager::set_highlighted_group_id(uint64_t highlighted_group_id) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   highlighted_function_id_ = highlighted_group_id;
 }
 
 void DataManager::set_selected_thread_id(uint32_t thread_id) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_thread_id_ = thread_id;
 }
 
 bool DataManager::IsFunctionVisible(uint64_t function_id) const {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return visible_function_ids_.contains(function_id);
 }
 
 uint64_t DataManager::highlighted_function_id() const {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return highlighted_function_id_;
 }
 
 uint64_t DataManager::highlighted_group_id() const {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return highlighted_group_id_;
 }
 
 int32_t DataManager::selected_thread_id() const {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_thread_id_;
 }
 
 const orbit_client_protos::TimerInfo* DataManager::selected_timer() const {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_timer_;
 }
 
 void DataManager::set_selected_timer(const orbit_client_protos::TimerInfo* timer_info) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_timer_ = timer_info;
 }
 
 void DataManager::ClearSelectedFunctions() {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_functions_.clear();
 }
 
 bool DataManager::IsFunctionSelected(const FunctionInfo& function) const {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_functions_.contains(function);
 }
 
 std::vector<FunctionInfo> DataManager::GetSelectedFunctions() const {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return std::vector<FunctionInfo>(selected_functions_.begin(), selected_functions_.end());
 }
 
@@ -102,13 +102,13 @@ void DataManager::SelectTracepoint(const TracepointInfo& info) {
 }
 
 void DataManager::DeselectTracepoint(const TracepointInfo& info) {
-  CHECK(IsTracepointSelected(info));
+  ORBIT_CHECK(IsTracepointSelected(info));
   selected_tracepoints_.erase(info);
 }
 
 void DataManager::SelectCallstackEvents(
     const std::vector<orbit_client_protos::CallstackEvent>& selected_callstack_events) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_callstack_events_by_thread_id_.clear();
 
   for (auto& event : selected_callstack_events) {
@@ -119,7 +119,7 @@ void DataManager::SelectCallstackEvents(
 
 const std::vector<orbit_client_protos::CallstackEvent>& DataManager::GetSelectedCallstackEvents(
     uint32_t thread_id) {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_callstack_events_by_thread_id_[thread_id];
 }
 

--- a/src/ClientData/FunctionUtils.cpp
+++ b/src/ClientData/FunctionUtils.cpp
@@ -48,7 +48,7 @@ std::optional<uint64_t> GetAbsoluteAddress(const orbit_client_protos::FunctionIn
   }
 
   if (page_aligned_base_addresses.size() > 1) {
-    ERROR(
+    ORBIT_ERROR(
         "Found multiple mappings for \"%s\" with build_id=%s [%s]: "
         "will use the first one as a base address",
         module.file_path(), module.build_id(),
@@ -57,7 +57,7 @@ std::optional<uint64_t> GetAbsoluteAddress(const orbit_client_protos::FunctionIn
         }));
   }
 
-  CHECK(!page_aligned_base_addresses.empty());
+  ORBIT_CHECK(!page_aligned_base_addresses.empty());
 
   return orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
       func.address(), page_aligned_base_addresses.at(0), module.load_bias(),

--- a/src/ClientData/ModuleData.cpp
+++ b/src/ClientData/ModuleData.cpp
@@ -32,24 +32,24 @@ bool ModuleData::NeedsUpdate(const orbit_grpc_protos::ModuleInfo& info) const {
 bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo info) {
   absl::MutexLock lock(&mutex_);
 
-  CHECK(file_path() == info.file_path());
-  CHECK(build_id() == info.build_id());
-  CHECK(object_file_type() == info.object_file_type());
+  ORBIT_CHECK(file_path() == info.file_path());
+  ORBIT_CHECK(build_id() == info.build_id());
+  ORBIT_CHECK(object_file_type() == info.object_file_type());
 
   if (!NeedsUpdate(info)) return false;
 
   // The update only makes sense if build_id is empty.
-  CHECK(build_id().empty());
+  ORBIT_CHECK(build_id().empty());
 
   module_info_ = std::move(info);
 
-  LOG("WARNING: Module \"%s\" changed and will to be updated (it does not have build_id).",
-      file_path());
+  ORBIT_LOG("WARNING: Module \"%s\" changed and will to be updated (it does not have build_id).",
+            file_path());
 
   if (!is_loaded_) return false;
 
-  LOG("Module %s contained symbols. Because the module changed, those are now removed.",
-      file_path());
+  ORBIT_LOG("Module %s contained symbols. Because the module changed, those are now removed.",
+            file_path());
   functions_.clear();
   hash_to_function_map_.clear();
   is_loaded_ = false;
@@ -60,14 +60,14 @@ bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo info) {
 bool ModuleData::UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo info) {
   absl::MutexLock lock(&mutex_);
 
-  CHECK(file_path() == info.file_path());
-  CHECK(build_id() == info.build_id());
-  CHECK(object_file_type() == info.object_file_type());
+  ORBIT_CHECK(file_path() == info.file_path());
+  ORBIT_CHECK(build_id() == info.build_id());
+  ORBIT_CHECK(object_file_type() == info.object_file_type());
 
   if (!NeedsUpdate(info)) return true;
 
   // The update only makes sense if build_id is empty.
-  CHECK(build_id().empty());
+  ORBIT_CHECK(build_id().empty());
 
   if (is_loaded_) return false;
 
@@ -96,7 +96,7 @@ const FunctionInfo* ModuleData::FindFunctionByElfAddress(uint64_t elf_address,
 
   --it;
   FunctionInfo* function = it->second.get();
-  CHECK(function->address() <= elf_address);
+  ORBIT_CHECK(function->address() <= elf_address);
 
   if (function->address() + function->size() < elf_address) return nullptr;
 
@@ -105,7 +105,7 @@ const FunctionInfo* ModuleData::FindFunctionByElfAddress(uint64_t elf_address,
 
 void ModuleData::AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols) {
   absl::MutexLock lock(&mutex_);
-  CHECK(!is_loaded_);
+  ORBIT_CHECK(!is_loaded_);
 
   uint32_t address_reuse_counter = 0;
   uint32_t name_reuse_counter = 0;
@@ -122,7 +122,7 @@ void ModuleData::AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbo
     // __cxxabiv1::__class_type_info::~__class_type_info()
     // __cxxabiv1::__pbase_type_info::~__pbase_type_info()
     if (success_functions) {
-      CHECK(!function->pretty_name().empty());
+      ORBIT_CHECK(!function->pretty_name().empty());
       // Be careful about the scope, the key is a string_view. This is done to avoid name
       // duplication.
       bool success_function_name =
@@ -137,10 +137,12 @@ void ModuleData::AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbo
     }
   }
   if (address_reuse_counter != 0) {
-    LOG("Warning: %d absolute addresses are used by more than one symbol", address_reuse_counter);
+    ORBIT_LOG("Warning: %d absolute addresses are used by more than one symbol",
+              address_reuse_counter);
   }
   if (name_reuse_counter != 0) {
-    LOG("Warning: %d function name collisions happened (functions with the same demangled name). "
+    ORBIT_LOG(
+        "Warning: %d function name collisions happened (functions with the same demangled name). "
         "This is currently not supported by presets, since the presets are based on the demangled "
         "name.",
         name_reuse_counter);

--- a/src/ClientData/ModuleManager.cpp
+++ b/src/ClientData/ModuleManager.cpp
@@ -33,7 +33,7 @@ std::vector<ModuleData*> ModuleManager::AddOrUpdateModules(
     auto module_it = module_map_.find(module_id);
     if (module_it == module_map_.end()) {
       const bool success = module_map_.try_emplace(module_id, module_info).second;
-      CHECK(success);
+      ORBIT_CHECK(success);
     } else {
       ModuleData& module = module_it->second;
       if (module.UpdateIfChangedAndUnload(module_info)) {
@@ -56,7 +56,7 @@ std::vector<ModuleData*> ModuleManager::AddOrUpdateNotLoadedModules(
     auto module_it = module_map_.find(module_id);
     if (module_it == module_map_.end()) {
       const bool success = module_map_.try_emplace(module_id, module_info).second;
-      CHECK(success);
+      ORBIT_CHECK(success);
     } else {
       ModuleData& module = module_it->second;
       if (!module.UpdateIfChangedAndNotLoaded(module_info)) {

--- a/src/ClientData/PostProcessedSamplingData.cpp
+++ b/src/ClientData/PostProcessedSamplingData.cpp
@@ -26,9 +26,9 @@ uint32_t ThreadSampleData::GetCountForAddress(uint64_t address) const {
 const orbit_client_protos::CallstackInfo& PostProcessedSamplingData::GetResolvedCallstack(
     uint64_t sampled_callstack_id) const {
   auto resolved_callstack_id_it = original_id_to_resolved_callstack_id_.find(sampled_callstack_id);
-  CHECK(resolved_callstack_id_it != original_id_to_resolved_callstack_id_.end());
+  ORBIT_CHECK(resolved_callstack_id_it != original_id_to_resolved_callstack_id_.end());
   auto resolved_callstack_it = id_to_resolved_callstack_.find(resolved_callstack_id_it->second);
-  CHECK(resolved_callstack_it != id_to_resolved_callstack_.end());
+  ORBIT_CHECK(resolved_callstack_it != id_to_resolved_callstack_.end());
   return resolved_callstack_it->second;
 }
 
@@ -118,7 +118,7 @@ uint32_t PostProcessedSamplingData::GetCountOfFunction(uint64_t function_address
 
   uint32_t result = 0;
   for (const auto& [tid, thread_sample_data] : thread_id_to_sample_data_) {
-    CHECK(tid != orbit_base::kAllProcessThreadsTid);  // Because GetSummary() == nullptr
+    ORBIT_CHECK(tid != orbit_base::kAllProcessThreadsTid);  // Because GetSummary() == nullptr
 
     auto count_it = thread_sample_data.resolved_address_to_count.find(function_address);
     if (count_it != thread_sample_data.resolved_address_to_count.end()) {

--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -79,12 +79,12 @@ void ProcessData::UpdateModuleInfos(absl::Span<const ModuleInfo> module_infos) {
     const auto [unused_it, success] = start_address_to_module_in_memory_.try_emplace(
         module_info.address_start(), module_info.address_start(), module_info.address_end(),
         module_info.file_path(), module_info.build_id());
-    CHECK(success);
+    ORBIT_CHECK(success);
   }
 
   // Files saved with Orbit 1.65 may have intersecting maps, this is why we use DCHECK here
   // instead of CHECK
-  DCHECK(IsModuleMapValid(start_address_to_module_in_memory_));
+  ORBIT_DCHECK(IsModuleMapValid(start_address_to_module_in_memory_));
 }
 
 std::vector<std::string> ProcessData::FindModuleBuildIdsByPath(
@@ -124,7 +124,7 @@ void ProcessData::AddOrUpdateModuleInfo(const ModuleInfo& module_info) {
   start_address_to_module_in_memory_.insert_or_assign(module_info.address_start(),
                                                       module_in_memory);
 
-  CHECK(IsModuleMapValid(start_address_to_module_in_memory_));
+  ORBIT_CHECK(IsModuleMapValid(start_address_to_module_in_memory_));
 }
 
 ErrorMessageOr<ModuleInMemory> ProcessData::FindModuleByAddress(uint64_t absolute_address) const {
@@ -144,7 +144,7 @@ ErrorMessageOr<ModuleInMemory> ProcessData::FindModuleByAddress(uint64_t absolut
 
   --it;
   const ModuleInMemory& module_in_memory = it->second;
-  CHECK(absolute_address >= module_in_memory.start());
+  ORBIT_CHECK(absolute_address >= module_in_memory.start());
   if (absolute_address >= module_in_memory.end()) return not_found_error;
 
   return module_in_memory;

--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -24,7 +24,7 @@ void ScopeTreeTimerData::OnCaptureComplete() {
 
   std::vector<const TimerChain*> timer_chains = timer_data_.GetChains();
   for (const TimerChain* timer_chain : timer_chains) {
-    CHECK(timer_chain != nullptr);
+    ORBIT_CHECK(timer_chain != nullptr);
     absl::MutexLock lock(&scope_tree_mutex_);
     for (const auto& block : *timer_chain) {
       for (size_t k = 0; k < block.size(); ++k) {

--- a/src/ClientData/TimerData.cpp
+++ b/src/ClientData/TimerData.cpp
@@ -100,7 +100,7 @@ TimerChain* TimerData::GetOrCreateTimerChain(uint64_t depth) {
   }
 
   auto [inserted_it, inserted] = timers_.insert_or_assign(depth, std::make_unique<TimerChain>());
-  CHECK(inserted);
+  ORBIT_CHECK(inserted);
   return inserted_it->second.get();
 }
 

--- a/src/ClientData/TimerTrackDataIdManager.cpp
+++ b/src/ClientData/TimerTrackDataIdManager.cpp
@@ -36,7 +36,7 @@ uint32_t TimerTrackDataIdManager::GenerateTrackIdFromTimerInfo(const TimerInfo& 
     case TimerInfo::kPageFaults:
     case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MIN_SENTINEL_DO_NOT_USE_:
     case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MAX_SENTINEL_DO_NOT_USE_:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
   return -1;
 }

--- a/src/ClientData/TimestampIntervalSet.cpp
+++ b/src/ClientData/TimestampIntervalSet.cpp
@@ -11,14 +11,14 @@
 namespace orbit_client_data {
 
 void TimestampIntervalSet::Add(uint64_t start_inclusive, uint64_t end_exclusive) {
-  CHECK(start_inclusive < end_exclusive);
+  ORBIT_CHECK(start_inclusive < end_exclusive);
 
   uint64_t new_start = start_inclusive;
   auto it = intervals_.upper_bound(start_inclusive);
   if (it != intervals_.begin()) {
     // start_inclusive is not before the first interval.
     --it;
-    CHECK(start_inclusive >= it->start_inclusive());
+    ORBIT_CHECK(start_inclusive >= it->start_inclusive());
     if (start_inclusive <= it->end_exclusive() && end_exclusive <= it->end_exclusive()) {
       // The new interval is completely included in one of the existing intervals.
       return;

--- a/src/ClientData/TracepointData.cpp
+++ b/src/ClientData/TracepointData.cpp
@@ -23,7 +23,7 @@ void TracepointData::EmplaceTracepointEvent(uint64_t time, uint64_t tracepoint_h
 
   orbit_client_protos::TracepointEventInfo event;
   event.set_time(time);
-  CHECK(HasTracepointKey(tracepoint_hash));
+  ORBIT_CHECK(HasTracepointKey(tracepoint_hash));
   event.set_tracepoint_info_key(tracepoint_hash);
   event.set_tid(thread_id);
   event.set_pid(process_id);
@@ -37,7 +37,7 @@ void TracepointData::EmplaceTracepointEvent(uint64_t time, uint64_t tracepoint_h
   auto [unused_iterator, event_inserted] =
       event_map_iterator->second.try_emplace(time, std::move(event));
   if (!event_inserted) {
-    ERROR(
+    ORBIT_ERROR(
         "Tracepoint event was not inserted as there was already an event on this time and "
         "thread.");
   }

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -212,7 +212,7 @@ class CaptureData {
 
   [[nodiscard]] const orbit_client_data::PostProcessedSamplingData& post_processed_sampling_data()
       const {
-    CHECK(post_processed_sampling_data_.has_value());
+    ORBIT_CHECK(post_processed_sampling_data_.has_value());
     return post_processed_sampling_data_.value();
   }
 

--- a/src/ClientData/include/ClientData/TimerChain.h
+++ b/src/ClientData/include/ClientData/TimerChain.h
@@ -37,7 +37,7 @@ class TimerBlock {
   // Append a new element to the end of the block using placement-new.
   template <class... Args>
   const orbit_client_protos::TimerInfo& emplace_back(Args&&... args) {
-    CHECK(size() < kBlockSize);
+    ORBIT_CHECK(size() < kBlockSize);
     const orbit_client_protos::TimerInfo& timer_info =
         data_.emplace_back(std::forward<Args>(args)...);
     min_timestamp_ = std::min(timer_info.start(), min_timestamp_);
@@ -131,7 +131,7 @@ class TimerChain {
 
  private:
   void AllocateNewBlock() {
-    CHECK(current_->next_ == nullptr);
+    ORBIT_CHECK(current_->next_ == nullptr);
     current_->next_ = new TimerBlock(current_);
     current_ = current_->next_;
     ++num_blocks_;

--- a/src/ClientModel/SamplingDataPostProcessor.cpp
+++ b/src/ClientModel/SamplingDataPostProcessor.cpp
@@ -135,7 +135,7 @@ PostProcessedSamplingData SamplingDataPostProcessor::ProcessSamples(
   // Unique call stacks and per thread data
   callstack_data.ForEachCallstackEvent(
       [this, &callstack_data, generate_summary](const CallstackEvent& event) {
-        CHECK(callstack_data.HasCallstack(event.callstack_id()));
+        ORBIT_CHECK(callstack_data.HasCallstack(event.callstack_id()));
         const orbit_client_protos::CallstackInfo* callstack_info =
             callstack_data.GetCallstack(event.callstack_id());
 
@@ -143,7 +143,7 @@ PostProcessedSamplingData SamplingDataPostProcessor::ProcessSamples(
         // only one known to be correct. Note that, in the vast majority of cases, the innermost
         // frame is also the only one available.
         absl::flat_hash_set<uint64_t> unique_frames;
-        CHECK(!callstack_info->frames().empty());
+        ORBIT_CHECK(!callstack_info->frames().empty());
         if (callstack_info->type() == CallstackInfo::kComplete) {
           for (uint64_t frame : callstack_info->frames()) {
             unique_frames.insert(frame);
@@ -183,7 +183,7 @@ PostProcessedSamplingData SamplingDataPostProcessor::ProcessSamples(
       const CallstackInfo& resolved_callstack = id_to_resolved_callstack_[resolved_callstack_id];
 
       // "Exclusive" stat.
-      CHECK(!resolved_callstack.frames().empty());
+      ORBIT_CHECK(!resolved_callstack.frames().empty());
       thread_sample_data->resolved_address_to_exclusive_count[resolved_callstack.frames(0)] +=
           callstack_count;
 
@@ -255,7 +255,7 @@ void SamplingDataPostProcessor::ResolveCallstacks(const CallstackData& callstack
         MapAddressToFunctionAddress(address, capture_data);
       }
       auto function_address_it = exact_address_to_function_address_.find(address);
-      CHECK(function_address_it != exact_address_to_function_address_.end());
+      ORBIT_CHECK(function_address_it != exact_address_to_function_address_.end());
       resolved_callstack_frames.push_back(function_address_it->second);
     }
 
@@ -280,7 +280,7 @@ void SamplingDataPostProcessor::ResolveCallstacks(const CallstackData& callstack
         resolved_callstack_frames, resolved_callstack_type});
     if (it == resolved_callstack_to_id_.end()) {
       resolved_callstack_id = callstack_id;
-      CHECK(!id_to_resolved_callstack_.contains(resolved_callstack_id));
+      ORBIT_CHECK(!id_to_resolved_callstack_.contains(resolved_callstack_id));
 
       CallstackInfo resolved_callstack;
       *resolved_callstack.mutable_frames() = {resolved_callstack_frames.begin(),

--- a/src/ClientServices/CrashManager.cpp
+++ b/src/ClientServices/CrashManager.cpp
@@ -48,8 +48,8 @@ void CrashManagerImpl::CrashOrbitService(CrashOrbitServiceRequest_CrashType cras
   grpc::Status status = crash_service_->CrashOrbitService(&context, request, &response);
 
   if (status.error_code() != grpc::StatusCode::DEADLINE_EXCEEDED) {
-    ERROR("CrashOrbitService returned code %i with error message %s", status.error_code(),
-          status.error_message());
+    ORBIT_ERROR("CrashOrbitService returned code %i with error message %s", status.error_code(),
+                status.error_message());
   }
 }
 

--- a/src/ClientServices/ProcessClient.cpp
+++ b/src/ClientServices/ProcessClient.cpp
@@ -54,8 +54,8 @@ ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> ProcessClient::GetPr
 
   grpc::Status status = process_service_->GetProcessList(context.get(), request, &response);
   if (!status.ok()) {
-    ERROR("gRPC call to GetProcessList failed: %s (error_code=%d)", status.error_message(),
-          status.error_code());
+    ORBIT_ERROR("gRPC call to GetProcessList failed: %s (error_code=%d)", status.error_message(),
+                status.error_code());
     return ErrorMessage(status.error_message());
   }
 
@@ -74,7 +74,8 @@ ErrorMessageOr<std::vector<ModuleInfo>> ProcessClient::LoadModuleList(uint32_t p
   grpc::Status status = process_service_->GetModuleList(context.get(), request, &response);
 
   if (!status.ok()) {
-    ERROR("Grpc call failed: code=%d, message=%s", status.error_code(), status.error_message());
+    ORBIT_ERROR("Grpc call failed: code=%d, message=%s", status.error_code(),
+                status.error_message());
     return ErrorMessage(status.error_message());
   }
 
@@ -97,7 +98,7 @@ ErrorMessageOr<std::string> ProcessClient::FindDebugInfoFile(
 
   grpc::Status status = process_service_->GetDebugInfoFile(context.get(), request, &response);
   if (!status.ok()) {
-    ERROR("gRPC call to GetDebugInfoFile failed: %s", status.error_message());
+    ORBIT_ERROR("gRPC call to GetDebugInfoFile failed: %s", status.error_message());
     return ErrorMessage(status.error_message());
   }
 
@@ -118,7 +119,7 @@ ErrorMessageOr<std::string> ProcessClient::LoadProcessMemory(uint32_t pid, uint6
 
   grpc::Status status = process_service_->GetProcessMemory(context.get(), request, &response);
   if (!status.ok()) {
-    ERROR("gRPC call to GetProcessMemory failed: %s", status.error_message());
+    ORBIT_ERROR("gRPC call to GetProcessMemory failed: %s", status.error_message());
     return ErrorMessage(status.error_message());
   }
 

--- a/src/ClientServices/ProcessManager.cpp
+++ b/src/ClientServices/ProcessManager.cpp
@@ -89,7 +89,7 @@ ErrorMessageOr<std::string> ProcessManagerImpl::FindDebugInfoFile(
 }
 
 void ProcessManagerImpl::Start() {
-  CHECK(!worker_thread_.joinable());
+  ORBIT_CHECK(!worker_thread_.joinable());
   worker_thread_ = std::thread([this] { WorkerFunction(); });
 }
 
@@ -140,7 +140,7 @@ ErrorMessageOr<std::string> ProcessManagerImpl::LoadNullTerminatedString(uint32_
     const std::string& str = error_or_string.value();
     if (str.find('\0') == std::string::npos) {
       const char* error_msg = "Remote string is not null terminated";
-      ERROR("%s: %s", error_msg, str.c_str());
+      ORBIT_ERROR("%s: %s", error_msg, str.c_str());
       return ErrorMessage(error_msg);
     }
 

--- a/src/ClientServices/TracepointServiceClient.cpp
+++ b/src/ClientServices/TracepointServiceClient.cpp
@@ -33,8 +33,8 @@ ErrorMessageOr<std::vector<TracepointInfo>> TracepointServiceClient::GetTracepoi
     const std::string& error_message =
         absl::StrFormat("gRPC call to GetTracepointList failed: %s (error_code=%d)",
                         status.error_message(), status.error_code());
-    ERROR("gRPC call to GetTracepointList failed: %s (error_code=%d)", status.error_message(),
-          status.error_code());
+    ORBIT_ERROR("gRPC call to GetTracepointList failed: %s (error_code=%d)", status.error_message(),
+                status.error_code());
     return ErrorMessage(error_message);
   }
 

--- a/src/CodeReport/SourceCodeReport.cpp
+++ b/src/CodeReport/SourceCodeReport.cpp
@@ -29,12 +29,12 @@ SourceCodeReport::SourceCodeReport(std::string_view source_file,
 
     const auto& current_line_info = maybe_current_line_info.value();
     if (source_file != current_line_info.source_file()) {
-      ERROR(
+      ORBIT_ERROR(
           "Was trying to gather sampling data for function \"%s\" but the debug information "
           "tells me the function address %#x is defined in a different source file.",
           function.pretty_name(), function.address() + offset);
-      ERROR("Expected: %s", source_file);
-      ERROR("Actual: %s", current_line_info.source_file());
+      ORBIT_ERROR("Expected: %s", source_file);
+      ORBIT_ERROR("Actual: %s", current_line_info.source_file());
       continue;
     }
 

--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -556,7 +556,7 @@ LargestOccurringLineNumbers SetAnnotatingContentInDocument(
        current_block != document->end() && current_annotating_line != annotating_lines.end();
        current_block = current_block.next()) {
     const auto metadata = static_cast<const Metadata*>(current_block.userData());
-    CHECK(metadata != nullptr);
+    ORBIT_CHECK(metadata != nullptr);
 
     if (metadata->line_number == current_annotating_line->reference_line) {
       // That means the annotating line needs to go in front of the current block

--- a/src/Containers/include/Containers/BlockChain.h
+++ b/src/Containers/include/Containers/BlockChain.h
@@ -49,7 +49,7 @@ class Block final {
   // Returns block the element was inserted to.
   template <class... Args>
   T& emplace_back(Args&&... args) {
-    CHECK(size() < Size);
+    ORBIT_CHECK(size() < Size);
     return data_.emplace_back(std::forward<Args>(args)...);
   }
 

--- a/src/Containers/include/Containers/ScopeTree.h
+++ b/src/Containers/include/Containers/ScopeTree.h
@@ -75,7 +75,7 @@ class ScopeTree {
  public:
   ScopeTree();
   void Insert(ScopeT* scope);
-  void Print() const { LOG("%s", ToString()); }
+  void Print() const { ORBIT_LOG("%s", ToString()); }
   std::string ToString() const;
 
   using ScopeNodeT = ScopeNode<ScopeT>;
@@ -134,7 +134,7 @@ const ScopeNode<ScopeT>* ScopeTree<ScopeT>::FindScopeNode(const ScopeT& scope) c
 template <typename ScopeT>
 const ScopeT* ScopeTree<ScopeT>::FindParent(const ScopeT& scope) const {
   const ScopeNode<ScopeT>* node = FindScopeNode(scope);
-  CHECK(node != nullptr);
+  ORBIT_CHECK(node != nullptr);
   if (node->Parent() == root_) return nullptr;
   return node->Parent()->GetScope();
 }
@@ -142,7 +142,7 @@ const ScopeT* ScopeTree<ScopeT>::FindParent(const ScopeT& scope) const {
 template <typename ScopeT>
 const ScopeT* ScopeTree<ScopeT>::FindFirstChild(const ScopeT& scope) const {
   const ScopeNode<ScopeT>* node = FindScopeNode(scope);
-  CHECK(node != nullptr);
+  ORBIT_CHECK(node != nullptr);
   const auto children = node->GetChildrenByStartTime();
   if (children.empty()) return nullptr;
   return children.begin()->second->GetScope();
@@ -187,7 +187,7 @@ const ScopeT* ScopeTree<ScopeT>::FindFirstScopeAtOrAfterTime(uint32_t depth, uin
 template <typename ScopeT>
 const ScopeT* ScopeTree<ScopeT>::FindNextScopeAtDepth(const ScopeT& scope) const {
   const ScopeNode<ScopeT>* node = FindScopeNode(scope);
-  CHECK(node != nullptr);
+  ORBIT_CHECK(node != nullptr);
   auto nodes_at_depth = GetOrderedNodesByDepth().at(node->Depth());
   auto node_it = nodes_at_depth.upper_bound(node->Start());
   if (node_it == nodes_at_depth.end()) return nullptr;
@@ -197,7 +197,7 @@ const ScopeT* ScopeTree<ScopeT>::FindNextScopeAtDepth(const ScopeT& scope) const
 template <typename ScopeT>
 const ScopeT* ScopeTree<ScopeT>::FindPreviousScopeAtDepth(const ScopeT& scope) const {
   const ScopeNode<ScopeT>* node = FindScopeNode(scope);
-  CHECK(node != nullptr);
+  ORBIT_CHECK(node != nullptr);
   auto nodes_at_depth = GetOrderedNodesByDepth().at(node->Depth());
   auto node_it = nodes_at_depth.lower_bound(node->Start());
   if (node_it == nodes_at_depth.begin()) return nullptr;
@@ -277,7 +277,7 @@ size_t ScopeNode<ScopeT>::CountNodesInSubtree() const {
 
 template <typename ScopeT>
 void ScopeNode<ScopeT>::CountNodesInSubtree(const ScopeNode* node, size_t* count) {
-  CHECK(count != nullptr);
+  ORBIT_CHECK(count != nullptr);
   ++(*count);
   for (const auto [unused_time, child] : node->GetChildrenByStartTime()) {
     CountNodesInSubtree(child, count);
@@ -294,7 +294,7 @@ std::set<const ScopeNode<ScopeT>*> ScopeNode<ScopeT>::GetAllNodesInSubtree() con
 template <typename ScopeT>
 void ScopeNode<ScopeT>::GetAllNodesInSubtree(const ScopeNode* node,
                                              std::set<const ScopeNode*>* node_set) {
-  CHECK(node_set != nullptr);
+  ORBIT_CHECK(node_set != nullptr);
   node_set->insert(node);
   for (const auto [unused_time, child] : node->GetChildrenByStartTime()) {
     GetAllNodesInSubtree(child, node_set);

--- a/src/CrashHandler/CrashHandler.cpp
+++ b/src/CrashHandler/CrashHandler.cpp
@@ -36,7 +36,7 @@ namespace orbit_crash_handler {
 CrashHandler::CrashHandler(const std::string& dump_path, const std::string& handler_path,
                            const std::string& crash_server_url,
                            const std::vector<std::string>& attachments) {
-  CHECK(!is_init_);
+  ORBIT_CHECK(!is_init_);
   is_init_ = true;
 
   // Creates a new CrashpadClient instance that directs crashes to crashpad

--- a/src/CrashService/CrashServiceImpl.cpp
+++ b/src/CrashService/CrashServiceImpl.cpp
@@ -16,7 +16,7 @@ static void InfiniteRecursion(int num) {
   if (num != 1) {
     InfiniteRecursion(num);
   }
-  LOG("%i", num);
+  ORBIT_LOG("%i", num);
 }
 
 grpc::Status CrashServiceImpl::CrashOrbitService(grpc::ServerContext* /*context*/,
@@ -24,7 +24,7 @@ grpc::Status CrashServiceImpl::CrashOrbitService(grpc::ServerContext* /*context*
                                                  CrashOrbitServiceResponse* /*response*/) {
   switch (request->crash_type()) {
     case CrashOrbitServiceRequest::CHECK_FALSE: {
-      CHECK(false);
+      ORBIT_CHECK(false);
       break;
     }
     case CrashOrbitServiceRequest::STACK_OVERFLOW: {

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -213,7 +213,7 @@ CallstackDataView::CallstackDataViewFrame CallstackDataView::GetFrameFromRow(int
 
 CallstackDataView::CallstackDataViewFrame CallstackDataView::GetFrameFromIndex(
     int index_in_callstack) const {
-  CHECK(index_in_callstack < callstack_.frames_size());
+  ORBIT_CHECK(index_in_callstack < callstack_.frames_size());
   uint64_t address = callstack_.frames(index_in_callstack);
 
   CaptureData& capture_data = app_->GetMutableCaptureData();

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -28,7 +28,7 @@ std::string FormatValueForCsv(std::string_view value) {
 void DataView::Init() { InitSortingOrders(); }
 
 void DataView::InitSortingOrders() {
-  CHECK(sorting_orders_.empty());
+  ORBIT_CHECK(sorting_orders_.empty());
   for (const auto& column : GetColumns()) {
     sorting_orders_.push_back(column.initial_order);
   }
@@ -43,8 +43,8 @@ void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
     return;
   }
 
-  CHECK(column > 0);
-  CHECK(static_cast<size_t>(column) < sorting_orders_.size());
+  ORBIT_CHECK(column > 0);
+  ORBIT_CHECK(static_cast<size_t>(column) < sorting_orders_.size());
 
   sorting_column_ = column;
   if (new_order.has_value()) {
@@ -80,7 +80,7 @@ std::vector<std::vector<std::string>> DataView::GetContextMenuWithGrouping(
   // GetContextmenuWithGrouping is called when OrbitTreeView::indexAt returns a valid index and
   // hence the selected_indices retrieved from OrbitTreeView::selectionModel()->selectedIndexes()
   // should not be empty.
-  CHECK(!selected_indices.empty());
+  ORBIT_CHECK(!selected_indices.empty());
 
   static std::vector<std::string> default_group = {std::string{kMenuActionCopySelection},
                                                    std::string{kMenuActionExportToCsv}};

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -25,7 +25,7 @@ void CheckSingleAction(const std::vector<std::string>& context_menu, std::string
       EXPECT_THAT(context_menu, testing::Not(testing::Contains(action)));
       return;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -151,7 +151,7 @@ void LiveFunctionsDataView::OnSelect(const std::vector<int>& rows) {
 
 void LiveFunctionsDataView::DoSort() {
   if (!app_->HasCaptureData()) {
-    CHECK(functions_.empty());
+    ORBIT_CHECK(functions_.empty());
     return;
   }
   bool ascending = sorting_orders_[sorting_column_] == SortingOrder::kAscending;
@@ -286,7 +286,7 @@ void LiveFunctionsDataView::OnIteratorRequested(const std::vector<int>& selectio
 
 void LiveFunctionsDataView::OnJumpToRequested(const std::string& action,
                                               const std::vector<int>& selection) {
-  CHECK(selection.size() == 1);
+  ORBIT_CHECK(selection.size() == 1);
   auto function_id = GetInstrumentedFunctionId(selection[0]);
   if (action == kMenuActionJumpToFirst) {
     app_->JumpToTimerAndZoom(function_id, AppInterface::JumpToTimerMode::kFirst);
@@ -364,7 +364,7 @@ void LiveFunctionsDataView::OnExportEventsToCsvRequested(const std::vector<int>&
 
 void LiveFunctionsDataView::DoFilter() {
   if (!app_->HasCaptureData()) {
-    CHECK(functions_.empty());
+    ORBIT_CHECK(functions_.empty());
     return;
   }
   std::vector<uint64_t> indices;
@@ -457,13 +457,13 @@ void LiveFunctionsDataView::OnRefresh(const std::vector<int>& visible_selected_i
 }
 
 uint64_t LiveFunctionsDataView::GetInstrumentedFunctionId(uint32_t row) const {
-  CHECK(row < indices_.size());
+  ORBIT_CHECK(row < indices_.size());
   return indices_[row];
 }
 
 const FunctionInfo* LiveFunctionsDataView::GetFunctionInfoFromRow(int row) {
-  CHECK(static_cast<unsigned int>(row) < indices_.size());
-  CHECK(functions_.find(indices_[row]) != functions_.end());
+  ORBIT_CHECK(static_cast<unsigned int>(row) < indices_.size());
+  ORBIT_CHECK(functions_.find(indices_[row]) != functions_.end());
   return &functions_.at(indices_[row]);
 }
 

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -171,7 +171,7 @@ class LiveFunctionsDataViewTest : public testing::Test {
   void AddFunctionsByIndices(const std::vector<size_t>& indices) {
     std::set index_set(indices.begin(), indices.end());
     for (size_t index : index_set) {
-      CHECK(index < kNumFunctions);
+      ORBIT_CHECK(index < kNumFunctions);
       view_.AddFunction(kFunctionIds[index], functions_.at(kFunctionIds[index]));
     }
   }
@@ -753,7 +753,7 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
                       case orbit_data_views::DataView::SortingOrder::kDescending:
                         return lhs[column] > rhs[column];
                       default:
-                        UNREACHABLE();
+                        ORBIT_UNREACHABLE();
                     }
                   });
         break;
@@ -773,12 +773,12 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
                 case orbit_data_views::DataView::SortingOrder::kDescending:
                   return string_to_raw_value.at(lhs[column]) > string_to_raw_value.at(rhs[column]);
                 default:
-                  UNREACHABLE();
+                  ORBIT_UNREACHABLE();
               }
             });
         break;
       default:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
 
     for (size_t index = 0; index < view_entries.size(); ++index) {

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -190,7 +190,7 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
     // `ModuleManager::GetMutableModuleByPathAndBuildId` and ModuleManager never deletes modules,
     // only changes modules or adds new modules. And the memory_map cannot contain modules that are
     // not yet in ModuleManager, since these two locations get updated simultaneously.
-    CHECK(module != nullptr);
+    ORBIT_CHECK(module != nullptr);
     AddModule(start_address, module, module_in_memory);
   }
 
@@ -200,7 +200,7 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
 void ModulesDataView::OnRefreshButtonClicked() {
   const ProcessData* process = app_->GetTargetProcess();
   if (process == nullptr) {
-    LOG("Unable to refresh module list, no process selected");
+    ORBIT_LOG("Unable to refresh module list, no process selected");
     return;
   }
   app_->UpdateProcessAndModuleList();

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -76,7 +76,7 @@ class ModulesDataViewTest : public testing::Test {
   void AddModulesByIndices(const std::vector<size_t>& indices) {
     std::set index_set(indices.begin(), indices.end());
     for (size_t index : index_set) {
-      CHECK(index < kNumModules);
+      ORBIT_CHECK(index < kNumModules);
       view_.AddModule(
           modules_in_memory_[index].start(),
           module_manager_.GetMutableModuleByPathAndBuildId(modules_in_memory_[index].file_path(),
@@ -248,7 +248,7 @@ TEST_F(ModulesDataViewTest, ColumnSortingShowsRightResults) {
                   case orbit_data_views::DataView::SortingOrder::kDescending:
                     return lhs[column_index] > rhs[column_index];
                   default:
-                    UNREACHABLE();
+                    ORBIT_UNREACHABLE();
                 }
               });
 

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -52,7 +52,7 @@ std::string GetLoadStateString(orbit_data_views::AppInterface* app, const Preset
 std::string GetDateModifiedString(const PresetFile& preset) {
   auto datetime_or_error = orbit_base::GetFileDateModified(preset.file_path());
   if (datetime_or_error.has_error()) {
-    ERROR("%s", datetime_or_error.error().message());
+    ORBIT_ERROR("%s", datetime_or_error.error().message());
     return "";
   }
 
@@ -151,7 +151,7 @@ void PresetsDataView::DoSort() {
 std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
   // Note that the UI already enforces a single selection.
-  CHECK(selected_indices.size() == 1);
+  ORBIT_CHECK(selected_indices.size() == 1);
 
   std::vector<std::string> action_group;
   const PresetFile& preset = GetPreset(selected_indices[0]);
@@ -184,7 +184,7 @@ void PresetsDataView::OnDeletePresetRequested(const std::vector<int>& selection)
     presets_.erase(presets_.begin() + indices_[row]);
     OnDataChanged();
   } else {
-    ERROR("Deleting preset \"%s\": %s", filename, SafeStrerror(errno));
+    ORBIT_ERROR("Deleting preset \"%s\": %s", filename, SafeStrerror(errno));
     metric.SetStatusCode(orbit_metrics_uploader::OrbitLogEvent::INTERNAL_ERROR);
     app_->SendErrorToUi("Error deleting preset",
                         absl::StrFormat("Could not delete preset \"%s\".", filename));

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -191,13 +191,13 @@ const FunctionInfo* SamplingReportDataView::GetFunctionInfoFromRow(int row) {
 std::optional<std::pair<std::string, std::string>>
 SamplingReportDataView::GetModulePathAndBuildIdFromRow(int row) const {
   const ProcessData* process = app_->GetCaptureData().process();
-  CHECK(process != nullptr);
+  ORBIT_CHECK(process != nullptr);
 
   const SampledFunction& sampled_function = GetSampledFunction(row);
-  CHECK(sampled_function.absolute_address != 0);
+  ORBIT_CHECK(sampled_function.absolute_address != 0);
   auto result = process->FindModuleByAddress(sampled_function.absolute_address);
   if (result.has_error()) {
-    ERROR("result %s", result.error().message());
+    ORBIT_ERROR("result %s", result.error().message());
     return std::nullopt;
   }
 

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -207,7 +207,7 @@ class SamplingReportDataViewTest : public testing::Test {
   void AddFunctionsByIndices(const std::vector<size_t>& indices) {
     std::vector<SampledFunction> functions_to_add;
     for (size_t index : indices) {
-      CHECK(index < kNumFunctions);
+      ORBIT_CHECK(index < kNumFunctions);
       functions_to_add.push_back(sampled_functions_[index]);
     }
 
@@ -624,7 +624,7 @@ TEST_F(SamplingReportDataViewTest, ColumnSortingShowsRightResults) {
                       case orbit_data_views::DataView::SortingOrder::kDescending:
                         return lhs[column] > rhs[column];
                       default:
-                        UNREACHABLE();
+                        ORBIT_UNREACHABLE();
                     }
                   });
         break;
@@ -642,12 +642,12 @@ TEST_F(SamplingReportDataViewTest, ColumnSortingShowsRightResults) {
                 case orbit_data_views::DataView::SortingOrder::kDescending:
                   return string_to_raw_value.at(lhs[column]) > string_to_raw_value.at(rhs[column]);
                 default:
-                  UNREACHABLE();
+                  ORBIT_UNREACHABLE();
               }
             });
         break;
       default:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
 
     for (size_t index = 0; index < view_entries.size(); ++index) {

--- a/src/DataViews/TracepointsDataViewTest.cpp
+++ b/src/DataViews/TracepointsDataViewTest.cpp
@@ -54,7 +54,7 @@ class TracepointsDataViewTest : public testing::Test {
   void SetTracepointsByIndices(const std::vector<size_t>& indices) {
     std::vector<TracepointInfo> tracepoints_to_add;
     for (size_t index : indices) {
-      CHECK(index < kNumTracepoints);
+      ORBIT_CHECK(index < kNumTracepoints);
       tracepoints_to_add.push_back(tracepoints_[index]);
     }
 
@@ -250,7 +250,7 @@ TEST_F(TracepointsDataViewTest, ColumnSortingShowsRightResults) {
                   case orbit_data_views::DataView::SortingOrder::kDescending:
                     return lhs[column] > rhs[column];
                   default:
-                    UNREACHABLE();
+                    ORBIT_UNREACHABLE();
                 }
               });
 

--- a/src/FakeClient/FakeCaptureEventProcessor.h
+++ b/src/FakeClient/FakeCaptureEventProcessor.h
@@ -42,19 +42,19 @@ class FakeCaptureEventProcessor : public orbit_capture_client::CaptureEventProce
   ~FakeCaptureEventProcessor() override {
     std::filesystem::path file_path(absl::GetFlag(FLAGS_output_path));
     {
-      LOG("Events received: %u", event_count_);
+      ORBIT_LOG("Events received: %u", event_count_);
       ErrorMessageOr<void> event_count_write_result = orbit_base::WriteStringToFile(
           file_path / kEventCountFilename, std::to_string(event_count_));
-      FAIL_IF(event_count_write_result.has_error(), "Writing to \"%s\": %s", kEventCountFilename,
-              event_count_write_result.error().message());
+      ORBIT_FAIL_IF(event_count_write_result.has_error(), "Writing to \"%s\": %s",
+                    kEventCountFilename, event_count_write_result.error().message());
     }
 
     {
-      LOG("Bytes received: %u", byte_count_);
+      ORBIT_LOG("Bytes received: %u", byte_count_);
       ErrorMessageOr<void> byte_count_write_result = orbit_base::WriteStringToFile(
           file_path / kByteCountFilename, std::to_string(byte_count_));
-      FAIL_IF(byte_count_write_result.has_error(), "Writing to \"%s\": %s", kByteCountFilename,
-              byte_count_write_result.error().message());
+      ORBIT_FAIL_IF(byte_count_write_result.has_error(), "Writing to \"%s\": %s",
+                    kByteCountFilename, byte_count_write_result.error().message());
     }
 
     {
@@ -65,12 +65,12 @@ class FakeCaptureEventProcessor : public orbit_capture_client::CaptureEventProce
                                                    frame_boundary_min_timestamp_ns_) /
                                1'000'000.0 / static_cast<double>(frame_boundary_count_ - 1);
         frame_time_ms_string = absl::StrFormat("%.3f", frame_time_ms);
-        LOG("Avg. frame time (ms): %s", frame_time_ms_string);
+        ORBIT_LOG("Avg. frame time (ms): %s", frame_time_ms_string);
       }
       ErrorMessageOr<void> frame_time_write_result =
           orbit_base::WriteStringToFile(file_path / kFrameTimeFilename, frame_time_ms_string);
-      FAIL_IF(frame_time_write_result.has_error(), "Writing to \"%s\": %s", kFrameTimeFilename,
-              frame_time_write_result.error().message());
+      ORBIT_FAIL_IF(frame_time_write_result.has_error(), "Writing to \"%s\": %s",
+                    kFrameTimeFilename, frame_time_write_result.error().message());
     }
   }
 

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -74,7 +74,7 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromOff
     uint64_t function_id) {
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::ElfFile>> error_or_elf_file =
       orbit_object_utils::CreateElfFile(std::filesystem::path{file_path});
-  FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
+  ORBIT_FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
   std::unique_ptr<orbit_object_utils::ElfFile>& elf_file = error_or_elf_file.value();
   std::string build_id = elf_file->GetBuildId();
   uint64_t load_bias = elf_file->GetLoadBias();
@@ -84,7 +84,7 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromOff
   module_info.set_build_id(build_id);
   module_info.set_load_bias(load_bias);
   module_info.set_executable_segment_offset(elf_file->GetExecutableSegmentOffset());
-  CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
+  ORBIT_CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
 
   orbit_client_protos::FunctionInfo function_info;
   function_info.set_module_path(file_path);
@@ -101,7 +101,7 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromFun
     uint64_t function_id) {
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::ElfFile>> error_or_elf_file =
       orbit_object_utils::CreateElfFile(std::filesystem::path{file_path});
-  FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
+  ORBIT_FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
   std::unique_ptr<orbit_object_utils::ElfFile>& elf_file = error_or_elf_file.value();
   std::string build_id = elf_file->GetBuildId();
   uint64_t executable_segment_offset = elf_file->GetExecutableSegmentOffset();
@@ -112,10 +112,10 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromFun
   module_info.set_build_id(build_id);
   module_info.set_load_bias(elf_file->GetLoadBias());
   module_info.set_executable_segment_offset(executable_segment_offset);
-  CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
+  ORBIT_CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
 
   ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> symbols_or_error = elf_file->LoadDebugSymbols();
-  FAIL_IF(symbols_or_error.has_error(), "%s", symbols_or_error.error().message());
+  ORBIT_FAIL_IF(symbols_or_error.has_error(), "%s", symbols_or_error.error().message());
   orbit_grpc_protos::ModuleSymbols& symbols = symbols_or_error.value();
 
   std::optional<orbit_grpc_protos::SymbolInfo> symbol = std::nullopt;
@@ -125,8 +125,8 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromFun
       break;
     }
   }
-  FAIL_IF(!symbol.has_value(), "Could not find function \"%s\" in module \"%s\"",
-          demangled_function_name, file_path);
+  ORBIT_FAIL_IF(!symbol.has_value(), "Could not find function \"%s\" in module \"%s\"",
+                demangled_function_name, file_path);
 
   orbit_client_protos::FunctionInfo function_info;
   function_info.set_name(symbol->name());
@@ -159,7 +159,7 @@ std::optional<orbit_grpc_protos::ModuleSymbols> FindAndLoadDebugSymbols(
 
   for (const std::filesystem::path& candidate_path : candidate_paths) {
     ErrorMessageOr<bool> error_or_exists = orbit_base::FileExists(candidate_path);
-    FAIL_IF(error_or_exists.has_error(), "%s", error_or_exists.error().message());
+    ORBIT_FAIL_IF(error_or_exists.has_error(), "%s", error_or_exists.error().message());
     if (!error_or_exists.value()) {
       continue;
     }
@@ -167,7 +167,7 @@ std::optional<orbit_grpc_protos::ModuleSymbols> FindAndLoadDebugSymbols(
     ErrorMessageOr<std::unique_ptr<orbit_object_utils::ElfFile>> error_or_elf_file =
         orbit_object_utils::CreateElfFile(candidate_path);
     if (error_or_elf_file.has_error()) {
-      ERROR("%s", error_or_elf_file.error().message());
+      ORBIT_ERROR("%s", error_or_elf_file.error().message());
       continue;
     }
     std::unique_ptr<orbit_object_utils::ElfFile>& elf_file = error_or_elf_file.value();
@@ -179,12 +179,12 @@ std::optional<orbit_grpc_protos::ModuleSymbols> FindAndLoadDebugSymbols(
       continue;
     }
 
-    LOG("Loaded debug symbols of module \"%s\" from \"%s\"", file_name.string(),
-        elf_file->GetName());
+    ORBIT_LOG("Loaded debug symbols of module \"%s\" from \"%s\"", file_name.string(),
+              elf_file->GetName());
     return symbols_or_error.value();
   }
 
-  ERROR("Could not find debug symbols of module \"%s\"", file_name.string());
+  ORBIT_ERROR("Could not find debug symbols of module \"%s\"", file_name.string());
   return std::nullopt;
 }
 
@@ -193,7 +193,7 @@ void ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
     const std::string& demangled_function_prefix) {
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::ElfFile>> error_or_elf_file =
       orbit_object_utils::CreateElfFile(std::filesystem::path{file_path});
-  FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
+  ORBIT_FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
   std::unique_ptr<orbit_object_utils::ElfFile>& elf_file = error_or_elf_file.value();
   std::string build_id = elf_file->GetBuildId();
   uint64_t load_bias = elf_file->GetLoadBias();
@@ -204,7 +204,7 @@ void ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
   module_info.set_build_id(build_id);
   module_info.set_load_bias(load_bias);
   module_info.set_executable_segment_offset(elf_file->GetExecutableSegmentOffset());
-  CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
+  ORBIT_CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
 
   std::optional<orbit_grpc_protos::ModuleSymbols> symbols_opt = FindAndLoadDebugSymbols(file_path);
   if (!symbols_opt.has_value()) {
@@ -220,11 +220,11 @@ void ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
     }
   }
   if (!symbol.has_value()) {
-    ERROR("Could not find function with prefix \"%s\" in module \"%s\"", demangled_function_prefix,
-          elf_file->GetName());
+    ORBIT_ERROR("Could not find function with prefix \"%s\" in module \"%s\"",
+                demangled_function_prefix, elf_file->GetName());
     return;
   }
-  LOG("Found function \"%s\" in module \"%s\"", symbol->name(), elf_file->GetName());
+  ORBIT_LOG("Found function \"%s\" in module \"%s\"", symbol->name(), elf_file->GetName());
 
   orbit_grpc_protos::SymbolInfo symbol_info;
   symbol_info.set_name(symbol->name());
@@ -242,11 +242,11 @@ void ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
 
 uint32_t ReadPidFromFile(const std::string& file_path) {
   ErrorMessageOr<std::string> pid_string = orbit_base::ReadFileToString(file_path);
-  FAIL_IF(pid_string.has_error(), "Reading from \"%s\": %s", file_path,
-          pid_string.error().message());
+  ORBIT_FAIL_IF(pid_string.has_error(), "Reading from \"%s\": %s", file_path,
+                pid_string.error().message());
   uint32_t process_id = 0;
-  FAIL_IF(!absl::SimpleAtoi<uint32_t>(pid_string.value(), &process_id),
-          "Failed to read the PID from \"%s\"", file_path);
+  ORBIT_FAIL_IF(!absl::SimpleAtoi<uint32_t>(pid_string.value(), &process_id),
+                "Failed to read the PID from \"%s\"", file_path);
   return process_id;
 }
 
@@ -255,11 +255,11 @@ void WaitForFileModification(const std::string& file_path) {
   int wd = -1;
 
   inotify_fd = inotify_init();
-  FAIL_IF(inotify_fd == -1, "Failed to initialize inotify");
+  ORBIT_FAIL_IF(inotify_fd == -1, "Failed to initialize inotify");
 
   wd = inotify_add_watch(inotify_fd, file_path.c_str(), IN_MODIFY);
-  FAIL_IF(wd == -1, "Failed to watch \"%s\"", file_path);
-  LOG("Started to watch \"%s\"", file_path);
+  ORBIT_FAIL_IF(wd == -1, "Failed to watch \"%s\"", file_path);
+  ORBIT_LOG("Started to watch \"%s\"", file_path);
 
   // Wait for the first modify event received to read its PID
   constexpr ssize_t kMaxBufferSize = 1024;
@@ -269,15 +269,15 @@ void WaitForFileModification(const std::string& file_path) {
   char buffer[kMaxBufferSize];
   while (offset < kMinReadSize) {
     ssize_t bytes_read = read(inotify_fd, buffer + offset, kMaxBufferSize - offset);
-    FAIL_IF(bytes_read == -1, "Failed to read watch event");
+    ORBIT_FAIL_IF(bytes_read == -1, "Failed to read watch event");
     offset += bytes_read;
   }
 
   inotify_event* event = reinterpret_cast<inotify_event*>(buffer);
-  CHECK(event->wd == wd);
+  ORBIT_CHECK(event->wd == wd);
 
   close(inotify_fd);
-  LOG("Stopped watching \"%s\"", file_path);
+  ORBIT_LOG("Stopped watching \"%s\"", file_path);
 }
 
 }  // namespace
@@ -294,77 +294,79 @@ int main(int argc, char* argv[]) {
   absl::SetProgramUsageMessage("Orbit fake client for testing");
   absl::ParseCommandLine(argc, argv);
 
-  LOG("Starting Client");
+  ORBIT_LOG("Starting Client");
   uint32_t duration_s = absl::GetFlag(FLAGS_duration);
-  FAIL_IF(duration_s == 0, "Specified a zero-length duration");
-  FAIL_IF((absl::GetFlag(FLAGS_instrument_path).empty()) !=
-              (absl::GetFlag(FLAGS_instrument_offset) == 0),
-          "Binary path and offset of the function to instrument need to be specified together");
+  ORBIT_FAIL_IF(duration_s == 0, "Specified a zero-length duration");
+  ORBIT_FAIL_IF(
+      (absl::GetFlag(FLAGS_instrument_path).empty()) !=
+          (absl::GetFlag(FLAGS_instrument_offset) == 0),
+      "Binary path and offset of the function to instrument need to be specified together");
 
   uint32_t process_id = absl::GetFlag(FLAGS_pid);
   if (process_id == 0) {
     const std::string pid_file_path = absl::GetFlag(FLAGS_pid_file_path);
-    FAIL_IF(pid_file_path.empty(), "A PID or a path to a file is needed.");
+    ORBIT_FAIL_IF(pid_file_path.empty(), "A PID or a path to a file is needed.");
     WaitForFileModification(pid_file_path);
     process_id = ReadPidFromFile(pid_file_path);
   }
-  LOG("process_id=%d", process_id);
-  FAIL_IF(process_id == 0, "PID to capture not specified");
+  ORBIT_LOG("process_id=%d", process_id);
+  ORBIT_FAIL_IF(process_id == 0, "PID to capture not specified");
 
   uint16_t samples_per_second = absl::GetFlag(FLAGS_sampling_rate);
-  LOG("samples_per_second=%u", samples_per_second);
+  ORBIT_LOG("samples_per_second=%u", samples_per_second);
   constexpr uint16_t kStackDumpSize = 65000;
   const UnwindingMethod unwinding_method =
       absl::GetFlag(FLAGS_frame_pointers) ? CaptureOptions::kFramePointers : CaptureOptions::kDwarf;
-  LOG("unwinding_method=%s",
-      unwinding_method == CaptureOptions::kFramePointers ? "Frame pointers" : "DWARF");
+  ORBIT_LOG("unwinding_method=%s",
+            unwinding_method == CaptureOptions::kFramePointers ? "Frame pointers" : "DWARF");
 
   std::string file_path = absl::GetFlag(FLAGS_instrument_path);
   uint64_t file_offset = absl::GetFlag(FLAGS_instrument_offset);
-  FAIL_IF((file_path.empty()) != (file_offset == 0),
-          "Binary path and offset of the function to instrument need to be specified together");
+  ORBIT_FAIL_IF(
+      (file_path.empty()) != (file_offset == 0),
+      "Binary path and offset of the function to instrument need to be specified together");
   bool instrument_function = !file_path.empty() && file_offset != 0;
   uint64_t function_size = absl::GetFlag(FLAGS_instrument_size);
   DynamicInstrumentationMethod instrumentation_method =
       absl::GetFlag(FLAGS_user_space_instrumentation) ? CaptureOptions::kUserSpaceInstrumentation
                                                       : CaptureOptions::kKernelUprobes;
-  LOG("user_space_instrumentation=%d",
-      instrumentation_method == CaptureOptions::kUserSpaceInstrumentation);
+  ORBIT_LOG("user_space_instrumentation=%d",
+            instrumentation_method == CaptureOptions::kUserSpaceInstrumentation);
   if (instrument_function) {
-    LOG("file_path=%s", file_path);
-    LOG("file_offset=%#x", file_offset);
+    ORBIT_LOG("file_path=%s", file_path);
+    ORBIT_LOG("file_offset=%#x", file_offset);
     if (instrumentation_method == CaptureOptions::kUserSpaceInstrumentation) {
-      FAIL_IF(function_size == 0, "User space instrumentation requires the function size");
-      LOG("function_size=%d", function_size);
+      ORBIT_FAIL_IF(function_size == 0, "User space instrumentation requires the function size");
+      ORBIT_LOG("function_size=%d", function_size);
     }
   }
   constexpr bool kAlwaysRecordArguments = false;
   constexpr bool kRecordReturnValues = false;
 
   bool collect_scheduling_info = absl::GetFlag(FLAGS_scheduling);
-  LOG("collect_scheduling_info=%d", collect_scheduling_info);
+  ORBIT_LOG("collect_scheduling_info=%d", collect_scheduling_info);
   bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
-  LOG("collect_thread_state=%d", collect_thread_state);
+  ORBIT_LOG("collect_thread_state=%d", collect_thread_state);
   bool collect_gpu_jobs = absl::GetFlag(FLAGS_gpu_jobs);
-  LOG("collect_gpu_jobs=%d", collect_gpu_jobs);
+  ORBIT_LOG("collect_gpu_jobs=%d", collect_gpu_jobs);
   bool enable_api = absl::GetFlag(FLAGS_orbit_api);
-  LOG("enable_api=%d", enable_api);
+  ORBIT_LOG("enable_api=%d", enable_api);
   constexpr bool kEnableIntrospection = false;
   constexpr uint64_t kMaxLocalMarkerDepthPerCommandBuffer = std::numeric_limits<uint64_t>::max();
   bool collect_memory_info = absl::GetFlag(FLAGS_memory_sampling_rate) > 0;
-  LOG("collect_memory_info=%d", collect_memory_info);
+  ORBIT_LOG("collect_memory_info=%d", collect_memory_info);
   uint64_t memory_sampling_period_ms = 0;
   if (collect_memory_info) {
     memory_sampling_period_ms = 1'000 / absl::GetFlag(FLAGS_memory_sampling_rate);
-    LOG("memory_sampling_period_ms=%u", memory_sampling_period_ms);
+    ORBIT_LOG("memory_sampling_period_ms=%u", memory_sampling_period_ms);
   }
 
   uint32_t grpc_port = absl::GetFlag(FLAGS_port);
   std::string service_address = absl::StrFormat("127.0.0.1:%d", grpc_port);
   std::shared_ptr<grpc::Channel> grpc_channel =
       grpc::CreateChannel(service_address, grpc::InsecureChannelCredentials());
-  LOG("service_address=%s", service_address);
-  CHECK(grpc_channel != nullptr);
+  ORBIT_LOG("service_address=%s", service_address);
+  ORBIT_CHECK(grpc_channel != nullptr);
 
   InstallSigintHandler();
 
@@ -384,7 +386,7 @@ int main(int argc, char* argv[]) {
   if (enable_api) {
     ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
         orbit_object_utils::ReadModules(process_id);
-    FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
+    ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
       ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
           &module_manager, module.file_path(),
@@ -393,7 +395,7 @@ int main(int argc, char* argv[]) {
   }
 
   const bool calculate_frame_time = absl::GetFlag(FLAGS_frame_time);
-  LOG("frame_time=%d", calculate_frame_time);
+  ORBIT_LOG("frame_time=%d", calculate_frame_time);
   if (calculate_frame_time) {
     // Instrument vkQueuePresentKHR, if possible.
     // Some application don't call libVulkan library directly; instead, they just query the
@@ -405,7 +407,7 @@ int main(int argc, char* argv[]) {
 
     ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
         orbit_object_utils::ReadModules(process_id);
-    FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
+    ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
     std::string libvulkan_file_path;
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
       if (module.soname() == kGgpvlkModuleName) {
@@ -414,13 +416,13 @@ int main(int argc, char* argv[]) {
       }
     }
     if (!libvulkan_file_path.empty()) {
-      LOG("%s found: instrumenting %s", kGgpvlkModuleName, kQueuePresentFunctionName);
+      ORBIT_LOG("%s found: instrumenting %s", kGgpvlkModuleName, kQueuePresentFunctionName);
       ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromFunctionNameInDebugSymbols(
           &module_manager, &selected_functions, libvulkan_file_path, kQueuePresentFunctionName,
           orbit_fake_client::FakeCaptureEventProcessor::kFrameBoundaryFunctionId);
-      LOG("%s instrumented", kQueuePresentFunctionName);
+      ORBIT_LOG("%s instrumented", kQueuePresentFunctionName);
     } else {
-      LOG("%s not found", kGgpvlkModuleName);
+      ORBIT_LOG("%s not found", kGgpvlkModuleName);
     }
   }
 
@@ -434,7 +436,7 @@ int main(int argc, char* argv[]) {
           std::make_unique<orbit_fake_client::GraphicsCaptureEventProcessor>();
       break;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   auto capture_outcome_future = capture_client.Capture(
@@ -444,24 +446,24 @@ int main(int argc, char* argv[]) {
       collect_gpu_jobs, enable_api, kEnableIntrospection, instrumentation_method,
       kMaxLocalMarkerDepthPerCommandBuffer, collect_memory_info, memory_sampling_period_ms,
       std::move(capture_event_processor));
-  LOG("Asked to start capture");
+  ORBIT_LOG("Asked to start capture");
 
   absl::Time start_time = absl::Now();
   while (!exit_requested && absl::Now() < start_time + absl::Seconds(duration_s)) {
     std::this_thread::sleep_for(std::chrono::milliseconds{100});
-    CHECK(!capture_outcome_future.IsFinished());
+    ORBIT_CHECK(!capture_outcome_future.IsFinished());
   }
-  CHECK(capture_client.StopCapture());
-  LOG("Asked to stop capture");
+  ORBIT_CHECK(capture_client.StopCapture());
+  ORBIT_LOG("Asked to stop capture");
 
   auto capture_outcome_or_error = capture_outcome_future.Get();
   if (capture_outcome_or_error.has_error()) {
-    FATAL("Capture failed: %s", capture_outcome_or_error.error().message());
+    ORBIT_FATAL("Capture failed: %s", capture_outcome_or_error.error().message());
   }
   thread_pool->ShutdownAndWait();
 
-  CHECK(capture_outcome_or_error.value() ==
-        orbit_capture_client::CaptureListener::CaptureOutcome::kComplete);
-  LOG("Capture completed");
+  ORBIT_CHECK(capture_outcome_or_error.value() ==
+              orbit_capture_client::CaptureListener::CaptureOutcome::kComplete);
+  ORBIT_LOG("Capture completed");
   return 0;
 }

--- a/src/FakeClient/GraphicsCaptureEventProcessor.h
+++ b/src/FakeClient/GraphicsCaptureEventProcessor.h
@@ -57,12 +57,12 @@ class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventP
     CalculateGpuStats();
     std::filesystem::path file_path(absl::GetFlag(FLAGS_output_path));
     std::string cpu_file_path = file_path.append(kCpuFrameTimeFilename).string();
-    LOG("Writing CPU results to \"%s\"", cpu_file_path);
+    ORBIT_LOG("Writing CPU results to \"%s\"", cpu_file_path);
     WriteToCsvFile(cpu_file_path, cpu_time_distribution_, cpu_avg_frame_time_ms_,
                    frame_start_boundary_timestamps_.size() - 1);
     file_path.assign(absl::GetFlag(FLAGS_output_path));
     std::string gpu_file_path = file_path.append(kGpuFrameTimeFilename).string();
-    LOG("Writing GPU results to \"%s\"", gpu_file_path);
+    ORBIT_LOG("Writing GPU results to \"%s\"", gpu_file_path);
     WriteToCsvFile(gpu_file_path, gpu_time_distribution_, gpu_avg_frame_time_ms_,
                    frame_start_boundary_timestamps_.size());
   }
@@ -93,14 +93,14 @@ class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventP
   }
 
   void CalculateGpuStats() {
-    LOG("Calculating GPU Times");
-    LOG("Calculating frame durations");
+    ORBIT_LOG("Calculating GPU Times");
+    ORBIT_LOG("Calculating frame durations");
     CalculateGpuFrameDurations();
-    LOG("Generating duration distribution");
+    ORBIT_LOG("Generating duration distribution");
     GenerateGpuDurationDistribution();
-    LOG("Calculating average frame time");
+    ORBIT_LOG("Calculating average frame time");
     CalculateGpuAvgFrameTime();
-    LOG("Finished calculating GPU times");
+    ORBIT_LOG("Finished calculating GPU times");
   }
 
   void CalculateGpuFrameDurations() {
@@ -137,8 +137,9 @@ class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventP
       uint64_t frame_time_ns = CalculateFrameGpuTime(command_buffer_timestamps);
       uint64_t frame_time_ms = frame_time_ns / 1000000;
       if (frame_time_ms > kMaxTimeMs) {
-        LOG("Frame with a duration of %u(ms) is bigger than %d(ms)", frame_time_ms, kMaxTimeMs);
-        LOG("Dumping frame command buffers timestamps...");
+        ORBIT_LOG("Frame with a duration of %u(ms) is bigger than %d(ms)", frame_time_ms,
+                  kMaxTimeMs);
+        ORBIT_LOG("Dumping frame command buffers timestamps...");
         PrintCommandBufferTimestamps(command_buffer_timestamps);
       } else {
         frame_gpu_durations_ns_.emplace_back(frame_time_ns);
@@ -152,8 +153,8 @@ class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventP
       const uint64_t begin_timestamp_ns = command_buffers_timestamps[i].begin;
       const uint64_t end_timestamp_ns = command_buffers_timestamps[i].end;
       const uint64_t duration_ns = end_timestamp_ns - begin_timestamp_ns;
-      LOG("CommandBuffer #%u: Start: %u End: %u Duration: %u(ns)", i, begin_timestamp_ns,
-          end_timestamp_ns, duration_ns);
+      ORBIT_LOG("CommandBuffer #%u: Start: %u End: %u Duration: %u(ns)", i, begin_timestamp_ns,
+                end_timestamp_ns, duration_ns);
     }
   }
 
@@ -210,19 +211,19 @@ class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventP
   }
 
   void CalculateCpuStats() {
-    LOG("Calculating CPU Times");
+    ORBIT_LOG("Calculating CPU Times");
 
     uint64_t frame_boundary_count = frame_start_boundary_timestamps_.size();
-    FAIL_IF(frame_boundary_count <= 2,
-            "Not enough calls to vkQueuePresentKHR to calculate CPU frame times.");
+    ORBIT_FAIL_IF(frame_boundary_count <= 2,
+                  "Not enough calls to vkQueuePresentKHR to calculate CPU frame times.");
 
-    LOG("Calculating frame durations");
+    ORBIT_LOG("Calculating frame durations");
     CalculateCpuFrameDurations();
-    LOG("Generating duration distribution");
+    ORBIT_LOG("Generating duration distribution");
     GenerateCpuDurationDistribution();
-    LOG("Calculating average frame times");
+    ORBIT_LOG("Calculating average frame times");
     CalculateCpuAvgFrameTime();
-    LOG("Finished calculating CPU times");
+    ORBIT_LOG("Finished calculating CPU times");
   }
 
   void CalculateCpuFrameDurations() {
@@ -277,8 +278,8 @@ class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventP
     absl::StrAppend(&output, "\n");
 
     ErrorMessageOr<void> frame_time_write_result = orbit_base::WriteStringToFile(filename, output);
-    FAIL_IF(frame_time_write_result.has_error(), "Writing to \"%s\": %s", filename,
-            frame_time_write_result.error().message());
+    ORBIT_FAIL_IF(frame_time_write_result.has_error(), "Writing to \"%s\": %s", filename,
+                  frame_time_write_result.error().message());
   }
 
   // Instrument a function with this function id in order for GraphicsCaptureEventProcessor to use

--- a/src/FramePointerValidator/FramePointerValidator.cpp
+++ b/src/FramePointerValidator/FramePointerValidator.cpp
@@ -28,7 +28,7 @@ std::optional<std::vector<CodeBlock>> FramePointerValidator::GetFpoFunctions(
   cs_mode mode = is_64_bit ? CS_MODE_64 : CS_MODE_32;
   csh temp_handle;
   if (cs_open(CS_ARCH_X86, mode, &temp_handle) != CS_ERR_OK) {
-    ERROR("Unable to open capstone.");
+    ORBIT_ERROR("Unable to open capstone.");
     return {};
   }
   orbit_base::unique_resource handle{temp_handle, [](csh handle) { cs_close(&handle); }};
@@ -37,7 +37,7 @@ std::optional<std::vector<CodeBlock>> FramePointerValidator::GetFpoFunctions(
 
   ErrorMessageOr<std::string> binary_or_error = orbit_base::ReadFileToString(file_name);
   if (binary_or_error.has_error()) {
-    ERROR("%s", binary_or_error.error().message());
+    ORBIT_ERROR("%s", binary_or_error.error().message());
     return {};
   }
 

--- a/src/FramePointerValidator/FramePointerValidatorTest.cpp
+++ b/src/FramePointerValidator/FramePointerValidatorTest.cpp
@@ -66,7 +66,7 @@ TEST(FramePointerValidator, GetFpoFunctions) {
                                                    return symbol_offset == code_block.offset();
                                                  });
 
-                   CHECK(symbol_it != symbol_infos.end());
+                   ORBIT_CHECK(symbol_it != symbol_infos.end());
                    return (*symbol_it).demangled_name();
                  });
 

--- a/src/FramePointerValidator/FunctionFramePointerValidator.cpp
+++ b/src/FramePointerValidator/FunctionFramePointerValidator.cpp
@@ -162,7 +162,7 @@ bool FunctionFramePointerValidator::IsLeafFunction() {
 
 bool FunctionFramePointerValidator::Validate() {
   if (instructions_count_ == 0) {
-    ERROR("Failed to disassemble given code!");
+    ORBIT_ERROR("Failed to disassemble given code!");
     return false;
   }
   bool validated = IsLeafFunction() || (instructions_count_ >= 4 && ValidateFramePointers());

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -44,7 +44,7 @@ IntrospectionListener::IntrospectionListener(IntrospectionEventCallback callback
 
   // Activate listener (only one listener instance is supported).
   absl::MutexLock lock(&global_introspection_mutex);
-  CHECK(!IsActive());
+  ORBIT_CHECK(!IsActive());
   InitializeIntrospection();
   global_introspection_listener = this;
   active_ = true;
@@ -58,7 +58,7 @@ IntrospectionListener::~IntrospectionListener() {
   // new events on the already shut down thread pool.
   {
     absl::MutexLock lock(&global_introspection_mutex);
-    CHECK(IsActive());
+    ORBIT_CHECK(IsActive());
     shutdown_initiated_ = true;
   }
   // Purge deferred scopes.

--- a/src/Introspection/IntrospectionSmokeTest.cpp
+++ b/src/Introspection/IntrospectionSmokeTest.cpp
@@ -33,28 +33,36 @@ inline int32_t RetrieveThreadId(const orbit_api::ApiScopeStop& scope_stop) {
   return scope_stop.meta_data.tid;
 }
 inline int32_t RetrieveThreadId(const orbit_api::ApiScopeStartAsync& /*scope_start_async*/) {
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 inline int32_t RetrieveThreadId(const orbit_api::ApiScopeStopAsync& /*scope_stop_async*/) {
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 inline int32_t RetrieveThreadId(const orbit_api::ApiStringEvent& /*string_event*/) {
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 inline int32_t RetrieveThreadId(const orbit_api::ApiTrackDouble& /*track_double*/) {
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
-inline int32_t RetrieveThreadId(const orbit_api::ApiTrackFloat& /*track_float*/) { UNREACHABLE(); }
-inline int32_t RetrieveThreadId(const orbit_api::ApiTrackInt& /*track_int*/) { UNREACHABLE(); }
-inline int32_t RetrieveThreadId(const orbit_api::ApiTrackInt64& /*track_int64*/) { UNREACHABLE(); }
-inline int32_t RetrieveThreadId(const orbit_api::ApiTrackUint& /*track_uint*/) { UNREACHABLE(); }
+inline int32_t RetrieveThreadId(const orbit_api::ApiTrackFloat& /*track_float*/) {
+  ORBIT_UNREACHABLE();
+}
+inline int32_t RetrieveThreadId(const orbit_api::ApiTrackInt& /*track_int*/) {
+  ORBIT_UNREACHABLE();
+}
+inline int32_t RetrieveThreadId(const orbit_api::ApiTrackInt64& /*track_int64*/) {
+  ORBIT_UNREACHABLE();
+}
+inline int32_t RetrieveThreadId(const orbit_api::ApiTrackUint& /*track_uint*/) {
+  ORBIT_UNREACHABLE();
+}
 inline int32_t RetrieveThreadId(const orbit_api::ApiTrackUint64& /*track_uint64*/) {
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 
 // The variant type `ApiEventVariant` requires to contain `std::monostate` in order to be default-
 // constructable. However, that state is never expected to be called in the visitor.
-inline int32_t RetrieveThreadId(const std::monostate& /*unused*/) { UNREACHABLE(); }
+inline int32_t RetrieveThreadId(const std::monostate& /*unused*/) { ORBIT_UNREACHABLE(); }
 }  // namespace
 
 TEST(Tracing, Scopes) {

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -92,18 +92,18 @@ static void StopInternalProducersAndCaptureStartStopListenersInParallel(
 
   stop_threads.emplace_back([&tracing_handler] {
     tracing_handler->Stop();
-    LOG("TracingHandler stopped: perf_event_open tracing is done");
+    ORBIT_LOG("TracingHandler stopped: perf_event_open tracing is done");
   });
 
   stop_threads.emplace_back([&memory_info_handler] {
     memory_info_handler->Stop();
-    LOG("MemoryInfoHandler stopped: memory usage information collection is done");
+    ORBIT_LOG("MemoryInfoHandler stopped: memory usage information collection is done");
   });
 
   for (CaptureStartStopListener* listener : *capture_start_stop_listeners) {
     stop_threads.emplace_back([&listener] {
       listener->OnCaptureStopRequested();
-      LOG("CaptureStartStopListener stopped: one or more producers finished capturing");
+      ORBIT_LOG("CaptureStartStopListener stopped: one or more producers finished capturing");
     });
   }
 
@@ -136,7 +136,7 @@ class ProducerEventProcessorHijackingFunctionEntryExitForLinuxTracing
         tracing_handler_->ProcessFunctionExit(event.function_exit());
         break;
       case ProducerCaptureEvent::EVENT_NOT_SET:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       default:
         producer_event_processor_->ProcessEvent(producer_id, std::move(event));
     }
@@ -173,26 +173,27 @@ LinuxCaptureService::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
 
         absl::MutexLock lock{stop_capture_mutex.get()};
         if (!*stop_capture) {
-          LOG("Client finished writing on Capture's gRPC stream: stopping capture");
+          ORBIT_LOG("Client finished writing on Capture's gRPC stream: stopping capture");
           *stop_capture = true;
           *stop_capture_reason = StopCaptureReason::kClientStop;
         } else {
-          LOG("Client finished writing on Capture's gRPC stream or the RPC has already finished; "
+          ORBIT_LOG(
+              "Client finished writing on Capture's gRPC stream or the RPC has already finished; "
               "the capture was already stopped");
         }
       }};
 
   static const uint64_t mem_total_bytes = GetPhysicalMemoryInBytes();
   static const uint64_t watchdog_threshold_bytes = mem_total_bytes / 2;
-  LOG("Starting memory watchdog with threshold %u B because total physical memory is %u B",
-      watchdog_threshold_bytes, mem_total_bytes);
+  ORBIT_LOG("Starting memory watchdog with threshold %u B because total physical memory is %u B",
+            watchdog_threshold_bytes, mem_total_bytes);
   while (true) {
     {
       absl::MutexLock lock{stop_capture_mutex.get()};
       static constexpr absl::Duration kWatchdogPollInterval = absl::Seconds(1);
       if (stop_capture_mutex->AwaitWithTimeout(absl::Condition(stop_capture.get()),
                                                kWatchdogPollInterval)) {
-        LOG("Stopping memory watchdog as the capture was stopped");
+        ORBIT_LOG("Stopping memory watchdog as the capture was stopped");
         break;
       }
     }
@@ -200,11 +201,11 @@ LinuxCaptureService::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
     // Repeatedly poll the resident set size (rss) of the current process (OrbitService).
     std::optional<uint64_t> rss_bytes = ReadRssInBytesFromProcPidStat();
     if (!rss_bytes.has_value()) {
-      ERROR_ONCE("Reading resident set size of OrbitService");
+      ORBIT_ERROR_ONCE("Reading resident set size of OrbitService");
       continue;
     }
     if (rss_bytes.value() > watchdog_threshold_bytes) {
-      LOG("Memory threshold exceeded: stopping capture (and stopping memory watchdog)");
+      ORBIT_LOG("Memory threshold exceeded: stopping capture (and stopping memory watchdog)");
       absl::MutexLock lock{stop_capture_mutex.get()};
       *stop_capture = true;
       *stop_capture_reason = StopCaptureReason::kMemoryWatchdog;
@@ -216,7 +217,7 @@ LinuxCaptureService::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
   // memory threshold was exceeded. So at that point we can proceed with stopping the capture.
   {
     absl::MutexLock lock{stop_capture_mutex.get()};
-    CHECK(stop_capture_reason->has_value());
+    ORBIT_CHECK(stop_capture_reason->has_value());
     return stop_capture_reason->value();
   }
 }
@@ -247,7 +248,7 @@ grpc::Status LinuxCaptureService::Capture(
   if (capture_options.enable_api()) {
     auto result = orbit_api_loader::EnableApiInTracee(capture_options);
     if (result.has_error()) {
-      ERROR("Enabling Orbit Api: %s", result.error().message());
+      ORBIT_ERROR("Enabling Orbit Api: %s", result.error().message());
       error_enabling_orbit_api =
           absl::StrFormat("Could not enable Orbit API: %s", result.error().message());
     }
@@ -269,14 +270,14 @@ grpc::Status LinuxCaptureService::Capture(
     if (result_or_error.has_error()) {
       error_enabling_user_space_instrumentation = absl::StrFormat(
           "Could not enable user space instrumentation: %s", result_or_error.error().message());
-      ERROR("%s", error_enabling_user_space_instrumentation.value());
+      ORBIT_ERROR("%s", error_enabling_user_space_instrumentation.value());
     } else {
       FilterOutInstrumentedFunctionsFromCaptureOptions(
           result_or_error.value().instrumented_function_ids, linux_tracing_capture_options);
 
-      LOG("User space instrumentation enabled for %u out of %u instrumented functions.",
-          result_or_error.value().instrumented_function_ids.size(),
-          capture_options.instrumented_functions_size());
+      ORBIT_LOG("User space instrumentation enabled for %u out of %u instrumented functions.",
+                result_or_error.value().instrumented_function_ids.size(),
+                capture_options.instrumented_functions_size());
 
       if (!result_or_error.value().function_ids_to_error_messages.empty()) {
         info_from_enabling_user_space_instrumentation =
@@ -336,7 +337,7 @@ grpc::Status LinuxCaptureService::Capture(
   if (capture_options.enable_api()) {
     auto result = orbit_api_loader::DisableApiInTracee(capture_options);
     if (result.has_error()) {
-      ERROR("Disabling Orbit Api: %s", result.error().message());
+      ORBIT_ERROR("Disabling Orbit Api: %s", result.error().message());
       producer_event_processor_->ProcessEvent(
           orbit_grpc_protos::kRootProducerId,
           orbit_capture_service::CreateWarningEvent(
@@ -352,7 +353,7 @@ grpc::Status LinuxCaptureService::Capture(
     const pid_t target_process_id = orbit_base::ToNativeProcessId(capture_options.pid());
     auto result_tmp = instrumentation_manager_->UninstrumentProcess(target_process_id);
     if (result_tmp.has_error()) {
-      ERROR("Disabling user space instrumentation: %s", result_tmp.error().message());
+      ORBIT_ERROR("Disabling user space instrumentation: %s", result_tmp.error().message());
       producer_event_processor_->ProcessEvent(
           orbit_grpc_protos::kRootProducerId,
           orbit_capture_service::CreateWarningEvent(

--- a/src/LinuxCaptureService/MemoryInfoHandler.cpp
+++ b/src/LinuxCaptureService/MemoryInfoHandler.cpp
@@ -21,17 +21,17 @@ void MemoryInfoHandler::Start(orbit_grpc_protos::CaptureOptions capture_options)
 
   const pid_t pid = orbit_base::ToNativeProcessId(capture_options.pid());
 
-  CHECK(system_memory_info_producer_ == nullptr);
+  ORBIT_CHECK(system_memory_info_producer_ == nullptr);
   system_memory_info_producer_ = orbit_memory_tracing::CreateSystemMemoryInfoProducer(
       this, capture_options.memory_sampling_period_ns(), pid);
   system_memory_info_producer_->Start();
 
-  CHECK(cgroup_memory_info_producer_ == nullptr);
+  ORBIT_CHECK(cgroup_memory_info_producer_ == nullptr);
   cgroup_memory_info_producer_ = orbit_memory_tracing::CreateCGroupMemoryInfoProducer(
       this, capture_options.memory_sampling_period_ns(), pid);
   cgroup_memory_info_producer_->Start();
 
-  CHECK(process_memory_info_producer_ == nullptr);
+  ORBIT_CHECK(process_memory_info_producer_ == nullptr);
   process_memory_info_producer_ = orbit_memory_tracing::CreateProcessMemoryInfoProducer(
       this, capture_options.memory_sampling_period_ns(), pid);
   process_memory_info_producer_->Start();

--- a/src/LinuxCaptureService/MemoryInfoHandler.h
+++ b/src/LinuxCaptureService/MemoryInfoHandler.h
@@ -22,7 +22,7 @@ class MemoryInfoHandler : public orbit_memory_tracing::MemoryInfoListener {
   explicit MemoryInfoHandler(
       orbit_producer_event_processor::ProducerEventProcessor* producer_event_processor)
       : producer_event_processor_{producer_event_processor} {
-    CHECK(producer_event_processor_ != nullptr);
+    ORBIT_CHECK(producer_event_processor_ != nullptr);
   }
 
   ~MemoryInfoHandler() override = default;

--- a/src/LinuxCaptureService/MemoryWatchdog.cpp
+++ b/src/LinuxCaptureService/MemoryWatchdog.cpp
@@ -40,7 +40,7 @@ std::optional<uint64_t> ExtractRssInPagesFromProcPidStat(std::string_view proc_p
 
   uint64_t rss_pages;
   if (!absl::SimpleAtoi(rss_string, &rss_pages)) {
-    ERROR_ONCE("Parsing rss \"%s\"", rss_string);
+    ORBIT_ERROR_ONCE("Parsing rss \"%s\"", rss_string);
     return std::nullopt;
   }
   return rss_pages;
@@ -52,13 +52,13 @@ std::optional<uint64_t> ReadRssInBytesFromProcPidStat() {
 
   ErrorMessageOr<std::string> error_or_stat = orbit_base::ReadFileToString(proc_pid_stat_filename);
   if (error_or_stat.has_error()) {
-    ERROR_ONCE("Reading \"%s\": %s", proc_pid_stat_filename, error_or_stat.error().message());
+    ORBIT_ERROR_ONCE("Reading \"%s\": %s", proc_pid_stat_filename, error_or_stat.error().message());
     return std::nullopt;
   }
 
   std::optional<uint64_t> rss_pages = ExtractRssInPagesFromProcPidStat(error_or_stat.value());
   if (!rss_pages.has_value()) {
-    ERROR_ONCE("Extracting rss from \"%s\"", proc_pid_stat_filename);
+    ORBIT_ERROR_ONCE("Extracting rss from \"%s\"", proc_pid_stat_filename);
     return std::nullopt;
   }
 

--- a/src/LinuxCaptureService/TracingHandler.cpp
+++ b/src/LinuxCaptureService/TracingHandler.cpp
@@ -30,7 +30,7 @@ using orbit_grpc_protos::kLinuxTracingProducerId;
 void TracingHandler::Start(
     const CaptureOptions& capture_options,
     std::unique_ptr<UserSpaceInstrumentationAddressesImpl> user_space_instrumentation_addresses) {
-  CHECK(tracer_ == nullptr);
+  ORBIT_CHECK(tracer_ == nullptr);
 
   tracer_ = orbit_linux_tracing::Tracer::Create(
       capture_options, std::move(user_space_instrumentation_addresses), this);
@@ -38,7 +38,7 @@ void TracingHandler::Start(
 }
 
 void TracingHandler::Stop() {
-  CHECK(tracer_ != nullptr);
+  ORBIT_CHECK(tracer_ != nullptr);
   tracer_->Stop();
   // tracer_ is not reset as FunctionEntry and FunctionExit events could still arrive afterwards. In
   // that case the Tracer will simply not process them.

--- a/src/LinuxTracing/ContextSwitchManager.cpp
+++ b/src/LinuxTracing/ContextSwitchManager.cpp
@@ -32,7 +32,7 @@ std::optional<SchedulingSlice> ContextSwitchManager::ProcessContextSwitchOut(
   pid_t open_tid = open_switch_it->second.tid;
   uint64_t open_timestamp_ns = open_switch_it->second.timestamp_ns;
 
-  CHECK(timestamp_ns >= open_timestamp_ns);
+  ORBIT_CHECK(timestamp_ns >= open_timestamp_ns);
 
   // Remove the OpenSwitchIn for this core before returning, as it will have been processed.
   open_switches_by_core_.erase(core);

--- a/src/LinuxTracing/GpuTracepointVisitor.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitor.cpp
@@ -103,7 +103,7 @@ void GpuTracepointVisitor::CreateGpuJobAndSendToListenerIfComplete(const Key& ke
   gpu_job.set_dma_fence_signaled_time_ns(dma_it->second.timestamp_ns);
   gpu_job.set_timeline(cs_it->second.timeline);
 
-  CHECK(listener_ != nullptr);
+  ORBIT_CHECK(listener_ != nullptr);
   listener_->OnGpuJob(std::move(gpu_job));
 
   // We need to update the timestamp when the last GPU job so far seen

--- a/src/LinuxTracing/GpuTracepointVisitor.h
+++ b/src/LinuxTracing/GpuTracepointVisitor.h
@@ -23,7 +23,7 @@ namespace orbit_linux_tracing {
 class GpuTracepointVisitor : public PerfEventVisitor {
  public:
   explicit GpuTracepointVisitor(TracerListener* listener) : listener_{listener} {
-    CHECK(listener_ != nullptr);
+    ORBIT_CHECK(listener_ != nullptr);
   }
 
   void Visit(uint64_t event_timestamp, const AmdgpuCsIoctlPerfEventData& event_data) override;

--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -41,10 +41,10 @@ using orbit_grpc_protos::Callstack;
 Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
     const CallchainSamplePerfEventData* event_data, LibunwindstackMaps* current_maps,
     LibunwindstackUnwinder* unwinder) {
-  CHECK(event_data != nullptr);
-  CHECK(current_maps != nullptr);
-  CHECK(unwinder != nullptr);
-  CHECK(event_data->GetCallchainSize() > 2);
+  ORBIT_CHECK(event_data != nullptr);
+  ORBIT_CHECK(current_maps != nullptr);
+  ORBIT_CHECK(unwinder != nullptr);
+  ORBIT_CHECK(event_data->GetCallchainSize() > 2);
 
   uint64_t rbp = event_data->GetRegisters()[PERF_REG_X86_BP];
   uint64_t rsp = event_data->GetRegisters()[PERF_REG_X86_SP];
@@ -65,8 +65,9 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
       libunwindstack_result.frames();
 
   if (libunwindstack_callstack.empty()) {
-    ERROR("Discarding sample as DWARF-based unwinding resulted in empty callstack (error: %s)",
-          LibunwindstackUnwinder::LibunwindstackErrorString(libunwindstack_result.error_code()));
+    ORBIT_ERROR(
+        "Discarding sample as DWARF-based unwinding resulted in empty callstack (error: %s)",
+        LibunwindstackUnwinder::LibunwindstackErrorString(libunwindstack_result.error_code()));
     return Callstack::kStackTopDwarfUnwindingError;
   }
 
@@ -84,7 +85,7 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
   }
 
   const std::vector<uint64_t> original_callchain = event_data->CopyOfIpsAsVector();
-  CHECK(original_callchain.size() > 2);
+  ORBIT_CHECK(original_callchain.size() > 2);
 
   std::vector<uint64_t> result;
   result.reserve(original_callchain.size() + 1);
@@ -92,7 +93,7 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
     result.push_back(original_callchain[i]);
   }
 
-  CHECK(libunwindstack_callstack.size() == 2);
+  ORBIT_CHECK(libunwindstack_callstack.size() == 2);
   uint64_t libunwindstack_leaf_caller_pc = libunwindstack_callstack[1].pc;
 
   // If the caller is not executable, we have an unwinding error.

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -109,8 +109,8 @@ LibunwindstackResult LibunwindstackUnwinderImpl::Unwind(
 
 #ifndef NDEBUG
   if (unwinder.LastErrorCode() != 0) {
-    ERROR("%s at %#016lx", LibunwindstackErrorString(unwinder.LastErrorCode()),
-          unwinder.LastErrorAddress());
+    ORBIT_ERROR("%s at %#016lx", LibunwindstackErrorString(unwinder.LastErrorCode()),
+                unwinder.LastErrorAddress());
   }
 #endif
 

--- a/src/LinuxTracing/LinuxTracingUtils.cpp
+++ b/src/LinuxTracing/LinuxTracingUtils.cpp
@@ -49,14 +49,15 @@ std::optional<char> GetThreadState(pid_t tid) {
 
   ErrorMessageOr<std::string> file_content_or_error = orbit_base::ReadFileToString(stat);
   if (file_content_or_error.has_error()) {
-    ERROR("Could not open \"%s\": %s", stat.string(), file_content_or_error.error().message());
+    ORBIT_ERROR("Could not open \"%s\": %s", stat.string(),
+                file_content_or_error.error().message());
     return std::nullopt;
   }
 
   std::vector<std::string> lines =
       absl::StrSplit(file_content_or_error.value(), absl::MaxSplits('\n', 1));
   if (lines.empty()) {
-    ERROR("Empty \"%s\" file", stat.string());
+    ORBIT_ERROR("Empty \"%s\" file", stat.string());
     return std::nullopt;
   }
   std::string first_line = lines.at(0);
@@ -175,14 +176,14 @@ int GetTracepointId(const char* tracepoint_category, const char* tracepoint_name
 
   ErrorMessageOr<std::string> file_content_or_error = orbit_base::ReadFileToString(filename);
   if (file_content_or_error.has_error()) {
-    ERROR("Reading tracepoint id of %s:%s: %s", tracepoint_category, tracepoint_name,
-          file_content_or_error.error().message());
+    ORBIT_ERROR("Reading tracepoint id of %s:%s: %s", tracepoint_category, tracepoint_name,
+                file_content_or_error.error().message());
     return -1;
   }
 
   int tp_id = -1;
   if (!absl::SimpleAtoi(file_content_or_error.value(), &tp_id)) {
-    ERROR("Parsing tracepoint id for: %s:%s", tracepoint_category, tracepoint_name);
+    ORBIT_ERROR("Parsing tracepoint id for: %s:%s", tracepoint_category, tracepoint_name);
     return -1;
   }
   return tp_id;
@@ -192,7 +193,7 @@ uint64_t GetMaxOpenFilesHardLimit() {
   rlimit limit{};
   int ret = getrlimit(RLIMIT_NOFILE, &limit);
   if (ret != 0) {
-    ERROR("getrlimit: %s", SafeStrerror(errno));
+    ORBIT_ERROR("getrlimit: %s", SafeStrerror(errno));
     return 0;
   }
   return limit.rlim_max;
@@ -206,7 +207,7 @@ bool SetMaxOpenFilesSoftLimit(uint64_t soft_limit) {
   rlimit limit{soft_limit, hard_limit};
   int ret = setrlimit(RLIMIT_NOFILE, &limit);
   if (ret != 0) {
-    ERROR("setrlimit: %s", SafeStrerror(errno));
+    ORBIT_ERROR("setrlimit: %s", SafeStrerror(errno));
     return false;
   }
   return true;

--- a/src/LinuxTracing/LostAndDiscardedEventVisitor.h
+++ b/src/LinuxTracing/LostAndDiscardedEventVisitor.h
@@ -17,7 +17,7 @@ namespace orbit_linux_tracing {
 class LostAndDiscardedEventVisitor : public PerfEventVisitor {
  public:
   explicit LostAndDiscardedEventVisitor(TracerListener* listener) : listener_{listener} {
-    CHECK(listener_ != nullptr);
+    ORBIT_CHECK(listener_ != nullptr);
   }
 
   void Visit(uint64_t event_timestamp, const LostPerfEventData& event_data) override {
@@ -25,7 +25,7 @@ class LostAndDiscardedEventVisitor : public PerfEventVisitor {
     lost_perf_records_event.set_duration_ns(event_timestamp - event_data.previous_timestamp);
     lost_perf_records_event.set_end_timestamp_ns(event_timestamp);
 
-    CHECK(listener_ != nullptr);
+    ORBIT_CHECK(listener_ != nullptr);
     listener_->OnLostPerfRecordsEvent(std::move(lost_perf_records_event));
   }
 
@@ -35,7 +35,7 @@ class LostAndDiscardedEventVisitor : public PerfEventVisitor {
                                                         event_data.begin_timestamp_ns);
     out_of_order_events_discarded_event.set_end_timestamp_ns(event_timestamp);
 
-    CHECK(listener_ != nullptr);
+    ORBIT_CHECK(listener_ != nullptr);
     listener_->OnOutOfOrderEventsDiscardedEvent(std::move(out_of_order_events_discarded_event));
   }
 

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -34,7 +34,7 @@ perf_event_attr generic_event_attr() {
 int generic_event_open(perf_event_attr* attr, pid_t pid, int32_t cpu) {
   int fd = perf_event_open(attr, pid, cpu, -1, PERF_FLAG_FD_CLOEXEC);
   if (fd == -1) {
-    ERROR("perf_event_open: %s", SafeStrerror(errno));
+    ORBIT_ERROR("perf_event_open: %s", SafeStrerror(errno));
   }
   return fd;
 }
@@ -153,14 +153,14 @@ void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length) {
   // The size of the ring buffer excluding the metadata page must be a power of
   // two number of pages.
   if (mmap_length < GetPageSize() || __builtin_popcountl(mmap_length - GetPageSize()) != 1) {
-    ERROR("mmap length for perf_event_open not 1+2^n pages: %lu", mmap_length);
+    ORBIT_ERROR("mmap length for perf_event_open not 1+2^n pages: %lu", mmap_length);
     return nullptr;
   }
 
   // Use mmap to get access to the ring buffer.
   void* mmap_ret = mmap(nullptr, mmap_length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (mmap_ret == MAP_FAILED) {
-    ERROR("mmap: %s", SafeStrerror(errno));
+    ORBIT_ERROR("mmap: %s", SafeStrerror(errno));
     return nullptr;
   }
 

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -27,28 +27,28 @@ namespace orbit_linux_tracing {
 inline void perf_event_reset(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_RESET, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_RESET: %s", SafeStrerror(errno));
+    ORBIT_ERROR("PERF_EVENT_IOC_RESET: %s", SafeStrerror(errno));
   }
 }
 
 inline void perf_event_enable(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_ENABLE, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_ENABLE: %s", SafeStrerror(errno));
+    ORBIT_ERROR("PERF_EVENT_IOC_ENABLE: %s", SafeStrerror(errno));
   }
 }
 
 inline void perf_event_disable(int file_descriptor) {
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_DISABLE, 0);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_DISABLE: %s", SafeStrerror(errno));
+    ORBIT_ERROR("PERF_EVENT_IOC_DISABLE: %s", SafeStrerror(errno));
   }
 }
 
 inline void perf_event_redirect(int from_fd, int to_fd) {
   int ret = ioctl(from_fd, PERF_EVENT_IOC_SET_OUTPUT, to_fd);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_SET_OUTPUT: %s", SafeStrerror(errno));
+    ORBIT_ERROR("PERF_EVENT_IOC_SET_OUTPUT: %s", SafeStrerror(errno));
   }
 }
 
@@ -56,7 +56,7 @@ inline uint64_t perf_event_get_id(int file_descriptor) {
   uint64_t id;
   int ret = ioctl(file_descriptor, PERF_EVENT_IOC_ID, &id);
   if (ret != 0) {
-    ERROR("PERF_EVENT_IOC_ID: %s", SafeStrerror(errno));
+    ORBIT_ERROR("PERF_EVENT_IOC_ID: %s", SafeStrerror(errno));
     return 0;
   }
   return id;

--- a/src/LinuxTracing/PerfEventProcessor.cpp
+++ b/src/LinuxTracing/PerfEventProcessor.cpp
@@ -46,7 +46,7 @@ std::optional<DiscardedPerfEvent> PerfEventProcessor::HandleOutOfOrderEvent(
 
   std::optional<DiscardedPerfEvent> optional_discarded_event = std::nullopt;
 
-  CHECK(discarded_end >= last_discarded_end_);
+  ORBIT_CHECK(discarded_end >= last_discarded_end_);
   if (discarded_end == last_discarded_end_ && discarded_begin < last_discarded_begin_) {
     optional_discarded_event = optional_discarded_event = DiscardedPerfEvent{
         .timestamp = discarded_end,
@@ -74,7 +74,7 @@ std::optional<DiscardedPerfEvent> PerfEventProcessor::HandleOutOfOrderEvent(
     };
     last_discarded_begin_ = discarded_begin;
   } else {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
 
   last_discarded_end_ = discarded_end;
@@ -85,12 +85,12 @@ std::optional<DiscardedPerfEvent> PerfEventProcessor::HandleOutOfOrderEvent(
 }
 
 void PerfEventProcessor::ProcessAllEvents() {
-  CHECK(!visitors_.empty());
+  ORBIT_CHECK(!visitors_.empty());
   while (event_queue_.HasEvent()) {
     const PerfEvent& event = event_queue_.TopEvent();
     // Events are guaranteed to be processed in order of timestamp
     // as out-of-order events are discarded in AddEvent.
-    CHECK(event.timestamp >= last_processed_timestamp_ns_);
+    ORBIT_CHECK(event.timestamp >= last_processed_timestamp_ns_);
     last_processed_timestamp_ns_ = event.timestamp;
     for (PerfEventVisitor* visitor : visitors_) {
       event.Accept(visitor);
@@ -100,7 +100,7 @@ void PerfEventProcessor::ProcessAllEvents() {
 }
 
 void PerfEventProcessor::ProcessOldEvents() {
-  CHECK(!visitors_.empty());
+  ORBIT_CHECK(!visitors_.empty());
   const uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
 
   while (event_queue_.HasEvent()) {
@@ -113,7 +113,7 @@ void PerfEventProcessor::ProcessOldEvents() {
     }
     // Events are guaranteed to be processed in order of timestamp
     // as out-of-order events are discarded in AddEvent.
-    CHECK(timestamp >= last_processed_timestamp_ns_);
+    ORBIT_CHECK(timestamp >= last_processed_timestamp_ns_);
     last_processed_timestamp_ns_ = timestamp;
 
     for (PerfEventVisitor* visitor : visitors_) {

--- a/src/LinuxTracing/PerfEventQueue.cpp
+++ b/src/LinuxTracing/PerfEventQueue.cpp
@@ -23,9 +23,9 @@ void PerfEventQueue::PushEvent(PerfEvent&& event) {
              queue_it != queues_of_events_ordered_in_stream_.end()) {
     const std::unique_ptr<std::queue<PerfEvent>>& queue = queue_it->second;
 
-    CHECK(!queue->empty());
+    ORBIT_CHECK(!queue->empty());
     // Fundamental assumption: events from the same file descriptor come already in order.
-    CHECK(event.timestamp >= queue->back().timestamp);
+    ORBIT_CHECK(event.timestamp >= queue->back().timestamp);
     queue->push(std::move(event));
   } else {
     queue_it = queues_of_events_ordered_in_stream_
@@ -49,12 +49,12 @@ const PerfEvent& PerfEventQueue::TopEvent() {
   // top of the two queues. In case those two events have the exact same timestamp, return the one
   // at the top of priority_queue_of_events_not_ordered_in_stream_ (and do the same in PopEvent).
   if (priority_queue_of_events_not_ordered_in_stream_.empty()) {
-    CHECK(!heap_of_queues_of_events_ordered_in_stream_.empty());
-    CHECK(!heap_of_queues_of_events_ordered_in_stream_.front()->empty());
+    ORBIT_CHECK(!heap_of_queues_of_events_ordered_in_stream_.empty());
+    ORBIT_CHECK(!heap_of_queues_of_events_ordered_in_stream_.front()->empty());
     return heap_of_queues_of_events_ordered_in_stream_.front()->front();
   }
   if (heap_of_queues_of_events_ordered_in_stream_.empty()) {
-    CHECK(!priority_queue_of_events_not_ordered_in_stream_.empty());
+    ORBIT_CHECK(!priority_queue_of_events_not_ordered_in_stream_.empty());
     return priority_queue_of_events_not_ordered_in_stream_.top();
   }
   return (heap_of_queues_of_events_ordered_in_stream_.front()->front().timestamp <

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -25,9 +25,9 @@ namespace orbit_linux_tracing {
 
 void ReadPerfSampleIdAll(PerfEventRingBuffer* ring_buffer, const perf_event_header& header,
                          perf_event_sample_id_tid_time_streamid_cpu* sample_id) {
-  CHECK(sample_id != nullptr);
-  CHECK(header.size >
-        sizeof(perf_event_header) + sizeof(perf_event_sample_id_tid_time_streamid_cpu));
+  ORBIT_CHECK(sample_id != nullptr);
+  ORBIT_CHECK(header.size >
+              sizeof(perf_event_header) + sizeof(perf_event_sample_id_tid_time_streamid_cpu));
   // sample_id_all is always the last field in the event
   uint64_t offset = header.size - sizeof(perf_event_sample_id_tid_time_streamid_cpu);
   ring_buffer->ReadValueAtOffset(sample_id, offset);
@@ -99,7 +99,7 @@ MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
   // read filename
   size_t filename_offset = sizeof(perf_event_mmap_up_to_pgoff);
   // strictly > because filename is null-terminated string
-  CHECK(header.size > (filename_offset + sizeof(perf_event_sample_id_tid_time_streamid_cpu)));
+  ORBIT_CHECK(header.size > (filename_offset + sizeof(perf_event_sample_id_tid_time_streamid_cpu)));
   size_t filename_size =
       header.size - filename_offset - sizeof(perf_event_sample_id_tid_time_streamid_cpu);
   std::vector<char> filename_vector(filename_size);
@@ -270,14 +270,14 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
 
 SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  CHECK(header.size >= sizeof(perf_event_raw_sample_fixed));
+  ORBIT_CHECK(header.size >= sizeof(perf_event_raw_sample_fixed));
   perf_event_raw_sample_fixed ring_buffer_record;
   ring_buffer->ReadRawAtOffset(&ring_buffer_record, 0, sizeof(perf_event_raw_sample_fixed));
 
   // The last fields of the sched:sched_wakeup tracepoint aren't always the same, depending on the
   // kernel version. Fortunately we only need the first fields, which are always the same, so only
   // read those. See `sched_wakeup_tracepoint_fixed`.
-  CHECK(ring_buffer_record.size >= sizeof(sched_wakeup_tracepoint_fixed));
+  ORBIT_CHECK(ring_buffer_record.size >= sizeof(sched_wakeup_tracepoint_fixed));
   sched_wakeup_tracepoint_fixed sched_wakeup;
   ring_buffer->ReadRawAtOffset(
       &sched_wakeup,

--- a/src/LinuxTracing/PerfEventRingBuffer.h
+++ b/src/LinuxTracing/PerfEventRingBuffer.h
@@ -35,7 +35,7 @@ class PerfEventRingBuffer {
 
   template <typename T>
   void ConsumeRecord(const perf_event_header& header, T* record) {
-    CHECK(header.size == sizeof(T));
+    ORBIT_CHECK(header.size == sizeof(T));
     ConsumeRawRecord(header, record);
   }
 

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
@@ -23,7 +23,7 @@ using orbit_grpc_protos::ThreadStateSlice;
 void SwitchesStatesNamesVisitor::ProcessInitialTidToPidAssociation(pid_t tid, pid_t pid) {
   bool new_insertion = tid_to_pid_association_.insert_or_assign(tid, pid).second;
   if (!new_insertion) {
-    ERROR("Overwriting previous pid for tid %d with initial pid %d", tid, pid);
+    ORBIT_ERROR("Overwriting previous pid for tid %d with initial pid %d", tid, pid);
   }
 }
 
@@ -33,7 +33,7 @@ void SwitchesStatesNamesVisitor::Visit(uint64_t /*event_timestamp*/,
   pid_t tid = event_data.tid;
   bool new_insertion = tid_to_pid_association_.insert_or_assign(tid, pid).second;
   if (!new_insertion) {
-    ERROR("Overwriting previous pid for tid %d with pid %d from PERF_RECORD_FORK", tid, pid);
+    ORBIT_ERROR("Overwriting previous pid for tid %d with pid %d from PERF_RECORD_FORK", tid, pid);
   }
 }
 
@@ -82,7 +82,7 @@ void SwitchesStatesNamesVisitor::ProcessInitialState(uint64_t timestamp_ns, pid_
 
   std::optional<ThreadStateSlice::ThreadState> initial_state = GetThreadStateFromChar(state_char);
   if (!initial_state.has_value()) {
-    ERROR("Parsing thread state char '%c' for tid %d", state_char, tid);
+    ORBIT_ERROR("Parsing thread state char '%c' for tid %d", state_char, tid);
     return;
   }
   state_manager_.OnInitialState(timestamp_ns, tid, initial_state.value());
@@ -125,7 +125,7 @@ void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
         prev_pid, event_data.prev_tid, event_data.cpu, event_timestamp);
     if (scheduling_slice.has_value()) {
       if (scheduling_slice->pid() == orbit_base::kInvalidProcessId) {
-        ERROR("SchedulingSlice with unknown pid");
+        ORBIT_ERROR("SchedulingSlice with unknown pid");
       }
       listener_->OnSchedulingSlice(std::move(scheduling_slice.value()));
     }
@@ -244,8 +244,8 @@ std::optional<ThreadStateSlice::ThreadState> SwitchesStatesNamesVisitor::GetThre
 // https://github.com/torvalds/linux/blob/master/fs/proc/array.c.
 ThreadStateSlice::ThreadState SwitchesStatesNamesVisitor::GetThreadStateFromBits(uint64_t bits) {
   if (__builtin_popcountl(bits & 0xFF) > 1) {
-    ERROR("The thread state mask %#lx is a combination of states, reporting only the first",
-          bits & 0xFF);
+    ORBIT_ERROR("The thread state mask %#lx is a combination of states, reporting only the first",
+                bits & 0xFF);
   }
   if ((bits & 0x01) != 0) return ThreadStateSlice::kInterruptibleSleep;
   if ((bits & 0x02) != 0) return ThreadStateSlice::kUninterruptibleSleep;

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.h
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.h
@@ -37,7 +37,7 @@ namespace orbit_linux_tracing {
 class SwitchesStatesNamesVisitor : public PerfEventVisitor {
  public:
   explicit SwitchesStatesNamesVisitor(TracerListener* listener) : listener_{listener} {
-    CHECK(listener_ != nullptr);
+    ORBIT_CHECK(listener_ != nullptr);
   }
 
   void SetThreadStateCounter(std::atomic<uint64_t>* thread_state_counter) {

--- a/src/LinuxTracing/SwitchesStatesNamesVisitorTest.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitorTest.cpp
@@ -112,7 +112,7 @@ TaskNewtaskPerfEvent MakeFakeTaskNewtaskPerfEvent(pid_t new_tid, const char* com
               .new_tid = new_tid,
           },
   };
-  CHECK(strlen(comm) < 16);
+  ORBIT_CHECK(strlen(comm) < 16);
   strncpy(event.data.comm, comm, 16);
   return event;
 }
@@ -126,7 +126,7 @@ TaskRenamePerfEvent MakeFakeTaskRenamePerfEvent(pid_t renamed_tid, const char* n
               .renamed_tid = renamed_tid,
           },
   };
-  CHECK(strlen(new_comm) < 16);
+  ORBIT_CHECK(strlen(new_comm) < 16);
   strncpy(event.data.newcomm, new_comm, 16);
   return event;
 }

--- a/src/LinuxTracing/UprobesFunctionCallManager.h
+++ b/src/LinuxTracing/UprobesFunctionCallManager.h
@@ -43,7 +43,7 @@ class UprobesFunctionCallManager {
     std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_.at(tid);
 
     // As we erase the stack for this thread as soon as it becomes empty.
-    CHECK(!stack_of_open_functions.empty());
+    ORBIT_CHECK(!stack_of_open_functions.empty());
     OpenFunction& open_function = stack_of_open_functions.back();
 
     orbit_grpc_protos::FunctionCall function_call;

--- a/src/LinuxTracing/UprobesReturnAddressManager.h
+++ b/src/LinuxTracing/UprobesReturnAddressManager.h
@@ -47,7 +47,7 @@ class UprobesReturnAddressManager {
     }
 
     std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_.at(tid);
-    CHECK(!stack_of_open_functions.empty());
+    ORBIT_CHECK(!stack_of_open_functions.empty());
     stack_of_open_functions.pop_back();
     if (stack_of_open_functions.empty()) {
       tid_to_stack_of_open_functions_.erase(tid);
@@ -61,7 +61,7 @@ class UprobesReturnAddressManager {
     }
 
     std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_.at(tid);
-    CHECK(!stack_of_open_functions.empty());
+    ORBIT_CHECK(!stack_of_open_functions.empty());
 
     // Apply saved return addresses in reverse order, from the last called function. In case two
     // return addresses are hijacked at the same stack pointer (e.g., in case of tail-call
@@ -91,9 +91,9 @@ class UprobesReturnAddressManager {
   // addresses saved by uprobes or user space instrumentation on function entry.
   virtual bool PatchCallchain(pid_t tid, uint64_t* callchain, uint64_t callchain_size,
                               LibunwindstackMaps* maps) {
-    CHECK(callchain_size > 0);
-    CHECK(callchain != nullptr);
-    CHECK(maps != nullptr);
+    ORBIT_CHECK(callchain_size > 0);
+    ORBIT_CHECK(callchain != nullptr);
+    ORBIT_CHECK(maps != nullptr);
 
     std::vector<uint64_t> frames_to_patch;
     for (uint64_t i = 0; i < callchain_size; i++) {
@@ -119,7 +119,7 @@ class UprobesReturnAddressManager {
       //     some uprobes);
       //  2. When some events are lost or processed out of order.
       if (!frames_to_patch.empty()) {
-        ERROR(
+        ORBIT_ERROR(
             "Discarding sample in a dynamically instrumented function as all information is "
             "missing (tid=%d)",
             tid);
@@ -129,7 +129,7 @@ class UprobesReturnAddressManager {
     }
 
     std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_.at(tid);
-    CHECK(!stack_of_open_functions.empty());
+    ORBIT_CHECK(!stack_of_open_functions.empty());
 
     size_t num_unique_open_functions = 0;
     uint64_t prev_open_function_stack_pointer = -1;
@@ -149,7 +149,7 @@ class UprobesReturnAddressManager {
     // This is the same situation as above, but we have at least some open dynamically instrumented
     // functions.
     if (num_unique_open_functions < frames_to_patch.size()) {
-      ERROR(
+      ORBIT_ERROR(
           "Discarding sample in a dynamically instrumented function as some information is "
           "missing (tid=%d)",
           tid);
@@ -158,7 +158,7 @@ class UprobesReturnAddressManager {
     // In cases of lost events, or out of order processing, there might be wrong open dynamically
     // instrumented functions. So we need to discard the event.
     if (num_unique_open_functions > frames_to_patch.size() + 1) {
-      ERROR(
+      ORBIT_ERROR(
           "Discarding sample in a dynamically instrumented function as some information is "
           "incorrect (tid=%d)",
           tid);
@@ -205,7 +205,7 @@ class UprobesReturnAddressManager {
       callchain[frame_to_patch] = open_function.return_address;
       frames_to_patch_it++;
     }
-    CHECK(frames_to_patch_it == frames_to_patch.rend());
+    ORBIT_CHECK(frames_to_patch_it == frames_to_patch.rend());
     return true;
   }
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -55,12 +55,12 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
         unwinder_{unwinder},
         leaf_function_call_manager_{leaf_function_call_manager},
         user_space_instrumentation_addresses_{user_space_instrumentation_addresses} {
-    CHECK(listener_ != nullptr);
-    CHECK(function_call_manager_ != nullptr);
-    CHECK(return_address_manager_ != nullptr);
-    CHECK(current_maps_ != nullptr);
-    CHECK(unwinder_ != nullptr);
-    CHECK(leaf_function_call_manager_ != nullptr);
+    ORBIT_CHECK(listener_ != nullptr);
+    ORBIT_CHECK(function_call_manager_ != nullptr);
+    ORBIT_CHECK(return_address_manager_ != nullptr);
+    ORBIT_CHECK(current_maps_ != nullptr);
+    ORBIT_CHECK(unwinder_ != nullptr);
+    ORBIT_CHECK(leaf_function_call_manager_ != nullptr);
   }
 
   UprobesUnwindingVisitor(const UprobesUnwindingVisitor&) = delete;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -1216,8 +1216,8 @@ TEST_F(UprobesUnwindingVisitorTest, VisitPatchableCallchainSampleSendsCompleteCa
   auto fake_patch_callchain = [](pid_t /*tid*/, uint64_t* callchain, uint64_t callchain_size,
                                  orbit_linux_tracing::LibunwindstackMaps *
                                  /*maps*/) -> bool {
-    CHECK(callchain != nullptr);
-    CHECK(callchain_size == 4);
+    ORBIT_CHECK(callchain != nullptr);
+    ORBIT_CHECK(callchain_size == 4);
     callchain[2] = kTargetAddress2 + 1;
     return true;
   };
@@ -1304,7 +1304,7 @@ TEST_F(UprobesUnwindingVisitorTest,
                                                LibunwindstackMaps* /*maps*/,
                                                orbit_linux_tracing::LibunwindstackUnwinder *
                                                /*unwinder*/) -> Callstack::CallstackType {
-    CHECK(event_data != nullptr);
+    ORBIT_CHECK(event_data != nullptr);
     std::vector<uint64_t> patched_callchain;
     EXPECT_THAT(event_data->CopyOfIpsAsVector(),
                 ElementsAre(kKernelAddress, kTargetAddress1, kTargetAddress3 + 1));

--- a/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
@@ -29,7 +29,7 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
   bool inner_function_symbol_found = false;
   for (const orbit_grpc_protos::SymbolInfo& symbol : module_symbols.symbol_infos()) {
     if (symbol.name() == PuppetConstants::kOuterFunctionName) {
-      CHECK(!outer_function_symbol_found);
+      ORBIT_CHECK(!outer_function_symbol_found);
       outer_function_symbol_found = true;
       orbit_grpc_protos::InstrumentedFunction instrumented_function;
       instrumented_function.set_file_path(executable_path);
@@ -42,7 +42,7 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
     }
 
     if (symbol.name() == PuppetConstants::kInnerFunctionName) {
-      CHECK(!inner_function_symbol_found);
+      ORBIT_CHECK(!inner_function_symbol_found);
       inner_function_symbol_found = true;
       orbit_grpc_protos::InstrumentedFunction instrumented_function;
       instrumented_function.set_file_path(executable_path);
@@ -54,8 +54,8 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
       capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
     }
   }
-  CHECK(outer_function_symbol_found);
-  CHECK(inner_function_symbol_found);
+  ORBIT_CHECK(outer_function_symbol_found);
+  ORBIT_CHECK(inner_function_symbol_found);
 }
 
 void VerifyFunctionCallsOfPuppetOuterAndInnerFunction(

--- a/src/LinuxTracingIntegrationTests/IntegrationTestUtils.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestUtils.cpp
@@ -18,7 +18,7 @@ namespace orbit_linux_tracing_integration_tests {
 std::filesystem::path GetExecutableBinaryPath(pid_t pid) {
   auto error_or_executable_path =
       orbit_base::GetExecutablePath(orbit_base::FromNativeProcessId(pid));
-  CHECK(error_or_executable_path.has_value());
+  ORBIT_CHECK(error_or_executable_path.has_value());
   return error_or_executable_path.value();
 }
 
@@ -26,17 +26,17 @@ orbit_grpc_protos::ModuleSymbols GetExecutableBinaryModuleSymbols(pid_t pid) {
   const std::filesystem::path& executable_path = GetExecutableBinaryPath(pid);
 
   auto error_or_elf_file = orbit_object_utils::CreateElfFile(executable_path.string());
-  CHECK(error_or_elf_file.has_value());
+  ORBIT_CHECK(error_or_elf_file.has_value());
   const std::unique_ptr<orbit_object_utils::ElfFile>& elf_file = error_or_elf_file.value();
 
   auto error_or_module = elf_file->LoadDebugSymbols();
-  CHECK(error_or_module.has_value());
+  ORBIT_CHECK(error_or_module.has_value());
   return error_or_module.value();
 }
 
 orbit_grpc_protos::ModuleInfo GetExecutableBinaryModuleInfo(pid_t pid) {
   auto error_or_module_infos = orbit_object_utils::ReadModules(pid);
-  CHECK(error_or_module_infos.has_value());
+  ORBIT_CHECK(error_or_module_infos.has_value());
   const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos = error_or_module_infos.value();
 
   const std::filesystem::path& executable_path = GetExecutableBinaryPath(pid);
@@ -48,7 +48,7 @@ orbit_grpc_protos::ModuleInfo GetExecutableBinaryModuleInfo(pid_t pid) {
       break;
     }
   }
-  CHECK(executable_module_info != nullptr);
+  ORBIT_CHECK(executable_module_info != nullptr);
   return *executable_module_info;
 }
 

--- a/src/LinuxTracingIntegrationTests/IntegrationTestUtils.h
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestUtils.h
@@ -24,7 +24,7 @@ namespace orbit_linux_tracing_integration_tests {
     return true;
   }
 
-  ERROR("Root required for this test");
+  ORBIT_ERROR("Root required for this test");
   return false;
 }
 

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -37,11 +37,11 @@ namespace {
 
 [[nodiscard]] int ReadPerfEventParanoid() {
   auto error_or_content = orbit_base::ReadFileToString("/proc/sys/kernel/perf_event_paranoid");
-  CHECK(error_or_content.has_value());
+  ORBIT_CHECK(error_or_content.has_value());
   const std::string& content = error_or_content.value();
   int perf_event_paranoid = 2;
   bool atoi_succeeded = absl::SimpleAtoi(content, &perf_event_paranoid);
-  CHECK(atoi_succeeded);
+  ORBIT_CHECK(atoi_succeeded);
   return perf_event_paranoid;
 }
 
@@ -55,15 +55,15 @@ namespace {
     return true;
   }
 
-  ERROR("Root or max perf_event_paranoid %d (actual is %d) required for this test",
-        max_perf_event_paranoid, perf_event_paranoid);
+  ORBIT_ERROR("Root or max perf_event_paranoid %d (actual is %d) required for this test",
+              max_perf_event_paranoid, perf_event_paranoid);
   return false;
 }
 
 [[nodiscard]] std::string ReadUnameKernelRelease() {
   utsname utsname{};
   int uname_result = uname(&utsname);
-  CHECK(uname_result == 0);
+  ORBIT_CHECK(uname_result == 0);
   return utsname.release;
 }
 
@@ -73,7 +73,7 @@ namespace {
     return true;
   }
 
-  ERROR("Stadia instance required for this test (but kernel release is \"%s\")", release);
+  ORBIT_ERROR("Stadia instance required for this test (but kernel release is \"%s\")", release);
   return false;
 }
 
@@ -268,12 +268,12 @@ class LinuxTracingIntegrationTestFixture {
 
   void StartTracingAndWaitForTracingLoopStarted(
       const orbit_grpc_protos::CaptureOptions& capture_options) {
-    CHECK(tracer_ == nullptr);
-    CHECK(!listener_.has_value());
+    ORBIT_CHECK(tracer_ == nullptr);
+    ORBIT_CHECK(!listener_.has_value());
 
     if (IsRunningAsRoot()) {
       // Needed for BufferTracerListener::WaitForAtLeastOneSchedulingSlice().
-      CHECK(capture_options.trace_context_switches());
+      ORBIT_CHECK(capture_options.trace_context_switches());
     }
 
     listener_.emplace();
@@ -295,8 +295,8 @@ class LinuxTracingIntegrationTestFixture {
   }
 
   [[nodiscard]] std::vector<orbit_grpc_protos::ProducerCaptureEvent> StopTracingAndGetEvents() {
-    CHECK(tracer_ != nullptr);
-    CHECK(listener_.has_value());
+    ORBIT_CHECK(tracer_ != nullptr);
+    ORBIT_CHECK(listener_.has_value());
     tracer_->Stop();
     tracer_.reset();
     std::vector<orbit_grpc_protos::ProducerCaptureEvent> events = listener_->GetAndClearEvents();
@@ -315,7 +315,7 @@ using PuppetConstants = IntegrationTestPuppetConstants;
 [[nodiscard]] std::vector<orbit_grpc_protos::ProducerCaptureEvent> TraceAndGetEvents(
     LinuxTracingIntegrationTestFixture* fixture, std::string_view command,
     std::optional<orbit_grpc_protos::CaptureOptions> capture_options = std::nullopt) {
-  CHECK(fixture != nullptr);
+  ORBIT_CHECK(fixture != nullptr);
   if (!capture_options.has_value()) {
     capture_options = fixture->BuildDefaultCaptureOptions();
   }
@@ -338,41 +338,41 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
     switch (event.event_case()) {
       case orbit_grpc_protos::ProducerCaptureEvent::kApiEvent:
         // TracingHandler does not send this event.
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStart:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStartAsync:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStop:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStopAsync:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiStringEvent:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackDouble:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackFloat:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackInt:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackInt64:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackUint:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackUint64:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kCallstackSample:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kCaptureFinished:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kCaptureStarted:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kClockResolutionEvent:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kErrorEnablingOrbitApiEvent:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kErrorEnablingUserSpaceInstrumentationEvent:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kErrorsWithPerfEventOpenEvent:
         EXPECT_GE(event.errors_with_perf_event_open_event().timestamp_ns(),
                   previous_event_timestamp_ns);
@@ -390,28 +390,28 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         previous_event_timestamp_ns = event.full_gpu_job().dma_fence_signaled_time_ns();
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kFullTracepointEvent:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kFunctionCall:
         EXPECT_GE(event.function_call().end_timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.function_call().end_timestamp_ns();
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kFunctionEntry:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kFunctionExit:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kGpuQueueSubmission:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedCallstack:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedString:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kLostPerfRecordsEvent:
         EXPECT_GE(event.lost_perf_records_event().end_timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.lost_perf_records_event().end_timestamp_ns();
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kMemoryUsageEvent:
         // Cases of memory events are tested in MemoryTracingIntegrationTest.
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kModulesSnapshot:
         EXPECT_GE(event.modules_snapshot().timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.modules_snapshot().timestamp_ns();
@@ -443,12 +443,12 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         previous_event_timestamp_ns = event.thread_state_slice().end_timestamp_ns();
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kWarningEvent:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::
           kWarningInstrumentingWithUserSpaceInstrumentationEvent:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::EVENT_NOT_SET:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
 }
@@ -509,7 +509,7 @@ TEST(LinuxTracingIntegrationTest, SchedulingSlices) {
     last_out_timestamp_ns = scheduling_slice.out_timestamp_ns();
   }
 
-  LOG("scheduling_slice_count=%lu", scheduling_slice_count);
+  ORBIT_LOG("scheduling_slice_count=%lu", scheduling_slice_count);
   // "- 1" as it is the expected number of SchedulingSlices *only between* the first and last sleep.
   EXPECT_GE(scheduling_slice_count, PuppetConstants::kSleepCount - 1);
 }
@@ -564,7 +564,8 @@ GetOuterAndInnerFunctionVirtualAddressRanges(pid_t pid) {
   uint64_t inner_function_virtual_address_end = 0;
   for (const orbit_grpc_protos::SymbolInfo& symbol : module_symbols.symbol_infos()) {
     if (symbol.name() == PuppetConstants::kOuterFunctionName) {
-      CHECK(outer_function_virtual_address_start == 0 && outer_function_virtual_address_end == 0);
+      ORBIT_CHECK(outer_function_virtual_address_start == 0 &&
+                  outer_function_virtual_address_end == 0);
       outer_function_virtual_address_start =
           orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
               symbol.address(), module_info.address_start(), module_info.load_bias(),
@@ -573,7 +574,8 @@ GetOuterAndInnerFunctionVirtualAddressRanges(pid_t pid) {
     }
 
     if (symbol.name() == PuppetConstants::kInnerFunctionName) {
-      CHECK(inner_function_virtual_address_start == 0 && inner_function_virtual_address_end == 0);
+      ORBIT_CHECK(inner_function_virtual_address_start == 0 &&
+                  inner_function_virtual_address_end == 0);
       inner_function_virtual_address_start =
           orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
               symbol.address(), module_info.address_start(), module_info.load_bias(),
@@ -581,10 +583,10 @@ GetOuterAndInnerFunctionVirtualAddressRanges(pid_t pid) {
       inner_function_virtual_address_end = inner_function_virtual_address_start + symbol.size() - 1;
     }
   }
-  CHECK(outer_function_virtual_address_start != 0);
-  CHECK(outer_function_virtual_address_end != 0);
-  CHECK(inner_function_virtual_address_start != 0);
-  CHECK(inner_function_virtual_address_end != 0);
+  ORBIT_CHECK(outer_function_virtual_address_start != 0);
+  ORBIT_CHECK(outer_function_virtual_address_end != 0);
+  ORBIT_CHECK(inner_function_virtual_address_start != 0);
+  ORBIT_CHECK(inner_function_virtual_address_end != 0);
   return std::make_pair(
       std::make_pair(outer_function_virtual_address_start, outer_function_virtual_address_end),
       std::make_pair(inner_function_virtual_address_start, inner_function_virtual_address_end));
@@ -668,7 +670,8 @@ void VerifyCallstackSamplesWithOuterAndInnerFunction(
     ASSERT_EQ(callstack_sample.tid(), pid);
 
     if (callstack_sample.callstack().type() != orbit_grpc_protos::Callstack::kComplete) {
-      LOG("callstack_sample.callstack().type() == %s",
+      ORBIT_LOG(
+          "callstack_sample.callstack().type() == %s",
           orbit_grpc_protos::Callstack::CallstackType_Name(callstack_sample.callstack().type()));
       continue;
     }
@@ -705,9 +708,9 @@ void VerifyCallstackSamplesWithOuterAndInnerFunction(
   }
 
   ASSERT_GT(matching_callstack_count, 0);
-  CHECK(first_matching_callstack_timestamp_ns <= last_matching_callstack_timestamp_ns);
-  LOG("Found %lu of the expected callstacks over %.0f ms", matching_callstack_count,
-      (last_matching_callstack_timestamp_ns - first_matching_callstack_timestamp_ns) / 1e6);
+  ORBIT_CHECK(first_matching_callstack_timestamp_ns <= last_matching_callstack_timestamp_ns);
+  ORBIT_LOG("Found %lu of the expected callstacks over %.0f ms", matching_callstack_count,
+            (last_matching_callstack_timestamp_ns - first_matching_callstack_timestamp_ns) / 1e6);
   constexpr double kMinExpectedScheduledRelativeTime = 0.67;
   const auto min_expected_matching_callstack_count = static_cast<uint64_t>(
       floor((last_matching_callstack_timestamp_ns - first_matching_callstack_timestamp_ns) / 1e9 *
@@ -933,9 +936,9 @@ TEST(LinuxTracingIntegrationTest, ThreadStateSlices) {
     last_end_timestamp_ns = thread_state_slice.end_timestamp_ns();
   }
 
-  LOG("running_slice_count=%lu", running_slice_count);
-  LOG("runnable_slice_count=%lu", runnable_slice_count);
-  LOG("interruptible_sleep_slice_count=%lu", interruptible_sleep_slice_count);
+  ORBIT_LOG("running_slice_count=%lu", running_slice_count);
+  ORBIT_LOG("runnable_slice_count=%lu", runnable_slice_count);
+  ORBIT_LOG("interruptible_sleep_slice_count=%lu", interruptible_sleep_slice_count);
   // "- 1" as these are the expected numbers of kRunning and kRunnable ThreadStateSlices *only
   // between* the first and last sleep.
   EXPECT_GE(running_slice_count, PuppetConstants::kSleepCount - 1);
@@ -1063,7 +1066,7 @@ TEST(LinuxTracingIntegrationTest, GpuJobs) {
       break;
     }
   }
-  LOG("another_process_used_gpu=%d", another_process_used_gpu);
+  ORBIT_LOG("another_process_used_gpu=%d", another_process_used_gpu);
 
   uint64_t gpu_job_count = 0;
   for (const auto& event : events) {
@@ -1100,7 +1103,7 @@ TEST(LinuxTracingIntegrationTest, GpuJobs) {
     ++gpu_job_count;
   }
 
-  LOG("gpu_job_count=%lu", gpu_job_count);
+  ORBIT_LOG("gpu_job_count=%lu", gpu_job_count);
   EXPECT_GE(gpu_job_count, PuppetConstants::kFrameCount);
 }
 

--- a/src/MemoryTracing/MemoryInfoProducer.cpp
+++ b/src/MemoryTracing/MemoryInfoProducer.cpp
@@ -42,8 +42,8 @@ void MemoryInfoProducer::SetExitRequested(bool exit_requested) {
 void MemoryInfoProducer::Run() {
   orbit_base::SetCurrentThreadName(thread_name_.c_str());
 
-  CHECK(listener_ != nullptr);
-  CHECK(pid_ != kMissingInfo);
+  ORBIT_CHECK(listener_ != nullptr);
+  ORBIT_CHECK(pid_ != kMissingInfo);
 
   absl::Time scheduled_time = absl::Now();
   absl::MutexLock lock(&exit_requested_mutex_);

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -60,10 +60,10 @@ class MemoryTracingIntegrationTestFixture {
       : memory_sampling_period_ns_(memory_sampling_period_ns) {}
 
   void StartTracing() {
-    CHECK(!listener_.has_value());
-    CHECK(system_memory_info_producer_ == nullptr);
-    CHECK(cgroup_memory_info_producer_ == nullptr);
-    CHECK(process_memory_info_producer_ == nullptr);
+    ORBIT_CHECK(!listener_.has_value());
+    ORBIT_CHECK(system_memory_info_producer_ == nullptr);
+    ORBIT_CHECK(cgroup_memory_info_producer_ == nullptr);
+    ORBIT_CHECK(process_memory_info_producer_ == nullptr);
 
     listener_.emplace();
     listener_->SetSamplingStartTimestampNs(orbit_base::CaptureTimestampNs());
@@ -88,10 +88,10 @@ class MemoryTracingIntegrationTestFixture {
   }
 
   [[nodiscard]] std::vector<ProducerCaptureEvent> StopTracingAndGetEvents() {
-    CHECK(listener_.has_value());
-    CHECK(system_memory_info_producer_ != nullptr);
-    CHECK(cgroup_memory_info_producer_ != nullptr);
-    CHECK(process_memory_info_producer_ != nullptr);
+    ORBIT_CHECK(listener_.has_value());
+    ORBIT_CHECK(system_memory_info_producer_ != nullptr);
+    ORBIT_CHECK(cgroup_memory_info_producer_ != nullptr);
+    ORBIT_CHECK(process_memory_info_producer_ != nullptr);
 
     system_memory_info_producer_->Stop();
     system_memory_info_producer_.reset();
@@ -117,7 +117,7 @@ class MemoryTracingIntegrationTestFixture {
 
 [[nodiscard]] std::vector<ProducerCaptureEvent> TraceAndGetEvents(
     MemoryTracingIntegrationTestFixture* fixture, absl::Duration tracing_period) {
-  CHECK(fixture != nullptr);
+  ORBIT_CHECK(fixture != nullptr);
 
   fixture->StartTracing();
   absl::SleepFor(tracing_period);

--- a/src/MemoryTracing/MemoryTracingUtils.cpp
+++ b/src/MemoryTracing/MemoryTracingUtils.cpp
@@ -123,26 +123,26 @@ ErrorMessageOr<SystemMemoryUsage> GetSystemMemoryUsage() {
   ErrorMessageOr<std::string> reading_result =
       orbit_base::ReadFileToString(kSystemMemoryUsageFilename);
   if (reading_result.has_error()) {
-    ERROR("%s", reading_result.error().message());
+    ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
   }
   ErrorMessageOr<void> updating_result =
       UpdateSystemMemoryUsageFromMemInfo(reading_result.value(), &system_memory_usage);
   if (updating_result.has_error()) {
-    ERROR("Error while updating SystemMemoryUsage from %s: %s", kSystemMemoryUsageFilename,
-          updating_result.error().message());
+    ORBIT_ERROR("Error while updating SystemMemoryUsage from %s: %s", kSystemMemoryUsageFilename,
+                updating_result.error().message());
   }
 
   const std::string kSystemPageFaultsFilename = "/proc/vmstat";
   reading_result = orbit_base::ReadFileToString(kSystemPageFaultsFilename);
   if (reading_result.has_error()) {
-    ERROR("%s", reading_result.error().message());
+    ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
   }
   updating_result = UpdateSystemMemoryUsageFromVmStat(reading_result.value(), &system_memory_usage);
   if (updating_result.has_error()) {
-    ERROR("Error while updating SystemMemoryUsage from %s: %s", kSystemPageFaultsFilename,
-          updating_result.error().message());
+    ORBIT_ERROR("Error while updating SystemMemoryUsage from %s: %s", kSystemPageFaultsFilename,
+                updating_result.error().message());
   }
 
   return system_memory_usage;
@@ -223,27 +223,27 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) {
   ErrorMessageOr<std::string> reading_result =
       orbit_base::ReadFileToString(kProcessPageFaultsFilename);
   if (reading_result.has_error()) {
-    ERROR("%s", reading_result.error().message());
+    ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
   }
   ErrorMessageOr<void> updating_result =
       UpdateProcessMemoryUsageFromProcessStat(reading_result.value(), &process_memory_usage);
   if (updating_result.has_error()) {
-    ERROR("Error while updating ProcessMemoryUsage from %s: %s", kProcessPageFaultsFilename,
-          updating_result.error().message());
+    ORBIT_ERROR("Error while updating ProcessMemoryUsage from %s: %s", kProcessPageFaultsFilename,
+                updating_result.error().message());
   }
 
   const std::string kProcessMemoryUsageFilename = absl::StrFormat("/proc/%u/status", pid);
   reading_result = orbit_base::ReadFileToString(kProcessMemoryUsageFilename);
   if (reading_result.has_error()) {
-    ERROR("%s", reading_result.error().message());
+    ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
   }
   ErrorMessageOr<int64_t> extracting_result =
       ExtractRssAnonFromProcessStatus(reading_result.value());
   if (extracting_result.has_error()) {
-    ERROR("Error while extracting process RssAnon from %s: %s", kProcessMemoryUsageFilename,
-          extracting_result.error().message());
+    ORBIT_ERROR("Error while extracting process RssAnon from %s: %s", kProcessMemoryUsageFilename,
+                extracting_result.error().message());
   } else {
     process_memory_usage.set_rss_anon_kb(extracting_result.value());
   }
@@ -348,14 +348,14 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
   ErrorMessageOr<std::string> reading_result =
       orbit_base::ReadFileToString(kProcessCGroupsFilename);
   if (reading_result.has_error()) {
-    ERROR("%s", reading_result.error().message());
+    ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
   }
   std::string cgroup_name = GetProcessMemoryCGroupName(reading_result.value());
   if (cgroup_name.empty()) {
     std::string error_message =
         absl::StrFormat("Fail to extract the cgroup name of the target process %u.", pid);
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     return ErrorMessage{std::move(error_message)};
   }
 
@@ -367,28 +367,28 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
       absl::StrFormat("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", cgroup_name);
   reading_result = orbit_base::ReadFileToString(kCGroupMemoryLimitFilename);
   if (reading_result.has_error()) {
-    ERROR("%s", reading_result.error().message());
+    ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
   }
   ErrorMessageOr<void> updating_result =
       UpdateCGroupMemoryUsageFromMemoryLimitInBytes(reading_result.value(), &cgroup_memory_usage);
   if (updating_result.has_error()) {
-    ERROR("Error while updating CGroupMemoryUsage from %s: %s", kCGroupMemoryLimitFilename,
-          updating_result.error().message());
+    ORBIT_ERROR("Error while updating CGroupMemoryUsage from %s: %s", kCGroupMemoryLimitFilename,
+                updating_result.error().message());
   }
 
   const std::string kCGroupMemoryUsageAndPageFaultsFilename =
       absl::StrFormat("/sys/fs/cgroup/memory/%s/memory.stat", cgroup_name);
   reading_result = orbit_base::ReadFileToString(kCGroupMemoryUsageAndPageFaultsFilename);
   if (reading_result.has_error()) {
-    ERROR("%s", reading_result.error().message());
+    ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
   }
   updating_result =
       UpdateCGroupMemoryUsageFromMemoryStat(reading_result.value(), &cgroup_memory_usage);
   if (updating_result.has_error()) {
-    ERROR("Error while updating CGroupMemoryUsage from %s: %s",
-          kCGroupMemoryUsageAndPageFaultsFilename, updating_result.error().message());
+    ORBIT_ERROR("Error while updating CGroupMemoryUsage from %s: %s",
+                kCGroupMemoryUsageAndPageFaultsFilename, updating_result.error().message());
   }
 
   return cgroup_memory_usage;

--- a/src/MetricsUploader/CaptureMetric.cpp
+++ b/src/MetricsUploader/CaptureMetric.cpp
@@ -16,7 +16,7 @@ namespace orbit_metrics_uploader {
 
 CaptureMetric::CaptureMetric(MetricsUploader* uploader, const CaptureStartData& start_data)
     : uploader_(uploader), start_(std::chrono::steady_clock::now()) {
-  CHECK(uploader_ != nullptr);
+  ORBIT_CHECK(uploader_ != nullptr);
   capture_data_.set_number_of_instrumented_functions(start_data.number_of_instrumented_functions);
   capture_data_.set_number_of_frame_tracks(start_data.number_of_frame_tracks);
   capture_data_.set_thread_states(start_data.thread_states);
@@ -72,12 +72,12 @@ bool CaptureMetric::SendCaptureSucceeded(std::chrono::milliseconds duration_in_m
   status_code_ = OrbitLogEvent::SUCCESS;
 
   if (file_path_.empty()) {
-    ERROR("Unable to determine capture file size for metrics. File path is empty");
+    ORBIT_ERROR("Unable to determine capture file size for metrics. File path is empty");
   } else {
     ErrorMessageOr<uint64_t> file_size = orbit_base::FileSize(file_path_);
     if (file_size.has_error()) {
-      ERROR("Unable to determine capture file size for metrics. File: \"%s\"; error: %s",
-            file_path_.string(), file_size.error().message());
+      ORBIT_ERROR("Unable to determine capture file size for metrics. File: \"%s\"; error: %s",
+                  file_path_.string(), file_size.error().message());
     } else {
       capture_data_.set_file_size(file_size.value());
     }

--- a/src/MetricsUploader/MetricsUploaderLinux.cpp
+++ b/src/MetricsUploader/MetricsUploaderLinux.cpp
@@ -10,7 +10,7 @@
 namespace orbit_metrics_uploader {
 
 std::unique_ptr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::string) {
-  ERROR("MetricsUploader is not implemented on Linux");
+  ORBIT_ERROR("MetricsUploader is not implemented on Linux");
   return std::make_unique<MetricsUploaderStub>();
 }
 

--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -98,7 +98,7 @@ MetricsUploaderImpl::~MetricsUploaderImpl() {
   if (nullptr != shutdown_connection_addr_) {
     Result result = shutdown_connection_addr_();
     if (result != kNoError) {
-      ERROR("Error while closing connection: %s", GetErrorMessage(result));
+      ORBIT_ERROR("Error while closing connection: %s", GetErrorMessage(result));
     }
   }
   // Here FreeLibrary should be called. However, calling it on go-shared library leads to crash.
@@ -113,21 +113,21 @@ std::unique_ptr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::str
   HMODULE metrics_uploader_client_dll;
   if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, client_name.c_str(),
                          &metrics_uploader_client_dll) != 0) {
-    ERROR("MetricsUploader is already created");
+    ORBIT_ERROR("MetricsUploader is already created");
     return std::make_unique<MetricsUploaderStub>();
   }
 
   auto uuid_result = GenerateUUID();
   if (uuid_result.has_error()) {
-    ERROR("%s", uuid_result.error().message());
+    ORBIT_ERROR("%s", uuid_result.error().message());
     return std::make_unique<MetricsUploaderStub>();
   }
   std::string session_uuid = uuid_result.value();
-  LOG("Session UUID for metrics: %s", session_uuid);
+  ORBIT_LOG("Session UUID for metrics: %s", session_uuid);
 
   metrics_uploader_client_dll = LoadLibraryA(client_name.c_str());
   if (metrics_uploader_client_dll == nullptr) {
-    ERROR("Metrics uploader client library is not found");
+    ORBIT_ERROR("Metrics uploader client library is not found");
     return std::make_unique<MetricsUploaderStub>();
   }
 
@@ -138,7 +138,7 @@ std::unique_ptr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::str
     // to crash. This should be revisited as soon as the issue in golang is fixed.
     //
     // FreeLibrary(metrics_uploader_client_dll);
-    ERROR("%s function not found", kSetupConnectionFunctionName);
+    ORBIT_ERROR("%s function not found", kSetupConnectionFunctionName);
     return std::make_unique<MetricsUploaderStub>();
   }
 
@@ -146,7 +146,7 @@ std::unique_ptr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::str
       GetProcAddress(metrics_uploader_client_dll, kShutdownConnectionFunctionName));
   if (nullptr == shutdown_connection_addr) {
     // FreeLibrary(metrics_uploader_client_dll);
-    ERROR("%s function not found", kShutdownConnectionFunctionName);
+    ORBIT_ERROR("%s function not found", kShutdownConnectionFunctionName);
     return std::make_unique<MetricsUploaderStub>();
   }
 
@@ -154,7 +154,7 @@ std::unique_ptr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::str
       GetProcAddress(metrics_uploader_client_dll, kSendLogEventFunctionName));
   if (nullptr == send_log_event_addr) {
     // FreeLibrary(metrics_uploader_client_dll);
-    ERROR("%s function not found", kSendLogEventFunctionName);
+    ORBIT_ERROR("%s function not found", kSendLogEventFunctionName);
     return std::make_unique<MetricsUploaderStub>();
   }
 
@@ -164,15 +164,15 @@ std::unique_ptr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::str
     if (result != kCannotOpenConnection) {
       Result shutdown_result = shutdown_connection_addr();
       if (shutdown_result != kNoError) {
-        ERROR("Error while closing connection: %s", GetErrorMessage(shutdown_result));
+        ORBIT_ERROR("Error while closing connection: %s", GetErrorMessage(shutdown_result));
       }
     }
     // FreeLibrary(metrics_uploader_client_dll);
-    ERROR("Error while starting the metrics uploader client: %s", GetErrorMessage(result));
+    ORBIT_ERROR("Error while starting the metrics uploader client: %s", GetErrorMessage(result));
     return std::make_unique<MetricsUploaderStub>();
   }
 
-  LOG("MetricsUploader was initialized successfully");
+  ORBIT_LOG("MetricsUploader was initialized successfully");
   return std::make_unique<MetricsUploaderImpl>(client_name, session_uuid, send_log_event_addr,
                                                shutdown_connection_addr,
                                                metrics_uploader_client_dll);
@@ -201,7 +201,7 @@ ErrorMessageOr<std::string> GenerateUUID() {
 
 bool MetricsUploaderImpl::FillAndSendLogEvent(OrbitLogEvent partial_filled_event) const {
   if (send_log_event_addr_ == nullptr) {
-    ERROR("Unable to send metric, send_log_event_addr_ is nullptr");
+    ORBIT_ERROR("Unable to send metric, send_log_event_addr_ is nullptr");
     return false;
   }
 
@@ -214,7 +214,7 @@ bool MetricsUploaderImpl::FillAndSendLogEvent(OrbitLogEvent partial_filled_event
 
   Result result = send_log_event_addr_(buffer.data(), message_size);
   if (result != kNoError) {
-    ERROR("Unable to send metrics event: %s", GetErrorMessage(result));
+    ORBIT_ERROR("Unable to send metrics event: %s", GetErrorMessage(result));
     return false;
   }
 

--- a/src/MoveFilesToDocuments/MoveFilesProcess.cpp
+++ b/src/MoveFilesToDocuments/MoveFilesProcess.cpp
@@ -33,7 +33,7 @@ void MoveFilesProcess::Start() {
 void MoveFilesProcess::RequestInterruption() { interruption_requested_ = true; }
 
 void MoveFilesProcess::ReportError(const std::string& error_message) {
-  ERROR("%s", error_message);
+  ORBIT_ERROR("%s", error_message);
   emit generalError(QString::fromStdString(error_message));
 }
 
@@ -62,7 +62,7 @@ void MoveFilesProcess::TryMoveFilesAndRemoveDirIfNeeded(const std::filesystem::p
     if (interruption_requested_) return;
     const auto& file_name = file_path.filename();
     const auto& new_file_path = dest_dir / file_name;
-    LOG("Moving \"%s\" to \"%s\"...", file_path.string(), new_file_path.string());
+    ORBIT_LOG("Moving \"%s\" to \"%s\"...", file_path.string(), new_file_path.string());
     emit moveFileStarted(QString::fromStdString(file_path.string()));
     auto move_result = orbit_base::MoveFile(file_path, new_file_path);
     if (move_result.has_error()) {
@@ -82,7 +82,7 @@ void MoveFilesProcess::TryMoveFilesAndRemoveDirIfNeeded(const std::filesystem::p
 }
 
 void MoveFilesProcess::Run() {
-  CHECK(QThread::currentThread() == thread());
+  ORBIT_CHECK(QThread::currentThread() == thread());
   TryMoveFilesAndRemoveDirIfNeeded(orbit_paths::GetPresetDirPriorTo1_66(),
                                    orbit_paths::CreateOrGetPresetDir());
   TryMoveFilesAndRemoveDirIfNeeded(orbit_paths::GetCaptureDirPriorTo1_66(),

--- a/src/MoveFilesToDocuments/MoveFilesToDocuments.cpp
+++ b/src/MoveFilesToDocuments/MoveFilesToDocuments.cpp
@@ -20,8 +20,8 @@ namespace orbit_move_files_to_documents {
 static bool IsDirectoryEmpty(const std::filesystem::path& directory) {
   auto exists_or_error = orbit_base::FileExists(directory);
   if (exists_or_error.has_error()) {
-    ERROR("Unable to check for existence of \"%s\": %s", directory.string(),
-          exists_or_error.error().message());
+    ORBIT_ERROR("Unable to check for existence of \"%s\": %s", directory.string(),
+                exists_or_error.error().message());
     return false;
   }
 
@@ -31,8 +31,8 @@ static bool IsDirectoryEmpty(const std::filesystem::path& directory) {
 
   auto file_list_or_error = orbit_base::ListFilesInDirectory(directory);
   if (file_list_or_error.has_error()) {
-    ERROR("Unable to list directory \"%s\": %s", directory.string(),
-          file_list_or_error.error().message());
+    ORBIT_ERROR("Unable to list directory \"%s\": %s", directory.string(),
+                file_list_or_error.error().message());
     return false;
   }
 
@@ -58,7 +58,7 @@ void TryMoveSavedDataLocationIfNeeded() {
 
   QObject::connect(&process, &MoveFilesProcess::generalError, &dialog,
                    [&dialog, main_thread_id](const QString& error_message) {
-                     CHECK(main_thread_id == std::this_thread::get_id());
+                     ORBIT_CHECK(main_thread_id == std::this_thread::get_id());
                      dialog.AddText(absl::StrFormat("Error: %s", error_message.toStdString()));
                    });
 
@@ -66,39 +66,39 @@ void TryMoveSavedDataLocationIfNeeded() {
       &process, &MoveFilesProcess::moveDirectoryStarted, &dialog,
       [&dialog, main_thread_id](const QString& from_dir_path, const QString& to_dir_path,
                                 quint64 number_of_files) {
-        CHECK(main_thread_id == std::this_thread::get_id());
+        ORBIT_CHECK(main_thread_id == std::this_thread::get_id());
         dialog.AddText(absl::StrFormat(R"(Moving %d files from "%s" to "%s"...)", number_of_files,
                                        from_dir_path.toStdString(), to_dir_path.toStdString()));
       });
 
   QObject::connect(&process, &MoveFilesProcess::moveDirectoryDone, &dialog,
                    [&dialog, main_thread_id]() {
-                     CHECK(main_thread_id == std::this_thread::get_id());
+                     ORBIT_CHECK(main_thread_id == std::this_thread::get_id());
                      dialog.AddText("Done.\n");
                    });
 
   QObject::connect(
       &process, &MoveFilesProcess::moveFileStarted, &dialog,
       [&dialog, main_thread_id](const QString& from_path) {
-        CHECK(main_thread_id == std::this_thread::get_id());
+        ORBIT_CHECK(main_thread_id == std::this_thread::get_id());
         dialog.AddText(absl::StrFormat("        Moving \"%s\"...", from_path.toStdString()));
       });
 
   QObject::connect(&process, &MoveFilesProcess::moveFileDone, &dialog, [&dialog, main_thread_id]() {
-    CHECK(main_thread_id == std::this_thread::get_id());
+    ORBIT_CHECK(main_thread_id == std::this_thread::get_id());
     dialog.AddText("        Done.");
   });
 
   QObject::connect(&process, &MoveFilesProcess::processFinished, &dialog,
                    [&dialog, main_thread_id]() {
-                     CHECK(main_thread_id == std::this_thread::get_id());
+                     ORBIT_CHECK(main_thread_id == std::this_thread::get_id());
                      dialog.AddText("Finished.");
                      dialog.OnMoveFinished();
                    });
 
   QObject::connect(&process, &MoveFilesProcess::processInterrupted, &dialog,
                    [&dialog, main_thread_id]() {
-                     CHECK(main_thread_id == std::this_thread::get_id());
+                     ORBIT_CHECK(main_thread_id == std::this_thread::get_id());
                      dialog.AddText("Interrupted.");
                      dialog.OnMoveInterrupted();
                    });

--- a/src/ObjectUtils/Address.cpp
+++ b/src/ObjectUtils/Address.cpp
@@ -20,8 +20,8 @@ uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
                                                uint64_t module_base_address,
                                                uint64_t module_load_bias,
                                                uint64_t module_executable_section_offset) {
-  CHECK((module_base_address % kPageSize) == 0);
-  CHECK((module_load_bias % kPageSize) == 0);
+  ORBIT_CHECK((module_base_address % kPageSize) == 0);
+  ORBIT_CHECK((module_load_bias % kPageSize) == 0);
   return symbol_address + module_base_address - module_load_bias -
          orbit_base::AlignDown<kPageSize>(module_executable_section_offset);
 }
@@ -34,8 +34,9 @@ uint64_t SymbolOffsetToAbsoluteAddress(uint64_t symbol_address, uint64_t module_
 
 uint64_t SymbolAbsoluteAddressToOffset(uint64_t absolute_address, uint64_t module_base_address,
                                        uint64_t module_executable_section_offset) {
-  CHECK((module_base_address % kPageSize) == 0);
-  CHECK(absolute_address >= (module_base_address + module_executable_section_offset % kPageSize));
+  ORBIT_CHECK((module_base_address % kPageSize) == 0);
+  ORBIT_CHECK(absolute_address >=
+              (module_base_address + module_executable_section_offset % kPageSize));
   return absolute_address - module_base_address +
          orbit_base::AlignDown<kPageSize>(module_executable_section_offset);
 }

--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -83,7 +83,7 @@ static void FillDebugSymbolsFromDWARF(llvm::DWARFContext* dwarf_context,
         // The method getName will fallback to ShortName if LinkageName is
         // not present, so this should never return an empty name.
         std::string name(full_die.getName(llvm::DINameKind::LinkageName));
-        CHECK(!name.empty());
+        ORBIT_CHECK(!name.empty());
         symbol_info.set_name(name);
         symbol_info.set_demangled_name(llvm::demangle(name));
         symbol_info.set_address(low_pc);
@@ -118,7 +118,7 @@ bool CoffFileImpl::HasDebugSymbols() const { return has_debug_info_ && !AreDebug
 bool CoffFileImpl::AreDebugSymbolsEmpty() const {
   const auto dwarf_context = llvm::DWARFContext::create(*owning_binary_.getBinary());
   if (dwarf_context == nullptr) {
-    ERROR("Could not create DWARF context.");
+    ORBIT_ERROR("Could not create DWARF context.");
     return true;
   }
 
@@ -144,7 +144,7 @@ std::string CoffFileImpl::GetName() const { return file_path_.filename().string(
 
 uint64_t CoffFileImpl::GetLoadBias() const { return object_file_->getImageBase(); }
 uint64_t CoffFileImpl::GetExecutableSegmentOffset() const {
-  CHECK(object_file_->is64());
+  ORBIT_CHECK(object_file_->is64());
   return object_file_->getPE32PlusHeader()->BaseOfCode;
 }
 
@@ -156,7 +156,7 @@ ErrorMessageOr<PdbDebugInfo> CoffFileImpl::GetDebugPdbInfo() const {
   llvm::StringRef pdb_file_path;
 
   // If 'this' was successfully created with CreateCoffFile, 'object_file_' cannot be nullptr.
-  CHECK(object_file_ != nullptr);
+  ORBIT_CHECK(object_file_ != nullptr);
 
   llvm::Error error = object_file_->getDebugPDBInfo(debug_info, pdb_file_path);
   if (error) {
@@ -169,7 +169,7 @@ ErrorMessageOr<PdbDebugInfo> CoffFileImpl::GetDebugPdbInfo() const {
   }
   // Only support PDB 70 until we learn otherwise.
   constexpr uint32_t kPdb70Signature = 0x53445352;
-  CHECK(debug_info->PDB70.CVSignature == kPdb70Signature);
+  ORBIT_CHECK(debug_info->PDB70.CVSignature == kPdb70Signature);
 
   PdbDebugInfo pdb_debug_info;
   pdb_debug_info.pdb_file_path = pdb_file_path.str();
@@ -182,7 +182,7 @@ ErrorMessageOr<PdbDebugInfo> CoffFileImpl::GetDebugPdbInfo() const {
 std::string CoffFileImpl::GetBuildId() const {
   ErrorMessageOr<PdbDebugInfo> pdb_debug_info = GetDebugPdbInfo();
   if (pdb_debug_info.has_error()) {
-    LOG("WARNING: No PDB debug info found, cannot form build id (ignoring).");
+    ORBIT_LOG("WARNING: No PDB debug info found, cannot form build id (ignoring).");
     return "";
   }
   return ComputeWindowsBuildId(pdb_debug_info.value().guid, pdb_debug_info.value().age);

--- a/src/ObjectUtils/ElfFile.cpp
+++ b/src/ObjectUtils/ElfFile.cpp
@@ -174,7 +174,7 @@ ErrorMessageOr<void> ElfFileImpl<ElfT>::InitDynamicEntries() {
     auto error_message =
         absl::StrFormat("Unable to get dynamic entries from \"%s\": %s", file_path_.string(),
                         llvm::toString(dynamic_entries_or_error.takeError()));
-    ERROR("%s (ignored)", error_message);
+    ORBIT_ERROR("%s (ignored)", error_message);
     // Apparently empty dynamic section results in error - we are going to ignore it.
     return outcome::success();
   }
@@ -210,7 +210,7 @@ ErrorMessageOr<void> ElfFileImpl<ElfT>::InitDynamicEntries() {
     auto error_message =
         absl::StrFormat("Unable to get last byte address of dynamic string table \"%s\": %s",
                         file_path_.string(), llvm::toString(strtab_last_byte_or_error.takeError()));
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     return ErrorMessage{error_message};
   }
 
@@ -219,14 +219,14 @@ ErrorMessageOr<void> ElfFileImpl<ElfT>::InitDynamicEntries() {
         "Soname offset is out of bounds of the string table (file=\"%s\", offset=%u "
         "strtab size=%u)",
         file_path_.string(), soname_offset.value(), dynamic_string_table_size.value());
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     return ErrorMessage{error_message};
   }
 
   if (*strtab_last_byte_or_error.get() != 0) {
     auto error_message = absl::StrFormat(
         "Dynamic string table is not null-termintated (file=\"%s\")", file_path_.string());
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     return ErrorMessage{error_message};
   }
 
@@ -235,7 +235,7 @@ ErrorMessageOr<void> ElfFileImpl<ElfT>::InitDynamicEntries() {
     auto error_message =
         absl::StrFormat("Unable to get dynamic string table from DT_STRTAB in \"%s\": %s",
                         file_path_.string(), llvm::toString(strtab_addr_or_error.takeError()));
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     return ErrorMessage{error_message};
   }
 
@@ -252,7 +252,7 @@ ErrorMessageOr<void> ElfFileImpl<ElfT>::InitSections() {
   if (!sections_or_error) {
     auto error_message = absl::StrFormat("Unable to load sections: %s",
                                          llvm::toString(sections_or_error.takeError()));
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     return ErrorMessage{error_message};
   }
 
@@ -319,8 +319,8 @@ ErrorMessageOr<SymbolInfo> ElfFileImpl<ElfT>::CreateSymbolInfo(
 
   llvm::Expected<uint32_t> maybe_flags = symbol_ref.getFlags();
   if (!maybe_flags) {
-    LOG("WARNING: Flags are not set for symbol \"%s\" in \"%s\", skipping. Details: %s", name,
-        file_path_.string(), llvm::toString(maybe_flags.takeError()));
+    ORBIT_LOG("WARNING: Flags are not set for symbol \"%s\" in \"%s\", skipping. Details: %s", name,
+              file_path_.string(), llvm::toString(maybe_flags.takeError()));
     return ErrorMessage(absl::StrFormat(R"(Flags are not set for symbol "%s" in "%s", skipping.)",
                                         name, file_path_.string()));
   }
@@ -332,8 +332,8 @@ ErrorMessageOr<SymbolInfo> ElfFileImpl<ElfT>::CreateSymbolInfo(
   // Unknown type - skip and generate a warning.
   llvm::Expected<llvm::object::SymbolRef::Type> maybe_type = symbol_ref.getType();
   if (!maybe_type) {
-    LOG("WARNING: Type is not set for symbol \"%s\" in \"%s\", skipping. Details: %s", name,
-        file_path_.string(), llvm::toString(maybe_type.takeError()));
+    ORBIT_LOG("WARNING: Type is not set for symbol \"%s\" in \"%s\", skipping. Details: %s", name,
+              file_path_.string(), llvm::toString(maybe_type.takeError()));
     return ErrorMessage(absl::StrFormat(R"(Type is not set for symbol "%s" in "%s", skipping.)",
                                         name, file_path_.string()));
   }
@@ -344,8 +344,8 @@ ErrorMessageOr<SymbolInfo> ElfFileImpl<ElfT>::CreateSymbolInfo(
 
   llvm::Expected<uint64_t> maybe_value = symbol_ref.getValue();
   if (!maybe_value) {
-    LOG("WARNING: Address is not set for symbol \"%s\" in \"%s\", skipping. Details: %s", name,
-        file_path_.string(), llvm::toString(maybe_value.takeError()));
+    ORBIT_LOG("WARNING: Address is not set for symbol \"%s\" in \"%s\", skipping. Details: %s",
+              name, file_path_.string(), llvm::toString(maybe_value.takeError()));
     return ErrorMessage(absl::StrFormat(R"(Address is not set for symbol "%s" in "%s", skipping.)",
                                         name, file_path_.string()));
   }
@@ -422,7 +422,7 @@ ErrorMessageOr<void> ElfFileImpl<ElfT>::InitProgramHeaders() {
     std::string error = absl::StrFormat(
         "Unable to get load bias of ELF file: \"%s\". Error loading program headers: %s",
         file_path_.string(), llvm::toString(range.takeError()));
-    ERROR("%s", error);
+    ORBIT_ERROR("%s", error);
     return ErrorMessage(std::move(error));
   }
 
@@ -444,7 +444,7 @@ ErrorMessageOr<void> ElfFileImpl<ElfT>::InitProgramHeaders() {
   std::string error = absl::StrFormat(
       "Unable to get load bias of ELF file: \"%s\". No executable PT_LOAD segment found.",
       file_path_.string());
-  ERROR("%s", error);
+  ORBIT_ERROR("%s", error);
   return ErrorMessage(std::move(error));
 }
 
@@ -490,7 +490,7 @@ const std::filesystem::path& ElfFileImpl<ElfT>::GetFilePath() const {
 
 template <typename ElfT>
 ErrorMessageOr<LineInfo> orbit_object_utils::ElfFileImpl<ElfT>::GetLineInfo(uint64_t address) {
-  CHECK(has_debug_info_section_);
+  ORBIT_CHECK(has_debug_info_section_);
   auto line_info_or_error =
       symbolizer_.symbolizeInlinedCode(std::string{object_file_->getFileName()},
                                        {address, llvm::object::SectionedAddress::UndefSection});

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -71,7 +71,7 @@ ErrorMessageOr<ModuleInfo> CreateModule(const std::filesystem::path& module_path
 
   if (object_file_or_error.value()->IsElf()) {
     auto* elf_file = dynamic_cast<ElfFile*>((object_file_or_error.value().get()));
-    CHECK(elf_file != nullptr);
+    ORBIT_CHECK(elf_file != nullptr);
     module_info.set_soname(elf_file->GetSoname());
     module_info.set_object_file_type(ModuleInfo::kElfFile);
   } else if (object_file_or_error.value()->IsCoff()) {
@@ -114,7 +114,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
     ErrorMessageOr<ModuleInfo> module_info_or_error = CreateModule(module_path, start, end);
 
     if (module_info_or_error.has_error()) {
-      ERROR("Unable to create module: %s", module_info_or_error.error().message());
+      ORBIT_ERROR("Unable to create module: %s", module_info_or_error.error().message());
       continue;
     }
 

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -74,7 +74,7 @@ PdbFileLlvm::PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& 
 
   llvm::Expected<llvm::pdb::DbiStream&> debug_info_stream = pdb_file.getPDBDbiStream();
   // Given that we check hasPDBDbiStream above, we must get a DbiStream here.
-  CHECK(debug_info_stream);
+  ORBIT_CHECK(debug_info_stream);
 
   const llvm::pdb::DbiModuleList& modules = debug_info_stream->modules();
 

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -82,7 +82,7 @@ static std::optional<orbit_session_setup::TargetConfiguration> ConnectToSpecifie
   auto connection_target_result =
       orbit_session_setup::ConnectionTarget::FromString(connection_target_string);
   if (!connection_target_result.has_value()) {
-    ERROR(
+    ORBIT_ERROR(
         "Invalid connection target parameter was specified. Expected format: pid@instance_id, got "
         "\"%s\"",
         connection_target_string.toStdString());
@@ -174,7 +174,7 @@ int RunUiInstance(const DeploymentConfiguration& deployment_configuration,
       continue;
     }
 
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
 
   return 0;
@@ -191,7 +191,8 @@ static bool DevModeEnabledViaEnvironmentVariable() {
 
 static void LogAndMaybeWarnAboutClockResolution() {
   uint64_t estimated_clock_resolution = orbit_base::EstimateClockResolution();
-  LOG("%s", absl::StrFormat("Clock resolution on client: %d (ns)", estimated_clock_resolution));
+  ORBIT_LOG("%s",
+            absl::StrFormat("Clock resolution on client: %d (ns)", estimated_clock_resolution));
 
   // Since a low clock resolution on the client only affects our own introspection and logging
   // timings, we only show a warning dialogue when running in devmode.
@@ -216,17 +217,17 @@ static void LogAndMaybeWarnAboutClockResolution() {
 static void ClearSourcePathsMappings() {
   orbit_source_paths_mapping::MappingManager mapping_manager{};
   mapping_manager.SetMappings({});
-  LOG("Cleared the saved source paths mappings.");
+  ORBIT_LOG("Cleared the saved source paths mappings.");
 }
 
 // Put the command line into the log.
 static void LogCommandLine(int argc, char* argv[]) {
-  LOG("Command line invoking Orbit:");
-  LOG("%s", argv[0]);
+  ORBIT_LOG("Command line invoking Orbit:");
+  ORBIT_LOG("%s", argv[0]);
   for (int i = 1; i < argc; i++) {
-    LOG("  %s", argv[i]);
+    ORBIT_LOG("  %s", argv[i]);
   }
-  LOG("");
+  ORBIT_LOG("");
 }
 
 int main(int argc, char* argv[]) {
@@ -246,13 +247,13 @@ int main(int argc, char* argv[]) {
 
   std::filesystem::path log_file{orbit_paths::GetLogFilePath()};
   orbit_base::InitLogFile(log_file);
-  LOG("You are running Orbit Profiler version %s", orbit_version::GetVersionString());
+  ORBIT_LOG("You are running Orbit Profiler version %s", orbit_version::GetVersionString());
   LogCommandLine(argc, argv);
   ErrorMessageOr<void> remove_old_log_result =
       orbit_base::TryRemoveOldLogFiles(orbit_paths::CreateOrGetLogDir());
   if (remove_old_log_result.has_error()) {
-    LOG("Warning: Unable to remove some old log files:\n%s",
-        remove_old_log_result.error().message());
+    ORBIT_LOG("Warning: Unable to remove some old log files:\n%s",
+              remove_old_log_result.error().message());
   }
 
 #if __linux__
@@ -317,8 +318,8 @@ int main(int argc, char* argv[]) {
     return -1;
   }
 
-  LOG("Detected OpenGL version: %i.%i %s", open_gl_version->major, open_gl_version->minor,
-      open_gl_version->is_opengl_es ? "OpenGL ES" : "OpenGL");
+  ORBIT_LOG("Detected OpenGL version: %i.%i %s", open_gl_version->major, open_gl_version->minor,
+            open_gl_version->is_opengl_es ? "OpenGL ES" : "OpenGL");
 
   if (open_gl_version->is_opengl_es) {
     DisplayErrorToUser(
@@ -355,7 +356,8 @@ int main(int argc, char* argv[]) {
   const std::string& connection_target = absl::GetFlag(FLAGS_connection_target);
 
   if (capture_file_paths.size() > 0 && !connection_target.empty()) {
-    LOG("Aborting startup: User specified a connection target and one or multiple capture files at "
+    ORBIT_LOG(
+        "Aborting startup: User specified a connection target and one or multiple capture files at "
         "the same time.");
     DisplayErrorToUser(
         QString("Invalid combination of startup flags: Specify either one or multiple capture "

--- a/src/OrbitAccessibility/AccessibleInterfaceRegistry.cpp
+++ b/src/OrbitAccessibility/AccessibleInterfaceRegistry.cpp
@@ -13,7 +13,9 @@ AccessibleInterfaceRegistry& AccessibleInterfaceRegistry::Get() {
   return registry;
 }
 
-AccessibleInterfaceRegistry::~AccessibleInterfaceRegistry() { CHECK(interfaces_.size() == 0); }
+AccessibleInterfaceRegistry::~AccessibleInterfaceRegistry() {
+  ORBIT_CHECK(interfaces_.size() == 0);
+}
 
 void AccessibleInterfaceRegistry::Register(AccessibleInterface* iface) {
   if (!interfaces_.contains(iface)) {
@@ -25,7 +27,7 @@ void AccessibleInterfaceRegistry::Register(AccessibleInterface* iface) {
 }
 
 void AccessibleInterfaceRegistry::Unregister(AccessibleInterface* iface) {
-  CHECK(interfaces_.contains(iface));
+  ORBIT_CHECK(interfaces_.contains(iface));
   interfaces_.erase(iface);
   if (on_unregistered_ != nullptr) {
     on_unregistered_(iface);
@@ -33,12 +35,12 @@ void AccessibleInterfaceRegistry::Unregister(AccessibleInterface* iface) {
 }
 
 void AccessibleInterfaceRegistry::SetOnRegisterCallback(Callback callback) {
-  CHECK(on_registered_ == nullptr);
+  ORBIT_CHECK(on_registered_ == nullptr);
   on_registered_ = callback;
 }
 
 void AccessibleInterfaceRegistry::SetOnUnregisterCallback(Callback callback) {
-  CHECK(on_unregistered_ == nullptr);
+  ORBIT_CHECK(on_unregistered_ == nullptr);
   on_unregistered_ = callback;
 }
 

--- a/src/OrbitBase/ExecutablePathLinux.cpp
+++ b/src/OrbitBase/ExecutablePathLinux.cpp
@@ -22,7 +22,7 @@ std::filesystem::path GetExecutablePath() {
   char buffer[PATH_MAX];
   ssize_t length = readlink("/proc/self/exe", buffer, sizeof(buffer));
   if (length == -1) {
-    FATAL("Unable to readlink /proc/self/exe: %s", SafeStrerror(errno));
+    ORBIT_FATAL("Unable to readlink /proc/self/exe: %s", SafeStrerror(errno));
   }
 
   return std::filesystem::path(std::string(buffer, length));

--- a/src/OrbitBase/ExecutablePathWindows.cpp
+++ b/src/OrbitBase/ExecutablePathWindows.cpp
@@ -20,13 +20,13 @@ std::filesystem::path GetExecutablePath() {
   constexpr uint32_t kMaxPath = 2048;
   char exe_file_name[kMaxPath] = {0};
   if (!GetModuleFileNameA(/*hModule=*/nullptr, exe_file_name, kMaxPath)) {
-    FATAL("GetModuleFileName failed with: %s", GetLastErrorAsString());
+    ORBIT_FATAL("GetModuleFileName failed with: %s", GetLastErrorAsString());
   }
 
   // Clean up "../" inside full path
   char exe_full_path[kMaxPath] = {0};
   if (!GetFullPathNameA(exe_file_name, kMaxPath, exe_full_path, nullptr)) {
-    FATAL("GetFullPathNameA failed with: %s", GetLastErrorAsString());
+    ORBIT_FATAL("GetFullPathNameA failed with: %s", GetLastErrorAsString());
   }
 
   return std::filesystem::path(exe_full_path);

--- a/src/OrbitBase/ExecuteCommandLinux.cpp
+++ b/src/OrbitBase/ExecuteCommandLinux.cpp
@@ -16,7 +16,7 @@ namespace orbit_base {
 std::optional<std::string> ExecuteCommand(const std::string& cmd) {
   std::unique_ptr<FILE, decltype(&pclose)> pipe{popen(cmd.c_str(), "r"), pclose};
   if (!pipe) {
-    ERROR("Could not open pipe for \"%s\"", cmd.c_str());
+    ORBIT_ERROR("Could not open pipe for \"%s\"", cmd.c_str());
     return std::optional<std::string>{};
   }
 

--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -117,7 +117,7 @@ ErrorMessageOr<void> WriteFully(const unique_fd& fd, const void* data, size_t si
     bytes_left -= bytes_written;
   }
 
-  CHECK(bytes_left == 0);
+  ORBIT_CHECK(bytes_left == 0);
   return outcome::success();
 }
 

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -105,7 +105,7 @@ TEST(File, OpenExistingFileForReadWrite) {
 
 TEST(File, WriteFullySmoke) {
   auto temporary_file_or_error = TemporaryFile::Create();
-  CHECK(temporary_file_or_error.has_value());
+  ORBIT_CHECK(temporary_file_or_error.has_value());
   TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
   // Write buffer into file.
@@ -126,7 +126,7 @@ TEST(File, WriteFullySmoke) {
 
 TEST(File, WriteFullyAtOffsetSmoke) {
   auto temporary_file_or_error = TemporaryFile::Create();
-  CHECK(temporary_file_or_error.has_value());
+  ORBIT_CHECK(temporary_file_or_error.has_value());
   TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
   // Write at the beginning of the previously empty file.
@@ -201,9 +201,9 @@ TEST(File, ReadFullySmoke) {
 
 TEST(File, ReadFullyAtOffsetSmoke) {
   const auto fd_or_error = OpenFileForReading(orbit_test::GetTestdataDir() / "textfile.bin");
-  CHECK(!fd_or_error.has_error());
+  ORBIT_CHECK(!fd_or_error.has_error());
   const auto& fd = fd_or_error.value();
-  CHECK(fd.valid());
+  ORBIT_CHECK(fd.valid());
   std::array<char, 64> buf{};
 
   // Read at beginning of file.

--- a/src/OrbitBase/GetLastErrorWindows.cpp
+++ b/src/OrbitBase/GetLastErrorWindows.cpp
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "OrbitBase/GetLastError.h"
-
 #include <absl/base/casts.h>
 #include <absl/strings/ascii.h>
 #include <windows.h>
+
+#include "OrbitBase/GetLastError.h"
+#include "OrbitBase/Logging.h"
 
 namespace orbit_base {
 
@@ -30,7 +31,7 @@ std::string GetLastErrorAsString() {
       /*Arguments=*/nullptr);
 
   if (buffer == nullptr) {
-    ERROR("Calling FormatMessageA in GetLastErrorAsString");
+    ORBIT_ERROR("Calling FormatMessageA in GetLastErrorAsString");
     return {};
   }
 

--- a/src/OrbitBase/GetProcessIdsLinux.cpp
+++ b/src/OrbitBase/GetProcessIdsLinux.cpp
@@ -21,7 +21,7 @@ static std::optional<pid_t> ProcEntryToPid(const std::filesystem::directory_entr
   std::error_code error;
   bool is_directory = entry.is_directory(error);
   if (error) {
-    ERROR("Unable to stat \"%s\": %s", entry.path(), error.message());
+    ORBIT_ERROR("Unable to stat \"%s\": %s", entry.path(), error.message());
     return std::nullopt;
   }
 
@@ -45,7 +45,7 @@ std::vector<pid_t> GetAllPids() {
   std::error_code error;
   fs::directory_iterator proc{"/proc", error};
   if (error) {
-    ERROR("Unable to ls /proc: %s", error.message());
+    ORBIT_ERROR("Unable to ls /proc: %s", error.message());
     return {};
   }
 
@@ -53,7 +53,7 @@ std::vector<pid_t> GetAllPids() {
 
   for (auto it = fs::begin(proc), end = fs::end(proc); it != end; it.increment(error)) {
     if (error) {
-      ERROR("directory_iterator::increment failed with: %s (stopping)", error.message());
+      ORBIT_ERROR("directory_iterator::increment failed with: %s (stopping)", error.message());
       break;
     }
     auto pid = ProcEntryToPid(*it);
@@ -70,7 +70,7 @@ std::vector<pid_t> GetTidsOfProcess(pid_t pid) {
   fs::directory_iterator proc_pid_task{fs::path{"/proc"} / std::to_string(pid) / "task", error};
   if (error) {
     // The process with id `pid` could have stopped existing.
-    ERROR("Getting tids of threads of process %d: %s", pid, error.message());
+    ORBIT_ERROR("Getting tids of threads of process %d: %s", pid, error.message());
     return {};
   }
 
@@ -78,7 +78,7 @@ std::vector<pid_t> GetTidsOfProcess(pid_t pid) {
   for (auto it = fs::begin(proc_pid_task), end = fs::end(proc_pid_task); it != end;
        it.increment(error)) {
     if (error) {
-      ERROR("directory_iterator::increment failed with: %s (stopping)", error.message());
+      ORBIT_ERROR("directory_iterator::increment failed with: %s (stopping)", error.message());
       break;
     }
     if (auto tid = ProcEntryToPid(*it); tid.has_value()) {

--- a/src/OrbitBase/JoinFutures.cpp
+++ b/src/OrbitBase/JoinFutures.cpp
@@ -23,7 +23,7 @@ Future<void> JoinFutures(absl::Span<const Future<void>> futures) {
   shared_state->incomplete_futures = futures.size();
 
   for (const auto& future : futures) {
-    CHECK(future.IsValid());
+    ORBIT_CHECK(future.IsValid());
     orbit_base::FutureRegisterContinuationResult const result =
         future.RegisterContinuation([shared_state]() {
           absl::MutexLock lock{&shared_state->mutex};

--- a/src/OrbitBase/Logging.cpp
+++ b/src/OrbitBase/Logging.cpp
@@ -52,7 +52,7 @@ void InitLogFile(const std::filesystem::path& path) {
   // which tries to lock on the same mutex a second time. This will
   // lead to an error since the mutex is not recursive.
   if (log_file.get() != nullptr) {
-    PLATFORM_ABORT();
+    ORBIT_INTERNAL_PLATFORM_ABORT();
   }
 
   // TEMP_FAILURE_RETRY for FILE*
@@ -92,7 +92,7 @@ void LogStacktrace() {
     if (absl::Symbolize(raw_stack[i], buf.data(), buf.size())) {
       symbol = buf.data();
     }
-    LOG("  %p: %s\n", raw_stack[i], symbol);
+    ORBIT_LOG("  %p: %s\n", raw_stack[i], symbol);
   }
 }
 

--- a/src/OrbitBase/LoggingUtils.cpp
+++ b/src/OrbitBase/LoggingUtils.cpp
@@ -27,7 +27,7 @@ std::vector<std::filesystem::path> ListFilesRecursivelyIgnoreErrors(
   std::error_code error;
   auto directory_iterator = std::filesystem::recursive_directory_iterator(dir, error);
   if (error) {
-    ERROR("Unable to open directory \"%s\": %s", dir.string(), error.message());
+    ORBIT_ERROR("Unable to open directory \"%s\": %s", dir.string(), error.message());
     return {};
   }
 
@@ -35,14 +35,14 @@ std::vector<std::filesystem::path> ListFilesRecursivelyIgnoreErrors(
             end = std::filesystem::end(directory_iterator);
        it != end; it.increment(error)) {
     if (error) {
-      ERROR("directory_iterator::increment failed for \"%s\": %s (stopping)", dir.string(),
-            error.message());
+      ORBIT_ERROR("directory_iterator::increment failed for \"%s\": %s (stopping)", dir.string(),
+                  error.message());
       break;
     }
 
     bool is_regular_file = it->is_regular_file(error);
     if (error) {
-      ERROR("Unable to stat \"%s\": %s (will ignore)", it->path().string(), error.message());
+      ORBIT_ERROR("Unable to stat \"%s\": %s (will ignore)", it->path().string(), error.message());
       continue;
     }
 
@@ -79,7 +79,7 @@ std::vector<std::filesystem::path> FindOldLogFiles(
     ErrorMessageOr<absl::Time> timestamp_or_error =
         ParseLogFileTimestamp(log_file_path.filename().string());
     if (timestamp_or_error.has_error()) {
-      LOG("Warning: %s", timestamp_or_error.error().message());
+      ORBIT_LOG("Warning: %s", timestamp_or_error.error().message());
       continue;
     }
     if (timestamp_or_error.value() < expiration_time) {

--- a/src/OrbitBase/Profiling.cpp
+++ b/src/OrbitBase/Profiling.cpp
@@ -47,9 +47,9 @@ uint64_t EstimateAndLogClockResolution() {
   // We expect the value to be in the order of 35-100 nanoseconds.
   uint64_t clock_resolution_ns = orbit_base::EstimateClockResolution();
   if (clock_resolution_ns > 0) {
-    LOG("Clock resolution: %d (ns)", clock_resolution_ns);
+    ORBIT_LOG("Clock resolution: %d (ns)", clock_resolution_ns);
   } else {
-    ERROR("Failed to estimate clock resolution");
+    ORBIT_ERROR("Failed to estimate clock resolution");
   }
 
   return clock_resolution_ns;

--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -43,22 +43,22 @@ pid_t GetCurrentThreadIdNative() {
 pid_t GetCurrentProcessIdNative() { return getpid(); }
 
 uint32_t FromNativeThreadId(pid_t tid) {
-  CHECK(tid == kInvalidLinuxThreadId || tid >= 0);
+  ORBIT_CHECK(tid == kInvalidLinuxThreadId || tid >= 0);
   return static_cast<uint32_t>(tid);
 }
 
 uint32_t FromNativeProcessId(pid_t pid) {
-  CHECK(pid == kInvalidLinuxProcessId || pid >= 0);
+  ORBIT_CHECK(pid == kInvalidLinuxProcessId || pid >= 0);
   return static_cast<uint32_t>(pid);
 }
 
 pid_t ToNativeThreadId(uint32_t tid) {
-  CHECK(tid <= kIntMax || tid == kInvalidThreadId);
+  ORBIT_CHECK(tid <= kIntMax || tid == kInvalidThreadId);
   return static_cast<pid_t>(tid);
 }
 
 pid_t ToNativeProcessId(uint32_t pid) {
-  CHECK(pid <= kIntMax || pid == kInvalidProcessId);
+  ORBIT_CHECK(pid <= kIntMax || pid == kInvalidProcessId);
   return static_cast<pid_t>(pid);
 }
 
@@ -68,7 +68,7 @@ std::string GetThreadNameNative(pid_t tid) {
   std::string comm_filename = absl::StrFormat("/proc/%d/comm", tid);
   ErrorMessageOr<std::string> comm_content = ReadFileToString(comm_filename);
   if (!comm_content.has_value()) {
-    ERROR("Getting thread name for tid %d: %s", tid, comm_content.error().message());
+    ORBIT_ERROR("Getting thread name for tid %d: %s", tid, comm_content.error().message());
     return "";
   }
   if (!comm_content.value().empty() && comm_content.value().back() == '\n') {
@@ -86,7 +86,7 @@ void SetCurrentThreadName(const char* thread_name) {
 
   int result = pthread_setname_np(pthread_self(), thread_name);
   if (result != 0) {
-    ERROR("Setting thread name for tid %d. Error %d", GetCurrentThreadIdNative(), result);
+    ORBIT_ERROR("Setting thread name for tid %d. Error %d", GetCurrentThreadIdNative(), result);
   }
 }
 

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -41,23 +41,23 @@ uint32_t GetCurrentThreadIdNative() {
 uint32_t GetCurrentProcessIdNative() { return ::GetCurrentProcessId(); }
 
 uint32_t FromNativeThreadId(uint32_t tid) {
-  CHECK(IsMultipleOfFour(tid) || tid == kInvalidWindowsThreadId);
+  ORBIT_CHECK(IsMultipleOfFour(tid) || tid == kInvalidWindowsThreadId);
   return tid != kInvalidWindowsThreadId ? tid : orbit_base::kInvalidThreadId;
 }
 
 uint32_t FromNativeProcessId(uint32_t pid) {
   bool is_invalid_pid = (pid == kInvalidWindowsProcessId_0 || pid == kInvalidWindowsProcessId_1);
-  CHECK(IsMultipleOfFour(pid) || is_invalid_pid);
+  ORBIT_CHECK(IsMultipleOfFour(pid) || is_invalid_pid);
   return !is_invalid_pid ? pid : orbit_base::kInvalidProcessId;
 }
 
 uint32_t ToNativeThreadId(uint32_t tid) {
-  CHECK(IsMultipleOfFour(tid) || tid == orbit_base::kInvalidThreadId);
+  ORBIT_CHECK(IsMultipleOfFour(tid) || tid == orbit_base::kInvalidThreadId);
   return tid != orbit_base::kInvalidThreadId ? tid : kInvalidWindowsThreadId;
 }
 
 uint32_t ToNativeProcessId(uint32_t pid) {
-  CHECK(IsMultipleOfFour(pid) || pid == orbit_base::kInvalidProcessId);
+  ORBIT_CHECK(IsMultipleOfFour(pid) || pid == orbit_base::kInvalidProcessId);
   return pid != orbit_base::kInvalidProcessId ? pid : kInvalidWindowsProcessId_0;
 }
 
@@ -67,7 +67,7 @@ template <typename FunctionPrototypeT>
 static FunctionPrototypeT GetProcAddress(const std::string& library, const std::string& procedure) {
   HMODULE module_handle = LoadLibraryA(library.c_str());
   if (module_handle == nullptr) {
-    ERROR("Could not find procedure %s in %s", procedure, library);
+    ORBIT_ERROR("Could not find procedure %s in %s", procedure, library);
     return nullptr;
   }
   return reinterpret_cast<FunctionPrototypeT>(::GetProcAddress(module_handle, procedure.c_str()));
@@ -83,14 +83,14 @@ std::string GetThreadNameNative(uint32_t tid) {
   static auto get_thread_description =
       GetProcAddress<HRESULT(WINAPI*)(HANDLE, PWSTR*)>("kernel32.dll", "GetThreadDescription");
   if (get_thread_description == nullptr) {
-    ERROR("Getting thread name from id %u with proc[%llx]", tid, get_thread_description);
+    ORBIT_ERROR("Getting thread name from id %u with proc[%llx]", tid, get_thread_description);
     return kEmptyString;
   }
 
   // Get thread handle from tid.
   HANDLE thread_handle = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, tid);
   if (thread_handle == nullptr) {
-    ERROR("Retrieving thread handle for tid %u", tid);
+    ORBIT_ERROR("Retrieving thread handle for tid %u", tid);
     return kEmptyString;
   }
 
@@ -103,7 +103,7 @@ std::string GetThreadNameNative(uint32_t tid) {
     return thread_name;
   }
 
-  ERROR("Getting thread name from id %u with proc[%llx]", tid, get_thread_description);
+  ORBIT_ERROR("Getting thread name from id %u with proc[%llx]", tid, get_thread_description);
   return kEmptyString;
 }
 
@@ -113,7 +113,7 @@ void SetCurrentThreadName(const char* name) {
   std::wstring wide_name(name, name + strlen(name));
   if (set_thread_description == nullptr ||
       !SUCCEEDED((*set_thread_description)(GetCurrentThread(), wide_name.c_str()))) {
-    ERROR("Setting thread name %s with proc[%llx]", name, set_thread_description);
+    ORBIT_ERROR("Setting thread name %s with proc[%llx]", name, set_thread_description);
   }
 }
 

--- a/src/OrbitBase/include/OrbitBase/AnyMovable.h
+++ b/src/OrbitBase/include/OrbitBase/AnyMovable.h
@@ -26,7 +26,7 @@ namespace orbit_base {
 // std::cout << int_ptr; // Prints 0, since `other` does not hold an `int`.
 //
 // std::unique_ptr<int>* unique_int_ptr = any_movable_cast<std::unique_ptr<int>>(&other);
-// CHECK(unique_int_ptr != nulllptr);
+// ORBIT_CHECK(unique_int_ptr != nulllptr);
 // std::cout << **unique_int_ptr; // Prints "42"
 class AnyMovable {
   struct Base {

--- a/src/OrbitBase/include/OrbitBase/Executor.h
+++ b/src/OrbitBase/include/OrbitBase/Executor.h
@@ -56,7 +56,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
   // Note: The continuation is only executed if `*this` is still alive when `future` completes.
   template <typename T, typename F>
   auto ScheduleAfter(const orbit_base::Future<T>& future, F&& functor) {
-    CHECK(future.IsValid());
+    ORBIT_CHECK(future.IsValid());
 
     using ReturnType = typename orbit_base::ContinuationReturnType<T, F>::Type;
 
@@ -80,7 +80,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
             // iterator under the hood and this lambda will only be executed if the executor is
             // still alive.
             auto functor = orbit_base::any_movable_cast<std::decay_t<F>>(&*function_reference);
-            CHECK(functor != nullptr);
+            ORBIT_CHECK(functor != nullptr);
             std::apply([&](auto... args) { helper.Call(*functor, args...); }, std::move(argument));
             waiting_continuations_.erase(function_reference);
           };
@@ -107,7 +107,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
   // Note: The continuation is only executed if `*this` is still alive when `future` completes.
   template <typename T, typename F>
   auto ScheduleAfterIfSuccess(const orbit_base::Future<ErrorMessageOr<T>>& future, F&& functor) {
-    CHECK(future.IsValid());
+    ORBIT_CHECK(future.IsValid());
 
     using ContinuationReturnType = typename orbit_base::ContinuationReturnType<T, F>::Type;
     using PromiseReturnType =
@@ -139,7 +139,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
       auto success_function_wrapper = [this, function_reference, promise = std::move(promise),
                                        argument]() mutable {
         auto functor = orbit_base::any_movable_cast<std::decay_t<F>>(&*function_reference);
-        CHECK(functor != nullptr);
+        ORBIT_CHECK(functor != nullptr);
 
         orbit_base::HandleErrorAndSetResultInPromise<PromiseReturnType> helper{&promise};
         helper.Call(*functor, argument);

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -54,7 +54,7 @@ class unique_fd {
   [[nodiscard]] constexpr bool valid() const { return fd_ != kInvalidFd; }
 
   [[nodiscard]] int get() const {
-    CHECK(valid());
+    ORBIT_CHECK(valid());
     return fd_;
   }
 

--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -85,7 +85,7 @@ class InternalFutureBase {
   }
 
   void Wait() const {
-    CHECK(IsValid());
+    ORBIT_CHECK(IsValid());
     absl::MutexLock lock{&this->shared_state_->mutex};
     this->shared_state_->mutex.Await(absl::Condition(
         +[](const std::shared_ptr<SharedState<T>>* shared_state) ABSL_EXCLUSIVE_LOCKS_REQUIRED(

--- a/src/OrbitBase/include/OrbitBase/FutureHelpers.h
+++ b/src/OrbitBase/include/OrbitBase/FutureHelpers.h
@@ -38,7 +38,7 @@ template <typename T>
 
 template <typename T>
 [[nodiscard]] inline Future<T> UnwrapFuture(const Future<Future<T>>& outer_future) {
-  CHECK(outer_future.IsValid());
+  ORBIT_CHECK(outer_future.IsValid());
 
   // A quick explanation what's happening here:
   // We have an outer and a inner future. When the outer future completes, the inner
@@ -61,7 +61,7 @@ template <typename T>
 }
 
 [[nodiscard]] inline Future<void> UnwrapFuture(const Future<Future<void>>& outer_future) {
-  CHECK(outer_future.IsValid());
+  ORBIT_CHECK(outer_future.IsValid());
 
   auto promise = std::make_shared<Promise<void>>();
 

--- a/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
@@ -43,7 +43,7 @@ class ImmediateExecutor {
 
   template <typename T, typename F>
   auto ScheduleAfter(const Future<T>& future, F&& invocable) {
-    CHECK(future.IsValid());
+    ORBIT_CHECK(future.IsValid());
 
     using ReturnType = typename ContinuationReturnType<T, F>::Type;
     orbit_base::Promise<ReturnType> promise{};
@@ -61,7 +61,7 @@ class ImmediateExecutor {
 
   template <typename T, typename F>
   auto ScheduleAfterIfSuccess(const Future<ErrorMessageOr<T>>& future, F&& invocable) {
-    CHECK(future.IsValid());
+    ORBIT_CHECK(future.IsValid());
 
     using ResultType = typename ContinuationReturnType<T, F>::Type;
     using ReturnType = typename EnsureWrappedInErrorMessageOr<ResultType>::Type;

--- a/src/OrbitBase/include/OrbitBase/JoinFutures.h
+++ b/src/OrbitBase/include/OrbitBase/JoinFutures.h
@@ -28,7 +28,7 @@ class SharedStateJoin {
     output.reserve(results.size());
     std::transform(results.begin(), results.end(), std::back_inserter(output),
                    [](std::optional<T>& element) {
-                     CHECK(element.has_value());
+                     ORBIT_CHECK(element.has_value());
                      return *std::move(element);
                    });
     results.clear();
@@ -74,7 +74,7 @@ class SharedStateJoinTuple {
   template <std::size_t... Indexes>
   void SetResultsInPromiseImpl(std::index_sequence<Indexes...> /* indexes */)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) {
-    CHECK(std::get<Indexes>(results) && ...);
+    ORBIT_CHECK(std::get<Indexes>(results) && ...);
     auto finished_tuple = std::make_tuple(std::move(std::get<Indexes>(results).value())...);
     (std::get<Indexes>(results).reset(), ...);
     promise.SetResult(std::move(finished_tuple));
@@ -107,7 +107,7 @@ class SharedStateJoinTuple {
 template <typename... Args, std::size_t... Indexes>
 orbit_base::Future<std::tuple<Args...>> JoinFuturesTupleImpl(
     orbit_base::Future<Args>... futures, std::index_sequence<Indexes...> /* indexes */) {
-  CHECK(futures.IsValid() && ...);
+  ORBIT_CHECK(futures.IsValid() && ...);
 
   auto shared_state = std::make_shared<orbit_base_internal::SharedStateJoinTuple<Args...>>();
 
@@ -140,7 +140,7 @@ Future<std::vector<T>> JoinFutures(absl::Span<const Future<T>> futures) {
 
   for (auto it = futures.begin(); it != futures.end(); ++it) {
     const auto& future = *it;
-    CHECK(future.IsValid());
+    ORBIT_CHECK(future.IsValid());
 
     const size_t index = it - futures.begin();
     RegisterContinuationOrCallDirectly(future, [shared_state, index](const T& argument) {

--- a/src/OrbitCaptureGgpClient/OrbitCaptureGgpClient.cpp
+++ b/src/OrbitCaptureGgpClient/OrbitCaptureGgpClient.cpp
@@ -53,7 +53,7 @@ CaptureClientGgpClient::CaptureClientGgpClient(const std::string& grpc_server_ad
 int CaptureClientGgpClient::StartCapture() {
   ErrorMessageOr<void> result = pimpl->StartCapture();
   if (result.has_error()) {
-    ERROR("Not possible to start capture: %s", result.error().message());
+    ORBIT_ERROR("Not possible to start capture: %s", result.error().message());
     return 0;
   }
   return 1;
@@ -62,7 +62,7 @@ int CaptureClientGgpClient::StartCapture() {
 int CaptureClientGgpClient::StopCapture() {
   ErrorMessageOr<void> result = pimpl->StopCapture();
   if (result.has_error()) {
-    ERROR("Not possible to stop or save capture: %s", result.error().message());
+    ORBIT_ERROR("Not possible to stop or save capture: %s", result.error().message());
     return 0;
   }
   return 1;
@@ -72,7 +72,7 @@ int CaptureClientGgpClient::UpdateSelectedFunctions(
     const std::vector<std::string>& selected_functions) {
   ErrorMessageOr<void> result = pimpl->UpdateSelectedFunctions(selected_functions);
   if (result.has_error()) {
-    ERROR("Not possible to update functions %s", result.error().message());
+    ORBIT_ERROR("Not possible to update functions %s", result.error().message());
     return 0;
   }
   return 1;
@@ -92,10 +92,10 @@ void CaptureClientGgpClient::CaptureClientGgpClientImpl::SetupGrpcClient(
   std::shared_ptr<::grpc::Channel> grpc_channel = grpc::CreateCustomChannel(
       grpc_server_address, grpc::InsecureChannelCredentials(), channel_arguments);
   if (!grpc_channel) {
-    ERROR("Unable to create GRPC channel to %s", grpc_server_address);
+    ORBIT_ERROR("Unable to create GRPC channel to %s", grpc_server_address);
     return;
   }
-  LOG("Created GRPC channel to %s", grpc_server_address);
+  ORBIT_LOG("Created GRPC channel to %s", grpc_server_address);
 
   capture_client_ggp_service_ = orbit_grpc_protos::CaptureClientGgpService::NewStub(grpc_channel);
 }
@@ -108,11 +108,11 @@ ErrorMessageOr<void> CaptureClientGgpClient::CaptureClientGgpClientImpl::StartCa
   Status status = capture_client_ggp_service_->StartCapture(context.get(), request, &response);
 
   if (!status.ok()) {
-    ERROR("gRPC call to StartCapture failed: %s (error_code=%d)", status.error_message(),
-          status.error_code());
+    ORBIT_ERROR("gRPC call to StartCapture failed: %s (error_code=%d)", status.error_message(),
+                status.error_code());
     return ErrorMessage(status.error_message());
   }
-  LOG("Capture started");
+  ORBIT_LOG("Capture started");
   return outcome::success();
 }
 
@@ -123,11 +123,11 @@ ErrorMessageOr<void> CaptureClientGgpClient::CaptureClientGgpClientImpl::StopCap
 
   Status status = capture_client_ggp_service_->StopCapture(context.get(), request, &response);
   if (!status.ok()) {
-    ERROR("gRPC call to StopCapture failed: %s (error_code=%d)", status.error_message(),
-          status.error_code());
+    ORBIT_ERROR("gRPC call to StopCapture failed: %s (error_code=%d)", status.error_message(),
+                status.error_code());
     return ErrorMessage(status.error_message());
   }
-  LOG("Capture finished");
+  ORBIT_LOG("Capture finished");
   return outcome::success();
 }
 
@@ -143,11 +143,11 @@ ErrorMessageOr<void> CaptureClientGgpClient::CaptureClientGgpClientImpl::UpdateS
   Status status =
       capture_client_ggp_service_->UpdateSelectedFunctions(context.get(), request, &response);
   if (!status.ok()) {
-    ERROR("gRPC call to UpdateSelectedFunctions failed: %s (error_code=%d)", status.error_message(),
-          status.error_code());
+    ORBIT_ERROR("gRPC call to UpdateSelectedFunctions failed: %s (error_code=%d)",
+                status.error_message(), status.error_code());
     return ErrorMessage(status.error_message());
   }
-  LOG("Functions updated");
+  ORBIT_LOG("Functions updated");
   return outcome::success();
 }
 

--- a/src/OrbitCaptureGgpClient/main.cpp
+++ b/src/OrbitCaptureGgpClient/main.cpp
@@ -49,11 +49,11 @@ int main(int argc, char** argv) {
     std::cin >> i;
     switch (i) {
       case kStartCaptureCommand:
-        LOG("Chosen %d: Start capture", i);
+        ORBIT_LOG("Chosen %d: Start capture", i);
         ggp_capture_client.StartCapture();
         break;
       case kStopAndSaveCaptureCommand:
-        LOG("Chosen %d: Stop and save capture", i);
+        ORBIT_LOG("Chosen %d: Stop and save capture", i);
         ggp_capture_client.StopCapture();
         break;
       case kUpdateSelectedFunctionsCommand: {
@@ -70,11 +70,11 @@ int main(int argc, char** argv) {
         break;
       }
       case kShutdownServiceCommand:
-        LOG("Chosen %d: Shutdown service and exit", i);
+        ORBIT_LOG("Chosen %d: Shutdown service and exit", i);
         exit = true;
         break;
       default:
-        ERROR("Option selected not valid. Try again");
+        ORBIT_ERROR("Option selected not valid. Try again");
     }
   }
 

--- a/src/OrbitCaptureGgpService/OrbitCaptureGgpService.cpp
+++ b/src/OrbitCaptureGgpService/OrbitCaptureGgpService.cpp
@@ -28,14 +28,14 @@ void OrbitCaptureGgpService::RunServer() {
   grpc::EnableDefaultHealthCheckService(true);
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 
-  LOG("Starting gRPC capture ggp server at %s", server_address);
+  ORBIT_LOG("Starting gRPC capture ggp server at %s", server_address);
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(&ggp_capture_service);
   std::unique_ptr<Server> server(builder.BuildAndStart());
 
   if (server == nullptr) {
-    ERROR("Unable to start gRPC server");
+    ORBIT_ERROR("Unable to start gRPC server");
     return;
   }
 
@@ -47,7 +47,7 @@ void OrbitCaptureGgpService::RunServer() {
     server->Shutdown();
   });
 
-  LOG("Capture ggp server listening on %s", server_address);
+  ORBIT_LOG("Capture ggp server listening on %s", server_address);
   server->Wait();
   server_shutdown_watcher.join();
 }

--- a/src/OrbitCaptureGgpService/OrbitCaptureGgpServiceImpl.cpp
+++ b/src/OrbitCaptureGgpService/OrbitCaptureGgpServiceImpl.cpp
@@ -46,7 +46,7 @@ CaptureClientGgpServiceImpl::CaptureClientGgpServiceImpl()
 }
 
 void CaptureClientGgpServiceImpl::InitClientGgp() {
-  LOG("Initialise ClientGgp");
+  ORBIT_LOG("Initialise ClientGgp");
   ClientGgpOptions client_ggp_options;
   uint64_t orbit_service_grpc_port = absl::GetFlag(FLAGS_orbit_service_grpc_port);
   client_ggp_options.grpc_server_address = absl::StrFormat("127.0.0.1:%d", orbit_service_grpc_port);
@@ -57,16 +57,16 @@ void CaptureClientGgpServiceImpl::InitClientGgp() {
 
   client_ggp_ = std::make_unique<ClientGgp>(std::move(client_ggp_options));
   if (!client_ggp_->InitClient()) {
-    ERROR("Not possible to initialise client");
+    ORBIT_ERROR("Not possible to initialise client");
     return;
   }
-  LOG("ClientGgp Initialised");
+  ORBIT_LOG("ClientGgp Initialised");
 }
 
 Status CaptureClientGgpServiceImpl::StartCapture(ServerContext* /*context*/,
                                                  const StartCaptureRequest* /*request*/,
                                                  StartCaptureResponse* /*response*/) {
-  LOG("Start capture grpc call received");
+  ORBIT_LOG("Start capture grpc call received");
   if (CaptureIsRunning()) {
     return Status(StatusCode::INTERNAL, "A capture is already running");
   }
@@ -82,7 +82,7 @@ Status CaptureClientGgpServiceImpl::StartCapture(ServerContext* /*context*/,
 Status CaptureClientGgpServiceImpl::StopCapture(grpc::ServerContext* /*context*/,
                                                 const StopCaptureRequest* /*request*/,
                                                 StopCaptureResponse* /*response*/) {
-  LOG("Stop capture grpc call received");
+  ORBIT_LOG("Stop capture grpc call received");
   if (!client_ggp_->StopCapture()) {
     return Status(StatusCode::INTERNAL, "Not possible to stop the capture");
   }
@@ -95,7 +95,7 @@ Status CaptureClientGgpServiceImpl::StopCapture(grpc::ServerContext* /*context*/
 Status CaptureClientGgpServiceImpl::UpdateSelectedFunctions(
     grpc::ServerContext* /*context*/, const UpdateSelectedFunctionsRequest* request,
     UpdateSelectedFunctionsResponse* /* response */) {
-  LOG("UpdateSelectedFunctions grpc call received");
+  ORBIT_LOG("UpdateSelectedFunctions grpc call received");
   std::vector<std::string> capture_functions;
   for (const auto& function : request->functions()) {
     capture_functions.push_back(function);
@@ -108,7 +108,7 @@ Status CaptureClientGgpServiceImpl::UpdateSelectedFunctions(
 Status CaptureClientGgpServiceImpl::ShutdownService(grpc::ServerContext* /*context*/,
                                                     const ShutdownServiceRequest* /*request*/,
                                                     ShutdownServiceResponse* /*response*/) {
-  LOG("Shutdown grpc call received");
+  ORBIT_LOG("Shutdown grpc call received");
   Shutdown();
   return Status::OK;
 }
@@ -116,14 +116,14 @@ Status CaptureClientGgpServiceImpl::ShutdownService(grpc::ServerContext* /*conte
 void CaptureClientGgpServiceImpl::Shutdown() {
   if (CaptureIsRunning()) {
     if (!client_ggp_->StopCapture()) {
-      LOG("Not possible to stop the capture");
+      ORBIT_LOG("Not possible to stop the capture");
     }
   }
-  LOG("Shut down the thread and wait for it to finish");
+  ORBIT_LOG("Shut down the thread and wait for it to finish");
   thread_pool_->ShutdownAndWait();
   shutdown_finished_ = true;
 
-  LOG("All done");
+  ORBIT_LOG("All done");
 }
 
 bool CaptureClientGgpServiceImpl::CaptureIsRunning() {

--- a/src/OrbitCaptureGgpService/main.cpp
+++ b/src/OrbitCaptureGgpService/main.cpp
@@ -38,7 +38,7 @@ std::string GetLogFilePath(const std::string& log_directory) {
   std::filesystem::path log_directory_path{log_directory};
   std::filesystem::create_directory(log_directory_path);
   const std::string log_file_path = log_directory_path / "OrbitCaptureGgpService.log";
-  LOG("Log file: %s", log_file_path);
+  ORBIT_LOG("Log file: %s", log_file_path);
   return log_file_path;
 }
 
@@ -49,9 +49,9 @@ int main(int argc, char** argv) {
   absl::SetFlagsUsageConfig(absl::FlagsUsageConfig{{}, {}, {}, &orbit_version::GetBuildReport, {}});
   absl::ParseCommandLine(argc, argv);
 
-  LOG("------------------------------------");
-  LOG("OrbitCaptureGgpService started");
-  LOG("------------------------------------");
+  ORBIT_LOG("------------------------------------");
+  ORBIT_LOG("OrbitCaptureGgpService started");
+  ORBIT_LOG("------------------------------------");
 
   const std::string log_directory = absl::GetFlag(FLAGS_log_directory);
   if (!log_directory.empty()) {
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
   }
 
   if (!absl::GetFlag(FLAGS_pid)) {
-    FATAL("pid to capture not provided; set using -pid");
+    ORBIT_FATAL("pid to capture not provided; set using -pid");
   }
 
   // Start the service and waits for calls from the game

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -71,7 +71,7 @@ using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
 
 bool ClientGgp::InitClient() {
   if (options_.grpc_server_address.empty()) {
-    ERROR("gRPC server address not provided");
+    ORBIT_ERROR("gRPC server address not provided");
     return false;
   }
 
@@ -82,10 +82,10 @@ bool ClientGgp::InitClient() {
   grpc_channel_ = grpc::CreateCustomChannel(options_.grpc_server_address,
                                             grpc::InsecureChannelCredentials(), channel_arguments);
   if (!grpc_channel_) {
-    ERROR("Unable to create GRPC channel to %s", options_.grpc_server_address);
+    ORBIT_ERROR("Unable to create GRPC channel to %s", options_.grpc_server_address);
     return false;
   }
-  LOG("Created GRPC channel to %s", options_.grpc_server_address);
+  ORBIT_LOG("Created GRPC channel to %s", options_.grpc_server_address);
 
   process_client_ = std::make_unique<orbit_client_services::ProcessClient>(grpc_channel_);
 
@@ -107,7 +107,7 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
         "No process selected. Please choose a target process for the capture."};
   }
 
-  LOG("Capture pid %d", pid);
+  ORBIT_LOG("Capture pid %d", pid);
   TracepointInfoSet selected_tracepoints;
   const UnwindingMethod unwinding_method =
       options_.use_framepointer_unwinding ? CaptureOptions::kFramePointers : CaptureOptions::kDwarf;
@@ -122,11 +122,11 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
 
   std::filesystem::path file_path = GenerateFilePath();
 
-  LOG("Saving capture to \"%s\"", file_path.string());
+  ORBIT_LOG("Saving capture to \"%s\"", file_path.string());
 
   OUTCOME_TRY(auto&& event_processor, CaptureEventProcessor::CreateSaveToFileProcessor(
                                           GenerateFilePath(), [](const ErrorMessage& error) {
-                                            ERROR("%s", error.message());
+                                            ORBIT_ERROR("%s", error.message());
                                           }));
 
   Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> result = capture_client_->Capture(
@@ -142,18 +142,18 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
 
   result.Then(&executor, [](ErrorMessageOr<CaptureListener::CaptureOutcome> result) {
     if (!result.has_value()) {
-      ERROR("Capture failed: %s", result.error().message());
+      ORBIT_ERROR("Capture failed: %s", result.error().message());
     }
 
     // We do not send try aborting capture - it cannot be cancelled.
-    CHECK(result.value() == CaptureListener::CaptureOutcome::kComplete);
+    ORBIT_CHECK(result.value() == CaptureListener::CaptureOutcome::kComplete);
   });
 
   return outcome::success();
 }
 
 bool ClientGgp::StopCapture() {
-  LOG("Request to stop capture");
+  ORBIT_LOG("Request to stop capture");
   return capture_client_->StopCapture();
 }
 
@@ -174,20 +174,20 @@ std::filesystem::path ClientGgp::GenerateFilePath() {
 ErrorMessageOr<std::unique_ptr<ProcessData>> ClientGgp::GetOrbitProcessByPid(uint32_t pid) {
   // We retrieve the information of the process to later get the module corresponding to its binary
   OUTCOME_TRY(auto&& process_infos, process_client_->GetProcessList());
-  LOG("List of processes:");
+  ORBIT_LOG("List of processes:");
   for (const ProcessInfo& info : process_infos) {
-    LOG("pid:%d, name:%s, path:%s, is64:%d", info.pid(), info.name(), info.full_path(),
-        info.is_64_bit());
+    ORBIT_LOG("pid:%d, name:%s, path:%s, is64:%d", info.pid(), info.name(), info.full_path(),
+              info.is_64_bit());
   }
   auto process_it = find_if(process_infos.begin(), process_infos.end(),
                             [&pid](const ProcessInfo& info) { return info.pid() == pid; });
   if (process_it == process_infos.end()) {
     return ErrorMessage(absl::StrFormat("Error: Process with pid %d not found", pid));
   }
-  LOG("Found process by pid, set target process");
+  ORBIT_LOG("Found process by pid, set target process");
   auto process = std::make_unique<ProcessData>(*process_it);
-  LOG("Process info: pid:%d, name:%s, path:%s, is64:%d", process->pid(), process->name(),
-      process->full_path(), process->is_64_bit());
+  ORBIT_LOG("Process info: pid:%d, name:%s, path:%s, is64:%d", process->pid(), process->name(),
+            process->full_path(), process->is_64_bit());
   return process;
 }
 
@@ -195,19 +195,19 @@ ErrorMessageOr<void> ClientGgp::LoadModuleAndSymbols() {
   // Load modules for target_process_
   OUTCOME_TRY(auto&& module_infos, process_client_->LoadModuleList(target_process_->pid()));
 
-  LOG("List of modules");
+  ORBIT_LOG("List of modules");
   std::string target_process_build_id;
   for (const ModuleInfo& info : module_infos) {
     // TODO(dimitry): eventually we want to get build_id directly from ProcessData
     if (info.file_path() == target_process_->full_path()) {
       target_process_build_id = info.build_id();
     }
-    LOG("name:%s, path:%s, size:%d, address_start:%d. address_end:%d, build_id:%s", info.name(),
-        info.file_path(), info.file_size(), info.address_start(), info.address_end(),
-        info.build_id());
+    ORBIT_LOG("name:%s, path:%s, size:%d, address_start:%d. address_end:%d, build_id:%s",
+              info.name(), info.file_path(), info.file_size(), info.address_start(),
+              info.address_end(), info.build_id());
   }
 
-  CHECK(module_manager_.AddOrUpdateModules(module_infos).empty());
+  ORBIT_CHECK(module_manager_.AddOrUpdateModules(module_infos).empty());
 
   // Process name can be arbitrary so we use the path to find the module corresponding to the binary
   // of target_process_
@@ -216,19 +216,19 @@ ErrorMessageOr<void> ClientGgp::LoadModuleAndSymbols() {
   if (main_module_ == nullptr) {
     return ErrorMessage("Error: Module corresponding to process binary not found");
   }
-  LOG("Found module correspondent to process binary");
-  LOG("Module info: name:%s, path:%s, size:%d, build_id:%s", main_module_->name(),
-      main_module_->file_path(), main_module_->file_size(), main_module_->build_id());
+  ORBIT_LOG("Found module correspondent to process binary");
+  ORBIT_LOG("Module info: name:%s, path:%s, size:%d, build_id:%s", main_module_->name(),
+            main_module_->file_path(), main_module_->file_size(), main_module_->build_id());
 
   target_process_->UpdateModuleInfos(module_infos);
 
   // Load symbols for the module
   const std::string& module_path = main_module_->file_path();
-  LOG("Looking for debug info file for %s", module_path);
+  ORBIT_LOG("Looking for debug info file for %s", module_path);
   OUTCOME_TRY(auto&& main_executable_debug_file,
               process_client_->FindDebugInfoFile(module_path, {}));
-  LOG("Found file: %s", main_executable_debug_file);
-  LOG("Loading symbols");
+  ORBIT_LOG("Found file: %s", main_executable_debug_file);
+  ORBIT_LOG("Loading symbols");
   orbit_object_utils::ObjectFileInfo object_file_info{main_module_->load_bias(),
                                                       main_module_->executable_segment_offset()};
   OUTCOME_TRY(auto&& symbols, orbit_symbols::SymbolHelper::LoadSymbolsFromFile(
@@ -241,14 +241,15 @@ bool ClientGgp::InitCapture() {
   ErrorMessageOr<std::unique_ptr<ProcessData>> target_process_result =
       GetOrbitProcessByPid(options_.capture_pid);
   if (target_process_result.has_error()) {
-    ERROR("Not able to set target process: %s", target_process_result.error().message());
+    ORBIT_ERROR("Not able to set target process: %s", target_process_result.error().message());
     return false;
   }
   target_process_ = std::move(target_process_result.value());
   // Load the module and symbols
   ErrorMessageOr<void> result = LoadModuleAndSymbols();
   if (result.has_error()) {
-    ERROR("Not possible to finish loading the module and symbols: %s", result.error().message());
+    ORBIT_ERROR("Not possible to finish loading the module and symbols: %s",
+                result.error().message());
     return false;
   }
   // Load selected functions
@@ -259,16 +260,16 @@ bool ClientGgp::InitCapture() {
 void ClientGgp::LoadSelectedFunctions() {
   // Load selected functions if provided
   if (!options_.capture_functions.empty()) {
-    LOG("Loading selected functions");
+    ORBIT_LOG("Loading selected functions");
     selected_functions_ = GetSelectedFunctions();
     if (!selected_functions_.empty()) {
-      LOG("List of selected functions to hook in the capture:");
+      ORBIT_LOG("List of selected functions to hook in the capture:");
       for (auto const& [address, selected_function] : selected_functions_) {
-        LOG("%d %s", address, selected_function.pretty_name());
+        ORBIT_LOG("%d %s", address, selected_function.pretty_name());
       }
     }
   } else {
-    LOG("No functions provided; no functions hooked in the capture");
+    ORBIT_LOG("No functions provided; no functions hooked in the capture");
   }
 }
 
@@ -277,12 +278,12 @@ void ClientGgp::InformUsedSelectedCaptureFunctions(
   if (capture_functions_used.size() != options_.capture_functions.size()) {
     for (const std::string& selected_function : options_.capture_functions) {
       if (!capture_functions_used.contains(selected_function)) {
-        ERROR("Function matching %s not found; will not be hooked in the capture",
-              selected_function);
+        ORBIT_ERROR("Function matching %s not found; will not be hooked in the capture",
+                    selected_function);
       }
     }
   } else {
-    LOG("All functions provided had at least a match");
+    ORBIT_LOG("All functions provided had at least a match");
   }
 }
 

--- a/src/OrbitClientGgp/main.cpp
+++ b/src/OrbitClientGgp/main.cpp
@@ -47,7 +47,7 @@ std::string GetLogFilePath(const std::string& log_directory) {
   std::filesystem::path log_directory_path{log_directory};
   std::filesystem::create_directory(log_directory_path);
   std::filesystem::path log_file_path = log_directory_path / "OrbitClientGgp.log";
-  LOG("Log file: %s", log_file_path);
+  ORBIT_LOG("Log file: %s", log_file_path);
   return log_file_path;
 }
 
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
   }
 
   if (absl::GetFlag(FLAGS_pid) == 0) {
-    FATAL("pid to capture not provided; set using -pid");
+    ORBIT_FATAL("pid to capture not provided; set using -pid");
   }
 
   ClientGgpOptions options;
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
   options.capture_file_directory = absl::GetFlag(FLAGS_file_directory);
   options.samples_per_second = absl::GetFlag(FLAGS_sampling_rate);
   uint16_t stack_dump_size = absl::GetFlag(FLAGS_stack_dump_size);
-  CHECK(stack_dump_size <= 65000);
+  ORBIT_CHECK(stack_dump_size <= 65000);
   options.stack_dump_size = stack_dump_size;
   options.use_framepointer_unwinding = absl::GetFlag(FLAGS_frame_pointer_unwinding);
 
@@ -92,24 +92,24 @@ int main(int argc, char** argv) {
   auto start_capture_result = client_ggp.RequestStartCapture(thread_pool.get());
   if (start_capture_result.has_error()) {
     thread_pool->ShutdownAndWait();
-    FATAL("Unable to start capture: %s", start_capture_result.error().message());
+    ORBIT_FATAL("Unable to start capture: %s", start_capture_result.error().message());
   }
 
   // Captures for the period of time requested
   uint32_t capture_length = absl::GetFlag(FLAGS_capture_length);
-  LOG("Go to sleep for %d seconds", capture_length);
+  ORBIT_LOG("Go to sleep for %d seconds", capture_length);
   absl::SleepFor(absl::Seconds(capture_length));
-  LOG("Back from sleep");
+  ORBIT_LOG("Back from sleep");
 
   // Requests to stop the capture and waits for thread to finish
   if (!client_ggp.StopCapture()) {
     thread_pool->ShutdownAndWait();
-    FATAL("Unable to stop the capture; exiting");
+    ORBIT_FATAL("Unable to stop the capture; exiting");
   }
 
-  LOG("Shut down the thread and wait for it to finish");
+  ORBIT_LOG("Shut down the thread and wait for it to finish");
   thread_pool->ShutdownAndWait();
 
-  LOG("All done");
+  ORBIT_LOG("All done");
   return 0;
 }

--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -79,8 +79,8 @@ ErrorMessageOr<std::unique_ptr<Client>> CreateClient(QString ggp_program,
       error_message.append(absl::StrFormat(", ggp error message: \"%s\"", ggp_stderr));
     }
 
-    LOG("%s", error_message);
-    LOG("ggp stdout: \"%s\"", QString(ggp_process.readAllStandardOutput()).toStdString());
+    ORBIT_LOG("%s", error_message);
+    ORBIT_LOG("ggp stdout: \"%s\"", QString(ggp_process.readAllStandardOutput()).toStdString());
     return ErrorMessage{error_message};
   }
 

--- a/src/OrbitGgp/InstanceItemModel.cpp
+++ b/src/OrbitGgp/InstanceItemModel.cpp
@@ -26,9 +26,9 @@ int InstanceItemModel::columnCount(const QModelIndex& parent) const {
 }
 
 QVariant InstanceItemModel::data(const QModelIndex& index, int role) const {
-  CHECK(index.isValid());
-  CHECK(index.model() == this);
-  CHECK(index.row() < instances_.size());  // instances_.size());
+  ORBIT_CHECK(index.isValid());
+  ORBIT_CHECK(index.model() == this);
+  ORBIT_CHECK(index.row() < instances_.size());  // instances_.size());
 
   const Instance& current_instance = instances_[index.row()];
 
@@ -52,11 +52,11 @@ QVariant InstanceItemModel::data(const QModelIndex& index, int role) const {
     case Columns::kState:
       return current_instance.state;
     case Columns::kEnd:
-      CHECK(false);
+      ORBIT_CHECK(false);
       return {};
   }
 
-  CHECK(false);  // That means, someone (me?) forgot a column.
+  ORBIT_CHECK(false);  // That means, someone (me?) forgot a column.
   return {};
 }
 
@@ -91,11 +91,11 @@ QVariant InstanceItemModel::headerData(int section, Qt::Orientation orientation,
     case Columns::kState:
       return QLatin1String("State");
     case Columns::kEnd:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
       return {};
   }
 
-  CHECK(false);
+  ORBIT_CHECK(false);
   return {};
 }
 
@@ -140,12 +140,12 @@ void InstanceItemModel::SetInstances(QVector<Instance> new_instances) {
   if (old_iter == old_instances.end() && new_iter != new_instances.end()) {
     beginInsertRows({}, old_instances.size(), new_instances.size() - 1);
     std::copy(new_iter, new_instances.end(), std::back_inserter(old_instances));
-    CHECK(old_instances.size() == new_instances.size());
+    ORBIT_CHECK(old_instances.size() == new_instances.size());
     endInsertRows();
   } else if (old_iter != old_instances.end() && new_iter == new_instances.end()) {
     beginRemoveRows({}, new_instances.size(), old_instances.size() - 1);
     old_instances.erase(old_iter, old_instances.end());
-    CHECK(old_instances.size() == new_instances.size());
+    ORBIT_CHECK(old_instances.size() == new_instances.size());
     endRemoveRows();
   }
 }

--- a/src/OrbitGl/AccessibleCaptureViewElement.cpp
+++ b/src/OrbitGl/AccessibleCaptureViewElement.cpp
@@ -16,7 +16,7 @@ const orbit_accessibility::AccessibleInterface* AccessibleCaptureViewElement::Ac
   return parent->GetOrCreateAccessibleInterface();
 }
 orbit_accessibility::AccessibilityRect AccessibleCaptureViewElement::AccessibleRect() const {
-  CHECK(capture_view_element_ != nullptr);
+  ORBIT_CHECK(capture_view_element_ != nullptr);
   const Viewport* viewport = capture_view_element_->GetViewport();
 
   Vec2 pos = capture_view_element_->GetPos();

--- a/src/OrbitGl/AccessibleCaptureViewElement.h
+++ b/src/OrbitGl/AccessibleCaptureViewElement.h
@@ -13,7 +13,7 @@ class AccessibleCaptureViewElement : public orbit_accessibility::AccessibleInter
  public:
   explicit AccessibleCaptureViewElement(const CaptureViewElement* capture_view_element)
       : capture_view_element_(capture_view_element) {
-    CHECK(capture_view_element != nullptr);
+    ORBIT_CHECK(capture_view_element != nullptr);
   }
 
   [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;

--- a/src/OrbitGl/AccessibleTimeGraph.h
+++ b/src/OrbitGl/AccessibleTimeGraph.h
@@ -16,7 +16,7 @@ namespace orbit_gl {
 class TimeGraphAccessibility : public orbit_accessibility::AccessibleInterface {
  public:
   explicit TimeGraphAccessibility(TimeGraph* time_graph) : time_graph_(time_graph) {
-    CHECK(time_graph != nullptr);
+    ORBIT_CHECK(time_graph != nullptr);
   }
   [[nodiscard]] int AccessibleChildCount() const override;
   [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleChild(

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -96,7 +96,7 @@ const AccessibleInterface* AccessibleTrackTab::AccessibleChild(int /*unused*/) c
 }
 
 std::string AccessibleTrackTab::AccessibleName() const {
-  CHECK(track_ != nullptr);
+  ORBIT_CHECK(track_ != nullptr);
   return track_->GetName() + "_tab";
 }
 
@@ -110,7 +110,7 @@ AccessibleTrack::AccessibleTrack(Track* track, TimeGraphLayout* layout)
       fake_timers_pane_(std::make_unique<FakeTimerPane>(track, layout, fake_tab_.get())) {}
 
 int AccessibleTrack::AccessibleChildCount() const {
-  CHECK(track_ != nullptr);
+  ORBIT_CHECK(track_ != nullptr);
 
   // Only expose the "Timer" pane if any timers were rendered in the visible field
   if (track_->GetVisiblePrimitiveCount() > 0) {
@@ -121,7 +121,7 @@ int AccessibleTrack::AccessibleChildCount() const {
 }
 
 const AccessibleInterface* AccessibleTrack::AccessibleChild(int index) const {
-  CHECK(track_ != nullptr);
+  ORBIT_CHECK(track_ != nullptr);
 
   // The first child is the "virtual" tab.
   if (index == 0) {
@@ -146,12 +146,12 @@ const AccessibleInterface* AccessibleTrack::AccessibleChild(int index) const {
 }
 
 std::string AccessibleTrack::AccessibleName() const {
-  CHECK(track_ != nullptr);
+  ORBIT_CHECK(track_ != nullptr);
   return track_->GetName();
 }
 
 AccessibilityState AccessibleTrack::AccessibleState() const {
-  CHECK(track_ != nullptr);
+  ORBIT_CHECK(track_ != nullptr);
 
   using State = AccessibilityState;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -122,11 +122,11 @@ class OrbitApp final : public DataViewFactory,
   void ClearCapture();
   [[nodiscard]] bool HasCaptureData() const override { return capture_data_ != nullptr; }
   [[nodiscard]] orbit_client_data::CaptureData& GetMutableCaptureData() override {
-    CHECK(capture_data_ != nullptr);
+    ORBIT_CHECK(capture_data_ != nullptr);
     return *capture_data_;
   }
   [[nodiscard]] const orbit_client_data::CaptureData& GetCaptureData() const override {
-    CHECK(capture_data_ != nullptr);
+    ORBIT_CHECK(capture_data_ != nullptr);
     return *capture_data_;
   }
 
@@ -182,11 +182,11 @@ class OrbitApp final : public DataViewFactory,
 
   void SetCaptureWindow(CaptureWindow* capture);
   [[nodiscard]] const TimeGraph* GetTimeGraph() const {
-    CHECK(capture_window_ != nullptr);
+    ORBIT_CHECK(capture_window_ != nullptr);
     return capture_window_->GetTimeGraph();
   }
   [[nodiscard]] TimeGraph* GetMutableTimeGraph() {
-    CHECK(capture_window_ != nullptr);
+    ORBIT_CHECK(capture_window_ != nullptr);
     return capture_window_->GetTimeGraph();
   }
   void SetDebugCanvas(GlCanvas* debug_canvas);
@@ -358,13 +358,13 @@ class OrbitApp final : public DataViewFactory,
   void CrashOrbitService(orbit_grpc_protos::CrashOrbitServiceRequest_CrashType crash_type);
 
   void SetGrpcChannel(std::shared_ptr<grpc::Channel> grpc_channel) {
-    CHECK(grpc_channel_ == nullptr);
-    CHECK(grpc_channel != nullptr);
+    ORBIT_CHECK(grpc_channel_ == nullptr);
+    ORBIT_CHECK(grpc_channel != nullptr);
     grpc_channel_ = std::move(grpc_channel);
   }
   void SetProcessManager(orbit_client_services::ProcessManager* process_manager) {
-    CHECK(process_manager_ == nullptr);
-    CHECK(process_manager != nullptr);
+    ORBIT_CHECK(process_manager_ == nullptr);
+    ORBIT_CHECK(process_manager != nullptr);
     process_manager_ = process_manager;
   }
   void SetTargetProcess(orbit_client_data::ProcessData* process);

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -42,7 +42,7 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent,
   if (timer_info == nullptr) return "";
   auto* manual_inst_manager = app_->GetManualInstrumentationManager();
 
-  CHECK(timer_info->type() == TimerInfo::kApiScopeAsync);
+  ORBIT_CHECK(timer_info->type() == TimerInfo::kApiScopeAsync);
 
   uint64_t event_id = timer_info->api_async_scope_id();
   std::string label = manual_inst_manager->GetString(event_id);
@@ -99,7 +99,7 @@ float AsyncTrack::GetDefaultBoxHeight() const {
 }
 
 std::string AsyncTrack::GetTimesliceText(const TimerInfo& timer_info) const {
-  CHECK(timer_info.type() == TimerInfo::kApiScopeAsync);
+  ORBIT_CHECK(timer_info.type() == TimerInfo::kApiScopeAsync);
   std::string time = GetDisplayTime(timer_info);
   uint64_t event_id = timer_info.api_async_scope_id();
   std::string name = app_->GetManualInstrumentationManager()->GetString(event_id);
@@ -108,7 +108,7 @@ std::string AsyncTrack::GetTimesliceText(const TimerInfo& timer_info) const {
 
 Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, bool is_highlighted,
                                 const internal::DrawData& /*draw_data*/) const {
-  CHECK(timer_info.type() == TimerInfo::kApiScopeAsync);
+  ORBIT_CHECK(timer_info.type() == TimerInfo::kApiScopeAsync);
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
   if (is_highlighted) {
@@ -122,10 +122,10 @@ Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, b
   }
 
   if (timer_info.has_color()) {
-    CHECK(timer_info.color().red() < 256);
-    CHECK(timer_info.color().green() < 256);
-    CHECK(timer_info.color().blue() < 256);
-    CHECK(timer_info.color().alpha() < 256);
+    ORBIT_CHECK(timer_info.color().red() < 256);
+    ORBIT_CHECK(timer_info.color().green() < 256);
+    ORBIT_CHECK(timer_info.color().blue() < 256);
+    ORBIT_CHECK(timer_info.color().alpha() < 256);
     return Color(static_cast<uint8_t>(timer_info.color().red()),
                  static_cast<uint8_t>(timer_info.color().green()),
                  static_cast<uint8_t>(timer_info.color().blue()),

--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -23,7 +23,7 @@ void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                       std::shared_ptr<Pickable> pickable) {
-  CHECK(picking_manager_ != nullptr);
+  ORBIT_CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
 
@@ -37,7 +37,7 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
 
 void Batcher::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
                               std::shared_ptr<Pickable> pickable) {
-  CHECK(picking_manager_ != nullptr);
+  ORBIT_CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
 
@@ -80,7 +80,7 @@ void Batcher::AddBox(const Box& box, const Color& color,
 }
 
 void Batcher::AddBox(const Box& box, const Color& color, std::shared_ptr<Pickable> pickable) {
-  CHECK(picking_manager_ != nullptr);
+  ORBIT_CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
   std::array<Color, 4> colors;
@@ -219,7 +219,7 @@ void Batcher::AddTriangle(const Triangle& triangle, const Color& color,
 
 void Batcher::AddTriangle(const Triangle& triangle, const Color& color,
                           std::shared_ptr<Pickable> pickable) {
-  CHECK(picking_manager_ != nullptr);
+  ORBIT_CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
 
@@ -285,8 +285,8 @@ void Batcher::AddCircle(const Vec2& position, float radius, float z, Color color
 }
 
 const PickingUserData* Batcher::GetUserData(PickingId id) const {
-  CHECK(id.element_id >= 0);
-  CHECK(id.batcher_id == batcher_id_);
+  ORBIT_CHECK(id.element_id >= 0);
+  ORBIT_CHECK(id.batcher_id == batcher_id_);
 
   switch (id.type) {
     case PickingType::kInvalid:
@@ -294,15 +294,15 @@ const PickingUserData* Batcher::GetUserData(PickingId id) const {
     case PickingType::kBox:
     case PickingType::kTriangle:
     case PickingType::kLine:
-      CHECK(id.element_id < user_data_.size());
+      ORBIT_CHECK(id.element_id < user_data_.size());
       return user_data_[id.element_id].get();
     case PickingType::kPickable:
       return nullptr;
     case PickingType::kCount:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 
 PickingUserData* Batcher::GetUserData(PickingId id) {
@@ -361,7 +361,7 @@ void Batcher::ResetElements() {
 }
 
 void Batcher::StartNewFrame() {
-  CHECK(translations_.IsEmpty());
+  ORBIT_CHECK(translations_.IsEmpty());
   ResetElements();
   user_data_.clear();
 }

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -106,7 +106,7 @@ std::string CGroupAndProcessMemoryTrack::GetLegendTooltips(size_t legend_index) 
           "<i>/sys/fs/cgroup/memory/$0/memory.limit_in_bytes</i>",
           cgroup_name_);
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -50,7 +50,7 @@ CallTreeThread* CallTreeNode::GetThreadOrNull(uint32_t thread_id) {
 CallTreeThread* CallTreeNode::AddAndGetThread(uint32_t thread_id, std::string thread_name) {
   const auto& [it, inserted] = thread_children_.try_emplace(
       thread_id, CallTreeThread{thread_id, std::move(thread_name), this});
-  CHECK(inserted);
+  ORBIT_CHECK(inserted);
   children_cache_.reset();
   return &it->second;
 }
@@ -71,7 +71,7 @@ CallTreeFunction* CallTreeNode::AddAndGetFunction(uint64_t function_absolute_add
       function_absolute_address,
       CallTreeFunction{function_absolute_address, std::move(function_name), std::move(module_path),
                        std::move(module_build_id), this});
-  CHECK(inserted);
+  ORBIT_CHECK(inserted);
   children_cache_.reset();
   return &it->second;
 }
@@ -79,7 +79,7 @@ CallTreeFunction* CallTreeNode::AddAndGetFunction(uint64_t function_absolute_add
 CallTreeUnwindErrors* CallTreeNode::GetUnwindErrorsOrNull() { return unwind_errors_child_.get(); }
 
 CallTreeUnwindErrors* CallTreeNode::AddAndGetUnwindErrors() {
-  CHECK(unwind_errors_child_ == nullptr);
+  ORBIT_CHECK(unwind_errors_child_ == nullptr);
   unwind_errors_child_ = std::make_unique<CallTreeUnwindErrors>(this);
   children_cache_.reset();
   return unwind_errors_child_.get();
@@ -144,7 +144,7 @@ static void AddUnwindErrorToTopDownThread(CallTreeThread* thread_node,
   }
   unwind_errors_node->IncreaseSampleCount(callstack_sample_count);
 
-  CHECK(!resolved_callstack.frames().empty());
+  ORBIT_CHECK(!resolved_callstack.frames().empty());
   // Only use the innermost frame for unwind errors.
   uint64_t frame = resolved_callstack.frames(0);
   const std::string& function_name = capture_data.GetFunctionNameByAddress(frame);
@@ -175,7 +175,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
     const PostProcessedSamplingData& post_processed_sampling_data,
     const CaptureData& capture_data) {
   ORBIT_SCOPE_FUNCTION;
-  SCOPED_TIMED_LOG("CreateTopDownViewFromPostProcessedSamplingData");
+  ORBIT_SCOPED_TIMED_LOG("CreateTopDownViewFromPostProcessedSamplingData");
 
   auto top_down_view = std::make_unique<CallTreeView>();
   const std::string& process_name = capture_data.process_name();
@@ -228,7 +228,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
 [[nodiscard]] static CallTreeUnwindErrors* AddUnwindErrorToBottomUpViewAndReturnUnwindingErrorsNode(
     CallTreeView* bottom_up_view, const CallstackInfo& resolved_callstack,
     uint64_t callstack_sample_count, const CaptureData& capture_data) {
-  CHECK(!resolved_callstack.frames().empty());
+  ORBIT_CHECK(!resolved_callstack.frames().empty());
   // Only use the innermost frame for unwind errors.
   uint64_t frame = resolved_callstack.frames(0);
   const std::string& function_name = capture_data.GetFunctionNameByAddress(frame);
@@ -250,7 +250,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedS
     const PostProcessedSamplingData& post_processed_sampling_data,
     const CaptureData& capture_data) {
   ORBIT_SCOPE_FUNCTION;
-  SCOPED_TIMED_LOG("CreateBottomUpViewFromPostProcessedSamplingData");
+  ORBIT_SCOPED_TIMED_LOG("CreateBottomUpViewFromPostProcessedSamplingData");
 
   auto bottom_up_view = std::make_unique<CallTreeView>();
   const std::string& process_name = capture_data.process_name();

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -107,13 +107,13 @@ void CallstackThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text
   const Color kWhite(255, 255, 255, 255);
   const Color kGreenSelection(0, 255, 0, 255);
   const Color kGreyError(160, 160, 160, 255);
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
 
   if (!picking) {
     // Sampling Events
     auto action_on_callstack_events = [&](const CallstackEvent& event) {
       const uint64_t time = event.time();
-      CHECK(time >= min_tick && time <= max_tick);
+      ORBIT_CHECK(time >= min_tick && time <= max_tick);
       Vec2 pos(timeline_info_->GetWorldFromTick(time), GetPos()[1]);
       Color color = kWhite;
       if (capture_data_->GetCallstackData().GetCallstack(event.callstack_id())->type() !=
@@ -146,7 +146,7 @@ void CallstackThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text
 
     auto action_on_callstack_events = [&, this](const CallstackEvent& event) {
       const uint64_t time = event.time();
-      CHECK(time >= min_tick && time <= max_tick);
+      ORBIT_CHECK(time >= min_tick && time <= max_tick);
       Vec2 pos(timeline_info_->GetWorldFromTick(time) - kPickingBoxOffset, GetPos()[1]);
       Vec2 size(kPickingBoxWidth, track_height);
       auto user_data = std::make_unique<PickingUserData>(
@@ -189,7 +189,7 @@ void CallstackThreadBar::SelectCallstacks() {
   int64_t thread_id = GetThreadId();
   bool thread_id_is_all_threads = thread_id == orbit_base::kAllProcessThreadsTid;
 
-  CHECK(capture_data_);
+  ORBIT_CHECK(capture_data_);
   auto selected_callstack_events =
       thread_id_is_all_threads
           ? capture_data_->GetCallstackData().GetCallstackEventsInTimeRange(t0, t1)
@@ -213,7 +213,7 @@ bool CallstackThreadBar::IsEmpty() const {
 [[nodiscard]] std::string CallstackThreadBar::SafeGetFormattedFunctionName(
     const orbit_client_protos::CallstackInfo& callstack, int frame_index,
     int max_line_length) const {
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
   if (frame_index >= callstack.frames_size()) {
     return std::string("<i>") + CaptureData::kUnknownFunctionOrModuleName + "</i>";
   }
@@ -264,7 +264,7 @@ std::string CallstackThreadBar::GetSampleTooltip(const Batcher& batcher, Picking
     return unknown_return_text;
   }
 
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
   const CallstackData& callstack_data = capture_data_->GetCallstackData();
   const auto* callstack_event = static_cast<const CallstackEvent*>(user_data->custom_data_);
 

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -12,7 +12,7 @@ namespace orbit_gl {
 CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, Viewport* viewport,
                                        TimeGraphLayout* layout)
     : viewport_(viewport), layout_(layout), parent_(parent) {
-  CHECK(layout != nullptr);
+  ORBIT_CHECK(layout != nullptr);
 }
 
 void CaptureViewElement::Draw(Batcher& batcher, TextRenderer& text_renderer,

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -197,7 +197,7 @@ void CaptureWindow::HandlePickedElement(PickingMode picking_mode, PickingId pick
 }
 
 void CaptureWindow::SelectTimer(const TimerInfo* timer_info) {
-  CHECK(time_graph_ != nullptr);
+  ORBIT_CHECK(time_graph_ != nullptr);
   if (timer_info == nullptr) return;
 
   app_->SelectTimer(timer_info);
@@ -244,7 +244,7 @@ bool CaptureWindow::RightUp() {
   if (app_->IsDevMode()) {
     auto result = selection_stats_.Generate(this, select_start_time_, select_stop_time_);
     if (result.has_error()) {
-      ERROR("%s", result.error().message());
+      ORBIT_ERROR("%s", result.error().message());
     }
   }
 
@@ -533,7 +533,7 @@ void CaptureWindow::RenderAllLayers() {
   auto it = std::unique(all_layers.begin(), all_layers.end());
   all_layers.resize(std::distance(all_layers.begin(), it));
   if (all_layers.size() > GlCanvas::kMaxNumberRealZLayers) {
-    ERROR("Too many z-layers. The current number is %d", all_layers.size());
+    ORBIT_ERROR("Too many z-layers. The current number is %d", all_layers.size());
   }
 
   for (float layer : all_layers) {
@@ -648,12 +648,12 @@ void CaptureWindow::CreateTimeGraph(CaptureData* capture_data) {
 Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {
   switch (batcher_id) {
     case BatcherId::kTimeGraph:
-      CHECK(time_graph_ != nullptr);
+      ORBIT_CHECK(time_graph_ != nullptr);
       return time_graph_->GetBatcher();
     case BatcherId::kUi:
       return ui_batcher_;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 

--- a/src/OrbitGl/FramePointerValidatorClient.cpp
+++ b/src/OrbitGl/FramePointerValidatorClient.cpp
@@ -35,7 +35,7 @@ FramePointerValidatorClient::FramePointerValidatorClient(
 
 void FramePointerValidatorClient::AnalyzeModules(const std::vector<const ModuleData*>& modules) {
   if (modules.empty()) {
-    ERROR("No module to validate, cancelling");
+    ORBIT_ERROR("No module to validate, cancelling");
     return;
   }
 
@@ -45,7 +45,7 @@ void FramePointerValidatorClient::AnalyzeModules(const std::vector<const ModuleD
   for (const ModuleData* module : modules) {
     ValidateFramePointersRequest request;
     ValidateFramePointersResponse response;
-    CHECK(module != nullptr);
+    ORBIT_CHECK(module != nullptr);
 
     std::vector<const FunctionInfo*> functions = module->GetFunctions();
     request.set_module_path(module->file_path());

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, OrbitApp* app
     case CanvasType::kDebug:
       return std::make_unique<GlCanvas>();
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -241,7 +241,7 @@ void GlCanvas::CleanupGlState() { glPopAttrib(); }
 
 void GlCanvas::Render(int width, int height) {
   ORBIT_SCOPE("GlCanvas::Render");
-  CHECK(width == viewport_.GetScreenWidth() && height == viewport_.GetScreenHeight());
+  ORBIT_CHECK(width == viewport_.GetScreenWidth() && height == viewport_.GetScreenHeight());
 
   if (!IsRedrawNeeded()) {
     return;

--- a/src/OrbitGl/GlUtils.cpp
+++ b/src/OrbitGl/GlUtils.cpp
@@ -48,6 +48,6 @@ void CheckGlError() {
   GLenum error_code = glGetError();
   if (error_code != GL_NO_ERROR) {
     const char* error_string = GetGlError(error_code);
-    LOG("OpenGL ERROR : %s", error_string);
+    ORBIT_LOG("OpenGL ERROR : %s", error_string);
   }
 }

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -47,7 +47,7 @@ std::string GpuDebugMarkerTrack::GetTooltip() const {
 Color GpuDebugMarkerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
                                          bool is_highlighted,
                                          const internal::DrawData& /*draw_data*/) const {
-  CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
+  ORBIT_CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
   if (is_highlighted) {
@@ -60,10 +60,10 @@ Color GpuDebugMarkerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_se
     return kInactiveColor;
   }
   if (timer_info.has_color()) {
-    CHECK(timer_info.color().red() < 256);
-    CHECK(timer_info.color().green() < 256);
-    CHECK(timer_info.color().blue() < 256);
-    CHECK(timer_info.color().alpha() < 256);
+    ORBIT_CHECK(timer_info.color().red() < 256);
+    ORBIT_CHECK(timer_info.color().green() < 256);
+    ORBIT_CHECK(timer_info.color().blue() < 256);
+    ORBIT_CHECK(timer_info.color().alpha() < 256);
     return Color(static_cast<uint8_t>(timer_info.color().red()),
                  static_cast<uint8_t>(timer_info.color().green()),
                  static_cast<uint8_t>(timer_info.color().blue()),
@@ -74,7 +74,7 @@ Color GpuDebugMarkerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_se
 }
 
 std::string GpuDebugMarkerTrack::GetTimesliceText(const TimerInfo& timer_info) const {
-  CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
+  ORBIT_CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
 
   std::string time = GetDisplayTime(timer_info);
   return absl::StrFormat("%s  %s", string_manager_->Get(timer_info.user_data_key()).value_or(""),
@@ -87,7 +87,7 @@ std::string GpuDebugMarkerTrack::GetBoxTooltip(const Batcher& batcher, PickingId
     return "";
   }
 
-  CHECK(timer_info->type() == TimerInfo::kGpuDebugMarker);
+  ORBIT_CHECK(timer_info->type() == TimerInfo::kGpuDebugMarker);
 
   std::string marker_text = string_manager_->Get(timer_info->user_data_key()).value_or("");
   return absl::StrFormat(

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -87,10 +87,10 @@ Color GpuSubmissionTrack::GetTimerColor(const TimerInfo& timer_info, bool is_sel
     return kInactiveColor;
   }
   if (timer_info.has_color()) {
-    CHECK(timer_info.color().red() < 256);
-    CHECK(timer_info.color().green() < 256);
-    CHECK(timer_info.color().blue() < 256);
-    CHECK(timer_info.color().alpha() < 256);
+    ORBIT_CHECK(timer_info.color().red() < 256);
+    ORBIT_CHECK(timer_info.color().green() < 256);
+    ORBIT_CHECK(timer_info.color().blue() < 256);
+    ORBIT_CHECK(timer_info.color().alpha() < 256);
     return Color(static_cast<uint8_t>(timer_info.color().red()),
                  static_cast<uint8_t>(timer_info.color().green()),
                  static_cast<uint8_t>(timer_info.color().blue()),
@@ -130,8 +130,8 @@ float GpuSubmissionTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (IsCollapsed()) {
     adjusted_depth = 0.f;
   }
-  CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
-        timer_info.type() == TimerInfo::kGpuCommandBuffer);
+  ORBIT_CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
+              timer_info.type() == TimerInfo::kGpuCommandBuffer);
 
   // We are drawing a small gap between each depth, for visualization purposes.
   // There won't be a gap between "hw execution"timers and command buffer timers, which
@@ -164,8 +164,8 @@ bool GpuSubmissionTrack::TimerFilter(const TimerInfo& timer_info) const {
 }
 
 std::string GpuSubmissionTrack::GetTimesliceText(const TimerInfo& timer_info) const {
-  CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
-        timer_info.type() == TimerInfo::kGpuCommandBuffer);
+  ORBIT_CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
+              timer_info.type() == TimerInfo::kGpuCommandBuffer);
   std::string time = GetDisplayTime(timer_info);
 
   return absl::StrFormat("%s  %s", string_manager_->Get(timer_info.user_data_key()).value_or(""),
@@ -224,7 +224,7 @@ std::string GpuSubmissionTrack::GetBoxTooltip(const Batcher& batcher, PickingId 
 }
 
 std::string GpuSubmissionTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
   return absl::StrFormat(
       "<b>Software Queue</b><br/>"
       "<i>Time between amdgpu_cs_ioctl (job submitted) and "
@@ -241,7 +241,7 @@ std::string GpuSubmissionTrack::GetSwQueueTooltip(const TimerInfo& timer_info) c
 }
 
 std::string GpuSubmissionTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
   return absl::StrFormat(
       "<b>Hardware Queue</b><br/><i>Time between amdgpu_sched_run_job "
       "(job scheduled) and start of GPU execution</i>"
@@ -257,7 +257,7 @@ std::string GpuSubmissionTrack::GetHwQueueTooltip(const TimerInfo& timer_info) c
 }
 
 std::string GpuSubmissionTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
   return absl::StrFormat(
       "<b>Hardware Execution</b><br/>"
       "<i>End is marked by \"dma_fence_signaled\" event for this command "

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -78,7 +78,7 @@ void GpuTrack::OnTimer(const TimerInfo& timer_info) {
       marker_track_->OnTimer(timer_info);
       break;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -143,7 +143,7 @@ const TimerInfo* GpuTrack::GetLeft(const TimerInfo& timer_info) const {
     case TimerInfo::kGpuDebugMarker:
       return marker_track_->GetLeft(timer_info);
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -156,7 +156,7 @@ const TimerInfo* GpuTrack::GetRight(const TimerInfo& timer_info) const {
     case TimerInfo::kGpuDebugMarker:
       return marker_track_->GetRight(timer_info);
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -169,7 +169,7 @@ const TimerInfo* GpuTrack::GetUp(const TimerInfo& timer_info) const {
     case TimerInfo::kGpuDebugMarker:
       return marker_track_->GetUp(timer_info);
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -182,6 +182,6 @@ const TimerInfo* GpuTrack::GetDown(const TimerInfo& timer_info) const {
     case TimerInfo::kGpuDebugMarker:
       return marker_track_->GetDown(timer_info);
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }

--- a/src/OrbitGl/ImGuiOrbit.cpp
+++ b/src/OrbitGl/ImGuiOrbit.cpp
@@ -77,10 +77,10 @@ static bool CheckShader(GLuint handle, const char* desc) {
     ImVector<char> buf;
     buf.resize(static_cast<int>(log_length + 1));
     glGetShaderInfoLog(handle, log_length, NULL, static_cast<GLchar*>(buf.begin()));
-    LOG("Log from shader compilation: %s", buf.begin());
+    ORBIT_LOG("Log from shader compilation: %s", buf.begin());
   }
   if (static_cast<GLboolean>(status) == GL_FALSE) {
-    FATAL("Orbit_ImGui_CreateDeviceObjects: failed to compile %s!", desc);
+    ORBIT_FATAL("Orbit_ImGui_CreateDeviceObjects: failed to compile %s!", desc);
   }
   return static_cast<GLboolean>(status) == GL_TRUE;
 }
@@ -95,10 +95,10 @@ static bool CheckProgram(GLuint handle, const char* desc) {
     ImVector<char> buf;
     buf.resize(static_cast<int>(log_length + 1));
     glGetProgramInfoLog(handle, log_length, NULL, static_cast<GLchar*>(buf.begin()));
-    LOG("Log from shader program linking: %s", buf.begin());
+    ORBIT_LOG("Log from shader program linking: %s", buf.begin());
   }
   if (static_cast<GLboolean>(status) == GL_FALSE) {
-    FATAL("Orbit_ImGui_CreateDeviceObjects: failed to link %s!", desc);
+    ORBIT_FATAL("Orbit_ImGui_CreateDeviceObjects: failed to link %s!", desc);
   }
   return static_cast<GLboolean>(status) == GL_TRUE;
 }

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -94,14 +94,14 @@ void HandleCaptureEvent(const orbit_api::ApiTrackUint64& track_uint64,
 // constructable. However, that state is never expected to be called in the visitor.
 void HandleCaptureEvent(const std::monostate& /*unused*/,
                         orbit_capture_client::ApiEventProcessor* /*unused*/) {
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 
 class IntrospectionCaptureListener : public orbit_capture_client::CaptureListener {
  public:
   explicit IntrospectionCaptureListener(IntrospectionWindow* introspection_window)
       : introspection_window_{introspection_window} {
-    CHECK(introspection_window_ != nullptr);
+    ORBIT_CHECK(introspection_window_ != nullptr);
   }
 
  private:
@@ -120,73 +120,77 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& /*capture_started*/,
                         std::optional<std::filesystem::path> /*file_path*/,
                         absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnCaptureFinished(const orbit_grpc_protos::CaptureFinished& /*capture_finished*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
-  void OnKeyAndString(uint64_t /*key*/, std::string /*str*/) override { UNREACHABLE(); }
+  void OnKeyAndString(uint64_t /*key*/, std::string /*str*/) override { ORBIT_UNREACHABLE(); }
   void OnUniqueCallstack(uint64_t /*callstack_id*/,
                          orbit_client_protos::CallstackInfo /*callstack*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnCallstackEvent(orbit_client_protos::CallstackEvent /*callstack_event*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
-  void OnThreadName(uint32_t /*thread_id*/, std::string /*thread_name*/) override { UNREACHABLE(); }
+  void OnThreadName(uint32_t /*thread_id*/, std::string /*thread_name*/) override {
+    ORBIT_UNREACHABLE();
+  }
   void OnThreadStateSlice(
       orbit_client_protos::ThreadStateSliceInfo /*thread_state_slice*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo /*address_info*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnUniqueTracepointInfo(uint64_t /*key*/,
                               orbit_grpc_protos::TracepointInfo /*tracepoint_info*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnTracepointEvent(
       orbit_client_protos::TracepointEventInfo /*tracepoint_event_info*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnModuleUpdate(uint64_t /*timestamp_ns*/,
                       orbit_grpc_protos::ModuleInfo /*module_info*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnModulesSnapshot(uint64_t /*timestamp_ns*/,
                          std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
-  void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override { UNREACHABLE(); }
+  void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {
+    ORBIT_UNREACHABLE();
+  }
   void OnClockResolutionEvent(
       orbit_grpc_protos::ClockResolutionEvent /*clock_resolution_event*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnErrorsWithPerfEventOpenEvent(
       orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/)
       override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnErrorEnablingOrbitApiEvent(
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnErrorEnablingUserSpaceInstrumentationEvent(
       orbit_grpc_protos::ErrorEnablingUserSpaceInstrumentationEvent /*error_event*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnWarningInstrumentingWithUserSpaceInstrumentationEvent(
       orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent /*warning_event*/)
       override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnLostPerfRecordsEvent(
       orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
   void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent
                                         /*out_of_order_events_discarded_event*/) override {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
 
   IntrospectionWindow* introspection_window_;
@@ -221,7 +225,7 @@ const char* IntrospectionWindow::GetHelpText() const {
 bool IntrospectionWindow::IsIntrospecting() const { return introspection_listener_ != nullptr; }
 
 void IntrospectionWindow::StartIntrospection() {
-  CHECK(!IsIntrospecting());
+  ORBIT_CHECK(!IsIntrospecting());
   set_draw_help(false);
   CreateTimeGraph(capture_data_.get());
   introspection_listener_ = std::make_unique<orbit_introspection::IntrospectionListener>(

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -238,11 +238,11 @@ uint64_t LiveFunctionsController::GetStartTime(uint64_t index) const {
 }
 
 uint64_t LiveFunctionsController::GetCaptureMin() const {
-  CHECK(app_ != nullptr);
+  ORBIT_CHECK(app_ != nullptr);
   return app_->GetTimeGraph()->GetCaptureMin();
 }
 uint64_t LiveFunctionsController::GetCaptureMax() const {
-  CHECK(app_ != nullptr);
+  ORBIT_CHECK(app_ != nullptr);
   return app_->GetTimeGraph()->GetCaptureMax();
 }
 

--- a/src/OrbitGl/MajorPageFaultsTrack.cpp
+++ b/src/OrbitGl/MajorPageFaultsTrack.cpp
@@ -46,7 +46,7 @@ std::string MajorPageFaultsTrack::GetLegendTooltips(size_t legend_index) const {
           "Derived from the <i>pgmajfault</i> field in file <i>/proc/vmstat</i>.",
           memory_sampling_period_ms_);
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -35,8 +35,8 @@ void MemoryTrack<Dimension>::TrySetValueUpperBound(const std::string& pretty_lab
                                                    double raw_value) {
   double max_series_value = GraphTrack<Dimension>::GetGraphMaxValue();
   if (raw_value < max_series_value) {
-    LOG("Fail to set MemoryTrack value upper bound: input value %f < maximum series value %f",
-        raw_value, max_series_value);
+    ORBIT_LOG("Fail to set MemoryTrack value upper bound: input value %f < maximum series value %f",
+              raw_value, max_series_value);
     return;
   }
   this->SetValueUpperBound(pretty_label, raw_value);
@@ -47,8 +47,8 @@ void MemoryTrack<Dimension>::TrySetValueLowerBound(const std::string& pretty_lab
                                                    double raw_value) {
   double min_series_value = GraphTrack<Dimension>::GetGraphMinValue();
   if (raw_value > min_series_value) {
-    LOG("Fail to set MemoryTrack value lower bound: input value %f > minimum series value %f",
-        raw_value, min_series_value);
+    ORBIT_LOG("Fail to set MemoryTrack value lower bound: input value %f > minimum series value %f",
+              raw_value, min_series_value);
     return;
   }
   this->SetValueLowerBound(pretty_label, raw_value);

--- a/src/OrbitGl/MinorPageFaultsTrack.cpp
+++ b/src/OrbitGl/MinorPageFaultsTrack.cpp
@@ -36,7 +36,7 @@ std::string MinorPageFaultsTrack::GetLegendTooltips(size_t legend_index) const {
           "<i>/proc/vmstat</i>.",
           memory_sampling_period_ms_);
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 

--- a/src/OrbitGl/MultivariateTimeSeries.h
+++ b/src/OrbitGl/MultivariateTimeSeries.h
@@ -61,12 +61,12 @@ class MultivariateTimeSeries {
 
   [[nodiscard]] uint64_t StartTimeInNs() const {
     absl::MutexLock lock(&mutex_);
-    CHECK(!time_to_series_values_.empty());
+    ORBIT_CHECK(!time_to_series_values_.empty());
     return time_to_series_values_.begin()->first;
   }
   [[nodiscard]] uint64_t EndTimeInNs() const {
     absl::MutexLock lock(&mutex_);
-    CHECK(!time_to_series_values_.empty());
+    ORBIT_CHECK(!time_to_series_values_.empty());
     return time_to_series_values_.rbegin()->first;
   }
 
@@ -114,7 +114,7 @@ class MultivariateTimeSeries {
  private:
   [[nodiscard]] TimeSeriesEntryIter GetPreviousOrFirstEntryIterator(uint64_t time) const
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
-    CHECK(!time_to_series_values_.empty());
+    ORBIT_CHECK(!time_to_series_values_.empty());
 
     auto iterator_lower = time_to_series_values_.upper_bound(time);
     if (iterator_lower != time_to_series_values_.begin()) --iterator_lower;
@@ -123,7 +123,7 @@ class MultivariateTimeSeries {
 
   [[nodiscard]] TimeSeriesEntryIter GetNextOrLastEntryIterator(uint64_t time) const
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
-    CHECK(!time_to_series_values_.empty());
+    ORBIT_CHECK(!time_to_series_values_.empty());
 
     auto iterator_higher = time_to_series_values_.lower_bound(time);
     if (iterator_higher == time_to_series_values_.end()) --iterator_higher;

--- a/src/OrbitGl/PickingManager.cpp
+++ b/src/OrbitGl/PickingManager.cpp
@@ -37,7 +37,7 @@ void PickingManager::Reset() {
 }
 
 std::shared_ptr<Pickable> PickingManager::GetPickableFromId(PickingId id) const {
-  CHECK(id.type == PickingType::kPickable);
+  ORBIT_CHECK(id.type == PickingType::kPickable);
 
   absl::MutexLock lock(&mutex_);
   auto it = pid_pickable_map_.find(id.element_id);

--- a/src/OrbitGl/PickingManager.h
+++ b/src/OrbitGl/PickingManager.h
@@ -67,9 +67,9 @@ struct PickingId {
 
   [[nodiscard]] inline static PickingId Create(PickingType type, uint32_t element_id,
                                                BatcherId batcher_id = BatcherId::kTimeGraph) {
-    CHECK(element_id >> kElementIDBitSize == 0);
-    CHECK(type >= PickingType{} && type < PickingType::kCount);
-    CHECK(batcher_id >= BatcherId{} && batcher_id < BatcherId::kCount);
+    ORBIT_CHECK(element_id >> kElementIDBitSize == 0);
+    ORBIT_CHECK(type >= PickingType{} && type < PickingType::kCount);
+    ORBIT_CHECK(batcher_id >= BatcherId{} && batcher_id < BatcherId::kCount);
     PickingId result{};
     result.type = type;
     result.element_id = element_id;
@@ -79,8 +79,8 @@ struct PickingId {
 
   [[nodiscard]] inline static PickingId FromPixelValue(uint32_t value) {
     const Layout layout = absl::bit_cast<Layout, uint32_t>(value);
-    CHECK(layout.type < static_cast<uint32_t>(PickingType::kCount));
-    CHECK(layout.batcher_id < static_cast<uint32_t>(BatcherId::kCount));
+    ORBIT_CHECK(layout.type < static_cast<uint32_t>(PickingType::kCount));
+    ORBIT_CHECK(layout.batcher_id < static_cast<uint32_t>(BatcherId::kCount));
 
     PickingId id{};
     id.element_id = layout.element_id;

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -28,7 +28,7 @@ SamplingReport::SamplingReport(
       has_summary_{has_summary},
       app_{app} {
   ORBIT_SCOPE_FUNCTION;
-  SCOPED_TIMED_LOG("SamplingReport::SamplingReport");
+  ORBIT_SCOPED_TIMED_LOG("SamplingReport::SamplingReport");
   FillReport();
 }
 
@@ -108,7 +108,7 @@ void SamplingReport::OnSelectAddresses(const absl::flat_hash_set<uint64_t>& addr
 }
 
 void SamplingReport::IncrementCallstackIndex() {
-  CHECK(HasCallstacks());
+  ORBIT_CHECK(HasCallstacks());
   size_t max_index = selected_sorted_callstack_report_->callstack_counts.size() - 1;
   if (++selected_callstack_index_ > max_index) {
     selected_callstack_index_ = 0;
@@ -118,7 +118,7 @@ void SamplingReport::IncrementCallstackIndex() {
 }
 
 void SamplingReport::DecrementCallstackIndex() {
-  CHECK(HasCallstacks());
+  ORBIT_CHECK(HasCallstacks());
   size_t max_index = selected_sorted_callstack_report_->callstack_counts.size() - 1;
   if (selected_callstack_index_ == 0) {
     selected_callstack_index_ = max_index;
@@ -141,7 +141,7 @@ std::string SamplingReport::GetSelectedCallstackString() const {
   uint64_t callstack_id =
       selected_sorted_callstack_report_->callstack_counts[selected_callstack_index_].callstack_id;
   auto callstack_it = unique_callstacks_.find(callstack_id);
-  CHECK(callstack_it != unique_callstacks_.end());
+  ORBIT_CHECK(callstack_it != unique_callstacks_.end());
   CallstackInfo::CallstackType callstack_type = callstack_it->second->type();
 
   std::string type_string = (callstack_type == CallstackInfo::kComplete) ? "" : "  -  Unwind error";
@@ -156,7 +156,7 @@ void SamplingReport::OnCallstackIndexChanged(size_t index) {
     const CallstackCount& cs = selected_sorted_callstack_report_->callstack_counts[index];
     selected_callstack_index_ = index;
     auto it = unique_callstacks_.find(cs.callstack_id);
-    CHECK(it != unique_callstacks_.end());
+    ORBIT_CHECK(it != unique_callstacks_.end());
     callstack_data_view_->SetCallstack(*it->second);
     callstack_data_view_->SetFunctionsToHighlight(selected_addresses_);
   } else {

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -56,7 +56,7 @@ void SchedulerTrack::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_ren
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
   bool is_same_tid_as_selected = timer_info.thread_id() == app_->selected_thread_id();
 
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
   uint32_t capture_process_id = capture_data_->process_id();
   bool is_same_pid_as_target =
       capture_process_id == 0 || capture_process_id == timer_info.process_id();
@@ -116,7 +116,7 @@ std::string SchedulerTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) 
     return "";
   }
 
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
   return absl::StrFormat(
       "<b>CPU Core activity</b><br/>"
       "<br/>"

--- a/src/OrbitGl/ScopedStatus.h
+++ b/src/OrbitGl/ScopedStatus.h
@@ -63,7 +63,7 @@ class ScopedStatus final {
   ~ScopedStatus() { reset(); }
 
   void UpdateMessage(const std::string& message) {
-    CHECK(data_ != nullptr);
+    ORBIT_CHECK(data_ != nullptr);
     if (std::this_thread::get_id() == data_->main_thread_id) {
       data_->status_listener->UpdateStatus(data_->status_id, message);
     } else {

--- a/src/OrbitGl/SystemMemoryTrack.cpp
+++ b/src/OrbitGl/SystemMemoryTrack.cpp
@@ -86,7 +86,7 @@ std::string SystemMemoryTrack::GetLegendTooltips(size_t legend_index) const {
       return "<b>Physical memory not used by the system</b><br/><br/>"
              "Derived from the <i>MemFree</i> field in file <i>/proc/meminfo</i>";
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 

--- a/src/OrbitGl/TextRenderer.cpp
+++ b/src/OrbitGl/TextRenderer.cpp
@@ -112,7 +112,7 @@ void TextRenderer::Init() {
 }
 
 ftgl::texture_font_t* TextRenderer::GetFont(uint32_t size) {
-  CHECK(!fonts_by_size_.empty());
+  ORBIT_CHECK(!fonts_by_size_.empty());
   if (fonts_by_size_.count(size) == 0) {
     auto iterator_next = fonts_by_size_.upper_bound(size);
     // If there isn't that font_size in the map, we will search for the next one or previous one

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -85,7 +85,7 @@ static Color GetThreadStateColor(ThreadStateSliceInfo::ThreadState state) {
     case ThreadStateSliceInfo::kIdle:
       return kBrown500;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -112,7 +112,7 @@ static std::string GetThreadStateName(ThreadStateSliceInfo::ThreadState state) {
     case ThreadStateSliceInfo::kIdle:
       return "Idle";
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -140,7 +140,7 @@ static std::string GetThreadStateDescription(ThreadStateSliceInfo::ThreadState s
     case ThreadStateSliceInfo::kIdle:
       return "Idle kernel thread.";
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -174,7 +174,7 @@ void ThreadStateBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_ren
 
   uint64_t ignore_until_ns = 0;
 
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
   capture_data_->ForEachThreadStateSliceIntersectingTimeRange(
       GetThreadId(), min_tick, max_tick, [&](const ThreadStateSliceInfo& slice) {
         if (slice.end_timestamp_ns() <= ignore_until_ns) {

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -178,10 +178,10 @@ bool ThreadTrack::IsTrackSelected() const {
     if (!timer_info.has_color()) {
       return std::nullopt;
     }
-    CHECK(timer_info.color().red() < 256);
-    CHECK(timer_info.color().green() < 256);
-    CHECK(timer_info.color().blue() < 256);
-    CHECK(timer_info.color().alpha() < 256);
+    ORBIT_CHECK(timer_info.color().red() < 256);
+    ORBIT_CHECK(timer_info.color().green() < 256);
+    ORBIT_CHECK(timer_info.color().blue() < 256);
+    ORBIT_CHECK(timer_info.color().alpha() < 256);
     return Color(static_cast<uint8_t>(timer_info.color().red()),
                  static_cast<uint8_t>(timer_info.color().green()),
                  static_cast<uint8_t>(timer_info.color().blue()),
@@ -293,8 +293,8 @@ std::string ThreadTrack::GetTimesliceText(const TimerInfo& timer_info) const {
     return absl::StrFormat("%s %s %s", timer_info.api_scope_name(), extra_info.c_str(), time);
   }
 
-  ERROR("Unexpected case in ThreadTrack::SetTimesliceText: function=\"%s\", type=%d",
-        func->function_name(), static_cast<int>(timer_info.type()));
+  ORBIT_ERROR("Unexpected case in ThreadTrack::SetTimesliceText: function=\"%s\", type=%d",
+              func->function_name(), static_cast<int>(timer_info.type()));
   return "";
 }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -127,7 +127,7 @@ double TimeGraph::GetCaptureTimeSpanUs() const {
       capture_min_timestamp_ == std::numeric_limits<uint64_t>::max()) {
     return 0.0;
   }
-  CHECK(capture_min_timestamp_ <= capture_max_timestamp_);
+  ORBIT_CHECK(capture_min_timestamp_ <= capture_max_timestamp_);
   return TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
 }
 
@@ -322,7 +322,7 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
       break;
     }
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   RequestUpdate();
@@ -357,7 +357,7 @@ void TimeGraph::ProcessApiTrackValueEvent(const orbit_client_protos::ApiTrackVal
       track->AddValue(time, track_event.data_uint64());
       break;
     default:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 
@@ -400,7 +400,7 @@ void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
     uint64_t memory_sampling_period_ms = app_->GetMemorySamplingPeriodMs();
     track = track_manager_->CreateAndGetPageFaultsTrack(cgroup_name, memory_sampling_period_ms);
   }
-  CHECK(track != nullptr);
+  ORBIT_CHECK(track != nullptr);
   track->OnTimer(timer_info);
 }
 
@@ -457,7 +457,7 @@ uint64_t TimeGraph::GetTickFromUs(double micros) const {
 // Select a timer_info. Also move the view in order to assure that the timer_info and its track are
 // visible.
 void TimeGraph::SelectAndMakeVisible(const TimerInfo* timer_info) {
-  CHECK(timer_info != nullptr);
+  ORBIT_CHECK(timer_info != nullptr);
   app_->SelectTimer(timer_info);
   HorizontallyMoveIntoView(VisibilityType::kPartlyVisible, *timer_info);
   VerticallyMoveIntoView(*timer_info);
@@ -493,7 +493,7 @@ const TimerInfo* TimeGraph::FindNextFunctionCall(uint64_t function_address, uint
   uint64_t goal_time = std::numeric_limits<uint64_t>::max();
   std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
   for (const TimerChain* chain : chains) {
-    CHECK(chain != nullptr);
+    ORBIT_CHECK(chain != nullptr);
     for (const auto& block : *chain) {
       if (!block.Intersects(current_time, goal_time)) continue;
       for (uint64_t i = 0; i < block.size(); i++) {
@@ -516,7 +516,7 @@ std::vector<const TimerInfo*> TimeGraph::GetAllTimersForHookedFunction(
   std::vector<const TimerInfo*> timers;
   std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
   for (const TimerChain* chain : chains) {
-    CHECK(chain != nullptr);
+    ORBIT_CHECK(chain != nullptr);
     for (const auto& block : *chain) {
       for (uint64_t i = 0; i < block.size(); i++) {
         const TimerInfo& timer = block[i];
@@ -534,7 +534,7 @@ void TimeGraph::RequestUpdate() {
 
 void TimeGraph::PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode) {
   ORBIT_SCOPE_FUNCTION;
-  CHECK(app_->GetStringManager() != nullptr);
+  ORBIT_CHECK(app_->GetStringManager() != nullptr);
 
   batcher_.StartNewFrame();
 
@@ -690,8 +690,8 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
 
     uint64_t id_a = timers[k - 1].first;
     uint64_t id_b = timers[k].first;
-    CHECK(iterator_id_to_function_id_.find(id_a) != iterator_id_to_function_id_.end());
-    CHECK(iterator_id_to_function_id_.find(id_b) != iterator_id_to_function_id_.end());
+    ORBIT_CHECK(iterator_id_to_function_id_.find(id_a) != iterator_id_to_function_id_.end());
+    ORBIT_CHECK(iterator_id_to_function_id_.find(id_b) != iterator_id_to_function_id_.end());
     uint64_t function_a_id = iterator_id_to_function_id_.at(id_a);
     uint64_t function_b_id = iterator_id_to_function_id_.at(id_b);
     const CaptureData& capture_data = app_->GetCaptureData();
@@ -699,8 +699,8 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
         capture_data.GetInstrumentedFunctionById(function_a_id);
     const InstrumentedFunction* function_b =
         capture_data.GetInstrumentedFunctionById(function_b_id);
-    CHECK(function_a != nullptr);
-    CHECK(function_b != nullptr);
+    ORBIT_CHECK(function_a != nullptr);
+    ORBIT_CHECK(function_b != nullptr);
     const std::string& label = GetLabelBetweenIterators(*function_a, *function_b);
     const std::string& time = GetTimeString(*timers[k - 1].second, *timers[k].second);
 
@@ -810,7 +810,7 @@ void TimeGraph::SetThreadFilter(const std::string& filter) {
 }
 
 void TimeGraph::SelectAndZoom(const TimerInfo* timer_info) {
-  CHECK(timer_info);
+  ORBIT_CHECK(timer_info);
   Zoom(*timer_info);
   SelectAndMakeVisible(timer_info);
 }
@@ -842,7 +842,7 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
         break;
       default:
         // Other choices are not implemented.
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
   if (jump_direction == JumpDirection::kNext) {
@@ -857,7 +857,7 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
         goal = FindNextFunctionCall(function_id, current_time, thread_id);
         break;
       default:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
   if (jump_direction == JumpDirection::kTop) {

--- a/src/OrbitGl/TimelineTicks.cpp
+++ b/src/OrbitGl/TimelineTicks.cpp
@@ -72,7 +72,7 @@ std::vector<uint64_t> TimelineTicks::GetMajorTicks(uint64_t start_ns, uint64_t e
 uint64_t TimelineTicks::GetScale(uint64_t visible_ns) const {
   // Biggest scale smaller than half the total range, as we want to see at least 2 major ticks.
   uint64_t half_visible_ns = visible_ns / 2;
-  CHECK(half_visible_ns > 0);
+  ORBIT_CHECK(half_visible_ns > 0);
   return *std::prev(kTimelineScales.upper_bound(half_visible_ns));
 }
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -105,8 +105,8 @@ bool TimerTrack::DrawTimer(TextRenderer& text_renderer, const TimerInfo* prev_ti
                            const TimerInfo* next_timer_info, const internal::DrawData& draw_data,
                            const TimerInfo* current_timer_info, uint64_t* min_ignore,
                            uint64_t* max_ignore) {
-  CHECK(min_ignore != nullptr);
-  CHECK(max_ignore != nullptr);
+  ORBIT_CHECK(min_ignore != nullptr);
+  ORBIT_CHECK(max_ignore != nullptr);
   if (current_timer_info == nullptr) return false;
   if (draw_data.min_tick > current_timer_info->end() ||
       draw_data.max_tick < current_timer_info->start()) {
@@ -278,7 +278,7 @@ void TimerTrack::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_rendere
   draw_data.min_timegraph_tick = timeline_info_->GetTickFromUs(timeline_info_->GetMinTimeUs());
 
   for (const TimerChain* chain : chains) {
-    CHECK(chain != nullptr);
+    ORBIT_CHECK(chain != nullptr);
     // In order to draw overlaps correctly, we need for every text box to be drawn (current),
     // its previous and next text box. In order to avoid looking ahead for the next text (which is
     // error-prone), we are doing just one traversal of the text boxes, while keeping track of the

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -65,7 +65,7 @@ void TracepointThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& tex
   const Color kWhiteTransparent(255, 255, 255, 190);
   const Color kGrey(128, 128, 128, 255);
 
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
 
   if (!picking) {
     capture_data_->ForEachTracepointEventOfThreadInTimeRange(
@@ -108,14 +108,14 @@ void TracepointThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& tex
 
 std::string TracepointThreadBar::GetTracepointTooltip(Batcher& batcher, PickingId id) const {
   auto* user_data = batcher.GetUserData(id);
-  CHECK(user_data && user_data->custom_data_);
+  ORBIT_CHECK(user_data && user_data->custom_data_);
 
   const auto* tracepoint_event_info =
       static_cast<const orbit_client_protos::TracepointEventInfo*>(user_data->custom_data_);
 
   uint64_t tracepoint_info_key = tracepoint_event_info->tracepoint_info_key();
 
-  CHECK(capture_data_ != nullptr);
+  ORBIT_CHECK(capture_data_ != nullptr);
 
   orbit_grpc_protos::TracepointInfo tracepoint_info =
       capture_data_->GetTracepointInfo(tracepoint_info_key);

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -44,7 +44,7 @@ TrackManager::TrackManager(TimeGraph* time_graph, Viewport* viewport, TimeGraphL
       layout_(layout),
       capture_data_{capture_data},
       app_{app} {
-  CHECK(capture_data != nullptr);
+  ORBIT_CHECK(capture_data != nullptr);
   for (Track::Type type : Track::kAllTrackTypes) {
     track_type_visibility_[type] = true;
   }
@@ -181,7 +181,7 @@ void TrackManager::SetFilter(const std::string& filter) {
 }
 
 void TrackManager::UpdateVisibleTrackList() {
-  CHECK(visible_track_list_needs_update_);
+  ORBIT_CHECK(visible_track_list_needs_update_);
 
   visible_track_list_needs_update_ = false;
   visible_tracks_.clear();
@@ -425,7 +425,7 @@ Track* TrackManager::GetOrCreateTrackFromTimerInfo(const TimerInfo& timer_info) 
       return GetPageFaultsTrack();
     case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MIN_SENTINEL_DO_NOT_USE_:
     case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MAX_SENTINEL_DO_NOT_USE_:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
   return nullptr;
 }

--- a/src/OrbitGl/TranslationStack.cpp
+++ b/src/OrbitGl/TranslationStack.cpp
@@ -13,7 +13,7 @@ void orbit_gl::TranslationStack::PushTranslation(float x, float y, float z) {
 }
 
 void orbit_gl::TranslationStack::PopTranslation() {
-  CHECK(!translation_stack_.empty());
+  ORBIT_CHECK(!translation_stack_.empty());
   current_translation_ = translation_stack_.back();
   translation_stack_.pop_back();
 }

--- a/src/OrbitGl/Viewport.cpp
+++ b/src/OrbitGl/Viewport.cpp
@@ -14,8 +14,8 @@ Viewport::Viewport(int width, int height)
     : screen_width_(width), screen_height_(height), world_width_(width), world_height_(height) {}
 
 void Viewport::Resize(int width, int height) {
-  CHECK(width > 0);
-  CHECK(height > 0);
+  ORBIT_CHECK(width > 0);
+  ORBIT_CHECK(height > 0);
 
   if (width == screen_width_ && height == screen_height_) return;
 

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -42,8 +42,8 @@ static std::string GetEnvVar(const char* variable_name) {
 static void CreateDirectoryOrDie(const std::filesystem::path& directory) {
   auto create_directory_result = orbit_base::CreateDirectory(directory);
   if (create_directory_result.has_error()) {
-    FATAL("Unable to create directory \"%s\": %s", directory.string(),
-          create_directory_result.error().message());
+    ORBIT_FATAL("Unable to create directory \"%s\": %s", directory.string(),
+                create_directory_result.error().message());
   }
 }
 
@@ -106,7 +106,8 @@ static std::filesystem::path GetDocumentsPath() {
         nullptr, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
         reinterpret_cast<LPSTR>(&error_string), 0, nullptr);
     std::filesystem::path path = std::filesystem::path(GetEnvVar("USERPROFILE")) / "Documents";
-    ERROR("Retrieving path to Documents (defaulting to \"%s\"): %s", path.string(), error_string);
+    ORBIT_ERROR("Retrieving path to Documents (defaulting to \"%s\"): %s", path.string(),
+                error_string);
     LocalFree(error_string);
     return path;
   }
@@ -114,7 +115,7 @@ static std::filesystem::path GetDocumentsPath() {
   std::wstring wpath = ppszPath;
   CoTaskMemFree(ppszPath);
   std::filesystem::path path{wpath};
-  LOG("Path to Documents: %s", path.string());
+  ORBIT_LOG("Path to Documents: %s", path.string());
   return path;
 #else
   return std::filesystem::path(GetEnvVar("HOME")) / "Documents";

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -18,7 +18,7 @@ TEST(Path, AllAutoCreatedDirsExist) {
 
   for (auto fn : test_fns) {
     std::filesystem::path path = fn();
-    LOG("Testing existence of \"%s\"", path.string());
+    ORBIT_LOG("Testing existence of \"%s\"", path.string());
     EXPECT_TRUE(std::filesystem::is_directory(path));
   }
 }
@@ -28,7 +28,7 @@ TEST(Paths, AllDirsOfFilesExist) {
 
   for (auto fn : test_fns) {
     std::filesystem::path path = fn().parent_path();
-    LOG("Testing existence of \"%s\"", path.string());
+    ORBIT_LOG("Testing existence of \"%s\"", path.string());
     EXPECT_TRUE(std::filesystem::is_directory(path));
   }
 }

--- a/src/OrbitQt/AccessibilityAdapter.cpp
+++ b/src/OrbitQt/AccessibilityAdapter.cpp
@@ -133,7 +133,7 @@ QAccessibleInterface* AdapterRegistry::InterfaceWrapperFactory(const QString& cl
                                                                QObject* object) {
   if (classname == QLatin1String("orbit_qt::OrbitGlInterfaceWrapper")) {
     auto iface_obj = static_cast<OrbitGlInterfaceWrapper*>(object);
-    CHECK(!all_interfaces_map_.contains(iface_obj->GetInterface()));
+    ORBIT_CHECK(!all_interfaces_map_.contains(iface_obj->GetInterface()));
     auto wrapper = std::make_unique<OrbitGlInterfaceWrapper>(iface_obj->GetInterface());
     QAccessibleInterface* result = new AccessibilityAdapter(iface_obj->GetInterface(), object);
     RegisterAdapter(iface_obj->GetInterface(), result);
@@ -169,7 +169,7 @@ QAccessibleInterface* AdapterRegistry::GetOrCreateAdapter(const AccessibleInterf
 
   auto wrapper = std::make_unique<OrbitGlInterfaceWrapper>(iface);
   QAccessibleInterface* result = QAccessible::queryAccessibleInterface(wrapper.get());
-  CHECK(result != nullptr);
+  ORBIT_CHECK(result != nullptr);
   RegisterAdapter(iface, result);
   managed_adapters_.emplace(iface, std::move(wrapper));
   return result;
@@ -242,12 +242,12 @@ class OrbitGlWidgetAccessible : public QAccessibleWidget {
 
 OrbitGlWidgetAccessible::OrbitGlWidgetAccessible(OrbitGLWidget* widget)
     : QAccessibleWidget(widget, QAccessible::Role::Graphic, "CaptureWindow") {
-  CHECK(widget != nullptr);
+  ORBIT_CHECK(widget != nullptr);
   /* TODO(b/175676123): For some reason setting an accessible name for the Canvas results in
    * a memory access exception during runtime when accessibility is queried. This also happens when
    * the accessibleName is explicitely set to "" in Qt Designer, which this check can't catch...
    */
-  CHECK(widget->accessibleName() == "");
+  ORBIT_CHECK(widget->accessibleName() == "");
   AdapterRegistry::Get().RegisterAdapter(
       static_cast<OrbitGLWidget*>(widget)->GetCanvas()->GetOrCreateAccessibleInterface(), this);
 }

--- a/src/OrbitQt/AccessibilityAdapter.h
+++ b/src/OrbitQt/AccessibilityAdapter.h
@@ -52,7 +52,7 @@ class OrbitGlInterfaceWrapper : public QObject {
 
 class AdapterRegistry {
  public:
-  ~AdapterRegistry() { CHECK(all_interfaces_map_.size() == 0); }
+  ~AdapterRegistry() { ORBIT_CHECK(all_interfaces_map_.size() == 0); }
   AdapterRegistry(const AdapterRegistry&) = delete;
   AdapterRegistry(AdapterRegistry&&) = delete;
   AdapterRegistry& operator=(const AdapterRegistry&) = delete;

--- a/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
@@ -121,8 +121,8 @@ void AnnotatingSourceCodeDialog::LoadSourceCode() {
 void AnnotatingSourceCodeDialog::HandleDebugInfo(
     const ErrorMessageOr<std::filesystem::path>& local_file_path_or_error) {
   if (local_file_path_or_error.has_error()) {
-    LOG("Error while loading debug information for the disassembly view: %s",
-        local_file_path_or_error.error().message());
+    ORBIT_LOG("Error while loading debug information for the disassembly view: %s",
+              local_file_path_or_error.error().message());
 
     SetStatusMessage(QString::fromStdString(local_file_path_or_error.error().message()), "Hide");
     awaited_button_action_ = ButtonAction::kHide;

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -23,7 +23,7 @@ CallTreeViewItemModel::CallTreeViewItemModel(std::unique_ptr<CallTreeView> call_
     : QAbstractItemModel{parent}, call_tree_view_{std::move(call_tree_view)} {}
 
 QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) const {
-  CHECK(index.isValid());
+  ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* thread_item = dynamic_cast<CallTreeThread*>(item);
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
@@ -96,7 +96,7 @@ QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) con
 }
 
 QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const {
-  CHECK(index.isValid());
+  ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* thread_item = dynamic_cast<CallTreeThread*>(item);
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
@@ -143,7 +143,7 @@ QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const 
 }
 
 QVariant CallTreeViewItemModel::GetToolTipRoleData(const QModelIndex& index) const {
-  CHECK(index.isValid());
+  ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
@@ -158,7 +158,7 @@ QVariant CallTreeViewItemModel::GetToolTipRoleData(const QModelIndex& index) con
 }
 
 QVariant CallTreeViewItemModel::GetForegroundRoleData(const QModelIndex& index) const {
-  CHECK(index.isValid());
+  ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* unwind_errors_item = dynamic_cast<CallTreeUnwindErrors*>(item);
   if (unwind_errors_item != nullptr && index.column() == kThreadOrFunction) {
@@ -169,7 +169,7 @@ QVariant CallTreeViewItemModel::GetForegroundRoleData(const QModelIndex& index) 
 }
 
 QVariant CallTreeViewItemModel::GetModulePathRoleData(const QModelIndex& index) const {
-  CHECK(index.isValid());
+  ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
@@ -179,7 +179,7 @@ QVariant CallTreeViewItemModel::GetModulePathRoleData(const QModelIndex& index) 
 }
 
 QVariant CallTreeViewItemModel::GetModuleBuildIdRoleData(const QModelIndex& index) const {
-  CHECK(index.isValid());
+  ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
@@ -191,7 +191,7 @@ QVariant CallTreeViewItemModel::GetModuleBuildIdRoleData(const QModelIndex& inde
 // For columns with two values, a percentage and a raw number, only copy the percentage, so that it
 // can be interpreted as a number by a spreadsheet.
 QVariant CallTreeViewItemModel::GetCopyableValueRoleData(const QModelIndex& index) const {
-  CHECK(index.isValid());
+  ORBIT_CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
   auto* thread_item = dynamic_cast<CallTreeThread*>(item);
   auto* function_item = dynamic_cast<CallTreeFunction*>(item);

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -70,7 +70,7 @@ CallTreeWidget::CallTreeWidget(QWidget* parent)
 
 void CallTreeWidget::SetCallTreeView(std::unique_ptr<CallTreeView> call_tree_view,
                                      std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model) {
-  CHECK(app_ != nullptr);
+  ORBIT_CHECK(app_ != nullptr);
 
   model_ = std::make_unique<CallTreeViewItemModel>(std::move(call_tree_view));
 

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -73,7 +73,7 @@ double CaptureOptionsDialog::GetSamplingPeriodMs() const {
 
 void CaptureOptionsDialog::SetUnwindingMethod(UnwindingMethod unwinding_method) {
   int index = ui_->unwindingMethodComboBox->findData(static_cast<int>(unwinding_method));
-  CHECK(index >= 0);
+  ORBIT_CHECK(index >= 0);
   return ui_->unwindingMethodComboBox->setCurrentIndex(index);
 }
 
@@ -113,7 +113,7 @@ bool CaptureOptionsDialog::GetEnableApi() const { return ui_->apiCheckBox->isChe
 
 void CaptureOptionsDialog::SetDynamicInstrumentationMethod(DynamicInstrumentationMethod method) {
   const int index = ui_->dynamicInstrumentationMethodComboBox->findData(static_cast<int>(method));
-  CHECK(index >= 0);
+  ORBIT_CHECK(index >= 0);
   ui_->dynamicInstrumentationMethodComboBox->setCurrentIndex(index);
 }
 
@@ -145,10 +145,10 @@ void CaptureOptionsDialog::SetMaxLocalMarkerDepthPerCommandBuffer(
 }
 
 uint64_t CaptureOptionsDialog::GetMaxLocalMarkerDepthPerCommandBuffer() const {
-  CHECK(!ui_->localMarkerDepthLineEdit->text().isEmpty());
+  ORBIT_CHECK(!ui_->localMarkerDepthLineEdit->text().isEmpty());
   bool valid = false;
   uint64_t result = ui_->localMarkerDepthLineEdit->text().toULongLong(&valid);
-  CHECK(valid);
+  ORBIT_CHECK(valid);
   return result;
 }
 
@@ -179,11 +179,11 @@ void CaptureOptionsDialog::ResetMemorySamplingPeriodMsLineEditWhenEmpty() {
 }
 
 uint64_t CaptureOptionsDialog::GetMemorySamplingPeriodMs() const {
-  CHECK(!ui_->memorySamplingPeriodMsLineEdit->text().isEmpty());
+  ORBIT_CHECK(!ui_->memorySamplingPeriodMsLineEdit->text().isEmpty());
   bool valid = false;
   uint64_t memory_sampling_period_ms =
       ui_->memorySamplingPeriodMsLineEdit->text().toULongLong(&valid);
-  CHECK(valid);
+  ORBIT_CHECK(valid);
   return memory_sampling_period_ms;
 }
 
@@ -200,10 +200,10 @@ void CaptureOptionsDialog::ResetMemoryWarningThresholdKbLineEditWhenEmpty() {
 }
 
 uint64_t CaptureOptionsDialog::GetMemoryWarningThresholdKb() const {
-  CHECK(!ui_->memoryWarningThresholdKbLineEdit->text().isEmpty());
+  ORBIT_CHECK(!ui_->memoryWarningThresholdKbLineEdit->text().isEmpty());
   bool valid = false;
   uint64_t result = ui_->memoryWarningThresholdKbLineEdit->text().toULongLong(&valid);
-  CHECK(valid);
+  ORBIT_CHECK(valid);
   return result;
 }
 

--- a/src/OrbitQt/StatusListenerImpl.cpp
+++ b/src/OrbitQt/StatusListenerImpl.cpp
@@ -25,7 +25,7 @@ uint64_t StatusListenerImpl::AddStatus(std::string message) {
 }
 
 void StatusListenerImpl::ClearStatus(uint64_t status_id) {
-  CHECK(status_messages_.count(status_id) == 1);
+  ORBIT_CHECK(status_messages_.count(status_id) == 1);
   status_messages_.erase(status_id);
   status_id_stack_.erase(std::remove(status_id_stack_.begin(), status_id_stack_.end(), status_id),
                          status_id_stack_.end());
@@ -39,9 +39,9 @@ void StatusListenerImpl::ClearStatus(uint64_t status_id) {
 }
 
 void StatusListenerImpl::UpdateStatus(uint64_t status_id, std::string message) {
-  CHECK(status_messages_.count(status_id) == 1);
+  ORBIT_CHECK(status_messages_.count(status_id) == 1);
   auto it = std::find(status_id_stack_.begin(), status_id_stack_.end(), status_id);
-  CHECK(it != status_id_stack_.end());
+  ORBIT_CHECK(it != status_id_stack_.end());
 
   status_id_stack_.erase(it);
   status_id_stack_.push_back(status_id);
@@ -55,6 +55,6 @@ std::unique_ptr<StatusListener> StatusListenerImpl::Create(QStatusBar* status_ba
 }
 
 uint64_t StatusListenerImpl::GetNextId() {
-  CHECK(next_id_ < std::numeric_limits<uint64_t>::max());
+  ORBIT_CHECK(next_id_ < std::numeric_limits<uint64_t>::max());
   return next_id_++;
 }

--- a/src/OrbitQt/TrackTypeItemModel.cpp
+++ b/src/OrbitQt/TrackTypeItemModel.cpp
@@ -18,10 +18,10 @@ int TrackTypeItemModel::columnCount(const QModelIndex& parent) const {
 }
 
 QVariant TrackTypeItemModel::data(const QModelIndex& idx, int role) const {
-  CHECK(idx.isValid());
-  CHECK(idx.model() == static_cast<const QAbstractItemModel*>(this));
-  CHECK(idx.row() >= 0 && idx.row() < static_cast<int>(known_track_types_.size()));
-  CHECK(idx.column() >= 0 && idx.column() < static_cast<int>(Column::kEnd));
+  ORBIT_CHECK(idx.isValid());
+  ORBIT_CHECK(idx.model() == static_cast<const QAbstractItemModel*>(this));
+  ORBIT_CHECK(idx.row() >= 0 && idx.row() < static_cast<int>(known_track_types_.size()));
+  ORBIT_CHECK(idx.column() >= 0 && idx.column() < static_cast<int>(Column::kEnd));
 
   Track::Type track_type = known_track_types_.at(idx.row());
   Column col = static_cast<Column>(idx.column());
@@ -45,10 +45,10 @@ QVariant TrackTypeItemModel::data(const QModelIndex& idx, int role) const {
 }
 
 bool TrackTypeItemModel::setData(const QModelIndex& idx, const QVariant& value, int role) {
-  CHECK(idx.isValid());
-  CHECK(idx.model() == static_cast<const QAbstractItemModel*>(this));
-  CHECK(idx.row() >= 0 && idx.row() < static_cast<int>(known_track_types_.size()));
-  CHECK(idx.column() >= 0 && idx.column() < static_cast<int>(Column::kEnd));
+  ORBIT_CHECK(idx.isValid());
+  ORBIT_CHECK(idx.model() == static_cast<const QAbstractItemModel*>(this));
+  ORBIT_CHECK(idx.row() >= 0 && idx.row() < static_cast<int>(known_track_types_.size()));
+  ORBIT_CHECK(idx.column() >= 0 && idx.column() < static_cast<int>(Column::kEnd));
 
   Track::Type track_type = known_track_types_.at(idx.row());
   Column col = static_cast<Column>(idx.column());
@@ -78,7 +78,7 @@ QVariant TrackTypeItemModel::headerData(int section, Qt::Orientation orientation
       case Column::kName:
         return "Track Type";
       case Column::kEnd:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
   return {};
@@ -139,10 +139,10 @@ QString TrackTypeItemModel::GetTrackTypeDisplayName(Track::Type track_type) cons
     case Track::Type::kTimerTrack:
       [[fallthrough]];
     case Track::Type::kUnknown:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   };
 
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/TutorialOverlay.cpp
+++ b/src/OrbitQt/TutorialOverlay.cpp
@@ -75,7 +75,7 @@ void TutorialOverlay::InitAllStepsFromUi() {
   steps_.clear();
   for (int i = 0; i < ui_->tabWidget->count(); ++i) {
     const std::string tab_name = ui_->tabWidget->widget(i)->objectName().toStdString();
-    CHECK(steps_.find(tab_name) == steps_.end());
+    ORBIT_CHECK(steps_.find(tab_name) == steps_.end());
     steps_[tab_name] = InitializeStep(i);
   }
 }
@@ -119,9 +119,9 @@ void TutorialOverlay::CreateProgressIndicators() {
 }
 
 void TutorialOverlay::UpdateProgressIndicators() {
-  CHECK(HasActiveStep());
+  ORBIT_CHECK(HasActiveStep());
   int active_step = GetActiveSection().active_step_index;
-  CHECK(active_step >= 0 && static_cast<size_t>(active_step) < progress_indicators_.size());
+  ORBIT_CHECK(active_step >= 0 && static_cast<size_t>(active_step) < progress_indicators_.size());
   progress_indicators_[active_step]->setChecked(true);
 }
 
@@ -163,7 +163,7 @@ void TutorialOverlay::StartSection(const std::string& section) {
   }
 
   auto it = sections_.find(section);
-  CHECK(it != sections_.end());
+  ORBIT_CHECK(it != sections_.end());
 
   active_section_ = it;
   it->second.active_step_index = it->second.step_names.empty() ? -1 : 0;
@@ -176,7 +176,7 @@ void TutorialOverlay::AddSection(std::string section_name, std::string title,
                                  std::vector<std::string> step_names) {
   Section section;
   for (auto& name : step_names) {
-    CHECK(StepExists(name));
+    ORBIT_CHECK(StepExists(name));
   }
   section.step_names = std::move(step_names);
   section.title = std::move(title);
@@ -255,12 +255,12 @@ bool TutorialOverlay::eventFilter(QObject*, QEvent* event) {
 
 void TutorialOverlay::SetupStep(const std::string& ui_tab_name, StepSetup step_setup) {
   auto it = steps_.find(ui_tab_name);
-  CHECK(it != steps_.end());
+  ORBIT_CHECK(it != steps_.end());
   it->second.setup = step_setup;
 }
 
 const TutorialOverlay::StepSetup& TutorialOverlay::GetStep(const std::string& name) const {
-  CHECK(StepExists(name));
+  ORBIT_CHECK(StepExists(name));
   auto it = steps_.find(name);
   return it->second.setup;
 }
@@ -402,10 +402,10 @@ bool TutorialOverlay::HasActiveStep() const {
 }
 
 const TutorialOverlay::Step& TutorialOverlay::GetActiveStep() const {
-  CHECK(HasActiveStep());
+  ORBIT_CHECK(HasActiveStep());
   auto& section = GetActiveSection();
   auto it = steps_.find(section.step_names[section.active_step_index]);
-  CHECK(it != steps_.end());
+  ORBIT_CHECK(it != steps_.end());
 
   return it->second;
 }
@@ -416,7 +416,7 @@ TutorialOverlay::Step& TutorialOverlay::GetActiveStep() {
 }
 
 const TutorialOverlay::Section& TutorialOverlay::GetActiveSection() const {
-  CHECK(HasActiveSection());
+  ORBIT_CHECK(HasActiveSection());
   return active_section_->second;
 }
 
@@ -426,12 +426,12 @@ TutorialOverlay::Section& TutorialOverlay::GetActiveSection() {
 }
 
 bool TutorialOverlay::ActiveStepIsFirstInSection() const {
-  CHECK(HasActiveSection());
+  ORBIT_CHECK(HasActiveSection());
   return GetActiveSection().active_step_index == 0;
 }
 
 bool TutorialOverlay::ActiveStepIsLastInSection() const {
-  CHECK(HasActiveSection());
+  ORBIT_CHECK(HasActiveSection());
   return static_cast<size_t>(GetActiveSection().active_step_index) ==
          GetActiveSection().step_names.size() - 1;
 }

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -35,8 +35,8 @@
 
 OrbitGLWidget::OrbitGLWidget(QWidget* parent) : QOpenGLWidget(parent) {
   QSurfaceFormat requested_format = QSurfaceFormat::defaultFormat();
-  LOG("OpenGL version requested: %i.%i", requested_format.majorVersion(),
-      requested_format.minorVersion());
+  ORBIT_LOG("OpenGL version requested: %i.%i", requested_format.majorVersion(),
+            requested_format.minorVersion());
   gl_canvas_ = nullptr;
   debug_logger_ = nullptr;
   setFocusPolicy(Qt::WheelFocus);
@@ -78,7 +78,7 @@ void OrbitGLWidget::initializeGL() {
 #if ORBIT_DEBUG_OPEN_GL
   debug_logger_ = new QOpenGLDebugLogger(this);
   if (debug_logger_->initialize()) {
-    LOG("GL_DEBUG Debug Logger %s", debug_logger_->metaObject()->className());
+    ORBIT_LOG("GL_DEBUG Debug Logger %s", debug_logger_->metaObject()->className());
     connect(debug_logger_, SIGNAL(messageLogged(QOpenGLDebugMessage)), this,
             SLOT(messageLogged(QOpenGLDebugMessage)));
     debug_logger_->startLogging(QOpenGLDebugLogger::SynchronousLogging);
@@ -116,7 +116,7 @@ void OrbitGLWidget::PrintContextInformation() {
     CASE(CompatibilityProfile);
   }
 #undef CASE
-  LOG(R"(glType="%s", glVersion="%s", glProfile="%s")", glType, glVersion, glProfile);
+  ORBIT_LOG(R"(glType="%s", glVersion="%s", glProfile="%s")", glType, glVersion, glProfile);
 }
 
 void OrbitGLWidget::messageLogged(const QOpenGLDebugMessage& msg) {
@@ -185,14 +185,14 @@ void OrbitGLWidget::messageLogged(const QOpenGLDebugMessage& msg) {
 #undef CASE
 
   error += ")";
-  LOG("%s\n%s", qPrintable(error), qPrintable(msg.message()));
+  ORBIT_LOG("%s\n%s", qPrintable(error), qPrintable(msg.message()));
 }
 
 void OrbitGLWidget::resizeGL(int w, int h) {
   if (gl_canvas_) {
     gl_canvas_->Resize(w, h);
-    CHECK(this->geometry().width() == w);
-    CHECK(this->geometry().height() == h);
+    ORBIT_CHECK(this->geometry().width() == w);
+    ORBIT_CHECK(this->geometry().height() == h);
   }
 }
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -188,7 +188,7 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
 
   if (FLAGS_stack_dump_size.IsSpecifiedOnCommandLine()) {
     uint16_t stack_dump_size = absl::GetFlag(FLAGS_stack_dump_size);
-    CHECK(stack_dump_size != std::numeric_limits<uint16_t>::max());
+    ORBIT_CHECK(stack_dump_size != std::numeric_limits<uint16_t>::max());
     app_->SetStackDumpSize(stack_dump_size);
   } else {
     app_->SetStackDumpSize(std::numeric_limits<uint16_t>::max());
@@ -211,8 +211,8 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
   ErrorMessageOr<bool> symbol_paths_file_has_depr_note =
       orbit_symbols::FileStartsWithDeprecationNote(orbit_paths::GetSymbolsFilePath());
   if (symbol_paths_file_has_depr_note.has_error()) {
-    ERROR("Unable to check SymbolPaths.txt file for depreciation note, error: %s",
-          symbol_paths_file_has_depr_note.error().message());
+    ORBIT_ERROR("Unable to check SymbolPaths.txt file for depreciation note, error: %s",
+                symbol_paths_file_has_depr_note.error().message());
     return;
   }
 
@@ -248,8 +248,8 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
   ErrorMessageOr<void> add_depr_note_result =
       orbit_symbols::AddDeprecationNoteToFile(orbit_paths::GetSymbolsFilePath());
   if (add_depr_note_result.has_error()) {
-    ERROR("Unable to add deprecation note to SymbolPaths.txt, error: %s",
-          add_depr_note_result.error().message());
+    ORBIT_ERROR("Unable to add deprecation note to SymbolPaths.txt, error: %s",
+                add_depr_note_result.error().message());
   }
 }
 
@@ -609,7 +609,7 @@ void OrbitMainWindow::CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_in
     move_action.setText(QString("Move \"") + tab_widget->tabText(tab_index) + "\" to left pane");
     other_widget = ui->MainTabWidget;
   } else {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   }
 
   move_action.setEnabled(tab_widget->count() > 0);
@@ -631,7 +631,7 @@ void OrbitMainWindow::CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_in
 void OrbitMainWindow::UpdateCaptureStateDependentWidgets() {
   auto set_tab_enabled = [this](QWidget* widget, bool enabled) -> void {
     QTabWidget* tab_widget = FindParentTabWidget(widget);
-    CHECK(tab_widget != nullptr);
+    ORBIT_CHECK(tab_widget != nullptr);
     tab_widget->setTabEnabled(tab_widget->indexOf(widget), enabled);
   };
 
@@ -1102,9 +1102,9 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
         settings.value(kCallstackSamplingPeriodMsSettingKey, kCallstackSamplingPeriodMsDefaultValue)
             .toDouble(&conversion_succeeded);
     if (!conversion_succeeded || sampling_period_ms <= 0.0) {
-      ERROR("Invalid value for setting \"%s\", resetting to %.1f",
-            kCallstackSamplingPeriodMsSettingKey.toStdString(),
-            kCallstackSamplingPeriodMsDefaultValue);
+      ORBIT_ERROR("Invalid value for setting \"%s\", resetting to %.1f",
+                  kCallstackSamplingPeriodMsSettingKey.toStdString(),
+                  kCallstackSamplingPeriodMsDefaultValue);
       settings.setValue(kCallstackSamplingPeriodMsSettingKey,
                         kCallstackSamplingPeriodMsDefaultValue);
       sampling_period_ms = kCallstackSamplingPeriodMsDefaultValue;
@@ -1123,7 +1123,7 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
                    static_cast<int>(kCallstackUnwindingMethodDefaultValue))
             .toInt());
     if (unwinding_method == CaptureOptions::kUndefined) {
-      ERROR("Unknown unwinding method specified; Using default unwinding method");
+      ORBIT_ERROR("Unknown unwinding method specified; Using default unwinding method");
       unwinding_method = kCallstackUnwindingMethodDefaultValue;
     }
     app_->SetUnwindingMethod(unwinding_method);
@@ -1250,7 +1250,7 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
 
 void OrbitMainWindow::on_actionHelp_toggled(bool checked) {
   auto* capture_window = dynamic_cast<CaptureWindow*>(ui->CaptureGLWidget->GetCanvas());
-  CHECK(capture_window != nullptr);
+  ORBIT_CHECK(capture_window != nullptr);
   capture_window->set_draw_help(checked);
 }
 
@@ -1283,7 +1283,7 @@ void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerIn
   if (timer_info) {
     uint64_t function_id = timer_info->function_id();
     const auto live_functions_controller = ui->liveFunctions->GetLiveFunctionsController();
-    CHECK(live_functions_controller.has_value());
+    ORBIT_CHECK(live_functions_controller.has_value());
     orbit_data_views::LiveFunctionsDataView& live_functions_data_view =
         live_functions_controller.value()->GetDataView();
     selected_row = live_functions_data_view.GetRowFromFunctionId(function_id);
@@ -1307,7 +1307,7 @@ void OrbitMainWindow::on_actionOpen_Capture_triggered() {
 }
 
 void OrbitMainWindow::on_actionRename_Capture_File_triggered() {
-  CHECK(target_label_->GetFilePath().has_value());
+  ORBIT_CHECK(target_label_->GetFilePath().has_value());
   const std::filesystem::path& current_file_path = target_label_->GetFilePath().value();
   QString file_path =
       QFileDialog::getSaveFileName(this, "Rename or Move capture...",
@@ -1385,14 +1385,14 @@ void OrbitMainWindow::OpenCapture(const std::string& filepath) {
   FindParentTabWidget(ui->CaptureTab)->setCurrentWidget(ui->CaptureTab);
 }
 
-void OrbitMainWindow::on_actionCheckFalse_triggered() { CHECK(false); }
+void OrbitMainWindow::on_actionCheckFalse_triggered() { ORBIT_CHECK(false); }
 
 void InfiniteRecursion(int num) {
   if (num != 1) {
     InfiniteRecursion(num);
   }
 
-  LOG("num=%d", num);
+  ORBIT_LOG("num=%d", num);
 }
 
 void OrbitMainWindow::on_actionStackOverflow_triggered() { InfiniteRecursion(0); }
@@ -1498,7 +1498,7 @@ void OrbitMainWindow::closeEvent(QCloseEvent* event) {
 }
 
 void OrbitMainWindow::OnStadiaConnectionError(std::error_code error) {
-  CHECK(std::holds_alternative<StadiaTarget>(target_configuration_));
+  ORBIT_CHECK(std::holds_alternative<StadiaTarget>(target_configuration_));
   const StadiaTarget& target = std::get<StadiaTarget>(target_configuration_);
 
   target.GetProcessManager()->SetProcessListUpdateListener(nullptr);
@@ -1521,7 +1521,7 @@ void OrbitMainWindow::SetTarget(const StadiaTarget& target) {
   ServiceDeployManager* service_deploy_manager = connection->GetServiceDeployManager();
   app_->SetSecureCopyCallback([service_deploy_manager](std::string_view source,
                                                        std::string_view destination) {
-    CHECK(service_deploy_manager != nullptr);
+    ORBIT_CHECK(service_deploy_manager != nullptr);
     return service_deploy_manager->CopyFileToLocal(std::string{source}, std::string{destination});
   });
 
@@ -1697,7 +1697,7 @@ void OrbitMainWindow::ShowSourceCode(
   constexpr orbit_code_viewer::FontSizeInEm kHeatmapAreaWidth{1.3f};
 
   if (maybe_code_report.has_value()) {
-    CHECK(maybe_code_report->get() != nullptr);
+    ORBIT_CHECK(maybe_code_report->get() != nullptr);
     code_viewer_dialog->SetEnableSampleCounters(true);
     code_viewer_dialog->SetOwningHeatmap(kHeatmapAreaWidth, std::move(*maybe_code_report));
   }
@@ -1766,5 +1766,6 @@ void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Dura
   std::string pretty_time = orbit_display_formats::GetDisplayTime(capture_time);
   ui->captureLogTextEdit->append(
       QString::fromStdString(absl::StrFormat("%s\t%s", pretty_time, message)));
-  LOG("\"%s  %s\" with severity %s added to the capture log", pretty_time, message, severity_name);
+  ORBIT_LOG("\"%s  %s\" with severity %s added to the capture log", pretty_time, message,
+            severity_name);
 }

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -109,13 +109,13 @@ void OrbitSamplingReport::Deinitialize() {
 }
 
 void OrbitSamplingReport::on_NextCallstackButton_clicked() {
-  CHECK(sampling_report_ != nullptr);
+  ORBIT_CHECK(sampling_report_ != nullptr);
   sampling_report_->IncrementCallstackIndex();
   RefreshCallstackView();
 }
 
 void OrbitSamplingReport::on_PreviousCallstackButton_clicked() {
-  CHECK(sampling_report_ != nullptr);
+  ORBIT_CHECK(sampling_report_ != nullptr);
   sampling_report_->DecrementCallstackIndex();
   RefreshCallstackView();
 }

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -357,7 +357,7 @@ void OrbitTreeView::columnResized(int column, int /*oldSize*/, int newSize) {
   // proper event filtering magic that will let us differentiate between direct and indirect column
   // resizing.
   if (maintain_user_column_ratios_ && column_ratios_.size()) {
-    CHECK(column < static_cast<int>(column_ratios_.size()));
+    ORBIT_CHECK(column < static_cast<int>(column_ratios_.size()));
     column_ratios_[column] = static_cast<float>(newSize) / size().width();
   }
 }

--- a/src/OrbitSsh/Channel.cpp
+++ b/src/OrbitSsh/Channel.cpp
@@ -30,7 +30,7 @@ outcome::result<Channel> Channel::OpenChannel(Session* session) {
 
   const auto [last_errno, error_message] = LibSsh2SessionLastError(session->GetRawSessionPtr());
   if (last_errno != LIBSSH2_ERROR_EAGAIN) {
-    ERROR("Unable to open Channel, last session error message: %s", error_message);
+    ORBIT_ERROR("Unable to open Channel, last session error message: %s", error_message);
   }
   return static_cast<Error>(last_errno);
 }
@@ -46,7 +46,7 @@ outcome::result<Channel> Channel::OpenTcpIpTunnel(Session* session,
 
   const auto [last_errno, error_message] = LibSsh2SessionLastError(session->GetRawSessionPtr());
   if (last_errno != LIBSSH2_ERROR_EAGAIN) {
-    ERROR("Unable to open TcpIpTunnel, last session error message: %s", error_message);
+    ORBIT_ERROR("Unable to open TcpIpTunnel, last session error message: %s", error_message);
   }
   return static_cast<Error>(last_errno);
 }

--- a/src/OrbitSsh/LinuxSocket.cpp
+++ b/src/OrbitSsh/LinuxSocket.cpp
@@ -51,7 +51,7 @@ outcome::result<Socket> Socket::Accept() const {
 }
 
 void Socket::PrintWithLastError(const std::string& message) {
-  ERROR("%s: %s", message.c_str(), SafeStrerror(errno));
+  ORBIT_ERROR("%s: %s", message.c_str(), SafeStrerror(errno));
 }
 
 outcome::result<void> Socket::Shutdown() const {

--- a/src/OrbitSsh/Sftp.cpp
+++ b/src/OrbitSsh/Sftp.cpp
@@ -15,13 +15,14 @@
 namespace orbit_ssh {
 
 outcome::result<Sftp> Sftp::Init(Session* session) {
-  CHECK(session);
+  ORBIT_CHECK(session);
   auto* const result = libssh2_sftp_init(session->GetRawSessionPtr());
 
   if (result == nullptr) {
     const auto [last_errno, error_message] = LibSsh2SessionLastError(session->GetRawSessionPtr());
     if (last_errno != LIBSSH2_ERROR_EAGAIN) {
-      ERROR("Call to ligssh2_sftp_init() failed. Last session error message: %s", error_message);
+      ORBIT_ERROR("Call to ligssh2_sftp_init() failed. Last session error message: %s",
+                  error_message);
     }
     return static_cast<Error>(last_errno);
   }
@@ -30,7 +31,7 @@ outcome::result<Sftp> Sftp::Init(Session* session) {
 }
 
 outcome::result<void> Sftp::Shutdown() {
-  CHECK(raw_sftp_ptr_);
+  ORBIT_CHECK(raw_sftp_ptr_);
   const auto result = libssh2_sftp_shutdown(raw_sftp_ptr_.get());
 
   if (result < 0) {

--- a/src/OrbitSsh/SftpFile.cpp
+++ b/src/OrbitSsh/SftpFile.cpp
@@ -24,7 +24,7 @@ outcome::result<SftpFile> SftpFile::Open(Session* session, Sftp* sftp, std::stri
     const auto [last_errno, error_message] = LibSsh2SessionLastError(session->GetRawSessionPtr());
 
     if (last_errno != LIBSSH2_ERROR_EAGAIN) {
-      ERROR("Unable to open sftp file \"%s\": %s", filepath, error_message);
+      ORBIT_ERROR("Unable to open sftp file \"%s\": %s", filepath, error_message);
     }
 
     return static_cast<Error>(last_errno);
@@ -39,8 +39,8 @@ outcome::result<std::string> SftpFile::Read(size_t max_length_in_bytes) {
 
   if (result < 0) {
     if (result != LIBSSH2_ERROR_EAGAIN) {
-      ERROR("Unable to read from sftp file \"%s\": %s", filepath_,
-            LibSsh2SessionLastError(session_->GetRawSessionPtr()).second);
+      ORBIT_ERROR("Unable to read from sftp file \"%s\": %s", filepath_,
+                  LibSsh2SessionLastError(session_->GetRawSessionPtr()).second);
     }
     return static_cast<Error>(result);
   }
@@ -54,8 +54,8 @@ outcome::result<void> SftpFile::Close() {
 
   if (result < 0) {
     if (result != LIBSSH2_ERROR_EAGAIN) {
-      ERROR("Unable to close sftp file \"%s\": %s", filepath_,
-            LibSsh2SessionLastError(session_->GetRawSessionPtr()).second);
+      ORBIT_ERROR("Unable to close sftp file \"%s\": %s", filepath_,
+                  LibSsh2SessionLastError(session_->GetRawSessionPtr()).second);
     }
     return static_cast<Error>(result);
   }
@@ -71,8 +71,8 @@ outcome::result<size_t> SftpFile::Write(std::string_view data) {
 
   if (result < 0) {
     if (result != LIBSSH2_ERROR_EAGAIN) {
-      ERROR("Unable to write to sftp file \"%s\": %s", filepath_,
-            LibSsh2SessionLastError(session_->GetRawSessionPtr()).second);
+      ORBIT_ERROR("Unable to write to sftp file \"%s\": %s", filepath_,
+                  LibSsh2SessionLastError(session_->GetRawSessionPtr()).second);
     }
     return static_cast<Error>(result);
   }

--- a/src/OrbitSsh/Socket.cpp
+++ b/src/OrbitSsh/Socket.cpp
@@ -144,7 +144,7 @@ outcome::result<void> Socket::WaitDisconnect() {
 
   if (data.empty()) return outcome::success();
 
-  LOG("Received data after sending shutdown on socket (%d bytes)", data.length());
+  ORBIT_LOG("Received data after sending shutdown on socket (%d bytes)", data.length());
   return GetLastError();
 }
 

--- a/src/OrbitSsh/WindowsSocket.cpp
+++ b/src/OrbitSsh/WindowsSocket.cpp
@@ -12,7 +12,7 @@ outcome::result<Socket> Socket::Create(int domain, int type, int protocol) {
   WSADATA wsadata;
   int err = WSAStartup(MAKEWORD(2, 0), &wsadata);
   if (err != 0) {
-    ERROR("WSAStartup failed with error: %d", err);
+    ORBIT_ERROR("WSAStartup failed with error: %d", err);
   }
 
   Descriptor descriptor = socket(domain, type, protocol);
@@ -52,7 +52,7 @@ void Socket::PrintWithLastError(const std::string& message) {
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
       nullptr, WSAGetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
       reinterpret_cast<LPWSTR>(&error_string), 0, nullptr);
-  ERROR("%s: %s", message.c_str(), error_string);
+  ORBIT_ERROR("%s: %s", message.c_str(), error_string);
   LocalFree(error_string);
 }
 

--- a/src/OrbitSshQt/IntegrationTests.cpp
+++ b/src/OrbitSshQt/IntegrationTests.cpp
@@ -98,7 +98,7 @@ TEST(OrbitSshQtTests, IntegrationTest) {
   });
 
   QObject::connect(&session, &orbit_ssh_qt::Session::started, &session, [&]() {
-    LOG("Session connected. Starting task...");
+    ORBIT_LOG("Session connected. Starting task...");
     task.Start();
     CheckCheckpoint(Checkpoint::kSessionStarted);
   });
@@ -109,7 +109,7 @@ TEST(OrbitSshQtTests, IntegrationTest) {
                    [&]() { data_sink.append(task.ReadStdOut()); });
 
   QObject::connect(&task, &orbit_ssh_qt::Task::started, &loop, [&]() {
-    LOG("process started. Starting tunnel...");
+    ORBIT_LOG("process started. Starting tunnel...");
     task.Write("Data in reverse direction!");
     tunnel.Start();
     CheckCheckpoint(Checkpoint::kTaskStarted);
@@ -150,13 +150,13 @@ TEST(OrbitSshQtTests, IntegrationTest) {
   };
 
   QObject::connect(&client, &QTcpSocket::connected, &loop, [&]() {
-    LOG("TCP Socket connected. Writing data...");
+    ORBIT_LOG("TCP Socket connected. Writing data...");
     write_bytes(write_bytes);
     CheckCheckpoint(Checkpoint::kSocketConnected);
   });
 
   QObject::connect(&tunnel, &orbit_ssh_qt::Tunnel::started, &loop, [&]() {
-    LOG("Tunnel opened. Connecting tcp client...");
+    ORBIT_LOG("Tunnel opened. Connecting tcp client...");
     client.connectToHost("127.0.0.1", tunnel.GetListenPort());
     CheckCheckpoint(Checkpoint::kTunnelStarted);
   });
@@ -171,7 +171,7 @@ TEST(OrbitSshQtTests, IntegrationTest) {
     temp_file->write("This is a test content!\nSecond line.");
     temp_file->close();
 
-    LOG("Sftp channel opened! Starting file copy...");
+    ORBIT_LOG("Sftp channel opened! Starting file copy...");
     sftp_op.CopyFileToRemote(temp_file->fileName().toStdString(), "/tmp/temporary_file.txt",
                              orbit_ssh_qt::SftpCopyToRemoteOperation::FileMode::kUserWritable);
     CheckCheckpoint(Checkpoint::kSftpChannelStarted);
@@ -184,7 +184,7 @@ TEST(OrbitSshQtTests, IntegrationTest) {
                    });
 
   QObject::connect(&sftp_channel, &orbit_ssh_qt::SftpChannel::stopped, &loop, [&]() {
-    LOG("Sftp channel closed!");
+    ORBIT_LOG("Sftp channel closed!");
     loop.quit();
     CheckCheckpoint(Checkpoint::kSftpChannelStopped);
   });
@@ -198,13 +198,13 @@ TEST(OrbitSshQtTests, IntegrationTest) {
                    });
 
   QObject::connect(&sftp_op, &orbit_ssh_qt::SftpCopyToRemoteOperation::stopped, &loop, [&]() {
-    LOG("Sftp file copy finished!");
+    ORBIT_LOG("Sftp file copy finished!");
     sftp_channel.Stop();
     CheckCheckpoint(Checkpoint::kSftpOperationStopped);
   });
 
   session.ConnectToServer(creds);
-  LOG("connect to server");
+  ORBIT_LOG("connect to server");
   QTimer::singleShot(std::chrono::seconds{5}, &loop, [&]() {
     loop.quit();
     FAIL() << "Timeout occurred. The whole integration test should be done in 5 "
@@ -240,9 +240,9 @@ TEST(OrbitSshQtTests, CopyToLocalTest) {
   orbit_ssh_qt::SftpCopyToLocalOperation sftp_copy_to_local{&session, &channel};
 
   session.ConnectToServer(creds);
-  LOG("connect to server");
+  ORBIT_LOG("connect to server");
   QObject::connect(&session, &orbit_ssh_qt::Session::started, &session, [&]() {
-    LOG("Session connected. Starting channel...");
+    ORBIT_LOG("Session connected. Starting channel...");
     channel.Start();
   });
 
@@ -253,18 +253,18 @@ TEST(OrbitSshQtTests, CopyToLocalTest) {
     file_name = temp_file.fileName().toStdString();
     temp_file.remove();
 
-    LOG("Sftp channel opened! Starting file copy to \"%s\"...", file_name);
+    ORBIT_LOG("Sftp channel opened! Starting file copy to \"%s\"...", file_name);
     sftp_copy_to_local.CopyFileToLocal("/proc/cpuinfo", file_name);
   });
 
   QObject::connect(&channel, &orbit_ssh_qt::SftpChannel::stopped, &loop, [&]() {
-    LOG("Sftp channel closed!");
+    ORBIT_LOG("Sftp channel closed!");
     loop.quit();
   });
 
   QObject::connect(&sftp_copy_to_local, &orbit_ssh_qt::SftpCopyToLocalOperation::stopped, &loop,
                    [&]() {
-                     LOG("Sftp file copy finished!");
+                     ORBIT_LOG("Sftp file copy finished!");
                      channel.Stop();
                    });
 

--- a/src/OrbitSshQt/Session.cpp
+++ b/src/OrbitSshQt/Session.cpp
@@ -62,7 +62,7 @@ outcome::result<void> Session::startup() {
     case State::kAboutToDisconnect:
     case State::kDone:
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   return outcome::success();
@@ -79,7 +79,7 @@ outcome::result<void> Session::shutdown() {
     case State::kMatchedKnownHosts:
     case State::kStarted:
     case State::kConnected:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
     case State::kShutdown:
     case State::kAboutToDisconnect: {
       OUTCOME_TRY(session_->Disconnect());
@@ -92,7 +92,7 @@ outcome::result<void> Session::shutdown() {
     case State::kDone:
       break;
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   return outcome::success();

--- a/src/OrbitSshQt/SftpChannel.cpp
+++ b/src/OrbitSshQt/SftpChannel.cpp
@@ -67,7 +67,7 @@ outcome::result<void> SftpChannel::shutdown() {
     case State::kNoChannel:
     case State::kStarted:
     case State::kChannelInitialized:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
     case State::kShutdown:
     case State::kClosingChannel:
       if (sftp_) {
@@ -81,7 +81,7 @@ outcome::result<void> SftpChannel::shutdown() {
       about_to_shutdown_connection_ = std::nullopt;
       break;
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   return outcome::success();

--- a/src/OrbitSshQt/SftpCopyToLocalOperation.cpp
+++ b/src/OrbitSshQt/SftpCopyToLocalOperation.cpp
@@ -101,7 +101,7 @@ outcome::result<void> SftpCopyToLocalOperation::startup() {
     case State::kDone:
       break;
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   };
 
   return outcome::success();

--- a/src/OrbitSshQt/SftpCopyToRemoteOperation.cpp
+++ b/src/OrbitSshQt/SftpCopyToRemoteOperation.cpp
@@ -110,7 +110,7 @@ outcome::result<void> SftpCopyToRemoteOperation::startup() {
     case State::kDone:
       break;
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   };
 
   return outcome::success();

--- a/src/OrbitSshQt/Task.cpp
+++ b/src/OrbitSshQt/Task.cpp
@@ -35,7 +35,7 @@ void Task::Start() {
 void Task::Stop() {
   QTimer::singleShot(kShutdownTimeoutMs, this, [this]() {
     if (state_ < State::kChannelClosed) {
-      ERROR("Task shutdown timed out");
+      ORBIT_ERROR("Task shutdown timed out");
       SetError(Error::kOrbitServiceShutdownTimedout);
     }
   });
@@ -171,7 +171,7 @@ outcome::result<void> Task::startup() {
     case State::kWaitChannelClosed:
     case State::kChannelClosed:
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   return outcome::success();
@@ -184,7 +184,7 @@ outcome::result<void> Task::shutdown() {
     case State::kChannelInitialized:
     case State::kStarted:
     case State::kCommandRunning:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
 
     case State::kShutdown:
     case State::kSignalEOF: {
@@ -216,7 +216,7 @@ outcome::result<void> Task::shutdown() {
       channel_ = std::nullopt;
       break;
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   return outcome::success();

--- a/src/OrbitSshQt/Tunnel.cpp
+++ b/src/OrbitSshQt/Tunnel.cpp
@@ -129,7 +129,7 @@ outcome::result<void> Tunnel::startup() {
     case State::kWaitRemoteClosed:
     case State::kDone:
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
   return outcome::success();
 }
@@ -141,7 +141,7 @@ outcome::result<void> Tunnel::shutdown() {
     case State::kChannelInitialized:
     case State::kStarted:
     case State::kServerListening:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
     case State::kShutdown:
     case State::kFlushing: {
       OUTCOME_TRY(writeToChannel());
@@ -177,7 +177,7 @@ outcome::result<void> Tunnel::shutdown() {
     case State::kDone:
       break;
     case State::kError:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 
   return outcome::success();
@@ -210,7 +210,7 @@ outcome::result<void> Tunnel::readFromChannel() {
     if (bytes_written == -1) {
       SetError(Error::kLocalSocketClosed);
     } else {
-      CHECK(static_cast<size_t>(bytes_written) <= read_buffer_.size());
+      ORBIT_CHECK(static_cast<size_t>(bytes_written) <= read_buffer_.size());
       read_buffer_.erase(read_buffer_.begin(), read_buffer_.begin() + bytes_written);
     }
   }
@@ -223,7 +223,7 @@ outcome::result<void> Tunnel::writeToChannel() {
   if (!write_buffer_.empty()) {
     const std::string_view buffer_view{write_buffer_.data(), write_buffer_.size()};
     OUTCOME_TRY(auto&& bytes_written, channel_->Write(buffer_view));
-    CHECK(static_cast<size_t>(bytes_written) <= write_buffer_.size());
+    ORBIT_CHECK(static_cast<size_t>(bytes_written) <= write_buffer_.size());
     write_buffer_.erase(write_buffer_.begin(), write_buffer_.begin() + bytes_written);
     ORBIT_UINT64("writeToChannel bytes written", bytes_written);
   }

--- a/src/OrbitSshQt/include/OrbitSshQt/StateMachineHelper.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/StateMachineHelper.h
@@ -90,17 +90,17 @@ namespace orbit_ssh_qt {
     outcome::result<void> startup() {
       switch(CurrentState()) {
       case State::kInitial:
-        FATAL("Should not happen!");
+        ORBIT_FATAL("Should not happen!");
       case State::kStarting:
-        LOG("About to start!");
+        ORBIT_LOG("About to start!");
         SetState(State::kStarted);
       case State::kStarted:
-        LOG("started!")
+        ORBIT_LOG("started!")
         break;
       case State::kShutdown:
       case State::kDone:
       case State::kError:
-        FATAL("Should not happen!");
+        ORBIT_FATAL("Should not happen!");
       }
 
       return outcome::success();
@@ -110,12 +110,12 @@ namespace orbit_ssh_qt {
       switch(CurrentState()) {
       case State::kInitial:
       case State::kStarting:
-        FATAL("Should not happen!");
+        ORBIT_FATAL("Should not happen!");
       case State::kStarted:
       case State::kShutdown:
       case State::kDone:
       case State::kError:
-        FATAL("Should not happen!");
+        ORBIT_FATAL("Should not happen!");
       }
 
       return outcome::success();
@@ -126,15 +126,15 @@ namespace orbit_ssh_qt {
       case State::kInitial:
       case State::kStarting:
       case State::kStarted:
-        FATAL("Should not happen!");
+        ORBIT_FATAL("Should not happen!");
       case State::kShutdown:
-        LOG("about to shut down!");
+        ORBIT_LOG("about to shut down!");
         SetState(State::kDone);
       case State::kDone:
-        LOG("shutted down!");
+        ORBIT_LOG("shutted down!");
         break;
       case State::kError:
-        FATAL("Should not happen!");
+        ORBIT_FATAL("Should not happen!");
       }
 
       return outcome::success();

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -127,7 +127,7 @@ static void ExecuteTask(uint32_t id) {
 void OrbitTestImpl::OutputOrbitApiState() {
   while (!exit_requested_) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-    LOG("g_orbit_api.enabled = %u", g_orbit_api.enabled);
+    ORBIT_LOG("g_orbit_api.enabled = %u", g_orbit_api.enabled);
   }
 }
 

--- a/src/OrbitTriggerCaptureVulkanLayer/LayerLogic.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/LayerLogic.cpp
@@ -26,9 +26,9 @@ constexpr uint16_t kGrpcPort = 44767;
 void LayerLogic::StartOrbitCaptureService() {
   pid_t pid = fork();
   if (pid < 0) {
-    ERROR("Fork failed; not able to start Orbit capture service");
+    ORBIT_ERROR("Fork failed; not able to start Orbit capture service");
   } else if (pid == 0) {
-    LOG("Starting Orbit capture service");
+    ORBIT_LOG("Starting Orbit capture service");
     std::string game_pid_str = absl::StrFormat("%d", getppid());
     std::vector<std::string> argv_str = layer_options_.BuildOrbitCaptureServiceArgv(game_pid_str);
 
@@ -44,8 +44,8 @@ void LayerLogic::StartOrbitCaptureService() {
     for (auto const& arg : argv) {
       absl::StrAppendFormat(&log_message, " %s", arg);
     }
-    LOG("%s", log_message);
-    LOG("%d arguments", argv.size());
+    ORBIT_LOG("%s", log_message);
+    ORBIT_LOG("%d arguments", argv.size());
 
     execv(argv[0], argv.data());
   }
@@ -55,7 +55,7 @@ void LayerLogic::Init() {
   // Although this method is expected to be called just once, we include a flag to make sure the
   // gRPC service and client are not initialized more than once.
   if (!data_initialized_) {
-    LOG("Making initializations required in the layer");
+    ORBIT_LOG("Making initializations required in the layer");
 
     // Initialize and load data from config file
     layer_options_.Init();
@@ -98,8 +98,8 @@ void LayerLogic::ProcessQueuePresentKHR() {
     auto frame_time = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
         current_time - last_frame_time_);
     if (std::isgreater(frame_time.count(), layer_options_.GetFrameTimeThresholdMilliseconds())) {
-      LOG("Time frame is %fms and exceeds the %fms threshold; starting capture", frame_time.count(),
-          layer_options_.GetFrameTimeThresholdMilliseconds());
+      ORBIT_LOG("Time frame is %fms and exceeds the %fms threshold; starting capture",
+                frame_time.count(), layer_options_.GetFrameTimeThresholdMilliseconds());
       RunCapture();
     }
   } else {
@@ -107,8 +107,8 @@ void LayerLogic::ProcessQueuePresentKHR() {
     auto capture_time = std::chrono::duration_cast<std::chrono::duration<int64_t>>(
         current_time - capture_started_time_);
     if (capture_time.count() >= layer_options_.GetCaptureLengthSeconds()) {
-      LOG("Capture has been running for %ds; stopping it",
-          layer_options_.GetCaptureLengthSeconds());
+      ORBIT_LOG("Capture has been running for %ds; stopping it",
+                layer_options_.GetCaptureLengthSeconds());
       StopCapture();
     }
   }

--- a/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.cpp
@@ -32,25 +32,26 @@ constexpr uint32_t kCaptureLengthSecondsDefault = 10;
 
 void LayerOptions::Init() {
   // Load data from config file
-  LOG("Loading  vulkan layer config file from %s", std::string(kConfigFileName));
+  ORBIT_LOG("Loading  vulkan layer config file from %s", std::string(kConfigFileName));
 
   // Config is a proto text file
   int config_file_descriptor = open(kConfigFileName, O_RDONLY);
   if (config_file_descriptor < 0) {
-    ERROR("Not being able to open file: %s. Default values will be used", SafeStrerror(errno));
+    ORBIT_ERROR("Not being able to open file: %s. Default values will be used",
+                SafeStrerror(errno));
     return;
   }
 
   google::protobuf::io::FileInputStream config_file_stream(config_file_descriptor);
   if (!google::protobuf::TextFormat::Parse(&config_file_stream, &layer_config_)) {
-    ERROR("Parsing vulkan layer config file. Default values will be used");
+    ORBIT_ERROR("Parsing vulkan layer config file. Default values will be used");
     layer_config_.Clear();
   } else {
-    LOG("Config data loaded successfully");
+    ORBIT_LOG("Config data loaded successfully");
   }
 
   if (close(config_file_descriptor) < 0) {
-    ERROR("Closing config file: %s", SafeStrerror(errno));
+    ORBIT_ERROR("Closing config file: %s", SafeStrerror(errno));
   }
 }
 

--- a/src/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
@@ -46,7 +46,7 @@ LayerLogic layer_logic;
 VkResult VKAPI_CALL
 OrbitCaptureClientCreateInstance(const VkInstanceCreateInfo* instance_create_info,
                                  const VkAllocationCallbacks* allocator, VkInstance* instance) {
-  LOG("OrbitCaptureClientCreateInstance called");
+  ORBIT_LOG("OrbitCaptureClientCreateInstance called");
   auto* layer_instance_create_info =
       absl::bit_cast<VkLayerInstanceCreateInfo*>(instance_create_info->pNext);
 
@@ -82,7 +82,7 @@ OrbitCaptureClientCreateInstance(const VkInstanceCreateInfo* instance_create_inf
 
 void VKAPI_CALL OrbitCaptureClientDestroyInstance(VkInstance instance,
                                                   const VkAllocationCallbacks* /*allocator*/) {
-  LOG("OrbitCaptureClientDestroyInstance called");
+  ORBIT_LOG("OrbitCaptureClientDestroyInstance called");
   absl::WriterMutexLock lock(&layer_mutex);
   // Cleaning up the data initialized in the layer before the instance is destroyed. This method is
   // expected to be called before exiting the program so the data is not longer needed.

--- a/src/OrbitVulkanLayer/DeviceManager.h
+++ b/src/OrbitVulkanLayer/DeviceManager.h
@@ -35,11 +35,11 @@ class DeviceManager {
 
   void TrackLogicalDevice(VkPhysicalDevice physical_device, VkDevice logical_device) {
     absl::WriterMutexLock lock(&mutex_);
-    CHECK(!logical_device_to_physical_device_.contains(logical_device));
+    ORBIT_CHECK(!logical_device_to_physical_device_.contains(logical_device));
     logical_device_to_physical_device_[logical_device] = physical_device;
 
-    CHECK(!physical_device_to_logical_devices_.contains(physical_device) ||
-          !physical_device_to_logical_devices_.at(physical_device).contains(logical_device));
+    ORBIT_CHECK(!physical_device_to_logical_devices_.contains(physical_device) ||
+                !physical_device_to_logical_devices_.at(physical_device).contains(logical_device));
     if (!physical_device_to_logical_devices_.contains(physical_device)) {
       physical_device_to_logical_devices_[physical_device] = {logical_device};
     } else {
@@ -57,20 +57,20 @@ class DeviceManager {
 
   [[nodiscard]] VkPhysicalDevice GetPhysicalDeviceOfLogicalDevice(VkDevice logical_device) {
     absl::ReaderMutexLock lock(&mutex_);
-    CHECK(logical_device_to_physical_device_.contains(logical_device));
+    ORBIT_CHECK(logical_device_to_physical_device_.contains(logical_device));
     return logical_device_to_physical_device_.at(logical_device);
   }
 
   void UntrackLogicalDevice(VkDevice logical_device) {
     absl::WriterMutexLock lock(&mutex_);
-    CHECK(logical_device_to_physical_device_.contains(logical_device));
+    ORBIT_CHECK(logical_device_to_physical_device_.contains(logical_device));
     VkPhysicalDevice physical_device = logical_device_to_physical_device_.at(logical_device);
     logical_device_to_physical_device_.erase(logical_device);
 
-    CHECK(physical_device_to_logical_devices_.contains(physical_device));
+    ORBIT_CHECK(physical_device_to_logical_devices_.contains(physical_device));
     absl::flat_hash_set<VkDevice>& logical_devices =
         physical_device_to_logical_devices_.at(physical_device);
-    CHECK(logical_devices.contains(logical_device));
+    ORBIT_CHECK(logical_devices.contains(logical_device));
     logical_devices.erase(logical_device);
 
     if (!logical_devices.empty()) {
@@ -83,7 +83,7 @@ class DeviceManager {
   [[nodiscard]] VkPhysicalDeviceProperties GetPhysicalDeviceProperties(
       VkPhysicalDevice physical_device) {
     absl::ReaderMutexLock lock(&mutex_);
-    CHECK(physical_device_to_properties_.contains(physical_device));
+    ORBIT_CHECK(physical_device_to_properties_.contains(physical_device));
     return physical_device_to_properties_.at(physical_device);
   }
 

--- a/src/OrbitVulkanLayer/DispatchTable.cpp
+++ b/src/OrbitVulkanLayer/DispatchTable.cpp
@@ -38,22 +38,22 @@ void DispatchTable::CreateInstanceDispatchTable(
   void* key = GetDispatchTableKey(instance);
   {
     absl::WriterMutexLock lock(&mutex_);
-    CHECK(!instance_dispatch_table_.contains(key));
+    ORBIT_CHECK(!instance_dispatch_table_.contains(key));
     instance_dispatch_table_[key] = dispatch_table;
 
-    CHECK(!instance_supports_debug_utils_extension_.contains(key));
+    ORBIT_CHECK(!instance_supports_debug_utils_extension_.contains(key));
     instance_supports_debug_utils_extension_[key] =
         dispatch_table.CreateDebugUtilsMessengerEXT != nullptr &&
         dispatch_table.DestroyDebugUtilsMessengerEXT != nullptr &&
         dispatch_table.SubmitDebugUtilsMessageEXT != nullptr;
 
-    CHECK(!instance_supports_debug_report_extension_.contains(key));
+    ORBIT_CHECK(!instance_supports_debug_report_extension_.contains(key));
     instance_supports_debug_report_extension_[key] =
         dispatch_table.CreateDebugReportCallbackEXT != nullptr &&
         dispatch_table.DestroyDebugReportCallbackEXT != nullptr &&
         dispatch_table.DebugReportMessageEXT != nullptr;
 
-    CHECK(!instance_dispatchable_object_to_instance_.contains(key));
+    ORBIT_CHECK(!instance_dispatchable_object_to_instance_.contains(key));
     instance_dispatchable_object_to_instance_[key] = instance;
   }
 }
@@ -62,16 +62,16 @@ void DispatchTable::RemoveInstanceDispatchTable(VkInstance instance) {
   void* key = GetDispatchTableKey(instance);
   {
     absl::WriterMutexLock lock(&mutex_);
-    CHECK(instance_dispatch_table_.contains(key));
+    ORBIT_CHECK(instance_dispatch_table_.contains(key));
     instance_dispatch_table_.erase(key);
 
-    CHECK(instance_supports_debug_utils_extension_.contains(key));
+    ORBIT_CHECK(instance_supports_debug_utils_extension_.contains(key));
     instance_supports_debug_utils_extension_.erase(key);
 
-    CHECK(instance_supports_debug_report_extension_.contains(key));
+    ORBIT_CHECK(instance_supports_debug_report_extension_.contains(key));
     instance_supports_debug_report_extension_.erase(key);
 
-    CHECK(instance_dispatchable_object_to_instance_.contains(key));
+    ORBIT_CHECK(instance_dispatchable_object_to_instance_.contains(key));
     instance_dispatchable_object_to_instance_.erase(key);
   }
 }
@@ -155,10 +155,10 @@ void DispatchTable::CreateDeviceDispatchTable(
   void* key = GetDispatchTableKey(device);
   {
     absl::WriterMutexLock lock(&mutex_);
-    CHECK(!device_dispatch_table_.contains(key));
+    ORBIT_CHECK(!device_dispatch_table_.contains(key));
     device_dispatch_table_[key] = dispatch_table;
 
-    CHECK(!device_supports_debug_utils_extension_.contains(key));
+    ORBIT_CHECK(!device_supports_debug_utils_extension_.contains(key));
     device_supports_debug_utils_extension_[key] =
         dispatch_table.CmdBeginDebugUtilsLabelEXT != nullptr &&
         dispatch_table.CmdEndDebugUtilsLabelEXT != nullptr &&
@@ -169,7 +169,7 @@ void DispatchTable::CreateDeviceDispatchTable(
         dispatch_table.QueueInsertDebugUtilsLabelEXT != nullptr &&
         dispatch_table.CmdInsertDebugUtilsLabelEXT != nullptr;
 
-    CHECK(!device_supports_debug_marker_extension_.contains(key));
+    ORBIT_CHECK(!device_supports_debug_marker_extension_.contains(key));
     device_supports_debug_marker_extension_[key] =
         dispatch_table.CmdDebugMarkerBeginEXT != nullptr &&
         dispatch_table.CmdDebugMarkerEndEXT != nullptr &&
@@ -184,13 +184,13 @@ void DispatchTable::RemoveDeviceDispatchTable(VkDevice device) {
   {
     absl::WriterMutexLock lock(&mutex_);
 
-    CHECK(device_dispatch_table_.contains(key));
+    ORBIT_CHECK(device_dispatch_table_.contains(key));
     device_dispatch_table_.erase(key);
 
-    CHECK(device_supports_debug_utils_extension_.contains(key));
+    ORBIT_CHECK(device_supports_debug_utils_extension_.contains(key));
     device_supports_debug_utils_extension_.erase(key);
 
-    CHECK(device_supports_debug_marker_extension_.contains(key));
+    ORBIT_CHECK(device_supports_debug_marker_extension_.contains(key));
     device_supports_debug_marker_extension_.erase(key);
   }
 }

--- a/src/OrbitVulkanLayer/DispatchTable.h
+++ b/src/OrbitVulkanLayer/DispatchTable.h
@@ -48,8 +48,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).DestroyDevice != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).DestroyDevice != nullptr);
       return device_dispatch_table_.at(key).DestroyDevice;
     }
   }
@@ -59,8 +59,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).DestroyInstance != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).DestroyInstance != nullptr);
       return instance_dispatch_table_.at(key).DestroyInstance;
     }
   }
@@ -71,8 +71,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties != nullptr);
       return instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties;
     }
   }
@@ -83,8 +83,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).GetPhysicalDeviceProperties != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).GetPhysicalDeviceProperties != nullptr);
       return instance_dispatch_table_.at(key).GetPhysicalDeviceProperties;
     }
   }
@@ -94,8 +94,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).GetInstanceProcAddr != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).GetInstanceProcAddr != nullptr);
       return instance_dispatch_table_.at(key).GetInstanceProcAddr;
     }
   }
@@ -105,8 +105,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).GetDeviceProcAddr != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).GetDeviceProcAddr != nullptr);
       return device_dispatch_table_.at(key).GetDeviceProcAddr;
     }
   }
@@ -116,8 +116,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).ResetCommandPool != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).ResetCommandPool != nullptr);
       return device_dispatch_table_.at(key).ResetCommandPool;
     }
   }
@@ -127,8 +127,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).AllocateCommandBuffers != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).AllocateCommandBuffers != nullptr);
       return device_dispatch_table_.at(key).AllocateCommandBuffers;
     }
   }
@@ -138,8 +138,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).FreeCommandBuffers != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).FreeCommandBuffers != nullptr);
       return device_dispatch_table_.at(key).FreeCommandBuffers;
     }
   }
@@ -149,8 +149,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).BeginCommandBuffer != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).BeginCommandBuffer != nullptr);
       return device_dispatch_table_.at(key).BeginCommandBuffer;
     }
   }
@@ -160,8 +160,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).EndCommandBuffer != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).EndCommandBuffer != nullptr);
       return device_dispatch_table_.at(key).EndCommandBuffer;
     }
   }
@@ -171,8 +171,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).ResetCommandBuffer != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).ResetCommandBuffer != nullptr);
       return device_dispatch_table_.at(key).ResetCommandBuffer;
     }
   }
@@ -182,8 +182,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).GetDeviceQueue != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).GetDeviceQueue != nullptr);
       return device_dispatch_table_.at(key).GetDeviceQueue;
     }
   }
@@ -193,8 +193,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).GetDeviceQueue2 != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).GetDeviceQueue2 != nullptr);
       return device_dispatch_table_.at(key).GetDeviceQueue2;
     }
   }
@@ -204,8 +204,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).QueueSubmit != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).QueueSubmit != nullptr);
       return device_dispatch_table_.at(key).QueueSubmit;
     }
   }
@@ -215,8 +215,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).QueuePresentKHR != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).QueuePresentKHR != nullptr);
       return device_dispatch_table_.at(key).QueuePresentKHR;
     }
   }
@@ -226,8 +226,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CreateQueryPool != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).CreateQueryPool != nullptr);
       return device_dispatch_table_.at(key).CreateQueryPool;
     }
   }
@@ -237,8 +237,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).DestroyQueryPool != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).DestroyQueryPool != nullptr);
       return device_dispatch_table_.at(key).DestroyQueryPool;
     }
   }
@@ -248,8 +248,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).ResetQueryPoolEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).ResetQueryPoolEXT != nullptr);
       return device_dispatch_table_.at(key).ResetQueryPoolEXT;
     }
   }
@@ -259,8 +259,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).GetQueryPoolResults != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).GetQueryPoolResults != nullptr);
       return device_dispatch_table_.at(key).GetQueryPoolResults;
     }
   }
@@ -270,8 +270,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdWriteTimestamp != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).CmdWriteTimestamp != nullptr);
       return device_dispatch_table_.at(key).CmdWriteTimestamp;
     }
   }
@@ -284,8 +284,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT != nullptr);
       return device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT;
     }
   }
@@ -295,8 +295,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerEndEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).CmdDebugMarkerEndEXT != nullptr);
       return device_dispatch_table_.at(key).CmdDebugMarkerEndEXT;
     }
   }
@@ -306,8 +306,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerInsertEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).CmdDebugMarkerInsertEXT != nullptr);
       return device_dispatch_table_.at(key).CmdDebugMarkerInsertEXT;
     }
   }
@@ -318,8 +318,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).DebugMarkerSetObjectTagEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).DebugMarkerSetObjectTagEXT != nullptr);
       return device_dispatch_table_.at(key).DebugMarkerSetObjectTagEXT;
     }
   }
@@ -330,8 +330,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).DebugMarkerSetObjectNameEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).DebugMarkerSetObjectNameEXT != nullptr);
       return device_dispatch_table_.at(key).DebugMarkerSetObjectNameEXT;
     }
   }
@@ -341,7 +341,7 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_supports_debug_marker_extension_.contains(key));
+      ORBIT_CHECK(device_supports_debug_marker_extension_.contains(key));
       return device_supports_debug_marker_extension_.at(key);
     }
   }
@@ -355,8 +355,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT;
     }
   }
@@ -366,8 +366,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT;
     }
   }
@@ -378,8 +378,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdInsertDebugUtilsLabelEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).CmdInsertDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).CmdInsertDebugUtilsLabelEXT;
     }
   }
@@ -390,8 +390,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).SetDebugUtilsObjectNameEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).SetDebugUtilsObjectNameEXT != nullptr);
       return device_dispatch_table_.at(key).SetDebugUtilsObjectNameEXT;
     }
   }
@@ -401,8 +401,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).SetDebugUtilsObjectTagEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).SetDebugUtilsObjectTagEXT != nullptr);
       return device_dispatch_table_.at(key).SetDebugUtilsObjectTagEXT;
     }
   }
@@ -413,8 +413,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).QueueBeginDebugUtilsLabelEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).QueueBeginDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).QueueBeginDebugUtilsLabelEXT;
     }
   }
@@ -425,8 +425,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).QueueEndDebugUtilsLabelEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).QueueEndDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).QueueEndDebugUtilsLabelEXT;
     }
   }
@@ -437,8 +437,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).QueueInsertDebugUtilsLabelEXT != nullptr);
+      ORBIT_CHECK(device_dispatch_table_.contains(key));
+      ORBIT_CHECK(device_dispatch_table_.at(key).QueueInsertDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).QueueInsertDebugUtilsLabelEXT;
     }
   }
@@ -449,8 +449,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).CreateDebugUtilsMessengerEXT != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).CreateDebugUtilsMessengerEXT != nullptr);
       return instance_dispatch_table_.at(key).CreateDebugUtilsMessengerEXT;
     }
   }
@@ -461,8 +461,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).DestroyDebugUtilsMessengerEXT != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).DestroyDebugUtilsMessengerEXT != nullptr);
       return instance_dispatch_table_.at(key).DestroyDebugUtilsMessengerEXT;
     }
   }
@@ -473,8 +473,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).SubmitDebugUtilsMessageEXT != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).SubmitDebugUtilsMessageEXT != nullptr);
       return instance_dispatch_table_.at(key).SubmitDebugUtilsMessageEXT;
     }
   }
@@ -484,7 +484,7 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_supports_debug_utils_extension_.contains(key));
+      ORBIT_CHECK(device_supports_debug_utils_extension_.contains(key));
       return device_supports_debug_utils_extension_.at(key);
     }
   }
@@ -493,7 +493,7 @@ class DispatchTable {
     void* key = GetDispatchTableKey(instance);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_supports_debug_utils_extension_.contains(key));
+      ORBIT_CHECK(instance_supports_debug_utils_extension_.contains(key));
       return instance_supports_debug_utils_extension_.at(key);
     }
   }
@@ -507,8 +507,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).CreateDebugReportCallbackEXT != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).CreateDebugReportCallbackEXT != nullptr);
       return instance_dispatch_table_.at(key).CreateDebugReportCallbackEXT;
     }
   }
@@ -519,8 +519,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).DestroyDebugReportCallbackEXT != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).DestroyDebugReportCallbackEXT != nullptr);
       return instance_dispatch_table_.at(key).DestroyDebugReportCallbackEXT;
     }
   }
@@ -530,8 +530,8 @@ class DispatchTable {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatch_table_.contains(key));
-      CHECK(instance_dispatch_table_.at(key).DebugReportMessageEXT != nullptr);
+      ORBIT_CHECK(instance_dispatch_table_.contains(key));
+      ORBIT_CHECK(instance_dispatch_table_.at(key).DebugReportMessageEXT != nullptr);
       return instance_dispatch_table_.at(key).DebugReportMessageEXT;
     }
   }
@@ -540,7 +540,7 @@ class DispatchTable {
     void* key = GetDispatchTableKey(instance);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_supports_debug_report_extension_.contains(key));
+      ORBIT_CHECK(instance_supports_debug_report_extension_.contains(key));
       return instance_supports_debug_report_extension_.at(key);
     }
   }
@@ -550,7 +550,7 @@ class DispatchTable {
     void* key = GetDispatchTableKey(instance_dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(instance_dispatchable_object_to_instance_.contains(key));
+      ORBIT_CHECK(instance_dispatchable_object_to_instance_.contains(key));
       return instance_dispatchable_object_to_instance_.at(key);
     }
   }

--- a/src/OrbitVulkanLayer/QueueManager.cpp
+++ b/src/OrbitVulkanLayer/QueueManager.cpp
@@ -10,13 +10,13 @@ namespace orbit_vulkan_layer {
 
 void QueueManager::TrackQueue(VkQueue queue, VkDevice device) {
   absl::WriterMutexLock lock(&mutex_);
-  CHECK(!queue_to_device_.contains(queue) || queue_to_device_.at(queue) == device);
+  ORBIT_CHECK(!queue_to_device_.contains(queue) || queue_to_device_.at(queue) == device);
   queue_to_device_.emplace(queue, device);
 }
 
 VkDevice QueueManager::GetDeviceOfQueue(VkQueue queue) {
   absl::ReaderMutexLock lock(&mutex_);
-  CHECK(queue_to_device_.contains(queue));
+  ORBIT_CHECK(queue_to_device_.contains(queue));
   return queue_to_device_.at(queue);
 }
 }  // namespace orbit_vulkan_layer

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -138,9 +138,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
         timer_query_pool_(timer_query_pool),
         device_manager_(device_manager),
         max_local_marker_depth_per_command_buffer_(max_local_marker_depth_per_command_buffer) {
-    CHECK(dispatch_table_ != nullptr);
-    CHECK(timer_query_pool_ != nullptr);
-    CHECK(device_manager_ != nullptr);
+    ORBIT_CHECK(dispatch_table_ != nullptr);
+    ORBIT_CHECK(timer_query_pool_ != nullptr);
+    ORBIT_CHECK(device_manager_ != nullptr);
   }
 
   // Sets a producer to be used to enqueue capture events and asks if we are capturing.
@@ -182,7 +182,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   void UntrackCommandBuffers(VkDevice device, VkCommandPool pool,
                              const VkCommandBuffer* command_buffers, uint32_t count) {
     absl::WriterMutexLock lock(&mutex_);
-    CHECK(pool_to_command_buffers_.contains(pool));
+    ORBIT_CHECK(pool_to_command_buffers_.contains(pool));
     absl::flat_hash_set<VkCommandBuffer>& associated_command_buffers =
         pool_to_command_buffers_.at(pool);
     for (uint32_t i = 0; i < count; ++i) {
@@ -203,8 +203,8 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
         command_buffer_to_state_.erase(command_buffer);
       }
 
-      CHECK(command_buffer_to_device_.contains(command_buffer));
-      CHECK(command_buffer_to_device_.at(command_buffer) == device);
+      ORBIT_CHECK(command_buffer_to_device_.contains(command_buffer));
+      ORBIT_CHECK(command_buffer_to_device_.at(command_buffer) == device);
       command_buffer_to_device_.erase(command_buffer);
     }
     if (associated_command_buffers.empty()) {
@@ -238,7 +238,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
     uint32_t slot_index;
     if (RecordTimestamp(command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, &slot_index)) {
-      CHECK(command_buffer_to_state_.contains(command_buffer));
+      ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
       command_buffer_to_state_.at(command_buffer).command_buffer_begin_slot_index =
           std::make_optional(slot_index);
     }
@@ -250,7 +250,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       return;
     }
     if (!command_buffer_to_state_.contains(command_buffer)) {
-      ERROR_ONCE(
+      ORBIT_ERROR_ONCE(
           "Calling vkEndCommandBuffer on a command buffer that is in the initial state "
           "(i.e. either freshly allocated or reset with vkResetCommandBuffer).");
       return;
@@ -260,7 +260,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     if (RecordTimestamp(command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, &slot_index)) {
       // MarkCommandBufferBegin/End are called from within the same submit, and as the
       // `MarkCommandBufferBegin` will always insert the state, we can assume that it is there.
-      CHECK(command_buffer_to_state_.contains(command_buffer));
+      ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
       CommandBufferState& command_buffer_state = command_buffer_to_state_.at(command_buffer);
       command_buffer_state.command_buffer_end_slot_index = std::make_optional(slot_index);
     }
@@ -269,17 +269,17 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   void MarkDebugMarkerBegin(VkCommandBuffer command_buffer, const char* text, Color color) {
     absl::WriterMutexLock lock(&mutex_);
     // It is ensured by the Vulkan spec. that `text` must not be nullptr.
-    CHECK(text != nullptr);
+    ORBIT_CHECK(text != nullptr);
     bool marker_depth_exceeds_maximum;
     {
       if (!command_buffer_to_state_.contains(command_buffer)) {
-        ERROR_ONCE(
+        ORBIT_ERROR_ONCE(
             "Calling vkCmdDebugMarkerBeginEXT/vkCmdBeginDebugUtilsLabelEXT on a command buffer "
             "that is in the initial state (i.e. either freshly allocated or reset with "
             "vkResetCommandBuffer).");
         return;
       }
-      CHECK(command_buffer_to_state_.contains(command_buffer));
+      ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
       CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
       ++state.local_marker_stack_size;
       marker_depth_exceeds_maximum =
@@ -297,7 +297,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
     uint32_t slot_index;
     if (RecordTimestamp(command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, &slot_index)) {
-      CHECK(command_buffer_to_state_.contains(command_buffer));
+      ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
       CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
       state.markers.back().slot_index = std::make_optional(slot_index);
     }
@@ -308,13 +308,13 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     bool marker_depth_exceeds_maximum;
 
     if (!command_buffer_to_state_.contains(command_buffer)) {
-      ERROR_ONCE(
+      ORBIT_ERROR_ONCE(
           "Calling vkCmdDebugMarkerEndEXT/vkCmdEndDebugUtilsLabelEXT on a command buffer "
           "that is in the initial state (i.e. either freshly allocated or reset with "
           "vkResetCommandBuffer).");
       return;
     }
-    CHECK(command_buffer_to_state_.contains(command_buffer));
+    ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
     CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
     marker_depth_exceeds_maximum =
         state.local_marker_stack_size > max_local_marker_depth_per_command_buffer_;
@@ -332,7 +332,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
     uint32_t slot_index;
     if (RecordTimestamp(command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, &slot_index)) {
-      CHECK(command_buffer_to_state_.contains(command_buffer));
+      ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
       CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
       state.markers.back().slot_index = std::make_optional(slot_index);
     }
@@ -410,7 +410,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     if (!queue_to_markers_.contains(queue)) {
       queue_to_markers_[queue] = {};
     }
-    CHECK(queue_to_markers_.contains(queue));
+    ORBIT_CHECK(queue_to_markers_.contains(queue));
     QueueMarkerState& markers = queue_to_markers_.at(queue);
 
     // If we consider that we are still capturing, take a cpu timestamp as "post submission" such
@@ -429,7 +429,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
            ++command_buffer_index) {
         VkCommandBuffer command_buffer = submit_info.pCommandBuffers[command_buffer_index];
         if (device == VK_NULL_HANDLE) {
-          CHECK(command_buffer_to_device_.contains(command_buffer));
+          ORBIT_CHECK(command_buffer_to_device_.contains(command_buffer));
           device = command_buffer_to_device_.at(command_buffer);
         }
         PersistDebugMarkersOfASingleCommandBufferOnSubmit(
@@ -544,7 +544,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       if (!pool_to_command_buffers_.contains(command_pool)) {
         return;
       }
-      CHECK(pool_to_command_buffers_.contains(command_pool));
+      ORBIT_CHECK(pool_to_command_buffers_.contains(command_pool));
       command_buffers = pool_to_command_buffers_.at(command_pool);
     }
     for (const auto& command_buffer : command_buffers) {
@@ -570,7 +570,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     for (auto& [command_buffer, command_buffer_state] : command_buffer_to_state_) {
       if (command_buffer_state.pre_submission_cpu_timestamp.has_value()) continue;
       if (device == VK_NULL_HANDLE) {
-        CHECK(command_buffer_to_device_.contains(command_buffer));
+        ORBIT_CHECK(command_buffer_to_device_.contains(command_buffer));
         device = command_buffer_to_device_.at(command_buffer);
       }
       if (command_buffer_state.command_buffer_begin_slot_index.has_value()) {
@@ -645,7 +645,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     mutex_.AssertReaderHeld();
     VkDevice device;
     {
-      CHECK(command_buffer_to_device_.contains(command_buffer));
+      ORBIT_CHECK(command_buffer_to_device_.contains(command_buffer));
       device = command_buffer_to_device_.at(command_buffer);
     }
 
@@ -690,10 +690,10 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
                                                         std::vector<uint32_t>* query_slots_to_reset,
                                                         VkDevice device, VkQueryPool query_pool,
                                                         float timestamp_period) {
-    CHECK(command_buffer != nullptr);
+    ORBIT_CHECK(command_buffer != nullptr);
 
     if (!command_buffer->end_timestamp.has_value()) {
-      CHECK(command_buffer->command_buffer_end_slot_index.has_value());
+      ORBIT_CHECK(command_buffer->command_buffer_end_slot_index.has_value());
       uint32_t slot_index = command_buffer->command_buffer_end_slot_index.value();
       std::optional<uint64_t> end_timestamp =
           QueryGpuTimestampNs(device, query_pool, slot_index, timestamp_period);
@@ -744,7 +744,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
                                                       std::vector<uint32_t>* query_slots_to_reset,
                                                       VkDevice device, VkQueryPool query_pool,
                                                       float timestamp_period) {
-    CHECK(marker_slice != nullptr);
+    ORBIT_CHECK(marker_slice != nullptr);
 
     if (!marker_slice->end_info.timestamp.has_value()) {
       std::optional<uint64_t> end_timestamp = QueryGpuTimestampNs(
@@ -799,14 +799,14 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
         if (completed_command_buffer.command_buffer_begin_slot_index.has_value()) {
           // This function must only be called once queries have actually succeeded. If this command
           // buffer has a slot index for the begin timestamp, we must have a value here.
-          CHECK(completed_command_buffer.begin_timestamp.has_value());
+          ORBIT_CHECK(completed_command_buffer.begin_timestamp.has_value());
           command_buffer_proto->set_begin_gpu_timestamp_ns(
               completed_command_buffer.begin_timestamp.value());
         }
 
         // Similarly here, this function must only be called once timestamp queries have succeeded,
         // and therefore we must have an end timestamp here.
-        CHECK(completed_command_buffer.end_timestamp.has_value());
+        ORBIT_CHECK(completed_command_buffer.end_timestamp.has_value());
         command_buffer_proto->set_end_gpu_timestamp_ns(
             completed_command_buffer.end_timestamp.value());
 
@@ -821,7 +821,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     submission_proto->set_num_begin_markers(completed_submission.num_begin_markers);
     bool has_at_least_one_timestamp = false;
     for (const auto& marker_state : completed_submission.completed_markers) {
-      CHECK(marker_state.end_info.timestamp.has_value());
+      ORBIT_CHECK(marker_state.end_info.timestamp.has_value());
       uint64_t end_timestamp = marker_state.end_info.timestamp.value();
       has_at_least_one_timestamp = true;
 
@@ -856,7 +856,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       WriteMetaInfo(marker_state.begin_info->meta_information,
                     begin_debug_marker_proto->mutable_meta_info());
 
-      CHECK(marker_state.begin_info->timestamp.has_value());
+      ORBIT_CHECK(marker_state.begin_info->timestamp.has_value());
       uint64_t begin_timestamp = marker_state.begin_info->timestamp.value();
       begin_debug_marker_proto->set_gpu_timestamp_ns(begin_timestamp);
     }
@@ -870,9 +870,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     if (!command_buffer_to_state_.contains(command_buffer)) {
       return;
     }
-    CHECK(command_buffer_to_state_.contains(command_buffer));
+    ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
     CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
-    CHECK(command_buffer_to_device_.contains(command_buffer));
+    ORBIT_CHECK(command_buffer_to_device_.contains(command_buffer));
     VkDevice device = command_buffer_to_device_.at(command_buffer);
     std::vector<uint32_t> query_slots_to_reset{};
     if (state.command_buffer_begin_slot_index.has_value()) {
@@ -900,17 +900,17 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
                                           SubmitInfo* submitted_submit_info,
                                           std::vector<uint32_t>* query_slots_not_needed_to_read) {
     mutex_.AssertHeld();
-    CHECK(queue_submission != nullptr);
-    CHECK(submitted_submit_info != nullptr);
-    CHECK(query_slots_not_needed_to_read != nullptr);
+    ORBIT_CHECK(queue_submission != nullptr);
+    ORBIT_CHECK(submitted_submit_info != nullptr);
+    ORBIT_CHECK(query_slots_not_needed_to_read != nullptr);
 
     if (!command_buffer_to_state_.contains(command_buffer)) {
-      ERROR_ONCE(
+      ORBIT_ERROR_ONCE(
           "Calling vkQueueSubmit on a command buffer that is in the initial state (i.e. "
           "either freshly allocated or reset with vkResetCommandBuffer).");
       return;
     }
-    CHECK(command_buffer_to_state_.contains(command_buffer));
+    ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
     CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
     bool has_been_submitted_before = state.pre_submission_cpu_timestamp.has_value();
 
@@ -957,23 +957,23 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       VkCommandBuffer command_buffer, std::optional<QueueSubmission>* queue_submission_optional,
       QueueMarkerState* markers, std::vector<uint32_t>* marker_slots_not_needed_to_read) {
     mutex_.AssertHeld();
-    CHECK(queue_submission_optional != nullptr);
-    CHECK(markers != nullptr);
-    CHECK(marker_slots_not_needed_to_read != nullptr);
+    ORBIT_CHECK(queue_submission_optional != nullptr);
+    ORBIT_CHECK(markers != nullptr);
+    ORBIT_CHECK(marker_slots_not_needed_to_read != nullptr);
 
     if (!command_buffer_to_state_.contains(command_buffer)) {
-      ERROR_ONCE(
+      ORBIT_ERROR_ONCE(
           "Calling vkQueueSubmit on a command buffer that is in the initial state (i.e. "
           "either freshly allocated or reset with vkResetCommandBuffer).");
       return;
     }
-    CHECK(command_buffer_to_state_.contains(command_buffer));
+    ORBIT_CHECK(command_buffer_to_state_.contains(command_buffer));
     const CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
 
     for (const Marker& marker : state.markers) {
       std::optional<SubmittedMarker> submitted_marker = std::nullopt;
-      CHECK(!queue_submission_optional->has_value() ||
-            state.pre_submission_cpu_timestamp.has_value());
+      ORBIT_CHECK(!queue_submission_optional->has_value() ||
+                  state.pre_submission_cpu_timestamp.has_value());
       if (marker.slot_index.has_value() && queue_submission_optional->has_value() &&
           (state.pre_submission_cpu_timestamp.value() ==
            queue_submission_optional->value().meta_information.pre_submission_cpu_timestamp)) {
@@ -986,8 +986,8 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
           if (queue_submission_optional->has_value() && marker.slot_index.has_value()) {
             ++queue_submission_optional->value().num_begin_markers;
           }
-          CHECK(marker.label_name.has_value());
-          CHECK(marker.color.has_value());
+          ORBIT_CHECK(marker.label_name.has_value());
+          ORBIT_CHECK(marker.color.has_value());
           MarkerState marker_state{.begin_info = submitted_marker,
                                    .label_name = marker.label_name.value(),
                                    .color = marker.color.value(),
@@ -1017,7 +1017,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
           if (queue_submission_optional->has_value() && marker.slot_index.has_value() &&
               !marker_state.depth_exceeds_maximum) {
-            CHECK(submitted_marker.has_value());
+            ORBIT_CHECK(submitted_marker.has_value());
             queue_submission_optional->value().completed_markers.emplace_back(
                 SubmittedMarkerSlice{.begin_info = marker_state.begin_info,
                                      .end_info = submitted_marker.value(),

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -222,7 +222,7 @@ class SubmissionTrackerTest : public ::testing::Test {
         *absl::bit_cast<uint64_t*>(data) = kTimestamp7;
         break;
       default:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
     return VK_SUCCESS;
   };
@@ -610,7 +610,7 @@ TEST_F(SubmissionTrackerTest, WillRetryCompletingSubmissionsWhenTimestampQueryFa
   // VkCommandBuffer's that are different, which is needed for this test.
   std::array<VkCommandBuffer, 2> command_buffers{absl::bit_cast<VkCommandBuffer>(1L),
                                                  absl::bit_cast<VkCommandBuffer>(2L)};
-  CHECK(command_buffers[0] != command_buffers[1]);
+  ORBIT_CHECK(command_buffers[0] != command_buffers[1]);
 
   tracker_.TrackCommandBuffers(device_, command_pool_, &command_buffers[0], 2);
   tracker_.MarkCommandBufferBegin(command_buffers[0]);
@@ -1153,7 +1153,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNestedDebugMarkerTimestampsForAComplete
     if (str == text_inner) {
       return expected_text_key_inner;
     }
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   };
   EXPECT_CALL(*producer_, InternStringIfNecessaryAndGetKey)
       .Times(2)
@@ -1232,7 +1232,7 @@ TEST_F(SubmissionTrackerTest,
     if (str == text_inner) {
       return expected_text_key_inner;
     }
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   };
   EXPECT_CALL(*producer_, InternStringIfNecessaryAndGetKey)
       .Times(2)
@@ -1579,7 +1579,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBuffer) {
     if (str == text_outer) {
       return expected_text_key_outer;
     }
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
   };
   EXPECT_CALL(*producer_, InternStringIfNecessaryAndGetKey)
       .Times(1)

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -371,7 +371,7 @@ TEST_F(
       .Times(2)
       .WillRepeatedly(Invoke([](const char* /*layer_name*/, uint32_t* property_count,
                                 VkExtensionProperties* properties) -> VkResult {
-        CHECK(property_count != nullptr);
+        ORBIT_CHECK(property_count != nullptr);
         if (properties == nullptr) {
           *property_count = 1;
           return VK_SUCCESS;
@@ -451,7 +451,7 @@ TEST_F(
       .Times(2)
       .WillRepeatedly(Invoke([](const char* /*layer_name*/, uint32_t* property_count,
                                 VkExtensionProperties* properties) -> VkResult {
-        CHECK(property_count != nullptr);
+        ORBIT_CHECK(property_count != nullptr);
         if (properties == nullptr) {
           *property_count = 1;
           return VK_SUCCESS;
@@ -519,7 +519,7 @@ TEST_F(VulkanLayerControllerTest, WillDumpPidOnCreateInstance) {
   EXPECT_CALL(*vulkan_wrapper, CallVkEnumerateInstanceExtensionProperties)
       .WillRepeatedly(Invoke([](const char* /*layer_name*/, uint32_t* property_count,
                                 VkExtensionProperties* properties) -> VkResult {
-        CHECK(property_count != nullptr);
+        ORBIT_CHECK(property_count != nullptr);
         if (properties == nullptr) {
           *property_count = 1;
           return VK_SUCCESS;
@@ -572,7 +572,7 @@ TEST_F(VulkanLayerControllerTest, DumpProcessIdFailsOnCreateInstanceByNonExisten
   EXPECT_CALL(*vulkan_wrapper, CallVkEnumerateInstanceExtensionProperties)
       .WillRepeatedly(Invoke([](const char* /*layer_name*/, uint32_t* property_count,
                                 VkExtensionProperties* properties) -> VkResult {
-        CHECK(property_count != nullptr);
+        ORBIT_CHECK(property_count != nullptr);
         if (properties == nullptr) {
           *property_count = 1;
           return VK_SUCCESS;
@@ -621,7 +621,7 @@ TEST_F(VulkanLayerControllerTest, DumpProcessIdFailsOnCreateInstanceByInvalidFil
   EXPECT_CALL(*vulkan_wrapper, CallVkEnumerateInstanceExtensionProperties)
       .WillRepeatedly(Invoke([](const char* /*layer_name*/, uint32_t* property_count,
                                 VkExtensionProperties* properties) -> VkResult {
-        CHECK(property_count != nullptr);
+        ORBIT_CHECK(property_count != nullptr);
         if (properties == nullptr) {
           *property_count = 1;
           return VK_SUCCESS;
@@ -717,7 +717,7 @@ TEST_F(
       kFakeEnumerateDeviceExtensionProperties =
           +[](VkPhysicalDevice /*physical_device*/, const char* /*layer_name*/,
               uint32_t* property_count, VkExtensionProperties* properties) -> VkResult {
-    CHECK(property_count != nullptr);
+    ORBIT_CHECK(property_count != nullptr);
     if (properties == nullptr) {
       *property_count = 1;
       return VK_SUCCESS;
@@ -794,7 +794,7 @@ TEST_F(VulkanLayerControllerTest,
       kFakeEnumerateDeviceExtensionProperties =
           +[](VkPhysicalDevice /*physical_device*/, const char* /*layer_name*/,
               uint32_t* property_count, VkExtensionProperties* properties) -> VkResult {
-    CHECK(property_count != nullptr);
+    ORBIT_CHECK(property_count != nullptr);
     if (properties == nullptr) {
       *property_count = 1;
       return VK_SUCCESS;

--- a/src/PresetFile/PresetFile.cpp
+++ b/src/PresetFile/PresetFile.cpp
@@ -77,8 +77,8 @@ bool PresetFile::IsLegacyFileFormat() const { return is_legacy_format_; }
 
 std::vector<uint64_t> PresetFile::GetSelectedFunctionHashesForModuleLegacy(
     const std::filesystem::path& module_path) const {
-  CHECK(IsLegacyFileFormat());
-  CHECK(preset_info_legacy_.path_to_module().contains(module_path.string()));
+  ORBIT_CHECK(IsLegacyFileFormat());
+  ORBIT_CHECK(preset_info_legacy_.path_to_module().contains(module_path.string()));
   const auto& function_hashes =
       preset_info_legacy_.path_to_module().at(module_path.string()).function_hashes();
   return {function_hashes.begin(), function_hashes.end()};
@@ -86,8 +86,8 @@ std::vector<uint64_t> PresetFile::GetSelectedFunctionHashesForModuleLegacy(
 
 std::vector<uint64_t> PresetFile::GetFrameTrackFunctionHashesForModuleLegacy(
     const std::filesystem::path& module_path) const {
-  CHECK(IsLegacyFileFormat());
-  CHECK(preset_info_legacy_.path_to_module().contains(module_path.string()));
+  ORBIT_CHECK(IsLegacyFileFormat());
+  ORBIT_CHECK(preset_info_legacy_.path_to_module().contains(module_path.string()));
   const auto& frame_track_function_hashes =
       preset_info_legacy_.path_to_module().at(module_path.string()).frame_track_function_hashes();
   return {frame_track_function_hashes.begin(), frame_track_function_hashes.end()};
@@ -95,16 +95,16 @@ std::vector<uint64_t> PresetFile::GetFrameTrackFunctionHashesForModuleLegacy(
 
 std::vector<std::string> PresetFile::GetSelectedFunctionNamesForModule(
     const std::filesystem::path& module_path) const {
-  CHECK(!IsLegacyFileFormat());
-  CHECK(preset_info_.modules().contains(module_path.string()));
+  ORBIT_CHECK(!IsLegacyFileFormat());
+  ORBIT_CHECK(preset_info_.modules().contains(module_path.string()));
   const auto& function_names = preset_info_.modules().at(module_path.string()).function_names();
   return {function_names.begin(), function_names.end()};
 }
 
 std::vector<std::string> PresetFile::GetFrameTrackFunctionNamesForModule(
     const std::filesystem::path& module_path) const {
-  CHECK(!IsLegacyFileFormat());
-  CHECK(preset_info_.modules().contains(module_path.string()));
+  ORBIT_CHECK(!IsLegacyFileFormat());
+  ORBIT_CHECK(preset_info_.modules().contains(module_path.string()));
   const auto& function_names =
       preset_info_.modules().at(module_path.string()).frame_track_function_names();
   return {function_names.begin(), function_names.end()};
@@ -125,16 +125,16 @@ ErrorMessageOr<PresetFile> ReadPresetFromFile(const std::filesystem::path& file_
 }
 
 ErrorMessageOr<void> PresetFile::SaveToFile() const {
-  CHECK(!is_legacy_format_);
+  ORBIT_CHECK(!is_legacy_format_);
 
   OUTCOME_TRY(auto&& fd, orbit_base::OpenFileForWriting(file_path_));
-  LOG("Saving preset to \"%s\"", file_path_.string());
+  ORBIT_LOG("Saving preset to \"%s\"", file_path_.string());
 
   auto write_result = orbit_base::WriteFully(fd, kPresetFileSignature);
   if (write_result.has_error()) {
     std::string error_message = absl::StrFormat(
         "Failed to save preset to \"%s\": %s", file_path_.string(), write_result.error().message());
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     return ErrorMessage(error_message);
   }
 
@@ -147,7 +147,7 @@ ErrorMessageOr<void> PresetFile::SaveToFile() const {
   if (write_result.has_error()) {
     std::string error_message = absl::StrFormat(
         "Failed to save preset to \"%s\": %s", file_path_.string(), write_result.error().message());
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     return ErrorMessage(error_message);
   }
 

--- a/src/PresetFile/PresetFileTest.cpp
+++ b/src/PresetFile/PresetFileTest.cpp
@@ -21,7 +21,7 @@ using orbit_client_protos::PresetModuleLegacy;
 static TemporaryFile CreateTemporaryFileOrDie() {
   auto temporary_file_or_error = TemporaryFile::Create();
   if (temporary_file_or_error.has_error()) {
-    FATAL("Unable to create temporary file: %s", temporary_file_or_error.error().message());
+    ORBIT_FATAL("Unable to create temporary file: %s", temporary_file_or_error.error().message());
   }
 
   return std::move(temporary_file_or_error.value());

--- a/src/ProcessService/Process.cpp
+++ b/src/ProcessService/Process.cpp
@@ -75,7 +75,7 @@ ErrorMessageOr<Process> Process::FromPid(uint32_t pid) {
   if (cpu_time && total_cpu_time) {
     process.UpdateCpuUsage(cpu_time.value(), total_cpu_time.value());
   } else {
-    LOG("Could not update the CPU usage of process %u", process.process_info().pid());
+    ORBIT_LOG("Could not update the CPU usage of process %u", process.process_info().pid());
   }
 
   // "The command-line arguments appear [...] as a set of strings
@@ -100,8 +100,8 @@ ErrorMessageOr<Process> Process::FromPid(uint32_t pid) {
       process.process_info_.set_is_64_bit(elf_file.value()->Is64Bit());
       process.process_info_.set_build_id(elf_file.value()->GetBuildId());
     } else {
-      LOG("Warning: Unable to parse the executable \"%s\" as elf file. (pid: %u): %s",
-          file_path_result.value(), pid, elf_file.error().message());
+      ORBIT_LOG("Warning: Unable to parse the executable \"%s\" as elf file. (pid: %u): %s",
+                file_path_result.value(), pid, elf_file.error().message());
     }
   }
 

--- a/src/ProcessService/ProcessList.cpp
+++ b/src/ProcessService/ProcessList.cpp
@@ -38,7 +38,7 @@ ErrorMessageOr<void> ProcessList::Refresh() {
 
     bool is_directory = it->is_directory(error);
     if (error) {
-      ERROR("Unable to stat \"%s\" directory entry: %s", it->path(), error.message());
+      ORBIT_ERROR("Unable to stat \"%s\" directory entry: %s", it->path(), error.message());
       continue;
     }
 
@@ -62,7 +62,7 @@ ErrorMessageOr<void> ProcessList::Refresh() {
       } else {
         // We don't fail in this case. This could be a permission problem which might occur when not
         // running as root.
-        ERROR("Could not update the CPU usage of process %d", process.key());
+        ORBIT_ERROR("Could not update the CPU usage of process %d", process.key());
       }
 
       updated_processes.insert(std::move(process));
@@ -74,8 +74,8 @@ ErrorMessageOr<void> ProcessList::Refresh() {
     if (process_or_error.has_error()) {
       // We don't fail in this case. This could be a permission problem which is restricted to a
       // small amount of processes.
-      ERROR("Could not create process list entry for pid %u: %s", pid,
-            process_or_error.error().message());
+      ORBIT_ERROR("Could not create process list entry for pid %u: %s", pid,
+                  process_or_error.error().message());
       continue;
     }
 

--- a/src/ProcessService/ProcessServiceImpl.cpp
+++ b/src/ProcessService/ProcessServiceImpl.cpp
@@ -63,7 +63,7 @@ Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
                                          const GetModuleListRequest* request,
                                          GetModuleListResponse* response) {
   pid_t pid = orbit_base::ToNativeProcessId(request->process_id());
-  LOG("Sending modules for process %d", pid);
+  ORBIT_LOG("Sending modules for process %d", pid);
 
   const auto module_infos = orbit_object_utils::ReadModules(pid);
   if (module_infos.has_error()) {
@@ -90,8 +90,8 @@ Status ProcessServiceImpl::GetProcessMemory(ServerContext* /*context*/,
   }
 
   response->mutable_memory()->resize(0);
-  ERROR("GetProcessMemory: reading %lu bytes from address %#lx of process %u", size,
-        request->address(), request->pid());
+  ORBIT_ERROR("GetProcessMemory: reading %lu bytes from address %#lx of process %u", size,
+              request->address(), request->pid());
   return Status(StatusCode::PERMISSION_DENIED,
                 absl::StrFormat("Could not read %lu bytes from address %#lx of process %u", size,
                                 request->address(), request->pid()));
@@ -100,7 +100,7 @@ Status ProcessServiceImpl::GetProcessMemory(ServerContext* /*context*/,
 Status ProcessServiceImpl::GetDebugInfoFile(ServerContext* /*context*/,
                                             const GetDebugInfoFileRequest* request,
                                             GetDebugInfoFileResponse* response) {
-  CHECK(request != nullptr);
+  ORBIT_CHECK(request != nullptr);
   const auto symbols_path = FindSymbolsFilePath(*request);
   if (symbols_path.has_error()) {
     return Status(StatusCode::NOT_FOUND, symbols_path.error().message());

--- a/src/ProcessService/ProcessServiceUtils.cpp
+++ b/src/ProcessService/ProcessServiceUtils.cpp
@@ -75,14 +75,15 @@ std::optional<Jiffies> GetCumulativeCpuTimeFromProcess(pid_t pid) {
 
   ErrorMessageOr<std::string> file_content_or_error = orbit_base::ReadFileToString(stat);
   if (file_content_or_error.has_error()) {
-    ERROR("Could not read \"%s\": %s", stat.string(), file_content_or_error.error().message());
+    ORBIT_ERROR("Could not read \"%s\": %s", stat.string(),
+                file_content_or_error.error().message());
     return std::nullopt;
   }
 
   std::vector<std::string> lines =
       absl::StrSplit(file_content_or_error.value(), absl::MaxSplits('\n', 1));
   if (lines.empty()) {
-    ERROR("\"%s\" file is empty", stat.string());
+    ORBIT_ERROR("\"%s\" file is empty", stat.string());
     return std::nullopt;
   }
 
@@ -125,7 +126,7 @@ std::optional<Jiffies> GetCumulativeCpuTimeFromProcess(pid_t pid) {
 std::optional<TotalCpuTime> GetCumulativeTotalCpuTime() {
   ErrorMessageOr<std::string> stat_content_or_error = orbit_base::ReadFileToString("/proc/stat");
   if (stat_content_or_error.has_error()) {
-    ERROR("%s", stat_content_or_error.error().message());
+    ORBIT_ERROR("%s", stat_content_or_error.error().message());
     return std::nullopt;
   }
 
@@ -282,7 +283,7 @@ ErrorMessageOr<fs::path> FindSymbolsFilePath(
     ErrorMessageOr<bool> file_exists = orbit_base::FileExists(search_path);
 
     if (file_exists.has_error()) {
-      ERROR("%s", file_exists.error().message());
+      ORBIT_ERROR("%s", file_exists.error().message());
       error_messages.emplace_back(file_exists.error().message());
       continue;
     }

--- a/src/ProducerEventProcessor/GrpcClientCaptureEventCollector.cpp
+++ b/src/ProducerEventProcessor/GrpcClientCaptureEventCollector.cpp
@@ -35,7 +35,7 @@ GrpcClientCaptureEventCollector::GrpcClientCaptureEventCollector(
     grpc::ServerReaderWriterInterface<orbit_grpc_protos::CaptureResponse,
                                       orbit_grpc_protos::CaptureRequest>* reader_writer)
     : reader_writer_{reader_writer} {
-  CHECK(reader_writer_ != nullptr);
+  ORBIT_CHECK(reader_writer_ != nullptr);
 
   InitializeArenaOfCaptureResponses(&arena_of_capture_responses_being_built_,
                                     &initial_block_of_first_arena_);
@@ -68,7 +68,7 @@ void GrpcClientCaptureEventCollector::AddEvent(ClientCaptureEvent&& event) {
 }
 
 void GrpcClientCaptureEventCollector::StopAndWait() {
-  CHECK(sender_thread_.joinable());
+  ORBIT_CHECK(sender_thread_.joinable());
   {
     // Protect stop_requested_ with mutex_ so that we can use stop_requested_ in Conditions for
     // Await/LockWhen (specifically, in SenderThread).
@@ -79,15 +79,15 @@ void GrpcClientCaptureEventCollector::StopAndWait() {
 }
 
 GrpcClientCaptureEventCollector::~GrpcClientCaptureEventCollector() {
-  CHECK(!sender_thread_.joinable());
+  ORBIT_CHECK(!sender_thread_.joinable());
 
-  LOG("Total number of events sent: %u", total_number_of_events_sent_);
-  LOG("Total number of bytes sent: %u", total_number_of_bytes_sent_);
+  ORBIT_LOG("Total number of events sent: %u", total_number_of_events_sent_);
+  ORBIT_LOG("Total number of bytes sent: %u", total_number_of_bytes_sent_);
 
   if (total_number_of_events_sent_ > 0) {
     float average_bytes = static_cast<float>(total_number_of_bytes_sent_) /
                           static_cast<float>(total_number_of_events_sent_);
-    LOG("Average number of bytes per event: %.2f", average_bytes);
+    ORBIT_LOG("Average number of bytes per event: %.2f", average_bytes);
   }
 }
 
@@ -138,7 +138,7 @@ void GrpcClientCaptureEventCollector::SenderThread() {
     for (CaptureResponse* capture_response : capture_responses_to_send_) {
       // Record statistics on event count and byte size for this CaptureResponse.
       int capture_response_event_count = capture_response->capture_events_size();
-      CHECK(capture_response_event_count > 0);
+      ORBIT_CHECK(capture_response_event_count > 0);
       ORBIT_INT("Number of CaptureEvents in CaptureResponse", capture_response_event_count);
 
       uint64_t capture_response_bytes = capture_response->ByteSizeLong();
@@ -158,7 +158,7 @@ void GrpcClientCaptureEventCollector::SenderThread() {
     {
       ORBIT_UINT64("Number of buffered CaptureEvents sent", number_of_events_sent);
 
-      CHECK(number_of_events_sent > 0);
+      ORBIT_CHECK(number_of_events_sent > 0);
       [[maybe_unused]] const float average_bytes =
           static_cast<float>(number_of_bytes_sent) / static_cast<float>(number_of_events_sent);
       ORBIT_FLOAT("Average bytes per CaptureEvent", average_bytes);

--- a/src/ProducerEventProcessor/GrpcClientCaptureEventCollectorTest.cpp
+++ b/src/ProducerEventProcessor/GrpcClientCaptureEventCollectorTest.cpp
@@ -68,7 +68,7 @@ class GrpcClientCaptureEventCollectorTest : public testing::Test {
   }
 
   void CallStopAndWaitEarly() {
-    CHECK(!stop_and_wait_called_);
+    ORBIT_CHECK(!stop_and_wait_called_);
     collector_.StopAndWait();
     stop_and_wait_called_ = true;
   }

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -76,7 +76,7 @@ class InternPool final {
 
     uint64_t new_id = id_counter_++;
     auto [unused_it, inserted] = entry_to_id_.insert_or_assign(entry, new_id);
-    CHECK(inserted);
+    ORBIT_CHECK(inserted);
     return std::make_pair(new_id, true);
   }
 
@@ -255,7 +255,7 @@ void ProducerEventProcessorImpl::ProcessCallstackSampleAndTransferOwnership(
   auto it = producer_interned_callstack_id_to_client_callstack_id_.find(
       {producer_id, callstack_sample->callstack_id()});
   // TODO(b/180235290): replace with error message
-  CHECK(it != producer_interned_callstack_id_to_client_callstack_id_.end());
+  ORBIT_CHECK(it != producer_interned_callstack_id_to_client_callstack_id_.end());
   callstack_sample->set_callstack_id(it->second);
 
   ClientCaptureEvent event;
@@ -412,7 +412,7 @@ void ProducerEventProcessorImpl::ProcessGpuQueueSubmissionAndTransferOwnership(
   for (GpuDebugMarker& mutable_marker : *gpu_queue_submission->mutable_completed_markers()) {
     auto it = producer_interned_string_id_to_client_string_id_.find(
         {producer_id, mutable_marker.text_key()});
-    CHECK(it != producer_interned_string_id_to_client_string_id_.end());
+    ORBIT_CHECK(it != producer_interned_string_id_to_client_string_id_.end());
     mutable_marker.set_text_key(it->second);
   }
 
@@ -424,7 +424,7 @@ void ProducerEventProcessorImpl::ProcessGpuQueueSubmissionAndTransferOwnership(
 void ProducerEventProcessorImpl::ProcessInternedCallstack(uint64_t producer_id,
                                                           InternedCallstack* interned_callstack) {
   // TODO(b/180235290): replace with error message
-  CHECK(!producer_interned_callstack_id_to_client_callstack_id_.contains(
+  ORBIT_CHECK(!producer_interned_callstack_id_to_client_callstack_id_.contains(
       {producer_id, interned_callstack->key()}));
 
   std::pair<std::vector<uint64_t>, Callstack::CallstackType> callstack_data{
@@ -449,7 +449,7 @@ void ProducerEventProcessorImpl::ProcessInternedCallstack(uint64_t producer_id,
 void ProducerEventProcessorImpl::ProcessInternedString(uint64_t producer_id,
                                                        InternedString* interned_string) {
   // TODO(b/180235290): replace with error message
-  CHECK(!producer_interned_string_id_to_client_string_id_.contains(
+  ORBIT_CHECK(!producer_interned_string_id_to_client_string_id_.contains(
       {producer_id, interned_string->key()}));
 
   auto [client_string_id, assigned] = string_pool_.GetOrAssignId(interned_string->intern());
@@ -624,9 +624,9 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
       ProcessFunctionCallAndTransferOwnership(event.release_function_call());
       break;
     case ProducerCaptureEvent::kFunctionEntry:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
     case ProducerCaptureEvent::kFunctionExit:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
     case ProducerCaptureEvent::kGpuQueueSubmission:
       ProcessGpuQueueSubmissionAndTransferOwnership(producer_id,
                                                     event.release_gpu_queue_submission());
@@ -673,7 +673,7 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
           event.release_warning_instrumenting_with_user_space_instrumentation_event());
       break;
     case ProducerCaptureEvent::EVENT_NOT_SET:
-      UNREACHABLE();
+      ORBIT_UNREACHABLE();
   }
 }
 

--- a/src/ProducerEventProcessor/UploaderClientCaptureEventCollector.cpp
+++ b/src/ProducerEventProcessor/UploaderClientCaptureEventCollector.cpp
@@ -25,23 +25,23 @@ UploaderClientCaptureEventCollector::UploaderClientCaptureEventCollector() {
 }
 
 UploaderClientCaptureEventCollector::~UploaderClientCaptureEventCollector() {
-  LOG("Total number of events uploaded: %u", total_uploaded_event_count_);
-  LOG("Total number of bytes uploaded: %u", total_uploaded_data_bytes_);
+  ORBIT_LOG("Total number of events uploaded: %u", total_uploaded_event_count_);
+  ORBIT_LOG("Total number of bytes uploaded: %u", total_uploaded_data_bytes_);
 
   if (total_uploaded_event_count_ > 0) {
     float average_bytes = static_cast<float>(total_uploaded_data_bytes_) /
                           static_cast<float>(total_uploaded_event_count_);
-    LOG("Average number of bytes per event: %.2f", average_bytes);
+    ORBIT_LOG("Average number of bytes per event: %.2f", average_bytes);
   }
 }
 
 void UploaderClientCaptureEventCollector::Stop() {
   absl::MutexLock lock{&mutex_};
 
-  CHECK(output_stream_ != nullptr);
+  ORBIT_CHECK(output_stream_ != nullptr);
   auto close_result = output_stream_->Close();
   if (close_result.has_error()) {
-    ERROR("Closing output stream: %s", close_result.error().message());
+    ORBIT_ERROR("Closing output stream: %s", close_result.error().message());
   }
 }
 
@@ -51,11 +51,11 @@ void UploaderClientCaptureEventCollector::AddEvent(ClientCaptureEvent&& event) {
 
     // The output stream gets closed when processing the `CaptureFinishedEvent`. Drop events
     // received after closing the output stream.
-    CHECK(output_stream_ != nullptr);
+    ORBIT_CHECK(output_stream_ != nullptr);
     if (!output_stream_->IsOpen()) return;
 
     auto write_result = output_stream_->WriteCaptureEvent(event);
-    CHECK(!write_result.has_error());
+    ORBIT_CHECK(!write_result.has_error());
 
     ++buffered_event_count_;
     buffered_event_bytes_ += event.ByteSizeLong();

--- a/src/QtUtils/ExecuteProcess.cpp
+++ b/src/QtUtils/ExecuteProcess.cpp
@@ -50,7 +50,7 @@ Future<ErrorMessageOr<QByteArray>> ExecuteProcess(const QString& program,
             process_description, QMetaEnum::fromType<QProcess::ProcessError>().valueToKey(error),
             process->readAllStandardOutput().toStdString(),
             process->readAllStandardError().toStdString());
-        ERROR("%s", error_message);
+        ORBIT_ERROR("%s", error_message);
 
         promise->SetResult(ErrorMessage{error_message});
       });
@@ -78,7 +78,7 @@ Future<ErrorMessageOr<QByteArray>> ExecuteProcess(const QString& program,
             "Process \"%s\" failed with exit code: %d,\nstdout:\n%s\nstderr:\n%s\n",
             process_description, exit_code, process->readAllStandardOutput().toStdString(),
             process->readAllStandardError().toStdString())};
-        ERROR("%s", error_message);
+        ORBIT_ERROR("%s", error_message);
         promise->SetResult(ErrorMessage{error_message});
         return;
       });
@@ -92,7 +92,7 @@ Future<ErrorMessageOr<QByteArray>> ExecuteProcess(const QString& program,
           std::string error_message{
               absl::StrFormat("Process \"%s\" killed because the parent object was destroyed.",
                               process_description)};
-          ERROR("%s", error_message);
+          ORBIT_ERROR("%s", error_message);
           promise->SetResult(ErrorMessage{error_message});
           // Killing the process results in errorOccured signal getting emitted. The process is then
           // deleted in the errorOccured signal handler
@@ -115,7 +115,7 @@ Future<ErrorMessageOr<QByteArray>> ExecuteProcess(const QString& program,
 
         std::string error_message{absl::StrFormat("Process \"%s\" timed out after %dms",
                                                   process_description, timeout_in_ms)};
-        ERROR("%s", error_message);
+        ORBIT_ERROR("%s", error_message);
         promise->SetResult(ErrorMessage{error_message});
         // Killing the process results in errorOccured signal getting emitted. The process is then
         // deleted in the errorOccured signal handler

--- a/src/QtUtils/MainThreadExecutorImpl.cpp
+++ b/src/QtUtils/MainThreadExecutorImpl.cpp
@@ -42,7 +42,7 @@ MainThreadExecutor::WaitResult MapToWaitResult(orbit_qt_utils::FutureWatcher::Re
       return WaitResult::kTimedOut;
   }
 
-  UNREACHABLE();
+  ORBIT_UNREACHABLE();
 }
 
 MainThreadExecutor::WaitResult MainThreadExecutorImpl::WaitFor(

--- a/src/QtUtils/include/QtUtils/AssertNoQtLogWarnings.h
+++ b/src/QtUtils/include/QtUtils/AssertNoQtLogWarnings.h
@@ -30,10 +30,12 @@ class AssertNoQtLogWarnings {
     const char* function = context.function ? context.function : "";
     switch (type) {
       case QtDebugMsg:
-        LOG("Qt debug message: %s (%s:%u, %s)", localMsg.constData(), file, context.line, function);
+        ORBIT_LOG("Qt debug message: %s (%s:%u, %s)", localMsg.constData(), file, context.line,
+                  function);
         break;
       case QtInfoMsg:
-        LOG("Qt info message: %s (%s:%u, %s)", localMsg.constData(), file, context.line, function);
+        ORBIT_LOG("Qt info message: %s (%s:%u, %s)", localMsg.constData(), file, context.line,
+                  function);
         break;
       case QtWarningMsg:
         EXPECT_EQ(false, NO_WARNING_MSG) << msg.toStdString();

--- a/src/QtUtils/include/QtUtils/EventLoop.h
+++ b/src/QtUtils/include/QtUtils/EventLoop.h
@@ -38,7 +38,7 @@ class EventLoop : public QObject {
       (void)loop_.exec(flags);
     }
 
-    CHECK(result_ != std::nullopt);
+    ORBIT_CHECK(result_ != std::nullopt);
 
     auto result = result_.value();
     result_ = std::nullopt;

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -38,9 +38,9 @@ void PrintInstanceVersions() {
     constexpr const char* kKernelVersionCommand = "uname -a";
     std::optional<std::string> version = orbit_base::ExecuteCommand(kKernelVersionCommand);
     if (version.has_value()) {
-      LOG("%s: %s", kKernelVersionCommand, absl::StripSuffix(version.value(), "\n"));
+      ORBIT_LOG("%s: %s", kKernelVersionCommand, absl::StripSuffix(version.value(), "\n"));
     } else {
-      ERROR("Could not execute \"%s\"", kKernelVersionCommand);
+      ORBIT_ERROR("Could not execute \"%s\"", kKernelVersionCommand);
     }
   }
 
@@ -48,9 +48,9 @@ void PrintInstanceVersions() {
     constexpr const char* kVersionFilePath = "/usr/local/cloudcast/VERSION";
     ErrorMessageOr<std::string> version = orbit_base::ReadFileToString(kVersionFilePath);
     if (version.has_value()) {
-      LOG("%s:\n%s", kVersionFilePath, absl::StripSuffix(version.value(), "\n"));
+      ORBIT_LOG("%s:\n%s", kVersionFilePath, absl::StripSuffix(version.value(), "\n"));
     } else {
-      ERROR("%s", version.error().message());
+      ORBIT_ERROR("%s", version.error().message());
     }
   }
 
@@ -58,9 +58,9 @@ void PrintInstanceVersions() {
     constexpr const char* kBaseVersionFilePath = "/usr/local/cloudcast/BASE_VERSION";
     ErrorMessageOr<std::string> version = orbit_base::ReadFileToString(kBaseVersionFilePath);
     if (version.has_value()) {
-      LOG("%s:\n%s", kBaseVersionFilePath, absl::StripSuffix(version.value(), "\n"));
+      ORBIT_LOG("%s:\n%s", kBaseVersionFilePath, absl::StripSuffix(version.value(), "\n"));
     } else {
-      ERROR("%s", version.error().message());
+      ORBIT_ERROR("%s", version.error().message());
     }
   }
 
@@ -68,9 +68,9 @@ void PrintInstanceVersions() {
     constexpr const char* kInstanceVersionFilePath = "/usr/local/cloudcast/INSTANCE_VERSION";
     ErrorMessageOr<std::string> version = orbit_base::ReadFileToString(kInstanceVersionFilePath);
     if (version.has_value()) {
-      LOG("%s:\n%s", kInstanceVersionFilePath, absl::StripSuffix(version.value(), "\n"));
+      ORBIT_LOG("%s:\n%s", kInstanceVersionFilePath, absl::StripSuffix(version.value(), "\n"));
     } else {
-      ERROR("%s", version.error().message());
+      ORBIT_ERROR("%s", version.error().message());
     }
   }
 
@@ -82,9 +82,9 @@ void PrintInstanceVersions() {
       stripped_version = absl::StripSuffix(version.value(), "\n");
     }
     if (!stripped_version.empty()) {
-      LOG("%s: %s", kDriverVersionCommand, stripped_version);
+      ORBIT_LOG("%s: %s", kDriverVersionCommand, stripped_version);
     } else {
-      ERROR("Could not execute \"%s\"", kDriverVersionCommand);
+      ORBIT_ERROR("Could not execute \"%s\"", kDriverVersionCommand);
     }
   }
 }
@@ -112,24 +112,24 @@ bool IsSshConnectionAlive(std::chrono::time_point<std::chrono::steady_clock> las
 
 std::unique_ptr<OrbitGrpcServer> CreateGrpcServer(uint16_t grpc_port, bool dev_mode) {
   std::string grpc_address = absl::StrFormat("127.0.0.1:%d", grpc_port);
-  LOG("Starting gRPC server at %s", grpc_address);
+  ORBIT_LOG("Starting gRPC server at %s", grpc_address);
   std::unique_ptr<OrbitGrpcServer> grpc_server = OrbitGrpcServer::Create(grpc_address, dev_mode);
   if (grpc_server == nullptr) {
-    ERROR("Unable to start gRPC server");
+    ORBIT_ERROR("Unable to start gRPC server");
     return nullptr;
   }
-  LOG("gRPC server is running");
+  ORBIT_LOG("gRPC server is running");
   return grpc_server;
 }
 
 std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServerWithUri(std::string uri) {
   auto producer_side_server = std::make_unique<ProducerSideServer>();
-  LOG("Starting producer-side server at %s", uri);
+  ORBIT_LOG("Starting producer-side server at %s", uri);
   if (!producer_side_server->BuildAndStart(uri)) {
-    ERROR("Unable to start producer-side server");
+    ORBIT_ERROR("Unable to start producer-side server");
     return nullptr;
   }
-  LOG("Producer-side server is running");
+  ORBIT_LOG("Producer-side server is running");
   return producer_side_server;
 }
 
@@ -142,8 +142,8 @@ std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServer() {
   std::error_code error_code;
   std::filesystem::create_directories(unix_domain_socket_dir, error_code);
   if (error_code) {
-    ERROR("Unable to create directory for socket for producer-side server: %s",
-          error_code.message());
+    ORBIT_ERROR("Unable to create directory for socket for producer-side server: %s",
+                error_code.message());
     return nullptr;
   }
 
@@ -154,7 +154,7 @@ std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServer() {
   // When OrbitService runs as root, also allow non-root producers
   // (e.g., the game) to communicate over the Unix domain socket.
   if (chmod(unix_socket_path.c_str(), 0777) != 0) {
-    ERROR("Changing mode bits to 777 of \"%s\": %s", unix_socket_path, SafeStrerror(errno));
+    ORBIT_ERROR("Changing mode bits to 777 of \"%s\": %s", unix_socket_path, SafeStrerror(errno));
     producer_side_server->ShutdownAndWait();
     return nullptr;
   }
@@ -178,22 +178,22 @@ int OrbitService::Run(std::atomic<bool>* exit_requested) {
   PrintInstanceVersions();
 #endif
 
-  LOG("Running Orbit Service version %s", orbit_version::GetVersionString());
+  ORBIT_LOG("Running Orbit Service version %s", orbit_version::GetVersionString());
 #ifndef NDEBUG
-  LOG("**********************************");
-  LOG("Orbit Service is running in DEBUG!");
-  LOG("**********************************");
+  ORBIT_LOG("**********************************");
+  ORBIT_LOG("Orbit Service is running in DEBUG!");
+  ORBIT_LOG("**********************************");
 #endif
 
   std::unique_ptr<OrbitGrpcServer> grpc_server = CreateGrpcServer(grpc_port_, dev_mode_);
   if (grpc_server == nullptr) {
-    ERROR("Unable to create gRPC server.");
+    ORBIT_ERROR("Unable to create gRPC server.");
     return -1;
   }
 
   std::unique_ptr<ProducerSideServer> producer_side_server = BuildAndStartProducerSideServer();
   if (producer_side_server == nullptr) {
-    ERROR("Unable to build and start ProducerSideServer.");
+    ORBIT_ERROR("Unable to build and start ProducerSideServer.");
     return -1;
   }
   grpc_server->AddCaptureStartStopListener(producer_side_server.get());
@@ -212,7 +212,7 @@ int OrbitService::Run(std::atomic<bool>* exit_requested) {
     std::string stdin_data = ReadStdIn();
     // If ssh sends EOF, end main loop.
     if (feof(stdin) != 0) {
-      LOG("Received EOF on stdin. Exiting main loop.");
+      ORBIT_LOG("Received EOF on stdin. Exiting main loop.");
       break;
     }
 
@@ -222,7 +222,7 @@ int OrbitService::Run(std::atomic<bool>* exit_requested) {
       }
 
       if (!IsSshConnectionAlive(last_stdin_message_.value(), kWatchdogTimeoutInSeconds)) {
-        ERROR("Connection is not alive (watchdog timed out). Exiting main loop.");
+        ORBIT_ERROR("Connection is not alive (watchdog timed out). Exiting main loop.");
         return_code = -1;
         break;
       }

--- a/src/Service/ProducerSideServer.cpp
+++ b/src/Service/ProducerSideServer.cpp
@@ -17,7 +17,7 @@
 namespace orbit_service {
 
 bool ProducerSideServer::BuildAndStart(std::string uri) {
-  CHECK(server_ == nullptr);
+  ORBIT_CHECK(server_ == nullptr);
 
   grpc::ServerBuilder builder;
   builder.AddListeningPort(uri, grpc::InsecureServerCredentials());
@@ -33,7 +33,7 @@ bool ProducerSideServer::BuildAndStart(std::string uri) {
 }
 
 void ProducerSideServer::ShutdownAndWait() {
-  CHECK(server_ != nullptr);
+  ORBIT_CHECK(server_ != nullptr);
   producer_side_service_.OnExitRequest();
   server_->Shutdown();
   server_->Wait();

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -45,7 +45,7 @@ BOOL WINAPI CtrlHandler(DWORD event_type) {
 
 void InstallSigintHandler() {
   if (!SetConsoleCtrlHandler(CtrlHandler, TRUE)) {
-    ERROR("Calling SetConsoleCtrlHandler: %s", orbit_base::GetLastErrorAsString());
+    ORBIT_ERROR("Calling SetConsoleCtrlHandler: %s", orbit_base::GetLastErrorAsString());
   }
 }
 

--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -128,7 +128,7 @@ void ConnectToStadiaWidget::SetActive(bool value) {
 
 void ConnectToStadiaWidget::SetSshConnectionArtifacts(
     SshConnectionArtifacts* ssh_connection_artifacts) {
-  CHECK(ssh_connection_artifacts != nullptr);
+  ORBIT_CHECK(ssh_connection_artifacts != nullptr);
   ssh_connection_artifacts_ = ssh_connection_artifacts;
 }
 
@@ -147,7 +147,7 @@ void ConnectToStadiaWidget::SetConnection(StadiaConnection connection) {
 }
 
 void ConnectToStadiaWidget::Start() {
-  CHECK(ssh_connection_artifacts_ != nullptr);
+  ORBIT_CHECK(ssh_connection_artifacts_ != nullptr);
 
   auto client_result = orbit_ggp::CreateClient();
   if (client_result.has_error()) {
@@ -272,7 +272,7 @@ void ConnectToStadiaWidget::SetupStateMachine() {
 }
 
 void ConnectToStadiaWidget::LoadCredentials() {
-  CHECK(selected_instance_.has_value());
+  ORBIT_CHECK(selected_instance_.has_value());
 
   const std::string instance_id{selected_instance_->id.toStdString()};
 
@@ -289,11 +289,11 @@ void ConnectToStadiaWidget::LoadCredentials() {
 }
 
 void ConnectToStadiaWidget::DeployOrbitService() {
-  CHECK(ssh_connection_artifacts_ != nullptr);
-  CHECK(service_deploy_manager_ == nullptr);
-  CHECK(selected_instance_.has_value());
+  ORBIT_CHECK(ssh_connection_artifacts_ != nullptr);
+  ORBIT_CHECK(service_deploy_manager_ == nullptr);
+  ORBIT_CHECK(selected_instance_.has_value());
   const std::string instance_id = selected_instance_->id.toStdString();
-  CHECK(instance_credentials_.contains(instance_id));
+  ORBIT_CHECK(instance_credentials_.contains(instance_id));
 
   const Credentials& credentials{instance_credentials_.at(instance_id)};
 
@@ -329,9 +329,9 @@ void ConnectToStadiaWidget::DeployOrbitService() {
                                .arg(QString::fromStdString(error.message())));
       });
 
-  CHECK(grpc_channel_ == nullptr);
+  ORBIT_CHECK(grpc_channel_ == nullptr);
   grpc_channel_ = CreateGrpcChannel(deployment_result.value().grpc_port);
-  CHECK(grpc_channel_ != nullptr);
+  ORBIT_CHECK(grpc_channel_ != nullptr);
 
   emit Connected();
 }
@@ -356,7 +356,7 @@ void ConnectToStadiaWidget::OnErrorOccurred(const QString& message) {
   if (IsActive()) {
     QMessageBox::critical(this, QApplication::applicationName(), message);
   } else {
-    ERROR("%s", message.toStdString());
+    ORBIT_ERROR("%s", message.toStdString());
   }
 }
 
@@ -371,7 +371,7 @@ void ConnectToStadiaWidget::OnSelectionChanged(const QModelIndex& current) {
 void ConnectToStadiaWidget::UpdateRememberInstance(bool value) {
   QSettings settings;
   if (value) {
-    CHECK(selected_instance_ != std::nullopt);
+    ORBIT_CHECK(selected_instance_ != std::nullopt);
     settings.setValue(kRememberChosenInstance, selected_instance_->id);
   } else {
     settings.remove(kRememberChosenInstance);
@@ -396,12 +396,12 @@ void ConnectToStadiaWidget::OnSshInfoLoaded(ErrorMessageOr<orbit_ggp::SshInfo> s
     std::string error_message =
         absl::StrFormat("Unable to load encryption credentials for instance with id %s: %s",
                         instance_id, ssh_info_result.error().message());
-    ERROR("%s", error_message);
+    ORBIT_ERROR("%s", error_message);
     emit ErrorOccurred(QString::fromStdString(error_message));
     return;
   }
 
-  LOG("Received ssh info for instance with id: %s", instance_id);
+  ORBIT_LOG("Received ssh info for instance with id: %s", instance_id);
 
   orbit_ggp::SshInfo& ssh_info{ssh_info_result.value()};
   instance_credentials_.emplace(instance_id, CredentialsFromSshInfo(ssh_info));
@@ -427,7 +427,7 @@ void ConnectToStadiaWidget::TrySelectRememberedInstance() {
 bool ConnectToStadiaWidget::IsActive() const { return ui_->contentFrame->isEnabled(); }
 
 void ConnectToStadiaWidget::Connect() {
-  CHECK(selected_instance_.has_value());
+  ORBIT_CHECK(selected_instance_.has_value());
 
   auto account_result = GetAccountSync();
   if (account_result.has_error()) {

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -29,7 +29,7 @@ ConnectToTargetDialog::ConnectToTargetDialog(
       process_id_(process_id),
       metrics_uploader_(metrics_uploader),
       main_thread_executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()) {
-  CHECK(ssh_connection_artifacts != nullptr);
+  ORBIT_CHECK(ssh_connection_artifacts != nullptr);
 
   ui_->setupUi(this);
   ui_->instanceIdLabel->setText(instance_id_or_name);
@@ -39,8 +39,8 @@ ConnectToTargetDialog::ConnectToTargetDialog(
 ConnectToTargetDialog::~ConnectToTargetDialog() {}
 
 std::optional<TargetConfiguration> ConnectToTargetDialog::Exec() {
-  LOG("Trying to establish a connection to specified target %s:%d",
-      instance_id_or_name_.toStdString(), process_id_);
+  ORBIT_LOG("Trying to establish a connection to specified target %s:%d",
+            instance_id_or_name_.toStdString(), process_id_);
 
   auto ggp_client_result = orbit_ggp::CreateClient();
   if (ggp_client_result.has_error()) {
@@ -102,10 +102,10 @@ ErrorMessageOr<StadiaTarget> ConnectToTargetDialog::OnAsyncDataAvailable(
 
 StadiaTarget ConnectToTargetDialog::CreateTarget(ConnectionData result,
                                                  orbit_ggp::Instance instance) const {
-  CHECK(instance.id == instance_id_or_name_ || instance.display_name == instance_id_or_name_);
-  CHECK(result.grpc_channel_ != nullptr);
-  CHECK(result.service_deploy_manager_ != nullptr);
-  CHECK(result.process_data_ != nullptr);
+  ORBIT_CHECK(instance.id == instance_id_or_name_ || instance.display_name == instance_id_or_name_);
+  ORBIT_CHECK(result.grpc_channel_ != nullptr);
+  ORBIT_CHECK(result.service_deploy_manager_ != nullptr);
+  ORBIT_CHECK(result.process_data_ != nullptr);
 
   auto process_manager =
       orbit_client_services::ProcessManager::Create(result.grpc_channel_, absl::Milliseconds(1000));
@@ -137,7 +137,7 @@ ConnectToTargetDialog::DeployOrbitService(
 ErrorMessageOr<std::unique_ptr<orbit_client_data::ProcessData>>
 ConnectToTargetDialog::FindSpecifiedProcess(std::shared_ptr<grpc::Channel> grpc_channel,
                                             uint32_t process_id) {
-  CHECK(grpc_channel != nullptr);
+  ORBIT_CHECK(grpc_channel != nullptr);
 
   orbit_client_services::ProcessClient client(grpc_channel);
   auto process_list = client.GetProcessList();
@@ -160,7 +160,7 @@ void ConnectToTargetDialog::SetStatusMessage(const QString& message) {
 }
 
 void ConnectToTargetDialog::LogAndDisplayError(const ErrorMessage& message) {
-  ERROR("%s", message.message());
+  ORBIT_ERROR("%s", message.message());
   QMessageBox::critical(nullptr, QApplication::applicationName(),
                         QString::fromStdString(message.message()));
 }

--- a/src/SessionSetup/OverlayWidget.cpp
+++ b/src/SessionSetup/OverlayWidget.cpp
@@ -25,7 +25,7 @@ OverlayWidget::~OverlayWidget() = default;
 
 OverlayWidget::OverlayWidget(QWidget* parent)
     : QWidget(parent), ui_(std::make_unique<Ui::OverlayWidget>()) {
-  CHECK(parent != nullptr);
+  ORBIT_CHECK(parent != nullptr);
   parent->installEventFilter(this);
   ui_->setupUi(this);
   ui_->cancelButton->setEnabled(true);

--- a/src/SessionSetup/ProcessItemModel.cpp
+++ b/src/SessionSetup/ProcessItemModel.cpp
@@ -21,10 +21,10 @@ int ProcessItemModel::columnCount(const QModelIndex& parent) const {
 }
 
 QVariant ProcessItemModel::data(const QModelIndex& idx, int role) const {
-  CHECK(idx.isValid());
-  CHECK(idx.model() == static_cast<const QAbstractItemModel*>(this));
-  CHECK(idx.row() >= 0 && idx.row() < static_cast<int>(processes_.size()));
-  CHECK(idx.column() >= 0 && idx.column() < static_cast<int>(Column::kEnd));
+  ORBIT_CHECK(idx.isValid());
+  ORBIT_CHECK(idx.model() == static_cast<const QAbstractItemModel*>(this));
+  ORBIT_CHECK(idx.row() >= 0 && idx.row() < static_cast<int>(processes_.size()));
+  ORBIT_CHECK(idx.column() >= 0 && idx.column() < static_cast<int>(Column::kEnd));
 
   const auto& process = processes_[idx.row()];
 
@@ -41,7 +41,7 @@ QVariant ProcessItemModel::data(const QModelIndex& idx, int role) const {
       case Column::kCpu:
         return QString("%1 %").arg(process.cpu_usage(), 0, 'f', 1);
       case Column::kEnd:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
 
@@ -56,7 +56,7 @@ QVariant ProcessItemModel::data(const QModelIndex& idx, int role) const {
       case Column::kCpu:
         return process.cpu_usage();
       case Column::kEnd:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
 
@@ -75,7 +75,7 @@ QVariant ProcessItemModel::data(const QModelIndex& idx, int role) const {
       case Column::kCpu:
         return QVariant(Qt::AlignVCenter | Qt::AlignRight);
       case Column::kEnd:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
 
@@ -96,7 +96,7 @@ QVariant ProcessItemModel::headerData(int section, Qt::Orientation orientation, 
       case Column::kCpu:
         return "CPU %";
       case Column::kEnd:
-        UNREACHABLE();
+        ORBIT_UNREACHABLE();
     }
   }
   return {};
@@ -154,12 +154,12 @@ void ProcessItemModel::SetProcesses(std::vector<ProcessInfo> new_processes) {
   if (old_iter == processes_.end() && new_iter != new_processes.end()) {
     beginInsertRows({}, processes_.size(), new_processes.size() - 1);
     std::copy(new_iter, new_processes.end(), std::back_inserter(processes_));
-    CHECK(processes_.size() == new_processes.size());
+    ORBIT_CHECK(processes_.size() == new_processes.size());
     endInsertRows();
   } else if (old_iter != processes_.end() && new_iter == new_processes.end()) {
     beginRemoveRows({}, new_processes.size(), processes_.size() - 1);
     processes_.erase(old_iter, processes_.end());
-    CHECK(processes_.size() == new_processes.size());
+    ORBIT_CHECK(processes_.size() == new_processes.size());
     endRemoveRows();
   }
 }

--- a/src/SessionSetup/RetrieveInstances.cpp
+++ b/src/SessionSetup/RetrieveInstances.cpp
@@ -70,8 +70,8 @@ std::unique_ptr<RetrieveInstances> RetrieveInstances::Create(
 RetrieveInstancesImpl::RetrieveInstancesImpl(Client* ggp_client,
                                              MainThreadExecutor* main_thread_executor)
     : ggp_client_(ggp_client), main_thread_executor_(main_thread_executor) {
-  CHECK(ggp_client != nullptr);
-  CHECK(main_thread_executor != nullptr);
+  ORBIT_CHECK(ggp_client != nullptr);
+  ORBIT_CHECK(main_thread_executor != nullptr);
 }
 
 Future<ErrorMessageOr<QVector<Instance>>> RetrieveInstancesImpl::LoadInstances(

--- a/src/SessionSetup/RetrieveInstancesWidget.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidget.cpp
@@ -83,7 +83,7 @@ void RetrieveInstancesWidget::SetupStateMachine() {
 }
 
 void RetrieveInstancesWidget::Start() {
-  CHECK(retrieve_instances_ != nullptr);
+  ORBIT_CHECK(retrieve_instances_ != nullptr);
   state_machine_.setInitialState(&s_loading_);
   state_machine_.start();
 
@@ -99,7 +99,7 @@ InstanceListScope RetrieveInstancesWidget::GetSelectedInstanceListScope() const 
 }
 
 void RetrieveInstancesWidget::InitialLoad(const std::optional<Project>& remembered_project) {
-  CHECK(ui_->projectComboBox->count() == 0);
+  ORBIT_CHECK(ui_->projectComboBox->count() == 0);
   emit LoadingStarted();
   ScopedMetric metric{metrics_uploader_, OrbitLogEvent::ORBIT_INSTANCES_INITIAL_LOAD};
   retrieve_instances_->LoadProjectsAndInstances(remembered_project, GetSelectedInstanceListScope())
@@ -129,7 +129,7 @@ void RetrieveInstancesWidget::InitialLoad(const std::optional<Project>& remember
 
 void RetrieveInstancesWidget::OnInitialLoadingReturnedSuccess(
     LoadProjectsAndInstancesResult initial_load_result) {
-  CHECK(ui_->projectComboBox->count() == 0);
+  ORBIT_CHECK(ui_->projectComboBox->count() == 0);
 
   // From here on the projectComboBox is filled. To not trigger currentIndexChanged signals, the
   // signals of projectComboBox are blocked until the end of this function.
@@ -169,7 +169,7 @@ void RetrieveInstancesWidget::OnInitialLoadingReturnedSuccess(
 void RetrieveInstancesWidget::OnInstancesLoadingReturned(
     const ErrorMessageOr<QVector<Instance>>& loading_result) {
   if (loading_result.has_error()) {
-    ERROR("instance loading returned with error: %s", loading_result.error().message());
+    ORBIT_ERROR("instance loading returned with error: %s", loading_result.error().message());
     QMessageBox::critical(this, QCoreApplication::applicationName(),
                           QString::fromStdString(loading_result.error().message()));
     emit LoadingFailed();

--- a/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidgetDemo/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
   QCoreApplication::setApplicationName(kApplicationName);
 
   ErrorMessageOr<std::unique_ptr<Client>> client_or_error = orbit_ggp::CreateClient();
-  FAIL_IF(client_or_error.has_error(), "%s", client_or_error.error().message());
+  ORBIT_FAIL_IF(client_or_error.has_error(), "%s", client_or_error.error().message());
   Client* client_ptr = client_or_error.value().get();
 
   std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor{

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -85,8 +85,8 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
       state_local_processes_loading_(&state_local_connected_),
       state_local_process_selected_(&state_local_connected_),
       state_local_no_process_selected_(&state_local_connected_) {
-  CHECK(ssh_connection_artifacts != nullptr);
-  CHECK(metrics_uploader_ != nullptr);
+  ORBIT_CHECK(ssh_connection_artifacts != nullptr);
+  ORBIT_CHECK(metrics_uploader_ != nullptr);
 
   ui_->setupUi(this);
   ui_->stadiaWidget->SetMetricsUploader(metrics_uploader);
@@ -193,7 +193,7 @@ std::optional<TargetConfiguration> SessionSetupDialog::Exec() {
   } else if (state_machine_.configuration().contains(&state_file_)) {
     return FileTarget(selected_file_path_);
   } else {
-    UNREACHABLE();
+    ORBIT_UNREACHABLE();
     return std::nullopt;
   }
 }
@@ -206,7 +206,7 @@ void SessionSetupDialog::ProcessSelectionChanged(const QModelIndex& current) {
     return;
   }
 
-  CHECK(current.data(Qt::UserRole).canConvert<const ProcessInfo*>());
+  ORBIT_CHECK(current.data(Qt::UserRole).canConvert<const ProcessInfo*>());
   process_ = std::make_unique<orbit_client_data::ProcessData>(
       *current.data(Qt::UserRole).value<const ProcessInfo*>());
   emit ProcessSelected();
@@ -278,8 +278,8 @@ void SessionSetupDialog::SetupStadiaStates() {
   state_stadia_process_selected_.addTransition(this, &SessionSetupDialog::NoProcessSelected,
                                                &state_stadia_no_process_selected_);
   QObject::connect(&state_stadia_process_selected_, &QState::entered, this, [this] {
-    CHECK(process_ != nullptr);
-    CHECK(ui_->stadiaWidget->GetSelectedInstance().has_value());
+    ORBIT_CHECK(process_ != nullptr);
+    ORBIT_CHECK(ui_->stadiaWidget->GetSelectedInstance().has_value());
     ui_->targetLabel->ChangeToStadiaTarget(*process_,
                                            ui_->stadiaWidget->GetSelectedInstance().value());
   });
@@ -354,7 +354,7 @@ void SessionSetupDialog::SetupLocalStates() {
   state_local_process_selected_.addTransition(this, &SessionSetupDialog::NoProcessSelected,
                                               &state_local_no_process_selected_);
   QObject::connect(&state_local_process_selected_, &QState::entered, this, [this] {
-    CHECK(process_ != nullptr);
+    ORBIT_CHECK(process_ != nullptr);
     ui_->targetLabel->ChangeToLocalTarget(*process_);
   });
   QObject::connect(&state_local_process_selected_, &QState::exited, ui_->targetLabel,
@@ -403,7 +403,7 @@ void SessionSetupDialog::TearDownProcessManager() {
 }
 
 void SessionSetupDialog::SetupProcessManager(const std::shared_ptr<grpc::Channel>& grpc_channel) {
-  CHECK(grpc_channel != nullptr);
+  ORBIT_CHECK(grpc_channel != nullptr);
 
   if (process_manager_ != nullptr) return;
 
@@ -460,7 +460,7 @@ void SessionSetupDialog::OnProcessListUpdate(
     if (process_ != nullptr) {
       bool success = TrySelectProcessByName(process_->name());
       if (success) {
-        LOG("Selected remembered process with name: %s", process_->name());
+        ORBIT_LOG("Selected remembered process with name: %s", process_->name());
         return;
       }
     }
@@ -468,8 +468,8 @@ void SessionSetupDialog::OnProcessListUpdate(
     if (!absl::GetFlag(FLAGS_process_name).empty()) {
       bool success = TrySelectProcessByName(absl::GetFlag(FLAGS_process_name));
       if (success) {
-        LOG("Selected process with name: %s (provided via --process_name flag)",
-            absl::GetFlag(FLAGS_process_name));
+        ORBIT_LOG("Selected process with name: %s (provided via --process_name flag)",
+                  absl::GetFlag(FLAGS_process_name));
         accept();
         return;
       }

--- a/src/SessionSetup/SessionSetupUtils.cpp
+++ b/src/SessionSetup/SessionSetupUtils.cpp
@@ -22,10 +22,10 @@ orbit_ssh::Credentials CredentialsFromSshInfo(const orbit_ggp::SshInfo& ssh_info
 
 std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port) {
   std::string grpc_server_address = absl::StrFormat("127.0.0.1:%d", port);
-  LOG("Starting gRPC channel to: %s", grpc_server_address);
+  ORBIT_LOG("Starting gRPC channel to: %s", grpc_server_address);
   std::shared_ptr<grpc::Channel> result = grpc::CreateCustomChannel(
       grpc_server_address, grpc::InsecureChannelCredentials(), grpc::ChannelArguments());
-  CHECK(result != nullptr);
+  ORBIT_CHECK(result != nullptr);
   return result;
 }
 

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -239,7 +239,7 @@ void TargetLabel::OpenContainingFolder() {
   if (!file_path_.has_value()) return;
   QUrl url = QUrl::fromLocalFile(QString::fromStdString(file_path_->parent_path().string()));
   if (!QDesktopServices::openUrl(url)) {
-    ERROR("Opening containing folder of \"%s\"", file_path_->string());
+    ORBIT_ERROR("Opening containing folder of \"%s\"", file_path_->string());
   }
 }
 

--- a/src/SessionSetup/include/SessionSetup/Connections.h
+++ b/src/SessionSetup/include/SessionSetup/Connections.h
@@ -37,8 +37,8 @@ class SshConnectionArtifacts {
       : ssh_context_(ssh_context),
         grpc_port_(grpc_port),
         deployment_configuration_(deployment_configuration) {
-    CHECK(ssh_context != nullptr);
-    CHECK(deployment_configuration != nullptr);
+    ORBIT_CHECK(ssh_context != nullptr);
+    ORBIT_CHECK(deployment_configuration != nullptr);
   }
 
   [[nodiscard]] const orbit_ssh::Context* GetSshContext() const { return ssh_context_; }
@@ -70,8 +70,8 @@ class StadiaConnection {
       : instance_(std::move(instance)),
         service_deploy_manager_(std::move(service_deploy_manager)),
         grpc_channel_(std::move(grpc_channel)) {
-    CHECK(service_deploy_manager_ != nullptr);
-    CHECK(grpc_channel_ != nullptr);
+    ORBIT_CHECK(service_deploy_manager_ != nullptr);
+    ORBIT_CHECK(grpc_channel_ != nullptr);
   }
   [[nodiscard]] const orbit_ggp::Instance& GetInstance() const { return instance_; }
   [[nodiscard]] ServiceDeployManager* GetServiceDeployManager() const {
@@ -97,7 +97,7 @@ class LocalConnection {
  public:
   explicit LocalConnection(std::shared_ptr<grpc::Channel>&& grpc_channel)
       : grpc_channel_(std::move(grpc_channel)) {
-    CHECK(grpc_channel_ != nullptr);
+    ORBIT_CHECK(grpc_channel_ != nullptr);
   }
   [[nodiscard]] const std::shared_ptr<grpc::Channel>& GetGrpcChannel() const {
     return grpc_channel_;

--- a/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
+++ b/src/SessionSetup/include/SessionSetup/RetrieveInstancesWidget.h
@@ -36,7 +36,7 @@ class RetrieveInstancesWidget : public QWidget {
   }
   void SetMetricsUploader(orbit_metrics_uploader::MetricsUploader* metrics_uploader) {
     metrics_uploader_ = metrics_uploader;
-    CHECK(retrieve_instances_ != nullptr);
+    ORBIT_CHECK(retrieve_instances_ != nullptr);
     retrieve_instances_->SetMetricsUploader(metrics_uploader);
   }
 

--- a/src/SessionSetup/include/SessionSetup/TargetConfiguration.h
+++ b/src/SessionSetup/include/SessionSetup/TargetConfiguration.h
@@ -27,8 +27,8 @@ class StadiaTarget {
       : connection_(std::move(connection)),
         process_manager_(std::move(process_manager)),
         process_(std::move(process)) {
-    CHECK(process_manager_ != nullptr);
-    CHECK(process_ != nullptr);
+    ORBIT_CHECK(process_manager_ != nullptr);
+    ORBIT_CHECK(process_ != nullptr);
   }
   [[nodiscard]] const StadiaConnection* GetConnection() const { return &connection_; }
   [[nodiscard]] orbit_client_services::ProcessManager* GetProcessManager() const {
@@ -59,8 +59,8 @@ class LocalTarget {
       : connection_(connection),
         process_manager_(std::move(process_manager)),
         process_(std::move(process)) {
-    CHECK(process_manager_ != nullptr);
-    CHECK(process_ != nullptr);
+    ORBIT_CHECK(process_manager_ != nullptr);
+    ORBIT_CHECK(process_ != nullptr);
   }
   [[nodiscard]] const LocalConnection* GetConnection() const { return &connection_; }
   [[nodiscard]] orbit_client_services::ProcessManager* GetProcessManager() const {

--- a/src/SourcePathsMapping/Mapping.cpp
+++ b/src/SourcePathsMapping/Mapping.cpp
@@ -20,7 +20,7 @@ static bool IsRegularFile(const std::filesystem::path& target_path) {
   std::error_code error{};
   if (fs::is_regular_file(target_path, error)) return true;
   if (error.value() != 0) {
-    ERROR("Failed to 'stat' the file \"%s\": %s", target_path.string(), error.message());
+    ORBIT_ERROR("Failed to 'stat' the file \"%s\": %s", target_path.string(), error.message());
   }
   return false;
 }

--- a/src/SourcePathsMapping/MappingItemModel.cpp
+++ b/src/SourcePathsMapping/MappingItemModel.cpp
@@ -34,8 +34,8 @@ Qt::ItemFlags MappingItemModel::flags(const QModelIndex& index) const {
 }
 
 QVariant MappingItemModel::data(const QModelIndex& index, int role) const {
-  CHECK(index.model() == this);
-  CHECK(index.row() < static_cast<int>(mappings_.size()));
+  ORBIT_CHECK(index.model() == this);
+  ORBIT_CHECK(index.row() < static_cast<int>(mappings_.size()));
 
   const auto& mapping = mappings_.at(index.row());
 
@@ -64,8 +64,8 @@ QVariant MappingItemModel::headerData(int section, Qt::Orientation orientation, 
 
 bool MappingItemModel::moveRows(const QModelIndex& source_parent, int source_row, int count,
                                 const QModelIndex& destination_parent, int destination_child) {
-  CHECK(!source_parent.isValid());
-  CHECK(!destination_parent.isValid());
+  ORBIT_CHECK(!source_parent.isValid());
+  ORBIT_CHECK(!destination_parent.isValid());
   // We don't have to support moving more than a single row.
   if (count != 1) return false;
 
@@ -99,8 +99,8 @@ bool MappingItemModel::RemoveRows(int row, int count, const QModelIndex& parent)
 }
 
 bool MappingItemModel::setData(const QModelIndex& idx, const QVariant& value, int role) {
-  CHECK(idx.isValid());
-  CHECK(idx.model() == this);
+  ORBIT_CHECK(idx.isValid());
+  ORBIT_CHECK(idx.model() == this);
 
   if (role != Qt::EditRole) return false;
   if (!value.canConvert<Mapping>()) return false;

--- a/src/SourcePathsMapping/MappingManager.cpp
+++ b/src/SourcePathsMapping/MappingManager.cpp
@@ -59,8 +59,8 @@ void InferAndAppendSourcePathsMapping(const std::filesystem::path& source_path,
   std::optional<orbit_source_paths_mapping::Mapping> maybe_mapping =
       orbit_source_paths_mapping::InferMappingFromExample(source_path, target_path);
   if (!maybe_mapping.has_value()) {
-    ERROR("Unable to infer a mapping from \"%s\" to \"%s\"", source_path.string(),
-          target_path.string());
+    ORBIT_ERROR("Unable to infer a mapping from \"%s\" to \"%s\"", source_path.string(),
+                target_path.string());
     return;
   }
 

--- a/src/StringManager/StringManager.cpp
+++ b/src/StringManager/StringManager.cpp
@@ -17,7 +17,7 @@ bool StringManager::AddIfNotPresent(uint64_t key, std::string_view str) {
   absl::MutexLock lock{&mutex_};
   bool inserted = key_to_string_.emplace(key, str).second;
   if (!inserted) {
-    ERROR("String collision for key: %u and string: %s", key, str);
+    ORBIT_ERROR("String collision for key: %u and string: %s", key, str);
   }
   return inserted;
 }

--- a/src/TracepointService/TracepointServiceImpl.cpp
+++ b/src/TracepointService/TracepointServiceImpl.cpp
@@ -14,7 +14,7 @@ namespace orbit_tracepoint_service {
 grpc::Status TracepointServiceImpl::GetTracepointList(grpc::ServerContext* /*context*/,
                                                       const GetTracepointListRequest* /*request*/,
                                                       GetTracepointListResponse* response) {
-  LOG("Sending tracepoints");
+  ORBIT_LOG("Sending tracepoints");
 
   const auto tracepoint_infos = ReadTracepoints();
   if (tracepoint_infos.has_error()) {

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -26,7 +26,7 @@ using orbit_base::ReadFileToString;
 [[nodiscard]] ErrorMessageOr<std::vector<uint8_t>> ReadTraceesMemory(pid_t pid,
                                                                      uint64_t start_address,
                                                                      uint64_t length) {
-  CHECK(length != 0);
+  ORBIT_CHECK(length != 0);
 
   OUTCOME_TRY(auto&& fd, orbit_base::OpenFileForReading(absl::StrFormat("/proc/%d/mem", pid)));
 
@@ -44,7 +44,7 @@ using orbit_base::ReadFileToString;
 
 [[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t start_address,
                                                       const std::vector<uint8_t>& bytes) {
-  CHECK(!bytes.empty());
+  ORBIT_CHECK(!bytes.empty());
 
   OUTCOME_TRY(auto&& fd, orbit_base::OpenFileForWriting(absl::StrFormat("/proc/%d/mem", pid)));
 

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -37,13 +37,13 @@ AddressRange AddressRangeFromString(const std::string& string_address) {
   AddressRange result;
   const std::vector<std::string> addresses = absl::StrSplit(string_address, '-');
   if (addresses.size() != 2) {
-    FATAL("Not an address range: %s", string_address);
+    ORBIT_FATAL("Not an address range: %s", string_address);
   }
   if (!absl::numbers_internal::safe_strtou64_base(addresses[0], &result.start, 16)) {
-    FATAL("Not a number: %s", addresses[0]);
+    ORBIT_FATAL("Not a number: %s", addresses[0]);
   }
   if (!absl::numbers_internal::safe_strtou64_base(addresses[1], &result.end, 16)) {
-    FATAL("Not a number: %s", addresses[1]);
+    ORBIT_FATAL("Not a number: %s", addresses[1]);
   }
   return result;
 }
@@ -78,7 +78,7 @@ TEST(AccessTraceesMemoryTest, ReadFailures) {
   */
 
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -91,10 +91,10 @@ TEST(AccessTraceesMemoryTest, ReadFailures) {
   }
 
   // Stop the child process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   auto continuous_range_or_error = GetFirstContinuousAddressRange(pid);
-  CHECK(continuous_range_or_error.has_value());
+  ORBIT_CHECK(continuous_range_or_error.has_value());
   const auto continuous_range = continuous_range_or_error.value();
   const uint64_t address = continuous_range.start;
 
@@ -121,7 +121,7 @@ TEST(AccessTraceesMemoryTest, ReadFailures) {
   EXPECT_THAT(result, HasError("Input/output error"));
 
   // Detach and end child.
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);
 }
@@ -132,7 +132,7 @@ TEST(AccessTraceesMemoryTest, WriteFailures) {
   */
 
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -145,10 +145,10 @@ TEST(AccessTraceesMemoryTest, WriteFailures) {
   }
 
   // Stop the child process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   auto continuous_range_or_error = GetFirstContinuousAddressRange(pid);
-  CHECK(continuous_range_or_error.has_value());
+  ORBIT_CHECK(continuous_range_or_error.has_value());
   const auto continuous_range = continuous_range_or_error.value();
   const uint64_t address = continuous_range.start;
 
@@ -157,7 +157,7 @@ TEST(AccessTraceesMemoryTest, WriteFailures) {
 
   // Backup.
   auto backup = ReadTraceesMemory(pid, address, length);
-  CHECK(backup.has_value());
+  ORBIT_CHECK(backup.has_value());
 
   // Good write.
   std::vector<uint8_t> bytes(length, 0);
@@ -182,15 +182,15 @@ TEST(AccessTraceesMemoryTest, WriteFailures) {
   EXPECT_THAT(result, HasError("Input/output error"));
 
   // Restore, detach and end child.
-  CHECK(!WriteTraceesMemory(pid, address, backup.value()).has_error());
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!WriteTraceesMemory(pid, address, backup.value()).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);
 }
 
 TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -203,10 +203,10 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   }
 
   // Stop the child process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   auto memory_region_or_error = GetExistingExecutableMemoryRegion(pid);
-  CHECK(memory_region_or_error.has_value());
+  ORBIT_CHECK(memory_region_or_error.has_value());
   const uint64_t address = memory_region_or_error.value().start;
 
   constexpr uint64_t kMemorySize = 4 * 1024;
@@ -226,8 +226,8 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   EXPECT_EQ(new_data, read_back_or_error.value());
 
   // Restore, detach and end child.
-  CHECK(WriteTraceesMemory(pid, address, backup.value()).has_value());
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(WriteTraceesMemory(pid, address, backup.value()).has_value());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);
 }

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -116,12 +116,13 @@ namespace {
   // Clean up memory and registers.
   auto restore_memory_result = WriteTraceesMemory(pid, start_address, backup_or_error.value());
   if (restore_memory_result.has_error()) {
-    FATAL("Unable to restore memory state of tracee: %s", restore_memory_result.error().message());
+    ORBIT_FATAL("Unable to restore memory state of tracee: %s",
+                restore_memory_result.error().message());
   }
   restore_registers_result = original_registers.RestoreRegisters();
   if (restore_registers_result.has_error()) {
-    FATAL("Unable to restore register state of tracee: %s",
-          restore_registers_result.error().message());
+    ORBIT_FATAL("Unable to restore register state of tracee: %s",
+                restore_registers_result.error().message());
   }
 
   return result;
@@ -152,8 +153,8 @@ ErrorMessageOr<std::unique_ptr<MemoryInTracee>> MemoryInTracee::Create(pid_t pid
 
   if (address != 0 && result->GetAddress() != address) {
     auto free_memory_result = result->Free();
-    FAIL_IF(free_memory_result.has_error(), "Unable to free previously allocated memory: %s",
-            free_memory_result.error().message());
+    ORBIT_FAIL_IF(free_memory_result.has_error(), "Unable to free previously allocated memory: %s",
+                  free_memory_result.error().message());
     return ErrorMessage(
         absl::StrFormat("MemoryInTracee wanted to allocate memory at %#x but got memory at a "
                         "different address: %#x. The memory has been freed again.",
@@ -239,8 +240,8 @@ ErrorMessageOr<std::unique_ptr<AutomaticMemoryInTracee>> AutomaticMemoryInTracee
 
   if (address != 0 && result->GetAddress() != address) {
     auto free_memory_result = result->Free();
-    FAIL_IF(free_memory_result.has_error(), "Unable to free previously allocated memory: %s",
-            free_memory_result.error().message());
+    ORBIT_FAIL_IF(free_memory_result.has_error(), "Unable to free previously allocated memory: %s",
+                  free_memory_result.error().message());
     return ErrorMessage(absl::StrFormat(
         "AutomaticMemoryInTracee wanted to allocate memory at %#x but got memory at a "
         "different address: %#x. The memory has been freed again.",
@@ -254,7 +255,7 @@ AutomaticMemoryInTracee::~AutomaticMemoryInTracee() {
   if (pid_ == -1) return;  // Freed manually already.
   auto result = Free();
   if (result.has_error()) {
-    ERROR("Unable to free memory in tracee: %s", result.error().message());
+    ORBIT_ERROR("Unable to free memory in tracee: %s", result.error().message());
   }
 }
 

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -37,7 +37,7 @@ enum class ProtState { kWrite, kExec, kAny };
 // segment at `address`.
 [[nodiscard]] bool ProcessHasMapAtAddress(pid_t pid, uint64_t address, ProtState state) {
   auto maps_or_error = ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
-  CHECK(maps_or_error.has_value());
+  ORBIT_CHECK(maps_or_error.has_value());
   std::vector<std::string> lines = absl::StrSplit(maps_or_error.value(), '\n', absl::SkipEmpty());
   for (const auto& line : lines) {
     std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
@@ -71,7 +71,7 @@ enum class ProtState { kWrite, kExec, kAny };
 
 TEST(AllocateInTraceeTest, AllocateAndFree) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -84,7 +84,7 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
   }
 
   // Stop the process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   // Allocation fails for invalid process.
   constexpr uint64_t kMemorySize = 1024 * 1024;
@@ -109,9 +109,9 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
 
   // Allocate a megabyte at a low memory position.
   auto mmap_min_addr_or_error = ReadFileToString("/proc/sys/vm/mmap_min_addr");
-  CHECK(mmap_min_addr_or_error.has_value());
+  ORBIT_CHECK(mmap_min_addr_or_error.has_value());
   uint64_t mmap_min_addr = 0;
-  CHECK(absl::SimpleAtoi(mmap_min_addr_or_error.value(), &mmap_min_addr));
+  ORBIT_CHECK(absl::SimpleAtoi(mmap_min_addr_or_error.value(), &mmap_min_addr));
   my_memory_or_error = MemoryInTracee::Create(pid, mmap_min_addr, kMemorySize);
   ASSERT_THAT(my_memory_or_error, HasNoError());
   auto my_memory = std::move(my_memory_or_error.value());
@@ -131,14 +131,14 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
   EXPECT_FALSE(ProcessHasMapAtAddress(pid, address, ProtState::kAny));
 
   // Detach and end child.
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);
 }
 
 TEST(AllocateInTraceeTest, AutomaticAllocateAndFree) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -151,7 +151,7 @@ TEST(AllocateInTraceeTest, AutomaticAllocateAndFree) {
   }
 
   // Stop the process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   constexpr uint64_t kMemorySize = 1024 * 1024;
   uint64_t address = 0;
@@ -165,7 +165,7 @@ TEST(AllocateInTraceeTest, AutomaticAllocateAndFree) {
   EXPECT_FALSE(ProcessHasMapAtAddress(pid, address, ProtState::kAny));
 
   // Detach and end child.
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);
 }

--- a/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
@@ -31,7 +31,7 @@ class ExecuteInProcessTest : public testing::Test {
  protected:
   ExecuteInProcessTest() {
     pid_ = fork();
-    CHECK(pid_ != -1);
+    ORBIT_CHECK(pid_ != -1);
     if (pid_ == 0) {
       prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -42,22 +42,22 @@ class ExecuteInProcessTest : public testing::Test {
       }
     }
 
-    CHECK(!AttachAndStopProcess(pid_).has_error());
+    ORBIT_CHECK(!AttachAndStopProcess(pid_).has_error());
 
     auto library_path_or_error = GetTestLibLibraryPath();
-    CHECK(library_path_or_error.has_value());
+    ORBIT_CHECK(library_path_or_error.has_value());
     std::filesystem::path library_path = std::move(library_path_or_error.value());
 
     // Load dynamic lib into tracee.
     auto library_handle_or_error = DlopenInTracee(pid_, library_path, RTLD_NOW);
-    CHECK(library_handle_or_error.has_value());
+    ORBIT_CHECK(library_handle_or_error.has_value());
     library_handle_ = library_handle_or_error.value();
   }
 
   ~ExecuteInProcessTest() override {
     // Cleanup, detach and end child.
-    CHECK(!DlcloseInTracee(pid_, library_handle_).has_error());
-    CHECK(!DetachAndContinueProcess(pid_).has_error());
+    ORBIT_CHECK(!DlcloseInTracee(pid_, library_handle_).has_error());
+    ORBIT_CHECK(!DetachAndContinueProcess(pid_).has_error());
     kill(pid_, SIGKILL);
     waitpid(pid_, nullptr, 0);
   }

--- a/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
@@ -24,7 +24,7 @@ using orbit_test_utils::HasNoError;
 
 TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -36,13 +36,13 @@ TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
   }
 
   // Stop the child process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   {
     // Allocate a small chunk of memory.
     constexpr uint64_t kScratchPadSize = 1024;
     auto memory_or_error = AutomaticMemoryInTracee::Create(pid, 0, kScratchPadSize);
-    CHECK(memory_or_error.has_value());
+    ORBIT_CHECK(memory_or_error.has_value());
     auto memory = std::move(memory_or_error.value());
 
     // This code moves a constant into rax and enters a breakpoint. The value in rax is interpreted
@@ -57,7 +57,7 @@ TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
   }
 
   // Cleanup, end child process.
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);
 }

--- a/src/UserSpaceInstrumentation/FindFunctionAddressTest.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddressTest.cpp
@@ -17,7 +17,7 @@ namespace orbit_user_space_instrumentation {
 
 TEST(FindFunctionAddressTest, FindFunctionAddress) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -29,7 +29,7 @@ TEST(FindFunctionAddressTest, FindFunctionAddress) {
   }
 
   // Stop the child process using our tooling.
-  CHECK(AttachAndStopProcess(pid).has_value());
+  ORBIT_CHECK(AttachAndStopProcess(pid).has_value());
 
   auto function_address_or_error = FindFunctionAddress(pid, "libc.so.6", "printf");
   ASSERT_TRUE(function_address_or_error.has_value()) << function_address_or_error.error().message();
@@ -50,7 +50,7 @@ TEST(FindFunctionAddressTest, FindFunctionAddress) {
       absl::StrContains(function_address_or_error.error().message(), "Unable to open file"));
 
   // Detach and end child.
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);
 }

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -75,7 +75,7 @@ ErrorMessageOr<ino_t> GetInodeFromFilePath(const std::string& file_path) {
 
 void OpenUseAndCloseLibrary(pid_t pid) {
   // Stop the child process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   auto library_path_or_error = GetTestLibLibraryPath();
   ASSERT_THAT(library_path_or_error, HasNoError());
@@ -128,14 +128,14 @@ void OpenUseAndCloseLibrary(pid_t pid) {
   EXPECT_THAT(IsInodeInMapsFile(inode_of_library.value(), pid),
               orbit_test_utils::HasValue(Eq(false)));
 
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
 }
 
 }  // namespace
 
 TEST(InjectLibraryInTraceeTest, OpenUseAndCloseLibraryInUserCode) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -155,7 +155,7 @@ TEST(InjectLibraryInTraceeTest, OpenUseAndCloseLibraryInUserCode) {
 
 TEST(InjectLibraryInTraceeTest, OpenUseAndCloseLibraryInSyscall) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -174,7 +174,7 @@ TEST(InjectLibraryInTraceeTest, OpenUseAndCloseLibraryInSyscall) {
 
 TEST(InjectLibraryInTraceeTest, NonExistingLibrary) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -185,7 +185,7 @@ TEST(InjectLibraryInTraceeTest, NonExistingLibrary) {
   }
 
   // Stop the child process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   // Try to load non existing dynamic lib into tracee.
   const std::string kNonExistingLibName = "libNotFound.so";
@@ -193,7 +193,7 @@ TEST(InjectLibraryInTraceeTest, NonExistingLibrary) {
   ASSERT_THAT(library_handle_or_error, HasError("Library does not exist at"));
 
   // Continue child process.
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
 
   // End child process.
   kill(pid, SIGKILL);

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -88,7 +88,7 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
   }
 
   const pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -101,7 +101,7 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
 
   // We spawn another child and wait for it to trace `pid`. Then we can't attach.
   const pid_t pid_tracer = fork();
-  CHECK(pid_tracer != -1);
+  ORBIT_CHECK(pid_tracer != -1);
   if (pid_tracer == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -115,7 +115,7 @@ TEST(InstrumentProcessTest, FailToInstrumentAlreadyAttached) {
   bool already_tracing = false;
   while (!already_tracing) {
     auto tracer_pid_or_error = orbit_base::GetTracerPidOfProcess(pid);
-    CHECK(!tracer_pid_or_error.has_error());
+    ORBIT_CHECK(!tracer_pid_or_error.has_error());
     already_tracing = tracer_pid_or_error.value() != 0;
   }
 
@@ -174,7 +174,7 @@ TEST(InstrumentProcessTest, Instrument) {
   InstrumentationManager* instrumentation_manager = GetInstrumentationManager();
 
   const pid_t pid_process_1 = fork();
-  CHECK(pid_process_1 != -1);
+  ORBIT_CHECK(pid_process_1 != -1);
   if (pid_process_1 == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -202,7 +202,7 @@ TEST(InstrumentProcessTest, Instrument) {
   // Just do the same thing with another process to trigger the code path deleting the data for the
   // first. Also Instrument / Uninstrument repeatedly.
   const pid_t pid_process_2 = fork();
-  CHECK(pid_process_2 != -1);
+  ORBIT_CHECK(pid_process_2 != -1);
   if (pid_process_2 == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -238,7 +238,7 @@ TEST(InstrumentProcessTest, GetErrorMessage) {
   InstrumentationManager* instrumentation_manager = GetInstrumentationManager();
 
   const pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 

--- a/src/UserSpaceInstrumentation/RegisterState.cpp
+++ b/src/UserSpaceInstrumentation/RegisterState.cpp
@@ -93,7 +93,7 @@ ErrorMessageOr<void> RegisterState::BackupRegisters(pid_t tid) {
   } else if (iov.iov_len == sizeof(GeneralPurposeRegisters64)) {
     bitness_ = Bitness::k64Bit;
   } else {
-    FATAL("Bitness is neither 32 or 64 bit.");
+    ORBIT_FATAL("Bitness is neither 32 or 64 bit.");
   }
 
   auto xsave_area_size = GetXSaveAreaSize();
@@ -120,7 +120,7 @@ ErrorMessageOr<void> RegisterState::BackupRegisters(pid_t tid) {
 
 ErrorMessageOr<void> RegisterState::RestoreRegisters() {
   // BackupRegisters needs to be called before RestoreRegisters.
-  CHECK(tid_ != -1);
+  ORBIT_CHECK(tid_ != -1);
 
   iovec iov;
   iov.iov_base = &general_purpose_registers_;

--- a/src/UserSpaceInstrumentation/RegisterStateTest.cpp
+++ b/src/UserSpaceInstrumentation/RegisterStateTest.cpp
@@ -23,7 +23,7 @@ using orbit_test_utils::HasError;
 // registers and verifies the modifications done by the parent. The exit code indicates the outcome
 // of that verification.
 void Child() {
-  CHECK(ptrace(PTRACE_TRACEME, 0, nullptr, 0) != -1);
+  ORBIT_CHECK(ptrace(PTRACE_TRACEME, 0, nullptr, 0) != -1);
 
   uint64_t rax = 0xaabbccdd;
   std::array<uint8_t, 32> avx_bytes;
@@ -60,7 +60,7 @@ void Child() {
 
 TEST(RegisterStateTest, BackupModifyRestore) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     Child();
   }
@@ -68,9 +68,9 @@ TEST(RegisterStateTest, BackupModifyRestore) {
   // Wait for child to break.
   int status = 0;
   pid_t waited = waitpid(pid, &status, 0);
-  CHECK(waited == pid);
-  CHECK(WIFSTOPPED(status));
-  CHECK(WSTOPSIG(status) == SIGTRAP);
+  ORBIT_CHECK(waited == pid);
+  ORBIT_CHECK(WIFSTOPPED(status));
+  ORBIT_CHECK(WSTOPSIG(status) == SIGTRAP);
 
   // Read child's registers and check values.
   RegisterState state;
@@ -94,12 +94,12 @@ TEST(RegisterStateTest, BackupModifyRestore) {
   EXPECT_TRUE(state.RestoreRegisters().has_value());
 
   // Continue child.
-  CHECK(ptrace(PT_CONTINUE, pid, 1, 0) == 0);
+  ORBIT_CHECK(ptrace(PT_CONTINUE, pid, 1, 0) == 0);
 
   // Wait for the child to exit. Exit status is zero if the modified registers could be verified.
   waited = waitpid(pid, &status, 0);
-  CHECK(waited == pid);
-  CHECK(WIFEXITED(status));
+  ORBIT_CHECK(waited == pid);
+  ORBIT_CHECK(WIFEXITED(status));
   EXPECT_EQ(WEXITSTATUS(status), 0);
 
   // After the process exited we get errors when backing up / restoring registers.

--- a/src/UserSpaceInstrumentation/TestUtils.cpp
+++ b/src/UserSpaceInstrumentation/TestUtils.cpp
@@ -38,7 +38,7 @@ static ErrorMessageOr<AddressRange> FindFunctionAbsoluteAddressInModule(
 
 AddressRange GetFunctionAbsoluteAddressRangeOrDie(std::string_view function_name) {
   auto modules_or_error = orbit_object_utils::ReadModules(getpid());
-  CHECK(!modules_or_error.has_error());
+  ORBIT_CHECK(!modules_or_error.has_error());
   auto& modules = modules_or_error.value();
 
   // We check the main module first because it's most likely to find the function there.
@@ -61,7 +61,7 @@ AddressRange GetFunctionAbsoluteAddressRangeOrDie(std::string_view function_name
     if (result.has_value()) return result.value();
   }
 
-  FATAL("GetFunctionAbsoluteAddressRangeOrDie hasn't found a function '%s'", function_name);
+  ORBIT_FATAL("GetFunctionAbsoluteAddressRangeOrDie hasn't found a function '%s'", function_name);
 }
 
 static ErrorMessageOr<AddressRange> FindFunctionRelativeAddressInModule(
@@ -79,7 +79,7 @@ static ErrorMessageOr<AddressRange> FindFunctionRelativeAddressInModule(
 
 FunctionLocation FindFunctionOrDie(std::string_view function_name) {
   auto modules_or_error = orbit_object_utils::ReadModules(getpid());
-  CHECK(!modules_or_error.has_error());
+  ORBIT_CHECK(!modules_or_error.has_error());
   auto& modules = modules_or_error.value();
 
   // We check the main module first because it's most likely to find the function there.
@@ -97,16 +97,16 @@ FunctionLocation FindFunctionOrDie(std::string_view function_name) {
     auto result = FindFunctionRelativeAddressInModule(function_name, module.file_path());
     if (result.has_value()) return FunctionLocation{module.file_path(), result.value()};
   }
-  FATAL("FindFunctionOrDie hasn't found a function '%s'", function_name);
+  ORBIT_FATAL("FindFunctionOrDie hasn't found a function '%s'", function_name);
 }
 
 void DumpDisassembly(const std::vector<uint8_t>& code, uint64_t start_address) {
   // Init Capstone disassembler.
   csh capstone_handle = 0;
   cs_err error_code = cs_open(CS_ARCH_X86, CS_MODE_64, &capstone_handle);
-  CHECK(error_code == CS_ERR_OK);
+  ORBIT_CHECK(error_code == CS_ERR_OK);
   error_code = cs_option(capstone_handle, CS_OPT_DETAIL, CS_OPT_ON);
-  CHECK(error_code == CS_ERR_OK);
+  ORBIT_CHECK(error_code == CS_ERR_OK);
   orbit_base::unique_resource close_on_exit{
       &capstone_handle, [](csh* capstone_handle) { cs_close(capstone_handle); }};
 
@@ -121,11 +121,11 @@ void DumpDisassembly(const std::vector<uint8_t>& code, uint64_t start_address) {
           absl::StrCat(machine_code, j == 0 ? absl::StrFormat("%#0.2x", instruction[i].bytes[j])
                                             : absl::StrFormat(" %0.2x", instruction[i].bytes[j]));
     }
-    LOG("%#x:\t%-12s %s , %s", instruction[i].address, instruction[i].mnemonic,
-        instruction[i].op_str, machine_code);
+    ORBIT_LOG("%#x:\t%-12s %s , %s", instruction[i].address, instruction[i].mnemonic,
+              instruction[i].op_str, machine_code);
   }
   // Print out the next offset, after the last instruction.
-  LOG("%#x:", instruction[i - 1].address + instruction[i - 1].size);
+  ORBIT_LOG("%#x:", instruction[i - 1].address + instruction[i - 1].size);
   cs_free(instruction, count);
 }
 

--- a/src/UserSpaceInstrumentation/TestUtilsTest.cpp
+++ b/src/UserSpaceInstrumentation/TestUtilsTest.cpp
@@ -33,7 +33,7 @@ extern "C" int SomethingToDisassemble() {
 
 TEST(TestUtilTest, Disassemble) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ORBIT_CHECK(pid != -1);
   if (pid == 0) {
     prctl(PR_SET_PDEATHSIG, SIGTERM);
 
@@ -46,16 +46,16 @@ TEST(TestUtilTest, Disassemble) {
   }
 
   // Stop the child process using our tooling.
-  CHECK(!AttachAndStopProcess(pid).has_error());
+  ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   constexpr const char* kFunctionName = "SomethingToDisassemble";
   const AddressRange range = GetFunctionAbsoluteAddressRangeOrDie(kFunctionName);
   auto function_code_or_error = ReadTraceesMemory(pid, range.start, range.end - range.start);
-  CHECK(!function_code_or_error.has_error());
+  ORBIT_CHECK(!function_code_or_error.has_error());
 
   DumpDisassembly(function_code_or_error.value(), range.start);
 
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  ORBIT_CHECK(!DetachAndContinueProcess(pid).has_error());
 
   // End child process.
   kill(pid, SIGKILL);

--- a/src/WindowsCaptureService/TracingHandler.cpp
+++ b/src/WindowsCaptureService/TracingHandler.cpp
@@ -21,16 +21,16 @@ using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::kWindowsTracingProducerId;
 
 void TracingHandler::Start(CaptureOptions capture_options) {
-  CHECK(tracer_ == nullptr);
+  ORBIT_CHECK(tracer_ == nullptr);
   tracer_ = orbit_windows_tracing::Tracer::Create(std::move(capture_options), this);
   tracer_->Start();
 }
 
 void TracingHandler::Stop() {
-  CHECK(tracer_ != nullptr);
+  ORBIT_CHECK(tracer_ != nullptr);
   tracer_->Stop();
   tracer_.reset();
-  LOG("Windows TracingHandler stopped: ETW tracing is done");
+  ORBIT_LOG("Windows TracingHandler stopped: ETW tracing is done");
 }
 
 void TracingHandler::OnSchedulingSlice(SchedulingSlice scheduling_slice) {

--- a/src/WindowsTracing/ContextSwitchManager.cpp
+++ b/src/WindowsTracing/ContextSwitchManager.cpp
@@ -36,7 +36,7 @@ void ContextSwitchManager::ProcessContextSwitch(uint16_t cpu, uint32_t old_tid, 
     return;
   }
 
-  CHECK(new_context_switch.timestamp_ns >= last_context_switch->timestamp_ns);
+  ORBIT_CHECK(new_context_switch.timestamp_ns >= last_context_switch->timestamp_ns);
 
   if (last_context_switch->new_tid == new_context_switch.old_tid) {
     orbit_grpc_protos::SchedulingSlice scheduling_slice;
@@ -64,14 +64,14 @@ void ContextSwitchManager::ProcessContextSwitch(uint16_t cpu, uint32_t old_tid, 
 }
 
 void ContextSwitchManager::OutputStats() {
-  LOG("--- ContextSwitchManager stats ---");
-  LOG("Number of processed cpu events: %u", stats_.num_processed_cpu_events_);
-  LOG("Number of processed thread events: %u", stats_.num_processed_thread_events_);
-  LOG("Number of thread mismatches: %u", stats_.num_tid_mismatches_);
-  LOG("Number of scheduling slices: %u", stats_.num_scheduling_slices);
-  LOG("Number of scheduling slices with invalid pid: %u",
-      stats_.num_scheduling_slices_with_invalid_pid);
-  LOG("Number of unique tids without pid: %u", stats_.tid_witout_pid_set_.size());
+  ORBIT_LOG("--- ContextSwitchManager stats ---");
+  ORBIT_LOG("Number of processed cpu events: %u", stats_.num_processed_cpu_events_);
+  ORBIT_LOG("Number of processed thread events: %u", stats_.num_processed_thread_events_);
+  ORBIT_LOG("Number of thread mismatches: %u", stats_.num_tid_mismatches_);
+  ORBIT_LOG("Number of scheduling slices: %u", stats_.num_scheduling_slices);
+  ORBIT_LOG("Number of scheduling slices with invalid pid: %u",
+            stats_.num_scheduling_slices_with_invalid_pid);
+  ORBIT_LOG("Number of unique tids without pid: %u", stats_.tid_witout_pid_set_.size());
 }
 
 }  // namespace orbit_windows_tracing

--- a/src/WindowsTracing/KrabsTracer.cpp
+++ b/src/WindowsTracing/KrabsTracer.cpp
@@ -60,13 +60,13 @@ void KrabsTracer::EnableProviders() {
 
 void KrabsTracer::SetIsSystemProfilePrivilegeEnabled(bool value) {
   auto result = orbit_windows_utils::AdjustTokenPrivilege(SE_SYSTEM_PROFILE_NAME, value);
-  if (result.has_error()) ERROR("%s", result.error().message());
+  if (result.has_error()) ORBIT_ERROR("%s", result.error().message());
 }
 
 void KrabsTracer::SetupStackTracing() {
   // Set sampling frequency for ETW trace. Note that the session handle must be 0.
   const double frequency = capture_options_.samples_per_second();
-  CHECK(frequency >= 0);
+  ORBIT_CHECK(frequency >= 0);
   if (frequency == 0) return;
   double period_ns = 1'000'000'000.0 / frequency;
   static uint64_t performance_counter_period_ns = orbit_base::GetPerformanceCounterPeriodNs();
@@ -74,7 +74,7 @@ void KrabsTracer::SetupStackTracing() {
   interval.Interval = static_cast<ULONG>(period_ns / performance_counter_period_ns);
   ULONG status = TraceSetInformation(/*SessionHandle=*/0, TraceSampledProfileIntervalInfo,
                                      (void*)&interval, sizeof(TRACE_PROFILE_INTERVAL));
-  CHECK(status == ERROR_SUCCESS);
+  ORBIT_CHECK(status == ERROR_SUCCESS);
 
   // Initialize ETW stack tracing. Note that this must be executed after trace_.open() as
   // set_trace_information needs a valid session handle.
@@ -85,7 +85,7 @@ void KrabsTracer::SetupStackTracing() {
 }
 
 void KrabsTracer::Start() {
-  CHECK(trace_thread_ == nullptr);
+  ORBIT_CHECK(trace_thread_ == nullptr);
   context_switch_manager_ = std::make_unique<ContextSwitchManager>(listener_);
   SetIsSystemProfilePrivilegeEnabled(true);
   trace_.open();
@@ -94,7 +94,7 @@ void KrabsTracer::Start() {
 }
 
 void KrabsTracer::Stop() {
-  CHECK(trace_thread_ != nullptr && trace_thread_->joinable());
+  ORBIT_CHECK(trace_thread_ != nullptr && trace_thread_->joinable());
   trace_.stop();
   trace_thread_->join();
   trace_thread_ = nullptr;
@@ -157,12 +157,12 @@ void KrabsTracer::OnStackWalkEvent(const EVENT_RECORD& record,
 
   // Get callstack addresses. The first address is at offset 16, see stackwalk-event doc above.
   constexpr uint32_t kStackDataOffset = 16;
-  CHECK(record.UserDataLength >= kStackDataOffset);
+  ORBIT_CHECK(record.UserDataLength >= kStackDataOffset);
   const uint8_t* buffer_start = absl::bit_cast<uint8_t*>(record.UserData);
   const uint8_t* buffer_end = buffer_start + record.UserDataLength;
   const uint8_t* stack_data = buffer_start + kStackDataOffset;
   uint32_t depth = (buffer_end - stack_data) / sizeof(void*);
-  CHECK(stack_data + depth * sizeof(void*) == buffer_end);
+  ORBIT_CHECK(stack_data + depth * sizeof(void*) == buffer_end);
 
   FullCallstackSample sample;
   sample.set_pid(pid);
@@ -182,17 +182,17 @@ void KrabsTracer::OnStackWalkEvent(const EVENT_RECORD& record,
 
 void KrabsTracer::OutputStats() {
   krabs::trace_stats trace_stats = trace_.query_stats();
-  LOG("--- ETW stats ---");
-  LOG("Number of buffers: %u", trace_stats.buffersCount);
-  LOG("Free buffers: %u", trace_stats.buffersFree);
-  LOG("Buffers written: %u", trace_stats.buffersWritten);
-  LOG("Buffers lost: %u", trace_stats.buffersLost);
-  LOG("Events total (handled+lost): %u", trace_stats.eventsTotal);
-  LOG("Events handled: %u", trace_stats.eventsHandled);
-  LOG("Events lost: %u", trace_stats.eventsLost);
-  LOG("--- KrabsTracer stats ---");
-  LOG("Number of stack events: %u", stats_.num_stack_events);
-  LOG("Number of stack events for target pid: %u", stats_.num_stack_events_for_target_pid);
+  ORBIT_LOG("--- ETW stats ---");
+  ORBIT_LOG("Number of buffers: %u", trace_stats.buffersCount);
+  ORBIT_LOG("Free buffers: %u", trace_stats.buffersFree);
+  ORBIT_LOG("Buffers written: %u", trace_stats.buffersWritten);
+  ORBIT_LOG("Buffers lost: %u", trace_stats.buffersLost);
+  ORBIT_LOG("Events total (handled+lost): %u", trace_stats.eventsTotal);
+  ORBIT_LOG("Events handled: %u", trace_stats.eventsHandled);
+  ORBIT_LOG("Events lost: %u", trace_stats.eventsLost);
+  ORBIT_LOG("--- KrabsTracer stats ---");
+  ORBIT_LOG("Number of stack events: %u", stats_.num_stack_events);
+  ORBIT_LOG("Number of stack events for target pid: %u", stats_.num_stack_events_for_target_pid);
   context_switch_manager_->OutputStats();
 }
 

--- a/src/WindowsTracing/TracerImpl.cpp
+++ b/src/WindowsTracing/TracerImpl.cpp
@@ -23,7 +23,7 @@ TracerImpl::TracerImpl(orbit_grpc_protos::CaptureOptions capture_options, Tracer
     : capture_options_(std::move(capture_options)), listener_(listener) {}
 
 void TracerImpl::Start() {
-  CHECK(krabs_tracer_ == nullptr);
+  ORBIT_CHECK(krabs_tracer_ == nullptr);
   SendModulesSnapshot();
   SendThreadNamesSnapshot();
   krabs_tracer_ = std::make_unique<KrabsTracer>(capture_options_, listener_);
@@ -31,7 +31,7 @@ void TracerImpl::Start() {
 }
 
 void TracerImpl::Stop() {
-  CHECK(krabs_tracer_ != nullptr);
+  ORBIT_CHECK(krabs_tracer_ != nullptr);
   krabs_tracer_->Stop();
   krabs_tracer_ = nullptr;
 }
@@ -44,7 +44,7 @@ void TracerImpl::SendModulesSnapshot() {
 
   std::vector<Module> modules = orbit_windows_utils::ListModules(pid);
   if (modules.empty()) {
-    ERROR("Unable to load modules for %u", pid);
+    ORBIT_ERROR("Unable to load modules for %u", pid);
     return;
   }
 
@@ -67,7 +67,7 @@ void TracerImpl::SendThreadNamesSnapshot() {
 
   std::vector<Thread> threads = orbit_windows_utils::ListAllThreads();
   if (threads.empty()) {
-    ERROR("Unable to list threads");
+    ORBIT_ERROR("Unable to list threads");
     return;
   }
 

--- a/src/WindowsUtils/DllInjection.cpp
+++ b/src/WindowsUtils/DllInjection.cpp
@@ -133,7 +133,7 @@ ErrorMessageOr<void> EnsureModuleIsNotAlreadyLoaded(uint32_t pid, std::string_vi
 
 ErrorMessageOr<void> InjectDll(uint32_t pid, std::filesystem::path dll_path) {
   const std::string dll_name = dll_path.string();
-  SCOPED_TIMED_LOG("Injecting dll \"%s\" in process %u", dll_name, pid);
+  ORBIT_SCOPED_TIMED_LOG("Injecting dll \"%s\" in process %u", dll_name, pid);
 
   OUTCOME_TRY(ValidatePath(dll_path));
   OUTCOME_TRY(EnsureModuleIsNotAlreadyLoaded(pid, dll_path.filename().string()));
@@ -145,7 +145,7 @@ ErrorMessageOr<void> InjectDll(uint32_t pid, std::filesystem::path dll_path) {
   constexpr uint32_t kNumRetries = 10;
   OUTCOME_TRY(Module module, FindModuleWithRetries(pid, dll_path.filename().string(), kNumRetries));
 
-  LOG("Module \"%s\" successfully injected in process %u", dll_name, pid);
+  ORBIT_LOG("Module \"%s\" successfully injected in process %u", dll_name, pid);
   return outcome::success();
 }
 

--- a/src/WindowsUtils/FindDebugSymbols.cpp
+++ b/src/WindowsUtils/FindDebugSymbols.cpp
@@ -73,7 +73,7 @@ ErrorMessageOr<std::filesystem::path> FindDebugSymbols(
     ErrorMessageOr<bool> file_exists = orbit_base::FileExists(search_path);
 
     if (file_exists.has_error()) {
-      ERROR("%s", file_exists.error().message());
+      ORBIT_ERROR("%s", file_exists.error().message());
       error_messages.emplace_back(file_exists.error().message());
       continue;
     }

--- a/src/WindowsUtils/ListModules.cpp
+++ b/src/WindowsUtils/ListModules.cpp
@@ -30,7 +30,7 @@ std::vector<Module> ListModules(uint32_t pid) {
   // Take a snapshot of all modules in the specified process.
   module_snap_handle = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
   if (module_snap_handle == INVALID_HANDLE_VALUE) {
-    ERROR("Calling CreateToolhelp32Snapshot for modules");
+    ORBIT_ERROR("Calling CreateToolhelp32Snapshot for modules");
     return {};
   }
   orbit_base::unique_resource handle{module_snap_handle, ::CloseHandle};
@@ -38,7 +38,7 @@ std::vector<Module> ListModules(uint32_t pid) {
   // Retrieve information about the first module.
   module_entry.dwSize = sizeof(MODULEENTRY32);
   if (!Module32First(module_snap_handle, &module_entry)) {
-    ERROR("Calling Module32First for pid %u", pid);
+    ORBIT_ERROR("Calling Module32First for pid %u", pid);
     return {};
   }
 
@@ -54,7 +54,8 @@ std::vector<Module> ListModules(uint32_t pid) {
     if (coff_file_or_error.has_value()) {
       build_id = coff_file_or_error.value()->GetBuildId();
     } else {
-      ERROR("Could not create Coff file for module \"%s\", build-id will be empty", module_path);
+      ORBIT_ERROR("Could not create Coff file for module \"%s\", build-id will be empty",
+                  module_path);
     }
 
     Module& module = modules.emplace_back();

--- a/src/WindowsUtils/ListModulesTest.cpp
+++ b/src/WindowsUtils/ListModulesTest.cpp
@@ -26,7 +26,7 @@ static std::string GetCurrentModuleName() {
   HMODULE module_handle = NULL;
   GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)GetCurrentModuleName,
                     &module_handle);
-  CHECK(module_handle);
+  ORBIT_CHECK(module_handle);
   char module_name[MAX_PATH] = {0};
   GetModuleFileNameA(module_handle, module_name, MAX_PATH);
   return module_name;

--- a/src/WindowsUtils/ListThreads.cpp
+++ b/src/WindowsUtils/ListThreads.cpp
@@ -28,7 +28,7 @@ std::vector<Thread> ListThreads(uint32_t pid) {
   uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   thread_snap_handle = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
   if (thread_snap_handle == INVALID_HANDLE_VALUE) {
-    ERROR("Calling CreateToolhelp32Snapshot for threads");
+    ORBIT_ERROR("Calling CreateToolhelp32Snapshot for threads");
     return {};
   }
   orbit_base::unique_resource handle{thread_snap_handle, ::CloseHandle};
@@ -36,7 +36,7 @@ std::vector<Thread> ListThreads(uint32_t pid) {
   // Retrieve information about the first thread.
   thread_entry.dwSize = sizeof(THREADENTRY32);
   if (!Thread32First(thread_snap_handle, &thread_entry)) {
-    ERROR("Calling Thread32First for pid %u", pid);
+    ORBIT_ERROR("Calling Thread32First for pid %u", pid);
     return {};
   }
 

--- a/src/WindowsUtils/ProcessList.cpp
+++ b/src/WindowsUtils/ProcessList.cpp
@@ -38,8 +38,8 @@ namespace {
   if (IsWow64Process(process_handle, &is_32_bit_process_on_64_bit_os) != 0) {
     return is_32_bit_process_on_64_bit_os != TRUE;
   }
-  ERROR("Calling IsWow64Process for pid %u: %s", GetProcessId(process_handle),
-        orbit_base::GetLastErrorAsString());
+  ORBIT_ERROR("Calling IsWow64Process for pid %u: %s", GetProcessId(process_handle),
+              orbit_base::GetLastErrorAsString());
   return std::nullopt;
 }
 
@@ -58,7 +58,7 @@ namespace {
 [[nodiscard]] inline uint64_t FileTimeDiffNs(FILETIME file_time_0, FILETIME file_time_1) {
   uint64_t t_0 = FiletimeToUint64(file_time_0);
   uint64_t t_1 = FiletimeToUint64(file_time_1);
-  CHECK(t_1 >= t_0);
+  ORBIT_CHECK(t_1 >= t_0);
   constexpr uint64_t kIntervalNs = 100;
   return (t_1 - t_0) * kIntervalNs;
 }
@@ -160,8 +160,8 @@ ErrorMessageOr<void> ProcessListImpl::Refresh() {
       if (handle == nullptr) {
         // "System" processes cannot be opened, track errors to skip further OpenProcess calls.
         process_info.open_process_error = ::GetLastError();
-        ERROR("Calling OpenProcess for %s[%u]: %s", process_name, pid,
-              orbit_base::GetLastErrorAsString());
+        ORBIT_ERROR("Calling OpenProcess for %s[%u]: %s", process_name, pid,
+                    orbit_base::GetLastErrorAsString());
       } else {
         std::optional<bool> result = Is64Bit(handle);
         if (result.has_value()) {
@@ -170,7 +170,7 @@ ErrorMessageOr<void> ProcessListImpl::Refresh() {
 
         DWORD buffer_size = sizeof(full_path);
         if (QueryFullProcessImageNameA(handle, 0, full_path, &buffer_size) == 0) {
-          ERROR("Calling GetModuleFileNameExA for pid %u", pid);
+          ORBIT_ERROR("Calling GetModuleFileNameExA for pid %u", pid);
         }
       }
 
@@ -214,8 +214,8 @@ void ProcessListImpl::UpdateCpuUsage() {
 
     if (process_handle == nullptr) {
       process_info.open_process_error = ::GetLastError();
-      ERROR("Calling OpenProcess for %s[%u]: %s", process.name, pid,
-            orbit_base::GetLastErrorAsString());
+      ORBIT_ERROR("Calling OpenProcess for %s[%u]: %s", process.name, pid,
+                  orbit_base::GetLastErrorAsString());
       continue;
     }
 
@@ -225,8 +225,8 @@ void ProcessListImpl::UpdateCpuUsage() {
     FILETIME user_file_time = {};
     if (GetProcessTimes(process_handle, &creation_file_time, &exit_file_time, &kernel_file_time,
                         &user_file_time) == FALSE) {
-      ERROR("Calling GetProcessTimes for %s[%u]: %s", process.name, process.pid,
-            orbit_base::GetLastErrorAsString());
+      ORBIT_ERROR("Calling GetProcessTimes for %s[%u]: %s", process.name, process.pid,
+                  orbit_base::GetLastErrorAsString());
       continue;
     }
 
@@ -253,7 +253,7 @@ std::unique_ptr<ProcessList> ProcessList::Create() {
   auto process_list = std::make_unique<ProcessListImpl>();
   ErrorMessageOr<void> result = process_list->Refresh();
   if (result.has_error()) {
-    ERROR("Refreshing process list: %s", result.error().message());
+    ORBIT_ERROR("Refreshing process list: %s", result.error().message());
   }
   return std::move(process_list);
 }

--- a/third_party/VulkanTutorial/OffscreenRenderingVulkanTutorial.cpp
+++ b/third_party/VulkanTutorial/OffscreenRenderingVulkanTutorial.cpp
@@ -11,7 +11,7 @@
 #include "VulkanTutorialFragmentShader.h"
 #include "VulkanTutorialVertexShader.h"
 
-#define CHECK_VK_SUCCESS(call) CHECK((call) == VK_SUCCESS)
+#define CHECK_VK_SUCCESS(call) ORBIT_CHECK((call) == VK_SUCCESS)
 
 namespace orbit_vulkan_tutorial {
 
@@ -30,7 +30,7 @@ void OffscreenRenderingVulkanTutorial::StopAsync() {
 }
 
 void OffscreenRenderingVulkanTutorial::InitVulkan() {
-  LOG("InitVulkan");
+  ORBIT_LOG("InitVulkan");
   // To simplify our dependencies, we don't link to Vulkan, but we use volk instead:
   // https://github.com/zeux/volk
   CHECK_VK_SUCCESS(volkInitialize());
@@ -56,7 +56,7 @@ void OffscreenRenderingVulkanTutorial::InitVulkan() {
 }
 
 void OffscreenRenderingVulkanTutorial::MainLoop(uint64_t frame_count) {
-  LOG("MainLoop");
+  ORBIT_LOG("MainLoop");
   for (uint64_t frame = 0; frame < frame_count; ++frame) {
     absl::Time next_frame_time = absl::Now() + absl::Microseconds(16667);
     DrawFrame();
@@ -73,7 +73,7 @@ void OffscreenRenderingVulkanTutorial::MainLoop(uint64_t frame_count) {
 }
 
 void OffscreenRenderingVulkanTutorial::CleanUp() {
-  LOG("CleanUp");
+  ORBIT_LOG("CleanUp");
   vkDestroyFence(device_, fence_, nullptr);
   // Command buffers will be automatically freed when their command pool is destroyed, so we don't
   // need an explicit cleanup.
@@ -99,7 +99,7 @@ void OffscreenRenderingVulkanTutorial::CreateInstance() {
       .apiVersion = VK_API_VERSION_1_1,
   };
 
-  CHECK(AreValidationLayersSupported());
+  ORBIT_CHECK(AreValidationLayersSupported());
   VkInstanceCreateInfo create_info{
       .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
       .pApplicationInfo = &app_info,
@@ -142,7 +142,7 @@ bool OffscreenRenderingVulkanTutorial::AreValidationLayersSupported() {
 void OffscreenRenderingVulkanTutorial::PickPhysicalDevice() {
   uint32_t physical_device_count = 0;
   CHECK_VK_SUCCESS(vkEnumeratePhysicalDevices(instance_, &physical_device_count, nullptr));
-  CHECK(physical_device_count > 0);
+  ORBIT_CHECK(physical_device_count > 0);
 
   std::vector<VkPhysicalDevice> physical_devices(physical_device_count);
   vkEnumeratePhysicalDevices(instance_, &physical_device_count, physical_devices.data());
@@ -154,7 +154,7 @@ void OffscreenRenderingVulkanTutorial::PickPhysicalDevice() {
     }
   }
 
-  CHECK(physical_device_ != VK_NULL_HANDLE);
+  ORBIT_CHECK(physical_device_ != VK_NULL_HANDLE);
 }
 
 bool OffscreenRenderingVulkanTutorial::IsPhysicalDeviceSuitable(
@@ -243,8 +243,8 @@ void OffscreenRenderingVulkanTutorial::CreateOffscreenImage() {
     }
   }
 
-  CHECK(image_format_ != VkFormat::VK_FORMAT_UNDEFINED);
-  LOG("image_format_=%d", image_format_);
+  ORBIT_CHECK(image_format_ != VkFormat::VK_FORMAT_UNDEFINED);
+  ORBIT_LOG("image_format_=%d", image_format_);
   create_info.format = image_format_;
   CHECK_VK_SUCCESS(vkCreateImage(device_, &create_info, nullptr, &image_));
 
@@ -253,7 +253,7 @@ void OffscreenRenderingVulkanTutorial::CreateOffscreenImage() {
 
   VkMemoryRequirements memory_requirements{};
   vkGetImageMemoryRequirements(device_, image_, &memory_requirements);
-  CHECK(memory_requirements.memoryTypeBits != 0);
+  ORBIT_CHECK(memory_requirements.memoryTypeBits != 0);
 
   // "memoryTypeBits is a bitmask and contains one bit set for every supported memory type for the
   // resource. Bit i is set if and only if the memory type i in the
@@ -262,7 +262,7 @@ void OffscreenRenderingVulkanTutorial::CreateOffscreenImage() {
   // Since we don't have any requirement on the *properties* of the memory, simply choose the
   // lowest-indexed memory type.
   uint32_t memory_type_index = __builtin_ctz(memory_requirements.memoryTypeBits);
-  LOG("memory_type_index=%d", memory_type_index);
+  ORBIT_LOG("memory_type_index=%d", memory_type_index);
 
   VkMemoryAllocateInfo allocate_info{
       .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,


### PR DESCRIPTION
This applies what has been discussed in http://go/stadia-orbit-macro-names

- Rename LOG macro to ORBIT_LOG
- Rename ERROR macro to ORBIT_ERROR
- Rename LOG_ONCE macro to ORBIT_LOG_ONCE
- Rename ERROR_ONCE macro to ORBIT_ERROR_ONCE
- Rename FATAL macro to ORBIT_FATAL
- Rename UNREACHABLE macro to ORBIT_UNREACHABLE
- Rename LIKELY macro to ORBIT_LIKELY
- Rename UNLIKELY macro to ORBIT_UNLIKELY
- Rename FAIL_IF macro to ORBIT_FAIL_IF
- Rename CHECK macro to ORBIT_CHECK
- Rename DCHECK macro to ORBIT_DCHECK
- Rename SCOPED_TIMED_LOG_* macros to ORBIT_INTERNAL_SCOPED_TIMED_LOG_*
- Rename SCOPED_TIMED_LOG macro to ORBIT_SCOPED_TIMED_LOG
- Rename PLATFORM_LOG macro to ORBIT_INTERNAL_PLATFORM_LOG
- Rename PLATFORM_ABORT macro to ORBIT_INTERNAL_PLATFORM_ABORT