### PR TITLE
Add histogram selection view

### DIFF
--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -90,9 +90,7 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(const orbit_statistics::BinomialConfidenceIntervalEstimator&,
               GetConfidenceIntervalEstimator, (), (const));
 
-  MOCK_METHOD(void, ShowHistogram,
-              (std::optional<orbit_statistics::Histogram> histogram,
-               const std::string& function_name),
+  MOCK_METHOD(void, ShowHistogram, (std::vector<uint64_t> data, const std::string& function_name),
               ());
 };
 

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -109,8 +109,7 @@ class AppInterface {
   virtual void Disassemble(uint32_t pid, const orbit_client_protos::FunctionInfo& function) = 0;
   virtual void ShowSourceCode(const orbit_client_protos::FunctionInfo& function) = 0;
 
-  virtual void ShowHistogram(std::optional<orbit_statistics::Histogram> histogram,
-                             const std::string& function_name) = 0;
+  virtual void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) = 0;
 
   [[nodiscard]] virtual const orbit_statistics::BinomialConfidenceIntervalEstimator&
   GetConfidenceIntervalEstimator() const = 0;

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -83,7 +83,7 @@ class LiveFunctionsDataView : public DataView {
  private:
   [[nodiscard]] const orbit_client_protos::FunctionInfo* GetFunctionInfoFromRow(int row) override;
 
-  std::tuple<std::optional<orbit_statistics::Histogram>, std::string> ShowHistogram(int row);
+  std::vector<uint64_t> GetFunctionTimerDurations(int row);
 
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 };

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2961,7 +2961,6 @@ OrbitApp::GetConfidenceIntervalEstimator() const {
   return confidence_interval_estimator_;
 }
 
-void OrbitApp::ShowHistogram(std::optional<orbit_statistics::Histogram> histogram,
-                             const std::string& function_name) {
-  main_window_->ShowHistogram(std::move(histogram), function_name);
+void OrbitApp::ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) {
+  main_window_->ShowHistogram(std::move(data), function_name);
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -558,8 +558,7 @@ class OrbitApp final : public DataViewFactory,
   // Only call from the capture thread
   void CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& timer);
 
