### PR TITLE
Clean up CaptureSync

### DIFF
--- a/src/CaptureClient/CMakeLists.txt
+++ b/src/CaptureClient/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(CaptureClient PUBLIC
         include/CaptureClient/CaptureClient.h
         include/CaptureClient/CaptureListener.h
         include/CaptureClient/CaptureEventProcessor.h
+        include/CaptureClient/ClientCaptureOptions.h
         include/CaptureClient/GpuQueueSubmissionProcessor.h)
 
 target_sources(CaptureClient PRIVATE

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -45,18 +45,73 @@ using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
 
 using orbit_base::Future;
 
+// This is specifically for the code review, so that the diff is easy to read. Will move the
+// function before merging the PR.
+[[nodiscard]] std::vector<ApiFunction> FindApiFunctions(
+    const orbit_client_data::ModuleManager& module_manager);
+
+namespace {
+
+[[nodiscard]] orbit_grpc_protos::CaptureOptions ToGrpcCaptureOptions(
+    const CaptureClientOptions& options, const orbit_client_data::ModuleManager& module_manager) {
+  CaptureOptions capture_options;
+  capture_options.set_trace_context_switches(options.collect_scheduling_info);
+  capture_options.set_pid(options.process_id);
+  ORBIT_CHECK(options.unwinding_method != CaptureOptions::kUndefined);
+  capture_options.set_unwinding_method(options.unwinding_method);
+  capture_options.set_stack_dump_size(options.stack_dump_size);
+  capture_options.set_samples_per_second(options.samples_per_second);
+
+  capture_options.set_collect_memory_info(options.collect_memory_info);
+  constexpr const uint64_t kMsToNs = 1'000'000;
+  capture_options.set_memory_sampling_period_ns(options.memory_sampling_period_ms * kMsToNs);
+
+  capture_options.set_trace_thread_state(options.collect_thread_states);
+  capture_options.set_trace_gpu_driver(options.collect_gpu_jobs);
+  capture_options.set_max_local_marker_depth_per_command_buffer(
+      options.max_local_marker_depth_per_command_buffer);
+
+  for (const auto& [function_id, function] : options.selected_functions) {
+    InstrumentedFunction* instrumented_function = capture_options.add_instrumented_functions();
+    instrumented_function->set_file_path(function.module_path());
+    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(function.module_path(),
+                                                                        function.module_build_id());
+    ORBIT_CHECK(module != nullptr);
+    instrumented_function->set_file_offset(function.FileOffset(module->load_bias()));
+    instrumented_function->set_file_build_id(function.module_build_id());
+    instrumented_function->set_function_id(function_id);
+    instrumented_function->set_function_size(function.size());
+    instrumented_function->set_function_name(function.pretty_name());
+    instrumented_function->set_record_arguments(options.record_arguments);
+    instrumented_function->set_record_return_value(options.record_return_values);
+  }
+
+  for (const auto& tracepoint : options.selected_tracepoints) {
+    TracepointInfo* instrumented_tracepoint = capture_options.add_instrumented_tracepoint();
+    instrumented_tracepoint->set_category(tracepoint.category());
+    instrumented_tracepoint->set_name(tracepoint.name());
+  }
+
+  capture_options.set_enable_api(options.enable_api);
+  capture_options.set_enable_introspection(options.enable_introspection);
+  ORBIT_CHECK(options.dynamic_instrumentation_method == CaptureOptions::kKernelUprobes ||
+              options.dynamic_instrumentation_method == CaptureOptions::kUserSpaceInstrumentation);
+  capture_options.set_dynamic_instrumentation_method(options.dynamic_instrumentation_method);
+
+  auto api_functions = FindApiFunctions(module_manager);
+  *(capture_options.mutable_api_functions()) = {api_functions.begin(), api_functions.end()};
+
+  return capture_options;
+}
+
+}  // namespace
+
 // TODO(b/187170164): This method contains a lot of arguments. Consider making it more structured.
-Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
-    orbit_base::ThreadPool* thread_pool, uint32_t process_id,
+orbit_base::Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
+    orbit_base::ThreadPool* thread_pool,
+    std::unique_ptr<CaptureEventProcessor> capture_event_processor,
     const orbit_client_data::ModuleManager& module_manager,
-    absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions, bool record_arguments,
-    bool record_return_values, TracepointInfoSet selected_tracepoints, double samples_per_second,
-    uint16_t stack_dump_size, UnwindingMethod unwinding_method, bool collect_scheduling_info,
-    bool collect_thread_state, bool collect_gpu_jobs, bool enable_api, bool enable_introspection,
-    DynamicInstrumentationMethod dynamic_instrumentation_method,
-    uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
-    uint64_t memory_sampling_period_ms,
-    std::unique_ptr<CaptureEventProcessor> capture_event_processor) {
+    const CaptureClientOptions& capture_options) {
   absl::MutexLock lock(&state_mutex_);
   if (state_ != State::kStopped) {
     return {
@@ -67,32 +122,18 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
   state_ = State::kStarting;
   ORBIT_LOG("State is now kStarting");
 
-  auto capture_result = thread_pool->Schedule(
-      [this, process_id, &module_manager, selected_functions = std::move(selected_functions),
-       record_arguments, record_return_values,
-       selected_tracepoints = std::move(selected_tracepoints), samples_per_second, stack_dump_size,
-       unwinding_method, collect_scheduling_info, collect_thread_state, collect_gpu_jobs,
-       enable_api, enable_introspection, dynamic_instrumentation_method,
-       max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ms,
-       capture_event_processor = std::move(capture_event_processor)]() mutable {
-        return CaptureSync(process_id, module_manager, selected_functions, record_arguments,
-                           record_return_values, selected_tracepoints, samples_per_second,
-                           stack_dump_size, unwinding_method, collect_scheduling_info,
-                           collect_thread_state, collect_gpu_jobs, enable_api, enable_introspection,
-                           dynamic_instrumentation_method,
-                           max_local_marker_depth_per_command_buffer, collect_memory_info,
-                           memory_sampling_period_ms, capture_event_processor.get());
+  return thread_pool->Schedule(
+      [this, capture_event_processor = std::move(capture_event_processor),
+       grpc_capture_options = ToGrpcCaptureOptions(capture_options, module_manager)]() {
+        return CaptureSync(grpc_capture_options, capture_event_processor.get());
       });
-
-  return capture_result;
 }
 
 // Api functions are declared in Orbit.h. They are implemented in user code through the
 // ORBIT_API_INSTANTIATE macro. Those functions are used to query the tracee for Orbit specific
 // information, such as the memory location where Orbit should write function pointers to enable
 // the Api after having injected liborbit.so.
-[[nodiscard]] static std::vector<ApiFunction> FindApiFunctions(
-    const orbit_client_data::ModuleManager& module_manager) {
+std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager& module_manager) {
   // We have a different function name for each supported platform.
   static const std::vector<std::string> kOrbitApiGetFunctionTableAddressPrefixes{
       orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix,
@@ -126,14 +167,8 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
 }
 
 ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
-    uint32_t process_id, const orbit_client_data::ModuleManager& module_manager,
-    const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions, bool record_arguments,
-    bool record_return_values, const TracepointInfoSet& selected_tracepoints,
-    double samples_per_second, uint16_t stack_dump_size, UnwindingMethod unwinding_method,
-    bool collect_scheduling_info, bool collect_thread_state, bool collect_gpu_jobs, bool enable_api,
-    bool enable_introspection, DynamicInstrumentationMethod dynamic_instrumentation_method,
-    uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
-    uint64_t memory_sampling_period_ms, CaptureEventProcessor* capture_event_processor) {
+    orbit_grpc_protos::CaptureOptions capture_options,
+    CaptureEventProcessor* capture_event_processor) {
   ORBIT_SCOPE_FUNCTION;
   writes_done_failed_ = false;
   try_abort_ = false;
@@ -146,53 +181,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
   }
 
   CaptureRequest request;
-  CaptureOptions* capture_options = request.mutable_capture_options();
-  capture_options->set_trace_context_switches(collect_scheduling_info);
-  capture_options->set_pid(process_id);
-  ORBIT_CHECK(unwinding_method != CaptureOptions::kUndefined);
-  capture_options->set_unwinding_method(unwinding_method);
-  capture_options->set_stack_dump_size(stack_dump_size);
-  capture_options->set_samples_per_second(samples_per_second);
-
-  capture_options->set_collect_memory_info(collect_memory_info);
-  constexpr const uint64_t kMsToNs = 1'000'000;
-  capture_options->set_memory_sampling_period_ns(memory_sampling_period_ms * kMsToNs);
-
-  capture_options->set_trace_thread_state(collect_thread_state);
-  capture_options->set_trace_gpu_driver(collect_gpu_jobs);
-  capture_options->set_max_local_marker_depth_per_command_buffer(
-      max_local_marker_depth_per_command_buffer);
-  absl::flat_hash_map<uint64_t, InstrumentedFunction> instrumented_functions;
-  for (const auto& [function_id, function] : selected_functions) {
-    InstrumentedFunction* instrumented_function = capture_options->add_instrumented_functions();
-    instrumented_function->set_file_path(function.module_path());
-    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(function.module_path(),
-                                                                        function.module_build_id());
-    ORBIT_CHECK(module != nullptr);
-    instrumented_function->set_file_offset(function.FileOffset(module->load_bias()));
-    instrumented_function->set_file_build_id(function.module_build_id());
-    instrumented_function->set_function_id(function_id);
-    instrumented_function->set_function_size(function.size());
-    instrumented_function->set_function_name(function.pretty_name());
-    instrumented_function->set_record_arguments(record_arguments);
-    instrumented_function->set_record_return_value(record_return_values);
-    instrumented_functions.insert_or_assign(function_id, *instrumented_function);
-  }
-
-  for (const auto& tracepoint : selected_tracepoints) {
-    TracepointInfo* instrumented_tracepoint = capture_options->add_instrumented_tracepoint();
-    instrumented_tracepoint->set_category(tracepoint.category());
-    instrumented_tracepoint->set_name(tracepoint.name());
-  }
-
-  capture_options->set_enable_api(enable_api);
-  capture_options->set_enable_introspection(enable_introspection);
-  ORBIT_CHECK(dynamic_instrumentation_method == CaptureOptions::kKernelUprobes ||
-              dynamic_instrumentation_method == CaptureOptions::kUserSpaceInstrumentation);
-  capture_options->set_dynamic_instrumentation_method(dynamic_instrumentation_method);
-
-  auto api_functions = FindApiFunctions(module_manager);
-  *(capture_options->mutable_api_functions()) = {api_functions.begin(), api_functions.end()};
+  *request.mutable_capture_options() = std::move(capture_options);
 
   bool request_write_succeeded;
   {

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -17,6 +17,7 @@
 
 #include "CaptureClient/CaptureEventProcessor.h"
 #include "CaptureClient/CaptureListener.h"
+#include "CaptureClient/ClientCaptureOptions.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ModuleManager.h"
 #include "ClientData/ProcessData.h"
@@ -32,34 +33,6 @@
 
 namespace orbit_capture_client {
 
-struct CaptureClientOptions {
-  uint32_t process_id = 0;
-
-  absl::flat_hash_map<uint64_t, orbit_client_data::FunctionInfo> selected_functions;
-  orbit_client_data::TracepointInfoSet selected_tracepoints;
-
-  orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod dynamic_instrumentation_method =
-      orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod::
-          CaptureOptions_DynamicInstrumentationMethod_kDynamicInstrumentationMethodUnspecified;
-
-  orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method =
-      orbit_grpc_protos::CaptureOptions::UnwindingMethod::CaptureOptions_UnwindingMethod_kUndefined;
-
-  uint16_t stack_dump_size = 0;
-  uint64_t max_local_marker_depth_per_command_buffer = 0;
-  uint64_t memory_sampling_period_ms = 0;
-  double samples_per_second = 0;
-
-  bool collect_gpu_jobs = false;
-  bool collect_memory_info = false;
-  bool collect_scheduling_info = false;
-  bool collect_thread_states = false;
-  bool enable_api = false;
-  bool enable_introspection = false;
-  bool record_arguments = false;
-  bool record_return_values = false;
-};
-
 class CaptureClient {
  public:
   enum class State { kStopped = 0, kStarting, kStarted, kStopping };
@@ -71,7 +44,7 @@ class CaptureClient {
       orbit_base::ThreadPool* thread_pool,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor,
       const orbit_client_data::ModuleManager& module_manager,
-      const CaptureClientOptions& capture_client_options);
+      const ClientCaptureOptions& capture_client_options);
 
   // Returns true if stop was initiated and false otherwise.
   // The latter can happen if for example the stop was already

--- a/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
+++ b/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAPTURE_CLIENT_CLIENT_CAPTURE_OPTIONS_H_
+#define CAPTURE_CLIENT_CLIENT_CAPTURE_OPTIONS_H_
+
+#include <absl/container/flat_hash_map.h>
+#include <stdint.h>
+
+#include "ClientData/FunctionInfo.h"
+#include "ClientData/TracepointCustom.h"
+#include "GrpcProtos/capture.pb.h"
+
+namespace orbit_capture_client {
+
+struct ClientCaptureOptions {
+  uint32_t process_id = 0;
+
+  absl::flat_hash_map<uint64_t, orbit_client_data::FunctionInfo> selected_functions;
+  orbit_client_data::TracepointInfoSet selected_tracepoints;
+
+  orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod dynamic_instrumentation_method =
+      orbit_grpc_protos::CaptureOptions::CaptureOptions::kDynamicInstrumentationMethodUnspecified;
+
+  orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method =
+      orbit_grpc_protos::CaptureOptions::UnwindingMethod::CaptureOptions_UnwindingMethod_kUndefined;
+
+  uint16_t stack_dump_size = 0;
+  uint64_t max_local_marker_depth_per_command_buffer = 0;
+  uint64_t memory_sampling_period_ms = 0;
+  double samples_per_second = 0;
+
+  bool collect_gpu_jobs = false;
+  bool collect_memory_info = false;
+  bool collect_scheduling_info = false;
+  bool collect_thread_states = false;
+  bool enable_api = false;
+  bool enable_introspection = false;
+  bool record_arguments = false;
+  bool record_return_values = false;
+};
+
+}  // namespace orbit_capture_client
+
+#endif  // CAPTURE_CLIENT_CLIENT_CAPTURE_OPTIONS_H_

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -42,7 +42,7 @@ using orbit_grpc_protos::CaptureOptions;
 using DynamicInstrumentationMethod =
     orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod;
 using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
-using orbit_capture_client::CaptureClientOptions;
+using orbit_capture_client::ClientCaptureOptions;
 
 std::atomic<bool> exit_requested = false;
 
@@ -294,7 +294,7 @@ int main(int argc, char* argv[]) {
           (absl::GetFlag(FLAGS_instrument_offset) == 0),
       "Binary path and offset of the function to instrument need to be specified together");
 
-  CaptureClientOptions options;
+  ClientCaptureOptions options;
   options.process_id = absl::GetFlag(FLAGS_pid);
   if (options.process_id == 0) {
     const std::string pid_file_path = absl::GetFlag(FLAGS_pid_file_path);
@@ -306,7 +306,7 @@ int main(int argc, char* argv[]) {
   ORBIT_FAIL_IF(options.process_id == 0, "PID to capture not specified");
 
   options.samples_per_second = absl::GetFlag(FLAGS_sampling_rate);
-  ORBIT_LOG("samples_per_second=%f", options.samples_per_second);
+  ORBIT_LOG("samples_per_second=%.0f", options.samples_per_second);
   options.stack_dump_size = 65000;
   options.unwinding_method =
       absl::GetFlag(FLAGS_frame_pointers) ? CaptureOptions::kFramePointers : CaptureOptions::kDwarf;

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -42,6 +42,7 @@ using orbit_grpc_protos::CaptureOptions;
 using DynamicInstrumentationMethod =
     orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod;
 using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
+using orbit_capture_client::CaptureClientOptions;
 
 std::atomic<bool> exit_requested = false;
 
@@ -293,63 +294,64 @@ int main(int argc, char* argv[]) {
           (absl::GetFlag(FLAGS_instrument_offset) == 0),
       "Binary path and offset of the function to instrument need to be specified together");
 
-  uint32_t process_id = absl::GetFlag(FLAGS_pid);
-  if (process_id == 0) {
+  CaptureClientOptions options;
+  options.process_id = absl::GetFlag(FLAGS_pid);
+  if (options.process_id == 0) {
     const std::string pid_file_path = absl::GetFlag(FLAGS_pid_file_path);
     ORBIT_FAIL_IF(pid_file_path.empty(), "A PID or a path to a file is needed.");
     WaitForFileModification(pid_file_path);
-    process_id = ReadPidFromFile(pid_file_path);
+    options.process_id = ReadPidFromFile(pid_file_path);
   }
-  ORBIT_LOG("process_id=%d", process_id);
-  ORBIT_FAIL_IF(process_id == 0, "PID to capture not specified");
+  ORBIT_LOG("process_id=%d", options.process_id);
+  ORBIT_FAIL_IF(options.process_id == 0, "PID to capture not specified");
 
-  uint16_t samples_per_second = absl::GetFlag(FLAGS_sampling_rate);
-  ORBIT_LOG("samples_per_second=%u", samples_per_second);
-  constexpr uint16_t kStackDumpSize = 65000;
-  const UnwindingMethod unwinding_method =
+  options.samples_per_second = absl::GetFlag(FLAGS_sampling_rate);
+  ORBIT_LOG("samples_per_second=%f", options.samples_per_second);
+  options.stack_dump_size = 65000;
+  options.unwinding_method =
       absl::GetFlag(FLAGS_frame_pointers) ? CaptureOptions::kFramePointers : CaptureOptions::kDwarf;
-  ORBIT_LOG("unwinding_method=%s",
-            unwinding_method == CaptureOptions::kFramePointers ? "Frame pointers" : "DWARF");
+  ORBIT_LOG("unwinding_method=%s", options.unwinding_method == CaptureOptions::kFramePointers
+                                       ? "Frame pointers"
+                                       : "DWARF");
 
   std::string file_path = absl::GetFlag(FLAGS_instrument_path);
   uint64_t file_offset = absl::GetFlag(FLAGS_instrument_offset);
   bool instrument_function = !file_path.empty() && file_offset != 0;
   const int64_t function_size = absl::GetFlag(FLAGS_instrument_size);
   const std::string function_name = absl::GetFlag(FLAGS_instrument_name);
-  DynamicInstrumentationMethod instrumentation_method =
-      absl::GetFlag(FLAGS_user_space_instrumentation) ? CaptureOptions::kUserSpaceInstrumentation
-                                                      : CaptureOptions::kKernelUprobes;
+  options.dynamic_instrumentation_method = absl::GetFlag(FLAGS_user_space_instrumentation)
+                                               ? CaptureOptions::kUserSpaceInstrumentation
+                                               : CaptureOptions::kKernelUprobes;
   ORBIT_LOG("user_space_instrumentation=%d",
-            instrumentation_method == CaptureOptions::kUserSpaceInstrumentation);
+            options.dynamic_instrumentation_method == CaptureOptions::kUserSpaceInstrumentation);
   if (instrument_function) {
     ORBIT_LOG("file_path=%s", file_path);
     ORBIT_LOG("file_offset=%#x", file_offset);
-    if (instrumentation_method == CaptureOptions::kUserSpaceInstrumentation) {
+    if (options.dynamic_instrumentation_method == CaptureOptions::kUserSpaceInstrumentation) {
       ORBIT_FAIL_IF(function_size == -1, "User space instrumentation requires the function size");
       ORBIT_LOG("function_size=%d", function_size);
       ORBIT_FAIL_IF(function_name.empty(), "User space instrumentation requires the function name");
       ORBIT_LOG("function_name=%s", function_name);
     }
   }
-  constexpr bool kAlwaysRecordArguments = false;
-  constexpr bool kRecordReturnValues = false;
-
-  bool collect_scheduling_info = absl::GetFlag(FLAGS_scheduling);
-  ORBIT_LOG("collect_scheduling_info=%d", collect_scheduling_info);
-  bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
-  ORBIT_LOG("collect_thread_state=%d", collect_thread_state);
-  bool collect_gpu_jobs = absl::GetFlag(FLAGS_gpu_jobs);
-  ORBIT_LOG("collect_gpu_jobs=%d", collect_gpu_jobs);
-  bool enable_api = absl::GetFlag(FLAGS_orbit_api);
-  ORBIT_LOG("enable_api=%d", enable_api);
-  constexpr bool kEnableIntrospection = false;
+  options.record_arguments = false;
+  options.record_return_values = false;
+  options.collect_scheduling_info = absl::GetFlag(FLAGS_scheduling);
+  ORBIT_LOG("collect_scheduling_info=%d", options.collect_scheduling_info);
+  options.collect_thread_states = absl::GetFlag(FLAGS_thread_state);
+  ORBIT_LOG("collect_thread_states=%d", options.collect_thread_states);
+  options.collect_gpu_jobs = absl::GetFlag(FLAGS_gpu_jobs);
+  ORBIT_LOG("collect_gpu_jobs=%d", options.collect_gpu_jobs);
+  options.enable_api = absl::GetFlag(FLAGS_orbit_api);
+  ORBIT_LOG("enable_api=%d", options.enable_api);
+  options.enable_introspection = false;
   constexpr uint64_t kMaxLocalMarkerDepthPerCommandBuffer = std::numeric_limits<uint64_t>::max();
-  bool collect_memory_info = absl::GetFlag(FLAGS_memory_sampling_rate) > 0;
-  ORBIT_LOG("collect_memory_info=%d", collect_memory_info);
-  uint64_t memory_sampling_period_ms = 0;
-  if (collect_memory_info) {
-    memory_sampling_period_ms = 1'000 / absl::GetFlag(FLAGS_memory_sampling_rate);
-    ORBIT_LOG("memory_sampling_period_ms=%u", memory_sampling_period_ms);
+  options.max_local_marker_depth_per_command_buffer = kMaxLocalMarkerDepthPerCommandBuffer;
+  options.collect_memory_info = absl::GetFlag(FLAGS_memory_sampling_rate) > 0;
+  ORBIT_LOG("collect_memory_info=%d", options.collect_memory_info);
+  if (options.collect_memory_info) {
+    options.memory_sampling_period_ms = 1'000 / absl::GetFlag(FLAGS_memory_sampling_rate);
+    ORBIT_LOG("memory_sampling_period_ms=%u", options.memory_sampling_period_ms);
   }
 
   uint32_t grpc_port = absl::GetFlag(FLAGS_port);
@@ -366,17 +368,16 @@ int main(int argc, char* argv[]) {
       orbit_base::ThreadPool::Create(1, 1, absl::Seconds(1));
 
   orbit_client_data::ModuleManager module_manager;
-  absl::flat_hash_map<uint64_t, orbit_client_data::FunctionInfo> selected_functions;
   if (instrument_function) {
     constexpr uint64_t kInstrumentedFunctionId = 1;
     ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromOffset(
-        &module_manager, &selected_functions, file_path, function_name, file_offset, function_size,
-        kInstrumentedFunctionId);
+        &module_manager, &options.selected_functions, file_path, function_name, file_offset,
+        function_size, kInstrumentedFunctionId);
   }
 
-  if (enable_api) {
+  if (options.enable_api) {
     ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
-        orbit_object_utils::ReadModules(process_id);
+        orbit_object_utils::ReadModules(options.process_id);
     ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
       ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
@@ -397,7 +398,7 @@ int main(int argc, char* argv[]) {
         "VkPresentInfoKHR const*)"};
 
     ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
-        orbit_object_utils::ReadModules(process_id);
+        orbit_object_utils::ReadModules(options.process_id);
     ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
     std::string libvulkan_file_path;
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
@@ -409,7 +410,8 @@ int main(int argc, char* argv[]) {
     if (!libvulkan_file_path.empty()) {
       ORBIT_LOG("%s found: instrumenting %s", kGgpvlkModuleName, kQueuePresentFunctionName);
       ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromFunctionNameInDebugSymbols(
-          &module_manager, &selected_functions, libvulkan_file_path, kQueuePresentFunctionName,
+          &module_manager, &options.selected_functions, libvulkan_file_path,
+          kQueuePresentFunctionName,
           orbit_fake_client::FakeCaptureEventProcessor::kFrameBoundaryFunctionId);
       ORBIT_LOG("%s instrumented", kQueuePresentFunctionName);
     } else {
@@ -431,12 +433,7 @@ int main(int argc, char* argv[]) {
   }
 
   auto capture_outcome_future = capture_client.Capture(
-      thread_pool.get(), process_id, module_manager, selected_functions, kAlwaysRecordArguments,
-      kRecordReturnValues, orbit_client_data::TracepointInfoSet{}, samples_per_second,
-      kStackDumpSize, unwinding_method, collect_scheduling_info, collect_thread_state,
-      collect_gpu_jobs, enable_api, kEnableIntrospection, instrumentation_method,
-      kMaxLocalMarkerDepthPerCommandBuffer, collect_memory_info, memory_sampling_period_ms,
-      std::move(capture_event_processor));
+      thread_pool.get(), std::move(capture_event_processor), module_manager, options);
   ORBIT_LOG("Asked to start capture");
 
   absl::Time start_time = absl::Now();

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -44,7 +44,7 @@ ABSL_DECLARE_FLAG(uint64_t, max_local_marker_depth_per_command_buffer);
 using orbit_base::Future;
 
 using orbit_capture_client::CaptureClient;
-using orbit_capture_client::CaptureClientOptions;
+using orbit_capture_client::ClientCaptureOptions;
 using orbit_capture_client::CaptureEventProcessor;
 using orbit_capture_client::CaptureListener;
 
@@ -99,7 +99,7 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
   }
 
   ORBIT_LOG("Capture pid %d", pid);
-  CaptureClientOptions options;
+  ClientCaptureOptions options;
   options.process_id = pid;
   options.unwinding_method =
       options_.use_framepointer_unwinding ? CaptureOptions::kFramePointers : CaptureOptions::kDwarf;

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -44,9 +44,9 @@ ABSL_DECLARE_FLAG(uint64_t, max_local_marker_depth_per_command_buffer);
 using orbit_base::Future;
 
 using orbit_capture_client::CaptureClient;
-using orbit_capture_client::ClientCaptureOptions;
 using orbit_capture_client::CaptureEventProcessor;
 using orbit_capture_client::CaptureListener;
+using orbit_capture_client::ClientCaptureOptions;
 
 using orbit_client_data::FunctionInfo;
 using orbit_client_data::ProcessData;

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -44,6 +44,7 @@ ABSL_DECLARE_FLAG(uint64_t, max_local_marker_depth_per_command_buffer);
 using orbit_base::Future;
 
 using orbit_capture_client::CaptureClient;
+using orbit_capture_client::CaptureClientOptions;
 using orbit_capture_client::CaptureEventProcessor;
 using orbit_capture_client::CaptureListener;
 
@@ -98,17 +99,20 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
   }
 
   ORBIT_LOG("Capture pid %d", pid);
-  TracepointInfoSet selected_tracepoints;
-  const UnwindingMethod unwinding_method =
+  CaptureClientOptions options;
+  options.process_id = pid;
+  options.unwinding_method =
       options_.use_framepointer_unwinding ? CaptureOptions::kFramePointers : CaptureOptions::kDwarf;
-  bool collect_scheduling_info = true;
-  bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
-  bool collect_gpu_jobs = true;
-  bool enable_api = false;
-  bool enable_introspection = false;
-  DynamicInstrumentationMethod dynamic_instrumentation_method = CaptureOptions::kKernelUprobes;
-  uint64_t max_local_marker_depth_per_command_buffer =
+  options.collect_scheduling_info = true;
+  options.collect_thread_states = absl::GetFlag(FLAGS_thread_state);
+  options.collect_gpu_jobs = true;
+  options.enable_api = false;
+  options.enable_introspection = false;
+  options.dynamic_instrumentation_method = CaptureOptions::kKernelUprobes;
+  options.max_local_marker_depth_per_command_buffer =
       absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
+  options.selected_functions = selected_functions_;
+  options.stack_dump_size = options_.stack_dump_size;
 
   std::filesystem::path file_path = GenerateFilePath();
 
@@ -119,14 +123,8 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
                                             ORBIT_ERROR("%s", error.message());
                                           }));
 
-  Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> result = capture_client_->Capture(
-      thread_pool, target_process_->pid(), module_manager_, selected_functions_,
-      /*record_arguments=*/false, /*record_return_values=*/false, selected_tracepoints,
-      options_.samples_per_second, options_.stack_dump_size, unwinding_method,
-      collect_scheduling_info, collect_thread_state, collect_gpu_jobs, enable_api,
-      enable_introspection, dynamic_instrumentation_method,
-      max_local_marker_depth_per_command_buffer, /*collect_memory_info=*/false, 0,
-      std::move(event_processor));
+  Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> result =
+      capture_client_->Capture(thread_pool, std::move(event_processor), module_manager_, options);
 
   orbit_base::ImmediateExecutor executor;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -93,7 +93,7 @@
 using orbit_base::Future;
 
 using orbit_capture_client::CaptureClient;
-using orbit_capture_client::CaptureClientOptions;
+using orbit_capture_client::ClientCaptureOptions;
 using orbit_capture_client::CaptureEventProcessor;
 using orbit_capture_client::CaptureListener;
 
@@ -1423,7 +1423,7 @@ void OrbitApp::StartCapture() {
     selected_functions_map.insert_or_assign(function_id++, function);
   }
 
-  CaptureClientOptions options;
+  ClientCaptureOptions options;
   options.selected_tracepoints = data_manager_->selected_tracepoints();
   options.collect_scheduling_info = !IsDevMode() || data_manager_->collect_scheduler_info();
   options.collect_thread_states = data_manager_->collect_thread_states();

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -93,9 +93,9 @@
 using orbit_base::Future;
 
 using orbit_capture_client::CaptureClient;
-using orbit_capture_client::ClientCaptureOptions;
 using orbit_capture_client::CaptureEventProcessor;
 using orbit_capture_client::CaptureListener;
+using orbit_capture_client::ClientCaptureOptions;
 
 using orbit_capture_file::CaptureFile;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -93,6 +93,7 @@
 using orbit_base::Future;
 
 using orbit_capture_client::CaptureClient;
+using orbit_capture_client::CaptureClientOptions;
 using orbit_capture_client::CaptureEventProcessor;
 using orbit_capture_client::CaptureListener;
 
@@ -1422,31 +1423,35 @@ void OrbitApp::StartCapture() {
     selected_functions_map.insert_or_assign(function_id++, function);
   }
 
-  TracepointInfoSet selected_tracepoints = data_manager_->selected_tracepoints();
-  bool collect_scheduling_info = !IsDevMode() || data_manager_->collect_scheduler_info();
-  bool collect_thread_states = data_manager_->collect_thread_states();
-  bool collect_gpu_jobs = !IsDevMode() || data_manager_->trace_gpu_submissions();
-  bool enable_api = data_manager_->enable_api();
-  bool enable_introspection = IsDevMode() && data_manager_->enable_introspection();
-  const DynamicInstrumentationMethod dynamic_instrumentation_method =
-      data_manager_->dynamic_instrumentation_method();
-  double samples_per_second = data_manager_->samples_per_second();
-  uint16_t stack_dump_size = data_manager_->stack_dump_size();
-  const UnwindingMethod unwinding_method =
+  CaptureClientOptions options;
+  options.selected_tracepoints = data_manager_->selected_tracepoints();
+  options.collect_scheduling_info = !IsDevMode() || data_manager_->collect_scheduler_info();
+  options.collect_thread_states = data_manager_->collect_thread_states();
+  options.collect_gpu_jobs = !IsDevMode() || data_manager_->trace_gpu_submissions();
+  options.enable_api = data_manager_->enable_api();
+  options.enable_introspection = IsDevMode() && data_manager_->enable_introspection();
+  options.dynamic_instrumentation_method = data_manager_->dynamic_instrumentation_method();
+  options.samples_per_second = data_manager_->samples_per_second();
+  options.stack_dump_size = data_manager_->stack_dump_size();
+  options.unwinding_method =
       IsDevMode() ? data_manager_->unwinding_method() : CaptureOptions::kDwarf;
-  uint64_t max_local_marker_depth_per_command_buffer =
+  options.max_local_marker_depth_per_command_buffer =
       data_manager_->max_local_marker_depth_per_command_buffer();
 
-  bool collect_memory_info = data_manager_->collect_memory_info();
-  uint64_t memory_sampling_period_ms = data_manager_->memory_sampling_period_ms();
+  options.collect_memory_info = data_manager_->collect_memory_info();
+  options.memory_sampling_period_ms = data_manager_->memory_sampling_period_ms();
+  options.selected_functions = std::move(selected_functions_map);
+  options.process_id = process->pid();
+  options.record_return_values = absl::GetFlag(FLAGS_show_return_values);
+  options.record_arguments = false;
 
   // In metrics, -1 indicates memory collection was turned off. See also the comment in
   // orbit_log_event.proto
   constexpr int64_t kMemoryCollectionDisabledMetricsValue = -1;
   int64_t memory_information_sampling_period_ms_for_metrics = kMemoryCollectionDisabledMetricsValue;
-  if (collect_memory_info) {
+  if (options.collect_memory_info) {
     memory_information_sampling_period_ms_for_metrics =
-        static_cast<int64_t>(memory_sampling_period_ms);
+        static_cast<int64_t>(options.memory_sampling_period_ms);
   }
 
   // Whether the Orbit custom vulkan layer is used by the process (game), is determined via the
@@ -1466,15 +1471,15 @@ void OrbitApp::StartCapture() {
       CreateCaptureStartData(
           selected_functions, user_defined_capture_data.frame_track_functions().size(),
           data_manager_->collect_thread_states(), memory_information_sampling_period_ms_for_metrics,
-          orbit_vulkan_layer_loaded_by_process, max_local_marker_depth_per_command_buffer,
-          dynamic_instrumentation_method, static_cast<uint64_t>(samples_per_second),
-          unwinding_method)};
+          orbit_vulkan_layer_loaded_by_process, options.max_local_marker_depth_per_command_buffer,
+          options.dynamic_instrumentation_method, static_cast<uint64_t>(options.samples_per_second),
+          options.unwinding_method)};
 
   metrics_capture_complete_data_ = orbit_metrics_uploader::CaptureCompleteData{};
 
   ORBIT_CHECK(capture_client_ != nullptr);
 
-  auto capture_event_processor = CreateCaptureEventProcessor(
+  std::unique_ptr<CaptureEventProcessor> capture_event_processor = CreateCaptureEventProcessor(
       this, process->name(), frame_track_function_ids, [this](const ErrorMessage& error) {
         capture_data_->reset_file_path();
         SendErrorToUi("Error saving capture", error.message());
@@ -1482,13 +1487,7 @@ void OrbitApp::StartCapture() {
       });
 
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
-      thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
-      /*record_arguments=*/false, absl::GetFlag(FLAGS_show_return_values),
-      std::move(selected_tracepoints), samples_per_second, stack_dump_size, unwinding_method,
-      collect_scheduling_info, collect_thread_states, collect_gpu_jobs, enable_api,
-      enable_introspection, dynamic_instrumentation_method,
-      max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ms,
-      std::move(capture_event_processor));
+      thread_pool_.get(), std::move(capture_event_processor), *module_manager_, options);
 
   // TODO(b/187250643): Refactor this to be more readable and maybe remove parts that are not needed
   // here (capture cancelled)


### PR DESCRIPTION
CaptureClient::Capture was taking over 20 arguments and was 
duplicated by CaptureClient::CaptureSync which made adding 
a new capture option quite annoying. Clean up that code a little.

Tests: profiled on instance with manual and dynamic instrumentation.
b/187170164