### PR TITLE
[REBASE] Don't pick when right-clicking in TimeGraph

### DIFF
--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -181,7 +181,6 @@ void GlCanvas::RightDown(int x, int y) {
 
   select_start_pos_world_ = select_stop_pos_world_ = mouse_click_pos_world_;
   is_selecting_ = true;
-  SetPickingMode(PickingMode::kClick);
 
   Orbit_ImGui_MouseButtonCallback(imgui_context_, 1, true);
   RequestRedraw();


### PR DESCRIPTION
In this PR, as Florian suggested we are not setting picking_mode when
right-clicking. After this, no timers and tracks will be selected while
right-clicking as it was with left-clicking, that was undesired.

But more importantly we are solving several issues caused by the
inconsistency that RightDown was producing a picking event, but RightUp
wasn't releasing it.

The most noticeable one was when right-clicking on the track-tab. This:

- Was making timers disappear for a second and make that Track as it was
always picked without releasing it. (Regression from 1.79)

- Was producing a Track jump after left clicking in other part of the
  screen (Always like that but we never realized).

Bug: http://b/234358251.

Test: Load a capture. Move tracks, test selection overlay, test right
clicking in different places.