### PR TITLE
Fix crash on clicking a non-dynamic instrumented timer

### DIFF
--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -168,7 +168,7 @@ void LiveFunctionsDataView::UpdateHistogramWithIndices(
 
 void LiveFunctionsDataView::UpdateHistogramWithFunctionIds(
     const std::vector<uint64_t>& function_ids) {
-  if (function_ids.empty()) {
+  if (function_ids.empty() || !timer_durations_.contains(function_ids[0])) {
     app_->ShowHistogram(nullptr, "", orbit_grpc_protos::kInvalidFunctionId);
     return;
   }

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -58,6 +58,7 @@ namespace {
 
 constexpr size_t kNumFunctions = 3;
 const std::array<uint64_t, kNumFunctions> kFunctionIds{11, 22, 33};
+constexpr uint64_t kNonDynamicallyInstrumentedFunctionId = 123456;
 const std::array<std::string, kNumFunctions> kNames{"foo", "main", "ffind"};
 const std::array<std::string, kNumFunctions> kPrettyNames{"void foo()", "main(int, char**)",
                                                           "ffind(int)"};
@@ -800,4 +801,11 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
     // Sort by descending
     { sort_and_verify(column, orbit_data_views::DataView::SortingOrder::kDescending); }
   }
+}
+
+TEST_F(LiveFunctionsDataViewTest,
+       RemoveHistogramWhenUpdatedWithIdOfNonDynamicallyInstrumentedFunction) {
+  EXPECT_CALL(app_, ShowHistogram(nullptr, "", orbit_grpc_protos::kInvalidFunctionId)).Times(1);
+
+  view_.UpdateHistogramWithFunctionIds({kNonDynamicallyInstrumentedFunctionId});
 }


### PR DESCRIPTION
Adds a check for the supplied function id being
a dynamically instrumented function.

Tests: Unit tests, Manual tests
Bug: http://b/222122786