### PR TITLE
Refactor TimelineInfo to include ZoomTime

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -283,12 +283,9 @@ bool CaptureWindow::RightUp() {
 
 void CaptureWindow::ZoomHorizontally(int delta, int mouse_x) {
   if (delta == 0) return;
-
-  auto delta_float = static_cast<float>(delta);
-
   if (time_graph_ != nullptr) {
     double mouse_ratio = static_cast<double>(mouse_x) / time_graph_->GetTimelineWidth();
-    time_graph_->ZoomTime(delta_float, mouse_ratio);
+    time_graph_->ZoomTime(delta, mouse_ratio);
   }
 }
 

--- a/src/OrbitGl/MockTimelineInfo.h
+++ b/src/OrbitGl/MockTimelineInfo.h
@@ -51,7 +51,7 @@ class MockTimelineInfo : public TimelineInfoInterface {
 
   void ZoomTime(int delta, double mouse_ratio) override {
     double ratio =
-        (delta > 0) ? (1 + kIncrementalZoomingRatio) : (1 / (1 + kIncrementalZoomingRatio));
+        (delta > 0) ? (1 + kIncrementalZoomTimeRatio) : (1 / (1 + kIncrementalZoomTimeRatio));
     double alpha = ratio - 1.;
     uint64_t visible_range_ns = max_visible_ns_ - min_visible_ns_;
     uint64_t mouse_timestamp_ns =

--- a/src/OrbitGl/MockTimelineInfo.h
+++ b/src/OrbitGl/MockTimelineInfo.h
@@ -49,6 +49,22 @@ class MockTimelineInfo : public TimelineInfoInterface {
     max_capture_ns_ = std::max(max_capture_ns_, max_tick);
   }
 
+  void ZoomTime(int delta, double mouse_ratio) override {
+    double ratio =
+        (delta > 0) ? (1 + kIncrementalZoomingRatio) : (1 / (1 + kIncrementalZoomingRatio));
+    double alpha = ratio - 1.;
+    uint64_t visible_range_ns = max_visible_ns_ - min_visible_ns_;
+    uint64_t mouse_timestamp_ns =
+        min_visible_ns_ + static_cast<uint64_t>(mouse_ratio * visible_range_ns);
+
+    uint64_t desired_min_visible_ns =
+        static_cast<uint64_t>(min_visible_ns_ * (1. - alpha) + mouse_timestamp_ns * alpha);
+    uint64_t desired_max_visible_ns =
+        static_cast<uint64_t>(max_visible_ns_ * (1. - alpha) + mouse_timestamp_ns * alpha);
+
+    SetMinMax(desired_min_visible_ns, desired_max_visible_ns);
+  }
+
  private:
   double width_ = 0.f;
   uint64_t min_visible_ns_ = 0;

--- a/src/OrbitGl/MockTimelineInfo.h
+++ b/src/OrbitGl/MockTimelineInfo.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_GL_MOCK_TIMELINE_INFO_H_
 #define ORBIT_GL_MOCK_TIMELINE_INFO_H_
 
+#include <gmock/gmock.h>
+
 #include "TimelineInfoInterface.h"
 
 namespace orbit_gl {
@@ -49,21 +51,7 @@ class MockTimelineInfo : public TimelineInfoInterface {
     max_capture_ns_ = std::max(max_capture_ns_, max_tick);
   }
 
-  void ZoomTime(int delta, double mouse_ratio) override {
-    double ratio =
-        (delta > 0) ? (1 + kIncrementalZoomTimeRatio) : (1 / (1 + kIncrementalZoomTimeRatio));
-    double alpha = ratio - 1.;
-    uint64_t visible_range_ns = max_visible_ns_ - min_visible_ns_;
-    uint64_t mouse_timestamp_ns =
-        min_visible_ns_ + static_cast<uint64_t>(mouse_ratio * visible_range_ns);
-
-    uint64_t desired_min_visible_ns =
-        static_cast<uint64_t>(min_visible_ns_ * (1. - alpha) + mouse_timestamp_ns * alpha);
-    uint64_t desired_max_visible_ns =
-        static_cast<uint64_t>(max_visible_ns_ * (1. - alpha) + mouse_timestamp_ns * alpha);
-
-    SetMinMax(desired_min_visible_ns, desired_max_visible_ns);
-  }
+  MOCK_METHOD(void, ZoomTime, (int, double), (override));
 
  private:
   double width_ = 0.f;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -160,7 +160,7 @@ void TimeGraph::Zoom(const TimerInfo& timer_info) { Zoom(timer_info.start(), tim
 double TimeGraph::GetCaptureTimeSpanUs() const { return GetCaptureTimeSpanNs() * 0.001; }
 
 void TimeGraph::ZoomTime(int zoom_delta, double center_time_ratio) {
-  constexpr float kIncrementalZoomTimeRatio = 0.1;
+  constexpr double kIncrementalZoomTimeRatio = 0.1;
   double scale =
       (zoom_delta > 0) ? (1 + kIncrementalZoomTimeRatio) : (1 / (1 + kIncrementalZoomTimeRatio));
   // The horizontal zoom could have been triggered from the margin of TimeGraph, so we clamp the

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -159,15 +159,16 @@ void TimeGraph::Zoom(const TimerInfo& timer_info) { Zoom(timer_info.start(), tim
 
 double TimeGraph::GetCaptureTimeSpanUs() const { return GetCaptureTimeSpanNs() * 0.001; }
 
-void TimeGraph::ZoomTime(int delta, double mouse_ratio) {
-  double scale = (delta > 0) ? (1 + orbit_gl::kIncrementalZoomTimeRatio)
-                             : (1 / (1 + orbit_gl::kIncrementalZoomTimeRatio));
+void TimeGraph::ZoomTime(int zoom_delta, double center_time_ratio) {
+  constexpr float kIncrementalZoomTimeRatio = 0.1;
+  double scale =
+      (zoom_delta > 0) ? (1 + kIncrementalZoomTimeRatio) : (1 / (1 + kIncrementalZoomTimeRatio));
   // The horizontal zoom could have been triggered from the margin of TimeGraph, so we clamp the
   // mouse_ratio to ensure it is between 0 and 1.
-  mouse_ratio = std::clamp(mouse_ratio, 0., 1.);
+  center_time_ratio = std::clamp(center_time_ratio, 0., 1.);
 
   double current_time_window_us = max_time_us_ - min_time_us_;
-  ref_time_us_ = min_time_us_ + mouse_ratio * current_time_window_us;
+  ref_time_us_ = min_time_us_ + center_time_ratio * current_time_window_us;
 
   double time_left = std::max(ref_time_us_ - min_time_us_, 0.0);
   double time_right = std::max(max_time_us_ - ref_time_us_, 0.0);
@@ -179,8 +180,8 @@ void TimeGraph::ZoomTime(int delta, double mouse_ratio) {
 
   if (duration < kTimeGraphMinTimeWindowsUs) {
     const double diff = kTimeGraphMinTimeWindowsUs - duration;
-    min_time_us -= diff * mouse_ratio;
-    max_time_us += diff * (1. - mouse_ratio);
+    min_time_us -= diff * center_time_ratio;
+    max_time_us += diff * (1. - center_time_ratio);
   }
 
   SetMinMax(min_time_us, max_time_us);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -159,9 +159,9 @@ void TimeGraph::Zoom(const TimerInfo& timer_info) { Zoom(timer_info.start(), tim
 
 double TimeGraph::GetCaptureTimeSpanUs() const { return GetCaptureTimeSpanNs() * 0.001; }
 
-void TimeGraph::ZoomTime(float zoom_value, double mouse_ratio) {
-  static double increment_ratio = 0.1;
-  double scale = (zoom_value > 0) ? (1 + increment_ratio) : (1 / (1 + increment_ratio));
+void TimeGraph::ZoomTime(int delta, double mouse_ratio) {
+  double scale = (delta > 0) ? (1 + orbit_gl::kIncrementalZoomTimeRatio)
+                             : (1 / (1 + orbit_gl::kIncrementalZoomTimeRatio));
   // The horizontal zoom could have been triggered from the margin of TimeGraph, so we clamp the
   // mouse_ratio to ensure it is between 0 and 1.
   mouse_ratio = std::clamp(mouse_ratio, 0., 1.);
@@ -414,7 +414,7 @@ orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     VerticalZoom(delta_normalized, mouse_pos[1]);
   } else {
     double mouse_ratio = mouse_pos[0] / GetTimelineWidth();
-    ZoomTime(delta_normalized, mouse_ratio);
+    ZoomTime(delta, mouse_ratio);
   }
 
   return EventResult::kHandled;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -80,7 +80,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   void ZoomAll();
   void Zoom(const orbit_client_protos::TimerInfo& timer_info);
   void Zoom(uint64_t min, uint64_t max);
-  void ZoomTime(float zoom_value, double mouse_ratio);
+  void ZoomTime(int delta, double mouse_ratio) override;
   void SetMinMax(double min_time_us, double max_time_us);
   void PanTime(int initial_x, int current_x, int width, double initial_time);
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -80,7 +80,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   void ZoomAll();
   void Zoom(const orbit_client_protos::TimerInfo& timer_info);
   void Zoom(uint64_t min, uint64_t max);
-  void ZoomTime(int delta, double mouse_ratio) override;
+  void ZoomTime(int zoom_delta, double center_time_ratio) override;
   void SetMinMax(double min_time_us, double max_time_us);
   void PanTime(int initial_x, int current_x, int width, double initial_time);
 

--- a/src/OrbitGl/TimelineInfoInterface.h
+++ b/src/OrbitGl/TimelineInfoInterface.h
@@ -9,8 +9,6 @@
 
 namespace orbit_gl {
 
-constexpr float kIncrementalZoomTimeRatio = 0.1;
-
 class TimelineInfoInterface {
  public:
   virtual ~TimelineInfoInterface() = default;
@@ -26,7 +24,7 @@ class TimelineInfoInterface {
   [[nodiscard]] virtual double GetMinTimeUs() const = 0;
   [[nodiscard]] virtual double GetMaxTimeUs() const = 0;
 
-  virtual void ZoomTime(int delta, double mouse_ratio) = 0;
+  virtual void ZoomTime(int zoom_delta, double center_time_ratio) = 0;
 
   [[nodiscard]] virtual uint64_t GetCaptureTimeSpanNs() const = 0;
 };

--- a/src/OrbitGl/TimelineInfoInterface.h
+++ b/src/OrbitGl/TimelineInfoInterface.h
@@ -9,6 +9,8 @@
 
 namespace orbit_gl {
 
+constexpr float kIncrementalZoomTimeRatio = 0.1;
+
 class TimelineInfoInterface {
  public:
   virtual ~TimelineInfoInterface() = default;
@@ -23,6 +25,8 @@ class TimelineInfoInterface {
   [[nodiscard]] virtual double GetTimeWindowUs() const = 0;
   [[nodiscard]] virtual double GetMinTimeUs() const = 0;
   [[nodiscard]] virtual double GetMaxTimeUs() const = 0;
+
+  virtual void ZoomTime(int delta, double mouse_ratio) = 0;
 
   [[nodiscard]] virtual uint64_t GetCaptureTimeSpanNs() const = 0;
 };


### PR DESCRIPTION
As it was previously designed in go/stadia-orbit-timeline-improvements,
we are including a way in TimelineInfoInterface to allow timeline
zooming.

MockTimelineInfo is including a simplified version of ZoomTime.

Test: Load a capture works as expected.