### PR TITLE
Only send "AddressInfos" once

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -102,7 +102,6 @@ void UprobesUnwindingVisitor::SendFullAddressInfoToListener(
   if (!inserted) {
     return;
   }
-  known_linux_address_infos_.insert(libunwindstack_frame.pc);
 
   FullAddressInfo address_info;
   address_info.set_absolute_address(libunwindstack_frame.pc);

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -33,37 +33,6 @@ using orbit_grpc_protos::FullAddressInfo;
 using orbit_grpc_protos::FullCallstackSample;
 using orbit_grpc_protos::FunctionCall;
 
-static void SendFullAddressInfoToListener(TracerListener* listener,
-                                          const unwindstack::FrameData& libunwindstack_frame) {
-  ORBIT_CHECK(listener != nullptr);
-
-  FullAddressInfo address_info;
-  address_info.set_absolute_address(libunwindstack_frame.pc);
-
-  // Careful: unwindstack::FrameData::map_info might contain nullptr.
-  if (libunwindstack_frame.map_info != nullptr) {
-    address_info.set_module_name(libunwindstack_frame.map_info->name());
-  }
-
-  // For addresses falling directly inside u(ret)probes code, unwindstack::FrameData has limited
-  // information. Nonetheless, we can send a perfectly meaningful FullAddressInfo, treating
-  // u(ret)probes code as a single function. This makes sense as the only affected virtual addresses
-  // I observed are 0x7fffffffe000 (~1% of uprobes addresses) and 0x7fffffffe001 (~99%). This way
-  // the client can show more information for such a frame, in particular when associated with the
-  // corresponding unwinding error.
-  if (libunwindstack_frame.map_info != nullptr &&
-      libunwindstack_frame.map_info->name() == "[uprobes]") {
-    address_info.set_function_name("[uprobes]");
-    address_info.set_offset_in_function(libunwindstack_frame.pc -
-                                        libunwindstack_frame.map_info->start());
-  } else {
-    address_info.set_function_name(libunwindstack_frame.function_name);
-    address_info.set_offset_in_function(libunwindstack_frame.function_offset);
-  }
-
-  listener->OnAddressInfo(std::move(address_info));
-}
-
 static bool CallstackIsInUserSpaceInstrumentation(
     const std::vector<unwindstack::FrameData>& frames,
     const UserSpaceInstrumentationAddresses& user_space_instrumentation_addresses) {
@@ -125,6 +94,42 @@ static bool CallchainIsInUserSpaceInstrumentation(
       [&user_space_instrumentation_addresses](uint64_t frame) {
         return user_space_instrumentation_addresses.IsInEntryOrReturnTrampoline(frame);
       });
+}
+
+void UprobesUnwindingVisitor::SendFullAddressInfoToListener(
+    TracerListener* listener, const unwindstack::FrameData& libunwindstack_frame) {
+  ORBIT_CHECK(listener != nullptr);
+
+  if (known_linux_address_infos_.contains(libunwindstack_frame.pc)) {
+    return;
+  }
+  known_linux_address_infos_.insert(libunwindstack_frame.pc);
+
+  FullAddressInfo address_info;
+  address_info.set_absolute_address(libunwindstack_frame.pc);
+
+  // Careful: unwindstack::FrameData::map_info might contain nullptr.
+  if (libunwindstack_frame.map_info != nullptr) {
+    address_info.set_module_name(libunwindstack_frame.map_info->name());
+  }
+
+  // For addresses falling directly inside u(ret)probes code, unwindstack::FrameData has limited
+  // information. Nonetheless, we can send a perfectly meaningful FullAddressInfo, treating
+  // u(ret)probes code as a single function. This makes sense as the only affected virtual addresses
+  // I observed are 0x7fffffffe000 (~1% of uprobes addresses) and 0x7fffffffe001 (~99%). This way
+  // the client can show more information for such a frame, in particular when associated with the
+  // corresponding unwinding error.
+  if (libunwindstack_frame.map_info != nullptr &&
+      libunwindstack_frame.map_info->name() == "[uprobes]") {
+    address_info.set_function_name("[uprobes]");
+    address_info.set_offset_in_function(libunwindstack_frame.pc -
+                                        libunwindstack_frame.map_info->start());
+  } else {
+    address_info.set_function_name(libunwindstack_frame.function_name);
+    address_info.set_offset_in_function(libunwindstack_frame.function_offset);
+  }
+
+  listener->OnAddressInfo(std::move(address_info));
 }
 
 orbit_grpc_protos::Callstack::CallstackType

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -6,6 +6,7 @@
 #define LINUX_TRACING_UPROBES_UNWINDING_VISITOR_H_
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <sys/types.h>
 
 #include <atomic>
@@ -103,6 +104,9 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   [[nodiscard]] orbit_grpc_protos::Callstack::CallstackType
   ComputeCallstackTypeFromCallchainAndPatch(const CallchainSamplePerfEventData& event_data);
 
+  void SendFullAddressInfoToListener(TracerListener* listener,
+                                     const unwindstack::FrameData& libunwindstack_frame);
+
   TracerListener* listener_;
 
   UprobesFunctionCallManager* function_call_manager_;
@@ -118,6 +122,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   absl::flat_hash_map<pid_t, std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>>
       uprobe_sps_ips_cpus_per_thread_{};
+  absl::flat_hash_set<uint64_t> known_linux_address_infos_{};
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -104,8 +104,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   [[nodiscard]] orbit_grpc_protos::Callstack::CallstackType
   ComputeCallstackTypeFromCallchainAndPatch(const CallchainSamplePerfEventData& event_data);
 
-  void SendFullAddressInfoToListener(TracerListener* listener,
-                                     const unwindstack::FrameData& libunwindstack_frame);
+  void SendFullAddressInfoToListener(const unwindstack::FrameData& libunwindstack_frame);
 
   TracerListener* listener_;
 


### PR DESCRIPTION
While in the ProducerEventProcessor, we already hash
the strings of AddressInfo events and only send them once,
we are still sending up to 256 (4x64) bytes PER frame, for
each callstack. Even if we've already sent the data
for a respective absolute address.

This simple change, only sends the address infos once per
absolute address.

On a 18sec capture of OrbitService, this already reduced
the capture size from 3MB to 1.5MB.

Test: Capture OrbitService and validate symbols + Unit tests
Bug: http://b/230315380