### PR TITLE
Create MockTextRenderer

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -197,6 +197,7 @@ add_executable(OrbitGlTests)
 target_sources(OrbitGlTests PRIVATE
                CaptureViewElementTester.h
                MockBatcher.h
+               MockTextRenderer.h
                PickingManagerTest.h
                UnitTestSlider.h)
 
@@ -209,6 +210,7 @@ target_sources(OrbitGlTests PRIVATE
                GlUtilsTest.cpp
                GpuTrackTest.cpp
                MockBatcher.cpp
+               MockTextRenderer.cpp
                MultivariateTimeSeriesTest.cpp
                OpenGlBatcherTest.cpp
                PageFaultsTrackTest.cpp

--- a/src/OrbitGl/CoreMath.h
+++ b/src/OrbitGl/CoreMath.h
@@ -21,20 +21,34 @@ using Vec4i = gte::Vector4<int>;
 
 using Color = gte::Vector4<unsigned char>;
 
+// TODO(b/229089446): Test these methods.
 [[nodiscard]] inline Vec2 Vec3ToVec2(const Vec3& v) { return {v[0], v[1]}; }
 [[nodiscard]] inline Vec3 Vec2ToVec3(Vec2 vertex, float z = 0) { return {vertex[0], vertex[1], z}; }
 
-[[nodiscard]] inline bool IsInBetween(float point, float min, float max) {
-  return point >= min && point <= max;
+namespace orbit_gl {
+
+struct ClosedInterval {
+  static ClosedInterval FromValues(float value_1, float value_2) {
+    return {std::min(value_1, value_2), std::max(value_1, value_2)};
+  }
+  float min;
+  float max;
+};
+
+[[nodiscard]] inline bool IsElementOf(float value, ClosedInterval closed_interval) {
+  return value >= closed_interval.min && value <= closed_interval.max;
 }
 
-[[nodiscard]] inline bool IsInsideRectangle(Vec2 point, Vec2 top_left, Vec2 size) {
+[[nodiscard]] inline bool IsInsideRectangle(const Vec2& point, const Vec2& top_left,
+                                            const Vec2& size) {
   for (int i = 0; i < 2; i++) {
-    if (!IsInBetween(point[i], top_left[i], top_left[i] + size[i])) {
+    if (!IsElementOf(point[i], ClosedInterval::FromValues(top_left[i], top_left[i] + size[i]))) {
       return false;
     }
   }
   return true;
 }
+
+}  // namespace orbit_gl
 
 #endif  // ORBIT_GL_CORE_MATH_H_

--- a/src/OrbitGl/CoreMath.h
+++ b/src/OrbitGl/CoreMath.h
@@ -24,4 +24,17 @@ using Color = gte::Vector4<unsigned char>;
 [[nodiscard]] inline Vec2 Vec3ToVec2(const Vec3& v) { return {v[0], v[1]}; }
 [[nodiscard]] inline Vec3 Vec2ToVec3(Vec2 vertex, float z = 0) { return {vertex[0], vertex[1], z}; }
 
+[[nodiscard]] inline bool IsInBetween(float point, float min, float max) {
+  return point >= min && point <= max;
+}
+
+[[nodiscard]] inline bool IsInsideRectangle(Vec2 point, Vec2 top_left, Vec2 size) {
+  for (int i = 0; i < 2; i++) {
+    if (!IsInBetween(point[i], top_left[i], top_left[i] + size[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 #endif  // ORBIT_GL_CORE_MATH_H_

--- a/src/OrbitGl/MockBatcher.cpp
+++ b/src/OrbitGl/MockBatcher.cpp
@@ -8,19 +8,6 @@
 
 namespace orbit_gl {
 
-[[nodiscard]] static bool IsInBetween(float point, float min, float max) {
-  return point >= min && point <= max;
-}
-
-[[nodiscard]] static bool IsInsideRectangle(Vec2 point, Vec2 top_left, Vec2 bottom_right) {
-  for (int i = 0; i < 2; i++) {
-    if (!IsInBetween(point[i], top_left[i], bottom_right[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
 MockBatcher::MockBatcher(BatcherId batcher_id) : Batcher(batcher_id) { ResetElements(); }
 
 void MockBatcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
@@ -92,9 +79,8 @@ int MockBatcher::GetNumBoxes() const {
 // To check that everything is inside a rectangle, we just need to check the minimum and maximum
 // used coordinates.
 bool MockBatcher::IsEverythingInsideRectangle(Vec2 start, Vec2 size) const {
-  Vec2 end = start + size;
-  return IsInsideRectangle({min_point_[0], min_point_[1]}, start, end) &&
-         IsInsideRectangle({max_point_[0], max_point_[1]}, start, end);
+  return IsInsideRectangle({min_point_[0], min_point_[1]}, start, size) &&
+         IsInsideRectangle({max_point_[0], max_point_[1]}, start, size);
 }
 
 bool MockBatcher::IsEverythingBetweenZLayers(float z_layer_min, float z_layer_max) const {

--- a/src/OrbitGl/MockBatcher.cpp
+++ b/src/OrbitGl/MockBatcher.cpp
@@ -79,13 +79,13 @@ int MockBatcher::GetNumBoxes() const {
 // To check that everything is inside a rectangle, we just need to check the minimum and maximum
 // used coordinates.
 bool MockBatcher::IsEverythingInsideRectangle(Vec2 start, Vec2 size) const {
-  return IsInsideRectangle({min_point_[0], min_point_[1]}, start, size) &&
-         IsInsideRectangle({max_point_[0], max_point_[1]}, start, size);
+  return IsInsideRectangle(Vec3ToVec2(min_point_), start, size) &&
+         IsInsideRectangle(Vec3ToVec2(max_point_), start, size);
 }
 
 bool MockBatcher::IsEverythingBetweenZLayers(float z_layer_min, float z_layer_max) const {
-  return IsInBetween(min_point_[2], z_layer_min, z_layer_max) &&
-         IsInBetween(max_point_[2], z_layer_min, z_layer_max);
+  return IsElementOf(min_point_[2], ClosedInterval::FromValues(z_layer_min, z_layer_max)) &&
+         IsElementOf(max_point_[2], ClosedInterval::FromValues(z_layer_min, z_layer_max));
 }
 
 void MockBatcher::AdjustDrawingBoundaries(Vec3 point) {

--- a/src/OrbitGl/MockTextRenderer.cpp
+++ b/src/OrbitGl/MockTextRenderer.cpp
@@ -79,13 +79,13 @@ float MockTextRenderer::GetStringHeight(const char* /*text*/, uint32_t font_size
 }
 
 [[nodiscard]] bool MockTextRenderer::IsTextInsideRectangle(Vec2 start, Vec2 size) const {
-  return IsInsideRectangle({min_point_[0], min_point_[1]}, start, size) &&
-         IsInsideRectangle({max_point_[0], max_point_[1]}, start, size);
+  return IsInsideRectangle(Vec3ToVec2(min_point_), start, size) &&
+         IsInsideRectangle(Vec3ToVec2(max_point_), start, size);
 }
 
 bool MockTextRenderer::IsTextBetweenZLayers(float z_layer_min, float z_layer_max) const {
-  return IsInBetween(min_point_[2], z_layer_min, z_layer_max) &&
-         IsInBetween(max_point_[2], z_layer_min, z_layer_max);
+  return IsElementOf(min_point_[2], ClosedInterval::FromValues(z_layer_min, z_layer_max)) &&
+         IsElementOf(max_point_[2], ClosedInterval::FromValues(z_layer_min, z_layer_max));
 }
 
 void MockTextRenderer::UpdateDrawingBoundaries(Vec3 point) {

--- a/src/OrbitGl/MockTextRenderer.cpp
+++ b/src/OrbitGl/MockTextRenderer.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MockTextRenderer.h"
+
+#include "CoreMath.h"
+
+namespace orbit_gl {
+
+// Clearing counters also in creation to not duplicate code.
+MockTextRenderer::MockTextRenderer() { Clear(); }
+
+void MockTextRenderer::Clear() {
+  min_point_ = Vec3{std::numeric_limits<float>::max(), std::numeric_limits<float>::max(),
+                    std::numeric_limits<float>::max()};
+  max_point_ = Vec3{std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(),
+                    std::numeric_limits<float>::lowest()};
+  num_characters_in_add_text_.clear();
+  vertical_position_in_add_text.clear();
+  num_add_text_calls_ = 0;
+}
+
+void MockTextRenderer::AddText(const char* text, float x, float y, float z,
+                               TextFormatting formatting) {
+  UpdateDrawingBoundaries({x, y, z});
+  UpdateDrawingBoundaries({x + GetStringWidth(text, formatting.font_size),
+                           y + GetStringHeight(text, formatting.font_size), z});
+  num_add_text_calls_++;
+  num_characters_in_add_text_.insert(strlen(text));
+  vertical_position_in_add_text.insert(y);
+}
+
+void MockTextRenderer::AddText(const char* text, float x, float y, float z,
+                               TextFormatting formatting, Vec2* /*out_text_pos*/,
+                               Vec2* /*out_text_size*/) {
+  return AddText(text, x, y, z, formatting);
+}
+
+float MockTextRenderer::AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
+                                                        TextFormatting formatting,
+                                                        size_t /*trailing_chars_length*/) {
+  AddText(text, x, y, z, formatting);
+  return GetStringWidth(text, formatting.font_size);
+}
+
+// GetStringWidth is being a bit over-estimated when using font_size. Anyway, the estimation is
+// really close to the real width of the widest character ('W').
+float MockTextRenderer::GetStringWidth(const char* text, uint32_t font_size) {
+  return strlen(text) * font_size;
+};
+
+// GetStringHeight is clearly over-estimated here. Comparting to the one in OpenGlTextRenderer, the
+// real height is 10 (with font-size 14) and 8 (with font-size 10). It should not be a problem.
+float MockTextRenderer::GetStringHeight(const char* /*text*/, uint32_t font_size) {
+  return font_size;
+}
+
+[[nodiscard]] bool MockTextRenderer::IsTextInsideRectangle(Vec2 start, Vec2 size) const {
+  return IsInsideRectangle({min_point_[0], min_point_[1]}, start, size) &&
+         IsInsideRectangle({max_point_[0], max_point_[1]}, start, size);
+}
+
+bool MockTextRenderer::IsTextBetweenZLayers(float z_layer_min, float z_layer_max) const {
+  return IsInBetween(min_point_[2], z_layer_min, z_layer_max) &&
+         IsInBetween(max_point_[2], z_layer_min, z_layer_max);
+}
+
+void MockTextRenderer::UpdateDrawingBoundaries(Vec3 point) {
+  min_point_[0] = std::min(point[0], min_point_[0]);
+  min_point_[1] = std::min(point[1], min_point_[1]);
+  min_point_[2] = std::min(point[2], min_point_[2]);
+  max_point_[0] = std::max(point[0], max_point_[0]);
+  max_point_[1] = std::max(point[1], max_point_[1]);
+  max_point_[2] = std::max(point[2], max_point_[2]);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/MockTextRenderer.h
+++ b/src/OrbitGl/MockTextRenderer.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_MOCK_TEXT_RENDERER_H_
+#define ORBIT_GL_MOCK_TEXT_RENDERER_H_
+
+#include <gmock/gmock.h>
+
+#include "TextRenderer.h"
+
+namespace orbit_gl {
+
+class MockTextRenderer : public TextRenderer {
+ public:
+  explicit MockTextRenderer();
+
+  MOCK_METHOD(void, Init, (), (override));
+  void Clear() override;
+
+  MOCK_METHOD(void, RenderLayer, (float), (override));
+  MOCK_METHOD(void, RenderDebug, (PrimitiveAssembler*), (override));
+  MOCK_METHOD(std::vector<float>, GetLayers, (), (const override));
+
+  void AddText(const char* text, float x, float y, float z, TextFormatting formatting) override;
+  void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
+               Vec2* out_text_pos, Vec2* out_text_size) override;
+
+  float AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
+                                        TextFormatting formatting,
+                                        size_t trailing_chars_length) override;
+
+  [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size) override;
+  [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size) override;
+
+  bool HasAddTextsSameLength() const { return num_characters_in_add_text_.size() <= 1; }
+  bool AreAddTextsAlignedVertically() const { return vertical_position_in_add_text.size() <= 1; }
+  const int GetNumAddTextCalls() const { return num_add_text_calls_; }
+  [[nodiscard]] bool IsTextInsideRectangle(Vec2 start, Vec2 size) const;
+  [[nodiscard]] bool IsTextBetweenZLayers(float z_layer_min, float z_layer_max) const;
+
+ private:
+  void UpdateDrawingBoundaries(Vec3 point);
+  Vec3 min_point_;
+  Vec3 max_point_;
+
+  std::set<uint32_t> num_characters_in_add_text_;
+  std::set<float> vertical_position_in_add_text;
+  int num_add_text_calls_ = 0;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_MOCK_TEXT_RENDERER_H_

--- a/src/OrbitGl/MockTextRenderer.h
+++ b/src/OrbitGl/MockTextRenderer.h
@@ -33,9 +33,13 @@ class MockTextRenderer : public TextRenderer {
   [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size) override;
   [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size) override;
 
-  bool HasAddTextsSameLength() const { return num_characters_in_add_text_.size() <= 1; }
-  bool AreAddTextsAlignedVertically() const { return vertical_position_in_add_text.size() <= 1; }
-  const int GetNumAddTextCalls() const { return num_add_text_calls_; }
+  [[nodiscard]] bool HasAddTextsSameLength() const {
+    return num_characters_in_add_text_.size() <= 1;
+  }
+  [[nodiscard]] bool AreAddTextsAlignedVertically() const {
+    return vertical_position_in_add_text.size() <= 1;
+  }
+  [[nodiscard]] const int GetNumAddTextCalls() const { return num_add_text_calls_; }
   [[nodiscard]] bool IsTextInsideRectangle(Vec2 start, Vec2 size) const;
   [[nodiscard]] bool IsTextBetweenZLayers(float z_layer_min, float z_layer_max) const;
 


### PR DESCRIPTION
In this PR we are creating MockTextRenderer. Similar to MockBatcher, it will 
be used by CaptureViewElements to test UpdatePrimitives and DrawMethods().

- I also changed all the rectangle methods to use (top_left and size).

Bug: http://b/228609901.