### PR TITLE
Temporary fix for CloudCollectorStartStopCaptureRequestWaiter

### DIFF
--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -27,7 +27,8 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
 
   // WaitForStopCaptureRequest is blocked until StopCapture is called.
   [[nodiscard]] CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() override;
-  void StopCapture(CaptureServiceBase::StopCaptureReason stop_capture_reason);
+  void StopCapture(CaptureServiceBase::StopCaptureReason stop_capture_reason =
+                       CaptureServiceBase::StopCaptureReason::kClientStop);
 
  private:
   mutable absl::Mutex start_mutex_;


### PR DESCRIPTION
The "StopCapture" interface change in #3399 broke internal code compilation.
Add default "StopCaptureReason" so that "StopCapture()" still compiles.

b/223656548