### PR TITLE
Add ProcessLauncherWidget to SessionSetupDialog

### DIFF
--- a/src/SessionSetup/CMakeLists.txt
+++ b/src/SessionSetup/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
           include/SessionSetup/OtherUserDialog.h
           include/SessionSetup/PersistentStorage.h
           include/SessionSetup/ProcessItemModel.h
+          include/SessionSetup/ProcessLauncherWidget.h
           include/SessionSetup/RetrieveInstances.h
           include/SessionSetup/RetrieveInstancesWidget.h
           include/SessionSetup/ServiceDeployManager.h
@@ -43,6 +44,8 @@ target_sources(
           OverlayWidget.ui
           PersistentStorage.cpp
           ProcessItemModel.cpp
+          ProcessLauncherWidget.cpp
+          ProcessLauncherWidget.ui
           RetrieveInstances.cpp
           RetrieveInstancesWidget.cpp
           RetrieveInstancesWidget.ui

--- a/src/SessionSetup/ProcessLauncherWidget.cpp
+++ b/src/SessionSetup/ProcessLauncherWidget.cpp
@@ -22,6 +22,8 @@ ProcessLauncherWidget::ProcessLauncherWidget(QWidget* parent)
   ui_->gridLayout_2->setColumnStretch(0, 90);
 }
 
