### PR TITLE
Add a method to get precision of Ticks

### DIFF
--- a/src/OrbitGl/TimelineTicks.cpp
+++ b/src/OrbitGl/TimelineTicks.cpp
@@ -69,19 +69,15 @@ std::vector<uint64_t> TimelineTicks::GetMajorTicks(uint64_t start_ns, uint64_t e
   return major_ticks;
 }
 
-int TimelineTicks::GetTimestampsNumDigitsPrecision(uint64_t start_ns, uint64_t end_ns) const {
+int TimelineTicks::GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const {
   constexpr int kMaxDigitsPrecision = 9;  // 1ns = 0.000'000'001s
 
   uint64_t current_precision_ns = kNanosecondsPerSecond;
   for (int num_digits = 0; num_digits < kMaxDigitsPrecision;
        num_digits++, current_precision_ns /= 10) {
-    bool precision_is_enough = true;
-    for (uint64_t timestamp : GetMajorTicks(start_ns, end_ns)) {
-      if (timestamp % current_precision_ns != 0) {
-        precision_is_enough = false;
-      }
+    if (timestamp_ns % current_precision_ns == 0) {
+      return num_digits;
     }
-    if (precision_is_enough) return num_digits;
   }
   return kMaxDigitsPrecision;
 }

--- a/src/OrbitGl/TimelineTicks.cpp
+++ b/src/OrbitGl/TimelineTicks.cpp
@@ -69,6 +69,23 @@ std::vector<uint64_t> TimelineTicks::GetMajorTicks(uint64_t start_ns, uint64_t e
   return major_ticks;
 }
 
+int TimelineTicks::GetTimestampsNumDigitsPrecision(uint64_t start_ns, uint64_t end_ns) const {
+  constexpr int kMaxDigitsPrecision = 9;  // 1ns = 0.000'000'001s
+
+  uint64_t current_precision_ns = kNanosecondsPerSecond;
+  for (int num_digits = 0; num_digits < kMaxDigitsPrecision;
+       num_digits++, current_precision_ns /= 10) {
+    bool precision_is_enough = true;
+    for (uint64_t timestamp : GetMajorTicks(start_ns, end_ns)) {
+      if (timestamp % current_precision_ns != 0) {
+        precision_is_enough = false;
+      }
+    }
+    if (precision_is_enough) return num_digits;
+  }
+  return kMaxDigitsPrecision;
+}
+
 uint64_t TimelineTicks::GetScale(uint64_t visible_ns) const {
   // Biggest scale smaller than half the total range, as we want to see at least 2 major ticks.
   uint64_t half_visible_ns = visible_ns / 2;

--- a/src/OrbitGl/TimelineTicks.h
+++ b/src/OrbitGl/TimelineTicks.h
@@ -27,8 +27,8 @@ class TimelineTicks {
   [[nodiscard]] std::vector<std::pair<TickType, uint64_t> > GetAllTicks(uint64_t start_ns,
                                                                         uint64_t end_ns) const;
   [[nodiscard]] std::vector<uint64_t> GetMajorTicks(uint64_t start_ns, uint64_t end_ns) const;
-  // Number of digits needed to show precisely parts of a second in major-ticks' timestamps.
-  [[nodiscard]] int GetTimestampsNumDigitsPrecision(uint64_t start_ns, uint64_t end_ns) const;
+  // Number of digits needed to show precisely parts of a second in a timestamp.
+  [[nodiscard]] int GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const;
 
  private:
   uint64_t GetScale(uint64_t time_range_ns) const;

--- a/src/OrbitGl/TimelineTicks.h
+++ b/src/OrbitGl/TimelineTicks.h
@@ -27,6 +27,8 @@ class TimelineTicks {
   [[nodiscard]] std::vector<std::pair<TickType, uint64_t> > GetAllTicks(uint64_t start_ns,
                                                                         uint64_t end_ns) const;
   [[nodiscard]] std::vector<uint64_t> GetMajorTicks(uint64_t start_ns, uint64_t end_ns) const;
+  // Number of digits needed to show precisely parts of a second in major-ticks' timestamps.
+  [[nodiscard]] int GetTimestampsNumDigitsPrecision(uint64_t start_ns, uint64_t end_ns) const;
 
  private:
   uint64_t GetScale(uint64_t time_range_ns) const;

--- a/src/OrbitGl/TimelineTicksTest.cpp
+++ b/src/OrbitGl/TimelineTicksTest.cpp
@@ -26,24 +26,20 @@ TEST(TimelineTicks, GetMajorTicks) {
                                    1 * kNanosecondsPerMinute));
 }
 
-TEST(TimelineTicks, GetTimestampsNumDigitsPrecision) {
+TEST(TimelineTicks, GetTimestampNumDigitsPrecision) {
   TimelineTicks timeline_ticks;
 
-  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(0, 20), 8);   // 10ns = 0.000'000'01s
-  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(0, 299), 7);  // 100ns = 0.000'000'1s
-  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(1, 299), 7);
-  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(50, 249), 7);
-  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(50, 248), 8);
-  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(40 * kNanosecondsPerMicrosecond,
-                                                           100 * kNanosecondsPerMicrosecond),
-            5);  // 0.01 ms = 0.000'01s
-  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(1 * kNanosecondsPerSecond,
-                                                           6 * kNanosecondsPerSecond),
+  EXPECT_EQ(timeline_ticks.GetTimestampNumDigitsPrecision(10), 8);   // 10ns = 0.000'000'01s
+  EXPECT_EQ(timeline_ticks.GetTimestampNumDigitsPrecision(200), 7);  // 200ns = 0.000'000'2s
+  EXPECT_EQ(timeline_ticks.GetTimestampNumDigitsPrecision(297), 9);
+  EXPECT_EQ(timeline_ticks.GetTimestampNumDigitsPrecision(40 * kNanosecondsPerMicrosecond),
+            5);  // 0.040 ms = 0.000'04s
+  EXPECT_EQ(timeline_ticks.GetTimestampNumDigitsPrecision(1 * kNanosecondsPerSecond), 0);
+  EXPECT_EQ(timeline_ticks.GetTimestampNumDigitsPrecision(1 * kNanosecondsPerMinute), 0);
+  EXPECT_EQ(timeline_ticks.GetTimestampNumDigitsPrecision(3 * kNanosecondsPerHour +
+                                                          2 * kNanosecondsPerSecond),
             0);
