### PR TITLE
Expose "potentially broken" frames

### DIFF
--- a/src/ClientData/include/ClientData/CallstackInfo.h
+++ b/src/ClientData/include/ClientData/CallstackInfo.h
@@ -26,6 +26,8 @@ class CallstackInfo {
   [[nodiscard]] CallstackType type() const { return type_; }
   void set_type(CallstackType type) { type_ = type; }
 
+  bool IsUnwindingError() const { return type_ != CallstackType::kComplete; }
+
   friend bool operator==(const CallstackInfo& lhs, const CallstackInfo& rhs) {
     return lhs.type_ == rhs.type_ && lhs.frames_ == rhs.frames_;
   }

--- a/src/ClientData/include/ClientData/CallstackInfo.h
+++ b/src/ClientData/include/ClientData/CallstackInfo.h
@@ -26,7 +26,7 @@ class CallstackInfo {
   [[nodiscard]] CallstackType type() const { return type_; }
   void set_type(CallstackType type) { type_ = type; }
 
-  bool IsUnwindingError() const { return type_ != CallstackType::kComplete; }
+  [[nodiscard]] bool IsUnwindingError() const { return type_ != CallstackType::kComplete; }
 
   friend bool operator==(const CallstackInfo& lhs, const CallstackInfo& rhs) {
     return lhs.type_ == rhs.type_ && lhs.frames_ == rhs.frames_;

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -211,6 +211,12 @@ void CallstackDataView::SetFunctionsToHighlight(
 
 bool CallstackDataView::GetDisplayColor(int row, int /*column*/, unsigned char& red,
                                         unsigned char& green, unsigned char& blue) {
+  if (callstack_->IsUnwindingError() && row != 0) {
+    red = 255;
+    green = 128;
+    blue = 0;
+    return true;
+  }
   CallstackDataViewFrame frame = GetFrameFromRow(row);
   if (functions_to_highlight_.contains(frame.address)) {
     red = 200;

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -16,6 +16,7 @@
 #include "ClientData/CaptureData.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ModuleAndFunctionLookup.h"
+#include "CoreMath.h"
 #include "DataViews/DataViewType.h"
 #include "DataViews/FunctionsDataView.h"
 #include "OrbitBase/Append.h"
@@ -211,10 +212,12 @@ void CallstackDataView::SetFunctionsToHighlight(
 
 bool CallstackDataView::GetDisplayColor(int row, int /*column*/, unsigned char& red,
                                         unsigned char& green, unsigned char& blue) {
+  // Row "0" refers to the program counter and is always "correct".
   if (callstack_->IsUnwindingError() && row != 0) {
-    red = 255;
-    green = 128;
-    blue = 0;
+    static const Color kUnwindingErrorColor{255, 128, 0, 255};
+    red = kUnwindingErrorColor[0];
+    green = kUnwindingErrorColor[1];
+    blue = kUnwindingErrorColor[2];
     return true;
   }
   CallstackDataViewFrame frame = GetFrameFromRow(row);

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -98,10 +98,10 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
                  uint64_t function_id);
   void OnUretprobes(uint64_t timestamp_ns, pid_t pid, pid_t tid, std::optional<uint64_t> ax);
 
-  void HandleErrorCasesAndPatchStackSample(orbit_grpc_protos::Callstack* callstack,
-                                           const LibunwindstackResult& libunwindstack_result);
-  void HandleErrorCasesAndPatchCallchain(orbit_grpc_protos::Callstack* callstack,
-                                         const CallchainSamplePerfEventData& event_data);
+  [[nodiscard]] orbit_grpc_protos::Callstack::CallstackType ComputeCallstackTypeFromStackSample(
+      const LibunwindstackResult& libunwindstack_result);
+  [[nodiscard]] orbit_grpc_protos::Callstack::CallstackType
+  ComputeCallstackTypeFromCallchainAndPatch(const CallchainSamplePerfEventData& event_data);
 
   TracerListener* listener_;
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "GrpcProtos/capture.pb.h"
 #include "LeafFunctionCallManager.h"
 #include "LibunwindstackMaps.h"
 #include "LibunwindstackUnwinder.h"
@@ -96,6 +97,11 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
                  std::optional<perf_event_sample_regs_user_sp_ip_arguments> registers,
                  uint64_t function_id);
   void OnUretprobes(uint64_t timestamp_ns, pid_t pid, pid_t tid, std::optional<uint64_t> ax);
+
+  void HandleErrorCasesAndPatchStackSample(orbit_grpc_protos::Callstack* callstack,
+                                           const LibunwindstackResult& libunwindstack_result);
+  void HandleErrorCasesAndPatchCallchain(orbit_grpc_protos::Callstack* callstack,
+                                         const CallchainSamplePerfEventData& event_data);
 
   TracerListener* listener_;
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -613,7 +613,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitEmptyStackSampleWithoutUprobesDoesNothi
 }
 
 TEST_F(UprobesUnwindingVisitorTest,
-       VisitInvalidStackSampleWithoutUprobesSendsUnwindingErrorAndAddressInfo) {
+       VisitInvalidStackSampleWithoutUprobesSendsUnwindingErrorAndAddressInfos) {
   StackSamplePerfEvent event = BuildFakeStackSamplePerfEvent();
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillRepeatedly(Return());
@@ -643,7 +643,6 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  // On unwinding errors, only the first frame is added to the Callstack.
   EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
               ElementsAre(kTargetAddress1, kTargetAddress2));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
@@ -665,7 +664,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 }
 
 TEST_F(UprobesUnwindingVisitorTest,
-       VisitSingleFrameStackSampleWithoutUprobesSendsUnwindingErrorAndAddressInfo) {
+       VisitSingleFrameStackSampleWithoutUprobesSendsUnwindingErrorAndAddressInfos) {
   StackSamplePerfEvent event = BuildFakeStackSamplePerfEvent();
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -1284,7 +1284,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitPatchableCallchainSampleSendsCompleteCa
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   auto fake_patch_callchain = [](pid_t /*tid*/, uint64_t* callchain, uint64_t callchain_size,
-                                 orbit_linux_tracing::LibunwindstackMaps*
+                                 orbit_linux_tracing::LibunwindstackMaps *
                                  /*maps*/) -> bool {
     ORBIT_CHECK(callchain != nullptr);
     ORBIT_CHECK(callchain_size == 4);
@@ -1373,7 +1373,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   auto fake_patch_caller_of_leaf_function = [](const CallchainSamplePerfEventData* event_data,
                                                LibunwindstackMaps* /*maps*/,
-                                               orbit_linux_tracing::LibunwindstackUnwinder*
+                                               orbit_linux_tracing::LibunwindstackUnwinder *
                                                /*unwinder*/) -> Callstack::CallstackType {
     ORBIT_CHECK(event_data != nullptr);
     std::vector<uint64_t> patched_callchain;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -634,7 +634,7 @@ TEST_F(UprobesUnwindingVisitorTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(listener_, OnAddressInfo).Times(1).WillRepeatedly(Invoke(save_address_info));
+  EXPECT_CALL(listener_, OnAddressInfo).Times(2).WillRepeatedly(Invoke(save_address_info));
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -644,15 +644,21 @@ TEST_F(UprobesUnwindingVisitorTest,
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
   // On unwinding errors, only the first frame is added to the Callstack.
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kTargetAddress2));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kDwarfUnwindingError);
-  EXPECT_THAT(actual_address_infos,
-              UnorderedElementsAre(AllOf(
-                  Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
-                  Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
-                  Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
-                  Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
+  EXPECT_THAT(
+      actual_address_infos,
+      UnorderedElementsAre(
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress2),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName2),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
 
   EXPECT_EQ(unwinding_errors, 1);
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
@@ -723,7 +729,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleWithinUprobeSendsInUprobesCa
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(listener_, OnAddressInfo).Times(1).WillRepeatedly(Invoke(save_address_info));
+  EXPECT_CALL(listener_, OnAddressInfo).Times(2).WillRepeatedly(Invoke(save_address_info));
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -732,15 +738,20 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleWithinUprobeSendsInUprobesCa
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kUprobesMapsStart));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kUprobesMapsStart, kTargetAddress2));
   EXPECT_EQ(actual_callstack_sample.callstack().type(), orbit_grpc_protos::Callstack::kInUprobes);
   EXPECT_THAT(
       actual_address_infos,
       UnorderedElementsAre(
           AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kUprobesMapsStart),
-                Property(&orbit_grpc_protos::FullAddressInfo::function_name, "[uprobes]"),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kUprobesName),
                 Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
-                Property(&orbit_grpc_protos::FullAddressInfo::module_name, "[uprobes]"))));
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kUprobesName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress2),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName2),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
 
   EXPECT_EQ(unwinding_errors, 0);
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 1);
@@ -763,7 +774,12 @@ TEST_F(
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
 
-  EXPECT_CALL(listener_, OnAddressInfo).Times(0);
+  std::vector<orbit_grpc_protos::FullAddressInfo> actual_address_infos;
+  auto save_address_info =
+      [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
+        actual_address_infos.push_back(std::move(actual_address_info));
+      };
+  EXPECT_CALL(listener_, OnAddressInfo).Times(2).WillRepeatedly(Invoke(save_address_info));
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -772,9 +788,23 @@ TEST_F(
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kEntryTrampolineAddress));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kEntryTrampolineAddress, kTargetAddress2));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kInUserSpaceInstrumentation);
+  EXPECT_THAT(
+      actual_address_infos,
+      UnorderedElementsAre(
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address,
+                         kEntryTrampolineAddress),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name,
+                         kEntryTrampolineFunctionName),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, "")),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress2),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName2),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
 
   EXPECT_EQ(unwinding_errors, 0);
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
@@ -803,7 +833,7 @@ TEST_F(
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(listener_, OnAddressInfo).Times(1).WillRepeatedly(Invoke(save_address_info));
+  EXPECT_CALL(listener_, OnAddressInfo).Times(4).WillRepeatedly(Invoke(save_address_info));
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -814,15 +844,34 @@ TEST_F(
 
   // While this is a Callstack::kInUserSpaceInstrumentation, the innermost frame we used is still
   // one of the "regular" frames in the target, i.e., kFrame1.
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kUserSpaceLibraryAddress, kTargetAddress3,
+                          kEntryTrampolineAddress));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kInUserSpaceInstrumentation);
-  EXPECT_THAT(actual_address_infos,
-              UnorderedElementsAre(AllOf(
-                  Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
-                  Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
-                  Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
-                  Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
+  EXPECT_THAT(
+      actual_address_infos,
+      UnorderedElementsAre(
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address,
+                         kUserSpaceLibraryAddress),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name,
+                         kUserSpaceLibraryFunctionName),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kUserSpaceLibraryName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress3),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName3),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address,
+                         kEntryTrampolineAddress),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name,
+                         kEntryTrampolineFunctionName),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, ""))));
 
   EXPECT_EQ(unwinding_errors, 0);
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
@@ -904,7 +953,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleStoppedAtUprobesSendsPatchin
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(listener_, OnAddressInfo).Times(1).WillRepeatedly(Invoke(save_address_info));
+  EXPECT_CALL(listener_, OnAddressInfo).Times(2).WillRepeatedly(Invoke(save_address_info));
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -913,15 +962,21 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleStoppedAtUprobesSendsPatchin
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kUprobesMapsStart));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kCallstackPatchingFailed);
-  EXPECT_THAT(actual_address_infos,
-              UnorderedElementsAre(AllOf(
-                  Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
-                  Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
-                  Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
-                  Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
+  EXPECT_THAT(
+      actual_address_infos,
+      UnorderedElementsAre(
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kUprobesMapsStart),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kUprobesName),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kUprobesName))));
 
   EXPECT_EQ(unwinding_errors, 1);
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
@@ -948,7 +1003,7 @@ TEST_F(UprobesUnwindingVisitorTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(listener_, OnAddressInfo).Times(1).WillRepeatedly(Invoke(save_address_info));
+  EXPECT_CALL(listener_, OnAddressInfo).Times(2).WillRepeatedly(Invoke(save_address_info));
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -957,15 +1012,23 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kReturnTrampolineAddress));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kCallstackPatchingFailed);
-  EXPECT_THAT(actual_address_infos,
-              UnorderedElementsAre(AllOf(
-                  Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
-                  Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
-                  Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
-                  Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
+  EXPECT_THAT(
+      actual_address_infos,
+      UnorderedElementsAre(
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName1),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address,
+                         kReturnTrampolineAddress),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name,
+                         kReturnTrampolineFunctionName),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, ""))));
 
   EXPECT_EQ(unwinding_errors, 1);
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
@@ -1061,7 +1124,8 @@ TEST_F(UprobesUnwindingVisitorTest, VisitCallchainSampleInsideUprobeCodeSendsInU
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kUprobesMapsStart));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kUprobesMapsStart, kTargetAddress2, kTargetAddress3));
   EXPECT_EQ(actual_callstack_sample.callstack().type(), orbit_grpc_protos::Callstack::kInUprobes);
 
   EXPECT_EQ(unwinding_errors, 0);
