### PR TITLE
Don't back up and restore st(0) and st(1) in return trampoline

### DIFF
--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
@@ -23,8 +23,10 @@ extern "C" __attribute__((ms_abi)) uint64_t TrivialSumWithMsAbi(uint64_t p0, uin
 
 // Payload called on entry of an instrumented function. Needs to record the return address of the
 // function (in order to have it available in `ExitPayload`) and the stack pointer (i.e., the
-// address of the return address). `function_id` is the id of the instrumented function.
-extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer);
+// address of the return address). `function_id` is the id of the instrumented function. Also needs
+// to overwrite the return address stored at `stack_pointer` with the `return_trampoline_address`.
+extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer,
+                             uint64_t return_trampoline_address);
 
 // Payload called on exit of an instrumented function. Needs to return the actual return address of
 // the function such that the execution can be continued there.
@@ -36,17 +38,20 @@ extern "C" uint64_t ExitPayload();
 // We are assuming that this function updates the frame pointer, i.e., that it starts with
 // `push rbp; mov rbp, rsp`.
 extern "C" void EntryPayloadAlignedCopy(uint64_t return_address, uint64_t function_id,
-                                        uint64_t stack_pointer);
+                                        uint64_t stack_pointer, uint64_t return_trampoline_address);
 
 // Overwrites rdi, rsi, rdx, rcx, r8, r9, rax, r10. These registers are used to hand over parameters
 // to a called function. This function is used to assert our backup of these registers works
 // properly. The two functions below do the same thing for SSE/AVX registers that can be used to
 // hand over floating point parameters.
 extern "C" void EntryPayloadClobberParameterRegisters(uint64_t return_address, uint64_t function_id,
-                                                      uint64_t stack_pointer);
+                                                      uint64_t stack_pointer,
+                                                      uint64_t return_trampoline_address);
 extern "C" void EntryPayloadClobberXmmRegisters(uint64_t return_address, uint64_t function_id,
-                                                uint64_t stack_pointer);
+                                                uint64_t stack_pointer,
+                                                uint64_t return_trampoline_address);
 extern "C" void EntryPayloadClobberYmmRegisters(uint64_t return_address, uint64_t function_id,
-                                                uint64_t stack_pointer);
+                                                uint64_t stack_pointer,
+                                                uint64_t return_trampoline_address);
 
 #endif  // USER_SPACE_INSTRUMENTATION_TEST_LIB_H_


### PR DESCRIPTION
There were two issues:
- Popping from the x87 stack if it's empty causes a crash if the
  invalid-operation exception is not masked;
- The x87 stack should be empty when returning from a function that doesn't use
  the x87 stack to return values, while we were always leaving two values on it.

We add two unit tests for this cases to `TrampolineTest`.

The x87 FPU is basically only used for `long double`s. We can just assume that
the `ExitPayload` doesn't use it, so let's not back up and restore `st(0)` and
`st(1)`.

We add a unit test for this to `InstrumentProcessTest`.

I tried two other solutions:
- Using `FSAVE` and `FRSTOR` to back up and restore the entire state of the FPU:
  this caused a ~150 ns additional overhead on each call;
- Doing the following, which is even worse, with an additional overhead of ~300
  ns because of the conditional jumps:
  - back up the x87 Control Word;
  - set bit 0 of the Control Word to mask the invalid-operation exception;
  - pop the x87 stack and back up the value;
  - save the Status Word;
  - pop the x87 stack and back up the value;
  - save the Status Word;
  - restore the Control Word;
  - ...
  - if the invalid-operation bit in the saved Status Word is not set, push the
    saved value to the x87 stack;
  - again, if the invalid-operation bit in the saved Status Word is not set,
    push the saved value to the x87 stack.

Also fix existing unit tests after moving the responsibility of overwriting the
return address from the entry trampoline to the `EntryPayload`.

Bug: http://b/224446632

Test: New unit tests. On Trata.