### PR TITLE
Process launching on Windows

### DIFF
--- a/src/ClientServices/CMakeLists.txt
+++ b/src/ClientServices/CMakeLists.txt
@@ -13,12 +13,14 @@ target_include_directories(ClientServices PRIVATE
 
 target_sources(ClientServices PUBLIC
         include/ClientServices/CrashManager.h
+        include/ClientServices/LaunchedProcess.h
         include/ClientServices/ProcessManager.h
         include/ClientServices/ProcessClient.h
         include/ClientServices/TracepointServiceClient.h)
 
 target_sources(ClientServices PRIVATE
         CrashManager.cpp
+        LaunchedProcess.cpp
         ProcessManager.cpp
         ProcessClient.cpp
         TracepointServiceClient.cpp)
@@ -27,3 +29,17 @@ target_link_libraries(ClientServices PUBLIC
         GrpcProtos
         Introspection
         OrbitBase)
+
+add_executable(ClientServicesTests)
+
+target_sources(ClientServicesTests PRIVATE
+        LaunchedProcessTest.cpp
+        MockProcessClient.h)
+
+target_link_libraries(
+        ClientServicesTests PRIVATE
+        ClientServices
+        TestUtils
+        GTest::Main)
+
+register_test(ClientServicesTests)

--- a/src/ClientServices/LaunchedProcess.cpp
+++ b/src/ClientServices/LaunchedProcess.cpp
@@ -11,15 +11,13 @@ namespace orbit_client_services {
 using orbit_grpc_protos::ProcessInfo;
 using orbit_grpc_protos::ProcessToLaunch;
 
-ErrorMessageOr<std::unique_ptr<LaunchedProcess>> LaunchedProcess::LaunchProcess(
+ErrorMessageOr<LaunchedProcess> LaunchedProcess::LaunchProcess(
     const orbit_grpc_protos::ProcessToLaunch& process_to_launch, ProcessClient* client) {
   OUTCOME_TRY(ProcessInfo process_info, client->LaunchProcess(process_to_launch));
   LaunchedProcess::State initial_state = process_to_launch.spin_at_entry_point()
                                              ? LaunchedProcess::State::kSpinningAtEntryPoint
                                              : LaunchedProcess::State::kExecutingOrExited;
-  // Using "new" to access non-public constructor.
-  return std::unique_ptr<LaunchedProcess>(
-      new LaunchedProcess(initial_state, std::move(process_info)));
+  return LaunchedProcess(initial_state, process_info);
 }
 
 LaunchedProcess::LaunchedProcess(State initial_state, orbit_grpc_protos::ProcessInfo process_info)

--- a/src/ClientServices/LaunchedProcess.cpp
+++ b/src/ClientServices/LaunchedProcess.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ClientServices/LaunchedProcess.h"
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_client_services {
+
+using orbit_grpc_protos::ProcessInfo;
+using orbit_grpc_protos::ProcessToLaunch;
+
+ErrorMessageOr<std::unique_ptr<LaunchedProcess>> LaunchedProcess::LaunchProcess(
+    const orbit_grpc_protos::ProcessToLaunch& process_to_launch, ProcessClient* client) {
+  OUTCOME_TRY(ProcessInfo process_info, client->LaunchProcess(process_to_launch));
+  LaunchedProcess::State initial_state = process_to_launch.spin_at_entry_point()
+                                             ? LaunchedProcess::State::kSpinningAtEntryPoint
+                                             : LaunchedProcess::State::kExecutingOrExited;
+  // Using "new" to access non-public constructor.
+  return std::unique_ptr<LaunchedProcess>(
+      new LaunchedProcess(initial_state, std::move(process_info)));
+}
+
+LaunchedProcess::LaunchedProcess(State initial_state, orbit_grpc_protos::ProcessInfo process_info)
+    : state_(initial_state), process_info_(std::move(process_info)) {}
+
+ErrorMessageOr<void> LaunchedProcess::SuspendProcessSpinningAtEntryPoint(ProcessClient* client) {
+  ORBIT_CHECK(state_ == State::kSpinningAtEntryPoint);
+  OUTCOME_TRY(client->SuspendProcessSpinningAtEntryPoint(process_info_.pid()));
+  state_ = State::kSuspendedAtEntryPoint;
+  return outcome::success();
+}
+
+ErrorMessageOr<void> LaunchedProcess::ResumeProcessSuspendedAtEntryPoint(ProcessClient* client) {
+  ORBIT_CHECK(state_ == State::kSuspendedAtEntryPoint);
+  OUTCOME_TRY(client->ResumeProcessSuspendedAtEntryPoint(process_info_.pid()));
+  state_ = State::kExecutingOrExited;
+  return outcome::success();
+}
+
+const ProcessInfo& LaunchedProcess::GetProcessInfo() const { return process_info_; }
+
+bool LaunchedProcess::IsProcessSpinningAtEntryPoint() const {
+  return state_ == State::kSpinningAtEntryPoint;
+}
+
+bool LaunchedProcess::IsProcessSuspendedAtEntryPoint() const {
+  return state_ == State::kSuspendedAtEntryPoint;
+}
+
+bool LaunchedProcess::IsProcessExecutingOrExited() const {
+  return state_ == State::kExecutingOrExited;
+}
+
+}  // namespace orbit_client_services

--- a/src/ClientServices/LaunchedProcessTest.cpp
+++ b/src/ClientServices/LaunchedProcessTest.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "ClientServices/LaunchedProcess.h"
+#include "ClientServices/ProcessClient.h"
+#include "MockProcessClient.h"
+#include "OrbitBase/Logging.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_client_services {
+
+using orbit_grpc_protos::ProcessInfo;
+using orbit_grpc_protos::ProcessToLaunch;
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasValue;
+using ::testing::Return;
+
+TEST(LaunchedProcess, LaunchProcess) {
+  MockProcessClient mock_process_client;
+  // Setup a process to be launched and executed straight away, not spinning at entry point.
+  orbit_grpc_protos::ProcessToLaunch process_to_launch;
+  process_to_launch.set_spin_at_entry_point(false);
+
+  // The "MockProcessClient" returns a valid ProcessInfo when its "LaunchProcess" method is called.
+  ON_CALL(mock_process_client, LaunchProcess).WillByDefault(Return(ProcessInfo()));
+  EXPECT_CALL(mock_process_client, LaunchProcess).Times(1);
+
+  // "LaunchedProcess::LaunchProcess" function will invoke "MockProcessClient::LaunchProcess".
+  ErrorMessageOr<std::unique_ptr<LaunchedProcess>> launch_result =
+      LaunchedProcess::LaunchProcess(process_to_launch, &mock_process_client);
+
+  // Make sure the returned "LaunchedProcess" is valid and is not set as "spinning on entry point".
+  ASSERT_THAT(launch_result, HasValue());
+  LaunchedProcess& launched_process = *launch_result.value();
+  ASSERT_FALSE(launched_process.IsProcessSpinningAtEntryPoint());
+  ASSERT_FALSE(launched_process.IsProcessSuspendedAtEntryPoint());
+  ASSERT_TRUE(launched_process.IsProcessExecutingOrExited());
+
+  // Calling "SuspendProcessSpinningAtEntryPoint" should abort the program since the process was not
+  // launched spinning at entry point.
+  EXPECT_DEATH((void)launched_process.SuspendProcessSpinningAtEntryPoint(&mock_process_client),
+               "Check failed");
+}
+
+TEST(LaunchedProcess, LaunchProcessSpinningAtEntryPoint) {
+  MockProcessClient mock_process_client;
+  // Setup a process to be launched spinning at entry point.
+  orbit_grpc_protos::ProcessToLaunch process_to_launch;
+  process_to_launch.set_spin_at_entry_point(true);
+
+  // The "MockProcessClient" returns a valid ProcessInfo when its "LaunchProcess" method is called.
+  ON_CALL(mock_process_client, LaunchProcess).WillByDefault(Return(ProcessInfo()));
+  EXPECT_CALL(mock_process_client, LaunchProcess).Times(1);
+
+  // "LaunchedProcess::LaunchProcess" function will invoke "MockProcessClient::LaunchProcess".
+  ErrorMessageOr<std::unique_ptr<LaunchedProcess>> launch_result =
+      LaunchedProcess::LaunchProcess(process_to_launch, &mock_process_client);
+
+  // Make sure the returned "LaunchedProcess" is valid and is set as "spinning on entry point".
+  ASSERT_THAT(launch_result, HasValue());
+  LaunchedProcess& launched_process = *launch_result.value();
+  ASSERT_TRUE(launched_process.IsProcessSpinningAtEntryPoint());
+  ASSERT_FALSE(launched_process.IsProcessSuspendedAtEntryPoint());
+  ASSERT_FALSE(launched_process.IsProcessExecutingOrExited());
+
+  // Suspend the process spinning at entry point, making the launched process change state.
+  ON_CALL(mock_process_client, SuspendProcessSpinningAtEntryPoint)
+      .WillByDefault(Return(outcome::success()));
+  EXPECT_CALL(mock_process_client, SuspendProcessSpinningAtEntryPoint).Times(1);
+  auto suspend_result = launched_process.SuspendProcessSpinningAtEntryPoint(&mock_process_client);
+  ASSERT_THAT(suspend_result, HasValue());
+  ASSERT_FALSE(launched_process.IsProcessSpinningAtEntryPoint());
+  ASSERT_TRUE(launched_process.IsProcessSuspendedAtEntryPoint());
+  ASSERT_FALSE(launched_process.IsProcessExecutingOrExited());
+
+  // Resume the process suspended at entry point, making the launched process change state.
+  ON_CALL(mock_process_client, ResumeProcessSuspendedAtEntryPoint)
+      .WillByDefault(Return(outcome::success()));
+  EXPECT_CALL(mock_process_client, ResumeProcessSuspendedAtEntryPoint).Times(1);
+  auto resume_result = launched_process.ResumeProcessSuspendedAtEntryPoint(&mock_process_client);
+  ASSERT_THAT(resume_result, HasValue());
+  ASSERT_FALSE(launched_process.IsProcessSpinningAtEntryPoint());
+  ASSERT_FALSE(launched_process.IsProcessSuspendedAtEntryPoint());
+  ASSERT_TRUE(launched_process.IsProcessExecutingOrExited());
+}
+
+}  // namespace orbit_client_services

--- a/src/ClientServices/LaunchedProcessTest.cpp
+++ b/src/ClientServices/LaunchedProcessTest.cpp
@@ -30,12 +30,12 @@ TEST(LaunchedProcess, LaunchProcess) {
   EXPECT_CALL(mock_process_client, LaunchProcess).Times(1);
 
   // "LaunchedProcess::LaunchProcess" function will invoke "MockProcessClient::LaunchProcess".
-  ErrorMessageOr<std::unique_ptr<LaunchedProcess>> launch_result =
+  ErrorMessageOr<LaunchedProcess> launch_result =
       LaunchedProcess::LaunchProcess(process_to_launch, &mock_process_client);
 
   // Make sure the returned "LaunchedProcess" is valid and is not set as "spinning on entry point".
   ASSERT_THAT(launch_result, HasValue());
-  LaunchedProcess& launched_process = *launch_result.value();
+  LaunchedProcess& launched_process = launch_result.value();
   ASSERT_FALSE(launched_process.IsProcessSpinningAtEntryPoint());
   ASSERT_FALSE(launched_process.IsProcessSuspendedAtEntryPoint());
   ASSERT_TRUE(launched_process.IsProcessExecutingOrExited());
@@ -57,12 +57,12 @@ TEST(LaunchedProcess, LaunchProcessSpinningAtEntryPoint) {
   EXPECT_CALL(mock_process_client, LaunchProcess).Times(1);
 
   // "LaunchedProcess::LaunchProcess" function will invoke "MockProcessClient::LaunchProcess".
-  ErrorMessageOr<std::unique_ptr<LaunchedProcess>> launch_result =
+  ErrorMessageOr<LaunchedProcess> launch_result =
       LaunchedProcess::LaunchProcess(process_to_launch, &mock_process_client);
 
   // Make sure the returned "LaunchedProcess" is valid and is set as "spinning on entry point".
   ASSERT_THAT(launch_result, HasValue());
-  LaunchedProcess& launched_process = *launch_result.value();
+  LaunchedProcess& launched_process = launch_result.value();
   ASSERT_TRUE(launched_process.IsProcessSpinningAtEntryPoint());
   ASSERT_FALSE(launched_process.IsProcessSuspendedAtEntryPoint());
   ASSERT_FALSE(launched_process.IsProcessExecutingOrExited());

--- a/src/ClientServices/MockProcessClient.h
+++ b/src/ClientServices/MockProcessClient.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+
+#include "ClientServices/ProcessClient.h"
+
+namespace orbit_client_services {
+
+class MockProcessClient : public ProcessClient {
+ public:
+  MOCK_METHOD(ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>>, GetProcessList, (),
+              (override));
+  MOCK_METHOD(ErrorMessageOr<orbit_grpc_protos::ProcessInfo>, LaunchProcess,
+              (const orbit_grpc_protos::ProcessToLaunch&), (override));
+  MOCK_METHOD(ErrorMessageOr<void>, SuspendProcessSpinningAtEntryPoint, (uint32_t), (override));
+  MOCK_METHOD(ErrorMessageOr<void>, ResumeProcessSuspendedAtEntryPoint, (uint32_t), (override));
+  MOCK_METHOD(ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>>, LoadModuleList,
+              (uint32_t), (override));
+  MOCK_METHOD(ErrorMessageOr<std::string>, FindDebugInfoFile,
+              (const std::string& module_path, absl::Span<const std::string>), (override));
+  MOCK_METHOD(ErrorMessageOr<std::string>, LoadProcessMemory, (uint32_t, uint64_t, uint64_t),
+              (override));
+};
+
+}  // namespace orbit_client_services

--- a/src/ClientServices/ProcessClient.cpp
+++ b/src/ClientServices/ProcessClient.cpp
@@ -44,7 +44,6 @@ class ProcessClientImpl : public ProcessClient {
  public:
   explicit ProcessClientImpl(const std::shared_ptr<grpc::Channel>& channel)
       : process_service_(orbit_grpc_protos::ProcessService::NewStub(channel)) {}
-  ProcessClientImpl() = default;
   virtual ~ProcessClientImpl() = default;
 
   ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> GetProcessList() override;

--- a/src/ClientServices/include/ClientServices/LaunchedProcess.h
+++ b/src/ClientServices/include/ClientServices/LaunchedProcess.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_SERVICES_LAUNCHED_PROCESS_
+#define CLIENT_SERVICES_LAUNCHED_PROCESS_
+
+#include "ClientServices/ProcessClient.h"
+#include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/Result.h"
+
+namespace orbit_client_services {
+
+// LaunchedProcess holds client side information about a process that has been launched from
+// OrbitService, possibly spinning at entry point, and manages its state transitions.
+class LaunchedProcess {
+ public:
+  // A LaunchedProcess can only be created by launching a process.
+  static ErrorMessageOr<std::unique_ptr<LaunchedProcess>> LaunchProcess(
+      const orbit_grpc_protos::ProcessToLaunch& process_to_launch, ProcessClient* client);
+
+  // Prevent other creation methods.
+  LaunchedProcess() = delete;
+  LaunchedProcess(const LaunchedProcess&) = delete;
+  LaunchedProcess(const LaunchedProcess&&) = delete;
+  LaunchedProcess& operator=(const LaunchedProcess&) = delete;
+  LaunchedProcess& operator=(const LaunchedProcess&&) = delete;
+
+  // Suspend a process spinning at entry point and restore its original instructions.
+  [[nodiscard]] ErrorMessageOr<void> SuspendProcessSpinningAtEntryPoint(ProcessClient* client);
+  // Resume a process suspended at entry point.
+  [[nodiscard]] ErrorMessageOr<void> ResumeProcessSuspendedAtEntryPoint(ProcessClient* client);
+  // Get process info.
+  [[nodiscard]] const orbit_grpc_protos::ProcessInfo& GetProcessInfo() const;
+  // Get current state of the launched process.
+  [[nodiscard]] bool IsProcessSpinningAtEntryPoint() const;
+  [[nodiscard]] bool IsProcessSuspendedAtEntryPoint() const;
+  [[nodiscard]] bool IsProcessExecutingOrExited() const;
+
+ private:
+  enum class State { kInvalid, kExecutingOrExited, kSpinningAtEntryPoint, kSuspendedAtEntryPoint };
+  LaunchedProcess(State initial_state, orbit_grpc_protos::ProcessInfo process_info);
+  State state_ = State::kInvalid;
+  orbit_grpc_protos::ProcessInfo process_info_;
+};
+
+}  // namespace orbit_client_services
+
+#endif  // CLIENT_SERVICES_LAUNCHED_PROCESS_

--- a/src/ClientServices/include/ClientServices/LaunchedProcess.h
+++ b/src/ClientServices/include/ClientServices/LaunchedProcess.h
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef CLIENT_SERVICES_LAUNCHED_PROCESS_
-#define CLIENT_SERVICES_LAUNCHED_PROCESS_
+#ifndef CLIENT_SERVICES_LAUNCHED_PROCESS_H_
+#define CLIENT_SERVICES_LAUNCHED_PROCESS_H_
 
 #include "ClientServices/ProcessClient.h"
-#include "GrpcProtos/capture.pb.h"
+#include "GrpcProtos/services.pb.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_client_services {
@@ -16,15 +16,14 @@ namespace orbit_client_services {
 class LaunchedProcess {
  public:
   // A LaunchedProcess can only be created by launching a process.
-  static ErrorMessageOr<std::unique_ptr<LaunchedProcess>> LaunchProcess(
+  static ErrorMessageOr<LaunchedProcess> LaunchProcess(
       const orbit_grpc_protos::ProcessToLaunch& process_to_launch, ProcessClient* client);
+  LaunchedProcess(LaunchedProcess&&) = default;
 
   // Prevent other creation methods.
   LaunchedProcess() = delete;
   LaunchedProcess(const LaunchedProcess&) = delete;
-  LaunchedProcess(const LaunchedProcess&&) = delete;
   LaunchedProcess& operator=(const LaunchedProcess&) = delete;
-  LaunchedProcess& operator=(const LaunchedProcess&&) = delete;
 
   // Suspend a process spinning at entry point and restore its original instructions.
   [[nodiscard]] ErrorMessageOr<void> SuspendProcessSpinningAtEntryPoint(ProcessClient* client);
@@ -46,4 +45,4 @@ class LaunchedProcess {
 
 }  // namespace orbit_client_services
 
-#endif  // CLIENT_SERVICES_LAUNCHED_PROCESS_
+#endif  // CLIENT_SERVICES_LAUNCHED_PROCESS_H_

--- a/src/ClientServices/include/ClientServices/ProcessClient.h
+++ b/src/ClientServices/include/ClientServices/ProcessClient.h
@@ -27,17 +27,23 @@ class ProcessClient {
  public:
   explicit ProcessClient(const std::shared_ptr<grpc::Channel>& channel)
       : process_service_(orbit_grpc_protos::ProcessService::NewStub(channel)) {}
+  ProcessClient() = default;
+  virtual ~ProcessClient() = default;
 
-  [[nodiscard]] ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> GetProcessList();
+  virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> GetProcessList();
 
-  [[nodiscard]] ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(
-      uint32_t pid);
+  virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(uint32_t pid);
 
-  [[nodiscard]] ErrorMessageOr<std::string> FindDebugInfoFile(
+  virtual ErrorMessageOr<std::string> FindDebugInfoFile(
       const std::string& module_path, absl::Span<const std::string> additional_search_directories);
 
-  [[nodiscard]] ErrorMessageOr<std::string> LoadProcessMemory(uint32_t pid, uint64_t address,
-                                                              uint64_t size);
+  virtual ErrorMessageOr<std::string> LoadProcessMemory(uint32_t pid, uint64_t address,
+                                                        uint64_t size);
+
+  virtual ErrorMessageOr<orbit_grpc_protos::ProcessInfo> LaunchProcess(
+      const orbit_grpc_protos::ProcessToLaunch& process_to_launch);
+  virtual ErrorMessageOr<void> SuspendProcessSpinningAtEntryPoint(uint32_t pid);
+  virtual ErrorMessageOr<void> ResumeProcessSuspendedAtEntryPoint(uint32_t pid);
 
  private:
   std::unique_ptr<orbit_grpc_protos::ProcessService::Stub> process_service_;

--- a/src/ClientServices/include/ClientServices/ProcessClient.h
+++ b/src/ClientServices/include/ClientServices/ProcessClient.h
@@ -25,28 +25,22 @@ namespace orbit_client_services {
 // This class handles the client calls related to process service.
 class ProcessClient {
  public:
-  explicit ProcessClient(const std::shared_ptr<grpc::Channel>& channel)
-      : process_service_(orbit_grpc_protos::ProcessService::NewStub(channel)) {}
-  ProcessClient() = default;
-  virtual ~ProcessClient() = default;
-
-  virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> GetProcessList();
-
-  virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(uint32_t pid);
-
+  virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> GetProcessList() = 0;
+  virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(
+      uint32_t pid) = 0;
   virtual ErrorMessageOr<std::string> FindDebugInfoFile(
-      const std::string& module_path, absl::Span<const std::string> additional_search_directories);
-
+      const std::string& module_path,
+      absl::Span<const std::string> additional_search_directories) = 0;
   virtual ErrorMessageOr<std::string> LoadProcessMemory(uint32_t pid, uint64_t address,
-                                                        uint64_t size);
+                                                        uint64_t size) = 0;
 
   virtual ErrorMessageOr<orbit_grpc_protos::ProcessInfo> LaunchProcess(
-      const orbit_grpc_protos::ProcessToLaunch& process_to_launch);
-  virtual ErrorMessageOr<void> SuspendProcessSpinningAtEntryPoint(uint32_t pid);
-  virtual ErrorMessageOr<void> ResumeProcessSuspendedAtEntryPoint(uint32_t pid);
+      const orbit_grpc_protos::ProcessToLaunch& process_to_launch) = 0;
+  virtual ErrorMessageOr<void> SuspendProcessSpinningAtEntryPoint(uint32_t pid) = 0;
+  virtual ErrorMessageOr<void> ResumeProcessSuspendedAtEntryPoint(uint32_t pid) = 0;
 
- private:
-  std::unique_ptr<orbit_grpc_protos::ProcessService::Stub> process_service_;
+  [[nodiscard]] static std::unique_ptr<ProcessClient> Create(
+      const std::shared_ptr<grpc::Channel>& channel);
 };
 
 }  // namespace orbit_client_services

--- a/src/ClientServices/include/ClientServices/ProcessClient.h
+++ b/src/ClientServices/include/ClientServices/ProcessClient.h
@@ -25,6 +25,8 @@ namespace orbit_client_services {
 // This class handles the client calls related to process service.
 class ProcessClient {
  public:
+  virtual ~ProcessClient() = default;
+
   virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> GetProcessList() = 0;
   virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(
       uint32_t pid) = 0;

--- a/src/ClientServices/include/ClientServices/ProcessManager.h
+++ b/src/ClientServices/include/ClientServices/ProcessManager.h
@@ -25,13 +25,14 @@
 
 namespace orbit_client_services {
 
-// ProcessManager is used to access or launch processes on the target machine through OrbitService.
+// ProcessManager is used to query information about existing processes on the target machine as
+// well as launching new ones.
 class ProcessManager {
  public:
   ProcessManager() = default;
   virtual ~ProcessManager() = default;
 
-  // Set callback to periodically receive the list of processes running on the target.
+  // Set callback to periodically receive a list of processes running on the target machine.
   virtual void SetProcessListUpdateListener(
       const std::function<void(std::vector<orbit_grpc_protos::ProcessInfo>)>& listener) = 0;
 
@@ -47,8 +48,6 @@ class ProcessManager {
       const std::string& module_path,
       absl::Span<const std::string> additional_search_directories) = 0;
 
-  // Process launching is only implemented on Windows for now.
-  // TODO(https://b/232009293): Profile from entry point on Stadia/Linux.
 #ifdef _WIN32
   virtual ErrorMessageOr<orbit_grpc_protos::ProcessInfo> LaunchProcess(
       const orbit_grpc_protos::ProcessToLaunch& process_to_launch) = 0;

--- a/src/GrpcProtos/BUILD
+++ b/src/GrpcProtos/BUILD
@@ -75,6 +75,7 @@ proto_library(
         ":code_block_proto",
         ":module_proto",
         ":process_proto",
+        ":symbol_proto",
         ":tracepoint_proto",
     ],
 )

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -39,6 +39,13 @@ message ApiFunction {
   uint64 api_version = 5;
 }
 
+message ProcessToLaunch {
+  string executable_path = 1;
+  string working_directory = 2;
+  string arguments = 3;
+  bool spin_at_entry_point = 4;
+}
+
 // NextId: 19
 message CaptureOptions {
   reserved 17;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -39,13 +39,6 @@ message ApiFunction {
   uint64 api_version = 5;
 }
 
-message ProcessToLaunch {
-  string executable_path = 1;
-  string working_directory = 2;
-  string arguments = 3;
-  bool spin_at_entry_point = 4;
-}
-
 // NextId: 19
 message CaptureOptions {
   reserved 17;

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -68,6 +68,13 @@ message GetDebugInfoFileResponse {
   string debug_info_file_path = 1;
 }
 
+message ProcessToLaunch {
+  string executable_path = 1;
+  string working_directory = 2;
+  string arguments = 3;
+  bool spin_at_entry_point = 4;
+}
+
 message LaunchProcessRequest {
   ProcessToLaunch process_to_launch = 1;
 }

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -10,6 +10,7 @@ import "capture.proto";
 import "code_block.proto";
 import "module.proto";
 import "process.proto";
+import "symbol.proto";
 import "tracepoint.proto";
 
 option cc_enable_arenas = true;
@@ -67,6 +68,26 @@ message GetDebugInfoFileResponse {
   string debug_info_file_path = 1;
 }
 
+message LaunchProcessRequest {
+  ProcessToLaunch process_to_launch = 1;
+}
+
+message LaunchProcessResponse {
+  ProcessInfo process_info = 1;
+}
+
+message SuspendProcessSpinningAtEntryPointRequest {
+  uint32 pid = 1;
+}
+
+message SuspendProcessSpinningAtEntryPointResponse {}
+
+message ResumeProcessSuspendedAtEntryPointRequest {
+  uint32 pid = 1;
+}
+
+message ResumeProcessSuspendedAtEntryPointResponse {}
+
 service ProcessService {
   rpc GetProcessList(GetProcessListRequest) returns (GetProcessListResponse) {}
 
@@ -77,6 +98,14 @@ service ProcessService {
 
   rpc GetDebugInfoFile(GetDebugInfoFileRequest)
       returns (GetDebugInfoFileResponse) {}
+
+  rpc LaunchProcess(LaunchProcessRequest) returns (LaunchProcessResponse) {}
+  rpc SuspendProcessSpinningAtEntryPoint(
+      SuspendProcessSpinningAtEntryPointRequest)
+      returns (SuspendProcessSpinningAtEntryPointResponse) {}
+  rpc ResumeProcessSuspendedAtEntryPoint(
+      ResumeProcessSuspendedAtEntryPointRequest)
+      returns (ResumeProcessSuspendedAtEntryPointResponse) {}
 }
 
 service TracepointService {

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -78,7 +78,7 @@ bool ClientGgp::InitClient() {
   }
   ORBIT_LOG("Created GRPC channel to %s", options_.grpc_server_address);
 
-  process_client_ = std::make_unique<orbit_client_services::ProcessClient>(grpc_channel_);
+  process_client_ = orbit_client_services::ProcessClient::Create(grpc_channel_);
 
   // Initialisations needed for capture to work
   if (!InitCapture()) {

--- a/src/SessionSetup/CMakeLists.txt
+++ b/src/SessionSetup/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(
 target_link_libraries(
   SessionSetup
   PUBLIC  CaptureFileInfo
+          CaptureClient
           ClientData
           ClientFlags
           ClientServices

--- a/src/SessionSetup/ProcessLauncherWidget.cpp
+++ b/src/SessionSetup/ProcessLauncherWidget.cpp
@@ -44,7 +44,25 @@ void ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked() {
 }
 
 void ProcessLauncherWidget::on_LaunchButton_clicked() {
-  // TODO(b/225906734): Windows Process Launcher
+#ifdef _WIN32
+  ORBIT_CHECK(process_manager_ != nullptr);
+  QString process = ui_->ProcessComboBox->lineEdit()->text();
+  QString working_dir = ui_->WorkingDirComboBox->lineEdit()->text();
+  QString args = ui_->ArgumentsComboBox->lineEdit()->text();
+  bool pause_on_entry_point = ui_->PauseAtEntryPoingCheckBox->isChecked();
+
+  orbit_grpc_protos::ProcessToLaunch process_to_launch;
+  process_to_launch.set_executable_path(process.toStdString());
+  process_to_launch.set_working_directory(working_dir.toStdString());
+  process_to_launch.set_arguments(args.toStdString());
+  process_to_launch.set_spin_at_entry_point(pause_on_entry_point);
+  auto result = process_manager_->LaunchProcess(process_to_launch);
+  if (result.has_error()) {
+    ui_->ErrorLabel->setText(result.error().message().c_str());
+  } else {
+    emit ProcessLaunched(result.value());
+  }
+#endif  // _WIN32
 }
 
 }  // namespace orbit_session_setup

--- a/src/WindowsProcessService/include/WindowsProcessService/ProcessServiceImpl.h
+++ b/src/WindowsProcessService/include/WindowsProcessService/ProcessServiceImpl.h
@@ -10,6 +10,7 @@
 
 #include "GrpcProtos/services.grpc.pb.h"
 #include "GrpcProtos/services.pb.h"
+#include "WindowsUtils/ProcessLauncher.h"
 #include "WindowsUtils/ProcessList.h"
 
 namespace orbit_windows_process_service {
@@ -32,9 +33,24 @@ class ProcessServiceImpl final : public orbit_grpc_protos::ProcessService::Servi
       grpc::ServerContext* context, const orbit_grpc_protos::GetDebugInfoFileRequest* request,
       orbit_grpc_protos::GetDebugInfoFileResponse* response) override;
 
+  [[nodiscard]] grpc::Status LaunchProcess(
+      grpc::ServerContext* context, const orbit_grpc_protos::LaunchProcessRequest* request,
+      orbit_grpc_protos::LaunchProcessResponse* response) override;
+
+  [[nodiscard]] grpc::Status SuspendProcessSpinningAtEntryPoint(
+      grpc::ServerContext* context,
+      const orbit_grpc_protos::SuspendProcessSpinningAtEntryPointRequest* request,
+      orbit_grpc_protos::SuspendProcessSpinningAtEntryPointResponse* response) override;
+
+  [[nodiscard]] grpc::Status ResumeProcessSuspendedAtEntryPoint(
+      grpc::ServerContext* context,
+      const orbit_grpc_protos::ResumeProcessSuspendedAtEntryPointRequest* request,
+      orbit_grpc_protos::ResumeProcessSuspendedAtEntryPointResponse* response) override;
+
  private:
   absl::Mutex mutex_;
   std::unique_ptr<orbit_windows_utils::ProcessList> process_list_;
+  orbit_windows_utils::ProcessLauncher process_launcher_;
 
   static constexpr size_t kMaxGetProcessMemoryResponseSize = 8 * 1024 * 1024;
 };

--- a/src/WindowsUtils/ProcessLauncher.cpp
+++ b/src/WindowsUtils/ProcessLauncher.cpp
@@ -43,7 +43,7 @@ ErrorMessageOr<uint32_t> ProcessLauncher::LaunchProcessPausedAtEntryPoint(
   return pid;
 }
 
-ErrorMessageOr<void> ProcessLauncher::SuspendProcess(uint32_t process_id) {
+ErrorMessageOr<void> ProcessLauncher::SuspendProcessSpinningAtEntryPoint(uint32_t process_id) {
   absl::MutexLock lock(&mutex_);
   auto it = busy_loop_launchers_by_pid_.find(process_id);
   if (it == busy_loop_launchers_by_pid_.end()) {
@@ -54,7 +54,7 @@ ErrorMessageOr<void> ProcessLauncher::SuspendProcess(uint32_t process_id) {
   return outcome::success();
 }
 
-ErrorMessageOr<void> ProcessLauncher::ResumeProcess(uint32_t process_id) {
+ErrorMessageOr<void> ProcessLauncher::ResumeProcessSuspendedAtEntryPoint(uint32_t process_id) {
   absl::MutexLock lock(&mutex_);
   auto it = busy_loop_launchers_by_pid_.find(process_id);
   if (it == busy_loop_launchers_by_pid_.end()) {

--- a/src/WindowsUtils/ProcessLauncherTest.cpp
+++ b/src/WindowsUtils/ProcessLauncherTest.cpp
@@ -36,10 +36,10 @@ TEST(ProcessLauncher, LaunchSuspendResumeProcess) {
   ASSERT_THAT(launch_result, HasNoError());
   uint32_t process_id = launch_result.value();
 
-  auto suspend_result = launcher.SuspendProcess(process_id);
+  auto suspend_result = launcher.SuspendProcessSpinningAtEntryPoint(process_id);
   ASSERT_THAT(suspend_result, HasNoError());
 
-  auto resume_result = launcher.ResumeProcess(process_id);
+  auto resume_result = launcher.ResumeProcessSuspendedAtEntryPoint(process_id);
   ASSERT_THAT(resume_result, HasNoError());
 }
 
@@ -54,13 +54,13 @@ TEST(ProcessLauncher, LaunchNonExistingProcess) {
 
 TEST(ProcessLauncher, SuspendNonExistingProcess) {
   ProcessLauncher launcher;
-  auto result = launcher.SuspendProcess(orbit_base::kInvalidProcessId);
+  auto result = launcher.SuspendProcessSpinningAtEntryPoint(orbit_base::kInvalidProcessId);
   ASSERT_THAT(result, HasError("Trying to suspend unknown process"));
 }
 
 TEST(ProcessLauncher, ResumeNonExistingProcess) {
   ProcessLauncher launcher;
-  auto result = launcher.ResumeProcess(orbit_base::kInvalidProcessId);
+  auto result = launcher.ResumeProcessSuspendedAtEntryPoint(orbit_base::kInvalidProcessId);
   ASSERT_THAT(result, HasError("Trying to resume unknown process"));
 }
 

--- a/src/WindowsUtils/ProcessLauncherTest.cpp
+++ b/src/WindowsUtils/ProcessLauncherTest.cpp
@@ -26,7 +26,13 @@ using orbit_test_utils::HasNoError;
 
 }  // namespace
 
-TEST(ProcessLauncher, LaunchProcess) {}
+TEST(ProcessLauncher, LaunchProcess) {
+  ProcessLauncher launcher;
+  auto launch_result =
+      launcher.LaunchProcess(GetTestExecutablePath(), /*working_directory=*/"", /*arguments=*/"",
+                             /*pause_at_entry_point*/ false);
+  ASSERT_THAT(launch_result, HasNoError());
+}
 
 TEST(ProcessLauncher, LaunchSuspendResumeProcess) {
   ProcessLauncher launcher;

--- a/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
+++ b/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
@@ -26,11 +26,11 @@ class ProcessLauncher {
   // Suspend a process that is currently spinning ("paused") at entry point and replace the busy
   // loop by the original instructions. This call will fail if the process can't be found or if it
   // is not in the spinning state.
-  ErrorMessageOr<void> SuspendProcess(uint32_t process_id);
+  ErrorMessageOr<void> SuspendProcessSpinningAtEntryPoint(uint32_t process_id);
 
   // Resume a process that was suspended using the "SuspendProcess" method above. This call will
   // fail if the process can't be found or if it is not in the suspended state.
-  ErrorMessageOr<void> ResumeProcess(uint32_t process_id);
+  ErrorMessageOr<void> ResumeProcessSuspendedAtEntryPoint(uint32_t process_id);
 
  private:
   ErrorMessageOr<uint32_t> LaunchProcess(const std::filesystem::path& executable,


### PR DESCRIPTION
We can now launch a process Windows and optionally pause it at entry
point and resume it on capture start. The feature is only enabled when
launching with "--local" and "--devmode".

https://screenshot.googleplex.com/95pLBxXXL7yYCAA.png

This change contains 3 main parts:

1. Creation LaunchedProcess class which holds client-side information
about a processe launched on the service-side. It also manages state
transitions from "spinning" to "suspended" to "running". The launched
processes are themselves mananged by the ProcessManager.

2. Adding MockProcessClient to be able to test the LaunchedProcess class.

3. Adding the grpc services to link client side requests to service side
actions which use the existing "ProcessLauncher" to perform the actual
process launching.

If this is too large a PR, I could split it, but I feel it might be
easier to get the full picture this way. It looks big but is actually
less than 2/3 what it looks like:

The 3 files in WindowsUtils are trivial renames, we have 2 CMakeLists
files and 2 .proto files, leaving 12 files for the actual core change.