### PR TITLE
Draw grey lines between labels of the the new Timeline

### DIFF
--- a/src/OrbitGl/TimelineTicks.cpp
+++ b/src/OrbitGl/TimelineTicks.cpp
@@ -50,6 +50,7 @@ std::vector<std::pair<TimelineTicks::TickType, uint64_t> > TimelineTicks::GetAll
   std::vector<std::pair<TickType, uint64_t> > ticks;
   if (end_ns <= start_ns) return ticks;
 
+  // We are including both borders (start_ns and end_ns) as visible points in time.
   uint64_t visible_ns = end_ns + 1 - start_ns;
   uint64_t major_scale = GetMajorTicksScale(visible_ns);
   uint64_t minor_scale = GetMinorTicksScale(visible_ns);
@@ -87,7 +88,7 @@ int TimelineTicks::GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const {
 
 uint64_t TimelineTicks::GetMinorTicksScale(uint64_t visible_ns) const {
   uint64_t major_scale = GetMajorTicksScale(visible_ns);
-  // For consistency, minor ticks scale is the next finer scale than the one used for major ticks.
+  // For consistency, minor ticks scale is the next finer scale after the one used for major ticks.
   if (major_scale <= 1) return 1;
   return *std::prev(kTimelineScales.lower_bound(major_scale));
 }

--- a/src/OrbitGl/TimelineTicks.cpp
+++ b/src/OrbitGl/TimelineTicks.cpp
@@ -50,8 +50,9 @@ std::vector<std::pair<TimelineTicks::TickType, uint64_t> > TimelineTicks::GetAll
   std::vector<std::pair<TickType, uint64_t> > ticks;
   if (end_ns <= start_ns) return ticks;
 
-  uint64_t major_scale = GetScale(end_ns + 1 - start_ns);
-  uint64_t minor_scale = GetPreviousScale(major_scale);
+  uint64_t visible_ns = end_ns + 1 - start_ns;
+  uint64_t major_scale = GetMajorTicksScale(visible_ns);
+  uint64_t minor_scale = GetMinorTicksScale(visible_ns);
 
   uint64_t first_tick = ((start_ns + minor_scale - 1) / minor_scale) * minor_scale;
   for (uint64_t tick = first_tick; tick <= end_ns; tick += minor_scale) {
@@ -82,13 +83,16 @@ int TimelineTicks::GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const {
     }
   }
   return kMaxDigitsPrecision;
+}
 
-  uint64_t TimelineTicks::GetPreviousScale(uint64_t tick_scale) const {
-    if (tick_scale <= 1) return 1;
-    return *std::prev(kTimelineScales.lower_bound(tick_scale));
-  }
+uint64_t TimelineTicks::GetMinorTicksScale(uint64_t visible_ns) const {
+  uint64_t major_scale = GetMajorTicksScale(visible_ns);
+  // For consistency, minor ticks scale is the next finer scale than the one used for major ticks.
+  if (major_scale <= 1) return 1;
+  return *std::prev(kTimelineScales.lower_bound(major_scale));
+}
 
