### PR TITLE
Fix the memory warning threshold

### DIFF
--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -66,6 +66,12 @@ class CaptureData {
   }
 
   [[nodiscard]] uint64_t memory_sampling_period_ns() const { return memory_sampling_period_ns_; }
+  [[nodiscard]] uint64_t memory_warning_threshold_kb() const {
+    return memory_warning_threshold_kb_;
+  }
+  void set_memory_warning_threshold_kb(uint64_t memory_warning_threshold_kb) {
+    memory_warning_threshold_kb_ = memory_warning_threshold_kb;
+  }
 
   [[nodiscard]] const orbit_grpc_protos::InstrumentedFunction* GetInstrumentedFunctionById(
       uint64_t function_id) const;
@@ -234,6 +240,7 @@ class CaptureData {
   orbit_client_data::ProcessData process_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions_;
   uint64_t memory_sampling_period_ns_;
+  uint64_t memory_warning_threshold_kb_;
 
   orbit_client_data::CallstackData callstack_data_;
   std::optional<PostProcessedSamplingData> post_processed_sampling_data_;

--- a/src/OrbitGl/AnnotationTrack.cpp
+++ b/src/OrbitGl/AnnotationTrack.cpp
@@ -45,8 +45,8 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
     Vec2 text_box_position(content_right_x - string_width, content_bottom_y);
 
-    TextRenderer::TextFormatting formatting{font_size, kWhite, string_width};
-    formatting.valign = TextRenderer::VAlign::Bottom;
+    TextRenderer::TextFormatting formatting{
+        font_size, kWhite, string_width, TextRenderer::HAlign::Left, TextRenderer::VAlign::Bottom};
     text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z, formatting);
   }
 
@@ -65,8 +65,9 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
     Vec2 text_box_position(track_pos[0] + layout->GetRightMargin(), y);
 
-    TextRenderer::TextFormatting formatting{font_size, kThresholdColor, string_width};
-    formatting.valign = TextRenderer::VAlign::Middle;
+    TextRenderer::TextFormatting formatting{font_size, kThresholdColor, string_width,
+                                            TextRenderer::HAlign::Left,
+                                            TextRenderer::VAlign::Middle};
     text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z, formatting);
 
     Vec2 from(track_pos[0], y);

--- a/src/OrbitGl/AnnotationTrack.cpp
+++ b/src/OrbitGl/AnnotationTrack.cpp
@@ -8,7 +8,7 @@ namespace {
 
 const Color kWhite(255, 255, 255, 255);
 const Color kFullyTransparent(255, 255, 255, 0);
-const Color kThresholdColor(244, 67, 54, 255);
+const Color kThresholdColor(179, 0, 80, 255);
 
 }  // namespace
 
@@ -26,12 +26,12 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
   if (value_upper_bound_.has_value()) {
     std::string text = value_upper_bound_.value().first;
     float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
-    Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
-    Vec2 text_box_position(content_right_x - text_box_size[0], content_bottom_y - content_height);
+    Vec2 text_box_position(content_right_x - string_width, content_bottom_y - content_height);
     text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z,
-                          {font_size, kWhite, text_box_size[0]});
+                          {font_size, kWhite, string_width});
 
     if (!GetValueUpperBoundTooltip().empty()) {
+      Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
       auto user_data = std::make_unique<PickingUserData>(
           nullptr, [&](PickingId /*id*/) { return this->GetValueUpperBoundTooltip(); });
       batcher.AddShadedBox(text_box_position, text_box_size, z, kFullyTransparent,
@@ -43,10 +43,9 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
   if (value_lower_bound_.has_value()) {
     std::string text = value_lower_bound_.value().first;
     float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
-    Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
-    Vec2 text_box_position(content_right_x - text_box_size[0], content_bottom_y);
+    Vec2 text_box_position(content_right_x - string_width, content_bottom_y);
 
-    TextRenderer::TextFormatting formatting{font_size, kWhite, text_box_size[0]};
+    TextRenderer::TextFormatting formatting{font_size, kWhite, string_width};
     formatting.valign = TextRenderer::VAlign::Bottom;
     text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z, formatting);
   }
@@ -60,18 +59,19 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     if (warning_threshold <= min || warning_threshold >= max) return;
 
     double normalized_value = (warning_threshold - min) / (max - min);
-    float y = content_bottom_y + static_cast<float>(normalized_value) * content_height;
+    float y = content_bottom_y - static_cast<float>(normalized_value) * content_height;
 
     std::string text = warning_threshold_.value().first;
     float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
-    Vec2 text_box_size(string_width, layout->GetTextBoxHeight());
-    Vec2 text_box_position(track_pos[0] + layout->GetRightMargin(), y - text_box_size[1] / 2.f);
-    text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z,
-                          {font_size, kThresholdColor, text_box_size[0]});
+    Vec2 text_box_position(track_pos[0] + layout->GetRightMargin(), y);
+
+    TextRenderer::TextFormatting formatting{font_size, kThresholdColor, string_width};
+    formatting.valign = TextRenderer::VAlign::Middle;
+    text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], z, formatting);
 
     Vec2 from(track_pos[0], y);
     Vec2 to(track_pos[0] + track_size[0], y);
     batcher.AddLine(from, from + Vec2(layout->GetRightMargin() / 2.f, 0), z, kThresholdColor);
