### PR TITLE
Fix the graph track content top margin

### DIFF
--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -38,23 +38,26 @@ GraphTrack<Dimension>::GraphTrack(CaptureViewElement* parent,
       series_{series_names, series_value_decimal_digits, std::move(series_value_units)} {}
 
 template <size_t Dimension>
+bool GraphTrack<Dimension>::HasLegend() const {
+  return !IsCollapsed() && Dimension > 1;
+}
+
+template <size_t Dimension>
 float GraphTrack<Dimension>::GetHeight() const {
-  // Top content margin is counted twice because it it inserted before and after the legend
-  float height = layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() * 2 +
-                 GetLegendHeight() + GetGraphContentHeight() +
-                 layout_->GetTrackContentBottomMargin();
-  return height;
+  // Top content margin is counted twice when there are legends because it is inserted above and
+  // below the legend.
+  float track_content_top_margin = (HasLegend() ? 2.f : 1.f) * layout_->GetTrackContentTopMargin();
+
+  return layout_->GetTrackTabHeight() + track_content_top_margin + GetLegendHeight() +
+         GetGraphContentHeight() + layout_->GetTrackContentBottomMargin();
 }
 
 template <size_t Dimension>
 float GraphTrack<Dimension>::GetLegendHeight() const {
-  if (IsCollapsed() || Dimension <= 1) {
-    return 0;
-  }
   // This is a bit of an arbitrary choice - I don't want to introduce an additional layout
   // parameter just for the legend size, but it should be smaller than all regular textboxes
   // across Orbit.
-  return layout_->GetTextBoxHeight() / 2.f;
+  return HasLegend() ? layout_->GetTextBoxHeight() / 2.f : 0;
 }
 
 template <size_t Dimension>
@@ -75,7 +78,7 @@ void GraphTrack<Dimension>::DoDraw(Batcher& batcher, TextRenderer& text_renderer
   const Color kTransparentWhite(255, 255, 255, 180);
   DrawLabel(batcher, text_renderer, Vec2(point_x, point_y), text, kBlack, kTransparentWhite);
 
-  if (Dimension == 1) return;
+  if (!HasLegend()) return;
 
   // Draw legends
   const Color kWhite(255, 255, 255, 255);

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -46,18 +46,20 @@ template <size_t Dimension>
 float GraphTrack<Dimension>::GetHeight() const {
   // Top content margin is counted twice when there are legends because it is inserted above and
   // below the legend.
-  float track_content_top_margin = (HasLegend() ? 2.f : 1.f) * layout_->GetTrackContentTopMargin();
+  float legend_height_with_margins =
+      GetLegendHeight() + (HasLegend() ? 2.f : 1.f) * layout_->GetTrackContentTopMargin();
 
-  return layout_->GetTrackTabHeight() + track_content_top_margin + GetLegendHeight() +
-         GetGraphContentHeight() + layout_->GetTrackContentBottomMargin();
+  return layout_->GetTrackTabHeight() + legend_height_with_margins + GetGraphContentHeight() +
+         layout_->GetTrackContentBottomMargin();
 }
 
 template <size_t Dimension>
 float GraphTrack<Dimension>::GetLegendHeight() const {
-  // This is a bit of an arbitrary choice - I don't want to introduce an additional layout
-  // parameter just for the legend size, but it should be smaller than all regular textboxes
-  // across Orbit.
-  return HasLegend() ? layout_->GetTextBoxHeight() / 2.f : 0;
+  if (!HasLegend()) return 0;
+
+  // Legend size should be smaller than all regular textboxes across Orbit.
+  const float kLegendHeight = layout_->GetTextBoxHeight() / 2.f;
+  return kLegendHeight;
 }
 
 template <size_t Dimension>

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -46,10 +46,10 @@ template <size_t Dimension>
 float GraphTrack<Dimension>::GetHeight() const {
   // Top content margin is counted twice when there are legends because it is inserted above and
   // below the legend.
-  float legend_height_with_margins =
+  float height_above_content =
       GetLegendHeight() + (HasLegend() ? 2.f : 1.f) * layout_->GetTrackContentTopMargin();
 
-  return layout_->GetTrackTabHeight() + legend_height_with_margins + GetGraphContentHeight() +
+  return layout_->GetTrackTabHeight() + height_above_content + GetGraphContentHeight() +
          layout_->GetTrackContentBottomMargin();
 }
 

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -110,6 +110,7 @@ class GraphTrack : public Track {
   [[nodiscard]] virtual std::string GetLegendTooltips(size_t legend_index) const = 0;
   void DrawSingleSeriesEntry(Batcher& batcher, uint64_t start_tick, uint64_t end_tick,
                              const std::array<float, Dimension>& normalized_values, float z);
+  [[nodiscard]] bool HasLegend() const;
 
   std::optional<std::array<Color, Dimension>> series_colors_;
 };


### PR DESCRIPTION
In graph tracks, the top context margin was count twice as it is inserted
both above and below the legends. But this should only happen when there
are legends.

Bug: http://b/218517055