### PR TITLE
Make Hooked column under Live tab show entry types

### DIFF
--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -335,7 +335,7 @@ class VerifySymbolsLoaded(E2ETestCase):
 
 
 selected_function_string : str = 'H'
-frame_track_enabled_function_string : str = 'F'
+frame_track_enabled_string : str = 'F'
 
 
 class FilterAndHookFunction(E2ETestCase):
@@ -387,7 +387,7 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
 
         self.find_context_menu_item('Enable frame track(s)').click_input()
         
-        awaited_string : str = selected_function_string + ' [' + frame_track_enabled_function_string + ']'
+        awaited_string : str = selected_function_string + ' [' + frame_track_enabled_string + ']'
         wait_for_condition(lambda: awaited_string in functions_dataview.get_item_at(0, 0).texts()[0])
 
 

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -387,7 +387,7 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
 
         self.find_context_menu_item('Enable frame track(s)').click_input()
         
-        awaited_string : str = selected_function_string + ' ' + frame_track_enabled_function_string
+        awaited_string : str = selected_function_string + ' [' + frame_track_enabled_function_string + ']'
         wait_for_condition(lambda: awaited_string in functions_dataview.get_item_at(0, 0).texts()[0])
 
 

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -23,7 +23,8 @@ from test_cases.capture_window import Capture
 from test_cases.live_tab import VerifyFunctionCallCount
 
 Module = namedtuple("Module", ["name", "path", "is_loaded"])
-CACHE_LOCATION = "{appdata}\\OrbitProfiler\\cache\\".format(appdata=os.getenv('APPDATA'))
+CACHE_LOCATION = "{appdata}\\OrbitProfiler\\cache\\".format(
+    appdata=os.getenv('APPDATA'))
 
 
 def _show_symbols_and_functions_tabs(top_window):
@@ -54,7 +55,8 @@ def _find_and_close_error_dialog(top_window) -> str or None:
     if not module_path:
         return None
 
-    logging.info("Found error dialog for module {path}, closing.".format(path=module_path))
+    logging.info(
+        "Found error dialog for module {path}, closing.".format(path=module_path))
     find_control(window, 'Button', 'Cancel').click_input()
     return module_path
 
@@ -68,7 +70,8 @@ class ClearSymbolCache(E2ETestCase):
     """
 
     def _execute(self):
-        logging.info("Clearing symbol cache at {location}".format(location=CACHE_LOCATION))
+        logging.info("Clearing symbol cache at {location}".format(
+            location=CACHE_LOCATION))
         for file in os.listdir(CACHE_LOCATION):
             full_path = os.path.join(CACHE_LOCATION, file)
             if os.path.isfile(full_path):
@@ -98,7 +101,8 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
             Violating those conditions will result in test failure.
         """
         _show_symbols_and_functions_tabs(self.suite.top_window())
-        self._modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
+        self._modules_dataview = DataViewPanel(
+            self.find_control("Group", "ModulesDataView"))
         self._load_all_modules()
 
         modules_loading_result = self._wait_for_loading_and_collect_errors()
@@ -108,7 +112,8 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
 
         modules = self._gather_module_states()
         self._verify_all_modules_are_cached(modules)
-        self._verify_all_errors_were_raised(modules, modules_loading_result.errors)
+        self._verify_all_errors_were_raised(
+            modules, modules_loading_result.errors)
         logging.info("Done. Loading time: {time:.2f}s, module errors: {errors}".format(
             time=modules_loading_result.time, errors=modules_loading_result.errors))
 
@@ -143,13 +148,15 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
                 [module.name for module in module_set]))
 
     def _verify_all_errors_were_raised(self, all_modules: List[Module], errors: List[str]):
-        modules_not_loaded = set([module.path for module in all_modules if not module.is_loaded])
+        modules_not_loaded = set(
+            [module.path for module in all_modules if not module.is_loaded])
         error_set = set(errors)
         for module in modules_not_loaded:
             self.expect_true(module in error_set,
                              'Error has been raised for module {}'.format(module))
             error_set.remove(module)
-        self.expect_eq(0, len(error_set), 'All errors raised resulted in non-loadable modules')
+        self.expect_eq(0, len(error_set),
+                       'All errors raised resulted in non-loadable modules')
 
     def _wait_for_loading_and_collect_errors(self) -> ModulesLoadingResult:
         assume_loading_complete = 0
@@ -166,8 +173,10 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
             # show an error dialog. Then check if any of those is visible.
             # If not, try a few more times to make sure we didn't just accidentally query the UI while the status
             # message was being updated.
-            error_module = _find_and_close_error_dialog(self.suite.top_window())
-            status_message = self.find_control('StatusBar', recurse=False).texts()[0]
+            error_module = _find_and_close_error_dialog(
+                self.suite.top_window())
+            status_message = self.find_control(
+                'StatusBar', recurse=False).texts()[0]
             if "Copying debug info file" not in status_message and "Loading symbols" not in status_message:
                 status_message = None
 
@@ -186,7 +195,8 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
     def _gather_module_states(self) -> List[Module]:
         result = []
         for i in range(0, self._modules_dataview.get_row_count()):
-            is_loaded = self._modules_dataview.get_item_at(i, 0).texts()[0] == "*"
+            is_loaded = self._modules_dataview.get_item_at(i, 0).texts()[
+                0] == "*"
             name = self._modules_dataview.get_item_at(i, 1).texts()[0]
             path = self._modules_dataview.get_item_at(i, 2).texts()[0]
             result.append(Module(name, path, is_loaded))
@@ -235,8 +245,10 @@ class ForceAndVerifySymbolUpdate(E2ETestCase):
 
         Both modules need to exist in the local cache.
         """
-        dst_module = os.path.join(CACHE_LOCATION, full_module_path.replace("/", "_"))
-        src_module = os.path.join(CACHE_LOCATION, replace_with_module.replace("/", "_"))
+        dst_module = os.path.join(
+            CACHE_LOCATION, full_module_path.replace("/", "_"))
+        src_module = os.path.join(
+            CACHE_LOCATION, replace_with_module.replace("/", "_"))
         old_size = os.stat(dst_module).st_size
 
         os.unlink(os.path.join(CACHE_LOCATION, dst_module))
@@ -265,8 +277,10 @@ class LoadSymbols(E2ETestCase):
         """
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Start loading symbols for module %s', module_search_string)
-        modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
+        logging.info('Start loading symbols for module %s',
+                     module_search_string)
+        modules_dataview = DataViewPanel(
+            self.find_control("Group", "ModulesDataView"))
 
         logging.info('Waiting for module list to be populated...')
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0, 100)
@@ -287,7 +301,8 @@ class LoadSymbols(E2ETestCase):
             wait_for_condition(
                 lambda: _find_and_close_error_dialog(self.suite.top_window()) is not None)
         else:
-            wait_for_condition(lambda: modules_dataview.get_item_at(0, 0).texts()[0] == "*", 100)
+            wait_for_condition(lambda: modules_dataview.get_item_at(
+                0, 0).texts()[0] == "*", 100)
 
         VerifySymbolsLoaded(symbol_search_string=module_search_string,
                             expect_loaded=not expect_fail).execute(self.suite)
@@ -303,13 +318,15 @@ class VerifyModuleLoaded(E2ETestCase):
 
         logging.info('Start verifying module %s is %s.', module_search_string,
                      "loaded" if expect_loaded else "not loaded")
-        modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
+        modules_dataview = DataViewPanel(
+            self.find_control("Group", "ModulesDataView"))
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0, 100)
         modules_dataview.filter.set_focus()
         modules_dataview.filter.set_edit_text('')
         send_keys(module_search_string)
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0)
-        self.expect_true('*' in modules_dataview.get_item_at(0, 0).texts()[0], 'Module is loaded.')
+        self.expect_true('*' in modules_dataview.get_item_at(0,
+                         0).texts()[0], 'Module is loaded.')
 
 
 class VerifySymbolsLoaded(E2ETestCase):
@@ -318,7 +335,8 @@ class VerifySymbolsLoaded(E2ETestCase):
         logging.info(
             'Start verifying symbols with substring %s are {}loaded'.format(
                 "" if expect_loaded else "not "), symbol_search_string)
