### PR TITLE
Fix Memory Tracing E2E test

### DIFF
--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -579,7 +579,7 @@ class SetAndCheckMemorySamplingPeriod(E2ETestCase):
         logging.info('Selecting "Collect memory usage and page faults information" checkbox')
         collect_system_memory_usage_checkbox = self.find_control(
             'CheckBox',
-            'Collect memory usage and page faults information',
+            'CollectMemoryInfoCheckBox',
             parent=self.find_control('Window', 'Capture Options'))
         if not collect_system_memory_usage_checkbox.get_toggle_state():
             collect_system_memory_usage_checkbox.click_input()


### PR DESCRIPTION
With #3661, we gave the edits in the capture options proper
accessible names. However, we missed changing the call to
find_control for the memory tracing case.

This fixes the call by using the new name.

Test: Run test locally
Bug: http://b/231524280