### PR TITLE
Back up all registers that are volatile for Microsoft x64 in trampolines

### DIFF
--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -50,7 +50,7 @@ size_t kMaxRelocatedPrologueSize = kSizeOfJmp * 16;
 // before each run. This happens in `InstrumentFunction`. Whenever the code of the trampoline is
 // changed this constant needs to be adjusted as well. There is a CHECK in the code below to make
 // sure this number is correct.
-constexpr uint64_t kOffsetOfFunctionIdInCallToEntryPayload = 184;
+constexpr uint64_t kOffsetOfFunctionIdInCallToEntryPayload = 178;
 
 [[nodiscard]] std::string InstructionBytesAsString(cs_insn* instruction) {
   std::string result;
@@ -77,97 +77,137 @@ constexpr uint64_t kOffsetOfFunctionIdInCallToEntryPayload = 184;
   return result;
 }
 
-void AppendBackupCode(MachineCode& trampoline) {
-  // This code is executed immediately after the control is passed to the instrumented function. The
-  // top of the stack contains the return address. Above that are the parameters passed via the
-  // stack.
-  // Some of the general purpose and vector registers contain the parameters for the instrumented
-  // function not passed via the stack. These need to be backed up - see explanation at the bottom
-  // of this comment.
-  //
-  // There are other guarantees from the calling convention, but these do not require any work from
-  // our side:
-  //
-  // x87 state: The calling convention requires the cpu to be in x87 state when entering a function.
-  // Since we don't alter the state in the machine code and the calling function and the payload
-  // function obey the calling convention we don't need to take care of anything here. We are in x87
-  // mode when we enter the trampoline and it will stay like this. If the payload switches to mmx it
-  // is guaranteed to switch back to x87 before returning.
-  //
-  // The direction flag DF in the %rFLAGS register: must be clear (set to “forward” direction) on
-  // function entry and return. As above with the x87 state we don't need to care about that.
-  //
-  // Similar to this we do not need to do anything to obey the other requirements of the calling
-  // convention: The control bits of the MXCSR register are callee-saved, while the status bits are
-  // caller-saved. The x87 status word register is caller-saved, whereas the x87 control word is
-  // callee-saved.
-  //
-  // For all of the above compare section "3.2 Function Calling Sequence" in "System V Application
-  // Binary Interface" https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf
-  //
-  // While we focus primarily on the System V calling convention, we also want to consider
-  // instrumented functions that follow the Microsoft x64 calling convention or the __vectorcall
-  // convention. This is for two cases: a Windows binary running under Wine; a Linux binary with
-  // functions following the Microsoft x64 calling convention, e.g., with GCC's and Clang's
-  // `__attribute__((ms_abi))`.
-  // Again, we need to back up registers that are used for parameter passing. In the Microsoft x64
-  // calling convention, these are only RCX, RDX, R8, R9, XMM0, XMM1, XMM2, XMM3. The __vectorcall
-  // convention adds XMM4 and XMM5, or the full YMM0 to YMM5 if AVX is supported. All of these are
-  // already used for parameter passing by the System V calling convention.
-  // Furthermore, as the payload functions follow the System V calling convention, we also need to
-  // back up registers that are preserved across function calls ("callee-saved", "non-volatile") in
-  // the Microsoft x64 calling convention or in the __vectorcall convention, but aren't
-  // ("caller-saved", "volatile") in the System V calling convention - the caller could expect the
-  // content of these registers to not change, but our payload functions could modify it. Such
-  // registers are RDI, RSI, and XMM6 to XMM15.
-  // Refer to https://docs.microsoft.com/en-us/cpp/build/x64-software-conventions,
-  // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention, and
-  // https://docs.microsoft.com/en-us/cpp/cpp/vectorcall.
+// This code is executed immediately after the control is passed to the instrumented function. The
+// top of the stack contains the return address. Above that are the parameters passed via the stack.
+// Some registers contain the parameters for the instrumented function not passed via the stack.
+// Other registers are expected by the caller to not be modified by the callee ("callee-saved",
+// "caller-owned" or "non-volatile" registers). As we are going to call the entry payload function,
+// all these registers need to be backed up and then restored.
+//
+// Primarily, we focus on instrumenting functions that follow the System V calling convention
+// (see section "3.2 Function Calling Sequence" in "System V Application Binary Interface" at
+// https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf, find later versions at
+// https://gitlab.com/x86-psABIs/x86-64-ABI/-/wikis/home). But we also want to consider functions
+// that follow the Microsoft x64 calling convention (see
+// https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention) or the __vectorcall
+// convention, which is just a small extension of the Microsoft x64 (see
+// https://docs.microsoft.com/en-us/cpp/cpp/vectorcall). This is for two cases: a Windows binary
+// running under Wine; a Linux binary with functions following the Microsoft x64 calling convention,
+// e.g., with GCC's and Clang's `__attribute__((ms_abi))`.
+//
+// We assume that our payload functions strictly follow the System V calling convention, and only
+// modify registers that don't need to be preserved across function calls in this calling convention
+// ("caller-saved", "callee-owned" or "volatile" registers).
 
-  // In the System V calling convention, general purpose registers used for passing parameters are
-  // rdi, rsi, rdx, rcx, r8, r9 in that order. rax is used to indicate the number of vector
-  // arguments passed to a function requiring a variable number of arguments. r10 is used for
-  // passing a function’s static chain pointer. All of these need to be backed up:
+// Therefore, for the case of instrumenting functions following the System V calling convention, we
+// only need to back up registers used for parameter passing. These are RDI, RSI, RDX, RCX, R8 and
+// R9 in that order; XMM{0..7} for floating point arguments, or YMM{0..7} if AVX is available, which
+// include XMM{0..7} as their lower half (see section "3.2.3 Parameter Passing" in, again, "System V
+// Application Binary Interface"). We know that the remaining volatile registers can be modified,
+// and that non-volatile registers will not be modified.
+//
+// For the case of instrumenting functions that follow the Microsoft x64 calling convention or the
+// __vectorcall convention, we again need to back up registers used for parameters passing. These
+// are RCX, RDX, R8 and R9, in that order; XMM{0..4} for floating point arguments; XMM{4,5}, or the
+// full YMM{0..5} if AVX is supported, for vector arguments in __vectorcall.
+// But this time we also need to back up registers that are non-volatile in the Microsoft x64
+// calling convention or in the __vectorcall convention, but are volatile in the System V calling
+// convention of the payload functions: these are RDI, RSI and XMM{6..15} (but not the full
+// YMM{6..15} as their upper half is volatile).
+//
+// There are other guarantees from the System V calling convention.
+// The CPU must be in x87 state when entering a function. If a function switches to MMX, it is
+// required to switch back to x87 before returning or calling another function. We don't use x87 or
+// alter its state in the machine code, and if the payload switches to MMX, it is guaranteed to
+// switch back before returning.
+// The x87 status word register is volatile, while the x87 control word (FPCSR) is non-volatile. The
+// status bits of the MMX control and status register (MXCSR) are volatile, while the control bits
+// are non-volatile.
+// The direction flag DF in the %rFLAGS register must be clear (set to "forward" direction) on
+// function entry and return.
+// We don't need to do anything here: we don't alter the x87 state nor any of the registers just
+// mentioned in the machine code, and the payload functions obey the System V calling convention.
+// Also, we don't interfere with the Microsoft x64 or __vectorcall convention, as in these
+// conventions the x87 status word, the x87 control word, and the MMX control and status bits have
+// the same requirements in terms of volatility.
+//
+// However, the Microsoft x64 calling convention, and the __vectorcall convention that derives from
+// it, states
+// (https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention#callercallee-saved-registers):
+// "The x64 ABI considers the registers RAX, RCX, RDX, R8, R9, R10, R11, and XMM0-XMM5 volatile.
+// When present, the upper portions of YMM0-YMM15 [...] are also volatile. [...] Consider volatile
+// registers destroyed on function calls **unless otherwise safety-provable by analysis such as
+// whole program optimization**."
+// Compilers seem to make use of this possibility for optimization. For example, despite them being
+// volatile, we have observed R8, R9, R10, R11 being considered preserved across specific function
+// calls by some callers, i.e., being written before a function call and read after a function call
+// without backing up and restoring the content. Therefore, we decide to back up all registers that
+// are volatile in the Microsoft x64 calling convention, regardless of whether they are used for
+// parameter passing.
+// In the end, this results in backing up almost all registers that are volatile in the System V
+// calling convention, except for: the x87 registers ST{0..7}, which also include the MMX mm{0..7}
+// registers as their lower 8 bytes; the x87 status word; the status bits of MXCSR. We ignore these:
+// the Microsoft x64 and __vectorcall conventions call these "floating-point support for older code"
+// and states that "there's no explicit calling convention for" the MM{0..7}/ST{0..7} registers.
+//
+// Similarly, and more worryingly, the System V calling convention also states: "The standard
+// calling sequence requirements apply only to global functions. Local functions that are not
+// reachable from other compilation units may use different conventions. Nevertheless, it is
+// recommended that all functions use the standard calling sequence when possible."
+// For now, we assume that compilers follow the recommendation. Otherwise, we would probably have to
+// back up all registers. Note, though, that in practice this would only add RBX, R12, R13, R14 and
+// R15 (plus possibly the x87 and MMX registers).
+//
+// AVX-512 also introduced the ZMM{0..31} registers, to add another 32 bytes to the existing
+// YMM{0..15} and add 16 more of them. These are volatile in all the calling conventions we
+// consider. We are ignoring these registers for now as AVX-512 is not yet widely used or available,
+// but we will probably want to back up the full ZMM{0..7} registers in the future as they can be
+// used to pass values of vector type __m512 in the System V calling convention.
+//
+// In conclusion, we are backing up: RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11, XMM0-15 (YMM0-15 if
+// AVX is available).
+void AppendBackupCode(MachineCode& trampoline) {
+  // Back up the general purpose registers on the stack.
   //
-  // push rdi      57
-  // push rsi      56
-  // push rdx      52
-  // push rcx      51
-  // push r8       41 50
-  // push r9       41 51
-  // push rax      50
-  // push r10      41 52
-  trampoline.AppendBytes({0x57})
-      .AppendBytes({0x56})
-      .AppendBytes({0x52})
+  // push rax        50
+  // push rcx        51
+  // push rdx        52
+  // push rsi        56
+  // push rdi        57
+  // push r8         41 50
+  // push r9         41 51
+  // push r10        41 52
+  // push r11        41 53
+  trampoline.AppendBytes({0x50})
       .AppendBytes({0x51})
+      .AppendBytes({0x52})
+      .AppendBytes({0x56})
+      .AppendBytes({0x57})
       .AppendBytes({0x41, 0x50})
       .AppendBytes({0x41, 0x51})
-      .AppendBytes({0x50})
-      .AppendBytes({0x41, 0x52});
+      .AppendBytes({0x41, 0x52})
+      .AppendBytes({0x41, 0x53});
 
-  // We align the stack to 32 bytes first: round down to a multiple of 32, subtract another 24 and
-  // then push 8 byte original rsp. So we are 32 byte aligned after these commands and we can 'pop
-  // rsp' later to undo this.
+  // Align the stack to 32 bytes: round down to a multiple of 32, subtract another 24 and then push
+  // the original rsp (another 8 bytes). We can 'pop rsp' later to undo this.
   //
-  // mov rax, rsp
-  // and rsp, $0xffffffffffffffe0
-  // sub rsp, 0x18
-  // push rax
+  // mov rax, rsp                       48 89 e0
+  // and rsp, 0xffffffffffffffe0        48 83 e4 e0
+  // sub rsp, 0x18                      48 83 ec 18
+  // push rax                           50
   trampoline.AppendBytes({0x48, 0x89, 0xe0})
       .AppendBytes({0x48, 0x83, 0xe4, 0xe0})
       .AppendBytes({0x48, 0x83, 0xec, 0x18})
       .AppendBytes({0x50});
 
-  // Backup vector registers on the stack. They are used to pass float parameters so they need to be
-  // preserved. If Avx is supported backup ymm{0,..,7} (which include the xmm{0,..,7} registers as
-  // their lower half).
+  // Back up the vector registers on the stack. If AVX is supported, back up ymm{0,..,15} (which
+  // include the xmm{0,..,15} registers as their lower half).
   if (HasAvx()) {
-    // sub       rsp, 32
-    // vmovdqa   (rsp), ymm0
+    // sub       rsp, 32            48 83 ec 20
+    // vmovdqa   [rsp], ymm0        c5 fd 7f 04 24
     // ...
-    // sub       rsp, 32
-    // vmovdqa   (rsp), ymm7
+    // sub       rsp, 32            48 83 ec 20
+    // vmovdqa   [rsp], ymm15       c5 7d 7f 3c 24
     trampoline.AppendBytes({0x48, 0x83, 0xec, 0x20})
         .AppendBytes({0xc5, 0xfd, 0x7f, 0x04, 0x24})
         .AppendBytes({0x48, 0x83, 0xec, 0x20})
@@ -183,13 +223,29 @@ void AppendBackupCode(MachineCode& trampoline) {
         .AppendBytes({0x48, 0x83, 0xec, 0x20})
         .AppendBytes({0xc5, 0xfd, 0x7f, 0x34, 0x24})
         .AppendBytes({0x48, 0x83, 0xec, 0x20})
-        .AppendBytes({0xc5, 0xfd, 0x7f, 0x3c, 0x24});
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x3c, 0x24});
   } else {
-    // sub     rsp, 16
-    // movdqa  (rsp), xmm0
+    // sub     rsp, 16            48 83 ec 10
+    // movdqa  [rsp], xmm0        66 0f 7f 04 24
     // ...
-    // sub     rsp, 16
-    // movdqa  (rsp), xmm7
+    // sub     rsp, 16            48 83 ec 10
+    // movdqa  [rsp], xmm15       66 44 0f 7f 3c 24
     trampoline.AppendBytes({0x48, 0x83, 0xec, 0x10})
         .AppendBytes({0x66, 0x0f, 0x7f, 0x04, 0x24})
         .AppendBytes({0x48, 0x83, 0xec, 0x10})
@@ -205,38 +261,24 @@ void AppendBackupCode(MachineCode& trampoline) {
         .AppendBytes({0x48, 0x83, 0xec, 0x10})
         .AppendBytes({0x66, 0x0f, 0x7f, 0x34, 0x24})
         .AppendBytes({0x48, 0x83, 0xec, 0x10})
-        .AppendBytes({0x66, 0x0f, 0x7f, 0x3c, 0x24});
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x3c, 0x24});
   }
