### PR TITLE
Add symbol loading to `MizarData`

### DIFF
--- a/src/ClientSymbols/QSettingsBasedStorageManager.cpp
+++ b/src/ClientSymbols/QSettingsBasedStorageManager.cpp
@@ -18,59 +18,55 @@ constexpr const char* kModuleSymbolFileMappingSymbolFileKey =
 namespace orbit_client_symbols {
 
 std::vector<std::filesystem::path> QSettingsBasedStorageManager::LoadPaths() {
-  QSettings settings = MakeSettings();
-  const int size = settings.beginReadArray(kSymbolPathsSettingsKey);
+  const int size = settings_.beginReadArray(kSymbolPathsSettingsKey);
   std::vector<std::filesystem::path> paths{};
   paths.reserve(size);
   for (int i = 0; i < size; ++i) {
-    settings.setArrayIndex(i);
-    paths.emplace_back(settings.value(kDirectoryPathKey).toString().toStdString());
+    settings_.setArrayIndex(i);
+    paths.emplace_back(settings_.value(kDirectoryPathKey).toString().toStdString());
   }
-  settings.endArray();
+  settings_.endArray();
   return paths;
 }
 
 void QSettingsBasedStorageManager::SavePaths(absl::Span<const std::filesystem::path> paths) {
-  QSettings settings = MakeSettings();
-  settings.beginWriteArray(kSymbolPathsSettingsKey, static_cast<int>(paths.size()));
+  settings_.beginWriteArray(kSymbolPathsSettingsKey, static_cast<int>(paths.size()));
   for (size_t i = 0; i < paths.size(); ++i) {
-    settings.setArrayIndex(static_cast<int>(i));
-    settings.setValue(kDirectoryPathKey, QString::fromStdString(paths[i].string()));
+    settings_.setArrayIndex(static_cast<int>(i));
+    settings_.setValue(kDirectoryPathKey, QString::fromStdString(paths[i].string()));
   }
-  settings.endArray();
+  settings_.endArray();
 }
 
 void QSettingsBasedStorageManager::SaveModuleSymbolFileMappings(
     const ModuleSymbolFileMappings& mappings) {
-  QSettings settings = MakeSettings();
-  settings.beginWriteArray(kModuleSymbolFileMappingKey, static_cast<int>(mappings.size()));
+  settings_.beginWriteArray(kModuleSymbolFileMappingKey, static_cast<int>(mappings.size()));
   int index = 0;
   for (const auto& [module_path, symbol_file_path] : mappings) {
-    settings.setArrayIndex(index);
-    settings.setValue(kModuleSymbolFileMappingModuleKey, QString::fromStdString(module_path));
-    settings.setValue(kModuleSymbolFileMappingSymbolFileKey,
-                      QString::fromStdString(symbol_file_path.string()));
+    settings_.setArrayIndex(index);
+    settings_.setValue(kModuleSymbolFileMappingModuleKey, QString::fromStdString(module_path));
+    settings_.setValue(kModuleSymbolFileMappingSymbolFileKey,
+                       QString::fromStdString(symbol_file_path.string()));
     ++index;
   }
-  settings.endArray();
+  settings_.endArray();
 }
 
 [[nodiscard]] ModuleSymbolFileMappings
 QSettingsBasedStorageManager::LoadModuleSymbolFileMappings() {
-  QSettings settings = MakeSettings();
-  const int size = settings.beginReadArray(kModuleSymbolFileMappingKey);
+  const int size = settings_.beginReadArray(kModuleSymbolFileMappingKey);
   ModuleSymbolFileMappings mappings{};
   mappings.reserve(size);
   for (int i = 0; i < size; ++i) {
-    settings.setArrayIndex(i);
+    settings_.setArrayIndex(i);
 
     std::string module_path =
-        settings.value(kModuleSymbolFileMappingModuleKey).toString().toStdString();
+        settings_.value(kModuleSymbolFileMappingModuleKey).toString().toStdString();
     std::filesystem::path symbol_file_path = std::filesystem::path{
-        settings.value(kModuleSymbolFileMappingSymbolFileKey).toString().toStdString()};
+        settings_.value(kModuleSymbolFileMappingSymbolFileKey).toString().toStdString()};
     mappings[module_path] = symbol_file_path;
   }
-  settings.endArray();
+  settings_.endArray();
   return mappings;
 }
 

