### PR TITLE
Fix E2E test `orbit_instrument_libs`

### DIFF
--- a/contrib/automation_tests/test_cases/live_tab.py
+++ b/contrib/automation_tests/test_cases/live_tab.py
@@ -97,7 +97,7 @@ class VerifyScopeTypeAndHitCount(LiveTabTestCase):
             'Scope "%s" expected to be of type %s , was %s' % (scope_name, scope_type, scope_type))
 
 
-class VerifyOneFunctionWasCalled(LiveTabTestCase):
+class VerifyOneFunctionWasHit(LiveTabTestCase):
     """
     Verify that at least one of the functions matching the function name has 
     received the given number of hits.


### PR DESCRIPTION
Due to inconsistent renaming, a class could not be found

Tests: E2E
Bug: http://b/233168520