### PR TITLE
Fix crash in user space instrumentation.

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -310,16 +310,7 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
       result.function_ids_to_error_messages[function_id] = message;
       continue;
     }
-    // Getting the machine code of the function serves multiple purposes: we need to have a backup
-    // of the code since we intend to overwrite the first five bytes with a jump. Also we need to
-    // relocate all instructions that get overwritten into the trampoline. Finally we check if the
-    // function contains a jump back into the first five bytes (which would prohibit
-    // instrumentation). For the first two reasons 20 bytes would be enough; the 200 is chosen
-    // somewhat arbitrarily to cover all cases of jumps into the first five bytes we encountered in
-    // the wild. Compare the comment of CheckForJumpIntoFirstFiveBytes in Trampoline.cpp.
-    constexpr uint64_t kMaxFunctionBackupSize = 200;
-    const uint64_t backup_size = std::min(kMaxFunctionBackupSize, function.function_size());
-    if (backup_size == 0) {
+    if (function.function_size() == 0) {
       const std::string message = absl::StrFormat(
           "Can't instrument function \"%s\" since it has size zero.", function.function_name());
       ORBIT_ERROR("%s", message);
@@ -341,10 +332,18 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
           continue;
         }
         const uint64_t trampoline_address = trampoline_address_or_error.value();
-        TrampolineData trampoline_data;
-        trampoline_data.trampoline_address = trampoline_address;
-        OUTCOME_TRY(auto&& function_data, ReadTraceesMemory(pid_, function_address, backup_size));
-        trampoline_data.function_data = function_data;
+        // We need the machine code of the function for two purposes: We need to relocate the
+        // instructions that get overwritten into the trampoline and we also need to check if the
+        // function contains a jump back into the first five bytes (which would prohibit
+        // instrumentation). For the first reason 20 bytes would be enough; the 200 is chosen
+        // somewhat arbitrarily to cover all cases of jumps into the first five bytes we encountered
+        // in the wild. Specifically this covers all relative jumps to a signed 8 bit offset.
+        // Compare the comment of CheckForRelativeJumpIntoFirstFiveBytes in Trampoline.cpp.
+        constexpr uint64_t kMaxFunctionReadSize = 200;
+        const uint64_t function_read_size =
+            std::min(kMaxFunctionReadSize, function.function_size());
+        OUTCOME_TRY(auto&& function_data,
+                    ReadTraceesMemory(pid_, function_address, function_read_size));
         auto address_after_prologue_or_error =
             CreateTrampoline(pid_, function_address, function_data, trampoline_address,
                              entry_payload_function_address_, return_trampoline_address_,
@@ -358,6 +357,17 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
           OUTCOME_TRY(ReleaseMostRecentlyAllocatedTrampolineMemory(module_address_range));
           continue;
         }
+        TrampolineData trampoline_data;
+        trampoline_data.trampoline_address = trampoline_address;
+        // We'll overwrite the first five bytes of the function and the rest of the instruction that
+        // we clobbered. Since we'll need to restore that when we remove the instrumentation we need
+        // a backup.
+        constexpr uint64_t kMaxFunctionBackupSize = 20;
+        const uint64_t function_backup_size =
+            std::min(kMaxFunctionBackupSize, function.function_size());
+        OUTCOME_TRY(auto&& function_backup_data,
+                    ReadTraceesMemory(pid_, function_address, function_backup_size));
+        trampoline_data.function_data = function_backup_data;
         trampoline_data.address_after_prologue = address_after_prologue_or_error.value();
         trampoline_map_.emplace(function_address, trampoline_data);
       }

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -77,6 +77,60 @@ constexpr uint64_t kOffsetOfFunctionIdInCallToEntryPayload = 178;
   return result;
 }
 
