### PR TITLE
Add error_code support and comparison operators to ErrorMessage

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -102,6 +102,7 @@ target_sources(OrbitBaseTests PRIVATE
         PromiseTest.cpp
         PromiseHelpersTest.cpp
         ReadFileToStringTest.cpp
+        ResultTest.cpp
         SimpleExecutorTest.cpp
         TemporaryFileTest.cpp
         ThreadUtilsTest.cpp

--- a/src/OrbitBase/ResultTest.cpp
+++ b/src/OrbitBase/ResultTest.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <system_error>
+
+#include "OrbitBase/Result.h"
+
+TEST(Result, ErrorMessageCanBeConstructedFromString) {
+  ErrorMessage error_message{"Hello World!"};
+  EXPECT_EQ(error_message.message(), "Hello World!");
+}
+
+TEST(Result, ErrorMessageCanBeConstructedFromErrorCode) {
+  ErrorMessage error_message{std::make_error_code(std::errc::io_error)};
+  EXPECT_EQ(error_message.message(), std::make_error_code(std::errc::io_error).message());
+}
+
+TEST(Result, ErrorMessageCanBeEqualityCompared) {
+  ErrorMessage error_message1{"Hello"};
+  ErrorMessage error_message2{"Hello"};
+  ErrorMessage error_message3{"Hello World!"};
+
+  EXPECT_EQ(error_message1, error_message2);
+  EXPECT_NE(error_message1, error_message3);
+  EXPECT_NE(error_message2, error_message3);
+}

--- a/src/OrbitBase/include/OrbitBase/Result.h
+++ b/src/OrbitBase/include/OrbitBase/Result.h
@@ -34,7 +34,20 @@ class [[nodiscard]] ErrorMessage final {
   ErrorMessage() = default;
   explicit ErrorMessage(std::string message) : message_(std::move(message)) {}
 
+  // This implicit conversion constructor helps migrating code from outcome::result<T> to
+  // ErrorMessageOr<T> because it allows OUTCOME_TRY to call functions that return outcome::result
+  // in functions that return ErrorMessageOr. NOLINTNEXTLINE
+  /* explicit(false) */ ErrorMessage(std::error_code ec) : message_(ec.message()) {}
+
   [[nodiscard]] const std::string& message() const { return message_; }
+
+  [[nodiscard]] friend bool operator==(const ErrorMessage& lhs, const ErrorMessage& rhs) {
+    return lhs.message_ == rhs.message_;
+  }
+
+  [[nodiscard]] friend bool operator!=(const ErrorMessage& lhs, const ErrorMessage& rhs) {
+    return !(lhs == rhs);
+  }
 
  private:
   std::string message_;


### PR DESCRIPTION
This change helps with migrating the remaining parts of the code base
from outcome::result to ErrorMessageOr.

The conversion constructor for std::error_code may be removed or marked
explicit after that's done.

Bug: http://b/221369463