### PR TITLE
Ignore instrumentation events from threads spawned by injected lib.

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -125,16 +125,16 @@ ErrorMessageOr<MachineCode> MachineCodeForCloneCall(pid_t pid, void* library_han
               DlsymInTracee(pid, library_handle, kInitializeInstrumentationFunctionName));
   MachineCode code;
   code.AppendBytes({0x48, 0xbf})
-      .AppendImmediate64(kCloneFlags)  // mov kCloneFlags, rdi
+      .AppendImmediate64(kCloneFlags)  // mov rdi, kCloneFlags
       .AppendBytes({0x48, 0xbe})
-      .AppendImmediate64(top_of_stack)  // mov top_of_stack, rsi
+      .AppendImmediate64(top_of_stack)  // mov rsi, top_of_stack
       .AppendBytes({0x48, 0xba})
-      .AppendImmediate64(0x0)  // mov parent_tid, rdx
+      .AppendImmediate64(0x0)  // mov rdx, parent_tid
       .AppendBytes({0x49, 0xba})
-      .AppendImmediate64(0x0)  // mov child_tid, r10
+      .AppendImmediate64(0x0)  // mov r10, child_tid
       .AppendBytes({0x49, 0xb8})
-      .AppendImmediate64(0x0)           // mov tls, r8
-      .AppendBytes({0x48, 0xc7, 0xc0})  // mov kSyscallNumberClone, rax
+      .AppendImmediate64(0x0)           // mov r8, tls
+      .AppendBytes({0x48, 0xc7, 0xc0})  // mov rax, kSyscallNumberClone
       .AppendImmediate32(kSyscallNumberClone)
       .AppendBytes({0x0f, 0x05})                          // syscall (clone)
       .AppendBytes({0x48, 0x85, 0xc0})                    // testq	rax, rax
@@ -142,10 +142,10 @@ ErrorMessageOr<MachineCode> MachineCodeForCloneCall(pid_t pid, void* library_han
       .AppendBytes({0xcc})                                // int3
       .AppendBytes({0x48, 0xb8})
       .AppendImmediate64(absl::bit_cast<uint64_t>(
-          initialize_instrumentation_function_address))  // mov initialize_instrumentation, rax
+          initialize_instrumentation_function_address))  // mov rax, initialize_instrumentation
       .AppendBytes({0xff, 0xd0})                         // call rax
-      .AppendBytes({0x48, 0xc7, 0xc7, 0x00, 0x00, 0x00, 0x00})  // mov 0x0, rdi
-      .AppendBytes({0x48, 0xc7, 0xc0})                          // mov kSyscallNumberExit, rax
+      .AppendBytes({0x48, 0xc7, 0xc7, 0x00, 0x00, 0x00, 0x00})  // mov rdi, 0x0
+      .AppendBytes({0x48, 0xc7, 0xc0})                          // mov rax, kSyscallNumberExit
       .AppendImmediate32(kSyscallNumberExit)
       .AppendBytes({0x0f, 0x05});  // syscall (exit)
   return code;
@@ -168,7 +168,7 @@ ErrorMessageOr<void> WaitForThreadToExit(pid_t pid, pid_t tid) {
   return outcome::success();
 }
 
