### PR TITLE
Enforce usage from the main thread on all of DataManager's methods

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(ClientData PUBLIC
 add_executable(ClientDataTests)
 target_sources(ClientDataTests PRIVATE
         CallstackDataTest.cpp
+        DataManagerTest.cpp
         FunctionInfoSetTest.cpp
         ModuleDataTest.cpp
         ModuleManagerTest.cpp

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -32,6 +32,11 @@ void DataManager::DeselectFunction(const FunctionInfo& function) {
   selected_functions_.erase(function);
 }
 
+void DataManager::ClearSelectedFunctions() {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  selected_functions_.clear();
+}
+
 void DataManager::set_visible_function_ids(absl::flat_hash_set<uint64_t> visible_function_ids) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   visible_function_ids_ = std::move(visible_function_ids);
@@ -52,6 +57,21 @@ void DataManager::set_selected_thread_id(uint32_t thread_id) {
   selected_thread_id_ = thread_id;
 }
 
+void DataManager::set_selected_timer(const orbit_client_protos::TimerInfo* timer_info) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  selected_timer_ = timer_info;
+}
+
+bool DataManager::IsFunctionSelected(const FunctionInfo& function) const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return selected_functions_.contains(function);
+}
+
+std::vector<FunctionInfo> DataManager::GetSelectedFunctions() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return {selected_functions_.begin(), selected_functions_.end()};
+}
+
 bool DataManager::IsFunctionVisible(uint64_t function_id) const {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return visible_function_ids_.contains(function_id);
@@ -67,7 +87,7 @@ uint64_t DataManager::highlighted_group_id() const {
   return highlighted_group_id_;
 }
 
-int32_t DataManager::selected_thread_id() const {
+uint32_t DataManager::selected_thread_id() const {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_thread_id_;
 }
@@ -77,28 +97,11 @@ const orbit_client_protos::TimerInfo* DataManager::selected_timer() const {
   return selected_timer_;
 }
 
-void DataManager::set_selected_timer(const orbit_client_protos::TimerInfo* timer_info) {
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  selected_timer_ = timer_info;
-}
-
-void DataManager::ClearSelectedFunctions() {
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  selected_functions_.clear();
-}
-
-bool DataManager::IsFunctionSelected(const FunctionInfo& function) const {
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  return selected_functions_.contains(function);
-}
-
-std::vector<FunctionInfo> DataManager::GetSelectedFunctions() const {
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  return std::vector<FunctionInfo>(selected_functions_.begin(), selected_functions_.end());
-}
-
 void DataManager::SelectTracepoint(const TracepointInfo& info) {
-  if (!IsTracepointSelected(info)) selected_tracepoints_.emplace(info);
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  if (!IsTracepointSelected(info)) {
+    selected_tracepoints_.emplace(info);
+  }
 }
 
 void DataManager::DeselectTracepoint(const TracepointInfo& info) {
@@ -107,23 +110,170 @@ void DataManager::DeselectTracepoint(const TracepointInfo& info) {
 }
 
 bool DataManager::IsTracepointSelected(const TracepointInfo& info) const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_tracepoints_.contains(info);
 }
 
-const TracepointInfoSet& DataManager::selected_tracepoints() const { return selected_tracepoints_; }
+const TracepointInfoSet& DataManager::selected_tracepoints() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return selected_tracepoints_;
+}
 
 void DataManager::EnableFrameTrack(const FunctionInfo& function) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   user_defined_capture_data_.InsertFrameTrack(function);
 }
 
 void DataManager::DisableFrameTrack(const FunctionInfo& function) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   user_defined_capture_data_.EraseFrameTrack(function);
 }
 
 [[nodiscard]] bool DataManager::IsFrameTrackEnabled(const FunctionInfo& function) const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return user_defined_capture_data_.ContainsFrameTrack(function);
 }
 
