### PR TITLE
Don't #include <Windows.h> in OrbitBase/Logging.h

### DIFF
--- a/src/MoveFilesToDocuments/MoveFilesProcess.cpp
+++ b/src/MoveFilesToDocuments/MoveFilesProcess.cpp
@@ -64,7 +64,7 @@ void MoveFilesProcess::TryMoveFilesAndRemoveDirIfNeeded(const std::filesystem::p
     const auto& new_file_path = dest_dir / file_name;
     ORBIT_LOG("Moving \"%s\" to \"%s\"...", file_path.string(), new_file_path.string());
     emit moveFileStarted(QString::fromStdString(file_path.string()));
-    auto move_result = orbit_base::MoveFile(file_path, new_file_path);
+    auto move_result = orbit_base::MoveOrRenameFile(file_path, new_file_path);
     if (move_result.has_error()) {
       ReportError(absl::StrFormat(R"(Unable to move "%s" to "%s": %s)", file_path.string(),
                                   new_file_path.string(), move_result.error().message()));

--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -175,7 +175,8 @@ ErrorMessageOr<bool> FileExists(const std::filesystem::path& path) {
   return result;
 }
 
-ErrorMessageOr<void> MoveFile(const std::filesystem::path& from, const std::filesystem::path& to) {
+ErrorMessageOr<void> MoveOrRenameFile(const std::filesystem::path& from,
+                                      const std::filesystem::path& to) {
   std::error_code error;
   std::filesystem::rename(from, to, error);
   if (error) {
@@ -195,7 +196,7 @@ ErrorMessageOr<bool> RemoveFile(const std::filesystem::path& file_path) {
   return removed;
 }
 
-ErrorMessageOr<bool> CreateDirectory(const std::filesystem::path& file_path) {
+ErrorMessageOr<bool> CreateDirectories(const std::filesystem::path& file_path) {
   std::error_code error;
   bool created = std::filesystem::create_directories(file_path, error);
   if (error) {

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -284,7 +284,7 @@ TEST(File, ReadStructureAtOffset) {
   EXPECT_STREQ(test_struct.char_array.data(), kCharArray);
 }
 
-TEST(File, MoveFile) {
+TEST(File, MoveOrRenameFile) {
   auto tmp_file_or_error = TemporaryFile::Create();
   ASSERT_THAT(tmp_file_or_error, HasNoError());
   auto tmp_file = std::move(tmp_file_or_error.value());
@@ -307,7 +307,7 @@ TEST(File, MoveFile) {
   ASSERT_THAT(exists_or_error, HasNoError());
   EXPECT_TRUE(exists_or_error.value());
 
-  auto move_result = MoveFile(tmp_file.file_path(), new_path);
+  auto move_result = MoveOrRenameFile(tmp_file.file_path(), new_path);
   ASSERT_THAT(move_result, HasNoError());
 
   exists_or_error = FileExists(new_path);
@@ -340,16 +340,16 @@ TEST(File, RemoveFile) {
   ASSERT_FALSE(exists_or_error.value());
 }
 
-TEST(File, CreateDirectory) {
+TEST(File, CreateDirectories) {
   auto tmp_file_or_error = TemporaryFile::Create();
   ASSERT_THAT(tmp_file_or_error, HasNoError());
   auto tmp_file = std::move(tmp_file_or_error.value());
 
   tmp_file.CloseAndRemove();
 
-  auto directory_created_or_error = CreateDirectory(tmp_file.file_path());
-  ASSERT_THAT(directory_created_or_error, HasNoError());
-  EXPECT_TRUE(directory_created_or_error.value());
+  auto directories_created_or_error = CreateDirectories(tmp_file.file_path());
+  ASSERT_THAT(directories_created_or_error, HasNoError());
+  EXPECT_TRUE(directories_created_or_error.value());
 
   auto exists_or_error = FileExists(tmp_file.file_path());
   ASSERT_THAT(exists_or_error, HasNoError());

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -120,9 +120,10 @@ ErrorMessageOr<T> ReadFullyAtOffset(const unique_fd& fd, int64_t offset) {
 
 // Following functions make sure we call stl in exception-free manner
 ErrorMessageOr<bool> FileExists(const std::filesystem::path& path);
-ErrorMessageOr<void> MoveFile(const std::filesystem::path& from, const std::filesystem::path& to);
+ErrorMessageOr<void> MoveOrRenameFile(const std::filesystem::path& from,
+                                      const std::filesystem::path& to);
 ErrorMessageOr<bool> RemoveFile(const std::filesystem::path& file_path);
-ErrorMessageOr<bool> CreateDirectory(const std::filesystem::path& file_path);
+ErrorMessageOr<bool> CreateDirectories(const std::filesystem::path& file_path);
 ErrorMessageOr<void> ResizeFile(const std::filesystem::path& file_path, uint64_t new_size);
 ErrorMessageOr<uint64_t> FileSize(const std::filesystem::path& file_path);
 // Returns all files in directory; non recursively.

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -15,10 +15,6 @@
 #include <mutex>
 #include <string>
 
-#ifdef _WIN32
-#include <Windows.h>
-#endif
-
 #include "OrbitBase/Result.h"
 
 #ifdef __clang__
@@ -130,11 +126,11 @@ struct FuzzingException {};
 #define ORBIT_INTERNAL_PLATFORM_ABORT() \
   throw orbit_base::FuzzingException {}
 #elif defined(_WIN32)
-#define ORBIT_INTERNAL_PLATFORM_LOG(message) \
-  do {                                       \
-    fprintf(stderr, "%s", message);          \
-    OutputDebugStringA(message);             \
-    orbit_base::LogToFile(message);          \
+#define ORBIT_INTERNAL_PLATFORM_LOG(message)          \
+  do {                                                \
+    fprintf(stderr, "%s", message);                   \
+    orbit_base_internal::OutputDebugStringA(message); \
+    orbit_base_internal::LogToFile(message);          \
   } while (0)
 #define ORBIT_INTERNAL_PLATFORM_ABORT() \
   do {                                  \
@@ -145,7 +141,7 @@ struct FuzzingException {};
 #define ORBIT_INTERNAL_PLATFORM_LOG(message) \
   do {                                       \
     fprintf(stderr, "%s", message);          \
-    orbit_base::LogToFile(message);          \
+    orbit_base_internal::LogToFile(message); \
   } while (0)
 #define ORBIT_INTERNAL_PLATFORM_ABORT() abort()
 #endif
@@ -162,9 +158,19 @@ std::string GetLogFileName();
 ErrorMessageOr<void> TryRemoveOldLogFiles(const std::filesystem::path& log_dir);
 
 void InitLogFile(const std::filesystem::path& path);
-void LogToFile(const std::string& message);
 
 void LogStacktrace();
 }  // namespace orbit_base
+
+namespace orbit_base_internal {
+
+void LogToFile(const std::string& message);
+
+#ifdef _WIN32
+// Add one indirection so that we can #include <Windows.h> in the .cpp instead of in this header.
+void OutputDebugStringA(const char* str);
+#endif
+
+}  // namespace orbit_base_internal
 
 #endif  // ORBIT_BASE_LOGGING_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1331,7 +1331,7 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::MoveCaptureFile(
     const std::filesystem::path& src, const std::filesystem::path& dest) {
   std::optional<absl::Duration> capture_length =
       capture_file_info_manager_.GetCaptureLengthByPath(src);
-  return thread_pool_->Schedule([src, dest]() { return orbit_base::MoveFile(src, dest); })
+  return thread_pool_->Schedule([src, dest]() { return orbit_base::MoveOrRenameFile(src, dest); })
       .ThenIfSuccess(main_thread_executor_, [this, dest, capture_length] {
         capture_file_info_manager_.AddOrTouchCaptureFile(dest, capture_length);
       });

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -9,13 +9,16 @@
 #include <filesystem>
 #include <string>
 
-#include "OrbitBase/File.h"
-#include "OrbitBase/Logging.h"
-
 #ifdef _WIN32
+// clang-format off
+#include <Windows.h>
 #include <KnownFolders.h>
+// clang-format on
 #include <shlobj.h>
 #endif
+
+#include "OrbitBase/File.h"
+#include "OrbitBase/Logging.h"
 
 ABSL_FLAG(std::string, log_dir, "", "Set directory for the log.");
 
@@ -40,10 +43,10 @@ static std::string GetEnvVar(const char* variable_name) {
 }
 
 static void CreateDirectoryOrDie(const std::filesystem::path& directory) {
-  auto create_directory_result = orbit_base::CreateDirectory(directory);
-  if (create_directory_result.has_error()) {
+  auto create_directories_result = orbit_base::CreateDirectories(directory);
+  if (create_directories_result.has_error()) {
     ORBIT_FATAL("Unable to create directory \"%s\": %s", directory.string(),
-                create_directory_result.error().message());
+                create_directories_result.error().message());
   }
 }
 

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/flags/flag.h>
+#include <absl/flags/parse.h>
+#include <absl/flags/usage.h>
+#include <absl/flags/usage_config.h>
 #include <stdint.h>
 
 #include <atomic>
@@ -9,15 +13,15 @@
 #include <filesystem>
 #include <string>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 #include "OrbitBase/Logging.h"
 #include "OrbitService.h"
 #include "OrbitVersion/OrbitVersion.h"
-#include "absl/flags/flag.h"
-#include "absl/flags/parse.h"
-#include "absl/flags/usage.h"
-#include "absl/flags/usage_config.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/GetLastError.h"
 #endif


### PR DESCRIPTION
Otherwise this brings `#include <Windows.h>` almost everywhere, which is often
problematic.

Add `orbit_base_internal::OutputDebugStringA` to only `#include <Windows.h>`
in `Logging.cpp`.

Also rename `orbit_base::CreateDirectory` to `orbit_base::CreateDirectories` and
`orbit_base::MoveFile` to `orbit_base::MoveOrRenameFile`. This prevents clashes
with `#define CreateDirectory CreateDirectoryW` and `#define MoveFile MoveFileW`
in `<Windows.h>`, but it also matches the semantics better.