### PR TITLE
Make ApiTrackValue a class

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -241,8 +241,8 @@ auto ApiTrackValueEq(const ApiTrackValue& expected) {
   return AllOf(Property("process_id()", &ApiTrackValue::process_id, expected.process_id()),
                Property("thread_id()", &ApiTrackValue::thread_id, expected.thread_id()),
                Property("timestamp_ns()", &ApiTrackValue::timestamp_ns, expected.timestamp_ns()),
-               Property("name()", &ApiTrackValue::name, expected.name()),
-               Property("data()", &ApiTrackValue::data, DoubleEq(expected.data())));
+               Property("track_name()", &ApiTrackValue::track_name, expected.track_name()),
+               Property("value()", &ApiTrackValue::value, DoubleEq(expected.value())));
 }
 
 }  // namespace

--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -18,12 +18,14 @@
 namespace orbit_capture_client {
 
 using orbit_client_data::ApiStringEvent;
+using orbit_client_data::ApiTrackValue;
 using orbit_client_data::CallstackInfo;
 
 using orbit_client_protos::TimerInfo;
 
 using google::protobuf::util::MessageDifferencer;
 using ::testing::AllOf;
+using ::testing::DoubleEq;
 using ::testing::Invoke;
 using ::testing::Property;
 using ::testing::SaveArg;
@@ -60,7 +62,7 @@ class MockCaptureListener : public CaptureListener {
                std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/),
               (override));
   MOCK_METHOD(void, OnApiStringEvent, (const orbit_client_data::ApiStringEvent&), (override));
-  MOCK_METHOD(void, OnApiTrackValue, (const orbit_client_protos::ApiTrackValue&), (override));
+  MOCK_METHOD(void, OnApiTrackValue, (const orbit_client_data::ApiTrackValue&), (override));
   MOCK_METHOD(void, OnWarningEvent, (orbit_grpc_protos::WarningEvent /*warning_event*/),
               (override));
   MOCK_METHOD(void, OnClockResolutionEvent,
@@ -176,20 +178,6 @@ class ApiEventProcessorTest : public ::testing::Test {
 
     return result;
   }
-  template <typename DataType>
-  static orbit_client_protos::ApiTrackValue CreateClientTrackValue(
-      uint64_t timestamp_ns, int32_t process_id, int32_t thread_id, const char* name,
-      void (orbit_client_protos::ApiTrackValue::*set_data)(DataType), DataType data) {
-    orbit_client_protos::ApiTrackValue result;
-    result.set_timestamp_ns(timestamp_ns);
-    result.set_process_id(process_id);
-    result.set_thread_id(thread_id);
-    result.set_name(name);
-
-    (result.*set_data)(data);
-
-    return result;
-  }
 
   [[deprecated]] static orbit_grpc_protos::ApiEvent CreateApiEventLegacy(
       int32_t pid, int32_t tid, uint64_t timestamp_ns, orbit_api::EventType type,
@@ -247,6 +235,14 @@ auto ApiStringEventEq(const ApiStringEvent& expected) {
   return AllOf(Property(&ApiStringEvent::async_scope_id, expected.async_scope_id()),
                Property(&ApiStringEvent::name, expected.name()),
                Property(&ApiStringEvent::should_concatenate, expected.should_concatenate()));
+}
+
+auto ApiTrackValueEq(const ApiTrackValue& expected) {
+  return AllOf(Property("process_id()", &ApiTrackValue::process_id, expected.process_id()),
+               Property("thread_id()", &ApiTrackValue::thread_id, expected.thread_id()),
+               Property("timestamp_ns()", &ApiTrackValue::timestamp_ns, expected.timestamp_ns()),
+               Property("name()", &ApiTrackValue::name, expected.name()),
+               Property("data()", &ApiTrackValue::data, DoubleEq(expected.data())));
 }
 
 }  // namespace
@@ -447,107 +443,112 @@ TEST_F(ApiEventProcessorTest, TrackDouble) {
   auto track_double = CreateTrackValue<double, orbit_grpc_protos::ApiTrackDouble>(
       1, kProcessId, kThreadId1, "Some name", 3.14);
 
-  auto expected_track_value =
-      CreateClientTrackValue<double>(1, kProcessId, kThreadId1, "Some name",
-                                     &orbit_client_protos::ApiTrackValue::set_data_double, 3.14);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name", 3.14};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiTrackDouble(track_double);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackFloat) {
+  constexpr float kValue = 3.14f;
   auto track_float = CreateTrackValue<float, orbit_grpc_protos::ApiTrackFloat>(
-      1, kProcessId, kThreadId1, "Some name", 3.14f);
+      1, kProcessId, kThreadId1, "Some name", kValue);
 
-  auto expected_track_value =
-      CreateClientTrackValue<float>(1, kProcessId, kThreadId1, "Some name",
-                                    &orbit_client_protos::ApiTrackValue::set_data_float, 3.14f);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiTrackFloat(track_float);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackInt) {
+  constexpr int32_t kValue = 3;
   auto track_int = CreateTrackValue<int32_t, orbit_grpc_protos::ApiTrackInt>(
-      1, kProcessId, kThreadId1, "Some name", 3);
+      1, kProcessId, kThreadId1, "Some name", kValue);
 
