### PR TITLE
Add minimum size for Buttons

### DIFF
--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -9,13 +9,23 @@
 namespace orbit_gl {
 
 Button::Button(CaptureViewElement* parent, const Viewport* viewport, const TimeGraphLayout* layout)
-    : CaptureViewElement(parent, viewport, layout) {}
+    : CaptureViewElement(parent, viewport, layout) {
+  SetWidth(layout->GetMinButtonSize());
+  SetHeight(layout->GetMinButtonSize());
+}
 
 void Button::SetHeight(float height) {
   if (height == height_) return;
 
   height_ = height;
   RequestUpdate();
+}
+
+void Button::DoUpdateLayout() {
+  CaptureViewElement::DoUpdateLayout();
+
+  SetWidth(std::max(GetWidth(), layout_->GetMinButtonSize()));
+  SetHeight(std::max(GetHeight(), layout_->GetMinButtonSize()));
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> Button::CreateAccessibleInterface() {

--- a/src/OrbitGl/Button.h
+++ b/src/OrbitGl/Button.h
@@ -20,6 +20,9 @@ class Button : public CaptureViewElement {
 
   void SetHeight(float height);
 
+ protected:
+  void DoUpdateLayout() override;
+
  private:
   [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -48,4 +48,17 @@ TEST(Button, SizeGettersAndSettersWork) {
   EXPECT_EQ(button.GetSize(), size);
 }
 
+TEST(Button, SizeCannotBeZero) {
+  orbit_gl::CaptureViewElementTester tester;
+  Button button(nullptr, tester.GetViewport(), tester.GetLayout());
+
+  button.SetWidth(0.f);
+  button.SetHeight(0.f);
+
+  tester.SimulatePreRender(&button);
+
+  EXPECT_EQ(button.GetWidth(), tester.GetLayout()->GetMinButtonSize());
+  EXPECT_EQ(button.GetHeight(), tester.GetLayout()->GetMinButtonSize());
+}
+
 }  // namespace orbit_gl

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -22,11 +22,7 @@ void orbit_gl::CaptureViewElementTester::CheckDrawFlags(CaptureViewElement* elem
   EXPECT_EQ(element->HasLayoutChanged(), draw || update_primitives);
 }
 
-void orbit_gl::CaptureViewElementTester::SimulateDrawLoop(CaptureViewElement* element, bool draw,
-                                                          bool update_primitives) {
-  primitive_assembler_.StartNewFrame();
-  text_renderer_.Clear();
-
+void orbit_gl::CaptureViewElementTester::SimulatePreRender(CaptureViewElement* element) {
   const int kMaxLayoutLoops = layout_.GetMaxLayoutingLoops();
   int layout_loops = 0;
 
@@ -35,6 +31,14 @@ void orbit_gl::CaptureViewElementTester::SimulateDrawLoop(CaptureViewElement* el
   } while (++layout_loops < kMaxLayoutLoops && element->HasLayoutChanged());
 
   EXPECT_LT(layout_loops, kMaxLayoutLoops);
+}
+
+void orbit_gl::CaptureViewElementTester::SimulateDrawLoop(CaptureViewElement* element, bool draw,
+                                                          bool update_primitives) {
+  SimulatePreRender(element);
+
+  primitive_assembler_.StartNewFrame();
+  text_renderer_.Clear();
 
   if (draw) {
     element->Draw(primitive_assembler_, text_renderer_, CaptureViewElement::DrawContext());

--- a/src/OrbitGl/CaptureViewElementTester.h
+++ b/src/OrbitGl/CaptureViewElementTester.h
@@ -39,6 +39,13 @@ class CaptureViewElementTester {
   // and an update / render loop.
   void CheckDrawFlags(CaptureViewElement* element, bool draw, bool update_primitives);
 
+  // Run layout updates without rendering. This is equal to what would happen during
+  // CaptureWindow::PreRender. You'll want to use this when you want to verify that a particular
+  // functionality is executed during PreRender, and you don't care about what happens during
+  // rendering, or explicitely want to check that rendering is not required.
+  // Usually, you should be good with simply using `SimulateDrawLoop`.
+  void SimulatePreRender(CaptureViewElement* element);
+
   // Simulate a cycle of `UpdateLayout`, followed by rendering.
   // Depending on the parameters, `Draw`, `UpdatePrimitives`, or both are executed.
   // Most of the times, you'll probably want to use `SimulateDrawLoopAndCheckFlags` instead.

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -35,6 +35,7 @@ TimeGraphLayout::TimeGraphLayout() {
   rounding_num_sides_ = 16;
   text_offset_ = 5.f;
   right_margin_ = 10.f;
+  min_button_size_ = 5.f;
   toolbar_icon_height_ = 24.f;
   generic_fixed_spacer_width_ = 10.f;
   scale_ = 1.f;
@@ -77,6 +78,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(rounding_num_sides_);
   FLOAT_SLIDER(text_offset_);
   FLOAT_SLIDER(right_margin_);
+  FLOAT_SLIDER(min_button_size_);
   FLOAT_SLIDER_MIN_MAX(track_tab_width_, 0, 1000.f);
   FLOAT_SLIDER_MIN_MAX(track_content_bottom_margin_, 0, 20.f);
   FLOAT_SLIDER_MIN_MAX(track_content_top_margin_, 0, 20.f);

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -42,6 +42,7 @@ class TimeGraphLayout {
   float GetBottomMargin() const;
   float GetTracksTopMargin() const { return GetTimeBarHeight() + GetTimeBarMargin(); }
   float GetRightMargin() const { return right_margin_; }
+  float GetMinButtonSize() const { return min_button_size_; }
   float GetSpaceBetweenTracks() const { return space_between_tracks_ * scale_; }
   float GetSpaceBetweenCores() const { return space_between_cores_ * scale_; }
   float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }
@@ -85,6 +86,7 @@ class TimeGraphLayout {
   float rounding_num_sides_;
   float text_offset_;
   float right_margin_;
+  float min_button_size_;
 
   uint32_t font_size_;
 


### PR DESCRIPTION
Adds a configurable minimum size to orbit_gl::Button.

This is part of a larger change, see the overview here: https://github.com/google/orbit/pull/3623
Bug: b/230455107