### PR TITLE
Remove the CHECK that fails during capturing

### DIFF
--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -31,8 +31,6 @@ void CaptureViewElement::Draw(PrimitiveAssembler& primitive_assembler, TextRende
 
   text_renderer.PopTranslation();
   primitive_assembler.PopTranslation();
-
-  ORBIT_CHECK(!draw_requested_);
 }
 
 void CaptureViewElement::UpdatePrimitives(PrimitiveAssembler& primitive_assembler,
@@ -55,8 +53,6 @@ void CaptureViewElement::UpdatePrimitives(PrimitiveAssembler& primitive_assemble
 
   text_renderer.PopTranslation();
   primitive_assembler.PopTranslation();
-
-  ORBIT_CHECK(!update_primitives_requested_);
 }
 
 CaptureViewElement::EventResult CaptureViewElement::OnMouseWheel(


### PR DESCRIPTION
As timers are added from another thread during capturing, it is expected that
these checks sometimes fail even if there is no issue in the drawing routines.

Bug: b/230434611