### PR TITLE
Update the callstack index when changing the functions

### DIFF
--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -131,6 +131,7 @@ void SamplingReport::OnSelectAddresses(const absl::flat_hash_set<uint64_t>& addr
     if (selected_addresses_ != addresses || selected_thread_id_ != thread_id) {
       selected_addresses_ = addresses;
       selected_thread_id_ = thread_id;
+      selected_callstack_index_ = 0;
       UpdateDisplayedCallstack();
     }
   }


### PR DESCRIPTION
When changing the selected functions (i.e. also the callstacks),
we do not update the selected callstack index.
When the old selected index is now larger than the new number
of unique callstacks, we do not update the callstack at all.

With this change, we are resetting the selected callstack
whenever we select a "new" set of functions (if there is no
change, we do nothing).

Test: Take a capture and play with callstack selections.
Bug: http://b/232059032