### PR TITLE
Scale consistently in TimeGraph

### DIFF
--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -121,10 +121,10 @@ void Button::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& /*tex
 void Button::DrawSymbol(PrimitiveAssembler& primitive_assembler) {
   const Color kSymbolBaseColor(191, 191, 192, 255);
   const Color kSymbolHighlightColor(255, 255, 255, 255);
-  // Symbol wide and the padding are related to the size of the button, so they can scale
+  // Symbol width and the padding are related to the size of the button, so they can scale
   // proportionally if the button size changes.
   const float symbol_padding_size = GetWidth() / 5.f;
-  const float symbol_wide = GetWidth() / 5.f;
+  const float symbol_width = GetWidth() / 5.f;
 
   Color symbol_color = IsMouseOver() ? kSymbolHighlightColor : kSymbolBaseColor;
 
@@ -132,15 +132,15 @@ void Button::DrawSymbol(PrimitiveAssembler& primitive_assembler) {
     case SymbolType::kNoSymbol:
       break;
     case SymbolType::kPlusSymbol:
-      primitive_assembler.AddBox(MakeBox({GetPos()[0] + (GetWidth() - symbol_wide) / 2.f,
+      primitive_assembler.AddBox(MakeBox({GetPos()[0] + (GetWidth() - symbol_width) / 2.f,
                                           GetPos()[1] + symbol_padding_size},
-                                         {symbol_wide, GetHeight() - 2 * symbol_padding_size}),
+                                         {symbol_width, GetHeight() - 2 * symbol_padding_size}),
                                  GlCanvas::kZValueButton, symbol_color, shared_from_this());
       [[fallthrough]];
     case SymbolType::kMinusSymbol:
       primitive_assembler.AddBox(MakeBox({GetPos()[0] + symbol_padding_size,
-                                          GetPos()[1] + (GetHeight() - symbol_wide) / 2.f},
-                                         {GetWidth() - 2 * symbol_padding_size, symbol_wide}),
+                                          GetPos()[1] + (GetHeight() - symbol_width) / 2.f},
+                                         {GetWidth() - 2 * symbol_padding_size, symbol_width}),
                                  GlCanvas::kZValueButton, symbol_color, shared_from_this());
       break;
     default:

--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -121,8 +121,10 @@ void Button::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& /*tex
 void Button::DrawSymbol(PrimitiveAssembler& primitive_assembler) {
   const Color kSymbolBaseColor(191, 191, 192, 255);
   const Color kSymbolHighlightColor(255, 255, 255, 255);
-  const float kSymbolPaddingSize = 3.f;
-  const float kSymbolWide = 3.f;
+  // Symbol wide and the padding are related to the size of the button, so they can scale
+  // proportionally if the button size changes.
+  const float symbol_padding_size = GetWidth() / 5.f;
+  const float symbol_wide = GetWidth() / 5.f;
 
   Color symbol_color = IsMouseOver() ? kSymbolHighlightColor : kSymbolBaseColor;
 
@@ -130,15 +132,15 @@ void Button::DrawSymbol(PrimitiveAssembler& primitive_assembler) {
     case SymbolType::kNoSymbol:
       break;
     case SymbolType::kPlusSymbol:
-      primitive_assembler.AddBox(MakeBox({GetPos()[0] + (GetWidth() - kSymbolWide) / 2.f,
-                                          GetPos()[1] + kSymbolPaddingSize},
-                                         {kSymbolWide, GetHeight() - 2 * kSymbolPaddingSize}),
+      primitive_assembler.AddBox(MakeBox({GetPos()[0] + (GetWidth() - symbol_wide) / 2.f,
+                                          GetPos()[1] + symbol_padding_size},
+                                         {symbol_wide, GetHeight() - 2 * symbol_padding_size}),
                                  GlCanvas::kZValueButton, symbol_color, shared_from_this());
       [[fallthrough]];
     case SymbolType::kMinusSymbol:
-      primitive_assembler.AddBox(MakeBox({GetPos()[0] + kSymbolPaddingSize,
-                                          GetPos()[1] + (GetHeight() - kSymbolWide) / 2.f},
-                                         {GetWidth() - 2 * kSymbolPaddingSize, kSymbolWide}),
+      primitive_assembler.AddBox(MakeBox({GetPos()[0] + symbol_padding_size,
+                                          GetPos()[1] + (GetHeight() - symbol_wide) / 2.f},
+                                         {GetWidth() - 2 * symbol_padding_size, symbol_wide}),
                                  GlCanvas::kZValueButton, symbol_color, shared_from_this());
       break;
     default:

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -740,7 +740,7 @@ void CaptureWindow::RenderSelectionOverlay() {
                                        ? TextRenderer::HAlign::Left
                                        : TextRenderer::HAlign::Right;
   TextRenderer::TextFormatting formatting;
-  formatting.font_size = time_graph_->GetLayout().CalculateZoomedFontSize();
+  formatting.font_size = time_graph_->GetLayout().GetFontSize();
   formatting.color = Color(255, 255, 255, 255);
   formatting.halign = alignment;
 

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -226,7 +226,7 @@ void FrameTrack::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& t
   std::string avg_time =
       orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats_.ComputeAverageTimeNs()));
   std::string label = absl::StrFormat("Avg: %s", avg_time);
-  uint32_t font_size = layout_->CalculateZoomedFontSize();
+  uint32_t font_size = layout_->GetFontSize();
   float string_width = text_renderer.GetStringWidth(label.c_str(), font_size);
   Vec2 white_text_box_position(pos[0] + layout_->GetRightMargin(), y);
 

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -264,12 +264,12 @@ void GlVerticalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
   const Color dark_border_color = GetDarkerColor(bar_color_);
 
   // Background
-  DrawBackground(primitive_assembler, 0, 0, GetSliderWide(), bar_pixel_len);
+  DrawBackground(primitive_assembler, 0, 0, GetSliderWidth(), bar_pixel_len);
 
   float start = ceilf(pos_ratio_ * non_slider_height);
 
   ShadingDirection shading_direction = ShadingDirection::kRightToLeft;
-  DrawSlider(primitive_assembler, 0, start, GetSliderWide(), slider_height, shading_direction);
+  DrawSlider(primitive_assembler, 0, start, GetSliderWidth(), slider_height, shading_direction);
 
   primitive_assembler.PopTranslation();
 }
@@ -291,12 +291,12 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
   float slider_width = ceilf(length_ratio_ * bar_pixel_len);
   float non_slider_width = bar_pixel_len - slider_width;
 
-  DrawBackground(primitive_assembler, 0, 0, bar_pixel_len, GetSliderWide());
+  DrawBackground(primitive_assembler, 0, 0, bar_pixel_len, GetSliderWidth());
 
   float start = floorf(pos_ratio_ * non_slider_width);
 
   ShadingDirection shading_direction = ShadingDirection::kTopToBottom;
-  DrawSlider(primitive_assembler, start, 0, slider_width, GetSliderWide(), shading_direction);
+  DrawSlider(primitive_assembler, start, 0, slider_width, GetSliderWidth(), shading_direction);
 
   const float kEpsilon = 0.0001f;
 
@@ -306,8 +306,8 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
   // and there is no margin between the border and the triangle to make it as big as possible.
   // On the other side, there is a 1 pixel margin between the triangle and the vertical line
   float tri_size = GetSliderResizeMargin() - 3.f;
-  tri_size = std::min(tri_size, GetSliderWide() - tri_size * kHeightFactor - 2.f);
-  const float tri_y_offset = (GetSliderWide() - tri_size * kHeightFactor) / 2.f;
+  tri_size = std::min(tri_size, GetSliderWidth() - tri_size * kHeightFactor - 2.f);
+  const float tri_y_offset = (GetSliderWidth() - tri_size * kHeightFactor) / 2.f;
   const Color kWhite = GetLighterColor(GetLighterColor(bar_color_));
   const float z = GlCanvas::kZValueButton + 2 * kEpsilon;
   const float x = start;
@@ -319,7 +319,7 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
                Vec2(x + width - tri_size - 2.f, tri_y_offset)),
       z, kWhite, shared_from_this());
   primitive_assembler.AddVerticalLine(Vec2(x + width - GetSliderResizeMargin(), 2.f),
-                                      GetSliderWide() - 4.f, z, kWhite, shared_from_this());
+                                      GetSliderWidth() - 4.f, z, kWhite, shared_from_this());
 
   primitive_assembler.AddTriangle(
       Triangle(Vec2(x + tri_size + 2.f, kHeightFactor * tri_size + tri_y_offset),
@@ -327,19 +327,19 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
                Vec2(x + 2.f, tri_y_offset + kHeightFactor / 2.f * tri_size)),
       z, kWhite, shared_from_this());
   primitive_assembler.AddVerticalLine(Vec2(x + GetSliderResizeMargin() + 1, 2.f),
-                                      GetSliderWide() - 4.f, z, kWhite, shared_from_this());
+                                      GetSliderWidth() - 4.f, z, kWhite, shared_from_this());
 
   // Highlight the scale part of the slider
   bool is_picked = primitive_assembler.GetPickingManager()->IsThisElementPicked(this);
   if (is_picked) {
     if (drag_type_ == DragType::kScaleMax) {
       primitive_assembler.AddShadedBox(Vec2(x + width - GetSliderResizeMargin(), 2),
-                                       Vec2(GetSliderResizeMargin() - 2, GetSliderWide() - 4),
+                                       Vec2(GetSliderResizeMargin() - 2, GetSliderWidth() - 4),
                                        GlCanvas::kZValueButton + kEpsilon, selected_color_,
                                        ShadingDirection::kTopToBottom);
     } else if (drag_type_ == DragType::kScaleMin) {
       primitive_assembler.AddShadedBox(
-          Vec2(x + 2, 2), Vec2(GetSliderResizeMargin() - 2, GetSliderWide() - 4),
+          Vec2(x + 2, 2), Vec2(GetSliderResizeMargin() - 2, GetSliderWidth() - 4),
           GlCanvas::kZValueButton + kEpsilon, selected_color_, ShadingDirection::kTopToBottom);
     }
   }

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -25,7 +25,7 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
 
   void SetNormalizedPosition(float start_ratio);  // [0,1]
   void SetNormalizedLength(float length_ratio);   // [0,1]
-  [[nodiscard]] float GetSliderWide() const { return layout_->GetSliderWide(); }
+  [[nodiscard]] float GetSliderWidth() const { return layout_->GetSliderWidth(); }
 
   [[nodiscard]] Color GetBarColor() const { return slider_color_; }
 
@@ -117,10 +117,10 @@ class GlVerticalSlider : public GlSlider {
   void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
 
-  [[nodiscard]] float GetWidth() const override { return GetSliderWide(); }
+  [[nodiscard]] float GetWidth() const override { return GetSliderWidth(); }
 
   [[nodiscard]] float GetHeight() const override {
-    return viewport_->GetScreenHeight() - GetPos()[1] - layout_->GetSliderWide();
+    return viewport_->GetScreenHeight() - GetPos()[1] - layout_->GetSliderWidth();
   }
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
@@ -141,9 +141,9 @@ class GlHorizontalSlider : public GlSlider {
               const DrawContext& draw_context) override;
 
   [[nodiscard]] float GetWidth() const override {
-    return viewport_->GetScreenWidth() - layout_->GetSliderWide();
+    return viewport_->GetScreenWidth() - layout_->GetSliderWidth();
   }
-  [[nodiscard]] float GetHeight() const override { return GetSliderWide(); }
+  [[nodiscard]] float GetHeight() const override { return GetSliderWidth(); }
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -25,14 +25,9 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
 
   void SetNormalizedPosition(float start_ratio);  // [0,1]
   void SetNormalizedLength(float length_ratio);   // [0,1]
+  [[nodiscard]] float GetSliderWide() const { return layout_->GetSliderWide(); }
 
   [[nodiscard]] Color GetBarColor() const { return slider_color_; }
-
-  void SetPixelHeight(int height) { pixel_height_ = height; }
-  [[nodiscard]] int GetPixelHeight() const { return pixel_height_; }
-
-  void SetOrthogonalSliderPixelHeight(int size) { orthogonal_slider_size_ = size; }
-  [[nodiscard]] int GetOrthogonalSliderSize() const { return orthogonal_slider_size_; }
 
   // Parameter: Position in [0, 1], relative to the size of the current data window
   using DragCallback = std::function<void(float)>;
@@ -48,7 +43,7 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
   void OnPick(int x, int y) override;
   void OnDrag(int x, int y) override;
 
-  [[nodiscard]] float GetMinSliderPixelLength() const { return min_slider_pixel_length_; }
+  [[nodiscard]] float GetMinSliderPixelLength() const { return layout_->GetMinSliderLength(); }
 
   [[nodiscard]] float GetSliderPixelPos() const { return PosToPixel(pos_ratio_); }
   [[nodiscard]] float GetSliderPixelLength() const { return LenToPixel(length_ratio_); }
@@ -75,7 +70,7 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
   [[nodiscard]] EventResult OnMouseLeave() override;
   [[nodiscard]] bool HandlePageScroll(float click_value);
 
- protected:
+  [[nodiscard]] float GetSliderResizeMargin() const { return layout_->GetSliderResizeMargin(); }
   [[nodiscard]] virtual float GetBarPixelLength() const = 0;
   [[nodiscard]] bool PosIsInMinResizeArea(const Vec2& pos) const;
   [[nodiscard]] bool PosIsInMaxResizeArea(const Vec2& pos) const;
@@ -106,13 +101,8 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
   Color selected_color_;
   Color slider_color_;
   Color bar_color_;
-  int min_slider_pixel_length_;
-  int pixel_height_;
-  int orthogonal_slider_size_;
 
   bool can_resize_ = false;
-
-  int slider_resize_pixel_margin_;
 
   enum class DragType { kPan, kScaleMin, kScaleMax, kNone };
   DragType drag_type_ = DragType::kNone;
@@ -127,10 +117,10 @@ class GlVerticalSlider : public GlSlider {
   void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
 
-  [[nodiscard]] float GetWidth() const override { return pixel_height_; }
+  [[nodiscard]] float GetWidth() const override { return GetSliderWide(); }
 
   [[nodiscard]] float GetHeight() const override {
-    return viewport_->GetScreenHeight() - GetPos()[1] - orthogonal_slider_size_;
+    return viewport_->GetScreenHeight() - GetPos()[1] - layout_->GetSliderWide();
   }
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
@@ -151,9 +141,9 @@ class GlHorizontalSlider : public GlSlider {
               const DrawContext& draw_context) override;
 
   [[nodiscard]] float GetWidth() const override {
-    return viewport_->GetScreenWidth() - orthogonal_slider_size_;
+    return viewport_->GetScreenWidth() - layout_->GetSliderWide();
   }
-  [[nodiscard]] float GetHeight() const override { return pixel_height_; }
+  [[nodiscard]] float GetHeight() const override { return GetSliderWide(); }
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -149,7 +149,7 @@ uint32_t GraphTrack<Dimension>::GetLegendFontSize(uint32_t indentation_level) co
   constexpr uint32_t kMinIndentationLevel = 1;
   int capped_indentation_level = std::max(indentation_level, kMinIndentationLevel);
 
-  uint32_t font_size = layout_->CalculateZoomedFontSize();
+  uint32_t font_size = layout_->GetFontSize();
   return (font_size * (10 - capped_indentation_level)) / 10;
 }
 

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -59,9 +59,9 @@ std::tuple<std::unique_ptr<SliderClass>, std::unique_ptr<Viewport>,
 Setup() {
   std::unique_ptr<CaptureViewElementTester> tester = std::make_unique<CaptureViewElementTester>();
   // Making space for the orthogonal slider as well.
-  int orthogonal_slider_wide = static_cast<int>(tester->GetLayout()->GetSliderWide());
+  int orthogonal_slider_width = static_cast<int>(tester->GetLayout()->GetSliderWidth());
   std::unique_ptr<Viewport> viewport =
-      std::make_unique<Viewport>(100 + orthogonal_slider_wide, 1000 + orthogonal_slider_wide);
+      std::make_unique<Viewport>(100 + orthogonal_slider_width, 1000 + orthogonal_slider_width);
 
   std::unique_ptr<SliderClass> slider =
       std::make_unique<SliderClass>(nullptr, viewport.get(), tester->GetLayout(), nullptr);

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -54,28 +54,30 @@ void PickDragRelease(GlSlider& slider, int start, int end = -1, int other_dim = 
 }
 
 template <typename SliderClass>
-std::pair<std::unique_ptr<SliderClass>, std::unique_ptr<Viewport>> Setup() {
-  orbit_gl::CaptureViewElementTester tester;
+std::tuple<std::unique_ptr<SliderClass>, std::unique_ptr<Viewport>,
+           std::unique_ptr<CaptureViewElementTester>>
+Setup() {
+  std::unique_ptr<CaptureViewElementTester> tester = std::make_unique<CaptureViewElementTester>();
   // Making space for the orthogonal slider as well.
-  int orthogonal_slider_wide = static_cast<int>(tester.GetLayout()->GetSliderWide());
+  int orthogonal_slider_wide = static_cast<int>(tester->GetLayout()->GetSliderWide());
   std::unique_ptr<Viewport> viewport =
       std::make_unique<Viewport>(100 + orthogonal_slider_wide, 1000 + orthogonal_slider_wide);
 
   std::unique_ptr<SliderClass> slider =
-      std::make_unique<SliderClass>(nullptr, viewport.get(), tester.GetLayout(), nullptr);
+      std::make_unique<SliderClass>(nullptr, viewport.get(), tester->GetLayout(), nullptr);
 
   // Set the slider to be 50% of the maximum size, position in the middle
   slider->SetNormalizedPosition(0.5f);
   slider->SetNormalizedLength(0.5f);
 
-  return std::make_pair(std::move(slider), std::move(viewport));
+  return std::make_tuple(std::move(slider), std::move(viewport), std::move(tester));
 }
 
 const float kEpsilon = 0.01f;
 
 template <typename SliderClass, int dim>
 static void TestDragType() {
-  auto [slider, viewport] = Setup<SliderClass>();
+  auto [slider, viewport, tester] = Setup<SliderClass>();
 
   const float kPos = 0.5f;
   const float kSize = 0.5f;
@@ -149,7 +151,7 @@ TEST(Slider, DragType) {
 
 template <typename SliderClass, int dim>
 static void TestScroll(float slider_length = 0.25) {
-  auto [slider, viewport] = Setup<SliderClass>();
+  auto [slider, viewport, tester] = Setup<SliderClass>();
 
   // Use different scales for x and y to make sure dims are chosen correctly
   int scale = static_cast<int>(pow(10, dim));
@@ -174,7 +176,7 @@ TEST(Slider, Scroll) {
 
 template <typename SliderClass, int dim>
 static void TestDrag(float slider_length = 0.25) {
-  auto [slider, viewport] = Setup<SliderClass>();
+  auto [slider, viewport, tester] = Setup<SliderClass>();
 
   // Use different scales for x and y to make sure dims are chosen correctly
   int scale = static_cast<int>(pow(10, dim));
@@ -222,7 +224,7 @@ TEST(Slider, DragBreakTests) {
 
 template <typename SliderClass, int dim>
 static void TestScaling() {
-  auto [slider, viewport] = Setup<SliderClass>();
+  auto [slider, viewport, tester] = Setup<SliderClass>();
 
   if (!slider->CanResize()) {
     return;
@@ -284,7 +286,7 @@ TEST(Slider, Scale) {
 
 template <typename SliderClass, int dim>
 static void TestBreakScaling() {
-  auto [slider, viewport] = Setup<SliderClass>();
+  auto [slider, viewport, tester] = Setup<SliderClass>();
 
   if (!slider->CanResize()) {
     return;

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -56,12 +56,13 @@ void PickDragRelease(GlSlider& slider, int start, int end = -1, int other_dim = 
 template <typename SliderClass>
 std::pair<std::unique_ptr<SliderClass>, std::unique_ptr<Viewport>> Setup() {
   orbit_gl::CaptureViewElementTester tester;
-  std::unique_ptr<Viewport> viewport = std::make_unique<Viewport>(150, 1050);
+  // Making space for the orthogonal slider as well.
+  int orthogonal_slider_wide = static_cast<int>(tester.GetLayout()->GetSliderWide());
+  std::unique_ptr<Viewport> viewport =
+      std::make_unique<Viewport>(100 + orthogonal_slider_wide, 1000 + orthogonal_slider_wide);
 
   std::unique_ptr<SliderClass> slider =
       std::make_unique<SliderClass>(nullptr, viewport.get(), tester.GetLayout(), nullptr);
-  slider->SetPixelHeight(15);
-  slider->SetOrthogonalSliderPixelHeight(50);
 
   // Set the slider to be 50% of the maximum size, position in the middle
   slider->SetNormalizedPosition(0.5f);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -94,9 +94,6 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
   vertical_slider_->SetDragCallback(
       [&](float ratio) { track_container_->UpdateVerticalScrollUsingRatio(ratio); });
 
-  vertical_slider_->SetOrthogonalSliderPixelHeight(horizontal_slider_->GetPixelHeight());
-  horizontal_slider_->SetOrthogonalSliderPixelHeight(vertical_slider_->GetPixelHeight());
-
   plus_button_ = std::make_shared<Button>(/*parent=*/this, viewport, &layout_, "Plus Button",
                                           Button::SymbolType::kPlusSymbol);
   plus_button_->SetMouseReleaseCallback(
@@ -724,12 +721,12 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
   track_container_->SetWidth(GetWidth() - total_right_margin);
   track_container_->SetPos(timegraph_current_x, timegraph_current_y);
 
-  vertical_slider_->SetWidth(layout_.GetSliderWidth());
+  vertical_slider_->SetWidth(layout_.GetSliderWide());
   vertical_slider_->SetPos(GetWidth() - vertical_slider_->GetWidth(), timegraph_current_y);
 
   timegraph_current_y += track_container_->GetHeight();
   horizontal_slider_->SetWidth(GetWidth() - vertical_slider_->GetWidth());
-  horizontal_slider_->SetPos(timegraph_current_x, timegraph_current_y);
+  horizontal_slider_->SetPos(timegraph_current_x, ceil(timegraph_current_y));
 
   // TODO(b/230442062): Refactor this to be part of Slider::UpdateLayout().
   UpdateHorizontalSliderFromWorld();
@@ -750,8 +747,6 @@ void TimeGraph::UpdateHorizontalSliderFromWorld() {
 
   constexpr double kEpsilon = 1e-8;
   double ratio = max_start > kEpsilon ? start / max_start : 0;
-  int slider_width = static_cast<int>(GetLayout().GetSliderWidth());
-  horizontal_slider_->SetPixelHeight(slider_width);
   horizontal_slider_->SetNormalizedLength(static_cast<float>(width / time_span));
   horizontal_slider_->SetNormalizedPosition(static_cast<float>(ratio));
 }
@@ -763,8 +758,6 @@ void TimeGraph::UpdateVerticalSliderFromWorld() {
       max_height > 0 ? GetTrackContainer()->GetVerticalScrollingOffset() / max_height : 0.f;
   float size_ratio =
       visible_tracks_height > 0 ? vertical_slider_->GetHeight() / visible_tracks_height : 1.f;
-  int slider_width = static_cast<int>(GetLayout().GetSliderWidth());
-  vertical_slider_->SetPixelHeight(slider_width);
   vertical_slider_->SetNormalizedPosition(pos_ratio);
   vertical_slider_->SetNormalizedLength(size_ratio);
 }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -721,7 +721,7 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
   track_container_->SetWidth(GetWidth() - total_right_margin);
   track_container_->SetPos(timegraph_current_x, timegraph_current_y);
 
-  vertical_slider_->SetWidth(layout_.GetSliderWide());
+  vertical_slider_->SetWidth(layout_.GetSliderWidth());
   vertical_slider_->SetPos(GetWidth() - vertical_slider_->GetWidth(), timegraph_current_y);
 
   timegraph_current_y += track_container_->GetHeight();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -726,7 +726,10 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
 
   timegraph_current_y += track_container_->GetHeight();
   horizontal_slider_->SetWidth(GetWidth() - vertical_slider_->GetWidth());
-  horizontal_slider_->SetPos(timegraph_current_x, ceil(timegraph_current_y));
+  // The horizontal slider should be at the bottom of the TimeGraph. Because how OpenGl renders, the
+  // way to assure that there is no pixels below the scrollbar is by making a ceiling.
+  horizontal_slider_->SetPos(timegraph_current_x,
+                             ceil(GetHeight() - horizontal_slider_->GetHeight()));
 
   // TODO(b/230442062): Refactor this to be part of Slider::UpdateLayout().
   UpdateHorizontalSliderFromWorld();

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -117,6 +117,6 @@ float TimeGraphLayout::GetEventTrackHeightFromTid(uint32_t tid) const {
 
 float TimeGraphLayout::GetSliderResizeMargin() const {
   // The resize part of the slider is 1/3 of the min length.
-  const float kRatioMinSliderLenghtResizePart = 3.f;
-  return GetMinSliderLength() / kRatioMinSliderLenghtResizePart;
+  const float kRatioMinSliderLengthResizePart = 3.f;
+  return GetMinSliderLength() / kRatioMinSliderLengthResizePart;
 }

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -24,7 +24,8 @@ TimeGraphLayout::TimeGraphLayout() {
   space_between_thread_panes_ = 5.f;
   space_between_subtracks_ = 0.f;
   track_label_offset_x_ = 30.f;
-  slider_width_ = 15.f;
+  slider_wide_ = 15.f;
+  min_slider_length_ = 20.f;
   track_tab_width_ = 350.f;
   track_tab_height_ = 25.f;
   track_tab_offset_ = 0.f;
@@ -67,7 +68,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(space_between_tracks_and_timeline_);
   FLOAT_SLIDER(space_between_thread_panes_);
   FLOAT_SLIDER(space_between_subtracks_);
-  FLOAT_SLIDER(slider_width_);
+  FLOAT_SLIDER(slider_wide_);
   FLOAT_SLIDER(time_bar_height_);
   FLOAT_SLIDER(track_tab_height_);
   FLOAT_SLIDER(track_tab_offset_);
@@ -112,4 +113,10 @@ float TimeGraphLayout::GetEventTrackHeightFromTid(uint32_t tid) const {
     height *= GetAllThreadsEventTrackScale();
   }
   return height;
+}
+
+float TimeGraphLayout::GetSliderResizeMargin() const {
+  // The resize part of the slider is 1/3 of the min length.
+  const float kRatioMinSliderLenghtResizePart = 3.f;
+  return GetMinSliderLength() / kRatioMinSliderLenghtResizePart;
 }

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -24,7 +24,7 @@ TimeGraphLayout::TimeGraphLayout() {
   space_between_thread_panes_ = 5.f;
   space_between_subtracks_ = 0.f;
   track_label_offset_x_ = 30.f;
-  slider_wide_ = 15.f;
+  slider_width_ = 15.f;
   min_slider_length_ = 20.f;
   track_tab_width_ = 350.f;
   track_tab_height_ = 25.f;
@@ -68,7 +68,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(space_between_tracks_and_timeline_);
   FLOAT_SLIDER(space_between_thread_panes_);
   FLOAT_SLIDER(space_between_subtracks_);
-  FLOAT_SLIDER(slider_wide_);
+  FLOAT_SLIDER(slider_width_);
   FLOAT_SLIDER(time_bar_height_);
   FLOAT_SLIDER(track_tab_height_);
   FLOAT_SLIDER(track_tab_offset_);

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -27,7 +27,7 @@ class TimeGraphLayout {
   float GetTrackContentBottomMargin() const { return track_content_bottom_margin_ * scale_; }
   float GetTrackContentTopMargin() const { return track_content_top_margin_ * scale_; }
   float GetTrackLabelOffsetX() const { return track_label_offset_x_; }
-  float GetSliderWide() const { return slider_wide_ * scale_; }
+  float GetSliderWidth() const { return slider_width_ * scale_; }
   float GetMinSliderLength() const { return min_slider_length_ * scale_; }
   float GetSliderResizeMargin() const;
   float GetTimeBarHeight() const { return time_bar_height_ * scale_; }
@@ -72,7 +72,7 @@ class TimeGraphLayout {
   float track_content_bottom_margin_;
   float track_content_top_margin_;
   float track_label_offset_x_;
-  float slider_wide_;
+  float slider_width_;
   float min_slider_length_;
   float time_bar_height_;
   float track_tab_width_;

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -27,8 +27,10 @@ class TimeGraphLayout {
   float GetTrackContentBottomMargin() const { return track_content_bottom_margin_ * scale_; }
   float GetTrackContentTopMargin() const { return track_content_top_margin_ * scale_; }
   float GetTrackLabelOffsetX() const { return track_label_offset_x_; }
-  float GetSliderWidth() const { return slider_width_; }
-  float GetTimeBarHeight() const { return time_bar_height_; }
+  float GetSliderWide() const { return slider_wide_ * scale_; }
+  float GetMinSliderLength() const { return min_slider_length_ * scale_; }
+  float GetSliderResizeMargin() const;
+  float GetTimeBarHeight() const { return time_bar_height_ * scale_; }
   float GetTrackTabWidth() const { return track_tab_width_; }
   float GetTrackTabHeight() const { return track_tab_height_ * scale_; }
   float GetTrackTabOffset() const { return track_tab_offset_; }
@@ -38,10 +40,10 @@ class TimeGraphLayout {
   float GetRoundingRadius() const { return rounding_radius_ * scale_; }
   float GetRoundingNumSides() const { return rounding_num_sides_; }
   float GetTextOffset() const { return text_offset_ * scale_; }
-  float GetRightMargin() const { return right_margin_; }
+  float GetRightMargin() const { return right_margin_ * scale_; }
   float GetMinButtonSize() const { return min_button_size_; }
-  float GetButtonWidth() const { return button_width_; }
-  float GetButtonHeight() const { return button_height_; }
+  float GetButtonWidth() const { return button_width_ * scale_; }
+  float GetButtonHeight() const { return button_height_ * scale_; }
   float GetSpaceBetweenTracks() const { return space_between_tracks_ * scale_; }
   float GetSpaceBetweenTracksAndTimeline() const {
     return space_between_tracks_and_timeline_ * scale_;
@@ -50,17 +52,13 @@ class TimeGraphLayout {
   float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }
   float GetSpaceBetweenThreadPanes() const { return space_between_thread_panes_ * scale_; }
   float GetSpaceBetweenSubtracks() const { return space_between_subtracks_ * scale_; }
-  float GetToolbarIconHeight() const { return toolbar_icon_height_; }
   float GetGenericFixedSpacerWidth() const { return generic_fixed_spacer_width_; }
   float GetScale() const { return scale_; }
   void SetScale(float value) { scale_ = std::clamp(value, kMinScale, kMaxScale); }
   void SetDrawProperties(bool value) { draw_properties_ = value; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return draw_track_background_; }
-  uint32_t GetFontSize() const { return font_size_; }
-  [[nodiscard]] uint32_t CalculateZoomedFontSize() const {
-    return lround(GetFontSize() * GetScale());
-  }
+  uint32_t GetFontSize() const { return lround(font_size_ * scale_); }
 
   int GetMaxLayoutingLoops() const { return max_layouting_loops_; }
 
@@ -74,7 +72,8 @@ class TimeGraphLayout {
   float track_content_bottom_margin_;
   float track_content_top_margin_;
   float track_label_offset_x_;
-  float slider_width_;
+  float slider_wide_;
+  float min_slider_length_;
   float time_bar_height_;
   float track_tab_width_;
   float track_tab_height_;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -101,7 +101,7 @@ void TimerTrack::DrawTimesliceText(TextRenderer& text_renderer,
   float pos_x = std::max(box_pos[0], min_x);
   float max_size = box_pos[0] + box_size[0] - pos_x;
 
-  TextRenderer::TextFormatting formatting{layout_->CalculateZoomedFontSize(), kTextWhite, max_size};
+  TextRenderer::TextFormatting formatting{layout_->GetFontSize(), kTextWhite, max_size};
   formatting.valign = TextRenderer::VAlign::Bottom;
 
   text_renderer.AddTextTrailingCharsPrioritized(

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -159,7 +159,7 @@ class TimerTrack : public Track {
 
   [[nodiscard]] inline bool BoxHasRoomForText(orbit_gl::TextRenderer& text_renderer,
                                               const float width) {
-    return text_renderer.GetStringWidth("w", layout_->CalculateZoomedFontSize()) < width;
+    return text_renderer.GetStringWidth("w", layout_->GetFontSize()) < width;
   }
 
   [[nodiscard]] bool ShouldHaveBorder(

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -89,7 +89,7 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
 
   // Draw label.
 
-  uint32_t font_size = layout_->CalculateZoomedFontSize();
+  uint32_t font_size = layout_->GetFontSize();
   // For the first 5 indentations, we decrease the font_size by 10 percent points (per
   // indentation).
   constexpr uint32_t kMaxIndentationLevel = 5;


### PR DESCRIPTION
In this PR we are scaling consistently across all elements in TimeGraph, so:

- We are only having one font size (before was impossible because text in
the Timeline was overlapping).
- We are scaling symbol sizes in Buttons accordingly.
- Move a few hardcoded values from Slider to Layout, so they can scale.
- An additional ceiling needed for the horizontal scrollbar to avoid
  having this situation because OpenGl: http://screenshot/3mVGcjPYHgfYuKF

And in addition:
- Rename SliderWidth x SliderWide.
- Refactor a bit Slider class.

Some screenshots:
TimeGraph after zooming-in: http://screenshot/AvYgew2RL5ToNaU
Min size of Scrollbar after zooming-in: http://screenshot/kPY4FfmPBnpeppL
Iterator text is zoomed as well: http://screenshot/M3wLVRPdTJYZmW4

Bugs:
http://b/234358833 -> Scale Timeline - Button - Scrollbar
http://b/200905950 -> Text of iterators doesn't get zoomed.
http://b/230442062 -> Refactor Sliders (although I won't close it since
there is still a bit of cleaning work we can do there).

TODO:
http://b/177200179 -> Scale Qt part (not a priority for now).

Test: Load a capture, see scaling works as. expected.

Edit: Clang11 test was failing because layout was being destroyed. Before we 
were not using layout consistently, so it wasn't failing. I included a fixup. 
