### PR TITLE
Implement the stat test for sampling with frametrack

### DIFF
--- a/src/MizarData/ActiveFunctionTimePerFrameComparatorTest.cpp
+++ b/src/MizarData/ActiveFunctionTimePerFrameComparatorTest.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+#include "MizarData/ActiveFunctionTimePerFrameComparator.h"
+#include "MizarData/BaselineOrComparison.h"
+#include "MizarData/SampledFunctionId.h"
+#include "MizarData/SamplingWithFrameTrackComparisonReport.h"
+
+namespace orbit_mizar_data {
+
+using testing::DoubleNear;
+using testing::Return;
+
+namespace {
+class MockCounts {
+ public:
+  MOCK_METHOD(double, GetExclusiveRate, (SFID), (const));
+  MOCK_METHOD(uint64_t, GetTotalCallstacks, (), (const));
+};
+
+class MockFrameTrackStats {
+ public:
+  MOCK_METHOD(double, ComputeAverageTimeNs, (), (const));
+  MOCK_METHOD(uint64_t, variance_ns, (), (const));
+  MOCK_METHOD(uint64_t, count, (), (const));
+};
+
+}  // namespace
+
+constexpr uint64_t kTotalCallstacksBaseline = 100;
+constexpr uint64_t kTotalCallstacksComparison = 200;
+
+constexpr double kRateBaseline = 0.1;
+constexpr double kRateComparison = 0.15;
+
+constexpr uint64_t kFramesCntBaseline = 1000;
+constexpr uint64_t kFramesCntComparison = 1300;
+
+constexpr double kFrametimeVarBaseline = 100;
+constexpr double kFrametimeVarComparison = 150;
+
+constexpr double kAvgFrametimeBaseline = 1000;
+constexpr double kAvgFrametimeComparison = 900;
+
+constexpr SFID kArbitrarySfid(10);
+
+constexpr double kExpectedStatistic = -0.929944;
+constexpr double kPvalue = 0.352400;
+constexpr double kTol = 1e-3;
+
+class ActiveFunctionTimePerFrameComparatorTest : public ::testing::Test {
+ public:
+  ActiveFunctionTimePerFrameComparatorTest()
+      : baseline_counts_(std::in_place_t{}),
+        comparision_counts_(std::in_place_t{}),
+        baseline_frame_track_stats_(std::in_place_t{}),
+        comparison_frame_track_stats_(std::in_place_t{}) {
+    EXPECT_CALL(*baseline_frame_track_stats_, ComputeAverageTimeNs)
+        .WillRepeatedly(Return(kAvgFrametimeBaseline));
+    EXPECT_CALL(*comparison_frame_track_stats_, ComputeAverageTimeNs)
+        .WillRepeatedly(Return(kAvgFrametimeComparison));
+
+    EXPECT_CALL(*baseline_frame_track_stats_, count).WillRepeatedly(Return(kFramesCntBaseline));
+    EXPECT_CALL(*comparison_frame_track_stats_, count).WillRepeatedly(Return(kFramesCntComparison));
+
+    EXPECT_CALL(*baseline_frame_track_stats_, variance_ns)
+        .WillRepeatedly(Return(kFrametimeVarBaseline));
+    EXPECT_CALL(*comparison_frame_track_stats_, variance_ns)
+        .WillRepeatedly(Return(kFrametimeVarComparison));
+
+    EXPECT_CALL(*baseline_counts_, GetTotalCallstacks)
+        .WillRepeatedly(Return(kTotalCallstacksBaseline));
+    EXPECT_CALL(*comparision_counts_, GetTotalCallstacks)
+        .WillRepeatedly(Return(kTotalCallstacksComparison));
+  }
+
+ protected:
+  Baseline<MockCounts> baseline_counts_;
+  Comparison<MockCounts> comparision_counts_;
+
+  Baseline<MockFrameTrackStats> baseline_frame_track_stats_;
+  Comparison<MockFrameTrackStats> comparison_frame_track_stats_;
+};
+
+TEST_F(ActiveFunctionTimePerFrameComparatorTest, ComparatorIsCorrectWithNonZeroRates) {
+  ActiveFunctionTimePerFrameComparatorTmpl<MockCounts, MockFrameTrackStats> comparator(
+      baseline_counts_, baseline_frame_track_stats_, comparision_counts_,
+      comparison_frame_track_stats_);
+  EXPECT_CALL(*baseline_counts_, GetExclusiveRate).WillRepeatedly(Return(kRateBaseline));
+  EXPECT_CALL(*comparision_counts_, GetExclusiveRate).WillRepeatedly(Return(kRateComparison));
+
+  auto result = comparator.Compare(SFID(kArbitrarySfid));
+
+  EXPECT_THAT(result.statistic, DoubleNear(kExpectedStatistic, kTol));
+  EXPECT_THAT(result.pvalue, DoubleNear(kPvalue, kTol));
+}
+
+TEST_F(ActiveFunctionTimePerFrameComparatorTest, ComparatorIsCorrectWithZeroRates) {
+  ActiveFunctionTimePerFrameComparatorTmpl<MockCounts, MockFrameTrackStats> comparator(
+      baseline_counts_, baseline_frame_track_stats_, comparision_counts_,
+      comparison_frame_track_stats_);
+  // As if no data is observed
+  EXPECT_CALL(*baseline_counts_, GetExclusiveRate).WillRepeatedly(Return(0));
+  EXPECT_CALL(*comparision_counts_, GetExclusiveRate).WillRepeatedly(Return(0));
+
+  ComparisonResult result = comparator.Compare(SFID(kArbitrarySfid));
+
+  EXPECT_THAT(result.statistic, testing::IsNan());
+  EXPECT_THAT(result.pvalue,
+              DoubleNear(1.0, kTol));  // no difference observed, largest pvalue returned
+}
+
+}  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -101,11 +101,15 @@ constexpr SFID kSFIDFirst = SFID(1);
 constexpr SFID kSFIDSecond = SFID(2);
 constexpr SFID kSFIDThird = SFID(3);
 constexpr std::array<SFID, kSFIDCnt> kSFIDs = {kSFIDFirst, kSFIDSecond, kSFIDThird};
