### PR TITLE
Extract BuildAndStartProducerSideServer method from Service module

### DIFF
--- a/src/ProducerSideService/BuildAndStartProducerSideServerLinux.cpp
+++ b/src/ProducerSideService/BuildAndStartProducerSideServerLinux.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/str_format.h>
+#include <sys/stat.h>
+
+#include <filesystem>
+#include <system_error>
+
+#include "BuildAndStartProducerSideServerWithUri.h"
+#include "OrbitBase/SafeStrerror.h"
+#include "ProducerSideChannel/ProducerSideChannel.h"
+#include "ProducerSideService/BuildAndStartProducerSideServer.h"
+
+namespace orbit_producer_side_service {
+
+std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServer() {
+  const std::filesystem::path unix_domain_socket_dir =
+      std::filesystem::path{orbit_producer_side_channel::kProducerSideUnixDomainSocketPath}
+          .parent_path();
+  std::error_code error_code;
+  std::filesystem::create_directories(unix_domain_socket_dir, error_code);
+  if (error_code) {
+    ORBIT_ERROR("Unable to create directory for socket for producer-side server: %s",
+                error_code.message());
+    return nullptr;
+  }
+
+  std::string unix_socket_path(orbit_producer_side_channel::kProducerSideUnixDomainSocketPath);
+  std::string uri = absl::StrFormat("unix:%s", unix_socket_path);
+  auto producer_side_server = BuildAndStartProducerSideServerWithUri(uri);
+
+  // When OrbitService runs as root, also allow non-root producers
+  // (e.g., the game) to communicate over the Unix domain socket.
+  if (chmod(unix_socket_path.c_str(), 0777) != 0) {
+    ORBIT_ERROR("Changing mode bits to 777 of \"%s\": %s", unix_socket_path, SafeStrerror(errno));
+    producer_side_server->ShutdownAndWait();
+    return nullptr;
+  }
+
+  return producer_side_server;
+}
+
+}  // namespace orbit_producer_side_service

--- a/src/ProducerSideService/BuildAndStartProducerSideServerWindows.cpp
+++ b/src/ProducerSideService/BuildAndStartProducerSideServerWindows.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "BuildAndStartProducerSideServerWithUri.h"
+#include "ProducerSideService/BuildAndStartProducerSideServer.h"
+
+namespace orbit_producer_side_service {
+
+std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServer() {
+  constexpr const char* kProducerSideServerUri = "127.0.0.1:1789";
+  return BuildAndStartProducerSideServerWithUri(kProducerSideServerUri);
+}
+
+}  // namespace orbit_producer_side_service

--- a/src/ProducerSideService/BuildAndStartProducerSideServerWithUri.h
+++ b/src/ProducerSideService/BuildAndStartProducerSideServerWithUri.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_PRODUCER_SIDE_SERVICE_BUILD_AND_START_PRODUCER_SIDE_SERVER_WITH_URI_H_
+#define ORBIT_PRODUCER_SIDE_SERVICE_BUILD_AND_START_PRODUCER_SIDE_SERVER_WITH_URI_H_
+
+#include "OrbitBase/Logging.h"
+#include "ProducerSideService/ProducerSideServer.h"
+
+namespace orbit_producer_side_service {
+
+[[nodiscard]] std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServerWithUri(
+    std::string uri) {
+  auto producer_side_server = std::make_unique<ProducerSideServer>();
+  ORBIT_LOG("Starting producer-side server at %s", uri);
+  if (!producer_side_server->BuildAndStart(uri)) {
+    ORBIT_ERROR("Unable to start producer-side server");
+    return nullptr;
+  }
+  ORBIT_LOG("Producer-side server is running");
+  return producer_side_server;
+}
+
+}  // namespace orbit_producer_side_service
+
+#endif  // ORBIT_PRODUCER_SIDE_SERVICE_BUILD_AND_START_PRODUCER_SIDE_SERVER_WITH_URI_H_

--- a/src/ProducerSideService/CMakeLists.txt
+++ b/src/ProducerSideService/CMakeLists.txt
@@ -12,12 +12,25 @@ target_include_directories(ProducerSideService PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}) 
 
 target_sources(ProducerSideService PUBLIC
+        include/ProducerSideService/BuildAndStartProducerSideServer.h
         include/ProducerSideService/ProducerSideServer.h
         include/ProducerSideService/ProducerSideServiceImpl.h)    
         
 target_sources(ProducerSideService PRIVATE
+        BuildAndStartProducerSideServerWithUri.h
         ProducerSideServer.cpp
         ProducerSideServiceImpl.cpp)
+
+if (WIN32)        
+target_sources(ProducerSideService PRIVATE
+        BuildAndStartProducerSideServerWindows.cpp)
+else()
+target_sources(ProducerSideService PRIVATE
+        BuildAndStartProducerSideServerLinux.cpp)
+
+target_link_libraries(ProducerSideService PUBLIC
+        ProducerSideChannel)
+endif()
 
 target_link_libraries(ProducerSideService PUBLIC
         CaptureServiceBase

--- a/src/ProducerSideService/include/ProducerSideService/BuildAndStartProducerSideServer.h
+++ b/src/ProducerSideService/include/ProducerSideService/BuildAndStartProducerSideServer.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_PRODUCER_SIDE_SERVICE_BUILD_AND_START_PRODUCER_SIDE_SERVER_H_
+#define ORBIT_PRODUCER_SIDE_SERVICE_BUILD_AND_START_PRODUCER_SIDE_SERVER_H_
+
+#include "ProducerSideService/ProducerSideServer.h"
+
+namespace orbit_producer_side_service {
+[[nodiscard]] std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServer();
+}  // namespace orbit_producer_side_service
+
+#endif  // ORBIT_PRODUCER_SIDE_SERVICE_BUILD_AND_START_PRODUCER_SIDE_SERVER_H_

--- a/src/Service/BUILD
+++ b/src/Service/BUILD
@@ -36,7 +36,6 @@ orbit_cc_library(
         "//src/OrbitBase",
         "//src/OrbitVersion",
         "//src/ProcessService",
-        "//src/ProducerSideChannel",
         "//src/ProducerSideService",
         "//src/TracepointService",
         "//src/UserSpaceInstrumentation",

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -20,7 +20,6 @@ target_include_directories(OrbitServiceLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(OrbitServiceLib PUBLIC
         GrpcProtos
         OrbitVersion
-        ProducerSideChannel
         ProducerSideService
 )
 


### PR DESCRIPTION
We extracted the `BuildAndStartProducerSideServer` method from the
Service module and moved it in to the ProducerSideService module.
This makes the CloudCollector able to reuse the
`BuildAndStartProducerSideServer` method.

Bug: http://b/218500565