### PR TITLE
Rework capture options dialogue

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -30,55 +30,66 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
 
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-  QObject::connect(ui_->unwindingMethodComboBox, qOverload<int>(&QComboBox::currentIndexChanged),
-                   ui_->maxCopyRawStackSizeLineEdit, [this]() {
-                     auto unwinding_method = ui_->unwindingMethodComboBox->currentData().toInt();
-                     ui_->maxCopyRawStackSizeLineEdit->setEnabled(unwinding_method ==
-                                                                  CaptureOptions::kFramePointers);
-                   });
-  QObject::connect(ui_->maxCopyRawStackSizeLineEdit, &QLineEdit::editingFinished,
-                   ui_->maxCopyRawStackSizeLineEdit, [this]() {
-                     if (ui_->maxCopyRawStackSizeLineEdit->text().isEmpty()) {
-                       ui_->maxCopyRawStackSizeLineEdit->setText(
-                           QString::number(kMaxCopyRawStackSizeDefaultValue));
-                     }
+  QObject::connect(ui_->framePointerUnwindingRadioButton, qOverload<bool>(&QRadioButton::toggled),
+                   ui_->maxCopyRawStackSizeWidget,
+                   [this](bool checked) { ui_->maxCopyRawStackSizeWidget->setEnabled(checked); });
+  QObject::connect(ui_->collectMemoryInfoCheckBox, qOverload<bool>(&QCheckBox::toggled),
+                   ui_->memoryHorizontalLayout, [this](bool checked) {
+                     ui_->memorySamplingPeriodMsLabel->setEnabled(checked);
+                     ui_->memorySamplingPeriodMsLineEdit->setEnabled(checked);
+                     ui_->memoryWarningThresholdKbLabel->setEnabled(checked);
+                     ui_->memoryWarningThresholdKbLineEdit->setEnabled(checked);
                    });
 
-  ui_->unwindingMethodComboBox->addItem("DWARF", static_cast<int>(CaptureOptions::kDwarf));
-  ui_->unwindingMethodComboBox->addItem("Frame pointers",
-                                        static_cast<int>(CaptureOptions::kFramePointers));
-  ui_->maxCopyRawStackSizeLineEdit->setText(QString::number(kMaxCopyRawStackSizeDefaultValue));
-  ui_->dynamicInstrumentationMethodComboBox->addItem(
-      "Kernel (Uprobes)", static_cast<int>(CaptureOptions::kKernelUprobes));
-  ui_->dynamicInstrumentationMethodComboBox->addItem(
-      "Orbit", static_cast<int>(CaptureOptions::kUserSpaceInstrumentation));
-  if (!absl::GetFlag(FLAGS_devmode)) {
-    // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
-    ui_->samplingCheckBox->hide();
-    ui_->unwindingMethodWidget->hide();
-    ui_->maxCopyRawStackSizeWidget->hide();
-    ui_->schedulerCheckBox->hide();
-    ui_->gpuSubmissionsCheckBox->hide();
-    ui_->introspectionCheckBox->hide();
-  }
+  QObject::connect(ui_->samplingCheckBox, qOverload<bool>(&QCheckBox::toggled),
+                   ui_->samplingPeriodMsHorizontalLayout, [this](bool checked) {
+                     ui_->samplingPeriodMsLabel->setEnabled(checked);
+                     ui_->samplingPeriodMsDoubleSpinBox->setEnabled(checked);
+                     ui_->unwindingMethodGroupBox->setEnabled(checked);
+                   });
 
-  ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);
-  ui_->memorySamplingPeriodMsLineEdit->setValidator(new UInt64Validator(
-      1, std::numeric_limits<uint64_t>::max(), ui_->memorySamplingPeriodMsLineEdit));
-  ui_->memoryWarningThresholdKbLineEdit->setValidator(&uint64_validator_);
-  ui_->maxCopyRawStackSizeLineEdit->setValidator(
-      new UInt64Validator(0, kMaxCopyRawStackSizeMaxValue, ui_->maxCopyRawStackSizeLineEdit));
+  ui_->samplingPeriodMsLabel->setEnabled(ui_->samplingCheckBox->isChecked());
+  ui_->samplingPeriodMsDoubleSpinBox->setEnabled(ui_->samplingCheckBox->isChecked());
+  ui_->unwindingMethodGroupBox->setEnabled(ui_->samplingCheckBox->isChecked());
 
+  ui_->framePointerUnwindingRadioButton->setToolTip(
+      "Frame-pointer unwinding has lower overhead, but requires all\n"
+      "binaries to be compiled with '-fno-omit-frame-pointer'.\n"
+      "Orbit also supports compiling with '-momit-leaf-frame-pointer'\n"
+      "in addition to '-fno-omit-frame-pointer', but this is optional.\n\n"
+      "Callstack samples containing functions not compiled with frame\n"
+      "pointers will result in unwinding errors.");
+
+  ui_->maxCopyRawStackSizeSpinBox->setValue(kMaxCopyRawStackSizeDefaultValue);
+  ui_->maxCopyRawStackSizeWidget->setEnabled(ui_->framePointerUnwindingRadioButton->isChecked());
   ui_->maxCopyRawStackSizeLabel->setToolTip(QString::fromStdString(
       "To improve performance, we don't require to preserve the frame pointer register on leaf\n"
-      "functions (-momit-leaf-frame-pointer). In order to recover the frame corresponding to the\n"
+      "functions ('-momit-leaf-frame-pointer'). In order to recover the frame corresponding to "
+      "the\n"
       "caller of a leaf function, we need to copy a portion of the raw stack and DWARF-unwind the\n"
       "first frame. Specify how much data Orbit should copy. A larger value reduces the number of\n"
       "unwind errors, but increases the performance overhead of sampling."));
 
+  ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);
+
+  ui_->memorySamplingPeriodMsLabel->setEnabled(ui_->collectMemoryInfoCheckBox->isChecked());
+  ui_->memorySamplingPeriodMsLineEdit->setEnabled(ui_->collectMemoryInfoCheckBox->isChecked());
+  ui_->memoryWarningThresholdKbLabel->setEnabled(ui_->collectMemoryInfoCheckBox->isChecked());
+  ui_->memoryWarningThresholdKbLineEdit->setEnabled(ui_->collectMemoryInfoCheckBox->isChecked());
+  ui_->memorySamplingPeriodMsLineEdit->setValidator(new UInt64Validator(
+      1, std::numeric_limits<uint64_t>::max(), ui_->memorySamplingPeriodMsLineEdit));
+  ui_->memoryWarningThresholdKbLineEdit->setValidator(&uint64_validator_);
   if (!absl::GetFlag(FLAGS_enable_warning_threshold)) {
     ui_->memoryWarningThresholdKbLabel->hide();
     ui_->memoryWarningThresholdKbLineEdit->hide();
+  }
+
+  if (!absl::GetFlag(FLAGS_devmode)) {
+    // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
+    ui_->samplingCheckBox->hide();
+    ui_->unwindingMethodGroupBox->hide();
+    ui_->schedulerCheckBox->hide();
+    ui_->devModeGroupBox->hide();
   }
 }
 
