### PR TITLE
Add end-to-end test script for mixed callstack unwinding on triangle.exe

### DIFF
--- a/contrib/automation_tests/orbit_mixed_unwinding.py
+++ b/contrib/automation_tests/orbit_mixed_unwinding.py
@@ -1,0 +1,54 @@
+"""
+Copyright (c) 2022 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from test_cases.bottom_up_tab import VerifyBottomUpContentForTriangleExe
+from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.capture_window import Capture
+from test_cases.sampling_tab import VerifySamplingContentForTriangleExe
+from test_cases.symbols_tab import LoadSymbols
+from test_cases.top_down_tab import VerifyTopDownContentForTriangleExe
+"""Verify mixed (DWARF and PE/COFF) callstack unwinding by inspecting the "Sampling", "Top-Down", "Bottom-Up" tabs.
+
+Before this script is run there needs to be a gamelet reserved and our "triangle.exe" has to be started.
+
+The script requires absl and pywinauto. Since pywinauto requires the bitness of
+the python installation to match the bitness of the program under test, it needs
+to be run from 64 bit python.
+
+This automation script covers a basic workflow:
+ - connect to a gamelet;
+ - select a process;
+ - load symbols;
+ - take a capture;
+ - verify the top functions by inclusive time in the "Sampling" tab;
+ - verify the outermost functions in the top-down view;
+ - verify the start function and some of its callees for some threads in the top-down view; 
+ - verify the top function in the bottom-up view and some of its callers.
+"""
+
+
+def main(argv):
+    test_cases = [
+        ConnectToStadiaInstance(),
+        FilterAndSelectFirstProcess(process_filter="triangle.exe"),
+        LoadSymbols(module_search_string="ntdll.dll"),
+        LoadSymbols(module_search_string="kernel32.dll"),
+        LoadSymbols(module_search_string="d3d11.dll"),
+        LoadSymbols(module_search_string="triangle.exe"),
+        Capture(),
+        VerifySamplingContentForTriangleExe(),
+        VerifyTopDownContentForTriangleExe(),
+        VerifyBottomUpContentForTriangleExe()
+    ]
+    suite = E2ETestSuite(test_name="Mixed callstack unwinding", test_cases=test_cases)
+    suite.execute()
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/contrib/automation_tests/test_cases/sampling_tab.py
+++ b/contrib/automation_tests/test_cases/sampling_tab.py
@@ -1,0 +1,40 @@
+"""
+Copyright (c) 2022 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+import logging
+import time
+
+from core.common_controls import DataViewPanel
+from core.orbit_e2e import E2ETestCase
+
+
+class VerifySamplingContentForTriangleExe(E2ETestCase):
+    """
+    Verify that the first two rows of the "(all threads)" sub-tab of the "Sampling" tab correspond to the functions
+    `RtlUserThreadStart` (thread start function) and `BaseThreadInitThunk` (calls the thread entry point), in any order.
+    """
+
+    def _execute(self):
+        self.find_control('TabItem', "Sampling").click_input()
+        logging.info("Switched to the 'Sampling' tab")
+        tab = self.find_control('Group', 'samplingTab')
+
+        subtab_widget = self.find_control('Group', 'TabWidget', parent=tab)
+        thread_subtab = self.find_control('Group', 'SamplingReportThreadTab', parent=subtab_widget)
+        sampling_report_dataview = DataViewPanel(
+            self.find_control('Group', 'SamplingReportDataView', parent=thread_subtab))
+
+        logging.info(
+            "Verifying the functions with the highest inclusive count from the 'Sampling' tab")
+        first_function_name = sampling_report_dataview.get_item_at(0, 1).window_text()
+        second_function_name = sampling_report_dataview.get_item_at(1, 1).window_text()
+        # Allow any order because the two functions will most likely have the same number of inclusive samples.
+        self.expect_eq(
+            sorted([first_function_name,
+                    second_function_name]), ["BaseThreadInitThunk", "RtlUserThreadStart"],
+            "Top functions in the 'Sampling' tab are 'RtlUserThreadStart' and 'BaseThreadInitThunk'"
+        )
+        logging.info(
+            "Verified the functions with the highest inclusive count from the 'Sampling' tab")

