### PR TITLE
Rename "average_time_ns" to "ComputeAverageTimeNs"

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -117,7 +117,7 @@ void CaptureData::OnCaptureComplete() {
         ScopeStats& stats = stats_it->second;
         if (stats.count() > 0) {
           uint64_t elapsed_nanos = timer_info.end() - timer_info.start();
-          int64_t deviation = elapsed_nanos - stats.average_time_ns();
+          int64_t deviation = elapsed_nanos - stats.ComputeAverageTimeNs();
           id_to_sum_of_deviations_squared[timer_info.function_id()] += deviation * deviation;
         }
       }

--- a/src/ClientData/ScopeStats.cpp
+++ b/src/ClientData/ScopeStats.cpp
@@ -8,11 +8,12 @@
 
 namespace orbit_client_data {
 void ScopeStats::UpdateStats(uint64_t elapsed_nanos) {
-  double old_avg = static_cast<double>(average_time_ns());
+  auto old_avg = static_cast<double>(ComputeAverageTimeNs());
   count_++;
   total_time_ns_ += elapsed_nanos;
-  double new_avg = static_cast<double>(average_time_ns());  // it should be double for arithmetics
-  double elapsed_nanos_double = static_cast<double>(elapsed_nanos);
+  auto new_avg =
+      static_cast<double>(ComputeAverageTimeNs());  // it should be double for arithmetics
+  auto elapsed_nanos_double = static_cast<double>(elapsed_nanos);
 
   // variance(N) = ( (N-1)*variance(N-1) + (x-avg(N))*(x-avg(N-1)) ) / N
   variance_ns_ = ((static_cast<double>(count_ - 1) * variance_ns_ +
@@ -28,5 +29,12 @@ void ScopeStats::UpdateStats(uint64_t elapsed_nanos) {
   if (min_ns_ == 0 || elapsed_nanos < min_ns_) {
     min_ns_ = elapsed_nanos;
   }
+}
+
+uint64_t ScopeStats::ComputeAverageTimeNs() const {
+  if (count_ == 0) {
+    return 0;
+  }
+  return total_time_ns_ / count_;
 }
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ScopeStats.h
+++ b/src/ClientData/include/ClientData/ScopeStats.h
@@ -22,7 +22,6 @@ class ScopeStats {
 
   [[nodiscard]] uint64_t ComputeAverageTimeNs() const;
 
-
   [[nodiscard]] uint64_t count() const { return count_; }
   void set_count(uint64_t count) { count_ = count; }
 

--- a/src/ClientData/include/ClientData/ScopeStats.h
+++ b/src/ClientData/include/ClientData/ScopeStats.h
@@ -20,18 +20,14 @@ class ScopeStats {
 
   void UpdateStats(uint64_t elapsed_nanos);
 
+  [[nodiscard]] uint64_t ComputeAverageTimeNs() const;
+
+
   [[nodiscard]] uint64_t count() const { return count_; }
   void set_count(uint64_t count) { count_ = count; }
 
   [[nodiscard]] uint64_t total_time_ns() const { return total_time_ns_; }
   void set_total_time_ns(uint64_t set_total_time_ns) { total_time_ns_ = set_total_time_ns; }
-
-  [[nodiscard]] uint64_t average_time_ns() const {
-    if (count_ == 0) {
-      return 0;
-    }
-    return total_time_ns_ / count_;
-  }
 
   [[nodiscard]] uint64_t min_ns() const { return min_ns_; }
   void set_min_ns(uint64_t min_ns) { min_ns_ = min_ns; }

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -109,7 +109,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
     case kColumnTimeTotal:
       return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.total_time_ns()));
     case kColumnTimeAvg:
-      return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.average_time_ns()));
+      return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.ComputeAverageTimeNs()));
     case kColumnTimeMin:
       return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.min_ns()));
     case kColumnTimeMax:
@@ -218,7 +218,7 @@ void LiveFunctionsDataView::DoSort() {
       sorter = ORBIT_STAT_SORT(total_time_ns());
       break;
     case kColumnTimeAvg:
-      sorter = ORBIT_STAT_SORT(average_time_ns());
+      sorter = ORBIT_STAT_SORT(ComputeAverageTimeNs());
       break;
     case kColumnTimeMin:
       sorter = ORBIT_STAT_SORT(min_ns());

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -765,8 +765,8 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
     string_to_raw_value.insert_or_assign(entry[kColumnCount], stats.count());
     entry[kColumnTimeTotal] = GetExpectedDisplayTime(stats.total_time_ns());
     string_to_raw_value.insert_or_assign(entry[kColumnTimeTotal], stats.total_time_ns());
-    entry[kColumnTimeAvg] = GetExpectedDisplayTime(stats.average_time_ns());
-    string_to_raw_value.insert_or_assign(entry[kColumnTimeAvg], stats.average_time_ns());
+    entry[kColumnTimeAvg] = GetExpectedDisplayTime(stats.ComputeAverageTimeNs());
+    string_to_raw_value.insert_or_assign(entry[kColumnTimeAvg], stats.ComputeAverageTimeNs());
     entry[kColumnTimeMin] = GetExpectedDisplayTime(stats.min_ns());
     string_to_raw_value.insert_or_assign(entry[kColumnTimeMin], stats.min_ns());
     entry[kColumnTimeMax] = GetExpectedDisplayTime(stats.max_ns());


### PR DESCRIPTION
As it is now not being computed.
This also fixes clang_tidy warnings.

Test: Compile
Bug: https://github.com/google/orbit/pull/3500#discussion_r837100935