### PR TITLE
Add DataView::GetActionVisibilities

### DIFF
--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -105,38 +105,51 @@ const std::string CallstackDataView::kHighlightedFunctionString = "➜ ";
 const std::string CallstackDataView::kHighlightedFunctionBlankString =
     std::string(kHighlightedFunctionString.size(), ' ');
 
-absl::flat_hash_map<std::string_view, bool> CallstackDataView::GetActionVisibilities(
-    int clicked_index, const std::vector<int>& selected_indices) {
-  absl::flat_hash_map<std::string_view, bool> visible_action_name_to_availability =
-      DataView::GetActionVisibilities(clicked_index, selected_indices);
+DataView::ActionStatus CallstackDataView::GetActionStatus(
+    std::string_view action, int clicked_index, const std::vector<int>& selected_indices) {
+  bool is_capture_connected = app_->IsCaptureConnected(app_->GetCaptureData());
+  if (!is_capture_connected &&
+      (action == kMenuActionSelect || action == kMenuActionUnselect ||
+       action == kMenuActionDisassembly || action == kMenuActionSourceCode)) {
+    return ActionStatus::kVisibleButDisabled;
+  }
 
-  visible_action_name_to_availability.insert({{kMenuActionLoadSymbols, false},
-                                              {kMenuActionSelect, false},
-                                              {kMenuActionUnselect, false},
-                                              {kMenuActionDisassembly, false},
-                                              {kMenuActionSourceCode, false}});
+  std::function<bool(const FunctionInfo*, const ModuleData*)> is_visible_action_enabled;
+  if (action == kMenuActionLoadSymbols) {
+    is_visible_action_enabled = [](const FunctionInfo* /*function*/, const ModuleData* module) {
+      return module != nullptr && !module->is_loaded();
+    };
+
+  } else if (action == kMenuActionSelect) {
+    is_visible_action_enabled = [this](const FunctionInfo* function, const ModuleData* /*module*/) {
+      return function != nullptr && !app_->IsFunctionSelected(*function) &&
+             orbit_client_data::function_utils::IsFunctionSelectable(*function);
+    };
+
+  } else if (action == kMenuActionUnselect) {
+    is_visible_action_enabled = [this](const FunctionInfo* function, const ModuleData* /*module*/) {
+      return function != nullptr && app_->IsFunctionSelected(*function);
+    };
+
+  } else if (action == kMenuActionDisassembly || action == kMenuActionSourceCode) {
+    is_visible_action_enabled = [](const FunctionInfo* function, const ModuleData* /*module*/) {
+      return function != nullptr;
+    };
+
+  } else {
+    return DataView::GetActionStatus(action, clicked_index, selected_indices);
+  }
 
   for (int index : selected_indices) {
     CallstackDataViewFrame frame = GetFrameFromRow(index);
     const FunctionInfo* function = frame.function;
     const ModuleData* module = frame.module;
-
-    if (frame.function != nullptr && app_->IsCaptureConnected(app_->GetCaptureData())) {
-      visible_action_name_to_availability[kMenuActionSelect] |=
-          !app_->IsFunctionSelected(*function) &&
-          orbit_client_data::function_utils::IsFunctionSelectable(*function);
-      visible_action_name_to_availability[kMenuActionUnselect] |=
-          app_->IsFunctionSelected(*function);
-      visible_action_name_to_availability[kMenuActionDisassembly] = true;
-      visible_action_name_to_availability[kMenuActionSourceCode] = true;
-    } else if (module != nullptr && !module->is_loaded()) {
-      visible_action_name_to_availability[kMenuActionLoadSymbols] = true;
-    }
+    if (is_visible_action_enabled(function, module)) return ActionStatus::kVisibleAndEnabled;
   }
-  return visible_action_name_to_availability;
+  return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// TODO(b/205676296): Remove this when we change to use GetActionStatus in
 // DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> CallstackDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -36,11 +36,6 @@ void DataView::InitSortingOrders() {
   sorting_column_ = GetDefaultSortingColumn();
 }
 
-absl::flat_hash_map<std::string_view, bool> DataView::GetActionVisibilities(
-    int /* clicked_index */, const std::vector<int>& /* selected_indices */) {
-  return {{kMenuActionCopySelection, true}, {kMenuActionExportToCsv, true}};
-}
-
 void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
   ORBIT_SCOPE_FUNCTION;
 
@@ -78,6 +73,17 @@ void DataView::OnDataChanged() {
   ORBIT_SCOPE_FUNCTION;
   DoFilter();
   OnSort(sorting_column_, std::optional<SortingOrder>{});
+}
+
+DataView::ActionStatus DataView::GetActionStatus(std::string_view action, int /* clicked_index */,
+                                                 const std::vector<int>& /* selected_indices */) {
+  if (action == kMenuActionCopySelection) {
+    return ActionStatus::kVisibleAndEnabled;
+  } else if (action == kMenuActionExportToCsv) {
+    return ActionStatus::kVisibleAndEnabled;
+  }
+
+  return ActionStatus::kInvisible;
 }
 
 std::vector<std::vector<std::string>> DataView::GetContextMenuWithGrouping(

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -77,9 +77,7 @@ void DataView::OnDataChanged() {
 
 DataView::ActionStatus DataView::GetActionStatus(std::string_view action, int /* clicked_index */,
                                                  const std::vector<int>& /* selected_indices */) {
-  if (action == kMenuActionCopySelection) {
-    return ActionStatus::kVisibleAndEnabled;
-  } else if (action == kMenuActionExportToCsv) {
+  if (action == kMenuActionCopySelection || action == kMenuActionExportToCsv) {
     return ActionStatus::kVisibleAndEnabled;
   }
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -36,6 +36,11 @@ void DataView::InitSortingOrders() {
   sorting_column_ = GetDefaultSortingColumn();
 }
 
+absl::flat_hash_map<std::string_view, bool> DataView::GetActionVisibilities(
+    int /* clicked_index */, const std::vector<int>& /* selected_indices */) {
+  return {{kMenuActionCopySelection, true}, {kMenuActionExportToCsv, true}};
+}
+
 void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
   ORBIT_SCOPE_FUNCTION;
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -201,7 +201,7 @@ DataView::ActionStatus FunctionsDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// TODO(b/205676296): Remove this when we change to use GetActionStatus in
 // DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> FunctionsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -162,6 +162,35 @@ void FunctionsDataView::DoSort() {
   }
 }
 
+absl::flat_hash_map<std::string_view, bool> FunctionsDataView::GetActionVisibilities(
+    int clicked_index, const std::vector<int>& selected_indices) {
+  absl::flat_hash_map<std::string_view, bool> visible_action_name_to_availability =
+      DataView::GetActionVisibilities(clicked_index, selected_indices);
+
+  visible_action_name_to_availability.insert({{kMenuActionSelect, false},
+                                              {kMenuActionUnselect, false},
+                                              {kMenuActionEnableFrameTrack, false},
+                                              {kMenuActionDisableFrameTrack, false},
+                                              {kMenuActionDisassembly, true},
+                                              {kMenuActionSourceCode, true}});
+
+  for (int index : selected_indices) {
+    const FunctionInfo& function = *GetFunctionInfoFromRow(index);
+    visible_action_name_to_availability[kMenuActionSelect] |=
+        !app_->IsFunctionSelected(function) &&
+        orbit_client_data::function_utils::IsFunctionSelectable(function);
+    visible_action_name_to_availability[kMenuActionUnselect] |= app_->IsFunctionSelected(function);
+    visible_action_name_to_availability[kMenuActionEnableFrameTrack] |=
+        !app_->IsFrameTrackEnabled(function);
+    visible_action_name_to_availability[kMenuActionDisableFrameTrack] |=
+        app_->IsFrameTrackEnabled(function);
+  }
+
+  return visible_action_name_to_availability;
+}
+
+// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> FunctionsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
   bool enable_select = false;

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -252,6 +252,70 @@ void LiveFunctionsDataView::DoSort() {
   }
 }
 
+absl::flat_hash_map<std::string_view, bool> LiveFunctionsDataView::GetActionVisibilities(
+    int clicked_index, const std::vector<int>& selected_indices) {
+  absl::flat_hash_map<std::string_view, bool> visible_action_name_to_availability =
+      DataView::GetActionVisibilities(clicked_index, selected_indices);
+
+  visible_action_name_to_availability.insert({{kMenuActionSelect, false},
+                                              {kMenuActionUnselect, false},
+                                              {kMenuActionEnableFrameTrack, false},
+                                              {kMenuActionDisableFrameTrack, false},
+                                              {kMenuActionAddIterator, false},
+                                              {kMenuActionDisassembly, false},
+                                              {kMenuActionSourceCode, false},
+                                              {kMenuActionJumpToFirst, false},
+                                              {kMenuActionJumpToLast, false},
+                                              {kMenuActionJumpToMax, false},
+                                              {kMenuActionJumpToMin, false},
+                                              {kMenuActionExportEventsToCsv, true}});
+
+  const CaptureData& capture_data = app_->GetCaptureData();
+  for (int index : selected_indices) {
+    uint64_t instrumented_function_id = GetInstrumentedFunctionId(index);
+    const FunctionInfo& instrumented_function = *GetFunctionInfoFromRow(index);
+
+    if (app_->IsCaptureConnected(capture_data)) {
+      visible_action_name_to_availability[kMenuActionSelect] |=
+          !app_->IsFunctionSelected(instrumented_function) &&
+          orbit_client_data::function_utils::IsFunctionSelectable(instrumented_function);
+      visible_action_name_to_availability[kMenuActionUnselect] |=
+          app_->IsFunctionSelected(instrumented_function);
+      visible_action_name_to_availability[kMenuActionDisassembly] = true;
+      visible_action_name_to_availability[kMenuActionSourceCode] = true;
+
+      visible_action_name_to_availability[kMenuActionEnableFrameTrack] |=
+          !app_->IsFrameTrackEnabled(instrumented_function);
+      visible_action_name_to_availability[kMenuActionDisableFrameTrack] |=
+          app_->IsFrameTrackEnabled(instrumented_function);
+    } else {
+      visible_action_name_to_availability[kMenuActionEnableFrameTrack] |=
+          !capture_data.IsFrameTrackEnabled(instrumented_function_id);
+      visible_action_name_to_availability[kMenuActionDisableFrameTrack] |=
+          capture_data.IsFrameTrackEnabled(instrumented_function_id);
+    }
+
+    const FunctionStats& stats = capture_data.GetFunctionStatsOrDefault(instrumented_function_id);
+    // We need at least one function call to a function so that adding iterators makes sense.
+    visible_action_name_to_availability[kMenuActionAddIterator] |= stats.count() > 0;
+  }
+
+  if (selected_indices.size() == 1) {
+    uint64_t instrumented_function_id = GetInstrumentedFunctionId(selected_indices[0]);
+    const FunctionStats& stats = capture_data.GetFunctionStatsOrDefault(instrumented_function_id);
+    if (stats.count() > 0) {
+      visible_action_name_to_availability[kMenuActionJumpToFirst] = true;
+      visible_action_name_to_availability[kMenuActionJumpToLast] = true;
+      visible_action_name_to_availability[kMenuActionJumpToMin] = true;
+      visible_action_name_to_availability[kMenuActionJumpToMax] = true;
+    }
+  }
+
+  return visible_action_name_to_availability;
+}
+
+// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> LiveFunctionsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
   bool enable_select = false;

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -328,7 +328,7 @@ DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// TODO(b/205676296): Remove this when we change to use GetActionStatus in
 // DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> LiveFunctionsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -133,7 +133,7 @@ DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action,
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// TODO(b/205676296): Remove this when we change to use GetActionStatus in
 // DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> ModulesDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -108,22 +108,29 @@ void ModulesDataView::DoSort() {
   }
 }
 
