### PR TITLE
Fix TrackContainer vertical position

### DIFF
--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -105,7 +105,7 @@ void TrackContainer::DoUpdateLayout() {
 void TrackContainer::UpdateTracksPosition() {
   const float track_pos_x = GetPos()[0];
 
-  float current_y = layout_->GetSchedulerTrackOffset() - vertical_scrolling_offset_;
+  float current_y = GetPos()[1] + layout_->GetSchedulerTrackOffset() - vertical_scrolling_offset_;
 
   // Track height including space between them
   for (auto& track : track_manager_->GetVisibleTracks()) {


### PR DESCRIPTION
This assumed TrackContainer vertical position is 0, which won't be true
after moving Timeline to the top.

Bug: http://b/208450369