### PR TITLE
Implement MouseEvent in CaptureViewElements

### DIFF
--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -95,7 +95,8 @@ void Button::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_
   size_w_border -= kBorderSize + kBorderSize;
 
   // Button itself
-  primitive_assembler.AddShadedBox(pos_w_border, size_w_border, z, kBaseColor,
+  const Color slider_color = IsMouseOver(mouse_pos_cur_) ? kHighlightColor : kBaseColor;
+  primitive_assembler.AddShadedBox(pos_w_border, size_w_border, z, slider_color,
                                    ShadingDirection::kTopToBottom);
 
   TextRendererInterface::TextFormatting format;

--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -95,7 +95,7 @@ void Button::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_
   size_w_border -= kBorderSize + kBorderSize;
 
   // Button itself
-  const Color slider_color = IsMouseOver(mouse_pos_cur_) ? kHighlightColor : kBaseColor;
+  const Color slider_color = IsMouseOver() ? kHighlightColor : kBaseColor;
   primitive_assembler.AddShadedBox(pos_w_border, size_w_border, z, slider_color,
                                    ShadingDirection::kTopToBottom);
 

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -77,6 +77,7 @@ CaptureViewElement::EventResult CaptureViewElement::OnMouseEnter() {
 
 CaptureViewElement::EventResult CaptureViewElement::OnMouseLeave() {
   is_mouse_over_ = false;
+  mouse_pos_cur_ = kInvalidPosition;
   return EventResult::kIgnored;
 }
 
@@ -184,16 +185,12 @@ CaptureViewElement::EventResult CaptureViewElement::HandleMouseEvent(
     case MouseEventType::kMouseWheelDown:
       return OnMouseWheel(mouse_pos, -1, modifiers);
     case MouseEventType::kLeftUp:
-      [[fallthrough]];
     case MouseEventType::kLeftDown:
-      [[fallthrough]];
     case MouseEventType::kRightUp:
-      [[fallthrough]];
     case MouseEventType::kRightDown:
       // Currently being handled using PickingManager (OnPick, OnDrag, OnRelease).
       return EventResult::kIgnored;
     case MouseEventType::kInvalidEvent:
-      [[fallthrough]];
     default:
       ORBIT_ERROR("Mouse Invalid Event");
       break;

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -157,18 +157,20 @@ CaptureViewElement::EventResult CaptureViewElement::HandleMouseEvent(
     MouseEvent mouse_event, const ModifierKeys& modifiers) {
   Vec2 mouse_pos = mouse_event.mouse_position;
 
-  // If the mouse is not over, it only should react to MouseMove (to update mouse_over flag).
-  if (!is_mouse_over_ && mouse_event.event_type != EventType::kMouseMove) {
+  if (mouse_event.event_type != EventType::kMouseLeave && !ShouldReactToMouseOver(mouse_pos)) {
     return EventResult::kIgnored;
   }
 
   for (CaptureViewElement* child : GetAllChildren()) {
-    if (child->HandleMouseEvent(mouse_event, modifiers) == EventResult::kHandled) {
+    if (child->IsMouseOver() && !child->ShouldReactToMouseOver(mouse_pos)) {
+      std::ignore = child->HandleMouseEvent(MouseEvent{EventType::kMouseLeave});
+    }
+    if (child->ShouldReactToMouseOver(mouse_pos) &&
+        child->HandleMouseEvent(mouse_event, modifiers) == EventResult::kHandled) {
       return EventResult::kHandled;
     }
   }
 
-  const Vec2 kOutsidePosition{std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
   switch (mouse_event.event_type) {
     case EventType::kMouseMove: {
       if (!mouse_event.left && !mouse_event.right && !mouse_event.middle) {

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -143,12 +143,12 @@ bool CaptureViewElement::ContainsPoint(const Vec2& pos) const {
          pos[1] < GetPos()[1] + GetSize()[1];
 }
 
-bool CaptureViewElement::ContainsPointRecursively(const Vec2& mouse_pos) const {
-  if (parent_ != nullptr && !parent_->ContainsPointRecursively(mouse_pos)) {
+bool CaptureViewElement::ContainsPointRecursively(const Vec2& point) const {
+  if (parent_ != nullptr && !parent_->ContainsPointRecursively(point)) {
     return false;
   }
 
-  return ContainsPoint(mouse_pos);
+  return ContainsPoint(point);
 }
 
 CaptureViewElement::EventResult CaptureViewElement::HandleMouseEvent(
@@ -181,9 +181,9 @@ CaptureViewElement::EventResult CaptureViewElement::HandleMouseEvent(
     case MouseEventType::kMouseLeave:
       return OnMouseLeave();
     case MouseEventType::kMouseWheelUp:
-      return OnMouseWheel(mouse_pos, 1, modifiers);
+      return OnMouseWheel(mouse_pos, /* delta= */ 1, modifiers);
     case MouseEventType::kMouseWheelDown:
-      return OnMouseWheel(mouse_pos, -1, modifiers);
+      return OnMouseWheel(mouse_pos, /* delta= */ -1, modifiers);
     case MouseEventType::kLeftUp:
     case MouseEventType::kLeftDown:
     case MouseEventType::kRightUp:
@@ -192,7 +192,7 @@ CaptureViewElement::EventResult CaptureViewElement::HandleMouseEvent(
       return EventResult::kIgnored;
     case MouseEventType::kInvalidEvent:
     default:
-      ORBIT_ERROR("Mouse Invalid Event");
+      ORBIT_ERROR("Invalid Mouse Event");
       break;
   }
   return EventResult::kIgnored;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -55,13 +55,13 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override { return true; }
 
-  // This also checks ShouldReactToMouseOver() for the parent, and only returns true if the mouse
-  // position is included in all parents up to the root
-  [[nodiscard]] bool ShouldReactToMouseOver(const Vec2& mouse_pos) const;
+  // This also checks ContainsPointRecursively() for the parent, and only returns true if the mouse
+  // position is included in all parents up to the root.
+  [[nodiscard]] bool ContainsPointRecursively(const Vec2& mouse_pos) const;
 
   [[nodiscard]] bool IsMouseOver() const { return is_mouse_over_; }
 
-  enum class EventType {
+  enum class MouseEventType {
     kInvalidEvent,
     kMouseMove,
     kMouseLeave,
@@ -76,7 +76,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   const inline static Vec2 kOutsidePosition{std::numeric_limits<float>::max(),
                                             std::numeric_limits<float>::max()};
   struct MouseEvent {
-    EventType event_type = EventType::kInvalidEvent;
+    MouseEventType event_type = MouseEventType::kInvalidEvent;
     Vec2 mouse_position = kOutsidePosition;
     bool left = false;
     bool right = false;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -73,11 +73,11 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
     kRightDown
   };
 
-  const inline static Vec2 kOutsidePosition{std::numeric_limits<float>::max(),
+  const inline static Vec2 kInvalidPosition{std::numeric_limits<float>::max(),
                                             std::numeric_limits<float>::max()};
   struct MouseEvent {
     MouseEventType event_type = MouseEventType::kInvalidEvent;
-    Vec2 mouse_position = kOutsidePosition;
+    Vec2 mouse_position = kInvalidPosition;
     bool left = false;
     bool right = false;
     bool middle = false;
@@ -130,6 +130,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   const TimeGraphLayout* layout_;
 
   Vec2 mouse_pos_last_click_;
+  // TODO(b/232530544): Consider not storing mouse position and getting it only while drawing.
   Vec2 mouse_pos_cur_;
   Vec2 picking_offset_ = Vec2(0, 0);
   bool picked_ = false;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -55,9 +55,8 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override { return true; }
 
-  // This also checks ContainsPointRecursively() for the parent, and only returns true if the mouse
-  // position is included in all parents up to the root.
-  [[nodiscard]] bool ContainsPointRecursively(const Vec2& mouse_pos) const;
+  // Recursively check if self and all parents up to the root contain a given point.
+  [[nodiscard]] bool ContainsPointRecursively(const Vec2& point) const;
 
   [[nodiscard]] bool IsMouseOver() const { return is_mouse_over_; }
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -60,10 +60,31 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   // This also checks IsMouseOver() for the parent, and only returns true if the mouse
   // position is included in all parents up to the root
   [[nodiscard]] bool IsMouseOver(const Vec2& mouse_pos) const;
+  virtual void OnMouseEnter(){};
+  virtual void OnMouseLeave(){};
+
+  enum class EventType {
+    kMouseMoved,
+    kMouseOut,
+    kMouseWheelUp,
+    kMouseWheelDown,
+    kLeftUp,
+    kLeftDown,
+    kRightUp,
+    kRightDown,
+    kInvalidEvent
+  };
+  struct MouseEvent {
+    EventType event_type = EventType::kInvalidEvent;
+    Vec2 mouse_position = {0.f, 0.f};
+    bool left = false;
+    bool right = false;
+    bool middle = false;
+  };
 
   enum class EventResult { kHandled, kIgnored };
-  [[nodiscard]] EventResult HandleMouseWheelEvent(const Vec2& mouse_pos, int delta,
-                                                  const ModifierKeys& modifiers = ModifierKeys());
+  [[nodiscard]] EventResult HandleMouseEvent(MouseEvent mouse_event,
+                                             const ModifierKeys& modifiers = ModifierKeys());
 
   [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetAllChildren() const { return {}; }
@@ -133,6 +154,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   [[nodiscard]] virtual EventResult OnMouseWheel(const Vec2& mouse_pos, int delta,
                                                  const ModifierKeys& modifiers);
+  virtual void OnMouseMove(const Vec2& mouse_pos);
 
  private:
   float width_ = 0.;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -55,25 +55,24 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override { return true; }
 
-  [[nodiscard]] bool ContainsPoint(const Vec2& pos) const;
-
-  // This also checks IsMouseOver() for the parent, and only returns true if the mouse
+  // This also checks ShouldReactToMouseOver() for the parent, and only returns true if the mouse
   // position is included in all parents up to the root
-  [[nodiscard]] bool IsMouseOver(const Vec2& mouse_pos) const;
-  virtual void OnMouseEnter(){};
-  virtual void OnMouseLeave(){};
+  [[nodiscard]] bool ShouldReactToMouseOver(const Vec2& mouse_pos) const;
+
+  [[nodiscard]] bool IsMouseOver() const { return is_mouse_over_; }
 
   enum class EventType {
-    kMouseMoved,
-    kMouseOut,
+    kInvalidEvent,
+    kMouseMove,
+    kMouseLeave,
     kMouseWheelUp,
     kMouseWheelDown,
     kLeftUp,
     kLeftDown,
     kRightUp,
-    kRightDown,
-    kInvalidEvent
+    kRightDown
   };
+
   struct MouseEvent {
     EventType event_type = EventType::kInvalidEvent;
     Vec2 mouse_position = {0.f, 0.f};
@@ -152,11 +151,16 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
   virtual void DoUpdateLayout() {}
 
+  [[nodiscard]] bool ContainsPoint(const Vec2& pos) const;
   [[nodiscard]] virtual EventResult OnMouseWheel(const Vec2& mouse_pos, int delta,
                                                  const ModifierKeys& modifiers);
-  virtual void OnMouseMove(const Vec2& mouse_pos);
+  [[nodiscard]] virtual EventResult OnMouseMove(const Vec2& mouse_pos);
+  [[nodiscard]] virtual EventResult OnMouseEnter();
+  [[nodiscard]] virtual EventResult OnMouseLeave();
 
  private:
+  bool is_mouse_over_ = false;
+
   float width_ = 0.;
   Vec2 pos_ = Vec2(0, 0);
   CaptureViewElement* parent_;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -73,9 +73,11 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
     kRightDown
   };
 
+  const inline static Vec2 kOutsidePosition{std::numeric_limits<float>::max(),
+                                            std::numeric_limits<float>::max()};
   struct MouseEvent {
     EventType event_type = EventType::kInvalidEvent;
-    Vec2 mouse_position = {0.f, 0.f};
+    Vec2 mouse_position = kOutsidePosition;
     bool left = false;
     bool right = false;
     bool middle = false;

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -107,7 +107,7 @@ TEST(CaptureViewElementTesterTest, PassesAllTestsOnExistingElement) {
 const Viewport kViewport(100, 100);
 const TimeGraphLayout kLayout;
 
-TEST(CaptureViewElement, VisibleElementsReactToMouseOver) {
+TEST(CaptureViewElement, ContainsPointRecursively) {
   UnitTestCaptureViewLeafElement elem(nullptr, &kViewport, &kLayout);
   elem.SetWidth(kViewport.GetWorldWidth());
   float pos_x = elem.GetPos()[0];
@@ -121,7 +121,7 @@ TEST(CaptureViewElement, VisibleElementsReactToMouseOver) {
   EXPECT_FALSE(elem.ContainsPointRecursively({pos_x + elem.GetWidth(), pos_y + elem.GetHeight()}));
 }
 
-TEST(CaptureViewElement, ElementsOutsideOfTheParentDontReactToMouseOver) {
+TEST(CaptureViewElement, ContainsPointRecursivelyForElementsOutsideOfTheParent) {
   const int kChildCount = 2;
   UnitTestCaptureViewContainerElement elem(nullptr, &kViewport, &kLayout, kChildCount);
 

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -213,28 +213,18 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
       .Times(Exactly(1))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kHandled));
 
-  std::ignore = container_elem.HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosOutside});
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
                 CaptureViewElement::EventType::kMouseWheelUp, kPosOutside}));
-  std::ignore = container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-      CaptureViewElement::EventType::kMouseMove, kPosBetweenChildren});
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
                 CaptureViewElement::EventType::kMouseWheelUp, kPosBetweenChildren}));
-  std::ignore = container_elem.HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosOnChild0});
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
                 CaptureViewElement::EventType::kMouseWheelUp, kPosOnChild0}));
-  std::ignore = container_elem.HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosOnChild1});
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
                 CaptureViewElement::EventType::kMouseWheelUp, kPosOnChild1}));
-  std::ignore = container_elem.HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosOnChild2});
   EXPECT_EQ(CaptureViewElement::EventResult::kHandled,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
                 CaptureViewElement::EventType::kMouseWheelUp, kPosOnChild2}));

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -171,15 +171,20 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kHandled));
 
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
-            container_elem.HandleMouseWheelEvent(kPosOutside, kDelta));
+            container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::EventType::kMouseWheelUp, kPosOutside}));
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
-            container_elem.HandleMouseWheelEvent(kPosBetweenChildren, kDelta));
+            container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::EventType::kMouseWheelUp, kPosBetweenChildren}));
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
-            container_elem.HandleMouseWheelEvent(kPosOnChild0, kDelta));
+            container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::EventType::kMouseWheelUp, kPosOnChild0}));
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
-            container_elem.HandleMouseWheelEvent(kPosOnChild1, kDelta));
+            container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::EventType::kMouseWheelUp, kPosOnChild1}));
   EXPECT_EQ(CaptureViewElement::EventResult::kHandled,
-            container_elem.HandleMouseWheelEvent(kPosOnChild2, kDelta));
+            container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::EventType::kMouseWheelUp, kPosOnChild2}));
 }
 
 TEST(CaptureViewElement, RequestUpdateBubblesUpAndIsClearedAfterDrawLoop) {

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -125,10 +125,9 @@ void CaptureWindow::MouseMoved(int x, int y, bool left, bool right, bool middle)
   GlCanvas::MouseMoved(x, y, left, right, middle);
   if (time_graph_ == nullptr) return;
 
-  if (!(left || right || middle)) {
-    std::ignore = time_graph_->HandleMouseEvent(CaptureViewElement::MouseEvent{
-        CaptureViewElement::EventType::kMouseMove, viewport_.ScreenToWorld({x, y})});
-  }
+  std::ignore = time_graph_->HandleMouseEvent(
+      CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kMouseMove,
+                                     viewport_.ScreenToWorld({x, y}), left, right, middle});
 
   // Pan
   if (left && !picking_manager_.IsDragging() && !capture_client_app_->IsCapturing()) {
@@ -168,8 +167,9 @@ void CaptureWindow::LeftUp() {
   }
 
   if (time_graph_ != nullptr) {
-    std::ignore = time_graph_->HandleMouseEvent(CaptureViewElement::MouseEvent{
-        CaptureViewElement::EventType::kLeftUp, viewport_.ScreenToWorld(mouse_move_pos_screen_)});
+    std::ignore = time_graph_->HandleMouseEvent(
+        CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kLeftUp,
+                                       viewport_.ScreenToWorld(mouse_move_pos_screen_)});
   }
 }
 
