### PR TITLE
Add mouse release callback to Button

### DIFF
--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -28,6 +28,17 @@ void Button::SetLabel(const std::string& label) {
   RequestUpdate(RequestUpdateScope::kDraw);
 }
 
+void Button::SetMouseReleaseCallback(MouseReleaseCallback callback) {
+  mouse_release_callback_ = callback;
+}
+
+void Button::OnRelease() {
+  CaptureViewElement::OnRelease();
+  if (mouse_release_callback_ != nullptr) {
+    mouse_release_callback_(this);
+  }
+}
+
 void Button::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 

--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -29,7 +29,7 @@ void Button::SetLabel(const std::string& label) {
 }
 
 void Button::SetMouseReleaseCallback(MouseReleaseCallback callback) {
-  mouse_release_callback_ = callback;
+  mouse_release_callback_ = std::move(callback);
 }
 
 void Button::OnRelease() {

--- a/src/OrbitGl/Button.h
+++ b/src/OrbitGl/Button.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_GL_BUTTON_H_
 #define ORBIT_GL_BUTTON_H_
 
+#include <functional>
+
 #include "CaptureViewElement.h"
 #include "TimeGraphLayout.h"
 #include "Viewport.h"
@@ -23,6 +25,11 @@ class Button : public CaptureViewElement {
   void SetLabel(const std::string& label);
   [[nodiscard]] const std::string& GetLabel() const { return label_; }
 
+  using MouseReleaseCallback = std::function<void(Button*)>;
+  void SetMouseReleaseCallback(MouseReleaseCallback callback);
+
+  void OnRelease() override;
+
  protected:
   void DoUpdateLayout() override;
 
@@ -32,6 +39,8 @@ class Button : public CaptureViewElement {
 
   float height_ = 0.f;
   std::string label_;
+
+  MouseReleaseCallback mouse_release_callback_ = nullptr;
 };
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -75,4 +75,29 @@ TEST(Button, LabelWorksAsExpected) {
   EXPECT_EQ(button.GetLabel(), kLabel);
 }
 
+TEST(Button, MouseReleaseCallback) {
+  orbit_gl::CaptureViewElementTester tester;
+  Button button(nullptr, tester.GetViewport(), tester.GetLayout());
+
+  uint32_t mouse_released_called = 0;
+  auto callback = [&](Button* button_param) {
+    if (button_param == &button) mouse_released_called++;
+  };
+  button.SetMouseReleaseCallback(callback);
+
+  uint32_t mouse_released_called_expected = 0;
+  button.OnRelease();
+  EXPECT_EQ(mouse_released_called, ++mouse_released_called_expected);
+  button.OnRelease();
+  EXPECT_EQ(mouse_released_called, ++mouse_released_called_expected);
+  button.SetMouseReleaseCallback(nullptr);
+  button.OnRelease();
+  EXPECT_EQ(mouse_released_called, mouse_released_called_expected);
+
+  Button button_with_wrong_callback(nullptr, tester.GetViewport(), tester.GetLayout());
+  button_with_wrong_callback.SetMouseReleaseCallback(callback);
+  button_with_wrong_callback.OnRelease();
+  EXPECT_EQ(mouse_released_called, mouse_released_called_expected);
+}
+
 }  // namespace orbit_gl

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -93,11 +93,6 @@ TEST(Button, MouseReleaseCallback) {
   button.SetMouseReleaseCallback(nullptr);
   button.OnRelease();
   EXPECT_EQ(mouse_released_called, mouse_released_called_expected);
-
-  Button button_with_wrong_callback(nullptr, tester.GetViewport(), tester.GetLayout());
-  button_with_wrong_callback.SetMouseReleaseCallback(callback);
-  button_with_wrong_callback.OnRelease();
-  EXPECT_EQ(mouse_released_called, mouse_released_called_expected);
 }
 
 }  // namespace orbit_gl


### PR DESCRIPTION
Adds functionality to `orbit_gl::Button` to respond to mouse releases.
Functionality is currently rather limited - the callback is fired on release
rather than on click because that is the expected behaviour of buttons in
any UI, but it is not verified if the mouse is actually still over the button when
being released.

IMO this needs to be fixed by the picking framework though and is not in
scope of this change.

This is part of a larger change, see the overview here: https://github.com/google/orbit/pull/3623
Bug: b/230455107