### PR TITLE
Fix enabling Orbit Api on Silenus

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -106,6 +106,12 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
         std::string function_name =
             absl::StrFormat("%s%u", orbit_api_get_function_table_address_prefix, i);
         const FunctionInfo* function_info = module_data->FindFunctionFromPrettyName(function_name);
+        if (function_info == nullptr) {
+          // Try both variants, with and without trailing parentheses, as the function name might or
+          // might not have them depending on the symbol loading library.
+          function_name.append("()");
+          function_info = module_data->FindFunctionFromPrettyName(function_name);
+        }
         if (function_info == nullptr) continue;
         ApiFunction api_function;
         api_function.set_module_path(function_info->module_path());


### PR DESCRIPTION
After https://github.com/google/orbit/pull/3354 and
https://github.com/google/orbit/pull/3396,
`orbit_api_get_function_table_address_win_v2` is now displayed as
`orbit_api_get_function_table_address_win_v2()`. As we match by exact name
(by trying all known version numbers), `FindApiFunctions` in `CaptureClient.cpp`
couldn't find the function. Now try both variants, with and without `()`.

Bug: http://b/225818169

Test: Tried on `triangle.exe` with manual instrumentation that we use in
end-to-end tests, with client both on Linux (symbols loaded with LLVM) and
Windows (with DIA). Done the same on "regular" `OrbitTest`.