-
-  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(1 * kNanosecondsPerMinute,
-                                                           5 * kNanosecondsPerMinute),
-            0);
+  EXPECT_EQ(timeline_ticks.GetTimestampNumDigitsPrecision(3 * kNanosecondsPerHour + 10), 8);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TimelineTicksTest.cpp
+++ b/src/OrbitGl/TimelineTicksTest.cpp
@@ -26,4 +26,24 @@ TEST(TimelineTicks, GetMajorTicks) {
                                    1 * kNanosecondsPerMinute));
 }
 
+TEST(TimelineTicks, GetTimestampsNumDigitsPrecision) {
+  TimelineTicks timeline_ticks;
+
+  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(0, 20), 8);   // 10ns = 0.000'000'01s
+  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(0, 299), 7);  // 100ns = 0.000'000'1s
+  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(1, 299), 7);
+  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(50, 249), 7);
+  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(50, 248), 8);
+  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(40 * kNanosecondsPerMicrosecond,
+                                                           100 * kNanosecondsPerMicrosecond),
+            5);  // 0.01 ms = 0.000'01s
+  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(1 * kNanosecondsPerSecond,
+                                                           6 * kNanosecondsPerSecond),
+            0);
+
+  EXPECT_EQ(timeline_ticks.GetTimestampsNumDigitsPrecision(1 * kNanosecondsPerMinute,
+                                                           5 * kNanosecondsPerMinute),
+            0);
+}
+
 }  // namespace orbit_gl


### PR DESCRIPTION
We are adding GetTicksNumDigitsPrecision, a method which will be used
by TimelineUI to display all the timestamps labels with the same number
of digits after the comma.

Test: Unit Test. Also tested with following PRs.

Bug: Timestamps ISO 8601. http://b/162485497.