### PR TITLE
Add class for handling PE/COFF runtime functions in libunwindstack

### DIFF
--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -67,6 +67,8 @@ target_sources(libunwindstack_common PRIVATE
   Object.cpp
   PeCoff.cpp
   PeCoffInterface.cpp
+  PeCoffRuntimeFunctions.cpp
+  PeCoffRuntimeFunctions.h
   RegsArm64.cpp
   RegsArm.cpp
   Regs.cpp
@@ -249,6 +251,7 @@ target_sources(libunwindstack_tests PRIVATE
   tests/ObjectCacheTest.cpp
   tests/PeCoffInterfaceTest.cpp
   tests/PeCoffFake.cpp
+  tests/PeCoffRuntimeFunctionsTest.cpp
   tests/PeCoffTest.cpp
   tests/RegsInfoTest.cpp
   tests/RegsIterateTest.cpp

--- a/third_party/libunwindstack/PeCoffRuntimeFunctions.cpp
+++ b/third_party/libunwindstack/PeCoffRuntimeFunctions.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PeCoffRuntimeFunctions.h"
+
+namespace unwindstack {
+
+bool PeCoffRuntimeFunctions::Init(uint64_t pdata_begin, uint64_t pdata_end) {
+  // Since pdata_begin and pdata_end are read from the file, we can't CHECK here.
+  if (pdata_end < pdata_begin) {
+    return false;
+  }
+  const uint64_t pdata_size = pdata_end - pdata_begin;
+  if (pdata_size % sizeof(RuntimeFunction) != 0) {
+    return false;
+  }
+
+  runtime_functions_.resize(pdata_size / sizeof(RuntimeFunction));
+  pe_coff_memory_->set_cur_offset(pdata_begin);
+  return pe_coff_memory_->GetFully(static_cast<void*>(&runtime_functions_[0]), pdata_size);
+}
+
+// Binary search on the vector of runtime functions, which are guaranteed to be sorted per
+// Windows PE/COFF specification
+// (https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64). Using a binary search here
+// for performance makes a huge difference (as opposed to a linear search) as this function is
+// called on every unwinding step and there can be a lot of entries in the vector.
+bool PeCoffRuntimeFunctions::FindRuntimeFunction(uint64_t pc_rva,
+                                                 RuntimeFunction* runtime_function) const {
+  size_t begin = 0;
+  size_t end = runtime_functions_.size();
+  while (begin < end) {
+    size_t current = (begin + end) / 2;
+    const RuntimeFunction& function = runtime_functions_[current];
+    if (pc_rva >= function.start_address && pc_rva < function.end_address) {
+      *runtime_function = function;
+      return true;
+    }
+    if (function.start_address > pc_rva) {
+      end = current;
+    }
+    if (function.end_address <= pc_rva) {
+      begin = current + 1;
+    }
+  }
+  return false;
+}
+
+}  // namespace unwindstack

--- a/third_party/libunwindstack/PeCoffRuntimeFunctions.h
+++ b/third_party/libunwindstack/PeCoffRuntimeFunctions.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H
+#define _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H
+
+#include <unordered_map>
+#include <vector>
+
+#include "unwindstack/PeCoffInterface.h"
+
+namespace unwindstack {
+
+// Data as parsed from the RUNTIME_FUNCTION array.
+// https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=msvc-160#struct-runtime_function
+struct RuntimeFunction {
+  uint32_t start_address;
+  uint32_t end_address;
+  uint32_t unwind_info_offset;
+};
+
+// The RUNTIME_FUNCTION struct, and thus PeCoffRuntimeFunctions, is only used on x86_64.
+class PeCoffRuntimeFunctions {
+ public:
+  PeCoffRuntimeFunctions(PeCoffMemory* pe_coff_memory) : pe_coff_memory_(pe_coff_memory) {}
+
+  bool Init(uint64_t pdata_begin, uint64_t pdata_end);
+  bool FindRuntimeFunction(uint64_t pc_rva, RuntimeFunction* runtime_function) const;
+
+ private:
+  PeCoffMemory* pe_coff_memory_;
+
+  std::vector<RuntimeFunction> runtime_functions_;
+};
+
+}  // namespace unwindstack
+
+#endif  // _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H

--- a/third_party/libunwindstack/tests/PeCoffRuntimeFunctionsTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffRuntimeFunctionsTest.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unwindstack/PeCoffInterface.h>
+#include "PeCoffRuntimeFunctions.h"
+#include "utils/MemoryFake.h"
+
+#include <gtest/gtest.h>
+
+namespace unwindstack {
+
+class PeCoffRuntimeFunctionsTest : public ::testing::Test {
+ public:
+  PeCoffRuntimeFunctionsTest() : memory_fake_(new MemoryFake) {}
+  ~PeCoffRuntimeFunctionsTest() {}
+
+  uint64_t SetRuntimeFunctionAtOffset(uint64_t offset, uint32_t start, uint32_t end,
+                                      uint32_t unwind_info_offset) {
+    memory_fake_->SetData32(offset, start);
+    offset += sizeof(uint32_t);
+    memory_fake_->SetData32(offset, end);
+    offset += sizeof(uint32_t);
+    memory_fake_->SetData32(offset, unwind_info_offset);
+    offset += sizeof(uint32_t);
+    return offset;
+  }
+
+  MemoryFake* GetMemoryFake() { return memory_fake_.get(); }
+
+ private:
+  std::unique_ptr<MemoryFake> memory_fake_;
+};
+
+TEST_F(PeCoffRuntimeFunctionsTest, init_succeeds_on_well_formed_data) {
+  uint64_t offset = 0x5000;
+  offset = SetRuntimeFunctionAtOffset(offset, 0x100, 0x200, 0x6000);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x200, 0x300, 0x6100);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x300, 0x400, 0x6100);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  EXPECT_TRUE(runtime_functions.Init(0x5000, 0x5000 + 3 * 3 * sizeof(uint32_t)));
+}
+
+TEST_F(PeCoffRuntimeFunctionsTest, init_fails_due_to_bad_section_bounds) {
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  EXPECT_FALSE(runtime_functions.Init(0x5000, 0x4000));
+}
+
+TEST_F(PeCoffRuntimeFunctionsTest, init_fails_due_to_incongruent_section_bounds) {
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  EXPECT_FALSE(runtime_functions.Init(0x5000, 0x5004));
+}
+
+TEST_F(PeCoffRuntimeFunctionsTest, init_fails_due_to_bad_memory) {
+  GetMemoryFake()->SetData32(0x5000, 0x100);
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  EXPECT_FALSE(runtime_functions.Init(0x5000, 0x5000 + 3 * sizeof(uint32_t)));
+}
+
+TEST_F(PeCoffRuntimeFunctionsTest, find_function_at_the_start) {
+  uint64_t offset = 0x5000;
+  offset = SetRuntimeFunctionAtOffset(offset, 0x100, 0x200, 0x6000);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x200, 0x300, 0x6100);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x300, 0x400, 0x6200);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x400, 0x500, 0x6300);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x500, 0x600, 0x6400);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  ASSERT_TRUE(runtime_functions.Init(0x5000, 0x5000 + 5 * 3 * sizeof(uint32_t)));
+
+  RuntimeFunction function;
+  EXPECT_TRUE(runtime_functions.FindRuntimeFunction(0x112, &function));
+  EXPECT_EQ(0x100, function.start_address);
+  EXPECT_EQ(0x200, function.end_address);
+  EXPECT_EQ(0x6000, function.unwind_info_offset);
+}
+
+TEST_F(PeCoffRuntimeFunctionsTest, find_function_in_the_middle) {
+  uint64_t offset = 0x5000;
+  offset = SetRuntimeFunctionAtOffset(offset, 0x100, 0x200, 0x6000);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x200, 0x300, 0x6100);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x300, 0x400, 0x6200);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x400, 0x500, 0x6300);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x500, 0x600, 0x6400);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  ASSERT_TRUE(runtime_functions.Init(0x5000, 0x5000 + 5 * 3 * sizeof(uint32_t)));
+
+  RuntimeFunction function;
+  EXPECT_TRUE(runtime_functions.FindRuntimeFunction(0x304, &function));
+  EXPECT_EQ(0x300, function.start_address);
+  EXPECT_EQ(0x400, function.end_address);
+  EXPECT_EQ(0x6200, function.unwind_info_offset);
+}
+
+TEST_F(PeCoffRuntimeFunctionsTest, find_function_at_the_end) {
+  uint64_t offset = 0x5000;
+  offset = SetRuntimeFunctionAtOffset(offset, 0x100, 0x200, 0x6000);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x200, 0x300, 0x6100);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x300, 0x400, 0x6200);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x400, 0x500, 0x6300);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x500, 0x600, 0x6400);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  ASSERT_TRUE(runtime_functions.Init(0x5000, 0x5000 + 5 * 3 * sizeof(uint32_t)));
+
+  RuntimeFunction function;
+  EXPECT_TRUE(runtime_functions.FindRuntimeFunction(0x520, &function));
+  EXPECT_EQ(0x500, function.start_address);
+  EXPECT_EQ(0x600, function.end_address);
+  EXPECT_EQ(0x6400, function.unwind_info_offset);
+}
+
+TEST_F(PeCoffRuntimeFunctionsTest, fails_to_find_function_when_address_too_large) {
+  uint64_t offset = 0x5000;
+  offset = SetRuntimeFunctionAtOffset(offset, 0x100, 0x200, 0x6000);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x200, 0x300, 0x6100);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x300, 0x400, 0x6200);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x400, 0x500, 0x6300);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x500, 0x600, 0x6400);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  ASSERT_TRUE(runtime_functions.Init(0x5000, 0x5000 + 5 * 3 * sizeof(uint32_t)));
+
+  RuntimeFunction function;
+  EXPECT_FALSE(runtime_functions.FindRuntimeFunction(0x608, &function));
+}
+
+TEST_F(PeCoffRuntimeFunctionsTest, fails_to_find_function_when_address_too_small) {
+  uint64_t offset = 0x5000;
+  offset = SetRuntimeFunctionAtOffset(offset, 0x100, 0x200, 0x6000);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x200, 0x300, 0x6100);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x300, 0x400, 0x6200);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x400, 0x500, 0x6300);
+  offset = SetRuntimeFunctionAtOffset(offset, 0x500, 0x600, 0x6400);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
+  ASSERT_TRUE(runtime_functions.Init(0x5000, 0x5000 + 5 * 3 * sizeof(uint32_t)));
+
+  RuntimeFunction function;
+  EXPECT_FALSE(runtime_functions.FindRuntimeFunction(0x20, &function));
+}
+}  // namespace unwindstack


### PR DESCRIPTION
This change adds a class for parsing, storing, and finding PE/COFF
runtime functions (as stored in RUNTIME_FUNCTION structs in the PE/COFF
file). These structs represent the address ranges of functions in a
module, can be found in the .pdata section of a PE/COFF file, and
include a pointer to the unwind information for the represented
function.

It is critical to be able to retrieve a runtime function entry quickly
during an unwind step to look up the corresponding unwind information,
hence we add a binary search on the (guaranteed to be sorted) list of
runtime functions entries.

See https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64
for more on the RUNTIME_FUNCTION struct.

Tested: Unit tests.
Bug: http://b/194768602