### PR TITLE
Add automated test script for OrbitService's memory watchdog

### DIFF
--- a/contrib/automation_tests/orbit_memory_watchdog.py
+++ b/contrib/automation_tests/orbit_memory_watchdog.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture
+from test_cases.capture_window import CaptureAndWaitForInterruptedWarning
 from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
 """Test that OrbitService stops the capture when it is using too much memory.
 
@@ -33,8 +33,7 @@ def main(argv):
         FilterAndSelectFirstProcess(process_filter="call_foo_repeat"),
         LoadSymbols(module_search_string="call_foo_repeatedly"),
         FilterAndHookFunction(function_search_string="foo{(}{)}"),
-        Capture(user_space_instrumentation=True,
-                expect_interrupted_by_service=True)
+        CaptureAndWaitForInterruptedWarning(user_space_instrumentation=True)
     ]
     suite = E2ETestSuite(test_name="Memory watchdog", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/orbit_memory_watchdog.py
+++ b/contrib/automation_tests/orbit_memory_watchdog.py
@@ -1,0 +1,45 @@
+"""
+Copyright (c) 2022 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.capture_window import Capture
+from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
+"""Test that OrbitService stops the capture when it is using too much memory.
+
+Before this script is run there needs to be a gamelet reserved and
+"call_foo_repeatedly" (can be downloaded from GCS) needs to be started.
+
+The script requires absl and pywinauto. Since pywinauto requires the bitness of
+the python installation to match the bitness of the program under test, it needs
+to be run from 64 bit python.
+
+This automation script covers a basic workflow:
+ - connect to a gamelet and select a process;
+ - instrument a high-frequency function with user space instrumentation;
+ - start a long capture;
+ - verify that the capture gets stopped by OrbitService and that the corresponding warning is shown.
+"""
+
+
+def main(argv):
+    test_cases = [
+        ConnectToStadiaInstance(),
+        FilterAndSelectFirstProcess(process_filter="call_foo_repeat"),
+        LoadSymbols(module_search_string="call_foo_repeatedly"),
+        FilterAndHookFunction(function_search_string="foo{(}{)}"),
+        Capture(length_in_seconds=60,
+                user_space_instrumentation=True,
+                expect_interrupted_by_service=True)
+    ]
+    suite = E2ETestSuite(test_name="Memory watchdog", test_cases=test_cases)
+    suite.execute()
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/contrib/automation_tests/orbit_memory_watchdog.py
+++ b/contrib/automation_tests/orbit_memory_watchdog.py
@@ -33,8 +33,7 @@ def main(argv):
         FilterAndSelectFirstProcess(process_filter="call_foo_repeat"),
         LoadSymbols(module_search_string="call_foo_repeatedly"),
         FilterAndHookFunction(function_search_string="foo{(}{)}"),
-        Capture(length_in_seconds=60,
-                user_space_instrumentation=True,
+        Capture(user_space_instrumentation=True,
                 expect_interrupted_by_service=True)
     ]
     suite = E2ETestSuite(test_name="Memory watchdog", test_cases=test_cases)

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -357,6 +357,7 @@ class Capture(E2ETestCase):
         if expect_interrupted_by_service:
             self._verify_capture_interrupted()
         else:
+            time.sleep(length_in_seconds)
             logging.info('Stopping capture')
             toggle_capture_button.click_input()
             self._wait_for_capture_completion()


### PR DESCRIPTION
Bug: http://b/214164984

Test:
 - Ran the script locally.
 - Created nightly build and ran on the infrastructure:
   - `blaze test`: http://sponge2/e0df3991-3878-4596-a8d2-559cbbe14c9c
   - `guitar run`: http://fusion2/4101aa6d-b637-4c5b-b285-dce21f3e8869