### PR TITLE
Make jumps to timers faster

### DIFF
--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -244,8 +244,8 @@ class CaptureData {
   [[nodiscard]] const std::vector<uint64_t>* GetSortedTimerDurationsForScopeId(
       uint64_t scope_id) const;
 
-  // This is a hack allowing for fast jumps to timers. The class should be removed after the way we
-  // store the `timer_info`s is refactored.
+  // TODO(b/205037572) This is a hack allowing for fast jumps to timers. The class should be removed
+  // after the way we store the `timer_info`s is refactored.
   class FirstLastMinMaxTimers {
    public:
     explicit FirstLastMinMaxTimers(const TimerInfo* first_timer_observed)

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1718,7 +1718,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 


### PR DESCRIPTION
With the new generalised way of treating timers of all types
an efficient implementation of min/max/first/last timer
search has became much more difficult. In that regard we
pre-calculate min/max/first/last timers for each scope_id
upon capture finalisation.

Tests: Manual
Bug: http://b/229731732