### PR TITLE
String encoding conversion utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,10 @@ add_definitions(-DNOMINMAX)
 add_definitions(-DUNICODE -D_UNICODE)
 
 if (MSVC)
-  string(APPEND CMAKE_CXX_FLAGS " /MP")
+  # Build with Multiple Processes.
+  add_compile_options("/MP")
+  # Set source and execution character sets to UTF-8.
+  add_compile_options("/utf-8")
 endif()
 
 if(WIN32)

--- a/src/ObjectUtils/PdbFileDia.cpp
+++ b/src/ObjectUtils/PdbFileDia.cpp
@@ -12,6 +12,7 @@
 #include "ObjectUtils/PdbUtilsDia.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/StringConversion.h"
 
 using orbit_grpc_protos::ModuleSymbols;
 using orbit_grpc_protos::SymbolInfo;
@@ -103,8 +104,7 @@ ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> PdbFileDia::LoadDebugSymbols() 
 
     BSTR function_name = {};
     if (dia_symbol->get_name(&function_name) != S_OK) continue;
-    std::wstring name(function_name);
-    symbol_info.set_name(std::string(name.begin(), name.end()));
+    symbol_info.set_name(orbit_base::Narrow(function_name));
     ErrorMessageOr<std::string> parameter_list_or_error = PdbDiaParameterListAsString(dia_symbol);
     if (parameter_list_or_error.has_value()) {
       symbol_info.set_demangled_name(symbol_info.name() + parameter_list_or_error.value());

--- a/src/ObjectUtils/PdbFileDia.cpp
+++ b/src/ObjectUtils/PdbFileDia.cpp
@@ -104,7 +104,7 @@ ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> PdbFileDia::LoadDebugSymbols() 
 
     BSTR function_name = {};
     if (dia_symbol->get_name(&function_name) != S_OK) continue;
-    symbol_info.set_name(orbit_base::Narrow(function_name));
+    symbol_info.set_name(orbit_base::ToStdString(function_name));
     ErrorMessageOr<std::string> parameter_list_or_error = PdbDiaParameterListAsString(dia_symbol);
     if (parameter_list_or_error.has_value()) {
       symbol_info.set_demangled_name(symbol_info.name() + parameter_list_or_error.value());

--- a/src/ObjectUtils/PdbUtilsDia.cpp
+++ b/src/ObjectUtils/PdbUtilsDia.cpp
@@ -276,7 +276,7 @@ ErrorMessageOr<std::string> PdbDiaTypeAsString(IDiaSymbol* type,
   BSTR type_name_bstr = {};
   std::string type_name;
   if (SUCCEEDED(type->get_name(&type_name_bstr)) && type_name_bstr != NULL) {
-    type_name = orbit_base::Narrow(type_name_bstr);
+    type_name = orbit_base::ToStdString(type_name_bstr);
     SysFreeString(type_name_bstr);
   }
 

--- a/src/ObjectUtils/PdbUtilsDia.cpp
+++ b/src/ObjectUtils/PdbUtilsDia.cpp
@@ -16,6 +16,7 @@
 #include <absl/strings/str_join.h>
 
 #include "OrbitBase/GetLastError.h"
+#include "OrbitBase/StringConversion.h"
 
 namespace {
 [[nodiscard]] ErrorMessageOr<std::string> GetSignedIntegerTypeFromSizeInBytes(IDiaSymbol* type) {
@@ -275,8 +276,7 @@ ErrorMessageOr<std::string> PdbDiaTypeAsString(IDiaSymbol* type,
   BSTR type_name_bstr = {};
   std::string type_name;
   if (SUCCEEDED(type->get_name(&type_name_bstr)) && type_name_bstr != NULL) {
-    std::wstring type_name_wstring{type_name_bstr};
-    type_name = std::string(type_name_wstring.begin(), type_name_wstring.end());
+    type_name = orbit_base::Narrow(type_name_bstr);
     SysFreeString(type_name_bstr);
   }
 

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(OrbitBase PRIVATE
         ReadFileToString.cpp
         SafeStrerror.cpp
         SimpleExecutor.cpp
+        StringConversion.cpp
         TemporaryFile.cpp
         ThreadPool.cpp
         WriteStringToFile.cpp)

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/SafeStrerror.h
         include/OrbitBase/SharedState.h
         include/OrbitBase/SimpleExecutor.h
+        include/OrbitBase/StringConversion.h
         include/OrbitBase/TaskGroup.h
         include/OrbitBase/TemporaryFile.h
         include/OrbitBase/ThreadConstants.h
@@ -107,6 +108,7 @@ target_sources(OrbitBaseTests PRIVATE
         ReadFileToStringTest.cpp
         ResultTest.cpp
         SimpleExecutorTest.cpp
+        StringConversionTest.cpp
         TaskGroupTest.cpp
         TemporaryFileTest.cpp
         ThreadUtilsTest.cpp

--- a/src/OrbitBase/StringConversion.cpp
+++ b/src/OrbitBase/StringConversion.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitBase/StringConversion.h"
+
+#include <codecvt>
+#include <locale>
+
+namespace orbit_base {
+
+#ifdef _WIN32
+// On Windows, wchar_t is a 16-bit wide UTF-16 unicode character that we convert to and from UTF-8.
+using PlatformWStringConversionFacet = std::codecvt_utf8_utf16<wchar_t>;
+#else
+// On Linux, wchar_t is a 32-bit wide UTF-32 unicode character that we convert to and from UTF-8.
+using PlatformWStringConversionFacet = std::codecvt_utf8<wchar_t>;
+#endif
+
+std::string ToStdString(std::wstring_view wide_string) {
+  std::wstring_convert<PlatformWStringConversionFacet> converter;
+  return converter.to_bytes(wide_string.data(), wide_string.data() + wide_string.length());
+}
+
+std::wstring ToStdWString(std::string_view string) {
+  std::wstring_convert<PlatformWStringConversionFacet> converter;
+  return converter.from_bytes(string.data(), string.data() + string.length());
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/StringConversionTest.cpp
+++ b/src/OrbitBase/StringConversionTest.cpp
@@ -4,43 +4,64 @@
 
 #include <gtest/gtest.h>
 
+#include "OrbitBase/Logging.h"
 #include "OrbitBase/StringConversion.h"
 
 namespace {
 
-const std::wstring kAsciiWideString = L"Ascii string";
-const std::string kAsciiString = "Ascii string";
-const std::wstring kUnicodeWideString = L"CaféSchloß🏰🚀😎🐨😁";
-const std::string kUnicodeString = "CaféSchloß🏰🚀😎🐨😁";
+constexpr const wchar_t* kAsciiWideString = L"Ascii string";
+constexpr const char* kAsciiString = "Ascii string";
+constexpr const wchar_t* kUnicodeWideString = L"CaféSchloß☕🏰🚀😎🐨😁";
+constexpr const char* kUnicodeString = "CaféSchloß☕🏰🚀😎🐨😁";
+const std::string kEmptyString;
+const std::wstring kEmptyWideString;
 
 }  // namespace
 
 TEST(StringConversion, NarrowAscii) {
-  // Ascii string.
-  EXPECT_EQ(orbit_base::Narrow(kAsciiWideString), kAsciiString);
+  // const wchar_t* to std::string.
+  EXPECT_EQ(orbit_base::ToStdString(kAsciiWideString), kAsciiString);
+
+  // std::wstring to std::string.
+  EXPECT_EQ(orbit_base::ToStdString(std::wstring(kAsciiWideString)), kAsciiString);
 }
 
 TEST(StringConversion, WidenAscii) {
-  // Ascii string.
-  EXPECT_EQ(orbit_base::Widen(kAsciiString), kAsciiWideString);
+  // const char* to std::wstring.
+  EXPECT_EQ(orbit_base::ToStdWString(kAsciiString), kAsciiWideString);
+
+  // std::string to std::wstring.
+  EXPECT_EQ(orbit_base::ToStdWString(std::string(kAsciiString)), kAsciiWideString);
 }
 
 TEST(StringConversion, NarrowUnicode) {
-  // Unicode string.
-  EXPECT_EQ(orbit_base::Narrow(kUnicodeWideString), kUnicodeString);
+  // const wchar_t* to std::string.
+  EXPECT_EQ(orbit_base::ToStdString(kUnicodeWideString), kUnicodeString);
+
+  // std::wstring to std::string.
+  EXPECT_EQ(orbit_base::ToStdString(std::wstring(kUnicodeWideString)), kUnicodeString);
 }
 
 TEST(StringConversion, WidenUnicode) {
-  // Unicode string.
-  EXPECT_EQ(orbit_base::Widen(kUnicodeString), kUnicodeWideString);
+  // const char* to std::wstring.
+  EXPECT_EQ(orbit_base::ToStdWString(kUnicodeString), kUnicodeWideString);
+
+  // std::string to std::wstring.
+  EXPECT_EQ(orbit_base::ToStdWString(std::string(kUnicodeString)), kUnicodeWideString);
 }
 
 TEST(StringConversion, NarrowEmpty) {
-  // Empty string.
-  EXPECT_EQ(orbit_base::Narrow(L""), "");
+  // const wchar_t* to std::string.
+  EXPECT_EQ(orbit_base::ToStdString(L""), "");
+
+  // std::wstring to std::string.
+  EXPECT_EQ(orbit_base::ToStdString(kEmptyWideString), "");
 }
 
 TEST(StringConversion, WidenEmpty) {
-  // Empty string.
-  EXPECT_EQ(orbit_base::Widen(""), L"");
+  // const char* to std::wstring.
+  EXPECT_EQ(orbit_base::ToStdWString(""), L"");
+
+  // std::string to std::wstring.
+  EXPECT_EQ(orbit_base::ToStdWString(kEmptyString), L"");
 }

--- a/src/OrbitBase/StringConversionTest.cpp
+++ b/src/OrbitBase/StringConversionTest.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/StringConversion.h"
+
+namespace {
+
+const std::wstring kAsciiWideString = L"Ascii string";
+const std::string kAsciiString = "Ascii string";
+const std::wstring kUnicodeWideString = L"CaféSchloß🏰🚀😎🐨😁";
+const std::string kUnicodeString = "CaféSchloß🏰🚀😎🐨😁";
+
+}  // namespace
+
+TEST(StringConversion, NarrowAscii) {
+  // Ascii string.
+  EXPECT_EQ(orbit_base::Narrow(kAsciiWideString), kAsciiString);
+}
+
+TEST(StringConversion, WidenAscii) {
+  // Ascii string.
+  EXPECT_EQ(orbit_base::Widen(kAsciiString), kAsciiWideString);
+}
+
+TEST(StringConversion, NarrowUnicode) {
+  // Unicode string.
+  EXPECT_EQ(orbit_base::Narrow(kUnicodeWideString), kUnicodeString);
+}
+
+TEST(StringConversion, WidenUnicode) {
+  // Unicode string.
+  EXPECT_EQ(orbit_base::Widen(kUnicodeString), kUnicodeWideString);
+}
+
+TEST(StringConversion, NarrowEmpty) {
+  // Empty string.
+  EXPECT_EQ(orbit_base::Narrow(L""), "");
+}
+
+TEST(StringConversion, WidenEmpty) {
+  // Empty string.
+  EXPECT_EQ(orbit_base::Widen(""), L"");
+}

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -9,6 +9,7 @@
 
 #include "OrbitBase/GetProcAddress.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/StringConversion.h"
 #include "OrbitBase/ThreadUtils.h"
 
 namespace orbit_base {
@@ -88,9 +89,8 @@ std::string GetThreadNameNative(uint32_t tid) {
   // Get thread name from handle.
   PWSTR thread_name_pwstr;
   if (SUCCEEDED((*get_thread_description)(thread_handle, &thread_name_pwstr))) {
-    std::wstring thread_name_w(thread_name_pwstr);
+    std::string thread_name = orbit_base::Narrow(thread_name_pwstr);
     LocalFree(thread_name_pwstr);
-    std::string thread_name(thread_name_w.begin(), thread_name_w.end());
     return thread_name;
   }
 

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -89,7 +89,7 @@ std::string GetThreadNameNative(uint32_t tid) {
   // Get thread name from handle.
   PWSTR thread_name_pwstr;
   if (SUCCEEDED((*get_thread_description)(thread_handle, &thread_name_pwstr))) {
-    std::string thread_name = orbit_base::Narrow(thread_name_pwstr);
+    std::string thread_name = orbit_base::ToStdString(thread_name_pwstr);
     LocalFree(thread_name_pwstr);
     return thread_name;
   }

--- a/src/OrbitBase/include/OrbitBase/StringConversion.h
+++ b/src/OrbitBase/include/OrbitBase/StringConversion.h
@@ -5,33 +5,16 @@
 #ifndef ORBIT_BASE_STRING_CONVERSION_H_
 #define ORBIT_BASE_STRING_CONVERSION_H_
 
-#include <codecvt>
-#include <locale>
 #include <string>
+#include <string_view>
 
 namespace orbit_base {
 
-#if WIN32
-// On Windows, wchar_t is a 16-bit wide UTF-16 unicode character that we convert to and from UTF-8.
-using PlatformWStringConversionFacet = std::codecvt_utf8_utf16<wchar_t>;
-#else
-// On Linux, wchar_t is a 32-bit wide UTF-32 unicode character that we convert to and from UTF-8.
-using PlatformWStringConversionFacet = std::codecvt_utf8<wchar_t>;
-#endif
-
 // Convert a wide string to a std::string.
-template <typename T>
-[[nodiscard]] std::string Narrow(const T& wide_string) {
-  static std::wstring_convert<PlatformWStringConversionFacet> converter;
-  return converter.to_bytes(wide_string);
-}
+[[nodiscard]] std::string ToStdString(std::wstring_view wide_string);
 
 // Convert a narrow string to a std::wstring.
-template <typename T>
-[[nodiscard]] std::wstring Widen(const T& string) {
-  static std::wstring_convert<PlatformWStringConversionFacet> converter;
-  return converter.from_bytes(string);
-}
+[[nodiscard]] std::wstring ToStdWString(std::string_view string);
 
 }  // namespace orbit_base
 

--- a/src/OrbitBase/include/OrbitBase/StringConversion.h
+++ b/src/OrbitBase/include/OrbitBase/StringConversion.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_STRING_CONVERSION_H_
+#define ORBIT_BASE_STRING_CONVERSION_H_
+
+#include <codecvt>
+#include <locale>
+#include <string>
+
+namespace orbit_base {
+
+#if WIN32
+// On Windows, wchar_t is a 16-bit wide UTF-16 unicode character that we convert to and from UTF-8.
+using PlatformWStringConversionFacet = std::codecvt_utf8_utf16<wchar_t>;
+#else
+// On Linux, wchar_t is a 32-bit wide UTF-32 unicode character that we convert to and from UTF-8.
+using PlatformWStringConversionFacet = std::codecvt_utf8<wchar_t>;
+#endif
+
+// Convert a wide string to a std::string.
+template <typename T>
+[[nodiscard]] std::string Narrow(const T& wide_string) {
+  static std::wstring_convert<PlatformWStringConversionFacet> converter;
+  return converter.to_bytes(wide_string);
+}
+
+// Convert a narrow string to a std::wstring.
+template <typename T>
+[[nodiscard]] std::wstring Widen(const T& string) {
+  static std::wstring_convert<PlatformWStringConversionFacet> converter;
+  return converter.from_bytes(string);
+}
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_STRING_CONVERSION_H_

--- a/src/WindowsUtils/AdjustTokenPrivilege.cpp
+++ b/src/WindowsUtils/AdjustTokenPrivilege.cpp
@@ -9,7 +9,7 @@
 namespace orbit_windows_utils {
 
 ErrorMessageOr<void> AdjustTokenPrivilege(LPCTSTR token_name, bool enabled) {
-  std::string token_name_str = orbit_base::Narrow(token_name);
+  std::string token_name_str(orbit_base::ToStdString(token_name));
   HANDLE token_handle;
   if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &token_handle)) {
     return ErrorMessage{absl::StrFormat("Unable to open process token \"%s\"", token_name_str)};

--- a/src/WindowsUtils/AdjustTokenPrivilege.cpp
+++ b/src/WindowsUtils/AdjustTokenPrivilege.cpp
@@ -4,11 +4,12 @@
 
 #include "WindowsUtils/AdjustTokenPrivilege.h"
 
+#include "OrbitBase/StringConversion.h"
+
 namespace orbit_windows_utils {
 
 ErrorMessageOr<void> AdjustTokenPrivilege(LPCTSTR token_name, bool enabled) {
-  std::wstring token_name_wstr(token_name);
-  std::string token_name_str(token_name_wstr.begin(), token_name_wstr.end());
+  std::string token_name_str = orbit_base::Narrow(token_name);
   HANDLE token_handle;
   if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &token_handle)) {
     return ErrorMessage{absl::StrFormat("Unable to open process token \"%s\"", token_name_str)};

--- a/src/WindowsUtils/ListModules.cpp
+++ b/src/WindowsUtils/ListModules.cpp
@@ -11,6 +11,7 @@
 
 #include "ObjectUtils/CoffFile.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/StringConversion.h"
 #include "OrbitBase/UniqueResource.h"
 
 // clang-format off
@@ -45,11 +46,8 @@ std::vector<Module> ListModules(uint32_t pid) {
   // Walk the module list of the process.
   std::vector<Module> modules;
   do {
-    std::wstring module_name_w = module_entry.szModule;
-    std::wstring module_path_w = module_entry.szExePath;
-
     std::string build_id;
-    std::string module_path = std::string(module_path_w.begin(), module_path_w.end());
+    std::string module_path = orbit_base::Narrow(module_entry.szExePath);
     auto coff_file_or_error = orbit_object_utils::CreateCoffFile(module_path);
     if (coff_file_or_error.has_value()) {
       build_id = coff_file_or_error.value()->GetBuildId();
@@ -59,7 +57,7 @@ std::vector<Module> ListModules(uint32_t pid) {
     }
 
     Module& module = modules.emplace_back();
-    module.name = std::string(module_name_w.begin(), module_name_w.end());
+    module.name = orbit_base::Narrow(module_entry.szModule);
     module.full_path = module_path;
     module.file_size = module_entry.modBaseSize;
     module.address_start = absl::bit_cast<uint64_t>(module_entry.modBaseAddr);

--- a/src/WindowsUtils/ListModules.cpp
+++ b/src/WindowsUtils/ListModules.cpp
@@ -47,7 +47,7 @@ std::vector<Module> ListModules(uint32_t pid) {
   std::vector<Module> modules;
   do {
     std::string build_id;
-    std::string module_path = orbit_base::Narrow(module_entry.szExePath);
+    std::string module_path = orbit_base::ToStdString(module_entry.szExePath);
     auto coff_file_or_error = orbit_object_utils::CreateCoffFile(module_path);
     if (coff_file_or_error.has_value()) {
       build_id = coff_file_or_error.value()->GetBuildId();
@@ -57,7 +57,7 @@ std::vector<Module> ListModules(uint32_t pid) {
     }
 
     Module& module = modules.emplace_back();
-    module.name = orbit_base::Narrow(module_entry.szModule);
+    module.name = orbit_base::ToStdString(module_entry.szModule);
     module.full_path = module_path;
     module.file_size = module_entry.modBaseSize;
     module.address_start = absl::bit_cast<uint64_t>(module_entry.modBaseAddr);

--- a/src/WindowsUtils/ProcessList.cpp
+++ b/src/WindowsUtils/ProcessList.cpp
@@ -150,7 +150,7 @@ ErrorMessageOr<void> ProcessListImpl::Refresh() {
     auto it = process_infos_.find(pid);
     if (it == process_infos_.end()) {
       ProcessInfo& process_info = process_infos_[pid];
-      std::string process_name = orbit_base::Narrow(process_entry.szExeFile);
+      std::string process_name = orbit_base::ToStdString(process_entry.szExeFile);
       char full_path[MAX_PATH] = {0};
       // Assume 64 bit as the default.
       bool is_64_bit = true;

--- a/src/WindowsUtils/ProcessList.cpp
+++ b/src/WindowsUtils/ProcessList.cpp
@@ -16,6 +16,7 @@
 #include "OrbitBase/GetLastError.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Profiling.h"
+#include "OrbitBase/StringConversion.h"
 #include "OrbitBase/UniqueResource.h"
 
 // clang-format off
@@ -149,8 +150,7 @@ ErrorMessageOr<void> ProcessListImpl::Refresh() {
     auto it = process_infos_.find(pid);
     if (it == process_infos_.end()) {
       ProcessInfo& process_info = process_infos_[pid];
-      std::wstring process_name_w = process_entry.szExeFile;
-      std::string process_name(process_name_w.begin(), process_name_w.end());
+      std::string process_name = orbit_base::Narrow(process_entry.szExeFile);
       char full_path[MAX_PATH] = {0};
       // Assume 64 bit as the default.
       bool is_64_bit = true;


### PR DESCRIPTION
Add StringConversion.h which contains "ToStdString" and "ToStdWString" 
functions to convert to and from a wide string and a Utf-8 string.

On Windows, wchar_t is a 16-bit wide UTF-16 unicode character that we
convert to and from UTF-8. On Linux, wchar_t is a 32-bit wide UTF-32
unicode character that we convert to and from UTF-8. The different
wchar_t representations require to specify a conversion facet per
platform (PlatformWStringConversionFacet). "Narrow" is a Utf-16 to Utf-8
conversion on Windows and a Utf-32 to Utf-8 conversion on Linux.

Replace truncating conversions from wide-string to string by
"Narrow" calls in Windows code to properly convert strings
retrieved from the Windows API from Utf-16 to Utf-8.

Add "/utf-8" compiler flag on Windows to set the source and execution
character sets to Utf-8. This is needed to make sure the narrow string
literals in the code are Utf-8 encoded, which is mainly useful for the
tests, but it's nice to be clear about the string encoding we use in the
code.

Add StringConversionTest.cpp to test the string conversions.