### PR TITLE
Windows Debugger

### DIFF
--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -22,6 +22,7 @@ target_include_directories(WindowsUtils PRIVATE
 target_sources(WindowsUtils PUBLIC
         include/WindowsUtils/AdjustTokenPrivilege.h
         include/WindowsUtils/CreateProcess.h
+        include/WindowsUtils/Debugger.h
         include/WindowsUtils/DllInjection.h
         include/WindowsUtils/FindDebugSymbols.h
         include/WindowsUtils/ListModules.h
@@ -35,6 +36,7 @@ target_sources(WindowsUtils PUBLIC
 target_sources(WindowsUtils PRIVATE
         AdjustTokenPrivilege.cpp
         CreateProcess.cpp
+        Debugger.cpp
         DllInjection.cpp
         FindDebugSymbols.cpp
         ListModules.cpp
@@ -54,6 +56,7 @@ add_executable(WindowsUtilsTests)
 
 target_sources(WindowsUtilsTests PRIVATE
         CreateProcessTest.cpp
+        DebuggerTest.cpp
         DllInjectionTest.cpp
         FindDebugSymbolsTest.cpp
         ListModulesTest.cpp

--- a/src/WindowsUtils/Debugger.cpp
+++ b/src/WindowsUtils/Debugger.cpp
@@ -36,7 +36,7 @@ Debugger::~Debugger() { Wait(); }
 ErrorMessageOr<Debugger::StartInfo> Debugger::Start(const std::filesystem::path& executable,
                                                     const std::filesystem::path& working_directory,
                                                     const std::string_view arguments) {
-  // Make sure we have at least on debug event listener.
+  // Make sure we have at least one debug event listener.
   if (debug_event_listeners_.size() == 0) {
     return ErrorMessage("Debugger has no debug event listener");
   }

--- a/src/WindowsUtils/Debugger.cpp
+++ b/src/WindowsUtils/Debugger.cpp
@@ -29,23 +29,20 @@ ErrorMessageOr<Debugger::StartInfo> CreateStartInfoOrError(
 }  // namespace
 
 Debugger::Debugger(std::vector<DebugEventListener*> debug_event_listeners)
-    : debug_event_listeners_(std::move(debug_event_listeners)) {}
+    : debug_event_listeners_(std::move(debug_event_listeners)) {
+  ORBIT_CHECK(debug_event_listeners_.size() != 0);
+}
 
 Debugger::~Debugger() { Wait(); }
 
 ErrorMessageOr<Debugger::StartInfo> Debugger::Start(const std::filesystem::path& executable,
                                                     const std::filesystem::path& working_directory,
                                                     const std::string_view arguments) {
-  // Make sure we have at least one debug event listener.
-  if (debug_event_listeners_.size() == 0) {
-    return ErrorMessage("Debugger has no debug event listener");
-  }
-
   // Launch process and start debugging loop on the same separate thread.
   thread_ = std::thread(&Debugger::DebuggerThread, this, executable, working_directory,
                         std::string(arguments));
 
-  // Return "StartInfo" or error based on the result of process creation from "DebuggerThread".
+  // Wait for "DebuggerThread" to create the process and return result of process creation.
   return start_info_or_error_promise_.GetFuture().Get();
 }
 

--- a/src/WindowsUtils/Debugger.cpp
+++ b/src/WindowsUtils/Debugger.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/Debugger.h"
+
+#include "OrbitBase/GetLastError.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/StringConversion.h"
+#include "OrbitBase/ThreadUtils.h"
+#include "WindowsUtils/CreateProcess.h"
+#include "WindowsUtils/SafeHandle.h"
+
+namespace orbit_windows_utils {
+
+Debugger::Debugger() : process_info_or_error_(ErrorMessage()) {}
+Debugger::~Debugger() { Wait(); }
+
+ErrorMessageOr<ProcessInfo> Debugger::Start(const std::filesystem::path& executable,
+                                            const std::filesystem::path& working_directory,
+                                            std::string_view arguments) {
+  // Launch process and start debugging loop on the same separate thread.
+  thread_ = std::thread(&Debugger::DebuggerThread, this, executable, working_directory,
+                        std::string(arguments));
+
+  // We use "create_process_promise_" to wait until the result of "CreateProcessToDebug", which is
+  // stored in "process_info_or_error_", is available from the  debugger thread.
+  create_process_promise_.GetFuture().Wait();
+  return std::move(process_info_or_error_);
+}
+
+void Debugger::Detach() { detach_requested_ = true; }
+
+void Debugger::Wait() {
+  if (thread_.joinable()) thread_.join();
+}
+
+void Debugger::DebuggerThread(std::filesystem::path executable,
+                              std::filesystem::path working_directory, std::string arguments) {
+  orbit_base::SetCurrentThreadName("OrbitDebugger");
+
+  // Only the thread that created the process being debugged can call WaitForDebugEvent.
+  process_info_or_error_ = CreateProcessToDebug(executable, working_directory, arguments);
+  create_process_promise_.SetResult(true);
+  if (process_info_or_error_.has_error()) {
+    return;
+  }
+
+  DEBUG_EVENT debug_event = {0};
+  bool continue_debugging = true;
+  DWORD continue_status = DBG_CONTINUE;
+  constexpr uint32_t kWaitForDebugEventMs = 500;
+  constexpr uint32_t kSemaphoreExpiredErrorCode = 121;
+
+  while (continue_debugging) {
+    if (!WaitForDebugEvent(&debug_event, kWaitForDebugEventMs)) {
+      if (::GetLastError() != kSemaphoreExpiredErrorCode) {
+        ORBIT_ERROR("Calling \"WaitForDebugEvent\": %s", orbit_base::GetLastErrorAsString());
+        detach_requested_ = true;
+      }
+      if (!detach_requested_) continue;
+      DebugActiveProcessStop(process_info_or_error_.value().process_id);
+      break;
+    }
+
+    switch (debug_event.dwDebugEventCode) {
+      case CREATE_PROCESS_DEBUG_EVENT:
+        OnCreateProcessDebugEvent(debug_event);
+        break;
+      case EXIT_PROCESS_DEBUG_EVENT:
+        OnExitProcessDebugEvent(debug_event);
+        Detach();
+        break;
+      case CREATE_THREAD_DEBUG_EVENT:
+        OnCreateThreadDebugEvent(debug_event);
+        break;
+      case EXIT_THREAD_DEBUG_EVENT:
+        OnExitThreadDebugEvent(debug_event);
+        break;
+      case LOAD_DLL_DEBUG_EVENT:
+        OnLoadDllDebugEvent(debug_event);
+        break;
+      case UNLOAD_DLL_DEBUG_EVENT:
+        OnUnLoadDllDebugEvent(debug_event);
+        break;
+      case OUTPUT_DEBUG_STRING_EVENT:
+        OnOutputStringDebugEvent(debug_event);
+        break;
+      case RIP_EVENT:
+        OnRipEvent(debug_event);
+        break;
+      case EXCEPTION_DEBUG_EVENT: {
+        EXCEPTION_DEBUG_INFO& exception = debug_event.u.Exception;
+        if (exception.ExceptionRecord.ExceptionCode == STATUS_BREAKPOINT) {
+          OnBreakpointDebugEvent(debug_event);
+        } else {
+          OnExceptionDebugEvent(debug_event);
+          if (exception.dwFirstChance == 1) {
+            ORBIT_LOG("First chance exception at %x, exception-code: 0x%08x",
+                      exception.ExceptionRecord.ExceptionAddress,
+                      exception.ExceptionRecord.ExceptionCode);
+          }
+          continue_status = DBG_EXCEPTION_NOT_HANDLED;
+        }
+        break;
+      }
+      default:
+        ORBIT_ERROR("Unhandled debugger event code: %u", debug_event.dwDebugEventCode);
+    }
+
+    ContinueDebugEvent(debug_event.dwProcessId, debug_event.dwThreadId, continue_status);
+    continue_status = DBG_CONTINUE;
+  }
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/DebuggerTest.cpp
+++ b/src/WindowsUtils/DebuggerTest.cpp
@@ -54,11 +54,11 @@ TEST(Debugger, LaunchProcess) {
   const std::string kArguments = "--sleep_for_ms=20";
   auto result = debugger.Start(GetTestExecutablePath(), /*working_directory=*/"", kArguments);
   ASSERT_TRUE(result.has_value());
-  ProcessInfo& process_info = result.value();
 
+  Debugger::StartInfo& start_info = result.value();
   std::string expected_command_line = GetTestExecutablePath().string();
   if (!kArguments.empty()) expected_command_line += absl::StrFormat(" %s", kArguments);
-  EXPECT_STREQ(process_info.command_line.c_str(), expected_command_line.c_str());
+  EXPECT_STREQ(start_info.command_line.c_str(), expected_command_line.c_str());
 
   // Wait for debugger to automatically detach upon process termination.
   debugger.Wait();

--- a/src/WindowsUtils/DebuggerTest.cpp
+++ b/src/WindowsUtils/DebuggerTest.cpp
@@ -7,24 +7,16 @@
 #include <gtest/gtest.h>
 
 #include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/GetLastError.h"
 #include "OrbitBase/StringConversion.h"
 #include "TestUtils/TestUtils.h"
 #include "WindowsUtils/Debugger.h"
+#include "WindowsUtils/OpenProcess.h"
+#include "WindowsUtils/ProcessList.h"
 
 namespace {
 
-std::filesystem::path GetTestExecutablePath() {
-  static auto path = orbit_base::GetExecutableDir() / "FakeCliProgram.exe";
-  return path;
-}
-
-using orbit_windows_utils::DebugEventListener;
-using orbit_windows_utils::Debugger;
-using orbit_windows_utils::ProcessInfo;
-
-}  // namespace
-
-struct MockListener : public DebugEventListener {
+struct MockListener : public orbit_windows_utils::DebugEventListener {
   MOCK_METHOD(void, OnCreateProcessDebugEvent, (const DEBUG_EVENT& event), (override));
   MOCK_METHOD(void, OnExitProcessDebugEvent, (const DEBUG_EVENT& event), (override));
   MOCK_METHOD(void, OnCreateThreadDebugEvent, (const DEBUG_EVENT& event), (override));
@@ -36,6 +28,19 @@ struct MockListener : public DebugEventListener {
   MOCK_METHOD(void, OnExceptionDebugEvent, (const DEBUG_EVENT& event), (override));
   MOCK_METHOD(void, OnRipEvent, (const DEBUG_EVENT& event), (override));
 };
+
+std::filesystem::path GetTestExecutablePath() {
+  static auto path = orbit_base::GetExecutableDir() / "FakeCliProgram.exe";
+  return path;
+}
+
+using orbit_windows_utils::DebugEventListener;
+using orbit_windows_utils::Debugger;
+using orbit_windows_utils::ProcessInfo;
+using orbit_windows_utils::ProcessList;
+using orbit_windows_utils::SafeHandle;
+
+}  // namespace
 
 TEST(Debugger, LaunchProcess) {
   constexpr size_t kNumListeners = 10;
@@ -64,13 +69,61 @@ TEST(Debugger, LaunchProcess) {
   auto result = debugger.Start(GetTestExecutablePath(), /*working_directory=*/"", kArguments);
   ASSERT_TRUE(result.has_value());
 
-  Debugger::StartInfo& start_info = result.value();
+  const Debugger::StartInfo& start_info = result.value();
   std::string expected_command_line = GetTestExecutablePath().string();
   if (!kArguments.empty()) expected_command_line += absl::StrFormat(" %s", kArguments);
-  EXPECT_STREQ(start_info.command_line.c_str(), expected_command_line.c_str());
+  EXPECT_EQ(start_info.command_line, expected_command_line);
 
   // Wait for debugger to automatically detach upon process termination.
   debugger.Wait();
+
+  // Make sure process is not still runnning.
+  std::unique_ptr<ProcessList> process_list = ProcessList::Create();
+  EXPECT_FALSE(process_list->GetProcessByPid(start_info.process_id).has_value());
+}
+
+TEST(Debugger, Detach) {
+  MockListener mock_listener;
+  Debugger debugger({&mock_listener});
+
+  EXPECT_CALL(mock_listener, OnCreateProcessDebugEvent).Times(1);
+  EXPECT_CALL(mock_listener, OnExitProcessDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(mock_listener, OnBreakpointDebugEvent).Times(1);
+  EXPECT_CALL(mock_listener, OnCreateThreadDebugEvent).Times(testing::AtLeast(1));
+  EXPECT_CALL(mock_listener, OnExitThreadDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(mock_listener, OnLoadDllDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(mock_listener, OnUnLoadDllDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(mock_listener, OnOutputStringDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(mock_listener, OnExceptionDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(mock_listener, OnRipEvent).Times(testing::AnyNumber());
+
+  // Start process which sleeps indefinitely as debuggee.
+  constexpr const char* kArguments = "--infinite_sleep=true";
+  auto result = debugger.Start(GetTestExecutablePath(), /*working_directory=*/"", kArguments);
+  ASSERT_TRUE(result.has_value());
+  const Debugger::StartInfo& start_info = result.value();
+
+  // Detach debugger from debuggee.
+  debugger.Detach();
+
+  // Make sure the debugger thread exits.
+  debugger.Wait();
+
+  // Make sure debuggee is still runnning after detach operation.
+  std::unique_ptr<ProcessList> process_list = ProcessList::Create();
+  EXPECT_TRUE(process_list->GetProcessByPid(start_info.process_id).has_value());
+
+  // Terminate debuggee.
+  auto safe_handle_or_error = orbit_windows_utils::OpenProcess(
+      PROCESS_ALL_ACCESS, /*inherit_handle=*/false, start_info.process_id);
+  ASSERT_TRUE(safe_handle_or_error.has_value());
+  const SafeHandle& process_handle = safe_handle_or_error.value();
+  EXPECT_NE(TerminateProcess(*process_handle, /*exit_code*/ 0), 0)
+      << orbit_base::GetLastErrorAsString();
+
+  // Make sure debuggee is not still runnning.
+  process_list->Refresh();
+  EXPECT_FALSE(process_list->GetProcessByPid(start_info.process_id).has_value());
 }
 
 TEST(Debugger, NoListener) {

--- a/src/WindowsUtils/DebuggerTest.cpp
+++ b/src/WindowsUtils/DebuggerTest.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/base/casts.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/StringConversion.h"
+#include "TestUtils/TestUtils.h"
+#include "WindowsUtils/Debugger.h"
+
+namespace {
+
+std::filesystem::path GetTestExecutablePath() {
+  static auto path = orbit_base::GetExecutableDir() / "FakeCliProgram.exe";
+  return path;
+}
+
+using orbit_windows_utils::Debugger;
+using orbit_windows_utils::ProcessInfo;
+
+}  // namespace
+
+class MockDebugger : public Debugger {
+ public:
+  MOCK_METHOD(void, OnCreateProcessDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnExitProcessDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnCreateThreadDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnExitThreadDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnLoadDllDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnUnLoadDllDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnBreakpointDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnOutputStringDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnExceptionDebugEvent, (const DEBUG_EVENT& event), (override));
+  MOCK_METHOD(void, OnRipEvent, (const DEBUG_EVENT& event), (override));
+};
+
+TEST(Debugger, LaunchProcess) {
+  MockDebugger debugger;
+
+  EXPECT_CALL(debugger, OnCreateProcessDebugEvent).Times(1);
+  EXPECT_CALL(debugger, OnExitProcessDebugEvent).Times(1);
+  EXPECT_CALL(debugger, OnBreakpointDebugEvent).Times(1);
+  EXPECT_CALL(debugger, OnCreateThreadDebugEvent).Times(testing::AtLeast(1));
+  EXPECT_CALL(debugger, OnExitThreadDebugEvent).Times(testing::AtLeast(1));
+  EXPECT_CALL(debugger, OnLoadDllDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(debugger, OnUnLoadDllDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(debugger, OnOutputStringDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(debugger, OnExceptionDebugEvent).Times(testing::AnyNumber());
+  EXPECT_CALL(debugger, OnRipEvent).Times(testing::AnyNumber());
+
+  const std::string kArguments = "--sleep_for_ms=20";
+  auto result = debugger.Start(GetTestExecutablePath(), /*working_directory=*/"", kArguments);
+  ASSERT_TRUE(result.has_value());
+  ProcessInfo& process_info = result.value();
+
+  std::string expected_command_line = GetTestExecutablePath().string();
+  if (!kArguments.empty()) expected_command_line += absl::StrFormat(" %s", kArguments);
+  EXPECT_STREQ(process_info.command_line.c_str(), expected_command_line.c_str());
+
+  // Wait for debugger to automatically detach upon process termination.
+  debugger.Wait();
+}
+
+TEST(Debugger, NonExistingExecutable) {
+  MockDebugger debugger;
+  const std::string executable = R"(C:\non_existing_executable.exe)";
+  auto result = debugger.Start(executable, "", "");
+  EXPECT_THAT(result, orbit_test_utils::HasError("Executable does not exist"));
+}
+
+TEST(Debugger, NonExistingWorkingDirectory) {
+  MockDebugger debugger;
+  const std::string non_existing_working_directory = R"(C:\non_existing_directory)";
+  auto result = debugger.Start(GetTestExecutablePath(), non_existing_working_directory, "");
+  EXPECT_THAT(result, orbit_test_utils::HasError("Working directory does not exist"));
+}

--- a/src/WindowsUtils/DebuggerTest.cpp
+++ b/src/WindowsUtils/DebuggerTest.cpp
@@ -122,16 +122,11 @@ TEST(Debugger, Detach) {
       << orbit_base::GetLastErrorAsString();
 
   // Make sure debuggee is not still runnning.
-  process_list->Refresh();
+  EXPECT_TRUE(process_list->Refresh().has_value());
   EXPECT_FALSE(process_list->GetProcessByPid(start_info.process_id).has_value());
 }
 
-TEST(Debugger, NoListener) {
-  Debugger debugger({});
-  const std::string kArguments = "--sleep_for_ms=20";
-  auto result = debugger.Start(GetTestExecutablePath(), /*working_directory=*/"", kArguments);
-  EXPECT_THAT(result, orbit_test_utils::HasError("Debugger has no debug event listener"));
-}
+TEST(Debugger, NoListener) { EXPECT_DEATH(Debugger({}), "Check failed"); }
 
 TEST(Debugger, NonExistingExecutable) {
   MockListener listener;

--- a/src/WindowsUtils/DebuggerTest.cpp
+++ b/src/WindowsUtils/DebuggerTest.cpp
@@ -120,10 +120,6 @@ TEST(Debugger, Detach) {
   const SafeHandle& process_handle = safe_handle_or_error.value();
   EXPECT_NE(TerminateProcess(*process_handle, /*exit_code*/ 0), 0)
       << orbit_base::GetLastErrorAsString();
-
-  // Make sure debuggee is not still runnning.
-  EXPECT_TRUE(process_list->Refresh().has_value());
-  EXPECT_FALSE(process_list->GetProcessByPid(start_info.process_id).has_value());
 }
 
 TEST(Debugger, NoListener) { EXPECT_DEATH(Debugger({}), "Check failed"); }

--- a/src/WindowsUtils/include/WindowsUtils/Debugger.h
+++ b/src/WindowsUtils/include/WindowsUtils/Debugger.h
@@ -21,7 +21,10 @@
 
 namespace orbit_windows_utils {
 
+// Base class for debug event listeners to be used by the "Debugger" class below.
 struct DebugEventListener {
+  virtual ~DebugEventListener() = default;
+
   virtual void OnCreateProcessDebugEvent(const DEBUG_EVENT& event) = 0;
   virtual void OnExitProcessDebugEvent(const DEBUG_EVENT& event) = 0;
   virtual void OnCreateThreadDebugEvent(const DEBUG_EVENT& event) = 0;
@@ -34,10 +37,13 @@ struct DebugEventListener {
   virtual void OnRipEvent(const DEBUG_EVENT& event) = 0;
 };
 
+// "Debugger" allows to launch a process and receive debugging events such as process and thread
+// creation and exit, module loads and unloads, breakpoints, etc. Debugging events are relayed to
+// listeners of type "DebugEventListener" which need to be specified at creation.
 class Debugger {
  public:
   explicit Debugger(std::vector<DebugEventListener*> debug_event_listeners);
-  virtual ~Debugger();
+  ~Debugger();
 
   struct StartInfo {
     std::string working_directory;

--- a/src/WindowsUtils/include/WindowsUtils/Debugger.h
+++ b/src/WindowsUtils/include/WindowsUtils/Debugger.h
@@ -25,10 +25,16 @@ class Debugger {
   Debugger();
   virtual ~Debugger();
 
+  struct StartInfo {
+    std::string working_directory;
+    std::string command_line;
+    uint32_t process_id = 0;
+  };
+
   // Start debugging, this call is non-blocking.
-  ErrorMessageOr<ProcessInfo> Start(const std::filesystem::path& executable,
-                                    const std::filesystem::path& working_directory,
-                                    const std::string_view arguments);
+  ErrorMessageOr<StartInfo> Start(const std::filesystem::path& executable,
+                                  const std::filesystem::path& working_directory,
+                                  const std::string_view arguments);
   // Detach debugger from process.
   void Detach();
   // Wait for debuggee to exit.
@@ -50,10 +56,12 @@ class Debugger {
  private:
   void DebuggerThread(std::filesystem::path executable, std::filesystem::path working_directory,
                       std::string arguments);
+  void DebuggingLoop(uint32_t process_id);
+  uint32_t HandleDebugEvent(const DEBUG_EVENT& event);
+
   std::thread thread_;
   std::atomic<bool> detach_requested_ = false;
-  ErrorMessageOr<ProcessInfo> process_info_or_error_;
-  orbit_base::Promise<bool> create_process_promise_;
+  orbit_base::Promise<ErrorMessageOr<StartInfo>> start_info_or_error_promise_;
 };
 
 }  // namespace orbit_windows_utils

--- a/src/WindowsUtils/include/WindowsUtils/Debugger.h
+++ b/src/WindowsUtils/include/WindowsUtils/Debugger.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_DEBUGGER_H_
+#define WINDOWS_UTILS_DEBUGGER_H_
+
+// clang-format off
+#include <Windows.h>
+#include <psapi.h>
+// clang-format on
+
+#include "OrbitBase/Promise.h"
+#include "OrbitBase/Result.h"
+#include "WindowsUtils/CreateProcess.h"
+
+#include <filesystem>
+#include <string>
+#include <thread>
+
+namespace orbit_windows_utils {
+
+class Debugger {
+ public:
+  Debugger();
+  virtual ~Debugger();
+
+  // Start debugging, this call is non-blocking.
+  ErrorMessageOr<ProcessInfo> Start(const std::filesystem::path& executable,
+                                    const std::filesystem::path& working_directory,
+                                    const std::string_view arguments);
+  // Detach debugger from process.
+  void Detach();
+  // Wait for debuggee to exit.
+  void Wait();
+
+ protected:
+  // The functions below will not be called from the thread "Start" was called from.
+  virtual void OnCreateProcessDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnExitProcessDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnCreateThreadDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnExitThreadDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnLoadDllDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnUnLoadDllDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnBreakpointDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnOutputStringDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnExceptionDebugEvent(const DEBUG_EVENT& event) = 0;
+  virtual void OnRipEvent(const DEBUG_EVENT& event) = 0;
+
+ private:
+  void DebuggerThread(std::filesystem::path executable, std::filesystem::path working_directory,
+                      std::string arguments);
+  std::thread thread_;
+  std::atomic<bool> detach_requested_ = false;
+  ErrorMessageOr<ProcessInfo> process_info_or_error_;
+  orbit_base::Promise<bool> create_process_promise_;
+};
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_DEBUGGER_H_


### PR DESCRIPTION
Implement a simple Windows debugger which allows us to launch a process
and receive debugging events such as process and thread creation and
exit, module loads and unloads, etc. This will be used to implement
profiling from entry point.

Tests: Compiled, ran tests.