### PR TITLE
Warn about many unwinding errors

### DIFF
--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -43,6 +43,7 @@ struct ThreadSampleData {
 
   ThreadID thread_id = 0;
   uint32_t samples_count = 0;
+  uint32_t unwinding_errors_count = 0;
   absl::flat_hash_map<uint64_t, std::vector<orbit_client_data::CallstackEvent>>
       sampled_callstack_id_to_events;
   absl::flat_hash_map<uint64_t, uint32_t> sampled_address_to_count;

--- a/src/ClientModel/SamplingDataPostProcessor.cpp
+++ b/src/ClientModel/SamplingDataPostProcessor.cpp
@@ -328,6 +328,8 @@ void SamplingDataPostProcessor::FillThreadSampleDataSampleReports(
       if (auto it = thread_sample_data->resolved_address_to_error_count.find(absolute_address);
           it != thread_sample_data->resolved_address_to_error_count.end()) {
         function.unwind_errors = it->second;
+        // We only write the innermost frame into "resolved_address_to_error_count", so we get the
+        // sum of all samples with unwinding errors by computing the sum of errors per function.
         thread_sample_data->unwinding_errors_count += function.unwind_errors;
         function.unwind_errors_percent = 100.f * it->second / thread_sample_data->samples_count;
       }

--- a/src/ClientModel/SamplingDataPostProcessor.cpp
+++ b/src/ClientModel/SamplingDataPostProcessor.cpp
@@ -328,6 +328,7 @@ void SamplingDataPostProcessor::FillThreadSampleDataSampleReports(
       if (auto it = thread_sample_data->resolved_address_to_error_count.find(absolute_address);
           it != thread_sample_data->resolved_address_to_error_count.end()) {
         function.unwind_errors = it->second;
+        thread_sample_data->unwinding_errors_count += function.unwind_errors;
         function.unwind_errors_percent = 100.f * it->second / thread_sample_data->samples_count;
       }
       function.absolute_address = absolute_address;

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -458,6 +458,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data, uint32_t expected_thread_id) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, expected_thread_id);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 5);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 0);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(
@@ -506,6 +507,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data, uint32_t expected_thread_id) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, expected_thread_id);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 5);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 3);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(
@@ -557,6 +559,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data, uint32_t expected_thread_id) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, expected_thread_id);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 5);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 5);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(
@@ -595,6 +598,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data, uint32_t expected_thread_id) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, expected_thread_id);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 5);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 0);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(
@@ -657,6 +661,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, kThreadId1);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 2);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 0);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(
@@ -699,6 +704,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, kThreadId2);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 3);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 0);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(
@@ -751,6 +757,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
             CallstackIdToCallstackEventsEq(std::make_pair(
                 kCallstack4Id, std::vector<CallstackEvent>{{500, kCallstack4Id, kThreadId2}}))));
     EXPECT_EQ(actual_thread_sample_data.samples_count, 5);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 0);
     EXPECT_THAT(actual_thread_sample_data.sampled_address_to_count,
                 UnorderedElementsAre(std::make_pair(kFunction1Instruction1AbsoluteAddress, 5),
                                      std::make_pair(kFunction2Instruction1AbsoluteAddress, 3),
@@ -787,6 +794,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, kThreadId1);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 2);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 1);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(
@@ -829,6 +837,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, kThreadId2);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 3);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 2);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(
@@ -863,6 +872,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
       const ThreadSampleData& actual_thread_sample_data, uint32_t expected_thread_id) {
     EXPECT_EQ(actual_thread_sample_data.thread_id, expected_thread_id);
     EXPECT_EQ(actual_thread_sample_data.samples_count, 5);
+    EXPECT_EQ(actual_thread_sample_data.unwinding_errors_count, 3);
     EXPECT_THAT(
         actual_thread_sample_data.sampled_callstack_id_to_events,
         UnorderedElementsAre(

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -190,7 +190,7 @@ std::string SamplingReport::GetSelectedCallstackString() const {
       100.f * num_occurrences / total_callstacks, type_string);
 }
 
-double SamplingReport::UnwindErrorRatio(uint32_t thread_id) const {
+double SamplingReport::ComputeUnwindErrorRatio(uint32_t thread_id) const {
   if (post_processed_sampling_data_ == nullptr) {
     return 0.;
   }

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -190,6 +190,19 @@ std::string SamplingReport::GetSelectedCallstackString() const {
       100.f * num_occurrences / total_callstacks, type_string);
 }
 
+double SamplingReport::UnwindErrorRatio(uint32_t thread_id) const {
+  if (post_processed_sampling_data_ == nullptr) {
+    return 0.;
+  }
+  auto* thread_sampling_data =
+      post_processed_sampling_data_->GetThreadSampleDataByThreadId(thread_id);
+  if (thread_sampling_data == nullptr) {
+    return 0.;
+  }
+  return static_cast<double>(thread_sampling_data->unwinding_errors_count) /
+         thread_sampling_data->samples_count;
+}
+
 std::string SamplingReport::GetSelectedCallstackTooltipString() const {
   if (selected_sorted_callstack_report_ == nullptr) {
     return "";

--- a/src/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/SamplingReport.h
@@ -51,7 +51,7 @@ class SamplingReport : public orbit_data_views::SamplingReportInterface {
   void SetUiRefreshFunc(std::function<void()> func) { ui_refresh_func_ = std::move(func); };
   [[nodiscard]] bool HasCallstacks() const { return selected_sorted_callstack_report_ != nullptr; };
   [[nodiscard]] bool HasSamples() const { return !thread_data_views_.empty(); }
-  [[nodiscard]] double UnwindErrorRatio(uint32_t thread_id) const;
+  [[nodiscard]] double ComputeUnwindErrorRatio(uint32_t thread_id) const;
   [[nodiscard]] bool has_summary() const { return has_summary_; }
   void ClearReport();
   [[nodiscard]] const orbit_client_data::CallstackData& GetCallstackData() const override;

--- a/src/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/SamplingReport.h
@@ -51,6 +51,7 @@ class SamplingReport : public orbit_data_views::SamplingReportInterface {
   void SetUiRefreshFunc(std::function<void()> func) { ui_refresh_func_ = std::move(func); };
   [[nodiscard]] bool HasCallstacks() const { return selected_sorted_callstack_report_ != nullptr; };
   [[nodiscard]] bool HasSamples() const { return !thread_data_views_.empty(); }
+  [[nodiscard]] double UnwindErrorRatio(uint32_t thread_id) const;
   [[nodiscard]] bool has_summary() const { return has_summary_; }
   void ClearReport();
   [[nodiscard]] const orbit_client_data::CallstackData& GetCallstackData() const override;

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -116,7 +116,7 @@ void OrbitSamplingReport::Initialize(orbit_data_views::DataView* callstack_data_
                      notice_box);
       notice_box_layout->addWidget(notice_label, 0, 0);
       auto* notice_button = new QPushButton(notice_box);
-      notice_button->setText("Acknowledge");
+      notice_button->setText("Hide");
       QObject::connect(notice_button, &QPushButton::clicked, notice_box,
                        [notice_box]() { notice_box->hide(); });
       notice_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -19,6 +19,7 @@
 #include <Qt>
 #include <algorithm>
 #include <optional>
+#include <regex>
 #include <string>
 
 #include "DataViews/SamplingReportDataView.h"
@@ -93,7 +94,38 @@ void OrbitSamplingReport::Initialize(orbit_data_views::DataView* callstack_data_
     //  is no need for manual updates.
     orbit_data_views_.push_back(treeView);
 
-    QString thread_name = QString::fromStdString(report_data_view.GetName());
+    std::string thread_name_std = report_data_view.GetName();
+    QString thread_name = QString::fromStdString(thread_name_std);
+
+    uint32_t thread_id = report_data_view.GetThreadID();
+    // Report any thread that contains more than 5% unwinding errors.
+    constexpr double kUnwindErrorThreshold = 0.05;
+    double unwind_error_ratio = sampling_report_->UnwindErrorRatio(thread_id);
+    if (sampling_report_->UnwindErrorRatio(thread_id) > kUnwindErrorThreshold) {
+      auto* notice_box = new QWidget(tab);
+      notice_box->setStyleSheet(
+          ".QWidget { border-radius: 5px; border: 1px solid palette(text); background:"
+          " rgba(255,0,0, 10%); } "
+          "QPushButton:focus { border-color: rgba(255, 0, 0, 20%); }");
+      auto* notice_box_layout = new QGridLayout(notice_box);
+
+      auto* notice_label =
+          new QLabel(QString::fromStdString(absl::StrFormat(
+                         "There are %.2f %% unwinding errors in %s.", unwind_error_ratio * 100,
+                         std::regex_replace(thread_name_std, std::regex("\n"), " "))),
+                     notice_box);
+      notice_box_layout->addWidget(notice_label, 0, 0);
+      auto* notice_button = new QPushButton(notice_box);
+      notice_button->setText("Acknowledge");
+      QObject::connect(notice_button, &QPushButton::clicked, notice_box,
+                       [notice_box]() { notice_box->hide(); });
+      notice_button->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+      notice_box_layout->addWidget(notice_button, 0, 1);
+
+      gridLayout_2->addWidget(notice_box, 1, 0);
+    }
+
     ui_->tabWidget->addTab(tab, thread_name);
   }
 


### PR DESCRIPTION
Top-down and button-up views already report unwinding errors,
quite prominently to the user.
However, in the sampling tab, on the unwinding errors per function
are reported so far. So a user does not realize directly, that
a capture has many unwinding errors.

This change adds a notification box (similar to the code view)
to the sampling tab, if there are more than 5% unwinding errors
in the selected thread.

Screenshots:
"All threads" - with warning:
http://screenshot/ApwzyhdMGykqLNA

"All threads" - after "Acknowledge"
http://screenshot/ArpmydiqYUaKfH4

A single thread:
http://screenshot/8JduEUWPVhBxucG

Test: Take a capture and navigate the sampling tabs. Unit tests.
Bug: No bug