@@ -270,7 +270,7 @@ bool CaptureWindow::RightUp() {
 
   if (time_graph_ != nullptr) {
     std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove,
+        CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kMouseMove,
                                        viewport_.ScreenToWorld(mouse_move_pos_screen_)});
   }
 
@@ -306,9 +306,10 @@ void CaptureWindow::MouseWheelMoved(int x, int y, int delta, bool ctrl) {
     orbit_gl::ModifierKeys modifiers;
     modifiers.ctrl = ctrl;
     std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{(delta > 0 ? CaptureViewElement::EventType::kMouseWheelUp
-                                                  : CaptureViewElement::EventType::kMouseWheelDown),
-                                       viewport_.ScreenToWorld(Vec2i(x, y))},
+        CaptureViewElement::MouseEvent{
+            (delta > 0 ? CaptureViewElement::MouseEventType::kMouseWheelUp
+                       : CaptureViewElement::MouseEventType::kMouseWheelDown),
+            viewport_.ScreenToWorld(Vec2i(x, y))},
         modifiers);
   }
 }
@@ -397,7 +398,7 @@ void CaptureWindow::SetIsMouseOver(bool value) {
 
   if (time_graph_ != nullptr && !value) {
     std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseLeave});
+        CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kMouseLeave});
   }
 }
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -127,7 +127,7 @@ void CaptureWindow::MouseMoved(int x, int y, bool left, bool right, bool middle)
 
   std::ignore = time_graph_->HandleMouseEvent(
       CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kMouseMove,
-                                     viewport_.ScreenToWorld({x, y}), left, right, middle});
+                                     viewport_.ScreenToWorld(Vec2i(x, y)), left, right, middle});
 
   // Pan
   if (left && !picking_manager_.IsDragging() && !capture_client_app_->IsCapturing()) {

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -127,7 +127,7 @@ void CaptureWindow::MouseMoved(int x, int y, bool left, bool right, bool middle)
 
   if (!(left || right || middle)) {
     std::ignore = time_graph_->HandleMouseEvent(CaptureViewElement::MouseEvent{
-        CaptureViewElement::EventType::kMouseMoved, viewport_.ScreenToWorld({x, y})});
+        CaptureViewElement::EventType::kMouseMove, viewport_.ScreenToWorld({x, y})});
   }
 
   // Pan
