### PR TITLE
Add class for handling PE/COFF unwind infos in libunwindstack

### DIFF
--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -69,6 +69,8 @@ target_sources(libunwindstack_common PRIVATE
   PeCoffInterface.cpp
   PeCoffRuntimeFunctions.cpp
   PeCoffRuntimeFunctions.h
+  PeCoffUnwindInfos.cpp
+  PeCoffUnwindInfos.h
   RegsArm64.cpp
   RegsArm.cpp
   Regs.cpp
@@ -252,6 +254,7 @@ target_sources(libunwindstack_tests PRIVATE
   tests/PeCoffInterfaceTest.cpp
   tests/PeCoffFake.cpp
   tests/PeCoffRuntimeFunctionsTest.cpp
+  tests/PeCoffUnwindInfosTest.cpp
   tests/PeCoffTest.cpp
   tests/RegsInfoTest.cpp
   tests/RegsIterateTest.cpp

--- a/third_party/libunwindstack/PeCoffRuntimeFunctions.h
+++ b/third_party/libunwindstack/PeCoffRuntimeFunctions.h
@@ -17,9 +17,9 @@
 #ifndef _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H
 #define _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H
 
-#include <unordered_map>
 #include <vector>
 
+#include "unwindstack/Error.h"
 #include "unwindstack/PeCoffInterface.h"
 
 namespace unwindstack {
@@ -35,13 +35,16 @@ struct RuntimeFunction {
 // The RUNTIME_FUNCTION struct, and thus PeCoffRuntimeFunctions, is only used on x86_64.
 class PeCoffRuntimeFunctions {
  public:
-  PeCoffRuntimeFunctions(PeCoffMemory* pe_coff_memory) : pe_coff_memory_(pe_coff_memory) {}
+  explicit PeCoffRuntimeFunctions(PeCoffMemory* pe_coff_memory) : pe_coff_memory_(pe_coff_memory) {}
 
   bool Init(uint64_t pdata_begin, uint64_t pdata_end);
   bool FindRuntimeFunction(uint64_t pc_rva, RuntimeFunction* runtime_function) const;
+  ErrorData GetLastError() const { return last_error_; }
 
  private:
   PeCoffMemory* pe_coff_memory_;
+
+  ErrorData last_error_{ERROR_NONE, 0};
 
   std::vector<RuntimeFunction> runtime_functions_;
 };

--- a/third_party/libunwindstack/PeCoffUnwindInfos.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PeCoffUnwindInfos.h"
+
+namespace unwindstack {
+
+bool PeCoffUnwindInfos::GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindInfo* unwind_info) {
+  const auto& it = unwind_info_offset_to_unwind_info_.find(unwind_info_file_offset);
+  if (it != unwind_info_offset_to_unwind_info_.end()) {
+    *unwind_info = it->second;
+    return true;
+  }
+
+  UnwindInfo new_unwind_info;
+  if (!ParseUnwindInfoAtOffset(unwind_info_file_offset, &new_unwind_info)) {
+    return false;
+  }
+
+  unwind_info_offset_to_unwind_info_[unwind_info_file_offset] = new_unwind_info;
+  *unwind_info = new_unwind_info;
+  return true;
+}
+
+bool PeCoffUnwindInfos::ParseUnwindInfoAtOffset(uint64_t offset, UnwindInfo* unwind_info) {
+  // Need to remember the original offset for later
+  const uint64_t base_offset = offset;
+
+  constexpr uint64_t kUnwindInfoHeaderSize = 4;
+  std::vector<uint8_t> data_info(kUnwindInfoHeaderSize);
+  pe_coff_memory_->set_cur_offset(offset);
+  if (!pe_coff_memory_->GetFully(static_cast<void*>(&data_info[0]), kUnwindInfoHeaderSize)) {
+    last_error_.code = ERROR_MEMORY_INVALID;
+    last_error_.address = offset;
+    return false;
+  }
+
+  unwind_info->version_and_flags = data_info[0];
+  unwind_info->prolog_size = data_info[1];
+  unwind_info->num_codes = data_info[2];
+  unwind_info->frame_register_and_offset = data_info[3];
+
+  // 0x01 is the only version that exists right now.
+  if (unwind_info->GetVersion() != 0x01) {
+    last_error_.code = ERROR_INVALID_COFF;
+    return false;
+  }
+
+  unwind_info->unwind_codes.resize(unwind_info->num_codes);
+  pe_coff_memory_->set_cur_offset(offset + kUnwindInfoHeaderSize);
+  if (!pe_coff_memory_->GetFully(static_cast<void*>(&unwind_info->unwind_codes[0]),
+                                 unwind_info->num_codes * sizeof(UnwindCode))) {
+    last_error_.code = ERROR_MEMORY_INVALID;
+    last_error_.address = pe_coff_memory_->cur_offset();
+    return false;
+  }
+
+  if (unwind_info->GetFlags() & 0x04) {  // Chained unwind info.
+    // For alignment purposes, the unwind codes array always has an even number of entries,
+    // with the last one potentially being unused (as indicated by num_codes). To find the
+    // chained function (which is a RUNTIME_FUNCTION struct), we therefore need to round
+    // the num_codes value to an even number. See also
+    // https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=msvc-170#chained-unwind-info-structures
+    // for the source of the expression used below.
+    const uint64_t runtime_function_offset =
+        base_offset + kUnwindInfoHeaderSize +
+        ((unwind_info->num_codes + 1) & ~1) * sizeof(UnwindCode);
+
+    pe_coff_memory_->set_cur_offset(runtime_function_offset);
+    if (!pe_coff_memory_->Get32(&(unwind_info->chained_info.start_address)) ||
+        !pe_coff_memory_->Get32(&(unwind_info->chained_info.end_address)) ||
+        !pe_coff_memory_->Get32(&(unwind_info->chained_info.unwind_info_offset))) {
+      last_error_.code = ERROR_MEMORY_INVALID;
+      last_error_.address = pe_coff_memory_->cur_offset();
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace unwindstack

--- a/third_party/libunwindstack/PeCoffUnwindInfos.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBUNWINDSTACK_PE_COFF_UNWIND_INFOS_H
+#define _LIBUNWINDSTACK_PE_COFF_UNWIND_INFOS_H
+
+#include <unordered_map>
+#include <vector>
+
+#include "PeCoffRuntimeFunctions.h"
+#include "unwindstack/Error.h"
+#include "unwindstack/PeCoffInterface.h"
+
+namespace unwindstack {
+
+union UnwindCode {
+  struct {
+    uint8_t code_offset;
+    uint8_t unwind_op_and_op_info;
+  } code_and_op;
+  uint16_t frame_offset;
+
+  uint8_t GetUnwindOp() const { return code_and_op.unwind_op_and_op_info & 0x0f; }
+  uint8_t GetOpInfo() const { return (code_and_op.unwind_op_and_op_info >> 4) & 0x0f; }
+};
+
+// Per specification, the size of each unwind code in the file is 2 bytes and we use
+// sizeof(UnwindCode) later when reading data from the file.
+static_assert(sizeof(UnwindCode) == 2);
+
+// Data as parsed from the UNWIND_INFO struct in a PE/COFF file, with convenience methods to access
+// data that is encoded as bit subsets of bytes.
+// https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=msvc-160#struct-unwind_info
+struct UnwindInfo {
+  // Low 3 bits are the version, other 5 bits are the flags.
+  uint8_t version_and_flags;
+  uint8_t prolog_size;
+  uint8_t num_codes;
+  // Low 4 bits frame register, second 4 bits frame register offset.
+  uint8_t frame_register_and_offset;
+  std::vector<UnwindCode> unwind_codes;
+
+  uint64_t exception_handler_address;
+  RuntimeFunction chained_info;
+
+  uint8_t GetVersion() const { return version_and_flags & 0x07; }
+  uint8_t GetFlags() const { return (version_and_flags >> 3) & 0x1f; }
+  uint8_t GetFrameRegister() const { return frame_register_and_offset & 0x0f; }
+  uint8_t GetFrameOffset() const { return (frame_register_and_offset >> 4) & 0x0f; }
+};
+
+class PeCoffUnwindInfos {
+ public:
+  explicit PeCoffUnwindInfos(PeCoffMemory* pe_coff_memory) : pe_coff_memory_(pe_coff_memory) {}
+
+  // The value 'unwind_info_file_offset' is the file offset derived from the unwind info
+  // offset in the RUNTIME_FUNCTION struct, which is a relative virtual address (RVA). Computing the
+  // file offset from the unwind info RVA requires knowledge about the sections of the file, which
+  // the class using 'PeCoffUnwindInfos' must use to pass in the right value here.
+  bool GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindInfo* unwind_info);
+  ErrorData GetLastError() const { return last_error_; }
+
+ private:
+  bool ParseUnwindInfoAtOffset(uint64_t file_offset, UnwindInfo* unwind_info);
+
+  PeCoffMemory* pe_coff_memory_;
+  ErrorData last_error_{ERROR_NONE, 0};
+
+  // This is a cache of unwind infos.
+  std::unordered_map<uint64_t, UnwindInfo> unwind_info_offset_to_unwind_info_;
+};
+
+}  // namespace unwindstack
+
+#endif  // _LIBUNWINDSTACK_PE_COFF_UNWIND_INFOS_H

--- a/third_party/libunwindstack/tests/PeCoffRuntimeFunctionsTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffRuntimeFunctionsTest.cpp
@@ -16,6 +16,7 @@
 
 #include <unwindstack/PeCoffInterface.h>
 #include "PeCoffRuntimeFunctions.h"
+#include "unwindstack/Error.h"
 #include "utils/MemoryFake.h"
 
 #include <gtest/gtest.h>
@@ -59,12 +60,14 @@ TEST_F(PeCoffRuntimeFunctionsTest, init_fails_due_to_bad_section_bounds) {
   PeCoffMemory pe_coff_memory(GetMemoryFake());
   PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
   EXPECT_FALSE(runtime_functions.Init(0x5000, 0x4000));
+  EXPECT_EQ(ERROR_INVALID_COFF, runtime_functions.GetLastError().code);
 }
 
 TEST_F(PeCoffRuntimeFunctionsTest, init_fails_due_to_incongruent_section_bounds) {
   PeCoffMemory pe_coff_memory(GetMemoryFake());
   PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
   EXPECT_FALSE(runtime_functions.Init(0x5000, 0x5004));
+  EXPECT_EQ(ERROR_INVALID_COFF, runtime_functions.GetLastError().code);
 }
 
 TEST_F(PeCoffRuntimeFunctionsTest, init_fails_due_to_bad_memory) {
@@ -72,6 +75,8 @@ TEST_F(PeCoffRuntimeFunctionsTest, init_fails_due_to_bad_memory) {
   PeCoffMemory pe_coff_memory(GetMemoryFake());
   PeCoffRuntimeFunctions runtime_functions(&pe_coff_memory);
   EXPECT_FALSE(runtime_functions.Init(0x5000, 0x5000 + 3 * sizeof(uint32_t)));
+  EXPECT_EQ(ERROR_MEMORY_INVALID, runtime_functions.GetLastError().code);
+  EXPECT_EQ(0x5000, runtime_functions.GetLastError().address);
 }
 
 TEST_F(PeCoffRuntimeFunctionsTest, find_function_at_the_start) {

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unwindstack/PeCoffInterface.h>
+#include "PeCoffUnwindInfos.h"
+#include "unwindstack/Error.h"
+#include "utils/MemoryFake.h"
+
+#include <gtest/gtest.h>
+
+namespace unwindstack {
+
+class PeCoffUnwindInfosTest : public ::testing::Test {
+ public:
+  PeCoffUnwindInfosTest() : memory_fake_(new MemoryFake) {}
+  ~PeCoffUnwindInfosTest() {}
+
+  uint64_t SetUnwindInfoHeaderAtOffset(uint64_t offset, uint8_t num_codes, bool chained) {
+    uint8_t flags = 0x00;
+    if (chained) {
+      // To get the flags, this value will be shifted right by 3. To get chained info,
+      // after shifting, this value must be 0x04.
+      flags = 0x20;
+    }
+    // Only version "1" is supported.
+    uint8_t version_and_flags = flags | 0x01;
+    memory_fake_->SetData8(offset, version_and_flags);
+    offset += sizeof(uint8_t);
+
+    // prolog_size, actual value doesn't matter for tests here.
+    memory_fake_->SetData8(offset, 0x20);
+    offset += sizeof(uint8_t);
+    memory_fake_->SetData8(offset, num_codes);
+    offset += sizeof(uint8_t);
+
+    // frame_register_and_offset, actual value doesn't matter for tests here.
+    memory_fake_->SetData8(offset, 0x22);
+    offset += sizeof(uint8_t);
+    return offset;
+  }
+  uint64_t SetUnwindOpCodeOrFrameOffsetAtOffset(uint64_t offset, uint16_t value) {
+    memory_fake_->SetData16(offset, value);
+    return offset + sizeof(uint16_t);
+  }
+
+  // Exception handler and chained info are  exclusive, only one of them can be present,
+  // if at all.
+  uint64_t SetExceptionHandlerOffsetAtOffset(uint64_t offset, uint64_t exception_handler_offset) {
+    memory_fake_->SetData64(offset, exception_handler_offset);
+    return offset + sizeof(uint64_t);
+  }
+
+  uint64_t SetChainedInfoOffsetAtOffset(uint64_t offset) {
+    // The PeCoffUnwindInfo class does not interpret chained infos, so it doesn't really
+    // matter what values we put here.
+    RuntimeFunction chained_function{0x100, 0x200, 0x6000};
+    memory_fake_->SetData32(offset, chained_function.start_address);
+    offset += sizeof(uint32_t);
+    memory_fake_->SetData32(offset, chained_function.end_address);
+    offset += sizeof(uint32_t);
+    memory_fake_->SetData32(offset, chained_function.unwind_info_offset);
+    offset += sizeof(uint32_t);
+    return offset;
+  }
+
+  MemoryFake* GetMemoryFake() { return memory_fake_.get(); }
+
+ private:
+  std::unique_ptr<MemoryFake> memory_fake_;
+};
+
+TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_on_well_formed_data_no_chained_info) {
+  uint64_t offset = 0x6000;
+  offset = SetUnwindInfoHeaderAtOffset(offset, 2, false);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_TRUE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_EQ(ERROR_NONE, unwind_infos.GetLastError().code);
+
+  EXPECT_EQ(2, unwind_info.num_codes);
+}
+
+TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_multiple_times) {
+  uint64_t offset = 0x6000;
+  offset = SetUnwindInfoHeaderAtOffset(offset, 2, false);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
+
+  offset = SetUnwindInfoHeaderAtOffset(offset, 4, false);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x5678);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x8765);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x8756);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x7658);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_TRUE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+
+  // This should read from the cache, though we don't verify that here. The returned
+  // data should be the same, though.
+  UnwindInfo unwind_info2;
+  EXPECT_TRUE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info2));
+
+  EXPECT_EQ(unwind_info.version_and_flags, unwind_info2.version_and_flags);
+  EXPECT_EQ(unwind_info.prolog_size, unwind_info2.prolog_size);
+  EXPECT_EQ(unwind_info.num_codes, unwind_info2.num_codes);
+  EXPECT_EQ(unwind_info.frame_register_and_offset, unwind_info2.frame_register_and_offset);
+}
+
+TEST_F(PeCoffUnwindInfosTest,
+       get_unwind_info_succeeds_on_well_formed_data_chained_info_even_number_of_opcodes) {
+  uint64_t offset = 0x6000;
+  offset = SetUnwindInfoHeaderAtOffset(offset, 2, true);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
+
+  offset = SetChainedInfoOffsetAtOffset(offset);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_TRUE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_EQ(ERROR_NONE, unwind_infos.GetLastError().code);
+
+  EXPECT_EQ(2, unwind_info.num_codes);
+}
+
+TEST_F(PeCoffUnwindInfosTest,
+       get_unwind_info_succeeds_on_well_formed_data_chained_info_odd_number_of_opcodes) {
+  uint64_t offset = 0x6000;
+  offset = SetUnwindInfoHeaderAtOffset(offset, 3, true);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x3124);
+  // Add padding, per specification.
+  GetMemoryFake()->SetData16(offset, 0x0000);
+  offset += sizeof(uint16_t);
+
+  offset = SetChainedInfoOffsetAtOffset(offset);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_TRUE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_EQ(ERROR_NONE, unwind_infos.GetLastError().code);
+
+  EXPECT_EQ(3, unwind_info.num_codes);
+}
+
+TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_with_exception_handler_data) {
+  uint64_t offset = 0x6000;
+  offset = SetUnwindInfoHeaderAtOffset(offset, 2, false);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
+  offset = SetExceptionHandlerOffsetAtOffset(offset, 0x8000);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_TRUE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_EQ(ERROR_NONE, unwind_infos.GetLastError().code);
+
+  EXPECT_EQ(2, unwind_info.num_codes);
+}
+
+TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_bad_version) {
+  uint64_t offset = 0x6000;
+  offset = SetUnwindInfoHeaderAtOffset(offset, 2, false);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
+
+  // Clobber the version with 0.
+  GetMemoryFake()->SetData8(0x6000, 0x00);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_FALSE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_EQ(ERROR_INVALID_COFF, unwind_infos.GetLastError().code);
+}
+
+TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_bad_memory) {
+  GetMemoryFake()->SetData8(0x6000, 0x1);
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_FALSE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos.GetLastError().code);
+
+  // We read the first 4 bytes with a GetFully, so we must fail on this address
+  // (and not 0x6001, which is the first missing address).
+  EXPECT_EQ(0x6000, unwind_infos.GetLastError().address);
+}
+
+TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_incomplete_op_codes_memory) {
+  uint64_t offset = 0x6000;
+  offset = SetUnwindInfoHeaderAtOffset(offset, 3, false);
+
+  // Since we are using GetFully to get all op codes in a single memory read, we
+  // expect the error on this offset.
+  const uint64_t expected_error_address = offset;
+
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_FALSE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos.GetLastError().code);
+  EXPECT_EQ(expected_error_address, unwind_infos.GetLastError().address);
+}
+
+TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_incomplete_chained_info) {
+  uint64_t offset = 0x6000;
+  offset = SetUnwindInfoHeaderAtOffset(offset, 2, true);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
+  offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
+
+  // We expect chained info but don't set it here, so getting the unwind info below
+  // must fail on this address.
+  const uint64_t expected_error_address = offset;
+
+  PeCoffMemory pe_coff_memory(GetMemoryFake());
+  PeCoffUnwindInfos unwind_infos(&pe_coff_memory);
+
+  UnwindInfo unwind_info;
+  EXPECT_FALSE(unwind_infos.GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos.GetLastError().code);
+  EXPECT_EQ(expected_error_address, unwind_infos.GetLastError().address);
+}
+
+}  // namespace unwindstack


### PR DESCRIPTION
We add a class PeCoffUnwindInfos that is used to parse and cache
unwind infos (as defined by the UNWIND_INFO struct) from PE/COFF object
files.

It is similar to the corresponding class for handling runtime
functions (RUNTIME_FUNCTION struct), with some minor differences: (1)
The section bounds are not passed in, as they are generally not known
for  unwind infos (runtime functions are always in the .pdata section,
we don't know this for unwind infos), (2) not all data is parsed
upfront, we parse on request and cache the entry (based on performance
tests in the prototype, this is the better approach here).

Some changes are made to PeCoffRuntimeFunctions* files for consistency
or because I noticed some smaller issues (like using 'explicit' on the
constructor and more info on errors).

Tested: Unit tests.
Bug: http://b/194768602