### PR TITLE
Show at least one digit precision in Timestamps

### DIFF
--- a/src/DisplayFormats/DisplayFormats.cpp
+++ b/src/DisplayFormats/DisplayFormats.cpp
@@ -69,20 +69,14 @@ std::string GetDisplayISOTimestamp(absl::Duration timestamp, int num_digits_prec
   label += ToStringAtLeastTwoDigits(seconds);
   timestamp -= absl::Seconds(seconds);
 
-  if (num_digits_precision == 0) {
-    // Special case. If we are only showing seconds, let's add an 's';
-    if (label.size() <= 2) {
-      label += 's';
+  if (num_digits_precision != 0) {
+    // Parts of a second
+    label += ".";
+    absl::Duration precision_level = absl::Seconds(1);
+    for (int i = 0; i < num_digits_precision; ++i) {
+      precision_level /= 10;
+      label += std::to_string(absl::IDivDuration(timestamp, precision_level, &timestamp));
     }
-    return label;
-  }
-
-  // Parts of a second
-  label += ".";
-  absl::Duration precision_level = absl::Seconds(1);
-  for (int i = 0; i < num_digits_precision; ++i) {
-    precision_level /= 10;
-    label += std::to_string(absl::IDivDuration(timestamp, precision_level, &timestamp));
   }
   return label;
 }

--- a/src/DisplayFormats/DisplayFormatsTest.cpp
+++ b/src/DisplayFormats/DisplayFormatsTest.cpp
@@ -34,10 +34,11 @@ TEST(DisplayFormats, GetDisplayISOTimestamp) {
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(450), 2), "00.45");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(4005), 3), "04.005");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(4500), 1), "04.5");
-  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(0), 0), "00s");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(0), 1), "00.0");
-  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(10), 0), "10s");
-  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(13), 0), "13s");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(0), 2), "00.00");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(10), 1), "10");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(10), 1), "10.0");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(13), 1), "13.0");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Minutes(1), 0), "01:00");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Minutes(1), 1), "01:00.0");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Nanoseconds(12'345'600), 7), "00.0123456");

--- a/src/DisplayFormats/DisplayFormatsTest.cpp
+++ b/src/DisplayFormats/DisplayFormatsTest.cpp
@@ -36,7 +36,7 @@ TEST(DisplayFormats, GetDisplayISOTimestamp) {
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Milliseconds(4500), 1), "04.5");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(0), 1), "00.0");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(0), 2), "00.00");
-  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(10), 1), "10");
+  EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(10), 0), "10");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(10), 1), "10.0");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Seconds(13), 1), "13.0");
   EXPECT_EQ(GetDisplayISOTimestamp(absl::Minutes(1), 0), "01:00");

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -45,7 +45,7 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
     all_major_ticks.insert(all_major_ticks.begin(), previous_major_tick.value());
   }
 
-  int number_of_decimal_places_needed = 0;
+  int number_of_decimal_places_needed = 1;
   for (uint64_t tick : all_major_ticks) {
     number_of_decimal_places_needed = std::max(
         number_of_decimal_places_needed, timeline_ticks_.GetTimestampNumDigitsPrecision(tick));


### PR DESCRIPTION
After rediscuss it, we decided to align in being more consistent with
the timestamps displayed:
- Never show the 's' after the timestamps. (Ex: 42s, 42.186s)
- Always show at least one-digit precision after the '.'. (Ex: 42.0 or
  42.186). This includes also when we are at a minute scale (instead of
     02:00, we will show 02:00.0).

In some way we are sacrificing space when timestamps shouldn't use too
many digits.

Test: Start a capture, load a capture, see displayed timestamps.