-  auto expected_track_value = CreateClientTrackValue<int32_t>(
-      1, kProcessId, kThreadId1, "Some name", &orbit_client_protos::ApiTrackValue::set_data_int, 3);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiTrackInt(track_int);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackInt64) {
+  constexpr int64_t kValue = std::numeric_limits<int64_t>::max();
   auto track_int64 = CreateTrackValue<int64_t, orbit_grpc_protos::ApiTrackInt64>(
-      1, kProcessId, kThreadId1, "Some name", 3);
+      1, kProcessId, kThreadId1, "Some name", kValue);
 
-  auto expected_track_value =
-      CreateClientTrackValue<int64_t>(1, kProcessId, kThreadId1, "Some name",
-                                      &orbit_client_protos::ApiTrackValue::set_data_int64, 3);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiTrackInt64(track_int64);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackUint) {
+  constexpr uint32_t kValue = std::numeric_limits<uint32_t>::max();
   auto track_uint = CreateTrackValue<uint32_t, orbit_grpc_protos::ApiTrackUint>(
-      1, kProcessId, kThreadId1, "Some name", 3);
+      1, kProcessId, kThreadId1, "Some name", kValue);
 
-  auto expected_track_value =
-      CreateClientTrackValue<uint32_t>(1, kProcessId, kThreadId1, "Some name",
-                                       &orbit_client_protos::ApiTrackValue::set_data_uint, 3);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiTrackUint(track_uint);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackUint64) {
+  constexpr uint64_t kValue = std::numeric_limits<uint64_t>::max();
   auto track_uint64 = CreateTrackValue<uint64_t, orbit_grpc_protos::ApiTrackUint64>(
-      1, kProcessId, kThreadId1, "Some name", 3);
+      1, kProcessId, kThreadId1, "Some name", kValue);
 
-  auto expected_track_value =
-      CreateClientTrackValue<uint64_t>(1, kProcessId, kThreadId1, "Some name",
-                                       &orbit_client_protos::ApiTrackValue::set_data_uint64, 3);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiTrackUint64(track_uint64);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, ScopesFromSameThreadLegacy) {
@@ -698,115 +699,121 @@ TEST_F(ApiEventProcessorTest, StringEventLegacy) {
 }
 
 TEST_F(ApiEventProcessorTest, TrackDoubleLegacy) {
+  constexpr double kValue = 3.14;
   auto track_double =
       CreateApiEventLegacy(kProcessId, kThreadId1, 1, orbit_api::EventType::kTrackDouble,
-                           "Some name", orbit_api::Encode<uint64_t>(3.14));
+                           "Some name", orbit_api::Encode<uint64_t>(kValue));
 
-  auto expected_track_value =
-      CreateClientTrackValue<double>(1, kProcessId, kThreadId1, "Some name",
-                                     &orbit_client_protos::ApiTrackValue::set_data_double, 3.14);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name", kValue};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiEventLegacy(track_double);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackFloatLegacy) {
+  constexpr float kValue = 3.14f;
   auto track_float =
       CreateApiEventLegacy(kProcessId, kThreadId1, 1, orbit_api::EventType::kTrackFloat,
-                           "Some name", orbit_api::Encode<uint64_t>(3.14f));
+                           "Some name", orbit_api::Encode<uint64_t>(kValue));
 
