### PR TITLE
Don't fail in front of UNWIND_INFOs with version 2

### DIFF
--- a/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.cpp
@@ -224,6 +224,20 @@ bool PeCoffUnwindInfoEvaluatorImpl::Eval(Memory* process_memory, Regs* regs,
         op_idx += 3;
         break;
       }
+      case UWOP_EPILOG: {
+        // This is an undocumented opcode from the rare and undocumented version 2 of UNWIND_INFO.
+        // We know that it takes two slots, but the meaning of the operation info and of the second
+        // slot is not certain. The purpose seems to be to describe the location of the epilogs of
+        // the function, which would speed up unwinding by removing the need for epilog detection.
+        if (unwind_info.GetVersion() != 2) {
+          last_error_.code = ERROR_INVALID_COFF;
+          return false;
+        }
+        // As this is rare and undocumented, just do nothing for now and rely on epilog detection as
+        // in version 1.
+        op_idx += 2;
+        break;
+      }
       case UWOP_SAVE_XMM128: {
         // We do not actually have to save the XMM registers here and in the UWOP_SAVE_XMM128_FAR
         // case, we just have to skip the unwind codes. XMM registers are not read by other unwind

--- a/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.h
@@ -33,7 +33,8 @@ enum UnwindOpCode : uint8_t {
   UWOP_SET_FPREG = 3,
   UWOP_SAVE_NONVOL = 4,
   UWOP_SAVE_NONVOL_FAR = 5,
-  // There are no codes 6 and 7
+  UWOP_EPILOG = 6,  // Only in UNWIND_INFOs with version 2.
+  // There are no opcodes 6 and 7 in version 1. There is no opcode 7 in version 2 either.
   UWOP_SAVE_XMM128 = 8,
   UWOP_SAVE_XMM128_FAR = 9,
   UWOP_PUSH_MACHFRAME = 10

--- a/third_party/libunwindstack/PeCoffUnwindInfos.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.cpp
@@ -96,8 +96,10 @@ bool PeCoffUnwindInfosImpl::ParseUnwindInfoAtOffset(uint64_t offset, UnwindInfo*
   unwind_info->num_codes = data_info[2];
   unwind_info->frame_register_and_offset = data_info[3];
 
-  // 0x01 is the only version that exists right now.
-  if (unwind_info->GetVersion() != 0x01) {
+  // Version 1 is the only documented one:
+  // https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64#struct-unwind_info
+  // However, there is also an undocumented version 2 that adds the UWOP_EPILOG opcode.
+  if (unwind_info->GetVersion() != 0x01 && unwind_info->GetVersion() != 0x02) {
     last_error_.code = ERROR_INVALID_COFF;
     return false;
   }


### PR DESCRIPTION
Version 2 adds the undocumented `UWOP_EPILOG`. Don't use it and keep relying on
epilog detection in all cases, but handle it gracefully.

More information and links in the bug.

Bug: http://b/233328376

Test: 
- Extend unit tests.
- Tried on Silenus game that showed this. Unwinding now proceeds correctly
from the one address that was affected by this.