### PR TITLE
Make zooming-out in the histogram always react

### DIFF
--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -513,7 +513,7 @@ void HistogramWidget::mouseReleaseEvent(QMouseEvent* /* event*/) {
       const auto max_it = std::upper_bound(data_begin, data_end, max);
       const auto selection = absl::Span<const uint64_t>(&*min_it, std::distance(min_it, max_it));
 
-      if (*min_it == MinValue() && *(max_it - 1) == MaxValue()) {
+      if (selection.front() == MinValue() && selection.back() == MaxValue()) {
         selected_area_.reset();
         UpdateAndNotify();
         return;

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -321,7 +321,7 @@ static void DrawSelection(QPainter& painter, int start_x, int end_x,
 [[nodiscard]] static uint64_t LocationToValue(int pos_x, int width, uint64_t min_value,
                                               uint64_t max_value) {
   if (pos_x <= kLeftMargin) return min_value;
-  if (pos_x > width - kRightMargin) return max_value + 1;
+  if (pos_x > width - kRightMargin) return max_value;
 
   const int location = pos_x - kLeftMargin;
   const int histogram_width = width - kLeftMargin - kRightMargin;
@@ -512,6 +512,12 @@ void HistogramWidget::mouseReleaseEvent(QMouseEvent* /* event*/) {
     if (min_it != scope_data_->data->end()) {
       const auto max_it = std::upper_bound(data_begin, data_end, max);
       const auto selection = absl::Span<const uint64_t>(&*min_it, std::distance(min_it, max_it));
+
+      if (*min_it == MinValue() && *(max_it - 1) == MaxValue()) {
+        selected_area_.reset();
+        UpdateAndNotify();
+        return;
+      }
 
       auto histogram = orbit_statistics::BuildHistogram(selection);
       if (histogram) {


### PR DESCRIPTION
Previously it was possible to stack up multiple equal selections.
In that case a single click (that is supposed to zoom-out)
was switching from the current histogram to the previous one
that was exactly the same. This was confusing to the user.

A simple check is added to avoid such stacking-up.

This also fixes a hidden bug in `LocationToValue`
that was leading to slightly imprecise selections. 

Tests: Manual
Bug: http://b/228167388