### PR TITLE
Fix handling of SSH channel reads

### DIFF
--- a/src/OrbitSsh/Channel.cpp
+++ b/src/OrbitSsh/Channel.cpp
@@ -80,6 +80,12 @@ outcome::result<std::string> Channel::ReadStdErr(int buffer_size) {
   return outcome::success(std::move(buffer));
 }
 
+size_t Channel::GetNumBytesToRead() {
+  unsigned long read_avail{};  // NOLINT
+  libssh2_channel_window_read_ex(raw_channel_ptr_.get(), &read_avail, nullptr);
+  return static_cast<size_t>(read_avail);
+}
+
 outcome::result<int> Channel::Write(std::string_view text) {
   const int rc = libssh2_channel_write(raw_channel_ptr_.get(), text.data(), text.size());
 

--- a/src/OrbitSsh/include/OrbitSsh/Channel.h
+++ b/src/OrbitSsh/include/OrbitSsh/Channel.h
@@ -30,6 +30,11 @@ class Channel {
 
   outcome::result<std::string> ReadStdOut(int buffer_size = 0x400);
   outcome::result<std::string> ReadStdErr(int buffer_size = 0x400);
+
+  // Returns the accumulated number of bytes available to read from all data streams. That's usually
+  // stdout and stderr but there could be more streams.
+  size_t GetNumBytesToRead();
+
   outcome::result<void> WriteBlocking(std::string_view text);
   outcome::result<int> Write(std::string_view text);
   outcome::result<void> Exec(const std::string& command);


### PR DESCRIPTION
Whenever libssh2_channel_read_ex or libssh2_channel_write_ex is called
it potentially process queued packets from the underlying transport (TCP
in our case), parses them and puts them into queues.

So the following situation could appear:
1. We read all data available for stdout
2. We read all data available for stderr. While doing so a new stdout
   data packet is processed.
3. We end the data processing and arm the socket notifier. Thus we won't
   process the stdout data packet until the socket notifier fires again
   due to an unrelated TCP packet coming in.

The solution is to check whether any more data is available for reading
after all stream-specific operations (read and write) have been
performed and start over if there is any more data available.

Bug: http://b/226103092