### PR TITLE
Also show module names in CallstackThreadBar's tooltips

### DIFF
--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -294,7 +294,7 @@ std::string CallstackThreadBar::FormatFunctionName(
 constexpr const char* kUnwindErrorColorString = "#ffb000";
 
 std::string CallstackThreadBar::FormatCallstackForTooltip(const CallstackInfo& callstack) const {
-  constexpr int kMaxLineLength = 100;
+  constexpr int kMaxLineLength = 120;
   constexpr int kMaxLines = 20;
   constexpr int kBottomLineCount = 5;
 
@@ -370,6 +370,7 @@ std::string CallstackThreadBar::GetSampleTooltip(const PrimitiveAssembler& primi
       FormatModuleName(innermost_module_and_function_name);
 
   std::string result;
+  result.append("<p style=\"white-space:pre;\">");  // Prevent word wrapping.
   result += absl::StrFormat("<b>%s</b><br/>", innermost_formatted_function_name);
   result += "<i>Stack sample</i><br/>";
   result += "<br/>";
@@ -386,6 +387,7 @@ std::string CallstackThreadBar::GetSampleTooltip(const PrimitiveAssembler& primi
   result += FormatCallstackForTooltip(*callstack);
   result += "<br/>";
   result += "<i>To select samples, click the bar & drag across multiple samples</i>";
+  result.append("</p>");
   return result;
 }
 

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -295,11 +295,15 @@ constexpr const char* kUnwindErrorColorString = "#ffb000";
 
 std::string CallstackThreadBar::FormatCallstackForTooltip(const CallstackInfo& callstack) const {
   constexpr int kMaxLineLength = 120;
+  // If the callstack has more than `kMaxLines` frames, we only show the `kBottomLineCount`
+  // outermost frames and the `kMaxLines - kBottomLineCount` innermost frames, separated by
+  // `kShortenedForReadabilityString`.
   constexpr int kMaxLines = 20;
   constexpr int kBottomLineCount = 5;
+  static_assert(kBottomLineCount < kMaxLines);
 
   int callstack_size = static_cast<int>(callstack.frames().size());
-  const int bottom_n = std::min(std::min(kMaxLines - 1, kBottomLineCount), callstack_size);
+  const int bottom_n = std::min(kBottomLineCount, callstack_size);
   const int top_n = std::min(kMaxLines, callstack_size) - bottom_n;
 
   constexpr int kShortenedForReadabilityFakeIndex = -1;
@@ -308,7 +312,7 @@ std::string CallstackThreadBar::FormatCallstackForTooltip(const CallstackInfo& c
   for (int i = 0; i < top_n; ++i) {
     frame_indices_to_display.push_back(i);
   }
-  if (kMaxLines < callstack_size) {
+  if (callstack_size > kMaxLines) {
     frame_indices_to_display.push_back(kShortenedForReadabilityFakeIndex);
   }
   for (int i = callstack_size - bottom_n; i < callstack_size; ++i) {

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -52,18 +52,18 @@ class CallstackThreadBar : public ThreadBar {
  private:
   void SelectCallstacks();
 
-  struct ModuleAndFunctionNameToFormat {
+  struct UnformattedModuleAndFunctionName {
     std::string module_name;
     bool module_is_unknown;
     std::string function_name;
     bool function_is_unknown;
   };
-  [[nodiscard]] ModuleAndFunctionNameToFormat SafeGetModuleAndFunctionNames(
+  [[nodiscard]] UnformattedModuleAndFunctionName SafeGetModuleAndFunctionName(
       const orbit_client_data::CallstackInfo& callstack, size_t frame_index) const;
   [[nodiscard]] static std::string FormatModuleName(
-      const CallstackThreadBar::ModuleAndFunctionNameToFormat& module_and_function_name);
+      const CallstackThreadBar::UnformattedModuleAndFunctionName& module_and_function_name);
   [[nodiscard]] static std::string FormatFunctionName(
-      const CallstackThreadBar::ModuleAndFunctionNameToFormat& module_and_function_name,
+      const CallstackThreadBar::UnformattedModuleAndFunctionName& module_and_function_name,
       int max_length);
   [[nodiscard]] std::string FormatCallstackForTooltip(
       const orbit_client_data::CallstackInfo& callstack) const;

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -53,6 +53,8 @@ class CallstackThreadBar : public ThreadBar {
   void SelectCallstacks();
 
   struct UnformattedModuleAndFunctionName {
+    // {module,function}_is_unknown doesn't imply that {module,function}_name is empty.
+    // Rather, it indicates that the name might need to be formatted differently.
     std::string module_name;
     bool module_is_unknown;
     std::string function_name;

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -51,13 +51,22 @@ class CallstackThreadBar : public ThreadBar {
 
  private:
   void SelectCallstacks();
-  [[nodiscard]] std::string SafeGetFormattedFunctionName(
-      const orbit_client_data::CallstackInfo& callstack, size_t frame_index,
-      int max_line_length) const;
-  [[nodiscard]] std::string FormatCallstackForTooltip(
-      const orbit_client_data::CallstackInfo& callstack, int max_line_length = 80,
-      int max_lines = 20, int bottom_n_lines = 5) const;
 
+  struct ModuleAndFunctionNameToFormat {
+    std::string module_name;
+    bool module_is_unknown;
+    std::string function_name;
+    bool function_is_unknown;
+  };
+  [[nodiscard]] ModuleAndFunctionNameToFormat SafeGetModuleAndFunctionNames(
+      const orbit_client_data::CallstackInfo& callstack, size_t frame_index) const;
+  [[nodiscard]] static std::string FormatModuleName(
+      const CallstackThreadBar::ModuleAndFunctionNameToFormat& module_and_function_name);
+  [[nodiscard]] static std::string FormatFunctionName(
+      const CallstackThreadBar::ModuleAndFunctionNameToFormat& module_and_function_name,
+      int max_length);
+  [[nodiscard]] std::string FormatCallstackForTooltip(
+      const orbit_client_data::CallstackInfo& callstack) const;
   [[nodiscard]] std::string GetSampleTooltip(const PrimitiveAssembler& primitive_assembler,
                                              PickingId id) const;
 };


### PR DESCRIPTION
The recent work on Silenus showed that the additional information is very
useful, in particular when the function is in a module that the user doesn't
know about, or when there is no symbol for the function and only the absolute
address is shown.

For the frames in the callstack, I chose "module | function". This is similar to
Visual Studio's "module!function", but I think it's a bit more readable.

Screenshots:
http://screen/rvJx5qbpa9nsBfb
http://screen/BcNjjrQEuEUgkPV

Bug: http://b/233200089

Test: Various manual tests.