### PR TITLE
Cover OrbitApp::ShowHistogram calls in LiveFunctionsDataView

### DIFF
--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -462,7 +462,7 @@ void LiveFunctionsDataView::AddFunction(uint64_t function_id,
 }
 
 void LiveFunctionsDataView::OnDataChanged() {
-  app_->ShowHistogram(nullptr, "", orbit_grpc_protos::kInvalidFunctionId);
+  UpdateHistogramWithFunctionIds({});
   functions_.clear();
   indices_.clear();
   timer_durations_.clear();

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -4,7 +4,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/strings/str_format.h>
-#include <gmock/gmock-spec-builders.h>
+#include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -57,6 +57,7 @@ using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::ModuleInfo;
 
 using ::testing::_;
+using ::testing::Pointee;
 using ::testing::Return;
 
 namespace {
@@ -101,26 +102,31 @@ constexpr std::array<uint64_t, kNumTimers> kStarts = {1000, 2345, 6789};
 constexpr std::array<uint64_t, kNumTimers> kEnds = {1500, 5432, 9876};
 constexpr std::array<uint64_t, kNumTimers> kThreadIndices = {
     0, 1, 1};  // kThreadIndices[i] is the index of the thread that timer i corresponds to.
-std::array<TimerInfo, kNumTimers> timers;
 
-std::vector<const TimerInfo*> GetTimersForInstrumentedFunctions() {
-  std::vector<const TimerInfo*> timers_for_instrumented_function;
+const std::array<TimerInfo, kNumTimers> kTimers = []() {
+  std::array<TimerInfo, kNumTimers> timers;
   for (size_t i = 0; i < kNumTimers; i++) {
     timers[i].set_start(kStarts[i]);
     timers[i].set_end(kEnds[i]);
     timers[i].set_thread_id(kThreadIds[kThreadIndices[i]]);
-    timers_for_instrumented_function.push_back(&timers[i]);
   }
-  return timers_for_instrumented_function;
-}
+  return timers;
+}();
 
-std::vector<uint64_t> GetDurationsForInstrumentedFunctions() {
+const std::vector<const TimerInfo*> kTimerPointers = []() {
+  std::vector<const TimerInfo*> pointers;
+  std::transform(std::begin(kTimers), std::end(kTimers), std::back_inserter(pointers),
+                 [](const TimerInfo& timer) { return &timer; });
+  return pointers;
+}();
+
+const std::vector<uint64_t> kDurations = []() {
   std::vector<uint64_t> durations;
-  auto timers = GetTimersForInstrumentedFunctions();
-  std::transform(std::begin(timers), std::end(timers), std::back_inserter(durations),
+  std::transform(std::begin(kTimerPointers), std::end(kTimerPointers),
+                 std::back_inserter(durations),
                  [](const TimerInfo* timer) { return timer->end() - timer->start(); });
   return durations;
-}
+}();
 
 std::string GetExpectedDisplayTime(uint64_t time_ns) {
   return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(time_ns));
@@ -448,9 +454,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     }
     EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
-    auto timers_for_instrumented_function = GetTimersForInstrumentedFunctions();
     EXPECT_CALL(app_, GetAllTimersForHookedFunction)
-        .WillRepeatedly(testing::Return(timers_for_instrumented_function));
+        .WillRepeatedly(testing::Return(kTimerPointers));
 
     std::string expected_contents("\"Name\",\"Thread\",\"Start\",\"End\",\"Duration (ns)\"\r\n");
     for (size_t i = 0; i < kNumTimers; ++i) {
@@ -835,18 +840,13 @@ TEST_F(LiveFunctionsDataViewTest, OnRefreshWithNoIndicesResetsHistogram) {
   view_.OnRefresh({}, RefreshMode::kOther);
 }
 
-MATCHER(ExpectedDurations, "") {
-  auto durations = *arg;
-  return durations == GetDurationsForInstrumentedFunctions();
-}
-
 TEST_F(LiveFunctionsDataViewTest, HistogramIsProperlyUpdated) {
-  EXPECT_CALL(app_, GetAllTimersForHookedFunction(_))
-      .WillOnce(Return(GetTimersForInstrumentedFunctions()));
+  EXPECT_CALL(app_, GetAllTimersForHookedFunction(_)).WillOnce(Return(kTimerPointers));
   view_.OnDataChanged();
   AddFunctionsByIndices({0});
 
-  EXPECT_CALL(app_, ShowHistogram(ExpectedDurations(), kPrettyNames[0], kFunctionIds[0])).Times(3);
+  EXPECT_CALL(app_, ShowHistogram(testing::Pointee(kDurations), kPrettyNames[0], kFunctionIds[0]))
+      .Times(3);
 
   view_.OnRefresh({0}, RefreshMode::kOnFilter);
   view_.OnRefresh({0}, RefreshMode::kOther);

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -4,11 +4,15 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/strings/str_format.h>
+#include <gmock/gmock-spec-builders.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
+#include <iterator>
 #include <string>
+#include <vector>
 
 #include "ClientData/CaptureData.h"
 #include "ClientData/FunctionUtils.h"
@@ -52,6 +56,7 @@ using orbit_data_views::kMenuActionUnselect;
 using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::ModuleInfo;
 
+using ::testing::_;
 using ::testing::Return;
 
 namespace {
@@ -86,6 +91,36 @@ constexpr int kColumnStdDev = 7;
 constexpr int kColumnModule = 8;
 constexpr int kColumnAddress = 9;
 constexpr int kNumColumns = 10;
+
+constexpr size_t kNumThreads = 2;
+constexpr std::array<uint32_t, kNumThreads> kThreadIds = {111, 222};
+const std::array<std::string, kNumThreads> kThreadNames = {"Test Thread 1", "Test Thread 2"};
+
+constexpr size_t kNumTimers = 3;
+constexpr std::array<uint64_t, kNumTimers> kStarts = {1000, 2345, 6789};
+constexpr std::array<uint64_t, kNumTimers> kEnds = {1500, 5432, 9876};
+constexpr std::array<uint64_t, kNumTimers> kThreadIndices = {
+    0, 1, 1};  // kThreadIndices[i] is the index of the thread that timer i corresponds to.
+std::array<TimerInfo, kNumTimers> timers;
+
+std::vector<const TimerInfo*> GetTimersForInstrumentedFunctions() {
+  std::vector<const TimerInfo*> timers_for_instrumented_function;
+  for (size_t i = 0; i < kNumTimers; i++) {
+    timers[i].set_start(kStarts[i]);
+    timers[i].set_end(kEnds[i]);
+    timers[i].set_thread_id(kThreadIds[kThreadIndices[i]]);
+    timers_for_instrumented_function.push_back(&timers[i]);
+  }
+  return timers_for_instrumented_function;
+}
+
+std::vector<uint64_t> GetDurationsForInstrumentedFunctions() {
+  std::vector<uint64_t> durations;
+  auto timers = GetTimersForInstrumentedFunctions();
+  std::transform(std::begin(timers), std::end(timers), std::back_inserter(durations),
+                 [](const TimerInfo* timer) { return timer->end() - timer->start(); });
+  return durations;
+}
 
 std::string GetExpectedDisplayTime(uint64_t time_ns) {
   return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(time_ns));
@@ -408,27 +443,12 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Export events to CSV
   {
-    constexpr size_t kNumThreads = 2;
-    const std::array<uint32_t, kNumThreads> kThreadIds = {111, 222};
-    const std::array<std::string, kNumThreads> kThreadNames = {"Test Thread 1", "Test Thread 2"};
     for (size_t i = 0; i < kNumThreads; ++i) {
       capture_data_->AddOrAssignThreadName(kThreadIds[i], kThreadNames[i]);
     }
     EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
-    constexpr size_t kNumTimers = 3;
-    const std::array<uint64_t, kNumTimers> kStarts = {1000, 2345, 6789};
-    const std::array<uint64_t, kNumTimers> kEnds = {1500, 5432, 9876};
-    const std::array<uint64_t, kNumTimers> kThreadIndices = {
-        0, 1, 1};  // kThreadIndices[i] is the index of the thread that timer i corresponds to.
-    std::array<TimerInfo, kNumTimers> timers;
-    std::vector<const TimerInfo*> timers_for_instrumented_function;
-    for (size_t i = 0; i < kNumTimers; i++) {
-      timers[i].set_start(kStarts[i]);
-      timers[i].set_end(kEnds[i]);
-      timers[i].set_thread_id(kThreadIds[kThreadIndices[i]]);
-      timers_for_instrumented_function.push_back(&timers[i]);
-    }
+    auto timers_for_instrumented_function = GetTimersForInstrumentedFunctions();
     EXPECT_CALL(app_, GetAllTimersForHookedFunction)
         .WillRepeatedly(testing::Return(timers_for_instrumented_function));
 
@@ -800,4 +820,35 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
     // Sort by descending
     { sort_and_verify(column, orbit_data_views::DataView::SortingOrder::kDescending); }
   }
+}
+
+TEST_F(LiveFunctionsDataViewTest, OnDataChangeResetsHistogram) {
+  EXPECT_CALL(app_, ShowHistogram(nullptr, "", orbit_grpc_protos::kInvalidFunctionId)).Times(1);
+
+  view_.OnDataChanged();
+}
+
+TEST_F(LiveFunctionsDataViewTest, OnRefreshWithNoIndicesResetsHistogram) {
+  EXPECT_CALL(app_, ShowHistogram(nullptr, "", orbit_grpc_protos::kInvalidFunctionId)).Times(2);
+
+  view_.OnRefresh({}, RefreshMode::kOnFilter);
+  view_.OnRefresh({}, RefreshMode::kOther);
+}
+
+MATCHER(ExpectedDurations, "") {
+  auto durations = *arg;
+  return durations == GetDurationsForInstrumentedFunctions();
+}
+
+TEST_F(LiveFunctionsDataViewTest, HistogramIsProperlyUpdated) {
+  EXPECT_CALL(app_, GetAllTimersForHookedFunction(_))
+      .WillOnce(Return(GetTimersForInstrumentedFunctions()));
+  view_.OnDataChanged();
+  AddFunctionsByIndices({0});
+
+  EXPECT_CALL(app_, ShowHistogram(ExpectedDurations(), kPrettyNames[0], kFunctionIds[0])).Times(3);
+
+  view_.OnRefresh({0}, RefreshMode::kOnFilter);
+  view_.OnRefresh({0}, RefreshMode::kOther);
+  view_.UpdateHistogramWithFunctionIds({kFunctionIds[0]});
 }

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -4,7 +4,6 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/strings/str_format.h>
-#include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Implementation of Histogram view required adding some code
to `LiveFunctionsDataView`. This adds the corresponding
unit-tests.

Bug: http://b/222046168