### PR TITLE
Add argument list to symbol's name for PdbFileLlvm

### DIFF
--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -64,6 +64,7 @@ class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
                             object_file_info_.executable_segment_offset);
     symbol_info.set_size(proc.CodeSize);
 
+    ORBIT_CHECK(module_symbols_ != nullptr);
     *(module_symbols_->add_symbol_infos()) = std::move(symbol_info);
 
     return llvm::Error::success();
@@ -71,10 +72,11 @@ class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
 
  private:
   [[nodiscard]] llvm::StringRef RetrieveArgumentList(const llvm::codeview::ProcSym& proc) const {
+    ORBIT_CHECK(type_info_stream_ != nullptr);
     llvm::codeview::LazyRandomTypeCollection& type_collection = type_info_stream_->typeCollection();
 
     // We expect function types being either LF_PROCEDURE or LF_MFUNCTION, which are non-simple
-    // types. However, there are cases where the function type is "<no type>. In those cases, we
+    // types. However, there are cases where the function type is "<no type>". In those cases, we
     // can't retrieve the argument list.
     if (proc.FunctionType.isSimple()) {
       llvm::StringRef function_type = type_collection.getTypeName(proc.FunctionType);

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -5,6 +5,11 @@
 #include "PdbFileLlvm.h"
 
 #include <absl/memory/memory.h>
+#include <absl/strings/str_cat.h>
+#include <llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h>
+#include <llvm/DebugInfo/CodeView/TypeDeserializer.h>
+#include <llvm/DebugInfo/CodeView/TypeRecord.h>
+#include <llvm/DebugInfo/PDB/Native/TpiStream.h>
 
 #include <memory>
 
@@ -26,8 +31,14 @@ namespace {
 // all symbol info required for functions.
 class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
  public:
-  SymbolInfoVisitor(ModuleSymbols* module_symbols, const ObjectFileInfo& object_file_info)
-      : module_symbols_(module_symbols), object_file_info_(object_file_info) {}
+  SymbolInfoVisitor(ModuleSymbols* module_symbols, const ObjectFileInfo& object_file_info,
+                    llvm::pdb::TpiStream* type_info_stream)
+      : module_symbols_(module_symbols),
+        object_file_info_(object_file_info),
+        type_info_stream_(type_info_stream) {
+    ORBIT_CHECK(module_symbols != nullptr);
+    ORBIT_CHECK(type_info_stream != nullptr);
+  }
 
   // This is the only record type (ProcSym) we are interested in, so we only override this
   // method. Other records will simply return llvm::Error::success without any work done.
@@ -36,20 +47,72 @@ class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
     SymbolInfo symbol_info;
     symbol_info.set_name(proc.Name.str());
     symbol_info.set_demangled_name(llvm::demangle(proc.Name.str()));
+
+    // The ProcSym's name does not contain an argument list. However, this information is required
+    // when dealing with overloads and it is available in the type info stream. See:
+    // https://llvm.org/docs/PDB/TpiStream.html
+    llvm::StringRef argument_list = RetrieveArgumentList(proc);
+    if (!argument_list.empty()) {
+      symbol_info.set_demangled_name(
+          absl::StrCat(symbol_info.demangled_name(), argument_list.data()));
+    }
+
     // The address in PDB files is a relative virtual address (RVA), to make the address compatible
     // with how we do the computation, we need to add both the load bias (ImageBase for COFF) and
     // the offset of the executable section.
     symbol_info.set_address(proc.CodeOffset + object_file_info_.load_bias +
                             object_file_info_.executable_segment_offset);
     symbol_info.set_size(proc.CodeSize);
+
     *(module_symbols_->add_symbol_infos()) = std::move(symbol_info);
 
     return llvm::Error::success();
   }
 
  private:
+  [[nodiscard]] llvm::StringRef RetrieveArgumentList(const llvm::codeview::ProcSym& proc) const {
+    llvm::codeview::LazyRandomTypeCollection& type_collection = type_info_stream_->typeCollection();
+
+    // We expect function types being either LF_PROCEDURE or LF_MFUNCTION, which are non-simple
+    // types. However, there are cases where the function type is "<no type>. In those cases, we
+    // can't retrieve the argument list.
+    if (proc.FunctionType.isSimple()) {
+      llvm::StringRef function_type = type_collection.getTypeName(proc.FunctionType);
+      ORBIT_ERROR(
+          "Unable to retrieve parameter list for function \"%s\"; The function type is \"%s\"",
+          proc.Name, function_type);
+      return "";
+    }
+
+    llvm::codeview::CVType function_type = type_info_stream_->getType(proc.FunctionType);
+    switch (function_type.kind()) {
+      case llvm::codeview::LF_PROCEDURE: {
+        llvm::codeview::ProcedureRecord procedure_record;
+        llvm::Error error =
+            llvm::codeview::TypeDeserializer::deserializeAs<llvm::codeview::ProcedureRecord>(
+                function_type, procedure_record);
+        ORBIT_CHECK(!error);
+
+        llvm::StringRef parameter_list = type_collection.getTypeName(procedure_record.ArgumentList);
+        return parameter_list;
+      }
+      case llvm::codeview::LF_MFUNCTION: {
+        llvm::codeview::MemberFunctionRecord member_function_record;
+        llvm::Error error =
+            llvm::codeview::TypeDeserializer::deserializeAs<llvm::codeview::MemberFunctionRecord>(
+                function_type, member_function_record);
+        ORBIT_CHECK(!error);
+
+        return type_collection.getTypeName(member_function_record.ArgumentList);
+      }
+      default:
+        ORBIT_UNREACHABLE();
+    }
+  }
+
   ModuleSymbols* module_symbols_;
   ObjectFileInfo object_file_info_;
+  llvm::pdb::TpiStream* type_info_stream_;
 };
 
 }  // namespace
