### PR TITLE
Execute layout changes in a loop

### DIFF
--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -58,7 +58,7 @@ CaptureViewElement::EventResult CaptureViewElement::OnMouseWheel(
 }
 
 void CaptureViewElement::UpdateLayout() {
-  layout_has_changed_ = false;
+  has_layout_changed_ = false;
 
   // Perform any layout changes of this element
   DoUpdateLayout();
@@ -168,7 +168,7 @@ std::vector<CaptureViewElement*> CaptureViewElement::GetChildrenVisibleInViewpor
 }
 
 void CaptureViewElement::RequestUpdate() {
-  layout_has_changed_ = true;
+  has_layout_changed_ = true;
 
   if (parent_ != nullptr) {
     parent_->RequestUpdate();

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -58,6 +58,8 @@ CaptureViewElement::EventResult CaptureViewElement::OnMouseWheel(
 }
 
 void CaptureViewElement::UpdateLayout() {
+  layout_has_changed_ = false;
+
   // Perform any layout changes of this element
   DoUpdateLayout();
 
@@ -166,6 +168,8 @@ std::vector<CaptureViewElement*> CaptureViewElement::GetChildrenVisibleInViewpor
 }
 
 void CaptureViewElement::RequestUpdate() {
+  layout_has_changed_ = true;
+
   if (parent_ != nullptr) {
     parent_->RequestUpdate();
   }

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -76,6 +76,8 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] virtual uint32_t GetLayoutFlags() const { return kScaleHorizontallyWithParent; }
   [[nodiscard]] virtual float DetermineZOffset() const { return 0.f; }
 
+  [[nodiscard]] bool LayoutHasChanged() const { return layout_has_changed_; }
+
  protected:
   struct DrawContext {
     uint64_t current_mouse_time_ns = 0;
@@ -90,6 +92,8 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   Vec2 picking_offset_ = Vec2(0, 0);
   bool picked_ = false;
   bool visible_ = true;
+
+  bool layout_has_changed_ = false;
 
   void Draw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
             const DrawContext& draw_context);

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -76,7 +76,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] virtual uint32_t GetLayoutFlags() const { return kScaleHorizontallyWithParent; }
   [[nodiscard]] virtual float DetermineZOffset() const { return 0.f; }
 
-  [[nodiscard]] bool LayoutHasChanged() const { return layout_has_changed_; }
+  [[nodiscard]] bool HasLayoutChanged() const { return has_layout_changed_; }
 
  protected:
   struct DrawContext {
@@ -93,7 +93,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   bool picked_ = false;
   bool visible_ = true;
 
-  bool layout_has_changed_ = false;
+  bool has_layout_changed_ = false;
 
   void Draw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
             const DrawContext& draw_context);

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -127,7 +127,7 @@ void CaptureWindow::PreRender() {
     do {
       UpdateChildrenPosAndSize();
       time_graph_->UpdateLayout();
-    } while (time_graph_->LayoutHasChanged() || ++layout_loops < kMaxLayoutLoops);
+    } while (time_graph_->LayoutHasChanged() && ++layout_loops < kMaxLayoutLoops);
   }
 }
 


### PR DESCRIPTION
Layout changes of one element may require other elements to be updated
as well, so layouting needs to be done until all elements report that
they do not need to be updated further. As layout requests bubble up,
it's enough to check this for the root element (time graph) of the tree.

During loading or capturing, only a single layouting loop is
executed as we're streaming in data from a seperate thread.

Bugs: b/227989316
Test: Manual testing