### PR TITLE
Let DataView decide the menu order

### DIFF
--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -149,45 +149,6 @@ DataView::ActionStatus CallstackDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionStatus in
-// DataView::GetContextMenuWithGrouping.
-std::vector<std::vector<std::string>> CallstackDataView::GetContextMenuWithGrouping(
-    int clicked_index, const std::vector<int>& selected_indices) {
-  bool enable_load = false;
-  bool enable_select = false;
-  bool enable_unselect = false;
-  bool enable_disassembly = false;
-  bool enable_source_code = false;
-  for (int index : selected_indices) {
-    CallstackDataViewFrame frame = GetFrameFromRow(index);
-    const FunctionInfo* function = frame.function;
-    const ModuleData* module = frame.module;
-
-    if (frame.function != nullptr && app_->IsCaptureConnected(app_->GetCaptureData())) {
-      enable_select |= !app_->IsFunctionSelected(*function) &&
-                       orbit_client_data::function_utils::IsFunctionSelectable(*function);
-      enable_unselect |= app_->IsFunctionSelected(*function);
-      enable_disassembly = true;
-      enable_source_code = true;
-    } else if (module != nullptr && !module->is_loaded()) {
-      enable_load = true;
-    }
-  }
-
-  std::vector<std::string> action_group;
-  if (enable_load) action_group.emplace_back(std::string{kMenuActionLoadSymbols});
-  if (enable_select) action_group.emplace_back(std::string{kMenuActionSelect});
-  if (enable_unselect) action_group.emplace_back(std::string{kMenuActionUnselect});
-  if (enable_disassembly) action_group.emplace_back(std::string{kMenuActionDisassembly});
-  if (enable_source_code) action_group.emplace_back(std::string{kMenuActionSourceCode});
-
-  std::vector<std::vector<std::string>> menu =
-      DataView::GetContextMenuWithGrouping(clicked_index, selected_indices);
-  menu.insert(menu.begin(), action_group);
-
-  return menu;
-}
-
 void CallstackDataView::DoFilter() {
   if (callstack_.frames_size() == 0) {
     return;

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -36,7 +36,10 @@ using orbit_data_views::CallstackDataView;
 using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::ContextMenuEntry;
+using orbit_data_views::FlattenContextMenu;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::GetActionIndexOnMenu;
+using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
 using orbit_data_views::kMenuActionDisassembly;
 using orbit_data_views::kMenuActionExportToCsv;
@@ -327,7 +330,7 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       });
 
   auto verify_context_menu_action_availability = [&](std::vector<int> selected_indices) {
-    std::vector<std::string> context_menu =
+    FlattenContextMenu context_menu =
         FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
@@ -396,7 +399,7 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
 
   constexpr uint64_t kFrameAddress = 0x3140;
   SetCallstackFromFrames({kFrameAddress});
-  std::vector<std::string> context_menu =
+  FlattenContextMenu context_menu =
       FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
@@ -426,44 +429,37 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Go to Disassembly
   {
-    const auto disassembly_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionDisassembly) -
-        context_menu.begin();
-    ASSERT_LT(disassembly_index, context_menu.size());
+    const int disassembly_index = GetActionIndexOnMenu(context_menu, kMenuActionDisassembly);
+    EXPECT_TRUE(disassembly_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, Disassemble)
         .Times(1)
         .WillOnce([&](int32_t /*pid*/, const FunctionInfo& function) {
           EXPECT_EQ(function.name(), kFunctionNames[0]);
         });
-    view_.OnContextMenu(std::string{kMenuActionDisassembly}, static_cast<int>(disassembly_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionDisassembly}, disassembly_index, {0});
   }
 
   // Go to Source code
   {
-    const auto source_code_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionSourceCode) -
-        context_menu.begin();
-    ASSERT_LT(source_code_index, context_menu.size());
+    const int source_code_index = GetActionIndexOnMenu(context_menu, kMenuActionSourceCode);
+    EXPECT_TRUE(source_code_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, ShowSourceCode).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionSourceCode}, static_cast<int>(source_code_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionSourceCode}, source_code_index, {0});
   }
 
   // Hook
   {
-    const auto hook_index = std::find(context_menu.begin(), context_menu.end(), kMenuActionSelect) -
-                            context_menu.begin();
-    ASSERT_LT(hook_index, context_menu.size());
+    const auto hook_index = GetActionIndexOnMenu(context_menu, kMenuActionSelect);
+    EXPECT_TRUE(hook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, SelectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionSelect}, static_cast<int>(hook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSelect}, hook_index, {0});
   }
 
   function_selected = true;
@@ -472,15 +468,13 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Unhook
   {
-    const auto unhook_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionUnselect) -
-        context_menu.begin();
-    ASSERT_LT(unhook_index, context_menu.size());
+    const auto unhook_index = GetActionIndexOnMenu(context_menu, kMenuActionUnselect);
+    EXPECT_TRUE(unhook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, DeselectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionUnselect}, static_cast<int>(unhook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionUnselect}, unhook_index, {0});
   }
 }
 

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -37,7 +37,7 @@ using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
 using orbit_data_views::GetActionIndexOnMenu;
 using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
@@ -330,8 +330,8 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       });
 
   auto verify_context_menu_action_availability = [&](std::vector<int> selected_indices) {
-    FlattenContextMenu context_menu =
-        FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
+    FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
+        view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
     CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
@@ -400,7 +400,7 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
   constexpr uint64_t kFrameAddress = 0x3140;
   SetCallstackFromFrames({kFrameAddress});
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Copy Selection
@@ -463,7 +463,8 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
   }
 
   function_selected = true;
-  context_menu = FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+  context_menu =
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Unhook

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -84,7 +84,7 @@ DataView::ActionStatus DataView::GetActionStatus(std::string_view action, int /*
   return ActionStatus::kInvisible;
 }
 
-std::vector<ActionGroup> DataView::GetContextMenuWithGrouping(
+std::vector<DataView::ActionGroup> DataView::GetContextMenuWithGrouping(
     int clicked_index, const std::vector<int>& selected_indices) {
   // GetContextmenuWithGrouping is called when OrbitTreeView::indexAt returns a valid index and
   // hence the selected_indices retrieved from OrbitTreeView::selectionModel()->selectedIndexes()
@@ -92,15 +92,15 @@ std::vector<ActionGroup> DataView::GetContextMenuWithGrouping(
   ORBIT_CHECK(!selected_indices.empty());
 
   std::vector<ActionGroup> menu;
-  auto try_add_action_group = [&](std::vector<std::string_view> actions) {
+  auto try_add_action_group = [&](std::vector<std::string_view> action_names) {
     ActionGroup action_group;
-    for (std::string_view action : actions) {
-      switch (GetActionStatus(action, clicked_index, selected_indices)) {
+    for (std::string_view action_name : action_names) {
+      switch (GetActionStatus(action_name, clicked_index, selected_indices)) {
         case ActionStatus::kVisibleAndEnabled:
-          action_group.emplace_back(action, true);
+          action_group.emplace_back(action_name, /*enabled=*/true);
           break;
         case ActionStatus::kVisibleButDisabled:
