### PR TITLE
Differentiate between total and visible Height

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -557,7 +557,8 @@ void CaptureWindow::UpdateHorizontalScroll(float ratio) {
 
 void CaptureWindow::UpdateVerticalScroll(float ratio) {
   if (time_graph_ == nullptr) return;
-  float range = std::max(0.f, time_graph_->GetHeight() - viewport_.GetWorldHeight());
+  float range = std::max(0.f, time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight() -
+                                  viewport_.GetWorldHeight());
   float new_scrolling_offset = ratio * range;
   time_graph_->GetTrackContainer()->SetVerticalScrollingOffset(new_scrolling_offset);
 }
@@ -602,11 +603,12 @@ void CaptureWindow::ProcessSliderMouseMoveEvents(int x, int y) {
 
 void CaptureWindow::UpdateVerticalSliderFromWorld() {
   if (time_graph_ == nullptr) return;
-  float max = std::max(0.f, time_graph_->GetHeight() - viewport_.GetWorldHeight());
+  float visible_tracks_height = time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight();
+  float max = std::max(0.f, visible_tracks_height - viewport_.GetWorldHeight());
   float pos_ratio =
       max > 0 ? time_graph_->GetTrackContainer()->GetVerticalScrollingOffset() / max : 0.f;
   float size_ratio =
-      time_graph_->GetHeight() > 0 ? viewport_.GetWorldHeight() / time_graph_->GetHeight() : 1.f;
+      visible_tracks_height > 0 ? viewport_.GetWorldHeight() / visible_tracks_height : 1.f;
   int slider_width = static_cast<int>(time_graph_->GetLayout().GetSliderWidth());
   vertical_slider_->SetPixelHeight(slider_width);
   vertical_slider_->SetNormalizedPosition(pos_ratio);

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -55,14 +55,19 @@ TrackContainer::TrackContainer(CaptureViewElement* parent, TimelineInfoInterface
 }
 
 float TrackContainer::GetHeight() const {
+  // The entire TimeGraph without the horizontal slider and the timeline.
+  return viewport_->GetWorldHeight() - layout_.GetBottomMargin();
+}
+
+float TrackContainer::GetVisibleTracksTotalHeight() const {
   // Top and Bottom Margin. TODO: Margins should be treated in a different way (http://b/192070555).
-  float total_height = layout_.GetSchedulerTrackOffset() + layout_.GetBottomMargin();
+  float visible_tracks_total_height = layout_.GetSchedulerTrackOffset() + layout_.GetBottomMargin();
 
   // Track height including space between them
   for (auto& track : GetNonHiddenChildren()) {
-    total_height += (track->GetHeight() + layout_.GetSpaceBetweenTracks());
+    visible_tracks_total_height += (track->GetHeight() + layout_.GetSpaceBetweenTracks());
   }
-  return total_height;
+  return visible_tracks_total_height;
 }
 
 void TrackContainer::VerticalZoom(float real_ratio, float mouse_screen_y_position) {
@@ -390,7 +395,8 @@ void TrackContainer::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
 }
 
 void TrackContainer::SetVerticalScrollingOffset(float value) {
-  float clamped_value = std::max(std::min(value, GetHeight() - viewport_->GetWorldHeight()), 0.f);
+  float clamped_value =
+      std::max(std::min(value, GetVisibleTracksTotalHeight() - viewport_->GetWorldHeight()), 0.f);
   if (clamped_value == vertical_scrolling_offset_) return;
 
   vertical_scrolling_offset_ = clamped_value;

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -30,6 +30,7 @@ class TrackContainer final : public CaptureViewElement {
                           orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] float GetHeight() const override;
+  [[nodiscard]] float GetVisibleTracksTotalHeight() const;
 
   [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
 


### PR DESCRIPTION
TrackContainer::GetHeight method is returning the total tracks height.
Although sometimes is needed, we also want to know how much space is
taking the visual container.