### PR TITLE
Add mean/var active frame time calculation for Mizar

### DIFF
--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -53,24 +53,30 @@ int main(int argc, char* argv[]) {
   orbit_mizar_data::BaselineAndComparison bac =
       CreateBaselineAndComparison(std::move(baseline), std::move(comparison));
 
-  constexpr uint64_t kStart = 0;
+  constexpr uint64_t kStart = 20'000'000'000;
   constexpr uint64_t kDuration = std::numeric_limits<uint64_t>::max();
 
   const orbit_mizar_data::SamplingWithFrameTrackComparisonReport report =
       bac.MakeSamplingWithFrameTrackReport(
           orbit_mizar_data::BaselineSamplingWithFrameTrackReportConfig{
-              {orbit_base::kAllProcessThreadsTid}, kStart, kDuration},
+              {orbit_base::kAllProcessThreadsTid}, kStart, kDuration, 1},
           orbit_mizar_data::ComparisonSamplingWithFrameTrackReportConfig{
-              {orbit_base::kAllProcessThreadsTid}, kStart, kDuration});
+              {orbit_base::kAllProcessThreadsTid}, kStart, kDuration, 1});
 
   for (const auto& [sfid, name] : bac.sfid_to_name()) {
     const uint64_t baseline_cnt = report.baseline_sampling_counts.GetExclusiveCount(sfid);
     const uint64_t comparison_cnt = report.baseline_sampling_counts.GetExclusiveCount(sfid);
     if (baseline_cnt > 0 || comparison_cnt > 0) {
-      ORBIT_LOG("%s %.2f %.2f", static_cast<std::string>(sfid), baseline_cnt, comparison_cnt);
+      ORBIT_LOG("%s %s %.2f %.2f", name, static_cast<std::string>(sfid), baseline_cnt,
+                comparison_cnt);
     }
   }
   ORBIT_LOG("Total number of common names %u  ", bac.sfid_to_name().size());
-
+  ORBIT_LOG("Baseline mean frametime %u ns, stddev %u",
+            report.baseline_frame_track_stats.ComputeAverageTimeNs(),
+            report.baseline_frame_track_stats.ComputeStdDevNs());
+  ORBIT_LOG("Comparison mean frametime %u ns, stddev %u",
+            report.comparison_frame_track_stats.ComputeAverageTimeNs(),
+            report.comparison_frame_track_stats.ComputeStdDevNs());
   return 0;
 }

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -18,6 +18,9 @@
 #include "MizarData/BaselineAndComparison.h"
 #include "OrbitBase/ThreadConstants.h"
 
+using ::testing::DoubleNear;
+using ::testing::UnorderedElementsAreArray;
+
 namespace orbit_mizar_data {
 
 constexpr size_t kFunctionNum = 3;
@@ -89,7 +92,7 @@ TEST(BaselineAndComparisonTest, BaselineAndComparisonHelperIsCorrect) {
   ExpectCorrectNames(comparison_address_to_sfid, sfid_to_name, kComparisonAddressToName);
 
   EXPECT_THAT(Values(baseline_address_to_sfid),
-              testing::UnorderedElementsAreArray(Values(comparison_address_to_sfid)));
+              UnorderedElementsAreArray(Values(comparison_address_to_sfid)));
 }
 
 constexpr size_t kSFIDCnt = 3;