-          action_group.emplace_back(action, false);
+          action_group.emplace_back(action_name, /*enabled=*/false);
           break;
         case ActionStatus::kInvisible:
           break;

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -84,16 +84,49 @@ DataView::ActionStatus DataView::GetActionStatus(std::string_view action, int /*
   return ActionStatus::kInvisible;
 }
 
-std::vector<std::vector<std::string>> DataView::GetContextMenuWithGrouping(
-    int /*clicked_index*/, const std::vector<int>& selected_indices) {
+std::vector<ActionGroup> DataView::GetContextMenuWithGrouping(
+    int clicked_index, const std::vector<int>& selected_indices) {
   // GetContextmenuWithGrouping is called when OrbitTreeView::indexAt returns a valid index and
   // hence the selected_indices retrieved from OrbitTreeView::selectionModel()->selectedIndexes()
   // should not be empty.
   ORBIT_CHECK(!selected_indices.empty());
 
-  static std::vector<std::string> default_group = {std::string{kMenuActionCopySelection},
-                                                   std::string{kMenuActionExportToCsv}};
-  return {default_group};
+  std::vector<ActionGroup> menu;
+  auto try_add_action_group = [&](std::vector<std::string_view> actions) {
+    ActionGroup action_group;
+    for (std::string_view action : actions) {
+      switch (GetActionStatus(action, clicked_index, selected_indices)) {
+        case ActionStatus::kVisibleAndEnabled:
+          action_group.emplace_back(action, true);
+          break;
+        case ActionStatus::kVisibleButDisabled:
+          action_group.emplace_back(action, false);
+          break;
+        case ActionStatus::kInvisible:
+          break;
+      }
+    }
+    if (!action_group.empty()) menu.push_back(std::move(action_group));
+  };
+
+  // Hooking related actions
+  try_add_action_group({kMenuActionLoadSymbols, kMenuActionSelect, kMenuActionUnselect,
+                        kMenuActionEnableFrameTrack, kMenuActionDisableFrameTrack,
+                        kMenuActionVerifyFramePointers});
+
+  try_add_action_group({kMenuActionDisassembly, kMenuActionSourceCode});
+
+  // Navigating related actions
+  try_add_action_group({kMenuActionAddIterator, kMenuActionJumpToFirst, kMenuActionJumpToLast,
+                        kMenuActionJumpToMin, kMenuActionJumpToMax});
+
+  // Preset related actions
+  try_add_action_group({kMenuActionLoadPreset, kMenuActionDeletePreset, kMenuActionShowInExplorer});
+
+  // Exporting relate actions
+  try_add_action_group(
+      {kMenuActionCopySelection, kMenuActionExportToCsv, kMenuActionExportEventsToCsv});
+  return menu;
 }
 
 void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -15,33 +15,50 @@
 
 namespace orbit_data_views {
 
-// TODO(vickyliu) Update the unit tests.
-void CheckSingleAction(const std::vector<std::string>& context_menu, std::string_view action,
-                       ContextMenuEntry /*menu_entry*/) {
-  EXPECT_THAT(context_menu, testing::Contains(action));
+int GetActionIndexOnMenu(const FlattenContextMenu& context_menu, std::string_view action) {
+  auto matcher = [&action](std::pair<std::string, bool> action_name_and_availability) {
+    return action_name_and_availability.first == std::string{action};
+  };
+
+  const auto menu_index = static_cast<int>(
+      std::find_if(context_menu.begin(), context_menu.end(), matcher) - context_menu.begin());
+
+  if (menu_index == static_cast<int>(context_menu.size())) return kInvalidActionIndex;
+
+  return menu_index;
 }
 
-void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
+void CheckSingleAction(const FlattenContextMenu& context_menu, std::string_view action,
+                       ContextMenuEntry menu_entry) {
+  const int action_index = GetActionIndexOnMenu(context_menu, action);
+  EXPECT_TRUE(action_index != kInvalidActionIndex);
+
+  switch (menu_entry) {
+    case ContextMenuEntry::kEnabled:
+      EXPECT_TRUE(context_menu[action_index].second);
+      break;
+    case ContextMenuEntry::kDisabled:
+      EXPECT_FALSE(context_menu[action_index].second);
+  }
+}
+
+void CheckCopySelectionIsInvoked(const FlattenContextMenu& context_menu,
                                  const MockAppInterface& app, DataView& view,
                                  const std::string& expected_clipboard) {
-  const auto copy_selection_index =
-      std::find(context_menu.begin(), context_menu.end(), kMenuActionCopySelection) -
-      context_menu.begin();
-  ASSERT_LT(copy_selection_index, context_menu.size());
+  const int action_index = GetActionIndexOnMenu(context_menu, kMenuActionCopySelection);
+  EXPECT_TRUE(action_index != kInvalidActionIndex);
 
   std::string clipboard;
   EXPECT_CALL(app, SetClipboard).Times(1).WillOnce(testing::SaveArg<0>(&clipboard));
-  view.OnContextMenu(std::string{kMenuActionCopySelection}, static_cast<int>(copy_selection_index),
-                     {0});
+  view.OnContextMenu(std::string{kMenuActionCopySelection}, action_index, {0});
   EXPECT_EQ(clipboard, expected_clipboard);
 }
 
-void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
-                               const MockAppInterface& app, DataView& view,
-                               const std::string& expected_contents, std::string_view action_name) {
-  const auto action_index =
-      std::find(context_menu.begin(), context_menu.end(), action_name) - context_menu.begin();
-  ASSERT_LT(action_index, context_menu.size());
+void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const MockAppInterface& app,
+                               DataView& view, const std::string& expected_contents,
+                               std::string_view action_name) {
+  const int action_index = GetActionIndexOnMenu(context_menu, action_name);
+  EXPECT_TRUE(action_index != kInvalidActionIndex);
 
   ErrorMessageOr<orbit_base::TemporaryFile> temporary_file_or_error =
       orbit_base::TemporaryFile::Create();
@@ -54,7 +71,7 @@ void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
   temporary_file_or_error.value().CloseAndRemove();
 
   EXPECT_CALL(app, GetSaveFile).Times(1).WillOnce(testing::Return(temporary_file_path.string()));
-  view.OnContextMenu(std::string{action_name}, static_cast<int>(action_index), {0});
+  view.OnContextMenu(std::string{action_name}, action_index, {0});
 
   ErrorMessageOr<std::string> contents_or_error = orbit_base::ReadFileToString(temporary_file_path);
   ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());
@@ -62,12 +79,12 @@ void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
   EXPECT_EQ(contents_or_error.value(), expected_contents);
 }
 
-std::vector<std::string> FlattenContextMenuWithGrouping(
+FlattenContextMenu FlattenContextMenuWithGrouping(
     const std::vector<ActionGroup>& menu_with_grouping) {
-  std::vector<std::string> menu;
+  FlattenContextMenu menu;
   for (const ActionGroup& action_group : menu_with_grouping) {
     for (const auto& action_name_and_availability : action_group) {
-      menu.push_back(action_name_and_availability.first);
+      menu.push_back(action_name_and_availability);
     }
   }
   return menu;

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -79,7 +79,32 @@ void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const Moc
   EXPECT_EQ(contents_or_error.value(), expected_contents);
 }
 
-FlattenContextMenu FlattenContextMenuWithGrouping(
+void CheckContextMenuOrder(const FlattenContextMenu& context_menu) {
+  const std::vector<std::string_view> ordered_action_names = {
+      /* Hooking related actions */
+      kMenuActionLoadSymbols, kMenuActionSelect, kMenuActionUnselect, kMenuActionEnableFrameTrack,
+      kMenuActionDisableFrameTrack, kMenuActionVerifyFramePointers,
+      /* Disassembly & source code related actions */
+      kMenuActionDisassembly, kMenuActionSourceCode,
+      /* Navigating related actions */
+      kMenuActionAddIterator, kMenuActionJumpToFirst, kMenuActionJumpToLast, kMenuActionJumpToMin,
+      kMenuActionJumpToMax,
+      /* Preset related actions */
+      kMenuActionLoadPreset, kMenuActionDeletePreset, kMenuActionShowInExplorer,
+      /* Exporting related actions */
+      kMenuActionCopySelection, kMenuActionExportToCsv, kMenuActionExportEventsToCsv};
+
+  std::vector<int> visible_action_indices;
+  for (auto action_name : ordered_action_names) {
+    const int action_index = GetActionIndexOnMenu(context_menu, action_name);
+    if (action_index == kInvalidActionIndex) continue;
+    visible_action_indices.push_back(action_index);
+  }
+
+  EXPECT_TRUE(is_sorted(visible_action_indices.begin(), visible_action_indices.end()));
+}
+
+FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
     const std::vector<ActionGroup>& menu_with_grouping) {
   FlattenContextMenu menu;
   for (const ActionGroup& action_group : menu_with_grouping) {
@@ -87,6 +112,8 @@ FlattenContextMenu FlattenContextMenuWithGrouping(
       menu.push_back(action_name_and_availability);
     }
   }
+
+  CheckContextMenuOrder(menu);
   return menu;
 }
 

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -15,18 +15,10 @@
 
 namespace orbit_data_views {
 
+// TODO(vickyliu) Update the unit tests.
 void CheckSingleAction(const std::vector<std::string>& context_menu, std::string_view action,
-                       ContextMenuEntry menu_entry) {
-  switch (menu_entry) {
-    case ContextMenuEntry::kEnabled:
-      EXPECT_THAT(context_menu, testing::Contains(action));
-      return;
-    case ContextMenuEntry::kDisabled:
-      EXPECT_THAT(context_menu, testing::Not(testing::Contains(action)));
-      return;
-    default:
-      ORBIT_UNREACHABLE();
-  }
+                       ContextMenuEntry /*menu_entry*/) {
+  EXPECT_THAT(context_menu, testing::Contains(action));
 }
 
 void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
@@ -71,10 +63,12 @@ void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
 }
 
 std::vector<std::string> FlattenContextMenuWithGrouping(
-    const std::vector<std::vector<std::string>>& menu_with_grouping) {
+    const std::vector<ActionGroup>& menu_with_grouping) {
   std::vector<std::string> menu;
-  for (const std::vector<std::string>& action_group : menu_with_grouping) {
-    orbit_base::Append(menu, action_group);
+  for (const ActionGroup& action_group : menu_with_grouping) {
+    for (const auto& action_name_and_availability : action_group) {
+      menu.push_back(action_name_and_availability.first);
+    }
   }
   return menu;
 }

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -15,9 +15,9 @@
 
 namespace orbit_data_views {
 
-int GetActionIndexOnMenu(const FlattenContextMenu& context_menu, std::string_view action) {
-  auto matcher = [&action](std::pair<std::string, bool> action_name_and_availability) {
-    return action_name_and_availability.first == std::string{action};
+int GetActionIndexOnMenu(const FlattenContextMenu& context_menu, std::string_view action_name) {
+  auto matcher = [&action_name](DataView::Action action) {
+    return action.name == std::string{action_name};
   };
 
   const auto menu_index = static_cast<int>(
@@ -28,17 +28,18 @@ int GetActionIndexOnMenu(const FlattenContextMenu& context_menu, std::string_vie
   return menu_index;
 }
 
-void CheckSingleAction(const FlattenContextMenu& context_menu, std::string_view action,
+void CheckSingleAction(const FlattenContextMenu& context_menu, std::string_view action_name,
                        ContextMenuEntry menu_entry) {
-  const int action_index = GetActionIndexOnMenu(context_menu, action);
+  const int action_index = GetActionIndexOnMenu(context_menu, action_name);
   EXPECT_TRUE(action_index != kInvalidActionIndex);
+  const DataView::Action& action = context_menu[action_index];
 
   switch (menu_entry) {
     case ContextMenuEntry::kEnabled:
-      EXPECT_TRUE(context_menu[action_index].second);
+      EXPECT_TRUE(action.enabled);
       break;
     case ContextMenuEntry::kDisabled:
-      EXPECT_FALSE(context_menu[action_index].second);
+      EXPECT_FALSE(action.enabled);
   }
 }
 
@@ -105,12 +106,10 @@ void CheckContextMenuOrder(const FlattenContextMenu& context_menu) {
 }
 
 FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
-    const std::vector<ActionGroup>& menu_with_grouping) {
+    const std::vector<DataView::ActionGroup>& menu_with_grouping) {
   FlattenContextMenu menu;
-  for (const ActionGroup& action_group : menu_with_grouping) {
-    for (const auto& action_name_and_availability : action_group) {
-      menu.push_back(action_name_and_availability);
-    }
+  for (const DataView::ActionGroup& action_group : menu_with_grouping) {
+    for (const auto& action : action_group) menu.push_back(action);
   }
 
   CheckContextMenuOrder(menu);

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -13,21 +13,27 @@
 
 namespace orbit_data_views {
 
+using FlattenContextMenu = std::vector<std::pair<std::string, bool>>;
+
+constexpr int kInvalidActionIndex = -1;
+
+[[nodiscard]] int GetActionIndexOnMenu(const FlattenContextMenu& context_menu,
+                                       std::string_view action);
+
 enum class ContextMenuEntry { kEnabled, kDisabled };
 
-void CheckSingleAction(const std::vector<std::string>& context_menu, std::string_view action,
+void CheckSingleAction(const FlattenContextMenu& context_menu, std::string_view action,
                        ContextMenuEntry menu_entry);
 
-void CheckCopySelectionIsInvoked(const std::vector<std::string>& context_menu,
+void CheckCopySelectionIsInvoked(const FlattenContextMenu& flatten_context_menu,
                                  const MockAppInterface& app, DataView& view,
                                  const std::string& expected_clipboard);
 
-void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
-                               const MockAppInterface& app, DataView& view,
-                               const std::string& expected_contents,
+void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const MockAppInterface& app,
+                               DataView& view, const std::string& expected_contents,
                                std::string_view action_name = kMenuActionExportToCsv);
 
-std::vector<std::string> FlattenContextMenuWithGrouping(
+[[nodiscard]] FlattenContextMenu FlattenContextMenuWithGrouping(
     const std::vector<ActionGroup>& menu_with_grouping);
 
 }  // namespace orbit_data_views

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -28,7 +28,7 @@ void CheckExportToCsvIsInvoked(const std::vector<std::string>& context_menu,
                                std::string_view action_name = kMenuActionExportToCsv);
 
 std::vector<std::string> FlattenContextMenuWithGrouping(
-    const std::vector<std::vector<std::string>>& menu_with_grouping);
+    const std::vector<ActionGroup>& menu_with_grouping);
 
 }  // namespace orbit_data_views
 

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -13,16 +13,16 @@
 
 namespace orbit_data_views {
 
-using FlattenContextMenu = std::vector<std::pair<std::string, bool>>;
+using FlattenContextMenu = std::vector<DataView::Action>;
 
 constexpr int kInvalidActionIndex = -1;
 
 [[nodiscard]] int GetActionIndexOnMenu(const FlattenContextMenu& context_menu,
-                                       std::string_view action);
+                                       std::string_view action_name);
 
 enum class ContextMenuEntry { kEnabled, kDisabled };
 
-void CheckSingleAction(const FlattenContextMenu& context_menu, std::string_view action,
+void CheckSingleAction(const FlattenContextMenu& context_menu, std::string_view action_name,
                        ContextMenuEntry menu_entry);
 
 void CheckCopySelectionIsInvoked(const FlattenContextMenu& flatten_context_menu,
@@ -36,7 +36,7 @@ void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const Moc
 void CheckContextMenuOrder(const FlattenContextMenu& context_menu);
 
 [[nodiscard]] FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
-    const std::vector<ActionGroup>& menu_with_grouping);
+    const std::vector<DataView::ActionGroup>& menu_with_grouping);
 
 }  // namespace orbit_data_views
 

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -33,7 +33,9 @@ void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const Moc
                                DataView& view, const std::string& expected_contents,
                                std::string_view action_name = kMenuActionExportToCsv);
 
-[[nodiscard]] FlattenContextMenu FlattenContextMenuWithGrouping(
+void CheckContextMenuOrder(const FlattenContextMenu& context_menu);
+
+[[nodiscard]] FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
     const std::vector<ActionGroup>& menu_with_grouping);
 
 }  // namespace orbit_data_views

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -201,43 +201,6 @@ DataView::ActionStatus FunctionsDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionStatus in
-// DataView::GetContextMenuWithGrouping.
-std::vector<std::vector<std::string>> FunctionsDataView::GetContextMenuWithGrouping(
-    int clicked_index, const std::vector<int>& selected_indices) {
-  bool enable_select = false;
-  bool enable_unselect = false;
-  bool enable_enable_frame_track = false;
-  bool enable_disable_frame_track = false;
-
-  for (int index : selected_indices) {
-    const FunctionInfo& function = *GetFunctionInfoFromRow(index);
-    enable_select |= !app_->IsFunctionSelected(function) &&
-                     orbit_client_data::function_utils::IsFunctionSelectable(function);
-    enable_unselect |= app_->IsFunctionSelected(function);
-    enable_enable_frame_track |= !app_->IsFrameTrackEnabled(function);
-    enable_disable_frame_track |= app_->IsFrameTrackEnabled(function);
-  }
-
-  std::vector<std::string> action_group;
-  if (enable_select) action_group.emplace_back(std::string{kMenuActionSelect});
-  if (enable_unselect) action_group.emplace_back(std::string{kMenuActionUnselect});
-  action_group.emplace_back(std::string{kMenuActionDisassembly});
-  action_group.emplace_back(std::string{kMenuActionSourceCode});
-  if (enable_enable_frame_track) {
-    action_group.emplace_back(std::string{kMenuActionEnableFrameTrack});
-  }
-  if (enable_disable_frame_track) {
-    action_group.emplace_back(std::string{kMenuActionDisableFrameTrack});
-  }
-
-  std::vector<std::vector<std::string>> menu =
-      DataView::GetContextMenuWithGrouping(clicked_index, selected_indices);
-  menu.insert(menu.begin(), action_group);
-
-  return menu;
-}
-
 void FunctionsDataView::DoFilter() {
   filter_tokens_ = absl::StrSplit(absl::AsciiStrToLower(filter_), ' ');
 

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -28,7 +28,7 @@ using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
 using orbit_data_views::GetActionIndexOnMenu;
 using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
@@ -395,8 +395,8 @@ TEST_F(FunctionsDataViewTest, ContextMenuEntriesChangeOnFunctionState) {
   view_.AddFunctions({&functions_[0], &functions_[1], &functions_[2]});
 
   auto verify_context_menu_action_availability = [&](std::vector<int> selected_indices) {
-    FlattenContextMenu context_menu =
-        FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
+    FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
+        view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
     CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
@@ -459,7 +459,7 @@ TEST_F(FunctionsDataViewTest, GenericDataExportFunctionShowCorrectData) {
   view_.AddFunctions({&functions_[0]});
 
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
 
   // Copy Selection
   {

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -27,7 +27,10 @@ using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
+using orbit_data_views::FlattenContextMenu;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::GetActionIndexOnMenu;
+using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
 using orbit_data_views::kMenuActionDisableFrameTrack;
 using orbit_data_views::kMenuActionDisassembly;
@@ -392,7 +395,7 @@ TEST_F(FunctionsDataViewTest, ContextMenuEntriesChangeOnFunctionState) {
   view_.AddFunctions({&functions_[0], &functions_[1], &functions_[2]});
 
   auto verify_context_menu_action_availability = [&](std::vector<int> selected_indices) {
-    std::vector<std::string> context_menu =
+    FlattenContextMenu context_menu =
         FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
@@ -455,7 +458,7 @@ TEST_F(FunctionsDataViewTest, GenericDataExportFunctionShowCorrectData) {
 
   view_.AddFunctions({&functions_[0]});
 
-  std::vector<std::string> context_menu =
+  FlattenContextMenu context_menu =
       FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
 
   // Copy Selection

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -254,6 +254,8 @@ void LiveFunctionsDataView::DoSort() {
 
 DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
     std::string_view action, int clicked_index, const std::vector<int>& selected_indices) {
+  if (action == kMenuActionExportEventsToCsv) return ActionStatus::kVisibleAndEnabled;
+
   const CaptureData& capture_data = app_->GetCaptureData();
   if (action == kMenuActionJumpToFirst || action == kMenuActionJumpToLast ||
       action == kMenuActionJumpToMin || action == kMenuActionJumpToMax) {
@@ -326,80 +328,6 @@ DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
     }
   }
   return ActionStatus::kVisibleButDisabled;
-}
-
-// TODO(b/205676296): Remove this when we change to use GetActionStatus in
-// DataView::GetContextMenuWithGrouping.
-std::vector<std::vector<std::string>> LiveFunctionsDataView::GetContextMenuWithGrouping(
-    int clicked_index, const std::vector<int>& selected_indices) {
-  bool enable_select = false;
-  bool enable_unselect = false;
-  bool enable_disassembly = false;
-  bool enable_source_code = false;
-  bool enable_enable_frame_track = false;
-  bool enable_disable_frame_track = false;
-  bool enable_iterator = false;
-
-  const CaptureData& capture_data = app_->GetCaptureData();
-  for (int index : selected_indices) {
-    uint64_t instrumented_function_id = GetInstrumentedFunctionId(index);
-    const FunctionInfo& instrumented_function = *GetFunctionInfoFromRow(index);
-
-    if (app_->IsCaptureConnected(capture_data)) {
-      enable_select |=
-          !app_->IsFunctionSelected(instrumented_function) &&
-          orbit_client_data::function_utils::IsFunctionSelectable(instrumented_function);
-      enable_unselect |= app_->IsFunctionSelected(instrumented_function);
-      enable_disassembly = true;
-      enable_source_code = true;
-    }
-
-    const FunctionStats& stats = capture_data.GetFunctionStatsOrDefault(instrumented_function_id);
-    // We need at least one function call to a function so that adding iterators makes sense.
-    enable_iterator |= stats.count() > 0;
-
-    if (app_->IsCaptureConnected(capture_data)) {
-      enable_enable_frame_track |= !app_->IsFrameTrackEnabled(instrumented_function);
-      enable_disable_frame_track |= app_->IsFrameTrackEnabled(instrumented_function);
-    } else {
-      enable_enable_frame_track |= !capture_data.IsFrameTrackEnabled(instrumented_function_id);
-      enable_disable_frame_track |= capture_data.IsFrameTrackEnabled(instrumented_function_id);
-    }
-  }
-
-  std::vector<std::vector<std::string>> menu =
-      DataView::GetContextMenuWithGrouping(clicked_index, selected_indices);
-  menu.begin()->push_back(std::string{kMenuActionExportEventsToCsv});
-
-  std::vector<std::string> action_group;
-  if (enable_iterator) action_group.emplace_back(std::string{kMenuActionAddIterator});
-  // For now, these actions only make sense when one function is selected,
-  // so we don't show them otherwise.
-  if (selected_indices.size() == 1) {
-    uint64_t instrumented_function_id = GetInstrumentedFunctionId(selected_indices[0]);
-    const FunctionStats& stats = capture_data.GetFunctionStatsOrDefault(instrumented_function_id);
-    if (stats.count() > 0) {
-      action_group.insert(action_group.end(),
-                          {std::string{kMenuActionJumpToFirst}, std::string{kMenuActionJumpToLast},
-                           std::string{kMenuActionJumpToMin}, std::string{kMenuActionJumpToMax}});
-    }
-  }
-  menu.insert(menu.begin(), action_group);
-
-  action_group.clear();
-  if (enable_select) action_group.emplace_back(std::string{kMenuActionSelect});
-  if (enable_unselect) action_group.emplace_back(std::string{kMenuActionUnselect});
-  if (enable_disassembly) action_group.emplace_back(std::string{kMenuActionDisassembly});
-  if (enable_source_code) action_group.emplace_back(std::string{kMenuActionSourceCode});
-  if (enable_enable_frame_track) {
-    action_group.emplace_back(std::string{kMenuActionEnableFrameTrack});
-  }
-  if (enable_disable_frame_track) {
-    action_group.emplace_back(std::string{kMenuActionDisableFrameTrack});
-  }
-  menu.insert(menu.begin(), action_group);
-
-  return menu;
 }
 
 void LiveFunctionsDataView::OnIteratorRequested(const std::vector<int>& selection) {

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -37,7 +37,10 @@ using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
+using orbit_data_views::FlattenContextMenu;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::GetActionIndexOnMenu;
+using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionAddIterator;
 using orbit_data_views::kMenuActionCopySelection;
 using orbit_data_views::kMenuActionDisableFrameTrack;
@@ -325,7 +328,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
   });
 
   auto verify_context_menu_action_availability = [&](std::vector<int> selected_indices) {
-    std::vector<std::string> context_menu =
+    FlattenContextMenu context_menu =
         FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
@@ -415,7 +418,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
       .WillRepeatedly(testing::ReturnPointee(&frame_track_enabled));
 
   AddFunctionsByIndices({0});
-  std::vector<std::string> context_menu =
+  FlattenContextMenu context_menu =
       FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
@@ -471,104 +474,84 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Go to Disassembly
   {
-    const auto disassembly_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionDisassembly) -
-        context_menu.begin();
-    ASSERT_LT(disassembly_index, context_menu.size());
+    const int disassembly_index = GetActionIndexOnMenu(context_menu, kMenuActionDisassembly);
+    EXPECT_TRUE(disassembly_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, Disassemble)
         .Times(1)
         .WillOnce([&](int32_t /*pid*/, const FunctionInfo& function) {
           EXPECT_EQ(function.name(), kNames[0]);
         });
-    view_.OnContextMenu(std::string{kMenuActionDisassembly}, static_cast<int>(disassembly_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionDisassembly}, disassembly_index, {0});
   }
 
   // Go to Source code
   {
-    const auto source_code_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionSourceCode) -
-        context_menu.begin();
-    ASSERT_LT(source_code_index, context_menu.size());
+    const int source_code_index = GetActionIndexOnMenu(context_menu, kMenuActionDisassembly);
+    EXPECT_TRUE(source_code_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, ShowSourceCode).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionSourceCode}, static_cast<int>(source_code_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionSourceCode}, source_code_index, {0});
   }
 
   // Jump to first
   {
-    const auto jump_to_first_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionJumpToFirst) -
-        context_menu.begin();
-    ASSERT_LT(jump_to_first_index, context_menu.size());
+    const int jump_to_first_index = GetActionIndexOnMenu(context_menu, kMenuActionJumpToFirst);
+    EXPECT_TRUE(jump_to_first_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, JumpToTimerAndZoom)
         .Times(1)
         .WillOnce([](uint64_t /*function_id*/, JumpToTimerMode selection_mode) {
           EXPECT_EQ(selection_mode, JumpToTimerMode::kFirst);
         });
-    view_.OnContextMenu(std::string{kMenuActionJumpToFirst}, static_cast<int>(jump_to_first_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionJumpToFirst}, jump_to_first_index, {0});
   }
 
   // Jump to last
   {
-    const auto jump_to_last_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionJumpToLast) -
-        context_menu.begin();
-    ASSERT_LT(jump_to_last_index, context_menu.size());
+    const int jump_to_last_index = GetActionIndexOnMenu(context_menu, kMenuActionJumpToLast);
+    EXPECT_TRUE(jump_to_last_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, JumpToTimerAndZoom)
         .Times(1)
         .WillOnce([](uint64_t /*function_id*/, JumpToTimerMode selection_mode) {
           EXPECT_EQ(selection_mode, JumpToTimerMode::kLast);
         });
-    view_.OnContextMenu(std::string{kMenuActionJumpToLast}, static_cast<int>(jump_to_last_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionJumpToLast}, jump_to_last_index, {0});
   }
 
   // Jump to min
   {
-    const auto jump_to_min_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionJumpToMin) -
-        context_menu.begin();
-    ASSERT_LT(jump_to_min_index, context_menu.size());
+    const int jump_to_min_index = GetActionIndexOnMenu(context_menu, kMenuActionJumpToMin);
+    EXPECT_TRUE(jump_to_min_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, JumpToTimerAndZoom)
         .Times(1)
         .WillOnce([](uint64_t /*function_id*/, JumpToTimerMode selection_mode) {
           EXPECT_EQ(selection_mode, JumpToTimerMode::kMin);
         });
-    view_.OnContextMenu(std::string{kMenuActionJumpToMin}, static_cast<int>(jump_to_min_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionJumpToMin}, jump_to_min_index, {0});
   }
 
   // Jump to max
   {
-    const auto jump_to_max_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionJumpToMax) -
-        context_menu.begin();
-    ASSERT_LT(jump_to_max_index, context_menu.size());
+    const int jump_to_max_index = GetActionIndexOnMenu(context_menu, kMenuActionJumpToMax);
+    EXPECT_TRUE(jump_to_max_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, JumpToTimerAndZoom)
         .Times(1)
         .WillOnce([](uint64_t /*function_id*/, JumpToTimerMode selection_mode) {
           EXPECT_EQ(selection_mode, JumpToTimerMode::kMax);
         });
-    view_.OnContextMenu(std::string{kMenuActionJumpToMax}, static_cast<int>(jump_to_max_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionJumpToMax}, jump_to_max_index, {0});
   }
 
   // Add iterator(s)
   {
-    const auto add_iterators_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionAddIterator) -
-        context_menu.begin();
-    ASSERT_LT(add_iterators_index, context_menu.size());
+    const int add_iterators_index = GetActionIndexOnMenu(context_menu, kMenuActionAddIterator);
+    EXPECT_TRUE(add_iterators_index != kInvalidActionIndex);
 
     EXPECT_CALL(live_functions_, AddIterator)
         .Times(1)
@@ -576,28 +559,25 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
           EXPECT_EQ(instrumented_function_id, kFunctionIds[0]);
           EXPECT_EQ(function->name(), kNames[0]);
         });
-    view_.OnContextMenu(std::string{kMenuActionAddIterator}, static_cast<int>(add_iterators_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionAddIterator}, add_iterators_index, {0});
   }
 
   // Hook
   {
-    const auto hook_index = std::find(context_menu.begin(), context_menu.end(), kMenuActionSelect) -
-                            context_menu.begin();
-    ASSERT_LT(hook_index, context_menu.size());
+    const auto hook_index = GetActionIndexOnMenu(context_menu, kMenuActionSelect);
+    EXPECT_TRUE(hook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, SelectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionSelect}, static_cast<int>(hook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSelect}, hook_index, {0});
   }
 
   // Enable frame track(s)
   {
     const auto enable_frame_track_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionEnableFrameTrack) -
-        context_menu.begin();
-    ASSERT_LT(enable_frame_track_index, context_menu.size());
+        GetActionIndexOnMenu(context_menu, kMenuActionEnableFrameTrack);
+    EXPECT_TRUE(enable_frame_track_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, SelectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kNames[0]);
@@ -606,8 +586,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, AddFrameTrack(testing::A<const orbit_client_protos::FunctionInfo&>()))
         .Times(1)
         .WillOnce([&](const FunctionInfo& function) { EXPECT_EQ(function.name(), kNames[0]); });
-    view_.OnContextMenu(std::string{kMenuActionEnableFrameTrack},
-                        static_cast<int>(enable_frame_track_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionEnableFrameTrack}, enable_frame_track_index, {0});
   }
 
   function_selected = true;