-// These are the names of the threads that we will be spawned when
+// These are the names of the threads that will be spawned when
 // liborbituserspaceinstrumentation.so is injected into the target process.
 std::multiset<std::string> GetExpectedOrbitThreadNames() {
   static const std::multiset<std::string> kThreadNames{"default-executo", "resolver-execut",

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -4,9 +4,6 @@
 
 #include "OrbitUserSpaceInstrumentation.h"
 
-#include <sys/types.h>
-
-#include <cstdint>
 #include <stack>
 #include <variant>
 
@@ -36,6 +33,8 @@ std::stack<OpenFunctionCall>& GetOpenFunctionCallStack() {
 }
 
 uint64_t current_capture_start_timestamp_ns = 0;
+
+pid_t orbit_threads[] = {-1, -1, -1, -1, -1, -1};
 
 // Don't use the orbit_grpc_protos::FunctionEntry and orbit_grpc_protos::FunctionExit protos
 // directly. While in memory those protos are basically plain structs as their fields are all
@@ -134,18 +133,21 @@ bool& GetIsInPayload() {
 
 }  // namespace
 
+// Initialize the LockFreeUserSpaceInstrumentationEventProducer and establish the connection to
+// OrbitService.
+void InitializeInstrumentation() { GetCaptureEventProducer(); }
+
+void SetOrbitThreads(pid_t tid_0, pid_t tid_1, pid_t tid_2, pid_t tid_3, pid_t tid_4, pid_t tid_5) {
+  orbit_threads[0] = tid_0;
+  orbit_threads[1] = tid_1;
+  orbit_threads[2] = tid_2;
+  orbit_threads[3] = tid_3;
+  orbit_threads[4] = tid_4;
+  orbit_threads[5] = tid_5;
+}
+
 void StartNewCapture(uint64_t capture_start_timestamp_ns) {
   current_capture_start_timestamp_ns = capture_start_timestamp_ns;
-
-  // If the library has just been injected, initialize the
-  // LockFreeUserSpaceInstrumentationEventProducer and establish the connection to OrbitService now
-  // instead of waiting for the first call to EntryPayload. As it takes a bit to
-  // establish the connection, GetCaptureEventProducer().IsCapturing() would otherwise always be
-  // false in the first call to EntryPayload, which would cause the first function call to be missed
-  // even if the time between StartNewCapture() and the first function call is large.
-  // TODO(b/205939288): The fix involving calling GetCaptureEventProducer() here was removed because
-  //  of b/209560448 (we could have interrupted a malloc, which is not re-entrant, so we need to
-  //  avoid any memory allocation). Re-add the call once we have a solution to allow re-entrancy.
 }
 
 void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer,
@@ -158,16 +160,24 @@ void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_
   }
   is_in_payload = true;
 
+  thread_local const pid_t tid = orbit_base::GetCurrentProcessIdNative();
+
+  if (tid == orbit_threads[0] || tid == orbit_threads[1] || tid == orbit_threads[2] ||
+      tid == orbit_threads[3] || tid == orbit_threads[4] || tid == orbit_threads[5]) {
+    is_in_payload = false;
+    return;
+  }
+
   const uint64_t timestamp_on_entry_ns = CaptureTimestampNs();
 
   std::stack<OpenFunctionCall>& open_function_call_stack = GetOpenFunctionCallStack();
   open_function_call_stack.emplace(return_address, timestamp_on_entry_ns);
 
   if (GetCaptureEventProducer().IsCapturing()) {
-    static uint32_t pid = orbit_base::GetCurrentProcessId();
-    thread_local uint32_t tid = orbit_base::GetCurrentThreadId();
+    static const uint32_t pid = orbit_base::GetCurrentProcessId();
     GetCaptureEventProducer().EnqueueIntermediateEvent(
-        FunctionEntry{pid, tid, function_id, stack_pointer, return_address, timestamp_on_entry_ns});
+        FunctionEntry{pid, orbit_base::FromNativeThreadId(tid), function_id, stack_pointer,
+                      return_address, timestamp_on_entry_ns});
   }
 
   // Overwrite return address so that we end up returning to the exit trampoline.

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -160,7 +160,7 @@ void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_
   }
   is_in_payload = true;
 
-  thread_local const pid_t tid = orbit_base::GetCurrentProcessIdNative();
+  thread_local const pid_t tid = orbit_base::GetCurrentThreadIdNative();
 
   if (tid == orbit_threads[0] || tid == orbit_threads[1] || tid == orbit_threads[2] ||
       tid == orbit_threads[3] || tid == orbit_threads[4] || tid == orbit_threads[5]) {

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
@@ -5,11 +5,24 @@
 #ifndef ORBIT_USER_SPACE_INSTRUMENTATION_H_
 #define ORBIT_USER_SPACE_INSTRUMENTATION_H_
 
+#include <sys/types.h>
+
 #include <cstdint>
 
 // Needs to be called when a capture starts. `capture_start_timestamp_ns` should be a current
 // timestamp as obtained from orbit_base::CaptureTimestampNs.
 extern "C" void StartNewCapture(uint64_t capture_start_timestamp_ns);
+
+// InitializeInstrumentation needs to be called once after this library is injected into the target
+// process. It sets up the communication to OrbitService.
+extern "C" void InitializeInstrumentation();
+
+// We'll spawn six threads when injecting this library. This happens immediatly after the call to
+// InitializeInstrumentation above. These threads facilitate the grpc communication with
+// OrbitService. OrbitService will detect the threads and call SetOrbitThreads to set the thread ids
+// such that events from these threads can be ignored in EntryPayload.
+extern "C" void SetOrbitThreads(pid_t tid_0, pid_t tid_1, pid_t tid_2, pid_t tid_3, pid_t tid_4,
+                                pid_t tid_5);
 
 // Payload called on entry of an instrumented function. Needs to record the return address of the
 // function (in order to have it available in `ExitPayload`) and the stack pointer (i.e., the


### PR DESCRIPTION
Directly after the injection of the library we create a new thread using the
clone syscall and execute the initialization code in this thread.

We resume the execution of the game and allow the initlization to happen. After
that we detect the newly spawned threads, attach again to the target and set
the tids in the lib so that we can ignore these threads in EntryPayload.

The bug contains some additional context.

Bug: b/236121842
Test: Covered by existing unit tests. Also manual testing with several
targets.