### PR TITLE
Implement raw callstack export to csv

### DIFF
--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -301,7 +301,7 @@ ErrorMessageOr<void> DataView::ExportToCSVFile(const std::string& file_path) {
   std::vector<std::string> column_names;
   std::transform(std::begin(GetColumns()), std::end(GetColumns()), std::back_inserter(column_names),
                  [](const Column& column) { return column.header; });
-  OUTCOME_TRY(WriteHeaderToCSV(fd, column_names));
+  OUTCOME_TRY(WriteLineToCSV(fd, column_names));
 
   const size_t num_columns = column_names.size();
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -373,4 +373,22 @@ void DataView::OnCopySelectionRequested(const std::vector<int>& selection) {
   app_->SetClipboard(clipboard);
 }
 
+std::optional<orbit_base::unique_fd> DataView::GetCSVSaveFile(
+    std::string_view error_window_title) const {
+  auto send_error = [&](const std::string& error_msg) {
+    app_->SendErrorToUi(std::string{error_window_title}, error_msg);
+  };
+
+  std::string file_path = app_->GetSaveFile(".csv");
+  if (file_path.empty()) return std::nullopt;
+
+  ErrorMessageOr<orbit_base::unique_fd> result = orbit_base::OpenFileForWriting(file_path);
+  if (result.has_error()) {
+    send_error(
+        absl::StrFormat("Failed to open \"%s\" file: %s", file_path, result.error().message()));
+    return std::nullopt;
+  }
+  return {result.value()};
+}
+
 }  // namespace orbit_data_views

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -388,16 +388,11 @@ void LiveFunctionsDataView::OnJumpToRequested(const std::string& action,
   OUTCOME_TRY(auto fd, orbit_base::OpenFileForWriting(file_path));
 
   // Write header line
-  constexpr const char* kFieldSeparator = ",";
-  constexpr const char* kLineSeparator = "\r\n";
   constexpr size_t kNumColumns = 5;
   const std::array<std::string, kNumColumns> kNames{"Name", "Thread", "Start", "End",
                                                     "Duration (ns)"};
-  std::string header_line = absl::StrJoin(
-      kNames, kFieldSeparator,
-      [](std::string* out, const std::string& name) { out->append(FormatValueForCsv(name)); });
-  header_line.append(kLineSeparator);
-  OUTCOME_TRY(orbit_base::WriteFully(fd, header_line));
+
+  OUTCOME_TRY(WriteHeaderToCSV(fd, kNames));
 
   for (int row : selection) {
     const CaptureData& capture_data = app_->GetCaptureData();

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -392,7 +392,7 @@ void LiveFunctionsDataView::OnJumpToRequested(const std::string& action,
   const std::array<std::string, kNumColumns> kNames{"Name", "Thread", "Start", "End",
                                                     "Duration (ns)"};
 
-  OUTCOME_TRY(WriteHeaderToCSV(fd, kNames));
+  OUTCOME_TRY(WriteLineToCSV(fd, kNames));
 
   for (int row : selection) {
     const CaptureData& capture_data = app_->GetCaptureData();

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -458,12 +458,13 @@ void SamplingReportDataView::OnExportEventsToCsvRequested(const std::vector<int>
 
   const std::string kErrorWindowTitle = "Export sampled stacks to CSV";
 
-  const std::optional<orbit_base::unique_fd> fd = GetCSVSaveFile(
-      file_path, kErrorWindowTitle, absl::StrFormat("Failed to open \"%s\" file: ", file_path));
-  if (!fd) return;
+  // const std::optional<orbit_base::unique_fd> fd = GetCSVSaveFile(
+  //     file_path, kErrorWindowTitle, absl::StrFormat("Failed to open \"%s\" file: ", file_path));
+  // if (!fd) return;
 
-  const std::array<std::string, kNumColumns> kNames{
-      "Thread", "Timestamp (ns)", "Names main/foo/leaf", "Addresses main_addr/foo_addr/leaf_addr"};
+  // const std::array<std::string, kNumColumns> kNames{
+  //     "Thread", "Timestamp (ns)", "Names main/foo/leaf", "Addresses
+  //     main_addr/foo_addr/leaf_addr"};
 }
 
 }  // namespace orbit_data_views

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -452,6 +452,18 @@ SampledFunction& SamplingReportDataView::GetSampledFunction(unsigned int row) {
   return functions_[indices_[row]];
 }
 
-void SamplingReportDataView::OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) {}
+void SamplingReportDataView::OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) {
+  std::string file_path = app_->GetSaveFile(".csv");
+  if (file_path.empty()) return;
+
+  const std::string kErrorWindowTitle = "Export sampled stacks to CSV";
+
+  const std::optional<orbit_base::unique_fd> fd = GetCSVSaveFile(
+      file_path, kErrorWindowTitle, absl::StrFormat("Failed to open \"%s\" file: ", file_path));
+  if (!fd) return;
+
+  const std::array<std::string, kNumColumns> kNames{
+      "Thread", "Timestamp (ns)", "Names main/foo/leaf", "Addresses main_addr/foo_addr/leaf_addr"};
+}
 
 }  // namespace orbit_data_views

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -236,6 +236,8 @@ DataView::ActionStatus SamplingReportDataView::GetActionStatus(
     return ActionStatus::kVisibleButDisabled;
   }
 
