### PR TITLE
Split interface and implementation in TextRenderer

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -20,7 +20,6 @@ target_sources(
          BasicPageFaultsTrack.h
          Batcher.h
          BatcherInterface.h
-         OpenGlBatcher.h
          CallstackThreadBar.h
          CallTreeView.h
          CaptureStats.h
@@ -51,6 +50,8 @@ target_sources(
          MinorPageFaultsTrack.h
          MockTimelineInfo.h
          MultivariateTimeSeries.h
+         OpenGlBatcher.h
+         OpenGlTextRenderer.h
          PageFaultsTrack.h
          PickingManager.h
          PrimitiveAssembler.h
@@ -97,7 +98,6 @@ target_sources(
           App.cpp
           AsyncTrack.cpp
           BasicPageFaultsTrack.cpp
-          OpenGlBatcher.cpp
           CallstackThreadBar.cpp
           CallTreeView.cpp
           CaptureStats.cpp
@@ -122,6 +122,8 @@ target_sources(
           MajorPageFaultsTrack.cpp
           MemoryTrack.cpp
           MinorPageFaultsTrack.cpp
+          OpenGlBatcher.cpp
+          OpenGlTextRenderer.cpp
           PageFaultsTrack.cpp
           PickingManager.cpp
           PrimitiveAssembler.cpp
@@ -130,7 +132,6 @@ target_sources(
           SchedulingStats.cpp
           SimpleTimings.cpp
           SystemMemoryTrack.cpp
-          TextRenderer.cpp
           TimeGraph.cpp
           TimeGraphLayout.cpp
           TimelineTicks.cpp

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -21,10 +21,10 @@
 #include "GlUtils.h"
 #include "ImGuiOrbit.h"
 #include "OpenGlBatcher.h"
+#include "OpenGlTextRenderer.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "OrbitAccessibility/AccessibleWidgetBridge.h"
 #include "PickingManager.h"
-#include "TextRenderer.h"
 #include "Timer.h"
 #include "Viewport.h"
 
@@ -150,7 +150,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   ImGuiContext* imgui_context_ = nullptr;
   double ref_time_click_;
   float track_container_click_scrolling_offset_ = 0;
-  orbit_gl::TextRenderer text_renderer_;
+  orbit_gl::OpenGlTextRenderer text_renderer_;
   PickingManager picking_manager_;
   bool double_clicking_;
   bool control_key_;

--- a/src/OrbitGl/OpenGlTextRenderer.cpp
+++ b/src/OrbitGl/OpenGlTextRenderer.cpp
@@ -45,7 +45,7 @@ int GetStringLineCount(const char* string) {
   return result;
 }
 
-inline ftgl::vec4 ColorToVec4(const Color& color) {
+ftgl::vec4 ColorToVec4(const Color& color) {
   const float coeff = 1.f / 255.f;
   ftgl::vec4 vec;
   vec.r = color[0] * coeff;

--- a/src/OrbitGl/OpenGlTextRenderer.h
+++ b/src/OrbitGl/OpenGlTextRenderer.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_OPEN_GL_TEXT_RENDERER_H_
+#define ORBIT_GL_OPEN_GL_TEXT_RENDERER_H_
+
+#include <GteVector.h>
+#include <freetype-gl/mat4.h>
+#include <freetype-gl/texture-atlas.h>
+#include <freetype-gl/texture-font.h>
+#include <freetype-gl/vec234.h>
+#include <glad/glad.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "CoreMath.h"
+#include "PickingManager.h"
+#include "PrimitiveAssembler.h"
+#include "TextRenderer.h"
+
+namespace ftgl {
+struct vertex_buffer_t;
+struct texture_font_t;
+}  // namespace ftgl
+
+namespace orbit_gl {
+
+// OpenGl implementation of the TextRenderer.
+class OpenGlTextRenderer : public TextRenderer {
+ public:
+  explicit OpenGlTextRenderer();
+  ~OpenGlTextRenderer();
+
+  void Init() override;
+  void Clear() override;
+
+  void RenderLayer(float layer) override;
+  void RenderDebug(PrimitiveAssembler* primitive_assembler) override;
+  [[nodiscard]] std::vector<float> GetLayers() const override;
+
+  void AddText(const char* text, float x, float y, float z, TextFormatting formatting) override;
+  void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
+               Vec2* out_text_pos, Vec2* out_text_size) override;
+
+  float AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
+                                        TextFormatting formatting,
+                                        size_t trailing_chars_length) override;
+
+  [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size) override;
+  [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size) override;
+
+ protected:
+  void AddTextInternal(const char* text, ftgl::vec2* pen, const TextFormatting& formatting, float z,
+                       ftgl::vec2* out_text_pos = nullptr, ftgl::vec2* out_text_size = nullptr);
+
+  [[nodiscard]] int GetStringWidthScreenSpace(const char* text, uint32_t font_size);
+  [[nodiscard]] int GetStringHeightScreenSpace(const char* text, uint32_t font_size);
+  [[nodiscard]] ftgl::texture_font_t* GetFont(uint32_t size);
+  [[nodiscard]] ftgl::texture_glyph_t* MaybeLoadAndGetGlyph(ftgl::texture_font_t* self,
+                                                            const char* character);
+
+  void DrawOutline(PrimitiveAssembler* primitive_assembler, ftgl::vertex_buffer_t* buffer);
+
+ private:
+  ftgl::texture_atlas_t* texture_atlas_;
+  // Indicates when a change to the texture atlas occurred so that we have to reupload the
+  // texture data. Only freetype-gl's texture_font_load_glyph modifies the texture atlas,
+  // so we need to set this to true when and only when we call that function.
+  bool texture_atlas_changed_;
+  std::unordered_map<float, ftgl::vertex_buffer_t*> vertex_buffers_by_layer_;
+  std::map<uint32_t, ftgl::texture_font_t*> fonts_by_size_;
+  GLuint shader_;
+  ftgl::mat4 model_;
+  ftgl::mat4 view_;
+  ftgl::mat4 projection_;
+  ftgl::vec2 pen_;
+  bool initialized_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_OPEN_GL_TEXT_RENDERER_H_

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -5,54 +5,15 @@
 #ifndef ORBIT_GL_TEXT_RENDERER_H_
 #define ORBIT_GL_TEXT_RENDERER_H_
 
-#include <GteVector.h>
-#include <freetype-gl/mat4.h>
-#include <freetype-gl/texture-atlas.h>
-#include <freetype-gl/texture-font.h>
-#include <freetype-gl/vec234.h>
-#include <glad/glad.h>
-#include <stddef.h>
-#include <stdint.h>
-
-#include <map>
-#include <unordered_map>
-#include <vector>
-
-#include "CoreMath.h"
-#include "PickingManager.h"
-#include "PrimitiveAssembler.h"
 #include "TextRendererInterface.h"
 #include "Viewport.h"
-
-namespace ftgl {
-struct vertex_buffer_t;
-struct texture_font_t;
-}  // namespace ftgl
 
 namespace orbit_gl {
 
 class TextRenderer : public TextRendererInterface {
  public:
-  explicit TextRenderer();
-  ~TextRenderer();
-
-  void Init() override;
-  void Clear() override;
+  explicit TextRenderer() {}
   void SetViewport(Viewport* viewport) { viewport_ = viewport; }
-
-  void RenderLayer(float layer) override;
-  void RenderDebug(PrimitiveAssembler* primitive_assembler) override;
-  [[nodiscard]] std::vector<float> GetLayers() const override;
-
-  void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
-               Vec2* out_text_pos = nullptr, Vec2* out_text_size = nullptr) override;
-
-  float AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
-                                        TextFormatting formatting,
-                                        size_t trailing_chars_length) override;
-
-  [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size) override;
-  [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size) override;
 
   void PushTranslation(float x, float y, float z = 0.f) { translations_.PushTranslation(x, y, z); }
   void PopTranslation() { translations_.PopTranslation(); }
@@ -60,46 +21,11 @@ class TextRenderer : public TextRendererInterface {
   static void SetDrawOutline(bool value) { draw_outline_ = value; }
 
  protected:
-  void AddTextInternal(const char* text, ftgl::vec2* pen, const TextFormatting& formatting, float z,
-                       ftgl::vec2* out_text_pos = nullptr, ftgl::vec2* out_text_size = nullptr);
-
-  [[nodiscard]] int GetStringWidthScreenSpace(const char* text, uint32_t font_size);
-  [[nodiscard]] int GetStringHeightScreenSpace(const char* text, uint32_t font_size);
-  [[nodiscard]] ftgl::texture_font_t* GetFont(uint32_t size);
-  [[nodiscard]] ftgl::texture_glyph_t* MaybeLoadAndGetGlyph(ftgl::texture_font_t* self,
-                                                            const char* character);
-
-  void DrawOutline(PrimitiveAssembler* primitive_assembler, ftgl::vertex_buffer_t* buffer);
-
- private:
-  ftgl::texture_atlas_t* texture_atlas_;
-  // Indicates when a change to the texture atlas occurred so that we have to reupload the
-  // texture data. Only freetype-gl's texture_font_load_glyph modifies the texture atlas,
-  // so we need to set this to true when and only when we call that function.
-  bool texture_atlas_changed_;
-  std::unordered_map<float, ftgl::vertex_buffer_t*> vertex_buffers_by_layer_;
-  std::map<uint32_t, ftgl::texture_font_t*> fonts_by_size_;
-  Viewport* viewport_;
-  GLuint shader_;
-  ftgl::mat4 model_;
-  ftgl::mat4 view_;
-  ftgl::mat4 projection_;
-  ftgl::vec2 pen_;
-  bool initialized_;
-  static bool draw_outline_;
+  Viewport* viewport_ = nullptr;
+  inline static bool draw_outline_ = false;
 
   TranslationStack translations_;
 };
-
-inline ftgl::vec4 ColorToVec4(const Color& color) {
-  const float coeff = 1.f / 255.f;
-  ftgl::vec4 vec;
-  vec.r = color[0] * coeff;
-  vec.g = color[1] * coeff;
-  vec.b = color[2] * coeff;
-  vec.a = color[3] * coeff;
-  return vec;
-}
 
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -12,7 +12,6 @@ namespace orbit_gl {
 
 class TextRenderer : public TextRendererInterface {
  public:
-  explicit TextRenderer() {}
   void SetViewport(Viewport* viewport) { viewport_ = viewport; }
 
   void PushTranslation(float x, float y, float z = 0.f) { translations_.PushTranslation(x, y, z); }

--- a/src/OrbitGl/TextRendererInterface.h
+++ b/src/OrbitGl/TextRendererInterface.h
@@ -36,6 +36,7 @@ class TextRendererInterface {
   virtual void RenderDebug(PrimitiveAssembler* primitive_assembler) = 0;
   [[nodiscard]] virtual std::vector<float> GetLayers() const = 0;
 
+  virtual void AddText(const char* text, float x, float y, float z, TextFormatting formatting) = 0;
   virtual void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
                        Vec2* out_text_pos, Vec2* out_text_size) = 0;
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -17,9 +17,9 @@
 #include "CoreMath.h"
 #include "ManualInstrumentationManager.h"
 #include "OpenGlBatcher.h"
+#include "OpenGlTextRenderer.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
-#include "TextRenderer.h"
 #include "TimeGraphLayout.h"
 #include "TimelineInfoInterface.h"
 #include "TimelineUi.h"
@@ -177,7 +177,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
       const orbit_gl::ModifierKeys& modifiers = orbit_gl::ModifierKeys()) override;
 
   AccessibleInterfaceProvider* accessible_parent_;
-  orbit_gl::TextRenderer text_renderer_static_;
+  orbit_gl::OpenGlTextRenderer text_renderer_static_;
 
   double ref_time_us_ = 0;
   double min_time_us_ = 0;


### PR DESCRIPTION
Similar that what we did in Batcher class, in this PR we are splitting TextRenderer
with the proper open-gl implementation of the class. In the following PR,
MockTextRenderer will mock TextRenderer class.

A few things:
- We erase TextRenderer.cpp and move definition of draw_outline to the header.
- UnitTests are missing for all the classes. I will create a bug for that but not address
it in the short time. This is only because I need to Mock TextRenderer.
- We are adding an extra method AddText without output parameters, instead of
having them defaulted to nullptr.
- I'm not changing any extra functionality.

Bug: http://b/228609901.

Test: Load a capture.