### PR TITLE
Add Windows ProcessLauncher

### DIFF
--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(WindowsUtils PUBLIC
         include/WindowsUtils/ListThreads.h
         include/WindowsUtils/OpenProcess.h
         include/WindowsUtils/PathConverter.h
+        include/WindowsUtils/ProcessLauncher.h
         include/WindowsUtils/ProcessList.h
         include/WindowsUtils/ReadProcessMemory.h
         include/WindowsUtils/SafeHandle.h
@@ -48,6 +49,7 @@ target_sources(WindowsUtils PRIVATE
         ListThreads.cpp
         OpenProcess.cpp
         PathConverter.cpp
+        ProcessLauncher.cpp
         ProcessList.cpp
         ReadProcessMemory.cpp
         SafeHandle.cpp
@@ -70,6 +72,7 @@ target_sources(WindowsUtilsTests PRIVATE
         ListThreadsTest.cpp
         OpenProcessTest.cpp
         PathConverterTest.cpp
+        ProcessLauncherTest.cpp
         ProcessListTest.cpp
         ReadProcessMemoryTest.cpp
         SafeHandleTest.cpp

--- a/src/WindowsUtils/ProcessLauncher.cpp
+++ b/src/WindowsUtils/ProcessLauncher.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/WindowsUtils/ProcessLauncher.cpp
+++ b/src/WindowsUtils/ProcessLauncher.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "WindowsUtils/ProcessLauncher.h"
+
+#include "WindowsUtils/CreateProcess.h"
+
+namespace orbit_windows_utils {
+
+using orbit_windows_utils::BusyLoopInfo;
+using orbit_windows_utils::BusyLoopLauncher;
+using orbit_windows_utils::ProcessInfo;
+
+ErrorMessageOr<uint32_t> ProcessLauncher::LaunchProcess(
+    const std::filesystem::path& executable, const std::filesystem::path& working_directory,
+    const std::string_view arguments, bool pause_at_entry_point) {
+  if (pause_at_entry_point) {
+    return LaunchProcessPausedAtEntryPoint(executable, working_directory, arguments);
+  } else {
+    return LaunchProcess(executable, working_directory, arguments);
+  }
+}
+
+ErrorMessageOr<uint32_t> ProcessLauncher::LaunchProcess(
+    const std::filesystem::path& executable, const std::filesystem::path& working_directory,
+    const std::string_view arguments) {
+  OUTCOME_TRY(ProcessInfo & process_info,
+              orbit_windows_utils::CreateProcess(executable, working_directory, arguments));
+  return process_info.process_id;
+}
+
+ErrorMessageOr<uint32_t> ProcessLauncher::LaunchProcessPausedAtEntryPoint(
+    const std::filesystem::path& executable, const std::filesystem::path& working_directory,
+    const std::string_view arguments) {
+  std::unique_ptr<BusyLoopLauncher> launcher = std::make_unique<BusyLoopLauncher>();
+  OUTCOME_TRY(BusyLoopInfo busy_loop_info,
+              launcher->StartWithBusyLoopAtEntryPoint(executable, working_directory, arguments));
+  uint32_t pid = busy_loop_info.process_id;
+  absl::MutexLock lock(&mutex_);
+  ORBIT_CHECK(busy_loop_launchers_by_pid_.count(pid) == 0);
+  busy_loop_launchers_by_pid_.emplace(pid, std::move(launcher));
+  return pid;
+}
+
+ErrorMessageOr<void> ProcessLauncher::SuspendProcess(uint32_t process_id) {
+  absl::MutexLock lock(&mutex_);
+  auto it = busy_loop_launchers_by_pid_.find(process_id);
+  if (it == busy_loop_launchers_by_pid_.end()) {
+    return ErrorMessage("Trying to suspend unknown process");
+  }
+  BusyLoopLauncher* launcher = it->second.get();
+  OUTCOME_TRY(launcher->SuspendMainThreadAndRemoveBusyLoop());
+  return outcome::success();
+}
+
+ErrorMessageOr<void> ProcessLauncher::ResumeProcess(uint32_t process_id) {
+  absl::MutexLock lock(&mutex_);
+  auto it = busy_loop_launchers_by_pid_.find(process_id);
+  if (it == busy_loop_launchers_by_pid_.end()) {
+    return ErrorMessage("Trying to resume unknown process");
+  }
+  BusyLoopLauncher* launcher = it->second.get();
+  OUTCOME_TRY(launcher->ResumeMainThread());
+  busy_loop_launchers_by_pid_.erase(process_id);
+  return outcome::success();
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/ProcessLauncherTest.cpp
+++ b/src/WindowsUtils/ProcessLauncherTest.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/str_format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadConstants.h"
+#include "TestUtils/TestUtils.h"
+#include "WindowsUtils/ProcessLauncher.h"
+
+namespace orbit_windows_utils {
+
+namespace {
+
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
+
+[[nodiscard]] std::filesystem::path GetTestExecutablePath() {
+  static auto path = orbit_base::GetExecutableDir() / "FakeCliProgram.exe";
+  return path;
+}
+
+}  // namespace
+
+TEST(ProcessLauncher, LaunchProcess) {}
+
+TEST(ProcessLauncher, LaunchSuspendResumeProcess) {
+  ProcessLauncher launcher;
+  auto launch_result =
+      launcher.LaunchProcess(GetTestExecutablePath(), /*working_directory=*/"", /*arguments=*/"",
+                             /*pause_at_entry_point*/ true);
+  ASSERT_THAT(launch_result, HasNoError());
+  uint32_t process_id = launch_result.value();
+
+  auto suspend_result = launcher.SuspendProcess(process_id);
+  ASSERT_THAT(suspend_result, HasNoError());
+
+  auto resume_result = launcher.ResumeProcess(process_id);
+  ASSERT_THAT(resume_result, HasNoError());
+}
+
+TEST(ProcessLauncher, LaunchNonExistingProcess) {
+  constexpr const char* non_existing_executable = R"(C:\non_existing_executable.exe)";
+  ProcessLauncher launcher;
+  auto result =
+      launcher.LaunchProcess(non_existing_executable, /*working_directory=*/"", /*arguments=*/"",
+                             /*pause_at_entry_point*/ false);
+  ASSERT_THAT(result, HasError("Executable does not exist"));
+}
+
+TEST(ProcessLauncher, SuspendNonExistingProcess) {
+  ProcessLauncher launcher;
+  auto result = launcher.SuspendProcess(orbit_base::kInvalidProcessId);
+  ASSERT_THAT(result, HasError("Trying to suspend unknown process"));
+}
+
+TEST(ProcessLauncher, ResumeNonExistingProcess) {
+  ProcessLauncher launcher;
+  auto result = launcher.ResumeProcess(orbit_base::kInvalidProcessId);
+  ASSERT_THAT(result, HasError("Trying to resume unknown process"));
+}
+
+}  // namespace orbit_windows_utils

--- a/src/WindowsUtils/include/WindowsUtils/BusyLoopLauncher.h
+++ b/src/WindowsUtils/include/WindowsUtils/BusyLoopLauncher.h
@@ -32,6 +32,7 @@ class BusyLoopLauncher : public DebugEventListener {
   ErrorMessageOr<void> SuspendMainThreadAndRemoveBusyLoop();
   ErrorMessageOr<void> ResumeMainThread();
 
+  bool IsProcessSuspended() const { return state_ == State::kMainThreadSuspended; }
   void WaitForProcessToExit();
 
  protected:

--- a/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
+++ b/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef WINDOWS_UTILS_PROCESS_LAUNCHER_H_
+#define WINDOWS_UTILS_PROCESS_LAUNCHER_H_
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/synchronization/mutex.h>
+
+#include "WindowsUtils/BusyLoopLauncher.h"
+
+namespace orbit_windows_utils {
+
+// Class used to launch a process, optionally pausing it at the entry point and
+// maintaining information required to suspend and resume the process main thread.
+class ProcessLauncher {
+ public:
+  ErrorMessageOr<uint32_t> LaunchProcess(const std::filesystem::path& executable,
+                                         const std::filesystem::path& working_directory,
+                                         const std::string_view arguments,
+                                         bool pause_at_entry_point);
+
+  ErrorMessageOr<void> SuspendProcess(uint32_t process_id);
+  ErrorMessageOr<void> ResumeProcess(uint32_t process_id);
+
+ private:
+  ErrorMessageOr<uint32_t> LaunchProcess(const std::filesystem::path& executable,
+                                         const std::filesystem::path& working_directory,
+                                         const std::string_view arguments);
+
+  ErrorMessageOr<uint32_t> LaunchProcessPausedAtEntryPoint(
+      const std::filesystem::path& executable, const std::filesystem::path& working_directory,
+      const std::string_view arguments);
+
+  absl::Mutex mutex_;
+  absl::flat_hash_map<uint32_t, std::unique_ptr<orbit_windows_utils::BusyLoopLauncher>>
+      busy_loop_launchers_by_pid_ GUARDED_BY(mutex_);
+};
+
+}  // namespace orbit_windows_utils
+
+#endif  // WINDOWS_UTILS_PROCESS_LAUNCHER_H_

--- a/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
+++ b/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
@@ -12,8 +12,10 @@
 
 namespace orbit_windows_utils {
 
-// Class used to launch a process, optionally pausing it at the entry point and
-// maintaining information required to suspend and resume the process main thread.
+// Class used to launch a process, optionally pausing it at the entry point and maintaining
+// information required to suspend and resume the process' main thread. A "paused" process is
+// initially busy-looping at entry point. To remove the busy loop but remain paused at entry,
+// we call "SuspendProcess". "ResumeProcess" can then be called to resume normal execution.
 class ProcessLauncher {
  public:
   ErrorMessageOr<uint32_t> LaunchProcess(const std::filesystem::path& executable,
@@ -23,7 +25,7 @@ class ProcessLauncher {
 
   // Suspend a process that is currently spinning ("paused") at entry point and replace the busy
   // loop by the original instructions. This call will fail if the process can't be found or if it
-  // is not in the paused state.
+  // is not in the spinning state.
   ErrorMessageOr<void> SuspendProcess(uint32_t process_id);
 
   // Resume a process that was suspended using the "SuspendProcess" method above. This call will

--- a/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
+++ b/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
@@ -21,7 +21,13 @@ class ProcessLauncher {
                                          const std::string_view arguments,
                                          bool pause_at_entry_point);
 
+  // Suspend a process that is currently spinning ("paused") at entry point and replace the busy
+  // loop by the original instructions. This call will fail if the process can't be found or if it
+  // is not in the paused state.
   ErrorMessageOr<void> SuspendProcess(uint32_t process_id);
+
+  // Resume a process that was suspended using the "SuspendProcess" method above. This call will
+  // fail if the process can't be found or if it is not in the suspended state.
   ErrorMessageOr<void> ResumeProcess(uint32_t process_id);
 
  private:


### PR DESCRIPTION
ProcessLauncher is a wrapper around CreateProcess and BusyLoopLauncher.
It is used to launch a process, optionally pausing it at the entry
point, and maintaining information required to suspend and resume the
process main thread.