### PR TITLE
Add fuzzing for PE/COFF unwind data parsers in libunwindstack

### DIFF
--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -382,5 +382,13 @@ set_target_properties(libunwindstack_local PROPERTIES
 
 # Fuzz testing for parsers
 add_fuzzer(PeCoffInterfaceFuzzer tests/fuzz/PeCoffInterfaceFuzzer.cpp)
-target_include_directories(PeCoffInterfaceFuzzer PRIVATE include/)
+target_include_directories(PeCoffInterfaceFuzzer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} include/)
 target_link_libraries(PeCoffInterfaceFuzzer PRIVATE libunwindstack)
+
+add_fuzzer(PeCoffUnwindInfosFuzzer tests/fuzz/PeCoffUnwindInfosFuzzer.cpp)
+target_include_directories(PeCoffUnwindInfosFuzzer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} include/)
+target_link_libraries(PeCoffUnwindInfosFuzzer PRIVATE libunwindstack)
+
+add_fuzzer(PeCoffRuntimeFunctionsFuzzer tests/fuzz/PeCoffRuntimeFunctionsFuzzer.cpp)
+target_include_directories(PeCoffRuntimeFunctionsFuzzer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} include/)
+target_link_libraries(PeCoffRuntimeFunctionsFuzzer PRIVATE libunwindstack)

--- a/third_party/libunwindstack/tests/PeCoffEpilogTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffEpilogTest.cpp
@@ -16,6 +16,7 @@
 
 #include "PeCoffEpilog.h"
 
+#include <array>
 #include <cstring>
 #include <memory>
 #include <vector>

--- a/third_party/libunwindstack/tests/fuzz/PeCoffRuntimeFunctionsFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffRuntimeFunctionsFuzzer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,19 @@
 
 #include <unwindstack/Memory.h>
 #include <unwindstack/PeCoffInterface.h>
+#include "PeCoffRuntimeFunctions.h"
 
 namespace {
-template <typename AddressType>
-void FuzzPeCoffInterface(const uint8_t* data, size_t size) {
+void FuzzPeCoffRuntimeFunctions(const uint8_t* data, size_t size) {
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(data, 0, size);
-  unwindstack::PeCoffInterfaceImpl<AddressType> pe_coff_interface(memory.get());
-  int64_t load_bias;
-  pe_coff_interface.Init(&load_bias);
+  unwindstack::PeCoffMemory pe_coff_memory(memory.get());
+  unwindstack::PeCoffRuntimeFunctions pe_coff_runtime_functions(&pe_coff_memory);
+  pe_coff_runtime_functions.Init(0, size);
 }
 }  // namespace
 
-// The most basic fuzzer for PE/COFF parsing, not PE/COFF structure aware.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  FuzzPeCoffInterface<uint32_t>(data, size);
-  FuzzPeCoffInterface<uint64_t>(data, size);
+  FuzzPeCoffRuntimeFunctions(data, size);
   return 0;
 }

--- a/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,24 @@
 
 #include <unwindstack/Memory.h>
 #include <unwindstack/PeCoffInterface.h>
+#include "PeCoffUnwindInfos.h"
 
 namespace {
-template <typename AddressType>
-void FuzzPeCoffInterface(const uint8_t* data, size_t size) {
+void FuzzPeCoffUnwindInfos(const uint8_t* data, size_t size) {
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(data, 0, size);
-  unwindstack::PeCoffInterfaceImpl<AddressType> pe_coff_interface(memory.get());
-  int64_t load_bias;
-  pe_coff_interface.Init(&load_bias);
+  unwindstack::PeCoffMemory pe_coff_memory(memory.get());
+  unwindstack::PeCoffUnwindInfos pe_coff_unwind_infos(&pe_coff_memory);
+  unwindstack::UnwindInfo info;
+  // Try all possible offsets to increase coverage. This will also test the parser
+  // running over the end of the memory.
+  for (size_t offset = 0; offset < size; ++offset) {
+    pe_coff_unwind_infos.GetUnwindInfo(offset, &info);
+  }
 }
 }  // namespace
 
-// The most basic fuzzer for PE/COFF parsing, not PE/COFF structure aware.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  FuzzPeCoffInterface<uint32_t>(data, size);
-  FuzzPeCoffInterface<uint64_t>(data, size);
+  FuzzPeCoffUnwindInfos(data, size);
   return 0;
 }


### PR DESCRIPTION
We already have a fuzzer for the main PE/COFF parsing part, which is
done in PeCoffInterface, but there is more data that we need to parse
from PE/COFF files, namely the unwind infos (UNWIND_INFO struct) and
runtime functions (RUNTIME_FUNCTIONS struct). This change adds fuzzers
for both parsers. Fuzzers are basic without any structure awareness.

Tested: Built and ran fuzzers with local oss-fuzz clone.
Bug: http://b/194768602