@@ -618,10 +597,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Unhook
   {
-    const auto unhook_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionUnselect) -
-        context_menu.begin();
-    ASSERT_LT(unhook_index, context_menu.size());
+    const auto unhook_index = GetActionIndexOnMenu(context_menu, kMenuActionUnselect);
+    EXPECT_TRUE(unhook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, DeselectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kNames[0]);
@@ -630,15 +607,14 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, RemoveFrameTrack(testing::An<const FunctionInfo&>()))
         .Times(1)
         .WillOnce([&](const FunctionInfo& function) { EXPECT_EQ(function.name(), kNames[0]); });
-    view_.OnContextMenu(std::string{kMenuActionUnselect}, static_cast<int>(unhook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionUnselect}, unhook_index, {0});
   }
 
   // Disable frame track(s)
   {
     const auto disable_frame_track_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionDisableFrameTrack) -
-        context_menu.begin();
-    ASSERT_LT(disable_frame_track_index, context_menu.size());
+        GetActionIndexOnMenu(context_menu, kMenuActionDisableFrameTrack);
+    EXPECT_TRUE(disable_frame_track_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, DisableFrameTrack).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kNames[0]);
@@ -646,8 +622,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, RemoveFrameTrack(testing::An<const FunctionInfo&>()))
         .Times(1)
         .WillOnce([&](const FunctionInfo& function) { EXPECT_EQ(function.name(), kNames[0]); });
