### PR TITLE
Change the target label to no longer be a corner widget

### DIFF
--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -128,6 +128,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
  protected:
   void closeEvent(QCloseEvent* event) override;
+  void resizeEvent(QResizeEvent* event) override;
 
  public slots:
   void OnFilterFunctionsTextChanged(const QString& text);
@@ -198,6 +199,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void SetTarget(const orbit_session_setup::LocalTarget& target);
   void SetTarget(const orbit_session_setup::FileTarget& target);
 
+  void UpdateTargetLabelPosition();
+
   void OnProcessListUpdated(const std::vector<orbit_grpc_protos::ProcessInfo>& processes);
 
   void ExecuteSymbolLocationsDialog(std::optional<const orbit_client_data::ModuleData*> module);
@@ -242,6 +245,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   std::unique_ptr<OrbitGLWidget> introspection_widget_ = nullptr;
   QFrame* hint_frame_ = nullptr;
   orbit_session_setup::TargetLabel* target_label_ = nullptr;
+  QWidget* target_widget_ = nullptr;
   QPushButton* capture_log_button_ = nullptr;
 
   QStringList command_line_flags_;

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -107,6 +107,7 @@ void TargetLabel::ChangeToFileTarget(const fs::path& path) {
   Clear();
   SetFile(path);
   ui_->targetLabel->setVisible(false);
+  setAccessibleName("File target");
   emit SizeChanged();
 }
 
@@ -128,6 +129,7 @@ void TargetLabel::ChangeToStadiaTarget(const QString& process_name, double cpu_u
   SetProcessCpuUsageInPercent(cpu_usage);
   ui_->targetLabel->setVisible(true);
   ui_->fileLabel->setVisible(false);
+  setAccessibleName("Stadia target");
 }
 
 void TargetLabel::ChangeToLocalTarget(const LocalTarget& local_target) {
@@ -145,6 +147,7 @@ void TargetLabel::ChangeToLocalTarget(const QString& process_name, double cpu_us
   SetProcessCpuUsageInPercent(cpu_usage);
   ui_->targetLabel->setVisible(true);
   ui_->fileLabel->setVisible(false);
+  setAccessibleName("Local target");
 }
 
 bool TargetLabel::SetProcessCpuUsageInPercent(double cpu_usage) {


### PR DESCRIPTION
This was causing issues with accessibility and E2E tests as the corner
widget did not show up in the accessibility tree. With this, the E2E
tests can now verify the connection to the Stadia instance by checking
the target label.

This also fixes the weird "flickering" of the menu bar that occured
during update of the CPU %.

Bug: b/230690933
Tests: Manual testing, and verified the accessibility tree using
Accessibility Insights.