### PR TITLE
Shorten process names in --target_process

### DIFF
--- a/src/SessionSetup/SessionSetupUtils.cpp
+++ b/src/SessionSetup/SessionSetupUtils.cpp
@@ -32,12 +32,14 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port) {
 std::unique_ptr<orbit_client_data::ProcessData> TryToFindProcessData(
     std::vector<orbit_grpc_protos::ProcessInfo> process_list,
     const std::string& process_name_or_path) {
+  std::string shortened_process_name = process_name_or_path.substr(0, kMaxProcessNameLength);
+
   std::sort(
       process_list.begin(), process_list.end(),
       [](const orbit_grpc_protos::ProcessInfo& lhs,
          const orbit_grpc_protos::ProcessInfo& rhs) -> bool { return lhs.pid() > rhs.pid(); });
   for (auto& process : process_list) {
-    if (process.full_path() == process_name_or_path || process.name() == process_name_or_path) {
+    if (process.full_path() == process_name_or_path || process.name() == shortened_process_name) {
       return std::make_unique<orbit_client_data::ProcessData>(process);
     }
   }

--- a/src/SessionSetup/SessionSetupUtilsTest.cpp
+++ b/src/SessionSetup/SessionSetupUtilsTest.cpp
@@ -32,26 +32,31 @@ TEST(SessionSetupUtils, CredentialsFromSshInfoWorksCorrectly) {
   EXPECT_EQ(info.user.toStdString(), credentials.user);
 }
 
+// Tests below need to be adjusted if the name changes, they are conveniently set up
+// for process names that are exactly at the length limit
+static_assert(kMaxProcessNameLength == 15);
+
 const uint32_t kPid = 100;
-const char* kProcessName = "process_name";
-const char* kProcessPath = "/path/to/process_name";
+const char* kFullProcessName = "ok_process_name_long";
+const char* kShortProcessName = "ok_process_name";
+const char* kProcessPath = "/path/to/ok_process_name_long";
 
 std::vector<orbit_grpc_protos::ProcessInfo> SetupTestProcessList() {
   using orbit_grpc_protos::ProcessInfo;
 
   ProcessInfo expected_target_process;
   expected_target_process.set_pid(kPid);
-  expected_target_process.set_name(kProcessName);
+  expected_target_process.set_name(kShortProcessName);
   expected_target_process.set_full_path(kProcessPath);
 
   ProcessInfo lower_pid_process1;
   lower_pid_process1.set_pid(kPid - 1);
-  lower_pid_process1.set_name(kProcessName);
+  lower_pid_process1.set_name(kShortProcessName);
   lower_pid_process1.set_full_path(kProcessPath);
 
   ProcessInfo lower_pid_process2;
   lower_pid_process2.set_pid(kPid - 2);
-  lower_pid_process2.set_name(kProcessName);
+  lower_pid_process2.set_name(kShortProcessName);
   lower_pid_process2.set_full_path(kProcessPath);
 
   ProcessInfo different_process1;
@@ -70,10 +75,16 @@ std::vector<orbit_grpc_protos::ProcessInfo> SetupTestProcessList() {
           lower_pid_process2};
 }
 
-TEST(SessionSetupUtils, TryToFindProcessDataFindsProcessByName) {
+TEST(SessionSetupUtils, TryToFindProcessDataFindsProcessByShortName) {
   std::vector<orbit_grpc_protos::ProcessInfo> processes = SetupTestProcessList();
 
-  EXPECT_EQ(kPid, TryToFindProcessData(processes, kProcessName)->pid());
+  EXPECT_EQ(kPid, TryToFindProcessData(processes, kShortProcessName)->pid());
+}
+
+TEST(SessionSetupUtils, TryToFindProcessDataFindsProcessByLongName) {
+  std::vector<orbit_grpc_protos::ProcessInfo> processes = SetupTestProcessList();
+
+  EXPECT_EQ(kPid, TryToFindProcessData(processes, kFullProcessName)->pid());
 }
 
 TEST(SessionSetupUtils, TryToFindProcessDataFindsProcessByPath) {

--- a/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
@@ -17,6 +17,7 @@
 
 namespace orbit_session_setup {
 
+const int kMaxProcessNameLength = 15;
 [[nodiscard]] orbit_ssh::Credentials CredentialsFromSshInfo(const orbit_ggp::SshInfo& ssh_info);
 [[nodiscard]] std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port);
 [[nodiscard]] std::unique_ptr<orbit_client_data::ProcessData> TryToFindProcessData(


### PR DESCRIPTION
Process names longer than 15 characters are shortened automatically
when searching for a process by name, so users no longer need to
remember this when using the --target_process parameter.

Bug: b/226538685
Test: Unit tests