### PR TITLE
Fix the updating of highlighted_function_id

### DIFF
--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -49,7 +49,7 @@ void DataManager::set_highlighted_function_id(uint64_t highlighted_function_id) 
 
 void DataManager::set_highlighted_group_id(uint64_t highlighted_group_id) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  highlighted_function_id_ = highlighted_group_id;
+  highlighted_group_id_ = highlighted_group_id;
 }
 
 void DataManager::set_selected_thread_id(uint32_t thread_id) {


### PR DESCRIPTION
We updated `DataManager::highlighted_function_id_` with highlighted
group id by mistake. Fix this now.

Bugs: http://b/221195800