### PR TITLE
Detect PE text section based on characteristics, not name

### DIFF
--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -103,24 +103,26 @@ struct SectionHeader {
 // Represents preprocessed data of a section that we need for further processing. Section name
 // is already looked up in the string table.
 struct Section {
-  Section() : name(""), vmsize(0), vmaddr(0), size(0), offset(0) {}
+  Section() : name(""), vmsize(0), vmaddr(0), size(0), offset(0), flags(0) {}
   Section(std::string name_arg, uint32_t vmsize_arg, uint32_t vmaddr_arg, uint32_t size_arg,
-          uint32_t offset_arg)
+          uint32_t offset_arg, uint32_t flags_arg)
       : name(std::move(name_arg)),
         vmsize(vmsize_arg),
         vmaddr(vmaddr_arg),
         size(size_arg),
-        offset(offset_arg) {}
+        offset(offset_arg),
+        flags(flags_arg) {}
   std::string name;
   uint32_t vmsize;
   uint32_t vmaddr;
   uint32_t size;    // Size in file
   uint32_t offset;  // Offset in file
+  uint32_t flags;
 };
 
 class PeCoffMemory {
  public:
-  PeCoffMemory(Memory* memory) : memory_(memory), cur_offset_(0) {}
+  explicit PeCoffMemory(Memory* memory) : memory_(memory), cur_offset_(0) {}
 
   bool Get8(uint8_t* value);
   bool Get16(uint16_t* value);
@@ -199,7 +201,6 @@ class PeCoffInterfaceImpl : public PeCoffInterface {
     uint64_t memory_size = 0;
     uint64_t memory_offset = 0;
     uint64_t file_offset = 0;
-    size_t section_index = 0;
   };
   std::optional<TextSectionData> text_section_data_;
 

--- a/third_party/libunwindstack/tests/PeCoffFake.h
+++ b/third_party/libunwindstack/tests/PeCoffFake.h
@@ -44,9 +44,12 @@ class PeCoffFake {
   static constexpr uint64_t kTextSectionMemoryOffset = 0x2000;
   static constexpr uint64_t kTextSectionMemorySize = 0xFFF;
 
-  // File offset and size for the .debug_frame section.
+  static constexpr uint32_t kTextSectionFlags = 0x20000020;
+
+  // File offset for the .debug_frame section.
   static constexpr uint64_t kDebugFrameSectionFileOffset = 0x3000;
-  static constexpr uint64_t kDebugFrameSectionSize = 0x200;
+
+  static constexpr uint32_t kDebugFrameSectionFlags = 0x40000040;
 
   // File offset for the exception table, equivalent to the .pdata section, which consists
   // of a list of RUNTIME_FUNCTION entries.
@@ -58,6 +61,8 @@ class PeCoffFake {
   // While this value determines the memory layout, our code only looks at the file content,
   // so this value is only used in arithmetic converting virtual addresses to file offset.
   static constexpr uint64_t kExceptionTableVmAddr = 0x5000;
+
+  static constexpr uint32_t kPdataSectionFlags = 0x40000040;
 
   // Fake load bias, does not change the layout of the file data.
   static constexpr int64_t kLoadBiasFake = 0x31000;
@@ -74,9 +79,9 @@ class PeCoffFake {
 
   // Returns the offset where the section *would* go, so tests can add data there as desired.
   uint64_t InitNoSectionHeaders();
-  uint64_t SetSectionHeaderAtOffset(uint64_t offset, std::string section_name, uint64_t vmsize = 0,
-                                    uint64_t vmaddr = 0, uint64_t size = 0,
-                                    uint64_t file_offset = 0);
+  uint64_t SetSectionHeaderAtOffset(uint64_t offset, const std::string& section_name,
+                                    uint64_t vmsize = 0, uint64_t vmaddr = 0, uint64_t size = 0,
+                                    uint64_t file_offset = 0, uint32_t flags = 0);
 
   uint64_t coff_header_nsects_offset() const { return coff_header_nsects_offset_; };
   uint64_t coff_header_symoff_offset() const { return coff_header_symoff_offset_; };
@@ -85,7 +90,6 @@ class PeCoffFake {
   uint64_t optional_header_num_data_dirs_offset() const {
     return optional_header_num_data_dirs_offset_;
   };
-  uint64_t executable_section_offset() const { return executable_section_offset_; };
 
  private:
   uint64_t coff_header_nsects_offset_;
@@ -93,7 +97,6 @@ class PeCoffFake {
   uint64_t optional_header_size_offset_;
   uint64_t optional_header_start_offset_;
   uint64_t optional_header_num_data_dirs_offset_;
-  uint64_t executable_section_offset_;
   std::unique_ptr<MemoryFake> memory_;
 
   uint64_t SetData8(uint64_t offset, uint8_t value);
@@ -115,7 +118,6 @@ class PeCoffFake {
   uint64_t SetDebugFrameEntryAtOffset(uint64_t offset, uint32_t pc_start);
   uint64_t SetRuntimeFunctionsAtOffset(uint64_t offset, uint64_t size);
 
-  std::unique_ptr<MemoryFake> memory_fake_;
   std::vector<std::pair<uint64_t, std::string>> section_names_in_string_table_;
 };
 

--- a/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
@@ -38,7 +38,7 @@ template <typename PeCoffInterfaceType>
 class PeCoffInterfaceTest : public ::testing::Test {
  public:
   PeCoffInterfaceTest() : fake_(new PeCoffFake<PeCoffInterfaceType>) {}
-  ~PeCoffInterfaceTest() {}
+  ~PeCoffInterfaceTest() override = default;
 
   PeCoffFake<PeCoffInterfaceType>* GetFake() { return fake_.get(); }
   MemoryFake* GetMemory() { return fake_->GetMemoryFake(); }
@@ -56,7 +56,7 @@ template <typename PeCoffInterfaceType>
 class PeCoffInterfaceFileTest : public ::testing::Test {
  public:
   PeCoffInterfaceFileTest() : memory_(nullptr) {}
-  ~PeCoffInterfaceFileTest() {}
+  ~PeCoffInterfaceFileTest() override = default;
 
   static std::unique_ptr<MemoryBuffer> ReadFile(const char* filename) {
     std::string dir = android::base::GetExecutableDirectory() + "/tests/files/";

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
@@ -29,13 +29,14 @@ namespace unwindstack {
 constexpr uint32_t kSectionSize = 0x1000;
 constexpr uint32_t kVmAddress = 0x6600;
 constexpr uint32_t kFileOffset = 0x4000;
-std::vector<unwindstack::Section> kSections{
-    unwindstack::Section{"all_addresses", kSectionSize, kVmAddress, kSectionSize, kFileOffset}};
+constexpr uint32_t kSectionFlags = 0x40000040;
+std::vector<unwindstack::Section> kSections{unwindstack::Section{
+    "all_addresses", kSectionSize, kVmAddress, kSectionSize, kFileOffset, kSectionFlags}};
 
 class PeCoffUnwindInfosTest : public ::testing::Test {
  public:
   PeCoffUnwindInfosTest() : memory_fake_(new MemoryFake) {}
-  ~PeCoffUnwindInfosTest() {}
+  ~PeCoffUnwindInfosTest() override = default;
 
   uint64_t SetUnwindInfoHeaderAtOffset(uint64_t offset, uint8_t num_codes, bool chained) {
     uint8_t flags = 0x00;

--- a/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
@@ -36,7 +36,7 @@ void FuzzPeCoffUnwindInfos(const uint8_t* data, size_t size) {
   // a file offset.
   constexpr uint32_t kUint32Max = std::numeric_limits<uint32_t>::max();
   std::vector<unwindstack::Section> sections{
-      unwindstack::Section{"all_addresses", kUint32Max, 0, kUint32Max, 0}};
+      unwindstack::Section{"all_addresses", kUint32Max, 0, kUint32Max, 0, 0}};
   std::unique_ptr<unwindstack::PeCoffUnwindInfos> pe_coff_unwind_infos(
       CreatePeCoffUnwindInfos(memory.get(), sections));
   unwindstack::UnwindInfo info;


### PR DESCRIPTION
This brings `unwindstack::PeCoffInterface` in line with
`orbit_object_utils::CreateCoffFile`.
Section characteristics are more reliable because they determine how the section
is loaded in memory, while names are an aid for tools and can be changed as a
way of obfuscating the binary. For example, we have observed that in some cases
the section called ".text" is not executable and doesn't actually contain code.

Additionally, while the case of multiple executable sections is more complex,
this method reports the first executable section, which seems to be the text
section we are looking for in all observed cases. After all, that section is at
least where the code starts.

On a complex Silenus game, this dramatically reduces the number of unwind
errors, because which anonymous map corresponds to the text section can now be
detected correctly.

Also address a couple of clang-tidy warnings along the way.

Test: Updated unit tests. Tried on aforementioned game.