### PR TITLE
Vicky UI/preaset is loaded

### DIFF
--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -31,7 +31,7 @@ class MockAppInterface : public AppInterface {
 
   MOCK_METHOD(void, SendErrorToUi, (const std::string& title, const std::string& text));
 
-  MOCK_METHOD(void, LoadPreset, (const orbit_preset_file::PresetFile&));
+  MOCK_METHOD(void, LoadPreset, (orbit_preset_file::PresetFile&));
   MOCK_METHOD(PresetLoadState, GetPresetLoadState, (const orbit_preset_file::PresetFile&), (const));
   MOCK_METHOD(void, ShowPresetInExplorer, (const orbit_preset_file::PresetFile&));
 

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -168,7 +168,7 @@ DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action,
 }
 
 void PresetsDataView::OnLoadPresetRequested(const std::vector<int>& selection) {
-  const PresetFile& preset = GetPreset(selection[0]);
+  PresetFile& preset = GetMutablePreset(selection[0]);
   app_->LoadPreset(preset);
 }
 
@@ -196,7 +196,7 @@ void PresetsDataView::OnShowInExplorerRequested(const std::vector<int>& selectio
 }
 
 void PresetsDataView::OnDoubleClicked(int index) {
-  const PresetFile& preset = GetPreset(index);
+  PresetFile& preset = GetMutablePreset(index);
   if (app_->GetPresetLoadState(preset).state != PresetLoadState::kNotLoadable) {
     app_->LoadPreset(preset);
   }
@@ -260,6 +260,9 @@ void PresetsDataView::SetPresets(std::vector<PresetFile> presets) {
 const PresetFile& PresetsDataView::GetPreset(unsigned int row) const {
   return presets_[indices_[row]];
 }
+
+PresetFile& PresetsDataView::GetMutablePreset(unsigned int row) { return presets_[indices_[row]]; }
+
 const std::vector<PresetsDataView::ModuleView>& PresetsDataView::GetModules(uint32_t row) const {
   return modules_[indices_[row]];
 }

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -44,9 +44,13 @@ constexpr const float kHookedFunctionsColumnWidth = 0.16f;
 constexpr const float kDateModifiedColumnWidth = 0.16f;
 
 namespace {
-std::string GetLoadStateString(orbit_data_views::AppInterface* app, const PresetFile& preset) {
+std::string GetLoadStatusAndStateString(orbit_data_views::AppInterface* app,
+                                        const PresetFile& preset) {
+  std::string load_status = preset.IsLoaded()
+                                ? orbit_data_views::PresetsDataView::kLoadedPresetString
+                                : orbit_data_views::PresetsDataView::kLoadedPresetBlankString;
   orbit_data_views::PresetLoadState load_state = app->GetPresetLoadState(preset);
-  return load_state.GetName();
+  return absl::StrCat(load_status, load_state.GetName());
 }
 
 std::string GetDateModifiedString(const PresetFile& preset) {
@@ -61,6 +65,10 @@ std::string GetDateModifiedString(const PresetFile& preset) {
 }  // namespace
 
 namespace orbit_data_views {
+
+const std::string PresetsDataView::kLoadedPresetString = "* ";
+const std::string PresetsDataView::kLoadedPresetBlankString =
+    std::string(kLoadedPresetString.size(), ' ');
 
 PresetsDataView::PresetsDataView(AppInterface* app,
                                  orbit_metrics_uploader::MetricsUploader* metrics_uploader)
@@ -100,7 +108,7 @@ std::string PresetsDataView::GetValue(int row, int column) {
 
   switch (column) {
     case kColumnLoadState:
-      return GetLoadStateString(app_, preset);
+      return GetLoadStatusAndStateString(app_, preset);
     case kColumnPresetName:
       return preset.file_path().filename().string();
     case kColumnModules:

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -74,10 +74,10 @@ TEST_F(PresetsDataViewTest, Empty) {
 }
 
 TEST_F(PresetsDataViewTest, CheckLabelAndColorForLoadStates) {
-  // GetPresetLoadState is called once per `GetValue` and `GetToolTip` call.
+  // GetPresetLoadState is called once per `GetValue`, `GetToolTip` and `GetDisplayColor` call.
   auto load_state = PresetLoadState::kLoadable;
   EXPECT_CALL(app_, GetPresetLoadState)
-      .Times(9)
+      .Times(11)
       .WillRepeatedly(testing::ReturnPointee(&load_state));
 
   orbit_client_protos::PresetInfo preset_info0{};
@@ -87,21 +87,21 @@ TEST_F(PresetsDataViewTest, CheckLabelAndColorForLoadStates) {
   EXPECT_EQ(view_.GetNumElements(), 1);
 
   load_state = PresetLoadState::kLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), "Yes");
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetBlankString, "Yes"));
   EXPECT_TRUE(view_.GetToolTip(0, 0).empty());
   Color color_loadable_state{};
   view_.GetDisplayColor(0, 0, color_loadable_state.r, color_loadable_state.g,
                         color_loadable_state.b);
 
   load_state = PresetLoadState::kNotLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), "No");
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetBlankString, "No"));
   EXPECT_FALSE(view_.GetToolTip(0, 0).empty());
   Color color_not_loadable_state{};
   view_.GetDisplayColor(0, 0, color_not_loadable_state.r, color_not_loadable_state.g,
                         color_not_loadable_state.b);
 
   load_state = PresetLoadState::kPartiallyLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), "Partially");
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetBlankString, "Partially"));
   EXPECT_TRUE(view_.GetToolTip(0, 0).empty());
   Color color_partially_loadable_state{};
   view_.GetDisplayColor(0, 0, color_partially_loadable_state.r, color_partially_loadable_state.g,
@@ -113,6 +113,15 @@ TEST_F(PresetsDataViewTest, CheckLabelAndColorForLoadStates) {
   EXPECT_NE(color_loadable_state, color_partially_loadable_state);
   EXPECT_NE(color_loadable_state, color_not_loadable_state);
   EXPECT_NE(color_partially_loadable_state, color_not_loadable_state);
+
+  preset_file0.SetIsLoaded(true);
+  view_.SetPresets({preset_file0});
+
+  load_state = PresetLoadState::kLoadable;
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetString, "Yes"));
+
+  load_state = PresetLoadState::kPartiallyLoadable;
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetString, "Partially"));
 }
 
 TEST_F(PresetsDataViewTest, PresetNameIsFileName) {
@@ -264,7 +273,7 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
   {
     std::string expected_clipboard = absl::StrFormat(
         "Loadable\tPreset\tModules\tHooked Functions\tDate Modified\n"
-        "Yes\t%s\t\t\t%s\n",
+        "  Yes\t%s\t\t\t%s\n",
         preset_filename0.filename().string(), FormatShortDatetime(date_modified.value()));
     CheckCopySelectionIsInvoked(context_menu, app_, view_, expected_clipboard);
   }
@@ -274,7 +283,7 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
     std::string expected_contents = absl::StrFormat(
         R"("Loadable","Preset","Modules","Hooked Functions","Date Modified")"
         "\r\n"
-        R"("Yes","%s","","","%s")"
+        R"("  Yes","%s","","","%s")"
         "\r\n",
         preset_filename0.filename().string(), FormatShortDatetime(date_modified.value()));
     CheckExportToCsvIsInvoked(context_menu, app_, view_, expected_contents);

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -35,7 +35,7 @@ class AppInterface {
   virtual void SendErrorToUi(const std::string& title, const std::string& text) = 0;
 
   // Functions needed by PresetsDataView
-  virtual void LoadPreset(const orbit_preset_file::PresetFile& preset) = 0;
+  virtual void LoadPreset(orbit_preset_file::PresetFile& preset) = 0;
   [[nodiscard]] virtual PresetLoadState GetPresetLoadState(
       const orbit_preset_file::PresetFile& preset) const = 0;
   virtual void ShowPresetInExplorer(const orbit_preset_file::PresetFile& preset) = 0;

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -43,6 +43,9 @@ class PresetsDataView : public DataView {
   void OnDeletePresetRequested(const std::vector<int>& selection) override;
   void OnShowInExplorerRequested(const std::vector<int>& selection) override;
 
+  static const std::string kLoadedPresetString;
+  static const std::string kLoadedPresetBlankString;
+
  protected:
   struct ModuleView {
     ModuleView(std::string name, uint32_t count)

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -58,6 +58,7 @@ class PresetsDataView : public DataView {
   [[nodiscard]] static std::string GetModulesList(const std::vector<ModuleView>& modules);
   [[nodiscard]] static std::string GetFunctionCountList(const std::vector<ModuleView>& modules);
   [[nodiscard]] const orbit_preset_file::PresetFile& GetPreset(unsigned int row) const;
+  [[nodiscard]] orbit_preset_file::PresetFile& GetMutablePreset(unsigned int row);
   [[nodiscard]] const std::vector<ModuleView>& GetModules(uint32_t row) const;
 
   std::vector<orbit_preset_file::PresetFile> presets_;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2132,7 +2132,7 @@ void OrbitApp::EnableFrameTracksByName(const ModuleData* module,
   }
 }
 
-void OrbitApp::LoadPreset(const PresetFile& preset_file) {
+void OrbitApp::LoadPreset(PresetFile& preset_file) {
   ScopedMetric metric{metrics_uploader_, orbit_metrics_uploader::OrbitLogEvent::ORBIT_PRESET_LOAD};
   std::vector<orbit_base::Future<std::string>> load_module_results{};
   auto module_paths = preset_file.GetModulePaths();
@@ -2158,7 +2158,7 @@ void OrbitApp::LoadPreset(const PresetFile& preset_file) {
   // Then - when all modules are loaded or failed to load - we update the UI and potentially show an
   // error message.
   auto results = orbit_base::JoinFutures(absl::MakeConstSpan(load_module_results));
-  results.Then(main_thread_executor_, [this, metric = std::move(metric), preset_file](
+  results.Then(main_thread_executor_, [this, metric = std::move(metric), &preset_file](
                                           std::vector<std::string> module_paths_not_found) mutable {
     size_t tried_to_load_amount = module_paths_not_found.size();
     module_paths_not_found.erase(
@@ -2186,6 +2186,8 @@ void OrbitApp::LoadPreset(const PresetFile& preset_file) {
                     preset_file.file_path().string(), convertion_result.error().message());
       }
     }
+
+    preset_file.SetIsLoaded(true);
 
     FireRefreshCallbacks();
   });

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -368,7 +368,7 @@ class OrbitApp final : public DataViewFactory,
 
   orbit_base::Future<ErrorMessageOr<void>> LoadPresetModule(
       const std::filesystem::path& module_path, const orbit_preset_file::PresetFile& preset_file);
-  void LoadPreset(const orbit_preset_file::PresetFile& preset) override;
+  void LoadPreset(orbit_preset_file::PresetFile& preset) override;
   [[nodiscard]] orbit_data_views::PresetLoadState GetPresetLoadState(
       const orbit_preset_file::PresetFile& preset) const override;
   void ShowPresetInExplorer(const orbit_preset_file::PresetFile& preset) override;

--- a/src/PresetFile/include/PresetFile/PresetFile.h
+++ b/src/PresetFile/include/PresetFile/PresetFile.h
@@ -33,6 +33,9 @@ class PresetFile final {
       const std::filesystem::path& module_path) const;
   [[nodiscard]] bool IsLegacyFileFormat() const;
 
+  void SetIsLoaded(bool is_loaded) { is_loaded_ = is_loaded; }
+  [[nodiscard]] bool IsLoaded() const { return is_loaded_; }
+
   [[nodiscard]] std::vector<uint64_t> GetSelectedFunctionHashesForModuleLegacy(
       const std::filesystem::path& module_path) const;
   [[nodiscard]] std::vector<uint64_t> GetFrameTrackFunctionHashesForModuleLegacy(
@@ -48,6 +51,7 @@ class PresetFile final {
  private:
   std::filesystem::path file_path_;
   bool is_legacy_format_;
+  bool is_loaded_ = false;
   orbit_client_protos::PresetInfo preset_info_;
   orbit_client_protos::PresetInfoLegacy preset_info_legacy_;
 };


### PR DESCRIPTION
With this change, we update the PresetsDataView first column to also
indicate whether the preset file is loaded.
To be specific, for a (partially) loadable preset file, if it is
(partially) loaded successfully, we add a "* " in front of the load
state to notify the user the load result.

Bug: http://b/187411031
Test: run unit tests

After the change: https://screenshot/9tdNrwtEeLLKMbW