### PR TITLE
Add no build id check to SymbolErrorDialog

### DIFF
--- a/src/ConfigWidgets/SymbolErrorDialog.cpp
+++ b/src/ConfigWidgets/SymbolErrorDialog.cpp
@@ -19,9 +19,18 @@ SymbolErrorDialog::SymbolErrorDialog(const orbit_client_data::ModuleData* module
     : QDialog(parent), ui_(std::make_unique<Ui::SymbolErrorDialog>()), module_(module) {
   ORBIT_CHECK(module_ != nullptr);
   ui_->setupUi(this);
-  ui_->moduleNameLabel->setText(QString::fromStdString(module_->file_path()));
+  QString module_file_path = QString::fromStdString(module_->file_path());
+  ui_->moduleNameLabel->setText(module_file_path);
   ui_->errorPlainTextEdit->setPlainText(QString::fromStdString(detailed_error));
-  ui_->addSymbolLocationButton->setFocus();
+  if (!module_->build_id().empty()) {
+    ui_->addSymbolLocationButton->setFocus();
+  } else {
+    ui_->addSymbolLocationButton->setEnabled(false);
+    ui_->addSymbolLocationButton->setToolTip(
+        QString("Orbit matches modules and symbol files based on build-id. Module %1, does not "
+                "contain a build id.")
+            .arg(module_file_path));
+  }
 }
 
 SymbolErrorDialog::~SymbolErrorDialog() = default;

--- a/src/ConfigWidgets/SymbolErrorDialog.cpp
+++ b/src/ConfigWidgets/SymbolErrorDialog.cpp
@@ -24,13 +24,13 @@ SymbolErrorDialog::SymbolErrorDialog(const orbit_client_data::ModuleData* module
   ui_->errorPlainTextEdit->setPlainText(QString::fromStdString(detailed_error));
   if (!module_->build_id().empty()) {
     ui_->addSymbolLocationButton->setFocus();
-  } else {
-    ui_->addSymbolLocationButton->setEnabled(false);
-    ui_->addSymbolLocationButton->setToolTip(
-        QString("Orbit matches modules and symbol files based on build-id. Module %1, does not "
-                "contain a build id.")
-            .arg(module_file_path));
+    return;
   }
+  ui_->addSymbolLocationButton->setEnabled(false);
+  ui_->addSymbolLocationButton->setToolTip(
+      QString("Orbit matches modules and symbol files based on build-id. Module %1 does not "
+              "contain a build id.")
+          .arg(module_file_path));
 }
 
 SymbolErrorDialog::~SymbolErrorDialog() = default;

--- a/src/ConfigWidgets/SymbolErrorDialog.ui
+++ b/src/ConfigWidgets/SymbolErrorDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Symbol Loading Error</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/src/ConfigWidgets/SymbolErrorDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolErrorDialogTest.cpp
@@ -19,6 +19,7 @@ namespace orbit_config_widgets {
 orbit_grpc_protos::ModuleInfo CreateModuleInfo(std::string module_path) {
   orbit_grpc_protos::ModuleInfo module_info;
   module_info.set_file_path(std::move(module_path));
+  module_info.set_build_id("some build id");
   return module_info;
 }
 class SymbolErrorDialogTest : public testing::Test {
@@ -71,6 +72,7 @@ TEST_F(SymbolErrorDialogTest, OnShowErrorButtonClicked) {
 TEST_F(SymbolErrorDialogTest, OnAddSymbolLocationButtonClicked) {
   auto* on_add_symbol_location_button = dialog_.findChild<QPushButton*>("addSymbolLocationButton");
   ASSERT_NE(on_add_symbol_location_button, nullptr);
+  ASSERT_TRUE(on_add_symbol_location_button->isEnabled());
   QMetaObject::invokeMethod(
       &dialog_, [&]() { QTest::mouseClick(on_add_symbol_location_button, Qt::LeftButton); },
       Qt::QueuedConnection);
@@ -106,6 +108,14 @@ TEST_F(SymbolErrorDialogTest, OnRejected) {
 
   SymbolErrorDialog::Result result = dialog_.Exec();
   EXPECT_EQ(result, SymbolErrorDialog::Result::kCancel);
+}
+
+TEST(SymbolErrorDialog, EmptyBuildId) {
+  orbit_client_data::ModuleData module{{}};
+  SymbolErrorDialog dialog{&module, "error"};
+  auto* on_add_symbol_location_button = dialog.findChild<QPushButton*>("addSymbolLocationButton");
+  ASSERT_NE(on_add_symbol_location_button, nullptr);
+  EXPECT_FALSE(on_add_symbol_location_button->isEnabled());
 }
 
 }  // namespace orbit_config_widgets


### PR DESCRIPTION
This adds a new check to SymbolErrorDialog, whether the module has a
build-id. If it doesn't, the "Add Symbol Location" Button is disabled,
because no matching with local symbol files can currently be done
without a build-id. Also changes the name of the dialog to "Symbol
Loading Error".

Test: Unit tests

(In the future there will be the option to add unsafe symbol files. Then this check will be removed / moved to the SymbolsDialog)