### PR TITLE
Show scope name in histogram title

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -198,14 +198,18 @@ void CaptureData::DisableFrameTrack(uint64_t instrumented_function_id) {
   frame_track_function_ids_.erase(instrumented_function_id);
 }
 
-[[nodiscard]] bool CaptureData::IsFrameTrackEnabled(uint64_t instrumented_function_id) const {
+bool CaptureData::IsFrameTrackEnabled(uint64_t instrumented_function_id) const {
   return frame_track_function_ids_.contains(instrumented_function_id);
 }
 
-[[nodiscard]] uint64_t CaptureData::ProvideScopeId(
-    const orbit_client_protos::TimerInfo& timer_info) const {
+uint64_t CaptureData::ProvideScopeId(const orbit_client_protos::TimerInfo& timer_info) const {
   ORBIT_CHECK(scope_id_provider_);
   return scope_id_provider_->ProvideId(timer_info);
+}
+
+const std::string& CaptureData::GetScopeName(uint64_t scope_id) const {
+  ORBIT_CHECK(scope_id_provider_);
+  return scope_id_provider_->GetScopeName(scope_id);
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -239,6 +239,7 @@ class CaptureData {
   }
 
   [[nodiscard]] uint64_t ProvideScopeId(const orbit_client_protos::TimerInfo& timer_info) const;
+  [[nodiscard]] const std::string& GetScopeName(uint64_t scope_id) const;
 
  private:
   orbit_client_data::ProcessData process_;

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -166,14 +166,8 @@ void LiveFunctionsDataView::UpdateHistogramWithScopeIds(const std::vector<uint64
   }
 
   const uint64_t scope_id = scope_ids[0];
-
-  std::string function_name = "MANUAL";
-  if (functions_.contains(scope_id)) {
-    const FunctionInfo& function = functions_.at(scope_id);
-    function_name = orbit_client_data::function_utils::GetDisplayName(function);
-  }
-
-  app_->ShowHistogram(timer_durations, function_name, scope_id);
+  const std::string& scope_name = app_->GetCaptureData().GetScopeName(scope_id);
+  app_->ShowHistogram(timer_durations, scope_name, scope_id);
 }
 
 void LiveFunctionsDataView::OnSelect(const std::vector<int>& rows) {
@@ -546,8 +540,11 @@ std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrum
     return std::nullopt;
   }
 
+  const std::string& function_name =
+      app_->GetCaptureData().GetScopeName(instrumented_function.function_id());
+
   FunctionInfo result;
-  result.set_pretty_name(llvm::demangle(instrumented_function.function_name()));
+  result.set_pretty_name(function_name);
   result.set_module_path(instrumented_function.file_path());
   result.set_module_build_id(instrumented_function.file_build_id());
   result.set_address(module_data->load_bias() + instrumented_function.file_offset());

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -185,6 +185,7 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
     instrumented_function->set_file_offset(
         orbit_client_data::function_utils::Offset(function, *module_data));
     instrumented_function->set_function_id(kFunctionIds[i]);
+    instrumented_function->set_function_name(kPrettyNames[i]);
   }
 
   auto capture_data =


### PR DESCRIPTION
This leverages the GetScopeName method of
`ScopeIdProvider` to show the correct scope name
in the histogram title for manually instrumented
scopes.

Also, this makes an effort to make `ScopeIdProvider`
the single source of names for scopes.

Tests: Unit, Manual
Bug: http://b/226913232