### PR TITLE
Add ToString.h and ORBIT_LOG_VAR/ORBIT_LOG_VARN macros

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/ThreadConstants.h
         include/OrbitBase/ThreadPool.h
         include/OrbitBase/ThreadUtils.h
+        include/OrbitBase/ToString.h
         include/OrbitBase/UniqueResource.h
         include/OrbitBase/WriteStringToFile.h)
 
@@ -105,6 +106,7 @@ target_sources(OrbitBaseTests PRIVATE
         SimpleExecutorTest.cpp
         TemporaryFileTest.cpp
         ThreadUtilsTest.cpp
+        ToStringTest.cpp
         UniqueResourceTest.cpp
         WriteStringToFileTest.cpp
 )

--- a/src/OrbitBase/ToStringTest.cpp
+++ b/src/OrbitBase/ToStringTest.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/str_format.h>
+#include <gtest/gtest.h>
+
+#ifdef WIN32
+#include <Windows.h>
+#endif
+
+#include "OrbitBase/ToString.h"
+
+TEST(ToString, CommonTypes) {
+  // uint32_t
+  ASSERT_EQ(orbit_base::ToString(static_cast<uint32_t>(1234)), "1234");
+
+  // int
+  ASSERT_EQ(orbit_base::ToString(static_cast<int>(1)), "1");
+  ASSERT_EQ(orbit_base::ToString(-1), "-1");
+
+  // float
+  ASSERT_EQ(orbit_base::ToString(1.5f), "1.500000");
+  ASSERT_EQ(orbit_base::ToString(-1.5f), "-1.500000");
+
+  // double
+  ASSERT_EQ(orbit_base::ToString(1.5), "1.500000");
+  ASSERT_EQ(orbit_base::ToString(-1.5), "-1.500000");
+
+  // const char*
+  constexpr const char* kTestString = "test_string";
+  ASSERT_EQ(orbit_base::ToString(kTestString), kTestString);
+
+  // char*
+  std::string test_string = absl::StrFormat("test_string%s", "\0");
+  char* test_string_ptr = &test_string[0];
+  ASSERT_EQ(orbit_base::ToString(test_string_ptr), test_string);
+
+  // std::string
+  ASSERT_EQ(orbit_base::ToString(std::string(kTestString)), kTestString);
+
+  // const wchar_t*
+  constexpr const wchar_t* kTestStringW = L"test_string_w";
+  ASSERT_EQ(orbit_base::ToString(kTestStringW), "test_string_w");
+
+  // wchar_t*
+  std::wstring wide_test_string = std::wstring(L"test_string_w") + L"\0";
+  wchar_t* wide_test_string_ptr = &wide_test_string[0];
+  ASSERT_EQ(orbit_base::ToString(wide_test_string_ptr), "test_string_w");
+
+  // std::wstring
+  ASSERT_EQ(orbit_base::ToString(std::wstring(kTestStringW)), "test_string_w");
+}
+
+#ifdef WIN32
+TEST(ToString, WindowsString) {
+  // Matches ToString(const wchar_t*).
+  constexpr const LPCWSTR lpcwstr = L"test_string_const_lpcwstr";
+  ASSERT_EQ(orbit_base::ToString(lpcwstr), "test_string_const_lpcwstr");
+
+  // Matches ToString(wchar_t*).
+  LPCWSTR non_const_lpcwstr = L"test_string_non_const_lpcwstr";
+  ASSERT_EQ(orbit_base::ToString(non_const_lpcwstr), "test_string_non_const_lpcwstr");
+}
+#endif  // WIN32

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -20,6 +20,7 @@
 #endif
 
 #include "OrbitBase/Result.h"
+#include "OrbitBase/ToString.h"
 
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -120,6 +121,9 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
   } ORBIT_INTERNAL_SCOPED_TIMED_LOG_CONCAT(scoped_timed_log_, __LINE__) {                      \
     absl::StrFormat(format, ##__VA_ARGS__)                                                     \
   }
+
+#define ORBIT_LOG_VAR(x) ORBIT_LOG("%s = %s", #x, orbit_base::ToString(x))
+#define ORBIT_LOG_VARN(x, name) ORBIT_LOG("%s = %s", name, orbit_base::ToString(x))
 
 // Internal.
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)

--- a/src/OrbitBase/include/OrbitBase/ToString.h
+++ b/src/OrbitBase/include/OrbitBase/ToString.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_TO_STRING_H_
+#define ORBIT_BASE_TO_STRING_H_
+
+#include <algorithm>
+#include <string>
+
+// Wrapper around std::to_string which adds support for strings.
+
+namespace orbit_base {
+
+template <typename T>
+[[nodiscard]] inline std::string ToString(const T& value) {
+  return std::to_string(value);
+}
+
+[[nodiscard]] inline std::string ToString(const wchar_t* value, size_t length) {
+  std::string result(length, 0);
+  std::transform(value, value + length, result.begin(),
+                 [](wchar_t c) { return static_cast<char>(c); });
+  return result;
+}
+
+[[nodiscard]] inline std::string ToString(wchar_t* value) { return ToString(value, wcslen(value)); }
+[[nodiscard]] inline std::string ToString(const wchar_t* value) {
+  return ToString(value, wcslen(value));
+}
+[[nodiscard]] inline std::string ToString(const std::wstring& value) {
+  return ToString(value.c_str(), value.size());
+}
+
+[[nodiscard]] inline std::string ToString(char* value) { return std::string(value); }
+[[nodiscard]] inline std::string ToString(const char* value) { return std::string(value); }
+[[nodiscard]] inline std::string ToString(const std::string& value) { return value; }
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_TO_STRING_H_

--- a/src/OrbitBase/include/OrbitBase/ToString.h
+++ b/src/OrbitBase/include/OrbitBase/ToString.h
@@ -6,6 +6,7 @@
 #define ORBIT_BASE_TO_STRING_H_
 
 #include <algorithm>
+#include <cwchar>
 #include <string>
 
 // Wrapper around std::to_string which adds support for strings.
@@ -24,9 +25,11 @@ template <typename T>
   return result;
 }
 
