### PR TITLE
Add callstack to tooltips on unwinding error

### DIFF
--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -260,13 +260,23 @@ std::string CallstackThreadBar::FormatCallstackForTooltip(const CallstackInfo& c
   const int top_n = std::min(max_lines, size) - bottom_n;
 
   for (int i = 0; i < top_n; ++i) {
-    result.append("<br/>" + SafeGetFormattedFunctionName(callstack, i, max_line_length));
+    if (callstack.IsUnwindingError() && i > 0) {
+      result.append("<br/><span style=\" color:#ffb000;\">" +
+                    SafeGetFormattedFunctionName(callstack, i, max_line_length) + "</span>");
+    } else {
+      result.append("<br/>" + SafeGetFormattedFunctionName(callstack, i, max_line_length));
+    }
   }
   if (max_lines < size) {
     result += "<br/><i>... shortened for readability ...</i>";
   }
   for (int i = size - bottom_n; i < size; ++i) {
-    result.append("<br/>" + SafeGetFormattedFunctionName(callstack, i, max_line_length));
+    if (callstack.IsUnwindingError() && i > 0) {
+      result.append("<br/><span style=\" color:#ffb000;\">" +
+                    SafeGetFormattedFunctionName(callstack, i, max_line_length) + "</span>");
+    } else {
+      result.append("<br/>" + SafeGetFormattedFunctionName(callstack, i, max_line_length));
+    }
   }
 
   return result;
@@ -294,9 +304,10 @@ std::string CallstackThreadBar::GetSampleTooltip(const PrimitiveAssembler& primi
   std::string function_name = SafeGetFormattedFunctionName(*callstack, 0, -1);
   std::string result =
       absl::StrFormat("<b>%s</b><br/><i>Stack sample</i><br/><br/>", function_name.c_str());
-  if (callstack->type() != CallstackType::kComplete) {
+  if (callstack->IsUnwindingError()) {
     result += absl::StrFormat(
-        "<b>Unwinding error:</b> the stack could not be unwound successfully.<br/>%s",
+        "<span style=\" color:#ffb000;\"><b>Unwinding error:</b> the stack could not be unwound "
+        "successfully.<br/>%s</span>",
         orbit_client_data::CallstackTypeToDescription(callstack->type()));
   }
   result += "<br/><br/><b>Callstack:</b>" + FormatCallstackForTooltip(*callstack);

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -248,9 +248,7 @@ bool CallstackThreadBar::IsEmpty() const {
   return absl::StrReplaceAll(fn_name, {{"&", "&amp;"}, {"<", "&lt;"}, {">", "&gt;"}});
 }
 
-namespace {
-static std::string kErrorColorString = "#ffb000";
-}  // namespace
+constexpr const char* kErrorColorString = "#ffb000";
 
 std::string CallstackThreadBar::FormatCallstackForTooltip(const CallstackInfo& callstack,
                                                           int max_line_length, int max_lines,

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -248,6 +248,10 @@ bool CallstackThreadBar::IsEmpty() const {
   return absl::StrReplaceAll(fn_name, {{"&", "&amp;"}, {"<", "&lt;"}, {">", "&gt;"}});
 }
 
+namespace {
+static std::string kErrorColorString = "#ffb000";
+}  // namespace
+
 std::string CallstackThreadBar::FormatCallstackForTooltip(const CallstackInfo& callstack,
                                                           int max_line_length, int max_lines,
                                                           int bottom_n_lines) const {
@@ -260,9 +264,10 @@ std::string CallstackThreadBar::FormatCallstackForTooltip(const CallstackInfo& c
   const int top_n = std::min(max_lines, size) - bottom_n;
 
   for (int i = 0; i < top_n; ++i) {
+    // The first frame is always correct.
     if (callstack.IsUnwindingError() && i > 0) {
-      result.append("<br/><span style=\" color:#ffb000;\">" +
-                    SafeGetFormattedFunctionName(callstack, i, max_line_length) + "</span>");
+      result.append(absl::StrFormat("<br/><span style=\" color:%s;\">%s</span>", kErrorColorString,
+                                    SafeGetFormattedFunctionName(callstack, i, max_line_length)));
     } else {
       result.append("<br/>" + SafeGetFormattedFunctionName(callstack, i, max_line_length));
     }
@@ -271,9 +276,10 @@ std::string CallstackThreadBar::FormatCallstackForTooltip(const CallstackInfo& c
     result += "<br/><i>... shortened for readability ...</i>";
   }
   for (int i = size - bottom_n; i < size; ++i) {
+    // The first frame is always correct.
     if (callstack.IsUnwindingError() && i > 0) {
-      result.append("<br/><span style=\" color:#ffb000;\">" +
-                    SafeGetFormattedFunctionName(callstack, i, max_line_length) + "</span>");
+      result.append(absl::StrFormat("<br/><span style=\" color:%s;\">%s</span>", kErrorColorString,
+                                    SafeGetFormattedFunctionName(callstack, i, max_line_length)));
     } else {
       result.append("<br/>" + SafeGetFormattedFunctionName(callstack, i, max_line_length));
     }
@@ -306,9 +312,9 @@ std::string CallstackThreadBar::GetSampleTooltip(const PrimitiveAssembler& primi
       absl::StrFormat("<b>%s</b><br/><i>Stack sample</i><br/><br/>", function_name.c_str());
   if (callstack->IsUnwindingError()) {
     result += absl::StrFormat(
-        "<span style=\" color:#ffb000;\"><b>Unwinding error:</b> the stack could not be unwound "
+        "<span style=\" color:%s;\"><b>Unwinding error:</b> the stack could not be unwound "
         "successfully.<br/>%s</span>",
-        orbit_client_data::CallstackTypeToDescription(callstack->type()));
+        kErrorColorString, orbit_client_data::CallstackTypeToDescription(callstack->type()));
   }
   result += "<br/><br/><b>Callstack:</b>" + FormatCallstackForTooltip(*callstack);
   return result +

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -294,13 +294,12 @@ std::string CallstackThreadBar::GetSampleTooltip(const PrimitiveAssembler& primi
   std::string function_name = SafeGetFormattedFunctionName(*callstack, 0, -1);
   std::string result =
       absl::StrFormat("<b>%s</b><br/><i>Stack sample</i><br/><br/>", function_name.c_str());
-  if (callstack->type() == CallstackType::kComplete) {
-    result += "<b>Callstack:</b>" + FormatCallstackForTooltip(*callstack);
-  } else {
+  if (callstack->type() != CallstackType::kComplete) {
     result += absl::StrFormat(
-        "<b>Callstack not available:</b> the stack could not be unwound successfully.<br/>%s",
+        "<b>Unwinding error:</b> the stack could not be unwound successfully.<br/>%s",
         orbit_client_data::CallstackTypeToDescription(callstack->type()));
   }
+  result += "<br/><br/><b>Callstack:</b>" + FormatCallstackForTooltip(*callstack);
   return result +
          "<br/><br/><i>To select samples, click the bar & drag across multiple samples</i>";
 }


### PR DESCRIPTION
We now expose the (potentially) broken callstack for unwinding
errors in the callstack view.

This change, also adds the callstack to the tooltip.

Screenshot: http://screenshot/9uEXqehFbHsQmpU

Test: Take a capture, however over a grey callstack.
Bug: http://b/232060791