### PR TITLE
Allow for csv export for manual instrumentation events

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <iterator>
 #include <memory>
 #include <vector>
 
@@ -208,6 +209,17 @@ void CaptureData::UpdateTimerDurations() {
   for (auto& [id, timer_durations] : scope_id_to_timer_durations_) {
     std::sort(timer_durations.begin(), timer_durations.end());
   }
+}
+
+[[nodiscard]] std::vector<const TimerInfo*> CaptureData::GetAllTimersForScope(
+    uint64_t scope_id, uint64_t min_tick, uint64_t max_tick) const {
+  std::vector<const TimerInfo*> result;
+  const std::vector<const TimerInfo*> all_timers = GetAllScopeTimers(min_tick, max_tick);
+  std::copy_if(std::begin(all_timers), std::end(all_timers), std::back_inserter(result),
+               [this, scope_id](const TimerInfo* timer) {
+                 return scope_id_provider_->ProvideId(*timer) == scope_id;
+               });
+  return result;
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -249,6 +249,10 @@ class CaptureData {
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
       uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
 
+  [[nodiscard]] std::vector<const TimerInfo*> GetAllTimersForScope(
+      uint64_t scope_id, uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
+
  private:
   void UpdateTimerDurations();
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -385,15 +385,14 @@ void LiveFunctionsDataView::OnExportEventsToCsvRequested(const std::vector<int>&
   }
 
   for (int row : selection) {
-    const FunctionInfo& function = *GetFunctionInfoFromRow(row);
-    std::string function_name = function.pretty_name();
-
-    // TODO(b/228151558) Allow for csv export for manual instrumentation events
-    const uint64_t function_id = GetScopeId(row);
     const CaptureData& capture_data = app_->GetCaptureData();
-    for (const TimerInfo* timer : app_->GetAllTimersForHookedFunction(function_id)) {
+
+    const uint64_t scope_id = GetScopeId(row);
+
+    const std::string& scope_name = capture_data.GetScopeName(scope_id);
+    for (const TimerInfo* timer : capture_data.GetAllTimersForScope(scope_id)) {
       std::string line;
-      line.append(FormatValueForCsv(function_name));
+      line.append(FormatValueForCsv(scope_name));
       line.append(kFieldSeparator);
       line.append(FormatValueForCsv(absl::StrFormat(
           "%s [%lu]", capture_data.GetThreadName(timer->thread_id()), timer->thread_id())));

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -204,7 +204,6 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
     stats.set_variance_ns(kStdDevNs[i] * kStdDevNs[i]);
     capture_data->AddScopeStats(kFunctionIds[i], std::move(stats));
   }
-
   return capture_data;
 }
 
@@ -477,8 +476,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     }
     EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
-    EXPECT_CALL(app_, GetAllTimersForHookedFunction)
-        .WillRepeatedly(testing::Return(kTimerPointers));
+    AddTimersToThreadTrackDataProvider(capture_data_->GetThreadTrackDataProvider());
+    capture_data_->OnCaptureComplete();
 
     std::string expected_contents("\"Name\",\"Thread\",\"Start\",\"End\",\"Duration (ns)\"\r\n");
     for (size_t i = 0; i < kNumTimers; ++i) {

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -46,8 +46,6 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(void, DeselectTimer, ());
   MOCK_METHOD(bool, IsCapturing, (), (const));
   MOCK_METHOD(void, JumpToTimerAndZoom, (uint64_t function_id, JumpToTimerMode selection_mode));
-  MOCK_METHOD(std::vector<const orbit_client_protos::TimerInfo*>, GetAllTimersForHookedFunction,
-              (uint64_t), (const));
   MOCK_METHOD(std::vector<const orbit_client_data::TimerChain*>, GetAllThreadTimerChains, (),
               (const));
 

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -55,8 +55,6 @@ class AppInterface {
   virtual void SetVisibleScopeIds(absl::flat_hash_set<uint64_t> visible_scope_ids) = 0;
   virtual void DeselectTimer() = 0;
   [[nodiscard]] virtual bool IsCapturing() const = 0;
-  [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*>
-  GetAllTimersForHookedFunction(uint64_t function_id) const = 0;
   [[nodiscard]] virtual std::vector<const orbit_client_data::TimerChain*> GetAllThreadTimerChains()
       const = 0;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1700,7 +1700,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 
@@ -2812,10 +2812,6 @@ void OrbitApp::JumpToTimerAndZoom(uint64_t scope_id, JumpToTimerMode selection_m
       break;
     }
   }
-}
-
-std::vector<const TimerInfo*> OrbitApp::GetAllTimersForHookedFunction(uint64_t function_id) const {
-  return GetTimeGraph()->GetAllTimersForHookedFunction(function_id);
 }
 
 [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> OrbitApp::GetAllThreadTimerChains()

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -516,8 +516,6 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] bool HasFrameTrackInCaptureData(uint64_t instrumented_function_id) const override;
 
   void JumpToTimerAndZoom(uint64_t scope_id, JumpToTimerMode selection_mode) override;
-  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllTimersForHookedFunction(
-      uint64_t function_id) const override;
   [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetAllThreadTimerChains()
       const override;
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -455,22 +455,6 @@ const TimerInfo* TimeGraph::FindNextScopeTimer(uint64_t scope_id, uint64_t curre
   return next_timer;
 }
 
-std::vector<const TimerInfo*> TimeGraph::GetAllTimersForHookedFunction(
-    uint64_t function_address) const {
-  std::vector<const TimerInfo*> timers;
-  std::vector<const TimerChain*> chains = GetAllThreadTrackTimerChains();
-  for (const TimerChain* chain : chains) {
-    ORBIT_CHECK(chain != nullptr);
-    for (const auto& block : *chain) {
-      for (uint64_t i = 0; i < block.size(); i++) {
-        const TimerInfo& timer = block[i];
-        if (timer.function_id() == function_address) timers.push_back(&timer);
-      }
-    }
-  }
-  return timers;
-}
-
 std::vector<const TimerChain*> TimeGraph::GetAllThreadTrackTimerChains() const {
   ORBIT_CHECK(thread_track_data_provider_ != nullptr);
   return thread_track_data_provider_->GetAllThreadTimerChains();

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -105,8 +105,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] const orbit_client_protos::TimerInfo* FindNextScopeTimer(
       uint64_t scope_id, uint64_t current_time,
       std::optional<uint32_t> thread_id = std::nullopt) const;
-  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetAllTimersForHookedFunction(
-      uint64_t function_address) const;
   [[nodiscard]] std::vector<const orbit_client_data::TimerChain*> GetAllThreadTrackTimerChains()
       const;
   [[nodiscard]] std::pair<const orbit_client_protos::TimerInfo*,


### PR DESCRIPTION
Naturally, this also allows for mixed export of dynamically
and manually instumented events.

This also removes `OrbitApp::GetAllTimersForHookedFunction`
and addss `CaptureData::GetAllTimersForScope`.

Test: Unit, Manual
Bug: http://b/228151558