### PR TITLE
[Release] Fix lazy update in Childrens inside CaptureWindow

### DIFF
--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -53,10 +53,10 @@ void CaptureViewElement::UpdatePrimitives(Batcher& batcher, TextRenderer& text_r
 }
 
 void CaptureViewElement::UpdateLayout() {
+  DoUpdateLayout();
   for (CaptureViewElement* child : GetAllChildren()) {
     child->UpdateLayout();
   }
-  DoUpdateLayout();
 }
 
 void CaptureViewElement::SetPos(float x, float y) {


### PR DESCRIPTION
We are having 2 visual lazy-update issues.

- Track's initial position is wrong (only visible when loading a capture
  and leaving the mouse on the right). Regression from 1.74.

- Triangles in Gpu subtracks are being lazy-updated (an old regression).

This PR is fixing this issues, as it's first updating parent's position
before its children. Anyway, it's kind of a hack, because this could
lead to the opposite problem (children needing to update parent's
position).

The real solution is not clear, but could mean updating Layout position
recursively until nothing change. Anyway, this is solving the current
issues.

http://b/218665084
http://b/218454734

Test: Load a capture, see that everything is correctly positioned in the
first draw. Insert/Erase FrameTracks, check sliders and that everything
is updated correctly in the first draw.