### PR TITLE
Refactor margin between tracks and timeline

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -685,7 +685,7 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
   // |            TIMELINE            |   |  +  |
   // |                                |   |  -  |
   // |--------------------------------|   |-----|
-  // |             MARGIN                       |
+  // |     SPACE TRACKS - TIMELINE              |
   // |--------------------------------| M |-----|
   // |                                | A |  S  |
   // |                                | R |  L  |
@@ -699,8 +699,9 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
 
   // First we calculate TrackContainer's height. TimeGraph will set TrackContainer height based on
   // its free space.
-  float total_height_without_track_container =
-      GetHeight() - horizontal_slider_->GetHeight() - timeline_ui_->GetHeight();
+  float total_height_without_track_container = GetHeight() - horizontal_slider_->GetHeight() -
+                                               timeline_ui_->GetHeight() -
+                                               layout_.GetSpaceBetweenTracksAndTimeline();
   track_container_->SetHeight(total_height_without_track_container);
 
   // After we set positions.
@@ -720,8 +721,7 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
   minus_button_->SetPos(GetWidth() - minus_button_->GetWidth(),
                         timegraph_current_y + plus_button_->GetHeight());
 
-  // TODO(b/230441392): Margin between timeline and tracks shouldn't be part of the timeline.
-  timegraph_current_y += timeline_ui_->GetHeight();
+  timegraph_current_y += timeline_ui_->GetHeight() + layout_.GetSpaceBetweenTracksAndTimeline();
   track_container_->SetWidth(GetWidth() - total_right_margin);
   track_container_->SetPos(timegraph_current_x, timegraph_current_y);
 
@@ -867,10 +867,19 @@ void TimeGraph::DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
                                         kGreenLineColor);
   }
 
-  // Right vertical margin of the Tracks to make them look nicer. If the vertical slider is visible,
-  // the margin will be between the slider and the tracks.
-  Vec2 right_margin_pos{GetWidth() - GetRightMargin(), GetPos()[1]};
+  DrawMarginsBetweenChildren(primitive_assembler);
+}
 
+void TimeGraph::DrawMarginsBetweenChildren(
+    orbit_gl::PrimitiveAssembler& primitive_assembler) const {
+  // Margin between the Tracks and the Timeline.
+  Vec2 timeline_margin_pos = Vec2(GetPos()[0], GetPos()[1] + timeline_ui_->GetHeight());
+  Vec2 timeline_margin_size = Vec2(GetSize()[0], layout_.GetSpaceBetweenTracksAndTimeline());
+  primitive_assembler.AddBox(MakeBox(timeline_margin_pos, timeline_margin_size),
+                             GlCanvas::kZValueTimeBar, GlCanvas::kBackgroundColor);
+
+  // Margin between the Tracks and the vertical scrollbar.
+  Vec2 right_margin_pos{GetWidth() - GetRightMargin(), GetPos()[1]};
   Quad box = MakeBox(right_margin_pos, GetSize() - (right_margin_pos - GetPos()));
   primitive_assembler.AddBox(box, GlCanvas::kZValueMargin, GlCanvas::kBackgroundColor);
 }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -867,6 +867,9 @@ void TimeGraph::DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
                                         kGreenLineColor);
   }
 
+  // TODO(http://b/217719000): We are drawing boxes in margin positions because some elements are
+  // being drawn partially outside the TrackContainer space. This hack is needed until we assure
+  // that no element is drawn outside of its parent's area.
   DrawMarginsBetweenChildren(primitive_assembler);
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -191,6 +191,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] bool IsPartlyVisible(uint64_t min, uint64_t max) const;
   [[nodiscard]] bool IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) const;
 
