### PR TITLE
Show call targets in disassembly view (if possible)

### DIFF
--- a/src/CodeReport/AnnotateDisassemblyTest.cpp
+++ b/src/CodeReport/AnnotateDisassemblyTest.cpp
@@ -58,7 +58,10 @@ static void TestSimple(bool windows_line_endings) {
   function_info.set_size(kMainFunctionInstructions.size());
 
   orbit_code_report::Disassembler disassembler{};
-  disassembler.Disassemble(static_cast<const void*>(kMainFunctionInstructions.data()),
+  orbit_client_data::ProcessData process;
+  orbit_client_data::ModuleManager module_manager;
+  disassembler.Disassemble(process, module_manager,
+                           static_cast<const void*>(kMainFunctionInstructions.data()),
                            kMainFunctionInstructions.size(), 0x401140, true);
   orbit_code_report::DisassemblyReport report{std::move(disassembler), kAddressOfMainFunction};
 

--- a/src/CodeReport/AssemblyTestLiterals.h
+++ b/src/CodeReport/AssemblyTestLiterals.h
@@ -42,7 +42,7 @@ constexpr std::string_view kFibonacciDisassembledNoSymbolsLoaded =
     "0x40103e:\tje           0x40104f\n"
     "0x401040:\tlea          edi, [rbx - 1]\n"
     "0x401043:\tsub          ebx, 2\n"
-    "0x401046:\tcall         0x401030 ([???])\n"
+    "0x401046:\tcall         0x401030 (\?\?\?)\n"
     "0x40104b:\tadd          ebp, eax\n"
     "0x40104d:\tjmp          0x401037\n"
     "0x40104f:\tlea          eax, [rbp + rbx]\n"

--- a/src/CodeReport/AssemblyTestLiterals.h
+++ b/src/CodeReport/AssemblyTestLiterals.h
@@ -25,7 +25,7 @@ constexpr std::string_view kFibonacciAssembly =
     "\x85\xdb\x74\x14\x83\xfb\x01\x74\x0f\x8d\x7b\xff\x83\xeb\x02\xe8\xe5\xff\xff\xff\x01\xc5\xeb"
     "\xe8\x8d\x44\x1d\x00\x5a\x5b\x5d\xc3\x01\x1f\x80\x00\x00\x00\x00"sv;
 
-constexpr std::string_view kFibonacciDisassembled =
+constexpr std::string_view kFibonacciDisassembledNoSymbolsLoaded =
     "Platform: X86 64 (Intel syntax)\n"  // Line 0
     "0x401020:\txor          eax, eax\n"
     "0x401022:\tret          \n"
@@ -42,7 +42,37 @@ constexpr std::string_view kFibonacciDisassembled =
     "0x40103e:\tje           0x40104f\n"
     "0x401040:\tlea          edi, [rbx - 1]\n"
     "0x401043:\tsub          ebx, 2\n"
-    "0x401046:\tcall         0x401030\n"
+    "0x401046:\tcall         0x401030 ([???])\n"
+    "0x40104b:\tadd          ebp, eax\n"
+    "0x40104d:\tjmp          0x401037\n"
+    "0x40104f:\tlea          eax, [rbp + rbx]\n"
+    "0x401053:\tpop          rdx\n"
+    "0x401054:\tpop          rbx\n"
+    "0x401055:\tpop          rbp\n"
+    "0x401056:\tret          \n"
+    "0x401057:\tadd          dword ptr [rdi], ebx\n"  // Line 24
+    "0x401059:\tadd          byte ptr [rax], 0\n"
+    "0x40105c:\tadd          byte ptr [rax], al\n"
+    "0x40105e:\n\n"sv;  // Line 27 & 28
+
+constexpr std::string_view kFibonacciDisassembledWithSymbolsLoaded =
+    "Platform: X86 64 (Intel syntax)\n"  // Line 0
+    "0x401020:\txor          eax, eax\n"
+    "0x401022:\tret          \n"
+    "0x401023:\tnop          word ptr cs:[rax + rax]\n"
+    "0x40102d:\tnop          dword ptr [rax]\n"  // Line 4
+    "0x401030:\tpush         rbp\n"
+    "0x401031:\txor          ebp, ebp\n"
+    "0x401033:\tpush         rbx\n"
+    "0x401034:\tmov          ebx, edi\n"
+    "0x401036:\tpush         rcx\n"
+    "0x401037:\ttest         ebx, ebx\n"
+    "0x401039:\tje           0x40104f\n"
+    "0x40103b:\tcmp          ebx, 1\n"  // Line 12
+    "0x40103e:\tje           0x40104f\n"
+    "0x401040:\tlea          edi, [rbx - 1]\n"
+    "0x401043:\tsub          ebx, 2\n"
+    "0x401046:\tcall         0x401030 (int fib(int))\n"
     "0x40104b:\tadd          ebp, eax\n"
     "0x40104d:\tjmp          0x401037\n"
     "0x40104f:\tlea          eax, [rbp + rbx]\n"

--- a/src/CodeReport/DisassemblerTest.cpp
+++ b/src/CodeReport/DisassemblerTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <ObjectUtils/Address.h>
 #include <gtest/gtest.h>
 
 #include "AssemblyTestLiterals.h"
@@ -9,13 +10,17 @@
 
 using orbit_code_report::kFibonacciAbsoluteAddress;
 using orbit_code_report::kFibonacciAssembly;
-using orbit_code_report::kFibonacciDisassembled;
+using orbit_code_report::kFibonacciDisassembledNoSymbolsLoaded;
+using orbit_code_report::kFibonacciDisassembledWithSymbolsLoaded;
 
 TEST(Disassembler, Disassemble) {
   orbit_code_report::Disassembler disassembler{};
-  disassembler.Disassemble(static_cast<const void*>(kFibonacciAssembly.data()),
+  orbit_client_data::ProcessData empty_process{};
+  orbit_client_data::ModuleManager empty_module_manager{};
+  disassembler.Disassemble(empty_process, empty_module_manager,
+                           static_cast<const void*>(kFibonacciAssembly.data()),
                            kFibonacciAssembly.size(), kFibonacciAbsoluteAddress, true);
-  EXPECT_EQ(disassembler.GetResult(), kFibonacciDisassembled);
+  EXPECT_EQ(disassembler.GetResult(), kFibonacciDisassembledNoSymbolsLoaded);
   EXPECT_EQ(disassembler.GetAddressAtLine(0), 0);
   EXPECT_EQ(disassembler.GetAddressAtLine(4), kFibonacciAbsoluteAddress + 0x0d);
   EXPECT_EQ(disassembler.GetAddressAtLine(12), kFibonacciAbsoluteAddress + 0x1b);
@@ -32,4 +37,40 @@ TEST(Disassembler, Disassemble) {
   EXPECT_EQ(disassembler.GetLineAtAddress(kFibonacciAbsoluteAddress + 0x37).value_or(0), 24);
   EXPECT_FALSE(disassembler.GetLineAtAddress(kFibonacciAbsoluteAddress + 0xdf).has_value());
   EXPECT_FALSE(disassembler.GetLineAtAddress(0x0).has_value());
+}
+
+TEST(Disassembler, DisassembleWithSymbols) {
+  orbit_code_report::Disassembler disassembler{};
+
+  orbit_grpc_protos::ModuleInfo module_info;
+  constexpr uint64_t kOffset = kFibonacciAbsoluteAddress % orbit_object_utils::kPageSize;
+  module_info.set_address_start(kFibonacciAbsoluteAddress - kOffset);
+  module_info.set_address_end(kFibonacciAbsoluteAddress + kFibonacciAssembly.size());
+  constexpr const char* kBuildId = "build_id";
+  constexpr const char* kFilePath = "path/to/file";
+  module_info.set_build_id(kBuildId);
+  module_info.set_file_path(kFilePath);
+
+  orbit_client_data::ProcessData process{};
+  process.AddOrUpdateModuleInfo(module_info);
+
+  orbit_client_data::ModuleManager module_manager{};
+  (void)module_manager.AddOrUpdateModules({module_info});
+  orbit_client_data::ModuleData* module_data =
+      module_manager.GetMutableModuleByPathAndBuildId(kFilePath, kBuildId);
+
+  orbit_grpc_protos::ModuleSymbols symbols;
+  orbit_grpc_protos::SymbolInfo* symbol = symbols.add_symbol_infos();
+  symbol->set_address(kOffset);
+  constexpr const char* kFunctionName = "_Z3fibi";
+  symbol->set_name(kFunctionName);
+  constexpr const char* kDemangledFunctionName = "int fib(int)";
+  symbol->set_demangled_name(kDemangledFunctionName);
+  symbol->set_size(kFibonacciAssembly.size());
+  module_data->AddSymbols(symbols);
+
+  disassembler.Disassemble(process, module_manager,
+                           static_cast<const void*>(kFibonacciAssembly.data()),
+                           kFibonacciAssembly.size(), kFibonacciAbsoluteAddress, true);
+  EXPECT_EQ(disassembler.GetResult(), kFibonacciDisassembledWithSymbolsLoaded);
 }

--- a/src/CodeReport/DisassemblyReportTest.cpp
+++ b/src/CodeReport/DisassemblyReportTest.cpp
@@ -19,7 +19,10 @@ TEST(DisassemblyReport, Empty) {
   // We expect all counters to be 0 and not to crash when poking.
 
   orbit_code_report::Disassembler disassembler{};
-  disassembler.Disassemble(static_cast<const void*>(kFibonacciAssembly.data()),
+  orbit_client_data::ProcessData process;
+  orbit_client_data::ModuleManager module_manager;
+  disassembler.Disassemble(process, module_manager,
+                           static_cast<const void*>(kFibonacciAssembly.data()),
                            kFibonacciAssembly.size(), kFibonacciAbsoluteAddress, true);
 
   orbit_code_report::DisassemblyReport disassembly_report{disassembler, kFibonacciAbsoluteAddress};
@@ -53,7 +56,10 @@ TEST(DisassemblyReport, Simple) {
   // This creates a simple DisassemblyReport with samples in three different locations.
 
   orbit_code_report::Disassembler disassembler{};
-  disassembler.Disassemble(static_cast<const void*>(kFibonacciAssembly.data()),
+  orbit_client_data::ProcessData process;
+  orbit_client_data::ModuleManager module_manager;
+  disassembler.Disassemble(process, module_manager,
+                           static_cast<const void*>(kFibonacciAssembly.data()),
                            kFibonacciAssembly.size(), kFibonacciAbsoluteAddress, true);
 
   constexpr size_t kFunctionCount = 7;

--- a/src/CodeReport/include/CodeReport/Disassembler.h
+++ b/src/CodeReport/include/CodeReport/Disassembler.h
@@ -5,6 +5,7 @@
 #ifndef CODE_REPORT_DISASSEMBLER_H_
 #define CODE_REPORT_DISASSEMBLER_H_
 
+#include <absl/container/flat_hash_map.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -12,12 +13,15 @@
 #include <string>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
+#include "ClientData/ModuleManager.h"
+#include "ClientData/ProcessData.h"
 
 namespace orbit_code_report {
 class Disassembler {
  public:
-  void Disassemble(const void* machine_code, size_t size, uint64_t address, bool is_64bit);
+  void Disassemble(orbit_client_data::ProcessData& process,
+                   orbit_client_data::ModuleManager& module_manager, const void* machine_code,
+                   size_t size, uint64_t address, bool is_64bit);
   void AddLine(std::string, std::optional<uint64_t> address = std::nullopt);
 
   [[nodiscard]] const std::string& GetResult() const { return result_; }

--- a/src/CodeViewerDemo/CodeExamples.h
+++ b/src/CodeViewerDemo/CodeExamples.h
@@ -351,6 +351,9 @@ inline const QString x86Assembly_example = R"(Platform: X86 64 (Intel syntax)
 0x557e1f8091d4:	sub          rsp, 0x10
 0x557e1f8091d8:	mov          rax, qword ptr fs:[0x28]
 0x557e1f8091e1:	mov          qword ptr [rbp - 8], rax
+0x557e1f8091e2:	call         0x123 (bbb::foo())
+0x557e1f8091e3:	call         0x123 (bbb::foo<int a, std::function<void (int)>>(int, std::function<void (B)>))
+0x55da67cf3ee4:	call         0x55da686727c0 ([???])
 0x557e1f8091e5:	xorps        xmm0, xmm0
 0x557e1f8091e8:	movups       xmmword ptr [rdi], xmm0
 0x557e1f8091eb:	mov          qword ptr [rdi + 0x10], 0

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -903,7 +903,8 @@ void OrbitApp::Disassemble(uint32_t pid, const FunctionInfo& function) {
     orbit_code_report::Disassembler disasm;
     disasm.AddLine(absl::StrFormat("asm: /* %s */",
                                    orbit_client_data::function_utils::GetDisplayName(function)));
-    disasm.Disassemble(memory.data(), memory.size(), absolute_address, is_64_bit);
+    disasm.Disassemble(*process_, *module_manager_, memory.data(), memory.size(), absolute_address,
+                       is_64_bit);
     if (!HasCaptureData() || !GetCaptureData().has_post_processed_sampling_data()) {
       orbit_code_report::DisassemblyReport empty_report(disasm, absolute_address);
       SendDisassemblyToUi(function, disasm.GetResult(), std::move(empty_report));

--- a/src/OrbitQt/AnnotatingSourceCodeDialogTest.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialogTest.cpp
@@ -70,7 +70,10 @@ TEST(AnnotatingSourceCodeDialog, SmokeTest) {
   function_info.set_size(kMainFunctionInstructions.size());
 
   orbit_code_report::Disassembler disassembler{};
-  disassembler.Disassemble(static_cast<const void*>(kMainFunctionInstructions.data()),
+  orbit_client_data::ProcessData process_data{};
+  orbit_client_data::ModuleManager module_manager{};
+  disassembler.Disassemble(process_data, module_manager,
+                           static_cast<const void*>(kMainFunctionInstructions.data()),
                            kMainFunctionInstructions.size(), 0x401140, true);
   std::string assembly = disassembler.GetResult();
   orbit_code_report::DisassemblyReport report{std::move(disassembler), kAddressOfMainFunction};

--- a/src/SyntaxHighlighter/X86Assembly.cpp
+++ b/src/SyntaxHighlighter/X86Assembly.cpp
@@ -23,9 +23,10 @@ const QColor kOpcodeColor{0xf8, 0xc5, 0x55};
 const QColor kNumberColor{0xf0, 0x8d, 0x49};
 const QColor kRegisterColor{0x7e, 0xc6, 0x99};
 const QColor kKeywordColor{0xcc, 0x99, 0xcd};
+const QColor kCallTargetColor{0x80, 0x80, 0x00};
 
 namespace AssemblyRegex {
-const QRegularExpression kCaracterRegex{"\\S"};
+const QRegularExpression kCharacterRegex{"\\S"};
 const QRegularExpression kNumberRegex{"\\s(0x)?[\\da-f]+\\b"};
 const QRegularExpression kProgramCounterRegex{"^0x[0-9a-f]+:"};
 const QRegularExpression kOpCodeRegex{
@@ -213,6 +214,7 @@ const QRegularExpression kRegisterRegex{
 const QRegularExpression kKeywordRegex{"\\b(?:ptr|[xy]mmword|[sdq]?word|byte)\\b"};
 const QRegularExpression kCommentRegex{";.*$"};
 const QRegularExpression kPlatformRegex{"^Platform:.*$"};
+const QRegularExpression kCallTargetRegex{"(?<=\\()(.*?\\(.*?\\)+|\\[.*?\\])(?=\\))"};
 }  // namespace AssemblyRegex
 }  // namespace
 
@@ -247,7 +249,7 @@ void HighlightAnnotatingBlock(
     }
   };
 
-  apply(AssemblyRegex::kCaracterRegex, default_color);
+  apply(AssemblyRegex::kCharacterRegex, default_color);
 }
 
 void HighlightBlockAssembly(
@@ -270,5 +272,6 @@ void HighlightBlockAssembly(
   apply(AssemblyRegex::kKeywordRegex, kKeywordColor);
   apply(AssemblyRegex::kCommentRegex, kCommentColor);
   apply(AssemblyRegex::kPlatformRegex, kPlatformColor);
+  apply(AssemblyRegex::kCallTargetRegex, kCallTargetColor);
 }
 }  // namespace orbit_syntax_highlighter

--- a/src/SyntaxHighlighter/X86Assembly.cpp
+++ b/src/SyntaxHighlighter/X86Assembly.cpp
@@ -214,7 +214,7 @@ const QRegularExpression kRegisterRegex{
 const QRegularExpression kKeywordRegex{"\\b(?:ptr|[xy]mmword|[sdq]?word|byte)\\b"};
 const QRegularExpression kCommentRegex{";.*$"};
 const QRegularExpression kPlatformRegex{"^Platform:.*$"};
-const QRegularExpression kCallTargetRegex{"(?<=\\()(.*?\\(.*?\\)+|\\[.*?\\])(?=\\))"};
+const QRegularExpression kCallTargetRegex{"(?<=\\()(.*?\\(.*?\\)+|\\?\\?\\?)(?=\\))"};
 }  // namespace AssemblyRegex
 }  // namespace
 


### PR DESCRIPTION
Currently, in disassembly view, call instructions only show
a target address. In is quite some figure out what the actual
target function will be.

This change, does a simple approache to show the target function
name. It tries to convert the operant of a call instruction
into a hex number and check if there is a function under this
number interpreted as absolute address. If not it will show
[???] as function name (as in the other views).

As a result, the change will not be able to resolve relative
calls, as well as more complex calls (e.g. based on registers).

In general, function names will always be in addtion to the
actual disassembly string, i.e.:

call         0x401030 (int fib(int))

Test: Open disassembly from modules/function tab as well as from
      sampling tab. Also open the CodeViewerDemo (for highlighting).
      Run unit test.
Bug: http://177827187