### PR TITLE
Revert "Temporary fix for CloudCollectorStartStopCaptureRequestWaiter"

### DIFF
--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -27,8 +27,7 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
 
   // WaitForStopCaptureRequest is blocked until StopCapture is called.
   [[nodiscard]] CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() override;
-  void StopCapture(CaptureServiceBase::StopCaptureReason stop_capture_reason =
-                       CaptureServiceBase::StopCaptureReason::kClientStop);
+  void StopCapture(CaptureServiceBase::StopCaptureReason stop_capture_reason);
 
  private:
   mutable absl::Mutex start_mutex_;


### PR DESCRIPTION
Reverts google/orbit#3411

I updated the cloud collector in cl/433695776 and now should be safe to revert the temporary fix.

Thanks Pierric for the help!