### PR TITLE
Add an abstraction to handle a pair of Captures

### DIFF
--- a/src/CaptureClient/include/CaptureClient/AbstractCaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/AbstractCaptureListener.h
@@ -17,6 +17,14 @@ namespace orbit_capture_client {
 template <typename Derived>
 class AbstractCaptureListener : public CaptureListener {
  public:
+  AbstractCaptureListener() = default;
+
+  AbstractCaptureListener(AbstractCaptureListener&) = default;
+  AbstractCaptureListener& operator=(const AbstractCaptureListener& other) = default;
+
+  AbstractCaptureListener(AbstractCaptureListener&&) = default;
+  AbstractCaptureListener& operator=(AbstractCaptureListener&& other) = default;
+
   virtual ~AbstractCaptureListener() = default;
 
   void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) override {

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -28,6 +28,14 @@ class CaptureListener {
  public:
   enum class CaptureOutcome { kComplete, kCancelled };
 
+  CaptureListener() = default;
+
+  CaptureListener(CaptureListener&) = default;
+  CaptureListener& operator=(const CaptureListener& other) = default;
+
+  CaptureListener(CaptureListener&&) = default;
+  CaptureListener& operator=(CaptureListener&& other) = default;
+
   virtual ~CaptureListener() = default;
 
   virtual void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,

--- a/src/ClientData/include/ClientData/CaptureDataHolder.h
+++ b/src/ClientData/include/ClientData/CaptureDataHolder.h
@@ -16,6 +16,14 @@ namespace orbit_client_data {
 
 class CaptureDataHolder {
  public:
+  CaptureDataHolder() = default;
+
+  CaptureDataHolder(CaptureDataHolder&) = delete;
+  CaptureDataHolder& operator=(const CaptureDataHolder& other) = delete;
+
+  CaptureDataHolder(CaptureDataHolder&&) = default;
+  CaptureDataHolder& operator=(CaptureDataHolder&& other) = default;
+
   virtual ~CaptureDataHolder() = default;
 
   // TODO(b/234095077): The two methods should not return ref, as capture_data_ doesn't

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -30,6 +30,7 @@ namespace orbit_data_views {
 
 class AppInterface : public orbit_client_data::CaptureDataHolder {
  public:
+  AppInterface() = default;
   virtual ~AppInterface() = default;
 
   // Functions needed by DataView

--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -47,7 +47,8 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  orbit_mizar_data::BaselineAndComparison bac = CreateBaselineAndComparison(baseline, comparison);
+  orbit_mizar_data::BaselineAndComparison bac =
+      CreateBaselineAndComparison(std::move(baseline), std::move(comparison));
   for (auto& [id, name] : bac.sampled_function_id_to_name()) {
     ORBIT_LOG("%u %s", id, name);
   }

--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -9,46 +9,48 @@
 
 #include "CaptureClient/LoadCapture.h"
 #include "CaptureFile/CaptureFile.h"
+#include "MizarData/BaselineAndComparison.h"
 #include "MizarData/MizarData.h"
 #include "OrbitBase/Logging.h"
 
-int main(int argc, char* argv[]) {
-  // The main in its current state is used to testing/experimenting and serves no other purpose
-  if (argc < 2) {
-    ORBIT_ERROR("No file path given");
-    return 1;
-  }
-  const std::filesystem::path path = argv[1];
-  auto capture_file_or_error = orbit_capture_file::CaptureFile::OpenForReadWrite(path);
-  if (capture_file_or_error.has_error()) {
-    ORBIT_ERROR("%s", capture_file_or_error.error().message());
-    return 1;
-  }
+[[nodiscard]] static ErrorMessageOr<void> LoadCapture(orbit_mizar_data::MizarData* data,
+                                                      std::filesystem::path path) {
+  OUTCOME_TRY(auto capture_file, orbit_capture_file::CaptureFile::OpenForReadWrite(path));
   std::atomic<bool> capture_loading_cancellation_requested = false;
 
-  orbit_mizar_data::MizarData data;
-  auto status = orbit_capture_client::LoadCapture(&data, capture_file_or_error.value().get(),
+  std::ignore = orbit_capture_client::LoadCapture(data, capture_file.get(),
                                                   &capture_loading_cancellation_requested);
-  const auto& callstack_data = data.GetCaptureData().GetCallstackData();
-  std::vector<orbit_client_data::CallstackEvent> callstack_events =
-      callstack_data.GetCallstackEventsInTimeRange(std::numeric_limits<uint64_t>::min(),
-                                                   std::numeric_limits<uint64_t>::max());
+  return outcome::success();
+}
 
-  absl::flat_hash_set<std::string> names;
-  for (auto event : callstack_events) {
-    const orbit_client_data::CallstackInfo* callstack =
-        callstack_data.GetCallstack(event.callstack_id());
-    for (auto addr : callstack->frames()) {
-      std::optional<std::string> name = data.GetFunctionNameFromAddress(addr);
-      if (name.has_value()) names.insert(name.value());
-    }
+int main(int argc, char* argv[]) {
+  // The main in its current state is used to testing/experimenting and serves no other purpose
+  if (argc < 3) {
+    ORBIT_ERROR("Two filepaths should be given");
+    return 1;
+  }
+  orbit_mizar_data::MizarData baseline;
+  orbit_mizar_data::MizarData comparison;
+
+  const std::filesystem::path baseline_path = argv[1];
+  const std::filesystem::path comparison_path = argv[2];
+
+  auto baseline_error_message = LoadCapture(&baseline, baseline_path);
+  if (baseline_error_message.has_error()) {
+    ORBIT_ERROR("%s", baseline_error_message.error().message());
+    return 1;
   }
 
-  for (const auto& name : names) {
-    ORBIT_LOG("%s", name);
+  auto comparison_error_message = LoadCapture(&comparison, comparison_path);
+  if (comparison_error_message.has_error()) {
+    ORBIT_ERROR("%s", comparison_error_message.error().message());
+    return 1;
   }
 
-  ORBIT_LOG("total stack sample count %u, total number of functions %u",
-            callstack_data.GetCallstackEventsCount(), names.size());
+  orbit_mizar_data::BaselineAndComparison bac = CreateBaselineAndComparison(baseline, comparison);
+  for (auto& [id, name] : bac.sampled_function_id_to_name()) {
+    ORBIT_LOG("%u %s", id, name);
+  }
+  ORBIT_LOG("Total number of common names %u  ", bac.sampled_function_id_to_name().size());
   return 0;
 }

--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -19,6 +19,7 @@
   OUTCOME_TRY(auto capture_file, orbit_capture_file::CaptureFile::OpenForReadWrite(path));
   std::atomic<bool> capture_loading_cancellation_requested = false;
 
+  // The treatment is the same for CaptureOutcome::kComplete, CaptureOutcome::kCancelled
   std::ignore = orbit_capture_client::LoadCapture(data, capture_file.get(),
                                                   &capture_loading_cancellation_requested);
   return outcome::success();

--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -5,6 +5,7 @@
 #include <absl/container/flat_hash_set.h>
 
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "CaptureClient/LoadCapture.h"
@@ -29,19 +30,19 @@ int main(int argc, char* argv[]) {
     ORBIT_ERROR("Two filepaths should be given");
     return 1;
   }
-  orbit_mizar_data::MizarData baseline;
-  orbit_mizar_data::MizarData comparison;
+  auto baseline = std::make_unique<orbit_mizar_data::MizarData>();
+  auto comparison = std::make_unique<orbit_mizar_data::MizarData>();
 
   const std::filesystem::path baseline_path = argv[1];
   const std::filesystem::path comparison_path = argv[2];
 
-  auto baseline_error_message = LoadCapture(&baseline, baseline_path);
+  auto baseline_error_message = LoadCapture(baseline.get(), baseline_path);
   if (baseline_error_message.has_error()) {
     ORBIT_ERROR("%s", baseline_error_message.error().message());
     return 1;
   }
 
-  auto comparison_error_message = LoadCapture(&comparison, comparison_path);
+  auto comparison_error_message = LoadCapture(comparison.get(), comparison_path);
   if (comparison_error_message.has_error()) {
     ORBIT_ERROR("%s", comparison_error_message.error().message());
     return 1;
@@ -49,7 +50,7 @@ int main(int argc, char* argv[]) {
 
   orbit_mizar_data::BaselineAndComparison bac =
       CreateBaselineAndComparison(std::move(baseline), std::move(comparison));
-  for (auto& [id, name] : bac.sampled_function_id_to_name()) {
+  for (const auto& [id, name] : bac.sampled_function_id_to_name()) {
     ORBIT_LOG("%u %s", id, name);
   }
   ORBIT_LOG("Total number of common names %u  ", bac.sampled_function_id_to_name().size());

--- a/src/MizarData/BaselineAndComparison.cpp
+++ b/src/MizarData/BaselineAndComparison.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MizarData/BaselineAndComparison.h"
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+
+#include "BaselineAndComparisonHelper.h"
+#include "ClientData/CaptureData.h"
+
+namespace orbit_mizar_data {
+
+orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(const MizarData& baseline,
+                                                                    const MizarData& comparison) {
+  const absl::flat_hash_map<uint64_t, std::string> baseline_address_to_name =
+      baseline.AllAddressToName();
+  const absl::flat_hash_map<uint64_t, std::string> comparison_address_to_name =
+      comparison.AllAddressToName();
+
+  auto [baseline_address_to_frame_id, comparison_address_to_frame_id, frame_id_to_name] =
+      AssignSampledFunctionIds(baseline_address_to_name, comparison_address_to_name);
+
+  return BaselineAndComparison({baseline, std::move(baseline_address_to_frame_id)},
+                               {comparison, std::move(comparison_address_to_frame_id)},
+                               std::move(frame_id_to_name));
+}
+
+}  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparison.cpp
+++ b/src/MizarData/BaselineAndComparison.cpp
@@ -13,11 +13,12 @@
 
 #include "BaselineAndComparisonHelper.h"
 #include "ClientData/CaptureData.h"
+#include "MizarData/MizarData.h"
 
 namespace orbit_mizar_data {
 
-orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(const MizarData& baseline,
-                                                                    const MizarData& comparison) {
+orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(MizarData baseline,
+                                                                    MizarData comparison) {
   const absl::flat_hash_map<uint64_t, std::string> baseline_address_to_name =
       baseline.AllAddressToName();
   const absl::flat_hash_map<uint64_t, std::string> comparison_address_to_name =
@@ -26,9 +27,12 @@ orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(const MizarD
   auto [baseline_address_to_frame_id, comparison_address_to_frame_id, frame_id_to_name] =
       AssignSampledFunctionIds(baseline_address_to_name, comparison_address_to_name);
 
-  return BaselineAndComparison({baseline, std::move(baseline_address_to_frame_id)},
-                               {comparison, std::move(comparison_address_to_frame_id)},
-                               std::move(frame_id_to_name));
+  MizarDataWithSampledFunctionId baseline_with_ids(std::move(baseline),
+                                                   std::move(baseline_address_to_frame_id));
+
+  return {{std::move(baseline), std::move(baseline_address_to_frame_id)},
+          {std::move(comparison), std::move(comparison_address_to_frame_id)},
+          std::move(frame_id_to_name)};
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparison.cpp
+++ b/src/MizarData/BaselineAndComparison.cpp
@@ -27,9 +27,6 @@ orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(
   auto [baseline_address_to_frame_id, comparison_address_to_frame_id, frame_id_to_name] =
       AssignSampledFunctionIds(baseline_address_to_name, comparison_address_to_name);
 
-  MizarDataWithSampledFunctionId baseline_with_ids(std::move(baseline),
-                                                   std::move(baseline_address_to_frame_id));
-
   return {{std::move(baseline), std::move(baseline_address_to_frame_id)},
           {std::move(comparison), std::move(comparison_address_to_frame_id)},
           std::move(frame_id_to_name)};

--- a/src/MizarData/BaselineAndComparison.cpp
+++ b/src/MizarData/BaselineAndComparison.cpp
@@ -19,13 +19,8 @@ namespace orbit_mizar_data {
 
 orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(
     std::unique_ptr<MizarDataProvider> baseline, std::unique_ptr<MizarDataProvider> comparison) {
-  const absl::flat_hash_map<uint64_t, std::string> baseline_address_to_name =
-      baseline->AllAddressToName();
-  const absl::flat_hash_map<uint64_t, std::string> comparison_address_to_name =
-      comparison->AllAddressToName();
-
   auto [baseline_address_to_frame_id, comparison_address_to_frame_id, frame_id_to_name] =
-      AssignSampledFunctionIds(baseline_address_to_name, comparison_address_to_name);
+      AssignSampledFunctionIds(baseline->AllAddressToName(), comparison->AllAddressToName());
 
   return {{std::move(baseline), std::move(baseline_address_to_frame_id)},
           {std::move(comparison), std::move(comparison_address_to_frame_id)},

--- a/src/MizarData/BaselineAndComparison.cpp
+++ b/src/MizarData/BaselineAndComparison.cpp
@@ -17,12 +17,12 @@
 
 namespace orbit_mizar_data {
 
-orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(MizarData baseline,
-                                                                    MizarData comparison) {
+orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(
+    std::unique_ptr<MizarDataProvider> baseline, std::unique_ptr<MizarDataProvider> comparison) {
   const absl::flat_hash_map<uint64_t, std::string> baseline_address_to_name =
-      baseline.AllAddressToName();
+      baseline->AllAddressToName();
   const absl::flat_hash_map<uint64_t, std::string> comparison_address_to_name =
-      comparison.AllAddressToName();
+      comparison->AllAddressToName();
 
   auto [baseline_address_to_frame_id, comparison_address_to_frame_id, frame_id_to_name] =
       AssignSampledFunctionIds(baseline_address_to_name, comparison_address_to_name);

--- a/src/MizarData/BaselineAndComparisonHelper.cpp
+++ b/src/MizarData/BaselineAndComparisonHelper.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "BaselineAndComparisonHelper.h"
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <stdint.h>
+
+namespace orbit_mizar_data {
+
+template <typename K, typename V>
+[[nodiscard]] static absl::flat_hash_set<V> ValueSet(const absl::flat_hash_map<K, V>& map) {
+  absl::flat_hash_set<V> result;
+  std::transform(std::begin(map), std::end(map), std::inserter(result, std::begin(result)),
+                 [](const std::pair<K, V> pair) { return pair.second; });
+  return result;
+}
+
+static absl::flat_hash_map<uint64_t, uint64_t> AddressToSampledFunctionId(
+    const absl::flat_hash_map<uint64_t, std::string>& address_to_name,
+    const absl::flat_hash_map<std::string, uint64_t>& name_to_frame_id) {
+  absl::flat_hash_map<uint64_t, uint64_t> address_to_frame_id;
+  for (const auto& [address, name] : address_to_name) {
+    if (const auto it = name_to_frame_id.find(name); it != name_to_frame_id.end()) {
+      address_to_frame_id[address] = it->second;
+    }
+  }
+  return address_to_frame_id;
+}
+
+[[nodiscard]] std::tuple<absl::flat_hash_map<uint64_t, uint64_t>,
+                         absl::flat_hash_map<uint64_t, uint64_t>,
+                         absl::flat_hash_map<uint64_t, std::string>>
+AssignSampledFunctionIds(
+    const absl::flat_hash_map<uint64_t, std::string>& baseline_address_to_name,
+    const absl::flat_hash_map<uint64_t, std::string>& comparison_address_to_name) {
+  absl::flat_hash_set<std::string> baseline_names = ValueSet(baseline_address_to_name);
+  absl::flat_hash_set<std::string> comparison_names = ValueSet(comparison_address_to_name);
+
+  absl::flat_hash_map<std::string, uint64_t> name_to_frame_id;
+  absl::flat_hash_map<uint64_t, std::string> frame_id_to_name;
+
+  uint64_t next_frame_id = 1;
+  for (const std::string& name : baseline_names) {
+    if (comparison_names.contains(name) && !name_to_frame_id.contains(name)) {
+      name_to_frame_id[name] = next_frame_id;
+      frame_id_to_name[next_frame_id] = name;
+      next_frame_id++;
+    }
+  }
+
+  absl::flat_hash_map<uint64_t, uint64_t> baseline_address_to_sampled_function_id =
+      AddressToSampledFunctionId(baseline_address_to_name, name_to_frame_id);
+  absl::flat_hash_map<uint64_t, uint64_t> comparison_address_to_sampled_function_id =
+      AddressToSampledFunctionId(comparison_address_to_name, name_to_frame_id);
+
+  return std::make_tuple(baseline_address_to_sampled_function_id,
+                         comparison_address_to_sampled_function_id, frame_id_to_name);
+}
+
+}  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonHelper.cpp
+++ b/src/MizarData/BaselineAndComparisonHelper.cpp
@@ -30,10 +30,7 @@ static absl::flat_hash_map<uint64_t, uint64_t> AddressToSampledFunctionId(
   return address_to_frame_id;
 }
 
-[[nodiscard]] std::tuple<absl::flat_hash_map<uint64_t, uint64_t>,
-                         absl::flat_hash_map<uint64_t, uint64_t>,
-                         absl::flat_hash_map<uint64_t, std::string>>
-AssignSampledFunctionIds(
+[[nodiscard]] AddressToIdAndIdToName AssignSampledFunctionIds(
     const absl::flat_hash_map<uint64_t, std::string>& baseline_address_to_name,
     const absl::flat_hash_map<uint64_t, std::string>& comparison_address_to_name) {
   absl::flat_hash_set<std::string> baseline_names = ValueSet(baseline_address_to_name);
@@ -56,8 +53,8 @@ AssignSampledFunctionIds(
   absl::flat_hash_map<uint64_t, uint64_t> comparison_address_to_sampled_function_id =
       AddressToSampledFunctionId(comparison_address_to_name, name_to_frame_id);
 
-  return std::make_tuple(baseline_address_to_sampled_function_id,
-                         comparison_address_to_sampled_function_id, frame_id_to_name);
+  return {std::move(baseline_address_to_sampled_function_id),
+          std::move(comparison_address_to_sampled_function_id), std::move(frame_id_to_name)};
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonHelper.h
+++ b/src/MizarData/BaselineAndComparisonHelper.h
@@ -9,14 +9,20 @@
 #include <absl/container/flat_hash_set.h>
 #include <stdint.h>
 
+#include <string>
+
 namespace orbit_mizar_data {
 
-[[nodiscard]] std::tuple<absl::flat_hash_map<uint64_t, uint64_t>,
-                         absl::flat_hash_map<uint64_t, uint64_t>,
-                         absl::flat_hash_map<uint64_t, std::string>>
-AssignSampledFunctionIds(
+struct AddressToIdAndIdToName {
+  absl::flat_hash_map<uint64_t, uint64_t> baseline_address_to_sampled_function_id;
+  absl::flat_hash_map<uint64_t, uint64_t> comparison_address_to_sampled_function_id;
+  absl::flat_hash_map<uint64_t, std::string> frame_id_to_name;
+};
+
+[[nodiscard]] AddressToIdAndIdToName AssignSampledFunctionIds(
     const absl::flat_hash_map<uint64_t, std::string>& baseline_address_to_name,
     const absl::flat_hash_map<uint64_t, std::string>& comparison_address_to_name);
+
 }  // namespace orbit_mizar_data
 
 #endif  // MIZAR_DATA_BASELINE_AND_COMPARISON_HELPER_H_

--- a/src/MizarData/BaselineAndComparisonHelper.h
+++ b/src/MizarData/BaselineAndComparisonHelper.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_BASELINE_AND_COMPARISON_HELPER_H_
+#define MIZAR_DATA_BASELINE_AND_COMPARISON_HELPER_H_
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <stdint.h>
+
+namespace orbit_mizar_data {
+
+[[nodiscard]] std::tuple<absl::flat_hash_map<uint64_t, uint64_t>,
+                         absl::flat_hash_map<uint64_t, uint64_t>,
+                         absl::flat_hash_map<uint64_t, std::string>>
+AssignSampledFunctionIds(
+    const absl::flat_hash_map<uint64_t, std::string>& baseline_address_to_name,
+    const absl::flat_hash_map<uint64_t, std::string>& comparison_address_to_name);
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_BASELINE_AND_COMPARISON_HELPER_H_

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -48,8 +48,7 @@ auto MakeMap(const Container& keys, const AnotherContainer& values) {
   using std::end;
 
   absl::flat_hash_map<K, V> result;
-  std::transform(begin(keys), end(keys), begin(values),
-                 std::inserter(result, std::begin(result)),
+  std::transform(begin(keys), end(keys), begin(values), std::inserter(result, std::begin(result)),
                  [](const K& k, const V& v) { return std::make_pair(k, v); });
   return result;
 }

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/container/flat_hash_map.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "BaselineAndComparisonHelper.h"
+#include "MizarData/BaselineAndComparison.h"
+
+namespace orbit_mizar_data {
+
+constexpr size_t kFunctionNum = 3;
+constexpr std::array<uint64_t, kFunctionNum> kBaselineFunctionAddresses = {0xF00D, 0xBEAF, 0xDEAF};
+constexpr std::array<uint64_t, kFunctionNum> kComparisonFunctionAddresses = {0x0FF, 0xCAFE, 0xDEA};
+static const std::vector<std::string> kBaselineFunctionNames = {"foo()", "bar()", "biz()"};
+static const std::vector<std::string> kComparisonFunctionNames = {"foo()", "bar()", "fiz()"};
+
+template <typename Container>
+auto Commons(const Container& a, const Container& b) {
+  typedef typename Container::value_type E;
+  absl::flat_hash_set<E> a_set(std::begin(a), std::end(a));
+  std::vector<E> result;
+  std::copy_if(std::begin(b), std::end(b), std::back_inserter(result),
+               [&a_set](const E& element) { return a_set.contains(element); });
+  return result;
+}
+
+static const std::vector<std::string> kCommonFunctionNames =
+    Commons(kBaselineFunctionNames, kComparisonFunctionNames);
+
+template <typename Container, typename AnotherContainer>
+auto MakeMap(const Container& keys, const AnotherContainer& values) {
+  typedef typename Container::value_type K;
+  typedef typename AnotherContainer::value_type V;
+
+  absl::flat_hash_map<K, V> result;
+  std::transform(std::begin(keys), std::end(keys), std::begin(values),
+                 std::inserter(result, std::begin(result)),
+                 [](const K& k, const V& v) { return std::make_pair(k, v); });
+  return result;
+}
+
+static const absl::flat_hash_map<uint64_t, std::string> kBaselineAddressToName =
+    MakeMap(kBaselineFunctionAddresses, kBaselineFunctionNames);
+static const absl::flat_hash_map<uint64_t, std::string> kComparisonAddressToName =
+    MakeMap(kComparisonFunctionAddresses, kComparisonFunctionNames);
+
+void ExpectCorrectNames(const absl::flat_hash_map<uint64_t, uint64_t>& address_to_id,
+                        const absl::flat_hash_map<uint64_t, std::string>& id_to_name,
+                        const absl::flat_hash_map<uint64_t, std::string>& address_to_name) {
+  for (const auto& [address, id] : address_to_id) {
+    if (id_to_name.contains(address)) {
+      EXPECT_EQ(id_to_name.at(address), address_to_name.at(address));
+    }
+  }
+}
+
+template <typename K, typename V>
+std::vector<V> Values(const absl::flat_hash_map<K, V>& map) {
+  std::vector<V> values;
+  std::transform(std::begin(map), std::end(map), std::back_inserter(values),
+                 [](const std::pair<K, V> pair) { return pair.second; });
+  return values;
+}
+
+TEST(BaselineAndComparisonTest, BaselineAndComparisonHelperIsCorrect) {
+  const auto [baseline_address_to_sampled_function_id, comparison_address_to_sampled_function_id,
+              sampled_function_id_id_to_name] =
+      AssignSampledFunctionIds(kBaselineAddressToName, kComparisonAddressToName);
+
+  EXPECT_EQ(baseline_address_to_sampled_function_id.size(), kCommonFunctionNames.size());
+  EXPECT_EQ(comparison_address_to_sampled_function_id.size(), kCommonFunctionNames.size());
+  EXPECT_EQ(sampled_function_id_id_to_name.size(), kCommonFunctionNames.size());
+
+  ExpectCorrectNames(baseline_address_to_sampled_function_id, sampled_function_id_id_to_name,
+                     kBaselineAddressToName);
+  ExpectCorrectNames(comparison_address_to_sampled_function_id, sampled_function_id_id_to_name,
+                     kComparisonAddressToName);
+
+  EXPECT_THAT(
+      Values(baseline_address_to_sampled_function_id),
+      testing::UnorderedElementsAreArray(Values(comparison_address_to_sampled_function_id)));
+}
+
+}  // namespace orbit_mizar_data

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -7,12 +7,16 @@ cmake_minimum_required(VERSION 3.15)
 add_library(MizarData STATIC)
 
 target_sources(MizarData PUBLIC 
+         include/MizarData/BaselineAndComparison.h
          include/MizarData/MizarData.h
          include/MizarData/MizarDataProvider.h)
 
 target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include) 
 
 target_sources(MizarData PRIVATE
+                BaselineAndComparison.cpp
+                BaselineAndComparisonHelper.h
+                BaselineAndComparisonHelper.cpp
                 MizarData.cpp)
 
 
@@ -28,7 +32,10 @@ target_link_libraries(
 
 add_executable(MizarDataTests)
 
-target_sources(MizarDataTests PRIVATE MizarDataTest.cpp)
+target_sources(MizarDataTests PRIVATE 
+                BaselineAndComparisonTest.cpp
+                MizarDataTest.cpp)
+
 target_link_libraries(MizarDataTests PRIVATE GrpcProtos
                                                 MizarData
                                                 GTest::GTest

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -33,7 +33,7 @@ namespace orbit_mizar_data {
         for (const uint64_t address : info.frames()) {
           std::optional<std::string> name = this->GetFunctionNameFromAddress(address);
           if (name.has_value()) {
-            result[address] = name.value();
+            result.try_emplace(address, std::move(name.value()));
           }
         }
       });

--- a/src/MizarData/MizarDataTest.cpp
+++ b/src/MizarData/MizarDataTest.cpp
@@ -23,6 +23,10 @@
 #include "GrpcProtos/capture.pb.h"
 #include "MizarData/MizarData.h"
 
+using ::testing::Invoke;
+using ::testing::UnorderedElementsAre;
+using ::testing::UnorderedPointwise;
+
 namespace orbit_mizar_data {
 
 using google::protobuf::util::MessageDifferencer;
@@ -115,7 +119,7 @@ TEST(MizarDataTest, OnTimerAddsDAndMSAndOnlyThem) {
   std::transform(std::begin(stored_timers_ptrs), std::end(stored_timers_ptrs),
                  std::back_inserter(stored_timers), [](const TimerInfo* ptr) { return (*ptr); });
 
-  EXPECT_THAT(stored_timers, testing::UnorderedPointwise(TimerInfosEq(), kTimersToStore));
+  EXPECT_THAT(stored_timers, UnorderedPointwise(TimerInfosEq(), kTimersToStore));
 }
 
 constexpr uint64_t kFunctionAddress = 0xBEAF;
@@ -150,9 +154,6 @@ static const orbit_client_data::CallstackEvent kCallstackEvent(kTime, kCallstack
 static const absl::flat_hash_map<uint64_t, std::string> kSymbolsTable = {
     {kFunctionAddress, kFunctionName}, {kAnotherFunctionAddress, "food()"}};
 
-using ::testing::Invoke;
-using ::testing::UnorderedElementsAreArray;
-
 TEST(MizarDataTest, AllAddressToNameIsCorrect) {
   MockMizarData data;
 
@@ -170,6 +171,6 @@ TEST(MizarDataTest, AllAddressToNameIsCorrect) {
   data.OnCaptureFinished({});
 
   EXPECT_THAT(data.AllAddressToName(),
-              UnorderedElementsAreArray({make_pair(kFunctionAddress, kFunctionName)}));
+              UnorderedElementsAre(std::make_pair(kFunctionAddress, kFunctionName)));
 }
 }  // namespace orbit_mizar_data

--- a/src/MizarData/MizarDataTest.cpp
+++ b/src/MizarData/MizarDataTest.cpp
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
@@ -10,8 +12,11 @@
 #include <array>
 #include <cstdint>
 #include <iterator>
+#include <optional>
+#include <string>
 #include <vector>
 
+#include "ClientData/CallstackInfo.h"
 #include "ClientData/LinuxAddressInfo.h"
 #include "ClientData/ScopeInfo.h"
 #include "ClientProtos/capture_data.pb.h"
@@ -114,7 +119,8 @@ TEST(MizarDataTest, OnTimerAddsDAndMSAndOnlyThem) {
 }
 
 constexpr uint64_t kFunctionAddress = 0xBEAF;
-constexpr uint64_t kUnknownFunctionAddress = 0xF00D;
+constexpr uint64_t kAnotherFunctionAddress = 0xF00D;
+constexpr uint64_t kUnknownFunctionAddress = 0xBAD;
 const orbit_client_data::LinuxAddressInfo kLinuxAddressInfo(kFunctionAddress, 0, "/module/path",
                                                             kFunctionName);
 
@@ -130,4 +136,40 @@ TEST(MizarDataTest, GetFunctionNameFromAddressIsCorrect) {
   EXPECT_FALSE(data.GetFunctionNameFromAddress(kUnknownFunctionAddress));
 }
 
+class MockMizarData : public MizarData {
+ public:
+  MOCK_METHOD(std::optional<std::string>, GetFunctionNameFromAddress, (uint64_t), (const override));
+};
+
+const uint64_t kTime = 951753;
+const orbit_client_data::CallstackInfo kCallstackInfo({kFunctionAddress, kUnknownFunctionAddress,
+                                                       kFunctionAddress},
+                                                      orbit_client_data::CallstackType::kComplete);
+constexpr uint64_t kCallstackId = 0xCA11;
+static const orbit_client_data::CallstackEvent kCallstackEvent(kTime, kCallstackId, kTID);
+static const absl::flat_hash_map<uint64_t, std::string> kSymbolsTable = {
+    {kFunctionAddress, kFunctionName}, {kAnotherFunctionAddress, "food()"}};
+
+using ::testing::Invoke;
+using ::testing::UnorderedElementsAreArray;
+
+TEST(MizarDataTest, AllAddressToNameIsCorrect) {
+  MockMizarData data;
+
+  EXPECT_CALL(data, GetFunctionNameFromAddress)
+      .WillRepeatedly(Invoke([](uint64_t addr) -> std::optional<std::string> {
+        if (const auto it = kSymbolsTable.find(addr); it != kSymbolsTable.end()) {
+          return it->second;
+        }
+        return std::nullopt;
+      }));
+
+  CallOnCaptureStarted(data);
+  data.OnUniqueCallstack(kCallstackId, kCallstackInfo);
+  data.OnCallstackEvent(kCallstackEvent);
+  data.OnCaptureFinished({});
+
+  EXPECT_THAT(data.AllAddressToName(),
+              UnorderedElementsAreArray({make_pair(kFunctionAddress, kFunctionName)}));
+}
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -20,6 +20,9 @@ struct MizarDataWithSampledFunctionId {
   absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id;
 };
 
+// The class owns the data from two capture files via owning two instances of
+// `MizarDataWithSampledFunctionId`. Also owns the map from sampled function ids to the
+// corresponding function names.
 class BaselineAndComparison {
  public:
   BaselineAndComparison(MizarDataWithSampledFunctionId baseline,

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -17,11 +17,12 @@ namespace orbit_mizar_data {
 
 struct MizarDataWithSampledFunctionId {
   MizarDataWithSampledFunctionId(
-      MizarData data, absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id)
+      std::unique_ptr<MizarDataProvider> data,
+      absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id)
       : data(std::move(data)),
         address_to_sampled_function_id(std::move(address_to_sampled_function_id)) {}
 
-  MizarData data;
+  std::unique_ptr<MizarDataProvider> data;
   absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id;
 };
 
@@ -48,8 +49,8 @@ class BaselineAndComparison {
   absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name_;
 };
 
-orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(MizarData baseline,
-                                                                    MizarData comparison);
+orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(
+    std::unique_ptr<MizarDataProvider> baseline, std::unique_ptr<MizarDataProvider> comparison);
 
 }  // namespace orbit_mizar_data
 

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -16,7 +16,12 @@
 namespace orbit_mizar_data {
 
 struct MizarDataWithSampledFunctionId {
-  const MizarData& data;
+  MizarDataWithSampledFunctionId(
+      MizarData data, absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id)
+      : data(std::move(data)),
+        address_to_sampled_function_id(std::move(address_to_sampled_function_id)) {}
+
+  MizarData data;
   absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id;
 };
 
@@ -43,8 +48,8 @@ class BaselineAndComparison {
   absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name_;
 };
 
-orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(const MizarData& baseline,
-                                                                    const MizarData& comparison);
+orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(MizarData baseline,
+                                                                    MizarData comparison);
 
 }  // namespace orbit_mizar_data
 

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_BASELINE_AND_COMPARISON_H_
+#define MIZAR_DATA_BASELINE_AND_COMPARISON_H_
+
+#include <absl/container/flat_hash_set.h>
+
+#include <cstdint>
+#include <utility>
+
+#include "ClientData/CaptureData.h"
+#include "MizarData/MizarData.h"
+
+namespace orbit_mizar_data {
+
+struct MizarDataWithSampledFunctionId {
+  const MizarData& data;
+  absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id;
+};
+
+class BaselineAndComparison {
+ public:
+  BaselineAndComparison(MizarDataWithSampledFunctionId baseline,
+                        MizarDataWithSampledFunctionId comparison,
+                        absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name)
+      : baseline_(std::move(baseline)),
+        comparison_(std::move(comparison)),
+        sampled_function_id_to_name_(std::move(sampled_function_id_to_name)) {}
+
+  [[nodiscard]] const absl::flat_hash_map<uint64_t, std::string>& sampled_function_id_to_name()
+      const {
+    return sampled_function_id_to_name_;
+  }
+
+ private:
+  MizarDataWithSampledFunctionId baseline_;
+  MizarDataWithSampledFunctionId comparison_;
+  absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name_;
+};
+
+orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(const MizarData& baseline,
+                                                                    const MizarData& comparison);
+
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_BASELINE_AND_COMPARISON_H_

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -25,6 +25,8 @@
 
 namespace orbit_mizar_data {
 
+// This class is used by Mizar to read a capture file and load the symbols.
+// Also owns a map from the function absolute addresses to their names.
 class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData>,
                   public MizarDataProvider {
  public:

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -39,7 +39,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
 
   virtual ~MizarData() = default;
 
-  [[nodiscard]] absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const;
+  [[nodiscard]] absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const override;
 
   // virtual for testing purposes
   [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -5,6 +5,8 @@
 #ifndef MIZAR_DATA_MIZAR_DATA_H_
 #define MIZAR_DATA_MIZAR_DATA_H_
 
+#include <absl/container/flat_hash_set.h>
+
 #include <memory>
 #include <optional>
 #include <vector>
@@ -28,7 +30,10 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
  public:
   virtual ~MizarData() = default;
 
-  [[nodiscard]] std::optional<std::string> GetFunctionNameFromAddress(
+  [[nodiscard]] absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const;
+
+  // virtual for testing purposes
+  [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(
       uint64_t address) const override;
 
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -41,8 +41,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
 
   [[nodiscard]] absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const override;
 
-  // virtual for testing purposes
-  [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(
+  [[nodiscard]] std::optional<std::string> GetFunctionNameFromAddress(
       uint64_t address) const override;
 
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -30,6 +30,13 @@ namespace orbit_mizar_data {
 class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData>,
                   public MizarDataProvider {
  public:
+  MizarData() = default;
+  MizarData(MizarData&) = delete;
+  MizarData& operator=(const MizarData& other) = delete;
+
+  MizarData(MizarData&& other) = default;
+  MizarData& operator=(MizarData&& other) = delete;
+
   virtual ~MizarData() = default;
 
   [[nodiscard]] absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const;

--- a/src/MizarData/include/MizarData/MizarDataProvider.h
+++ b/src/MizarData/include/MizarData/MizarDataProvider.h
@@ -30,6 +30,7 @@ class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
 
   [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(
       uint64_t address) const = 0;
+  [[nodiscard]] virtual absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const = 0;
 };
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/MizarDataProvider.h
+++ b/src/MizarData/include/MizarData/MizarDataProvider.h
@@ -18,6 +18,14 @@ namespace orbit_mizar_data {
 // Handles one of the two datasets Mizar operates on
 class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
  public:
+  MizarDataProvider() = default;
+
+  MizarDataProvider(MizarDataProvider&) = delete;
+  MizarDataProvider& operator=(const MizarDataProvider& other) = delete;
+
+  MizarDataProvider(MizarDataProvider&&) = default;
+  MizarDataProvider& operator=(MizarDataProvider&& other) = default;
+
   virtual ~MizarDataProvider() = default;
 
   [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(


### PR DESCRIPTION
This adds `BaselineAndComparison`. For now it
assigns ids to the sampled functions.

Tests: Unit
Bug: http://b/234720314