### PR TITLE
Replace ThreadSampleData.sampled_callstack_id_to_count with ...to_events

### DIFF
--- a/src/ClientData/PostProcessedSamplingData.cpp
+++ b/src/ClientData/PostProcessedSamplingData.cpp
@@ -57,9 +57,9 @@ static std::multimap<int, uint64_t> SortCallstacksByCount(const ThreadSampleData
                                                           const std::set<uint64_t>& callstacks) {
   std::multimap<int, uint64_t> sorted_callstacks;
   for (uint64_t id : callstacks) {
-    auto it = data.sampled_callstack_id_to_count.find(id);
-    if (it != data.sampled_callstack_id_to_count.end()) {
-      int count = it->second;
+    auto it = data.sampled_callstack_id_to_events.find(id);
+    if (it != data.sampled_callstack_id_to_events.end()) {
+      int count = it->second.size();
       sorted_callstacks.insert(std::make_pair(count, id));
     }
   }

--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "ClientData/CallstackEvent.h"
 #include "ClientData/CallstackTypes.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/ThreadConstants.h"
@@ -41,7 +42,8 @@ struct ThreadSampleData {
 
   ThreadID thread_id = 0;
   uint32_t samples_count = 0;
-  absl::flat_hash_map<uint64_t, uint32_t> sampled_callstack_id_to_count;
+  absl::flat_hash_map<uint64_t, std::vector<orbit_client_data::CallstackEvent>>
+      sampled_callstack_id_to_events;
   absl::flat_hash_map<uint64_t, uint32_t> sampled_address_to_count;
   absl::flat_hash_map<uint64_t, uint32_t> resolved_address_to_count;
   absl::flat_hash_map<uint64_t, uint32_t> resolved_address_to_exclusive_count;

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -99,48 +99,6 @@ MATCHER_P(CallstackIdToCallstackEventsEq, that, "") {
   return CallstackIdToCallstackEventPairsAreEqual(lhs, rhs);
 }
 
-MATCHER_P(ThreadSampleDataEq, that, "") {
-  const ThreadSampleData& lhs = arg;
-  const ThreadSampleData& rhs = that;
-
-  // Compare sampled_callstack_id_to_events.
-  auto sampled_callstack_id_to_event_pair_less =
-      [](const std::pair<uint64_t, std::vector<CallstackEvent>>& l,
-         const std::pair<uint64_t, std::vector<CallstackEvent>>& r) { return l.first < r.first; };
-
-  std::vector<std::pair<uint64_t, std::vector<CallstackEvent>>>
-      lhs_sampled_callstack_id_to_event_pairs;
-  for (const auto& [callstack_id, events] : lhs.sampled_callstack_id_to_events) {
-    lhs_sampled_callstack_id_to_event_pairs.emplace_back(callstack_id, events);
-  }
-  std::sort(lhs_sampled_callstack_id_to_event_pairs.begin(),
-            lhs_sampled_callstack_id_to_event_pairs.end(), sampled_callstack_id_to_event_pair_less);
-  std::vector<std::pair<uint64_t, std::vector<CallstackEvent>>>
-      rhs_sampled_callstack_id_to_event_pairs;
-  for (const auto& [callstack_id, events] : rhs.sampled_callstack_id_to_events) {
-    rhs_sampled_callstack_id_to_event_pairs.emplace_back(callstack_id, events);
-  }
-  std::sort(rhs_sampled_callstack_id_to_event_pairs.begin(),
-            rhs_sampled_callstack_id_to_event_pairs.end(), sampled_callstack_id_to_event_pair_less);
-  if (!std::equal(lhs_sampled_callstack_id_to_event_pairs.begin(),
-                  lhs_sampled_callstack_id_to_event_pairs.end(),
-                  rhs_sampled_callstack_id_to_event_pairs.begin(),
-                  rhs_sampled_callstack_id_to_event_pairs.end(),
-                  CallstackIdToCallstackEventPairsAreEqual)) {
-    return false;
-  }
-
-  // Compare the rest.
-  return lhs.thread_id == rhs.thread_id && lhs.samples_count == rhs.samples_count &&
-         lhs.sampled_address_to_count == rhs.sampled_address_to_count &&
-         lhs.resolved_address_to_count == rhs.resolved_address_to_count &&
-         lhs.resolved_address_to_exclusive_count == rhs.resolved_address_to_exclusive_count &&
-         lhs.sorted_count_to_resolved_address == rhs.sorted_count_to_resolved_address &&
-         std::equal(lhs.sampled_functions.begin(), lhs.sampled_functions.end(),
-                    rhs.sampled_functions.begin(), rhs.sampled_functions.end(),
-                    SampledFunctionsAreEqual);
-}
-
 SortedCallstackReport MakeSortedCallstackReport(
     const std::vector<std::pair<int, uint64_t>>& counts_and_callstack_ids) {
   SortedCallstackReport report{};

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -197,8 +197,8 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
        post_processed_sampling_data.GetSortedThreadSampleData()) {
     const uint32_t tid = thread_sample_data->thread_id;
 
-    for (const auto& [callstack_id, sample_count] :
-         thread_sample_data->sampled_callstack_id_to_count) {
+    for (const auto& [callstack_id, events] : thread_sample_data->sampled_callstack_id_to_events) {
+      uint64_t sample_count = events.size();
       const CallstackInfo& resolved_callstack =
           post_processed_sampling_data.GetResolvedCallstack(callstack_id);
 
@@ -287,8 +287,8 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedS
       continue;
     }
 
-    for (const auto& [callstack_id, sample_count] :
-         thread_sample_data->sampled_callstack_id_to_count) {
+    for (const auto& [callstack_id, events] : thread_sample_data->sampled_callstack_id_to_events) {
+      uint64_t sample_count = events.size();
       const CallstackInfo& resolved_callstack =
           post_processed_sampling_data.GetResolvedCallstack(callstack_id);
 


### PR DESCRIPTION
This will be needed in the next change to determine which `CallstackEvent`s
pertain to each node of a `CallTreeView`.

`SamplingDataPostProcessorTest` becomes a bit more complex.

Bug: http://b/168218963

Test: Unit tests. Tried as part of the whole "make a selection from a sub-tree"
prototype.