### PR TITLE
Fixes to horizontal zoom & tests

### DIFF
--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -30,7 +30,7 @@ constexpr int kViewportWidth = 600;
 constexpr int kViewportHeight = 100;
 
 constexpr double kSliderPosEpsilon = 0.0001;
-constexpr double kTimeEpsilonUs = 0.0001;
+constexpr double kTimeEpsilonUs = 0.0000001;
 
 class NavigationTestCaptureWindow : public CaptureWindow, public testing::Test {
  public:
@@ -63,8 +63,8 @@ class NavigationTestCaptureWindow : public CaptureWindow, public testing::Test {
     EXPECT_DOUBLE_EQ(time_graph_->GetHorizontalSlider()->GetPosRatio(), 0.0);
 
     if (allow_small_imprecision) {
-      EXPECT_NEAR(time_graph_->GetMaxTimeUs() * 1000, time_graph_->GetCaptureMax(), kTimeEpsilonUs);
-      EXPECT_NEAR(time_graph_->GetMinTimeUs() * 1000, 0, kTimeEpsilonUs);
+      EXPECT_NEAR(time_graph_->GetMaxTimeUs(), time_graph_->GetCaptureMax() / 1000, kTimeEpsilonUs);
+      EXPECT_NEAR(time_graph_->GetMinTimeUs(), 0, kTimeEpsilonUs);
     } else {
       EXPECT_DOUBLE_EQ(time_graph_->GetMaxTimeUs() * 1000, time_graph_->GetCaptureMax());
       EXPECT_DOUBLE_EQ(time_graph_->GetMinTimeUs() * 1000, 0);
@@ -152,8 +152,8 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtRandomPositions) {
 
   constexpr int kNumTries = 100;
   for (int i = 0; i < kNumTries; ++i) {
-    int x = dist(mt);
-    int y = kTimelineSize[1] - kBottomSafetyMargin;
+    const int x = dist(mt);
+    const int y = kTimelineSize[1] - kBottomSafetyMargin;
 
     // Zoom in twice, then zoom out twice. Check that the intermediate states match
     MouseWheelMoved(x, y, 1, false);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -194,8 +194,6 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_world_y_pos) {
 // TODO(b/214280802): include SetMinMax in the TimelineInfoInterface, so the scrollbar could call
 // it.
 void TimeGraph::SetMinMax(double min_time_us, double max_time_us) {
-  constexpr double kTimeGraphMinTimeWindowsUs = 0.1; /* 100 ns */
-
   // Center the interval on screen if needed
   if (max_time_us - min_time_us < kTimeGraphMinTimeWindowsUs || min_time_us < 0. ||
       max_time_us > GetCaptureTimeSpanUs()) {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -158,6 +158,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   void SetIsMouseOver(bool value);
 
  protected:
+  static constexpr double kTimeGraphMinTimeWindowsUs = 0.1; /* 100 ns */
+
   void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
               orbit_gl::TextRenderer& text_renderer, const DrawContext& draw_context) override;
   void PrepareBatcherAndUpdatePrimitives(PickingMode picking_mode);


### PR DESCRIPTION
Fixes the issue that zooming when already at maximum zoom level
started to move the time window.

To reproduce: Zoom in until at max zoom level. Trying to zoom further
will start moving the time window slightly to the left or right, depending
on the position of the mouse.

Also fixes some smaller inconsistencies in the tests.