### PR TITLE
Reset PeCoffEpilog::last_error_ in DetectAndHandleEpilog

### DIFF
--- a/third_party/libunwindstack/PeCoffEpilog.cpp
+++ b/third_party/libunwindstack/PeCoffEpilog.cpp
@@ -388,6 +388,8 @@ bool PeCoffEpilogImpl::DetectAndHandleEpilog(uint64_t function_start_address,
                                              uint64_t function_end_address,
                                              uint64_t current_offset_from_start_of_function,
                                              Memory* process_memory, Regs* regs) {
+  last_error_ = {ERROR_NONE, 0};
+
   if (function_start_address + current_offset_from_start_of_function >= function_end_address) {
     last_error_.code = ERROR_INVALID_COFF;
     return false;

--- a/third_party/libunwindstack/PeCoffEpilog.h
+++ b/third_party/libunwindstack/PeCoffEpilog.h
@@ -36,8 +36,10 @@ class PeCoffEpilog {
   // Detects if the instructions from 'current_offset_from_start_of_function' onwards represent
   // a function epilog. Returns true if an epilog was detected. The registers are updated to reflect
   // the actions from executing the epilog (which effectively unwinds the current callframe).
-  // Returns false if no epilog was found *or* if an error occured. In the latter case, the error
+  // Returns false if no epilog was found *or* if an error occurred. In the latter case, the error
   // can be retrieved using GetLastError() and registers 'regs' are not updated.
+  // TODO(b/235952532): Change the interface to only use the bool return value to indicate whether
+  //  an error occurred. Use a bool* parameter to return whether an epilog was detected.
   virtual bool DetectAndHandleEpilog(uint64_t function_start_address, uint64_t function_end_address,
                                      uint64_t current_offset_from_start_of_function,
                                      Memory* process_memory, Regs* regs) = 0;


### PR DESCRIPTION
`PeCoffEpilog::GetLastError` is used to tell whether
`PeCoffEpilog::DetectAndHandleEpilog` returning false means that we are not in
the epilog or that an error occurred. This means that
`PeCoffEpilog::last_error_` needs to be reset for every invocation of
`PeCoffEpilog::DetectAndHandleEpilog`. This didn't happen before, always keeping
`PeCoffEpilog` in an error state.

Test: Add unit test: failed before, passes now.