### PR TITLE
Add StopSymbolDownloadDialog

### DIFF
--- a/src/ConfigWidgets/CMakeLists.txt
+++ b/src/ConfigWidgets/CMakeLists.txt
@@ -19,10 +19,13 @@ target_link_libraries(ConfigWidgets PUBLIC ClientFlags
 
 target_sources(
   ConfigWidgets PUBLIC include/ConfigWidgets/SourcePathsMappingDialog.h
+                       include/ConfigWidgets/StopSymbolDownloadDialog.h
                        include/ConfigWidgets/SymbolErrorDialog.h
                        include/ConfigWidgets/SymbolLocationsDialog.h)
 target_sources(ConfigWidgets PRIVATE SourcePathsMappingDialog.cpp
                                      SourcePathsMappingDialog.ui
+                                     StopSymbolDownloadDialog.cpp
+                                     StopSymbolDownloadDialog.ui
                                      SymbolErrorDialog.cpp
                                      SymbolErrorDialog.ui
                                      SymbolLocationsDialog.cpp
@@ -33,7 +36,8 @@ set_target_properties(ConfigWidgets PROPERTIES AUTOUIC ON)
 
 add_executable(ConfigWidgetsTests)
 
-target_sources(ConfigWidgetsTests PRIVATE SymbolErrorDialogTest.cpp
+target_sources(ConfigWidgetsTests PRIVATE StopSymbolDownloadDialogTest.cpp
+                                          SymbolErrorDialogTest.cpp
                                           SymbolLocationsDialogTest.cpp)
 
 target_link_libraries(ConfigWidgetsTests PRIVATE ConfigWidgets

--- a/src/ConfigWidgets/StopSymbolDownloadDialog.cpp
+++ b/src/ConfigWidgets/StopSymbolDownloadDialog.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ConfigWidgets/StopSymbolDownloadDialog.h"
+
+#include <absl/container/flat_hash_set.h>
+
+#include <memory>
+
+#include "ClientData/ModuleData.h"
+#include "ClientSymbols/QSettingsBasedStorageManager.h"
+#include "OrbitBase/Logging.h"
+#include "ui_StopSymbolDownloadDialog.h"
+
+namespace orbit_config_widgets {
+
+StopSymbolDownloadDialog::StopSymbolDownloadDialog(const orbit_client_data::ModuleData* module)
+    : ui_(std::make_unique<Ui::StopSymbolDownloadDialog>()) {
+  ORBIT_CHECK(module != nullptr);
+  ui_->setupUi(this);
+  ui_->moduleLabel->setText(QString("<b>%1</b>").arg(QString::fromStdString(module->file_path())));
+}
+
+StopSymbolDownloadDialog::~StopSymbolDownloadDialog() = default;
+
+StopSymbolDownloadDialog::Result StopSymbolDownloadDialog::Exec() {
+  int rc = exec();
+  if (rc != QDialog::Accepted) {
+    return Result::kCancel;
+  }
+
+  if (ui_->rememberCheckBox->isChecked()) {
+    return Result::kStopAndDisable;
+  }
+
+  return Result::kStop;
+}
+
+}  // namespace orbit_config_widgets

--- a/src/ConfigWidgets/StopSymbolDownloadDialog.ui
+++ b/src/ConfigWidgets/StopSymbolDownloadDialog.ui
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StopSymbolDownloadDialog</class>
+ <widget class="QDialog" name="StopSymbolDownloadDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>256</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Stop Symbol Download</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="3,1,4,1,1,0">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Symbols for this module are still downloading</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="moduleLabel">
+     <property name="text">
+      <string></string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Once downloaded, these symbols will be cached locally and will load quickly for subsequent sessions.&lt;br/&gt;If you don't need to load symbols for this module, you can stop this download.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="rememberCheckBox">
+     <property name="text">
+      <string>Never download symbols for this module</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="stopDownloadButton">
+       <property name="text">
+        <string>Stop downloading</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>stopDownloadButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+  <tabstop>rememberCheckBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>stopDownloadButton</sender>
+   <signal>clicked()</signal>
+   <receiver>StopSymbolDownloadDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>365</x>
+     <y>241</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>302</x>
+     <y>173</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cancelButton</sender>
+   <signal>clicked()</signal>
+   <receiver>StopSymbolDownloadDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>257</x>
+     <y>234</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>243</x>
+     <y>199</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots/>
+</ui>

--- a/src/ConfigWidgets/StopSymbolDownloadDialogTest.cpp
+++ b/src/ConfigWidgets/StopSymbolDownloadDialogTest.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/match.h>
+#include <gtest/gtest.h>
+#include <qnamespace.h>
+
+#include <QCheckBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QTest>
+
+#include "ClientData/ModuleData.h"
+#include "ConfigWidgets/StopSymbolDownloadDialog.h"
+#include "GrpcProtos/module.pb.h"
+
+namespace orbit_config_widgets {
+
+constexpr const char* kFilePath = "test/file/path";
+
+orbit_grpc_protos::ModuleInfo CreateModuleInfo() {
+  orbit_grpc_protos::ModuleInfo module_info;
+  module_info.set_file_path(kFilePath);
+  return module_info;
+}
+
+class StopSymbolDownloadDialogTest : public testing::Test {
+ public:
+  explicit StopSymbolDownloadDialogTest() : module_(CreateModuleInfo()), dialog_(&module_) {}
+
+ protected:
+  void SetUp() override {
+    stop_button_ = dialog_.findChild<QPushButton*>("stopDownloadButton");
+    ASSERT_NE(stop_button_, nullptr);
+  }
+  orbit_client_data::ModuleData module_;
+  StopSymbolDownloadDialog dialog_;
+  QPushButton* stop_button_ = nullptr;
+};
+
+TEST_F(StopSymbolDownloadDialogTest, UiContent) {
+  auto* module_label = dialog_.findChild<QLabel*>("moduleLabel");
+  ASSERT_NE(module_label, nullptr);
+  std::string module_label_text = module_label->text().toStdString();
+  EXPECT_TRUE(absl::StrContains(module_label_text, kFilePath));
+}
+
+TEST_F(StopSymbolDownloadDialogTest, Canceled) {
+  auto* cancel_button = dialog_.findChild<QPushButton*>("cancelButton");
+  ASSERT_NE(cancel_button, nullptr);
+
+  QMetaObject::invokeMethod(
+      &dialog_, [&] { QTest::mouseClick(cancel_button, Qt::LeftButton); }, Qt::QueuedConnection);
+  StopSymbolDownloadDialog::Result dialog_result = dialog_.Exec();
+
+  EXPECT_EQ(dialog_result, StopSymbolDownloadDialog::Result::kCancel);
+}
+
+TEST_F(StopSymbolDownloadDialogTest, StopDownload) {
+  QMetaObject::invokeMethod(
+      &dialog_, [this] { QTest::mouseClick(stop_button_, Qt::LeftButton); }, Qt::QueuedConnection);
+  StopSymbolDownloadDialog::Result dialog_result = dialog_.Exec();
+
+  EXPECT_EQ(dialog_result, StopSymbolDownloadDialog::Result::kStop);
+}
+
+TEST_F(StopSymbolDownloadDialogTest, StopDownloadAndDisable) {
+  auto* rememberCheckBox = dialog_.findChild<QCheckBox*>("rememberCheckBox");
+  ASSERT_NE(rememberCheckBox, nullptr);
+
+  rememberCheckBox->setCheckState(Qt::Checked);
+
+  QMetaObject::invokeMethod(
+      &dialog_, [this] { QTest::mouseClick(stop_button_, Qt::LeftButton); }, Qt::QueuedConnection);
+  StopSymbolDownloadDialog::Result dialog_result = dialog_.Exec();
+
+  EXPECT_EQ(dialog_result, StopSymbolDownloadDialog::Result::kStopAndDisable);
+}
+
+}  // namespace orbit_config_widgets

--- a/src/ConfigWidgets/include/ConfigWidgets/StopSymbolDownloadDialog.h
+++ b/src/ConfigWidgets/include/ConfigWidgets/StopSymbolDownloadDialog.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CONFIG_WIDGETS_STOP_SYMBOL_DOWNLOAD_DIALOG_H_
+#define CONFIG_WIDGETS_STOP_SYMBOL_DOWNLOAD_DIALOG_H_
+
+#include <absl/container/flat_hash_set.h>
+
+#include <QDialog>
+#include <memory>
+
+#include "ClientData/ModuleData.h"
+
+namespace Ui {
+class StopSymbolDownloadDialog;
+}
+
+namespace orbit_config_widgets {
+
+class StopSymbolDownloadDialog : public QDialog {
+  Q_OBJECT;
+
+ public:
+  enum class Result { kCancel, kStop, kStopAndDisable };
+
+  explicit StopSymbolDownloadDialog(const orbit_client_data::ModuleData* module);
+  ~StopSymbolDownloadDialog() override;
+  [[nodiscard]] Result Exec();
+
+ private:
+  std::unique_ptr<Ui::StopSymbolDownloadDialog> ui_;
+};
+
+}  // namespace orbit_config_widgets
+
+#endif  // CONFIG_WIDGETS_STOP_SYMBOL_DOWNLOAD_DIALOG_H_


### PR DESCRIPTION
This adds StopSymbolDownloadDialog and tests. This is not used yet, but
will be as a confirmation for stopping symbol downloads. This includes
a remember checkbox to disable downloads for this module.

Screenshot: https://screenshot.googleplex.com/6SbJcW6YpwS2px6 
(Note: After I took the screenshot, I saw that the title is still "Dialog". I fixed that and named it "Stop Symbol Download", its in this commit)

Test: Unit Test
Bug: http://b/231579238