### PR TITLE
Fix border cases in MockBatcher and MockTextRenderer

### DIFF
--- a/src/OrbitGl/MockBatcher.h
+++ b/src/OrbitGl/MockBatcher.h
@@ -27,18 +27,25 @@ class MockBatcher : public Batcher {
   void ResetElements() override;
   [[nodiscard]] uint32_t GetNumElements() const override;
 
-  [[nodiscard]] std::vector<float> GetLayers() const override { return {}; };
+  [[nodiscard]] std::vector<float> GetLayers() const override {
+    return std::vector<float>(z_layers_.begin(), z_layers_.end());
+  }
+
   virtual void DrawLayer(float /*layer*/, bool /*picking*/) const override{};
 
   [[nodiscard]] const PickingUserData* GetUserData(PickingId /*id*/) const override {
     return nullptr;
   }
 
-  [[nodiscard]] int GetNumLinesByColor(Color color) const { return num_lines_by_color_.at(color); }
-  [[nodiscard]] int GetNumTrianglesByColor(Color color) const {
-    return num_triangles_by_color_.at(color);
+  [[nodiscard]] int GetNumLinesByColor(Color color) const {
+    return num_lines_by_color_.count(color) ? num_lines_by_color_.at(color) : 0;
   }
-  [[nodiscard]] int GetNumBoxesByColor(Color color) const { return num_boxes_by_color_.at(color); }
+  [[nodiscard]] int GetNumTrianglesByColor(Color color) const {
+    return num_triangles_by_color_.count(color) ? num_triangles_by_color_.at(color) : 0;
+  }
+  [[nodiscard]] int GetNumBoxesByColor(Color color) const {
+    return num_boxes_by_color_.count(color) ? num_boxes_by_color_.at(color) : 0;
+  }
   [[nodiscard]] int GetNumHorizontalLines() const { return num_horizontal_lines_; }
   [[nodiscard]] int GetNumVerticalLines() const { return num_vertical_lines_; }
   [[nodiscard]] int GetNumLines() const;
@@ -49,10 +56,11 @@ class MockBatcher : public Batcher {
   [[nodiscard]] bool IsEverythingBetweenZLayers(float z_layer_min, float z_layer_max) const;
 
  private:
-  void AdjustDrawingBoundaries(Vec3 point);
+  void AdjustDrawingBoundaries(Vec2 point);
 
-  Vec3 min_point_;
-  Vec3 max_point_;
+  Vec2 min_point_;
+  Vec2 max_point_;
+  std::set<float> z_layers_;
   int num_vertical_lines_;
   int num_horizontal_lines_;
   std::map<Color, int> num_lines_by_color_;

--- a/src/OrbitGl/MockTextRenderer.h
+++ b/src/OrbitGl/MockTextRenderer.h
@@ -20,7 +20,9 @@ class MockTextRenderer : public TextRenderer {
 
   MOCK_METHOD(void, RenderLayer, (float), (override));
   MOCK_METHOD(void, RenderDebug, (PrimitiveAssembler*), (override));
-  MOCK_METHOD(std::vector<float>, GetLayers, (), (const override));
+  [[nodiscard]] std::vector<float> GetLayers() const override {
+    return std::vector<float>(z_layers_.begin(), z_layers_.end());
+  }
 
   void AddText(const char* text, float x, float y, float z, TextFormatting formatting) override;
   void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
@@ -44,10 +46,11 @@ class MockTextRenderer : public TextRenderer {
   [[nodiscard]] bool IsTextBetweenZLayers(float z_layer_min, float z_layer_max) const;
 
  private:
-  void UpdateDrawingBoundaries(Vec3 point);
-  Vec3 min_point_;
-  Vec3 max_point_;
+  void AdjustDrawingBoundaries(Vec2 point);
 
+  Vec2 min_point_;
+  Vec2 max_point_;
+  std::set<float> z_layers_;
   std::set<uint32_t> num_characters_in_add_text_;
   std::set<float> vertical_position_in_add_text;
   int num_add_text_calls_ = 0;


### PR DESCRIPTION
In this PR we are:

- Fixing a crash if you GetBoxesWithColor with a non-existing color.
- Fixing Rectangle and Z-layer Check when there were no elements added.
- Implementing Mock***::GetLayers().

Bug: http://b/230447233.