-    view_.OnContextMenu(std::string{kMenuActionDisableFrameTrack},
-                        static_cast<int>(disable_frame_track_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionDisableFrameTrack}, disable_frame_track_index, {0});
   }
 }
 

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -38,7 +38,7 @@ using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
 using orbit_data_views::GetActionIndexOnMenu;
 using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionAddIterator;
@@ -328,8 +328,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
   });
 
   auto verify_context_menu_action_availability = [&](std::vector<int> selected_indices) {
-    FlattenContextMenu context_menu =
-        FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
+    FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
+        view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
     CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
@@ -419,7 +419,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
 
   AddFunctionsByIndices({0});
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Copy Selection
@@ -592,7 +592,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
   function_selected = true;
   frame_track_enabled = true;
   capture_data_->EnableFrameTrack(kFunctionIds[0]);
-  context_menu = FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+  context_menu =
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Unhook

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -133,36 +133,6 @@ DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action,
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionStatus in
-// DataView::GetContextMenuWithGrouping.
-std::vector<std::vector<std::string>> ModulesDataView::GetContextMenuWithGrouping(
-    int clicked_index, const std::vector<int>& selected_indices) {
-  bool enable_load = false;
-  bool enable_verify = false;
-  for (int index : selected_indices) {
-    const ModuleData* module = GetModuleDataFromRow(index);
-    if (!module->is_loaded()) {
-      enable_load = true;
-    }
-
-    if (module->is_loaded()) {
-      enable_verify = true;
-    }
-  }
-
-  std::vector<std::string> action_group;
-  if (enable_load) action_group.emplace_back(std::string{kMenuActionLoadSymbols});
-  if (enable_verify && absl::GetFlag(FLAGS_enable_frame_pointer_validator)) {
-    action_group.emplace_back(std::string{kMenuActionVerifyFramePointers});
-  }
-
-  std::vector<std::vector<std::string>> menu =
-      DataView::GetContextMenuWithGrouping(clicked_index, selected_indices);
-  menu.insert(menu.begin(), action_group);
-
-  return menu;
-}
-
 void ModulesDataView::OnDoubleClicked(int index) {
   ModuleData* module_data = GetModuleDataFromRow(index);
   if (!module_data->is_loaded()) {

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -23,7 +23,7 @@ using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
 using orbit_data_views::GetActionIndexOnMenu;
 using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
@@ -122,7 +122,7 @@ TEST_F(ModulesDataViewTest, ColumnValuesAreCorrect) {
 TEST_F(ModulesDataViewTest, ContextMenuEntriesArePresent) {
   AddModulesByIndices({0});
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
 
   CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
   CheckSingleAction(context_menu, kMenuActionExportToCsv, ContextMenuEntry::kEnabled);
@@ -132,7 +132,7 @@ TEST_F(ModulesDataViewTest, ContextMenuEntriesArePresent) {
 TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
   AddModulesByIndices({0});
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Load Symbols

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -167,28 +167,6 @@ DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action,
   }
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionStatus in
-// DataView::GetContextMenuWithGrouping.
-std::vector<std::vector<std::string>> PresetsDataView::GetContextMenuWithGrouping(
-    int clicked_index, const std::vector<int>& selected_indices) {
-  // Note that the UI already enforces a single selection.
-  ORBIT_CHECK(selected_indices.size() == 1);
-
-  std::vector<std::string> action_group;
-  const PresetFile& preset = GetPreset(selected_indices[0]);
-  if (app_->GetPresetLoadState(preset).state != PresetLoadState::kNotLoadable) {
-    action_group.emplace_back(std::string{kMenuActionLoadPreset});
-  }
-  action_group.emplace_back(std::string{kMenuActionDeletePreset});
-  action_group.emplace_back(std::string{kMenuActionShowInExplorer});
-
-  std::vector<std::vector<std::string>> menu =
-      DataView::GetContextMenuWithGrouping(clicked_index, selected_indices);
-  menu.insert(menu.begin(), action_group);
-
-  return menu;
-}
-
 void PresetsDataView::OnLoadPresetRequested(const std::vector<int>& selection) {
   const PresetFile& preset = GetPreset(selection[0]);
   app_->LoadPreset(preset);

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -220,8 +220,9 @@ TEST_F(PresetsDataViewTest, CheckPresenceOfContextMenuEntries) {
 
   // Not loadable preset
   EXPECT_THAT(FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(1, {1})),
-              testing::ElementsAre(kMenuActionDeletePreset, kMenuActionShowInExplorer,
-                                   kMenuActionCopySelection, kMenuActionExportToCsv))
+              testing::ElementsAre(kMenuActionLoadPreset, kMenuActionDeletePreset,
+                                   kMenuActionShowInExplorer, kMenuActionCopySelection,
+                                   kMenuActionExportToCsv))
       << view_.GetValue(1, 1);
 
   // Partially loadable preset

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -28,7 +28,7 @@
 using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
 using orbit_data_views::GetActionIndexOnMenu;
 using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
@@ -216,7 +216,7 @@ TEST_F(PresetsDataViewTest, CheckPresenceOfContextMenuEntries) {
 
   auto verify_context_menu_action_availability = [&](int selected_index,
                                                      bool expect_load_preset_enabled) {
-    FlattenContextMenu context_menu = FlattenContextMenuWithGrouping(
+    FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
         view_.GetContextMenuWithGrouping(selected_index, {selected_index}));
 
     // Check always available actions
@@ -257,7 +257,7 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
 
   view_.SetPresets({preset_file0});
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Copy Selection
@@ -343,7 +343,7 @@ TEST_F(PresetsDataViewTest, CheckLoadPresetOnDoubleClick) {
 
   view_.SetPresets({preset_file0});
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   EXPECT_CALL(app_, LoadPreset)

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -39,7 +39,7 @@ using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
 using orbit_data_views::GetActionIndexOnMenu;
 using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
@@ -379,7 +379,8 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         }
       }
     }
-    return FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_rows));
+    return FlattenContextMenuWithGroupingAndCheckOrder(
+        view_.GetContextMenuWithGrouping(0, selected_rows));
   };
 
   auto verify_context_menu_action_availability = [&](const std::vector<int>& selected_indices) {
@@ -478,7 +479,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
 
   AddFunctionsByIndices({0});
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Copy Selection
@@ -543,7 +544,8 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
   }
 
   function_selected = true;
-  context_menu = FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+  context_menu =
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Unhook
@@ -558,7 +560,8 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
   }
 
   AddFunctionsByIndices({2});
-  context_menu = FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+  context_menu =
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Load Symbols

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -38,7 +38,10 @@ using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
+using orbit_data_views::FlattenContextMenu;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::GetActionIndexOnMenu;
+using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
 using orbit_data_views::kMenuActionDisassembly;
 using orbit_data_views::kMenuActionExportToCsv;
@@ -366,7 +369,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       });
 
   auto get_context_menu_from_selected_indices =