--- a/contrib/automation_tests/test_cases/top_down_tab.py
+++ b/contrib/automation_tests/test_cases/top_down_tab.py
@@ -7,7 +7,7 @@ import logging
 import time
 
 from core.common_controls import Table
-from core.orbit_e2e import E2ETestCase, find_control
+from core.orbit_e2e import E2ETestCase, find_control, OrbitE2EError
 from pywinauto.keyboard import send_keys
 from typing import Sequence
 
@@ -252,3 +252,95 @@ class VerifyTopDownContentForLoadedCapture(E2ETestCase):
         self._verify_rows_when_thread_recursively_expanded(tree_view_table)
         self._verify_rows_when_tree_expanded(tree_view_table)
         self._verify_rows_on_search(tab, tree_view_table)
+
+
+class VerifyTopDownContentForTriangleExe(E2ETestCase):
+    """
+    Verify that the two outermost functions are `RtlUserThreadStart` (Windows) and `clone` (Linux) from the
+    "(all threads)" node of the top-down view.
+    Verify the start function and some of its callees for the "triangle.exe" and "dxvk-submit" threads.
+    """
+
+    def _execute(self):
+        self.find_control("TabItem", "Top-Down").click_input()
+        logging.info("Switched to the 'Top-Down' tab")
+        tab = self.find_control('Group', 'topDownTab')
+        tree_view_table = Table(self.find_control('Tree', parent=tab))
+
+        self._verify_all_threads(tree_view_table)
+        self._collapse_tree(tree_view_table)
+        self._verify_triangle_exe_thread(tree_view_table)
+        self._collapse_tree(tree_view_table)
+        self._verify_dxvk_submit_thread(tree_view_table)
+
+    def _collapse_tree(self, tree_view_table: Table):
+        tree_view_table.get_item_at(0, 0).click_input(button='right')
+        self.find_context_menu_item("Collapse all").click_input()
+
+    def _verify_all_threads(self, tree_view_table: Table):
+        first_row_tree_item = tree_view_table.get_item_at(0, 0)
+        self.expect_eq(first_row_tree_item.window_text(), "wine64-preloader (all threads)",
+                       "First item of the top-down view is 'wine64-preloader (all threads)'")
+
+        logging.info("Expanding the '(all threads)' node of the top-down view")
+        row_count_before_expansion = tree_view_table.get_row_count()
+        first_row_tree_item.double_click_input()
+        row_count_after_expansion = tree_view_table.get_row_count()
+        self.expect_true(row_count_after_expansion - row_count_before_expansion >= 2,
+                         "The '(all threads)' node has at least two children")
+
+        self.expect_eq(
+            tree_view_table.get_item_at(1, 0).window_text(), "RtlUserThreadStart",
+            "The most common outermost function is 'RtlUserThreadStart'")
+        self.expect_eq(
+            tree_view_table.get_item_at(2, 0).window_text(), "clone",
+            "The second most common outermost function is 'clone'")
+        logging.info("Verified the outermost functions from the top-down view")
+
+    def _verify_triangle_exe_thread(self, tree_view_table: Table):
+        thread_name = "triangle.exe"
+        logging.info(f"Verifying the top outer functions for the thread '{thread_name}'")
+        thread_row = self._find_thread_row(tree_view_table, thread_name)
+        self._verify_top_outer_functions(tree_view_table, thread_row, [
+            "RtlUserThreadStart", "BaseThreadInitThunk", "__scrt_common_main_seh", "wWinMain",
+            "dxvk::DxgiSwapChain::Present1"
+        ])
+        logging.info(f"Verified the top outer functions for the thread '{thread_name}'")
+
+    def _verify_dxvk_submit_thread(self, tree_view_table: Table):
+        thread_name = "dxvk-submit"
+        logging.info(f"Verifying the top outer functions for the thread '{thread_name}'")
+        thread_row = self._find_thread_row(tree_view_table, thread_name)
+        self._verify_top_outer_functions(tree_view_table, thread_row, [
+            "RtlUserThreadStart", "BaseThreadInitThunk", "dxvk::ThreadFn::threadProc",
+            "dxvk::DxvkSubmissionQueue::submitCmdLists", "dxvk::vk::Presenter::presentImage",
+            "wine_vkAcquireNextImageKHR", "ggpdrv::(anonymous namespace)::AcquireNextImageKHR",
+            "yeti::internal::vulkan::Swapchain::AcquireNextImage"
+        ])
+        logging.info(f"Verified the top outer functions for the thread '{thread_name}'")
+
+    @staticmethod
+    def _find_thread_row(tree_view_table: Table, thread_name: str):
+        for row in range(tree_view_table.get_row_count()):
+            if tree_view_table.get_item_at(row, 0).window_text().startswith(thread_name + " ["):
+                return row
+        raise OrbitE2EError(f"The top-down view has no '{thread_name}' thread")
+
+    def _verify_top_outer_functions(self, tree_view_table: Table, thread_row: int,
+                                    expected_functions: Sequence[str]):
+        for index, expected in enumerate(expected_functions):
+            # Expand the previous node (thread or caller of the expected function).
+            parent_row = thread_row + index
+            parent_item = tree_view_table.get_item_at(parent_row, 0)
+            parent_text = parent_item.window_text()
+            row_count_before_expansion = tree_view_table.get_row_count()
+            parent_item.double_click_input()
+            row_count_after_expansion = tree_view_table.get_row_count()
+            self.expect_true(row_count_after_expansion > row_count_before_expansion,
+                             f"The '{parent_text}' node has at least one child")
+
+            # Verify the function name.
+            row = parent_row + 1
+            self.expect_true(
+                tree_view_table.get_item_at(row, 0).window_text().startswith(expected),
+                f"The top ${index + 1}-th outer function is '${expected}'")

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -59,7 +59,8 @@ void OrbitSamplingReport::Initialize(orbit_data_views::DataView* callstack_data_
   for (orbit_data_views::SamplingReportDataView& report_data_view : report->GetThreadDataViews()) {
     ORBIT_SCOPE("SamplingReportDataView tab creation");
     auto* tab = new QWidget();
-    tab->setObjectName(QStringLiteral("tab"));
+    tab->setObjectName(QStringLiteral("samplingReportThreadTab"));
+    tab->setAccessibleName(QStringLiteral("SamplingReportThreadTab"));
 
     auto* gridLayout_2 = new QGridLayout(tab);
     gridLayout_2->setObjectName(QStringLiteral("gridLayout_2"));
@@ -77,7 +78,8 @@ void OrbitSamplingReport::Initialize(orbit_data_views::DataView* callstack_data_
       treeView->GetTreeView()->sortByColumn(column, order);
     }
 
-    treeView->setObjectName(QStringLiteral("treeView"));
+    treeView->setObjectName(QStringLiteral("samplingReportDataView"));
+    treeView->setAccessibleName(QStringLiteral("SamplingReportDataView"));
     gridLayout_2->addWidget(treeView, 0, 0, 1, 1);
     treeView->Initialize(&report_data_view, SelectionType::kExtended, FontType::kDefault);
     {

--- a/src/OrbitQt/orbitsamplingreport.ui
+++ b/src/OrbitQt/orbitsamplingreport.ui
@@ -38,6 +38,9 @@
       <enum>Qt::Vertical</enum>
      </property>
      <widget class="QTabWidget" name="tabWidget">
+      <property name="accessibleName">
+        <string>TabWidget</string>
+      </property>
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
         <horstretch>0</horstretch>
@@ -51,7 +54,10 @@
        <number>-1</number>
       </property>
      </widget>
-     <widget class="QFrame" name="frame">
+     <widget class="QFrame" name="callstackFrame">
+      <property name="accessibleName">
+        <string>CallstackFrame</string>
+      </property>
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
       </property>


### PR DESCRIPTION
The test is somewhat strict. However, the top functions that get checked have a
high margin over others so the test should still behave consistently. We'll
relax it if it turns out otherwise.

Also set some accessibility names in the "Sampling" tab.

Bug: http://b/232083351

Test: Ran script locally.