@@ -1098,7 +1162,8 @@ TEST_F(
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kEntryTrampolineAddress));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kEntryTrampolineAddress, kTargetAddress2, kTargetAddress3));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kInUserSpaceInstrumentation);
 
@@ -1140,7 +1205,9 @@ TEST_F(
 
   // While this is a Callstack::kInUserSpaceInstrumentation, the innermost frame we used is still
   // one of the "regular" frames in the target, i.e., at kTargetAddress1.
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kUserSpaceLibraryAddress, kTargetAddress3,
+                          kEntryTrampolineAddress));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kInUserSpaceInstrumentation);
 
@@ -1194,7 +1261,9 @@ TEST_F(
 
   // While this is a Callstack::kInUserSpaceInstrumentation, the innermost frame we used is still
   // one of the "regular" frames in the target, i.e., at kTargetAddress1.
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kUserSpaceLibraryAddress, kTargetAddress3,
+                          kEntryTrampolineAddress));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kInUserSpaceInstrumentation);
 
@@ -1215,7 +1284,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitPatchableCallchainSampleSendsCompleteCa
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   auto fake_patch_callchain = [](pid_t /*tid*/, uint64_t* callchain, uint64_t callchain_size,
-                                 orbit_linux_tracing::LibunwindstackMaps *
+                                 orbit_linux_tracing::LibunwindstackMaps*
                                  /*maps*/) -> bool {
     ORBIT_CHECK(callchain != nullptr);
     ORBIT_CHECK(callchain_size == 4);
@@ -1279,7 +1348,8 @@ TEST_F(UprobesUnwindingVisitorTest, VisitUnpatchableCallchainSampleSendsPatching
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kUprobesMapsStart, kTargetAddress3));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kCallstackPatchingFailed);
 