-  auto expected_track_value =
-      CreateClientTrackValue<float>(1, kProcessId, kThreadId1, "Some name",
-                                    &orbit_client_protos::ApiTrackValue::set_data_float, 3.14f);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiEventLegacy(track_float);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackIntLegacy) {
+  constexpr int32_t kValue = 3;
   auto track_int = CreateApiEventLegacy(kProcessId, kThreadId1, 1, orbit_api::EventType::kTrackInt,
-                                        "Some name", orbit_api::Encode<uint64_t>(3));
+                                        "Some name", orbit_api::Encode<uint64_t>(kValue));
 
-  auto expected_track_value = CreateClientTrackValue<int32_t>(
-      1, kProcessId, kThreadId1, "Some name", &orbit_client_protos::ApiTrackValue::set_data_int, 3);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiEventLegacy(track_int);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackInt64Legacy) {
+  constexpr int64_t kValue = std::numeric_limits<int64_t>::max();
   auto track_int64 =
       CreateApiEventLegacy(kProcessId, kThreadId1, 1, orbit_api::EventType::kTrackInt64,
-                           "Some name", orbit_api::Encode<uint64_t>(3));
+                           "Some name", orbit_api::Encode<uint64_t>(kValue));
 
-  auto expected_track_value =
-      CreateClientTrackValue<int64_t>(1, kProcessId, kThreadId1, "Some name",
-                                      &orbit_client_protos::ApiTrackValue::set_data_int64, 3);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiEventLegacy(track_int64);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackUintLegacy) {
+  constexpr uint32_t kValue = std::numeric_limits<uint32_t>::max();
   auto track_uint =
       CreateApiEventLegacy(kProcessId, kThreadId1, 1, orbit_api::EventType::kTrackUint, "Some name",
-                           orbit_api::Encode<uint64_t>(3));
+                           orbit_api::Encode<uint64_t>(kValue));
 
-  auto expected_track_value =
-      CreateClientTrackValue<uint32_t>(1, kProcessId, kThreadId1, "Some name",
-                                       &orbit_client_protos::ApiTrackValue::set_data_uint, 3);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiEventLegacy(track_uint);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 TEST_F(ApiEventProcessorTest, TrackUint64Legacy) {
+  constexpr uint64_t kValue = std::numeric_limits<uint64_t>::max();
   auto track_uint64 =
       CreateApiEventLegacy(kProcessId, kThreadId1, 1, orbit_api::EventType::kTrackUint64,
-                           "Some name", orbit_api::Encode<uint64_t>(3));
+                           "Some name", orbit_api::Encode<uint64_t>(kValue));
 
-  auto expected_track_value =
-      CreateClientTrackValue<uint64_t>(1, kProcessId, kThreadId1, "Some name",
-                                       &orbit_client_protos::ApiTrackValue::set_data_uint64, 3);
+  ApiTrackValue expected_track_value{kProcessId, kThreadId1, 1, "Some name",
+                                     static_cast<double>(kValue)};
 
-  orbit_client_protos::ApiTrackValue actual_track_value;
+  std::optional<ApiTrackValue> actual_track_value;
   EXPECT_CALL(capture_listener_, OnApiTrackValue)
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_track_value));
 
   api_event_processor_.ProcessApiEventLegacy(track_uint64);
 
