### PR TITLE
Add a label for the timestamp pointed by the mouse

### DIFF
--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -38,6 +38,7 @@ float GlCanvas::kZValueUi = 0.61f;
 float GlCanvas::kZValueTextUi = 0.61f;
 float GlCanvas::kZValueTimeBarBg = 0.81f;
 float GlCanvas::kZValueTimeBar = 0.83f;
+float GlCanvas::kZValueTimeBarMouseLabel = 0.84f;
 float GlCanvas::kZValueMargin = 0.85f;
 float GlCanvas::kZValueSliderBg = 0.87f;
 float GlCanvas::kZValueSlider = 0.89f;

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -100,6 +100,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   static float kZValueSlider;
   static float kZValueSliderBg;
   static float kZValueMargin;
+  static float kZValueTimeBarMouseLabel;
   static float kZValueTimeBar;
   static float kZValueTimeBarBg;
   static float kZValueTextUi;

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -46,16 +46,12 @@ class TimelineUi : public CaptureViewElement {
   [[nodiscard]] float GetTickWorldXPos(uint64_t tick_ns) const;
   [[nodiscard]] float GetHeightWithoutMargin() const { return layout_->GetTimeBarHeight(); }
   [[nodiscard]] float GetMarginHeight() const { return layout_->GetTimeBarMargin(); }
-  [[nodiscard]] uint32_t GetNumberOfDecimalPlacesNeeded() const {
-    return number_of_decimal_places_needed_;
-  }
-  void SetNumberOfDecimalPlacesNeeded(uint32_t number_of_decimal_places_needed) const {
-    number_of_decimal_places_needed_ = number_of_decimal_places_needed;
-  }
+  [[nodiscard]] uint32_t GetNumDecimalsInLabels() const { return num_decimals_in_labels_; }
+  void UpdateNumDecimalsInLabels(uint64_t min_timestamp_ns, uint64_t max_timestamp_ns);
 
   const TimelineInfoInterface* timeline_info_interface_;
   TimelineTicks timeline_ticks_;
-  mutable uint32_t number_of_decimal_places_needed_ = 0;
+  uint32_t num_decimals_in_labels_ = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -25,6 +25,8 @@ class TimelineUi : public CaptureViewElement {
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
  private:
+  void DoDraw(Batcher& batcher, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
   void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,
                           uint64_t max_tick, PickingMode picking_mode) override;
   void RenderLines(Batcher& batcher, uint64_t min_timestamp_ns, uint64_t max_timestamp_ns) const;
@@ -33,23 +35,27 @@ class TimelineUi : public CaptureViewElement {
   void RenderMargin(Batcher& batcher) const;
   void RenderBackground(Batcher& batcher) const;
   void RenderLabel(Batcher& batcher, TextRenderer& text_renderer, uint64_t tick_ns,
-                   uint32_t number_of_decimal_places_needed, float label_z,
-                   Color background_color) const;
-  [[nodiscard]] std::string GetLabel(uint64_t tick_ns,
-                                     uint32_t number_of_decimal_places_needed) const;
+                   uint32_t number_of_decimal_places, float label_z, Color background_color) const;
+  void RenderMouseLabel(Batcher& batcher, TextRenderer& text_renderer,
+                        uint64_t mouse_tick_ns) const;
+  [[nodiscard]] std::string GetLabel(uint64_t tick_ns, uint32_t number_of_decimal_places) const;
   [[nodiscard]] std::vector<uint64_t> GetTicksForNonOverlappingLabels(
-      TextRenderer& text_renderer, const std::vector<uint64_t>& all_major_ticks,
-      float horizontal_margin, uint32_t number_of_decimal_places) const;
+      TextRenderer& text_renderer, const std::vector<uint64_t>& all_major_ticks) const;
   [[nodiscard]] bool WillLabelsOverlap(TextRenderer& text_renderer,
-                                       const std::vector<uint64_t>& tick_list,
-                                       float horizontal_margin,
-                                       uint32_t number_of_decimal_places) const;
+                                       const std::vector<uint64_t>& tick_list) const;
   [[nodiscard]] float GetTickWorldXPos(uint64_t tick_ns) const;
   [[nodiscard]] float GetHeightWithoutMargin() const { return layout_->GetTimeBarHeight(); }
   [[nodiscard]] float GetMarginHeight() const { return layout_->GetTimeBarMargin(); }
+  [[nodiscard]] uint32_t GetNumberOfDecimalPlacesNeeded() const {
+    return number_of_decimal_places_needed_;
+  }
+  void SetNumberOfDecimalPlacesNeeded(uint32_t number_of_decimal_places_needed) const {
+    number_of_decimal_places_needed_ = number_of_decimal_places_needed;
+  }
 
   const TimelineInfoInterface* timeline_info_interface_;
   TimelineTicks timeline_ticks_;
+  mutable uint32_t number_of_decimal_places_needed_ = 0;
 };
 
 }  // namespace orbit_gl


### PR DESCRIPTION
In this PR we are adding a new label for the timestamp pointed by the
mouse. This label has 2 more digits of precision.

The label can be found in http://screenshot/3DBDt7K8CVgiwUr.

I made a few refactors:
- I simplify kLeftMargin and kRightMargin and kPixelMargin by only using
  kLabelPadding for the 4 dimensions.
- The label has to be drawn in Draw(), since it has to be updated in
  every frame, so we need to save the number of digits of places needed
  for the labels.

http://b/218312292

TODO: Timeline should be below the green line pointed by the mouse, as
well the green overlay (right click). Will come in a following PR.