### PR TITLE
Unify updates of TimeGraph time info

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -103,6 +103,8 @@ void TimeGraph::UpdateCaptureMinMaxTimestamps() {
 
   capture_min_timestamp_ = capture_min_timestamp;
   capture_max_timestamp_ = capture_max_timestamp;
+
+  RequestUpdate();
 }
 
 void TimeGraph::ZoomAll() {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -89,18 +89,30 @@ float TimeGraph::GetHeight() const {
 void TimeGraph::UpdateCaptureMinMaxTimestamps() {
   auto [tracks_min_time, tracks_max_time] = GetTrackManager()->GetTracksMinMaxTimestamps();
 
-  capture_min_timestamp_ = std::min(capture_min_timestamp_, tracks_min_time);
-  capture_max_timestamp_ = std::max(capture_max_timestamp_, tracks_max_time);
+  uint64_t capture_min_timestamp = std::min(capture_min_timestamp_, tracks_min_time);
+  uint64_t capture_max_timestamp = std::max(capture_max_timestamp_, tracks_max_time);
+
+  capture_min_timestamp =
+      std::min(capture_min_timestamp, capture_data_->GetCallstackData().min_time());
+  capture_max_timestamp =
+      std::max(capture_max_timestamp, capture_data_->GetCallstackData().max_time());
+
+  if (capture_min_timestamp == capture_min_timestamp_ &&
+      capture_max_timestamp == capture_max_timestamp_)
+    return;
+
+  capture_min_timestamp_ = capture_min_timestamp;
+  capture_max_timestamp_ = capture_max_timestamp;
 }
 
 void TimeGraph::ZoomAll() {
   constexpr double kNumHistorySeconds = 2.f;
   UpdateCaptureMinMaxTimestamps();
-  max_time_us_ = TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
-  min_time_us_ = max_time_us_ - (kNumHistorySeconds * 1000 * 1000);
-  if (min_time_us_ < 0) min_time_us_ = 0;
 
-  RequestUpdate();
+  double max_time_us = TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
+  double min_time_us = max_time_us - (kNumHistorySeconds * 1000 * 1000);
+
+  SetMinMax(min_time_us, max_time_us);
 }
 
 void TimeGraph::Zoom(uint64_t min, uint64_t max) {
@@ -162,22 +174,27 @@ void TimeGraph::SetMinMax(double min_time_us, double max_time_us) {
   // Centering the interval in screen.
   const double center_time_us = (max_time_us + min_time_us) / 2.;
 
-  min_time_us_ = std::max(center_time_us - desired_time_window / 2, 0.0);
-  max_time_us_ = std::min(min_time_us_ + desired_time_window, GetCaptureTimeSpanUs());
+  min_time_us = std::max(center_time_us - desired_time_window / 2, 0.0);
+  max_time_us = std::min(min_time_us + desired_time_window, GetCaptureTimeSpanUs());
+
+  if (min_time_us == min_time_us_ && max_time_us == max_time_us_) return;
+
+  min_time_us_ = min_time_us;
+  max_time_us_ = max_time_us;
 
   RequestUpdate();
 }
 
 void TimeGraph::PanTime(int initial_x, int current_x, int width, double initial_time) {
-  time_window_us_ = max_time_us_ - min_time_us_;
-  double initial_local_time = static_cast<double>(initial_x) / width * time_window_us_;
-  double dt = static_cast<double>(current_x - initial_x) / width * time_window_us_;
+  double time_window_us = max_time_us_ - min_time_us_;
+  double initial_local_time = static_cast<double>(initial_x) / width * time_window_us;
+  double dt = static_cast<double>(current_x - initial_x) / width * time_window_us;
   double current_time = initial_time - dt;
-  min_time_us_ =
-      std::clamp(current_time - initial_local_time, 0.0, GetCaptureTimeSpanUs() - time_window_us_);
-  max_time_us_ = min_time_us_ + time_window_us_;
+  double min_time_us =
+      std::clamp(current_time - initial_local_time, 0.0, GetCaptureTimeSpanUs() - time_window_us);
+  double max_time_us = min_time_us + time_window_us;
 
-  RequestUpdate();
+  SetMinMax(min_time_us, max_time_us);
 }
 
 void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, uint64_t min, uint64_t max,
@@ -214,8 +231,10 @@ void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, const TimerInf
 void TimeGraph::UpdateHorizontalScroll(float ratio) {
   double time_span = GetCaptureTimeSpanUs();
   double time_window = max_time_us_ - min_time_us_;
-  min_time_us_ = ratio * (time_span - time_window);
-  max_time_us_ = min_time_us_ + time_window;
+  double min_time_us = ratio * (time_span - time_window);
+  double max_time_us = min_time_us + time_window;
+
+  SetMinMax(min_time_us, max_time_us);
 }
 
 double TimeGraph::GetTime(double ratio) const {
@@ -225,9 +244,6 @@ double TimeGraph::GetTime(double ratio) const {
 }
 
 void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunction* function) {
-  capture_min_timestamp_ = std::min(capture_min_timestamp_, timer_info.start());
-  capture_max_timestamp_ = std::max(capture_max_timestamp_, timer_info.end());
-
   TrackManager* track_manager = GetTrackManager();
   // TODO(b/175869409): Change the way to create and get the tracks. Move this part to TrackManager.
   switch (timer_info.type()) {
@@ -368,9 +384,10 @@ void TimeGraph::ProcessAsyncTimer(const TimerInfo& timer_info) {
 }
 
 float TimeGraph::GetWorldFromTick(uint64_t time) const {
-  if (time_window_us_ > 0) {
+  double time_window_us = GetTimeWindowUs();
+  if (time_window_us > 0) {
     double start = TicksToMicroseconds(capture_min_timestamp_, time) - min_time_us_;
-    double normalized_start = start / time_window_us_;
+    double normalized_start = start / time_window_us;
     float pos = static_cast<float>(normalized_start * GetWidth());
     return pos;
   }
@@ -508,13 +525,7 @@ void TimeGraph::PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode) {
 void TimeGraph::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 
-  capture_min_timestamp_ =
-      std::min(capture_min_timestamp_, capture_data_->GetCallstackData().min_time());
-  capture_max_timestamp_ =
-      std::max(capture_max_timestamp_, capture_data_->GetCallstackData().max_time());
-
-  time_window_us_ = max_time_us_ - min_time_us_;
-
+  UpdateCaptureMinMaxTimestamps();
   UpdateChildrenPosAndContainerSize();
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -67,7 +67,7 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   [[nodiscard]] uint64_t GetTickFromUs(double micros) const override;
   [[nodiscard]] double GetUsFromTick(uint64_t time) const override;
   [[nodiscard]] uint64_t GetNsSinceStart(uint64_t time) const override;
-  [[nodiscard]] double GetTimeWindowUs() const override { return time_window_us_; }
+  [[nodiscard]] double GetTimeWindowUs() const override { return max_time_us_ - min_time_us_; }
   [[nodiscard]] double GetMinTimeUs() const override { return min_time_us_; }
   [[nodiscard]] double GetMaxTimeUs() const override { return max_time_us_; }
   [[nodiscard]] uint64_t GetCaptureTimeSpanNs() const override;
@@ -184,7 +184,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   double max_time_us_ = 0;
   uint64_t capture_min_timestamp_ = std::numeric_limits<uint64_t>::max();
   uint64_t capture_max_timestamp_ = 0;
-  double time_window_us_ = 0;
 
   TimeGraphLayout layout_;
 


### PR DESCRIPTION
This fixes the issue that double-clicking on an event does not correctly
update the capture window. The reason is that we set the capture
min / max times (both for the full capture and the visible area) in
multiple places. Not all of them trigger a `RequestUpdate`, and in this
particular case, the values for min / max time may have been updated
before redrawing, but the visible_timeframe_ may not.

This PR unifies all modifications to min and max timestamps and makes
sure we call `RequestUpdate` on all of them.

Bug: b/227162509
Test: Manual testing