### PR TITLE
Make ETW timestamps match that of QueryPerformanceCounter()

### DIFF
--- a/src/WindowsTracing/KrabsTracer.cpp
+++ b/src/WindowsTracing/KrabsTracer.cpp
@@ -88,7 +88,7 @@ void KrabsTracer::Start() {
   ORBIT_CHECK(trace_thread_ == nullptr);
   context_switch_manager_ = std::make_unique<ContextSwitchManager>(listener_);
   SetIsSystemProfilePrivilegeEnabled(true);
-  trace_.open();
+  log_file_ = trace_.open();
   SetupStackTracing();
   trace_thread_ = std::make_unique<std::thread>(&KrabsTracer::Run, this);
 }

--- a/src/WindowsTracing/KrabsTracer.h
+++ b/src/WindowsTracing/KrabsTracer.h
@@ -56,6 +56,7 @@ class KrabsTracer {
   krabs::kernel::thread_provider thread_provider_;
   krabs::kernel::context_switch_provider context_switch_provider_;
   krabs::kernel_provider stack_walk_provider_;
+  EVENT_TRACE_LOGFILE log_file_ = {0};
 };
 
 }  // namespace orbit_windows_tracing

--- a/third_party/krabsetw/krabs/krabs/etw.hpp
+++ b/third_party/krabsetw/krabs/krabs/etw.hpp
@@ -263,8 +263,8 @@ namespace krabs { namespace details {
     {
         EVENT_TRACE_LOGFILE file = {};
         file.LoggerName          = const_cast<wchar_t*>(trace_.name_.c_str());
-        file.ProcessTraceMode    = PROCESS_TRACE_MODE_EVENT_RECORD |
-                                   PROCESS_TRACE_MODE_REAL_TIME;
+        file.ProcessTraceMode    = PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_REAL_TIME |
+                                   PROCESS_TRACE_MODE_RAW_TIMESTAMP;
         file.Context             = (void *)&trace_;
         file.EventRecordCallback = trace_callback_thunk<T>;
         file.BufferCallback      = trace_buffer_callback<T>;


### PR DESCRIPTION
Use PROCESS_TRACE_MODE_RAW_TIMESTAMP when setting up the ETW trace so
that timestamps are not converted into system time but rather kept in
their original format, in our case, the format that matches
QueryPerformanceCounter timestamps.

Log the state of the ETW trace file when starting a capture to confirm
the timestamp format change took place.

An issue was opened upstream in the krabsetw repo:
https://github.com/microsoft/krabsetw/issues/189

Test: locally tested, instrumented scopes now align with call stack
samples and scheduling events.