### PR TITLE
Fix leaf function patching when requiring red zone

### DIFF
--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -34,7 +34,7 @@ using orbit_grpc_protos::Callstack;
 //     (b) We are in a leaf function that modified $rbp. The complete callchain is broken and should
 //         be reported as unwinding error.
 // As libunwindstack does not report us the canonical frame address (CFA) from an unwinding step, we
-// can not differentiate between (2a) and (2b) reliably. However, we do perform the following
+// cannot differentiate between (2a) and (2b) reliably. However, we do perform the following
 // validity checks (for the reasoning remember that the stack grows downwards):
 // (I)   If the CFA is computed using $rbp + 16, we know the $rbp was correct, i.e. case (2a)
 // (II)  If $rbp is below $rsp, $rbp is not a frame pointer, i.e. case (2b)
@@ -82,8 +82,8 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
       event_data->pid, current_maps->Get(), event_data->GetRegisters(), event_data->GetStackData(),
       std::min<uint64_t>(stack_size, stack_dump_size_), true, /*max_frames=*/1);
 
-  // If unwinding a single frame yields a success, we are in the outer-most frame, i.e. don't have
-  // a caller to patch in.
+  // If unwinding a single frame yields a success, we are in the outer-most frame, i.e. we don't
+  // have a caller to patch in.
   if (libunwindstack_result.IsSuccess()) {
     return Callstack::kComplete;
   }
@@ -106,7 +106,7 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
   if (new_rbp != rbp) {
     // If the $rbp after unwinding is below the sampled $rbp, the sampled $rbp could not be a valid
     // frame pointer (remember the stack grows downwards).
-    // Note, that in addition to this check, we also check if the complete callchain is in
+    // Note that, in addition to this check, we also check if the complete callchain is in
     // executable code in the UprobesUnwindingVisitor.
     if (new_rbp < rbp) {
       return Callstack::kFramePointerUnwindingError;

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -122,8 +122,7 @@ LibunwindstackResult LibunwindstackUnwinderImpl::Unwind(
                 unwinder.LastErrorAddress());
   }
 #endif
-
-  return LibunwindstackResult{unwinder.ConsumeFrames(), unwinder.LastErrorCode()};
+  return LibunwindstackResult{unwinder.ConsumeFrames(), std::move(regs), unwinder.LastErrorCode()};
 }
 
 // This functions detects if a frame pointer register was set in the given program counter using

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -9,6 +9,7 @@
 #include <unwindstack/Error.h>
 #include <unwindstack/MachineX86_64.h>
 #include <unwindstack/Maps.h>
+#include <unwindstack/RegsX86_64.h>
 #include <unwindstack/Unwinder.h>
 
 #include <array>
@@ -20,7 +21,6 @@
 #include <vector>
 
 #include "OrbitBase/Result.h"
-#include "unwindstack/RegsX86_64.h"
 
 namespace orbit_linux_tracing {
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -20,17 +20,20 @@
 #include <vector>
 
 #include "OrbitBase/Result.h"
+#include "unwindstack/RegsX86_64.h"
 
 namespace orbit_linux_tracing {
 
 class LibunwindstackResult {
  public:
   explicit LibunwindstackResult(
-      std::vector<unwindstack::FrameData> frames,
+      std::vector<unwindstack::FrameData> frames, unwindstack::RegsX86_64 regs,
       unwindstack::ErrorCode error_code = unwindstack::ErrorCode::ERROR_NONE)
-      : frames_{std::move(frames)}, error_code_{error_code} {}
+      : frames_{std::move(frames)}, regs_{std::move(regs)}, error_code_{error_code} {}
 
   [[nodiscard]] const std::vector<unwindstack::FrameData>& frames() const { return frames_; }
+
+  [[nodiscard]] const unwindstack::RegsX86_64& regs() const { return regs_; }
 
   [[nodiscard]] unwindstack::ErrorCode error_code() const { return error_code_; }
 
@@ -38,6 +41,7 @@ class LibunwindstackResult {
 
  private:
   std::vector<unwindstack::FrameData> frames_;
+  unwindstack::RegsX86_64 regs_;
   unwindstack::ErrorCode error_code_;
 };
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -296,15 +296,15 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
   // perf_event_open to give us "almost" correct callstacks (the caller of the leaf function will be
   // missing). We do a plausibility check for this assumption by checking if the callstack only
   // contains executable code.
-  // TODO(b/187690455): As soon as we actually have frame pointers in all non-leaf functions, we can
-  //  report an unwinding error here. Till that point this check will always fail, because the
-  //  caller of __libc_start_main will be invalid since libc doesn't have frame-pointers. This
-  //  prevents us from testing the current implementation, which will have "almost" correct
-  //  callstack.
   for (uint64_t frame_index = 1; frame_index < event_data.GetCallchainSize(); ++frame_index) {
     unwindstack::MapInfo* map_info = current_maps_->Find(event_data.GetCallchain()[frame_index]);
     if (map_info == nullptr || (map_info->flags() & PROT_EXEC) == 0) {
-      break;
+      if (unwind_error_counter_ != nullptr) {
+        ++(*unwind_error_counter_);
+      }
+      callstack->set_type(Callstack::kFramePointerUnwindingError);
+      callstack->add_pcs(top_ip);
+      listener_->OnCallstackSample(std::move(sample));
     }
   }
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -305,6 +305,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
       callstack->set_type(Callstack::kFramePointerUnwindingError);
       callstack->add_pcs(top_ip);
       listener_->OnCallstackSample(std::move(sample));
+      return;
     }
   }
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -542,7 +542,7 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
       .WillOnce(Return(
-          LibunwindstackResult{libunwindstack_callstack, unwindstack::ErrorCode::ERROR_NONE}));
+          LibunwindstackResult{libunwindstack_callstack, {}, unwindstack::ErrorCode::ERROR_NONE}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -595,7 +595,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitEmptyStackSampleWithoutUprobesDoesNothi
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
       .WillOnce(Return(
-          LibunwindstackResult{empty_callstack, unwindstack::ErrorCode::ERROR_MEMORY_INVALID}));
+          LibunwindstackResult{empty_callstack, {}, unwindstack::ErrorCode::ERROR_MEMORY_INVALID}));
 
   EXPECT_CALL(listener_, OnCallstackSample).Times(0);
 
