### PR TITLE
Report more detailed unwinding error

### DIFF
--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -130,6 +130,11 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
   // If the caller is not executable, we have an unwinding error.
   unwindstack::MapInfo* caller_map_info = current_maps->Find(libunwindstack_leaf_caller_pc);
   if (caller_map_info == nullptr || (caller_map_info->flags() & PROT_EXEC) == 0) {
+    // If the error was because the stack sample was too small, the user can act and increase the
+    // stack size. So we report that case separately.
+    if (stack_size > stack_dump_size_) {
+      return Callstack::kStackTopForDwarfUnwindingTooSmall;
+    }
     return Callstack::kStackTopDwarfUnwindingError;
   }
 

--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -130,8 +130,8 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
   // If the caller is not executable, we have an unwinding error.
   unwindstack::MapInfo* caller_map_info = current_maps->Find(libunwindstack_leaf_caller_pc);
   if (caller_map_info == nullptr || (caller_map_info->flags() & PROT_EXEC) == 0) {
-    // If the error was because the stack sample was too small, the user can act and increase the
-    // stack size. So we report that case separately.
+    // As above, if the error was because the stack sample was too small, the user can act and
+    // increase the stack size. So we report that case separately.
     if (stack_size > stack_dump_size_) {
       return Callstack::kStackTopForDwarfUnwindingTooSmall;
     }


### PR DESCRIPTION
In case of an unwinding error during leaf function patching,
where we already know its a leaf function, we should ensure
to tell the user if the stack dump was too small (as this is
actionable).

Test: Inspect unwind errors on sample game.