### PR TITLE
Test OpenGl methods in FakeBatcher test

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -499,7 +499,8 @@ void CaptureWindow::DrawScreenSpace() {
   float margin_x0 = margin_x1 - GetRightMargin();
 
   Box box(Vec2(margin_x0, 0), Vec2(margin_x1 - margin_x0, canvas_height), GlCanvas::kZValueMargin);
-  ui_batcher_.AddBox(box, kBackgroundColor);
+  // TODO(b/225173189): Use primitive assembler here after splitting it with BatcherInterface.
+  ui_batcher_.PrimitiveAssembler::AddBox(box, kBackgroundColor);
 }
 
 void CaptureWindow::RenderAllLayers() {
@@ -808,7 +809,8 @@ void CaptureWindow::RenderSelectionOverlay() {
   const Color color(0, 128, 0, 128);
 
   Box box(pos, size, GlCanvas::kZValueOverlay);
-  ui_batcher_.AddBox(box, color);
+  // TODO(b/225173189): Use primitive assembler here after splitting it with BatcherInterface.
+  ui_batcher_.PrimitiveAssembler::AddBox(box, color);
 
   TextRenderer::HAlign alignment = select_stop_pos_world_[0] < select_start_pos_world_[0]
                                        ? TextRenderer::HAlign::Left

--- a/src/OrbitGl/OpenGlBatcher.cpp
+++ b/src/OrbitGl/OpenGlBatcher.cpp
@@ -24,9 +24,9 @@ static void MoveLineToPixelCenterIfHorizontal(Line& line) {
   line.end_point[1] += 0.5f;
 }
 
-void OpenGlBatcher::AddLineInternal(Vec2 from, Vec2 to, float z, const Color& color,
-                                    const Color& picking_color,
-                                    std::unique_ptr<PickingUserData> user_data) {
+void OpenGlBatcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
+                            const Color& picking_color,
+                            std::unique_ptr<PickingUserData> user_data) {
   Line line;
   line.start_point = translations_.TranslateAndFloorVertex(Vec3(from[0], from[1], z));
   line.end_point = translations_.TranslateAndFloorVertex(Vec3(to[0], to[1], z));
@@ -41,9 +41,8 @@ void OpenGlBatcher::AddLineInternal(Vec2 from, Vec2 to, float z, const Color& co
   user_data_.push_back(std::move(user_data));
 }
 
-void OpenGlBatcher::AddBoxInternal(const Box& box, const std::array<Color, 4>& colors,
-                                   const Color& picking_color,
-                                   std::unique_ptr<PickingUserData> user_data) {
+void OpenGlBatcher::AddBox(const Box& box, const std::array<Color, 4>& colors,
+                           const Color& picking_color, std::unique_ptr<PickingUserData> user_data) {
   Box rounded_box = box;
   for (size_t v = 0; v < 4; ++v) {
     rounded_box.vertices[v] = translations_.TranslateAndFloorVertex(rounded_box.vertices[v]);
@@ -56,10 +55,9 @@ void OpenGlBatcher::AddBoxInternal(const Box& box, const std::array<Color, 4>& c
   user_data_.push_back(std::move(user_data));
 }
 
-void OpenGlBatcher::AddTriangleInternal(const Triangle& triangle,
-                                        const std::array<Color, 3>& colors,
-                                        const Color& picking_color,
-                                        std::unique_ptr<PickingUserData> user_data) {
+void OpenGlBatcher::AddTriangle(const Triangle& triangle, const std::array<Color, 3>& colors,
+                                const Color& picking_color,
+                                std::unique_ptr<PickingUserData> user_data) {
   Triangle rounded_tri = triangle;
   for (auto& vertex : rounded_tri.vertices) {
     vertex = translations_.TranslateAndFloorVertex(vertex);

--- a/src/OrbitGl/OpenGlBatcher.h
+++ b/src/OrbitGl/OpenGlBatcher.h
@@ -81,6 +81,15 @@ class OpenGlBatcher : public PrimitiveAssembler {
  public:
   explicit OpenGlBatcher(BatcherId batcher_id, PickingManager* picking_manager = nullptr)
       : PrimitiveAssembler(batcher_id, picking_manager) {}
+
+  void ResetElements() override;
+  void AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
+               std::unique_ptr<PickingUserData> user_data) override;
+  void AddBox(const Box& box, const std::array<Color, 4>& colors, const Color& picking_color,
+              std::unique_ptr<PickingUserData> user_data) override;
+  void AddTriangle(const Triangle& triangle, const std::array<Color, 3>& colors,
+                   const Color& picking_color, std::unique_ptr<PickingUserData> user_data) override;
+
   [[nodiscard]] std::vector<float> GetLayers() const override;
   void DrawLayer(float layer, bool picking) const override;
 
@@ -88,16 +97,6 @@ class OpenGlBatcher : public PrimitiveAssembler {
   std::unordered_map<float, orbit_gl_internal::PrimitiveBuffers> primitive_buffers_by_layer_;
 
  private:
-  void ResetElements() override;
-  void AddLineInternal(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
-                       std::unique_ptr<PickingUserData> user_data) override;
-  void AddBoxInternal(const Box& box, const std::array<Color, 4>& colors,
-                      const Color& picking_color,
-                      std::unique_ptr<PickingUserData> user_data) override;
-  void AddTriangleInternal(const Triangle& triangle, const std::array<Color, 3>& colors,
-                           const Color& picking_color,
-                           std::unique_ptr<PickingUserData> user_data) override;
-
   void DrawLineBuffer(float layer, bool picking) const;
   void DrawBoxBuffer(float layer, bool picking) const;
   void DrawTriangleBuffer(float layer, bool picking) const;

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -14,7 +14,7 @@ void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color
                                  std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingId::ToColor(PickingType::kLine, user_data_.size(), batcher_id_);
 
-  AddLineInternal(from, to, z, color, picking_color, std::move(user_data));
+  AddLine(from, to, z, color, picking_color, std::move(user_data));
 }
 
 void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
@@ -23,7 +23,7 @@ void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
 
-  AddLineInternal(from, to, z, color, picking_color, nullptr);
+  AddLine(from, to, z, color, picking_color, nullptr);
 }
 
 void PrimitiveAssembler::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
@@ -37,13 +37,13 @@ void PrimitiveAssembler::AddVerticalLine(Vec2 pos, float size, float z, const Co
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
 
-  AddLineInternal(pos, pos + Vec2(0, size), z, color, picking_color, nullptr);
+  AddLine(pos, pos + Vec2(0, size), z, color, picking_color, nullptr);
 }
 
 void PrimitiveAssembler::AddBox(const Box& box, const std::array<Color, 4>& colors,
                                 std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingId::ToColor(PickingType::kBox, user_data_.size(), batcher_id_);
-  AddBoxInternal(box, colors, picking_color, std::move(user_data));
+  AddBox(box, colors, picking_color, std::move(user_data));
 }
 
 void PrimitiveAssembler::AddBox(const Box& box, const Color& color,
@@ -61,7 +61,7 @@ void PrimitiveAssembler::AddBox(const Box& box, const Color& color,
   std::array<Color, 4> colors;
   colors.fill(color);
 
-  AddBoxInternal(box, colors, picking_color, nullptr);
+  AddBox(box, colors, picking_color, nullptr);
 }
 
 void PrimitiveAssembler::AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color) {
@@ -174,7 +174,7 @@ void PrimitiveAssembler::AddShadedBox(Vec2 pos, Vec2 size, float z, const Color&
   GetBoxGradientColors(color, &colors, shading_direction);
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
   Box box(pos, size, z);
-  AddBoxInternal(box, colors, picking_color, nullptr);
+  AddBox(box, colors, picking_color, nullptr);
 }
 
 void PrimitiveAssembler::AddTriangle(const Triangle& triangle, const Color& color,
@@ -198,7 +198,7 @@ void PrimitiveAssembler::AddTriangle(const Triangle& triangle, const Color& colo
                                      std::unique_ptr<PickingUserData> user_data) {
   std::array<Color, 3> colors;
   colors.fill(color);
-  AddTriangleInternal(triangle, colors, picking_color, std::move(user_data));
+  AddTriangle(triangle, colors, picking_color, std::move(user_data));
 }
 
 // Draw a shaded trapezium with two sides parallel to the x-axis or y-axis.
@@ -212,11 +212,10 @@ void PrimitiveAssembler::AddShadedTrapezium(const Vec3& top_left, const Vec3& bo
   Color picking_color = PickingId::ToColor(PickingType::kTriangle, user_data_.size(), batcher_id_);
   Triangle triangle_1{top_left, bottom_left, top_right};
   std::array<Color, 3> colors_1{colors[0], colors[1], colors[2]};
-  AddTriangleInternal(triangle_1, colors_1, picking_color,
-                      std::make_unique<PickingUserData>(*user_data));
+  AddTriangle(triangle_1, colors_1, picking_color, std::make_unique<PickingUserData>(*user_data));
   Triangle triangle_2{bottom_left, bottom_right, top_right};
   std::array<Color, 3> colors_2{colors[1], colors[2], colors[3]};
-  AddTriangleInternal(triangle_2, colors_2, picking_color, std::move(user_data));
+  AddTriangle(triangle_2, colors_2, picking_color, std::move(user_data));
 }
 
 void PrimitiveAssembler::AddCircle(const Vec2& position, float radius, float z, Color color) {

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -128,6 +128,17 @@ class PrimitiveAssembler {
 
   static constexpr uint32_t kNumArcSides = 16;
 
+  virtual void ResetElements() = 0;
+  virtual void AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
+                       std::unique_ptr<PickingUserData> user_data) = 0;
+  virtual void AddBox(const Box& box, const std::array<Color, 4>& colors,
+                      const Color& picking_color, std::unique_ptr<PickingUserData> user_data) = 0;
+  virtual void AddTriangle(const Triangle& triangle, const std::array<Color, 3>& colors,
+                           const Color& picking_color,
+                           std::unique_ptr<PickingUserData> user_data) = 0;
+  [[nodiscard]] virtual uint32_t GetNumElements() const { return user_data_.size(); }
+  [[nodiscard]] BatcherId GetBatcherId() const { return batcher_id_; }
+
  protected:
   void AddTriangle(const Triangle& triangle, const Color& color, const Color& picking_color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
@@ -137,16 +148,6 @@ class PrimitiveAssembler {
  private:
   void GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors,
                             ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
-  virtual void ResetElements() = 0;
-  virtual void AddLineInternal(Vec2 from, Vec2 to, float z, const Color& color,
-                               const Color& picking_color,
-                               std::unique_ptr<PickingUserData> user_data) = 0;
-  virtual void AddBoxInternal(const Box& box, const std::array<Color, 4>& colors,
-                              const Color& picking_color,
-                              std::unique_ptr<PickingUserData> user_data) = 0;
-  virtual void AddTriangleInternal(const Triangle& triangle, const std::array<Color, 3>& colors,
-                                   const Color& picking_color,
-                                   std::unique_ptr<PickingUserData> user_data) = 0;
 
   BatcherId batcher_id_;
   PickingManager* picking_manager_;


### PR DESCRIPTION
Part of the work to split Batcher in BatcherInterface and
PrimitiveAssembler.
(https://github.com/karupayun/orbit/commit/1d4d264fc5f1f90c033b62bc2d0b22f45750401f).

This class is testing different things (internal implementation, picking
and shared pickable) that now are going to be in separate files. As a
first step I'm testing the internal methods that are going to be used in
OpenGl implementation instead of the PrimitiveAssembler part.

In addition I'm renaming the internal methods to the original name since
they are going to be public functions used by the PrimitiveAssembler
(Henning's suggestion).

As a side effect, CaptureWindow complains correctly that they expect
that methods to be in OpenGlBatcher. This is because CaptureWindow
should use primitive assembler there. This is already in
https://github.com/karupayun/orbit/commit/1d4d264fc5f1f90c033b62bc2d0b22f45750401f,
but for now I just added a temporal TODO.

- As little temporal detail, I add GetBatcherId() and GetNumElements()
  temporary to Batcher.

2nd step in http://b/225173189