### PR TITLE
Show capture length in the load capture widget

### DIFF
--- a/src/CaptureFileInfo/CaptureFileInfo.cpp
+++ b/src/CaptureFileInfo/CaptureFileInfo.cpp
@@ -6,11 +6,12 @@
 
 namespace orbit_capture_file_info {
 
-CaptureFileInfo::CaptureFileInfo(const QString& path)
-    : file_info_(path), last_used_(QDateTime::currentDateTime()) {}
+CaptureFileInfo::CaptureFileInfo(const QString& path, absl::Duration capture_length)
+    : file_info_(path), last_used_(QDateTime::currentDateTime()), capture_length_(capture_length) {}
 
-CaptureFileInfo::CaptureFileInfo(const QString& path, QDateTime last_used)
-    : file_info_(path), last_used_(std::move(last_used)) {}
+CaptureFileInfo::CaptureFileInfo(const QString& path, QDateTime last_used,
+                                 absl::Duration capture_length)
+    : file_info_(path), last_used_(std::move(last_used)), capture_length_(capture_length) {}
 
 bool CaptureFileInfo::FileExists() const { return file_info_.exists() && file_info_.isFile(); }
 

--- a/src/CaptureFileInfo/CaptureFileInfo.cpp
+++ b/src/CaptureFileInfo/CaptureFileInfo.cpp
@@ -6,11 +6,11 @@
 
 namespace orbit_capture_file_info {
 
-CaptureFileInfo::CaptureFileInfo(const QString& path, absl::Duration capture_length)
+CaptureFileInfo::CaptureFileInfo(const QString& path, std::optional<absl::Duration> capture_length)
     : file_info_(path), last_used_(QDateTime::currentDateTime()), capture_length_(capture_length) {}
 
 CaptureFileInfo::CaptureFileInfo(const QString& path, QDateTime last_used,
-                                 absl::Duration capture_length)
+                                 std::optional<absl::Duration> capture_length)
     : file_info_(path), last_used_(std::move(last_used)), capture_length_(capture_length) {}
 
 bool CaptureFileInfo::FileExists() const { return file_info_.exists() && file_info_.isFile(); }

--- a/src/CaptureFileInfo/CaptureFileInfo.cpp
+++ b/src/CaptureFileInfo/CaptureFileInfo.cpp
@@ -7,14 +7,45 @@
 namespace orbit_capture_file_info {
 
 CaptureFileInfo::CaptureFileInfo(const QString& path, std::optional<absl::Duration> capture_length)
-    : file_info_(path), last_used_(QDateTime::currentDateTime()), capture_length_(capture_length) {}
+    : file_info_(path),
+      last_used_(QDateTime::currentDateTime()),
+      last_modified_(file_info_.lastModified()),
+      file_size_(file_info_.size()),
+      capture_length_(capture_length) {}
 
 CaptureFileInfo::CaptureFileInfo(const QString& path, QDateTime last_used,
                                  std::optional<absl::Duration> capture_length)
-    : file_info_(path), last_used_(std::move(last_used)), capture_length_(capture_length) {}
+    : file_info_(path),
+      last_used_(std::move(last_used)),
+      last_modified_(file_info_.lastModified()),
+      file_size_(file_info_.size()),
+      capture_length_(capture_length) {}
+
+CaptureFileInfo::CaptureFileInfo(const QString& path, QDateTime last_used, QDateTime last_modified,
+                                 uint64_t file_size, std::optional<absl::Duration> capture_length)
+    : file_info_(path),
+      last_used_(std::move(last_used)),
+      last_modified_(std::move(last_modified)),
+      file_size_(file_size),
+      capture_length_(capture_length) {}
 
 bool CaptureFileInfo::FileExists() const { return file_info_.exists() && file_info_.isFile(); }
 
-uint64_t CaptureFileInfo::FileSize() const { return file_info_.size(); }
+bool CaptureFileInfo::IsOutOfSync() const {
+  return file_size_ != static_cast<uint64_t>(file_info_.size()) ||
+         last_modified_ != file_info_.lastModified();
+}
+
+void CaptureFileInfo::Touch() {
+  last_used_ = QDateTime::currentDateTime();
+
+  // Note that QFileInfo is not synchronized, it reads the information from the file system when it
+  // is created when caching is enabled (by default). We need to call refresh() to refresh the file
+  // information from the file system. See QFileInfo::refresh() and QFileInfo::setCaching() for more
+  // details.
+  file_info_.refresh();
+  last_modified_ = file_info_.lastModified();
+  file_size_ = static_cast<uint64_t>(file_info_.size());
+}
 
 }  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/CaptureFileInfoTest.cpp
+++ b/src/CaptureFileInfo/CaptureFileInfoTest.cpp
@@ -68,7 +68,7 @@ TEST(CaptureFileInfo, FullInfoConstructorAndIsOutOfSync) {
   EXPECT_EQ(capture_file_info.FileSize(), kFileSize);
   EXPECT_EQ(capture_file_info.CaptureLength().value(), kCaptureLength);
 
-  // The file size and the last modified time we provided to construct the CaptureFileInfo donnot
+  // The file size and the last modified time we provided to construct the CaptureFileInfo do not
   // match with the information retrieved from the file system. Hence they are out of sync with the
   // associated file.
   EXPECT_TRUE(capture_file_info.IsOutOfSync());

--- a/src/CaptureFileInfo/CaptureFileInfoTest.cpp
+++ b/src/CaptureFileInfo/CaptureFileInfoTest.cpp
@@ -22,7 +22,7 @@ TEST(CaptureFileInfo, PathConstructor) {
 
   EXPECT_EQ(capture_file_info.FilePath(), kFullPath);
   EXPECT_EQ(capture_file_info.FileName(), kFileName);
-  EXPECT_EQ(capture_file_info.CaptureLength(), kCaptureLength);
+  EXPECT_EQ(capture_file_info.CaptureLength().value(), kCaptureLength);
 
   // LastUsed() before or equal to now.
   EXPECT_LE(capture_file_info.LastUsed(), QDateTime::currentDateTime());
@@ -39,7 +39,7 @@ TEST(CaptureFileInfo, PathLastUsedConstructor) {
 
   EXPECT_EQ(capture_file_info.FilePath(), kFullPath);
   EXPECT_EQ(capture_file_info.FileName(), kFileName);
-  EXPECT_EQ(capture_file_info.CaptureLength(), kCaptureLength);
+  EXPECT_EQ(capture_file_info.CaptureLength().value(), kCaptureLength);
 
   EXPECT_EQ(capture_file_info.LastUsed(), last_used);
 }
@@ -48,8 +48,7 @@ TEST(CaptureFileInfo, FileExistsAndCreated) {
   {
     const std::filesystem::path path = orbit_test::GetTestdataDir() / "test_file.txt";
 
-    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()),
-                                      CaptureFileInfo::kMissingCaptureLengthValue};
+    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()), std::nullopt};
 
     ASSERT_TRUE(capture_file_info.FileExists());
 
@@ -60,8 +59,7 @@ TEST(CaptureFileInfo, FileExistsAndCreated) {
   {
     const std::filesystem::path path = orbit_test::GetTestdataDir() / "not_existing_test_file.txt";
 
-    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()),
-                                      CaptureFileInfo::kMissingCaptureLengthValue};
+    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()), std::nullopt};
 
     ASSERT_FALSE(capture_file_info.FileExists());
 
