### PR TITLE
Refactor UpdateHistogram methods

### DIFF
--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -54,8 +54,7 @@ class LiveFunctionsDataView : public DataView {
   // timestamp, and duration) associated with the selected rows in to a CSV file.
   void OnExportEventsToCsvRequested(const std::vector<int>& selection) override;
 
-  // TODO make it take function_id as a parameter
-  void UpdateHistogram();
+  void UpdateHistogramWithFunctionIds(const std::vector<uint64_t>& function_ids);
 
  protected:
   void DoFilter() override;
@@ -92,7 +91,7 @@ class LiveFunctionsDataView : public DataView {
 
   std::vector<uint64_t> GetFunctionTimerDurations(uint64_t function_id);
 
-  void UpdateHistogram(const std::vector<int>& visible_selected_indices);
+  void UpdateHistogramWithIndices(const std::vector<int>& visible_selected_indices);
 
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 };

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1292,7 +1292,7 @@ void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerIn
         live_functions_controller.value()->GetDataView();
     selected_row = live_functions_data_view.GetRowFromFunctionId(function_id);
     live_functions_data_view.UpdateSelectedFunctionId();
-    live_functions_data_view.UpdateHistogram();
+    live_functions_data_view.UpdateHistogramWithFunctionIds({function_id});
   }
   ui->liveFunctions->OnRowSelected(selected_row);
 }


### PR DESCRIPTION
there were two methods of the same name.
Now their names reflect the difference of their arguments.
One of them now relies on function ids,
the other -- on indices.

Tests: Manual
Bug: http://b/221444792