### PR TITLE
Fix inconsistency with AsyncTrack's bottom Margin

### DIFF
--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -71,11 +71,11 @@ FrameTrack::FrameTrack(CaptureViewElement* parent,
 }
 
 float FrameTrack::GetHeight() const {
-  return GetHeaderHeight() + GetMaximumBoxHeight() + layout_->GetTrackContentBottomMargin();
+  return GetHeightAboveTimers() + GetMaximumBoxHeight() + layout_->GetTrackContentBottomMargin();
 }
 
 float FrameTrack::GetYFromTimer(const TimerInfo& timer_info) const {
-  return GetPos()[1] + GetHeaderHeight() +
+  return GetPos()[1] + GetHeightAboveTimers() +
          (GetMaximumBoxHeight() - GetDynamicBoxHeight(timer_info));
 }
 
@@ -223,7 +223,7 @@ void FrameTrack::DoDraw(Batcher& batcher, TextRenderer& text_renderer,
   const Vec2 pos = GetPos();
 
   const float x = pos[0];
-  const float y = pos[1] + GetHeaderHeight() + GetMaximumBoxHeight() - GetAverageBoxHeight();
+  const float y = pos[1] + GetHeightAboveTimers() + GetMaximumBoxHeight() - GetAverageBoxHeight();
   Vec2 from(x, y);
   Vec2 to(x + GetWidth(), y);
   float text_z = GlCanvas::kZValueTrackText;

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -153,7 +153,8 @@ float GpuSubmissionTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
     adjusted_depth += 1.f;
   }
-  return GetPos()[1] + GetHeaderHeight() + layout_->GetTextBoxHeight() * adjusted_depth + gap_space;
+  return GetPos()[1] + GetHeightAboveTimers() + layout_->GetTextBoxHeight() * adjusted_depth +
+         gap_space;
 }
 
 // When track or its parent is collapsed, only draw "hardware execution" timers.

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -44,7 +44,7 @@ void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 
 float SchedulerTrack::GetHeight() const {
   uint32_t num_gaps = std::max(GetDepth() - 1, 0u);
-  return GetHeaderHeight() + (GetDepth() * layout_->GetTextCoresHeight()) +
+  return GetHeightAboveTimers() + (GetDepth() * layout_->GetTextCoresHeight()) +
          (num_gaps * layout_->GetSpaceBetweenCores()) + layout_->GetTrackContentBottomMargin();
 }
 
@@ -86,7 +86,7 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
 
 float SchedulerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   uint32_t num_gaps = timer_info.depth();
