### PR TITLE
Do not discard kernel samples with frame pointers

### DIFF
--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -96,9 +96,6 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu,
   // TODO(kuebler): Read this from /proc/sys/kernel/perf_event_max_stack
   pe.sample_max_stack = 127;
   pe.exclude_callchain_kernel = true;
-  // Exclude all samples that fall into the kernel. In particular this will discard samples falling
-  // into the int3 triggered uprobe code, which we could otherwise not really detect.
-  pe.exclude_kernel = true;
 
   // Also capture a small part of the stack and the registers to allow patching the callers of
   // leaf functions. This is done by unwinding the first two frame using DWARF.


### PR DESCRIPTION
We used to discard samples in kernel code (triggered by user code),
as this was also going to discard samples falling into the 'int3'
of a uprobe.

However, later we added detection of the uprobe module. And now
we are missing samples which changes the distribution of samples.

In this change, we re-enable samples on kernel code. In most cases
we will receive completely valid samples. For the uprobes case,
we are still able to mark them as unwinding error, which also
has the benefit of exposing them to the user.

Test: Carefully inspected samples on "uprobes_target"
Bug: http://b/231672823