### PR TITLE
Refactor SftpCopyToLocalOperation

### DIFF
--- a/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
@@ -24,14 +24,13 @@ namespace orbit_ssh_qt {
 namespace details {
 enum class SftpCopyToLocalOperationState {
   kInitial,
-  kNoOperation,
-  kRemoteFileOpened,
-  kLocalFileOpened,
-  kStarted,
+  kOpenRemoteFile,
+  kOpenLocalFile,
+  kStarted,  // This is the running state, where the data transfer happens
   kShutdown,
-  kCopyDone,
-  kLocalFileClosed,
-  kRemoteFileClosed,
+  kCloseLocalFile,
+  kCloseRemoteFile,
+  kCloseEventConnections,
   kDone,
   kError
 };

--- a/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
@@ -25,12 +25,13 @@ namespace details {
 enum class SftpCopyToLocalOperationState {
   kInitial,
   kNoOperation,
-  kStarted,
   kRemoteFileOpened,
   kLocalFileOpened,
-  kLocalFileWritten,
-  kLocalFileClosed,
+  kStarted,
   kShutdown,
+  kCopyDone,
+  kLocalFileClosed,
+  kRemoteFileClosed,
   kDone,
   kError
 };


### PR DESCRIPTION
This refactors SftpCopyToLocalOperation to use slightly different named
and ordered states. The states kNoOperation and kRemoteFileOpened are
now part of the start phase (function startup()). The state kStarted is
the state that in which the function run() is used and handles the
actual copy of the file. The states kCopyDone, kLocalFileClosed and
kRemoteFileClosed are part of the shutdown phase (function shutdown()).
This refactor is done so the class can be extended to support aborting
downloads in the future.

Test: Manual test: Symbol downloads still work.
Bug: part of http://b/230757105