-  return GetPos()[1] + GetHeaderHeight() +
+  return GetPos()[1] + GetHeightAboveTimers() +
          (layout_->GetTextCoresHeight() * static_cast<float>(timer_info.depth())) +
          num_gaps * layout_->GetSpaceBetweenCores();
 }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -255,7 +255,7 @@ bool ThreadTrack::IsEmpty() const {
 void ThreadTrack::UpdatePositionOfSubtracks() {
   const float thread_state_track_height = layout_->GetThreadStateTrackHeight();
   const float event_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
-  const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
+  const float space_between_subtracks = layout_->GetSpaceBetweenThreadPanes();
 
   const Vec2 pos = GetPos();
   float current_y = pos[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
@@ -319,16 +319,16 @@ float ThreadTrack::GetHeight() const {
   bool gap_between_tracks_and_timers =
       (!thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty()) &&
       (depth > 0);
-  return GetHeaderHeight() +
-         (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
+  return GetHeightAboveTimers() +
+         (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenThreadPanes() : 0) +
          layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
 }
 
-float ThreadTrack::GetHeaderHeight() const {
+float ThreadTrack::GetHeightAboveTimers() const {
   const float thread_state_track_height = layout_->GetThreadStateTrackHeight();
   const float event_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const float tracepoint_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
-  const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
+  const float space_between_subtracks = layout_->GetSpaceBetweenThreadPanes();
 
   float header_height = layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
   int track_count = 0;
@@ -354,8 +354,8 @@ float ThreadTrack::GetHeaderHeight() const {
 float ThreadTrack::GetYFromDepth(uint32_t depth) const {
   bool gap_between_tracks_and_timers =
       !thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty();
-  return GetPos()[1] + GetHeaderHeight() +
-         (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
+  return GetPos()[1] + GetHeightAboveTimers() +
+         (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenThreadPanes() : 0) +
          GetDefaultBoxHeight() * static_cast<float>(depth);
 }
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -100,7 +100,7 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
   [[nodiscard]] float GetHeight() const override;
-  [[nodiscard]] float GetHeaderHeight() const override;
+  [[nodiscard]] float GetHeightAboveTimers() const override;
 
   void UpdatePositionOfSubtracks() override;
 

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -20,9 +20,8 @@ TimeGraphLayout::TimeGraphLayout() {
   space_between_cores_ = 2.f;
   space_between_gpu_depths_ = 2.f;
   space_between_tracks_ = 10.f;
-  space_between_tracks_and_thread_ = 5.f;
+  space_between_thread_panes_ = 5.f;
   space_between_subtracks_ = 0.f;
-  space_between_thread_blocks_ = 35.f;
   track_label_offset_x_ = 30.f;
   slider_width_ = 15.f;
   track_tab_width_ = 350.f;
@@ -62,9 +61,8 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(space_between_cores_);
   FLOAT_SLIDER(space_between_gpu_depths_);
   FLOAT_SLIDER(space_between_tracks_);
-  FLOAT_SLIDER(space_between_tracks_and_thread_);
+  FLOAT_SLIDER(space_between_thread_panes_);
   FLOAT_SLIDER(space_between_subtracks_);
-  FLOAT_SLIDER(space_between_thread_blocks_);
   FLOAT_SLIDER(slider_width_);
   FLOAT_SLIDER(time_bar_height_);
   FLOAT_SLIDER(time_bar_margin_);

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -45,7 +45,7 @@ class TimeGraphLayout {
   float GetSpaceBetweenTracks() const { return space_between_tracks_ * scale_; }
   float GetSpaceBetweenCores() const { return space_between_cores_ * scale_; }
   float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }
-  float GetSpaceBetweenTracksAndThread() const { return space_between_tracks_and_thread_ * scale_; }
+  float GetSpaceBetweenThreadPanes() const { return space_between_thread_panes_ * scale_; }
   float GetSpaceBetweenSubtracks() const { return space_between_subtracks_ * scale_; }
   float GetToolbarIconHeight() const { return toolbar_icon_height_; }
   float GetGenericFixedSpacerWidth() const { return generic_fixed_spacer_width_; }
@@ -89,9 +89,8 @@ class TimeGraphLayout {
   float space_between_cores_;
   float space_between_gpu_depths_;
   float space_between_tracks_;
-  float space_between_tracks_and_thread_;
+  float space_between_thread_panes_;
   float space_between_subtracks_;
-  float space_between_thread_blocks_;
   float generic_fixed_spacer_width_;
 
   float toolbar_icon_height_;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -55,7 +55,7 @@ float TimerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 }
 
 float TimerTrack::GetYFromDepth(uint32_t depth) const {
-  return GetPos()[1] + GetHeaderHeight() + GetDefaultBoxHeight() * static_cast<float>(depth);
+  return GetPos()[1] + GetHeightAboveTimers() + GetDefaultBoxHeight() * static_cast<float>(depth);
 }
 
 namespace {
@@ -328,9 +328,7 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
 float TimerTrack::GetHeight() const {
   uint32_t collapsed_depth = std::min<uint32_t>(1, GetDepth());
   uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : GetDepth();
-  return GetHeaderHeight() + layout_->GetTrackContentTopMargin() +
-         layout_->GetTextBoxHeight() * depth +
-         (depth > 0 ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
+  return GetHeightAboveTimers() + layout_->GetTextBoxHeight() * depth +
          layout_->GetTrackContentBottomMargin();
 }
 
@@ -361,7 +359,7 @@ std::string TimerTrack::GetBoxTooltip(const Batcher& /*batcher*/, PickingId /*id
   return "";
 }
 
-float TimerTrack::GetHeaderHeight() const {
+float TimerTrack::GetHeightAboveTimers() const {
   return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
 }
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -88,7 +88,7 @@ class TimerTrack : public Track {
   [[nodiscard]] virtual float GetYFromTimer(const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
 
-  [[nodiscard]] virtual float GetHeaderHeight() const;
+  [[nodiscard]] virtual float GetHeightAboveTimers() const;
 
   [[nodiscard]] int GetVisiblePrimitiveCount() const override { return visible_timer_count_; }
 


### PR DESCRIPTION
AsyncTrack's bottom margin was considerably bigger than expected
comparing it to other types of Tracks.

After investigating the issue, seems to be that we have 2 different
issues in `TimerTracks::GetHeight()`. As this method is overwrited in most
of the TimerTracks, it was only visible in AsyncTrack.

Basically:

- We are renaming `GetHeaderHeight` by `GetHeightAboveTimers`, a more
  precise name. In TimerTracks is the distance above content, but in
  ThreadTracks include also the bars.
- We are erasing `layout_->GetTrackContentTopMargin()` from GetHeight (it
  is already counted in `GetHeighAboveTimers`). This is a regression from
  Orbit 1.72 (https://github.com/google/orbit/pull/2670).
- We are also erasing this from `TimerTrack::GetHeight()`:
  `(depth > 0 ? layout_->GetSpaceBetweenTracksAndThread() : 0)`.
  To be honest I'm not really sure why this was added. In my opinion
  doesn't have any sense. This actually was the bigger issue with
  AsyncTrack, as it's the only one which `GetHeight()` is not overwrited.
- We are renaming `GetSpaceBetweenTracksAndThread` by
  `GetSpaceBetweenThreadPanes` because ... actually it's used for this.

We also erase `GetSpaceBetweenThreadBlocks` (unused).

Test: Load a capture, test sizes, play a bit with imgui.

TODO:
- I wanted to move this implementation to AsyncTracks and make
`TimerTrack::GetHeight` a pure virtual method but this PR is already too
big. (part of http://b/218517047).
- I also wanted to fix the bottom space behind GpuDebugMarker, but this
  will come in another PR (http://b/218516297).

http://b/209745264