### PR TITLE
Make proto CallstackEvent a class

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -41,7 +41,7 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnKeyAndString, (uint64_t /*key*/, std::string), (override));
   MOCK_METHOD(void, OnUniqueCallstack, (uint64_t /*callstack_id*/, CallstackInfo /*callstack*/),
               (override));
-  MOCK_METHOD(void, OnCallstackEvent, (orbit_client_protos::CallstackEvent), (override));
+  MOCK_METHOD(void, OnCallstackEvent, (orbit_client_data::CallstackEvent), (override));
   MOCK_METHOD(void, OnThreadName, (uint32_t /*thread_id*/, std::string /*thread_name*/),
               (override));
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_client_protos::ThreadStateSliceInfo), (override));

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -13,13 +13,15 @@
 
 #include "CaptureClient/ApiEventProcessor.h"
 #include "CaptureClient/GpuQueueSubmissionProcessor.h"
+#include "ClientData/CallstackEvent.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/Constants.h"
 #include "OrbitBase/Logging.h"
 
 namespace orbit_capture_client {
 
-using orbit_client_protos::CallstackEvent;
+using orbit_client_data::CallstackEvent;
+
 using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::ThreadStateSliceInfo;
@@ -288,15 +290,13 @@ void CaptureEventProcessorForListener::ProcessCallstackSample(
 
   SendCallstackToListenerIfNecessary(callstack_id, callstack);
 
-  CallstackEvent callstack_event;
-  callstack_event.set_time(callstack_sample.timestamp_ns());
-  callstack_event.set_callstack_id(callstack_id);
   // Note: callstack_sample.pid() is available, but currently dropped.
-  callstack_event.set_thread_id(callstack_sample.tid());
+  CallstackEvent callstack_event{callstack_sample.timestamp_ns(), callstack_id,
+                                 callstack_sample.tid()};
 
   gpu_queue_submission_processor_.UpdateBeginCaptureTime(callstack_sample.timestamp_ns());
 
-  capture_listener_->OnCallstackEvent(std::move(callstack_event));
+  capture_listener_->OnCallstackEvent(callstack_event);
 }
 
 void CaptureEventProcessorForListener::ProcessFunctionCall(const FunctionCall& function_call) {

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -22,7 +22,7 @@
 
 namespace orbit_capture_client {
 
-using orbit_client_protos::CallstackEvent;
+using orbit_client_data::CallstackEvent;
 using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::TimerInfo;

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -5,6 +5,7 @@
 #ifndef CAPTURE_CLIENT_CAPTURE_LISTENER_H_
 #define CAPTURE_CLIENT_CAPTURE_LISTENER_H_
 
+#include "ClientData/CallstackEvent.h"
 #include "ClientData/ProcessData.h"
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/UserDefinedCaptureData.h"
@@ -30,7 +31,7 @@ class CaptureListener {
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;
   virtual void OnUniqueCallstack(uint64_t callstack_id,
                                  orbit_client_protos::CallstackInfo callstack) = 0;
-  virtual void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) = 0;
+  virtual void OnCallstackEvent(orbit_client_data::CallstackEvent callstack_event) = 0;
   virtual void OnThreadName(uint32_t thread_id, std::string thread_name) = 0;
   virtual void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) = 0;
   virtual void OnModulesSnapshot(uint64_t timestamp_ns,

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(ClientData PRIVATE
 
 target_sources(ClientData PUBLIC
         include/ClientData/CallstackData.h
+        include/ClientData/CallstackEvent.h
         include/ClientData/CallstackTypes.h
         include/ClientData/CaptureData.h
         include/ClientData/DataManager.h

--- a/src/ClientData/CallstackDataTest.cpp
+++ b/src/ClientData/CallstackDataTest.cpp
@@ -11,9 +11,10 @@
 #include <vector>
 
 #include "ClientData/CallstackData.h"
+#include "ClientData/CallstackEvent.h"
 #include "ClientProtos/capture_data.pb.h"
 
-using orbit_client_protos::CallstackEvent;
+using orbit_client_data::CallstackEvent;
 using orbit_client_protos::CallstackInfo;
 
 namespace orbit_client_data {
@@ -21,7 +22,7 @@ namespace orbit_client_data {
 MATCHER(CallstackEventEq, "") {
   const CallstackEvent& a = std::get<0>(arg);
   const CallstackEvent& b = std::get<1>(arg);
-  return a.time() == b.time() && a.callstack_id() == b.callstack_id() &&
+  return a.timestamp_ns() == b.timestamp_ns() && a.callstack_id() == b.callstack_id() &&
          a.thread_id() == b.thread_id();
 }
 
@@ -69,73 +70,43 @@ TEST(CallstackData, FilterCallstackEventsBasedOnMajorityStart) {
   callstack_data.AddUniqueCallstack(non_complete_cs_id, non_complete_cs);
 
   const uint64_t time1 = 142;
-  CallstackEvent event1;
-  event1.set_time(time1);
-  event1.set_thread_id(tid);
-  event1.set_callstack_id(cs1_id);
+  CallstackEvent event1{time1, cs1_id, tid};
   callstack_data.AddCallstackEvent(event1);
 
   const uint64_t time2 = 242;
-  CallstackEvent event2;
-  event2.set_time(time2);
-  event2.set_thread_id(tid);
-  event2.set_callstack_id(broken_cs_id);
+  CallstackEvent event2{time2, broken_cs_id, tid};
   callstack_data.AddCallstackEvent(event2);
 
   const uint64_t time3 = 342;
-  CallstackEvent event3;
-  event3.set_time(time3);
-  event3.set_thread_id(tid);
-  event3.set_callstack_id(cs2_id);
+  CallstackEvent event3{time3, cs2_id, tid};
   callstack_data.AddCallstackEvent(event3);
 
   const uint64_t time4 = 442;
-  CallstackEvent event4;
-  event4.set_time(time4);
-  event4.set_thread_id(tid);
-  event4.set_callstack_id(cs1_id);
+  CallstackEvent event4{time4, cs1_id, tid};
   callstack_data.AddCallstackEvent(event4);
 
   const uint64_t time5 = 542;
-  CallstackEvent event5;
-  event5.set_time(time5);
-  event5.set_thread_id(tid);
-  event5.set_callstack_id(non_complete_cs_id);
+  CallstackEvent event5{time5, non_complete_cs_id, tid};
   callstack_data.AddCallstackEvent(event5);
 
   const uint64_t time6 = 143;
-  CallstackEvent event6;
-  event6.set_time(time6);
-  event6.set_thread_id(tid_with_no_complete);
-  event6.set_callstack_id(broken_cs_id);
+  CallstackEvent event6{time6, broken_cs_id, tid_with_no_complete};
   callstack_data.AddCallstackEvent(event6);
 
   const uint64_t time7 = 243;
-  CallstackEvent event7;
-  event7.set_time(time7);
-  event7.set_thread_id(tid_with_no_complete);
-  event7.set_callstack_id(non_complete_cs_id);
+  CallstackEvent event7{time7, non_complete_cs_id, tid_with_no_complete};
   callstack_data.AddCallstackEvent(event7);
 
   const uint64_t time8 = 144;
-  CallstackEvent event8;
-  event8.set_time(time8);
-  event8.set_thread_id(tid_without_supermajority);
-  event8.set_callstack_id(cs1_id);
+  CallstackEvent event8{time8, cs1_id, tid_without_supermajority};
   callstack_data.AddCallstackEvent(event8);
 
   const uint64_t time9 = 244;
-  CallstackEvent event9;
-  event9.set_time(time9);
-  event9.set_thread_id(tid_without_supermajority);
-  event9.set_callstack_id(broken_cs_id);
+  CallstackEvent event9{time9, broken_cs_id, tid_without_supermajority};
   callstack_data.AddCallstackEvent(event9);
 
   const uint64_t time10 = 344;
-  CallstackEvent event10;
-  event10.set_time(time10);
-  event10.set_thread_id(tid_without_supermajority);
-  event10.set_callstack_id(non_complete_cs_id);
+  CallstackEvent event10{time10, non_complete_cs_id, tid_without_supermajority};
   callstack_data.AddCallstackEvent(event10);
 
   callstack_data.UpdateCallstackTypeBasedOnMajorityStart();

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "CallstackTypes.h"
+#include "ClientData/CallstackEvent.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "absl/container/flat_hash_map.h"
 
@@ -33,31 +34,31 @@ class CallstackData {
 
   // Assume that callstack_event.callstack_hash is filled correctly and the
   // Callstack with the corresponding id is already in unique_callstacks_.
-  void AddCallstackEvent(orbit_client_protos::CallstackEvent callstack_event);
+  void AddCallstackEvent(orbit_client_data::CallstackEvent callstack_event);
   void AddUniqueCallstack(uint64_t callstack_id, orbit_client_protos::CallstackInfo callstack);
-  void AddCallstackFromKnownCallstackData(const orbit_client_protos::CallstackEvent& event,
+  void AddCallstackFromKnownCallstackData(const orbit_client_data::CallstackEvent& event,
                                           const CallstackData& known_callstack_data);
 
   [[nodiscard]] uint32_t GetCallstackEventsCount() const;
 
-  [[nodiscard]] std::vector<orbit_client_protos::CallstackEvent> GetCallstackEventsInTimeRange(
+  [[nodiscard]] std::vector<orbit_client_data::CallstackEvent> GetCallstackEventsInTimeRange(
       uint64_t time_begin, uint64_t time_end) const;
 
   [[nodiscard]] uint32_t GetCallstackEventsOfTidCount(uint32_t thread_id) const;
 
-  [[nodiscard]] std::vector<orbit_client_protos::CallstackEvent> GetCallstackEventsOfTidInTimeRange(
+  [[nodiscard]] std::vector<orbit_client_data::CallstackEvent> GetCallstackEventsOfTidInTimeRange(
       uint32_t tid, uint64_t time_begin, uint64_t time_end) const;
 
   void ForEachCallstackEvent(
-      const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
+      const std::function<void(const orbit_client_data::CallstackEvent&)>& action) const;
 
   void ForEachCallstackEventInTimeRange(
       uint64_t min_timestamp, uint64_t max_timestamp,
-      const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
+      const std::function<void(const orbit_client_data::CallstackEvent&)>& action) const;
 
   void ForEachCallstackEventOfTidInTimeRange(
       uint32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
-      const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
+      const std::function<void(const orbit_client_data::CallstackEvent&)>& action) const;
 
   [[nodiscard]] uint64_t max_time() const {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
@@ -94,7 +95,7 @@ class CallstackData {
   mutable std::recursive_mutex mutex_;
   absl::flat_hash_map<uint64_t, std::shared_ptr<orbit_client_protos::CallstackInfo>>
       unique_callstacks_;
-  absl::flat_hash_map<uint32_t, std::map<uint64_t, orbit_client_protos::CallstackEvent>>
+  absl::flat_hash_map<uint32_t, std::map<uint64_t, orbit_client_data::CallstackEvent>>
       callstack_events_by_tid_;
 
   uint64_t max_time_ = 0;

--- a/src/ClientData/include/ClientData/CallstackEvent.h
+++ b/src/ClientData/include/ClientData/CallstackEvent.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_CALLSTACK_EVENT_H_
+#define CLIENT_DATA_CALLSTACK_EVENT_H_
+
+#include <stdint.h>
+
+namespace orbit_client_data {
+
+class CallstackEvent {
+ public:
+  CallstackEvent() = delete;
+  CallstackEvent(uint64_t timestamp_ns, uint64_t callstack_id, uint32_t thread_id)
+      : timestamp_ns_{timestamp_ns}, callstack_id_{callstack_id}, thread_id_{thread_id} {}
+
+  [[nodiscard]] uint64_t timestamp_ns() const { return timestamp_ns_; }
+  [[nodiscard]] uint64_t callstack_id() const { return callstack_id_; }
+  [[nodiscard]] uint32_t thread_id() const { return thread_id_; }
+
+ private:
+  uint64_t timestamp_ns_;
+  uint64_t callstack_id_;
+  uint32_t thread_id_;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_CALLSTACK_EVENT_H_

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "ClientData/CallstackData.h"
+#include "ClientData/CallstackEvent.h"
 #include "ClientData/FunctionInfoSet.h"
 #include "ClientData/ModuleData.h"
 #include "ClientData/ModuleManager.h"
@@ -151,7 +152,7 @@ class CaptureData {
     callstack_data_.AddUniqueCallstack(callstack_id, std::move(callstack));
   }
 
-  void AddCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) {
+  void AddCallstackEvent(orbit_client_data::CallstackEvent callstack_event) {
     callstack_data_.AddCallstackEvent(std::move(callstack_event));
   }
 

--- a/src/ClientData/include/ClientData/FunctionInfoSet.h
+++ b/src/ClientData/include/ClientData/FunctionInfoSet.h
@@ -36,11 +36,6 @@ using FunctionInfoSet =
     absl::flat_hash_set<orbit_client_protos::FunctionInfo, internal::HashFunctionInfo,
                         internal::EqualFunctionInfo>;
 
-template <class V>
-using FunctionInfoMap =
-    absl::flat_hash_map<orbit_client_protos::FunctionInfo, V, internal::HashFunctionInfo,
-                        internal::EqualFunctionInfo>;
-
 }  // namespace orbit_client_data
 
 #endif  // CLIENT_DATA_FUNCTION_INFO_SET_H_

--- a/src/ClientModel/SamplingDataPostProcessor.cpp
+++ b/src/ClientModel/SamplingDataPostProcessor.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "ClientData/CallstackEvent.h"
 #include "ClientData/CallstackTypes.h"
 #include "ClientData/ModuleAndFunctionLookup.h"
 #include "ClientProtos/capture_data.pb.h"
@@ -23,6 +24,7 @@
 #include "absl/container/flat_hash_set.h"
 
 using orbit_client_data::CallstackData;
+using orbit_client_data::CallstackEvent;
 using orbit_client_data::CaptureData;
 using orbit_client_data::ModuleManager;
 using orbit_client_data::PostProcessedSamplingData;
@@ -30,7 +32,6 @@ using orbit_client_data::SampledFunction;
 using orbit_client_data::ThreadID;
 using orbit_client_data::ThreadSampleData;
 
-using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::CallstackInfo;
 
 namespace orbit_client_model {

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -8,6 +8,7 @@
 
 #include <vector>
 
+#include "ClientData/CallstackEvent.h"
 #include "ClientData/CaptureData.h"
 #include "ClientData/ModuleAndFunctionLookup.h"
 #include "ClientData/ModuleManager.h"
@@ -16,6 +17,7 @@
 #include "OrbitBase/ThreadConstants.h"
 
 using orbit_client_data::CallstackCount;
+using orbit_client_data::CallstackEvent;
 using orbit_client_data::CaptureData;
 using orbit_client_data::ModuleManager;
 using orbit_client_data::PostProcessedSamplingData;
@@ -23,7 +25,6 @@ using orbit_client_data::SampledFunction;
 using orbit_client_data::SortedCallstackReport;
 using orbit_client_data::ThreadSampleData;
 
-using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::LinuxAddressInfo;
 
@@ -134,11 +135,8 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
 
   void AddCallstackEvent(uint64_t callstack_id, uint32_t thread_id) {
     current_callstack_timestamp_ns_ += 100;
-    CallstackEvent callstack_event;
-    callstack_event.set_time(current_callstack_timestamp_ns_);
-    callstack_event.set_callstack_id(callstack_id);
-    callstack_event.set_thread_id(thread_id);
-    capture_data_.AddCallstackEvent(std::move(callstack_event));
+    CallstackEvent callstack_event{current_callstack_timestamp_ns_, callstack_id, thread_id};
+    capture_data_.AddCallstackEvent(callstack_event);
   }
 
   void AddAddressInfo(std::string module_path, std::string function_name, uint64_t absolute_address,

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -45,12 +45,6 @@ message FunctionInfo {
   uint64 size = 7;
 }
 
-message CallstackEvent {
-  uint64 time = 1;
-  uint64 callstack_id = 2;
-  uint32 thread_id = 3;
-}
-
 message CallstackInfo {
   repeated uint64 frames = 1;
 

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -23,6 +23,7 @@
 
 #include "CaptureClient/CaptureClient.h"
 #include "CaptureClient/CaptureListener.h"
+#include "ClientData/CallstackEvent.h"
 #include "ClientData/FunctionUtils.h"
 #include "ClientData/ProcessData.h"
 #include "ClientData/UserDefinedCaptureData.h"
@@ -49,11 +50,11 @@ using orbit_capture_client::CaptureClient;
 using orbit_capture_client::CaptureEventProcessor;
 using orbit_capture_client::CaptureListener;
 
+using orbit_client_data::CallstackEvent;
 using orbit_client_data::CaptureData;
 using orbit_client_data::ProcessData;
 using orbit_client_data::TracepointInfoSet;
 
-using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::LinuxAddressInfo;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -96,6 +96,7 @@ using orbit_capture_client::CaptureListener;
 using orbit_capture_file::CaptureFile;
 
 using orbit_client_data::CallstackData;
+using orbit_client_data::CallstackEvent;
 using orbit_client_data::CaptureData;
 using orbit_client_data::ModuleData;
 using orbit_client_data::PostProcessedSamplingData;
@@ -107,7 +108,6 @@ using orbit_client_data::TimerChain;
 using orbit_client_data::TracepointInfoSet;
 using orbit_client_data::UserDefinedCaptureData;
 
-using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -158,7 +158,7 @@ class OrbitApp final : public DataViewFactory,
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallstack(uint64_t callstack_id,
                          orbit_client_protos::CallstackInfo callstack) override;
-  void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;
+  void OnCallstackEvent(orbit_client_data::CallstackEvent callstack_event) override;
   void OnThreadName(uint32_t thread_id, std::string thread_name) override;
   void OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo thread_state_slice) override;
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) override;
@@ -462,7 +462,7 @@ class OrbitApp final : public DataViewFactory,
   // origin_is_multiple_threads defines if the selection is specific to a single thread,
   // or spans across multiple threads.
   void SelectCallstackEvents(
-      const std::vector<orbit_client_protos::CallstackEvent>& selected_callstack_events,
+      const std::vector<orbit_client_data::CallstackEvent>& selected_callstack_events,
       bool origin_is_multiple_threads);
 
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info) override;

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -29,9 +29,9 @@
 #include "Viewport.h"
 
 using orbit_client_data::CallstackData;
+using orbit_client_data::CallstackEvent;
 using orbit_client_data::CaptureData;
 using orbit_client_data::ThreadID;
-using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::CallstackInfo;
 
 namespace orbit_gl {
@@ -114,7 +114,7 @@ void CallstackThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text
   if (!picking) {
     // Draw all callstack samples.
     auto action_on_callstack_events = [&](const CallstackEvent& event) {
-      const uint64_t time = event.time();
+      const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
       Vec2 pos(timeline_info_->GetWorldFromTick(time), GetPos()[1]);
       Color color = kWhite;
@@ -135,9 +135,9 @@ void CallstackThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text
 
     // Draw selected callstack samples.
     auto action_on_selected_callstack_events = [&](const CallstackEvent& event) {
-      const uint64_t time = event.time();
+      const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(timeline_info_->GetWorldFromTick(event.time()), GetPos()[1]);
+      Vec2 pos(timeline_info_->GetWorldFromTick(event.timestamp_ns()), GetPos()[1]);
       batcher.AddVerticalLine(pos, track_height, z, kGreenSelection);
     };
     const orbit_client_data::CallstackData& selection_callstack_data =
@@ -156,7 +156,7 @@ void CallstackThreadBar::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text
     constexpr const float kPickingBoxOffset = (kPickingBoxWidth - 1.0f) / 2.0f;
 
     auto action_on_callstack_events = [&, this](const CallstackEvent& event) {
-      const uint64_t time = event.time();
+      const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
       Vec2 pos(timeline_info_->GetWorldFromTick(time) - kPickingBoxOffset, GetPos()[1]);
       Vec2 size(kPickingBoxWidth, track_height);

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -5,6 +5,7 @@
 #include "IntrospectionWindow.h"
 
 #include "App.h"
+#include "ClientData/CallstackEvent.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/Logging.h"
 
@@ -130,7 +131,7 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
                          orbit_client_protos::CallstackInfo /*callstack*/) override {
     ORBIT_UNREACHABLE();
   }
-  void OnCallstackEvent(orbit_client_protos::CallstackEvent /*callstack_event*/) override {
+  void OnCallstackEvent(orbit_client_data::CallstackEvent /*callstack_event*/) override {
     ORBIT_UNREACHABLE();
   }
   void OnThreadName(uint32_t /*thread_id*/, std::string /*thread_name*/) override {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -17,6 +17,7 @@
 #include "AsyncTrack.h"
 #include "CGroupAndProcessMemoryTrack.h"
 #include "CaptureClient/CaptureEventProcessor.h"
+#include "ClientData/CallstackEvent.h"
 #include "ClientData/FunctionUtils.h"
 #include "ClientFlags/ClientFlags.h"
 #include "FrameTrack.h"
@@ -36,10 +37,10 @@
 
 using orbit_capture_client::CaptureEventProcessor;
 
+using orbit_client_data::CallstackEvent;
 using orbit_client_data::CaptureData;
 using orbit_client_data::TimerChain;
 using orbit_client_protos::ApiTrackValue;
-using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::TimerInfo;
 
 using orbit_gl::CGroupAndProcessMemoryTrack;

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -16,7 +16,6 @@
 
 #include "AccessibleTrackContainer.h"
 #include "App.h"
-#include "CaptureClient/CaptureEventProcessor.h"
 #include "ClientData/FunctionUtils.h"
 #include "ClientFlags/ClientFlags.h"
 #include "DisplayFormats/DisplayFormats.h"
@@ -33,15 +32,9 @@
 
 namespace orbit_gl {
 
-using orbit_capture_client::CaptureEventProcessor;
-
 using orbit_client_data::CaptureData;
 using orbit_client_data::ModuleManager;
-using orbit_client_data::TimerChain;
-using orbit_client_protos::ApiTrackValue;
-using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::TimerInfo;
-
 using orbit_grpc_protos::InstrumentedFunction;
 
 TrackContainer::TrackContainer(CaptureViewElement* parent, TimelineInfoInterface* timeline_info,

--- a/src/OrbitGl/TrackTestData.cpp
+++ b/src/OrbitGl/TrackTestData.cpp
@@ -4,6 +4,8 @@
 
 #include "TrackTestData.h"
 
+#include "ClientData/CallstackEvent.h"
+
 using orbit_client_data::CaptureData;
 
 namespace orbit_gl {
@@ -29,10 +31,8 @@ std::unique_ptr<CaptureData> TrackTestData::GenerateTestCaptureData() {
   capture_data->AddUniqueCallstack(kCallstackId, std::move(callstack_info));
 
   // CallstackEvent
-  orbit_client_protos::CallstackEvent callstack_event;
-  callstack_event.set_callstack_id(kCallstackId);
-  callstack_event.set_thread_id(kThreadId);
-  capture_data->AddCallstackEvent(std::move(callstack_event));
+  orbit_client_data::CallstackEvent callstack_event{1234, kCallstackId, kThreadId};
+  capture_data->AddCallstackEvent(callstack_event);
 
   capture_data->AddOrAssignThreadName(kThreadId, kThreadName);
   capture_data->AddOrAssignThreadName(kTimerOnlyThreadId, kTimerOnlyThreadName);

--- a/src/OrbitQt/CallTreeViewItemModelTest.cpp
+++ b/src/OrbitQt/CallTreeViewItemModelTest.cpp
@@ -10,6 +10,7 @@
 
 #include "CallTreeView.h"
 #include "CallTreeViewItemModel.h"
+#include "ClientData/CallstackEvent.h"
 #include "ClientData/CaptureData.h"
 #include "ClientData/PostProcessedSamplingData.h"
 #include "ClientModel/SamplingDataPostProcessor.h"
@@ -50,10 +51,8 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData() {
   capture_data->AddUniqueCallstack(kCallstackId, std::move(callstack_info));
 
   // CallstackEvent
-  orbit_client_protos::CallstackEvent callstack_event;
-  callstack_event.set_callstack_id(kCallstackId);
-  callstack_event.set_thread_id(kThreadId);
-  capture_data->AddCallstackEvent(std::move(callstack_event));
+  orbit_client_data::CallstackEvent callstack_event{1234, kCallstackId, kThreadId};
+  capture_data->AddCallstackEvent(callstack_event);
 
   capture_data->AddOrAssignThreadName(kThreadId, kThreadName);
 


### PR DESCRIPTION
This gives us control over the interface (we can add the constructor) and the
implementation (e.g., 40 to 24 bytes, which will be useful to offset the
upcoming changes...).

This and many other protos in `capture_data.proto` are protos because they were
used in the old capture format, but that's gone now.

Bug: http://b/216089402

Test: Build, take some captures.