### PR TITLE
Fix missing metrics uploader

### DIFF
--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -167,6 +167,7 @@ void ConnectToStadiaWidget::Start() {
 
   retrieve_instances_ = RetrieveInstances::Create(ggp_client_.get(), main_thread_executor_.get());
   ui_->retrieveInstancesWidget->SetRetrieveInstances(retrieve_instances_.get());
+  ui_->retrieveInstancesWidget->SetMetricsUploader(metrics_uploader_);
   ui_->retrieveInstancesWidget->Start();
 }
 


### PR DESCRIPTION
This sets the metrics uploader in RetrieveInstancesWidget.

It was forgotten before, because the design here is not great and it can be easily forgotten. I do not have time to change this in a better way, so I am just adding the call at the right location