### PR TITLE
Refactoring of PE/COFF classes for easier unit testing

### DIFF
--- a/third_party/libunwindstack/CMakeLists.txt
+++ b/third_party/libunwindstack/CMakeLists.txt
@@ -71,10 +71,10 @@ target_sources(libunwindstack_common PRIVATE
   PeCoffInterface.cpp
   PeCoffRuntimeFunctions.cpp
   PeCoffRuntimeFunctions.h
+  PeCoffUnwindInfoEvaluator.h
+  PeCoffUnwindInfoEvaluator.cpp
   PeCoffUnwindInfos.cpp
   PeCoffUnwindInfos.h
-  PeCoffUnwindInfoUnwinderX86_64.h
-  PeCoffUnwindInfoUnwinderX86_64.cpp
   RegsArm64.cpp
   RegsArm.cpp
   Regs.cpp
@@ -260,8 +260,8 @@ target_sources(libunwindstack_tests PRIVATE
   tests/PeCoffFake.cpp
   tests/PeCoffRuntimeFunctionsTest.cpp
   tests/PeCoffTest.cpp
+  tests/PeCoffUnwindInfoEvaluatorTest.cpp
   tests/PeCoffUnwindInfosTest.cpp
-  tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
   tests/PeCoffEpilogTest.cpp
   tests/RegsInfoTest.cpp
   tests/RegsIterateTest.cpp

--- a/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H
-#define _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H
+#ifndef _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_EVALUATOR_H
+#define _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_EVALUATOR_H
 
 #include <memory>
 
@@ -39,26 +39,26 @@ enum UnwindOpCode : uint8_t {
   UWOP_PUSH_MACHFRAME = 10
 };
 
-class PeCoffUnwindInfoUnwinderX86_64 {
+class PeCoffUnwindInfoEvaluator {
  public:
-  explicit PeCoffUnwindInfoUnwinderX86_64(Memory* object_file_memory)
-      : unwind_infos_(CreatePeCoffUnwindInfos(object_file_memory)) {}
+  virtual ~PeCoffUnwindInfoEvaluator() {}
 
   // This function should only be called when we know that we are not in the epilog of the function.
   // If one attempts to unwind using this when one is actually on an instruction in the epilog, the
   // results will most likely be wrong.
   // The function will skip unwind codes as needed based on 'current_code_offset', e.g. when we are
   // in the middle of the prolog and not all instructions in the prolog have been executed yet.
-  bool Eval(Memory* process_memory, Regs* regs, const UnwindInfo& unwind_info,
-            uint64_t current_code_offset, uint64_t* frame_pointer, bool* frame_pointer_used);
+  virtual bool Eval(Memory* process_memory, Regs* regs, const UnwindInfo& unwind_info,
+                    PeCoffUnwindInfos* unwind_infos, uint64_t current_code_offset) = 0;
 
   ErrorData GetLastError() const { return last_error_; }
 
- private:
+ protected:
   ErrorData last_error_{ERROR_NONE, 0};
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos_;
 };
+
+std::unique_ptr<PeCoffUnwindInfoEvaluator> CreatePeCoffUnwindInfoEvaluator();
 
 }  // namespace unwindstack
 
-#endif  // _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H
+#endif  // _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_EVALUATOR_H

--- a/third_party/libunwindstack/PeCoffUnwindInfos.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.h
@@ -70,18 +70,15 @@ class PeCoffUnwindInfos {
  public:
   virtual ~PeCoffUnwindInfos() {}
 
-  // The value 'unwind_info_file_offset' is the file offset derived from the unwind info
-  // offset in the RUNTIME_FUNCTION struct, which is a relative virtual address (RVA). Computing the
-  // file offset from the unwind info RVA requires knowledge about the sections of the file, which
-  // the class using 'PeCoffUnwindInfos' must use to pass in the right value here.
-  virtual bool GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindInfo* unwind_info) = 0;
+  virtual bool GetUnwindInfo(uint64_t unwind_info_rva, UnwindInfo* unwind_info) = 0;
   ErrorData GetLastError() const { return last_error_; }
 
  protected:
   ErrorData last_error_{ERROR_NONE, 0};
 };
 
-std::unique_ptr<PeCoffUnwindInfos> CreatePeCoffUnwindInfos(Memory* object_file_memory);
+std::unique_ptr<PeCoffUnwindInfos> CreatePeCoffUnwindInfos(Memory* object_file_memory,
+                                                           const std::vector<Section>& sections);
 
 }  // namespace unwindstack
 

