### PR TITLE
Defer deletion of frame tracks

### DIFF
--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -98,6 +98,7 @@ class TrackManager {
   [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
   // Filter tracks that are already sorted in sorted_tracks_.
   void UpdateVisibleTrackList();
+  void DeletePendingTracks();
 
   void AddTrack(const std::shared_ptr<Track>& track);
   void AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track);
@@ -119,6 +120,12 @@ class TrackManager {
   std::shared_ptr<SystemMemoryTrack> system_memory_track_;
   std::shared_ptr<CGroupAndProcessMemoryTrack> cgroup_and_process_memory_track_;
   std::shared_ptr<PageFaultsTrack> page_faults_track_;
+
+  // This intermediatly stores tracks that have been deleted from one of the track vectors above
+  // so they can safely be removed from the list of sorted and visible tracks.
+  // This makes sure tracks are always removed during UpdateLayout(), so no elements retains
+  // stale pointers returned in GetAllChildren() or GetNonHiddenChildren().
+  std::vector<std::shared_ptr<Track>> deleted_tracks_;
 
   Viewport* viewport_;
   TimeGraphLayout* layout_;

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -123,7 +123,7 @@ class TrackManager {
 
   // This intermediatly stores tracks that have been deleted from one of the track vectors above
   // so they can safely be removed from the list of sorted and visible tracks.
-  // This makes sure tracks are always removed during UpdateLayout(), so no elements retains
+  // This makes sure tracks are always removed during UpdateLayout(), so no elements retain
   // stale pointers returned in GetAllChildren() or GetNonHiddenChildren().
   std::vector<std::shared_ptr<Track>> deleted_tracks_;
 


### PR DESCRIPTION
This could be a potential source of issues: Frame tracks are being
deleted, but the pointer is still referenced in visible_tracks_. Update
of visible_tracks_ will eventually happen during UpdateLayout(), but
until then, we keep the stale pointer in this array.

Even though deletion of tracks happens from the main thread, it could
still happen in between UpdateLayout() and Draw() when they are handled
during different executions of the main thread.

Bug: b/208768988 - maybe
Test: Manual testing