### PR TITLE
Mark "Frame pointer unwinding" as experimental

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -47,6 +47,23 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   ui_->unwindingMethodComboBox->addItem("DWARF", static_cast<int>(CaptureOptions::kDwarf));
   ui_->unwindingMethodComboBox->addItem("Frame pointers",
                                         static_cast<int>(CaptureOptions::kFramePointers));
+
+  QObject::connect(ui_->unwindingMethodComboBox, &QComboBox::currentTextChanged,
+                   ui_->unwindingMethodWidget, [this](const QString& /*unused*/) {
+                     auto unwinding_method = static_cast<UnwindingMethod>(
+                         ui_->unwindingMethodComboBox->currentData().toInt());
+                     if (unwinding_method == CaptureOptions::kFramePointers) {
+                       ui_->unwindingMethodWidget->setStyleSheet("QWidget { color:#ff8000; }");
+                       ui_->unwindingMethodWidget->setToolTip(
+                           "Frame-pointer unwinding is experimental.\n"
+                           "Successful unwinding requires all binaries to be compiled with\n"
+                           "'-fno-omit-frame-pointer' and optionally '-momit-leaf-frame-pointer'.");
+                     } else {
+                       ui_->unwindingMethodWidget->setStyleSheet("QWidget { color : white; }");
+                       ui_->unwindingMethodWidget->setToolTip("");
+                     }
+                   });
+
   ui_->maxCopyRawStackSizeLineEdit->setText(QString::number(kMaxCopyRawStackSizeDefaultValue));
   ui_->dynamicInstrumentationMethodComboBox->addItem(
       "Kernel (Uprobes)", static_cast<int>(CaptureOptions::kKernelUprobes));

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -45,7 +45,7 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
                    });
 
   ui_->unwindingMethodComboBox->addItem("DWARF", static_cast<int>(CaptureOptions::kDwarf));
-  ui_->unwindingMethodComboBox->addItem("Frame pointers",
+  ui_->unwindingMethodComboBox->addItem("Frame pointers (experimental)",
                                         static_cast<int>(CaptureOptions::kFramePointers));
 
   const QString kFramePointerTooltip =

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -48,21 +48,32 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   ui_->unwindingMethodComboBox->addItem("Frame pointers",
                                         static_cast<int>(CaptureOptions::kFramePointers));
 
-  QObject::connect(ui_->unwindingMethodComboBox, &QComboBox::currentTextChanged,
-                   ui_->unwindingMethodWidget, [this](const QString& /*unused*/) {
-                     auto unwinding_method = static_cast<UnwindingMethod>(
-                         ui_->unwindingMethodComboBox->currentData().toInt());
-                     if (unwinding_method == CaptureOptions::kFramePointers) {
-                       ui_->unwindingMethodWidget->setStyleSheet("QWidget { color:#ff8000; }");
-                       ui_->unwindingMethodWidget->setToolTip(
-                           "Frame-pointer unwinding is experimental.\n"
-                           "Successful unwinding requires all binaries to be compiled with\n"
-                           "'-fno-omit-frame-pointer' and optionally '-momit-leaf-frame-pointer'.");
-                     } else {
-                       ui_->unwindingMethodWidget->setStyleSheet("QWidget { color : white; }");
-                       ui_->unwindingMethodWidget->setToolTip("");
-                     }
-                   });
+  const QString kFramePointerTooltip =
+      "Frame-pointer unwinding is experimental.\n"
+      "Successful unwinding requires all binaries to be compiled with\n"
+      "'-fno-omit-frame-pointer', but '-momit-leaf-frame-pointer' is\n"
+      "also supported.";
+
+  int frame_pointer_item_index =
+      ui_->unwindingMethodComboBox->findData(static_cast<int>(CaptureOptions::kFramePointers));
+  ui_->unwindingMethodComboBox->setItemData(frame_pointer_item_index, QColor(255, 128, 0, 255),
+                                            Qt::ForegroundRole);
+  ui_->unwindingMethodComboBox->setItemData(frame_pointer_item_index, kFramePointerTooltip,
+                                            Qt::ToolTipRole);
+
+  QObject::connect(
+      ui_->unwindingMethodComboBox, &QComboBox::currentTextChanged, ui_->unwindingMethodWidget,
+      [this, kFramePointerTooltip]() {
+        auto unwinding_method =
+            static_cast<UnwindingMethod>(ui_->unwindingMethodComboBox->currentData().toInt());
+        if (unwinding_method == CaptureOptions::kFramePointers) {
+          ui_->unwindingMethodComboBox->setStyleSheet("QComboBox:editable { color:#ff8000; }");
+          ui_->unwindingMethodWidget->setToolTip(kFramePointerTooltip);
+        } else {
+          ui_->unwindingMethodComboBox->setStyleSheet("QComboBox:editable { color : white; }");
+          ui_->unwindingMethodWidget->setToolTip("");
+        }
+      });
 
   ui_->maxCopyRawStackSizeLineEdit->setText(QString::number(kMaxCopyRawStackSizeDefaultValue));
   ui_->dynamicInstrumentationMethodComboBox->addItem(


### PR DESCRIPTION
We want to make the user notice, that frame pointer unwinding
needs to be treated with caution.

In this change, we change to color of the unwinding method selection
in the capture options to orange, when the user selects frame
pointer unwinding. In this case, we also add a tooltip, explaining
frame pointer unwinding being experimental and the requirement
of compiling with frame pointers.

Note that the feature is still hidden behind dev-mode.

Screenshot (frame pointer): http://screenshot/79fiZexfBmcw9nD
Screenshot (DWARF): http://screenshot/6oFJzrqA6USrRdt

Test: Change unwinding method in capture options.
Bug: no bug.