### PR TITLE
Fix Load Symbols available bug

### DIFF
--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -157,7 +157,7 @@ DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action,
 
   bool at_least_one_module_can_be_loaded =
       std::any_of(modules.begin(), modules.end(), [this](const ModuleData* module) {
-        return !app_->IsSymbolLoadingInProgressForModule(module);
+        return !module->is_loaded() && !app_->IsSymbolLoadingInProgressForModule(module);
       });
 
   bool at_least_one_module_is_downloading =


### PR DESCRIPTION
(only in devmode)
This bug fixes "Load Symbols" being available in the context menu when
it shouldn't.

Test: Start with --devmode, Load Symbols, after successful load, the
context menu entry is grayed out.
Bug: http:/b/234706544