### PR TITLE
Add type for sampled function ids

### DIFF
--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -51,9 +51,9 @@ int main(int argc, char* argv[]) {
 
   orbit_mizar_data::BaselineAndComparison bac =
       CreateBaselineAndComparison(std::move(baseline), std::move(comparison));
-  for (const auto& [id, name] : bac.sampled_function_id_to_name()) {
-    ORBIT_LOG("%u %s", id, name);
+  for (const auto& [sfid, name] : bac.sfid_to_name()) {
+    ORBIT_LOG("%s %s", static_cast<std::string>(sfid), name);
   }
-  ORBIT_LOG("Total number of common names %u  ", bac.sampled_function_id_to_name().size());
+  ORBIT_LOG("Total number of common names %u  ", bac.sfid_to_name().size());
   return 0;
 }

--- a/src/MizarData/BaselineAndComparison.cpp
+++ b/src/MizarData/BaselineAndComparison.cpp
@@ -19,12 +19,12 @@ namespace orbit_mizar_data {
 
 orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(
     std::unique_ptr<MizarDataProvider> baseline, std::unique_ptr<MizarDataProvider> comparison) {
-  auto [baseline_address_to_frame_id, comparison_address_to_frame_id, frame_id_to_name] =
+  auto [baseline_address_sfid, comparison_address_to_sfid, sfid_to_name] =
       AssignSampledFunctionIds(baseline->AllAddressToName(), comparison->AllAddressToName());
 
-  return {{std::move(baseline), std::move(baseline_address_to_frame_id)},
-          {std::move(comparison), std::move(comparison_address_to_frame_id)},
-          std::move(frame_id_to_name)};
+  return {{std::move(baseline), std::move(baseline_address_sfid)},
+          {std::move(comparison), std::move(comparison_address_to_sfid)},
+          std::move(sfid_to_name)};
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonHelper.cpp
+++ b/src/MizarData/BaselineAndComparisonHelper.cpp
@@ -8,53 +8,57 @@
 #include <absl/container/flat_hash_set.h>
 #include <stdint.h>
 
+#include <string>
+
 namespace orbit_mizar_data {
 
 template <typename K, typename V>
 [[nodiscard]] static absl::flat_hash_set<V> ValueSet(const absl::flat_hash_map<K, V>& map) {
   absl::flat_hash_set<V> result;
   std::transform(std::begin(map), std::end(map), std::inserter(result, std::begin(result)),
-                 [](const std::pair<K, V> pair) { return pair.second; });
+                 std::mem_fn(&std::pair<std::add_const_t<K>, V>::second));
   return result;
 }
 
-static absl::flat_hash_map<uint64_t, uint64_t> AddressToSampledFunctionId(
+static absl::flat_hash_map<uint64_t, SFID> AddressToSFID(
     const absl::flat_hash_map<uint64_t, std::string>& address_to_name,
-    const absl::flat_hash_map<std::string, uint64_t>& name_to_frame_id) {
-  absl::flat_hash_map<uint64_t, uint64_t> address_to_frame_id;
+    const absl::flat_hash_map<std::string, SFID>& name_to_sfid) {
+  absl::flat_hash_map<uint64_t, SFID> address_to_sfid;
   for (const auto& [address, name] : address_to_name) {
-    if (const auto it = name_to_frame_id.find(name); it != name_to_frame_id.end()) {
-      address_to_frame_id[address] = it->second;
+    if (const auto it = name_to_sfid.find(name); it != name_to_sfid.end()) {
+      address_to_sfid.try_emplace(address, it->second);
     }
   }
-  return address_to_frame_id;
+  return address_to_sfid;
 }
 
 [[nodiscard]] AddressToIdAndIdToName AssignSampledFunctionIds(
     const absl::flat_hash_map<uint64_t, std::string>& baseline_address_to_name,
     const absl::flat_hash_map<uint64_t, std::string>& comparison_address_to_name) {
-  absl::flat_hash_set<std::string> baseline_names = ValueSet(baseline_address_to_name);
-  absl::flat_hash_set<std::string> comparison_names = ValueSet(comparison_address_to_name);
+  absl::flat_hash_set<std::string> baseline_names =
+      ValueSet<uint64_t, std::string>(baseline_address_to_name);
+  absl::flat_hash_set<std::string> comparison_names =
+      ValueSet<uint64_t, std::string>(comparison_address_to_name);
 
-  absl::flat_hash_map<std::string, uint64_t> name_to_frame_id;
-  absl::flat_hash_map<uint64_t, std::string> frame_id_to_name;
+  absl::flat_hash_map<std::string, SFID> name_to_sfid;
+  absl::flat_hash_map<SFID, std::string> sfid_to_name;
 
-  uint64_t next_frame_id = 1;
+  uint64_t next_sfid_value = 1;
   for (const std::string& name : baseline_names) {
-    if (comparison_names.contains(name) && !name_to_frame_id.contains(name)) {
-      name_to_frame_id[name] = next_frame_id;
-      frame_id_to_name[next_frame_id] = name;
-      next_frame_id++;
+    if (comparison_names.contains(name) && !name_to_sfid.contains(name)) {
+      name_to_sfid.try_emplace(name, SFID(next_sfid_value));
+      sfid_to_name.try_emplace(SFID(next_sfid_value), name);
+      next_sfid_value++;
     }
   }
 
-  absl::flat_hash_map<uint64_t, uint64_t> baseline_address_to_sampled_function_id =
-      AddressToSampledFunctionId(baseline_address_to_name, name_to_frame_id);
-  absl::flat_hash_map<uint64_t, uint64_t> comparison_address_to_sampled_function_id =
-      AddressToSampledFunctionId(comparison_address_to_name, name_to_frame_id);
+  absl::flat_hash_map<uint64_t, SFID> baseline_address_to_sfid =
+      AddressToSFID(baseline_address_to_name, name_to_sfid);
+  absl::flat_hash_map<uint64_t, SFID> comparison_address_to_sfid =
+      AddressToSFID(comparison_address_to_name, name_to_sfid);
 
-  return {std::move(baseline_address_to_sampled_function_id),
-          std::move(comparison_address_to_sampled_function_id), std::move(frame_id_to_name)};
+  return {std::move(baseline_address_to_sfid), std::move(comparison_address_to_sfid),
+          std::move(sfid_to_name)};
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonHelper.h
+++ b/src/MizarData/BaselineAndComparisonHelper.h
@@ -11,12 +11,14 @@
 
 #include <string>
 
+#include "MizarData/SampledFunctionId.h"
+
 namespace orbit_mizar_data {
 
 struct AddressToIdAndIdToName {
-  absl::flat_hash_map<uint64_t, uint64_t> baseline_address_to_sampled_function_id;
-  absl::flat_hash_map<uint64_t, uint64_t> comparison_address_to_sampled_function_id;
-  absl::flat_hash_map<uint64_t, std::string> frame_id_to_name;
+  absl::flat_hash_map<uint64_t, SFID> baseline_address_to_sfid;
+  absl::flat_hash_map<uint64_t, SFID> comparison_address_to_sfid;
+  absl::flat_hash_map<SFID, std::string> sfid_to_name;
 };
 
 [[nodiscard]] AddressToIdAndIdToName AssignSampledFunctionIds(

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -58,14 +58,12 @@ const absl::flat_hash_map<uint64_t, std::string> kBaselineAddressToName =
 const absl::flat_hash_map<uint64_t, std::string> kComparisonAddressToName =
     MakeMap(kComparisonFunctionAddresses, kComparisonFunctionNames);
 
-static void ExpectCorrectNames(const absl::flat_hash_map<uint64_t, uint64_t>& address_to_id,
-                               const absl::flat_hash_map<uint64_t, std::string>& id_to_name,
+static void ExpectCorrectNames(const absl::flat_hash_map<uint64_t, SFID>& address_to_sfid,
+                               const absl::flat_hash_map<SFID, std::string>& sfid_to_name,
                                const absl::flat_hash_map<uint64_t, std::string>& address_to_name) {
-  for (const auto& [address, id] : address_to_id) {
-    if (id_to_name.contains(address)) {
-      EXPECT_TRUE(address_to_name.contains(address));
-      EXPECT_EQ(id_to_name.at(address), address_to_name.at(address));
-    }
+  for (const auto& [address, sfid] : address_to_sfid) {
+    EXPECT_TRUE(sfid_to_name.contains(sfid));
+    EXPECT_EQ(sfid_to_name.at(sfid), address_to_name.at(address));
   }
 }
 
@@ -78,22 +76,18 @@ template <typename K, typename V>
 }
 
 TEST(BaselineAndComparisonTest, BaselineAndComparisonHelperIsCorrect) {
-  const auto [baseline_address_to_sampled_function_id, comparison_address_to_sampled_function_id,
-              sampled_function_id_id_to_name] =
+  const auto [baseline_address_to_sfid, comparison_address_to_sfid, sfid_to_name] =
       AssignSampledFunctionIds(kBaselineAddressToName, kComparisonAddressToName);
 
-  EXPECT_EQ(baseline_address_to_sampled_function_id.size(), kCommonFunctionNames.size());
-  EXPECT_EQ(comparison_address_to_sampled_function_id.size(), kCommonFunctionNames.size());
-  EXPECT_EQ(sampled_function_id_id_to_name.size(), kCommonFunctionNames.size());
+  EXPECT_EQ(baseline_address_to_sfid.size(), kCommonFunctionNames.size());
+  EXPECT_EQ(comparison_address_to_sfid.size(), kCommonFunctionNames.size());
+  EXPECT_EQ(sfid_to_name.size(), kCommonFunctionNames.size());
 
-  ExpectCorrectNames(baseline_address_to_sampled_function_id, sampled_function_id_id_to_name,
-                     kBaselineAddressToName);
-  ExpectCorrectNames(comparison_address_to_sampled_function_id, sampled_function_id_id_to_name,
-                     kComparisonAddressToName);
+  ExpectCorrectNames(baseline_address_to_sfid, sfid_to_name, kBaselineAddressToName);
+  ExpectCorrectNames(comparison_address_to_sfid, sfid_to_name, kComparisonAddressToName);
 
-  EXPECT_THAT(
-      Values(baseline_address_to_sampled_function_id),
-      testing::UnorderedElementsAreArray(Values(comparison_address_to_sampled_function_id)));
+  EXPECT_THAT(Values(baseline_address_to_sfid),
+              testing::UnorderedElementsAreArray(Values(comparison_address_to_sfid)));
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -10,7 +10,8 @@ target_sources(MizarData PUBLIC
          include/MizarData/BaselineAndComparison.h
          include/MizarData/MizarData.h
          include/MizarData/MizarDataProvider.h
-         include/MizarData/MizarPairedData.h)
+         include/MizarData/MizarPairedData.h
+         include/MizarData/SampledFunctionId.h)
 
 target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include) 
 

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -13,6 +13,7 @@
 #include "ClientData/CaptureData.h"
 #include "MizarData/MizarData.h"
 #include "MizarData/MizarPairedData.h"
+#include "MizarData/SampledFunctionId.h"
 
 namespace orbit_mizar_data {
 
@@ -23,20 +24,19 @@ class BaselineAndComparison {
  public:
   BaselineAndComparison(MizarPairedData<MizarDataProvider> baseline,
                         MizarPairedData<MizarDataProvider> comparison,
-                        absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name)
+                        absl::flat_hash_map<SFID, std::string> sfid_to_name)
       : baseline_(std::move(baseline)),
         comparison_(std::move(comparison)),
-        sampled_function_id_to_name_(std::move(sampled_function_id_to_name)) {}
+        sfid_to_name_(std::move(sfid_to_name)) {}
 
-  [[nodiscard]] const absl::flat_hash_map<uint64_t, std::string>& sampled_function_id_to_name()
-      const {
-    return sampled_function_id_to_name_;
+  [[nodiscard]] const absl::flat_hash_map<SFID, std::string>& sfid_to_name() const {
+    return sfid_to_name_;
   }
 
  private:
   MizarPairedData<MizarDataProvider> baseline_;
   MizarPairedData<MizarDataProvider> comparison_;
-  absl::flat_hash_map<uint64_t, std::string> sampled_function_id_to_name_;
+  absl::flat_hash_map<SFID, std::string> sfid_to_name_;
 };
 
 orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(

--- a/src/MizarData/include/MizarData/SampledFunctionId.h
+++ b/src/MizarData/include/MizarData/SampledFunctionId.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_SAMPLED_FUNCTION_ID_H_
+#define MIZAR_DATA_SAMPLED_FUNCTION_ID_H_
+
+#include <absl/strings/str_format.h>
+#include <stdint.h>
+
+#include <string>
+#include <utility>
+
+namespace orbit_mizar_data {
+
+// The class represents a sampled function id. These ids are the same for the same function across
+// all the captures.
+class SFID {
+ public:
+  constexpr explicit SFID(uint64_t id) : id_(id) {}
+
+  friend bool operator==(const SFID& lhs, const SFID& rhs) { return lhs.id_ == rhs.id_; }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const SFID& c) {
+    return H::combine(std::move(h), c.id_);
+  }
+
+  // For debug purposes
+  explicit operator std::string() const { return std::to_string(id_); }
+
+ private:
+  uint64_t id_;
+};
+
+// Making sure we do not waste memory on the abstraction
+static_assert(sizeof(SFID) == sizeof(uint64_t));
+
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_SAMPLED_FUNCTION_ID_H_


### PR DESCRIPTION
This introduces a type SFID, that represents a sampled function
id and should be used instead `uint64_t` to improve type
readability and catch the bugs at compile time.

This also fixes a bug in the Unit test that is not possible with
SFIDs.

Bug: http://b/235321420
Test: Unit, Compile