### PR TITLE
Enable setting the StopCaptureReason

### DIFF
--- a/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
@@ -30,9 +30,11 @@ void CloudCollectorStartStopCaptureRequestWaiter::WaitForStopCaptureRequest() {
   ORBIT_LOG("Stopping capture");
 }
 
-void CloudCollectorStartStopCaptureRequestWaiter::StopCapture() {
+void CloudCollectorStartStopCaptureRequestWaiter::StopCapture(
+    CaptureServiceBase::StopCaptureReason stop_capture_reason) {
   absl::MutexLock lock(&stop_mutex_);
   ORBIT_LOG("Stop capture requested");
+  SetStopCaptureReason(stop_capture_reason);
   stop_requested_ = true;
 }
 

--- a/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
@@ -24,17 +24,19 @@ void CloudCollectorStartStopCaptureRequestWaiter::StartCapture(CaptureOptions ca
   start_requested_ = true;
 }
 
-void CloudCollectorStartStopCaptureRequestWaiter::WaitForStopCaptureRequest() {
+CaptureServiceBase::StopCaptureReason
+CloudCollectorStartStopCaptureRequestWaiter::WaitForStopCaptureRequest() {
   absl::MutexLock lock(&stop_mutex_);
   stop_mutex_.Await(absl::Condition(&stop_requested_));
   ORBIT_LOG("Stopping capture");
+  return stop_capture_reason_;
 }
 
 void CloudCollectorStartStopCaptureRequestWaiter::StopCapture(
     CaptureServiceBase::StopCaptureReason stop_capture_reason) {
   absl::MutexLock lock(&stop_mutex_);
   ORBIT_LOG("Stop capture requested");
-  SetStopCaptureReason(stop_capture_reason);
+  stop_capture_reason_ = std::move(stop_capture_reason);
   stop_requested_ = true;
 }
 

--- a/src/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.cpp
@@ -29,7 +29,7 @@ class GrpcStartStopCaptureRequestWaiter : public StartStopCaptureRequestWaiter {
     return request.capture_options();
   }
 
-  void WaitForStopCaptureRequest() override {
+  [[nodiscard]] CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() override {
     CaptureRequest request;
     // The client asks for the capture to be stopped by calling WritesDone. At that point, this
     // call to Read will return false. In the meantime, it blocks if no message is received.
@@ -37,10 +37,8 @@ class GrpcStartStopCaptureRequestWaiter : public StartStopCaptureRequestWaiter {
     while (reader_writer_->Read(&request)) {
     }
 
-    if (!GetStopCaptureReason().has_value()) {
-      SetStopCaptureReason(CaptureServiceBase::StopCaptureReason::kClientStop);
-    }
     ORBIT_LOG("Client finished writing on Capture's gRPC stream: stopping capture");
+    return CaptureServiceBase::StopCaptureReason::kClientStop;
   }
 
  private:

--- a/src/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.cpp
@@ -36,6 +36,10 @@ class GrpcStartStopCaptureRequestWaiter : public StartStopCaptureRequestWaiter {
     // Read also unblocks and returns false if the gRPC finishes.
     while (reader_writer_->Read(&request)) {
     }
+
+    if (!GetStopCaptureReason().has_value()) {
+      SetStopCaptureReason(CaptureServiceBase::StopCaptureReason::kClientStop);
+    }
     ORBIT_LOG("Client finished writing on Capture's gRPC stream: stopping capture");
   }
 

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -25,10 +25,9 @@ class CaptureServiceBase {
   void RemoveCaptureStartStopListener(CaptureStartStopListener* listener);
 
   enum class CaptureInitializationResult { kSuccess, kAlreadyInProgress };
-
- protected:
   enum class StopCaptureReason { kClientStop, kMemoryWatchdog };
 
+ protected:
   [[nodiscard]] CaptureInitializationResult InitializeCapture(
       orbit_producer_event_processor::ClientCaptureEventCollector* client_capture_event_collector);
   void TerminateCapture();

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -21,7 +21,7 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
   void StartCapture(orbit_grpc_protos::CaptureOptions capture_options);
 
   // WaitForStopCaptureRequest is blocked until StopCapture is called.
-  void WaitForStopCaptureRequest() override;
+  [[nodiscard]] CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() override;
   void StopCapture(CaptureServiceBase::StopCaptureReason stop_capture_reason);
 
  private:
@@ -30,6 +30,7 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
   bool start_requested_ ABSL_GUARDED_BY(start_mutex_) = false;
 
   mutable absl::Mutex stop_mutex_;
+  CaptureServiceBase::StopCaptureReason stop_capture_reason_ ABSL_GUARDED_BY(stop_mutex_);
   bool stop_requested_ ABSL_GUARDED_BY(stop_mutex_) = false;
 };
 

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -22,7 +22,7 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
 
   // WaitForStopCaptureRequest is blocked until StopCapture is called.
   void WaitForStopCaptureRequest() override;
-  void StopCapture();
+  void StopCapture(CaptureServiceBase::StopCaptureReason stop_capture_reason);
 
  private:
   mutable absl::Mutex start_mutex_;

--- a/src/CaptureServiceBase/include/CaptureServiceBase/StartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/StartStopCaptureRequestWaiter.h
@@ -5,6 +5,7 @@
 #ifndef CAPTURE_SERVICE_BASE_START_STOP_CAPTURE_REQUEST_WAITER_H_
 #define CAPTURE_SERVICE_BASE_START_STOP_CAPTURE_REQUEST_WAITER_H_
 
+#include "CaptureServiceBase/CaptureServiceBase.h"
 #include "GrpcProtos/capture.pb.h"
 
 namespace orbit_capture_service_base {
@@ -17,6 +18,16 @@ class StartStopCaptureRequestWaiter {
   virtual ~StartStopCaptureRequestWaiter() = default;
   [[nodiscard]] virtual orbit_grpc_protos::CaptureOptions WaitForStartCaptureRequest() = 0;
   virtual void WaitForStopCaptureRequest() = 0;
+
+  void SetStopCaptureReason(CaptureServiceBase::StopCaptureReason stop_capture_reason) {
+    stop_capture_reason_ = std::move(stop_capture_reason);
+  }
+  [[nodiscard]] std::optional<CaptureServiceBase::StopCaptureReason> GetStopCaptureReason() const {
+    return stop_capture_reason_;
+  }
+
+ private:
+  std::optional<CaptureServiceBase::StopCaptureReason> stop_capture_reason_;
 };
 
 }  // namespace orbit_capture_service_base

--- a/src/CaptureServiceBase/include/CaptureServiceBase/StartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/StartStopCaptureRequestWaiter.h
@@ -17,17 +17,7 @@ class StartStopCaptureRequestWaiter {
  public:
   virtual ~StartStopCaptureRequestWaiter() = default;
   [[nodiscard]] virtual orbit_grpc_protos::CaptureOptions WaitForStartCaptureRequest() = 0;
-  virtual void WaitForStopCaptureRequest() = 0;
-
-  void SetStopCaptureReason(CaptureServiceBase::StopCaptureReason stop_capture_reason) {
-    stop_capture_reason_ = std::move(stop_capture_reason);
-  }
-  [[nodiscard]] std::optional<CaptureServiceBase::StopCaptureReason> GetStopCaptureReason() const {
-    return stop_capture_reason_;
-  }
-
- private:
-  std::optional<CaptureServiceBase::StopCaptureReason> stop_capture_reason_;
+  [[nodiscard]] virtual CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() = 0;
 };
 
 }  // namespace orbit_capture_service_base

--- a/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
@@ -165,12 +165,9 @@ LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
         //   which blocks until the client has called WritesDone, or until we finish the
         //   gRPC (before the client has called WritesDone). In the latter case, the Read unblocks
         //   *after* LinuxCaptureServiceBase::DoCapture has returned, so we need to keep the thread
-        //   around and join it at a later time (we don't want to just detach it). If the
-        //   capture_stop_reason is not set yet, this will set the capture_stop_reason as
-        //   StopCaptureReason::kClientStop before returns.
+        //   around and join it at a later time (we don't want to just detach it).
         // - For a CloudCollectorStartStopCaptureRequestWaiter, this will wait until
-        //   CloudCollectorStartStopCaptureRequestWaiter::StopCapture is called externally, in which
-        //   we will set the CaptureStopReason.
+        //   CloudCollectorStartStopCaptureRequestWaiter::StopCapture is called externally.
         StopCaptureReason external_stop_reason =
             start_stop_capture_request_waiter->WaitForStopCaptureRequest();
 

--- a/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
@@ -151,28 +151,30 @@ class ProducerEventProcessorHijackingFunctionEntryExitForLinuxTracing
 
 }  // namespace
 
-CaptureServiceBase::StopCaptureReason
-LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
+void LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
     const std::shared_ptr<StartStopCaptureRequestWaiter>& start_stop_capture_request_waiter) {
   // wait_for_stop_capture_request_thread_ below outlives this method, hence the shared pointers.
   auto stop_capture_mutex = std::make_shared<absl::Mutex>();
   auto stop_capture = std::make_shared<bool>(false);
-  auto stop_capture_reason = std::make_shared<std::optional<StopCaptureReason>>();
 
-  wait_for_stop_capture_request_thread_ = std::thread{
-      [start_stop_capture_request_waiter, stop_capture_mutex, stop_capture, stop_capture_reason] {
-        // For a GrpcStartStopCaptureRequestWaiter, this will wait on ServerReaderWriter::Read,
-        // which blocks until the client has called WritesDone, or until we finish the
-        // gRPC (before the client has called WritesDone). In the latter case, the Read unblocks
-        // *after* LinuxCaptureServiceBase::DoCapture has returned, so we need to keep the thread
-        // around and join it at a later time (we don't want to just detach it).
+  wait_for_stop_capture_request_thread_ =
+      std::thread{[start_stop_capture_request_waiter, stop_capture_mutex, stop_capture] {
+        // - For a GrpcStartStopCaptureRequestWaiter, this will wait on ServerReaderWriter::Read,
+        //   which blocks until the client has called WritesDone, or until we finish the
+        //   gRPC (before the client has called WritesDone). In the latter case, the Read unblocks
+        //   *after* LinuxCaptureServiceBase::DoCapture has returned, so we need to keep the thread
+        //   around and join it at a later time (we don't want to just detach it). If the
+        //   capture_stop_reason is not set yet, this will set the capture_stop_reason as
+        //   StopCaptureReason::kClientStop before returns.
+        // - For a CloudCollectorStartStopCaptureRequestWaiter, this will wait until
+        //   CloudCollectorStartStopCaptureRequestWaiter::StopCapture is called externally, in which
+        //   we will set the CaptureStopReason.
         start_stop_capture_request_waiter->WaitForStopCaptureRequest();
 
         absl::MutexLock lock{stop_capture_mutex.get()};
         if (!*stop_capture) {
           ORBIT_LOG("Client finished writing on Capture's gRPC stream: stopping capture");
           *stop_capture = true;
-          *stop_capture_reason = StopCaptureReason::kClientStop;
         } else {
           ORBIT_LOG(
               "Client finished writing on Capture's gRPC stream or the RPC has already finished; "
@@ -205,18 +207,16 @@ LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
       ORBIT_LOG("Memory threshold exceeded: stopping capture (and stopping memory watchdog)");
       absl::MutexLock lock{stop_capture_mutex.get()};
       *stop_capture = true;
-      *stop_capture_reason = StopCaptureReason::kMemoryWatchdog;
+      if (!start_stop_capture_request_waiter->GetStopCaptureReason().has_value()) {
+        start_stop_capture_request_waiter->SetStopCaptureReason(StopCaptureReason::kMemoryWatchdog);
+      }
       break;
     }
   }
 
-  // The memory watchdog loop exits when either the client requested to stop the capture, or the
+  // The memory watchdog loop exits when either the stop capture is requested, or the
   // memory threshold was exceeded. So at that point we can proceed with stopping the capture.
-  {
-    absl::MutexLock lock{stop_capture_mutex.get()};
-    ORBIT_CHECK(stop_capture_reason->has_value());
-    return stop_capture_reason->value();
-  }
+  ORBIT_CHECK(start_stop_capture_request_waiter->GetStopCaptureReason().has_value());
 }
 
 CaptureServiceBase::CaptureInitializationResult LinuxCaptureServiceBase::DoCapture(
@@ -325,8 +325,7 @@ CaptureServiceBase::CaptureInitializationResult LinuxCaptureServiceBase::DoCaptu
     listener->OnCaptureStartRequested(capture_options, &function_entry_exit_hijacker);
   }
 
-  StopCaptureReason stop_capture_reason =
-      WaitForStopCaptureRequestOrMemoryThresholdExceeded(start_stop_capture_request_waiter);
+  WaitForStopCaptureRequestOrMemoryThresholdExceeded(start_stop_capture_request_waiter);
 
   // Disable Orbit API in tracee.
   if (capture_options.enable_api()) {
@@ -364,6 +363,8 @@ CaptureServiceBase::CaptureInitializationResult LinuxCaptureServiceBase::DoCaptu
   // The destructor of IntrospectionListener takes care of actually disabling introspection.
   introspection_listener.reset();
 
+  StopCaptureReason stop_capture_reason =
+      start_stop_capture_request_waiter->GetStopCaptureReason().value();
   FinalizeEventProcessing(stop_capture_reason);
 
   TerminateCapture();

--- a/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureServiceBase.h
+++ b/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureServiceBase.h
@@ -39,7 +39,8 @@ class LinuxCaptureServiceBase : public orbit_capture_service_base::CaptureServic
   // Note that start_stop_capture_request_waiter needs to be a shared_ptr here as it might outlive
   // this method. See wait_for_stop_capture_request_thread_ in
   // WaitForStopCaptureRequestOrMemoryThresholdExceeded.
-  orbit_capture_service_base::CaptureServiceBase::CaptureInitializationResult DoCapture(
+  [[nodiscard]] orbit_capture_service_base::CaptureServiceBase::CaptureInitializationResult
+  DoCapture(
       orbit_producer_event_processor::ClientCaptureEventCollector* client_capture_event_collector,
       const std::shared_ptr<orbit_capture_service_base::StartStopCaptureRequestWaiter>&
           start_stop_capture_request_waiter);
@@ -51,10 +52,12 @@ class LinuxCaptureServiceBase : public orbit_capture_service_base::CaptureServic
   // This method returns when the first of the following happens:
   // - start_stop_capture_request_waiter->WaitForStopCaptureRequest returns. For the native Orbit
   //   capture service with a GrpcStartStopCaptureRequestWaiter, this happens when the client calls
-  //   WritesDone on reader_writer;
+  //   WritesDone on reader_writer; For the cloud collector capture service with a
+  //   CloudCollectorStartStopCaptureRequestWaiter, this happends when
+  //   CloudCollectorStartStopCaptureRequestWaiter::StopCapture is called.
   // - The resident set size of the current process exceeds the threshold (i.e., total physical
   //   memory / 2).
-  [[nodiscard]] StopCaptureReason WaitForStopCaptureRequestOrMemoryThresholdExceeded(
+  void WaitForStopCaptureRequestOrMemoryThresholdExceeded(
       const std::shared_ptr<orbit_capture_service_base::StartStopCaptureRequestWaiter>&
           start_stop_capture_request_waiter);
   std::thread wait_for_stop_capture_request_thread_;

--- a/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureServiceBase.h
+++ b/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureServiceBase.h
@@ -57,7 +57,7 @@ class LinuxCaptureServiceBase : public orbit_capture_service_base::CaptureServic
   //   CloudCollectorStartStopCaptureRequestWaiter::StopCapture is called.
   // - The resident set size of the current process exceeds the threshold (i.e., total physical
   //   memory / 2).
-  void WaitForStopCaptureRequestOrMemoryThresholdExceeded(
+  [[nodiscard]] StopCaptureReason WaitForStopCaptureRequestOrMemoryThresholdExceeded(
       const std::shared_ptr<orbit_capture_service_base::StartStopCaptureRequestWaiter>&
           start_stop_capture_request_waiter);
   std::thread wait_for_stop_capture_request_thread_;

--- a/src/WindowsCaptureService/WindowsCaptureService.cpp
+++ b/src/WindowsCaptureService/WindowsCaptureService.cpp
@@ -47,13 +47,10 @@ grpc::Status WindowsCaptureService::Capture(
   StartEventProcessing(capture_options);
   TracingHandler tracing_handler{producer_event_processor_.get()};
   tracing_handler.Start(capture_options);
-  start_stop_capture_request_waiter->WaitForStopCaptureRequest();
+  StopCaptureReason stop_capture_reason =
+      start_stop_capture_request_waiter->WaitForStopCaptureRequest();
   tracing_handler.Stop();
-
-  std::optional<StopCaptureReason> stop_capture_reason =
-      start_stop_capture_request_waiter->GetStopCaptureReason();
-  ORBIT_CHECK(stop_capture_reason.has_value());
-  FinalizeEventProcessing(stop_capture_reason.value());
+  FinalizeEventProcessing(stop_capture_reason);
 
   TerminateCapture();
 

--- a/src/WindowsCaptureService/WindowsCaptureService.cpp
+++ b/src/WindowsCaptureService/WindowsCaptureService.cpp
@@ -49,7 +49,11 @@ grpc::Status WindowsCaptureService::Capture(
   tracing_handler.Start(capture_options);
   start_stop_capture_request_waiter->WaitForStopCaptureRequest();
   tracing_handler.Stop();
-  FinalizeEventProcessing(StopCaptureReason::kClientStop);
+
+  std::optional<StopCaptureReason> stop_capture_reason =
+      start_stop_capture_request_waiter->GetStopCaptureReason();
+  ORBIT_CHECK(stop_capture_reason.has_value());
+  FinalizeEventProcessing(stop_capture_reason.value());
 
   TerminateCapture();
 


### PR DESCRIPTION
With this change, we allow the `StartStopCaptureRequestWaiter` to set
the `StopCaptureReason`. This allows the CloudCollector to call
`StopCapture` with different reasons such as `kExceedsTimeDuration`,
`kUploaderStop`, `kSignalStop` and so on.

Bug: http://b/223124163