### PR TITLE
Accept single-frame callstacks for functions requested to stop at

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -131,6 +131,25 @@ void UprobesUnwindingVisitor::SendFullAddressInfoToListener(
   listener_->OnAddressInfo(std::move(address_info));
 }
 
+static inline bool IsPcInFunctionsToStop(
+    const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at,
+    uint64_t pc) {
+  if (absolute_address_to_size_of_functions_to_stop_at == nullptr) {
+    return false;
+  }
+  auto function_it = absolute_address_to_size_of_functions_to_stop_at->upper_bound(pc);
+  if (function_it == absolute_address_to_size_of_functions_to_stop_at->begin()) {
+    return false;
+  }
+
+  --function_it;
+
+  uint64_t function_start = function_it->first;
+  ORBIT_CHECK(function_start <= pc);
+  uint64_t size = function_it->second;
+  return (pc < function_start + size);
+}
+
 orbit_grpc_protos::Callstack::CallstackType
 UprobesUnwindingVisitor::ComputeCallstackTypeFromStackSample(
     const LibunwindstackResult& libunwindstack_result) {
@@ -174,13 +193,18 @@ UprobesUnwindingVisitor::ComputeCallstackTypeFromStackSample(
     }
     return Callstack::kCallstackPatchingFailed;
   }
-  if (!libunwindstack_result.IsSuccess() || libunwindstack_result.frames().size() == 1) {
+  if (!libunwindstack_result.IsSuccess() ||
+      (libunwindstack_result.frames().size() == 1 &&
+       !IsPcInFunctionsToStop(absolute_address_to_size_of_functions_to_stop_at_,
+                   libunwindstack_result.frames().at(0).pc))) {
     // Callstacks with only one frame (the sampled address) are also unwinding errors, that were not
     // reported as such by LibunwindstackUnwinder::Unwind.
     // Note that this doesn't exclude samples inside the main function of any thread as the main
     // function is never the outermost frame. For example, for the main thread the outermost
     // function is _start, followed by __libc_start_main. For other threads, the outermost function
     // is clone.
+    // The only exception are callstacks where the single frame is inside a function we forced the
+    // unwinder to stop at (e.g. __wine_syscall_dispatcher).
     if (unwind_error_counter_ != nullptr) {
       ++(*unwind_error_counter_);
     }

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -131,7 +131,7 @@ void UprobesUnwindingVisitor::SendFullAddressInfoToListener(
   listener_->OnAddressInfo(std::move(address_info));
 }
 
-static inline bool IsPcInFunctionsToStop(
+static inline bool IsPcInFunctionsToStopAt(
     const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at,
     uint64_t pc) {
   if (absolute_address_to_size_of_functions_to_stop_at == nullptr) {
@@ -195,8 +195,8 @@ UprobesUnwindingVisitor::ComputeCallstackTypeFromStackSample(
   }
   if (!libunwindstack_result.IsSuccess() ||
       (libunwindstack_result.frames().size() == 1 &&
-       !IsPcInFunctionsToStop(absolute_address_to_size_of_functions_to_stop_at_,
-                   libunwindstack_result.frames().at(0).pc))) {
+       !IsPcInFunctionsToStopAt(absolute_address_to_size_of_functions_to_stop_at_,
+                                libunwindstack_result.frames().at(0).pc))) {
     // Callstacks with only one frame (the sampled address) are also unwinding errors, that were not
     // reported as such by LibunwindstackUnwinder::Unwind.
     // Note that this doesn't exclude samples inside the main function of any thread as the main

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -50,7 +50,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
       UprobesReturnAddressManager* uprobes_return_address_manager, LibunwindstackMaps* initial_maps,
       LibunwindstackUnwinder* unwinder, LeafFunctionCallManager* leaf_function_call_manager,
       UserSpaceInstrumentationAddresses* user_space_instrumentation_addresses,
-      const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at = nullptr)
+      const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at =
+          nullptr /*TODO(kuebler): Don't make this parameter default*/)
       : listener_{listener},
         function_call_manager_{function_call_manager},
         return_address_manager_{uprobes_return_address_manager},

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -49,14 +49,17 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
       TracerListener* listener, UprobesFunctionCallManager* function_call_manager,
       UprobesReturnAddressManager* uprobes_return_address_manager, LibunwindstackMaps* initial_maps,
       LibunwindstackUnwinder* unwinder, LeafFunctionCallManager* leaf_function_call_manager,
-      UserSpaceInstrumentationAddresses* user_space_instrumentation_addresses)
+      UserSpaceInstrumentationAddresses* user_space_instrumentation_addresses,
+      const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at = nullptr)
       : listener_{listener},
         function_call_manager_{function_call_manager},
         return_address_manager_{uprobes_return_address_manager},
         current_maps_{initial_maps},
         unwinder_{unwinder},
         leaf_function_call_manager_{leaf_function_call_manager},
-        user_space_instrumentation_addresses_{user_space_instrumentation_addresses} {
+        user_space_instrumentation_addresses_{user_space_instrumentation_addresses},
+        absolute_address_to_size_of_functions_to_stop_at_{
+            absolute_address_to_size_of_functions_to_stop_at} {
     ORBIT_CHECK(listener_ != nullptr);
     ORBIT_CHECK(function_call_manager_ != nullptr);
     ORBIT_CHECK(return_address_manager_ != nullptr);
@@ -115,6 +118,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   LeafFunctionCallManager* leaf_function_call_manager_;
 
   UserSpaceInstrumentationAddresses* user_space_instrumentation_addresses_;
+
+  const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at_;
 
   std::atomic<uint64_t>* unwind_error_counter_ = nullptr;
   std::atomic<uint64_t>* samples_in_uretprobes_counter_ = nullptr;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -68,10 +68,6 @@ class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
               (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
                const void*, uint64_t, bool, size_t),
               (override));
-  MOCK_METHOD(LibunwindstackResult, Unwind,
-              (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
-               const void*, uint64_t, const void*, uint64_t, uint64_t, bool, size_t),
-              (override));
   MOCK_METHOD(std::optional<bool>, HasFramePointerSet, (uint64_t, pid_t, unwindstack::Maps*),
               (override));
 };

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -889,7 +889,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 }
 
 TEST_F(UprobesUnwindingVisitorTest,
-       VisitSingleFrameStackSampleOutsideAnyFunctionToStopSendsUnwindingErrorAndAddressInfos) {
+       VisitSingleFrameStackSampleOutsideOfAnyFunctionToStopAtSendsUnwindingErrorAndAddressInfos) {
   StackSamplePerfEvent event = BuildFakeStackSamplePerfEvent();
 
   absolute_address_to_size_of_functions_to_stop_at_[kTargetAddress2] = 100;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -843,9 +843,8 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
 }
 
