### PR TITLE
Update wording in SymbolsDialog

### DIFF
--- a/src/ConfigWidgets/SymbolsDialog.cpp
+++ b/src/ConfigWidgets/SymbolsDialog.cpp
@@ -29,6 +29,13 @@ constexpr const char* kModuleHeadlineLabel = "Add Symbols for <font color=\"#E64
 constexpr const char* kOverrideWarningText =
     "The Build ID in the file you selected does not match. This may lead to unexpected behavior in "
     "Orbit.<br />Override to use this file.";
+constexpr const char* kInfoLabelTemplate =
+    "<p>Add folders and files to the symbol locations Orbit loads from:</p><p><b>Add Folder</b> to "
+    "add a symbol location. The symbol files' filenames and build IDs must match the module's name "
+    "and build ID. Supported file extensions are “.so”, “.debug”, “.so.debug”, “.dll” and "
+    "“.pdb”.</p><p><b>Add File</b> to load from a symbol file with a different filename%1</p>";
+constexpr const char* kInfoLabelArgumentNoBuildIdOverride = " or extension.";
+constexpr const char* kInfoLabelArgumentWithBuildIdOverride = ", extension or build ID.";
 constexpr QListWidgetItem::ItemType kOverrideMappingItemType = QListWidgetItem::ItemType::UserType;
 
 using orbit_client_data::ModuleData;
@@ -118,6 +125,7 @@ SymbolsDialog::SymbolsDialog(
   }
 
   ui_->setupUi(this);
+  SetUpInfoLabel();
 
   if (allow_unsafe_symbols_) AddModuleSymbolFileMappingsToList();
   AddSymbolPathsToListWidget(persistent_storage_manager_->LoadPaths());
@@ -347,6 +355,16 @@ void SymbolsDialog::DisableAddFolder() {
       QString("Module %1 does not have a build ID. For modules without build ID, Orbit cannot find "
               "symbols in folders.")
           .arg(QString::fromStdString(module_.value()->name())));
+}
+
+void SymbolsDialog::SetUpInfoLabel() {
+  QString label_text{kInfoLabelTemplate};
+  if (allow_unsafe_symbols_) {
+    label_text = label_text.arg(kInfoLabelArgumentWithBuildIdOverride);
+  } else {
+    label_text = label_text.arg(kInfoLabelArgumentNoBuildIdOverride);
+  }
+  ui_->infoLabel->setText(label_text);
 }
 
 }  // namespace orbit_config_widgets

--- a/src/ConfigWidgets/SymbolsDialog.ui
+++ b/src/ConfigWidgets/SymbolsDialog.ui
@@ -52,9 +52,9 @@
     </layout>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="infoLabel">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add folders and files to load symbols:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Add Folder&lt;/span&gt; to load symbol files contained in that folder. Symbols will be loaded if the file name and build ID match the module and the file extension is “.so”, “.debug”, “.so.debug”, “.dll” or “.pdb”.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Add File&lt;/span&gt; to load symbols from an individual file, even if file name or file extension don’t match the module. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string/>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/ConfigWidgets/include/ConfigWidgets/SymbolsDialog.h
+++ b/src/ConfigWidgets/include/ConfigWidgets/SymbolsDialog.h
@@ -77,6 +77,7 @@ class SymbolsDialog : public QDialog {
   [[nodiscard]] OverrideWarningResult DisplayOverrideWarning();
   void SetUpModuleHeadlineLabel();
   void DisableAddFolder();
+  void SetUpInfoLabel();
 };
 
 }  // namespace orbit_config_widgets


### PR DESCRIPTION
This updates the text in the Symbol Locations dialog to the latest agreed upon copy from [go/stadia-orbit-symbol-loading-explanatory-wording](https://goto.google.com/stadia-orbit-symbol-loading-explanatory-wording)

The build ID override is phrase is determined based on the flag `--enable_unsafe_symbols`. 
Without flag: https://screenshot.googleplex.com/h2RyJQYYs5tGQ9f
With flag: https://screenshot.googleplex.com/EZmkgcMnKMNDkTv

http://b/227302107