-  EXPECT_TRUE(MessageDifferencer::Equivalent(expected_track_value, actual_track_value));
+  ASSERT_TRUE(actual_track_value.has_value());
+  EXPECT_THAT(actual_track_value.value(), ApiTrackValueEq(expected_track_value));
 }
 
 }  // namespace orbit_capture_client

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -50,7 +50,7 @@ class MyCaptureListener : public CaptureListener {
   void OnModulesSnapshot(uint64_t /*timestamp_ns*/,
                          std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/) override {}
   void OnApiStringEvent(const orbit_client_data::ApiStringEvent& /*api_string_event*/) override {}
-  void OnApiTrackValue(const orbit_client_protos::ApiTrackValue& /*api_track_value*/) override {}
+  void OnApiTrackValue(const orbit_client_data::ApiTrackValue& /*api_track_value*/) override {}
   void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {}
   void OnClockResolutionEvent(
       orbit_grpc_protos::ClockResolutionEvent /*clock_resolution_event*/) override {}

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -23,12 +23,12 @@
 namespace orbit_capture_client {
 
 using orbit_client_data::ApiStringEvent;
+using orbit_client_data::ApiTrackValue;
 using orbit_client_data::CallstackEvent;
 using orbit_client_data::CallstackInfo;
 using orbit_client_data::LinuxAddressInfo;
 using orbit_client_data::ThreadStateSliceInfo;
 
-using orbit_client_protos::ApiTrackValue;
 using orbit_client_protos::TimerInfo;
 using orbit_client_protos::TracepointEventInfo;
 

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -6,6 +6,7 @@
 #define CAPTURE_CLIENT_CAPTURE_LISTENER_H_
 
 #include "ClientData/ApiStringEvent.h"
+#include "ClientData/ApiTrackValue.h"
 #include "ClientData/CallstackEvent.h"
 #include "ClientData/CallstackInfo.h"
 #include "ClientData/LinuxAddressInfo.h"
@@ -46,7 +47,7 @@ class CaptureListener {
   virtual void OnTracepointEvent(
       orbit_client_protos::TracepointEventInfo tracepoint_event_info) = 0;
   virtual void OnApiStringEvent(const orbit_client_data::ApiStringEvent&) = 0;
-  virtual void OnApiTrackValue(const orbit_client_protos::ApiTrackValue&) = 0;
+  virtual void OnApiTrackValue(const orbit_client_data::ApiTrackValue&) = 0;
   virtual void OnWarningEvent(orbit_grpc_protos::WarningEvent warning_event) = 0;
   virtual void OnClockResolutionEvent(
       orbit_grpc_protos::ClockResolutionEvent clock_resolution_event) = 0;

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(ClientData PRIVATE
 
 target_sources(ClientData PUBLIC
         include/ClientData/ApiStringEvent.h
+        include/ClientData/ApiTrackValue.h
         include/ClientData/CallstackData.h
         include/ClientData/CallstackEvent.h
         include/ClientData/CallstackInfo.h

--- a/src/ClientData/include/ClientData/ApiTrackValue.h
+++ b/src/ClientData/include/ClientData/ApiTrackValue.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_API_TRACK_VALUE_H_
+#define CLIENT_DATA_API_TRACK_VALUE_H_
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+namespace orbit_client_data {
+
+// Represents a value tracking event from our manual instrumentation API (Orbit.h). It contains a
+// name of the track to which the data point should be added, and the data point itself.
+// Note that we only display "double" values in the UI. Values of other types need to be converted
+// to double.
+// See `orbit_grpc_protos::ApiTrackValue*` protos.
+class ApiTrackValue {
+ private:
+ public:
+  ApiTrackValue(const uint32_t& process_id, const uint32_t& thread_id, const uint64_t& timestamp_ns,
+                std::string name, double data)
+      : process_id_(process_id),
+        thread_id_(thread_id),
+        timestamp_ns_(timestamp_ns),
+        name_(std::move(name)),
+        data_(data) {}
+
+  [[nodiscard]] uint32_t process_id() const { return process_id_; }
+  [[nodiscard]] uint32_t thread_id() const { return thread_id_; }
+  [[nodiscard]] uint64_t timestamp_ns() const { return timestamp_ns_; }
+  [[nodiscard]] const std::string& name() const { return name_; }
+  [[nodiscard]] double data() const { return data_; }
+
+ private:
+  uint32_t process_id_;
+  uint32_t thread_id_;
+  uint64_t timestamp_ns_;
+  std::string name_;
+  double data_;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_API_TRACK_VALUE_H_

--- a/src/ClientData/include/ClientData/ApiTrackValue.h
+++ b/src/ClientData/include/ClientData/ApiTrackValue.h
@@ -11,34 +11,34 @@
 
 namespace orbit_client_data {
 
-// Represents a value tracking event from our manual instrumentation API (Orbit.h). It contains a
+// Represents a value tracking event from our manual instrumentation API (Orbit.h). It contains the
 // name of the track to which the data point should be added, and the data point itself.
 // Note that we only display "double" values in the UI. Values of other types need to be converted
 // to double.
 // See `orbit_grpc_protos::ApiTrackValue*` protos.
 class ApiTrackValue {
- private:
  public:
-  ApiTrackValue(const uint32_t& process_id, const uint32_t& thread_id, const uint64_t& timestamp_ns,
-                std::string name, double data)
+  ApiTrackValue() = delete;
+  ApiTrackValue(uint32_t process_id, uint32_t thread_id, const uint64_t& timestamp_ns,
+                std::string track_name, double value)
       : process_id_(process_id),
         thread_id_(thread_id),
         timestamp_ns_(timestamp_ns),
-        name_(std::move(name)),
-        data_(data) {}
+        track_name_(std::move(track_name)),
+        value_(value) {}
 
   [[nodiscard]] uint32_t process_id() const { return process_id_; }
   [[nodiscard]] uint32_t thread_id() const { return thread_id_; }
   [[nodiscard]] uint64_t timestamp_ns() const { return timestamp_ns_; }
-  [[nodiscard]] const std::string& name() const { return name_; }
-  [[nodiscard]] double data() const { return data_; }
+  [[nodiscard]] const std::string& track_name() const { return track_name_; }
+  [[nodiscard]] double value() const { return value_; }
 
  private:
   uint32_t process_id_;
   uint32_t thread_id_;
   uint64_t timestamp_ns_;
-  std::string name_;
-  double data_;
+  std::string track_name_;
+  double value_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -67,23 +67,6 @@ message TimerInfo {
   string api_scope_name = 17;
 }
 
-message ApiTrackValue {
-  // NextID: 11
-  uint32 process_id = 1;
-  uint32 thread_id = 2;
-  uint64 timestamp_ns = 3;
-  string name = 4;
-
-  oneof data {
-    int32 data_int = 5;
-    int64 data_int64 = 6;
-    uint32 data_uint = 7;
-    uint64 data_uint64 = 8;
-    float data_float = 9;
-    double data_double = 10;
-  }
-}
-
 message Color {
   // Each color must be between 0 and 255 (including).
   uint32 red = 1;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -476,7 +476,7 @@ void OrbitApp::OnApiStringEvent(const orbit_client_data::ApiStringEvent& api_str
   GetMutableTimeGraph()->ProcessApiStringEvent(api_string_event);
 }
 
-void OrbitApp::OnApiTrackValue(const orbit_client_protos::ApiTrackValue& api_track_value) {
+void OrbitApp::OnApiTrackValue(const orbit_client_data::ApiTrackValue& api_track_value) {
   metrics_capture_complete_data_.number_of_manual_tracked_value_timers++;
   GetMutableTimeGraph()->ProcessApiTrackValueEvent(api_track_value);
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -180,7 +180,7 @@ class OrbitApp final : public DataViewFactory,
   void OnModulesSnapshot(uint64_t timestamp_ns,
                          std::vector<orbit_grpc_protos::ModuleInfo> module_infos) override;
   void OnApiStringEvent(const orbit_client_data::ApiStringEvent& api_string_event) override;
-  void OnApiTrackValue(const orbit_client_protos::ApiTrackValue& api_track_value) override;
+  void OnApiTrackValue(const orbit_client_data::ApiTrackValue& api_track_value) override;
   void OnWarningEvent(orbit_grpc_protos::WarningEvent warning_event) override;
   void OnClockResolutionEvent(
       orbit_grpc_protos::ClockResolutionEvent clock_resolution_event) override;

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -114,7 +114,7 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
     introspection_window_->GetTimeGraph()->ProcessApiStringEvent(api_string_event);
   }
 
-  void OnApiTrackValue(const orbit_client_protos::ApiTrackValue& api_track_value) override {
+  void OnApiTrackValue(const orbit_client_data::ApiTrackValue& api_track_value) override {
     introspection_window_->GetTimeGraph()->ProcessApiTrackValueEvent(api_track_value);
   }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -37,10 +37,10 @@
 
 using orbit_capture_client::CaptureEventProcessor;
 
+using orbit_client_data::ApiTrackValue;
 using orbit_client_data::CallstackEvent;
 using orbit_client_data::CaptureData;
 using orbit_client_data::TimerChain;
-using orbit_client_protos::ApiTrackValue;
 using orbit_client_protos::TimerInfo;
 
 using orbit_gl::CGroupAndProcessMemoryTrack;
@@ -293,33 +293,11 @@ void TimeGraph::ProcessApiStringEvent(const orbit_client_data::ApiStringEvent& s
   manual_instrumentation_manager_->ProcessStringEvent(string_event);
 }
 
-void TimeGraph::ProcessApiTrackValueEvent(const orbit_client_protos::ApiTrackValue& track_event) {
+void TimeGraph::ProcessApiTrackValueEvent(const orbit_client_data::ApiTrackValue& track_event) {
   VariableTrack* track = GetTrackManager()->GetOrCreateVariableTrack(track_event.name());
 
   uint64_t time = track_event.timestamp_ns();
-
-  switch (track_event.data_case()) {
-    case ApiTrackValue::kDataDouble:
-      track->AddValue(time, track_event.data_double());
-      break;
-    case ApiTrackValue::kDataFloat:
-      track->AddValue(time, track_event.data_float());
-      break;
-    case ApiTrackValue::kDataInt:
-      track->AddValue(time, track_event.data_int());
-      break;
-    case ApiTrackValue::kDataInt64:
-      track->AddValue(time, track_event.data_int64());
-      break;
-    case ApiTrackValue::kDataUint:
-      track->AddValue(time, track_event.data_uint());
-      break;
-    case ApiTrackValue::kDataUint64:
-      track->AddValue(time, track_event.data_uint64());
-      break;
-    default:
-      ORBIT_UNREACHABLE();
-  }
+  track->AddValue(time, track_event.data());
 }
 
 void TimeGraph::ProcessSystemMemoryTrackingTimer(const TimerInfo& timer_info) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -294,10 +294,10 @@ void TimeGraph::ProcessApiStringEvent(const orbit_client_data::ApiStringEvent& s
 }
 
 void TimeGraph::ProcessApiTrackValueEvent(const orbit_client_data::ApiTrackValue& track_event) {
-  VariableTrack* track = GetTrackManager()->GetOrCreateVariableTrack(track_event.name());
+  VariableTrack* track = GetTrackManager()->GetOrCreateVariableTrack(track_event.track_name());
 
   uint64_t time = track_event.timestamp_ns();
-  track->AddValue(time, track_event.data());
+  track->AddValue(time, track_event.value());
 }
 
 void TimeGraph::ProcessSystemMemoryTrackingTimer(const TimerInfo& timer_info) {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -11,6 +11,7 @@
 
 #include "AccessibleInterfaceProvider.h"
 #include "CaptureViewElement.h"
+#include "ClientData/ApiTrackValue.h"
 #include "ClientData/CaptureData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "CoreMath.h"
@@ -46,7 +47,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_grpc_protos::InstrumentedFunction* function);
   void ProcessApiStringEvent(const orbit_client_data::ApiStringEvent& string_event);
-  void ProcessApiTrackValueEvent(const orbit_client_protos::ApiTrackValue& track_event);
+  void ProcessApiTrackValueEvent(const orbit_client_data::ApiTrackValue& track_event);
 
   [[nodiscard]] const orbit_client_data::CaptureData* GetCaptureData() const {
     return capture_data_;


### PR DESCRIPTION
This also sets the type of the "data" value fix to "double", as
we currently only support doubles in the client. Conversion
is currently done by static casts (see http://b/227287183).

Bug: http://b/226551747