@@ -97,24 +108,38 @@ double CaptureOptionsDialog::GetSamplingPeriodMs() const {
 }
 
 void CaptureOptionsDialog::SetUnwindingMethod(UnwindingMethod unwinding_method) {
-  int index = ui_->unwindingMethodComboBox->findData(static_cast<int>(unwinding_method));
-  ORBIT_CHECK(index >= 0);
-  return ui_->unwindingMethodComboBox->setCurrentIndex(index);
+  switch (unwinding_method) {
+    case CaptureOptions::kDwarf:
+      ui_->dwarfUnwindingRadioButton->setChecked(true);
+      break;
+    case CaptureOptions::kFramePointers:
+      ui_->framePointerUnwindingRadioButton->setChecked(true);
+      break;
+    default:
+      ORBIT_UNREACHABLE();
+  }
 }
 
 UnwindingMethod CaptureOptionsDialog::GetUnwindingMethod() const {
-  return static_cast<UnwindingMethod>(ui_->unwindingMethodComboBox->currentData().toInt());
+  if (ui_->dwarfUnwindingRadioButton->isChecked()) {
+    ORBIT_CHECK(!ui_->framePointerUnwindingRadioButton->isChecked());
+    return CaptureOptions::kDwarf;
+  }
+  if (ui_->framePointerUnwindingRadioButton->isChecked()) {
+    ORBIT_CHECK(!ui_->dwarfUnwindingRadioButton->isChecked());
+    return CaptureOptions::kFramePointers;
+  }
+  ORBIT_UNREACHABLE();
 }
 
 void CaptureOptionsDialog::SetMaxCopyRawStackSize(uint16_t stack_dump_size) {
-  ui_->maxCopyRawStackSizeLineEdit->setText(QString::number(stack_dump_size));
+  ORBIT_CHECK(stack_dump_size % 8 == 0);
+  ui_->maxCopyRawStackSizeSpinBox->setValue(stack_dump_size);
 }
 
 uint16_t CaptureOptionsDialog::GetMaxCopyRawStackSize() const {
-  ORBIT_CHECK(!ui_->maxCopyRawStackSizeLineEdit->text().isEmpty());
-  bool valid = false;
-  uint16_t result = ui_->maxCopyRawStackSizeLineEdit->text().toUShort(&valid);
-  ORBIT_CHECK(valid);
+  uint16_t result = ui_->maxCopyRawStackSizeSpinBox->value();
+  ORBIT_CHECK(result % 8 == 0);
   return result;
 }
 
