### PR TITLE
Add StopSource/StopToken to symbol downloads

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1687,7 +1687,7 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
         std::chrono::steady_clock::now();
     ORBIT_LOG("Copying \"%s\" started", debug_file_path);
     orbit_base::Future<ErrorMessageOr<void>> copy_result =
-        secure_copy_callback_(debug_file_path, local_debug_file_path.string(), stop_token);
+        main_window_->DownloadFileFromInstance(debug_file_path, local_debug_file_path, stop_token);
 
     orbit_base::ImmediateExecutor immediate_executor{};
     return copy_result.Then(

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -80,6 +80,8 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/MainThreadExecutor.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/StopSource.h"
+#include "OrbitBase/StopToken.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/UniqueResource.h"
 #include "OrbitBase/WhenAll.h"
@@ -1651,7 +1653,7 @@ void OrbitApp::SendErrorToUi(const std::string& title, const std::string& text,
 }
 
 orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModuleFromRemote(
-    const std::string& module_file_path) {
+    const std::string& module_file_path, orbit_base::StopToken stop_token) {
   ORBIT_SCOPE_FUNCTION;
   ScopedStatus scoped_status = CreateScopedStatus(absl::StrFormat(
       "Searching for symbols on remote instance for module \"%s\"...", module_file_path));
@@ -1665,8 +1667,9 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
                                                   {absl::GetFlag(FLAGS_instance_symbols_folder)});
       });
 
-  auto download_file = [this, module_file_path, scoped_status = std::move(scoped_status)](
-                           ErrorMessageOr<std::string> result) mutable
+  auto download_file = [this, module_file_path, scoped_status = std::move(scoped_status),
+                        stop_token =
+                            std::move(stop_token)](ErrorMessageOr<std::string> result) mutable
       -> orbit_base::Future<ErrorMessageOr<std::filesystem::path>> {
     if (result.has_error()) return result.error();
 
@@ -1684,17 +1687,21 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
         std::chrono::steady_clock::now();
     ORBIT_LOG("Copying \"%s\" started", debug_file_path);
     orbit_base::Future<ErrorMessageOr<void>> copy_result =
-        secure_copy_callback_(debug_file_path, local_debug_file_path.string());
+        secure_copy_callback_(debug_file_path, local_debug_file_path.string(), stop_token);
 
     orbit_base::ImmediateExecutor immediate_executor{};
     return copy_result.Then(
         &immediate_executor,
         [debug_file_path, local_debug_file_path, scoped_status = std::move(scoped_status),
-         copy_begin](ErrorMessageOr<void> sftp_result) -> ErrorMessageOr<std::filesystem::path> {
+         copy_begin, stop_token = std::move(stop_token)](
+            ErrorMessageOr<void> sftp_result) -> ErrorMessageOr<std::filesystem::path> {
           if (sftp_result.has_error()) {
             return ErrorMessage{
                 absl::StrFormat("Could not copy debug info file from the remote: %s",
                                 sftp_result.error().message())};
+          }
+          if (stop_token.IsStopRequested()) {
+            return ErrorMessage{"User canceled download."};
           }
           const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
               std::chrono::steady_clock::now() - copy_begin);
@@ -1811,7 +1818,8 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
 
   const auto it = modules_currently_loading_.find(module_id);
   if (it != modules_currently_loading_.end()) {
-    return it->second;
+    const ModuleLoadOperation& operation{it->second};
+    return operation.second;
   }
 
   Future<ErrorMessageOr<std::filesystem::path>> local_symbols_future =
@@ -1823,16 +1831,20 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
     return local_symbols_future;
   }
 
+  orbit_base::StopSource stop_source{};
+
   Future<ErrorMessageOr<std::filesystem::path>> final_result =
       orbit_base::UnwrapFuture(local_symbols_future.Then(
           main_thread_executor_,
-          [this, module_id](ErrorMessageOr<std::filesystem::path> local_symbols_path)
+          [this, module_id, stop_token = stop_source.GetStopToken()](
+              ErrorMessageOr<std::filesystem::path> local_symbols_path)
               -> Future<ErrorMessageOr<std::filesystem::path>> {
             if (local_symbols_path.has_value()) {
+              modules_currently_loading_.erase(module_id);
               return local_symbols_path;
             }
 
-            return RetrieveModuleFromRemote(module_id.first)
+            return RetrieveModuleFromRemote(module_id.first, std::move(stop_token))
                 .Then(main_thread_executor_,
                       [this, module_id, local_error_message = local_symbols_path.error().message()](
                           const ErrorMessageOr<std::filesystem::path>& remote_result)
@@ -1849,7 +1861,8 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
                       });
           }));
 
