### PR TITLE
Fix crash on Add Iterator click when MS or MA selected

### DIFF
--- a/src/DataViews/CMakeLists.txt
+++ b/src/DataViews/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(DataViews PRIVATE
         ModulesDataView.cpp
         PresetsDataView.cpp
         SamplingReportDataView.cpp
+        ScopeDataView.cpp
         TracepointsDataView.cpp)
 
 target_sources(DataViews PUBLIC

--- a/src/DataViews/CMakeLists.txt
+++ b/src/DataViews/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(DataViews PUBLIC
         include/DataViews/PresetLoadState.h
         include/DataViews/SamplingReportDataView.h        
         include/DataViews/SamplingReportInterface.h
+        include/DataViews/ScopeDataView.h
         include/DataViews/SymbolLoadingState.h
         include/DataViews/TracepointsDataView.h)
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -245,8 +245,10 @@ void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
   metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_FRAME_TRACK_ENABLE_CLICKED);
 
   for (int i : selection) {
+    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeId(i))) continue;
+
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
-    if (function == nullptr) continue;
+    ORBIT_CHECK(function != nullptr);
     // Functions used as frame tracks must be hooked (selected), otherwise the
     // data to produce the frame track will not be captured.
     // The condition is supposed to prevent "selecting" a function when a capture
@@ -264,8 +266,10 @@ void DataView::OnDisableFrameTrackRequested(const std::vector<int>& selection) {
   metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_FRAME_TRACK_DISABLE_CLICKED);
 
   for (int i : selection) {
+    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeId(i))) continue;
+
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
-    if (function == nullptr) continue;
+    ORBIT_CHECK(function != nullptr);
 
     // When we remove a frame track, we do not unhook (deselect) the function as
     // it may have been selected manually (not as part of adding a frame track).
@@ -363,6 +367,16 @@ void DataView::OnCopySelectionRequested(const std::vector<int>& selection) {
   }
 
   app_->SetClipboard(clipboard);
+}
+
+uint64_t DataView::GetScopeId(uint32_t row) const {
+  ORBIT_CHECK(row < indices_.size());
+  return indices_[row];
+}
+
+[[nodiscard]] bool DataView::IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) const {
+  return app_->GetCaptureData().GetScopeInfo(scope_id).GetType() ==
+         orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction;
 }
 
 }  // namespace orbit_data_views

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <optional>
 
 #include "ClientData/FunctionInfo.h"
 #include "MetricsUploader/orbit_log_event.pb.h"
@@ -245,7 +246,9 @@ void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
   metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_FRAME_TRACK_ENABLE_CLICKED);
 
   for (int i : selection) {
-    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeId(i))) continue;
+    std::optional<uint64_t> scope_id = GetScopeIdFromRow(i);
+    ORBIT_CHECK(scope_id.has_value());
+    if (!IsScopeDynamicallyInstrumentedFunction(*scope_id)) continue;
 
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     ORBIT_CHECK(function != nullptr);
@@ -266,7 +269,9 @@ void DataView::OnDisableFrameTrackRequested(const std::vector<int>& selection) {
   metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_FRAME_TRACK_DISABLE_CLICKED);
 
   for (int i : selection) {
-    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeId(i))) continue;
+    std::optional<uint64_t> scope_id = GetScopeIdFromRow(i);
+    ORBIT_CHECK(scope_id.has_value());
+    if (!IsScopeDynamicallyInstrumentedFunction(*scope_id)) continue;
 
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     ORBIT_CHECK(function != nullptr);
@@ -367,11 +372,6 @@ void DataView::OnCopySelectionRequested(const std::vector<int>& selection) {
   }
 
   app_->SetClipboard(clipboard);