+ProcessLauncherWidget ::~ProcessLauncherWidget() {}
+
 void ProcessLauncherWidget::on_BrowseProcessButton_clicked() {
   QString file = QFileDialog::getOpenFileName(this, "Select an executable file...");
   if (!file.isEmpty()) {

--- a/src/SessionSetup/ProcessLauncherWidget.cpp
+++ b/src/SessionSetup/ProcessLauncherWidget.cpp
@@ -24,36 +24,16 @@ ProcessLauncherWidget::ProcessLauncherWidget(QWidget* parent)
 
 ProcessLauncherWidget ::~ProcessLauncherWidget() {}
 
+void ProcessLauncherWidget::SetProcessManager(
+    orbit_client_services::ProcessManager* process_manager) {
+  process_manager_ = process_manager;
+}
+
 void ProcessLauncherWidget::on_BrowseProcessButton_clicked() {
   QString file = QFileDialog::getOpenFileName(this, "Select an executable file...");
   if (!file.isEmpty()) {
     ui_->ProcessComboBox->lineEdit()->setText(file);
   }
-}
-
-void ProcessLauncherWidget::on_LaunchButton_clicked() {
-  // TODO(b/225906734): Windows Process Launcher
-  // The code below is for reference. It shows how a subsequent PR will trigger a process launch and
-  // set the error label on failure.
-  //
-  // ORBIT_CHECK(process_manager_ != nullptr);
-  // QString process = ui->ProcessComboBox->lineEdit()->text();
-  // QString working_dir = ui->WorkingDirComboBox->lineEdit()->text();
-  // QString args = ui->ArgumentsComboBox->lineEdit()->text();
-  // bool pause_on_entry_point = ui->PauseAtEntryPoingCheckBox->isChecked();
-  //
-  // orbit_grpc_protos::ProcessToLaunch process_to_launch;
-  // process_to_launch.set_executable_path(process.toStdString());
-  // process_to_launch.set_working_directory(working_dir.toStdString());
-  // process_to_launch.set_arguments(args.toStdString());
-  // process_to_launch.set_spin_at_entry_point(pause_on_entry_point);
-  // auto result = process_manager_->LaunchProcess(process_to_launch);
-  //  if (result.has_error()) {
-  //    ui->ErrorLabel->setText(result.error().message().c_str());
-  // }
-  // else {
-  //  emit ProcessLaunched(result.value());
-  // }
 }
 
 void ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked() {
@@ -63,9 +43,8 @@ void ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked() {
   }
 }
 
-void ProcessLauncherWidget::SetProcessManager(
-    orbit_client_services::ProcessManager* process_manager) {
-  process_manager_ = process_manager;
+void ProcessLauncherWidget::on_LaunchButton_clicked() {
+  // TODO(b/225906734): Windows Process Launcher
 }
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/ProcessLauncherWidget.cpp
+++ b/src/SessionSetup/ProcessLauncherWidget.cpp
@@ -13,19 +13,14 @@
 namespace orbit_session_setup {
 
 ProcessLauncherWidget::ProcessLauncherWidget(QWidget* parent)
-    : QWidget(parent),
-      ui_(std::make_unique<Ui::ProcessLauncherWidget>()),
-      last_launched_process_or_error_(ErrorMessage()) {
+    : QWidget(parent), ui_(std::make_unique<Ui::ProcessLauncherWidget>()) {
   ui_->setupUi(this);
   ui_->ProcessComboBox->lineEdit()->setPlaceholderText("Process");
   ui_->WorkingDirComboBox->lineEdit()->setPlaceholderText("Working directory");
   ui_->ArgumentsComboBox->lineEdit()->setPlaceholderText("Arguments");
   ui_->ErrorLabel->setText("");
-
   ui_->gridLayout_2->setColumnStretch(0, 90);
 }
-
-ProcessLauncherWidget::~ProcessLauncherWidget() {}
 
 void ProcessLauncherWidget::on_BrowseProcessButton_clicked() {
   QString file = QFileDialog::getOpenFileName(this, "Select an executable file...");
@@ -49,16 +44,17 @@ void ProcessLauncherWidget::on_LaunchButton_clicked() {
   // process_to_launch.set_working_directory(working_dir.toStdString());
   // process_to_launch.set_arguments(args.toStdString());
   // process_to_launch.set_spin_at_entry_point(pause_on_entry_point);
-  // last_launched_process_or_error_ = process_manager_->LaunchProcess(process_to_launch);
-  //  if (last_launched_process_or_error_.has_error()) {
-  //    ui->ErrorLabel->setText(last_launched_process_or_error_.error().message().c_str());
+  // auto result = process_manager_->LaunchProcess(process_to_launch);
+  //  if (result.has_error()) {
+  //    ui->ErrorLabel->setText(result.error().message().c_str());
+  // }
+  // else {
+  //  emit ProcessLaunched(result.value());
   // }
 }
 
 void ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked() {
-  QString directory = QFileDialog::getExistingDirectory(
-      this, tr("Open Directory"), "/home",
-      QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+  QString directory = QFileDialog::getExistingDirectory(this, "Select a working directory");
   if (!directory.isEmpty()) {
     ui_->WorkingDirComboBox->lineEdit()->setText(directory);
   }
@@ -67,13 +63,6 @@ void ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked() {
 void ProcessLauncherWidget::SetProcessManager(
     orbit_client_services::ProcessManager* process_manager) {
   process_manager_ = process_manager;
-}
-
-QPushButton* ProcessLauncherWidget::GetLaunchButton() { return ui_->LaunchButton; }
-
-const ErrorMessageOr<orbit_grpc_protos::ProcessInfo>&
-ProcessLauncherWidget::GetLastLaunchedProcessOrError() const {
-  return last_launched_process_or_error_;
 }
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/ProcessLauncherWidget.cpp
+++ b/src/SessionSetup/ProcessLauncherWidget.cpp
@@ -14,24 +14,23 @@ namespace orbit_session_setup {
 
 ProcessLauncherWidget::ProcessLauncherWidget(QWidget* parent)
     : QWidget(parent),
-      ui(new Ui::ProcessLauncherWidget),
+      ui_(std::make_unique<Ui::ProcessLauncherWidget>()),
       last_launched_process_or_error_(ErrorMessage()) {
-  ui->setupUi(this);
-  ui->ProcessComboBox->lineEdit()->setPlaceholderText("Process");
-  ui->WorkingDirComboBox->lineEdit()->setPlaceholderText("Working directory");
-  ui->ArgumentsComboBox->lineEdit()->setPlaceholderText("Arguments");
-  ui->ErrorLabel->setText("");
+  ui_->setupUi(this);
+  ui_->ProcessComboBox->lineEdit()->setPlaceholderText("Process");
+  ui_->WorkingDirComboBox->lineEdit()->setPlaceholderText("Working directory");
+  ui_->ArgumentsComboBox->lineEdit()->setPlaceholderText("Arguments");
+  ui_->ErrorLabel->setText("");
 
-  ui->gridLayout_2->setColumnStretch(0, 90);
+  ui_->gridLayout_2->setColumnStretch(0, 90);
 }
 
-ProcessLauncherWidget::~ProcessLauncherWidget() { delete ui; }
+ProcessLauncherWidget::~ProcessLauncherWidget() {}
 
 void ProcessLauncherWidget::on_BrowseProcessButton_clicked() {
-  QStringList list = QFileDialog::getOpenFileNames(this, "Select an executable file...");
-  for (auto& file : list) {
-    ui->ProcessComboBox->lineEdit()->setText(file);
-    break;
+  QString file = QFileDialog::getOpenFileName(this, "Select an executable file...");
+  if (!file.isEmpty()) {
+    ui_->ProcessComboBox->lineEdit()->setText(file);
   }
 }
 
@@ -57,13 +56,24 @@ void ProcessLauncherWidget::on_LaunchButton_clicked() {
 }
 
 void ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked() {
-  ORBIT_LOG("ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked()");
-  QString dir = QFileDialog::getExistingDirectory(
+  QString directory = QFileDialog::getExistingDirectory(
       this, tr("Open Directory"), "/home",
       QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
-  ui->WorkingDirComboBox->lineEdit()->setText(dir);
+  if (!directory.isEmpty()) {
+    ui_->WorkingDirComboBox->lineEdit()->setText(directory);
+  }
 }
 
-QPushButton* ProcessLauncherWidget::GetLaunchButton() { return ui->LaunchButton; }
+void ProcessLauncherWidget::SetProcessManager(
+    orbit_client_services::ProcessManager* process_manager) {
+  process_manager_ = process_manager;
+}
+
+QPushButton* ProcessLauncherWidget::GetLaunchButton() { return ui_->LaunchButton; }
+
+const ErrorMessageOr<orbit_grpc_protos::ProcessInfo>&
+ProcessLauncherWidget::GetLastLaunchedProcessOrError() const {
+  return last_launched_process_or_error_;
+}
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/ProcessLauncherWidget.cpp
+++ b/src/SessionSetup/ProcessLauncherWidget.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SessionSetup/ProcessLauncherWidget.h"
+
+#include <QFileDialog>
+#include <QLineEdit>
+
+#include "OrbitBase/Logging.h"
+#include "ui_ProcessLauncherWidget.h"
+
+namespace orbit_session_setup {
+
+ProcessLauncherWidget::ProcessLauncherWidget(QWidget* parent)
+    : QWidget(parent),
+      ui(new Ui::ProcessLauncherWidget),
+      last_launched_process_or_error_(ErrorMessage()) {
+  ui->setupUi(this);
+  ui->ProcessComboBox->lineEdit()->setPlaceholderText("Process");
+  ui->WorkingDirComboBox->lineEdit()->setPlaceholderText("Working directory");
+  ui->ArgumentsComboBox->lineEdit()->setPlaceholderText("Arguments");
+  ui->ErrorLabel->setText("");
+
+  ui->gridLayout_2->setColumnStretch(0, 90);
+}
+
+ProcessLauncherWidget::~ProcessLauncherWidget() { delete ui; }
+
+void ProcessLauncherWidget::on_BrowseProcessButton_clicked() {
+  QStringList list = QFileDialog::getOpenFileNames(this, "Select an executable file...");
+  for (auto& file : list) {
+    ui->ProcessComboBox->lineEdit()->setText(file);
+    break;
+  }
+}
+
+void ProcessLauncherWidget::on_LaunchButton_clicked() {
+  // The code below is for reference. It shows how a subsequent PR will trigger a process launch and
+  // set the error label on failure.
+  //
+  // ORBIT_CHECK(process_manager_ != nullptr);
+  // QString process = ui->ProcessComboBox->lineEdit()->text();
+  // QString working_dir = ui->WorkingDirComboBox->lineEdit()->text();
+  // QString args = ui->ArgumentsComboBox->lineEdit()->text();
+  // bool pause_on_entry_point = ui->PauseAtEntryPoingCheckBox->isChecked();
+  //
+  // orbit_grpc_protos::ProcessToLaunch process_to_launch;
+  // process_to_launch.set_executable_path(process.toStdString());
+  // process_to_launch.set_working_directory(working_dir.toStdString());
+  // process_to_launch.set_arguments(args.toStdString());
+  // process_to_launch.set_spin_at_entry_point(pause_on_entry_point);
+  // last_launched_process_or_error_ = process_manager_->LaunchProcess(process_to_launch);
+  //  if (last_launched_process_or_error_.has_error()) {
+  //    ui->ErrorLabel->setText(last_launched_process_or_error_.error().message().c_str());
+  // }
+}
+
+void ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked() {
+  ORBIT_LOG("ProcessLauncherWidget::on_BrowseWorkingDirButton_clicked()");
+  QString dir = QFileDialog::getExistingDirectory(
+      this, tr("Open Directory"), "/home",
+      QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+  ui->WorkingDirComboBox->lineEdit()->setText(dir);
+}
+
+QPushButton* ProcessLauncherWidget::GetLaunchButton() { return ui->LaunchButton; }
+
+}  // namespace orbit_session_setup

--- a/src/SessionSetup/ProcessLauncherWidget.cpp
+++ b/src/SessionSetup/ProcessLauncherWidget.cpp
@@ -30,6 +30,7 @@ void ProcessLauncherWidget::on_BrowseProcessButton_clicked() {
 }
 
 void ProcessLauncherWidget::on_LaunchButton_clicked() {
+  // TODO(b/225906734): Windows Process Launcher
   // The code below is for reference. It shows how a subsequent PR will trigger a process launch and
   // set the error label on failure.
   //

--- a/src/SessionSetup/ProcessLauncherWidget.ui
+++ b/src/SessionSetup/ProcessLauncherWidget.ui
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ProcessLauncherWidget</class>
+ <widget class="QWidget" name="ProcessLauncherWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>550</width>
+    <height>416</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QFrame" name="frame">
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="LaunchProcessLabel">
+             <property name="text">
+              <string>Launch a process</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QComboBox" name="ProcessComboBox">
+             <property name="editable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QPushButton" name="BrowseProcessButton">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QComboBox" name="WorkingDirComboBox">
+             <property name="editable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QPushButton" name="BrowseWorkingDirButton">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QComboBox" name="ArgumentsComboBox">
+             <property name="editable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QPushButton" name="LaunchButton">
+             <property name="text">
+              <string>Launch</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QCheckBox" name="PauseAtEntryPoingCheckBox">
+             <property name="toolTip">
+              <string>Resume exectution by starting a capture</string>
+             </property>
+             <property name="text">
+              <string>Pause at Entry Point</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>198</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="ErrorLabel">
+             <property name="text">
+              <string>ErrorLabel</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -115,9 +115,8 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
   ui_->processesTableView->verticalHeader()->setDefaultSectionSize(kProcessesRowHeight);
   ui_->processesTableView->verticalHeader()->setVisible(false);
 
-  if (absl::GetFlag(FLAGS_local)) {
-    ui_->localFrame->setVisible(true);
-  }
+  ui_->localFrame->setVisible(absl::GetFlag(FLAGS_local));
+  ui_->processLauncherWidget->setVisible(absl::GetFlag(FLAGS_devmode));
 
   // If a user clicks on the localProfilingRadioButton when it is already checked, it will not
   // become unchecked.
@@ -131,6 +130,8 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
   QObject::connect(ui_->processFilterLineEdit, &QLineEdit::textChanged, &process_proxy_model_,
                    &QSortFilterProxyModel::setFilterFixedString);
   QObject::connect(ui_->confirmButton, &QPushButton::clicked, this, &QDialog::accept);
+  QObject::connect(ui_->processLauncherWidget->GetLaunchButton(), &QPushButton::clicked, this,
+                   &SessionSetupDialog::ProcessLaunched);
   QObject::connect(ui_->loadCaptureWidget, &LoadCaptureWidget::FileSelected, this,
                    [this](std::filesystem::path path) { selected_file_path_ = std::move(path); });
   QObject::connect(ui_->loadCaptureWidget, &LoadCaptureWidget::SelectionConfirmed, this,
@@ -226,6 +227,7 @@ void SessionSetupDialog::SetupStadiaStates() {
   state_stadia_.assignProperty(ui_->stadiaWidget, "active", true);
   state_stadia_.assignProperty(ui_->loadCaptureWidget, "active", false);
   state_stadia_.assignProperty(ui_->localProfilingRadioButton, "checked", false);
+  state_stadia_.assignProperty(ui_->processLauncherWidget, "enabled", false);
 
   // STATE state_stadia_connecting_
   state_stadia_connecting_.assignProperty(ui_->processesFrame, "enabled", false);
@@ -302,6 +304,7 @@ void SessionSetupDialog::SetupLocalStates() {
   state_local_.assignProperty(ui_->localProfilingRadioButton, "checked", true);
   state_local_.assignProperty(ui_->stadiaWidget, "active", false);
   state_local_.assignProperty(ui_->loadCaptureWidget, "active", false);
+  state_local_.assignProperty(ui_->processLauncherWidget, "enabled", false);
 
   // STATE state_local_connecting_
   state_local_connecting_.assignProperty(ui_->localProfilingStatusMessage, "text", "Connecting...");
@@ -312,6 +315,7 @@ void SessionSetupDialog::SetupLocalStates() {
 
   // STATE state_local_connected_
   state_local_connected_.assignProperty(ui_->localProfilingStatusMessage, "text", "Connected");
+  state_local_connected_.assignProperty(ui_->processLauncherWidget, "enabled", true);
 
   // STATE state_local_processes_loading_
   state_local_processes_loading_.assignProperty(ui_->processesTableOverlay, "visible", true);
@@ -374,6 +378,7 @@ void SessionSetupDialog::SetupFileStates() {
   state_file_.assignProperty(ui_->loadCaptureWidget, "active", true);
   state_file_.assignProperty(ui_->processesFrame, "enabled", false);
   state_file_.assignProperty(ui_->localProfilingRadioButton, "checked", false);
+  state_file_.assignProperty(ui_->processLauncherWidget, "enabled", false);
 
   // STATE state_file_selected_
   state_file_selected_.assignProperty(ui_->confirmButton, "enabled", true);
@@ -496,7 +501,20 @@ void SessionSetupDialog::ConnectToLocal() {
   SetupLocalProcessManager();
 }
 
-void SessionSetupDialog::SetupLocalProcessManager() { SetupProcessManager(local_grpc_channel_); }
+void SessionSetupDialog::SetupLocalProcessManager() {
+  SetupProcessManager(local_grpc_channel_);
+  ui_->processLauncherWidget->SetProcessManager(process_manager_.get());
+}
+
+void SessionSetupDialog::ProcessLaunched() {
+  const ErrorMessageOr<orbit_grpc_protos::ProcessInfo>& process_info_or_error =
+      ui_->processLauncherWidget->GetLastLaunchedProcessOrError();
+  if (process_info_or_error.has_value()) {
+    process_ = std::make_unique<orbit_client_data::ProcessData>(process_info_or_error.value());
+    emit ProcessSelected();
+    accept();
+  }
+}
 
 void SessionSetupDialog::SetTargetAndStateMachineInitialState(StadiaTarget target) {
   state_machine_.setInitialState(&state_stadia_);

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -130,7 +130,7 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
   QObject::connect(ui_->processFilterLineEdit, &QLineEdit::textChanged, &process_proxy_model_,
                    &QSortFilterProxyModel::setFilterFixedString);
   QObject::connect(ui_->confirmButton, &QPushButton::clicked, this, &QDialog::accept);
-  QObject::connect(ui_->processLauncherWidget->GetLaunchButton(), &QPushButton::clicked, this,
+  QObject::connect(ui_->processLauncherWidget, &ProcessLauncherWidget::ProcessLaunched, this,
                    &SessionSetupDialog::ProcessLaunched);
   QObject::connect(ui_->loadCaptureWidget, &LoadCaptureWidget::FileSelected, this,
                    [this](std::filesystem::path path) { selected_file_path_ = std::move(path); });
@@ -506,14 +506,10 @@ void SessionSetupDialog::SetupLocalProcessManager() {
   ui_->processLauncherWidget->SetProcessManager(process_manager_.get());
 }
 
-void SessionSetupDialog::ProcessLaunched() {
-  const ErrorMessageOr<orbit_grpc_protos::ProcessInfo>& process_info_or_error =
-      ui_->processLauncherWidget->GetLastLaunchedProcessOrError();
-  if (process_info_or_error.has_value()) {
-    process_ = std::make_unique<orbit_client_data::ProcessData>(process_info_or_error.value());
-    emit ProcessSelected();
-    accept();
-  }
+void SessionSetupDialog::ProcessLaunched(const orbit_grpc_protos::ProcessInfo& process_info) {
+  process_ = std::make_unique<orbit_client_data::ProcessData>(process_info);
+  emit ProcessSelected();
+  accept();
 }
 
 void SessionSetupDialog::SetTargetAndStateMachineInitialState(StadiaTarget target) {

--- a/src/SessionSetup/SessionSetupDialog.ui
+++ b/src/SessionSetup/SessionSetupDialog.ui
@@ -82,12 +82,9 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="orbit_session_setup::ConnectToStadiaWidget" name="stadiaWidget" native="true"/>
-         </item>
-         <item>
           <widget class="QFrame" name="localFrame">
            <property name="visible">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <property name="frameShape">
             <enum>QFrame::StyledPanel</enum>
@@ -95,41 +92,51 @@
            <property name="frameShadow">
             <enum>QFrame::Raised</enum>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout">
+           <layout class="QVBoxLayout" name="verticalLayout_6">
             <item>
-             <widget class="QRadioButton" name="localProfilingRadioButton">
-              <property name="font">
-               <font>
-                <pointsize>12</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Local profiling</string>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QRadioButton" name="localProfilingRadioButton">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Local profiling</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QLabel" name="localProfilingStatusMessage">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="localProfilingStatusMessage">
-              <property name="text">
-               <string/>
-              </property>
-             </widget>
+             <widget class="orbit_session_setup::ProcessLauncherWidget" name="processLauncherWidget" native="true"/>
             </item>
            </layout>
           </widget>
+         </item>
+         <item>
+          <widget class="orbit_session_setup::ConnectToStadiaWidget" name="stadiaWidget" native="true"/>
          </item>
          <item>
           <widget class="orbit_capture_file_info::LoadCaptureWidget" name="loadCaptureWidget" native="true"/>
@@ -335,6 +342,12 @@
    <class>orbit_session_setup::TargetLabel</class>
    <extends>QWidget</extends>
    <header>SessionSetup/TargetLabel.h</header>
+  </customwidget>
+  <customwidget>
+   <class>orbit_session_setup::ProcessLauncherWidget</class>
+   <extends>QWidget</extends>
+   <header>SessionSetup/ProcessLauncherWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/SessionSetup/SessionSetupDialog.ui
+++ b/src/SessionSetup/SessionSetupDialog.ui
@@ -83,6 +83,12 @@
          </property>
          <item>
           <widget class="QFrame" name="localFrame">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="visible">
             <bool>true</bool>
            </property>

--- a/src/SessionSetup/include/SessionSetup/ProcessLauncherWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessLauncherWidget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -7,6 +7,7 @@
 
 #include <QPushButton>
 #include <QWidget>
+#include <memory>
 
 #include "ClientServices/ProcessManager.h"
 
@@ -20,14 +21,13 @@ class ProcessLauncherWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit ProcessLauncherWidget(QWidget* parent = 0);
-  ~ProcessLauncherWidget();
+  explicit ProcessLauncherWidget(QWidget* parent = nullptr);
+  ~ProcessLauncherWidget() override;
 
-  void SetProcessManager(orbit_client_services::ProcessManager* process_manager) {
-    process_manager_ = process_manager;
-  }
-
+  void SetProcessManager(orbit_client_services::ProcessManager* process_manager);
   [[nodiscard]] QPushButton* GetLaunchButton();
+  [[nodiscard]] const ErrorMessageOr<orbit_grpc_protos::ProcessInfo>&
+  GetLastLaunchedProcessOrError() const;
 
   struct ProcessToLaunch {
     std::string executable_path;
@@ -36,17 +36,13 @@ class ProcessLauncherWidget : public QWidget {
     bool spin_on_entry_point;
   };
 
-  const ErrorMessageOr<orbit_grpc_protos::ProcessInfo>& GetLastLaunchedProcessOrError() const {
-    return last_launched_process_or_error_;
-  }
-
  private slots:
   void on_BrowseProcessButton_clicked();
   void on_BrowseWorkingDirButton_clicked();
   void on_LaunchButton_clicked();
 
  private:
-  Ui::ProcessLauncherWidget* ui;
+  std::unique_ptr<Ui::ProcessLauncherWidget> ui_;
 
   ErrorMessageOr<orbit_grpc_protos::ProcessInfo> last_launched_process_or_error_;
   orbit_client_services::ProcessManager* process_manager_ = nullptr;

--- a/src/SessionSetup/include/SessionSetup/ProcessLauncherWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessLauncherWidget.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SESSION_SETUP_PROCESS_LAUNCHER_WIDGET_H_
+#define SESSION_SETUP_PROCESS_LAUNCHER_WIDGET_H_
+
+#include <QPushButton>
+#include <QWidget>
+
+#include "ClientServices/ProcessManager.h"
+
+namespace Ui {
+class ProcessLauncherWidget;
+}
+
+namespace orbit_session_setup {
+
+class ProcessLauncherWidget : public QWidget {
+  Q_OBJECT
+
+ public:
+  explicit ProcessLauncherWidget(QWidget* parent = 0);
+  ~ProcessLauncherWidget();
+
+  void SetProcessManager(orbit_client_services::ProcessManager* process_manager) {
+    process_manager_ = process_manager;
+  }
+
+  [[nodiscard]] QPushButton* GetLaunchButton();
+
+  struct ProcessToLaunch {
+    std::string executable_path;
+    std::string working_directory;
+    std::string arguments;
+    bool spin_on_entry_point;
+  };
+
+  const ErrorMessageOr<orbit_grpc_protos::ProcessInfo>& GetLastLaunchedProcessOrError() const {
+    return last_launched_process_or_error_;
+  }
+
+ private slots:
+  void on_BrowseProcessButton_clicked();
+  void on_BrowseWorkingDirButton_clicked();
+  void on_LaunchButton_clicked();
+
+ private:
+  Ui::ProcessLauncherWidget* ui;
+
+  ErrorMessageOr<orbit_grpc_protos::ProcessInfo> last_launched_process_or_error_;
+  orbit_client_services::ProcessManager* process_manager_ = nullptr;
+};
+
+}  // namespace orbit_session_setup
+
+#endif  // SESSION_SETUP_PROCESS_LAUNCHER_WIDGET_H_

--- a/src/SessionSetup/include/SessionSetup/ProcessLauncherWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessLauncherWidget.h
@@ -23,6 +23,7 @@ class ProcessLauncherWidget : public QWidget {
 
  public:
   explicit ProcessLauncherWidget(QWidget* parent = nullptr);
+  ~ProcessLauncherWidget() override;
   void SetProcessManager(orbit_client_services::ProcessManager* process_manager);
 
  signals:

--- a/src/SessionSetup/include/SessionSetup/ProcessLauncherWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessLauncherWidget.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 #include <memory>
 
+#include "ClientData/ProcessData.h"
 #include "ClientServices/ProcessManager.h"
 
 namespace Ui {
@@ -22,19 +23,10 @@ class ProcessLauncherWidget : public QWidget {
 
  public:
   explicit ProcessLauncherWidget(QWidget* parent = nullptr);
-  ~ProcessLauncherWidget() override;
-
   void SetProcessManager(orbit_client_services::ProcessManager* process_manager);
-  [[nodiscard]] QPushButton* GetLaunchButton();
-  [[nodiscard]] const ErrorMessageOr<orbit_grpc_protos::ProcessInfo>&
-  GetLastLaunchedProcessOrError() const;
 
-  struct ProcessToLaunch {
-    std::string executable_path;
-    std::string working_directory;
-    std::string arguments;
-    bool spin_on_entry_point;
-  };
+ signals:
+  void ProcessLaunched(const orbit_grpc_protos::ProcessInfo& process_info);
 
  private slots:
   void on_BrowseProcessButton_clicked();
@@ -43,8 +35,6 @@ class ProcessLauncherWidget : public QWidget {
 
  private:
   std::unique_ptr<Ui::ProcessLauncherWidget> ui_;
-
-  ErrorMessageOr<orbit_grpc_protos::ProcessInfo> last_launched_process_or_error_;
   orbit_client_services::ProcessManager* process_manager_ = nullptr;
 };
 

--- a/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
@@ -52,7 +52,7 @@ class SessionSetupDialog : public QDialog {
   void TearDownProcessManager();
   void ProcessSelectionChanged(const QModelIndex& current);
   void ConnectToLocal();
-  void ProcessLaunched();
+  void ProcessLaunched(const orbit_grpc_protos::ProcessInfo& process_info);
 
  signals:
   void ProcessSelected();

--- a/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
@@ -52,6 +52,7 @@ class SessionSetupDialog : public QDialog {
   void TearDownProcessManager();
   void ProcessSelectionChanged(const QModelIndex& current);
   void ConnectToLocal();
+  void ProcessLaunched();
 
  signals:
   void ProcessSelected();


### PR DESCRIPTION
Add UI for upcoming feature to allow profiling from entry
point. This adds a widget to specify an executable to launch,
arguments and a working directory, as well as a checkbox to
control whether we should pause the launched process at entry
point.

https://screenshot.googleplex.com/95pLBxXXL7yYCAA.png

The widget is only visible when launching Orbit with
"--local" and "--devmode".

The full feature is implemented in #3599, of which the current
PR is a subset.