@@ -101,11 +104,15 @@ constexpr std::array<SFID, kSFIDCnt> kSFIDs = {kSFIDFirst, kSFIDSecond, kSFIDThi
 const std::vector<std::vector<SFID>> kCallstacks = {
     std::vector<SFID>{kSFIDFirst, kSFIDSecond, kSFIDThird}, {kSFIDSecond}, {}};
 
+const std::vector<uint64_t> kFrameTrackActiveTimes = {300, 100, 200};
+
 namespace {
 class MockPairedData {
  public:
-  explicit MockPairedData(std::vector<std::vector<SFID>> callstacks)
-      : callstacks_(std::move(callstacks)) {}
+  explicit MockPairedData(std::vector<std::vector<SFID>> callstacks,
+                          std::vector<uint64_t> frame_track_active_times)
+      : callstacks_(std::move(callstacks)),
+        frame_track_active_times_(std::move(frame_track_active_times)) {}
 
   template <typename Action>
   void ForEachCallstackEvent(uint32_t /*tid*/, uint64_t /*min_timestamp*/,
@@ -113,19 +120,25 @@ class MockPairedData {
     std::for_each(std::begin(callstacks_), std::end(callstacks_), std::forward<Action>(action));
   }
 
+  [[nodiscard]] std::vector<uint64_t> ActiveInvocationTimes(uint64_t /*_*/, uint64_t /*_*/,
+                                                            uint64_t /*_*/) const {
+    return frame_track_active_times_;
+  };
+
  private:
   std::vector<std::vector<SFID>> callstacks_;
+  std::vector<uint64_t> frame_track_active_times_;
 };
 }  // namespace
 
 TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
-  MockPairedData full(kCallstacks);
-  MockPairedData empty({});
+  MockPairedData full(kCallstacks, kFrameTrackActiveTimes);
+  MockPairedData empty({}, {});
 
   BaselineAndComparisonTmpl<MockPairedData> bac(full, empty, {});
-  SamplingWithFrameTrackComparisonReport report = bac.MakeSamplingWithFrameTrackReport(
-      BaselineSamplingWithFrameTrackReportConfig{{orbit_base::kAllProcessThreadsTid}, 0, 1},
-      ComparisonSamplingWithFrameTrackReportConfig{{orbit_base::kAllProcessThreadsTid}, 0, 1});
+  const SamplingWithFrameTrackComparisonReport report = bac.MakeSamplingWithFrameTrackReport(
+      BaselineSamplingWithFrameTrackReportConfig{{orbit_base::kAllProcessThreadsTid}, 0, 1, 1},
+      ComparisonSamplingWithFrameTrackReportConfig{{orbit_base::kAllProcessThreadsTid}, 0, 1, 1});
 
   EXPECT_EQ(report.baseline_sampling_counts.GetTotalCallstacks(), kCallstacks.size());
 
@@ -142,6 +155,18 @@ TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
     EXPECT_EQ(report.comparison_sampling_counts.GetExclusiveCount(sfid), 0);
     EXPECT_EQ(report.comparison_sampling_counts.GetInclusiveCount(sfid), 0);
   }
+
+  constexpr uint64_t kExpectedFullActiveFrameTime = 200;
+  EXPECT_EQ(report.baseline_frame_track_stats.ComputeAverageTimeNs(), kExpectedFullActiveFrameTime);
+  EXPECT_EQ(report.comparison_frame_track_stats.ComputeAverageTimeNs(), 0);
+
+  constexpr double kExpectedFullActiveFrameTimeVariance = 6666.66666;
+  EXPECT_THAT(report.baseline_frame_track_stats.variance_ns(),
+              DoubleNear(kExpectedFullActiveFrameTimeVariance, 1e-3));
+  EXPECT_THAT(report.comparison_frame_track_stats.variance_ns(), DoubleNear(0, 1e-3));
+
+  EXPECT_EQ(report.baseline_frame_track_stats.count(), kFrameTrackActiveTimes.size());
+  EXPECT_EQ(report.comparison_frame_track_stats.count(), 0);
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -120,8 +121,9 @@ class MockPairedData {
     std::for_each(std::begin(callstacks_), std::end(callstacks_), std::forward<Action>(action));
   }
 
-  [[nodiscard]] std::vector<uint64_t> ActiveInvocationTimes(uint64_t /*_*/, uint64_t /*_*/,
-                                                            uint64_t /*_*/) const {
+  [[nodiscard]] std::vector<uint64_t> ActiveInvocationTimes(
+      const absl::flat_hash_set<uint32_t>& /*_*/, uint64_t /*_*/, uint64_t /*_*/,
+      uint64_t /*_*/) const {
     return frame_track_active_times_;
   };
 

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -187,8 +187,8 @@ TEST_F(MizarPairedDataTest, ForeachCallstackIsCorrect) {
 TEST_F(MizarPairedDataTest, ActiveInvocationTimesIsCorrect) {
   MizarPairedData<MockMizarData> mizar_paired_data(std::move(data_), kAddressToId);
   std::vector<uint64_t> actual_active_invocation_times =
-      mizar_paired_data.ActiveInvocationTimes(1, 0, std::numeric_limits<uint64_t>::max());
-  EXPECT_THAT(actual_active_invocation_times, ElementsAre(kSamplingPeriod * 2, kSamplingPeriod));
+      mizar_paired_data.ActiveInvocationTimes({kTID, kAnotherTID}, 1, 0, std::numeric_limits<uint64_t>::max());
+  EXPECT_THAT(actual_active_invocation_times, ElementsAre(kSamplingPeriod * 2, kSamplingPeriod * 2));
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -20,17 +20,25 @@
 #include "ClientData/CaptureData.h"
 #include "MizarData/BaselineAndComparison.h"
 
+using ::testing::ElementsAre;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::UnorderedElementsAre;
+
 namespace {
 
 class MockCaptureData {
  public:
   MOCK_METHOD(const orbit_client_data::CallstackData&, GetCallstackData, (), (const));
+  MOCK_METHOD(std::vector<const TimerInfo*>, GetTimersForScope, (uint64_t, uint64_t, uint64_t),
+              (const));
 };
 
 class MockMizarData {
  public:
   MOCK_METHOD(const MockCaptureData&, GetCaptureData, (), (const));
   MOCK_METHOD(uint64_t, GetCaptureStartTimestampNs, (), (const));
+  MOCK_METHOD(uint64_t, GetNominalSamplingPeriodNs, (), (const));
 };
 
 }  // namespace
@@ -55,10 +63,10 @@ constexpr uint64_t kInCompleteCallstackId = 2;
 constexpr uint64_t kAnotherCompleteCallstackId = 3;
 
 constexpr uint64_t kCaptureStart = 123;
-constexpr uint64_t kRelativeTime1 = 1;
-constexpr uint64_t kRelativeTime2 = 2;
-constexpr uint64_t kRelativeTime3 = 3;
-constexpr uint64_t kRelativeTime4 = 4;
+constexpr uint64_t kRelativeTime1 = 10;
+constexpr uint64_t kRelativeTime2 = 20;
+constexpr uint64_t kRelativeTime3 = 30;
+constexpr uint64_t kRelativeTime4 = 40;
 constexpr uint64_t kTID = 0x3AD1;
 constexpr uint64_t kAnotherTID = 0x3AD2;
 
@@ -96,15 +104,57 @@ const std::vector<SFID> kInCompleteCallstackIds =
 const std::vector<SFID> kAnotherCompleteCallstackIds =
     SFIDsForCallstacks(kAnotherCompleteCallstack.frames());
 
-TEST(MizarPairedDataTest, ForeachCallstackIsCorrect) {
-  auto capture_data = std::make_unique<MockCaptureData>();
-  auto data = std::make_unique<MockMizarData>();
+constexpr size_t kInvocationsCount = 3;
+constexpr std::array<uint64_t, kInvocationsCount> kStarts = {
+    kCaptureStart, kCaptureStart + kRelativeTime2 - 1, kCaptureStart + kRelativeTime4};
+const std::array<uint64_t, kInvocationsCount> kEnds = [] {
+  std::array<uint64_t, kInvocationsCount> result{};
+  std::transform(std::begin(kStarts), std::end(kStarts), std::begin(result),
+                 [](const uint64_t start) { return start + 1; });
+  return result;
+}();
 
-  EXPECT_CALL(*capture_data, GetCallstackData).WillRepeatedly(testing::ReturnRef(*kCallstackData));
-  EXPECT_CALL(*data, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data));
-  EXPECT_CALL(*data, GetCaptureStartTimestampNs).WillRepeatedly(testing::Return(kCaptureStart));
+const std::array<orbit_client_protos::TimerInfo, kInvocationsCount> kTimers = [] {
+  std::array<orbit_client_protos::TimerInfo, kInvocationsCount> result;
+  std::transform(std::begin(kStarts), std::end(kStarts), std::begin(kEnds), std::begin(result),
+                 [](const uint64_t start, const uint64_t end) {
+                   orbit_client_protos::TimerInfo timer;
+                   timer.set_start(start);
+                   timer.set_end(end);
+                   timer.set_thread_id(kTID);
+                   return timer;
+                 });
+  return result;
+}();
 
-  MizarPairedData<MockMizarData> mizar_paired_data(std::move(data), kAddressToId);
+const std::vector<const orbit_client_protos::TimerInfo*> kTimerPtrs = [] {
+  std::vector<const orbit_client_protos::TimerInfo*> result;
+  std::transform(std::begin(kTimers), std::end(kTimers), std::back_inserter(result),
+                 [](const TimerInfo& timer) { return &timer; });
+  return result;
+}();
+
+constexpr uint64_t kSamplingPeriod = 10;
+
+class MizarPairedDataTest : public ::testing::Test {
+ public:
+  MizarPairedDataTest()
+      : capture_data_(std::make_unique<MockCaptureData>()),
+        data_(std::make_unique<MockMizarData>()) {
+    EXPECT_CALL(*capture_data_, GetCallstackData).WillRepeatedly(ReturnRef(*kCallstackData));
+    EXPECT_CALL(*capture_data_, GetTimersForScope).WillRepeatedly(Return(kTimerPtrs));
+    EXPECT_CALL(*data_, GetCaptureData).WillRepeatedly(ReturnRef(*capture_data_));
+    EXPECT_CALL(*data_, GetCaptureStartTimestampNs).WillRepeatedly(Return(kCaptureStart));
+    EXPECT_CALL(*data_, GetNominalSamplingPeriodNs).WillRepeatedly(Return(kSamplingPeriod));
+  }
+
+ protected:
+  std::unique_ptr<MockCaptureData> capture_data_;
+  std::unique_ptr<MockMizarData> data_;
+};
+
+TEST_F(MizarPairedDataTest, ForeachCallstackIsCorrect) {
+  MizarPairedData<MockMizarData> mizar_paired_data(std::move(data_), kAddressToId);
   std::vector<std::vector<SFID>> actual_ids_fed_to_action;
   auto action = [&actual_ids_fed_to_action](const std::vector<SFID> ids) {
     actual_ids_fed_to_action.push_back(ids);
@@ -115,23 +165,30 @@ TEST(MizarPairedDataTest, ForeachCallstackIsCorrect) {
   mizar_paired_data.ForEachCallstackEvent(orbit_base::kAllProcessThreadsTid, 0, kRelativeTime4,
                                           action);
   EXPECT_THAT(actual_ids_fed_to_action,
-              testing::UnorderedElementsAre(kCompleteCallstackIds, kCompleteCallstackIds,
-                                            kInCompleteCallstackIds, kAnotherCompleteCallstackIds));
+              UnorderedElementsAre(kCompleteCallstackIds, kCompleteCallstackIds,
+                                   kInCompleteCallstackIds, kAnotherCompleteCallstackIds));
 
   // One thread, all timestamps
   actual_ids_fed_to_action.clear();
   mizar_paired_data.ForEachCallstackEvent(kTID, 0, kRelativeTime4, action);
-  EXPECT_THAT(actual_ids_fed_to_action,
-              testing::UnorderedElementsAre(kCompleteCallstackIds, kCompleteCallstackIds,
-                                            kInCompleteCallstackIds));
+  EXPECT_THAT(
+      actual_ids_fed_to_action,
+      UnorderedElementsAre(kCompleteCallstackIds, kCompleteCallstackIds, kInCompleteCallstackIds));
 
   // All threads, some timestamps
   actual_ids_fed_to_action.clear();
   mizar_paired_data.ForEachCallstackEvent(orbit_base::kAllProcessThreadsTid, kRelativeTime1,
                                           kRelativeTime4, action);
   EXPECT_THAT(actual_ids_fed_to_action,
-              testing::UnorderedElementsAre(kCompleteCallstackIds, kInCompleteCallstackIds,
-                                            kAnotherCompleteCallstackIds));
+              UnorderedElementsAre(kCompleteCallstackIds, kInCompleteCallstackIds,
+                                   kAnotherCompleteCallstackIds));
+}
+
+TEST_F(MizarPairedDataTest, ActiveInvocationTimesIsCorrect) {
+  MizarPairedData<MockMizarData> mizar_paired_data(std::move(data_), kAddressToId);
+  std::vector<uint64_t> actual_active_invocation_times =
+      mizar_paired_data.ActiveInvocationTimes(1, 0, std::numeric_limits<uint64_t>::max());
+  EXPECT_THAT(actual_active_invocation_times, ElementsAre(kSamplingPeriod * 2, kSamplingPeriod));
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -47,7 +47,7 @@ class BaselineAndComparisonTmpl {
   [[nodiscard]] orbit_client_data::ScopeStats MakeFrameTrackStats(
       const PairedData& data, const HalfOfSamplingWithFrameTrackReportConfig& config) const {
     const std::vector<uint64_t> active_invocation_times = data.ActiveInvocationTimes(
-        config.frame_track_scope_id, config.start_relative_ns,
+        config.tids, config.frame_track_scope_id, config.start_relative_ns,
         NonWrappingAddition(config.start_relative_ns, config.duration_ns));
     orbit_client_data::ScopeStats stats;
     for (const uint64_t active_invocation_time : active_invocation_times) {

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -37,13 +37,27 @@ class BaselineAndComparisonTmpl {
 
   [[nodiscard]] SamplingWithFrameTrackComparisonReport MakeSamplingWithFrameTrackReport(
       BaselineSamplingWithFrameTrackReportConfig baseline_config,
-      ComparisonSamplingWithFrameTrackReportConfig comparison_config) {
-    return {MakeCounts(baseline_, baseline_config), MakeCounts(comparison_, comparison_config)};
+      ComparisonSamplingWithFrameTrackReportConfig comparison_config) const {
+    return {MakeCounts(baseline_, baseline_config), MakeCounts(comparison_, comparison_config),
+            MakeFrameTrackStats(baseline_, comparison_config),
+            MakeFrameTrackStats(comparison_, comparison_config)};
   }
 
  private:
-  [[nodiscard]] SamplingCounts MakeCounts(const PairedData& data,
-                                          const HalfOfSamplingWithFrameTrackReportConfig& config) {
+  [[nodiscard]] orbit_client_data::ScopeStats MakeFrameTrackStats(
+      const PairedData& data, const HalfOfSamplingWithFrameTrackReportConfig& config) const {
+    const std::vector<uint64_t> active_invocation_times = data.ActiveInvocationTimes(
+        config.frame_track_scope_id, config.start_relative_ns,
+        NonWrappingAddition(config.start_relative_ns, config.duration_ns));
+    orbit_client_data::ScopeStats stats;
+    for (const uint64_t active_invocation_time : active_invocation_times) {
+      stats.UpdateStats(active_invocation_time);
+    }
+    return stats;
+  }
+
+  [[nodiscard]] SamplingCounts MakeCounts(
+      const PairedData& data, const HalfOfSamplingWithFrameTrackReportConfig& config) const {
     uint64_t total_callstacks = 0;
     absl::flat_hash_map<SFID, InclusiveAndExclusive> counts;
     for (const uint32_t tid : config.tids) {

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -48,6 +48,12 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
     return GetCaptureData().GetCaptureStarted().capture_start_timestamp_ns();
   }
 
+  [[nodiscard]] uint64_t GetNominalSamplingPeriodNs() const override {
+    const double samples_per_second =
+        GetCaptureData().GetCaptureStarted().capture_options().samples_per_second();
+    return static_cast<uint64_t>(1'000'000'000 / samples_per_second);
+  }
+
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,
                         std::optional<std::filesystem::path> file_path,
                         absl::flat_hash_set<uint64_t> frame_track_function_ids) override;

--- a/src/MizarData/include/MizarData/MizarDataProvider.h
+++ b/src/MizarData/include/MizarData/MizarDataProvider.h
@@ -33,6 +33,8 @@ class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
   [[nodiscard]] virtual absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const = 0;
 
   [[nodiscard]] virtual uint64_t GetCaptureStartTimestampNs() const = 0;
+
+  [[nodiscard]] virtual uint64_t GetNominalSamplingPeriodNs() const = 0;
 };
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -6,11 +6,14 @@
 #define MIZAR_DATA_MIZAR_PAIRED_DATA_H_
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <memory>
+#include <numeric>
 #include <utility>
 #include <vector>
 
@@ -31,24 +34,32 @@ class MizarPairedData {
   MizarPairedData(std::unique_ptr<Data> data, absl::flat_hash_map<uint64_t, SFID> address_to_sfid)
       : data_(std::move(data)), address_to_sfid_(std::move(address_to_sfid)) {}
 
+  // The function estimates how much of CPU-time has been actually spent by the threads in `tids`
+  // during each of the frames. scope-id is used as a frame-track. This time does not include the
+  // time the process was waiting, de-scheduled, or the VM itself was de-scheduled. This is achieved
+  // by counting how many callstack samples have been obtained during each frame and them multiplied
+  // by the sampling period.
   [[nodiscard]] std::vector<uint64_t> ActiveInvocationTimes(
-      uint64_t scope_id, uint64_t min_relative_timestamp_ns,
-      uint64_t max_relative_timestamp_ns) const {
+      const absl::flat_hash_set<uint32_t>& tids, uint64_t frame_track_scope_id,
+      uint64_t min_relative_timestamp_ns, uint64_t max_relative_timestamp_ns) const {
     const auto [min_timestamp_ns, max_timestamp_ns] =
         RelativeToAbsoluteTimestampRange(min_relative_timestamp_ns, max_relative_timestamp_ns);
     const std::vector<const orbit_client_protos::TimerInfo*> timers =
-        data_->GetCaptureData().GetTimersForScope(scope_id, min_timestamp_ns, max_timestamp_ns);
+        data_->GetCaptureData().GetTimersForScope(frame_track_scope_id, min_timestamp_ns,
+                                                  max_timestamp_ns);
     if (timers.size() < 2) return {};
 
     // TODO(b/235572160) Estimate the actual sampling period and use it instead
     const uint64_t sampling_period = data_->GetNominalSamplingPeriodNs();
 
-    const uint32_t tid = timers.front()->thread_id();
-
     std::vector<uint64_t> result;
     for (size_t i = 0; i + 1 < timers.size(); ++i) {
-      const uint64_t callstack_count =
-          CallstackSamplesCount(tid, timers[i]->start(), timers[i + 1]->start());
+      const uint64_t callstack_count = std::transform_reduce(
+          std::begin(tids), std::end(tids), 0, std::plus<>(),
+          [this, i, &timers](const uint64_t tid) {
+            return CallstackSamplesCount(tid, timers[i]->start(), timers[i + 1]->start());
+          });
+
       result.push_back(sampling_period * callstack_count);
     }
     return result;
@@ -75,6 +86,17 @@ class MizarPairedData {
 
     const auto [min_timestamp_ns, max_timestamp_ns] =
         RelativeToAbsoluteTimestampRange(min_relative_timestamp_ns, max_relative_timestamp_ns);
+    ForEachCallstackEventOfTidInTimeRange(tid, min_timestamp_ns, max_timestamp_ns,
+                                          action_on_callstack_events);
+  }
+
+ private:
+  template <typename Action>
+  void ForEachCallstackEventOfTidInTimeRange(uint32_t tid, uint64_t min_timestamp_ns,
+                                             uint64_t max_timestamp_ns,
+                                             Action&& action_on_callstack_events) const {
+    const orbit_client_data::CallstackData& callstack_data =
+        data_->GetCaptureData().GetCallstackData();
     if (tid == orbit_base::kAllProcessThreadsTid) {
       callstack_data.ForEachCallstackEventInTimeRange(min_timestamp_ns, max_timestamp_ns,
                                                       action_on_callstack_events);
@@ -84,12 +106,11 @@ class MizarPairedData {
     }
   }
 
- private:
   [[nodiscard]] uint64_t CallstackSamplesCount(uint32_t tid, uint64_t min_timestamp_ns,
                                                uint64_t max_timestamp_ns) const {
     uint64_t count = 0;
-    data_->GetCaptureData().GetCallstackData().ForEachCallstackEventOfTidInTimeRange(
-        tid, min_timestamp_ns, max_timestamp_ns, [&count](const auto& /*_*/) { count++; });
+    ForEachCallstackEventOfTidInTimeRange(tid, min_timestamp_ns, max_timestamp_ns,
+                                          [&count](const auto& /*_*/) { count++; });
     return count;
   }
 

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -8,10 +8,14 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <iterator>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include "ClientData/CallstackData.h"
+#include "ClientProtos/capture_data.pb.h"
 #include "MizarData/NonWrappingAddition.h"
 #include "MizarData/SampledFunctionId.h"
 #include "OrbitBase/ThreadConstants.h"
@@ -26,6 +30,29 @@ class MizarPairedData {
  public:
   MizarPairedData(std::unique_ptr<Data> data, absl::flat_hash_map<uint64_t, SFID> address_to_sfid)
       : data_(std::move(data)), address_to_sfid_(std::move(address_to_sfid)) {}
+
+  [[nodiscard]] std::vector<uint64_t> ActiveInvocationTimes(
+      uint64_t scope_id, uint64_t min_relative_timestamp_ns,
+      uint64_t max_relative_timestamp_ns) const {
+    const auto [min_timestamp_ns, max_timestamp_ns] =
+        RelativeToAbsoluteTimestampRange(min_relative_timestamp_ns, max_relative_timestamp_ns);
+    const std::vector<const orbit_client_protos::TimerInfo*> timers =
+        data_->GetCaptureData().GetTimersForScope(scope_id, min_timestamp_ns, max_timestamp_ns);
+    if (timers.size() < 2) return {};
+
+    // TODO(b/235572160) Estimate the actual sampling period and use it instead
+    const uint64_t sampling_period = data_->GetNominalSamplingPeriodNs();
+
+    const uint32_t tid = timers.front()->thread_id();
+
+    std::vector<uint64_t> result;
+    for (size_t i = 0; i + 1 < timers.size(); ++i) {
+      const uint64_t callstack_count =
+          CallstackSamplesCount(tid, timers[i]->start(), timers[i + 1]->start());
+      result.push_back(sampling_period * callstack_count);
+    }
+    return result;
+  }
 
   // Action is a void callable that takes a single argument of type
   // `const std::vector<uint64_t>` representing a callstack sample, each element of the vector is a
@@ -46,11 +73,8 @@ class MizarPairedData {
       std::invoke(std::forward<Action>(action), sfids);
     };
 
-    const uint64_t min_timestamp_ns =
-        NonWrappingAddition(data_->GetCaptureStartTimestampNs(), min_relative_timestamp_ns);
-    const uint64_t max_timestamp_ns =
-        NonWrappingAddition(data_->GetCaptureStartTimestampNs(), max_relative_timestamp_ns);
-
+    const auto [min_timestamp_ns, max_timestamp_ns] =
+        RelativeToAbsoluteTimestampRange(min_relative_timestamp_ns, max_relative_timestamp_ns);
     if (tid == orbit_base::kAllProcessThreadsTid) {
       callstack_data.ForEachCallstackEventInTimeRange(min_timestamp_ns, max_timestamp_ns,
                                                       action_on_callstack_events);
@@ -61,6 +85,21 @@ class MizarPairedData {
   }
 
  private:
+  [[nodiscard]] uint64_t CallstackSamplesCount(uint32_t tid, uint64_t min_timestamp_ns,
+                                               uint64_t max_timestamp_ns) const {
+    uint64_t count = 0;
+    data_->GetCaptureData().GetCallstackData().ForEachCallstackEventOfTidInTimeRange(
+        tid, min_timestamp_ns, max_timestamp_ns, [&count](const auto& /*_*/) { count++; });
+    return count;
+  }
+
+  [[nodiscard]] std::pair<uint64_t, uint64_t> RelativeToAbsoluteTimestampRange(
+      uint64_t min_relative_timestamp_ns, uint64_t max_relative_timestamp_ns) const {
+    return std::make_pair(
+        NonWrappingAddition(data_->GetCaptureStartTimestampNs(), min_relative_timestamp_ns),
+        NonWrappingAddition(data_->GetCaptureStartTimestampNs(), max_relative_timestamp_ns));
+  }
+
   [[nodiscard]] std::vector<SFID> CallstackWithSFIDs(
       const orbit_client_data::CallstackInfo* callstack) const {
     if (callstack->frames().empty()) return {};

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -36,9 +36,9 @@ class MizarPairedData {
 
   // The function estimates how much of CPU-time has been actually spent by the threads in `tids`
   // during each of the frames. scope-id is used as a frame-track. This time does not include the
-  // time the process was waiting, de-scheduled, or the VM itself was de-scheduled. This is achieved
-  // by counting how many callstack samples have been obtained during each frame and them multiplied
-  // by the sampling period.
+  // time the process was waiting, de-scheduled, or the VM itself was de-scheduled. The estimate is
+  // obtained via counting how many callstack samples have been obtained during each frame and then
+  // multiplying the counter by the sampling period.
   [[nodiscard]] std::vector<uint64_t> ActiveInvocationTimes(
       const absl::flat_hash_set<uint32_t>& tids, uint64_t frame_track_scope_id,
       uint64_t min_relative_timestamp_ns, uint64_t max_relative_timestamp_ns) const {

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -11,6 +11,7 @@
 
 #include <utility>
 
+#include "ClientData/ScopeStats.h"
 #include "MizarData/SampledFunctionId.h"
 #include "OrbitBase/Logging.h"
 
@@ -20,24 +21,33 @@ namespace orbit_mizar_data {
 // comparison.
 struct HalfOfSamplingWithFrameTrackReportConfig {
   explicit HalfOfSamplingWithFrameTrackReportConfig(absl::flat_hash_set<uint32_t> tids,
-                                                    uint64_t start_ns, uint64_t duration_ns)
-      : tids(std::move(tids)), start_relative_ns(start_ns), duration_ns(duration_ns) {}
+                                                    uint64_t start_ns, uint64_t duration_ns,
+                                                    uint64_t frame_track_scope_id)
+      : tids(std::move(tids)),
+        start_relative_ns(start_ns),
+        duration_ns(duration_ns),
+        frame_track_scope_id(frame_track_scope_id) {}
 
   absl::flat_hash_set<uint32_t> tids{};
   uint64_t start_relative_ns{};  // nanoseconds elapsed since capture start
   uint64_t duration_ns{};
+  uint64_t frame_track_scope_id{};
 };
 
 struct BaselineSamplingWithFrameTrackReportConfig : HalfOfSamplingWithFrameTrackReportConfig {
   explicit BaselineSamplingWithFrameTrackReportConfig(absl::flat_hash_set<uint32_t> tids,
-                                                      uint64_t start_ns, uint64_t duration_ns)
-      : HalfOfSamplingWithFrameTrackReportConfig(std::move(tids), start_ns, duration_ns) {}
+                                                      uint64_t start_ns, uint64_t duration_ns,
+                                                      uint64_t frame_track_scope_id)
+      : HalfOfSamplingWithFrameTrackReportConfig(std::move(tids), start_ns, duration_ns,
+                                                 frame_track_scope_id) {}
 };
 
 struct ComparisonSamplingWithFrameTrackReportConfig : HalfOfSamplingWithFrameTrackReportConfig {
   explicit ComparisonSamplingWithFrameTrackReportConfig(absl::flat_hash_set<uint32_t> tids,
-                                                        uint64_t start_ns, uint64_t duration_ns)
-      : HalfOfSamplingWithFrameTrackReportConfig(std::move(tids), start_ns, duration_ns) {}
+                                                        uint64_t start_ns, uint64_t duration_ns,
+                                                        uint64_t frame_track_scope_id)
+      : HalfOfSamplingWithFrameTrackReportConfig(std::move(tids), start_ns, duration_ns,
+                                                 frame_track_scope_id) {}
 };
 
 struct InclusiveAndExclusive {
@@ -79,6 +89,8 @@ class SamplingCounts {
 struct SamplingWithFrameTrackComparisonReport {
   SamplingCounts baseline_sampling_counts;
   SamplingCounts comparison_sampling_counts;
+  orbit_client_data::ScopeStats baseline_frame_track_stats;
+  orbit_client_data::ScopeStats comparison_frame_track_stats;
 };
 
 }  // namespace orbit_mizar_data


### PR DESCRIPTION
The estimate is obtained via counting how many callstack
samples have been obtained during each frame and then multiplying
the counter by the sampling period.

Bug: http://b/235598873
Tests: Unit, Manual