### PR TITLE
Flip time at the cursor when needed

### DIFF
--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -86,19 +86,15 @@ void TimelineUi::RenderLabel(PrimitiveAssembler& primitive_assembler, TextRender
 
   float label_start_x = world_x + kLabelsPadding + label_extra_margin;
 
-  // Flip mouse label if it doesn't fit at the right and rather it fits all the way at the left.
+  // Flip mouse label if it doesn't fit on the right and rather it fits all the way on the left.
   if (is_mouse_label) {
-    float label_at_right_start_x = label_start_x;
-    float label_at_left_start_x = world_x - kLabelsPadding - label_extra_margin - label_width;
-    ClosedInterval left_margin_x_range{std::numeric_limits<float>::lowest(), GetPos()[0]};
-    ClosedInterval right_margin_x_range{GetPos()[0] + GetWidth(),
-                                        std::numeric_limits<float>::max()};
-    ClosedInterval label_at_left_range{label_at_left_start_x, label_at_left_start_x + label_width};
-    ClosedInterval label_at_right_range{label_at_right_start_x,
-                                        label_at_right_start_x + label_width};
-    if (label_at_right_range.Intersects(right_margin_x_range) &&
-        !label_at_left_range.Intersects(left_margin_x_range)) {
-      label_start_x = label_at_left_start_x;
+    float right_margin_x = GetPos()[0] + GetWidth();
+    if (label_start_x + label_width >= right_margin_x) {
+      // If there is no enough space on the right, check whether there is enough space on the left
+      if (float label_at_left_start_x = world_x - kLabelsPadding - label_extra_margin - label_width;
+          label_at_left_start_x >= GetPos()[0]) {
+        label_start_x = label_at_left_start_x;
+      }
     }
   }
 


### PR DESCRIPTION
When the mouse was close to the right border of the capture window, the last
digits of the "time at cursor" indicator were cut of.

In this PR we are flipping only the mouse_label when there is no space
at the right but instead there is space to completely draw the label at
the left. This last check is only made for really tiny screens (< 100/150
width), where there could be no space at either side. In that case,  we still
prefer to draw it at the right.

http://screenshot/3DKBDSgnGNKH3Dg

Bug: b/231158495.

Test: Load a capture. Zoom-in/out. Move mouse to the corners.