### PR TITLE
Add epilog detection and handling for PE/COFF in libunwindstack

### DIFF
--- a/third_party/libunwindstack/BUILD
+++ b/third_party/libunwindstack/BUILD
@@ -125,5 +125,6 @@ cc_library(
         "@android_platform_system_libbase//:libbase",
         "@android_platform_system_libprocinfo//:libprocinfo",
         "@com_7-zip_org_sdk//lzma",
+        "@com_github_capstone-engine_capstone//capstone",
     ],
 )

--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -66,6 +66,8 @@ target_sources(libunwindstack_common PRIVATE
   MemoryXz.h
   Object.cpp
   PeCoff.cpp
+  PeCoffEpilog.cpp
+  PeCoffEpilog.h
   PeCoffInterface.cpp
   PeCoffRuntimeFunctions.cpp
   PeCoffRuntimeFunctions.h
@@ -148,6 +150,7 @@ target_sources(libunwindstack_common PUBLIC
 target_include_directories(libunwindstack_common PUBLIC include/)
 target_compile_features(libunwindstack_common PUBLIC cxx_std_17)
 target_link_libraries(libunwindstack_common PRIVATE
+  CONAN_PKG::capstone
   CONAN_PKG::libunwindstack-android-dependencies
   CONAN_PKG::lzma_sdk)
 
@@ -259,6 +262,7 @@ target_sources(libunwindstack_tests PRIVATE
   tests/PeCoffTest.cpp
   tests/PeCoffUnwindInfosTest.cpp
   tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
+  tests/PeCoffEpilogTest.cpp
   tests/RegsInfoTest.cpp
   tests/RegsIterateTest.cpp
   tests/RegsStepIfSignalHandlerTest.cpp
@@ -286,6 +290,7 @@ target_link_libraries(libunwindstack_tests PRIVATE ${CMAKE_DL_LIBS})
 # so we link to it explicitly here.
 find_library(liblog_shared log_shared REQUIRED)
 target_link_libraries(libunwindstack_tests PRIVATE
+  CONAN_PKG::capstone
   CONAN_PKG::libunwindstack-android-dependencies
   CONAN_PKG::lzma_sdk
   CONAN_PKG::zlib

--- a/third_party/libunwindstack/PeCoffEpilog.h
+++ b/third_party/libunwindstack/PeCoffEpilog.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBUNWINDSTACK_PE_COFF_EPILOG_H
+#define _LIBUNWINDSTACK_PE_COFF_EPILOG_H
+
+#include <vector>
+
+#include <capstone/capstone.h>
+
+#include <unwindstack/Error.h>
+#include <unwindstack/Memory.h>
+#include <unwindstack/Regs.h>
+
+namespace unwindstack {
+
+// Helper class for epilog detection and handling used for X86_64 unwinding for PE/COFF modules.
+class PeCoffEpilog {
+ public:
+  ~PeCoffEpilog();
+
+  // Needs to be called before one can use DetectAndHandleEpilog.
+  bool Init();
+
+  // Detects if the bytes in 'machine_code' represent an epilog of a function and handles
+  // executing the instructions in the epilog if that is the case.
+  // Returns true if an epilog was detected. The registers are updated to reflect the actions from
+  // executing the epilog (which effectively unwinds the current callframe). Returns false if
+  // machine_code does not represent an epilog or if an error occured. In the latter case, the
+  // error can be retrieved using GetLastError() and registers 'regs' are not updated.
+  bool DetectAndHandleEpilog(const std::vector<uint8_t>& machine_code, Memory* process_memory,
+                             Regs* regs);
+  ErrorData GetLastError() const { return last_error_; }
+
+ private:
+  // The validation methods below check if the instructions satisfy the requirements imposed by the
+  // epilog specification, as outlined on
+  // https://docs.microsoft.com/en-us/cpp/build/prolog-and-epilog?view=msvc-170
+  // The corresponding handling methods must only be called after the validation was successful.
+  bool ValidateLeaInstruction();
+  void HandleLeaInstruction(RegsImpl<uint64_t>* registers);
+  bool ValidateAddInstruction();
+  void HandleAddInstruction(RegsImpl<uint64_t>* registers);
+  bool HandlePopInstruction(Memory* process_memory, RegsImpl<uint64_t>* registers);
+  bool HandleReturnInstruction(Memory* process_memory, RegsImpl<uint64_t>* registers);
+  bool ValidateJumpInstruction();
+  bool HandleJumpInstruction(Memory* process_memory, RegsImpl<uint64_t>* registers);
+
+  ErrorData last_error_{ERROR_NONE, 0};
+
+  bool capstone_initialized_ = false;
+  csh capstone_handle_ = 0;
+  cs_insn* capstone_instruction_ = nullptr;
+};
+
+}  // namespace unwindstack
+
+#endif  // _LIBUNWINDSTACK_PE_COFF_EPILOG_H

--- a/third_party/libunwindstack/tests/PeCoffEpilogTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffEpilogTest.cpp
@@ -1,0 +1,591 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PeCoffEpilog.h"
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include <unwindstack/MachineX86_64.h>
+#include <unwindstack/RegsX86_64.h>
+#include "Check.h"
+#include "MemoryFake.h"
+
+#include <gtest/gtest.h>
+
+namespace unwindstack {
+
+// While XMM registers can occur in epilog code (and as UNWIND_INFO codes), they can
+// not be pushed to the stack, they are always saved with a 'mov' instruction into the
+// area allocated on the stack for the current stack frame. In epilogs, the
+// corresponding restore operations do not exist and we therefore do not have to care
+// about them here.
+enum Register : uint8_t {
+  RAX = 0,
+  RCX = 1,
+  RDX = 2,
+  RBX = 3,
+  RSP = 4,
+  RBP = 5,
+  RSI = 6,
+  RDI = 7,
+  R8 = 8,
+  R9 = 9,
+  R10 = 10,
+  R11 = 11,
+  R12 = 12,
+  R13 = 13,
+  R14 = 14,
+  R15 = 15,
+};
+
+// Only non-volatile registers should be used for these:
+// RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15
+struct PopOp {
+  Register reg;
+  uint64_t value;
+};
+
+// Used as a parameter for BuildEpilog below to specify the structure of the
+// epilog.
+struct EpilogOptions {
+  // Return address to be set on the stack.
+  uint64_t return_address = 0;
+
+  // Insert 'lea' instruction as the first instruction of the epilog.
+  bool insert_lea_instruction = false;
+  // The 'lea' instruction is only to be used when a frame pointer register
+  // is being used. This sets the frame pointer register to be used.
+  Register frame_pointer_register = RBP;
+  // Displacement value to be used by the 'lea' instruction.
+  uint32_t lea_displacement = 0;
+  // Value in the frame pointer register.
+  uint64_t frame_pointer_register_value = 0;
+
+  // Insert 'add' instruction as the first instruction of the epilog. This
+  // is for deallocating the stack allocation.
+  bool insert_add_instruction = false;
+  // Must be > 0 when inserting an 'add' instruction/
+  int32_t added_value = 0;
+
+  // Sequence of pop instructions to be added into the epilog. These are all
+  // the callee saved registers that are saved by the function.
+  std::vector<PopOp> pop_operations;
+
+  // Instruction bytes for the final 'jmp' or 'ret' can be fairly diverse,
+  // so we just directly specify the bytes in each test and pass them in the
+  // BuildEpilog method to insert them at the end of the machine code built up.
+  std::vector<uint8_t> jmp_instruction_bytes;
+  std::vector<uint8_t> ret_instruction_bytes;
+};
+
+class PeCoffEpilogTest : public ::testing::Test {
+ public:
+  PeCoffEpilogTest() : process_mem_fake_(new MemoryFake) {}
+  ~PeCoffEpilogTest() {}
+
+  void SetUp() { ASSERT_TRUE(pe_coff_epilog_.Init()); }
+
+  // Builds machine code according to the desired epilog structure as specified in the 'options'
+  // argument. A good source for understanding and validating instruction encoding can be found
+  // here: https://wiki.osdev.org/X86-64_Instruction_Encoding. In particular relevant are REX
+  // prefix and ModRM encodings. Instruction reference with opcodes can be found on
+  // https://www.felixcloutier.com/x86/, or in the official AMD and Intel manuals, which can be
+  // found at https://www.amd.com/system/files/TechDocs/24594.pdf and
+  // https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
+  std::vector<uint8_t> BuildEpilog(const EpilogOptions& options) {
+    std::vector<uint8_t> machine_code;
+    // Cannot have both a 'lea' and an 'add' to deallocate the stack allocation.
+    CHECK(!options.insert_lea_instruction || !options.insert_add_instruction);
+    if (options.insert_lea_instruction) {
+      // The REX prefix always has the value 0100 WRXB, where RB can be used to
+      // modulate the registers used as operands. In this case, if the frame
+      // pointer register is one of R8 to R15, then we need to set the B bit to 1.
+      uint8_t rex_byte = 0x48;
+      if (options.frame_pointer_register >= R8) {
+        rex_byte = 0x49;
+      }
+      machine_code.insert(machine_code.end(), {rex_byte, 0x8d});
+      if (options.lea_displacement <= 0xff) {
+        // Only want the lower three bits of the register, the highest bit is indicated
+        // in the REX prefix.
+        uint8_t modrm = 0b01'100'000 | (options.frame_pointer_register & 0b0111);
+        machine_code.emplace_back(modrm);
+        uint8_t disp = static_cast<uint8_t>(options.lea_displacement);
+        machine_code.emplace_back(disp);
+      } else {
+        // Only want the lower three bits of the register, the highest bit is indicated
+        // in the REX prefix.
+        uint8_t modrm = 0b10'100'000 | (options.frame_pointer_register & 0b0111);
+        machine_code.emplace_back(modrm);
+        std::array<uint8_t, 4> values;
+        uint32_t lea_displacement = options.lea_displacement;
+        std::memcpy(static_cast<void*>(&values[0]), static_cast<void*>(&lea_displacement),
+                    sizeof(uint32_t));
+        machine_code.insert(machine_code.end(), values.begin(), values.end());
+      }
+      expected_stack_pointer_after_unwind_ =
+          options.frame_pointer_register_value + options.lea_displacement;
+    }
+    if (options.insert_add_instruction) {
+      CHECK(options.added_value > 0);
+      machine_code.emplace_back(0x48);
+      if (options.added_value <= 127) {
+        machine_code.insert(machine_code.end(), {0x83, 0xc4});
+        uint8_t immediate = static_cast<uint8_t>(options.added_value);
+        machine_code.emplace_back(immediate);
+      } else {
+        machine_code.insert(machine_code.end(), {0x81, 0xc4});
+        std::array<uint8_t, 4> values;
+        int32_t added_value = options.added_value;
+        std::memcpy(static_cast<void*>(&values[0]), static_cast<void*>(&added_value),
+                    sizeof(int32_t));
+        machine_code.insert(machine_code.end(), values.begin(), values.end());
+      }
+      expected_stack_pointer_after_unwind_ += options.added_value;
+    }
+
+    for (const auto& pop_op : options.pop_operations) {
+      process_mem_fake_->SetData64(expected_stack_pointer_after_unwind_, pop_op.value);
+      expected_stack_pointer_after_unwind_ += sizeof(uint64_t);
+      // For 'pop' operations, the REX prefix is only used when one of R8 to R15 is
+      // the operand. In that case we need to use the fixed value of 0x41 as the
+      // REX prefix.
+      if (pop_op.reg >= R8) {
+        machine_code.emplace_back(0x41);
+      }
+      // Only want the lower three bits of the register value. If the highest bit is
+      // 1, this is indicated by presence of the REX prefix.
+      uint8_t opcode_byte = 0x58 | (pop_op.reg & 0x7);
+      machine_code.emplace_back(opcode_byte);
+    }
+
+    process_mem_fake_->SetData64(expected_stack_pointer_after_unwind_, options.return_address);
+    expected_stack_pointer_after_unwind_ += sizeof(uint64_t);
+
+    CHECK(options.jmp_instruction_bytes.empty() != options.ret_instruction_bytes.empty());
+    machine_code.insert(machine_code.end(), options.jmp_instruction_bytes.begin(),
+                        options.jmp_instruction_bytes.end());
+    machine_code.insert(machine_code.end(), options.ret_instruction_bytes.begin(),
+                        options.ret_instruction_bytes.end());
+    return machine_code;
+  }
+
+ protected:
+  PeCoffEpilog pe_coff_epilog_;
+  std::unique_ptr<MemoryFake> process_mem_fake_;
+  // Anything we do in the tests will increase the stack pointer value, so this is a safe starting
+  // point.
+  uint64_t expected_stack_pointer_after_unwind_ = 0;
+};
+
+TEST_F(PeCoffEpilogTest, fails_with_error_if_disassembling_fails) {
+  std::vector<uint8_t> machine_code{0x48, 0x81, 0xc1, 0x07,
+                                    0xc3};  // bogus machine code, two bytes are missing
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_UNSUPPORTED);
+}
+
+TEST_F(PeCoffEpilogTest, fails_if_memory_at_return_address_is_invalid) {
+  std::vector<uint8_t> machine_code{0xc3};  // ret
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_MEMORY_INVALID);
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().address, 0);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_add_with_small_value_and_ret_only) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.insert_add_instruction = true;
+  // Needs to be <= 0xff to trigger the "small value case".
+  options.added_value = 0x10;
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+
+  EXPECT_EQ(regs.pc(), options.return_address);
+  EXPECT_EQ(regs.sp(), expected_stack_pointer_after_unwind_);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_add_with_large_value_and_ret_only) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.insert_add_instruction = true;
+  // Needs to be > 0xff to trigger the "large value case".
+  options.added_value = 0x1000;
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+
+  EXPECT_EQ(regs.pc(), options.return_address);
+  EXPECT_EQ(regs.sp(), expected_stack_pointer_after_unwind_);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_missing_ret_instruction) {
+  std::vector<uint8_t> machine_code{0x48, 0x83, 0xc4, 0x28};  // add sp, 0x28
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_add_instruction_not_rsp) {
+  std::vector<uint8_t> machine_code{0x48, 0x83, 0xc1, 0x07, 0xc3};  // add rcx, 0x7 and ret
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_add_instruction_not_immediate_added_to_rsp) {
+  std::vector<uint8_t> machine_code{0x48, 0x01, 0xc4, 0xc3};  // add rsp, rax and ret
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_instruction_destination_not_register) {
+  std::vector<uint8_t> machine_code{0x48, 0x01, 0x04, 0x24, 0xc3};  // add [rsp], rax and ret
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_instruction_immediate_negative) {
+  // The immediate value represents the stack allocation size, so must be non-negative.
+  std::vector<uint8_t> machine_code{0x48, 0x83, 0xc4, 0xff, 0xc3};  // add rsp, -1 and ret
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_lea_with_small_displacement_and_ret_only) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.insert_lea_instruction = true;
+  // Needs to be <= 0xff to trigger the "small displacement" case.
+  options.lea_displacement = 0x20;
+  options.frame_pointer_register_value = 0x1000;
+  options.frame_pointer_register = RBP;
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+  regs[X86_64Reg::X86_64_REG_RBP] = options.frame_pointer_register_value;
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+
+  EXPECT_EQ(regs.pc(), options.return_address);
+  EXPECT_EQ(regs.sp(), expected_stack_pointer_after_unwind_);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_lea_with_large_displacement_and_ret_only) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.insert_lea_instruction = true;
+  // Needs to be > 0xff to trigger the "large displacement" case.
+  options.lea_displacement = 0x100;
+  options.frame_pointer_register_value = 0x1000;
+  options.frame_pointer_register = RBP;
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+  regs[X86_64Reg::X86_64_REG_RBP] = options.frame_pointer_register_value;
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+
+  EXPECT_EQ(regs.pc(), options.return_address);
+  EXPECT_EQ(regs.sp(), expected_stack_pointer_after_unwind_);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_instruction_lea_destination_is_not_rsp) {
+  std::vector<uint8_t> machine_code{0x48, 0x8d, 0x75, 0x00, 0xc3};  // lea rsi,[rbp+0x0] and ret
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_instruction_lea_second_operand_is_not_base_plus_value) {
+  // lea rsp,[rbp+rax*2+0x2]
+  std::vector<uint8_t> machine_code{0x48, 0x8d, 0x64, 0x45, 0x02, 0xc3};
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_pop_instructions_and_ret_only) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.pop_operations = {PopOp{RSI, 0x100}, PopOp{R12, 0x200}, PopOp{RBX, 0x300},
+                            PopOp{R11, 0x400}};
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+  regs[X86_64Reg::X86_64_REG_RSI] = 0;
+  regs[X86_64Reg::X86_64_REG_R12] = 0;
+  regs[X86_64Reg::X86_64_REG_RBX] = 0;
+  regs[X86_64Reg::X86_64_REG_R11] = 0;
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+
+  EXPECT_EQ(regs.pc(), options.return_address);
+  EXPECT_EQ(regs.sp(), expected_stack_pointer_after_unwind_);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_RSI], 0x100);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_R12], 0x200);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_RBX], 0x300);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_R11], 0x400);
+}
+
+TEST_F(PeCoffEpilogTest, fails_with_invalid_memory_on_register_store_location) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.pop_operations = {PopOp{RSI, 0x100}};
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  // This is where RSI is stored, clear it so that we run into the error case.
+  process_mem_fake_->ClearMemory(0, sizeof(uint64_t));
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_MEMORY_INVALID);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_near_return) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_near_return_with_immediate) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.ret_instruction_bytes = {0xc2, 0x01, 0x02};  // ret 0x201
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_far_return) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.ret_instruction_bytes = {0xcb};  // retf
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_far_return_with_immediate) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.ret_instruction_bytes = {0xca, 0x01, 0x02};  // retf 0x201
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_jmp_ff) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  // jmp    QWORD PTR [rip+0x918ea]
+  options.jmp_instruction_bytes = {0xff, 0x25, 0xea, 0x18, 0x09, 0x00};
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_jmp_with_rex_prefix) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  // rex.W jmp QWORD PTR [rip+0x126ced]
+  options.jmp_instruction_bytes = {0x48, 0xff, 0x25, 0xed, 0x6c, 0x12, 0x00};
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_jmp_wrong_modrm_byte) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  // modrm.mod is 01 in this case, which should be rejected
+  // jmp    QWORD PTR [rbp-0x16]
+  options.jmp_instruction_bytes = {0xff, 0x65, 0xea};
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, detects_non_epilog_jmp_no_memory_reference) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.jmp_instruction_bytes = {0xeb, 0x01};  // jmp 0x3
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+
+  EXPECT_FALSE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_general_case_with_lea_as_first_instruction) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.insert_lea_instruction = true;
+  options.lea_displacement = 0x20;
+  options.frame_pointer_register_value = 0x1000;
+  options.frame_pointer_register = RBP;
+  options.pop_operations = {PopOp{RDI, 0x100}, PopOp{R12, 0x200}, PopOp{RBX, 0x300}};
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+  regs[X86_64Reg::X86_64_REG_RBP] = options.frame_pointer_register_value;
+  regs[X86_64Reg::X86_64_REG_RDI] = 0;
+  regs[X86_64Reg::X86_64_REG_R12] = 0;
+  regs[X86_64Reg::X86_64_REG_RBX] = 0;
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+
+  EXPECT_EQ(regs.pc(), options.return_address);
+  EXPECT_EQ(regs.sp(), expected_stack_pointer_after_unwind_);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_RDI], 0x100);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_R12], 0x200);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_RBX], 0x300);
+}
+
+TEST_F(PeCoffEpilogTest, succeeds_for_general_case_with_add_as_first_instruction) {
+  EpilogOptions options;
+  options.return_address = 0x1234;
+  options.insert_add_instruction = true;
+  options.added_value = 0x1000;
+  options.pop_operations = {PopOp{RDI, 0x100}, PopOp{R12, 0x200}, PopOp{RBX, 0x300}};
+  options.ret_instruction_bytes = {0xc3};  // ret
+
+  std::vector<uint8_t> machine_code = BuildEpilog(options);
+
+  RegsX86_64 regs;
+  regs.set_sp(0);
+  regs[X86_64Reg::X86_64_REG_RDI] = 0;
+  regs[X86_64Reg::X86_64_REG_R12] = 0;
+  regs[X86_64Reg::X86_64_REG_RBX] = 0;
+
+  EXPECT_TRUE(pe_coff_epilog_.DetectAndHandleEpilog(machine_code, process_mem_fake_.get(), &regs));
+  EXPECT_EQ(pe_coff_epilog_.GetLastError().code, ERROR_NONE);
+
+  EXPECT_EQ(regs.pc(), options.return_address);
+  EXPECT_EQ(regs.sp(), expected_stack_pointer_after_unwind_);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_RDI], 0x100);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_R12], 0x200);
+  EXPECT_EQ(regs[X86_64Reg::X86_64_REG_RBX], 0x300);
+}
+
+}  // namespace unwindstack


### PR DESCRIPTION
Unwinding PE/COFF files uses unwind codes in the prolog and in the
body of a function. They contain information on the size of the prolog.
However, to detect whether one is in the body of a function or in the
epilog, one has to disassemble the machine code, and identify if it's an
epilog. Once idenfied, one unwinds accordingly: If in the body of a
function, one unwinds using all unwind codes. If in the epilog, one
unwinds by virtually executing the effect of the machine instructions
on the registers.

In this change, epilog detection and handling is implemented, following
the documentation on:
https://docs.microsoft.com/en-us/cpp/build/prolog-and-epilog?view=msvc-170#epilog-code

Tests: Unit tests.
Bug: http://b/194768602