### PR TITLE
Add ObjectFile::GetImageSize

### DIFF
--- a/src/CodeReport/SourceCodeReportTest.cpp
+++ b/src/CodeReport/SourceCodeReportTest.cpp
@@ -19,6 +19,7 @@ class MockElfFile : public orbit_object_utils::ElfFile {
   MOCK_METHOD(uint64_t, GetLoadBias, (), (const, override));
   MOCK_METHOD(uint64_t, GetExecutableSegmentOffset, (), (const, override));
   MOCK_METHOD(uint64_t, GetExecutableSegmentSize, (), (const, override));
+  MOCK_METHOD(uint64_t, GetImageSize, (), (const, override));
 
   MOCK_METHOD(bool, HasDynsym, (), (const, override));
   MOCK_METHOD(bool, HasDebugInfo, (), (const, override));

--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -43,6 +43,7 @@ class CoffFileImpl : public CoffFile {
   [[nodiscard]] std::string GetBuildId() const override;
   [[nodiscard]] uint64_t GetExecutableSegmentOffset() const override;
   [[nodiscard]] uint64_t GetExecutableSegmentSize() const override;
+  [[nodiscard]] uint64_t GetImageSize() const override;
   [[nodiscard]] bool IsElf() const override;
   [[nodiscard]] bool IsCoff() const override;
   [[nodiscard]] ErrorMessageOr<PdbDebugInfo> GetDebugPdbInfo() const override;
@@ -334,6 +335,10 @@ uint64_t CoffFileImpl::GetExecutableSegmentOffset() const {
 }
 
 uint64_t CoffFileImpl::GetExecutableSegmentSize() const { return text_section_virtual_size_; }
+
+uint64_t CoffFileImpl::GetImageSize() const {
+  return object_file_->getPE32PlusHeader()->SizeOfImage;
+}
 
 bool CoffFileImpl::IsElf() const { return false; }
 bool CoffFileImpl::IsCoff() const { return true; }

--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -136,21 +136,25 @@ TEST(CoffFile, GetsEmptyBuildIdIfPdbInfoIsNotPresent) {
   EXPECT_EQ("", coff_file_or_error.value()->GetBuildId());
 }
 
-TEST(CoffFile, GetExecutableSegmentOffsetAndSize) {
+TEST(CoffFile, GetLoadBiasAndExecutableSegmentOffsetAndSizeAndImageSize) {
   {
     std::filesystem::path file_path = orbit_test::GetTestdataDir() / "dllmain.dll";
     auto coff_file_or_error = CreateCoffFile(file_path);
     ASSERT_THAT(coff_file_or_error, HasNoError());
     const CoffFile& coff_file = *coff_file_or_error.value();
+    EXPECT_EQ(coff_file.GetLoadBias(), 0x180000000);
     EXPECT_EQ(coff_file.GetExecutableSegmentOffset(), 0x1000);
     EXPECT_EQ(coff_file.GetExecutableSegmentSize(), 0xce9e4);
+    EXPECT_EQ(coff_file.GetImageSize(), 0x10d000);
   }
   {
     std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libtest.dll";
     auto coff_file_or_error = CreateCoffFile(file_path);
     ASSERT_THAT(coff_file_or_error, HasNoError());
     const CoffFile& coff_file = *coff_file_or_error.value();
+    EXPECT_EQ(coff_file.GetLoadBias(), 0x62640000);
     EXPECT_EQ(coff_file.GetExecutableSegmentOffset(), 0x1000);
     EXPECT_EQ(coff_file.GetExecutableSegmentSize(), 0x1338);
+    EXPECT_EQ(coff_file.GetImageSize(), 0x20000);
   }
 }

--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -93,7 +93,7 @@ TEST(ElfFile, LoadSymbolsFromDynsym) {
   EXPECT_EQ(symbol_info.size(), 591);
 }
 
-TEST(ElfFile, LoadBiasAndExecutableSegmentOffsetAndSize) {
+TEST(ElfFile, LoadBiasAndExecutableSegmentOffsetAndSizeAndImageSize) {
   {
     const std::filesystem::path test_elf_file_dynamic =
         orbit_test::GetTestdataDir() / "hello_world_elf";
@@ -102,6 +102,7 @@ TEST(ElfFile, LoadBiasAndExecutableSegmentOffsetAndSize) {
     EXPECT_EQ(elf_file_dynamic.value()->GetLoadBias(), 0x0);
     EXPECT_EQ(elf_file_dynamic.value()->GetExecutableSegmentOffset(), 0x1000);
     EXPECT_EQ(elf_file_dynamic.value()->GetExecutableSegmentSize(), 0x1cd);
+    EXPECT_EQ(elf_file_dynamic.value()->GetImageSize(), 0x4038);
   }
 
   {
@@ -112,6 +113,7 @@ TEST(ElfFile, LoadBiasAndExecutableSegmentOffsetAndSize) {
     EXPECT_EQ(elf_file_static.value()->GetLoadBias(), 0x400000);
     EXPECT_EQ(elf_file_static.value()->GetExecutableSegmentOffset(), 0x1000);
     EXPECT_EQ(elf_file_static.value()->GetExecutableSegmentSize(), 0x7b4e1);
+    EXPECT_EQ(elf_file_static.value()->GetImageSize(), 0xaaaa0);
   }
 }
 

--- a/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
@@ -53,6 +53,9 @@ class ObjectFile : public SymbolsFile {
   // This is the size of the text segment *when loaded into memory*.
   [[nodiscard]] virtual uint64_t GetExecutableSegmentSize() const = 0;
 
+  // Size of the object when loaded into memory.
+  [[nodiscard]] virtual uint64_t GetImageSize() const = 0;
+
   [[nodiscard]] virtual bool IsElf() const = 0;
   [[nodiscard]] virtual bool IsCoff() const = 0;
 };


### PR DESCRIPTION
This represents the size of the object file when loaded into memory.
It will be used in particular for PEs, for which `SizeOfImage` is returned.

Bug: http://b/235481314
Bug: http://b/235480245

Test: Add unit tests.