### PR TITLE
Save which symbol loading resulted in an error

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1747,9 +1747,12 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::RetrieveModuleAndLoadSymbols(
     metric.SetStatusCode(OrbitLogEvent::INTERNAL_ERROR);
     return {ErrorMessage{absl::StrFormat("Module \"%s\" was not found", module_path)}};
   }
-  if (module_data->is_loaded()) return {outcome::success()};
 
   const auto module_id = std::make_pair(module_data->file_path(), module_data->build_id());
+
+  modules_with_symbol_loading_error_.erase(module_id);
+
+  if (module_data->is_loaded()) return {outcome::success()};
 
   const auto it = symbols_currently_loading_.find(module_id);
   if (it != symbols_currently_loading_.end()) {
@@ -1772,7 +1775,6 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::RetrieveModuleAndLoadSymbols(
     symbols_currently_loading_.erase(module_id);
   });
 
-  modules_with_symbol_loading_error_.erase(module_id);
   symbols_currently_loading_.emplace(module_id, load_result);
 
   return load_result;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -632,6 +632,7 @@ class OrbitApp final : public DataViewFactory,
   // if a module ID is contained in symbol_files_currently_downloading_, it is also contained in
   // symbol_files_currently_being_retrieved_.
   // ONLY access this from the main thread.
+  // TODO(b/234586730) Replace pair with struct
   absl::flat_hash_map<std::pair<std::string, std::string>,
                       orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
       symbol_files_currently_being_retrieved_;
@@ -642,12 +643,14 @@ class OrbitApp final : public DataViewFactory,
   // symbol_files_currently_being_retrieved_ or symbol_files_currently_downloading_, it is also
   // contained in symbols_currently_loading_.
   // ONLY access this from the main thread.
+  // TODO(b/234586730) Replace pair with struct
   absl::flat_hash_map<std::pair<std::string, std::string>, orbit_base::Future<ErrorMessageOr<void>>>
       symbols_currently_loading_;
 
-  // Set of modules where an symbol loading error has occurred. The module identifier is file path
-  // and build ID.
+  // Set of modules where a symbol loading error has occurred. The module identifier consists of
+  // file path and build ID.
   // ONLY access this from the main thread.
+  // TODO(b/234586730) Replace pair with struct
   absl::flat_hash_set<std::pair<std::string, std::string>> modules_with_symbol_loading_error_;
 
   orbit_string_manager::StringManager string_manager_;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -645,6 +645,11 @@ class OrbitApp final : public DataViewFactory,
   absl::flat_hash_map<std::pair<std::string, std::string>, orbit_base::Future<ErrorMessageOr<void>>>
       symbols_currently_loading_;
 
+  // Set of modules where an symbol loading error has occurred. The module identifier is file path
+  // and build ID.
+  // ONLY access this from the main thread.
+  absl::flat_hash_set<std::pair<std::string, std::string>> modules_with_symbol_loading_error_;
+
   orbit_string_manager::StringManager string_manager_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
 


### PR DESCRIPTION
This adds a set to OrbitApp of all the modules where symbol loading
resulted in an error and uses that information in
`OrbitApp::GetSymbolLoadingStateForModule`.

Test: Start with --devmode, attempt to load symbols for a module where
symbols are missing. After dismissing the error, the module list
displays "error" (with auto symbol loading, there will not be an error
pop up anymore, but only the "error" in the list).
Bug: http://b/234581674