### PR TITLE
Add utility function to test if a file is potentially a PE/COFF file

### DIFF
--- a/third_party/libunwindstack/include/unwindstack/PeCoff.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoff.h
@@ -36,6 +36,12 @@ class Regs;
 class Memory;
 struct ErrorData;
 
+// Inspects the first bytes of the file / memory to check if this is potentially a PE/COFF file.
+// Since we don't read the full file and don't validate if this is really a proper PE/COFF file,
+// this should only be considered a hint.
+bool IsPotentiallyPeCoffFile(Memory* memory);
+bool IsPotentiallyPeCoffFile(const std::string& filename);
+
 class PeCoff : public Object {
  public:
   explicit PeCoff(Memory* memory) : memory_(memory) {}

--- a/third_party/libunwindstack/tests/PeCoffTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffTest.cpp
@@ -237,4 +237,28 @@ TEST_F(PeCoff64Test, returns_correct_arch_for_64bit_pe_coff) {
   EXPECT_EQ(ARCH_X86_64, coff.arch());
 }
 
+TEST(PeCoffTest, detects_pe_coff_magic_value_for_given_memory) {
+  MemoryFake memory;
+  constexpr uint16_t kMsDosTwoPointZeroMagicValue = 0x5a4d;
+  memory.SetData16(0, kMsDosTwoPointZeroMagicValue);
+  EXPECT_TRUE(IsPotentiallyPeCoffFile(&memory));
+}
+
+TEST(PeCoffTest, rejects_incorrect_pe_coff_magic_value_for_given_memory) {
+  MemoryFake memory;
+  constexpr uint16_t kIncorrectMagicValue = 0x5a4e;
+  memory.SetData16(0, kIncorrectMagicValue);
+  EXPECT_FALSE(IsPotentiallyPeCoffFile(&memory));
+}
+
+TEST(PeCoffTest, detects_pe_coff_file_correctly) {
+  std::string file = android::base::GetExecutableDirectory() + "/tests/files/libtest.dll";
+  EXPECT_TRUE(IsPotentiallyPeCoffFile(file));
+}
+
+TEST(PeCoffTest, rejects_non_pe_coff_correctly) {
+  std::string file = android::base::GetExecutableDirectory() + "/tests/files/elf32.xz";
+  EXPECT_FALSE(IsPotentiallyPeCoffFile(file));
+}
+
 }  // namespace unwindstack


### PR DESCRIPTION
This is needed to distinguish between PE/COFF and ELF files during
initialization of object files when they are first encountered during
unwinding. The function doesn't have to (and can't) correctly predict
if an object file is really a PE/COFF (unless we'd fully read, parse,
and validate everything, which is not feasible), but there are later
safeguards that prevent incorrect handling when the file is not actually
a PE/COFF file. An important requirement is however that an ELF file is 
not incorrectly detected as a PE/COFF file.

Tested: Unit tests.
Bug: http://b/194768602