### PR TITLE
Support anonymously mapped PE/COFF files in LinuxMap

### DIFF
--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -129,8 +129,9 @@ class FileMappedIntoMemory {
   FileMappedIntoMemory(std::string file_path, uint64_t first_map_start, uint64_t first_map_offset)
       : file_path_{std::move(file_path)}, base_address_{first_map_start - first_map_offset} {
     if (first_map_start < first_map_offset) {
-      // base_address_ is the result of an underflow. This shouldn't normally happen, so immediately
-      // coff_text_section_map_might_be_encountered_ to false and never use base_address_.
+      // In this case, base_address_ is the result of an underflow. This shouldn't normally happen,
+      // so immediately set coff_text_section_map_might_be_encountered_ to false and never use
+      // base_address_.
       coff_text_section_map_might_be_encountered_ = false;
     }
   }

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -213,6 +213,13 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
     std::vector<std::string> tokens = absl::StrSplit(line, absl::MaxSplits(' ', 5));
     if (tokens.size() < 5) continue;
 
+    if (tokens.size() == 6) {
+      absl::StripLeadingAsciiWhitespace(&tokens[5]);
+      if (tokens[5].empty()) {
+        tokens.pop_back();
+      }
+    }
+
     const std::string& inode = tokens[4];
     // If inode equals 0, then the memory is not backed by a file.
     // If a map not backed by a file has a name, it's a special one like [stack], [heap], etc.
@@ -228,7 +235,6 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
     std::string module_path;
     if (inode != "0") {  // The mapping is file-backed.
       if (tokens.size() == 6) {
-        absl::StripLeadingAsciiWhitespace(&tokens[5]);
         module_path = tokens[5];
         if (!last_file_mapped_into_memory.has_value() ||
             module_path != last_file_mapped_into_memory->GetFilePath()) {

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -250,6 +250,8 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
     if (inode != "0") {  // The mapping is file-backed.
       if (tokens.size() == 6) {
         module_path = tokens[5];
+        // Keep track of the last file we encountered. Only create a new FileMappedIntoMemory if
+        // this file mapping is backed by a different file than the previous file mapping.
         if (!last_file_mapped_into_memory.has_value() ||
             module_path != last_file_mapped_into_memory->GetFilePath()) {
           last_file_mapped_into_memory.emplace(module_path, start, offset);

--- a/src/ObjectUtils/LinuxMapTest.cpp
+++ b/src/ObjectUtils/LinuxMapTest.cpp
@@ -222,7 +222,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtExpectedOffset) {
 
   const std::string data{
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
-                      "101000-103000 r-xp 00000000 00:00 0\n",
+                      "101000-103000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
@@ -249,11 +249,11 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyInMoreComplexExample) {
   const std::string data{
       absl::StrFormat("10000-11000 r--p 00000000 00:00 0    [stack]\n"
                       "100000-100C00 r--p 00000000 01:02 42    %1$s\n"  // The headers.
-                      "100C00-100D00 rw-p 00000000 00:00 0\n"
+                      "100C00-100D00 rw-p 00000000 00:00 0 \n"
                       "100D00-100E00 r--p 00000D00 01:02 42    %1$s\n"
                       "100E00-100F00 rw-p 00000000 00:00 0    [special]\n"
                       "100F00-101000 r--p 00000F00 01:02 42    %1$s\n"
-                      "101000-103000 r-xp 00000000 00:00 0\n"  // The .text segment.
+                      "101000-103000 r-xp 00000000 00:00 0 \n"  // The .text segment.
                       "200000-201000 r-xp 00000000 01:02 42    /path/to/nothing\n",
                       libtest_path)};
   const auto result = ParseMaps(data);
@@ -305,7 +305,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtLowerThanExpectedOffset) {
   // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
   const std::string data{
       absl::StrFormat("100100-101000 r--p 00000100 01:02 42    %s\n"
-                      "100F00-103000 r-xp 00000000 00:00 0\n",
+                      "100F00-103000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
@@ -331,7 +331,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtExpectedOffsetAndFirstMapWi
   // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
   const std::string data{
       absl::StrFormat("100100-101000 r--p 00000100 01:02 42    %s\n"
-                      "101000-103000 r-xp 00000000 00:00 0\n",
+                      "101000-103000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
@@ -369,7 +369,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyButNotExecutable) {
 
   const std::string data{
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
-                      "101000-103000 r--p 00000000 00:00 0\n",
+                      "101000-103000 r--p 00000000 00:00 0 \n",
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
@@ -382,7 +382,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyButExecutableMapAlreadyExists
 
   const std::string data{
       absl::StrFormat("100000-101000 r-xp 00000000 01:02 42    %s\n"
-                      "101000-103000 r-xp 00000000 00:00 0\n",
+                      "101000-103000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
@@ -408,7 +408,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtOffsetTooHigh) {
 
   const std::string data{
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
-                      "102000-103000 r-xp 00000000 00:00 0\n",
+                      "102000-103000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
@@ -421,7 +421,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyWithSizeTooSmall) {
 
   const std::string data{
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
-                      "101000-102000 r-xp 00000000 00:00 0\n",
+                      "101000-102000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());

--- a/src/ObjectUtils/LinuxMapTest.cpp
+++ b/src/ObjectUtils/LinuxMapTest.cpp
@@ -221,7 +221,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtExpectedOffset) {
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
   const std::string data{
-      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
                       "101000-103000 r-xp 00000000 00:00 0\n",
                       libtest_path)};
   const auto result = ParseMaps(data);
@@ -248,14 +248,14 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyInMoreComplexExample) {
   // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
   const std::string data{
       absl::StrFormat("10000-11000 r--p 00000000 00:00 0    [stack]\n"
-                      "100000-100C00 r--p 00000000 01:02 42    %s\n"  // The headers.
+                      "100000-100C00 r--p 00000000 01:02 42    %1$s\n"  // The headers.
                       "100C00-100D00 rw-p 00000000 00:00 0\n"
-                      "100D00-100E00 r--p 00000D00 01:02 42    %s\n"
+                      "100D00-100E00 r--p 00000D00 01:02 42    %1$s\n"
                       "100E00-100F00 rw-p 00000000 00:00 0    [special]\n"
-                      "100F00-101000 r--p 00000F00 01:02 42    %s\n"
+                      "100F00-101000 r--p 00000F00 01:02 42    %1$s\n"
                       "101000-103000 r-xp 00000000 00:00 0\n"  // The .text segment.
                       "200000-201000 r-xp 00000000 01:02 42    /path/to/nothing\n",
-                      libtest_path, libtest_path, libtest_path)};
+                      libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
   ASSERT_EQ(result.value().size(), 1);
@@ -278,9 +278,9 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedNotAnonymously) {
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
   const std::string data{
-      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
-                      "101000-103000 r-xp 00001000 01:02 42    %s\n",
-                      libtest_path, libtest_path)};
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
+                      "101000-103000 r-xp 00001000 01:02 42    %1$s\n",
+                      libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
   ASSERT_EQ(result.value().size(), 1);

--- a/src/ObjectUtils/LinuxMapTest.cpp
+++ b/src/ObjectUtils/LinuxMapTest.cpp
@@ -85,7 +85,7 @@ TEST(LinuxMap, CreateModuleNotElf) {
               testing::HasSubstr("The file was not recognized as a valid object file"));
 }
 
-TEST(LinuxMan, CreateModuleWithSoname) {
+TEST(LinuxMap, CreateModuleWithSoname) {
   const std::filesystem::path hello_world_path = orbit_test::GetTestdataDir() / "libtest-1.0.so";
 
   constexpr uint64_t kStartAddress = 23;
@@ -214,6 +214,218 @@ TEST(LinuxMap, ParseMapsWithSpacesInPath) {
   EXPECT_EQ(hello_module_info.build_id(), "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
   EXPECT_EQ(hello_module_info.load_bias(), 0x0);
   EXPECT_EQ(hello_module_info.object_file_type(), ModuleInfo::kElfFile);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtExpectedOffset) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
+                      "101000-103000 r-xp 00000000 00:00 0\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 1);
+
+  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
+  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
+  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
+  EXPECT_EQ(libtest_module_info.file_size(), 96441);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
+  EXPECT_EQ(libtest_module_info.build_id(), "");
+  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
+  EXPECT_EQ(libtest_module_info.soname(), "");
+  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyInMoreComplexExample) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
+  const std::string data{
+      absl::StrFormat("10000-11000 r--p 00000000 00:00 0    [stack]\n"
+                      "100000-100C00 r--p 00000000 01:02 42    %s\n"  // The headers.
+                      "100C00-100D00 rw-p 00000000 00:00 0\n"
+                      "100D00-100E00 r--p 00000D00 01:02 42    %s\n"
+                      "100E00-100F00 rw-p 00000000 00:00 0    [special]\n"
+                      "100F00-101000 r--p 00000F00 01:02 42    %s\n"
+                      "101000-103000 r-xp 00000000 00:00 0\n"  // The .text segment.
+                      "200000-201000 r-xp 00000000 01:02 42    /path/to/nothing\n",
+                      libtest_path, libtest_path, libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 1);
+
+  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
+  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
+  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
+  EXPECT_EQ(libtest_module_info.file_size(), 96441);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
+  EXPECT_EQ(libtest_module_info.build_id(), "");
+  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
+  EXPECT_EQ(libtest_module_info.soname(), "");
+  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedNotAnonymously) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
+                      "101000-103000 r-xp 00001000 01:02 42    %s\n",
+                      libtest_path, libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 1);
+
+  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
+  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
+  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
+  EXPECT_EQ(libtest_module_info.file_size(), 96441);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
+  EXPECT_EQ(libtest_module_info.build_id(), "");
+  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
+  EXPECT_EQ(libtest_module_info.soname(), "");
+  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtLowerThanExpectedOffset) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
+  const std::string data{
+      absl::StrFormat("100100-101000 r--p 00000100 01:02 42    %s\n"
+                      "100F00-103000 r-xp 00000000 00:00 0\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 1);
+
+  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
+  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
+  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
+  EXPECT_EQ(libtest_module_info.file_size(), 96441);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x100F00);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
+  EXPECT_EQ(libtest_module_info.build_id(), "");
+  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
+  EXPECT_EQ(libtest_module_info.soname(), "");
+  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtExpectedOffsetAndFirstMapWithOffset) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
+  const std::string data{
+      absl::StrFormat("100100-101000 r--p 00000100 01:02 42    %s\n"
+                      "101000-103000 r-xp 00000000 00:00 0\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 1);
+
+  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
+  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
+  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
+  EXPECT_EQ(libtest_module_info.file_size(), 96441);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
+  EXPECT_EQ(libtest_module_info.build_id(), "");
+  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
+  EXPECT_EQ(libtest_module_info.soname(), "");
+  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedWithWrongName) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
+                      "101000-103000 r-xp 00000000 00:00 42    /wrong/path\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  EXPECT_EQ(result.value().size(), 0);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyButNotExecutable) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
+                      "101000-103000 r--p 00000000 00:00 0\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  EXPECT_EQ(result.value().size(), 0);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyButExecutableMapAlreadyExists) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("100000-101000 r-xp 00000000 01:02 42    %s\n"
+                      "101000-103000 r-xp 00000000 00:00 0\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 1);
+
+  // This comes from the first mapping, not the second.
+  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
+  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
+  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
+  EXPECT_EQ(libtest_module_info.file_size(), 96441);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x100000);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x101000);
+  EXPECT_EQ(libtest_module_info.build_id(), "");
+  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
+  EXPECT_EQ(libtest_module_info.soname(), "");
+  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtOffsetTooHigh) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
+                      "102000-103000 r-xp 00000000 00:00 0\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  EXPECT_EQ(result.value().size(), 0);
+}
+
+TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyWithSizeTooSmall) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
+                      "101000-102000 r-xp 00000000 00:00 0\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  EXPECT_EQ(result.value().size(), 0);
 }
 
 }  // namespace orbit_object_utils


### PR DESCRIPTION
We want to detect whether an anonymous mapping corresponds to the .text segment
of a PE loaded by Wine. The mapping is anonymous if the offset of the section in
the file (`PointerToRawData`) is not congruent to the offset when loaded into
memory (`VirtualAddress`) modulo the page size.

The idea is the following:
Given an anonymous executable mapping, consider the previous "group" of file
mappings that are all backed by the same file, and in particular consider the
first of these mappings. If that file is a PE, and there is no executable file
mapping in this "group" of file mappings, and the address range where the .text
section of that PE should be mapped (based on the file mapping's address and on
the .text section's `VirtualAddress` and `VirtualSize`) is contained in the
anonymous mapping's address range, then we can be fairly sure that the anonymous
mapping does indeed correspond to the .text of the PE.

We add this logic to `orbit_object_utils::ParseMaps` so that PEs with the
characteristic mentioned above are recognized as modules and loaded. The class
`FileMappedIntoMemory` helps contains most of the logic and allows us to perform
the detection while scanning `/proc/[pid]/maps` line by line.

More information on the problem in the documents linked in the bug.

Bug: http://b/226562022

Test: Unit tests. Load modules of unaligned `triangle.exe` and of Virtus: verify
the main binary shows up. Use user space instrumentation on `triangle.exe` and
on Virtus: this confirms addresses are correct.