### PR TITLE
Dedup and test code around symbol file names

### DIFF
--- a/src/ProcessService/BUILD
+++ b/src/ProcessService/BUILD
@@ -18,6 +18,7 @@ orbit_cc_library(
         "//src/GrpcProtos:tracepoint_cc_proto",
         "//src/ObjectUtils",
         "//src/OrbitBase",
+        "//src/Symbols",
         "@com_github_grpc_grpc//:grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/base",

--- a/src/ProcessService/CMakeLists.txt
+++ b/src/ProcessService/CMakeLists.txt
@@ -27,7 +27,8 @@ target_sources(ProcessService PRIVATE
 target_link_libraries(ProcessService PUBLIC
         GrpcProtos
         ObjectUtils
-        OrbitBase)
+        OrbitBase
+        Symbols)
 
 add_executable(ProcessServiceTests)
 

--- a/src/Symbols/CMakeLists.txt
+++ b/src/Symbols/CMakeLists.txt
@@ -6,8 +6,12 @@ cmake_minimum_required(VERSION 3.15)
 
 add_library(Symbols STATIC)
 
-target_sources(Symbols PRIVATE SymbolHelper.cpp)
-target_sources(Symbols PUBLIC include/Symbols/SymbolHelper.h)
+target_sources(Symbols PRIVATE 
+        SymbolHelper.cpp
+        SymbolUtils.cpp)
+target_sources(Symbols PUBLIC 
+        include/Symbols/SymbolHelper.h
+        include/Symbols/SymbolUtils.h)
 
 target_include_directories(Symbols PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -18,8 +22,9 @@ target_link_libraries(Symbols PUBLIC
         ObjectUtils
         OrbitBase)
 
-
 add_executable(SymbolsTests)
-target_sources(SymbolsTests PRIVATE SymbolHelperTest.cpp)
+target_sources(SymbolsTests PRIVATE 
+        SymbolHelperTest.cpp
+        SymbolUtilsTest.cpp)
 target_link_libraries(SymbolsTests PRIVATE Symbols TestUtils GTest::Main)
 register_test(SymbolsTests)

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -31,6 +31,7 @@
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/WriteStringToFile.h"
+#include "Symbols/SymbolUtils.h"
 
 using orbit_grpc_protos::ModuleSymbols;
 
@@ -192,23 +193,13 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
     }
   }
 
-  // The file extensions for symbols files are .debug for elf files and .pdb for coff files. Only
-  // files with following formats are considered `module.sym_ext`, `module.mod_ext.sym_ext` and
-  // `module.mod_ext`. (`mod_ext` is the module file extension, usually .elf, .so, .exe or .dll;
-  // `sym_ext` is either .debug or .pdb)
-  std::string sym_ext = object_file_type == ModuleInfo::kElfFile ? ".debug" : ".pdb";
-
-  const fs::path& filename = module_path.filename();
-  fs::path filename_dot_sym_ext = filename;
-  filename_dot_sym_ext.replace_extension(sym_ext);
-  fs::path filename_plus_sym_ext = filename;
-  filename_plus_sym_ext.replace_extension(filename.extension().string() + sym_ext);
-
+  // Search in all directories for all the allowed symbol filenames
   std::set<fs::path> search_paths;
   for (const auto& directory : directories) {
-    search_paths.insert(directory / filename_dot_sym_ext);
-    search_paths.insert(directory / filename_plus_sym_ext);
-    search_paths.insert(directory / filename);
+    for (const auto& filename :
+         orbit_symbols::GetStandardSymbolFilenamesForModule(module_path, object_file_type)) {
+      search_paths.insert(directory / filename);
+    }
   }
 
   ORBIT_LOG("Trying to find symbols for module: \"%s\"", module_path.string());

--- a/src/Symbols/SymbolUtils.cpp
+++ b/src/Symbols/SymbolUtils.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Symbols/SymbolUtils.h"
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_symbols {
+
+[[nodiscard]] std::vector<std::filesystem::path> GetStandardSymbolFilenamesForModule(
+    const std::filesystem::path& module_path,
+    const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type) {
+  std::string sym_ext;
+  switch (object_file_type) {
+    case orbit_grpc_protos::ModuleInfo::kElfFile:
+      sym_ext = ".debug";
+      break;
+    case orbit_grpc_protos::ModuleInfo::kCoffFile:
+      sym_ext = ".pdb";
+      break;
+    case orbit_grpc_protos::ModuleInfo::kUnknown:
+      ORBIT_ERROR("Unknown object file type");
+      return {module_path.filename()};
+    case orbit_grpc_protos::
+        ModuleInfo_ObjectFileType_ModuleInfo_ObjectFileType_INT_MIN_SENTINEL_DO_NOT_USE_:
+      [[fallthrough]];
+    case orbit_grpc_protos::
+        ModuleInfo_ObjectFileType_ModuleInfo_ObjectFileType_INT_MAX_SENTINEL_DO_NOT_USE_:
+      ORBIT_UNREACHABLE();
+      break;
+  }
+
+  const std::filesystem::path& filename = module_path.filename();
+  std::filesystem::path filename_dot_sym_ext = filename;
+  filename_dot_sym_ext.replace_extension(sym_ext);
+  std::filesystem::path filename_plus_sym_ext = filename;
+  filename_plus_sym_ext.replace_extension(filename.extension().string() + sym_ext);
+
+  return {filename_dot_sym_ext, filename_plus_sym_ext, filename};
+}
+
+}  // namespace orbit_symbols

