### PR TITLE
[DO NOT MERGE] gRPC-free DoCapture

### DIFF
--- a/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureService.h
+++ b/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureService.h
@@ -39,6 +39,10 @@ class LinuxCaptureService final : public orbit_capture_service::CaptureService {
       grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse,
                                orbit_grpc_protos::CaptureRequest>* reader_writer) override;
 
+  CaptureService::CaptureInitializationResult DoCapture(
+      ClientCaptureEventCollectorBuilder* client_capture_event_collector_builder,
+      const std::shared_ptr<StartStopCaptureRequestWaiter>& start_stop_capture_request_waiter);
+
  private:
   std::unique_ptr<orbit_user_space_instrumentation::InstrumentationManager>
       instrumentation_manager_;
@@ -48,8 +52,8 @@ class LinuxCaptureService final : public orbit_capture_service::CaptureService {
   //   CaptureService::WaitForStopCaptureRequestFromClient);
   // - MemoryWatchdog calls OnThresholdExceeded.
   [[nodiscard]] StopCaptureReason WaitForStopCaptureRequestOrMemoryThresholdExceeded(
-      grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse,
-                               orbit_grpc_protos::CaptureRequest>* reader_writer);
+      const std::shared_ptr<LinuxCaptureService::StartStopCaptureRequestWaiter>&
+          start_stop_capture_request_waiter);
   std::thread wait_for_stop_capture_request_thread_;
 };
 


### PR DESCRIPTION
This is what I had in mind regarding https://github.com/google/orbit/pull/3286
and its follow-ups. In my mind this succeeds in keeping a single "capture"
method on Linux.
Of course:
 - this might actually be worse, depending on the follow-up changes;
 - it might just not fit at all the plans for the cloud colletor.

Compared to the "Original Refactoring Plan" in
http://go/orbit-refactor-capture-service-for-cloud-collector, it avoids
`void*` by adding the two interfaces `ClientCaptureEventCollectorBuilder` and
`StartStopCaptureRequestWaiter`, and it avoids having to duplicate
`WaitForStopCaptureRequestOrMemoryThresholdExceeded`.

Of course gRPC `Capture` and gRPC-free `DoCapture` should be in appropriate
classes. I put everything in `CaptureService` and `LinuxCaptureService` just to
be faster.

Also this doesn't consider `WindowsCaptureService`.