-
-  // Also back up xmm{8,..,15} as xmm{6,..,15} (but we already backed up xmm6 and xmm7 above) are
-  // callee-saved in the Microsoft x64 calling convention (e.g., under Wine), but not in the System
-  // V calling convention. Note that, even if AVX is supported, only the lower half of ymm{6,..,15}
-  // (xmm{6,..,15}) is callee-saved.
-  //
-  // RSI and RDI should also be backed up for the same reason, but that already happens as they are
-  // used for parameter passing in the System V calling convention.
-  //
-  // sub     rsp, 16
-  // movdqa  (rsp), xmm8
-  // ...
-  // sub     rsp, 16
-  // movdqa  (rsp), xmm15
-  trampoline.AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x04, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x0c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x14, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x1c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x24, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x2c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x34, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x3c, 0x24});
 }
 
 // Call the entry payload function with the return address, the id of the instrumented function,
@@ -246,17 +288,17 @@ void AppendBackupCode(MachineCode& trampoline) {
 // Application Binary Interface".
 void AppendCallToEntryPayload(uint64_t entry_payload_function_address,
                               uint64_t return_trampoline_address, MachineCode& trampoline) {
-  // At this point rax is the rsp after pushing the general purpose registers, so adding 0x40 gets
-  // us the location of the return address (see above in `AppendBackupCode`).
+  // At this point rax is the rsp after pushing the general purpose registers, so adding 0x48 (72)
+  // gets us the location of the return address (see above in `AppendBackupCode`).
 
-  // add rax, 0x40                                   48 83 c0 40
-  // mov rdi, (rax)                                  48 8b 38
+  // add rax, 0x48                                   48 83 c0 48
+  // mov rdi, [rax]                                  48 8b 38
   // mov rsi, function_id                            48 be function_id
   // mov rdx, rax                                    48 89 c2
   // mov rcx, return_trampoline_address              48 b9 return_trampoline_address
   // mov rax, entry_payload_function_address         48 b8 addr
   // call rax                                        ff d0
-  trampoline.AppendBytes({0x48, 0x83, 0xc0, 0x40})
+  trampoline.AppendBytes({0x48, 0x83, 0xc0, 0x48})
       .AppendBytes({0x48, 0x8b, 0x38})
       .AppendBytes({0x48, 0xbe});
   // This fails if the code for the trampoline was changed - see the comment at the declaration of
@@ -274,39 +316,30 @@ void AppendCallToEntryPayload(uint64_t entry_payload_function_address,
 }
 
 void AppendRestoreCode(MachineCode& trampoline) {
-  // Restore vector registers that are callee-saved in the Microsoft x64 calling convention, but not
-  // in the System V calling convention.
-  //
-  // movdqa   xmm15, (rsp)
-  // add rsp, $0x10
-  //...
-  // movdqa   xmm8, (rsp)
-  // add rsp, $0x10
-  trampoline.AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x3c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x34, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x2c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x24, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x1c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x14, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x0c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x04, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10});
-
-  // Restore vector registers (see comment on AppendBackupCode above).
+  // Restore the vector registers (see comment on AppendBackupCode above).
   if (HasAvx()) {
-    // vmovdqa   ymm7, (rsp)
-    // add       rsp, 32
+    // vmovdqa   ymm15, [rsp]        c5 7d 6f 3c 24
+    // add       rsp, 32             48 83 c4 20
     // ...
-    // vmovdqa   ymm0, (rsp)
-    // add       rsp, 32
-    trampoline.AppendBytes({0xc5, 0xfd, 0x6f, 0x3c, 0x24})
+    // vmovdqa   ymm0, [rsp]         c5 fd 6f 04 24
+    // add       rsp, 32             48 83 c4 20
+    trampoline.AppendBytes({0xc5, 0x7d, 0x6f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x3c, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x20})
         .AppendBytes({0xc5, 0xfd, 0x6f, 0x34, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x20})
@@ -323,12 +356,28 @@ void AppendRestoreCode(MachineCode& trampoline) {
         .AppendBytes({0xc5, 0xfd, 0x6f, 0x04, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x20});
   } else {
-    // movdqa   xmm7, (rsp)
-    // add rsp, $0x10
+    // movdqa   xmm15, [rsp]       66 44 0f 6f 3c 24
+    // add rsp, 0x10               48 83 c4 10
     //...
-    // movdqa   xmm0, (rsp)
-    // add rsp, $0x10
-    trampoline.AppendBytes({0x66, 0x0f, 0x6f, 0x3c, 0x24})
+    // movdqa   xmm0, [rsp]        66 0f 6f 04 24
+    // add rsp, 0x10               48 83 c4 10
+    trampoline.AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x3c, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x10})
         .AppendBytes({0x66, 0x0f, 0x6f, 0x34, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x10})
@@ -346,36 +395,39 @@ void AppendRestoreCode(MachineCode& trampoline) {
         .AppendBytes({0x48, 0x83, 0xc4, 0x10});
   }
 
-  // Undo the 32 byte alignment (see comment on AppendBackupCode above).
-  // pop rsp
+  // Undo the 32-byte alignment (see comment on AppendBackupCode above).
+  //
+  // pop rsp        5c
   trampoline.AppendBytes({0x5c});
 
   // Restore the general purpose registers (see comment on AppendBackupCode above).
-  // pop r10
-  // pop rax
-  // pop r9
-  // pop r8
-  // pop rcx
-  // pop rdx
-  // pop rsi
-  // pop rdi
-  trampoline.AppendBytes({0x41, 0x5a})
-      .AppendBytes({0x58})
+  // pop r11        41 5b
+  // pop r10        41 5a
+  // pop r9         41 59
+  // pop r8         41 58
+  // pop rdi        5f
+  // pop rsi        5e
+  // pop rdx        5a
+  // pop rcx        59
+  // pop rax        58
+  trampoline.AppendBytes({0x41, 0x5b})
+      .AppendBytes({0x41, 0x5a})
       .AppendBytes({0x41, 0x59})
       .AppendBytes({0x41, 0x58})
-      .AppendBytes({0x59})
-      .AppendBytes({0x5a})
+      .AppendBytes({0x5f})
       .AppendBytes({0x5e})
-      .AppendBytes({0x5f});
+      .AppendBytes({0x5a})
+      .AppendBytes({0x59})
+      .AppendBytes({0x58});
 }
 
 // Relocates instructions beginning at `function_address` into the trampoline until `kSizeOfJmp`
 // bytes at the beginning of the function are cleared.
 // Returns a mapping from old instruction start addresses in the function to new addresses in the
 // trampoline. The map is meant to be used to move instruction pointers inside the overwritten areas
