### PR TITLE
Launch process with busy loop at entry point

### DIFF
--- a/src/WindowsUtils/BusyLoopLauncher.cpp
+++ b/src/WindowsUtils/BusyLoopLauncher.cpp
@@ -4,6 +4,10 @@
 
 #include "WindowsUtils/BusyLoopLauncher.h"
 
+#include <absl/strings/str_format.h>
+
+#include "OrbitBase/GetLastError.h"
+
 namespace orbit_windows_utils {
 
 BusyLoopLauncher::BusyLoopLauncher() : debugger_({this}) {}
@@ -11,6 +15,10 @@ BusyLoopLauncher::BusyLoopLauncher() : debugger_({this}) {}
 ErrorMessageOr<BusyLoopInfo> BusyLoopLauncher::StartWithBusyLoopAtEntryPoint(
     const std::filesystem::path& executable, const std::filesystem::path& working_directory,
     const std::string_view arguments) {
+  // Calling "StartWithBusyLoopAtEntryPoint" multiple times is not supported.
+  ORBIT_CHECK(state_ == State::kInitialState);
+  state_ = State::kProcessStarted;
+
   // Launch process as debuggee in order to receive debugging events.
   OUTCOME_TRY(debugger_.Start(executable, working_directory, arguments));
 
@@ -24,8 +32,42 @@ void BusyLoopLauncher::OnCreateProcessDebugEvent(const DEBUG_EVENT& event) {
   busy_loop_info_or_error_promise_.SetResult(InstallBusyLoopAtAddress(
       event.u.CreateProcessInfo.hProcess, event.u.CreateProcessInfo.lpStartAddress));
 
-  // At this point, we don't need to continue debugging the process, detach.
-  debugger_.Detach();
+  // Keep a handle on the main thread of the created process.
+  main_thread_handle_ = event.u.CreateProcessInfo.hThread;
+}
+
+ErrorMessageOr<void> BusyLoopLauncher::SuspendMainThreadAndRemoveBusyLoop() {
+  ORBIT_CHECK(main_thread_handle_ != nullptr);
+  ORBIT_CHECK(state_ == State::kProcessStarted);
+
+  // Make sure the busy loop has been has been installed, possibly waiting.
+  OUTCOME_TRY(const BusyLoopInfo& busy_loop_info,
+              busy_loop_info_or_error_promise_.GetFuture().Get());
+
+  // Suspend the main thread.
+  OUTCOME_TRY(SuspendThread(main_thread_handle_));
+  state_ = State::kProcessSuspended;
+
+  // Replace busy loop by original instructions.
+  OUTCOME_TRY(RemoveBusyLoop(busy_loop_info));
+
+  // Make sure the instruction pointer is set back to the entry point.
+  OUTCOME_TRY(SetThreadInstructionPointer(main_thread_handle_, busy_loop_info.address));
+
+  return outcome::success();
+}
+
+ErrorMessageOr<void> BusyLoopLauncher::ResumeMainThread() {
+  ORBIT_CHECK(state_ == State::kProcessSuspended);
+  ORBIT_CHECK(main_thread_handle_ != nullptr);
+  OUTCOME_TRY(ResumeThread(main_thread_handle_));
+  state_ = State::kProcessResumed;
+  return outcome::success();
+}
+
+void BusyLoopLauncher::WaitForProcessToExit() {
+  debugger_.Wait();
+  state_ = State::kProcessExited;
 }
 
 }  // namespace orbit_windows_utils

--- a/src/WindowsUtils/BusyLoopLauncher.cpp
+++ b/src/WindowsUtils/BusyLoopLauncher.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/BusyLoopLauncher.h"
+
+namespace orbit_windows_utils {
+
+BusyLoopLauncher::BusyLoopLauncher() : debugger_({this}) {}
+
+ErrorMessageOr<BusyLoopInfo> BusyLoopLauncher::StartWithBusyLoopAtEntryPoint(
+    const std::filesystem::path& executable, const std::filesystem::path& working_directory,
+    const std::string_view arguments) {
+  // Launch process as debuggee in order to receive debugging events.
+  OUTCOME_TRY(debugger_.Start(executable, working_directory, arguments));
+
+  // Wait for "OnCreateProcessDebugEvent" to be called on process creation and for the result of the
+  // busy loop installation to be ready.
+  return busy_loop_info_or_error_promise_.GetFuture().Get();
+}
+
+void BusyLoopLauncher::OnCreateProcessDebugEvent(const DEBUG_EVENT& event) {
+  // Try installing a busy loop at entry point.
+  busy_loop_info_or_error_promise_.SetResult(InstallBusyLoopAtAddress(
+      event.u.CreateProcessInfo.hProcess, event.u.CreateProcessInfo.lpStartAddress));
+
+  // At this point, we don't need to continue debugging the process, detach.
+  debugger_.Detach();
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/BusyLoopLauncherTest.cpp
+++ b/src/WindowsUtils/BusyLoopLauncherTest.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/base/casts.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/GetLastError.h"
+#include "TestUtils/TestUtils.h"
+#include "WindowsUtils/BusyLoopLauncher.h"
+#include "WindowsUtils/BusyLoopUtils.h"
+#include "WindowsUtils/OpenProcess.h"
+#include "WindowsUtils/ProcessList.h"
+
+namespace {
+
+using orbit_windows_utils::BusyLoopInfo;
+using orbit_windows_utils::BusyLoopLauncher;
+using orbit_windows_utils::OpenProcess;
+using orbit_windows_utils::ProcessList;
+using orbit_windows_utils::SafeHandle;
+
+[[nodiscard]] std::filesystem::path GetTestExecutablePath() {
+  static auto path = orbit_base::GetExecutableDir() / "FakeCliProgram.exe";
+  return path;
+}
+
+__declspec(noinline) void IncrementCounter(uint32_t* counter, std::atomic<bool>* exit_requested) {
+  ++(*counter);
+
+  // Wait for exit request.
+  while (!(*exit_requested)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+
+}  // namespace
+
+TEST(BusyLoop, BusyLoopLauncher) {
+  // Start process that would normally exit instantly and install busy loop at entry point.
+  BusyLoopLauncher busy_loop_launcher;
+  const std::string kArguments = "";
+  ErrorMessageOr<BusyLoopInfo> result = busy_loop_launcher.StartWithBusyLoopAtEntryPoint(
+      GetTestExecutablePath(), /*working_directory=*/"", kArguments);
+  ASSERT_TRUE(result.has_value());
+
+  // Validate returned busy loop info.
+  const BusyLoopInfo& busy_loop_info = result.value();
+  EXPECT_TRUE(busy_loop_info.original_bytes.size() > 0);
+  EXPECT_NE(busy_loop_info.process_id, 0);
+  EXPECT_NE(busy_loop_info.address, 0);
+
+  // At this point, the process should be busy looping at entry point.
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  // Make sure the process is still alive.
+  std::unique_ptr<ProcessList> process_list = ProcessList::Create();
+  EXPECT_TRUE(process_list->GetProcessByPid(busy_loop_info.process_id).has_value());
+
+  // Kill process.
+  auto open_result =
+      OpenProcess(PROCESS_ALL_ACCESS, /*inherit_handle=*/false, busy_loop_info.process_id);
+  ASSERT_TRUE(open_result.has_value());
+  const SafeHandle& process_handle = open_result.value();
+  EXPECT_NE(TerminateProcess(*process_handle, /*exit_code*/ 0), 0)
+      << orbit_base::GetLastErrorAsString();
+}
+
+TEST(BusyLoop, BusyLoopAtFunction) {
+  std::atomic<bool> exit_requested = false;
+  uint32_t counter = 0;
+
+  // Install busy loop at start of "IncrementCounter" function.
+  auto busy_loop_info_or =
+      orbit_windows_utils::InstallBusyLoopAtAddress(GetCurrentProcess(), &IncrementCounter);
+  ASSERT_TRUE(busy_loop_info_or.has_value());
+  const BusyLoopInfo& busy_loop_info = busy_loop_info_or.value();
+
+  // Launch a thread that calls "IncrementCounter" which should spin at function entry.
+  std::thread t(&IncrementCounter, &counter, &exit_requested);
+
+  // Verify that our counter has not been incremented.
+  constexpr size_t kNumChecks = 10;
+  for (int i = 0; i < kNumChecks; ++i) {
+    ASSERT_EQ(counter, 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Suspend thread and replace busy loop by original code.
+  HANDLE thread_handle = t.native_handle();
+  ASSERT_TRUE(orbit_windows_utils::SuspendThread(thread_handle).has_value());
+  ASSERT_TRUE(orbit_windows_utils::RemoveBusyLoop(busy_loop_info_or.value()).has_value());
+
+  // Make sure the instruction pointer is back to the original address.
+  ASSERT_TRUE(
+      orbit_windows_utils::SetThreadInstructionPointer(thread_handle, busy_loop_info.address)
+          .has_value());
+
+  // Verify that our counter has still not been incremented.
+  for (int i = 0; i < kNumChecks; ++i) {
+    ASSERT_EQ(counter, 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // Resume thread.
+  ASSERT_TRUE(orbit_windows_utils::ResumeThread(thread_handle).has_value());
+
+  // Wait for thread to exit.
+  exit_requested = true;
+  t.join();
+
+  // Make sure our counter was incremented.
+  ASSERT_EQ(counter, 1);
+}

--- a/src/WindowsUtils/BusyLoopUtils.cpp
+++ b/src/WindowsUtils/BusyLoopUtils.cpp
@@ -17,15 +17,11 @@ namespace orbit_windows_utils {
 
 namespace {
 
-using orbit_base::GetLastErrorAsString;
-
-ErrorMessage GetLastErrorForFunction(std::string_view function) {
-  return ErrorMessage(absl::StrFormat("Calling \"%s\": %s", function, GetLastErrorAsString()));
-}
+using orbit_base::GetLastErrorAsErrorMessage;
 
 ErrorMessageOr<void> FlushInstructionCache(HANDLE process_handle, void* address, size_t size) {
   if (::FlushInstructionCache(process_handle, address, size) == 0) {
-    return GetLastErrorForFunction("FlushInstructionCache");
+    return GetLastErrorAsErrorMessage("FlushInstructionCache");
   }
   return outcome::success();
 }
@@ -74,13 +70,13 @@ ErrorMessageOr<void> SetThreadInstructionPointer(HANDLE thread_handle,
   CONTEXT c = {0};
   c.ContextFlags = CONTEXT_CONTROL;
   if (!GetThreadContext(thread_handle, &c)) {
-    return GetLastErrorForFunction("GetThreadContext");
+    return GetLastErrorAsErrorMessage("GetThreadContext");
   }
 
   c.Rip = instruction_pointer;
 
   if (SetThreadContext(thread_handle, &c) == 0) {
-    return GetLastErrorForFunction("SetThreadContext");
+    return GetLastErrorAsErrorMessage("SetThreadContext");
   }
 
   return outcome::success();
@@ -88,14 +84,14 @@ ErrorMessageOr<void> SetThreadInstructionPointer(HANDLE thread_handle,
 
 ErrorMessageOr<void> SuspendThread(HANDLE thread_handle) {
   if (::SuspendThread(thread_handle) == (DWORD)-1) {
-    return GetLastErrorForFunction("SuspendThread");
+    return GetLastErrorAsErrorMessage("SuspendThread");
   }
   return outcome::success();
 }
 
 ErrorMessageOr<void> ResumeThread(HANDLE thread_handle) {
   if (::ResumeThread(thread_handle) == (DWORD)-1) {
-    return GetLastErrorForFunction("ResumeThread");
+    return GetLastErrorAsErrorMessage("ResumeThread");
   }
   return outcome::success();
 }

--- a/src/WindowsUtils/BusyLoopUtils.cpp
+++ b/src/WindowsUtils/BusyLoopUtils.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/BusyLoopUtils.h"
+
+#include <absl/base/casts.h>
+#include <absl/strings/str_format.h>
+
+#include "OrbitBase/GetLastError.h"
+#include "WindowsUtils/ReadProcessMemory.h"
+#include "WindowsUtils/SafeHandle.h"
+#include "WindowsUtils/WriteProcessMemory.h"
+
+namespace orbit_windows_utils {
+
+namespace {
+
+ErrorMessage GetLastErrorForFunction(std::string_view function) {
+  return ErrorMessage(
+      absl::StrFormat("Calling \"%s\": %s", function, orbit_base::GetLastErrorAsString()));
+}
+
+ErrorMessageOr<void> FlushInstructionCache(HANDLE process_handle, void* address, size_t size) {
+  if (::FlushInstructionCache(process_handle, address, size) == 0) {
+    return GetLastErrorForFunction("FlushInstructionCache");
+  }
+  return outcome::success();
+}
+
+ErrorMessageOr<void> WriteInstructionsAtAddress(const std::string& byte_buffer, void* address) {
+  // Mark memory page for writing.
+  DWORD old_protect = 0;
+  if (!VirtualProtect(address, byte_buffer.size(), PAGE_EXECUTE_READWRITE, &old_protect)) {
+    return GetLastErrorForFunction("VirtualProtect");
+  }
+
+  // Write original bytes.
+  memcpy(address, byte_buffer.data(), byte_buffer.size());
+
+  // Restore original page protection.
+  if (!VirtualProtect(address, byte_buffer.size(), old_protect, &old_protect)) {
+    return GetLastErrorForFunction("VirtualProtect");
+  }
+
+  OUTCOME_TRY(FlushInstructionCache(GetCurrentProcess(), address, byte_buffer.size()));
+  return outcome::success();
+}
+
+}  // namespace
+
+ErrorMessageOr<BusyLoopInfo> InstallBusyLoopAtAddress(HANDLE process_handle, void* address) {
+  constexpr const char kBusyLoopCode[] = {0xEB, 0xFE};
+  BusyLoopInfo busy_loop;
+  busy_loop.address = absl::bit_cast<uint64_t>(address);
+  busy_loop.process_id = GetProcessId(process_handle);
+
+  // Copy original bytes before installing busy loop.
+  OUTCOME_TRY(busy_loop.original_bytes,
+              ReadProcessMemory(busy_loop.process_id, busy_loop.address, sizeof(kBusyLoopCode)));
+
+  // Install busy loop.
+  OUTCOME_TRY(WriteProcessMemory(process_handle, address, kBusyLoopCode));
+
+  // Flush instruction cache.
+  OUTCOME_TRY(FlushInstructionCache(process_handle, address, sizeof(kBusyLoopCode)));
+
+  return busy_loop;
+}
+
+ErrorMessageOr<void> SuspendThread(HANDLE thread_handle) {
+  if (::SuspendThread(thread_handle) == (DWORD)-1) {
+    return GetLastErrorForFunction("SuspendThread");
+  }
+  return outcome::success();
+}
+
+ErrorMessageOr<void> ResumeThread(HANDLE thread_handle) {
+  if (::ResumeThread(thread_handle) == (DWORD)-1) {
+    return GetLastErrorForFunction("ResumeThread");
+  }
+  return outcome::success();
+}
+
+ErrorMessageOr<void> RemoveBusyLoop(const BusyLoopInfo& busy_loop_info) {
+  // Remove the busy loop and restore the original bytes.
+  void* busy_loop_address = absl::bit_cast<void*>(busy_loop_info.address);
+  OUTCOME_TRY(WriteInstructionsAtAddress(busy_loop_info.original_bytes, busy_loop_address));
+  return outcome::success();
+}
+
+ErrorMessageOr<void> SetThreadInstructionPointer(HANDLE thread_handle,
+                                                 uint64_t instruction_pointer) {
+  CONTEXT c = {0};
+  c.ContextFlags = CONTEXT_CONTROL;
+  if (!GetThreadContext(thread_handle, &c)) {
+    return GetLastErrorForFunction("GetThreadContext");
+  }
+
+  c.Rip = instruction_pointer;
+
+  if (SetThreadContext(thread_handle, &c) == 0) {
+    return GetLastErrorForFunction("SetThreadContext");
+  }
+
+  return outcome::success();
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -21,6 +21,8 @@ target_include_directories(WindowsUtils PRIVATE
 
 target_sources(WindowsUtils PUBLIC
         include/WindowsUtils/AdjustTokenPrivilege.h
+        include/WindowsUtils/BusyLoopLauncher.h
+        include/WindowsUtils/BusyLoopUtils.h
         include/WindowsUtils/CreateProcess.h
         include/WindowsUtils/Debugger.h
         include/WindowsUtils/DllInjection.h
@@ -35,6 +37,8 @@ target_sources(WindowsUtils PUBLIC
 
 target_sources(WindowsUtils PRIVATE
         AdjustTokenPrivilege.cpp
+        BusyLoopLauncher.cpp
+        BusyLoopUtils.cpp
         CreateProcess.cpp
         Debugger.cpp
         DllInjection.cpp
@@ -55,6 +59,7 @@ target_link_libraries(WindowsUtils PUBLIC
 add_executable(WindowsUtilsTests)
 
 target_sources(WindowsUtilsTests PRIVATE
+        BusyLoopLauncherTest.cpp
         CreateProcessTest.cpp
         DebuggerTest.cpp
         DllInjectionTest.cpp

--- a/src/WindowsUtils/include/WindowsUtils/BusyLoopLauncher.h
+++ b/src/WindowsUtils/include/WindowsUtils/BusyLoopLauncher.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_BUSY_LOOP_LAUNCHER_H_
+#define WINDOWS_UTILS_BUSY_LOOP_LAUNCHER_H_
+
+#include "WindowsUtils/BusyLoopUtils.h"
+#include "WindowsUtils/Debugger.h"
+
+namespace orbit_windows_utils {
+
+// "BusyLoopLauncher" is a utility to launch a process and install a busy loop at entry point.
+class BusyLoopLauncher : public DebugEventListener {
+ public:
+  BusyLoopLauncher();
+
+  ErrorMessageOr<BusyLoopInfo> StartWithBusyLoopAtEntryPoint(
+      const std::filesystem::path& executable, const std::filesystem::path& working_directory,
+      const std::string_view arguments);
+
+ protected:
+  void OnCreateProcessDebugEvent(const DEBUG_EVENT& event) override;
+
+  // Unused DebugEventListener methods.
+  void OnExitProcessDebugEvent(const DEBUG_EVENT& event) override{};
+  void OnCreateThreadDebugEvent(const DEBUG_EVENT& event) override{};
+  void OnExitThreadDebugEvent(const DEBUG_EVENT& event) override{};
+  void OnLoadDllDebugEvent(const DEBUG_EVENT& event) override{};
+  void OnUnLoadDllDebugEvent(const DEBUG_EVENT& event) override{};
+  void OnBreakpointDebugEvent(const DEBUG_EVENT& event) override{};
+  void OnOutputStringDebugEvent(const DEBUG_EVENT& event) override{};
+  void OnExceptionDebugEvent(const DEBUG_EVENT& event) override{};
+  void OnRipEvent(const DEBUG_EVENT& event) override{};
+
+ private:
+  Debugger debugger_;
+  orbit_base::Promise<ErrorMessageOr<BusyLoopInfo>> busy_loop_info_or_error_promise_;
+};
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_BUSY_LOOP_LAUNCHER_H_

--- a/src/WindowsUtils/include/WindowsUtils/BusyLoopLauncher.h
+++ b/src/WindowsUtils/include/WindowsUtils/BusyLoopLauncher.h
@@ -11,9 +11,9 @@
 
 namespace orbit_windows_utils {
 
-// "BusyLoopLauncher" is a utility to launch a process and install a busy loop at entry point.
-// This is mainly used to allow to inject a dll as early as possible during process creation.
-// The class is single-use only, it can not be reused to launch multiple processes.
+// Utility to launch a process and install a busy loop at entry point. This is mainly used to allow
+// dll injection as early as possible during process creation. The class is single-use only, it can
+// not be reused to launch multiple processes.
 //
 // Typical usage:
 //  1. Call "StartWithBusyLoopAtEntryPoint" to launch process that will spin at entry point.
@@ -51,9 +51,9 @@ class BusyLoopLauncher : public DebugEventListener {
  private:
   enum class State {
     kInitialState,
-    kProcessStarted,
-    kProcessSuspended,
-    kProcessResumed,
+    kMainThreadInBusyLoop,
+    kMainThreadSuspended,
+    kMainThreadResumed,
     kProcessExited
   };
 

--- a/src/WindowsUtils/include/WindowsUtils/BusyLoopUtils.h
+++ b/src/WindowsUtils/include/WindowsUtils/BusyLoopUtils.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_BUSY_LOOP_UTILS_H_
+#define WINDOWS_UTILS_BUSY_LOOP_UTILS_H_
+
+// clang-format off
+#include <Windows.h>
+// clang-format on
+
+#include <stdint.h>
+#include <string>
+#include "OrbitBase/Result.h"
+
+namespace orbit_windows_utils {
+
+// Information returned from "InstallBusyLoopAtAddress" required to resume the original code.
+struct BusyLoopInfo {
+  uint32_t process_id = 0;
+  uint64_t address = 0;
+  std::string original_bytes;
+};
+
+ErrorMessageOr<BusyLoopInfo> InstallBusyLoopAtAddress(HANDLE process_handle, void* address);
+ErrorMessageOr<void> RemoveBusyLoop(const BusyLoopInfo& busy_loop_info);
+
+ErrorMessageOr<void> SuspendThread(HANDLE thread_handle);
+ErrorMessageOr<void> ResumeThread(HANDLE thread_handle);
+ErrorMessageOr<void> SetThreadInstructionPointer(HANDLE thread_handle,
+                                                 uint64_t instruction_pointer);
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_BUSY_LOOP_UTILS_H_

--- a/src/WindowsUtils/include/WindowsUtils/BusyLoopUtils.h
+++ b/src/WindowsUtils/include/WindowsUtils/BusyLoopUtils.h
@@ -27,8 +27,9 @@ struct BusyLoopInfo {
 // Overwrite instructions at address by a 2 bytes busy loop.
 ErrorMessageOr<BusyLoopInfo> InstallBusyLoopAtAddress(HANDLE process_handle, void* address);
 // Replace the instructions overwritten by "InstallBusyLoopAtAddress" by the original instructions.
+// The busy looping thread(s) should be suspended before the call.
 ErrorMessageOr<void> RemoveBusyLoop(const BusyLoopInfo& busy_loop_info);
-// Set instruction pointer for given thread.
+// Set instruction pointer for given suspended thread.
 ErrorMessageOr<void> SetThreadInstructionPointer(HANDLE thread_handle,
                                                  uint64_t instruction_pointer);
 // Suspend given thread.

--- a/src/WindowsUtils/include/WindowsUtils/BusyLoopUtils.h
+++ b/src/WindowsUtils/include/WindowsUtils/BusyLoopUtils.h
@@ -19,16 +19,22 @@ namespace orbit_windows_utils {
 struct BusyLoopInfo {
   uint32_t process_id = 0;
   uint64_t address = 0;
+  // TODO (b/228234988) remove std::string from Write/ReadProcessMemory interface.
+  // We use std::string as a byte buffer here.
   std::string original_bytes;
 };
 
+// Overwrite instructions at address by a 2 bytes busy loop.
 ErrorMessageOr<BusyLoopInfo> InstallBusyLoopAtAddress(HANDLE process_handle, void* address);
+// Replace the instructions overwritten by "InstallBusyLoopAtAddress" by the original instructions.
 ErrorMessageOr<void> RemoveBusyLoop(const BusyLoopInfo& busy_loop_info);
-
-ErrorMessageOr<void> SuspendThread(HANDLE thread_handle);
-ErrorMessageOr<void> ResumeThread(HANDLE thread_handle);
+// Set instruction pointer for given thread.
 ErrorMessageOr<void> SetThreadInstructionPointer(HANDLE thread_handle,
                                                  uint64_t instruction_pointer);
+// Suspend given thread.
+ErrorMessageOr<void> SuspendThread(HANDLE thread_handle);
+// Resume given thread.
+ErrorMessageOr<void> ResumeThread(HANDLE thread_handle);
 
 }  // namespace orbit_windows_utils
 


### PR DESCRIPTION
"BusyLoopLauncher" is a utility to launch a process and install a busy 
loop at entry point. It uses functions defined in "BusyLoopUtils.h", which
also contains functions to resume execution of the original code. 
Tests are found in "BusyLoopLauncherTest".

Note that resuming the execution of the launched process has not been
implemented yet. We test that functionality in the current process for now.

Tests: ran tests.