### PR TITLE
Make text eliding consistent

### DIFF
--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -39,7 +39,6 @@ OrbitTreeView::OrbitTreeView(QWidget* parent) : QTreeView(parent) {
   setItemsExpandable(false);
   setContextMenuPolicy(Qt::CustomContextMenu);
   setSelectionBehavior(QTreeView::SelectRows);
-  setTextElideMode(Qt::ElideMiddle);
 
   connect(header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this,
           SLOT(OnSort(int, Qt::SortOrder)));


### PR DESCRIPTION
The text eliding in table views is different to what we use in the
top-down and bottom-up views.

Users have reported that they like right-elided text more over the
middle-elided one.

This change changes the table views to right elided text - as it is in
the tree views (bottom up and top down).

Bug: http://b/197498131