### PR TITLE
Make mouse line visible in the timeline

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -801,8 +801,11 @@ void CaptureWindow::RenderSelectionOverlay() {
   float stop_pos_world = time_graph_->GetWorldFromTick(select_stop_time_);
 
   float size_x = to_world - from_world;
-  Vec2 pos(from_world, 0);
-  Vec2 size(size_x, viewport_.GetWorldHeight());
+  // TODO(http://b/226401787): Allow green selection overlay to be on top of the Timeline after
+  // modifying its design and how it the overlay is drawn.
+  float initial_y_position = time_graph_->GetLayout().GetTimeBarHeight();
+  Vec2 pos(from_world, initial_y_position);
+  Vec2 size(size_x, viewport_.GetWorldHeight() - initial_y_position);
 
   std::string text = orbit_display_formats::GetDisplayTime(TicksToDuration(min_time, max_time));
   const Color color(0, 128, 0, 128);

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -802,7 +802,7 @@ void CaptureWindow::RenderSelectionOverlay() {
 
   float size_x = to_world - from_world;
   // TODO(http://b/226401787): Allow green selection overlay to be on top of the Timeline after
-  // modifying its design and how it the overlay is drawn.
+  // modifying its design and how the overlay is drawn
   float initial_y_position = time_graph_->GetLayout().GetTimeBarHeight();
   Vec2 pos(from_world, initial_y_position);
   Vec2 size(size_x, viewport_.GetWorldHeight() - initial_y_position);

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -20,6 +20,9 @@
 #include "OrbitBase/Logging.h"
 
 // Tracks: 0.0 - 0.1
+// Tracks - Moving: 0.1 - 0.2
+// Tracks - Pinned: 0.2 - 0.3
+// TimeBar: 0.3 - 0.4
 // World Overlay: 0.4 - 0.5
 // UI: 0.6 - 0.7
 // ScreenSpace: 0.8 - 0.9
@@ -30,15 +33,15 @@ float GlCanvas::kZValueBox = 0.05f;
 float GlCanvas::kZValueEvent = 0.07f;
 float GlCanvas::kZValueTrackText = 0.08f;
 float GlCanvas::kZValueTrackLabel = 0.09f;
+float GlCanvas::kZValueTimeBar = 0.31f;
+float GlCanvas::kZValueTimeBarLabel = 0.33f;
+float GlCanvas::kZValueTimeBarMouseLabel = 0.35f;
 float GlCanvas::kZValueIncompleteDataOverlay = 0.42f;
 float GlCanvas::kZValueOverlay = 0.43f;
 float GlCanvas::kZValueOverlayTextBackground = 0.45f;
 float GlCanvas::kZValueEventBarPicking = 0.49f;
 float GlCanvas::kZValueUi = 0.61f;
 float GlCanvas::kZValueTextUi = 0.61f;
-float GlCanvas::kZValueTimeBarBg = 0.81f;
-float GlCanvas::kZValueTimeBar = 0.83f;
-float GlCanvas::kZValueTimeBarMouseLabel = 0.84f;
 float GlCanvas::kZValueMargin = 0.85f;
 float GlCanvas::kZValueSliderBg = 0.87f;
 float GlCanvas::kZValueSlider = 0.89f;

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -97,26 +97,25 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   [[nodiscard]] const orbit_gl::Viewport& GetViewport() const { return viewport_; }
   [[nodiscard]] orbit_gl::Viewport& GetViewport() { return viewport_; }
 
-  static float kZValueSlider;
-  static float kZValueSliderBg;
-  static float kZValueMargin;
-  static float kZValueTimeBarMouseLabel;
-  static float kZValueTimeBar;
-  static float kZValueTimeBarBg;
-  static float kZValueTextUi;
-  static float kZValueUi;
-  static float kZValueEventBarPicking;
-  static float kZValueOverlayTextBackground;
-  static float kZValueOverlay;
-  static float kZValueIncompleteDataOverlay;
+  static float kZValueTrack;
+  static float kZValueIncompleteDataOverlayPicking;
+  static float kZValueEventBar;
+  static float kZValueBox;
+  static float kZValueEvent;
   static float kZValueTrackText;
   static float kZValueTrackLabel;
-  static float kZValueEvent;
-  static float kZValueBox;
-  static float kZValueBoxBorder;
-  static float kZValueEventBar;
-  static float kZValueIncompleteDataOverlayPicking;
-  static float kZValueTrack;
+  static float kZValueTimeBar;
+  static float kZValueTimeBarLabel;
+  static float kZValueTimeBarMouseLabel;
+  static float kZValueIncompleteDataOverlay;
+  static float kZValueOverlay;
+  static float kZValueOverlayTextBackground;
+  static float kZValueEventBarPicking;
+  static float kZValueUi;
+  static float kZValueTextUi;
+  static float kZValueMargin;
+  static float kZValueSliderBg;
+  static float kZValueSlider;
 
   static float kZOffsetMovingTrack;
   static float kZOffsetPinnedTrack;

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -20,7 +20,7 @@ const Color kBackgroundColorSpecialLabels(68, 67, 69, 255);
 void TimelineUi::RenderLines(Batcher& batcher, uint64_t min_timestamp_ns,
                              uint64_t max_timestamp_ns) const {
   const Color kMajorTickColor(255, 254, 253, 255);
-  const Color kMinorTickColor(63, 62, 63, 255);
+  const Color kMinorTickColor(255, 254, 253, 63);
 
   for (auto& [tick_type, tick_ns] :
        timeline_ticks_.GetAllTicks(min_timestamp_ns, max_timestamp_ns)) {
@@ -28,7 +28,7 @@ void TimelineUi::RenderLines(Batcher& batcher, uint64_t min_timestamp_ns,
         tick_ns / static_cast<double>(kNanosecondsPerMicrosecond));
     int screen_x = viewport_->WorldToScreen(Vec2(world_x, 0))[0];
     batcher.AddVerticalLine(
-        Vec2(screen_x, GetPos()[1]), GetHeightWithoutMargin(), GlCanvas::kZValueTimeBarBg,
+        Vec2(screen_x, GetPos()[1]), GetHeightWithoutMargin(), GlCanvas::kZValueTimeBar,
         tick_type == TimelineTicks::TickType::kMajorTick ? kMajorTickColor : kMinorTickColor);
   }
 }
@@ -45,8 +45,8 @@ void TimelineUi::RenderLabels(Batcher& batcher, TextRenderer& text_renderer,
   }
 
   for (uint64_t tick_ns : GetTicksForNonOverlappingLabels(text_renderer, all_major_ticks)) {
-    RenderLabel(batcher, text_renderer, tick_ns, GetNumDecimalsInLabels(), GlCanvas::kZValueTimeBar,
-                GlCanvas::kTimeBarBackgroundColor);
+    RenderLabel(batcher, text_renderer, tick_ns, GetNumDecimalsInLabels(),
+                GlCanvas::kZValueTimeBarLabel, GlCanvas::kTimeBarBackgroundColor);
   }
 }
 
@@ -59,7 +59,7 @@ void TimelineUi::RenderMargin(Batcher& batcher) const {
 
 void TimelineUi::RenderBackground(Batcher& batcher) const {
   Box background_box(GetPos(), Vec2(GetWidth(), GetHeightWithoutMargin()),
-                     GlCanvas::kZValueTimeBarBg);
+                     GlCanvas::kZValueTimeBar);
   batcher.AddBox(background_box, GlCanvas::kTimeBarBackgroundColor);
 }
 


### PR DESCRIPTION
In this PR we are decreasing the z-position of the timeline, so it is
drawn below the mouse green line. In addition, we are decreasing the
size of the green overlay so it's not being drawn on top of the timeline
(Open bug: http://b/226401787) and modifying the minor tick to be fully
white but with alpha value as Carsten suggested.

http://screenshot/yxKUy2iCcJbTxFm

Bug: https://b/226402406