### PR TITLE
Set up context menu for non-function entries under Live tab

### DIFF
--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/strings/str_replace.h>
 
+#include <cstddef>
 #include <memory>
 
 #include "ClientData/FunctionInfo.h"
@@ -228,13 +229,14 @@ void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
       orbit_metrics_uploader::OrbitLogEvent::ORBIT_FRAME_TRACK_ENABLE_CLICKED);
 
   for (int i : selection) {
-    const FunctionInfo& function = *GetFunctionInfoFromRow(i);
+    const FunctionInfo* function = GetFunctionInfoFromRow(i);
+    if (function == nullptr) continue;
     // Functions used as frame tracks must be hooked (selected), otherwise the
     // data to produce the frame track will not be captured.
-    app_->SelectFunction(function);
+    app_->SelectFunction(*function);
 
-    app_->EnableFrameTrack(function);
-    app_->AddFrameTrack(function);
+    app_->EnableFrameTrack(*function);
+    app_->AddFrameTrack(*function);
   }
 }
 
@@ -243,12 +245,14 @@ void DataView::OnDisableFrameTrackRequested(const std::vector<int>& selection) {
       orbit_metrics_uploader::OrbitLogEvent::ORBIT_FRAME_TRACK_DISABLE_CLICKED);
 
   for (int i : selection) {
-    const FunctionInfo& function = *GetFunctionInfoFromRow(i);
+    const FunctionInfo* function = GetFunctionInfoFromRow(i);
+    if (function == nullptr) continue;
+
     // When we remove a frame track, we do not unhook (deselect) the function as
     // it may have been selected manually (not as part of adding a frame track).
     // However, disable the frame track, so it is not recreated on the next capture.
-    app_->DisableFrameTrack(function);
-    app_->RemoveFrameTrack(function);
+    app_->DisableFrameTrack(*function);
+    app_->RemoveFrameTrack(*function);
   }
 }
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -264,49 +264,45 @@ DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
   }
 
   bool is_capture_connected = app_->IsCaptureConnected(capture_data);
-  if (action == kMenuActionDisassembly || action == kMenuActionSourceCode) {
-    return is_capture_connected ? ActionStatus::kVisibleAndEnabled
-                                : ActionStatus::kVisibleButDisabled;
-  }
-
-  if ((action == kMenuActionSelect || action == kMenuActionUnselect) && !is_capture_connected) {
-    return ActionStatus::kVisibleButDisabled;
-  }
 
   std::function<bool(uint64_t, const FunctionInfo&)> is_visible_action_enabled;
