### PR TITLE
Fix missing leftmost label in the Timeline

### DIFF
--- a/src/OrbitGl/TimelineTicks.cpp
+++ b/src/OrbitGl/TimelineTicks.cpp
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 #include "TimelineTicks.h"
 
+#include <optional>
+
 #include "OrbitBase/Logging.h"
 
 namespace orbit_gl {
@@ -71,6 +73,18 @@ std::vector<uint64_t> TimelineTicks::GetMajorTicks(uint64_t start_ns, uint64_t e
     }
   }
   return major_ticks;
+}
+
+std::optional<uint64_t> TimelineTicks::GetPreviousMajorTick(uint64_t start_ns,
+                                                            uint64_t end_ns) const {
+  std::vector<uint64_t> major_ticks = GetMajorTicks(start_ns, end_ns);
+  ORBIT_CHECK(major_ticks.size() != 0);
+
+  uint64_t major_tick_scale = GetMajorTicksScale(end_ns + 1 - start_ns);
+  if (major_ticks[0] < major_tick_scale) {
+    return std::nullopt;
+  }
+  return major_ticks[0] - major_tick_scale;
 }
 
 int TimelineTicks::GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const {

--- a/src/OrbitGl/TimelineTicks.h
+++ b/src/OrbitGl/TimelineTicks.h
@@ -6,6 +6,7 @@
 #define ORBIT_GL_TIMELINE_IMPL_H_
 
 #include <cstdint>
+#include <optional>
 #include <set>
 #include <vector>
 
@@ -27,6 +28,8 @@ class TimelineTicks {
   [[nodiscard]] std::vector<std::pair<TickType, uint64_t> > GetAllTicks(uint64_t start_ns,
                                                                         uint64_t end_ns) const;
   [[nodiscard]] std::vector<uint64_t> GetMajorTicks(uint64_t start_ns, uint64_t end_ns) const;
+  [[nodiscard]] std::optional<uint64_t> GetPreviousMajorTick(uint64_t start_ns,
+                                                             uint64_t end_ns) const;
   // Number of digits needed to show precisely parts of a second in a timestamp.
   [[nodiscard]] int GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const;
 

--- a/src/OrbitGl/TimelineTicksTest.cpp
+++ b/src/OrbitGl/TimelineTicksTest.cpp
@@ -26,6 +26,20 @@ TEST(TimelineTicks, GetMajorTicks) {
                                    1 * kNanosecondsPerMinute));
 }
 
+TEST(TimelineTicks, GetPreviousMajorTick) {
+  TimelineTicks timeline_ticks;
+
+  EXPECT_EQ(timeline_ticks.GetPreviousMajorTick(0, 20), std::nullopt);
+  EXPECT_EQ(timeline_ticks.GetPreviousMajorTick(1, 299), 0);
+  EXPECT_EQ(timeline_ticks.GetPreviousMajorTick(20, 40), 10);
+  EXPECT_EQ(timeline_ticks.GetPreviousMajorTick(20, 38), 15);
+  EXPECT_EQ(
+      timeline_ticks.GetPreviousMajorTick(1 * kNanosecondsPerSecond, 6 * kNanosecondsPerSecond), 0);
+  EXPECT_EQ(
+      timeline_ticks.GetPreviousMajorTick(40 * kNanosecondsPerSecond, 1 * kNanosecondsPerMinute),
+      30 * kNanosecondsPerSecond);
+}
+
 static void CheckTicks(uint64_t start_ns, uint64_t end_ns, const std::set<uint64_t>& major_ticks,
                        const std::set<uint64_t>& minor_ticks) {
   TimelineTicks timeline_ticks;

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -36,16 +36,21 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
   const float kLabelMarginRight = 2;
   const float kPixelMargin = 1;
 
-  float previous_label_end_x = std::numeric_limits<float>::lowest();
   std::vector<uint64_t> all_major_ticks =
       timeline_ticks_.GetMajorTicks(min_timestamp_ns, max_timestamp_ns);
+  // The label of the previous major tick could be also partially visible.
+  std::optional<uint64_t> previous_major_tick =
+      timeline_ticks_.GetPreviousMajorTick(min_timestamp_ns, max_timestamp_ns);
+  if (previous_major_tick.has_value()) {
+    all_major_ticks.insert(all_major_ticks.begin(), previous_major_tick.value());
+  }
 
   int number_of_decimal_places_needed = 0;
   for (uint64_t tick : all_major_ticks) {
     number_of_decimal_places_needed = std::max(
         number_of_decimal_places_needed, timeline_ticks_.GetTimestampNumDigitsPrecision(tick));
   }
-
+  float previous_label_end_x = std::numeric_limits<float>::lowest();
   for (uint64_t tick_ns : all_major_ticks) {
     std::string label;
     // TODO(http://b/170712621): Remove this flag when we decide which timestamp format we will use.


### PR DESCRIPTION
Based on that labels are shown only when a tick is visible, if the left
major tick is not in screen, the label wasn't appearing. This confused
the user because we were losing the continuity while navigating through
the capture windows.

This is now fixed by including the previous major tick when rendering
labels.

http://screen/BaQgHujAqu7nens

First issue in http://b/217728115.