### PR TITLE
Use stop dialog

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -3172,6 +3172,13 @@ void OrbitApp::RequestSymbolDownloadStop(absl::Span<const ModuleData* const> mod
       // Download already ended
       continue;
     }
+    CanceledOr<void> canceled_or = main_window_->DisplayStopDownloadDialog(module);
+    if (orbit_base::IsCanceled(canceled_or)) continue;
+
+    if (!symbol_files_currently_downloading_.contains(module->file_path())) {
+      // Download already ended (while user was looking at the dialog)
+      continue;
+    }
     symbol_files_currently_downloading_.at(module->file_path()).stop_source.RequestStop();
   }
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -663,6 +663,10 @@ class OrbitApp final : public DataViewFactory,
   // TODO(b/234586730) Replace pair with struct
   absl::flat_hash_set<std::pair<std::string, std::string>> modules_with_symbol_loading_error_;
 
+  // Set of modules for which the download is disabled.
+  // ONLY access this from the main thread.
+  absl::flat_hash_set<std::string> download_disabled_modules_;
+
   orbit_string_manager::StringManager string_manager_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
 

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -59,6 +59,10 @@ class MainWindowInterface {
       std::filesystem::path path_on_instance, std::filesystem::path local_path,
       orbit_base::StopToken stop_token) = 0;
 
+  // Returns orbit_base::Canceled if the user chooses cancel in the dialog, void otherwise
+  virtual orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
+      const orbit_client_data::ModuleData* module) = 0;
+
   virtual ~MainWindowInterface() = default;
 };
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -127,6 +127,9 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
       std::filesystem::path path_on_instance, std::filesystem::path local_path,
       orbit_base::StopToken stop_token) override;
 
+  orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
+      const orbit_client_data::ModuleData* module) override;
+
  protected:
   void closeEvent(QCloseEvent* event) override;
   void resizeEvent(QResizeEvent* event) override;


### PR DESCRIPTION
From the commit messages:

    Add download_disabled_modules_ list
    
    This adds download_disabled_modules_ to OrbitApp and uses it. The list
    contains the modules for which the user checked "Never download symbols
    for this module" before. Making this list persistent is done via
    QSettingsStorageManager. A entry is removed from the list when the user
    manually clicks "Load Symbols" on this module (LoadSymbolsManually).

    Use StopSymbolDownloadDialog
    
    This commit adds the usage of StopSymbolDownloadDialog to Orbit via the
    method MainWindowInterface::DisplayStopDownloadDialog. When a user
    clicks "Stop Download" in the module list context menu, the dialog is
    shown.
    
    Test: Manual, start with devmode, click Stop Download
    Bug: http://b/231579238