### PR TITLE
Fix incorrect over-the-edge selection

### DIFF
--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -247,7 +247,7 @@ static void DrawSelection(QPainter& painter, int start_x, int end_x,
 
 [[nodiscard]] static uint64_t LocationToValue(int pos_x, int width, uint64_t min_value,
                                               uint64_t max_value) {
-  if (pos_x <= kLeftMargin) return 0;
+  if (pos_x <= kLeftMargin) return min_value;
   if (pos_x > width - kRightMargin) return max_value + 1;
 
   const int location = pos_x - kLeftMargin;


### PR DESCRIPTION
If a selection is active and the left edge of the histogram is
greater than the  absolute minimum of the dataset and if the user
selects again right-to-left and releases to the left from zero,
the new selection will start from the absolute minimum of the dataset.

This happens because `LocationToValue` returns 0 instead of `min_value`.

This fixes it.

Tests: Manual
Bug: http://b/225403525