### PR TITLE
Make MizarPairedData::ForEachCallstackEvent work on relative times

### DIFF
--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(MizarData PUBLIC
          include/MizarData/MizarData.h
          include/MizarData/MizarDataProvider.h
          include/MizarData/MizarPairedData.h
-         include/MizarData/SafeTimestampAdd.h
+         include/MizarData/NonWrappingAddition.h
          include/MizarData/SampledFunctionId.h)
 
 target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include) 

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(MizarData PUBLIC
          include/MizarData/MizarData.h
          include/MizarData/MizarDataProvider.h
          include/MizarData/MizarPairedData.h
+         include/MizarData/SafeTimestampAdd.h
          include/MizarData/SampledFunctionId.h)
 
 target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include) 

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -46,7 +46,8 @@ class BaselineAndComparisonTmpl {
     uint64_t total_callstacks = 0;
     absl::flat_hash_map<SFID, InclusiveAndExclusive> counts;
     for (const uint32_t tid : config.tids) {
-      data.ForEachCallstackEvent(tid, config.start_ns, config.start_ns + config.duration_ns,
+      data.ForEachCallstackEvent(tid, config.start_relative_ns,
+                                 config.start_relative_ns + config.duration_ns,
                                  [&total_callstacks, &counts](const std::vector<SFID>& callstack) {
                                    total_callstacks++;
                                    if (callstack.empty()) return;

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -13,7 +13,7 @@
 #include "ClientData/CaptureData.h"
 #include "MizarData/MizarData.h"
 #include "MizarData/MizarPairedData.h"
-#include "MizarData/SafeTimestampAdd.h"
+#include "MizarData/NonWrappingAddition.h"
 #include "MizarData/SampledFunctionId.h"
 #include "MizarData/SamplingWithFrameTrackComparisonReport.h"
 
@@ -48,7 +48,7 @@ class BaselineAndComparisonTmpl {
     absl::flat_hash_map<SFID, InclusiveAndExclusive> counts;
     for (const uint32_t tid : config.tids) {
       data.ForEachCallstackEvent(tid, config.start_relative_ns,
-                                 SafeTimestampsAdd(config.start_relative_ns, config.duration_ns),
+                                 NonWrappingAddition(config.start_relative_ns, config.duration_ns),
                                  [&total_callstacks, &counts](const std::vector<SFID>& callstack) {
                                    total_callstacks++;
                                    if (callstack.empty()) return;

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -13,6 +13,7 @@
 #include "ClientData/CaptureData.h"
 #include "MizarData/MizarData.h"
 #include "MizarData/MizarPairedData.h"
+#include "MizarData/SafeTimestampAdd.h"
 #include "MizarData/SampledFunctionId.h"
 #include "MizarData/SamplingWithFrameTrackComparisonReport.h"
 
@@ -47,7 +48,7 @@ class BaselineAndComparisonTmpl {
     absl::flat_hash_map<SFID, InclusiveAndExclusive> counts;
     for (const uint32_t tid : config.tids) {
       data.ForEachCallstackEvent(tid, config.start_relative_ns,
-                                 config.start_relative_ns + config.duration_ns,
+                                 SafeTimestampsAdd(config.start_relative_ns, config.duration_ns),
                                  [&total_callstacks, &counts](const std::vector<SFID>& callstack) {
                                    total_callstacks++;
                                    if (callstack.empty()) return;

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -44,6 +44,10 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
   [[nodiscard]] std::optional<std::string> GetFunctionNameFromAddress(
       uint64_t address) const override;
 
+  [[nodiscard]] uint64_t GetCaptureStartTimestampNs() const override {
+    return GetCaptureData().GetCaptureStarted().capture_start_timestamp_ns();
+  }
+
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,
                         std::optional<std::filesystem::path> file_path,
                         absl::flat_hash_set<uint64_t> frame_track_function_ids) override;

--- a/src/MizarData/include/MizarData/MizarDataProvider.h
+++ b/src/MizarData/include/MizarData/MizarDataProvider.h
@@ -31,6 +31,8 @@ class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
   [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(
       uint64_t address) const = 0;
   [[nodiscard]] virtual absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const = 0;
+
+  [[nodiscard]] virtual uint64_t GetCaptureStartTimestampNs() const = 0;
 };
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -12,6 +12,7 @@
 #include <memory>
 
 #include "ClientData/CallstackData.h"
+#include "MizarData/SafeTimestampAdd.h"
 #include "MizarData/SampledFunctionId.h"
 #include "OrbitBase/ThreadConstants.h"
 
@@ -46,9 +47,9 @@ class MizarPairedData {
     };
 
     const uint64_t min_timestamp_ns =
-        data_->GetCaptureStartTimestampNs() + min_relative_timestamp_ns;
+        SafeTimestampsAdd(data_->GetCaptureStartTimestampNs(), min_relative_timestamp_ns);
     const uint64_t max_timestamp_ns =
-        data_->GetCaptureStartTimestampNs() + max_relative_timestamp_ns;
+        SafeTimestampsAdd(data_->GetCaptureStartTimestampNs(), max_relative_timestamp_ns);
 
     if (tid == orbit_base::kAllProcessThreadsTid) {
       callstack_data.ForEachCallstackEventInTimeRange(min_timestamp_ns, max_timestamp_ns,

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -12,7 +12,7 @@
 #include <memory>
 
 #include "ClientData/CallstackData.h"
-#include "MizarData/SafeTimestampAdd.h"
+#include "MizarData/NonWrappingAddition.h"
 #include "MizarData/SampledFunctionId.h"
 #include "OrbitBase/ThreadConstants.h"
 
@@ -47,9 +47,9 @@ class MizarPairedData {
     };
 
     const uint64_t min_timestamp_ns =
-        SafeTimestampsAdd(data_->GetCaptureStartTimestampNs(), min_relative_timestamp_ns);
+        NonWrappingAddition(data_->GetCaptureStartTimestampNs(), min_relative_timestamp_ns);
     const uint64_t max_timestamp_ns =
-        SafeTimestampsAdd(data_->GetCaptureStartTimestampNs(), max_relative_timestamp_ns);
+        NonWrappingAddition(data_->GetCaptureStartTimestampNs(), max_relative_timestamp_ns);
 
     if (tid == orbit_base::kAllProcessThreadsTid) {
       callstack_data.ForEachCallstackEventInTimeRange(min_timestamp_ns, max_timestamp_ns,

--- a/src/MizarData/include/MizarData/NonWrappingAddition.h
+++ b/src/MizarData/include/MizarData/NonWrappingAddition.h
@@ -2,18 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef MIZAR_DATA_SAFE_TIMESTAMP_ADD_H_
-#define MIZAR_DATA_SAFE_TIMESTAMP_ADD_H_
+#ifndef MIZAR_DATA_NON_WRAPPING_ADDITION_H_
+#define MIZAR_DATA_NON_WRAPPING_ADDITION_H_
 
 #include <stdint.h>
 
 #include <cstdint>
 #include <limits>
 
-[[nodiscard]] inline uint64_t SafeTimestampsAdd(const uint64_t a, const uint64_t b) {
+namespace orbit_mizar_data {
+
+[[nodiscard]] inline uint64_t NonWrappingAddition(const uint64_t a, const uint64_t b) {
   const uint64_t sum = a + b;
   if (sum < a || sum < b) return std::numeric_limits<uint64_t>::max();
   return a + b;
 }
 
-#endif  // MIZAR_DATA_SAFE_TIMESTAMP_ADD_H_
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_NON_WRAPPING_ADDITION_H_

--- a/src/MizarData/include/MizarData/SafeTimestampAdd.h
+++ b/src/MizarData/include/MizarData/SafeTimestampAdd.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_SAFE_TIMESTAMP_ADD_H_
+#define MIZAR_DATA_SAFE_TIMESTAMP_ADD_H_
+
+#include <stdint.h>
+
+#include <cstdint>
+#include <limits>
+
+[[nodiscard]] inline uint64_t SafeTimestampsAdd(const uint64_t a, const uint64_t b) {
+  const uint64_t sum = a + b;
+  if (sum < a || sum < b) return std::numeric_limits<uint64_t>::max();
+  return a + b;
+}
+
+#endif  // MIZAR_DATA_SAFE_TIMESTAMP_ADD_H_

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -21,10 +21,10 @@ namespace orbit_mizar_data {
 struct HalfOfSamplingWithFrameTrackReportConfig {
   explicit HalfOfSamplingWithFrameTrackReportConfig(absl::flat_hash_set<uint32_t> tids,
                                                     uint64_t start_ns, uint64_t duration_ns)
-      : tids(std::move(tids)), start_ns(start_ns), duration_ns(duration_ns) {}
+      : tids(std::move(tids)), start_relative_ns(start_ns), duration_ns(duration_ns) {}
 
   absl::flat_hash_set<uint32_t> tids{};
-  uint64_t start_ns{};
+  uint64_t start_relative_ns{};  // nanoseconds elapsed since capture start
   uint64_t duration_ns{};
 };
 


### PR DESCRIPTION
Currently it takes two timestamps. These make sense only relative
to the capture start timestamps. Given Mizar has to deal with two
captures at the same time, this relativeness should be encapsulated
in MizarPairedData.
The relative timestamps are just `timestamp_ns - capture_start_ns`.

Bug: http://b/235564164
Test: Unit
