### PR TITLE
Make symbol paths mockable 2

### DIFF
--- a/src/ConfigWidgets/SymbolErrorDialog.cpp
+++ b/src/ConfigWidgets/SymbolErrorDialog.cpp
@@ -10,7 +10,7 @@
 
 #include "ConfigWidgets/SymbolsDialog.h"
 #include "OrbitBase/Logging.h"
-#include "SymbolPaths/QSettingsWrapper.h"
+#include "SymbolPaths/PersistentStorageManager.h"
 #include "ui_SymbolErrorDialog.h"
 
 namespace orbit_config_widgets {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -84,7 +84,7 @@
 #include "OrbitVersion/OrbitVersion.h"
 #include "SamplingReport.h"
 #include "Statistics/BinomialConfidenceInterval.h"
-#include "SymbolPaths/QSettingsWrapper.h"
+#include "SymbolPaths/PersistentStorageManager.h"
 #include "Symbols/SymbolHelper.h"
 #include "TimeGraph.h"
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -223,7 +223,9 @@ orbit_metrics_uploader::CaptureStartData CreateCaptureStartData(
 }
 
 std::vector<std::filesystem::path> GetAllSymbolPaths() {
-  std::vector<std::filesystem::path> all_paths = orbit_symbol_paths::LoadPaths();
+  std::unique_ptr<orbit_symbol_paths::PersistentStorageManager> symbol_paths_storage_manager =
+      orbit_symbol_paths::CreatePersistenStorageManager();
+  std::vector<std::filesystem::path> all_paths = symbol_paths_storage_manager->LoadPaths();
   std::vector<std::string> temp_paths = absl::GetFlag(FLAGS_additional_symbol_paths);
   all_paths.insert(all_paths.end(), temp_paths.begin(), temp_paths.end());
   return all_paths;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -236,14 +236,16 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
     }
   }
 
-  for (const auto& dir : orbit_symbol_paths::LoadPaths()) {
+  std::unique_ptr<orbit_symbol_paths::PersistentStorageManager> symbol_paths_storage_manager =
+      orbit_symbol_paths::CreatePersistenStorageManager();
+  for (const auto& dir : symbol_paths_storage_manager->LoadPaths()) {
     if (!already_seen_paths.contains(dir.string())) {
       already_seen_paths.insert(dir.string());
       dirs_to_save.push_back(dir);
     }
   }
 
-  orbit_symbol_paths::SavePaths(dirs_to_save);
+  symbol_paths_storage_manager->SavePaths(dirs_to_save);
 
   ErrorMessageOr<void> add_depr_note_result =
       orbit_symbols::AddDeprecationNoteToFile(orbit_paths::GetSymbolsFilePath());
@@ -1420,12 +1422,14 @@ void OrbitMainWindow::on_actionSourcePathMappings_triggered() {
 }
 
 void OrbitMainWindow::on_actionSymbolsDialog_triggered() {
+  std::unique_ptr<orbit_symbol_paths::PersistentStorageManager> symbol_paths_storage_manager =
+      orbit_symbol_paths::CreatePersistenStorageManager();
   orbit_config_widgets::SymbolsDialog dialog{this};
-  dialog.SetSymbolPaths(orbit_symbol_paths::LoadPaths());
+  dialog.SetSymbolPaths(symbol_paths_storage_manager->LoadPaths());
   const int result_code = dialog.exec();
 
   if (result_code == QDialog::Accepted) {
-    orbit_symbol_paths::SavePaths(dialog.GetSymbolPaths());
+    symbol_paths_storage_manager->SavePaths(dialog.GetSymbolPaths());
   }
 }
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -109,7 +109,7 @@
 #include "SourcePathsMapping/MappingManager.h"
 #include "SourcePathsMappingUI/AskUserForFile.h"
 #include "StatusListenerImpl.h"
-#include "SymbolPaths/QSettingsWrapper.h"
+#include "SymbolPaths/PersistentStorageManager.h"
 #include "Symbols/SymbolHelper.h"
 #include "SyntaxHighlighter/Cpp.h"
 #include "SyntaxHighlighter/X86Assembly.h"

--- a/src/SymbolPaths/CMakeLists.txt
+++ b/src/SymbolPaths/CMakeLists.txt
@@ -11,12 +11,12 @@ target_include_directories(SymbolPaths PUBLIC include/)
 target_link_libraries(SymbolPaths PUBLIC Qt5::Core)
 
 target_sources(
-  SymbolPaths PUBLIC include/SymbolPaths/QSettingsWrapper.h)
+  SymbolPaths PUBLIC include/SymbolPaths/PersistentStorageManager.h)
 
