### PR TITLE
Add ListModulesEtw

### DIFF
--- a/src/WindowsProcessService/CMakeLists.txt
+++ b/src/WindowsProcessService/CMakeLists.txt
@@ -21,5 +21,6 @@ target_link_libraries(WindowsProcessService PUBLIC
         GrpcProtos
         ObjectUtils
         OrbitBase
+        WindowsTracing
         WindowsUtils)
 

--- a/src/WindowsProcessService/ProcessServiceImpl.cpp
+++ b/src/WindowsProcessService/ProcessServiceImpl.cpp
@@ -80,7 +80,7 @@ Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
                                          GetModuleListResponse* response) {
   std::vector<Module> modules = orbit_windows_utils::ListModules(request->process_id());
   if (modules.empty()) {
-    // Fallback etw module enumeration which involves more work.
+    // Fallback on etw module enumeration which involves more work.
     modules = orbit_windows_tracing::ListModulesEtw(request->process_id());
   }
 

--- a/src/WindowsProcessService/ProcessServiceImpl.cpp
+++ b/src/WindowsProcessService/ProcessServiceImpl.cpp
@@ -19,6 +19,7 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "WindowsTracing/ListModulesETW.h"
 #include "WindowsUtils/FindDebugSymbols.h"
 #include "WindowsUtils/ListModules.h"
 #include "WindowsUtils/ProcessList.h"
@@ -78,6 +79,11 @@ Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
                                          const GetModuleListRequest* request,
                                          GetModuleListResponse* response) {
   std::vector<Module> modules = orbit_windows_utils::ListModules(request->process_id());
+  if (modules.empty()) {
+    // Fallback etw module enumeration which involves more work.
+    modules = orbit_windows_tracing::ListModulesEtw(request->process_id());
+  }
+
   if (modules.empty()) {
     return Status(StatusCode::NOT_FOUND, "Error listing modules");
   }

--- a/src/WindowsTracing/CMakeLists.txt
+++ b/src/WindowsTracing/CMakeLists.txt
@@ -61,6 +61,4 @@ target_link_libraries(WindowsTracingTests PRIVATE
 
 SET_TARGET_PROPERTIES(WindowsTracingTests PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")
 
-register_test(WindowsTracingTests)
-
-
+register_test(WindowsTracingTests PROPERTIES RUN_SERIAL TRUE)

--- a/src/WindowsTracing/CMakeLists.txt
+++ b/src/WindowsTracing/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(WindowsTracing PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})
 
 target_sources(WindowsTracing PUBLIC
+        include/WindowsTracing/ListModulesEtw.h
         include/WindowsTracing/Tracer.h
         include/WindowsTracing/TracerListener.h)
 
@@ -29,6 +30,7 @@ target_sources(WindowsTracing PRIVATE
         EtwEventTypes.h
         KrabsTracer.cpp
         KrabsTracer.h
+        ListModulesEtw.cpp
         Tracer.cpp
         TracerImpl.h
         TracerImpl.cpp)
@@ -37,6 +39,7 @@ target_include_directories(WindowsTracing INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/
 
 target_link_libraries(WindowsTracing PUBLIC
         GrpcProtos
+        Introspection
         ObjectUtils
         OrbitBase
         WindowsUtils
@@ -48,7 +51,8 @@ target_link_libraries(WindowsTracing PUBLIC
 add_executable(WindowsTracingTests)
 
 target_sources(WindowsTracingTests PRIVATE
-        ContextSwitchManagerTest.cpp)
+        ContextSwitchManagerTest.cpp
+        ListModulesEtwTest.cpp)
 
 target_link_libraries(WindowsTracingTests PRIVATE
         WindowsTracing

--- a/src/WindowsTracing/EtwEventTypes.h
+++ b/src/WindowsTracing/EtwEventTypes.h
@@ -59,6 +59,12 @@ static constexpr uint8_t kEtwFileIoReadWriteEventWrite = 68;
 // https://docs.microsoft.com/en-us/windows/win32/etw/stackwalk-event
 static constexpr uint8_t kStackWalkEventStack = 32;
 
+// https://docs.microsoft.com/is-is/windows/win32/etw/image-load
+static constexpr uint8_t kImageLoadEventLoad = 10;
+static constexpr uint8_t kImageLoadEventUnload = 2;
+static constexpr uint8_t kImageLoadEventDcStart = 3;
+static constexpr uint8_t kImageLoadEventDcEnd = 4;
+
 }  // namespace orbit_windows_tracing
 
 #endif  // WINDOWS_TRACING_EVENT_TYPES_H_

--- a/src/WindowsTracing/KrabsTracer.cpp
+++ b/src/WindowsTracing/KrabsTracer.cpp
@@ -7,13 +7,20 @@
 #include <absl/base/casts.h>
 #include <evntrace.h>
 
+#include <filesystem>
 #include <optional>
 
 #include "EtwEventTypes.h"
+#include "ObjectUtils/CoffFile.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Profiling.h"
+#include "OrbitBase/StringConversion.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "WindowsUtils/AdjustTokenPrivilege.h"
+
+// clang-format off
+#include "fileapi.h"
+// clang-format on
 
 namespace orbit_windows_tracing {
 
@@ -21,12 +28,15 @@ using orbit_grpc_protos::Callstack;
 using orbit_grpc_protos::FullCallstackSample;
 using orbit_grpc_protos::SchedulingSlice;
 
-KrabsTracer::KrabsTracer(orbit_grpc_protos::CaptureOptions capture_options,
-                         TracerListener* listener)
-    : capture_options_(std::move(capture_options)),
-      listener_(listener),
-      target_pid_(capture_options_.pid()),
+KrabsTracer::KrabsTracer(uint32_t pid, double sampling_frequency_hz, TracerListener* listener)
+    : KrabsTracer(pid, sampling_frequency_hz, listener, ProviderFlags::kAll) {}
 
+KrabsTracer::KrabsTracer(uint32_t pid, double sampling_frequency_hz, TracerListener* listener,
+                         ProviderFlags providers)
+    : target_pid_(pid),
+      sampling_frequency_hz_(sampling_frequency_hz),
+      listener_(listener),
+      providers_(providers),
       trace_(KERNEL_LOGGER_NAME),
       stack_walk_provider_(EVENT_TRACE_FLAG_PROFILE, krabs::guids::stack_walk) {
   SetTraceProperties();
@@ -44,18 +54,34 @@ void KrabsTracer::SetTraceProperties() {
   trace_.set_trace_properties(&properties);
 }
 
+bool KrabsTracer::ProviderEnabled(ProviderFlags provider) const {
+  return (providers_ & provider) != 0;
+}
+
 void KrabsTracer::EnableProviders() {
-  thread_provider_.add_on_event_callback(
-      [this](const auto& record, const auto& context) { OnThreadEvent(record, context); });
-  trace_.enable(thread_provider_);
+  if (ProviderEnabled(ProviderFlags::kThread)) {
+    thread_provider_.add_on_event_callback(
+        [this](const auto& record, const auto& context) { OnThreadEvent(record, context); });
+    trace_.enable(thread_provider_);
+  }
 
-  context_switch_provider_.add_on_event_callback(
-      [this](const auto& record, const auto& context) { OnThreadEvent(record, context); });
-  trace_.enable(context_switch_provider_);
+  if (ProviderEnabled(ProviderFlags::kContextSwitch)) {
+    context_switch_provider_.add_on_event_callback(
+        [this](const auto& record, const auto& context) { OnThreadEvent(record, context); });
+    trace_.enable(context_switch_provider_);
+  }
 
-  stack_walk_provider_.add_on_event_callback(
-      [this](const auto& record, const auto& context) { OnStackWalkEvent(record, context); });
-  trace_.enable(stack_walk_provider_);
+  if (ProviderEnabled(ProviderFlags::kStackWalk)) {
+    stack_walk_provider_.add_on_event_callback(
+        [this](const auto& record, const auto& context) { OnStackWalkEvent(record, context); });
+    trace_.enable(stack_walk_provider_);
+  }
+
+  if (ProviderEnabled(ProviderFlags::kImageLoad)) {
+    image_load_provider_.add_on_event_callback(
+        [this](const auto& record, const auto& context) { OnImageLoadEvent(record, context); });
+    trace_.enable(image_load_provider_);
+  }
 }
 
 void KrabsTracer::SetIsSystemProfilePrivilegeEnabled(bool value) {
@@ -65,10 +91,8 @@ void KrabsTracer::SetIsSystemProfilePrivilegeEnabled(bool value) {
 
 void KrabsTracer::SetupStackTracing() {
   // Set sampling frequency for ETW trace. Note that the session handle must be 0.
-  const double frequency = capture_options_.samples_per_second();
-  ORBIT_CHECK(frequency >= 0);
-  if (frequency == 0) return;
-  double period_ns = 1'000'000'000.0 / frequency;
+  ORBIT_CHECK(sampling_frequency_hz_ >= 0);
+  double period_ns = 1'000'000'000.0 / sampling_frequency_hz_;
   static uint64_t performance_counter_period_ns = orbit_base::GetPerformanceCounterPeriodNs();
   TRACE_PROFILE_INTERVAL interval = {0};
   interval.Interval = static_cast<ULONG>(period_ns / performance_counter_period_ns);
@@ -178,6 +202,43 @@ void KrabsTracer::OnStackWalkEvent(const EVENT_RECORD& record,
   }
 
   listener_->OnCallstackSample(sample);
+}
+
+void KrabsTracer::OnImageLoadEvent(const EVENT_RECORD& record,
+                                   const krabs::trace_context& context) {
+  krabs::schema schema(record, context.schema_locator);
+  krabs::parser parser(schema);
+
+  if (record.EventHeader.EventDescriptor.Opcode == kImageLoadEventDcStart) {
+    uint32_t pid = parser.parse<uint32_t>(L"ProcessId");
+    if (pid != target_pid_) return;
+    ++stats_.num_image_load_events_for_target_pid;
+
+    orbit_windows_utils::Module module;
+    module.full_path = orbit_base::ToStdString(parser.parse<std::wstring>(L"FileName"));
+    module.name = std::filesystem::path(module.full_path).filename().string();
+    module.file_size = parser.parse<uint64_t>(L"ImageSize");
+    module.address_start = parser.parse<uint64_t>(L"ImageBase");
+    module.address_end = module.address_start + module.file_size;
+
+    auto coff_file_or_error = orbit_object_utils::CreateCoffFile(module.full_path);
+    if (coff_file_or_error.has_value()) {
+      module.build_id = coff_file_or_error.value()->GetBuildId();
+    } else {
+      ORBIT_ERROR("Could not create Coff file for module \"%s\", build-id will be empty",
+                  module.full_path);
+    }
+
+    absl::MutexLock lock{&modules_mutex_};
+    modules_.emplace_back(std::move(module));
+  }
+}
+
+std::vector<orbit_windows_utils::Module> KrabsTracer::GetLoadedModules() const {
+  std::vector<orbit_windows_utils::Module> modules;
+  absl::MutexLock lock{&modules_mutex_};
+  modules = modules_;
+  return modules;
 }
 
 void KrabsTracer::OutputStats() {

--- a/src/WindowsTracing/KrabsTracer.cpp
+++ b/src/WindowsTracing/KrabsTracer.cpp
@@ -240,7 +240,8 @@ void KrabsTracer::OnImageLoadEvent(const EVENT_RECORD& record,
       if (result.has_value()) {
         module.full_path = result.value();
       } else {
-        ORBIT_ERROR("Calling \"DeviceToDrive\": %s", result.error().message());
+        ORBIT_ERROR("Calling \"DeviceToDrive\": %s %s", result.error().message(),
+                    path_converter_->ToString());
       }
     }
 

--- a/src/WindowsTracing/KrabsTracer.h
+++ b/src/WindowsTracing/KrabsTracer.h
@@ -5,6 +5,8 @@
 #ifndef WINDOWS_TRACING_KRABS_TRACER_H_
 #define WINDOWS_TRACING_KRABS_TRACER_H_
 
+#include <absl/synchronization/mutex.h>
+
 #include <krabs/krabs.hpp>
 #include <memory>
 #include <thread>
@@ -12,6 +14,7 @@
 #include "ContextSwitchManager.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "WindowsTracing/TracerListener.h"
+#include "WindowsUtils/ListModules.h"
 
 namespace orbit_windows_tracing {
 
@@ -20,12 +23,25 @@ namespace orbit_windows_tracing {
 // stack traces.
 class KrabsTracer {
  public:
-  KrabsTracer(orbit_grpc_protos::CaptureOptions capture_options, TracerListener* listener);
+  enum ProviderFlags {
+    kThread = 1 << 0,
+    kContextSwitch = 1 << 2,
+    kStackWalk = 1 << 3,
+    kImageLoad = 1 << 4,
+    kAll = kThread | kContextSwitch | kStackWalk | kImageLoad,
+  };
+
+  KrabsTracer(uint32_t pid, double sampling_frequency_hz, TracerListener* listener);
+  KrabsTracer(uint32_t pid, double sampling_frequency_hz, TracerListener* listener,
+              ProviderFlags providers);
+
   KrabsTracer() = delete;
   void Start();
   void Stop();
 
   krabs::kernel_trace& GetTrace() { return trace_; }
+  [[nodiscard]] bool ProviderEnabled(ProviderFlags provider) const;
+  [[nodiscard]] std::vector<orbit_windows_utils::Module> GetLoadedModules() const;
 
  private:
   void SetTraceProperties();
@@ -35,18 +51,21 @@ class KrabsTracer {
   void Run();
   void OnThreadEvent(const EVENT_RECORD& record, const krabs::trace_context& context);
   void OnStackWalkEvent(const EVENT_RECORD& record, const krabs::trace_context& context);
+  void OnImageLoadEvent(const EVENT_RECORD& record, const krabs::trace_context& context);
   void OutputStats();
 
   struct Stats {
     uint64_t num_thread_events = 0;
     uint64_t num_stack_events = 0;
     uint64_t num_stack_events_for_target_pid = 0;
+    uint64_t num_image_load_events_for_target_pid = 0;
   };
 
  private:
-  orbit_grpc_protos::CaptureOptions capture_options_;
-  TracerListener* listener_ = nullptr;
   uint32_t target_pid_ = orbit_base::kInvalidProcessId;
+  double sampling_frequency_hz_ = 0;
+  TracerListener* listener_ = nullptr;
+  ProviderFlags providers_ = ProviderFlags::kAll;
 
   std::unique_ptr<ContextSwitchManager> context_switch_manager_;
   std::unique_ptr<std::thread> trace_thread_;
@@ -56,7 +75,11 @@ class KrabsTracer {
   krabs::kernel::thread_provider thread_provider_;
   krabs::kernel::context_switch_provider context_switch_provider_;
   krabs::kernel_provider stack_walk_provider_;
+  krabs::kernel::image_load_provider image_load_provider_;
   EVENT_TRACE_LOGFILE log_file_ = {0};
+
+  mutable absl::Mutex modules_mutex_;
+  std::vector<orbit_windows_utils::Module> modules_ ABSL_GUARDED_BY(modules_mutex_);
 };
 
 }  // namespace orbit_windows_tracing

--- a/src/WindowsTracing/KrabsTracer.h
+++ b/src/WindowsTracing/KrabsTracer.h
@@ -15,6 +15,7 @@
 #include "OrbitBase/ThreadConstants.h"
 #include "WindowsTracing/TracerListener.h"
 #include "WindowsUtils/ListModules.h"
+#include "WindowsUtils/PathConverter.h"
 
 namespace orbit_windows_tracing {
 
@@ -40,7 +41,7 @@ class KrabsTracer {
   void Stop();
 
   krabs::kernel_trace& GetTrace() { return trace_; }
-  [[nodiscard]] bool ProviderEnabled(ProviderFlags provider) const;
+  [[nodiscard]] bool IsProviderEnabled(ProviderFlags provider) const;
   [[nodiscard]] std::vector<orbit_windows_utils::Module> GetLoadedModules() const;
 
  private:
@@ -80,6 +81,7 @@ class KrabsTracer {
 
   mutable absl::Mutex modules_mutex_;
   std::vector<orbit_windows_utils::Module> modules_ ABSL_GUARDED_BY(modules_mutex_);
+  std::unique_ptr<orbit_windows_utils::PathConverter> path_converter_;
 };
 
 }  // namespace orbit_windows_tracing

--- a/src/WindowsTracing/ListModulesEtw.cpp
+++ b/src/WindowsTracing/ListModulesEtw.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsTracing/ListModulesEtw.h"
+
+#include "Introspection/Introspection.h"
+#include "KrabsTracer.h"
+
+namespace orbit_windows_tracing {
+
+[[nodiscard]] std::vector<orbit_windows_utils::Module> ListModulesEtw(uint32_t pid) {
+  ORBIT_SCOPE_FUNCTION;
+  KrabsTracer krabs_tracer(pid, /*sampling_frequency_hz=*/0, /*listener=*/nullptr,
+                           KrabsTracer::ProviderFlags::kImageLoad);
+  krabs_tracer.Start();
+  krabs_tracer.Stop();
+  return krabs_tracer.GetLoadedModules();
+}
+
+}  // namespace orbit_windows_tracing

--- a/src/WindowsTracing/ListModulesEtwTest.cpp
+++ b/src/WindowsTracing/ListModulesEtwTest.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/str_format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <windows.h>
+
+// clang-format off
+#include <libloaderapi.h>
+// clang-format on
+
+#include <vector>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadUtils.h"
+#include "WindowsTracing/ListModulesEtw.h"
+
+namespace orbit_windows_tracing {
+
+using orbit_windows_utils::Module;
+
+static std::string GetCurrentModulePath() {
+  HMODULE module_handle = NULL;
+  GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)GetCurrentModulePath,
+                    &module_handle);
+  ORBIT_CHECK(module_handle);
+  char module_name[MAX_PATH] = {0};
+  GetModuleFileNameA(module_handle, module_name, MAX_PATH);
+  return module_name;
+}
+
+TEST(ListModules, ContainsCurrentModule) {
+  uint32_t pid = orbit_base::GetCurrentProcessId();
+  std::vector<Module> modules = ListModulesEtw(pid);
+  EXPECT_NE(modules.size(), 0);
+
+  // The full path return by ETW contains the device name, not the drive letter.
+  std::string this_module_name = std::filesystem::path(GetCurrentModulePath()).filename().string();
+  bool found_this_module = false;
+  for (const Module& module : modules) {
+    if (module.name == this_module_name) {
+      found_this_module = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_this_module);
+}
+
+}  // namespace orbit_windows_tracing

--- a/src/WindowsTracing/ListModulesEtwTest.cpp
+++ b/src/WindowsTracing/ListModulesEtwTest.cpp
@@ -26,19 +26,17 @@ using orbit_windows_utils::Module;
 TEST(ListModulesEtw, ContainsCurrentExecutable) {
   uint32_t pid = orbit_base::GetCurrentProcessId();
   std::vector<Module> modules = ListModulesEtw(pid);
-  EXPECT_NE(modules.size(), 0);
+  ASSERT_NE(modules.size(), 0);
 
   std::filesystem::path this_module_path = orbit_base::GetExecutablePath();
   bool found_this_module = false;
   for (const Module& module : modules) {
-    ORBIT_LOG("Module name: %s", module.name);
-    ORBIT_LOG("Module full_path: %s", module.full_path);
-    if (module.full_path == this_module_path) {
-      found_this_module = true;
-      break;
+    if (std::filesystem::path(module.full_path).filename() == this_module_path.filename()) {
+      return;
     }
   }
-  EXPECT_TRUE(found_this_module);
+
+  FAIL() << "ListModulesEtw did not find current executable";
 }
 
 }  // namespace orbit_windows_tracing

--- a/src/WindowsTracing/TracerImpl.cpp
+++ b/src/WindowsTracing/TracerImpl.cpp
@@ -46,7 +46,7 @@ void TracerImpl::SendModulesSnapshot() {
 
   std::vector<Module> modules = orbit_windows_utils::ListModules(pid);
   if (modules.empty()) {
-    // Fallback etw module enumeration which involves more work.
+    // Fallback on etw module enumeration which involves more work.
     modules = ListModulesEtw(pid);
   }
 

--- a/src/WindowsTracing/include/WindowsTracing/ListModulesEtw.h
+++ b/src/WindowsTracing/include/WindowsTracing/ListModulesEtw.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_TRACING_LIST_MODULES_ETW_H_
+#define WINDOWS_TRACING_LIST_MODULES_ETW_H_
+
+#include "WindowsUtils/ListModules.h"
+
+namespace orbit_windows_tracing {
+
+// List all modules of the process identified by "pid" using ETW.
+[[nodiscard]] std::vector<orbit_windows_utils::Module> ListModulesEtw(uint32_t pid);
+
+}  // namespace orbit_windows_tracing
+
+#endif  // WINDOWS_TRACING_LIST_MODULES_H_

--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(WindowsUtils PUBLIC
         include/WindowsUtils/ListModules.h
         include/WindowsUtils/ListThreads.h
         include/WindowsUtils/OpenProcess.h
+        include/WindowsUtils/PathConverter.h
         include/WindowsUtils/ProcessList.h
         include/WindowsUtils/ReadProcessMemory.h
         include/WindowsUtils/SafeHandle.h
@@ -46,6 +47,7 @@ target_sources(WindowsUtils PRIVATE
         ListModules.cpp
         ListThreads.cpp
         OpenProcess.cpp
+        PathConverter.cpp
         ProcessList.cpp
         ReadProcessMemory.cpp
         SafeHandle.cpp
@@ -67,6 +69,7 @@ target_sources(WindowsUtilsTests PRIVATE
         ListModulesTest.cpp
         ListThreadsTest.cpp
         OpenProcessTest.cpp
+        PathConverterTest.cpp
         ProcessListTest.cpp
         ReadProcessMemoryTest.cpp
         SafeHandleTest.cpp

--- a/src/WindowsUtils/ListModules.cpp
+++ b/src/WindowsUtils/ListModules.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 
 #include "ObjectUtils/CoffFile.h"
+#include "OrbitBase/GetLastError.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/StringConversion.h"
 #include "OrbitBase/UniqueResource.h"
@@ -32,7 +33,8 @@ std::vector<Module> ListModules(uint32_t pid) {
   // Take a snapshot of all modules in the specified process.
   module_snap_handle = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
   if (module_snap_handle == INVALID_HANDLE_VALUE) {
-    ORBIT_ERROR("Calling CreateToolhelp32Snapshot for modules");
+    ORBIT_ERROR("Calling CreateToolhelp32Snapshot for modules: %s",
+                orbit_base::GetLastErrorAsString());
     return {};
   }
   SafeHandle handle_closer(module_snap_handle);

--- a/src/WindowsUtils/PathConverter.cpp
+++ b/src/WindowsUtils/PathConverter.cpp
@@ -113,8 +113,23 @@ class PathConverterImpl : public orbit_windows_utils::PathConverter {
         return volume_info.paths[0] + suffix;
       }
     }
-    return ErrorMessage(absl::StrFormat("Could not convert path %s", full_path));
+
+    return ErrorMessage(absl::StrFormat("Could not convert path %s\n %s", full_path, ToString()));
   }
+
+   std::string ToString() const override {
+     std::string summary =
+         absl::StrFormat("PathConverter has %u device names:", device_to_volume_info_map_.size());
+     for (const auto& [device, volume_info] : device_to_volume_info_map_) {
+       std::string paths;
+       for (const std::string& path : volume_info.paths) {
+         paths += path + " ";
+       }
+       summary += absl::StrFormat("device: %s volume: %s paths: %s\n", device,
+                                  volume_info.volume_name, paths);
+     }
+     return summary;
+   }
 
  private:
   absl::flat_hash_map<std::string, VolumeInfo> device_to_volume_info_map_;

--- a/src/WindowsUtils/PathConverter.cpp
+++ b/src/WindowsUtils/PathConverter.cpp
@@ -117,19 +117,19 @@ class PathConverterImpl : public orbit_windows_utils::PathConverter {
     return ErrorMessage(absl::StrFormat("Could not convert path %s\n %s", full_path, ToString()));
   }
 
-   std::string ToString() const override {
-     std::string summary =
-         absl::StrFormat("PathConverter has %u device names:", device_to_volume_info_map_.size());
-     for (const auto& [device, volume_info] : device_to_volume_info_map_) {
-       std::string paths;
-       for (const std::string& path : volume_info.paths) {
-         paths += path + " ";
-       }
-       summary += absl::StrFormat("device: %s volume: %s paths: %s\n", device,
-                                  volume_info.volume_name, paths);
-     }
-     return summary;
-   }
+  std::string ToString() const override {
+    std::string summary =
+        absl::StrFormat("PathConverter has %u device names:", device_to_volume_info_map_.size());
+    for (const auto& [device, volume_info] : device_to_volume_info_map_) {
+      std::string paths;
+      for (const std::string& path : volume_info.paths) {
+        paths += path + " ";
+      }
+      summary += absl::StrFormat("device: %s volume: %s paths: %s\n", device,
+                                 volume_info.volume_name, paths);
+    }
+    return summary;
+  }
 
  private:
   absl::flat_hash_map<std::string, VolumeInfo> device_to_volume_info_map_;

--- a/src/WindowsUtils/PathConverter.cpp
+++ b/src/WindowsUtils/PathConverter.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/PathConverter.h"
+
+#include <Windows.h>
+#include <absl/strings/match.h>
+
+#include <cstring>
+
+#include "OrbitBase/GetLastError.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/UniqueResource.h"
+
+namespace {
+
+using orbit_windows_utils::VolumeInfo;
+
+// https://docs.microsoft.com/en-us/windows/win32/fileio/displaying-volume-paths
+ErrorMessageOr<std::vector<std::string>> GetVolumePaths(const char* volume) {
+  DWORD buffer_size = 1024;
+  std::string paths(buffer_size, 0);
+
+  // Obtain all of the paths for this volume.
+  // From Microsoft's documentation, regarding the passed in buffer:
+  // "A pointer to a buffer that receives the list of drive letters and mounted folder paths. The
+  // list is an array of null-terminated strings terminated by an additional NULL character. If the
+  // buffer is not large enough to hold the complete list, the buffer holds as much of the list as
+  // possible."
+  BOOL success = GetVolumePathNamesForVolumeNameA(volume, paths.data(), buffer_size, &buffer_size);
+  if (!success && GetLastError() == ERROR_MORE_DATA) {
+    // The buffer was too small, try again with the new suggested size.
+    paths = std::string(buffer_size, 0);
+    success = GetVolumePathNamesForVolumeNameA(volume, paths.data(), buffer_size, &buffer_size);
+  }
+
+  if (!success) {
+    return orbit_base::GetLastErrorAsErrorMessage("GetVolumePathNamesForVolumeNameA");
+  }
+
+  // Return paths as vector.
+  std::vector<std::string> path_vector;
+  for (const char* path = paths.c_str(); path[0] != '\0'; path += std::strlen(path) + 1) {
+    path_vector.push_back(path);
+  }
+  return path_vector;
+}
+
+// Return a map of device names to VolumeInfo objects.
+ErrorMessageOr<absl::flat_hash_map<std::string, VolumeInfo>> BuildDeviceToVolumeInfoMap() {
+  absl::flat_hash_map<std::string, VolumeInfo> device_to_volume_info_map;
+
+  // Enumerate all volumes in the system.
+  char volume_name[MAX_PATH] = "";
+  HANDLE find_handle = FindFirstVolumeA(volume_name, ARRAYSIZE(volume_name));
+  if (find_handle == INVALID_HANDLE_VALUE) {
+    return orbit_base::GetLastErrorAsErrorMessage("FindFirstVolumeA");
+  }
+  orbit_base::unique_resource handle_closer(find_handle, FindVolumeClose);
+
+  while (true) {
+    // Validate volume name.
+    size_t volume_name_length = std::strlen(volume_name);
+    size_t last_index = std::strlen(volume_name) - 1;
+    if (volume_name[0] != '\\' || volume_name[1] != '\\' || volume_name[2] != '?' ||
+        volume_name[3] != '\\' || volume_name[last_index] != '\\') {
+      return ErrorMessage(
+          absl::StrFormat("FindFirstVolumeA/FindNextVolumeA returned a bad path: %s", volume_name));
+    }
+
+    char device_name[MAX_PATH] = "";
+    // QueryDosDeviceA does not allow a trailing backslash, so temporarily remove it.
+    volume_name[last_index] = '\0';
+    // Get device name from volume name, skipping the "\\?\" prefix.
+    ORBIT_CHECK(volume_name_length > 4);
+    if (QueryDosDeviceA(&volume_name[4], device_name, ARRAYSIZE(device_name)) == 0) {
+      return orbit_base::GetLastErrorAsErrorMessage("QueryDosDeviceA");
+    }
+    volume_name[last_index] = '\\';
+
+    VolumeInfo volume_info;
+    volume_info.device_name = absl::StrFormat("%s%s", device_name, "\\");
+    volume_info.volume_name = volume_name;
+    OUTCOME_TRY(volume_info.paths, GetVolumePaths(volume_name));
+    device_to_volume_info_map.emplace(volume_info.device_name, volume_info);
+
+    //  Move on to the next volume.
+    if (!FindNextVolumeA(find_handle, volume_name, ARRAYSIZE(volume_name))) {
+      if (GetLastError() != ERROR_NO_MORE_FILES) {
+        return orbit_base::GetLastErrorAsErrorMessage("FindNextVolumeA");
+      }
+      break;
+    }
+  }
+
+  return device_to_volume_info_map;
+}
+
+class PathConverterImpl : public orbit_windows_utils::PathConverter {
+ public:
+  PathConverterImpl(absl::flat_hash_map<std::string, VolumeInfo> device_to_volume_info_map)
+      : device_to_volume_info_map_(std::move(device_to_volume_info_map)) {}
+
+  const absl::flat_hash_map<std::string, VolumeInfo>& GetDeviceToVolumeInfoMap() override {
+    return device_to_volume_info_map_;
+  }
+
+  ErrorMessageOr<std::string> DeviceToDrive(std::string_view full_path) override {
+    for (const auto& [device, volume_info] : device_to_volume_info_map_) {
+      if (absl::StartsWith(full_path, device) && !volume_info.paths.empty()) {
+        std::string suffix(full_path.begin() + device.size(), full_path.end());
+        return volume_info.paths[0] + suffix;
+      }
+    }
+    return ErrorMessage(absl::StrFormat("Could not convert path %s", full_path));
+  }
+
+ private:
+  absl::flat_hash_map<std::string, VolumeInfo> device_to_volume_info_map_;
+};
+
+}  // namespace
+
+namespace orbit_windows_utils {
+
+ErrorMessageOr<std::unique_ptr<PathConverter>> PathConverter::Create() {
+  OUTCOME_TRY(auto device_to_volume_info_map, BuildDeviceToVolumeInfoMap());
+  return std::make_unique<PathConverterImpl>(device_to_volume_info_map);
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/PathConverterTest.cpp
+++ b/src/WindowsUtils/PathConverterTest.cpp
@@ -22,14 +22,7 @@ TEST(PathConverter, ListDevices) {
       converter->GetDeviceToVolumeInfoMap();
 
   ASSERT_FALSE(device_to_volume_info_map.empty());
-
-  for (const auto& [device, volume_info] : device_to_volume_info_map) {
-    std::string paths;
-    for (const std::string& path : volume_info.paths) {
-      paths += path + " ";
-    }
-    ORBIT_LOG("device: %s volume: %s paths: %s", device, volume_info.volume_name, paths);
-  }
+  ORBIT_LOG("%s", converter->ToString());
 }
 
 TEST(PathConverter, ContainsCurrentDrive) {

--- a/src/WindowsUtils/PathConverterTest.cpp
+++ b/src/WindowsUtils/PathConverterTest.cpp
@@ -14,28 +14,20 @@ using orbit_test_utils::HasValue;
 using orbit_windows_utils::PathConverter;
 
 TEST(PathConverter, ListDevices) {
-  ErrorMessageOr<std::unique_ptr<PathConverter>> converter_or_error = PathConverter::Create();
-  ASSERT_THAT(converter_or_error, HasValue());
-  const std::unique_ptr<PathConverter>& converter = converter_or_error.value();
-
+  std::unique_ptr<PathConverter> path_converter = PathConverter::Create();
   const absl::flat_hash_map<std::string, VolumeInfo>& device_to_volume_info_map =
-      converter->GetDeviceToVolumeInfoMap();
-
+      path_converter->GetDeviceToVolumeInfoMap();
   ASSERT_FALSE(device_to_volume_info_map.empty());
-  ORBIT_LOG("%s", converter->ToString());
 }
 
 TEST(PathConverter, ContainsCurrentDrive) {
-  ErrorMessageOr<std::unique_ptr<PathConverter>> converter_or_error = PathConverter::Create();
-  ASSERT_THAT(converter_or_error, HasValue());
-  const std::unique_ptr<PathConverter>& converter = converter_or_error.value();
+  std::unique_ptr<PathConverter> path_converter = PathConverter::Create();
   const absl::flat_hash_map<std::string, VolumeInfo>& device_to_volume_info_map =
-      converter->GetDeviceToVolumeInfoMap();
+      path_converter->GetDeviceToVolumeInfoMap();
 
   std::string current_drive = orbit_base::GetExecutablePath().root_name().string() + "\\";
 
   for (const auto& [device, volume_info] : device_to_volume_info_map) {
-    std::string paths;
     for (const std::string& path : volume_info.paths) {
       if (path == current_drive) {
         return;
@@ -43,7 +35,8 @@ TEST(PathConverter, ContainsCurrentDrive) {
     }
   }
 
-  FAIL() << "device_to_volume_info_map does not contain current drive.";
+  FAIL() << "device_to_volume_info_map does not contain current drive.\n"
+         << path_converter->ToString();
 }
 
 }  // namespace orbit_windows_utils

--- a/src/WindowsUtils/PathConverterTest.cpp
+++ b/src/WindowsUtils/PathConverterTest.cpp
@@ -15,11 +15,13 @@ using orbit_windows_utils::PathConverter;
 
 TEST(PathConverter, ListDevices) {
   ErrorMessageOr<std::unique_ptr<PathConverter>> converter_or_error = PathConverter::Create();
-  EXPECT_THAT(converter_or_error, HasValue());
+  ASSERT_THAT(converter_or_error, HasValue());
   const std::unique_ptr<PathConverter>& converter = converter_or_error.value();
 
   const absl::flat_hash_map<std::string, VolumeInfo>& device_to_volume_info_map =
       converter->GetDeviceToVolumeInfoMap();
+
+  ASSERT_FALSE(device_to_volume_info_map.empty());
 
   for (const auto& [device, volume_info] : device_to_volume_info_map) {
     std::string paths;
@@ -32,13 +34,12 @@ TEST(PathConverter, ListDevices) {
 
 TEST(PathConverter, ContainsCurrentDrive) {
   ErrorMessageOr<std::unique_ptr<PathConverter>> converter_or_error = PathConverter::Create();
-  EXPECT_THAT(converter_or_error, HasValue());
+  ASSERT_THAT(converter_or_error, HasValue());
   const std::unique_ptr<PathConverter>& converter = converter_or_error.value();
   const absl::flat_hash_map<std::string, VolumeInfo>& device_to_volume_info_map =
       converter->GetDeviceToVolumeInfoMap();
 
   std::string current_drive = orbit_base::GetExecutablePath().root_name().string() + "\\";
-  bool found_root_path = false;
 
   for (const auto& [device, volume_info] : device_to_volume_info_map) {
     std::string paths;
@@ -49,7 +50,7 @@ TEST(PathConverter, ContainsCurrentDrive) {
     }
   }
 
-  ASSERT_TRUE(found_root_path);
+  FAIL() << "device_to_volume_info_map does not contain current drive.";
 }
 
 }  // namespace orbit_windows_utils

--- a/src/WindowsUtils/PathConverterTest.cpp
+++ b/src/WindowsUtils/PathConverterTest.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/Logging.h"
+#include "TestUtils/TestUtils.h"
+#include "WindowsUtils/PathConverter.h"
+namespace orbit_windows_utils {
+
+using orbit_test_utils::HasValue;
+using orbit_windows_utils::PathConverter;
+
+TEST(PathConverter, ListDevices) {
+  ErrorMessageOr<std::unique_ptr<PathConverter>> converter_or_error = PathConverter::Create();
+  EXPECT_THAT(converter_or_error, HasValue());
+  const std::unique_ptr<PathConverter>& converter = converter_or_error.value();
+
+  const absl::flat_hash_map<std::string, VolumeInfo>& device_to_volume_info_map =
+      converter->GetDeviceToVolumeInfoMap();
+
+  for (const auto& [device, volume_info] : device_to_volume_info_map) {
+    std::string paths;
+    for (const std::string& path : volume_info.paths) {
+      paths += path + " ";
+    }
+    ORBIT_LOG("device: %s volume: %s paths: %s", device, volume_info.volume_name, paths);
+  }
+}
+
+TEST(PathConverter, ContainsCurrentDrive) {
+  ErrorMessageOr<std::unique_ptr<PathConverter>> converter_or_error = PathConverter::Create();
+  EXPECT_THAT(converter_or_error, HasValue());
+  const std::unique_ptr<PathConverter>& converter = converter_or_error.value();
+  const absl::flat_hash_map<std::string, VolumeInfo>& device_to_volume_info_map =
+      converter->GetDeviceToVolumeInfoMap();
+
+  std::string current_drive = orbit_base::GetExecutablePath().root_name().string() + "\\";
+  bool found_root_path = false;
+
+  for (const auto& [device, volume_info] : device_to_volume_info_map) {
+    std::string paths;
+    for (const std::string& path : volume_info.paths) {
+      if (path == current_drive) {
+        return;
+      }
+    }
+  }
+
+  ASSERT_TRUE(found_root_path);
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/include/WindowsUtils/PathConverter.h
+++ b/src/WindowsUtils/include/WindowsUtils/PathConverter.h
@@ -30,7 +30,7 @@ struct PathConverter {
   [[nodiscard]] virtual std::string ToString() const = 0;
 
   // Create a converter.
-  static ErrorMessageOr<std::unique_ptr<PathConverter>> Create();
+  static std::unique_ptr<PathConverter> Create();
 };
 
 }  // namespace orbit_windows_utils

--- a/src/WindowsUtils/include/WindowsUtils/PathConverter.h
+++ b/src/WindowsUtils/include/WindowsUtils/PathConverter.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_PATH_CONVERTER_H_
+#define WINDOWS_UTILS_PATH_CONVERTER_H_
+
+#include <absl/container/flat_hash_map.h>
+
+#include <string>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_windows_utils {
+
+struct VolumeInfo {
+  std::string volume_name;
+  std::string device_name;
+  std::vector<std::string> paths;
+};
+
+struct PathConverter {
+  // Transforms an input of the form "/Device/..." to "C:/..." using the first matching path.
+  virtual ErrorMessageOr<std::string> DeviceToDrive(std::string_view full_path) = 0;
+
+  // Return a map of device names to VolumeInfo objects.
+  virtual const absl::flat_hash_map<std::string, VolumeInfo>& GetDeviceToVolumeInfoMap() = 0;
+
+  // Create a converter.
+  static ErrorMessageOr<std::unique_ptr<PathConverter>> Create();
+};
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_DEVICE_TO_DRIVE_H_

--- a/src/WindowsUtils/include/WindowsUtils/PathConverter.h
+++ b/src/WindowsUtils/include/WindowsUtils/PathConverter.h
@@ -26,6 +26,9 @@ struct PathConverter {
   // Return a map of device names to VolumeInfo objects.
   virtual const absl::flat_hash_map<std::string, VolumeInfo>& GetDeviceToVolumeInfoMap() = 0;
 
+  // Return a summary of the path converter as string.
+  [[nodiscard]] virtual std::string ToString() const = 0;
+
   // Create a converter.
   static ErrorMessageOr<std::unique_ptr<PathConverter>> Create();
 };

--- a/src/WindowsUtils/include/WindowsUtils/PathConverter.h
+++ b/src/WindowsUtils/include/WindowsUtils/PathConverter.h
@@ -20,7 +20,7 @@ struct VolumeInfo {
 };
 
 struct PathConverter {
-  // Transforms an input of the form "/Device/..." to "C:/..." using the first matching path.
+  // Transform an input of the form "\Device\HarddiskVolumeN\..." to "C:\...".
   virtual ErrorMessageOr<std::string> DeviceToDrive(std::string_view full_path) = 0;
 
   // Return a map of device names to VolumeInfo objects.


### PR DESCRIPTION
For certain "protected" processes, using "CreateToolhelp32Snapshot"
fails and we can't enumerate modules. When that's the case, fallback to
ETW which returns the modules fine. We keep the original implementation
for performance as setting an ETW trace is quite costly.