### PR TITLE
Add missing include to DwarfSection.cpp

### DIFF
--- a/third_party/libunwindstack/DwarfSection.cpp
+++ b/third_party/libunwindstack/DwarfSection.cpp
@@ -16,6 +16,8 @@
 
 #include <stdint.h>
 
+#include <algorithm>
+
 #include <unwindstack/DwarfError.h>
 #include <unwindstack/DwarfLocation.h>
 #include <unwindstack/DwarfMemory.h>


### PR DESCRIPTION
The latest version of libc++ is cleaning up some transitive includes of
the `algorthim` header. That means we need to explicitly include the
header in some places.

More details here: http://cl/432861273