### PR TITLE
Also use COFF symbol table (on top of DWARF) to load symbols from a PE

### DIFF
--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -227,7 +227,7 @@ void FillDebugSymbolsFromDwarf(llvm::DWARFContext* dwarf_context,
   std::sort(sorted_symbol_infos->begin(), sorted_symbol_infos->end(), &SymbolInfoLessByAddress);
 }
 
-static void DeduceDebugSymbolMissingSizes(std::vector<SymbolInfo>* sorted_symbol_infos) {
+void DeduceDebugSymbolMissingSizes(std::vector<SymbolInfo>* sorted_symbol_infos) {
   // We don't have sizes for functions obtained from the COFF symbol table. For these, compute the
   // size as the distance from the address of the next function.
   for (size_t i = 0; i < sorted_symbol_infos->size(); ++i) {

--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -48,6 +48,13 @@ class CoffFileImpl : public CoffFile {
   [[nodiscard]] ErrorMessageOr<PdbDebugInfo> GetDebugPdbInfo() const override;
 
  private:
+  [[nodiscard]] std::optional<uint64_t> GetVirtualAddressOfSymbolSection(
+      const llvm::object::SymbolRef& symbol_ref);
+  [[nodiscard]] std::optional<SymbolInfo> CreateSymbolInfo(
+      const llvm::object::SymbolRef& symbol_ref);
+  void AddNewDebugSymbolsFromCoffSymbolTable(
+      const llvm::object::ObjectFile::symbol_iterator_range& symbol_range,
+      std::vector<SymbolInfo>* sorted_symbol_infos);
   [[nodiscard]] bool AreDebugSymbolsEmpty() const;
 
   const std::filesystem::path file_path_;
@@ -64,7 +71,7 @@ CoffFileImpl::CoffFileImpl(std::filesystem::path file_path,
       has_debug_info_(false) {
   object_file_ = llvm::dyn_cast<llvm::object::COFFObjectFile>(owning_binary_.getBinary());
   const auto dwarf_context = llvm::DWARFContext::create(*owning_binary_.getBinary());
-  if (dwarf_context != nullptr) {
+  if (object_file_->getSymbolTable() != 0 || dwarf_context != nullptr) {
     has_debug_info_ = true;
   }
 }
@@ -86,49 +93,196 @@ ErrorMessageOr<void> CoffFileImpl::Initialize() {
   return ErrorMessage(std::move(error));
 }
 
-static void FillDebugSymbolsFromDWARF(llvm::DWARFContext* dwarf_context,
-                                      ModuleSymbols* module_symbols) {
+std::optional<uint64_t> CoffFileImpl::GetVirtualAddressOfSymbolSection(
+    const llvm::object::SymbolRef& symbol_ref) {
+  // Symbols in the COFF symbol table contain the offset relative to the start of the section. To
+  // compute the symbol's address relative to the start of the object file (RVA), we need to find
+  // the virtual address of the section.
+  llvm::object::COFFSymbolRef coff_symbol_ref = object_file_->getCOFFSymbol(symbol_ref);
+  int32_t section_index = coff_symbol_ref.getSectionNumber();
+  llvm::Expected<const llvm::object::coff_section*> section =
+      object_file_->getSection(section_index);
+  if (!section) {
+    return std::nullopt;
+  }
+  return section.get()->VirtualAddress;
+}
+
+uint64_t kUnknownSymbolSize = std::numeric_limits<uint64_t>::max();
+
+std::optional<SymbolInfo> CoffFileImpl::CreateSymbolInfo(
+    const llvm::object::SymbolRef& symbol_ref) {
+  ORBIT_CHECK(symbol_ref.getType());
+  ORBIT_CHECK(symbol_ref.getType().get() == llvm::object::SymbolRef::ST_Function);
+
+  if (!symbol_ref.getFlags() ||
+      (symbol_ref.getFlags().get() & llvm::object::BasicSymbolRef::SF_Undefined) != 0) {
+    return std::nullopt;
+  }
+
+  // The symbol's "Value" is the offset in the section.
+  if (!symbol_ref.getValue()) {
+    return std::nullopt;
+  }
+  auto section_offset = GetVirtualAddressOfSymbolSection(symbol_ref);
+  if (!section_offset.has_value()) {
+    return std::nullopt;
+  }
+
+  const std::string name = symbol_ref.getName() ? symbol_ref.getName().get().str() : "";
+  const uint64_t symbol_virtual_address =
+      GetLoadBias() + section_offset.value() + symbol_ref.getValue().get();
+
+  SymbolInfo symbol_info;
+  symbol_info.set_demangled_name(llvm::demangle(name));
+  symbol_info.set_address(symbol_virtual_address);
+
+  // The COFF symbol table doesn't contain the size of symbols. Set a placeholder for now.
+  symbol_info.set_size(kUnknownSymbolSize);
+
+  return symbol_info;
+}
+
+// Comparator to sort SymbolInfos by address, and perform the corresponding binary searches.
+bool SymbolInfoLessByAddress(const SymbolInfo& lhs, const SymbolInfo& rhs) {
+  return lhs.address() < rhs.address();
+}
+
+void CoffFileImpl::AddNewDebugSymbolsFromCoffSymbolTable(
+    const llvm::object::ObjectFile::symbol_iterator_range& symbol_range,
+    std::vector<SymbolInfo>* sorted_symbol_infos) {
+  std::vector<SymbolInfo> new_symbol_infos;
+
+  for (const auto& symbol_ref : symbol_range) {
+    if (!symbol_ref.getType() ||
+        symbol_ref.getType().get() != llvm::object::SymbolRef::ST_Function) {
+      // The symbol is not a function (or has unknown type). We skip it as we only list symbols of
+      // functions, ignoring sections and variables.
+      continue;
+    }
+
+    auto symbol_or_error = CreateSymbolInfo(symbol_ref);
+    if (!symbol_or_error.has_value()) {
+      continue;
+    }
+    SymbolInfo& symbol_info = symbol_or_error.value();
+
+    auto symbol_from_dwarf_it =
+        std::lower_bound(sorted_symbol_infos->begin(), sorted_symbol_infos->end(), symbol_info,
+                         &SymbolInfoLessByAddress);
+    if (symbol_from_dwarf_it != sorted_symbol_infos->end() &&
+        symbol_info.address() == symbol_from_dwarf_it->address()) {
+      // A symbol with this exact address was already extracted from the DWARF debug info.
+      continue;
+    }
+
+    if (symbol_from_dwarf_it != sorted_symbol_infos->begin()) {
+      symbol_from_dwarf_it--;
+      if (symbol_info.address() < symbol_from_dwarf_it->address() + symbol_from_dwarf_it->size()) {
+        // The address of this symbol from the COFF symbol table is inside the address range of a
+        // symbol already extracted from the DWARF debug info.
+        continue;
+      }
+    }
+
+    new_symbol_infos.emplace_back(std::move(symbol_info));
+  }
+
+  ORBIT_LOG(
+      "Added %u function symbols from COFF symbol table on top of %u from DWARF debug info for "
+      "\"%s\"",
+      new_symbol_infos.size(), sorted_symbol_infos->size(), file_path_.string());
+  sorted_symbol_infos->insert(sorted_symbol_infos->end(),
+                              std::make_move_iterator(new_symbol_infos.begin()),
+                              std::make_move_iterator(new_symbol_infos.end()));
+  std::sort(sorted_symbol_infos->begin(), sorted_symbol_infos->end(), &SymbolInfoLessByAddress);
+}
+
+void FillDebugSymbolsFromDwarf(llvm::DWARFContext* dwarf_context,
+                               std::vector<SymbolInfo>* sorted_symbol_infos) {
   for (const auto& info_section : dwarf_context->compile_units()) {
     for (uint32_t index = 0; index < info_section->getNumDIEs(); ++index) {
       llvm::DWARFDie full_die = info_section->getDIEAtIndex(index);
-      // We only want symbols of functions, which are DIEs with isSubprogramDIR()
+      // We only want symbols of functions, which are DIEs with isSubprogramDIR(),
       // and not of inlined functions, which are DIEs with isSubroutineDIE().
       if (full_die.isSubprogramDIE()) {
-        SymbolInfo symbol_info;
         uint64_t low_pc;
         uint64_t high_pc;
         uint64_t unused_section_index;
         if (!full_die.getLowAndHighPC(low_pc, high_pc, unused_section_index)) {
           continue;
         }
-        // The method getName will fallback to ShortName if LinkageName is
-        // not present, so this should never return an empty name.
+
+        SymbolInfo& symbol_info = sorted_symbol_infos->emplace_back();
+        // The method getName will fall back to ShortName if LinkageName is not present,
+        // so this should never return an empty name.
         std::string name(full_die.getName(llvm::DINameKind::LinkageName));
         ORBIT_CHECK(!name.empty());
         symbol_info.set_demangled_name(llvm::demangle(name));
         symbol_info.set_address(low_pc);
         symbol_info.set_size(high_pc - low_pc);
-        *(module_symbols->add_symbol_infos()) = std::move(symbol_info);
       }
     }
   }
+
+  std::sort(sorted_symbol_infos->begin(), sorted_symbol_infos->end(), &SymbolInfoLessByAddress);
 }
 
+// The COFF symbol table doesn't contain the size of functions. If present, the DWARF debug info
+// contains the sizes. However, we observed that the DWARF debug info misses some functions compared
+// to the COFF symbol table.
+// We integrate the two: we retrieve symbols from the DWARF debug info, and then we add symbols from
+// the COFF symbol table, but only the ones that were not in the DWARF debug info (based on their
+// address).
+// For the symbols that came from the COFF symbol table, we compute the size as the distance from
+// the address of the next function. In general this will overestimate the size of function, but we
+// prefer this to not listing the function at all.
+// Note: In some rare cases we observed that the address reported by the COFF symbol table is
+// slightly lower (e.g., by one instruction) that the one reported by the DWARF debug info. As we
+// don't have a simple way to deduce that the two addresses belong to the same function, such
+// function will appear twice in the symbol list. We accept this.
 ErrorMessageOr<ModuleSymbols> CoffFileImpl::LoadDebugSymbols() {
-  const auto dwarf_context = llvm::DWARFContext::create(*owning_binary_.getBinary());
-  if (dwarf_context == nullptr) {
-    return ErrorMessage("Could not create DWARF context.");
+  std::vector<SymbolInfo> sorted_symbol_infos;
+
+  const std::unique_ptr<llvm::DWARFContext> dwarf_context =
+      llvm::DWARFContext::create(*object_file_);
+  if (dwarf_context != nullptr) {
+    FillDebugSymbolsFromDwarf(dwarf_context.get(), &sorted_symbol_infos);
+  }
+
+  if (object_file_->getSymbolTable() != 0 && object_file_->getNumberOfSymbols() != 0) {
+    AddNewDebugSymbolsFromCoffSymbolTable(object_file_->symbols(), &sorted_symbol_infos);
+  }
+
+  // We don't have sizes for functions obtained from the COFF symbol table. Compute it as the
+  // distance from the address of the next function.
+  for (size_t i = 0; i < sorted_symbol_infos.size(); ++i) {
+    SymbolInfo& symbol_info = sorted_symbol_infos[i];
+    if (symbol_info.size() != kUnknownSymbolSize) {
+      // This function symbol was from DWARF debug info and already has a size.
+      continue;
+    }
+
+    if (i < sorted_symbol_infos.size() - 1) {
+      // Deduce the size as the distance from the next function's address.
+      symbol_info.set_size(sorted_symbol_infos[i + 1].address() - symbol_info.address());
+    } else {
+      // If the last symbol doesn't have a size, we can't deduce it, and we just set it to zero.
+      symbol_info.set_size(0);
+    }
+  }
+
+  if (sorted_symbol_infos.empty()) {
+    return ErrorMessage(
+        "Unable to load symbols from PE/COFF file, not even a single symbol of type function "
+        "found.");
   }
 
   ModuleSymbols module_symbols;
+  module_symbols.set_load_bias(GetLoadBias());
   module_symbols.set_symbols_file_path(file_path_.string());
-
-  FillDebugSymbolsFromDWARF(dwarf_context.get(), &module_symbols);
-
-  if (module_symbols.symbol_infos_size() == 0) {
-    return ErrorMessage(
-        "Unable to load symbols from object file, not even a single symbol of "
-        "type function found.");
+  for (SymbolInfo& symbol_info : sorted_symbol_infos) {
+    *module_symbols.add_symbol_infos() = std::move(symbol_info);
   }
   return module_symbols;
 }
@@ -136,9 +290,14 @@ ErrorMessageOr<ModuleSymbols> CoffFileImpl::LoadDebugSymbols() {
 bool CoffFileImpl::HasDebugSymbols() const { return has_debug_info_ && !AreDebugSymbolsEmpty(); }
 
 bool CoffFileImpl::AreDebugSymbolsEmpty() const {
-  const auto dwarf_context = llvm::DWARFContext::create(*owning_binary_.getBinary());
+  if (object_file_->getSymbolTable() != 0 && object_file_->getNumberOfSymbols() != 0) {
+    return false;
+  }
+
+  const std::unique_ptr<llvm::DWARFContext> dwarf_context =
+      llvm::DWARFContext::create(*object_file_);
   if (dwarf_context == nullptr) {
-    ORBIT_ERROR("Could not create DWARF context.");
+    ORBIT_ERROR("Could not create DWARF context for \"%s\"", file_path_.string());
     return true;
   }
 


### PR DESCRIPTION
Originally we were loading symbols from the COFF symbol table.
However, this doesn't contain function sizes, so
https://github.com/google/orbit/pull/2489 switched to using DWARF debug info.
But the DWARF debug info misses some functions compared to the COFF symbol
table.

We bring back the use of the COFF symbol table and integrate its information
with the DWARF debug info. Functions that are in the COFF symbol table but not
in the DWARF debug info are added to the symbol list, and their size is computed
as the distance from the next function. This can overestimate the size but is
better than not showing the function at all.

Note that this is mostly for Silenus, as MinGW adds the COFF symbol table and
the DWARF debug info to the DLLs. Other cases normally use PDB files.

Bug: http://b/234585733

Test:
- Update unit tests.
- The missing symbols for Silenus's `ntdll.dll` now show up. For example
  `NtQueryPerformanceCounter` (which triggered this investigation), which also
  has its size set correctly and can now be shown in Orbit's disassembly.