### PR TITLE
Add button and basic tests

### DIFF
--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Button.h"
+
+#include "AccessibleCaptureViewElement.h"
+
+namespace orbit_gl {
+
+Button::Button(CaptureViewElement* parent, const Viewport* viewport, const TimeGraphLayout* layout)
+    : CaptureViewElement(parent, viewport, layout) {}
+
+void Button::SetHeight(float height) {
+  if (height == height_) return;
+
+  height_ = height;
+  RequestUpdate();
+}
+
+std::unique_ptr<orbit_accessibility::AccessibleInterface> Button::CreateAccessibleInterface() {
+  // TODO: Should be `AccessibleButton`
+  return std::make_unique<AccessibleCaptureViewElement>(this, "TODO");
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/Button.h
+++ b/src/OrbitGl/Button.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_BUTTON_H_
+#define ORBIT_GL_BUTTON_H_
+
+#include "CaptureViewElement.h"
+#include "TimeGraphLayout.h"
+#include "Viewport.h"
+
+namespace orbit_gl {
+class Button : public CaptureViewElement {
+ public:
+  explicit Button(CaptureViewElement* parent, const Viewport* viewport,
+                  const TimeGraphLayout* layout);
+
+  [[nodiscard]] float GetHeight() const override { return height_; }
+  [[nodiscard]] uint32_t GetLayoutFlags() const override { return LayoutFlags::kNone; }
+
+  void SetHeight(float height);
+
+ private:
+  [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleInterface>
+  CreateAccessibleInterface() override;
+
+  float height_ = 0.f;
+};
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "Button.h"
+#include "CaptureViewElementTester.h"
+
+namespace orbit_gl {
+
+TEST(Button, CaptureViewElementWorksAsIntended) {
+  orbit_gl::CaptureViewElementTester tester;
+  Button button(nullptr, tester.GetViewport(), tester.GetLayout());
+
+  tester.RunTests(&button);
+}
+
+TEST(Button, SizeGettersAndSettersWork) {
+  orbit_gl::CaptureViewElementTester tester;
+  Button button(nullptr, tester.GetViewport(), tester.GetLayout());
+
+  Vec2 size(10.f, 10.f);
+  button.SetWidth(size[0]);
+  button.SetHeight(size[1]);
+
+  tester.SimulateDrawLoopAndCheckFlags(&button, true, true);
+
+  EXPECT_EQ(button.GetWidth(), size[0]);
+  EXPECT_EQ(button.GetHeight(), size[1]);
+  EXPECT_EQ(button.GetSize(), size);
+
+  // Setting width / height to the same values should not request an update
+  button.SetWidth(size[0]);
+  button.SetHeight(size[1]);
+
+  tester.SimulateDrawLoopAndCheckFlags(&button, false, false);
+
+  // Changing to a different size should affect the property and flags again
+  size = Vec2(15.f, 20.f);
+  button.SetWidth(size[0]);
+  button.SetHeight(size[1]);
+
+  tester.SimulateDrawLoopAndCheckFlags(&button, true, true);
+
+  EXPECT_EQ(button.GetWidth(), size[0]);
+  EXPECT_EQ(button.GetHeight(), size[1]);
+  EXPECT_EQ(button.GetSize(), size);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(
          BasicPageFaultsTrack.h
          Batcher.h
          BatcherInterface.h
+         Button.h
          CallstackThreadBar.h
          CallTreeView.h
          CaptureStats.h
@@ -98,6 +99,7 @@ target_sources(
           App.cpp
           AsyncTrack.cpp
           BasicPageFaultsTrack.cpp
+          Button.cpp
           CallstackThreadBar.cpp
           CallTreeView.cpp
           CaptureStats.cpp
@@ -203,6 +205,7 @@ target_sources(OrbitGlTests PRIVATE
 
 target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp
+               ButtonTest.cpp
                CaptureStatsTest.cpp
                CaptureViewElementTest.cpp
                CaptureViewElementTester.cpp


### PR DESCRIPTION
Adds a rudimentary version of `orbit_gl::Button` and unit tests.

This is part of a larger change, see the overview here: https://github.com/google/orbit/pull/3623
Bug: b/230455107