### PR TITLE
Handle chained info in PE/COFF unwinding in libunwindstack

### DIFF
--- a/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.cpp
@@ -230,7 +230,18 @@ bool PeCoffUnwindInfoUnwinderX86_64::Eval(Memory* process_memory, Regs* regs,
     }
   }
 
-  // TODO: Chained info.
+  if (unwind_info.HasChainedInfo()) {
+    UnwindInfo chained_unwind_info;
+    if (!unwind_infos_->GetUnwindInfo(unwind_info.chained_info.unwind_info_offset,
+                                      &chained_unwind_info)) {
+      return false;
+    }
+
+    // We have to chain all unwind operations that are in the chained info, so we pass the max
+    // uint64_t value as code offset.
+    return Eval(process_memory, regs, chained_unwind_info, std::numeric_limits<uint64_t>::max(),
+                frame_pointer, frame_pointer_used);
+  }
 
   return true;
 }

--- a/third_party/libunwindstack/PeCoffUnwindInfos.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.cpp
@@ -68,7 +68,7 @@ bool PeCoffUnwindInfos::ParseUnwindInfoAtOffset(uint64_t offset, UnwindInfo* unw
     return false;
   }
 
-  if (unwind_info->GetFlags() & 0x04) {  // Chained unwind info.
+  if (unwind_info->HasChainedInfo()) {
     // For alignment purposes, the unwind codes array always has an even number of entries,
     // with the last one potentially being unused (as indicated by num_codes). To find the
     // chained function (which is a RUNTIME_FUNCTION struct), we therefore need to round

--- a/third_party/libunwindstack/PeCoffUnwindInfos.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.h
@@ -61,6 +61,7 @@ struct UnwindInfo {
 
   uint8_t GetVersion() const { return version_and_flags & 0x07; }
   uint8_t GetFlags() const { return (version_and_flags >> 3) & 0x1f; }
+  bool HasChainedInfo() const { return GetFlags() & 0x04; }
   uint8_t GetFrameRegister() const { return frame_register_and_offset & 0x0f; }
   uint8_t GetFrameOffset() const { return (frame_register_and_offset >> 4) & 0x0f; }
 };

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
@@ -33,7 +33,7 @@ class PeCoffUnwindInfosTest : public ::testing::Test {
     if (chained) {
       // To get the flags, this value will be shifted right by 3. To get chained info,
       // after shifting, this value must be 0x04.
-      flags = 0x20;
+      flags |= 0x04 << 3;
     }
     // Only version "1" is supported.
     uint8_t version_and_flags = flags | 0x01;


### PR DESCRIPTION
Unwind info can be chained using the RUNTIME_FUNCTION member of the
UNWIND_INFO struct. This allows some optimizations like non-contiguous
code segments, or delaying saving registers in a function call. One
example are tail call optimizations where a function call is carried
out using a 'jmp' instruction and not a 'call' instruction. In all cases
the inner unwind infos (everything in the chain until the final chained
info) are considered "secondary", the final info in the chain represents
the "primary" unwind info (corresponding to an actual function call).

Info on chained unwind info can be found here:
https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=msvc-170#chained-unwind-info-structures
(There seems to be a typo with a mixup of volatile and nonvolatile
registers if I'm not mistaken.)

This change adds support for chained unwind info. We unit test chained
unwind info using a fake unwinder that omits the actual unwind info
parsing and caching, allowing a simple way to fake the chained info
(the alternative would be to write the unwind info to a fake object
file).

Tested: Unit tests.
Bug: http://b/194768602