### PR TITLE
Add render-loop utility functions to CaptureViewElementTester

### DIFF
--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -137,6 +137,8 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   float width_ = 0.;
   Vec2 pos_ = Vec2(0, 0);
   CaptureViewElement* parent_;
+
+  friend class CaptureViewElementTester;
 };
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -197,5 +197,8 @@ TEST(CaptureViewElement, RequestUpdateBubblesUpAndIsClearedAfterDrawLoop) {
   // ... and a request with the default value should also require "UpdatePrimitives"
   child.GetAllChildren()[0]->RequestUpdate();
   tester.SimulateDrawLoopAndCheckFlags(&root, true, true);
+
+  // Finally: There shouldn't be any draws required after a render loop has happened
+  tester.SimulateDrawLoopAndCheckFlags(&root, false, false);
 }
 }  // namespace orbit_gl

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -6,10 +6,6 @@
 #include <gtest/gtest.h>
 
 #include "CaptureViewElementTester.h"
-#include "MockBatcher.h"
-#include "MockTextRenderer.h"
-#include "PickingManager.h"
-#include "PrimitiveAssembler.h"
 
 namespace orbit_gl {
 
@@ -186,58 +182,20 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
             container_elem.HandleMouseWheelEvent(kPosOnChild2, kDelta));
 }
 