-absl::flat_hash_map<std::string_view, bool> ModulesDataView::GetActionVisibilities(
-    int clicked_index, const std::vector<int>& selected_indices) {
-  absl::flat_hash_map<std::string_view, bool> visible_action_name_to_availability =
-      DataView::GetActionVisibilities(clicked_index, selected_indices);
+DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action, int clicked_index,
+                                                        const std::vector<int>& selected_indices) {
+  if (action == kMenuActionVerifyFramePointers &&
+      !absl::GetFlag(FLAGS_enable_frame_pointer_validator)) {
+    return ActionStatus::kInvisible;
+  }
 
-  visible_action_name_to_availability.insert(
-      {{kMenuActionLoadSymbols, false}, {kMenuActionVerifyFramePointers, false}});
+  std::function<bool(const ModuleData*)> is_visible_action_enabled;
+  if (action == kMenuActionLoadSymbols) {
+    is_visible_action_enabled = [](const ModuleData* module) { return !module->is_loaded(); };
+
+  } else if (action == kMenuActionVerifyFramePointers) {
+    is_visible_action_enabled = [](const ModuleData* module) { return module->is_loaded(); };
+
+  } else {
+    return DataView::GetActionStatus(action, clicked_index, selected_indices);
+  }
 
   for (int index : selected_indices) {
     const ModuleData* module = GetModuleDataFromRow(index);
-    visible_action_name_to_availability[kMenuActionLoadSymbols] |= !module->is_loaded();
-    visible_action_name_to_availability[kMenuActionVerifyFramePointers] |=
-        absl::GetFlag(FLAGS_enable_frame_pointer_validator) && module->is_loaded();
+    if (is_visible_action_enabled(module)) return ActionStatus::kVisibleAndEnabled;
   }
-
-  return visible_action_name_to_availability;
+  return ActionStatus::kVisibleButDisabled;
 }
 
 // TODO(b/205676296): Remove this when we change to use GetActionVisibilities in

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -108,6 +108,26 @@ void ModulesDataView::DoSort() {
   }
 }
 
