### PR TITLE
Update conan version to latest (1.45.0)

### DIFF
--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-$conan_version_required = "1.40.3"
+$conan_version_required = "1.45.0"
 
 function Check-Conan-Version-Sufficient {
   $version = $args[0]

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-CONAN_VERSION_REQUIRED="1.40.3"
+CONAN_VERSION_REQUIRED="1.45.0"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -119,7 +119,7 @@ if [ -n "$1" ]; then
   # That's a temporary solution. The docker containers should have the
   # correct version of conan already preinstalled. This step will be removed
   # when the docker containers are restructured and versioned.
-  pip3 install conan==1.40.3
+  pip3 install conan==1.45.0
 
   echo "Installing conan configuration (profiles, settings, etc.)..."
   ${REPO_ROOT}/third_party/conan/configs/install.sh ${PUBLIC_BUILD:+--force-public-remotes}

--- a/third_party/conan/scripts/build_and_upload_dependencies.sh
+++ b/third_party/conan/scripts/build_and_upload_dependencies.sh
@@ -19,7 +19,7 @@ readonly SCRIPT="/mnt/third_party/conan/scripts/build_and_upload_dependencies.sh
 export CONAN_USE_ALWAYS_SHORT_PATHS=1
 
 if [[ -v IN_DOCKER ]]; then
-  pip3 install conan==1.40.3
+  pip3 install conan==1.45.0
   export QT_QPA_PLATFORM=offscreen
 
   if [[ -v ORBIT_PUBLIC_BUILD ]]; then

--- a/third_party/conan/scripts/sync_dependencies.sh
+++ b/third_party/conan/scripts/sync_dependencies.sh
@@ -13,7 +13,7 @@ REPO_ROOT_WIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" >/dev/null 2>&
 SCRIPT="/mnt/third_party/conan/scripts/sync_dependencies.sh"
 
 if [ "$1" ]; then
-  pip3 install conan==1.40.3
+  pip3 install conan==1.45.0
   export QT_QPA_PLATFORM=offscreen
 
   $REPO_ROOT/third_party/conan/configs/install.sh || exit $?


### PR DESCRIPTION
The update is needed to fix our oss-fuzz build due to some breaking
changes / incompatibilities in (at this point unmaintained versions of)
markupsafe and jinja2. Upgrading to the latest conan version also
upgrades the version used for these dependencies.

Tested: Built oss-fuzz Orbit project locally with these changes.
Bug: http://b/220807495