### PR TITLE
Add missing include in Geometry.h

### DIFF
--- a/src/OrbitGl/Geometry.h
+++ b/src/OrbitGl/Geometry.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_GEOMETRY_H_
 #define ORBIT_GL_GEOMETRY_H_
 
+#include <algorithm>
 #include <utility>
 
 #include "CoreMath.h"


### PR DESCRIPTION
Add <algorithm> include for "std::transform". This was breaking my
local build, not sure why it's not breaking the CI.