### PR TITLE
Move FindModuleLocally off the main thread

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1700,7 +1700,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 
@@ -1949,8 +1949,7 @@ Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::FindModuleLocally(
   return thread_pool_->Schedule(
       [this, module_data,
        scoped_status = std::move(scoped_status)]() -> ErrorMessageOr<std::filesystem::path> {
-        const ModuleData& module_data_ref{*module_data};
-        return FindModuleLocallyImpl(symbol_helper_, module_data_ref);
+        return FindModuleLocallyImpl(symbol_helper_, *module_data);
       });
 }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1700,7 +1700,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -550,8 +550,8 @@ class OrbitApp final : public DataViewFactory,
   void SelectFunctionsByName(const orbit_client_data::ModuleData* module,
                              absl::Span<const std::string> function_names);
 
-  ErrorMessageOr<std::filesystem::path> FindModuleLocally(
-      const orbit_client_data::ModuleData& module_data);
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> FindModuleLocally(
+      const orbit_client_data::ModuleData* module_data);
   [[nodiscard]] orbit_base::Future<ErrorMessageOr<void>> LoadSymbols(
       const std::filesystem::path& symbols_path, const std::string& module_file_path,
       const std::string& module_build_id);


### PR DESCRIPTION
This changes OrbitApp::FindModuleLocally to return type Future and
changes the functionality to use thread_pool when searching for local
files. This is done because in rare cases this find operation can take
longer than expected and then blocks the main thread. This is not
solving the root cause that but rather mitigates the main thread issue.

Bug: http://b/228599959
Test: Manual test that symbol loading of local files still works