### PR TITLE
Make UpdateProcessAndModuleList return a future

### DIFF
--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -67,7 +67,7 @@ class MockAppInterface : public AppInterface {
 
   MOCK_METHOD(void, OnValidateFramePointers, (std::vector<const orbit_client_data::ModuleData*>),
               (override));
-  MOCK_METHOD(void, UpdateProcessAndModuleList, (), (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<void>>, UpdateProcessAndModuleList, (), (override));
 
   // This needs to be called from the main thread.
   MOCK_METHOD(bool, IsCaptureConnected, (const orbit_client_data::CaptureData&), (const, override));

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <tuple>
 
 #include "ClientData/ModuleData.h"
 #include "ClientData/ProcessData.h"
@@ -275,7 +276,7 @@ void ModulesDataView::OnRefreshButtonClicked() {
     ORBIT_LOG("Unable to refresh module list, no process selected");
     return;
   }
-  app_->UpdateProcessAndModuleList();
+  std::ignore = app_->UpdateProcessAndModuleList();
 }
 
 bool ModulesDataView::GetDisplayColor(int row, int /*column*/, unsigned char& red,

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -79,7 +79,7 @@ class AppInterface {
   // Functions needed by ModulesDataView
   virtual void OnValidateFramePointers(
       std::vector<const orbit_client_data::ModuleData*> modules_to_validate) = 0;
-  virtual void UpdateProcessAndModuleList() = 0;
+  virtual orbit_base::Future<ErrorMessageOr<void>> UpdateProcessAndModuleList() = 0;
 
   // Functions needed by TracepointsDataView
   virtual void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info) = 0;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -372,7 +372,7 @@ class OrbitApp final : public DataViewFactory,
   orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleWithDebugInfo(
       const std::string& module_path, const std::string& build_id);
 
-  void UpdateProcessAndModuleList() override;
+  orbit_base::Future<ErrorMessageOr<void>> UpdateProcessAndModuleList() override;
   orbit_base::Future<std::vector<ErrorMessageOr<void>>> ReloadModules(
       absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
   void RefreshUIAfterModuleReload();


### PR DESCRIPTION
This is so that we can schedule operations only after the initial
retrieval of process and module information, which will be needed for
the upcoming Windows process launching feature.