### PR TITLE
Fix non-updated green line and button click

### DIFF
--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -69,6 +69,8 @@ void Button::SetMouseReleaseCallback(MouseReleaseCallback callback) {
 
 void Button::OnRelease() {
   CaptureViewElement::OnRelease();
+  if (!IsMouseOver()) return;
+
   if (mouse_release_callback_ != nullptr) {
     mouse_release_callback_(this);
   }

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -101,7 +101,8 @@ TEST(Button, MouseReleaseCallback) {
   EXPECT_EQ(mouse_released_called, mouse_released_called_expected);
 
   // Releasing outside of the button shouldn't call the callback.
-  std::ignore = button.HandleMouseEvent({CaptureViewElement::MouseEventType::kMouseLeave});
+  EXPECT_EQ(button.HandleMouseEvent({CaptureViewElement::MouseEventType::kMouseLeave}),
+            CaptureViewElement::EventResult::kIgnored);
   button.SetMouseReleaseCallback(callback);
   button.OnRelease();
   EXPECT_EQ(mouse_released_called, mouse_released_called_expected);

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -88,6 +88,8 @@ TEST(Button, MouseReleaseCallback) {
     if (button_param == &button) mouse_released_called++;
   };
   button.SetMouseReleaseCallback(callback);
+  std::ignore =
+      button.HandleMouseEvent({CaptureViewElement::MouseEventType::kMouseMove, button.GetPos()});
 
   uint32_t mouse_released_called_expected = 0;
   button.OnRelease();
@@ -95,6 +97,12 @@ TEST(Button, MouseReleaseCallback) {
   button.OnRelease();
   EXPECT_EQ(mouse_released_called, ++mouse_released_called_expected);
   button.SetMouseReleaseCallback(nullptr);
+  button.OnRelease();
+  EXPECT_EQ(mouse_released_called, mouse_released_called_expected);
+
+  // Releasing outside of the button shouldn't call the callback.
+  std::ignore = button.HandleMouseEvent({CaptureViewElement::MouseEventType::kMouseLeave});
+  button.SetMouseReleaseCallback(callback);
   button.OnRelease();
   EXPECT_EQ(mouse_released_called, mouse_released_called_expected);
 }

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -65,7 +65,7 @@ CaptureViewElement::EventResult CaptureViewElement::OnMouseMove(const Vec2& mous
     std::ignore = OnMouseEnter();
   }
 
-  // Ignoring the event, so mouse move is executed for its ancestors as well.
+  // Ignore this event and let it be handled by its ancestors as well.
   return EventResult::kIgnored;
 }
 

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -65,8 +65,7 @@ CaptureViewElement::EventResult CaptureViewElement::OnMouseMove(const Vec2& mous
     std::ignore = OnMouseEnter();
   }
 
-  mouse_pos_cur_ = mouse_pos;
-  // Ignoring the event, so mouse position is updated for its ancestors as well.
+  // Ignoring the event, so mouse move is executed for its ancestors as well.
   return EventResult::kIgnored;
 }
 
@@ -170,6 +169,7 @@ CaptureViewElement::EventResult CaptureViewElement::HandleMouseEvent(
     }
   }
 
+  mouse_pos_cur_ = mouse_pos;
   switch (mouse_event.event_type) {
     case MouseEventType::kMouseMove: {
       if (!mouse_event.left && !mouse_event.right && !mouse_event.middle) {

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -173,9 +173,9 @@ TEST(CaptureViewElement, IsMouseOver) {
   EXPECT_FALSE(child0->IsMouseOver());
   EXPECT_FALSE(child1->IsMouseOver());
 
-  // Moving as part of left-click dragging shouldn't modify mouse_over. This is because highlighting
-  // of some elements rely on that and we only want to highlight them when we move the mouse without
-  // any modifier.
+  // Mouse moving when left-clicking + dragging should not update IsMouseOver() flag. We are using
+  // this flag to highlight some elements, but we only want to highlight them when we move the mouse
+  // without clicking any button.
   EXPECT_EQ(container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
                 CaptureViewElement::MouseEventType::kMouseMove, kPosOnChild1, /*left=*/true}),
             CaptureViewElement::EventResult::kIgnored);

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -172,6 +172,16 @@ TEST(CaptureViewElement, IsMouseOver) {
   EXPECT_FALSE(container_elem.IsMouseOver());
   EXPECT_FALSE(child0->IsMouseOver());
   EXPECT_FALSE(child1->IsMouseOver());
+
+  // Moving as part of left-click dragging shouldn't modify mouse_over. This is because highlighting
+  // of some elements rely on that and we only want to highlight them when we move the mouse without
+  // any modifier.
+  EXPECT_EQ(container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
+                CaptureViewElement::MouseEventType::kMouseMove, kPosOnChild1, /*left=*/true}),
+            CaptureViewElement::EventResult::kIgnored);
+  EXPECT_FALSE(container_elem.IsMouseOver());
+  EXPECT_FALSE(child0->IsMouseOver());
+  EXPECT_FALSE(child1->IsMouseOver());
 }
 
 TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {


### PR DESCRIPTION
In this PR we are solving 2 different bugs.

-We are updating the mouse green line while dragging
(http://b/233731564).

- We are only calling the callback for buttons if the mouse is still
  over the buttons.

In addition we are adding tests for these 2 functionalities.

Test: Load a capture, test dragging and clicking in the buttons.