-      [&](const std::vector<int>& selected_indices) -> std::vector<std::string> {
+      [&](const std::vector<int>& selected_indices) -> FlattenContextMenu {
     std::vector<int> selected_rows;
     for (int index : selected_indices) {
       for (int row = 0, row_counts = view_.GetNumElements(); row < row_counts; row++) {
@@ -380,8 +383,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
   };
 
   auto verify_context_menu_action_availability = [&](const std::vector<int>& selected_indices) {
-    std::vector<std::string> context_menu =
-        get_context_menu_from_selected_indices(selected_indices);
+    FlattenContextMenu context_menu = get_context_menu_from_selected_indices(selected_indices);
 
     // Common actions should always be available.
     CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
@@ -475,7 +477,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
           });
 
   AddFunctionsByIndices({0});
-  std::vector<std::string> context_menu =
+  FlattenContextMenu context_menu =
       FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
@@ -507,44 +509,37 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Go to Disassembly
   {
-    const auto disassembly_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionDisassembly) -
-        context_menu.begin();
-    ASSERT_LT(disassembly_index, context_menu.size());
+    const int disassembly_index = GetActionIndexOnMenu(context_menu, kMenuActionDisassembly);
+    EXPECT_TRUE(disassembly_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, Disassemble)
         .Times(1)
         .WillOnce([&](int32_t /*pid*/, const FunctionInfo& function) {
           EXPECT_EQ(function.name(), kFunctionNames[0]);
         });
-    view_.OnContextMenu(std::string{kMenuActionDisassembly}, static_cast<int>(disassembly_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionDisassembly}, disassembly_index, {0});
   }
 
   // Go to Source code
   {
-    const auto source_code_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionSourceCode) -
-        context_menu.begin();
-    ASSERT_LT(source_code_index, context_menu.size());
+    const int source_code_index = GetActionIndexOnMenu(context_menu, kMenuActionSourceCode);
+    EXPECT_TRUE(source_code_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, ShowSourceCode).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionSourceCode}, static_cast<int>(source_code_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionSourceCode}, source_code_index, {0});
   }
 
   // Hook
   {
-    const auto hook_index = std::find(context_menu.begin(), context_menu.end(), kMenuActionSelect) -
-                            context_menu.begin();
-    ASSERT_LT(hook_index, context_menu.size());
+    const int hook_index = GetActionIndexOnMenu(context_menu, kMenuActionSelect);
+    EXPECT_TRUE(hook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, SelectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionSelect}, static_cast<int>(hook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSelect}, hook_index, {0});
   }
 
   function_selected = true;
