### PR TITLE
Remove std_dev field from ScopeStats

### DIFF
--- a/src/ClientData/CaptureDataTest.cpp
+++ b/src/ClientData/CaptureDataTest.cpp
@@ -101,7 +101,6 @@ template <std::size_t Size>
   stats.set_min_ns(*std::min_element(begin, end));
   stats.set_max_ns(*std::max_element(begin, end));
   stats.set_variance_ns(variance);
-  stats.set_std_dev_ns(static_cast<uint64_t>(std::sqrt(variance)));
 
   return stats;
 }
@@ -120,7 +119,7 @@ static void ExpectStatsEqual(const ScopeStats& actual, const ScopeStats& other) 
   EXPECT_EQ(actual.max_ns(), other.max_ns());
 
   EXPECT_NEAR(actual.variance_ns(), other.variance_ns(), 1.0);
-  EXPECT_NEAR(actual.std_dev_ns(), other.std_dev_ns(), 1.0);
+  EXPECT_NEAR(actual.ComputeStdDevNs(), other.ComputeStdDevNs(), 1.0);
 }
 
 TEST_F(CaptureDataTest, UpdateScopeStatsIsCorrect) {

--- a/src/ClientData/ScopeStats.cpp
+++ b/src/ClientData/ScopeStats.cpp
@@ -19,8 +19,6 @@ void ScopeStats::UpdateStats(uint64_t elapsed_nanos) {
   variance_ns_ = ((static_cast<double>(count_ - 1) * variance_ns_ +
                    (elapsed_nanos_double - new_avg) * (elapsed_nanos_double - old_avg)) /
                   static_cast<double>(count_));
-  // std_dev = sqrt(variance)
-  std_dev_ns_ = static_cast<uint64_t>(std::sqrt(variance_ns_));
 
   if (max_ns_ < elapsed_nanos) {
     max_ns_ = elapsed_nanos;

--- a/src/ClientData/include/ClientData/ScopeStats.h
+++ b/src/ClientData/include/ClientData/ScopeStats.h
@@ -6,6 +6,8 @@
 
 #include <stdint.h>
 
+#include <cmath>
+
 namespace orbit_client_data {
 
 // A simple class that keeps track of some basic statistics for a particular scope id (e.g. a
@@ -35,8 +37,10 @@ class ScopeStats {
   [[nodiscard]] double variance_ns() const { return variance_ns_; }
   void set_variance_ns(double variance_ns) { variance_ns_ = variance_ns; }
 
-  [[nodiscard]] uint64_t std_dev_ns() const { return std_dev_ns_; }
-  void set_std_dev_ns(uint64_t std_dev_ns) { std_dev_ns_ = std_dev_ns; }
+  [[nodiscard]] uint64_t ComputeStdDevNs() const {
+    // std_dev = sqrt(variance)
+    return static_cast<uint64_t>(std::sqrt(variance_ns()));
+  }
 
  private:
   uint64_t count_;
@@ -44,7 +48,6 @@ class ScopeStats {
   uint64_t min_ns_;
   uint64_t max_ns_;
   double variance_ns_;
-  uint64_t std_dev_ns_;
 };
 
 }  // namespace orbit_client_data

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -115,7 +115,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
     case kColumnTimeMax:
       return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.max_ns()));
     case kColumnStdDev:
-      return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.std_dev_ns()));
+      return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.ComputeStdDevNs()));
     case kColumnModule:
       return function.module_path();
     case kColumnAddress:
@@ -226,7 +226,7 @@ void LiveFunctionsDataView::DoSort() {
       sorter = ORBIT_STAT_SORT(max_ns());
       break;
     case kColumnStdDev:
-      sorter = ORBIT_STAT_SORT(std_dev_ns());
+      sorter = ORBIT_STAT_SORT(ComputeStdDevNs());
       break;
     case kColumnModule: {
       auto module_name = [](const orbit_client_data::FunctionInfo& function) {

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -201,7 +201,7 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
     stats.set_total_time_ns(kTotalTimeNs[i]);
     stats.set_min_ns(kMinNs[i]);
     stats.set_max_ns(kMaxNs[i]);
-    stats.set_std_dev_ns(kStdDevNs[i]);
+    stats.set_variance_ns(kStdDevNs[i] * kStdDevNs[i]);
     capture_data->AddScopeStats(kFunctionIds[i], std::move(stats));
   }
 
@@ -765,8 +765,8 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
     string_to_raw_value.insert_or_assign(entry[kColumnTimeMin], stats.min_ns());
     entry[kColumnTimeMax] = GetExpectedDisplayTime(stats.max_ns());
     string_to_raw_value.insert_or_assign(entry[kColumnTimeMax], stats.max_ns());
-    entry[kColumnStdDev] = GetExpectedDisplayTime(stats.std_dev_ns());
-    string_to_raw_value.insert_or_assign(entry[kColumnStdDev], stats.std_dev_ns());
+    entry[kColumnStdDev] = GetExpectedDisplayTime(stats.ComputeStdDevNs());
+    string_to_raw_value.insert_or_assign(entry[kColumnStdDev], stats.ComputeStdDevNs());
 
     view_entries.push_back(entry);
   }


### PR DESCRIPTION
Now the stadard deviation is computed on demand.

Test: Unit, Manual, Compile
Bug: http://b/227736548