+// Check if somewhere in the code of `function` there is a (conditional) jump back to the first five
+// bytes of the function (which we intend to overwrite with a jump into the trampoline). If so we
+// must not instrument the function. Note that the entire function is not necessarily available
+// here; we'll just disassemble and check whatever we have.
+// This is merely a heuristic. There can be other jumps either further down in the function or in
+// different places in the same translation unit that target the first five bytes of a function.
+// However analysing existing code shows that many of the problematic jumps are in small functions
+// that are written in assembly. These are detected by the function below.
+bool CheckForJumpIntoFirstFiveBytes(uint64_t function_address, const std::vector<uint8_t>& function,
+                                    csh capstone_handle) {
+  cs_insn* instruction = cs_malloc(capstone_handle);
+  ORBIT_FAIL_IF(instruction == nullptr, "Failed to allocate memory for capstone disassembler.");
+  orbit_base::unique_resource scope_exit{instruction,
+                                         [](cs_insn* instruction) { cs_free(instruction, 1); }};
+
+  const uint8_t* code_pointer = function.data();
+  size_t code_size = function.size();
+  uint64_t disassemble_address = function_address;
+
+  // Disassemble until we processed the first kBytesToDisassemble bytes or we run out of
+  // instructions in this function.
+  while (cs_disasm_iter(capstone_handle, &code_pointer, &code_size, &disassemble_address,
+                        instruction)) {
+    const uint64_t original_instruction_address = disassemble_address - instruction->size;
+    if ((instruction->detail->x86.opcode[0] == 0xeb) ||
+        ((instruction->detail->x86.opcode[0] & 0xf0) == 0x70)) {
+      // 0xeb is an uncoditional jump to an 8 bit immediate offset.
+      // 0x7? are conditional jumps to an 8 bit immediate offset.
+      const int8_t immediate = *absl::bit_cast<int8_t*>(
+          instruction->bytes + instruction->detail->x86.encoding.imm_offset);
+      const uint64_t jump_target_address =
+          original_instruction_address + instruction->size + immediate;
+      if (jump_target_address >= function_address &&
+          jump_target_address < function_address + kSizeOfJmp) {
+        return true;
+      }
+    } else if ((instruction->detail->x86.opcode[0] == 0xe9) ||
+               (instruction->detail->x86.opcode[0] == 0x0f &&
+                (instruction->detail->x86.opcode[1] & 0xf0) == 0x80)) {
+      // 0xe9 is an uncoditional jump to an 32 bit immediate offset.
+      // 0x0f 0x8? are conditional jumps to a 32 bit immediate offset.
+      const int32_t immediate = *absl::bit_cast<int32_t*>(
+          instruction->bytes + instruction->detail->x86.encoding.imm_offset);
+      const uint64_t jump_target_address =
+          original_instruction_address + instruction->size + immediate;
+      if (jump_target_address >= function_address &&
+          jump_target_address < function_address + kSizeOfJmp) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // This code is executed immediately after the control is passed to the instrumented function. The
 // top of the stack contains the return address. Above that are the parameters passed via the stack.
 // Some registers contain the parameters for the instrumented function not passed via the stack.
@@ -1113,6 +1167,13 @@ ErrorMessageOr<uint64_t> CreateTrampoline(pid_t pid, uint64_t function_address,
                                           uint64_t entry_payload_function_address,
                                           uint64_t return_trampoline_address, csh capstone_handle,
                                           absl::flat_hash_map<uint64_t, uint64_t>& relocation_map) {
+  const bool harmful_jump =
+      CheckForJumpIntoFirstFiveBytes(function_address, function, capstone_handle);
+  if (harmful_jump) {
+    return ErrorMessage(
+        "Failed to create trampoline since the function contains a jump into its own prolog.");
+  }
+
   MachineCode trampoline;
   // Add code to backup register state, execute the payload and restore the register state.
   AppendBackupCode(trampoline);

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -104,7 +104,7 @@ bool CheckForRelativeJumpIntoFirstFiveBytes(uint64_t function_address,
                         instruction)) {
     if ((instruction->detail->x86.opcode[0] == 0xeb) ||
         ((instruction->detail->x86.opcode[0] & 0xf0) == 0x70)) {
-      // 0xeb is an uncoditional jump to a 8 bit immediate offset.
+      // 0xeb is an unconditional jump to a 8 bit immediate offset.
       // 0x7? are conditional jumps to a 8 bit immediate offset.
       const int8_t immediate = *absl::bit_cast<int8_t*>(
           instruction->bytes + instruction->detail->x86.encoding.imm_offset);
@@ -116,7 +116,7 @@ bool CheckForRelativeJumpIntoFirstFiveBytes(uint64_t function_address,
     } else if ((instruction->detail->x86.opcode[0] == 0xe9) ||
                (instruction->detail->x86.opcode[0] == 0x0f &&
                 (instruction->detail->x86.opcode[1] & 0xf0) == 0x80)) {
-      // 0xe9 is an uncoditional jump to a 32 bit immediate offset.
+      // 0xe9 is an unconditional jump to a 32 bit immediate offset.
       // 0x0f 0x8? are conditional jumps to a 32 bit immediate offset.
       const int32_t immediate = *absl::bit_cast<int32_t*>(
           instruction->bytes + instruction->detail->x86.encoding.imm_offset);

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -1154,7 +1154,7 @@ TEST_F(InstrumentFunctionTest, CheckNoX87UnderflowInReturnTrampoline) {
   RestartAndRemoveInstrumentation();
 }
 
-extern "C" __attribute__((noinline, naked)) int UnconditionalJump8BitOffsetBackIntoProlog() {
+extern "C" __attribute__((noinline, naked)) int UnconditionalJump8BitOffsetBackToBeginning() {
   __asm__ __volatile__(
       "nop \n\t"
       "nop \n\t"
@@ -1170,21 +1170,20 @@ extern "C" __attribute__((noinline, naked)) int UnconditionalJump8BitOffsetBackI
       :);
 }
 
-// This will fail to create a trampoline since the function contains an unconditional jump to a
+// This will fail to create a trampoline since the function contains an unconditional jump to an
 // eight bit offset which points back into the first five bytes of the function.
-TEST_F(InstrumentFunctionTest, UnconditionalJump8BitOffsetBackIntoProlog) {
-  RunChild(&UnconditionalJump8BitOffsetBackIntoProlog, "UnconditionalJump8BitOffsetBackIntoProlog");
+TEST_F(InstrumentFunctionTest, UnconditionalJump8BitOffsetBackToBeginning) {
+  RunChild(&UnconditionalJump8BitOffsetBackToBeginning,
+           "UnconditionalJump8BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
   ErrorMessageOr<uint64_t> result = CreateTrampoline(
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(
-      result,
-      HasError(
-          "Failed to create trampoline since the function contains a jump into its own prolog."));
+  EXPECT_THAT(result,
+              HasError("Failed to create trampoline since the function contains a jump back into"));
 }
 
-extern "C" __attribute__((noinline, naked)) int UnconditionalJump32BitOffsetBackIntoProlog() {
+extern "C" __attribute__((noinline, naked)) int UnconditionalJump32BitOffsetBackToBeginning() {
   __asm__ __volatile__(
       "nop \n\t"
       "nop \n\t"
@@ -1202,20 +1201,18 @@ extern "C" __attribute__((noinline, naked)) int UnconditionalJump32BitOffsetBack
 
 // This will fail to create a trampoline since the function contains an unconditional jump to a
 // 32 bit offset which points back into the first five bytes of the function.
-TEST_F(InstrumentFunctionTest, UnconditionalJump32BitOffsetBackIntoProlog) {
-  RunChild(&UnconditionalJump32BitOffsetBackIntoProlog,
-           "UnconditionalJump32BitOffsetBackIntoProlog");
+TEST_F(InstrumentFunctionTest, UnconditionalJump32BitOffsetBackToBeginning) {
+  RunChild(&UnconditionalJump32BitOffsetBackToBeginning,
+           "UnconditionalJump32BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
   ErrorMessageOr<uint64_t> result = CreateTrampoline(
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(
-      result,
-      HasError(
-          "Failed to create trampoline since the function contains a jump into its own prolog."));
+  EXPECT_THAT(result,
+              HasError("Failed to create trampoline since the function contains a jump back into"));
 }
 
-extern "C" __attribute__((noinline, naked)) int ConditionalJump8BitOffsetBackIntoProlog() {
+extern "C" __attribute__((noinline, naked)) int ConditionalJump8BitOffsetBackToBeginning() {
   __asm__ __volatile__(
       "nop \n\t"
       "nop \n\t"
@@ -1231,21 +1228,19 @@ extern "C" __attribute__((noinline, naked)) int ConditionalJump8BitOffsetBackInt
       :);
 }
 
-// This will fail to create a trampoline since the function contains a conditional jump to a
+// This will fail to create a trampoline since the function contains a conditional jump to an
 // eight bit offset which points back into the first five bytes of the function.
-TEST_F(InstrumentFunctionTest, ConditionalJump8BitOffsetBackIntoProlog) {
-  RunChild(&ConditionalJump8BitOffsetBackIntoProlog, "ConditionalJump8BitOffsetBackIntoProlog");
+TEST_F(InstrumentFunctionTest, ConditionalJump8BitOffsetBackToBeginning) {
+  RunChild(&ConditionalJump8BitOffsetBackToBeginning, "ConditionalJump8BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
   ErrorMessageOr<uint64_t> result = CreateTrampoline(
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(
-      result,
-      HasError(
-          "Failed to create trampoline since the function contains a jump into its own prolog."));
+  EXPECT_THAT(result,
+              HasError("Failed to create trampoline since the function contains a jump back into"));
 }
 
-extern "C" __attribute__((noinline, naked)) int ConditionalJump32BitOffsetBackIntoProlog() {
+extern "C" __attribute__((noinline, naked)) int ConditionalJump32BitOffsetBackToBeginning() {
   __asm__ __volatile__(
       "nop \n\t"
       "nop \n\t"
@@ -1264,19 +1259,17 @@ extern "C" __attribute__((noinline, naked)) int ConditionalJump32BitOffsetBackIn
 
 // This will fail to create a trampoline since the function contains a conditional jump to a
 // 32 bit offset which points back into the first five bytes of the function.
-TEST_F(InstrumentFunctionTest, ConditionalJump32BitOffsetBackIntoProlog) {
-  RunChild(&ConditionalJump32BitOffsetBackIntoProlog, "ConditionalJump32BitOffsetBackIntoProlog");
+TEST_F(InstrumentFunctionTest, ConditionalJump32BitOffsetBackToBeginning) {
+  RunChild(&ConditionalJump32BitOffsetBackToBeginning, "ConditionalJump32BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
   ErrorMessageOr<uint64_t> result = CreateTrampoline(
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(
-      result,
-      HasError(
-          "Failed to create trampoline since the function contains a jump into its own prolog."));
+  EXPECT_THAT(result,
+              HasError("Failed to create trampoline since the function contains a jump back into"));
 }
 
-extern "C" __attribute__((noinline, naked)) int LongConditionalJump32BitOffsetBackIntoProlog() {
+extern "C" __attribute__((noinline, naked)) int LongConditionalJump32BitOffsetBackToBeginning() {
   __asm__ __volatile__(
       "xor %%eax, %%eax \n\t"
       "ret \n\t"
@@ -1292,9 +1285,9 @@ extern "C" __attribute__((noinline, naked)) int LongConditionalJump32BitOffsetBa
 // This will create a trampoline. The function contains a conditional jump to a
 // 32 bit offset which points back into the first five bytes of the function. However the jump is
 // occurring after the 200 byte limit and therefore it stays undetected.
-TEST_F(InstrumentFunctionTest, LongConditionalJump32BitOffsetBackIntoProlog) {
-  RunChild(&LongConditionalJump32BitOffsetBackIntoProlog,
-           "LongConditionalJump32BitOffsetBackIntoProlog");
+TEST_F(InstrumentFunctionTest, LongConditionalJump32BitOffsetBackToBeginning) {
+  RunChild(&LongConditionalJump32BitOffsetBackToBeginning,
+           "LongConditionalJump32BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
   ErrorMessageOr<uint64_t> result = CreateTrampoline(
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -623,8 +623,8 @@ class InstrumentFunctionTest : public testing::Test {
     ORBIT_CHECK(!return_trampoline_or_error.value()->EnsureMemoryExecutable().has_error());
 
     // Copy the beginning of the function over into this process.
-    constexpr uint64_t kMaxFunctionPrologueBackupSize = 200;
-    const uint64_t bytes_to_copy = std::min(size_of_function, kMaxFunctionPrologueBackupSize);
+    constexpr uint64_t kMaxFunctionBackupSize = 200;
+    const uint64_t bytes_to_copy = std::min(size_of_function, kMaxFunctionBackupSize);
     ErrorMessageOr<std::vector<uint8_t>> function_backup =
         ReadTraceesMemory(pid_, function_address_, bytes_to_copy);
     ORBIT_CHECK(function_backup.has_value());

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -1173,6 +1173,10 @@ extern "C" __attribute__((noinline, naked)) int UnconditionalJump8BitOffsetBackT
 // This will fail to create a trampoline since the function contains an unconditional jump to an
 // eight bit offset which points back into the first five bytes of the function.
 TEST_F(InstrumentFunctionTest, UnconditionalJump8BitOffsetBackToBeginning) {
+// Exclude gcc builds: the inline assembly above gets messed up by the compiler.
+#if defined(ORBIT_COVERAGE_BUILD) || !defined(__clang__) || !defined(NDEBUG)
+  GTEST_SKIP();
+#endif
   RunChild(&UnconditionalJump8BitOffsetBackToBeginning,
            "UnconditionalJump8BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
@@ -1202,6 +1206,10 @@ extern "C" __attribute__((noinline, naked)) int UnconditionalJump32BitOffsetBack
 // This will fail to create a trampoline since the function contains an unconditional jump to a
 // 32 bit offset which points back into the first five bytes of the function.
 TEST_F(InstrumentFunctionTest, UnconditionalJump32BitOffsetBackToBeginning) {
+// Exclude gcc builds: the inline assembly above gets messed up by the compiler.
+#if defined(ORBIT_COVERAGE_BUILD) || !defined(__clang__) || !defined(NDEBUG)
+  GTEST_SKIP();
+#endif
   RunChild(&UnconditionalJump32BitOffsetBackToBeginning,
            "UnconditionalJump32BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
@@ -1231,6 +1239,10 @@ extern "C" __attribute__((noinline, naked)) int ConditionalJump8BitOffsetBackToB
 // This will fail to create a trampoline since the function contains a conditional jump to an
 // eight bit offset which points back into the first five bytes of the function.
 TEST_F(InstrumentFunctionTest, ConditionalJump8BitOffsetBackToBeginning) {
+// Exclude gcc builds: the inline assembly above gets messed up by the compiler.
+#if defined(ORBIT_COVERAGE_BUILD) || !defined(__clang__) || !defined(NDEBUG)
+  GTEST_SKIP();
+#endif
   RunChild(&ConditionalJump8BitOffsetBackToBeginning, "ConditionalJump8BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
   ErrorMessageOr<uint64_t> result = CreateTrampoline(
@@ -1260,6 +1272,10 @@ extern "C" __attribute__((noinline, naked)) int ConditionalJump32BitOffsetBackTo
 // This will fail to create a trampoline since the function contains a conditional jump to a
 // 32 bit offset which points back into the first five bytes of the function.
 TEST_F(InstrumentFunctionTest, ConditionalJump32BitOffsetBackToBeginning) {
+// Exclude gcc builds: the inline assembly above gets messed up by the compiler.
+#if defined(ORBIT_COVERAGE_BUILD) || !defined(__clang__) || !defined(NDEBUG)
+  GTEST_SKIP();
+#endif
   RunChild(&ConditionalJump32BitOffsetBackToBeginning, "ConditionalJump32BitOffsetBackToBeginning");
   PrepareInstrumentation(kEntryPayloadFunctionName, kExitPayloadFunctionName);
   ErrorMessageOr<uint64_t> result = CreateTrampoline(


### PR DESCRIPTION
If a function constains a jump into its first five bytes we must not instrument
it: During instrumentation we would overwrite these five bytes and therefore
any jump into this address range would just execute garbage.

Previously this issue was competely ignored. This PR provides a
heuristic catching the cases I found "in the wild". Some additional details are
documented in the bug.

Test: Runs with example games, unit tests in the PR.
Bug: http://b/234825095