### PR TITLE
Transition orbit_qt_utils::EventLoop to ErrorMessageOr

### DIFF
--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -58,8 +58,8 @@ template <typename Func>
 [[nodiscard]] orbit_ssh_qt::ScopedConnection ConnectErrorHandler(
     orbit_qt_utils::EventLoop* loop,
     const typename QtPrivate::FunctionPointer<Func>::Object* sender, Func signal) {
-  return orbit_ssh_qt::ScopedConnection{
-      QObject::connect(sender, signal, loop, &orbit_qt_utils::EventLoop::error)};
+  return orbit_ssh_qt::ScopedConnection{QObject::connect(
+      sender, signal, loop, qOverload<std::error_code>(&orbit_qt_utils::EventLoop::error))};
 }
 
 [[nodiscard]] orbit_ssh_qt::ScopedConnection ConnectCancelHandler(orbit_qt_utils::EventLoop* loop,


### PR DESCRIPTION
This changes `orbit_qt_utils::EventLoop::exec` to return an `ErrorMessageOr`
instead of a `outcome::result`. In addition there is a new overload of
`EventLoop::error` which accepts an `ErrorMessage`.

This allows us to better use the EventLoop in functions that return ErrorMessageOr.

Bug: http://b/221369463