### PR TITLE
Rename JoinFutures to WhenAll

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -28,7 +28,6 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/File.h
         include/OrbitBase/Future.h
         include/OrbitBase/FutureHelpers.h
-        include/OrbitBase/JoinFutures.h
         include/OrbitBase/Logging.h
         include/OrbitBase/MainThreadExecutor.h
         include/OrbitBase/MakeUniqueForOverwrite.h
@@ -47,12 +46,12 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/ThreadPool.h
         include/OrbitBase/ThreadUtils.h
         include/OrbitBase/UniqueResource.h
+        include/OrbitBase/WhenAll.h
         include/OrbitBase/WriteStringToFile.h)
 
 target_sources(OrbitBase PRIVATE
         ExecutablePath.cpp
         File.cpp
-        JoinFutures.cpp
         Logging.cpp
         LoggingUtils.cpp
         Profiling.cpp
@@ -62,6 +61,7 @@ target_sources(OrbitBase PRIVATE
         StringConversion.cpp
         TemporaryFile.cpp
         ThreadPool.cpp
+        WhenAll.cpp
         WriteStringToFile.cpp)
 
 if (WIN32)
@@ -102,7 +102,6 @@ target_sources(OrbitBaseTests PRIVATE
         FutureTest.cpp
         FutureHelpersTest.cpp
         ImmediateExecutorTest.cpp
-        JoinFuturesTest.cpp
         LoggingUtilsTest.cpp
         ProfilingTest.cpp
         PromiseTest.cpp
@@ -115,6 +114,7 @@ target_sources(OrbitBaseTests PRIVATE
         TemporaryFileTest.cpp
         ThreadUtilsTest.cpp
         UniqueResourceTest.cpp
+        WhenAllTest.cpp
         WriteStringToFileTest.cpp
 )
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -76,12 +76,12 @@
 #include "OrbitBase/Future.h"
 #include "OrbitBase/FutureHelpers.h"
 #include "OrbitBase/ImmediateExecutor.h"
-#include "OrbitBase/JoinFutures.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/MainThreadExecutor.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/UniqueResource.h"
+#include "OrbitBase/WhenAll.h"
 #include "OrbitPaths/Paths.h"
 #include "OrbitVersion/OrbitVersion.h"
 #include "SamplingReport.h"
@@ -1695,7 +1695,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
     futures.emplace_back(RetrieveModuleAndLoadSymbolsAndHandleError(module));
   }
 
-  return orbit_base::JoinFutures(futures);
+  return orbit_base::WhenAll(futures);
 }
 
 orbit_base::Future<void> OrbitApp::RetrieveModuleAndLoadSymbolsAndHandleError(
@@ -2139,7 +2139,7 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::LoadPreset(const PresetFile& 
 
   // Then - when all modules are loaded or failed to load - we update the UI and potentially show an
   // error message.
-  auto results = orbit_base::JoinFutures(absl::MakeConstSpan(load_module_results));
+  auto results = orbit_base::WhenAll(absl::MakeConstSpan(load_module_results));
   return results.Then(
       main_thread_executor_,
       [this, metric = std::move(metric), preset_file](
@@ -2329,7 +2329,7 @@ orbit_base::Future<std::vector<ErrorMessageOr<void>>> OrbitApp::ReloadModules(
     reloaded_modules.emplace_back(std::move(reloaded_module));
   }
 
-  return orbit_base::JoinFutures(absl::MakeConstSpan(reloaded_modules));
+  return orbit_base::WhenAll(absl::MakeConstSpan(reloaded_modules));
 }
 
 void OrbitApp::SetCollectSchedulerInfo(bool collect_scheduler_info) {

--- a/src/QtUtils/FutureWatcher.cpp
+++ b/src/QtUtils/FutureWatcher.cpp
@@ -13,7 +13,7 @@
 #include <QTimer>
 #include <chrono>
 
-#include "OrbitBase/JoinFutures.h"
+#include "OrbitBase/WhenAll.h"
 
 namespace orbit_qt_utils {
 
@@ -59,6 +59,6 @@ FutureWatcher::Reason FutureWatcher::WaitFor(
 FutureWatcher::Reason FutureWatcher::WaitForAll(
     absl::Span<orbit_base::Future<void>> futures,
     std::optional<std::chrono::milliseconds> timeout) const {
-  return WaitFor(orbit_base::JoinFutures(futures), timeout);
+  return WaitFor(orbit_base::WhenAll(futures), timeout);
 }
 }  // namespace orbit_qt_utils

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -14,8 +14,8 @@
 
 #include "ClientFlags/ClientFlags.h"
 #include "ClientServices/ProcessClient.h"
-#include "OrbitBase/JoinFutures.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/WhenAll.h"
 #include "SessionSetup/ConnectToTargetDialog.h"
 #include "SessionSetup/ServiceDeployManager.h"
 #include "SessionSetup/SessionSetupUtils.h"
@@ -68,7 +68,7 @@ std::optional<TargetConfiguration> ConnectToTargetDialog::Exec() {
 
   auto process_future = ggp_client_->GetSshInfoAsync(target_.instance_name_or_id, std::nullopt);
   auto instance_future = ggp_client_->DescribeInstanceAsync(target_.instance_name_or_id);
-  auto joined_future = orbit_base::JoinFutures(process_future, instance_future);
+  auto joined_future = orbit_base::WhenAll(process_future, instance_future);
 
   joined_future.Then(main_thread_executor_.get(),
                      [this](MaybeSshAndInstanceData ssh_instance_data) {

--- a/src/SessionSetup/RetrieveInstances.cpp
+++ b/src/SessionSetup/RetrieveInstances.cpp
@@ -21,9 +21,9 @@
 #include "MetricsUploader/ScopedMetric.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/FutureHelpers.h"
-#include "OrbitBase/JoinFutures.h"
 #include "OrbitBase/MainThreadExecutor.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WhenAll.h"
 
 namespace orbit_session_setup {
 
@@ -128,9 +128,9 @@ RetrieveInstancesImpl::LoadProjectsAndInstances(const std::optional<orbit_ggp::P
 
   Future<std::tuple<ErrorMessageOr<QVector<Project>>, ErrorMessageOr<Project>,
                     ErrorMessageOr<QVector<Instance>>, ErrorMessageOr<QVector<Instance>>>>
-      combined_future = orbit_base::JoinFutures(projects_future, default_project_future,
-                                                instances_from_project_future,
-                                                instances_from_default_project_future);
+      combined_future =
+          orbit_base::WhenAll(projects_future, default_project_future,
+                              instances_from_project_future, instances_from_default_project_future);
 
   return combined_future.Then(
       main_thread_executor_,


### PR DESCRIPTION
This makes it easier to understand what's happening and it prepares the
code base for another join operation - WhenAny.

I'm doing this now because I wanna be able to add timeouts to futures. For this I need `WhenAny`.

Example what I have in mind:

```cpp
Future<Value> result = LongOperation();
Future<std::variant<Value,Timeout>> result_or_timeout = WhenAny(result, CreateTimeout(std::chrono::seconds{42});
Future<Value> result_or_default = result_or_timeout.Then(executor,
    [](const std::variant<Value,Timeout>& value_or_timeout) {
      if (std::hold_alternative<Timeout>(value_or_timeout)) return CreateDefaultValue();
      return std::get<Value>(value_or_timeout);
});
```