### PR TITLE
Use btree_map for CallstackData::callstack_events_by_tid_

### DIFF
--- a/src/ClientData/CallstackData.cpp
+++ b/src/ClientData/CallstackData.cpp
@@ -54,7 +54,7 @@ std::vector<orbit_client_data::CallstackEvent> CallstackData::GetCallstackEvents
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::vector<CallstackEvent> callstack_events;
   for (const auto& tid_and_events : callstack_events_by_tid_) {
-    const std::map<uint64_t, CallstackEvent>& events = tid_and_events.second;
+    const absl::btree_map<uint64_t, CallstackEvent>& events = tid_and_events.second;
     for (auto event_it = events.lower_bound(time_begin); event_it != events.end(); ++event_it) {
       uint64_t time = event_it->first;
       if (time < time_end) {
@@ -86,7 +86,7 @@ std::vector<CallstackEvent> CallstackData::GetCallstackEventsOfTidInTimeRange(
     return callstack_events;
   }
 
-  const std::map<uint64_t, CallstackEvent>& events = tid_and_events_it->second;
+  const absl::btree_map<uint64_t, CallstackEvent>& events = tid_and_events_it->second;
   for (auto event_it = events.lower_bound(time_begin); event_it != events.end(); ++event_it) {
     uint64_t time = event_it->first;
     if (time < time_end) {

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -5,6 +5,8 @@
 #ifndef CLIENT_DATA_CALLSTACK_DATA_H_
 #define CLIENT_DATA_CALLSTACK_DATA_H_
 
+#include <absl/container/btree_map.h>
+#include <absl/container/flat_hash_map.h>
 #include <stdint.h>
 
 #include <functional>
@@ -17,7 +19,6 @@
 #include "CallstackTypes.h"
 #include "ClientData/CallstackEvent.h"
 #include "ClientProtos/capture_data.pb.h"
-#include "absl/container/flat_hash_map.h"
 
 namespace orbit_client_data {
 
@@ -95,7 +96,7 @@ class CallstackData {
   mutable std::recursive_mutex mutex_;
   absl::flat_hash_map<uint64_t, std::shared_ptr<orbit_client_protos::CallstackInfo>>
       unique_callstacks_;
-  absl::flat_hash_map<uint32_t, std::map<uint64_t, orbit_client_data::CallstackEvent>>
+  absl::flat_hash_map<uint32_t, absl::btree_map<uint64_t, orbit_client_data::CallstackEvent>>
       callstack_events_by_tid_;
 
   uint64_t max_time_ = 0;


### PR DESCRIPTION
This speeds up `CreatePostProcessedSamplingData` by ~15% (as per the
timings we print in the logs with a capture with 4M samples)
I expect it to also speed up the logic of the capture view related to
callstacks, but I didn't do any measurement there.