### PR TITLE
Change connection_target to two independent parameters

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -54,11 +54,14 @@ ABSL_FLAG(bool, enforce_full_redraw, false,
           "Enforce full redraw every frame (used for performance measurements)");
 
 // VSI
-ABSL_FLAG(std::string, connection_target, "",
-          "Instance and process in the form <pid>@<instance>, where <instance> is either an "
-          "instance ID or an instance display name. Specify this to skip the connection setup and "
-          "open the main window instead. If either the instance or the process ID can't be found "
-          "or deployment is aborted by the user Orbit will exit with return code -1 immediately.");
+ABSL_FLAG(std::string, target_process, "",
+          "Process name or path. Specify this together with --target_instance to skip the "
+          "connection setup and open the main window instead. If the process can't be found or "
+          "deployment is aborted by the user Orbit will exit with return code -1 immediately.");
+ABSL_FLAG(std::string, target_instance, "",
+          "Instance name or id. Specify this together with --target_process to skip the "
+          "connection setup and open the main window instead. If the instance can't be found or "
+          "deployment is aborted by the user Orbit will exit with return code -1 immediately.");
 ABSL_FLAG(std::vector<std::string>, additional_symbol_paths, {},
           "Additional local symbol locations (comma-separated)");
 

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -54,7 +54,8 @@ ABSL_DECLARE_FLAG(std::string, instance_symbols_folder);
 ABSL_DECLARE_FLAG(bool, enforce_full_redraw);
 
 // VSI
-ABSL_DECLARE_FLAG(std::string, connection_target);
+ABSL_DECLARE_FLAG(std::string, target_process);
+ABSL_DECLARE_FLAG(std::string, target_instance);
 ABSL_DECLARE_FLAG(std::vector<std::string>, additional_symbol_paths);
 
 // Clears QSettings. This is intended for e2e tests.

--- a/src/SessionSetup/ConnectToTargetDialog.ui
+++ b/src/SessionSetup/ConnectToTargetDialog.ui
@@ -90,7 +90,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Process ID:</string>
+         <string>Process:</string>
         </property>
        </widget>
       </item>

--- a/src/SessionSetup/SessionSetupUtils.cpp
+++ b/src/SessionSetup/SessionSetupUtils.cpp
@@ -29,21 +29,4 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port) {
   return result;
 }
 
-std::optional<ConnectionTarget> orbit_session_setup::ConnectionTarget::FromString(
-    const QString& connection_target) {
-  auto parts = connection_target.split('@', QString::SplitBehavior::KeepEmptyParts);
-
-  if (parts.size() != 2) {
-    return std::nullopt;
-  }
-
-  bool ok = false;
-  uint pid = parts[0].toUInt(&ok);
-  if (!ok) {
-    return std::nullopt;
-  }
-
-  return ConnectionTarget{parts[1], pid};
-}
-
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/SessionSetupUtilsTest.cpp
+++ b/src/SessionSetup/SessionSetupUtilsTest.cpp
@@ -31,41 +31,4 @@ TEST(SessionSetupUtils, CredentialsFromSshInfoWorksCorrectly) {
   EXPECT_EQ(info.user.toStdString(), credentials.user);
 }
 
