### PR TITLE
Detect multiple anonymous executable PE maps in MapInfo::GetObject

### DIFF
--- a/third_party/libunwindstack/PeCoff.cpp
+++ b/third_party/libunwindstack/PeCoff.cpp
@@ -155,7 +155,10 @@ uint64_t PeCoff::GetRelPc(uint64_t pc, MapInfo* map_info) {
   if (!valid_) {
     return 0;
   }
-  return interface_->GetRelPc(pc, map_info->start(), map_info->object_offset());
+  if (map_info->object_offset() == 0 && map_info->object_rva() != 0) {
+    return interface_->GetRelPcWithMapRva(pc, map_info->start(), map_info->object_rva());
+  }
+  return interface_->GetRelPcWithMapOffset(pc, map_info->start(), map_info->object_offset());
 }
 
 bool PeCoff::StepIfSignalHandler(uint64_t, Regs*, Memory*) {

--- a/third_party/libunwindstack/PeCoffInterface.cpp
+++ b/third_party/libunwindstack/PeCoffInterface.cpp
@@ -521,13 +521,19 @@ bool PeCoffInterfaceImpl<uint32_t>::InitNativeUnwinder() {
 }
 
 template <typename AddressType>
-uint64_t PeCoffInterfaceImpl<AddressType>::GetRelPc(uint64_t pc, uint64_t map_start,
-                                                    uint64_t map_object_offset) {
+uint64_t PeCoffInterfaceImpl<AddressType>::GetRelPcWithMapOffset(uint64_t pc, uint64_t map_start,
+                                                                 uint64_t map_object_offset) {
   uint64_t map_rva;
   if (!MapFromFileOffsetToRva(map_object_offset, &map_rva)) {
     return 0;
   }
   return pc - map_start + optional_header_.image_base + map_rva;
+}
+
+template <typename AddressType>
+uint64_t PeCoffInterfaceImpl<AddressType>::GetRelPcWithMapRva(uint64_t pc, uint64_t map_start,
+                                                              uint64_t map_object_rva) {
+  return pc - map_start + optional_header_.image_base + map_object_rva;
 }
 
 template <typename AddressType>

--- a/third_party/libunwindstack/include/unwindstack/MapInfo.h
+++ b/third_party/libunwindstack/include/unwindstack/MapInfo.h
@@ -87,6 +87,11 @@ class MapInfo {
     // start of the elf. This is not equal to offset when the linker splits
     // shared libraries into a read-only and read-execute map.
     uint64_t object_start_offset_ = 0;
+    // The Relative Virtual Address of the beginning of this mapping. In other words, the offset in
+    // memory of the beginning of this mapping relative to the address in memory where the beginning
+    // of the file is mapped (base address). Only applies to anonymous executable mappings that
+    // belong to PEs as the alternative to object_offset_, which is not available for such mappings.
+    uint64_t object_rva_ = 0;
 
     std::atomic_uint64_t load_bias_;
 
@@ -161,6 +166,9 @@ class MapInfo {
   inline void set_object_start_offset(uint64_t value) {
     GetObjectFields().object_start_offset_ = value;
   }
+
+  inline uint64_t object_rva() { return GetObjectFields().object_rva_; }
+  inline void set_object_rva(uint64_t value) { GetObjectFields().object_rva_ = value; }
 
   inline std::atomic_uint64_t& load_bias() { return GetObjectFields().load_bias_; }
   inline void set_load_bias(uint64_t value) { GetObjectFields().load_bias_ = value; }

--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -152,7 +152,9 @@ class PeCoffInterface {
   virtual ErrorCode LastErrorCode() = 0;
   virtual uint64_t LastErrorAddress() = 0;
   virtual DwarfSection* DebugFrameSection() = 0;
-  virtual uint64_t GetRelPc(uint64_t pc, uint64_t map_start, uint64_t map_object_offset) = 0;
+  virtual uint64_t GetRelPcWithMapOffset(uint64_t pc, uint64_t map_start,
+                                         uint64_t map_object_offset) = 0;
+  virtual uint64_t GetRelPcWithMapRva(uint64_t pc, uint64_t map_start, uint64_t map_object_rva) = 0;
   virtual bool GetTextRange(uint64_t* addr, uint64_t* size) const = 0;
   virtual uint64_t GetTextOffsetInFile() const = 0;
   virtual uint64_t GetSizeOfImage() const = 0;
@@ -176,7 +178,9 @@ class PeCoffInterfaceImpl : public PeCoffInterface {
   uint64_t LastErrorAddress() override { return last_error_.address; }
 
   DwarfSection* DebugFrameSection() override { return debug_frame_.get(); }
-  uint64_t GetRelPc(uint64_t pc, uint64_t map_start, uint64_t map_object_offset) override;
+  uint64_t GetRelPcWithMapOffset(uint64_t pc, uint64_t map_start,
+                                 uint64_t map_object_offset) override;
+  uint64_t GetRelPcWithMapRva(uint64_t pc, uint64_t map_start, uint64_t map_object_rva) override;
   bool GetTextRange(uint64_t* addr, uint64_t* size) const override;
   uint64_t GetTextOffsetInFile() const override;
   uint64_t GetSizeOfImage() const override;

--- a/third_party/libunwindstack/tests/MapInfoCreateMemoryTest.cpp
+++ b/third_party/libunwindstack/tests/MapInfoCreateMemoryTest.cpp
@@ -516,6 +516,7 @@ TYPED_TEST(MapInfoCreateMemoryForPeTest, correctly_initializes_memory_for_pe) {
     EXPECT_NE(memory, nullptr);
     EXPECT_EQ(map_info->object_offset(), 0);
     EXPECT_EQ(map_info->object_start_offset(), 0);
+    EXPECT_EQ(map_info->object_rva(), 0);
     EXPECT_FALSE(map_info->memory_backed_object());
   }
   {
@@ -524,6 +525,7 @@ TYPED_TEST(MapInfoCreateMemoryForPeTest, correctly_initializes_memory_for_pe) {
     EXPECT_NE(memory, nullptr);
     EXPECT_EQ(map_info->object_offset(), 0x1000);
     EXPECT_EQ(map_info->object_start_offset(), 0);
+    EXPECT_EQ(map_info->object_rva(), 0);
     EXPECT_FALSE(map_info->memory_backed_object());
   }
 }

--- a/third_party/libunwindstack/tests/PeCoffTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffTest.cpp
@@ -37,7 +37,8 @@ class MockPeCoffInterface : public PeCoffInterface {
   MOCK_METHOD(ErrorCode, LastErrorCode, (), (override));
   MOCK_METHOD(uint64_t, LastErrorAddress, (), (override));
   MOCK_METHOD(DwarfSection*, DebugFrameSection, (), (override));
-  MOCK_METHOD(uint64_t, GetRelPc, (uint64_t, uint64_t, uint64_t), (override));
+  MOCK_METHOD(uint64_t, GetRelPcWithMapOffset, (uint64_t, uint64_t, uint64_t), (override));
+  MOCK_METHOD(uint64_t, GetRelPcWithMapRva, (uint64_t, uint64_t, uint64_t), (override));
   MOCK_METHOD(bool, GetTextRange, (uint64_t*, uint64_t*), (const override));
   MOCK_METHOD(uint64_t, GetTextOffsetInFile, (), (const override));
   MOCK_METHOD(uint64_t, GetSizeOfImage, (), (const override));
@@ -134,7 +135,7 @@ TYPED_TEST(PeCoffTest, getting_global_variable_offset_aborts) {
   ASSERT_DEATH(coff.GetGlobalVariableOffset("", nullptr), "");
 }
 
-TYPED_TEST(PeCoffTest, rel_pc_is_correctly_passed_through) {
+TYPED_TEST(PeCoffTest, rel_pc_is_computed_using_offset_and_correctly_passed_through) {
   this->GetFake()->Init();
   FakePeCoff coff(this->ReleaseMemory());
   EXPECT_TRUE(coff.Init());
@@ -146,15 +147,38 @@ TYPED_TEST(PeCoffTest, rel_pc_is_correctly_passed_through) {
 
   // This test is not testing whether the GetRelPc computation is correct, only whether the
   // return value from PeCoffInterface::GetRelPc is correctly passed through.
-  constexpr uint64_t kMockReturnValue = 0x3000;
+  constexpr uint64_t kMockRelPc = 0x3000;
   MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
-  EXPECT_CALL(*mock_interface, GetRelPc(kPcValue, kMapStart, kMapObjectOffset))
-      .WillOnce(::testing::Return(kMockReturnValue));
+  EXPECT_CALL(*mock_interface, GetRelPcWithMapOffset(kPcValue, kMapStart, kMapObjectOffset))
+      .WillOnce(::testing::Return(kMockRelPc));
+  EXPECT_CALL(*mock_interface, GetRelPcWithMapRva).Times(0);
   coff.SetFakePeCoffInterface(mock_interface);
 
-  auto map_info = MapInfo::Create(/*start=*/kMapStart, /*end=*/kMapEnd, 0, 0, "no_name");
+  auto map_info = MapInfo::Create(kMapStart, kMapEnd, 0, 0, "no_name");
   map_info->set_object_offset(kMapObjectOffset);
-  EXPECT_EQ(kMockReturnValue, coff.GetRelPc(kPcValue, map_info.get()));
+  EXPECT_EQ(kMockRelPc, coff.GetRelPc(kPcValue, map_info.get()));
+}
+
+TYPED_TEST(PeCoffTest, rel_pc_is_computed_using_rva_and_correctly_passed_through) {
+  this->GetFake()->Init();
+  FakePeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
+
+  constexpr uint64_t kPcValue = 0x2000;
+  constexpr uint64_t kMapStart = 0x1000;
+  constexpr uint64_t kMapEnd = 0x4000;
+  constexpr uint64_t kMapObjectRva = 0x3000;
+
+  constexpr uint64_t kMockRelPc = 0x3000;
+  MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
+  EXPECT_CALL(*mock_interface, GetRelPcWithMapOffset).Times(0);
+  EXPECT_CALL(*mock_interface, GetRelPcWithMapRva(kPcValue, kMapStart, kMapObjectRva))
+      .WillOnce(::testing::Return(kMockRelPc));
+  coff.SetFakePeCoffInterface(mock_interface);
+
+  auto map_info = MapInfo::Create(kMapStart, kMapEnd, 0, 0, "no_name");
+  map_info->set_object_rva(kMapObjectRva);
+  EXPECT_EQ(kMockRelPc, coff.GetRelPc(kPcValue, map_info.get()));
 }
 
 TYPED_TEST(PeCoffTest, rel_pc_is_zero_for_invalid) {


### PR DESCRIPTION
https://github.com/google/orbit/pull/3590 added the detection of anonymous
executable maps that belong to PEs with a file alignment incompatible with
`mmap`: this is done in
`MapInfo::GetFileMemoryFromAnonExecMapIfPeCoffTextSection`. The detection could
be quite strict by assuming that a PE only has one executable section. We
observed that this doesn't always hold, so we need to relax some conditions. Now
we simply accept any anonymous executable map that lies inside the address range
of size `PeCoff::GetSizeOfImage()` that starts at the first address at which the
PE is mapped. This logic is similar to what is done in
`orbit_object_utils::ParseMaps` after https://github.com/google/orbit/pull/3786.

The start of these maps doesn't necessarily correspond to an offset in the file:
not only because an anonymous map doesn't have an offset by definition, but
especially because the start of the anonymous map could correspond to no byte in
the file.
But `MapInfo::object_offset()` is needed to compute the relative PC from a PC.
To support this case, we add `MapInfo::object_rva()` and make `PeCoff::GetRelPc`
choose what to use. In all other cases (file mappings, ELF files),
`MapInfo::object_rva()` is zero and `MapInfo::object_offset()` applies as
before.

Bug: http://b/235480245

Test:
- Adjusted `MapInfoGetObjectTest.cpp`.
- Tried on `triangle.exe`: already worked fine before, still works.
- Tried on complex Silenus game that highlighted the problem. Together with
  https://github.com/google/orbit/pull/3791, unwinding errors are basically gone
  (except for the ones related to `__wine_syscall_dispatcher`, as usual).