### PR TITLE
Choose the precision for the histogram ticks dynamically

### DIFF
--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -93,11 +93,13 @@ static void DrawVerticalLine(QPainter& painter, const QPoint& start, int length)
   painter.drawLine(start, {start.x(), start.y() + length});
 }
 
+namespace {
 struct Ticks {
   std::vector<QString> labels;
   std::vector<double> values;
   int precision{};
 };
+}  // namespace
 
 [[nodiscard]] static std::vector<QString> DoublesToLabels(const std::vector<double>& values,
                                                           int precision) {

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -4,8 +4,6 @@
 
 #include "HistogramWidget.h"
 
-#include <absl/container/flat_hash_map.h>
-#include <absl/container/flat_hash_set.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_replace.h>
@@ -50,12 +48,6 @@ const QColor kHoveredBarColor(QStringLiteral("#99CCFF"));
 constexpr int kHoverLabelPadding = 6;
 
 namespace {
-struct Ticks {
-  std::vector<QString> labels;
-  std::vector<double> values;
-  int precision{};
-};
-
 struct TickStep {
   double value{};
   int precision{};
@@ -145,6 +137,14 @@ static void DrawVerticalLine(QPainter& painter, const QPoint& start, int length)
   }
   return *best_step;
 }
+
+namespace {
+struct Ticks {
+  std::vector<QString> labels;
+  std::vector<double> values;
+  int precision{};
+};
+}  // namespace
 
 [[nodiscard]] static Ticks MakeTicksFromValues(const std::vector<double>& values, int precision) {
   std::vector<QString> labels;

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -10,8 +10,6 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_replace.h>
 #include <absl/time/time.h>
-#include <qnamespace.h>
-#include <qstringliteral.h>
 #include <qwindowdefs.h>
 
 #include <QColor>
@@ -22,6 +20,7 @@
 #include <QPoint>
 #include <QStringLiteral>
 #include <QWidget>
+#include <Qt>
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -134,7 +133,7 @@ template <typename Rounder>
 }
 
 template <typename T>
-bool AreAllUnique(std::vector<T> vector) {
+static bool AreAllUnique(std::vector<T> vector) {
   std::sort(vector.begin(), vector.end());
   return std::unique(vector.begin(), vector.end()) == vector.end();
 }

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -172,6 +172,8 @@ static void DrawHorizontalAxis(QPainter& painter, const QPoint& axes_intersectio
     const int tick_location =
         ValueToAxisLocation(tick_value, axis_length, min_value, max_value) + axes_intersection.x();
 
+    // We skip the ticks that do not fall into the horizontal axis range. Such ticks might appear
+    // due to rounding errors.
     if (!(axes_intersection.x() <= tick_location &&
           tick_location <= axes_intersection.x() + axis_length)) {
       continue;

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -109,8 +109,8 @@ struct Ticks {
 }
 
 [[nodiscard]] static double Round(double x, int precision) {
-  const double powerOfTen = pow(10.0, precision);
-  return static_cast<double>(RoundToClosestInt(x * powerOfTen)) / powerOfTen;
+  const double power_of_ten = pow(10.0, precision);
+  return std::round(x * power_of_ten) / power_of_ten;
 }
 
 [[nodiscard]] static std::vector<double> RoundDoubles(const std::vector<double>& values,
@@ -130,9 +130,9 @@ bool AreAllUnique(std::vector<T> vector) {
 [[nodiscard]] static Ticks GetTicklabels(const std::vector<double>& values, int max_precision) {
   Ticks result;
   for (int precision = 0; precision <= max_precision; precision++) {
-    auto labels = DoublesToLabels(values, precision);
+    std::vector<QString> labels = DoublesToLabels(values, precision);
     if (precision == max_precision || AreAllUnique(labels)) {
-      auto rounded_values = RoundDoubles(values, precision);
+      std::vector<double> rounded_values = RoundDoubles(values, precision);
       result = {labels, rounded_values, precision};
       break;
     }
@@ -156,7 +156,7 @@ bool AreAllUnique(std::vector<T> vector) {
 
 [[nodiscard]] static int ValueToAxisLocation(double value, int axis_length, double min_value,
                                              double max_value) {
-  if (min_value == max_value) max_value++;
+  if (min_value == max_value) return 0;
   return RoundToClosestInt(((value - min_value) / (max_value - min_value)) * axis_length);
 }
 
@@ -294,9 +294,10 @@ static void DrawHistogram(QPainter& painter, const QPoint& axes_intersection,
     left_x += widths[i];
   }
 
-  if (hovered_bar_data)
+  if (hovered_bar_data) {
     DrawVerticalHoverLabel(painter, axes_intersection, *hovered_bar_data,
                            vertical_label_decimal_count);
+  }
 }
 
 static void DrawSelection(QPainter& painter, int start_x, int end_x,

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -124,7 +124,7 @@ template <typename Rounder>
   return rounded;
 }
 
-[[nodiscard]] static Ticks DoublesToLabels(const std::vector<double>& values, int precision) {
+[[nodiscard]] static Ticks MakeTicks(const std::vector<double>& values, int precision) {
   std::vector<QString> labels;
   const std::vector<double> rounded_values = RoundDoubles(values, precision);
   std::transform(
@@ -139,9 +139,10 @@ bool AreAllUnique(std::vector<T> vector) {
   return std::unique(vector.begin(), vector.end()) == vector.end();
 }
 
-[[nodiscard]] static Ticks GetTicklabels(const std::vector<double>& values, int max_precision) {
+[[nodiscard]] static Ticks MakeTicksChoosePrecision(const std::vector<double>& values,
+                                                    int max_precision) {
   for (int precision = 0; precision <= max_precision; precision++) {
-    Ticks ticks = DoublesToLabels(values, precision);
+    Ticks ticks = MakeTicks(values, precision);
     if (precision == max_precision || AreAllUnique(ticks.labels)) {
       return ticks;
     }
@@ -160,7 +161,7 @@ bool AreAllUnique(std::vector<T> vector) {
 }
 
 [[nodiscard]] static Ticks GenerateLabels(double min, double spacing, int max_precision) {
-  return GetTicklabels(GenerateEquidistantTickValues(min, spacing), max_precision);
+  return MakeTicksChoosePrecision(GenerateEquidistantTickValues(min, spacing), max_precision);
 }
 
 [[nodiscard]] static int ValueToAxisLocation(double value, int axis_length, double min_value,

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -200,6 +200,8 @@ static void DrawVerticalAxis(QPainter& painter, const QPoint& axes_intersection,
     const int tick_location =
         axes_intersection.y() - ValueToAxisLocation(tick_value, axis_length, 0.0, max_value);
 
+    // We skip the ticks that do not fall into the horizontal axis range. Such ticks might appear
+    // due to rounding errors.
     if (!(axes_intersection.y() - axis_length <= tick_location &&
           tick_location <= axes_intersection.y())) {
       continue;

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -122,9 +122,9 @@ struct Ticks {
 }
 
 template <typename T>
-size_t CountUnique(const std::vector<T>& vector) {
-  absl::flat_hash_set<T> set(std::begin(vector), std::end(vector));
-  return set.size();
+size_t CountUnique(std::vector<T> vector) {
+  std::sort(vector.begin(), vector.end());
+  return std::unique(vector.begin(), vector.end()) - vector.begin();
 }
 
 [[nodiscard]] static Ticks GetTicklabels(const std::vector<double>& values, int max_precision) {

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -119,6 +119,9 @@ static void DrawVerticalLine(QPainter& painter, const QPoint& start, int length)
   return result;
 }
 
+// Providing exactly `optimal_tick_count` of ticks is impossible as we use a finite set of `steps`.
+// Hence, we choose the step leading to the number of ticks closest to `optimal_tick_count`.
+// If the available tick count is either 0 or 1, the step yielding zero ticks may be returned.
 [[nodiscard]] static TickStep ChooseBestStep(double min, double max,
                                              const std::vector<TickStep>& steps,
                                              uint32_t optimal_tick_count) {

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -122,16 +122,16 @@ struct Ticks {
 }
 
 template <typename T>
-size_t CountUnique(std::vector<T> vector) {
+bool AreAllUnique(std::vector<T> vector) {
   std::sort(vector.begin(), vector.end());
-  return std::unique(vector.begin(), vector.end()) - vector.begin();
+  return std::unique(vector.begin(), vector.end()) == vector.end();
 }
 
 [[nodiscard]] static Ticks GetTicklabels(const std::vector<double>& values, int max_precision) {
   Ticks result;
   for (int precision = 0; precision <= max_precision; precision++) {
     auto labels = DoublesToLabels(values, precision);
-    if (precision == max_precision || CountUnique(labels) == values.size()) {
+    if (precision == max_precision || AreAllUnique(labels)) {
       auto rounded_values = RoundDoubles(values, precision);
       result = {labels, rounded_values, precision};
       break;


### PR DESCRIPTION
Instead of using the hard-coded number of decimals we
choose the minimal number of decimals s.t. all the ticks
have different values. We have to limit the maximal number of
decimals due to space limitations.

Further, the tick is now rendered at the position driven by the
rounded value.

After rounding some ticks may fall off to the right or to the left.
Therefore, the maximal number of tics has been increased by 1.

Test: Manual
Bug: http://b/224967376