### PR TITLE
Fix an issue occurring when conan default profiles were created

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -6,8 +6,8 @@ function conan_profile_exists($profile) {
 }
 
 function conan_create_profile($profile) {
-  if (! (& $conan.Path profile show default)) {
-    if (! (& $conan.Path profile new --detect default)) {
+  if (! (& $conan.Path profile show $profile)) {
+    if (! (& $conan.Path profile new --detect $profile)) {
       exit $?
     }
   }

--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 function create_conan_profile {
   local readonly profile="$1"
-  if ! conan profile show default >/dev/null; then
-    conan profile new --detect default || exit $?
+  if ! conan profile show $profile >/dev/null; then
+    conan profile new --detect $profile || exit $?
   fi
 
   readonly compiler="$(conan profile show default | grep compiler= | cut -d= -f2 | sed -e 's/Visual Studio/msvc/')"


### PR DESCRIPTION
During the build of orbit, conan default profiles were not correctly created (only default)