### PR TITLE
Fix broken reference in MemoryWatchdog E2E test

### DIFF
--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -415,8 +415,11 @@ class CaptureAndWaitForInterruptedWarning(CaptureE2ETestCaseBase):
                  collect_system_memory_usage: bool = False,
                  user_space_instrumentation: bool = False,
                  manual_instrumentation: bool = False):
+        capture_tab = self.find_control('Group', "CaptureTab")
+        toggle_capture_button = self.find_control('Button', 'Toggle Capture', parent=capture_tab)
         self._set_up_and_start_capture(collect_thread_states, collect_system_memory_usage,
-                                       user_space_instrumentation, manual_instrumentation)
+                                       user_space_instrumentation, manual_instrumentation,
+                                       toggle_capture_button)
         self._wait_and_verify_capture_interrupted()
         self._verify_capture()
 


### PR DESCRIPTION
An issue from https://github.com/google/orbit/pull/3310. I missed the
reference to set_up_and_start_capture in the MemoryWatchdog E2E test.
The test was broken before and I'm not able to run it locally (It's
asking me for a process called "call_foo_repeat"), but I'm solving the
issue I caused.

http://b/218271948