### PR TITLE
Make TracepointInfo and TracepointEventInfo classes.

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -51,9 +51,9 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_client_data::ThreadStateSliceInfo), (override));
   MOCK_METHOD(void, OnAddressInfo, (orbit_client_data::LinuxAddressInfo), (override));
   MOCK_METHOD(void, OnUniqueTracepointInfo,
-              (uint64_t /*key*/, orbit_grpc_protos::TracepointInfo /*tracepoint_info*/),
+              (uint64_t /*key*/, orbit_client_data::TracepointInfo /*tracepoint_info*/),
               (override));
-  MOCK_METHOD(void, OnTracepointEvent, (orbit_client_protos::TracepointEventInfo), (override));
+  MOCK_METHOD(void, OnTracepointEvent, (orbit_client_data::TracepointEventInfo), (override));
   MOCK_METHOD(void, OnModuleUpdate,
               (uint64_t /*timestamp_ns*/, orbit_grpc_protos::ModuleInfo /*module_info*/),
               (override));

--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -51,7 +51,7 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_client_data::ThreadStateSliceInfo), (override));
   MOCK_METHOD(void, OnAddressInfo, (orbit_client_data::LinuxAddressInfo), (override));
   MOCK_METHOD(void, OnUniqueTracepointInfo,
-              (uint64_t /*key*/, orbit_client_data::TracepointInfo /*tracepoint_info*/),
+              (uint64_t /*tracepoint_id*/, orbit_client_data::TracepointInfo /*tracepoint_info*/),
               (override));
   MOCK_METHOD(void, OnTracepointEvent, (orbit_client_data::TracepointEventInfo), (override));
   MOCK_METHOD(void, OnModuleUpdate,

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -28,6 +28,7 @@ using orbit_client_data::CallstackInfo;
 using orbit_client_data::CallstackType;
 using orbit_client_data::LinuxAddressInfo;
 using orbit_client_data::ThreadStateSliceInfo;
+using orbit_client_data::TracepointInfo;
 
 using orbit_client_protos::TimerInfo;
 
@@ -588,23 +589,22 @@ void CaptureEventProcessorForListener::SendCallstackToListenerIfNecessary(
 
 void CaptureEventProcessorForListener::ProcessInternedTracepointInfo(
     orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info) {
+  TracepointInfo tracepoint_info{interned_tracepoint_info.intern().name(),
+                                 interned_tracepoint_info.intern().category()};
   capture_listener_->OnUniqueTracepointInfo(interned_tracepoint_info.key(),
-                                            std::move(*interned_tracepoint_info.mutable_intern()));
+                                            std::move(tracepoint_info));
 }
 void CaptureEventProcessorForListener::ProcessTracepointEvent(
     const orbit_grpc_protos::TracepointEvent& tracepoint_event) {
   uint64_t key = tracepoint_event.tracepoint_info_key();
 
-  orbit_client_protos::TracepointEventInfo tracepoint_event_info;
-  tracepoint_event_info.set_pid(tracepoint_event.pid());
-  tracepoint_event_info.set_tid(tracepoint_event.tid());
-  tracepoint_event_info.set_time(tracepoint_event.timestamp_ns());
-  tracepoint_event_info.set_cpu(tracepoint_event.cpu());
-  tracepoint_event_info.set_tracepoint_info_key(key);
+  orbit_client_data::TracepointEventInfo tracepoint_event_info{
+      tracepoint_event.pid(), tracepoint_event.tid(), tracepoint_event.cpu(),
+      tracepoint_event.timestamp_ns(), key};
 
   gpu_queue_submission_processor_.UpdateBeginCaptureTime(tracepoint_event.timestamp_ns());
 
-  capture_listener_->OnTracepointEvent(std::move(tracepoint_event_info));
+  capture_listener_->OnTracepointEvent(tracepoint_event_info);
 }
 
 void CaptureEventProcessorForListener::ProcessWarningEvent(

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -76,7 +76,7 @@ class CaptureEventProcessorForListener : public CaptureEventProcessor {
   void ProcessThreadStateSlice(const orbit_grpc_protos::ThreadStateSlice& thread_state_slice);
   void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
   void ProcessInternedTracepointInfo(
-      orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
+      const orbit_grpc_protos::InternedTracepointInfo& interned_tracepoint_info);
   void ProcessTracepointEvent(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
   void ProcessGpuQueueSubmission(const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission);
   void ProcessWarningEvent(const orbit_grpc_protos::WarningEvent& warning_event);
@@ -588,9 +588,9 @@ void CaptureEventProcessorForListener::SendCallstackToListenerIfNecessary(
 }
 
 void CaptureEventProcessorForListener::ProcessInternedTracepointInfo(
-    orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info) {
-  TracepointInfo tracepoint_info{interned_tracepoint_info.intern().name(),
-                                 interned_tracepoint_info.intern().category()};
+    const orbit_grpc_protos::InternedTracepointInfo& interned_tracepoint_info) {
+  TracepointInfo tracepoint_info{interned_tracepoint_info.intern().category(),
+                                 interned_tracepoint_info.intern().name()};
   capture_listener_->OnUniqueTracepointInfo(interned_tracepoint_info.key(),
                                             std::move(tracepoint_info));
 }

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -41,7 +41,7 @@ class MyCaptureListener : public CaptureListener {
   void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo /*thread_state_slice*/) override {
   }
   void OnAddressInfo(LinuxAddressInfo /*address_info*/) override {}
-  void OnUniqueTracepointInfo(uint64_t /*key*/,
+  void OnUniqueTracepointInfo(uint64_t /*tracepoint_id*/,
                               orbit_client_data::TracepointInfo /*tracepoint_info*/) override {}
   void OnTracepointEvent(
       orbit_client_data::TracepointEventInfo /*tracepoint_event_info*/) override {}

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -42,9 +42,9 @@ class MyCaptureListener : public CaptureListener {
   }
   void OnAddressInfo(LinuxAddressInfo /*address_info*/) override {}
   void OnUniqueTracepointInfo(uint64_t /*key*/,
-                              orbit_grpc_protos::TracepointInfo /*tracepoint_info*/) override {}
+                              orbit_client_data::TracepointInfo /*tracepoint_info*/) override {}
   void OnTracepointEvent(
-      orbit_client_protos::TracepointEventInfo /*tracepoint_event_info*/) override {}
+      orbit_client_data::TracepointEventInfo /*tracepoint_event_info*/) override {}
   void OnModuleUpdate(uint64_t /*timestamp_ns*/,
                       orbit_grpc_protos::ModuleInfo /*module_info*/) override {}
   void OnModulesSnapshot(uint64_t /*timestamp_ns*/,

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -92,7 +92,7 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnThreadStateSlice, (ThreadStateSliceInfo), (override));
   MOCK_METHOD(void, OnAddressInfo, (LinuxAddressInfo), (override));
   MOCK_METHOD(void, OnUniqueTracepointInfo,
-              (uint64_t /*key*/, orbit_client_data::TracepointInfo /*tracepoint_info*/),
+              (uint64_t /*tracepoint_id*/, orbit_client_data::TracepointInfo /*tracepoint_info*/),
               (override));
   MOCK_METHOD(void, OnTracepointEvent, (TracepointEventInfo), (override));
   MOCK_METHOD(void, OnModuleUpdate, (uint64_t /*timestamp_ns*/, ModuleInfo /*module_info*/),
@@ -479,12 +479,13 @@ TEST(CaptureEventProcessor, CanHandleInternedTracepointEvents) {
   event_processor->ProcessEvent(interned_tracepoint_event);
   event_processor->ProcessEvent(tracepoint_event);
 
-  ASSERT_TRUE(actual_tracepoint_event.has_value());
-  EXPECT_EQ(actual_key, actual_tracepoint_event->tracepoint_id());
-  EXPECT_EQ(actual_tracepoint_event->tracepoint_id(), tracepoint->tracepoint_info_key());
   ASSERT_TRUE(actual_tracepoint_info.has_value());
   EXPECT_EQ(actual_tracepoint_info->category(), tracepoint_intern->category());
   EXPECT_EQ(actual_tracepoint_info->name(), tracepoint_intern->name());
+
+  ASSERT_TRUE(actual_tracepoint_event.has_value());
+  EXPECT_EQ(actual_key, actual_tracepoint_event->tracepoint_id());
+  EXPECT_EQ(actual_tracepoint_event->tracepoint_id(), tracepoint->tracepoint_info_key());
   EXPECT_EQ(actual_tracepoint_event->pid(), tracepoint->pid());
   EXPECT_EQ(actual_tracepoint_event->tid(), tracepoint->tid());
   EXPECT_EQ(actual_tracepoint_event->timestamp_ns(), tracepoint->timestamp_ns());

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -28,9 +28,9 @@ using orbit_client_data::CallstackEvent;
 using orbit_client_data::CallstackInfo;
 using orbit_client_data::LinuxAddressInfo;
 using orbit_client_data::ThreadStateSliceInfo;
+using orbit_client_data::TracepointEventInfo;
 
 using orbit_client_protos::TimerInfo;
-using orbit_client_protos::TracepointEventInfo;
 
 using orbit_grpc_protos::AddressInfo;
 using orbit_grpc_protos::Callstack;
@@ -65,7 +65,6 @@ using orbit_grpc_protos::SystemMemoryUsage;
 using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::ThreadStateSlice;
 using orbit_grpc_protos::TracepointEvent;
-using orbit_grpc_protos::TracepointInfo;
 using orbit_grpc_protos::WarningEvent;
 using orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent;
 
@@ -92,7 +91,8 @@ class MockCaptureListener : public CaptureListener {
               (override));
   MOCK_METHOD(void, OnThreadStateSlice, (ThreadStateSliceInfo), (override));
   MOCK_METHOD(void, OnAddressInfo, (LinuxAddressInfo), (override));
-  MOCK_METHOD(void, OnUniqueTracepointInfo, (uint64_t /*key*/, TracepointInfo /*tracepoint_info*/),
+  MOCK_METHOD(void, OnUniqueTracepointInfo,
+              (uint64_t /*key*/, orbit_client_data::TracepointInfo /*tracepoint_info*/),
               (override));
   MOCK_METHOD(void, OnTracepointEvent, (TracepointEventInfo), (override));
   MOCK_METHOD(void, OnModuleUpdate, (uint64_t /*timestamp_ns*/, ModuleInfo /*module_info*/),
@@ -456,7 +456,7 @@ TEST(CaptureEventProcessor, CanHandleInternedTracepointEvents) {
   InternedTracepointInfo* interned_tracepoint =
       interned_tracepoint_event.mutable_interned_tracepoint_info();
   interned_tracepoint->set_key(2);
-  TracepointInfo* tracepoint_intern = interned_tracepoint->mutable_intern();
+  orbit_grpc_protos::TracepointInfo* tracepoint_intern = interned_tracepoint->mutable_intern();
   tracepoint_intern->set_name("name");
   tracepoint_intern->set_category("category");
 
@@ -468,25 +468,27 @@ TEST(CaptureEventProcessor, CanHandleInternedTracepointEvents) {
   tracepoint->set_cpu(2);
   tracepoint->set_tracepoint_info_key(interned_tracepoint->key());
 
-  uint64_t actual_key;
-  TracepointInfo actual_tracepoint_info;
+  uint64_t actual_key{};
+  std::optional<orbit_client_data::TracepointInfo> actual_tracepoint_info;
   EXPECT_CALL(listener, OnUniqueTracepointInfo)
       .Times(1)
       .WillOnce(DoAll(SaveArg<0>(&actual_key), SaveArg<1>(&actual_tracepoint_info)));
-  TracepointEventInfo actual_tracepoint_event;
+  std::optional<TracepointEventInfo> actual_tracepoint_event;
   EXPECT_CALL(listener, OnTracepointEvent).Times(1).WillOnce(SaveArg<0>(&actual_tracepoint_event));
 
   event_processor->ProcessEvent(interned_tracepoint_event);
   event_processor->ProcessEvent(tracepoint_event);
 
-  EXPECT_EQ(actual_key, actual_tracepoint_event.tracepoint_info_key());
-  EXPECT_EQ(actual_tracepoint_event.tracepoint_info_key(), tracepoint->tracepoint_info_key());
-  EXPECT_EQ(actual_tracepoint_info.category(), tracepoint_intern->category());
-  EXPECT_EQ(actual_tracepoint_info.name(), tracepoint_intern->name());
-  EXPECT_EQ(actual_tracepoint_event.pid(), tracepoint->pid());
-  EXPECT_EQ(actual_tracepoint_event.tid(), tracepoint->tid());
-  EXPECT_EQ(actual_tracepoint_event.time(), tracepoint->timestamp_ns());
-  EXPECT_EQ(actual_tracepoint_event.cpu(), tracepoint->cpu());
+  ASSERT_TRUE(actual_tracepoint_event.has_value());
+  EXPECT_EQ(actual_key, actual_tracepoint_event->tracepoint_id());
+  EXPECT_EQ(actual_tracepoint_event->tracepoint_id(), tracepoint->tracepoint_info_key());
+  ASSERT_TRUE(actual_tracepoint_info.has_value());
+  EXPECT_EQ(actual_tracepoint_info->category(), tracepoint_intern->category());
+  EXPECT_EQ(actual_tracepoint_info->name(), tracepoint_intern->name());
+  EXPECT_EQ(actual_tracepoint_event->pid(), tracepoint->pid());
+  EXPECT_EQ(actual_tracepoint_event->tid(), tracepoint->tid());
+  EXPECT_EQ(actual_tracepoint_event->timestamp_ns(), tracepoint->timestamp_ns());
+  EXPECT_EQ(actual_tracepoint_event->cpu(), tracepoint->cpu());
 }
 
 static constexpr int32_t kGpuPid = 1;

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -13,6 +13,8 @@
 #include "ClientData/ProcessData.h"
 #include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientData/TracepointCustom.h"
+#include "ClientData/TracepointEventInfo.h"
+#include "ClientData/TracepointInfo.h"
 #include "ClientData/UserDefinedCaptureData.h"
 #include "GrpcProtos/capture.pb.h"
 #include "OrbitBase/Result.h"
@@ -43,9 +45,8 @@ class CaptureListener {
   virtual void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) = 0;
   virtual void OnUniqueTracepointInfo(uint64_t key,
-                                      orbit_grpc_protos::TracepointInfo tracepoint_info) = 0;
-  virtual void OnTracepointEvent(
-      orbit_client_protos::TracepointEventInfo tracepoint_event_info) = 0;
+                                      orbit_client_data::TracepointInfo tracepoint_info) = 0;
+  virtual void OnTracepointEvent(orbit_client_data::TracepointEventInfo tracepoint_event_info) = 0;
   virtual void OnApiStringEvent(const orbit_client_data::ApiStringEvent&) = 0;
   virtual void OnApiTrackValue(const orbit_client_data::ApiTrackValue&) = 0;
   virtual void OnWarningEvent(orbit_grpc_protos::WarningEvent warning_event) = 0;

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -44,7 +44,7 @@ class CaptureListener {
                                  std::vector<orbit_grpc_protos::ModuleInfo> module_infos) = 0;
   virtual void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) = 0;
-  virtual void OnUniqueTracepointInfo(uint64_t key,
+  virtual void OnUniqueTracepointInfo(uint64_t tracepoint_id,
                                       orbit_client_data::TracepointInfo tracepoint_info) = 0;
   virtual void OnTracepointEvent(orbit_client_data::TracepointEventInfo tracepoint_event_info) = 0;
   virtual void OnApiStringEvent(const orbit_client_data::ApiStringEvent&) = 0;

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -43,6 +43,8 @@ target_sources(ClientData PUBLIC
         include/ClientData/TimestampIntervalSet.h
         include/ClientData/TracepointCustom.h
         include/ClientData/TracepointData.h
+        include/ClientData/TracepointEventInfo.h
+        include/ClientData/TracepointInfo.h
         include/ClientData/UserDefinedCaptureData.h)
 
 target_sources(ClientData PRIVATE

--- a/src/ClientData/TracepointData.cpp
+++ b/src/ClientData/TracepointData.cpp
@@ -111,18 +111,18 @@ bool TracepointData::AddUniqueTracepointInfo(uint64_t key, TracepointInfo tracep
   return inserted;
 }
 
-const TracepointInfo* TracepointData::GetTracepointInfo(uint64_t hash) const {
+const TracepointInfo* TracepointData::GetTracepointInfo(uint64_t tracepoint_id) const {
   absl::MutexLock lock{&unique_tracepoints_mutex_};
-  auto it = unique_tracepoints_.find(hash);
+  auto it = unique_tracepoints_.find(tracepoint_id);
   if (it != unique_tracepoints_.end()) {
     return it->second.get();
   }
   return nullptr;
 }
 
-bool TracepointData::HasTracepointKey(uint64_t key) const {
+bool TracepointData::HasTracepointId(uint64_t tracepoint_id) const {
   absl::MutexLock lock{&unique_tracepoints_mutex_};
-  return unique_tracepoints_.contains(key);
+  return unique_tracepoints_.contains(tracepoint_id);
 }
 
 void TracepointData::ForEachUniqueTracepointInfo(

--- a/src/ClientData/TracepointData.cpp
+++ b/src/ClientData/TracepointData.cpp
@@ -11,23 +11,15 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
 
-using orbit_client_protos::TracepointEventInfo;
-
 namespace orbit_client_data {
 
-void TracepointData::EmplaceTracepointEvent(uint64_t time, uint64_t tracepoint_hash,
+void TracepointData::EmplaceTracepointEvent(uint64_t timestamp_ns, uint64_t tracepoint_id,
                                             uint32_t process_id, uint32_t thread_id, int32_t cpu,
                                             bool is_same_pid_as_target) {
   absl::MutexLock lock(&mutex_);
   num_total_tracepoint_events_++;
 
-  orbit_client_protos::TracepointEventInfo event;
-  event.set_time(time);
-  ORBIT_CHECK(HasTracepointKey(tracepoint_hash));
-  event.set_tracepoint_info_key(tracepoint_hash);
-  event.set_tid(thread_id);
-  event.set_pid(process_id);
-  event.set_cpu(cpu);
+  TracepointEventInfo event(process_id, thread_id, cpu, timestamp_ns, tracepoint_id);
 
   int32_t insertion_thread_id =
       (is_same_pid_as_target) ? thread_id : orbit_base::kNotTargetProcessTid;
@@ -35,16 +27,16 @@ void TracepointData::EmplaceTracepointEvent(uint64_t time, uint64_t tracepoint_h
   auto [event_map_iterator, unused_inserted] =
       thread_id_to_time_to_tracepoint_.try_emplace(insertion_thread_id);
   auto [unused_iterator, event_inserted] =
-      event_map_iterator->second.try_emplace(time, std::move(event));
+      event_map_iterator->second.try_emplace(timestamp_ns, std::move(event));
   if (!event_inserted) {
     ORBIT_ERROR(
-        "Tracepoint event was not inserted as there was already an event on this time and "
+        "Tracepoint event was not inserted as there was already an event on this timestamp_ns and "
         "thread.");
   }
 }
 
 void TracepointData::ForEachTracepointEvent(
-    const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
+    const std::function<void(const TracepointEventInfo&)>& action) const {
   absl::MutexLock lock(&mutex_);
   for (auto const& entry : thread_id_to_time_to_tracepoint_) {
     for (auto const& time_to_tracepoint_event : entry.second) {
@@ -56,8 +48,8 @@ void TracepointData::ForEachTracepointEvent(
 namespace {
 void ForEachTracepointEventInRange(
     uint64_t min_tick, uint64_t max_tick_exclusive,
-    const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& time_to_tracepoint_events,
-    const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) {
+    const std::map<uint64_t, TracepointEventInfo>& time_to_tracepoint_events,
+    const std::function<void(const TracepointEventInfo&)>& action) {
   for (auto time_to_tracepoint_event = time_to_tracepoint_events.lower_bound(min_tick);
        time_to_tracepoint_event != time_to_tracepoint_events.end() &&
        time_to_tracepoint_event->first < max_tick_exclusive;
@@ -69,7 +61,7 @@ void ForEachTracepointEventInRange(
 
 void TracepointData::ForEachTracepointEventOfThreadInTimeRange(
     uint32_t thread_id, uint64_t min_tick, uint64_t max_tick_exclusive,
-    const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
+    const std::function<void(const TracepointEventInfo&)>& action) const {
   absl::MutexLock lock(&mutex_);
   if (thread_id == orbit_base::kAllThreadsOfAllProcessesTid) {
     for (const auto& [unused_thread_id, time_to_tracepoint] : thread_id_to_time_to_tracepoint_) {
@@ -112,20 +104,20 @@ uint32_t TracepointData::GetNumTracepointEventsForThreadId(uint32_t thread_id) c
   return it->second.size();
 }
 
-bool TracepointData::AddUniqueTracepointInfo(uint64_t key,
-                                             orbit_grpc_protos::TracepointInfo tracepoint) {
+bool TracepointData::AddUniqueTracepointInfo(uint64_t key, TracepointInfo tracepoint) {
   absl::MutexLock lock{&unique_tracepoints_mutex_};
-  auto [unused_it, inserted] = unique_tracepoints_.try_emplace(key, std::move(tracepoint));
+  auto [unused_it, inserted] =
+      unique_tracepoints_.try_emplace(key, std::make_unique<TracepointInfo>(std::move(tracepoint)));
   return inserted;
 }
 
-orbit_grpc_protos::TracepointInfo TracepointData::GetTracepointInfo(uint64_t hash) const {
+const TracepointInfo* TracepointData::GetTracepointInfo(uint64_t hash) const {
   absl::MutexLock lock{&unique_tracepoints_mutex_};
   auto it = unique_tracepoints_.find(hash);
   if (it != unique_tracepoints_.end()) {
-    return it->second;
+    return it->second.get();
   }
-  return {};
+  return nullptr;
 }
 
 bool TracepointData::HasTracepointKey(uint64_t key) const {
@@ -134,14 +126,11 @@ bool TracepointData::HasTracepointKey(uint64_t key) const {
 }
 
 void TracepointData::ForEachUniqueTracepointInfo(
-    const std::function<void(const orbit_client_protos::TracepointInfo&)>& action) const {
+    const std::function<void(const TracepointInfo&)>& action) const {
   absl::MutexLock lock(&unique_tracepoints_mutex_);
   for (const auto& it : unique_tracepoints_) {
-    orbit_client_protos::TracepointInfo tracepoint_info;
-    tracepoint_info.set_category(it.second.category());
-    tracepoint_info.set_name(it.second.name());
-    tracepoint_info.set_tracepoint_info_key(it.first);
-    action(tracepoint_info);
+    ORBIT_CHECK(it.second != nullptr);
+    action(*it.second);
   }
 }
 

--- a/src/ClientData/TracepointDataTest.cpp
+++ b/src/ClientData/TracepointDataTest.cpp
@@ -22,9 +22,9 @@ namespace orbit_client_data {
 TEST(TracepointData, AddAndGetTracepointEvents) {
   TracepointData tracepoint_data;
 
-  tracepoint_data.AddUniqueTracepointInfo(0, {});
-  tracepoint_data.AddUniqueTracepointInfo(1, {});
-  tracepoint_data.AddUniqueTracepointInfo(3, {});
+  tracepoint_data.AddUniqueTracepointInfo(0, {"", ""});
+  tracepoint_data.AddUniqueTracepointInfo(1, {"", ""});
+  tracepoint_data.AddUniqueTracepointInfo(3, {"", ""});
 
   tracepoint_data.EmplaceTracepointEvent(1, 0, 0, 1, 0, true);
   tracepoint_data.EmplaceTracepointEvent(2, 3, 2, 0, 1, true);
@@ -48,10 +48,8 @@ TEST(TracepointData, AddAndGetTracepointEvents) {
 
   std::vector<uint64_t> tracepoints_of_thread_1;
   tracepoint_data.ForEachTracepointEventOfThreadInTimeRange(
-      1, 0, 8,
-      [&tracepoints_of_thread_1](
-          const orbit_client_protos::TracepointEventInfo& tracepoint_event_info) {
-        tracepoints_of_thread_1.emplace_back(tracepoint_event_info.tracepoint_info_key());
+      1, 0, 8, [&tracepoints_of_thread_1](const TracepointEventInfo& tracepoint_event_info) {
+        tracepoints_of_thread_1.emplace_back(tracepoint_event_info.tracepoint_id());
       });
 
   EXPECT_THAT(tracepoints_of_thread_1, UnorderedElementsAre(0, 1, 1));
@@ -61,10 +59,8 @@ TEST(TracepointData, AddAndGetTracepointEvents) {
   std::vector<uint64_t> all_tracepoint_events_target_process;
   tracepoint_data.ForEachTracepointEventOfThreadInTimeRange(
       orbit_base::kAllProcessThreadsTid, 0, 3,
-      [&all_tracepoint_events_target_process](
-          const orbit_client_protos::TracepointEventInfo& tracepoint_event_info) {
-        all_tracepoint_events_target_process.emplace_back(
-            tracepoint_event_info.tracepoint_info_key());
+      [&all_tracepoint_events_target_process](const TracepointEventInfo& tracepoint_event_info) {
+        all_tracepoint_events_target_process.emplace_back(tracepoint_event_info.tracepoint_id());
       });
 
   EXPECT_THAT(all_tracepoint_events_target_process, UnorderedElementsAre(0, 1, 3));
@@ -73,7 +69,7 @@ TEST(TracepointData, AddAndGetTracepointEvents) {
 TEST(TracepointData, Contains) {
   TracepointData tracepoint_data;
 
-  tracepoint_data.AddUniqueTracepointInfo(1, {});
+  tracepoint_data.AddUniqueTracepointInfo(1, {"", ""});
   EXPECT_TRUE(tracepoint_data.HasTracepointKey(1));
   EXPECT_FALSE(tracepoint_data.HasTracepointKey(0));
 }
@@ -81,30 +77,33 @@ TEST(TracepointData, Contains) {
 TEST(TracepointData, AddUniqueTracepointEventInfo) {
   TracepointData tracepoint_info_manager;
 
-  EXPECT_TRUE(tracepoint_info_manager.AddUniqueTracepointInfo(1, {}));
+  EXPECT_TRUE(tracepoint_info_manager.AddUniqueTracepointInfo(1, {"", ""}));
   EXPECT_TRUE(tracepoint_info_manager.HasTracepointKey(1));
 
-  EXPECT_FALSE(tracepoint_info_manager.AddUniqueTracepointInfo(1, {}));
-  EXPECT_TRUE(tracepoint_info_manager.AddUniqueTracepointInfo(2, {}));
+  EXPECT_FALSE(tracepoint_info_manager.AddUniqueTracepointInfo(1, {"", ""}));
+  EXPECT_TRUE(tracepoint_info_manager.AddUniqueTracepointInfo(2, {"", ""}));
   EXPECT_TRUE(tracepoint_info_manager.HasTracepointKey(2));
 }
 
 TEST(TracepointData, Get) {
   TracepointData tracepoint_data;
 
-  orbit_grpc_protos::TracepointInfo tracepoint_info;
-  tracepoint_info.set_category("sched");
-  tracepoint_info.set_name("sched_switch");
+  TracepointInfo tracepoint_info{"sched_switch", "sched"};
 
-  EXPECT_TRUE(tracepoint_data.AddUniqueTracepointInfo(1, {}));
-  EXPECT_TRUE(tracepoint_data.AddUniqueTracepointInfo(2, {}));
+  EXPECT_TRUE(tracepoint_data.AddUniqueTracepointInfo(1, {"", ""}));
+  EXPECT_TRUE(tracepoint_data.AddUniqueTracepointInfo(2, {"", ""}));
   EXPECT_TRUE(tracepoint_data.AddUniqueTracepointInfo(3, tracepoint_info));
-  EXPECT_FALSE(tracepoint_data.AddUniqueTracepointInfo(1, {}));
+  EXPECT_FALSE(tracepoint_data.AddUniqueTracepointInfo(1, {"", ""}));
 
-  EXPECT_TRUE(tracepoint_data.GetTracepointInfo(3).category() == "sched" &&
-              tracepoint_data.GetTracepointInfo(3).name() == "sched_switch");
-  EXPECT_FALSE(tracepoint_data.GetTracepointInfo(2).category() == "sched" &&
-               tracepoint_data.GetTracepointInfo(2).name() == "sched_switch");
+  const TracepointInfo* sched_switch_tracepoint = tracepoint_data.GetTracepointInfo(3);
+  ASSERT_TRUE(sched_switch_tracepoint != nullptr);
+  EXPECT_TRUE(sched_switch_tracepoint->category() == "sched" &&
+              sched_switch_tracepoint->name() == "sched_switch");
+
+  const TracepointInfo* empty_trace_point = tracepoint_data.GetTracepointInfo(2);
+  ASSERT_TRUE(empty_trace_point != nullptr);
+  EXPECT_FALSE(empty_trace_point->category() == "sched" &&
+               empty_trace_point->name() == "sched_switch");
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/TracepointDataTest.cpp
+++ b/src/ClientData/TracepointDataTest.cpp
@@ -70,25 +70,25 @@ TEST(TracepointData, Contains) {
   TracepointData tracepoint_data;
 
   tracepoint_data.AddUniqueTracepointInfo(1, {"", ""});
-  EXPECT_TRUE(tracepoint_data.HasTracepointKey(1));
-  EXPECT_FALSE(tracepoint_data.HasTracepointKey(0));
+  EXPECT_TRUE(tracepoint_data.HasTracepointId(1));
+  EXPECT_FALSE(tracepoint_data.HasTracepointId(0));
 }
 
 TEST(TracepointData, AddUniqueTracepointEventInfo) {
   TracepointData tracepoint_info_manager;
 
   EXPECT_TRUE(tracepoint_info_manager.AddUniqueTracepointInfo(1, {"", ""}));
-  EXPECT_TRUE(tracepoint_info_manager.HasTracepointKey(1));
+  EXPECT_TRUE(tracepoint_info_manager.HasTracepointId(1));
 
   EXPECT_FALSE(tracepoint_info_manager.AddUniqueTracepointInfo(1, {"", ""}));
   EXPECT_TRUE(tracepoint_info_manager.AddUniqueTracepointInfo(2, {"", ""}));
-  EXPECT_TRUE(tracepoint_info_manager.HasTracepointKey(2));
+  EXPECT_TRUE(tracepoint_info_manager.HasTracepointId(2));
 }
 
 TEST(TracepointData, Get) {
   TracepointData tracepoint_data;
 
-  TracepointInfo tracepoint_info{"sched_switch", "sched"};
+  TracepointInfo tracepoint_info{"sched", "sched_switch"};
 
   EXPECT_TRUE(tracepoint_data.AddUniqueTracepointInfo(1, {"", ""}));
   EXPECT_TRUE(tracepoint_data.AddUniqueTracepointInfo(2, {"", ""}));

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -138,8 +138,8 @@ class CaptureData {
 
   [[nodiscard]] const CallstackData& GetCallstackData() const { return callstack_data_; };
 
-  [[nodiscard]] const TracepointInfo* GetTracepointInfo(uint64_t key) const {
-    return tracepoint_data_.GetTracepointInfo(key);
+  [[nodiscard]] const TracepointInfo* GetTracepointInfo(uint64_t tracepoint_id) const {
+    return tracepoint_data_.GetTracepointInfo(tracepoint_id);
   }
 
   void ForEachTracepointEventOfThreadInTimeRange(
@@ -165,8 +165,8 @@ class CaptureData {
 
   void FilterBrokenCallstacks() { callstack_data_.UpdateCallstackTypeBasedOnMajorityStart(); }
 
-  void AddUniqueTracepointEventInfo(uint64_t key, TracepointInfo tracepoint_info) {
-    tracepoint_data_.AddUniqueTracepointInfo(key, std::move(tracepoint_info));
+  void AddUniqueTracepointInfo(uint64_t tracepoint_id, TracepointInfo tracepoint_info) {
+    tracepoint_data_.AddUniqueTracepointInfo(tracepoint_id, std::move(tracepoint_info));
   }
 
   void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash,

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -138,13 +138,13 @@ class CaptureData {
 
   [[nodiscard]] const CallstackData& GetCallstackData() const { return callstack_data_; };
 
-  [[nodiscard]] orbit_grpc_protos::TracepointInfo GetTracepointInfo(uint64_t key) const {
+  [[nodiscard]] const TracepointInfo* GetTracepointInfo(uint64_t key) const {
     return tracepoint_data_.GetTracepointInfo(key);
   }
 
   void ForEachTracepointEventOfThreadInTimeRange(
       uint32_t thread_id, uint64_t min_tick, uint64_t max_tick,
-      const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
+      const std::function<void(const TracepointEventInfo&)>& action) const {
     return tracepoint_data_.ForEachTracepointEventOfThreadInTimeRange(thread_id, min_tick, max_tick,
                                                                       action);
   }
@@ -165,8 +165,7 @@ class CaptureData {
 
   void FilterBrokenCallstacks() { callstack_data_.UpdateCallstackTypeBasedOnMajorityStart(); }
 
-  void AddUniqueTracepointEventInfo(uint64_t key,
-                                    orbit_grpc_protos::TracepointInfo tracepoint_info) {
+  void AddUniqueTracepointEventInfo(uint64_t key, TracepointInfo tracepoint_info) {
     tracepoint_data_.AddUniqueTracepointInfo(key, std::move(tracepoint_info));
   }
 

--- a/src/ClientData/include/ClientData/TracepointData.h
+++ b/src/ClientData/include/ClientData/TracepointData.h
@@ -52,8 +52,8 @@ class TracepointData {
 
   bool AddUniqueTracepointInfo(uint64_t key, TracepointInfo tracepoint);
 
-  [[nodiscard]] const TracepointInfo* GetTracepointInfo(uint64_t hash) const;
-  [[nodiscard]] bool HasTracepointKey(uint64_t key) const;
+  [[nodiscard]] const TracepointInfo* GetTracepointInfo(uint64_t tracepoint_id) const;
+  [[nodiscard]] bool HasTracepointId(uint64_t tracepoint_id) const;
 
   void ForEachUniqueTracepointInfo(const std::function<void(const TracepointInfo&)>& action) const;
 
@@ -65,6 +65,9 @@ class TracepointData {
 
   absl::flat_hash_map<uint32_t, std::map<uint64_t, TracepointEventInfo>>
       thread_id_to_time_to_tracepoint_ GUARDED_BY(mutex_);
+
+  // Store unique pointers, such that we can hand out pointers to tracepoint infos, without
+  // requiring the caller to lock the mutex.
   absl::flat_hash_map<uint64_t, std::unique_ptr<TracepointInfo>> unique_tracepoints_
       GUARDED_BY(unique_tracepoints_mutex_);
 };

--- a/src/ClientData/include/ClientData/TracepointEventInfo.h
+++ b/src/ClientData/include/ClientData/TracepointEventInfo.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_TRACEPOINT_EVENT_INFO_H_
+#define CLIENT_DATA_TRACEPOINT_EVENT_INFO_H_
+
+#include <cstdint>
+
+namespace orbit_client_data {
+
+// This class is used on the client to represent a tracepoint event sample on a certain thread at a
+// certain timestamp. The actual callstack is referenced by the tracepoint id.
+// See `orbit_grpc_protos::TracePointEvent`.
+class TracepointEventInfo {
+ public:
+  TracepointEventInfo(uint32_t pid, uint32_t tid, int32_t cpu, uint64_t timestamp_ns,
+                      uint64_t tracepoint_id)
+      : pid_(pid),
+        tid_(tid),
+        cpu_(cpu),
+        timestamp_ns_(timestamp_ns),
+        tracepoint_id_(tracepoint_id) {}
+
+  [[nodiscard]] uint32_t pid() const { return pid_; }
+  [[nodiscard]] uint32_t tid() const { return tid_; }
+  [[nodiscard]] int32_t cpu() const { return cpu_; }
+  [[nodiscard]] uint64_t timestamp_ns() const { return timestamp_ns_; }
+  [[nodiscard]] uint64_t tracepoint_id() const { return tracepoint_id_; }
+
+ private:
+  uint32_t pid_;
+  uint32_t tid_;
+  int32_t cpu_;
+  uint64_t timestamp_ns_;
+  uint64_t tracepoint_id_;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_TRACEPOINT_EVENT_INFO_H_

--- a/src/ClientData/include/ClientData/TracepointEventInfo.h
+++ b/src/ClientData/include/ClientData/TracepointEventInfo.h
@@ -10,10 +10,11 @@
 namespace orbit_client_data {
 
 // This class is used on the client to represent a tracepoint event sample on a certain thread at a
-// certain timestamp. The actual callstack is referenced by the tracepoint id.
+// certain timestamp. The actual tracepoint is referenced by the tracepoint id.
 // See `orbit_grpc_protos::TracePointEvent`.
 class TracepointEventInfo {
  public:
+  TracepointEventInfo() = delete;
   TracepointEventInfo(uint32_t pid, uint32_t tid, int32_t cpu, uint64_t timestamp_ns,
                       uint64_t tracepoint_id)
       : pid_(pid),

--- a/src/ClientData/include/ClientData/TracepointInfo.h
+++ b/src/ClientData/include/ClientData/TracepointInfo.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_TRACEPOINT_INFO_H_
+#define CLIENT_DATA_TRACEPOINT_INFO_H_
+
+#include <string>
+#include <utility>
+
+namespace orbit_client_data {
+
+// This class is used on the client to represent a unique tracepoint, containing the tracepoint's
+// name and category.
+class TracepointInfo {
+ public:
+  TracepointInfo() = delete;
+  TracepointInfo(std::string name, std::string category)
+      : name_{std::move(name)}, category_{std::move(category)} {}
+
+  [[nodiscard]] const std::string& name() const { return name_; }
+  [[nodiscard]] const std::string& category() const { return category_; }
+
+ private:
+  std::string name_;
+  std::string category_;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_TRACEPOINT_INFO_H_

--- a/src/ClientData/include/ClientData/TracepointInfo.h
+++ b/src/ClientData/include/ClientData/TracepointInfo.h
@@ -15,15 +15,15 @@ namespace orbit_client_data {
 class TracepointInfo {
  public:
   TracepointInfo() = delete;
-  TracepointInfo(std::string name, std::string category)
-      : name_{std::move(name)}, category_{std::move(category)} {}
+  TracepointInfo(std::string category, std::string name)
+      : category_{std::move(category)}, name_{std::move(name)} {}
 
-  [[nodiscard]] const std::string& name() const { return name_; }
   [[nodiscard]] const std::string& category() const { return category_; }
+  [[nodiscard]] const std::string& name() const { return name_; }
 
  private:
-  std::string name_;
   std::string category_;
+  std::string name_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -15,20 +15,6 @@ message FunctionInfo {
   uint64 size = 7;
 }
 
-message TracepointInfo {
-  string name = 1;
-  string category = 2;
-  uint64 tracepoint_info_key = 3;
-}
-
-message TracepointEventInfo {
-  uint32 pid = 1;
-  uint32 tid = 2;
-  int64 time = 3;
-  int32 cpu = 4;
-  uint64 tracepoint_info_key = 5;
-}
-
 message TimerInfo {
   // NextID: 18
   uint64 start = 1;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -505,16 +505,16 @@ void OrbitApp::OnAddressInfo(LinuxAddressInfo address_info) {
 }
 
 void OrbitApp::OnUniqueTracepointInfo(uint64_t key,
-                                      orbit_grpc_protos::TracepointInfo tracepoint_info) {
+                                      orbit_client_data::TracepointInfo tracepoint_info) {
   GetMutableCaptureData().AddUniqueTracepointEventInfo(key, std::move(tracepoint_info));
 }
 
-void OrbitApp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) {
+void OrbitApp::OnTracepointEvent(orbit_client_data::TracepointEventInfo tracepoint_event_info) {
   uint32_t capture_process_id = GetCaptureData().process_id();
   bool is_same_pid_as_target = capture_process_id == tracepoint_event_info.pid();
 
   GetMutableCaptureData().AddTracepointEventAndMapToThreads(
-      tracepoint_event_info.time(), tracepoint_event_info.tracepoint_info_key(),
+      tracepoint_event_info.timestamp_ns(), tracepoint_event_info.tracepoint_id(),
       tracepoint_event_info.pid(), tracepoint_event_info.tid(), tracepoint_event_info.cpu(),
       is_same_pid_as_target);
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -504,9 +504,9 @@ void OrbitApp::OnAddressInfo(LinuxAddressInfo address_info) {
   GetMutableCaptureData().InsertAddressInfo(std::move(address_info));
 }
 
-void OrbitApp::OnUniqueTracepointInfo(uint64_t key,
+void OrbitApp::OnUniqueTracepointInfo(uint64_t tracepoint_id,
                                       orbit_client_data::TracepointInfo tracepoint_info) {
-  GetMutableCaptureData().AddUniqueTracepointEventInfo(key, std::move(tracepoint_info));
+  GetMutableCaptureData().AddUniqueTracepointInfo(tracepoint_id, std::move(tracepoint_info));
 }
 
 void OrbitApp::OnTracepointEvent(orbit_client_data::TracepointEventInfo tracepoint_event_info) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -174,8 +174,8 @@ class OrbitApp final : public DataViewFactory,
   void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo thread_state_slice) override;
   void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) override;
   void OnUniqueTracepointInfo(uint64_t key,
-                              orbit_grpc_protos::TracepointInfo tracepoint_info) override;
-  void OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) override;
+                              orbit_client_data::TracepointInfo tracepoint_info) override;
+  void OnTracepointEvent(orbit_client_data::TracepointEventInfo tracepoint_event_info) override;
   void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) override;
   void OnModulesSnapshot(uint64_t timestamp_ns,
                          std::vector<orbit_grpc_protos::ModuleInfo> module_infos) override;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -173,7 +173,7 @@ class OrbitApp final : public DataViewFactory,
   void OnThreadName(uint32_t thread_id, std::string thread_name) override;
   void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo thread_state_slice) override;
   void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) override;
-  void OnUniqueTracepointInfo(uint64_t key,
+  void OnUniqueTracepointInfo(uint64_t tracepoint_id,
                               orbit_client_data::TracepointInfo tracepoint_info) override;
   void OnTracepointEvent(orbit_client_data::TracepointEventInfo tracepoint_event_info) override;
   void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) override;

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -144,11 +144,11 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
     ORBIT_UNREACHABLE();
   }
   void OnUniqueTracepointInfo(uint64_t /*key*/,
-                              orbit_grpc_protos::TracepointInfo /*tracepoint_info*/) override {
+                              orbit_client_data::TracepointInfo /*tracepoint_info*/) override {
     ORBIT_UNREACHABLE();
   }
   void OnTracepointEvent(
-      orbit_client_protos::TracepointEventInfo /*tracepoint_event_info*/) override {
+      orbit_client_data::TracepointEventInfo /*tracepoint_event_info*/) override {
     ORBIT_UNREACHABLE();
   }
   void OnModuleUpdate(uint64_t /*timestamp_ns*/,

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -143,7 +143,7 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
   void OnAddressInfo(orbit_client_data::LinuxAddressInfo /*address_info*/) override {
     ORBIT_UNREACHABLE();
   }
-  void OnUniqueTracepointInfo(uint64_t /*key*/,
+  void OnUniqueTracepointInfo(uint64_t /*tracepoint_id*/,
                               orbit_client_data::TracepointInfo /*tracepoint_info*/) override {
     ORBIT_UNREACHABLE();
   }


### PR DESCRIPTION
Also ensure not to store the grpc protos in TracepointData
and than always construct the client type on request.

Test: Compile & run tests
Bug: http://b/226551739
Bug: http://b/226551010