@@ -553,15 +548,13 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Unhook
   {
-    const auto unhook_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionUnselect) -
-        context_menu.begin();
-    ASSERT_LT(unhook_index, context_menu.size());
+    const int unhook_index = GetActionIndexOnMenu(context_menu, kMenuActionUnselect);
+    EXPECT_TRUE(unhook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, DeselectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
       EXPECT_EQ(function.name(), kFunctionNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionUnselect}, static_cast<int>(unhook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionUnselect}, unhook_index, {0});
   }
 
   AddFunctionsByIndices({2});
@@ -570,10 +563,8 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Load Symbols
   {
-    const auto load_symbols_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionLoadSymbols) -
-        context_menu.begin();
-    ASSERT_LT(load_symbols_index, context_menu.size());
+    const int load_symbols_index = GetActionIndexOnMenu(context_menu, kMenuActionLoadSymbols);
+    EXPECT_TRUE(load_symbols_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, GetMutableModuleByPathAndBuildId)
         .Times(1)
@@ -584,8 +575,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, RetrieveModulesAndLoadSymbols)
         .Times(1)
         .WillOnce(testing::Return(orbit_base::Future<void>{}));
-    view_.OnContextMenu(std::string{kMenuActionLoadSymbols}, static_cast<int>(load_symbols_index),
-                        {0});
+    view_.OnContextMenu(std::string{kMenuActionLoadSymbols}, load_symbols_index, {0});
   }
 }
 

