### PR TITLE
Add CreateProcess utilities on Windows

### DIFF
--- a/src/QtUtils/FakeCliProgram/main.cpp
+++ b/src/QtUtils/FakeCliProgram/main.cpp
@@ -9,11 +9,14 @@
 
 #include <chrono>
 #include <cstdint>
+#include <future>
 #include <iostream>
 #include <string_view>
 #include <thread>
 
 ABSL_FLAG(int, sleep_for_ms, 0, "The program will sleep for X milliseconds");
+
+ABSL_FLAG(bool, infinite_sleep, false, "The program will sleep indefinitely");
 
 ABSL_FLAG(int, exit_code, 0, "The program returns this exit_code");
 
@@ -21,6 +24,12 @@ int main(int argc, char* argv[]) {
   absl::ParseCommandLine(argc, argv);
 
   std::cout << "Some example output" << std::endl;
+
+  bool infinite_sleep = absl::GetFlag(FLAGS_infinite_sleep);
+  if (infinite_sleep) {
+    // Wait on a promise which value is never set.
+    std::promise<void>().get_future().wait();
+  }
 
   int sleep_time = absl::GetFlag(FLAGS_sleep_for_ms);
   if (sleep_time != 0) {

--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(WindowsUtils PRIVATE
 
 target_sources(WindowsUtils PUBLIC
         include/WindowsUtils/AdjustTokenPrivilege.h
+        include/WindowsUtils/CreateProcess.h
         include/WindowsUtils/DllInjection.h
         include/WindowsUtils/FindDebugSymbols.h
         include/WindowsUtils/ListModules.h
@@ -33,6 +34,7 @@ target_sources(WindowsUtils PUBLIC
 
 target_sources(WindowsUtils PRIVATE
         AdjustTokenPrivilege.cpp
+        CreateProcess.cpp
         DllInjection.cpp
         FindDebugSymbols.cpp
         ListModules.cpp
@@ -51,6 +53,7 @@ target_link_libraries(WindowsUtils PUBLIC
 add_executable(WindowsUtilsTests)
 
 target_sources(WindowsUtilsTests PRIVATE
+        CreateProcessTest.cpp
         DllInjectionTest.cpp
         FindDebugSymbolsTest.cpp
         ListModulesTest.cpp

--- a/src/WindowsUtils/CreateProcess.cpp
+++ b/src/WindowsUtils/CreateProcess.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/CreateProcess.h"
+
+#include <absl/strings/str_format.h>
+
+#include <algorithm>
+
+#include "OrbitBase/GetLastError.h"
+
+// clang-format off
+#include <Windows.h>
+#include <psapi.h>
+// clang-format on
+
+namespace orbit_windows_utils {
+
+namespace {
+
+ErrorMessageOr<ProcessInfo> CreateProcess(std::filesystem::path executable,
+                                          std::filesystem::path working_directory,
+                                          std::string arguments, uint32_t creation_flags) {
+  if (!std::filesystem::exists(executable)) {
+    return ErrorMessage(absl::StrFormat("Executable does not exist: \"%s\"", executable.string()));
+  }
+
+  if (!working_directory.empty() && !std::filesystem::exists(working_directory)) {
+    return ErrorMessage(
+        absl::StrFormat("Working directory does not exist: \"%s\"", working_directory.string()));
+  }
+
+  ProcessInfo process_info;
+  process_info.working_directory = working_directory.string();
+  process_info.command_line = executable.string();
+  if (!arguments.empty()) {
+    process_info.command_line += absl::StrFormat(" %s", arguments);
+  }
+
+  const char* current_directory =
+      process_info.working_directory.empty() ? nullptr : process_info.working_directory.c_str();
+
+  STARTUPINFOA si = {0};
+  PROCESS_INFORMATION pi = {0};
+  si.cb = sizeof(si);
+
+  if (CreateProcessA(/*lpApplicationName=*/nullptr, process_info.command_line.data(),
+                     /*lpProcessAttributes*/ nullptr, /*lpThreadAttributes*/ nullptr,
+                     /*bInheritHandles*/ FALSE,
+                     /*dwCreationFlags=*/creation_flags, /*lpEnvironment*/ nullptr,
+                     /*lpCurrentDirectory=*/current_directory,
+                     /*lpStartupInfo=*/&si,
+                     /*lpProcessInformation=*/&pi) == 0) {
+    return ErrorMessage(
+        absl::StrFormat("Calling \"CreateProcess\": %s", orbit_base::GetLastErrorAsString()));
+  }
+
+  // A SafeHandle makes sure "CloseHandle" is called when process_info goes out of scope.
+  process_info.process_handle = SafeHandle(pi.hProcess);
+  process_info.thread_handle = SafeHandle(pi.hThread);
+
+  process_info.process_id = pi.dwProcessId;
+  return process_info;
+}
+
+}  // namespace
+
+ErrorMessageOr<ProcessInfo> CreateProcessToDebug(std::filesystem::path executable,
+                                                 std::filesystem::path working_directory,
+                                                 std::string arguments) {
+  return CreateProcess(executable, working_directory, arguments, DEBUG_ONLY_THIS_PROCESS);
+}
+
+ErrorMessageOr<ProcessInfo> CreateProcess(std::filesystem::path executable,
+                                          std::filesystem::path working_directory,
+                                          std::string arguments) {
+  return CreateProcess(executable, working_directory, arguments, /*creation_flags=*/0);
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/CreateProcessTest.cpp
+++ b/src/WindowsUtils/CreateProcessTest.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitBase/ExecutablePath.h"
+#include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
+#include "WindowsUtils/CreateProcess.h"
+#include "WindowsUtils/ProcessList.h"
+
+namespace {
+std::filesystem::path GetTestExecutablePath() {
+  static auto path = orbit_base::GetExecutableDir() / "FakeCliProgram.exe";
+  return path;
+}
+
+}  // namespace
+
+using orbit_windows_utils::ProcessInfo;
+using orbit_windows_utils::ProcessList;
+
+TEST(CreateProcess, SuccessfulProcessCreation) {
+  constexpr const char* kArguments = "sleep_for_ms=5000";
+  auto result = orbit_windows_utils::CreateProcess(GetTestExecutablePath(), "", kArguments);
+  ASSERT_FALSE(result.has_error());
+  ProcessInfo& process_info = result.value();
+  std::unique_ptr<ProcessList> process_list = ProcessList::Create();
+  EXPECT_TRUE(process_list->GetProcessByPid(process_info.process_id).has_value());
+}
+
+TEST(CreateProcess, CommandLine) {
+  constexpr const char* kArguments = "sleep_for_ms=20";
+  auto result = orbit_windows_utils::CreateProcess(GetTestExecutablePath(), "", kArguments);
+  ASSERT_FALSE(result.has_error());
+  ProcessInfo& process_info = result.value();
+  std::string expected_command_line =
+      absl::StrFormat("%s %s", GetTestExecutablePath().string(), kArguments);
+  EXPECT_EQ(process_info.command_line, expected_command_line);
+}
+
+TEST(CreateProcess, WorkingDirectory) {
+  auto result =
+      orbit_windows_utils::CreateProcess(GetTestExecutablePath(), orbit_test::GetTestdataDir(), "");
+  ASSERT_FALSE(result.has_error());
+  ProcessInfo& process_info = result.value();
+  EXPECT_EQ(process_info.working_directory, orbit_test::GetTestdataDir().string());
+}
+
+TEST(CreateProcess, NonExistingExecutable) {
+  const std::string executable = R"(C:\non_existing_executable.exe)";
+  auto result = orbit_windows_utils::CreateProcess(executable, "", "");
+  EXPECT_THAT(result, orbit_test_utils::HasError("Executable does not exist"));
+}
+
+TEST(CreateProcess, NonExistingWorkingDirectory) {
+  const std::string non_existing_working_directory = R"(C:\non_existing_directory)";
+  auto result = orbit_windows_utils::CreateProcess(GetTestExecutablePath(),
+                                                   non_existing_working_directory, "");
+  EXPECT_THAT(result, orbit_test_utils::HasError("Working directory does not exist"));
+}

--- a/src/WindowsUtils/CreateProcessTest.cpp
+++ b/src/WindowsUtils/CreateProcessTest.cpp
@@ -10,8 +10,6 @@
 #include "WindowsUtils/CreateProcess.h"
 #include "WindowsUtils/ProcessList.h"
 
-#pragma optimize("", off)
-
 namespace {
 std::filesystem::path GetTestExecutablePath() {
   static auto path = orbit_base::GetExecutableDir() / "FakeCliProgram.exe";

--- a/src/WindowsUtils/include/WindowsUtils/CreateProcess.h
+++ b/src/WindowsUtils/include/WindowsUtils/CreateProcess.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_CREATE_PROCESS_H_
+#define WINDOWS_UTILS_CREATE_PROCESS_H_
+
+#include <OrbitBase/Result.h>
+#include <WindowsUtils/SafeHandle.h>
+
+#include <filesystem>
+#include <string>
+
+namespace orbit_windows_utils {
+
+// ProcessInfo is the result from a call to our CreateProcess function. The SafeHandle objects will
+// call "CloseHandle" on destruction for both the thread and process handles returned by the
+// internal call to the Windows CreateProcess function.
+struct ProcessInfo {
+  std::string working_directory;
+  std::string command_line;
+  uint32_t process_id = 0;
+  SafeHandle process_handle;
+  SafeHandle thread_handle;
+};
+
+// Create a process.
+ErrorMessageOr<ProcessInfo> CreateProcess(std::filesystem::path executable,
+                                          std::filesystem::path working_directory,
+                                          std::string arguments);
+
+// Create a process for a debugger.
+ErrorMessageOr<ProcessInfo> CreateProcessToDebug(std::filesystem::path executable,
+                                                 std::filesystem::path working_directory,
+                                                 std::string arguments);
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_CREATE_PROCESS_H_

--- a/src/WindowsUtils/include/WindowsUtils/CreateProcess.h
+++ b/src/WindowsUtils/include/WindowsUtils/CreateProcess.h
@@ -25,14 +25,14 @@ struct ProcessInfo {
 };
 
 // Create a process.
-ErrorMessageOr<ProcessInfo> CreateProcess(std::filesystem::path executable,
-                                          std::filesystem::path working_directory,
-                                          std::string arguments);
+ErrorMessageOr<ProcessInfo> CreateProcess(const std::filesystem::path& executable,
+                                          const std::filesystem::path& working_directory,
+                                          const std::string_view arguments);
 
 // Create a process for a debugger.
-ErrorMessageOr<ProcessInfo> CreateProcessToDebug(std::filesystem::path executable,
-                                                 std::filesystem::path working_directory,
-                                                 std::string arguments);
+ErrorMessageOr<ProcessInfo> CreateProcessToDebug(const std::filesystem::path& executable,
+                                                 const std::filesystem::path& working_directory,
+                                                 const std::string_view arguments);
 
 }  // namespace orbit_windows_utils
 

--- a/src/WindowsUtils/include/WindowsUtils/SafeHandle.h
+++ b/src/WindowsUtils/include/WindowsUtils/SafeHandle.h
@@ -19,6 +19,7 @@ using SafeHandleBase = orbit_base::unique_resource<HANDLE, void (*)(HANDLE)>;
 
 // Wrapper around a Windows "HANDLE" which calls "CloseHandle" on destruction if non-null.
 struct SafeHandle : public SafeHandleBase {
+  SafeHandle() = default;
   explicit SafeHandle(HANDLE handle);
   [[nodiscard]] HANDLE operator*() const { return get(); }
 };

--- a/src/WindowsUtils/include/WindowsUtils/SafeHandle.h
+++ b/src/WindowsUtils/include/WindowsUtils/SafeHandle.h
@@ -19,7 +19,6 @@ using SafeHandleBase = orbit_base::unique_resource<HANDLE, void (*)(HANDLE)>;
 
 // Wrapper around a Windows "HANDLE" which calls "CloseHandle" on destruction if non-null.
 struct SafeHandle : public SafeHandleBase {
-  SafeHandle() = default;
   explicit SafeHandle(HANDLE handle);
   [[nodiscard]] HANDLE operator*() const { return get(); }
 };


### PR DESCRIPTION
Add wrappers around Windows' CreateProcess function.
This will be used in Windows tests that need to interact 
with remote processes, and for allowing profiling from
entry point.

Tests: Compiled and ran tests.