### PR TITLE
Implement ObjectFile::GetExecutableSegmentSize

### DIFF
--- a/src/CodeReport/SourceCodeReportTest.cpp
+++ b/src/CodeReport/SourceCodeReportTest.cpp
@@ -18,6 +18,7 @@ class MockElfFile : public orbit_object_utils::ElfFile {
               (override));
   MOCK_METHOD(uint64_t, GetLoadBias, (), (const, override));
   MOCK_METHOD(uint64_t, GetExecutableSegmentOffset, (), (const, override));
+  MOCK_METHOD(uint64_t, GetExecutableSegmentSize, (), (const, override));
 
   MOCK_METHOD(bool, HasDynsym, (), (const, override));
   MOCK_METHOD(bool, HasDebugInfo, (), (const, override));

--- a/src/ObjectUtils/Address.cpp
+++ b/src/ObjectUtils/Address.cpp
@@ -28,7 +28,8 @@ uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
 
 uint64_t SymbolOffsetToAbsoluteAddress(uint64_t symbol_address, uint64_t module_base_address,
                                        uint64_t module_executable_section_offset) {
-  return SymbolVirtualAddressToAbsoluteAddress(symbol_address, module_base_address, /*load_bias=*/0,
+  return SymbolVirtualAddressToAbsoluteAddress(symbol_address, module_base_address,
+                                               /*module_load_bias=*/0,
                                                module_executable_section_offset);
 }
 

--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -122,3 +122,22 @@ TEST(CoffFile, GetsEmptyBuildIdIfPdbInfoIsNotPresent) {
 
   EXPECT_EQ("", coff_file_or_error.value()->GetBuildId());
 }
+
+TEST(CoffFile, GetExecutableSegmentOffsetAndSize) {
+  {
+    std::filesystem::path file_path = orbit_test::GetTestdataDir() / "dllmain.dll";
+    auto coff_file_or_error = CreateCoffFile(file_path);
+    ASSERT_THAT(coff_file_or_error, HasNoError());
+    const CoffFile& coff_file = *coff_file_or_error.value();
+    EXPECT_EQ(coff_file.GetExecutableSegmentOffset(), 0x1000);
+    EXPECT_EQ(coff_file.GetExecutableSegmentSize(), 0xce9e4);
+  }
+  {
+    std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libtest.dll";
+    auto coff_file_or_error = CreateCoffFile(file_path);
+    ASSERT_THAT(coff_file_or_error, HasNoError());
+    const CoffFile& coff_file = *coff_file_or_error.value();
+    EXPECT_EQ(coff_file.GetExecutableSegmentOffset(), 0x1000);
+    EXPECT_EQ(coff_file.GetExecutableSegmentSize(), 0x1338);
+  }
+}

--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -93,7 +93,7 @@ TEST(ElfFile, LoadSymbolsFromDynsym) {
   EXPECT_EQ(symbol_info.size(), 591);
 }
 
-TEST(ElfFile, LoadBiasAndExecutableSegmentOffset) {
+TEST(ElfFile, LoadBiasAndExecutableSegmentOffsetAndSize) {
   {
     const std::filesystem::path test_elf_file_dynamic =
         orbit_test::GetTestdataDir() / "hello_world_elf";
@@ -101,6 +101,7 @@ TEST(ElfFile, LoadBiasAndExecutableSegmentOffset) {
     ASSERT_THAT(elf_file_dynamic, HasNoError());
     EXPECT_EQ(elf_file_dynamic.value()->GetLoadBias(), 0x0);
     EXPECT_EQ(elf_file_dynamic.value()->GetExecutableSegmentOffset(), 0x1000);
+    EXPECT_EQ(elf_file_dynamic.value()->GetExecutableSegmentSize(), 0x1cd);
   }
 
   {
@@ -110,6 +111,7 @@ TEST(ElfFile, LoadBiasAndExecutableSegmentOffset) {
     ASSERT_THAT(elf_file_static, HasNoError());
     EXPECT_EQ(elf_file_static.value()->GetLoadBias(), 0x400000);
     EXPECT_EQ(elf_file_static.value()->GetExecutableSegmentOffset(), 0x1000);
+    EXPECT_EQ(elf_file_static.value()->GetExecutableSegmentSize(), 0x7b4e1);
   }
 }
 

--- a/src/ObjectUtils/LinuxMapTest.cpp
+++ b/src/ObjectUtils/LinuxMapTest.cpp
@@ -177,7 +177,7 @@ TEST(LinuxMap, ParseMaps) {
 
     const ModuleInfo* hello_module_info = nullptr;
     const ModuleInfo* no_symbols_module_info = nullptr;
-    ;
+
     if (result.value()[0].name() == "hello_world_elf") {
       hello_module_info = &result.value()[0];
       no_symbols_module_info = &result.value()[1];

--- a/src/ObjectUtils/include/ObjectUtils/CoffFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/CoffFile.h
@@ -29,7 +29,7 @@ struct PdbDebugInfo {
 class CoffFile : public ObjectFile {
  public:
   CoffFile() = default;
-  virtual ~CoffFile() = default;
+  ~CoffFile() override = default;
 
   [[nodiscard]] virtual ErrorMessageOr<PdbDebugInfo> GetDebugPdbInfo() const = 0;
 };

--- a/src/ObjectUtils/include/ObjectUtils/ElfFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ElfFile.h
@@ -34,7 +34,7 @@ struct GnuDebugLinkInfo {
 class ElfFile : public ObjectFile {
  public:
   ElfFile() = default;
-  virtual ~ElfFile() = default;
+  ~ElfFile() override = default;
 
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::ModuleSymbols>
   LoadSymbolsFromDynsym() = 0;

--- a/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
@@ -21,7 +21,7 @@ namespace orbit_object_utils {
 class ObjectFile : public SymbolsFile {
  public:
   ObjectFile() = default;
-  virtual ~ObjectFile() = default;
+  ~ObjectFile() override = default;
 
   [[nodiscard]] virtual bool HasDebugSymbols() const = 0;
   [[nodiscard]] virtual std::string GetName() const = 0;
@@ -44,7 +44,15 @@ class ObjectFile : public SymbolsFile {
   // The same calculation applies for PE/COFF object files. Here, the address
   // to be subtracted is ImageBase as specified in the PE header.
   [[nodiscard]] virtual uint64_t GetLoadBias() const = 0;
+
+  // This is the offset of the text segment *when loaded into memory* relative to the base address.
+  // Note that, based on our definition of load bias, for ELF files this is the same as the offset
+  // in the file, while for COFF there is generally a difference.
   [[nodiscard]] virtual uint64_t GetExecutableSegmentOffset() const = 0;
+
+  // This is the size of the text segment *when loaded into memory*.
+  [[nodiscard]] virtual uint64_t GetExecutableSegmentSize() const = 0;
+
   [[nodiscard]] virtual bool IsElf() const = 0;
   [[nodiscard]] virtual bool IsCoff() const = 0;
 };

--- a/src/ObjectUtils/include/ObjectUtils/SymbolsFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/SymbolsFile.h
@@ -15,11 +15,13 @@
 namespace orbit_object_utils {
 
 struct ObjectFileInfo {
-  // This is the load bias for ELF, for COFF we use ImageBase here, so that our
-  // address computations are consistent between what we do we ELF and for COFF.
+  // For ELF, this is the load bias of the executable segment. For PE/COFF, we use ImageBase here,
+  // so that our address computations are consistent between what we do for ELF and for COFF.
   uint64_t load_bias = 0;
-  // File offset to the beginning of the executable segment. For COFF, this is
-  // the file offset to the beginning of the .text section.
+  // This is the offset of the executable segment when loaded into memory. For ELF, as we defined
+  // the load bias based on the executable segment, this is also the offset of the executable
+  // segment in the file. For PE/COFF, this is in general different from the offset of the .text
+  // section in the file.
   uint64_t executable_segment_offset = 0;
 };
 
@@ -29,10 +31,11 @@ class SymbolsFile {
   virtual ~SymbolsFile() = default;
 
   // For ELF files, the string returned by GetBuildId() is the standard build id that can be found
-  // in the .note.gnu.build-id section, formatted as a human readable string.
-  // PE/COFF object files are uniquely identfied by the PDB debug info consisting of a GUID and age.
-  // The build id is formed from these to provide a string that uniquely identifies this object file
-  // and the corresponding PDB debug info. The build id for PDB files is formed in the same way.
+  // in the .note.gnu.build-id section, formatted as a human-readable string.
+  // PE/COFF object files are uniquely identified by the PDB debug info consisting of a GUID and
+  // age. The build id is formed from these to provide a string that uniquely identifies this object
+  // file and the corresponding PDB debug info. The build id for PDB files is formed in the same
+  // way.
   [[nodiscard]] virtual std::string GetBuildId() const = 0;
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadDebugSymbols() = 0;
   [[nodiscard]] virtual const std::filesystem::path& GetFilePath() const = 0;


### PR DESCRIPTION
This is the counterpart of `GetExecutableSegmentOffset`. Both refer to the
executable segment when it's loaded into memory.

It will be necessary for the detection of Windows binaries whose executable
segment is mapped anonymously in `/proc/[pid]/maps` by Wine because the
`FileAlignment` is not multiple of the page size.

Bug: http://b/226562022

Test: Unit tests. Tried as part of a larger prototype for the problem mentioned
above.