### PR TITLE
Add error message reporting to the service

### DIFF
--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -44,10 +44,17 @@ int OrbitServiceMain() {
   ORBIT_LOG("OrbitService started");
   std::atomic<bool> exit_requested = false;
   // OrbitService's loop terminates when EOF is received, no need to manipulate exit_requested.
-  int exit_code =
+  ErrorMessageOr<void> error_message =
       orbit_service::OrbitService{kOrbitServicePort, /*dev_mode=*/false}.Run(&exit_requested);
-  ORBIT_LOG("OrbitService finished with exit code %d", exit_code);
-  return exit_code;
+
+  if (error_message.has_error()) {
+    ORBIT_LOG("OrbitService finished with an error: %s", error_message.error().message());
+    constexpr int kExitCodeIndicatingErrorMessage = 42;
+    return kExitCodeIndicatingErrorMessage;
+  }
+
+  ORBIT_LOG("OrbitService finished with exit code: 0");
+  return 0;
 }
 
 using PuppetConstants = IntegrationTestPuppetConstants;

--- a/src/Service/OrbitService.h
+++ b/src/Service/OrbitService.h
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_service {
 
@@ -23,7 +24,7 @@ class OrbitService {
   explicit OrbitService(uint16_t grpc_port, bool dev_mode)
       : grpc_port_{grpc_port}, dev_mode_{dev_mode} {}
 
-  [[nodiscard]] int Run(std::atomic<bool>* exit_requested);
+  ErrorMessageOr<void> Run(std::atomic<bool>* exit_requested);
 
  private:
   [[nodiscard]] bool IsSshWatchdogActive() { return last_stdin_message_ != std::nullopt; }

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -102,6 +102,8 @@ int main(int argc, char** argv) {
   std::puts(result.error().message().c_str());
   std::ignore = std::fflush(stdout);
 
+  // Note that changing the exit code value will affect the UI client which is checking for the
+  // exact value.
   constexpr int kExitCodeIndicatingErrorMessage = 42;
   return kExitCodeIndicatingErrorMessage;
 }

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -95,5 +95,13 @@ int main(int argc, char** argv) {
 
   exit_requested = false;
   orbit_service::OrbitService service{grpc_port, dev_mode};
-  return service.Run(&exit_requested);
+  auto result = service.Run(&exit_requested);
+
+  if (!result.has_error()) return 0;
+
+  std::puts(result.error().message().c_str());
+  std::ignore = std::fflush(stdout);
+
+  constexpr int kExitCodeIndicatingErrorMessage = 42;
+  return kExitCodeIndicatingErrorMessage;
 }


### PR DESCRIPTION
With this change the service will print the error message of any fatal error
that cannot be communicated via gRPC to stdout and exit with exit code
42. This will tell the client to look for an error message in the stdout
channel. The client will present the error message to the user in a
message box.

Bug: http://b/221369463
Screenshot: http://screenshot/32m4gzonSw4LKh4