### PR TITLE
Expose "stack dump size" in capture options (devmode)

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -25,13 +25,6 @@ ABSL_FLAG(std::string, process_name, "",
 
 ABSL_FLAG(bool, enable_tutorials_feature, false, "Enable tutorials");
 
-// Max to pass to perf_event_open without getting an error is (1u << 16u) - 8,
-// because the kernel stores this in a short and because of alignment reasons.
-// But the size the kernel actually returns is smaller and we leave some extra room (see
-// `PerfEventOpen.cpp`).
-ABSL_FLAG(uint16_t, stack_dump_size, 65000,
-          "Number of bytes to copy from the stack per sample. Max: 65000");
-
 // TODO(kuebler): remove this once we have the validator complete
 ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
 

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -27,12 +27,6 @@ ABSL_DECLARE_FLAG(std::string, process_name);
 
 ABSL_DECLARE_FLAG(bool, enable_tutorials_feature);
 
-// Max to pass to perf_event_open without getting an error is (1u << 16u) - 8,
-// because the kernel stores this in a short and because of alignment reasons.
-// But the size the kernel actually returns is smaller and we leave some extra room (see
-// `PerfEventOpen.cpp`).
-ABSL_DECLARE_FLAG(uint16_t, stack_dump_size);
-
 // TODO(b/160549506): Remove this flag once it can be specified in the ui.
 ABSL_DECLARE_FLAG(bool, frame_pointer_unwinding);
 

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -39,7 +39,8 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->maxCopyRawStackSizeLineEdit, &QLineEdit::editingFinished,
                    ui_->maxCopyRawStackSizeLineEdit, [this]() {
                      if (ui_->maxCopyRawStackSizeLineEdit->text().isEmpty()) {
-                       ui_->maxCopyRawStackSizeLineEdit->setText(QString::number(512));
+                       ui_->maxCopyRawStackSizeLineEdit->setText(
+                           QString::number(kMaxCopyRawStackSizeDefaultValue));
                      }
                    });
 
@@ -55,7 +56,7 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
     // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
     ui_->samplingCheckBox->hide();
     ui_->unwindingMethodWidget->hide();
-    ui_->maxCopyRawStackSizeLineEdit->hide();
+    ui_->maxCopyRawStackSizeWidget->hide();
     ui_->schedulerCheckBox->hide();
     ui_->gpuSubmissionsCheckBox->hide();
     ui_->introspectionCheckBox->hide();
@@ -70,8 +71,8 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
 
   ui_->maxCopyRawStackSizeLabel->setToolTip(QString::fromStdString(
       "To improve performance, we don't require to preserve the frame pointer register on leaf\n"
-      "functions (-momit-leaf-frame-pointer). In order to fix callstacks from samples falling\n"
-      "inside a leaf function, we need to copy a portion of the raw stack and Dwarf-unwind the\n"
+      "functions (-momit-leaf-frame-pointer). In order to recover the frame corresponding to the\n"
+      "caller of a leaf function, we need to copy a portion of the raw stack and DWARF-unwind the\n"
       "first frame. Specify how much data Orbit should copy. A larger value reduces the number of\n"
       "unwind errors, but increases the performance overhead of sampling."));
 
