### PR TITLE
Add GetStopCaptureReason

### DIFF
--- a/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
@@ -47,4 +47,10 @@ void CloudCollectorStartStopCaptureRequestWaiter::StopCapture(
   stop_requested_ = true;
 }
 
+CaptureServiceBase::StopCaptureReason
+CloudCollectorStartStopCaptureRequestWaiter::GetStopCaptureReason() const {
+  absl::MutexLock lock(&stop_mutex_);
+  return stop_capture_reason_;
+}
+
 }  // namespace orbit_capture_service_base

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -29,6 +29,8 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
   [[nodiscard]] CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() override;
   void StopCapture(CaptureServiceBase::StopCaptureReason stop_capture_reason);
 
+  [[nodiscard]] CaptureServiceBase::StopCaptureReason GetStopCaptureReason() const;
+
  private:
   mutable absl::Mutex start_mutex_;
   orbit_grpc_protos::CaptureOptions capture_options_ ABSL_GUARDED_BY(start_mutex_);


### PR DESCRIPTION
Add GetStopCaptureReason such that we can check the StopCaptureReason
in the CloudCollector tests.

Bug: http://b/220888294