### PR TITLE
Allow local files in SymbolHelper

### DIFF
--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -176,8 +176,7 @@ SymbolHelper::SymbolHelper(fs::path cache_directory)
 
 ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
     const fs::path& module_path, const std::string& build_id,
-    const ModuleInfo::ObjectFileType& object_file_type,
-    absl::Span<const fs::path> directories) const {
+    const ModuleInfo::ObjectFileType& object_file_type, absl::Span<const fs::path> paths) const {
   if (build_id.empty()) {
     return ErrorMessage(absl::StrFormat(
         "Could not find symbols file for module \"%s\", because it does not contain a build id",
@@ -195,10 +194,14 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
 
   // Search in all directories for all the allowed symbol filenames
   std::set<fs::path> search_paths;
-  for (const auto& directory : directories) {
+  for (const auto& path : paths) {
+    if (!fs::is_directory(path)) {
+      search_paths.insert(path);
+      continue;
+    }
     for (const auto& filename :
          orbit_symbols::GetStandardSymbolFilenamesForModule(module_path, object_file_type)) {
-      search_paths.insert(directory / filename);
+      search_paths.insert(path / filename);
     }
   }
 

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -35,7 +35,7 @@ class SymbolHelper {
   [[nodiscard]] ErrorMessageOr<fs::path> FindSymbolsFileLocally(
       const fs::path& module_path, const std::string& build_id,
       const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type,
-      absl::Span<const fs::path> directories) const;
+      absl::Span<const fs::path> paths) const;
   [[nodiscard]] ErrorMessageOr<fs::path> FindSymbolsInCache(const fs::path& module_path,
                                                             const std::string& build_id) const;
   [[nodiscard]] static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(


### PR DESCRIPTION
Beforehand, FindSymbolsFileLocally worked only with a list of
directories. Now it works with paths and checks if the path is a
directory. If its not, the path is used directly and it is checked
whether valid symbols are at that path. Also simplifies the tests
a bit.

Tests: Unit Tests
http://b/202391472