+absl::flat_hash_map<std::string_view, bool> ModulesDataView::GetActionVisibilities(
+    int clicked_index, const std::vector<int>& selected_indices) {
+  absl::flat_hash_map<std::string_view, bool> visible_action_name_to_availability =
+      DataView::GetActionVisibilities(clicked_index, selected_indices);
+
+  visible_action_name_to_availability.insert(
+      {{kMenuActionLoadSymbols, false}, {kMenuActionVerifyFramePointers, false}});
+
+  for (int index : selected_indices) {
+    const ModuleData* module = GetModuleDataFromRow(index);
+    visible_action_name_to_availability[kMenuActionLoadSymbols] |= !module->is_loaded();
+    visible_action_name_to_availability[kMenuActionVerifyFramePointers] |=
+        absl::GetFlag(FLAGS_enable_frame_pointer_validator) && module->is_loaded();
+  }
+
+  return visible_action_name_to_availability;
+}
+
+// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> ModulesDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
   bool enable_load = false;

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -148,23 +148,23 @@ void PresetsDataView::DoSort() {
   }
 }
 
-absl::flat_hash_map<std::string_view, bool> PresetsDataView::GetActionVisibilities(
-    int clicked_index, const std::vector<int>& selected_indices) {
+DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action, int clicked_index,
+                                                        const std::vector<int>& selected_indices) {
   // Note that the UI already enforces a single selection.
   ORBIT_CHECK(selected_indices.size() == 1);
 
-  absl::flat_hash_map<std::string_view, bool> visible_action_name_to_availability =
-      DataView::GetActionVisibilities(clicked_index, selected_indices);
+  if (action == kMenuActionDeletePreset || action == kMenuActionShowInExplorer) {
+    return ActionStatus::kVisibleAndEnabled;
 
-  visible_action_name_to_availability.insert({{kMenuActionLoadPreset, false},
-                                              {kMenuActionDeletePreset, true},
-                                              {kMenuActionShowInExplorer, true}});
+  } else if (action == kMenuActionLoadPreset) {
+    const PresetFile& preset = GetPreset(selected_indices[0]);
+    return app_->GetPresetLoadState(preset).state == PresetLoadState::kNotLoadable
+               ? ActionStatus::kVisibleButDisabled
+               : ActionStatus::kVisibleAndEnabled;
 
-  const PresetFile& preset = GetPreset(selected_indices[0]);
-  visible_action_name_to_availability[kMenuActionLoadPreset] =
-      app_->GetPresetLoadState(preset).state != PresetLoadState::kNotLoadable;
-
-  return visible_action_name_to_availability;
+  } else {
+    return DataView::GetActionStatus(action, clicked_index, selected_indices);
+  }
 }
 
 // TODO(b/205676296): Remove this when we change to use GetActionVisibilities in

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -167,7 +167,7 @@ DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action,
   }
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// TODO(b/205676296): Remove this when we change to use GetActionStatus in
 // DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -148,6 +148,27 @@ void PresetsDataView::DoSort() {
   }
 }
 