--- a/src/Symbols/SymbolUtilsTest.cpp
+++ b/src/Symbols/SymbolUtilsTest.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "Symbols/SymbolUtils.h"
+
+namespace orbit_symbols {
+
+TEST(GetStandardSymbolFilenamesForModule, ElfFile) {
+  orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type =
+      orbit_grpc_protos::ModuleInfo::kElfFile;
+  std::filesystem::path directory = std::filesystem::path{"path"} / "to" / "folder";
+  {  // .so file extention
+    const std::vector<std::filesystem::path> file_names =
+        GetStandardSymbolFilenamesForModule(directory / "lib.so", object_file_type);
+    EXPECT_THAT(file_names, testing::Contains("lib.debug"));
+    EXPECT_THAT(file_names, testing::Contains("lib.so.debug"));
+    EXPECT_THAT(file_names, testing::Contains("lib.so"));
+  }
+
+  {  // generic file extention (.ext)
+    const std::vector<std::filesystem::path> file_names =
+        GetStandardSymbolFilenamesForModule(directory / "lib.ext", object_file_type);
+    EXPECT_THAT(file_names, testing::Contains("lib.debug"));
+    EXPECT_THAT(file_names, testing::Contains("lib.ext.debug"));
+    EXPECT_THAT(file_names, testing::Contains("lib.ext"));
+  }
+}
+
+TEST(GetStandardSymbolFilenamesForModule, CoffFile) {
+  orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type =
+      orbit_grpc_protos::ModuleInfo::kCoffFile;
+  std::filesystem::path directory = std::filesystem::path{"C:"} / "path" / "to" / "folder";
+  {  // .dll file extention
+    const std::vector<std::filesystem::path> file_names =
+        GetStandardSymbolFilenamesForModule(directory / "lib.dll", object_file_type);
+    EXPECT_THAT(file_names, testing::Contains("lib.pdb"));
+    EXPECT_THAT(file_names, testing::Contains("lib.dll.pdb"));
+    EXPECT_THAT(file_names, testing::Contains("lib.pdb"));
+  }
+
+  {  // generic file extention (.ext)
+    const std::vector<std::filesystem::path> file_names =
+        GetStandardSymbolFilenamesForModule(directory / "lib.ext", object_file_type);
+    EXPECT_THAT(file_names, testing::Contains("lib.pdb"));
+    EXPECT_THAT(file_names, testing::Contains("lib.ext.pdb"));
+    EXPECT_THAT(file_names, testing::Contains("lib.ext"));
+  }
+}
+
+}  // namespace orbit_symbols

--- a/src/Symbols/include/Symbols/SymbolUtils.h
+++ b/src/Symbols/include/Symbols/SymbolUtils.h
@@ -13,9 +13,9 @@
 namespace orbit_symbols {
 
 // The file extensions for symbols files are .debug for elf files and .pdb for coff files. Only
-// files with following formats are considered `module.sym_ext`, `module.mod_ext.sym_ext` and
-// `module.mod_ext`. (`mod_ext` is the module file extension, usually .elf, .so, .exe or .dll;
-// `sym_ext` is either .debug or .pdb)
+// files with the following formats are considered: `module.sym_ext`, `module.mod_ext.sym_ext` and
+// `module.mod_ext` (`mod_ext` is the module file extension, usually .elf, .so, .exe or .dll;
+// `sym_ext` is either .debug or .pdb).
 [[nodiscard]] std::vector<std::filesystem::path> GetStandardSymbolFilenamesForModule(
     const std::filesystem::path& module_path,
     const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type);

--- a/src/Symbols/include/Symbols/SymbolUtils.h
+++ b/src/Symbols/include/Symbols/SymbolUtils.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SYMBOLS_SYMBOL_UTILS_H_
+#define SYMBOLS_SYMBOL_UTILS_H_
+
+#include <filesystem>
+#include <vector>
+
+#include "GrpcProtos/module.pb.h"
+
+namespace orbit_symbols {
+
+// The file extensions for symbols files are .debug for elf files and .pdb for coff files. Only
+// files with following formats are considered `module.sym_ext`, `module.mod_ext.sym_ext` and
+// `module.mod_ext`. (`mod_ext` is the module file extension, usually .elf, .so, .exe or .dll;
+// `sym_ext` is either .debug or .pdb)
+[[nodiscard]] std::vector<std::filesystem::path> GetStandardSymbolFilenamesForModule(
+    const std::filesystem::path& module_path,
+    const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type);
+
+}  // namespace orbit_symbols
+
+#endif  // SYMBOLS_SYMBOL_UTILS_H_


### PR DESCRIPTION
This extracts duplicate code from ProcessServiceUtils (OrbitService) and SymbolHelper and puts it in a free function in ObjectUtils/SymbolsFile.h (orbit_object_utils::GetAllowedSymbolFilenamesForModule). Also adds tests. 

SymbolsFile.h seemed like a good place to put the code, because ObjectUtils is already linked in ProcessService and Symbols. I am open to suggestions for a better location.