### PR TITLE
Add OrbitBase/Attributes.h

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/AnyInvocable.h
         include/OrbitBase/AnyMovable.h
         include/OrbitBase/Append.h
+        include/OrbitBase/Attributes.h
         include/OrbitBase/Chunk.h
         include/OrbitBase/CrashHandler.h
         include/OrbitBase/ExecutablePath.h

--- a/src/OrbitBase/include/OrbitBase/Attributes.h
+++ b/src/OrbitBase/include/OrbitBase/Attributes.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_ATTRIBUTES_H_
+#define ORBIT_BASE_ATTRIBUTES_H_
+
+// GCC and Clang both define "__has_attribute(x)", which evaluates to 1 if the attribute is
+// supported by the current compilation target. Define a version of "__has_attribute(x)" that
+// evaluates to 0 for other compilers.
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+// Generate code without prolog and epilog. We expect the compiler to support the "naked" attribute
+// and we generate a compilation error otherwise by not providing an empty default.
+#if __has_attribute(naked)
+#define ORBIT_NAKED __attribute__((naked))
+#elif _WIN32
+#define ORBIT_NAKED __declspec(naked)
+#endif
+
+// Prevent inlining of function. We expect the compiler to support the "noinline" attribute and we
+// generate a compilation error otherwise by not providing an empty default.
+#if __has_attribute(noinline)
+#define ORBIT_NOINLINE __attribute__((noinline))
+#elif _WIN32
+#define ORBIT_NOINLINE __declspec(noinline)
+#endif
+
+#endif  // ORBIT_BASE_ATTRIBUTES_H_

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -17,14 +17,10 @@
 #include <thread>
 
 #include "ApiInterface/Orbit.h"
+#include "OrbitBase/Attributes.h"
 #include "OrbitBase/ThreadUtils.h"
-ORBIT_API_INSTANTIATE;
 
-#if __linux__
-#define NO_INLINE __attribute__((noinline))
-#else
-#define NO_INLINE __declspec(noinline)
-#endif
+ORBIT_API_INSTANTIATE;
 
 #define ORBIT_SCOPE_FUNCTION ORBIT_SCOPE(__FUNCTION__)
 
@@ -71,21 +67,21 @@ void OrbitTestImpl::Loop() {
   }
 }
 
-void NO_INLINE OrbitTestImpl::TestFunc(uint32_t depth) {
+void ORBIT_NOINLINE OrbitTestImpl::TestFunc(uint32_t depth) {
   ORBIT_SCOPE_FUNCTION;
   if (depth == recurse_depth_) return;
   TestFunc(depth + 1);
   std::this_thread::sleep_for(std::chrono::microseconds(sleep_us_));
 }
 
-void NO_INLINE OrbitTestImpl::TestFunc2(uint32_t depth) {
+void ORBIT_NOINLINE OrbitTestImpl::TestFunc2(uint32_t depth) {
   ORBIT_SCOPE_FUNCTION;
   if (depth == recurse_depth_) return;
   TestFunc(depth + 1);
   BusyWork(sleep_us_);
 }
 
-void NO_INLINE OrbitTestImpl::BusyWork(uint64_t microseconds) {
+void ORBIT_NOINLINE OrbitTestImpl::BusyWork(uint64_t microseconds) {
   ORBIT_SCOPE_FUNCTION;
   auto start = std::chrono::system_clock::now();
   while (true) {
@@ -95,9 +91,11 @@ void NO_INLINE OrbitTestImpl::BusyWork(uint64_t microseconds) {
   }
 }
 
-static void NO_INLINE SleepFor1Ms() { std::this_thread::sleep_for(std::chrono::milliseconds(1)); }
+static void ORBIT_NOINLINE SleepFor1Ms() {
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+}
 
-static void NO_INLINE SleepFor2Ms() {
+static void ORBIT_NOINLINE SleepFor2Ms() {
   ORBIT_SCOPE("Sleep for two milliseconds");
   ORBIT_SCOPE_WITH_COLOR("Sleep for two milliseconds", kOrbitColorTeal);
   ORBIT_SCOPE_WITH_COLOR("Sleep for two milliseconds", kOrbitColorOrange);


### PR DESCRIPTION
Add a header to centralize cross-platform versions of compiler attributes. So far, 
only "naked" and "noinline" are implemented. Note that we make sure that the 
compiler supports those attributes and otherwise generate a compilation error.

Note that only OrbitTestImpl.cpp uses "Attributes.h", but we could replace all
occurrences of "noinline" and "naked" by "ORBIT_NOINLINE" and "ORBIT_NAKED"
if there is no objection. This would make it easier to re-use some of the 
dynamic-instrumentation tests on Windows for example.