-}
-
-uint64_t DataView::GetScopeId(uint32_t row) const {
-  ORBIT_CHECK(row < indices_.size());
-  return indices_[row];
 }
 
 [[nodiscard]] bool DataView::IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) const {

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -33,7 +33,7 @@ namespace orbit_data_views {
 
 FunctionsDataView::FunctionsDataView(AppInterface* app,
                                      orbit_metrics_uploader::MetricsUploader* metrics_uploader)
-    : DataView(DataViewType::kFunctions, app, metrics_uploader) {}
+    : ScopeDataView(DataViewType::kFunctions, app, metrics_uploader) {}
 
 const std::string FunctionsDataView::kUnselectedFunctionString = "";
 const std::string FunctionsDataView::kSelectedFunctionString = "H";

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -549,7 +549,11 @@ TEST_F(FunctionsDataViewTest, ContextMenuActionsCallCorrespondingFunctionsInAppI
       .Times(testing::AnyNumber())
       .WillRepeatedly(testing::Return(false));
 
-  CaptureData capture_data{{}, std::nullopt, {}, CaptureData::DataSource::kLiveCapture};
+  orbit_grpc_protos::CaptureStarted capture_started;
+  capture_started.mutable_capture_options()->add_instrumented_functions()->set_function_id(0);
+
+  CaptureData capture_data{
+      capture_started, std::nullopt, {}, CaptureData::DataSource::kLiveCapture};
   EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnPointee(&capture_data));
   EXPECT_CALL(app_, IsCaptureConnected).WillRepeatedly(testing::Return(true));
   EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -359,7 +359,9 @@ DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
 
 void LiveFunctionsDataView::OnIteratorRequested(const std::vector<int>& selection) {
   for (int i : selection) {
-    uint64_t scope_id = GetScopeId(i);
+    const uint64_t scope_id = GetScopeId(i);
+    if (!IsScopeDynamicallyInstrumentedFunction(scope_id)) continue;
+
     const FunctionInfo* instrumented_function = GetFunctionInfoFromRow(i);
     ORBIT_CHECK(instrumented_function != nullptr);
     const ScopeStats& stats = app_->GetCaptureData().GetScopeStatsOrDefault(scope_id);
@@ -536,11 +538,6 @@ void LiveFunctionsDataView::OnRefresh(const std::vector<int>& visible_selected_i
   if (mode != RefreshMode::kOnSort) {
     UpdateHistogramWithIndices(visible_selected_indices);
   }
-}
-
-uint64_t LiveFunctionsDataView::GetScopeId(uint32_t row) const {
-  ORBIT_CHECK(row < indices_.size());
-  return indices_[row];
 }
 
 const FunctionInfo* LiveFunctionsDataView::GetFunctionInfoFromRow(int row) {

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -238,7 +238,9 @@ void LiveFunctionsDataView::DoSort() {
     }
     case kColumnName:
       sorter = MakeSorter(
-          [this](uint64_t id) { return absl::AsciiStrToLower(GetScopeInfoFromScopeId(id).GetName()); },
+          [this](uint64_t id) {
+            return absl::AsciiStrToLower(GetScopeInfoFromScopeId(id).GetName());
+          },
           ascending);
       break;
     case kColumnCount:
@@ -565,7 +567,8 @@ std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrum
   }
 
   const std::string& function_name =
-      GetScopeInfoFromScopeId(app_->GetCaptureData().FunctionIdToScopeId(instrumented_function.function_id()))
+      GetScopeInfoFromScopeId(
+          app_->GetCaptureData().FunctionIdToScopeId(instrumented_function.function_id()))
           .GetName();
 
   // size is unknown

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -576,12 +576,6 @@ std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrum
   return result;
 }
 
-[[nodiscard]] const orbit_client_data::ScopeInfo& LiveFunctionsDataView::GetScopeInfo(
-    uint64_t scope_id) const {
-  ORBIT_CHECK(app_ != nullptr && app_->HasCaptureData());
-  return app_->GetCaptureData().GetScopeInfo(scope_id);
-}
-
 std::string LiveFunctionsDataView::GetToolTip(int /*row*/, int column) {
   if (column != kColumnType) return "";
   return "Notation:\n"

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -38,6 +38,7 @@
 #include "DataViews/DataView.h"
 #include "DataViews/DataViewType.h"
 #include "DataViews/FunctionsDataView.h"
+#include "DataViews/ScopeDataView.h"
 #include "DisplayFormats/DisplayFormats.h"
 #include "GrpcProtos/Constants.h"
 #include "Introspection/Introspection.h"
@@ -63,7 +64,7 @@ namespace orbit_data_views {
 LiveFunctionsDataView::LiveFunctionsDataView(
     LiveFunctionsInterface* live_functions, AppInterface* app,
     orbit_metrics_uploader::MetricsUploader* metrics_uploader)
-    : DataView(DataViewType::kLiveFunctions, app, metrics_uploader),
+    : ScopeDataView(DataViewType::kLiveFunctions, app, metrics_uploader),
       live_functions_(live_functions),
       selected_scope_id_(orbit_grpc_protos::kInvalidFunctionId) {
   update_period_ms_ = 300;

--- a/src/DataViews/ScopeDataView.cpp
+++ b/src/DataViews/ScopeDataView.cpp
@@ -8,7 +8,7 @@
 
 namespace orbit_data_views {
 
-uint64_t ScopeDataView::GetScopeId(uint32_t row) const {
+uint64_t ScopeDataView::GetScopeIdFromRow(uint32_t row) const {
   ORBIT_CHECK(row < indices_.size());
   return indices_[row];
 }
@@ -18,7 +18,7 @@ void ScopeDataView::OnEnableFrameTrackRequested(const std::vector<int>& selectio
       orbit_metrics_uploader::OrbitLogEvent::ORBIT_FRAME_TRACK_ENABLE_CLICKED);
 
   for (int i : selection) {
-    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeId(i))) continue;
+    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeIdFromRow(i))) continue;
 
     const orbit_client_data::FunctionInfo* function = GetFunctionInfoFromRow(i);
     ORBIT_CHECK(function != nullptr);
@@ -40,7 +40,7 @@ void ScopeDataView::OnDisableFrameTrackRequested(const std::vector<int>& selecti
       orbit_metrics_uploader::OrbitLogEvent::ORBIT_FRAME_TRACK_DISABLE_CLICKED);
 
   for (int i : selection) {
-    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeId(i))) continue;
+    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeIdFromRow(i))) continue;
 
     const orbit_client_data::FunctionInfo* function = GetFunctionInfoFromRow(i);
     ORBIT_CHECK(function != nullptr);
@@ -54,11 +54,11 @@ void ScopeDataView::OnDisableFrameTrackRequested(const std::vector<int>& selecti
 }
 
 bool ScopeDataView::IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) const {
-  return GetScopeInfo(scope_id).GetType() ==
+  return GetScopeInfoFromScopeId(scope_id).GetType() ==
          orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction;
 }
 
-const orbit_client_data::ScopeInfo& ScopeDataView::GetScopeInfo(uint64_t scope_id) const {
+const orbit_client_data::ScopeInfo& ScopeDataView::GetScopeInfoFromScopeId(uint64_t scope_id) const {
   ORBIT_CHECK(app_ != nullptr && app_->HasCaptureData());
   return app_->GetCaptureData().GetScopeInfo(scope_id);
 }

--- a/src/DataViews/ScopeDataView.cpp
+++ b/src/DataViews/ScopeDataView.cpp
@@ -58,7 +58,8 @@ bool ScopeDataView::IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) co
          orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction;
 }
 