-void DataManager::ClearUserDefinedCaptureData() { user_defined_capture_data_.Clear(); }
+void DataManager::ClearUserDefinedCaptureData() {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  user_defined_capture_data_.Clear();
+}
+
+const UserDefinedCaptureData& DataManager::user_defined_capture_data() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return user_defined_capture_data_;
+}
+
+void DataManager::set_collect_scheduler_info(bool collect_scheduler_info) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  collect_scheduler_info_ = collect_scheduler_info;
+}
+
+bool DataManager::collect_scheduler_info() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return collect_scheduler_info_;
+}
+
+void DataManager::set_collect_thread_states(bool collect_thread_states) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  collect_thread_states_ = collect_thread_states;
+}
+
+bool DataManager::collect_thread_states() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return collect_thread_states_;
+}
+
+void DataManager::set_trace_gpu_submissions(bool trace_gpu_submissions) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  trace_gpu_submissions_ = trace_gpu_submissions;
+}
+
+bool DataManager::trace_gpu_submissions() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return trace_gpu_submissions_;
+}
+
+void DataManager::set_enable_api(bool enable_api) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  enable_api_ = enable_api;
+}
+
+bool DataManager::enable_api() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return enable_api_;
+}
+
+void DataManager::set_enable_introspection(bool enable_introspection) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  enable_introspection_ = enable_introspection;
+}
+
+bool DataManager::enable_introspection() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return enable_introspection_;
+}
+
+void DataManager::set_dynamic_instrumentation_method(
+    orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod method) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  dynamic_instrumentation_method_ = method;
+}
+
+orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod
+DataManager::dynamic_instrumentation_method() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return dynamic_instrumentation_method_;
+}
+
+void DataManager::set_samples_per_second(double samples_per_second) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  samples_per_second_ = samples_per_second;
+}
+double DataManager::samples_per_second() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return samples_per_second_;
+}
+
+void DataManager::set_stack_dump_size(uint16_t stack_dump_size) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  stack_dump_size_ = stack_dump_size;
+}
+
+uint16_t DataManager::stack_dump_size() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return stack_dump_size_;
+}
+
+void DataManager::set_unwinding_method(orbit_grpc_protos::CaptureOptions::UnwindingMethod method) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  unwinding_method_ = method;
+}
+
+orbit_grpc_protos::CaptureOptions::UnwindingMethod DataManager::unwinding_method() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return unwinding_method_;
+}
+
+void DataManager::set_max_local_marker_depth_per_command_buffer(
+    uint64_t max_local_marker_depth_per_command_buffer) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  max_local_marker_depth_per_command_buffer_ = max_local_marker_depth_per_command_buffer;
+}
+
+uint64_t DataManager::max_local_marker_depth_per_command_buffer() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return max_local_marker_depth_per_command_buffer_;
+}
+
+void DataManager::set_collect_memory_info(bool collect_memory_info) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  collect_memory_info_ = collect_memory_info;
+}
+
+bool DataManager::collect_memory_info() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return collect_memory_info_;
+}
+
+void DataManager::set_memory_sampling_period_ms(uint64_t memory_sampling_period_ms) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  memory_sampling_period_ms_ = memory_sampling_period_ms;
+}
+
+uint64_t DataManager::memory_sampling_period_ms() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return memory_sampling_period_ms_;
+}
+
+void DataManager::set_memory_warning_threshold_kb(uint64_t memory_warning_threshold_kb) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  memory_warning_threshold_kb_ = memory_warning_threshold_kb;
+}
+
+uint64_t DataManager::memory_warning_threshold_kb() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return memory_warning_threshold_kb_;
+}
 
 }  // namespace orbit_client_data

