### PR TITLE
Add default-initalization for primitive fields of ScopeStats

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -75,7 +75,7 @@ void CaptureData::ForEachThreadStateSliceIntersectingTimeRange(
 }
 
 const ScopeStats& CaptureData::GetScopeStatsOrDefault(uint64_t scope_id) const {
-  static const ScopeStats kDefaultScopeStats{};
+  static const ScopeStats kDefaultScopeStats;
   auto scope_stats_it = scope_stats_.find(scope_id);
   if (scope_stats_it == scope_stats_.end()) {
     return kDefaultScopeStats;

--- a/src/ClientData/include/ClientData/ScopeStats.h
+++ b/src/ClientData/include/ClientData/ScopeStats.h
@@ -43,11 +43,11 @@ class ScopeStats {
   }
 
  private:
-  uint64_t count_;
-  uint64_t total_time_ns_;
-  uint64_t min_ns_;
-  uint64_t max_ns_;
-  double variance_ns_;
+  uint64_t count_{};
+  uint64_t total_time_ns_{};
+  uint64_t min_ns_{};
+  uint64_t max_ns_{};
+  double variance_ns_{};
 };
 
 }  // namespace orbit_client_data


### PR DESCRIPTION
This add explicit default initialization for ScopeStats
fields. Its absense wasn't an issue when an instance was
instantiated with `ScopeStats stats{}`, yet it wasn't
alsways the case. E. g. it wasn't in `FrameTrack` which
has lead to incorrect visualization of frame track
in the capture view.

Tests: Unit, Manual
Bug: http://b/228166267