-const orbit_client_data::ScopeInfo& ScopeDataView::GetScopeInfoFromScopeId(uint64_t scope_id) const {
+const orbit_client_data::ScopeInfo& ScopeDataView::GetScopeInfoFromScopeId(
+    uint64_t scope_id) const {
   ORBIT_CHECK(app_ != nullptr && app_->HasCaptureData());
   return app_->GetCaptureData().GetScopeInfo(scope_id);
 }

--- a/src/DataViews/ScopeDataView.cpp
+++ b/src/DataViews/ScopeDataView.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "DataViews/ScopeDataView.h"
+
+#include <vector>
+
+namespace orbit_data_views {
+
+uint64_t ScopeDataView::GetScopeId(uint32_t row) const {
+  ORBIT_CHECK(row < indices_.size());
+  return indices_[row];
+}
+
+void ScopeDataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent::ORBIT_FRAME_TRACK_ENABLE_CLICKED);
+
+  for (int i : selection) {
+    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeId(i))) continue;
+
+    const orbit_client_data::FunctionInfo* function = GetFunctionInfoFromRow(i);
+    ORBIT_CHECK(function != nullptr);
+    // Functions used as frame tracks must be hooked (selected), otherwise the
+    // data to produce the frame track will not be captured.
+    // The condition is supposed to prevent "selecting" a function when a capture
+    // is loaded with no connection to a process being established.
+    if (GetActionStatus(kMenuActionSelect, i, {i}) == ActionStatus::kVisibleAndEnabled) {
+      app_->SelectFunction(*function);
+    }
+
+    app_->EnableFrameTrack(*function);
+    app_->AddFrameTrack(*function);
+  }
+}
+
+void ScopeDataView::OnDisableFrameTrackRequested(const std::vector<int>& selection) {
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent::ORBIT_FRAME_TRACK_DISABLE_CLICKED);
+
+  for (int i : selection) {
+    if (!IsScopeDynamicallyInstrumentedFunction(GetScopeId(i))) continue;
+
+    const orbit_client_data::FunctionInfo* function = GetFunctionInfoFromRow(i);
+    ORBIT_CHECK(function != nullptr);
+
+    // When we remove a frame track, we do not unhook (deselect) the function as
+    // it may have been selected manually (not as part of adding a frame track).
+    // However, disable the frame track, so it is not recreated on the next capture.
+    app_->DisableFrameTrack(*function);
+    app_->RemoveFrameTrack(*function);
+  }
+}
+
+bool ScopeDataView::IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) const {
+  return GetScopeInfo(scope_id).GetType() ==
+         orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction;
+}
+
+const orbit_client_data::ScopeInfo& ScopeDataView::GetScopeInfo(uint64_t scope_id) const {
+  ORBIT_CHECK(app_ != nullptr && app_->HasCaptureData());
+  return app_->GetCaptureData().GetScopeInfo(scope_id);
+}
+
+}  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -189,6 +189,7 @@ class DataView {
   void OnCopySelectionRequested(const std::vector<int>& selection);
   void OnExportToCsvRequested();
   virtual void OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) {}
