### PR TITLE
Fix timeline's visual tests

### DIFF
--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -55,13 +55,13 @@ class TimelineUiTest : public TimelineUi {
 
     // Depending on the scale, there should be 1, 2 or 4 minor ticks between each major tick, which
     // means that (calling MT to the number of major ticks, and mt to the number of minor ticks)
-    // mt is between (MT-1, MT+1), (2*(MT-1), 2x(MT+1)) or (4x(MT-1), 4x(MT+1)).
+    // mt is between (MT-1, MT+1), (2*(MT-1), 2*(MT+1)) or (4*(MT-1), 4*(MT+1)).
     EXPECT_GE(num_minor_ticks, num_major_ticks - 1);
     EXPECT_LE(num_minor_ticks, 4 * (num_major_ticks + 1));
     EXPECT_THAT(num_minor_ticks,
                 testing::AnyOf(testing::Le(num_major_ticks + 1),
                                testing::AllOf(testing::Ge(2 * (num_major_ticks - 1)),
-                                              testing::Le(2 * num_major_ticks + 1)),
+                                              testing::Le(2 * (num_major_ticks + 1))),
                                testing::Ge(4 * (num_major_ticks - 1))));
 
     // Generally, labels should all have the same number of digits, start at the same vertical

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -68,7 +68,7 @@ class TimelineUiTest : public TimelineUi {
     // position and they will appear at the right of each major tick. The only exception is about
     // labels with the same number of digits when the number of hours is greater than 100. The hour
     // part of the iso timestamp will have 2 digits when it's smaller than 100.
-    if (max_tick <= 100 * kNanosecondsPerHour) {
+    if (max_tick < 100 * kNanosecondsPerHour) {
       EXPECT_TRUE(mock_text_renderer_.HasAddTextsSameLength());
     }
     EXPECT_TRUE(mock_text_renderer_.AreAddTextsAlignedVertically());
@@ -106,10 +106,12 @@ static void TestUpdatePrimitivesWithSeveralRanges(int world_width) {
   Viewport viewport(world_width, 0);
   TimelineUiTest timeline_ui_test(&mock_timeline_info, &viewport, &layout);
   timeline_ui_test.TestUpdatePrimitives(0, 100);
-  timeline_ui_test.TestUpdatePrimitives(1'000'000'000, 1'000'000'100);
-  timeline_ui_test.TestUpdatePrimitives(0, 999'999'000);
-  timeline_ui_test.TestUpdatePrimitives(0, 999'999'999);
-  timeline_ui_test.TestUpdatePrimitives(0, 1'000'000'000);
+  timeline_ui_test.TestUpdatePrimitives(kNanosecondsPerSecond, kNanosecondsPerSecond + 100);
+  timeline_ui_test.TestUpdatePrimitives(0, kNanosecondsPerSecond - 100);
+  timeline_ui_test.TestUpdatePrimitives(0, kNanosecondsPerSecond - 1);
+  timeline_ui_test.TestUpdatePrimitives(0, kNanosecondsPerSecond);
+  timeline_ui_test.TestUpdatePrimitives(0, 59 * kNanosecondsPerMinute);
+  timeline_ui_test.TestUpdatePrimitives(90 * kNanosecondsPerHour, 100 * kNanosecondsPerHour);
 
   // Maximum supported timestamp: 1 Month.
   std::mt19937 gen;


### PR DESCRIPTION
TimelineUiTest class was using ints instead of uint64_t to generate
random timestamps. As soon as I changed that, there were 2 special cases
we were not considering.

- The special case of 30 seconds and 30 minutes where there are exactly
  2 minor ticks between each major tick.
- The special case of really big timestamps (>100 hours) where we don't
  expect all labels to have the same number of characters.

Luckily both issues were expected behavior, so only the test class was
fixed.