-// into the correct positions in the trampoline. Therefore only the instructions after the first one
-// are included (function_address will contain a valid instruction - the jump into the trampoline -
-// when we are done).
+// into the correct positions in the trampoline. Therefore, only the instructions after the first
+// one are included (function_address will contain a valid instruction - the jump into the
+// trampoline - when we are done).
 [[nodiscard]] ErrorMessageOr<uint64_t> AppendRelocatedPrologueCode(
     uint64_t function_address, const std::vector<uint8_t>& function, uint64_t trampoline_address,
     csh capstone_handle, absl::flat_hash_map<uint64_t, uint64_t>& global_relocation_map,
@@ -434,7 +486,6 @@ void AppendRestoreCode(MachineCode& trampoline) {
                                                       MachineCode& trampoline) {
   const uint64_t address_after_jmp =
       trampoline_address + trampoline.GetResultAsVector().size() + kSizeOfJmp;
-  trampoline.AppendBytes({0xe9});
   ErrorMessageOr<int32_t> new_offset_or_error =
       AddressDifferenceAsInt32(address_after_prologue, address_after_jmp);
   // This should not happen since the trampoline is allocated such that it is located in the +-2GB
@@ -445,59 +496,91 @@ void AppendRestoreCode(MachineCode& trampoline) {
         "trampoline are more then +-2GB apart. address_after_prologue: %#x trampoline_address: %#x",
         address_after_prologue, trampoline_address));
   }
