### PR TITLE
Transition ServiceDeployManager to ErrorMessageOr

### DIFF
--- a/src/SessionSetup/ConnectToStadiaWidget.cpp
+++ b/src/SessionSetup/ConnectToStadiaWidget.cpp
@@ -311,7 +311,7 @@ void ConnectToStadiaWidget::DeployOrbitService() {
                        service_deploy_manager_.get(), &ServiceDeployManager::Cancel)};
 
   const auto deployment_result = service_deploy_manager_->Exec(metrics_uploader_);
-  if (!deployment_result) {
+  if (deployment_result.has_error()) {
     Disconnect();
     if (deployment_result.error() == make_error_code(Error::kUserCanceledServiceDeployment)) {
       return;

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -138,12 +138,7 @@ ConnectToTargetDialog::DeployOrbitService(
       QObject::connect(ui_->abortButton, &QPushButton::clicked, service_deploy_manager,
                        &ServiceDeployManager::Cancel)};
 
-  auto deployment_result = service_deploy_manager->Exec();
-  if (deployment_result.has_error()) {
-    return ErrorMessage{deployment_result.error().message()};
-  } else {
-    return deployment_result.value();
-  }
+  return service_deploy_manager->Exec();
 }
 
 void ConnectToTargetDialog::SetStatusMessage(const QString& message) {

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -49,7 +49,7 @@ class ServiceDeployManager : public QObject {
 
   ~ServiceDeployManager() override;
 
-  outcome::result<GrpcPort> Exec(
+  ErrorMessageOr<GrpcPort> Exec(
       orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
 
   // This method copies remote source file to local destination.
@@ -77,25 +77,25 @@ class ServiceDeployManager : public QObject {
 
   QThread background_thread_;
 
-  outcome::result<void> ConnectToServer();
-  outcome::result<bool> CheckIfInstalled();
-  outcome::result<void> CopyOrbitServicePackage();
-  outcome::result<void> CopyOrbitServiceExecutable(
+  ErrorMessageOr<void> ConnectToServer();
+  ErrorMessageOr<bool> CheckIfInstalled();
+  ErrorMessageOr<void> CopyOrbitServicePackage();
+  ErrorMessageOr<void> CopyOrbitServiceExecutable(
       const BareExecutableAndRootPasswordDeployment& config);
-  outcome::result<void> CopyOrbitApiLibrary(const BareExecutableAndRootPasswordDeployment& config);
-  outcome::result<void> CopyOrbitUserSpaceInstrumentationLibrary(
+  ErrorMessageOr<void> CopyOrbitApiLibrary(const BareExecutableAndRootPasswordDeployment& config);
+  ErrorMessageOr<void> CopyOrbitUserSpaceInstrumentationLibrary(
       const BareExecutableAndRootPasswordDeployment& config);
-  outcome::result<void> InstallOrbitServicePackage();
-  outcome::result<void> StartOrbitService();
-  outcome::result<void> StartOrbitServicePrivileged(
+  ErrorMessageOr<void> InstallOrbitServicePackage();
+  ErrorMessageOr<void> StartOrbitService();
+  ErrorMessageOr<void> StartOrbitServicePrivileged(
       const BareExecutableAndRootPasswordDeployment& config);
-  outcome::result<uint16_t> StartTunnel(std::optional<orbit_ssh_qt::Tunnel>* tunnel, uint16_t port);
-  outcome::result<std::unique_ptr<orbit_ssh_qt::SftpChannel>> StartSftpChannel();
-  outcome::result<void> ShutdownSftpChannel(orbit_ssh_qt::SftpChannel* sftp_channel);
-  outcome::result<void> ShutdownTunnel(orbit_ssh_qt::Tunnel* tunnel);
-  outcome::result<void> ShutdownTask(orbit_ssh_qt::Task* task);
-  outcome::result<void> ShutdownSession(orbit_ssh_qt::Session* session);
-  outcome::result<void> CopyFileToRemote(
+  ErrorMessageOr<uint16_t> StartTunnel(std::optional<orbit_ssh_qt::Tunnel>* tunnel, uint16_t port);
+  ErrorMessageOr<std::unique_ptr<orbit_ssh_qt::SftpChannel>> StartSftpChannel();
+  ErrorMessageOr<void> ShutdownSftpChannel(orbit_ssh_qt::SftpChannel* sftp_channel);
+  ErrorMessageOr<void> ShutdownTunnel(orbit_ssh_qt::Tunnel* tunnel);
+  ErrorMessageOr<void> ShutdownTask(orbit_ssh_qt::Task* task);
+  ErrorMessageOr<void> ShutdownSession(orbit_ssh_qt::Session* session);
+  ErrorMessageOr<void> CopyFileToRemote(
       const std::string& source, const std::string& dest,
       orbit_ssh_qt::SftpCopyToRemoteOperation::FileMode dest_mode);
 
@@ -107,7 +107,7 @@ class ServiceDeployManager : public QObject {
 
   void CopyFileToLocalImpl(orbit_base::Promise<ErrorMessageOr<void>> promise,
                            std::string_view source, std::string_view destination);
-  outcome::result<GrpcPort> ExecImpl();
+  ErrorMessageOr<GrpcPort> ExecImpl();
 
   void StartWatchdog();
 


### PR DESCRIPTION
The `ServiceDeployManager` used to still use the outcome::result type
directly instead of relying on ErrorMessageOr. This commit replaces
`outcome::result` by `ErrorMessageOr`.

`orbit_session_setup::Error` is still in use to generate the error message strings.

Bug: http://b/221369463