### PR TITLE
Add dependency to linux bootstrapping.

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -26,7 +26,7 @@ while true; do
 done
 
 readonly REQUIRED_PACKAGES=( build-essential libglu1-mesa-dev mesa-common-dev \
-                             libxmu-dev libxi-dev libopengl0 qtbase5-dev \
+                             libxmu-dev libxi-dev libopengl-dev qtbase5-dev \
                              qtwebengine5-dev libqt5webchannel5-dev \
                              libqt5websockets5-dev libxxf86vm-dev python3-pip )
 


### PR DESCRIPTION
Previously the build complained about a missing libOpenGL.so which is contained in libopengl-dev (it's merely a link to  libOpenGL.so.0). 
libopengl-dev depends on libopengl0 son now both get installed.