### PR TITLE
Add PeCoff::GetTextRange, PeCoff::GetTextOffsetInFile to libunwindstack

### DIFF
--- a/third_party/libunwindstack/PeCoff.cpp
+++ b/third_party/libunwindstack/PeCoff.cpp
@@ -94,6 +94,27 @@ void PeCoff::Invalidate() {
   valid_ = false;
 }
 
+bool PeCoff::GetTextRange(uint64_t* addr, uint64_t* size) {
+  if (!valid_) {
+    return false;
+  }
+
+  if (interface_->GetTextRange(addr, size)) {
+    *addr += load_bias_;
+    return true;
+  }
+
+  return false;
+}
+
+uint64_t PeCoff::GetTextOffsetInFile() const {
+  if (!valid_) {
+    return 0;
+  }
+
+  return interface_->GetTextOffsetInFile();
+}
+
 std::string PeCoff::GetBuildID() {
   // Not implemented, don't use.
   CHECK(false);

--- a/third_party/libunwindstack/PeCoffInterface.cpp
+++ b/third_party/libunwindstack/PeCoffInterface.cpp
@@ -351,7 +351,9 @@ bool PeCoffInterfaceImpl<AddressType>::InitSections() {
   for (size_t i = 0; i < sections_.size(); ++i) {
     if (sections_[i].name == ".text") {
       TextSectionData section_data;
-      section_data.executable_offset = sections_[i].vmaddr;
+      section_data.memory_size = sections_[i].vmsize;
+      section_data.memory_offset = sections_[i].vmaddr;
+      section_data.file_offset = sections_[i].offset;
       section_data.section_index = i;
       text_section_data_.emplace(section_data);
     }
@@ -444,7 +446,26 @@ uint64_t PeCoffInterfaceImpl<AddressType>::GetRelPc(uint64_t pc, uint64_t map_st
   if (!text_section_data_.has_value()) {
     return 0;
   }
-  return pc - map_start + optional_header_.image_base + text_section_data_->executable_offset;
+  return pc - map_start + optional_header_.image_base + text_section_data_->memory_offset;
+}
+
+template <typename AddressType>
+bool PeCoffInterfaceImpl<AddressType>::GetTextRange(uint64_t* addr, uint64_t* size) const {
+  if (!text_section_data_.has_value()) {
+    return false;
+  }
+
+  *addr = text_section_data_->memory_offset;
+  *size = text_section_data_->memory_size;
+  return true;
+}
+
+template <typename AddressType>
+uint64_t PeCoffInterfaceImpl<AddressType>::GetTextOffsetInFile() const {
+  if (!text_section_data_.has_value()) {
+    return 0;
+  }
+  return text_section_data_->file_offset;
 }
 
 template <typename AddressType>

--- a/third_party/libunwindstack/include/unwindstack/Elf.h
+++ b/third_party/libunwindstack/include/unwindstack/Elf.h
@@ -44,13 +44,14 @@ class Regs;
 class Elf : public Object {
  public:
   Elf(Memory* memory) : memory_(memory) {}
-  virtual ~Elf() = default;
+  ~Elf() override = default;
 
   bool Init() override;
   bool valid() override { return valid_; }
   void Invalidate() override;
 
   int64_t GetLoadBias() override { return load_bias_; }
+  bool GetTextRange(uint64_t* addr, uint64_t* size) override;
   std::string GetBuildID() override;
 
   std::string GetSoname() override;
@@ -76,8 +77,6 @@ class Elf : public Object {
   ElfInterface* CreateInterfaceFromMemory(Memory* memory);
 
   bool IsValidPc(uint64_t pc);
-
-  bool GetTextRange(uint64_t* addr, uint64_t* size);
 
   uint32_t machine_type() { return machine_type_; }
 

--- a/third_party/libunwindstack/include/unwindstack/Object.h
+++ b/third_party/libunwindstack/include/unwindstack/Object.h
@@ -44,6 +44,7 @@ class Object {
   virtual void Invalidate() = 0;
 
   virtual int64_t GetLoadBias() = 0;
+  virtual bool GetTextRange(uint64_t* addr, uint64_t* size) = 0;
   virtual std::string GetBuildID() = 0;
 
   virtual std::string GetSoname() = 0;

--- a/third_party/libunwindstack/include/unwindstack/PeCoff.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoff.h
@@ -45,13 +45,15 @@ bool IsPotentiallyPeCoffFile(const std::string& filename);
 class PeCoff : public Object {
  public:
   explicit PeCoff(Memory* memory) : memory_(memory) {}
-  virtual ~PeCoff() = default;
+  ~PeCoff() override = default;
 
   bool Init() override;
   bool valid() override { return valid_; }
   void Invalidate() override;
 
   int64_t GetLoadBias() override { return load_bias_; };
+  bool GetTextRange(uint64_t* addr, uint64_t* size) override;
+  uint64_t GetTextOffsetInFile() const;
 
   std::string GetBuildID() override;
   std::string GetSoname() override;

--- a/third_party/libunwindstack/tests/PeCoffFake.cpp
+++ b/third_party/libunwindstack/tests/PeCoffFake.cpp
@@ -32,7 +32,7 @@ inline constexpr bool kDependentFalse = false;
 template <typename PeCoffInterfaceType>
 void PeCoffFake<PeCoffInterfaceType>::Init() {
   memory_->Clear();
-  uint64_t offset = SetDosHeader(0x1000);
+  uint64_t offset = SetDosHeader(kNewHeaderOffsetValue);
   offset = SetNewHeaderAtOffset(offset);
   offset = SetCoffHeaderAtOffset(offset);
 
@@ -186,13 +186,13 @@ uint64_t PeCoffFake<PeCoffInterfaceType>::SetOptionalHeaderAtOffset(uint64_t off
   } else {
     static_assert(kDependentFalse<PeCoffInterfaceType>, "AddressType size must be 4 or 8 bytes");
   }
-  offset = SetData8(offset, 0);   // major_linker_version
-  offset = SetData8(offset, 0);   // minor_linker_version
-  offset = SetData32(offset, 0);  // code_size
-  offset = SetData32(offset, 0);  // data_size
-  offset = SetData32(offset, 0);  // bss_size
-  offset = SetData32(offset, 0);  // entry
-  offset = SetData32(offset, 0);  // code_offset
+  offset = SetData8(offset, 0);                      // major_linker_version
+  offset = SetData8(offset, 0);                      // minor_linker_version
+  offset = SetData32(offset, kTextSectionFileSize);  // code_size
+  offset = SetData32(offset, 0);                     // data_size
+  offset = SetData32(offset, 0);                     // bss_size
+  offset = SetData32(offset, 0);                     // entry
+  offset = SetData32(offset, 0);                     // code_offset
 
   if constexpr (sizeof(typename PeCoffInterfaceType::AddressType) == 4) {
     // Data offset only exists in 32-bit PE/COFF.
@@ -297,7 +297,9 @@ uint64_t PeCoffFake<PeCoffInterfaceType>::SetSectionHeadersAtOffset(uint64_t off
                                                                     uint32_t debug_frame_vmsize,
                                                                     uint32_t debug_frame_filesize) {
   // Shorter than kSectionNameInHeaderSize (== 8) characters
-  offset = SetSectionHeaderAtOffset(offset, ".text", 0, kTextSectionOffsetFake, 0, 0);
+  offset =
+      SetSectionHeaderAtOffset(offset, ".text", kTextSectionMemorySize, kTextSectionMemoryOffset,
+                               kTextSectionFileSize, kTextSectionFileOffset);
   // Longer than kSectionNameInHeaderSize (== 8) characters
   offset = SetSectionHeaderAtOffset(offset, ".debug_frame", debug_frame_vmsize,
                                     kDebugFrameSectionFileOffset, debug_frame_filesize,

--- a/third_party/libunwindstack/tests/PeCoffFake.h
+++ b/third_party/libunwindstack/tests/PeCoffFake.h
@@ -29,8 +29,20 @@ template <typename PeCoffInterfaceType>
 class PeCoffFake {
  public:
   static constexpr size_t kDosHeaderSizeInBytes = 0x40;
-  static constexpr uint64_t kDebugFrameSectionFileOffset = 0x2000;
+  // File offset for the new header.
+  static constexpr uint64_t kNewHeaderOffsetValue = 0xF8;
+
+  // Offset and size in the file of the .text section.
+  static constexpr uint64_t kTextSectionFileOffset = 0x400;
+  static constexpr uint64_t kTextSectionFileSize = 0x1000;
+  // Offset relative to the image base and size of the .text section when loaded into memory.
+  static constexpr uint64_t kTextSectionMemoryOffset = 0x2000;
+  static constexpr uint64_t kTextSectionMemorySize = 0xFFF;
+
+  // File offset and size for the .debug_frame section.
+  static constexpr uint64_t kDebugFrameSectionFileOffset = 0x3000;
   static constexpr uint64_t kDebugFrameSectionSize = 0x200;
+
   static constexpr int64_t kLoadBiasFake = 0x3100;
   static constexpr uint64_t kTextSectionOffsetFake = 0x200;
 
@@ -68,7 +80,6 @@ class PeCoffFake {
   uint64_t executable_section_offset_;
   std::unique_ptr<MemoryFake> memory_;
 
-  uint64_t InitPeCoffInterfaceFakeNoSectionHeaders();
   uint64_t SetData8(uint64_t offset, uint8_t value);
   uint64_t SetData16(uint64_t offset, uint16_t value);
   uint64_t SetData32(uint64_t offset, uint32_t value);


### PR DESCRIPTION
These will be used to adjust `unwindstack::Maps` in order to support unwinding
through frames of functions in Portable Executables whose executable section is
mapped anonymously in `/proc/[pid]/maps` by Wine because the file alignment
doesn't obey the requirements of `mmap`.

`GetTextRange` was already available with the same semantics for `Elf`, and is
now made a `virtual` method of `Object`. `GetTextOffsetInFile` is only added to
`PeCoff`.

Bug: http://b/226562022

Test: Unit tests.