### PR TITLE
Refactor pos and size of TimeGraph's children

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -77,11 +77,7 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
 }
 
 float TimeGraph::GetHeight() const {
-  float total_height = 0.;
-  for (orbit_gl::CaptureViewElement* capture_view_element : GetNonHiddenChildren()) {
-    total_height += capture_view_element->GetHeight();
-  }
-  return total_height;
+  return viewport_->GetWorldHeight() - layout_.GetBottomMargin();
 }
 
 void TimeGraph::UpdateCaptureMinMaxTimestamps() {
@@ -531,7 +527,6 @@ void TimeGraph::PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode) {
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
-  timeline_ui_->SetPos(0, track_container_->GetHeight());
   CaptureViewElement::UpdatePrimitives(batcher_, text_renderer_static_, min_tick, max_tick,
                                        picking_mode);
 
@@ -549,6 +544,12 @@ void TimeGraph::DoUpdateLayout() {
       std::max(capture_max_timestamp_, capture_data_->GetCallstackData().max_time());
 
   time_window_us_ = max_time_us_ - min_time_us_;
+
+  // Update position and size of children.
+  track_container_->SetPos(GetPos()[0], GetPos()[1]);
+  // TrackContainer height is the free space of the screen.
+  track_container_->SetHeight(GetHeight() - timeline_ui_->GetHeight());
+  timeline_ui_->SetPos(GetPos()[0], GetPos()[1] + track_container_->GetHeight());
 }
 
 void TimeGraph::SelectAndZoom(const TimerInfo* timer_info) {

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -101,8 +101,8 @@ float TimeGraphLayout::GetCollapseButtonSize(int indentation_level) const {
 
 float TimeGraphLayout::GetBottomMargin() const {
   // The bottom consists of the slider (where we have to take the width, as it
-  // is rotated), and the time bar.
-  return GetSliderWidth() + GetTimeBarHeight();
+  // is rotated).
+  return GetSliderWidth();
 }
 
 float TimeGraphLayout::GetEventTrackHeightFromTid(uint32_t tid) const {

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -30,7 +30,8 @@ class TrackContainer final : public CaptureViewElement {
                           const orbit_client_data::ModuleManager* module_manager,
                           orbit_client_data::CaptureData* capture_data);
 
-  [[nodiscard]] float GetHeight() const override;
+  [[nodiscard]] float GetHeight() const override { return height_; };
+  void SetHeight(float height) { height_ = height; }
   [[nodiscard]] float GetVisibleTracksTotalHeight() const;
 
   [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
@@ -87,6 +88,7 @@ class TrackContainer final : public CaptureViewElement {
   absl::flat_hash_map<uint64_t, uint64_t> iterator_id_to_function_id_;
 
   float vertical_scrolling_offset_ = 0;
+  float height_ = 0;
 
   std::unique_ptr<TrackManager> track_manager_;
 


### PR DESCRIPTION
This PR is a bunch of a few small cleanings solving an issue with
Timeline's position not being updated when resize Orbit Windows.

- Finish setting Timeline as a CaptureViewElement and not as a part of
  the margin anymore.

- TimeGraph takes care of positions and sizes of its children.

- Fix the assumptions about TrackContainer's position is (0,0) in iterators.

- Rename a few variables to make it easy to understand.

Screenshot(before) when resizing the Orbit's windows: http://screen/9rDV5FGB7JoLrvr

Test: Timeline updates correctly its position, Iterators works fine.
Finishing work for http://b/208431620 and allowing http://b/208450369.