+const absl::flat_hash_map<SFID, std::string> kSFIDToName = MakeMap(kSFIDs, kBaselineFunctionNames);
 
 const std::vector<std::vector<SFID>> kCallstacks = {
-    std::vector<SFID>{kSFIDFirst, kSFIDSecond, kSFIDThird}, {kSFIDSecond}, {}};
+    std::vector<SFID>{kSFIDThird, kSFIDSecond, kSFIDFirst}, {kSFIDSecond}, {}};
 
 const std::vector<uint64_t> kFrameTrackActiveTimes = {300, 100, 200};
+
+constexpr double kStatistic = 1.234;
+constexpr double kPvalue = 0.123456;
 
 namespace {
 class MockPairedData {
@@ -131,6 +135,17 @@ class MockPairedData {
   std::vector<std::vector<SFID>> callstacks_;
   std::vector<uint64_t> frame_track_active_times_;
 };
+
+class MockFunctionTimeComparator {
+ public:
+  MockFunctionTimeComparator(const Baseline<SamplingCounts>& /*_*/,
+                             const Baseline<orbit_client_data::ScopeStats>& /*_*/,
+                             const Comparison<SamplingCounts>& /*_*/,
+                             const Comparison<orbit_client_data::ScopeStats>& /*_*/) {}
+
+  [[nodiscard]] ComparisonResult Compare(SFID /*_*/) const { return {kStatistic, kPvalue}; };
+};
+
 }  // namespace
 
 TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
@@ -138,40 +153,47 @@ TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
   auto empty =
       MakeComparison<MockPairedData>(std::vector<std::vector<SFID>>{}, std::vector<uint64_t>{});
 
-  BaselineAndComparisonTmpl<MockPairedData> bac(std::move(full), std::move(empty), {});
+  BaselineAndComparisonTmpl<MockPairedData, MockFunctionTimeComparator> bac(
+      std::move(full), std::move(empty), {kSFIDToName});
   const SamplingWithFrameTrackComparisonReport report = bac.MakeSamplingWithFrameTrackReport(
       orbit_mizar_data::MakeBaseline<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
           absl::flat_hash_set<uint32_t>{orbit_base::kAllProcessThreadsTid}, 0, 1, 1),
       orbit_mizar_data::MakeComparison<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
           absl::flat_hash_set<uint32_t>{orbit_base::kAllProcessThreadsTid}, 0, 1, 1));
 
-  EXPECT_EQ(report.baseline_sampling_counts.GetTotalCallstacks(), kCallstacks.size());
+  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetTotalCallstacks(), kCallstacks.size());
 
-  EXPECT_EQ(report.baseline_sampling_counts.GetExclusiveCount(kSFIDFirst), 0);
-  EXPECT_EQ(report.baseline_sampling_counts.GetExclusiveCount(kSFIDSecond), 1);
-  EXPECT_EQ(report.baseline_sampling_counts.GetExclusiveCount(kSFIDThird), 1);
+  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetExclusiveCount(kSFIDFirst), 0);
+  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetExclusiveCount(kSFIDSecond), 1);
+  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetExclusiveCount(kSFIDThird), 1);
 
-  EXPECT_EQ(report.baseline_sampling_counts.GetInclusiveCount(kSFIDFirst), 1);
-  EXPECT_EQ(report.baseline_sampling_counts.GetInclusiveCount(kSFIDSecond), 2);
-  EXPECT_EQ(report.baseline_sampling_counts.GetInclusiveCount(kSFIDThird), 1);
+  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetInclusiveCount(kSFIDFirst), 1);
+  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetInclusiveCount(kSFIDSecond), 2);
+  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetInclusiveCount(kSFIDThird), 1);
 
