### PR TITLE
Rename ModuleLoadOperation

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1702,7 +1702,7 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
 
   symbol_files_currently_downloading_.emplace(
       module_file_path,
-      OrbitApp::ModuleLoadOperation{std::move(stop_source), chained_result_future});
+      OrbitApp::ModuleDownloadOperation{std::move(stop_source), chained_result_future});
   FireRefreshCallbacks(orbit_data_views::DataViewType::kModules);
   chained_result_future.Then(
       main_thread_executor_,

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -624,14 +624,14 @@ class OrbitApp final : public DataViewFactory,
   std::shared_ptr<SamplingReport> sampling_report_;
   std::shared_ptr<SamplingReport> selection_report_ = nullptr;
 
-  struct ModuleLoadOperation {
+  struct ModuleDownloadOperation {
     orbit_base::StopSource stop_source;
     orbit_base::Future<ErrorMessageOr<std::filesystem::path>> future;
   };
   // Map of module file path to download operation future, that holds all symbol downloads that
   // are currently in progress.
   // ONLY access this from the main thread.
-  absl::flat_hash_map<std::string, ModuleLoadOperation> symbol_files_currently_downloading_;
+  absl::flat_hash_map<std::string, ModuleDownloadOperation> symbol_files_currently_downloading_;
 
   // Map of "module ID" (file path and build ID) to symbol file retrieving future, that holds all
   // symbol retrieving operations currently in progress. (Retrieving here means finding locally or


### PR DESCRIPTION
Rename ModuleLoadOperation to ModuleDownloadOperation

To avoid confusion, since this operation is specifically about downloads