### PR TITLE
Unblock WaitForStartCaptureRequest when stop is requested

### DIFF
--- a/src/CaptureServiceBase/CMakeLists.txt
+++ b/src/CaptureServiceBase/CMakeLists.txt
@@ -17,7 +17,7 @@ target_sources(CaptureServiceBase PUBLIC
         include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
         include/CaptureServiceBase/CommonProducerCaptureEventBuilders.h
         include/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.h
-        include/CaptureServiceBase/StartStopCaptureRequestWaiter.h)
+        include/CaptureServiceBase/StopCaptureRequestWaiter.h)
 
 target_sources(CaptureServiceBase PRIVATE
         CaptureServiceBase.cpp

--- a/src/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.cpp
@@ -6,48 +6,28 @@
 
 #include "OrbitBase/Logging.h"
 
-using orbit_grpc_protos::CaptureOptions;
-using orbit_grpc_protos::CaptureRequest;
-using orbit_grpc_protos::CaptureResponse;
-
 namespace orbit_capture_service_base {
 
-// A `StartStopCaptureRequestWaiter` implementation with `ServerReaderWriter` for the native orbit
-// capture services.
-class GrpcStartStopCaptureRequestWaiter : public StartStopCaptureRequestWaiter {
- public:
-  explicit GrpcStartStopCaptureRequestWaiter(
-      grpc::ServerReaderWriter<CaptureResponse, CaptureRequest>* reader_writer)
-      : reader_writer_{reader_writer} {}
+orbit_grpc_protos::CaptureOptions GrpcStartStopCaptureRequestWaiter::WaitForStartCaptureRequest() {
+  orbit_grpc_protos::CaptureRequest request;
+  // This call is blocking.
+  reader_writer_->Read(&request);
 
-  [[nodiscard]] ErrorMessageOr<CaptureOptions> WaitForStartCaptureRequest() override {
-    CaptureRequest request;
-    // This call is blocking.
-    reader_writer_->Read(&request);
+  ORBIT_LOG("Read CaptureRequest from Capture's gRPC stream: starting capture");
+  return request.capture_options();
+}
 
-    ORBIT_LOG("Read CaptureRequest from Capture's gRPC stream: starting capture");
-    return request.capture_options();
+[[nodiscard]] CaptureServiceBase::StopCaptureReason
+GrpcStartStopCaptureRequestWaiter::WaitForStopCaptureRequest() {
+  orbit_grpc_protos::CaptureRequest request;
+  // The client asks for the capture to be stopped by calling WritesDone. At that point, this
+  // call to Read will return false. In the meantime, it blocks if no message is received.
+  // Read also unblocks and returns false if the gRPC finishes.
+  while (reader_writer_->Read(&request)) {
   }
 
-  [[nodiscard]] CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() override {
-    CaptureRequest request;
-    // The client asks for the capture to be stopped by calling WritesDone. At that point, this
-    // call to Read will return false. In the meantime, it blocks if no message is received.
-    // Read also unblocks and returns false if the gRPC finishes.
-    while (reader_writer_->Read(&request)) {
-    }
-
-    ORBIT_LOG("Client finished writing on Capture's gRPC stream: stopping capture");
-    return CaptureServiceBase::StopCaptureReason::kClientStop;
-  }
-
- private:
-  grpc::ServerReaderWriter<CaptureResponse, CaptureRequest>* reader_writer_;
-};
-
-std::shared_ptr<StartStopCaptureRequestWaiter> CreateGrpcStartStopCaptureRequestWaiter(
-    grpc::ServerReaderWriter<CaptureResponse, CaptureRequest>* reader_writer) {
-  return std::make_shared<GrpcStartStopCaptureRequestWaiter>(reader_writer);
+  ORBIT_LOG("Client finished writing on Capture's gRPC stream: stopping capture");
+  return CaptureServiceBase::StopCaptureReason::kClientStop;
 }
 
 }  // namespace orbit_capture_service_base

--- a/src/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.cpp
@@ -20,7 +20,7 @@ class GrpcStartStopCaptureRequestWaiter : public StartStopCaptureRequestWaiter {
       grpc::ServerReaderWriter<CaptureResponse, CaptureRequest>* reader_writer)
       : reader_writer_{reader_writer} {}
 
-  [[nodiscard]] CaptureOptions WaitForStartCaptureRequest() override {
+  [[nodiscard]] ErrorMessageOr<CaptureOptions> WaitForStartCaptureRequest() override {
     CaptureRequest request;
     // This call is blocking.
     reader_writer_->Read(&request);

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -24,11 +24,7 @@ class CaptureServiceBase {
   void AddCaptureStartStopListener(CaptureStartStopListener* listener);
   void RemoveCaptureStartStopListener(CaptureStartStopListener* listener);
 
-  enum class CaptureInitializationResult {
-    kSuccess,
-    kAlreadyInProgress,
-    kFailureWhileWaitingForStart,
-  };
+  enum class CaptureInitializationResult { kSuccess, kAlreadyInProgress };
   enum class StopCaptureReason {
     kClientStop,
     kMemoryWatchdog,

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -24,7 +24,11 @@ class CaptureServiceBase {
   void AddCaptureStartStopListener(CaptureStartStopListener* listener);
   void RemoveCaptureStartStopListener(CaptureStartStopListener* listener);
 
-  enum class CaptureInitializationResult { kSuccess, kAlreadyInProgress };
+  enum class CaptureInitializationResult {
+    kSuccess,
+    kAlreadyInProgress,
+    kFailureWhileWaitingForStart,
+  };
   enum class StopCaptureReason {
     kClientStop,
     kMemoryWatchdog,

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -33,11 +33,11 @@ class CaptureServiceBase {
     kGuestOrcConnectionFailure,
   };
 
- protected:
   [[nodiscard]] CaptureInitializationResult InitializeCapture(
       orbit_producer_event_processor::ClientCaptureEventCollector* client_capture_event_collector);
   void TerminateCapture();
 
+ protected:
   void StartEventProcessing(const orbit_grpc_protos::CaptureOptions& capture_options);
   void FinalizeEventProcessing(StopCaptureReason stop_capture_reason);
 

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -9,13 +9,13 @@
 #include <absl/synchronization/mutex.h>
 #include <absl/time/time.h>
 
-#include "CaptureServiceBase/StartStopCaptureRequestWaiter.h"
+#include "CaptureServiceBase/StopCaptureRequestWaiter.h"
 #include "GrpcProtos/capture.pb.h"
 
 namespace orbit_capture_service_base {
 
 // A `StartStopCaptureRequestWaiter` implementation for the cloud collector.
-class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureRequestWaiter {
+class CloudCollectorStartStopCaptureRequestWaiter : public StopCaptureRequestWaiter {
  public:
   explicit CloudCollectorStartStopCaptureRequestWaiter(
       std::optional<absl::Duration> max_capture_duration = std::nullopt)
@@ -23,8 +23,7 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StartStopCaptureReque
 
   // WaitForStartCaptureRequest is blocked until StartCapture or StopCapture is called. For the
   // latter case, it will return an error message.
-  [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::CaptureOptions> WaitForStartCaptureRequest()
-      override;
+  [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::CaptureOptions> WaitForStartCaptureRequest();
   void StartCapture(orbit_grpc_protos::CaptureOptions capture_options);
 
   // WaitForStopCaptureRequest is blocked until StopCapture is called.

--- a/src/CaptureServiceBase/include/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/GrpcStartStopCaptureRequestWaiter.h
@@ -7,18 +7,28 @@
 
 #include <grpcpp/grpcpp.h>
 
-#include "CaptureServiceBase/StartStopCaptureRequestWaiter.h"
+#include "CaptureServiceBase/StopCaptureRequestWaiter.h"
 #include "GrpcProtos/services.grpc.pb.h"
 #include "GrpcProtos/services.pb.h"
 
 namespace orbit_capture_service_base {
 
-// Create a `StartStopCaptureRequestWaiter` with `ServerReaderWriter` for the native orbit capture
+// A `StartStopCaptureRequestWaiter` with `ServerReaderWriter` for the native orbit capture
 // services.
-[[nodiscard]] std::shared_ptr<StartStopCaptureRequestWaiter>
-CreateGrpcStartStopCaptureRequestWaiter(
-    grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse, orbit_grpc_protos::CaptureRequest>*
-        reader_writer);
+class GrpcStartStopCaptureRequestWaiter : public StopCaptureRequestWaiter {
+ public:
+  explicit GrpcStartStopCaptureRequestWaiter(
+      grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse,
+                               orbit_grpc_protos::CaptureRequest>* reader_writer)
+      : reader_writer_{reader_writer} {}
+
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions WaitForStartCaptureRequest();
+  [[nodiscard]] CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() override;
+
+ private:
+  grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse, orbit_grpc_protos::CaptureRequest>*
+      reader_writer_;
+};
 
 }  // namespace orbit_capture_service_base
 

--- a/src/CaptureServiceBase/include/CaptureServiceBase/StartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/StartStopCaptureRequestWaiter.h
@@ -7,6 +7,7 @@
 
 #include "CaptureServiceBase/CaptureServiceBase.h"
 #include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_capture_service_base {
 
@@ -16,7 +17,8 @@ namespace orbit_capture_service_base {
 class StartStopCaptureRequestWaiter {
  public:
   virtual ~StartStopCaptureRequestWaiter() = default;
-  [[nodiscard]] virtual orbit_grpc_protos::CaptureOptions WaitForStartCaptureRequest() = 0;
+  [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::CaptureOptions>
+  WaitForStartCaptureRequest() = 0;
   [[nodiscard]] virtual CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() = 0;
 };
 

--- a/src/CaptureServiceBase/include/CaptureServiceBase/StopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/StopCaptureRequestWaiter.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef CAPTURE_SERVICE_BASE_START_STOP_CAPTURE_REQUEST_WAITER_H_
-#define CAPTURE_SERVICE_BASE_START_STOP_CAPTURE_REQUEST_WAITER_H_
+#ifndef CAPTURE_SERVICE_BASE_STOP_CAPTURE_REQUEST_WAITER_H_
+#define CAPTURE_SERVICE_BASE_STOP_CAPTURE_REQUEST_WAITER_H_
 
 #include "CaptureServiceBase/CaptureServiceBase.h"
 #include "GrpcProtos/capture.pb.h"
@@ -14,14 +14,12 @@ namespace orbit_capture_service_base {
 // This is mimicking the behavior of `ServerReaderWriter`. Native orbit capture services can still
 // implement it with `ServerReaderWriter` and the cloud collector can implement it in a gRPC-free
 // way.
-class StartStopCaptureRequestWaiter {
+class StopCaptureRequestWaiter {
  public:
-  virtual ~StartStopCaptureRequestWaiter() = default;
-  [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::CaptureOptions>
-  WaitForStartCaptureRequest() = 0;
+  virtual ~StopCaptureRequestWaiter() = default;
   [[nodiscard]] virtual CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() = 0;
 };
 
 }  // namespace orbit_capture_service_base
 
-#endif  // CAPTURE_SERVICE_BASE_START_STOP_CAPTURE_REQUEST_WAITER_H_
+#endif  // CAPTURE_SERVICE_BASE_STOP_CAPTURE_REQUEST_WAITER_H_

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -19,25 +19,32 @@ grpc::Status LinuxCaptureService::Capture(
 
   orbit_producer_event_processor::GrpcClientCaptureEventCollector
       grpc_client_capture_event_collector{reader_writer};
+  CaptureServiceBase::CaptureInitializationResult initialization_result =
+      InitializeCapture(&grpc_client_capture_event_collector);
+  switch (initialization_result) {
+    case CaptureInitializationResult::kSuccess:
+      break;
+    case CaptureInitializationResult::kAlreadyInProgress:
+      return {grpc::StatusCode::ALREADY_EXISTS,
+              "Cannot start capture because another capture is already in progress"};
+  }
 
   std::shared_ptr<orbit_capture_service_base::StartStopCaptureRequestWaiter>
       start_stop_capture_request_waiter =
           orbit_capture_service_base::CreateGrpcStartStopCaptureRequestWaiter(reader_writer);
-
-  CaptureServiceBase::CaptureInitializationResult initialization_result =
-      DoCapture(&grpc_client_capture_event_collector, start_stop_capture_request_waiter);
-  switch (initialization_result) {
-    case CaptureInitializationResult::kSuccess:
-      return grpc::Status::OK;
-    case CaptureInitializationResult::kAlreadyInProgress:
-      return {grpc::StatusCode::ALREADY_EXISTS,
-              "Cannot start capture because another capture is already in progress"};
-    case CaptureInitializationResult::kFailureWhileWaitingForStart:
-      return {grpc::StatusCode::INTERNAL,
-              "An error occurred while waiting for start capture request"};
+  auto capture_options_or_error = start_stop_capture_request_waiter->WaitForStartCaptureRequest();
+  if (capture_options_or_error.has_error()) {
+    std::string error_msg = absl::StrFormat("An error occurred while waiting for start: %s",
+                                            capture_options_or_error.error().message());
+    ORBIT_ERROR("%s", error_msg);
+    grpc_client_capture_event_collector.StopAndWait();
+    TerminateCapture();
+    return {grpc::StatusCode::INTERNAL, error_msg};
   }
 
-  ORBIT_UNREACHABLE();
+  const orbit_grpc_protos::CaptureOptions& capture_options = capture_options_or_error.value();
+  DoCapture(capture_options, start_stop_capture_request_waiter);
+  return grpc::Status::OK;
 }
 
 }  // namespace orbit_linux_capture_service

--- a/src/LinuxCaptureService/LinuxCaptureService.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureService.cpp
@@ -32,6 +32,9 @@ grpc::Status LinuxCaptureService::Capture(
     case CaptureInitializationResult::kAlreadyInProgress:
       return {grpc::StatusCode::ALREADY_EXISTS,
               "Cannot start capture because another capture is already in progress"};
+    case CaptureInitializationResult::kFailureWhileWaitingForStart:
+      return {grpc::StatusCode::INTERNAL,
+              "An error occurred while waiting for start capture request"};
   }
 
   ORBIT_UNREACHABLE();

--- a/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
@@ -245,7 +245,7 @@ CaptureServiceBase::CaptureInitializationResult LinuxCaptureServiceBase::DoCaptu
                 capture_options_or_error.error().message());
     client_capture_event_collector->StopAndWait();
     TerminateCapture();
-    return CaptureInitializationResult::kSuccess;
+    return CaptureInitializationResult::kFailureWhileWaitingForStart;
   }
   const CaptureOptions& capture_options = capture_options_or_error.value();
 

--- a/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureServiceBase.h
+++ b/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureServiceBase.h
@@ -13,7 +13,7 @@
 #include <thread>
 
 #include "CaptureServiceBase/CaptureServiceBase.h"
-#include "CaptureServiceBase/StartStopCaptureRequestWaiter.h"
+#include "CaptureServiceBase/StopCaptureRequestWaiter.h"
 #include "GrpcProtos/services.grpc.pb.h"
 #include "GrpcProtos/services.pb.h"
 #include "OrbitBase/Logging.h"
@@ -36,19 +36,19 @@ class LinuxCaptureServiceBase : public orbit_capture_service_base::CaptureServic
     }
   }
 
-  // Note that start_stop_capture_request_waiter needs to be a shared_ptr here as it might outlive
+  // Note that stop_capture_request_waiter needs to be a shared_ptr here as it might outlive
   // this method. See wait_for_stop_capture_request_thread_ in
   // WaitForStopCaptureRequestOrMemoryThresholdExceeded.
   void DoCapture(const orbit_grpc_protos::CaptureOptions& capture_options,
-                 const std::shared_ptr<orbit_capture_service_base::StartStopCaptureRequestWaiter>&
-                     start_stop_capture_request_waiter);
+                 const std::shared_ptr<orbit_capture_service_base::StopCaptureRequestWaiter>&
+                     stop_capture_request_waiter);
 
  private:
   std::unique_ptr<orbit_user_space_instrumentation::InstrumentationManager>
       instrumentation_manager_;
 
   // This method returns when the first of the following happens:
-  // - start_stop_capture_request_waiter->WaitForStopCaptureRequest returns. For the native Orbit
+  // - stop_capture_request_waiter->WaitForStopCaptureRequest returns. For the native Orbit
   //   capture service with a GrpcStartStopCaptureRequestWaiter, this happens when the client calls
   //   WritesDone on reader_writer; For the cloud collector capture service with a
   //   CloudCollectorStartStopCaptureRequestWaiter, this happends when
@@ -56,8 +56,8 @@ class LinuxCaptureServiceBase : public orbit_capture_service_base::CaptureServic
   // - The resident set size of the current process exceeds the threshold (i.e., total physical
   //   memory / 2).
   [[nodiscard]] StopCaptureReason WaitForStopCaptureRequestOrMemoryThresholdExceeded(
-      const std::shared_ptr<orbit_capture_service_base::StartStopCaptureRequestWaiter>&
-          start_stop_capture_request_waiter);
+      const std::shared_ptr<orbit_capture_service_base::StopCaptureRequestWaiter>&
+          stop_capture_request_waiter);
   std::thread wait_for_stop_capture_request_thread_;
 };
 

--- a/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureServiceBase.h
+++ b/src/LinuxCaptureService/include/LinuxCaptureService/LinuxCaptureServiceBase.h
@@ -39,11 +39,9 @@ class LinuxCaptureServiceBase : public orbit_capture_service_base::CaptureServic
   // Note that start_stop_capture_request_waiter needs to be a shared_ptr here as it might outlive
   // this method. See wait_for_stop_capture_request_thread_ in
   // WaitForStopCaptureRequestOrMemoryThresholdExceeded.
-  [[nodiscard]] orbit_capture_service_base::CaptureServiceBase::CaptureInitializationResult
-  DoCapture(
-      orbit_producer_event_processor::ClientCaptureEventCollector* client_capture_event_collector,
-      const std::shared_ptr<orbit_capture_service_base::StartStopCaptureRequestWaiter>&
-          start_stop_capture_request_waiter);
+  void DoCapture(const orbit_grpc_protos::CaptureOptions& capture_options,
+                 const std::shared_ptr<orbit_capture_service_base::StartStopCaptureRequestWaiter>&
+                     start_stop_capture_request_waiter);
 
  private:
   std::unique_ptr<orbit_user_space_instrumentation::InstrumentationManager>

--- a/src/WindowsCaptureService/WindowsCaptureService.cpp
+++ b/src/WindowsCaptureService/WindowsCaptureService.cpp
@@ -41,8 +41,9 @@ grpc::Status WindowsCaptureService::Capture(
               "Cannot start capture because another capture is already in progress"};
   }
 
-  const CaptureOptions& capture_options =
-      start_stop_capture_request_waiter->WaitForStartCaptureRequest();
+  auto capture_options_or_error = start_stop_capture_request_waiter->WaitForStartCaptureRequest();
+  ORBIT_CHECK(capture_options_or_error.has_value());
+  const CaptureOptions& capture_options = capture_options_or_error.value();
 
   StartEventProcessing(capture_options);
   TracingHandler tracing_handler{producer_event_processor_.get()};


### PR DESCRIPTION
Unblcok `CloudCollectorStartStopCaptureRequestWaiter::WaitForStartCaptureRequest`
when stop capture is requested.

For the CloudCollector, it is possible that StopCapture is called while
we are waiting for the start capture request, for instance, the GuestOrc
connection failed at the very beginning.
In this case, we unblock `WaitForStartCaptureRequest` and terminate the
capture immediately.

Bug: http://b/220888294