@@ -149,14 +174,28 @@ void CaptureOptionsDialog::SetEnableApi(bool enable_api) {
 bool CaptureOptionsDialog::GetEnableApi() const { return ui_->apiCheckBox->isChecked(); }
 
 void CaptureOptionsDialog::SetDynamicInstrumentationMethod(DynamicInstrumentationMethod method) {
-  const int index = ui_->dynamicInstrumentationMethodComboBox->findData(static_cast<int>(method));
-  ORBIT_CHECK(index >= 0);
-  ui_->dynamicInstrumentationMethodComboBox->setCurrentIndex(index);
+  switch (method) {
+    case CaptureOptions::kKernelUprobes:
+      ui_->uprobesRadioButton->setChecked(true);
+      break;
+    case CaptureOptions::kUserSpaceInstrumentation:
+      ui_->userSpaceRadioButton->setChecked(true);
+      break;
+    default:
+      ORBIT_UNREACHABLE();
+  }
 }
 
 DynamicInstrumentationMethod CaptureOptionsDialog::GetDynamicInstrumentationMethod() const {
-  return static_cast<DynamicInstrumentationMethod>(
-      ui_->dynamicInstrumentationMethodComboBox->currentData().toInt());
+  if (ui_->uprobesRadioButton->isChecked()) {
+    ORBIT_CHECK(!ui_->userSpaceRadioButton->isChecked());
+    return CaptureOptions::kKernelUprobes;
+  }
+  if (ui_->userSpaceRadioButton->isChecked()) {
+    ORBIT_CHECK(!ui_->uprobesRadioButton->isChecked());
+    return CaptureOptions::kUserSpaceInstrumentation;
+  }
+  ORBIT_UNREACHABLE();
 }
 
 void CaptureOptionsDialog::SetEnableIntrospection(bool enable_introspection) {

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>478</width>
-    <height>610</height>
+    <width>504</width>
+    <height>462</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,411 +20,450 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
    <property name="verticalSpacing">
     <number>9</number>
    </property>
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <property name="spacing">
-      <number>12</number>
-     </property>
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>General</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <item>
-         <widget class="QCheckBox" name="samplingCheckBox">
-          <property name="text">
-           <string>Enable callstack sampling</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="samplingPeriodMsHorizontalLayout">
-          <item>
-           <widget class="QLabel" name="samplingPeriodMsLabel">
-            <property name="text">
-             <string>Callstack sampling period (ms):</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QDoubleSpinBox" name="samplingPeriodMsDoubleSpinBox">
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="samplingPeriodMsHorizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="QWidget" name="unwindingMethodWidget" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="unwindingMethodLabel">
-             <property name="text">
-              <string>Callstack unwinding method:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="unwindingMethodComboBox"/>
-           </item>
-           <item>
-            <spacer name="unwindingMethodHorizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Expanding</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>112</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="maxCopyRawStackSizeWidget" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0,0">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="maxCopyRawStackSizeLabel">
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>[Frame pointers only] Max raw stack size to copy (Bytes):</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="maxCopyRawStackSizeLineEdit">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="maxLength">
-              <number>5</number>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="maxCopyRawStackSizeSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>80</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="schedulerCheckBox">
-          <property name="text">
-           <string>Collect scheduler information</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="threadStateCheckBox">
-          <property name="text">
-           <string>Collect thread states</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="gpuSubmissionsCheckBox">
-          <property name="text">
-           <string>Trace GPU queue submissions</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="apiCheckBox">
-          <property name="text">
-           <string>Enable Orbit Api in target</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="introspectionCheckBox">
-          <property name="text">
-           <string>Enable introspection</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="dynamicInstrumentationMethodWidget" native="true">
-          <property name="toolTip">
-           <string>Method 'Orbit' has lower overhead but is still experimental.</string>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>Dynamic Instrumentation method:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="dynamicInstrumentationMethodComboBox">
-             <property name="minimumSize">
-              <size>
-               <width>170</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="accessibleName">
-              <string>DynamicInstrumentationMethodComboBox</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_4">
-       <property name="title">
-        <string>Memory tracing</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_5">
-        <item>
-         <widget class="QCheckBox" name="collectMemoryInfoCheckBox">
-          <property name="text">
-           <string>Collect memory usage and page faults information</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="memoryHorizontalLayout">
-          <item>
-           <widget class="QLabel" name="memorySamplingPeriodMsLabel">
-            <property name="text">
-             <string>Sampling period (ms):</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="memorySamplingPeriodMsLineEdit">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="accessibleName">
-             <string>MemorySamplingPeriodEdit</string>
-            </property>
-            <property name="inputMethodHints">
-             <set>Qt::ImhDigitsOnly</set>
-            </property>
-            <property name="text">
-             <string>10</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>60</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QLabel" name="memoryWarningThresholdKbLabel">
-            <property name="text">
-             <string>Warning threshold (kB):</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="memoryWarningThresholdKbLineEdit">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="toolTip">
-             <string>The default value is 8388608 KB, i.e., 8GB.</string>
-            </property>
-            <property name="inputMethodHints">
-             <set>Qt::ImhDigitsOnly</set>
-            </property>
-            <property name="text">
-             <string>8388608</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_2">
-       <property name="toolTip">
-        <string>This requires Orbit's Vulkan layer to be loaded by the target process.</string>
-       </property>
-       <property name="title">
-        <string>Vulkan layer (requires Orbit's Vulkan layer to be loaded by the target)</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <item>
-         <layout class="QHBoxLayout" name="localMarkerDepthHorizontalLayout">
-          <item>
-           <widget class="QCheckBox" name="localMarkerDepthCheckBox">
-            <property name="text">
-             <string>Limit local depth of markers per command buffer to:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="localMarkerDepthLineEdit">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="toolTip">
-             <string>Limits the maximum depth of Vulkan debug markers per command buffer to the given value.
-Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</string>
-            </property>
-            <property name="inputMethodHints">
-             <set>Qt::ImhDigitsOnly</set>
-            </property>
-            <property name="text">
-             <string>3</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="1" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0">
-    <widget class="Line" name="line">
-     <property name="styleSheet">
-      <string notr="true">background: #353535</string>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>-380</y>
+        <width>470</width>
+        <height>753</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
+        <number>9</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="samplingGroupBox">
+         <property name="title">
+          <string>Sampling</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
+           <number>9</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="samplingCheckBox">
+            <property name="text">
+             <string>Enable callstack sampling</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="samplingPeriodMsHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="samplingPeriodMsLabel">
+              <property name="text">
+               <string>Callstack sampling period (ms):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="samplingPeriodMsDoubleSpinBox">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="minimum">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>10.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="samplingPeriodMsHorizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="unwindingMethodGroupBox">
+            <property name="title">
+             <string>Unwinding method</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_6">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="leftMargin">
+              <number>4</number>
+             </property>
+             <property name="topMargin">
+              <number>4</number>
+             </property>
+             <property name="rightMargin">
+              <number>4</number>
+             </property>
+             <property name="bottomMargin">
+              <number>4</number>
+             </property>
+             <item>
+              <widget class="QRadioButton" name="dwarfUnwindingRadioButton">
+               <property name="text">
+                <string>DWARF</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="framePointerUnwindingRadioButton">
+               <property name="text">
+                <string>Frame pointers | requires special build settings ⓘ</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="maxCopyRawStackSizeWidget" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0,0">
+                <property name="spacing">
+                 <number>6</number>
+                </property>
+                <property name="leftMargin">
+                 <number>20</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="maxCopyRawStackSizeLabel">
+                  <property name="toolTip">
+                   <string/>
+                  </property>
+                  <property name="text">
+                   <string>Max raw stack size to copy (multiple of 8 Bytes):</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="orbit_qt::MultipleOfSpinBox" name="maxCopyRawStackSizeSpinBox">
+                  <property name="minimum">
+                   <number>16</number>
+                  </property>
+                  <property name="maximum">
+                   <number>65528</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>8</number>
+                  </property>
+                  <property name="value">
+                   <number>512</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="maxCopyRawStackSizeSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>80</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="dynamicInstrumentationGroupBox">
+         <property name="toolTip">
+          <string>Method 'Orbit' has lower overhead but is still experimental.</string>
+         </property>
+         <property name="title">
+          <string>Dynamic instrumentation</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
+           <number>9</number>
+          </property>
+          <item>
+           <widget class="QRadioButton" name="uprobesRadioButton">
+            <property name="text">
+             <string>Kernel (uprobes)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="userSpaceRadioButton">
+            <property name="text">
+             <string>Orbit | experimental ⓘ</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="manualInstrumentationGroupBox">
+         <property name="title">
+          <string>Manual Instrumentation</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <widget class="QCheckBox" name="apiCheckBox">
+            <property name="text">
+             <string>Enable Orbit Api in target</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="memoryTracingGroupBox">
+         <property name="title">
+          <string>Memory tracing</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QCheckBox" name="collectMemoryInfoCheckBox">
+            <property name="text">
+             <string>Collect memory usage and page faults information</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="memoryHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="memorySamplingPeriodMsLabel">
+              <property name="text">
+               <string>Sampling period (ms):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="memorySamplingPeriodMsLineEdit">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="accessibleName">
+               <string>MemorySamplingPeriodEdit</string>
+              </property>
+              <property name="inputMethodHints">
+               <set>Qt::ImhDigitsOnly</set>
+              </property>
+              <property name="text">
+               <string>10</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>60</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="memoryWarningThresholdKbLabel">
+              <property name="text">
+               <string>Warning threshold (kB):</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="memoryWarningThresholdKbLineEdit">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="toolTip">
+               <string>The default value is 8388608 KB, i.e., 8GB.</string>
+              </property>
+              <property name="inputMethodHints">
+               <set>Qt::ImhDigitsOnly</set>
+              </property>
+              <property name="text">
+               <string>8388608</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="schedulingGroupBox">
+         <property name="title">
+          <string>Scheduling</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_8">
+          <item>
+           <widget class="QCheckBox" name="schedulerCheckBox">
+            <property name="text">
+             <string>Collect scheduler information</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="threadStateCheckBox">
+            <property name="text">
+             <string>Collect thread states</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="vulkanLayerGroupBox">
+         <property name="toolTip">
+          <string>This requires Orbit's Vulkan layer to be loaded by the target process.</string>
+         </property>
+         <property name="title">
+          <string>Vulkan layer (requires Orbit's Vulkan layer to be loaded by the target)</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <layout class="QHBoxLayout" name="localMarkerDepthHorizontalLayout">
+            <item>
+             <widget class="QCheckBox" name="localMarkerDepthCheckBox">
+              <property name="text">
+               <string>Limit local depth of markers per command buffer to:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="localMarkerDepthLineEdit">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="toolTip">
+               <string>Limits the maximum depth of Vulkan debug markers per command buffer to the given value.
+Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</string>
+              </property>
+              <property name="inputMethodHints">
+               <set>Qt::ImhDigitsOnly</set>
+              </property>
+              <property name="text">
+               <string>3</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="devModeGroupBox">
+         <property name="title">
+          <string>Dev. Mode</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <item>
+           <widget class="QCheckBox" name="introspectionCheckBox">
+            <property name="text">
+             <string>Enable introspection</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="gpuSubmissionsCheckBox">
+            <property name="text">
+             <string>Trace GPU queue submissions</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="label">
@@ -445,8 +484,41 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
      </item>
     </layout>
    </item>
+   <item row="3" column="0">
+    <widget class="Line" name="line">
+     <property name="styleSheet">
+      <string notr="true">background: #353535</string>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>8</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>orbit_qt::MultipleOfSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>MultipleOfSpinBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>
@@ -482,38 +554,6 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
    </hints>
   </connection>
   <connection>
-   <sender>collectMemoryInfoCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>memorySamplingPeriodMsLineEdit</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>239</x>
-     <y>103</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>173</x>
-     <y>128</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>collectMemoryInfoCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>memoryWarningThresholdKbLineEdit</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>239</x>
-     <y>103</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>413</x>
-     <y>128</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>memorySamplingPeriodMsLineEdit</sender>
    <signal>editingFinished()</signal>
    <receiver>CaptureOptionsDialog</receiver>
@@ -542,38 +582,6 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
     <hint type="destinationlabel">
      <x>239</x>
      <y>203</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>samplingCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>samplingPeriodMsDoubleSpinBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>238</x>
-     <y>51</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>202</x>
-     <y>80</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>samplingCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>unwindingMethodComboBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>238</x>
-     <y>50</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>259</x>
-     <y>110</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This groups together some changes to the
capture options dialogue to streamline
the UI and improve UX.

1. Group each category into group boxes. This
   unifies the complete dialogue.
2. Wrap the capture options into a scroll area,
   as 1. adds quite some vertical space.
3. Change the drop down menues to radio buttons.
   This provides more space for explanations and
   allows to tie the "max raw stack" entry to the
   frame pointer unwinding method.
4. Also disable the labels and not only the edits,
   when unchecking the checkboxes/radio buttons
   for sampling, frame pointer unwinding and
   the memory tracing.
5. For the "max raw stack" edit, we now use a
   spin box that also validates that the value
   is a multiple of 8.
6. Add proper tooltips to the frame pointer case.

Screenshots (now):

1. View with scrollbar:
   http://screenshot/8WYUSNGHfMmW2Pb
2. Complete (extended window) with --devmode:
   http://screenshot/6ZGSanoG2cM6rig
3. Complete (extended window) without --devmode
   http://screenshot/8MTWsza5cK3ofgb
4. Disabled label:
   http://screenshot/KPBQYLnSr6Syr4o
5. Frame-pointer tooltip:
   http://screenshot/7pL77FgBf29SCqc

Screenshots (before):

1. With --devmode
   http://screenshot/BM8FU8SaMm8EiHE
2. Wihtout --devmode
   http://screenshot/BPiJ8YAkp5nzSLn

Test: Open capture options with/without --devmode.