### PR TITLE
Add ScopedMetric::Pause and Resume to control the duration measurement

### DIFF
--- a/src/MetricsUploader/ScopedMetricTest.cpp
+++ b/src/MetricsUploader/ScopedMetricTest.cpp
@@ -100,15 +100,16 @@ TEST(ScopedMetric, PauseAndResume) {
   EXPECT_CALL(uploader,
               SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN,
                            AllOf(Ge(sleep_time), Lt(sleep_time * 2)), OrbitLogEvent::SUCCESS))
-      .Times(2);
+      .Times(3);
 
   {
     ScopedMetric metric{&uploader, OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN};
-    std::this_thread::sleep_for(sleep_time);
+    std::this_thread::sleep_for(sleep_time / 2);
 
     metric.Pause();
     std::this_thread::sleep_for(sleep_time);
     metric.Resume();
+    std::this_thread::sleep_for(sleep_time / 2);
   }
 
   {
@@ -117,6 +118,17 @@ TEST(ScopedMetric, PauseAndResume) {
 
     metric.Pause();
     std::this_thread::sleep_for(sleep_time);
+  }
+
+  {
+    ScopedMetric metric{&uploader, OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN};
+    std::this_thread::sleep_for(sleep_time / 2);
+
+    metric.Pause();
+    ScopedMetric moved_metric{std::move(metric)};
+    std::this_thread::sleep_for(sleep_time);
+    moved_metric.Resume();
+    std::this_thread::sleep_for(sleep_time / 2);
   }
 }
 

--- a/src/MetricsUploader/include/MetricsUploader/ScopedMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/ScopedMetric.h
@@ -6,6 +6,7 @@
 #define METRICS_UPLOADER_SCOPED_METRIC_H_
 
 #include <chrono>
+#include <optional>
 
 #include "MetricsUploader/MetricsUploader.h"
 #include "MetricsUploader/orbit_log_event.pb.h"
@@ -14,7 +15,7 @@ namespace orbit_metrics_uploader {
 
 class ScopedMetric {
  public:
-  explicit ScopedMetric(MetricsUploader* uploader, OrbitLogEvent_LogEventType log_event_type);
+  explicit ScopedMetric(MetricsUploader* uploader, OrbitLogEvent::LogEventType log_event_type);
   ScopedMetric(const ScopedMetric& other) = delete;
   ScopedMetric& operator=(const ScopedMetric& other) = delete;
   ScopedMetric(ScopedMetric&& other);
@@ -23,11 +24,17 @@ class ScopedMetric {
 
   void SetStatusCode(OrbitLogEvent::StatusCode status_code) { status_code_ = status_code; }
 
+  void Pause();
+  void Resume();
+
  private:
   MetricsUploader* uploader_;
-  OrbitLogEvent_LogEventType log_event_type_;
+  OrbitLogEvent::LogEventType log_event_type_;
   OrbitLogEvent::StatusCode status_code_ = OrbitLogEvent::SUCCESS;
   std::chrono::steady_clock::time_point start_;
+
+  std::optional<std::chrono::steady_clock::time_point> pause_start_ = std::nullopt;
+  std::chrono::milliseconds pause_duration_ = std::chrono::milliseconds::zero();
 };
 
 }  // namespace orbit_metrics_uploader


### PR DESCRIPTION
With this change, we add the `ScopedMetric::Pause` and
`ScopedMetric::Resume`. While being paused, the elapsed time won't be
counted into the metric duration.
This allows us to have more flexibility while measuring the metric
duraton, for instance, we can exclude the user interaction time.

Bug: http://b/228819167