-  if (action == kMenuActionSelect) {
-    is_visible_action_enabled = [this](uint64_t /*instrumented_function_id*/,
-                                       const FunctionInfo& instrumented_function) {
-      return !app_->IsFunctionSelected(instrumented_function) &&
-             instrumented_function.IsFunctionSelectable();
+  if (action == kMenuActionDisassembly || action == kMenuActionSourceCode) {
+    is_visible_action_enabled = [is_capture_connected](uint64_t /*scope_id*/,
+                                                       const FunctionInfo& /*function_info*/) {
+      return is_capture_connected;
+    };
+
+  } else if (action == kMenuActionSelect) {
+    is_visible_action_enabled = [this, is_capture_connected](uint64_t /*scope_id*/,
+                                                             const FunctionInfo& function_info) {
+      return is_capture_connected && !app_->IsFunctionSelected(function_info) &&
+             function_info.IsFunctionSelectable();
     };
 
   } else if (action == kMenuActionUnselect) {
-    is_visible_action_enabled = [this](uint64_t /*instrumented_function_id*/,
-                                       const FunctionInfo& instrumented_function) {
-      return app_->IsFunctionSelected(instrumented_function);
+    is_visible_action_enabled = [this, is_capture_connected](uint64_t /*scope_id*/,
+                                                             const FunctionInfo& function_info) {
+      return is_capture_connected && app_->IsFunctionSelected(function_info);
     };
 
   } else if (action == kMenuActionEnableFrameTrack) {
     is_visible_action_enabled = [this, &is_capture_connected, &capture_data](
-                                    uint64_t instrumented_function_id,
-                                    const FunctionInfo& instrumented_function) {
-      return is_capture_connected ? !app_->IsFrameTrackEnabled(instrumented_function)
-                                  : !capture_data.IsFrameTrackEnabled(instrumented_function_id);
+                                    uint64_t scope_id, const FunctionInfo& function_info) {
+      return is_capture_connected ? !app_->IsFrameTrackEnabled(function_info)
+                                  : !capture_data.IsFrameTrackEnabled(scope_id);
     };
 
   } else if (action == kMenuActionDisableFrameTrack) {
     is_visible_action_enabled = [this, &is_capture_connected, &capture_data](
-                                    uint64_t instrumented_function_id,
-                                    const FunctionInfo& instrumented_function) {
-      return is_capture_connected ? app_->IsFrameTrackEnabled(instrumented_function)
-                                  : capture_data.IsFrameTrackEnabled(instrumented_function_id);
+                                    uint64_t scope_id, const FunctionInfo& function_info) {
+      return is_capture_connected ? app_->IsFrameTrackEnabled(function_info)
+                                  : capture_data.IsFrameTrackEnabled(scope_id);
     };
 
   } else if (action == kMenuActionAddIterator) {
-    is_visible_action_enabled = [&capture_data](uint64_t instrumented_function_id,
-                                                const FunctionInfo& /*instrumented_function*/) {
-      const ScopeStats& stats = capture_data.GetScopeStatsOrDefault(instrumented_function_id);
+    is_visible_action_enabled = [&capture_data](uint64_t scope_id,
+                                                const FunctionInfo& /*function_info*/) {
+      const ScopeStats& stats = capture_data.GetScopeStatsOrDefault(scope_id);
       // We need at least one function call to a function so that adding iterators makes sense.
       return stats.count() > 0;
     };
@@ -315,13 +311,29 @@ DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
     return DataView::GetActionStatus(action, clicked_index, selected_indices);
   }
 
-  for (int index : selected_indices) {
-    uint64_t scope_id = GetScopeId(index);
-    const FunctionInfo& instrumented_function = *GetFunctionInfoFromRow(index);
-    if (is_visible_action_enabled(scope_id, instrumented_function)) {
-      return ActionStatus::kVisibleAndEnabled;
-    }
+  std::vector<const FunctionInfo*> function_infos;
+  std::transform(std::begin(selected_indices), std::end(selected_indices),
+                 std::back_inserter(function_infos),
+                 [this](int index) { return GetFunctionInfoFromRow(index); });
+
+  const bool no_functions_selected =
+      all_of(std::begin(function_infos), std::end(function_infos),
+             [](const FunctionInfo* function_info) { return function_info == nullptr; });
+
+  if (no_functions_selected) {
+    return ActionStatus::kInvisible;
   }
+
+  const bool enabled_for_any =
+      std::any_of(std::begin(selected_indices), std::end(selected_indices),
+                  [this, &is_visible_action_enabled](int index) {
+                    const uint64_t scope_id = GetScopeId(index);
+                    const FunctionInfo* function_info = GetFunctionInfoFromRow(index);
+                    if (function_info == nullptr) return false;
+                    return is_visible_action_enabled(scope_id, *function_info);
+                  });
+
+  if (enabled_for_any) return ActionStatus::kVisibleAndEnabled;
   return ActionStatus::kVisibleButDisabled;
 }
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -324,14 +324,14 @@ DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
     return ActionStatus::kInvisible;
   }
 
-  const bool enabled_for_any =
-      std::any_of(std::begin(selected_indices), std::end(selected_indices),
-                  [this, &is_visible_action_enabled](int index) {
-                    const uint64_t scope_id = GetScopeId(index);
-                    const FunctionInfo* function_info = GetFunctionInfoFromRow(index);
-                    if (function_info == nullptr) return false;
-                    return is_visible_action_enabled(scope_id, *function_info);
-                  });
+  const bool enabled_for_any = std::transform_reduce(
+      std::begin(selected_indices), std::end(selected_indices), std::begin(function_infos), false,
+      std::logical_or<>{},
+      [this, &is_visible_action_enabled](int index, const FunctionInfo* function_info) {
+        const uint64_t scope_id = GetScopeId(index);
+        if (function_info == nullptr) return false;
+        return is_visible_action_enabled(scope_id, *function_info);
+      });
 
   if (enabled_for_any) return ActionStatus::kVisibleAndEnabled;
   return ActionStatus::kVisibleButDisabled;


### PR DESCRIPTION
This leaves only jumps, copy and export to csv actions relevant.

If both manual scopes and hooked functions are shown under Live
tab, and the user selects them all, non-relevant entries will be
shown nevertherless. Hence, it's necessary to short-circuit such
actions for non-functions.

Tests: Unit, Manual
Bug: http://b/228288357