-  EXPECT_EQ(report.comparison_sampling_counts.GetTotalCallstacks(), 0);
+  EXPECT_EQ(report.GetSamplingCounts<Comparison>()->GetTotalCallstacks(), 0);
   for (const SFID sfid : kSFIDs) {
-    EXPECT_EQ(report.comparison_sampling_counts.GetExclusiveCount(sfid), 0);
-    EXPECT_EQ(report.comparison_sampling_counts.GetInclusiveCount(sfid), 0);
+    EXPECT_EQ(report.GetSamplingCounts<Comparison>()->GetExclusiveCount(sfid), 0);
+    EXPECT_EQ(report.GetSamplingCounts<Comparison>()->GetInclusiveCount(sfid), 0);
+
+    ComparisonResult comparision_result = report.GetComparisonResult(sfid);
+    constexpr double kTol = 1e-6;
+    EXPECT_THAT(comparision_result.statistic, DoubleNear(kStatistic, kTol));
+    EXPECT_THAT(comparision_result.pvalue, DoubleNear(kPvalue, kTol));
   }
 
   constexpr uint64_t kExpectedFullActiveFrameTime = 200;
-  EXPECT_EQ(report.baseline_frame_track_stats.ComputeAverageTimeNs(), kExpectedFullActiveFrameTime);
-  EXPECT_EQ(report.comparison_frame_track_stats.ComputeAverageTimeNs(), 0);
+  EXPECT_EQ(report.GetFrameTrackStats<Baseline>()->ComputeAverageTimeNs(),
+            kExpectedFullActiveFrameTime);
+  EXPECT_EQ(report.GetFrameTrackStats<Comparison>()->ComputeAverageTimeNs(), 0);
 
   constexpr double kExpectedFullActiveFrameTimeVariance = 6666.66666;
-  EXPECT_THAT(report.baseline_frame_track_stats.variance_ns(),
+  EXPECT_THAT(report.GetFrameTrackStats<Baseline>()->variance_ns(),
               DoubleNear(kExpectedFullActiveFrameTimeVariance, 1e-3));
-  EXPECT_THAT(report.comparison_frame_track_stats.variance_ns(), DoubleNear(0, 1e-3));
+  EXPECT_THAT(report.GetFrameTrackStats<Comparison>()->variance_ns(), DoubleNear(0, 1e-3));
 
-  EXPECT_EQ(report.baseline_frame_track_stats.count(), kFrameTrackActiveTimes.size());
-  EXPECT_EQ(report.comparison_frame_track_stats.count(), 0);
+  EXPECT_EQ(report.GetFrameTrackStats<Baseline>()->count(), kFrameTrackActiveTimes.size());
+  EXPECT_EQ(report.GetFrameTrackStats<Comparison>()->count(), 0);
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -6,42 +6,45 @@ cmake_minimum_required(VERSION 3.15)
 
 add_library(MizarData STATIC)
 
-target_sources(MizarData PUBLIC 
-         include/MizarData/BaselineAndComparison.h
-         include/MizarData/MizarData.h
-         include/MizarData/MizarDataProvider.h
-         include/MizarData/MizarPairedData.h
-         include/MizarData/NonWrappingAddition.h
-         include/MizarData/SampledFunctionId.h)
+target_sources(MizarData PUBLIC
+        include/MizarData/ActiveFunctionTimePerFrameComparator.h
+        include/MizarData/BaselineAndComparison.h
+        include/MizarData/BaselineOrComparison.h
+        include/MizarData/MizarData.h
+        include/MizarData/MizarDataProvider.h
+        include/MizarData/MizarPairedData.h
+        include/MizarData/NonWrappingAddition.h
+        include/MizarData/SampledFunctionId.h)
 
-target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include) 
+target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 target_sources(MizarData PRIVATE
-                BaselineAndComparison.cpp
-                BaselineAndComparisonHelper.h
-                BaselineAndComparisonHelper.cpp
-                MizarData.cpp)
-
+        BaselineAndComparison.cpp
+        BaselineAndComparisonHelper.h
+        BaselineAndComparisonHelper.cpp
+        MizarData.cpp)
 
 target_link_libraries(
-        MizarData 
-        PUBLIC  CaptureClient
-                OrbitPaths
-                Symbols
+        MizarData
+        PUBLIC CaptureClient
+        OrbitPaths
+        Statistics
+        Symbols
         PRIVATE CaptureFile
-                ClientData
-                ClientSymbols
-                OrbitBase)
+        ClientData
+        ClientSymbols
+        OrbitBase)
 
 add_executable(MizarDataTests)
 