--- a/src/ClientData/DataManagerTest.cpp
+++ b/src/ClientData/DataManagerTest.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+#include "ClientData/DataManager.h"
+#include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/ThreadUtils.h"
+
+namespace orbit_client_data {
+
+template <typename Method, typename... Args>
+static void CallMethodOnDifferentThreadAndExpectDeath(DataManager& data_manager, Method method,
+                                                      Args&&... args) {
+  EXPECT_DEATH(std::thread{[&]() { (data_manager.*method)(std::forward<Args>(args)...); }}.join(),
+               "Check failed");
+}
+
+TEST(DataManager, CanOnlyBeUsedFromTheMainThread) {
+  DataManager data_manager;
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::SelectFunction,
+                                            orbit_client_protos::FunctionInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::DeselectFunction,
+                                            orbit_client_protos::FunctionInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::SelectFunction,
+                                            orbit_client_protos::FunctionInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::ClearSelectedFunctions);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_visible_function_ids,
+                                            absl::flat_hash_set<uint64_t>{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_highlighted_function_id,
+                                            0);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_highlighted_group_id,
+                                            0);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_selected_thread_id, 0);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_selected_timer,
+                                            nullptr);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::SelectTracepoint,
+                                            orbit_grpc_protos::TracepointInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::DeselectTracepoint,
+                                            orbit_grpc_protos::TracepointInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::IsTracepointSelected,
+                                            orbit_grpc_protos::TracepointInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::selected_tracepoints);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::EnableFrameTrack,
+                                            orbit_client_protos::FunctionInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::DisableFrameTrack,
+                                            orbit_client_protos::FunctionInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::IsFrameTrackEnabled,
+                                            orbit_client_protos::FunctionInfo{});
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager,
+                                            &DataManager::ClearUserDefinedCaptureData);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::user_defined_capture_data);
+
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_collect_scheduler_info,
+                                            false);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::collect_scheduler_info);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_collect_thread_states,
+                                            false);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::collect_thread_states);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_trace_gpu_submissions,
+                                            false);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::trace_gpu_submissions);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_enable_api, false);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::enable_api);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_enable_introspection,
+                                            false);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::enable_introspection);
+  CallMethodOnDifferentThreadAndExpectDeath(
+      data_manager, &DataManager::set_dynamic_instrumentation_method,
+      orbit_grpc_protos::CaptureOptions::kDynamicInstrumentationMethodUnspecified);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager,
+                                            &DataManager::dynamic_instrumentation_method);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_samples_per_second,
+                                            0.0);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::samples_per_second);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_stack_dump_size, 0);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::stack_dump_size);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_unwinding_method,
+                                            orbit_grpc_protos::CaptureOptions::kUndefined);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::unwinding_method);
+  CallMethodOnDifferentThreadAndExpectDeath(
+      data_manager, &DataManager::set_max_local_marker_depth_per_command_buffer, 0);
+  CallMethodOnDifferentThreadAndExpectDeath(
+      data_manager, &DataManager::max_local_marker_depth_per_command_buffer);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_collect_memory_info,
+                                            false);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::collect_memory_info);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager,
+                                            &DataManager::set_memory_sampling_period_ms, 0);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::memory_sampling_period_ms);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager,
+                                            &DataManager::set_memory_warning_threshold_kb, 0);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager,
+                                            &DataManager::memory_warning_threshold_kb);
+}
+
+}  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -20,6 +20,7 @@
 #include "GrpcProtos/Constants.h"
 #include "GrpcProtos/capture.pb.h"
 #include "GrpcProtos/tracepoint.pb.h"
