### PR TITLE
Add missing include to HistogramTest

### DIFF
--- a/src/Statistics/HistogramTest.cpp
+++ b/src/Statistics/HistogramTest.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <numeric>


### PR DESCRIPTION
I am not sure why the windows CI does not complain, my local build fails because this include is missing. `std::min_element` is part of algorithm. https://en.cppreference.com/w/cpp/algorithm/min_element