@@ -74,7 +72,7 @@ TEST(CaptureFileInfo, Touch) {
   const QString path{"test/path/file.ext"};
   const QDateTime last_used = QDateTime::fromMSecsSinceEpoch(1600000000000);
 
-  CaptureFileInfo capture_file_info{path, last_used, CaptureFileInfo::kMissingCaptureLengthValue};
+  CaptureFileInfo capture_file_info{path, last_used, std::nullopt};
 
   EXPECT_EQ(capture_file_info.LastUsed(), last_used);
 
@@ -93,16 +91,15 @@ TEST(CaptureFileInfo, FileSize) {
   {
     const QString non_existing_path{"test/path/file.ext"};
 
-    CaptureFileInfo capture_file_info{non_existing_path,
-                                      CaptureFileInfo::kMissingCaptureLengthValue};
+    CaptureFileInfo capture_file_info{non_existing_path, std::nullopt};
 
     EXPECT_EQ(capture_file_info.FileSize(), 0);
   }
+
   {
     const std::filesystem::path path = orbit_test::GetTestdataDir() / "test_file.txt";
 
-    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()),
-                                      CaptureFileInfo::kMissingCaptureLengthValue};
+    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()), std::nullopt};
 
     // Not testing exact file size here, because it might be slightly different on windows and linux
     EXPECT_GT(capture_file_info.FileSize(), 0);

