### PR TITLE
Introspection thread states

### DIFF
--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
@@ -13,6 +13,7 @@
 #include "LinuxTracing/TracerListener.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
+#include "OrbitBase/ThreadUtils.h"
 
 namespace orbit_linux_tracing {
 
@@ -54,7 +55,7 @@ void SwitchesStatesNamesVisitor::Visit(uint64_t /*event_timestamp*/,
 }
 
 bool SwitchesStatesNamesVisitor::TidMatchesPidFilter(pid_t tid) {
-  if (thread_state_pid_filter_ == kPidFilterNoThreadState) {
+  if (thread_state_pid_filters_.empty()) {
     return false;
   }
 
@@ -63,7 +64,13 @@ bool SwitchesStatesNamesVisitor::TidMatchesPidFilter(pid_t tid) {
     return false;
   }
 
-  return tid_to_pid_it->second == thread_state_pid_filter_;
+  for (const pid_t thread_state_pid_filter : thread_state_pid_filters_) {
+    if (tid_to_pid_it->second == thread_state_pid_filter) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 std::optional<pid_t> SwitchesStatesNamesVisitor::GetPidOfTid(pid_t tid) {

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.h
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.h
@@ -31,8 +31,8 @@ namespace orbit_linux_tracing {
 // and is updated with ForkPerfEvents (and also ExitPerfEvents, see Visit(const ExitPerfEvent&)).
 // For thread states, we are able to collect partial slices at the beginning and at the end of the
 // capture, hence the ProcessInitialState and ProcessRemainingOpenStates methods.
-// Also, we only process thread states of the process with pid specified with
-// SetThreadStatePidFilters (so that we can collect thread states only for the process we are
+// Also, we only process thread states of the processes with pids specified with
+// SetThreadStatePidFilters (so that we can collect thread states only for the processes we are
 // profiling). For this we also need the system-wide association between tids and pids.
 class SwitchesStatesNamesVisitor : public PerfEventVisitor {
  public:

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.h
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.h
@@ -32,7 +32,7 @@ namespace orbit_linux_tracing {
 // For thread states, we are able to collect partial slices at the beginning and at the end of the
 // capture, hence the ProcessInitialState and ProcessRemainingOpenStates methods.
 // Also, we only process thread states of the process with pid specified with
-// SetThreadStatePidFilter (so that we can collect thread states only for the process we are
+// SetThreadStatePidFilters (so that we can collect thread states only for the process we are
 // profiling). For this we also need the system-wide association between tids and pids.
 class SwitchesStatesNamesVisitor : public PerfEventVisitor {
  public:
@@ -47,7 +47,9 @@ class SwitchesStatesNamesVisitor : public PerfEventVisitor {
   void SetProduceSchedulingSlices(bool produce_scheduling_slices) {
     produce_scheduling_slices_ = produce_scheduling_slices;
   }
-  void SetThreadStatePidFilter(pid_t pid) { thread_state_pid_filter_ = pid; }
+  void SetThreadStatePidFilters(std::set<pid_t> pids) {
+    thread_state_pid_filters_ = {pids.begin(), pids.end()};
+  }
 
   void ProcessInitialTidToPidAssociation(pid_t tid, pid_t pid);
   void Visit(uint64_t event_timestamp, const ForkPerfEventData& event_data) override;
@@ -73,8 +75,7 @@ class SwitchesStatesNamesVisitor : public PerfEventVisitor {
 
   bool TidMatchesPidFilter(pid_t tid);
   std::optional<pid_t> GetPidOfTid(pid_t tid);
-  static constexpr pid_t kPidFilterNoThreadState = -1;
-  pid_t thread_state_pid_filter_ = kPidFilterNoThreadState;
+  std::vector<pid_t> thread_state_pid_filters_;
   absl::flat_hash_map<pid_t, pid_t> tid_to_pid_association_;
 
   ContextSwitchManager switch_manager_;

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -513,6 +513,8 @@ void TracerImpl::InitSwitchesStatesNamesVisitor() {
   switches_states_names_visitor_ = std::make_unique<SwitchesStatesNamesVisitor>(listener_);
   switches_states_names_visitor_->SetProduceSchedulingSlices(trace_context_switches_);
   if (trace_thread_state_) {
+    // Filter thread states using target process id. We also send OrbitService's thread states when
+    // introspection is enabled for more context on what our own threads are doing when capturing.
     std::set<pid_t> pids = {target_pid_};
     if (introspection_enabled_) {
       pids.insert(orbit_base::GetCurrentProcessIdNative());

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -137,6 +137,7 @@ class TracerImpl : public Tracer {
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 5000;
 
   bool trace_context_switches_;
+  bool introspection_enabled_;
   pid_t target_pid_;
   std::optional<uint64_t> sampling_period_ns_;
   uint16_t stack_dump_size_;


### PR DESCRIPTION
Send OrbitService's thread states when introspection is enabled so that
we have more context on what our own threads are doing when capturing.
SwitchesStatesNamesVisitor now filters multiple process ids.

Tests: Launch a capture with introspection enabled and see that we now have
thread states. Note that OrbitService threads that don't have instrumented scopes
are displayed as if they were part of the target process (b/234029571), this should 
be fixed at some point, but is not trivial. This is not critical as the feature is internal. 