### PR TITLE
Rename Function column under Live tab

### DIFF
--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -74,7 +74,7 @@ const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     columns[kColumnType] = {"Type", .0f, SortingOrder::kDescending};
-    columns[kColumnName] = {"Function", .4f, SortingOrder::kAscending};
+    columns[kColumnName] = {"Name", .4f, SortingOrder::kAscending};
     columns[kColumnCount] = {"Count", .0f, SortingOrder::kDescending};
     columns[kColumnTimeTotal] = {"Total", .075f, SortingOrder::kDescending};
     columns[kColumnTimeAvg] = {"Avg", .075f, SortingOrder::kDescending};

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -466,7 +466,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
   // Copy Selection
   {
     std::string expected_clipboard = absl::StrFormat(
-        "Type\tFunction\tCount\tTotal\tAvg\tMin\tMax\tStd Dev\tModule\tAddress\n"
+        "Type\tName\tCount\tTotal\tAvg\tMin\tMax\tStd Dev\tModule\tAddress\n"
         "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
         orbit_data_views::FunctionsDataView::kDynamicallyInstrumentedFunctionTypeString,
         kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
@@ -480,7 +480,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
   // Export to CSV
   {
     std::string expected_contents = absl::StrFormat(
-        R"("Type","Function","Count","Total","Avg","Min","Max","Std Dev","Module","Address")"
+        R"("Type","Name","Count","Total","Avg","Min","Max","Std Dev","Module","Address")"
         "\r\n"
         R"("%s","%s","%s","%s","%s","%s","%s","%s","%s","%s")"
         "\r\n",


### PR DESCRIPTION
Now we also have manual instrumentation under Live tab,
so the column should rather be called `Name`.

Test: Manual, Unit
Bug: http://b/229973598