### PR TITLE
Make "CallstackInfo" a class

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -19,7 +19,8 @@
 
 namespace orbit_capture_client {
 
-using orbit_client_protos::CallstackInfo;
+using orbit_client_data::CallstackInfo;
+
 using orbit_client_protos::TimerInfo;
 
 using google::protobuf::util::MessageDifferencer;

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -23,7 +23,7 @@
 namespace orbit_capture_client {
 
 using orbit_client_data::CallstackEvent;
-using orbit_client_protos::CallstackInfo;
+using orbit_client_data::CallstackInfo;
 using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::TimerInfo;
 

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -218,7 +218,7 @@ static void CanHandleOneCallstackSampleOfType(Callstack::CallstackType type) {
   EXPECT_CALL(listener, OnCallstackEvent).Times(1).WillOnce(SaveArg<0>(&actual_callstack_event));
 
   event_processor->ProcessEvent(event);
-
+  ASSERT_TRUE(actual_callstack.has_value());
   ExpectCallstackSamplesEqual(*actual_callstack_event, actual_callstack_id, *actual_callstack,
                               callstack_sample, &interned_callstack->intern());
 }
@@ -274,6 +274,7 @@ TEST(CaptureEventProcessor, WillOnlyHandleUniqueCallstacksOnce) {
   event_processor->ProcessEvent(event_1);
   event_processor->ProcessEvent(event_2);
 
+  ASSERT_TRUE(actual_callstack.has_value());
   ExpectCallstackSamplesEqual(*actual_call_stack_event_1, actual_callstack_id, *actual_callstack,
                               callstack_sample_1, &interned_callstack->intern());
   ExpectCallstackSamplesEqual(*actual_call_stack_event_2, actual_callstack_id, *actual_callstack,
@@ -313,6 +314,7 @@ TEST(CaptureEventProcessor, CanHandleInternedCallstackSamples) {
   event_processor->ProcessEvent(interned_callstack_event);
   event_processor->ProcessEvent(callstack_event);
 
+  ASSERT_TRUE(actual_callstack.has_value());
   ExpectCallstackSamplesEqual(*actual_call_stack_event, actual_callstack_id, *actual_callstack,
                               callstack_sample, callstack_intern);
 }

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -22,10 +22,10 @@
 namespace orbit_capture_client {
 
 using orbit_client_data::CallstackEvent;
+using orbit_client_data::CallstackInfo;
 
 using orbit_client_protos::ApiStringEvent;
 using orbit_client_protos::ApiTrackValue;
-using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::ThreadStateSliceInfo;
 using orbit_client_protos::TimerInfo;
@@ -181,43 +181,13 @@ static void ExpectCallstackSamplesEqual(const CallstackEvent& actual_callstack_e
   EXPECT_EQ(actual_callstack_event.timestamp_ns(), expected_callstack_sample->timestamp_ns());
   EXPECT_EQ(actual_callstack_event.thread_id(), expected_callstack_sample->tid());
   EXPECT_EQ(actual_callstack_event.callstack_id(), actual_callstack_id);
-  ASSERT_EQ(actual_callstack.frames_size(), expected_callstack->pcs_size());
-  for (int i = 0; i < actual_callstack.frames_size(); ++i) {
-    EXPECT_EQ(actual_callstack.frames(i), expected_callstack->pcs(i));
+  ASSERT_EQ(actual_callstack.frames().size(), expected_callstack->pcs_size());
+  for (size_t i = 0; i < actual_callstack.frames().size(); ++i) {
+    EXPECT_EQ(actual_callstack.frames()[i], expected_callstack->pcs(i));
   }
 
-  switch (expected_callstack->type()) {
-    case Callstack::kComplete:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kComplete);
-      break;
-    case Callstack::kDwarfUnwindingError:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kDwarfUnwindingError);
-      break;
-    case Callstack::kFramePointerUnwindingError:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kFramePointerUnwindingError);
-      break;
-    case Callstack::kInUprobes:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kInUprobes);
-      break;
-    case Callstack::kInUserSpaceInstrumentation:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kInUserSpaceInstrumentation);
-      break;
-    case Callstack::kCallstackPatchingFailed:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kCallstackPatchingFailed);
-      break;
-    case Callstack::kStackTopDwarfUnwindingError:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kStackTopDwarfUnwindingError);
-      break;
-    case Callstack::kStackTopForDwarfUnwindingTooSmall:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kStackTopForDwarfUnwindingTooSmall);
-      break;
-    case orbit_grpc_protos::
-        Callstack_CallstackType_Callstack_CallstackType_INT_MIN_SENTINEL_DO_NOT_USE_:
-      [[fallthrough]];
-    case orbit_grpc_protos::
-        Callstack_CallstackType_Callstack_CallstackType_INT_MAX_SENTINEL_DO_NOT_USE_:
-      ORBIT_UNREACHABLE();
-  }
+  EXPECT_EQ(orbit_client_data::GrpcCallstackTypeToCallstackType(expected_callstack->type()),
+            actual_callstack.type());
 }
 
 static void CanHandleOneCallstackSampleOfType(Callstack::CallstackType type) {
@@ -237,16 +207,19 @@ static void CanHandleOneCallstackSampleOfType(Callstack::CallstackType type) {
   callstack_sample->set_timestamp_ns(100);
 
   uint64_t actual_callstack_id = 0;
-  CallstackInfo actual_callstack;
+  std::optional<CallstackInfo> actual_callstack;
   EXPECT_CALL(listener, OnUniqueCallstack)
       .Times(1)
-      .WillOnce(DoAll(SaveArg<0>(&actual_callstack_id), SaveArg<1>(&actual_callstack)));
+      .WillOnce([&](uint64_t id, CallstackInfo callstack) {
+        actual_callstack_id = id;
+        actual_callstack = std::move(callstack);
+      });
   std::optional<CallstackEvent> actual_callstack_event;
   EXPECT_CALL(listener, OnCallstackEvent).Times(1).WillOnce(SaveArg<0>(&actual_callstack_event));
 
   event_processor->ProcessEvent(event);
 
-  ExpectCallstackSamplesEqual(*actual_callstack_event, actual_callstack_id, actual_callstack,
+  ExpectCallstackSamplesEqual(*actual_callstack_event, actual_callstack_id, *actual_callstack,
                               callstack_sample, &interned_callstack->intern());
 }
 
@@ -283,10 +256,13 @@ TEST(CaptureEventProcessor, WillOnlyHandleUniqueCallstacksOnce) {
   callstack_sample_2->set_timestamp_ns(200);
 
   uint64_t actual_callstack_id = 0;
-  CallstackInfo actual_callstack;
+  std::optional<CallstackInfo> actual_callstack;
   EXPECT_CALL(listener, OnUniqueCallstack)
       .Times(1)
-      .WillOnce(DoAll(SaveArg<0>(&actual_callstack_id), SaveArg<1>(&actual_callstack)));
+      .WillOnce([&](uint64_t id, CallstackInfo callstack) {
+        actual_callstack_id = id;
+        actual_callstack = std::move(callstack);
+      });
   std::optional<CallstackEvent> actual_call_stack_event_1;
   std::optional<CallstackEvent> actual_call_stack_event_2;
   EXPECT_CALL(listener, OnCallstackEvent)
@@ -298,9 +274,9 @@ TEST(CaptureEventProcessor, WillOnlyHandleUniqueCallstacksOnce) {
   event_processor->ProcessEvent(event_1);
   event_processor->ProcessEvent(event_2);
 
-  ExpectCallstackSamplesEqual(*actual_call_stack_event_1, actual_callstack_id, actual_callstack,
+  ExpectCallstackSamplesEqual(*actual_call_stack_event_1, actual_callstack_id, *actual_callstack,
                               callstack_sample_1, &interned_callstack->intern());
-  ExpectCallstackSamplesEqual(*actual_call_stack_event_2, actual_callstack_id, actual_callstack,
+  ExpectCallstackSamplesEqual(*actual_call_stack_event_2, actual_callstack_id, *actual_callstack,
                               callstack_sample_2, &interned_callstack->intern());
 }
 
@@ -324,17 +300,20 @@ TEST(CaptureEventProcessor, CanHandleInternedCallstackSamples) {
   callstack_sample->set_timestamp_ns(100);
 
   uint64_t actual_callstack_id = 0;
-  CallstackInfo actual_callstack;
+  std::optional<CallstackInfo> actual_callstack;
   EXPECT_CALL(listener, OnUniqueCallstack)
       .Times(1)
-      .WillOnce(DoAll(SaveArg<0>(&actual_callstack_id), SaveArg<1>(&actual_callstack)));
+      .WillOnce([&](uint64_t id, CallstackInfo callstack) {
+        actual_callstack_id = id;
+        actual_callstack = std::move(callstack);
+      });
   std::optional<CallstackEvent> actual_call_stack_event;
   EXPECT_CALL(listener, OnCallstackEvent).Times(1).WillOnce(SaveArg<0>(&actual_call_stack_event));
 
   event_processor->ProcessEvent(interned_callstack_event);
   event_processor->ProcessEvent(callstack_event);
 
-  ExpectCallstackSamplesEqual(*actual_call_stack_event, actual_callstack_id, actual_callstack,
+  ExpectCallstackSamplesEqual(*actual_call_stack_event, actual_callstack_id, *actual_callstack,
                               callstack_sample, callstack_intern);
 }
 

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -6,10 +6,10 @@
 #define CAPTURE_CLIENT_CAPTURE_LISTENER_H_
 
 #include "ClientData/CallstackEvent.h"
+#include "ClientData/CallstackInfo.h"
 #include "ClientData/ProcessData.h"
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/UserDefinedCaptureData.h"
-#include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/capture.pb.h"
 #include "OrbitBase/Result.h"
 #include "absl/container/flat_hash_set.h"
@@ -30,7 +30,7 @@ class CaptureListener {
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;
   virtual void OnUniqueCallstack(uint64_t callstack_id,
-                                 orbit_client_protos::CallstackInfo callstack) = 0;
+                                 orbit_client_data::CallstackInfo callstack) = 0;
   virtual void OnCallstackEvent(orbit_client_data::CallstackEvent callstack_event) = 0;
   virtual void OnThreadName(uint32_t thread_id, std::string thread_name) = 0;
   virtual void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) = 0;

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(ClientData PRIVATE
 target_sources(ClientData PUBLIC
         include/ClientData/CallstackData.h
         include/ClientData/CallstackEvent.h
+        include/ClientData/CallstackInfo.h
         include/ClientData/CallstackType.h
         include/ClientData/CaptureData.h
         include/ClientData/DataManager.h

--- a/src/ClientData/CallstackType.cpp
+++ b/src/ClientData/CallstackType.cpp
@@ -31,6 +31,7 @@ std::string CallstackTypeToString(CallstackType callstack_type) {
     case CallstackType::kFilteredByMajorityOutermostFrame:
       return "Unknown unwinding error";
   }
+  ORBIT_UNREACHABLE();
 }
 
 std::string CallstackTypeToDescription(CallstackType callstack_type) {
@@ -58,6 +59,7 @@ std::string CallstackTypeToDescription(CallstackType callstack_type) {
       return "The outermost frame does not match the majority for this thread, so the callstack "
              "has been marked as unwound incorrectly.";
   }
+  ORBIT_UNREACHABLE();
 }
 
 CallstackType GrpcCallstackTypeToCallstackType(
@@ -86,6 +88,7 @@ CallstackType GrpcCallstackTypeToCallstackType(
         Callstack_CallstackType_Callstack_CallstackType_INT_MAX_SENTINEL_DO_NOT_USE_:
       ORBIT_UNREACHABLE();
   }
+  ORBIT_UNREACHABLE();
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/CallstackType.cpp
+++ b/src/ClientData/CallstackType.cpp
@@ -6,72 +6,86 @@
 
 #include "OrbitBase/Logging.h"
 
-using orbit_client_protos::CallstackInfo;
+using orbit_grpc_protos::Callstack;
 
 namespace orbit_client_data {
 
-std::string CallstackTypeToString(CallstackInfo::CallstackType callstack_type) {
+std::string CallstackTypeToString(CallstackType callstack_type) {
   switch (callstack_type) {
-    case CallstackInfo::kComplete:
+    case CallstackType::kComplete:
       return "Complete";
-    case CallstackInfo::kDwarfUnwindingError:
+    case CallstackType::kDwarfUnwindingError:
       return "DWARF unwinding error";
-    case CallstackInfo::kFramePointerUnwindingError:
+    case CallstackType::kFramePointerUnwindingError:
       return "Frame pointer unwinding error";
-    case CallstackInfo::kInUprobes:
+    case CallstackType::kInUprobes:
       return "Callstack inside uprobes (kernel)";
-    case CallstackInfo::kInUserSpaceInstrumentation:
+    case CallstackType::kInUserSpaceInstrumentation:
       return "Callstack inside user-space instrumentation";
-    case CallstackInfo::kCallstackPatchingFailed:
+    case CallstackType::kCallstackPatchingFailed:
       return "Callstack patching failed";
-    case CallstackInfo::kStackTopForDwarfUnwindingTooSmall:
+    case CallstackType::kStackTopForDwarfUnwindingTooSmall:
       return "Collected raw stack is too small";
-    case CallstackInfo::kStackTopDwarfUnwindingError:
+    case CallstackType::kStackTopDwarfUnwindingError:
       return "DWARF unwinding error in inner frame";
-    case CallstackInfo::kFilteredByMajorityOutermostFrame:
+    case CallstackType::kFilteredByMajorityOutermostFrame:
       return "Unknown unwinding error";
-    case orbit_client_protos::
-        CallstackInfo_CallstackType_CallstackInfo_CallstackType_INT_MIN_SENTINEL_DO_NOT_USE_:
-      ORBIT_UNREACHABLE();
-    case orbit_client_protos::
-        CallstackInfo_CallstackType_CallstackInfo_CallstackType_INT_MAX_SENTINEL_DO_NOT_USE_:
-      ORBIT_UNREACHABLE();
   }
-  ORBIT_UNREACHABLE();
 }
 
-std::string CallstackTypeToDescription(CallstackInfo::CallstackType callstack_type) {
+std::string CallstackTypeToDescription(CallstackType callstack_type) {
   switch (callstack_type) {
-    case CallstackInfo::kComplete:
+    case CallstackType::kComplete:
       return "Unwinding succeeded.";
-    case CallstackInfo::kDwarfUnwindingError:
+    case CallstackType::kDwarfUnwindingError:
       return "DWARF unwinding failed on the collected sample.";
-    case CallstackInfo::kFramePointerUnwindingError:
+    case CallstackType::kFramePointerUnwindingError:
       return "Frame pointer unwinding failed on the collected sample. Likely, the callstack "
              "contains a function not compiled with frame pointers (-fno-omit-frame-pointer).";
-    case CallstackInfo::kInUprobes:
+    case CallstackType::kInUprobes:
       return "The collected callstack falls inside uprobes (kernel) code.";
-    case CallstackInfo::kInUserSpaceInstrumentation:
+    case CallstackType::kInUserSpaceInstrumentation:
       return "The collected callstack falls inside the user-space instrumentation code.";
-    case CallstackInfo::kCallstackPatchingFailed:
+    case CallstackType::kCallstackPatchingFailed:
       return "Repairing a callstack that contains dynamically instrumented functions failed.";
-    case CallstackInfo::kStackTopForDwarfUnwindingTooSmall:
+    case CallstackType::kStackTopForDwarfUnwindingTooSmall:
       return "The collected raw stack is too small to unwind. You can increase the size to collect "
              "in the capture options.";
-    case CallstackInfo::kStackTopDwarfUnwindingError:
+    case CallstackType::kStackTopDwarfUnwindingError:
       return "DWARF unwinding the inner frame to patch a leaf function (-momit-leaf-frame-pointer) "
              "failed.";
-    case CallstackInfo::kFilteredByMajorityOutermostFrame:
+    case CallstackType::kFilteredByMajorityOutermostFrame:
       return "The outermost frame does not match the majority for this thread, so the callstack "
              "has been marked as unwound incorrectly.";
-    case orbit_client_protos::
-        CallstackInfo_CallstackType_CallstackInfo_CallstackType_INT_MIN_SENTINEL_DO_NOT_USE_:
+  }
+}
+
+CallstackType GrpcCallstackTypeToCallstackType(
+    orbit_grpc_protos::Callstack::CallstackType callstack_type) {
+  switch (callstack_type) {
+    case Callstack::kComplete:
+      return CallstackType::kComplete;
+    case Callstack::kDwarfUnwindingError:
+      return CallstackType::kDwarfUnwindingError;
+    case Callstack::kFramePointerUnwindingError:
+      return CallstackType::kFramePointerUnwindingError;
+    case Callstack::kInUprobes:
+      return CallstackType::kInUprobes;
+    case Callstack::kInUserSpaceInstrumentation:
+      return CallstackType::kInUserSpaceInstrumentation;
+    case Callstack::kCallstackPatchingFailed:
+      return CallstackType::kCallstackPatchingFailed;
+    case Callstack::kStackTopForDwarfUnwindingTooSmall:
+      return CallstackType::kStackTopForDwarfUnwindingTooSmall;
+    case Callstack::kStackTopDwarfUnwindingError:
+      return CallstackType::kStackTopDwarfUnwindingError;
+    case orbit_grpc_protos::
+        Callstack_CallstackType_Callstack_CallstackType_INT_MIN_SENTINEL_DO_NOT_USE_:
       ORBIT_UNREACHABLE();
-    case orbit_client_protos::
-        CallstackInfo_CallstackType_CallstackInfo_CallstackType_INT_MAX_SENTINEL_DO_NOT_USE_:
+    case orbit_grpc_protos::
+        Callstack_CallstackType_Callstack_CallstackType_INT_MAX_SENTINEL_DO_NOT_USE_:
       ORBIT_UNREACHABLE();
   }
-  ORBIT_UNREACHABLE();
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/PostProcessedSamplingData.cpp
+++ b/src/ClientData/PostProcessedSamplingData.cpp
@@ -4,7 +4,6 @@
 
 #include "ClientData/PostProcessedSamplingData.h"
 
-#include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <stddef.h>
 
@@ -23,7 +22,7 @@ uint32_t ThreadSampleData::GetCountForAddress(uint64_t address) const {
   return it->second;
 }
 
-const orbit_client_protos::CallstackInfo& PostProcessedSamplingData::GetResolvedCallstack(
+const CallstackInfo& PostProcessedSamplingData::GetResolvedCallstack(
     uint64_t sampled_callstack_id) const {
   auto resolved_callstack_id_it = original_id_to_resolved_callstack_id_.find(sampled_callstack_id);
   ORBIT_CHECK(resolved_callstack_id_it != original_id_to_resolved_callstack_id_.end());

--- a/src/ClientData/include/ClientData/CallstackInfo.h
+++ b/src/ClientData/include/ClientData/CallstackInfo.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_CALLSTACK_INFO_H_
+#define CLIENT_DATA_CALLSTACK_INFO_H_
+
+#include <stdint.h>
+
+#include "ClientData/CallstackType.h"
+namespace orbit_client_data {
+
+// This class is used on the client to represent a unique callstack, containing of the frames (as
+// pcs) as well as a `CallstackType`.
+class CallstackInfo {
+ public:
+  CallstackInfo() = delete;
+  CallstackInfo(std::vector<uint64_t> frames, CallstackType type)
+      : frames_{std::move(frames)}, type_{type} {}
+  CallstackInfo(const CallstackInfo&) = default;
+  CallstackInfo& operator=(const CallstackInfo&) = default;
+  CallstackInfo(CallstackInfo&&) = default;
+  CallstackInfo& operator=(CallstackInfo&&) = default;
+
+  [[nodiscard]] const std::vector<uint64_t>& frames() const { return frames_; }
+  [[nodiscard]] CallstackType type() const { return type_; }
+  void set_type(CallstackType type) { type_ = type; }
+
+  friend bool operator==(const CallstackInfo& lhs, const CallstackInfo& rhs) {
+    return lhs.type_ == rhs.type_ && lhs.frames_ == rhs.frames_;
+  }
+
+  friend bool operator!=(const CallstackInfo& lhs, const CallstackInfo& rhs) {
+    return !(lhs == rhs);
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const CallstackInfo& o) {
+    return H::combine(std::move(h), o.type_, o.frames_);
+  }
+
+ private:
+  std::vector<uint64_t> frames_;
+  CallstackType type_;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_CALLSTACK_EVENT_H_

--- a/src/ClientData/include/ClientData/CallstackInfo.h
+++ b/src/ClientData/include/ClientData/CallstackInfo.h
@@ -10,8 +10,8 @@
 #include "ClientData/CallstackType.h"
 namespace orbit_client_data {
 
-// This class is used on the client to represent a unique callstack, containing of the frames (as
-// pcs) as well as a `CallstackType`.
+// This class is used on the client to represent a unique callstack, containing  the frames (as
+// program counters) as well as a `CallstackType`.
 class CallstackInfo {
  public:
   CallstackInfo() = delete;

--- a/src/ClientData/include/ClientData/CallstackInfo.h
+++ b/src/ClientData/include/ClientData/CallstackInfo.h
@@ -10,7 +10,7 @@
 #include "ClientData/CallstackType.h"
 namespace orbit_client_data {
 
-// This class is used on the client to represent a unique callstack, containing  the frames (as
+// This class is used on the client to represent a unique callstack, containing the frames (as
 // program counters) as well as a `CallstackType`.
 class CallstackInfo {
  public:

--- a/src/ClientData/include/ClientData/CallstackType.h
+++ b/src/ClientData/include/ClientData/CallstackType.h
@@ -13,23 +13,23 @@ namespace orbit_client_data {
 
 using ThreadID = uint32_t;
 
-// This enum represents the different (error) types of a callstack. `kComplete` represents and
+// This enum represents the different (error) types of a callstack. `kComplete` represents an
 // intact callstack, while the other enum values describe different errors. In addition to the
 // values in `orbit_grpc_protos::Callstack`, error types detected by the client are added.
 // The enum must be kept in sync with the one in `orbit_grpc_protos::Callstack`.
 enum class CallstackType {
-  kComplete = 0,
-  kDwarfUnwindingError = 1,
-  kFramePointerUnwindingError = 2,
-  kInUprobes = 3,
-  kInUserSpaceInstrumentation = 7,
-  kCallstackPatchingFailed = 4,
-  kStackTopForDwarfUnwindingTooSmall = 5,
-  kStackTopDwarfUnwindingError = 6,
+  kComplete,
+  kDwarfUnwindingError,
+  kFramePointerUnwindingError,
+  kInUprobes,
+  kInUserSpaceInstrumentation,
+  kCallstackPatchingFailed,
+  kStackTopForDwarfUnwindingTooSmall,
+  kStackTopDwarfUnwindingError,
 
   // These are set by the client and are in addition to the ones in
-  // Callstack::CallstackType.
-  kFilteredByMajorityOutermostFrame = 100
+  // orbit_grpc_protos::Callstack::CallstackType.
+  kFilteredByMajorityOutermostFrame
 };
 
 [[nodiscard]] std::string CallstackTypeToString(CallstackType callstack_type);

--- a/src/ClientData/include/ClientData/CallstackType.h
+++ b/src/ClientData/include/ClientData/CallstackType.h
@@ -7,17 +7,37 @@
 
 #include <cstdint>
 
-#include "ClientProtos/capture_data.pb.h"
+#include "GrpcProtos/capture.pb.h"
 
 namespace orbit_client_data {
 
 using ThreadID = uint32_t;
 
-[[nodiscard]] std::string CallstackTypeToString(
-    orbit_client_protos::CallstackInfo::CallstackType callstack_type);
+// This enum represents the different (error) types of a callstack. `kComplete` represents and
+// intact callstack, while the other enum values describe different errors. In addition to the
+// values in `orbit_grpc_protos::Callstack`, error types detected by the client are added.
+// The enum must be kept in sync with the one in `orbit_grpc_protos::Callstack`.
+enum class CallstackType {
+  kComplete = 0,
+  kDwarfUnwindingError = 1,
+  kFramePointerUnwindingError = 2,
+  kInUprobes = 3,
+  kInUserSpaceInstrumentation = 7,
+  kCallstackPatchingFailed = 4,
+  kStackTopForDwarfUnwindingTooSmall = 5,
+  kStackTopDwarfUnwindingError = 6,
 
-[[nodiscard]] std::string CallstackTypeToDescription(
-    orbit_client_protos::CallstackInfo::CallstackType callstack_type);
+  // These are set by the client and are in addition to the ones in
+  // Callstack::CallstackType.
+  kFilteredByMajorityOutermostFrame = 100
+};
+
+[[nodiscard]] std::string CallstackTypeToString(CallstackType callstack_type);
+
+[[nodiscard]] std::string CallstackTypeToDescription(CallstackType callstack_type);
+
+[[nodiscard]] CallstackType GrpcCallstackTypeToCallstackType(
+    orbit_grpc_protos::Callstack::CallstackType callstack_type);
 
 }  // namespace orbit_client_data
 

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -22,6 +22,7 @@
 
 #include "ClientData/CallstackData.h"
 #include "ClientData/CallstackEvent.h"
+#include "ClientData/CallstackInfo.h"
 #include "ClientData/FunctionInfoSet.h"
 #include "ClientData/ModuleData.h"
 #include "ClientData/ModuleManager.h"
@@ -154,7 +155,7 @@ class CaptureData {
 
   void reset_file_path() { file_path_.reset(); }
 
-  void AddUniqueCallstack(uint64_t callstack_id, orbit_client_protos::CallstackInfo callstack) {
+  void AddUniqueCallstack(uint64_t callstack_id, CallstackInfo callstack) {
     callstack_data_.AddUniqueCallstack(callstack_id, std::move(callstack));
   }
 
@@ -242,7 +243,7 @@ class CaptureData {
   uint64_t memory_sampling_period_ns_;
   uint64_t memory_warning_threshold_kb_;
 
-  orbit_client_data::CallstackData callstack_data_;
+  CallstackData callstack_data_;
   std::optional<PostProcessedSamplingData> post_processed_sampling_data_;
 
   // selection_callstack_data_ is subset of callstack_data_.

--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "ClientData/CallstackEvent.h"
+#include "ClientData/CallstackInfo.h"
 #include "ClientData/CallstackType.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/ThreadConstants.h"
@@ -73,7 +74,7 @@ class PostProcessedSamplingData {
   PostProcessedSamplingData() = default;
   PostProcessedSamplingData(
       absl::flat_hash_map<ThreadID, ThreadSampleData> thread_id_to_sample_data,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::CallstackInfo> id_to_resolved_callstack,
+      absl::flat_hash_map<uint64_t, CallstackInfo> id_to_resolved_callstack,
       absl::flat_hash_map<uint64_t, uint64_t> original_id_to_resolved_callstack_id,
       absl::flat_hash_map<uint64_t, absl::flat_hash_set<uint64_t>>
           function_address_to_sampled_callstack_ids)
@@ -90,8 +91,7 @@ class PostProcessedSamplingData {
   PostProcessedSamplingData(PostProcessedSamplingData&& other) = default;
   PostProcessedSamplingData& operator=(PostProcessedSamplingData&& other) = default;
 
-  [[nodiscard]] const orbit_client_protos::CallstackInfo& GetResolvedCallstack(
-      uint64_t sampled_callstack_id) const;
+  [[nodiscard]] const CallstackInfo& GetResolvedCallstack(uint64_t sampled_callstack_id) const;
 
   [[nodiscard]] std::unique_ptr<SortedCallstackReport>
   GetSortedCallstackReportFromFunctionAddresses(const std::vector<uint64_t>& function_addresses,
@@ -108,7 +108,7 @@ class PostProcessedSamplingData {
       const std::vector<uint64_t>& function_addresses, uint32_t thread_id) const;
 
   absl::flat_hash_map<uint32_t, ThreadSampleData> thread_id_to_sample_data_;
-  absl::flat_hash_map<uint64_t, orbit_client_protos::CallstackInfo> id_to_resolved_callstack_;
+  absl::flat_hash_map<uint64_t, CallstackInfo> id_to_resolved_callstack_;
   absl::flat_hash_map<uint64_t, uint64_t> original_id_to_resolved_callstack_id_;
   absl::flat_hash_map<uint64_t, absl::flat_hash_set<uint64_t>>
       function_address_to_sampled_callstack_ids_;

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -44,26 +44,6 @@ message FunctionInfo {
   uint64 size = 7;
 }
 
-message CallstackInfo {
-  repeated uint64 frames = 1;
-
-  enum CallstackType {
-    // Keep these in sync with orbit_grpc_protos::Callstack::CallstackType.
-    kComplete = 0;
-    kDwarfUnwindingError = 1;
-    kFramePointerUnwindingError = 2;
-    kInUprobes = 3;
-    kInUserSpaceInstrumentation = 7;
-    kCallstackPatchingFailed = 4;
-    kStackTopForDwarfUnwindingTooSmall = 5;
-    kStackTopDwarfUnwindingError = 6;
-    // These are set by the client and are in addition to the ones in
-    // Callstack::CallstackType.
-    kFilteredByMajorityOutermostFrame = 100;
-  }
-  CallstackType type = 2;
-}
-
 message ThreadStateSliceInfo {
   // pid is absent as we don't yet get that information from the service.
   uint32 tid = 1;

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -10,6 +10,8 @@
 #include <filesystem>
 #include <string>
 
+#include "ClientData/CallstackInfo.h"
+#include "ClientData/CallstackType.h"
 #include "ClientData/CaptureData.h"
 #include "ClientData/FunctionUtils.h"
 #include "ClientData/ModuleAndFunctionLookup.h"
@@ -26,11 +28,12 @@
 #include "OrbitBase/TemporaryFile.h"
 #include "TestUtils/TestUtils.h"
 
+using orbit_client_data::CallstackInfo;
+using orbit_client_data::CallstackType;
 using orbit_client_data::CaptureData;
 using orbit_client_data::ModuleData;
 using orbit_client_data::ProcessData;
 using orbit_client_data::function_utils::GetLoadedModuleNameByPath;
-using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::FunctionInfo;
 using orbit_data_views::CallstackDataView;
 using orbit_data_views::CheckCopySelectionIsInvoked;
@@ -148,10 +151,9 @@ class CallstackDataViewTest : public testing::Test {
   }
 
   void SetCallstackFromFrames(std::vector<uint64_t> callstack_frames) {
-    orbit_client_protos::CallstackInfo callstack_info;
-    *callstack_info.mutable_frames() = {callstack_frames.begin(), callstack_frames.end()};
-    callstack_info.set_type(orbit_client_protos::CallstackInfo_CallstackType_kComplete);
-    view_.SetCallstack(callstack_info);
+    orbit_client_data::CallstackInfo callstack_info{std::move(callstack_frames),
+                                                    CallstackType::kComplete};
+    view_.SetCallstack(std::move(callstack_info));
   }
 
   std::string GetModulePathByAddressFromCaptureData(uint64_t frame_address) {

--- a/src/DataViews/include/DataViews/CallstackDataView.h
+++ b/src/DataViews/include/DataViews/CallstackDataView.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "ClientData/CallstackInfo.h"
 #include "ClientData/ModuleData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "DataViews/AppInterface.h"
@@ -29,13 +30,13 @@ class CallstackDataView : public DataView {
   std::string GetToolTip(int row, int /*column*/) override;
 
   void OnDataChanged() override;
-  void SetCallstack(const orbit_client_protos::CallstackInfo& callstack) {
+  void SetCallstack(const orbit_client_data::CallstackInfo& callstack) {
     callstack_ = callstack;
     OnDataChanged();
   }
 
   void ClearCallstack() {
-    callstack_ = orbit_client_protos::CallstackInfo{};
+    callstack_ = {};
     OnDataChanged();
   }
 
@@ -50,7 +51,7 @@ class CallstackDataView : public DataView {
  protected:
   void DoFilter() override;
 
-  orbit_client_protos::CallstackInfo callstack_;
+  std::optional<orbit_client_data::CallstackInfo> callstack_;
 
   struct CallstackDataViewFrame {
     CallstackDataViewFrame(uint64_t address, const orbit_client_protos::FunctionInfo* function,
@@ -67,7 +68,7 @@ class CallstackDataView : public DataView {
   };
 
   CallstackDataViewFrame GetFrameFromRow(int row) const;
-  CallstackDataViewFrame GetFrameFromIndex(int index_in_callstack) const;
+  CallstackDataViewFrame GetFrameFromIndex(size_t index_in_callstack) const;
 
   enum ColumnIndex {
     kColumnSelected,

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -50,19 +50,12 @@ using orbit_capture_client::CaptureClient;
 using orbit_capture_client::CaptureEventProcessor;
 using orbit_capture_client::CaptureListener;
 
-using orbit_client_data::CallstackEvent;
-using orbit_client_data::CaptureData;
 using orbit_client_data::ProcessData;
 using orbit_client_data::TracepointInfoSet;
 
-using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::FunctionInfo;
-using orbit_client_protos::LinuxAddressInfo;
-using orbit_client_protos::TimerInfo;
 
-using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::CaptureOptions;
-using orbit_grpc_protos::CaptureStarted;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::ProcessInfo;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -99,6 +99,7 @@ using orbit_capture_file::CaptureFile;
 
 using orbit_client_data::CallstackData;
 using orbit_client_data::CallstackEvent;
+using orbit_client_data::CallstackInfo;
 using orbit_client_data::CaptureData;
 using orbit_client_data::ModuleData;
 using orbit_client_data::PostProcessedSamplingData;
@@ -110,7 +111,6 @@ using orbit_client_data::TimerChain;
 using orbit_client_data::TracepointInfoSet;
 using orbit_client_data::UserDefinedCaptureData;
 
-using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
 using orbit_client_protos::LinuxAddressInfo;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -166,7 +166,7 @@ class OrbitApp final : public DataViewFactory,
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallstack(uint64_t callstack_id,
-                         orbit_client_protos::CallstackInfo callstack) override;
+                         orbit_client_data::CallstackInfo callstack) override;
   void OnCallstackEvent(orbit_client_data::CallstackEvent callstack_event) override;
   void OnThreadName(uint32_t thread_id, std::string thread_name) override;
   void OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo thread_state_slice) override;

--- a/src/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/CallTreeView.h
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "ClientData/CallstackType.h"
 #include "ClientData/CaptureData.h"
 #include "ClientData/PostProcessedSamplingData.h"
 
@@ -49,10 +50,10 @@ class CallTreeNode {
                                                     std::string module_build_id);
 
   [[nodiscard]] CallTreeUnwindErrorType* GetUnwindErrorTypeOrNull(
-      orbit_client_protos::CallstackInfo::CallstackType type);
+      orbit_client_data::CallstackType type);
 
   [[nodiscard]] CallTreeUnwindErrorType* AddAndGetUnwindErrorType(
-      orbit_client_protos::CallstackInfo::CallstackType type);
+      orbit_client_data::CallstackType type);
 
   [[nodiscard]] CallTreeUnwindErrors* GetUnwindErrorsOrNull();
 
@@ -99,7 +100,7 @@ class CallTreeNode {
   // needed for the CallTreeNode::parent_ field.
   absl::node_hash_map<uint32_t, CallTreeThread> thread_children_;
   absl::node_hash_map<uint64_t, CallTreeFunction> function_children_;
-  absl::node_hash_map<orbit_client_protos::CallstackInfo::CallstackType, CallTreeUnwindErrorType>
+  absl::node_hash_map<orbit_client_data::CallstackType, CallTreeUnwindErrorType>
       unwind_error_type_children_;
   // std::shared_ptr instead of std::unique_ptr because absl::node_hash_map
   // needs the copy constructor (even for try_emplace).
@@ -166,17 +167,15 @@ class CallTreeUnwindErrors : public CallTreeNode {
 class CallTreeUnwindErrorType : public CallTreeNode {
  public:
   explicit CallTreeUnwindErrorType(CallTreeNode* parent,
-                                   orbit_client_protos::CallstackInfo::CallstackType error_type)
+                                   orbit_client_data::CallstackType error_type)
       : CallTreeNode{parent}, error_type_{error_type} {
-    ORBIT_CHECK(error_type != orbit_client_protos::CallstackInfo::kComplete);
+    ORBIT_CHECK(error_type != orbit_client_data::CallstackType::kComplete);
   }
 
-  [[nodiscard]] orbit_client_protos::CallstackInfo::CallstackType error_type() const {
-    return error_type_;
-  }
+  [[nodiscard]] orbit_client_data::CallstackType error_type() const { return error_type_; }
 
  private:
-  orbit_client_protos::CallstackInfo::CallstackType error_type_;
+  orbit_client_data::CallstackType error_type_;
 };
 
 class CallTreeView : public CallTreeNode {

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 
+#include "ClientData/CallstackInfo.h"
 #include "ClientData/CallstackType.h"
 #include "ClientData/CaptureData.h"
 #include "ClientProtos/capture_data.pb.h"
@@ -51,10 +52,10 @@ class CallstackThreadBar : public ThreadBar {
  private:
   void SelectCallstacks();
   [[nodiscard]] std::string SafeGetFormattedFunctionName(
-      const orbit_client_protos::CallstackInfo& callstack, int frame_index,
+      const orbit_client_data::CallstackInfo& callstack, size_t frame_index,
       int max_line_length) const;
   [[nodiscard]] std::string FormatCallstackForTooltip(
-      const orbit_client_protos::CallstackInfo& callstack, int max_line_length = 80,
+      const orbit_client_data::CallstackInfo& callstack, int max_line_length = 80,
       int max_lines = 20, int bottom_n_lines = 5) const;
 
   [[nodiscard]] std::string GetSampleTooltip(const Batcher& batcher, PickingId id) const;

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -128,7 +128,7 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
   }
   void OnKeyAndString(uint64_t /*key*/, std::string /*str*/) override { ORBIT_UNREACHABLE(); }
   void OnUniqueCallstack(uint64_t /*callstack_id*/,
-                         orbit_client_protos::CallstackInfo /*callstack*/) override {
+                         orbit_client_data::CallstackInfo /*callstack*/) override {
     ORBIT_UNREACHABLE();
   }
   void OnCallstackEvent(orbit_client_data::CallstackEvent /*callstack_event*/) override {

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -10,15 +10,17 @@
 #include <algorithm>
 
 #include "App.h"
+#include "ClientData/CallstackInfo.h"
 #include "ClientData/CallstackType.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitBase/Logging.h"
 
 using orbit_client_data::CallstackCount;
+using orbit_client_data::CallstackInfo;
+using orbit_client_data::CallstackType;
 using orbit_client_data::PostProcessedSamplingData;
 using orbit_client_data::ThreadID;
 using orbit_client_data::ThreadSampleData;
-using orbit_client_protos::CallstackInfo;
 
 SamplingReport::SamplingReport(
     OrbitApp* app, const orbit_client_data::CallstackData* callstack_data,
@@ -146,12 +148,12 @@ std::string SamplingReport::GetSelectedCallstackString() const {
 
   uint64_t callstack_id =
       selected_sorted_callstack_report_->callstack_counts[selected_callstack_index_].callstack_id;
-  const orbit_client_protos::CallstackInfo* callstack = callstack_data_->GetCallstack(callstack_id);
+  const CallstackInfo* callstack = callstack_data_->GetCallstack(callstack_id);
   ORBIT_CHECK(callstack != nullptr);
-  CallstackInfo::CallstackType callstack_type = callstack->type();
+  CallstackType callstack_type = callstack->type();
 
   std::string type_string =
-      (callstack_type == CallstackInfo::kComplete)
+      (callstack_type == CallstackType::kComplete)
           ? ""
           : absl::StrFormat("  -  Unwind error (%s)",
                             orbit_client_data::CallstackTypeToString(callstack_type));
@@ -168,11 +170,11 @@ std::string SamplingReport::GetSelectedCallstackTooltipString() const {
 
   uint64_t callstack_id =
       selected_sorted_callstack_report_->callstack_counts[selected_callstack_index_].callstack_id;
-  const orbit_client_protos::CallstackInfo* callstack = callstack_data_->GetCallstack(callstack_id);
+  const CallstackInfo* callstack = callstack_data_->GetCallstack(callstack_id);
   ORBIT_CHECK(callstack != nullptr);
-  CallstackInfo::CallstackType callstack_type = callstack->type();
+  CallstackType callstack_type = callstack->type();
 
-  if (callstack_type == CallstackInfo::kComplete) {
+  if (callstack_type == CallstackType::kComplete) {
     return "";
   }
 
@@ -185,8 +187,7 @@ void SamplingReport::OnCallstackIndexChanged(size_t index) {
     const CallstackCount& callstack_count =
         selected_sorted_callstack_report_->callstack_counts[index];
     selected_callstack_index_ = index;
-    const orbit_client_protos::CallstackInfo* callstack =
-        callstack_data_->GetCallstack(callstack_count.callstack_id);
+    const CallstackInfo* callstack = callstack_data_->GetCallstack(callstack_count.callstack_id);
     ORBIT_CHECK(callstack != nullptr);
     callstack_data_view_->SetCallstack(*callstack);
     callstack_data_view_->SetFunctionsToHighlight(selected_addresses_);

--- a/src/OrbitGl/TrackTestData.cpp
+++ b/src/OrbitGl/TrackTestData.cpp
@@ -5,7 +5,10 @@
 #include "TrackTestData.h"
 
 #include "ClientData/CallstackEvent.h"
+#include "ClientData/CallstackInfo.h"
+#include "ClientData/CallstackType.h"
 
+using orbit_client_data::CallstackType;
 using orbit_client_data::CaptureData;
 
 namespace orbit_gl {
@@ -25,9 +28,8 @@ std::unique_ptr<CaptureData> TrackTestData::GenerateTestCaptureData() {
 
   // CallstackInfo
   const std::vector<uint64_t> callstack_frames{kInstructionAbsoluteAddress};
-  orbit_client_protos::CallstackInfo callstack_info;
-  *callstack_info.mutable_frames() = {callstack_frames.begin(), callstack_frames.end()};
-  callstack_info.set_type(orbit_client_protos::CallstackInfo_CallstackType_kComplete);
+  orbit_client_data::CallstackInfo callstack_info{
+      {callstack_frames.begin(), callstack_frames.end()}, CallstackType::kComplete};
   capture_data->AddUniqueCallstack(kCallstackId, std::move(callstack_info));
 
   // CallstackEvent


### PR DESCRIPTION
The protos in "capture_data.proto" used to be protos, as we
were using them to be stored in the old capture format.
This is obsolete. Having those as classes gain us full control
again.

Bug: http://b/226551182
Test: Compile & Run Tests