### PR TITLE
Find symbols locally off main

### DIFF
--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(
   ObjectUtils
   PUBLIC GrpcProtos
          OrbitBase
+         Introspection
          CONAN_PKG::abseil
          CONAN_PKG::llvm-core)
 

--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -17,6 +17,7 @@
 #include <system_error>
 
 #include "GrpcProtos/symbol.pb.h"
+#include "Introspection/Introspection.h"
 #include "ObjectUtils/WindowsBuildIdUtils.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
@@ -206,6 +207,7 @@ ErrorMessageOr<std::unique_ptr<CoffFile>> CreateCoffFile(const std::filesystem::
 ErrorMessageOr<std::unique_ptr<CoffFile>> CreateCoffFile(
     const std::filesystem::path& file_path,
     llvm::object::OwningBinary<llvm::object::ObjectFile>&& file) {
+  ORBIT_SCOPE_FUNCTION;
   llvm::object::COFFObjectFile* coff_object_file =
       llvm::dyn_cast<llvm::object::COFFObjectFile>(file.getBinary());
   if (coff_object_file != nullptr) {

--- a/src/ObjectUtils/ElfFile.cpp
+++ b/src/ObjectUtils/ElfFile.cpp
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "GrpcProtos/symbol.pb.h"
+#include "Introspection/Introspection.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
@@ -634,6 +635,7 @@ ErrorMessageOr<std::unique_ptr<ElfFile>> CreateElfFile(const std::filesystem::pa
 ErrorMessageOr<std::unique_ptr<ElfFile>> CreateElfFile(
     const std::filesystem::path& file_path,
     llvm::object::OwningBinary<llvm::object::ObjectFile>&& file) {
+  ORBIT_SCOPE_FUNCTION;
   llvm::object::ObjectFile* object_file = file.getBinary();
 
   // Create appropriate ElfFile implementation

--- a/src/ObjectUtils/ObjectFile.cpp
+++ b/src/ObjectUtils/ObjectFile.cpp
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "GrpcProtos/symbol.pb.h"
+#include "Introspection/Introspection.h"
 #include "ObjectUtils/CoffFile.h"
 #include "ObjectUtils/ElfFile.h"
 #include "OrbitBase/Result.h"
@@ -21,6 +22,7 @@ namespace orbit_object_utils {
 
 ErrorMessageOr<std::unique_ptr<ObjectFile>> CreateObjectFile(
     const std::filesystem::path& file_path) {
+  ORBIT_SCOPE_FUNCTION;
   // TODO(hebecker): Remove this explicit construction of StringRef when we switch to LLVM10.
   const std::string file_path_str = file_path.string();
   const llvm::StringRef file_path_llvm{file_path_str};

--- a/src/ObjectUtils/PdbFileDia.cpp
+++ b/src/ObjectUtils/PdbFileDia.cpp
@@ -9,6 +9,7 @@
 #include <llvm/Demangle/Demangle.h>
 #include <winerror.h>
 
+#include "Introspection/Introspection.h"
 #include "ObjectUtils/PdbUtilsDia.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
@@ -131,6 +132,7 @@ ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> PdbFileDia::LoadDebugSymbols() 
 
 ErrorMessageOr<std::unique_ptr<PdbFile>> PdbFileDia::CreatePdbFile(
     const std::filesystem::path& file_path, const ObjectFileInfo& object_file_info) {
+  ORBIT_SCOPE_FUNCTION;
   auto pdb_file_dia = absl::WrapUnique<PdbFileDia>(new PdbFileDia(file_path, object_file_info));
   auto result = pdb_file_dia->LoadDataForPDB();
   if (result.has_error()) {

--- a/src/ObjectUtils/SymbolsFile.cpp
+++ b/src/ObjectUtils/SymbolsFile.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "Introspection/Introspection.h"
 #include "ObjectUtils/ObjectFile.h"
 #include "ObjectUtils/PdbFile.h"
 #include "OrbitBase/File.h"
@@ -19,6 +20,7 @@ namespace orbit_object_utils {
 
 ErrorMessageOr<std::unique_ptr<SymbolsFile>> CreateSymbolsFile(
     const std::filesystem::path& file_path, const ObjectFileInfo& object_file_info) {
+  ORBIT_SCOPE_FUNCTION;
   std::string error_message{
       absl::StrFormat("Unable to create symbols file from \"%s\".", file_path.string())};
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1797,34 +1797,40 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
     return it->second;
   }
 
-  auto local_symbols_path = FindModuleLocally(*module_data);
-
-  if (local_symbols_path.has_value()) {
-    return local_symbols_path;
-  }
+  Future<ErrorMessageOr<std::filesystem::path>> local_symbols_future =
+      FindModuleLocally(module_data);
 
   // TODO(b/177304549): [new UI] maybe come up with a better indicator whether orbit is connected
   // than process_manager != nullptr
   if (absl::GetFlag(FLAGS_local) || GetProcessManager() == nullptr) {
-    return local_symbols_path;
+    return local_symbols_future;
   }
 
-  auto final_result =
-      RetrieveModuleFromRemote(module_path)
-          .Then(main_thread_executor_,
-                [this, module_id, local_error_message = local_symbols_path.error().message()](
-                    const ErrorMessageOr<std::filesystem::path>& remote_result)
-                    -> ErrorMessageOr<std::filesystem::path> {
-                  modules_currently_loading_.erase(module_id);
+  Future<ErrorMessageOr<std::filesystem::path>> final_result =
+      orbit_base::UnwrapFuture(local_symbols_future.Then(
+          main_thread_executor_,
+          [this, module_id](ErrorMessageOr<std::filesystem::path> local_symbols_path)
+              -> Future<ErrorMessageOr<std::filesystem::path>> {
+            if (local_symbols_path.has_value()) {
+              return local_symbols_path;
+            }
 
-                  // If remote loading fails as well, we combine the error messages.
-                  if (remote_result.has_value()) return remote_result;
-                  return {ErrorMessage{
-                      absl::StrFormat("Did not find symbols locally or on remote for module \"%s\" "
-                                      "with build_id=\"%s\": %s\n%s",
-                                      module_id.first, module_id.second, local_error_message,
-                                      remote_result.error().message())}};
-                });
+            return RetrieveModuleFromRemote(module_id.first)
+                .Then(main_thread_executor_,
+                      [this, module_id, local_error_message = local_symbols_path.error().message()](
+                          const ErrorMessageOr<std::filesystem::path>& remote_result)
+                          -> ErrorMessageOr<std::filesystem::path> {
+                        modules_currently_loading_.erase(module_id);
+
+                        // If remote loading fails as well, we combine the error messages.
+                        if (remote_result.has_value()) return remote_result;
+                        return {ErrorMessage{
+                            absl::StrFormat("Did not find symbols locally or on remote for module "
+                                            "\"%s\" with build_id=\"%s\": %s\n%s",
+                                            module_id.first, module_id.second, local_error_message,
+                                            remote_result.error().message())}};
+                      });
+          }));
 
   modules_currently_loading_.emplace(module_id, final_result);
   return final_result;
@@ -1936,11 +1942,17 @@ static ErrorMessageOr<std::filesystem::path> FindModuleLocallyImpl(
   return ErrorMessage(error_message);
 }
 
-ErrorMessageOr<std::filesystem::path> OrbitApp::FindModuleLocally(const ModuleData& module_data) {
+Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::FindModuleLocally(
+    const ModuleData* module_data) {
   ORBIT_SCOPE_FUNCTION;
-  const auto scoped_status = CreateScopedStatus(absl::StrFormat(
-      "Searching for symbols on local machine for module: \"%s\"...", module_data.file_path()));
-  return FindModuleLocallyImpl(symbol_helper_, module_data);
+  auto scoped_status = CreateScopedStatus(absl::StrFormat(
+      "Searching for symbols on local machine for module: \"%s\"...", module_data->file_path()));
+  return thread_pool_->Schedule(
+      [this, module_data,
+       scoped_status = std::move(scoped_status)]() -> ErrorMessageOr<std::filesystem::path> {
+        const ModuleData& module_data_ref{*module_data};
+        return FindModuleLocallyImpl(symbol_helper_, module_data_ref);
+      });
 }
 
 void OrbitApp::AddSymbols(const std::filesystem::path& module_file_path,

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1635,6 +1635,7 @@ void OrbitApp::SendErrorToUi(const std::string& title, const std::string& text) 
 
 orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModuleFromRemote(
     const std::string& module_file_path) {
+  ORBIT_SCOPE_FUNCTION;
   ScopedStatus scoped_status = CreateScopedStatus(absl::StrFormat(
       "Searching for symbols on remote instance for module \"%s\"...", module_file_path));
 
@@ -1700,7 +1701,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 
@@ -1753,6 +1754,7 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::RetrieveModuleAndLoadSymbols(
 
 orbit_base::Future<ErrorMessageOr<void>> OrbitApp::RetrieveModuleAndLoadSymbols(
     const std::string& module_path, const std::string& build_id) {
+  ORBIT_SCOPE_FUNCTION;
   ScopedMetric metric(metrics_uploader_, OrbitLogEvent::ORBIT_SYMBOL_LOAD);
 
   const ModuleData* const module_data = GetModuleByPathAndBuildId(module_path, build_id);
@@ -1781,6 +1783,7 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::RetrieveModuleAndLoadSymbols(
 
 orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModule(
     const std::string& module_path, const std::string& build_id) {
+  ORBIT_SCOPE_FUNCTION;
   const ModuleData* module_data = GetModuleByPathAndBuildId(module_path, build_id);
 
   if (module_data == nullptr) {
@@ -1874,6 +1877,7 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
 
 static ErrorMessageOr<std::filesystem::path> FindModuleLocallyImpl(
     const orbit_symbols::SymbolHelper& symbol_helper, const ModuleData& module_data) {
+  ORBIT_SCOPE_FUNCTION;
   if (absl::GetFlag(FLAGS_enable_unsafe_symbols)) {
     // First checkout if a symbol file override exists and if it does, use it
     OUTCOME_TRY(std::optional<std::filesystem::path> overriden_symbols_file,
@@ -1933,6 +1937,7 @@ static ErrorMessageOr<std::filesystem::path> FindModuleLocallyImpl(
 }
 
 ErrorMessageOr<std::filesystem::path> OrbitApp::FindModuleLocally(const ModuleData& module_data) {
+  ORBIT_SCOPE_FUNCTION;
   const auto scoped_status = CreateScopedStatus(absl::StrFormat(
       "Searching for symbols on local machine for module: \"%s\"...", module_data.file_path()));
   return FindModuleLocallyImpl(symbol_helper_, module_data);
@@ -1941,6 +1946,7 @@ ErrorMessageOr<std::filesystem::path> OrbitApp::FindModuleLocally(const ModuleDa
 void OrbitApp::AddSymbols(const std::filesystem::path& module_file_path,
                           const std::string& module_build_id,
                           const orbit_grpc_protos::ModuleSymbols& module_symbols) {
+  ORBIT_SCOPE_FUNCTION;
   ModuleData* module_data =
       GetMutableModuleByPathAndBuildId(module_file_path.string(), module_build_id);
   module_data->AddSymbols(module_symbols);
@@ -1960,6 +1966,7 @@ void OrbitApp::AddSymbols(const std::filesystem::path& module_file_path,
 orbit_base::Future<ErrorMessageOr<void>> OrbitApp::LoadSymbols(
     const std::filesystem::path& symbols_path, const std::string& module_file_path,
     const std::string& module_build_id) {
+  ORBIT_SCOPE_FUNCTION;
   auto module_id = std::make_pair(module_file_path, module_build_id);
   const auto it = symbols_currently_loading_.find(module_id);
   if (it != symbols_currently_loading_.end()) {
@@ -2233,6 +2240,7 @@ void OrbitApp::ShowPresetInExplorer(const PresetFile& preset) {
 }
 
 void OrbitApp::UpdateProcessAndModuleList() {
+  ORBIT_SCOPE_FUNCTION;
   functions_data_view_->ClearFunctions();
 
   auto module_infos = thread_pool_->Schedule(
@@ -2542,6 +2550,7 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
 }
 
 void OrbitApp::UpdateAfterSymbolLoading() {
+  ORBIT_SCOPE_FUNCTION;
   if (!HasCaptureData()) {
     return;
   }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -552,8 +552,8 @@ class OrbitApp final : public DataViewFactory,
   void SelectFunctionsByName(const orbit_client_data::ModuleData* module,
                              absl::Span<const std::string> function_names);
 
-  ErrorMessageOr<std::filesystem::path> FindModuleLocally(
-      const orbit_client_data::ModuleData& module_data);
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> FindModuleLocally(
+      const orbit_client_data::ModuleData* module_data);
   [[nodiscard]] orbit_base::Future<ErrorMessageOr<void>> LoadSymbols(
       const std::filesystem::path& symbols_path, const std::string& module_file_path,
       const std::string& module_build_id);

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -147,6 +147,7 @@ static std::vector<fs::path> FindStructuredDebugDirectories() {
 
 ErrorMessageOr<void> SymbolHelper::VerifySymbolsFile(const fs::path& symbols_path,
                                                      const std::string& build_id) {
+  ORBIT_SCOPE_FUNCTION;
   auto symbols_file_or_error = CreateSymbolsFile(symbols_path, ObjectFileInfo());
   if (symbols_file_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Unable to load symbols file \"%s\", error: %s",
@@ -177,6 +178,7 @@ SymbolHelper::SymbolHelper(fs::path cache_directory)
 ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
     const fs::path& module_path, const std::string& build_id,
     const ModuleInfo::ObjectFileType& object_file_type, absl::Span<const fs::path> paths) const {
+  ORBIT_SCOPE_FUNCTION;
   if (build_id.empty()) {
     return ErrorMessage(absl::StrFormat(
         "Could not find symbols file for module \"%s\", because it does not contain a build id",
@@ -235,6 +237,7 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
 
 [[nodiscard]] ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsInCache(
     const fs::path& module_path, const std::string& build_id) const {
+  ORBIT_SCOPE_FUNCTION;
   fs::path cache_file_path = GenerateCachedFileName(module_path);
   std::error_code error;
   bool exists = fs::exists(cache_file_path, error);
@@ -313,6 +316,7 @@ ErrorMessageOr<fs::path> SymbolHelper::FindDebugInfoFileLocally(
 
 ErrorMessageOr<fs::path> SymbolHelper::FindDebugInfoFileInDebugStore(
     const fs::path& debug_directory, std::string_view build_id) {
+  ORBIT_SCOPE_FUNCTION;
   // Since the first two digits form the name of a sub-directory, we will need at least 3 digits to
   // generate a proper filename: build_id[0:2]/build_id[2:].debug
   if (build_id.size() < 3) {


### PR DESCRIPTION
I noticed the UI freezing on my system in certain symbol loading situations. I investigated with introspection and added some scopes for that. I think they are valuable so I left them in as a first commit. The outcome of the investigation was, that `CreateObjectFile` (specifically the llvm function `llvm::object::ObjectFile::createObjectFile`) can take a longer amount of time. In my tests slightly longer than 1 second. This makes the UI freeze, because before this change this was done on the main thread. The second commit fixes the UI freeze, by moving the local file search off the main thread. 