### PR TITLE
Make all histogram bars of the same size and avoid overlap

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -115,6 +115,7 @@ target_sources(OrbitQtTests
         PRIVATE AccessibilityAdapterTest.cpp
                 AnnotatingSourceCodeDialogTest.cpp
                 CallTreeViewItemModelTest.cpp
+                HistogramWidgetTest.cpp
                 StatusListenerImplTest.cpp
                 TutorialOverlayTest.cpp
                 TrackTypeItemModelTest.cpp)

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -150,7 +150,7 @@ static void DrawHistogram(QPainter& painter, const QPoint& axes_intersection,
                           const orbit_statistics::Histogram& histogram, int horizontal_axis_length,
                           int vertical_axis_length, double max_freq, uint64_t min_value) {
   std::vector<int> widths =
-      orbit_qt::GenerateBinWidth(histogram.counts.size(), horizontal_axis_length);
+      orbit_qt::GenerateHistogramBinWidths(histogram.counts.size(), horizontal_axis_length);
 
   int left_x = axes_intersection.x() + kLineWidth / 2 +
                ValueToAxisLocation(histogram.min, horizontal_axis_length, min_value, histogram.max);
@@ -224,7 +224,8 @@ namespace orbit_qt {
 
 constexpr uint32_t kSeed = 31;
 
-[[nodiscard]] std::vector<int> GenerateBinWidth(size_t number_of_bins, int histogram_width) {
+[[nodiscard]] std::vector<int> GenerateHistogramBinWidths(size_t number_of_bins,
+                                                          int histogram_width) {
   std::mt19937 gen32(kSeed);
 
   const int narrower_width = histogram_width / number_of_bins;

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -150,7 +150,7 @@ static void DrawHistogram(QPainter& painter, const QPoint& axes_intersection,
                           const orbit_statistics::Histogram& histogram, int horizontal_axis_length,
                           int vertical_axis_length, double max_freq, uint64_t min_value) {
   std::vector<int> widths =
-      orbit_histogram_widget::GenerageBinWidth(histogram.counts.size(), horizontal_axis_length);
+      orbit_qt::GenerateBinWidth(histogram.counts.size(), horizontal_axis_length);
 
   int left_x = axes_intersection.x() + kLineWidth / 2 +
                ValueToAxisLocation(histogram.min, horizontal_axis_length, min_value, histogram.max);
@@ -220,11 +220,11 @@ static void DrawHint(QPainter& painter, int width) {
                     kHintSecondLineColor);
 }
 
-namespace orbit_histogram_widget {
+namespace orbit_qt {
 
 constexpr uint32_t kSeed = 31;
 
-[[nodiscard]] std::vector<int> GenerageBinWidth(size_t number_of_bins, int histogram_width) {
+[[nodiscard]] std::vector<int> GenerateBinWidth(size_t number_of_bins, int histogram_width) {
   std::mt19937 gen32(kSeed);
 
   const int narrower_width = histogram_width / number_of_bins;
@@ -416,4 +416,4 @@ constexpr size_t kMaxFunctionNameLengthForTitle = 80;
 
   return QString::fromStdString(title);
 }
-}  // namespace orbit_histogram_widget
+}  // namespace orbit_qt

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -148,6 +148,7 @@ static void DrawHistogram(QPainter& painter, const QPoint& axes_intersection,
 
   int left_x = axes_intersection.x() + kLineWidth / 2 +
                ValueToAxisLocation(histogram.min, horizontal_axis_length, min_value, histogram.max);
+  int color_index = 0;
 
   // If the number of bins exceeds the width of histogram in pixels, `widths[i]` might be zero.
   // In such case we plot the bar on top of the previous one
@@ -160,8 +161,10 @@ static void DrawHistogram(QPainter& painter, const QPoint& axes_intersection,
       const QPoint lower_right(left_x + std::max(widths[i] - 1, 0),
                                axes_intersection.y() - kLineWidth);
       const QRect bar(top_left, lower_right);
-      painter.fillRect(bar, kBarColors[i % kBarColors.size()]);
+      painter.fillRect(bar, kBarColors[color_index % kBarColors.size()]);
     }
+
+    if (widths[i] > 0) color_index++;
     left_x += widths[i];
   }
 }

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -20,6 +20,7 @@
 #include "App.h"
 #include "Statistics/Histogram.h"
 
+namespace orbit_histogram_widget {
 // Implements a widget that draws a histogram.
 // If the histogram is empty, draws a textual suggestion to select a function.
 class HistogramWidget : public QWidget {
@@ -80,5 +81,5 @@ class HistogramWidget : public QWidget {
 
   std::optional<SelectedArea> selected_area_;
 };
-
+}  // namespace orbit_histogram_widget
 #endif  // ORBIT_HISTOGRAM_H_

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -20,13 +20,13 @@
 #include "App.h"
 #include "Statistics/Histogram.h"
 
-namespace orbit_histogram_widget {
+namespace orbit_qt {
 
 // This method returns a vector specifying the width to be drawn for each bin of a histogram
 // Takes two positive intergers, returns a vector `result` of non-negative integers s.t.
 // their sum equals to `histogram_width` and for all `i` and `j` `max(result[i] - result[j]) <= 1`
 // `histogram_width` represents the width of the histogarm in pixels.
-[[nodiscard]] std::vector<int> GenerageBinWidth(size_t number_of_bins, int histogram_width);
+[[nodiscard]] std::vector<int> GenerateBinWidth(size_t number_of_bins, int histogram_width);
 
 // Implements a widget that draws a histogram.
 // If the histogram is empty, draws a textual suggestion to select a function.
@@ -88,5 +88,5 @@ class HistogramWidget : public QWidget {
 
   std::optional<SelectedArea> selected_area_;
 };
-}  // namespace orbit_histogram_widget
+}  // namespace orbit_qt
 #endif  // ORBIT_HISTOGRAM_H_

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -21,6 +21,13 @@
 #include "Statistics/Histogram.h"
 
 namespace orbit_histogram_widget {
+
+// This method returns a vector specifying the width to be drawn for each bin of a histogram
+// Takes two positive intergers, returns a vector `result` of non-negative integers s.t.
+// their sum equals to `histogram_width` and for all `i` and `j` `max(result[i] - result[j]) <= 1`
+// `histogram_width` represents the width of the histogarm in pixels.
+[[nodiscard]] std::vector<int> GenerageBinWidth(size_t number_of_bins, int histogram_width);
+
 // Implements a widget that draws a histogram.
 // If the histogram is empty, draws a textual suggestion to select a function.
 class HistogramWidget : public QWidget {

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -26,7 +26,8 @@ namespace orbit_qt {
 // Takes two positive intergers, returns a vector `result` of non-negative integers s.t.
 // their sum equals to `histogram_width` and for all `i` and `j` `max(result[i] - result[j]) <= 1`
 // `histogram_width` represents the width of the histogarm in pixels.
-[[nodiscard]] std::vector<int> GenerateBinWidth(size_t number_of_bins, int histogram_width);
+[[nodiscard]] std::vector<int> GenerateHistogramBinWidths(size_t number_of_bins,
+                                                          int histogram_width);
 
 // Implements a widget that draws a histogram.
 // If the histogram is empty, draws a textual suggestion to select a function.

--- a/src/OrbitQt/HistogramWidgetTest.cpp
+++ b/src/OrbitQt/HistogramWidgetTest.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "HistogramWidget.h"
+
+namespace orbit_histogram_widget {
+static void TestGetBinWidths(int number_of_bins, int histogram_width) {
+  const std::vector<int> widths = GenerageBinWidth(number_of_bins, histogram_width);
+  ASSERT_EQ(widths.size(), number_of_bins);
+  int sum = std::reduce(std::begin(widths), std::end(widths), 0);
+  ASSERT_EQ(sum, histogram_width);
+  int max = *std::max_element(std::begin(widths), std::end(widths));
+  int min = *std::min_element(std::begin(widths), std::end(widths));
+  ASSERT_LE(max - min, 1);
+  ASSERT_THAT(widths, testing::Each(testing::Ge(0)));
+}
+
+TEST(HistogramUtil, GetBinWidthIsCorrect) {
+  TestGetBinWidths(10, 100);
+  TestGetBinWidths(10, 115);
+  TestGetBinWidths(1, 115);
+  TestGetBinWidths(10, 2);
+  TestGetBinWidths(1, 1);
+}
+}  // namespace orbit_histogram_widget

--- a/src/OrbitQt/HistogramWidgetTest.cpp
+++ b/src/OrbitQt/HistogramWidgetTest.cpp
@@ -10,8 +10,8 @@
 #include "HistogramWidget.h"
 
 namespace orbit_qt {
-static void TestGetBinWidths(int number_of_bins, int histogram_width) {
-  const std::vector<int> widths = GenerateBinWidth(number_of_bins, histogram_width);
+static void TestGenerateHistogramBinWidths(int number_of_bins, int histogram_width) {
+  const std::vector<int> widths = GenerateHistogramBinWidths(number_of_bins, histogram_width);
   ASSERT_EQ(widths.size(), number_of_bins);
   int sum = std::reduce(std::begin(widths), std::end(widths), 0);
   ASSERT_EQ(sum, histogram_width);
@@ -21,11 +21,11 @@ static void TestGetBinWidths(int number_of_bins, int histogram_width) {
   ASSERT_THAT(widths, testing::Each(testing::Ge(0)));
 }
 
-TEST(HistogramUtil, GetBinWidthIsCorrect) {
-  TestGetBinWidths(10, 100);
-  TestGetBinWidths(10, 115);
-  TestGetBinWidths(1, 115);
-  TestGetBinWidths(10, 2);
-  TestGetBinWidths(1, 1);
+TEST(HistrogramWidget, GenerateHistogramBinWidthsIsCorrect) {
+  TestGenerateHistogramBinWidths(10, 100);
+  TestGenerateHistogramBinWidths(10, 115);
+  TestGenerateHistogramBinWidths(1, 115);
+  TestGenerateHistogramBinWidths(10, 2);
+  TestGenerateHistogramBinWidths(1, 1);
 }
 }  // namespace orbit_qt

--- a/src/OrbitQt/HistogramWidgetTest.cpp
+++ b/src/OrbitQt/HistogramWidgetTest.cpp
@@ -9,9 +9,9 @@
 
 #include "HistogramWidget.h"
 
-namespace orbit_histogram_widget {
+namespace orbit_qt {
 static void TestGetBinWidths(int number_of_bins, int histogram_width) {
-  const std::vector<int> widths = GenerageBinWidth(number_of_bins, histogram_width);
+  const std::vector<int> widths = GenerateBinWidth(number_of_bins, histogram_width);
   ASSERT_EQ(widths.size(), number_of_bins);
   int sum = std::reduce(std::begin(widths), std::end(widths), 0);
   ASSERT_EQ(sum, histogram_width);
@@ -28,4 +28,4 @@ TEST(HistogramUtil, GetBinWidthIsCorrect) {
   TestGetBinWidths(10, 2);
   TestGetBinWidths(1, 1);
 }
-}  // namespace orbit_histogram_widget
+}  // namespace orbit_qt

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -72,14 +72,16 @@ void OrbitLiveFunctions::Initialize(OrbitApp* app,
   dynamic_cast<QBoxLayout*>(ui->iteratorFrame->layout())
       ->insertWidget(ui->iteratorFrame->layout()->count() - 1, all_events_iterator_);
 
-  QObject::connect(ui->histogram_widget, &HistogramWidget::SignalSelectionRangeChange, this,
+  QObject::connect(ui->histogram_widget_,
+                   &orbit_histogram_widget::HistogramWidget::SignalSelectionRangeChange, this,
                    [this](std::optional<orbit_statistics::HistogramSelectionRange> range) {
                      emit SignalSelectionRangeChange(range);
                    });
 
-  ui->histogram_title_->setText(ui->histogram_widget->GetTitle());
-  QObject::connect(ui->histogram_widget, &HistogramWidget::SignalTitleChange, ui->histogram_title_,
-                   &QLabel::setText);
+  ui->histogram_title_->setText(ui->histogram_widget_->GetTitle());
+  QObject::connect(ui->histogram_widget_,
+                   &orbit_histogram_widget::HistogramWidget::SignalTitleChange,
+                   ui->histogram_title_, &QLabel::setText);
 }
 
 void OrbitLiveFunctions::Deinitialize() {
@@ -169,5 +171,5 @@ void OrbitLiveFunctions::OnRowSelected(std::optional<int> row) {
 
 void OrbitLiveFunctions::ShowHistogram(const std::vector<uint64_t>* data,
                                        const std::string& function_name, uint64_t function_id) {
-  ui->histogram_widget->UpdateData(data, function_name, function_id);
+  ui->histogram_widget_->UpdateData(data, function_name, function_id);
 }

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -72,15 +72,13 @@ void OrbitLiveFunctions::Initialize(OrbitApp* app,
   dynamic_cast<QBoxLayout*>(ui->iteratorFrame->layout())
       ->insertWidget(ui->iteratorFrame->layout()->count() - 1, all_events_iterator_);
 
-  QObject::connect(ui->histogram_widget_,
-                   &orbit_histogram_widget::HistogramWidget::SignalSelectionRangeChange, this,
-                   [this](std::optional<orbit_statistics::HistogramSelectionRange> range) {
+  QObject::connect(ui->histogram_widget_, &orbit_qt::HistogramWidget::SignalSelectionRangeChange,
+                   this, [this](std::optional<orbit_statistics::HistogramSelectionRange> range) {
                      emit SignalSelectionRangeChange(range);
                    });
 
   ui->histogram_title_->setText(ui->histogram_widget_->GetTitle());
-  QObject::connect(ui->histogram_widget_,
-                   &orbit_histogram_widget::HistogramWidget::SignalTitleChange,
+  QObject::connect(ui->histogram_widget_, &orbit_qt::HistogramWidget::SignalTitleChange,
                    ui->histogram_title_, &QLabel::setText);
 }
 

--- a/src/OrbitQt/orbitlivefunctions.ui
+++ b/src/OrbitQt/orbitlivefunctions.ui
@@ -80,7 +80,7 @@
          </widget>
         </item>
         <item>
-         <widget class="HistogramWidget" name="histogram_widget" native="true"/>
+         <widget class="orbit_histogram_widget::HistogramWidget" name="histogram_widget_" native="true"/>
         </item>
        </layout>
       </widget>

--- a/src/OrbitQt/orbitlivefunctions.ui
+++ b/src/OrbitQt/orbitlivefunctions.ui
@@ -80,7 +80,7 @@
          </widget>
         </item>
         <item>
-         <widget class="orbit_histogram_widget::HistogramWidget" name="histogram_widget_" native="true"/>
+         <widget class="orbit_qt::HistogramWidget" name="histogram_widget_" native="true"/>
         </item>
        </layout>
       </widget>

--- a/src/Statistics/Histogram.cpp
+++ b/src/Statistics/Histogram.cpp
@@ -6,11 +6,8 @@
 
 #include <absl/types/span.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <optional>
-#include <random>
-#include <vector>
 
 #include "HistogramUtils.h"
 #include "OrbitBase/Logging.h"
@@ -54,21 +51,6 @@ static Histogram BuildHistogramWithNumberOfBins(const std::optional<DataSet>& da
   }
 
   return best_histogram;
-}
-
-[[nodiscard]] std::vector<int> GetBinWidth(size_t number_of_bins, int histogram_width) {
-  const int narrower_width = histogram_width / number_of_bins;
-  const int wider_width = narrower_width + 1;
-
-  const int number_of_wider_bins = histogram_width % number_of_bins;
-  const int number_of_narrower_bins = number_of_bins - number_of_wider_bins;
-
-  std::vector<int> result(number_of_narrower_bins, narrower_width);
-  const std::vector<int> wider_widths(number_of_wider_bins, wider_width);
-  result.insert(std::end(result), std::begin(wider_widths), std::end(wider_widths));
-
-  std::shuffle(std::begin(result), std::end(result), std::default_random_engine{});
-  return result;
 }
 
 }  // namespace orbit_statistics

--- a/src/Statistics/Histogram.cpp
+++ b/src/Statistics/Histogram.cpp
@@ -6,8 +6,10 @@
 
 #include <absl/types/span.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
+#include <random>
 #include <vector>
 
 #include "HistogramUtils.h"
@@ -52,6 +54,21 @@ static Histogram BuildHistogramWithNumberOfBins(const std::optional<DataSet>& da
   }
 
   return best_histogram;
+}
+
+[[nodiscard]] std::vector<int> GetBinWidth(size_t number_of_bins, int histogram_width) {
+  const int narrower_width = histogram_width / number_of_bins;
+  const int wider_width = narrower_width + 1;
+
+  const int number_of_wider_bins = histogram_width % number_of_bins;
+  const int number_of_narrower_bins = number_of_bins - number_of_wider_bins;
+
+  std::vector<int> result(number_of_narrower_bins, narrower_width);
+  const std::vector<int> wider_widths(number_of_wider_bins, wider_width);
+  result.insert(std::end(result), std::begin(wider_widths), std::end(wider_widths));
+
+  std::shuffle(std::begin(result), std::end(result), std::default_random_engine{});
+  return result;
 }
 
 }  // namespace orbit_statistics

--- a/src/Statistics/HistogramTest.cpp
+++ b/src/Statistics/HistogramTest.cpp
@@ -166,4 +166,23 @@ TEST(Histogram, BuildHistogramCorrectlyChoosesTheBinWidth) {
   EXPECT_EQ(hist->counts.size(), 128);
 }
 
+static void TestGetBinWidths(int number_of_bins, int histogram_width) {
+  const std::vector<int> widths = GetBinWidth(number_of_bins, histogram_width);
+  ASSERT_EQ(widths.size(), number_of_bins);
+  int sum = std::reduce(std::begin(widths), std::end(widths), 0);
+  ASSERT_EQ(sum, histogram_width);
+  int max = *std::max_element(std::begin(widths), std::end(widths));
+  int min = *std::min_element(std::begin(widths), std::end(widths));
+  ASSERT_TRUE(max - min <= 1);
+  ASSERT_TRUE(std::all_of(std::begin(widths), std::end(widths),
+                          [](const int width) { return width >= 0; }));
+}
+
+TEST(HistogramUtil, GetBinWidthIsCorrect) {
+  TestGetBinWidths(10, 100);
+  TestGetBinWidths(10, 115);
+  TestGetBinWidths(1, 115);
+  TestGetBinWidths(10, 2);
+  TestGetBinWidths(1, 1);
+}
 }  // namespace orbit_statistics

--- a/src/Statistics/HistogramTest.cpp
+++ b/src/Statistics/HistogramTest.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <numeric>
@@ -166,23 +165,4 @@ TEST(Histogram, BuildHistogramCorrectlyChoosesTheBinWidth) {
   EXPECT_EQ(hist->counts.size(), 128);
 }
 
-static void TestGetBinWidths(int number_of_bins, int histogram_width) {
-  const std::vector<int> widths = GetBinWidth(number_of_bins, histogram_width);
-  ASSERT_EQ(widths.size(), number_of_bins);
-  int sum = std::reduce(std::begin(widths), std::end(widths), 0);
-  ASSERT_EQ(sum, histogram_width);
-  int max = *std::max_element(std::begin(widths), std::end(widths));
-  int min = *std::min_element(std::begin(widths), std::end(widths));
-  ASSERT_TRUE(max - min <= 1);
-  ASSERT_TRUE(std::all_of(std::begin(widths), std::end(widths),
-                          [](const int width) { return width >= 0; }));
-}
-
-TEST(HistogramUtil, GetBinWidthIsCorrect) {
-  TestGetBinWidths(10, 100);
-  TestGetBinWidths(10, 115);
-  TestGetBinWidths(1, 115);
-  TestGetBinWidths(10, 2);
-  TestGetBinWidths(1, 1);
-}
 }  // namespace orbit_statistics

--- a/src/Statistics/include/Statistics/Histogram.h
+++ b/src/Statistics/include/Statistics/Histogram.h
@@ -37,11 +37,6 @@ struct Histogram {
 // which minimizes it. The histogram will not own the data.
 [[nodiscard]] std::optional<Histogram> BuildHistogram(absl::Span<const uint64_t> data);
 
-// The functions aids histogram rendering.
-// Takes two positive intergers, returns a vector `result` of non-negative integers s.t.
-// their sum equals to `histogram_width` and for all `i` and `j` `max(result[i] - result[j]) <= 1`
-// `histogram_width` represents the width of the histogarm in pixels.
-[[nodiscard]] std::vector<int> GetBinWidth(size_t number_of_bins, int histogram_width);
 }  // namespace orbit_statistics
 
 #endif  // STATISTICS_HISTOGRAM_H_

--- a/src/Statistics/include/Statistics/Histogram.h
+++ b/src/Statistics/include/Statistics/Histogram.h
@@ -36,6 +36,12 @@ struct Histogram {
 // estimates the risk score using `HistogramRiskScore` and returns the histogram
 // which minimizes it. The histogram will not own the data.
 [[nodiscard]] std::optional<Histogram> BuildHistogram(absl::Span<const uint64_t> data);
+
+// The functions aids histogram rendering.
+// Takes two positive intergers, returns a vector `result` of non-negative integers s.t.
+// their sum equals to `histogram_width` and for all `i` and `j` `max(result[i] - result[j]) <= 1`
+// `histogram_width` represents the width of the histogarm in pixels.
+[[nodiscard]] std::vector<int> GetBinWidth(size_t number_of_bins, int histogram_width);
 }  // namespace orbit_statistics
 
 #endif  // STATISTICS_HISTOGRAM_H_


### PR DESCRIPTION
Histograms bars overlap. This became visible with the
alternating coloring. This fixes this.

Their width might be rather different due to rounding errors.
That is, it's possible to have one bar of width 1 and the other
bar of width 4. The max difference in pixel-width of the bars
rendered should not exceed one 1.
To this end we generate width of each bin beforehand.

Tests: Manual, Unit tests
Bug: http://b/223566472