### PR TITLE
Add WriteProcessMemory Windows utility

### DIFF
--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -28,7 +28,8 @@ target_sources(WindowsUtils PUBLIC
         include/WindowsUtils/OpenProcess.h
         include/WindowsUtils/ProcessList.h
         include/WindowsUtils/ReadProcessMemory.h
-        include/WindowsUtils/SafeHandle.h)
+        include/WindowsUtils/SafeHandle.h
+        include/WindowsUtils/WriteProcessMemory.h)
 
 target_sources(WindowsUtils PRIVATE
         AdjustTokenPrivilege.cpp
@@ -39,7 +40,8 @@ target_sources(WindowsUtils PRIVATE
         OpenProcess.cpp
         ProcessList.cpp
         ReadProcessMemory.cpp
-        SafeHandle.cpp)
+        SafeHandle.cpp
+        WriteProcessMemory.cpp)
 
 target_link_libraries(WindowsUtils PUBLIC
         ObjectUtils
@@ -56,7 +58,8 @@ target_sources(WindowsUtilsTests PRIVATE
         OpenProcessTest.cpp
         ProcessListTest.cpp
         ReadProcessMemoryTest.cpp
-        SafeHandleTest.cpp)
+        SafeHandleTest.cpp
+        WriteProcessMemoryTest.cpp)
 
 target_link_libraries(WindowsUtilsTests PRIVATE
         TestUtils

--- a/src/WindowsUtils/DllInjection.cpp
+++ b/src/WindowsUtils/DllInjection.cpp
@@ -14,6 +14,7 @@
 #include "WindowsUtils/ListModules.h"
 #include "WindowsUtils/OpenProcess.h"
 #include "WindowsUtils/SafeHandle.h"
+#include "WindowsUtils/WriteProcessMemory.h"
 
 // clang-format off
 #include <windows.h>
@@ -24,7 +25,7 @@ namespace orbit_windows_utils {
 
 namespace {
 
-ErrorMessageOr<uint64_t> RemoteWrite(HANDLE process_handle, const std::vector<uint8_t>& buffer) {
+ErrorMessageOr<uint64_t> RemoteWrite(HANDLE process_handle, absl::Span<const char> buffer) {
   // Allocate memory in target process.
   LPVOID base_address = VirtualAllocEx(process_handle, /*lpAddress=*/0, buffer.size(),
                                        MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
@@ -34,16 +35,7 @@ ErrorMessageOr<uint64_t> RemoteWrite(HANDLE process_handle, const std::vector<ui
   }
 
   // Write in allocated remote memory.
-  size_t num_bytes_written = 0;
-  if (!WriteProcessMemory(process_handle, base_address, static_cast<LPCVOID>(buffer.data()),
-                          buffer.size(), &num_bytes_written)) {
-    return ErrorMessage(absl::StrFormat("Error calling WriteProcessMemory: %s",
-                                        orbit_base::GetLastErrorAsString()));
-  }
-
-  if (num_bytes_written != buffer.size()) {
-    return ErrorMessage("WriteProcessMemory could not write the requested number bytes.");
-  }
+  OUTCOME_TRY(WriteProcessMemory(process_handle, base_address, buffer));
 
   return absl::bit_cast<uint64_t>(base_address);
 }
@@ -80,12 +72,6 @@ ErrorMessageOr<void> ValidatePath(std::filesystem::path path) {
   if (!std::filesystem::exists(path))
     return ErrorMessage(absl::StrFormat("Path does not exist: %s", path.string()));
   return outcome::success();
-}
-
-[[nodiscard]] std::vector<uint8_t> ToByteBuffer(std::string_view str) {
-  std::vector<uint8_t> result(str.size() + 1, 0);
-  std::memcpy(result.data(), str.data(), str.size());
-  return result;
 }
 
 ErrorMessageOr<Module> FindModule(uint32_t pid, std::string_view module_name) {
@@ -132,7 +118,7 @@ ErrorMessageOr<void> InjectDll(uint32_t pid, std::filesystem::path dll_path) {
   OUTCOME_TRY(EnsureModuleIsNotAlreadyLoaded(pid, dll_path.filename().string()));
 
   // Inject dll by calling "LoadLibraryA" in remote process with the name of our dll as parameter.
-  OUTCOME_TRY(CreateRemoteThread(pid, "kernel32.dll", "LoadLibraryA", ToByteBuffer(dll_name)));
+  OUTCOME_TRY(CreateRemoteThread(pid, "kernel32.dll", "LoadLibraryA", dll_name));
 
   // Find injected dll in target process. Allow for retries as the loading might take some time.
   constexpr uint32_t kNumRetries = 10;
@@ -144,7 +130,7 @@ ErrorMessageOr<void> InjectDll(uint32_t pid, std::filesystem::path dll_path) {
 
 ErrorMessageOr<void> CreateRemoteThread(uint32_t pid, std::string_view module_name,
                                         std::string_view function_name,
-                                        std::vector<uint8_t> parameter) {
+                                        absl::Span<const char> parameter) {
   OUTCOME_TRY(uint64_t function_address, GetRemoteProcAddress(pid, module_name, function_name));
   OUTCOME_TRY(SafeHandle safe_handle,
               OpenProcess(PROCESS_ALL_ACCESS, /*inherit_handle=*/false, pid));

--- a/src/WindowsUtils/WriteProcessMemory.cpp
+++ b/src/WindowsUtils/WriteProcessMemory.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/WriteProcessMemory.h"
+
+#include <absl/base/casts.h>
+#include <absl/strings/str_format.h>
+
+#include "OrbitBase/GetLastError.h"
+#include "WindowsUtils/OpenProcess.h"
+
+// clang-format off
+#include <Windows.h>
+#include <memoryapi.h>
+// clang-format on
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_windows_utils {
+
+// Write "buffer" at memory location "address" of process identified by "process_handle".
+ErrorMessageOr<void> WriteProcessMemory(HANDLE process_handle, void* address,
+                                        absl::Span<const char> buffer) {
+  SIZE_T num_bytes_written = 0;
+  BOOL result = ::WriteProcessMemory(process_handle, address, buffer.data(), buffer.size(),
+                                     &num_bytes_written);
+
+  if (result == 0 || num_bytes_written != buffer.size()) {
+    return ErrorMessage(absl::StrFormat(
+        "Could not write %u bytes at address %p of process %u. %u byte(s) were written: %s",
+        buffer.size(), address, GetProcessId(process_handle), num_bytes_written,
+        orbit_base::GetLastErrorAsString()));
+  }
+
+  return outcome::success();
+}
+
+ErrorMessageOr<void> WriteProcessMemory(uint32_t pid, void* address,
+                                        absl::Span<const char> buffer) {
+  OUTCOME_TRY(SafeHandle process_handle,
+              OpenProcess(PROCESS_ALL_ACCESS, /*inherit_handle=*/false, pid));
+
+  return WriteProcessMemory(*process_handle, address, buffer);
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/WriteProcessMemoryTest.cpp
+++ b/src/WindowsUtils/WriteProcessMemoryTest.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/base/casts.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ThreadUtils.h"
+#include "TestUtils/TestUtils.h"
+#include "WindowsUtils/OpenProcess.h"
+#include "WindowsUtils/SafeHandle.h"
+#include "WindowsUtils/WriteProcessMemory.h"
+
+using orbit_windows_utils::WriteProcessMemory;
+
+TEST(WriteProcessMemory, WriteCurrentProcessWithProcessId) {
+  uint32_t process_id = orbit_base::GetCurrentProcessId();
+  const std::string test_string("The quick brown fox jumps over the lazy dog");
+  std::string destination_buffer(2048, 0);
+  auto result =
+      orbit_windows_utils::WriteProcessMemory(process_id, destination_buffer.data(), test_string);
+
+  EXPECT_THAT(result, orbit_test_utils::HasNoError());
+  EXPECT_STREQ(destination_buffer.data(), test_string.c_str());
+}
+
+TEST(WriteProcessMemory, WriteCurrentProcessWithProcessHandle) {
+  orbit_windows_utils::SafeHandle process_handle(GetCurrentProcess());
+  const std::string test_string("The quick brown fox jumps over the lazy dog");
+  std::string destination_buffer(2048, 0);
+  auto result = orbit_windows_utils::WriteProcessMemory(*process_handle, destination_buffer.data(),
+                                                        test_string);
+
+  EXPECT_THAT(result, orbit_test_utils::HasNoError());
+  EXPECT_STREQ(destination_buffer.data(), test_string.c_str());
+}
+
+TEST(WriteProcessMemory, WriteToInvalidMemoryLocation) {
+  uint32_t pid = orbit_base::GetCurrentProcessId();
+  const std::string test_string("The quick brown fox jumps over the lazy dog");
+  auto result = orbit_windows_utils::WriteProcessMemory(pid, nullptr, test_string);
+  EXPECT_THAT(result, orbit_test_utils::HasError("Invalid access to memory location"));
+}

--- a/src/WindowsUtils/include/WindowsUtils/DllInjection.h
+++ b/src/WindowsUtils/include/WindowsUtils/DllInjection.h
@@ -5,6 +5,8 @@
 #ifndef WINDOWS_UTILS_DLL_INJECTION_H_
 #define WINDOWS_UTILS_DLL_INJECTION_H_
 
+#include <absl/types/span.h>
+
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -20,7 +22,7 @@ namespace orbit_windows_utils {
 // is copied to the target's memory and its address is passed to the thread function as argument.
 [[nodiscard]] ErrorMessageOr<void> CreateRemoteThread(uint32_t pid, std::string_view module_name,
                                                       std::string_view function_name,
-                                                      std::vector<uint8_t> parameter);
+                                                      absl::Span<const char> parameter);
 
 // Get address of function in a remote process.
 [[nodiscard]] ErrorMessageOr<uint64_t> GetRemoteProcAddress(uint32_t pid,

--- a/src/WindowsUtils/include/WindowsUtils/WriteProcessMemory.h
+++ b/src/WindowsUtils/include/WindowsUtils/WriteProcessMemory.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_WRITE_PROCESS_MEMORY_H_
+#define WINDOWS_UTILS_WRITE_PROCESS_MEMORY_H_
+
+#include <absl/types/span.h>
+#include <stdint.h>
+
+#include "OrbitBase/Result.h"
+
+// clang-format off
+#include <Windows.h>
+#include <handleapi.h>
+// clang-format on
+
+namespace orbit_windows_utils {
+
+// Write "buffer" at memory location "address" of process identified by "process_id".
+[[nodiscard]] ErrorMessageOr<void> WriteProcessMemory(uint32_t process_id, void* address,
+                                                      absl::Span<const char> buffer);
+
+// Write "buffer" at memory location "address" of process identified by "process_handle".
+[[nodiscard]] ErrorMessageOr<void> WriteProcessMemory(HANDLE process_handle, void* address,
+                                                      absl::Span<const char> buffer);
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_WRITE_PROCESS_MEMORY_H_


### PR DESCRIPTION
Write a buffer at specified memory location of process identified by
either a process ID or a process handle and return an error if
something goes wrong. Add "WriteProcessMemoryTest" and replace similar
logic in "DllInjection" by a call to the new function.

Tests: compiled, ran tests.

NOTE: This builds on top of a previous PR, #3482, please only consider the second commit.