@@ -270,7 +270,7 @@ bool CaptureWindow::RightUp() {
 
   if (time_graph_ != nullptr) {
     std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMoved,
+        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove,
                                        viewport_.ScreenToWorld(mouse_move_pos_screen_)});
   }
 
@@ -397,7 +397,7 @@ void CaptureWindow::SetIsMouseOver(bool value) {
 
   if (time_graph_ != nullptr && !value) {
     std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseOut});
+        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseLeave});
   }
 }
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -270,7 +270,7 @@ bool CaptureWindow::RightUp() {
 
   if (time_graph_ != nullptr) {
     std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kMouseMove,
+        CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kRightUp,
                                        viewport_.ScreenToWorld(mouse_move_pos_screen_)});
   }
 

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -21,25 +21,25 @@ namespace orbit_gl {
 const float GlSlider::kGradientFactor = 0.25f;
 
 CaptureViewElement::EventResult GlSlider::OnMouseEnter() {
-  std::ignore = CaptureViewElement::OnMouseEnter();
+  EventResult event_result = CaptureViewElement::OnMouseEnter();
   if (QGuiApplication::instance() != nullptr) {
     QGuiApplication::setOverrideCursor(Qt::ArrowCursor);
   }
   RequestUpdate(RequestUpdateScope::kDraw);
-  return EventResult::kIgnored;
+  return event_result;
 }
 
 CaptureViewElement::EventResult GlSlider::OnMouseLeave() {
-  std::ignore = CaptureViewElement::OnMouseLeave();
+  EventResult event_result = CaptureViewElement::OnMouseLeave();
   if (QGuiApplication::instance() != nullptr) {
     QGuiApplication::restoreOverrideCursor();
   }
   RequestUpdate(RequestUpdateScope::kDraw);
-  return EventResult::kIgnored;
+  return event_result;
 }
 
 CaptureViewElement::EventResult GlSlider::OnMouseMove(const Vec2& mouse_pos) {
-  std::ignore = CaptureViewElement::OnMouseMove(mouse_pos);
+  EventResult event_result = CaptureViewElement::OnMouseMove(mouse_pos);
   if (can_resize_ && QGuiApplication::instance() != nullptr) {
     if (PosIsInMinResizeArea(mouse_pos) || PosIsInMaxResizeArea(mouse_pos)) {
       QCursor cursor = is_vertical_ ? Qt::SizeVerCursor : Qt::SizeHorCursor;
@@ -48,7 +48,8 @@ CaptureViewElement::EventResult GlSlider::OnMouseMove(const Vec2& mouse_pos) {
       QGuiApplication::changeOverrideCursor(Qt::ArrowCursor);
     }
   }
-  return EventResult::kIgnored;
+  RequestUpdate(RequestUpdateScope::kDraw);
+  return event_result;
 }
 
 bool GlSlider::ContainsScreenSpacePoint(int x, int y) const {
@@ -182,7 +183,7 @@ void GlSlider::DrawSlider(PrimitiveAssembler& primitive_assembler, float x, floa
                           float height, ShadingDirection shading_direction) {
   bool is_picked = primitive_assembler.GetPickingManager()->IsThisElementPicked(this);
 
-  Color color = IsMouseOver() ? selected_color_ : slider_color_;
+  Color color = IsMouseOver() && PosIsInSlider(mouse_pos_cur_) ? selected_color_ : slider_color_;
   const Color dark_border_color = GetDarkerColor(bar_color_);
   const Color light_border_color = GetLighterColor(color);
   const float kEpsilon = 0.0001f;

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -20,24 +20,26 @@ namespace orbit_gl {
 
 const float GlSlider::kGradientFactor = 0.25f;
 
-void GlSlider::OnMouseEnter() {
-  CaptureViewElement::OnMouseEnter();
+CaptureViewElement::EventResult GlSlider::OnMouseEnter() {
+  std::ignore = CaptureViewElement::OnMouseEnter();
   if (QGuiApplication::instance() != nullptr) {
     QGuiApplication::setOverrideCursor(Qt::ArrowCursor);
   }
   RequestUpdate(RequestUpdateScope::kDraw);
+  return EventResult::kIgnored;
 }
 
-void GlSlider::OnMouseLeave() {
-  CaptureViewElement::OnMouseLeave();
+CaptureViewElement::EventResult GlSlider::OnMouseLeave() {
+  std::ignore = CaptureViewElement::OnMouseLeave();
   if (QGuiApplication::instance() != nullptr) {
     QGuiApplication::restoreOverrideCursor();
   }
   RequestUpdate(RequestUpdateScope::kDraw);
+  return EventResult::kIgnored;
 }
 
-void GlSlider::OnMouseMove(const Vec2& mouse_pos) {
-  CaptureViewElement::OnMouseMove(mouse_pos);
+CaptureViewElement::EventResult GlSlider::OnMouseMove(const Vec2& mouse_pos) {
+  std::ignore = CaptureViewElement::OnMouseMove(mouse_pos);
   if (can_resize_ && QGuiApplication::instance() != nullptr) {
     if (PosIsInMinResizeArea(mouse_pos) || PosIsInMaxResizeArea(mouse_pos)) {
       QCursor cursor = is_vertical_ ? Qt::SizeVerCursor : Qt::SizeHorCursor;
@@ -46,6 +48,7 @@ void GlSlider::OnMouseMove(const Vec2& mouse_pos) {
       QGuiApplication::changeOverrideCursor(Qt::ArrowCursor);
     }
   }
+  return EventResult::kIgnored;
 }
 
 bool GlSlider::ContainsScreenSpacePoint(int x, int y) const {
@@ -178,11 +181,8 @@ void GlSlider::DrawBackground(PrimitiveAssembler& primitive_assembler, float x, 
 void GlSlider::DrawSlider(PrimitiveAssembler& primitive_assembler, float x, float y, float width,
                           float height, ShadingDirection shading_direction) {
   bool is_picked = primitive_assembler.GetPickingManager()->IsThisElementPicked(this);
-  bool mouse_over_slider = false;
 
-  mouse_over_slider = IsMouseOver(mouse_pos_cur_);
-
-  Color color = mouse_over_slider ? selected_color_ : slider_color_;
+  Color color = IsMouseOver() ? selected_color_ : slider_color_;
   const Color dark_border_color = GetDarkerColor(bar_color_);
   const Color light_border_color = GetLighterColor(color);
   const float kEpsilon = 0.0001f;

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -104,7 +104,7 @@ Color GlSlider::GetDarkerColor(const Color& color) {
 
 void GlSlider::OnDrag(int x, int y) {
   CaptureViewElement::OnDrag(x, y);
-  Vec2 world_pos = viewport_->ScreenToWorld({x, y});
+  Vec2 world_pos = viewport_->ScreenToWorld(Vec2i(x, y));
   float value = is_vertical_ ? world_pos[1] - GetPos()[1] : world_pos[0] - GetPos()[0];
   float slider_pos = PosToPixel(pos_ratio_);
   float slider_right_pos = LenToPixel(right_edge_ratio_);
@@ -143,7 +143,7 @@ void GlSlider::OnDrag(int x, int y) {
 
 void GlSlider::OnPick(int x, int y) {
   CaptureViewElement::OnPick(x, y);
-  Vec2 world_pos = viewport_->ScreenToWorld({x, y});
+  Vec2 world_pos = viewport_->ScreenToWorld(Vec2i(x, y));
   float value = is_vertical_ ? world_pos[1] - GetPos()[1] : world_pos[0] - GetPos()[0];
 
   float slider_pos = PosToPixel(pos_ratio_);

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -183,7 +183,7 @@ void GlSlider::DrawSlider(PrimitiveAssembler& primitive_assembler, float x, floa
                           float height, ShadingDirection shading_direction) {
   bool is_picked = primitive_assembler.GetPickingManager()->IsThisElementPicked(this);
 
-  Color color = IsMouseOver() && PosIsInSlider(mouse_pos_cur_) ? selected_color_ : slider_color_;
+  Color color = (IsMouseOver() && PosIsInSlider(mouse_pos_cur_)) ? selected_color_ : slider_color_;
   const Color dark_border_color = GetDarkerColor(bar_color_);
   const Color light_border_color = GetLighterColor(color);
   const float kEpsilon = 0.0001f;

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -214,18 +214,18 @@ void GlSlider::DrawSlider(PrimitiveAssembler& primitive_assembler, float x, floa
 }
 
 bool GlSlider::PosIsInMinResizeArea(const Vec2& pos) const {
-  float relevant_value = is_vertical_ ? pos[1] : pos[0];
+  float relevant_value = is_vertical_ ? pos[1] - GetPos()[1] : pos[0] - GetPos()[0];
   return PosIsInSlider(pos) && relevant_value <= GetSliderPixelPos() + slider_resize_pixel_margin_;
 }
 
 bool GlSlider::PosIsInMaxResizeArea(const Vec2& pos) const {
-  float relevant_value = is_vertical_ ? pos[1] : pos[0];
+  float relevant_value = is_vertical_ ? pos[1] - GetPos()[1] : pos[0] - GetPos()[0];
   return PosIsInSlider(pos) && relevant_value >= GetSliderPixelPos() + GetSliderPixelLength() -
                                                      slider_resize_pixel_margin_;
 }
 
 bool GlSlider::PosIsInSlider(const Vec2& pos) const {
-  float relevant_value = is_vertical_ ? pos[1] : pos[0];
+  float relevant_value = is_vertical_ ? pos[1] - GetPos()[1] : pos[0] - GetPos()[0];
   return relevant_value >= GetSliderPixelPos() &&
          relevant_value <= GetSliderPixelPos() + GetSliderPixelLength();
 }

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -83,9 +83,9 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
     return value * LenToPixel(1.0f - length_ratio_);
   }
 
-  [[nodiscard]] virtual EventResult OnMouseMove(const Vec2& mouse_pos) override;
-  [[nodiscard]] virtual EventResult OnMouseEnter() override;
-  [[nodiscard]] virtual EventResult OnMouseLeave() override;
+  [[nodiscard]] EventResult OnMouseMove(const Vec2& mouse_pos) override;
+  [[nodiscard]] EventResult OnMouseEnter() override;
+  [[nodiscard]] EventResult OnMouseLeave() override;
   [[nodiscard]] bool HandlePageScroll(float click_value);
 
  protected:

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -55,9 +55,9 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
 
   [[nodiscard]] bool CanResize() const { return can_resize_; }
 
-  void OnMouseEnter();
-  void OnMouseLeave();
-  void OnMouseMove(int x, int y);
+  void OnMouseEnter() override;
+  void OnMouseLeave() override;
+  void OnMouseMove(const Vec2& pos) override;
   [[nodiscard]] bool ContainsScreenSpacePoint(int x, int y) const;
 
  protected:
@@ -73,9 +73,9 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
   void DrawSlider(PrimitiveAssembler& primitive_assembler, float x, float y, float width,
                   float height, ShadingDirection shading_direction);
 
-  [[nodiscard]] bool PosIsInMinResizeArea(int x, int y) const;
-  [[nodiscard]] bool PosIsInMaxResizeArea(int x, int y) const;
-  [[nodiscard]] bool PosIsInSlider(int x, int y) const;
+  [[nodiscard]] bool PosIsInMinResizeArea(const Vec2& pos) const;
+  [[nodiscard]] bool PosIsInMaxResizeArea(const Vec2& pos) const;
+  [[nodiscard]] bool PosIsInSlider(const Vec2& pos) const;
 
   [[nodiscard]] float PixelToLen(float value) const { return value / GetBarPixelLength(); }
   [[nodiscard]] float LenToPixel(float value) const { return value * GetBarPixelLength(); }
@@ -93,7 +93,6 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
 
   static const float kGradientFactor;
   const bool is_vertical_;
-  bool is_mouse_over_ = false;
 
   TimelineInfoInterface* timeline_info_;
 

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -55,9 +55,6 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
 
   [[nodiscard]] bool CanResize() const { return can_resize_; }
 
-  void OnMouseEnter() override;
-  void OnMouseLeave() override;
-  void OnMouseMove(const Vec2& pos) override;
   [[nodiscard]] bool ContainsScreenSpacePoint(int x, int y) const;
 
  protected:
@@ -86,6 +83,9 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
     return value * LenToPixel(1.0f - length_ratio_);
   }
 
+  [[nodiscard]] virtual EventResult OnMouseMove(const Vec2& mouse_pos) override;
+  [[nodiscard]] virtual EventResult OnMouseEnter() override;
+  [[nodiscard]] virtual EventResult OnMouseLeave() override;
   [[nodiscard]] bool HandlePageScroll(float click_value);
 
  protected:

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -70,6 +70,13 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
   void DrawSlider(PrimitiveAssembler& primitive_assembler, float x, float y, float width,
                   float height, ShadingDirection shading_direction);
 
+  [[nodiscard]] EventResult OnMouseMove(const Vec2& mouse_pos) override;
+  [[nodiscard]] EventResult OnMouseEnter() override;
+  [[nodiscard]] EventResult OnMouseLeave() override;
+  [[nodiscard]] bool HandlePageScroll(float click_value);
+
+ protected:
+  [[nodiscard]] virtual float GetBarPixelLength() const = 0;
   [[nodiscard]] bool PosIsInMinResizeArea(const Vec2& pos) const;
   [[nodiscard]] bool PosIsInMaxResizeArea(const Vec2& pos) const;
   [[nodiscard]] bool PosIsInSlider(const Vec2& pos) const;
@@ -82,14 +89,6 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
   [[nodiscard]] float PosToPixel(float value) const {
     return value * LenToPixel(1.0f - length_ratio_);
   }
-
-  [[nodiscard]] EventResult OnMouseMove(const Vec2& mouse_pos) override;
-  [[nodiscard]] EventResult OnMouseEnter() override;
-  [[nodiscard]] EventResult OnMouseLeave() override;
-  [[nodiscard]] bool HandlePageScroll(float click_value);
-
- protected:
-  [[nodiscard]] virtual float GetBarPixelLength() const = 0;
 
   static const float kGradientFactor;
   const bool is_vertical_;

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -111,7 +111,7 @@ static void TestDragType() {
     EXPECT_EQ(drag_count, 2);
     EXPECT_EQ(size_count, 0);
   }
-  EXPECT_EQ(pos, kPos);
+  EXPECT_NEAR(pos, kPos, kEpsilon);
   EXPECT_EQ(size, kSize);
 
   PickDragRelease<dim>(*slider, 75 * scale - kOffset);
@@ -122,7 +122,7 @@ static void TestDragType() {
     EXPECT_EQ(drag_count, 3);
     EXPECT_EQ(size_count, 0);
   }
-  EXPECT_EQ(pos, kPos);
+  EXPECT_NEAR(pos, kPos, kEpsilon);
   EXPECT_EQ(size, kSize);
 
   drag_count = 0;

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -336,4 +336,40 @@ TEST(Slider, ContainsScreenSpacePoint) {
                                                static_cast<int>(outside_point_slider[1])));
 }
 
+TEST(Slider, MouseMoveRequestRedraw) {
+  CaptureViewElementTester tester;
+  Viewport* viewport = tester.GetViewport();
+
+  std::shared_ptr<GlHorizontalSlider> slider{
+      std::make_shared<GlHorizontalSlider>(nullptr, viewport, tester.GetLayout(), nullptr)};
+  tester.SimulatePreRender(slider.get());
+
+  Vec2 kPosInSlider = slider->GetPos();
+  Vec2 kPosOutOfSlider{-1, -1};
+
+  // Going in the slider should trigger a redraw.
+  std::ignore = slider->HandleMouseEvent(
+      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosInSlider});
+  tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
+  std::ignore = slider->HandleMouseEvent(
+      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosInSlider});
+  tester.SimulateDrawLoopAndCheckFlags(slider.get(), false, false);
+
+  // Going out of the slider should also trigger a redraw.
+  std::ignore = slider->HandleMouseEvent(
+      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseLeave});
+  tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
+
+  std::ignore = slider->HandleMouseEvent(
+      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosOutOfSlider});
+  std::ignore = slider->HandleMouseEvent(
+      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseLeave});
+  tester.SimulateDrawLoopAndCheckFlags(slider.get(), false, false);
+
+  // Going in the slider again should trigger another redraw.
+  std::ignore = slider->HandleMouseEvent(
+      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosInSlider});
+  tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
+}
+
 }  // namespace orbit_gl

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -346,22 +346,22 @@ TEST(Slider, MouseMoveRequestRedraw) {
 
   Vec2 kPosInSlider = slider->GetPos();
 
-  // Going in the slider should trigger a redraw.
-  std::ignore = slider->HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosInSlider});
+  // Any mouse move or mouse leave should trigger a redraw in the slider.
+  EXPECT_EQ(slider->HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
+            CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
-  std::ignore = slider->HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosInSlider});
-  tester.SimulateDrawLoopAndCheckFlags(slider.get(), false, false);
-
-  // Going out of the slider should also trigger a redraw.
-  std::ignore = slider->HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseLeave});
+  EXPECT_EQ(slider->HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
+            CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
-
-  // Going in the slider again should trigger another redraw.
-  std::ignore = slider->HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosInSlider});
+  EXPECT_EQ(slider->HandleMouseEvent(
+                CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kMouseLeave}),
+            CaptureViewElement::EventResult::kIgnored);
+  tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
+  EXPECT_EQ(slider->HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
+            CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
 }
 

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -351,14 +351,17 @@ TEST(Slider, MouseMoveRequestRedraw) {
                 CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
             CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
+
   EXPECT_EQ(slider->HandleMouseEvent(CaptureViewElement::MouseEvent{
                 CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
             CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
+
   EXPECT_EQ(slider->HandleMouseEvent(
                 CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kMouseLeave}),
             CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
+
   EXPECT_EQ(slider->HandleMouseEvent(CaptureViewElement::MouseEvent{
                 CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
             CaptureViewElement::EventResult::kIgnored);

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -345,7 +345,6 @@ TEST(Slider, MouseMoveRequestRedraw) {
   tester.SimulatePreRender(slider.get());
 
   Vec2 kPosInSlider = slider->GetPos();
-  Vec2 kPosOutOfSlider{-1, -1};
 
   // Going in the slider should trigger a redraw.
   std::ignore = slider->HandleMouseEvent(
@@ -359,12 +358,6 @@ TEST(Slider, MouseMoveRequestRedraw) {
   std::ignore = slider->HandleMouseEvent(
       CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseLeave});
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
-
-  std::ignore = slider->HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, kPosOutOfSlider});
-  std::ignore = slider->HandleMouseEvent(
-      CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseLeave});
-  tester.SimulateDrawLoopAndCheckFlags(slider.get(), false, false);
 
   // Going in the slider again should trigger another redraw.
   std::ignore = slider->HandleMouseEvent(

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -384,42 +384,6 @@ void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
   track->OnTimer(timer_info);
 }
 
-void TimeGraph::ProcessSliderMouseMoveEvents(int x, int y) {
-  orbit_gl::GlSlider* slider = FindSliderUnderMouseCursor(x, y);
-  if (slider != last_mouseover_slider_) {
-    if (last_mouseover_slider_ != nullptr) {
-      last_mouseover_slider_->OnMouseLeave();
-    }
-    last_mouseover_slider_ = slider;
-    if (slider != nullptr) {
-      slider->OnMouseEnter();
-    }
-  }
-
-  if (slider != nullptr) {
-    slider->OnMouseMove(x, y);
-  }
-}
-
-// TODO(b/230441102): Refactor this using the new MouseEvent.
-void TimeGraph::SetIsMouseOver(bool value) {
-  if (!value && last_mouseover_slider_ != nullptr) {
-    last_mouseover_slider_->OnMouseLeave();
-    last_mouseover_slider_ = nullptr;
-    RequestUpdate(RequestUpdateScope::kDraw);
-  }
-}
-
-orbit_gl::GlSlider* TimeGraph::FindSliderUnderMouseCursor(int x, int y) {
-  for (orbit_gl::GlSlider* slider : {vertical_slider_.get(), horizontal_slider_.get()}) {
-    if (slider->ContainsScreenSpacePoint(x, y)) {
-      return slider;
-    }
-  }
-
-  return nullptr;
-}
-
 orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     const Vec2& mouse_pos, int delta, const orbit_gl::ModifierKeys& modifiers) {
   if (delta == 0) return EventResult::kIgnored;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -163,11 +163,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
     return accessible_parent_;
   }
 
-  // TODO(b/230442062): Refactor slider methods.
-  orbit_gl::GlSlider* FindSliderUnderMouseCursor(int x, int y);
-  void ProcessSliderMouseMoveEvents(int x, int y);
-  void SetIsMouseOver(bool value);
-
  protected:
   void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
               orbit_gl::TextRenderer& text_renderer, const DrawContext& draw_context) override;
@@ -216,7 +211,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   orbit_gl::OpenGlBatcher batcher_;
   orbit_gl::PrimitiveAssembler primitive_assembler_;
 
-  orbit_gl::GlSlider* last_mouseover_slider_ = nullptr;
   std::unique_ptr<orbit_gl::TrackContainer> track_container_;
   std::unique_ptr<orbit_gl::TimelineUi> timeline_ui_;
 

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -20,18 +20,16 @@ class UnitTestTimeGraph : public testing::Test {
                                               capture_data_.get(), nullptr);
   }
 
-  // TODO(b/230441102): Temporal solution while we implement mouse moved methods for
-  // CaptureViewElements.
-  void MouseMoved(int x, int y, bool left, bool right, bool middle) {
-    if (!(left || right || middle)) {
-      time_graph_->ProcessSliderMouseMoveEvents(x, y);
-    }
-  }
-
   void SimulatePreRender() { tester_.SimulatePreRender(time_graph_.get()); }
 
   orbit_gl::GlSlider* FindSliderUnderMouseCursor(int x, int y) {
-    return time_graph_->FindSliderUnderMouseCursor(x, y);
+    if (HorizontalSlider()->IsMouseOver(viewport_->ScreenToWorld({x, y}))) {
+      return HorizontalSlider();
+    }
+    if (VerticalSlider()->IsMouseOver(viewport_->ScreenToWorld({x, y}))) {
+      return VerticalSlider();
+    }
+    return nullptr;
   }
   [[nodiscard]] GlSlider* HorizontalSlider() { return time_graph_->GetHorizontalSlider(); }
   [[nodiscard]] GlSlider* VerticalSlider() { return time_graph_->GetVerticalSlider(); }

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "CaptureViewElementTester.h"
@@ -19,6 +18,7 @@ class UnitTestTimeGraph : public testing::Test {
     viewport_ = std::make_unique<Viewport>(100, 200);
     time_graph_ = std::make_unique<TimeGraph>(nullptr, nullptr, viewport_.get(),
                                               capture_data_.get(), nullptr);
+    time_graph_->ZoomAll();
   }
 
   void SimulatePreRender() { tester_.SimulatePreRender(time_graph_.get()); }
@@ -87,17 +87,15 @@ TEST_F(UnitTestTimeGraph, MouseWheel) {
   SimulatePreRender();
   const TimeGraph* time_graph = GetTimeGraph();
 
-  float time_window_us = time_graph->GetTimeWindowUs();
+  double time_window_us = time_graph->GetTimeWindowUs();
   Vec2 kCenteredMousePosition{time_graph->GetPos()[0] + time_graph->GetSize()[0] / 2.f,
                               time_graph->GetPos()[1] + time_graph->GetSize()[1] / 2.f};
-  MouseMove(kCenteredMousePosition);
   MouseWheelUp(kCenteredMousePosition);
 
   // MouseWheel in the center should modify the time window. This will change soon.
   EXPECT_NE(time_window_us, time_graph->GetTimeWindowUs());
 
   time_window_us = time_graph->GetTimeWindowUs();
-  MouseMove(time_graph->GetTimelineUi()->GetPos());
   MouseWheelUp(time_graph->GetTimelineUi()->GetPos());
 
   // MouseWheel in the timeline should modify the time windows.

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -23,10 +23,10 @@ class UnitTestTimeGraph : public testing::Test {
 
   void SimulatePreRender() { tester_.SimulatePreRender(time_graph_.get()); }
 
-  const TimeGraph* GetTimeGraph() { return time_graph_.get(); }
+  [[nodiscard]] TimeGraph* GetTimeGraph() const { return time_graph_.get(); }
   [[nodiscard]] GlSlider* HorizontalSlider() const { return time_graph_->GetHorizontalSlider(); }
   [[nodiscard]] GlSlider* VerticalSlider() const { return time_graph_->GetVerticalSlider(); }
-  [[nodiscard]] TimelineUi* TimelineUi() const { return time_graph_->GetTimelineUi(); }
+  [[nodiscard]] TimelineUi* GetTimelineUi() const { return time_graph_->GetTimelineUi(); }
 
   void MouseMove(const Vec2& pos) {
     EXPECT_EQ(time_graph_->HandleMouseEvent(CaptureViewElement::MouseEvent{
@@ -71,8 +71,8 @@ TEST_F(UnitTestTimeGraph, MouseMove) {
   MouseMove(VerticalSlider()->GetPos());
   CheckMouseIsOnlyOverAChild(VerticalSlider());
 
-  MouseMove(TimelineUi()->GetPos());
-  CheckMouseIsOnlyOverAChild(TimelineUi());
+  MouseMove(GetTimelineUi()->GetPos());
+  CheckMouseIsOnlyOverAChild(GetTimelineUi());
 }
 
 TEST_F(UnitTestTimeGraph, MouseLeave) {

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -24,21 +24,24 @@ class UnitTestTimeGraph : public testing::Test {
   void SimulatePreRender() { tester_.SimulatePreRender(time_graph_.get()); }
 
   const TimeGraph* GetTimeGraph() { return time_graph_.get(); }
-  [[nodiscard]] GlSlider* HorizontalSlider() { return time_graph_->GetHorizontalSlider(); }
-  [[nodiscard]] GlSlider* VerticalSlider() { return time_graph_->GetVerticalSlider(); }
-  [[nodiscard]] TimelineUi* TimelineUi() { return time_graph_->GetTimelineUi(); }
+  [[nodiscard]] GlSlider* HorizontalSlider() const { return time_graph_->GetHorizontalSlider(); }
+  [[nodiscard]] GlSlider* VerticalSlider() const { return time_graph_->GetVerticalSlider(); }
+  [[nodiscard]] TimelineUi* TimelineUi() const { return time_graph_->GetTimelineUi(); }
 
   void MouseMove(const Vec2& pos) {
-    std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseMove, pos});
+    EXPECT_EQ(time_graph_->HandleMouseEvent(CaptureViewElement::MouseEvent{
+                  CaptureViewElement::MouseEventType::kMouseMove, pos}),
+              CaptureViewElement::EventResult::kIgnored);
   }
   void MouseLeave() {
-    std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseLeave});
+    EXPECT_EQ(time_graph_->HandleMouseEvent(
+                  CaptureViewElement::MouseEvent{CaptureViewElement::MouseEventType::kMouseLeave}),
+              CaptureViewElement::EventResult::kIgnored);
   }
   void MouseWheelUp(const Vec2& pos) {
-    std::ignore = time_graph_->HandleMouseEvent(
-        CaptureViewElement::MouseEvent{CaptureViewElement::EventType::kMouseWheelUp, pos});
+    EXPECT_EQ(time_graph_->HandleMouseEvent(CaptureViewElement::MouseEvent{
+                  CaptureViewElement::MouseEventType::kMouseWheelUp, pos}),
+              CaptureViewElement::EventResult::kHandled);
   }
   void CheckMouseIsOnlyOverAChild(CaptureViewElement* child_over_mouse) {
     EXPECT_TRUE(time_graph_->IsMouseOver());


### PR DESCRIPTION
Disclaimer: It's not my cleanest PR for sure, sorry for that.

In this PR we are implementing mouse events for CaptureViewElements. 
They could not be implemented using picking because of performance.
In the future we will unify all mouse interactions (currently mixed by 
picking + custom implementations), but we probably will need to tackle
Timers differently (TBD).

For now we are using it for MouseMove events, MouseWheel and 
MouseLeave events. Parent will send events to the child under the mouse
and will take care of informing children that are no longer under the mouse.

- We are fixing highlighting of the scrollbars (http://b/231533802).
- We are also adding a few missing conversions from ScreenToWorld in the Slider.
- Several tests are added.

Bug: http://b/230441102.

Test: Load a capture, check sliders works as expected with MouseMoved
events.
