### PR TITLE
Use "const" target process

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2246,7 +2246,7 @@ void OrbitApp::UpdateProcessAndModuleList() {
 }
 
 void OrbitApp::RefreshUIAfterModuleReload() {
-  modules_data_view_->UpdateModules(GetMutableTargetProcess());
+  modules_data_view_->UpdateModules(GetTargetProcess());
 
   functions_data_view_->ClearFunctions();
   auto module_keys = GetTargetProcess()->GetUniqueModulesPathAndBuildId();


### PR DESCRIPTION
Removed a call to GetMutableTargetProcess, where only the const
pointer was needed.

Test: Compile