### PR TITLE
Cache current pid value in GetCurrentProcessId()

### DIFF
--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -40,7 +40,10 @@ pid_t GetCurrentThreadIdNative() {
   return current_tid;
 }
 
-pid_t GetCurrentProcessIdNative() { return getpid(); }
+pid_t GetCurrentProcessIdNative() {
+  static pid_t current_pid = getpid();
+  return current_pid;
+}
 
 uint32_t FromNativeThreadId(pid_t tid) {
   ORBIT_CHECK(tid == kInvalidLinuxThreadId || tid >= 0);

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -40,7 +40,10 @@ uint32_t GetCurrentThreadIdNative() {
   return current_tid;
 }
 
-uint32_t GetCurrentProcessIdNative() { return ::GetCurrentProcessId(); }
+uint32_t GetCurrentProcessIdNative() {
+  static uint32_t current_pid = ::GetCurrentProcessId();
+  return current_pid;
+}
 
 uint32_t FromNativeThreadId(uint32_t tid) {
   ORBIT_CHECK(IsMultipleOfFour(tid) || tid == kInvalidWindowsThreadId);


### PR DESCRIPTION
GetCurrentProcessId() is called on every introspection scope.
Profiling OrbitService, we saw that 7.1% of samples of the Tracer::Run
thread fell in GetCurrentProcessId() on a test version of OrbitService that
spawns a thread that generates dummy introspection events. This
change brings the 7.1% number down to 0.2%. We now cache the
return value of getpid() in a static variable instead of calling
the function all the time. Note that this change does not significantly
improve the performance of the Api scopes since similar caching was
already done at the caller level.