### PR TITLE
Add StopCaptureReason::kExceededMaxDurationLimit

### DIFF
--- a/src/CaptureServiceBase/CaptureServiceBase.cpp
+++ b/src/CaptureServiceBase/CaptureServiceBase.cpp
@@ -77,6 +77,8 @@ void CaptureServiceBase::FinalizeEventProcessing(StopCaptureReason stop_capture_
     case StopCaptureReason::kMemoryWatchdog:
       capture_finished = CreateMemoryThresholdExceededCaptureFinishedEvent();
       break;
+    case StopCaptureReason::kExceededMaxDurationLimit:
+      capture_finished = CreateMaxCaptureDurationExceededCaptureFinishedEvent();
   }
   producer_event_processor_->ProcessEvent(orbit_grpc_protos::kRootProducerId,
                                           std::move(capture_finished));

--- a/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
@@ -29,7 +29,7 @@ CaptureServiceBase::StopCaptureReason
 CloudCollectorStartStopCaptureRequestWaiter::WaitForStopCaptureRequest() {
   absl::MutexLock lock(&stop_mutex_);
 
-  if (max_capture_duration_.has_value()) {
+  if (!max_capture_duration_.has_value()) {
     stop_mutex_.Await(absl::Condition(&stop_requested_));
   } else if (!stop_mutex_.AwaitWithDeadline(absl::Condition(&stop_requested_),
                                             capture_start_time_ + max_capture_duration_.value())) {

--- a/src/CaptureServiceBase/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureServiceBase/CommonProducerCaptureEventBuilders.cpp
@@ -97,6 +97,14 @@ ProducerCaptureEvent CreateMemoryThresholdExceededCaptureFinishedEvent() {
   return event;
 }
 
+ProducerCaptureEvent CreateMaxCaptureDurationExceededCaptureFinishedEvent() {
+  ProducerCaptureEvent event;
+  CaptureFinished* capture_finished = event.mutable_capture_finished();
+  capture_finished->set_status(CaptureFinished::kInterruptedByService);
+  capture_finished->set_error_message("Capture duration exceeded the maximum duration limit.");
+  return event;
+}
+
 ProducerCaptureEvent CreateClockResolutionEvent(uint64_t timestamp_ns, uint64_t resolution_ns) {
   ProducerCaptureEvent event;
   orbit_grpc_protos::ClockResolutionEvent* clock_resolution_event =

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -25,7 +25,7 @@ class CaptureServiceBase {
   void RemoveCaptureStartStopListener(CaptureStartStopListener* listener);
 
   enum class CaptureInitializationResult { kSuccess, kAlreadyInProgress };
-  enum class StopCaptureReason { kClientStop, kMemoryWatchdog };
+  enum class StopCaptureReason { kClientStop, kMemoryWatchdog, kExceededMaxDurationLimit };
 
  protected:
   [[nodiscard]] CaptureInitializationResult InitializeCapture(

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -39,7 +39,6 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
   bool stop_requested_ ABSL_GUARDED_BY(stop_mutex_) = false;
 
   std::optional<absl::Duration> max_capture_duration_;
-  absl::Time capture_start_time_;
 };
 
 }  // namespace orbit_capture_service_base

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -7,6 +7,7 @@
 
 #include <absl/base/thread_annotations.h>
 #include <absl/synchronization/mutex.h>
+#include <absl/time/time.h>
 
 #include "CaptureServiceBase/StartStopCaptureRequestWaiter.h"
 #include "GrpcProtos/capture.pb.h"
@@ -16,6 +17,10 @@ namespace orbit_capture_service_base {
 // A `StartStopCaptureRequestWaiter` implementation for the cloud collector.
 class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureRequestWaiter {
  public:
+  explicit CloudCollectorStartStopCaptureRequestWaiter(
+      std::optional<absl::Duration> max_capture_duration = std::nullopt)
+      : max_capture_duration_(max_capture_duration) {}
+
   // WaitForStartCaptureRequest is blocked until StartCapture is called.
   [[nodiscard]] orbit_grpc_protos::CaptureOptions WaitForStartCaptureRequest() override;
   void StartCapture(orbit_grpc_protos::CaptureOptions capture_options);
@@ -32,6 +37,9 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
   mutable absl::Mutex stop_mutex_;
   CaptureServiceBase::StopCaptureReason stop_capture_reason_ ABSL_GUARDED_BY(stop_mutex_);
   bool stop_requested_ ABSL_GUARDED_BY(stop_mutex_) = false;
+
+  std::optional<absl::Duration> max_capture_duration_;
+  absl::Time capture_start_time_;
 };
 
 }  // namespace orbit_capture_service_base

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CommonProducerCaptureEventBuilders.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CommonProducerCaptureEventBuilders.h
@@ -24,6 +24,9 @@ namespace orbit_capture_service_base {
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
 CreateMemoryThresholdExceededCaptureFinishedEvent();
 
+[[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
+CreateMaxCaptureDurationExceededCaptureFinishedEvent();
+
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateClockResolutionEvent(
     uint64_t timestamp_ns, uint64_t resolution_ns);
 


### PR DESCRIPTION
The purpose is to enable the CloudCollector to limit the capture length by a fixed time duration.

In this change, we enable the `CloudCollectorStartStopCaptureRequestWaiter` to stop waiting for 
the external stop capture request and stop the capture internally if the capture duration exceeds 
the maximum capture duration limit, e.g., 10 min.
Also a `StopCaptureReason::kExceededMaxDurationLimit` and the corresponding `CaptureFinishedEvent` 
are added for this case.

Bug: http://b/222681438