@@ -1303,7 +1373,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   auto fake_patch_caller_of_leaf_function = [](const CallchainSamplePerfEventData* event_data,
                                                LibunwindstackMaps* /*maps*/,
-                                               orbit_linux_tracing::LibunwindstackUnwinder *
+                                               orbit_linux_tracing::LibunwindstackUnwinder*
                                                /*unwinder*/) -> Callstack::CallstackType {
     ORBIT_CHECK(event_data != nullptr);
     std::vector<uint64_t> patched_callchain;
@@ -1367,7 +1437,8 @@ TEST_F(
 
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
-  EXPECT_THAT(actual_callstack_sample.callstack().pcs(), ElementsAre(kTargetAddress1));
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kTargetAddress3));
   EXPECT_EQ(actual_callstack_sample.callstack().type(),
             orbit_grpc_protos::Callstack::kFramePointerUnwindingError);
 

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -156,8 +156,9 @@ std::string SamplingReport::GetSelectedCallstackString() const {
   std::string type_string =
       (callstack_type == CallstackType::kComplete)
           ? ""
-          : absl::StrFormat("  -  Unwind error (%s)",
-                            orbit_client_data::CallstackTypeToString(callstack_type));
+          : absl::StrFormat(
+                "  -  <span style=\" color:#ff8000; font-weight: bold;\">Unwind error (%s)</span>",
+                orbit_client_data::CallstackTypeToString(callstack_type));
   return absl::StrFormat(
       "%i of %i unique callstacks  [%i/%i total samples] (%.2f%%)%s", selected_callstack_index_ + 1,
       selected_sorted_callstack_report_->callstack_counts.size(), num_occurrences, total_callstacks,

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -157,7 +157,8 @@ std::string SamplingReport::GetSelectedCallstackString() const {
       (callstack_type == CallstackType::kComplete)
           ? ""
           : absl::StrFormat(
-                "  -  <span style=\" color:#ff8000; font-weight: bold;\">Unwind error (%s)</span>",
+                "  -  <span style=\" color:#ff8000; font-weight: bold;\">Unwind error</span><span "
+                "style=\" color:#ff8000;\"> (%s)</span>",
                 orbit_client_data::CallstackTypeToString(callstack_type));
   return absl::StrFormat(
       "%i of %i unique callstacks  [%i/%i total samples] (%.2f%%)%s", selected_callstack_index_ + 1,


### PR DESCRIPTION
On unwinding errors in the service, we cut off the potentially
broken call frames and only report the PC, which we are pretty
sure to be correct.

However, the "broken" frames may contain important information.
e.g. in the case of frame pointer unwinding, they might only miss
one frame.

With this change, we do not cut "broken" frames, but report them
and show them in orange.
We also highlight the "Unwind error" string in the label.

Screenshot: http://screenshot/9aJAiZrgjJ49QuM

Bug: http://b/230082209
Test: Take a capture