### PR TITLE
Assure no overlap between labels and ticks

### DIFF
--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -23,34 +23,40 @@ void TimelineUi::RenderLines(Batcher& batcher, uint64_t min_timestamp_ns,
     float world_x = timeline_info_interface_->GetWorldFromUs(
         tick_ns / static_cast<double>(kNanosecondsPerMicrosecond));
     int screen_x = viewport_->WorldToScreen(Vec2(world_x, 0))[0];
-    // TODO(b/208447247): Assure no overlap between minor ticks and labels.
     batcher.AddVerticalLine(
-        Vec2(screen_x, GetPos()[1]), ticks_height, GlCanvas::kZValueTimeBar,
+        Vec2(screen_x, GetPos()[1]), ticks_height, GlCanvas::kZValueTimeBarBg,
         tick_type == TimelineTicks::TickType::kMajorTick ? kMajorTickColor : kMinorTickColor);
   }
 }
 
-void TimelineUi::RenderLabels(TextRenderer& text_renderer, uint64_t min_timestamp_ns,
-                              uint64_t max_timestamp_ns) const {
+void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
+                              uint64_t min_timestamp_ns, uint64_t max_timestamp_ns) const {
   const float kLabelMarginLeft = 4;
   const float kLabelMarginBottom = 2;
+
+  float previous_label_end_x = std::numeric_limits<float>::lowest();
   for (uint64_t tick_ns : timeline_ticks_.GetMajorTicks(min_timestamp_ns, max_timestamp_ns)) {
     // TODO (b/170712621): Test the new format (ISO 8601) to draw timestamps.
     std::string text = orbit_display_formats::GetDisplayTime(absl::Nanoseconds(tick_ns));
 
     float world_x = timeline_info_interface_->GetWorldFromUs(
         tick_ns / static_cast<double>(kNanosecondsPerMicrosecond));
-    float label_bottom_y = GetPos()[1] + GetHeight() - kLabelMarginBottom;
-    text_renderer.AddText(text.c_str(), world_x + kLabelMarginLeft, label_bottom_y,
-                          GlCanvas::kZValueTimeBar,
-                          {layout_->GetFontSize(), Color(255, 255, 255, 255), -1.f,
-                           TextRenderer::HAlign::Left, TextRenderer::VAlign::Bottom});
+    if (world_x > previous_label_end_x) {
+      Vec2 pos, size;
+      float label_bottom_y = GetPos()[1] + GetHeight() - kLabelMarginBottom;
+      text_renderer.AddText(text.c_str(), world_x + kLabelMarginLeft, label_bottom_y,
+                            GlCanvas::kZValueTimeBar,
+                            {layout_->GetFontSize(), Color(255, 255, 255, 255), -1.f,
+                             TextRenderer::HAlign::Left, TextRenderer::VAlign::Bottom},
+                            &pos, &size);
+      previous_label_end_x = pos[0] + size[0];
+      Box background_box(pos, size, GlCanvas::kZValueTimeBar);
+      batcher.AddBox(background_box, GlCanvas::kTimeBarBackgroundColor);
+    }
   }
 }
 
 void TimelineUi::RenderBackground(Batcher& batcher) const {
-  Vec2 pos = GetPos();
-  Vec2 size = GetSize();
   Box background_box(GetPos(), GetSize(), GlCanvas::kZValueTimeBarBg);
   batcher.AddBox(background_box, GlCanvas::kTimeBarBackgroundColor);
 }
@@ -65,7 +71,7 @@ void TimelineUi::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_rendere
   uint64_t min_timestamp_ns = timeline_info_interface_->GetNsSinceStart(min_tick);
   uint64_t max_timestamp_ns = timeline_info_interface_->GetNsSinceStart(max_tick);
   RenderLines(batcher, min_timestamp_ns, max_timestamp_ns);
-  RenderLabels(text_renderer, min_timestamp_ns, max_timestamp_ns);
+  RenderLabels(batcher, text_renderer, min_timestamp_ns, max_timestamp_ns);
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> TimelineUi::CreateAccessibleInterface() {

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -26,7 +26,7 @@ class TimelineUi : public CaptureViewElement {
   void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                           uint64_t max_tick, PickingMode picking_mode) override;
   void RenderLines(Batcher& batcher, uint64_t min_timestamp_ns, uint64_t max_timestamp_ns) const;
-  void RenderLabels(TextRenderer& text_renderer, uint64_t min_timestamp_ns,
+  void RenderLabels(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_timestamp_ns,
                     uint64_t max_timestamp_ns) const;
   void RenderBackground(Batcher& batcher) const;
 


### PR DESCRIPTION
This PR is solving 2 overlap issues:
- Ticks won't be visible if there is a label on top of them (solved by
  drawing a rectangle with the background color between ticks and
  labels). This is mostly to include minor ticks who overlap very often
  with labels.
- Labels won't be draw if they overlap with previous ones. This is a
  temporal solution, which is better than the current state but has a
  flickering and a jumping issue. Both will be solved soon.

There is no bug created for this issue, but we can think it as part of
including Minor Ticks (http://b/208447247).

Screenshot: Overlapping ticks are shortened, labels aren't displayed.
http://screen/3NA6vWa5kFmHzTR

Test: Start a capture. Load a capture, make the capture windows very
small to be able to see overlaps.