### PR TITLE
Add duration to the thread state tooltip 

### DIFF
--- a/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
+++ b/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
@@ -5,6 +5,8 @@
 #ifndef CLIENT_DATA_THREAD_STATE_SLICE_INFO_H_
 #define CLIENT_DATA_THREAD_STATE_SLICE_INFO_H_
 
+#include <sys/types.h>
+#include <cstdint>
 #include "GrpcProtos/capture.pb.h"
 
 namespace orbit_client_data {

--- a/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
+++ b/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
@@ -5,8 +5,7 @@
 #ifndef CLIENT_DATA_THREAD_STATE_SLICE_INFO_H_
 #define CLIENT_DATA_THREAD_STATE_SLICE_INFO_H_
 
-#include <sys/types.h>
-#include <cstdint>
+
 #include "GrpcProtos/capture.pb.h"
 
 namespace orbit_client_data {

--- a/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
+++ b/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
@@ -5,7 +5,6 @@
 #ifndef CLIENT_DATA_THREAD_STATE_SLICE_INFO_H_
 #define CLIENT_DATA_THREAD_STATE_SLICE_INFO_H_
 
-
 #include "GrpcProtos/capture.pb.h"
 
 namespace orbit_client_data {

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -159,8 +159,8 @@ std::string ThreadStateBar::GetThreadStateSliceTooltip(PrimitiveAssembler& primi
 
   const auto* thread_state_slice =
       static_cast<const ThreadStateSliceInfo*>(user_data->custom_data_);
-  auto begin_ns = thread_state_slice->begin_timestamp_ns();
-  auto end_ns = thread_state_slice->end_timestamp_ns();
+  uint64_t begin_ns = thread_state_slice->begin_timestamp_ns();
+  uint64_t end_ns = thread_state_slice->end_timestamp_ns();
 
   return absl::StrFormat(
       "<b>%s</b><br/>"

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -5,7 +5,9 @@
 #include "ThreadStateBar.h"
 
 #include <absl/strings/str_format.h>
+#include <absl/time/time.h>
 
+#include <cstdint>
 #include <memory>
 #include <utility>
 
@@ -14,6 +16,7 @@
 #include "ClientData/CaptureData.h"
 #include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientProtos/capture_data.pb.h"
+#include "DisplayFormats/DisplayFormats.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
 #include "GrpcProtos/capture.pb.h"
@@ -157,13 +160,21 @@ std::string ThreadStateBar::GetThreadStateSliceTooltip(PrimitiveAssembler& primi
 
   const auto* thread_state_slice =
       static_cast<const ThreadStateSliceInfo*>(user_data->custom_data_);
+  auto begin_ns = std::chrono::nanoseconds(thread_state_slice -> begin_timestamp_ns());
+  auto end_ns = std::chrono::nanoseconds(thread_state_slice -> end_timestamp_ns());
+
+
   return absl::StrFormat(
       "<b>%s</b><br/>"
       "<i>Thread state</i><br/>"
       "<br/>"
-      "%s",
+      "<br/>"
+      "%s"
+      "<br/>"
+      "<b>Time:</b> %s",
       GetThreadStateName(thread_state_slice->thread_state()),
-      GetThreadStateDescription(thread_state_slice->thread_state()));
+      GetThreadStateDescription(thread_state_slice->thread_state()),
+      orbit_display_formats::GetDisplayTime(absl::FromChrono(end_ns - begin_ns)));
 }
 
 void ThreadStateBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -17,6 +17,7 @@
 #include "DisplayFormats/DisplayFormats.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
+#include "GlUtils.h"
 #include "GrpcProtos/capture.pb.h"
 #include "OrbitBase/Logging.h"
 #include "PrimitiveAssembler.h"
@@ -158,20 +159,19 @@ std::string ThreadStateBar::GetThreadStateSliceTooltip(PrimitiveAssembler& primi
 
   const auto* thread_state_slice =
       static_cast<const ThreadStateSliceInfo*>(user_data->custom_data_);
-  auto begin_ns = std::chrono::nanoseconds(thread_state_slice->begin_timestamp_ns());
-  auto end_ns = std::chrono::nanoseconds(thread_state_slice->end_timestamp_ns());
+  auto begin_ns = thread_state_slice->begin_timestamp_ns();
+  auto end_ns = thread_state_slice->end_timestamp_ns();
 
   return absl::StrFormat(
       "<b>%s</b><br/>"
       "<i>Thread state</i><br/>"
-      "<br/>"
       "<br/>"
       "%s"
       "<br/>"
       "<b>Time:</b> %s",
       GetThreadStateName(thread_state_slice->thread_state()),
       GetThreadStateDescription(thread_state_slice->thread_state()),
-      orbit_display_formats::GetDisplayTime(absl::FromChrono(end_ns - begin_ns)));
+      orbit_display_formats::GetDisplayTime(TicksToDuration(begin_ns, end_ns)));
 }
 
 void ThreadStateBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -161,7 +161,6 @@ std::string ThreadStateBar::GetThreadStateSliceTooltip(PrimitiveAssembler& primi
   auto begin_ns = std::chrono::nanoseconds(thread_state_slice->begin_timestamp_ns());
   auto end_ns = std::chrono::nanoseconds(thread_state_slice->end_timestamp_ns());
 
-
   return absl::StrFormat(
       "<b>%s</b><br/>"
       "<i>Thread state</i><br/>"

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -158,8 +158,8 @@ std::string ThreadStateBar::GetThreadStateSliceTooltip(PrimitiveAssembler& primi
 
   const auto* thread_state_slice =
       static_cast<const ThreadStateSliceInfo*>(user_data->custom_data_);
-  auto begin_ns = std::chrono::nanoseconds(thread_state_slice -> begin_timestamp_ns());
-  auto end_ns = std::chrono::nanoseconds(thread_state_slice -> end_timestamp_ns());
+  auto begin_ns = std::chrono::nanoseconds(thread_state_slice->begin_timestamp_ns());
+  auto end_ns = std::chrono::nanoseconds(thread_state_slice->end_timestamp_ns());
 
 
   return absl::StrFormat(

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -5,9 +5,7 @@
 #include "ThreadStateBar.h"
 
 #include <absl/strings/str_format.h>
-#include <absl/time/time.h>
 
-#include <cstdint>
 #include <memory>
 #include <utility>
 


### PR DESCRIPTION
Using the beginning and ending timestamps from `thread_state_slice` to calculate the duration of a certain state, and displaying it in the tooltip.

Bug: http://b/235554080

Screenshot: https://screenshot.googleplex.com/4XpVffNBuFdn2Yv.png