### PR TITLE
ParseMaps handles multiple executable sections and/or maps

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -487,6 +487,8 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp, const MmapPerfEven
     return;
   }
 
+  // TODO(b/235481314,b/235480245): Handle binaries with multiple executable mappings and PEs with
+  //  multiple executable sections.
   std::string module_path;
   if (!event_data.filename.empty() && event_data.filename[0] != '[') {
     // This is a file mapping.

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -75,11 +75,10 @@ ErrorMessageOr<ModuleInfo> CreateModule(const std::filesystem::path& module_path
     module_info.set_soname(elf_file->GetSoname());
     module_info.set_object_file_type(ModuleInfo::kElfFile);
   } else if (object_file_or_error.value()->IsCoff()) {
+    // Apart from this, all fields we need to set for COFF files are already set.
     module_info.set_object_file_type(ModuleInfo::kCoffFile);
   }
 
-  // All fields we need to set for COFF files are already set, no need to handle COFF
-  // specifically here.
   return module_info;
 }
 
@@ -91,62 +90,102 @@ ErrorMessageOr<std::vector<ModuleInfo>> ReadModules(int32_t pid) {
 
 namespace {
 
-// Loadable sections of an ELF file, including the .text section, are always aligned in the file
-// such that the loader can create a file mapping for them. We can therefore simply detect modules
-// loaded by a process from the executable file mappings.
+// We observed that in some cases, in particular for binaries running under Wine, a single loadable
+// executable segment of an ELF file or a single executable section of a PE can be loaded into
+// memory with multiple adjacent file mappings. In addition, some PEs can have multiple executable
+// sections. Therefore, simply detecting modules loaded by a process from individual executable file
+// mappings won't work.
 //
-// But in the case of Portable Executables, the .text section (and other sections) can have an
-// offset in the file (PointerToRawData, multiple of FileAlignment) that is not congruent to the
-// offset of that section when loaded into memory (VirtualAddress, multiple of SectionAlignment)
-// modulo the page size. This doesn't fulfill the requirements on the arguments of mmap, so in these
-// cases Wine cannot create a file-backed mapping for the .text section, and resorts to creating an
-// anonymous mapping and copying the .text section into it. This means that, for PE binaries with
-// this property, we cannot simply associate an executable mapping to the corresponding file using
-// the path in the mapping.
+// Instead, while scanning the /proc/[pid]/maps file, we can keep track of the module whose mappings
+// we are currently processing. We consider all executable mappings that belong to this module. In
+// the end, we build a ModuleInfo that spans the memory region from the start of the first
+// executable mapping to the end of the last executable mapping for this module.
+//
+// Such ModuleInfo will carry executable_segment_offset with the assumption that the value of
+// ObjectFile::GetExecutableSegmentOffset correspond to the *first* executable mapping. In the
+// normal case of a single executable section and a single executable mapping, ModuleInfo will
+// simply carry the address range of that one mapping.
+//
+// Note that, in the case of multiple executable sections, these are not necessarily adjacent, while
+// ModuleInfo as constructed will represent a single contiguous address range. We believe this is
+// fine, as the address range should still completely belong to the module, even if it can now
+// include non-executable parts, and as the additional complexity of keeping track of multiple
+// executable sections for a single module is not justified.
+//
+// In addition: All loadable sections of an ELF file, including the .text section, are always
+// aligned in the file such that the loader can create a file mapping for them. But in the case of
+// Portable Executables, the executable sections (and all the other sections) can have an offset in
+// the file (PointerToRawData, multiple of FileAlignment) that is not congruent to the offset of
+// that section when loaded into memory (VirtualAddress, multiple of SectionAlignment) modulo the
+// page size. This doesn't fulfill the requirements on the arguments of mmap, so in these cases Wine
+// cannot create a file-backed mapping for a section, and resorts to creating an anonymous mapping
+// and copying the section into it. This means that, for PE binaries with this property, we cannot
+// simply associate an executable mapping to the corresponding file using the path in the mapping.
 //
 // However, we can make an educated guess. The path of the PE will at least appear in the read-only
 // mapping that corresponds to the beginning of the file, which contains the headers (because the
 // offset in the file is zero and the address chosen for this mapping should always be a multiple of
-// the page size). If the executable file mapping for the .text section is not present, we consider
-// the anonymous executable mappings after the first file mapping for this PE: if the offset and
-// size of such a mapping are compatible with the address range where the .text section would be
-// loaded based on the header for the section (in particular, VirtualAddress and VirtualSize), we
-// can be quite sure that this is the mapping we are looking for.
-// Note that we assume that a PE (or an ELF file) only has one .text section and one executable
-// mapping: this is what we observed and is what we support.
+// the page size). We consider the anonymous executable mappings after the first file mapping for
+// this PE: if the address range of such a mapping is fully contained in the address range that we
+// expect contains the PE (based on the start address of the file mapping that contains the headers
+// and based on the PE's SizeOfImage), we can be confident that this mapping also belongs to the PE.
 //
-// This class contains logic to help ParseMaps with the detection mechanism. The intended usage is
+// This class contains logic to help ParseMaps with keeping track of the executable maps of a
+// module, and with detecting anonymous executable maps that belong to a PE. The intended usage is
 // as follows:
 // - Create a new instance of this class when a new file is encountered while parsing
 //   `/proc/[pid]/maps`;
-// - Call `MarkExecutableMapEncountered` when encountering an executable file mapping for the file
-//   this instance was created for.
-// - Use `TryIfAnonExecMapIsCoffTextSection` to query if an anonymous executable mapping is actually
-//   the PE .text section of the file this instance was created for. This will only return true once
-//   for each instance of this class, as it calls `MarkExecutableMapEncountered` on success.
+// - Call `AddExecFileMap` when encountering an executable file mapping for the file this instance
+//   was created for.
+// - Call `AddAnonExecMapIfCoffTextSection` when encountering an anonymous executable mapping.
+//   Internally, this will decide whether it's likely that this map belong to the file this instance
+//   was created for.
+// - Finally, call `MaybeCreateModule` when encountering a file mapping for a file different than
+//   the file this instance was created for, or when reaching the end of `/proc/[pid]/maps`. This
+//   will create the `ModuleInfo` if the file this instance was created for is an object file.
 class FileMappedIntoMemory {
  public:
   FileMappedIntoMemory(std::string file_path, uint64_t first_map_start, uint64_t first_map_offset)
-      : file_path_{std::move(file_path)}, base_address_{first_map_start - first_map_offset} {
-    if (first_map_start < first_map_offset) {
-      // In this case, base_address_ is the result of an underflow. This shouldn't normally happen,
-      // so immediately set coff_text_section_map_might_be_encountered_ to false and never use
-      // base_address_.
-      coff_text_section_map_might_be_encountered_ = false;
+      : file_path_{std::move(file_path)},
+        first_map_start_{first_map_start},
+        first_map_offset_{first_map_offset} {
+    if (absl::StartsWith(file_path_, "/dev/")) {
+      // This is a device file.
+      return;
     }
+
+    ErrorMessageOr<std::unique_ptr<ObjectFile>> object_file_or_error = CreateObjectFile(file_path_);
+    if (object_file_or_error.has_error()) {
+      return;
+    }
+
+    object_file_ = std::move(object_file_or_error.value());
   }
 
   [[nodiscard]] const std::string& GetFilePath() const { return file_path_; }
 
-  void MarkExecutableMapEncountered() {
-    coff_text_section_map_might_be_encountered_ = false;
-    cached_coff_file_ = nullptr;
+  void AddExecFileMap(uint64_t map_start, uint64_t map_end) {
+    if (object_file_ == nullptr) {
+      return;
+    }
+
+    if (HasAtLeastOneExecutableMap()) {
+      // Note that for ELF files we always assume a single executable segment. We never observed
+      // otherwise, and we wouldn't be able to handle more because the load bias can be different
+      // for each segment. Hence, if there are multiple executable maps for an ELF file, we will
+      // simply assume that they belong to the same executable segment (or at least that they belong
+      // to executable segments with the same load bias).
+      ORBIT_LOG("Adding another executable map at %#x-%#x for \"%s\"", map_start, map_end,
+                file_path_);
+    }
+
+    min_exec_map_start = std::min(min_exec_map_start, map_start);
+    max_exec_map_end = std::max(max_exec_map_end, map_end);
   }
 
-  [[nodiscard]] bool TryIfAnonExecMapIsCoffTextSection(uint64_t map_start, uint64_t map_end) {
-    if (!coff_text_section_map_might_be_encountered_) {
-      ORBIT_CHECK(cached_coff_file_ == nullptr);
-      return false;
+  void AddAnonExecMapIfCoffTextSection(uint64_t map_start, uint64_t map_end) {
+    if (object_file_ == nullptr) {
+      return;
     }
 
     ORBIT_LOG("Trying if anonymous executable map at %#x-%#x belongs to \"%s\"", map_start, map_end,
@@ -155,74 +194,67 @@ class FileMappedIntoMemory {
         absl::StrFormat("No, anonymous executable map at %#x-%#x does NOT belong to \"%s\"",
                         map_start, map_end, file_path_);
 
-    if (cached_coff_file_ == nullptr) {
-      // Don't even try to create an ObjectFile from character or block devices.
-      if (absl::StartsWith(file_path_, "/dev/")) {
-        ORBIT_LOG("%s: this is a device file", error_message);
-        coff_text_section_map_might_be_encountered_ = false;
-        return false;
-      }
-
-      auto object_file_or_error = CreateObjectFile(file_path_);
-      if (object_file_or_error.has_error()) {
-        ORBIT_LOG("%s: %s", error_message, object_file_or_error.error().message());
-        coff_text_section_map_might_be_encountered_ = false;
-        return false;
-      }
-
-      // Remember: we are only detecting anonymous maps that correspond to .text sections of PEs,
-      // because loadable sections of ELF files can always be file-mapped.
-      if (!object_file_or_error.value()->IsCoff()) {
-        ORBIT_LOG("%s: object file is not a PE", error_message);
-        coff_text_section_map_might_be_encountered_ = false;
-        return false;
-      }
-
-      cached_coff_file_ = std::move(object_file_or_error.value());
+    // Remember: we are only detecting anonymous maps that correspond to executable sections of PEs,
+    // because loadable segments of ELF files can always be file-mapped.
+    if (!object_file_->IsCoff()) {
+      ORBIT_LOG("%s: object file is not a PE", error_message);
+      return;
     }
 
-    ORBIT_CHECK(cached_coff_file_ != nullptr);
-
-    // The address range at which the text section of the PE is supposed to be mapped.
-    const uint64_t expected_text_start =
-        base_address_ + cached_coff_file_->GetExecutableSegmentOffset();
-    const uint64_t expected_text_end =
-        expected_text_start + cached_coff_file_->GetExecutableSegmentSize();
-
-    if (map_end <= expected_text_start) {
-      ORBIT_LOG("%s: map is before the expected address range of the .text section (%#x-%#x)",
-                error_message, expected_text_start, expected_text_end);
-      // Don't set coff_text_section_map_might_be_encountered_ to false in this case, the entry we
-      // are looking for could come later.
-      return false;
+    if (first_map_offset_ != 0) {
+      // We expect the first mapping for this PE to have offset zero, as the headers are also mapped
+      // into memory, and they are at the beginning of the file.
+      ORBIT_ERROR("%s: a map with offset 0 where the headers would be mapped is not present",
+                  error_message);
+      return;
     }
 
-    // We validate that the executable map fully contains the address range at which the .text
-    // section of the PE is supposed to be mapped. We consider the address at which the first byte
-    // of this file is mapped (base_address_), and the address range of the .text section relative
-    // to the image base when loaded into memory (determined by VirtualAddress and VirtualSize).
-    if (map_start <= expected_text_start && map_end >= expected_text_end) {
-      ORBIT_LOG("Guessing that anonymous executable map at %#x-%#x belongs to \"%s\"", map_start,
-                map_end, file_path_);
-      MarkExecutableMapEncountered();
-      return true;
+    // The start address of the map in which the first byte of the PE is mapped.
+    // It is page-aligned because it is the start address of a map.
+    const uint64_t base_address = first_map_start_;
+    constexpr uint64_t kPageSize = 0x1000;
+    // The end address of the map in which the last byte of the PE is mapped.
+    const uint64_t end_address =
+        base_address + orbit_base::AlignUp<kPageSize>(object_file_->GetImageSize());
+    // We validate that the executable map is fully contained in the address range at which the PE
+    // is supposed to be mapped.
+    if (map_end > end_address) {
+      ORBIT_LOG("%s: map is not contained in the absolute address range %#x-%#x of the PE",
+                error_message, base_address, end_address);
+      return;
     }
 
-    ORBIT_LOG("%s: map does not contain the expected address range of the .text section (%#x-%#x)",
-              error_message, expected_text_start, expected_text_end);
-    coff_text_section_map_might_be_encountered_ = false;
-    cached_coff_file_ = nullptr;
-    return false;
+    ORBIT_LOG("Guessing that anonymous executable map at %#x-%#x belongs to \"%s\"", map_start,
+              map_end, file_path_);
+    min_exec_map_start = std::min(min_exec_map_start, map_start);
+    max_exec_map_end = std::max(max_exec_map_end, map_end);
+  }
+
+  [[nodiscard]] std::optional<ModuleInfo> MaybeCreateModule() {
+    if (!HasAtLeastOneExecutableMap()) {
+      return std::nullopt;
+    }
+
+    ErrorMessageOr<ModuleInfo> module_info_or_error =
+        CreateModule(file_path_, min_exec_map_start, max_exec_map_end);
+    if (module_info_or_error.has_error()) {
+      ORBIT_ERROR("Unable to create module: %s", module_info_or_error.error().message());
+      return std::nullopt;
+    }
+    return std::move(module_info_or_error.value());
   }
 
  private:
   std::string file_path_;
-  // The address at which the first byte of the file is (or would be) mapped.
-  uint64_t base_address_;
-  // False if not a PE, if the .text segment has already been found, or if we are already past the
-  // address at which we could find the .text segment.
-  bool coff_text_section_map_might_be_encountered_ = true;
-  std::unique_ptr<ObjectFile> cached_coff_file_;
+  uint64_t first_map_start_;
+  uint64_t first_map_offset_;
+  std::unique_ptr<ObjectFile> object_file_;
+
+  uint64_t min_exec_map_start = std::numeric_limits<uint64_t>::max();
+  uint64_t max_exec_map_end = 0;
+  [[nodiscard]] bool HasAtLeastOneExecutableMap() const {
+    return min_exec_map_start < max_exec_map_end;
+  }
 };
 }  // namespace
 
@@ -231,8 +263,6 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
 
   std::vector<ModuleInfo> result;
 
-  // This is used to detect mappings that correspond to the .text section of a PE but that are not
-  // file-backed because the file alignment doesn't satisfy the requirements of mmap.
   std::optional<FileMappedIntoMemory> last_file_mapped_into_memory;
 
   for (const std::string& line : proc_maps) {
@@ -261,19 +291,24 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
     const uint64_t offset = std::stoull(tokens[2], nullptr, 16);
 
     std::string module_path;
-    if (inode != "0") {  // The mapping is file-backed.
-      if (tokens.size() == 6) {
-        module_path = tokens[5];
-        // Keep track of the last file we encountered. Only create a new FileMappedIntoMemory if
-        // this file mapping is backed by a different file than the previous file mapping.
-        if (!last_file_mapped_into_memory.has_value() ||
-            module_path != last_file_mapped_into_memory->GetFilePath()) {
-          last_file_mapped_into_memory.emplace(module_path, start, offset);
-        }
-      } else {  // Unexpected: the mapping is file-backed but no path is present.
+    if (inode != "0") {          // The mapping is file-backed.
+      if (tokens.size() != 6) {  // Unexpected: the mapping is file-backed but no path is present.
         ORBIT_ERROR("Map at %#x-%#x has inode %s (not 0) but no path", start, end, inode);
         last_file_mapped_into_memory.reset();
         continue;
+      }
+
+      module_path = tokens[5];
+      // Keep track of the last file we encountered. Only create a new FileMappedIntoMemory if this
+      // file mapping is backed by a different file than the previous file mapping.
+      if (!last_file_mapped_into_memory.has_value()) {
+        last_file_mapped_into_memory.emplace(module_path, start, offset);
+      } else if (module_path != last_file_mapped_into_memory->GetFilePath()) {
+        std::optional<ModuleInfo> module_info = last_file_mapped_into_memory->MaybeCreateModule();
+        if (module_info.has_value()) {
+          result.emplace_back(std::move(module_info.value()));
+        }
+        last_file_mapped_into_memory.emplace(module_path, start, offset);
       }
     }
 
@@ -283,22 +318,17 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
 
     if (!module_path.empty()) {
       ORBIT_CHECK(last_file_mapped_into_memory.has_value());
-      last_file_mapped_into_memory->MarkExecutableMapEncountered();
-    } else if (last_file_mapped_into_memory.has_value() &&
-               last_file_mapped_into_memory->TryIfAnonExecMapIsCoffTextSection(start, end)) {
-      module_path = last_file_mapped_into_memory->GetFilePath();
-    } else {
-      continue;
+      last_file_mapped_into_memory->AddExecFileMap(start, end);
+    } else if (last_file_mapped_into_memory.has_value()) {
+      last_file_mapped_into_memory->AddAnonExecMapIfCoffTextSection(start, end);
     }
+  }
 
-    ErrorMessageOr<ModuleInfo> module_info_or_error = CreateModule(module_path, start, end);
-
-    if (module_info_or_error.has_error()) {
-      ORBIT_ERROR("Unable to create module: %s", module_info_or_error.error().message());
-      continue;
+  if (last_file_mapped_into_memory.has_value()) {
+    std::optional<ModuleInfo> module_info = last_file_mapped_into_memory->MaybeCreateModule();
+    if (module_info.has_value()) {
+      result.emplace_back(std::move(module_info.value()));
     }
-
-    result.emplace_back(std::move(module_info_or_error.value()));
   }
 
   return result;

--- a/src/ObjectUtils/LinuxMapTest.cpp
+++ b/src/ObjectUtils/LinuxMapTest.cpp
@@ -28,7 +28,13 @@ using orbit_test_utils::HasNoError;
 
 namespace orbit_object_utils {
 
-TEST(LinuxMap, CreateModuleHelloWorld) {
+constexpr uint64_t kHelloWorldElfFileSize = 16616;
+constexpr const char* kHelloWorldElfBuildId = "d12d54bc5b72ccce54a408bdeda65e2530740ac8";
+
+constexpr uint64_t kLibTestDllImageBase = 0x62640000;
+constexpr uint64_t kLibTestDllFileSize = 96441;
+
+TEST(LinuxMap, CreateModuleElf) {
   const std::filesystem::path hello_world_path = orbit_test::GetTestdataDir() / "hello_world_elf";
 
   constexpr uint64_t kStartAddress = 23;
@@ -41,12 +47,12 @@ TEST(LinuxMap, CreateModuleHelloWorld) {
   EXPECT_EQ(result.value().file_size(), 16616);
   EXPECT_EQ(result.value().address_start(), kStartAddress);
   EXPECT_EQ(result.value().address_end(), kEndAddress);
-  EXPECT_EQ(result.value().build_id(), "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
+  EXPECT_EQ(result.value().build_id(), kHelloWorldElfBuildId);
   EXPECT_EQ(result.value().load_bias(), 0x0);
   EXPECT_EQ(result.value().object_file_type(), ModuleInfo::kElfFile);
 }
 
-TEST(LinuxMap, CreateModuleOnDev) {
+TEST(LinuxMap, CreateModuleInDev) {
   const std::filesystem::path dev_zero_path = "/dev/zero";
 
   constexpr uint64_t kStartAddress = 23;
@@ -57,7 +63,7 @@ TEST(LinuxMap, CreateModuleOnDev) {
             "The module \"/dev/zero\" is a character or block device (is in /dev/)");
 }
 
-TEST(LinuxMap, CreateCoffModule) {
+TEST(LinuxMap, CreateModuleCoff) {
   const std::filesystem::path dll_path = orbit_test::GetTestdataDir() / "libtest.dll";
 
   constexpr uint64_t kStartAddress = 23;
@@ -68,24 +74,13 @@ TEST(LinuxMap, CreateCoffModule) {
 
   EXPECT_EQ(result.value().name(), "libtest.dll");
   EXPECT_EQ(result.value().file_path(), dll_path);
-  EXPECT_EQ(result.value().file_size(), 96441);
+  EXPECT_EQ(result.value().file_size(), kLibTestDllFileSize);
   EXPECT_EQ(result.value().address_start(), kStartAddress);
   EXPECT_EQ(result.value().address_end(), kEndAddress);
-  EXPECT_EQ(result.value().load_bias(), 0x62640000);
+  EXPECT_EQ(result.value().load_bias(), kLibTestDllImageBase);
   EXPECT_EQ(result.value().executable_segment_offset(), 0x1000);
   EXPECT_EQ(result.value().build_id(), "");
   EXPECT_EQ(result.value().object_file_type(), ModuleInfo::kCoffFile);
-}
-
-TEST(LinuxMap, CreateModuleNotElf) {
-  const std::filesystem::path text_file = orbit_test::GetTestdataDir() / "textfile.txt";
-
-  constexpr uint64_t kStartAddress = 23;
-  constexpr uint64_t kEndAddress = 8004;
-  auto result = CreateModule(text_file, kStartAddress, kEndAddress);
-  ASSERT_TRUE(result.has_error());
-  EXPECT_THAT(result.error().message(),
-              testing::HasSubstr("The file was not recognized as a valid object file"));
 }
 
 TEST(LinuxMap, CreateModuleWithSoname) {
@@ -106,6 +101,17 @@ TEST(LinuxMap, CreateModuleWithSoname) {
   EXPECT_EQ(result.value().object_file_type(), ModuleInfo::kElfFile);
 }
 
+TEST(LinuxMap, CreateModuleNotAnObject) {
+  const std::filesystem::path text_file = orbit_test::GetTestdataDir() / "textfile.txt";
+
+  constexpr uint64_t kStartAddress = 23;
+  constexpr uint64_t kEndAddress = 8004;
+  auto result = CreateModule(text_file, kStartAddress, kEndAddress);
+  ASSERT_TRUE(result.has_error());
+  EXPECT_THAT(result.error().message(),
+              testing::HasSubstr("The file was not recognized as a valid object file"));
+}
+
 TEST(LinuxMap, CreateModuleFileDoesNotExist) {
   const std::filesystem::path file_path = "/not/a/valid/file/path";
 
@@ -121,79 +127,68 @@ TEST(LinuxMap, ReadModules) {
   EXPECT_THAT(result, HasNoError());
 }
 
-TEST(LinuxMap, ParseMaps) {
-  {
-    // Empty data
-    const auto result = ParseMaps(std::string_view{""});
-    ASSERT_THAT(result, HasNoError());
-    EXPECT_TRUE(result.value().empty());
-  }
+TEST(LinuxMap, ParseMapsEmptyData) {
+  const auto result = ParseMaps(std::string_view{""});
+  ASSERT_THAT(result, HasNoError());
+  EXPECT_TRUE(result.value().empty());
+}
 
+TEST(LinuxMap, ParseMaps1) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path hello_world_path = test_path / "hello_world_elf";
   const std::filesystem::path text_file = test_path / "textfile.txt";
 
-  {
-    // Testing correct size of result. The entry with dev/zero is ignored due to the path starting
-    // with /dev/. The last entry has a valid path, but the executable flag is not set.
-    const std::string data{absl::StrFormat(
-        "7f687428f000-7f6874290000 r-xp 00009000 fe:01 661216                     "
-        "/not/a/valid/file/path\n"
-        "7f6874290000-7f6874297000 r-xp 00000000 fe:01 661214                     %s\n"
-        "7f6874290000-7f6874297000 r-xp 00000000 fe:01 661214                     /dev/zero\n"
-        "7f6874290001-7f6874297002 r-dp 00000000 fe:01 661214                     %s\n",
-        hello_world_path, text_file)};
-    const auto result = ParseMaps(data);
-    ASSERT_THAT(result, HasNoError());
-    EXPECT_EQ(result.value().size(), 1);
-  }
+  // Only testing the correct size of the result. The entry with /dev/zero is ignored due to the
+  // path starting with /dev/. The last entry has a valid path, but the executable flag is not set.
+  const std::string data{absl::StrFormat(
+      "7f687428f000-7f6874290000 r-xp 00009000 fe:01 661216                     /path/to/nothing\n"
+      "7f6874290000-7f6874297000 r-xp 00000000 fe:01 661214                     %s\n"
+      "7f6874290000-7f6874297000 r-xp 00000000 fe:01 661214                     /dev/zero\n"
+      "7f6874290001-7f6874297002 r-dp 00000000 fe:01 661214                     %s\n",
+      hello_world_path, text_file)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  EXPECT_EQ(result.value().size(), 1);
+}
 
+TEST(LinuxMap, ParseMaps2) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path hello_world_path = test_path / "hello_world_elf";
   const std::filesystem::path no_symbols_path = test_path / "no_symbols_elf";
-  {
-    // Example data
-    const std::string data{absl::StrFormat(
-        "7f6874285000-7f6874288000 r--p 00000000 fe:01 661216                     %s\n"
-        "7f6874288000-7f687428c000 r-xp 00003000 fe:01 661216                     %s\n"
-        "7f687428c000-7f687428e000 r--p 00007000 fe:01 661216                     %s\n"
-        "7f687428e000-7f687428f000 r--p 00008000 fe:01 661216                     %s\n"
-        "7f687428f000-7f6874290000 rw-p 00009000 fe:01 661216                     %s\n"
-        "0-1000 r-xp 00009000 fe:01 661216                     %s\n",
-        hello_world_path, hello_world_path, hello_world_path, hello_world_path, hello_world_path,
-        no_symbols_path)};
 
-    const auto result = ParseMaps(data);
-    ASSERT_THAT(result, HasNoError());
-    ASSERT_EQ(result.value().size(), 2);
+  const std::string data{absl::StrFormat(
+      "7f6874285000-7f6874288000 r--p 00000000 fe:01 661216                     %1$s\n"
+      "7f6874288000-7f687428c000 r-xp 00003000 fe:01 661216                     %1$s\n"
+      "7f687428c000-7f687428e000 r--p 00007000 fe:01 661216                     %1$s\n"
+      "7f687428e000-7f687428f000 r--p 00008000 fe:01 661216                     %1$s\n"
+      "7f687428f000-7f6874290000 rw-p 00009000 fe:01 661216                     %1$s\n"
+      "800000000000-800000001000 r-xp 00009000 fe:01 661216                     %2$s\n",
+      hello_world_path, no_symbols_path)};
 
-    const ModuleInfo* hello_module_info = nullptr;
-    const ModuleInfo* no_symbols_module_info = nullptr;
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 2);
 
-    if (result.value()[0].name() == "hello_world_elf") {
-      hello_module_info = &result.value()[0];
-      no_symbols_module_info = &result.value()[1];
-    } else {
-      hello_module_info = &result.value()[1];
-      no_symbols_module_info = &result.value()[0];
-    }
+  const ModuleInfo& hello_module_info = result.value()[0];
+  const ModuleInfo& no_symbols_module_info = result.value()[1];
 
-    EXPECT_EQ(hello_module_info->name(), "hello_world_elf");
-    EXPECT_EQ(hello_module_info->file_path(), hello_world_path);
-    EXPECT_EQ(hello_module_info->file_size(), 16616);
-    EXPECT_EQ(hello_module_info->address_start(), 0x7f6874288000);
-    EXPECT_EQ(hello_module_info->address_end(), 0x7f687428c000);
-    EXPECT_EQ(hello_module_info->build_id(), "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
-    EXPECT_EQ(hello_module_info->load_bias(), 0x0);
-    EXPECT_EQ(hello_module_info->object_file_type(), ModuleInfo::kElfFile);
+  EXPECT_EQ(hello_module_info.name(), "hello_world_elf");
+  EXPECT_EQ(hello_module_info.file_path(), hello_world_path);
+  EXPECT_EQ(hello_module_info.file_size(), kHelloWorldElfFileSize);
+  EXPECT_EQ(hello_module_info.address_start(), 0x7f6874288000);
+  EXPECT_EQ(hello_module_info.address_end(), 0x7f687428c000);
+  EXPECT_EQ(hello_module_info.build_id(), kHelloWorldElfBuildId);
+  EXPECT_EQ(hello_module_info.load_bias(), 0x0);
+  EXPECT_EQ(hello_module_info.object_file_type(), ModuleInfo::kElfFile);
 
-    EXPECT_EQ(no_symbols_module_info->name(), "no_symbols_elf");
-    EXPECT_EQ(no_symbols_module_info->file_path(), no_symbols_path);
-    EXPECT_EQ(no_symbols_module_info->file_size(), 18768);
-    EXPECT_EQ(no_symbols_module_info->address_start(), 0x0);
-    EXPECT_EQ(no_symbols_module_info->address_end(), 0x1000);
-    EXPECT_EQ(no_symbols_module_info->build_id(), "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b");
-    EXPECT_EQ(no_symbols_module_info->load_bias(), 0x400000);
-    EXPECT_EQ(no_symbols_module_info->object_file_type(), ModuleInfo::kElfFile);
-  }
+  EXPECT_EQ(no_symbols_module_info.name(), "no_symbols_elf");
+  EXPECT_EQ(no_symbols_module_info.file_path(), no_symbols_path);
+  EXPECT_EQ(no_symbols_module_info.file_size(), 18768);
+  EXPECT_EQ(no_symbols_module_info.address_start(), 0x800000000000);
+  EXPECT_EQ(no_symbols_module_info.address_end(), 0x800000001000);
+  EXPECT_EQ(no_symbols_module_info.build_id(), "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b");
+  EXPECT_EQ(no_symbols_module_info.load_bias(), 0x400000);
+  EXPECT_EQ(no_symbols_module_info.object_file_type(), ModuleInfo::kElfFile);
 }
 
 TEST(LinuxMap, ParseMapsWithSpacesInPath) {
@@ -220,74 +215,43 @@ TEST(LinuxMap, ParseMapsWithSpacesInPath) {
   const ModuleInfo& hello_module_info = result.value()[0];
   EXPECT_EQ(hello_module_info.name(), hello_world_elf_temporary.file_path().filename().string());
   EXPECT_EQ(hello_module_info.file_path(), hello_world_elf_temporary.file_path());
-  EXPECT_EQ(hello_module_info.file_size(), 16616);
+  EXPECT_EQ(hello_module_info.file_size(), kHelloWorldElfFileSize);
   EXPECT_EQ(hello_module_info.address_start(), 0x7f6874290000);
   EXPECT_EQ(hello_module_info.address_end(), 0x7f6874297000);
-  EXPECT_EQ(hello_module_info.build_id(), "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
+  EXPECT_EQ(hello_module_info.build_id(), kHelloWorldElfBuildId);
   EXPECT_EQ(hello_module_info.load_bias(), 0x0);
   EXPECT_EQ(hello_module_info.object_file_type(), ModuleInfo::kElfFile);
 }
 
-TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtExpectedOffset) {
+TEST(LinuxMap, ParseMapsElfWithMultipleExecutableMaps) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
-  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+  const std::filesystem::path hello_world_path = test_path / "hello_world_elf";
 
   const std::string data{
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
-                      "101000-103000 r-xp 00000000 00:00 0 \n",
-                      libtest_path)};
+                      "101000-102000 r-xp 00000000 01:02 42    %1$s\n"
+                      "102000-103000 r--p 00000000 01:02 42    %1$s\n"
+                      "103000-104000 rw-p 00000000 00:00 0 \n"
+                      "104000-105000 r-xp 00000000 01:02 42    %1$s\n",
+                      hello_world_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
   ASSERT_EQ(result.value().size(), 1);
 
-  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
-  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
-  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
-  EXPECT_EQ(libtest_module_info.file_size(), 96441);
-  EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
-  EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
-  EXPECT_EQ(libtest_module_info.build_id(), "");
-  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
-  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
-  EXPECT_EQ(libtest_module_info.soname(), "");
-  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+  const ModuleInfo& hello_module_info = result.value()[0];
+  EXPECT_EQ(hello_module_info.name(), "hello_world_elf");
+  EXPECT_EQ(hello_module_info.file_path(), hello_world_path);
+  EXPECT_EQ(hello_module_info.file_size(), kHelloWorldElfFileSize);
+  EXPECT_EQ(hello_module_info.address_start(), 0x101000);
+  EXPECT_EQ(hello_module_info.address_end(), 0x105000);
+  EXPECT_EQ(hello_module_info.build_id(), kHelloWorldElfBuildId);
+  EXPECT_EQ(hello_module_info.load_bias(), 0x0);
+  EXPECT_EQ(hello_module_info.object_file_type(), ModuleInfo::kElfFile);
 }
 
-TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyInMoreComplexExample) {
+TEST(LinuxMap, ParseMapsPeTextMappedNotAnonymously) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
-  const std::filesystem::path libtest_path = test_path / "libtest.dll";
-
-  // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
-  const std::string data{
-      absl::StrFormat("10000-11000 r--p 00000000 00:00 0    [stack]\n"
-                      "100000-100C00 r--p 00000000 01:02 42    %1$s\n"  // The headers.
-                      "100C00-100D00 rw-p 00000000 00:00 0 \n"
-                      "100D00-100E00 r--p 00000D00 01:02 42    %1$s\n"
-                      "100E00-100F00 rw-p 00000000 00:00 0    [special]\n"
-                      "100F00-101000 r--p 00000F00 01:02 42    %1$s\n"
-                      "101000-103000 r-xp 00000000 00:00 0 \n"  // The .text segment.
-                      "200000-201000 r-xp 00000000 01:02 42    /path/to/nothing\n",
-                      libtest_path)};
-  const auto result = ParseMaps(data);
-  ASSERT_THAT(result, HasNoError());
-  ASSERT_EQ(result.value().size(), 1);
-
-  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
-  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
-  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
-  EXPECT_EQ(libtest_module_info.file_size(), 96441);
-  EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
-  EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
-  EXPECT_EQ(libtest_module_info.build_id(), "");
-  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
-  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
-  EXPECT_EQ(libtest_module_info.soname(), "");
-  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
-}
-
-TEST(LinuxMap, ParseMapsWithPeTextMappedNotAnonymously) {
-  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
-  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";  // SizeOfImage = 0x20000
 
   const std::string data{
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
@@ -300,24 +264,26 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedNotAnonymously) {
   const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
   EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
   EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
-  EXPECT_EQ(libtest_module_info.file_size(), 96441);
+  EXPECT_EQ(libtest_module_info.file_size(), kLibTestDllFileSize);
   EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
   EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
   EXPECT_EQ(libtest_module_info.build_id(), "");
-  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.load_bias(), kLibTestDllImageBase);
   EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
   EXPECT_EQ(libtest_module_info.soname(), "");
   EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
 }
 
-TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtLowerThanExpectedOffset) {
+TEST(LinuxMap, ParseMapsPeTextMappedNotAnonymouslyWithMultipleExecutableMaps) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
-  // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
   const std::string data{
-      absl::StrFormat("100100-101000 r--p 00000100 01:02 42    %s\n"
-                      "100F00-103000 r-xp 00000000 00:00 0 \n",
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
+                      "101000-102000 r-xp 00000000 01:02 42    %1$s\n"
+                      "102000-103000 r--p 00000000 01:02 42    %1$s\n"
+                      "103000-104000 rw-p 00000000 00:00 0 \n"
+                      "104000-105000 r-xp 00000000 01:02 42    %1$s\n",
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());
@@ -326,23 +292,22 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtLowerThanExpectedOffset) {
   const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
   EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
   EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
-  EXPECT_EQ(libtest_module_info.file_size(), 96441);
-  EXPECT_EQ(libtest_module_info.address_start(), 0x100F00);
-  EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
+  EXPECT_EQ(libtest_module_info.file_size(), kLibTestDllFileSize);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x105000);
   EXPECT_EQ(libtest_module_info.build_id(), "");
-  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.load_bias(), kLibTestDllImageBase);
   EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
   EXPECT_EQ(libtest_module_info.soname(), "");
   EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
 }
 
-TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtExpectedOffsetAndFirstMapWithOffset) {
+TEST(LinuxMap, ParseMapsPeTextMappedAnonymously) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
-  // The addresses in these maps are not page-aligned, but it doesn't matter for the test's purpose.
   const std::string data{
-      absl::StrFormat("100100-101000 r--p 00000100 01:02 42    %s\n"
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
                       "101000-103000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
   const auto result = ParseMaps(data);
@@ -352,17 +317,93 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtExpectedOffsetAndFirstMapWi
   const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
   EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
   EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
-  EXPECT_EQ(libtest_module_info.file_size(), 96441);
+  EXPECT_EQ(libtest_module_info.file_size(), kLibTestDllFileSize);
   EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
   EXPECT_EQ(libtest_module_info.address_end(), 0x103000);
   EXPECT_EQ(libtest_module_info.build_id(), "");
-  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
+  EXPECT_EQ(libtest_module_info.load_bias(), kLibTestDllImageBase);
   EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
   EXPECT_EQ(libtest_module_info.soname(), "");
   EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
 }
 
-TEST(LinuxMap, ParseMapsWithPeTextMappedWithWrongName) {
+TEST(LinuxMap, ParseMapsPeTextMappedAnonymouslyWithMultipleExecutableMaps) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
+                      "101000-102000 r-xp 00000000 00:00 0 \n"
+                      "102000-103000 r--p 00000000 00:00 0 \n"
+                      "103000-104000 rw-p 00000000 00:00 0 \n"
+                      "104000-105000 r-xp 00000000 00:00 0 \n"
+                      "105000-121000 r-xp 00000000 00:00 0 \n",  // Beyond SizeOfImage.
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 1);
+
+  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
+  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
+  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
+  EXPECT_EQ(libtest_module_info.file_size(), kLibTestDllFileSize);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x101000);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x105000);
+  EXPECT_EQ(libtest_module_info.build_id(), "");
+  EXPECT_EQ(libtest_module_info.load_bias(), kLibTestDllImageBase);
+  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
+  EXPECT_EQ(libtest_module_info.soname(), "");
+  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST(LinuxMap, ParseMapsPeTextMappedAnonymouslyInMoreComplexExample) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("10000-11000 r--p 00000000 00:00 0    [stack]\n"
+                      "100000-101000 r--p 00000000 01:02 42    %1$s\n"  // The headers.
+                      "101000-102000 rw-p 00000000 00:00 0 \n"
+                      "102000-103000 r--p 00002000 01:02 42    %1$s\n"
+                      "103000-104000 r-xp 00000000 00:00 0    [special]\n"
+                      "104000-105000 r--p 00004000 01:02 42    %1$s\n"
+                      "105000-106000 r-xp 00000000 00:00 0 \n"  // An executable map.
+                      "106000-107000 r--p 00006000 01:02 42    %1$s\n"
+                      "107000-108000 rw-p 00000000 00:00 0    [special]\n"
+                      "108000-109000 r-xp 00000000 00:00 0 \n"  // An executable map.
+                      "109000-10A000 r-xp 00000000 01:02 42    /path/to/nothing\n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 1);
+
+  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
+  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
+  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
+  EXPECT_EQ(libtest_module_info.file_size(), kLibTestDllFileSize);
+  EXPECT_EQ(libtest_module_info.address_start(), 0x105000);
+  EXPECT_EQ(libtest_module_info.address_end(), 0x109000);
+  EXPECT_EQ(libtest_module_info.build_id(), "");
+  EXPECT_EQ(libtest_module_info.load_bias(), kLibTestDllImageBase);
+  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
+  EXPECT_EQ(libtest_module_info.soname(), "");
+  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST(LinuxMap, ParseMapsPeTextMappedAnonymouslyAndFirstMapWithOffset) {
+  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
+  const std::filesystem::path libtest_path = test_path / "libtest.dll";
+
+  const std::string data{
+      absl::StrFormat("101000-102000 r--p 00001000 01:02 42    %s\n"
+                      "102000-103000 r-xp 00000000 00:00 0 \n",
+                      libtest_path)};
+  const auto result = ParseMaps(data);
+  ASSERT_THAT(result, HasNoError());
+  ASSERT_EQ(result.value().size(), 0);
+}
+
+TEST(LinuxMap, ParseMapsPeTextMappedWithWrongName) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -375,7 +416,7 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedWithWrongName) {
   EXPECT_EQ(result.value().size(), 0);
 }
 
-TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyButNotExecutable) {
+TEST(LinuxMap, ParseMapsPeNoExecutableMap) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -388,52 +429,13 @@ TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyButNotExecutable) {
   EXPECT_EQ(result.value().size(), 0);
 }
 
-TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyButExecutableMapAlreadyExists) {
-  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
-  const std::filesystem::path libtest_path = test_path / "libtest.dll";
-
-  const std::string data{
-      absl::StrFormat("100000-101000 r-xp 00000000 01:02 42    %s\n"
-                      "101000-103000 r-xp 00000000 00:00 0 \n",
-                      libtest_path)};
-  const auto result = ParseMaps(data);
-  ASSERT_THAT(result, HasNoError());
-  ASSERT_EQ(result.value().size(), 1);
-
-  // This comes from the first mapping, not the second.
-  const orbit_grpc_protos::ModuleInfo& libtest_module_info = result.value()[0];
-  EXPECT_EQ(libtest_module_info.name(), "libtest.dll");
-  EXPECT_EQ(libtest_module_info.file_path(), libtest_path);
-  EXPECT_EQ(libtest_module_info.file_size(), 96441);
-  EXPECT_EQ(libtest_module_info.address_start(), 0x100000);
-  EXPECT_EQ(libtest_module_info.address_end(), 0x101000);
-  EXPECT_EQ(libtest_module_info.build_id(), "");
-  EXPECT_EQ(libtest_module_info.load_bias(), 0x62640000);
-  EXPECT_EQ(libtest_module_info.executable_segment_offset(), 0x1000);
-  EXPECT_EQ(libtest_module_info.soname(), "");
-  EXPECT_EQ(libtest_module_info.object_file_type(), orbit_grpc_protos::ModuleInfo::kCoffFile);
-}
-
-TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyAtOffsetTooHigh) {
+TEST(LinuxMap, ParseMapsPeTextMappedAnonymouslyWithEndBeyondSizeOfImage) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
   const std::string data{
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
-                      "102000-103000 r-xp 00000000 00:00 0 \n",
-                      libtest_path)};
-  const auto result = ParseMaps(data);
-  ASSERT_THAT(result, HasNoError());
-  EXPECT_EQ(result.value().size(), 0);
-}
-
-TEST(LinuxMap, ParseMapsWithPeTextMappedAnonymouslyWithSizeTooSmall) {
-  const std::filesystem::path test_path = orbit_test::GetTestdataDir();
-  const std::filesystem::path libtest_path = test_path / "libtest.dll";
-
-  const std::string data{
-      absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
-                      "101000-102000 r-xp 00000000 00:00 0 \n",
+                      "101000-121000 r-xp 00000000 00:00 0 \n",  // Beyond SizeOfImage.
                       libtest_path)};
   const auto result = ParseMaps(data);
   ASSERT_THAT(result, HasNoError());


### PR DESCRIPTION
We are solving the issue with object files that are mapped into memory into
multiple mappings. This can happen if the single executable section is split
across multiple mappings, or if there is more than one executable section (the
latter should only be the case for PEs).

Before, each executable mapping was seen by Orbit as a separate module. In these
cases, the correspondence between symbols and addresses was computed
incorrectly, because only one of these "modules" had the correct address in
memory at which the first executable section of the object file was mapped.

Now, when scanning `/proc/[pid]/maps` in `orbit_object_utils::ParseMaps`, we
only create a single module for a sequence of mapping that correspond to the
same file. In particular, we consider an address range that covers all the
executable mappings for that file. This could also cover non-executable
sections, but it doesn't matter. The only assumption is that the beginning of
this address range still corresponds to the "executable segment offset", i.e.,
the "executable segment offset" corresponds to the first executable section.

We need to relax the conditions applied when detecting anonymous executable maps
that corresponds to PEs with a file alignment incompatible with `mmap`. Now we
simply accept any anonymous executable map that lies inside the address range of
size `ObjectFile::GetImageSize()` that starts at the first address at which the
PE is mapped.

Bug: http://b/235481314
Bug: http://b/235480245

Test:
- Adjusted and expanded `LinuxMapTest.cpp`.
- Tried on triangle.exe: already worked fine before, still works.
- Tried on complex Silenus games: now each module only shows up once and symbols
  are correctly assigned to addresses.