### PR TITLE
Add FullyDecoded option to QUrl::query call

### DIFF
--- a/src/SessionSetup/SessionSetupUtils.cpp
+++ b/src/SessionSetup/SessionSetupUtils.cpp
@@ -56,7 +56,7 @@ std::optional<ConnectionTarget> SplitTargetUri(const QString& target_uri) {
   if (url.query().isEmpty()) return std::nullopt;
 
   const QString instance = url.authority() + url.path();
-  const QString process = url.query();
+  const QString process = url.query(QUrl::FullyDecoded);
 
   return ConnectionTarget(process, instance);
 }


### PR DESCRIPTION
We store the path to the binary in the query string. By specifying the
fullyDecoded flag we ensure that Qt decodes URL encoded characters from
for example `%2F` to `/`.