### PR TITLE
Make TrackContainer the second children of the TimeGraph

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -880,8 +880,8 @@ bool TimeGraph::IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) c
 }
 
 std::vector<orbit_gl::CaptureViewElement*> TimeGraph::GetAllChildren() const {
-  return {GetTimelineUi(),     GetPlusButton(),       GetMinusButton(),
-          GetTrackContainer(), GetHorizontalSlider(), GetVerticalSlider()};
+  return {GetTimelineUi(), GetTrackContainer(), GetHorizontalSlider(),
+          GetPlusButton(), GetMinusButton(),    GetVerticalSlider()};
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> TimeGraph::CreateAccessibleInterface() {


### PR DESCRIPTION
It's because the E2E tests. The test is failing after https://github.com/google/orbit/pull/3660 
because TrackContainer is not the second children anymore. 

Since we don't have a required order for the
children, we set first the 3 children at the left and after the 3
children at the right margin, both lists from top to down.

