### PR TITLE
Replace the old timeline with the new one

### DIFF
--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -31,14 +31,13 @@ AccessibilityState TimeGraphAccessibility::AccessibleState() const {
 }
 
 int TimeGraphAccessibility::AccessibleChildCount() const {
-  // TODO(b/208431620): Include the Timeline as another children.
-  return 1;  // TrackContainer
+  return time_graph_->GetNonHiddenChildren().size();
 }
 
 const AccessibleInterface* TimeGraphAccessibility::AccessibleChild(int index) const {
-  // TODO(b/208431620): Include the Timeline as another children.
-  if (index == 0) {
-    return time_graph_->GetTrackContainer()->GetOrCreateAccessibleInterface();
+  auto children_list = time_graph_->GetNonHiddenChildren();
+  if (index >= 0 && index < static_cast<int>(children_list.size())) {
+    return children_list[index]->GetOrCreateAccessibleInterface();
   }
   return nullptr;
 }

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -76,7 +76,6 @@ class CaptureWindow : public GlCanvas {
   orbit_gl::GlSlider* FindSliderUnderMouseCursor(int x, int y);
 
   void RenderHelpUi();
-  void RenderTimeBar();
   void RenderSelectionOverlay();
   void SelectTimer(const orbit_client_protos::TimerInfo* timer_info);
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -68,6 +68,7 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
   batcher_.SetPickingManager(picking_manager);
   track_container_ = std::make_unique<orbit_gl::TrackContainer>(
       this, this, viewport, &layout_, app, app->GetModuleManager(), capture_data);
+  timeline_ui_ = std::make_unique<orbit_gl::TimelineUi>(this, this, viewport, &layout_);
 
   if (absl::GetFlag(FLAGS_enforce_full_redraw)) {
     RequestUpdate();
@@ -529,6 +530,7 @@ void TimeGraph::PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode) {
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
+  timeline_ui_->SetPos(0, track_container_->GetHeight());
   CaptureViewElement::UpdatePrimitives(batcher_, text_renderer_static_, min_tick, max_tick,
                                        picking_mode);
 
@@ -650,11 +652,11 @@ bool TimeGraph::IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) c
 }
 
 std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetAllChildren() const {
-  return {GetTrackContainer()};
+  return {GetTrackContainer(), GetTimelineUi()};
 }
 
 std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetNonHiddenChildren() const {
-  return {GetTrackContainer()};
+  return {GetTrackContainer(), GetTimelineUi()};
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> TimeGraph::CreateAccessibleInterface() {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -68,8 +68,8 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
   batcher_.SetPickingManager(picking_manager);
   track_container_ = std::make_unique<orbit_gl::TrackContainer>(
       this, this, viewport, &layout_, app, app->GetModuleManager(), capture_data);
-  timeline_ui_ = std::make_unique<orbit_gl::TimelineUi>(this, this, viewport, &layout_);
-
+  timeline_ui_ = std::make_unique<orbit_gl::TimelineUi>(
+      /*parent=*/this, /*timeline_info_interface=*/this, viewport, &layout_);
   if (absl::GetFlag(FLAGS_enforce_full_redraw)) {
     RequestUpdate();
   }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -21,6 +21,7 @@
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
 #include "TimelineInfoInterface.h"
+#include "TimelineUi.h"
 #include "TrackContainer.h"
 #include "Viewport.h"
 
@@ -53,6 +54,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] orbit_gl::TrackContainer* GetTrackContainer() const {
     return track_container_.get();
   }
+  [[nodiscard]] orbit_gl::TimelineUi* GetTimelineUi() const { return timeline_ui_.get(); }
   [[nodiscard]] orbit_gl::TrackManager* GetTrackManager() const {
     return track_container_->GetTrackManager();
   }
@@ -183,6 +185,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   Batcher batcher_;
 
   std::unique_ptr<orbit_gl::TrackContainer> track_container_;
+  std::unique_ptr<orbit_gl::TimelineUi> timeline_ui_;
 
   ManualInstrumentationManager* manual_instrumentation_manager_;
   orbit_client_data::ThreadTrackDataProvider* thread_track_data_provider_ = nullptr;


### PR DESCRIPTION
This PR simply includes the new timeline instead of the old one. The
main difference is the scale, the old timeline always include 9 labels
and the new one shows between 2 and 10, depending on the zooming level.
Also, major ticks are a bit longer as in the prototype.

There are several TODOs but they will be addressed soon.

TEST: Load a capture, test general actions, start/stop a capture.

Old Screenshots:
http://screen/4oJLcL6gaoY38Zf
http://screen/3RBQAMbeSmUFopr

New Screenshots:
http://screen/7SBa9jYhW4kVUzy
http://screen/4ynM7TkuwH67Web

Bug: http://b/208444071