### PR TITLE
Create TextRendererInterface

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(
          StatusListener.h
          SystemMemoryTrack.h
          TextRenderer.h
+         TextRendererInterface.h
          ThreadBar.h
          ThreadStateBar.h
          ThreadTrack.h

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -21,6 +21,7 @@
 #include "CoreMath.h"
 #include "PickingManager.h"
 #include "PrimitiveAssembler.h"
+#include "TextRendererInterface.h"
 #include "Viewport.h"
 
 namespace ftgl {
@@ -30,38 +31,28 @@ struct texture_font_t;
 
 namespace orbit_gl {
 
-class TextRenderer {
+class TextRenderer : public TextRendererInterface {
  public:
-  enum class HAlign { Left, Right };
-  enum class VAlign { Top, Middle, Bottom };
-
-  struct TextFormatting {
-    uint32_t font_size = 14;
-    Color color = Color(255, 255, 255, 255);
-    float max_size = -1.f;
-    HAlign halign = HAlign::Left;
-    VAlign valign = VAlign::Top;
-  };
-
   explicit TextRenderer();
   ~TextRenderer();
 
-  void Init();
-  void Clear();
+  void Init() override;
+  void Clear() override;
   void SetViewport(orbit_gl::Viewport* viewport) { viewport_ = viewport; }
 
-  void RenderLayer(float layer);
-  void RenderDebug(orbit_gl::PrimitiveAssembler* primitive_assembler);
-  [[nodiscard]] std::vector<float> GetLayers() const;
+  void RenderLayer(float layer) override;
+  void RenderDebug(orbit_gl::PrimitiveAssembler* primitive_assembler) override;
+  [[nodiscard]] std::vector<float> GetLayers() const override;
 
   void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
-               Vec2* out_text_pos = nullptr, Vec2* out_text_size = nullptr);
+               Vec2* out_text_pos = nullptr, Vec2* out_text_size = nullptr) override;
 
   float AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
-                                        TextFormatting formatting, size_t trailing_chars_length);
+                                        TextFormatting formatting,
+                                        size_t trailing_chars_length) override;
 
-  [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size);
-  [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size);
+  [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size) override;
+  [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size) override;
 
   void PushTranslation(float x, float y, float z = 0.f) { translations_.PushTranslation(x, y, z); }
   void PopTranslation() { translations_.PopTranslation(); }

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -38,10 +38,10 @@ class TextRenderer : public TextRendererInterface {
 
   void Init() override;
   void Clear() override;
-  void SetViewport(orbit_gl::Viewport* viewport) { viewport_ = viewport; }
+  void SetViewport(Viewport* viewport) { viewport_ = viewport; }
 
   void RenderLayer(float layer) override;
-  void RenderDebug(orbit_gl::PrimitiveAssembler* primitive_assembler) override;
+  void RenderDebug(PrimitiveAssembler* primitive_assembler) override;
   [[nodiscard]] std::vector<float> GetLayers() const override;
 
   void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
@@ -69,8 +69,7 @@ class TextRenderer : public TextRendererInterface {
   [[nodiscard]] ftgl::texture_glyph_t* MaybeLoadAndGetGlyph(ftgl::texture_font_t* self,
                                                             const char* character);
 
-  void DrawOutline(orbit_gl::PrimitiveAssembler* primitive_assembler,
-                   ftgl::vertex_buffer_t* buffer);
+  void DrawOutline(PrimitiveAssembler* primitive_assembler, ftgl::vertex_buffer_t* buffer);
 
  private:
   ftgl::texture_atlas_t* texture_atlas_;
@@ -80,7 +79,7 @@ class TextRenderer : public TextRendererInterface {
   bool texture_atlas_changed_;
   std::unordered_map<float, ftgl::vertex_buffer_t*> vertex_buffers_by_layer_;
   std::map<uint32_t, ftgl::texture_font_t*> fonts_by_size_;
-  orbit_gl::Viewport* viewport_;
+  Viewport* viewport_;
   GLuint shader_;
   ftgl::mat4 model_;
   ftgl::mat4 view_;
@@ -89,7 +88,7 @@ class TextRenderer : public TextRendererInterface {
   bool initialized_;
   static bool draw_outline_;
 
-  orbit_gl::TranslationStack translations_;
+  TranslationStack translations_;
 };
 
 inline ftgl::vec4 ColorToVec4(const Color& color) {

--- a/src/OrbitGl/TextRendererInterface.h
+++ b/src/OrbitGl/TextRendererInterface.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TEXT_RENDERER_INTERFACE_H_
+#define ORBIT_GL_TEXT_RENDERER_INTERFACE_H_
+
+#include <GteVector.h>
+#include <stdint.h>
+
+#include <vector>
+
+#include "CoreMath.h"
+#include "PrimitiveAssembler.h"
+
+namespace orbit_gl {
+
+class TextRendererInterface {
+ public:
+  enum class HAlign { Left, Right };
+  enum class VAlign { Top, Middle, Bottom };
+
+  struct TextFormatting {
+    uint32_t font_size = 14;
+    Color color = Color(255, 255, 255, 255);
+    float max_size = -1.f;
+    HAlign halign = HAlign::Left;
+    VAlign valign = VAlign::Top;
+  };
+  virtual ~TextRendererInterface() = default;
+
+  virtual void Init() = 0;
+  virtual void Clear() = 0;
+
+  virtual void RenderLayer(float layer) = 0;
+  virtual void RenderDebug(orbit_gl::PrimitiveAssembler* primitive_assembler) = 0;
+  [[nodiscard]] virtual std::vector<float> GetLayers() const = 0;
+
+  virtual void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
+                       Vec2* out_text_pos = nullptr, Vec2* out_text_size = nullptr) = 0;
+
+  virtual float AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
+                                                TextFormatting formatting,
+                                                size_t trailing_chars_length) = 0;
+
+  [[nodiscard]] virtual float GetStringWidth(const char* text, uint32_t font_size) = 0;
+  [[nodiscard]] virtual float GetStringHeight(const char* text, uint32_t font_size) = 0;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_TEXT_RENDERER_INTERFACE_H_

--- a/src/OrbitGl/TextRendererInterface.h
+++ b/src/OrbitGl/TextRendererInterface.h
@@ -33,11 +33,11 @@ class TextRendererInterface {
   virtual void Clear() = 0;
 
   virtual void RenderLayer(float layer) = 0;
-  virtual void RenderDebug(orbit_gl::PrimitiveAssembler* primitive_assembler) = 0;
+  virtual void RenderDebug(PrimitiveAssembler* primitive_assembler) = 0;
   [[nodiscard]] virtual std::vector<float> GetLayers() const = 0;
 
   virtual void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
-                       Vec2* out_text_pos = nullptr, Vec2* out_text_size = nullptr) = 0;
+                       Vec2* out_text_pos, Vec2* out_text_size) = 0;
 
   virtual float AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
                                                 TextFormatting formatting,


### PR DESCRIPTION
In this PR we are creating TextRendererInterface, similar to
BatcherInterface, a set of functions needed by any implementation of
TextRenderer. In the followings PR we will introduce OpenGlTextRenderer
and MockTextRenderer.

Bug: http://b/228609901.