### PR TITLE
Set a name for the thread that connects to ProducerSideService.

### DIFF
--- a/src/CaptureEventProducer/CaptureEventProducer.cpp
+++ b/src/CaptureEventProducer/CaptureEventProducer.cpp
@@ -10,6 +10,7 @@
 #include <chrono>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadUtils.h"
 
 using orbit_grpc_protos::ProducerSideService;
 using orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest;
@@ -109,6 +110,7 @@ bool CaptureEventProducer::NotifyAllEventsSent() {
 
 void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
   ORBIT_CHECK(producer_side_service_stub_ != nullptr);
+  orbit_base::SetCurrentThreadName("ConnectAndReceiveCommandsThread");
 
   while (true) {
     {

--- a/src/CaptureEventProducer/CaptureEventProducer.cpp
+++ b/src/CaptureEventProducer/CaptureEventProducer.cpp
@@ -110,7 +110,7 @@ bool CaptureEventProducer::NotifyAllEventsSent() {
 
 void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
   ORBIT_CHECK(producer_side_service_stub_ != nullptr);
-  orbit_base::SetCurrentThreadName("ConnectAndReceiveCommandsThread");
+  orbit_base::SetCurrentThreadName("ConnectRcvCmds");
 
   while (true) {
     {


### PR DESCRIPTION
This will help with blocking instrumentation events from the threads
that Orbit spawns inside the target process. See bug for some context.

Bug: b/236121842