### PR TITLE
Enable CloudCollector to use GenerateCaptureFileName

### DIFF
--- a/src/ClientModel/BUILD
+++ b/src/ClientModel/BUILD
@@ -1,0 +1,28 @@
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+package(default_visibility = [
+    "//:__subpackages__",
+    "//:users",  
+])
+
+licenses(["notice"])
+
+cc_library(
+    name = "capture_serializer",
+    srcs = ["CaptureSerializer.cpp"],
+    hdrs = ["include/ClientModel/CaptureSerializer.h"],
+    compatible_with = ["//buildenv/target:gce"],
+    includes = ["include/"],
+    deps = [
+        "@com_google_net//net/proto2/io/public:io_lite",
+        "@com_google_net//net/proto2/public",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "//src/ClientProtos:capture_data_cc_proto",
+        "//src/GrpcProtos:module_cc_proto",
+        "//src/OrbitBase",
+    ],
+)

--- a/src/ClientModel/include/ClientModel/CaptureSerializer.h
+++ b/src/ClientModel/include/ClientModel/CaptureSerializer.h
@@ -14,7 +14,6 @@
 #include <filesystem>
 #include <string>
 
-#include "ClientData/CaptureData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"

--- a/src/ClientProtos/BUILD
+++ b/src/ClientProtos/BUILD
@@ -18,11 +18,19 @@ proto_library(
     srcs = ["user_defined_capture_info.proto"],
 )
 
+proto_library(
+    name = "capture_data_proto",
+    srcs = ["capture_data.proto"],
+)
+
 # CC Proto and GRPC Library targets
 
 cc_proto_library(
     name = "user_defined_capture_info_cc_proto",
-    deps = [
-        ":user_defined_capture_info_proto",
-    ],
+    deps = [":user_defined_capture_info_proto"],
+)
+
+cc_proto_library(
+    name = "capture_data_cc_proto",
+    deps = [":capture_data_proto"],
 )


### PR DESCRIPTION
Update build files for ClientModel and ClientProto such that the
CloudCollector will be able to use the GenerateCaptureFileName method.

Bug: http://b/220889136