### PR TITLE
Use consistently timeline's width

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -279,7 +279,7 @@ void CaptureWindow::ZoomHorizontally(int delta, int mouse_x) {
   auto delta_float = static_cast<float>(delta);
 
   if (time_graph_ != nullptr) {
-    double mouse_ratio = static_cast<double>(mouse_x) / time_graph_->GetWidth();
+    double mouse_ratio = static_cast<double>(mouse_x) / time_graph_->GetTimelineWidth();
     time_graph_->ZoomTime(delta_float, mouse_ratio);
   }
 }

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -112,13 +112,15 @@ class NavigationTestCaptureWindow : public CaptureWindow, public testing::Test {
   }
 };
 
-TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksInTheMiddleOfTimeGraph) {
+TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksInTheMiddleOfTimeline) {
   PreRender();
   ExpectInitialState();
-  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
+  TimelineUi* timeline_ui = time_graph_->GetTimelineUi();
+  const Vec2i kTimelineSize = viewport_.WorldToScreen(timeline_ui->GetSize());
+  const Vec2i kTimelinePos = viewport_.WorldToScreen(timeline_ui->GetPos());
 
-  int x = kTimeGraphSize[0] / 2;
-  int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+  int x = kTimelinePos[0] + kTimelineSize[0] / 2;
+  int y = kTimelinePos[1] + kTimelineSize[1] / 2;
 
   MouseWheelMoved(x, y, 1, false);
   PreRender();
@@ -142,16 +144,16 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksInTheMiddleOfTimeGraph) {
 TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtRandomPositions) {
   PreRender();
   ExpectInitialState();
-  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
+  const Vec2i kTimelineSize = viewport_.WorldToScreen(time_graph_->GetTimelineUi()->GetSize());
 
   std::random_device rd;
   std::mt19937 mt(rd());
-  std::uniform_int_distribution<int> dist(0, kTimeGraphSize[0]);
+  std::uniform_int_distribution<int> dist(0, kTimelineSize[0]);
 
   constexpr int kNumTries = 100;
   for (int i = 0; i < kNumTries; ++i) {
     int x = dist(mt);
-    int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+    int y = kTimelineSize[1] - kBottomSafetyMargin;
 
     // Zoom in twice, then zoom out twice. Check that the intermediate states match
     MouseWheelMoved(x, y, 1, false);
@@ -202,13 +204,16 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtRandomPositions) {
   }
 }
 
-TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheRightOfTimeGraph) {
+TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheRightOfTimeline) {
   PreRender();
   ExpectInitialState();
-  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
 
-  int x = kTimeGraphSize[0];
-  int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+  TimelineUi* timeline_ui = time_graph_->GetTimelineUi();
+  const Vec2i kTimelineSize = viewport_.WorldToScreen(timeline_ui->GetSize());
+  const Vec2i kTimelinePos = viewport_.WorldToScreen(timeline_ui->GetPos());
+
+  int x = kTimelinePos[0] + kTimelineSize[0];
+  int y = kTimelinePos[1] + kTimelineSize[1] / 2;
 
   MouseWheelMoved(x, y, 1, false);
   PreRender();
@@ -229,17 +234,18 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheRightOfTimeGraph) {
   ExpectInitialState();
 }
 
-TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheLeftOfTimeGraph) {
+TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheLeftOfTimeline) {
   PreRender();
   ExpectInitialState();
-  const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
 
-  int x = kTimeGraphSize[0] / 2;
-  int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+  const Vec2i kTimelinePos = viewport_.WorldToScreen(time_graph_->GetTimelineUi()->GetPos());
+
+  int x = kTimelinePos[0];
+  int y = kTimelinePos[1];
 
   MouseWheelMoved(x, y, 1, false);
   PreRender();
-  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kMiddle);
+  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kLeft);
 
   MouseWheelMoved(x, y, -1, false);
   PreRender();
@@ -249,7 +255,7 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheLeftOfTimeGraph) {
   MouseMoved(x, y, false, false, false);
   KeyPressed('W', false, false, false);
   PreRender();
-  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kMiddle);
+  ExpectIsHorizontallyZoomedIn(PosWithinCapture::kLeft);
 
   KeyPressed('S', false, false, false);
   PreRender();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -429,7 +429,7 @@ orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
   if (modifiers.ctrl) {
     VerticalZoom(delta_normalized, mouse_pos[1]);
   } else {
-    double mouse_ratio = mouse_pos[0] / GetWidth();
+    double mouse_ratio = mouse_pos[0] / GetTimelineWidth();
     ZoomTime(delta_normalized, mouse_ratio);
   }
 
@@ -447,7 +447,7 @@ float TimeGraph::GetWorldFromTick(uint64_t time) const {
   if (time_window_us > 0) {
     double start = TicksToMicroseconds(capture_min_timestamp_, time) - min_time_us_;
     double normalized_start = start / time_window_us;
-    float pos = static_cast<float>(normalized_start * GetWidth());
+    float pos = static_cast<float>(normalized_start * GetTimelineWidth());
     return pos;
   }
 
@@ -465,7 +465,7 @@ double TimeGraph::GetUsFromTick(uint64_t time) const {
 uint64_t TimeGraph::GetNsSinceStart(uint64_t time) const { return time - capture_min_timestamp_; }
 
 uint64_t TimeGraph::GetTickFromWorld(float world_x) const {
-  double ratio = GetWidth() > 0 ? static_cast<double>(world_x / GetWidth()) : 0;
+  double ratio = GetTimelineWidth() > 0 ? static_cast<double>(world_x / GetTimelineWidth()) : 0;
   auto time_span_ns = static_cast<uint64_t>(1000 * GetTime(ratio));
   return capture_min_timestamp_ + time_span_ns;
 }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -60,6 +60,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] orbit_gl::TrackManager* GetTrackManager() const {
     return track_container_->GetTrackManager();
   }
+  [[nodiscard]] float GetTimelineWidth() const { return GetTimelineUi()->GetWidth(); }
 
   [[nodiscard]] float GetWorldFromTick(uint64_t time) const override;
   [[nodiscard]] float GetWorldFromUs(double micros) const override;


### PR DESCRIPTION
In https://github.com/google/orbit/pull/3624 we modify the width of the
TrackContainer and the Timeline consistently to only take into
consideration the visible part, but the conversion to time was still
using the total width.

In this PR, instead we use timeline_width for time conversions, so we are
fixing 2 issues:

- Not having an invisible part of the capture behind the vertical scrollbar.

- WheelZooming functionality has again the invariant of not changing the
  elements is pointing to.

Bug: http://b/231273317

In addition we are adapting the tests to use timeline's size and
position and fixing an issue with the tests in the left of the Timeline
that was testing a middle position instead.

Test: Load a capture, use the mouse wheel, analyze if some part of the
capture is invisible.
