### PR TITLE
Handle overlapping new maps in LibunwindstackMapsImpl

### DIFF
--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -77,6 +77,7 @@ target_sources(LinuxTracingTests PRIVATE
         ContextSwitchManagerTest.cpp
         GpuTracepointVisitorTest.cpp
         LeafFunctionCallManagerTest.cpp
+        LibunwindstackMapsTest.cpp
         LibunwindstackUnwinderTest.cpp
         LinuxTracingUtilsTest.cpp
         LostAndDiscardedEventVisitorTest.cpp

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -46,8 +46,8 @@ class MockLibunwindstackMaps : public LibunwindstackMaps {
  public:
   MOCK_METHOD(std::shared_ptr<unwindstack::MapInfo>, Find, (uint64_t), (override));
   MOCK_METHOD(unwindstack::Maps*, Get, (), (override));
-  MOCK_METHOD(void, AddAndSort,
-              (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&, uint64_t), (override));
+  MOCK_METHOD(void, AddAndSort, (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&),
+              (override));
 };
 
 class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {

--- a/src/LinuxTracing/LibunwindstackMaps.cpp
+++ b/src/LinuxTracing/LibunwindstackMaps.cpp
@@ -4,6 +4,8 @@
 
 #include "LibunwindstackMaps.h"
 
+#include "OrbitBase/Logging.h"
+
 namespace orbit_linux_tracing {
 
 namespace {
@@ -18,14 +20,78 @@ class LibunwindstackMapsImpl : public LibunwindstackMaps {
   unwindstack::Maps* Get() override { return maps_.get(); }
 
   void AddAndSort(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
-                  const std::string& name, uint64_t load_bias) override {
-    maps_->Add(start, end, offset, flags, name, load_bias);
-    maps_->Sort();
-  }
+                  const std::string& name) override;
 
  private:
   std::unique_ptr<unwindstack::BufferMaps> maps_;
 };
+
+void LibunwindstackMapsImpl::AddAndSort(uint64_t start, uint64_t end, uint64_t offset,
+                                        uint64_t flags, const std::string& name) {
+  // First, remove existing maps that are fully contained in the new map, and resize or split
+  // existing maps that intersect with the new map. This is how the kernel handles memory mappings
+  // when using `mmap` with `MAP_FIXED` causes a new map that overlaps with existing ones. From the
+  // manpage of `mmap`: "`MAP_FIXED` [...] If the memory region specified by `addr` and `length`
+  // overlaps pages of any existing mapping(s), then the overlapped part of the existing mapping(s)
+  // will be discarded."
+  for (auto map_info_it = maps_->begin(); map_info_it != maps_->end();) {
+    std::shared_ptr<unwindstack::MapInfo> map_info = *map_info_it;
+    if (end <= map_info->start() || start >= map_info->end()) {
+      // The new map does not intersect map_info. Keep map_info untouched (do nothing).
+      ++map_info_it;
+
+    } else if (start <= map_info->start() && end >= map_info->end()) {
+      // The new map encloses map_info. Remove map_info.
+      map_info_it = maps_->erase(map_info_it);
+
+    } else if (start <= map_info->start()) {
+      // The new map intersects the first part of map_info. Keep the second part of map_info.
+      uint64_t new_offset = 0;
+      if (!map_info->name().empty() && map_info->name().c_str()[0] != '[') {
+        // This was a file mapping: update the offset.
+        new_offset = map_info->offset() + (end - map_info->start());
+      }
+      map_info_it = maps_->erase(map_info_it);
+      map_info_it = maps_->Insert(map_info_it, end, map_info->end(), new_offset, map_info->flags(),
+                                  map_info->name());
+      ++map_info_it;
+
+    } else if (end >= map_info->end()) {
+      // The new map intersects the second part of map_info. Keep the first part of map_info.
+      map_info_it = maps_->erase(map_info_it);
+      map_info_it = maps_->Insert(map_info_it, map_info->start(), start, map_info->offset(),
+                                  map_info->flags(), map_info->name());
+      ++map_info_it;
+
+    } else {
+      // The new map intersects the central part of map_info.
+      ORBIT_CHECK(start > map_info->start() && end < map_info->end());
+      map_info_it = maps_->erase(map_info_it);
+      {
+        // Keep the first part of map_info.
+        map_info_it = maps_->Insert(map_info_it, map_info->start(), start, map_info->offset(),
+                                    map_info->flags(), map_info->name());
+        ++map_info_it;
+      }
+      {
+        // Keep the last part of map_info.
+        uint64_t new_offset = 0;
+        if (!map_info->name().empty() && map_info->name().c_str()[0] != '[') {
+          // This was a file mapping: update the offset.
+          new_offset = map_info->offset() + (end - map_info->start());
+        }
+        map_info_it = maps_->Insert(map_info_it, end, map_info->end(), new_offset,
+                                    map_info->flags(), map_info->name());
+        ++map_info_it;
+      }
+    }
+  }
+
+  // Now add the new map. For simplicity, add at the end and sort.
+  maps_->Add(start, end, offset, flags, name);
+  maps_->Sort();
+}
+
 }  // namespace
 
 std::unique_ptr<LibunwindstackMaps> LibunwindstackMaps::ParseMaps(const std::string& maps_buffer) {

--- a/src/LinuxTracing/LibunwindstackMaps.h
+++ b/src/LinuxTracing/LibunwindstackMaps.h
@@ -10,6 +10,8 @@
 
 namespace orbit_linux_tracing {
 
+// Wrapper around unwindstack::Maps that simplifies keeping the initial snapshot up to date when new
+// mappings are created. It also handles the case of new mappings overlapping existing ones.
 class LibunwindstackMaps {
  public:
   virtual ~LibunwindstackMaps() = default;
@@ -17,7 +19,7 @@ class LibunwindstackMaps {
   virtual std::shared_ptr<unwindstack::MapInfo> Find(uint64_t pc) = 0;
   virtual unwindstack::Maps* Get() = 0;
   virtual void AddAndSort(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
-                          const std::string& name, uint64_t load_bias) = 0;
+                          const std::string& name) = 0;
 
   static std::unique_ptr<LibunwindstackMaps> ParseMaps(const std::string& maps_buffer);
 };

--- a/src/LinuxTracing/LibunwindstackMapsTest.cpp
+++ b/src/LinuxTracing/LibunwindstackMapsTest.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+
+#include "LibunwindstackMaps.h"
+
+namespace orbit_linux_tracing {
+
+static constexpr const char* kMapsInitialContent =
+    "101000-104000 r--p 00001000 01:02 42    /path/to/file\n"
+    "104000-107000 r-xp 00000000 00:00 00\n"
+    "200000-210000 rw-p 00000000 00:00 00    [stack]\n";
+
+static testing::Matcher<unwindstack::MapInfo*> MapInfoEq(
+    uint64_t start, uint64_t end, uint64_t offset, uint64_t flags, std::string_view name,
+    const std::shared_ptr<unwindstack::MapInfo>& prev_map,
+    const std::shared_ptr<unwindstack::MapInfo>& next_map) {
+  return testing::AllOf(
+      testing::Property("start", &unwindstack::MapInfo::start, start),
+      testing::Property("end", &unwindstack::MapInfo::end, end),
+      testing::Property("offset", &unwindstack::MapInfo::offset, offset),
+      testing::Property("flags", &unwindstack::MapInfo::flags, flags),
+      // Can't use Property because MapInfo::name() is not const.
+      testing::ResultOf(
+          [](unwindstack::MapInfo* map_info) { return std::string{map_info->name()}; }, name),
+      testing::Property("prev_map", &unwindstack::MapInfo::prev_map, prev_map),
+      testing::Property("next_map", &unwindstack::MapInfo::next_map, next_map));
+}
+
+TEST(LibunwindstackMaps, ParseMaps) {
+  std::unique_ptr<LibunwindstackMaps> libunwindstack_maps =
+      LibunwindstackMaps::ParseMaps(kMapsInitialContent);
+  ASSERT_NE(libunwindstack_maps, nullptr);
+  unwindstack::Maps* maps = libunwindstack_maps->Get();
+  ASSERT_NE(maps, nullptr);
+  ASSERT_EQ(maps->Total(), 3);
+
+  EXPECT_THAT(maps->Get(0).get(), MapInfoEq(0x101000, 0x104000, 0x1000, PROT_READ, "/path/to/file",
+                                            nullptr, maps->Get(1)));
+  EXPECT_THAT(maps->Get(1).get(), MapInfoEq(0x104000, 0x107000, 0, PROT_READ | PROT_EXEC, "",
+                                            maps->Get(0), maps->Get(2)));
+  EXPECT_THAT(maps->Get(2).get(), MapInfoEq(0x200000, 0x210000, 0, PROT_READ | PROT_WRITE,
+                                            "[stack]", maps->Get(1), nullptr));
+}
+
+TEST(LibunwindstackMaps, Find) {
+  std::unique_ptr<LibunwindstackMaps> libunwindstack_maps =
+      LibunwindstackMaps::ParseMaps(kMapsInitialContent);
+  ASSERT_NE(libunwindstack_maps, nullptr);
+  unwindstack::Maps* maps = libunwindstack_maps->Get();
+  ASSERT_NE(maps, nullptr);
+
+  EXPECT_EQ(libunwindstack_maps->Find(0x101000 - 1), nullptr);
+  EXPECT_EQ(libunwindstack_maps->Find(0x101000), maps->Get(0));
+  EXPECT_EQ(libunwindstack_maps->Find(0x104000), maps->Get(1));
+  EXPECT_EQ(libunwindstack_maps->Find(0x107000), nullptr);
+}
+
+TEST(LibunwindstackMaps, AddAndSortNotOverlappingAnyExistingMap) {
+  std::unique_ptr<LibunwindstackMaps> libunwindstack_maps =
+      LibunwindstackMaps::ParseMaps(kMapsInitialContent);
+  ASSERT_NE(libunwindstack_maps, nullptr);
+
+  libunwindstack_maps->AddAndSort(0x107000, 0x200000, 0x7000, PROT_READ | PROT_WRITE,
+                                  "/path/to/newfile");
+  unwindstack::Maps* maps = libunwindstack_maps->Get();
+  ASSERT_NE(maps, nullptr);
+  ASSERT_EQ(maps->Total(), 4);
+
+  EXPECT_THAT(maps->Get(0).get(), MapInfoEq(0x101000, 0x104000, 0x1000, PROT_READ, "/path/to/file",
+                                            nullptr, maps->Get(1)));
+  EXPECT_THAT(maps->Get(1).get(), MapInfoEq(0x104000, 0x107000, 0, PROT_READ | PROT_EXEC, "",
+                                            maps->Get(0), maps->Get(2)));
+  EXPECT_THAT(maps->Get(2).get(), MapInfoEq(0x107000, 0x200000, 0x7000, PROT_READ | PROT_WRITE,
+                                            "/path/to/newfile", maps->Get(1), maps->Get(3)));
+  EXPECT_THAT(maps->Get(3).get(), MapInfoEq(0x200000, 0x210000, 0, PROT_READ | PROT_WRITE,
+                                            "[stack]", maps->Get(2), nullptr));
+}
+
+TEST(LibunwindstackMaps, AddAndSortOverlappingEntireExistingMap) {
+  std::unique_ptr<LibunwindstackMaps> libunwindstack_maps =
+      LibunwindstackMaps::ParseMaps(kMapsInitialContent);
+  ASSERT_NE(libunwindstack_maps, nullptr);
+
+  libunwindstack_maps->AddAndSort(0x101000, 0x200000, 0x7000, PROT_READ | PROT_WRITE,
+                                  "/path/to/newfile");
+  unwindstack::Maps* maps = libunwindstack_maps->Get();
+  ASSERT_NE(maps, nullptr);
+  ASSERT_EQ(maps->Total(), 2);
+
+  EXPECT_THAT(maps->Get(0).get(), MapInfoEq(0x101000, 0x200000, 0x7000, PROT_READ | PROT_WRITE,
+                                            "/path/to/newfile", nullptr, maps->Get(1)));
+  EXPECT_THAT(maps->Get(1).get(), MapInfoEq(0x200000, 0x210000, 0, PROT_READ | PROT_WRITE,
+                                            "[stack]", maps->Get(0), nullptr));
+}
+
+TEST(LibunwindstackMaps, AddAndSortOverlappingFirstPartOfExistingMap) {
+  std::unique_ptr<LibunwindstackMaps> libunwindstack_maps =
+      LibunwindstackMaps::ParseMaps(kMapsInitialContent);
+  ASSERT_NE(libunwindstack_maps, nullptr);
+
+  libunwindstack_maps->AddAndSort(0x100000, 0x102000, 0x7000, PROT_READ | PROT_WRITE,
+                                  "/path/to/newfile");
+  libunwindstack_maps->AddAndSort(0x1FF000, 0x201000, 0x0, PROT_READ, "");
+  unwindstack::Maps* maps = libunwindstack_maps->Get();
+  ASSERT_NE(maps, nullptr);
+  ASSERT_EQ(maps->Total(), 5);
+
+  EXPECT_THAT(maps->Get(0).get(), MapInfoEq(0x100000, 0x102000, 0x7000, PROT_READ | PROT_WRITE,
+                                            "/path/to/newfile", nullptr, maps->Get(1)));
+  EXPECT_THAT(maps->Get(1).get(), MapInfoEq(0x102000, 0x104000, 0x2000, PROT_READ, "/path/to/file",
+                                            maps->Get(0), maps->Get(2)));
+  EXPECT_THAT(maps->Get(2).get(), MapInfoEq(0x104000, 0x107000, 0, PROT_READ | PROT_EXEC, "",
+                                            maps->Get(1), maps->Get(3)));
+  EXPECT_THAT(maps->Get(3).get(),
+              MapInfoEq(0x1FF000, 0x201000, 0, PROT_READ, "", maps->Get(2), maps->Get(4)));
+  EXPECT_THAT(maps->Get(4).get(), MapInfoEq(0x201000, 0x210000, 0, PROT_READ | PROT_WRITE,
+                                            "[stack]", maps->Get(3), nullptr));
+}
+
+TEST(LibunwindstackMaps, AddAndSortOverlappingLastPartOfExistingMap) {
+  std::unique_ptr<LibunwindstackMaps> libunwindstack_maps =
+      LibunwindstackMaps::ParseMaps(kMapsInitialContent);
+  ASSERT_NE(libunwindstack_maps, nullptr);
+
+  libunwindstack_maps->AddAndSort(0x103000, 0x104000, 0x7000, PROT_READ | PROT_WRITE,
+                                  "/path/to/newfile");
+  unwindstack::Maps* maps = libunwindstack_maps->Get();
+  ASSERT_NE(maps, nullptr);
+  ASSERT_EQ(maps->Total(), 4);
+
+  EXPECT_THAT(maps->Get(0).get(), MapInfoEq(0x101000, 0x103000, 0x1000, PROT_READ, "/path/to/file",
+                                            nullptr, maps->Get(1)));
+  EXPECT_THAT(maps->Get(1).get(), MapInfoEq(0x103000, 0x104000, 0x7000, PROT_READ | PROT_WRITE,
+                                            "/path/to/newfile", maps->Get(0), maps->Get(2)));
+  EXPECT_THAT(maps->Get(2).get(), MapInfoEq(0x104000, 0x107000, 0, PROT_READ | PROT_EXEC, "",
+                                            maps->Get(1), maps->Get(3)));
+  EXPECT_THAT(maps->Get(3).get(), MapInfoEq(0x200000, 0x210000, 0, PROT_READ | PROT_WRITE,
+                                            "[stack]", maps->Get(2), nullptr));
+}
+
+TEST(LibunwindstackMaps, AddAndSortOverlappingMultipleExistingMaps) {
+  std::unique_ptr<LibunwindstackMaps> libunwindstack_maps =
+      LibunwindstackMaps::ParseMaps(kMapsInitialContent);
+  ASSERT_NE(libunwindstack_maps, nullptr);
+
+  libunwindstack_maps->AddAndSort(0x103000, 0x202000, 0x7000, PROT_READ | PROT_WRITE,
+                                  "/path/to/newfile");
+  unwindstack::Maps* maps = libunwindstack_maps->Get();
+  ASSERT_NE(maps, nullptr);
+  ASSERT_EQ(maps->Total(), 3);
+
+  EXPECT_THAT(maps->Get(0).get(), MapInfoEq(0x101000, 0x103000, 0x1000, PROT_READ, "/path/to/file",
+                                            nullptr, maps->Get(1)));
+  EXPECT_THAT(maps->Get(1).get(), MapInfoEq(0x103000, 0x202000, 0x7000, PROT_READ | PROT_WRITE,
+                                            "/path/to/newfile", maps->Get(0), maps->Get(2)));
+  EXPECT_THAT(maps->Get(2).get(), MapInfoEq(0x202000, 0x210000, 0, PROT_READ | PROT_WRITE,
+                                            "[stack]", maps->Get(1), nullptr));
+}
+
+TEST(LibunwindstackMaps, AddAndSortOverlappingMiddlePartOfExistingMap) {
+  std::unique_ptr<LibunwindstackMaps> libunwindstack_maps =
+      LibunwindstackMaps::ParseMaps(kMapsInitialContent);
+  ASSERT_NE(libunwindstack_maps, nullptr);
+
+  libunwindstack_maps->AddAndSort(0x102000, 0x103000, 0x7000, PROT_READ | PROT_WRITE,
+                                  "/path/to/newfile");
+  libunwindstack_maps->AddAndSort(0x201000, 0x202000, 0x0, PROT_READ, "");
+  unwindstack::Maps* maps = libunwindstack_maps->Get();
+  ASSERT_NE(maps, nullptr);
+  ASSERT_EQ(maps->Total(), 7);
+
+  EXPECT_THAT(maps->Get(0).get(), MapInfoEq(0x101000, 0x102000, 0x1000, PROT_READ, "/path/to/file",
+                                            nullptr, maps->Get(1)));
+  EXPECT_THAT(maps->Get(1).get(), MapInfoEq(0x102000, 0x103000, 0x7000, PROT_READ | PROT_WRITE,
+                                            "/path/to/newfile", maps->Get(0), maps->Get(2)));
+  EXPECT_THAT(maps->Get(2).get(), MapInfoEq(0x103000, 0x104000, 0x3000, PROT_READ, "/path/to/file",
+                                            maps->Get(1), maps->Get(3)));
+  EXPECT_THAT(maps->Get(3).get(), MapInfoEq(0x104000, 0x107000, 0, PROT_READ | PROT_EXEC, "",
+                                            maps->Get(2), maps->Get(4)));
+  EXPECT_THAT(maps->Get(4).get(), MapInfoEq(0x200000, 0x201000, 0, PROT_READ | PROT_WRITE,
+                                            "[stack]", maps->Get(3), maps->Get(5)));
+  EXPECT_THAT(maps->Get(5).get(),
+              MapInfoEq(0x201000, 0x202000, 0, PROT_READ, "", maps->Get(4), maps->Get(6)));
+  EXPECT_THAT(maps->Get(6).get(), MapInfoEq(0x202000, 0x210000, 0, PROT_READ | PROT_WRITE,
+                                            "[stack]", maps->Get(5), nullptr));
+}
+
+}  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -468,7 +468,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp, const MmapPerfEven
   // constructor.
   if (event_data.filename == "[uprobes]") {
     current_maps_->AddAndSort(event_data.address, event_data.address + event_data.length, 0,
-                              PROT_EXEC, event_data.filename, UINT64_MAX);
+                              PROT_EXEC, event_data.filename);
     return;
   }
 
@@ -484,8 +484,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp, const MmapPerfEven
 
   // For flags we assume PROT_READ and PROT_EXEC, MMAP event does not return flags.
   current_maps_->AddAndSort(module_info.address_start(), module_info.address_end(),
-                            event_data.page_offset, PROT_READ | PROT_EXEC, event_data.filename,
-                            module_info.load_bias());
+                            event_data.page_offset, PROT_READ | PROT_EXEC, event_data.filename);
 
   orbit_grpc_protos::ModuleUpdateEvent module_update_event;
   module_update_event.set_pid(event_data.pid);

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -57,8 +57,8 @@ class MockLibunwindstackMaps : public LibunwindstackMaps {
  public:
   MOCK_METHOD(std::shared_ptr<unwindstack::MapInfo>, Find, (uint64_t), (override));
   MOCK_METHOD(unwindstack::Maps*, Get, (), (override));
-  MOCK_METHOD(void, AddAndSort,
-              (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&, uint64_t), (override));
+  MOCK_METHOD(void, AddAndSort, (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&),
+              (override));
 };
 
 class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {


### PR DESCRIPTION
This was a general problem, but it showed because Wine creates overlapping maps
as part of the process of loading a PE.

Also stop passing the load bias. We were doing that because `Maps::Add`
supported it, but it's not necessary: `libunwindstack` retrieves the load bias
as part of associating a map to an object when necessary during unwinding.

Bug: http://b/226562022

Test: Add unit tests for `LibunwindstackMaps`. Capture Trata, also with
dynamic instrumentation, and verify unwinding works.