### PR TITLE
Display Symbol loading status in the module list

### DIFF
--- a/src/DataViews/CMakeLists.txt
+++ b/src/DataViews/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(DataViews PUBLIC
         include/DataViews/PresetLoadState.h
         include/DataViews/SamplingReportDataView.h        
         include/DataViews/SamplingReportInterface.h
+        include/DataViews/SymbolLoadingState.h
         include/DataViews/TracepointsDataView.h)
 
 target_include_directories(DataViews PUBLIC include/)

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -19,6 +19,7 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "DataViews/AppInterface.h"
 #include "DataViews/PresetLoadState.h"
+#include "DataViews/SymbolLoadingState.h"
 #include "OrbitBase/Future.h"
 #include "PresetFile/PresetFile.h"
 
@@ -107,6 +108,11 @@ class MockAppInterface : public AppInterface {
 
   MOCK_METHOD(uint64_t, ProvideScopeId, (const orbit_client_protos::TimerInfo& timer_info),
               (const));
+
+  MOCK_METHOD(bool, IsModuleDownloading, (const orbit_client_data::ModuleData* module),
+              (const, override));
+  MOCK_METHOD(SymbolLoadingState, GetSymbolLoadingStateForModule,
+              (const orbit_client_data::ModuleData* module), (const, override));
 };
 
 }  // namespace orbit_data_views

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -40,14 +40,14 @@ const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     if (new_ui_) {
-      columns[kColumnSymbols] = {"Symbols", .0f, SortingOrder::kDescending};
+      columns[kColumnSymbols] = {"Symbols", .175f, SortingOrder::kDescending};
     } else {
       columns[kColumnSymbols] = {"Loaded", .0f, SortingOrder::kDescending};
     }
     columns[kColumnName] = {"Name", .2f, SortingOrder::kAscending};
-    columns[kColumnPath] = {"Path", .5f, SortingOrder::kAscending};
-    columns[kColumnAddressRange] = {"Address Range", .15f, SortingOrder::kAscending};
-    columns[kColumnFileSize] = {"File Size", .0f, SortingOrder::kDescending};
+    columns[kColumnPath] = {"Path", .45f, SortingOrder::kAscending};
+    columns[kColumnAddressRange] = {"Address Range", .075f, SortingOrder::kAscending};
+    columns[kColumnFileSize] = {"File Size", .1f, SortingOrder::kDescending};
     return columns;
   }();
   return columns;

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <functional>
 
+#include "ClientData/ModuleData.h"
 #include "ClientData/ProcessData.h"
 #include "ClientFlags/ClientFlags.h"
 #include "DataViews/CompareAscendingOrDescending.h"
@@ -30,14 +31,19 @@ using orbit_client_data::ProcessData;
 namespace orbit_data_views {
 
 ModulesDataView::ModulesDataView(AppInterface* app,
-                                 orbit_metrics_uploader::MetricsUploader* metrics_uploader)
-    : DataView(DataViewType::kModules, app, metrics_uploader) {}
+                                 orbit_metrics_uploader::MetricsUploader* metrics_uploader,
+                                 bool new_ui)
+    : DataView(DataViewType::kModules, app, metrics_uploader), new_ui_(new_ui) {}
 
 const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
-  static const std::vector<Column> columns = [] {
+  static const std::vector<Column> columns = [this] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
-    columns[kColumnLoaded] = {"Loaded", .0f, SortingOrder::kDescending};
+    if (new_ui_) {
+      columns[kColumnSymbols] = {"Symbols", .0f, SortingOrder::kDescending};
+    } else {
+      columns[kColumnSymbols] = {"Loaded", .0f, SortingOrder::kDescending};
+    }
     columns[kColumnName] = {"Name", .2f, SortingOrder::kAscending};
     columns[kColumnPath] = {"Path", .5f, SortingOrder::kAscending};
     columns[kColumnAddressRange] = {"Address Range", .15f, SortingOrder::kAscending};
@@ -47,14 +53,23 @@ const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
   return columns;
 }
 
