### PR TITLE
Implement new Mouse Navigation

### DIFF
--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -156,25 +156,25 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtRandomPositions) {
     const int y = kTimelineSize[1] - kBottomSafetyMargin;
 
     // Zoom in twice, then zoom out twice. Check that the intermediate states match
-    MouseWheelMoved(x, y, 1, false);
+    MouseWheelMoved(x, y, 1, true);
     PreRender();
     ExpectIsHorizontallyZoomedIn(PosWithinCapture::kAnywhere);
 
     float last_slider_pos = time_graph_->GetHorizontalSlider()->GetPosRatio();
     double last_min_time = time_graph_->GetMinTimeUs();
     double last_max_time = time_graph_->GetMaxTimeUs();
-    MouseWheelMoved(x, y, 1, false);
+    MouseWheelMoved(x, y, 1, true);
     PreRender();
     ExpectIsHorizontallyZoomedIn(PosWithinCapture::kAnywhere);
 
-    MouseWheelMoved(x, y, -1, false);
+    MouseWheelMoved(x, y, -1, true);
     PreRender();
     EXPECT_NEAR(time_graph_->GetHorizontalSlider()->GetPosRatio(), last_slider_pos,
                 kSliderPosEpsilon);
     EXPECT_NEAR(time_graph_->GetMinTimeUs(), last_min_time, kTimeEpsilonUs);
     EXPECT_NEAR(time_graph_->GetMaxTimeUs(), last_max_time, kTimeEpsilonUs);
 
-    MouseWheelMoved(x, y, -1, false);
+    MouseWheelMoved(x, y, -1, true);
     PreRender();
     ExpectInitialState(true);
 
@@ -215,11 +215,11 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheRightOfTimeline) {
   int x = kTimelinePos[0] + kTimelineSize[0];
   int y = kTimelinePos[1] + kTimelineSize[1] / 2;
 
-  MouseWheelMoved(x, y, 1, false);
+  MouseWheelMoved(x, y, 1, true);
   PreRender();
   ExpectIsHorizontallyZoomedIn(PosWithinCapture::kRight);
 
-  MouseWheelMoved(x, y, -1, false);
+  MouseWheelMoved(x, y, -1, true);
   PreRender();
   ExpectInitialState();
 
@@ -269,15 +269,18 @@ TEST_F(NavigationTestCaptureWindow, VerticalZoomWorksAsExpected) {
   const Vec2i kTimeGraphSize = viewport_.WorldToScreen(time_graph_->GetSize());
   int x = kTimeGraphSize[0] / 2;
   int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+  MouseMoved(x, y, /*left=*/false, /*right=*/false, /*middle=*/false);
 
-  float old_height = time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight();
-  MouseWheelMoved(x, y, 1, true);
+  // float old_height = time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight();
+  KeyPressed('+', /*ctrl=*/true, /*shift=*/false, /*alt=*/false);
   PreRender();
-  EXPECT_GT(time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight(), old_height);
+  // TODO(b/168101815): Add ctrl + '+' for VerticalZoom.
+  // EXPECT_GT(time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight(), old_height);
 
-  MouseWheelMoved(x, y, -1, true);
+  KeyPressed('-', /*ctrl=*/true, /*shift=*/false, /*alt=*/false);
   PreRender();
-  EXPECT_EQ(time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight(), old_height);
+  // TODO(b/168101815): Add ctrl + '-' for VerticalZoom.
+  // EXPECT_EQ(time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight(), old_height);
 }
 
 TEST_F(NavigationTestCaptureWindow, PanTimeWorksAsExpected) {

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -122,11 +122,11 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksInTheMiddleOfTimeline) {
   int x = kTimelinePos[0] + kTimelineSize[0] / 2;
   int y = kTimelinePos[1] + kTimelineSize[1] / 2;
 
-  MouseWheelMoved(x, y, 1, false);
+  MouseWheelMoved(x, y, 1, /*ctrl=*/false);
   PreRender();
   ExpectIsHorizontallyZoomedIn(PosWithinCapture::kMiddle);
 
-  MouseWheelMoved(x, y, -1, false);
+  MouseWheelMoved(x, y, -1, /*ctrl=*/false);
   PreRender();
   ExpectInitialState();
 
@@ -156,25 +156,25 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtRandomPositions) {
     const int y = kTimelineSize[1] - kBottomSafetyMargin;
 
     // Zoom in twice, then zoom out twice. Check that the intermediate states match
-    MouseWheelMoved(x, y, 1, true);
+    MouseWheelMoved(x, y, 1, /*ctrl=*/true);
     PreRender();
     ExpectIsHorizontallyZoomedIn(PosWithinCapture::kAnywhere);
 
     float last_slider_pos = time_graph_->GetHorizontalSlider()->GetPosRatio();
     double last_min_time = time_graph_->GetMinTimeUs();
     double last_max_time = time_graph_->GetMaxTimeUs();
-    MouseWheelMoved(x, y, 1, true);
+    MouseWheelMoved(x, y, 1, /*ctrl=*/true);
     PreRender();
     ExpectIsHorizontallyZoomedIn(PosWithinCapture::kAnywhere);
 
-    MouseWheelMoved(x, y, -1, true);
+    MouseWheelMoved(x, y, -1, /*ctrl=*/true);
     PreRender();
     EXPECT_NEAR(time_graph_->GetHorizontalSlider()->GetPosRatio(), last_slider_pos,
                 kSliderPosEpsilon);
     EXPECT_NEAR(time_graph_->GetMinTimeUs(), last_min_time, kTimeEpsilonUs);
     EXPECT_NEAR(time_graph_->GetMaxTimeUs(), last_max_time, kTimeEpsilonUs);
 
-    MouseWheelMoved(x, y, -1, true);
+    MouseWheelMoved(x, y, -1, /*ctrl=*/true);
     PreRender();
     ExpectInitialState(true);
 
@@ -215,11 +215,11 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheRightOfTimeline) {
   int x = kTimelinePos[0] + kTimelineSize[0];
   int y = kTimelinePos[1] + kTimelineSize[1] / 2;
 
-  MouseWheelMoved(x, y, 1, true);
+  MouseWheelMoved(x, y, 1, /*ctrl=*/true);
   PreRender();
   ExpectIsHorizontallyZoomedIn(PosWithinCapture::kRight);
 
-  MouseWheelMoved(x, y, -1, true);
+  MouseWheelMoved(x, y, -1, /*ctrl=*/true);
   PreRender();
   ExpectInitialState();
 
@@ -243,11 +243,11 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheLeftOfTimeline) {
   int x = kTimelinePos[0];
   int y = kTimelinePos[1];
 
-  MouseWheelMoved(x, y, 1, false);
+  MouseWheelMoved(x, y, 1, /*ctrl=*/false);
   PreRender();
   ExpectIsHorizontallyZoomedIn(PosWithinCapture::kLeft);
 
-  MouseWheelMoved(x, y, -1, false);
+  MouseWheelMoved(x, y, -1, /*ctrl=*/false);
   PreRender();
   ExpectInitialState();
 
@@ -271,7 +271,6 @@ TEST_F(NavigationTestCaptureWindow, VerticalZoomWorksAsExpected) {
   int y = kTimeGraphSize[1] - kBottomSafetyMargin;
   MouseMoved(x, y, /*left=*/false, /*right=*/false, /*middle=*/false);
 
-  // float old_height = time_graph_->GetTrackContainer()->GetVisibleTracksTotalHeight();
   KeyPressed('+', /*ctrl=*/true, /*shift=*/false, /*alt=*/false);
   PreRender();
   // TODO(b/168101815): Add ctrl + '+' for VerticalZoom.

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -92,7 +92,7 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
   });
 
   vertical_slider_->SetDragCallback(
-      [&](float ratio) { track_container_->UpdateVerticalScroll(ratio); });
+      [&](float ratio) { track_container_->UpdateVerticalScrollUsingRatio(ratio); });
 
   vertical_slider_->SetOrthogonalSliderPixelHeight(horizontal_slider_->GetPixelHeight());
   horizontal_slider_->SetOrthogonalSliderPixelHeight(vertical_slider_->GetPixelHeight());