-  trampoline.AppendImmediate32(new_offset_or_error.value());
+  // jmp new_offset        e9 off
+  trampoline.AppendBytes({0xe9}).AppendImmediate32(new_offset_or_error.value());
   return outcome::success();
 }
 
-// First backup all the (potential) return values, in the System V calling convention (compare
-// section "3.2.3 Parameter Passing" in "System V Application Binary Interface"
-// https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf), in the Microsoft x64 calling
-// convention (see https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention), and in the
-// __vectorcall convention (see https://docs.microsoft.com/en-us/cpp/cpp/vectorcall).
-// Also back up registers that are callee-saved in the Microsoft x64 calling convention, but not in
-// the System V calling convention.
-// We make an exception: the top two elements of the x87 FPU register stack, st(0) and st(1), are
-// used to return (complex) long double values in the System V calling convention. We should back up
-// and restore them too, but only when they are actually used, as the calling convention also
-// requires to leave the x87 FPU register stack empty when leaving a function. This is not easy with
-// minimal overhead, so we simply decide not to back those registers up as the ExitPayload will not
-// use them anyway. More details in b/224446632.
-// Then call the exit payload, restore the return values and backed up registers, and finally jump
-// to the actual return address.
+// This code is executed immediately after the instrumented function has returned. We are going to
+// call the exit payload function, so we need to preserve the registers that might be used to return
+// values, and all registers that the payload might modify even if they are non-volatile in other
+// calling conventions.
+//
+// In particular, the System V calling convention returns values in RAX, RDX, XMM0, XMM1, ST0, ST1.
+// The Microsoft x64 calling convention returns values in RAX and XMM0.
+// The __vectorcall convention returns values in RAX and XMM{0..3} (YMM{0..3} if AVX is available).
+// In addition to the registers just mentioned, we also need to back up registers that are
+// non-volatile in the Microsoft x64 or __vectorcall conventions, but are volatile in the System V
+// calling convention.
+//
+// Almost everything that was said for the entry trampoline (see comment on AppendBackupCode above)
+// applies unchanged here. This includes backing up (almost) all registers that are volatile in the
+// Microsoft x64 or __vectorcall conventions.
+//
+// There is an additional detail, though: the top two elements of the x87 FPU register stack, ST0
+// and ST1 (we mentioned them above), are used in the System V calling convention to return `long
+// double` values (in ST0) and C99's `complex long double` values (real part in ST0, imaginary part
+// in ST1). We should back up and restore them, but only when they are actually used, as the calling
+// convention also requires us to leave the x87 FPU register stack empty when leaving a function
+// ("System V Application Binary Interface" for 64 bit is not clear on this, but this can be found
+// for 32 bit ,and we believe it carried over). This is not easy with minimal overhead, so we make
+// an exception: we simply decide not to back those registers up as the ExitPayload will not use
+// them anyway. More details in b/224446632.
+//
+// In conclusion, in the return trampoline we are backing up the same registers as in the entry
+// trampoline: RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11, ST0, ST1, XMM0-15 (YMM0-15 if AVX is
+// available).
+//
+// After having backed up these registers, called the exit payload, and restored the backed up
+// registers, we return to the actual return address, returned by the exit payload.
 void AppendCallToExitPayloadAndJumpToReturnAddress(uint64_t exit_payload_function_address,
                                                    MachineCode& return_trampoline) {
-  // Backup rax, rdx. Also back up rdi and rsi as they are callee-saved in the Microsoft x64 calling
-  // convention, but not in the System V calling convention.
+  // Make space to store the original return address returned by the ExitPayload.
   //
-  // push rax                                        50
-  // push rdx                                        52
-  // push rdi                                        57
-  // push rsi                                        56
-  return_trampoline.AppendBytes({0x50}).AppendBytes({0x52}).AppendBytes({0x57}).AppendBytes({0x56});
+  // sub rsp, 8        48 83 ec 08
+  return_trampoline.AppendBytes({0x48, 0x83, 0xec, 0x08});
 
-  // We align the stack to 32 bytes first: round down to a multiple of 32, subtract another 24 and
-  // then push 8 byte original rsp. So we are 32 byte aligned after these commands and we can 'pop
-  // rsp' later to undo this.
+  // Back up the general purpose registers.
   //
-  // mov rax, rsp                                    48 89 e0
-  // and rsp, 0xffffffffffffffe0                     48 83 e4 e0
-  // sub rsp, 0x18                                   48 83 ec 18
-  // push rax                                        50
+  // push rax        50
+  // push rcx        51
+  // push rdx        52
+  // push rsi        56
+  // push rdi        57
+  // push r8         41 50
+  // push r9         41 51
+  // push r10        41 52
+  // push r11        41 53
+  return_trampoline.AppendBytes({0x50})
+      .AppendBytes({0x51})
+      .AppendBytes({0x52})
+      .AppendBytes({0x56})
+      .AppendBytes({0x57})
+      .AppendBytes({0x41, 0x50})
+      .AppendBytes({0x41, 0x51})
+      .AppendBytes({0x41, 0x52})
+      .AppendBytes({0x41, 0x53});
+
+  // Align the stack to 32 bytes: round down to a multiple of 32, subtract another 24 and then push
+  // the original rsp (another 8 bytes). We can 'pop rsp' later to undo this.
+  //
+  // mov rax, rsp                       48 89 e0
+  // and rsp, 0xffffffffffffffe0        48 83 e4 e0
+  // sub rsp, 0x18                      48 83 ec 18
+  // push rax                           50
   return_trampoline.AppendBytes({0x48, 0x89, 0xe0})
       .AppendBytes({0x48, 0x83, 0xe4, 0xe0})
       .AppendBytes({0x48, 0x83, 0xec, 0x18})
       .AppendBytes({0x50});
 
-  // Store xmm{0,..,3} or ymm{0,..,3} on the stack, depending on whether AVX is available. xmm0 and
-  // xmm1 are used to return floating point values in the System V calling convention; xmm0 is used
-  // to return non-scalar types in the Microsoft x64 calling convention; xmm{0,..,3} or ymm{0,..,3}
-  // are used to return various types of values in the __vectorcall convention.
+  // Back up the vector registers on the stack. If AVX is supported backup ymm{0,..,15} (which
+  // include the xmm{0,..,15} registers as their lower half).
   if (HasAvx()) {
-    // sub       rsp, 32
-    // vmovdqa   (rsp), ymm0
+    // sub       rsp, 32            48 83 ec 20
+    // vmovdqa   [rsp], ymm0        c5 fd 7f 04 24
     // ...
-    // sub       rsp, 32
-    // vmovdqa   (rsp), ymm3
+    // sub       rsp, 32            48 83 ec 20
+    // vmovdqa   [rsp], ymm15       c5 7d 7f 3c 24
     return_trampoline.AppendBytes({0x48, 0x83, 0xec, 0x20})
         .AppendBytes({0xc5, 0xfd, 0x7f, 0x04, 0x24})
         .AppendBytes({0x48, 0x83, 0xec, 0x20})
@@ -505,13 +588,37 @@ void AppendCallToExitPayloadAndJumpToReturnAddress(uint64_t exit_payload_functio
         .AppendBytes({0x48, 0x83, 0xec, 0x20})
         .AppendBytes({0xc5, 0xfd, 0x7f, 0x14, 0x24})
         .AppendBytes({0x48, 0x83, 0xec, 0x20})
-        .AppendBytes({0xc5, 0xfd, 0x7f, 0x1c, 0x24});
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x7f, 0x3c, 0x24});
   } else {
-    // sub     rsp, 16
-    // movdqa  (rsp), xmm0
+    // sub     rsp, 16            48 83 ec 10
+    // movdqa  [rsp], xmm0        66 0f 7f 04 24
     // ...
-    // sub     rsp, 16
-    // movdqa  (rsp), xmm3
+    // sub     rsp, 16            48 83 ec 10
+    // movdqa  [rsp], xmm15       66 44 0f 7f 3c 24
     return_trampoline.AppendBytes({0x48, 0x83, 0xec, 0x10})
         .AppendBytes({0x66, 0x0f, 0x7f, 0x04, 0x24})
         .AppendBytes({0x48, 0x83, 0xec, 0x10})
@@ -519,86 +626,95 @@ void AppendCallToExitPayloadAndJumpToReturnAddress(uint64_t exit_payload_functio
         .AppendBytes({0x48, 0x83, 0xec, 0x10})
         .AppendBytes({0x66, 0x0f, 0x7f, 0x14, 0x24})
         .AppendBytes({0x48, 0x83, 0xec, 0x10})
-        .AppendBytes({0x66, 0x0f, 0x7f, 0x1c, 0x24});
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x3c, 0x24});
   }
 
