### PR TITLE
Also request and handle mmap_data events

### DIFF
--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -166,6 +166,7 @@ struct MmapPerfEventData {
   uint64_t length;
   uint64_t page_offset;
   std::string filename;
+  bool executable;
   pid_t pid;
 };
 using MmapPerfEvent = TypedPerfEvent<MmapPerfEventData>;

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -64,7 +64,10 @@ int mmap_task_event_open(pid_t pid, int32_t cpu) {
   perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_DUMMY;
+  // Generate events for mmap (and mprotect) calls with the PROT_EXEC flag set.
   pe.mmap = 1;
+  // Generate events for mmap (and mprotect) calls that do not have the PROT_EXEC flag set.
+  pe.mmap_data = 1;
   pe.task = 1;
 
   return generic_event_open(&pe, pid, cpu);

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -31,6 +31,7 @@
 #include "OrbitBase/Logging.h"
 #include "PerfEvent.h"
 #include "PerfEventRecords.h"
+#include "Test/Path.h"
 #include "UprobesFunctionCallManager.h"
 #include "UprobesReturnAddressManager.h"
 #include "UprobesUnwindingVisitor.h"
@@ -91,6 +92,134 @@ class MockLeafFunctionCallManager : public LeafFunctionCallManager {
               (const CallchainSamplePerfEventData*, LibunwindstackMaps*, LibunwindstackUnwinder*),
               (override));
 };
