### PR TITLE
Add OpenProcess and SafeHandle utilities

### DIFF
--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -25,8 +25,10 @@ target_sources(WindowsUtils PUBLIC
         include/WindowsUtils/FindDebugSymbols.h
         include/WindowsUtils/ListModules.h
         include/WindowsUtils/ListThreads.h
+        include/WindowsUtils/OpenProcess.h
         include/WindowsUtils/ProcessList.h
-        include/WindowsUtils/ReadProcessMemory.h)
+        include/WindowsUtils/ReadProcessMemory.h
+        include/WindowsUtils/SafeHandle.h)
 
 target_sources(WindowsUtils PRIVATE
         AdjustTokenPrivilege.cpp
@@ -34,8 +36,10 @@ target_sources(WindowsUtils PRIVATE
         FindDebugSymbols.cpp
         ListModules.cpp
         ListThreads.cpp
+        OpenProcess.cpp
         ProcessList.cpp
-        ReadProcessMemory.cpp)
+        ReadProcessMemory.cpp
+        SafeHandle.cpp)
 
 target_link_libraries(WindowsUtils PUBLIC
         ObjectUtils
@@ -49,8 +53,10 @@ target_sources(WindowsUtilsTests PRIVATE
         FindDebugSymbolsTest.cpp
         ListModulesTest.cpp
         ListThreadsTest.cpp
+        OpenProcessTest.cpp
         ProcessListTest.cpp
-        ReadProcessMemoryTest.cpp)
+        ReadProcessMemoryTest.cpp
+        SafeHandleTest.cpp)
 
 target_link_libraries(WindowsUtilsTests PRIVATE
         TestUtils

--- a/src/WindowsUtils/ListModules.cpp
+++ b/src/WindowsUtils/ListModules.cpp
@@ -13,6 +13,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/StringConversion.h"
 #include "OrbitBase/UniqueResource.h"
+#include "WindowsUtils/SafeHandle.h"
 
 // clang-format off
 #include <psapi.h>
@@ -34,7 +35,7 @@ std::vector<Module> ListModules(uint32_t pid) {
     ORBIT_ERROR("Calling CreateToolhelp32Snapshot for modules");
     return {};
   }
-  orbit_base::unique_resource handle{module_snap_handle, ::CloseHandle};
+  SafeHandle handle_closer(module_snap_handle);
 
   // Retrieve information about the first module.
   module_entry.dwSize = sizeof(MODULEENTRY32);

--- a/src/WindowsUtils/ListThreads.cpp
+++ b/src/WindowsUtils/ListThreads.cpp
@@ -11,6 +11,7 @@
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "OrbitBase/UniqueResource.h"
+#include "WindowsUtils/SafeHandle.h"
 
 // clang-format off
 #include <psapi.h>
@@ -31,7 +32,7 @@ std::vector<Thread> ListThreads(uint32_t pid) {
     ORBIT_ERROR("Calling CreateToolhelp32Snapshot for threads");
     return {};
   }
-  orbit_base::unique_resource handle{thread_snap_handle, ::CloseHandle};
+  SafeHandle handle_closer(thread_snap_handle);
 
   // Retrieve information about the first thread.
   thread_entry.dwSize = sizeof(THREADENTRY32);

--- a/src/WindowsUtils/OpenProcess.cpp
+++ b/src/WindowsUtils/OpenProcess.cpp
@@ -24,7 +24,7 @@ ErrorMessageOr<SafeHandle> OpenProcess(uint32_t desired_access, bool inherit_han
   return SafeHandle(process_handle);
 }
 
-ErrorMessageOr<SafeHandle> OpenProcess(uint32_t process_id) {
+ErrorMessageOr<SafeHandle> OpenProcessForReading(uint32_t process_id) {
   return OpenProcess(PROCESS_VM_READ, /*inherit_handle=*/false, process_id);
 }
 

--- a/src/WindowsUtils/OpenProcess.cpp
+++ b/src/WindowsUtils/OpenProcess.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/OpenProcess.h"
+
+#include <absl/strings/str_format.h>
+
+#include "OrbitBase/GetLastError.h"
+
+// clang-format off
+#include <processthreadsapi.h>
+// clang-format on
+
+namespace orbit_windows_utils {
+
+ErrorMessageOr<SafeHandle> OpenProcess(uint32_t desired_access, bool inherit_handle,
+                                       uint32_t process_id) {
+  HANDLE process_handle = ::OpenProcess(desired_access, inherit_handle ? TRUE : FALSE, process_id);
+  if (process_handle == nullptr) {
+    return ErrorMessage(absl::StrFormat("Could not get handle for process %u: %s", process_id,
+                                        orbit_base::GetLastErrorAsString()));
+  }
+  return SafeHandle(process_handle);
+}
+
+ErrorMessageOr<SafeHandle> OpenProcess(uint32_t process_id) {
+  return OpenProcess(PROCESS_VM_READ, /*inherit_handle=*/false, process_id);
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/OpenProcessTest.cpp
+++ b/src/WindowsUtils/OpenProcessTest.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/base/casts.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ThreadUtils.h"
+#include "WindowsUtils/OpenProcess.h"
+
+TEST(OpenProcess, ValidHandleForCurrentPid) {
+  auto result = orbit_windows_utils::OpenProcess(orbit_base::GetCurrentProcessId());
+  EXPECT_TRUE(result.has_value());
+}
+
+TEST(OpenProcess, ErrorForInvalidPid) {
+  auto result = orbit_windows_utils::OpenProcess(0);
+  EXPECT_TRUE(result.has_error());
+}

--- a/src/WindowsUtils/OpenProcessTest.cpp
+++ b/src/WindowsUtils/OpenProcessTest.cpp
@@ -9,11 +9,22 @@
 #include "WindowsUtils/OpenProcess.h"
 
 TEST(OpenProcess, ValidHandleForCurrentPid) {
-  auto result = orbit_windows_utils::OpenProcess(orbit_base::GetCurrentProcessId());
+  auto result = orbit_windows_utils::OpenProcess(PROCESS_VM_READ, /*inherit_handle=*/false,
+                                                 orbit_base::GetCurrentProcessId());
   EXPECT_TRUE(result.has_value());
 }
 
 TEST(OpenProcess, ErrorForInvalidPid) {
-  auto result = orbit_windows_utils::OpenProcess(0);
+  auto result = orbit_windows_utils::OpenProcess(PROCESS_VM_READ, /*inherit_handle=*/false, 0);
+  EXPECT_TRUE(result.has_error());
+}
+
+TEST(OpenProcess, OpenProcessForReadingValidHandleForCurrentPid) {
+  auto result = orbit_windows_utils::OpenProcessForReading(orbit_base::GetCurrentProcessId());
+  EXPECT_TRUE(result.has_value());
+}
+
+TEST(OpenProcess, OpenProcessForReadingErrorForInvalidPid) {
+  auto result = orbit_windows_utils::OpenProcessForReading(0);
   EXPECT_TRUE(result.has_error());
 }

--- a/src/WindowsUtils/ReadProcessMemory.cpp
+++ b/src/WindowsUtils/ReadProcessMemory.cpp
@@ -8,6 +8,9 @@
 #include <absl/strings/str_format.h>
 #include <windows.h>
 
+#include "WindowsUtils/OpenProcess.h"
+#include "WindowsUtils/SafeHandle.h"
+
 // clang-format off
 #include <memoryapi.h>
 // clang-format on
@@ -18,12 +21,8 @@ namespace orbit_windows_utils {
 
 ErrorMessageOr<void> ReadProcessMemory(uint32_t pid, uintptr_t address, void* buffer, uint64_t size,
                                        uint64_t* num_bytes_read) {
-  HANDLE process_handle = OpenProcess(PROCESS_VM_READ, /*bInheritHandle=*/FALSE, pid);
-  if (process_handle == nullptr) {
-    return ErrorMessage(absl::StrFormat("Could not get handle for process %u", pid));
-  }
-
-  BOOL result = ::ReadProcessMemory(process_handle, absl::bit_cast<void*>(address), buffer, size,
+  OUTCOME_TRY(SafeHandle process_handle, OpenProcess(pid));
+  BOOL result = ::ReadProcessMemory(*process_handle, absl::bit_cast<void*>(address), buffer, size,
                                     num_bytes_read);
 
   if (result == FALSE) {

--- a/src/WindowsUtils/ReadProcessMemory.cpp
+++ b/src/WindowsUtils/ReadProcessMemory.cpp
@@ -21,7 +21,7 @@ namespace orbit_windows_utils {
 
 ErrorMessageOr<void> ReadProcessMemory(uint32_t pid, uintptr_t address, void* buffer, uint64_t size,
                                        uint64_t* num_bytes_read) {
-  OUTCOME_TRY(SafeHandle process_handle, OpenProcess(pid));
+  OUTCOME_TRY(SafeHandle process_handle, OpenProcessForReading(pid));
   BOOL result = ::ReadProcessMemory(*process_handle, absl::bit_cast<void*>(address), buffer, size,
                                     num_bytes_read);
 

--- a/src/WindowsUtils/SafeHandle.cpp
+++ b/src/WindowsUtils/SafeHandle.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/SafeHandle.h"
+
+namespace orbit_windows_utils {
+
+namespace {
+
+// Wrapper around "CloseHandle" which supports nullptr.
+void SafeCloseHandle(HANDLE handle) {
+  if (handle) {
+    ::CloseHandle(handle);
+  }
+}
+
+}  // namespace
+
+SafeHandle::SafeHandle(HANDLE handle) : SafeHandleBase(handle, SafeCloseHandle) {}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/SafeHandleTest.cpp
+++ b/src/WindowsUtils/SafeHandleTest.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/base/casts.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ThreadUtils.h"
+#include "WindowsUtils/OpenProcess.h"
+#include "WindowsUtils/SafeHandle.h"
+
+using orbit_windows_utils::SafeHandle;
+
+TEST(SafeHandle, OwnershipTransfer) {
+  auto result = orbit_windows_utils::OpenProcess(orbit_base::GetCurrentProcessId());
+  EXPECT_TRUE(result.has_value());
+  SafeHandle safe_handle = std::move(result.value());
+}
+
+TEST(SafeHandle, NullHandle) { SafeHandle safe_handle(nullptr); }
+
+TEST(SafeHandle, DoubleCloseError) {
+  HANDLE handle = nullptr;
+  {
+    uint32_t pid = orbit_base::GetCurrentProcessId();
+    SafeHandle safe_handle =
+        orbit_windows_utils::OpenProcess(PROCESS_VM_READ, /*inherit_handle=*/false, pid).value();
+    handle = safe_handle.get();
+  }
+
+  // CloseHandle returns 0 on error.
+  EXPECT_EQ(CloseHandle(handle), 0);
+}

--- a/src/WindowsUtils/SafeHandleTest.cpp
+++ b/src/WindowsUtils/SafeHandleTest.cpp
@@ -12,8 +12,8 @@
 using orbit_windows_utils::SafeHandle;
 
 TEST(SafeHandle, OwnershipTransfer) {
-  auto result = orbit_windows_utils::OpenProcess(orbit_base::GetCurrentProcessId());
-  EXPECT_TRUE(result.has_value());
+  auto result = orbit_windows_utils::OpenProcessForReading(orbit_base::GetCurrentProcessId());
+  ASSERT_TRUE(result.has_value());
   SafeHandle safe_handle = std::move(result.value());
 }
 
@@ -22,9 +22,9 @@ TEST(SafeHandle, NullHandle) { SafeHandle safe_handle(nullptr); }
 TEST(SafeHandle, DoubleCloseError) {
   HANDLE handle = nullptr;
   {
-    uint32_t pid = orbit_base::GetCurrentProcessId();
-    SafeHandle safe_handle =
-        orbit_windows_utils::OpenProcess(PROCESS_VM_READ, /*inherit_handle=*/false, pid).value();
+    auto result = orbit_windows_utils::OpenProcessForReading(orbit_base::GetCurrentProcessId());
+    ASSERT_TRUE(result.has_value());
+    SafeHandle& safe_handle = result.value();
     handle = safe_handle.get();
   }
 

--- a/src/WindowsUtils/include/WindowsUtils/OpenProcess.h
+++ b/src/WindowsUtils/include/WindowsUtils/OpenProcess.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_OPEN_PROCESS_H_
+#define WINDOWS_UTILS_OPEN_PROCESS_H_
+
+#include "WindowsUtils/SafeHandle.h"
+
+namespace orbit_windows_utils {
+
+// Wrapper around Windows' "OpenProcess" function which either returns a "SafeHandle" or an error.
+ErrorMessageOr<SafeHandle> OpenProcess(uint32_t desired_access, bool inherit_handle,
+                                       uint32_t process_id);
+// Calls OpenProcess(PROCESS_VM_READ, /*inherit_handle=*/false, process_id).
+ErrorMessageOr<SafeHandle> OpenProcess(uint32_t process_id);
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_OPEN_PROCESS_H_

--- a/src/WindowsUtils/include/WindowsUtils/OpenProcess.h
+++ b/src/WindowsUtils/include/WindowsUtils/OpenProcess.h
@@ -13,7 +13,7 @@ namespace orbit_windows_utils {
 ErrorMessageOr<SafeHandle> OpenProcess(uint32_t desired_access, bool inherit_handle,
                                        uint32_t process_id);
 // Calls OpenProcess(PROCESS_VM_READ, /*inherit_handle=*/false, process_id).
-ErrorMessageOr<SafeHandle> OpenProcess(uint32_t process_id);
+ErrorMessageOr<SafeHandle> OpenProcessForReading(uint32_t process_id);
 
 }  // namespace orbit_windows_utils
 

--- a/src/WindowsUtils/include/WindowsUtils/SafeHandle.h
+++ b/src/WindowsUtils/include/WindowsUtils/SafeHandle.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_SAFE_HANDLE_H_
+#define WINDOWS_UTILS_SAFE_HANDLE_H_
+
+#include "OrbitBase/Result.h"
+#include "OrbitBase/UniqueResource.h"
+
+// clang-format off
+#include <Windows.h>
+#include <handleapi.h>
+// clang-format on
+
+namespace orbit_windows_utils {
+
+using SafeHandleBase = orbit_base::unique_resource<HANDLE, void (*)(HANDLE)>;
+
+// Wrapper around a Windows "HANDLE" which calls "CloseHandle" on destruction if non-null.
+struct SafeHandle : public SafeHandleBase {
+  explicit SafeHandle(HANDLE handle);
+  [[nodiscard]] HANDLE operator*() const { return get(); }
+};
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_SAFE_HANDLE_H_


### PR DESCRIPTION
"SafeHandle" is a wrapper around a Windows "HANDLE" which calls
"CloseHandle" on destruction if said handle is not null.

OpenProcess.h contains wrapper functions around Windows' "OpenProcess"
function which return a "SafeHandle" or an error.

Add SafeHandleTest.cpp, OpenProcessTest.cpp

Tests: Ran tests, compiled.