### PR TITLE
Fix scoped target metric not being deallocated

### DIFF
--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -84,13 +84,13 @@ std::optional<TargetConfiguration> ConnectToTargetDialog::Exec() {
   if (rc != QDialog::Accepted) {
     if (connection_metric_ != nullptr) {
       connection_metric_->SetStatusCode(orbit_metrics_uploader::OrbitLogEvent::CANCELLED);
-      connection_metric_.release();
+      connection_metric_.reset();
     }
     return std::nullopt;
   }
 
   if (connection_metric_ != nullptr) {
-    connection_metric_.release();
+    connection_metric_.reset();
   }
 
   return std::move(target_configuration_);


### PR DESCRIPTION
TIL that `unique_ptr::release()` does not destruct the object.