+  if (action == kMenuActionExportEventsToCsv) return ActionStatus::kVisibleAndEnabled;
+
   std::function<bool(const FunctionInfo*)> is_visible_action_enabled;
   if (action == kMenuActionSelect) {
     is_visible_action_enabled = [this](const FunctionInfo* function) {
@@ -449,5 +451,7 @@ const SampledFunction& SamplingReportDataView::GetSampledFunction(unsigned int r
 SampledFunction& SamplingReportDataView::GetSampledFunction(unsigned int row) {
   return functions_[indices_[row]];
 }
+
+void SamplingReportDataView::OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) {}
 
 }  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -198,10 +198,13 @@ class DataView {
   static constexpr const char* kLineSeparator = "\r\n";
 
   template <typename Range>
-  ErrorMessageOr<void> WriteHeaderToCSV(const Range& column_titles) {
+  ErrorMessageOr<void> WriteHeaderToCSV(const orbit_base::unique_fd& fd,
+                                        const Range& column_titles) const {
     std::string header_line = absl::StrJoin(
         column_titles, kFieldSeparator,
         [](std::string* out, const std::string& name) { out->append(FormatValueForCsv(name)); });
+    header_line.append(kLineSeparator);
+    return orbit_base::WriteFully(fd, header_line);
   }
 
   enum class ActionStatus { kInvisible, kVisibleButDisabled, kVisibleAndEnabled };

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -22,6 +22,7 @@
 #include "DataViews/AppInterface.h"
 #include "DataViews/DataViewType.h"
 #include "MetricsUploader/MetricsUploader.h"
+#include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 
@@ -179,6 +180,8 @@ class DataView {
   [[nodiscard]] virtual const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int /*row*/) {
     return nullptr;
   }
+  [[nodiscard]] std::optional<orbit_base::unique_fd> GetCSVSaveFile(
+      std::string_view error_window_title) const;
 
   enum class ActionStatus { kInvisible, kVisibleButDisabled, kVisibleAndEnabled };
   [[nodiscard]] virtual ActionStatus GetActionStatus(std::string_view action, int clicked_index,

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -182,20 +182,15 @@ class DataView {
   [[nodiscard]] virtual const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int /*row*/) {
     return nullptr;
   }
-  [[nodiscard]] std::optional<orbit_base::unique_fd> GetCSVSaveFile(
-      std::string_view file_path, const std::string& error_window_title,
-      const std::string& error_prefix) const;
+
+  ErrorMessageOr<void> ExportToCSVFile(const std::string& file_path);
 
   template <typename T>
-  [[nodiscard]] bool IsError(const ErrorMessageOr<T>& error_message_or,
-                             const std::string& error_window_title,
-                             const std::string& error_prefix) const {
+  void ReportErrorIfAny(const ErrorMessageOr<T>& error_message_or,
+                        const std::string& error_window_title) const {
     if (error_message_or.has_error()) {
-      app_->SendErrorToUi(error_window_title,
-                          absl::StrCat(error_prefix, error_message_or.error().message()));
-      return true;
+      app_->SendErrorToUi(error_window_title, error_message_or.error().message());
     }
-    return false;
   }
 
   static constexpr const char* kFieldSeparator = ",";

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -198,10 +198,9 @@ class DataView {
   static constexpr const char* kLineSeparator = "\r\n";
 
   template <typename Range>
-  ErrorMessageOr<void> WriteHeaderToCSV(const orbit_base::unique_fd& fd,
-                                        const Range& column_titles) const {
+  ErrorMessageOr<void> WriteLineToCSV(const orbit_base::unique_fd& fd, const Range& cells) const {
     std::string header_line = absl::StrJoin(
-        column_titles, kFieldSeparator,
+        cells, kFieldSeparator,
         [](std::string* out, const std::string& name) { out->append(FormatValueForCsv(name)); });
     header_line.append(kLineSeparator);
     return orbit_base::WriteFully(fd, header_line);

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -20,6 +20,7 @@
 #include "DataViews/DataView.h"
 #include "DataViews/LiveFunctionsInterface.h"
 #include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_data_views {
 
@@ -92,6 +93,9 @@ class LiveFunctionsDataView : public DataView {
   // The row does not necessarily refer to a dynamically instrumented function. If it does, a
   // pointer to the corresponding FunctionInfo is returned. `nullptr` is returned otherwise.
   [[nodiscard]] const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int row) override;
+
+  [[nodiscard]] ErrorMessageOr<void> WriteEventsToCSVFile(const std::vector<int>& selection,
+                                                          const std::string& file_path) const;
 
   void UpdateHistogramWithIndices(const std::vector<int>& visible_selected_indices);
 

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -49,6 +49,8 @@ class SamplingReportDataView : public DataView {
   void SetStackEventsCount(uint32_t stack_events_count);
   orbit_client_data::ThreadID GetThreadID() const { return tid_; }
 
+  void OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) override;
+
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
                                              const std::vector<int>& selected_indices) override;

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -49,7 +49,7 @@ class SamplingReportDataView : public DataView {
   void SetStackEventsCount(uint32_t stack_events_count);
   orbit_client_data::ThreadID GetThreadID() const { return tid_; }
 
-  void OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) override;
+  void OnExportEventsToCsvRequested(const std::vector<int>& selection) override;
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -18,6 +18,7 @@
 #include "DataViews/CallstackDataView.h"
 #include "DataViews/DataView.h"
 #include "DataViews/SamplingReportInterface.h"
+#include "OrbitBase/Result.h"
 #include "absl/container/flat_hash_set.h"
 
 class SamplingReport;
@@ -52,6 +53,8 @@ class SamplingReportDataView : public DataView {
   void OnExportEventsToCsvRequested(const std::vector<int>& selection) override;
 
  protected:
+  ErrorMessageOr<void> WriteStackEventsToCSVFile(const std::string& file_path);
+
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
                                              const std::vector<int>& selected_indices) override;
   void DoSort() override;


### PR DESCRIPTION
This adds export of the raw callstack data.
The format is "ThreadID, Timestamp, Names, Addresses", where
the latter two represent the names and addresses respectively
for all the functions in the said callstack (leaf-first) separated
by `/` character.

This also refactors the two existing methods exporting data
to csv to reduce code duplication.

Tests: Manual, Unit
Bug: http://b/230107052