### PR TITLE
Hide green line and labels when mouse isn't over

### DIFF
--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -121,7 +121,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
 
  protected:
   struct DrawContext {
-    uint64_t current_mouse_time_ns = 0;
+    std::optional<uint64_t> current_mouse_time_ns = std::nullopt;
     PickingMode picking_mode = PickingMode::kNone;
   };
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -430,20 +430,12 @@ void CaptureWindow::Draw() {
   }
 
   if (time_graph_ != nullptr) {
-    uint64_t timegraph_current_mouse_time_ns =
-        time_graph_->GetTickFromWorld(viewport_.ScreenToWorld(GetMouseScreenPos())[0]);
-    time_graph_->DrawAllElements(primitive_assembler_, GetTextRenderer(), picking_mode_,
-                                 timegraph_current_mouse_time_ns);
+    time_graph_->DrawAllElements(primitive_assembler_, GetTextRenderer(), picking_mode_);
   }
 
   RenderSelectionOverlay();
 
   if (picking_mode_ == PickingMode::kNone) {
-    Vec2 pos = viewport_.ScreenToWorld(Vec2i(mouse_move_pos_screen_[0], 0));
-    // Vertical green line at mouse x position
-    primitive_assembler_.AddVerticalLine(pos, viewport_.GetWorldHeight(), kZValueUi,
-                                         Color(0, 255, 0, 127));
-
     if (draw_help_) {
       RenderHelpUi();
     }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -73,17 +73,20 @@ void GraphTrack<Dimension>::DoDraw(PrimitiveAssembler& primitive_assembler,
   if (IsEmpty() || IsCollapsed()) return;
 
   // Draw label
-  const std::array<double, Dimension>& values =
-      series_.GetPreviousOrFirstEntry(draw_context.current_mouse_time_ns);
-  uint64_t first_time = series_.StartTimeInNs();
-  uint64_t label_time = std::max(draw_context.current_mouse_time_ns, first_time);
-  float point_x = timeline_info_->GetWorldFromTick(label_time);
-  float point_y = GetLabelYFromValues(values);
-  std::string text = GetLabelTextFromValues(values);
-  const Color kBlack(0, 0, 0, 255);
-  const Color kTransparentWhite(255, 255, 255, 180);
-  DrawLabel(primitive_assembler, text_renderer, Vec2(point_x, point_y), text, kBlack,
-            kTransparentWhite);
+  if (draw_context.current_mouse_time_ns) {
+    uint64_t current_mouse_time_ns = draw_context.current_mouse_time_ns.value();
+    const std::array<double, Dimension>& values =
+        series_.GetPreviousOrFirstEntry(current_mouse_time_ns);
+    uint64_t first_time = series_.StartTimeInNs();
+    uint64_t label_time = std::max(current_mouse_time_ns, first_time);
+    float point_x = timeline_info_->GetWorldFromTick(label_time);
+    float point_y = GetLabelYFromValues(values);
+    std::string text = GetLabelTextFromValues(values);
+    const Color kBlack(0, 0, 0, 255);
+    const Color kTransparentWhite(255, 255, 255, 180);
+    DrawLabel(primitive_assembler, text_renderer, Vec2(point_x, point_y), text, kBlack,
+              kTransparentWhite);
+  }
 
   if (!HasLegend()) return;
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -39,8 +39,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] float GetHeight() const override;
 
   void DrawAllElements(orbit_gl::PrimitiveAssembler& primitive_assembler,
-                       orbit_gl::TextRenderer& text_renderer, PickingMode& picking_mode,
-                       uint64_t current_mouse_time_ns);
+                       orbit_gl::TextRenderer& text_renderer, PickingMode& picking_mode);
   void DrawText(float layer);
 
   // TODO(b/214282122): Move Process Timers function outside the UI.
@@ -181,6 +180,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] EventResult OnMouseWheel(
       const Vec2& mouse_pos, int delta,
       const orbit_gl::ModifierKeys& modifiers = orbit_gl::ModifierKeys()) override;
+  [[nodiscard]] EventResult OnMouseLeave() override;
 
   void UpdateHorizontalScroll(float ratio);
   void UpdateHorizontalZoom(float normalized_start, float normalized_end);

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -193,10 +193,11 @@ void TimelineUi::UpdateNumDecimalsInLabels(uint64_t min_timestamp_ns, uint64_t m
 
 void TimelineUi::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                         const DrawContext& draw_context) {
-  const uint64_t mouse_timestamp_ns =
-      timeline_info_interface_->GetNsSinceStart(draw_context.current_mouse_time_ns);
-
-  RenderMouseLabel(primitive_assembler, text_renderer, mouse_timestamp_ns);
+  if (draw_context.current_mouse_time_ns) {
+    const uint64_t mouse_timestamp_ns =
+        timeline_info_interface_->GetNsSinceStart(draw_context.current_mouse_time_ns.value());
+    RenderMouseLabel(primitive_assembler, text_renderer, mouse_timestamp_ns);
+  }
 }
 
 void TimelineUi::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,


### PR DESCRIPTION
In this PR we are just drawing:
 - Green line in the TimeGraph
 - Labels in Variable/PageFault/Memory Tracks
 - MouseLabel in the Timeline
only when the mouse is over the TimeGraph and also inside the visible
time range. This last case is to avoid the case of having the mouse on 
top of the right-margin or the vertical slider resulting on this behavior:
http://screenshot/7M7dd7q4wTJe49P

Bugs:
http://b/231160028
http://b/233325318

Screenshots:
Mouse over TimeGraph: http://screenshot/9aUnjp8NqfPduyA
Mouse not over TimeGraph: http://screenshot/37JoH6YRGBVwPPM

Test: Load a capture, move the mouse around Orbit.