### PR TITLE
Highlight button's symbol when hovering

### DIFF
--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -28,9 +28,6 @@ constexpr float kGradientFactor = 0.25f;
 
 namespace orbit_gl {
 
-const Color Button::kHighlightColor(75, 75, 75, 255);
-const Color Button::kBaseColor(68, 68, 68, 255);
-
 Button::Button(CaptureViewElement* parent, const Viewport* viewport, const TimeGraphLayout* layout,
                std::string label, SymbolType symbol_type)
     : CaptureViewElement(parent, viewport, layout),
@@ -90,6 +87,8 @@ void Button::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& /*tex
   const Vec2 pos = GetPos();
   const Vec2 size = GetSize();
 
+  const Color kHighlightColor(75, 75, 75, 255);
+  const Color kBaseColor(68, 68, 68, 255);
   const Color kDarkBorderColor = GetDarkerColor(kBaseColor);
   const Color kLightBorderColor = GetLighterColor(kBaseColor);
 
@@ -118,12 +117,12 @@ void Button::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& /*tex
 }
 
 void Button::DrawSymbol(PrimitiveAssembler& primitive_assembler) {
-  const Color kSymbolColor(191, 191, 192, 255);
-  const Color kHighlightedSymbolColor(255, 255, 255, 255);
+  const Color kSymbolBaseColor(191, 191, 192, 255);
+  const Color kSymbolHighlightColor(255, 255, 255, 255);
   const float kSymbolPaddingSize = 3.f;
   const float kSymbolWide = 3.f;
 
-  Color symbol_color = IsMouseOver() ? kHighlightedSymbolColor : kSymbolColor;
+  Color symbol_color = IsMouseOver() ? kSymbolHighlightColor : kSymbolBaseColor;
 
   switch (symbol_type_) {
     case SymbolType::kNoSymbol:

--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -40,6 +40,18 @@ Button::Button(CaptureViewElement* parent, const Viewport* viewport, const TimeG
   SetHeight(layout->GetMinButtonSize());
 }
 
+CaptureViewElement::EventResult Button::OnMouseEnter() {
+  EventResult event_result = CaptureViewElement::OnMouseEnter();
+  RequestUpdate(RequestUpdateScope::kDraw);
+  return event_result;
+}
+
+CaptureViewElement::EventResult Button::OnMouseLeave() {
+  EventResult event_result = CaptureViewElement::OnMouseLeave();
+  RequestUpdate(RequestUpdateScope::kDraw);
+  return event_result;
+}
+
 void Button::SetHeight(float height) {
   if (height == height_) return;
 
@@ -107,8 +119,11 @@ void Button::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& /*tex
 
 void Button::DrawSymbol(PrimitiveAssembler& primitive_assembler) {
   const Color kSymbolColor(191, 191, 192, 255);
+  const Color kHighlightedSymbolColor(255, 255, 255, 255);
   const float kSymbolPaddingSize = 3.f;
   const float kSymbolWide = 3.f;
+
+  Color symbol_color = IsMouseOver() ? kHighlightedSymbolColor : kSymbolColor;
 
   switch (symbol_type_) {
     case SymbolType::kNoSymbol:
@@ -117,13 +132,13 @@ void Button::DrawSymbol(PrimitiveAssembler& primitive_assembler) {
       primitive_assembler.AddBox(MakeBox({GetPos()[0] + (GetWidth() - kSymbolWide) / 2.f,
                                           GetPos()[1] + kSymbolPaddingSize},
                                          {kSymbolWide, GetHeight() - 2 * kSymbolPaddingSize}),
-                                 GlCanvas::kZValueButton, kSymbolColor, shared_from_this());
+                                 GlCanvas::kZValueButton, symbol_color, shared_from_this());
       [[fallthrough]];
     case SymbolType::kMinusSymbol:
       primitive_assembler.AddBox(MakeBox({GetPos()[0] + kSymbolPaddingSize,
                                           GetPos()[1] + (GetHeight() - kSymbolWide) / 2.f},
                                          {GetWidth() - 2 * kSymbolPaddingSize, kSymbolWide}),
-                                 GlCanvas::kZValueButton, kSymbolColor, shared_from_this());
+                                 GlCanvas::kZValueButton, symbol_color, shared_from_this());
       break;
     default:
       ORBIT_UNREACHABLE();

--- a/src/OrbitGl/Button.h
+++ b/src/OrbitGl/Button.h
@@ -36,13 +36,13 @@ class Button : public CaptureViewElement, public std::enable_shared_from_this<Bu
 
   static const Color kHighlightColor;
   static const Color kBaseColor;
-  static const Color kTextColor;
-  static const Color kSymbolsColor;
 
  protected:
   void DoUpdateLayout() override;
   void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
+  [[nodiscard]] EventResult OnMouseEnter() override;
+  [[nodiscard]] EventResult OnMouseLeave() override;
 
  private:
   void DrawSymbol(PrimitiveAssembler& primitive_assembler);

--- a/src/OrbitGl/Button.h
+++ b/src/OrbitGl/Button.h
@@ -34,9 +34,6 @@ class Button : public CaptureViewElement, public std::enable_shared_from_this<Bu
 
   void OnRelease() override;
 
-  static const Color kHighlightColor;
-  static const Color kBaseColor;
-
  protected:
   void DoUpdateLayout() override;
   void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,


### PR DESCRIPTION
In this PR we are highlighting the symbol when moving the mouse is over the
button. It was agreed with Carsten.

We are also forcing a redraw when entering and leaving the mouse,
something we did in the scrollbars and it was missing in the previous
PR.

Bug: b/233090307

http://screenshot/BPdHh7Mw3V3Hhxj