-  modules_currently_loading_.emplace(module_id, final_result);
+  modules_currently_loading_.emplace(module_id,
+                                     std::make_pair(std::move(stop_source), final_result));
   return final_result;
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -623,10 +623,14 @@ class OrbitApp final : public DataViewFactory,
   std::shared_ptr<SamplingReport> sampling_report_;
   std::shared_ptr<SamplingReport> selection_report_ = nullptr;
 
-  using ModuleLoadOperation =
-      std::pair<orbit_base::StopSource, orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>;
+  struct ModuleLoadOperation {
+    orbit_base::StopSource stop_source;
+    orbit_base::Future<ErrorMessageOr<std::filesystem::path>> future;
+  };
+  // ONLY access this from the main thread
   absl::flat_hash_map<std::pair<std::string, std::string>, ModuleLoadOperation>
       modules_currently_loading_;
+  // ONLY access this from the main thread
   absl::flat_hash_map<std::pair<std::string, std::string>, orbit_base::Future<ErrorMessageOr<void>>>
       symbols_currently_loading_;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -326,11 +326,6 @@ class OrbitApp final : public DataViewFactory,
   void SetClipboardCallback(ClipboardCallback callback) {
     clipboard_callback_ = std::move(callback);
   }
-  using SecureCopyCallback = std::function<orbit_base::Future<ErrorMessageOr<void>>(
-      std::string_view, std::string_view, orbit_base::StopToken)>;
-  void SetSecureCopyCallback(SecureCopyCallback callback) {
-    secure_copy_callback_ = std::move(callback);
-  }
 
   void SetStatusListener(StatusListener* listener) { status_listener_ = listener; }
 
@@ -610,7 +605,6 @@ class OrbitApp final : public DataViewFactory,
   CallTreeViewCallback selection_bottom_up_view_callback_;
   SaveFileCallback save_file_callback_;
   ClipboardCallback clipboard_callback_;