-target_sources(SymbolPaths PRIVATE QSettingsWrapper.cpp)
+target_sources(SymbolPaths PRIVATE PersistentStorageManager.cpp)
 
 add_executable(SymbolPathsTests)
-target_sources(SymbolPathsTests PRIVATE QSettingsWrapperTest.cpp)
+target_sources(SymbolPathsTests PRIVATE PersistentStorageManagerTest.cpp)
 
 target_link_libraries(SymbolPathsTests PRIVATE SymbolPaths
                                                GTest::QtCoreMain)

--- a/src/SymbolPaths/PersistentStorageManager.cpp
+++ b/src/SymbolPaths/PersistentStorageManager.cpp
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "SymbolPaths/QSettingsWrapper.h"
-
 #include <QSettings>
 #include <filesystem>
+
+#include "SymbolPaths/PersistentStorageManager.h"
 
 constexpr const char* kSymbolPathsSettingsKey = "symbol_directories";
 constexpr const char* kDirectoryPathKey = "directory_path";

--- a/src/SymbolPaths/PersistentStorageManager.cpp
+++ b/src/SymbolPaths/PersistentStorageManager.cpp
@@ -2,17 +2,24 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "SymbolPaths/PersistentStorageManager.h"
+
 #include <QSettings>
 #include <filesystem>
