### PR TITLE
Fix focus for main window when connecting to a target

### DIFF
--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -16,11 +16,13 @@ from core.orbit_e2e import E2ETestCase, OrbitE2EError, wait_for_condition
 
 def _wait_for_main_window(application: Application, timeout=30):
     wait_for_condition(lambda: application.top_window().class_name() == "OrbitMainWindow", max_seconds=timeout)
+    application.top_window().set_focus()
 
 
 def _wait_for_connection_window(application: Application):
     wait_for_condition(lambda: application.top_window().class_name() == "orbit_session_setup::SessionSetupDialog",
                        max_seconds=30)
+    application.top_window().set_focus()
 
 
 def _get_number_of_instances_in_list(test_case: E2ETestCase) -> int:

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -145,6 +145,8 @@ int RunUiInstance(const DeploymentConfiguration& deployment_configuration,
       OrbitMainWindow w(std::move(target_config.value()), crash_handler, metrics_uploader.get(),
                         command_line_flags);
       w.show();
+      w.raise();
+      w.activateWindow();
 
       application_return_code = QApplication::exec();
 


### PR DESCRIPTION
* Orbit will bring the main window into focus after the modal dialog
was hidden
* The E2E test explicitly does the same in case the chrome window was
shown after the target dialog is visible
* Added the flag required to run the E2E test

Bug: b/202262744