@@ -65,7 +128,8 @@ PdbFileLlvm::PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& 
   module_symbols.set_load_bias(object_file_info_.load_bias);
   module_symbols.set_symbols_file_path(file_path_.string());
 
-  llvm::pdb::NativeSession* native_session = static_cast<llvm::pdb::NativeSession*>(session_.get());
+  auto* native_session = dynamic_cast<llvm::pdb::NativeSession*>(session_.get());
+  ORBIT_CHECK(native_session != nullptr);
   llvm::pdb::PDBFile& pdb_file = native_session->getPDBFile();
 
   if (!pdb_file.hasPDBDbiStream()) {
@@ -75,6 +139,13 @@ PdbFileLlvm::PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& 
   llvm::Expected<llvm::pdb::DbiStream&> debug_info_stream = pdb_file.getPDBDbiStream();
   // Given that we check hasPDBDbiStream above, we must get a DbiStream here.
   ORBIT_CHECK(debug_info_stream);
+
+  if (!pdb_file.hasPDBTpiStream()) {
+    return ErrorMessage("PDB file does not have a TPI stream.");
+  }
+  llvm::Expected<llvm::pdb::TpiStream&> type_info_stream = pdb_file.getPDBTpiStream();
+  // Given that we check hasPDBTpiStream above, we must get a TpiStream here.
+  ORBIT_CHECK(type_info_stream);
 
   const llvm::pdb::DbiModuleList& modules = debug_info_stream->modules();
 
@@ -102,7 +173,7 @@ PdbFileLlvm::PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& 
     llvm::codeview::SymbolDeserializer deserializer(nullptr,
                                                     llvm::codeview::CodeViewContainer::Pdb);
     pipeline.addCallbackToPipeline(deserializer);
-    SymbolInfoVisitor symbol_visitor(&module_symbols, object_file_info_);
+    SymbolInfoVisitor symbol_visitor(&module_symbols, object_file_info_, &type_info_stream.get());
     pipeline.addCallbackToPipeline(symbol_visitor);
     llvm::codeview::CVSymbolVisitor visitor(pipeline);
 

--- a/src/ObjectUtils/PdbFileLlvmTest.cpp
+++ b/src/ObjectUtils/PdbFileLlvmTest.cpp
@@ -8,3 +8,33 @@
 using orbit_object_utils::PdbFileLlvm;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(PdbFileLlvmTest, PdbFileTest, ::testing::Types<PdbFileLlvm>);
+
+// TODO(b/219413222): Once the parameter list gets also retrieved on the DIA implementation,
+//  this test should be unified with the general PdbFileTest
+TEST(PdbFileLlvmTest, LoadDebugSymbols) {
+  std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
+
+  ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result =
+      PdbFileLlvm::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
+  ASSERT_THAT(pdb_file_result, HasNoError());
+  std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
+  auto symbols_result = pdb_file->LoadDebugSymbols();
+  ASSERT_THAT(symbols_result, HasNoError());
+
+  auto symbols = std::move(symbols_result.value());
+
+  absl::flat_hash_map<uint64_t, const SymbolInfo*> symbol_infos_by_address;
+  for (const SymbolInfo& symbol_info : symbols.symbol_infos()) {
+    symbol_infos_by_address.emplace(symbol_info.address(), &symbol_info);
+  }
+
+  {
+    const SymbolInfo& symbol = *symbol_infos_by_address[0x18000ef90];
+    EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorldInternal()");
+  }
+
+  {
+    const SymbolInfo& symbol = *symbol_infos_by_address[0x18000efd0];
+    EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorld()");
+  }
+}

--- a/src/ObjectUtils/PdbFileTest.h
+++ b/src/ObjectUtils/PdbFileTest.h
@@ -55,7 +55,7 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo& symbol = *symbol_infos_by_address[0x18000ef90];
     EXPECT_EQ(symbol.name(), "PrintHelloWorldInternal");
-    EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorldInternal");
+    EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorldInternal()");
     EXPECT_EQ(symbol.address(), 0x18000ef90);
     EXPECT_EQ(symbol.size(), 0x2b);
   }
