### PR TITLE
Add prefer_ini_files flag

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -10,6 +10,9 @@
 
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 
+ABSL_FLAG(bool, prefer_ini_files, false,
+          "Use ini files instead of the registry to store settings on Windows");
+
 ABSL_FLAG(bool, nodeploy, false, "Disable automatic deployment of OrbitService");
 
 ABSL_FLAG(std::string, collector, "", "Full path of collector to be deployed");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -13,6 +13,8 @@
 
 ABSL_DECLARE_FLAG(bool, devmode);
 
+ABSL_DECLARE_FLAG(bool, prefer_ini_files);
+
 ABSL_DECLARE_FLAG(bool, nodeploy);
 
 ABSL_DECLARE_FLAG(std::string, collector);

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -254,6 +254,10 @@ int main(int argc, char* argv[]) {
   QApplication::setOrganizationName("The Orbit Authors");
   QApplication::setApplicationName("orbitprofiler");
 
+  if (absl::GetFlag(FLAGS_prefer_ini_files)) {
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+  }
+
   if (DevModeEnabledViaEnvironmentVariable()) {
     absl::SetFlag(&FLAGS_devmode, true);
   }


### PR DESCRIPTION
This stores QSettings properties in ini files instead of the registry
on windows. It significantly speeds up starting times when developing
on gWindows.

Bug: b/229088448
Test: Manual testing