### PR TITLE
Add mouse wheel handler for CaptureViewElement

### DIFF
--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -58,9 +58,6 @@ CaptureViewElement::EventResult CaptureViewElement::OnMouseWheel(
 }
 
 void CaptureViewElement::UpdateLayout() {
-  // Call all methods that may invoke layout changed for children
-  SetWidth(width_);
-
   // Perform any layout changes of this element
   DoUpdateLayout();
 
@@ -79,16 +76,16 @@ void CaptureViewElement::SetPos(float x, float y) {
 }
 
 void CaptureViewElement::SetWidth(float width) {
+  if (width == width_) return;
+
   for (auto& child : GetAllChildren()) {
     if (child->GetLayoutFlags() & LayoutFlags::kScaleHorizontallyWithParent) {
       child->SetWidth(width);
     }
   }
 
-  if (width != width_) {
-    width_ = width;
-    RequestUpdate();
-  }
+  width_ = width;
+  RequestUpdate();
 }
 
 void CaptureViewElement::SetVisible(bool value) {

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -52,9 +52,9 @@ void CaptureViewElement::UpdatePrimitives(Batcher& batcher, TextRenderer& text_r
   batcher.PopTranslation();
 }
 
-bool CaptureViewElement::OnMouseWheel(const Vec2& mouse_pos, int delta,
-                                      const ModifierKeys& modifiers) {
-  return false;
+CaptureViewElement::EventResult CaptureViewElement::OnMouseWheel(const Vec2& mouse_pos, int delta,
+                                                                 const ModifierKeys& modifiers) {
+  return EventResult::kIgnored;
 }
 
 void CaptureViewElement::UpdateLayout() {
@@ -115,24 +115,28 @@ void CaptureViewElement::OnDrag(int x, int y) {
   RequestUpdate();
 }
 
+bool CaptureViewElement::ContainsPoint(const Vec2& pos) {
+  return pos[0] >= GetPos()[0] && pos[0] <= GetPos()[0] + GetSize()[0] && pos[1] >= GetPos()[1] &&
+         pos[1] <= GetPos()[1] + GetSize()[1];
+}
+
 bool CaptureViewElement::IsMouseOver(const Vec2& mouse_pos) {
   if (parent_ != nullptr && !parent_->IsMouseOver(mouse_pos)) {
     return false;
   }
 
-  return mouse_pos[0] >= GetPos()[0] && mouse_pos[0] <= GetPos()[0] + GetSize()[0] &&
-         mouse_pos[1] >= GetPos()[1] && mouse_pos[1] <= GetPos()[1] + GetSize()[1];
+  return ContainsPoint(mouse_pos);
 }
 
-bool CaptureViewElement::HandleMouseWheelEvent(const Vec2& mouse_pos, int delta,
-                                               const ModifierKeys& modifiers) {
+CaptureViewElement::EventResult CaptureViewElement::HandleMouseWheelEvent(
+    const Vec2& mouse_pos, int delta, const ModifierKeys& modifiers) {
   if (!IsMouseOver(mouse_pos)) {
-    return false;
+    return EventResult::kIgnored;
   }
 
   for (CaptureViewElement* child : GetAllChildren()) {
-    if (child->HandleMouseWheelEvent(mouse_pos, delta, modifiers)) {
-      return true;
+    if (child->HandleMouseWheelEvent(mouse_pos, delta, modifiers) == EventResult::kHandled) {
+      return EventResult::kHandled;
     }
   }
 

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -52,8 +52,8 @@ void CaptureViewElement::UpdatePrimitives(Batcher& batcher, TextRenderer& text_r
   batcher.PopTranslation();
 }
 
-CaptureViewElement::EventResult CaptureViewElement::OnMouseWheel(const Vec2& mouse_pos, int delta,
-                                                                 const ModifierKeys& modifiers) {
+CaptureViewElement::EventResult CaptureViewElement::OnMouseWheel(
+    const Vec2& /*mouse_pos*/, int /*delta*/, const ModifierKeys& /*modifiers*/) {
   return EventResult::kIgnored;
 }
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -48,6 +48,17 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override { return true; }
 
+  // Mouse interaction (bounding-box based)
+  struct ModifierKeys {
+    bool ctrl = false;
+    bool shift = false;
+    bool alt = false;
+  };
+
+  [[nodiscard]] bool IsMouseOver(const Vec2& mouse_pos);
+  [[nodiscard]] bool HandleMouseWheelEvent(const Vec2& mouse_pos, int delta,
+                                           const ModifierKeys& modifiers = ModifierKeys());
+
   [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetAllChildren() const { return {}; }
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetNonHiddenChildren() const;
@@ -87,6 +98,9 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
                                   PickingMode /*picking_mode*/) {}
 
   virtual void DoUpdateLayout() {}
+
+  [[nodiscard]] virtual bool OnMouseWheel(const Vec2& mouse_pos, int delta,
+                                          const ModifierKeys& modifiers);
 
  private:
   float width_ = 0.;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -16,6 +16,12 @@
 
 namespace orbit_gl {
 
+struct ModifierKeys {
+  bool ctrl = false;
+  bool shift = false;
+  bool alt = false;
+};
+
 /* Base class for UI elements drawn underneath the capture window. */
 class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
  public:
@@ -47,13 +53,6 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void OnRelease() override;
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override { return true; }
-
-  // Mouse interaction (bounding-box based)
-  struct ModifierKeys {
-    bool ctrl = false;
-    bool shift = false;
-    bool alt = false;
-  };
 
   [[nodiscard]] bool IsMouseOver(const Vec2& mouse_pos);
   [[nodiscard]] bool HandleMouseWheelEvent(const Vec2& mouse_pos, int delta,

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -54,9 +54,15 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override { return true; }
 
+  [[nodiscard]] bool ContainsPoint(const Vec2& pos);
+
+  // This also checks IsMouseOver() for the parent, and only returns true if the mouse
+  // position is included in all parents up to the root
   [[nodiscard]] bool IsMouseOver(const Vec2& mouse_pos);
-  [[nodiscard]] bool HandleMouseWheelEvent(const Vec2& mouse_pos, int delta,
-                                           const ModifierKeys& modifiers = ModifierKeys());
+
+  enum class EventResult { kHandled, kIgnored };
+  [[nodiscard]] EventResult HandleMouseWheelEvent(const Vec2& mouse_pos, int delta,
+                                                  const ModifierKeys& modifiers = ModifierKeys());
 
   [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetAllChildren() const { return {}; }
@@ -98,8 +104,8 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   virtual void DoUpdateLayout() {}
 
-  [[nodiscard]] virtual bool OnMouseWheel(const Vec2& mouse_pos, int delta,
-                                          const ModifierKeys& modifiers);
+  [[nodiscard]] virtual EventResult OnMouseWheel(const Vec2& mouse_pos, int delta,
+                                                 const ModifierKeys& modifiers);
 
  private:
   float width_ = 0.;

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -130,7 +130,7 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
   using ::testing::Exactly;
   using ::testing::Return;
 
-  const int kChildCount = 2;
+  const int kChildCount = 3;
   UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, kChildCount);
 
   static_assert(kMarginAfterChild > 0);
@@ -141,29 +141,14 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
   const Vec2 kPosOnChild1(10, kLeafElementHeight + kMarginAfterChild);
   const Vec2 kPosOnChild2(10, (kLeafElementHeight + kMarginAfterChild) * 2);
 
-  class ElementThatHandlesMouseWheelEvents : public UnitTestCaptureViewLeafElement {
-   public:
-    explicit ElementThatHandlesMouseWheelEvents(CaptureViewElement* parent,
-                                                const Viewport* viewport,
-                                                const TimeGraphLayout* layout)
-        : UnitTestCaptureViewLeafElement(parent, viewport, layout) {}
-
-   protected:
-    [[nodiscard]] bool OnMouseWheel(const Vec2& mouse_pos, int delta,
-                                    const ModifierKeys& modifiers) override {
-      return true;
-    }
-  };
-
-  container_elem.AddChild(
-      std::make_unique<ElementThatHandlesMouseWheelEvents>(&container_elem, &kViewport, &kLayout));
-
   const int kDelta = 1;
 
   CaptureViewElementMock* child0 =
       dynamic_cast<CaptureViewElementMock*>(container_elem.GetAllChildren()[0]);
   CaptureViewElementMock* child1 =
       dynamic_cast<CaptureViewElementMock*>(container_elem.GetAllChildren()[1]);
+  CaptureViewElementMock* child2 =
+      dynamic_cast<CaptureViewElementMock*>(container_elem.GetAllChildren()[2]);
 
   // Expect the parent to catch all mouse wheel events of children 0 and 1, but not those of child 2
   // since child 2 actually handles the event
@@ -173,6 +158,7 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
 
   EXPECT_CALL(*child0, OnMouseWheel(_, kDelta, _)).Times(Exactly(1)).WillRepeatedly(Return(false));
   EXPECT_CALL(*child1, OnMouseWheel(_, kDelta, _)).Times(Exactly(1)).WillRepeatedly(Return(false));
+  EXPECT_CALL(*child2, OnMouseWheel(_, kDelta, _)).Times(Exactly(1)).WillRepeatedly(Return(true));
 
   EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOutside, kDelta));
   EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosBetweenChildren, kDelta));

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -69,6 +69,10 @@ class UnitTestCaptureViewContainerElement : public CaptureViewElementMock {
   };
 
   void AddChild(std::unique_ptr<CaptureViewElement>&& element) {
+    // TODO (b/226376237): This should not be needed
+    if (element->GetLayoutFlags() & LayoutFlags::kScaleHorizontallyWithParent) {
+      element->SetWidth(GetWidth());
+    }
     children_.push_back(std::move(element));
     UpdateLayout();
   }

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -2,19 +2,33 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "CaptureViewElementTester.h"
 
 namespace orbit_gl {
 
-class UnitTestCaptureViewLeafElement : public CaptureViewElement {
+constexpr float kMarginAfterChild = 10;
+constexpr float kLeafElementHeight = 20;
+
+class CaptureViewElementMock : public CaptureViewElement {
+ public:
+  explicit CaptureViewElementMock(CaptureViewElement* parent, const Viewport* viewport,
+                                  const TimeGraphLayout* layout)
+      : CaptureViewElement(parent, viewport, layout) {}
+
+  MOCK_METHOD(bool, OnMouseWheel, (const Vec2& mouse_pos, int delta, const ModifierKeys& modifiers),
+              (override));
+};
+
+class UnitTestCaptureViewLeafElement : public CaptureViewElementMock {
  public:
   explicit UnitTestCaptureViewLeafElement(CaptureViewElement* parent, const Viewport* viewport,
                                           const TimeGraphLayout* layout)
-      : CaptureViewElement(parent, viewport, layout) {}
+      : CaptureViewElementMock(parent, viewport, layout) {}
 
-  [[nodiscard]] float GetHeight() const override { return 10; }
+  [[nodiscard]] float GetHeight() const override { return kLeafElementHeight; }
 
  private:
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
@@ -23,22 +37,26 @@ class UnitTestCaptureViewLeafElement : public CaptureViewElement {
   }
 };
 
-class UnitTestCaptureViewContainerElement : public CaptureViewElement {
+class UnitTestCaptureViewContainerElement : public CaptureViewElementMock {
  public:
   explicit UnitTestCaptureViewContainerElement(CaptureViewElement* parent, const Viewport* viewport,
                                                const TimeGraphLayout* layout,
                                                int children_to_create = 0)
-      : CaptureViewElement(parent, viewport, layout) {
+      : CaptureViewElementMock(parent, viewport, layout) {
+    SetWidth(viewport->GetWorldWidth());
+
     for (int i = 0; i < children_to_create; ++i) {
       children_.emplace_back(
           std::make_unique<UnitTestCaptureViewLeafElement>(this, viewport, layout));
     }
+
+    UpdateLayout();
   }
 
   [[nodiscard]] float GetHeight() const override {
     float result = 0;
     for (auto& child : GetAllChildren()) {
-      result += child->GetHeight();
+      result += child->GetHeight() + kMarginAfterChild;
     }
     return result;
   }
@@ -51,8 +69,23 @@ class UnitTestCaptureViewContainerElement : public CaptureViewElement {
     return result;
   };
 
+  void AddChild(std::unique_ptr<CaptureViewElement>&& element) {
+    children_.push_back(std::move(element));
+    UpdateLayout();
+  }
+
+ protected:
+  void DoUpdateLayout() override {
+    float current_y = GetPos()[1];
+
+    for (auto& child : GetAllChildren()) {
+      child->SetPos(0, current_y);
+      current_y += child->GetHeight() + kMarginAfterChild;
+    }
+  }
+
  private:
-  std::vector<std::unique_ptr<UnitTestCaptureViewLeafElement>> children_;
+  std::vector<std::unique_ptr<CaptureViewElement>> children_;
 
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override {
@@ -66,5 +99,86 @@ TEST(CaptureViewElementTesterTest, PassesAllTestsOnExistingElement) {
   UnitTestCaptureViewContainerElement container_elem(nullptr, tester.GetViewport(),
                                                      tester.GetLayout(), kChildCount);
   tester.RunTests(&container_elem);
+}
+
+const Viewport kViewport(100, 100);
+const TimeGraphLayout kLayout;
+
+TEST(CaptureViewElement, IsMouseOverWorksForVisibleElements) {
+  UnitTestCaptureViewLeafElement elem(nullptr, &kViewport, &kLayout);
+  elem.SetWidth(kViewport.GetWorldWidth());
+
+  EXPECT_FALSE(elem.IsMouseOver(Vec2(-1, -1)));
+  EXPECT_TRUE(elem.IsMouseOver(Vec2(5, 5)));
+  EXPECT_TRUE(elem.IsMouseOver(elem.GetSize()));
+  EXPECT_TRUE(elem.IsMouseOver(Vec2(0, 0)));
+}
+
+TEST(CaptureViewElement, IsMouseOverDoesNotWorkForElementsOutsideOfTheParent) {
+  const int kChildCount = 2;
+  UnitTestCaptureViewContainerElement elem(nullptr, &kViewport, &kLayout, kChildCount);
+
+  CaptureViewElement* child0 = elem.GetAllChildren()[0];
+
+  static_assert(kLeafElementHeight > 5);
+  child0->SetPos(0, -5);
+  EXPECT_TRUE(child0->IsMouseOver(Vec2(0, 0)));
+  EXPECT_FALSE(child0->IsMouseOver(Vec2(0, -1)));
+}
+
+TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
+  using ::testing::_;
+  using ::testing::Exactly;
+  using ::testing::Return;
+
+  const int kChildCount = 2;
+  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, kChildCount);
+
+  static_assert(kMarginAfterChild > 0);
+
+  const Vec2 kPosOutside(-1, -1);
+  const Vec2 kPosOnParent(10, kLeafElementHeight + 1);
+  const Vec2 kPosOnChild0(10, kLeafElementHeight);
+  const Vec2 kPosOnChild1(10, kLeafElementHeight + kMarginAfterChild);
+  const Vec2 kPosOnChild2(10, (kLeafElementHeight + kMarginAfterChild) * 2);
+
+  class ElementThatHandlesMouseWheelEvents : public UnitTestCaptureViewLeafElement {
+   public:
+    explicit ElementThatHandlesMouseWheelEvents(CaptureViewElement* parent,
+                                                const Viewport* viewport,
+                                                const TimeGraphLayout* layout)
+        : UnitTestCaptureViewLeafElement(parent, viewport, layout) {}
+
+   protected:
+    [[nodiscard]] bool OnMouseWheel(const Vec2& mouse_pos, int delta,
+                                    const ModifierKeys& modifiers) override {
+      return true;
+    }
+  };
+
+  container_elem.AddChild(
+      std::make_unique<ElementThatHandlesMouseWheelEvents>(&container_elem, &kViewport, &kLayout));
+
+  const int kDelta = 1;
+
+  CaptureViewElementMock* child0 =
+      dynamic_cast<CaptureViewElementMock*>(container_elem.GetAllChildren()[0]);
+  CaptureViewElementMock* child1 =
+      dynamic_cast<CaptureViewElementMock*>(container_elem.GetAllChildren()[1]);
+
+  // Expect the parent to catch all mouse wheel events of children 0 and 1, but not those of child 2
+  // since child 2 actually handles the event
+  EXPECT_CALL(container_elem, OnMouseWheel(_, kDelta, _))
+      .Times(Exactly(3))
+      .WillRepeatedly(Return(false));
+
+  EXPECT_CALL(*child0, OnMouseWheel(_, kDelta, _)).Times(Exactly(1)).WillRepeatedly(Return(false));
+  EXPECT_CALL(*child1, OnMouseWheel(_, kDelta, _)).Times(Exactly(1)).WillRepeatedly(Return(false));
+
+  EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOutside, kDelta));
+  EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOnParent, kDelta));
+  EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOnChild0, kDelta));
+  EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOnChild1, kDelta));
+  EXPECT_TRUE(container_elem.HandleMouseWheelEvent(kPosOnChild2, kDelta));
 }
 }  // namespace orbit_gl

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -43,13 +43,12 @@ class UnitTestCaptureViewContainerElement : public CaptureViewElementMock {
                                                const TimeGraphLayout* layout,
                                                int children_to_create = 0)
       : CaptureViewElementMock(parent, viewport, layout) {
-    SetWidth(viewport->GetWorldWidth());
-
     for (int i = 0; i < children_to_create; ++i) {
       children_.emplace_back(
           std::make_unique<UnitTestCaptureViewLeafElement>(this, viewport, layout));
     }
 
+    SetWidth(viewport->GetWorldWidth());
     UpdateLayout();
   }
 
@@ -109,7 +108,7 @@ TEST(CaptureViewElement, IsMouseOverWorksForVisibleElements) {
   elem.SetWidth(kViewport.GetWorldWidth());
 
   EXPECT_FALSE(elem.IsMouseOver(Vec2(-1, -1)));
-  EXPECT_TRUE(elem.IsMouseOver(Vec2(5, 5)));
+  EXPECT_TRUE(elem.IsMouseOver(Vec2(kLeafElementHeight / 2, kLeafElementHeight / 2)));
   EXPECT_TRUE(elem.IsMouseOver(elem.GetSize()));
   EXPECT_TRUE(elem.IsMouseOver(Vec2(0, 0)));
 }
@@ -137,7 +136,7 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
   static_assert(kMarginAfterChild > 0);
 
   const Vec2 kPosOutside(-1, -1);
-  const Vec2 kPosOnParent(10, kLeafElementHeight + 1);
+  const Vec2 kPosBetweenChildren(10, kLeafElementHeight + 1);
   const Vec2 kPosOnChild0(10, kLeafElementHeight);
   const Vec2 kPosOnChild1(10, kLeafElementHeight + kMarginAfterChild);
   const Vec2 kPosOnChild2(10, (kLeafElementHeight + kMarginAfterChild) * 2);
@@ -176,7 +175,7 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
   EXPECT_CALL(*child1, OnMouseWheel(_, kDelta, _)).Times(Exactly(1)).WillRepeatedly(Return(false));
 
   EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOutside, kDelta));
-  EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOnParent, kDelta));
+  EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosBetweenChildren, kDelta));
   EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOnChild0, kDelta));
   EXPECT_FALSE(container_elem.HandleMouseWheelEvent(kPosOnChild1, kDelta));
   EXPECT_TRUE(container_elem.HandleMouseWheelEvent(kPosOnChild2, kDelta));


### PR DESCRIPTION
This is the first step to move handling of mouse events into `CaptureViewElement`
instead of handling them directly in `CaptureWindow`. Mouse wheel functionality
is now handled by `TimeGraph`. In the next PRs, the mouse wheel will behave
differently depending on the mouse position, and handling is then delegated
to `TimelineUI` if it is the element underneath the mouse.

The same pattern will be used to handle MouseEnter, MouseLeave, MouseMove,
MouseDown and MouseRelease in the future to support non-pixel perfect picking
(http://go/stadia-orbit-picking).

Bug: http://b/224764161
Test: CaptureWindow integration tests pass