### PR TITLE
Synchronize the histogram with the function selected

### DIFF
--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -15,6 +15,7 @@
 #include <stddef.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -157,13 +158,14 @@ void LiveFunctionsDataView::UpdateHistogram() { UpdateHistogram(GetVisibleSelect
 void LiveFunctionsDataView::UpdateHistogram(const std::vector<int>& visible_selected_indices) {
   std::vector<uint64_t> timer_durations;
   std::string function_name;
+  uint64_t function_id = orbit_grpc_protos::kInvalidFunctionId;
   if (!visible_selected_indices.empty()) {
     const FunctionInfo& function = *GetFunctionInfoFromRow(visible_selected_indices[0]);
     function_name = orbit_client_data::function_utils::GetDisplayName(function);
-
     timer_durations = GetFunctionTimerDurations(visible_selected_indices[0]);
+    function_id = indices_[visible_selected_indices[0]];
   }
-  app_->ShowHistogram(std::move(timer_durations), function_name);
+  app_->ShowHistogram(std::move(timer_durations), function_name, function_id);
 }
 
 void LiveFunctionsDataView::OnSelect(const std::vector<int>& rows) {
@@ -449,7 +451,7 @@ void LiveFunctionsDataView::AddFunction(uint64_t function_id,
 void LiveFunctionsDataView::OnDataChanged() {
   functions_.clear();
   indices_.clear();
-  app_->ShowHistogram({}, "");
+  app_->ShowHistogram({}, "", orbit_grpc_protos::kInvalidFunctionId);
 
   if (!app_->HasCaptureData()) {
     DataView::OnDataChanged();

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -152,6 +152,8 @@ std::vector<uint64_t> LiveFunctionsDataView::GetFunctionTimerDurations(int row) 
   return timer_durations;
 }
 
+void LiveFunctionsDataView::UpdateHistogram() { UpdateHistogram(GetVisibleSelectedIndices()); }
+
 void LiveFunctionsDataView::UpdateHistogram(const std::vector<int>& visible_selected_indices) {
   std::vector<uint64_t> timer_durations;
   std::string function_name;
@@ -167,7 +169,7 @@ void LiveFunctionsDataView::UpdateHistogram(const std::vector<int>& visible_sele
 void LiveFunctionsDataView::OnSelect(const std::vector<int>& rows) {
   UpdateHighlightedFunctionId(rows);
   UpdateSelectedFunctionId();
-  UpdateHistogram(GetVisibleSelectedIndices());
+  UpdateHistogram();
 }
 
 #define ORBIT_FUNC_SORT(Member)                                                         \

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -495,8 +495,12 @@ void LiveFunctionsDataView::OnTimer() {
 
 void LiveFunctionsDataView::OnRefresh(const std::vector<int>& visible_selected_indices,
                                       const RefreshMode& mode) {
-  if (mode != RefreshMode::kOther) UpdateHighlightedFunctionId(visible_selected_indices);
-  if (mode != RefreshMode::kOnSort) UpdateHistogram(visible_selected_indices);
+  if (mode == RefreshMode::kOnFilter || mode == RefreshMode::kOnSort) {
+    UpdateHighlightedFunctionId(visible_selected_indices);
+  }
+  if (mode != RefreshMode::kOnSort) {
+    UpdateHistogram(visible_selected_indices);
+  }
 }
 
 uint64_t LiveFunctionsDataView::GetInstrumentedFunctionId(uint32_t row) const {

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -9,6 +9,7 @@
 #include <gmock/gmock.h>
 #include <stdint.h>
 
+#include <cstdint>
 #include <string>
 
 #include "ClientData/CaptureData.h"
@@ -90,7 +91,8 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(const orbit_statistics::BinomialConfidenceIntervalEstimator&,
               GetConfidenceIntervalEstimator, (), (const));
 
-  MOCK_METHOD(void, ShowHistogram, (std::vector<uint64_t> data, const std::string& function_name),
+  MOCK_METHOD(void, ShowHistogram,
+              (std::vector<uint64_t> data, const std::string& function_name, uint64_t function_id),
               ());
 };
 

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -109,7 +109,8 @@ class AppInterface {
   virtual void Disassemble(uint32_t pid, const orbit_client_protos::FunctionInfo& function) = 0;
   virtual void ShowSourceCode(const orbit_client_protos::FunctionInfo& function) = 0;
 
-  virtual void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) = 0;
+  virtual void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name,
+                             uint64_t function_id) = 0;
 
   [[nodiscard]] virtual const orbit_statistics::BinomialConfidenceIntervalEstimator&
   GetConfidenceIntervalEstimator() const = 0;

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -53,6 +53,7 @@ class LiveFunctionsDataView : public DataView {
   // timestamp, and duration) associated with the selected rows in to a CSV file.
   void OnExportEventsToCsvRequested(const std::vector<int>& selection) override;
 
+  // TODO make it take function_id as a parameter
   void UpdateHistogram();
 
  protected:

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -53,6 +53,8 @@ class LiveFunctionsDataView : public DataView {
   // timestamp, and duration) associated with the selected rows in to a CSV file.
   void OnExportEventsToCsvRequested(const std::vector<int>& selection) override;
 
+  void UpdateHistogram();
+
  protected:
   void DoFilter() override;
   void DoSort() override;

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -83,6 +83,8 @@ class LiveFunctionsDataView : public DataView {
  private:
   [[nodiscard]] const orbit_client_protos::FunctionInfo* GetFunctionInfoFromRow(int row) override;
 
+  void UpdateHistogram(const std::vector<int>& visible_selected_indices);
+
   std::vector<uint64_t> GetFunctionTimerDurations(int row);
 
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2961,6 +2961,7 @@ OrbitApp::GetConfidenceIntervalEstimator() const {
   return confidence_interval_estimator_;
 }
 
-void OrbitApp::ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) {
-  main_window_->ShowHistogram(std::move(data), function_name);
+void OrbitApp::ShowHistogram(std::vector<uint64_t> data, const std::string& function_name,
+                             uint64_t function_id) {
+  main_window_->ShowHistogram(std::move(data), function_name, function_id);
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -558,7 +558,8 @@ class OrbitApp final : public DataViewFactory,
   // Only call from the capture thread
   void CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& timer);
 
-  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) override;
+  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name,
+                     uint64_t function_id) override;
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<orbit_client_data::CaptureData::DataSource> data_source_{

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -42,7 +42,8 @@ class MainWindowInterface {
   virtual void AppendToCaptureLog(CaptureLogSeverity severity, absl::Duration capture_time,
                                   std::string_view message) = 0;
 
-  virtual void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) = 0;
+  virtual void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name,
+                             uint64_t function_id) = 0;
 
   enum class SymbolErrorHandlingResult { kReloadRequired, kSymbolLoadingCancelled };
   virtual SymbolErrorHandlingResult HandleSymbolError(

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -134,11 +134,14 @@ static void DrawHistogram(QPainter& painter, const QPoint& axes_intersection,
   }
 }
 
-void HistogramWidget::UpdateData(std::vector<uint64_t> data, std::string function_name) {
+void HistogramWidget::UpdateData(std::vector<uint64_t> data, std::string function_name,
+                                 uint64_t function_id) {
+  if (function_data_.has_value() && function_data_->id == function_id) return;
+
   histogram_stack_ = {};
 
   std::sort(data.begin(), data.end());
-  function_data_.emplace(std::move(data), std::move(function_name));
+  function_data_.emplace(std::move(data), std::move(function_name), function_id);
 
   std::optional<orbit_statistics::Histogram> histogram =
       orbit_statistics::BuildHistogram(function_data_->data);

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -25,7 +25,7 @@ class HistogramWidget : public QWidget {
  public:
   using QWidget::QWidget;
 
-  void UpdateData(std::vector<uint64_t> data, std::string function_name);
+  void UpdateData(std::vector<uint64_t> data, std::string function_name, uint64_t function_id);
 
  protected:
   void paintEvent(QPaintEvent* /*event*/) override;
@@ -46,11 +46,12 @@ class HistogramWidget : public QWidget {
   [[nodiscard]] int HeightMargin() const;
 
   struct FunctionData {
-    FunctionData(std::vector<uint64_t> data, std::string name)
-        : data(std::move(data)), name(std::move(name)) {}
+    FunctionData(std::vector<uint64_t> data, std::string name, uint64_t id)
+        : data(std::move(data)), name(std::move(name)), id(id) {}
 
     std::vector<uint64_t> data;
     std::string name;
+    uint64_t id;
   };
 
   std::optional<FunctionData> function_data_;

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -156,7 +156,7 @@ void OrbitLiveFunctions::OnRowSelected(std::optional<int> row) {
   ui->data_view_panel_->GetTreeView()->SetIsInternalRefresh(false);
 }
 
-void OrbitLiveFunctions::ShowHistogram(std::vector<uint64_t> data,
-                                       const std::string& function_name) {
-  ui->histogram_widget->UpdateData(std::move(data), function_name);
+void OrbitLiveFunctions::ShowHistogram(std::vector<uint64_t> data, const std::string& function_name,
+                                       uint64_t function_id) {
+  ui->histogram_widget->UpdateData(std::move(data), function_name, function_id);
 }

--- a/src/OrbitQt/orbitlivefunctions.h
+++ b/src/OrbitQt/orbitlivefunctions.h
@@ -47,7 +47,8 @@ class OrbitLiveFunctions : public QWidget {
   std::optional<LiveFunctionsController*> GetLiveFunctionsController() {
     return live_functions_ ? &live_functions_.value() : nullptr;
   }
-  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name);
+  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name,
+                     uint64_t function_id);
 
  private:
   Ui::OrbitLiveFunctions* ui;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1292,6 +1292,7 @@ void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerIn
         live_functions_controller.value()->GetDataView();
     selected_row = live_functions_data_view.GetRowFromFunctionId(function_id);
     live_functions_data_view.UpdateSelectedFunctionId();
+    live_functions_data_view.UpdateHistogram();
   }
   ui->liveFunctions->OnRowSelected(selected_row);
 }

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1631,8 +1631,9 @@ void OrbitMainWindow::ShowWarningWithDontShowAgainCheckboxIfNeeded(
   message_box.exec();
 }
 
-void OrbitMainWindow::ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) {
-  ui->liveFunctions->ShowHistogram(std::move(data), function_name);
+void OrbitMainWindow::ShowHistogram(std::vector<uint64_t> data, const std::string& function_name,
+                                    uint64_t function_id) {
+  ui->liveFunctions->ShowHistogram(std::move(data), function_name, function_id);
 }
 
 static std::optional<QString> TryApplyMappingAndReadSourceFile(

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -116,7 +116,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
       std::string_view title, std::string_view text,
       std::string_view dont_show_again_setting_key) override;
 
-  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name) override;
+  void ShowHistogram(std::vector<uint64_t> data, const std::string& function_name,
+                     uint64_t function_id) override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION
The histogram is currently updated only when the user clicks on one of the
live functions (on the upper-right). And the histogram is not
updated if the selection is removed or changed. Also, the
histogram is not updated when the selected function is changed
via clicking on a timer in the timeline.

On the other hand, the histogram should not be updated if 
it's the already selected function is being chosen. 
E. g. function `foo` is chosen in  the upper-right list, 
the user applies several levels of zooming-in 
and then clicks on a timer related to `foo`. The zoom-in layers 
should not be lost. 

Tests: Manual
Bug: http://b/221011110