### PR TITLE
Collapse toggle refactor

### DIFF
--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -89,7 +89,7 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 
 float AsyncTrack::GetHeight() const {
   uint32_t collapsed_depth = std::min<uint32_t>(1, GetDepth());
-  uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : GetDepth();
+  uint32_t depth = IsCollapsed() ? collapsed_depth : GetDepth();
   return GetHeightAboveTimers() + layout_->GetTextBoxHeight() * depth +
          layout_->GetTrackContentBottomMargin();
 }
@@ -104,7 +104,7 @@ void AsyncTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
 
 float AsyncTrack::GetDefaultBoxHeight() const {
   auto box_height = layout_->GetTextBoxHeight();
-  if (collapse_toggle_->IsCollapsed() && GetDepth() > 0) {
+  if (IsCollapsed() && GetDepth() > 0) {
     return box_height / static_cast<float>(GetDepth());
   }
   return box_height;

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -104,7 +104,8 @@ void BasicPageFaultsTrack::DrawSingleSeriesEntry(
 }
 
 bool BasicPageFaultsTrack::IsCollapsed() const {
-  return collapse_toggle_->IsCollapsed() || GetParent()->IsCollapsed();
+  return LineGraphTrack<kBasicPageFaultsTrackDimension>::IsCollapsed() ||
+         GetParent()->IsCollapsed();
 }
 
 float BasicPageFaultsTrack::GetAnnotatedTrackContentHeight() const {

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -46,7 +46,7 @@ float FrameTrack::GetCappedMaximumToAverageRatio() const {
 }
 
 float FrameTrack::GetMaximumBoxHeight() const {
-  const bool is_collapsed = collapse_toggle_->IsCollapsed();
+  const bool is_collapsed = IsCollapsed();
   float scale_factor = is_collapsed ? 1.f : GetCappedMaximumToAverageRatio();
   return scale_factor * GetDefaultBoxHeight();
 }
@@ -67,7 +67,7 @@ FrameTrack::FrameTrack(CaptureViewElement* parent,
   // TODO(b/169554463): Support manual instrumentation.
 
   // Frame tracks are collapsed by default.
-  collapse_toggle_->SetCollapsed(true);
+  SetCollapsed(true);
 }
 
 float FrameTrack::GetHeight() const {

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -113,7 +113,7 @@ std::string GpuDebugMarkerTrack::GetBoxTooltip(const PrimitiveAssembler& primiti
 
 float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   uint32_t depth = timer_info.depth();
-  if (collapse_toggle_->IsCollapsed()) {
+  if (IsCollapsed()) {
     depth = 0;
   }
   return GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
@@ -121,14 +121,14 @@ float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 }
 
 float GpuDebugMarkerTrack::GetHeight() const {
-  bool collapsed = collapse_toggle_->IsCollapsed();
+  bool collapsed = IsCollapsed();
   uint32_t depth = collapsed ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
   return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
          layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
 }
 
 bool GpuDebugMarkerTrack::TimerFilter(const TimerInfo& timer_info) const {
-  if (collapse_toggle_->IsCollapsed()) {
+  if (IsCollapsed()) {
     return timer_info.depth() == 0;
   }
   return true;

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -65,7 +65,7 @@ GpuTrack::GpuTrack(CaptureViewElement* parent, const orbit_gl::TimelineInfoInter
       timeline_hash_{timeline_hash} {
   // Gpu are collapsed by default. Their subtracks are expanded by default, but are however not
   // shown while the Gpu track is collapsed.
-  collapse_toggle_->SetCollapsed(true);
+  SetCollapsed(true);
 }
 
 void GpuTrack::OnTimer(const TimerInfo& timer_info) {
@@ -85,7 +85,7 @@ void GpuTrack::OnTimer(const TimerInfo& timer_info) {
 
 void GpuTrack::UpdatePositionOfSubtracks() {
   const Vec2 pos = GetPos();
-  if (collapse_toggle_->IsCollapsed()) {
+  if (IsCollapsed()) {
     submission_track_->SetPos(pos[0], pos[1]);
     marker_track_->SetVisible(false);
     submission_track_->SetHeadless(true);
@@ -109,7 +109,7 @@ void GpuTrack::UpdatePositionOfSubtracks() {
 }
 
 float GpuTrack::GetHeight() const {
-  if (collapse_toggle_->IsCollapsed()) {
+  if (IsCollapsed()) {
     return submission_track_->GetHeight();
   }
   float height = layout_->GetTrackTabHeight();

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -26,7 +26,7 @@ void MemoryTrack<Dimension>::DoDraw(PrimitiveAssembler& primitive_assembler,
                                     const CaptureViewElement::DrawContext& draw_context) {
   GraphTrack<Dimension>::DoDraw(primitive_assembler, text_renderer, draw_context);
 
-  if (this->collapse_toggle_->IsCollapsed()) return;
+  if (this->IsCollapsed()) return;
   AnnotationTrack::DrawAnnotation(primitive_assembler, text_renderer, this->layout_,
                                   this->indentation_level_, GlCanvas::kZValueTrackText);
 }

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -31,7 +31,7 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
                               module_manager, capture_data),
         AnnotationTrack() {
     // Memory tracks are collapsed by default.
-    this->collapse_toggle_->SetCollapsed(true);
+    this->SetCollapsed(true);
   }
   ~MemoryTrack() override = default;
 

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -34,15 +34,15 @@ PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent,
           module_manager, capture_data)} {
   // PageFaults track is collapsed by default. The major and minor page faults subtracks are
   // expanded by default, but not shown while the page faults track is collapsed.
-  collapse_toggle_->SetCollapsed(true);
+  SetCollapsed(true);
 }
 
 std::string PageFaultsTrack::GetLabel() const {
-  return collapse_toggle_->IsCollapsed() ? major_page_faults_track_->GetName() : GetName();
+  return IsCollapsed() ? major_page_faults_track_->GetName() : GetName();
 }
 
 float PageFaultsTrack::GetHeight() const {
-  if (collapse_toggle_->IsCollapsed()) {
+  if (IsCollapsed()) {
     return major_page_faults_track_->GetHeight();
   }
 
@@ -57,7 +57,7 @@ float PageFaultsTrack::GetHeight() const {
 }
 
 std::string PageFaultsTrack::GetTooltip() const {
-  if (collapse_toggle_->IsCollapsed()) return major_page_faults_track_->GetTooltip();
+  if (IsCollapsed()) return major_page_faults_track_->GetTooltip();
   return "Shows the minor and major page faults statistics.";
 }
 
@@ -76,7 +76,7 @@ void PageFaultsTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler
 
 void PageFaultsTrack::UpdatePositionOfSubtracks() {
   const Vec2 pos = GetPos();
-  if (collapse_toggle_->IsCollapsed()) {
+  if (IsCollapsed()) {
     major_page_faults_track_->SetPos(pos[0], pos[1]);
     minor_page_faults_track_->SetVisible(false);
     major_page_faults_track_->SetHeadless(true);

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -205,7 +205,7 @@ bool ThreadTrack::IsTrackSelected() const {
 
 float ThreadTrack::GetDefaultBoxHeight() const {
   auto box_height = layout_->GetTextBoxHeight();
-  if (collapse_toggle_->IsCollapsed() && GetDepth() > 0) {
+  if (IsCollapsed() && GetDepth() > 0) {
     return box_height / static_cast<float>(GetDepth());
   }
   return box_height;
@@ -320,8 +320,7 @@ std::string ThreadTrack::GetTooltip() const {
 }
 
 float ThreadTrack::GetHeight() const {
-  const uint32_t depth =
-      collapse_toggle_->IsCollapsed() ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
+  const uint32_t depth = IsCollapsed() ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
 
   bool gap_between_tracks_and_timers =
       (!thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty()) &&
@@ -398,10 +397,10 @@ void ThreadTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   ORBIT_SCOPE_WITH_COLOR("ThreadTrack::DoUpdatePrimitives", kOrbitColorYellow);
   visible_timer_count_ = 0;
 
-  const internal::DrawData draw_data = GetDrawData(
-      min_tick, max_tick, GetPos()[0], GetWidth(), &primitive_assembler, timeline_info_, viewport_,
-      collapse_toggle_->IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
-      app_->GetGroupIdToHighlight(), app_->GetHistogramSelectionRange());
+  const internal::DrawData draw_data =
+      GetDrawData(min_tick, max_tick, GetPos()[0], GetWidth(), &primitive_assembler, timeline_info_,
+                  viewport_, IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
+                  app_->GetGroupIdToHighlight(), app_->GetHistogramSelectionRange());
 
   uint64_t resolution_in_pixels = draw_data.viewport->WorldToScreen({draw_data.track_width, 0})[0];
   for (uint32_t depth = 0; depth < GetDepth(); depth++) {
@@ -422,7 +421,7 @@ void ThreadTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
 
       auto timer_duration = timer_info->end() - timer_info->start();
       if (timer_duration > draw_data.ns_per_pixel) {
-        if (!collapse_toggle_->IsCollapsed() && BoxHasRoomForText(text_renderer, size[0])) {
+        if (!IsCollapsed() && BoxHasRoomForText(text_renderer, size[0])) {
           DrawTimesliceText(text_renderer, *timer_info, draw_data.track_start_x, pos, size);
         }
         primitive_assembler.AddShadedBox(pos, size, draw_data.z, color, std::move(user_data));

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -75,7 +75,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] virtual Color GetTrackBackgroundColor() const;
 
-  virtual void OnCollapseToggle(bool is_collapsed);
   [[nodiscard]] virtual bool IsCollapsible() const { return false; }
   TriangleToggle* GetTriangleToggle() const { return collapse_toggle_.get(); }
   [[nodiscard]] virtual uint32_t GetProcessId() const { return orbit_base::kInvalidProcessId; }
@@ -87,6 +86,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
 
   [[nodiscard]] virtual bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
+  void SetCollapsed(bool collapsed);
 
   [[nodiscard]] bool GetHeadless() const { return headless_; }
   void SetHeadless(bool value);

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -17,9 +17,9 @@
 
 using orbit_gl::PrimitiveAssembler;
 
-TriangleToggle::TriangleToggle(StateChangeHandler handler, orbit_gl::Viewport* viewport,
-                               TimeGraphLayout* layout, Track* track)
-    : CaptureViewElement(track, viewport, layout), handler_(std::move(handler)) {}
+TriangleToggle::TriangleToggle(CaptureViewElement* parent, const orbit_gl::Viewport* viewport,
+                               const TimeGraphLayout* layout, StateChangeHandler handler)
+    : CaptureViewElement(parent, viewport, layout), handler_(std::move(handler)) {}
 
 void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                             const DrawContext& draw_context) {

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -18,8 +18,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
                        public std::enable_shared_from_this<TriangleToggle> {
  public:
   using StateChangeHandler = std::function<void(bool)>;
-  explicit TriangleToggle(StateChangeHandler handler, orbit_gl::Viewport* viewport,
-                          TimeGraphLayout* layout, Track* track);
+  explicit TriangleToggle(CaptureViewElement* parent, const orbit_gl::Viewport* viewport,
+                          const TimeGraphLayout* layout, StateChangeHandler handler);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;


### PR DESCRIPTION
Slight refactoring to the usage of track collapse toggles:
* Unify order of constructor arguments
* Track now provides a direct API to set and query the "collapse"
state, so inheriting classes do not need to access the collapse toggle
directly.

This will allow easier decoupling of the collapse functionality.

Bug: b/185854980
Test: Manual testing