### PR TITLE
Include Timestamps with ISO 8601 format

### DIFF
--- a/src/DisplayFormats/DisplayFormats.cpp
+++ b/src/DisplayFormats/DisplayFormats.cpp
@@ -45,4 +45,50 @@ std::string GetDisplayTime(absl::Duration duration) {
   return absl::StrFormat("%.3f days", absl::ToDoubleHours(duration) / kHoursInOneDay);
 }
 
+std::string ToStringAtLeastTwoDigits(int number) {
+  return std::to_string(number / 10) + std::to_string(number % 10);
+}
+
+std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_precision,
+                                   absl::Duration total_capture_duration) {
+  std::string label;
+  // Hours, minutes and seconds
+  if (total_capture_duration >= absl::Hours(1)) {
+    int64_t hours = absl::ToInt64Hours(timestamp);
+    label += ToStringAtLeastTwoDigits(hours) + ":";
+    timestamp -= absl::Hours(hours);
+  }
+
+  if (total_capture_duration >= absl::Minutes(1)) {
+    int64_t minutes = absl::ToInt64Minutes(timestamp);
+    label += ToStringAtLeastTwoDigits(minutes) + ":";
+    timestamp -= absl::Minutes(minutes);
+  }
+
+  int64_t seconds = absl::ToInt64Seconds(timestamp);
+  label += ToStringAtLeastTwoDigits(seconds);
+  timestamp -= absl::Seconds(seconds);
+
+  if (num_digits_precision == 0) {
+    // Special case. If we are only showing seconds, let's add an 's';
+    if (label.size() <= 2) {
+      label += 's';
+    }
+    return label;
+  }
+
+  // Parts of a second
+  label += ".";
+  absl::Duration precision_level = absl::Seconds(1);
+  for (int i = 0; i < num_digits_precision; i++) {
+    precision_level /= 10;
+    label += std::to_string(absl::IDivDuration(timestamp, precision_level, &timestamp));
+  }
+  return label;
+}
+
+std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_precision) {
+  return GetDisplayISOTimestamp(timestamp, num_digits_precision, timestamp);
+}
+
 }  // namespace orbit_display_formats

--- a/src/DisplayFormats/DisplayFormats.cpp
+++ b/src/DisplayFormats/DisplayFormats.cpp
@@ -45,8 +45,8 @@ std::string GetDisplayTime(absl::Duration duration) {
   return absl::StrFormat("%.3f days", absl::ToDoubleHours(duration) / kHoursInOneDay);
 }
 
-std::string ToStringAtLeastTwoDigits(int number) {
-  return std::to_string(number / 10) + std::to_string(number % 10);
+[[nodiscard]] std::string ToStringAtLeastTwoDigits(int number) {
+  return number < 10 ? absl::StrFormat("0%i", number) : std::to_string(number);
 }
 
 std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_precision,
@@ -80,7 +80,7 @@ std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_prec
   // Parts of a second
   label += ".";
   absl::Duration precision_level = absl::Seconds(1);
-  for (int i = 0; i < num_digits_precision; i++) {
+  for (int i = 0; i < num_digits_precision; ++i) {
     precision_level /= 10;
     label += std::to_string(absl::IDivDuration(timestamp, precision_level, &timestamp));
   }

--- a/src/DisplayFormats/DisplayFormatsTest.cpp
+++ b/src/DisplayFormats/DisplayFormatsTest.cpp
@@ -43,10 +43,10 @@ TEST(DisplayFormats, GetDisplayISOTimestamp) {
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(12'345'600), 7), "00.0123456");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(12'345'600'000ULL), 4), "12.3456");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(60 * 12'345'600'000ULL), 3), "12:20.736");
-  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(60 * 60 * 12'345'600'000ULL), 2),
-            "12:20:44.16");
-  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(10 * 60 * 60 * 12'345'000'000ULL), 0),
-            "123:27:00");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(60 * 1'000'000'000ULL + 234'000'000), 3),
+            "01:00.234");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(60 * 60 * 1'000'000'000ULL), 5),
+            "01:00:00.00000");
 
   // Long Captures tests
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(450), 2, absl::Seconds(27)), "00.45");

--- a/src/DisplayFormats/DisplayFormatsTest.cpp
+++ b/src/DisplayFormats/DisplayFormatsTest.cpp
@@ -27,4 +27,33 @@ TEST(DisplayFormats, GetDisplayTime) {
   EXPECT_EQ(GetDisplayTime(absl::Nanoseconds(24 * 60 * 60 * 12'345'600'000ULL)), "12.346 days");
 }
 
+TEST(DisplayFormats, GetDisplayISOTimestamp) {
+  // Short Captures
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(12), 9), "00.000000012");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Microseconds(304), 6), "00.000304");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(450), 2), "00.45");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(4005), 3), "04.005");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(4500), 1), "04.5");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(0), 0), "00s");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(0), 1), "00.0");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(10), 0), "10s");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(13), 0), "13s");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Minutes(1), 0), "01:00");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Minutes(1), 1), "01:00.0");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(12'345'600), 7), "00.0123456");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(12'345'600'000ULL), 4), "12.3456");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(60 * 12'345'600'000ULL), 3), "12:20.736");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(60 * 60 * 12'345'600'000ULL), 2),
+            "12:20:44.16");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(10 * 60 * 60 * 12'345'000'000ULL), 0),
+            "123:27:00");
+
+  // Long Captures tests
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(450), 2, absl::Seconds(27)), "00.45");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(450), 9, absl::Minutes(1)),
+            "00:00.450000000");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(450), 9, absl::Hours(1)),
+            "00:00:00.450000000");
+}
+
 }  // namespace orbit_display_formats

--- a/src/DisplayFormats/include/DisplayFormats/DisplayFormats.h
+++ b/src/DisplayFormats/include/DisplayFormats/DisplayFormats.h
@@ -9,12 +9,13 @@
 
 namespace orbit_display_formats {
 
-std::string GetDisplaySize(uint64_t size_bytes);
+[[nodiscard]] std::string GetDisplaySize(uint64_t size_bytes);
 
-std::string GetDisplayTime(absl::Duration duration);
-std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_precision,
-                                   absl::Duration total_capture_duration);
-std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_precision);
+[[nodiscard]] std::string GetDisplayTime(absl::Duration duration);
+[[nodiscard]] std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_precision,
+                                                 absl::Duration total_capture_duration);
+[[nodiscard]] std::string GetDisplayISOTimestamp(absl::Duration timestamp,
+                                                 int num_digits_precision);
 
 }  // namespace orbit_display_formats
 

--- a/src/DisplayFormats/include/DisplayFormats/DisplayFormats.h
+++ b/src/DisplayFormats/include/DisplayFormats/DisplayFormats.h
@@ -12,6 +12,9 @@ namespace orbit_display_formats {
 std::string GetDisplaySize(uint64_t size_bytes);
 
 std::string GetDisplayTime(absl::Duration duration);
+std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_precision,
+                                   absl::Duration total_capture_duration);
+std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_precision);
 
 }  // namespace orbit_display_formats
 


### PR DESCRIPTION
In this PR we are adding the possibility to choose ISO-8601 format to
display time. This will be used in a following PR to display labels in
the Timeline.

The details of the implementation can be found in the doc:
go/stadia-orbit-timeline-improvements

Bug: http://b/162485497

Test: Unit tests, but also tested in a real capture (which will be
connected in a following PR).