### PR TITLE
Add unwindstack::PeCoff::GetSizeOfImage

### DIFF
--- a/third_party/libunwindstack/PeCoff.cpp
+++ b/third_party/libunwindstack/PeCoff.cpp
@@ -118,6 +118,13 @@ uint64_t PeCoff::GetTextOffsetInFile() const {
   return interface_->GetTextOffsetInFile();
 }
 
+uint64_t PeCoff::GetSizeOfImage() const {
+  if (!valid_) {
+    return 0;
+  }
+  return interface_->GetSizeOfImage();
+}
+
 std::string PeCoff::GetBuildID() {
   // Not implemented, don't use.
   CHECK(false);

--- a/third_party/libunwindstack/PeCoffInterface.cpp
+++ b/third_party/libunwindstack/PeCoffInterface.cpp
@@ -551,6 +551,11 @@ uint64_t PeCoffInterfaceImpl<AddressType>::GetTextOffsetInFile() const {
 }
 
 template <typename AddressType>
+uint64_t PeCoffInterfaceImpl<AddressType>::GetSizeOfImage() const {
+  return optional_header_.image_size;
+}
+
+template <typename AddressType>
 bool PeCoffInterfaceImpl<AddressType>::Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs,
                                             Memory* process_memory, bool* finished,
                                             bool* is_signal_frame) {

--- a/third_party/libunwindstack/include/unwindstack/PeCoff.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoff.h
@@ -54,6 +54,7 @@ class PeCoff : public Object {
   int64_t GetLoadBias() override { return load_bias_; };
   bool GetTextRange(uint64_t* addr, uint64_t* size) override;
   uint64_t GetTextOffsetInFile() const;
+  uint64_t GetSizeOfImage() const;
 
   std::string GetBuildID() override;
   std::string GetSoname() override;

--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -155,6 +155,7 @@ class PeCoffInterface {
   virtual uint64_t GetRelPc(uint64_t pc, uint64_t map_start, uint64_t map_object_offset) = 0;
   virtual bool GetTextRange(uint64_t* addr, uint64_t* size) const = 0;
   virtual uint64_t GetTextOffsetInFile() const = 0;
+  virtual uint64_t GetSizeOfImage() const = 0;
   virtual bool Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
                     bool* finished, bool* is_signal_frame) = 0;
 };
@@ -178,6 +179,7 @@ class PeCoffInterfaceImpl : public PeCoffInterface {
   uint64_t GetRelPc(uint64_t pc, uint64_t map_start, uint64_t map_object_offset) override;
   bool GetTextRange(uint64_t* addr, uint64_t* size) const override;
   uint64_t GetTextOffsetInFile() const override;
+  uint64_t GetSizeOfImage() const override;
   bool Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
             bool* finished, bool* is_signal_frame) override;
 

--- a/third_party/libunwindstack/tests/PeCoffFake.cpp
+++ b/third_party/libunwindstack/tests/PeCoffFake.cpp
@@ -223,20 +223,20 @@ uint64_t PeCoffFake<PeCoffInterfaceType>::SetOptionalHeaderAtOffset(uint64_t off
   // image_base
   offset = SetMax64(offset, kLoadBiasFake, sizeof(typename PeCoffInterfaceType::AddressType));
 
-  offset = SetData32(offset, 0x1000);  // sect_alignment
-  offset = SetData32(offset, 0x200);   // file_alignment
-  offset = SetData16(offset, 0);       // major_os_system_version
-  offset = SetData16(offset, 0);       // minor_os_system_version
-  offset = SetData16(offset, 0);       // major_image_version
-  offset = SetData16(offset, 0);       // minor_image_version
-  offset = SetData16(offset, 0);       // major_subsystem_version
-  offset = SetData16(offset, 0);       // minor_subsystem_version
-  offset = SetData32(offset, 0);       // reserved1
-  offset = SetData32(offset, 0);       // image_size
-  offset = SetData32(offset, 0);       // header_size
-  offset = SetData32(offset, 0);       // checksum
-  offset = SetData16(offset, 0);       // subsystem
-  offset = SetData16(offset, 0);       // dll_flags
+  offset = SetData32(offset, 0x1000);        // sect_alignment
+  offset = SetData32(offset, 0x200);         // file_alignment
+  offset = SetData16(offset, 0);             // major_os_system_version
+  offset = SetData16(offset, 0);             // minor_os_system_version
+  offset = SetData16(offset, 0);             // major_image_version
+  offset = SetData16(offset, 0);             // minor_image_version
+  offset = SetData16(offset, 0);             // major_subsystem_version
+  offset = SetData16(offset, 0);             // minor_subsystem_version
+  offset = SetData32(offset, 0);             // reserved1
+  offset = SetData32(offset, kSizeOfImage);  // image_size
+  offset = SetData32(offset, 0);             // header_size
+  offset = SetData32(offset, 0);             // checksum
+  offset = SetData16(offset, 0);             // subsystem
+  offset = SetData16(offset, 0);             // dll_flags
 
   // stack_reserve_size
   offset = SetMax64(offset, 0, sizeof(typename PeCoffInterfaceType::AddressType));

--- a/third_party/libunwindstack/tests/PeCoffFake.h
+++ b/third_party/libunwindstack/tests/PeCoffFake.h
@@ -37,6 +37,9 @@ class PeCoffFake {
   // File offset for the new header.
   static constexpr uint64_t kNewHeaderOffsetValue = 0xF8;
 
+  // Size of the whole PE when loaded into memory.
+  static constexpr uint64_t kSizeOfImage = 0x10000;
+
   // Offset and size in the file of the .text section.
   static constexpr uint64_t kTextSectionFileOffset = 0x400;
   static constexpr uint64_t kTextSectionFileSize = 0x1000;

--- a/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
@@ -312,7 +312,7 @@ TYPED_TEST(PeCoffInterfaceTest, debug_frame_section_parsed_correctly) {
   ASSERT_EQ(dwarf_fde2, nullptr);
 }
 
-TYPED_TEST(PeCoffInterfaceTest, get_correct_relative_pc) {
+TYPED_TEST(PeCoffInterfaceTest, gets_correct_relative_pc) {
   this->GetFake()->Init();
   TypeParam coff(this->GetMemory());
   int64_t load_bias;
@@ -328,7 +328,7 @@ TYPED_TEST(PeCoffInterfaceTest, get_correct_relative_pc) {
             coff.GetRelPc(kAbsolutePc, kMapStart, PeCoffFake<TypeParam>::kTextSectionFileOffset));
 }
 
-TYPED_TEST(PeCoffInterfaceTest, get_zero_as_relative_pc_if_map_offset_outside_of_any_section) {
+TYPED_TEST(PeCoffInterfaceTest, gets_zero_as_relative_pc_if_map_offset_outside_of_any_section) {
   this->GetFake()->Init();
   TypeParam coff(this->GetMemory());
   int64_t load_bias;
@@ -345,7 +345,7 @@ TYPED_TEST(PeCoffInterfaceTest, get_zero_as_relative_pc_if_map_offset_outside_of
   EXPECT_EQ(0, coff.GetRelPc(kAbsolutePc2, kMapStart2, kMapOffset2));
 }
 
-TYPED_TEST(PeCoffInterfaceTest, get_correct_text_range) {
+TYPED_TEST(PeCoffInterfaceTest, gets_correct_text_range) {
   this->GetFake()->Init();
   TypeParam coff(this->GetMemory());
   int64_t load_bias;
@@ -359,7 +359,7 @@ TYPED_TEST(PeCoffInterfaceTest, get_correct_text_range) {
   EXPECT_EQ(actual_size, PeCoffFake<TypeParam>::kTextSectionMemorySize);
 }
 
-TYPED_TEST(PeCoffInterfaceTest, get_no_text_range_if_no_text_section) {
+TYPED_TEST(PeCoffInterfaceTest, gets_no_text_range_if_no_text_section) {
   uint64_t offset = this->GetFake()->InitNoSectionHeaders();
   offset = this->GetFake()->SetSectionHeaderAtOffset(offset, ".no_text");
   this->GetMemory()->SetData16(this->GetFake()->coff_header_nsects_offset(), 1);
@@ -382,7 +382,7 @@ TYPED_TEST(PeCoffInterfaceTest, get_correct_text_offset_in_file) {
   EXPECT_EQ(coff.GetTextOffsetInFile(), PeCoffFake<TypeParam>::kTextSectionFileOffset);
 }
 
-TYPED_TEST(PeCoffInterfaceTest, get_zero_text_offset_in_file_if_no_text_section) {
+TYPED_TEST(PeCoffInterfaceTest, gets_zero_text_offset_in_file_if_no_text_section) {
   uint64_t offset = this->GetFake()->InitNoSectionHeaders();
   offset = this->GetFake()->SetSectionHeaderAtOffset(offset, ".no_text", 1, 2, 3, 4);
   this->GetMemory()->SetData16(this->GetFake()->coff_header_nsects_offset(), 1);
@@ -394,7 +394,7 @@ TYPED_TEST(PeCoffInterfaceTest, get_zero_text_offset_in_file_if_no_text_section)
   EXPECT_EQ(coff.GetTextOffsetInFile(), 0);
 }
 
-TYPED_TEST(PeCoffInterfaceTest, get_correct_size_of_image) {
+TYPED_TEST(PeCoffInterfaceTest, gets_correct_size_of_image) {
   this->GetFake()->Init();
   TypeParam coff(this->GetMemory());
   int64_t load_bias;

--- a/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffInterfaceTest.cpp
@@ -394,6 +394,14 @@ TYPED_TEST(PeCoffInterfaceTest, get_zero_text_offset_in_file_if_no_text_section)
   EXPECT_EQ(coff.GetTextOffsetInFile(), 0);
 }
 
+TYPED_TEST(PeCoffInterfaceTest, get_correct_size_of_image) {
+  this->GetFake()->Init();
+  TypeParam coff(this->GetMemory());
+  int64_t load_bias;
+  ASSERT_TRUE(coff.Init(&load_bias));
+  EXPECT_EQ(coff.GetSizeOfImage(), PeCoffFake<TypeParam>::kSizeOfImage);
+}
+
 template <typename AddressType>
 class PeCoffInterfaceFake : public PeCoffInterfaceImpl<AddressType> {
  public:


### PR DESCRIPTION
Simply returns `SizeOfImage` from the headers of the PE. It will be used to
relax the conditions of
`MapInfo::GetFileMemoryFromAnonExecMapIfPeCoffTextSection` in order to support
multiple anonymous executable maps (usually from multiple executable sections).

Bug: http://b/235480245

Test: Add unit tests.