### PR TITLE
Rename RetrieveModulesAndLoadSymbols

### DIFF
--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -199,7 +199,7 @@ void DataView::OnLoadSymbolsRequested(const std::vector<int>& selection) {
   }
   metrics_uploader_->SendLogEvent(
       orbit_metrics_uploader::OrbitLogEvent::ORBIT_LOAD_SYMBOLS_CLICKED);
-  app_->RetrieveModulesAndLoadSymbols(modules_to_load);
+  app_->LoadSymbolsManually(modules_to_load);
 }
 
 void DataView::OnStopDownloadRequested(const std::vector<int>& selection) {

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -78,7 +78,7 @@ class MockAppInterface : public AppInterface {
               (const std::string&, const std::string&), (const, override));
   MOCK_METHOD(orbit_client_data::ModuleData*, GetMutableModuleByPathAndBuildId,
               (const std::string&, const std::string&), (override));
-  MOCK_METHOD(orbit_base::Future<void>, RetrieveModulesAndLoadSymbols,
+  MOCK_METHOD(orbit_base::Future<void>, LoadSymbolsManually,
               (absl::Span<const orbit_client_data::ModuleData* const>), (override));
 
   MOCK_METHOD(void, SelectFunction, (const orbit_client_data::FunctionInfo&), (override));

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -213,7 +213,7 @@ void ModulesDataView::OnDoubleClicked(int index) {
   ModuleData* module_data = GetModuleDataFromRow(index);
   if (!module_data->is_loaded()) {
     std::vector<ModuleData*> modules_to_load = {module_data};
-    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
+    app_->LoadSymbolsManually(modules_to_load);
   }
 }
 

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -155,7 +155,7 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
     const int load_symbols_index = GetActionIndexOnMenu(context_menu, kMenuActionLoadSymbols);
     EXPECT_TRUE(load_symbols_index != kInvalidActionIndex);
 
-    EXPECT_CALL(app_, RetrieveModulesAndLoadSymbols)
+    EXPECT_CALL(app_, LoadSymbolsManually)
         .Times(1)
         .WillOnce(testing::Return(orbit_base::Future<void>{}));
     view_.OnContextMenu(std::string{kMenuActionLoadSymbols}, load_symbols_index, {0});
@@ -189,7 +189,7 @@ TEST_F(ModulesDataViewTest, ContextMenuActionsAreInvoked) {
 }
 
 TEST_F(ModulesDataViewTest, LoadModuleOnDoubleClick) {
-  EXPECT_CALL(app_, RetrieveModulesAndLoadSymbols)
+  EXPECT_CALL(app_, LoadSymbolsManually)
       .Times(1)
       .WillOnce(testing::Return(orbit_base::Future<void>{}));
 

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -708,7 +708,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuActionsAreInvoked) {
           EXPECT_EQ(build_id, kModuleBuildIds[2]);
           return module_manager_.GetMutableModuleByPathAndBuildId(module_path, build_id);
         });
-    EXPECT_CALL(app_, RetrieveModulesAndLoadSymbols)
+    EXPECT_CALL(app_, LoadSymbolsManually)
         .Times(1)
         .WillOnce(testing::Return(orbit_base::Future<void>{}));
     view_.OnContextMenu(std::string{kMenuActionLoadSymbols}, load_symbols_index, {0});

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -94,7 +94,7 @@ class AppInterface : public orbit_client_data::CaptureDataHolder {
       const std::string& path, const std::string& build_id) const = 0;
   [[nodiscard]] virtual orbit_client_data::ModuleData* GetMutableModuleByPathAndBuildId(
       const std::string& path, const std::string& build_id) = 0;
-  virtual orbit_base::Future<void> RetrieveModulesAndLoadSymbols(
+  virtual orbit_base::Future<void> LoadSymbolsManually(
       absl::Span<const orbit_client_data::ModuleData* const> modules) = 0;
 
   virtual void SelectFunction(const orbit_client_data::FunctionInfo& func) = 0;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1736,7 +1736,7 @@ OrbitApp::RetrieveModuleFromRemote(const std::string& module_file_path) {
   return chained_result_future;
 }
 
-orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
+orbit_base::Future<void> OrbitApp::LoadSymbolsManually(
     absl::Span<const ModuleData* const> modules) {
   // Use a set, to filter out duplicates
   absl::flat_hash_set<const ModuleData*> modules_set(modules.begin(), modules.end());

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -328,7 +328,7 @@ class OrbitApp final : public DataViewFactory,
   // local cache). Only modules with a .symtab section will be considered.
   orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>> RetrieveModule(
       const std::string& module_path, const std::string& build_id);
-  orbit_base::Future<void> RetrieveModulesAndLoadSymbols(
+  orbit_base::Future<void> LoadSymbolsManually(
       absl::Span<const orbit_client_data::ModuleData* const> modules) override;
 
   enum class SymbolLoadingAndErrorHandlingResult {

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -646,7 +646,7 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
   } else if (action->text() == kActionCollapseAll) {
     ui_->callTreeTreeView->collapseAll();
   } else if (action->text() == kActionLoadSymbols) {
-    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
+    app_->LoadSymbolsManually(modules_to_load);
   } else if (action->text() == kActionSelect) {
     for (const FunctionInfo* function : functions) {
       app_->SelectFunction(*function);


### PR DESCRIPTION
This renames the method RetrieveModulesAndLoadSymbols to
LoadSymbolsManually. This is done to avoid confusion with the similarly
named method RetrieveModuleAndLoadSymbols and to indicate that this
method is used to start symbol loading from user action.

Test: Still compiles
Bug: part of http://b/202140068