+absl::flat_hash_map<std::string_view, bool> PresetsDataView::GetActionVisibilities(
+    int clicked_index, const std::vector<int>& selected_indices) {
+  // Note that the UI already enforces a single selection.
+  ORBIT_CHECK(selected_indices.size() == 1);
+
+  absl::flat_hash_map<std::string_view, bool> visible_action_name_to_availability =
+      DataView::GetActionVisibilities(clicked_index, selected_indices);
+
+  visible_action_name_to_availability.insert({{kMenuActionLoadPreset, false},
+                                              {kMenuActionDeletePreset, true},
+                                              {kMenuActionShowInExplorer, true}});
+
+  const PresetFile& preset = GetPreset(selected_indices[0]);
+  visible_action_name_to_availability[kMenuActionLoadPreset] =
+      app_->GetPresetLoadState(preset).state != PresetLoadState::kNotLoadable;
+
+  return visible_action_name_to_availability;
+}
+
+// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
   // Note that the UI already enforces a single selection.

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -261,7 +261,7 @@ DataView::ActionStatus SamplingReportDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// TODO(b/205676296): Remove this when we change to use GetActionStatus in
 // DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> SamplingReportDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {

--- a/src/DataViews/TracepointsDataView.cpp
+++ b/src/DataViews/TracepointsDataView.cpp
@@ -101,6 +101,27 @@ void TracepointsDataView::DoFilter() {
   indices_ = std::move(indices);
 }
 
