### PR TITLE
Receive "functions to stop at" in LinuxTracing

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -39,7 +39,7 @@ message ApiFunction {
   uint64 api_version = 5;
 }
 
-// NextId: 19
+// NextId: 20
 message CaptureOptions {
   reserved 17;
 
@@ -64,6 +64,7 @@ message CaptureOptions {
   DynamicInstrumentationMethod dynamic_instrumentation_method = 18;
 
   repeated InstrumentedFunction instrumented_functions = 5;
+  map<uint64, uint64> absolute_address_to_size_of_functions_to_stop_at = 19;
 
   bool trace_thread_state = 8;
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -67,6 +67,10 @@ class StackAndProcessMemory : public unwindstack::Memory {
 
 class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
  public:
+  LibunwindstackUnwinderImpl(
+      const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at)
+      : absolute_address_to_size_of_functions_to_stop_at_{
+            absolute_address_to_size_of_functions_to_stop_at} {}
   LibunwindstackResult Unwind(pid_t pid, unwindstack::Maps* maps,
                               const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
                               const void* stack_dump, uint64_t stack_dump_size,
@@ -83,6 +87,8 @@ class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
       debug_frame_loc_regs_cache_;  // Single row indexed by pc_end.
   std::map<uint64_t, unwindstack::DwarfLocations>
       eh_frame_loc_regs_cache_;  // Single row indexed by pc_end.
+
+  const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at_;
 };
 
 const std::array<size_t, unwindstack::X86_64_REG_LAST>
@@ -114,7 +120,7 @@ LibunwindstackResult LibunwindstackUnwinderImpl::Unwind(
 
   unwindstack::Unwinder unwinder{max_frames, maps, &regs, memory};
   // Careful: regs are modified. Use regs.Clone() if you need to reuse regs later.
-  unwinder.Unwind();
+  unwinder.Unwind(nullptr, nullptr, absolute_address_to_size_of_functions_to_stop_at_);
 
 #ifndef NDEBUG
   if (unwinder.LastErrorCode() != 0) {
@@ -222,8 +228,10 @@ std::optional<bool> LibunwindstackUnwinderImpl::HasFramePointerSet(uint64_t inst
 }
 }  // namespace
 
-std::unique_ptr<LibunwindstackUnwinder> LibunwindstackUnwinder::Create() {
-  return std::make_unique<LibunwindstackUnwinderImpl>();
+std::unique_ptr<LibunwindstackUnwinder> LibunwindstackUnwinder::Create(
+    const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at) {
+  return std::make_unique<LibunwindstackUnwinderImpl>(
+      absolute_address_to_size_of_functions_to_stop_at);
 }
 
 std::string LibunwindstackUnwinder::LibunwindstackErrorString(unwindstack::ErrorCode error_code) {

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -61,7 +61,8 @@ class LibunwindstackUnwinder {
   virtual std::optional<bool> HasFramePointerSet(uint64_t instruction_pointer, pid_t pid,
                                                  unwindstack::Maps* maps) = 0;
 
-  static std::unique_ptr<LibunwindstackUnwinder> Create();
+  static std::unique_ptr<LibunwindstackUnwinder> Create(
+      const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at);
   static std::string LibunwindstackErrorString(unwindstack::ErrorCode error_code);
 
  protected:

--- a/src/LinuxTracing/LibunwindstackUnwinderTest.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinderTest.cpp
@@ -73,7 +73,7 @@ constexpr pid_t kProcessId = 123;
 //     12be:       48 83 c4 10 c3              add    $0x10,%rsp
 
 TEST(LibunwindstackUnwinder, DetectsFunctionWithFramePointerSet) {
-  auto unwinder = LibunwindstackUnwinder::Create();
+  auto unwinder = LibunwindstackUnwinder::Create({});
 
   auto maps = CreateFakeMapsEntry("target_fp");
 
@@ -85,7 +85,7 @@ TEST(LibunwindstackUnwinder, DetectsFunctionWithFramePointerSet) {
 }
 
 TEST(LibunwindstackUnwinder, DetectsLeafFunction) {
-  auto unwinder = LibunwindstackUnwinder::Create();
+  auto unwinder = LibunwindstackUnwinder::Create({});
 
   auto maps = CreateFakeMapsEntry("target_fp");
 
@@ -97,7 +97,7 @@ TEST(LibunwindstackUnwinder, DetectsLeafFunction) {
 }
 
 TEST(LibunwindstackUnwinder, DetectsFunctionWithoutFramePointer) {
-  auto unwinder = LibunwindstackUnwinder::Create();
+  auto unwinder = LibunwindstackUnwinder::Create({});
 
   auto maps = CreateFakeMapsEntry("target_no_fp");
 
@@ -109,7 +109,7 @@ TEST(LibunwindstackUnwinder, DetectsFunctionWithoutFramePointer) {
 }
 
 TEST(LibunwindstackUnwinder, DetectsFramePointerNotSetAtPushRbp) {
-  auto unwinder = LibunwindstackUnwinder::Create();
+  auto unwinder = LibunwindstackUnwinder::Create({});
 
   auto maps = CreateFakeMapsEntry("target_fp");
 
@@ -121,7 +121,7 @@ TEST(LibunwindstackUnwinder, DetectsFramePointerNotSetAtPushRbp) {
 }
 
 TEST(LibunwindstackUnwinder, DetectsFramePointerNotSetAtMovRspToRbp) {
-  auto unwinder = LibunwindstackUnwinder::Create();
+  auto unwinder = LibunwindstackUnwinder::Create({});
 
   auto maps = CreateFakeMapsEntry("target_fp");
 
@@ -133,7 +133,7 @@ TEST(LibunwindstackUnwinder, DetectsFramePointerNotSetAtMovRspToRbp) {
 }
 
 TEST(LibunwindstackUnwinder, DetectsFramePointerSetAtLeave) {
-  auto unwinder = LibunwindstackUnwinder::Create();
+  auto unwinder = LibunwindstackUnwinder::Create({});
 
   auto maps = CreateFakeMapsEntry("target_fp");
 
@@ -145,7 +145,7 @@ TEST(LibunwindstackUnwinder, DetectsFramePointerSetAtLeave) {
 }
 
 TEST(LibunwindstackUnwinder, DetectsFramePointerNotSetAtRet) {
-  auto unwinder = LibunwindstackUnwinder::Create();
+  auto unwinder = LibunwindstackUnwinder::Create({});
 
   auto maps = CreateFakeMapsEntry("target_fp");
 
@@ -157,7 +157,7 @@ TEST(LibunwindstackUnwinder, DetectsFramePointerNotSetAtRet) {
 }
 
 TEST(LibunwindstackUnwinder, FramePointerDetectionWorksWithCaching) {
-  auto unwinder = LibunwindstackUnwinder::Create();
+  auto unwinder = LibunwindstackUnwinder::Create({});
 
   auto maps = CreateFakeMapsEntry("target_fp");
 

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -105,6 +105,10 @@ TracerImpl::TracerImpl(
         instrumented_function.record_arguments(), instrumented_function.record_return_value());
   }
 
+  absolute_address_to_size_of_functions_to_stop_at_.insert(
+      capture_options.absolute_address_to_size_of_functions_to_stop_at().begin(),
+      capture_options.absolute_address_to_size_of_functions_to_stop_at().end());
+
   for (const orbit_grpc_protos::TracepointInfo& instrumented_tracepoint :
        capture_options.instrumented_tracepoint()) {
     orbit_grpc_protos::TracepointInfo info;
@@ -171,13 +175,13 @@ static void CloseFileDescriptors(const absl::flat_hash_map<int32_t, int>& fds_pe
 void TracerImpl::InitUprobesEventVisitor() {
   ORBIT_SCOPE_FUNCTION;
   maps_ = LibunwindstackMaps::ParseMaps(ReadMaps(target_pid_));
-  unwinder_ = LibunwindstackUnwinder::Create();
+  unwinder_ = LibunwindstackUnwinder::Create(&absolute_address_to_size_of_functions_to_stop_at_);
   return_address_manager_.emplace(user_space_instrumentation_addresses_.get());
   leaf_function_call_manager_ = std::make_unique<LeafFunctionCallManager>(stack_dump_size_);
   uprobes_unwinding_visitor_ = std::make_unique<UprobesUnwindingVisitor>(
       listener_, &function_call_manager_, &return_address_manager_.value(), maps_.get(),
       unwinder_.get(), leaf_function_call_manager_.get(),
-      user_space_instrumentation_addresses_.get());
+      user_space_instrumentation_addresses_.get(), &absolute_address_to_size_of_functions_to_stop_at_);
   uprobes_unwinding_visitor_->SetUnwindErrorsAndDiscardedSamplesCounters(
       &stats_.unwind_error_count, &stats_.samples_in_uretprobes_count);
   event_processor_.AddVisitor(uprobes_unwinding_visitor_.get());

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -143,6 +143,7 @@ class TracerImpl : public Tracer {
   uint16_t stack_dump_size_;
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_;
   std::vector<Function> instrumented_functions_;
+  std::map<uint64_t, uint64_t> absolute_address_to_size_of_functions_to_stop_at_;
   bool trace_thread_state_;
   bool trace_gpu_driver_;
   std::vector<orbit_grpc_protos::TracepointInfo> instrumented_tracepoints_;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -50,8 +50,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
       UprobesReturnAddressManager* uprobes_return_address_manager, LibunwindstackMaps* initial_maps,
       LibunwindstackUnwinder* unwinder, LeafFunctionCallManager* leaf_function_call_manager,
       UserSpaceInstrumentationAddresses* user_space_instrumentation_addresses,
-      const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at =
-          nullptr /*TODO(kuebler): Don't make this parameter default*/)
+      const std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_at)
       : listener_{listener},
         function_call_manager_{function_call_manager},
         return_address_manager_{uprobes_return_address_manager},

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -1692,7 +1692,8 @@ class UprobesUnwindingVisitorMmapTest : public ::testing::Test {
                                    &maps_,
                                    &unwinder_,
                                    &leaf_function_call_manager_,
-                                   /*user_space_instrumentation_addresses=*/nullptr};
+                                   /*user_space_instrumentation_addresses=*/nullptr,
+                                   /*absolute_address_to_size_of_functions_to_stop_at=*/nullptr};
 
  private:
   UprobesFunctionCallManager function_call_manager_;


### PR DESCRIPTION
Adds the functions to stop unwinding at to the capture options proto,
reads them and passes them to the unwinder and
UprobesUnwindingVisitor.

Test: E2E Integration and capture with __wine_syscall_dispatcher
Bug: http://b/236121587

Receive "functions to stop at" in LinuxTracing

Adds the functions to stop unwinding at to the capture options proto,
reads them and passes them to the unwinder and
UprobesUnwindingVisitor.

Test: E2E Integration and capture with __wine_syscall_dispatcher
Bug: http://b/236121587