-[[nodiscard]] inline std::string ToString(wchar_t* value) { return ToString(value, wcslen(value)); }
+[[nodiscard]] inline std::string ToString(wchar_t* value) {
+  return ToString(value, std::wcslen(value));
+}
 [[nodiscard]] inline std::string ToString(const wchar_t* value) {
-  return ToString(value, wcslen(value));
+  return ToString(value, std::wcslen(value));
 }
 [[nodiscard]] inline std::string ToString(const std::wstring& value) {
   return ToString(value.c_str(), value.size());

--- a/src/WindowsTracing/KrabsTracer.cpp
+++ b/src/WindowsTracing/KrabsTracer.cpp
@@ -181,6 +181,7 @@ void KrabsTracer::OnStackWalkEvent(const EVENT_RECORD& record,
 }
 
 void KrabsTracer::OutputStats() {
+  OutputLogFileInfo(log_file_);
   krabs::trace_stats trace_stats = trace_.query_stats();
   ORBIT_LOG("--- ETW stats ---");
   ORBIT_LOG("Number of buffers: %u", trace_stats.buffersCount);
@@ -194,6 +195,40 @@ void KrabsTracer::OutputStats() {
   ORBIT_LOG("Number of stack events: %u", stats_.num_stack_events);
   ORBIT_LOG("Number of stack events for target pid: %u", stats_.num_stack_events_for_target_pid);
   context_switch_manager_->OutputStats();
+}
+
+void KrabsTracer::OutputLogFileInfo(const EVENT_TRACE_LOGFILE& log_file) {
+  ORBIT_LOG("--- ETW Logfile info ---");
+  ORBIT_LOG_VAR(log_file.LoggerName);
+  ORBIT_LOG_VAR(log_file.CurrentTime);
+  ORBIT_LOG_VAR(log_file.BuffersRead);
+  ORBIT_LOG_VAR(log_file.BufferSize);
+  ORBIT_LOG_VAR(log_file.Filled);
+  ORBIT_LOG_VAR(log_file.EventsLost);
+  ORBIT_LOG_VAR(log_file.IsKernelTrace);
+
+  const TRACE_LOGFILE_HEADER& header = log_file.LogfileHeader;
+  ORBIT_LOG_VAR(header.VersionDetail.MajorVersion);
+  ORBIT_LOG_VAR(header.VersionDetail.MinorVersion);
+  ORBIT_LOG_VAR(header.VersionDetail.SubVersion);
+  ORBIT_LOG_VAR(header.VersionDetail.SubMinorVersion);
+  ORBIT_LOG_VAR(header.ProviderVersion);
+  ORBIT_LOG_VAR(header.EndTime.QuadPart);
+  ORBIT_LOG_VAR(header.TimerResolution);
+  ORBIT_LOG_VAR(header.MaximumFileSize);
+  ORBIT_LOG_VAR(header.LogFileMode);
+  ORBIT_LOG_VAR(header.BuffersWritten);
+  ORBIT_LOG_VAR(header.StartBuffers);
+  ORBIT_LOG_VAR(header.PointerSize);
+  ORBIT_LOG_VAR(header.EventsLost);
+  ORBIT_LOG_VAR(header.CpuSpeedInMHz);
+  ORBIT_LOG_VAR(header.LoggerName);
+  ORBIT_LOG_VAR(header.LogFileName);
+  ORBIT_LOG_VAR(header.BootTime.QuadPart);
+  ORBIT_LOG_VAR(header.PerfFreq.QuadPart);
+  ORBIT_LOG_VAR(header.StartTime.QuadPart);
+  ORBIT_LOG_VARN(header.ReservedFlags, "header.ReservedFlags (ClockType)");
+  ORBIT_LOG_VAR(header.BuffersLost);
 }
 
 }  // namespace orbit_windows_tracing

--- a/src/WindowsTracing/KrabsTracer.h
+++ b/src/WindowsTracing/KrabsTracer.h
@@ -36,6 +36,7 @@ class KrabsTracer {
   void OnThreadEvent(const EVENT_RECORD& record, const krabs::trace_context& context);
   void OnStackWalkEvent(const EVENT_RECORD& record, const krabs::trace_context& context);
   void OutputStats();
+  static void OutputLogFileInfo(const EVENT_TRACE_LOGFILE& log_file);
 
   struct Stats {
     uint64_t num_thread_events = 0;


### PR DESCRIPTION
This is in essence reviving the PRINT_VAR/PRINT_VARN macros that were
once present in the Orbit codebase. The macros are now named
ORBIT_LOG_VAR/ORBIT_LOG_VARN. They are utility macros that log the name
and value of a variable in a simple invocation:

int my_int = 42;
ORBIT_LOG_VAR(my_int); // Logs "my_int = 42"
ORBIT_LOG_VARN(my_int, "new_name"); // Logs "new_name = 42"

Internally, the macro calls a new orbit_base::ToString(...) function
which is essentially a wrapper around std::to_string(...). The
difference is that we can add custom or not-supported types. Currently,
ToString adds support for string types, which is not supported by
std::to_string.

This is mainly useful for day-to-day debugging, and we don't expect too
many occurences to make their way to the official codebase. That being
said, there are cases where we actually want to log information in the
exact "name = value" syntax. We will rely on code reviews to push back
on misuse.

Tests: ToStringTest.cpp.