### PR TITLE
Add default worker thread pool

### DIFF
--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -30,7 +30,6 @@
 #include "OrbitBase/JoinFutures.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/TaskGroup.h"
-#include "OrbitBase/ThreadPool.h"
 
 using orbit_client_data::CaptureData;
 using orbit_client_data::ModuleManager;
@@ -38,8 +37,7 @@ using orbit_client_protos::FunctionInfo;
 
 namespace orbit_data_views {
 
-FunctionsDataView::FunctionsDataView(AppInterface* app, orbit_base::ThreadPool* thread_pool)
-    : DataView(DataViewType::kFunctions, app), thread_pool_{thread_pool} {}
+FunctionsDataView::FunctionsDataView(AppInterface* app) : DataView(DataViewType::kFunctions, app) {}
 
 const std::string FunctionsDataView::kUnselectedFunctionString = "";
 const std::string FunctionsDataView::kSelectedFunctionString = "✓";
@@ -212,7 +210,7 @@ void FunctionsDataView::DoFilter() {
   std::vector<absl::Span<const FunctionInfo*>> chunks =
       orbit_base::CreateChunksOfSize(functions_, kNumFunctionsPerTask);
   std::vector<std::vector<uint64_t>> task_results(chunks.size());
-  orbit_base::TaskGroup task_group(thread_pool_);
+  orbit_base::TaskGroup task_group;
 
   for (size_t i = 0; i < chunks.size(); ++i) {
     task_group.AddTask([& chunk = chunks[i], &result = task_results[i], this]() {

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -45,9 +45,7 @@ using ::testing::Return;
 namespace {
 struct FunctionsDataViewTest : public testing::Test {
  public:
-  explicit FunctionsDataViewTest()
-      : thread_pool_{orbit_base::ThreadPool::Create(4, 4, absl::Milliseconds(50))},
-        view_{&app_, thread_pool_.get()} {
+  explicit FunctionsDataViewTest() : view_{&app_} {
     view_.Init();
     orbit_client_protos::FunctionInfo function0;
     function0.set_pretty_name("void foo()");
@@ -114,10 +112,9 @@ struct FunctionsDataViewTest : public testing::Test {
     module_infos_.emplace_back(std::move(module_info2));
   }
 
-  ~FunctionsDataViewTest() override { thread_pool_->ShutdownAndWait(); }
+  ~FunctionsDataViewTest() override {}
 
  protected:
-  std::shared_ptr<orbit_base::ThreadPool> thread_pool_;
   orbit_data_views::MockAppInterface app_;
   orbit_data_views::FunctionsDataView view_;
   std::vector<orbit_client_protos::FunctionInfo> functions_;

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -11,12 +11,11 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "DataViews/AppInterface.h"
 #include "DataViews/DataView.h"
-#include "OrbitBase/ThreadPool.h"
 
 namespace orbit_data_views {
 class FunctionsDataView : public DataView {
  public:
-  explicit FunctionsDataView(AppInterface* app, orbit_base::ThreadPool* thread_pool);
+  explicit FunctionsDataView(AppInterface* app);
 
   static const std::string kUnselectedFunctionString;
   static const std::string kSelectedFunctionString;
@@ -59,8 +58,6 @@ class FunctionsDataView : public DataView {
   static bool ShouldShowFrameTrackIcon(AppInterface* app,
                                        const orbit_client_protos::FunctionInfo& function);
   std::vector<const orbit_client_protos::FunctionInfo*> functions_;
-
-  orbit_base::ThreadPool* thread_pool_;
 };
 
 }  // namespace orbit_data_views

--- a/src/OrbitBase/ChunkTest.cpp
+++ b/src/OrbitBase/ChunkTest.cpp
@@ -7,11 +7,8 @@
 
 #include "OrbitBase/Chunk.h"
 #include "OrbitBase/TaskGroup.h"
-#include "OrbitBase/ThreadPool.h"
 
 using orbit_base::CreateChunksOfSize;
-using orbit_base::TaskGroup;
-using orbit_base::ThreadPool;
 
 namespace {
 
@@ -84,16 +81,10 @@ TEST(SpanUtils, SpanSizeBiggerThanVectorSize) {
 }
 
 TEST(SpanUtils, TaskGroupTestCase) {
-  constexpr size_t kThreadPoolMinSize = 2;
-  constexpr size_t kThreadPoolMaxSize = 2;
-  constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::shared_ptr<ThreadPool> thread_pool =
-      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
-
   constexpr size_t kNumElements = 1024;
   std::vector<uint32_t> counters(kNumElements);
 
-  TaskGroup task_group(thread_pool.get());
+  orbit_base::TaskGroup task_group;
   for (absl::Span<uint32_t> chunk : CreateChunksOfSize(counters, 10)) {
     task_group.AddTask([chunk]() {
       for (uint32_t& counter : chunk) ++counter;
@@ -104,6 +95,4 @@ TEST(SpanUtils, TaskGroupTestCase) {
   for (uint32_t counter : counters) {
     EXPECT_EQ(counter, 1);
   }
-
-  thread_pool->ShutdownAndWait();
 }

--- a/src/OrbitBase/TaskGroupTest.cpp
+++ b/src/OrbitBase/TaskGroupTest.cpp
@@ -5,30 +5,10 @@
 #include <gtest/gtest.h>
 #include <stddef.h>
 
-#include "OrbitBase/Logging.h"
 #include "OrbitBase/TaskGroup.h"
-#include "OrbitBase/ThreadPool.h"
-#include "OrbitBase/UniqueResource.h"
-
-using orbit_base::TaskGroup;
-using orbit_base::ThreadPool;
-
-namespace {
-
-void ShutdownThreadPool(std::shared_ptr<ThreadPool> thread_pool) { thread_pool->ShutdownAndWait(); }
-
-[[nodiscard]] ThreadPool* GetTestThreadPool() {
-  constexpr size_t kNumThreads = 4;
-  constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  static orbit_base::unique_resource handle{
-      ThreadPool::Create(kNumThreads, kNumThreads, kThreadTtl), ShutdownThreadPool};
-  return handle.get().get();
-}
-
-}  // namespace
 
 TEST(TaskGroup, EmptyTaskGroup) {
-  TaskGroup task_group(GetTestThreadPool());
+  orbit_base::TaskGroup task_group;
   task_group.Wait();
 }
 
@@ -36,7 +16,7 @@ TEST(TaskGroup, AllTasksAreCalledOnce) {
   constexpr size_t kNumElements = 1024;
   std::vector<uint32_t> counters(kNumElements);
 
-  TaskGroup task_group(GetTestThreadPool());
+  orbit_base::TaskGroup task_group;
   for (uint32_t& counter : counters) {
     task_group.AddTask([&counter] { ++counter; });
   }
@@ -53,7 +33,7 @@ TEST(TaskGroup, AllTasksAreCalledOnceNoExplicitWait) {
   std::vector<uint32_t> counters(kNumElements);
 
   {
-    TaskGroup task_group(GetTestThreadPool());
+    orbit_base::TaskGroup task_group;
     for (uint32_t& counter : counters) {
       task_group.AddTask([&counter] { ++counter; });
     }

--- a/src/OrbitBase/ThreadPoolTest.cpp
+++ b/src/OrbitBase/ThreadPoolTest.cpp
@@ -549,26 +549,22 @@ TEST(ThreadPool, DefaultThreadPoolNotNull) {
   EXPECT_NE(ThreadPool::GetDefaultThreadPool(), nullptr);
 }
 
-TEST(ThreadPool, InitializeDefaultThreadPool) {
-  ThreadPool::InitializeDefaultThreadPool();
-  EXPECT_NE(ThreadPool::GetDefaultThreadPool(), nullptr);
+TEST(ThreadPool, InitializeDefaultThreadPoolAfterFirstUse) {
+  (void)ThreadPool::GetDefaultThreadPool();
+  EXPECT_DEATH(ThreadPool::InitializeDefaultThreadPool(), "");
 }
 
-TEST(ThreadPool, OverrideDefaultThreadPool) {
+TEST(ThreadPool, SetDefaultThreadPoolAfterFirstUse) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
   static std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
-  EXPECT_EQ(thread_pool.use_count(), 1);
-  ThreadPool::SetDefaultThreadPool(thread_pool);
-  EXPECT_EQ(thread_pool.use_count(), 2);
-  EXPECT_EQ(ThreadPool::GetDefaultThreadPool(), thread_pool.get());
+  (void)ThreadPool::GetDefaultThreadPool();
+  EXPECT_DEATH(ThreadPool::SetDefaultThreadPool(thread_pool), "");
+}
 
-  ThreadPool::SetDefaultThreadPool(nullptr);
-  EXPECT_EQ(thread_pool.use_count(), 1);
-
-  EXPECT_NE(ThreadPool::GetDefaultThreadPool(), thread_pool.get());
-  EXPECT_NE(ThreadPool::GetDefaultThreadPool(), nullptr);
+TEST(ThreadPool, SetNullDefaultThreadPool) {
+  EXPECT_DEATH(ThreadPool::SetDefaultThreadPool(nullptr), "");
 }

--- a/src/OrbitBase/ThreadPoolTest.cpp
+++ b/src/OrbitBase/ThreadPoolTest.cpp
@@ -353,7 +353,9 @@ TEST(ThreadPool, InvalidArguments) {
       "");
 }
 
-TEST(ThreadPool, NoShutdown) { EXPECT_DEATH(ThreadPool::Create(1, 4, absl::Milliseconds(10)), ""); }
+TEST(ThreadPool, NoShutdown) {
+  auto thread_pool = ThreadPool::Create(1, 4, absl::Milliseconds(10));
+}
 
 TEST(ThreadPool, ScheduleAfterShutdown) {
   EXPECT_DEATH(

--- a/src/OrbitBase/ThreadPoolTest.cpp
+++ b/src/OrbitBase/ThreadPoolTest.cpp
@@ -544,3 +544,31 @@ TEST(ThreadPool, WithRunActionParameter) {
   EXPECT_EQ(run_before_action_count, 1);
   EXPECT_EQ(run_after_action_count, 1);
 }
+
+TEST(ThreadPool, DefaultThreadPoolNotNull) {
+  EXPECT_NE(ThreadPool::GetDefaultThreadPool(), nullptr);
+}
+
+TEST(ThreadPool, InitializeDefaultThreadPool) {
+  ThreadPool::InitializeDefaultThreadPool();
+  EXPECT_NE(ThreadPool::GetDefaultThreadPool(), nullptr);
+}
+
+TEST(ThreadPool, OverrideDefaultThreadPool) {
+  constexpr size_t kThreadPoolMinSize = 1;
+  constexpr size_t kThreadPoolMaxSize = 2;
+  constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
+  static std::shared_ptr<ThreadPool> thread_pool =
+      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
+
+  EXPECT_EQ(thread_pool.use_count(), 1);
+  ThreadPool::SetDefaultThreadPool(thread_pool);
+  EXPECT_EQ(thread_pool.use_count(), 2);
+  EXPECT_EQ(ThreadPool::GetDefaultThreadPool(), thread_pool.get());
+
+  ThreadPool::SetDefaultThreadPool(nullptr);
+  EXPECT_EQ(thread_pool.use_count(), 1);
+
+  EXPECT_NE(ThreadPool::GetDefaultThreadPool(), thread_pool.get());
+  EXPECT_NE(ThreadPool::GetDefaultThreadPool(), nullptr);
+}

--- a/src/OrbitBase/include/OrbitBase/TaskGroup.h
+++ b/src/OrbitBase/include/OrbitBase/TaskGroup.h
@@ -26,8 +26,8 @@ namespace orbit_base {
 //
 class TaskGroup {
  public:
-  TaskGroup() : executor_(ThreadPool::GetGlobalWorkerThreadPool()) {}
-  explicit TaskGroup(std::shared_ptr<orbit_base::Executor> executor) : executor_(executor) {}
+  TaskGroup() : executor_(ThreadPool::GetDefaultThreadPool()) {}
+  explicit TaskGroup(orbit_base::Executor* executor) : executor_(executor) {}
   ~TaskGroup() {
     if (!futures_.empty()) Wait();
   }
@@ -48,7 +48,7 @@ class TaskGroup {
   }
 
  private:
-  std::shared_ptr<orbit_base::Executor> executor_ = nullptr;
+  orbit_base::Executor* executor_ = nullptr;
   std::vector<Future<void>> futures_;
 };
 

--- a/src/OrbitBase/include/OrbitBase/TaskGroup.h
+++ b/src/OrbitBase/include/OrbitBase/TaskGroup.h
@@ -6,6 +6,7 @@
 #define ORBIT_BASE_TASK_GROUP_H_
 
 #include "OrbitBase/Executor.h"
+#include "OrbitBase/ThreadPool.h"
 
 namespace orbit_base {
 
@@ -25,12 +26,12 @@ namespace orbit_base {
 //
 class TaskGroup {
  public:
-  explicit TaskGroup(orbit_base::Executor* executor) : executor_(executor) {}
+  TaskGroup() : executor_(ThreadPool::GetGlobalWorkerThreadPool()) {}
+  explicit TaskGroup(std::shared_ptr<orbit_base::Executor> executor) : executor_(executor) {}
   ~TaskGroup() {
     if (!futures_.empty()) Wait();
   }
 
-  TaskGroup() = delete;
   TaskGroup(TaskGroup const&) = delete;
   TaskGroup& operator=(TaskGroup const&) = delete;
 
@@ -47,7 +48,7 @@ class TaskGroup {
   }
 
  private:
-  orbit_base::Executor* executor_ = nullptr;
+  std::shared_ptr<orbit_base::Executor> executor_ = nullptr;
   std::vector<Future<void>> futures_;
 };
 

--- a/src/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -72,12 +72,14 @@ class ThreadPool : public orbit_base::Executor {
       size_t thread_pool_min_size, size_t thread_pool_max_size, absl::Duration thread_ttl,
       std::function<void(const std::unique_ptr<Action>&)> run_action = nullptr);
 
-  // Initialize and set the default ThreadPool with a fixed number of threads that is equal to or
-  // smaller than the number of available cores on the system.
+  // Initialize a thread pool with a fixed number of threads that is equal to or smaller than the
+  // number of available cores on the system and set it as the default thread pool. This can only be
+  // called once, before any call to "GetDefaultThreadPool()".
   static void InitializeDefaultThreadPool();
-  // Set or override the current default thread pool.
+  // Set the default thread pool. This can only be called once and with a non-null thread pool,
+  // before any call to "GetDefaultThreadPool()".
   static void SetDefaultThreadPool(std::shared_ptr<ThreadPool> thread_pool);
-  // Get default thread pool. Create one if none was set, as if we had called
+  // Get the default thread pool. Create one if none was set, as if we had called
   // "InitializeDefaultThreadPool()" explicitly.
   [[nodiscard]] static ThreadPool* GetDefaultThreadPool();
 };

--- a/src/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -72,9 +72,14 @@ class ThreadPool : public orbit_base::Executor {
       size_t thread_pool_min_size, size_t thread_pool_max_size, absl::Duration thread_ttl,
       std::function<void(const std::unique_ptr<Action>&)> run_action = nullptr);
 
-  // Globally accessible ThreadPool with a fixed number of threads that equal to or slightly smaller
-  // than the number of available cores on the system.
-  [[nodiscard]] static std::shared_ptr<ThreadPool> GetGlobalWorkerThreadPool();
+  // Initialize and set the default ThreadPool with a fixed number of threads that is equal to or
+  // smaller than the number of available cores on the system.
+  static void InitializeDefaultThreadPool();
+  // Set or override the current default thread pool.
+  static void SetDefaultThreadPool(std::shared_ptr<ThreadPool> thread_pool);
+  // Get default thread pool. Create one if none was set, as if we had called
+  // "InitializeDefaultThreadPool()" explicitly.
+  [[nodiscard]] static ThreadPool* GetDefaultThreadPool();
 };
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -47,8 +47,8 @@ class ThreadPool : public orbit_base::Executor {
     Wait();
   }
 
-  virtual size_t GetPoolSize() = 0;
-  virtual size_t GetNumberOfBusyThreads() = 0;
+  [[nodiscard]] virtual size_t GetPoolSize() = 0;
+  [[nodiscard]] virtual size_t GetNumberOfBusyThreads() = 0;
 
   // Create ThreadPool with specified minimum and maximum number of worker
   // threads.
@@ -68,9 +68,13 @@ class ThreadPool : public orbit_base::Executor {
   // Action in a different way than simply calling Action::Execute. This can for
   // example be used to run some operation before and/or after the original
   // Action.
-  static std::shared_ptr<ThreadPool> Create(
+  [[nodiscard]] static std::shared_ptr<ThreadPool> Create(
       size_t thread_pool_min_size, size_t thread_pool_max_size, absl::Duration thread_ttl,
       std::function<void(const std::unique_ptr<Action>&)> run_action = nullptr);
+
+  // Globally accessible ThreadPool with a fixed number of threads that equal to or slightly smaller
+  // than the number of available cores on the system.
+  [[nodiscard]] static std::shared_ptr<ThreadPool> GetGlobalWorkerThreadPool();
 };
 
 }  // namespace orbit_base

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -244,6 +244,8 @@ OrbitApp::OrbitApp(orbit_gl::MainWindowInterface* main_window,
       metrics_uploader_(metrics_uploader) {
   ORBIT_CHECK(main_window_ != nullptr);
 
+  orbit_base::ThreadPool::InitializeDefaultThreadPool();
+
   thread_pool_ = orbit_base::ThreadPool::Create(
       /*thread_pool_min_size=*/4, /*thread_pool_max_size=*/256, /*thread_ttl=*/absl::Seconds(1),
       /*run_action=*/[](const std::unique_ptr<Action>& action) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -625,7 +625,6 @@ class OrbitApp final : public DataViewFactory,
   MainThreadExecutor* main_thread_executor_;
   std::thread::id main_thread_id_;
   std::shared_ptr<orbit_base::ThreadPool> thread_pool_;
-  std::shared_ptr<orbit_base::ThreadPool> core_count_sized_thread_pool_;
   std::unique_ptr<orbit_capture_client::CaptureClient> capture_client_;
   orbit_client_services::ProcessManager* process_manager_ = nullptr;
   std::unique_ptr<orbit_client_data::ModuleManager> module_manager_;


### PR DESCRIPTION
Add ThreadPool::GetDefaultThreadPool() which returns a pointer to a
global instance of a fixed-sized thread pool. This is done in order to
minimize the boilerplate code of having to pass in a ThreadPool object
to any object wanting to parallelize tasks. It is similar in spirit to std::async
being available from anywhere, and to Qt's QThreadPool::globalInstance(),
and to our internal executor's default thread pool.

A call to "ThreadPool::InitializeDefaultThreadPool()" will create the default 
thread pool. We can also override the default thread pool by calling 
"ThreadPool::SetDefaultThreadPool(...)". Note that if neither of these
functions are called, the default thread pool will be created on the first 
call to "ThreadPool::GetDefaultThreadPool()".

Fix the "ThreadPool" destruction sequence that required a manual call to 
"ShutdownAndWait()", which is now called from the destructor.

Having access to this global thread pool simplifies the use of the "TaskGroup"
object, which now uses the default thread pool if no executor is specified.

b/225063353

Tests: FunctionsDataView filtering, which uses a TaskGroup works as
expected.