### PR TITLE
GetLastErrorAsErrorMessage

### DIFF
--- a/src/ObjectUtils/PdbUtilsDia.cpp
+++ b/src/ObjectUtils/PdbUtilsDia.cpp
@@ -22,7 +22,7 @@ namespace {
 [[nodiscard]] ErrorMessageOr<std::string> GetSignedIntegerTypeFromSizeInBytes(IDiaSymbol* type) {
   ULONGLONG length;
   if (FAILED(type->get_length(&length))) {
-    return ErrorMessage(orbit_base::GetLastErrorAsString());
+    return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_length");
   }
 
   switch (length) {
@@ -42,8 +42,7 @@ namespace {
 [[nodiscard]] ErrorMessageOr<std::string> GetBaseTypeAsString(IDiaSymbol* type) {
   DWORD base_type;
   if (FAILED(type->get_baseType(&base_type))) {
-    return ErrorMessage(
-        absl::StrFormat("Error calling \"get_baseType\": %s", orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_baseType");
   }
 
   switch (base_type) {
@@ -69,8 +68,7 @@ namespace {
     {
       ULONGLONG length;
       if (FAILED(type->get_length(&length))) {
-        return ErrorMessage(absl::StrFormat("Error calling \"get_length\": %s",
-                                            orbit_base::GetLastErrorAsString()));
+        return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_length");
       }
 
       switch (length) {
@@ -137,8 +135,7 @@ namespace {
     IDiaSymbol* type, std::string_view parent_pointer_type_str) {
   CComPtr<IDiaSymbol> base_type = nullptr;
   if (FAILED(type->get_type(&base_type))) {
-    return ErrorMessage(
-        absl::StrFormat("Error calling \"get_type\": %s", orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_type");
   }
   if (base_type == nullptr) {
     return ErrorMessage("Unable to retrieve type symbol.");
@@ -155,8 +152,7 @@ namespace {
              is_ptr_to_member_function) {
     CComPtr<IDiaSymbol> class_parent = nullptr;
     if (FAILED(type->get_classParent(&class_parent))) {
-      return ErrorMessage(absl::StrFormat("Error calling \"get_classParent\": %s",
-                                          orbit_base::GetLastErrorAsString()));
+      return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_classParent");
     }
     if (class_parent == nullptr) {
       return ErrorMessage("Unable to retrieve class parent symbol.");
@@ -168,8 +164,7 @@ namespace {
              is_ptr_to_member_function) {
     CComPtr<IDiaSymbol> class_parent = nullptr;
     if (FAILED(type->get_classParent(&class_parent))) {
-      return ErrorMessage(absl::StrFormat("Error calling \"get_classParent\": %s",
-                                          orbit_base::GetLastErrorAsString()));
+      return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_classParent");
     }
     if (class_parent == nullptr) {
       return ErrorMessage("Unable to retrieve class parent symbol.");
@@ -196,14 +191,12 @@ namespace orbit_object_utils {
 ErrorMessageOr<std::string> PdbDiaParameterListAsString(IDiaSymbol* function_or_function_type) {
   DWORD tag;
   if (FAILED(function_or_function_type->get_symTag(&tag))) {
-    return ErrorMessage(
-        absl::StrFormat("Error calling \"get_symTag\": %s", orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_symTag");
   }
   if (tag == SymTagFunction) {
     CComPtr<IDiaSymbol> function_type = nullptr;
     if (FAILED(function_or_function_type->get_type(&function_type))) {
-      return ErrorMessage(
-          absl::StrFormat("Error calling \"get_type\": %s", orbit_base::GetLastErrorAsString()));
+      return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_type");
     }
     if (function_type == nullptr) {
       return ErrorMessage("Unable to retrieve type symbol.");
@@ -221,8 +214,7 @@ ErrorMessageOr<std::string> PdbDiaParameterListAsString(IDiaSymbol* function_or_
 
   CComPtr<IDiaEnumSymbols> parameter_enumeration = nullptr;
   if (FAILED(function_type->findChildren(SymTagNull, nullptr, nsNone, &parameter_enumeration))) {
-    return ErrorMessage(
-        absl::StrFormat("Error calling \"findChildren\": %s", orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::findChildren");
   }
   if (parameter_enumeration == nullptr) {
     return ErrorMessage("Unable to find child symbols.");
@@ -241,8 +233,7 @@ ErrorMessageOr<std::string> PdbDiaParameterListAsString(IDiaSymbol* function_or_
 
     CComPtr<IDiaSymbol> parameter_type = nullptr;
     if (FAILED(parameter->get_type(&parameter_type))) {
-      return ErrorMessage(
-          absl::StrFormat("Error calling \"get_type\": %s", orbit_base::GetLastErrorAsString()));
+      return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_type");
     }
     if (parameter_type == nullptr) {
       return ErrorMessage("Unable to retrieve type symbol.");
@@ -290,8 +281,7 @@ ErrorMessageOr<std::string> PdbDiaTypeAsString(IDiaSymbol* type,
       // We could e.g. also print the size of the array if known.
       CComPtr<IDiaSymbol> base_type = nullptr;
       if (FAILED(type->get_type(&base_type))) {
-        return ErrorMessage(
-            absl::StrFormat("Error calling \"get_type\": %s", orbit_base::GetLastErrorAsString()));
+        return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_type");
       }
       if (base_type == nullptr) {
         return ErrorMessage("Unable to retrieve type symbol.");
@@ -311,8 +301,7 @@ ErrorMessageOr<std::string> PdbDiaTypeAsString(IDiaSymbol* type,
     case SymTagFunctionType: {
       CComPtr<IDiaSymbol> return_type = nullptr;
       if (FAILED(type->get_type(&return_type))) {
-        return ErrorMessage(
-            absl::StrFormat("Error calling \"get_type\": %s", orbit_base::GetLastErrorAsString()));
+        return orbit_base::GetLastErrorAsErrorMessage("IDiaSymbol::get_type");
       }
       if (return_type == nullptr) {
         return ErrorMessage("Unable to retrieve type symbol.");

--- a/src/OrbitBase/ExecutablePathWindows.cpp
+++ b/src/OrbitBase/ExecutablePathWindows.cpp
@@ -20,13 +20,13 @@ std::filesystem::path GetExecutablePath() {
   constexpr uint32_t kMaxPath = 2048;
   char exe_file_name[kMaxPath] = {0};
   if (!GetModuleFileNameA(/*hModule=*/nullptr, exe_file_name, kMaxPath)) {
-    ORBIT_FATAL("GetModuleFileName failed with: %s", GetLastErrorAsString());
+    ORBIT_FATAL("%s", GetLastErrorAsString("GetModuleFileNameA"));
   }
 
   // Clean up "../" inside full path
   char exe_full_path[kMaxPath] = {0};
   if (!GetFullPathNameA(exe_file_name, kMaxPath, exe_full_path, nullptr)) {
-    ORBIT_FATAL("GetFullPathNameA failed with: %s", GetLastErrorAsString());
+    ORBIT_FATAL("%s", GetLastErrorAsString("GetFullPathNameA"));
   }
 
   return std::filesystem::path(exe_full_path);
@@ -42,15 +42,13 @@ ErrorMessageOr<std::filesystem::path> GetExecutablePath(uint32_t pid) {
   char exe_file_name[kMaxPath] = {0};
 
   if (!GetModuleFileNameExA(handle, /*hModule=*/nullptr, exe_file_name, kMaxPath)) {
-    return ErrorMessage(
-        absl::StrFormat("GetModuleFileNameExA failed with: %s", GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("GetModuleFileNameExA");
   }
 
   // Clean up "../" inside full path
   char exe_full_path[kMaxPath] = {0};
   if (!GetFullPathNameA(exe_file_name, kMaxPath, exe_full_path, nullptr)) {
-    return ErrorMessage(
-        absl::StrFormat("GetFullPathNameA failed with: %s", GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("GetFullPathNameA");
   }
 
   return std::filesystem::path(exe_full_path);

--- a/src/OrbitBase/GetLastErrorWindows.cpp
+++ b/src/OrbitBase/GetLastErrorWindows.cpp
@@ -4,6 +4,7 @@
 
 #include <absl/base/casts.h>
 #include <absl/strings/ascii.h>
+#include <absl/strings/str_format.h>
 #include <windows.h>
 
 #include "OrbitBase/GetLastError.h"
@@ -38,6 +39,14 @@ std::string GetLastErrorAsString() {
   std::string error_as_string(buffer, size);
   LocalFree(buffer);
   return std::string(absl::StripAsciiWhitespace(error_as_string));
+}
+
+std::string GetLastErrorAsString(std::string_view function_name) {
+  return absl::StrFormat("Calling %s: %s", function_name, GetLastErrorAsString());
+}
+
+ErrorMessage GetLastErrorAsErrorMessage(std::string_view function_name) {
+  return ErrorMessage(GetLastErrorAsString(function_name));
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/GetLastError.h
+++ b/src/OrbitBase/include/OrbitBase/GetLastError.h
@@ -7,10 +7,14 @@
 
 #include <string>
 
+#include "OrbitBase/Result.h"
+
 namespace orbit_base {
 
 #ifdef _WIN32
 [[nodiscard]] std::string GetLastErrorAsString();
+[[nodiscard]] std::string GetLastErrorAsString(std::string_view function_name);
+[[nodiscard]] ErrorMessage GetLastErrorAsErrorMessage(std::string_view function_name);
 #endif
 
 }  // namespace orbit_base

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -45,7 +45,7 @@ BOOL WINAPI CtrlHandler(DWORD event_type) {
 
 void InstallSigintHandler() {
   if (!SetConsoleCtrlHandler(CtrlHandler, TRUE)) {
-    ORBIT_ERROR("Calling SetConsoleCtrlHandler: %s", orbit_base::GetLastErrorAsString());
+    ORBIT_ERROR("%s", orbit_base::GetLastErrorAsString("SetConsoleCtrlHandler"));
   }
 }
 

--- a/src/WindowsUtils/CreateProcess.cpp
+++ b/src/WindowsUtils/CreateProcess.cpp
@@ -48,8 +48,7 @@ ErrorMessageOr<ProcessInfo> CreateProcess(const std::filesystem::path& executabl
                      /*bInheritHandles*/ FALSE, creation_flags, /*lpEnvironment*/ nullptr,
                      working_directory.empty() ? nullptr : working_directory.c_str(), &startup_info,
                      &process_info) == 0) {
-    return ErrorMessage(
-        absl::StrFormat("Calling \"CreateProcess\": %s", orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("CreateProcess");
   }
 
   // A SafeHandle makes sure "CloseHandle" is called when the ProcessInfo goes out of scope.

--- a/src/WindowsUtils/CreateProcessTest.cpp
+++ b/src/WindowsUtils/CreateProcessTest.cpp
@@ -29,7 +29,7 @@ TEST(CreateProcess, SuccessfulProcessCreation) {
   std::unique_ptr<ProcessList> process_list = ProcessList::Create();
   EXPECT_TRUE(process_list->GetProcessByPid(process_info.process_id).has_value());
   EXPECT_NE(TerminateProcess(*process_info.process_handle, /*exit_code*/ 0), 0)
-      << orbit_base::GetLastErrorAsString();
+      << orbit_base::GetLastErrorAsString("TerminateProcess");
 }
 
 TEST(CreateProcess, CommandLine) {

--- a/src/WindowsUtils/Debugger.cpp
+++ b/src/WindowsUtils/Debugger.cpp
@@ -76,7 +76,7 @@ void Debugger::DebuggingLoop(uint32_t process_id) {
   while (true) {
     if (!WaitForDebugEvent(&debug_event, kWaitForDebugEventMs)) {
       if (::GetLastError() != kSemaphoreExpiredErrorCode) {
-        ORBIT_ERROR("Calling \"WaitForDebugEvent\": %s", orbit_base::GetLastErrorAsString());
+        ORBIT_ERROR("%s", orbit_base::GetLastErrorAsString("WaitForDebugEvent"));
         detach_requested_ = true;
       }
 

--- a/src/WindowsUtils/DebuggerTest.cpp
+++ b/src/WindowsUtils/DebuggerTest.cpp
@@ -119,7 +119,7 @@ TEST(Debugger, Detach) {
   ASSERT_TRUE(safe_handle_or_error.has_value());
   const SafeHandle& process_handle = safe_handle_or_error.value();
   EXPECT_NE(TerminateProcess(*process_handle, /*exit_code*/ 0), 0)
-      << orbit_base::GetLastErrorAsString();
+      << orbit_base::GetLastErrorAsString("TerminateProcess");
 }
 
 TEST(Debugger, NoListener) { EXPECT_DEATH(Debugger({}), "Check failed"); }

--- a/src/WindowsUtils/DllInjection.cpp
+++ b/src/WindowsUtils/DllInjection.cpp
@@ -30,8 +30,7 @@ ErrorMessageOr<uint64_t> RemoteWrite(HANDLE process_handle, absl::Span<const cha
   LPVOID base_address = VirtualAllocEx(process_handle, /*lpAddress=*/0, buffer.size(),
                                        MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
   if (base_address == nullptr) {
-    return ErrorMessage(
-        absl::StrFormat("Error calling VirtualAllocEx: %s", orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("VirtualAllocEx");
   }
 
   // Write in allocated remote memory.
@@ -46,8 +45,7 @@ ErrorMessageOr<T> RemoteRead(HANDLE process_handle, uint64_t base_address) {
   T result = {0};
   if (!ReadProcessMemory(process_handle, absl::bit_cast<LPCVOID>(base_address), &result, sizeof(T),
                          &number_of_bytes_read)) {
-    return ErrorMessage(
-        absl::StrFormat("Error calling ReadProcessMemory: %s", orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("ReadProcessMemory");
   }
 
   if (number_of_bytes_read != sizeof(T)) {
@@ -147,8 +145,7 @@ ErrorMessageOr<void> CreateRemoteThread(uint32_t pid, std::string_view module_na
                             absl::bit_cast<LPTHREAD_START_ROUTINE>(function_address),
                             absl::bit_cast<LPVOID>(parameter_address),
                             /*dwCreationFlags=*/0, /*lpThreadId=*/0)) {
-    return ErrorMessage(absl::StrFormat("Error calling CreateRemoteThread: %s",
-                                        orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("CreateRemoteThread");
   }
 
   return outcome::success();

--- a/src/WindowsUtils/ProcessList.cpp
+++ b/src/WindowsUtils/ProcessList.cpp
@@ -129,15 +129,13 @@ ErrorMessageOr<void> ProcessListImpl::Refresh() {
   HANDLE process_snap_handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, /*th32ProcessID=*/0);
   SafeHandle handle_closer(process_snap_handle);
   if (process_snap_handle == INVALID_HANDLE_VALUE) {
-    return ErrorMessage(absl::StrFormat("Calling CreateToolhelp32Snapshot: %s",
-                                        orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("CreateToolhelp32Snapshot");
   }
 
   // Retrieve information about the first process, and exit if unsuccessful.
   process_entry.dwSize = sizeof(PROCESSENTRY32);
   if (!Process32First(process_snap_handle, &process_entry)) {
-    return ErrorMessage(
-        absl::StrFormat("Calling Process32First: %s", orbit_base::GetLastErrorAsString()));
+    return orbit_base::GetLastErrorAsErrorMessage("Process32First");
   }
 
   // Walk the snapshot of processes.


### PR DESCRIPTION
Simplify and formalize the creation of error messages based on
"GetLastError". "GetLastErrorAsString(std::string_view function_name)"
returns a string of the form "Calling function_name: error_as_string".
"GetLastErrorAsErrorMessage(std::string_view function_name)" returns an
ErrorMessage built from "GetLastErrorAsString(function_name)".

This also has the added benefit of saving one line of code (50%) when
returning common error messages from "GetLastError".