### PR TITLE
Crash fix in ConnectToTargetDialog

### DIFF
--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -115,7 +115,8 @@ ErrorMessageOr<void> ConnectToTargetDialog::OnAsyncDataAvailable(
   process_manager_ = orbit_client_services::ProcessManager::Create(
       stadia_connection_.value().GetGrpcChannel(), absl::Milliseconds(1000));
   process_manager_->SetProcessListUpdateListener(
-      [dialog = QPointer<ConnectToTargetDialog>(this)](std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
+      [dialog = QPointer<ConnectToTargetDialog>(this)](
+          std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
         if (dialog == nullptr) return;
         dialog->OnProcessListUpdate(std::move(process_list));
       });

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -5,6 +5,7 @@
 #include "SessionSetup/ConnectToTargetDialog.h"
 
 #include <absl/flags/flag.h>
+#include <qobjectdefs.h>
 
 #include <QApplication>
 #include <QMessageBox>
@@ -118,7 +119,10 @@ ErrorMessageOr<void> ConnectToTargetDialog::OnAsyncDataAvailable(
       [dialog = QPointer<ConnectToTargetDialog>(this)](
           std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
         if (dialog == nullptr) return;
-        dialog->OnProcessListUpdate(std::move(process_list));
+        QMetaObject::invokeMethod(dialog,
+                                  [dialog, process_list = std::move(process_list)]() mutable {
+                                    dialog->OnProcessListUpdate(std::move(process_list));
+                                  });
       });
   SetStatusMessage("Waiting for process to launch.");
 

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -5,7 +5,6 @@
 #include "SessionSetup/ConnectToTargetDialog.h"
 
 #include <absl/flags/flag.h>
-#include <qobjectdefs.h>
 
 #include <QApplication>
 #include <QMessageBox>

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -115,8 +115,9 @@ ErrorMessageOr<void> ConnectToTargetDialog::OnAsyncDataAvailable(
   process_manager_ = orbit_client_services::ProcessManager::Create(
       stadia_connection_.value().GetGrpcChannel(), absl::Milliseconds(1000));
   process_manager_->SetProcessListUpdateListener(
-      [this](std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
-        OnProcessListUpdate(std::move(process_list));
+      [dialog = QPointer<ConnectToTargetDialog>(this)](std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
+        if (dialog == nullptr) return;
+        dialog->OnProcessListUpdate(std::move(process_list));
       });
   SetStatusMessage("Waiting for process to launch.");
 


### PR DESCRIPTION
This is my idea on how to fix this. Please also take a look at the crash callstack to confirm

Bug: http://b/232729288
Test: Run Orbit with --target_process and --target_instance