@@ -623,8 +623,8 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
-      .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
-                                            unwindstack::ErrorCode::ERROR_MEMORY_INVALID}));
+      .WillOnce(Return(LibunwindstackResult{
+          libunwindstack_callstack, {}, unwindstack::ErrorCode::ERROR_MEMORY_INVALID}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -669,8 +669,8 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
-      .WillOnce(
-          Return(LibunwindstackResult{incomplete_callstack, unwindstack::ErrorCode::ERROR_NONE}));
+      .WillOnce(Return(
+          LibunwindstackResult{incomplete_callstack, {}, unwindstack::ErrorCode::ERROR_NONE}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -713,7 +713,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleWithinUprobeSendsInUprobesCa
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
-      .WillOnce(Return(LibunwindstackResult{callstack, unwindstack::ErrorCode::ERROR_NONE}));
+      .WillOnce(Return(LibunwindstackResult{callstack, {}, unwindstack::ErrorCode::ERROR_NONE}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -758,7 +758,7 @@ TEST_F(
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
-      .WillOnce(Return(LibunwindstackResult{callstack, unwindstack::ErrorCode::ERROR_NONE}));
+      .WillOnce(Return(LibunwindstackResult{callstack, {}, unwindstack::ErrorCode::ERROR_NONE}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -793,7 +793,7 @@ TEST_F(
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
-      .WillOnce(Return(LibunwindstackResult{callstack, unwindstack::ErrorCode::ERROR_NONE}));
+      .WillOnce(Return(LibunwindstackResult{callstack, {}, unwindstack::ErrorCode::ERROR_NONE}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -840,7 +840,7 @@ TEST_F(
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
-      .WillOnce(Return(LibunwindstackResult{callstack, unwindstack::ErrorCode::ERROR_NONE}));
+      .WillOnce(Return(LibunwindstackResult{callstack, {}, unwindstack::ErrorCode::ERROR_NONE}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -894,7 +894,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleStoppedAtUprobesSendsPatchin
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
-      .WillOnce(Return(LibunwindstackResult{callstack, unwindstack::ErrorCode::ERROR_NONE}));
+      .WillOnce(Return(LibunwindstackResult{callstack, {}, unwindstack::ErrorCode::ERROR_NONE}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -938,7 +938,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
-      .WillOnce(Return(LibunwindstackResult{callstack, unwindstack::ErrorCode::ERROR_NONE}));
+      .WillOnce(Return(LibunwindstackResult{callstack, {}, unwindstack::ErrorCode::ERROR_NONE}));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));


### PR DESCRIPTION
Libunwindstack will remove "speculative" frames, when
two unwinding errors in a row occurs.
There are special situations (ret instruction), where
the unwind information requires reading from the redzone
(rbp in that case), but unwinding actually works perfectly
fine (as rbp is actually not modified). For full unwinding,
libunwindstack will recover and actually completely report
the callstack. However, for leaf function patching, we
only passed in rbp-rsp, so unwinding the second frame will
fail. Libunwindstack will assume the "speculative" frame
was incorrect and removes this.
For the leaf function patching this means, we receive only
one frame from libunwindstack, thus, no need to patch.

This change fixes this issue, by taking a completely new
approach to leaf function patching:
We only unwind one frame from libunwindstack (i.e. the frame
with the instruction pointer), but also read the updated
registers after that unwinding step.
In particular, if rbp was not changed during unwinding,
we know, this was a leaf function, and we can patch in
the updated "pc" entry from the registers, which contains
the "return address".
If, rbp was changed, this could either be an unwinding error,
or a function with frame pointers. We retain our heuristics
to detect unwinding errors and actually send unwinding
errors when non-executable code is on the callstack.

To be still able to handle cases, where the collected
callstack is too small, to actually unwind, but we know
that the sampled function has a frame pointer, we keep
the HasFramePointerSet functionality.

Unfornately, libunwindstack does not report the canonical
frame address. Otherwise, we would have been able to actually
tell if the function had frame pointers set (there could
be cases were CFA does not get computed by $rbp + 16, but
the evaluated value is still $rbp+16).

A potential follow-up would be to improve HasFramePointerSet
such that it computes CFA instead of matching the computation
rule.

Bug: http://b/228428930
Test: Run tests & manually inspect callstacks in samples