--- a/src/ClientSymbols/QSettingsBasedStorageManager.cpp
+++ b/src/ClientSymbols/QSettingsBasedStorageManager.cpp
@@ -18,7 +18,7 @@ constexpr const char* kModuleSymbolFileMappingSymbolFileKey =
 namespace orbit_client_symbols {
 
 std::vector<std::filesystem::path> QSettingsBasedStorageManager::LoadPaths() {
-  QSettings settings{};
+  QSettings settings = MakeSettings();
   const int size = settings.beginReadArray(kSymbolPathsSettingsKey);
   std::vector<std::filesystem::path> paths{};
   paths.reserve(size);
@@ -31,7 +31,7 @@ std::vector<std::filesystem::path> QSettingsBasedStorageManager::LoadPaths() {
 }
 
 void QSettingsBasedStorageManager::SavePaths(absl::Span<const std::filesystem::path> paths) {
-  QSettings settings{};
+  QSettings settings = MakeSettings();
   settings.beginWriteArray(kSymbolPathsSettingsKey, static_cast<int>(paths.size()));
   for (size_t i = 0; i < paths.size(); ++i) {
     settings.setArrayIndex(static_cast<int>(i));
@@ -42,7 +42,7 @@ void QSettingsBasedStorageManager::SavePaths(absl::Span<const std::filesystem::p
 
 void QSettingsBasedStorageManager::SaveModuleSymbolFileMappings(
     const ModuleSymbolFileMappings& mappings) {
-  QSettings settings{};
+  QSettings settings = MakeSettings();
   settings.beginWriteArray(kModuleSymbolFileMappingKey, static_cast<int>(mappings.size()));
   int index = 0;
   for (const auto& [module_path, symbol_file_path] : mappings) {
@@ -57,7 +57,7 @@ void QSettingsBasedStorageManager::SaveModuleSymbolFileMappings(
 
 [[nodiscard]] ModuleSymbolFileMappings
 QSettingsBasedStorageManager::LoadModuleSymbolFileMappings() {
-  QSettings settings{};
+  QSettings settings = MakeSettings();
   const int size = settings.beginReadArray(kModuleSymbolFileMappingKey);
   ModuleSymbolFileMappings mappings{};
   mappings.reserve(size);

--- a/src/ClientSymbols/QSettingsBasedStorageManagerTest.cpp
+++ b/src/ClientSymbols/QSettingsBasedStorageManagerTest.cpp
@@ -45,7 +45,7 @@ TEST(QSettingsBasedStorageManager, LoadAndSavePaths) {
 }
 
 TEST(QSettingsBasedStorageManager, LoadAndSaveModuleSymbolFileMappings) {
-  QCoreApplication::setOrganizationDomain(kOrgName);
+  QCoreApplication::setOrganizationName(kOrgName);
   QCoreApplication::setApplicationName(
       "QSettingsBasedStorageManager.LoadAndSaveModuleSymbolFileMappings");
 

--- a/src/ClientSymbols/QSettingsBasedStorageManagerTest.cpp
+++ b/src/ClientSymbols/QSettingsBasedStorageManagerTest.cpp
@@ -22,7 +22,7 @@ constexpr const char* kOrgName = "The Orbit Authors";
 namespace orbit_client_symbols {
 
 TEST(QSettingsBasedStorageManager, LoadAndSavePaths) {
-  QCoreApplication::setOrganizationDomain(kOrgName);
+  QCoreApplication::setOrganizationName(kOrgName);
   QCoreApplication::setApplicationName("QSettingsBasedStorageManager.LoadAndSavePaths");
 
   {  // clear before test;

--- a/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
+++ b/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
@@ -5,16 +5,34 @@
 #ifndef CLIENT_SYMBOLS_Q_SETTINGS_BASED_STORAGE_MANAGER_H_
 #define CLIENT_SYMBOLS_Q_SETTINGS_BASED_STORAGE_MANAGER_H_
 
+#include <QCoreApplication>
+#include <QSettings>
+#include <QString>
+#include <utility>
+
 #include "ClientSymbols/PersistentStorageManager.h"
 
 namespace orbit_client_symbols {
 
 class QSettingsBasedStorageManager : public PersistentStorageManager {
  public:
+  QSettingsBasedStorageManager()
+      : organization_(QCoreApplication::organizationName()),
+        application_(QCoreApplication::applicationName()) {}
+
+  QSettingsBasedStorageManager(QString organization, QString application)
+      : organization_(std::move(organization)), application_(std::move(application)) {}
+
   void SavePaths(absl::Span<const std::filesystem::path> paths) override;
   [[nodiscard]] std::vector<std::filesystem::path> LoadPaths() override;
   void SaveModuleSymbolFileMappings(const ModuleSymbolFileMappings& mappings) override;
   [[nodiscard]] ModuleSymbolFileMappings LoadModuleSymbolFileMappings() override;
+
+ private:
+  QSettings MakeSettings() { return QSettings{organization_, application_}; }
+
+  QString organization_;
+  QString application_;
 };
 
 }  // namespace orbit_client_symbols

--- a/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
+++ b/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
@@ -18,7 +18,8 @@ class QSettingsBasedStorageManager : public PersistentStorageManager {
  public:
   QSettingsBasedStorageManager()
       : organization_(QCoreApplication::organizationName()),
-        application_(QCoreApplication::applicationName()) {}
+        application_(QCoreApplication::applicationName()),
+        settings_{organization_, application_} {}
 
   QSettingsBasedStorageManager(QString organization, QString application)
       : organization_(std::move(organization)), application_(std::move(application)) {}
@@ -29,10 +30,9 @@ class QSettingsBasedStorageManager : public PersistentStorageManager {
   [[nodiscard]] ModuleSymbolFileMappings LoadModuleSymbolFileMappings() override;
 
  private:
-  QSettings MakeSettings() { return QSettings{organization_, application_}; }
-
   QString organization_;
   QString application_;
+  QSettings settings_;
 };
 
 }  // namespace orbit_client_symbols

--- a/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
+++ b/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
@@ -17,12 +17,13 @@ namespace orbit_client_symbols {
 class QSettingsBasedStorageManager : public PersistentStorageManager {
  public:
   QSettingsBasedStorageManager()
-      : organization_(QCoreApplication::organizationName()),
-        application_(QCoreApplication::applicationName()),
-        settings_{organization_, application_} {}
+      : QSettingsBasedStorageManager(QCoreApplication::organizationName(),
+                                     QCoreApplication::applicationName()) {}
 
   QSettingsBasedStorageManager(QString organization, QString application)
-      : organization_(std::move(organization)), application_(std::move(application)) {}
+      : organization_(std::move(organization)),
+        application_(std::move(application)),
+        settings_{organization_, application_} {}
 
   void SavePaths(absl::Span<const std::filesystem::path> paths) override;
   [[nodiscard]] std::vector<std::filesystem::path> LoadPaths() override;

--- a/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
+++ b/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
@@ -20,10 +20,8 @@ class QSettingsBasedStorageManager : public PersistentStorageManager {
       : QSettingsBasedStorageManager(QCoreApplication::organizationName(),
                                      QCoreApplication::applicationName()) {}
 
-  QSettingsBasedStorageManager(QString organization, QString application)
-      : organization_(std::move(organization)),
-        application_(std::move(application)),
-        settings_{organization_, application_} {}
+  QSettingsBasedStorageManager(const QString& organization, const QString& application)
+      : settings_{organization, application} {}
 
   void SavePaths(absl::Span<const std::filesystem::path> paths) override;
   [[nodiscard]] std::vector<std::filesystem::path> LoadPaths() override;
@@ -31,8 +29,6 @@ class QSettingsBasedStorageManager : public PersistentStorageManager {
   [[nodiscard]] ModuleSymbolFileMappings LoadModuleSymbolFileMappings() override;
 
  private:
-  QString organization_;
-  QString application_;
   QSettings settings_;
 };
 

--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -39,7 +39,8 @@ int main(int argc, char* argv[]) {
     const orbit_client_data::CallstackInfo* callstack =
         callstack_data.GetCallstack(event.callstack_id());
     for (auto addr : callstack->frames()) {
-      names.insert(data.GetFunctionNameFromAddress(addr).value());
+      std::optional<std::string> name = data.GetFunctionNameFromAddress(addr);
+      if (name.has_value()) names.insert(name.value());
     }
   }
 

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -17,10 +17,13 @@ target_sources(MizarData PRIVATE
 
 
 target_link_libraries(
-        MizarData PUBLIC CaptureClient
-        PRIVATE 
-                CaptureFile
+        MizarData 
+        PUBLIC  CaptureClient 
+                OrbitPaths
+                Symbols
+        PRIVATE CaptureFile
                 ClientData
+                ClientSymbols
                 OrbitBase)
 
 add_executable(MizarDataTests)

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -4,6 +4,7 @@
 
 #include "MizarData/MizarData.h"
 
+#include <QStringLiteral>
 #include <memory>
 
 #include "ClientData/ModuleAndFunctionLookup.h"

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -235,36 +235,18 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
       module_path.string()));
 }
 
-ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsInCache(
-    const fs::path& module_path,
-    std::function<ErrorMessageOr<void>(const std::filesystem::path&)> verify) const {
-  ORBIT_SCOPE_FUNCTION;
-  fs::path cache_file_path = GenerateCachedFileName(module_path);
-  std::error_code error;
-  bool exists = fs::exists(cache_file_path, error);
-  if (error) {
-    return ErrorMessage{
-        absl::StrFormat("Unable to stat \"%s\": %s", cache_file_path.string(), error.message())};
-  }
-  if (!exists) {
-    return ErrorMessage(
-        absl::StrFormat("Unable to find symbols in cache for module \"%s\"", module_path.string()));
-  }
-  OUTCOME_TRY(verify(cache_file_path));
-  return cache_file_path;
-}
-
 ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsInCache(const fs::path& module_path,
                                                           const std::string& build_id) const {
-  return FindSymbolsInCache(module_path, [&build_id](const std::filesystem::path& cache_file_path) {
-    return VerifySymbolsFile(cache_file_path, build_id);
-  });
+  return FindSymbolsInCacheImpl(module_path,
+                                [&build_id](const std::filesystem::path& cache_file_path) {
+                                  return VerifySymbolsFile(cache_file_path, build_id);
+                                });
 }
 
 ErrorMessageOr<void> SymbolHelper::VerifySymbolsFile(const std::filesystem::path& symbols_path,
                                                      uint64_t expected_file_size) {
-  if (const uint64_t actual_file_size = std::filesystem::file_size(symbols_path);
-      actual_file_size != expected_file_size) {
+  OUTCOME_TRY(const uint64_t actual_file_size, orbit_base::FileSize(symbols_path));
+  if (actual_file_size != expected_file_size) {
     return ErrorMessage(absl::StrFormat("Symbol file size doesn't match. Expected: %u, Actual: %u ",
                                         expected_file_size, actual_file_size));
   }
@@ -273,10 +255,10 @@ ErrorMessageOr<void> SymbolHelper::VerifySymbolsFile(const std::filesystem::path
 
 ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsInCache(const fs::path& module_path,
                                                           uint64_t expected_file_size) const {
-  return FindSymbolsInCache(module_path,
-                            [&expected_file_size](const std::filesystem::path& cache_file_path) {
-                              return VerifySymbolsFile(cache_file_path, expected_file_size);
-                            });
+  return FindSymbolsInCacheImpl(
+      module_path, [&expected_file_size](const std::filesystem::path& cache_file_path) {
+        return VerifySymbolsFile(cache_file_path, expected_file_size);
+      });
 }
 
 ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsFromFile(

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -342,6 +342,20 @@ TEST(SymbolHelper, GenerateCachedFileName) {
 TEST(SymbolHelper, VerifySymbolsFile) {
   const std::filesystem::path testdata_directory = orbit_test::GetTestdataDir();
   {
+    // a file of matching file size
+    fs::path symbols_file = testdata_directory / "no_symbols_elf.debug";
+    const uint64_t correct_expected_size = 45856;
+    const auto result = SymbolHelper::VerifySymbolsFile(symbols_file, correct_expected_size);
+    EXPECT_THAT(result, HasNoError());
+  }
+  {
+    // a file of mis-matching file size
+    fs::path symbols_file = testdata_directory / "no_symbols_elf.debug";
+    const uint64_t incorrect_expected_size = 123456;
+    const auto result = SymbolHelper::VerifySymbolsFile(symbols_file, incorrect_expected_size);
+    EXPECT_THAT(result, HasError("file size doesn't match"));
+  }
+  {
     // valid elf file containing symbols and matching build id
     fs::path symbols_file = testdata_directory / "no_symbols_elf.debug";
     std::string build_id = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -30,18 +30,21 @@ class SymbolHelper {
       : cache_directory_(std::move(cache_directory)),
         structured_debug_directories_{std::move(structured_debug_directories)} {};
 
-  [[nodiscard]] ErrorMessageOr<std::filesystem::path> FindSymbolsFileLocally(
+  ErrorMessageOr<std::filesystem::path> FindSymbolsFileLocally(
       const std::filesystem::path& module_path, const std::string& build_id,
       const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type,
       absl::Span<const std::filesystem::path> paths) const;
-  [[nodiscard]] ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(
-      const std::filesystem::path& module_path, const std::string& build_id) const;
-  [[nodiscard]] static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
+  ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(const std::filesystem::path& module_path,
+                                                           const std::string& build_id) const;
+  ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(const std::filesystem::path& module_path,
+                                                           uint64_t expected_file_size) const;
+  static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
       const std::filesystem::path& file_path,
       const orbit_object_utils::ObjectFileInfo& object_file_info);
-  [[nodiscard]] static ErrorMessageOr<void> VerifySymbolsFile(
-      const std::filesystem::path& symbols_path, const std::string& build_id);
-
+  static ErrorMessageOr<void> VerifySymbolsFile(const std::filesystem::path& symbols_path,
+                                                const std::string& build_id);
+  static ErrorMessageOr<void> VerifySymbolsFile(const std::filesystem::path& symbols_path,
+                                                uint64_t expected_file_size);
   [[nodiscard]] std::filesystem::path GenerateCachedFileName(
       const std::filesystem::path& file_path) const;
 
@@ -57,6 +60,9 @@ class SymbolHelper {
       const std::filesystem::path& debug_directory, std::string_view build_id);
 
  private:
+  ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(
+      const std::filesystem::path& module_path,
+      std::function<ErrorMessageOr<void>(const std::filesystem::path&)>) const;
   const std::filesystem::path cache_directory_;
   const std::vector<std::filesystem::path> structured_debug_directories_;
 };

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -63,22 +63,7 @@ class SymbolHelper {
  private:
   template <typename Verifier>
   ErrorMessageOr<std::filesystem::path> FindSymbolsInCacheImpl(
-      const std::filesystem::path& module_path, Verifier verify) const {
-    ORBIT_SCOPE_FUNCTION;
-    std::filesystem::path cache_file_path = GenerateCachedFileName(module_path);
-    std::error_code error;
-    bool exists = std::filesystem::exists(cache_file_path, error);
-    if (error) {
-      return ErrorMessage{
-          absl::StrFormat("Unable to stat \"%s\": %s", cache_file_path.string(), error.message())};
-    }
-    if (!exists) {
-      return ErrorMessage(absl::StrFormat("Unable to find symbols in cache for module \"%s\"",
-                                          module_path.string()));
-    }
-    OUTCOME_TRY(verify(cache_file_path));
-    return cache_file_path;
-  }
+      const std::filesystem::path& module_path, Verifier&& verify) const;
 
   const std::filesystem::path cache_directory_;
   const std::vector<std::filesystem::path> structured_debug_directories_;


### PR DESCRIPTION
As Mizar needs to work with Windows captures void
of `LinuxAddressInfo`s, it is necessary to add symbol
loading from symbol files.

This adds automatic loading of symbols from the folders
Orbit App is configured to search for them and from
the caches of Orbit app.

We will have to work with binaries with no build ids.
Therefore, Mizar resorts to file size check instead.
The corresponding functionality is added to `Symbolhelper`.

Tests: Manual, Unit
Bug: http://b/233856442