### PR TITLE
Implement and unit test 'Step' for the native PE/COFF unwinder

### DIFF
--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -75,6 +75,8 @@ target_sources(libunwindstack_common PRIVATE
   PeCoffUnwindInfoEvaluator.cpp
   PeCoffUnwindInfos.cpp
   PeCoffUnwindInfos.h
+  PeCoffUnwindInfoUnwinderX86_64.h
+  PeCoffUnwindInfoUnwinderX86_64.cpp
   RegsArm64.cpp
   RegsArm.cpp
   Regs.cpp
@@ -262,6 +264,7 @@ target_sources(libunwindstack_tests PRIVATE
   tests/PeCoffTest.cpp
   tests/PeCoffUnwindInfoEvaluatorTest.cpp
   tests/PeCoffUnwindInfosTest.cpp
+  tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
   tests/PeCoffEpilogTest.cpp
   tests/RegsInfoTest.cpp
   tests/RegsIterateTest.cpp

--- a/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PeCoffUnwindInfoUnwinderX86_64.h"
+
+#include <limits>
+#include "unwindstack/MachineX86_64.h"
+#include "unwindstack/Regs.h"
+
+namespace unwindstack {
+
+bool PeCoffUnwindInfoUnwinderX86_64::Step(uint64_t pc, uint64_t pc_adjustment, Regs* regs,
+                                          Memory* process_memory, bool* finished,
+                                          bool* is_signal_frame) {
+  // Indicates that we are in the stack frame of a signal handler, which is never the case
+  // when unwinding a PE/COFF frame.
+  *is_signal_frame = false;
+
+  uint64_t pc_rva = pc - image_base_ + pc_adjustment;
+
+  RegsImpl<uint64_t>* cur_regs = static_cast<RegsImpl<uint64_t>*>(regs);
+
+  RuntimeFunction function_at_pc;
+  if (!runtime_functions_->FindRuntimeFunction(pc_rva, &function_at_pc)) {
+    // By specification, if we cannot find a runtime function at the current PC, we are in
+    // a leaf function, which for PE/COFF are precisely the functions that do not adjust any
+    // of the callee-saved registers (also called non-volatile registers), including the stack
+    // pointer. This implies that the stack pointer points to the return address and we can just
+    // read it out.
+    uint64_t return_address;
+    if (!process_memory->Read64(cur_regs->sp(), &return_address)) {
+      last_error_.code = ERROR_MEMORY_INVALID;
+      last_error_.address = cur_regs->sp();
+      return false;
+    }
+    cur_regs->set_pc(return_address);
+    cur_regs->set_sp(cur_regs->sp() + sizeof(uint64_t));
+
+    *finished = (regs->pc() == 0);
+    return true;
+  }
+
+  UnwindInfo unwind_info;
+  if (!unwind_infos_->GetUnwindInfo(function_at_pc.unwind_info_offset, &unwind_info)) {
+    last_error_ = unwind_infos_->GetLastError();
+    return false;
+  }
+
+  // If we are beyond the prolog, that is, the current PC offset from the start of the function is
+  // larger than the prolog size indicated in the unwind info, we need to check if we are in an
+  // epilog of the function. If yes, the registers, including SP and PC, are already adjusted by
+  // 'DetectAndHandleEpilog' and we can return here. If no, then we must unwind using the entire
+  // sequence of the unwind codes.
+  uint64_t current_offset_from_start = pc_rva - function_at_pc.start_address;
+  if (current_offset_from_start > unwind_info.prolog_size) {
+    if (epilog_->DetectAndHandleEpilog(function_at_pc.start_address, function_at_pc.end_address,
+                                       current_offset_from_start, process_memory, regs)) {
+      *finished = (regs->pc() == 0);
+      return true;
+    }
+    // If 'DetectAndHandleEpilog' fails with an error, we have to return here.
+    if (epilog_->GetLastError().code != ERROR_NONE) {
+      last_error_ = epilog_->GetLastError();
+      return false;
+    }
+  }
+
+  if (!unwind_info_evaluator_->Eval(process_memory, regs, unwind_info, unwind_infos_.get(),
+                                    current_offset_from_start)) {
+    last_error_ = unwind_info_evaluator_->GetLastError();
+    return false;
+  }
+
+  uint64_t return_address;
+  if (!process_memory->Read64(cur_regs->sp(), &return_address)) {
+    last_error_.code = ERROR_MEMORY_INVALID;
+    last_error_.address = cur_regs->sp();
+    return false;
+  }
+  cur_regs->set_sp(cur_regs->sp() + sizeof(uint64_t));
+  cur_regs->set_pc(return_address);
+
+  *finished = (regs->pc() == 0);
+
+  return true;
+}
+
+}  // namespace unwindstack

--- a/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H
+#define _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H
+
+#include <memory>
+
+#include "PeCoffEpilog.h"
+#include "PeCoffRuntimeFunctions.h"
+#include "PeCoffUnwindInfoEvaluator.h"
+#include "PeCoffUnwindInfos.h"
+#include "unwindstack/PeCoffInterface.h"
+#include "unwindstack/PeCoffNativeUnwinder.h"
+
+namespace unwindstack {
+
+// Unwinding for native PE/COFF frames on x86_64. The unwinding procedure is specific to the
+// x86_64 architecture: The unwind info used here (UNWIND_INFO and RUNTIME_FUNCTION) is only
+// defined for 64-bit binaries and parts of the procedure directly look and emulate machine
+// code (epilog detection).
+class PeCoffUnwindInfoUnwinderX86_64 : public PeCoffNativeUnwinder {
+ public:
+  explicit PeCoffUnwindInfoUnwinderX86_64(Memory* object_file_memory, int64_t image_base,
+                                          uint64_t pdata_begin, uint64_t pdata_end,
+                                          uint64_t text_section_vmaddr,
+                                          uint64_t text_section_offset,
+                                          const std::vector<Section>& sections)
+      : runtime_functions_(CreatePeCoffRuntimeFunctions(object_file_memory)),
+        unwind_infos_(CreatePeCoffUnwindInfos(object_file_memory, sections)),
+        unwind_info_evaluator_(CreatePeCoffUnwindInfoEvaluator()),
+        epilog_(CreatePeCoffEpilog(object_file_memory, text_section_vmaddr, text_section_offset)),
+        image_base_(image_base),
+        pdata_begin_(pdata_begin),
+        pdata_end_(pdata_end) {}
+
+  bool Init() override {
+    if (!epilog_->Init()) {
+      return false;
+    }
+    return runtime_functions_->Init(pdata_begin_, pdata_end_);
+  }
+
+  bool Step(uint64_t pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory, bool* finished,
+            bool* is_signal_frame) override;
+
+ protected:
+  std::unique_ptr<PeCoffRuntimeFunctions> runtime_functions_;
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos_;
+  std::unique_ptr<PeCoffUnwindInfoEvaluator> unwind_info_evaluator_;
+  std::unique_ptr<PeCoffEpilog> epilog_;
+
+  int64_t image_base_ = 0;
+  uint64_t pdata_begin_ = 0;
+  uint64_t pdata_end_ = 0;
+};
+
+}  // namespace unwindstack
+
+#endif  // _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H

--- a/third_party/libunwindstack/include/unwindstack/PeCoffNativeUnwinder.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffNativeUnwinder.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LIBUNWINDSTACK_PE_COFF_NATIVE_UNWINDER_H
+#define _LIBUNWINDSTACK_PE_COFF_NATIVE_UNWINDER_H
+
+#include <unwindstack/Error.h>
+#include <unwindstack/Memory.h>
+#include <unwindstack/Regs.h>
+
+namespace unwindstack {
+
+class PeCoffNativeUnwinder {
+ public:
+  virtual ~PeCoffNativeUnwinder() = default;
+
+  virtual bool Init() = 0;
+
+  virtual bool Step(uint64_t pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
+                    bool* finished, bool* is_signal_frame) = 0;
+  ErrorData GetLastError() const { return last_error_; }
+
+ protected:
+  ErrorData last_error_{ERROR_NONE, 0};
+};
+
+}  // namespace unwindstack
+
+#endif  // _LIBUNWINDSTACK_PE_COFF_NATIVE_UNWINDER_H

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
@@ -1,0 +1,385 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PeCoffUnwindInfoUnwinderX86_64.h"
+
+#include <algorithm>
+#include <limits>
+
+#include "unwindstack/Error.h"
+#include "unwindstack/MachineX86_64.h"
+#include "unwindstack/RegsX86_64.h"
+#include "utils/MemoryFake.h"
+
+#include "PeCoffEpilog.h"
+#include "PeCoffRuntimeFunctions.h"
+#include "PeCoffUnwindInfoEvaluator.h"
+#include "PeCoffUnwindInfos.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace unwindstack {
+
+class MockPeCoffRuntimeFunctions : public PeCoffRuntimeFunctions {
+ public:
+  MockPeCoffRuntimeFunctions() = default;
+
+  MOCK_METHOD(bool, Init, (uint64_t, uint64_t), (override));
+  MOCK_METHOD(bool, FindRuntimeFunction, (uint64_t, RuntimeFunction*), (const, override));
+};
+
+class MockPeCoffUnwindInfos : public PeCoffUnwindInfos {
+ public:
+  MockPeCoffUnwindInfos() = default;
+
+  MOCK_METHOD(bool, GetUnwindInfo, (uint64_t, UnwindInfo*), (override));
+};
+
+class MockPeCoffEpilog : public PeCoffEpilog {
+ public:
+  MockPeCoffEpilog() = default;
+
+  MOCK_METHOD(bool, Init, (), (override));
+  MOCK_METHOD(bool, DetectAndHandleEpilog, (uint64_t, uint64_t, uint64_t, Memory*, Regs*),
+              (override));
+
+  void FailWithError(ErrorCode error_code) { last_error_.code = error_code; }
+};
+
+class MockPeCoffUnwindInfoEvaluator : public PeCoffUnwindInfoEvaluator {
+ public:
+  MockPeCoffUnwindInfoEvaluator() = default;
+
+  MOCK_METHOD(bool, Eval, (Memory*, Regs*, const UnwindInfo&, PeCoffUnwindInfos*, uint64_t),
+              (override));
+};
+
+class TestPeCoffUnwindInfoUnwinderX86_64 : public PeCoffUnwindInfoUnwinderX86_64 {
+ public:
+  TestPeCoffUnwindInfoUnwinderX86_64()
+      : PeCoffUnwindInfoUnwinderX86_64(nullptr, 0, 0, 0, 0, 0, {}) {}
+
+  void SetFakeRuntimeFuntions(std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions) {
+    this->runtime_functions_ = std::move(runtime_functions);
+  }
+
+  void SetFakeUnwindInfos(std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos) {
+    this->unwind_infos_ = std::move(unwind_infos);
+  }
+
+  void SetFakeEpilog(std::unique_ptr<MockPeCoffEpilog> epilog) {
+    this->epilog_ = std::move(epilog);
+  }
+
+  void SetFakeUnwindInfoEvaluator(
+      std::unique_ptr<MockPeCoffUnwindInfoEvaluator> unwind_info_evaluator) {
+    this->unwind_info_evaluator_ = std::move(unwind_info_evaluator);
+  }
+};
+
+TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_succeeds_on_leaf_functions) {
+  TestPeCoffUnwindInfoUnwinderX86_64 test_unwinder;
+
+  std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions =
+      std::make_unique<MockPeCoffRuntimeFunctions>();
+  // Leaf functions are exactly the functions that don't have RUNTIME_FUNCTION entries.
+  EXPECT_CALL(*runtime_functions, FindRuntimeFunction(0, testing::_))
+      .WillOnce(::testing::Return(false));
+  test_unwinder.SetFakeRuntimeFuntions(std::move(runtime_functions));
+
+  RegsX86_64 regs;
+  MemoryFake process_memory;
+  bool finished = false;
+  bool is_signal_frame = false;
+
+  regs.set_sp(0x0);
+  process_memory.SetData64(0x0, 0x1000);
+
+  EXPECT_TRUE(test_unwinder.Step(0, 0, &regs, &process_memory, &finished, &is_signal_frame));
+  EXPECT_EQ(regs.sp(), 0x8);
+  EXPECT_EQ(regs.pc(), 0x1000);
+  EXPECT_FALSE(finished);
+  EXPECT_FALSE(is_signal_frame);
+}
+
+TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_fails_on_leaf_functions_if_memory_invalid) {
+  TestPeCoffUnwindInfoUnwinderX86_64 test_unwinder;
+
+  std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions =
+      std::make_unique<MockPeCoffRuntimeFunctions>();
+
+  // Leaf functions are exactly the functions that don't have RUNTIME_FUNCTION entries.
+  EXPECT_CALL(*runtime_functions, FindRuntimeFunction(0, testing::_))
+      .WillOnce(::testing::Return(false));
+
+  test_unwinder.SetFakeRuntimeFuntions(std::move(runtime_functions));
+
+  RegsX86_64 regs;
+  MemoryFake process_memory;
+  bool finished = false;
+  bool is_signal_frame = false;
+
+  EXPECT_FALSE(test_unwinder.Step(0, 0, &regs, &process_memory, &finished, &is_signal_frame));
+  EXPECT_EQ(test_unwinder.GetLastError().code, ERROR_MEMORY_INVALID);
+}
+
+TEST(PeCoffUnwindInfoUnwinderX86_64Test,
+     step_succeeds_when_epilog_detection_is_triggered_and_succeeds) {
+  TestPeCoffUnwindInfoUnwinderX86_64 test_unwinder;
+
+  constexpr uint64_t kFunctionStartAddress = 0x100;
+  constexpr uint64_t kFunctionEndAddress = 0x200;
+  constexpr uint64_t kPc = kFunctionStartAddress + 0x20;
+
+  std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions =
+      std::make_unique<MockPeCoffRuntimeFunctions>();
+  EXPECT_CALL(*runtime_functions, FindRuntimeFunction)
+      .WillOnce([](uint64_t, RuntimeFunction* runtime_function) {
+        RuntimeFunction function{kFunctionStartAddress, kFunctionEndAddress, 0};
+        *runtime_function = function;
+        return true;
+      });
+
+  std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info) {
+    UnwindInfo info;
+    info.prolog_size = 0x16;
+    *unwind_info = info;
+    return true;
+  });
+
+  std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
+  EXPECT_CALL(*epilog, DetectAndHandleEpilog).WillOnce(testing::Return(true));
+
+  std::unique_ptr<MockPeCoffUnwindInfoEvaluator> unwind_info_evaluator =
+      std::make_unique<MockPeCoffUnwindInfoEvaluator>();
+  EXPECT_CALL(*unwind_info_evaluator, Eval).Times(0);
+
+  test_unwinder.SetFakeRuntimeFuntions(std::move(runtime_functions));
+  test_unwinder.SetFakeUnwindInfos(std::move(unwind_infos));
+  test_unwinder.SetFakeEpilog(std::move(epilog));
+  test_unwinder.SetFakeUnwindInfoEvaluator(std::move(unwind_info_evaluator));
+
+  RegsX86_64 regs;
+  MemoryFake process_memory;
+  bool finished = false;
+  bool is_signal_frame = false;
+
+  EXPECT_TRUE(test_unwinder.Step(kPc, 0, &regs, &process_memory, &finished, &is_signal_frame));
+  EXPECT_TRUE(finished);
+  EXPECT_FALSE(is_signal_frame);
+}
+
+TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_fails_if_error_occurs_in_epilog_detection) {
+  TestPeCoffUnwindInfoUnwinderX86_64 test_unwinder;
+
+  constexpr uint64_t kFunctionStartAddress = 0x100;
+  constexpr uint64_t kFunctionEndAddress = 0x200;
+  constexpr uint64_t kPc = kFunctionStartAddress + 0x20;
+
+  std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions =
+      std::make_unique<MockPeCoffRuntimeFunctions>();
+  EXPECT_CALL(*runtime_functions, FindRuntimeFunction)
+      .WillOnce([](uint64_t, RuntimeFunction* runtime_function) {
+        RuntimeFunction function{kFunctionStartAddress, kFunctionEndAddress, 0};
+        *runtime_function = function;
+        return true;
+      });
+
+  std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info) {
+    UnwindInfo info;
+    info.prolog_size = 0x16;
+    *unwind_info = info;
+    return true;
+  });
+
+  std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
+  epilog->FailWithError(ERROR_MEMORY_INVALID);
+
+  EXPECT_CALL(*epilog, DetectAndHandleEpilog)
+      .WillOnce([](uint64_t, uint64_t, uint64_t, Memory*, Regs*) { return false; });
+
+  std::unique_ptr<MockPeCoffUnwindInfoEvaluator> unwind_info_evaluator =
+      std::make_unique<MockPeCoffUnwindInfoEvaluator>();
+  EXPECT_CALL(*unwind_info_evaluator, Eval).Times(0);
+
+  test_unwinder.SetFakeRuntimeFuntions(std::move(runtime_functions));
+  test_unwinder.SetFakeUnwindInfos(std::move(unwind_infos));
+  test_unwinder.SetFakeEpilog(std::move(epilog));
+  test_unwinder.SetFakeUnwindInfoEvaluator(std::move(unwind_info_evaluator));
+
+  RegsX86_64 regs;
+  MemoryFake process_memory;
+  bool finished = false;
+  bool is_signal_frame = false;
+
+  EXPECT_FALSE(test_unwinder.Step(kPc, 0, &regs, &process_memory, &finished, &is_signal_frame));
+
+  // Make sure the unwinder reports the same error that epilog detection reported.
+  EXPECT_EQ(test_unwinder.GetLastError().code, ERROR_MEMORY_INVALID);
+}
+
+TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_succeeds_if_eval_succeeds_inside_of_prolog) {
+  TestPeCoffUnwindInfoUnwinderX86_64 test_unwinder;
+
+  constexpr uint64_t kFunctionStartAddress = 0x100;
+  constexpr uint64_t kFunctionEndAddress = 0x200;
+  constexpr uint64_t kPc = kFunctionStartAddress + 0x10;
+
+  std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions =
+      std::make_unique<MockPeCoffRuntimeFunctions>();
+  EXPECT_CALL(*runtime_functions, FindRuntimeFunction)
+      .WillOnce([](uint64_t, RuntimeFunction* runtime_function) {
+        RuntimeFunction function{kFunctionStartAddress, kFunctionEndAddress, 0};
+        *runtime_function = function;
+        return true;
+      });
+
+  std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info_result) {
+    UnwindInfo info;
+    info.prolog_size = 0x20;
+    *unwind_info_result = info;
+    return true;
+  });
+
+  std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
+  EXPECT_CALL(*epilog, DetectAndHandleEpilog).Times(0);
+
+  std::unique_ptr<MockPeCoffUnwindInfoEvaluator> unwind_info_evaluator =
+      std::make_unique<MockPeCoffUnwindInfoEvaluator>();
+  EXPECT_CALL(*unwind_info_evaluator, Eval).WillOnce(testing::Return(true));
+
+  test_unwinder.SetFakeRuntimeFuntions(std::move(runtime_functions));
+  test_unwinder.SetFakeUnwindInfos(std::move(unwind_infos));
+  test_unwinder.SetFakeEpilog(std::move(epilog));
+  test_unwinder.SetFakeUnwindInfoEvaluator(std::move(unwind_info_evaluator));
+
+  RegsX86_64 regs;
+
+  // We need to make sure memory can be read when reading the return address, otherwise the step
+  // will fail. Since we are mocking everything, the registers are not updated correctly and it
+  // doesn't really make sense to test for a specific location of the stack pointer.
+  MemoryFakeAlwaysReadZero process_memory;
+
+  bool finished = false;
+  bool is_signal_frame = false;
+
+  EXPECT_TRUE(test_unwinder.Step(kPc, 0, &regs, &process_memory, &finished, &is_signal_frame));
+  EXPECT_TRUE(finished);
+  EXPECT_FALSE(is_signal_frame);
+}
+
+TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_succeeds_if_eval_succeeds_outside_of_prolog) {
+  TestPeCoffUnwindInfoUnwinderX86_64 test_unwinder;
+
+  constexpr uint64_t kFunctionStartAddress = 0x100;
+  constexpr uint64_t kFunctionEndAddress = 0x200;
+  constexpr uint64_t kPc = kFunctionStartAddress + 0x10;
+
+  std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions =
+      std::make_unique<MockPeCoffRuntimeFunctions>();
+  EXPECT_CALL(*runtime_functions, FindRuntimeFunction)
+      .WillOnce([](uint64_t, RuntimeFunction* runtime_function) {
+        RuntimeFunction function{kFunctionStartAddress, kFunctionEndAddress, 0};
+        *runtime_function = function;
+        return true;
+      });
+
+  std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info_result) {
+    UnwindInfo info;
+    info.prolog_size = 0x8;
+    *unwind_info_result = info;
+    return true;
+  });
+
+  std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
+  EXPECT_CALL(*epilog, DetectAndHandleEpilog).WillOnce(testing::Return(false));
+
+  std::unique_ptr<MockPeCoffUnwindInfoEvaluator> unwind_info_evaluator =
+      std::make_unique<MockPeCoffUnwindInfoEvaluator>();
+  EXPECT_CALL(*unwind_info_evaluator, Eval).WillOnce(testing::Return(true));
+
+  test_unwinder.SetFakeRuntimeFuntions(std::move(runtime_functions));
+  test_unwinder.SetFakeUnwindInfos(std::move(unwind_infos));
+  test_unwinder.SetFakeEpilog(std::move(epilog));
+  test_unwinder.SetFakeUnwindInfoEvaluator(std::move(unwind_info_evaluator));
+
+  RegsX86_64 regs;
+
+  // We need to make sure memory can be read when reading the return address, otherwise the step
+  // will fail. Since we are mocking everything, the registers are not updated correctly and it
+  // doesn't really make sense to test for a specific location of the stack pointer.
+  MemoryFakeAlwaysReadZero process_memory;
+
+  bool finished = false;
+  bool is_signal_frame = false;
+
+  EXPECT_TRUE(test_unwinder.Step(kPc, 0, &regs, &process_memory, &finished, &is_signal_frame));
+  EXPECT_TRUE(finished);
+  EXPECT_FALSE(is_signal_frame);
+}
+
+TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_fails_after_eval_if_return_address_location_invalid) {
+  TestPeCoffUnwindInfoUnwinderX86_64 test_unwinder;
+
+  constexpr uint64_t kFunctionStartAddress = 0x100;
+  constexpr uint64_t kFunctionEndAddress = 0x200;
+  constexpr uint64_t kPc = kFunctionStartAddress + 0x10;
+
+  std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions =
+      std::make_unique<MockPeCoffRuntimeFunctions>();
+  EXPECT_CALL(*runtime_functions, FindRuntimeFunction)
+      .WillOnce([](uint64_t, RuntimeFunction* runtime_function) {
+        RuntimeFunction function{kFunctionStartAddress, kFunctionEndAddress, 0};
+        *runtime_function = function;
+        return true;
+      });
+
+  std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info_result) {
+    UnwindInfo info;
+    info.prolog_size = 0x20;
+    *unwind_info_result = info;
+    return true;
+  });
+
+  std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
+  EXPECT_CALL(*epilog, DetectAndHandleEpilog).Times(0);
+
+  std::unique_ptr<MockPeCoffUnwindInfoEvaluator> unwind_info_evaluator =
+      std::make_unique<MockPeCoffUnwindInfoEvaluator>();
+  EXPECT_CALL(*unwind_info_evaluator, Eval).WillOnce(testing::Return(true));
+
+  test_unwinder.SetFakeRuntimeFuntions(std::move(runtime_functions));
+  test_unwinder.SetFakeUnwindInfos(std::move(unwind_infos));
+  test_unwinder.SetFakeEpilog(std::move(epilog));
+  test_unwinder.SetFakeUnwindInfoEvaluator(std::move(unwind_info_evaluator));
+
+  RegsX86_64 regs;
+  MemoryFake process_memory;
+
+  bool finished = false;
+  bool is_signal_frame = false;
+
+  EXPECT_FALSE(test_unwinder.Step(kPc, 0, &regs, &process_memory, &finished, &is_signal_frame));
+  EXPECT_EQ(test_unwinder.GetLastError().code, ERROR_MEMORY_INVALID);
+}
+
+}  // namespace unwindstack


### PR DESCRIPTION
This ties together various of the other classes to get the runtime
functions, the unwind info, detect and handle epilogs, and unwind
info evaluation. The tests mock away these other classes as they are 
unit tested in detail individually.

Tested: Unit tests pass.
Bug: http://b/194768602