### PR TITLE
Add more StopCaptureReason and CaptureFinished events for the CloudCollector

### DIFF
--- a/src/CaptureServiceBase/CaptureServiceBase.cpp
+++ b/src/CaptureServiceBase/CaptureServiceBase.cpp
@@ -84,8 +84,7 @@ void CaptureServiceBase::FinalizeEventProcessing(StopCaptureReason stop_capture_
           "Capture duration exceeded the maximum duration limit.");
       break;
     case StopCaptureReason::kGuestOrcConnectionFailure:
-      capture_finished =
-          CreateFailedCaptureFinishedEvent("Encountered GuestOrc connection failure.");
+      capture_finished = CreateFailedCaptureFinishedEvent("Connection with GuestOrc failed.");
       break;
   }
   producer_event_processor_->ProcessEvent(orbit_grpc_protos::kRootProducerId,

--- a/src/CaptureServiceBase/CaptureServiceBase.cpp
+++ b/src/CaptureServiceBase/CaptureServiceBase.cpp
@@ -72,13 +72,21 @@ void CaptureServiceBase::FinalizeEventProcessing(StopCaptureReason stop_capture_
   ProducerCaptureEvent capture_finished;
   switch (stop_capture_reason) {
     case StopCaptureReason::kClientStop:
+    case StopCaptureReason::kGuestOrcStop:
       capture_finished = CreateSuccessfulCaptureFinishedEvent();
       break;
     case StopCaptureReason::kMemoryWatchdog:
-      capture_finished = CreateMemoryThresholdExceededCaptureFinishedEvent();
+      capture_finished =
+          CreateInterruptedByServiceCaptureFinishedEvent("OrbitService was using too much memory.");
       break;
     case StopCaptureReason::kExceededMaxDurationLimit:
-      capture_finished = CreateMaxCaptureDurationExceededCaptureFinishedEvent();
+      capture_finished = CreateInterruptedByServiceCaptureFinishedEvent(
+          "Capture duration exceeded the maximum duration limit.");
+      break;
+    case StopCaptureReason::kGuestOrcConnectionFailure:
+      capture_finished =
+          CreateFailedCaptureFinishedEvent("Encountered GuestOrc connection failure.");
+      break;
   }
   producer_event_processor_->ProcessEvent(orbit_grpc_protos::kRootProducerId,
                                           std::move(capture_finished));

--- a/src/CaptureServiceBase/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureServiceBase/CommonProducerCaptureEventBuilders.cpp
@@ -89,19 +89,19 @@ ProducerCaptureEvent CreateSuccessfulCaptureFinishedEvent() {
   return event;
 }
 
-ProducerCaptureEvent CreateMemoryThresholdExceededCaptureFinishedEvent() {
+ProducerCaptureEvent CreateInterruptedByServiceCaptureFinishedEvent(std::string message) {
   ProducerCaptureEvent event;
   CaptureFinished* capture_finished = event.mutable_capture_finished();
   capture_finished->set_status(CaptureFinished::kInterruptedByService);
-  capture_finished->set_error_message("OrbitService was using too much memory.");
+  capture_finished->set_error_message(std::move(message));
   return event;
 }
 
-ProducerCaptureEvent CreateMaxCaptureDurationExceededCaptureFinishedEvent() {
+ProducerCaptureEvent CreateFailedCaptureFinishedEvent(std::string message) {
   ProducerCaptureEvent event;
   CaptureFinished* capture_finished = event.mutable_capture_finished();
-  capture_finished->set_status(CaptureFinished::kInterruptedByService);
-  capture_finished->set_error_message("Capture duration exceeded the maximum duration limit.");
+  capture_finished->set_status(CaptureFinished::kFailed);
+  capture_finished->set_error_message(std::move(message));
   return event;
 }
 

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -25,7 +25,13 @@ class CaptureServiceBase {
   void RemoveCaptureStartStopListener(CaptureStartStopListener* listener);
 
   enum class CaptureInitializationResult { kSuccess, kAlreadyInProgress };
-  enum class StopCaptureReason { kClientStop, kMemoryWatchdog, kExceededMaxDurationLimit };
+  enum class StopCaptureReason {
+    kClientStop,
+    kMemoryWatchdog,
+    kExceededMaxDurationLimit,
+    kGuestOrcStop,
+    kGuestOrcConnectionFailure,
+  };
 
  protected:
   [[nodiscard]] CaptureInitializationResult InitializeCapture(

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CommonProducerCaptureEventBuilders.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CommonProducerCaptureEventBuilders.h
@@ -11,6 +11,7 @@
 
 #include <string>
 
+#include "CaptureServiceBase/CaptureServiceBase.h"
 #include "GrpcProtos/capture.pb.h"
 
 namespace orbit_capture_service_base {
@@ -22,10 +23,10 @@ namespace orbit_capture_service_base {
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateSuccessfulCaptureFinishedEvent();
 
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
-CreateMemoryThresholdExceededCaptureFinishedEvent();
+CreateInterruptedByServiceCaptureFinishedEvent(std::string message);
 
-[[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent
-CreateMaxCaptureDurationExceededCaptureFinishedEvent();
+[[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateFailedCaptureFinishedEvent(
+    std::string message);
 
 [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent CreateClockResolutionEvent(
     uint64_t timestamp_ns, uint64_t resolution_ns);


### PR DESCRIPTION
StopCapture is requested under four cases for the CloudCollector. See
http://b/223124163 for more details.

In this change, we add the `StopCaptureReason`s and `CaptureFinished`
events for those cases.

Bug: http://b/223124163