### PR TITLE
Add capture window integration tests

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -405,7 +405,7 @@ std::unique_ptr<AccessibleInterface> CaptureWindow::CreateAccessibleInterface() 
 void CaptureWindow::Draw() {
   ORBIT_SCOPE("CaptureWindow::Draw");
   uint64_t start_time_ns = orbit_base::CaptureTimestampNs();
-  bool time_graph_was_redrawn = time_graph_ != nullptr ? time_graph_->IsRedrawNeeded() : false;
+  bool time_graph_was_redrawn = time_graph_ != nullptr && time_graph_->IsRedrawNeeded();
 
   text_renderer_.Init();
 
@@ -561,11 +561,15 @@ void CaptureWindow::UpdateHorizontalSliderFromWorld() {
   double stop = time_graph_->GetMaxTimeUs();
   double width = stop - start;
   double max_start = time_span - width;
-  double ratio = capture_client_app_->IsCapturing() ? 1 : (max_start != 0 ? start / max_start : 0);
+
+  constexpr double kEpsilon = 1e-8;
+  double ratio =
+      capture_client_app_->IsCapturing() ? 1 : (max_start > kEpsilon ? start / max_start : 0);
   int slider_width = static_cast<int>(time_graph_->GetLayout().GetSliderWidth());
   slider_->SetPixelHeight(slider_width);
-  slider_->SetNormalizedPosition(static_cast<float>(ratio));
   slider_->SetNormalizedLength(static_cast<float>(width / time_span));
+  slider_->SetNormalizedPosition(static_cast<float>(ratio));
+
   slider_->SetOrthogonalSliderPixelHeight(vertical_slider_->IsVisible() ? slider_width : 0);
 }
 

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -4,7 +4,11 @@
 
 #include <gtest/gtest.h>
 
+#include <random>
+
+#include "CaptureClient/AppInterface.h"
 #include "CaptureWindow.h"
+#include "TrackTestData.h"
 #include "UnitTestSlider.h"
 
 namespace orbit_gl {
@@ -77,6 +81,288 @@ TEST_F(UnitTestCaptureWindow, SlidersRespondToMouseLeave) {
   EXPECT_TRUE(unit_test_vertical_slider->IsMouseOver());
   SetIsMouseOver(false);
   EXPECT_FALSE(unit_test_vertical_slider->IsMouseOver());
+}
+
+class CaptureClientAppInterfaceFake : public orbit_capture_client::CaptureControlInterface {
+  [[nodiscard]] orbit_capture_client::CaptureClient::State GetCaptureState() const {
+    return orbit_capture_client::CaptureClient::State::kStopped;
+  }
+
+  [[nodiscard]] bool IsCapturing() const { return false; }
+
+  void StartCapture() {}
+  void StopCapture() {}
+  void AbortCapture() {}
+  void ToggleCapture() {}
+};
+
+constexpr int kBottomSafetyMargin = 5;
+constexpr int kViewportWidth = 600;
+constexpr int kViewportHeight = 100;
+
+constexpr double kSliderPosEpsilon = 0.0001;
+constexpr double kTimeEpsilonUs = 0.0001;
+
+class NavigationTestCaptureWindow : public CaptureWindow, public testing::Test {
+ public:
+  explicit NavigationTestCaptureWindow() : CaptureWindow(nullptr) {
+    capture_client_app_ = &capture_client_app_fake_;
+
+    Resize(kViewportWidth, kViewportHeight);
+
+    capture_data_ = TrackTestData::GenerateTestCaptureData();
+    time_graph_ = std::make_unique<TimeGraph>(this, nullptr, &viewport_, capture_data_.get(),
+                                              &picking_manager_);
+
+    AddTimers();
+    PreRender();
+    time_graph_->ZoomAll();
+
+    // Make sure our expectations about the height of the timeline are correct,
+    // otherwise zooming may not work as expected - if this fails, the overall
+    // viewport height should be changed and the test adjusted accordingly
+    ORBIT_CHECK(time_graph_->GetTimelineUi()->GetHeight() < kViewportHeight - kBottomSafetyMargin);
+    ORBIT_CHECK(time_graph_->GetTimelineUi()->GetPos()[0] == 0);
+  }
+
+ protected:
+  void ExpectInitialState(bool allow_small_imprecision = false) {
+    EXPECT_LT(vertical_slider_->GetLengthRatio(), 1.0);
+    EXPECT_DOUBLE_EQ(vertical_slider_->GetPosRatio(), 0.0);
+
+    EXPECT_DOUBLE_EQ(slider_->GetLengthRatio(), 1.0);
+    EXPECT_DOUBLE_EQ(slider_->GetPosRatio(), 0.0);
+
+    if (allow_small_imprecision) {
+      EXPECT_NEAR(time_graph_->GetMaxTimeUs() * 1000, time_graph_->GetCaptureMax(), kTimeEpsilonUs);
+      EXPECT_NEAR(time_graph_->GetMinTimeUs() * 1000, 0, kTimeEpsilonUs);
+    } else {
+      EXPECT_DOUBLE_EQ(time_graph_->GetMaxTimeUs() * 1000, time_graph_->GetCaptureMax());
+      EXPECT_DOUBLE_EQ(time_graph_->GetMinTimeUs() * 1000, 0);
+    }
+  }
+
+  enum struct PosWithinCapture { kLeft, kRight, kMiddle, kAnywhere };
+  void ExpectIsHorizontallyZoomedIn(PosWithinCapture pos) {
+    EXPECT_LT(slider_->GetLengthRatio(), 1.0);
+    EXPECT_LT(time_graph_->GetMaxTimeUs() - time_graph_->GetMinTimeUs(),
+              time_graph_->GetCaptureTimeSpanUs());
+
+    switch (pos) {
+      case PosWithinCapture::kLeft:
+        EXPECT_DOUBLE_EQ(slider_->GetPosRatio(), 0.0);
+        EXPECT_LT(time_graph_->GetMaxTimeUs() * 1000, time_graph_->GetCaptureMax());
+        EXPECT_DOUBLE_EQ(time_graph_->GetMinTimeUs() * 1000, 0);
+        break;
+      case PosWithinCapture::kRight:
+        // TODO (b/226376252): This should also check if pos + size == 100%
+        EXPECT_GT(slider_->GetPosRatio(), 0.0);
+        EXPECT_DOUBLE_EQ(time_graph_->GetMaxTimeUs() * 1000, time_graph_->GetCaptureMax());
+        EXPECT_GT(time_graph_->GetMinTimeUs() * 1000, 0);
+        break;
+      case PosWithinCapture::kMiddle:
+        EXPECT_NEAR(slider_->GetPosRatio(), 0.5, 0.01);
+        EXPECT_NEAR(time_graph_->GetCaptureMax() - time_graph_->GetMaxTimeUs() * 1000,
+                    time_graph_->GetMinTimeUs() * 1000 - time_graph_->GetCaptureMin(), 1);
+        break;
+      case PosWithinCapture::kAnywhere:
+        // Covered by basic conditions above
+        break;
+    }
+  }
+
+ private:
+  CaptureClientAppInterfaceFake capture_client_app_fake_;
+  std::unique_ptr<orbit_client_data::CaptureData> capture_data_;
+
+  void AddTimers() {
+    auto timers = TrackTestData::GenerateTimers();
+    for (auto& timer : timers) {
+      time_graph_->ProcessTimer(timer, nullptr);
+    }
+  }
+};
+
+TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksInTheMiddleOfTimeGraph) {
+  PreRender();
+  ExpectInitialState();
+  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
+
+  int x = kTimeGraphSize[0] / 2;
+  int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+
+  MouseWheelMoved(x, y, 1, false);
+  PreRender();
+  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kMiddle);
+
+  MouseWheelMoved(x, y, -1, false);
+  PreRender();
+  ExpectInitialState();
+
+  // Keyboard
+  MouseMoved(x, y, false, false, false);
+  KeyPressed('W', false, false, false);
+  PreRender();
+  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kMiddle);
+
+  KeyPressed('S', false, false, false);
+  PreRender();
+  ExpectInitialState();
+}
+
+TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtRandomPositions) {
+  PreRender();
+  ExpectInitialState();
+  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
+
+  std::random_device rd;
+  std::mt19937 mt(rd());
+  std::uniform_int_distribution<int> dist(0, kTimeGraphSize[0]);
+
+  constexpr int kNumTries = 100;
+  for (int i = 0; i < kNumTries; ++i) {
+    int x = dist(mt);
+    int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+
+    // Zoom in twice, then zoom out twice. Check that the intermediate states match
+    MouseWheelMoved(x, y, 1, false);
+    PreRender();
+    ExpectIsHorizontallyZoomedIn(PosWithinCapture::kAnywhere);
+
+    float last_slider_pos = slider_->GetPosRatio();
+    double last_min_time = time_graph_->GetMinTimeUs();
+    double last_max_time = time_graph_->GetMaxTimeUs();
+    MouseWheelMoved(x, y, 1, false);
+    PreRender();
+    ExpectIsHorizontallyZoomedIn(PosWithinCapture::kAnywhere);
+
+    MouseWheelMoved(x, y, -1, false);
+    PreRender();
+    EXPECT_NEAR(slider_->GetPosRatio(), last_slider_pos, kSliderPosEpsilon);
+    EXPECT_NEAR(time_graph_->GetMinTimeUs(), last_min_time, kTimeEpsilonUs);
+    EXPECT_NEAR(time_graph_->GetMaxTimeUs(), last_max_time, kTimeEpsilonUs);
+
+    MouseWheelMoved(x, y, -1, false);
+    PreRender();
+    ExpectInitialState(true);
+
+    // Same test using the Keyboard
+    MouseMoved(x, y, false, false, false);
+    KeyPressed('W', false, false, false);
+    PreRender();
+    ExpectIsHorizontallyZoomedIn(PosWithinCapture::kAnywhere);
+
+    last_slider_pos = slider_->GetPosRatio();
+    last_min_time = time_graph_->GetMinTimeUs();
+    last_max_time = time_graph_->GetMaxTimeUs();
+    KeyPressed('W', false, false, false);
+    PreRender();
+    ExpectIsHorizontallyZoomedIn(PosWithinCapture::kAnywhere);
+
+    KeyPressed('S', false, false, false);
+    PreRender();
+    EXPECT_NEAR(slider_->GetPosRatio(), last_slider_pos, kSliderPosEpsilon);
+    EXPECT_NEAR(time_graph_->GetMinTimeUs(), last_min_time, kTimeEpsilonUs);
+    EXPECT_NEAR(time_graph_->GetMaxTimeUs(), last_max_time, kTimeEpsilonUs);
+
+    KeyPressed('S', false, false, false);
+    PreRender();
+    ExpectInitialState(true);
+  }
+}
+
+TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheRightOfTimeGraph) {
+  PreRender();
+  ExpectInitialState();
+  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
+
+  int x = kTimeGraphSize[0];
+  int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+
+  MouseWheelMoved(x, y, 1, false);
+  PreRender();
+  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kRight);
+
+  MouseWheelMoved(x, y, -1, false);
+  PreRender();
+  ExpectInitialState();
+
+  // Keyboard
+  MouseMoved(x, y, false, false, false);
+  KeyPressed('W', false, false, false);
+  PreRender();
+  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kRight);
+
+  KeyPressed('S', false, false, false);
+  PreRender();
+  ExpectInitialState();
+}
+
+TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheLeftOfTimeGraph) {
+  PreRender();
+  ExpectInitialState();
+  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
+
+  int x = kTimeGraphSize[0] / 2;
+  int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+
+  MouseWheelMoved(x, y, 1, false);
+  PreRender();
+  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kMiddle);
+
+  MouseWheelMoved(x, y, -1, false);
+  PreRender();
+  ExpectInitialState();
+
+  // Keyboard
+  MouseMoved(x, y, false, false, false);
+  KeyPressed('W', false, false, false);
+  PreRender();
+  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kMiddle);
+
+  KeyPressed('S', false, false, false);
+  PreRender();
+  ExpectInitialState();
+}
+
+TEST_F(NavigationTestCaptureWindow, VerticalZoomWorksAsExpected) {
+  PreRender();
+  ExpectInitialState();
+
+  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
+  int x = kTimeGraphSize[0] / 2;
+  int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+
+  float old_height = time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight();
+  MouseWheelMoved(x, y, 1, true);
+  PreRender();
+  EXPECT_GT(time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight(), old_height);
+
+  MouseWheelMoved(x, y, -1, true);
+  PreRender();
+  EXPECT_EQ(time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight(), old_height);
+}
+
+TEST_F(NavigationTestCaptureWindow, PanTimeWorksAsExpected) {
+  // TODO (b/226386133): Extend this test
+  PreRender();
+  ExpectInitialState();
+
+  int x = 0;
+  int y = viewport_.GetScreenHeight() - kBottomSafetyMargin;
+
+  // Pan time - need to zoom in a bit first, then pan slighty right and back again
+  MouseMoved(x, y, false, false, false);
+  KeyPressed('W', false, false, false);
+  KeyPressed('D', false, false, false);
+  PreRender();
+  EXPECT_GT(slider_->GetPosRatio(), 0.0);
+  EXPECT_GT(time_graph_->GetMinTimeUs(), 0.0);
+
+  KeyPressed('A', false, false, false);
+  PreRender();
+  EXPECT_EQ(slider_->GetPosRatio(), 0.0);
+  EXPECT_EQ(time_graph_->GetMinTimeUs(), 0.0);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -146,7 +146,9 @@ void GlCanvas::LeftDown(int x, int y) {
   RequestRedraw();
 }
 
-void GlCanvas::MouseWheelMoved(int /*x*/, int /*y*/, int delta, bool /*ctrl*/) {
+void GlCanvas::MouseWheelMoved(int x, int y, int delta, bool /*ctrl*/) {
+  mouse_move_pos_screen_ = Vec2i(x, y);
+
   // Normalize and invert sign, so that delta < 0 is zoom in.
   int delta_normalized = delta < 0 ? 1 : -1;
 

--- a/src/OrbitGl/TrackTestData.cpp
+++ b/src/OrbitGl/TrackTestData.cpp
@@ -31,13 +31,30 @@ std::unique_ptr<CaptureData> TrackTestData::GenerateTestCaptureData() {
   capture_data->AddUniqueCallstack(kCallstackId, std::move(callstack_info));
 
   // CallstackEvent
-  orbit_client_data::CallstackEvent callstack_event{1234, kCallstackId, kThreadId};
-  capture_data->AddCallstackEvent(callstack_event);
+  orbit_client_data::CallstackEvent callstack_event0{1234, kCallstackId, kThreadId};
+  capture_data->AddCallstackEvent(callstack_event0);
+
+  orbit_client_data::CallstackEvent callstack_event1{5000, kCallstackId, kThreadId};
+  capture_data->AddCallstackEvent(callstack_event1);
 
   capture_data->AddOrAssignThreadName(kThreadId, kThreadName);
   capture_data->AddOrAssignThreadName(kTimerOnlyThreadId, kTimerOnlyThreadName);
 
   return capture_data;
+}
+
+std::vector<orbit_client_protos::TimerInfo> TrackTestData::GenerateTimers() {
+  using orbit_client_protos::TimerInfo;
+
+  TimerInfo timer;
+  timer.set_start(0);
+  timer.set_end(100);
+  timer.set_thread_id(TrackTestData::kThreadId);
+  timer.set_processor(0);
+  timer.set_depth(0);
+  timer.set_type(TimerInfo::kCoreActivity);
+
+  return {timer};
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TrackTestData.h
+++ b/src/OrbitGl/TrackTestData.h
@@ -7,8 +7,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "ClientData/CaptureData.h"
+#include "ClientProtos/capture_data.pb.h"
 
 namespace orbit_gl {
 
@@ -25,6 +27,7 @@ struct TrackTestData {
   static constexpr const char* kTimerOnlyThreadName = "timer only thread";
 
   static std::unique_ptr<orbit_client_data::CaptureData> GenerateTestCaptureData();
+  static std::vector<orbit_client_protos::TimerInfo> GenerateTimers();
 };
 
 }  // namespace orbit_gl


### PR DESCRIPTION
This PR adds several "integration" tests to the capture window:
The tests create all required UI elements underneath the capture window
from fake data, including a scheduler- and a single thread track.

The firsts tests verify the current mouse navigation scheme using the
mousewheel, and test if zooming / scrolling / panning works as expected.
Their main purpose is to shield against regressions for the upcoming PR
to delegate the scrolling handling to `TimeGraph`, and they will be changed
soon afterwards once we expect the `TimelineUI` to handle scrolling
differently from `TimeGraph`.

Bug: http://b/224764161
Test: Manual testing: navigation in the capture window still works as expected.