### PR TITLE
Fix bottom-up E2E test

### DIFF
--- a/contrib/automation_tests/orbit_bottom_up.py
+++ b/contrib/automation_tests/orbit_bottom_up.py
@@ -34,7 +34,8 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        LoadSymbols(module_search_string="libc-2.24"),
+        LoadSymbols(module_search_string='libc-2.24'),
+        LoadSymbols(module_search_string='libdrm.so.2'),
         Capture(frame_pointer_unwinding=False),
         VerifyHelloGgpBottomUpContents(),
         Capture(frame_pointer_unwinding=True, sampling_period_ms=0.1),

--- a/contrib/automation_tests/test_cases/bottom_up_tab.py
+++ b/contrib/automation_tests/test_cases/bottom_up_tab.py
@@ -30,7 +30,7 @@ class VerifyHelloGgpBottomUpContents(E2ETestCase):
             raise RuntimeError('Less than 10 rows in the bottom-up view')
 
         first_row_tree_item = tree_view_table.get_item_at(0, 0)
-        if first_row_tree_item.window_text() != 'ioctl':
+        if not first_row_tree_item.window_text().endswith('ioctl'):
             raise RuntimeError('First item of the bottom-up view is not "ioctl"')
         logging.info('Verified that first item is "ioctl"')
 


### PR DESCRIPTION
To support frame pointer unwinding in the bottom up test, we
load the symbols of libc. This yields to the fact that "ioctl"
is actually called "__ioctl". The test failed here.

Also, the test was missing to load the symbols of libdrm.so.

Test: Run E2E test locally.
Bug: http://b/231672823

Note, this does not fix the flakyness by frame pointer sampling
discarding kernel samples. This gets fixed by #3681.