### PR TITLE
Patch leafs even when stack dump is too small

### DIFF
--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -71,15 +71,9 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
 
   const uint64_t stack_size = rbp - rsp;
 
-  // TODO(b/228445173): If we are in a leaf function and the stack dump contains the return address
-  //  we should be able to patch the stack even if the stack dump is not from $rsp to $rbp.
-  if (stack_size > stack_dump_size_) {
-    return Callstack::kStackTopForDwarfUnwindingTooSmall;
-  }
-
-  const LibunwindstackResult& libunwindstack_result =
-      unwinder->Unwind(event_data->pid, current_maps->Get(), event_data->GetRegisters(),
-                       event_data->GetStackData(), stack_size, true);
+  const LibunwindstackResult& libunwindstack_result = unwinder->Unwind(
+      event_data->pid, current_maps->Get(), event_data->GetRegisters(), event_data->GetStackData(),
+      std::min<uint64_t>(stack_size, stack_dump_size_), true);
   const std::vector<unwindstack::FrameData>& libunwindstack_callstack =
       libunwindstack_result.frames();
 
@@ -90,10 +84,13 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
     return Callstack::kStackTopDwarfUnwindingError;
   }
 
-  // In case of an intact frame pointer, the region from $rsp to $rbp will only include the locals
-  // of the current frame, and NOT the return address. Thus, unwinding will only report one frame
-  // (the instruction pointer) and we know that the original callchain is already correct.
   if (libunwindstack_callstack.size() == 1) {
+    if (stack_size > stack_dump_size_) {
+      return Callstack::kStackTopForDwarfUnwindingTooSmall;
+    }
+    // In case of an intact frame pointer, the region from $rsp to $rbp will only include the locals
+    // of the current frame, and NOT the return address. Thus, unwinding will only report one frame
+    // (the instruction pointer) and we know that the original callchain is already correct.
     return Callstack::kComplete;
   }
 

--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -85,7 +85,7 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
   }
 
   if (libunwindstack_callstack.size() == 1) {
-    if (stack_size > stack_dump_size_) {
+    if (stack_size > stack_dump_size_ && !libunwindstack_result.IsSuccess()) {
       return Callstack::kStackTopForDwarfUnwindingTooSmall;
     }
     // In case of an intact frame pointer, the region from $rsp to $rbp will only include the locals

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -219,7 +219,7 @@ TEST_F(
 
   // We expect `kStackDumpSize` here as size, as we do not want libunwindstack
   // to read out of bounds.
-  EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, kStackDumpSize * 2, _, _))
+  EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, kStackDumpSize, _, _))
       .Times(1)
       .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
                                             unwindstack::ErrorCode::ERROR_INVALID_MAP}));

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -194,7 +194,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnTooSm
 
 TEST_F(
     LeafFunctionCallManagerTest,
-    PatchCallerOfLeafFunctionReturnsSuccessAndPatchesCallchainEvenIfStackDumpDoesContainFullCaller) {
+    PatchCallerOfLeafFunctionReturnsSuccessAndPatchesCallchainEvenIfStackDumpDoesNotFullyContainCaller) {
   std::vector<uint64_t> callchain;
   callchain.push_back(kKernelAddress);
   callchain.push_back(kTargetAddress1);


### PR DESCRIPTION
Previously, we gave up patching leaf functions, if the collected
raw stack was too small to include both the leaf's and the caller's
frame completely.

However, if the stack dump is only missing parts of the caller's
frame, unwinding may still be successfull to find out the leaf's
caller. In this case, we can still patch the callchain.

Now, we only return an unwinding error, if we actually not receive
two frames and the stack size is too small.

Test: Run tests & manually verify on samples.
Bug: http://b/228445173