### PR TITLE
Include top content margin in GpuDebugMarker

### DIFF
--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -114,7 +114,8 @@ float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (collapse_toggle_->IsCollapsed()) {
     depth = 0;
   }
-  return GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth;
+  return GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
+         layout_->GetTextBoxHeight() * depth;
 }
 
 float GpuDebugMarkerTrack::GetHeight() const {


### PR DESCRIPTION
It's included in GetHeight() but not in the position of the timers, as
it is in other tracks/subtracks. This margin was being included in the
bottom margin of that subtrack.

http://b/218516297