### PR TITLE
Add AccessibleButton

### DIFF
--- a/src/OrbitGl/AccessibleButton.h
+++ b/src/OrbitGl/AccessibleButton.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_ACCESSIBLE_BUTTON_H_
+#define ORBIT_GL_ACCESSIBLE_BUTTON_H_
+
+#include "AccessibleCaptureViewElement.h"
+#include "Button.h"
+
+namespace orbit_gl {
+class AccessibleButton : public AccessibleCaptureViewElement {
+ public:
+  explicit AccessibleButton(const Button* button)
+      : AccessibleCaptureViewElement(button, "Button",
+                                     orbit_accessibility::AccessibilityRole::Button),
+        button_(button) {
+    ORBIT_CHECK(button_ != nullptr);
+  }
+  [[nodiscard]] std::string AccessibleName() const override { return button_->GetLabel(); }
+
+ private:
+  const Button* button_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_ACCESSIBLE_CAPTURE_VIEW_ELEMENT_H_

--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -4,7 +4,7 @@
 
 #include "Button.h"
 
-#include "AccessibleCaptureViewElement.h"
+#include "AccessibleButton.h"
 
 namespace orbit_gl {
 
@@ -36,8 +36,7 @@ void Button::DoUpdateLayout() {
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> Button::CreateAccessibleInterface() {
-  // TODO: Should be `AccessibleButton`
-  return std::make_unique<AccessibleCaptureViewElement>(this, "TODO");
+  return std::make_unique<AccessibleButton>(this);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -9,7 +9,8 @@ add_library(OrbitGl STATIC)
 
 target_sources(
   OrbitGl
-  PUBLIC AccessibleCaptureViewElement.h
+  PUBLIC AccessibleButton.h
+         AccessibleCaptureViewElement.h
          AccessibleInterfaceProvider.h
          AccessibleTimeGraph.h
          AccessibleTrack.h


### PR DESCRIPTION
Replaces the use of `AccessibleCaptureViewElement` in `orbit_gl::Button`.
This needs a specific accessibility class because the name may change
during runtime.

This is part of a larger change, see the overview here: #3623
Bug: b/230455107