-uint64_t TimelineTicks::GetScale(uint64_t visible_ns) const {
+uint64_t TimelineTicks::GetMajorTicksScale(uint64_t visible_ns) const {
   // Biggest scale smaller than half the total range, as we want to see at least 2 major ticks.
   uint64_t half_visible_ns = visible_ns / 2;
   ORBIT_CHECK(half_visible_ns > 0);

--- a/src/OrbitGl/TimelineTicks.h
+++ b/src/OrbitGl/TimelineTicks.h
@@ -31,7 +31,8 @@ class TimelineTicks {
   [[nodiscard]] int GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const;
 
  private:
-  uint64_t GetScale(uint64_t time_range_ns) const;
+  [[nodiscard]] uint64_t GetScale(uint64_t time_range_ns) const;
+  [[nodiscard]] uint64_t GetPreviousScale(uint64_t tick_scale) const;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TimelineTicks.h
+++ b/src/OrbitGl/TimelineTicks.h
@@ -31,8 +31,8 @@ class TimelineTicks {
   [[nodiscard]] int GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const;
 
  private:
-  [[nodiscard]] uint64_t GetScale(uint64_t time_range_ns) const;
-  [[nodiscard]] uint64_t GetPreviousScale(uint64_t tick_scale) const;
+  [[nodiscard]] uint64_t GetMajorTicksScale(uint64_t visible_ns) const;
+  [[nodiscard]] uint64_t GetMinorTicksScale(uint64_t visible_ns) const;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TimelineTicksTest.cpp
+++ b/src/OrbitGl/TimelineTicksTest.cpp
@@ -26,26 +26,23 @@ TEST(TimelineTicks, GetMajorTicks) {
                                    1 * kNanosecondsPerMinute));
 }
 
-bool CheckTicks(uint64_t start_ns, uint64_t end_ns, std::set<uint64_t> major_ticks,
-                std::set<uint64_t> minor_ticks) {
+static void CheckTicks(uint64_t start_ns, uint64_t end_ns, const std::set<uint64_t>& major_ticks,
+                       const std::set<uint64_t>& minor_ticks) {
   TimelineTicks timeline_ticks;
   auto all_ticks = timeline_ticks.GetAllTicks(start_ns, end_ns);
-  if (all_ticks.size() != major_ticks.size() + minor_ticks.size()) return false;
+  EXPECT_EQ(all_ticks.size(), major_ticks.size() + minor_ticks.size());
   for (auto& [tick_type, timestamp_ns] : all_ticks) {
-    if (tick_type == TimelineTicks::TickType::kMajorTick && major_ticks.count(timestamp_ns) == 0) {
-      return false;
-    }
-    if (tick_type == TimelineTicks::TickType::kMinorTick && minor_ticks.count(timestamp_ns) == 0) {
-      return false;
-    }
+    EXPECT_FALSE(tick_type == TimelineTicks::TickType::kMajorTick &&
+                 major_ticks.count(timestamp_ns) == 0);
+    EXPECT_FALSE(tick_type == TimelineTicks::TickType::kMinorTick &&
+                 minor_ticks.count(timestamp_ns) == 0);
   }
-  return true;
 }
 
 TEST(TimelineTicks, GetAllTicks) {
   CheckTicks(0, 20, {0, 10, 20}, {5, 15});
-  CheckTicks(0, 299, {0, 100, 200}, {50, 150});
-  CheckTicks(1, 299, {100, 200}, {50, 150});
+  CheckTicks(0, 299, {0, 100, 200}, {50, 150, 250});
+  CheckTicks(1, 299, {100, 200}, {50, 150, 250});
   CheckTicks(50, 248, {50, 100, 150, 200},
              {60, 70, 80, 90, 110, 120, 130, 140, 160, 170, 180, 190, 210, 220, 230, 240});
   CheckTicks(40 * kNanosecondsPerSecond, 1 * kNanosecondsPerMinute,

--- a/src/OrbitGl/TimelineTicksTest.cpp
+++ b/src/OrbitGl/TimelineTicksTest.cpp
@@ -26,6 +26,33 @@ TEST(TimelineTicks, GetMajorTicks) {
                                    1 * kNanosecondsPerMinute));
 }
 
+bool CheckTicks(uint64_t start_ns, uint64_t end_ns, std::set<uint64_t> major_ticks,
+                std::set<uint64_t> minor_ticks) {
+  TimelineTicks timeline_ticks;
+  auto all_ticks = timeline_ticks.GetAllTicks(start_ns, end_ns);
+  if (all_ticks.size() != major_ticks.size() + minor_ticks.size()) return false;
+  for (auto& [tick_type, timestamp_ns] : all_ticks) {
+    if (tick_type == TimelineTicks::TickType::kMajorTick && major_ticks.count(timestamp_ns) == 0) {
+      return false;
+    }
+    if (tick_type == TimelineTicks::TickType::kMinorTick && minor_ticks.count(timestamp_ns) == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TEST(TimelineTicks, GetAllTicks) {
+  CheckTicks(0, 20, {0, 10, 20}, {5, 15});
+  CheckTicks(0, 299, {0, 100, 200}, {50, 150});
+  CheckTicks(1, 299, {100, 200}, {50, 150});
+  CheckTicks(50, 248, {50, 100, 150, 200},
+             {60, 70, 80, 90, 110, 120, 130, 140, 160, 170, 180, 190, 210, 220, 230, 240});
+  CheckTicks(40 * kNanosecondsPerSecond, 1 * kNanosecondsPerMinute,
+             {40 * kNanosecondsPerSecond, 50 * kNanosecondsPerSecond, 1 * kNanosecondsPerMinute},
+             {45 * kNanosecondsPerSecond, 55 * kNanosecondsPerSecond});
+}
+
 TEST(TimelineTicks, GetTimestampNumDigitsPrecision) {
   TimelineTicks timeline_ticks;
 

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -14,7 +14,7 @@ namespace orbit_gl {
 void TimelineUi::RenderLines(Batcher& batcher, uint64_t min_timestamp_ns,
                              uint64_t max_timestamp_ns) const {
   const Color kMajorTickColor(255, 255, 255, 255);
-  const Color kMinorTickColor(150, 150, 150, 255);
+  const Color kMinorTickColor(120, 120, 120, 255);
   constexpr int kPixelMargin = 1;
   const float ticks_height = GetHeight() - kPixelMargin;
 


### PR DESCRIPTION
In this PR we are including MinorTicks, which are lines between labels
to give more precision to the user. As discussed with Carsten, they are
using the next scale to give users a sense of continuity when they are
zooming-in/out.

You can see more details in go/stadia-oribit-timeline-improvements (step
number 3).

http://screen/C6aYsVp8Z5KWbuP

Test: Unit Tests + Loading a capture + Start/Stop a capture.

Bug: http://b/208447247