-
-#include "SymbolPaths/PersistentStorageManager.h"
+#include <memory>
 
 constexpr const char* kSymbolPathsSettingsKey = "symbol_directories";
 constexpr const char* kDirectoryPathKey = "directory_path";
 
 namespace orbit_symbol_paths {
 
-std::vector<std::filesystem::path> LoadPaths() {
+class PersistentStorageManagerImpl : public PersistentStorageManager {
+ public:
+  void SavePaths(const std::vector<std::filesystem::path>& paths) override;
+  [[nodiscard]] std::vector<std::filesystem::path> LoadPaths() override;
+};
+
+std::vector<std::filesystem::path> PersistentStorageManagerImpl::LoadPaths() {
   QSettings settings{};
   const int size = settings.beginReadArray(kSymbolPathsSettingsKey);
   std::vector<std::filesystem::path> paths{};
@@ -25,7 +32,7 @@ std::vector<std::filesystem::path> LoadPaths() {
   return paths;
 }
 
-void SavePaths(const std::vector<std::filesystem::path>& paths) {
+void PersistentStorageManagerImpl::SavePaths(const std::vector<std::filesystem::path>& paths) {
   QSettings settings{};
   settings.beginWriteArray(kSymbolPathsSettingsKey, static_cast<int>(paths.size()));
   for (size_t i = 0; i < paths.size(); ++i) {
@@ -33,6 +40,10 @@ void SavePaths(const std::vector<std::filesystem::path>& paths) {
     settings.setValue(kDirectoryPathKey, QString::fromStdString(paths[i].string()));
   }
   settings.endArray();
+}
+
+std::unique_ptr<PersistentStorageManager> CreatePersistenStorageManager() {
+  return std::make_unique<PersistentStorageManagerImpl>();
 }
 
 }  // namespace orbit_symbol_paths

--- a/src/SymbolPaths/PersistentStorageManagerTest.cpp
+++ b/src/SymbolPaths/PersistentStorageManagerTest.cpp
@@ -7,6 +7,7 @@
 #include <QCoreApplication>
 #include <QSettings>
 #include <filesystem>
+#include <memory>
 
 #include "SymbolPaths/PersistentStorageManager.h"
 
@@ -27,7 +28,9 @@ TEST(SymbolPathsManager, LoadAndSave) {
     settings.clear();
   }
 
-  EXPECT_EQ(LoadPaths(), std::vector<std::filesystem::path>{});
+  std::unique_ptr<PersistentStorageManager> manager = CreatePersistenStorageManager();
+
+  EXPECT_EQ(manager->LoadPaths(), std::vector<std::filesystem::path>{});
 
   std::vector<std::filesystem::path> paths{
       path0,
@@ -35,8 +38,8 @@ TEST(SymbolPathsManager, LoadAndSave) {
       path2,
   };
 
-  SavePaths(paths);
-  EXPECT_EQ(LoadPaths(), paths);
+  manager->SavePaths(paths);
+  EXPECT_EQ(manager->LoadPaths(), paths);
 }
 
 }  // namespace orbit_symbol_paths

--- a/src/SymbolPaths/PersistentStorageManagerTest.cpp
+++ b/src/SymbolPaths/PersistentStorageManagerTest.cpp
@@ -8,7 +8,7 @@
 #include <QSettings>
 #include <filesystem>
 
-#include "SymbolPaths/QSettingsWrapper.h"
+#include "SymbolPaths/PersistentStorageManager.h"
 
 const std::filesystem::path path0{"/path/to/symbols/path"};
 const std::filesystem::path path1{"/home/src/project/build/"};

--- a/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
+++ b/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef SYMBOL_PATHS_QSETTINGS_WRAPPER_H_
-#define SYMBOL_PATHS_QSETTINGS_WRAPPER_H_
+#ifndef SYMBOL_PATHS_PERSISTENT_STORAGE_MANAGER_H
+#define SYMBOL_PATHS_PERSISTENT_STORAGE_MANAGER_H
 
 #include <filesystem>
 #include <vector>
@@ -20,4 +20,4 @@ void SavePaths(const std::vector<std::filesystem::path>& paths);
 
 }  // namespace orbit_symbol_paths
 
-#endif  // SYMBOL_PATHS_QSETTINGS_WRAPPER_H_
+#endif  // SYMBOL_PATHS_PERSISTENT_STORAGE_MANAGER_H

--- a/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
+++ b/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
@@ -6,17 +6,26 @@
 #define SYMBOL_PATHS_PERSISTENT_STORAGE_MANAGER_H
 
 #include <filesystem>
+#include <memory>
 #include <vector>
 
 namespace orbit_symbol_paths {
 
-// This is a simple wrapper around QSettings, which makes this thread safe, see
-// https://doc.qt.io/qt-5/qsettings.html
-void SavePaths(const std::vector<std::filesystem::path>& paths);
+class PersistentStorageManager {
+ public:
+  PersistentStorageManager() = default;
+  virtual ~PersistentStorageManager() = default;
 
-// This is a simple wrapper around QSettings, which makes this thread safe, see
-// https://doc.qt.io/qt-5/qsettings.html
-[[nodiscard]] std::vector<std::filesystem::path> LoadPaths();
+  // This is a simple wrapper around QSettings, which makes this thread safe, see
+  // https://doc.qt.io/qt-5/qsettings.html
+  void virtual SavePaths(const std::vector<std::filesystem::path>& paths) = 0;
+
+  // This is a simple wrapper around QSettings, which makes this thread safe, see
+  // https://doc.qt.io/qt-5/qsettings.html
+  [[nodiscard]] std::vector<std::filesystem::path> virtual LoadPaths() = 0;
+};
+
+std::unique_ptr<PersistentStorageManager> CreatePersistenStorageManager();
 
 }  // namespace orbit_symbol_paths
 

--- a/src/SymbolsDialogDemo/main.cpp
+++ b/src/SymbolsDialogDemo/main.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "ConfigWidgets/SymbolsDialog.h"
-#include "SymbolPaths/QSettingsWrapper.h"
+#include "SymbolPaths/PersistentStorageManager.h"
 
 int main(int argc, char* argv[]) {
   QApplication app{argc, argv};

--- a/src/SymbolsDialogDemo/main.cpp
+++ b/src/SymbolsDialogDemo/main.cpp
@@ -14,12 +14,14 @@ int main(int argc, char* argv[]) {
   QApplication::setApplicationName("SymbolsDialogDemo");
   QApplication::setOrganizationName("The Orbit Authors");
 
+  std::unique_ptr<orbit_symbol_paths::PersistentStorageManager> symbol_paths_storage_manager =
+      orbit_symbol_paths::CreatePersistenStorageManager();
   orbit_config_widgets::SymbolsDialog dialog{};
-  dialog.SetSymbolPaths(orbit_symbol_paths::LoadPaths());
+  dialog.SetSymbolPaths(symbol_paths_storage_manager->LoadPaths());
   const int result_code = dialog.exec();
 
   if (result_code == QDialog::Accepted) {
-    orbit_symbol_paths::SavePaths(dialog.GetSymbolPaths());
+    symbol_paths_storage_manager->SavePaths(dialog.GetSymbolPaths());
   }
 
   return result_code;


### PR DESCRIPTION
This moves the `orbit_symbol_path` functions `LoadPaths` and `SavePaths` (file: QSettingsWrapper.h/cpp) into a mockable class `orbit_symbol_path::PersistentStorageManager`. This will be used to by SymbolsDialog