+absl::flat_hash_map<std::string_view, bool> TracepointsDataView::GetActionVisibilities(
+    int clicked_index, const std::vector<int>& selected_indices) {
+  absl::flat_hash_map<std::string_view, bool> visible_action_name_to_availability =
+      DataView::GetActionVisibilities(clicked_index, selected_indices);
+
+  visible_action_name_to_availability.insert(
+      {{kMenuActionSelect, false}, {kMenuActionUnselect, false}});
+
+  for (int index : selected_indices) {
+    const TracepointInfo& tracepoint = GetTracepoint(index);
+    visible_action_name_to_availability[kMenuActionSelect] |=
+        !app_->IsTracepointSelected(tracepoint);
+    visible_action_name_to_availability[kMenuActionUnselect] |=
+        app_->IsTracepointSelected(tracepoint);
+  }
+
+  return visible_action_name_to_availability;
+}
+
+// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> TracepointsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
   bool enable_select = false;

--- a/src/DataViews/TracepointsDataView.cpp
+++ b/src/DataViews/TracepointsDataView.cpp
@@ -125,7 +125,7 @@ DataView::ActionStatus TracepointsDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionVisibilities in
+// TODO(b/205676296): Remove this when we change to use GetActionStatus in
 // DataView::GetContextMenuWithGrouping.
 std::vector<std::vector<std::string>> TracepointsDataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {

--- a/src/DataViews/include/DataViews/CallstackDataView.h
+++ b/src/DataViews/include/DataViews/CallstackDataView.h
@@ -80,6 +80,9 @@ class CallstackDataView : public DataView {
     kNumColumns
   };
 
+  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
+      int clicked_index, const std::vector<int>& selected_indices) override;
+
  private:
   [[nodiscard]] const orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {
     return GetFrameFromRow(row).module;

--- a/src/DataViews/include/DataViews/CallstackDataView.h
+++ b/src/DataViews/include/DataViews/CallstackDataView.h
@@ -80,8 +80,8 @@ class CallstackDataView : public DataView {
     kNumColumns
   };
 
-  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
-      int clicked_index, const std::vector<int>& selected_indices) override;
+  [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
+                                             const std::vector<int>& selected_indices) override;
 
  private:
   [[nodiscard]] const orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -171,8 +171,9 @@ class DataView {
     return nullptr;
   }
 