@@ -63,7 +63,7 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo& symbol = *symbol_infos_by_address[0x18000efd0];
     EXPECT_EQ(symbol.name(), "PrintHelloWorld");
-    EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorld");
+    EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorld()");
     EXPECT_EQ(symbol.address(), 0x18000efd0);
     EXPECT_EQ(symbol.size(), 0xe);
   }

--- a/src/ObjectUtils/PdbFileTest.h
+++ b/src/ObjectUtils/PdbFileTest.h
@@ -55,7 +55,9 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo& symbol = *symbol_infos_by_address[0x18000ef90];
     EXPECT_EQ(symbol.name(), "PrintHelloWorldInternal");
-    EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorldInternal()");
+    // TODO(b/219413222): We actually also expect the parameter list (empty in this case), but the
+    //  DIA SDK implementation does not support this yet.
+    EXPECT_TRUE(absl::StrContains(symbol.demangled_name(), "PrintHelloWorldInternal"));
     EXPECT_EQ(symbol.address(), 0x18000ef90);
     EXPECT_EQ(symbol.size(), 0x2b);
   }
@@ -63,7 +65,9 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo& symbol = *symbol_infos_by_address[0x18000efd0];
     EXPECT_EQ(symbol.name(), "PrintHelloWorld");
-    EXPECT_EQ(symbol.demangled_name(), "PrintHelloWorld()");
+    // TODO(b/219413222): We actually also expect the parameter list (empty in this case), but the
+    //  DIA SDK implementation does not support this yet.
+    EXPECT_TRUE(absl::StrContains(symbol.demangled_name(), "PrintHelloWorld()"));
     EXPECT_EQ(symbol.address(), 0x18000efd0);
     EXPECT_EQ(symbol.size(), 0xe);
   }

--- a/src/ObjectUtils/PdbFileTest.h
+++ b/src/ObjectUtils/PdbFileTest.h
@@ -67,7 +67,7 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
     EXPECT_EQ(symbol.name(), "PrintHelloWorld");
     // TODO(b/219413222): We actually also expect the parameter list (empty in this case), but the
     //  DIA SDK implementation does not support this yet.
-    EXPECT_TRUE(absl::StrContains(symbol.demangled_name(), "PrintHelloWorld()"));
+    EXPECT_TRUE(absl::StrContains(symbol.demangled_name(), "PrintHelloWorld"));
     EXPECT_EQ(symbol.address(), 0x18000efd0);
     EXPECT_EQ(symbol.size(), 0xe);
   }


### PR DESCRIPTION
Pdb's `ProcSym` debug record for function information does not
contain the argument types in their names. As a result, we can't
differentiate overloaded functions in Orbit.
However, the information is transitively available in the type
info section of the Pdb file.

This change attempts to retrieve the argument list from the
type info section and appends this to the function's name.

Note, this change only fixes the issue for the LLVM-based PDB
backend. A follow up change will target the DIA SDK implementation.
Also, there is a similar issue in the Coff file case, which will
be also addressed later.

Test: Load symbols for triangle.exe
Bug: http://b/219413222