### PR TITLE
Pass PC adjustment from general unwinder to PE/COFF unwinder

### DIFF
--- a/third_party/libunwindstack/Elf.cpp
+++ b/third_party/libunwindstack/Elf.cpp
@@ -191,8 +191,8 @@ bool Elf::StepIfSignalHandler(uint64_t rel_pc, Regs* regs, Memory* process_memor
 }
 
 // The relative pc is always relative to the start of the map from which it comes.
-bool Elf::Step(uint64_t rel_pc, Regs* regs, Memory* process_memory, bool* finished,
-               bool* is_signal_frame) {
+bool Elf::Step(uint64_t rel_pc, uint64_t /*pc_adjustment*/, Regs* regs, Memory* process_memory,
+               bool* finished, bool* is_signal_frame) {
   if (!valid_) {
     return false;
   }

--- a/third_party/libunwindstack/PeCoff.cpp
+++ b/third_party/libunwindstack/PeCoff.cpp
@@ -150,13 +150,11 @@ bool PeCoff::StepIfSignalHandler(uint64_t, Regs*, Memory*) {
   return false;
 }
 
-bool PeCoff::Step(uint64_t rel_pc, Regs* regs, Memory* process_memory, bool* finished,
-                  bool* is_signal_frame) {
+bool PeCoff::Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
+                  bool* finished, bool* is_signal_frame) {
   // Lock during the step which can update information in the object.
   std::lock_guard<std::mutex> guard(lock_);
-
-  // TODO(ronaldfw): Plumb pc_adjustment.
-  return interface_->Step(rel_pc, 0, regs, process_memory, finished, is_signal_frame);
+  return interface_->Step(rel_pc, pc_adjustment, regs, process_memory, finished, is_signal_frame);
 }
 
 void PeCoff::GetLastError(ErrorData* data) {

--- a/third_party/libunwindstack/Unwinder.cpp
+++ b/third_party/libunwindstack/Unwinder.cpp
@@ -234,7 +234,7 @@ void Unwinder::Unwind(const std::vector<std::string>* initial_map_names_to_skip,
           if (object->StepIfSignalHandler(rel_pc, regs_, process_memory_.get())) {
             stepped = true;
             is_signal_frame = true;
-          } else if (object->Step(step_pc, regs_, process_memory_.get(), &finished,
+          } else if (object->Step(step_pc, pc_adjustment, regs_, process_memory_.get(), &finished,
                                   &is_signal_frame)) {
             stepped = true;
           }

--- a/third_party/libunwindstack/include/unwindstack/Elf.h
+++ b/third_party/libunwindstack/include/unwindstack/Elf.h
@@ -63,8 +63,8 @@ class Elf : public Object {
   uint64_t GetRelPc(uint64_t pc, MapInfo* map_info) override;
 
   bool StepIfSignalHandler(uint64_t rel_pc, Regs* regs, Memory* process_memory) override;
-  bool Step(uint64_t rel_pc, Regs* regs, Memory* process_memory, bool* finished,
-            bool* is_signal_frame) override;
+  bool Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
+            bool* finished, bool* is_signal_frame) override;
 
   Memory* memory() override { return memory_.get(); }
 

--- a/third_party/libunwindstack/include/unwindstack/Object.h
+++ b/third_party/libunwindstack/include/unwindstack/Object.h
@@ -57,8 +57,8 @@ class Object {
   virtual uint64_t GetRelPc(uint64_t pc, MapInfo* map_info) = 0;
 
   virtual bool StepIfSignalHandler(uint64_t rel_pc, Regs* regs, Memory* process_memory) = 0;
-  virtual bool Step(uint64_t rel_pc, Regs* regs, Memory* process_memory, bool* finished,
-                    bool* is_signal_frame) = 0;
+  virtual bool Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
+                    bool* finished, bool* is_signal_frame) = 0;
 
   virtual Memory* memory() = 0;
 

--- a/third_party/libunwindstack/include/unwindstack/PeCoff.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoff.h
@@ -65,8 +65,8 @@ class PeCoff : public Object {
   uint64_t GetRelPc(uint64_t pc, MapInfo* map_info) override;
 
   bool StepIfSignalHandler(uint64_t rel_pc, Regs* regs, Memory* process_memory) override;
-  bool Step(uint64_t rel_pc, Regs* regs, Memory* process_memory, bool* finished,
-            bool* is_signal_frame) override;
+  bool Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
+            bool* finished, bool* is_signal_frame) override;
 
   Memory* memory() override { return memory_.get(); }
 

--- a/third_party/libunwindstack/tests/ElfTest.cpp
+++ b/third_party/libunwindstack/tests/ElfTest.cpp
@@ -140,7 +140,7 @@ TEST_F(ElfTest, elf_invalid) {
 
   bool finished;
   bool is_signal_frame;
-  ASSERT_FALSE(elf.Step(0, nullptr, nullptr, &finished, &is_signal_frame));
+  ASSERT_FALSE(elf.Step(0, 0, nullptr, nullptr, &finished, &is_signal_frame));
   EXPECT_EQ(ERROR_INVALID_ELF, elf.GetLastErrorCode());
 }
 
@@ -374,7 +374,7 @@ TEST_F(ElfTest, step_in_interface) {
   EXPECT_CALL(*interface, Step(0x1000, &regs, &process_memory, &finished, &is_signal_frame))
       .WillOnce(::testing::Return(true));
 
-  ASSERT_TRUE(elf.Step(0x1000, &regs, &process_memory, &finished, &is_signal_frame));
+  ASSERT_TRUE(elf.Step(0x1000, 0, &regs, &process_memory, &finished, &is_signal_frame));
 }
 
 TEST_F(ElfTest, get_global_invalid_elf) {

--- a/third_party/libunwindstack/tests/PeCoffTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffTest.cpp
@@ -229,7 +229,7 @@ TYPED_TEST(PeCoffTest, step_succeeds_when_interface_step_succeeds) {
   EXPECT_CALL(*mock_interface, Step(0x2000, 0, nullptr, nullptr, nullptr, nullptr))
       .WillOnce(::testing::Return(true));
   coff.SetFakePeCoffInterface(mock_interface);
-  EXPECT_TRUE(coff.Step(0x2000, nullptr, nullptr, nullptr, nullptr));
+  EXPECT_TRUE(coff.Step(0x2000, 0, nullptr, nullptr, nullptr, nullptr));
 }
 
 TYPED_TEST(PeCoffTest, steps_fails_when_interface_step_fails) {
@@ -239,7 +239,7 @@ TYPED_TEST(PeCoffTest, steps_fails_when_interface_step_fails) {
   EXPECT_CALL(*mock_interface, Step(0x2000, 0, nullptr, nullptr, nullptr, nullptr))
       .WillOnce(::testing::Return(false));
   coff.SetFakePeCoffInterface(mock_interface);
-  EXPECT_FALSE(coff.Step(0x2000, nullptr, nullptr, nullptr, nullptr));
+  EXPECT_FALSE(coff.Step(0x2000, 0, nullptr, nullptr, nullptr, nullptr));
 }
 
 TYPED_TEST(PeCoffTest, returns_correct_memory_ptr) {


### PR DESCRIPTION
This is needed to make sure that disassembling for epilog detection
does have the right machine code address, otherwise it will (obviously)
fail.

This requires an interface change on the Object::Step(...) method, but
I don't see a different approach than this right now.

There is a potential optimization in the native unwinder based on the
value of the PC adjustment. If it's not 0, then we know we are not in
the innermost frame and can skip most of the logic of the native
unwinder (e.g. we know we can't be in the epilog).

Tested: Unit tests.
Bug: http://b/194768602