-  // Also back up xmm{6,..,15} as they are callee-saved in the Microsoft x64 calling convention, but
-  // not in the System V calling convention.
+  // At this point, rax is the rsp after pushing nine general purpose registers, so adding 72 gets
+  // us the location where we want to store the original return address. Back up this value.
   //
-  // sub     rsp, 16
-  // movdqa  (rsp), xmm6
-  // ...
-  // sub     rsp, 16
-  // movdqa  (rsp), xmm15
-  return_trampoline.AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x0f, 0x7f, 0x34, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x0f, 0x7f, 0x3c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x04, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x0c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x14, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x1c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x24, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x2c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x34, 0x24})
-      .AppendBytes({0x48, 0x83, 0xec, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x7f, 0x3c, 0x24});
-
-  // Note that rsp is 32 byte aligned now - we can just do the call. Call the exit payload and move
-  // the return address (which is returned by the exit payload) to a register that is not backed up
-  // and restored -- we choose rcx.
+  // add rax, 72        48 83 c0 48
+  // push rax           50
+  return_trampoline.AppendBytes({0x48, 0x83, 0xc0, 0x48}).AppendBytes({0x50});
+  // Now call ExitPayload.
+  // rsp was 32-byte aligned before the push, so we need to realign to 16 bytes before calling
+  // ExitPayload, as required by both the System V calling convention (see section "3.2.2 The Stack
+  // Frame" in, again, "System V Application Binary Interface") and the Microsoft x64 and
+  // __vectorcall conventions (see
+  // https://docs.microsoft.com/en-us/cpp/build/stack-usage#stack-allocation):
   //
