### PR TITLE
Move global ThreadPool initialization to main

### DIFF
--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -287,6 +287,8 @@ int main(int argc, char* argv[]) {
       dump_path, handler_path, crash_server_url, attachments);
 #endif  // ORBIT_CRASH_HANDLING
 
+  orbit_base::ThreadPool::InitializeDefaultThreadPool();
+
   if (absl::GetFlag(FLAGS_clear_source_paths_mappings)) {
     ClearSourcePathsMappings();
     return 0;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -265,8 +265,6 @@ OrbitApp::OrbitApp(orbit_gl::MainWindowInterface* main_window,
       metrics_uploader_(metrics_uploader) {
   ORBIT_CHECK(main_window_ != nullptr);
 
-  orbit_base::ThreadPool::InitializeDefaultThreadPool();
-
   thread_pool_ = orbit_base::ThreadPool::Create(
       /*thread_pool_min_size=*/4, /*thread_pool_max_size=*/256, /*thread_ttl=*/absl::Seconds(1),
       /*run_action=*/[](const std::unique_ptr<Action>& action) {


### PR DESCRIPTION
This function may only be called once. Calling it in OrbitApp's
constructor means Orbit crashes when the user starts a second session
and OrbitApp gets constructed for a second time.

So this change moves the call into the main function of the Orbit UI
executable.

Bug: http://b/226540540