+std::string ModulesDataView::GetSymbolLoadingStateForModuleString(const ModuleData* module) {
+  SymbolLoadingState loading_state = app_->GetSymbolLoadingStateForModule(module);
+  return loading_state.GetDescription();
+}
+
 std::string ModulesDataView::GetValue(int row, int col) {
   uint64_t start_address = indices_[row];
   const ModuleData* module = start_address_to_module_.at(start_address);
   const ModuleInMemory& memory_space = start_address_to_module_in_memory_.at(start_address);
 
   switch (col) {
-    case kColumnLoaded:
+    case kColumnSymbols: {
+      if (new_ui_) {
+        return GetSymbolLoadingStateForModuleString(module);
+      }
       return module->is_loaded() ? "*" : "";
+    }
     case kColumnName:
       return module->name();
     case kColumnPath:
@@ -87,7 +102,7 @@ void ModulesDataView::DoSort() {
   std::function<bool(uint64_t, uint64_t)> sorter = nullptr;
 
   switch (sorting_column_) {
-    case kColumnLoaded:
+    case kColumnSymbols:
       sorter = ORBIT_PROC_SORT(is_loaded());
       break;
     case kColumnName:
@@ -209,6 +224,11 @@ void ModulesDataView::OnRefreshButtonClicked() {
 bool ModulesDataView::GetDisplayColor(int row, int /*column*/, unsigned char& red,
                                       unsigned char& green, unsigned char& blue) {
   const ModuleData* module = GetModuleDataFromRow(row);
+
+  if (new_ui_) {
+    return app_->GetSymbolLoadingStateForModule(module).GetDisplayColor(red, green, blue);
+  }
+
   if (module->is_loaded()) {
     red = 42;
     green = 218;

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -292,7 +292,7 @@ TEST_F(ModulesDataViewTest, ColumnSortingShowsRightResults) {
 }
 
 TEST_F(ModulesDataViewTest, SymbolLoadingColumnContent) {
-  constexpr int kIndex = 0;
+  const int kIndex = 0;
   AddModulesByIndices({kIndex});
   const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
       modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
@@ -311,7 +311,7 @@ TEST_F(ModulesDataViewTest, SymbolLoadingColumnContent) {
 }
 
 TEST_F(ModulesDataViewTest, SymbolLoadingColor) {
-  constexpr int kIndex = 0;
+  const int kIndex = 0;
   AddModulesByIndices({kIndex});
   const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
       modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -3,16 +3,20 @@
 // found in the LICENSE file.
 
 #include <absl/strings/str_format.h>
+#include <gmock/gmock-actions.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
 
 #include "ClientData/ProcessData.h"
 #include "DataViewTestUtils.h"
+#include "DataViews/AppInterface.h"
 #include "DataViews/DataView.h"
 #include "DataViews/ModulesDataView.h"
+#include "DataViews/SymbolLoadingState.h"
 #include "DisplayFormats/DisplayFormats.h"
 #include "GrpcProtos/module.pb.h"
 #include "MetricsUploader/MetricsUploaderStub.h"
@@ -36,7 +40,7 @@ const std::array<std::string, kNumModules> kFilePaths{
 const std::array<std::string, kNumModules> kBuildIds{"build_id_0", "build_id_1", "build_id_2"};
 
 // ModulesDataView also has column index constants defined, but they are declared as private.
-constexpr int kColumnLoaded = 0;
+constexpr int kColumnSymbols = 0;
 constexpr int kColumnName = 1;
 constexpr int kColumnPath = 2;
 constexpr int kColumnAddressRange = 3;
@@ -53,7 +57,7 @@ std::string GetExpectedDisplayFileSizeByIndex(size_t index) {
 
 class ModulesDataViewTest : public testing::Test {
  public:
-  explicit ModulesDataViewTest() : view_{&app_, &metrics_uploader_} {
+  explicit ModulesDataViewTest() : view_{&app_, &metrics_uploader_, true} {
     view_.Init();
     for (size_t i = 0; i < kNumModules; i++) {
       ModuleInMemory module_in_memory{kStartAddresses[i], kEndAddresses[i], kFilePaths[i],
@@ -106,11 +110,14 @@ TEST_F(ModulesDataViewTest, HasValidDefaultSortingColumn) {
 TEST_F(ModulesDataViewTest, ColumnValuesAreCorrect) {
   AddModulesByIndices({0});
 
+  EXPECT_CALL(app_, GetSymbolLoadingStateForModule)
+      .WillOnce(testing::Return(SymbolLoadingState::kUnknown));
+
   EXPECT_EQ(view_.GetValue(0, kColumnName), kNames[0]);
   EXPECT_EQ(view_.GetValue(0, kColumnPath), kFilePaths[0]);
   EXPECT_EQ(view_.GetValue(0, kColumnAddressRange), GetExpectedDisplayAddressRangeByIndex(0));
   EXPECT_EQ(view_.GetValue(0, kColumnFileSize), GetExpectedDisplayFileSizeByIndex(0));
-  EXPECT_EQ(view_.GetValue(0, kColumnLoaded), "");
+  EXPECT_EQ(view_.GetValue(0, kColumnSymbols), "");
 }
 
 TEST_F(ModulesDataViewTest, ContextMenuEntriesArePresent) {
@@ -142,9 +149,11 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Copy Selection
   {
+    EXPECT_CALL(app_, GetSymbolLoadingStateForModule)
+        .WillOnce(testing::Return(SymbolLoadingState::kLoaded));
     std::string expected_clipboard = absl::StrFormat(
-        "Loaded\tName\tPath\tAddress Range\tFile Size\n"
-        "\t%s\t%s\t%s\t%s\n",
+        "Symbols\tName\tPath\tAddress Range\tFile Size\n"
+        "Loaded\t%s\t%s\t%s\t%s\n",
         kNames[0], kFilePaths[0], GetExpectedDisplayAddressRangeByIndex(0),
         GetExpectedDisplayFileSizeByIndex(0));
     CheckCopySelectionIsInvoked(context_menu, app_, view_, expected_clipboard);
@@ -152,10 +161,12 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
 
   // Export to CSV
   {
+    EXPECT_CALL(app_, GetSymbolLoadingStateForModule)
+        .WillOnce(testing::Return(SymbolLoadingState::kLoaded));
     std::string expected_contents =
-        absl::StrFormat(R"("Loaded","Name","Path","Address Range","File Size")"
+        absl::StrFormat(R"("Symbols","Name","Path","Address Range","File Size")"
                         "\r\n"
-                        R"("","%s","%s","%s","%s")"
+                        R"("Loaded","%s","%s","%s","%s")"
                         "\r\n",
                         kNames[0], kFilePaths[0], GetExpectedDisplayAddressRangeByIndex(0),
                         GetExpectedDisplayFileSizeByIndex(0));
@@ -278,6 +289,57 @@ TEST_F(ModulesDataViewTest, ColumnSortingShowsRightResults) {
 
   // Sort by address range descending
   { sort_and_verify(kColumnAddressRange, orbit_data_views::DataView::SortingOrder::kDescending); }
+}
+
+TEST_F(ModulesDataViewTest, SymbolLoadingColumnContent) {
+  constexpr int kIndex = 0;
+  AddModulesByIndices({kIndex});
+  const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
+      modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
+
+  auto get_content_for = [this, module](SymbolLoadingState state) -> std::string {
+    EXPECT_CALL(app_, GetSymbolLoadingStateForModule(module)).WillOnce(testing::Return(state));
+    return view_.GetValue(kIndex, kColumnSymbols);
+  };
+
+  EXPECT_EQ(get_content_for(SymbolLoadingState::kUnknown), "");
+  EXPECT_EQ(get_content_for(SymbolLoadingState::kDisabled), "Disabled");
+  EXPECT_EQ(get_content_for(SymbolLoadingState::kDownloading), "Downloading...");
+  EXPECT_EQ(get_content_for(SymbolLoadingState::kError), "Error");
+  EXPECT_EQ(get_content_for(SymbolLoadingState::kLoading), "Loading...");
+  EXPECT_EQ(get_content_for(SymbolLoadingState::kLoaded), "Loaded");
+}
+
+TEST_F(ModulesDataViewTest, SymbolLoadingColor) {
+  constexpr int kIndex = 0;
+  AddModulesByIndices({kIndex});
+  const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
+      modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
+
+  auto check_color_correct_for = [this, module](SymbolLoadingState state) {
+    uint8_t red = 0;
+    uint8_t green = 0;
+    uint8_t blue = 0;
+    bool default_color = !state.GetDisplayColor(red, green, blue);
+
+    EXPECT_CALL(app_, GetSymbolLoadingStateForModule(module)).WillOnce(testing::Return(state));
+    uint8_t view_red = 0;
+    uint8_t view_green = 0;
+    uint8_t view_blue = 0;
+    bool view_default_color =
+        !view_.GetDisplayColor(kIndex, kColumnSymbols, view_red, view_green, view_blue);
+    EXPECT_EQ(default_color, view_default_color);
+    EXPECT_EQ(red, view_red);
+    EXPECT_EQ(green, view_green);
+    EXPECT_EQ(blue, view_blue);
+  };
+
+  check_color_correct_for(SymbolLoadingState::kUnknown);
+  check_color_correct_for(SymbolLoadingState::kDisabled);
+  check_color_correct_for(SymbolLoadingState::kDownloading);
+  check_color_correct_for(SymbolLoadingState::kError);
+  check_color_correct_for(SymbolLoadingState::kLoading);
+  check_color_correct_for(SymbolLoadingState::kLoaded);
 }
 
 }  // namespace orbit_data_views

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -18,18 +18,10 @@
 #include "MetricsUploader/MetricsUploaderStub.h"
 #include "MockAppInterface.h"
 
+namespace orbit_data_views {
+
 using orbit_client_data::ModuleData;
 using orbit_client_data::ModuleInMemory;
-using orbit_data_views::CheckCopySelectionIsInvoked;
-using orbit_data_views::CheckExportToCsvIsInvoked;
-using orbit_data_views::ContextMenuEntry;
-using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
-using orbit_data_views::GetActionIndexOnMenu;
-using orbit_data_views::kInvalidActionIndex;
-using orbit_data_views::kMenuActionCopySelection;
-using orbit_data_views::kMenuActionExportToCsv;
-using orbit_data_views::kMenuActionLoadSymbols;
 using orbit_grpc_protos::ModuleInfo;
 
 namespace {
@@ -287,3 +279,5 @@ TEST_F(ModulesDataViewTest, ColumnSortingShowsRightResults) {
   // Sort by address range descending
   { sort_and_verify(kColumnAddressRange, orbit_data_views::DataView::SortingOrder::kDescending); }
 }
+
+}  // namespace orbit_data_views

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -297,7 +297,7 @@ TEST_F(ModulesDataViewTest, SymbolLoadingColumnContent) {
   const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
       modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
 
-  auto get_content_for = [this, module](SymbolLoadingState state) -> std::string {
+  auto get_content_for = [this, module, kIndex](SymbolLoadingState state) -> std::string {
     EXPECT_CALL(app_, GetSymbolLoadingStateForModule(module)).WillOnce(testing::Return(state));
     return view_.GetValue(kIndex, kColumnSymbols);
   };
@@ -316,7 +316,7 @@ TEST_F(ModulesDataViewTest, SymbolLoadingColor) {
   const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
       modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
 
-  auto check_color_correct_for = [this, module](SymbolLoadingState state) {
+  auto check_color_correct_for = [this, module, kIndex](SymbolLoadingState state) {
     uint8_t red = 0;
     uint8_t green = 0;
     uint8_t blue = 0;

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -292,14 +292,14 @@ TEST_F(ModulesDataViewTest, ColumnSortingShowsRightResults) {
 }
 
 TEST_F(ModulesDataViewTest, SymbolLoadingColumnContent) {
-  const int kIndex = 0;
+  constexpr int kIndex = 0;
   AddModulesByIndices({kIndex});
   const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
       modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
 
-  auto get_content_for = [this, module, kIndex](SymbolLoadingState state) -> std::string {
+  auto get_content_for = [this, module](SymbolLoadingState state) -> std::string {
     EXPECT_CALL(app_, GetSymbolLoadingStateForModule(module)).WillOnce(testing::Return(state));
-    return view_.GetValue(kIndex, kColumnSymbols);
+    return view_.GetValue(0, kColumnSymbols);
   };
 
   EXPECT_EQ(get_content_for(SymbolLoadingState::kUnknown), "");
@@ -311,12 +311,12 @@ TEST_F(ModulesDataViewTest, SymbolLoadingColumnContent) {
 }
 
 TEST_F(ModulesDataViewTest, SymbolLoadingColor) {
-  const int kIndex = 0;
+  constexpr int kIndex = 0;
   AddModulesByIndices({kIndex});
   const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
       modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
 
-  auto check_color_correct_for = [this, module, kIndex](SymbolLoadingState state) {
+  auto check_color_correct_for = [this, module](SymbolLoadingState state) {
     uint8_t red = 0;
     uint8_t green = 0;
     uint8_t blue = 0;
@@ -327,7 +327,7 @@ TEST_F(ModulesDataViewTest, SymbolLoadingColor) {
     uint8_t view_green = 0;
     uint8_t view_blue = 0;
     bool view_default_color =
-        !view_.GetDisplayColor(kIndex, kColumnSymbols, view_red, view_green, view_blue);
+        !view_.GetDisplayColor(0, kColumnSymbols, view_red, view_green, view_blue);
     EXPECT_EQ(default_color, view_default_color);
     EXPECT_EQ(red, view_red);
     EXPECT_EQ(green, view_green);

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -18,6 +18,7 @@
 #include "ClientData/ProcessData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "DataViews/PresetLoadState.h"
+#include "DataViews/SymbolLoadingState.h"
 #include "GrpcProtos/tracepoint.pb.h"
 #include "OrbitBase/Future.h"
 #include "PresetFile/PresetFile.h"
@@ -116,6 +117,11 @@ class AppInterface {
 
   [[nodiscard]] virtual const orbit_statistics::BinomialConfidenceIntervalEstimator&
   GetConfidenceIntervalEstimator() const = 0;
+
+  [[nodiscard]] virtual bool IsModuleDownloading(
+      const orbit_client_data::ModuleData* module) const = 0;
+  [[nodiscard]] virtual SymbolLoadingState GetSymbolLoadingStateForModule(
+      const orbit_client_data::ModuleData* module) const = 0;
 };
 
 }  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -6,7 +6,6 @@
 #define DATA_VIEWS_MODULES_DATA_VIEW_H_
 
 #include <absl/container/flat_hash_map.h>
-#include <absl/flags/flag.h>
 #include <stdint.h>
 
 #include <string>
@@ -14,7 +13,6 @@
 
 #include "ClientData/ModuleData.h"
 #include "ClientData/ProcessData.h"
-#include "ClientFlags/ClientFlags.h"
 #include "DataViews/AppInterface.h"
 #include "DataViews/DataView.h"
 

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -6,6 +6,7 @@
 #define DATA_VIEWS_MODULES_DATA_VIEW_H_
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/flags/flag.h>
 #include <stdint.h>
 
 #include <string>
@@ -13,6 +14,7 @@
 
 #include "ClientData/ModuleData.h"
 #include "ClientData/ProcessData.h"
+#include "ClientFlags/ClientFlags.h"
 #include "DataViews/AppInterface.h"
 #include "DataViews/DataView.h"
 
@@ -21,7 +23,8 @@ namespace orbit_data_views {
 class ModulesDataView : public DataView {
  public:
   explicit ModulesDataView(AppInterface* app,
-                           orbit_metrics_uploader::MetricsUploader* metrics_uploader);
+                           orbit_metrics_uploader::MetricsUploader* metrics_uploader,
+                           bool new_ui = absl::GetFlag(FLAGS_devmode));
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnFileSize; }
@@ -48,13 +51,18 @@ class ModulesDataView : public DataView {
   [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {
     return start_address_to_module_.at(indices_[row]);
   }
+  [[nodiscard]] std::string GetSymbolLoadingStateForModuleString(
+      const orbit_client_data::ModuleData* module);
+
+  // TODO(b/202140068) remove when auto symbol loading is released
+  bool new_ui_;
 
   absl::flat_hash_map<uint64_t, orbit_client_data::ModuleInMemory>
       start_address_to_module_in_memory_;
   absl::flat_hash_map<uint64_t, orbit_client_data::ModuleData*> start_address_to_module_;
 
   enum ColumnIndex {
-    kColumnLoaded,
+    kColumnSymbols,
     kColumnName,
     kColumnPath,
     kColumnAddressRange,

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -23,8 +23,7 @@ namespace orbit_data_views {
 class ModulesDataView : public DataView {
  public:
   explicit ModulesDataView(AppInterface* app,
-                           orbit_metrics_uploader::MetricsUploader* metrics_uploader,
-                           bool new_ui = absl::GetFlag(FLAGS_devmode));
+                           orbit_metrics_uploader::MetricsUploader* metrics_uploader, bool new_ui);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnFileSize; }

--- a/src/DataViews/include/DataViews/SymbolLoadingState.h
+++ b/src/DataViews/include/DataViews/SymbolLoadingState.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef DATA_VIEWS_SYMBOL_LOADING_STATE_H_
+#define DATA_VIEWS_SYMBOL_LOADING_STATE_H_
+
+#include <absl/base/attributes.h>
+
+#include <string>
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_data_views {
+
+struct SymbolLoadingState {
+  // TODO(b/202140068) remove unknown when not needed anymore
+  enum State { kUnknown, kDisabled, kDownloading, kError, kLoading, kLoaded } state;
+  SymbolLoadingState(State initial_state) : state(initial_state) {}
+
+  [[nodiscard]] std::string GetDescription() const {
+    switch (state) {
+      case kUnknown:
+        return "";
+      case kDisabled:
+        return "Disabled";
+      case kDownloading:
+        return "Downloading...";
+      case kError:
+        return "Error";
+      case kLoading:
+        return "Loading...";
+      case kLoaded:
+        return "Loaded";
+    }
+    ORBIT_UNREACHABLE();
+  }
+
+  // Returns false for the default color and true for any other color, in the latter case the
+  // parameters are changed.
+  bool GetDisplayColor(unsigned char& red, unsigned char& green, unsigned char& blue) const {
+    switch (state) {
+      case kUnknown:
+        ABSL_FALLTHROUGH_INTENDED;
+      case kLoaded:
+        return false;
+      case kDisabled: {
+        red = 153;
+        green = 153;
+        blue = 153;
+        break;
+      }
+      case kDownloading:
+        ABSL_FALLTHROUGH_INTENDED;
+      case kLoading: {
+        red = 55;
+        green = 138;
+        blue = 221;
+        break;
+      }
+      case kError: {
+        red = 230;
+        green = 70;
+        blue = 70;
+        break;
+      }
+    }
+    return true;
+  }
+};
+
+}  // namespace orbit_data_views
+
+#endif  // DATA_VIEWS_SYMBOL_LOADING_STATE_H_

--- a/src/DataViews/include/DataViews/SymbolLoadingState.h
+++ b/src/DataViews/include/DataViews/SymbolLoadingState.h
@@ -13,6 +13,8 @@
 
 namespace orbit_data_views {
 
+// Class to represent the current state of symbol loading for a certain module. Also provides a
+// textual description for each state via GetDescription and a color via GetDisplayColor
 struct SymbolLoadingState {
   // TODO(b/202140068) remove unknown when not needed anymore
   enum State { kUnknown, kDisabled, kDownloading, kError, kLoading, kLoaded } state;
@@ -41,7 +43,6 @@ struct SymbolLoadingState {
   bool GetDisplayColor(unsigned char& red, unsigned char& green, unsigned char& blue) const {
     switch (state) {
       case kUnknown:
-        ABSL_FALLTHROUGH_INTENDED;
       case kLoaded:
         return false;
       case kDisabled: {
@@ -51,7 +52,6 @@ struct SymbolLoadingState {
         break;
       }
       case kDownloading:
-        ABSL_FALLTHROUGH_INTENDED;
       case kLoading: {
         red = 55;
         green = 138;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2649,7 +2649,8 @@ orbit_data_views::DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kModules:
       if (!modules_data_view_) {
-        modules_data_view_ = DataView::CreateAndInit<ModulesDataView>(this, metrics_uploader_);
+        modules_data_view_ =
+            DataView::CreateAndInit<ModulesDataView>(this, metrics_uploader_, IsDevMode());
         panels_.push_back(modules_data_view_.get());
       }
       return modules_data_view_.get();

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -53,11 +53,13 @@
 #include "CodeReport/Disassembler.h"
 #include "CodeReport/DisassemblyReport.h"
 #include "CodeReport/SourceCodeReport.h"
+#include "DataViews/AppInterface.h"
 #include "DataViews/DataView.h"
 #include "DataViews/DataViewType.h"
 #include "DataViews/FunctionsDataView.h"
 #include "DataViews/ModulesDataView.h"
 #include "DataViews/PresetsDataView.h"
+#include "DataViews/SymbolLoadingState.h"
 #include "FrameTrackOnlineProcessor.h"
 #include "GlCanvas.h"
 #include "GrpcProtos/Constants.h"
@@ -131,6 +133,7 @@ using orbit_data_views::DataView;
 using orbit_data_views::FunctionsDataView;
 using orbit_data_views::ModulesDataView;
 using orbit_data_views::PresetsDataView;
+using orbit_data_views::SymbolLoadingState;
 using orbit_data_views::TracepointsDataView;
 
 using orbit_gl::MainWindowInterface;
@@ -3043,4 +3046,28 @@ OrbitApp::GetConfidenceIntervalEstimator() const {
 void OrbitApp::ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
                              uint64_t scope_id) {
   main_window_->ShowHistogram(data, scope_name, scope_id);
+}
+
+[[nodiscard]] bool OrbitApp::IsModuleDownloading(const ModuleData* module) const {
+  ORBIT_CHECK(module != nullptr);
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  return symbol_files_currently_downloading_.contains(module->file_path());
+}
+
+SymbolLoadingState OrbitApp::GetSymbolLoadingStateForModule(const ModuleData* module) const {
+  ORBIT_CHECK(module != nullptr);
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+
+  if (IsModuleDownloading(module)) return SymbolLoadingState::kDownloading;
+
+  if (symbols_currently_loading_.contains(
+          std::make_pair(module->file_path(), module->build_id()))) {
+    return SymbolLoadingState::kLoading;
+  }
+
+  if (module->is_loaded()) return SymbolLoadingState::kLoaded;
+
+  // TODO(b/202140068) add missing error and disabled case
+
+  return SymbolLoadingState::kUnknown;
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -57,6 +57,7 @@
 #include "DataViews/ModulesDataView.h"
 #include "DataViews/PresetLoadState.h"
 #include "DataViews/PresetsDataView.h"
+#include "DataViews/SymbolLoadingState.h"
 #include "DataViews/TracepointsDataView.h"
 #include "FramePointerValidatorClient.h"
 #include "FrameTrackOnlineProcessor.h"
@@ -530,6 +531,11 @@ class OrbitApp final : public DataViewFactory,
   GetHistogramSelectionRange() const {
     return histogram_selection_range_;
   }
+
+  [[nodiscard]] bool IsModuleDownloading(
+      const orbit_client_data::ModuleData* module) const override;
+  [[nodiscard]] orbit_data_views::SymbolLoadingState GetSymbolLoadingStateForModule(
+      const orbit_client_data::ModuleData* module) const override;
 
  private:
   void UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(


### PR DESCRIPTION
4 Commits to enable symbol loading status in the module list. Split up into 4 for ease of review. 

(hidden behind --devmode)

the struct `SymbolLoadingState` follows what `PresetLoadState` is doing, but relies on `enum` (without class) and implicit conversion. If someone has an idea how to make this better, I am all ear.