### PR TITLE
Fix "offset in function" for uprobes

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -37,7 +37,6 @@ static void SendFullAddressInfoToListener(TracerListener* listener,
 
   FullAddressInfo address_info;
   address_info.set_absolute_address(libunwindstack_frame.pc);
-  address_info.set_offset_in_function(libunwindstack_frame.function_offset);
   address_info.set_module_name(libunwindstack_frame.map_name);
 
   // For addresses falling directly inside u(ret)probes code, unwindstack::FrameData has limited
@@ -48,8 +47,10 @@ static void SendFullAddressInfoToListener(TracerListener* listener,
   // corresponding unwinding error.
   if (libunwindstack_frame.map_name == "[uprobes]") {
     address_info.set_function_name("[uprobes]");
+    address_info.set_offset_in_function(libunwindstack_frame.pc - libunwindstack_frame.map_start);
   } else {
     address_info.set_function_name(libunwindstack_frame.function_name);
+    address_info.set_offset_in_function(libunwindstack_frame.function_offset);
   }
 
   listener->OnAddressInfo(std::move(address_info));

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -182,8 +182,16 @@ class UprobesUnwindingVisitorTest : public ::testing::Test {
   static inline unwindstack::MapInfo kUprobesMapInfo{
       nullptr, nullptr, kUprobesMapsStart, kUprobesMapsEnd, 0, PROT_EXEC | PROT_READ, kUprobesName};
 
-  static inline const unwindstack::FrameData kUprobesFrame{
+  static inline const unwindstack::FrameData kUprobesFrame1{
       .pc = kUprobesMapsStart,
+      .function_name = "uprobe",
+      .function_offset = 0,
+      .map_name = kUprobesName,
+      .map_start = kUprobesMapsStart,
+  };
+
+  static inline const unwindstack::FrameData kUprobesFrame2{
+      .pc = kUprobesMapsStart + 1,
       .function_name = "uprobe",
       .function_offset = 0,
       .map_name = kUprobesName,
@@ -714,7 +722,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleWithinUprobeSendsInUprobesCa
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> callstack{kUprobesFrame, kFrame2};
+  std::vector<unwindstack::FrameData> callstack{kUprobesFrame2, kFrame2};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -738,14 +746,15 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleWithinUprobeSendsInUprobesCa
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
   EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
-              ElementsAre(kUprobesMapsStart, kTargetAddress2));
+              ElementsAre(kUprobesMapsStart + 1, kTargetAddress2));
   EXPECT_EQ(actual_callstack_sample.callstack().type(), orbit_grpc_protos::Callstack::kInUprobes);
   EXPECT_THAT(
       actual_address_infos,
       UnorderedElementsAre(
-          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kUprobesMapsStart),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address,
+                         kUprobesMapsStart + 1),
                 Property(&orbit_grpc_protos::FullAddressInfo::function_name, kUprobesName),
-                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 1),
                 Property(&orbit_grpc_protos::FullAddressInfo::module_name, kUprobesName)),
           AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress2),
                 Property(&orbit_grpc_protos::FullAddressInfo::function_name, kFunctionName2),
@@ -938,7 +947,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleStoppedAtUprobesSendsPatchin
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
 
-  std::vector<unwindstack::FrameData> callstack{kFrame1, kUprobesFrame};
+  std::vector<unwindstack::FrameData> callstack{kFrame1, kUprobesFrame1};
 
   EXPECT_CALL(unwinder_, Unwind(event.data.pid, nullptr, _, _, event.data.dyn_size, _, _))
       .Times(1)
@@ -1283,7 +1292,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitPatchableCallchainSampleSendsCompleteCa
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   auto fake_patch_callchain = [](pid_t /*tid*/, uint64_t* callchain, uint64_t callchain_size,
-                                 orbit_linux_tracing::LibunwindstackMaps *
+                                 orbit_linux_tracing::LibunwindstackMaps*
                                  /*maps*/) -> bool {
     ORBIT_CHECK(callchain != nullptr);
     ORBIT_CHECK(callchain_size == 4);
@@ -1372,7 +1381,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   auto fake_patch_caller_of_leaf_function = [](const CallchainSamplePerfEventData* event_data,
                                                LibunwindstackMaps* /*maps*/,
-                                               orbit_linux_tracing::LibunwindstackUnwinder *
+                                               orbit_linux_tracing::LibunwindstackUnwinder*
                                                /*unwinder*/) -> Callstack::CallstackType {
     ORBIT_CHECK(event_data != nullptr);
     std::vector<uint64_t> patched_callchain;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -1292,7 +1292,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitPatchableCallchainSampleSendsCompleteCa
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   auto fake_patch_callchain = [](pid_t /*tid*/, uint64_t* callchain, uint64_t callchain_size,
-                                 orbit_linux_tracing::LibunwindstackMaps*
+                                 orbit_linux_tracing::LibunwindstackMaps *
                                  /*maps*/) -> bool {
     ORBIT_CHECK(callchain != nullptr);
     ORBIT_CHECK(callchain_size == 4);
@@ -1381,7 +1381,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   auto fake_patch_caller_of_leaf_function = [](const CallchainSamplePerfEventData* event_data,
                                                LibunwindstackMaps* /*maps*/,
-                                               orbit_linux_tracing::LibunwindstackUnwinder*
+                                               orbit_linux_tracing::LibunwindstackUnwinder *
                                                /*unwinder*/) -> Callstack::CallstackType {
     ORBIT_CHECK(event_data != nullptr);
     std::vector<uint64_t> patched_callchain;


### PR DESCRIPTION
On uprobes, libunwindstack's address info does not contain a valid
"offset in function". Thus, we need to treat the whole uprobes map
as one function and compute the offset based on the map's start
and the pc.

This has been done previously, but was removed by #3616.

Test: Run test.