### PR TITLE
Remove CHECK that causes PE/COFF unwinding to fail in name resolution

### DIFF
--- a/third_party/libunwindstack/PeCoff.cpp
+++ b/third_party/libunwindstack/PeCoff.cpp
@@ -128,8 +128,10 @@ std::string PeCoff::GetSoname() {
 }
 
 bool PeCoff::GetFunctionName(uint64_t, SharedString*, uint64_t*) {
-  // Not implemented, don't use.
-  CHECK(false);
+  // For PE/COFF, in many cases getting the function name will require access to a separate PDB
+  // file and the ability to parse that file. Alternatives would be to get the name from the export
+  // directory (only for dlls and for public symbols) or from .debug_info if the file has DWARF
+  // information (e.g. for Wine dlls).
   return false;
 }
 

--- a/third_party/libunwindstack/tests/PeCoffTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffTest.cpp
@@ -119,11 +119,11 @@ TYPED_TEST(PeCoffTest, getting_soname_aborts) {
   ASSERT_DEATH(coff.GetSoname(), "");
 }
 
-TYPED_TEST(PeCoffTest, getting_function_name_aborts) {
+TYPED_TEST(PeCoffTest, getting_function_name_fails) {
   this->GetFake()->Init();
   PeCoff coff(this->ReleaseMemory());
   EXPECT_TRUE(coff.Init());
-  ASSERT_DEATH(coff.GetFunctionName(0, nullptr, nullptr), "");
+  EXPECT_FALSE(coff.GetFunctionName(0, nullptr, nullptr));
 }
 
 TYPED_TEST(PeCoffTest, getting_global_variable_offset_aborts) {


### PR DESCRIPTION
We remove a CHECK that gets triggered during unwinding when resolving
function names with Object::GetFunctionName(). Other CHECks for similar
methods (GetSoname(), GetBuildID(), GetGlobalVariableOffset()) are left
in, as these methods are not used during unwinding as used by Orbit.

This is a workaround for now and not the ideal solution. However, we
don't consider it reasonable to implement GetFunctionName() right now
or make other changes due to the following reasons:
* Resolving names can be turned off in the unwinder, however we
want to wait until we have automatic symbol loading implemented on the
client. Hence we need GetFunctionName() for ELF modules to still be
called and the same interface is used for PE/COFF modules.
* A proper implementation of GetFunctionName() for PE/COFF would need
to parse PDB files (which typically would not even be available
remotely), which is either a lot of work or requires an additional
dependency.

That said, we could partially resolve names for Wine dlls (using
.debug_info). This is worth considering as a follow-up step.

Tested: Unit tests.
Bug: http://b/194768602