### PR TITLE
Have Allstar ignore needed binary artifacts

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,10 @@
+# Ignore reason: These files are needed in unit tests
+ignorePaths:
+  - third_party/libunwindstack/offline_files/apk_rorx_arm64/run
+  - third_party/libunwindstack/offline_files/apk_rorx_unreadable_arm64/run
+  - third_party/libunwindstack/offline_files/apk_rx_arm64/run
+  - third_party/libunwindstack/offline_files/apk_rx_unreadable_arm64/run
+  - third_party/libunwindstack/tests/files/boot_arm.oat
+  - third_party/libunwindstack/tests/files/boot_arm.oat.gnu_debugdata
+  - third_party/libunwindstack/tests/files/libtest.dll
+  - third_party/libunwindstack/tests/files/libtest32.dl


### PR DESCRIPTION
There is a new security scanner for Google OSS projects that complains
about binary artifacts in our repo (#3756 and http://go/allstar).

This should disable to check for the listed files according to the
documentation.