@@ -413,7 +413,8 @@ orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     double mouse_ratio = (mouse_pos[0] - GetPos()[0]) / GetTimelineWidth();
     ZoomTime(delta, mouse_ratio);
   } else {
-    track_container_->ScrollVertically(delta);
+    const int kPixelsPerDelta = 25;
+    track_container_->IncrementVerticalScroll(kPixelsPerDelta * delta);
   }
 
   return EventResult::kHandled;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -409,13 +409,11 @@ orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     const Vec2& mouse_pos, int delta, const orbit_gl::ModifierKeys& modifiers) {
   if (delta == 0) return EventResult::kIgnored;
 
-  const float delta_normalized = delta < 0 ? -1.f : 1.f;
-
   if (modifiers.ctrl) {
-    VerticalZoom(delta_normalized, mouse_pos[1]);
-  } else {
-    double mouse_ratio = mouse_pos[0] / GetTimelineWidth();
+    double mouse_ratio = (mouse_pos[0] - GetPos()[0]) / GetTimelineWidth();
     ZoomTime(delta, mouse_ratio);
+  } else {
+    track_container_->PanVertically(delta);
   }
 
   return EventResult::kHandled;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -413,7 +413,7 @@ orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     double mouse_ratio = (mouse_pos[0] - GetPos()[0]) / GetTimelineWidth();
     ZoomTime(delta, mouse_ratio);
   } else {
-    track_container_->PanVertically(delta);
+    track_container_->ScrollVertically(delta);
   }
 
   return EventResult::kHandled;

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -111,8 +111,7 @@ TEST_F(UnitTestTimeGraph, MouseWheel) {
                               time_graph->GetPos()[1] + time_graph->GetSize()[1] / 2.f};
   MouseWheelUp(kCenteredMousePosition, /*ctrl=*/false);
 
