### PR TITLE
Refactor symbol loading lists in OrbitApp

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1739,7 +1739,7 @@ orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
   for (const auto& module : modules_set) {
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1812,8 +1812,8 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
 
   auto module_id = std::make_pair(module_path, build_id);
 
-  const auto it = modules_currently_loading_.find(module_id);
-  if (it != modules_currently_loading_.end()) {
+  const auto it = symbol_files_currently_retrieved_.find(module_id);
+  if (it != symbol_files_currently_retrieved_.end()) {
     return it->second.future;
   }
 
@@ -1835,7 +1835,7 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
               ErrorMessageOr<std::filesystem::path> local_symbols_path)
               -> Future<ErrorMessageOr<std::filesystem::path>> {
             if (local_symbols_path.has_value()) {
-              modules_currently_loading_.erase(module_id);
+              symbol_files_currently_retrieved_.erase(module_id);
               return local_symbols_path;
             }
 
@@ -1844,7 +1844,7 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
                       [this, module_id, local_error_message = local_symbols_path.error().message()](
                           const ErrorMessageOr<std::filesystem::path>& remote_result)
                           -> ErrorMessageOr<std::filesystem::path> {
-                        modules_currently_loading_.erase(module_id);
+                        symbol_files_currently_retrieved_.erase(module_id);
 
                         // If remote loading fails as well, we combine the error messages.
                         if (remote_result.has_value()) return remote_result;
@@ -1856,8 +1856,8 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
                       });
           }));
 
-  modules_currently_loading_.emplace(module_id,
-                                     ModuleLoadOperation{std::move(stop_source), final_result});
+  symbol_files_currently_retrieved_.emplace(
+      module_id, ModuleLoadOperation{std::move(stop_source), final_result});
   return final_result;
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -640,7 +640,7 @@ class OrbitApp final : public DataViewFactory,
   // ONLY access this from the main thread.
   absl::flat_hash_map<std::pair<std::string, std::string>,
                       orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
-      symbol_files_currently_retrieved_;
+      symbol_files_currently_being_retrieved_;
 
   // Map of "module ID" (file path and build ID) to symbol loading future, that holds all symbol
   // loading operations that are currently in progress. Since retrieving and downloading a file can

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -636,7 +636,7 @@ class OrbitApp final : public DataViewFactory,
   // symbol retrieving operations currently in progress. (Retrieving here means finding locally or
   // downloading from the instance). Since downloading a symbols file can be part of the retrieval,
   // if a module ID is contained in symbol_files_currently_downloading_, it is also contianed in
-  // symbol_files_currently_retrieved_.
+  // symbol_files_currently_being_retrieved_.
   // ONLY access this from the main thread.
   absl::flat_hash_map<std::pair<std::string, std::string>,
                       orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
@@ -645,8 +645,8 @@ class OrbitApp final : public DataViewFactory,
   // Map of "module ID" (file path and build ID) to symbol loading future, that holds all symbol
   // loading operations that are currently in progress. Since retrieving and downloading a file can
   // be part of the overall symbol loading process, if a module ID is contained in
-  // symbol_files_currently_retrieved_ or symbol_files_currently_downloading_, it is also contained
-  // in symbols_currently_loading_.
+  // symbol_files_currently_being_retrieved_ or symbol_files_currently_downloading_, it is also
+  // contained in symbols_currently_loading_.
   // ONLY access this from the main thread.
   absl::flat_hash_map<std::pair<std::string, std::string>, orbit_base::Future<ErrorMessageOr<void>>>
       symbols_currently_loading_;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -641,7 +641,13 @@ class OrbitApp final : public DataViewFactory,
   absl::flat_hash_map<std::pair<std::string, std::string>,
                       orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
       symbol_files_currently_retrieved_;
-  // ONLY access this from the main thread
+
+  // Map of "module ID" (file path and build ID) to symbol loading future, that holds all symbol
+  // loading operations that are currently in progress. Since retrieving and downloading a file can
+  // be part of the overall symbol loading process, if a module ID is contained in
+  // symbol_files_currently_retrieved_ or symbol_files_currently_downloading_, it is also contained
+  // in symbols_currently_loading_.
+  // ONLY access this from the main thread.
   absl::flat_hash_map<std::pair<std::string, std::string>, orbit_base::Future<ErrorMessageOr<void>>>
       symbols_currently_loading_;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -629,7 +629,7 @@ class OrbitApp final : public DataViewFactory,
   };
   // ONLY access this from the main thread
   absl::flat_hash_map<std::pair<std::string, std::string>, ModuleLoadOperation>
-      modules_currently_loading_;
+      symbol_files_currently_retrieved_;
   // ONLY access this from the main thread
   absl::flat_hash_map<std::pair<std::string, std::string>, orbit_base::Future<ErrorMessageOr<void>>>
       symbols_currently_loading_;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -635,7 +635,7 @@ class OrbitApp final : public DataViewFactory,
   // Map of "module ID" (file path and build ID) to symbol file retrieving future, that holds all
   // symbol retrieving operations currently in progress. (Retrieving here means finding locally or
   // downloading from the instance). Since downloading a symbols file can be part of the retrieval,
-  // if a module ID is contained in symbol_files_currently_downloading_, it is also contianed in
+  // if a module ID is contained in symbol_files_currently_downloading_, it is also contained in
   // symbol_files_currently_being_retrieved_.
   // ONLY access this from the main thread.
   absl::flat_hash_map<std::pair<std::string, std::string>,


### PR DESCRIPTION
This PR is a refactoring prework PR for showing the status of symbol loading in the module list. This is mainly about setting up 3 different hash maps that contain the modules that are currently loaded. These maps are
* symbol_files_currently_downloading_
* symbol_files_currently_retrieved_
* symbols_currently_loading_

How they will be used can be seen in https://github.com/google/orbit/pull/3671

This PR is purposefully split up in 4 commits for making it easier to review. The first 2 commits are fairly simple, the latter 2 are a bit more complicated. please look at the commit messages to get some context. 

Test: Still compiles + manual tests
Bug: part of http://b/231132857
