### PR TITLE
Extract parts of capture loading from `OrbitApp`

### DIFF
--- a/src/CaptureClient/CMakeLists.txt
+++ b/src/CaptureClient/CMakeLists.txt
@@ -12,13 +12,15 @@ target_include_directories(CaptureClient PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})
 
 target_sources(CaptureClient PUBLIC
+        include/CaptureClient/AbstractCaptureListener.h
         include/CaptureClient/ApiEventProcessor.h
         include/CaptureClient/AppInterface.h
         include/CaptureClient/CaptureClient.h
         include/CaptureClient/CaptureListener.h
         include/CaptureClient/CaptureEventProcessor.h
         include/CaptureClient/ClientCaptureOptions.h
-        include/CaptureClient/GpuQueueSubmissionProcessor.h)
+        include/CaptureClient/GpuQueueSubmissionProcessor.h
+        include/CaptureClient/LoadCapture.h)
 
 target_sources(CaptureClient PRIVATE
         ApiEventProcessor.cpp
@@ -26,6 +28,7 @@ target_sources(CaptureClient PRIVATE
         CaptureEventProcessor.cpp
         CompositeEventProcessor.cpp
         GpuQueueSubmissionProcessor.cpp
+        LoadCapture.cpp
         SaveToFileEventProcessor.cpp)
 
 target_link_libraries(CaptureClient PUBLIC

--- a/src/CaptureClient/LoadCapture.cpp
+++ b/src/CaptureClient/LoadCapture.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CaptureClient/LoadCapture.h"
+
+#include "CaptureClient/CaptureEventProcessor.h"
+#include "ClientProtos/user_defined_capture_info.pb.h"
+
+namespace orbit_capture_client {
+
+[[nodiscard]] ErrorMessageOr<CaptureListener::CaptureOutcome> LoadCapture(
+    CaptureListener* listener, orbit_capture_file::CaptureFile* capture_file,
+    std::atomic<bool>* capture_loading_cancellation_requested) {
+  {
+    ORBIT_SCOPED_TIMED_LOG("Loading capture from \"%s\"", capture_file->GetFilePath().string());
+    absl::flat_hash_set<uint64_t> frame_track_function_ids;
+
+    std::optional<uint64_t> section_index =
+        capture_file->FindSectionByType(orbit_capture_file::kSectionTypeUserData);
+    if (section_index.has_value()) {
+      orbit_client_protos::UserDefinedCaptureInfo user_defined_capture_info;
+      auto proto_input_stream = capture_file->CreateProtoSectionInputStream(section_index.value());
+      OUTCOME_TRY(proto_input_stream->ReadMessage(&user_defined_capture_info));
+      const auto& loaded_frame_track_function_ids =
+          user_defined_capture_info.frame_tracks_info().frame_track_function_ids();
+      frame_track_function_ids = {loaded_frame_track_function_ids.begin(),
+                                  loaded_frame_track_function_ids.end()};
+    }
+
+    std::unique_ptr<CaptureEventProcessor> capture_event_processor =
+        CaptureEventProcessor::CreateForCaptureListener(listener, capture_file->GetFilePath(),
+                                                        frame_track_function_ids);
+
+    auto capture_section_input_stream = capture_file->CreateCaptureSectionInputStream();
+    while (true) {
+      if (*capture_loading_cancellation_requested) {
+        return CaptureListener::CaptureOutcome::kCancelled;
+      }
+      orbit_grpc_protos::ClientCaptureEvent event;
+      OUTCOME_TRY(capture_section_input_stream->ReadMessage(&event));
+      capture_event_processor->ProcessEvent(event);
+      if (event.event_case() == orbit_grpc_protos::ClientCaptureEvent::kCaptureFinished) {
+        return CaptureListener::CaptureOutcome::kComplete;
+      }
+    }
+  }
+}
+
+}  // namespace orbit_capture_client

--- a/src/CaptureClient/include/CaptureClient/AbstractCaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/AbstractCaptureListener.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAPTURE_CLIENT_ABSTRACT_CAPTURE_LISTENER_H_
+#define CAPTURE_CLIENT_ABSTRACT_CAPTURE_LISTENER_H_
+
+#include "CaptureClient/CaptureListener.h"
+#include "ClientData/CaptureData.h"
+
+namespace orbit_capture_client {
+
+// TODO(b/234109592) Add a unit-test.
+// This is CRTP.  It provides implementations for CaptureListener virtual methods that are shared
+// between `OrbitApp` and `MizarData`. `Derived` should implement a public method
+// `orbit_client_data::CaptureData& Derived::GetMutableCaptureData()`
+template <typename Derived>
+class AbstractCaptureListener : public CaptureListener {
+ public:
+  virtual ~AbstractCaptureListener() = default;
+
+  void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) override {
+    GetMutableCaptureDataFromDerived().InsertAddressInfo(std::move(address_info));
+  }
+
+  void OnUniqueTracepointInfo(uint64_t tracepoint_id,
+                              orbit_client_data::TracepointInfo tracepoint_info) override {
+    GetMutableCaptureDataFromDerived().AddUniqueTracepointInfo(tracepoint_id,
+                                                               std::move(tracepoint_info));
+  }
+
+  void OnUniqueCallstack(uint64_t callstack_id,
+                         orbit_client_data::CallstackInfo callstack) override {
+    GetMutableCaptureDataFromDerived().AddUniqueCallstack(callstack_id, std::move(callstack));
+  }
+
+  void OnCallstackEvent(orbit_client_data::CallstackEvent callstack_event) override {
+    GetMutableCaptureDataFromDerived().AddCallstackEvent(callstack_event);
+  }
+
+  void OnThreadName(uint32_t thread_id, std::string thread_name) override {
+    GetMutableCaptureDataFromDerived().AddOrAssignThreadName(thread_id, std::move(thread_name));
+  }
+
+  void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo thread_state_slice) override {
+    GetMutableCaptureDataFromDerived().AddThreadStateSlice(thread_state_slice);
+  }
+
+  void OnTracepointEvent(orbit_client_data::TracepointEventInfo tracepoint_event_info) override {
+    uint32_t capture_process_id = GetMutableCaptureDataFromDerived().process_id();
+    bool is_same_pid_as_target = capture_process_id == tracepoint_event_info.pid();
+
+    GetMutableCaptureDataFromDerived().AddTracepointEventAndMapToThreads(
+        tracepoint_event_info.timestamp_ns(), tracepoint_event_info.tracepoint_id(),
+        tracepoint_event_info.pid(), tracepoint_event_info.tid(), tracepoint_event_info.cpu(),
+        is_same_pid_as_target);
+  }
+
+ private:
+  orbit_client_data::CaptureData& GetMutableCaptureDataFromDerived() {
+    return static_cast<Derived*>(this)->GetMutableCaptureData();
+  }
+};
+
+}  // namespace orbit_capture_client
+
+#endif  // CAPTURE_CLIENT_ABSTRACT_CAPTURE_LISTENER_H_