+#include "OrbitBase/ThreadConstants.h"
 
 namespace orbit_client_data {
 
@@ -35,7 +36,7 @@ class DataManager final {
   void ClearSelectedFunctions();
   void set_visible_function_ids(absl::flat_hash_set<uint64_t> visible_function_ids);
   void set_highlighted_function_id(uint64_t highlighted_function_id);
-  void set_highlighted_group_id(uint64_t highlighted_function_id);
+  void set_highlighted_group_id(uint64_t highlighted_group_id);
   void set_selected_thread_id(uint32_t thread_id);
   void set_selected_timer(const orbit_client_protos::TimerInfo* timer_info);
 
@@ -44,14 +45,13 @@ class DataManager final {
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
   [[nodiscard]] uint64_t highlighted_function_id() const;
   [[nodiscard]] uint64_t highlighted_group_id() const;
-  [[nodiscard]] int32_t selected_thread_id() const;
+  [[nodiscard]] uint32_t selected_thread_id() const;
   [[nodiscard]] const orbit_client_protos::TimerInfo* selected_timer() const;
 
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info);
   void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& info);
 
   [[nodiscard]] bool IsTracepointSelected(const orbit_grpc_protos::TracepointInfo& info) const;
-
   [[nodiscard]] const TracepointInfoSet& selected_tracepoints() const;
 
   void EnableFrameTrack(const orbit_client_protos::FunctionInfo& function);
@@ -59,85 +59,49 @@ class DataManager final {
   [[nodiscard]] bool IsFrameTrackEnabled(const orbit_client_protos::FunctionInfo& function) const;
   void ClearUserDefinedCaptureData();
 
-  void set_user_defined_capture_data(const UserDefinedCaptureData& user_defined_capture_data) {
-    user_defined_capture_data_ = user_defined_capture_data;
-  }
-  [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const {
-    return user_defined_capture_data_;
-  }
+  [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const;
 
-  void set_collect_scheduler_info(bool collect_scheduler_info) {
-    collect_scheduler_info_ = collect_scheduler_info;
-  }
-  [[nodiscard]] bool collect_scheduler_info() const { return collect_scheduler_info_; }
+  void set_collect_scheduler_info(bool collect_scheduler_info);
+  [[nodiscard]] bool collect_scheduler_info() const;
 
-  void set_collect_thread_states(bool collect_thread_states) {
-    collect_thread_states_ = collect_thread_states;
-  }
-  [[nodiscard]] bool collect_thread_states() const { return collect_thread_states_; }
+  void set_collect_thread_states(bool collect_thread_states);
+  [[nodiscard]] bool collect_thread_states() const;
 
-  void set_trace_gpu_submissions(bool trace_gpu_submissions) {
-    trace_gpu_submissions_ = trace_gpu_submissions;
-  }
-  [[nodiscard]] bool trace_gpu_submissions() const { return trace_gpu_submissions_; }
+  void set_trace_gpu_submissions(bool trace_gpu_submissions);
+  [[nodiscard]] bool trace_gpu_submissions() const;
 
-  void set_enable_api(bool enable_api) { enable_api_ = enable_api; }
-  [[nodiscard]] bool get_enable_api() const { return enable_api_; }
+  void set_enable_api(bool enable_api);
+  [[nodiscard]] bool enable_api() const;
 
-  void set_enable_introspection(bool enable_introspection) {
-    enable_introspection_ = enable_introspection;
-  }
-  [[nodiscard]] bool get_enable_introspection() const { return enable_introspection_; }
+  void set_enable_introspection(bool enable_introspection);
+  [[nodiscard]] bool enable_introspection() const;
 
   void set_dynamic_instrumentation_method(
-      orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod method) {
-    dynamic_instrumentation_method_ = method;
-  }
+      orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod method);
   [[nodiscard]] orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod
-  dynamic_instrumentation_method() const {
-    return dynamic_instrumentation_method_;
-  }
+  dynamic_instrumentation_method() const;
 
-  void set_samples_per_second(double samples_per_second) {
-    samples_per_second_ = samples_per_second;
-  }
-  [[nodiscard]] double samples_per_second() const { return samples_per_second_; }
+  void set_samples_per_second(double samples_per_second);
+  [[nodiscard]] double samples_per_second() const;
 
-  void set_stack_dump_size(uint16_t stack_dump_size) { stack_dump_size_ = stack_dump_size; }
-  [[nodiscard]] uint16_t stack_dump_size() const { return stack_dump_size_; }
+  void set_stack_dump_size(uint16_t stack_dump_size);
+  [[nodiscard]] uint16_t stack_dump_size() const;
 
-  void set_unwinding_method(orbit_grpc_protos::CaptureOptions::UnwindingMethod method) {
-    unwinding_method_ = method;
-  }
-  orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method() const {
-    return unwinding_method_;
-  }
+  void set_unwinding_method(orbit_grpc_protos::CaptureOptions::UnwindingMethod method);
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method() const;
 
   void set_max_local_marker_depth_per_command_buffer(
-      uint64_t max_local_marker_depth_per_command_buffer) {
-    max_local_marker_depth_per_command_buffer_ = max_local_marker_depth_per_command_buffer;
-  }
+      uint64_t max_local_marker_depth_per_command_buffer);
+  [[nodiscard]] uint64_t max_local_marker_depth_per_command_buffer() const;
 
-  [[nodiscard]] uint64_t max_local_marker_depth_per_command_buffer() {
-    return max_local_marker_depth_per_command_buffer_;
-  }
+  void set_collect_memory_info(bool collect_memory_info);
+  [[nodiscard]] bool collect_memory_info() const;
 
-  void set_collect_memory_info(bool collect_memory_info) {
-    collect_memory_info_ = collect_memory_info;
-  }
-  [[nodiscard]] bool collect_memory_info() const { return collect_memory_info_; }
+  void set_memory_sampling_period_ms(uint64_t memory_sampling_period_ms);
+  [[nodiscard]] uint64_t memory_sampling_period_ms() const;
 
-  void set_memory_sampling_period_ms(uint64_t memory_sampling_period_ms) {
-    memory_sampling_period_ms_ = memory_sampling_period_ms;
-  }
-  [[nodiscard]] uint64_t memory_sampling_period_ms() const { return memory_sampling_period_ms_; }
-
-  void set_memory_warning_threshold_kb(uint64_t memory_warning_threshold_kb) {
-    memory_warning_threshold_kb_ = memory_warning_threshold_kb;
-  }
-  [[nodiscard]] uint64_t memory_warning_threshold_kb() const {
-    return memory_warning_threshold_kb_;
-  }
+  void set_memory_warning_threshold_kb(uint64_t memory_warning_threshold_kb);
+  [[nodiscard]] uint64_t memory_warning_threshold_kb() const;
 
  private:
   const std::thread::id main_thread_id_;
@@ -148,7 +112,7 @@ class DataManager final {
 
   TracepointInfoSet selected_tracepoints_;
 
-  int32_t selected_thread_id_ = -1;
+  uint32_t selected_thread_id_ = orbit_base::kInvalidThreadId;
   const orbit_client_protos::TimerInfo* selected_timer_ = nullptr;
 
   // DataManager needs a copy of this so that we can persist user choices like frame tracks between
@@ -168,7 +132,7 @@ class DataManager final {
 
   bool collect_memory_info_ = false;
   uint64_t memory_sampling_period_ms_ = 10;
-  uint64_t memory_warning_threshold_kb_ = 1024 * 1024 * 8;
+  uint64_t memory_warning_threshold_kb_ = 8ULL * 1024 * 1024;
 };
 
 }  // namespace orbit_client_data

--- a/src/OrbitBase/include/OrbitBase/ThreadConstants.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadConstants.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_BASE_THREAD_CONSTANTS_H
-#define ORBIT_BASE_THREAD_CONSTANTS_H
+#ifndef ORBIT_BASE_THREAD_CONSTANTS_H_
+#define ORBIT_BASE_THREAD_CONSTANTS_H_
 
 #include <cstdint>
 
@@ -29,4 +29,4 @@ static constexpr uint32_t kAllThreadsOfAllProcessesTid = -2;
 static constexpr uint32_t kNotTargetProcessTid = -3;
 }  // namespace orbit_base
 
-#endif  // ORBIT_BASE_THREAD_CONSTANTS_H
+#endif  // ORBIT_BASE_THREAD_CONSTANTS_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1394,8 +1394,8 @@ void OrbitApp::StartCapture() {
   bool collect_scheduling_info = !IsDevMode() || data_manager_->collect_scheduler_info();
   bool collect_thread_states = data_manager_->collect_thread_states();
   bool collect_gpu_jobs = !IsDevMode() || data_manager_->trace_gpu_submissions();
-  bool enable_api = data_manager_->get_enable_api();
-  bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
+  bool enable_api = data_manager_->enable_api();
+  bool enable_introspection = IsDevMode() && data_manager_->enable_introspection();
   const DynamicInstrumentationMethod dynamic_instrumentation_method =
       data_manager_->dynamic_instrumentation_method();
   double samples_per_second = data_manager_->samples_per_second();

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -61,4 +61,4 @@ class CallstackThreadBar : public ThreadBar {
 
 }  // namespace orbit_gl
 
-#endif  // ORBIT_GL_EVENT_TRACK_H_
+#endif  // ORBIT_GL_CALLSTACK_THREAD_BAR_H_


### PR DESCRIPTION
Add `ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);` to all
methods. Re-add `DataManager` test to verify this.
Also, reorder method definitions to match declaration order.

Test: Play around with Orbit trying to make actions that are related to the
`DataManager`'s methods.