### PR TITLE
Adds more Info button to Symbol Locations

### DIFF
--- a/src/ConfigWidgets/SymbolsDialog.cpp
+++ b/src/ConfigWidgets/SymbolsDialog.cpp
@@ -21,7 +21,6 @@
 #include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
-#include "Symbols/SymbolUtils.h"
 #include "ui_SymbolsDialog.h"
 
 constexpr const char* kFileDialogSavedDirectoryKey = "symbols_file_dialog_saved_directory";

--- a/src/ConfigWidgets/SymbolsDialog.cpp
+++ b/src/ConfigWidgets/SymbolsDialog.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/strings/str_format.h>
 
+#include <QDesktopServices>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QPushButton>
@@ -20,6 +21,7 @@
 #include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "Symbols/SymbolUtils.h"
 #include "ui_SymbolsDialog.h"
 
 constexpr const char* kFileDialogSavedDirectoryKey = "symbols_file_dialog_saved_directory";
@@ -190,6 +192,16 @@ ErrorMessageOr<void> SymbolsDialog::TryAddSymbolFile(const std::filesystem::path
 
 void SymbolsDialog::OnListItemSelectionChanged() {
   ui_->removeButton->setEnabled(!ui_->listWidget->selectedItems().isEmpty());
+}
+
+void SymbolsDialog::OnMoreInfoButtonClicked() {
+  QString url_as_string{
+      "https://developers.google.com/stadia/docs/develop/optimize/"
+      "profile-cpu-with-orbit#load_symbols"};
+  if (!QDesktopServices::openUrl(QUrl(url_as_string, QUrl::StrictMode))) {
+    QMessageBox::critical(this, "Error opening URL",
+                          QString("Could not open %1").arg(url_as_string));
+  }
 }
 
 }  // namespace orbit_config_widgets

--- a/src/ConfigWidgets/SymbolsDialog.ui
+++ b/src/ConfigWidgets/SymbolsDialog.ui
@@ -14,59 +14,28 @@
    <string>Symbol Locations</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QPushButton" name="addFolderButton">
-       <property name="text">
-        <string>Add Folder</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="addFileButton">
-       <property name="text">
-        <string>Add File</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="removeButton">
-       <property name="text">
-        <string>Remove</string>
-       </property>
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Orbit tries to find symbols automatically based on filenames and build id.</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QListWidget" name="listWidget"/>
    </item>
-   <item row="4" column="0">
+   <item row="4" column="1">
+    <widget class="QPushButton" name="doneButton">
+     <property name="text">
+      <string>Done</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QPushButton" name="moreInfoButton">
+       <property name="styleSheet">
+        <string notr="true">border: none; color: #4F9CFF; font-weight: bold; text-decoration: underline</string>
+       </property>
+       <property name="text">
+        <string>More information on symbol loading</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
@@ -85,19 +54,53 @@
    <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Orbit attemps to load symbols to accurately label functions with their names, resolve callstack and more. When symbols can't be loaded, function names will be displayed as ???.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add folders and files to load symbols:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Add Folder&lt;/span&gt; to load symbol files contained in that folder. Symbols will be loaded if the file name and build ID match the module and the file extension is “.so”, “.debug”, “.so.debug”, “.dll” or “.pdb”.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Add File&lt;/span&gt; to load symbols from an individual file, even if file name, build ID or file extension don’t match the module. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="doneButton">
-     <property name="text">
-      <string>Done</string>
-     </property>
-    </widget>
+   <item row="1" column="1">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QPushButton" name="addFolderButton">
+       <property name="text">
+        <string>Add Folder</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="addFileButton">
+       <property name="text">
+        <string>Add File</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="removeButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Remove</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="moduleHeadlineLabel">
@@ -113,6 +116,7 @@
   <tabstop>addFileButton</tabstop>
   <tabstop>removeButton</tabstop>
   <tabstop>listWidget</tabstop>
+  <tabstop>moreInfoButton</tabstop>
   <tabstop>doneButton</tabstop>
  </tabstops>
  <resources/>
@@ -182,6 +186,22 @@
    </hints>
   </connection>
   <connection>
+   <sender>moreInfoButton</sender>
+   <signal>clicked()</signal>
+   <receiver>SymbolsDialog</receiver>
+   <slot>OnMoreInfoButtonClicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>472</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>477</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
    <sender>listWidget</sender>
    <signal>itemSelectionChanged()</signal>
    <receiver>SymbolsDialog</receiver>
@@ -202,6 +222,7 @@
   <slot>OnAddFolderButtonClicked()</slot>
   <slot>OnAddFileButtonClicked()</slot>
   <slot>OnRemoveButtonClicked()</slot>
+  <slot>OnMoreInfoButtonClicked()</slot>
   <slot>OnListItemSelectionChanged()</slot>
  </slots>
 </ui>

--- a/src/ConfigWidgets/SymbolsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolsDialogTest.cpp
@@ -46,6 +46,10 @@ TEST(SymbolsDialog, ConstructEmpty) {
   auto* list_widget = dialog.findChild<QListWidget*>("listWidget");
   ASSERT_NE(list_widget, nullptr);
   EXPECT_EQ(list_widget->count(), 0);
+
+  auto* more_info_button = dialog.findChild<QPushButton*>("moreInfoButton");
+  ASSERT_NE(more_info_button, nullptr);
+  EXPECT_EQ(more_info_button->text().toStdString(), "More information on symbol loading");
 }
 
 TEST(SymbolsDialog, ConstructNonEmpty) {

--- a/src/ConfigWidgets/SymbolsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolsDialogTest.cpp
@@ -46,10 +46,6 @@ TEST(SymbolsDialog, ConstructEmpty) {
   auto* list_widget = dialog.findChild<QListWidget*>("listWidget");
   ASSERT_NE(list_widget, nullptr);
   EXPECT_EQ(list_widget->count(), 0);
-
-  auto* more_info_button = dialog.findChild<QPushButton*>("moreInfoButton");
-  ASSERT_NE(more_info_button, nullptr);
-  EXPECT_EQ(more_info_button->text().toStdString(), "More information on symbol loading");
 }
 
 TEST(SymbolsDialog, ConstructNonEmpty) {

--- a/src/ConfigWidgets/include/ConfigWidgets/SymbolsDialog.h
+++ b/src/ConfigWidgets/include/ConfigWidgets/SymbolsDialog.h
@@ -48,6 +48,7 @@ class SymbolsDialog : public QDialog {
   void OnAddFolderButtonClicked();
   void OnAddFileButtonClicked();
   void OnListItemSelectionChanged();
+  void OnMoreInfoButtonClicked();
 
  private:
   std::unique_ptr<Ui::SymbolsDialog> ui_;


### PR DESCRIPTION
This changes the explanatory text in the Symbol Locations dialog and adds a more info button go/stadia-orbit-symbol-loading-explanatory-wording

screenshot: https://screenshot.googleplex.com/Bxzj9t4iNbvauCZ

