### PR TITLE
Remove mangled name from SymbolInfo

### DIFF
--- a/src/ClientData/FunctionInfoSetTest.cpp
+++ b/src/ClientData/FunctionInfoSetTest.cpp
@@ -16,7 +16,6 @@ namespace orbit_client_data {
 
 TEST(FunctionInfoSet, EqualFunctions) {
   FunctionInfo left;
-  left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_module_path("/path/to/module");
   left.set_module_build_id("buildid");
@@ -24,7 +23,6 @@ TEST(FunctionInfoSet, EqualFunctions) {
   left.set_size(16);
 
   FunctionInfo right;
-  right.set_name("foo");
   right.set_pretty_name("void foo()");
   right.set_module_path("/path/to/module");
   right.set_module_build_id("buildid");
@@ -39,7 +37,6 @@ TEST(FunctionInfoSet, EqualFunctions) {
 
 TEST(FunctionInfoSet, DifferentName) {
   FunctionInfo left;
-  left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_module_path("/path/to/module");
   left.set_module_build_id("buildid");
@@ -48,7 +45,7 @@ TEST(FunctionInfoSet, DifferentName) {
 
   FunctionInfo right;
   right.CopyFrom(left);
-  right.set_name("bar");
+  right.set_pretty_name("bar");
 
   internal::EqualFunctionInfo eq;
   EXPECT_TRUE(eq(left, right));
@@ -56,7 +53,6 @@ TEST(FunctionInfoSet, DifferentName) {
 
 TEST(FunctionInfoSet, DifferentPrettyName) {
   FunctionInfo left;
-  left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_module_path("/path/to/module");
   left.set_module_build_id("buildid");
@@ -73,7 +69,6 @@ TEST(FunctionInfoSet, DifferentPrettyName) {
 
 TEST(FunctionInfoSet, DifferentModulePath) {
   FunctionInfo left;
-  left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_module_path("/path/to/module");
   left.set_module_build_id("buildid");
@@ -90,7 +85,6 @@ TEST(FunctionInfoSet, DifferentModulePath) {
 
 TEST(FunctionInfoSet, DifferentBuildId) {
   FunctionInfo left;
-  left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_module_path("/path/to/module");
   left.set_module_build_id("buildid");
@@ -107,7 +101,6 @@ TEST(FunctionInfoSet, DifferentBuildId) {
 
 TEST(FunctionInfoSet, DifferentAddress) {
   FunctionInfo left;
-  left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_module_path("/path/to/module");
   left.set_module_build_id("buildid");
@@ -124,7 +117,6 @@ TEST(FunctionInfoSet, DifferentAddress) {
 
 TEST(FunctionInfoSet, DifferentSize) {
   FunctionInfo left;
-  left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_module_path("/path/to/module");
   left.set_module_build_id("buildid");
@@ -141,7 +133,6 @@ TEST(FunctionInfoSet, DifferentSize) {
 
 TEST(FunctionInfoSet, Insertion) {
   FunctionInfo function;
-  function.set_name("foo");
   function.set_pretty_name("void foo()");
   function.set_module_path("/path/to/module");
   function.set_module_build_id("buildid");
@@ -160,7 +151,6 @@ TEST(FunctionInfoSet, Insertion) {
 
 TEST(FunctionInfoSet, Deletion) {
   FunctionInfo function;
-  function.set_name("foo");
   function.set_pretty_name("void foo()");
   function.set_module_path("/path/to/module");
   function.set_module_build_id("buildid");

--- a/src/ClientData/FunctionUtils.cpp
+++ b/src/ClientData/FunctionUtils.cpp
@@ -69,7 +69,6 @@ std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
                                                  const std::string& module_build_id) {
   auto function_info = std::make_unique<FunctionInfo>();
 
-  function_info->set_name(symbol_info.name());
   function_info->set_pretty_name(symbol_info.demangled_name());
   function_info->set_address(symbol_info.address());
   function_info->set_size(symbol_info.size());

--- a/src/ClientData/ModuleDataTest.cpp
+++ b/src/ClientData/ModuleDataTest.cpp
@@ -59,14 +59,12 @@ TEST(ModuleData, LoadSymbols) {
   ModuleData module{module_info};
 
   // Setup ModuleSymbols
-  std::string symbol_name = "function name";
   auto symbol_pretty_name = "pretty name";
   uint64_t symbol_address = 15;
   uint64_t symbol_size = 12;
 
   ModuleSymbols module_symbols;
   SymbolInfo* symbol_info = module_symbols.add_symbol_infos();
-  symbol_info->set_name(symbol_name);
   symbol_info->set_demangled_name(symbol_pretty_name);
   symbol_info->set_address(symbol_address);
   symbol_info->set_size(symbol_size);
@@ -78,7 +76,6 @@ TEST(ModuleData, LoadSymbols) {
   ASSERT_EQ(module.GetFunctions().size(), 1);
 
   const FunctionInfo* function = module.GetFunctions()[0];
-  EXPECT_EQ(function->name(), symbol_name);
   EXPECT_EQ(function->pretty_name(), symbol_pretty_name);
   EXPECT_EQ(function->module_path(), module_file_path);
   EXPECT_EQ(function->module_build_id(), kBuildId);
@@ -88,21 +85,17 @@ TEST(ModuleData, LoadSymbols) {
 
 TEST(ModuleData, FindFunctionByOffset) {
   uint64_t address1 = 100;
-  std::string name1 = "Name 1";
   std::string demangled_name_1 = "Pretty Name 1";
   uint64_t address2 = 200;
-  std::string name2 = "Name 2";
   std::string demangled_name_2 = "Pretty Name 2";
   uint64_t size = 10;
 
   ModuleSymbols symbols;
   SymbolInfo* symbol1 = symbols.add_symbol_infos();
-  symbol1->set_name(name1);
   symbol1->set_demangled_name(demangled_name_1);
   symbol1->set_address(address1);
   symbol1->set_size(size);
   SymbolInfo* symbol2 = symbols.add_symbol_infos();
-  symbol2->set_name(name2);
   symbol2->set_demangled_name(demangled_name_2);
   symbol2->set_address(address2);
   symbol2->set_size(size);
@@ -117,13 +110,13 @@ TEST(ModuleData, FindFunctionByOffset) {
     // address 1
     const FunctionInfo* result = module.FindFunctionByOffset(address1, true);
     ASSERT_NE(result, nullptr);
-    EXPECT_EQ(result->name(), name1);
+    EXPECT_EQ(result->pretty_name(), demangled_name_1);
   }
   {
     // address 2
     const FunctionInfo* result = module.FindFunctionByOffset(address2, true);
     ASSERT_NE(result, nullptr);
-    EXPECT_EQ(result->name(), name2);
+    EXPECT_EQ(result->pretty_name(), demangled_name_2);
   }
   {
     // wrong address (larger)
@@ -141,14 +134,14 @@ TEST(ModuleData, FindFunctionByOffset) {
     // at address 1
     const FunctionInfo* result = module.FindFunctionByOffset(address1, false);
     ASSERT_NE(result, nullptr);
-    EXPECT_EQ(result->name(), name1);
+    EXPECT_EQ(result->pretty_name(), demangled_name_1);
   }
   {
     // at address 1 + offset (offset < size)
     uint64_t offset = 5;
     const FunctionInfo* result = module.FindFunctionByOffset(address1 + offset, false);
     ASSERT_NE(result, nullptr);
-    EXPECT_EQ(result->name(), name1);
+    EXPECT_EQ(result->pretty_name(), demangled_name_1);
   }
   {
     // at address 1 + offset (offset > size)
@@ -168,7 +161,6 @@ TEST(ModuleData, FindFunctionFromHash) {
   ModuleSymbols symbols;
 
   SymbolInfo* symbol = symbols.add_symbol_infos();
-  symbol->set_name("Symbol Name");
   symbol->set_demangled_name("demangled name");
 
   ModuleData module{ModuleInfo{}};

--- a/src/ClientData/UserDefinedCaptureDataTest.cpp
+++ b/src/ClientData/UserDefinedCaptureDataTest.cpp
@@ -17,7 +17,6 @@ namespace orbit_client_data {
 
 FunctionInfo CreateFunctionInfo(const std::string& function_name, uint64_t function_address) {
   FunctionInfo info;
-  info.set_name(function_name);
   info.set_pretty_name(function_name);
   info.set_module_path("/path/to/module");
   info.set_module_build_id("build id");

--- a/src/ClientData/include/ClientData/FunctionUtils.h
+++ b/src/ClientData/include/ClientData/FunctionUtils.h
@@ -20,7 +20,7 @@ namespace orbit_client_data::function_utils {
 
 [[nodiscard]] inline const std::string& GetDisplayName(
     const orbit_client_protos::FunctionInfo& func) {
-  return func.pretty_name().empty() ? func.name() : func.pretty_name();
+  return func.pretty_name();
 }
 
 [[nodiscard]] std::string GetLoadedModuleNameByPath(std::string_view module_path);

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -36,8 +36,7 @@ message ModuleInfo {
 }
 
 message FunctionInfo {
-  reserved 4, 6, 8, 9, 10, 11;
-  string name = 1;
+  reserved 1, 4, 6, 8, 9, 10, 11;
   string pretty_name = 2;
   string module_path = 3;
   string module_build_id = 12;

--- a/src/CodeReport/AnnotateDisassemblyTest.cpp
+++ b/src/CodeReport/AnnotateDisassemblyTest.cpp
@@ -51,7 +51,6 @@ static void TestSimple(bool windows_line_endings) {
   }
 
   orbit_client_protos::FunctionInfo function_info{};
-  function_info.set_name("main");
   function_info.set_pretty_name("main");
   function_info.set_module_path("line_info_test_binary");
   function_info.set_address(0x401140);

--- a/src/CodeReport/DisassemblerTest.cpp
+++ b/src/CodeReport/DisassemblerTest.cpp
@@ -62,8 +62,6 @@ TEST(Disassembler, DisassembleWithSymbols) {
   orbit_grpc_protos::ModuleSymbols symbols;
   orbit_grpc_protos::SymbolInfo* symbol = symbols.add_symbol_infos();
   symbol->set_address(kOffset);
-  constexpr const char* kFunctionName = "_Z3fibi";
-  symbol->set_name(kFunctionName);
   constexpr const char* kDemangledFunctionName = "int fib(int)";
   symbol->set_demangled_name(kDemangledFunctionName);
   symbol->set_size(kFibonacciAssembly.size());

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -61,7 +61,6 @@ constexpr int kColumnModule = 3;
 constexpr int kColumnAddress = 4;
 
 constexpr size_t kNumFunctions = 4;
-const std::array<std::string, kNumFunctions> kFunctionNames{"foo", "main", "ffind", "bar"};
 const std::array<std::string, kNumFunctions> kFunctionPrettyNames{"void foo()", "main(int, char**)",
                                                                   "ffind(int)", "bar(const char*)"};
 constexpr std::array<uint64_t, kNumFunctions> kFunctionAddresses{0x5100, 0x7250, 0x6700, 0x4450};
@@ -110,7 +109,6 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
 
     if (kModuleIsLoaded[i]) {
       orbit_grpc_protos::SymbolInfo symbol_info;
-      symbol_info.set_name(kFunctionNames[i]);
       symbol_info.set_demangled_name(kFunctionPrettyNames[i]);
       symbol_info.set_address(kFunctionAddresses[i]);
       symbol_info.set_size(kFunctionSizes[i]);
@@ -314,7 +312,7 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
 
   auto get_index_from_function_info = [&](const FunctionInfo& function) -> std::optional<size_t> {
     for (size_t i = 0; i < kNumFunctions; i++) {
-      if (kFunctionNames[i] == function.name()) return i;
+      if (kFunctionPrettyNames[i] == function.pretty_name()) return i;
     }
     return std::nullopt;
   };
@@ -435,7 +433,7 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, Disassemble)
         .Times(1)
         .WillOnce([&](int32_t /*pid*/, const FunctionInfo& function) {
-          EXPECT_EQ(function.name(), kFunctionNames[0]);
+          EXPECT_EQ(function.pretty_name(), kFunctionPrettyNames[0]);
         });
     view_.OnContextMenu(std::string{kMenuActionDisassembly}, disassembly_index, {0});
   }
@@ -446,7 +444,7 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_TRUE(source_code_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, ShowSourceCode).Times(1).WillOnce([&](const FunctionInfo& function) {
-      EXPECT_EQ(function.name(), kFunctionNames[0]);
+      EXPECT_EQ(function.pretty_name(), kFunctionPrettyNames[0]);
     });
     view_.OnContextMenu(std::string{kMenuActionSourceCode}, source_code_index, {0});
   }
@@ -457,7 +455,7 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_TRUE(hook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, SelectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
-      EXPECT_EQ(function.name(), kFunctionNames[0]);
+      EXPECT_EQ(function.pretty_name(), kFunctionPrettyNames[0]);
     });
     view_.OnContextMenu(std::string{kMenuActionSelect}, hook_index, {0});
   }
@@ -473,7 +471,7 @@ TEST_F(CallstackDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_TRUE(unhook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, DeselectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
-      EXPECT_EQ(function.name(), kFunctionNames[0]);
+      EXPECT_EQ(function.pretty_name(), kFunctionPrettyNames[0]);
     });
     view_.OnContextMenu(std::string{kMenuActionUnselect}, unhook_index, {0});
   }

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -50,7 +50,6 @@ struct FunctionsDataViewTest : public testing::Test {
         view_{&app_, thread_pool_.get()} {
     view_.Init();
     orbit_client_protos::FunctionInfo function0;
-    function0.set_name("foo");
     function0.set_pretty_name("void foo()");
     function0.set_module_path("/path/to/module");
     function0.set_module_build_id("buildid");
@@ -59,7 +58,6 @@ struct FunctionsDataViewTest : public testing::Test {
     functions_.emplace_back(std::move(function0));
 
     orbit_client_protos::FunctionInfo function1;
-    function1.set_name("main");
     function1.set_pretty_name("main(int, char**)");
     function1.set_module_path("/path/to/other");
     function1.set_module_build_id("buildid2");
@@ -68,7 +66,6 @@ struct FunctionsDataViewTest : public testing::Test {
     functions_.emplace_back(std::move(function1));
 
     orbit_client_protos::FunctionInfo function2;
-    function2.set_name("_ZeqRK1AS1_");
     function2.set_pretty_name("operator==(A const&, A const&)");
     function2.set_module_path("/somewhere/else/module");
     function2.set_module_build_id("buildid3");
@@ -77,7 +74,6 @@ struct FunctionsDataViewTest : public testing::Test {
     functions_.emplace_back(std::move(function2));
 
     orbit_client_protos::FunctionInfo function3;
-    function3.set_name("ffind");
     function3.set_pretty_name("ffind(int)");
     function3.set_module_path("/somewhere/else/foomodule");
     function3.set_module_build_id("buildid4");
@@ -86,7 +82,6 @@ struct FunctionsDataViewTest : public testing::Test {
     functions_.emplace_back(std::move(function3));
 
     orbit_client_protos::FunctionInfo function4;
-    function4.set_name("bar");
     function4.set_pretty_name("bar(const char*)");
     function4.set_module_path("/somewhere/else/barmodule");
     function4.set_module_build_id("buildid4");
@@ -95,7 +90,6 @@ struct FunctionsDataViewTest : public testing::Test {
     functions_.emplace_back(std::move(function4));
 
     orbit_grpc_protos::ModuleInfo module_info0{};
-    module_info0.set_name("module0");
     module_info0.set_file_path(functions_[0].module_path());
     module_info0.set_file_size(0x42);
     module_info0.set_build_id(functions_[0].module_build_id());
@@ -104,7 +98,6 @@ struct FunctionsDataViewTest : public testing::Test {
     module_infos_.emplace_back(std::move(module_info0));
 
     orbit_grpc_protos::ModuleInfo module_info1{};
-    module_info1.set_name("module1");
     module_info1.set_file_path(functions_[1].module_path());
     module_info1.set_file_size(0x24);
     module_info1.set_build_id(functions_[1].module_build_id());
@@ -113,7 +106,6 @@ struct FunctionsDataViewTest : public testing::Test {
     module_infos_.emplace_back(std::move(module_info1));
 
     orbit_grpc_protos::ModuleInfo module_info2{};
-    module_info2.set_name("module2");
     module_info2.set_file_path(functions_[2].module_path());
     module_info2.set_file_size(0x55);
     module_info2.set_build_id(functions_[2].module_build_id());
@@ -138,7 +130,7 @@ struct FunctionsDataViewTest : public testing::Test {
                                    // This is not a canonical comparison, but since we control
                                    // our testing data, we can assure that all our functions have
                                    // distinctive names.
-                                   return function.name() == candidate.name();
+                                   return function.pretty_name() == candidate.pretty_name();
                                  });
     if (it == functions_.end()) return std::nullopt;
     return std::distance(functions_.begin(), it);
@@ -287,7 +279,6 @@ TEST_F(FunctionsDataViewTest, FrameTrackSelectionAppearsInFirstColumnWhenACaptur
   ASSERT_EQ(module_manager.GetAllModuleData().size(), 1);
 
   orbit_grpc_protos::SymbolInfo symbol_info;
-  symbol_info.set_name(functions_[0].name());
   symbol_info.set_demangled_name(functions_[0].pretty_name());
   symbol_info.set_address(functions_[0].address());
   symbol_info.set_size(functions_[0].size());
@@ -663,13 +654,13 @@ TEST_F(FunctionsDataViewTest, FilteringByFunctionName) {
 
   // We know that the function name of function 3 is unique, so we expect only the very same
   // function as the filter result.
-  view_.OnFilter(functions_[3].name());
+  view_.OnFilter(functions_[3].pretty_name());
   EXPECT_EQ(view_.GetNumElements(), 1);
   EXPECT_EQ(view_.GetValue(0, 1), functions_[3].pretty_name());
 
   // We know that the function name of function 4 is unique, so we expect only the very same
   // function as the filter result.
-  view_.OnFilter(functions_[4].name());
+  view_.OnFilter(functions_[4].pretty_name());
   EXPECT_EQ(view_.GetNumElements(), 1);
   EXPECT_EQ(view_.GetValue(0, 1), functions_[4].pretty_name());
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -552,7 +552,6 @@ std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrum
   }
 
   FunctionInfo result;
-  result.set_name(instrumented_function.function_name());
   result.set_pretty_name(llvm::demangle(instrumented_function.function_name()));
   result.set_module_path(instrumented_function.file_path());
   result.set_module_build_id(instrumented_function.file_build_id());

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -81,7 +81,6 @@ constexpr int kNumColumns = 7;
 constexpr size_t kNumFunctions = 4;
 
 // Used for setting up FunctionInfo
-const std::array<std::string, kNumFunctions> kFunctionNames{"foo", "main", "ffind", "bar"};
 const std::array<std::string, kNumFunctions> kFunctionPrettyNames{"void foo()", "main(int, char**)",
                                                                   "ffind(int)", "bar(const char*)"};
 constexpr std::array<uint64_t, kNumFunctions> kFunctionAddresses{0x5100, 0x7250, 0x6700, 0x4450};
@@ -131,7 +130,6 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
 
     if (kModuleIsLoaded[i]) {
       orbit_grpc_protos::SymbolInfo symbol_info;
-      symbol_info.set_name(kFunctionNames[i]);
       symbol_info.set_demangled_name(kFunctionPrettyNames[i]);
       symbol_info.set_address(kFunctionAddresses[i]);
       symbol_info.set_size(kFunctionSizes[i]);
@@ -370,7 +368,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
   std::array<bool, kNumFunctions> functions_selected{true, false, false, true};
   auto get_index_from_function_info = [&](const FunctionInfo& function) -> std::optional<size_t> {
     for (size_t i = 0; i < kNumFunctions; i++) {
-      if (kFunctionNames[i] == function.name()) return i;
+      if (kFunctionPrettyNames[i] == function.pretty_name()) return i;
     }
     return std::nullopt;
   };
@@ -529,7 +527,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_CALL(app_, Disassemble)
         .Times(1)
         .WillOnce([&](int32_t /*pid*/, const FunctionInfo& function) {
-          EXPECT_EQ(function.name(), kFunctionNames[0]);
+          EXPECT_EQ(function.pretty_name(), kFunctionPrettyNames[0]);
         });
     view_.OnContextMenu(std::string{kMenuActionDisassembly}, disassembly_index, {0});
   }
@@ -540,7 +538,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_TRUE(source_code_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, ShowSourceCode).Times(1).WillOnce([&](const FunctionInfo& function) {
-      EXPECT_EQ(function.name(), kFunctionNames[0]);
+      EXPECT_EQ(function.pretty_name(), kFunctionPrettyNames[0]);
     });
     view_.OnContextMenu(std::string{kMenuActionSourceCode}, source_code_index, {0});
   }
@@ -551,7 +549,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_TRUE(hook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, SelectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
-      EXPECT_EQ(function.name(), kFunctionNames[0]);
+      EXPECT_EQ(function.pretty_name(), kFunctionPrettyNames[0]);
     });
     view_.OnContextMenu(std::string{kMenuActionSelect}, hook_index, {0});
   }
@@ -567,7 +565,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
     EXPECT_TRUE(unhook_index != kInvalidActionIndex);
 
     EXPECT_CALL(app_, DeselectFunction).Times(1).WillOnce([&](const FunctionInfo& function) {
-      EXPECT_EQ(function.name(), kFunctionNames[0]);
+      EXPECT_EQ(function.pretty_name(), kFunctionPrettyNames[0]);
     });
     view_.OnContextMenu(std::string{kMenuActionUnselect}, unhook_index, {0});
   }

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -130,7 +130,6 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromFun
                 demangled_function_name, file_path);
 
   orbit_client_protos::FunctionInfo function_info;
-  function_info.set_name(symbol->name());
   function_info.set_pretty_name(symbol->demangled_name());
   function_info.set_module_path(file_path);
   function_info.set_module_build_id(build_id);
@@ -225,10 +224,10 @@ void ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
                 demangled_function_prefix, elf_file->GetName());
     return;
   }
-  ORBIT_LOG("Found function \"%s\" in module \"%s\"", symbol->name(), elf_file->GetName());
+  ORBIT_LOG("Found function \"%s\" in module \"%s\"", symbol->demangled_name(),
+            elf_file->GetName());
 
   orbit_grpc_protos::SymbolInfo symbol_info;
-  symbol_info.set_name(symbol->name());
   symbol_info.set_demangled_name(symbol->demangled_name());
   symbol_info.set_address(symbol->address());
   symbol_info.set_size(symbol->size());

--- a/src/GrpcProtos/symbol.proto
+++ b/src/GrpcProtos/symbol.proto
@@ -13,8 +13,7 @@ message ModuleSymbols {
 }
 
 message SymbolInfo {
-  reserved 5, 6;
-  string name = 1;
+  reserved 1, 5, 6;
   string demangled_name = 2;
   uint64 address = 3;
   uint64 size = 4;

--- a/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
@@ -28,7 +28,7 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
   bool outer_function_symbol_found = false;
   bool inner_function_symbol_found = false;
   for (const orbit_grpc_protos::SymbolInfo& symbol : module_symbols.symbol_infos()) {
-    if (symbol.name() == PuppetConstants::kOuterFunctionName) {
+    if (absl::StrContains(symbol.demangled_name(), PuppetConstants::kOuterFunctionName)) {
       ORBIT_CHECK(!outer_function_symbol_found);
       outer_function_symbol_found = true;
       orbit_grpc_protos::InstrumentedFunction instrumented_function;
@@ -36,12 +36,12 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
       instrumented_function.set_file_offset(symbol.address() - module_symbols.load_bias());
       instrumented_function.set_function_id(outer_function_id);
       instrumented_function.set_function_size(symbol.size());
-      instrumented_function.set_function_name(symbol.name());
+      instrumented_function.set_function_name(symbol.demangled_name());
       instrumented_function.set_record_return_value(true);
       capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
     }
 
-    if (symbol.name() == PuppetConstants::kInnerFunctionName) {
+    if (absl::StrContains(symbol.demangled_name(), PuppetConstants::kInnerFunctionName)) {
       ORBIT_CHECK(!inner_function_symbol_found);
       inner_function_symbol_found = true;
       orbit_grpc_protos::InstrumentedFunction instrumented_function;
@@ -49,7 +49,7 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
       instrumented_function.set_file_offset(symbol.address() - module_symbols.load_bias());
       instrumented_function.set_function_id(inner_function_id);
       instrumented_function.set_function_size(symbol.size());
-      instrumented_function.set_function_name(symbol.name());
+      instrumented_function.set_function_name(symbol.demangled_name());
       instrumented_function.set_record_arguments(true);
       capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
     }

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -545,7 +545,7 @@ GetOuterAndInnerFunctionVirtualAddressRanges(pid_t pid) {
   uint64_t inner_function_virtual_address_start = 0;
   uint64_t inner_function_virtual_address_end = 0;
   for (const orbit_grpc_protos::SymbolInfo& symbol : module_symbols.symbol_infos()) {
-    if (symbol.name() == PuppetConstants::kOuterFunctionName) {
+    if (absl::StrContains(symbol.demangled_name(), PuppetConstants::kOuterFunctionName)) {
       ORBIT_CHECK(outer_function_virtual_address_start == 0 &&
                   outer_function_virtual_address_end == 0);
       outer_function_virtual_address_start =
@@ -555,7 +555,7 @@ GetOuterAndInnerFunctionVirtualAddressRanges(pid_t pid) {
       outer_function_virtual_address_end = outer_function_virtual_address_start + symbol.size() - 1;
     }
 
-    if (symbol.name() == PuppetConstants::kInnerFunctionName) {
+    if (absl::StrContains(symbol.demangled_name(), PuppetConstants::kInnerFunctionName)) {
       ORBIT_CHECK(inner_function_virtual_address_start == 0 &&
                   inner_function_virtual_address_end == 0);
       inner_function_virtual_address_start =

--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -331,7 +331,7 @@ static std::pair<uint64_t, uint64_t> GetUseOrbitApiFunctionVirtualAddressRange(p
   const orbit_grpc_protos::ModuleInfo& module_info = GetExecutableBinaryModuleInfo(pid);
   const orbit_grpc_protos::ModuleSymbols& module_symbols = GetExecutableBinaryModuleSymbols(pid);
   for (const orbit_grpc_protos::SymbolInfo& symbol : module_symbols.symbol_infos()) {
-    if (symbol.name() == PuppetConstants::kUseOrbitApiFunctionName) {
+    if (absl::StrContains(symbol.demangled_name(), PuppetConstants::kUseOrbitApiFunctionName)) {
       const uint64_t virtual_address_start =
           orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
               symbol.address(), module_info.address_start(), module_info.load_bias(),

--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -84,7 +84,6 @@ static void FillDebugSymbolsFromDWARF(llvm::DWARFContext* dwarf_context,
         // not present, so this should never return an empty name.
         std::string name(full_die.getName(llvm::DINameKind::LinkageName));
         ORBIT_CHECK(!name.empty());
-        symbol_info.set_name(name);
         symbol_info.set_demangled_name(llvm::demangle(name));
         symbol_info.set_address(low_pc);
         symbol_info.set_size(high_pc - low_pc);

--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -39,7 +39,6 @@ TEST(CoffFile, LoadDebugSymbols) {
   EXPECT_EQ(symbol_infos.size(), 35);
 
   SymbolInfo& symbol_info = symbol_infos[4];
-  EXPECT_EQ(symbol_info.name(), "pre_c_init");
   EXPECT_EQ(symbol_info.demangled_name(), "pre_c_init");
   uint64_t expected_address =
       0x0 + coff_file->GetExecutableSegmentOffset() + coff_file->GetLoadBias();
@@ -47,7 +46,6 @@ TEST(CoffFile, LoadDebugSymbols) {
   EXPECT_EQ(symbol_info.size(), 0xc);
 
   symbol_info = symbol_infos[5];
-  EXPECT_EQ(symbol_info.name(), "PrintHelloWorld");
   EXPECT_EQ(symbol_info.demangled_name(), "PrintHelloWorld");
   expected_address = 0x03a0 + coff_file->GetExecutableSegmentOffset() + coff_file->GetLoadBias();
   EXPECT_EQ(symbol_info.address(), expected_address);

--- a/src/ObjectUtils/ElfFile.cpp
+++ b/src/ObjectUtils/ElfFile.cpp
@@ -354,7 +354,6 @@ ErrorMessageOr<SymbolInfo> ElfFileImpl<ElfT>::CreateSymbolInfo(
   }
 
   SymbolInfo symbol_info;
-  symbol_info.set_name(name);
   symbol_info.set_demangled_name(llvm::demangle(name));
   symbol_info.set_address(maybe_value.get());
   symbol_info.set_size(symbol_ref.getSize());

--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -46,13 +46,11 @@ TEST(ElfFile, LoadDebugSymbols) {
   EXPECT_EQ(symbol_infos.size(), 10);
 
   SymbolInfo& symbol_info = symbol_infos[0];
-  EXPECT_EQ(symbol_info.name(), "deregister_tm_clones");
   EXPECT_EQ(symbol_info.demangled_name(), "deregister_tm_clones");
   EXPECT_EQ(symbol_info.address(), 0x1080);
   EXPECT_EQ(symbol_info.size(), 0);
 
   symbol_info = symbol_infos[5];
-  EXPECT_EQ(symbol_info.name(), "main");
   EXPECT_EQ(symbol_info.demangled_name(), "main");
   EXPECT_EQ(symbol_info.address(), 0x1140);
   EXPECT_EQ(symbol_info.size(), 45);
@@ -90,7 +88,6 @@ TEST(ElfFile, LoadSymbolsFromDynsym) {
   EXPECT_EQ(symbol_infos.size(), 8);
 
   SymbolInfo& symbol_info = symbol_infos[7];
-  EXPECT_EQ(symbol_info.name(), "UseTestLib");
   EXPECT_EQ(symbol_info.demangled_name(), "UseTestLib");
   EXPECT_EQ(symbol_info.address(), 0x2670);
   EXPECT_EQ(symbol_info.size(), 591);

--- a/src/ObjectUtils/PdbFileDia.cpp
+++ b/src/ObjectUtils/PdbFileDia.cpp
@@ -104,13 +104,14 @@ ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> PdbFileDia::LoadDebugSymbols() 
 
     BSTR function_name = {};
     if (dia_symbol->get_name(&function_name) != S_OK) continue;
-    symbol_info.set_name(orbit_base::ToStdString(function_name));
+    symbol_info.set_demangled_name(orbit_base::ToStdString(function_name));
     ErrorMessageOr<std::string> parameter_list_or_error = PdbDiaParameterListAsString(dia_symbol);
     if (parameter_list_or_error.has_value()) {
-      symbol_info.set_demangled_name(symbol_info.name() + parameter_list_or_error.value());
+      symbol_info.set_demangled_name(symbol_info.demangled_name() +
+                                     parameter_list_or_error.value());
     } else {
       ORBIT_ERROR("Unable to retrieve parameter types of function %s. Error: %s",
-                  symbol_info.name(), parameter_list_or_error.error().message());
+                  symbol_info.demangled_name(), parameter_list_or_error.error().message());
     }
     SysFreeString(function_name);
 

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -45,7 +45,6 @@ class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
   llvm::Error visitKnownRecord(llvm::codeview::CVSymbol& /*unused*/,
                                llvm::codeview::ProcSym& proc) override {
     SymbolInfo symbol_info;
-    symbol_info.set_name(proc.Name.str());
     symbol_info.set_demangled_name(llvm::demangle(proc.Name.str()));
 
     // The ProcSym's name does not contain an argument list. However, this information is required

--- a/src/ObjectUtils/PdbFileTest.h
+++ b/src/ObjectUtils/PdbFileTest.h
@@ -56,7 +56,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000eea0];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "PrintHelloWorldInternal");
     EXPECT_EQ(symbol->demangled_name(), "PrintHelloWorldInternal()");
     EXPECT_EQ(symbol->address(), 0x18000eea0);
     EXPECT_EQ(symbol->size(), 0x2b);
@@ -65,7 +64,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000eee0];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "PrintHelloWorld");
     EXPECT_EQ(symbol->demangled_name(), "PrintHelloWorld()");
     EXPECT_EQ(symbol->address(), 0x18000eee0);
     EXPECT_EQ(symbol->size(), 0xe);
@@ -74,7 +72,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000ef00];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "PrintString");
     EXPECT_EQ(symbol->demangled_name(), "PrintString(const char*)");
     EXPECT_EQ(symbol->address(), 0x18000ef00);
   }
@@ -82,7 +79,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000ef20];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesVolatileInt");
     EXPECT_EQ(symbol->demangled_name(), "TakesVolatileInt(volatile int)");
     EXPECT_EQ(symbol->address(), 0x18000ef20);
   }
@@ -90,7 +86,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000ef50];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesFooReference");
     EXPECT_EQ(symbol->demangled_name(), "TakesFooReference(Foo&)");
     EXPECT_EQ(symbol->address(), 0x18000ef50);
   }
@@ -98,7 +93,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000ef80];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesFooRValueReference");
     EXPECT_EQ(symbol->demangled_name(), "TakesFooRValueReference(Foo&&)");
     EXPECT_EQ(symbol->address(), 0x18000ef80);
   }
@@ -106,7 +100,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000efb0];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesConstPtrToInt");
     EXPECT_EQ(symbol->demangled_name(), "TakesConstPtrToInt(int* const)");
     EXPECT_EQ(symbol->address(), 0x18000efb0);
   }
@@ -114,7 +107,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000efe0];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesReferenceToIntPtr");
     EXPECT_EQ(symbol->demangled_name(), "TakesReferenceToIntPtr(int*&)");
     EXPECT_EQ(symbol->address(), 0x18000efe0);
   }
@@ -122,7 +114,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000f010];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesVoidFunctionPointer");
     // LLVM does not handle function pointers correctly, thus we also accept the wrong
     // strings here.
     EXPECT_THAT(symbol->demangled_name(), AnyOf("TakesVoidFunctionPointer(void (*)(int))",
@@ -133,7 +124,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000f030];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesCharFunctionPointer");
     // LLVM does not handle function pointers correctly, thus we also accept the wrong
     // strings here.
     EXPECT_THAT(symbol->demangled_name(), AnyOf("TakesCharFunctionPointer(char (*)(int))",
@@ -144,7 +134,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000f060];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesMemberFunctionPointer");
     // LLVM does not handle function pointers correctly, thus we also accept the wrong
     // strings here.
     EXPECT_THAT(symbol->demangled_name(),
@@ -156,7 +145,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000f090];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesVolatilePointerToConstUnsignedChar");
     EXPECT_EQ(symbol->demangled_name(),
               "TakesVolatilePointerToConstUnsignedChar(const unsigned char* volatile)");
     EXPECT_EQ(symbol->address(), 0x18000f090);
@@ -165,7 +153,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000f0b0];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesVolatileConstPtrToVolatileConstChar");
     EXPECT_EQ(symbol->demangled_name(),
               "TakesVolatileConstPtrToVolatileConstChar(const volatile char* const volatile)");
     EXPECT_EQ(symbol->address(), 0x18000f0b0);
@@ -174,7 +161,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000f0d0];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesConstPointerToConstFunctionPointer");
     // LLVM does not handle function pointers correctly, thus we also accept the wrong
     // strings here.
     EXPECT_THAT(symbol->demangled_name(),
@@ -186,7 +172,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000f100];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesVariableArguments");
     EXPECT_EQ(symbol->demangled_name(), "TakesVariableArguments(int, <no type>)");
     EXPECT_EQ(symbol->address(), 0x18000f100);
   }
@@ -194,7 +179,6 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   {
     const SymbolInfo* symbol = symbol_infos_by_address[0x18000f1b0];
     ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->name(), "TakesUserTypeInNamespace");
     EXPECT_EQ(symbol->demangled_name(), "TakesUserTypeInNamespace(A::FooA, A::B::FooAB)");
     EXPECT_EQ(symbol->address(), 0x18000f1b0);
   }

--- a/src/OrbitQt/AnnotatingSourceCodeDialogTest.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialogTest.cpp
@@ -63,7 +63,6 @@ TEST(AnnotatingSourceCodeDialog, SmokeTest) {
   std::string source_file_contents = std::move(source_file_contents_or_error.value());
 
   orbit_client_protos::FunctionInfo function_info{};
-  function_info.set_name("main");
   function_info.set_pretty_name("main");
   function_info.set_module_path("line_info_test_binary");
   function_info.set_address(0x401140);

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
@@ -42,7 +42,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddress(pid_t pid, std::string_view module_
   }
 
   for (const orbit_grpc_protos::SymbolInfo& symbol : symbols.value().symbol_infos()) {
-    if (symbol.name() == function_name) {
+    if (symbol.demangled_name() == function_name) {
       return orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
           symbol.address(), module_base_address, elf_file->GetLoadBias(),
           elf_file->GetExecutableSegmentOffset());

--- a/src/UserSpaceInstrumentation/TestUtils.cpp
+++ b/src/UserSpaceInstrumentation/TestUtils.cpp
@@ -24,7 +24,7 @@ static ErrorMessageOr<AddressRange> FindFunctionAbsoluteAddressInModule(
   OUTCOME_TRY(auto&& elf_file, orbit_object_utils::CreateElfFile(module_file_path));
   OUTCOME_TRY(auto&& syms, elf_file->LoadDebugSymbols());
   for (const auto& sym : syms.symbol_infos()) {
-    if (sym.name() == function_name) {
+    if (sym.demangled_name() == function_name) {
       const uint64_t address = orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
           sym.address(), module_address_range.start, syms.load_bias(),
           elf_file->GetExecutableSegmentOffset());
@@ -69,7 +69,7 @@ static ErrorMessageOr<AddressRange> FindFunctionRelativeAddressInModule(
   OUTCOME_TRY(auto&& elf_file, orbit_object_utils::CreateElfFile(module_file_path));
   OUTCOME_TRY(auto&& syms, elf_file->LoadDebugSymbols());
   for (const auto& sym : syms.symbol_infos()) {
-    if (sym.name() == function_name) {
+    if (sym.demangled_name() == function_name) {
       return AddressRange(sym.address(), sym.address() + sym.size());
     }
   }


### PR DESCRIPTION
"SymbolInfo" contained two fields related to the symbol name: "name" and "demangled_name".
The "name" field was sometimes used to store a symbol's mangled name, and sometimes used
to store the bare function name, with no argument or return type information. On top of having
a dual purpose, the "name" field wasn't really needed at all. The only place where we would use 
it is in the case where the "demangled_name" was not available, which should never happen.

Similarly, remove the "name" field from "FunctionInfo" which we used to store the "SymbolInfo" 
"name" field. This saves on proto size, but more  importantly reduces ambiguity. We now rely 
solely on the "demangled_name" field to identify a function. It contains the final *demangled* 
name which should in theory be a unique identifier for a function in a module.