### PR TITLE
Replace DeferToBackgroundThreadAndWait

### DIFF
--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -729,37 +729,40 @@ outcome::result<void> ServiceDeployManager::ShutdownSession(orbit_ssh_qt::Sessio
 
 void ServiceDeployManager::Shutdown() {
   ORBIT_SCOPED_TIMED_LOG("ServiceDeployManager::Shutdown");
-  DeferToBackgroundThreadAndWait(this, [this]() {
-    if (sftp_channel_ != nullptr) {
-      outcome::result<void> shutdown_result = ShutdownSftpChannel(sftp_channel_.get());
-      if (shutdown_result.has_error()) {
-        ORBIT_ERROR("Unable to ShutdownSftpChannel: %s", shutdown_result.error().message());
-      }
-      sftp_channel_.reset();
-    }
-    if (grpc_tunnel_.has_value()) {
-      outcome::result<void> shutdown_result = ShutdownTunnel(&grpc_tunnel_.value());
-      if (shutdown_result.has_error()) {
-        ORBIT_ERROR("Unable to ShutdownTunnel: %s", shutdown_result.error().message());
-      }
-      grpc_tunnel_ = std::nullopt;
-    }
-    ssh_watchdog_timer_.stop();
-    if (orbit_service_task_.has_value()) {
-      outcome::result<void> shutdown_result = ShutdownTask(&orbit_service_task_.value());
-      if (shutdown_result.has_error()) {
-        ORBIT_ERROR("Unable to ShutdownTask: %s", shutdown_result.error().message());
-      }
-      orbit_service_task_ = std::nullopt;
-    }
-    if (session_.has_value()) {
-      outcome::result<void> shutdown_result = ShutdownSession(&session_.value());
-      if (shutdown_result.has_error()) {
-        ORBIT_ERROR("Unable to ShutdownSession: %s", shutdown_result.error().message());
-      }
-      session_ = std::nullopt;
-    }
-  });
+  QMetaObject::invokeMethod(
+      this,
+      [this]() {
+        if (sftp_channel_ != nullptr) {
+          outcome::result<void> shutdown_result = ShutdownSftpChannel(sftp_channel_.get());
+          if (shutdown_result.has_error()) {
+            ORBIT_ERROR("Unable to ShutdownSftpChannel: %s", shutdown_result.error().message());
+          }
+          sftp_channel_.reset();
+        }
+        if (grpc_tunnel_.has_value()) {
+          outcome::result<void> shutdown_result = ShutdownTunnel(&grpc_tunnel_.value());
+          if (shutdown_result.has_error()) {
+            ORBIT_ERROR("Unable to ShutdownTunnel: %s", shutdown_result.error().message());
+          }
+          grpc_tunnel_ = std::nullopt;
+        }
+        ssh_watchdog_timer_.stop();
+        if (orbit_service_task_.has_value()) {
+          outcome::result<void> shutdown_result = ShutdownTask(&orbit_service_task_.value());
+          if (shutdown_result.has_error()) {
+            ORBIT_ERROR("Unable to ShutdownTask: %s", shutdown_result.error().message());
+          }
+          orbit_service_task_ = std::nullopt;
+        }
+        if (session_.has_value()) {
+          outcome::result<void> shutdown_result = ShutdownSession(&session_.value());
+          if (shutdown_result.has_error()) {
+            ORBIT_ERROR("Unable to ShutdownSession: %s", shutdown_result.error().message());
+          }
+          session_ = std::nullopt;
+        }
+      },
+      Qt::BlockingQueuedConnection);
 }
 
 }  // namespace orbit_session_setup


### PR DESCRIPTION
`ServiceDeployManager::Shutdown` uses `DeferToBackgroundThreadAndWait`
to synchronously execute functions on a different thread.

`DeferToBackgroundThreadAndWait` spins up an event loop to process
events while waiting.

That's not suitable since `Shutdown` is meant to be called from the
destructor. This has lead to crashing race conditions in the past.

The solution is to replace `DeferToBackgroundThreadAndWait` by a
blocking operation that does NOT process events while waiting.

Bug: http://b/217645830
Test: Manual