### PR TITLE
Dont show symbol stop dialog on capture start

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -585,6 +585,9 @@ class OrbitApp final : public DataViewFactory,
   void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
                      uint64_t scope_id) override;
 
+  void RequestSymbolDownloadStop(absl::Span<const orbit_client_data::ModuleData* const> modules,
+                                 bool show_dialog);
+
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<orbit_client_data::CaptureData::DataSource> data_source_{
       orbit_client_data::CaptureData::DataSource::kLiveCapture};


### PR DESCRIPTION
This adds an private overload to OrbitApp::RequestSymbolDownloadStop
with another bool parameter `show_dialog`. When this is called on
capture start, the parameter is set to false.

Test Manual: Checkout PR, start with devmode, start capture while
symbols are still loading. (Before commit: dialog is shown; after
after commit: no dialog is shown)
Bug: http://b/236364198