### PR TITLE
Generalize set position of TimeGraph children

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -545,24 +545,24 @@ void TimeGraph::DoUpdateLayout() {
 
   time_window_us_ = max_time_us_ - min_time_us_;
 
-  UpdateChildrenPosAndSize();
+  UpdateChildrenPosAndContainerSize();
 }
 
-void TimeGraph::UpdateChildrenPosAndSize() {
+void TimeGraph::UpdateChildrenPosAndContainerSize() {
   // Special case: TimeGraph will set TrackContainer height based on its free space.
   float total_height_without_track_container = 0;
-  for (orbit_gl::CaptureViewElement* children : GetNonHiddenChildren()) {
-    if (children != track_container_.get()) {
-      total_height_without_track_container += children->GetHeight();
+  for (orbit_gl::CaptureViewElement* child : GetNonHiddenChildren()) {
+    if (child != track_container_.get()) {
+      total_height_without_track_container += child->GetHeight();
     }
   }
   track_container_->SetHeight(GetHeight() - total_height_without_track_container);
 
   // Update position of visible children.
   float current_pos_y = GetPos()[1];
-  for (orbit_gl::CaptureViewElement* children : GetNonHiddenChildren()) {
-    children->SetPos(GetPos()[0], current_pos_y);
-    current_pos_y += children->GetHeight();
+  for (orbit_gl::CaptureViewElement* child : GetNonHiddenChildren()) {
+    child->SetPos(GetPos()[0], current_pos_y);
+    current_pos_y += child->GetHeight();
   }
 }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -545,11 +545,25 @@ void TimeGraph::DoUpdateLayout() {
 
   time_window_us_ = max_time_us_ - min_time_us_;
 
-  // Update position and size of children.
-  track_container_->SetPos(GetPos()[0], GetPos()[1]);
-  // TrackContainer height is the free space of the screen.
-  track_container_->SetHeight(GetHeight() - timeline_ui_->GetHeight());
-  timeline_ui_->SetPos(GetPos()[0], GetPos()[1] + track_container_->GetHeight());
+  UpdateChildrenPosAndSize();
+}
+
+void TimeGraph::UpdateChildrenPosAndSize() {
+  // Special case: TimeGraph will set TrackContainer height based on its free space.
+  float total_height_without_track_container = 0;
+  for (orbit_gl::CaptureViewElement* children : GetNonHiddenChildren()) {
+    if (children != track_container_.get()) {
+      total_height_without_track_container += children->GetHeight();
+    }
+  }
+  track_container_->SetHeight(GetHeight() - total_height_without_track_container);
+
+  // Update position of visible children.
+  float current_pos_y = GetPos()[1];
+  for (orbit_gl::CaptureViewElement* children : GetNonHiddenChildren()) {
+    children->SetPos(GetPos()[0], current_pos_y);
+    current_pos_y += children->GetHeight();
+  }
 }
 
 void TimeGraph::SelectAndZoom(const TimerInfo* timer_info) {
@@ -654,10 +668,6 @@ bool TimeGraph::IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) c
 }
 
 std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetAllChildren() const {
-  return {GetTrackContainer(), GetTimelineUi()};
-}
-
-std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetNonHiddenChildren() const {
   return {GetTrackContainer(), GetTimelineUi()};
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -150,7 +150,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
-  [[nodiscard]] std::vector<CaptureViewElement*> GetNonHiddenChildren() const override;
 
   [[nodiscard]] AccessibleInterfaceProvider* GetAccessibleParent() const {
     return accessible_parent_;
@@ -159,6 +158,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
  protected:
   void PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode);
   void DoUpdateLayout() override;
+  void UpdateChildrenPosAndSize();
 
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -158,7 +158,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
  protected:
   void PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode);
   void DoUpdateLayout() override;
-  void UpdateChildrenPosAndSize();
+  void UpdateChildrenPosAndContainerSize();
 
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;


### PR DESCRIPTION
A step to make easier to switch between children of TimeGraph. 
We are also erasing an unused overriden method.

Next steps:
- Add margin between children
- Switch Timeline with TrackContainer

http://b/208450369