### PR TITLE
Fix libtest32.dll ignore rule for Allstar

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -7,4 +7,4 @@ ignorePaths:
   - third_party/libunwindstack/tests/files/boot_arm.oat
   - third_party/libunwindstack/tests/files/boot_arm.oat.gnu_debugdata
   - third_party/libunwindstack/tests/files/libtest.dll
-  - third_party/libunwindstack/tests/files/libtest32.dl
+  - third_party/libunwindstack/tests/files/libtest32.dll


### PR DESCRIPTION
There was a typo for libtest32.dll in #3757.

Fix #3756.