### PR TITLE
Remove PostProcessedSamplingData::sorted_thread_sample_data_

### DIFF
--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -15,6 +15,7 @@
 
 #include "ClientData/CallstackTypes.h"
 #include "ClientProtos/capture_data.pb.h"
+#include "OrbitBase/ThreadConstants.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 
@@ -73,14 +74,12 @@ class PostProcessedSamplingData {
       absl::flat_hash_map<uint64_t, orbit_client_protos::CallstackInfo> id_to_resolved_callstack,
       absl::flat_hash_map<uint64_t, uint64_t> original_id_to_resolved_callstack_id,
       absl::flat_hash_map<uint64_t, absl::flat_hash_set<uint64_t>>
-          function_address_to_sampled_callstack_ids,
-      std::vector<ThreadSampleData> sorted_thread_sample_data)
+          function_address_to_sampled_callstack_ids)
       : thread_id_to_sample_data_{std::move(thread_id_to_sample_data)},
         id_to_resolved_callstack_{std::move(id_to_resolved_callstack)},
         original_id_to_resolved_callstack_id_{std::move(original_id_to_resolved_callstack_id)},
         function_address_to_sampled_callstack_ids_{
-            std::move(function_address_to_sampled_callstack_ids)},
-        sorted_thread_sample_data_{std::move(sorted_thread_sample_data)} {};
+            std::move(function_address_to_sampled_callstack_ids)} {};
 
   ~PostProcessedSamplingData() = default;
 
@@ -94,11 +93,9 @@ class PostProcessedSamplingData {
 
   [[nodiscard]] std::unique_ptr<SortedCallstackReport>
   GetSortedCallstackReportFromFunctionAddresses(const std::vector<uint64_t>& function_addresses,
-                                                ThreadID thread_id) const;
+                                                uint32_t thread_id) const;
 
-  [[nodiscard]] const std::vector<ThreadSampleData>& GetThreadSampleData() const {
-    return sorted_thread_sample_data_;
-  }
+  [[nodiscard]] std::vector<const ThreadSampleData*> GetSortedThreadSampleData() const;
   [[nodiscard]] const ThreadSampleData* GetThreadSampleDataByThreadId(uint32_t thread_id) const;
 
   [[nodiscard]] const ThreadSampleData* GetSummary() const;
@@ -106,14 +103,13 @@ class PostProcessedSamplingData {
 
  private:
   [[nodiscard]] std::multimap<int, uint64_t> GetCallstacksFromFunctionAddresses(
-      const std::vector<uint64_t>& function_addresses, ThreadID thread_id) const;
+      const std::vector<uint64_t>& function_addresses, uint32_t thread_id) const;
 
-  absl::flat_hash_map<ThreadID, ThreadSampleData> thread_id_to_sample_data_;
+  absl::flat_hash_map<uint32_t, ThreadSampleData> thread_id_to_sample_data_;
   absl::flat_hash_map<uint64_t, orbit_client_protos::CallstackInfo> id_to_resolved_callstack_;
   absl::flat_hash_map<uint64_t, uint64_t> original_id_to_resolved_callstack_id_;
   absl::flat_hash_map<uint64_t, absl::flat_hash_set<uint64_t>>
       function_address_to_sampled_callstack_ids_;
-  std::vector<ThreadSampleData> sorted_thread_sample_data_;
 };
 
 }  // namespace orbit_client_data

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -181,12 +181,12 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
   const std::string& process_name = capture_data.process_name();
   const absl::flat_hash_map<uint32_t, std::string>& thread_names = capture_data.thread_names();
 
-  for (const ThreadSampleData& thread_sample_data :
-       post_processed_sampling_data.GetThreadSampleData()) {
-    const uint32_t tid = thread_sample_data.thread_id;
+  for (const ThreadSampleData* thread_sample_data :
+       post_processed_sampling_data.GetSortedThreadSampleData()) {
+    const uint32_t tid = thread_sample_data->thread_id;
 
     for (const auto& [callstack_id, sample_count] :
-         thread_sample_data.sampled_callstack_id_to_count) {
+         thread_sample_data->sampled_callstack_id_to_count) {
       const CallstackInfo& resolved_callstack =
           post_processed_sampling_data.GetResolvedCallstack(callstack_id);
 
@@ -256,15 +256,15 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedS
   const std::string& process_name = capture_data.process_name();
   const absl::flat_hash_map<uint32_t, std::string>& thread_names = capture_data.thread_names();
 
-  for (const ThreadSampleData& thread_sample_data :
-       post_processed_sampling_data.GetThreadSampleData()) {
-    const uint32_t tid = thread_sample_data.thread_id;
+  for (const ThreadSampleData* thread_sample_data :
+       post_processed_sampling_data.GetSortedThreadSampleData()) {
+    const uint32_t tid = thread_sample_data->thread_id;
     if (tid == orbit_base::kAllProcessThreadsTid) {
       continue;
     }
 
     for (const auto& [callstack_id, sample_count] :
-         thread_sample_data.sampled_callstack_id_to_count) {
+         thread_sample_data->sampled_callstack_id_to_count) {
       const CallstackInfo& resolved_callstack =
           post_processed_sampling_data.GetResolvedCallstack(callstack_id);
 

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -41,13 +41,14 @@ void SamplingReport::ClearReport() {
 }
 
 void SamplingReport::FillReport() {
-  const auto& sample_data = post_processed_sampling_data_.GetThreadSampleData();
+  const std::vector<const ThreadSampleData*>& sample_data =
+      post_processed_sampling_data_.GetSortedThreadSampleData();
 
-  for (const ThreadSampleData& thread_sample_data : sample_data) {
+  for (const ThreadSampleData* thread_sample_data : sample_data) {
     orbit_data_views::SamplingReportDataView thread_report{app_};
     thread_report.Init();
-    thread_report.SetSampledFunctions(thread_sample_data.sampled_functions);
-    thread_report.SetThreadID(thread_sample_data.thread_id);
+    thread_report.SetSampledFunctions(thread_sample_data->sampled_functions);
+    thread_report.SetThreadID(thread_sample_data->thread_id);
     thread_report.SetSamplingReport(this);
     thread_reports_.push_back(std::move(thread_report));
   }


### PR DESCRIPTION
This was basically duplicating all the content of `thread_id_to_sample_data_`.
The sorting operation is cheap and performed very rarely, so let's just do it on
demand.

Test: Take some local captures and some captures on Trata. Verify "Sampling",
"Top-Down", "Bottom-Up" tabs, also on selections.