### PR TITLE
Set ModuleInfo's object_file_type on Windows

### DIFF
--- a/src/WindowsProcessService/ProcessServiceImpl.cpp
+++ b/src/WindowsProcessService/ProcessServiceImpl.cpp
@@ -95,6 +95,7 @@ Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
     module_info->set_address_start(module.address_start);
     module_info->set_address_end(module.address_end);
     module_info->set_build_id(module.build_id);
+    module_info->set_object_file_type(ModuleInfo::kCoffFile);
   }
 
   return Status::OK;

--- a/src/WindowsTracing/TracerImpl.cpp
+++ b/src/WindowsTracing/TracerImpl.cpp
@@ -62,6 +62,7 @@ void TracerImpl::SendModulesSnapshot() {
     module_info->set_address_start(module.address_start);
     module_info->set_address_end(module.address_end);
     module_info->set_build_id(module.build_id);
+    module_info->set_object_file_type(ModuleInfo::kCoffFile);
   }
 
   listener_->OnModulesSnapshot(std::move(modules_snapshot));


### PR DESCRIPTION
This fixes Orbit not finding pdb's in the module's directory.