-  SecureCopyCallback secure_copy_callback_;
   TimerSelectedCallback timer_selected_callback_;
 
   std::vector<orbit_data_views::DataView*> panels_;

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -173,6 +173,7 @@ target_link_libraries(
          GrpcProtos
          MetricsUploader
          OrbitAccessibility
+         OrbitBase
          OrbitPaths
          PresetFile
          StringManager

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -17,6 +17,8 @@
 #include "CodeReport/CodeReport.h"
 #include "CodeReport/DisassemblyReport.h"
 #include "MetricsUploader/ScopedMetric.h"
+#include "OrbitBase/Future.h"
+#include "OrbitBase/StopToken.h"
 #include "Statistics/Histogram.h"
 
 namespace orbit_gl {
@@ -51,6 +53,10 @@ class MainWindowInterface {
   enum class SymbolErrorHandlingResult { kReloadRequired, kSymbolLoadingCancelled };
   virtual SymbolErrorHandlingResult HandleSymbolError(
       const ErrorMessage& error, const orbit_client_data::ModuleData* module) = 0;
+
+  virtual orbit_base::Future<ErrorMessageOr<void>> DownloadFileFromInstance(
+      std::filesystem::path path_on_instance, std::filesystem::path local_path,
+      orbit_base::StopToken stop_token) = 0;
 
   virtual ~MainWindowInterface() = default;
 };

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -99,6 +99,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/StopToken.h"
 #include "OrbitGgp/Instance.h"
 #include "OrbitPaths/Paths.h"
 #include "OrbitVersion/OrbitVersion.h"
@@ -1569,9 +1570,11 @@ void OrbitMainWindow::SetTarget(const StadiaTarget& target) {
   const orbit_session_setup::StadiaConnection* connection = target.GetConnection();
   ServiceDeployManager* service_deploy_manager = connection->GetServiceDeployManager();
   app_->SetSecureCopyCallback([service_deploy_manager](std::string_view source,
-                                                       std::string_view destination) {
+                                                       std::string_view destination,
+                                                       orbit_base::StopToken stop_token) {
     ORBIT_CHECK(service_deploy_manager != nullptr);
-    return service_deploy_manager->CopyFileToLocal(std::string{source}, std::string{destination});
+    return service_deploy_manager->CopyFileToLocal(std::string{source}, std::string{destination},
+                                                   std::move(stop_token));
   });
 
   QObject::connect(service_deploy_manager, &ServiceDeployManager::socketErrorOccurred, this,

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -43,6 +43,7 @@
 #include "MainWindowInterface.h"
 #include "MetricsUploader/MetricsUploader.h"
 #include "OrbitBase/CrashHandler.h"
+#include "OrbitBase/Future.h"
 #include "OrbitBase/MainThreadExecutor.h"
 #include "SessionSetup/ServiceDeployManager.h"
 #include "SessionSetup/TargetConfiguration.h"
@@ -120,6 +121,10 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   void ShowHistogram(const std::vector<uint64_t>* data, const std::string& function_name,
                      uint64_t function_id) override;
+
+  orbit_base::Future<ErrorMessageOr<void>> DownloadFileFromInstance(
+      std::filesystem::path path_on_instance, std::filesystem::path local_path,
+      orbit_base::StopToken stop_token) override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/OrbitSshQt/IntegrationTests.cpp
+++ b/src/OrbitSshQt/IntegrationTests.cpp
@@ -26,6 +26,7 @@
 
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/StopSource.h"
 #include "OrbitSsh/Context.h"
 #include "OrbitSsh/Credentials.h"
 #include "OrbitSshQt/Session.h"
@@ -237,7 +238,9 @@ TEST(OrbitSshQtTests, CopyToLocalTest) {
 
   orbit_ssh_qt::SftpChannel channel{&session};
 
-  orbit_ssh_qt::SftpCopyToLocalOperation sftp_copy_to_local{&session, &channel};
+  orbit_base::StopSource stop_source;
+  orbit_ssh_qt::SftpCopyToLocalOperation sftp_copy_to_local{&session, &channel,
+                                                            stop_source.GetStopToken()};
 
   session.ConnectToServer(creds);
   ORBIT_LOG("connect to server");

--- a/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
@@ -14,6 +14,7 @@
 #include <system_error>
 
 #include "OrbitBase/Result.h"
+#include "OrbitBase/StopToken.h"
 #include "OrbitSsh/SftpFile.h"
 #include "OrbitSshQt/ScopedConnection.h"
 #include "OrbitSshQt/Session.h"
@@ -28,6 +29,7 @@ enum class SftpCopyToLocalOperationState {
   kOpenLocalFile,
   kStarted,  // This is the running state, where the data transfer happens
   kShutdown,
+  kCloseAndDeletePartialFile,
   kCloseLocalFile,
   kCloseRemoteFile,
   kCloseEventConnections,
@@ -48,7 +50,8 @@ class SftpCopyToLocalOperation
   friend StateMachineHelper;
 
  public:
-  explicit SftpCopyToLocalOperation(Session* session, SftpChannel* channel);
+  explicit SftpCopyToLocalOperation(Session* session, SftpChannel* channel,
+                                    orbit_base::StopToken stop_token);
 
   void CopyFileToLocal(std::filesystem::path source, std::filesystem::path destination);
 
@@ -70,6 +73,8 @@ class SftpCopyToLocalOperation
 
   std::filesystem::path source_;
   std::filesystem::path destination_;
+
+  orbit_base::StopToken stop_token_;
 
   void HandleChannelShutdown();
   void HandleEagain();

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -350,7 +350,7 @@ void ServiceDeployManager::CopyFileToLocalImpl(orbit_base::Promise<ErrorMessageO
 
   copy_file_operation_in_progress_ = true;
 
-  ORBIT_LOG("Copying remote \"%s\" to local \"%s\"", source, destination);
+  ORBIT_LOG("Copying remote \"%s\" to local \"%s\"", source.string(), destination.string());
 
   // NOLINTNEXTLINE - Unfortunately we have to fall back to a raw `new` here.
   auto operation = new orbit_ssh_qt::SftpCopyToLocalOperation{&session_.value(),
@@ -365,8 +365,7 @@ void ServiceDeployManager::CopyFileToLocalImpl(orbit_base::Promise<ErrorMessageO
   // from the ::stopped and ::errorOccured signals (see below).
   // By having a single handler we don't need to worry about sharing resources that are not supposed
   // to be shared like the promise.
-  auto finish_handler = [this, promise = std::move(promise), source = std::string{source},
-                         destination = std::string{destination}, operation,
+  auto finish_handler = [this, promise = std::move(promise), source, destination, operation,
                          stop_token = std::move(stop_token)](ErrorMessageOr<void> result) mutable {
     if (promise.HasResult()) return;
 
@@ -390,8 +389,8 @@ void ServiceDeployManager::CopyFileToLocalImpl(orbit_base::Promise<ErrorMessageO
 
     if (result.has_error()) {
       promise.SetResult(
-          ErrorMessage{absl::StrFormat(R"(Error copying remote "%s" to "%s": %s)", source,
-                                       destination, result.error().message())});
+          ErrorMessage{absl::StrFormat(R"(Error copying remote "%s" to "%s": %s)", source.string(),
+                                       destination.string(), result.error().message())});
       return;
     }
 

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -54,8 +54,8 @@ class ServiceDeployManager : public QObject {
       orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
 
   // This method copies remote source file to local destination.
-  orbit_base::Future<ErrorMessageOr<void>> CopyFileToLocal(std::string source,
-                                                           std::string destination,
+  orbit_base::Future<ErrorMessageOr<void>> CopyFileToLocal(std::filesystem::path source,
+                                                           std::filesystem::path destination,
                                                            orbit_base::StopToken stop_token);
 
   void Shutdown();
@@ -108,7 +108,7 @@ class ServiceDeployManager : public QObject {
   std::deque<orbit_base::AnyInvocable<void()>> waiting_copy_operations_;
 
   void CopyFileToLocalImpl(orbit_base::Promise<ErrorMessageOr<void>> promise,
-                           std::string_view source, std::string_view destination,
+                           std::filesystem::path source, std::filesystem::path destination,
                            orbit_base::StopToken stop_token);
   ErrorMessageOr<GrpcPort> ExecImpl();
 

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -25,6 +25,7 @@
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Promise.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/StopToken.h"
 #include "OrbitSsh/Context.h"
 #include "OrbitSsh/Credentials.h"
 #include "OrbitSshQt/Session.h"
@@ -54,7 +55,8 @@ class ServiceDeployManager : public QObject {
 
   // This method copies remote source file to local destination.
   orbit_base::Future<ErrorMessageOr<void>> CopyFileToLocal(std::string source,
-                                                           std::string destination);
+                                                           std::string destination,
+                                                           orbit_base::StopToken stop_token);
 
   void Shutdown();
   void Cancel();
@@ -106,7 +108,8 @@ class ServiceDeployManager : public QObject {
   std::deque<orbit_base::AnyInvocable<void()>> waiting_copy_operations_;
 
   void CopyFileToLocalImpl(orbit_base::Promise<ErrorMessageOr<void>> promise,
-                           std::string_view source, std::string_view destination);
+                           std::string_view source, std::string_view destination,
+                           orbit_base::StopToken stop_token);
   ErrorMessageOr<GrpcPort> ExecImpl();
 
   void StartWatchdog();


### PR DESCRIPTION
This adds StopSource and StopToken to the module download methods.
SftpCopyToLocalOperation checks whether a stop was requested in its copy
loop and if it was, jumps to a state that closes and deletes the partially
downloaded file. In a future commit stopping downloads will be enabled
in the following way. With the module id (file_path & build_id) get the
corresponding StopSource from OrbitApp::modules_currently_loading_
and call StopSource::RequestStop.

(For more context on how this will be used, see https://github.com/antonrohr/orbit/tree/autoload_symbols)

Test: Manual test that downloading still works
Bug http://b/230757105