### PR TITLE
Add orbit_symbol_paths::ModuleSymbolFileMapping

### DIFF
--- a/src/ConfigWidgets/SymbolsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolsDialogTest.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <absl/container/flat_hash_map.h>
 #include <gmock/gmock-actions.h>
 #include <gmock/gmock-function-mocker.h>
 #include <gmock/gmock-matchers.h>
@@ -27,14 +26,14 @@
 
 namespace orbit_config_widgets {
 
+using orbit_symbol_paths::ModuleSymbolFileMappings;
+
 class MockPersistentStorageManager : public orbit_symbol_paths::PersistentStorageManager {
  public:
   MOCK_METHOD(void, SavePaths, (absl::Span<const std::filesystem::path>), (override));
   MOCK_METHOD(std::vector<std::filesystem::path>, LoadPaths, (), (override));
-  MOCK_METHOD(void, SaveModuleSymbolFileMappings,
-              ((const absl::flat_hash_map<std::string, std::filesystem::path>&)), (override));
-  MOCK_METHOD((absl::flat_hash_map<std::string, std::filesystem::path>),
-              LoadModuleSymbolFileMappings, (), (override));
+  MOCK_METHOD(void, SaveModuleSymbolFileMappings, ((const ModuleSymbolFileMappings&)), (override));
+  MOCK_METHOD((ModuleSymbolFileMappings), LoadModuleSymbolFileMappings, (), (override));
 };
 
 class SymbolsDialogTest : public ::testing::Test {

--- a/src/SymbolPaths/QSettingsBasedStorageManager.cpp
+++ b/src/SymbolPaths/QSettingsBasedStorageManager.cpp
@@ -41,7 +41,7 @@ void QSettingsBasedStorageManager::SavePaths(absl::Span<const std::filesystem::p
 }
 
 void QSettingsBasedStorageManager::SaveModuleSymbolFileMappings(
-    const absl::flat_hash_map<std::string, std::filesystem::path>& mappings) {
+    const ModuleSymbolFileMappings& mappings) {
   QSettings settings{};
   settings.beginWriteArray(kModuleSymbolFileMappingKey, static_cast<int>(mappings.size()));
   int index = 0;
@@ -55,11 +55,11 @@ void QSettingsBasedStorageManager::SaveModuleSymbolFileMappings(
   settings.endArray();
 }
 
-[[nodiscard]] absl::flat_hash_map<std::string, std::filesystem::path>
+[[nodiscard]] ModuleSymbolFileMappings
 QSettingsBasedStorageManager::LoadModuleSymbolFileMappings() {
   QSettings settings{};
   const int size = settings.beginReadArray(kModuleSymbolFileMappingKey);
-  absl::flat_hash_map<std::string, std::filesystem::path> mappings{};
+  ModuleSymbolFileMappings mappings{};
   mappings.reserve(size);
   for (int i = 0; i < size; ++i) {
     settings.setArrayIndex(i);

--- a/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
+++ b/src/SymbolPaths/include/SymbolPaths/PersistentStorageManager.h
@@ -14,6 +14,12 @@
 
 namespace orbit_symbol_paths {
 
+// The hash map uses the key std::string for the module path instead of std::filesystem::path,
+// because the module path is always linux path (from the instance). When this is compiled on
+// windows, std::filesystem::path will use backslash instead of slash as directory separator which
+// leads to confusion.
+using ModuleSymbolFileMappings = absl::flat_hash_map<std::string, std::filesystem::path>;
+
 class PersistentStorageManager {
  public:
   virtual ~PersistentStorageManager() = default;
@@ -21,14 +27,8 @@ class PersistentStorageManager {
   virtual void SavePaths(absl::Span<const std::filesystem::path> paths) = 0;
   [[nodiscard]] virtual std::vector<std::filesystem::path> LoadPaths() = 0;
 
-  // The hash map uses the key std::string for the module path instead of std::filesystem::path,
-  // because the module path is always linux path (from the instance). When this is compiled on
-  // windows, std::filesystem::path will use backslash instead of slash as directory separator which
-  // leads to confusion.
-  virtual void SaveModuleSymbolFileMappings(
-      const absl::flat_hash_map<std::string, std::filesystem::path>& mappings) = 0;
-  [[nodiscard]] virtual absl::flat_hash_map<std::string, std::filesystem::path>
-  LoadModuleSymbolFileMappings() = 0;
+  virtual void SaveModuleSymbolFileMappings(const ModuleSymbolFileMappings& mappings) = 0;
+  [[nodiscard]] virtual ModuleSymbolFileMappings LoadModuleSymbolFileMappings() = 0;
 };
 
 }  // namespace orbit_symbol_paths

--- a/src/SymbolPaths/include/SymbolPaths/QSettingsBasedStorageManager.h
+++ b/src/SymbolPaths/include/SymbolPaths/QSettingsBasedStorageManager.h
@@ -13,10 +13,8 @@ class QSettingsBasedStorageManager : public PersistentStorageManager {
  public:
   void SavePaths(absl::Span<const std::filesystem::path> paths) override;
   [[nodiscard]] std::vector<std::filesystem::path> LoadPaths() override;
-  void SaveModuleSymbolFileMappings(
-      const absl::flat_hash_map<std::string, std::filesystem::path>& mappings) override;
-  [[nodiscard]] absl::flat_hash_map<std::string, std::filesystem::path>
-  LoadModuleSymbolFileMappings() override;
+  void SaveModuleSymbolFileMappings(const ModuleSymbolFileMappings& mappings) override;
+  [[nodiscard]] ModuleSymbolFileMappings LoadModuleSymbolFileMappings() override;
 };
 
 }  // namespace orbit_symbol_paths


### PR DESCRIPTION
This is just for convenience, to shorten the long absl based typename