-target_sources(MizarDataTests PRIVATE 
-                BaselineAndComparisonTest.cpp
-                MizarDataTest.cpp
-                MizarPairedDataTest.cpp)
+target_sources(MizarDataTests PRIVATE
+        ActiveFunctionTimePerFrameComparatorTest.cpp
+        BaselineAndComparisonTest.cpp
+        MizarDataTest.cpp
+        MizarPairedDataTest.cpp)
 
 target_link_libraries(MizarDataTests PRIVATE GrpcProtos
-                                                MizarData
-                                                GTest::GTest
-                                                GTest::Main)
+        MizarData
+        GTest::GTest
+        GTest::Main)
 register_test(MizarDataTests)

--- a/src/MizarData/include/MizarData/ActiveFunctionTimePerFrameComparator.h
+++ b/src/MizarData/include/MizarData/ActiveFunctionTimePerFrameComparator.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_STATISTICS_ACTIVE_FUNCTION_TIME_PER_FRAME_COMPARATOR_H_
+#define MIZAR_STATISTICS_ACTIVE_FUNCTION_TIME_PER_FRAME_COMPARATOR_H_
+
+#include <utility>
+
+#include "ClientData/ScopeStats.h"
+#include "MizarData/BaselineOrComparison.h"
+#include "MizarData/SamplingWithFrameTrackComparisonReport.h"
+#include "Statistics/Gaussian.h"
+#include "Statistics/StatisticsUtils.h"
+
+namespace orbit_mizar_data {
+
+// TODO(b/236130122) it should be moved to a new library
+template <typename Counts, typename FrameTrackStats>
+class ActiveFunctionTimePerFrameComparatorTmpl {
+ public:
+  explicit ActiveFunctionTimePerFrameComparatorTmpl(
+      const Baseline<Counts>& baseline_counts,
+      const Baseline<FrameTrackStats>& baseline_frame_stats,
+      const Comparison<Counts>& comparison_counts,
+      const Comparison<FrameTrackStats>& comparison_frame_stats)
+      : baseline_counts_(baseline_counts),
+        baseline_frame_stats_(baseline_frame_stats),
+        comparison_counts_(comparison_counts),
+        comparison_frame_stats_(comparison_frame_stats) {}
+
+  [[nodiscard]] ComparisonResult Compare(SFID sfid) const {
+    const auto baseline_active_time =
+        ActiveFunctionTime(baseline_counts_, baseline_frame_stats_, sfid);
+    const auto comparison_active_time =
+        ActiveFunctionTime(comparison_counts_, comparison_frame_stats_, sfid);
+    const orbit_statistics::MeanAndVariance non_normalized_stat =
+        NonNormalizedStat(baseline_active_time, comparison_active_time);
+
+    const double stat = non_normalized_stat.mean / std::sqrt(non_normalized_stat.variance);
+
+    const double pvalue_right_tail = orbit_statistics::GaussianCDF(stat);
+    if (std::isnan(pvalue_right_tail)) return {stat, 1.0};
+
+    // But the test is two-tailed. So by the symmetry of Normal distribution we have
+    const double pvalue = std::min(pvalue_right_tail, 1 - pvalue_right_tail) * 2;
+    return {stat, pvalue};
+  }
+
+ private:
+  [[nodiscard]] static orbit_statistics::MeanAndVariance NonNormalizedStat(
+      const Baseline<orbit_statistics::MeanAndVariance>& baseline_active_time,
+      const Comparison<orbit_statistics::MeanAndVariance>& comparison_active_time) {
+    return orbit_statistics::DiffOfTwoIndependent(*baseline_active_time, *comparison_active_time);
+  }
+
+  template <template <class> class Wrapper>
+  [[nodiscard]] static Wrapper<orbit_statistics::MeanAndVariance> ActiveFunctionTime(
+      const Wrapper<Counts>& counts, const Wrapper<FrameTrackStats>& frame_track_stats, SFID sfid) {
+    const double rate = counts->GetExclusiveRate(sfid);
+    const double frametime = frame_track_stats->ComputeAverageTimeNs();
+
+    const double rate_var = rate * (1 - rate) / counts->GetTotalCallstacks();
+    const double frametime_var =
+        frame_track_stats->variance_ns() / std::sqrt(frame_track_stats->count());
+
+    return Wrapper<orbit_statistics::MeanAndVariance>(
+        orbit_statistics::ProductOfTwoIndependent({rate, rate_var}, {frametime, frametime_var}));
+  }
+
+  const Baseline<Counts>& baseline_counts_;
+  const Baseline<FrameTrackStats>& baseline_frame_stats_;
+
+  const Comparison<Counts>& comparison_counts_;
+  const Comparison<FrameTrackStats>& comparison_frame_stats_;
+};
+
+using ActiveFunctionTimePerFrameComparator =
+    ActiveFunctionTimePerFrameComparatorTmpl<SamplingCounts, orbit_client_data::ScopeStats>;
+
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_STATISTICS_ACTIVE_FUNCTION_TIME_PER_FRAME_COMPARATOR_H_

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -5,14 +5,13 @@
 #ifndef MIZAR_DATA_BASELINE_AND_COMPARISON_H_
 #define MIZAR_DATA_BASELINE_AND_COMPARISON_H_
 
+#include <absl/container/flat_hash_map.h>
 #include <stdint.h>
 
 #include <string>
-#include <type_traits>
 
-#include "ClientData/CallstackData.h"
-#include "ClientData/CaptureData.h"
-#include "MizarData/MizarData.h"
+#include "MizarData/ActiveFunctionTimePerFrameComparator.h"
+#include "MizarData/BaselineOrComparison.h"
 #include "MizarData/MizarPairedData.h"
 #include "MizarData/NonWrappingAddition.h"
 #include "MizarData/SampledFunctionId.h"
@@ -20,54 +19,10 @@
 
 namespace orbit_mizar_data {
 
-template <typename T, typename U>
-using EnableIfUConvertibleToT = std::enable_if_t<std::is_convertible_v<U, T>>;
-
-template <typename T>
-class BaselineOrComparison {
- public:
-  ~BaselineOrComparison() = default;
-
-  const T* operator->() const { return &value_; }
-  T* operator->() { return &value_; }
-
- protected:
-  template <typename U, typename = EnableIfUConvertibleToT<U, T>>
-  explicit BaselineOrComparison(U&& value) : value_(std::forward<T>(value)) {}
-  BaselineOrComparison(BaselineOrComparison&& other) = default;
-
- private:
-  T value_;
-};
-
-template <typename T>
-class Baseline : public BaselineOrComparison<T> {
- public:
-  template <typename U, typename = EnableIfUConvertibleToT<U, T>>
-  explicit Baseline(U&& value) : BaselineOrComparison<T>(std::forward<U>(value)) {}
-};
-
-template <typename T>
-class Comparison : public BaselineOrComparison<T> {
- public:
-  template <typename U, typename = EnableIfUConvertibleToT<U, T>>
-  explicit Comparison(U&& value) : BaselineOrComparison<T>(std::forward<U>(value)) {}
-};
-
-template <typename T, typename... Args>
-Baseline<T> MakeBaseline(Args&&... args) {
-  return Baseline<T>(T(std::forward<Args>(args)...));
-}
-
-template <typename T, typename... Args>
-Comparison<T> MakeComparison(Args&&... args) {
-  return Comparison<T>(T(std::forward<Args>(args)...));
-}
-
 // The class owns the data from two capture files via owning two instances of
 // `PairedData`. Also owns the map from sampled function ids to the
 // corresponding function names.
-template <typename PairedData>
+template <typename PairedData, typename FunctionTimeComparator>
 class BaselineAndComparisonTmpl {
  public:
   BaselineAndComparisonTmpl(Baseline<PairedData> baseline, Comparison<PairedData> comparison,
@@ -83,14 +38,32 @@ class BaselineAndComparisonTmpl {
   [[nodiscard]] SamplingWithFrameTrackComparisonReport MakeSamplingWithFrameTrackReport(
       Baseline<HalfOfSamplingWithFrameTrackReportConfig> baseline_config,
       Comparison<HalfOfSamplingWithFrameTrackReportConfig> comparison_config) const {
-    return {MakeCounts(baseline_, baseline_config), MakeCounts(comparison_, comparison_config),
-            MakeFrameTrackStats(baseline_, baseline_config),
-            MakeFrameTrackStats(comparison_, comparison_config)};
+    Baseline<SamplingCounts> baseline_sampling_counts = MakeCounts(baseline_, baseline_config);
+    Baseline<orbit_client_data::ScopeStats> baseline_frame_stats =
+        MakeFrameTrackStats(baseline_, baseline_config);
+
+    Comparison<SamplingCounts> comparison_sampling_counts =
+        MakeCounts(comparison_, comparison_config);
+    Comparison<orbit_client_data::ScopeStats> comparison_frame_stats =
+        MakeFrameTrackStats(comparison_, comparison_config);
+
+    FunctionTimeComparator comparator(baseline_sampling_counts, baseline_frame_stats,
+                                      comparison_sampling_counts, comparison_frame_stats);
+
+    absl::flat_hash_map<SFID, ComparisonResult> sfid_to_comparison_result;
+    for (const auto& [sfid, _] : sfid_to_name_) {
+      sfid_to_comparison_result.try_emplace(sfid, comparator.Compare(sfid));
+    }
+
+    return SamplingWithFrameTrackComparisonReport(
+        std::move(baseline_sampling_counts), std::move(baseline_frame_stats),
+        std::move(comparison_sampling_counts), std::move(comparison_frame_stats),
+        std::move(sfid_to_comparison_result));
   }
 
  private:
-  template <template <class> class Wrapper>
-  [[nodiscard]] orbit_client_data::ScopeStats MakeFrameTrackStats(
+  template <template <typename> typename Wrapper>
+  [[nodiscard]] Wrapper<orbit_client_data::ScopeStats> MakeFrameTrackStats(
       const Wrapper<PairedData>& data,
       const Wrapper<HalfOfSamplingWithFrameTrackReportConfig>& config) const {
     const std::vector<uint64_t> active_invocation_times = data->ActiveInvocationTimes(
@@ -100,11 +73,11 @@ class BaselineAndComparisonTmpl {
     for (const uint64_t active_invocation_time : active_invocation_times) {
       stats.UpdateStats(active_invocation_time);
     }
-    return stats;
+    return Wrapper<orbit_client_data::ScopeStats>(stats);
   }
 
-  template <template <class> class Wrapper>
-  [[nodiscard]] SamplingCounts MakeCounts(
+  template <template <typename> typename Wrapper>
+  [[nodiscard]] Wrapper<SamplingCounts> MakeCounts(
       const Wrapper<PairedData>& data,
       const Wrapper<HalfOfSamplingWithFrameTrackReportConfig>& config) const {
     uint64_t total_callstacks = 0;
@@ -119,10 +92,11 @@ class BaselineAndComparisonTmpl {
             for (const SFID sfid : callstack) {
               counts[sfid].inclusive++;
             }
-            counts[callstack.back()].exclusive++;
+            counts[callstack.front()].exclusive++;
           });
     }
-    return SamplingCounts(std::move(counts), total_callstacks);
+
+    return Wrapper<SamplingCounts>(SamplingCounts(std::move(counts), total_callstacks));
   }
 
   Baseline<PairedData> baseline_;
@@ -130,7 +104,8 @@ class BaselineAndComparisonTmpl {
   absl::flat_hash_map<SFID, std::string> sfid_to_name_;
 };
 
-using BaselineAndComparison = BaselineAndComparisonTmpl<MizarPairedData>;
+using BaselineAndComparison =
+    BaselineAndComparisonTmpl<MizarPairedData, ActiveFunctionTimePerFrameComparator>;
 
 BaselineAndComparison CreateBaselineAndComparison(std::unique_ptr<MizarDataProvider> baseline,
                                                   std::unique_ptr<MizarDataProvider> comparison);

--- a/src/MizarData/include/MizarData/BaselineOrComparison.h
+++ b/src/MizarData/include/MizarData/BaselineOrComparison.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_BASELINE_OR_COMPARISON_H_
+#define MIZAR_DATA_BASELINE_OR_COMPARISON_H_
+
+#include <type_traits>
+#include <utility>
+
+namespace orbit_mizar_data {
+
+template <typename T, typename U>
+using EnableIfUConvertibleToT = std::enable_if_t<std::is_convertible_v<U, T>>;
+
+template <typename T>
+class BaselineOrComparison {
+ public:
+  ~BaselineOrComparison() = default;
+
+  const T* operator->() const { return &value_; }
+  T* operator->() { return &value_; }
+
+  const T& operator*() const { return value_; }
+  T& operator*() { return value_; }
+
+ protected:
+  template <typename U, typename = EnableIfUConvertibleToT<T, U>>
+  explicit BaselineOrComparison(U&& value) : value_(std::forward<T>(value)) {}
+  BaselineOrComparison(BaselineOrComparison&& other) = default;
+
+  template <typename... Args>
+  explicit BaselineOrComparison(std::in_place_t /*_*/, Args&&... args)
+      : value_(T(std::forward<T>(args)...)) {}
+
+ private:
+  T value_;
+};
+
+template <typename T>
+class Baseline : public BaselineOrComparison<T> {
+ public:
+  template <typename U, typename = EnableIfUConvertibleToT<T, U>>
+  explicit Baseline(U&& value) : BaselineOrComparison<T>(std::forward<U>(value)) {}
+
+  template <typename... Args>
+  explicit Baseline(std::in_place_t in_place, Args&&... args)
+      : BaselineOrComparison<T>(in_place, std::forward<T>(args)...) {}
+};
+
+template <typename T>
+class Comparison : public BaselineOrComparison<T> {
+ public:
+  template <typename U, typename = EnableIfUConvertibleToT<T, U>>
+  explicit Comparison(U&& value) : BaselineOrComparison<T>(std::forward<U>(value)) {}
+
+  template <typename... Args>
+  explicit Comparison(std::in_place_t in_place, Args&&... args)
+      : BaselineOrComparison<T>(in_place, std::forward<T>(args)...) {}
+};
+
+template <typename T, typename... Args>
+Baseline<T> MakeBaseline(Args&&... args) {
+  return Baseline<T>(T(std::forward<Args>(args)...));
+}
+
+template <typename T, typename... Args>
+Comparison<T> MakeComparison(Args&&... args) {
+  return Comparison<T>(T(std::forward<Args>(args)...));
+}
+
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_BASELINE_OR_COMPARISON_H_

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -12,10 +12,19 @@
 #include <utility>
 
 #include "ClientData/ScopeStats.h"
+#include "MizarData/BaselineOrComparison.h"
 #include "MizarData/SampledFunctionId.h"
 #include "OrbitBase/Logging.h"
 
 namespace orbit_mizar_data {
+
+// Whatever is usually referred to as "Statistical Test" we call "Comparison" in the project to save
+// confusion with Unit tests.
+struct ComparisonResult {
+  double statistic{};
+  double pvalue{};  // The term from Statistics. TL;DR: The smaller it is, the less we believe in
+                    // the assumption under test (e.g. no difference in active function time).
+};
 
 // The struct represents the part of configuration relevant to one of the two captures under
 // comparison.
@@ -70,11 +79,51 @@ class SamplingCounts {
   uint64_t total_callstacks_{};
 };
 
-struct SamplingWithFrameTrackComparisonReport {
-  SamplingCounts baseline_sampling_counts;
-  SamplingCounts comparison_sampling_counts;
-  orbit_client_data::ScopeStats baseline_frame_track_stats;
-  orbit_client_data::ScopeStats comparison_frame_track_stats;
+class SamplingWithFrameTrackComparisonReport {
+ public:
+  explicit SamplingWithFrameTrackComparisonReport(
+      Baseline<SamplingCounts> baseline_sampling_counts,
+      Baseline<orbit_client_data::ScopeStats> baseline_frame_track_stats,
+      Comparison<SamplingCounts> comparison_sampling_counts,
+      Comparison<orbit_client_data::ScopeStats> comparison_frame_track_stats,
+      absl::flat_hash_map<SFID, ComparisonResult> fid_to_comparison_results)
+      : baseline_sampling_counts_(std::move(baseline_sampling_counts)),
+        baseline_frame_track_stats_(std::move(baseline_frame_track_stats)),
+        comparison_sampling_counts_(std::move(comparison_sampling_counts)),
+        comparison_frame_track_stats_(std::move(comparison_frame_track_stats)),
+        fid_to_comparison_results_(std::move(fid_to_comparison_results)) {}
+
+  template <template <typename> typename Wrapper>
+  const Wrapper<SamplingCounts>& GetSamplingCounts() const {
+    if constexpr (std::is_same_v<Wrapper<SamplingCounts>, Baseline<SamplingCounts>>) {
+      return baseline_sampling_counts_;
+    } else {
+      return comparison_sampling_counts_;
+    }
+  }
+
+  template <template <typename> typename Wrapper>
+  const Wrapper<orbit_client_data::ScopeStats>& GetFrameTrackStats() const {
+    if constexpr (std::is_same_v<Wrapper<orbit_client_data::ScopeStats>,
+                                 Baseline<orbit_client_data::ScopeStats>>) {
+      return baseline_frame_track_stats_;
+    } else {
+      return comparison_frame_track_stats_;
+    }
+  }
+
+  [[nodiscard]] const ComparisonResult& GetComparisonResult(SFID sfid) const {
+    return fid_to_comparison_results_.at(sfid);
+  }
+
+ private:
+  Baseline<SamplingCounts> baseline_sampling_counts_;
+  Baseline<orbit_client_data::ScopeStats> baseline_frame_track_stats_;
+
+  Comparison<SamplingCounts> comparison_sampling_counts_;
+  Comparison<orbit_client_data::ScopeStats> comparison_frame_track_stats_;
+
+  absl::flat_hash_map<SFID, ComparisonResult> fid_to_comparison_results_;
 };
 
 }  // namespace orbit_mizar_data

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -24,16 +24,16 @@ target_link_libraries(OrbitServiceLib PUBLIC
 )
 
 if(WIN32)
-target_link_libraries(OrbitServiceLib PUBLIC
-        WindowsCaptureService
-        WindowsProcessService)
+        target_link_libraries(OrbitServiceLib PUBLIC
+                WindowsCaptureService
+                WindowsProcessService)
 else()
-target_link_libraries(OrbitServiceLib PUBLIC
-        CrashService
-        FramePointerValidatorService
-        LinuxCaptureService
-        ProcessService
-        TracepointService)
+        target_link_libraries(OrbitServiceLib PUBLIC
+                CrashService
+                FramePointerValidatorService
+                LinuxCaptureService
+                ProcessService
+                TracepointService)
 endif()
 
 project(OrbitService)

--- a/src/Statistics/CMakeLists.txt
+++ b/src/Statistics/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(Statistics STATIC)
 target_sources(Statistics PUBLIC
                 include/Statistics/BinomialConfidenceInterval.h
                 include/Statistics/DataSet.h
+                include/Statistics/Gaussian.h
                 include/Statistics/Histogram.h
                 include/Statistics/StatisticsUtils.h)
 
@@ -26,8 +27,10 @@ target_link_libraries(Statistics PRIVATE OrbitBase)
 
 add_executable(StatisticsTests)
 
-target_sources(StatisticsTests PRIVATE 
+target_sources(StatisticsTests PRIVATE
+          GaussianTest.cpp
           HistogramTest.cpp
+          StatisticsUtilTest.cpp
           WilsonBinomialConfidenceIntervalEstimatorTest.cpp)
 
 target_link_libraries(

--- a/src/Statistics/GaussianTest.cpp
+++ b/src/Statistics/GaussianTest.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <array>
+
+#include "Statistics/Gaussian.h"
+
+namespace orbit_statistics {
+
+using testing::DoubleNear;
+
+constexpr size_t kValuesCnt = 3;
+constexpr std::array<double, kValuesCnt> kValues = {0, 1.96, 100};
+constexpr std::array<double, kValuesCnt> kExpectedCDFValue = {0.5, 1 - 0.05 / 2, 1};
+
+TEST(GaussianTest, GaussianCDFIsCorrect) {
+  for (size_t i = 0; i < kValuesCnt; ++i) {
+    EXPECT_THAT(GaussianCDF(kValues[i]), DoubleNear(kExpectedCDFValue[i], 1e-3));
+
+    // Due to symmetry of Gaussian distribution
+    EXPECT_THAT(GaussianCDF(-kValues[i]), DoubleNear(1 - kExpectedCDFValue[i], 1e-3));
+  }
+}
+
+}  // namespace orbit_statistics

--- a/src/Statistics/StatisticsUtilTest.cpp
+++ b/src/Statistics/StatisticsUtilTest.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "Statistics/StatisticsUtils.h"
+
+namespace orbit_statistics {
+
+using testing::DoubleNear;
+
+static void ExpectMeanAndVarianceEq(const MeanAndVariance& actual,
+                                    const MeanAndVariance& expected) {
+  constexpr double kTolerance = 1e-3;
+  EXPECT_THAT(actual.mean, DoubleNear(expected.mean, kTolerance));
+  EXPECT_THAT(actual.variance, DoubleNear(expected.variance, kTolerance));
+}
+
+const MeanAndVariance kFirstRV = {2, 3};
+const MeanAndVariance kSecondRV = {4, 5};
+
+TEST(StatisticsUtilTest, ProductOfTwoIndependentIsCorrect) {
+  MeanAndVariance product = ProductOfTwoIndependent(kFirstRV, kSecondRV);
+  MeanAndVariance expected = {8.0, 83.0};
+  ExpectMeanAndVarianceEq(product, expected);
+}
+
+TEST(StatisticsUtilTest, DiffOfTwoIndependentIsCorrect) {
+  MeanAndVariance product = DiffOfTwoIndependent(kFirstRV, kSecondRV);
+  MeanAndVariance expected = {-2, 8};
+  ExpectMeanAndVarianceEq(product, expected);
+}
+
+}  // namespace orbit_statistics

--- a/src/Statistics/include/Statistics/Gaussian.h
+++ b/src/Statistics/include/Statistics/Gaussian.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef STATISTICS_GAUSSIAN_H_
+#define STATISTICS_GAUSSIAN_H_
+
+#include <cmath>
+
+namespace orbit_statistics {
+
+// Cumulative density function of the standard (zero mean, unit variance) Gaussian distribution.
+[[nodiscard]] inline double GaussianCDF(double x) { return std::erfc(-x / std::sqrt(2)) / 2; }
+
+}  // namespace orbit_statistics
+
+#endif  // STATISTICS_GAUSSIAN_H_

--- a/src/Statistics/include/Statistics/StatisticsUtils.h
+++ b/src/Statistics/include/Statistics/StatisticsUtils.h
@@ -20,6 +20,25 @@ namespace orbit_statistics {
   return std::max(interval.upper - rate, rate - interval.lower);
 }
 
+struct MeanAndVariance {
+  [[nodiscard]] double SecondMoment() const { return mean * mean + variance; }
+
+  double mean;
+  double variance;
+};
+
+[[nodiscard]] inline MeanAndVariance ProductOfTwoIndependent(const MeanAndVariance& x,
+                                                             const MeanAndVariance& y) {
+  const double product_of_means = x.mean * y.mean;
+  return {product_of_means,
+          x.SecondMoment() * y.SecondMoment() - product_of_means * product_of_means};
+}
+
+[[nodiscard]] inline MeanAndVariance DiffOfTwoIndependent(const MeanAndVariance& x,
+                                                          const MeanAndVariance& y) {
+  return {x.mean - y.mean, x.variance + y.variance};
+}
+
 }  // namespace orbit_statistics
 
-#endif /* STATISTICS_STATISTICS_UTILS_H_ */
+#endif  // STATISTICS_STATISTICS_UTILS_H_


### PR DESCRIPTION
This implements the statistical hypothesis testing method
that tests equality of the active invocation time of a function
in two captures.

Also this
1. Add operator* for Baseline<T> and Comparison<T>
2. Moves Baseline<T> and Comparison<T> (and their base class)
to BaselineOrComparison.h
3. Fixes a bug in MizarPairedData::ForAllCallstacks. The callstack
starts with innermost, not outermost.

Tests: Unit, Manual
Bug: http://b/236134257