### PR TITLE
Create DrawingInterface class

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(
          CaptureWindow.h
          CGroupAndProcessMemoryTrack.h
          CoreMath.h
+         DrawingInterface.h
          FramePointerValidatorClient.h
          FrameTrack.h
          FrameTrackOnlineProcessor.h

--- a/src/OrbitGl/DrawingInterface.h
+++ b/src/OrbitGl/DrawingInterface.h
@@ -11,6 +11,8 @@ namespace orbit_gl {
 
 class DrawingInterface {
  public:
+  ~DrawingInterface() = default;
+
   [[nodiscard]] virtual std::vector<float> GetLayers() const = 0;
   virtual void DrawLayer(float layer, bool picking) const = 0;
   virtual void Draw(bool picking) const = 0;

--- a/src/OrbitGl/DrawingInterface.h
+++ b/src/OrbitGl/DrawingInterface.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_DRAWING_INTERFACE_H_
+#define ORBIT_GL_DRAWING_INTERFACE_H_
+
+#include <vector>
+
+namespace orbit_gl {
+
+class DrawingInterface {
+ public:
+  [[nodiscard]] virtual std::vector<float> GetLayers() const = 0;
+  virtual void DrawLayer(float layer, bool picking) const = 0;
+  virtual void Draw(bool picking) const = 0;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_DRAWING_INTERFACE_H_


### PR DESCRIPTION
In this PR we are creating DrawingInterface class. We will move
GetLayers, DrawLayer and Draw methods from Batcher and TextRenderer
there (implemented by OpenGl methods).

Also, we will implement it in CaptureWindow with a new class
DrawingCombiner which will take care of combining Layers (logic which is
currently in CaptureWindow::Draw()