--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -103,7 +103,13 @@ struct SectionHeader {
 // is already looked up in the string table.
 struct Section {
   Section() : name(""), vmsize(0), vmaddr(0), size(0), offset(0) {}
-
+  Section(std::string name_arg, uint32_t vmsize_arg, uint32_t vmaddr_arg, uint32_t size_arg,
+          uint32_t offset_arg)
+      : name(std::move(name_arg)),
+        vmsize(vmsize_arg),
+        vmaddr(vmaddr_arg),
+        size(size_arg),
+        offset(offset_arg) {}
   std::string name;
   uint32_t vmsize;
   uint32_t vmaddr;

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
@@ -22,6 +22,15 @@
 #include <gtest/gtest.h>
 
 namespace unwindstack {
+// Unwind infos are indexed using their relative virtual address, which the
+// PeCoffUnwindInfos class internally converts to a file offset. We add a
+// simple mapping using a section that captures all possible addresses with
+// the constants below.
+constexpr uint32_t kSectionSize = 0x1000;
+constexpr uint32_t kVmAddress = 0x6600;
+constexpr uint32_t kFileOffset = 0x4000;
+std::vector<unwindstack::Section> kSections{
+    unwindstack::Section{"all_addresses", kSectionSize, kVmAddress, kSectionSize, kFileOffset}};
 
 class PeCoffUnwindInfosTest : public ::testing::Test {
  public:
@@ -66,7 +75,7 @@ class PeCoffUnwindInfosTest : public ::testing::Test {
   uint64_t SetChainedInfoOffsetAtOffset(uint64_t offset) {
     // The PeCoffUnwindInfo class does not interpret chained infos, so it doesn't really
     // matter what values we put here.
-    RuntimeFunction chained_function{0x100, 0x200, 0x6000};
+    RuntimeFunction chained_function{0x100, 0x200, kFileOffset};
     memory_fake_->SetData32(offset, chained_function.start_address);
     offset += sizeof(uint32_t);
     memory_fake_->SetData32(offset, chained_function.end_address);
@@ -83,22 +92,23 @@ class PeCoffUnwindInfosTest : public ::testing::Test {
 };
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_on_well_formed_data_no_chained_info) {
-  uint64_t offset = 0x6000;
+  uint64_t offset = kFileOffset;
   offset = SetUnwindInfoHeaderAtOffset(offset, 2, false);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
 
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_TRUE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
   EXPECT_EQ(2, unwind_info.num_codes);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_multiple_times) {
-  uint64_t offset = 0x6000;
+  uint64_t offset = kFileOffset;
   offset = SetUnwindInfoHeaderAtOffset(offset, 2, false);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
@@ -109,15 +119,16 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_multiple_times) {
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x8756);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x7658);
 
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_TRUE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
 
   // This should read from the cache, though we don't verify that here. The returned
   // data should be the same, though.
   UnwindInfo unwind_info2;
-  EXPECT_TRUE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info2));
+  EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info2));
 
   EXPECT_EQ(unwind_info.version_and_flags, unwind_info2.version_and_flags);
   EXPECT_EQ(unwind_info.prolog_size, unwind_info2.prolog_size);
