### PR TITLE
Add GetScopeName(id) method to ScopeIdProvider

### DIFF
--- a/src/ClientData/ThreadTrackDataProviderTest.cpp
+++ b/src/ClientData/ThreadTrackDataProviderTest.cpp
@@ -58,6 +58,7 @@ struct TimersInTest {
 class MockScopeIdProvider : public ScopeIdProvider {
  public:
   MOCK_METHOD(uint64_t, ProvideId, (const TimerInfo& timer_info));
+  MOCK_METHOD(const std::string&, GetScopeName, (uint64_t scope_id), (const));
 };
 
 }  // namespace

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -24,7 +24,7 @@ class ScopeIdProvider {
 
   [[nodiscard]] virtual uint64_t ProvideId(const TimerInfo& timer_info) = 0;
 
-  [[nodiscard]] virtual std::string& GetScopeName(uint64_t scope_id) = 0;
+  [[nodiscard]] virtual const std::string& GetScopeName(uint64_t scope_id) const = 0;
 };
 
 // This class, unless the timer does already have an id (`function_id`), it assigning an id for
@@ -40,7 +40,7 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
 
   [[nodiscard]] uint64_t ProvideId(const TimerInfo& timer_info) override;
 
-  [[nodiscard]] std::string& GetScopeName(uint64_t scope_id) override;
+  [[nodiscard]] const std::string& GetScopeName(uint64_t scope_id) const override;
 
  private:
   explicit NameEqualityScopeIdProvider(uint64_t start_id,

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_CLIENT_DATA_API_SCOPE_ID_PROVIDER_H_
 #define ORBIT_CLIENT_DATA_API_SCOPE_ID_PROVIDER_H_
 
+#include <absl/container/flat_hash_map.h>
+
 #include <cstdint>
 
 #include "ClientData/TimerTrackDataIdManager.h"
@@ -21,6 +23,8 @@ class ScopeIdProvider {
   virtual ~ScopeIdProvider() = default;
 
   [[nodiscard]] virtual uint64_t ProvideId(const TimerInfo& timer_info) = 0;
+
+  [[nodiscard]] virtual std::string& GetScopeName(uint64_t scope_id) = 0;
 };
 
 // This class, unless the timer does already have an id (`function_id`), it assigning an id for
@@ -36,12 +40,18 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
 
   [[nodiscard]] uint64_t ProvideId(const TimerInfo& timer_info) override;
 
+  [[nodiscard]] std::string& GetScopeName(uint64_t scope_id) override;
+
  private:
-  explicit NameEqualityScopeIdProvider(uint64_t start_id) : next_id_(start_id) {}
+  explicit NameEqualityScopeIdProvider(uint64_t start_id,
+                                       absl::flat_hash_map<uint64_t, std::string> scope_id_to_name)
+      : next_id_(start_id), scope_id_to_name_(std::move(scope_id_to_name)) {}
 
   absl::flat_hash_map<std::pair<orbit_client_protos::TimerInfo_Type, std::string>, uint64_t>
       name_to_id_;
   uint64_t next_id_{};
+
+  absl::flat_hash_map<uint64_t, std::string> scope_id_to_name_;
 };
 
 }  // namespace orbit_client_data


### PR DESCRIPTION
Every id represents a group, while every group
needs a name to be shown under Live tab.
This adds the needed functionality to
ScopeIdProvider.

Tests: Unit
Bug: http://b/226889590