### PR TITLE
Move the code required to update layouts to PreRender

### DIFF
--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -30,6 +30,8 @@ class CaptureWindow : public GlCanvas {
 
   enum class ZoomDirection { kHorizontal, kVertical };
 
+  void PreRender() override;
+
   void ZoomAll();
   void Zoom(ZoomDirection dir, int delta);
   void Pan(float ratio);


### PR DESCRIPTION
This moves all code that performs size and position changes to elements
in the capture window into `CaptureWindow::PreRender`. This way, they
are executed in every frame and can be used to request redraws if needed.

Before, this code was executed as part of `CaptureWindow::Draw`, so it was
skipped if no redraw had been requested, and the distinction between
layout-changing calls and render calls was not clear.

I split this commit out from https://github.com/google/orbit/pull/3466.

Bug: b/224764161
Test: Manual testing, unit tests will follow in linked PR.