### PR TITLE
Widen CallTreeWidget's "Thread / Function" column on row expansion

### DIFF
--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -185,8 +185,7 @@ void CallTreeWidget::ResizeColumnsIfNecessary() {
   column_resizing_state_ = ColumnResizingState::kDone;
 }
 
-static int FindDepthDifferenceFromIndexToDeepestVisibleNode(QTreeView* tree_view,
-                                                            const QModelIndex& index) {
+static int ComputeHeightOfSubtreeOfVisibleNodes(QTreeView* tree_view, const QModelIndex& index) {
   if (!tree_view->isExpanded(index)) {
     return 0;
   }
@@ -194,8 +193,8 @@ static int FindDepthDifferenceFromIndexToDeepestVisibleNode(QTreeView* tree_view
   int depth_difference = 0;
   for (int i = 0; i < index.model()->rowCount(index); ++i) {
     const QModelIndex& child = index.child(i, 0);
-    depth_difference = std::max(
-        depth_difference, 1 + FindDepthDifferenceFromIndexToDeepestVisibleNode(tree_view, child));
+    depth_difference =
+        std::max(depth_difference, 1 + ComputeHeightOfSubtreeOfVisibleNodes(tree_view, child));
   }
   return depth_difference;
 }
@@ -208,8 +207,7 @@ void CallTreeWidget::ResizeThreadOrFunctionColumnToShowVisibleDescendants(
   }
 
   int one_based_depth_of_deepest_visible_descendant =
-      one_based_depth_of_index +
-      FindDepthDifferenceFromIndexToDeepestVisibleNode(ui_->callTreeTreeView, index);
+      one_based_depth_of_index + ComputeHeightOfSubtreeOfVisibleNodes(ui_->callTreeTreeView, index);
 
   static constexpr int kMinThreadOrFunctionColumnSizeWithoutIndentation = 100;
   int min_thread_or_function_column_size =

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -61,6 +61,7 @@ CallTreeWidget::CallTreeWidget(QWidget* parent)
       CallTreeViewItemModel::kInclusive, new ProgressBarItemDelegate{ui_->callTreeTreeView});
   search_typing_finished_timer_->setSingleShot(true);
 
+  connect(ui_->callTreeTreeView, &QTreeView::expanded, this, &CallTreeWidget::OnRowExpanded);
   connect(ui_->callTreeTreeView, &CopyKeySequenceEnabledTreeView::copyKeySequencePressed, this,
           &CallTreeWidget::OnCopyKeySequencePressed);
   connect(ui_->callTreeTreeView, &QTreeView::customContextMenuRequested, this,
@@ -182,6 +183,74 @@ void CallTreeWidget::ResizeColumnsIfNecessary() {
   ui_->callTreeTreeView->header()->setStretchLastSection(true);
 
   column_resizing_state_ = ColumnResizingState::kDone;
+}
+
+static int FindDepthDifferenceFromIndexToDeepestVisibleNode(QTreeView* tree_view,
+                                                            const QModelIndex& index) {
+  if (!tree_view->isExpanded(index)) {
+    return 0;
+  }
+
+  int depth_difference = 0;
+  for (int i = 0; i < index.model()->rowCount(index); ++i) {
+    const QModelIndex& child = index.child(i, 0);
+    depth_difference = std::max(
+        depth_difference, 1 + FindDepthDifferenceFromIndexToDeepestVisibleNode(tree_view, child));
+  }
+  return depth_difference;
+}
+
+void CallTreeWidget::ResizeThreadOrFunctionColumnToShowVisibleDescendants(
+    const QModelIndex& index) {
+  int one_based_depth_of_index = 0;
+  for (QModelIndex temp_index = index; temp_index.isValid(); temp_index = temp_index.parent()) {
+    ++one_based_depth_of_index;
+  }
+
+  int one_based_depth_of_deepest_visible_descendant =
+      one_based_depth_of_index +
+      FindDepthDifferenceFromIndexToDeepestVisibleNode(ui_->callTreeTreeView, index);
+
+  static constexpr int kMinThreadOrFunctionColumnSizeWithoutIndentation = 100;
+  int min_thread_or_function_column_size =
+      one_based_depth_of_deepest_visible_descendant * ui_->callTreeTreeView->indentation() +
+      kMinThreadOrFunctionColumnSizeWithoutIndentation;
+  int actual_thread_or_function_column_size =
+      ui_->callTreeTreeView->header()->sectionSize(CallTreeViewItemModel::kThreadOrFunction);
+
+  if (min_thread_or_function_column_size > actual_thread_or_function_column_size) {
+    ui_->callTreeTreeView->header()->resizeSection(CallTreeViewItemModel::kThreadOrFunction,
+                                                   min_thread_or_function_column_size);
+  }
+}
+
+void CallTreeWidget::ResizeThreadOrFunctionColumnToShowAllVisibleNodes() {
+  for (int i = 0; i < ui_->callTreeTreeView->model()->rowCount(); ++i) {
+    ResizeThreadOrFunctionColumnToShowVisibleDescendants(
+        ui_->callTreeTreeView->model()->index(i, 0));
+  }
+}
+
+void CallTreeWidget::OnRowExpanded(const QModelIndex& index) {
+  if (resize_thread_or_function_column_on_row_expanded_) {
+    // Some descendants deeper than the immediate children also become visible if some descendant
+    // had already been expanded. But it's possible that the first column was shrunk again after
+    // that previous expansion. Instead of (possibly) resizing the first column only based on the
+    // depth of the direct children of the expanded row, this function considers the deepest
+    // descendant of this row.
+    ResizeThreadOrFunctionColumnToShowVisibleDescendants(index);
+  }
+}
+
+// When expanding a large number of nodes programmatically, we don't want
+// ResizeThreadOrFunctionColumnToShowVisibleDescendants to be called for each node, as it's
+// computationally expensive.
+void CallTreeWidget::DisableThreadOrFunctionColumnResizeOnRowExpanded() {
+  resize_thread_or_function_column_on_row_expanded_ = false;
+}
+
+void CallTreeWidget::ReEnableThreadOrFunctionColumnResizeOnRowExpanded() {
+  resize_thread_or_function_column_on_row_expanded_ = true;
 }
 
 static std::string BuildStringFromIndices(QTreeView* tree_view, const QModelIndexList& indices) {
@@ -536,7 +605,10 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
 
   if (action->text() == kActionExpandRecursively) {
     for (const QModelIndex& selected_index : selected_tree_indices) {
+      DisableThreadOrFunctionColumnResizeOnRowExpanded();
       ExpandRecursively(ui_->callTreeTreeView, selected_index);
+      ReEnableThreadOrFunctionColumnResizeOnRowExpanded();
+      ResizeThreadOrFunctionColumnToShowVisibleDescendants(selected_index);
     }
   } else if (action->text() == kActionCollapseRecursively) {
     for (const QModelIndex& selected_index : selected_tree_indices) {
@@ -547,7 +619,10 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
       CollapseChildrenRecursively(ui_->callTreeTreeView, selected_index);
     }
   } else if (action->text() == kActionExpandAll) {
+    DisableThreadOrFunctionColumnResizeOnRowExpanded();
     ui_->callTreeTreeView->expandAll();
+    ReEnableThreadOrFunctionColumnResizeOnRowExpanded();
+    ResizeThreadOrFunctionColumnToShowAllVisibleNodes();
   } else if (action->text() == kActionCollapseAll) {
     ui_->callTreeTreeView->collapseAll();
   } else if (action->text() == kActionLoadSymbols) {
@@ -628,8 +703,11 @@ void CallTreeWidget::OnSearchTypingFinishedTimerTimout() {
   search_proxy_model_->SetFilter(search_text);
   ui_->callTreeTreeView->viewport()->update();
   if (!search_text.empty()) {
+    DisableThreadOrFunctionColumnResizeOnRowExpanded();
     ExpandCollapseBasedOnRole(ui_->callTreeTreeView,
                               CallTreeViewItemModel::kMatchesCustomFilterRole);
+    ReEnableThreadOrFunctionColumnResizeOnRowExpanded();
+    ResizeThreadOrFunctionColumnToShowAllVisibleNodes();
   }
 }
 

--- a/src/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/CallTreeWidget.h
@@ -54,6 +54,7 @@ class CallTreeWidget : public QWidget {
   void resizeEvent(QResizeEvent* event) override;
 
  private slots:
+  void OnRowExpanded(const QModelIndex& index);
   void OnCopyKeySequencePressed();
   void OnCustomContextMenuRequested(const QPoint& point);
   void OnSearchLineEditTextEdited(const QString& text);
@@ -118,6 +119,10 @@ class CallTreeWidget : public QWidget {
                        std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model);
 
   void ResizeColumnsIfNecessary();
+  void ResizeThreadOrFunctionColumnToShowVisibleDescendants(const QModelIndex& index);
+  void ResizeThreadOrFunctionColumnToShowAllVisibleNodes();
+  void ReEnableThreadOrFunctionColumnResizeOnRowExpanded();
+  void DisableThreadOrFunctionColumnResizeOnRowExpanded();
 
   std::unique_ptr<Ui::CallTreeWidget> ui_;
   QTimer* search_typing_finished_timer_ = new QTimer{this};
@@ -133,6 +138,7 @@ class CallTreeWidget : public QWidget {
     kDone = 2            // The columns have been resized (once)
   };
   ColumnResizingState column_resizing_state_ = ColumnResizingState::kInitial;
+  bool resize_thread_or_function_column_on_row_expanded_ = true;
 };
 
 #endif  // ORBIT_QT_CALL_TREE_WIDGET_H_


### PR DESCRIPTION
When expanding a row of the top-down or bottom-up view, the newly visible nodes
could be completely hidden if the "Thread / Function" column was too narrow.
We now possibly widen the column so that the arrow and the first few characters
of these nodes are visible.

Keeping performance in mind, we have to distinguish between the case of a single
row expanded manually, and the case of many rows expanded programmatically with
a context menu action or with the search functionality.

Bug: http://b/218449940

Test: Multiple manual tests expanding rows manually, with the context menu
actions, and with the search bar.