### PR TITLE
Block problematic symbols in libc from instrumentation.

### DIFF
--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -335,9 +335,9 @@ int main(int argc, char* argv[]) {
     ORBIT_LOG("file_path=%s", file_path);
     ORBIT_LOG("file_offset=%#x", file_offset);
     if (instrumentation_method == CaptureOptions::kUserSpaceInstrumentation) {
-      ORBIT_FAIL_IF(function_size == -1, "User space instrumentation requires the function size.");
+      ORBIT_FAIL_IF(function_size == -1, "User space instrumentation requires the function size");
       ORBIT_LOG("function_size=%d", function_size);
-      ORBIT_FAIL_IF(function_name.empty(), "User space instrumentation requires the function name.");
+      ORBIT_FAIL_IF(function_name.empty(), "User space instrumentation requires the function name");
       ORBIT_LOG("function_name=%s", function_name);
     }
   }

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -70,8 +70,8 @@ void InstallSigintHandler() {
 void ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromOffset(
     orbit_client_data::ModuleManager* module_manager,
     absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>* selected_functions,
-    const std::string& file_path, uint64_t file_offset, uint64_t function_size,
-    uint64_t function_id) {
+    const std::string& file_path, const std::string& function_name, uint64_t file_offset,
+    uint64_t function_size, uint64_t function_id) {
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::ElfFile>> error_or_elf_file =
       orbit_object_utils::CreateElfFile(std::filesystem::path{file_path});
   ORBIT_FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
@@ -87,6 +87,7 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromOff
   ORBIT_CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
 
   orbit_client_protos::FunctionInfo function_info;
+  function_info.set_pretty_name(function_name);
   function_info.set_module_path(file_path);
   function_info.set_module_build_id(build_id);
   function_info.set_address(load_bias + file_offset);
@@ -322,11 +323,9 @@ int main(int argc, char* argv[]) {
 
   std::string file_path = absl::GetFlag(FLAGS_instrument_path);
   uint64_t file_offset = absl::GetFlag(FLAGS_instrument_offset);
-  ORBIT_FAIL_IF(
-      (file_path.empty()) != (file_offset == 0),
-      "Binary path and offset of the function to instrument need to be specified together");
   bool instrument_function = !file_path.empty() && file_offset != 0;
-  uint64_t function_size = absl::GetFlag(FLAGS_instrument_size);
+  const int64_t function_size = absl::GetFlag(FLAGS_instrument_size);
+  const std::string function_name = absl::GetFlag(FLAGS_instrument_name);
   DynamicInstrumentationMethod instrumentation_method =
       absl::GetFlag(FLAGS_user_space_instrumentation) ? CaptureOptions::kUserSpaceInstrumentation
                                                       : CaptureOptions::kKernelUprobes;
@@ -336,8 +335,10 @@ int main(int argc, char* argv[]) {
     ORBIT_LOG("file_path=%s", file_path);
     ORBIT_LOG("file_offset=%#x", file_offset);
     if (instrumentation_method == CaptureOptions::kUserSpaceInstrumentation) {
-      ORBIT_FAIL_IF(function_size == 0, "User space instrumentation requires the function size");
+      ORBIT_FAIL_IF(function_size == -1, "User space instrumentation requires the function size.");
       ORBIT_LOG("function_size=%d", function_size);
+      ORBIT_FAIL_IF(function_name.empty(), "User space instrumentation requires the function name.");
+      ORBIT_LOG("function_name=%s", function_name);
     }
   }
   constexpr bool kAlwaysRecordArguments = false;
@@ -379,7 +380,7 @@ int main(int argc, char* argv[]) {
   if (instrument_function) {
     constexpr uint64_t kInstrumentedFunctionId = 1;
     ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromOffset(
-        &module_manager, &selected_functions, file_path, file_offset, function_size,
+        &module_manager, &selected_functions, file_path, function_name, file_offset, function_size,
         kInstrumentedFunctionId);
   }
 

--- a/src/FakeClient/Flags.h
+++ b/src/FakeClient/Flags.h
@@ -43,8 +43,9 @@ ABSL_FLAG(uint16_t, sampling_rate, 1000,
           "Callstack sampling rate in samples per second (0: no sampling)");
 ABSL_FLAG(bool, frame_pointers, false, "Use frame pointers for unwinding");
 ABSL_FLAG(std::string, instrument_path, "", "Path of the binary of the function to instrument");
+ABSL_FLAG(std::string, instrument_name, "", "Name of the function to instrument");
 ABSL_FLAG(uint64_t, instrument_offset, 0, "Offset in the binary of the function to instrument");
-ABSL_FLAG(uint64_t, instrument_size, 0, "Size in bytes of the function to instrument");
+ABSL_FLAG(int64_t, instrument_size, -1, "Size in bytes of the function to instrument");
 ABSL_FLAG(bool, user_space_instrumentation, false,
           "Use user space instrumentation instead of uprobes");
 ABSL_FLAG(bool, scheduling, true, "Collect scheduling information");

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -72,9 +72,22 @@ bool ProcessWithPidExists(pid_t pid) {
 // a situation where instrumenting the functions below would lead to a recursive call into the
 // instrumentation. We just skip these and leave instrumenting them to the kernel/uprobe fallback.
 bool IsBlocklisted(std::string_view function_name) {
-  static const absl::flat_hash_set<std::string> kBlocklist{
-      "__GI___libc_malloc", "__GI___libc_free", "get_free_list",
-      "malloc_consolidate", "sysmalloc",        "_int_malloc"};
+  static const absl::flat_hash_set<std::string> kBlocklist{"__GI___libc_malloc",
+                                                           "__GI___libc_free",
+                                                           "get_free_list",
+                                                           "malloc_consolidate",
+                                                           "sysmalloc",
+                                                           "_int_malloc",
+                                                           "__libc_enable_asynccancel",
+                                                           "__GI___ctype_init",
+                                                           "__GI___mprotect",
+                                                           "__munmap",
+                                                           "new_heap",
+                                                           "__get_nprocs",
+                                                           "__get_nprocs_conf",
+                                                           "__strtoul",
+                                                           "arena_get2.part.3",
+                                                           "next_line"};
   return kBlocklist.contains(function_name);
 }
 


### PR DESCRIPTION
User space instrumentation crashes either orbit service or the tracee
when these symbols are instrumented. The reason is (mostly) unclear.
Some of the crashes happen only during thread creation; some other
symbols are used in the allocation of thread local storage in the
payload. Debugging this lead nowhere and I'd prefer to just exclude
these symbols from instrumentation (and fall back to kernel
functionality).

Additionally the fake client now requires the function name for
functions instrumented by user space instrumentation (such that the
block list can be applied appropriately).

Test: Local runs with fake client and ui.
Bug: http://b/215094990