### PR TITLE
Fix histogram title

### DIFF
--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -507,7 +507,7 @@ constexpr size_t kMaxFunctionNameLengthForTitle = 80;
       absl::StrReplaceAll(function_name, {{"&", "&amp;"}, {"<", "&lt;"}, {">", "&gt;"}});
 
   std::string title =
-      absl::StrFormat("<b>%s</b> (%d of %d samples)", function_name,
+      absl::StrFormat("<b>%s</b> (%d of %d invocations)", function_name,
                       histogram_stack_.top().data_set_size, function_data_->data->size());
 
   return QString::fromStdString(title);


### PR DESCRIPTION
The word "samples" may be misleading.
This replaces it with "invocations".

Tests: Manual
Bug: http:/b//224968901