### PR TITLE
Make the vertical scroolbar always visible

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -756,8 +756,9 @@ void TimeGraph::UpdateHorizontalSliderFromWorld() {
 
 void TimeGraph::UpdateVerticalSliderFromWorld() {
   float visible_tracks_height = GetTrackContainer()->GetVisibleTracksTotalHeight();
-  float max = std::max(0.f, visible_tracks_height - vertical_slider_->GetHeight());
-  float pos_ratio = max > 0 ? GetTrackContainer()->GetVerticalScrollingOffset() / max : 0.f;
+  float max_height = std::max(0.f, visible_tracks_height - vertical_slider_->GetHeight());
+  float pos_ratio =
+      max_height > 0 ? GetTrackContainer()->GetVerticalScrollingOffset() / max_height : 0.f;
   float size_ratio =
       visible_tracks_height > 0 ? vertical_slider_->GetHeight() / visible_tracks_height : 1.f;
   int slider_width = static_cast<int>(GetLayout().GetSliderWidth());


### PR DESCRIPTION
Since we are adding +/- buttons in the top-right corner, and given the
tracks and the timeline has to be vertically aligned because they share
min/max timestamps, there is no sense of making the vertical scrollbar
disappear when there are not too many tracks.

So, in this PR we simplified the way to update TimeGraph's children.
Now, TimeGraph never set the vertical scrollbar invisible.

In addition we are fixing a bug with the old-code (we were using the
viewport_->TotalHeight() instead of the height of the scrollbar itself.
This caused a small unalignment in the scrollbar.

http://screenshot/C97XFhSgT9CGKHQ.

Bug: http://b/230859340

Test: Load a capture, play with the vertical scrollbar and vertical
zoom. Start/Stop a capture.