### PR TITLE
Refactor some PE/COFF unwinding classes to use clear interfaces

### DIFF
--- a/third_party/libunwindstack/PeCoffRuntimeFunctions.cpp
+++ b/third_party/libunwindstack/PeCoffRuntimeFunctions.cpp
@@ -16,9 +16,28 @@
 
 #include "PeCoffRuntimeFunctions.h"
 
+#include <memory>
+
 namespace unwindstack {
 
-bool PeCoffRuntimeFunctions::Init(uint64_t pdata_begin, uint64_t pdata_end) {
+class PeCoffRuntimeFunctionsImpl : public PeCoffRuntimeFunctions {
+ public:
+  explicit PeCoffRuntimeFunctionsImpl(Memory* object_file_memory)
+      : pe_coff_memory_(object_file_memory) {}
+
+  bool Init(uint64_t pdata_begin, uint64_t pdata_end) override;
+  bool FindRuntimeFunction(uint64_t pc_rva, RuntimeFunction* runtime_function) const override;
+
+ private:
+  PeCoffMemory pe_coff_memory_;
+  std::vector<RuntimeFunction> runtime_functions_;
+};
+
+std::unique_ptr<PeCoffRuntimeFunctions> CreatePeCoffRuntimeFunctions(Memory* object_file_memory) {
+  return std::make_unique<PeCoffRuntimeFunctionsImpl>(object_file_memory);
+}
+
+bool PeCoffRuntimeFunctionsImpl::Init(uint64_t pdata_begin, uint64_t pdata_end) {
   // Since pdata_begin and pdata_end are read from the file, we can't CHECK here.
   if (pdata_end < pdata_begin) {
     last_error_.code = ERROR_INVALID_COFF;
@@ -31,10 +50,10 @@ bool PeCoffRuntimeFunctions::Init(uint64_t pdata_begin, uint64_t pdata_end) {
   }
 
   runtime_functions_.resize(pdata_size / sizeof(RuntimeFunction));
-  pe_coff_memory_->set_cur_offset(pdata_begin);
-  if (!pe_coff_memory_->GetFully(static_cast<void*>(&runtime_functions_[0]), pdata_size)) {
+  pe_coff_memory_.set_cur_offset(pdata_begin);
+  if (!pe_coff_memory_.GetFully(static_cast<void*>(&runtime_functions_[0]), pdata_size)) {
     last_error_.code = ERROR_MEMORY_INVALID;
-    last_error_.address = pe_coff_memory_->cur_offset();
+    last_error_.address = pe_coff_memory_.cur_offset();
     return false;
   }
   return true;
@@ -45,8 +64,8 @@ bool PeCoffRuntimeFunctions::Init(uint64_t pdata_begin, uint64_t pdata_end) {
 // (https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64). Using a binary search here
 // for performance makes a huge difference (as opposed to a linear search) as this function is
 // called on every unwinding step and there can be a lot of entries in the vector.
-bool PeCoffRuntimeFunctions::FindRuntimeFunction(uint64_t pc_rva,
-                                                 RuntimeFunction* runtime_function) const {
+bool PeCoffRuntimeFunctionsImpl::FindRuntimeFunction(uint64_t pc_rva,
+                                                     RuntimeFunction* runtime_function) const {
   size_t begin = 0;
   size_t end = runtime_functions_.size();
   while (begin < end) {

--- a/third_party/libunwindstack/PeCoffRuntimeFunctions.h
+++ b/third_party/libunwindstack/PeCoffRuntimeFunctions.h
@@ -17,6 +17,7 @@
 #ifndef _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H
 #define _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H
 
+#include <memory>
 #include <vector>
 
 #include "unwindstack/Error.h"
@@ -35,19 +36,17 @@ struct RuntimeFunction {
 // The RUNTIME_FUNCTION struct, and thus PeCoffRuntimeFunctions, is only used on x86_64.
 class PeCoffRuntimeFunctions {
  public:
-  explicit PeCoffRuntimeFunctions(PeCoffMemory* pe_coff_memory) : pe_coff_memory_(pe_coff_memory) {}
+  virtual ~PeCoffRuntimeFunctions() {}
+  virtual bool Init(uint64_t pdata_begin, uint64_t pdata_end) = 0;
+  virtual bool FindRuntimeFunction(uint64_t pc_rva, RuntimeFunction* runtime_function) const = 0;
 
-  bool Init(uint64_t pdata_begin, uint64_t pdata_end);
-  bool FindRuntimeFunction(uint64_t pc_rva, RuntimeFunction* runtime_function) const;
   ErrorData GetLastError() const { return last_error_; }
 
- private:
-  PeCoffMemory* pe_coff_memory_;
-
+ protected:
   ErrorData last_error_{ERROR_NONE, 0};
-
-  std::vector<RuntimeFunction> runtime_functions_;
 };
+
+std::unique_ptr<PeCoffRuntimeFunctions> CreatePeCoffRuntimeFunctions(Memory* object_file_memory);
 
 }  // namespace unwindstack
 

--- a/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.h
@@ -41,8 +41,8 @@ enum UnwindOpCode : uint8_t {
 
 class PeCoffUnwindInfoUnwinderX86_64 {
  public:
-  explicit PeCoffUnwindInfoUnwinderX86_64(PeCoffMemory* pe_coff_memory)
-      : unwind_infos_(new PeCoffUnwindInfos(pe_coff_memory)) {}
+  explicit PeCoffUnwindInfoUnwinderX86_64(Memory* object_file_memory)
+      : unwind_infos_(CreatePeCoffUnwindInfos(object_file_memory)) {}
 
   // This function should only be called when we know that we are not in the epilog of the function.
   // If one attempts to unwind using this when one is actually on an instruction in the epilog, the

--- a/third_party/libunwindstack/PeCoffUnwindInfos.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.cpp
@@ -16,9 +16,29 @@
 
 #include "PeCoffUnwindInfos.h"
 
+#include <memory>
+#include <unordered_map>
+
 namespace unwindstack {
 
-bool PeCoffUnwindInfos::GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindInfo* unwind_info) {
+class PeCoffUnwindInfosImpl : public PeCoffUnwindInfos {
+ public:
+  explicit PeCoffUnwindInfosImpl(Memory* memory) : pe_coff_memory_(memory) {}
+  bool GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindInfo* unwind_info) override;
+
+ private:
+  bool ParseUnwindInfoAtOffset(uint64_t file_offset, UnwindInfo* unwind_info);
+  PeCoffMemory pe_coff_memory_;
+  // This is a cache of unwind infos.
+  std::unordered_map<uint64_t, UnwindInfo> unwind_info_offset_to_unwind_info_;
+};
+
+std::unique_ptr<PeCoffUnwindInfos> CreatePeCoffUnwindInfos(Memory* memory) {
+  return std::make_unique<PeCoffUnwindInfosImpl>(memory);
+}
+
+bool PeCoffUnwindInfosImpl::GetUnwindInfo(uint64_t unwind_info_file_offset,
+                                          UnwindInfo* unwind_info) {
   const auto& it = unwind_info_offset_to_unwind_info_.find(unwind_info_file_offset);
   if (it != unwind_info_offset_to_unwind_info_.end()) {
     *unwind_info = it->second;
@@ -35,14 +55,14 @@ bool PeCoffUnwindInfos::GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindIn
   return true;
 }
 
-bool PeCoffUnwindInfos::ParseUnwindInfoAtOffset(uint64_t offset, UnwindInfo* unwind_info) {
+bool PeCoffUnwindInfosImpl::ParseUnwindInfoAtOffset(uint64_t offset, UnwindInfo* unwind_info) {
   // Need to remember the original offset for later
   const uint64_t base_offset = offset;
 
   constexpr uint64_t kUnwindInfoHeaderSize = 4;
   std::vector<uint8_t> data_info(kUnwindInfoHeaderSize);
-  pe_coff_memory_->set_cur_offset(offset);
-  if (!pe_coff_memory_->GetFully(static_cast<void*>(&data_info[0]), kUnwindInfoHeaderSize)) {
+  pe_coff_memory_.set_cur_offset(offset);
+  if (!pe_coff_memory_.GetFully(static_cast<void*>(&data_info[0]), kUnwindInfoHeaderSize)) {
     last_error_.code = ERROR_MEMORY_INVALID;
     last_error_.address = offset;
     return false;
@@ -60,11 +80,11 @@ bool PeCoffUnwindInfos::ParseUnwindInfoAtOffset(uint64_t offset, UnwindInfo* unw
   }
 
   unwind_info->unwind_codes.resize(unwind_info->num_codes);
-  pe_coff_memory_->set_cur_offset(offset + kUnwindInfoHeaderSize);
-  if (!pe_coff_memory_->GetFully(static_cast<void*>(&unwind_info->unwind_codes[0]),
-                                 unwind_info->num_codes * sizeof(UnwindCode))) {
+  pe_coff_memory_.set_cur_offset(offset + kUnwindInfoHeaderSize);
+  if (!pe_coff_memory_.GetFully(static_cast<void*>(&unwind_info->unwind_codes[0]),
+                                unwind_info->num_codes * sizeof(UnwindCode))) {
     last_error_.code = ERROR_MEMORY_INVALID;
-    last_error_.address = pe_coff_memory_->cur_offset();
+    last_error_.address = pe_coff_memory_.cur_offset();
     return false;
   }
 
@@ -79,12 +99,12 @@ bool PeCoffUnwindInfos::ParseUnwindInfoAtOffset(uint64_t offset, UnwindInfo* unw
         base_offset + kUnwindInfoHeaderSize +
         ((unwind_info->num_codes + 1) & ~1) * sizeof(UnwindCode);
 
-    pe_coff_memory_->set_cur_offset(runtime_function_offset);
-    if (!pe_coff_memory_->Get32(&(unwind_info->chained_info.start_address)) ||
-        !pe_coff_memory_->Get32(&(unwind_info->chained_info.end_address)) ||
-        !pe_coff_memory_->Get32(&(unwind_info->chained_info.unwind_info_offset))) {
+    pe_coff_memory_.set_cur_offset(runtime_function_offset);
+    if (!pe_coff_memory_.Get32(&(unwind_info->chained_info.start_address)) ||
+        !pe_coff_memory_.Get32(&(unwind_info->chained_info.end_address)) ||
+        !pe_coff_memory_.Get32(&(unwind_info->chained_info.unwind_info_offset))) {
       last_error_.code = ERROR_MEMORY_INVALID;
-      last_error_.address = pe_coff_memory_->cur_offset();
+      last_error_.address = pe_coff_memory_.cur_offset();
       return false;
     }
   }

--- a/third_party/libunwindstack/PeCoffUnwindInfos.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.h
@@ -18,7 +18,7 @@
 #define _LIBUNWINDSTACK_PE_COFF_UNWIND_INFOS_H
 
 #include <string.h>
-#include <unordered_map>
+#include <memory>
 #include <vector>
 
 #include "PeCoffRuntimeFunctions.h"
@@ -68,24 +68,20 @@ struct UnwindInfo {
 
 class PeCoffUnwindInfos {
  public:
-  explicit PeCoffUnwindInfos(PeCoffMemory* pe_coff_memory) : pe_coff_memory_(pe_coff_memory) {}
+  virtual ~PeCoffUnwindInfos() {}
 
   // The value 'unwind_info_file_offset' is the file offset derived from the unwind info
   // offset in the RUNTIME_FUNCTION struct, which is a relative virtual address (RVA). Computing the
   // file offset from the unwind info RVA requires knowledge about the sections of the file, which
   // the class using 'PeCoffUnwindInfos' must use to pass in the right value here.
-  bool GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindInfo* unwind_info);
+  virtual bool GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindInfo* unwind_info) = 0;
   ErrorData GetLastError() const { return last_error_; }
 
- private:
-  bool ParseUnwindInfoAtOffset(uint64_t file_offset, UnwindInfo* unwind_info);
-
-  PeCoffMemory* pe_coff_memory_;
+ protected:
   ErrorData last_error_{ERROR_NONE, 0};
-
-  // This is a cache of unwind infos.
-  std::unordered_map<uint64_t, UnwindInfo> unwind_info_offset_to_unwind_info_;
 };
+
+std::unique_ptr<PeCoffUnwindInfos> CreatePeCoffUnwindInfos(Memory* object_file_memory);
 
 }  // namespace unwindstack
 

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
@@ -34,7 +34,7 @@ class PeCoffUnwindInfoUnwinderX86_64Test : public ::testing::Test {
  public:
   PeCoffUnwindInfoUnwinderX86_64Test()
       : object_file_memory_fake_(new MemoryFake),
-        unwinder_(new PeCoffMemory(object_file_memory_fake_.get())),
+        unwinder_(object_file_memory_fake_.get()),
         process_mem_fake_(new MemoryFake) {}
   ~PeCoffUnwindInfoUnwinderX86_64Test() {}
 

--- a/third_party/libunwindstack/tests/fuzz/PeCoffRuntimeFunctionsFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffRuntimeFunctionsFuzzer.cpp
@@ -16,6 +16,7 @@
 
 #include <inttypes.h>
 #include <cstddef>
+#include <memory>
 
 #include <unwindstack/Memory.h>
 #include <unwindstack/PeCoffInterface.h>
@@ -25,9 +26,9 @@ namespace {
 void FuzzPeCoffRuntimeFunctions(const uint8_t* data, size_t size) {
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(data, 0, size);
-  unwindstack::PeCoffMemory pe_coff_memory(memory.get());
-  unwindstack::PeCoffRuntimeFunctions pe_coff_runtime_functions(&pe_coff_memory);
-  pe_coff_runtime_functions.Init(0, size);
+  std::unique_ptr<unwindstack::PeCoffRuntimeFunctions> pe_coff_runtime_functions(
+      CreatePeCoffRuntimeFunctions(memory.get()));
+  pe_coff_runtime_functions->Init(0, size);
 }
 }  // namespace
 

--- a/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
@@ -16,6 +16,7 @@
 
 #include <inttypes.h>
 #include <cstddef>
+#include <memory>
 
 #include <unwindstack/Memory.h>
 #include <unwindstack/PeCoffInterface.h>
@@ -25,13 +26,13 @@ namespace {
 void FuzzPeCoffUnwindInfos(const uint8_t* data, size_t size) {
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(data, 0, size);
-  unwindstack::PeCoffMemory pe_coff_memory(memory.get());
-  unwindstack::PeCoffUnwindInfos pe_coff_unwind_infos(&pe_coff_memory);
+  std::unique_ptr<unwindstack::PeCoffUnwindInfos> pe_coff_unwind_infos(
+      CreatePeCoffUnwindInfos(memory.get()));
   unwindstack::UnwindInfo info;
   // Try all possible offsets to increase coverage. This will also test the parser
   // running over the end of the memory.
   for (size_t offset = 0; offset < size; ++offset) {
-    pe_coff_unwind_infos.GetUnwindInfo(offset, &info);
+    pe_coff_unwind_infos->GetUnwindInfo(offset, &info);
   }
 }
 }  // namespace


### PR DESCRIPTION
This is a mostly mechanical refactor to better support mocking for
tests for the unwinder that integrates all these parts (to be added
later).

Tested: Unit tests pass.
Bug: http://b/194768602