-class CaptureViewElementRoot : public CaptureViewElement, public ::testing::Test {
- public:
-  CaptureViewElementRoot() : CaptureViewElement(nullptr, &kViewport, &kLayout) {}
-  [[nodiscard]] float GetHeight() const override { return 0; }
-
- private:
-  [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
-  CreateAccessibleInterface() override {
-    return nullptr;
-  }
-};
-
-TEST_F(CaptureViewElementRoot, RequestUpdateBubblesUpAndIsClearedAfterDrawLoop) {
-  MockBatcher batcher;
-  MockTextRenderer text_renderer;
-  PickingManager picking_manager;
-
-  PrimitiveAssembler primitive_assembler(&batcher, &picking_manager);
-
-  auto simulate_draw_loop_and_check_flags = [&](bool draw, bool update_primitives) {
-    EXPECT_EQ(draw_requested_, draw);
-    EXPECT_EQ(update_primitives_requested_, update_primitives);
-    EXPECT_EQ(HasLayoutChanged(), draw || update_primitives);
-
-    UpdateLayout();
-    if (draw) {
-      Draw(primitive_assembler, text_renderer, CaptureViewElement::DrawContext());
-    }
-    if (update_primitives) {
-      UpdatePrimitives(primitive_assembler, text_renderer, 0, 0, PickingMode::kNone);
-    }
-
-    EXPECT_FALSE(draw_requested_);
-    EXPECT_FALSE(update_primitives_requested_);
-    EXPECT_FALSE(HasLayoutChanged());
-  };
-
-  EXPECT_FALSE(draw_requested_);
-  EXPECT_FALSE(update_primitives_requested_);
-  EXPECT_FALSE(HasLayoutChanged());
-
-  UnitTestCaptureViewContainerElement child(this, &kViewport, &kLayout, 1);
+TEST(CaptureViewElement, RequestUpdateBubblesUpAndIsClearedAfterDrawLoop) {
+  CaptureViewElementTester tester;
+  UnitTestCaptureViewContainerElement root(nullptr, &kViewport, &kLayout);
+  UnitTestCaptureViewContainerElement child(&root, &kViewport, &kLayout, 1);
 
   // On creating the child, we expect everything to be invalidated as a new child has been added
-  simulate_draw_loop_and_check_flags(true, true);
+  tester.SimulateDrawLoopAndCheckFlags(&root, true, true);
 
   // A "Draw" request should only set the "draw" flag
-  child.GetAllChildren()[0]->RequestUpdate(RequestUpdateScope::kDraw);
-  simulate_draw_loop_and_check_flags(true, false);
+  child.GetAllChildren()[0]->RequestUpdate(CaptureViewElement::RequestUpdateScope::kDraw);
+  tester.SimulateDrawLoopAndCheckFlags(&root, true, false);
 
   // ... and a request with the default value should also require "UpdatePrimitives"
   child.GetAllChildren()[0]->RequestUpdate();
-  simulate_draw_loop_and_check_flags(true, true);
+  tester.SimulateDrawLoopAndCheckFlags(&root, true, true);
 }
 }  // namespace orbit_gl

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -8,8 +8,48 @@
 
 #include <unordered_map>
 
+orbit_gl::CaptureViewElementTester::CaptureViewElementTester()
+    : viewport_(1920, 1080), primitive_assembler_(&batcher_, &picking_manager_) {}
+
 void orbit_gl::CaptureViewElementTester::RunTests(CaptureViewElement* element) {
   TestWidthPropagationToChildren(element);
+}
+
+void orbit_gl::CaptureViewElementTester::CheckDrawFlags(CaptureViewElement* element, bool draw,
+                                                        bool update_primitives) {
+  EXPECT_EQ(element->draw_requested_, draw);
+  EXPECT_EQ(element->update_primitives_requested_, update_primitives);
+  EXPECT_EQ(element->HasLayoutChanged(), draw || update_primitives);
+}
+
+void orbit_gl::CaptureViewElementTester::SimulateDrawLoop(CaptureViewElement* element, bool draw,
+                                                          bool update_primitives) {
+  primitive_assembler_.StartNewFrame();
+  text_renderer_.Clear();
+
+  const int kMaxLayoutLoops = layout_.GetMaxLayoutingLoops();
+  int layout_loops = 0;
+
+  do {
+    element->UpdateLayout();
+  } while (++layout_loops < kMaxLayoutLoops && element->HasLayoutChanged());
+
+  EXPECT_LT(layout_loops, kMaxLayoutLoops);
+
+  if (draw) {
+    element->Draw(primitive_assembler_, text_renderer_, CaptureViewElement::DrawContext());
+  }
+  if (update_primitives) {
+    element->UpdatePrimitives(primitive_assembler_, text_renderer_, 0, 0, PickingMode::kNone);
+  }
+}
+
+void orbit_gl::CaptureViewElementTester::SimulateDrawLoopAndCheckFlags(CaptureViewElement* element,
+                                                                       bool draw,
+                                                                       bool update_primitives) {
+  CheckDrawFlags(element, draw, update_primitives);
+  SimulateDrawLoop(element, draw, update_primitives);
+  CheckDrawFlags(element, false, false);
 }
 
 void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(

--- a/src/OrbitGl/CaptureViewElementTester.h
+++ b/src/OrbitGl/CaptureViewElementTester.h
@@ -25,16 +25,16 @@ class CaptureViewElementTester {
   Viewport* GetViewport() { return &viewport_; }
   TimeGraphLayout* GetLayout() { return &layout_; }
 
-  // Check if internal flags for `element` as set correctly
-  //  * draw: Expect draw_required_ to be set
+  // Check if internal flags for `element` are set correctly:
+  //  * draw: Expect draw_required_ to be set.
   //  * update_primitives: Expect update_primitives_required_ to be set
   // Use this to verify that `UpdateLayout` or any other layout-changing methods work correctly.
   // You usually want to call this once to check the initial state, then call your setters, then
   // call this again. You will want to check that:
   //  * A call to a setter correctly updates the value, and sets draw_required_ or
-  //    update_primitives_required_ as needed
+  //    update_primitives_required_ as needed.
   //  * A call to a setter that does not change the value will *not* result in any of the flags
-  //    to be set
+  //    to be set.
   // In most cases, you'll want to use `SimulateDrawLoopAndCheckFlags` to combine flag checking
   // and an update / render loop.
   void CheckDrawFlags(CaptureViewElement* element, bool draw, bool update_primitives);

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -122,7 +122,9 @@ void CaptureWindow::PreRender() {
     // During loading or capturing, only a single layouting loop is executed as we're
     // streaming in data from a seperate thread (for performance reasons)
     const int kMaxLayoutLoops =
-        (app_ != nullptr && (app_->IsCapturing() || app_->IsLoadingCapture())) ? 1 : 10;
+        (app_ != nullptr && (app_->IsCapturing() || app_->IsLoadingCapture()))
+            ? 1
+            : time_graph_->GetLayout().GetMaxLayoutingLoops();
 
     // TODO (b/229222095) Log when the max loop count is exceeded
     do {

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -85,6 +85,10 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER_MIN_MAX(scale_, kMinScale, kMaxScale);
   ImGui::Checkbox("Draw Track Background", &draw_track_background_);
 
+  if (ImGui::SliderInt("Maximum # of layout loops", &max_layouting_loops_, 1, 100)) {
+    needs_redraw = true;
+  }
+
   return needs_redraw;
 }
 

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -59,6 +59,8 @@ class TimeGraphLayout {
     return lround(GetFontSize() * GetScale());
   }
 
+  int GetMaxLayoutingLoops() const { return max_layouting_loops_; }
+
  protected:
   float text_box_height_;
   float core_height_;
@@ -98,6 +100,8 @@ class TimeGraphLayout {
 
   bool draw_properties_ = false;
   bool draw_track_background_ = true;
+
+  int max_layouting_loops_ = 10;
 
  private:
   float GetEventTrackHeight() const { return event_track_height_ * scale_; }


### PR DESCRIPTION
This extends CaptureViewElementTester to include methods to simulate full
update / render loops, including the multiple "UpdateLayout" calls done by
the capture window. This will simplify testing of Capture View Elements in the
future.

I'm bracing for discussions around the "friend" declaration, happy to find a
better alternative. But I want this class to be able to test some internals of
`CaptureViewElement`, and I did not want to expose those publicly.

This is part of a larger change, see the overview here: https://github.com/google/orbit/pull/3623
Bug: b/230455107