+  void DrawMarginsBetweenChildren(orbit_gl::PrimitiveAssembler& primitive_assembler) const;
+
   [[nodiscard]] const TimerInfo* FindNextThreadTrackTimer(uint64_t scope_id, uint64_t current_time,
                                                           std::optional<uint32_t> thread_id) const;
 

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -20,6 +20,7 @@ TimeGraphLayout::TimeGraphLayout() {
   space_between_cores_ = 2.f;
   space_between_gpu_depths_ = 2.f;
   space_between_tracks_ = 10.f;
+  space_between_tracks_and_timeline_ = 10.f;
   space_between_thread_panes_ = 5.f;
   space_between_subtracks_ = 0.f;
   track_label_offset_x_ = 30.f;
@@ -42,7 +43,6 @@ TimeGraphLayout::TimeGraphLayout() {
   generic_fixed_spacer_width_ = 10.f;
   scale_ = 1.f;
   time_bar_height_ = 30.f;
-  time_bar_margin_ = 10.f;
   font_size_ = 14;
 };
 
@@ -64,11 +64,11 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(space_between_cores_);
   FLOAT_SLIDER(space_between_gpu_depths_);
   FLOAT_SLIDER(space_between_tracks_);
+  FLOAT_SLIDER(space_between_tracks_and_timeline_);
   FLOAT_SLIDER(space_between_thread_panes_);
   FLOAT_SLIDER(space_between_subtracks_);
   FLOAT_SLIDER(slider_width_);
   FLOAT_SLIDER(time_bar_height_);
-  FLOAT_SLIDER(time_bar_margin_);
   FLOAT_SLIDER(track_tab_height_);
   FLOAT_SLIDER(track_tab_offset_);
   FLOAT_SLIDER(track_indent_offset_);

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -29,7 +29,6 @@ class TimeGraphLayout {
   float GetTrackLabelOffsetX() const { return track_label_offset_x_; }
   float GetSliderWidth() const { return slider_width_; }
   float GetTimeBarHeight() const { return time_bar_height_; }
-  float GetTimeBarMargin() const { return time_bar_margin_; }
   float GetTrackTabWidth() const { return track_tab_width_; }
   float GetTrackTabHeight() const { return track_tab_height_ * scale_; }
   float GetTrackTabOffset() const { return track_tab_offset_; }
@@ -39,12 +38,14 @@ class TimeGraphLayout {
   float GetRoundingRadius() const { return rounding_radius_ * scale_; }
   float GetRoundingNumSides() const { return rounding_num_sides_; }
   float GetTextOffset() const { return text_offset_ * scale_; }
-  float GetTracksTopMargin() const { return GetTimeBarHeight() + GetTimeBarMargin(); }
   float GetRightMargin() const { return right_margin_; }
   float GetMinButtonSize() const { return min_button_size_; }
   float GetButtonWidth() const { return button_width_; }
   float GetButtonHeight() const { return button_height_; }
   float GetSpaceBetweenTracks() const { return space_between_tracks_ * scale_; }
+  float GetSpaceBetweenTracksAndTimeline() const {
+    return space_between_tracks_and_timeline_ * scale_;
+  }
   float GetSpaceBetweenCores() const { return space_between_cores_ * scale_; }
   float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }
   float GetSpaceBetweenThreadPanes() const { return space_between_thread_panes_ * scale_; }
@@ -75,7 +76,6 @@ class TimeGraphLayout {
   float track_label_offset_x_;
   float slider_width_;
   float time_bar_height_;
-  float time_bar_margin_;
   float track_tab_width_;
   float track_tab_height_;
   float track_tab_offset_;
@@ -96,6 +96,7 @@ class TimeGraphLayout {
   float space_between_cores_;
   float space_between_gpu_depths_;
   float space_between_tracks_;
+  float space_between_tracks_and_timeline_;
   float space_between_thread_panes_;
   float space_between_subtracks_;
   float generic_fixed_spacer_width_;

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -29,7 +29,7 @@ void TimelineUi::RenderLines(PrimitiveAssembler& primitive_assembler, uint64_t m
     if (timeline_x_visible_range.Contains(world_x)) {
       int screen_x = viewport_->WorldToScreen(Vec2(world_x, 0))[0];
       primitive_assembler.AddVerticalLine(
-          Vec2(screen_x, GetPos()[1]), GetHeightWithoutMargin(), GlCanvas::kZValueTimeBar,
+          Vec2(screen_x, GetPos()[1]), GetHeight(), GlCanvas::kZValueTimeBar,
           tick_type == TimelineTicks::TickType::kMajorTick ? kTimelineMajorTickColor
                                                            : kTimelineMinorTickColor);
     }
@@ -53,15 +53,8 @@ void TimelineUi::RenderLabels(PrimitiveAssembler& primitive_assembler, TextRende
   }
 }
 
-void TimelineUi::RenderMargin(PrimitiveAssembler& primitive_assembler) const {
-  Vec2 margin_pos = Vec2(GetPos()[0], GetPos()[1] + GetHeightWithoutMargin());
-  Vec2 margin_size = Vec2(GetSize()[0], GetMarginHeight());
-  primitive_assembler.AddBox(MakeBox(margin_pos, margin_size), GlCanvas::kZValueTimeBar,
-                             GlCanvas::kBackgroundColor);
-}
-
 void TimelineUi::RenderBackground(PrimitiveAssembler& primitive_assembler) const {
-  Quad background_box = MakeBox(GetPos(), Vec2(GetWidth(), GetHeightWithoutMargin()));
+  Quad background_box = MakeBox(GetPos(), GetSize());
   primitive_assembler.AddBox(background_box, GlCanvas::kZValueTimeBar,
                              GlCanvas::kTimeBarBackgroundColor);
 }
@@ -99,7 +92,7 @@ void TimelineUi::RenderLabel(PrimitiveAssembler& primitive_assembler, TextRender
   }
 
   Vec2 pos, size;
-  float label_middle_y = GetPos()[1] + GetHeightWithoutMargin() / 2.f;
+  float label_middle_y = GetPos()[1] + GetHeight() / 2.f;
   text_renderer.AddText(label.c_str(), label_start_x, label_middle_y, label_z, /*text_formatting=*/
                         {layout_->GetFontSize(), Color(255, 255, 255, 255), -1.f,
                          TextRenderer::HAlign::Left, TextRenderer::VAlign::Middle},
@@ -216,8 +209,6 @@ void TimelineUi::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   UpdateNumDecimalsInLabels(min_timestamp_ns, max_timestamp_ns);
   RenderLines(primitive_assembler, min_timestamp_ns, max_timestamp_ns);
   RenderLabels(primitive_assembler, text_renderer, min_timestamp_ns, max_timestamp_ns);
-  // TODO(http://b/217719000): Hack needed to not draw tracks on timeline's margin.
-  RenderMargin(primitive_assembler);
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> TimelineUi::CreateAccessibleInterface() {

--- a/src/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/TimelineUi.h
@@ -21,9 +21,7 @@ class TimelineUi : public CaptureViewElement {
                       Viewport* viewport, TimeGraphLayout* layout)
       : CaptureViewElement(parent, viewport, layout), timeline_info_interface_(timeline_info) {}
 
-  [[nodiscard]] float GetHeight() const override {
-    return GetHeightWithoutMargin() + GetMarginHeight();
-  }
+  [[nodiscard]] float GetHeight() const override { return layout_->GetTimeBarHeight(); }
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
@@ -36,7 +34,6 @@ class TimelineUi : public CaptureViewElement {
                    uint64_t max_timestamp_ns) const;
   void RenderLabels(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                     uint64_t min_timestamp_ns, uint64_t max_timestamp_ns) const;
-  void RenderMargin(PrimitiveAssembler& primitive_assembler) const;
   void RenderBackground(PrimitiveAssembler& primitive_assembler) const;
   void RenderLabel(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                    uint64_t tick_ns, uint32_t number_of_decimal_places, Color background_color,
@@ -49,8 +46,6 @@ class TimelineUi : public CaptureViewElement {
   [[nodiscard]] bool WillLabelsOverlap(TextRenderer& text_renderer,
                                        const std::vector<uint64_t>& tick_list) const;
   [[nodiscard]] float GetTickWorldXPos(uint64_t tick_ns) const;
-  [[nodiscard]] float GetHeightWithoutMargin() const { return layout_->GetTimeBarHeight(); }
-  [[nodiscard]] float GetMarginHeight() const { return layout_->GetTimeBarMargin(); }
   [[nodiscard]] uint32_t GetNumDecimalsInLabels() const { return num_decimals_in_labels_; }
   void UpdateNumDecimalsInLabels(uint64_t min_timestamp_ns, uint64_t max_timestamp_ns);
 

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -81,8 +81,8 @@ class TimelineUiTest : public TimelineUi {
     }
     EXPECT_LE(num_labels, num_major_ticks + 1);
 
-    // Boxes: One box per each label + Background box + margin box.
-    EXPECT_EQ(num_boxes, num_labels + 2);
+    // Boxes: One box per each label + Background box.
+    EXPECT_EQ(num_boxes, num_labels + 1);
 
     // Everything should be between kZValueTimeBar and kZValueTimeBarLabel.
     EXPECT_TRUE(mock_text_renderer_.IsTextBetweenZLayers(GlCanvas::kZValueTimeBar,


### PR DESCRIPTION
The margin was part of the timeline, but this forced us to have a few
hacks and also now, mouse wheel on this margin was producing a reaction
in the Timeline component, which was not desired.

Bug: http://b/230441392.

Test: Load a capture, see that everything looks normal.