### PR TITLE
Add RequestUpdateScope

### DIFF
--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -42,8 +42,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
                        uint64_t current_mouse_time_ns);
   void DrawText(float layer);
 
-  void RequestUpdate() override;
-
   // TODO(b/214282122): Move Process Timers function outside the UI.
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_grpc_protos::InstrumentedFunction* function);
@@ -113,7 +111,9 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
 
   void SelectAndZoom(const orbit_client_protos::TimerInfo* timer_info);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
-  [[nodiscard]] bool IsRedrawNeeded() const { return update_primitives_requested_; }
+  [[nodiscard]] bool IsRedrawNeeded() const {
+    return draw_requested_ || update_primitives_requested_;
+  }
 
   [[nodiscard]] bool IsFullyVisible(uint64_t min, uint64_t max) const;
   [[nodiscard]] bool IsPartlyVisible(uint64_t min, uint64_t max) const;
@@ -186,8 +186,6 @@ class TimeGraph final : public orbit_gl::CaptureViewElement,
   uint64_t capture_max_timestamp_ = 0;
 
   TimeGraphLayout layout_;
-
-  bool update_primitives_requested_ = false;
 
   orbit_gl::OpenGlBatcher batcher_;
   orbit_gl::PrimitiveAssembler primitive_assembler_;

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -368,7 +368,7 @@ void TrackContainer::SetIteratorOverlayData(
     const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id) {
   iterator_timer_info_ = iterator_timer_info;
   iterator_id_to_function_id_ = iterator_id_to_function_id;
-  RequestUpdate();
+  RequestUpdate(RequestUpdateScope::kDraw);
 }
 
 void TrackContainer::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,

--- a/src/OrbitGl/TrackHeader.h
+++ b/src/OrbitGl/TrackHeader.h
@@ -40,7 +40,9 @@ class TrackHeader : public CaptureViewElement, public std::enable_shared_from_th
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override;
 
-  [[nodiscard]] bool IsBeingDragged() { return picked_ && mouse_pos_last_click_ != mouse_pos_cur_; }
+  [[nodiscard]] bool IsBeingDragged() {
+    return picked_ && mouse_pos_last_click_[1] != mouse_pos_cur_[1];
+  }
 
  protected:
   void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,


### PR DESCRIPTION
Allow `CaptureViewElement` to request partial redraws.

This change allows `CaptureViewElement` to specify if they require a full
`UpdatePrimitives` or only `Draw` when calling `RequestUpdate`. This
will mostly be used to respond to mouse over events that change the
appearance of elements rendered during `Draw`, such as sliders and buttons.

This may be a temporary solution - I would like to run some experiments
with some suggestions from go/stadia-orbit-layers, but this will take more time.

Unit-tests should follow in a subsequent PR if the architecture already allows
me to do this in reasonable time.

Bug: b/226576485
Test: Manual testing