### PR TITLE
Remove namespace alias from header

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1700,7 +1700,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 
@@ -1898,8 +1898,8 @@ static ErrorMessageOr<std::filesystem::path> FindModuleLocallyImpl(
 
   std::string error_message;
   {
-    std::vector<fs::path> search_paths = GetAllSymbolPaths();
-    fs::path module_path(module_data.file_path());
+    std::vector<std::filesystem::path> search_paths = GetAllSymbolPaths();
+    std::filesystem::path module_path(module_data.file_path());
     search_paths.emplace_back(module_path.parent_path());
 
     const auto symbols_path =

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1700,7 +1700,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -201,7 +201,7 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
   // SymbolPaths.txt deprecation code
   // If file does not exist, do nothing. (It means the user never used an older Orbit version or
   // manually deleted the file)
-  if (!fs::is_regular_file(orbit_paths::GetSymbolsFilePath())) return;
+  if (!std::filesystem::is_regular_file(orbit_paths::GetSymbolsFilePath())) return;
 
   // If it exists, check if it starts with deprecation note.
   ErrorMessageOr<bool> symbol_paths_file_has_depr_note =
@@ -223,7 +223,7 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
   // This merging here via a hash set of the std::string representation only accomplishes that
   // paths with the same string representation are only added once.
   absl::flat_hash_set<std::string> already_seen_paths;
-  std::vector<fs::path> dirs_to_save;
+  std::vector<std::filesystem::path> dirs_to_save;
 
   for (const auto& dir : orbit_symbols::ReadSymbolsFile(orbit_paths::GetSymbolsFilePath())) {
     if (!already_seen_paths.contains(dir.string())) {

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -20,43 +20,45 @@
 #include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/Result.h"
 
-namespace fs = std::filesystem;
-
 namespace orbit_symbols {
 
 class SymbolHelper {
  public:
-  explicit SymbolHelper(fs::path cache_directory);
-  explicit SymbolHelper(fs::path cache_directory,
-                        std::vector<fs::path> structured_debug_directories)
+  explicit SymbolHelper(std::filesystem::path cache_directory);
+  explicit SymbolHelper(std::filesystem::path cache_directory,
+                        std::vector<std::filesystem::path> structured_debug_directories)
       : cache_directory_(std::move(cache_directory)),
         structured_debug_directories_{std::move(structured_debug_directories)} {};
 
-  [[nodiscard]] ErrorMessageOr<fs::path> FindSymbolsFileLocally(
-      const fs::path& module_path, const std::string& build_id,
+  [[nodiscard]] ErrorMessageOr<std::filesystem::path> FindSymbolsFileLocally(
+      const std::filesystem::path& module_path, const std::string& build_id,
       const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type,
-      absl::Span<const fs::path> paths) const;
-  [[nodiscard]] ErrorMessageOr<fs::path> FindSymbolsInCache(const fs::path& module_path,
-                                                            const std::string& build_id) const;
+      absl::Span<const std::filesystem::path> paths) const;
+  [[nodiscard]] ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(
+      const std::filesystem::path& module_path, const std::string& build_id) const;
   [[nodiscard]] static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
-      const fs::path& file_path, const orbit_object_utils::ObjectFileInfo& object_file_info);
-  [[nodiscard]] static ErrorMessageOr<void> VerifySymbolsFile(const fs::path& symbols_path,
-                                                              const std::string& build_id);
+      const std::filesystem::path& file_path,
+      const orbit_object_utils::ObjectFileInfo& object_file_info);
+  [[nodiscard]] static ErrorMessageOr<void> VerifySymbolsFile(
+      const std::filesystem::path& symbols_path, const std::string& build_id);
 
-  [[nodiscard]] fs::path GenerateCachedFileName(const fs::path& file_path) const;
+  [[nodiscard]] std::filesystem::path GenerateCachedFileName(
+      const std::filesystem::path& file_path) const;
 
-  [[nodiscard]] static bool IsMatchingDebugInfoFile(const fs::path& file_path, uint32_t checksum);
-  [[nodiscard]] ErrorMessageOr<fs::path> FindDebugInfoFileLocally(
-      std::string_view filename, uint32_t checksum, absl::Span<const fs::path> directories) const;
+  [[nodiscard]] static bool IsMatchingDebugInfoFile(const std::filesystem::path& file_path,
+                                                    uint32_t checksum);
+  [[nodiscard]] ErrorMessageOr<std::filesystem::path> FindDebugInfoFileLocally(
+      std::string_view filename, uint32_t checksum,
+      absl::Span<const std::filesystem::path> directories) const;
 
   // Check out GDB's documentation for how a debug directory is structured:
   // https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
-  [[nodiscard]] static ErrorMessageOr<fs::path> FindDebugInfoFileInDebugStore(
-      const fs::path& debug_directory, std::string_view build_id);
+  [[nodiscard]] static ErrorMessageOr<std::filesystem::path> FindDebugInfoFileInDebugStore(
+      const std::filesystem::path& debug_directory, std::string_view build_id);
 
  private:
-  const fs::path cache_directory_;
-  const std::vector<fs::path> structured_debug_directories_;
+  const std::filesystem::path cache_directory_;
+  const std::vector<std::filesystem::path> structured_debug_directories_;
 };
 
 [[nodiscard]] std::vector<std::filesystem::path> ReadSymbolsFile(


### PR DESCRIPTION
namespace fs = std::filesystem was used in SymbolHelper.h, resulting in
this leaking into every file that includes this header. This commit
removes the alias and exchanges the uses of fs with std::filesystem.

Test: Compile
http://b/229943842