### PR TITLE
Relax check for timers in manual instrumentation test. [Release] 

### DIFF
--- a/contrib/automation_tests/orbit_manual_instrumentation.py
+++ b/contrib/automation_tests/orbit_manual_instrumentation.py
@@ -62,7 +62,10 @@ def main(argv):
                      expected_minimum_track_count=3,
                      expected_maximum_track_count=4),
         ToggleCollapsedStateOfAllTracks(),
-        CheckTimers(track_name_filter="OrbitThread_*")
+        # For the same reason explained above 'FilterTracks' we only check if at leat one track
+        # contains timers; strictly speaking there are three tracks with timers and there might
+        # be anotherone without timers.
+        CheckTimers(track_name_filter="OrbitThread_*", require_all=False)
     ] + [
         VerifyScopeTypeAndHitCount(scope_name=name, scope_type=type)
         for name, type in zip(scope_names, scope_types)


### PR DESCRIPTION
Some of the threads we filter for do not contain timers since they are
created by the lib Orbit injects into the process.
Strictly speaking we could test for exactly three of the threads
containing timers. Since the code is already there and we loose nothing
of value we just check for at least one of the track containing timers.
Details are in the bug.

Test: Local run.
Bug: b/229709116