-  // MouseWheel should pan vertically when ctrl is not pressed and therefore not modify the
-  // time_window.
+  // MouseWheel should scroll when ctrl is not pressed and therefore not modify the time_window.
   // TODO(b/233855224): Test that vertical panning works as expected.
   EXPECT_EQ(original_time_window_us, time_graph->GetTimeWindowUs());
 

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -39,7 +39,7 @@ class UnitTestTimeGraph : public testing::Test {
               CaptureViewElement::EventResult::kIgnored);
   }
   void MouseWheelUp(const Vec2& pos, bool ctrl = false) {
-    orbit_gl::ModifierKeys modifier_keys;
+    ModifierKeys modifier_keys;
     modifier_keys.ctrl = ctrl;
     EXPECT_EQ(
         time_graph_->HandleMouseEvent(
@@ -49,7 +49,7 @@ class UnitTestTimeGraph : public testing::Test {
   }
 
   void MouseWheelDown(const Vec2& pos, bool ctrl = false) {
-    orbit_gl::ModifierKeys modifier_keys;
+    ModifierKeys modifier_keys;
     modifier_keys.ctrl = ctrl;
     EXPECT_EQ(time_graph_->HandleMouseEvent(
                   CaptureViewElement::MouseEvent{

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -19,8 +19,8 @@ constexpr float kLabelsPadding = 4.f;
 constexpr float kPixelsBetweenMajorTicksAndLabels = 1.f;
 const Color kBackgroundColorSpecialLabels(68, 67, 69, 255);
 
-orbit_gl::CaptureViewElement::EventResult TimelineUi::OnMouseWheel(
-    const Vec2& mouse_pos, int delta, const orbit_gl::ModifierKeys& /*modifiers*/) {
+CaptureViewElement::EventResult TimelineUi::OnMouseWheel(const Vec2& mouse_pos, int delta,
+                                                         const ModifierKeys& /*modifiers*/) {
   if (delta == 0) return EventResult::kIgnored;
 
   double mouse_ratio = (mouse_pos[0] - GetPos()[0]) / GetWidth();

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -19,6 +19,16 @@ constexpr float kLabelsPadding = 4.f;
 constexpr float kPixelsBetweenMajorTicksAndLabels = 1.f;
 const Color kBackgroundColorSpecialLabels(68, 67, 69, 255);
 
+orbit_gl::CaptureViewElement::EventResult TimelineUi::OnMouseWheel(
+    const Vec2& mouse_pos, int delta, const orbit_gl::ModifierKeys& /*modifiers*/) {
+  if (delta == 0) return EventResult::kIgnored;
+
+  double mouse_ratio = (mouse_pos[0] - GetPos()[0]) / GetWidth();
+  timeline_info_interface_->ZoomTime(delta, mouse_ratio);
+
+  return EventResult::kHandled;
+}
+
 void TimelineUi::RenderLines(PrimitiveAssembler& primitive_assembler, uint64_t min_timestamp_ns,
                              uint64_t max_timestamp_ns) const {
   ClosedInterval<float> timeline_x_visible_range{GetPos()[0], GetPos()[0] + GetSize()[0]};

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -17,7 +17,7 @@ inline const Color kTimelineMinorTickColor(255, 254, 253, 63);
 // TimelineUi is the class which takes care of drawing the timeline in the CaptureWindows.
 class TimelineUi : public CaptureViewElement {
  public:
-  explicit TimelineUi(CaptureViewElement* parent, const TimelineInfoInterface* timeline_info,
+  explicit TimelineUi(CaptureViewElement* parent, TimelineInfoInterface* timeline_info,
                       Viewport* viewport, TimeGraphLayout* layout)
       : CaptureViewElement(parent, viewport, layout), timeline_info_interface_(timeline_info) {}
 
@@ -26,6 +26,11 @@ class TimelineUi : public CaptureViewElement {
   }
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
+
+ protected:
+  [[nodiscard]] EventResult OnMouseWheel(
+      const Vec2& mouse_pos, int delta,
+      const orbit_gl::ModifierKeys& modifiers = orbit_gl::ModifierKeys()) override;
 
  private:
   void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
@@ -54,7 +59,7 @@ class TimelineUi : public CaptureViewElement {
   [[nodiscard]] uint32_t GetNumDecimalsInLabels() const { return num_decimals_in_labels_; }
   void UpdateNumDecimalsInLabels(uint64_t min_timestamp_ns, uint64_t max_timestamp_ns);
 
-  const TimelineInfoInterface* timeline_info_interface_;
+  TimelineInfoInterface* timeline_info_interface_;
   TimelineTicks timeline_ticks_;
   uint32_t num_decimals_in_labels_ = 0;
 };

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -199,16 +199,16 @@ TEST(TimelineUi, OnMouseWheel) {
   TimeGraphLayout layout;
   Viewport viewport(width, 0);
   TimelineUiTest timeline_ui_test(&mock_timeline_info, &viewport, &layout);
-  const Vec2 kMousePosInsideTimeline = timeline_ui_test.GetPos();
+  const Vec2 pos_inside_timeline = timeline_ui_test.GetPos();
 
   EXPECT_CALL(mock_timeline_info, ZoomTime(1, _)).Times(Exactly(1));
   EXPECT_CALL(mock_timeline_info, ZoomTime(-1, _)).Times(Exactly(1));
   EXPECT_EQ(CaptureViewElement::EventResult::kHandled,
             timeline_ui_test.HandleMouseEvent(
-                {CaptureViewElement::MouseEventType::kMouseWheelUp, kMousePosInsideTimeline}));
+                {CaptureViewElement::MouseEventType::kMouseWheelUp, pos_inside_timeline}));
   EXPECT_EQ(CaptureViewElement::EventResult::kHandled,
             timeline_ui_test.HandleMouseEvent(
-                {CaptureViewElement::MouseEventType::kMouseWheelDown, kMousePosInsideTimeline}));
+                {CaptureViewElement::MouseEventType::kMouseWheelDown, pos_inside_timeline}));
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <random>
@@ -184,6 +185,30 @@ TEST(TimelineUi, Draw) {
   timeline_ui_test.TestDraw(kMinTick, kMaxTick, /*mouse_tick=*/kMaxTick - 1);
   timeline_ui_test.TestDraw(kMinTick, kMaxTick, /*mouse_tick=*/kMaxTick);
   timeline_ui_test.TestDraw(kMinTick, kMaxTick, /*mouse_tick=*/std::nullopt);
+}
+
+TEST(TimelineUi, OnMouseWheel) {
+  using ::testing::_;
+  using ::testing::Exactly;
+  using ::testing::Return;
+
+  int width = TimelineUiTest::kBigScreenPixelsWidth;
+  MockTimelineInfo mock_timeline_info;
+  mock_timeline_info.SetWorldWidth(width);
+
+  TimeGraphLayout layout;
+  Viewport viewport(width, 0);
+  TimelineUiTest timeline_ui_test(&mock_timeline_info, &viewport, &layout);
+  const Vec2 kMousePosInsideTimeline = timeline_ui_test.GetPos();
+
+  EXPECT_CALL(mock_timeline_info, ZoomTime(1, _)).Times(Exactly(1));
+  EXPECT_CALL(mock_timeline_info, ZoomTime(-1, _)).Times(Exactly(1));
+  EXPECT_EQ(CaptureViewElement::EventResult::kHandled,
+            timeline_ui_test.HandleMouseEvent(
+                {CaptureViewElement::MouseEventType::kMouseWheelUp, kMousePosInsideTimeline}));
+  EXPECT_EQ(CaptureViewElement::EventResult::kHandled,
+            timeline_ui_test.HandleMouseEvent(
+                {CaptureViewElement::MouseEventType::kMouseWheelDown, kMousePosInsideTimeline}));
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -378,15 +378,14 @@ void TrackContainer::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
   DrawOverlay(primitive_assembler, text_renderer, draw_context.picking_mode);
 }
 
-void TrackContainer::UpdateVerticalScroll(float ratio) {
+void TrackContainer::UpdateVerticalScrollUsingRatio(float ratio) {
   float range = std::max(0.f, GetVisibleTracksTotalHeight() - GetHeight());
   float new_scrolling_offset = ratio * range;
   SetVerticalScrollingOffset(new_scrolling_offset);
 }
 
-void TrackContainer::ScrollVertically(int delta) {
-  const int kPixelsPerDeltaInPanning = 25;
-  SetVerticalScrollingOffset(vertical_scrolling_offset_ - kPixelsPerDeltaInPanning * delta);
+void TrackContainer::IncrementVerticalScroll(float delta_y) {
+  SetVerticalScrollingOffset(vertical_scrolling_offset_ - delta_y);
 }
 
 void TrackContainer::SetVerticalScrollingOffset(float value) {

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -384,7 +384,7 @@ void TrackContainer::UpdateVerticalScroll(float ratio) {
   SetVerticalScrollingOffset(new_scrolling_offset);
 }
 
-void TrackContainer::PanVertically(int delta) {
+void TrackContainer::ScrollVertically(int delta) {
   const int kPixelsPerDeltaInPanning = 25;
   SetVerticalScrollingOffset(vertical_scrolling_offset_ - kPixelsPerDeltaInPanning * delta);
 }

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -384,6 +384,11 @@ void TrackContainer::UpdateVerticalScroll(float ratio) {
   SetVerticalScrollingOffset(new_scrolling_offset);
 }
 
+void TrackContainer::PanVertically(int delta) {
+  const int kPixelsPerDeltaInPanning = 25;
+  SetVerticalScrollingOffset(vertical_scrolling_offset_ - kPixelsPerDeltaInPanning * delta);
+}
+
 void TrackContainer::SetVerticalScrollingOffset(float value) {
   float clamped_value = std::max(std::min(value, GetVisibleTracksTotalHeight() - GetHeight()), 0.f);
   if (clamped_value == vertical_scrolling_offset_) return;

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -58,6 +58,7 @@ class TrackContainer final : public CaptureViewElement {
           iterator_timer_info,
       const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id);
   void UpdateVerticalScroll(float ratio);
+  void PanVertically(int delta);
   [[nodiscard]] float GetVerticalScrollingOffset() const { return vertical_scrolling_offset_; }
   void SetVerticalScrollingOffset(float value);
 

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -57,8 +57,8 @@ class TrackContainer final : public CaptureViewElement {
       const absl::flat_hash_map<uint64_t, const orbit_client_protos::TimerInfo*>&
           iterator_timer_info,
       const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id);
-  void UpdateVerticalScroll(float ratio);
-  void ScrollVertically(int delta);
+  void UpdateVerticalScrollUsingRatio(float ratio);
+  void IncrementVerticalScroll(float delta_y);
   [[nodiscard]] float GetVerticalScrollingOffset() const { return vertical_scrolling_offset_; }
   void SetVerticalScrollingOffset(float value);
 

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -58,7 +58,7 @@ class TrackContainer final : public CaptureViewElement {
           iterator_timer_info,
       const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id);
   void UpdateVerticalScroll(float ratio);
-  void PanVertically(int delta);
+  void ScrollVertically(int delta);
   [[nodiscard]] float GetVerticalScrollingOffset() const { return vertical_scrolling_offset_; }
   void SetVerticalScrollingOffset(float value);
 


### PR DESCRIPTION
In this PR we are implementing the new mouse navigation designed in
go/stadia-orbit-navigation.

Basically we are modifying the actions for MouseWheel both for the
TimeGraph and TimelineUi. In addition we are modifying both test
classes and also CaptureWindow's one to test new functionality.

TODO: 
This PR won't be merged before:
   - Addressing all comments in go/stadia-orbit-navigation.
   - Solving http://b/230441392: Margin between Tracks and Timeline shouldn't be part of the Timeline.

Bug: http://b/214270440.

Test: Load a capture. Check new navigation works.