### PR TITLE
Make PeCoff::GetRelPc independent from the text section's VirtualAddress

### DIFF
--- a/third_party/libunwindstack/PeCoff.cpp
+++ b/third_party/libunwindstack/PeCoff.cpp
@@ -148,7 +148,7 @@ uint64_t PeCoff::GetRelPc(uint64_t pc, MapInfo* map_info) {
   if (!valid_) {
     return 0;
   }
-  return interface_->GetRelPc(pc, map_info->start());
+  return interface_->GetRelPc(pc, map_info->start(), map_info->object_offset());
 }
 
 bool PeCoff::StepIfSignalHandler(uint64_t, Regs*, Memory*) {

--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -152,7 +152,7 @@ class PeCoffInterface {
   virtual ErrorCode LastErrorCode() = 0;
   virtual uint64_t LastErrorAddress() = 0;
   virtual DwarfSection* DebugFrameSection() = 0;
-  virtual uint64_t GetRelPc(uint64_t pc, uint64_t map_start) const = 0;
+  virtual uint64_t GetRelPc(uint64_t pc, uint64_t map_start, uint64_t map_object_offset) = 0;
   virtual bool GetTextRange(uint64_t* addr, uint64_t* size) const = 0;
   virtual uint64_t GetTextOffsetInFile() const = 0;
   virtual bool Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
@@ -175,7 +175,7 @@ class PeCoffInterfaceImpl : public PeCoffInterface {
   uint64_t LastErrorAddress() override { return last_error_.address; }
 
   DwarfSection* DebugFrameSection() override { return debug_frame_.get(); }
-  uint64_t GetRelPc(uint64_t pc, uint64_t map_start) const override;
+  uint64_t GetRelPc(uint64_t pc, uint64_t map_start, uint64_t map_object_offset) override;
   bool GetTextRange(uint64_t* addr, uint64_t* size) const override;
   uint64_t GetTextOffsetInFile() const override;
   bool Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
@@ -229,6 +229,7 @@ class PeCoffInterfaceImpl : public PeCoffInterface {
   bool InitSections();
   bool InitDebugFrameSection();
   bool MapFromRvaToFileOffset(uint64_t rva, uint64_t* file_offset);
+  bool MapFromFileOffsetToRva(uint64_t file_offset, uint64_t* rva);
   bool InitNativeUnwinder();
 };
 

--- a/third_party/libunwindstack/tests/PeCoffTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffTest.cpp
@@ -37,7 +37,7 @@ class MockPeCoffInterface : public PeCoffInterface {
   MOCK_METHOD(ErrorCode, LastErrorCode, (), (override));
   MOCK_METHOD(uint64_t, LastErrorAddress, (), (override));
   MOCK_METHOD(DwarfSection*, DebugFrameSection, (), (override));
-  MOCK_METHOD(uint64_t, GetRelPc, (uint64_t, uint64_t), (const override));
+  MOCK_METHOD(uint64_t, GetRelPc, (uint64_t, uint64_t, uint64_t), (override));
   MOCK_METHOD(bool, GetTextRange, (uint64_t*, uint64_t*), (const override));
   MOCK_METHOD(uint64_t, GetTextOffsetInFile, (), (const override));
   MOCK_METHOD(bool, Step, (uint64_t, uint64_t, Regs*, Memory*, bool*, bool*), (override));
@@ -141,16 +141,18 @@ TYPED_TEST(PeCoffTest, rel_pc_is_correctly_passed_through) {
   constexpr uint64_t kPcValue = 0x2000;
   constexpr uint64_t kMapStart = 0x1000;
   constexpr uint64_t kMapEnd = 0x4000;
+  constexpr uint64_t kMapObjectOffset = 0x200;
 
   // This test is not testing whether the GetRelPc computation is correct, only whether the
   // return value from PeCoffInterface::GetRelPc is correctly passed through.
   constexpr uint64_t kMockReturnValue = 0x3000;
   MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
-  EXPECT_CALL(*mock_interface, GetRelPc(kPcValue, kMapStart))
+  EXPECT_CALL(*mock_interface, GetRelPc(kPcValue, kMapStart, kMapObjectOffset))
       .WillOnce(::testing::Return(kMockReturnValue));
   coff.SetFakePeCoffInterface(mock_interface);
 
   auto map_info = MapInfo::Create(/*start=*/kMapStart, /*end=*/kMapEnd, 0, 0, "no_name");
+  map_info->set_object_offset(kMapObjectOffset);
   EXPECT_EQ(kMockReturnValue, coff.GetRelPc(kPcValue, map_info.get()));
 }
 


### PR DESCRIPTION
Before, `PeCoff::GetRelPc` was assuming that the start of the map coincide with
the start of the executable section. For some games on Silenus we have seen that
this doesn't always hold, as a single executable section can end up being mapped
into multiple executable maps. `PeCoff::GetRelPc` can be made more generic to
support this, by applying the same logic as `Elf::GetRelPc`, which makes use of
`MapInfo::object_offset`. Compared to `Elf`, for PEs the offset in the file
isn't equal to the offset in memory relative to the load bias, so we need to
convert from file offset to RVA. For this, we add
`PeCoffInterface::MapFromFileOffsetToRva`.

Bug: http://b/234826808

Test:
- Update unit tests.
- Tried on complex Silenus game: the unwind errors targeted by this fix are
  gone.
- Tried on `triangle.exe`: unwinding still works correctly. This case is
  important because the alignment of `triangle.exe`'s executable section makes
  it so that Wine has to map it into an anonymous map.