### PR TITLE
Refactor drawing and cleaning in batcher

### DIFF
--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -364,12 +364,12 @@ void Batcher::ResetElements() {
   for (auto& [unused_layer, buffer] : primitive_buffers_by_layer_) {
     buffer.Reset();
   }
+  user_data_.clear();
 }
 
 void Batcher::StartNewFrame() {
   ORBIT_CHECK(translations_.IsEmpty());
   ResetElements();
-  user_data_.clear();
 }
 
 std::vector<float> Batcher::GetLayers() const {
@@ -405,7 +405,7 @@ void Batcher::DrawLayer(float layer, bool picking) const {
 }
 
 void Batcher::Draw(bool picking) const {
-  for (auto& [layer, unused_buffer] : primitive_buffers_by_layer_) {
+  for (float layer : GetLayers()) {
     DrawLayer(layer, picking);
   }
 }

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -163,10 +163,9 @@ class Batcher {
 
   void AddCircle(const Vec2& position, float radius, float z, Color color);
   [[nodiscard]] std::vector<float> GetLayers() const;
-  void DrawLayer(float layer, bool picking = false) const;
-  virtual void Draw(bool picking = false) const;
+  virtual void DrawLayer(float layer, bool picking = false) const;
+  void Draw(bool picking = false) const;
 
-  void ResetElements();
   void StartNewFrame();
 
   [[nodiscard]] PickingManager* GetPickingManager() const { return picking_manager_; }
@@ -209,6 +208,7 @@ class Batcher {
   void AddTriangleInternal(const Triangle& triangle, const std::array<Color, 3>& colors,
                            const Color& picking_color,
                            std::unique_ptr<PickingUserData> user_data = nullptr);
+  void ResetElements();
 };
 
 #endif

--- a/src/OrbitGl/BatcherTest.cpp
+++ b/src/OrbitGl/BatcherTest.cpp
@@ -36,51 +36,49 @@ class FakeBatcher : public Batcher {
   // Simulate drawing by simple appending all colors to internal
   // buffers. Only a single color per element will be appended
   // (start point for line, first vertex for triangle and box)
-  void Draw(bool picking = false) const override {
-    for (auto& [unused_layer, buffer] : primitive_buffers_by_layer_) {
-      if (picking) {
-        for (auto it = buffer.line_buffer.picking_colors_.begin();
-             it != buffer.line_buffer.picking_colors_.end();) {
-          drawn_line_colors_.push_back(*it);
-          ++it;
-          ++it;
-        }
-        for (auto it = buffer.triangle_buffer.picking_colors_.begin();
-             it != buffer.triangle_buffer.picking_colors_.end();) {
-          drawn_triangle_colors_.push_back(*it);
-          ++it;
-          ++it;
-          ++it;
-        }
-        for (auto it = buffer.box_buffer.picking_colors_.begin();
-             it != buffer.box_buffer.picking_colors_.end();) {
-          drawn_box_colors_.push_back(*it);
-          ++it;
-          ++it;
-          ++it;
-          ++it;
-        }
-      } else {
-        for (auto it = buffer.line_buffer.colors_.begin();
-             it != buffer.line_buffer.colors_.end();) {
-          drawn_line_colors_.push_back(*it);
-          ++it;
-          ++it;
-        }
-        for (auto it = buffer.triangle_buffer.colors_.begin();
-             it != buffer.triangle_buffer.colors_.end();) {
-          drawn_triangle_colors_.push_back(*it);
-          ++it;
-          ++it;
-          ++it;
-        }
-        for (auto it = buffer.box_buffer.colors_.begin(); it != buffer.box_buffer.colors_.end();) {
-          drawn_box_colors_.push_back(*it);
-          ++it;
-          ++it;
-          ++it;
-          ++it;
-        }
+  void DrawLayer(float layer, bool picking = false) const override {
+    auto& buffer = primitive_buffers_by_layer_.at(layer);
+    if (picking) {
+      for (auto it = buffer.line_buffer.picking_colors_.begin();
+           it != buffer.line_buffer.picking_colors_.end();) {
+        drawn_line_colors_.push_back(*it);
+        ++it;
+        ++it;
+      }
+      for (auto it = buffer.triangle_buffer.picking_colors_.begin();
+           it != buffer.triangle_buffer.picking_colors_.end();) {
+        drawn_triangle_colors_.push_back(*it);
+        ++it;
+        ++it;
+        ++it;
+      }
+      for (auto it = buffer.box_buffer.picking_colors_.begin();
+           it != buffer.box_buffer.picking_colors_.end();) {
+        drawn_box_colors_.push_back(*it);
+        ++it;
+        ++it;
+        ++it;
+        ++it;
+      }
+    } else {
+      for (auto it = buffer.line_buffer.colors_.begin(); it != buffer.line_buffer.colors_.end();) {
+        drawn_line_colors_.push_back(*it);
+        ++it;
+        ++it;
+      }
+      for (auto it = buffer.triangle_buffer.colors_.begin();
+           it != buffer.triangle_buffer.colors_.end();) {
+        drawn_triangle_colors_.push_back(*it);
+        ++it;
+        ++it;
+        ++it;
+      }
+      for (auto it = buffer.box_buffer.colors_.begin(); it != buffer.box_buffer.colors_.end();) {
+        drawn_box_colors_.push_back(*it);
+        ++it;
+        ++it;
+        ++it;
+        ++it;
       }
     }
   }
@@ -223,11 +221,6 @@ TEST(Batcher, MultipleDrawCalls) {
   auto line_color = batcher.GetDrawnLineColors()[0];
   auto triangle_color = batcher.GetDrawnTriangleColors()[0];
   auto box_color = batcher.GetDrawnBoxColors()[0];
-  ExpectCustomDataEq(batcher, line_color, line_custom_data);
-  ExpectCustomDataEq(batcher, triangle_color, triangle_custom_data);
-  ExpectCustomDataEq(batcher, box_color, box_custom_data);
-
-  batcher.ResetElements();
   ExpectCustomDataEq(batcher, line_color, line_custom_data);
   ExpectCustomDataEq(batcher, triangle_color, triangle_custom_data);
   ExpectCustomDataEq(batcher, box_color, box_custom_data);


### PR DESCRIPTION
In the process of creating an interface for batcher, we are first
cleaning the class a little bit.

This PR:
- Move user_data clear to ResetElements (more sense)
- Make ResetElements private (and will be pure virtual in the future).
  Batcher will only provide StartNewFrame method.
- We are making DrawLayer the virtual function (in the future pure
  virtual) instead of Draw which should have an only simple
  implementation for now.
- We are also updating BatcherTest (and erasing a few Expect that I
  think they don't provide any value).

Point 1 of http://b/223559986 (Part 2/3)

Next-PR: Divide between BatcherInterface and Impl.
Next-Next-PR: MockBatcher implementing the interface.