### PR TITLE
Fix highlighting for "const" functions

### DIFF
--- a/src/CodeViewerDemo/CodeExamples.h
+++ b/src/CodeViewerDemo/CodeExamples.h
@@ -351,7 +351,7 @@ inline const QString x86Assembly_example = R"(Platform: X86 64 (Intel syntax)
 0x557e1f8091d4:	sub          rsp, 0x10
 0x557e1f8091d8:	mov          rax, qword ptr fs:[0x28]
 0x557e1f8091e1:	mov          qword ptr [rbp - 8], rax
-0x557e1f8091e2:	call         0x123 (bbb::foo())
+0x557e1f8091e2:	call         0x123 (bbb::foo() const)
 0x557e1f8091e3:	call         0x123 (bbb::foo<int a, std::function<void (int)>>(int, std::function<void (B)>))
 0x55da67cf3ee4:	call         0x55da686727c0 ([???])
 0x557e1f8091e5:	xorps        xmm0, xmm0

--- a/src/SyntaxHighlighter/X86Assembly.cpp
+++ b/src/SyntaxHighlighter/X86Assembly.cpp
@@ -214,7 +214,7 @@ const QRegularExpression kRegisterRegex{
 const QRegularExpression kKeywordRegex{"\\b(?:ptr|[xy]mmword|[sdq]?word|byte)\\b"};
 const QRegularExpression kCommentRegex{";.*$"};
 const QRegularExpression kPlatformRegex{"^Platform:.*$"};
-const QRegularExpression kCallTargetRegex{"(?<=\\()(.*?\\(.*?\\)+|\\?\\?\\?)(?=\\))"};
+const QRegularExpression kCallTargetRegex{"(?<=\\()(.*?\\(.*?\\)+.*|\\?\\?\\?)(?=\\))"};
 }  // namespace AssemblyRegex
 }  // namespace
 


### PR DESCRIPTION
In Disassembly view, we highlight function calls since #3269.

However, the highlighting of the function calls does not work
if the function is "const".

This change adjust the regex, such that we also accept elements
after the closing ")" from the parameter list.

Test: CodeViewerDemo + tested on some random functions in Trata.
Bug: http://b/217357958