### PR TITLE
Add label to orbit_gl::Button

### DIFF
--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -21,6 +21,13 @@ void Button::SetHeight(float height) {
   RequestUpdate();
 }
 
+void Button::SetLabel(const std::string& label) {
+  if (label_ == label) return;
+
+  label_ = label;
+  RequestUpdate(RequestUpdateScope::kDraw);
+}
+
 void Button::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 

--- a/src/OrbitGl/Button.h
+++ b/src/OrbitGl/Button.h
@@ -20,6 +20,9 @@ class Button : public CaptureViewElement {
 
   void SetHeight(float height);
 
+  void SetLabel(const std::string& label);
+  [[nodiscard]] const std::string& GetLabel() const { return label_; }
+
  protected:
   void DoUpdateLayout() override;
 
@@ -28,6 +31,7 @@ class Button : public CaptureViewElement {
   CreateAccessibleInterface() override;
 
   float height_ = 0.f;
+  std::string label_;
 };
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -61,4 +61,18 @@ TEST(Button, SizeCannotBeZero) {
   EXPECT_EQ(button.GetHeight(), tester.GetLayout()->GetMinButtonSize());
 }
 
+TEST(Button, LabelWorksAsExpected) {
+  orbit_gl::CaptureViewElementTester tester;
+  Button button(nullptr, tester.GetViewport(), tester.GetLayout());
+
+  tester.SimulateDrawLoopAndCheckFlags(&button, true, true);
+
+  const std::string kLabel = "UnitTest";
+  button.SetLabel(kLabel);
+
+  tester.SimulateDrawLoopAndCheckFlags(&button, true, false);
+
+  EXPECT_EQ(button.GetLabel(), kLabel);
+}
+
 }  // namespace orbit_gl


### PR DESCRIPTION
Adds a label to `orbit_gl::Button`, and extends the unit-tests accordingly.
Rendering code is still missing, the label is currently only stored internally.

This is part of a larger change, see the overview here: https://github.com/google/orbit/pull/3623
Bug: b/230455107