### PR TITLE
Expose frame pointer unwinding

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1447,8 +1447,7 @@ void OrbitApp::StartCapture() {
   options.dynamic_instrumentation_method = data_manager_->dynamic_instrumentation_method();
   options.samples_per_second = data_manager_->samples_per_second();
   options.stack_dump_size = data_manager_->stack_dump_size();
-  options.unwinding_method =
-      IsDevMode() ? data_manager_->unwinding_method() : CaptureOptions::kDwarf;
+  options.unwinding_method = data_manager_->unwinding_method();
   options.max_local_marker_depth_per_command_buffer =
       data_manager_->max_local_marker_depth_per_command_buffer();
 
@@ -1721,7 +1720,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1720,7 +1720,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -69,7 +69,6 @@ class CaptureWindow : public GlCanvas {
 
   virtual void ToggleRecording();
 
-
   void RenderHelpUi();
   void RenderSelectionOverlay();
   void SelectTimer(const orbit_client_protos::TimerInfo* timer_info);

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -72,7 +72,6 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   if (!absl::GetFlag(FLAGS_devmode)) {
     // TODO(b/198748597): Don't hide samplingCheckBox once disabling sampling completely is exposed.
     ui_->samplingCheckBox->hide();
-    ui_->unwindingMethodGroupBox->hide();
     ui_->schedulerCheckBox->hide();
     ui_->devModeGroupBox->hide();
   }

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1116,32 +1116,27 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
     app_->SetSamplesPerSecond(0.0);
   }
 
-  if (!app_->IsDevMode()) {
-    app_->SetUnwindingMethod(orbit_qt::CaptureOptionsDialog::kCallstackUnwindingMethodDefaultValue);
-    app_->SetStackDumpSize(std::numeric_limits<uint16_t>::max());
-  } else {
-    UnwindingMethod unwinding_method = static_cast<UnwindingMethod>(
-        settings
-            .value(kCallstackUnwindingMethodSettingKey,
-                   static_cast<int>(
-                       orbit_qt::CaptureOptionsDialog::kCallstackUnwindingMethodDefaultValue))
-            .toInt());
-    if (unwinding_method == CaptureOptions::kUndefined) {
-      ORBIT_ERROR("Unknown unwinding method specified; Using default unwinding method");
-      unwinding_method = orbit_qt::CaptureOptionsDialog::kCallstackUnwindingMethodDefaultValue;
-    }
-    app_->SetUnwindingMethod(unwinding_method);
+  UnwindingMethod unwinding_method = static_cast<UnwindingMethod>(
+      settings
+          .value(kCallstackUnwindingMethodSettingKey,
+                 static_cast<int>(
+                     orbit_qt::CaptureOptionsDialog::kCallstackUnwindingMethodDefaultValue))
+          .toInt());
+  if (unwinding_method == CaptureOptions::kUndefined) {
+    ORBIT_ERROR("Unknown unwinding method specified; Using default unwinding method");
+    unwinding_method = orbit_qt::CaptureOptionsDialog::kCallstackUnwindingMethodDefaultValue;
+  }
+  app_->SetUnwindingMethod(unwinding_method);
 
-    if (unwinding_method == CaptureOptions::kFramePointers) {
-      uint16_t stack_dump_size = static_cast<uint16_t>(
-          settings
-              .value(kMaxCopyRawStackSizeSettingKey,
-                     orbit_qt::CaptureOptionsDialog::kMaxCopyRawStackSizeDefaultValue)
-              .toUInt());
-      app_->SetStackDumpSize(stack_dump_size);
-    } else {
-      app_->SetStackDumpSize(std::numeric_limits<uint16_t>::max());
-    }
+  if (unwinding_method == CaptureOptions::kFramePointers) {
+    uint16_t stack_dump_size = static_cast<uint16_t>(
+        settings
+            .value(kMaxCopyRawStackSizeSettingKey,
+                   orbit_qt::CaptureOptionsDialog::kMaxCopyRawStackSizeDefaultValue)
+            .toUInt());
+    app_->SetStackDumpSize(stack_dump_size);
+  } else {
+    app_->SetStackDumpSize(std::numeric_limits<uint16_t>::max());
   }
 
   app_->SetCollectSchedulerInfo(settings.value(kCollectSchedulerInfoSettingKey, true).toBool());

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1122,7 +1122,8 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
                  static_cast<int>(
                      orbit_qt::CaptureOptionsDialog::kCallstackUnwindingMethodDefaultValue))
           .toInt());
-  if (unwinding_method == CaptureOptions::kUndefined) {
+  if (unwinding_method != CaptureOptions::kFramePointers &&
+      unwinding_method != CaptureOptions::kDwarf) {
     ORBIT_ERROR("Unknown unwinding method specified; Using default unwinding method");
     unwinding_method = orbit_qt::CaptureOptionsDialog::kCallstackUnwindingMethodDefaultValue;
   }


### PR DESCRIPTION
This exposes frame pointer unwinding even when not in --devmode.

Test: Take a capture with and without frame pointer unwinding.
Bug: http://b/155869485