### PR TITLE
Add expansion slider to TopDownView in devmode

### DIFF
--- a/src/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/CallTreeView.h
@@ -36,6 +36,8 @@ class CallTreeNode {
            unwind_error_type_children_.size() + (unwind_errors_child_ != nullptr ? 1 : 0);
   }
 
+  [[nodiscard]] uint64_t thread_count() const { return thread_children_.size(); }
+
   [[nodiscard]] const std::vector<const CallTreeNode*>& children() const;
 
   [[nodiscard]] CallTreeThread* GetThreadOrNull(uint32_t thread_id);

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -174,7 +174,7 @@ static void CollapseRecursively(QTreeView* tree_view, const QModelIndex& index) 
 // Nodes with an inclusive percentage over `expansion_threshold` will be expanded, the other nodes
 // are collapsed recursively.
 static void ExpandRecursivelyWithThreshold(QTreeView* tree_view, const QModelIndex& index,
-                              float expansion_threshold = 0.f) {
+                                           float expansion_threshold = 0.f) {
   if (!index.isValid()) {
     return;
   }
@@ -201,8 +201,8 @@ void CallTreeWidget::SetTopDownView(std::unique_ptr<CallTreeView> top_down_view)
 
   if (should_expand) {
     float expansion_threshold = 100.f - ui_->horizontalSlider->value();
-    ExpandRecursivelyWithThreshold(ui_->callTreeTreeView, ui_->callTreeTreeView->model()->index(0, 0),
-                      expansion_threshold);
+    ExpandRecursivelyWithThreshold(
+        ui_->callTreeTreeView, ui_->callTreeTreeView->model()->index(0, 0), expansion_threshold);
   }
 }
 
@@ -771,10 +771,12 @@ void CallTreeWidget::OnSearchTypingFinishedTimerTimout() {
   }
 }
 
-void CallTreeWidget::OnSliderValueChanged(int value){ 
-    ORBIT_SCOPE_FUNCTION;
-    ORBIT_LOG("Slider value: %i", value); 
-    ExpandRecursivelyWithThreshold(ui_->callTreeTreeView, ui_->callTreeTreeView->model()->index(0, 0), 100-value);
+void CallTreeWidget::OnSliderValueChanged(int value) {
+  ORBIT_SCOPE_FUNCTION;
+  ORBIT_CHECK(value >= 0);
+  ORBIT_CHECK(value <= 100);
+  ExpandRecursivelyWithThreshold(ui_->callTreeTreeView, ui_->callTreeTreeView->model()->index(0, 0),
+                                 100 - value);
 }
 
 const QColor CallTreeWidget::HighlightCustomFilterSortFilterProxyModel::kHighlightColor{Qt::green};

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -202,12 +202,12 @@ static void ExpandRecursivelyWithThreshold(QTreeView* tree_view, const QModelInd
 
 void CallTreeWidget::SetTopDownView(std::unique_ptr<CallTreeView> top_down_view) {
   // Expand recursively if CallTreeView contains information for a single thread.
-  bool should_expand = top_down_view->thread_count() == 1;
+  bool should_expand = IsSliderEnabled() && top_down_view->thread_count() == 1;
 
   SetCallTreeView(std::move(top_down_view),
                   std::make_unique<HideValuesForTopDownProxyModel>(nullptr));
 
-  if (should_expand && IsSliderEnabled()) {
+  if (should_expand) {
     float expansion_threshold = 100.f - ui_->horizontalSlider->value();
     ExpandRecursivelyWithThreshold(
         ui_->callTreeTreeView, ui_->callTreeTreeView->model()->index(0, 0), expansion_threshold);

--- a/src/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/CallTreeWidget.h
@@ -23,6 +23,7 @@
 #include <QWidget>
 #include <Qt>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -67,6 +68,7 @@ class CallTreeWidget : public QWidget {
   void OnCustomContextMenuRequested(const QPoint& point);
   void OnSearchLineEditTextEdited(const QString& text);
   void OnSearchTypingFinishedTimerTimout();
+  void OnSliderValueChanged(int value);
 
  private:
   static const QString kActionExpandRecursively;

--- a/src/OrbitQt/CallTreeWidget.ui
+++ b/src/OrbitQt/CallTreeWidget.ui
@@ -2,31 +2,41 @@
 <ui version="4.0">
  <class>CallTreeWidget</class>
  <widget class="QWidget" name="CallTreeWidget">
-  <layout class="QGridLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>256</width>
+    <height>220</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLineEdit" name="searchLineEdit">
-     <property name="accessibleName">
-      <string>filter</string>
-     </property>
-     <property name="placeholderText">
-      <string>Search (invalidates the expanded/collapsed state of all nodes in the tree)</string>
-     </property>
-     <property name="clearButtonEnabled">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="8,2">
+     <item>
+      <widget class="QLineEdit" name="searchLineEdit">
+       <property name="accessibleName">
+        <string>filter</string>
+       </property>
+       <property name="placeholderText">
+        <string>Search (invalidates the expanded/collapsed state of all nodes in the tree)</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="horizontalSlider">
+       <property name="maximum">
+        <number>100</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="1" column="0">
     <widget class="CustomSignalsTreeView" name="callTreeTreeView">


### PR DESCRIPTION
Add a slider in CallTreeWidget to quickly control the expansion "level"
of the nodes. The slider fully to the left is replicating the current state, 
which is to have everything collapsed by default. The slider all the way
to the right makes the tree fully expand. The values in between expand
nodes progressively based on their "Inclusive" percentage.

The feature is in "devmode" only for now for internal validation.

https://screenshot.googleplex.com/Brm6xsZ6gfex8QR

b/235482436