### PR TITLE
PeCoffEpilog now supports multiple executable sections

### DIFF
--- a/third_party/libunwindstack/PeCoffEpilog.h
+++ b/third_party/libunwindstack/PeCoffEpilog.h
@@ -22,6 +22,7 @@
 #include <unwindstack/Error.h>
 #include <unwindstack/Memory.h>
 #include <unwindstack/Regs.h>
+#include "unwindstack/PeCoffInterface.h"
 
 namespace unwindstack {
 
@@ -51,8 +52,7 @@ class PeCoffEpilog {
 };
 
 std::unique_ptr<PeCoffEpilog> CreatePeCoffEpilog(Memory* object_file_memory,
-                                                 uint64_t text_section_vmaddr,
-                                                 uint64_t text_section_offset);
+                                                 std::vector<Section> sections);
 
 }  // namespace unwindstack
 

--- a/third_party/libunwindstack/PeCoffInterface.cpp
+++ b/third_party/libunwindstack/PeCoffInterface.cpp
@@ -511,8 +511,7 @@ bool PeCoffInterfaceImpl<uint64_t>::InitNativeUnwinder() {
   }
 
   native_unwinder_ = std::make_unique<PeCoffUnwindInfoUnwinderX86_64>(
-      memory_, optional_header_.image_base, pdata_file_begin, pdata_file_end,
-      text_section_data_->memory_offset, text_section_data_->file_offset, sections_);
+      memory_, optional_header_.image_base, pdata_file_begin, pdata_file_end, sections_);
   return native_unwinder_->Init();
 }
 

--- a/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.h
@@ -36,13 +36,11 @@ class PeCoffUnwindInfoUnwinderX86_64 : public PeCoffNativeUnwinder {
  public:
   explicit PeCoffUnwindInfoUnwinderX86_64(Memory* object_file_memory, int64_t image_base,
                                           uint64_t pdata_begin, uint64_t pdata_end,
-                                          uint64_t text_section_vmaddr,
-                                          uint64_t text_section_offset,
                                           const std::vector<Section>& sections)
       : runtime_functions_(CreatePeCoffRuntimeFunctions(object_file_memory)),
         unwind_infos_(CreatePeCoffUnwindInfos(object_file_memory, sections)),
         unwind_info_evaluator_(CreatePeCoffUnwindInfoEvaluator()),
-        epilog_(CreatePeCoffEpilog(object_file_memory, text_section_vmaddr, text_section_offset)),
+        epilog_(CreatePeCoffEpilog(object_file_memory, sections)),
         image_base_(image_base),
         pdata_begin_(pdata_begin),
         pdata_end_(pdata_end) {}

--- a/third_party/libunwindstack/PeCoffUnwindInfos.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.cpp
@@ -18,13 +18,14 @@
 
 #include <memory>
 #include <unordered_map>
+#include <utility>
 
 namespace unwindstack {
 
 class PeCoffUnwindInfosImpl : public PeCoffUnwindInfos {
  public:
-  explicit PeCoffUnwindInfosImpl(Memory* memory, const std::vector<Section>& sections)
-      : pe_coff_memory_(memory), sections_(sections) {}
+  explicit PeCoffUnwindInfosImpl(Memory* memory, std::vector<Section> sections)
+      : pe_coff_memory_(memory), sections_(std::move(sections)) {}
 
   bool GetUnwindInfo(uint64_t unwind_info_file_offset, UnwindInfo* unwind_info) override;
 
@@ -40,8 +41,8 @@ class PeCoffUnwindInfosImpl : public PeCoffUnwindInfos {
 };
 
 std::unique_ptr<PeCoffUnwindInfos> CreatePeCoffUnwindInfos(Memory* memory,
-                                                           const std::vector<Section>& sections) {
-  return std::make_unique<PeCoffUnwindInfosImpl>(memory, sections);
+                                                           std::vector<Section> sections) {
+  return std::make_unique<PeCoffUnwindInfosImpl>(memory, std::move(sections));
 }
 
 bool PeCoffUnwindInfosImpl::MapFromRVAToFileOffset(uint64_t rva, uint64_t* file_offset) {

--- a/third_party/libunwindstack/PeCoffUnwindInfos.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.h
@@ -78,7 +78,7 @@ class PeCoffUnwindInfos {
 };
 
 std::unique_ptr<PeCoffUnwindInfos> CreatePeCoffUnwindInfos(Memory* object_file_memory,
-                                                           const std::vector<Section>& sections);
+                                                           std::vector<Section> sections);
 
 }  // namespace unwindstack
 

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
@@ -70,8 +70,7 @@ class MockPeCoffUnwindInfoEvaluator : public PeCoffUnwindInfoEvaluator {
 
 class TestPeCoffUnwindInfoUnwinderX86_64 : public PeCoffUnwindInfoUnwinderX86_64 {
  public:
-  TestPeCoffUnwindInfoUnwinderX86_64()
-      : PeCoffUnwindInfoUnwinderX86_64(nullptr, 0, 0, 0, 0, 0, {}) {}
+  TestPeCoffUnwindInfoUnwinderX86_64() : PeCoffUnwindInfoUnwinderX86_64(nullptr, 0, 0, 0, {}) {}
 
   void SetFakeRuntimeFuntions(std::unique_ptr<MockPeCoffRuntimeFunctions> runtime_functions) {
     this->runtime_functions_ = std::move(runtime_functions);


### PR DESCRIPTION
With PEs with multiple executable sections, when a program counter was inside an
executable section other than the first, the computation of the offset in the
file was producing the wrong value. This was making us read bytes from the
wrong location, hence causing an error in epilog detection because
disassemblying would also most likely fail.

We now support multiple executable sections by following the same pattern as in
other parts of PE unwinding with the `MapFromRvaToFileOffset` function.

Bug: http://b/236091987

Test:
- Add and adjust unit tests.
- Tried on complex Silenus games that highlighted the problem. Together with
  another upcoming fix that handles multiple executable sections mapped
  anonymously, this drastically reduces unwind errors (leaving basically only
  `__wine_syscall_dispatcher`).