### PR TITLE
[Rebase] Fix the crash in DataView::OnSort

### DIFF
--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -43,7 +43,7 @@ void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
     return;
   }
 
-  ORBIT_CHECK(column > 0);
+  ORBIT_CHECK(column >= 0);
   ORBIT_CHECK(static_cast<size_t>(column) < sorting_orders_.size());
 
   sorting_column_ = column;


### PR DESCRIPTION
This fixes the crashes when sorting data views on the first column.

Bug: http://b/215295249