### PR TITLE
Split Batcher with PrimitiveAssembler

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -203,6 +203,7 @@ target_sources(OrbitGlTests PRIVATE
                MultivariateTimeSeriesTest.cpp
                PageFaultsTrackTest.cpp
                PickingManagerTest.cpp
+               PrimitiveAssemblerTest.cpp
                ScopedStatusTest.cpp
                SimpleTimingsTest.cpp
                SliderTest.cpp

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -419,7 +419,7 @@ void CaptureWindow::Draw() {
   if (time_graph_ != nullptr) {
     uint64_t timegraph_current_mouse_time_ns =
         time_graph_->GetTickFromWorld(viewport_.ScreenToWorld(GetMouseScreenPos())[0]);
-    time_graph_->DrawAllElements(GetPrimitiveAssembler(), GetTextRenderer(), picking_mode_,
+    time_graph_->DrawAllElements(primitive_assembler_, GetTextRenderer(), picking_mode_,
                                  timegraph_current_mouse_time_ns);
   }
 
@@ -439,7 +439,7 @@ void CaptureWindow::Draw() {
   DrawScreenSpace();
 
   if (picking_mode_ == PickingMode::kNone) {
-    text_renderer_.RenderDebug(&GetPrimitiveAssembler());
+    text_renderer_.RenderDebug(&primitive_assembler_);
   }
 
   if (picking_mode_ == PickingMode::kNone) {
@@ -490,9 +490,9 @@ void CaptureWindow::DrawScreenSpace() {
   auto canvas_height = static_cast<float>(viewport_.GetScreenHeight());
 
   if (time_span > 0) {
-    slider_->Draw(GetPrimitiveAssembler(), picking_manager_.IsThisElementPicked(slider_.get()));
+    slider_->Draw(primitive_assembler_, picking_manager_.IsThisElementPicked(slider_.get()));
     if (vertical_slider_->IsVisible()) {
-      vertical_slider_->Draw(GetPrimitiveAssembler(),
+      vertical_slider_->Draw(primitive_assembler_,
                              picking_manager_.IsThisElementPicked(vertical_slider_.get()));
     }
   }

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "Batcher.h"
 #include "CaptureClient/AppInterface.h"
 #include "CaptureStats.h"
 #include "GlCanvas.h"
@@ -58,8 +59,6 @@ class CaptureWindow : public GlCanvas {
   void CreateTimeGraph(orbit_client_data::CaptureData* capture_data);
   void ClearTimeGraph() { time_graph_.reset(nullptr); }
 
-  orbit_gl::PrimitiveAssembler& GetBatcherById(BatcherId batcher_id);
-
  protected:
   void Draw() override;
   void UpdateChildrenPosAndSize();
@@ -91,6 +90,7 @@ class CaptureWindow : public GlCanvas {
   [[nodiscard]] virtual const char* GetHelpText() const;
   [[nodiscard]] virtual bool ShouldAutoZoom() const;
   void HandlePickedElement(PickingMode picking_mode, PickingId picking_id, int x, int y) override;
+  orbit_gl::Batcher& GetBatcherById(BatcherId batcher_id);
 
   std::unique_ptr<TimeGraph> time_graph_ = nullptr;
   bool draw_help_;

--- a/src/OrbitGl/CoreMath.h
+++ b/src/OrbitGl/CoreMath.h
@@ -22,5 +22,6 @@ using Vec4i = gte::Vector4<int>;
 using Color = gte::Vector4<unsigned char>;
 
 [[nodiscard]] inline Vec2 Vec3ToVec2(const Vec3& v) { return {v[0], v[1]}; }
+[[nodiscard]] inline Vec3 Vec2ToVec3(Vec2 vertex, float z = 0) { return {vertex[0], vertex[1], z}; }
 
 #endif  // ORBIT_GL_CORE_MATH_H_

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -64,7 +64,8 @@ const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 GlCanvas::GlCanvas()
     : AccessibleInterfaceProvider(),
       viewport_(0, 0),
-      ui_batcher_(BatcherId::kUi, &picking_manager_) {
+      ui_batcher_(BatcherId::kUi),
+      primitive_assembler_(&ui_batcher_, &picking_manager_) {
   // Note that `GlCanvas` is the bridge to OpenGl content, and `GlCanvas`'s parent needs special
   // handling for accessibility. Thus, we use `nullptr` here.
   text_renderer_.SetViewport(&viewport_);
@@ -254,7 +255,7 @@ void GlCanvas::Render(int width, int height) {
   }
 
   redraw_requested_ = false;
-  ui_batcher_.StartNewFrame();
+  ui_batcher_.ResetElements();
 
   PrepareGlState();
   PrepareGlViewport();

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -84,7 +84,10 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
 
   void EnableImGui();
   [[nodiscard]] ImGuiContext* GetImGuiContext() const { return imgui_context_; }
-  [[nodiscard]] orbit_gl::PrimitiveAssembler& GetPrimitiveAssembler() { return ui_batcher_; }
+  [[nodiscard]] orbit_gl::BatcherInterface& GetBatcher() { return ui_batcher_; }
+  [[nodiscard]] orbit_gl::PrimitiveAssembler& GetPrimitiveAssembler() {
+    return primitive_assembler_;
+  }
 
   [[nodiscard]] virtual bool IsRedrawNeeded() const;
   void RequestRedraw() { redraw_requested_ = true; }
@@ -162,6 +165,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
 
   // PrimitiveAssembler to draw elements in the UI.
   orbit_gl::OpenGlBatcher ui_batcher_;
+  orbit_gl::PrimitiveAssembler primitive_assembler_;
   std::vector<RenderCallback> render_callbacks_;
 
  private:

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -84,10 +84,6 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
 
   void EnableImGui();
   [[nodiscard]] ImGuiContext* GetImGuiContext() const { return imgui_context_; }
-  [[nodiscard]] orbit_gl::BatcherInterface& GetBatcher() { return ui_batcher_; }
-  [[nodiscard]] orbit_gl::PrimitiveAssembler& GetPrimitiveAssembler() {
-    return primitive_assembler_;
-  }
 
   [[nodiscard]] virtual bool IsRedrawNeeded() const;
   void RequestRedraw() { redraw_requested_ = true; }

--- a/src/OrbitGl/OpenGlBatcher.h
+++ b/src/OrbitGl/OpenGlBatcher.h
@@ -5,13 +5,12 @@
 #ifndef ORBIT_GL_OPEN_GL_BATCHER_H_
 #define ORBIT_GL_OPEN_GL_BATCHER_H_
 
-#include <PrimitiveAssembler.h>
-
 #include <array>
 #include <memory>
 #include <unordered_map>
 #include <vector>
 
+#include "Batcher.h"
 #include "Containers/BlockChain.h"
 #include "PickingManager.h"
 
@@ -75,29 +74,32 @@ struct PrimitiveBuffers {
 // Implements internal methods to collects primitives to be rendered at a later point in time.
 //
 // NOTE: The OpenGlBatcher assumes x/y coordinates are in pixels and will automatically round those
-// down to the next integer in all PrimitiveAssembler::AddXXX methods. This fixes the issue of
-// primitives "jumping" around when their coordinates are changed slightly.
-class OpenGlBatcher : public PrimitiveAssembler {
+// down to the next integer in all Batcher::AddXXX methods. This fixes the issue of primitives
+// "jumping" around when their coordinates are changed slightly.
+class OpenGlBatcher : public Batcher {
  public:
-  explicit OpenGlBatcher(BatcherId batcher_id, PickingManager* picking_manager = nullptr)
-      : PrimitiveAssembler(batcher_id, picking_manager) {}
+  explicit OpenGlBatcher(BatcherId batcher_id) : Batcher(batcher_id) {}
+
+  void ResetElements() override;
+  void AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
+               std::unique_ptr<PickingUserData> user_data = nullptr) override;
+  void AddBox(const Tetragon& box, const std::array<Color, 4>& colors, const Color& picking_color,
+              std::unique_ptr<PickingUserData> user_data = nullptr) override;
+  void AddTriangle(const Triangle& triangle, const std::array<Color, 3>& colors,
+                   const Color& picking_color,
+                   std::unique_ptr<PickingUserData> user_data = nullptr) override;
+
+  [[nodiscard]] uint32_t GetNumElements() const override { return user_data_.size(); }
   [[nodiscard]] std::vector<float> GetLayers() const override;
   void DrawLayer(float layer, bool picking) const override;
 
+  [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const override;
+
  protected:
   std::unordered_map<float, orbit_gl_internal::PrimitiveBuffers> primitive_buffers_by_layer_;
+  std::vector<std::unique_ptr<PickingUserData>> user_data_;
 
  private:
-  void ResetElements() override;
-  void AddLineInternal(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
-                       std::unique_ptr<PickingUserData> user_data) override;
-  void AddBoxInternal(const Tetragon& box, const std::array<Color, 4>& colors,
-                      const Color& picking_color,
-                      std::unique_ptr<PickingUserData> user_data) override;
-  void AddTriangleInternal(const Triangle& triangle, const std::array<Color, 3>& colors,
-                           const Color& picking_color,
-                           std::unique_ptr<PickingUserData> user_data) override;
-
   void DrawLineBuffer(float layer, bool picking) const;
   void DrawBoxBuffer(float layer, bool picking) const;
   void DrawTriangleBuffer(float layer, bool picking) const;

--- a/src/OrbitGl/OpenGlBatcher.h
+++ b/src/OrbitGl/OpenGlBatcher.h
@@ -12,7 +12,6 @@
 
 #include "Batcher.h"
 #include "Containers/BlockChain.h"
-#include "PickingManager.h"
 
 namespace orbit_gl {
 

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -14,18 +14,19 @@ namespace orbit_gl {
 
 void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                                  std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingId::ToColor(PickingType::kLine, user_data_.size(), batcher_id_);
+  Color picking_color =
+      PickingId::ToColor(PickingType::kLine, batcher_->GetNumElements(), GetBatcherId());
 
-  AddLineInternal(from, to, z, color, picking_color, std::move(user_data));
+  batcher_->AddLine(from, to, z, color, picking_color, std::move(user_data));
 }
 
 void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                                  std::shared_ptr<Pickable> pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
-  Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
+  Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());
 
-  AddLineInternal(from, to, z, color, picking_color, nullptr);
+  batcher_->AddLine(from, to, z, color, picking_color, nullptr);
 }
 
 void PrimitiveAssembler::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
@@ -37,15 +38,16 @@ void PrimitiveAssembler::AddVerticalLine(Vec2 pos, float size, float z, const Co
                                          std::shared_ptr<Pickable> pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
-  Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
+  Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());
 
-  AddLineInternal(pos, pos + Vec2(0, size), z, color, picking_color, nullptr);
+  batcher_->AddLine(pos, pos + Vec2(0, size), z, color, picking_color, nullptr);
 }
 
 void PrimitiveAssembler::AddBox(const Tetragon& box, const std::array<Color, 4>& colors,
                                 std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingId::ToColor(PickingType::kBox, user_data_.size(), batcher_id_);
-  AddBoxInternal(box, colors, picking_color, std::move(user_data));
+  Color picking_color =
+      PickingId::ToColor(PickingType::kBox, batcher_->GetNumElements(), GetBatcherId());
+  batcher_->AddBox(box, colors, picking_color, std::move(user_data));
 }
 
 void PrimitiveAssembler::AddBox(const Tetragon& box, const Color& color,
@@ -59,11 +61,11 @@ void PrimitiveAssembler::AddBox(const Tetragon& box, const Color& color,
                                 std::shared_ptr<Pickable> pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
-  Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
+  Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());
   std::array<Color, 4> colors;
   colors.fill(color);
 
-  AddBoxInternal(box, colors, picking_color, nullptr);
+  batcher_->AddBox(box, colors, picking_color, nullptr);
 }
 
 void PrimitiveAssembler::AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color) {
@@ -175,14 +177,15 @@ void PrimitiveAssembler::AddShadedBox(Vec2 pos, Vec2 size, float z, const Color&
                                       ShadingDirection shading_direction) {
   std::array<Color, 4> colors;
   GetBoxGradientColors(color, &colors, shading_direction);
-  Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
+  Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());
   Tetragon box = MakeBox(pos, size, z);
-  AddBoxInternal(box, colors, picking_color, nullptr);
+  batcher_->AddBox(box, colors, picking_color, nullptr);
 }
 
 void PrimitiveAssembler::AddTriangle(const Triangle& triangle, const Color& color,
                                      std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingId::ToColor(PickingType::kTriangle, user_data_.size(), batcher_id_);
+  Color picking_color =
+      PickingId::ToColor(PickingType::kTriangle, batcher_->GetNumElements(), GetBatcherId());
 
   AddTriangle(triangle, color, picking_color, std::move(user_data));
 }
@@ -191,7 +194,7 @@ void PrimitiveAssembler::AddTriangle(const Triangle& triangle, const Color& colo
                                      std::shared_ptr<Pickable> pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
-  Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
+  Color picking_color = GetPickingManager()->GetPickableColor(pickable, GetBatcherId());
 
   AddTriangle(triangle, color, picking_color, nullptr);
 }
@@ -201,7 +204,7 @@ void PrimitiveAssembler::AddTriangle(const Triangle& triangle, const Color& colo
                                      std::unique_ptr<PickingUserData> user_data) {
   std::array<Color, 3> colors;
   colors.fill(color);
-  AddTriangleInternal(triangle, colors, picking_color, std::move(user_data));
+  batcher_->AddTriangle(triangle, colors, picking_color, std::move(user_data));
 }
 
 // Draw a shaded trapezium with two sides parallel to the x-axis or y-axis.
@@ -210,14 +213,15 @@ void PrimitiveAssembler::AddShadedTrapezium(const Tetragon& trapezium, const Col
                                             ShadingDirection shading_direction) {
   std::array<Color, 4> colors;  // top_left, bottom_left, bottom_right, top_right.
   GetBoxGradientColors(color, &colors, shading_direction);
-  Color picking_color = PickingId::ToColor(PickingType::kTriangle, user_data_.size(), batcher_id_);
+  Color picking_color =
+      PickingId::ToColor(PickingType::kTriangle, batcher_->GetNumElements(), GetBatcherId());
   Triangle triangle_1{trapezium.vertices[0], trapezium.vertices[3], trapezium.vertices[1]};
   std::array<Color, 3> colors_1{colors[0], colors[1], colors[2]};
-  AddTriangleInternal(triangle_1, colors_1, picking_color,
-                      std::make_unique<PickingUserData>(*user_data));
+  batcher_->AddTriangle(triangle_1, colors_1, picking_color,
+                        std::make_unique<PickingUserData>(*user_data));
   Triangle triangle_2{trapezium.vertices[3], trapezium.vertices[2], trapezium.vertices[1]};
   std::array<Color, 3> colors_2{colors[1], colors[2], colors[3]};
-  AddTriangleInternal(triangle_2, colors_2, picking_color, std::move(user_data));
+  batcher_->AddTriangle(triangle_2, colors_2, picking_color, std::move(user_data));
 }
 
 void PrimitiveAssembler::AddCircle(const Vec2& position, float radius, float z, Color color) {
@@ -226,13 +230,11 @@ void PrimitiveAssembler::AddCircle(const Vec2& position, float radius, float z, 
     circle_points_scaled_by_radius.emplace_back(radius * point);
   }
 
-  Vec3 final_position = translations_.TranslateAndFloorVertex(Vec3(position[0], position[1], z));
-
-  Vec3 prev_point(final_position[0], final_position[1] - radius, z);
-  Vec3 point_0 = final_position;
+  Vec3 prev_point(position[0], position[1] - radius, z);
+  Vec3 point_0 = Vec3(position[0], position[1], z);
   for (size_t i = 0; i < circle_points_scaled_by_radius.size(); ++i) {
-    Vec3 new_point(final_position[0] + circle_points_scaled_by_radius[i][0],
-                   final_position[1] - circle_points_scaled_by_radius[i][1], z);
+    Vec3 new_point(position[0] + circle_points_scaled_by_radius[i][0],
+                   position[1] - circle_points_scaled_by_radius[i][1], z);
     Vec3 point_1 = Vec3(prev_point[0], prev_point[1], z);
     Vec3 point_2 = Vec3(new_point[0], new_point[1], z);
     Triangle triangle(point_0, point_1, point_2);
@@ -252,42 +254,6 @@ void PrimitiveAssembler::AddTetragonBorder(const Tetragon& tetragon, const Color
           std::make_unique<PickingUserData>(*user_data));
   AddLine(Vec3ToVec2(tetragon.vertices[3]), Vec3ToVec2(tetragon.vertices[0]), z, color,
           std::move(user_data));
-}
-
-const PickingUserData* PrimitiveAssembler::GetUserData(PickingId id) const {
-  ORBIT_CHECK(id.element_id >= 0);
-  ORBIT_CHECK(id.batcher_id == batcher_id_);
-
-  switch (id.type) {
-    case PickingType::kInvalid:
-      return nullptr;
-    case PickingType::kBox:
-    case PickingType::kTriangle:
-    case PickingType::kLine:
-      ORBIT_CHECK(id.element_id < user_data_.size());
-      return user_data_[id.element_id].get();
-    case PickingType::kPickable:
-      return nullptr;
-    case PickingType::kCount:
-      ORBIT_UNREACHABLE();
-  }
-
-  ORBIT_UNREACHABLE();
-}
-
-PickingUserData* PrimitiveAssembler::GetUserData(PickingId id) {
-  return const_cast<PickingUserData*>(
-      static_cast<const PrimitiveAssembler*>(this)->GetUserData(id));
-}
-
-const orbit_client_protos::TimerInfo* PrimitiveAssembler::GetTimerInfo(PickingId id) const {
-  const PickingUserData* data = GetUserData(id);
-
-  if (data && data->timer_info_) {
-    return data->timer_info_;
-  }
-
-  return nullptr;
 }
 
 void PrimitiveAssembler::GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors,
@@ -325,15 +291,16 @@ void PrimitiveAssembler::GetBoxGradientColors(const Color& color, std::array<Col
   }
 }
 
-void PrimitiveAssembler::StartNewFrame() {
-  ORBIT_CHECK(translations_.IsEmpty());
-  ResetElements();
-}
+void PrimitiveAssembler::StartNewFrame() { batcher_->ResetElements(); }
 
-void PrimitiveAssembler::Draw(bool picking) const {
-  for (float layer : GetLayers()) {
-    DrawLayer(layer, picking);
+const orbit_client_protos::TimerInfo* PrimitiveAssembler::GetTimerInfo(PickingId id) const {
+  const PickingUserData* data = GetUserData(id);
+
+  if (data && data->timer_info_) {
+    return data->timer_info_;
   }
+
+  return nullptr;
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -194,7 +194,7 @@ void PrimitiveAssembler::AddTriangle(const Triangle& triangle, const Color& colo
                                      std::shared_ptr<Pickable> pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
-  Color picking_color = GetPickingManager()->GetPickableColor(pickable, GetBatcherId());
+  Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());
 
   AddTriangle(triangle, color, picking_color, nullptr);
 }

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -38,8 +38,10 @@ AddInternalMethods, ResetElements(), GetLayers() and DrawLayers().
 **/
 class PrimitiveAssembler {
  public:
-  explicit PrimitiveAssembler(Batcher* batcher, PickingManager* picking_manager = nullptr)
+  explicit PrimitiveAssembler(Batcher* batcher, PickingManager* picking_manager)
       : batcher_(batcher), picking_manager_(picking_manager) {
+    ORBIT_CHECK(batcher_ != nullptr);
+    ORBIT_CHECK(picking_manager_ != nullptr);
     constexpr int32_t kSteps = 22;
     const float angle = (kPiFloat * 2.f) / kSteps;
     for (int32_t i = 1; i <= kSteps; i++) {

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -38,10 +38,10 @@ AddInternalMethods, ResetElements(), GetLayers() and DrawLayers().
 **/
 class PrimitiveAssembler {
  public:
-  explicit PrimitiveAssembler(Batcher* batcher, PickingManager* picking_manager)
+  explicit PrimitiveAssembler(Batcher* batcher, PickingManager* picking_manager = nullptr)
       : batcher_(batcher), picking_manager_(picking_manager) {
     ORBIT_CHECK(batcher_ != nullptr);
-    ORBIT_CHECK(picking_manager_ != nullptr);
+
     constexpr int32_t kSteps = 22;
     const float angle = (kPiFloat * 2.f) / kSteps;
     for (int32_t i = 1; i <= kSteps; i++) {

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "MockBatcher.h"
+#include "PickingManagerTest.h"
+#include "PrimitiveAssembler.h"
+
+namespace orbit_gl {
+
+// TODO(http://b/228063067): Test all methods in Primitive Assembler
+class PrimitiveAssemblerTester : public PrimitiveAssembler {
+ public:
+  PrimitiveAssemblerTester(PickingManager* picking_manager = nullptr)
+      : PrimitiveAssembler(&mock_batcher_, picking_manager) {}
+  void ExpectAdded(uint32_t line_count, uint32_t triangle_count, uint32_t box_count) {
+    EXPECT_EQ(mock_batcher_.GetNumLines(), line_count);
+    EXPECT_EQ(mock_batcher_.GetNumTriangles(), triangle_count);
+    EXPECT_EQ(mock_batcher_.GetNumBoxes(), box_count);
+  }
+
+ private:
+  MockBatcher mock_batcher_;
+};
+
+TEST(PrimitiveAssembler, NullPickingManager) {
+  PrimitiveAssemblerTester primitive_assembler_tester;
+  std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
+  EXPECT_DEATH(primitive_assembler_tester.AddLine(Vec2(0, 0), Vec2(1, 0), 0,
+                                                  Color(255, 255, 255, 255), pickable),
+               "nullptr");
+}
+
+static Vec3 Vec2ToVec3(Vec2 vertex, float z = 0) { return {vertex[0], vertex[1], z}; }
+
+TEST(PrimitiveAssembler, BasicAdditions) {
+  PickingManager pm;
+  PrimitiveAssemblerTester primitive_assembler_tester(&pm);
+  std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
+
+  Color kFakeColor{42, 42, 128, 43};
+  Vec2 kTopLeft{0, 0};
+  Vec2 kTopRight{5, 0};
+  Vec2 kBottomRight{5, 5};
+  Vec2 kBottomLeft{0, 5};
+
+  // Lines
+  float kLineSize = 5.;
+  primitive_assembler_tester.AddLine(kTopLeft, kBottomLeft, 0, kFakeColor);
+  primitive_assembler_tester.AddLine(kTopLeft, kBottomLeft, 0, kFakeColor, pickable);
+  primitive_assembler_tester.AddVerticalLine(kTopLeft, kLineSize, 0, kFakeColor);
+  primitive_assembler_tester.AddVerticalLine(kTopLeft, kLineSize, 0, kFakeColor, pickable);
+
+  primitive_assembler_tester.ExpectAdded(4, 0, 0);
+  // Triangles
+  Triangle kFakeTriangle{Vec2ToVec3(kTopLeft), Vec2ToVec3(kTopRight), Vec2ToVec3(kBottomRight)};
+  primitive_assembler_tester.AddTriangle(kFakeTriangle, kFakeColor);
+  primitive_assembler_tester.AddTriangle(kFakeTriangle, kFakeColor, pickable);
+  primitive_assembler_tester.ExpectAdded(4, 2, 0);
+
+  // Boxes
+  Tetragon kFakeBox{std::array<Vec3, 4>{Vec2ToVec3(kTopLeft), Vec2ToVec3(kTopRight),
+                                        Vec2ToVec3(kBottomRight), Vec2ToVec3(kBottomLeft)}};
+  primitive_assembler_tester.AddBox(kFakeBox, {kFakeColor, kFakeColor, kFakeColor, kFakeColor});
+  primitive_assembler_tester.AddBox(kFakeBox, kFakeColor);
+  primitive_assembler_tester.AddBox(kFakeBox, kFakeColor, pickable);
+  primitive_assembler_tester.ExpectAdded(4, 2, 3);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -150,7 +150,7 @@ static std::string GetThreadStateDescription(ThreadStateSlice::ThreadState state
 
 std::string ThreadStateBar::GetThreadStateSliceTooltip(PrimitiveAssembler& primitive_assembler,
                                                        PickingId id) const {
-  PickingUserData* user_data = primitive_assembler.GetUserData(id);
+  const PickingUserData* user_data = primitive_assembler.GetUserData(id);
   if (user_data == nullptr || user_data->custom_data_ == nullptr) {
     return "";
   }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -59,7 +59,8 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
     // parent in accessible_parent_ which doesn't need to be a CaptureViewElement.
     : orbit_gl::CaptureViewElement(nullptr, viewport, &layout_),
       accessible_parent_{parent},
-      primitive_assembler_(BatcherId::kTimeGraph),
+      batcher_(BatcherId::kTimeGraph),
+      primitive_assembler_(&batcher_, picking_manager),
       thread_track_data_provider_(capture_data->GetThreadTrackDataProvider()),
       capture_data_{capture_data},
       app_{app} {
@@ -67,7 +68,6 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
     manual_instrumentation_manager_ = app->GetManualInstrumentationManager();
   }
   text_renderer_static_.SetViewport(viewport);
-  primitive_assembler_.SetPickingManager(picking_manager);
 
   const orbit_client_data::ModuleManager* module_manager =
       app != nullptr ? app->GetModuleManager() : nullptr;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -37,8 +37,9 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   [[nodiscard]] float GetHeight() const override;
 
-  void DrawAllElements(orbit_gl::PrimitiveAssembler& batcher, TextRenderer& text_renderer,
-                       PickingMode& picking_mode, uint64_t current_mouse_time_ns);
+  void DrawAllElements(orbit_gl::PrimitiveAssembler& primitive_assembler,
+                       TextRenderer& text_renderer, PickingMode& picking_mode,
+                       uint64_t current_mouse_time_ns);
   void DrawText(float layer);
 
   void RequestUpdate() override;
@@ -124,6 +125,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] orbit_gl::PrimitiveAssembler& GetPrimitiveAssembler() {
     return primitive_assembler_;
   }
+  [[nodiscard]] orbit_gl::Batcher& GetBatcher() { return batcher_; }
 
   void UpdateHorizontalScroll(float ratio);
   [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
@@ -190,7 +192,8 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   bool update_primitives_requested_ = false;
 
-  orbit_gl::OpenGlBatcher primitive_assembler_;
+  orbit_gl::OpenGlBatcher batcher_;
+  orbit_gl::PrimitiveAssembler primitive_assembler_;
 
   std::unique_ptr<orbit_gl::TrackContainer> track_container_;
   std::unique_ptr<orbit_gl::TimelineUi> timeline_ui_;


### PR DESCRIPTION
Split Batcher with PrimitiveAssembler

In this PR we are finally splitting Batcher with PrimitiveAssembler (step 2 in http://b/225173189).

This is a big PR that const in several little things. I wanted to make this in a few small steps (https://github.com/google/orbit/pull/3517) but turned to be that it was difficult to understand the big picture and we agreed with Henning in making everything in one PR.

TimeGraph owns now a PrimitiveAssembler and a Batcher. The first is passed to CaptureViewElements to draw and the second is used by CaptureWindow to draw. CaptureWindow also owns another copy (at it was before). This is a bit confused (actually one batcher is used to UpdatePrimitives(timers) and the other for the rest of the elements), but it was like that before and I'm not aiming to solve this.

OpenGlBatcher is adapted to Batcher/BatcherInterface.

PrimitiveAssembler is simplified and now depends on having a Batcher to perform additions. There is no more drawing logic in this class, ResetElements neither Translations.

Fixed an small issue in AddCircle (we were making double-translations)

BatcherTest
- Now is faking OpenGlBatcher and it will renamed in a following PR to OpenGlBatcherTest (http://b/228053356)
- Erased 2 tests (PickingElementsDrawing is fully replaced and improved in PrimitiveAssemblerTest and PickingPickables is part of http://b/228063067).

Test: Load a capture. Picking works as expected.