### PR TITLE
Fix use of wrong size when initializing .debug_frame section

### DIFF
--- a/third_party/libunwindstack/PeCoffInterface.cpp
+++ b/third_party/libunwindstack/PeCoffInterface.cpp
@@ -358,7 +358,7 @@ bool PeCoffInterfaceImpl<AddressType>::InitSections() {
     if (sections_[i].name == ".debug_frame") {
       DebugFrameSectionData section_data;
       section_data.file_offset = sections_[i].offset;
-      section_data.size = sections_[i].size;
+      section_data.size = sections_[i].vmsize;
       uint64_t debug_frame_section_bias =
           static_cast<int64_t>(sections_[i].vmaddr) - sections_[i].offset;
       section_data.section_bias = debug_frame_section_bias;

--- a/third_party/libunwindstack/tests/PeCoffFake.h
+++ b/third_party/libunwindstack/tests/PeCoffFake.h
@@ -83,8 +83,9 @@ class PeCoffFake {
   uint64_t SetOptionalHeaderMagicPE32PlusAtOffset(uint64_t offset);
   uint64_t SetOptionalHeaderAtOffset(uint64_t offset);
   uint64_t SetSectionStringsAtOffset(uint64_t offset);
-  uint64_t SetSectionHeadersAtOffset(uint64_t offset);
-  uint64_t SetDebugFrameSectionAtOffset(uint64_t offset);
+  uint64_t SetSectionHeadersAtOffset(uint64_t offset, uint32_t debug_frame_vmsize,
+                                     uint32_t debug_frame_filesize);
+  uint64_t SetDebugFrameEntryAtOffset(uint64_t offset, uint32_t pc_start);
 
   std::unique_ptr<MemoryFake> memory_fake_;
   std::vector<std::pair<uint64_t, std::string>> section_names_in_string_table_;

--- a/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
@@ -307,6 +307,9 @@ TYPED_TEST(PeCoffInterfaceTest, debug_frame_section_parsed_correctly) {
   ASSERT_NE(dwarf_fde, nullptr);
   EXPECT_EQ(0x2100, dwarf_fde->pc_start);
   EXPECT_EQ(0x2500, dwarf_fde->pc_end);
+
+  const DwarfFde* dwarf_fde2 = coff.DebugFrameSection()->GetFdeFromPc(0x10000);
+  ASSERT_EQ(dwarf_fde2, nullptr);
 }
 
 TYPED_TEST(PeCoffInterfaceTest, get_correct_relative_pc) {


### PR DESCRIPTION
The current code incorrectly uses the file size of the .debug_frame
section, which is the actual size plus any padding, which can can
contain bogus data. The bad data may incorrectly be parsed as a frame
description entry (FDE), which can cause unwinding to fail. This is
fixed by using the correct in-memory size ("vmsize") to avoid parsing
beyond the end.

The PeCoffInterface test is adjusted to include padding in the
.debug_frame section with bad data that leads to an incorrect FDE
being parsed. We validate that, despite the bad data, there is no FDE
entry in the parsed data structure corresponding to the start address
of the bad FDE.

In an end-to-end integration, this change leads to unwind errors
dropping from ~6-8% to < 1% (which is probably as low as it gets).

Tested: Unit tests.
Bug: http://b/194768602