@@ -127,17 +138,18 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_multiple_times) {
 
 TEST_F(PeCoffUnwindInfosTest,
        get_unwind_info_succeeds_on_well_formed_data_chained_info_even_number_of_opcodes) {
-  uint64_t offset = 0x6000;
+  uint64_t offset = kFileOffset;
   offset = SetUnwindInfoHeaderAtOffset(offset, 2, true);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
 
   offset = SetChainedInfoOffsetAtOffset(offset);
 
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_TRUE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
   EXPECT_EQ(2, unwind_info.num_codes);
@@ -145,7 +157,7 @@ TEST_F(PeCoffUnwindInfosTest,
 
 TEST_F(PeCoffUnwindInfosTest,
        get_unwind_info_succeeds_on_well_formed_data_chained_info_odd_number_of_opcodes) {
-  uint64_t offset = 0x6000;
+  uint64_t offset = kFileOffset;
   offset = SetUnwindInfoHeaderAtOffset(offset, 3, true);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
@@ -156,62 +168,66 @@ TEST_F(PeCoffUnwindInfosTest,
 
   offset = SetChainedInfoOffsetAtOffset(offset);
 
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_TRUE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
   EXPECT_EQ(3, unwind_info.num_codes);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_with_exception_handler_data) {
-  uint64_t offset = 0x6000;
+  uint64_t offset = kFileOffset;
   offset = SetUnwindInfoHeaderAtOffset(offset, 2, false);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
   offset = SetExceptionHandlerOffsetAtOffset(offset, 0x8000);
 
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_TRUE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
   EXPECT_EQ(2, unwind_info.num_codes);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_bad_version) {
-  uint64_t offset = 0x6000;
+  uint64_t offset = kFileOffset;
   offset = SetUnwindInfoHeaderAtOffset(offset, 2, false);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
 
   // Clobber the version with 0.
-  GetMemoryFake()->SetData8(0x6000, 0x00);
+  GetMemoryFake()->SetData8(kFileOffset, 0x00);
 
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_FALSE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_FALSE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_INVALID_COFF, unwind_infos->GetLastError().code);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_bad_memory) {
-  GetMemoryFake()->SetData8(0x6000, 0x1);
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  GetMemoryFake()->SetData8(kFileOffset, 0x1);
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_FALSE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_FALSE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos->GetLastError().code);
 
   // We read the first 4 bytes with a GetFully, so we must fail on this address
   // (and not 0x6001, which is the first missing address).
-  EXPECT_EQ(0x6000, unwind_infos->GetLastError().address);
+  EXPECT_EQ(kFileOffset, unwind_infos->GetLastError().address);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_incomplete_op_codes_memory) {
-  uint64_t offset = 0x6000;
+  uint64_t offset = kFileOffset;
   offset = SetUnwindInfoHeaderAtOffset(offset, 3, false);
 
   // Since we are using GetFully to get all op codes in a single memory read, we
@@ -221,16 +237,17 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_incomplete_op_codes_memor
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
 
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_FALSE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_FALSE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos->GetLastError().code);
   EXPECT_EQ(expected_error_address, unwind_infos->GetLastError().address);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_incomplete_chained_info) {
-  uint64_t offset = 0x6000;
+  uint64_t offset = kFileOffset;
   offset = SetUnwindInfoHeaderAtOffset(offset, 2, true);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x1234);
   offset = SetUnwindOpCodeOrFrameOffsetAtOffset(offset, 0x2134);
@@ -239,10 +256,11 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_incomplete_chained_info) 
   // must fail on this address.
   const uint64_t expected_error_address = offset;
 
-  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(CreatePeCoffUnwindInfos(GetMemoryFake()));
+  std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
+      CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
   UnwindInfo unwind_info;
-  EXPECT_FALSE(unwind_infos->GetUnwindInfo(0x6000, &unwind_info));
+  EXPECT_FALSE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos->GetLastError().code);
   EXPECT_EQ(expected_error_address, unwind_infos->GetLastError().address);
 }

--- a/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
@@ -16,6 +16,7 @@
 
 #include <inttypes.h>
 #include <cstddef>
+#include <limits>
 #include <memory>
 
 #include <unwindstack/Memory.h>
@@ -23,11 +24,21 @@
 #include "PeCoffUnwindInfos.h"
 
 namespace {
+
 void FuzzPeCoffUnwindInfos(const uint8_t* data, size_t size) {
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(data, 0, size);
+
+  // Unwind infos are indexed using their relative virtual address, which the
+  // PeCoffUnwindInfos class internally converts to a file offset. We don't
+  // care about this mapping for fuzzing. With this "all_adresses" section as
+  // defined below, all possible input RVAs are mapped to the identical value as
+  // a file offset.
+  constexpr uint32_t kUint32Max = std::numeric_limits<uint32_t>::max();
+  std::vector<unwindstack::Section> sections{
+      unwindstack::Section{"all_addresses", kUint32Max, 0, kUint32Max, 0}};
   std::unique_ptr<unwindstack::PeCoffUnwindInfos> pe_coff_unwind_infos(
-      CreatePeCoffUnwindInfos(memory.get()));
+      CreatePeCoffUnwindInfos(memory.get(), sections));
   unwindstack::UnwindInfo info;
   // Try all possible offsets to increase coverage. This will also test the parser
   // running over the end of the memory.


### PR DESCRIPTION
This change renames the general PE/COFF unwinder class to a specific
class only intended for evaluating unwind infos. This class will later
be used by the general unwinder class as part of the 'Step'
implementation.

This change also adds a mapping of relative virtual addresses (RVA) to
file offset directly inside the PeCoffUnwindInfos class to make usage
of that class easier for external code. This also minimizes usage
of the function to map RVA to file offsets, which can be expensive,
by caching unwind info entries based on the RVA and not the file offset.

Tested: Unit tests.
Bug: http://b/194768602