### PR TITLE
Extend PersistantStorageManager to symbol mappings

### DIFF
--- a/src/ConfigWidgets/SymbolsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolsDialogTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/container/flat_hash_map.h>
 #include <gmock/gmock-actions.h>
 #include <gmock/gmock-function-mocker.h>
 #include <gmock/gmock-matchers.h>
@@ -32,6 +33,10 @@ class MockPersistentStorageManager : public orbit_symbol_paths::PersistentStorag
  public:
   MOCK_METHOD(void, SavePaths, (absl::Span<const std::filesystem::path>), (override));
   MOCK_METHOD(std::vector<std::filesystem::path>, LoadPaths, (), (override));
+  MOCK_METHOD(void, SaveModuleSymbolFileMappings,
+              ((const absl::flat_hash_map<std::string, std::filesystem::path>&)), (override));
+  MOCK_METHOD((absl::flat_hash_map<std::string, std::filesystem::path>),
+              LoadModuleSymbolFileMappings, (), (override));
 };
 
 TEST(SymbolsDialog, ConstructEmpty) {

--- a/src/SymbolPaths/QSettingsBasedStorageManager.cpp
+++ b/src/SymbolPaths/QSettingsBasedStorageManager.cpp
@@ -10,7 +10,7 @@
 
 constexpr const char* kSymbolPathsSettingsKey = "symbol_directories";
 constexpr const char* kDirectoryPathKey = "directory_path";
-constexpr const char* kModuleSymbolFileMappingKey = "module_symbol_file_mappings";
+constexpr const char* kModuleSymbolFileMappingKey = "module_symbol_file_mapping_key";
 constexpr const char* kModuleSymbolFileMappingModuleKey = "module_symbol_file_mapping_module_key";
 constexpr const char* kModuleSymbolFileMappingSymbolFileKey =
     "module_symbol_file_mapping_symbol_file_key";

--- a/src/SymbolPaths/QSettingsBasedStorageManagerTest.cpp
+++ b/src/SymbolPaths/QSettingsBasedStorageManagerTest.cpp
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/container/flat_hash_map.h>
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <QCoreApplication>
@@ -19,9 +21,9 @@ constexpr const char* kOrgName = "The Orbit Authors";
 
 namespace orbit_symbol_paths {
 
-TEST(QSettingsBasedStorageManager, LoadAndSave) {
+TEST(QSettingsBasedStorageManager, LoadAndSavePaths) {
   QCoreApplication::setOrganizationDomain(kOrgName);
-  QCoreApplication::setApplicationName("SymbolPathsManager.SetAndGet");
+  QCoreApplication::setApplicationName("QSettingsBasedStorageManager.LoadAndSavePaths");
 
   {  // clear before test;
     QSettings settings;
@@ -40,6 +42,39 @@ TEST(QSettingsBasedStorageManager, LoadAndSave) {
 
   manager.SavePaths(paths);
   EXPECT_EQ(manager.LoadPaths(), paths);
+}
+
+TEST(QSettingsBasedStorageManager, LoadAndSaveModuleSymbolFileMappings) {
+  QCoreApplication::setOrganizationDomain(kOrgName);
+  QCoreApplication::setApplicationName(
+      "QSettingsBasedStorageManager.LoadAndSaveModuleSymbolFileMappings");
+
+  {  // clear before test;
+    QSettings settings;
+    settings.clear();
+  }
+
+  absl::flat_hash_map<std::string, std::filesystem::path> mappings;
+  mappings["/path/to/module1"] = path0;
+  mappings["/path/to/module2"] = path1;
+  mappings["/other/module/path"] = path2;
+
+  {
+    QSettingsBasedStorageManager manager;
+    EXPECT_TRUE(manager.LoadModuleSymbolFileMappings().empty());
+    manager.SaveModuleSymbolFileMappings(mappings);
+  }
+
+  QSettingsBasedStorageManager manager;
+  absl::flat_hash_map<std::string, std::filesystem::path> loaded_mappings =
+      manager.LoadModuleSymbolFileMappings();
+
+  // Deep compare mappings and loaded_mappings
+  EXPECT_EQ(loaded_mappings.size(), mappings.size());
+  for (const auto& [module_path, symbol_file_path] : mappings) {
+    ASSERT_TRUE(loaded_mappings.contains(module_path));
+    EXPECT_EQ(mappings[module_path], loaded_mappings[module_path]);
+  }
 }
 
 }  // namespace orbit_symbol_paths

--- a/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
+++ b/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
@@ -5,6 +5,7 @@
 #ifndef SYMBOL_PATHS_PERSISTENT_STORAGE_MANAGER_H
 #define SYMBOL_PATHS_PERSISTENT_STORAGE_MANAGER_H
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/types/span.h>
 
 #include <filesystem>
@@ -19,6 +20,14 @@ class PersistentStorageManager {
 
   virtual void SavePaths(absl::Span<const std::filesystem::path> paths) = 0;
   [[nodiscard]] virtual std::vector<std::filesystem::path> LoadPaths() = 0;
+  // The hash map uses the key std::string for the module path instead of std::filesystem::path,
+  // because the module path is always linux path (from the instance). When this is compiled on
+  // windows, std::filesystem::path will use backslash instead of slash as directory separator which
+  // leads to confusion.
+  virtual void SaveModuleSymbolFileMappings(
+      const absl::flat_hash_map<std::string, std::filesystem::path>& mappings) = 0;
+  [[nodiscard]] virtual absl::flat_hash_map<std::string, std::filesystem::path>
+  LoadModuleSymbolFileMappings() = 0;
 };
 
 }  // namespace orbit_symbol_paths

--- a/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
+++ b/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
@@ -20,6 +20,7 @@ class PersistentStorageManager {
 
   virtual void SavePaths(absl::Span<const std::filesystem::path> paths) = 0;
   [[nodiscard]] virtual std::vector<std::filesystem::path> LoadPaths() = 0;
+
   // The hash map uses the key std::string for the module path instead of std::filesystem::path,
   // because the module path is always linux path (from the instance). When this is compiled on
   // windows, std::filesystem::path will use backslash instead of slash as directory separator which

--- a/src/SymbolPaths/include/SymbolPaths/QSettingsBasedStorageManager.h
+++ b/src/SymbolPaths/include/SymbolPaths/QSettingsBasedStorageManager.h
@@ -12,7 +12,11 @@ namespace orbit_symbol_paths {
 class QSettingsBasedStorageManager : public PersistentStorageManager {
  public:
   void SavePaths(absl::Span<const std::filesystem::path> paths) override;
-  [[nodiscard]] virtual std::vector<std::filesystem::path> LoadPaths() override;
+  [[nodiscard]] std::vector<std::filesystem::path> LoadPaths() override;
+  void SaveModuleSymbolFileMappings(
+      const absl::flat_hash_map<std::string, std::filesystem::path>& mappings) override;
+  [[nodiscard]] absl::flat_hash_map<std::string, std::filesystem::path>
+  LoadModuleSymbolFileMappings() override;
 };
 
 }  // namespace orbit_symbol_paths


### PR DESCRIPTION
This adds the methods LoadModuleSymbolFileMappings and
SaveModuleSymbolFileMappings to PersistenStorageManager and its
implementation. This will be used to save the module to symbol file
overrides. The argument type is a hash map from module path (as the
module identifier) to a local file path (symbol file).

Test: Unit tests
Part of http://b/202391472