### PR TITLE
Assure we don't draw invisible elements in the Timeline

### DIFF
--- a/src/OrbitGl/CoreMath.h
+++ b/src/OrbitGl/CoreMath.h
@@ -31,6 +31,11 @@ struct ClosedInterval {
   static ClosedInterval FromValues(float value_1, float value_2) {
     return {std::min(value_1, value_2), std::max(value_1, value_2)};
   }
+
+  [[nodiscard]] bool Intersects(const ClosedInterval& closed_interval) const {
+    return this->min <= closed_interval.max && this->max >= closed_interval.min;
+  }
+
   float min;
   float max;
 };

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -80,7 +80,7 @@ void TimelineUi::RenderLabel(PrimitiveAssembler& primitive_assembler, TextRender
   // Check that the label is visible or partially visible.
   if (ClosedInterval label_x_interval{
           world_x, world_x + text_renderer.GetStringWidth(label.c_str(), layout_->GetFontSize())};
-      label_x_interval.Intersects(ClosedInterval{GetPos()[0], GetPos()[0] + GetWidth()})) {
+      !label_x_interval.Intersects(ClosedInterval{GetPos()[0], GetPos()[0] + GetWidth()})) {
     return;
   }
 

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -8,6 +8,7 @@
 
 #include "AccessibleCaptureViewElement.h"
 #include "ClientFlags/ClientFlags.h"
+#include "CoreMath.h"
 #include "DisplayFormats/DisplayFormats.h"
 #include "GlCanvas.h"
 #include "TimelineTicks.h"
@@ -24,11 +25,13 @@ void TimelineUi::RenderLines(PrimitiveAssembler& primitive_assembler, uint64_t m
        timeline_ticks_.GetAllTicks(min_timestamp_ns, max_timestamp_ns)) {
     float world_x = timeline_info_interface_->GetWorldFromUs(
         tick_ns / static_cast<double>(kNanosecondsPerMicrosecond));
-    int screen_x = viewport_->WorldToScreen(Vec2(world_x, 0))[0];
-    primitive_assembler.AddVerticalLine(
-        Vec2(screen_x, GetPos()[1]), GetHeightWithoutMargin(), GlCanvas::kZValueTimeBar,
-        tick_type == TimelineTicks::TickType::kMajorTick ? kTimelineMajorTickColor
-                                                         : kTimelineMinorTickColor);
+    if (IsElementOf(world_x, ClosedInterval::FromValues(GetPos()[0], GetPos()[0] + GetSize()[0]))) {
+      int screen_x = viewport_->WorldToScreen(Vec2(world_x, 0))[0];
+      primitive_assembler.AddVerticalLine(
+          Vec2(screen_x, GetPos()[1]), GetHeightWithoutMargin(), GlCanvas::kZValueTimeBar,
+          tick_type == TimelineTicks::TickType::kMajorTick ? kTimelineMajorTickColor
+                                                           : kTimelineMinorTickColor);
+    }
   }
 }
 
@@ -73,6 +76,12 @@ void TimelineUi::RenderLabel(PrimitiveAssembler& primitive_assembler, TextRender
 
   std::string label = GetLabel(tick_ns, number_of_decimal_places);
   float world_x = GetTickWorldXPos(tick_ns);
+  // Checking that at least some part of the label will be visible.
+  if (world_x + text_renderer.GetStringWidth(label.c_str(), layout_->GetFontSize()) < GetPos()[0] ||
+      world_x > GetPos()[0] + GetSize()[0]) {
+    return;
+  }
+
   Vec2 pos, size;
   float label_middle_y = GetPos()[1] + GetHeightWithoutMargin() / 2.f;
   text_renderer.AddText(label.c_str(), world_x + kLabelsPadding + extra_left_margin, label_middle_y,

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -28,6 +28,7 @@ class TimelineUiTest : public TimelineUi {
         viewport_(viewport),
         mock_timeline_info_(mock_timeline_info) {
     viewport->SetWorldSize(viewport->GetWorldWidth(), TimelineUi::GetHeight());
+    SetWidth(viewport_->GetWorldWidth());
   }
 
   void TestUpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
@@ -88,6 +89,17 @@ class TimelineUiTest : public TimelineUi {
                                                          GlCanvas::kZValueTimeBarLabel));
     EXPECT_TRUE(mock_batcher_.IsEverythingBetweenZLayers(GlCanvas::kZValueTimeBar,
                                                          GlCanvas::kZValueTimeBarLabel));
+
+    // The label is the only thing that can be out of the expected space for the timeline.
+    const char* kOneMonthLabel = "730:00:00.000000000";
+    const float kMaxSizeLabel =
+        mock_text_renderer_.GetStringWidth(kOneMonthLabel, layout_->GetFontSize());
+    const Vec2 kExpectedMinPos{GetPos()[0] - kMaxSizeLabel, GetPos()[1]};
+    const Vec2 kExpectedMaxPos{GetPos() + Vec2{GetSize()[0] + kMaxSizeLabel, GetSize()[1]}};
+    EXPECT_TRUE(mock_text_renderer_.IsTextInsideRectangle(kExpectedMinPos,
+                                                          kExpectedMaxPos - kExpectedMinPos));
+    EXPECT_TRUE(mock_batcher_.IsEverythingInsideRectangle(kExpectedMinPos,
+                                                          kExpectedMaxPos - kExpectedMinPos));
   }
 
   void TestDraw(uint64_t min_tick, uint64_t max_tick, uint64_t mouse_tick) {

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -92,10 +92,10 @@ class TimelineUiTest : public TimelineUi {
 
     // The label is the only thing that can be out of the expected space for the timeline.
     const char* kOneMonthLabel = "730:00:00.000000000";
-    const float kMaxSizeLabel =
+    const float kMaxLabelWidth =
         mock_text_renderer_.GetStringWidth(kOneMonthLabel, layout_->GetFontSize());
-    const Vec2 kExpectedMinPos{GetPos()[0] - kMaxSizeLabel, GetPos()[1]};
-    const Vec2 kExpectedMaxPos{GetPos() + Vec2{GetSize()[0] + kMaxSizeLabel, GetSize()[1]}};
+    const Vec2 kExpectedMinPos{GetPos()[0] - kMaxLabelWidth, GetPos()[1]};
+    const Vec2 kExpectedMaxPos{GetPos() + Vec2{GetSize()[0] + kMaxLabelWidth, GetSize()[1]}};
     EXPECT_TRUE(mock_text_renderer_.IsTextInsideRectangle(kExpectedMinPos,
                                                           kExpectedMaxPos - kExpectedMinPos));
     EXPECT_TRUE(mock_batcher_.IsEverythingInsideRectangle(kExpectedMinPos,


### PR DESCRIPTION
In this PR we are doing one step in forcing only visible elements in
Draw and UpdatePrimitives. We are checking both ticks and labels to be
at least partially visible.

We also extend the unit-test, and fix an issue in the tests we didn't need 
before (timeline didn't have set the width).

Test: Unit-test. Load a capture, check everything works as expected.

Bug: http://b/230703439