### PR TITLE
Fix E2E Test "Capture Repeatedly"

### DIFF
--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -387,7 +387,7 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
 
         self.find_context_menu_item('Enable frame track(s)').click_input()
         
-        awaited_string : str = selected_function_string + ' [' + frame_track_enabled_string + ']'
+        awaited_string : str = selected_function_string + ' ' + frame_track_enabled_string
         wait_for_condition(lambda: awaited_string in functions_dataview.get_item_at(0, 0).texts()[0])
 
 


### PR DESCRIPTION
It used to await for the wrong frame track icon.

Test: E2E
Bug: http://b/229946316