### PR TITLE
Fix hooking a function when a capture is not connected

### DIFF
--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -235,10 +235,9 @@ void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
     if (function == nullptr) continue;
     // Functions used as frame tracks must be hooked (selected), otherwise the
     // data to produce the frame track will not be captured.
-    // TODO(b/228151393) The condition is supposed to prevent "selecting" a function when a capture
-    // is loaded with no connection to a process being established. Perhaps, resolution of the
-    // mentioned but would allow for a better way to check it.
-    if (!app_->HasCaptureData() || app_->IsCaptureConnected(app_->GetCaptureData())) {
+    // The condition is supposed to prevent "selecting" a function when a capture
+    // is loaded with no connection to a process being established.
+    if (GetActionStatus(kMenuActionSelect, i, {i}) == ActionStatus::kVisibleAndEnabled) {
       app_->SelectFunction(*function);
     }
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -235,7 +235,12 @@ void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
     if (function == nullptr) continue;
     // Functions used as frame tracks must be hooked (selected), otherwise the
     // data to produce the frame track will not be captured.
-    if (app_->IsCaptureConnected(app_->GetCaptureData())) app_->SelectFunction(*function);
+    // TODO(b/228151393) The condition is supposed to prevent "selecting" a function when a capture
+    // is loaded with no connection to a process being established. Perhaps, resolution of the
+    // mentioned but would allow for a better way to check it.
+    if (!app_->HasCaptureData() || app_->IsCaptureConnected(app_->GetCaptureData())) {
+      app_->SelectFunction(*function);
+    }
 
     app_->EnableFrameTrack(*function);
     app_->AddFrameTrack(*function);

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -228,12 +228,14 @@ void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
   metrics_uploader_->SendLogEvent(
       orbit_metrics_uploader::OrbitLogEvent::ORBIT_FRAME_TRACK_ENABLE_CLICKED);
 
+  ORBIT_CHECK(app_->HasCaptureData());
+
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     if (function == nullptr) continue;
     // Functions used as frame tracks must be hooked (selected), otherwise the
     // data to produce the frame track will not be captured.
-    app_->SelectFunction(*function);
+    if (app_->IsCaptureConnected(app_->GetCaptureData())) app_->SelectFunction(*function);
 
     app_->EnableFrameTrack(*function);
     app_->AddFrameTrack(*function);

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -552,6 +552,7 @@ TEST_F(FunctionsDataViewTest, ContextMenuActionsCallCorrespondingFunctionsInAppI
   CaptureData capture_data{{}, std::nullopt, {}, CaptureData::DataSource::kLiveCapture};
   EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnPointee(&capture_data));
   EXPECT_CALL(app_, IsCaptureConnected).WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
 
   view_.AddFunctions({&functions_[0]});
 


### PR DESCRIPTION
Currently, when no capture is connected and the user
enables a frametrack for a dynamically instrumented function,
the Type column of the Live tab shows the `F` character
(which is correct) and `H` character, which makes no sense,
as with no capture connected, the function cannot be hooked
on the next capture as the next capture is not possible.

Tests: Unit, Manual.
Bug: http://b/229709235