### PR TITLE
Use ISO-timestamps in capture duration

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -667,8 +667,8 @@ void OrbitMainWindow::UpdateCaptureStateDependentWidgets() {
 
   hint_frame_->setVisible(!has_data);
 
-  filter_panel_action_->SetTimerLabelText(
-      QString::fromStdString(orbit_display_formats::GetDisplayTime(app_->GetCaptureTime())));
+  filter_panel_action_->SetTimerLabelText(QString::fromStdString(
+      orbit_display_formats::GetDisplayISOTimestamp(app_->GetCaptureTime(), 3)));
 
   UpdateCaptureToolbarIconOpacity();
 
@@ -1006,8 +1006,8 @@ void OrbitMainWindow::OnTimer() {
   }
 
   if (app_->IsCapturing()) {
-    filter_panel_action_->SetTimerLabelText(
-        QString::fromStdString(orbit_display_formats::GetDisplayTime(app_->GetCaptureTime())));
+    filter_panel_action_->SetTimerLabelText(QString::fromStdString(
+        orbit_display_formats::GetDisplayISOTimestamp(app_->GetCaptureTime(), 3)));
   }
 }
 


### PR DESCRIPTION
We decided to use ISO-timestamps where we are showing capture duration
as well as in the timeline for consistency. We will always show 3 digits of 
precision.

http://screen/BiSNR4sQZJBY72a