### PR TITLE
Fix asan error (stack_use_after_scope)

### DIFF
--- a/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
@@ -104,7 +104,7 @@ static void StopInternalProducersAndCaptureStartStopListenersInParallel(
   });
 
   for (CaptureStartStopListener* listener : *capture_start_stop_listeners) {
-    stop_threads.emplace_back([&listener] {
+    stop_threads.emplace_back([listener] {
       listener->OnCaptureStopRequested();
       ORBIT_LOG("CaptureStartStopListener stopped: one or more producers finished capturing");
     });


### PR DESCRIPTION
Pass in the pointer as value to the lambda's capture. The reference
is in a scope that is destroyed after the loop iteration.

Bug: http://b/226879942
Test: Run rabbit internally before/after the change and verify
      no error being reported.