### PR TITLE
Integrate symbol error

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1678,10 +1678,13 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
 
 orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
     absl::Span<const ModuleData* const> modules) {
-  std::vector<orbit_base::Future<void>> futures;
-  futures.reserve(modules.size());
+  // Use a set, to filter out duplicates
+  absl::flat_hash_set<const ModuleData*> modules_set(modules.begin(), modules.end());
 
-  for (const auto& module : modules) {
+  std::vector<orbit_base::Future<void>> futures;
+  futures.reserve(modules_set.size());
+
+  for (const auto& module : modules_set) {
     futures.emplace_back(RetrieveModuleAndLoadSymbolsAndHandleError(module));
   }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -265,13 +265,6 @@ class OrbitApp final : public DataViewFactory,
   void SetErrorMessageCallback(ErrorMessageCallback callback) {
     error_message_callback_ = std::move(callback);
   }
-  // returns true when the error was handled/resolved. This means Orbit needs to retry loading
-  // symbols for this module
-  using SymbolLoadingErrorCallback =
-      std::function<bool(const ErrorMessage&, const orbit_client_data::ModuleData*)>;
-  void SetSymbolLoadingErrorCallback(SymbolLoadingErrorCallback callback) {
-    symbol_error_loading_callback_ = std::move(callback);
-  }
   using WarningMessageCallback = std::function<void(const std::string&, const std::string&)>;
   void SetWarningMessageCallback(WarningMessageCallback callback) {
     warning_message_callback_ = std::move(callback);
@@ -576,7 +569,6 @@ class OrbitApp final : public DataViewFactory,
   CaptureClearedCallback capture_cleared_callback_;
   SelectLiveTabCallback select_live_tab_callback_;
   ErrorMessageCallback error_message_callback_;
-  SymbolLoadingErrorCallback symbol_error_loading_callback_;
   WarningMessageCallback warning_message_callback_;
   InfoMessageCallback info_message_callback_;
   RefreshCallback refresh_callback_;

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string_view>
 
+#include "ClientData/ModuleData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "CodeReport/CodeReport.h"
 #include "CodeReport/DisassemblyReport.h"
@@ -39,6 +40,10 @@ class MainWindowInterface {
   enum class CaptureLogSeverity { kInfo, kWarning, kSevereWarning, kError };
   virtual void AppendToCaptureLog(CaptureLogSeverity severity, absl::Duration capture_time,
                                   std::string_view message) = 0;
+
+  enum class SymbolErrorHandlingResult { kReloadRequired, kSymbolLoadingCancelled };
+  virtual SymbolErrorHandlingResult HandleSymbolError(
+      const ErrorMessage& error, const orbit_client_data::ModuleData* module) = 0;
 
   virtual ~MainWindowInterface() = default;
 };

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -32,6 +32,7 @@
 
 #include "App.h"
 #include "CallTreeView.h"
+#include "ClientData/ModuleData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "ClientServices/ProcessManager.h"
 #include "DataViews/DataView.h"
@@ -39,6 +40,7 @@
 #include "FilterPanelWidgetAction.h"
 #include "GrpcProtos/process.pb.h"
 #include "MainThreadExecutor.h"
+#include "MainWindowInterface.h"
 #include "MetricsUploader/MetricsUploader.h"
 #include "OrbitBase/CrashHandler.h"
 #include "SessionSetup/ServiceDeployManager.h"
@@ -108,6 +110,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   void AppendToCaptureLog(CaptureLogSeverity severity, absl::Duration capture_time,
                           std::string_view message) override;
+  orbit_gl::MainWindowInterface::SymbolErrorHandlingResult HandleSymbolError(
+      const ErrorMessage& error, const orbit_client_data::ModuleData* module) override;
   void ShowWarningWithDontShowAgainCheckboxIfNeeded(
       std::string_view title, std::string_view text,
       std::string_view dont_show_again_setting_key) override;
@@ -185,6 +189,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void SetTarget(const orbit_session_setup::FileTarget& target);
 
   void OnProcessListUpdated(const std::vector<orbit_grpc_protos::ProcessInfo>& processes);
+
+  void ExecuteSymbolsDialog(std::optional<const orbit_client_data::ModuleData*> module);
 
   static const QString kEnableCallstackSamplingSettingKey;
   static const QString kCallstackSamplingPeriodMsSettingKey;


### PR DESCRIPTION
This changes the symbol loading error handling by integrating the
SymbolErrorDialog. In the SymbolErrorDialog the user can either cancel
the symbol loading, click try again, or go to the SymbolsDialog (Symbol
Locations). In the later to cases, Orbit tries to load the symbols
again.

http://b/153637024

Avoid duplicate symbol loading attempts

http://b/220095606