### PR TITLE
Use CanceledOr in symbol loading

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -72,6 +72,7 @@
 #include "ManualInstrumentationManager.h"
 #include "MetricsUploader/CaptureMetric.h"
 #include "MetricsUploader/MetricsUploader.h"
+#include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/CrashHandler.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Logging.h"
@@ -325,7 +326,7 @@ class OrbitApp final : public DataViewFactory,
 
   // RetrieveModule retrieves a module file and returns the local file path (potentially from the
   // local cache). Only modules with a .symtab section will be considered.
-  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModule(
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>> RetrieveModule(
       const std::string& module_path, const std::string& build_id);
   orbit_base::Future<void> RetrieveModulesAndLoadSymbols(
       absl::Span<const orbit_client_data::ModuleData* const> modules) override;
@@ -343,9 +344,9 @@ class OrbitApp final : public DataViewFactory,
 
   // RetrieveModuleAndSymbols is a helper function which first retrieves the module by calling
   // `RetrieveModule` and afterwards load the symbols by calling `LoadSymbols`.
-  orbit_base::Future<ErrorMessageOr<void>> RetrieveModuleAndLoadSymbols(
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> RetrieveModuleAndLoadSymbols(
       const orbit_client_data::ModuleData* module);
-  orbit_base::Future<ErrorMessageOr<void>> RetrieveModuleAndLoadSymbols(
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> RetrieveModuleAndLoadSymbols(
       const std::string& module_path, const std::string& build_id);
 
   // This method is pretty similar to `RetrieveModule`, but it also requires debug information to be
@@ -536,8 +537,8 @@ class OrbitApp final : public DataViewFactory,
   ErrorMessageOr<void> ConvertPresetToNewFormatIfNecessary(
       const orbit_preset_file::PresetFile& preset_file);
 
-  [[nodiscard]] orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleFromRemote(
-      const std::string& module_file_path);
+  [[nodiscard]] orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
+  RetrieveModuleFromRemote(const std::string& module_file_path);
 
   void SelectFunctionsFromHashes(const orbit_client_data::ModuleData* module,
                                  absl::Span<const uint64_t> function_hashes);
@@ -582,7 +583,7 @@ class OrbitApp final : public DataViewFactory,
   // with a simple prioritization. The module `ggpvlk.so` is queued to be loaded first, the "main
   // module" (binary of the process) is queued to be loaded second. All other modules are queued in
   // no particular order.
-  orbit_base::Future<std::vector<ErrorMessageOr<void>>> LoadAllSymbols();
+  orbit_base::Future<std::vector<ErrorMessageOr<orbit_base::CanceledOr<void>>>> LoadAllSymbols();
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<orbit_client_data::CaptureData::DataSource> data_source_{
@@ -626,7 +627,7 @@ class OrbitApp final : public DataViewFactory,
 
   struct ModuleLoadOperation {
     orbit_base::StopSource stop_source;
-    orbit_base::Future<ErrorMessageOr<std::filesystem::path>> future;
+    orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>> future;
   };
   // Map of module file path to download operation future, that holds all symbol downloads that
   // are currently in progress.
@@ -640,8 +641,9 @@ class OrbitApp final : public DataViewFactory,
   // symbol_files_currently_being_retrieved_.
   // ONLY access this from the main thread.
   // TODO(b/234586730) Replace pair with struct
-  absl::flat_hash_map<std::pair<std::string, std::string>,
-                      orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
+  absl::flat_hash_map<
+      std::pair<std::string, std::string>,
+      orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>>
       symbol_files_currently_being_retrieved_;
 
   // Map of "module ID" (file path and build ID) to symbol loading future, that holds all symbol
@@ -651,7 +653,8 @@ class OrbitApp final : public DataViewFactory,
   // contained in symbols_currently_loading_.
   // ONLY access this from the main thread.
   // TODO(b/234586730) Replace pair with struct
-  absl::flat_hash_map<std::pair<std::string, std::string>, orbit_base::Future<ErrorMessageOr<void>>>
+  absl::flat_hash_map<std::pair<std::string, std::string>,
+                      orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>>
       symbols_currently_loading_;
 
   // Set of modules where a symbol loading error has occurred. The module identifier consists of

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -17,6 +17,7 @@
 #include "CodeReport/CodeReport.h"
 #include "CodeReport/DisassemblyReport.h"
 #include "MetricsUploader/ScopedMetric.h"
+#include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/StopToken.h"
 #include "Statistics/Histogram.h"
@@ -54,7 +55,7 @@ class MainWindowInterface {
   virtual SymbolErrorHandlingResult HandleSymbolError(
       const ErrorMessage& error, const orbit_client_data::ModuleData* module) = 0;
 
-  virtual orbit_base::Future<ErrorMessageOr<void>> DownloadFileFromInstance(
+  virtual orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> DownloadFileFromInstance(
       std::filesystem::path path_on_instance, std::filesystem::path local_path,
       orbit_base::StopToken stop_token) = 0;
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -95,6 +95,7 @@
 #include "Introspection/Introspection.h"
 #include "LiveFunctionsController.h"
 #include "MetricsUploader/orbit_log_event.pb.h"
+#include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Logging.h"
@@ -1857,9 +1858,10 @@ orbit_gl::MainWindowInterface::SymbolErrorHandlingResult OrbitMainWindow::Handle
   ORBIT_UNREACHABLE();
 }
 
-orbit_base::Future<ErrorMessageOr<void>> OrbitMainWindow::DownloadFileFromInstance(
-    std::filesystem::path path_on_instance, std::filesystem::path local_path,
-    orbit_base::StopToken stop_token) {
+orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>
+OrbitMainWindow::DownloadFileFromInstance(std::filesystem::path path_on_instance,
+                                          std::filesystem::path local_path,
+                                          orbit_base::StopToken stop_token) {
   ORBIT_CHECK(is_connected_);
   ORBIT_CHECK(std::holds_alternative<StadiaTarget>(target_configuration_));
   ServiceDeployManager* service_deploy_manager =

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -42,6 +42,7 @@
 #include "GrpcProtos/process.pb.h"
 #include "MainWindowInterface.h"
 #include "MetricsUploader/MetricsUploader.h"
+#include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/CrashHandler.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/MainThreadExecutor.h"
@@ -122,7 +123,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void ShowHistogram(const std::vector<uint64_t>* data, const std::string& function_name,
                      uint64_t function_id) override;
 
-  orbit_base::Future<ErrorMessageOr<void>> DownloadFileFromInstance(
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> DownloadFileFromInstance(
       std::filesystem::path path_on_instance, std::filesystem::path local_path,
       orbit_base::StopToken stop_token) override;
 

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -22,6 +22,7 @@
 #include "DeploymentConfigurations.h"
 #include "MetricsUploader/MetricsUploader.h"
 #include "OrbitBase/AnyInvocable.h"
+#include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Promise.h"
 #include "OrbitBase/Result.h"
@@ -54,9 +55,9 @@ class ServiceDeployManager : public QObject {
       orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
 
   // This method copies remote source file to local destination.
-  orbit_base::Future<ErrorMessageOr<void>> CopyFileToLocal(std::filesystem::path source,
-                                                           std::filesystem::path destination,
-                                                           orbit_base::StopToken stop_token);
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> CopyFileToLocal(
+      std::filesystem::path source, std::filesystem::path destination,
+      orbit_base::StopToken stop_token);
 
   void Shutdown();
   void Cancel();
@@ -107,9 +108,10 @@ class ServiceDeployManager : public QObject {
   bool copy_file_operation_in_progress_ = false;
   std::deque<orbit_base::AnyInvocable<void()>> waiting_copy_operations_;
 
-  void CopyFileToLocalImpl(orbit_base::Promise<ErrorMessageOr<void>> promise,
-                           std::filesystem::path source, std::filesystem::path destination,
-                           orbit_base::StopToken stop_token);
+  void CopyFileToLocalImpl(
+      orbit_base::Promise<ErrorMessageOr<orbit_base::CanceledOr<void>>> promise,
+      std::filesystem::path source, std::filesystem::path destination,
+      orbit_base::StopToken stop_token);
   ErrorMessageOr<GrpcPort> ExecImpl();
 
   void StartWatchdog();


### PR DESCRIPTION
With this commit the new type CanceledOr<T> is used in symbol loading.
This starts with ServiceDeployManager where CopyFileToLocal returns
`Future<ErrorMessageOr<CanceledOr<void>>>` and is passed down until
OrbitApp. In 2 cases (Preset loading and debug info loading, which is
used for disassembly & source code view), a cancellation is turned back
into an error. For regular symbol loading this change means that a
cancellation does not result in an ErrorMessage, which means a canceled
symbol loading result is not saved in
`modules_with_symbol_loading_error_`, which means its not displayed as
error in the module list.

To see more context: https://github.com/antonrohr/orbit/tree/autoload_symbols

Test: Manual. Start Orbit with --devmode, click "Load Symbols" on a
module, click "Stop Download" on that module. No error should appear.
(Beforehand an error with detailed message: "User canceled download"
was shown)
Bug: part of http://b/231579238