--- a/src/CaptureClient/include/CaptureClient/LoadCapture.h
+++ b/src/CaptureClient/include/CaptureClient/LoadCapture.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAPTURE_CLIENT_LOAD_CAPTURE_H_
+#define CAPTURE_CLIENT_LOAD_CAPTURE_H_
+
+#include "CaptureClient/CaptureListener.h"
+#include "CaptureFile/CaptureFile.h"
+
+namespace orbit_capture_client {
+
+// TODO(b/234110675) Add a smoke test
+[[nodiscard]] ErrorMessageOr<CaptureListener::CaptureOutcome> LoadCapture(
+    CaptureListener* listener, orbit_capture_file::CaptureFile* capture_file,
+    std::atomic<bool>* capture_loading_cancellation_requested);
+
+}  // namespace orbit_capture_client
+#endif  // CAPTURE_CLIENT_LOAD_CAPTURE_H_

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(ClientData PUBLIC
         include/ClientData/CallstackInfo.h
         include/ClientData/CallstackType.h
         include/ClientData/CaptureData.h
+        include/ClientData/CaptureDataHolder.h
         include/ClientData/DataManager.h
         include/ClientData/FunctionInfo.h
         include/ClientData/LinuxAddressInfo.h

--- a/src/ClientData/include/ClientData/CaptureDataHolder.h
+++ b/src/ClientData/include/ClientData/CaptureDataHolder.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_CAPTURE_DATA_HOLDER_H_
+#define CLIENT_DATA_CAPTURE_DATA_HOLDER_H_
+
+#include <functional>
+#include <memory>
+#include <optional>
+
+#include "ClientData/CaptureData.h"
+#include "OrbitBase/Logging.h"
+
+namespace orbit_client_data {
+
+class CaptureDataHolder {
+ public:
+  virtual ~CaptureDataHolder() = default;
+
+  // TODO(b/234095077): The two methods should not return ref, as capture_data_ doesn't
+  // necessarily store a value. They should either return a pointer, or
+  // `std::optional<std::reference_wrapper<CaptureData>>`
+  [[nodiscard]] virtual const CaptureData& GetCaptureData() const {
+    ORBIT_CHECK(HasCaptureData());
+    return *capture_data_;
+  }
+  // CallstackDataView needs OrbitApp::GetMutableCaptureData()
+  [[nodiscard]] virtual CaptureData& GetMutableCaptureData() {
+    ORBIT_CHECK(HasCaptureData());
+    return *capture_data_;
+  }
+
+  [[nodiscard]] virtual bool HasCaptureData() const { return static_cast<bool>(capture_data_); }
+
+ protected:
+  void ConstructCaptureData(const orbit_grpc_protos::CaptureStarted& capture_started,
+                            std::optional<std::filesystem::path> file_path,
+                            absl::flat_hash_set<uint64_t> frame_track_function_ids,
+                            CaptureData::DataSource data_source) {
+    capture_data_ = std::make_unique<orbit_client_data::CaptureData>(
+        capture_started, std::move(file_path), std::move(frame_track_function_ids), data_source);
+  }
+
+  void ResetCaptureData() { capture_data_.reset(); }
+
+ private:
+  // TODO(b/166767590): This is mostly written during capture by the capture thread on the
+  // CaptureListener parts of App, but may be read also during capturing by all threads.
+  // Currently, it is not properly synchronized (and thus it can't live at DataManager).
+  std::unique_ptr<orbit_client_data::CaptureData> capture_data_;
+};
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_CAPTURE_DATA_HOLDER_H_

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "ClientData/CaptureData.h"
+#include "ClientData/CaptureDataHolder.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ModuleData.h"
 #include "ClientData/PostProcessedSamplingData.h"
@@ -27,7 +28,7 @@
 
 namespace orbit_data_views {
 
-class AppInterface {
+class AppInterface : public orbit_client_data::CaptureDataHolder {
  public:
   virtual ~AppInterface() = default;
 
@@ -59,9 +60,6 @@ class AppInterface {
   [[nodiscard]] virtual std::vector<const orbit_client_data::TimerChain*> GetAllThreadTimerChains()
       const = 0;
 
-  // Function needed by CallstackDataView
-  [[nodiscard]] virtual orbit_client_data::CaptureData& GetMutableCaptureData() = 0;
-
   // Functions needed by SamplingReportsDataView
   [[nodiscard]] virtual bool IsFunctionSelected(
       const orbit_client_data::SampledFunction& func) const = 0;
@@ -71,8 +69,6 @@ class AppInterface {
   [[nodiscard]] virtual bool HasFrameTrackInCaptureData(
       uint64_t instrumented_function_id) const = 0;
 
-  [[nodiscard]] virtual bool HasCaptureData() const = 0;
-  [[nodiscard]] virtual const orbit_client_data::CaptureData& GetCaptureData() const = 0;
   [[nodiscard]] virtual const orbit_client_data::ModuleManager* GetModuleManager() const = 0;
   [[nodiscard]] virtual orbit_client_data::ModuleManager* GetMutableModuleManager() = 0;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "CallTreeView.h"
+#include "CaptureClient/AbstractCaptureListener.h"
 #include "CaptureClient/AppInterface.h"
 #include "CaptureClient/CaptureClient.h"
 #include "CaptureClient/CaptureListener.h"
@@ -88,7 +89,7 @@
 #include "Symbols/SymbolHelper.h"
 
 class OrbitApp final : public DataViewFactory,
-                       public orbit_capture_client::CaptureListener,
+                       public orbit_capture_client::AbstractCaptureListener<OrbitApp>,
                        public orbit_data_views::AppInterface,
                        public orbit_capture_client::CaptureControlInterface {
  public:
@@ -136,16 +137,6 @@ class OrbitApp final : public DataViewFactory,
 
   [[nodiscard]] bool IsLoadingCapture() const;
 
-  [[nodiscard]] bool HasCaptureData() const override { return capture_data_ != nullptr; }
-  [[nodiscard]] orbit_client_data::CaptureData& GetMutableCaptureData() override {
-    ORBIT_CHECK(capture_data_ != nullptr);
-    return *capture_data_;
-  }
-  [[nodiscard]] const orbit_client_data::CaptureData& GetCaptureData() const override {
-    ORBIT_CHECK(capture_data_ != nullptr);
-    return *capture_data_;
-  }
-
   [[nodiscard]] const orbit_client_data::ModuleManager* GetModuleManager() const override {
     ORBIT_CHECK(module_manager_ != nullptr);
     return module_manager_.get();
@@ -171,15 +162,7 @@ class OrbitApp final : public DataViewFactory,
   void OnCaptureFinished(const orbit_grpc_protos::CaptureFinished& capture_finished) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
-  void OnUniqueCallstack(uint64_t callstack_id,
-                         orbit_client_data::CallstackInfo callstack) override;
-  void OnCallstackEvent(orbit_client_data::CallstackEvent callstack_event) override;
-  void OnThreadName(uint32_t thread_id, std::string thread_name) override;
-  void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo thread_state_slice) override;
-  void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) override;
-  void OnUniqueTracepointInfo(uint64_t tracepoint_id,
-                              orbit_client_data::TracepointInfo tracepoint_info) override;
-  void OnTracepointEvent(orbit_client_data::TracepointEventInfo tracepoint_event_info) override;
+
   void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) override;
   void OnModulesSnapshot(uint64_t timestamp_ns,
                          std::vector<orbit_grpc_protos::ModuleInfo> module_infos) override;
@@ -448,13 +431,13 @@ class OrbitApp final : public DataViewFactory,
     data_manager_->set_memory_sampling_period_ms(memory_sampling_period_ms);
   }
   [[nodiscard]] uint64_t GetMemorySamplingPeriodMs() const {
-    return capture_data_->memory_sampling_period_ns() / 1'000'000;
+    return GetCaptureData().memory_sampling_period_ns() / 1'000'000;
   }
   void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb) {
     data_manager_->set_memory_warning_threshold_kb(memory_warning_threshold_kb);
   }
   [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const {
-    return capture_data_->memory_warning_threshold_kb();
+    return GetCaptureData().memory_warning_threshold_kb();
   }
 
   // TODO(kuebler): Move them to a separate controller at some point
@@ -683,11 +666,6 @@ class OrbitApp final : public DataViewFactory,
   orbit_client_data::ProcessData* process_ = nullptr;
 
   std::unique_ptr<FramePointerValidatorClient> frame_pointer_validator_client_;
-
-  // TODO(b/166767590): This is mostly written during capture by the capture thread on the
-  //  CaptureListener parts of App, but may be read also during capturing by all threads.
-  //  Currently, it is not properly synchronized (and thus it can't live at DataManager).
-  std::unique_ptr<orbit_client_data::CaptureData> capture_data_;
 
   orbit_gl::FrameTrackOnlineProcessor frame_track_online_processor_;
 


### PR DESCRIPTION
`OrbitApp` implements capture loading. As we plan to work
on Mizar (aka comparison tool), that should also be capable
of loading captures, some parts of the OrbitApp code need to
be made reusable.

Namely, this
1. introduces `AbstractCaptureListener` implementing some
of `CaptureListener` virtual methods.
2. Renames and moves the earlier static function
`LoadCaptureFromNewFormat`.

Tests: Manual
Bug: http://b/233869757