### PR TITLE
Make CaptureInitializationResult public

### DIFF
--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -24,8 +24,9 @@ class CaptureServiceBase {
   void AddCaptureStartStopListener(CaptureStartStopListener* listener);
   void RemoveCaptureStartStopListener(CaptureStartStopListener* listener);
 
- protected:
   enum class CaptureInitializationResult { kSuccess, kAlreadyInProgress };
+
+ protected:
   enum class StopCaptureReason { kClientStop, kMemoryWatchdog };
 
   [[nodiscard]] CaptureInitializationResult InitializeCapture(


### PR DESCRIPTION
The CloudCollector needs to access the CaptureInitializationResult
returned by `LinuxCaptureService::DoCapture`. We change the
`CaptureServiceBase::CaptureInitializationResult` to be public.

Bug: http://b/220889136