### PR TITLE
Fix syntax highlighting for call targets

### DIFF
--- a/src/SyntaxHighlighter/X86Assembly.cpp
+++ b/src/SyntaxHighlighter/X86Assembly.cpp
@@ -214,7 +214,7 @@ const QRegularExpression kRegisterRegex{
 const QRegularExpression kKeywordRegex{"\\b(ptr|[xy]mmword|[sdq]?word|byte)\\b"};
 const QRegularExpression kCommentRegex{"(;.*)$"};
 const QRegularExpression kPlatformRegex{"^(Platform:.*)$"};
-const QRegularExpression kCallTargetRegex{"\\bcall[^\\(]*\\()(.*)\\)$"};
+const QRegularExpression kCallTargetRegex{R"(\bcall[^\(]*\((.*)\)$)"};
 }  // namespace AssemblyRegex
 }  // namespace
 


### PR DESCRIPTION
The regex was broken previously...

http://screenshot/4DhWXPoz4ANMyiF

Test: CodeViewDemo and actual disassembly
Bug: http://b/224757578