-  void ShowHistogram(std::optional<orbit_statistics::Histogram> histogram,
-                     const std::string& function_name) override;
+  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) override;
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<orbit_client_data::CaptureData::DataSource> data_source_{

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -42,8 +42,7 @@ class MainWindowInterface {
   virtual void AppendToCaptureLog(CaptureLogSeverity severity, absl::Duration capture_time,
                                   std::string_view message) = 0;
 
-  virtual void ShowHistogram(std::optional<orbit_statistics::Histogram> histogram,
-                             const std::string& function_name) = 0;
+  virtual void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) = 0;
 
   enum class SymbolErrorHandlingResult { kReloadRequired, kSymbolLoadingCancelled };
   virtual SymbolErrorHandlingResult HandleSymbolError(

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -29,7 +29,7 @@ constexpr uint32_t kVerticalTickCount = 3;
 constexpr uint32_t kHorizontalTickCount = 3;
 constexpr int kTickLength = 5;
 
-constexpr QColor kSelectionColor = QColor(128, 128, 255, 128);
+const QColor kSelectionColor = QColor(128, 128, 255, 128);
 
 [[nodiscard]] static int RoundToClosestInt(double x) { return static_cast<int>(std::round(x)); }
 

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -48,13 +48,12 @@ static void DrawHorizontalAxis(QPainter& painter, const QPoint& axes_intersectio
                                uint64_t min_value) {
   DrawHorizontalLine(painter, axes_intersection, length);
 
-
-  const auto tick_spacing_as_value = histogram.max / kHorizontalTickCount;
+  const auto tick_spacing_as_value = (histogram.max - min_value) / kHorizontalTickCount;
   const int tick_spacing_pixels =
       RoundToClosestInt(static_cast<double>(length) / kHorizontalTickCount);
 
-  int current_tick_location = tick_spacing_pixels + axes_intersection.x();
-  uint64_t current_tick_value = tick_spacing_as_value;
+  int current_tick_location = axes_intersection.x();
+  uint64_t current_tick_value = min_value;
 
   const QFontMetrics font_metrics(painter.font());
 

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -15,6 +15,7 @@
 #include <optional>
 #include <stack>
 #include <string>
+#include <vector>
 
 #include "Statistics/Histogram.h"
 
@@ -44,13 +45,24 @@ class HistogramWidget : public QWidget {
   [[nodiscard]] int WidthMargin() const;
   [[nodiscard]] int HeightMargin() const;
 
-  std::optional<const std::vector<uint64_t>> data_;
-  std::optional<const std::string> function_name_;
+  struct FunctionData {
+    FunctionData(std::vector<uint64_t> data, std::string name)
+        : data(std::move(data)), name(std::move(name)) {}
+
+    std::vector<uint64_t> data;
+    std::string name;
+  };
+
+  std::optional<FunctionData> function_data_;
 
   std::stack<orbit_statistics::Histogram> histogram_stack_;
 
-  std::optional<int> selection_start_pixel;
-  std::optional<int> selection_current_pixel;
+  struct SelectedArea {
+    int selection_start_pixel;
+    int selection_current_pixel;
+  };
+
+  std::optional<SelectedArea> selected_area_;
 };
 
 #endif  // ORBIT_HISTOGRAM_H_

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -5,9 +5,13 @@
 #ifndef ORBIT_HISTOGRAM_H_
 #define ORBIT_HISTOGRAM_H_
 
+#include <absl/types/span.h>
+
 #include <QEvent>
+#include <QMouseEvent>
 #include <QPainter>
 #include <QWidget>
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -19,15 +23,24 @@ class HistogramWidget : public QWidget {
  public:
   using QWidget::QWidget;
 
-  void UpdateHistogram(std::optional<orbit_statistics::Histogram> histogram,
-                       std::string function_name);
+  void UpdateData(std::vector<uint64_t> data, std::string function_name);
 
  protected:
   void paintEvent(QPaintEvent* /*event*/) override;
 
+  void mousePressEvent(QMouseEvent* event) override;
+  void mouseReleaseEvent(QMouseEvent* event) override;
+  void mouseMoveEvent(QMouseEvent* event) override;
+
  private:
-  std::optional<orbit_statistics::Histogram> histogram_;
+  std::optional<std::vector<uint64_t>> data_;
   std::optional<std::string> function_name_;
+
+  std::optional<orbit_statistics::Histogram> histogram_;
+  std::optional<orbit_statistics::Histogram> selection_histogram_;
+
+  std::optional<int> selection_start_pixel;
+  std::optional<int> selection_current_pixel;
 };
 
 #endif  // ORBIT_HISTOGRAM_H_

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -13,6 +13,7 @@
 #include <QWidget>
 #include <cstdint>
 #include <optional>
+#include <stack>
 #include <string>
 
 #include "Statistics/Histogram.h"
@@ -36,8 +37,7 @@ class HistogramWidget : public QWidget {
   std::optional<std::vector<uint64_t>> data_;
   std::optional<std::string> function_name_;
 
-  std::optional<orbit_statistics::Histogram> histogram_;
-  std::optional<orbit_statistics::Histogram> selection_histogram_;
+  std::stack<orbit_statistics::Histogram> histogram_stack_;
 
   std::optional<int> selection_start_pixel;
   std::optional<int> selection_current_pixel;

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -34,8 +34,18 @@ class HistogramWidget : public QWidget {
   void mouseMoveEvent(QMouseEvent* event) override;
 
  private:
-  std::optional<std::vector<uint64_t>> data_;
-  std::optional<std::string> function_name_;
+  [[nodiscard]] bool IsSelectionActive() const;
+
+  [[nodiscard]] uint64_t MinValue() const;
+  [[nodiscard]] uint64_t MaxValue() const;
+
+  [[nodiscard]] int Width() const;
+  [[nodiscard]] int Height() const;
+  [[nodiscard]] int WidthMargin() const;
+  [[nodiscard]] int HeightMargin() const;
+
+  std::optional<const std::vector<uint64_t>> data_;
+  std::optional<const std::string> function_name_;
 
   std::stack<orbit_statistics::Histogram> histogram_stack_;
 

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -156,7 +156,7 @@ void OrbitLiveFunctions::OnRowSelected(std::optional<int> row) {
   ui->data_view_panel_->GetTreeView()->SetIsInternalRefresh(false);
 }
 
-void OrbitLiveFunctions::ShowHistogram(std::optional<orbit_statistics::Histogram> histogram,
+void OrbitLiveFunctions::ShowHistogram(std::vector<uint64_t> data,
                                        const std::string& function_name) {
-  ui->histogram_widget->UpdateHistogram(std::move(histogram), function_name);
+  ui->histogram_widget->UpdateData(std::move(data), function_name);
 }

--- a/src/OrbitQt/orbitlivefunctions.h
+++ b/src/OrbitQt/orbitlivefunctions.h
@@ -47,8 +47,7 @@ class OrbitLiveFunctions : public QWidget {
   std::optional<LiveFunctionsController*> GetLiveFunctionsController() {
     return live_functions_ ? &live_functions_.value() : nullptr;
   }
-  void ShowHistogram(std::optional<orbit_statistics::Histogram> histogram,
-                     const std::string& function_name);
+  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name);
 
  private:
   Ui::OrbitLiveFunctions* ui;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1630,9 +1630,8 @@ void OrbitMainWindow::ShowWarningWithDontShowAgainCheckboxIfNeeded(
   message_box.exec();
 }
 
-void OrbitMainWindow::ShowHistogram(std::optional<orbit_statistics::Histogram> histogram,
-                                    const std::string& function_name) {
-  ui->liveFunctions->ShowHistogram(std::move(histogram), function_name);
+void OrbitMainWindow::ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) {
+  ui->liveFunctions->ShowHistogram(std::move(data), function_name);
 }
 
 static std::optional<QString> TryApplyMappingAndReadSourceFile(

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -116,8 +116,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
       std::string_view title, std::string_view text,
       std::string_view dont_show_again_setting_key) override;
 
-  void ShowHistogram(std::optional<orbit_statistics::Histogram> histogram,
-                     const std::string& function_name) override;
+  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/Statistics/DataSet.cpp
+++ b/src/Statistics/DataSet.cpp
@@ -13,10 +13,9 @@
 
 namespace orbit_statistics {
 
-[[nodiscard]] std::optional<DataSet> DataSet::Create(const std::vector<uint64_t>* data) {
-  ORBIT_CHECK(data != nullptr);
-  if (data->empty()) return std::nullopt;
-  const auto [min, max] = std::minmax_element(data->begin(), data->end());
+[[nodiscard]] std::optional<DataSet> DataSet::Create(absl::Span<const uint64_t> data) {
+  if (data.empty()) return std::nullopt;
+  const auto [min, max] = std::minmax_element(data.begin(), data.end());
 
   return DataSet(data, *min, *max);
 }

--- a/src/Statistics/Histogram.cpp
+++ b/src/Statistics/Histogram.cpp
@@ -4,6 +4,8 @@
 
 #include "Statistics/Histogram.h"
 
+#include <absl/types/span.h>
+
 #include <cstdint>
 #include <optional>
 #include <vector>
@@ -16,8 +18,8 @@ namespace orbit_statistics {
 
 constexpr uint32_t kNumberOfBinsGridSize = 12;
 
-[[nodiscard]] std::optional<Histogram> BuildHistogram(const std::vector<uint64_t>& data) {
-  std::optional<DataSet> data_set = DataSet::Create(&data);
+[[nodiscard]] std::optional<Histogram> BuildHistogram(absl::Span<const uint64_t> data) {
+  std::optional<DataSet> data_set = DataSet::Create(data);
   if (!data_set.has_value()) return std::nullopt;
 
   size_t number_of_bins = 1;

--- a/src/Statistics/HistogramTest.cpp
+++ b/src/Statistics/HistogramTest.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <absl/types/span.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -40,7 +39,7 @@ TEST(DataSet, TestCreateDataSetWithNonEmptyVector) {
 }
 
 TEST(HistogramUtils, ValueToHistogramBinIndexTest) {
-  const std::optional<DataSet> data_set = DataSet::Create(absl::MakeSpan(raw_data_set));
+  const std::optional<DataSet> data_set = DataSet::Create((raw_data_set));
 
   EXPECT_EQ(ValueToHistogramBinIndex(15ULL, data_set.value(), kBinWidth), 0);
   EXPECT_EQ(ValueToHistogramBinIndex(14ULL, data_set.value(), kBinWidth), 0);

--- a/src/Statistics/HistogramTest.cpp
+++ b/src/Statistics/HistogramTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/types/span.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -27,19 +28,19 @@ const static std::vector<uint64_t> raw_data_set(kRawDataSet.begin(), kRawDataSet
 
 TEST(DataSet, TestCreateDataSetWithEmptyVector) {
   const std::vector<uint64_t> empty;
-  const std::optional<DataSet> data_set = DataSet::Create(&empty);
+  const std::optional<DataSet> data_set = DataSet::Create(absl::MakeSpan(empty));
   EXPECT_FALSE(data_set.has_value());
 }
 
 TEST(DataSet, TestCreateDataSetWithNonEmptyVector) {
-  const std::optional<DataSet> data_set = DataSet::Create(&raw_data_set);
+  const std::optional<DataSet> data_set = DataSet::Create(absl::MakeSpan(raw_data_set));
   ASSERT_TRUE(data_set.has_value());
   EXPECT_EQ(data_set->GetMin(), kMin);
   EXPECT_EQ(data_set->GetMax(), kMax);
 }
 
 TEST(HistogramUtils, ValueToHistogramBinIndexTest) {
-  const std::optional<DataSet> data_set = DataSet::Create(&raw_data_set);
+  const std::optional<DataSet> data_set = DataSet::Create(absl::MakeSpan(raw_data_set));
 
   EXPECT_EQ(ValueToHistogramBinIndex(15ULL, data_set.value(), kBinWidth), 0);
   EXPECT_EQ(ValueToHistogramBinIndex(14ULL, data_set.value(), kBinWidth), 0);
@@ -51,7 +52,7 @@ TEST(HistogramUtils, ValueToHistogramBinIndexTest) {
 }
 
 TEST(HistogramUtils, TestBuildHistogramCounts) {
-  const std::optional<DataSet> data_set = DataSet::Create(&raw_data_set);
+  const std::optional<DataSet> data_set = DataSet::Create(absl::MakeSpan(raw_data_set));
 
   const auto histogram = BuildHistogram(data_set.value(), kBinWidth);
   EXPECT_EQ(histogram.data_set_size, kDataSetSize);
@@ -73,7 +74,7 @@ TEST(HistogramUtils, TestBuildHistogramCounts) {
 TEST(HistogramUtils, TestBuildHistogramCountsAllEqualDataElements) {
   const size_t singular_dataset_size = 100;
   const std::vector<uint64_t> singular_raw_data_set(singular_dataset_size, 5ULL);
-  const auto data_set = DataSet::Create(&singular_raw_data_set);
+  const auto data_set = DataSet::Create(absl::MakeSpan(singular_raw_data_set));
 
   auto histogram = BuildHistogram(data_set.value(), kBinWidth);
   EXPECT_EQ(histogram.data_set_size, singular_dataset_size);
@@ -86,7 +87,7 @@ TEST(HistogramUtils, TestBuildHistogramCountsAllEqualDataElements) {
 
 static uint64_t NumberOfBinsToBinWidthHelper(size_t bins_num, uint64_t max, uint64_t min) {
   const std::vector<uint64_t> raw_data = {max, min};
-  const auto data_set = DataSet::Create(&raw_data);
+  const auto data_set = DataSet::Create(absl::MakeSpan(raw_data));
   return NumberOfBinsToBinWidth(data_set.value(), bins_num);
 }
 
@@ -160,7 +161,8 @@ TEST(Histogram, BuildHistogramCorrectlyChoosesTheBinWidth) {
       39884349, 39889010, 39925959, 39933440, 39987806, 40223294, 43078564, 43081818, 43700203,
       43843646};
 
-  std::optional<Histogram> hist = BuildHistogram(data);
+  const absl::Span<const uint64_t> span = absl::MakeSpan(data);
+  std::optional<Histogram> hist = BuildHistogram(span);
   ASSERT_TRUE(hist.has_value());
   EXPECT_EQ(hist->counts.size(), 128);
 }

--- a/src/Statistics/HistogramUtils.cpp
+++ b/src/Statistics/HistogramUtils.cpp
@@ -45,10 +45,10 @@ namespace orbit_statistics {
 [[nodiscard]] Histogram BuildHistogram(const DataSet& data_set, uint64_t bin_width) {
   const size_t bin_num = ValueToHistogramBinIndex(data_set.GetMax(), data_set, bin_width) + 1;
   std::vector<size_t> counts(bin_num, 0UL);
-  for (uint64_t value : *data_set.GetData()) {
+  for (uint64_t value : data_set.GetData()) {
     counts[ValueToHistogramBinIndex(value, data_set, bin_width)]++;
   }
-  return {data_set.GetMin(), data_set.GetMax(), bin_width, data_set.GetData()->size(),
+  return {data_set.GetMin(), data_set.GetMax(), bin_width, data_set.GetData().size(),
           std::move(counts)};
 }
 

--- a/src/Statistics/include/Statistics/DataSet.h
+++ b/src/Statistics/include/Statistics/DataSet.h
@@ -5,6 +5,8 @@
 #ifndef STATISTICS_DATA_SET_H_
 #define STATISTICS_DATA_SET_H_
 
+#include <absl/types/span.h>
+
 #include <cstdint>
 #include <optional>
 #include <vector>
@@ -15,16 +17,16 @@ namespace orbit_statistics {
 // Also stores and exposes minimum and maximum value.
 class DataSet {
  public:
-  [[nodiscard]] static std::optional<DataSet> Create(const std::vector<uint64_t>* data);
+  [[nodiscard]] static std::optional<DataSet> Create(absl::Span<const uint64_t> data);
 
-  [[nodiscard]] const std::vector<uint64_t>* GetData() const { return data_; }
+  [[nodiscard]] absl::Span<const uint64_t> GetData() const { return data_; }
   [[nodiscard]] uint64_t GetMin() const { return min_; }
   [[nodiscard]] uint64_t GetMax() const { return max_; }
 
  private:
-  DataSet(const std::vector<uint64_t>* data, uint64_t min, uint64_t max)
+  DataSet(absl::Span<const uint64_t> data, uint64_t min, uint64_t max)
       : data_(data), min_(min), max_(max) {}
-  const std::vector<uint64_t>* data_;
+  absl::Span<const uint64_t> data_;
   uint64_t min_;
   uint64_t max_;
 };

--- a/src/Statistics/include/Statistics/Histogram.h
+++ b/src/Statistics/include/Statistics/Histogram.h
@@ -28,7 +28,7 @@ struct Histogram {
 
 // The function builds multiple histograms with different number of bins,
 // estimates the risk score using `HistogramRiskScore` and returns the histogram
-// which minimizes it.
+// which minimizes it. The histogram will not own the data.
 [[nodiscard]] std::optional<Histogram> BuildHistogram(absl::Span<const uint64_t> data);
 }  // namespace orbit_statistics
 

--- a/src/Statistics/include/Statistics/Histogram.h
+++ b/src/Statistics/include/Statistics/Histogram.h
@@ -5,6 +5,8 @@
 #ifndef STATISTICS_HISTOGRAM_H_
 #define STATISTICS_HISTOGRAM_H_
 
+#include <absl/types/span.h>
+
 #include <cstdint>
 #include <optional>
 #include <vector>
@@ -27,7 +29,7 @@ struct Histogram {
 // The function builds multiple histograms with different number of bins,
 // estimates the risk score using `HistogramRiskScore` and returns the histogram
 // which minimizes it.
-[[nodiscard]] std::optional<Histogram> BuildHistogram(const std::vector<uint64_t>& data);
+[[nodiscard]] std::optional<Histogram> BuildHistogram(absl::Span<const uint64_t> data);
 }  // namespace orbit_statistics
 
 #endif  // STATISTICS_HISTOGRAM_H_


### PR DESCRIPTION
HistogramWidget is significantly extended.
Now it keeps track of click-n-drag events over the histogram.
Each non-empty selection yield a re-plotting of histogram on
the selected portion of the data. A click returns to the previous view.

The widget now owns the dataset it operates on.

Tests: Unit tests, manual profiling of OrbitTest
Bug: http://b/220682825