-  // mov rax, exit_payload_function_address          48 b8 addr
-  // call rax                                        ff d0
-  // mov rcx, rax                                    48 89 c1
-  return_trampoline.AppendBytes({0x48, 0xb8})
+  // sub rsp, 0x08                                 48 83 ec 08
+  // mov rax, exit_payload_function_address        48 b8 addr
+  // call rax                                      ff d0
+  return_trampoline.AppendBytes({0x48, 0x83, 0xec, 0x08})
+      .AppendBytes({0x48, 0xb8})
       .AppendImmediate64(exit_payload_function_address)
-      .AppendBytes({0xff, 0xd0})
-      .AppendBytes({0x48, 0x89, 0xc1});
+      .AppendBytes({0xff, 0xd0});
+  // The original return address is now in rax. Place it in the desired location, which we recover
+  // from the stack and temporarily place in rcx.
+  //
+  // add rsp, 0x08         48 83 c4 08
+  // pop rcx               59
+  // mov [rcx], rax        48 89 01
+  return_trampoline.AppendBytes({0x48, 0x83, 0xc4, 0x08})
+      .AppendBytes({0x59})
+      .AppendBytes({0x48, 0x89, 0x01});
 
-  // Restore in reverse order: xmm{15..6}; xmm{3..0} or ymm{3..0}; pop rsp; st(1), st(0), rsi, rdi,
-  // rdx, rax.
-
-  // movdqa   xmm15, (rsp)
-  // add rsp, $0x10
-  //...
-  // movdqa   xmm6, (rsp)
-  // add rsp, $0x10
-  return_trampoline.AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x3c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x34, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x2c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x24, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x1c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x14, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x0c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x04, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x0f, 0x6f, 0x3c, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10})
-      .AppendBytes({0x66, 0x0f, 0x6f, 0x34, 0x24})
-      .AppendBytes({0x48, 0x83, 0xc4, 0x10});
-
+  // Restore the vector registers.
   if (HasAvx()) {
-    // vmovdqa   ymm3, (rsp)
-    // add       rsp, 32
+    // vmovdqa   ymm15, [rsp]        c5 7d 6f 3c 24
+    // add       rsp, 32             48 83 c4 20
     // ...
-    // vmovdqa   ymm0, (rsp)
-    // add       rsp, 32
-    return_trampoline.AppendBytes({0xc5, 0xfd, 0x6f, 0x1c, 0x24})
+    // vmovdqa   ymm0, [rsp]         c5 fd 6f 04 24
+    // add       rsp, 32             48 83 c4 20
+    return_trampoline.AppendBytes({0xc5, 0x7d, 0x6f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0x7d, 0x6f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x1c, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x20})
         .AppendBytes({0xc5, 0xfd, 0x6f, 0x14, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x20})
@@ -607,12 +723,36 @@ void AppendCallToExitPayloadAndJumpToReturnAddress(uint64_t exit_payload_functio
         .AppendBytes({0xc5, 0xfd, 0x6f, 0x04, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x20});
   } else {
-    // movdqa   xmm3, (rsp)
-    // add rsp, $0x10
+    // movdqa   xmm15, [rsp]       66 44 0f 6f 3c 24
+    // add rsp, 0x10               48 83 c4 10
     //...
-    // movdqa   xmm0, (rsp)
-    // add rsp, $0x10
-    return_trampoline.AppendBytes({0x66, 0x0f, 0x6f, 0x1c, 0x24})
+    // movdqa   xmm0, [rsp]        66 0f 6f 04 24
+    // add rsp, 0x10               48 83 c4 10
+    return_trampoline.AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x44, 0x0f, 0x6f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x1c, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x10})
         .AppendBytes({0x66, 0x0f, 0x6f, 0x14, 0x24})
         .AppendBytes({0x48, 0x83, 0xc4, 0x10})
