### PR TITLE
Add CaptureData::memory_sampling_period_ns_, use in OrbitApp

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -31,6 +31,7 @@ CaptureData::CaptureData(ModuleManager* module_manager, const CaptureStarted& ca
                          absl::flat_hash_set<uint64_t> frame_track_function_ids,
                          DataSource data_source)
     : module_manager_{module_manager},
+      memory_sampling_period_ns_(capture_started.capture_options().memory_sampling_period_ns()),
       selection_callstack_data_(std::make_unique<CallstackData>()),
       frame_track_function_ids_{std::move(frame_track_function_ids)},
       file_path_{std::move(file_path)},

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -62,6 +62,8 @@ class CaptureData {
     return instrumented_functions_;
   }
 
+  [[nodiscard]] uint64_t memory_sampling_period_ns() const { return memory_sampling_period_ns_; }
+
   [[nodiscard]] const orbit_grpc_protos::InstrumentedFunction* GetInstrumentedFunctionById(
       uint64_t function_id) const;
   [[nodiscard]] std::optional<uint64_t> FindInstrumentedFunctionIdSlow(
@@ -249,6 +251,7 @@ class CaptureData {
   orbit_client_data::ProcessData process_;
   orbit_client_data::ModuleManager* module_manager_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions_;
+  uint64_t memory_sampling_period_ns_;
 
   orbit_client_data::CallstackData callstack_data_;
   // selection_callstack_data_ is subset of callstack_data_.

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -404,17 +404,17 @@ class OrbitApp final : public DataViewFactory,
   void SetStackDumpSize(uint16_t stack_dump_size);
   void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
-
   void SetCollectMemoryInfo(bool collect_memory_info) {
     data_manager_->set_collect_memory_info(collect_memory_info);
   }
-  [[nodiscard]] bool GetCollectMemoryInfo() const { return data_manager_->collect_memory_info(); }
   void SetMemorySamplingPeriodMs(uint64_t memory_sampling_period_ms) {
     data_manager_->set_memory_sampling_period_ms(memory_sampling_period_ms);
   }
+
   [[nodiscard]] uint64_t GetMemorySamplingPeriodMs() const {
-    return data_manager_->memory_sampling_period_ms();
+    return capture_data_->memory_sampling_period_ns() / 1'000'000;
   }
+
   void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb) {
     data_manager_->set_memory_warning_threshold_kb(memory_warning_threshold_kb);
   }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -370,6 +370,7 @@ void TimeGraph::ProcessSystemMemoryTrackingTimer(const TimerInfo& timer_info) {
 
   if (absl::GetFlag(FLAGS_enable_warning_threshold) && !track->GetWarningThreshold().has_value()) {
     constexpr double kMegabytesToKilobytes = 1024.0;
+    // TODO(b/216245594): This uses the DataManager not from the main thread, failing a check.
     double warning_threshold_mb =
         static_cast<double>(app_->GetMemoryWarningThresholdKb()) / kMegabytesToKilobytes;
     track->SetWarningThreshold(warning_threshold_mb);

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1145,10 +1145,11 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
   }
   app_->SetDynamicInstrumentationMethod(instrumentation_method);
 
-  app_->SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
+  bool collect_memory_info = settings.value(kCollectMemoryInfoSettingKey, false).toBool();
+  app_->SetCollectMemoryInfo(collect_memory_info);
   uint64_t memory_sampling_period_ms = kMemorySamplingPeriodMsDefaultValue;
   uint64_t memory_warning_threshold_kb = kMemoryWarningThresholdKbDefaultValue;
-  if (app_->GetCollectMemoryInfo()) {
+  if (collect_memory_info) {
     memory_sampling_period_ms = settings
                                     .value(kMemorySamplingPeriodMsSettingKey,
                                            QVariant::fromValue(kMemorySamplingPeriodMsDefaultValue))


### PR DESCRIPTION
`OrbitApp::GetMemorySamplingPeriodMs` now uses `CaptureData`, not the
`DataManager`:
- The capture view should use the current capture
  (`CaptureData::memory_sampling_period_ns_`), not the
  options for the next (`DataManager::memory_sampling_period_ms_`);
- The `DataManager` should only be used from the main thread; this caused a
  `CHECK` to fail.

Bug: http://b/216103267

Test: Take a capture with memory sampling enabled, which was previously causing
the crash.