+
+TEST(UprobesUnwindingVisitor, VisitMmapPerfEventUpdatesLibunwindstackMapsAndSendsModuleUpdates) {
+  static constexpr pid_t kPid = 42;
+
+  MockTracerListener listener;
+  UprobesFunctionCallManager function_call_manager;
+  MockUprobesReturnAddressManager return_address_manager{nullptr};
+  MockLibunwindstackMaps maps;
+  MockLibunwindstackUnwinder unwinder;
+  MockLeafFunctionCallManager leaf_function_call_manager{128};
+  UprobesUnwindingVisitor visitor{&listener,
+                                  &function_call_manager,
+                                  &return_address_manager,
+                                  &maps,
+                                  &unwinder,
+                                  &leaf_function_call_manager,
+                                  nullptr};
+
+  // 7f4b0c7ab000-7f4b0c845000 r-xp 00000000 00:00 0
+  // Anonymous executable mapping.
+  MmapPerfEvent anon_mmap_event{
+      .timestamp = 1,
+      .data =
+          {
+              .address = 0x7f4b0c7ab000,
+              .length = 0x9A000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps, AddAndSort(0x7f4b0c7ab000, 0x7f4b0c845000, 0, PROT_READ | PROT_EXEC, ""))
+      .Times(1);
+  PerfEvent(std::move(anon_mmap_event)).Accept(&visitor);
+
+  // 7fffffffe000-7ffffffff000 --xp 00000000 00:00 0    [uprobes]
+  // Special anonymous executable mapping.
+  MmapPerfEvent special_mmap_event{
+      .timestamp = 2,
+      .data =
+          {
+              .address = 0x7fffffffe000,
+              .length = 0x1000,
+              .page_offset = 0,
+              .filename = "[uprobes]",
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps,
+              AddAndSort(0x7fffffffe000, 0x7ffffffff000, 0, PROT_READ | PROT_EXEC, "[uprobes]"))
+      .Times(1);
+  PerfEvent(std::move(special_mmap_event)).Accept(&visitor);
+
+  const std::string test_binary_path = (orbit_test::GetTestdataDir() / "target_fp").string();
+
+  // 55bf53c22000-55bf53c24000 r-xp 00001000 fe:00 60425802    /path/to/target_fp
+  // File-backed executable mapping.
+  MmapPerfEvent file_mmap_event{
+      .timestamp = 3,
+      .data =
+          {
+              .address = 0x55bf53c22000,
+              .length = 0x2000,
+              .page_offset = 0x1000,
+              .filename = test_binary_path,
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps, AddAndSort(0x55bf53c22000, 0x55bf53c24000, 0x1000, PROT_READ | PROT_EXEC,
+                               test_binary_path))
+      .Times(1);
+  orbit_grpc_protos::ModuleUpdateEvent actual_module_update;
+  EXPECT_CALL(listener, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
+  PerfEvent(std::move(file_mmap_event)).Accept(&visitor);
+  EXPECT_EQ(actual_module_update.pid(), kPid);
+  EXPECT_EQ(actual_module_update.timestamp_ns(), 3);
+  EXPECT_EQ(actual_module_update.module().name(), "target_fp");
+  EXPECT_EQ(actual_module_update.module().file_path(), test_binary_path);
+  EXPECT_EQ(actual_module_update.module().file_size(), 27824);
+  EXPECT_EQ(actual_module_update.module().address_start(), 0x55bf53c22000);
+  EXPECT_EQ(actual_module_update.module().address_end(), 0x55bf53c24000);
+  EXPECT_EQ(actual_module_update.module().build_id(), "d7e2447f79faa88528dd0d130ac7cc5f168ca090");
+  EXPECT_EQ(actual_module_update.module().load_bias(), 0);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), 0x1000);
+  EXPECT_EQ(actual_module_update.module().soname(), "");
+  EXPECT_EQ(actual_module_update.module().object_file_type(),
+            orbit_grpc_protos::ModuleInfo::kElfFile);
+
+  // 55bf53c24000-55bf53c25000 r--p 00003000 fe:00 60425802    /path/to/target_fp
+  // File-backed non-executable mapping.
+  MmapPerfEvent file_mmap_data_event{
+      .timestamp = 4,
+      .data =
+          {
+              .address = 0x55bf53c24000,
+              .length = 0x1000,
+              .page_offset = 0x3000,
+              .filename = test_binary_path,
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps, AddAndSort(0x55bf53c24000, 0x55bf53c25000, 0x3000, PROT_READ, test_binary_path))
+      .Times(1);
+  PerfEvent(std::move(file_mmap_data_event)).Accept(&visitor);
+
+  // 7f4b0cabe000-7f4b0cad5000 r-xp 00003000 fe:00 50336180    /path/to/nothing
+  // File-backed executable mapping, but the file doesn't exist.
+  MmapPerfEvent bad_file_mmap_event{
+      .timestamp = 5,
+      .data =
+          {
+              .address = 0x7f4b0cabe000,
+              .length = 0x17000,
+              .page_offset = 0x3000,
+              .filename = "/path/to/nothing",
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps, AddAndSort(0x7f4b0cabe000, 0x7f4b0cad5000, 0x3000, PROT_READ | PROT_EXEC,
+                               "/path/to/nothing"))
+      .Times(1);
+  PerfEvent(std::move(bad_file_mmap_event)).Accept(&visitor);
+}
 
 class UprobesUnwindingVisitorTest : public ::testing::Test {
  protected:
@@ -530,9 +659,9 @@ TEST_F(UprobesUnwindingVisitorTest,
   }
 }
 
-//-------------------------------//
-// VISIT STACK SAMPLE PERF EVENT //
-//-------------------------------//
+//--------------------------------//
+// Visit StackSamplePerfEventData //
+//--------------------------------//
 
 TEST_F(UprobesUnwindingVisitorTest,
        VisitValidStackSampleWithoutUprobesSendsCompleteCallstackAndAddressInfos) {
@@ -1100,9 +1229,9 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
 }
 
-//-----------------------------------//
-// VISIT CALLCHAIN SAMPLE PERF EVENT //
-//-----------------------------------//
+//------------------------------------//
+// Visit CallchainSamplePerfEventData //
+//------------------------------------//
 
 TEST_F(UprobesUnwindingVisitorTest, VisitValidCallchainSampleWithoutUprobesSendsCallstack) {
   std::vector<uint64_t> callchain{


### PR DESCRIPTION
In other words, also include non-executable mappings when keeping our snapshot
of the target's maps up to date during a capture.

This will be needed to detect if a new anonymous executable mapping corresponds
to a PE .text section mapped anonymously by Wine, both for unwinding purposes in
`libunwindstack` and to send the corresponding `ModuleUpdateEvent`s. As a
reminder, the logic is the following:
Given an anonymous executable mapping, consider the previous file mapping, and
consider the "group" of mappings for this file. If this is a PE, and there is no
executable file mapping for this PE (in this "group" of mappings), and the
address range where the .text section of this PE should be mapped (based on the
address of the first mapping in the "group" and on the .text section's
`VirtualAddress` and `VirtualSize`) is contained in the anonymous mapping's
address range, then we can be fairly sure that the anonymous mapping does indeed
correspond to the .text of the PE.
See also https://github.com/google/orbit/pull/3568 and
https://github.com/google/orbit/pull/3590.

Bug: http://b/226562022

Test:
- Add unit test for
  `UprobesUnwindingVisitor::Visit(uint64_t, const MmapPerfEventData&)`;
- Capture Trata, including from the beginning with `--debug`, and verify things
  are in order;
- Tried as part of the prototype for mixed unwinding, including the detection of
  new mappings that correspond to anonymously mapped PE text sections, by
  capturing unaligned `triangle.exe` from the beginning with `--debug`.