### PR TITLE
Replace fake track header with real element

### DIFF
--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -35,7 +35,7 @@ class FakeTimerPane : public CaptureViewElement {
 
   [[nodiscard]] Vec2 GetPos() const override {
     // The element is positioned after the last visible child. We can safely assume there's always
-    // one child due to the track header.
+    // at least one child due to the track header.
     CaptureViewElement* last_child = *track_->GetNonHiddenChildren().rbegin();
     float pos_y = last_child->GetPos()[1] + last_child->GetHeight();
 

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -21,38 +21,10 @@ namespace orbit_gl {
 
 namespace {
 
-class FakeTrackTab : public CaptureViewElement {
- public:
-  explicit FakeTrackTab(Track* track, const TimeGraphLayout* layout)
-      : CaptureViewElement(track, track->GetViewport(), layout), track_(track) {
-    // Compute and set the size (which would usually be done by the parent). As the position may
-    // change, we override the GetPos() function.
-    SetWidth(layout_->GetTrackTabWidth());
-  }
-
-  [[nodiscard]] std::unique_ptr<AccessibleInterface> CreateAccessibleInterface() override {
-    return std::make_unique<AccessibleCaptureViewElement>(
-        this, track_->GetName() + "_tab", orbit_accessibility::AccessibilityRole::PageTab);
-  }
-
-  [[nodiscard]] float GetHeight() const override { return layout_->GetTrackTabHeight(); }
-
-  [[nodiscard]] Vec2 GetPos() const override {
-    Vec2 track_pos = track_->GetPos();
-    Vec2 pos = track_pos + Vec2(layout_->GetTrackTabOffset(), 0);
-    return pos;
-  }
-
- private:
-  Track* track_;
-};
-
 class FakeTimerPane : public CaptureViewElement {
  public:
-  explicit FakeTimerPane(Track* track, const TimeGraphLayout* layout, CaptureViewElement* track_tab)
-      : CaptureViewElement(track, track->GetViewport(), layout),
-        track_(track),
-        track_tab_(track_tab) {
+  explicit FakeTimerPane(Track* track, const TimeGraphLayout* layout)
+      : CaptureViewElement(track, track->GetViewport(), layout), track_(track) {
     SetWidth(track->GetWidth());
   }
 
@@ -61,16 +33,8 @@ class FakeTimerPane : public CaptureViewElement {
   }
 
   [[nodiscard]] Vec2 GetPos() const override {
-    std::vector<CaptureViewElement*> track_children = track_->GetNonHiddenChildren();
-
-    // We are looking for the track's child that is right above the timer pane.
-    CaptureViewElement* predecessor = track_tab_;
-
-    if (!track_children.empty()) {
-      predecessor = track_children[track_children.size() - 1];
-    }
-
-    Vec2 pos{track_->GetPos()[0], predecessor->GetPos()[1] + predecessor->GetSize()[1]};
+    CaptureViewElement* track_tab = track_->GetAllChildren()[0];
+    Vec2 pos{track_->GetPos()[0], track_tab->GetPos()[1] + track_tab->GetHeight()};
     return pos;
   }
 
@@ -83,7 +47,6 @@ class FakeTimerPane : public CaptureViewElement {
 
  private:
   Track* track_;
-  CaptureViewElement* track_tab_;
 };
 
 }  //  namespace
@@ -92,43 +55,38 @@ AccessibleTrack::AccessibleTrack(Track* track, const TimeGraphLayout* layout)
     : AccessibleCaptureViewElement(track, track->GetName(),
                                    orbit_accessibility::AccessibilityRole::Grouping),
       track_(track),
-      fake_tab_(std::make_unique<FakeTrackTab>(track, layout)),
-      fake_timers_pane_(std::make_unique<FakeTimerPane>(track, layout, fake_tab_.get())) {}
+      fake_timers_pane_(std::make_unique<FakeTimerPane>(track, layout)) {}
 
 int AccessibleTrack::AccessibleChildCount() const {
   ORBIT_CHECK(track_ != nullptr);
 
-  // Only expose the "Timer" pane if any timers were rendered in the visible field
+  // If any timers were rendered, report an additional element. The accessibility interface
+  // simulates a "FakeTimerPane" to group all the timers together.
   if (track_->GetVisiblePrimitiveCount() > 0) {
-    return static_cast<int>(track_->GetNonHiddenChildren().size()) + 2;
+    return static_cast<int>(track_->GetNonHiddenChildren().size()) + 1;
   }
 
-  return static_cast<int>(track_->GetNonHiddenChildren().size()) + 1;
+  return static_cast<int>(track_->GetNonHiddenChildren().size());
 }
 
 const AccessibleInterface* AccessibleTrack::AccessibleChild(int index) const {
   ORBIT_CHECK(track_ != nullptr);
 
-  // The first child is the "virtual" tab.
-  if (index == 0) {
-    return fake_tab_->GetOrCreateAccessibleInterface();
-  }
-
   const auto& children = track_->GetNonHiddenChildren();
   auto child_count = static_cast<int>(children.size());
 
   // The last child is the timer pane if it has timers.
-  if (index == child_count + 1 && track_->GetVisiblePrimitiveCount() > 0) {
+  if (index == child_count && track_->GetVisiblePrimitiveCount() > 0) {
     return fake_timers_pane_->GetOrCreateAccessibleInterface();
   }
 
-  // Are we out of bound?
-  if (index < 0 || index >= child_count + 1) {
+  // Are we out of bounds?
+  if (index < 0 || index > child_count) {
     return nullptr;
   }
 
-  // Indexes between 1 and child_count + 1 are reserved for the actual children.
-  return children[index - 1]->GetOrCreateAccessibleInterface();
+  // Indexes between 0 and child_count are reserved for the actual children.
+  return children[index]->GetOrCreateAccessibleInterface();
 }
 
 AccessibilityState AccessibleTrack::AccessibleState() const {

--- a/src/OrbitGl/AccessibleTrack.h
+++ b/src/OrbitGl/AccessibleTrack.h
@@ -17,9 +17,10 @@ namespace orbit_gl {
 
 /*
  * Accessibility information for the track.
- * This will return the two "virtual" controls for the title tab and the timers in addition to the
- * actual children of the track.
- * The title tab is the first child and the timers pane is the last child.
+ * This will return a "virtual" control for the timers in addition to the actual children of the
+ * track. The timers pane is the last child.
+ *
+ * TODO (b/185854980): Remove the fake elements.
  */
 class AccessibleTrack : public AccessibleCaptureViewElement {
  public:
@@ -32,7 +33,6 @@ class AccessibleTrack : public AccessibleCaptureViewElement {
 
  private:
   Track* track_;
-  std::unique_ptr<CaptureViewElement> fake_tab_;
   std::unique_ptr<CaptureViewElement> fake_timers_pane_;
 };
 

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -35,9 +35,7 @@ BasicPageFaultsTrack::BasicPageFaultsTrack(Track* parent,
       AnnotationTrack(),
       cgroup_name_(std::move(cgroup_name)),
       memory_sampling_period_ms_(memory_sampling_period_ms),
-      parent_(parent) {
-  draw_background_ = false;
-}
+      parent_(parent) {}
 
 void BasicPageFaultsTrack::AddValues(
     uint64_t timestamp_ns, const std::array<double, kBasicPageFaultsTrackDimension>& values) {

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -76,7 +76,10 @@ target_sources(
          TracepointThreadBar.h
          Track.h
          TrackContainer.h
+         TrackControlInterface.h
+         TrackHeader.h
          TrackManager.h
+         TrackRenderHelper.h
          TrackTestData.h
          TranslationStack.h
          TriangleToggle.h
@@ -139,7 +142,9 @@ target_sources(
           TracepointThreadBar.cpp
           Track.cpp
           TrackContainer.cpp
+          TrackHeader.cpp
           TrackManager.cpp
+          TrackRenderHelper.cpp
           TrackTestData.cpp
           TranslationStack.cpp
           TriangleToggle.cpp
@@ -215,6 +220,7 @@ target_sources(OrbitGlTests PRIVATE
                TimerInfosIteratorTest.cpp
                TranslationStackTest.cpp
                ThreadTrackTest.cpp
+               TrackHeaderTest.cpp
                TrackManagerTest.cpp
                ViewportTest.cpp)
 

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -34,9 +34,7 @@ GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent,
     : TimerTrack(parent, timeline_info, viewport, layout, app, module_manager, capture_data,
                  timer_data),
       string_manager_{app->GetStringManager()},
-      timeline_hash_{timeline_hash} {
-  draw_background_ = false;
-}
+      timeline_hash_{timeline_hash} {}
 
 std::string GpuDebugMarkerTrack::GetName() const {
   return absl::StrFormat(

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -40,9 +40,7 @@ GpuSubmissionTrack::GpuSubmissionTrack(Track* parent,
                  timer_data),
       timeline_hash_{timeline_hash},
       string_manager_{app->GetStringManager()},
-      parent_{parent} {
-  draw_background_ = false;
-}
+      parent_{parent} {}
 
 std::string GpuSubmissionTrack::GetName() const {
   return absl::StrFormat(

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -181,7 +181,7 @@ float GpuSubmissionTrack::GetHeight() const {
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
     depth *= 2;
   }
-  return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
+  return header_->GetHeight() + layout_->GetTrackContentTopMargin() +
          layout_->GetTextBoxHeight() * depth + (num_gaps * layout_->GetSpaceBetweenGpuDepths()) +
          layout_->GetTrackContentBottomMargin();
 }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -226,7 +226,8 @@ void GraphTrack<Dimension>::DrawLegend(PrimitiveAssembler& primitive_assembler,
   const float legend_symbol_height = GetLegendHeight();
   const float legend_symbol_width = legend_symbol_height;
   float x0 = GetPos()[0] + layout_->GetRightMargin();
-  const float y0 = GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
+  const float y0 =
+      header_->GetPos()[1] + header_->GetHeight() + layout_->GetTrackContentTopMargin();
   uint32_t font_size = GetLegendFontSize(indentation_level_);
   const Color kFullyTransparent(255, 255, 255, 0);
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -281,10 +281,7 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   tracepoint_bar_->SetPos(pos[0], current_y);
 }
 
-void ThreadTrack::OnPick(int x, int y) {
-  Track::OnPick(x, y);
-  app_->set_selected_thread_id(GetThreadId());
-}
+void ThreadTrack::SelectTrack() { app_->set_selected_thread_id(GetThreadId()); }
 
 std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetAllChildren() const {
   auto result = Track::GetAllChildren();

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -266,7 +266,8 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   const float space_between_subtracks = layout_->GetSpaceBetweenThreadPanes();
 
   const Vec2 pos = GetPos();
-  float current_y = pos[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
+  float current_y =
+      header_->GetPos()[1] + header_->GetHeight() + layout_->GetTrackContentTopMargin();
 
   thread_state_bar_->SetPos(pos[0], current_y);
   if (thread_state_bar_->ShouldBeRendered()) {
@@ -334,7 +335,7 @@ float ThreadTrack::GetHeightAboveTimers() const {
   const float tracepoint_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const float space_between_subtracks = layout_->GetSpaceBetweenThreadPanes();
 
-  float header_height = layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
+  float header_height = header_->GetHeight() + layout_->GetTrackContentTopMargin();
   int track_count = 0;
   if (!thread_state_bar_->IsEmpty()) {
     header_height += thread_state_track_height;

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -69,7 +69,7 @@ class ThreadTrack final : public TimerTrack {
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
 
-  void OnPick(int x, int y) override;
+  void SelectTrack() override;
 
   [[nodiscard]] bool IsEmpty() const override;
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -381,7 +381,7 @@ std::string TimerTrack::GetBoxTooltip(const PrimitiveAssembler& /*primitive_asse
 }
 
 float TimerTrack::GetHeightAboveTimers() const {
-  return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin();
+  return header_->GetHeight() + layout_->GetTrackContentTopMargin();
 }
 
 internal::DrawData TimerTrack::GetDrawData(

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -15,6 +15,7 @@
 #include "OrbitBase/ThreadUtils.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
+#include "TrackRenderHelper.h"
 #include "Viewport.h"
 
 using orbit_client_data::TimerData;
@@ -30,75 +31,12 @@ Track::Track(CaptureViewElement* parent, const orbit_gl::TimelineInfoInterface* 
       timeline_info_(timeline_info),
       module_manager_(module_manager),
       capture_data_(capture_data) {
-  collapse_toggle_ = std::make_shared<TriangleToggle>(
-      this, viewport, layout, [this](bool /*is_collapsed*/) { RequestUpdate(); });
+  header_ = std::make_shared<orbit_gl::TrackHeader>(this, viewport, layout, this);
 }
 
-std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
-  std::vector<Vec2> points;
-  points.emplace_back(0.f, 0.f);
-  points.emplace_back(0.f, radius);
-
-  float increment_radians = 0.5f * kPiFloat / static_cast<float>(num_sides);
-  for (uint32_t i = 1; i < num_sides; ++i) {
-    float angle = kPiFloat + static_cast<float>(i) * increment_radians;
-    points.emplace_back(radius * cosf(angle) + radius, radius * sinf(angle) + radius);
-  }
-
-  points.emplace_back(radius, 0.f);
-  return points;
-}
-
-std::vector<Vec2> RotatePoints(const std::vector<Vec2>& points, float rotation) {
-  float cos_r = cosf(kPiFloat * rotation / 180.f);
-  float sin_r = sinf(kPiFloat * rotation / 180.f);
-  std::vector<Vec2> result;
-  for (const Vec2& point : points) {
-    float x_rotated = cos_r * point[0] + sin_r * point[1];
-    float y_rotated = sin_r * point[0] - cos_r * point[1];
-    result.emplace_back(x_rotated, y_rotated);
-  }
-  return result;
-}
-
-void Track::DrawTriangleFan(PrimitiveAssembler& primitive_assembler,
-                            const std::vector<Vec2>& points, const Vec2& pos, const Color& color,
-                            float rotation, float z) {
-  if (points.size() < 3) {
-    return;
-  }
-
-  std::vector<Vec2> rotated_points = RotatePoints(points, rotation);
-  Vec3 position(pos[0], pos[1], z);
-  Vec3 pivot = position + Vec3(rotated_points[0][0], rotated_points[0][1], z);
-
-  Vec3 vertices[2];
-  vertices[0] = position + Vec3(rotated_points[1][0], rotated_points[1][1], z);
-
-  for (size_t i = 1; i < rotated_points.size() - 1; ++i) {
-    vertices[i % 2] = position + Vec3(rotated_points[i + 1][0], rotated_points[i + 1][1], z);
-    Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);
-    primitive_assembler.AddTriangle(triangle, color, shared_from_this());
-  }
-}
-
-void Track::UpdatePositionOfCollapseToggle() {
-  const float label_height = layout_->GetTrackTabHeight();
-  const float half_label_height = 0.5f * label_height;
-  const float x0 = GetPos()[0] + layout_->GetTrackTabOffset() +
-                   layout_->GetTrackIndentOffset() * indentation_level_;
-  const float button_offset = layout_->GetCollapseButtonOffset();
-  const float toggle_y_pos = GetPos()[1] + half_label_height;
-  Vec2 toggle_pos = Vec2(x0 + button_offset, toggle_y_pos);
-
-  float size = layout_->GetCollapseButtonSize(indentation_level_);
-  collapse_toggle_->SetWidth(size);
-  collapse_toggle_->SetHeight(size);
-  collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1]);
-
-  // This makes sure that changes to the track "collapsible" property are correctly
-  // disabling the triangle toggle, even if they change during runtime.
-  collapse_toggle_->SetIsCollapsible(IsCollapsible());
+void Track::OnPick(int x, int y) {
+  CaptureViewElement::OnPick(x, y);
+  SelectTrack();
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> Track::CreateAccessibleInterface() {
@@ -109,111 +47,79 @@ void Track::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_r
                    const DrawContext& draw_context) {
   CaptureViewElement::DoDraw(primitive_assembler, text_renderer, draw_context);
 
-  if (headless_) return;
-
+  // An indentation level > 0 means this track is nested under a parent track. In this case, we
+  // don't want to draw any background for this track.
+  const bool draw_background = GetIndentationLevel() == 0 && layout_->GetDrawTrackBackground();
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
+
+  // Tab and content are handled by child elements or inheriting classes, so we can early-out here
+  // if we don't need to draw any tab background.
+  // Same for picking - the track background is not pickable
+  if (picking || !draw_background) return;
 
   const float x0 = GetPos()[0];
   const float y0 = GetPos()[1];
-  float track_z = GlCanvas::kZValueTrack;
-  float text_z = GlCanvas::kZValueTrackText;
+  const float header_height = header_->GetHeight();
+  const float track_z = GlCanvas::kZValueTrack;
 
   Color track_background_color = GetTrackBackgroundColor();
-  if (!draw_background_) {
-    track_background_color[3] = 0;
-  }
-
-  // Draw tab.
-  float label_height = layout_->GetTrackTabHeight();
-  float half_label_height = 0.5f * label_height;
-  float label_width = layout_->GetTrackTabWidth();
-  float half_label_width = 0.5f * label_width;
-  float tab_x0 = x0 + layout_->GetTrackTabOffset();
-
-  const float indentation_x0 = tab_x0 + (indentation_level_ * layout_->GetTrackIndentOffset());
-  Tetragon box = MakeBox(Vec2(indentation_x0, y0), Vec2(label_width, label_height), track_z);
-  primitive_assembler.AddBox(box, track_background_color, shared_from_this());
 
   Vec2 track_size = GetSize();
 
   // Draw rounded corners.
-  if (!picking && draw_background_) {
-    float radius = std::min(layout_->GetRoundingRadius(), half_label_height);
-    radius = std::min(radius, half_label_width);
-    uint32_t sides = static_cast<uint32_t>(layout_->GetRoundingNumSides() + 0.5f);
-    auto rounded_corner = GetRoundedCornerMask(radius, sides);
+  float radius = std::min(layout_->GetRoundingRadius(), layout_->GetTrackTabHeight() * 0.5f);
+  uint32_t sides = static_cast<uint32_t>(layout_->GetRoundingNumSides() + 0.5f);
+  auto rounded_corner = orbit_gl::GetRoundedCornerMask(radius, sides);
 
-    // top_left       tab_top_right
-    //  __________________              content_top_right
-    // /                  \_______________
-    // |             tab_bottom_right     `
-    // |XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
-    // \__________________________________/
-    // content_bottom_left                      content_bottom_right
-    //
-    // In addition, there is a small margin before and after the track content
-    // defined by TrackContentTopMargin and TrackContentBottomMargin.
-    // Both margins are factored into the total height of each track.
-    Vec2 top_left(indentation_x0, y0);
-    Vec2 tab_top_right(top_left[0] + label_width, top_left[1]);
-    Vec2 tab_bottom_right(top_left[0] + label_width, top_left[1] + label_height);
-    Vec2 content_bottom_left(top_left[0] - tab_x0, top_left[1] + track_size[1]);
-    Vec2 content_bottom_right(top_left[0] + track_size[0], top_left[1] + track_size[1]);
-    Vec2 content_top_right(top_left[0] + track_size[0], top_left[1] + label_height);
+  // This draws the non-tab content of the track. The tab itself is a separate CaptureViewElement
+  // child of the track.
+  // Note that the top-left corner is not rounded due to the design of the track tab sitting
+  // in the top left.
+  //
+  // [ Header ] ________________________  content_top_right
+  // |                                  `
+  // |XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
+  // \__________________________________/
+  // content_bottom_left                 content_bottom_right
+  //
+  Vec2 content_bottom_left(x0, y0 + track_size[1]);
+  Vec2 content_bottom_right(x0 + track_size[0], y0 + track_size[1]);
 
-    DrawTriangleFan(primitive_assembler, rounded_corner, top_left, GlCanvas::kBackgroundColor, 90.f,
-                    track_z);
-    DrawTriangleFan(primitive_assembler, rounded_corner, tab_top_right, GlCanvas::kBackgroundColor,
-                    180.f, track_z);
-    DrawTriangleFan(primitive_assembler, rounded_corner, tab_bottom_right, track_background_color,
-                    0, track_z);
-    DrawTriangleFan(primitive_assembler, rounded_corner, content_bottom_left,
-                    GlCanvas::kBackgroundColor, 0, track_z);
-    DrawTriangleFan(primitive_assembler, rounded_corner, content_bottom_right,
-                    GlCanvas::kBackgroundColor, -90.f, track_z);
-    DrawTriangleFan(primitive_assembler, rounded_corner, content_top_right,
-                    GlCanvas::kBackgroundColor, 180.f, track_z);
-  }
+  // The track content starts underneath the track header, and we only draw the background
+  // starting
+  // there. This could be prevented by moving the track content into a separate child, but in the
+  // end, the design of track and track header will need to influence each other...
+  Vec2 content_top_right(x0 + track_size[0], y0 + header_height);
+  Vec2 content_top_left(x0, y0 + header_height);
 
-  // Draw label.
-  if (!picking) {
-    uint32_t font_size = layout_->CalculateZoomedFontSize();
-    // For the first 5 indentations, we decrease the font_size by 10 percent points (per
-    // indentation).
-    constexpr uint32_t kMaxIndentationLevel = 5;
-    uint32_t capped_indentation_level = std::min(indentation_level_, kMaxIndentationLevel);
-    font_size = (font_size * (10 - capped_indentation_level)) / 10;
-    float label_offset_x = layout_->GetTrackLabelOffsetX();
-
-    const Color kColor =
-        IsTrackSelected() ? GlCanvas::kTabTextColorSelected : Color(255, 255, 255, 255);
-
-    TextRenderer::TextFormatting formatting{font_size, kColor, label_width - label_offset_x};
-    formatting.valign = TextRenderer::VAlign::Middle;
-
-    text_renderer.AddTextTrailingCharsPrioritized(
-        GetLabel().c_str(), indentation_x0 + label_offset_x, y0 + half_label_height, text_z,
-        formatting, GetNumberOfPrioritizedTrailingCharacters());
-  }
+  auto shared_this = shared_from_this();
+  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_bottom_left,
+                            GlCanvas::kBackgroundColor, 0, track_z, shared_this);
+  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_bottom_right,
+                            GlCanvas::kBackgroundColor, -90.f, track_z, shared_this);
+  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_top_right,
+                            GlCanvas::kBackgroundColor, 180.f, track_z, shared_this);
 
   // Draw track's content background.
-  if (!picking) {
-    if (layout_->GetDrawTrackBackground()) {
-      Tetragon box = MakeBox(Vec2(x0, y0 + label_height),
-                             Vec2(GetWidth(), GetHeight() - label_height), track_z);
-      primitive_assembler.AddBox(box, track_background_color, shared_from_this());
-    }
-  }
+  Tetragon box = MakeBox(content_top_left, Vec2(GetWidth(), GetHeight() - header_height), track_z);
+  primitive_assembler.AddBox(box, track_background_color, shared_from_this());
 }
 
 void Track::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 
+  header_->SetWidth(layout_->GetTrackTabWidth());
+  header_->SetPos(GetPos()[0] + layout_->GetTrackTabOffset(), GetPos()[1]);
   UpdatePositionOfSubtracks();
-  UpdatePositionOfCollapseToggle();
 }
 
 void Track::SetPinned(bool value) { pinned_ = value; }
+
+void Track::DragBy(float delta_y) {
+  if (!Draggable()) return;
+
+  SetPos(GetPos()[0], GetPos()[1] + delta_y);
+}
 
 Color Track::GetTrackBackgroundColor() const {
   uint32_t capture_process_id = capture_data_->process_id();
@@ -243,7 +149,7 @@ float Track::DetermineZOffset() const {
 }
 
 void Track::SetCollapsed(bool collapsed) {
-  collapse_toggle_->SetCollapsed(collapsed);
+  header_->GetCollapseToggle()->SetCollapsed(collapsed);
 
   RequestUpdate();
 }
@@ -252,7 +158,7 @@ void Track::SetHeadless(bool value) {
   if (headless_ == value) return;
 
   headless_ = value;
-  collapse_toggle_->SetVisible(!headless_);
+  header_->SetVisible(!value);
   RequestUpdate();
 }
 
@@ -261,10 +167,4 @@ void Track::SetIndentationLevel(uint32_t level) {
 
   indentation_level_ = level;
   RequestUpdate();
-}
-
-void Track::OnDrag(int x, int y) {
-  CaptureViewElement::OnDrag(x, y);
-
-  SetPos(GetPos()[0], mouse_pos_cur_[1] - picking_offset_[1]);
 }

--- a/src/OrbitGl/TrackControlInterface.h
+++ b/src/OrbitGl/TrackControlInterface.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TRACK_CONTROL_INTERFACE_H_
+#define ORBIT_GL_TRACK_CONTROL_INTERFACE_H_
+
+#include <string>
+
+#include "Geometry.h"
+
+namespace orbit_gl {
+
+// Interface to query and control track behavior. Used to decouple Track from TrackHeader.
+// It is expected that TrackHeader will receive more functionality (e.g. hiding / pinning tracks) in
+// the future, which will move more methods into this interface.
+class TrackControlInterface {
+ public:
+  [[nodiscard]] virtual bool IsPinned() const = 0;
+  virtual void SetPinned(bool value) = 0;
+
+  [[nodiscard]] virtual std::string GetLabel() const = 0;
+  [[nodiscard]] virtual std::string GetName() const = 0;
+  [[nodiscard]] virtual int GetNumberOfPrioritizedTrailingCharacters() const = 0;
+  [[nodiscard]] virtual Color GetTrackBackgroundColor() const = 0;
+  [[nodiscard]] virtual uint32_t GetIndentationLevel() const = 0;
+
+  [[nodiscard]] virtual bool IsCollapsible() const = 0;
+  [[nodiscard]] virtual bool Draggable() = 0;
+
+  [[nodiscard]] virtual bool IsTrackSelected() const = 0;
+  virtual void SelectTrack() = 0;
+
+  virtual void DragBy(float delta_y) = 0;
+};
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/TrackControlInterface.h
+++ b/src/OrbitGl/TrackControlInterface.h
@@ -16,6 +16,8 @@ namespace orbit_gl {
 // the future, which will move more methods into this interface.
 class TrackControlInterface {
  public:
+  virtual ~TrackControlInterface() = default;
+
   [[nodiscard]] virtual bool IsPinned() const = 0;
   virtual void SetPinned(bool value) = 0;
 

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -70,8 +70,8 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
     //
     // top_left       tab_top_right
     //  __________________
-    // /                  \
-    // |__________________(
+    // /                   `
+    // |___________________(
     // [ Track content below]
 
     Vec2 top_left(indentation_x0, y0);

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TrackHeader.h"
+
+#include "AccessibleCaptureViewElement.h"
+#include "GlCanvas.h"
+#include "Track.h"
+#include "TrackRenderHelper.h"
+
+namespace orbit_gl {
+
+TrackHeader::TrackHeader(CaptureViewElement* parent, const Viewport* viewport,
+                         const TimeGraphLayout* layout, TrackControlInterface* track)
+    : CaptureViewElement(parent, viewport, layout), track_(track) {
+  ORBIT_CHECK(track_ != nullptr);
+  collapse_toggle_ = std::make_shared<TriangleToggle>(
+      this, viewport, layout, [this](bool /*is_collapsed*/) { RequestUpdate(); });
+}
+
+void TrackHeader::OnPick(int x, int y) {
+  CaptureViewElement::OnPick(x, y);
+
+  track_->SelectTrack();
+}
+
+std::unique_ptr<orbit_accessibility::AccessibleInterface> TrackHeader::CreateAccessibleInterface() {
+  return std::make_unique<orbit_gl::AccessibleCaptureViewElement>(
+      this, track_->GetName() + "_tab", orbit_accessibility::AccessibilityRole::PageTab);
+}
+
+void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
+                         const DrawContext& draw_context) {
+  CaptureViewElement::DoDraw(primitive_assembler, text_renderer, draw_context);
+
+  const bool picking = draw_context.picking_mode != PickingMode::kNone;
+
+  const float x0 = GetPos()[0];
+  const float y0 = GetPos()[1];
+  const float track_z = GlCanvas::kZValueTrack;
+  const float text_z = GlCanvas::kZValueTrackText;
+
+  // Draw tab background
+  const float label_height = GetHeight();
+  const float half_label_height = 0.5f * label_height;
+  const float label_width = GetWidth();
+  const float half_label_width = 0.5f * label_width;
+
+  const float indentation_x0 =
+      x0 + (track_->GetIndentationLevel() * layout_->GetTrackIndentOffset());
+  Tetragon box = MakeBox(Vec2(indentation_x0, y0), Vec2(label_width, label_height), track_z);
+  primitive_assembler.AddBox(box, track_->GetTrackBackgroundColor(), shared_from_this());
+
+  // Early-out: In picking mode, don't draw the text and rounded corners.
+  if (picking) {
+    return;
+  }
+
+  // Don't draw rounded corners when this track is a child of another track
+  if (track_->GetIndentationLevel() == 0) {
+    // Draw rounded corners.
+    float radius = std::min(layout_->GetRoundingRadius(), half_label_height);
+    radius = std::min(radius, half_label_width);
+    uint32_t sides = static_cast<uint32_t>(layout_->GetRoundingNumSides() + 0.5f);
+    auto rounded_corner = GetRoundedCornerMask(radius, sides);
+
+    // This only draw the tab-part of a track. It's expecting to sit on the top of the track.
+    // See comments in Track::DoDraw for a full picture.
+    //
+    // top_left       tab_top_right
+    //  __________________
+    // /                  \
+    // |__________________(
+    // [ Track content below]
+
+    Vec2 top_left(indentation_x0, y0);
+    Vec2 tab_top_right(top_left[0] + label_width, top_left[1]);
+    Vec2 tab_bottom_right(top_left[0] + label_width, top_left[1] + label_height);
+
+    auto shared_this = shared_from_this();
+    DrawTriangleFan(primitive_assembler, rounded_corner, top_left, GlCanvas::kBackgroundColor, 90.f,
+                    track_z, shared_this);
+    DrawTriangleFan(primitive_assembler, rounded_corner, tab_top_right, GlCanvas::kBackgroundColor,
+                    180.f, track_z, shared_this);
+    DrawTriangleFan(primitive_assembler, rounded_corner, tab_bottom_right,
+                    track_->GetTrackBackgroundColor(), 0, track_z, shared_this);
+  }
+
+  // Draw label.
+
+  uint32_t font_size = layout_->CalculateZoomedFontSize();
+  // For the first 5 indentations, we decrease the font_size by 10 percent points (per
+  // indentation).
+  constexpr uint32_t kMaxIndentationLevel = 5;
+  uint32_t capped_indentation_level = std::min(track_->GetIndentationLevel(), kMaxIndentationLevel);
+  font_size = (font_size * (10 - capped_indentation_level)) / 10;
+  float label_offset_x = layout_->GetTrackLabelOffsetX();
+
+  const Color kColor =
+      track_->IsTrackSelected() ? GlCanvas::kTabTextColorSelected : Color(255, 255, 255, 255);
+
+  TextRenderer::TextFormatting formatting{font_size, kColor, label_width - label_offset_x};
+  formatting.valign = TextRenderer::VAlign::Middle;
+
+  text_renderer.AddTextTrailingCharsPrioritized(
+      track_->GetLabel().c_str(), indentation_x0 + label_offset_x, y0 + half_label_height, text_z,
+      formatting, track_->GetNumberOfPrioritizedTrailingCharacters());
+}
+
+void orbit_gl::TrackHeader::DoUpdateLayout() {
+  CaptureViewElement::DoUpdateLayout();
+
+  UpdateCollapseToggle();
+}
+
+void TrackHeader::UpdateCollapseToggle() {
+  const float label_height = layout_->GetTrackTabHeight();
+  const float half_label_height = 0.5f * label_height;
+  const float x0 = GetPos()[0] + layout_->GetTrackTabOffset() +
+                   layout_->GetTrackIndentOffset() * track_->GetIndentationLevel();
+  const float button_offset = layout_->GetCollapseButtonOffset();
+  const float toggle_y_pos = GetPos()[1] + half_label_height;
+  Vec2 toggle_pos = Vec2(x0 + button_offset, toggle_y_pos);
+
+  float size = layout_->GetCollapseButtonSize(track_->GetIndentationLevel());
+  collapse_toggle_->SetWidth(size);
+  collapse_toggle_->SetHeight(size);
+  collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1]);
+
+  // Update the "collapsible" property of the triangle toggle to match the same property in the
+  // parent track. This makes sure that changes to the track "collapsible" property are correctly
+  // disabling the triangle toggle, even if they change during runtime.
+  collapse_toggle_->SetIsCollapsible(track_->IsCollapsible());
+}
+
+void TrackHeader::OnDrag(int x, int y) {
+  CaptureViewElement::OnDrag(x, y);
+
+  if (track_->Draggable()) {
+    track_->DragBy(mouse_pos_cur_[1] - picking_offset_[1] - GetPos()[1]);
+  }
+}
+
+bool TrackHeader::Draggable() { return track_->Draggable(); }
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/TrackHeader.h
+++ b/src/OrbitGl/TrackHeader.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TRACK_HEADER_H_
+#define ORBIT_GL_TRACK_HEADER_H_
+
+#include <memory>
+
+#include "CaptureViewElement.h"
+#include "OrbitBase/Logging.h"
+#include "TrackControlInterface.h"
+#include "TriangleToggle.h"
+
+namespace orbit_gl {
+
+// "Tab" element of the track. This encapsulates:
+// * Display of track title
+// * Collapse functionality
+// * Click-to-drag behavior
+class TrackHeader : public CaptureViewElement, public std::enable_shared_from_this<TrackHeader> {
+ public:
+  explicit TrackHeader(CaptureViewElement* parent, const Viewport* viewport,
+                       const TimeGraphLayout* layout, TrackControlInterface* track);
+
+  [[nodiscard]] const TriangleToggle* GetCollapseToggle() const { return collapse_toggle_.get(); }
+  [[nodiscard]] TriangleToggle* GetCollapseToggle() { return collapse_toggle_.get(); }
+
+  [[nodiscard]] float GetHeight() const override { return layout_->GetTrackTabHeight(); }
+  [[nodiscard]] uint32_t GetLayoutFlags() const override { return 0; }
+
+  void OnPick(int x, int y) override;
+
+  [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override {
+    return {collapse_toggle_.get()};
+  }
+
+  [[nodiscard]] std::string GetTooltip() const override { return GetParent()->GetTooltip(); }
+
+  void OnDrag(int x, int y) override;
+  [[nodiscard]] bool Draggable() override;
+
+  [[nodiscard]] bool IsBeingDragged() { return picked_ && mouse_pos_last_click_ != mouse_pos_cur_; }
+
+ protected:
+  void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
+              const DrawContext& draw_context) override;
+  void DoUpdateLayout() override;
+
+  void UpdateCollapseToggle();
+
+  std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
+
+ private:
+  std::shared_ptr<TriangleToggle> collapse_toggle_;
+  TrackControlInterface* track_;
+};
+
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/TrackHeaderTest.cpp
+++ b/src/OrbitGl/TrackHeaderTest.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "CaptureViewElementTester.h"
+#include "TrackControlInterface.h"
+#include "TrackHeader.h"
+
+namespace orbit_gl {
+
+using ::testing::Exactly;
+using testing::Return;
+
+class MockTrack : public TrackControlInterface {
+ public:
+  MOCK_METHOD(bool, IsPinned, (), (const override));
+  MOCK_METHOD(void, SetPinned, (bool), (override));
+
+  MOCK_METHOD(std ::string, GetLabel, (), (const override));
+  MOCK_METHOD(std::string, GetName, (), (const override));
+  MOCK_METHOD(int, GetNumberOfPrioritizedTrailingCharacters, (), (const override));
+  MOCK_METHOD(Color, GetTrackBackgroundColor, (), (const override));
+  MOCK_METHOD(uint32_t, GetIndentationLevel, (), (const override));
+
+  MOCK_METHOD(bool, IsCollapsible, (), (const override));
+  MOCK_METHOD(bool, Draggable, (), (override));
+
+  MOCK_METHOD(bool, IsTrackSelected, (), (const override));
+  MOCK_METHOD(void, SelectTrack, (), (override));
+
+  MOCK_METHOD(void, DragBy, (float), (override));
+};
+
+TEST(TrackHeader, TrackHeaderDragsTheTrack) {
+  CaptureViewElementTester tester;
+
+  MockTrack track;
+  const int kDelta = 5;
+
+  EXPECT_CALL(track, DragBy(kDelta)).Times(Exactly(2));
+  EXPECT_CALL(track, Draggable()).Times(Exactly(2)).WillRepeatedly(Return(true));
+
+  TrackHeader header(nullptr, tester.GetViewport(), tester.GetLayout(), &track);
+  header.UpdateLayout();
+
+  header.OnPick(0, 0);
+  header.OnDrag(0, kDelta);
+  header.OnDrag(0, kDelta);
+  header.OnRelease();
+}
+
+TEST(TrackHeader, TrackHeaderDoesNotDragNonDraggableTracks) {
+  CaptureViewElementTester tester;
+
+  MockTrack track;
+  const int kDelta = 5;
+
+  EXPECT_CALL(track, DragBy(kDelta)).Times(Exactly(0));
+  EXPECT_CALL(track, Draggable()).Times(Exactly(2)).WillRepeatedly(Return(false));
+
+  TrackHeader header(nullptr, tester.GetViewport(), tester.GetLayout(), &track);
+  header.UpdateLayout();
+
+  header.OnPick(0, 0);
+  header.OnDrag(0, kDelta);
+  header.OnDrag(0, kDelta);
+  header.OnRelease();
+}
+
+TEST(TrackHeader, ClickingTrackHeadersSelectsTheTrack) {
+  CaptureViewElementTester tester;
+
+  MockTrack track;
+
+  EXPECT_CALL(track, SelectTrack()).Times(Exactly(1));
+
+  TrackHeader header(nullptr, tester.GetViewport(), tester.GetLayout(), &track);
+  header.UpdateLayout();
+
+  header.OnPick(0, 0);
+  header.OnRelease();
+}
+
+TEST(TrackHeader, CollapseToggleWorksForCollapsibleTracks) {
+  CaptureViewElementTester tester;
+
+  MockTrack track;
+
+  EXPECT_CALL(track, IsCollapsible()).WillRepeatedly(Return(true));
+
+  TrackHeader header(nullptr, tester.GetViewport(), tester.GetLayout(), &track);
+  header.UpdateLayout();
+
+  TriangleToggle* toggle = header.GetCollapseToggle();
+  EXPECT_TRUE(toggle->IsCollapsible());
+  EXPECT_FALSE(toggle->IsCollapsed());
+
+  toggle->OnPick(0, 0);
+  toggle->OnRelease();
+
+  EXPECT_TRUE(toggle->IsCollapsed());
+}
+
+TEST(TrackHeader, CollapseToggleDoesNotWorkForNonCollapsibleTracks) {
+  CaptureViewElementTester tester;
+
+  MockTrack track;
+
+  EXPECT_CALL(track, IsCollapsible()).WillRepeatedly(Return(false));
+
+  TrackHeader header(nullptr, tester.GetViewport(), tester.GetLayout(), &track);
+  header.UpdateLayout();
+
+  TriangleToggle* toggle = header.GetCollapseToggle();
+  EXPECT_FALSE(toggle->IsCollapsible());
+  EXPECT_FALSE(toggle->IsCollapsed());
+
+  toggle->OnPick(0, 0);
+  toggle->OnRelease();
+
+  EXPECT_FALSE(toggle->IsCollapsed());
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/TrackRenderHelper.cpp
+++ b/src/OrbitGl/TrackRenderHelper.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TrackRenderHelper.h"
+
+namespace {
+
+std::vector<Vec2> RotatePoints(const std::vector<Vec2>& points, float rotation) {
+  float cos_r = cosf(kPiFloat * rotation / 180.f);
+  float sin_r = sinf(kPiFloat * rotation / 180.f);
+  std::vector<Vec2> result;
+  for (const Vec2& point : points) {
+    float x_rotated = cos_r * point[0] + sin_r * point[1];
+    float y_rotated = sin_r * point[0] - cos_r * point[1];
+    result.emplace_back(x_rotated, y_rotated);
+  }
+  return result;
+}
+
+}  // namespace
+
+namespace orbit_gl {
+
+std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
+  std::vector<Vec2> points;
+  points.emplace_back(0.f, 0.f);
+  points.emplace_back(0.f, radius);
+
+  float increment_radians = 0.5f * kPiFloat / static_cast<float>(num_sides);
+  for (uint32_t i = 1; i < num_sides; ++i) {
+    float angle = kPiFloat + static_cast<float>(i) * increment_radians;
+    points.emplace_back(radius * cosf(angle) + radius, radius * sinf(angle) + radius);
+  }
+
+  points.emplace_back(radius, 0.f);
+  return points;
+}
+
+void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, const std::vector<Vec2>& points,
+                     const Vec2& pos, const Color& color, float rotation, float z,
+                     std::shared_ptr<Pickable> pickable) {
+  if (points.size() < 3) {
+    return;
+  }
+
+  std::vector<Vec2> rotated_points = RotatePoints(points, rotation);
+  Vec3 position(pos[0], pos[1], z);
+  Vec3 pivot = position + Vec3(rotated_points[0][0], rotated_points[0][1], z);
+
+  Vec3 vertices[2];
+  vertices[0] = position + Vec3(rotated_points[1][0], rotated_points[1][1], z);
+
+  for (size_t i = 1; i < rotated_points.size() - 1; ++i) {
+    vertices[i % 2] = position + Vec3(rotated_points[i + 1][0], rotated_points[i + 1][1], z);
+    Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);
+    primitive_assembler.AddTriangle(triangle, color, pickable);
+  }
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/TrackRenderHelper.h
+++ b/src/OrbitGl/TrackRenderHelper.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TRACK_RENDER_HELPER_H_
+#define ORBIT_GL_TRACK_RENDER_HELPER_H_
+
+#include <vector>
+
+#include "CoreMath.h"
+#include "PickingManager.h"
+#include "PrimitiveAssembler.h"
+
+// Contains free functions used to render track elements such as rounded corners.
+namespace orbit_gl {
+void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, const std::vector<Vec2>& points,
+                     const Vec2& pos, const Color& color, float rotation, float z,
+                     std::shared_ptr<Pickable> pickable);
+[[nodiscard]] std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides);
+}  // namespace orbit_gl
+
+#endif


### PR DESCRIPTION
We're currently rendering the track as a single element, but expose it as a
composition of track, tab and timer pane in E2E tests. As a first step to fix
this, the tab is now converted to an actual `CaptureViewElement`.

The new `TrackHeader` expects to be parented under a `Track`, and construction
will fail if the parent is not of type `Track`. This allows us to directly interact with
the parent through the more specialized `Track` API.

While this to some extent breaks the generic parent / child relationship, it is
IMO a common restriction that certain UI elements have to live as children of
specific parents, and I think it's an acceptable solution. Let me know if there's
other ideas.

Bug: b/185854980
Tests: E2E test "orbit_tracks" works, and manual testing.