### PR TITLE
Erase default implementation of TimerTrack::GetHeight

### DIFF
--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -86,6 +86,13 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   TimerTrack::OnTimer(new_timer_info);
 }
 
+float AsyncTrack::GetHeight() const {
+  uint32_t collapsed_depth = std::min<uint32_t>(1, GetDepth());
+  uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : GetDepth();
+  return GetHeightAboveTimers() + layout_->GetTextBoxHeight() * depth +
+         layout_->GetTrackContentBottomMargin();
+}
+
 void AsyncTrack::DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer,
                                     uint64_t min_tick, uint64_t max_tick,
                                     PickingMode picking_mode) {

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -35,6 +35,7 @@ class AsyncTrack final : public TimerTrack {
   [[nodiscard]] Type GetType() const override { return Type::kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+  [[nodiscard]] float GetHeight() const override;
 
  protected:
   void DoUpdatePrimitives(Batcher& batcher, TextRenderer& text_renderer, uint64_t min_tick,

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -326,13 +326,6 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
   timer_data_->AddTimer(timer_info, timer_info.depth());
 }
 
-float TimerTrack::GetHeight() const {
-  uint32_t collapsed_depth = std::min<uint32_t>(1, GetDepth());
-  uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : GetDepth();
-  return GetHeightAboveTimers() + layout_->GetTextBoxHeight() * depth +
-         layout_->GetTrackContentBottomMargin();
-}
-
 std::string TimerTrack::GetTooltip() const {
   return "Shows collected samples and timings from dynamically instrumented "
          "functions";

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -94,7 +94,6 @@ class TimerTrack : public Track {
 
   [[nodiscard]] int GetVisiblePrimitiveCount() const override { return visible_timer_count_; }
 
-  [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] virtual uint32_t GetDepth() const { return timer_data_->GetDepth(); }
 
   [[nodiscard]] virtual size_t GetNumberOfTimers() const;


### PR DESCRIPTION
A single task I didn't manage to do in
https://github.com/google/orbit/pull/3323, the long term plan is
removing TimerTrack as an intermediate class or at least make it as
small as possible (http://b/218517047).

Bug: http://b/225335540