-    batcher.AddLine(Vec2(text_box_position[0] - text_box_size[0], y), to, z, kThresholdColor);
+    batcher.AddLine(Vec2(text_box_position[0] + string_width, y), to, z, kThresholdColor);
   }
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -347,6 +347,8 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
         // this task is completely executed.
         capture_data_ = std::make_unique<CaptureData>(
             capture_started, file_path, std::move(frame_track_function_ids), data_source_);
+        capture_data_->set_memory_warning_threshold_kb(
+            data_manager_->memory_warning_threshold_kb());
         capture_window_->CreateTimeGraph(capture_data_.get());
         orbit_gl::TrackManager* track_manager = GetMutableTimeGraph()->GetTrackManager();
         track_manager->SetIsDataFromSavedCapture(data_source_ ==

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -423,22 +423,21 @@ class OrbitApp final : public DataViewFactory,
   void SetStackDumpSize(uint16_t stack_dump_size);
   void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
+
   void SetCollectMemoryInfo(bool collect_memory_info) {
     data_manager_->set_collect_memory_info(collect_memory_info);
   }
   void SetMemorySamplingPeriodMs(uint64_t memory_sampling_period_ms) {
     data_manager_->set_memory_sampling_period_ms(memory_sampling_period_ms);
   }
-
   [[nodiscard]] uint64_t GetMemorySamplingPeriodMs() const {
     return capture_data_->memory_sampling_period_ns() / 1'000'000;
   }
-
   void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb) {
     data_manager_->set_memory_warning_threshold_kb(memory_warning_threshold_kb);
   }
   [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const {
-    return data_manager_->memory_warning_threshold_kb();
+    return capture_data_->memory_warning_threshold_kb();
   }
 
   // TODO(kuebler): Move them to a separate controller at some point

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -327,7 +327,6 @@ void TimeGraph::ProcessSystemMemoryTrackingTimer(const TimerInfo& timer_info) {
 
   if (absl::GetFlag(FLAGS_enable_warning_threshold) && !track->GetWarningThreshold().has_value()) {
     constexpr double kMegabytesToKilobytes = 1024.0;
-    // TODO(b/216245594): This uses the DataManager not from the main thread, failing a check.
     double warning_threshold_mb =
         static_cast<double>(app_->GetMemoryWarningThresholdKb()) / kMegabytesToKilobytes;
     track->SetWarningThreshold(warning_threshold_mb);


### PR DESCRIPTION
We fix two issues related to the memory warning threshold in this change:
- In `TimeGraph`, we were using the `DataManager` to retrieve the memory warning threshold, 
which caused a check to fail as `DataManager` verifies whether it is used from the main thread. (http://b/216245594)
- The memory warning threshold is drawn out of the system memory track (http://b/216109608)

After the fix: https://screenshot/96xecUqQvNZmNnQ