@@ -622,18 +762,34 @@ void AppendCallToExitPayloadAndJumpToReturnAddress(uint64_t exit_payload_functio
         .AppendBytes({0x48, 0x83, 0xc4, 0x10});
   }
 
-  // pop rsp                                         5c
+  // Undo the 32-byte alignment.
+  //
+  // pop rsp        5c
   return_trampoline.AppendBytes({0x5c});
 
-  // pop rsi                                         5e
-  // pop rdi                                         5f
-  // pop rdx                                         5a
-  // pop rax                                         58
-  return_trampoline.AppendBytes({0x5e}).AppendBytes({0x5f}).AppendBytes({0x5a}).AppendBytes({0x58});
+  // Restore the general purpose registers.
+  // pop r11        41 5b
+  // pop r10        41 5a
+  // pop r9         41 59
+  // pop r8         41 58
+  // pop rdi        5f
+  // pop rsi        5e
+  // pop rdx        5a
+  // pop rcx        59
+  // pop rax        58
+  return_trampoline.AppendBytes({0x41, 0x5b})
+      .AppendBytes({0x41, 0x5a})
+      .AppendBytes({0x41, 0x59})
+      .AppendBytes({0x41, 0x58})
+      .AppendBytes({0x5f})
+      .AppendBytes({0x5e})
+      .AppendBytes({0x5a})
+      .AppendBytes({0x59})
+      .AppendBytes({0x58});
 
