### PR TITLE
Extend keys for navigation in CaptureWindow

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -332,9 +332,9 @@ void CaptureWindow::MouseWheelMovedHorizontally(int x, int y, int delta, bool ct
 
 void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt) {
   GlCanvas::KeyPressed(key_code, ctrl, shift, alt);
-  const float kPanRatioPerLeftAndRightArrowKeys = 0.1;
-  const float kScrollingRatioPerUpAndDownArrowKeys = 0.05;
-  const float kScrollingRatioPerPageUpAndDown = 0.9;
+  const float kPanRatioPerLeftAndRightArrowKeys = 0.1f;
+  const float kScrollingRatioPerUpAndDownArrowKeys = 0.05f;
+  const float kScrollingRatioPerPageUpAndDown = 0.9f;
 
   // TODO(b/234116147): Move this part to TimeGraph and manage events similarly to HandleMouseEvent.
   switch (key_code) {

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -657,14 +657,14 @@ void CaptureWindow::RenderHelpUi() {
 
 const char* CaptureWindow::GetHelpText() const {
   const char* help_message =
-      "Start/Stop Capture: 'F5'\n"
-      "Pan: 'A','D' or \"Left Click + Drag\"\n"
-      "Scroll: Arrow keys or Mouse Wheel\n"
-      "Timeline Zoom: 'W', 'S' or \"Ctrl + Mouse Wheel\"\n"
-      "Zoom to specific time range: \"Ctrl + Right Click + Drag\"\n"
-      "UI scale: \"Ctrl + '+'/'-' \"\n"
-      "Select: Left Click\n"
-      "Measure: \"Right Click + Drag\"\n"
+      "Start/Stop Capture: 'F5'\n\n"
+      "Pan: 'A','D' or \"Left Click + Drag\"\n\n"
+      "Scroll: Arrow Keys or Mouse Wheel\n\n"
+      "Timeline Zoom (10%): 'W', 'S' or \"Ctrl + Mouse Wheel\"\n\n"
+      "Zoom to Time Range: \"Ctrl + Right Click + Drag\"\n\n"
+      "Select: Left Click\n\n"
+      "Measure: \"Right Click + Drag\"\n\n"
+      "UI Scale (10%): \"Ctrl + '+'/'-' \"\n\n"
       "Toggle Help: Ctrl + 'H'";
   return help_message;
 }

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -292,13 +292,19 @@ TEST_F(NavigationTestCaptureWindow, PanTimeWorksAsExpected) {
   // TODO (b/226386133): Extend this test
   PreRender();
   ExpectInitialState();
+  const double kEpsilon = 1e-9;
 
   int x = 0;
   int y = viewport_.GetScreenHeight() - kBottomSafetyMargin;
 
   // Pan time - need to zoom in a bit first, then pan slighty right and back again
   MouseMoved(x, y, false, false, false);
-  KeyPressed('W', false, false, false);
+  for (int i = 0; i < 10; i++) {
+    KeyPressed('W', false, false, false);
+  }
+
+  EXPECT_DOUBLE_EQ(time_graph_->GetHorizontalSlider()->GetPosRatio(), 0.0);
+
   KeyPressed('D', false, false, false);
   PreRender();
   EXPECT_GT(time_graph_->GetHorizontalSlider()->GetPosRatio(), 0.0);
@@ -306,20 +312,26 @@ TEST_F(NavigationTestCaptureWindow, PanTimeWorksAsExpected) {
 
   KeyPressed('A', false, false, false);
   PreRender();
-  EXPECT_EQ(time_graph_->GetHorizontalSlider()->GetPosRatio(), 0.0);
-  EXPECT_EQ(time_graph_->GetMinTimeUs(), 0.0);
+  EXPECT_NEAR(time_graph_->GetHorizontalSlider()->GetPosRatio(), 0.0, kEpsilon);
+  EXPECT_NEAR(time_graph_->GetMinTimeUs(), 0.0, kEpsilon);
 
-  // Right arrow
-  KeyPressed(20, false, false, false);
+  const int kRightArrowKeyCode = 20;
+  const int kLeftArrowKeyCode = 18;
+  KeyPressed(kRightArrowKeyCode, false, false, false);
   PreRender();
   EXPECT_GT(time_graph_->GetHorizontalSlider()->GetPosRatio(), 0.0);
   EXPECT_GT(time_graph_->GetMinTimeUs(), 0.0);
 
-  // Left Arrow
-  KeyPressed(18, false, false, false);
+  double min_time_us_after_right_arrow = time_graph_->GetMinTimeUs();
+  KeyPressed(kRightArrowKeyCode, false, false, false);
+  KeyPressed(kLeftArrowKeyCode, false, false, false);
+  // A right arrow key pressed followed by a left one should return to the original position.
+  EXPECT_NEAR(min_time_us_after_right_arrow, time_graph_->GetMinTimeUs(), kEpsilon);
+
+  KeyPressed(kLeftArrowKeyCode, false, false, false);
   PreRender();
-  EXPECT_EQ(time_graph_->GetHorizontalSlider()->GetPosRatio(), 0.0);
-  EXPECT_EQ(time_graph_->GetMinTimeUs(), 0.0);
+  EXPECT_NEAR(time_graph_->GetHorizontalSlider()->GetPosRatio(), 0.0, kEpsilon);
+  EXPECT_NEAR(time_graph_->GetMinTimeUs(), 0.0, kEpsilon);
 }
 
 TEST_F(NavigationTestCaptureWindow, Scrolling) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -408,12 +408,13 @@ void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
 orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     const Vec2& mouse_pos, int delta, const orbit_gl::ModifierKeys& modifiers) {
   if (delta == 0) return EventResult::kIgnored;
+  const float kScrollingRatioPerDelta = 0.05;
 
   if (modifiers.ctrl) {
     double mouse_ratio = (mouse_pos[0] - GetPos()[0]) / GetTimelineWidth();
     ZoomTime(delta, mouse_ratio);
   } else {
-    track_container_->OnVerticalScroll(delta);
+    track_container_->IncrementVerticalScroll(delta * kScrollingRatioPerDelta);
   }
 
   return EventResult::kHandled;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -408,7 +408,7 @@ void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
 orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     const Vec2& mouse_pos, int delta, const orbit_gl::ModifierKeys& modifiers) {
   if (delta == 0) return EventResult::kIgnored;
-  const float kScrollingRatioPerDelta = 0.05;
+  const float kScrollingRatioPerDelta = 0.05f;
 
   if (modifiers.ctrl) {
     double mouse_ratio = (mouse_pos[0] - GetPos()[0]) / GetTimelineWidth();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -413,8 +413,7 @@ orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     double mouse_ratio = (mouse_pos[0] - GetPos()[0]) / GetTimelineWidth();
     ZoomTime(delta, mouse_ratio);
   } else {
-    const int kPixelsPerDelta = 25;
-    track_container_->IncrementVerticalScroll(kPixelsPerDelta * delta);
+    track_container_->OnVerticalScroll(delta);
   }
 
   return EventResult::kHandled;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -83,6 +83,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   void ZoomTime(int zoom_delta, double center_time_ratio) override;
   void SetMinMax(double min_time_us, double max_time_us);
   void PanTime(int initial_x, int current_x, int width, double initial_time);
+  void VerticalZoom(float zoom_value, float mouse_world_y_pos);
 
   enum class VisibilityType {
     kPartlyVisible,
@@ -184,7 +185,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
 
   void UpdateHorizontalScroll(float ratio);
   void UpdateHorizontalZoom(float normalized_start, float normalized_end);
-  void VerticalZoom(float zoom_value, float mouse_world_y_pos);
 
   void SelectAndMakeVisible(const orbit_client_protos::TimerInfo* timer_info);
   [[nodiscard]] bool IsFullyVisible(uint64_t min, uint64_t max) const;

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -384,13 +384,8 @@ void TrackContainer::UpdateVerticalScrollUsingRatio(float ratio) {
   SetVerticalScrollingOffset(new_scrolling_offset);
 }
 
-void TrackContainer::OnVerticalScroll(int delta) {
-  const int kPixelsPerDelta = 25;
-  IncrementVerticalScroll(kPixelsPerDelta * delta);
-}
-
-void TrackContainer::IncrementVerticalScroll(float world_delta_y) {
-  SetVerticalScrollingOffset(vertical_scrolling_offset_ - world_delta_y);
+void TrackContainer::IncrementVerticalScroll(float ratio) {
+  SetVerticalScrollingOffset(vertical_scrolling_offset_ - ratio * GetHeight());
 }
 
 void TrackContainer::SetVerticalScrollingOffset(float value) {

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -384,8 +384,13 @@ void TrackContainer::UpdateVerticalScrollUsingRatio(float ratio) {
   SetVerticalScrollingOffset(new_scrolling_offset);
 }
 
-void TrackContainer::IncrementVerticalScroll(float delta_y) {
-  SetVerticalScrollingOffset(vertical_scrolling_offset_ - delta_y);
+void TrackContainer::OnVerticalScroll(int delta) {
+  const int kPixelsPerDelta = 25;
+  IncrementVerticalScroll(kPixelsPerDelta * delta);
+}
+
+void TrackContainer::IncrementVerticalScroll(float world_delta_y) {
+  SetVerticalScrollingOffset(vertical_scrolling_offset_ - world_delta_y);
 }
 
 void TrackContainer::SetVerticalScrollingOffset(float value) {

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -60,11 +60,8 @@ class TrackContainer final : public CaptureViewElement {
   void UpdateVerticalScrollUsingRatio(float ratio);
   [[nodiscard]] float GetVerticalScrollingOffset() const { return vertical_scrolling_offset_; }
   void SetVerticalScrollingOffset(float value);
-  void OnVerticalScroll(int delta);
-  const float kHeightRatioPerPageUpAndDown = 0.9f;
-  void OnPageUp() { IncrementVerticalScroll(kHeightRatioPerPageUpAndDown * GetHeight()); }
-  void OnPageDown() { IncrementVerticalScroll(-kHeightRatioPerPageUpAndDown * GetHeight()); }
 
+  void IncrementVerticalScroll(float ratio);
   [[nodiscard]] bool HasFrameTrack(uint64_t function_id) const;
   void RemoveFrameTrack(uint64_t function_id);
 
@@ -82,7 +79,6 @@ class TrackContainer final : public CaptureViewElement {
   CreateAccessibleInterface() override;
 
  private:
-  void IncrementVerticalScroll(float world_delta_y);
   void DrawOverlay(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                    PickingMode picking_mode);
   void DrawIteratorBox(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -58,9 +58,12 @@ class TrackContainer final : public CaptureViewElement {
           iterator_timer_info,
       const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id);
   void UpdateVerticalScrollUsingRatio(float ratio);
-  void IncrementVerticalScroll(float delta_y);
   [[nodiscard]] float GetVerticalScrollingOffset() const { return vertical_scrolling_offset_; }
   void SetVerticalScrollingOffset(float value);
+  void OnVerticalScroll(int delta);
+  const float kHeightRatioPerPageUpAndDown = 0.9f;
+  void OnPageUp() { IncrementVerticalScroll(kHeightRatioPerPageUpAndDown * GetHeight()); }
+  void OnPageDown() { IncrementVerticalScroll(-kHeightRatioPerPageUpAndDown * GetHeight()); }
 
   [[nodiscard]] bool HasFrameTrack(uint64_t function_id) const;
   void RemoveFrameTrack(uint64_t function_id);
@@ -79,6 +82,7 @@ class TrackContainer final : public CaptureViewElement {
   CreateAccessibleInterface() override;
 
  private:
+  void IncrementVerticalScroll(float world_delta_y);
   void DrawOverlay(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                    PickingMode picking_mode);
   void DrawIteratorBox(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,


### PR DESCRIPTION
As it was planned in http://go/stadia-orbit-navigation, we are extending keys for
navigation similarly we did with mouse wheel events.

In this PR we added arrow keys to perform a scrolling or a pan if no timers has been
selected (this could be done nicer if we do something similar as we did for mouse 
events: http://b/234116147). We also included PageUp/PageDown and Ctrl + '+' and 
'-' for VerticalZoom. 

Tests were adapted for the new commands. And a bit of a renaming methods had
been added to VerticalScrolling in TrackContainer. Get/SetVerticalScrollingOffset
shouldn't be public, but this implies a refactor in panning that I'm not planning to do
soon.

Also the toggle help was outdated. I'm opened to suggestions, especially for the
 new "Zoom to specific time range" (http://screenshot/7f5bH894LDpNRwd).

Bug: http://b/168101815

Test: Load a capture, check all the keyboard and mouse wheel new commands.