### PR TITLE
Represent callstacks as sequences of sampled function ids

### DIFF
--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -56,7 +56,7 @@ class CallstackData {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
       for (const auto& [unused_timestamp, event] : events) {
-        action(event);
+        std::invoke(std::forward<Action>(action), event);
       }
     }
   }
@@ -69,7 +69,7 @@ class CallstackData {
     for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
       for (auto event_it = events.lower_bound(min_timestamp);
            event_it != events.upper_bound(max_timestamp); ++event_it) {
-        action(event_it->second);
+        std::invoke(std::forward<Action>(action), event_it->second);
       }
     }
   }
@@ -86,7 +86,7 @@ class CallstackData {
     const auto& events = tid_and_events_it->second;
     for (auto event_it = events.lower_bound(min_timestamp);
          event_it != events.upper_bound(max_timestamp); ++event_it) {
-      action(event_it->second);
+      std::invoke(std::forward<Action>(action), event_it->second);
     }
   }
 
@@ -108,7 +108,7 @@ class CallstackData {
   void ForEachUniqueCallstack(Action&& action) const {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     for (const auto& [callstack_id, callstack_ptr] : unique_callstacks_) {
-      action(callstack_id, *callstack_ptr);
+      std::invoke(std::forward<Action>(action), callstack_id, *callstack_ptr);
     }
   }
 

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -9,7 +9,6 @@
 #include <absl/container/flat_hash_map.h>
 #include <stdint.h>
 
-#include <functional>
 #include <limits>
 #include <map>
 #include <memory>
@@ -20,6 +19,7 @@
 #include "ClientData/CallstackEvent.h"
 #include "ClientData/CallstackInfo.h"
 #include "ClientProtos/capture_data.pb.h"
+#include "OrbitBase/Logging.h"
 
 namespace orbit_client_data {
 
@@ -51,16 +51,44 @@ class CallstackData {
   [[nodiscard]] std::vector<orbit_client_data::CallstackEvent> GetCallstackEventsOfTidInTimeRange(
       uint32_t tid, uint64_t time_begin, uint64_t time_end) const;
 
-  void ForEachCallstackEvent(
-      const std::function<void(const orbit_client_data::CallstackEvent&)>& action) const;
+  template <typename Action>
+  void ForEachCallstackEvent(Action&& action) const {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
+      for (const auto& [unused_timestamp, event] : events) {
+        action(event);
+      }
+    }
+  }
 
-  void ForEachCallstackEventInTimeRange(
-      uint64_t min_timestamp, uint64_t max_timestamp,
-      const std::function<void(const orbit_client_data::CallstackEvent&)>& action) const;
+  template <typename Action>
+  void ForEachCallstackEventInTimeRange(uint64_t min_timestamp, uint64_t max_timestamp,
+                                        Action&& action) const {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    ORBIT_CHECK(min_timestamp <= max_timestamp);
+    for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
+      for (auto event_it = events.lower_bound(min_timestamp);
+           event_it != events.upper_bound(max_timestamp); ++event_it) {
+        action(event_it->second);
+      }
+    }
+  }
 
-  void ForEachCallstackEventOfTidInTimeRange(
-      uint32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
-      const std::function<void(const orbit_client_data::CallstackEvent&)>& action) const;
+  template <typename Action>
+  void ForEachCallstackEventOfTidInTimeRange(uint32_t tid, uint64_t min_timestamp,
+                                             uint64_t max_timestamp, Action&& action) const {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    ORBIT_CHECK(min_timestamp <= max_timestamp);
+    const auto& tid_and_events_it = callstack_events_by_tid_.find(tid);
+    if (tid_and_events_it == callstack_events_by_tid_.end()) {
+      return;
+    }
+    const auto& events = tid_and_events_it->second;
+    for (auto event_it = events.lower_bound(min_timestamp);
+         event_it != events.upper_bound(max_timestamp); ++event_it) {
+      action(event_it->second);
+    }
+  }
 
   [[nodiscard]] uint64_t max_time() const {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
@@ -76,9 +104,13 @@ class CallstackData {
 
   [[nodiscard]] bool HasCallstack(uint64_t callstack_id) const;
 
-  void ForEachUniqueCallstack(
-      const std::function<void(uint64_t callstack_id, const CallstackInfo& callstack)>& action)
-      const;
+  template <typename Action>
+  void ForEachUniqueCallstack(Action&& action) const {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    for (const auto& [callstack_id, callstack_ptr] : unique_callstacks_) {
+      action(callstack_id, *callstack_ptr);
+    }
+  }
 
   // Assuming that, for each thread, the outermost frame of each callstack is always the same,
   // update the type of all the kComplete callstacks that have the outermost frame not matching the

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -34,7 +34,8 @@ add_executable(MizarDataTests)
 
 target_sources(MizarDataTests PRIVATE 
                 BaselineAndComparisonTest.cpp
-                MizarDataTest.cpp)
+                MizarDataTest.cpp
+                MizarDataWithSampledFunctionIdTest.cpp)
 
 target_link_libraries(MizarDataTests PRIVATE GrpcProtos
                                                 MizarData

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -9,7 +9,8 @@ add_library(MizarData STATIC)
 target_sources(MizarData PUBLIC 
          include/MizarData/BaselineAndComparison.h
          include/MizarData/MizarData.h
-         include/MizarData/MizarDataProvider.h)
+         include/MizarData/MizarDataProvider.h
+         include/MizarData/MizarPairedData.h)
 
 target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include) 
 
@@ -35,7 +36,7 @@ add_executable(MizarDataTests)
 target_sources(MizarDataTests PRIVATE 
                 BaselineAndComparisonTest.cpp
                 MizarDataTest.cpp
-                MizarDataWithSampledFunctionIdTest.cpp)
+                MizarPairedDataTest.cpp)
 
 target_link_libraries(MizarDataTests PRIVATE GrpcProtos
                                                 MizarData

--- a/src/MizarData/MizarDataTest.cpp
+++ b/src/MizarData/MizarDataTest.cpp
@@ -27,6 +27,13 @@ using ::testing::Invoke;
 using ::testing::UnorderedElementsAre;
 using ::testing::UnorderedPointwise;
 
+namespace {
+class MockMizarData : public orbit_mizar_data::MizarData {
+ public:
+  MOCK_METHOD(std::optional<std::string>, GetFunctionNameFromAddress, (uint64_t), (const override));
+};
+}  // namespace
+
 namespace orbit_mizar_data {
 
 using google::protobuf::util::MessageDifferencer;
@@ -139,11 +146,6 @@ TEST(MizarDataTest, GetFunctionNameFromAddressIsCorrect) {
 
   EXPECT_FALSE(data.GetFunctionNameFromAddress(kUnknownFunctionAddress));
 }
-
-class MockMizarData : public MizarData {
- public:
-  MOCK_METHOD(std::optional<std::string>, GetFunctionNameFromAddress, (uint64_t), (const override));
-};
 
 const uint64_t kTime = 951753;
 const orbit_client_data::CallstackInfo kCallstackInfo({kFunctionAddress, kUnknownFunctionAddress,

--- a/src/MizarData/MizarDataWithSampledFunctionIdTest.cpp
+++ b/src/MizarData/MizarDataWithSampledFunctionIdTest.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/container/flat_hash_map.h>
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock-spec-builders.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <vector>
+
+#include "ClientData/CallstackData.h"
+#include "ClientData/CallstackInfo.h"
+#include "ClientData/CaptureData.h"
+#include "MizarData/BaselineAndComparison.h"
+
+namespace orbit_mizar_data {
+
+constexpr uint64_t kAddressFood = 0xF00D;
+constexpr uint64_t kAddressBad = 0xBAD;
+constexpr uint64_t kAddressCall = 0xCA11;
+constexpr uint64_t kAddressBefore = 0xB3F0;
+
+const orbit_client_data::CallstackInfo kCompleteCallstack(
+    {kAddressBefore, kAddressCall, kAddressBad}, orbit_client_data::CallstackType::kComplete);
+const orbit_client_data::CallstackInfo kInCompleteCallstack(
+    {kAddressBefore, kAddressCall, kAddressBad},
+    orbit_client_data::CallstackType::kDwarfUnwindingError);
+const orbit_client_data::CallstackInfo kAnotherCompleteCallstack(
+    {kAddressBefore, kAddressCall, kAddressFood}, orbit_client_data::CallstackType::kComplete);
+
+constexpr uint64_t kCompleteCallstackId = 1;
+constexpr uint64_t kInCompleteCallstackId = 2;
+constexpr uint64_t kAnotherCompleteCallstackId = 3;
+
+constexpr uint64_t kTime = 123;
+constexpr uint64_t kTID = 0x3AD1;
+constexpr uint64_t kAnotherTID = 0x3AD2;
+
+static const absl::flat_hash_map<uint64_t, uint64_t> kAddressToId = {
+    {kAddressFood, 1}, {kAddressCall, 2}, {kAddressBefore, 3}};
+
+const std::unique_ptr<orbit_client_data::CallstackData> kCallstackData = [] {
+  auto callstack_data = std::make_unique<orbit_client_data::CallstackData>();
+  callstack_data->AddUniqueCallstack(kCompleteCallstackId, kCompleteCallstack);
+  callstack_data->AddUniqueCallstack(kInCompleteCallstackId, kInCompleteCallstack);
+  callstack_data->AddUniqueCallstack(kAnotherCompleteCallstackId, kAnotherCompleteCallstack);
+
+  callstack_data->AddCallstackEvent({kTime, kCompleteCallstackId, kTID});
+  callstack_data->AddCallstackEvent({kTime + 1, kCompleteCallstackId, kTID});
+  callstack_data->AddCallstackEvent({kTime + 2, kInCompleteCallstackId, kTID});
+  callstack_data->AddCallstackEvent({kTime + 3, kAnotherCompleteCallstackId, kAnotherTID});
+
+  return callstack_data;
+}();
+
+class MockCaptureData {
+ public:
+  MOCK_METHOD(const orbit_client_data::CallstackData&, GetCallstackData, (), (const));
+};
+
+class MockMizarData {
+ public:
+  MOCK_METHOD(const MockCaptureData&, GetCaptureData, (), (const));
+};
+
+static std::vector<uint64_t> IdsForCallstacks(const std::vector<uint64_t>& addresses) {
+  std::vector<uint64_t> good_addresses;
+  std::copy_if(std::begin(addresses), std::end(addresses), std::back_inserter(good_addresses),
+               [](uint64_t address) { return kAddressToId.contains(address); });
+  std::vector<uint64_t> ids;
+  std::transform(std::begin(good_addresses), std::end(good_addresses), std::back_inserter(ids),
+                 [](uint64_t address) { return kAddressToId.at(address); });
+  return ids;
+}
+
+const std::vector<uint64_t> kCompleteCallstackIds = IdsForCallstacks(kCompleteCallstack.frames());
+const std::vector<uint64_t> kInCompleteCallstackIds =
+    IdsForCallstacks({kInCompleteCallstack.frames()[0]});
+const std::vector<uint64_t> kAnotherCompleteCallstackIds =
+    IdsForCallstacks(kAnotherCompleteCallstack.frames());
+
+TEST(MizarDataWithSampledFunctionId, ForeachCallstackIsCorrect) {
+  auto capture_data = std::make_unique<MockCaptureData>();
+  auto data = std::make_unique<MockMizarData>();
+
+  EXPECT_CALL(*capture_data, GetCallstackData).WillRepeatedly(testing::ReturnRef(*kCallstackData));
+  EXPECT_CALL(*data, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data));
+
+  MizarDataWithSampledFunctionId<MockMizarData> mizar_data_with_sampled_function_id(std::move(data),
+                                                                                    kAddressToId);
+
+  ORBIT_LOG("%u", kCallstackData->GetCallstackEventsOfTidCount(kTID));
+  std::vector<std::vector<uint64_t>> actual_ids_fed_to_action;
+  auto action = [&actual_ids_fed_to_action](const std::vector<uint64_t> ids) {
+    actual_ids_fed_to_action.push_back(ids);
+  };
+
+  // All threads, all timestamps
+  actual_ids_fed_to_action.clear();
+  mizar_data_with_sampled_function_id.ForEachCallstackEvent(orbit_base::kAllProcessThreadsTid, 0,
+                                                            kTime + 4, action);
+  EXPECT_THAT(actual_ids_fed_to_action,
+              testing::UnorderedElementsAre(kCompleteCallstackIds, kCompleteCallstackIds,
+                                            kInCompleteCallstackIds, kAnotherCompleteCallstackIds));
+
+  // One thread, all timestamps
+  actual_ids_fed_to_action.clear();
+  mizar_data_with_sampled_function_id.ForEachCallstackEvent(kTID, 0, kTime + 4, action);
+  EXPECT_THAT(actual_ids_fed_to_action,
+              testing::UnorderedElementsAre(kCompleteCallstackIds, kCompleteCallstackIds,
+                                            kInCompleteCallstackIds));
+
+  // All threads, some timestamps
+  actual_ids_fed_to_action.clear();
+  mizar_data_with_sampled_function_id.ForEachCallstackEvent(orbit_base::kAllProcessThreadsTid,
+                                                            kTime + 1, kTime + 4, action);
+  EXPECT_THAT(actual_ids_fed_to_action,
+              testing::UnorderedElementsAre(kCompleteCallstackIds, kInCompleteCallstackIds,
+                                            kAnotherCompleteCallstackIds));
+}
+
+}  // namespace orbit_mizar_data

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -20,6 +20,20 @@
 #include "ClientData/CaptureData.h"
 #include "MizarData/BaselineAndComparison.h"
 
+namespace {
+
+class MockCaptureData {
+ public:
+  MOCK_METHOD(const orbit_client_data::CallstackData&, GetCallstackData, (), (const));
+};
+
+class MockMizarData {
+ public:
+  MOCK_METHOD(const MockCaptureData&, GetCaptureData, (), (const));
+};
+
+}  // namespace
+
 namespace orbit_mizar_data {
 
 constexpr uint64_t kAddressFood = 0xF00D;
@@ -64,16 +78,6 @@ const std::unique_ptr<orbit_client_data::CallstackData> kCallstackData = [] {
   return callstack_data;
 }();
 
-class MockCaptureData {
- public:
-  MOCK_METHOD(const orbit_client_data::CallstackData&, GetCallstackData, (), (const));
-};
-
-class MockMizarData {
- public:
-  MOCK_METHOD(const MockCaptureData&, GetCaptureData, (), (const));
-};
-
 [[nodiscard]] static std::vector<uint64_t> IdsForCallstacks(
     const std::vector<uint64_t>& addresses) {
   std::vector<uint64_t> good_addresses;
@@ -91,7 +95,7 @@ const std::vector<uint64_t> kInCompleteCallstackIds =
 const std::vector<uint64_t> kAnotherCompleteCallstackIds =
     IdsForCallstacks(kAnotherCompleteCallstack.frames());
 
-TEST(MizarPairedDataTest, ForeachCallstackIsCorrect) {
+void foo() {
   auto capture_data = std::make_unique<MockCaptureData>();
   auto data = std::make_unique<MockMizarData>();
 
@@ -99,7 +103,6 @@ TEST(MizarPairedDataTest, ForeachCallstackIsCorrect) {
   EXPECT_CALL(*data, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data));
 
   MizarPairedData<MockMizarData> mizar_paired_data(std::move(data), kAddressToId);
-
   std::vector<std::vector<uint64_t>> actual_ids_fed_to_action;
   auto action = [&actual_ids_fed_to_action](const std::vector<uint64_t> ids) {
     actual_ids_fed_to_action.push_back(ids);
@@ -127,5 +130,7 @@ TEST(MizarPairedDataTest, ForeachCallstackIsCorrect) {
               testing::UnorderedElementsAre(kCompleteCallstackIds, kInCompleteCallstackIds,
                                             kAnotherCompleteCallstackIds));
 }
+
+TEST(MizarPairedDataTest, ForeachCallstackIsCorrect) { foo(); }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -7,23 +7,70 @@
 
 #include <absl/container/flat_hash_set.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <iterator>
 #include <utility>
 
+#include "ClientData/CallstackData.h"
 #include "ClientData/CaptureData.h"
 #include "MizarData/MizarData.h"
 
 namespace orbit_mizar_data {
 
-struct MizarDataWithSampledFunctionId {
+template <typename Data>
+class MizarDataWithSampledFunctionId {
+ public:
   MizarDataWithSampledFunctionId(
-      std::unique_ptr<MizarDataProvider> data,
+      std::unique_ptr<Data> data,
       absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id)
-      : data(std::move(data)),
-        address_to_sampled_function_id(std::move(address_to_sampled_function_id)) {}
+      : data_(std::move(data)),
+        address_to_sampled_function_id_(std::move(address_to_sampled_function_id)) {}
 
-  std::unique_ptr<MizarDataProvider> data;
-  absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id;
+  template <typename Action>
+  void ForEachCallstackEvent(uint32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
+                             Action&& action) const {
+    const orbit_client_data::CallstackData& callstack_data =
+        data_->GetCaptureData().GetCallstackData();
+    auto action_of_callstack_events =
+        [this, &callstack_data, &action](const orbit_client_data::CallstackEvent& event) -> void {
+      const orbit_client_data::CallstackInfo* callstack =
+          callstack_data.GetCallstack(event.callstack_id());
+      const std::vector<uint64_t> sampled_function_ids = FramesWithIds(callstack);
+      std::forward<Action>(action)(sampled_function_ids);
+    };
+    if (tid == orbit_base::kAllProcessThreadsTid) {
+      callstack_data.ForEachCallstackEventInTimeRange(min_timestamp, max_timestamp,
+                                                      action_of_callstack_events);
+    } else {
+      callstack_data.ForEachCallstackEventOfTidInTimeRange(tid, min_timestamp, max_timestamp,
+                                                           action_of_callstack_events);
+    }
+  }
+
+ private:
+  [[nodiscard]] std::vector<uint64_t> FramesWithIds(
+      const orbit_client_data::CallstackInfo* callstack) const {
+    if (callstack->frames().empty()) return {};
+    if (callstack->type() != orbit_client_data::CallstackType::kComplete) {
+      return CallstackWithIds({callstack->frames()[0]});
+    }
+    return CallstackWithIds(callstack->frames());
+  }
+
+  [[nodiscard]] std::vector<uint64_t> CallstackWithIds(const std::vector<uint64_t>& frames) const {
+    std::vector<uint64_t> result;
+    for (const uint64_t address : frames) {
+      if (auto it = address_to_sampled_function_id_.find(address);
+          it != address_to_sampled_function_id_.end()) {
+        result.push_back(it->second);
+      }
+    }
+    return result;
+  }
+
+  std::unique_ptr<Data> data_;
+  absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id_;
 };
 
 // The class owns the data from two capture files via owning two instances of
@@ -31,8 +78,8 @@ struct MizarDataWithSampledFunctionId {
 // corresponding function names.
 class BaselineAndComparison {
  public:
-  BaselineAndComparison(MizarDataWithSampledFunctionId baseline,
-                        MizarDataWithSampledFunctionId comparison,
+  BaselineAndComparison(MizarDataWithSampledFunctionId<MizarDataProvider> baseline,
+                        MizarDataWithSampledFunctionId<MizarDataProvider> comparison,
                         absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name)
       : baseline_(std::move(baseline)),
         comparison_(std::move(comparison)),
@@ -44,8 +91,8 @@ class BaselineAndComparison {
   }
 
  private:
-  MizarDataWithSampledFunctionId baseline_;
-  MizarDataWithSampledFunctionId comparison_;
+  MizarDataWithSampledFunctionId<MizarDataProvider> baseline_;
+  MizarDataWithSampledFunctionId<MizarDataProvider> comparison_;
   absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name_;
 };
 

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -5,81 +5,24 @@
 #ifndef MIZAR_DATA_BASELINE_AND_COMPARISON_H_
 #define MIZAR_DATA_BASELINE_AND_COMPARISON_H_
 
-#include <absl/container/flat_hash_set.h>
+#include <stdint.h>
 
-#include <algorithm>
-#include <cstdint>
-#include <iterator>
-#include <utility>
+#include <string>
 
 #include "ClientData/CallstackData.h"
 #include "ClientData/CaptureData.h"
 #include "MizarData/MizarData.h"
+#include "MizarData/MizarPairedData.h"
 
 namespace orbit_mizar_data {
-
-template <typename Data>
-class MizarDataWithSampledFunctionId {
- public:
-  MizarDataWithSampledFunctionId(
-      std::unique_ptr<Data> data,
-      absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id)
-      : data_(std::move(data)),
-        address_to_sampled_function_id_(std::move(address_to_sampled_function_id)) {}
-
-  template <typename Action>
-  void ForEachCallstackEvent(uint32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
-                             Action&& action) const {
-    const orbit_client_data::CallstackData& callstack_data =
-        data_->GetCaptureData().GetCallstackData();
-    auto action_of_callstack_events =
-        [this, &callstack_data, &action](const orbit_client_data::CallstackEvent& event) -> void {
-      const orbit_client_data::CallstackInfo* callstack =
-          callstack_data.GetCallstack(event.callstack_id());
-      const std::vector<uint64_t> sampled_function_ids = FramesWithIds(callstack);
-      std::forward<Action>(action)(sampled_function_ids);
-    };
-    if (tid == orbit_base::kAllProcessThreadsTid) {
-      callstack_data.ForEachCallstackEventInTimeRange(min_timestamp, max_timestamp,
-                                                      action_of_callstack_events);
-    } else {
-      callstack_data.ForEachCallstackEventOfTidInTimeRange(tid, min_timestamp, max_timestamp,
-                                                           action_of_callstack_events);
-    }
-  }
-
- private:
-  [[nodiscard]] std::vector<uint64_t> FramesWithIds(
-      const orbit_client_data::CallstackInfo* callstack) const {
-    if (callstack->frames().empty()) return {};
-    if (callstack->type() != orbit_client_data::CallstackType::kComplete) {
-      return CallstackWithIds({callstack->frames()[0]});
-    }
-    return CallstackWithIds(callstack->frames());
-  }
-
-  [[nodiscard]] std::vector<uint64_t> CallstackWithIds(const std::vector<uint64_t>& frames) const {
-    std::vector<uint64_t> result;
-    for (const uint64_t address : frames) {
-      if (auto it = address_to_sampled_function_id_.find(address);
-          it != address_to_sampled_function_id_.end()) {
-        result.push_back(it->second);
-      }
-    }
-    return result;
-  }
-
-  std::unique_ptr<Data> data_;
-  absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id_;
-};
 
 // The class owns the data from two capture files via owning two instances of
 // `MizarDataWithSampledFunctionId`. Also owns the map from sampled function ids to the
 // corresponding function names.
 class BaselineAndComparison {
  public:
-  BaselineAndComparison(MizarDataWithSampledFunctionId<MizarDataProvider> baseline,
-                        MizarDataWithSampledFunctionId<MizarDataProvider> comparison,
+  BaselineAndComparison(MizarPairedData<MizarDataProvider> baseline,
+                        MizarPairedData<MizarDataProvider> comparison,
                         absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name)
       : baseline_(std::move(baseline)),
         comparison_(std::move(comparison)),
@@ -91,8 +34,8 @@ class BaselineAndComparison {
   }
 
  private:
-  MizarDataWithSampledFunctionId<MizarDataProvider> baseline_;
-  MizarDataWithSampledFunctionId<MizarDataProvider> comparison_;
+  MizarPairedData<MizarDataProvider> baseline_;
+  MizarPairedData<MizarDataProvider> comparison_;
   absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name_;
 };
 

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_MIZAR_PAIRED_DATA_H_
+#define MIZAR_DATA_MIZAR_PAIRED_DATA_H_
+
+#include <absl/container/flat_hash_map.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+
+#include "ClientData/CallstackData.h"
+#include "OrbitBase/ThreadConstants.h"
+
+namespace orbit_mizar_data {
+
+// This class represents the data loaded from a capture that has been made aware of its counterpart
+// it will be compared against. In particular, it is aware of the functions that has been sampled in
+// the other capture. Also, it is aware of the sampled function ids assigned to the functions.
+template <typename Data>
+class MizarPairedData {
+ public:
+  MizarPairedData(std::unique_ptr<Data> data,
+                  absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id)
+      : data_(std::move(data)),
+        address_to_sampled_function_id_(std::move(address_to_sampled_function_id)) {}
+
+  // Action is a callable that does not return and takes a single argument of type
+  // `const std::vector<uint64_t>` representing a callstack sample, each element of the vector is a
+  // sampled function id.
+  template <typename Action>
+  void ForEachCallstackEvent(uint32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
+                             Action&& action) const {
+    const orbit_client_data::CallstackData& callstack_data =
+        data_->GetCaptureData().GetCallstackData();
+
+    auto action_on_callstack_events =
+        [this, &callstack_data, &action](const orbit_client_data::CallstackEvent& event) -> void {
+      const orbit_client_data::CallstackInfo* callstack =
+          callstack_data.GetCallstack(event.callstack_id());
+      const std::vector<uint64_t> sampled_function_ids = FramesWithIds(callstack);
+      std::forward<Action>(action)(sampled_function_ids);
+    };
+
+    if (tid == orbit_base::kAllProcessThreadsTid) {
+      callstack_data.ForEachCallstackEventInTimeRange(min_timestamp, max_timestamp,
+                                                      action_on_callstack_events);
+    } else {
+      callstack_data.ForEachCallstackEventOfTidInTimeRange(tid, min_timestamp, max_timestamp,
+                                                           action_on_callstack_events);
+    }
+  }
+
+ private:
+  [[nodiscard]] std::vector<uint64_t> FramesWithIds(
+      const orbit_client_data::CallstackInfo* callstack) const {
+    if (callstack->frames().empty()) return {};
+    if (callstack->type() != orbit_client_data::CallstackType::kComplete) {
+      return CallstackWithIds({callstack->frames()[0]});
+    }
+    return CallstackWithIds(callstack->frames());
+  }
+
+  [[nodiscard]] std::vector<uint64_t> CallstackWithIds(const std::vector<uint64_t>& frames) const {
+    std::vector<uint64_t> result;
+    for (const uint64_t address : frames) {
+      if (auto it = address_to_sampled_function_id_.find(address);
+          it != address_to_sampled_function_id_.end()) {
+        result.push_back(it->second);
+      }
+    }
+    return result;
+  }
+
+  std::unique_ptr<Data> data_;
+  absl::flat_hash_map<uint64_t, uint64_t> address_to_sampled_function_id_;
+};
+
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_MIZAR_PAIRED_DATA_H_

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -27,7 +27,7 @@ class MizarPairedData {
       : data_(std::move(data)),
         address_to_sampled_function_id_(std::move(address_to_sampled_function_id)) {}
 
-  // Action is a callable that does not return and takes a single argument of type
+  // Action is a void callable that takes a single argument of type
   // `const std::vector<uint64_t>` representing a callstack sample, each element of the vector is a
   // sampled function id.
   template <typename Action>

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -41,7 +41,7 @@ class MizarPairedData {
       const orbit_client_data::CallstackInfo* callstack =
           callstack_data.GetCallstack(event.callstack_id());
       const std::vector<uint64_t> sampled_function_ids = FramesWithIds(callstack);
-      std::forward<Action>(action)(sampled_function_ids);
+      std::invoke(std::forward<Action>(action), sampled_function_ids);
     };
 
     if (tid == orbit_base::kAllProcessThreadsTid) {


### PR DESCRIPTION
For now the callstack samples are represented as sequences of
addresses. And these addresses vary run-to-run. Mizar needs a
general way to treat these based on sampled function ids.

This renames MizarDataWithSampledFunctionIds to
MizarPairedData.

The method MizarPairedData::ForEachCallstackEvent is added.
One of its arguemnts is a callable `Action` that takes a
callstack that is represented as a sequence of
sampled function ids.

Also, this makes the methods CallstackData::ForEach*
take a templated Action, not std::function.

Bug: http://b/235197552
Tets: Unit