### PR TITLE
Solve both flickering and jumping timeline labels 

### DIFF
--- a/src/OrbitGl/TimelineTicks.cpp
+++ b/src/OrbitGl/TimelineTicks.cpp
@@ -87,11 +87,11 @@ std::optional<uint64_t> TimelineTicks::GetPreviousMajorTick(uint64_t start_ns,
   return major_ticks[0] - major_tick_scale;
 }
 
-int TimelineTicks::GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const {
-  constexpr int kMaxDigitsPrecision = 9;  // 1ns = 0.000'000'001s
+uint32_t TimelineTicks::GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const {
+  constexpr uint32_t kMaxDigitsPrecision = 9;  // 1ns = 0.000'000'001s
 
   uint64_t current_precision_ns = kNanosecondsPerSecond;
-  for (int num_digits = 0; num_digits < kMaxDigitsPrecision;
+  for (uint32_t num_digits = 0; num_digits < kMaxDigitsPrecision;
        num_digits++, current_precision_ns /= 10) {
     if (timestamp_ns % current_precision_ns == 0) {
       return num_digits;

--- a/src/OrbitGl/TimelineTicks.h
+++ b/src/OrbitGl/TimelineTicks.h
@@ -31,7 +31,7 @@ class TimelineTicks {
   [[nodiscard]] std::optional<uint64_t> GetPreviousMajorTick(uint64_t start_ns,
                                                              uint64_t end_ns) const;
   // Number of digits needed to show precisely parts of a second in a timestamp.
-  [[nodiscard]] int GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const;
+  [[nodiscard]] uint32_t GetTimestampNumDigitsPrecision(uint64_t timestamp_ns) const;
 
  private:
   [[nodiscard]] uint64_t GetMajorTicksScale(uint64_t visible_ns) const;

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -45,7 +45,7 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
     all_major_ticks.insert(all_major_ticks.begin(), previous_major_tick.value());
   }
 
-  int number_of_decimal_places_needed = 1;
+  uint32_t number_of_decimal_places_needed = 1;
   for (uint64_t tick : all_major_ticks) {
     number_of_decimal_places_needed = std::max(
         number_of_decimal_places_needed, timeline_ticks_.GetTimestampNumDigitsPrecision(tick));
@@ -87,11 +87,11 @@ void TimelineUi::RenderBackground(Batcher& batcher) const {
   batcher.AddBox(background_box, GlCanvas::kTimeBarBackgroundColor);
 }
 
-std::string TimelineUi::GetLabel(uint64_t tick_ns, int number_of_decimal_places) const {
+std::string TimelineUi::GetLabel(uint64_t tick_ns, uint32_t number_of_decimal_places_needed) const {
   // TODO(http://b/170712621): Remove this flag when we decide which timestamp format we will use.
   if (absl::GetFlag(FLAGS_iso_timestamps)) {
     return orbit_display_formats::GetDisplayISOTimestamp(
-        absl::Nanoseconds(tick_ns), number_of_decimal_places,
+        absl::Nanoseconds(tick_ns), number_of_decimal_places_needed,
         absl::Nanoseconds(timeline_info_interface_->GetCaptureTimeSpanNs()));
   }
   return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(tick_ns));
@@ -103,8 +103,8 @@ float TimelineUi::GetTickWorldXPos(uint64_t tick_ns) const {
 }
 
 std::vector<uint64_t> TimelineUi::GetTicksForNonOverlappingLabels(
-    TextRenderer& text_renderer, std::vector<uint64_t> all_major_ticks, float horizontal_margin,
-    int number_of_decimal_places) const {
+    TextRenderer& text_renderer, const std::vector<uint64_t>& all_major_ticks,
+    float horizontal_margin, uint32_t number_of_decimal_places) const {
   if (all_major_ticks.size() <= 1) return all_major_ticks;
   uint64_t ns_between_major_ticks = all_major_ticks[1] - all_major_ticks[0];
 
@@ -129,8 +129,9 @@ std::vector<uint64_t> TimelineUi::GetTicksForNonOverlappingLabels(
   return visible_labels;
 }
 
-bool TimelineUi::WillLabelsOverlap(TextRenderer& text_renderer, std::vector<uint64_t> tick_list,
-                                   float horizontal_margin, int number_of_decimal_places) const {
+bool TimelineUi::WillLabelsOverlap(TextRenderer& text_renderer,
+                                   const std::vector<uint64_t>& tick_list, float horizontal_margin,
+                                   uint32_t number_of_decimal_places) const {
   if (tick_list.size() <= 1) return false;
   float distance_between_labels = GetTickWorldXPos(tick_list[1]) - GetTickWorldXPos(tick_list[0]);
   for (auto tick_ns : tick_list) {

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -32,13 +32,15 @@ class TimelineUi : public CaptureViewElement {
                     uint64_t max_timestamp_ns) const;
   void RenderMargin(Batcher& batcher) const;
   void RenderBackground(Batcher& batcher) const;
-  [[nodiscard]] std::string GetLabel(uint64_t tick_ns, int number_of_decimal_places_needed) const;
+  [[nodiscard]] std::string GetLabel(uint64_t tick_ns,
+                                     uint32_t number_of_decimal_places_needed) const;
   [[nodiscard]] std::vector<uint64_t> GetTicksForNonOverlappingLabels(
-      TextRenderer& text_renderer, std::vector<uint64_t> all_major_ticks, float horizontal_margin,
-      int number_of_decimal_places) const;
+      TextRenderer& text_renderer, const std::vector<uint64_t>& all_major_ticks,
+      float horizontal_margin, uint32_t number_of_decimal_places) const;
   [[nodiscard]] bool WillLabelsOverlap(TextRenderer& text_renderer,
-                                       std::vector<uint64_t> timestamp_list,
-                                       float horizontal_margin, int number_of_decimal_places) const;
+                                       const std::vector<uint64_t>& tick_list,
+                                       float horizontal_margin,
+                                       uint32_t number_of_decimal_places) const;
   [[nodiscard]] float GetTickWorldXPos(uint64_t tick_ns) const;
   [[nodiscard]] float GetHeightWithoutMargin() const { return layout_->GetTimeBarHeight(); }
   [[nodiscard]] float GetMarginHeight() const { return layout_->GetTimeBarMargin(); }

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -32,6 +32,14 @@ class TimelineUi : public CaptureViewElement {
                     uint64_t max_timestamp_ns) const;
   void RenderMargin(Batcher& batcher) const;
   void RenderBackground(Batcher& batcher) const;
+  [[nodiscard]] std::string GetLabel(uint64_t tick_ns, int number_of_decimal_places_needed) const;
+  [[nodiscard]] std::vector<uint64_t> GetTicksForNonOverlappingLabels(
+      TextRenderer& text_renderer, std::vector<uint64_t> all_major_ticks, float horizontal_margin,
+      int number_of_decimal_places) const;
+  [[nodiscard]] bool WillLabelsOverlap(TextRenderer& text_renderer,
+                                       std::vector<uint64_t> timestamp_list,
+                                       float horizontal_margin, int number_of_decimal_places) const;
+  [[nodiscard]] float GetTickWorldXPos(uint64_t tick_ns) const;
   [[nodiscard]] float GetHeightWithoutMargin() const { return layout_->GetTimeBarHeight(); }
   [[nodiscard]] float GetMarginHeight() const { return layout_->GetTimeBarMargin(); }
 


### PR DESCRIPTION
In this PR we are solving 2 issues:

- Flickering: As labels were shown or not based on the size of the previous one,
there were some border cases which leads to skip some of them but not others.
http://screen/65dRc2myhGevgTy

- Jumping issue: As Orbit started by showing the left-most and was greedily
showing the next one which didn't intercept, the apparition of a new label in the
left part of the screen was swapping all the labels.
Before: http://screen/6H7uydk2dtxKEuW
After: http://screen/iuRBB8voXrMozme


To solve Flickering we now have the same number of skipped labels between
visible ones. To solve jumping we take advantage of an invariant and used it to
always show the same set of labels given a time_range (the ones which are 
multiple of the distance between them). 

After making this, RenderLabels was a complete monster and so I split it into 
a few smaller methods. Finally RenderLabel is now shorter than before.

Test: Load a capture, make the capture windows as smaller as possible, play 
with scales and also took a capture.

Ps: I know that this PR should have been splitted in at least 2, sorry for that. 
It should be the last one before branch cut if I'm not missing something.

http://b/217728115