### PR TITLE
Store `CaptureStarted` in `CaptureData`

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -25,20 +25,20 @@ using orbit_grpc_protos::ProcessInfo;
 
 namespace orbit_client_data {
 
-CaptureData::CaptureData(const CaptureStarted& capture_started,
+CaptureData::CaptureData(CaptureStarted capture_started,
                          std::optional<std::filesystem::path> file_path,
                          absl::flat_hash_set<uint64_t> frame_track_function_ids,
                          DataSource data_source)
-    : capture_started_(capture_started),
+    : capture_started_(std::move(capture_started)),
       selection_callstack_data_(std::make_unique<CallstackData>()),
       frame_track_function_ids_{std::move(frame_track_function_ids)},
       file_path_{std::move(file_path)},
-      scope_id_provider_(NameEqualityScopeIdProvider::Create(capture_started.capture_options())),
+      scope_id_provider_(NameEqualityScopeIdProvider::Create(capture_started_.capture_options())),
       thread_track_data_provider_(
           std::make_unique<ThreadTrackDataProvider>(data_source == DataSource::kLoadedCapture)) {
   ProcessInfo process_info;
-  process_info.set_pid(capture_started.process_id());
-  std::filesystem::path executable_path{capture_started.executable_path()};
+  process_info.set_pid(capture_started_.process_id());
+  std::filesystem::path executable_path{capture_started_.executable_path()};
   process_info.set_full_path(executable_path.string());
   process_info.set_name(executable_path.filename().string());
   process_info.set_is_64_bit(true);
@@ -47,7 +47,7 @@ CaptureData::CaptureData(const CaptureStarted& capture_started,
   absl::flat_hash_map<uint64_t, FunctionInfo> instrumented_functions;
 
   for (const auto& instrumented_function :
-       capture_started.capture_options().instrumented_functions()) {
+       capture_started_.capture_options().instrumented_functions()) {
     instrumented_functions_.insert_or_assign(instrumented_function.function_id(),
                                              instrumented_function);
   }

--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -29,7 +29,7 @@ CaptureData::CaptureData(const CaptureStarted& capture_started,
                          std::optional<std::filesystem::path> file_path,
                          absl::flat_hash_set<uint64_t> frame_track_function_ids,
                          DataSource data_source)
-    : memory_sampling_period_ns_(capture_started.capture_options().memory_sampling_period_ns()),
+    : capture_started_(capture_started),
       selection_callstack_data_(std::make_unique<CallstackData>()),
       frame_track_function_ids_{std::move(frame_track_function_ids)},
       file_path_{std::move(file_path)},

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -51,7 +51,7 @@ namespace orbit_client_data {
 class CaptureData {
  public:
   enum class DataSource { kLiveCapture, kLoadedCapture };
-  explicit CaptureData(const orbit_grpc_protos::CaptureStarted& capture_started,
+  explicit CaptureData(orbit_grpc_protos::CaptureStarted capture_started,
                        std::optional<std::filesystem::path> file_path,
                        absl::flat_hash_set<uint64_t> frame_track_function_ids,
                        DataSource data_source);

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -71,7 +71,9 @@ class CaptureData {
     return instrumented_functions_;
   }
 
-  [[nodiscard]] uint64_t memory_sampling_period_ns() const { return memory_sampling_period_ns_; }
+  [[nodiscard]] uint64_t GetMemorySamplingPeriodNs() const {
+    return capture_started_.capture_options().memory_sampling_period_ns();
+  }
   [[nodiscard]] uint64_t memory_warning_threshold_kb() const {
     return memory_warning_threshold_kb_;
   }
@@ -255,12 +257,17 @@ class CaptureData {
       uint64_t scope_id, uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
       uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
 
+  [[nodiscard]] const orbit_grpc_protos::CaptureStarted& GetCaptureStarted() const {
+    return capture_started_;
+  }
+
  private:
   void UpdateTimerDurations();
 
+  orbit_grpc_protos::CaptureStarted capture_started_;
+
   orbit_client_data::ProcessData process_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions_;
-  uint64_t memory_sampling_period_ns_;
   uint64_t memory_warning_threshold_kb_;
 
   CallstackData callstack_data_;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -432,7 +432,7 @@ class OrbitApp final : public DataViewFactory,
     data_manager_->set_memory_sampling_period_ms(memory_sampling_period_ms);
   }
   [[nodiscard]] uint64_t GetMemorySamplingPeriodMs() const {
-    return GetCaptureData().memory_sampling_period_ns() / 1'000'000;
+    return GetCaptureData().GetMemorySamplingPeriodNs() / 1'000'000;
   }
   void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb) {
     data_manager_->set_memory_warning_threshold_kb(memory_warning_threshold_kb);


### PR DESCRIPTION
This adds the `CaptureData::capture_started_` field.
Removes `CaptureData::memory_sampling_period_ns_`.

Bug: http://b/235465005
Test: Manual, Compile