-  [[nodiscard]] virtual absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
-      int clicked_index, const std::vector<int>& selected_indices);
+  enum class ActionStatus { kInvisible, kVisibleButDisabled, kVisibleAndEnabled };
+  [[nodiscard]] virtual ActionStatus GetActionStatus(std::string_view action, int clicked_index,
+                                                     const std::vector<int>& selected_indices);
 
   void InitSortingOrders();
   virtual void DoSort() {}
@@ -187,7 +188,7 @@ class DataView {
   absl::flat_hash_set<int> selected_indices_;
   DataViewType type_;
 
-  orbit_data_views::AppInterface* app_ = nullptr;
+  AppInterface* app_ = nullptr;
 };
 
 }  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -5,7 +5,7 @@
 #ifndef DATA_VIEWS_DATA_VIEW_H_
 #define DATA_VIEWS_DATA_VIEW_H_
 
-#include <absl/container/flat_hash_set.h>
+#include <absl/container/flat_hash_map.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -170,6 +170,9 @@ class DataView {
       int /*row*/) {
     return nullptr;
   }
+
+  [[nodiscard]] virtual absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
+      int clicked_index, const std::vector<int>& selected_indices);
 
   void InitSortingOrders();
   virtual void DoSort() {}

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -5,7 +5,7 @@
 #ifndef DATA_VIEWS_DATA_VIEW_H_
 #define DATA_VIEWS_DATA_VIEW_H_
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -35,8 +35,8 @@ class FunctionsDataView : public DataView {
   void ClearFunctions();
 
  protected:
-  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
-      int clicked_index, const std::vector<int>& selected_indices) override;
+  [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
+                                             const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -35,6 +35,8 @@ class FunctionsDataView : public DataView {
   void ClearFunctions();
 
  protected:
+  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
+      int clicked_index, const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -57,8 +57,8 @@ class LiveFunctionsDataView : public DataView {
   void UpdateHistogramWithFunctionIds(const std::vector<uint64_t>& function_ids);
 
  protected:
-  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
-      int clicked_index, const std::vector<int>& selected_indices) override;
+  [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
+                                             const std::vector<int>& selected_indices) override;
   void DoFilter() override;
   void DoSort() override;
   [[nodiscard]] uint64_t GetInstrumentedFunctionId(uint32_t row) const;

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -57,6 +57,8 @@ class LiveFunctionsDataView : public DataView {
   void UpdateHistogramWithFunctionIds(const std::vector<uint64_t>& function_ids);
 
  protected:
+  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
+      int clicked_index, const std::vector<int>& selected_indices) override;
   void DoFilter() override;
   void DoSort() override;
   [[nodiscard]] uint64_t GetInstrumentedFunctionId(uint32_t row) const;

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -40,8 +40,8 @@ class ModulesDataView : public DataView {
   void UpdateModules(const orbit_client_data::ProcessData* process);
 
  protected:
-  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
-      int clicked_index, const std::vector<int>& selected_indices) override;
+  [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
+                                             const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -40,6 +40,8 @@ class ModulesDataView : public DataView {
   void UpdateModules(const orbit_client_data::ProcessData* process);
 
  protected:
+  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
+      int clicked_index, const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -53,6 +53,8 @@ class PresetsDataView : public DataView {
     uint32_t function_count;
   };
 
+  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
+      int clicked_index, const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
   [[nodiscard]] static std::string GetModulesList(const std::vector<ModuleView>& modules);

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -53,8 +53,8 @@ class PresetsDataView : public DataView {
     uint32_t function_count;
   };
 
-  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
-      int clicked_index, const std::vector<int>& selected_indices) override;
+  [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
+                                             const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
   [[nodiscard]] static std::string GetModulesList(const std::vector<ModuleView>& modules);

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -50,6 +50,8 @@ class SamplingReportDataView : public DataView {
   orbit_client_data::ThreadID GetThreadID() const { return tid_; }
 
  protected:
+  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
+      int clicked_index, const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
   const orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row) const;

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -50,8 +50,8 @@ class SamplingReportDataView : public DataView {
   orbit_client_data::ThreadID GetThreadID() const { return tid_; }
 
  protected:
-  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
-      int clicked_index, const std::vector<int>& selected_indices) override;
+  [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
+                                             const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
   const orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row) const;

--- a/src/DataViews/include/DataViews/TracepointsDataView.h
+++ b/src/DataViews/include/DataViews/TracepointsDataView.h
@@ -33,8 +33,8 @@ class TracepointsDataView : public DataView {
   void SetTracepoints(const std::vector<orbit_grpc_protos::TracepointInfo>& tracepoints);
 
  private:
-  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
-      int clicked_index, const std::vector<int>& selected_indices) override;
+  [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
+                                             const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/TracepointsDataView.h
+++ b/src/DataViews/include/DataViews/TracepointsDataView.h
@@ -33,6 +33,8 @@ class TracepointsDataView : public DataView {
   void SetTracepoints(const std::vector<orbit_grpc_protos::TracepointInfo>& tracepoints);
 
  private:
+  [[nodiscard]] absl::flat_hash_map<std::string_view, bool> GetActionVisibilities(
+      int clicked_index, const std::vector<int>& selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 


### PR DESCRIPTION
**Updated**:
This PR added `GetActionStatus` for data views to determine the action status, which can be:
* `kInvisiable`: Action is not visible from the context menu;
* `kVisibleButDisabled`: Action is visible in the context menu, but is greyed out as being disabled.
* `kVisbleAndEnabled`: Action is visible and enabled in the context menu.

The goal is to make the context menu in data views have a consistent behavior with the context menu in top-down & bottom-up views: **All actions that could be invoked from this view are visible, and unavailable (i.e., disabled) actions are greyed out**.

To achieve this goal, we first change to let each individual views decide the action status in `GetActionStatus`. The next step would be let `DataView::GetMenuWithGrouping` to define the context menu order and get the action status from `GetActionStatus`.

Bug: http://b/205676296

<s>This PR adds `GetActionVisibilities` for data views to determine the visible actions and their availability.

To be specific, the `GetActionVisibilities` method returns a map with the visible action name as key,  and action availability (i.e., enabled or disabled) as value. For the current data view context menu, we only show enabled actions. That's why for different rows in the same data view, their context menus can be totally different.
As a contrast, the context menu of top-down and bottom-up views shows both the enabled & disabled actions.

Our goal is to make the context menu in data views have a consistent behavior with the context menu in top-down & bottom-up views: **All actions that could be invoked from this view are visible, and unavailable (i.e., disabled) actions are greyed out**.

To achieve this goal, we first change to let each individual views decide the visible actions (i.e., the actions we can see in the context menu) and their availabilities (i.e., grayed out or not) in `GetActionVisibilities`. 

The next step would be let `DataView::GetMenuWithGrouping` to define the context menu order and get the visible actions from `GetActionsVisibilities`. The full change is now tracked in https://github.com/google/orbit/pull/3378</s>