-TEST_F(
-    UprobesUnwindingVisitorTest,
-    VisitSingleFrameStackSampleInFunctionToStopWithoutUprobesSendsCompleteCallstackAndAddressInfos) {
+TEST_F(UprobesUnwindingVisitorTest,
+       VisitSingleFrameStackSampleInFunctionToStopAtSendsCompleteCallstackAndAddressInfos) {
   StackSamplePerfEvent event = BuildFakeStackSamplePerfEvent();
 
   absolute_address_to_size_of_functions_to_stop_at_[kTargetAddress1] = 100;
@@ -889,9 +888,8 @@ TEST_F(
   EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
 }
 
-TEST_F(
-    UprobesUnwindingVisitorTest,
-    VisitSingleFrameStackSamplOutsideAFunctionToStopWithoutUprobesSendsUnwindingErrroAndAddressInfos) {
+TEST_F(UprobesUnwindingVisitorTest,
+       VisitSingleFrameStackSampleOutsideAnyFunctionToStopSendsUnwindingErrorAndAddressInfos) {
   StackSamplePerfEvent event = BuildFakeStackSamplePerfEvent();
 
   absolute_address_to_size_of_functions_to_stop_at_[kTargetAddress2] = 100;


### PR DESCRIPTION
Before this change, we were always expecting at least two frames for
a complete callstack. However, since we want to  be able to stop
unwinding at certain functions (in particular
__wine_syscall_dispatcher), we don't want to mark single-frame
callstacks in those functions as unwinding errors.

Bug: http://b/236121587
Test: Unit test