--- a/src/CaptureFileInfo/CaptureFileInfoTest.cpp
+++ b/src/CaptureFileInfo/CaptureFileInfoTest.cpp
@@ -16,11 +16,13 @@ TEST(CaptureFileInfo, PathConstructor) {
   const QString kParentPath{"this/is/a/test/path/"};
   const QString kFileName{"example file name.extension"};
   const QString kFullPath{kParentPath + kFileName};
+  const absl::Duration kCaptureLength{absl::Seconds(10)};
 
-  CaptureFileInfo capture_file_info{kFullPath};
+  CaptureFileInfo capture_file_info{kFullPath, kCaptureLength};
 
   EXPECT_EQ(capture_file_info.FilePath(), kFullPath);
   EXPECT_EQ(capture_file_info.FileName(), kFileName);
+  EXPECT_EQ(capture_file_info.CaptureLength(), kCaptureLength);
 
   // LastUsed() before or equal to now.
   EXPECT_LE(capture_file_info.LastUsed(), QDateTime::currentDateTime());
@@ -31,11 +33,13 @@ TEST(CaptureFileInfo, PathLastUsedConstructor) {
   const QString kFileName{"example file name.extension"};
   const QString kFullPath{kParentPath + kFileName};
   const QDateTime last_used = QDateTime::fromMSecsSinceEpoch(1600000000000);
+  const absl::Duration kCaptureLength{absl::Seconds(5)};
 
-  CaptureFileInfo capture_file_info{kFullPath, last_used};
+  CaptureFileInfo capture_file_info{kFullPath, last_used, kCaptureLength};
 
   EXPECT_EQ(capture_file_info.FilePath(), kFullPath);
   EXPECT_EQ(capture_file_info.FileName(), kFileName);
+  EXPECT_EQ(capture_file_info.CaptureLength(), kCaptureLength);
 
   EXPECT_EQ(capture_file_info.LastUsed(), last_used);
 }
@@ -44,7 +48,8 @@ TEST(CaptureFileInfo, FileExistsAndCreated) {
   {
     const std::filesystem::path path = orbit_test::GetTestdataDir() / "test_file.txt";
 
-    CaptureFileInfo capture_file_info{QString::fromStdString(path.string())};
+    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()),
+                                      CaptureFileInfo::kMissingCaptureLengthValue};
 
     ASSERT_TRUE(capture_file_info.FileExists());
 
@@ -55,7 +60,8 @@ TEST(CaptureFileInfo, FileExistsAndCreated) {
   {
     const std::filesystem::path path = orbit_test::GetTestdataDir() / "not_existing_test_file.txt";
 
-    CaptureFileInfo capture_file_info{QString::fromStdString(path.string())};
+    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()),
+                                      CaptureFileInfo::kMissingCaptureLengthValue};
 
     ASSERT_FALSE(capture_file_info.FileExists());
 
@@ -68,7 +74,7 @@ TEST(CaptureFileInfo, Touch) {
   const QString path{"test/path/file.ext"};
   const QDateTime last_used = QDateTime::fromMSecsSinceEpoch(1600000000000);
 
-  CaptureFileInfo capture_file_info{path, last_used};
+  CaptureFileInfo capture_file_info{path, last_used, CaptureFileInfo::kMissingCaptureLengthValue};
 
   EXPECT_EQ(capture_file_info.LastUsed(), last_used);
 
@@ -87,14 +93,16 @@ TEST(CaptureFileInfo, FileSize) {
   {
     const QString non_existing_path{"test/path/file.ext"};
 
-    CaptureFileInfo capture_file_info{non_existing_path};
+    CaptureFileInfo capture_file_info{non_existing_path,
+                                      CaptureFileInfo::kMissingCaptureLengthValue};
 
     EXPECT_EQ(capture_file_info.FileSize(), 0);
   }
   {
     const std::filesystem::path path = orbit_test::GetTestdataDir() / "test_file.txt";
 
-    CaptureFileInfo capture_file_info{QString::fromStdString(path.string())};
+    CaptureFileInfo capture_file_info{QString::fromStdString(path.string()),
+                                      CaptureFileInfo::kMissingCaptureLengthValue};
 
     // Not testing exact file size here, because it might be slightly different on windows and linux
     EXPECT_GT(capture_file_info.FileSize(), 0);

--- a/src/CaptureFileInfo/ItemModel.cpp
+++ b/src/CaptureFileInfo/ItemModel.cpp
@@ -16,12 +16,10 @@ namespace {
 
 const QString kMissingCaptureLengthDisplayText = QStringLiteral("--");
 
-[[nodiscard]] QString GetCaptureLengthToDisplay(absl::Duration capture_length) {
-  if (capture_length == CaptureFileInfo::kMissingCaptureLengthValue) {
-    return kMissingCaptureLengthDisplayText;
-  }
+[[nodiscard]] QString GetCaptureLengthToDisplay(std::optional<absl::Duration> capture_length) {
+  if (!capture_length.has_value()) return kMissingCaptureLengthDisplayText;
 
-  return QString::fromStdString(orbit_display_formats::GetDisplayTime(capture_length));
+  return QString::fromStdString(orbit_display_formats::GetDisplayTime(capture_length.value()));
 }
 
 }  // namespace
@@ -80,7 +78,7 @@ QVariant ItemModel::data(const QModelIndex& idx, int role) const {
                            .arg(QString::fromStdString(
                                orbit_display_formats::GetDisplaySize(capture_file_info.FileSize())))
                            .arg(capture_file_info.FilePath());
-    if (capture_file_info.CaptureLength() == CaptureFileInfo::kMissingCaptureLengthValue) {
+    if (!capture_file_info.CaptureLength().has_value()) {
       tooltips.append("\n(The capture length will be available after the capture file is loaded.)");
     }
     return tooltips;

--- a/src/CaptureFileInfo/ItemModel.cpp
+++ b/src/CaptureFileInfo/ItemModel.cpp
@@ -76,10 +76,14 @@ QVariant ItemModel::data(const QModelIndex& idx, int role) const {
   }
 
   if (role == Qt::ToolTipRole) {
-    return QString::fromStdString("%1 - %2")
-        .arg(QString::fromStdString(
-            orbit_display_formats::GetDisplaySize(capture_file_info.FileSize())))
-        .arg(capture_file_info.FilePath());
+    QString tooltips = QString::fromStdString("%1 - %2")
+                           .arg(QString::fromStdString(
+                               orbit_display_formats::GetDisplaySize(capture_file_info.FileSize())))
+                           .arg(capture_file_info.FilePath());
+    if (capture_file_info.CaptureLength() == CaptureFileInfo::kMissingCaptureLengthValue) {
+      tooltips.append("\n(The capture length will be available after the capture file is loaded.)");
+    }
+    return tooltips;
   }
 
   return {};

--- a/src/CaptureFileInfo/ItemModel.cpp
+++ b/src/CaptureFileInfo/ItemModel.cpp
@@ -4,11 +4,25 @@
 
 #include "CaptureFileInfo/ItemModel.h"
 
+#include <absl/time/time.h>
+
 #include "CaptureFileInfo/CaptureFileInfo.h"
 #include "DisplayFormats/DisplayFormats.h"
 #include "OrbitBase/Logging.h"
 
 namespace orbit_capture_file_info {
+
+namespace {
+
+const QString kMisingCaptureLengthToDisplay = QStringLiteral("--");
+
+[[nodiscard]] QString GetCaptureLengthToDisplay(absl::Duration capture_length) {
+  if (capture_length == absl::Nanoseconds(0)) return kMisingCaptureLengthToDisplay;
+
+  return QString::fromStdString(orbit_display_formats::GetDisplayTime(capture_length));
+}
+
+}  // namespace
 
 void ItemModel::SetCaptureFileInfos(std::vector<CaptureFileInfo> capture_file_infos) {
   if (!capture_files_.empty()) {
@@ -52,6 +66,8 @@ QVariant ItemModel::data(const QModelIndex& idx, int role) const {
         return capture_file_info.LastUsed();
       case Column::kCreated:
         return capture_file_info.Created();
+      case Column::kCaptureLength:
+        return GetCaptureLengthToDisplay(capture_file_info.CaptureLength());
       case Column::kEnd:
         ORBIT_UNREACHABLE();
     }
@@ -79,6 +95,8 @@ QVariant ItemModel::headerData(int section, Qt::Orientation orientation, int rol
       return "Last used";
     case Column::kCreated:
       return "Created";
+    case Column::kCaptureLength:
+      return "Capture length";
     case Column::kEnd:
       ORBIT_UNREACHABLE();
   }

--- a/src/CaptureFileInfo/ItemModel.cpp
+++ b/src/CaptureFileInfo/ItemModel.cpp
@@ -17,7 +17,9 @@ namespace {
 const QString kMisingCaptureLengthToDisplay = QStringLiteral("--");
 
 [[nodiscard]] QString GetCaptureLengthToDisplay(absl::Duration capture_length) {
-  if (capture_length == absl::Nanoseconds(0)) return kMisingCaptureLengthToDisplay;
+  if (capture_length == CaptureFileInfo::kMissingCaptureLengthValue) {
+    return kMisingCaptureLengthToDisplay;
+  }
 
   return QString::fromStdString(orbit_display_formats::GetDisplayTime(capture_length));
 }

--- a/src/CaptureFileInfo/ItemModel.cpp
+++ b/src/CaptureFileInfo/ItemModel.cpp
@@ -14,11 +14,11 @@ namespace orbit_capture_file_info {
 
 namespace {
 
-const QString kMisingCaptureLengthToDisplay = QStringLiteral("--");
+const QString kMissingCaptureLengthDisplayText = QStringLiteral("--");
 
 [[nodiscard]] QString GetCaptureLengthToDisplay(absl::Duration capture_length) {
   if (capture_length == CaptureFileInfo::kMissingCaptureLengthValue) {
-    return kMisingCaptureLengthToDisplay;
+    return kMissingCaptureLengthDisplayText;
   }
 
   return QString::fromStdString(orbit_display_formats::GetDisplayTime(capture_length));

--- a/src/CaptureFileInfo/ItemModelTest.cpp
+++ b/src/CaptureFileInfo/ItemModelTest.cpp
@@ -12,6 +12,26 @@
 
 namespace orbit_capture_file_info {
 
+namespace {
+
+template <typename... Args>
+CaptureFileInfo CreateCaptureFileInfoAndSetCaptureDuration(absl::Duration capture_length,
+                                                           Args... args) {
+  CaptureFileInfo capture_file_info{args...};
+  capture_file_info.SetCaptureLength(capture_length);
+  return capture_file_info;
+}
+
+const CaptureFileInfo capture_file_info1{"/path/to/file1"};
+const CaptureFileInfo capture_file_info2 =
+    CreateCaptureFileInfoAndSetCaptureDuration(absl::Seconds(10), "/path/to/file2");
+const CaptureFileInfo capture_file_info3 = CreateCaptureFileInfoAndSetCaptureDuration(
+    absl::Minutes(2), "/path/to/file3", QDateTime::fromMSecsSinceEpoch(100000000));
+const std::vector<CaptureFileInfo> capture_file_infos{capture_file_info1, capture_file_info2,
+                                                      capture_file_info3};
+
+}  // namespace
+
 TEST(CaptureFileInfoItemModel, EmptyModel) {
   orbit_qt_utils::AssertNoQtLogWarnings message_handler{};
 
@@ -24,12 +44,23 @@ TEST(CaptureFileInfoItemModel, FilledModel) {
   orbit_qt_utils::AssertNoQtLogWarnings message_handler{};
 
   ItemModel model{};
-
-  model.SetCaptureFileInfos(
-      {CaptureFileInfo{"/path/to/file1"}, CaptureFileInfo{"/path/to/file2"},
-       CaptureFileInfo{"/path/to/file3", QDateTime::fromMSecsSinceEpoch(100000000)}});
+  model.SetCaptureFileInfos({capture_file_infos});
 
   QAbstractItemModelTester(&model, QAbstractItemModelTester::FailureReportingMode::Warning);
+}
+
+TEST(CaptureFileInfoItemModel, SetCaptureFileInfos) {
+  ItemModel model{};
+  EXPECT_EQ(model.rowCount(), 0);
+
+  model.SetCaptureFileInfos(capture_file_infos);
+  EXPECT_EQ(model.rowCount(), 3);
+
+  model.SetCaptureFileInfos({capture_file_info1});
+  EXPECT_EQ(model.rowCount(), 1);
+
+  model.SetCaptureFileInfos(capture_file_infos);
+  EXPECT_EQ(model.rowCount(), 3);
 }
 
 }  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/ItemModelTest.cpp
+++ b/src/CaptureFileInfo/ItemModelTest.cpp
@@ -14,8 +14,7 @@ namespace orbit_capture_file_info {
 
 namespace {
 
-const CaptureFileInfo capture_file_info1{"/path/to/file1",
-                                         CaptureFileInfo::kMissingCaptureLengthValue};
+const CaptureFileInfo capture_file_info1{"/path/to/file1", std::nullopt};
 const CaptureFileInfo capture_file_info2{"/path/to/file2", absl::Seconds(10)};
 const CaptureFileInfo capture_file_info3{
     "/path/to/file3", QDateTime::fromMSecsSinceEpoch(100000000), absl::Minutes(2)};

--- a/src/CaptureFileInfo/ItemModelTest.cpp
+++ b/src/CaptureFileInfo/ItemModelTest.cpp
@@ -14,19 +14,11 @@ namespace orbit_capture_file_info {
 
 namespace {
 
-template <typename... Args>
-CaptureFileInfo CreateCaptureFileInfoAndSetCaptureDuration(absl::Duration capture_length,
-                                                           Args... args) {
-  CaptureFileInfo capture_file_info{args...};
-  capture_file_info.SetCaptureLength(capture_length);
-  return capture_file_info;
-}
-
-const CaptureFileInfo capture_file_info1{"/path/to/file1"};
-const CaptureFileInfo capture_file_info2 =
-    CreateCaptureFileInfoAndSetCaptureDuration(absl::Seconds(10), "/path/to/file2");
-const CaptureFileInfo capture_file_info3 = CreateCaptureFileInfoAndSetCaptureDuration(
-    absl::Minutes(2), "/path/to/file3", QDateTime::fromMSecsSinceEpoch(100000000));
+const CaptureFileInfo capture_file_info1{"/path/to/file1",
+                                         CaptureFileInfo::kMissingCaptureLengthValue};
+const CaptureFileInfo capture_file_info2{"/path/to/file2", absl::Seconds(10)};
+const CaptureFileInfo capture_file_info3{
+    "/path/to/file3", QDateTime::fromMSecsSinceEpoch(100000000), absl::Minutes(2)};
 const std::vector<CaptureFileInfo> capture_file_infos{capture_file_info1, capture_file_info2,
                                                       capture_file_info3};
 

--- a/src/CaptureFileInfo/LoadCaptureWidgetTest.cpp
+++ b/src/CaptureFileInfo/LoadCaptureWidgetTest.cpp
@@ -87,7 +87,7 @@ TEST(LoadCaptureWidget, SelectFromTableView) {
   // To make sure there is one table entry, it is set here.
   Manager manager{};
   manager.Clear();
-  manager.AddOrTouchCaptureFile(test_file_path);
+  manager.AddOrTouchCaptureFile(test_file_path, std::nullopt);
 
   LoadCaptureWidget widget{};
   auto* table_view = widget.findChild<QTableView*>("tableView");
@@ -125,8 +125,8 @@ TEST(LoadCaptureWidget, EditCaptureFileFilter) {
 
   Manager manager{};
   manager.Clear();
-  manager.AddOrTouchCaptureFile(test_file_path0);
-  manager.AddOrTouchCaptureFile(test_file_path1);
+  manager.AddOrTouchCaptureFile(test_file_path0, std::nullopt);
+  manager.AddOrTouchCaptureFile(test_file_path1, std::nullopt);
 
   LoadCaptureWidget widget{};
   auto* table_view = widget.findChild<QTableView*>("tableView");

--- a/src/CaptureFileInfo/Manager.cpp
+++ b/src/CaptureFileInfo/Manager.cpp
@@ -83,6 +83,18 @@ void Manager::AddOrTouchCaptureFile(const std::filesystem::path& path,
   SaveCaptureFileInfos();
 }
 
+std::optional<absl::Duration> Manager::GetCaptureLengthByPath(
+    const std::filesystem::path& path) const {
+  auto it = std::find_if(capture_file_infos_.begin(), capture_file_infos_.end(),
+                         [&](const CaptureFileInfo& capture_file_info) {
+                           std::filesystem::path path_from_capture_file_info{
+                               capture_file_info.FilePath().toStdString()};
+                           return path_from_capture_file_info == path;
+                         });
+  if (it == capture_file_infos_.end()) return std::nullopt;
+  return it->CaptureLength();
+}
+
 void Manager::Clear() {
   capture_file_infos_.clear();
   SaveCaptureFileInfos();

--- a/src/CaptureFileInfo/Manager.cpp
+++ b/src/CaptureFileInfo/Manager.cpp
@@ -87,7 +87,6 @@ void Manager::AddOrTouchCaptureFile(const std::filesystem::path& path,
 
   if (it == capture_file_infos_.end()) {
     capture_file_infos_.emplace_back(QString::fromStdString(path.string()), capture_length);
-
   } else {
     it->Touch();
     it->SetCaptureLength(capture_length);

--- a/src/CaptureFileInfo/ManagerTest.cpp
+++ b/src/CaptureFileInfo/ManagerTest.cpp
@@ -30,15 +30,15 @@ TEST(CaptureFileInfoManager, Clear) {
   manager.Clear();
   EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
 
-  manager.AddOrTouchCaptureFile("test/path1");
+  manager.AddOrTouchCaptureFile("test/path1", std::nullopt);
   EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
 
   manager.Clear();
   EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
 
-  manager.AddOrTouchCaptureFile("test/path1");
+  manager.AddOrTouchCaptureFile("test/path1", std::nullopt);
   EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
-  manager.AddOrTouchCaptureFile("test/path2");
+  manager.AddOrTouchCaptureFile("test/path2", std::nullopt);
   EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
 
   manager.Clear();
@@ -55,7 +55,7 @@ TEST(CaptureFileInfoManager, AddOrTouchCaptureFile) {
 
   // Add 1st file
   const std::filesystem::path path1 = "path/to/file1";
-  manager.AddOrTouchCaptureFile(path1);
+  manager.AddOrTouchCaptureFile(path1, std::nullopt);
   ASSERT_EQ(manager.GetCaptureFileInfos().size(), 1);
 
   const CaptureFileInfo& capture_file_info_1 = manager.GetCaptureFileInfos()[0];
@@ -113,7 +113,7 @@ TEST(CaptureFileInfoManager, AddOrTouchCaptureFilePathFormatting) {
 
   std::set<std::filesystem::path> control_set;
   for (const auto& path : test_paths) {
-    manager.AddOrTouchCaptureFile(path);
+    manager.AddOrTouchCaptureFile(path, std::nullopt);
     control_set.insert(path);
   }
 
@@ -128,14 +128,14 @@ TEST(CaptureFileInfoManager, PurgeNonExistingFiles) {
   manager.Clear();
   EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
 
-  manager.AddOrTouchCaptureFile("non/existing/path");
+  manager.AddOrTouchCaptureFile("non/existing/path", std::nullopt);
   EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
 
   manager.PurgeNonExistingFiles();
   EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
 
   const std::filesystem::path existing_file = orbit_test::GetTestdataDir() / "test_file.txt";
-  manager.AddOrTouchCaptureFile(existing_file);
+  manager.AddOrTouchCaptureFile(existing_file, std::nullopt);
   EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
 
   manager.PurgeNonExistingFiles();
@@ -162,7 +162,7 @@ TEST(CaptureFileInfoManager, Persistency) {
   const std::filesystem::path existing_file = orbit_test::GetTestdataDir() / "test_file.txt";
   {
     Manager manager;
-    manager.AddOrTouchCaptureFile(existing_file);
+    manager.AddOrTouchCaptureFile(existing_file, std::nullopt);
     EXPECT_EQ(manager.GetCaptureFileInfos().size(), 1);
   }
 
@@ -218,7 +218,7 @@ TEST(CaptureFileInfoManager, GetCaptureLengthByPath) {
   manager.Clear();
 
   const std::filesystem::path path1 = "path/to/file1";
-  manager.AddOrTouchCaptureFile(path1);
+  manager.AddOrTouchCaptureFile(path1, std::nullopt);
   ASSERT_EQ(manager.GetCaptureLengthByPath(path1).value(),
             CaptureFileInfo::kMissingCaptureLengthValue);
 

--- a/src/CaptureFileInfo/ManagerTest.cpp
+++ b/src/CaptureFileInfo/ManagerTest.cpp
@@ -219,8 +219,7 @@ TEST(CaptureFileInfoManager, GetCaptureLengthByPath) {
 
   const std::filesystem::path path1 = "path/to/file1";
   manager.AddOrTouchCaptureFile(path1, std::nullopt);
-  ASSERT_EQ(manager.GetCaptureLengthByPath(path1).value(),
-            CaptureFileInfo::kMissingCaptureLengthValue);
+  ASSERT_FALSE(manager.GetCaptureLengthByPath(path1).has_value());
 
   const std::filesystem::path path2 = "path/to/file2";
   ASSERT_FALSE(manager.GetCaptureLengthByPath(path2).has_value());

--- a/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
@@ -20,26 +20,33 @@ class CaptureFileInfo {
   explicit CaptureFileInfo(const QString& path, std::optional<absl::Duration> capture_length);
   explicit CaptureFileInfo(const QString& path, QDateTime last_used,
                            std::optional<absl::Duration> capture_length);
+  explicit CaptureFileInfo(const QString& path, QDateTime last_used, QDateTime last_modified,
+                           uint64_t file_size, std::optional<absl::Duration> capture_length);
 
   [[nodiscard]] QString FilePath() const { return file_info_.filePath(); }
   [[nodiscard]] QString FileName() const { return file_info_.fileName(); }
+  [[nodiscard]] QDateTime Created() const { return file_info_.birthTime(); }
 
   [[nodiscard]] QDateTime LastUsed() const { return last_used_; }
-  [[nodiscard]] QDateTime Created() const { return file_info_.birthTime(); }
+  [[nodiscard]] QDateTime LastModified() const { return last_modified_; }
+  [[nodiscard]] uint64_t FileSize() const { return file_size_; }
   [[nodiscard]] std::optional<absl::Duration> CaptureLength() const { return capture_length_; }
 
   [[nodiscard]] bool FileExists() const;
+  [[nodiscard]] bool IsOutOfSync() const;
 
-  [[nodiscard]] uint64_t FileSize() const;
-
-  void Touch() { last_used_ = QDateTime::currentDateTime(); }
+  void Touch();
   void SetCaptureLength(std::optional<absl::Duration> capture_length) {
     capture_length_ = capture_length;
   }
 
  private:
   QFileInfo file_info_;
+  // Last used time inside Orbit
   QDateTime last_used_;
+  // Last modified time inside Orbit
+  QDateTime last_modified_;
+  uint64_t file_size_;
   std::optional<absl::Duration> capture_length_ = std::nullopt;
 };
 

--- a/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
@@ -33,7 +33,7 @@ class CaptureFileInfo {
   void Touch() { last_used_ = QDateTime::currentDateTime(); }
   void SetCaptureLength(absl::Duration capture_length) { capture_length_ = capture_length; }
 
-  static constexpr absl::Duration kMissingCaptureLengthValue{absl::Nanoseconds(0)};
+  static constexpr absl::Duration kMissingCaptureLengthValue{absl::ZeroDuration()};
 
  private:
   QFileInfo file_info_;

--- a/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
@@ -33,10 +33,12 @@ class CaptureFileInfo {
   void Touch() { last_used_ = QDateTime::currentDateTime(); }
   void SetCaptureLength(absl::Duration capture_length) { capture_length_ = capture_length; }
 
+  static constexpr absl::Duration kMissingCaptureLengthValue{absl::Nanoseconds(0)};
+
  private:
   QFileInfo file_info_;
   QDateTime last_used_;
-  absl::Duration capture_length_ = absl::Nanoseconds(0);
+  absl::Duration capture_length_ = kMissingCaptureLengthValue;
 };
 
 }  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
@@ -5,6 +5,8 @@
 #ifndef CAPTURE_FILE_INFO_CAPTURE_FILE_INFO_H_
 #define CAPTURE_FILE_INFO_CAPTURE_FILE_INFO_H_
 
+#include <absl/time/time.h>
+
 #include <QDateTime>
 #include <QFileInfo>
 #include <filesystem>
@@ -22,16 +24,19 @@ class CaptureFileInfo {
 
   [[nodiscard]] QDateTime LastUsed() const { return last_used_; }
   [[nodiscard]] QDateTime Created() const { return file_info_.birthTime(); }
+  [[nodiscard]] absl::Duration CaptureLength() const { return capture_length_; }
 
   [[nodiscard]] bool FileExists() const;
 
   [[nodiscard]] uint64_t FileSize() const;
 
   void Touch() { last_used_ = QDateTime::currentDateTime(); }
+  void SetCaptureLength(absl::Duration capture_length) { capture_length_ = capture_length; }
 
  private:
   QFileInfo file_info_;
   QDateTime last_used_;
+  absl::Duration capture_length_ = absl::Nanoseconds(0);
 };
 
 }  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
@@ -16,8 +16,8 @@ namespace orbit_capture_file_info {
 
 class CaptureFileInfo {
  public:
-  explicit CaptureFileInfo(const QString& path);
-  explicit CaptureFileInfo(const QString& path, QDateTime last_used);
+  explicit CaptureFileInfo(const QString& path, absl::Duration capture_length);
+  explicit CaptureFileInfo(const QString& path, QDateTime last_used, absl::Duration capture_length);
 
   [[nodiscard]] QString FilePath() const { return file_info_.filePath(); }
   [[nodiscard]] QString FileName() const { return file_info_.fileName(); }

--- a/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/CaptureFileInfo.h
@@ -10,35 +10,37 @@
 #include <QDateTime>
 #include <QFileInfo>
 #include <filesystem>
+#include <optional>
 #include <utility>
 
 namespace orbit_capture_file_info {
 
 class CaptureFileInfo {
  public:
-  explicit CaptureFileInfo(const QString& path, absl::Duration capture_length);
-  explicit CaptureFileInfo(const QString& path, QDateTime last_used, absl::Duration capture_length);
+  explicit CaptureFileInfo(const QString& path, std::optional<absl::Duration> capture_length);
+  explicit CaptureFileInfo(const QString& path, QDateTime last_used,
+                           std::optional<absl::Duration> capture_length);
 
   [[nodiscard]] QString FilePath() const { return file_info_.filePath(); }
   [[nodiscard]] QString FileName() const { return file_info_.fileName(); }
 
   [[nodiscard]] QDateTime LastUsed() const { return last_used_; }
   [[nodiscard]] QDateTime Created() const { return file_info_.birthTime(); }
-  [[nodiscard]] absl::Duration CaptureLength() const { return capture_length_; }
+  [[nodiscard]] std::optional<absl::Duration> CaptureLength() const { return capture_length_; }
 
   [[nodiscard]] bool FileExists() const;
 
   [[nodiscard]] uint64_t FileSize() const;
 
   void Touch() { last_used_ = QDateTime::currentDateTime(); }
-  void SetCaptureLength(absl::Duration capture_length) { capture_length_ = capture_length; }
-
-  static constexpr absl::Duration kMissingCaptureLengthValue{absl::ZeroDuration()};
+  void SetCaptureLength(std::optional<absl::Duration> capture_length) {
+    capture_length_ = capture_length;
+  }
 
  private:
   QFileInfo file_info_;
   QDateTime last_used_;
-  absl::Duration capture_length_ = kMissingCaptureLengthValue;
+  std::optional<absl::Duration> capture_length_ = std::nullopt;
 };
 
 }  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/include/CaptureFileInfo/ItemModel.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/ItemModel.h
@@ -17,7 +17,7 @@ class ItemModel : public QAbstractTableModel {
   Q_OBJECT
 
  public:
-  enum class Column { kFilename, kLastUsed, kCreated, kEnd };
+  enum class Column { kFilename, kLastUsed, kCreated, kCaptureLength, kEnd };
 
   explicit ItemModel(QObject* parent = nullptr) : QAbstractTableModel(parent) {}
 

--- a/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
@@ -33,7 +33,7 @@ class Manager {
   // TODO(http://b/218298681) use std::filesystem::equivalent instead of operator== to check whether
   // 2 paths are actually pointing to the same file.
   void AddOrTouchCaptureFile(const std::filesystem::path& path,
-                             std::optional<absl::Duration> capture_length = std::nullopt);
+                             std::optional<absl::Duration> capture_length);
   void Clear();
   void PurgeNonExistingFiles();
   ErrorMessageOr<void> FillFromDirectory(const std::filesystem::path& directory);

--- a/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
@@ -6,6 +6,7 @@
 #define CAPTURE_FILE_INFO_MANAGER_H_
 
 #include <filesystem>
+#include <optional>
 #include <vector>
 
 #include "CaptureFileInfo/CaptureFileInfo.h"
@@ -28,7 +29,8 @@ class Manager {
   // paths that use slash (/) as directory separators, are equal to paths that are using backslash.
   // TODO(http://b/218298681) use std::filesystem::equivalent instead of operator== to check whether
   // 2 paths are actually pointing to the same file.
-  void AddOrTouchCaptureFile(const std::filesystem::path& path);
+  void AddOrTouchCaptureFile(const std::filesystem::path& path,
+                             std::optional<absl::Duration> capture_length = std::nullopt);
   void Clear();
   void PurgeNonExistingFiles();
   ErrorMessageOr<void> FillFromDirectory(const std::filesystem::path& directory);

--- a/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
@@ -21,6 +21,9 @@ class Manager {
     return capture_file_infos_;
   }
 
+  [[nodiscard]] std::optional<absl::Duration> GetCaptureLengthByPath(
+      const std::filesystem::path& path) const;
+
   // This function adds or touches a capture file at `path` to the list of capture files saved in
   // this class. The file is added if path is not yet contained in the list, and touches it if is.
   // Whether a file is contained in the list is determined by whether there paths are

--- a/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
@@ -36,13 +36,15 @@ class Manager {
                              std::optional<absl::Duration> capture_length);
   void Clear();
   void PurgeNonExistingFiles();
+  void ProcessOutOfSyncFiles();
   ErrorMessageOr<void> FillFromDirectory(const std::filesystem::path& directory);
+
+ protected:
+  std::vector<CaptureFileInfo> capture_file_infos_;
 
  private:
   void SaveCaptureFileInfos();
   void LoadCaptureFileInfos();
-
-  std::vector<CaptureFileInfo> capture_file_infos_;
 };
 
 }  // namespace orbit_capture_file_info

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -317,7 +317,8 @@ void OrbitApp::OnCaptureFinished(const CaptureFinished& capture_finished) {
         break;
     }
 
-    if (capture_data_ != nullptr && capture_data_->file_path().has_value()) {
+    ORBIT_CHECK(capture_data_ != nullptr);
+    if (capture_data_->file_path().has_value()) {
       capture_file_info_manager_.AddOrTouchCaptureFile(capture_data_->file_path().value(),
                                                        GetCaptureTime());
     }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1327,9 +1327,12 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> OrbitApp::LoadCaptureFro
 
 orbit_base::Future<ErrorMessageOr<void>> OrbitApp::MoveCaptureFile(
     const std::filesystem::path& src, const std::filesystem::path& dest) {
+  std::optional<absl::Duration> capture_length =
+      capture_file_info_manager_.GetCaptureLengthByPath(src);
   return thread_pool_->Schedule([src, dest]() { return orbit_base::MoveFile(src, dest); })
-      .ThenIfSuccess(main_thread_executor_,
-                     [this, dest] { capture_file_info_manager_.AddOrTouchCaptureFile(dest); });
+      .ThenIfSuccess(main_thread_executor_, [this, dest, capture_length] {
+        capture_file_info_manager_.AddOrTouchCaptureFile(dest, capture_length);
+      });
 }
 
 void OrbitApp::OnLoadCaptureCancelRequested() { capture_loading_cancellation_requested_ = true; }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1316,12 +1316,11 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> OrbitApp::LoadCaptureFro
 
   DoZoom = true;  // TODO: remove global, review logic
 
-  (void)load_future.ThenIfSuccess(main_thread_executor_,
-                                  [this, file_path](CaptureListener::CaptureOutcome outcome) {
-                                    if (outcome == CaptureOutcome::kComplete) {
-                                      capture_file_info_manager_.AddOrTouchCaptureFile(file_path);
-                                    }
-                                  });
+  (void)load_future.ThenIfSuccess(
+      main_thread_executor_, [this, file_path](CaptureListener::CaptureOutcome outcome) {
+        if (outcome != CaptureOutcome::kComplete) return;
+        capture_file_info_manager_.AddOrTouchCaptureFile(file_path, GetCaptureTime());
+      });
 
   return load_future;
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2999,6 +2999,7 @@ void OrbitApp::TrySaveUserDefinedCaptureInfo() {
       SendErrorToUi("Save failed", absl::StrFormat("Save to \"%s\" failed: %s", file_path.string(),
                                                    write_result.error().message()));
     }
+    capture_file_info_manager_.AddOrTouchCaptureFile(file_path, GetCaptureTime());
   });
 }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -316,6 +316,11 @@ void OrbitApp::OnCaptureFinished(const CaptureFinished& capture_finished) {
         ORBIT_UNREACHABLE();
         break;
     }
+
+    if (capture_data_ != nullptr && capture_data_->file_path().has_value()) {
+      capture_file_info_manager_.AddOrTouchCaptureFile(capture_data_->file_path().value(),
+                                                       GetCaptureTime());
+    }
   });
 }
 
@@ -344,10 +349,6 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
     }
 
     ClearCapture();
-
-    if (file_path.has_value()) {
-      capture_file_info_manager_.AddOrTouchCaptureFile(file_path.value());
-    }
 
     // It is safe to do this write on the main thread, as the capture thread is suspended until
     // this task is completely executed.


### PR DESCRIPTION
With this change, we add the capture length information to the load capture widget.

Now, when the user takes a new capture file or touches a previous capture file, the capture length information will be added to corresponding `CaptureFileInfo` and saved. (More use cases can be found in the following test cases).

Screenshots: [After the change](http://screenshot/47AFnYyrkQQgFVo); [Tooltips if the capture length is missing](http://screenshot/5qVQXAcjGGsREen)

Bug: http://b/198562119, http://b/227554942, http://b/227547320 

Test: 
1) Unit test; 
2) Run Orbit and take a new capture. Return to the connection window, see that the correct capture length value in the load capture widget; 
3) Run Orbit and on the connection window, pick a capture file with "--" in the "Capture length" column to load. Return to the connection window, see that the capture length value changed from "--" to the same value that we see in the capture main window timer label;
4) Rename a capture file from the capture main window. Return to the connection window, see that the renamed file also has the correct capture length value.
5) Close Orbit and modify a capture file from the file explorer. Run Orbit again and check that the capture length value changes to "--".

Besides, now we changed the `CaptureFileInfo` to only reflect the information of a capture file when it is changed inside Orbit. Take the file size as an example. Previously, `CaptureFileInfo` retrieves the file size from QFileInfo; while now, we save the file size in `CaptureFileInfo` and update the value only when we change / touch the file inside Orbit (`orbit_capture_file_info::Manager::AddOrTouchCaptureFile` should be called).
Then if the information from QFileInfo does not match the information from CaptureFileInfo, we say that the capture file might be modified outside Orbit and so the CaptureFileInfo is out of sync with the actual file.