-TEST(SessionSetupUtils, ConnectionTargetFromValidInstanceId) {
-  const QString instance_id = "some/i-nstanc-3/id123";
-  const uint32_t pid = 1234;
-
-  // Correct format: "pid@instance_id", where PID is a uint32_t
-  QString target_string = QString("%1@%2").arg(QString::number(pid), instance_id);
-  const auto result = ConnectionTarget::FromString(target_string);
-  EXPECT_TRUE(result.has_value());
-  if (result.has_value()) {
-    EXPECT_EQ(result.value().instance_id_or_name_.toStdString(), instance_id.toStdString());
-    EXPECT_EQ(result.value().process_id_, pid);
-  }
-}
-
-TEST(SessionSetupUtils, ConnectionTargetFromValidInstanceName) {
-  const QString instance_name = "somename-1";
-  const uint32_t pid = 1234;
-
-  // Correct format: "pid@instance_name", where PID is a uint32_t
-  const QString target_string = QString("%1@%2").arg(QString::number(pid), instance_name);
-  auto result = ConnectionTarget::FromString(target_string);
-  EXPECT_TRUE(result.has_value());
-  if (result.has_value()) {
-    EXPECT_EQ(result.value().instance_id_or_name_.toStdString(), instance_name.toStdString());
-    EXPECT_EQ(result.value().process_id_, pid);
-  }
-}
-
-TEST(SessionSetupUtils, ErrorRaisedOnInvalidTarget) {
-  // Fail-tests for multiple incorrect formats
-  EXPECT_FALSE(ConnectionTarget::FromString("no/id/found").has_value());
-  EXPECT_FALSE(ConnectionTarget::FromString("invalid_pid@valid/i-nstanc-3/id").has_value());
-  EXPECT_FALSE(ConnectionTarget::FromString("").has_value());
-  // Double "@" results in failure as it's ambiguous
-  EXPECT_FALSE(ConnectionTarget::FromString("1234@invalid@i-nstanc-3/id").has_value());
-}
-
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
@@ -23,6 +23,14 @@ class ConnectToTargetDialog;  // IWYU pragma: keep
 }
 namespace orbit_session_setup {
 
+struct ConnectionTarget {
+  QString process_name_or_path;
+  QString instance_name_or_id;
+
+  ConnectionTarget(const QString& process_name_or_path, const QString& instance_name_or_id)
+      : process_name_or_path(process_name_or_path), instance_name_or_id(instance_name_or_id) {}
+};
+
 // Simple dialog to show progress while connecting to a specified instance id and process id.
 // This takes care of establishing the connection and deploying Orbit service, and will either
 // return a TargetConfiguration or nullopt on Exec. If a nullopt is returned, an error was
@@ -32,7 +40,7 @@ class ConnectToTargetDialog : public QDialog {
 
  public:
   explicit ConnectToTargetDialog(SshConnectionArtifacts* ssh_connection_artifacts,
-                                 const QString& instance_id, uint32_t process_id,
+                                 const ConnectionTarget& target,
                                  orbit_metrics_uploader::MetricsUploader* metrics_uploader,
                                  QWidget* parent = nullptr);
   ~ConnectToTargetDialog() override;
@@ -44,8 +52,7 @@ class ConnectToTargetDialog : public QDialog {
 
   SshConnectionArtifacts* ssh_connection_artifacts_;
 
-  QString instance_id_or_name_;
-  uint32_t process_id_;
+  ConnectionTarget target_;
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 
   struct ConnectionData {
@@ -67,7 +74,8 @@ class ConnectToTargetDialog : public QDialog {
   [[nodiscard]] ErrorMessageOr<orbit_session_setup::ServiceDeployManager::GrpcPort>
   DeployOrbitService(orbit_session_setup::ServiceDeployManager* service_deploy_manager);
   [[nodiscard]] ErrorMessageOr<std::unique_ptr<orbit_client_data::ProcessData>>
-  FindSpecifiedProcess(std::shared_ptr<grpc::Channel> grpc_channel, uint32_t process_id);
+  FindSpecifiedProcess(std::shared_ptr<grpc::Channel> grpc_channel,
+                       const QString& process_name_or_path);
 
   void SetStatusMessage(const QString& message);
   void LogAndDisplayError(const ErrorMessage& message);

--- a/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
@@ -18,14 +18,6 @@ namespace orbit_session_setup {
 [[nodiscard]] orbit_ssh::Credentials CredentialsFromSshInfo(const orbit_ggp::SshInfo& ssh_info);
 [[nodiscard]] std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port);
 
-struct ConnectionTarget {
-  QString instance_id_or_name_;
-  uint32_t process_id_;
-
-  // Split a target given as "<pid>@<instance>" into its components
-  [[nodiscard]] static std::optional<ConnectionTarget> FromString(const QString& connection_target);
-};
-
 }  // namespace orbit_session_setup
 
 #endif


### PR DESCRIPTION
Instead of pid@instance, users now need to specify two parameters:
--target_instance (instance ID or name)
--target_process (process path or name)

Input on how to make this testable (except with an E2E test) appreciated...