+  [[nodiscard]] virtual uint64_t GetScopeId(uint32_t row) const;
 
  protected:
   [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleDataFromRow(
@@ -212,6 +213,8 @@ class DataView {
   enum class ActionStatus { kInvisible, kVisibleButDisabled, kVisibleAndEnabled };
   [[nodiscard]] virtual ActionStatus GetActionStatus(std::string_view action, int clicked_index,
                                                      const std::vector<int>& selected_indices);
+
+  [[nodiscard]] bool IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) const;
 
   void InitSortingOrders();
   virtual void DoSort() {}

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -218,7 +218,7 @@ class DataView {
   virtual void DoFilter() {}
   FilterCallback filter_callback_;
 
-  // Contains a list of scope_id in the displayed order
+  // TODO(b/232085051) The field is used inconsistently in the subclasses
   std::vector<uint64_t> indices_;
   std::vector<SortingOrder> sorting_orders_;
   int sorting_column_ = 0;

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -175,8 +175,8 @@ class DataView {
   void OnStopDownloadRequested(const std::vector<int>& selection);
   virtual void OnSelectRequested(const std::vector<int>& selection);
   virtual void OnUnselectRequested(const std::vector<int>& selection);
-  void OnEnableFrameTrackRequested(const std::vector<int>& selection);
-  void OnDisableFrameTrackRequested(const std::vector<int>& selection);
+  virtual void OnEnableFrameTrackRequested(const std::vector<int>& /*selection*/) {}
+  virtual void OnDisableFrameTrackRequested(const std::vector<int>& /*selection*/) {}
   virtual void OnIteratorRequested(const std::vector<int>& /*selection*/) {}
   void OnVerifyFramePointersRequested(const std::vector<int>& selection);
   void OnDisassemblyRequested(const std::vector<int>& selection);
@@ -191,10 +191,6 @@ class DataView {
   virtual void OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) {}
 
  protected:
-  [[nodiscard]] virtual std::optional<uint64_t> GetScopeIdFromRow(uint32_t /*row*/) const {
-    return std::nullopt;
-  }
-
   [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleDataFromRow(
       int /*row*/) const {
     return nullptr;
@@ -216,8 +212,6 @@ class DataView {
   enum class ActionStatus { kInvisible, kVisibleButDisabled, kVisibleAndEnabled };
   [[nodiscard]] virtual ActionStatus GetActionStatus(std::string_view action, int clicked_index,
                                                      const std::vector<int>& selected_indices);
-
-  [[nodiscard]] bool IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) const;
 
   void InitSortingOrders();
   virtual void DoSort() {}

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -189,9 +189,12 @@ class DataView {
   void OnCopySelectionRequested(const std::vector<int>& selection);
   void OnExportToCsvRequested();
   virtual void OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) {}
-  [[nodiscard]] virtual uint64_t GetScopeId(uint32_t row) const;
 
  protected:
+  [[nodiscard]] virtual std::optional<uint64_t> GetScopeIdFromRow(uint32_t /*row*/) const {
+    return std::nullopt;
+  }
+
   [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleDataFromRow(
       int /*row*/) const {
     return nullptr;

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -10,10 +10,10 @@
 
 #include "ClientData/FunctionInfo.h"
 #include "DataViews/AppInterface.h"
-#include "DataViews/DataView.h"
+#include "DataViews/ScopeDataView.h"
 
 namespace orbit_data_views {
-class FunctionsDataView : public DataView {
+class FunctionsDataView : public ScopeDataView {
  public:
   explicit FunctionsDataView(AppInterface* app,
                              orbit_metrics_uploader::MetricsUploader* metrics_uploader);

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -62,7 +62,6 @@ class LiveFunctionsDataView : public DataView {
                                              const std::vector<int>& selected_indices) override;
   void DoFilter() override;
   void DoSort() override;
-  [[nodiscard]] uint64_t GetScopeId(uint32_t row) const;
   [[nodiscard]] std::optional<orbit_client_data::FunctionInfo>
   CreateFunctionInfoFromInstrumentedFunction(
       const orbit_grpc_protos::InstrumentedFunction& instrumented_function);

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -17,14 +17,14 @@
 #include "ClientData/FunctionInfo.h"
 #include "DataViews/AppInterface.h"
 #include "DataViews/CompareAscendingOrDescending.h"
-#include "DataViews/DataView.h"
 #include "DataViews/LiveFunctionsInterface.h"
+#include "DataViews/ScopeDataView.h"
 #include "GrpcProtos/capture.pb.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_data_views {
 
-class LiveFunctionsDataView : public DataView {
+class LiveFunctionsDataView : public ScopeDataView {
  public:
   explicit LiveFunctionsDataView(LiveFunctionsInterface* live_functions, AppInterface* app,
                                  orbit_metrics_uploader::MetricsUploader* metrics_uploader);

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -117,8 +117,6 @@ class LiveFunctionsDataView : public ScopeDataView {
         },
         ascending);
   }
-
-  [[nodiscard]] const orbit_client_data::ScopeInfo& GetScopeInfo(uint64_t scope_id) const;
 };
 
 }  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/ScopeDataView.h
+++ b/src/DataViews/include/DataViews/ScopeDataView.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef DATA_VIEWS_SCOPE_DATA_VIEW_H_
+#define DATA_VIEWS_SCOPE_DATA_VIEW_H_
+
+#include <cstdint>
+
+#include "DataViews/DataView.h"
+
+namespace orbit_data_views {
+
+class ScopeDataView : public DataView {
+ public:
+  ScopeDataView(DataViewType type, AppInterface* app,
+                orbit_metrics_uploader::MetricsUploader* metrics_uploader)
+      : DataView(type, app, metrics_uploader) {}
+
+ protected:
+  [[nodiscard]] std::optional<uint64_t> GetScopeIdFromRow(uint32_t row) const override {
+    return GetScopeId(row);
+  }
+
+  [[nodiscard]] uint64_t GetScopeId(uint32_t row) const {
+    ORBIT_CHECK(row < indices_.size());
+    return indices_[row];
+  }
+};
+
+}  // namespace orbit_data_views
+
+#endif  // DATA_VIEWS_SCOPE_DATA_VIEW_H_

--- a/src/DataViews/include/DataViews/ScopeDataView.h
+++ b/src/DataViews/include/DataViews/ScopeDataView.h
@@ -11,21 +11,23 @@
 
 namespace orbit_data_views {
 
+// The abstract class for all the DataView to that deal with scopes to inherit from.
 class ScopeDataView : public DataView {
  public:
   ScopeDataView(DataViewType type, AppInterface* app,
                 orbit_metrics_uploader::MetricsUploader* metrics_uploader)
       : DataView(type, app, metrics_uploader) {}
 
- protected:
-  [[nodiscard]] std::optional<uint64_t> GetScopeIdFromRow(uint32_t row) const override {
-    return GetScopeId(row);
-  }
+  void OnEnableFrameTrackRequested(const std::vector<int>& selection) override;
 
-  [[nodiscard]] uint64_t GetScopeId(uint32_t row) const {
-    ORBIT_CHECK(row < indices_.size());
-    return indices_[row];
-  }
+  void OnDisableFrameTrackRequested(const std::vector<int>& selection) override;
+
+ protected:
+  [[nodiscard]] uint64_t GetScopeId(uint32_t row) const;
+
+  [[nodiscard]] bool IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) const;
+
+  [[nodiscard]] const orbit_client_data::ScopeInfo& GetScopeInfo(uint64_t scope_id) const;
 };
 
 }  // namespace orbit_data_views

--- a/src/DataViews/include/DataViews/ScopeDataView.h
+++ b/src/DataViews/include/DataViews/ScopeDataView.h
@@ -23,11 +23,12 @@ class ScopeDataView : public DataView {
   void OnDisableFrameTrackRequested(const std::vector<int>& selection) override;
 
  protected:
-  [[nodiscard]] uint64_t GetScopeId(uint32_t row) const;
+  [[nodiscard]] uint64_t GetScopeIdFromRow(uint32_t row) const;
 
   [[nodiscard]] bool IsScopeDynamicallyInstrumentedFunction(uint64_t scope_id) const;
 
-  [[nodiscard]] const orbit_client_data::ScopeInfo& GetScopeInfo(uint64_t scope_id) const;
+  [[nodiscard]] const orbit_client_data::ScopeInfo& GetScopeInfoFromScopeId(
+      uint64_t scope_id) const;
 };
 
 }  // namespace orbit_data_views


### PR DESCRIPTION
When a user selected a number of dynamically instrumented
functions and a number of manually instrumented scopes,
the "Add Iterator" action is active. A click on was crashing
the client.

The fix consists in a check for the scope_id corresponding
to dynamic instrumentation. The same thing is now done for
"Add Frametrack" aciton. These checks are followed by
ORBIT_CHECK that ensures an InstrumentedFunction instance
is found.

Also, `GetScopeId(row)` is moved to DataView.

Tests: Manual, Unit
Bug: http://b/232058826