### PR TITLE
Improve Timeline's layout

### DIFF
--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -54,7 +54,7 @@ unsigned GlCanvas::kMaxNumberRealZLayers = kNumberOriginalLayers + kExtraLayersF
                                            kExtraLayersForSliderEpsilons;
 
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
-const Color GlCanvas::kTimeBarBackgroundColor = Color(90, 90, 90, 255);
+const Color GlCanvas::kTimeBarBackgroundColor = Color(33, 32, 33, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
 GlCanvas::GlCanvas()

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -40,7 +40,7 @@ TimeGraphLayout::TimeGraphLayout() {
   toolbar_icon_height_ = 24.f;
   generic_fixed_spacer_width_ = 10.f;
   scale_ = 1.f;
-  time_bar_height_ = 15.f;
+  time_bar_height_ = 30.f;
   font_size_ = 14;
 };
 

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -68,7 +68,7 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
                             &pos, &size);
       previous_label_end_x = pos[0] + size[0];
 
-      // Box between labels and ticks, so they don't overlap.
+      // Box behind the label to hide the ticks behind it.
       const float kBackgroundBoxVerticalMargin = 4;
       size[0] += kLabelMarginRight;
       pos[1] = pos[1] - kBackgroundBoxVerticalMargin;

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -34,7 +34,6 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
                               uint64_t min_timestamp_ns, uint64_t max_timestamp_ns) const {
   const float kLabelMarginLeft = 4;
   const float kLabelMarginRight = 2;
-  const float kLabelMarginBottom = 2;
   const float kPixelMargin = 1;
 
   float previous_label_end_x = std::numeric_limits<float>::lowest();
@@ -61,12 +60,11 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
         tick_ns / static_cast<double>(kNanosecondsPerMicrosecond));
     if (world_x > previous_label_end_x + kLabelMarginRight + kPixelMargin) {
       Vec2 pos, size;
-      float label_bottom_y =
-          GetPos()[1] + (GetHeight() + layout_->GetFontSize()) / 2 - kLabelMarginBottom;
-      text_renderer.AddText(label.c_str(), world_x + kLabelMarginLeft, label_bottom_y,
+      float label_middle_y = GetPos()[1] + GetHeight() / 2;
+      text_renderer.AddText(label.c_str(), world_x + kLabelMarginLeft, label_middle_y,
                             GlCanvas::kZValueTimeBar,
                             {layout_->GetFontSize(), Color(255, 255, 255, 255), -1.f,
-                             TextRenderer::HAlign::Left, TextRenderer::VAlign::Bottom},
+                             TextRenderer::HAlign::Left, TextRenderer::VAlign::Middle},
                             &pos, &size);
       previous_label_end_x = pos[0] + size[0];
 


### PR DESCRIPTION
This PR is improving the layout of the Timeline following Carsten
proposition.

Basically:
- We are changing colors.
- We are making the timeline bigger.
- We are centering the labels in the timeline.
- We are fixing an inconsistency between when printing the next label
  and the related tick. Now both are drawn or neither of them.

http://screen/884Hy5d4oonANZ2

Nit: This could have been two different PRs.

http://b/217509785