### PR TITLE
Create visual tests in the Timeline

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -221,6 +221,7 @@ target_sources(OrbitGlTests PRIVATE
                SliderTest.cpp
                ShortenStringWithEllipsisTest.cpp
                TimelineTicksTest.cpp
+               TimelineUiTest.cpp
                TimerInfosIteratorTest.cpp
                TranslationStackTest.cpp
                ThreadTrackTest.cpp

--- a/src/OrbitGl/MockTimelineInfo.h
+++ b/src/OrbitGl/MockTimelineInfo.h
@@ -25,7 +25,7 @@ class MockTimelineInfo : public TimelineInfoInterface {
     return GetWorldFromUs(GetUsFromTick(time));
   }
   [[nodiscard]] float GetWorldFromUs(double micros) const override {
-    return (micros - GetMinTimeUs()) * width_ / GetTimeWindowUs();
+    return static_cast<float>((micros - GetMinTimeUs()) * width_ / GetTimeWindowUs());
   }
   [[nodiscard]] uint64_t GetTickFromWorld(float world_x) const override {
     double ratio = world_x / width_;

--- a/src/OrbitGl/TimelineTicks.h
+++ b/src/OrbitGl/TimelineTicks.h
@@ -16,6 +16,8 @@ constexpr uint64_t kNanosecondsPerMicrosecond = 1000;
 constexpr uint64_t kNanosecondsPerSecond = 1000 * 1000 * 1000;
 constexpr uint64_t kNanosecondsPerMinute = 60 * kNanosecondsPerSecond;
 constexpr uint64_t kNanosecondsPerHour = 60 * kNanosecondsPerMinute;
+constexpr uint64_t kNanosecondsPerDay = 24 * kNanosecondsPerHour;
+constexpr uint64_t kNanosecondsPerMonth = 30 * kNanosecondsPerDay;
 
 // TimelineTicks class manages the logic about the ticks, scale and visible timestamps in the
 // timeline.

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -27,7 +27,8 @@ void TimelineUi::RenderLines(PrimitiveAssembler& primitive_assembler, uint64_t m
     int screen_x = viewport_->WorldToScreen(Vec2(world_x, 0))[0];
     primitive_assembler.AddVerticalLine(
         Vec2(screen_x, GetPos()[1]), GetHeightWithoutMargin(), GlCanvas::kZValueTimeBar,
-        tick_type == TimelineTicks::TickType::kMajorTick ? kMajorTickColor : kMinorTickColor);
+        tick_type == TimelineTicks::TickType::kMajorTick ? kTimelineMajorTickColor
+                                                         : kTimelineMinorTickColor);
   }
 }
 

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -20,9 +20,6 @@ const Color kBackgroundColorSpecialLabels(68, 67, 69, 255);
 
 void TimelineUi::RenderLines(PrimitiveAssembler& primitive_assembler, uint64_t min_timestamp_ns,
                              uint64_t max_timestamp_ns) const {
-  const Color kMajorTickColor(255, 254, 253, 255);
-  const Color kMinorTickColor(255, 254, 253, 63);
-
   for (auto& [tick_type, tick_ns] :
        timeline_ticks_.GetAllTicks(min_timestamp_ns, max_timestamp_ns)) {
     float world_x = timeline_info_interface_->GetWorldFromUs(
@@ -54,7 +51,7 @@ void TimelineUi::RenderLabels(PrimitiveAssembler& primitive_assembler, TextRende
 void TimelineUi::RenderMargin(PrimitiveAssembler& primitive_assembler) const {
   Vec2 margin_pos = Vec2(GetPos()[0], GetPos()[1] + GetHeightWithoutMargin());
   Vec2 margin_size = Vec2(GetSize()[0], GetMarginHeight());
-  primitive_assembler.AddBox(MakeBox(margin_pos, margin_size), GlCanvas::kZValueOverlay,
+  primitive_assembler.AddBox(MakeBox(margin_pos, margin_size), GlCanvas::kZValueTimeBar,
                              GlCanvas::kBackgroundColor);
 }
 

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -13,8 +13,8 @@ namespace orbit_gl {
 
 namespace {
 
-const Color kMajorTickColor(255, 254, 253, 255);
-const Color kMinorTickColor(255, 254, 253, 63);
+inline Color kTimelineMajorTickColor(255, 254, 253, 255);
+inline Color kTimelineMinorTickColor(255, 254, 253, 63);
 
 }  // namespace
 

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -11,12 +11,8 @@
 
 namespace orbit_gl {
 
-namespace {
-
 inline Color kTimelineMajorTickColor(255, 254, 253, 255);
 inline Color kTimelineMinorTickColor(255, 254, 253, 63);
-
-}  // namespace
 
 // TimelineUi is the class which takes care of drawing the timeline in the CaptureWindows.
 class TimelineUi : public CaptureViewElement {

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -11,6 +11,13 @@
 
 namespace orbit_gl {
 
+namespace {
+
+const Color kMajorTickColor(255, 254, 253, 255);
+const Color kMinorTickColor(255, 254, 253, 63);
+
+}  // namespace
+
 // TimelineUi is the class which takes care of drawing the timeline in the CaptureWindows.
 class TimelineUi : public CaptureViewElement {
  public:

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -11,8 +11,8 @@
 
 namespace orbit_gl {
 
-inline Color kTimelineMajorTickColor(255, 254, 253, 255);
-inline Color kTimelineMinorTickColor(255, 254, 253, 63);
+inline const Color kTimelineMajorTickColor(255, 254, 253, 255);
+inline const Color kTimelineMinorTickColor(255, 254, 253, 63);
 
 // TimelineUi is the class which takes care of drawing the timeline in the CaptureWindows.
 class TimelineUi : public CaptureViewElement {

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "GlCanvas.h"
+#include "MockBatcher.h"
+#include "MockTextRenderer.h"
+#include "MockTimelineInfo.h"
+#include "TimelineUi.h"
+#include "Viewport.h"
+
+namespace orbit_gl {
+
+class TimelineUiTest : public TimelineUi {
+ public:
+  TimelineUiTest(int width)
+      : TimelineUi(nullptr /*parent*/, &mock_timeline_info, &viewport_, &layout_),
+        primitive_assembler_(&mock_batcher_),
+        viewport_(width, 0) {
+    mock_timeline_info.SetWorldWidth(width);
+  }
+
+  void TestUpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool is_small_screen = false) {
+    mock_text_renderer_.Clear();
+    mock_batcher_.ResetElements();
+    mock_timeline_info.SetMinMax(min_tick, max_tick);
+
+    UpdatePrimitives(primitive_assembler_, mock_text_renderer_, min_tick, max_tick,
+                     PickingMode::kNone);
+
+    int num_labels = mock_text_renderer_.GetNumAddTextCalls();
+    int num_boxes = mock_batcher_.GetNumBoxes();
+    int num_major_ticks = mock_batcher_.GetNumLinesByColor(kMajorTickColor);
+    int num_minor_ticks = mock_batcher_.GetNumLinesByColor(kMinorTickColor);
+
+    // Lines should be only major and minor ticks.
+    EXPECT_EQ(mock_batcher_.GetNumLines(), num_major_ticks + num_minor_ticks);
+
+    // Major ticks should always be between 2 and 10, given scale set. In extremely small screens
+    // (Width < 160), we don't force a minimum number of major ticks.
+    if (!is_small_screen) EXPECT_GE(num_major_ticks, 2);
+    EXPECT_LE(num_major_ticks, 10);
+
+    // Depending on the scale, there should be 1 minor ticks or 4 between each major tick, which
+    // means that (calling MT to the number of major ticks, and mt to the number of minor ticks)
+    // mt is between (MT-1, MT+1) or mt is between (4x(MT-1), 4x(MT+1)).
+    EXPECT_GE(num_minor_ticks, num_major_ticks - 1);
+    EXPECT_LE(num_minor_ticks, 4 * (num_major_ticks + 1));
+    EXPECT_TRUE(num_minor_ticks <= num_major_ticks + 1 ||
+                num_minor_ticks >= 4 * (num_major_ticks - 1));
+
+    // Labels should all have the same number of numbers, start at the same vertical position and
+    // they will appear at the right of each major tick.
+    EXPECT_TRUE(mock_text_renderer_.HasAddTextsSameLength());
+    EXPECT_TRUE(mock_text_renderer_.AreAddTextsAlignedVertically());
+    EXPECT_GE(num_labels, num_major_ticks - 1);
+    EXPECT_LE(num_labels, num_major_ticks + 1);
+
+    // Boxes: One box per each label + Background box + margin box.
+    EXPECT_EQ(num_boxes, num_labels + 2);
+
+    // Everything should be between kZValueTimeBar and kZValueTimeBarMouseLabel.
+    EXPECT_TRUE(mock_text_renderer_.IsTextBetweenZLayers(GlCanvas::kZValueTimeBar,
+                                                         GlCanvas::kZValueTimeBarMouseLabel));
+    EXPECT_TRUE(mock_batcher_.IsEverythingBetweenZLayers(GlCanvas::kZValueTimeBar,
+                                                         GlCanvas::kZValueTimeBarMouseLabel));
+  }
+
+ private:
+  MockBatcher mock_batcher_;
+  MockTextRenderer mock_text_renderer_;
+  PrimitiveAssembler primitive_assembler_;
+  TimeGraphLayout layout_;
+  Viewport viewport_;
+  MockTimelineInfo mock_timeline_info;
+};
+
+TEST(TimelineUI, UpdatePrimitivesBigScreen) {
+  // TODO(b/218311326): In some cases, small screens and even medium screens (Width < 700) failed in
+  // the condition between #labels and #major_ticks, since we are drawing major_ticks anyways when
+  // labels intersect.
+  const int kBigScreenWidth = 2000;
+  TimelineUiTest timeline_ui_test(kBigScreenWidth);
+  timeline_ui_test.TestUpdatePrimitives(0, 100);
+  for (int i = 0; i < 100; i++) {
+    uint64_t timestamp_1 = rand();
+    uint64_t timestamp_2 = rand();
+    timeline_ui_test.TestUpdatePrimitives(std::min(timestamp_1, timestamp_2),
+                                          std::max(timestamp_1, timestamp_2));
+  }
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -40,7 +40,9 @@ class TimelineUiTest : public TimelineUi {
 
     // Major ticks should always be between 2 and 10, given scale set. In extremely small screens
     // (Width < 160), we don't force a minimum number of major ticks.
-    if (!is_small_screen) EXPECT_GE(num_major_ticks, 2);
+    if (!is_small_screen) {
+      EXPECT_GE(num_major_ticks, 2);
+    }
     EXPECT_LE(num_major_ticks, 10);
 
     // Depending on the scale, there should be 1 minor ticks or 4 between each major tick, which

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <random>
+
 #include "GlCanvas.h"
 #include "MockBatcher.h"
 #include "MockTextRenderer.h"
@@ -15,32 +17,39 @@ namespace orbit_gl {
 
 class TimelineUiTest : public TimelineUi {
  public:
-  TimelineUiTest(int width)
-      : TimelineUi(nullptr /*parent*/, &mock_timeline_info, &viewport_, &layout_),
+  inline static const int kBigScreenPixelsWidth = 2000;
+  inline static const int kSmallScreenMaxPixelsWidth = 700;
+  inline static const int kTinyScreenMaxPixelsWidth = 200;
+
+  explicit TimelineUiTest(int width, MockTimelineInfo* mock_timeline_info, Viewport* viewport,
+                          TimeGraphLayout* layout)
+      : TimelineUi(nullptr /*parent*/, mock_timeline_info, viewport, layout),
         primitive_assembler_(&mock_batcher_),
-        viewport_(width, 0) {
-    mock_timeline_info.SetWorldWidth(width);
+        viewport_(viewport),
+        mock_timeline_info_(mock_timeline_info) {
+    mock_timeline_info_->SetWorldWidth(width);
+    viewport_->SetWorldSize(width, TimelineUi::GetHeight());
   }
 
-  void TestUpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool is_small_screen = false) {
+  void TestUpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
     mock_text_renderer_.Clear();
     mock_batcher_.ResetElements();
-    mock_timeline_info.SetMinMax(min_tick, max_tick);
+    mock_timeline_info_->SetMinMax(min_tick, max_tick);
 
     UpdatePrimitives(primitive_assembler_, mock_text_renderer_, min_tick, max_tick,
                      PickingMode::kNone);
 
     int num_labels = mock_text_renderer_.GetNumAddTextCalls();
     int num_boxes = mock_batcher_.GetNumBoxes();
-    int num_major_ticks = mock_batcher_.GetNumLinesByColor(kMajorTickColor);
-    int num_minor_ticks = mock_batcher_.GetNumLinesByColor(kMinorTickColor);
+    int num_major_ticks = mock_batcher_.GetNumLinesByColor(kTimelineMajorTickColor);
+    int num_minor_ticks = mock_batcher_.GetNumLinesByColor(kTimelineMinorTickColor);
 
     // Lines should be only major and minor ticks.
     EXPECT_EQ(mock_batcher_.GetNumLines(), num_major_ticks + num_minor_ticks);
 
     // Major ticks should always be between 2 and 10, given scale set. In extremely small screens
-    // (Width < 160), we don't force a minimum number of major ticks.
-    if (!is_small_screen) {
+    // (Width < 200), we don't force a minimum number of major ticks.
+    if (viewport_->GetWorldWidth() > kTinyScreenMaxPixelsWidth) {
       EXPECT_GE(num_major_ticks, 2);
     }
     EXPECT_LE(num_major_ticks, 10);
@@ -53,11 +62,16 @@ class TimelineUiTest : public TimelineUi {
     EXPECT_TRUE(num_minor_ticks <= num_major_ticks + 1 ||
                 num_minor_ticks >= 4 * (num_major_ticks - 1));
 
-    // Labels should all have the same number of numbers, start at the same vertical position and
+    // Labels should all have the same number of digits, start at the same vertical position and
     // they will appear at the right of each major tick.
     EXPECT_TRUE(mock_text_renderer_.HasAddTextsSameLength());
     EXPECT_TRUE(mock_text_renderer_.AreAddTextsAlignedVertically());
-    EXPECT_GE(num_labels, num_major_ticks - 1);
+
+    // TODO(b/218311326): In some cases, small screens (Width < 700) failed in the condition between
+    // #labels and #major_ticks, since we are drawing major_ticks anyways when labels intersect.
+    if (viewport_->GetWorldWidth() > kSmallScreenMaxPixelsWidth) {
+      EXPECT_GE(num_labels, num_major_ticks - 1);
+    }
     EXPECT_LE(num_labels, num_major_ticks + 1);
 
     // Boxes: One box per each label + Background box + margin box.
@@ -74,24 +88,36 @@ class TimelineUiTest : public TimelineUi {
   MockBatcher mock_batcher_;
   MockTextRenderer mock_text_renderer_;
   PrimitiveAssembler primitive_assembler_;
-  TimeGraphLayout layout_;
-  Viewport viewport_;
-  MockTimelineInfo mock_timeline_info;
+  Viewport* viewport_;
+  MockTimelineInfo* mock_timeline_info_;
 };
 
-TEST(TimelineUI, UpdatePrimitivesBigScreen) {
-  // TODO(b/218311326): In some cases, small screens and even medium screens (Width < 700) failed in
-  // the condition between #labels and #major_ticks, since we are drawing major_ticks anyways when
-  // labels intersect.
-  const int kBigScreenWidth = 2000;
-  TimelineUiTest timeline_ui_test(kBigScreenWidth);
+static void TestUpdatePrimitivesWithSeveralRanges(int world_width) {
+  MockTimelineInfo mock_timeline_info;
+  Viewport viewport(0, 0);
+  TimeGraphLayout layout;
+  TimelineUiTest timeline_ui_test(world_width, &mock_timeline_info, &viewport, &layout);
   timeline_ui_test.TestUpdatePrimitives(0, 100);
+  timeline_ui_test.TestUpdatePrimitives(1'000'000'000, 1'000'000'100);
+  timeline_ui_test.TestUpdatePrimitives(0, 999'999'000);
+  timeline_ui_test.TestUpdatePrimitives(0, 999'999'999);
+  timeline_ui_test.TestUpdatePrimitives(0, 1'000'000'000);
+
+  // Maximum supported timestamp: 1 Month.
+  std::mt19937 gen;
+  std::uniform_int_distribution<> distrib(0, kNanosecondsPerMonth);
+
   for (int i = 0; i < 100; i++) {
-    uint64_t timestamp_1 = rand();
-    uint64_t timestamp_2 = rand();
+    uint64_t timestamp_1 = distrib(gen);
+    uint64_t timestamp_2 = distrib(gen);
     timeline_ui_test.TestUpdatePrimitives(std::min(timestamp_1, timestamp_2),
                                           std::max(timestamp_1, timestamp_2));
   }
+}
+
+TEST(TimelineUI, UpdatePrimitives) {
+  TestUpdatePrimitivesWithSeveralRanges(TimelineUiTest::kBigScreenPixelsWidth);
+  TestUpdatePrimitivesWithSeveralRanges(TimelineUiTest::kTinyScreenMaxPixelsWidth);
 }
 
 }  // namespace orbit_gl


### PR DESCRIPTION
In this PR we are creating visual tests in the TimelineUi component.
After creating several mock classes, we were able to test comparisons
between number of major ticks, number of minor ticks and labels for
different ranges. We were also able to test number of characters in the
labels, and positions of objects.

As a result, one bug was found and fixed (the margin below timeline was
outside of the kZTimeline ranges and on top of the incomplete data
intervals: http://screenshot/56bT7Cr7b5aE5GM).

Also, we found something we previously now about small screens: 
http://b/218311326. This is a small issue that need a bit of a refactor to
be fixed and not a big priority but it was good that it was catched in
these unit tests. The issue is that screens below 700 pixels width
sometimes has intersecting labels (actually it's more like 500 but the
MockTextRenderer is estimating every character as a 'w').

Finally, we don't expect in really small screens to force to have at
least 2 labels.

Bug: http://b/218302149.