### PR TITLE
Add grpc dependency to a few more libraries

### DIFF
--- a/src/Api/BUILD
+++ b/src/Api/BUILD
@@ -14,6 +14,7 @@ licenses(["notice"])
 orbit_cc_library(
     name = "Api",
     deps = [
+        "//net/grpc:grpc++",
         "//src/ApiInterface",
         "//src/ApiUtils",
         "//src/CaptureEventProducer",

--- a/src/ApiLoader/BUILD
+++ b/src/ApiLoader/BUILD
@@ -14,6 +14,7 @@ licenses(["notice"])
 orbit_cc_library(
     name = "ApiLoader",
     deps = [
+        "//net/grpc:grpc++",
         "//src/ApiUtils",
         "//src/GrpcProtos:capture_cc_proto",
         "//src/ObjectUtils",

--- a/src/UserSpaceInstrumentation/BUILD
+++ b/src/UserSpaceInstrumentation/BUILD
@@ -18,6 +18,7 @@ orbit_cc_library(
         "UserSpaceInstrumentationTestLib.*",
     ],
     deps = [
+        "//net/grpc:grpc++",
         "//src/CaptureEventProducer",
         "//src/ObjectUtils",
         "//src/OrbitBase",


### PR DESCRIPTION
This is needed for the tests to build via --config=gce on TAP.
Previously we weren't building the tests on gce as they don't need to be
built on gce but with the tap project setup this is now necessary.