--- a/src/DataViews/TracepointsDataView.cpp
+++ b/src/DataViews/TracepointsDataView.cpp
@@ -125,29 +125,6 @@ DataView::ActionStatus TracepointsDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-// TODO(b/205676296): Remove this when we change to use GetActionStatus in
-// DataView::GetContextMenuWithGrouping.
-std::vector<std::vector<std::string>> TracepointsDataView::GetContextMenuWithGrouping(
-    int clicked_index, const std::vector<int>& selected_indices) {
-  bool enable_select = false;
-  bool enable_unselect = false;
-  for (int index : selected_indices) {
-    const TracepointInfo& tracepoint = GetTracepoint(index);
-    enable_select |= !app_->IsTracepointSelected(tracepoint);
-    enable_unselect |= app_->IsTracepointSelected(tracepoint);
-  }
-
-  std::vector<std::string> action_group;
-  if (enable_select) action_group.emplace_back(std::string{kMenuActionSelect});
-  if (enable_unselect) action_group.emplace_back(std::string{kMenuActionUnselect});
-
-  std::vector<std::vector<std::string>> menu =
-      DataView::GetContextMenuWithGrouping(clicked_index, selected_indices);
-  menu.insert(menu.begin(), action_group);
-
-  return menu;
-}
-
 void TracepointsDataView::OnSelectRequested(const std::vector<int>& selection) {
   for (int i : selection) {
     app_->SelectTracepoint(GetTracepoint(i));

--- a/src/DataViews/TracepointsDataViewTest.cpp
+++ b/src/DataViews/TracepointsDataViewTest.cpp
@@ -16,7 +16,7 @@ using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
 using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
 using orbit_data_views::GetActionIndexOnMenu;
 using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
@@ -115,8 +115,8 @@ TEST_F(TracepointsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       });
 
   auto verify_context_menu_action_availability = [&](const std::vector<int>& selected_indices) {
-    FlattenContextMenu context_menu =
-        FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
+    FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
+        view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
     CheckSingleAction(context_menu, kMenuActionCopySelection, ContextMenuEntry::kEnabled);
@@ -152,7 +152,7 @@ TEST_F(TracepointsDataViewTest, ContextMenuActionsAreInvoked) {
 
   SetTracepointsByIndices({0});
   FlattenContextMenu context_menu =
-      FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Copy Selection
@@ -187,7 +187,8 @@ TEST_F(TracepointsDataViewTest, ContextMenuActionsAreInvoked) {
   }
 
   tracepoint_selected = true;
-  context_menu = FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
+  context_menu =
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
   // Unhook

--- a/src/DataViews/TracepointsDataViewTest.cpp
+++ b/src/DataViews/TracepointsDataViewTest.cpp
@@ -15,7 +15,10 @@ using orbit_data_views::CheckCopySelectionIsInvoked;
 using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::CheckSingleAction;
 using orbit_data_views::ContextMenuEntry;
+using orbit_data_views::FlattenContextMenu;
 using orbit_data_views::FlattenContextMenuWithGrouping;
+using orbit_data_views::GetActionIndexOnMenu;
+using orbit_data_views::kInvalidActionIndex;
 using orbit_data_views::kMenuActionCopySelection;
 using orbit_data_views::kMenuActionExportToCsv;
 using orbit_data_views::kMenuActionSelect;
@@ -112,7 +115,7 @@ TEST_F(TracepointsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       });
 
   auto verify_context_menu_action_availability = [&](const std::vector<int>& selected_indices) {
-    std::vector<std::string> context_menu =
+    FlattenContextMenu context_menu =
         FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, selected_indices));
 
     // Common actions should always be available.
@@ -148,7 +151,7 @@ TEST_F(TracepointsDataViewTest, ContextMenuActionsAreInvoked) {
       .WillRepeatedly(testing::ReturnPointee(&tracepoint_selected));
 
   SetTracepointsByIndices({0});
-  std::vector<std::string> context_menu =
+  FlattenContextMenu context_menu =
       FlattenContextMenuWithGrouping(view_.GetContextMenuWithGrouping(0, {0}));
   ASSERT_FALSE(context_menu.empty());
 
@@ -174,14 +177,13 @@ TEST_F(TracepointsDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Hook
   {
-    const auto hook_index = std::find(context_menu.begin(), context_menu.end(), kMenuActionSelect) -
-                            context_menu.begin();
-    ASSERT_LT(hook_index, context_menu.size());
+    const auto hook_index = GetActionIndexOnMenu(context_menu, kMenuActionSelect);
+    EXPECT_TRUE(hook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, SelectTracepoint).Times(1).WillOnce([&](const TracepointInfo& tracepoint) {
       EXPECT_EQ(tracepoint.name(), kTracepointNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionSelect}, static_cast<int>(hook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionSelect}, hook_index, {0});
   }
 
   tracepoint_selected = true;
@@ -190,15 +192,13 @@ TEST_F(TracepointsDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Unhook
   {
-    const auto unhook_index =
-        std::find(context_menu.begin(), context_menu.end(), kMenuActionUnselect) -
-        context_menu.begin();
-    ASSERT_LT(unhook_index, context_menu.size());
+    const auto unhook_index = GetActionIndexOnMenu(context_menu, kMenuActionUnselect);
+    EXPECT_TRUE(unhook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, DeselectTracepoint).Times(1).WillOnce([&](const TracepointInfo& tracepoint) {
       EXPECT_EQ(tracepoint.name(), kTracepointNames[0]);
     });
-    view_.OnContextMenu(std::string{kMenuActionUnselect}, static_cast<int>(unhook_index), {0});
+    view_.OnContextMenu(std::string{kMenuActionUnselect}, unhook_index, {0});
   }
 }
 

--- a/src/DataViews/include/DataViews/CallstackDataView.h
+++ b/src/DataViews/include/DataViews/CallstackDataView.h
@@ -25,8 +25,6 @@ class CallstackDataView : public DataView {
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnAddress; }
   bool IsSortingAllowed() override { return false; }
-  std::vector<std::vector<std::string>> GetContextMenuWithGrouping(
-      int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
   std::string GetToolTip(int row, int /*column*/) override;
 

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -62,8 +62,6 @@ constexpr std::string_view kMenuActionExportEventsToCsv = "Export events to CSV"
 // specification in https://tools.ietf.org/html/rfc4180.
 std::string FormatValueForCsv(std::string_view value);
 
-using ActionGroup = std::vector<std::pair<std::string, bool>>;
-
 class DataView {
  public:
   enum class SortingOrder {
@@ -79,6 +77,13 @@ class DataView {
     float ratio;
     SortingOrder initial_order;
   };
+
+  struct Action {
+    Action(std::string_view name, bool enabled) : name{std::move(name)}, enabled{enabled} {}
+    std::string name;
+    bool enabled;
+  };
+  using ActionGroup = std::vector<Action>;
 
   explicit DataView(DataViewType type, AppInterface* app)
       : update_period_ms_(-1), type_(type), app_{app} {}

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -62,6 +62,8 @@ constexpr std::string_view kMenuActionExportEventsToCsv = "Export events to CSV"
 // specification in https://tools.ietf.org/html/rfc4180.
 std::string FormatValueForCsv(std::string_view value);
 
+using ActionGroup = std::vector<std::pair<std::string, bool>>;
+
 class DataView {
  public:
   enum class SortingOrder {
@@ -98,8 +100,8 @@ class DataView {
   virtual const std::vector<Column>& GetColumns() = 0;
   virtual bool IsSortingAllowed() { return true; }
   virtual int GetDefaultSortingColumn() { return 0; }
-  virtual std::vector<std::vector<std::string>> GetContextMenuWithGrouping(
-      int clicked_index, const std::vector<int>& selected_indices);
+  std::vector<ActionGroup> GetContextMenuWithGrouping(int clicked_index,
+                                                      const std::vector<int>& selected_indices);
   virtual size_t GetNumElements() { return indices_.size(); }
   virtual std::string GetValue(int /*row*/, int /*column*/) { return ""; }
   virtual std::string GetValueForCopy(int row, int column) { return GetValue(row, column); }

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -26,8 +26,6 @@ class FunctionsDataView : public DataView {
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnAddressInModule; }
-  std::vector<std::vector<std::string>> GetContextMenuWithGrouping(
-      int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
   std::string GetLabel() override { return "Functions"; }
 

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -30,8 +30,6 @@ class LiveFunctionsDataView : public DataView {
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnCount; }
-  std::vector<std::vector<std::string>> GetContextMenuWithGrouping(
-      int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
   // As we allow single selection on Live tab, this method returns either an empty vector or a
   // single-value vector.

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -24,8 +24,6 @@ class ModulesDataView : public DataView {
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnFileSize; }
-  std::vector<std::vector<std::string>> GetContextMenuWithGrouping(
-      int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
 
   void OnDoubleClicked(int index) override;

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -26,8 +26,6 @@ class PresetsDataView : public DataView {
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnPresetName; }
-  std::vector<std::vector<std::string>> GetContextMenuWithGrouping(
-      int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
   std::string GetToolTip(int row, int column) override;
   std::string GetLabel() override { return "Presets"; }

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -29,8 +29,6 @@ class SamplingReportDataView : public DataView {
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnInclusive; }
-  std::vector<std::vector<std::string>> GetContextMenuWithGrouping(
-      int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
   std::string GetValueForCopy(int row, int column) override;
   std::string GetToolTip(int /*row*/, int /*column*/) override;

--- a/src/DataViews/include/DataViews/TracepointsDataView.h
+++ b/src/DataViews/include/DataViews/TracepointsDataView.h
@@ -23,8 +23,6 @@ class TracepointsDataView : public DataView {
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnCategory; }
-  std::vector<std::vector<std::string>> GetContextMenuWithGrouping(
-      int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
 
   void OnSelectRequested(const std::vector<int>& selection) override;

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -210,7 +210,7 @@ void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
     }
     std::vector<int> selected_indices(selection_set.begin(), selection_set.end());
 
-    const std::vector<std::vector<std::string>> menu_with_grouping =
+    const std::vector<orbit_data_views::ActionGroup> menu_with_grouping =
         model_->GetDataView()->GetContextMenuWithGrouping(clicked_index, selected_indices);
     if (menu_with_grouping.empty()) return;
 
@@ -219,11 +219,16 @@ void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
     for (size_t i = 0; i < menu_with_grouping.size(); ++i) {
       if (i > 0) context_menu.addSeparator();
 
-      for (const std::string& action_name : menu_with_grouping[i]) {
-        actions.push_back(std::make_unique<QAction>(QString::fromStdString(action_name)));
+      for (const std::pair<std::string, bool>& action_name_and_availability :
+           menu_with_grouping[i]) {
+        actions.push_back(
+            std::make_unique<QAction>(QString::fromStdString(action_name_and_availability.first)));
+        actions.back()->setEnabled(action_name_and_availability.second);
         size_t action_index = actions.size();
         connect(actions.back().get(), &QAction::triggered,
-                [this, action_name, action_index] { OnMenuClicked(action_name, action_index); });
+                [this, action_name_and_availability, action_index] {
+                  OnMenuClicked(action_name_and_availability.first, action_index);
+                });
         context_menu.addAction(actions.back().get());
       }
     }

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -210,7 +210,7 @@ void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
     }
     std::vector<int> selected_indices(selection_set.begin(), selection_set.end());
 
-    const std::vector<orbit_data_views::ActionGroup> menu_with_grouping =
+    const std::vector<orbit_data_views::DataView::ActionGroup> menu_with_grouping =
         model_->GetDataView()->GetContextMenuWithGrouping(clicked_index, selected_indices);
     if (menu_with_grouping.empty()) return;
 
@@ -219,16 +219,12 @@ void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
     for (size_t i = 0; i < menu_with_grouping.size(); ++i) {
       if (i > 0) context_menu.addSeparator();
 
-      for (const std::pair<std::string, bool>& action_name_and_availability :
-           menu_with_grouping[i]) {
-        actions.push_back(
-            std::make_unique<QAction>(QString::fromStdString(action_name_and_availability.first)));
-        actions.back()->setEnabled(action_name_and_availability.second);
+      for (const orbit_data_views::DataView::Action& action : menu_with_grouping[i]) {
+        actions.push_back(std::make_unique<QAction>(QString::fromStdString(action.name)));
+        actions.back()->setEnabled(action.enabled);
         size_t action_index = actions.size();
         connect(actions.back().get(), &QAction::triggered,
-                [this, action_name_and_availability, action_index] {
-                  OnMenuClicked(action_name_and_availability.first, action_index);
-                });
+                [this, action, action_index] { OnMenuClicked(action.name, action_index); });
         context_menu.addAction(actions.back().get());
       }
     }


### PR DESCRIPTION
With this change, we change the `DataView` to determine the menu order and grouping 
in `DataView::GetMenuWithGrouping`, and change each individual data views to decide action
status (i.e., `kInvisible`, `kVisibleButDisabled`, `kVisibleAndEnabled`) in `GetActionStatus`.

We temporarily changed the unit tests which checks the context menu entries to only check 
the appearances of visible and enabled actions (as the previous tests).
The test will be refactored to also check the menu order and action status.

Bug: http://b/205676296