### PR TITLE
Show unwinding error type in callstack view

### DIFF
--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -5,13 +5,14 @@
 #include "SamplingReport.h"
 
 #include <absl/meta/type_traits.h>
+#include <absl/strings/str_format.h>
 
 #include <algorithm>
 
 #include "App.h"
+#include "ClientData/CallstackType.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/Logging.h"
-#include "absl/strings/str_format.h"
 
 using orbit_client_data::CallstackCount;
 using orbit_client_data::PostProcessedSamplingData;
@@ -149,11 +150,35 @@ std::string SamplingReport::GetSelectedCallstackString() const {
   ORBIT_CHECK(callstack != nullptr);
   CallstackInfo::CallstackType callstack_type = callstack->type();
 
-  std::string type_string = (callstack_type == CallstackInfo::kComplete) ? "" : "  -  Unwind error";
+  std::string type_string =
+      (callstack_type == CallstackInfo::kComplete)
+          ? ""
+          : absl::StrFormat("  - Unwind error (%s)",
+                            orbit_client_data::CallstackTypeToString(callstack_type));
   return absl::StrFormat(
       "%i of %i unique callstacks  [%i/%i total samples] (%.2f%%)%s", selected_callstack_index_ + 1,
       selected_sorted_callstack_report_->callstack_counts.size(), num_occurrences, total_callstacks,
       100.f * num_occurrences / total_callstacks, type_string);
+}
+
+std::string SamplingReport::GetSelectedCallstackTooltipString() const {
+  if (selected_sorted_callstack_report_ == nullptr) {
+    return "";
+  }
+
+  uint64_t callstack_id =
+      selected_sorted_callstack_report_->callstack_counts[selected_callstack_index_].callstack_id;
+  const orbit_client_protos::CallstackInfo* callstack = callstack_data_->GetCallstack(callstack_id);
+  ORBIT_CHECK(callstack != nullptr);
+  CallstackInfo::CallstackType callstack_type = callstack->type();
+
+  if (callstack_type == CallstackInfo::kComplete) {
+    return "";
+  }
+
+  return absl::StrFormat(
+        "The callstack could not be unwound successfully.<br/>%s",
+        orbit_client_data::CallstackTypeToDescription(callstack_type));
 }
 
 void SamplingReport::OnCallstackIndexChanged(size_t index) {

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -176,9 +176,8 @@ std::string SamplingReport::GetSelectedCallstackTooltipString() const {
     return "";
   }
 
-  return absl::StrFormat(
-        "The callstack could not be unwound successfully.<br/>%s",
-        orbit_client_data::CallstackTypeToDescription(callstack_type));
+  return absl::StrFormat("The callstack could not be unwound successfully.<br/>%s",
+                         orbit_client_data::CallstackTypeToDescription(callstack_type));
 }
 
 void SamplingReport::OnCallstackIndexChanged(size_t index) {

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -153,7 +153,7 @@ std::string SamplingReport::GetSelectedCallstackString() const {
   std::string type_string =
       (callstack_type == CallstackInfo::kComplete)
           ? ""
-          : absl::StrFormat("  - Unwind error (%s)",
+          : absl::StrFormat("  -  Unwind error (%s)",
                             orbit_client_data::CallstackTypeToString(callstack_type));
   return absl::StrFormat(
       "%i of %i unique callstacks  [%i/%i total samples] (%.2f%%)%s", selected_callstack_index_ + 1,

--- a/src/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/SamplingReport.h
@@ -47,6 +47,7 @@ class SamplingReport : public orbit_data_views::SamplingReportInterface {
   void IncrementCallstackIndex();
   void DecrementCallstackIndex();
   [[nodiscard]] std::string GetSelectedCallstackString() const;
+  [[nodiscard]] std::string GetSelectedCallstackTooltipString() const;
   void SetUiRefreshFunc(std::function<void()> func) { ui_refresh_func_ = std::move(func); };
   [[nodiscard]] bool HasCallstacks() const { return selected_sorted_callstack_report_ != nullptr; };
   [[nodiscard]] bool HasSamples() const { return !thread_data_views_.empty(); }

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -141,6 +141,9 @@ void OrbitSamplingReport::RefreshCallstackView() {
 
   std::string label = sampling_report_->GetSelectedCallstackString();
   ui_->CallstackLabel->setText(QString::fromStdString(label));
+
+  std::string tooltip = sampling_report_->GetSelectedCallstackTooltipString();
+  ui_->CallstackLabel->setToolTip(QString::fromStdString(tooltip));
   ui_->CallstackTreeView->Refresh();
 }
 

--- a/src/OrbitQt/orbitsamplingreport.ui
+++ b/src/OrbitQt/orbitsamplingreport.ui
@@ -103,7 +103,7 @@
                <string/>
               </property>
               <property name="icon">
-               <iconset resource="../icons/orbiticons.qrc">
+               <iconset>
                 <normaloff>:/actions/keyboard_arrow_left</normaloff>:/actions/keyboard_arrow_left</iconset>
               </property>
              </widget>
@@ -120,13 +120,16 @@
                <string/>
               </property>
               <property name="icon">
-               <iconset resource="../icons/orbiticons.qrc">
+               <iconset>
                 <normaloff>:/actions/keyboard_arrow_right</normaloff>:/actions/keyboard_arrow_right</iconset>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="CallstackLabel">
+              <property name="toolTip">
+               <string/>
+              </property>
               <property name="text">
                <string>Callstack</string>
               </property>

--- a/src/OrbitQt/orbitsamplingreport.ui
+++ b/src/OrbitQt/orbitsamplingreport.ui
@@ -103,7 +103,7 @@
                <string/>
               </property>
               <property name="icon">
-               <iconset>
+               <iconset resource="../icons/orbiticons.qrc">
                 <normaloff>:/actions/keyboard_arrow_left</normaloff>:/actions/keyboard_arrow_left</iconset>
               </property>
              </widget>
@@ -120,16 +120,13 @@
                <string/>
               </property>
               <property name="icon">
-               <iconset>
+               <iconset resource="../icons/orbiticons.qrc">
                 <normaloff>:/actions/keyboard_arrow_right</normaloff>:/actions/keyboard_arrow_right</iconset>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="CallstackLabel">
-              <property name="toolTip">
-               <string/>
-              </property>
               <property name="text">
                <string>Callstack</string>
               </property>


### PR DESCRIPTION
This adds the unwinding error type to the the callstack
view's text. Further, it adds a tooltip describing the
error more detailed.

http://screenshot/C85Tio98X5hSQCZ

Test: Take capture, select broken callstack, show tooltip.
Bug: http://b/190590422