### PR TITLE
Add retry for Client::GetSshInfoAsync

### DIFF
--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -31,6 +31,8 @@
 
 ABSL_FLAG(uint32_t, ggp_timeout_seconds, 20, "Timeout for Ggp commands in seconds");
 
+constexpr int kNumberOfRetries = 3;
+
 namespace {
 template <typename T>
 orbit_base::Future<ErrorMessageOr<T>> RetryTask(
@@ -110,7 +112,7 @@ ErrorMessageOr<std::unique_ptr<Client>> CreateClient(QString ggp_program,
 
 Future<ErrorMessageOr<QVector<Instance>>> ClientImpl::GetInstancesAsync(
     InstanceListScope scope, std::optional<Project> project) {
-  return GetInstancesAsync(scope, project, 3);
+  return GetInstancesAsync(scope, project, kNumberOfRetries);
 }
 
 Future<ErrorMessageOr<QVector<Instance>>> ClientImpl::GetInstancesAsync(
@@ -142,7 +144,7 @@ Future<ErrorMessageOr<QVector<Instance>>> ClientImpl::GetInstancesAsync(
 
 Future<ErrorMessageOr<SshInfo>> ClientImpl::GetSshInfoAsync(const QString& instance_id,
                                                             std::optional<Project> project) {
-  return GetSshInfoAsync(instance_id, std::move(project), 3);
+  return GetSshInfoAsync(instance_id, std::move(project), kNumberOfRetries);
 }
 
 Future<ErrorMessageOr<SshInfo>> ClientImpl::GetSshInfoAsync(const QString& instance_id,

--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -31,6 +31,24 @@
 
 ABSL_FLAG(uint32_t, ggp_timeout_seconds, 20, "Timeout for Ggp commands in seconds");
 
+namespace {
+template <typename T>
+orbit_base::Future<ErrorMessageOr<T>> RetryTask(
+    int retry, std::function<orbit_base::Future<ErrorMessageOr<T>>()> async_task) {
+  orbit_base::ImmediateExecutor executor;
+  return orbit_base::UnwrapFuture(async_task().Then(
+      &executor,
+      [retry, async_task](ErrorMessageOr<T> result) -> orbit_base::Future<ErrorMessageOr<T>> {
+        if (result.has_value()) return {result.value()};
+
+        if (retry > 0) {
+          return RetryTask(retry - 1, async_task);
+        }
+        return result.error();
+      }));
+}
+}  // namespace
+
 namespace orbit_ggp {
 
 using orbit_base::Future;
@@ -47,6 +65,9 @@ class ClientImpl : public Client, public QObject {
                                                               int retry) override;
   Future<ErrorMessageOr<SshInfo>> GetSshInfoAsync(const QString& instance_id,
                                                   std::optional<Project> project) override;
+  Future<ErrorMessageOr<SshInfo>> GetSshInfoAsync(const QString& instance_id,
+                                                  std::optional<Project> project,
+                                                  int retry) override;
   Future<ErrorMessageOr<QVector<Project>>> GetProjectsAsync() override;
   Future<ErrorMessageOr<Project>> GetDefaultProjectAsync() override;
   Future<ErrorMessageOr<Instance>> DescribeInstanceAsync(const QString& instance_id) override;
@@ -103,40 +124,49 @@ Future<ErrorMessageOr<QVector<Instance>>> ClientImpl::GetInstancesAsync(
     arguments.append(project.value().id);
   }
 
-  Future<ErrorMessageOr<QByteArray>> ggp_call_future =
-      orbit_qt_utils::ExecuteProcess(ggp_program_, arguments, this, absl::FromChrono(timeout_));
+  std::function<Future<ErrorMessageOr<QVector<Instance>>>()> call_ggp_and_create_instance_list =
+      [client_ptr = QPointer<ClientImpl>(this),
+       arguments = std::move(arguments)]() -> Future<ErrorMessageOr<QVector<Instance>>> {
+    if (client_ptr == nullptr) return ErrorMessage{"orbit_ggp::Client no longer exists"};
 
-  orbit_base::ImmediateExecutor executor;
-  return orbit_base::UnwrapFuture(ggp_call_future.Then(
-      &executor,
-      [=,
-       client_ptr = QPointer<ClientImpl>(this)](ErrorMessageOr<QByteArray> ggp_call_result) mutable
-      -> Future<ErrorMessageOr<QVector<Instance>>> {
-        if (client_ptr == nullptr) return ErrorMessage{"orbit_ggp::Client no longer exists"};
+    orbit_base::ImmediateExecutor executor;
+    return orbit_qt_utils::ExecuteProcess(client_ptr->ggp_program_, arguments, client_ptr,
+                                          absl::FromChrono(client_ptr->timeout_))
+        .ThenIfSuccess(&executor, [](const QByteArray& json) -> ErrorMessageOr<QVector<Instance>> {
+          return Instance::GetListFromJson(json);
+        });
+  };
 
-        if (ggp_call_result.has_error()) {
-          if (retry > 0) {
-            return client_ptr->GetInstancesAsync(scope, project, retry - 1);
-          }
-          return ggp_call_result.error();
-        }
-        return Instance::GetListFromJson(ggp_call_result.value());
-      }));
+  return RetryTask(retry, call_ggp_and_create_instance_list);
 }
 
 Future<ErrorMessageOr<SshInfo>> ClientImpl::GetSshInfoAsync(const QString& instance_id,
                                                             std::optional<Project> project) {
+  return GetSshInfoAsync(instance_id, std::move(project), 3);
+}
+
+Future<ErrorMessageOr<SshInfo>> ClientImpl::GetSshInfoAsync(const QString& instance_id,
+                                                            std::optional<Project> project,
+                                                            int retry) {
   QStringList arguments{"ssh", "init", "-s", "--instance", instance_id};
   if (project != std::nullopt) {
     arguments.append("--project");
     arguments.append(project.value().id);
   }
 
-  orbit_base::ImmediateExecutor executor;
-  return orbit_qt_utils::ExecuteProcess(ggp_program_, arguments, this, absl::FromChrono(timeout_))
-      .ThenIfSuccess(&executor, [](const QByteArray& json) -> ErrorMessageOr<SshInfo> {
-        return SshInfo::CreateFromJson(json);
-      });
+  std::function<Future<ErrorMessageOr<SshInfo>>()> call_ggp_and_create_ssh_info =
+      [client_ptr = QPointer<ClientImpl>(this),
+       arguments = std::move(arguments)]() -> Future<ErrorMessageOr<SshInfo>> {
+    if (client_ptr == nullptr) return {ErrorMessage{"orbit_ggp::Client no longer exists"}};
+
+    orbit_base::ImmediateExecutor executor;
+    return orbit_qt_utils::ExecuteProcess(client_ptr->ggp_program_, arguments, client_ptr,
+                                          absl::FromChrono(client_ptr->timeout_))
+        .ThenIfSuccess(&executor, [](const QByteArray& json) -> ErrorMessageOr<SshInfo> {
+          return SshInfo::CreateFromJson(json);
+        });
+  };
+  return RetryTask(retry, std::move(call_ggp_and_create_ssh_info));
 }
 
 Future<ErrorMessageOr<QVector<Project>>> ClientImpl::GetProjectsAsync() {

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -280,13 +280,13 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncClientGetsDestroyed) {
 
     future = client.value()->GetSshInfoAsync(test_instance_id, std::nullopt);
 
-    future.Then(main_thread_executor_.get(), [&future_is_resolved](
-                                                 const ErrorMessageOr<SshInfo>& ssh_info_result) {
-      EXPECT_FALSE(future_is_resolved);
-      future_is_resolved = true;
-      EXPECT_THAT(ssh_info_result, HasError("killed because the parent object was destroyed"));
-      QCoreApplication::exit();
-    });
+    future.Then(main_thread_executor_.get(),
+                [&future_is_resolved](const ErrorMessageOr<SshInfo>& ssh_info_result) {
+                  EXPECT_FALSE(future_is_resolved);
+                  future_is_resolved = true;
+                  EXPECT_THAT(ssh_info_result, HasError("orbit_ggp::Client no longer exists"));
+                  QCoreApplication::exit();
+                });
   }
 
   QCoreApplication::exec();

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -42,6 +42,8 @@ class Client {
       InstanceListScope scope, std::optional<Project> project, int retry) = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<SshInfo>> GetSshInfoAsync(
       const QString& instance_id, std::optional<Project> project) = 0;
+  [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<SshInfo>> GetSshInfoAsync(
+      const QString& instance_id, std::optional<Project> project, int retry) = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<QVector<Project>>> GetProjectsAsync() = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Project>> GetDefaultProjectAsync() = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Instance>> DescribeInstanceAsync(

--- a/src/SessionSetup/RetrieveInstancesTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesTest.cpp
@@ -42,6 +42,9 @@ class MockGgpClient : public orbit_ggp::Client {
               (override));
   MOCK_METHOD(Future<ErrorMessageOr<SshInfo>>, GetSshInfoAsync,
               (const QString& /*instance_id*/, std::optional<Project> /*project*/), (override));
+  MOCK_METHOD(Future<ErrorMessageOr<SshInfo>>, GetSshInfoAsync,
+              (const QString& /*instance_id*/, std::optional<Project> /*project*/, int /*retry*/),
+              (override));
   MOCK_METHOD(Future<ErrorMessageOr<QVector<Project>>>, GetProjectsAsync, (), (override));
   MOCK_METHOD(Future<ErrorMessageOr<Project>>, GetDefaultProjectAsync, (), (override));
   MOCK_METHOD(Future<ErrorMessageOr<Instance>>, DescribeInstanceAsync,


### PR DESCRIPTION
This adds 3 retries for Client::GetSshInfoAsync, to tackle flaky ggp cli
and make e2e tests more stable. This is done by refactoring the code in
a way that reuses the same retrying mechanism for GetSshInfoAsync and
GetInstancesAsync, which already had a retry mechanism.

Test: Unit Test and manual test (Orbit still connects)
Bug: http://b/230794772