### PR TITLE
Move TextRenderer to orbit_gl namespace

### DIFF
--- a/src/OrbitGl/AnnotationTrack.cpp
+++ b/src/OrbitGl/AnnotationTrack.cpp
@@ -14,6 +14,7 @@ const Color kThresholdColor(179, 0, 80, 255);
 
 using orbit_gl::PickingUserData;
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
 
 void AnnotationTrack::DrawAnnotation(PrimitiveAssembler& primitive_assembler,
                                      TextRenderer& text_renderer, const TimeGraphLayout* layout,

--- a/src/OrbitGl/AnnotationTrack.h
+++ b/src/OrbitGl/AnnotationTrack.h
@@ -37,7 +37,7 @@ class AnnotationTrack {
   }
 
   void DrawAnnotation(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                      TextRenderer& text_renderer, const TimeGraphLayout* layout,
+                      orbit_gl::TextRenderer& text_renderer, const TimeGraphLayout* layout,
                       int indentation_level, float z);
 
  private:

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -28,6 +28,8 @@
 
 using orbit_client_protos::TimerInfo;
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
+
 using orbit_grpc_protos::InstrumentedFunction;
 
 AsyncTrack::AsyncTrack(CaptureViewElement* parent,

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -40,8 +40,8 @@ class AsyncTrack final : public TimerTrack {
 
  protected:
   void DoUpdatePrimitives(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                          TextRenderer& text_renderer, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode) override;
+                          orbit_gl::TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
   [[nodiscard]] float GetDefaultBoxHeight() const override;
   [[nodiscard]] std::string GetTimesliceText(
       const orbit_client_protos::TimerInfo& timer) const override;

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -46,6 +46,7 @@ using orbit_client_data::CaptureData;
 using orbit_gl::Batcher;
 using orbit_gl::PickingUserData;
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
 
 constexpr const char* kTimingDraw = "Draw";
 constexpr const char* kTimingDrawAndUpdatePrimitives = "Draw & Update Primitives";

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -22,7 +22,10 @@
 
 using orbit_client_data::CaptureData;
 using orbit_client_protos::TimerInfo;
+
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
+
 using orbit_grpc_protos::InstrumentedFunction;
 
 namespace {

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -58,11 +58,11 @@ class FrameTrack : public TimerTrack {
 
  protected:
   void DoUpdatePrimitives(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                          TextRenderer& text_renderer, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode) override;
+                          orbit_gl::TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
 
-  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
-              const DrawContext& draw_context) override;
+  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
+              orbit_gl::TextRenderer& text_renderer, const DrawContext& draw_context) override;
 
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected, bool is_highlighted,

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -68,7 +68,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   }
   virtual void OnContextMenu(const std::string& /*a_Action*/, int /*a_MenuIndex*/) {}
 
-  [[nodiscard]] TextRenderer& GetTextRenderer() { return text_renderer_; }
+  [[nodiscard]] orbit_gl::TextRenderer& GetTextRenderer() { return text_renderer_; }
 
   [[nodiscard]] const Vec2i& GetMouseScreenPos() const { return mouse_move_pos_screen_; }
 
@@ -150,7 +150,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   ImGuiContext* imgui_context_ = nullptr;
   double ref_time_click_;
   float track_container_click_scrolling_offset_ = 0;
-  TextRenderer text_renderer_;
+  orbit_gl::TextRenderer text_renderer_;
   PickingManager picking_manager_;
   bool double_clicking_;
   bool control_key_;

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -16,11 +16,11 @@
 #include "CoreMath.h"
 #include "PickingManager.h"
 #include "StringManager/StringManager.h"
+#include "TextRenderer.h"
 #include "TimerTrack.h"
 #include "Track.h"
 
 class OrbitApp;
-class TextRenderer;
 
 // This is a thin implementation of a `TimerTrack` to display Vulkan debug markers, used in the
 // `GpuTrack`.

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -17,10 +17,10 @@
 #include "GpuDebugMarkerTrack.h"
 #include "PickingManager.h"
 #include "StringManager/StringManager.h"
+#include "TextRenderer.h"
 #include "Track.h"
 
 class OrbitApp;
-class TextRenderer;
 
 // This track displays the "vkQueueSubmit"s including its hardware execution times and -- if
 // available -- command buffer timings on a certain command queue. In order to visually separate

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -17,12 +17,12 @@
 #include "GpuDebugMarkerTrack.h"
 #include "GpuSubmissionTrack.h"
 #include "PickingManager.h"
+#include "TextRenderer.h"
 #include "TimerTrack.h"
 #include "Track.h"
 #include "Viewport.h"
 
 class OrbitApp;
-class TextRenderer;
 
 namespace orbit_gl {
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -27,6 +27,7 @@ constexpr const float kBoxHeightMultiplier = 1.5f;
 
 using orbit_gl::PickingUserData;
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
 
 template <size_t Dimension>
 GraphTrack<Dimension>::GraphTrack(CaptureViewElement* parent,

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -67,12 +67,12 @@ class GraphTrack : public Track {
   }
 
  protected:
-  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
-              const DrawContext& draw_context) override;
+  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
+              orbit_gl::TextRenderer& text_renderer, const DrawContext& draw_context) override;
 
   void DoUpdatePrimitives(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                          TextRenderer& text_renderer, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode) override;
+                          orbit_gl::TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
 
   [[nodiscard]] virtual Color GetColor(size_t index) const;
   [[nodiscard]] virtual double GetGraphMaxValue() const { return series_.GetMax(); }
@@ -94,10 +94,10 @@ class GraphTrack : public Track {
   [[nodiscard]] uint32_t GetLegendFontSize(uint32_t indentation_level = 0) const;
 
   virtual void DrawLabel(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                         TextRenderer& text_renderer, Vec2 target_pos, const std::string& text,
-                         const Color& text_color, const Color& font_color);
+                         orbit_gl::TextRenderer& text_renderer, Vec2 target_pos,
+                         const std::string& text, const Color& text_color, const Color& font_color);
   virtual void DrawLegend(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                          TextRenderer& text_renderer,
+                          orbit_gl::TextRenderer& text_renderer,
                           const std::array<std::string, Dimension>& series_names,
                           const Color& legend_text_color);
   virtual void DrawSeries(orbit_gl::PrimitiveAssembler& primitive_assembler, uint64_t min_tick,

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -19,6 +19,7 @@
 
 using orbit_client_protos::TimerInfo;
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
 
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSamePidColor(140, 140, 140, 255);

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -46,8 +46,8 @@ class SchedulerTrack final : public TimerTrack {
 
  protected:
   void DoUpdatePrimitives(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                          TextRenderer& text_renderer, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode) override;
+                          orbit_gl::TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected, bool is_highlighted,

--- a/src/OrbitGl/TextRenderer.cpp
+++ b/src/OrbitGl/TextRenderer.cpp
@@ -25,7 +25,7 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 
-using orbit_gl::PrimitiveAssembler;
+namespace orbit_gl {
 
 namespace {
 
@@ -503,3 +503,5 @@ void TextRenderer::Clear() {
     vertex_buffer_clear(buffer);
   }
 }
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -28,6 +28,8 @@ struct vertex_buffer_t;
 struct texture_font_t;
 }  // namespace ftgl
 
+namespace orbit_gl {
+
 class TextRenderer {
  public:
   enum class HAlign { Left, Right };
@@ -108,5 +110,7 @@ inline ftgl::vec4 ColorToVec4(const Color& color) {
   vec.a = color[3] * coeff;
   return vec;
 }
+
+}  // namespace orbit_gl
 
 #endif  // ORBIT_GL_TEXT_RENDERER_H_

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -39,6 +39,7 @@ using orbit_client_data::TimerChain;
 
 using orbit_gl::PickingUserData;
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
 
 using orbit_client_protos::TimerInfo;
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -83,8 +83,8 @@ class ThreadTrack final : public TimerTrack {
 
  protected:
   void DoUpdatePrimitives(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                          TextRenderer& text_renderer, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode picking_mode) override;
+                          orbit_gl::TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode picking_mode) override;
 
   [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -47,6 +47,7 @@ using orbit_gl::CGroupAndProcessMemoryTrack;
 using orbit_gl::PageFaultsTrack;
 using orbit_gl::PrimitiveAssembler;
 using orbit_gl::SystemMemoryTrack;
+using orbit_gl::TextRenderer;
 using orbit_gl::TrackManager;
 using orbit_gl::VariableTrack;
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -38,7 +38,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] float GetHeight() const override;
 
   void DrawAllElements(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                       TextRenderer& text_renderer, PickingMode& picking_mode,
+                       orbit_gl::TextRenderer& text_renderer, PickingMode& picking_mode,
                        uint64_t current_mouse_time_ns);
   void DrawText(float layer);
 
@@ -121,7 +121,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] bool IsPartlyVisible(uint64_t min, uint64_t max) const;
   [[nodiscard]] bool IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) const;
 
-  [[nodiscard]] TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
+  [[nodiscard]] orbit_gl::TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
   [[nodiscard]] orbit_gl::PrimitiveAssembler& GetPrimitiveAssembler() {
     return primitive_assembler_;
   }
@@ -179,7 +179,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
       const orbit_gl::ModifierKeys& modifiers = orbit_gl::ModifierKeys()) override;
 
   AccessibleInterfaceProvider* accessible_parent_;
-  TextRenderer text_renderer_static_;
+  orbit_gl::TextRenderer text_renderer_static_;
 
   double ref_time_us_ = 0;
   double min_time_us_ = 0;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -34,6 +34,7 @@ using orbit_client_protos::TimerInfo;
 
 using orbit_gl::PickingUserData;
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
 
 const Color TimerTrack::kHighlightColor = Color(100, 181, 246, 255);
 const Color TimerTrack::kBoxBorderColor = Color(255, 255, 255, 255);

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -102,8 +102,8 @@ class TimerTrack : public Track {
 
  protected:
   void DoUpdatePrimitives(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                          TextRenderer& text_renderer, uint64_t min_tick, uint64_t max_tick,
-                          PickingMode /*picking_mode*/) override;
+                          orbit_gl::TextRenderer& text_renderer, uint64_t min_tick,
+                          uint64_t max_tick, PickingMode /*picking_mode*/) override;
 
   [[nodiscard]] virtual bool IsTimerActive(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
@@ -117,7 +117,7 @@ class TimerTrack : public Track {
     return true;
   }
 
-  [[nodiscard]] bool DrawTimer(TextRenderer& text_renderer,
+  [[nodiscard]] bool DrawTimer(orbit_gl::TextRenderer& text_renderer,
                                const orbit_client_protos::TimerInfo* prev_timer_info,
                                const orbit_client_protos::TimerInfo* next_timer_info,
                                const internal::DrawData& draw_data,
@@ -130,8 +130,9 @@ class TimerTrack : public Track {
   }
   [[nodiscard]] std::string GetDisplayTime(const orbit_client_protos::TimerInfo&) const;
 
-  void DrawTimesliceText(TextRenderer& text_renderer, const orbit_client_protos::TimerInfo& timer,
-                         float min_x, Vec2 box_pos, Vec2 box_size);
+  void DrawTimesliceText(orbit_gl::TextRenderer& text_renderer,
+                         const orbit_client_protos::TimerInfo& timer, float min_x, Vec2 box_pos,
+                         Vec2 box_size);
 
   [[nodiscard]] static internal::DrawData GetDrawData(
       uint64_t min_tick, uint64_t max_tick, float track_pos_x, float track_width,
@@ -152,7 +153,8 @@ class TimerTrack : public Track {
         });
   }
 
-  [[nodiscard]] inline bool BoxHasRoomForText(TextRenderer& text_renderer, const float width) {
+  [[nodiscard]] inline bool BoxHasRoomForText(orbit_gl::TextRenderer& text_renderer,
+                                              const float width) {
     return text_renderer.GetStringWidth("w", layout_->CalculateZoomedFontSize()) < width;
   }
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -19,6 +19,7 @@
 
 using orbit_client_data::TimerData;
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
 
 Track::Track(CaptureViewElement* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
              orbit_gl::Viewport* viewport, TimeGraphLayout* layout,

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -114,8 +114,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
       const orbit_client_protos::TimerInfo& /*timer_info*/) const = 0;
 
  protected:
-  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
-              const DrawContext& draw_context) override;
+  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
+              orbit_gl::TextRenderer& text_renderer, const DrawContext& draw_context) override;
   void DoUpdateLayout() override;
 
   void DrawTriangleFan(orbit_gl::PrimitiveAssembler& primitive_assembler,

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -16,6 +16,7 @@
 #include "Track.h"
 
 using orbit_gl::PrimitiveAssembler;
+using orbit_gl::TextRenderer;
 
 TriangleToggle::TriangleToggle(CaptureViewElement* parent, const orbit_gl::Viewport* viewport,
                                const TimeGraphLayout* layout, StateChangeHandler handler)

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -42,8 +42,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   [[nodiscard]] uint32_t GetLayoutFlags() const override { return LayoutFlags::kNone; }
 
  protected:
-  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
-              const DrawContext& draw_context) override;
+  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
+              orbit_gl::TextRenderer& text_renderer, const DrawContext& draw_context) override;
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 


### PR DESCRIPTION
In this PR we are moving TextRenderer to orbit_gl namespace. We are
planning to Mock that class and since the mock class, the interface and
TextRenderer itself should be in that namespace we are previously
solving that tech-debt.

In addition we are erasing 3 forward declarations of TextRenderer that
are not needed anymore.

Bug: http://b/228609901

Test: The code compiles.