### PR TITLE
Fix vertical alignment in TrackContainer

### DIFF
--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -36,7 +36,6 @@ TimeGraphLayout::TimeGraphLayout() {
   rounding_num_sides_ = 16;
   text_offset_ = 5.f;
   right_margin_ = 10.f;
-  scheduler_track_offset_ = 10.f;
   toolbar_icon_height_ = 24.f;
   generic_fixed_spacer_width_ = 10.f;
   scale_ = 1.f;
@@ -80,7 +79,6 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(rounding_num_sides_);
   FLOAT_SLIDER(text_offset_);
   FLOAT_SLIDER(right_margin_);
-  FLOAT_SLIDER(scheduler_track_offset_);
   FLOAT_SLIDER_MIN_MAX(track_tab_width_, 0, 1000.f);
   FLOAT_SLIDER_MIN_MAX(track_content_bottom_margin_, 0, 20.f);
   FLOAT_SLIDER_MIN_MAX(track_content_top_margin_, 0, 20.f);

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -40,9 +40,8 @@ class TimeGraphLayout {
   float GetRoundingNumSides() const { return rounding_num_sides_; }
   float GetTextOffset() const { return text_offset_ * scale_; }
   float GetBottomMargin() const;
-  float GetTopMargin() const { return GetSchedulerTrackOffset(); }
+  float GetTracksTopMargin() const { return GetTimeBarHeight() + GetTimeBarMargin(); }
   float GetRightMargin() const { return right_margin_; }
-  float GetSchedulerTrackOffset() const { return scheduler_track_offset_; }
   float GetSpaceBetweenTracks() const { return space_between_tracks_ * scale_; }
   float GetSpaceBetweenCores() const { return space_between_cores_ * scale_; }
   float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }
@@ -84,7 +83,6 @@ class TimeGraphLayout {
   float rounding_num_sides_;
   float text_offset_;
   float right_margin_;
-  float scheduler_track_offset_;
 
   uint32_t font_size_;
 

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -50,8 +50,7 @@ TrackContainer::TrackContainer(CaptureViewElement* parent, TimelineInfoInterface
 
 float TrackContainer::GetVisibleTracksTotalHeight() const {
   // Top and Bottom Margin. TODO: Margins should be treated in a different way (http://b/192070555).
-  float visible_tracks_total_height =
-      layout_->GetSchedulerTrackOffset() + layout_->GetBottomMargin();
+  float visible_tracks_total_height = layout_->GetTracksTopMargin() + layout_->GetBottomMargin();
 
   // Track height including space between them
   for (auto& track : GetNonHiddenChildren()) {
@@ -105,7 +104,7 @@ void TrackContainer::DoUpdateLayout() {
 void TrackContainer::UpdateTracksPosition() {
   const float track_pos_x = GetPos()[0];
 
-  float current_y = GetPos()[1] + layout_->GetSchedulerTrackOffset() - vertical_scrolling_offset_;
+  float current_y = GetPos()[1] - vertical_scrolling_offset_;
 
   // Track height including space between them
   for (auto& track : track_manager_->GetVisibleTracks()) {


### PR DESCRIPTION
This PR is adding TopMargin to TotalTracksHeight, this is a hack before
making the vertical slider a part of TrackContainer and not the
complete TimeGraph. After both TopMargin and BottomMargin won't have any
sense.

Also we are erasing SchedulerTrackOffset, which is not used and needed
anymore.

Test: Load a Capture, move the vertical sliders, everything works.