### PR TITLE
Integrate custom protocol support into Orbit main

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -61,6 +61,14 @@ ABSL_FLAG(std::vector<std::string>, additional_symbol_paths, {},
           "Additional local symbol locations (comma-separated)");
 ABSL_FLAG(bool, launched_from_vsi, false, "Indicates Orbit was launched from VSI.");
 
+// TestHub custom protocol support
+ABSL_FLAG(std::string, target_uri, "",
+          "Target URI in the format orbitprofiler://instance?process. Specify this to skip the "
+          "connection setup and open the main window instead. If the process can't be found or "
+          "deployment is aborted by the user Orbit will exit with return code -1 immediately. "
+          "If multiple instances of the same process exist, the one with the highest PID will be "
+          "chosen.");
+
 // Clears QSettings. This is intended for e2e tests.
 ABSL_FLAG(bool, clear_settings, false,
           "Clears user defined settings. This includes symbol locations and source path mappings.");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -53,6 +53,9 @@ ABSL_DECLARE_FLAG(std::string, target_instance);
 ABSL_DECLARE_FLAG(std::vector<std::string>, additional_symbol_paths);
 ABSL_DECLARE_FLAG(bool, launched_from_vsi);
 
+// TestHub custom protocol support
+ABSL_DECLARE_FLAG(std::string, target_uri);
+
 // Clears QSettings. This is intended for e2e tests.
 ABSL_DECLARE_FLAG(bool, clear_settings);
 

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -364,6 +364,17 @@ int main(int argc, char* argv[]) {
                                                    QString::fromStdString(target_instance));
   }
 
+  const std::string& target_uri = absl::GetFlag(FLAGS_target_uri);
+  if (!target_uri.empty()) {
+    auto maybe_target = orbit_session_setup::SplitTargetUri(QString::fromStdString(target_uri));
+    if (!maybe_target.has_value()) {
+      ORBIT_LOG("Invalid target URI specified.");
+      DisplayErrorToUser("Invalid target URI specified.");
+      return -1;
+    }
+    target = maybe_target.value();
+  }
+
   if (capture_file_paths.size() > 0 && target.has_value()) {
     ORBIT_LOG(
         "Aborting startup: User specified a process and instance to connect to, and one or "


### PR DESCRIPTION
Adds support for Orbit to handle URI parameters in the format "orbitprofiler://instance?process".
This PR only adds the parameter `--target_uri` to Orbit.exe.

Bug: b/234550267
Test: Unit tests