### PR TITLE
Add GetCaptureTimeSpanNs to TimelineInfoInterface

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -487,7 +487,7 @@ void CaptureWindow::UpdateChildrenPosAndSize() {
 void CaptureWindow::DrawScreenSpace() {
   ORBIT_SCOPE("CaptureWindow::DrawScreenSpace");
   if (time_graph_ == nullptr) return;
-  double time_span = time_graph_->GetCaptureTimeSpanUs();
+  uint64_t time_span = time_graph_->GetCaptureTimeSpanNs();
 
   Color col = slider_->GetBarColor();
   auto canvas_height = static_cast<float>(viewport_.GetScreenHeight());

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -109,17 +109,7 @@ void TimeGraph::Zoom(uint64_t min, uint64_t max) {
 
 void TimeGraph::Zoom(const TimerInfo& timer_info) { Zoom(timer_info.start(), timer_info.end()); }
 
-double TimeGraph::GetCaptureTimeSpanUs() const {
-  // Do we have an empty capture?
-  if (capture_max_timestamp_ == 0 &&
-      capture_min_timestamp_ == std::numeric_limits<uint64_t>::max()) {
-    return 0.0;
-  }
-  ORBIT_CHECK(capture_min_timestamp_ <= capture_max_timestamp_);
-  return TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
-}
-
-double TimeGraph::GetCurrentTimeSpanUs() const { return max_time_us_ - min_time_us_; }
+double TimeGraph::GetCaptureTimeSpanUs() const { return GetCaptureTimeSpanNs() * 0.001; }
 
 void TimeGraph::ZoomTime(float zoom_value, double mouse_ratio) {
   static double increment_ratio = 0.1;
@@ -408,6 +398,16 @@ uint64_t TimeGraph::GetTickFromWorld(float world_x) const {
 uint64_t TimeGraph::GetTickFromUs(double micros) const {
   auto nanos = static_cast<uint64_t>(1000 * micros);
   return capture_min_timestamp_ + nanos;
+}
+
+uint64_t TimeGraph::GetCaptureTimeSpanNs() const {
+  // Do we have an empty capture?
+  if (capture_max_timestamp_ == 0 &&
+      capture_min_timestamp_ == std::numeric_limits<uint64_t>::max()) {
+    return 0;
+  }
+  ORBIT_CHECK(capture_min_timestamp_ <= capture_max_timestamp_);
+  return capture_max_timestamp_ - capture_min_timestamp_;
 }
 
 // Select a timer_info. Also move the view in order to assure that the timer_info and its track are

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -68,6 +68,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] double GetTimeWindowUs() const override { return time_window_us_; }
   [[nodiscard]] double GetMinTimeUs() const override { return min_time_us_; }
   [[nodiscard]] double GetMaxTimeUs() const override { return max_time_us_; }
+  [[nodiscard]] uint64_t GetCaptureTimeSpanNs() const override;
 
   void UpdateCaptureMinMaxTimestamps();
 
@@ -111,7 +112,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   void SelectAndZoom(const orbit_client_protos::TimerInfo* timer_info);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
-  [[nodiscard]] double GetCurrentTimeSpanUs() const;
   [[nodiscard]] bool IsRedrawNeeded() const { return update_primitives_requested_; }
 
   [[nodiscard]] bool IsFullyVisible(uint64_t min, uint64_t max) const;

--- a/src/OrbitGl/TimelineInfoInterface.h
+++ b/src/OrbitGl/TimelineInfoInterface.h
@@ -19,10 +19,12 @@ class TimelineInfoInterface {
   [[nodiscard]] virtual uint64_t GetTickFromUs(double micros) const = 0;
   [[nodiscard]] virtual double GetUsFromTick(uint64_t time) const = 0;
   [[nodiscard]] virtual uint64_t GetNsSinceStart(uint64_t tick) const = 0;
-  [[nodiscard]] virtual double GetTimeWindowUs() const = 0;
 
+  [[nodiscard]] virtual double GetTimeWindowUs() const = 0;
   [[nodiscard]] virtual double GetMinTimeUs() const = 0;
   [[nodiscard]] virtual double GetMaxTimeUs() const = 0;
+
+  [[nodiscard]] virtual uint64_t GetCaptureTimeSpanNs() const = 0;
 };
 
 }  // namespace orbit_gl


### PR DESCRIPTION
We are adding a method which returns the total number of nanoseconds
which the capture longs. This method will be used to print timestamps in
the new ISO-8601 format. Depending on the total size of the capture,
the displayed format will be different.

- We are also using this method instead of getting the number of microseconds
while possible because precision but the total refactor is not finished
(neither a priority).

Test: Load a capture, everything works.

http://b/170712621