### PR TITLE
Improve PrimitiveAssemblerTest

### DIFF
--- a/src/OrbitGl/Geometry.h
+++ b/src/OrbitGl/Geometry.h
@@ -17,9 +17,9 @@ struct Line {
 // TODO(b/227748244) Tetragon should store four Vec2
 struct Tetragon {
   Tetragon() = default;
-  Tetragon(std::array<Vec3, 4> clockwise_ordered_vertices)
+  explicit Tetragon(std::array<Vec3, 4> clockwise_ordered_vertices)
       : vertices(std::move(clockwise_ordered_vertices)) {}
-  Tetragon(std::array<Vec2, 4> clockwise_ordered_vertices, float z = 0) {
+  explicit Tetragon(std::array<Vec2, 4> clockwise_ordered_vertices, float z = 0) {
     std::transform(clockwise_ordered_vertices.begin(), clockwise_ordered_vertices.end(),
                    vertices.begin(), [z](Vec2& v) { return Vec2ToVec3(v, z); });
   }

--- a/src/OrbitGl/Geometry.h
+++ b/src/OrbitGl/Geometry.h
@@ -28,8 +28,8 @@ struct Tetragon {
 };
 
 [[nodiscard]] inline Tetragon MakeBox(const Vec2& pos, const Vec2& size, float z) {
-  return {{Vec3(pos[0], pos[1], z), Vec3(pos[0], pos[1] + size[1], z),
-           Vec3(pos[0] + size[0], pos[1] + size[1], z), Vec3(pos[0] + size[0], pos[1], z)}};
+  return Tetragon{{Vec3(pos[0], pos[1], z), Vec3(pos[0], pos[1] + size[1], z),
+                   Vec3(pos[0] + size[0], pos[1] + size[1], z), Vec3(pos[0] + size[0], pos[1], z)}};
 }
 
 struct Triangle {

--- a/src/OrbitGl/Geometry.h
+++ b/src/OrbitGl/Geometry.h
@@ -17,8 +17,12 @@ struct Line {
 // TODO(b/227748244) Tetragon should store four Vec2
 struct Tetragon {
   Tetragon() = default;
-  Tetragon(std::array<Vec3, 4> clockwise_ordered_vartices)
-      : vertices(std::move(clockwise_ordered_vartices)) {}
+  Tetragon(std::array<Vec3, 4> clockwise_ordered_vertices)
+      : vertices(std::move(clockwise_ordered_vertices)) {}
+  Tetragon(std::array<Vec2, 4> clockwise_ordered_vertices, float z = 0) {
+    std::transform(clockwise_ordered_vertices.begin(), clockwise_ordered_vertices.end(),
+                   vertices.begin(), [z](Vec2 v) { return Vec2ToVec3(v, z); });
+  }
 
   std::array<Vec3, 4> vertices;
 };

--- a/src/OrbitGl/Geometry.h
+++ b/src/OrbitGl/Geometry.h
@@ -21,7 +21,7 @@ struct Tetragon {
       : vertices(std::move(clockwise_ordered_vertices)) {}
   Tetragon(std::array<Vec2, 4> clockwise_ordered_vertices, float z = 0) {
     std::transform(clockwise_ordered_vertices.begin(), clockwise_ordered_vertices.end(),
-                   vertices.begin(), [z](Vec2 v) { return Vec2ToVec3(v, z); });
+                   vertices.begin(), [z](Vec2& v) { return Vec2ToVec3(v, z); });
   }
 
   std::array<Vec3, 4> vertices;

--- a/src/OrbitGl/MockBatcher.cpp
+++ b/src/OrbitGl/MockBatcher.cpp
@@ -91,7 +91,8 @@ int MockBatcher::GetNumBoxes() const {
 
 // To check that everything is inside a rectangle, we just need to check the minimum and maximum
 // used coordinates.
-bool MockBatcher::IsEverythingInsideRectangle(Vec2 start, Vec2 end) const {
+bool MockBatcher::IsEverythingInsideRectangle(Vec2 start, Vec2 size) const {
+  Vec2 end = start + size;
   return IsInsideRectangle({min_point_[0], min_point_[1]}, start, end) &&
          IsInsideRectangle({max_point_[0], max_point_[1]}, start, end);
 }

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -38,13 +38,13 @@ AddInternalMethods, ResetElements(), GetLayers() and DrawLayers().
 **/
 class PrimitiveAssembler {
  public:
+  static constexpr int32_t kCirclePoints = 22;
   explicit PrimitiveAssembler(Batcher* batcher, PickingManager* picking_manager = nullptr)
       : batcher_(batcher), picking_manager_(picking_manager) {
     ORBIT_CHECK(batcher_ != nullptr);
 
-    constexpr int32_t kSteps = 22;
-    const float angle = (kPiFloat * 2.f) / kSteps;
-    for (int32_t i = 1; i <= kSteps; i++) {
+    const float angle = (kPiFloat * 2.f) / kCirclePoints;
+    for (int32_t i = 1; i <= kCirclePoints; i++) {
       float new_x = sinf(angle * i);
       float new_y = cosf(angle * i);
       circle_points.emplace_back(Vec2(new_x, new_y));
@@ -84,19 +84,14 @@ class PrimitiveAssembler {
   void AddRoundedBox(Vec2 pos, Vec2 size, float z, float radius, const Color& color,
                      float margin = 0);
 
-  void AddBottomLeftRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
-  void AddTopLeftRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
-  void AddTopRightRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
-  void AddBottomRightRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
-
-  void AddTriangle(const Triangle& triangle, const Color& color,
-                   std::unique_ptr<PickingUserData> user_data = nullptr);
   // TODO(b/227744958) This should probably be removed and AddBox should be used instead
   void AddShadedTrapezium(const Tetragon& trapezium, const Color& color,
-                          std::unique_ptr<PickingUserData> user_data = nullptr,
+                          std::unique_ptr<PickingUserData> user_data,
                           ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
   void AddTriangle(const Triangle& triangle, const Color& color,
                    std::shared_ptr<Pickable> pickable);
+  void AddTriangle(const Triangle& triangle, const Color& color,
+                   std::unique_ptr<PickingUserData> user_data = nullptr);
 
   void AddTetragonBorder(const Tetragon& tetragon, const Color& color,
                          std::unique_ptr<orbit_gl::PickingUserData> user_data);
@@ -113,12 +108,16 @@ class PrimitiveAssembler {
 
   static constexpr uint32_t kNumArcSides = 16;
 
- protected:
+ private:
+  [[nodiscard]] BatcherId GetBatcherId() const { return batcher_->GetBatcherId(); }
+
+  void AddBottomLeftRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
+  void AddTopLeftRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
+  void AddTopRightRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
+  void AddBottomRightRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
   void AddTriangle(const Triangle& triangle, const Color& color, const Color& picking_color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
 
- private:
-  [[nodiscard]] BatcherId GetBatcherId() const { return batcher_->GetBatcherId(); }
   void GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors,
                             ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
 

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -12,12 +12,12 @@ namespace orbit_gl {
 
 namespace {
 
-Color kFakeColor{42, 42, 128, 43};
-Vec2 kTopLeft{0, 0};
-Vec2 kTopRight{5, 0};
-Vec2 kBottomRight{5, 5};
-Vec2 kBottomLeft{0, 5};
-Vec2 kBoxSize{5, 5};
+const Color kFakeColor{42, 42, 128, 43};
+const Vec2 kTopLeft{0, 0};
+const Vec2 kTopRight{5, 0};
+const Vec2 kBottomRight{5, 5};
+const Vec2 kBottomLeft{0, 5};
+const Vec2 kBoxSize{5, 5};
 
 class PrimitiveAssemblerTester : public PrimitiveAssembler {
  public:
@@ -93,7 +93,6 @@ TEST(PrimitiveAssembler, ComplexShapes) {
   PickingManager pm;
   PrimitiveAssemblerTester primitive_assembler_tester(&pm);
   std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
-  std::unique_ptr<PickingUserData> picking_user_data;
 
   // AddShadedBox -> Should be just a box with shaded color.
   primitive_assembler_tester.AddShadedBox(kTopLeft, kBoxSize, 0, kFakeColor);

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -125,7 +125,7 @@ TEST(PrimitiveAssembler, ComplexShapes) {
   // AddShadedTrapezium -> 2 Triangles
   Vec2 kTopCentred = {(kTopLeft[0] + kTopRight[0]) / 2.f, kTopLeft[1]};
   primitive_assembler_tester.AddShadedTrapezium(
-      {{kTopLeft, kTopCentred, kBottomRight, kBottomLeft}, 0}, kFakeColor,
+      Tetragon{{kTopLeft, kTopCentred, kBottomRight, kBottomLeft}, 0}, kFakeColor,
       std::make_unique<PickingUserData>());
   EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), 2);
   EXPECT_EQ(primitive_assembler_tester.GetNumElements(), 2);
@@ -135,7 +135,7 @@ TEST(PrimitiveAssembler, ComplexShapes) {
 
   // AddTetragonBorder -> 4 Lines
   primitive_assembler_tester.AddTetragonBorder(
-      {{kBottomRight, kBottomLeft, kTopLeft, kTopRight}, 0}, kFakeColor,
+      Tetragon{{kBottomRight, kBottomLeft, kTopLeft, kTopRight}, 0}, kFakeColor,
       std::make_unique<PickingUserData>());
   EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 4);
   EXPECT_EQ(primitive_assembler_tester.GetNumElements(), 4);

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -12,6 +12,13 @@ namespace orbit_gl {
 
 namespace {
 
+Color kFakeColor{42, 42, 128, 43};
+Vec2 kTopLeft{0, 0};
+Vec2 kTopRight{5, 0};
+Vec2 kBottomRight{5, 5};
+Vec2 kBottomLeft{0, 5};
+Vec2 kBoxSize{5, 5};
+
 class PrimitiveAssemblerTester : public PrimitiveAssembler {
  public:
   explicit PrimitiveAssemblerTester(PickingManager* picking_manager = nullptr)
@@ -20,6 +27,9 @@ class PrimitiveAssemblerTester : public PrimitiveAssembler {
   [[nodiscard]] uint32_t GetNumTriangles() const { return mock_batcher_.GetNumTriangles(); }
   [[nodiscard]] uint32_t GetNumBoxes() const { return mock_batcher_.GetNumBoxes(); }
   [[nodiscard]] uint32_t GetNumElements() const { return mock_batcher_.GetNumElements(); }
+  [[nodiscard]] bool IsEverythingInsideRectangle(Vec2 pos, Vec2 size) const {
+    return mock_batcher_.IsEverythingInsideRectangle(pos, size);
+  }
 
  private:
   MockBatcher mock_batcher_;
@@ -28,7 +38,7 @@ class PrimitiveAssemblerTester : public PrimitiveAssembler {
 }  // namespace
 
 // TODO(http://b/228063067): Test all methods in Primitive Assembler
-TEST(PrimitiveAssembler, NullPickingManager) {
+TEST(PrimitiveAssembler, PickableInNullPickingManager) {
   PrimitiveAssemblerTester primitive_assembler_tester;
   std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
   EXPECT_DEATH(primitive_assembler_tester.AddLine(Vec2(0, 0), Vec2(1, 0), 0,
@@ -36,16 +46,19 @@ TEST(PrimitiveAssembler, NullPickingManager) {
                "nullptr");
 }
 
+TEST(PrimitiveAssembler, StartNewFrame) {
+  PrimitiveAssemblerTester primitive_assembler_tester;
+  primitive_assembler_tester.AddLine(kTopLeft, kTopRight, 0, kFakeColor);
+  EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 1);
+
+  primitive_assembler_tester.StartNewFrame();
+  EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 0);
+}
+
 TEST(PrimitiveAssembler, BasicAdditions) {
   PickingManager pm;
   PrimitiveAssemblerTester primitive_assembler_tester(&pm);
   std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
-
-  Color kFakeColor{42, 42, 128, 43};
-  Vec2 kTopLeft{0, 0};
-  Vec2 kTopRight{5, 0};
-  Vec2 kBottomRight{5, 5};
-  Vec2 kBottomLeft{0, 5};
 
   constexpr uint32_t kNumLines = 4;
   constexpr uint32_t kNumTriangles = 2;
@@ -72,8 +85,73 @@ TEST(PrimitiveAssembler, BasicAdditions) {
   primitive_assembler_tester.AddBox(kFakeBox, kFakeColor);
   primitive_assembler_tester.AddBox(kFakeBox, kFakeColor, pickable);
   EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), kNumBoxes);
-
   EXPECT_EQ(primitive_assembler_tester.GetNumElements(), kNumLines + kNumTriangles + kNumBoxes);
+  EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(kTopLeft, kBoxSize));
+}
+
+TEST(PrimitiveAssembler, ComplexShapes) {
+  PickingManager pm;
+  PrimitiveAssemblerTester primitive_assembler_tester(&pm);
+  std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
+  std::unique_ptr<PickingUserData> picking_user_data;
+
+  // AddShadedBox -> Should be just a box with shaded color.
+  primitive_assembler_tester.AddShadedBox(kTopLeft, kBoxSize, 0, kFakeColor);
+  primitive_assembler_tester.AddShadedBox(kTopLeft, kBoxSize, 0, kFakeColor,
+                                          ShadingDirection::kRightToLeft);
+  primitive_assembler_tester.AddShadedBox(kTopLeft, kBoxSize, 0, kFakeColor,
+                                          std::make_unique<PickingUserData>(),
+                                          ShadingDirection::kTopToBottom);
+  primitive_assembler_tester.AddShadedBox(kTopLeft, kBoxSize, 0, kFakeColor, pickable,
+                                          ShadingDirection::kLeftToRight);
+  EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), 4);
+  EXPECT_EQ(primitive_assembler_tester.GetNumElements(), 4);
+  EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(kTopLeft, kBoxSize));
+
+  primitive_assembler_tester.StartNewFrame();
+
+  constexpr float kRoundedRadius = 2.f;
+
+  // AddRoundedBox -> 3 boxes + 4 rounding corners
+  primitive_assembler_tester.AddRoundedBox(kTopLeft, kBoxSize, 0, kRoundedRadius, kFakeColor);
+  EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), 3);
+  EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(),
+            4 * primitive_assembler_tester.kNumArcSides);
+  EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 0);
+  EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(kTopLeft, kBoxSize));
+
+  primitive_assembler_tester.StartNewFrame();
+
+  // TODO(b/227744958) This should probably be removed and AddBox should be used instead
+  // AddShadedTrapezium -> 2 Triangles
+  Vec2 kTopCentred = {(kTopLeft[0] + kTopRight[0]) / 2.f, kTopLeft[1]};
+  primitive_assembler_tester.AddShadedTrapezium(
+      {{kTopLeft, kTopCentred, kBottomRight, kBottomLeft}, 0}, kFakeColor,
+      std::make_unique<PickingUserData>());
+  EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), 2);
+  EXPECT_EQ(primitive_assembler_tester.GetNumElements(), 2);
+  EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(kTopLeft, kBoxSize));
+
+  primitive_assembler_tester.StartNewFrame();
+
+  // AddTetragonBorder -> 4 Lines
+  primitive_assembler_tester.AddTetragonBorder(
+      {{kBottomRight, kBottomLeft, kTopLeft, kTopRight}, 0}, kFakeColor,
+      std::make_unique<PickingUserData>());
+  EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 4);
+  EXPECT_EQ(primitive_assembler_tester.GetNumElements(), 4);
+  EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(kTopLeft, kBoxSize));
+
+  primitive_assembler_tester.StartNewFrame();
+
+  // AddCircle -> several Triangles
+  primitive_assembler_tester.AddCircle(kBottomRight, kRoundedRadius, 0, kFakeColor);
+  EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), PrimitiveAssembler::kCirclePoints);
+  EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 0);
+  EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), 0);
+  EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(
+      kBottomRight - Vec2{kRoundedRadius, kRoundedRadius},
+      {kRoundedRadius * 2.f, kRoundedRadius * 2.f}));
 }
 
 }  // namespace orbit_gl


### PR DESCRIPTION
In this PR I'm improving tests in PrimitiveAssemblerTest to test all
the possible additions for the PrimitiveAssembler.

For all the basic and combination methods we are testing the number of
calls we do to the Batcher and also if everything is inside the
rectangle that it should be.

Test are pretty basic though, I'm always using the same coordinates but
it should be enough.

- I'm adding a method to construct a Tetragon.
- I moved some non-publicly used methods in PrimitiveAssembler to be private.

http://b/228063067