### PR TITLE
Use relative positions when aligned a Track vertically

### DIFF
--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -76,10 +76,10 @@ void TrackContainer::VerticallyMoveIntoView(const TimerInfo& timer_info) {
 
 // Move vertically the view to make a Track fully visible.
 void TrackContainer::VerticallyMoveIntoView(const Track& track) {
-  float pos = track.GetPos()[1] + vertical_scrolling_offset_;
+  float relative_track_y_pos = track.GetPos()[1] - GetPos()[1] + vertical_scrolling_offset_;
 
-  float max_vertical_scrolling_offset = pos;
-  float min_vertical_scrolling_offset = pos + track.GetHeight() - GetHeight();
+  float max_vertical_scrolling_offset = relative_track_y_pos;
+  float min_vertical_scrolling_offset = relative_track_y_pos + track.GetHeight() - GetHeight();
   SetVerticalScrollingOffset(std::clamp(vertical_scrolling_offset_, min_vertical_scrolling_offset,
                                         max_vertical_scrolling_offset));
 }


### PR DESCRIPTION
An old issue that before didn't generate a bug just because Timegraph
position was (0,0). VerticallyMove into a Track need to use a relative
position since its aligned a Track into the respective container.

We are basically solving 2 issues, both moving a track and jumping to a
timer was aligned at (0,0) and not a TrackContainer position.

http://b/220682817

Test: Load a capture, see that moving tracks and jumping to timers works
as expected.