### PR TITLE
Use ISO-8061 timestamps in the timeline

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -65,3 +65,6 @@ ABSL_FLAG(std::vector<std::string>, additional_symbol_paths, {},
 // Clears QSettings. This is intended for e2e tests.
 ABSL_FLAG(bool, clear_settings, false,
           "Clears user defined settings. This includes symbol locations and source path mappings.");
+
+// TODO(http://b/170712621): Remove this flag when we decide which timestamp format we will use.
+ABSL_FLAG(bool, iso_timestamps, true, "Show timestamps using ISO-8601 format.");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -60,4 +60,7 @@ ABSL_DECLARE_FLAG(std::vector<std::string>, additional_symbol_paths);
 // Clears QSettings. This is intended for e2e tests.
 ABSL_DECLARE_FLAG(bool, clear_settings);
 
+// TODO(http://b/170712621): Remove this flag when we decide which timestamp format we will use.
+ABSL_DECLARE_FLAG(bool, iso_timestamps);
+
 #endif  // CLIENT_FLAGS_CLIENT_FLAGS_H_

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -41,9 +41,10 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
   std::vector<uint64_t> all_major_ticks =
       timeline_ticks_.GetMajorTicks(min_timestamp_ns, max_timestamp_ns);
 
-  int max_precision = 0;
+  int number_of_decimal_places_needed = 0;
   for (uint64_t tick : all_major_ticks) {
-    max_precision = std::max(max_precision, timeline_ticks_.GetTimestampNumDigitsPrecision(tick));
+    number_of_decimal_places_needed = std::max(
+        number_of_decimal_places_needed, timeline_ticks_.GetTimestampNumDigitsPrecision(tick));
   }
 
   for (uint64_t tick_ns : all_major_ticks) {
@@ -51,7 +52,7 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
     // TODO(http://b/170712621): Remove this flag when we decide which timestamp format we will use.
     if (absl::GetFlag(FLAGS_iso_timestamps)) {
       label = orbit_display_formats::GetDisplayISOTimestamp(
-          absl::Nanoseconds(tick_ns), max_precision,
+          absl::Nanoseconds(tick_ns), number_of_decimal_places_needed,
           absl::Nanoseconds(timeline_info_interface_->GetCaptureTimeSpanNs()));
     } else {
       label = orbit_display_formats::GetDisplayTime(absl::Nanoseconds(tick_ns));


### PR DESCRIPTION
As a result of several discussions, we will introduce ISO-8601
timestamps behind a flag. After finishing the layout improvements in the
timeline, we will decide which timestamp we will finally use.

As it is explained in go/stadia-orbit-timeline-improvements, the iso
timestamps are generated using the timestamp, the total time of the
capture and the precision used (Same number of digits will be  used for
the labels).

For now, the flag is true, so we can test it easily.

Bug: http://b/162485497.

http://screen/3ScEoma8yqrJQSD, an example to show how it change
before/after a minute.