### PR TITLE
Refactor/Dedup code in SymbolsDialogTest

### DIFF
--- a/src/ConfigWidgets/SymbolsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolsDialogTest.cpp
@@ -40,9 +40,7 @@ class MockPersistentStorageManager : public orbit_symbol_paths::PersistentStorag
 class SymbolsDialogTest : public ::testing::Test {
  protected:
   explicit SymbolsDialogTest() {
-    EXPECT_CALL(mock_storage_manager_, LoadPaths).WillOnce(testing::Return([this]() {
-      return load_paths_;
-    }));
+    EXPECT_CALL(mock_storage_manager_, LoadPaths).WillOnce(testing::Return(std::ref(load_paths_)));
     EXPECT_CALL(mock_storage_manager_, SavePaths)
         .WillOnce([this](absl::Span<const std::filesystem::path> paths) {
           EXPECT_EQ(paths, expected_save_paths_);

--- a/src/ConfigWidgets/SymbolsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolsDialogTest.cpp
@@ -40,7 +40,9 @@ class MockPersistentStorageManager : public orbit_symbol_paths::PersistentStorag
 class SymbolsDialogTest : public ::testing::Test {
  protected:
   explicit SymbolsDialogTest() {
-    EXPECT_CALL(mock_storage_manager_, LoadPaths).WillOnce(testing::Return(load_paths_));
+    EXPECT_CALL(mock_storage_manager_, LoadPaths).WillOnce(testing::Return([this]() {
+      return load_paths_;
+    }));
     EXPECT_CALL(mock_storage_manager_, SavePaths)
         .WillOnce([this](absl::Span<const std::filesystem::path> paths) {
           EXPECT_EQ(paths, expected_save_paths_);

--- a/src/ConfigWidgets/SymbolsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolsDialogTest.cpp
@@ -83,7 +83,7 @@ TEST(SymbolsDialog, ConstructWithElfModule) {
   MockPersistentStorageManager mock_storage_manager;
   SetUpExpectMockCalls(&mock_storage_manager);
 
-  SymbolsDialog dialog{&mock_storage_manager, false, &module};
+  SymbolsDialog dialog{&mock_storage_manager, &module};
 }
 
 TEST(SymbolsDialog, TryAddSymbolPath) {
@@ -174,7 +174,7 @@ TEST(SymbolsDialog, TryAddSymbolFileWithModuleNoOverride) {
   MockPersistentStorageManager mock_storage_manager;
   SetUpExpectMockCalls(&mock_storage_manager, {}, save_paths);
 
-  SymbolsDialog dialog{&mock_storage_manager, false, &module};
+  SymbolsDialog dialog{&mock_storage_manager, &module};
 
   // Success (build id matches)
   {

--- a/src/ConfigWidgets/SymbolsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolsDialogTest.cpp
@@ -39,27 +39,24 @@ class MockPersistentStorageManager : public orbit_symbol_paths::PersistentStorag
 
 class SymbolsDialogTest : public ::testing::Test {
  protected:
-  explicit SymbolsDialogTest() {
-    EXPECT_CALL(mock_storage_manager_, LoadPaths).WillOnce(testing::Return(std::ref(load_paths_)));
-    EXPECT_CALL(mock_storage_manager_, SavePaths)
-        .WillOnce([this](absl::Span<const std::filesystem::path> paths) {
-          EXPECT_EQ(paths, expected_save_paths_);
-        });
-  }
-
   void SetLoadPaths(std::vector<std::filesystem::path> load_paths) {
-    load_paths_ = std::move(load_paths);
+    EXPECT_CALL(mock_storage_manager_, LoadPaths).WillOnce(testing::Return(std::move(load_paths)));
   }
-  void SetExpectSavePaths(std::vector<std::filesystem::path> expected_save_paths) {
-    expected_save_paths_ = std::move(expected_save_paths);
+  void SetExpectSavePaths(std::vector<std::filesystem::path> save_paths) {
+    EXPECT_CALL(mock_storage_manager_, SavePaths)
+        .WillOnce(
+            [save_paths = std::move(save_paths)](absl::Span<const std::filesystem::path> paths) {
+              EXPECT_EQ(paths, save_paths);
+            });
   }
 
   MockPersistentStorageManager mock_storage_manager_;
-  std::vector<std::filesystem::path> load_paths_;
-  std::vector<std::filesystem::path> expected_save_paths_;
 };
 
 TEST_F(SymbolsDialogTest, ConstructEmpty) {
+  SetLoadPaths({});
+  SetExpectSavePaths({});
+
   SymbolsDialog dialog{&mock_storage_manager_};
 
   auto* list_widget = dialog.findChild<QListWidget*>("listWidget");
@@ -87,6 +84,9 @@ TEST_F(SymbolsDialogTest, ConstructWithElfModule) {
   module_info.set_file_path("/path/to/lib.so");
   orbit_client_data::ModuleData module{module_info};
 
+  SetLoadPaths({});
+  SetExpectSavePaths({});
+
   SymbolsDialog dialog{&mock_storage_manager_, &module};
 }
 
@@ -96,6 +96,7 @@ TEST_F(SymbolsDialogTest, TryAddSymbolPath) {
   std::filesystem::path file{"/path/to/file.ext"};
   std::vector<std::filesystem::path> save_paths = {path, path_2, file};
 
+  SetLoadPaths({});
   SetExpectSavePaths(save_paths);
 
   SymbolsDialog dialog{&mock_storage_manager_};
@@ -133,6 +134,7 @@ TEST_F(SymbolsDialogTest, TryAddSymbolFileWithoutModule) {
   std::filesystem::path hello_world_elf = orbit_test::GetTestdataDir() / "hello_world_elf";
   std::vector<std::filesystem::path> save_paths{hello_world_elf};
 
+  SetLoadPaths({});
   SetExpectSavePaths(save_paths);
 
   SymbolsDialog dialog{&mock_storage_manager_};
@@ -173,6 +175,7 @@ TEST_F(SymbolsDialogTest, TryAddSymbolFileWithModule) {
       orbit_test::GetTestdataDir() / "no_symbols_elf.debug";
   std::vector<std::filesystem::path> save_paths{no_symbols_elf_debug};
 
+  SetLoadPaths({});
   SetExpectSavePaths(save_paths);
 
   SymbolsDialog dialog{&mock_storage_manager_, &module};


### PR DESCRIPTION
This does not affect logic, it only moves the boilerplate code around
EXPECT_CALL to a free function. A bit of rearranging is in the tests
is necessary.