-        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        functions_dataview = DataViewPanel(
+            self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Filtering symbols')
         functions_dataview.filter.set_focus()
@@ -327,11 +345,16 @@ class VerifySymbolsLoaded(E2ETestCase):
         if expect_loaded:
             logging.info('Verifying at least one symbol with substring %s has been loaded',
                          symbol_search_string)
-            self.expect_true(functions_dataview.get_row_count() > 1, "Found expected symbol(s)")
+            self.expect_true(functions_dataview.get_row_count()
+                             > 1, "Found expected symbol(s)")
         else:
             logging.info('Verifying no symbols with substring %s has been loaded',
                          symbol_search_string)
-            self.expect_true(functions_dataview.get_row_count() == 0, "Found no symbols")
+            self.expect_true(functions_dataview.get_row_count()
+                             == 0, "Found no symbols")
+
+
+selected_function_icon = 'H'
 
 
 class FilterAndHookFunction(E2ETestCase):
@@ -342,8 +365,10 @@ class FilterAndHookFunction(E2ETestCase):
     def _execute(self, function_search_string):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Hooking function based on search "%s"', function_search_string)
-        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        logging.info('Hooking function based on search "%s"',
+                     function_search_string)
+        functions_dataview = DataViewPanel(
+            self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -356,7 +381,8 @@ class FilterAndHookFunction(E2ETestCase):
         functions_dataview.get_item_at(0, 0).click_input('right')
 
         self.find_context_menu_item('Hook').click_input()
-        wait_for_condition(lambda: '✓' in functions_dataview.get_item_at(0, 0).texts()[0])
+        wait_for_condition(
+            lambda: selected_function_icon in functions_dataview.get_item_at(0, 0).texts()[0])
 
 
 class FilterAndEnableFrameTrackForFunction(E2ETestCase):
@@ -369,7 +395,8 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
 
         logging.info('Enabling frame track for function based on search "%s"',
                      function_search_string)
-        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        functions_dataview = DataViewPanel(
+            self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -382,7 +409,8 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
         functions_dataview.get_item_at(0, 0).click_input('right')
 
         self.find_context_menu_item('Enable frame track(s)').click_input()
-        wait_for_condition(lambda: '✓ F' in functions_dataview.get_item_at(0, 0).texts()[0])
+        wait_for_condition(
+            lambda: selected_function_icon + ' F' in functions_dataview.get_item_at(0, 0).texts()[0])
 
 
 class UnhookAllFunctions(E2ETestCase):
@@ -393,7 +421,8 @@ class UnhookAllFunctions(E2ETestCase):
     def _execute(self):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        functions_dataview = DataViewPanel(
+            self.find_control("Group", "FunctionsDataView"))
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
         functions_dataview.filter.set_focus()
@@ -413,8 +442,10 @@ class FilterAndHookMultipleFunctions(E2ETestCase):
     def _execute(self, function_search_string):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Hooking functions based on search "%s"', function_search_string)
-        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        logging.info('Hooking functions based on search "%s"',
+                     function_search_string)
+        functions_dataview = DataViewPanel(
+            self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -428,7 +459,8 @@ class FilterAndHookMultipleFunctions(E2ETestCase):
         for i in range(functions_dataview.get_row_count()):
             functions_dataview.get_item_at(i, 0).click_input('right')
             self.find_context_menu_item('Hook').click_input()
-            wait_for_condition(lambda: '✓' in functions_dataview.get_item_at(i, 0).texts()[0])
+            wait_for_condition(
+                lambda: selected_function_icon in functions_dataview.get_item_at(i, 0).texts()[0])
 
 
 class LoadAndVerifyHelloGgpPreset(E2ETestCase):
@@ -453,30 +485,36 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
                                 max_calls=3000).execute(self.suite)
 
     def _load_presets(self):
-        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
+        presets_panel = DataViewPanel(
+            self.find_control('Group', 'PresetsDataView'))
 
         draw_frame_preset_row = presets_panel.find_first_item_row('draw_frame_in_hello_ggp_1_68', 1,
                                                                   True)
         issue_frame_token_preset_row = presets_panel.find_first_item_row(
             'ggp_issue_frame_token_in_hello_ggp_1_68', 1, True)
 
-        self.expect_true(draw_frame_preset_row is not None, 'Found draw_frame preset')
+        self.expect_true(draw_frame_preset_row is not None,
+                         'Found draw_frame preset')
         self.expect_true(issue_frame_token_preset_row is not None,
                          'Found ggp_issue_frame_token preset')
 
-        presets_panel.get_item_at(draw_frame_preset_row, 0).click_input(button='right')
+        presets_panel.get_item_at(
+            draw_frame_preset_row, 0).click_input(button='right')
         self.find_context_menu_item('Load Preset').click_input()
         logging.info('Loaded Preset DrawFrame')
 
-        presets_panel.get_item_at(issue_frame_token_preset_row, 0).click_input(button='right')
+        presets_panel.get_item_at(
+            issue_frame_token_preset_row, 0).click_input(button='right')
         self.find_context_menu_item('Load Preset').click_input()
         logging.info('Loaded Preset GgpIssueFrameToken')
 
     def _try_verify_functions_are_hooked(self):
         logging.info('Finding rows in the function list')
-        functions_panel = DataViewPanel(self.find_control('Group', 'FunctionsDataViewD'))
+        functions_panel = DataViewPanel(
+            self.find_control('Group', 'FunctionsDataViewD'))
         draw_frame_row = functions_panel.find_first_item_row('DrawFrame', 1)
-        issue_frame_token_row = functions_panel.find_first_item_row('GgpIssueFrameToken', 1)
+        issue_frame_token_row = functions_panel.find_first_item_row(
+            'GgpIssueFrameToken', 1)
 
         if draw_frame_row is None:
             return False
@@ -484,9 +522,9 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
             return False
 
         logging.info('Verifying hook status of functions')
-        self.expect_true('✓' in functions_panel.get_item_at(draw_frame_row, 0).texts()[0],
+        self.expect_true(selected_function_icon in functions_panel.get_item_at(draw_frame_row, 0).texts()[0],
                          'DrawFrame is marked as hooked')
-        self.expect_true('✓' in functions_panel.get_item_at(issue_frame_token_row, 0).texts()[0],
+        self.expect_true(selected_function_icon in functions_panel.get_item_at(issue_frame_token_row, 0).texts()[0],
                          'GgpIssueFrameToken is marked as hooked')
 
         return True
@@ -494,22 +532,23 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
 
 class VerifyFunctionHooked(E2ETestCase):
     """
-    Verfify wether or not function is hooked in the functions table in the symbols tab.
+    Verify whether or not function is hooked in the functions table in the symbols tab.
     """
 
     def _execute(self, function_search_string: str, expect_hooked: bool = True):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        functions_dataview = DataViewPanel(
+            self.find_control("Group", "FunctionsDataView"))
         functions_dataview.filter.set_focus()
         functions_dataview.filter.set_edit_text('')
         send_keys(function_search_string)
         row = functions_dataview.find_first_item_row(function_search_string, 1)
         if expect_hooked:
-            self.expect_true('✓' in functions_dataview.get_item_at(row, 0).texts()[0],
+            self.expect_true(selected_function_icon in functions_dataview.get_item_at(row, 0).texts()[0],
                              'Function is marked as hooked.')
         else:
-            self.expect_true('✓' not in functions_dataview.get_item_at(row, 0).texts()[0],
+            self.expect_true(selected_function_icon not in functions_dataview.get_item_at(row, 0).texts()[0],
                              'Function is not marked as hooked.')
 
 
@@ -527,14 +566,16 @@ class VerifyPresetStatus(E2ETestCase):
     def _execute(self, preset_name: str, expected_status: PresetStatus):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
+        presets_panel = DataViewPanel(
+            self.find_control('Group', 'PresetsDataView'))
         preset_row = presets_panel.find_first_item_row(preset_name, 1, True)
         self.expect_true(preset_row is not None, 'Found preset.')
         status_text = presets_panel.get_item_at(preset_row, 0).texts()[0]
         if expected_status is PresetStatus.LOADABLE:
             self.expect_true('Yes' in status_text, 'Preset is loadable.')
         if expected_status is PresetStatus.PARTIALLY_LOADABLE:
-            self.expect_true('Partially' in status_text, 'Preset is partially loadable.')
+            self.expect_true('Partially' in status_text,
+                             'Preset is partially loadable.')
         if expected_status is PresetStatus.NOT_LOADABLE:
             self.expect_true('No' in status_text, 'Preset is not loadable.')
 
@@ -547,23 +588,27 @@ class LoadPreset(E2ETestCase):
     def _execute(self, preset_name: str):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
+        presets_panel = DataViewPanel(
+            self.find_control('Group', 'PresetsDataView'))
         preset_row = presets_panel.find_first_item_row(preset_name, 1, True)
         self.expect_true(preset_row is not None, 'Found preset.')
         status_text = presets_panel.get_item_at(preset_row, 0).texts()[0]
 
         if 'No' in status_text:
-            app_menu = self.suite.top_window().descendants(control_type="MenuBar")[1]
+            app_menu = self.suite.top_window().descendants(
+                control_type="MenuBar")[1]
             app_menu.item_by_path("File->Open Preset...").click_input()
             dialog = self.suite.top_window().child_window(title_re="Select a file*")
             dialog.FileNameEdit.type_keys(preset_name)
             dialog.FileNameEdit.type_keys('{DOWN}{ENTER}')
 
-            message_box = self.suite.top_window().child_window(title_re="Preset loading failed*")
+            message_box = self.suite.top_window().child_window(
+                title_re="Preset loading failed*")
             self.expect_true(message_box is not None, 'Message box found.')
             message_box.Ok.click()
         else:
-            presets_panel.get_item_at(preset_row, 0).click_input(button='right')
+            presets_panel.get_item_at(
+                preset_row, 0).click_input(button='right')
             self.find_context_menu_item('Load Preset').click_input()
             logging.info('Loaded preset: %s', preset_name)
 
@@ -580,7 +625,8 @@ class SavePreset(E2ETestCase):
     """
 
     def _execute(self, preset_name: str):
-        app_menu = self.suite.top_window().descendants(control_type="MenuBar")[1]
+        app_menu = self.suite.top_window().descendants(
+            control_type="MenuBar")[1]
         app_menu.item_by_path("File->Save Preset As ...").click_input()
         dialog = self.suite.top_window().child_window(title_re="Specify*")
         dialog.FileNameCombo.type_keys(preset_name)
@@ -602,8 +648,10 @@ class ShowSourceCode(E2ETestCase):
     def _provoke_goto_source_action(self, function_search_string: str):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Start showing source code for function {}'.format(function_search_string))
-        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
+        logging.info('Start showing source code for function {}'.format(
+            function_search_string))
+        functions_dataview = DataViewPanel(
+            self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -647,7 +695,8 @@ class ShowSourceCode(E2ETestCase):
 
         wait_for_condition(lambda: get_file_open_dialog().is_visible())
         file_open_dialog = get_file_open_dialog()
-        logging.info("File Open Dialog is now visible. Looking for file edit...")
+        logging.info(
+            "File Open Dialog is now visible. Looking for file edit...")
 
         logging.info("File Edit was found. Entering file path...")
         file_edit = self.find_control(control_type="Edit",
@@ -677,7 +726,8 @@ class ShowSourceCode(E2ETestCase):
     def _handle_source_code_dialog(self):
         logging.info("Waiting for the source code dialog.")
 
-        source_code_dialog = self.suite.application.window(auto_id="CodeViewerDialog")
+        source_code_dialog = self.suite.application.window(
+            auto_id="CodeViewerDialog")
         source_code_dialog.wait('visible')
 
         logging.info("Found source code dialog. Checking contents...")

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -334,7 +334,8 @@ class VerifySymbolsLoaded(E2ETestCase):
             self.expect_true(functions_dataview.get_row_count() == 0, "Found no symbols")
 
 
-selected_function_icon : str = 'H'
+selected_function_string : str = 'H'
+frame_track_enabled_function_string : str = 'F'
 
 
 class FilterAndHookFunction(E2ETestCase):
@@ -359,7 +360,7 @@ class FilterAndHookFunction(E2ETestCase):
         functions_dataview.get_item_at(0, 0).click_input('right')
 
         self.find_context_menu_item('Hook').click_input()
-        wait_for_condition(lambda: selected_function_icon in functions_dataview.get_item_at(0, 0).texts()[0])
+        wait_for_condition(lambda: selected_function_string in functions_dataview.get_item_at(0, 0).texts()[0])
 
 
 class FilterAndEnableFrameTrackForFunction(E2ETestCase):
@@ -385,7 +386,9 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
         functions_dataview.get_item_at(0, 0).click_input('right')
 
         self.find_context_menu_item('Enable frame track(s)').click_input()
-        wait_for_condition(lambda: selected_function_icon + ' F' in functions_dataview.get_item_at(0, 0).texts()[0])
+        
+        awaited_string : str = selected_function_string + ' ' + frame_track_enabled_function_string
+        wait_for_condition(lambda: awaited_string in functions_dataview.get_item_at(0, 0).texts()[0])
 
 
 class UnhookAllFunctions(E2ETestCase):
@@ -431,7 +434,7 @@ class FilterAndHookMultipleFunctions(E2ETestCase):
         for i in range(functions_dataview.get_row_count()):
             functions_dataview.get_item_at(i, 0).click_input('right')
             self.find_context_menu_item('Hook').click_input()
-            wait_for_condition(lambda: selected_function_icon in functions_dataview.get_item_at(i, 0).texts()[0])
+            wait_for_condition(lambda: selected_function_string in functions_dataview.get_item_at(i, 0).texts()[0])
 
 
 class LoadAndVerifyHelloGgpPreset(E2ETestCase):
@@ -487,9 +490,9 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
             return False
 
         logging.info('Verifying hook status of functions')
-        self.expect_true(selected_function_icon in functions_panel.get_item_at(draw_frame_row, 0).texts()[0],
+        self.expect_true(selected_function_string in functions_panel.get_item_at(draw_frame_row, 0).texts()[0],
                          'DrawFrame is marked as hooked')
-        self.expect_true(selected_function_icon in functions_panel.get_item_at(issue_frame_token_row, 0).texts()[0],
+        self.expect_true(selected_function_string in functions_panel.get_item_at(issue_frame_token_row, 0).texts()[0],
                          'GgpIssueFrameToken is marked as hooked')
 
         return True
@@ -509,10 +512,10 @@ class VerifyFunctionHooked(E2ETestCase):
         send_keys(function_search_string)
         row = functions_dataview.find_first_item_row(function_search_string, 1)
         if expect_hooked:
-            self.expect_true(selected_function_icon in functions_dataview.get_item_at(row, 0).texts()[0],
+            self.expect_true(selected_function_string in functions_dataview.get_item_at(row, 0).texts()[0],
                              'Function is marked as hooked.')
         else:
-            self.expect_true(selected_function_icon not in functions_dataview.get_item_at(row, 0).texts()[0],
+            self.expect_true(selected_function_string not in functions_dataview.get_item_at(row, 0).texts()[0],
                              'Function is not marked as hooked.')
 
 

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -334,7 +334,7 @@ class VerifySymbolsLoaded(E2ETestCase):
             self.expect_true(functions_dataview.get_row_count() == 0, "Found no symbols")
 
 
-selected_function_icon : bool = true
+selected_function_icon : str = 'H'
 
 
 class FilterAndHookFunction(E2ETestCase):

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -23,8 +23,7 @@ from test_cases.capture_window import Capture
 from test_cases.live_tab import VerifyFunctionCallCount
 
 Module = namedtuple("Module", ["name", "path", "is_loaded"])
-CACHE_LOCATION = "{appdata}\\OrbitProfiler\\cache\\".format(
-    appdata=os.getenv('APPDATA'))
+CACHE_LOCATION = "{appdata}\\OrbitProfiler\\cache\\".format(appdata=os.getenv('APPDATA'))
 
 
 def _show_symbols_and_functions_tabs(top_window):
@@ -55,8 +54,7 @@ def _find_and_close_error_dialog(top_window) -> str or None:
     if not module_path:
         return None
 
-    logging.info(
-        "Found error dialog for module {path}, closing.".format(path=module_path))
+    logging.info("Found error dialog for module {path}, closing.".format(path=module_path))
     find_control(window, 'Button', 'Cancel').click_input()
     return module_path
 
@@ -70,8 +68,7 @@ class ClearSymbolCache(E2ETestCase):
     """
 
     def _execute(self):
-        logging.info("Clearing symbol cache at {location}".format(
-            location=CACHE_LOCATION))
+        logging.info("Clearing symbol cache at {location}".format(location=CACHE_LOCATION))
         for file in os.listdir(CACHE_LOCATION):
             full_path = os.path.join(CACHE_LOCATION, file)
             if os.path.isfile(full_path):
@@ -101,8 +98,7 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
             Violating those conditions will result in test failure.
         """
         _show_symbols_and_functions_tabs(self.suite.top_window())
-        self._modules_dataview = DataViewPanel(
-            self.find_control("Group", "ModulesDataView"))
+        self._modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
         self._load_all_modules()
 
         modules_loading_result = self._wait_for_loading_and_collect_errors()
@@ -112,8 +108,7 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
 
         modules = self._gather_module_states()
         self._verify_all_modules_are_cached(modules)
-        self._verify_all_errors_were_raised(
-            modules, modules_loading_result.errors)
+        self._verify_all_errors_were_raised(modules, modules_loading_result.errors)
         logging.info("Done. Loading time: {time:.2f}s, module errors: {errors}".format(
             time=modules_loading_result.time, errors=modules_loading_result.errors))
 
@@ -148,15 +143,13 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
                 [module.name for module in module_set]))
 
     def _verify_all_errors_were_raised(self, all_modules: List[Module], errors: List[str]):
-        modules_not_loaded = set(
-            [module.path for module in all_modules if not module.is_loaded])
+        modules_not_loaded = set([module.path for module in all_modules if not module.is_loaded])
         error_set = set(errors)
         for module in modules_not_loaded:
             self.expect_true(module in error_set,
                              'Error has been raised for module {}'.format(module))
             error_set.remove(module)
-        self.expect_eq(0, len(error_set),
-                       'All errors raised resulted in non-loadable modules')
+        self.expect_eq(0, len(error_set), 'All errors raised resulted in non-loadable modules')
 
     def _wait_for_loading_and_collect_errors(self) -> ModulesLoadingResult:
         assume_loading_complete = 0
@@ -173,10 +166,8 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
             # show an error dialog. Then check if any of those is visible.
             # If not, try a few more times to make sure we didn't just accidentally query the UI while the status
             # message was being updated.
-            error_module = _find_and_close_error_dialog(
-                self.suite.top_window())
-            status_message = self.find_control(
-                'StatusBar', recurse=False).texts()[0]
+            error_module = _find_and_close_error_dialog(self.suite.top_window())
+            status_message = self.find_control('StatusBar', recurse=False).texts()[0]
             if "Copying debug info file" not in status_message and "Loading symbols" not in status_message:
                 status_message = None
 
@@ -195,8 +186,7 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
     def _gather_module_states(self) -> List[Module]:
         result = []
         for i in range(0, self._modules_dataview.get_row_count()):
-            is_loaded = self._modules_dataview.get_item_at(i, 0).texts()[
-                0] == "*"
+            is_loaded = self._modules_dataview.get_item_at(i, 0).texts()[0] == "*"
             name = self._modules_dataview.get_item_at(i, 1).texts()[0]
             path = self._modules_dataview.get_item_at(i, 2).texts()[0]
             result.append(Module(name, path, is_loaded))
@@ -245,10 +235,8 @@ class ForceAndVerifySymbolUpdate(E2ETestCase):
 
         Both modules need to exist in the local cache.
         """
-        dst_module = os.path.join(
-            CACHE_LOCATION, full_module_path.replace("/", "_"))
-        src_module = os.path.join(
-            CACHE_LOCATION, replace_with_module.replace("/", "_"))
+        dst_module = os.path.join(CACHE_LOCATION, full_module_path.replace("/", "_"))
+        src_module = os.path.join(CACHE_LOCATION, replace_with_module.replace("/", "_"))
         old_size = os.stat(dst_module).st_size
 
         os.unlink(os.path.join(CACHE_LOCATION, dst_module))
@@ -277,10 +265,8 @@ class LoadSymbols(E2ETestCase):
         """
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Start loading symbols for module %s',
-                     module_search_string)
-        modules_dataview = DataViewPanel(
-            self.find_control("Group", "ModulesDataView"))
+        logging.info('Start loading symbols for module %s', module_search_string)
+        modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
 
         logging.info('Waiting for module list to be populated...')
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0, 100)
@@ -301,8 +287,7 @@ class LoadSymbols(E2ETestCase):
             wait_for_condition(
                 lambda: _find_and_close_error_dialog(self.suite.top_window()) is not None)
         else:
-            wait_for_condition(lambda: modules_dataview.get_item_at(
-                0, 0).texts()[0] == "*", 100)
+            wait_for_condition(lambda: modules_dataview.get_item_at(0, 0).texts()[0] == "*", 100)
 
         VerifySymbolsLoaded(symbol_search_string=module_search_string,
                             expect_loaded=not expect_fail).execute(self.suite)
@@ -318,15 +303,13 @@ class VerifyModuleLoaded(E2ETestCase):
 
         logging.info('Start verifying module %s is %s.', module_search_string,
                      "loaded" if expect_loaded else "not loaded")
-        modules_dataview = DataViewPanel(
-            self.find_control("Group", "ModulesDataView"))
+        modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0, 100)
         modules_dataview.filter.set_focus()
         modules_dataview.filter.set_edit_text('')
         send_keys(module_search_string)
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0)
-        self.expect_true('*' in modules_dataview.get_item_at(0,
-                         0).texts()[0], 'Module is loaded.')
+        self.expect_true('*' in modules_dataview.get_item_at(0, 0).texts()[0], 'Module is loaded.')
 
 
 class VerifySymbolsLoaded(E2ETestCase):
@@ -335,8 +318,7 @@ class VerifySymbolsLoaded(E2ETestCase):
         logging.info(
             'Start verifying symbols with substring %s are {}loaded'.format(
                 "" if expect_loaded else "not "), symbol_search_string)
-        functions_dataview = DataViewPanel(
-            self.find_control("Group", "FunctionsDataView"))
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Filtering symbols')
         functions_dataview.filter.set_focus()
@@ -345,16 +327,14 @@ class VerifySymbolsLoaded(E2ETestCase):
         if expect_loaded:
             logging.info('Verifying at least one symbol with substring %s has been loaded',
                          symbol_search_string)
-            self.expect_true(functions_dataview.get_row_count()
-                             > 1, "Found expected symbol(s)")
+            self.expect_true(functions_dataview.get_row_count() > 1, "Found expected symbol(s)")
         else:
             logging.info('Verifying no symbols with substring %s has been loaded',
                          symbol_search_string)
-            self.expect_true(functions_dataview.get_row_count()
-                             == 0, "Found no symbols")
+            self.expect_true(functions_dataview.get_row_count() == 0, "Found no symbols")
 
 
-selected_function_icon = 'H'
+selected_function_icon : bool = true
 
 
 class FilterAndHookFunction(E2ETestCase):
@@ -365,10 +345,8 @@ class FilterAndHookFunction(E2ETestCase):
     def _execute(self, function_search_string):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Hooking function based on search "%s"',
-                     function_search_string)
-        functions_dataview = DataViewPanel(
-            self.find_control("Group", "FunctionsDataView"))
+        logging.info('Hooking function based on search "%s"', function_search_string)
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -381,8 +359,7 @@ class FilterAndHookFunction(E2ETestCase):
         functions_dataview.get_item_at(0, 0).click_input('right')
 
         self.find_context_menu_item('Hook').click_input()
-        wait_for_condition(
-            lambda: selected_function_icon in functions_dataview.get_item_at(0, 0).texts()[0])
+        wait_for_condition(lambda: selected_function_icon in functions_dataview.get_item_at(0, 0).texts()[0])
 
 
 class FilterAndEnableFrameTrackForFunction(E2ETestCase):
@@ -395,8 +372,7 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
 
         logging.info('Enabling frame track for function based on search "%s"',
                      function_search_string)
-        functions_dataview = DataViewPanel(
-            self.find_control("Group", "FunctionsDataView"))
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -409,8 +385,7 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
         functions_dataview.get_item_at(0, 0).click_input('right')
 
         self.find_context_menu_item('Enable frame track(s)').click_input()
-        wait_for_condition(
-            lambda: selected_function_icon + ' F' in functions_dataview.get_item_at(0, 0).texts()[0])
+        wait_for_condition(lambda: selected_function_icon + ' F' in functions_dataview.get_item_at(0, 0).texts()[0])
 
 
 class UnhookAllFunctions(E2ETestCase):
@@ -421,8 +396,7 @@ class UnhookAllFunctions(E2ETestCase):
     def _execute(self):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        functions_dataview = DataViewPanel(
-            self.find_control("Group", "FunctionsDataView"))
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
         functions_dataview.filter.set_focus()
@@ -442,10 +416,8 @@ class FilterAndHookMultipleFunctions(E2ETestCase):
     def _execute(self, function_search_string):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Hooking functions based on search "%s"',
-                     function_search_string)
-        functions_dataview = DataViewPanel(
-            self.find_control("Group", "FunctionsDataView"))
+        logging.info('Hooking functions based on search "%s"', function_search_string)
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -459,8 +431,7 @@ class FilterAndHookMultipleFunctions(E2ETestCase):
         for i in range(functions_dataview.get_row_count()):
             functions_dataview.get_item_at(i, 0).click_input('right')
             self.find_context_menu_item('Hook').click_input()
-            wait_for_condition(
-                lambda: selected_function_icon in functions_dataview.get_item_at(i, 0).texts()[0])
+            wait_for_condition(lambda: selected_function_icon in functions_dataview.get_item_at(i, 0).texts()[0])
 
 
 class LoadAndVerifyHelloGgpPreset(E2ETestCase):
@@ -485,36 +456,30 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
                                 max_calls=3000).execute(self.suite)
 
     def _load_presets(self):
-        presets_panel = DataViewPanel(
-            self.find_control('Group', 'PresetsDataView'))
+        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
 
         draw_frame_preset_row = presets_panel.find_first_item_row('draw_frame_in_hello_ggp_1_68', 1,
                                                                   True)
         issue_frame_token_preset_row = presets_panel.find_first_item_row(
             'ggp_issue_frame_token_in_hello_ggp_1_68', 1, True)
 
-        self.expect_true(draw_frame_preset_row is not None,
-                         'Found draw_frame preset')
+        self.expect_true(draw_frame_preset_row is not None, 'Found draw_frame preset')
         self.expect_true(issue_frame_token_preset_row is not None,
                          'Found ggp_issue_frame_token preset')
 
-        presets_panel.get_item_at(
-            draw_frame_preset_row, 0).click_input(button='right')
+        presets_panel.get_item_at(draw_frame_preset_row, 0).click_input(button='right')
         self.find_context_menu_item('Load Preset').click_input()
         logging.info('Loaded Preset DrawFrame')
 
-        presets_panel.get_item_at(
-            issue_frame_token_preset_row, 0).click_input(button='right')
+        presets_panel.get_item_at(issue_frame_token_preset_row, 0).click_input(button='right')
         self.find_context_menu_item('Load Preset').click_input()
         logging.info('Loaded Preset GgpIssueFrameToken')
 
     def _try_verify_functions_are_hooked(self):
         logging.info('Finding rows in the function list')
-        functions_panel = DataViewPanel(
-            self.find_control('Group', 'FunctionsDataViewD'))
+        functions_panel = DataViewPanel(self.find_control('Group', 'FunctionsDataViewD'))
         draw_frame_row = functions_panel.find_first_item_row('DrawFrame', 1)
-        issue_frame_token_row = functions_panel.find_first_item_row(
-            'GgpIssueFrameToken', 1)
+        issue_frame_token_row = functions_panel.find_first_item_row('GgpIssueFrameToken', 1)
 
         if draw_frame_row is None:
             return False
@@ -532,14 +497,13 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
 
 class VerifyFunctionHooked(E2ETestCase):
     """
-    Verify whether or not function is hooked in the functions table in the symbols tab.
+    Verfify wether or not function is hooked in the functions table in the symbols tab.
     """
 
     def _execute(self, function_search_string: str, expect_hooked: bool = True):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        functions_dataview = DataViewPanel(
-            self.find_control("Group", "FunctionsDataView"))
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
         functions_dataview.filter.set_focus()
         functions_dataview.filter.set_edit_text('')
         send_keys(function_search_string)
@@ -566,16 +530,14 @@ class VerifyPresetStatus(E2ETestCase):
     def _execute(self, preset_name: str, expected_status: PresetStatus):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        presets_panel = DataViewPanel(
-            self.find_control('Group', 'PresetsDataView'))
+        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
         preset_row = presets_panel.find_first_item_row(preset_name, 1, True)
         self.expect_true(preset_row is not None, 'Found preset.')
         status_text = presets_panel.get_item_at(preset_row, 0).texts()[0]
         if expected_status is PresetStatus.LOADABLE:
             self.expect_true('Yes' in status_text, 'Preset is loadable.')
         if expected_status is PresetStatus.PARTIALLY_LOADABLE:
-            self.expect_true('Partially' in status_text,
-                             'Preset is partially loadable.')
+            self.expect_true('Partially' in status_text, 'Preset is partially loadable.')
         if expected_status is PresetStatus.NOT_LOADABLE:
             self.expect_true('No' in status_text, 'Preset is not loadable.')
 
@@ -588,27 +550,23 @@ class LoadPreset(E2ETestCase):
     def _execute(self, preset_name: str):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        presets_panel = DataViewPanel(
-            self.find_control('Group', 'PresetsDataView'))
+        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
         preset_row = presets_panel.find_first_item_row(preset_name, 1, True)
         self.expect_true(preset_row is not None, 'Found preset.')
         status_text = presets_panel.get_item_at(preset_row, 0).texts()[0]
 
         if 'No' in status_text:
-            app_menu = self.suite.top_window().descendants(
-                control_type="MenuBar")[1]
+            app_menu = self.suite.top_window().descendants(control_type="MenuBar")[1]
             app_menu.item_by_path("File->Open Preset...").click_input()
             dialog = self.suite.top_window().child_window(title_re="Select a file*")
             dialog.FileNameEdit.type_keys(preset_name)
             dialog.FileNameEdit.type_keys('{DOWN}{ENTER}')
 
-            message_box = self.suite.top_window().child_window(
-                title_re="Preset loading failed*")
+            message_box = self.suite.top_window().child_window(title_re="Preset loading failed*")
             self.expect_true(message_box is not None, 'Message box found.')
             message_box.Ok.click()
         else:
-            presets_panel.get_item_at(
-                preset_row, 0).click_input(button='right')
+            presets_panel.get_item_at(preset_row, 0).click_input(button='right')
             self.find_context_menu_item('Load Preset').click_input()
             logging.info('Loaded preset: %s', preset_name)
 
@@ -625,8 +583,7 @@ class SavePreset(E2ETestCase):
     """
 
     def _execute(self, preset_name: str):
-        app_menu = self.suite.top_window().descendants(
-            control_type="MenuBar")[1]
+        app_menu = self.suite.top_window().descendants(control_type="MenuBar")[1]
         app_menu.item_by_path("File->Save Preset As ...").click_input()
         dialog = self.suite.top_window().child_window(title_re="Specify*")
         dialog.FileNameCombo.type_keys(preset_name)
@@ -648,10 +605,8 @@ class ShowSourceCode(E2ETestCase):
     def _provoke_goto_source_action(self, function_search_string: str):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Start showing source code for function {}'.format(
-            function_search_string))
-        functions_dataview = DataViewPanel(
-            self.find_control("Group", "FunctionsDataView"))
+        logging.info('Start showing source code for function {}'.format(function_search_string))
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -695,8 +650,7 @@ class ShowSourceCode(E2ETestCase):
 
         wait_for_condition(lambda: get_file_open_dialog().is_visible())
         file_open_dialog = get_file_open_dialog()
-        logging.info(
-            "File Open Dialog is now visible. Looking for file edit...")
+        logging.info("File Open Dialog is now visible. Looking for file edit...")
 
         logging.info("File Edit was found. Entering file path...")
         file_edit = self.find_control(control_type="Edit",
@@ -726,8 +680,7 @@ class ShowSourceCode(E2ETestCase):
     def _handle_source_code_dialog(self):
         logging.info("Waiting for the source code dialog.")
 
-        source_code_dialog = self.suite.application.window(
-            auto_id="CodeViewerDialog")
+        source_code_dialog = self.suite.application.window(auto_id="CodeViewerDialog")
         source_code_dialog.wait('visible')
 
         logging.info("Found source code dialog. Checking contents...")

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(ClientData PUBLIC
         include/ClientData/ProcessData.h
         include/ClientData/ScopeIdConstants.h
         include/ClientData/ScopeIdProvider.h
+        include/ClientData/ScopeInfo.h
         include/ClientData/ScopeStats.h
         include/ClientData/ScopeTreeTimerData.h
         include/ClientData/ThreadStateSliceInfo.h

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -91,6 +91,7 @@ target_sources(ClientDataTests PRIVATE
         ModuleDataTest.cpp
         ModuleManagerTest.cpp
         ProcessDataTest.cpp
+        ScopeInfoTest.cpp
         ScopeTreeTimerDataTest.cpp
         ThreadTrackDataManagerTest.cpp
         ThreadTrackDataProviderTest.cpp

--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -162,9 +162,9 @@ uint64_t CaptureData::ProvideScopeId(const orbit_client_protos::TimerInfo& timer
   return scope_id_provider_->GetAllProvidedScopeIds();
 }
 
-const std::string& CaptureData::GetScopeName(uint64_t scope_id) const {
+const ScopeInfo& CaptureData::GetScopeInfo(uint64_t scope_id) const {
   ORBIT_CHECK(scope_id_provider_);
-  return scope_id_provider_->GetScopeName(scope_id);
+  return scope_id_provider_->GetScopeInfo(scope_id);
 }
 
 uint64_t CaptureData::FunctionIdToScopeId(uint64_t function_id) const {

--- a/src/ClientData/CaptureDataTest.cpp
+++ b/src/ClientData/CaptureDataTest.cpp
@@ -33,7 +33,7 @@ class MockScopeIdProvider : public ScopeIdProvider {
  public:
   MOCK_METHOD(uint64_t, FunctionIdToScopeId, (uint64_t function_id), (const));
   MOCK_METHOD(uint64_t, ProvideId, (const TimerInfo& timer_info));
-  MOCK_METHOD(const std::string&, GetScopeName, (uint64_t scope_id), (const));
+  MOCK_METHOD(const ScopeInfo&, GetScopeInfo, (uint64_t scope_id), (const));
   MOCK_METHOD(std::vector<uint64_t>, GetAllProvidedScopeIds, (), (const));
 };
 

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -16,7 +16,6 @@
 #include "ClientData/ScopeIdConstants.h"
 #include "ClientData/ScopeInfo.h"
 #include "ClientFlags/ClientFlags.h"
-#include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/Constants.h"
 #include "OrbitBase/Logging.h"
 
@@ -63,13 +62,10 @@ uint64_t NameEqualityScopeIdProvider::FunctionIdToScopeId(uint64_t function_id) 
 }
 
 uint64_t NameEqualityScopeIdProvider::ProvideId(const TimerInfo& timer_info) {
-  ScopeType scope_type = ScopeTypeForTimerInfo(timer_info);
+  const ScopeType scope_type = ScopeTypeForTimerInfo(timer_info);
 
   if (scope_type == ScopeType::kOther) return orbit_client_data::kInvalidScopeId;
 
-  // Check if the `timer_info` corresponds to a hooked function event. Checking for `function_id`
-  // not being invalid is not sufficient, as e.g. frametrack events may also have non-invalid
-  // function_id
   if (scope_type == ScopeType::kHookedFunction) {
     return FunctionIdToScopeId(timer_info.function_id());
   }

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -34,8 +34,9 @@ std::unique_ptr<NameEqualityScopeIdProvider> NameEqualityScopeIdProvider::Create
 
   absl::flat_hash_map<uint64_t, const ScopeInfo> scope_id_to_info;
   for (const auto& instrumented_function : instrumented_functions) {
-    scope_id_to_info.insert({instrumented_function.function_id(),
-                             {instrumented_function.function_name(), ScopeType::kDynamicallyInstrumentedFunction}});
+    scope_id_to_info.insert(
+        {instrumented_function.function_id(),
+         {instrumented_function.function_name(), ScopeType::kDynamicallyInstrumentedFunction}});
   }
 
   return std::unique_ptr<NameEqualityScopeIdProvider>(

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -75,6 +75,8 @@ uint64_t NameEqualityScopeIdProvider::ProvideId(const TimerInfo& timer_info) {
   // released.
   if (!absl::GetFlag(FLAGS_devmode)) return kInvalidScopeId;
 
+  ORBIT_CHECK(scope_type == ScopeType::kApiScope || scope_type == ScopeType::kApiScopeAsync);
+
   const ScopeInfo scope_info{timer_info.api_scope_name(), scope_type};
 
   const auto it = scope_info_to_id_.find(scope_info);

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -14,7 +14,9 @@
 #include <vector>
 
 #include "ClientData/ScopeIdConstants.h"
+#include "ClientData/ScopeInfo.h"
 #include "ClientFlags/ClientFlags.h"
+#include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/Constants.h"
 #include "OrbitBase/Logging.h"
 
@@ -31,59 +33,75 @@ std::unique_ptr<NameEqualityScopeIdProvider> NameEqualityScopeIdProvider::Create
                 [](const auto& a, const auto& b) { return a.function_id() < b.function_id(); })
                 ->function_id();
 
-  absl::flat_hash_map<uint64_t, std::string> scope_id_to_name;
+  absl::flat_hash_map<uint64_t, ScopeInfo> scope_id_to_info;
   for (const auto& instrumented_function : instrumented_functions) {
-    scope_id_to_name[instrumented_function.function_id()] = instrumented_function.function_name();
+    scope_id_to_info[instrumented_function.function_id()] = {instrumented_function.function_name(),
+                                                             ScopeType::kHookedFunction};
   }
 
   return std::unique_ptr<NameEqualityScopeIdProvider>(
-      new NameEqualityScopeIdProvider(max_id + 1, std::move(scope_id_to_name)));
+      new NameEqualityScopeIdProvider(max_id + 1, std::move(scope_id_to_info)));
 }
 
 uint64_t NameEqualityScopeIdProvider::FunctionIdToScopeId(uint64_t function_id) const {
   return function_id;
 }
 
+[[nodiscard]] static ScopeType ScopeTypeForTimerInfo(const TimerInfo& timer) {
+  switch (timer.type()) {
+    case TimerInfo::kNone:
+      return timer.function_id() != orbit_grpc_protos::kInvalidFunctionId
+                 ? ScopeType::kHookedFunction
+                 : ScopeType::kOther;
+    case TimerInfo::kApiScope:
+      return ScopeType::kApiScope;
+    case TimerInfo::kApiScopeAsync:
+      return ScopeType::kApiScopeAsync;
+    default:
+      return ScopeType::kOther;
+  }
+}
+
 uint64_t NameEqualityScopeIdProvider::ProvideId(const TimerInfo& timer_info) {
+  ScopeType scope_type = ScopeTypeForTimerInfo(timer_info);
+
+  if (scope_type == ScopeType::kOther) return orbit_client_data::kInvalidScopeId;
+
   // Check if the `timer_info` corresponds to a hooked function event. Checking for `function_id`
   // not being invalid is not sufficient, as e.g. frametrack events may also have non-invalid
   // function_id
-  if (timer_info.function_id() != orbit_grpc_protos::kInvalidFunctionId &&
-      timer_info.type() == orbit_client_protos::TimerInfo::kNone) {
+  if (scope_type == ScopeType::kHookedFunction) {
     return FunctionIdToScopeId(timer_info.function_id());
   }
 
   // TODO (b/226565085) remove the flag check when the manual instrumentation grouping feature is
   // released.
-  if (absl::GetFlag(FLAGS_devmode) &&
-      (timer_info.type() == orbit_client_protos::TimerInfo_Type_kApiScope ||
-       timer_info.type() == orbit_client_protos::TimerInfo_Type_kApiScopeAsync)) {
-    const auto key = std::make_pair(timer_info.type(), timer_info.api_scope_name());
+  if (!absl::GetFlag(FLAGS_devmode)) return kInvalidScopeId;
 
-    const auto it = name_to_id_.find(key);
-    if (it != name_to_id_.end()) {
-      return it->second;
-    }
+  const ScopeInfo scope_info{timer_info.api_scope_name(), scope_type};
 
-    uint64_t id = next_id_;
-    name_to_id_[key] = id;
-    scope_id_to_name_[id] = timer_info.api_scope_name();
-    next_id_++;
-    return id;
+  const auto it = scope_info_to_id_.find(scope_info);
+  if (it != scope_info_to_id_.end()) {
+    return it->second;
   }
-  return orbit_client_data::kInvalidScopeId;
+
+  uint64_t id = next_id_;
+  scope_info_to_id_[scope_info] = id;
+  scope_id_to_info_[id] = scope_info;
+  next_id_++;
+  return id;
 }
 
 [[nodiscard]] std::vector<uint64_t> NameEqualityScopeIdProvider::GetAllProvidedScopeIds() const {
   std::vector<uint64_t> ids;
-  std::transform(std::begin(scope_id_to_name_), std::end(scope_id_to_name_),
+  std::transform(std::begin(scope_id_to_info_), std::end(scope_id_to_info_),
                  std::back_inserter(ids), [](const auto& entry) { return entry.first; });
   return ids;
 }
 
-const std::string& NameEqualityScopeIdProvider::GetScopeName(uint64_t scope_id) const {
-  const auto it = scope_id_to_name_.find(scope_id);
-  ORBIT_CHECK(it != scope_id_to_name_.end());
+const ScopeInfo& NameEqualityScopeIdProvider::GetScopeInfo(uint64_t scope_id) const {
+  const auto it = scope_id_to_info_.find(scope_id);
+  ORBIT_CHECK(it != scope_id_to_info_.end());
   return it->second;
 }
 

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -34,9 +34,9 @@ std::unique_ptr<NameEqualityScopeIdProvider> NameEqualityScopeIdProvider::Create
 
   absl::flat_hash_map<uint64_t, const ScopeInfo> scope_id_to_info;
   for (const auto& instrumented_function : instrumented_functions) {
-    scope_id_to_info.insert(
-        {instrumented_function.function_id(),
-         {instrumented_function.function_name(), ScopeType::kDynamicallyInstrumentedFunction}});
+    scope_id_to_info.try_emplace(instrumented_function.function_id(),
+                                 instrumented_function.function_name(),
+                                 ScopeType::kDynamicallyInstrumentedFunction);
   }
 
   return std::unique_ptr<NameEqualityScopeIdProvider>(
@@ -85,8 +85,8 @@ uint64_t NameEqualityScopeIdProvider::ProvideId(const TimerInfo& timer_info) {
   }
 
   uint64_t id = next_id_;
-  scope_info_to_id_[scope_info] = id;
-  scope_id_to_info_.insert({id, scope_info});
+  scope_info_to_id_.emplace(scope_info, id);
+  scope_id_to_info_.emplace(id, scope_info);
   next_id_++;
   return id;
 }

--- a/src/ClientData/ScopeIdProviderTest.cpp
+++ b/src/ClientData/ScopeIdProviderTest.cpp
@@ -71,7 +71,7 @@ static void TestProvideId(std::vector<orbit_client_protos::TimerInfo>& timer_inf
   const std::vector<uint64_t> ids = GetIds(id_provider.get(), timer_infos);
   AssertNameToIdIsBijective(timer_infos, ids);
   for (size_t i = 0; i < timer_infos.size(); ++i) {
-    EXPECT_EQ(id_provider->GetScopeInfo(ids[i]).name, timer_infos[i].api_scope_name());
+    EXPECT_EQ(id_provider->GetScopeInfo(ids[i]).GetName(), timer_infos[i].api_scope_name());
   }
 }
 

--- a/src/ClientData/ScopeIdProviderTest.cpp
+++ b/src/ClientData/ScopeIdProviderTest.cpp
@@ -133,7 +133,7 @@ TEST(NameEqualityScopeIdProviderTest, CreateIsCorrect) {
             *std::max_element(std::begin(kFunctionIds), std::end(kFunctionIds)) + 1);
 
   for (size_t i = 0; i < kFunctionCount; ++i) {
-    const ScopeInfo expected{kFunctionNames[i], ScopeType::kHookedFunction};
+    const ScopeInfo expected{kFunctionNames[i], ScopeType::kDynamicallyInstrumentedFunction};
     EXPECT_EQ(id_provider->GetScopeInfo(kFunctionIds[i]), expected);
   }
 }

--- a/src/ClientData/ScopeIdProviderTest.cpp
+++ b/src/ClientData/ScopeIdProviderTest.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "ClientData/ScopeIdProvider.h"
+#include "ClientData/ScopeInfo.h"
 #include "ClientFlags/ClientFlags.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/Constants.h"
@@ -70,7 +71,7 @@ static void TestProvideId(std::vector<orbit_client_protos::TimerInfo>& timer_inf
   const std::vector<uint64_t> ids = GetIds(id_provider.get(), timer_infos);
   AssertNameToIdIsBijective(timer_infos, ids);
   for (size_t i = 0; i < timer_infos.size(); ++i) {
-    EXPECT_EQ(id_provider->GetScopeName(ids[i]), timer_infos[i].api_scope_name());
+    EXPECT_EQ(id_provider->GetScopeInfo(ids[i]).name, timer_infos[i].api_scope_name());
   }
 }
 
@@ -126,13 +127,14 @@ TEST(NameEqualityScopeIdProviderTest, CreateIsCorrect) {
   }
 
   auto id_provider = NameEqualityScopeIdProvider::Create(capture_options);
-  TimerInfo timer_info = MakeTimerInfo("A", orbit_client_protos::TimerInfo_Type_kApiScope);
+  TimerInfo timer_info = MakeTimerInfo("A", TimerInfo::kApiScope);
 
   ASSERT_EQ(id_provider->ProvideId(timer_info),
             *std::max_element(std::begin(kFunctionIds), std::end(kFunctionIds)) + 1);
 
   for (size_t i = 0; i < kFunctionCount; ++i) {
-    EXPECT_EQ(id_provider->GetScopeName(kFunctionIds[i]), kFunctionNames[i]);
+    const ScopeInfo expected{kFunctionNames[i], ScopeType::kHookedFunction};
+    EXPECT_EQ(id_provider->GetScopeInfo(kFunctionIds[i]), expected);
   }
 }
 

--- a/src/ClientData/ScopeInfoTest.cpp
+++ b/src/ClientData/ScopeInfoTest.cpp
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/hash/hash_testing.h>
 #include <gtest/gtest.h>
 
 #include "ClientData/ScopeInfo.h"
-#include "absl/hash/hash_testing.h"
 
 namespace orbit_client_data {
 TEST(ScopeInfo, Hash) {

--- a/src/ClientData/ScopeInfoTest.cpp
+++ b/src/ClientData/ScopeInfoTest.cpp
@@ -10,7 +10,7 @@
 namespace orbit_client_data {
 TEST(ScopeInfo, Hash) {
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
-      {ScopeInfo{}, ScopeInfo{"", ScopeType::kInvalid},
+      {ScopeInfo{"", ScopeType::kInvalid},
        ScopeInfo{"", ScopeType::kDynamicallyInstrumentedFunction},
        ScopeInfo{"", ScopeType::kApiScope}, ScopeInfo{"kapiscope", ScopeType::kApiScope},
        ScopeInfo{"kapiscope", ScopeType::kApiScopeAsync},

--- a/src/ClientData/ScopeInfoTest.cpp
+++ b/src/ClientData/ScopeInfoTest.cpp
@@ -10,10 +10,11 @@
 namespace orbit_client_data {
 TEST(ScopeInfo, Hash) {
   EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
-      {ScopeInfo{}, ScopeInfo{"", ScopeType::kOther}, ScopeInfo{"", ScopeType::kHookedFunction},
+      {ScopeInfo{}, ScopeInfo{"", ScopeType::kInvalid},
+       ScopeInfo{"", ScopeType::kDynamicallyInstrumentedFunction},
        ScopeInfo{"", ScopeType::kApiScope}, ScopeInfo{"kapiscope", ScopeType::kApiScope},
        ScopeInfo{"kapiscope", ScopeType::kApiScopeAsync},
        ScopeInfo{"kApiScope", ScopeType::kApiScope},
-       ScopeInfo{"kApiScope", ScopeType::kHookedFunction}}));
+       ScopeInfo{"kApiScope", ScopeType::kDynamicallyInstrumentedFunction}}));
 }
 }  // namespace orbit_client_data

--- a/src/ClientData/ScopeInfoTest.cpp
+++ b/src/ClientData/ScopeInfoTest.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "ClientData/ScopeInfo.h"
+#include "absl/hash/hash_testing.h"
+
+namespace orbit_client_data {
+TEST(ScopeInfo, Hash) {
+  EXPECT_TRUE(
+      absl::VerifyTypeImplementsAbslHashCorrectly({ScopeInfo{},
+                                                   {"", ScopeType::kOther},
+                                                   {"", ScopeType::kHookedFunction},
+                                                   {"", ScopeType::kApiScope},
+                                                   {"kapiscope", ScopeType::kApiScope},
+                                                   {"kapiscope", ScopeType::kApiScopeAsync},
+                                                   {"kApiScope", ScopeType::kApiScope},
+                                                   {"kApiScope", ScopeType::kHookedFunction}}));
+}
+}  // namespace orbit_client_data

--- a/src/ClientData/ScopeInfoTest.cpp
+++ b/src/ClientData/ScopeInfoTest.cpp
@@ -9,14 +9,11 @@
 
 namespace orbit_client_data {
 TEST(ScopeInfo, Hash) {
-  EXPECT_TRUE(
-      absl::VerifyTypeImplementsAbslHashCorrectly({ScopeInfo{},
-                                                   {"", ScopeType::kOther},
-                                                   {"", ScopeType::kHookedFunction},
-                                                   {"", ScopeType::kApiScope},
-                                                   {"kapiscope", ScopeType::kApiScope},
-                                                   {"kapiscope", ScopeType::kApiScopeAsync},
-                                                   {"kApiScope", ScopeType::kApiScope},
-                                                   {"kApiScope", ScopeType::kHookedFunction}}));
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      {ScopeInfo{}, ScopeInfo{"", ScopeType::kOther}, ScopeInfo{"", ScopeType::kHookedFunction},
+       ScopeInfo{"", ScopeType::kApiScope}, ScopeInfo{"kapiscope", ScopeType::kApiScope},
+       ScopeInfo{"kapiscope", ScopeType::kApiScopeAsync},
+       ScopeInfo{"kApiScope", ScopeType::kApiScope},
+       ScopeInfo{"kApiScope", ScopeType::kHookedFunction}}));
 }
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -238,7 +238,7 @@ class CaptureData {
 
   [[nodiscard]] uint64_t ProvideScopeId(const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::vector<uint64_t> GetAllProvidedScopeIds() const;
-  [[nodiscard]] const std::string& GetScopeName(uint64_t scope_id) const;
+  [[nodiscard]] const ScopeInfo& GetScopeInfo(uint64_t scope_id) const;
   [[nodiscard]] uint64_t FunctionIdToScopeId(uint64_t function_id) const;
 
   [[nodiscard]] const std::vector<uint64_t>* GetSortedTimerDurationsForScopeId(

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 
+#include "ClientData/ScopeInfo.h"
 #include "ClientData/TimerTrackDataIdManager.h"
 #include "GrpcProtos/capture.pb.h"
 
@@ -28,7 +29,7 @@ class ScopeIdProvider {
 
   [[nodiscard]] virtual std::vector<uint64_t> GetAllProvidedScopeIds() const = 0;
 
-  [[nodiscard]] virtual const std::string& GetScopeName(uint64_t scope_id) const = 0;
+  [[nodiscard]] virtual const ScopeInfo& GetScopeInfo(uint64_t scope_id) const = 0;
 };
 
 // This class, unless the timer does already have an id (`function_id`), it assigning an id for
@@ -48,18 +49,17 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
 
   [[nodiscard]] std::vector<uint64_t> GetAllProvidedScopeIds() const override;
 
-  [[nodiscard]] const std::string& GetScopeName(uint64_t scope_id) const override;
+  [[nodiscard]] const ScopeInfo& GetScopeInfo(uint64_t scope_id) const override;
 
  private:
   explicit NameEqualityScopeIdProvider(uint64_t start_id,
-                                       absl::flat_hash_map<uint64_t, std::string> scope_id_to_name)
-      : next_id_(start_id), scope_id_to_name_(std::move(scope_id_to_name)) {}
+                                       absl::flat_hash_map<uint64_t, ScopeInfo> scope_id_to_info)
+      : next_id_(start_id), scope_id_to_info_(std::move(scope_id_to_info)) {}
 
-  absl::flat_hash_map<std::pair<orbit_client_protos::TimerInfo_Type, std::string>, uint64_t>
-      name_to_id_;
+  absl::flat_hash_map<ScopeInfo, uint64_t> scope_info_to_id_;
   uint64_t next_id_{};
 
-  absl::flat_hash_map<uint64_t, std::string> scope_id_to_name_;
+  absl::flat_hash_map<uint64_t, ScopeInfo> scope_id_to_info_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -52,14 +52,14 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   [[nodiscard]] const ScopeInfo& GetScopeInfo(uint64_t scope_id) const override;
 
  private:
-  explicit NameEqualityScopeIdProvider(uint64_t start_id,
-                                       absl::flat_hash_map<uint64_t, ScopeInfo> scope_id_to_info)
+  explicit NameEqualityScopeIdProvider(
+      uint64_t start_id, absl::flat_hash_map<uint64_t, const ScopeInfo> scope_id_to_info)
       : next_id_(start_id), scope_id_to_info_(std::move(scope_id_to_info)) {}
 
   absl::flat_hash_map<ScopeInfo, uint64_t> scope_info_to_id_;
   uint64_t next_id_{};
 
-  absl::flat_hash_map<uint64_t, ScopeInfo> scope_id_to_info_;
+  absl::flat_hash_map<uint64_t, const ScopeInfo> scope_id_to_info_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ScopeInfo.h
+++ b/src/ClientData/include/ClientData/ScopeInfo.h
@@ -9,10 +9,18 @@
 
 namespace orbit_client_data {
 
-enum ScopeType : uint8_t { kOther = 0, kHookedFunction = 1, kApiScope = 2, kApiScopeAsync = 3 };
+enum class ScopeType {
+  kInvalid = 0,
+  kDynamicallyInstrumentedFunction = 1,
+  kApiScope = 2,
+  kApiScopeAsync = 3
+};
 
 // An instance of the type uniquely identifies a scope by its name and type. The type is hashable
 // and implements `==` and `!=` operators.
+//
+// DO NOT ADD FIELDS TO THE STRUCT. Especially, if they don't make sense for all the `ScopeType`s.
+// If you really have to, consider using std::variant or inheritance and removing ScopeType.
 struct ScopeInfo {
   template <typename H>
   friend H AbslHashValue(H h, const ScopeInfo& scope) {

--- a/src/ClientData/include/ClientData/ScopeInfo.h
+++ b/src/ClientData/include/ClientData/ScopeInfo.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CLIENT_DATA_SCOPE_INFO_H_
+#define ORBIT_CLIENT_DATA_SCOPE_INFO_H_
+#include <string>
+
+namespace orbit_client_data {
+
+enum ScopeType : uint8_t { kOther = 0, kHookedFunction = 1, kApiScope = 2, kApiScopeAsync = 3 };
+
+struct ScopeInfo {
+  template <typename H>
+  friend H AbslHashValue(H h, const ScopeInfo& c) {
+    return H::combine(std::move(h), c.name, c.type);
+  }
+
+  friend bool operator==(const ScopeInfo& lhs, const ScopeInfo& rhs) {
+    return lhs.type == rhs.type && lhs.name == rhs.name;
+  }
+
+  std::string name;
+  ScopeType type{};
+};
+
+}  // namespace orbit_client_data
+
+#endif  // ORBIT_CLIENT_DATA_SCOPE_INFO_H_

--- a/src/ClientData/include/ClientData/ScopeInfo.h
+++ b/src/ClientData/include/ClientData/ScopeInfo.h
@@ -13,8 +13,8 @@ enum ScopeType : uint8_t { kOther = 0, kHookedFunction = 1, kApiScope = 2, kApiS
 
 struct ScopeInfo {
   template <typename H>
-  friend H AbslHashValue(H h, const ScopeInfo& c) {
-    return H::combine(std::move(h), c.name, c.type);
+  friend H AbslHashValue(H h, const ScopeInfo& scope) {
+    return H::combine(std::move(h), scope.name, scope.type);
   }
 
   friend bool operator==(const ScopeInfo& lhs, const ScopeInfo& rhs) {

--- a/src/ClientData/include/ClientData/ScopeInfo.h
+++ b/src/ClientData/include/ClientData/ScopeInfo.h
@@ -19,22 +19,29 @@ enum class ScopeType {
 // An instance of the type uniquely identifies a scope by its name and type. The type is hashable
 // and implements `==` and `!=` operators.
 //
-// DO NOT ADD FIELDS TO THE STRUCT. Especially, if they don't make sense for all the `ScopeType`s.
+// DO NOT ADD FIELDS TO THE CLASS. Especially, if they don't make sense for all the `ScopeType`s.
 // If you really have to, consider using std::variant or inheritance and removing ScopeType.
-struct ScopeInfo {
+class ScopeInfo {
+ public:
+  ScopeInfo(std::string name, ScopeType type) : name_(std::move(name)), type_(type) {}
+
+  [[nodiscard]] const std::string& GetName() const { return name_; }
+  [[nodiscard]] ScopeType GetType() const { return type_; }
+
   template <typename H>
   friend H AbslHashValue(H h, const ScopeInfo& scope) {
-    return H::combine(std::move(h), scope.name, scope.type);
+    return H::combine(std::move(h), scope.GetName(), scope.GetType());
   }
 
   friend bool operator==(const ScopeInfo& lhs, const ScopeInfo& rhs) {
-    return lhs.type == rhs.type && lhs.name == rhs.name;
+    return lhs.GetType() == rhs.GetType() && lhs.GetName() == rhs.GetName();
   }
 
   friend bool operator!=(const ScopeInfo& lhs, const ScopeInfo& rhs) { return !(lhs == rhs); }
 
-  std::string name;
-  ScopeType type{};
+ private:
+  std::string name_;
+  ScopeType type_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ScopeInfo.h
+++ b/src/ClientData/include/ClientData/ScopeInfo.h
@@ -4,6 +4,7 @@
 
 #ifndef ORBIT_CLIENT_DATA_SCOPE_INFO_H_
 #define ORBIT_CLIENT_DATA_SCOPE_INFO_H_
+
 #include <string>
 
 namespace orbit_client_data {

--- a/src/ClientData/include/ClientData/ScopeInfo.h
+++ b/src/ClientData/include/ClientData/ScopeInfo.h
@@ -11,6 +11,8 @@ namespace orbit_client_data {
 
 enum ScopeType : uint8_t { kOther = 0, kHookedFunction = 1, kApiScope = 2, kApiScopeAsync = 3 };
 
+// An instance of the type uniquely identifies a scope by its name and type. The type is hashable
+// and implements `==` and `!=` operators.
 struct ScopeInfo {
   template <typename H>
   friend H AbslHashValue(H h, const ScopeInfo& scope) {
@@ -20,6 +22,8 @@ struct ScopeInfo {
   friend bool operator==(const ScopeInfo& lhs, const ScopeInfo& rhs) {
     return lhs.type == rhs.type && lhs.name == rhs.name;
   }
+
+  friend bool operator!=(const ScopeInfo& lhs, const ScopeInfo& rhs) { return !(lhs == rhs); }
 
   std::string name;
   ScopeType type{};

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -288,7 +288,7 @@ TEST_F(CallstackDataViewTest, ColumnSelectedShowsRightResults) {
     EXPECT_EQ(view_.GetValue(0, kColumnSelected), "");
 
     function_selected = true;
-    EXPECT_EQ(view_.GetValue(0, kColumnSelected), "✓");
+    EXPECT_EQ(view_.GetValue(0, kColumnSelected), "H");
   }
 }
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -217,7 +217,7 @@ void FunctionsDataView::DoFilter() {
   orbit_base::TaskGroup task_group;
 
   for (size_t i = 0; i < chunks.size(); ++i) {
-    task_group.AddTask([&chunk = chunks[i], &result = task_results[i], this]() {
+    task_group.AddTask([& chunk = chunks[i], &result = task_results[i], this]() {
       ORBIT_SCOPE("FunctionsDataView::DoFilter Task");
       for (const FunctionInfo*& function : chunk) {
         ORBIT_CHECK(function != nullptr);

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -40,7 +40,7 @@ const std::string FunctionsDataView::kSelectedFunctionString = "H";
 const std::string FunctionsDataView::kFrameTrackString = "F";
 const std::string FunctionsDataView::kApiScopeTypeSting = "MS";
 const std::string FunctionsDataView::kApiScopeAsyncTypeString = "MA";
-const std::string FunctionsDataView::kHookedFunctionTypeString = "D";
+const std::string FunctionsDataView::kDynamicallyInstrumentedFunctionTypeString = "D";
 
 const std::vector<DataView::Column>& FunctionsDataView::GetColumns() {
   static const std::vector<Column> columns = [] {

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -38,9 +38,9 @@ FunctionsDataView::FunctionsDataView(AppInterface* app,
 const std::string FunctionsDataView::kUnselectedFunctionString = "";
 const std::string FunctionsDataView::kSelectedFunctionString = "H";
 const std::string FunctionsDataView::kFrameTrackString = "F";
-const std::string FunctionsDataView::kApiScopeType = "MS";
-const std::string FunctionsDataView::kApiScopeAsyncType = "MA";
-const std::string FunctionsDataView::kHookedFunctionType = "D";
+const std::string FunctionsDataView::kApiScopeTypeSting = "MS";
+const std::string FunctionsDataView::kApiScopeAsyncTypeString = "MA";
+const std::string FunctionsDataView::kHookedFunctionTypeString = "D";
 
 const std::vector<DataView::Column>& FunctionsDataView::GetColumns() {
   static const std::vector<Column> columns = [] {
@@ -79,8 +79,8 @@ bool FunctionsDataView::ShouldShowFrameTrackIcon(AppInterface* app, const Functi
          app->HasFrameTrackInCaptureData(instrumented_function_id.value());
 }
 
-std::string FunctionsDataView::BuildSelectedAndFrametrackIconsString(AppInterface* app,
-                                                                     const FunctionInfo& function) {
+std::string FunctionsDataView::BuildSelectedAndFrameTrackString(AppInterface* app,
+                                                                const FunctionInfo& function) {
   std::string result = kUnselectedFunctionString;
   if (ShouldShowSelectedFunctionIcon(app, function)) {
     absl::StrAppend(&result, kSelectedFunctionString);
@@ -102,7 +102,7 @@ std::string FunctionsDataView::GetValue(int row, int column) {
 
   switch (column) {
     case kColumnSelected:
-      return BuildSelectedAndFrametrackIconsString(app_, function);
+      return BuildSelectedAndFrameTrackString(app_, function);
     case kColumnName:
       return function.pretty_name();
     case kColumnSize:
@@ -217,7 +217,7 @@ void FunctionsDataView::DoFilter() {
   orbit_base::TaskGroup task_group;
 
   for (size_t i = 0; i < chunks.size(); ++i) {
-    task_group.AddTask([& chunk = chunks[i], &result = task_results[i], this]() {
+    task_group.AddTask([&chunk = chunks[i], &result = task_results[i], this]() {
       ORBIT_SCOPE("FunctionsDataView::DoFilter Task");
       for (const FunctionInfo*& function : chunk) {
         ORBIT_CHECK(function != nullptr);

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -36,8 +36,11 @@ FunctionsDataView::FunctionsDataView(AppInterface* app,
     : DataView(DataViewType::kFunctions, app, metrics_uploader) {}
 
 const std::string FunctionsDataView::kUnselectedFunctionString = "";
-const std::string FunctionsDataView::kSelectedFunctionString = "✓";
+const std::string FunctionsDataView::kSelectedFunctionString = "H";
 const std::string FunctionsDataView::kFrameTrackString = "F";
+const std::string FunctionsDataView::kApiScopeType = "MS";
+const std::string FunctionsDataView::kApiScopeAsyncType = "MA";
+const std::string FunctionsDataView::kHookedFunctionType = "D";
 
 const std::vector<DataView::Column>& FunctionsDataView::GetColumns() {
   static const std::vector<Column> columns = [] {
@@ -76,8 +79,8 @@ bool FunctionsDataView::ShouldShowFrameTrackIcon(AppInterface* app, const Functi
          app->HasFrameTrackInCaptureData(instrumented_function_id.value());
 }
 
-std::string FunctionsDataView::BuildSelectedColumnsString(AppInterface* app,
-                                                          const FunctionInfo& function) {
+std::string FunctionsDataView::BuildTypeColumnsString(AppInterface* app,
+                                                      const FunctionInfo& function) {
   std::string result = kUnselectedFunctionString;
   if (ShouldShowSelectedFunctionIcon(app, function)) {
     absl::StrAppend(&result, kSelectedFunctionString);
@@ -99,7 +102,7 @@ std::string FunctionsDataView::GetValue(int row, int column) {
 
   switch (column) {
     case kColumnSelected:
-      return BuildSelectedColumnsString(app_, function);
+      return BuildTypeColumnsString(app_, function);
     case kColumnName:
       return function.pretty_name();
     case kColumnSize:
@@ -214,7 +217,7 @@ void FunctionsDataView::DoFilter() {
   orbit_base::TaskGroup task_group;
 
   for (size_t i = 0; i < chunks.size(); ++i) {
-    task_group.AddTask([& chunk = chunks[i], &result = task_results[i], this]() {
+    task_group.AddTask([&chunk = chunks[i], &result = task_results[i], this]() {
       ORBIT_SCOPE("FunctionsDataView::DoFilter Task");
       for (const FunctionInfo*& function : chunk) {
         ORBIT_CHECK(function != nullptr);

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -38,7 +38,7 @@ FunctionsDataView::FunctionsDataView(AppInterface* app,
 const std::string FunctionsDataView::kUnselectedFunctionString = "";
 const std::string FunctionsDataView::kSelectedFunctionString = "H";
 const std::string FunctionsDataView::kFrameTrackString = "F";
-const std::string FunctionsDataView::kApiScopeTypeSting = "MS";
+const std::string FunctionsDataView::kApiScopeTypeString = "MS";
 const std::string FunctionsDataView::kApiScopeAsyncTypeString = "MA";
 const std::string FunctionsDataView::kDynamicallyInstrumentedFunctionTypeString = "D";
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -79,8 +79,8 @@ bool FunctionsDataView::ShouldShowFrameTrackIcon(AppInterface* app, const Functi
          app->HasFrameTrackInCaptureData(instrumented_function_id.value());
 }
 
-std::string FunctionsDataView::BuildTypeColumnsString(AppInterface* app,
-                                                      const FunctionInfo& function) {
+std::string FunctionsDataView::BuildSelectedAndFrametrackIconsString(AppInterface* app,
+                                                                     const FunctionInfo& function) {
   std::string result = kUnselectedFunctionString;
   if (ShouldShowSelectedFunctionIcon(app, function)) {
     absl::StrAppend(&result, kSelectedFunctionString);
@@ -102,7 +102,7 @@ std::string FunctionsDataView::GetValue(int row, int column) {
 
   switch (column) {
     case kColumnSelected:
-      return BuildTypeColumnsString(app_, function);
+      return BuildSelectedAndFrametrackIconsString(app_, function);
     case kColumnName:
       return function.pretty_name();
     case kColumnSize:

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -173,6 +173,8 @@ TEST_F(FunctionsDataViewTest, ClearFunctionsRemovesAllElements) {
   ASSERT_EQ(view_.GetNumElements(), 0);
 }
 
+const std::string kSelectedFunctionIcon = "H";
+
 TEST_F(FunctionsDataViewTest, FunctionSelectionAppearsInFirstColumn) {
   bool function_selected = false;
   bool frame_track_enabled = false;
@@ -194,19 +196,19 @@ TEST_F(FunctionsDataViewTest, FunctionSelectionAppearsInFirstColumn) {
 
   function_selected = false;
   frame_track_enabled = false;
-  EXPECT_THAT(view_.GetValue(0, 0), testing::Not(testing::StartsWith("✓")));
+  EXPECT_THAT(view_.GetValue(0, 0), testing::Not(testing::StartsWith(kSelectedFunctionIcon)));
 
   function_selected = true;
   frame_track_enabled = false;
-  EXPECT_THAT(view_.GetValue(0, 0), testing::StartsWith("✓"));
+  EXPECT_THAT(view_.GetValue(0, 0), testing::StartsWith(kSelectedFunctionIcon));
 
   function_selected = false;
   frame_track_enabled = false;
-  EXPECT_THAT(view_.GetValue(0, 0), testing::Not(testing::StartsWith("✓")));
+  EXPECT_THAT(view_.GetValue(0, 0), testing::Not(testing::StartsWith(kSelectedFunctionIcon)));
 
   function_selected = true;
   frame_track_enabled = true;
-  EXPECT_THAT(view_.GetValue(0, 0), testing::StartsWith("✓"));
+  EXPECT_THAT(view_.GetValue(0, 0), testing::StartsWith(kSelectedFunctionIcon));
 }
 
 TEST_F(FunctionsDataViewTest, FrameTrackSelectionAppearsInFirstColumn) {

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -173,7 +173,7 @@ TEST_F(FunctionsDataViewTest, ClearFunctionsRemovesAllElements) {
   ASSERT_EQ(view_.GetNumElements(), 0);
 }
 
-const std::string kSelectedFunctionIcon = "H";
+const std::string kSelectedFunctionString = "H";
 
 TEST_F(FunctionsDataViewTest, FunctionSelectionAppearsInFirstColumn) {
   bool function_selected = false;
@@ -196,19 +196,19 @@ TEST_F(FunctionsDataViewTest, FunctionSelectionAppearsInFirstColumn) {
 
   function_selected = false;
   frame_track_enabled = false;
-  EXPECT_THAT(view_.GetValue(0, 0), testing::Not(testing::StartsWith(kSelectedFunctionIcon)));
+  EXPECT_THAT(view_.GetValue(0, 0), testing::Not(testing::StartsWith(kSelectedFunctionString)));
 
   function_selected = true;
   frame_track_enabled = false;
-  EXPECT_THAT(view_.GetValue(0, 0), testing::StartsWith(kSelectedFunctionIcon));
+  EXPECT_THAT(view_.GetValue(0, 0), testing::StartsWith(kSelectedFunctionString));
 
   function_selected = false;
   frame_track_enabled = false;
-  EXPECT_THAT(view_.GetValue(0, 0), testing::Not(testing::StartsWith(kSelectedFunctionIcon)));
+  EXPECT_THAT(view_.GetValue(0, 0), testing::Not(testing::StartsWith(kSelectedFunctionString)));
 
   function_selected = true;
   frame_track_enabled = true;
-  EXPECT_THAT(view_.GetValue(0, 0), testing::StartsWith(kSelectedFunctionIcon));
+  EXPECT_THAT(view_.GetValue(0, 0), testing::StartsWith(kSelectedFunctionString));
 }
 
 TEST_F(FunctionsDataViewTest, FrameTrackSelectionAppearsInFirstColumn) {

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -88,8 +88,7 @@ const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
   return columns;
 }
 
-[[nodiscard]] static std::string BuildTypeColumnsString(
-    const orbit_client_data::ScopeInfo& scope_info) {
+[[nodiscard]] static std::string BuildTypeString(const orbit_client_data::ScopeInfo& scope_info) {
   switch (scope_info.type) {
     case orbit_client_data::ScopeType::kApiScope:
       return "MS";
@@ -117,12 +116,13 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
   const FunctionInfo* function = GetFunctionInfoFromRow(row);
   switch (column) {
     case kColumnType: {
-      const std::string prefix =
+      const std::string state =
           function == nullptr
               ? ""
-              : FunctionsDataView::BuildSelectedAndFrametrackIconsString(app_, *function);
-
-      return absl::StrCat(prefix, prefix.empty() ? "" : " ", BuildTypeColumnsString(scope_info));
+              : FunctionsDataView::BuildSelectedAndFrameTrackString(app_, *function);
+      const std::string type_string = BuildTypeString(scope_info);
+      if (state.empty()) return type_string;
+      return absl::StrFormat("%s [%s]", type_string, state);
     }
     case kColumnName:
       return scope_info.name;

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -117,13 +117,13 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
   const FunctionInfo* function = GetFunctionInfoFromRow(row);
   switch (column) {
     case kColumnType: {
-      const std::string state =
+      const std::string state_string =
           function == nullptr
               ? ""
               : FunctionsDataView::BuildSelectedAndFrameTrackString(app_, *function);
       const std::string type_string = BuildTypePartOfTypeColumnString(scope_info);
-      if (state.empty()) return type_string;
-      return absl::StrFormat("%s [%s]", type_string, state);
+      if (state_string.empty()) return type_string;
+      return absl::StrFormat("%s [%s]", type_string, state_string);
     }
     case kColumnName:
       return scope_info.name;

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -88,7 +88,8 @@ const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
   return columns;
 }
 
-[[nodiscard]] static std::string BuildTypeString(const orbit_client_data::ScopeInfo& scope_info) {
+[[nodiscard]] static std::string BuildTypePartOfTypeColumnString(
+    const orbit_client_data::ScopeInfo& scope_info) {
   switch (scope_info.type) {
     case orbit_client_data::ScopeType::kApiScope:
       return FunctionsDataView::kApiScopeTypeSting;
@@ -120,7 +121,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
           function == nullptr
               ? ""
               : FunctionsDataView::BuildSelectedAndFrameTrackString(app_, *function);
-      const std::string type_string = BuildTypeString(scope_info);
+      const std::string type_string = BuildTypePartOfTypeColumnString(scope_info);
       if (state.empty()) return type_string;
       return absl::StrFormat("%s [%s]", type_string, state);
     }

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -91,11 +91,11 @@ const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
 [[nodiscard]] static std::string BuildTypeString(const orbit_client_data::ScopeInfo& scope_info) {
   switch (scope_info.type) {
     case orbit_client_data::ScopeType::kApiScope:
-      return "MS";
+      return FunctionsDataView::kApiScopeTypeSting;
     case orbit_client_data::ScopeType::kApiScopeAsync:
-      return "MA";
-    case orbit_client_data::ScopeType::kHookedFunction:
-      return "D";
+      return FunctionsDataView::kApiScopeAsyncTypeString;
+    case orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction:
+      return FunctionsDataView::kDynamicallyInstrumentedFunctionTypeString;
     default:
       return "";
   }
@@ -217,6 +217,8 @@ void LiveFunctionsDataView::DoSort() {
 
   switch (sorting_column_) {
     case kColumnType: {
+      // We order by type first, then whether the function is selected, then by whether a frame
+      // track is enabled
       sorter = MakeSorter(
           [this](uint64_t id) -> std::tuple<orbit_client_data::ScopeType, bool, bool> {
             bool is_selected = false;
@@ -596,11 +598,11 @@ std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrum
 std::string LiveFunctionsDataView::GetToolTip(int /*row*/, int column) {
   if (column != kColumnType) return "";
   return "Notation:\n"
-         "H — The function will be hooked on the next capture\n"
-         "F — Frametrack enabled\n"
          "D — Dynamically instrumented function\n"
          "MS — Synchronous manually instrumented scope\n"
-         "MA — Asynchronous manually instrumented scope";
+         "MA — Asynchronous manually instrumented scope\n"
+         "H — The function will be hooked on the next capture\n"
+         "F — Frame track enabled";
 }
 
 }  // namespace orbit_data_views

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -92,7 +92,7 @@ const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
     const orbit_client_data::ScopeInfo& scope_info) {
   switch (scope_info.GetType()) {
     case orbit_client_data::ScopeType::kApiScope:
-      return FunctionsDataView::kApiScopeTypeSting;
+      return FunctionsDataView::kApiScopeTypeString;
     case orbit_client_data::ScopeType::kApiScopeAsync:
       return FunctionsDataView::kApiScopeAsyncTypeString;
     case orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction:
@@ -218,7 +218,7 @@ void LiveFunctionsDataView::DoSort() {
 
   switch (sorting_column_) {
     case kColumnType: {
-      // We order by type first, then whether the function is selected, then by whether a frame
+      // We order by type first, then by whether the function is selected, then by whether a frame
       // track is enabled
       sorter = MakeSorter(
           [this](uint64_t id) -> std::tuple<orbit_client_data::ScopeType, bool, bool> {
@@ -603,7 +603,7 @@ std::string LiveFunctionsDataView::GetToolTip(int /*row*/, int column) {
          "D — Dynamically instrumented function\n"
          "MS — Synchronous manually instrumented scope\n"
          "MA — Asynchronous manually instrumented scope\n"
-         "H — The function will be hooked on the next capture\n"
+         "H — The function will be hooked in the next capture\n"
          "F — Frame track enabled";
 }
 

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -285,6 +286,9 @@ TEST_F(LiveFunctionsDataViewTest, ColumnValuesAreCorrect) {
   EXPECT_EQ(view_.GetValue(0, kColumnStdDev), GetExpectedDisplayTime(kStdDevNs[0]));
 }
 
+const std::string kSelectedFunctionIcon = "H";
+const std::string kDynamicallyInstumentedFunctionIcon = "D";
+
 TEST_F(LiveFunctionsDataViewTest, ColumnSelectedShowsRightResults) {
   bool function_selected = false;
   bool frame_track_enabled = false;
@@ -300,17 +304,20 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSelectedShowsRightResults) {
       .WillRepeatedly(testing::ReturnPointee(&frame_track_enabled));
 
   AddFunctionsByIndices({0});
-  EXPECT_EQ(view_.GetValue(0, kColumnSelected), "");
+  EXPECT_EQ(view_.GetValue(0, kColumnSelected), "D");
 
   function_selected = true;
-  EXPECT_EQ(view_.GetValue(0, kColumnSelected), "✓");
+  EXPECT_EQ(view_.GetValue(0, kColumnSelected),
+            absl::StrCat(kSelectedFunctionIcon, " ", kDynamicallyInstumentedFunctionIcon));
 
   function_selected = false;
   frame_track_enabled = true;
-  EXPECT_EQ(view_.GetValue(0, kColumnSelected), "F");
+  EXPECT_EQ(view_.GetValue(0, kColumnSelected),
+            absl::StrCat("F ", kDynamicallyInstumentedFunctionIcon));
 
   function_selected = true;
-  EXPECT_EQ(view_.GetValue(0, kColumnSelected), "✓ F");
+  EXPECT_EQ(view_.GetValue(0, kColumnSelected),
+            absl::StrCat(kSelectedFunctionIcon, " F ", kDynamicallyInstumentedFunctionIcon));
 }
 
 TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
@@ -442,9 +449,9 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
   // Copy Selection
   {
     std::string expected_clipboard = absl::StrFormat(
-        "Hooked\tFunction\tCount\tTotal\tAvg\tMin\tMax\tStd Dev\tModule\tAddress\n"
-        "\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-        kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
+        "Type\tFunction\tCount\tTotal\tAvg\tMin\tMax\tStd Dev\tModule\tAddress\n"
+        "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+        kDynamicallyInstumentedFunctionIcon, kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
         GetExpectedDisplayTime(kTotalTimeNs[0]), GetExpectedDisplayTime(kAvgTimeNs[0]),
         GetExpectedDisplayTime(kMinNs[0]), GetExpectedDisplayTime(kMaxNs[0]),
         GetExpectedDisplayTime(kStdDevNs[0]), kModulePaths[0],
@@ -455,11 +462,11 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
   // Export to CSV
   {
     std::string expected_contents = absl::StrFormat(
-        R"("Hooked","Function","Count","Total","Avg","Min","Max","Std Dev","Module","Address")"
+        R"("Type","Function","Count","Total","Avg","Min","Max","Std Dev","Module","Address")"
         "\r\n"
-        R"("","%s","%s","%s","%s","%s","%s","%s","%s","%s")"
+        R"("%s","%s","%s","%s","%s","%s","%s","%s","%s","%s")"
         "\r\n",
-        kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
+        kDynamicallyInstumentedFunctionIcon, kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
         GetExpectedDisplayTime(kTotalTimeNs[0]), GetExpectedDisplayTime(kAvgTimeNs[0]),
         GetExpectedDisplayTime(kMinNs[0]), GetExpectedDisplayTime(kMaxNs[0]),
         GetExpectedDisplayTime(kStdDevNs[0]), kModulePaths[0],

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -353,7 +353,7 @@ TEST_F(SamplingReportDataViewTest, ColumnSelectedShowsRightResults) {
   EXPECT_EQ(view_.GetValue(0, kColumnSelected), "");
 
   function_selected = true;
-  EXPECT_EQ(view_.GetValue(0, kColumnSelected), "✓");
+  EXPECT_EQ(view_.GetValue(0, kColumnSelected), "H");
 }
 
 TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -21,10 +21,10 @@ class FunctionsDataView : public DataView {
   static const std::string kUnselectedFunctionString;
   static const std::string kSelectedFunctionString;
   static const std::string kFrameTrackString;
-  static const std::string kApiScopeType;
-  static const std::string kApiScopeAsyncType;
-  static const std::string kHookedFunctionType;
-  static std::string BuildSelectedAndFrametrackIconsString(
+  static const std::string kApiScopeTypeSting;
+  static const std::string kApiScopeAsyncTypeString;
+  static const std::string kHookedFunctionTypeString;
+  static std::string BuildSelectedAndFrameTrackString(
       AppInterface* app, const orbit_client_data::FunctionInfo& function);
   static bool ShouldShowFrameTrackIcon(AppInterface* app,
                                        const orbit_client_data::FunctionInfo& function);

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -21,7 +21,7 @@ class FunctionsDataView : public DataView {
   static const std::string kUnselectedFunctionString;
   static const std::string kSelectedFunctionString;
   static const std::string kFrameTrackString;
-  static const std::string kApiScopeTypeSting;
+  static const std::string kApiScopeTypeString;
   static const std::string kApiScopeAsyncTypeString;
   static const std::string kDynamicallyInstrumentedFunctionTypeString;
   static std::string BuildSelectedAndFrameTrackString(

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -21,8 +21,13 @@ class FunctionsDataView : public DataView {
   static const std::string kUnselectedFunctionString;
   static const std::string kSelectedFunctionString;
   static const std::string kFrameTrackString;
-  static std::string BuildSelectedColumnsString(AppInterface* app,
-                                                const orbit_client_data::FunctionInfo& function);
+  static const std::string kApiScopeType;
+  static const std::string kApiScopeAsyncType;
+  static const std::string kHookedFunctionType;
+  static std::string BuildTypeColumnsString(AppInterface* app,
+                                            const orbit_client_data::FunctionInfo& function);
+  static bool ShouldShowFrameTrackIcon(AppInterface* app,
+                                       const orbit_client_data::FunctionInfo& function);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnAddressInModule; }
@@ -50,14 +55,12 @@ class FunctionsDataView : public DataView {
   };
 
  private:
+  static bool ShouldShowSelectedFunctionIcon(AppInterface* app,
+                                             const orbit_client_data::FunctionInfo& function);
   [[nodiscard]] const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int row) override {
     return functions_[indices_[row]];
   }
 
-  static bool ShouldShowSelectedFunctionIcon(AppInterface* app,
-                                             const orbit_client_data::FunctionInfo& function);
-  static bool ShouldShowFrameTrackIcon(AppInterface* app,
-                                       const orbit_client_data::FunctionInfo& function);
   std::vector<const orbit_client_data::FunctionInfo*> functions_;
 };
 

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -23,7 +23,7 @@ class FunctionsDataView : public DataView {
   static const std::string kFrameTrackString;
   static const std::string kApiScopeTypeSting;
   static const std::string kApiScopeAsyncTypeString;
-  static const std::string kHookedFunctionTypeString;
+  static const std::string kDynamicallyInstrumentedFunctionTypeString;
   static std::string BuildSelectedAndFrameTrackString(
       AppInterface* app, const orbit_client_data::FunctionInfo& function);
   static bool ShouldShowFrameTrackIcon(AppInterface* app,

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -24,8 +24,8 @@ class FunctionsDataView : public DataView {
   static const std::string kApiScopeType;
   static const std::string kApiScopeAsyncType;
   static const std::string kHookedFunctionType;
-  static std::string BuildTypeColumnsString(AppInterface* app,
-                                            const orbit_client_data::FunctionInfo& function);
+  static std::string BuildSelectedAndFrametrackIconsString(AppInterface* app,
+                                                  const orbit_client_data::FunctionInfo& function);
   static bool ShouldShowFrameTrackIcon(AppInterface* app,
                                        const orbit_client_data::FunctionInfo& function);
 

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -24,8 +24,8 @@ class FunctionsDataView : public DataView {
   static const std::string kApiScopeType;
   static const std::string kApiScopeAsyncType;
   static const std::string kHookedFunctionType;
-  static std::string BuildSelectedAndFrametrackIconsString(AppInterface* app,
-                                                  const orbit_client_data::FunctionInfo& function);
+  static std::string BuildSelectedAndFrametrackIconsString(
+      AppInterface* app, const orbit_client_data::FunctionInfo& function);
   static bool ShouldShowFrameTrackIcon(AppInterface* app,
                                        const orbit_client_data::FunctionInfo& function);
 

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -73,7 +73,7 @@ class LiveFunctionsDataView : public DataView {
   uint64_t selected_scope_id_;
 
   enum ColumnIndex {
-    kColumnSelected,
+    kColumnType,
     kColumnName,
     kColumnCount,
     kColumnTimeTotal,

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -54,6 +54,8 @@ class LiveFunctionsDataView : public DataView {
 
   void UpdateHistogramWithScopeIds(const std::vector<uint64_t>& scope_ids);
 
+  std::string GetToolTip(int /*row*/, int column) override;
+
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
                                              const std::vector<int>& selected_indices) override;
@@ -112,6 +114,8 @@ class LiveFunctionsDataView : public DataView {
         },
         ascending);
   }
+
+  [[nodiscard]] const orbit_client_data::ScopeInfo& GetScopeInfo(uint64_t scope_id) const;
 };
 
 }  // namespace orbit_data_views


### PR DESCRIPTION
Now we include manual instrumentation under Live tab,
so we have to also report the types of the entries.
This is done via reporting the abbreviations e. g.
MS means manual, synchronous.

As the tab now reports much more than hook-edness
(it already was showing whether frametrack is enabled,
but now we add types), its name is also changed.

Further, as the column is not called "Hooked" anymore,
the tick sing is not self-explanatory, so this also
replaces the tick with `H`.

Test: Manual, Unit, E2E
Bug: http://b/229218555