@@ -190,7 +191,7 @@ uint64_t CaptureOptionsDialog::GetMaxLocalMarkerDepthPerCommandBuffer() const {
 
 void CaptureOptionsDialog::ResetLocalMarkerDepthLineEdit() {
   if (ui_->localMarkerDepthLineEdit->text().isEmpty()) {
-    ui_->localMarkerDepthLineEdit->setText(QString::number(0));
+    ui_->localMarkerDepthLineEdit->setText(QString::number(kLocalMarkerDepthDefaultValue));
   }
 }
 
@@ -208,8 +209,6 @@ void CaptureOptionsDialog::SetMemorySamplingPeriodMs(uint64_t memory_sampling_pe
 
 void CaptureOptionsDialog::ResetMemorySamplingPeriodMsLineEditWhenEmpty() {
   if (!ui_->memorySamplingPeriodMsLineEdit->text().isEmpty()) return;
-
-  constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 10;
   ui_->memorySamplingPeriodMsLineEdit->setText(
       QString::number(kMemorySamplingPeriodMsDefaultValue));
 }
@@ -229,8 +228,6 @@ void CaptureOptionsDialog::SetMemoryWarningThresholdKb(uint64_t memory_warning_t
 
 void CaptureOptionsDialog::ResetMemoryWarningThresholdKbLineEditWhenEmpty() {
   if (!ui_->memoryWarningThresholdKbLineEdit->text().isEmpty()) return;
-
-  constexpr uint64_t kMemoryWarningThresholdKbDefaultValue = 1024 * 1024 * 8;
   ui_->memoryWarningThresholdKbLineEdit->setText(
       QString::number(kMemoryWarningThresholdKbDefaultValue));
 }

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -81,6 +81,15 @@ class CaptureOptionsDialog : public QDialog {
   void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb);
   [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const;
 
+  static constexpr double kCallstackSamplingPeriodMsDefaultValue = 1.0;
+  static constexpr orbit_grpc_protos::CaptureOptions::UnwindingMethod
+      kCallstackUnwindingMethodDefaultValue = orbit_grpc_protos::CaptureOptions::kDwarf;
+  static constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 10;
+  static constexpr uint64_t kMemoryWarningThresholdKbDefaultValue = 1024 * 1024 * 8;  // 8Gb
+  static constexpr orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod
+      kDynamicInstrumentationMethodDefaultValue = orbit_grpc_protos::CaptureOptions::kKernelUprobes;
+  static constexpr uint64_t kLocalMarkerDepthDefaultValue = 0;
+
   // Max to pass to perf_event_open without getting an error is (1u << 16u) - 8,
   // because the kernel stores this in a short and because of alignment reasons.
   // But the size the kernel actually returns is smaller and we leave some extra room (see

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -21,15 +21,15 @@ namespace orbit_qt {
 class UInt64Validator : public QValidator {
  public:
   explicit UInt64Validator(QObject* parent = nullptr) : QValidator(parent) {}
-  explicit UInt64Validator(uint64_t minimum, QObject* parent = nullptr)
-      : QValidator(parent), minimum_(minimum) {}
+  explicit UInt64Validator(uint64_t minimum, uint64_t maximum, QObject* parent = nullptr)
+      : QValidator(parent), minimum_(minimum), maximum_(maximum) {}
   QValidator::State validate(QString& input, int& /*pos*/) const override {
     if (input.isEmpty()) {
       return QValidator::State::Acceptable;
     }
     bool valid = false;
     uint64_t input_value = input.toULongLong(&valid);
-    if (valid && input_value >= minimum_) {
+    if (valid && input_value >= minimum_ && input_value <= maximum_) {
       return QValidator::State::Acceptable;
     }
     return QValidator::State::Invalid;
@@ -37,6 +37,7 @@ class UInt64Validator : public QValidator {
 
  private:
   uint64_t minimum_ = 0;
+  uint64_t maximum_ = std::numeric_limits<uint64_t>::max();
 };
 
 class CaptureOptionsDialog : public QDialog {
@@ -51,6 +52,8 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] double GetSamplingPeriodMs() const;
   void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
   [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod GetUnwindingMethod() const;
+  void SetMaxCopyRawStackSize(uint16_t stack_dump_size);
+  [[nodiscard]] uint16_t GetMaxCopyRawStackSize() const;
   void SetCollectSchedulerInfo(bool collect_scheduler_info);
   [[nodiscard]] bool GetCollectSchedulerInfo() const;
   void SetCollectThreadStates(bool collect_thread_state);
@@ -77,6 +80,13 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] uint64_t GetMemorySamplingPeriodMs() const;
   void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb);
   [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const;
+
+  // Max to pass to perf_event_open without getting an error is (1u << 16u) - 8,
+  // because the kernel stores this in a short and because of alignment reasons.
+  // But the size the kernel actually returns is smaller and we leave some extra room (see
+  // `PerfEventOpen.cpp`).
+  static constexpr uint16_t kMaxCopyRawStackSizeMaxValue = 65000;
+  static constexpr uint16_t kMaxCopyRawStackSizeDefaultValue = 512;
 
  public slots:
   void ResetLocalMarkerDepthLineEdit();

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -152,14 +152,14 @@
               <string/>
              </property>
              <property name="text">
-              <string>Maximal raw stack size to copy to (Bytes):</string>
+              <string>[Frame pointers only] Max raw stack size to copy (Bytes):</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QLineEdit" name="maxCopyRawStackSizeLineEdit">
              <property name="enabled">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
              <property name="maxLength">
               <number>5</number>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -132,6 +132,57 @@
          </widget>
         </item>
         <item>
+         <widget class="QWidget" name="maxCopyRawStackSizeWidget" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0,0">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="maxCopyRawStackSizeLabel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Maximal raw stack size to copy to (Bytes):</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="maxCopyRawStackSizeLineEdit">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="maxLength">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="maxCopyRawStackSizeSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>80</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="schedulerCheckBox">
           <property name="text">
            <string>Collect scheduler information</string>
@@ -199,14 +250,14 @@
            </item>
            <item>
             <widget class="QComboBox" name="dynamicInstrumentationMethodComboBox">
-             <property name="accessibleName">
-              <string>DynamicInstrumentationMethodComboBox</string>
-             </property>
              <property name="minimumSize">
               <size>
                <width>170</width>
                <height>0</height>
               </size>
+             </property>
+             <property name="accessibleName">
+              <string>DynamicInstrumentationMethodComboBox</string>
              </property>
             </widget>
            </item>
@@ -531,5 +582,6 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
   <slot>ResetLocalMarkerDepthLineEdit()</slot>
   <slot>ResetMemorySamplingPeriodMsLineEditWhenEmpty()</slot>
   <slot>ResetMemoryWarningThresholdKbLineEditWhenEmpty()</slot>
+  <slot>EnableOrDisableMaxCopyRawStackSizeLineEdit(int)</slot>
  </slots>
 </ui>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1070,7 +1070,7 @@ void OrbitMainWindow::on_actionToggle_Capture_triggered() { app_->ToggleCapture(
 const QString OrbitMainWindow::kEnableCallstackSamplingSettingKey{"EnableCallstackSampling"};
 const QString OrbitMainWindow::kCallstackSamplingPeriodMsSettingKey{"CallstackSamplingPeriodMs"};
 const QString OrbitMainWindow::kCallstackUnwindingMethodSettingKey{"CallstackUnwindingMethod"};
-const QString OrbitMainWindow::kMaxCopyRawStackSizeSettingsKey{"MaxCopyRawStackSize"};
+const QString OrbitMainWindow::kMaxCopyRawStackSizeSettingKey{"MaxCopyRawStackSize"};
 const QString OrbitMainWindow::kCollectSchedulerInfoSettingKey{"CollectSchedulerInfo"};
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
 const QString OrbitMainWindow::kTraceGpuSubmissionsSettingKey{"TraceGpuSubmissions"};
@@ -1129,7 +1129,7 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
     if (unwinding_method == CaptureOptions::kFramePointers) {
       uint16_t stack_dump_size = static_cast<uint16_t>(
           settings
-              .value(kMaxCopyRawStackSizeSettingsKey,
+              .value(kMaxCopyRawStackSizeSettingKey,
                      orbit_qt::CaptureOptionsDialog::kMaxCopyRawStackSizeDefaultValue)
               .toUInt());
       app_->SetStackDumpSize(stack_dump_size);
@@ -1211,7 +1211,7 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   dialog.SetUnwindingMethod(unwinding_method);
   dialog.SetMaxCopyRawStackSize(static_cast<uint16_t>(
       settings
-          .value(kMaxCopyRawStackSizeSettingsKey,
+          .value(kMaxCopyRawStackSizeSettingKey,
                  orbit_qt::CaptureOptionsDialog::kMaxCopyRawStackSizeDefaultValue)
           .toUInt()));
   dialog.SetCollectSchedulerInfo(settings.value(kCollectSchedulerInfoSettingKey, true).toBool());
@@ -1261,7 +1261,7 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   settings.setValue(kCallstackSamplingPeriodMsSettingKey, dialog.GetSamplingPeriodMs());
   settings.setValue(kCallstackUnwindingMethodSettingKey,
                     static_cast<int>(dialog.GetUnwindingMethod()));
-  settings.setValue(kMaxCopyRawStackSizeSettingsKey,
+  settings.setValue(kMaxCopyRawStackSizeSettingKey,
                     static_cast<int>(dialog.GetMaxCopyRawStackSize()));
   settings.setValue(kCollectSchedulerInfoSettingKey, dialog.GetCollectSchedulerInfo());
   settings.setValue(kCollectThreadStatesSettingKey, dialog.GetCollectThreadStates());

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -199,6 +199,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kEnableCallstackSamplingSettingKey;
   static const QString kCallstackSamplingPeriodMsSettingKey;
   static const QString kCallstackUnwindingMethodSettingKey;
+  static const QString kMaxCopyRawStackSizeKey;
   static const QString kCollectSchedulerInfoSettingKey;
   static const QString kCollectThreadStatesSettingKey;
   static const QString kTraceGpuSubmissionsSettingKey;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -199,7 +199,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kEnableCallstackSamplingSettingKey;
   static const QString kCallstackSamplingPeriodMsSettingKey;
   static const QString kCallstackUnwindingMethodSettingKey;
-  static const QString kMaxCopyRawStackSizeSettingsKey;
+  static const QString kMaxCopyRawStackSizeSettingKey;
   static const QString kCollectSchedulerInfoSettingKey;
   static const QString kCollectThreadStatesSettingKey;
   static const QString kTraceGpuSubmissionsSettingKey;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -199,7 +199,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kEnableCallstackSamplingSettingKey;
   static const QString kCallstackSamplingPeriodMsSettingKey;
   static const QString kCallstackUnwindingMethodSettingKey;
-  static const QString kMaxCopyRawStackSizeKey;
+  static const QString kMaxCopyRawStackSizeSettingsKey;
   static const QString kCollectSchedulerInfoSettingKey;
   static const QString kCollectThreadStatesSettingKey;
   static const QString kTraceGpuSubmissionsSettingKey;


### PR DESCRIPTION
For frame pointer unwinding, we require to copy a small
portion of the stack to fix leaf functions. It is essential
for performance that this value is small. However, sometimes
the default value is too small, and the unwinding errors are
too many.

In those cases, we want to be able to adjust the size of the stack
to copy.

This change exposes the option via the capture option dialogue
(in devmode). For now, we only allow this for frame pointer
unwinding. The maximal value allowed to use is 65000, while the
default value is 512.

Note, in the Dwarf case, we will remain using the current default
of 65000.
Further note, we are now not anymore able to set the value for
Dwarf. However, this is fine, as the specified value is always
an upper bound. If the actual stack is smaller, only the actual
size will be copied. For Dwarf, we will always require the complete
stack.

This also removes the flag to specify the max stack size to copy.

http://screenshot/35CX69b2MeUbmqA
http://screenshot/5PdoM6JaGa3tk4W

Bug: http://b/228187977
Test: Manual test capture options ui with different sampling modes
      and values for the text field. Take captures with different
      unwinding methods and max stack dump sizes; verify unwinding
      errors.