-  // Jump to the actual return address.
-  // jmp rcx                                         ff e1
-  return_trampoline.AppendBytes({0xff, 0xe1});
+  // Return to the actual return address, which is now at the top of the stack.
+  // ret        c3
+  return_trampoline.AppendBytes({0xc3});
 }
 
 }  // namespace

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -110,7 +110,7 @@ struct RelocatedInstruction {
                                                                        uint64_t old_address,
                                                                        uint64_t new_address);
 
-// Strictly speaking the max trampoline size is a compile time constant, but we prefer to compute it
+// Strictly speaking the max trampoline size is a compile-time constant, but we prefer to compute it
 // here since this captures every change to the code constructing the trampoline.
 [[nodiscard]] uint64_t GetMaxTrampolineSize();
 
@@ -135,18 +135,19 @@ struct RelocatedInstruction {
     uint64_t return_trampoline_address, csh capstone_handle,
     absl::flat_hash_map<uint64_t, uint64_t>& relocation_map);
 
-// As above with `GetMaxTrampolineSize` this is a compile time constant, but we prefer to compute it
+// As above with `GetMaxTrampolineSize` this is a compile-time constant, but we prefer to compute it
 // here since this captures every change to the code constructing the return trampoline.
 [[nodiscard]] uint64_t GetReturnTrampolineSize();
 
 // Creates a "return trampoline" i.e. a bit of code that is used as a target for overwritten return
-// addresses. It calls the function `exit_payload_function_address` and jumps to the return value of
-// that function. The return trampoline is constructed at address `return_trampoline_address`.
-// Unlike what is done in `CreateTrampoline` we don't need an individual trampoline for each
-// function we instrument. The different functions are disambiguated by the order in which the
-// function exit appears (and it is the responsibility of the payload functions to keep track of
-// this). Also the return trampoline does not need to be located close (32 bit offset) to any
-// specific code location; all jumps involved are to absolute 64 bit addresses.
+// addresses. It calls the function `exit_payload_function_address` and returns to the return value
+// of that function (the original return address). The return trampoline is constructed at address
+// `return_trampoline_address`. Unlike what is done in `CreateTrampoline`, we don't need an
+// individual trampoline for each function we instrument. The different functions are disambiguated
+// by the order in which the function exit appears (and it is the responsibility of the payload
+// functions to keep track of this). Also, the return trampoline does not need to be located close
+// (32 bit offset) to any specific code location; all jumps involved are to absolute 64 bit
+// addresses.
 [[nodiscard]] ErrorMessageOr<void> CreateReturnTrampoline(pid_t pid,
                                                           uint64_t exit_payload_function_address,
                                                           uint64_t return_trampoline_address);


### PR DESCRIPTION
We have observed some Windows functions (running on Wine) calling other
functions assuming that some registers are non-volatile even if they are
volatile according to the calling convention. This is likely an optimization
based on "Consider volatile registers destroyed on function calls unless
otherwise safety-provable by analysis such as whole program optimization" from
https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention#callercallee-saved-registers.

We decide to just back up all registers that are volatile in the Microsoft x64
and __vectorcall conventions (except for x87 and MMX registers, it doesn't seem
to make a lot of sense), in addition to the ones we were already backing up.

This effectively adds:
- entry trampoline: R11, upper part of YMM8-15 if AVX;
- return trampoline: RCX, R8, R9, R10, R11, X/YMM4-5, upper part of YMM6-15 if
  AVX.

As RCX is now backed up, the return address of the `ExitPayload` is stored on
the stack and jumped to with a `ret`.

Some comments are re-worked.

Performance implications: on my usual single-threaded benchmark with the
instrumented function called one million times per second, the overhead is
measurable but doesn't exceed 20 ns.

Bug: http://b/219015201

Test: Tried on mentioned single-threaded benchmark, on Trata, on Windows binary
that showed the issue described above.