### PR TITLE
Improve StartNewCapture.

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -23,6 +23,7 @@
 #include "OrbitBase/File.h"
 #include "OrbitBase/GetProcessIds.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "OrbitBase/UniqueResource.h"
 #include "ReadSeccompModeOfThread.h"
@@ -268,7 +269,7 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
 
 ErrorMessageOr<InstrumentationManager::InstrumentationResult>
 InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) {
-  OUTCOME_TRY(auto&& already_attached_tids, AttachAndStopProcess(pid_));
+  OUTCOME_TRY(AttachAndStopProcess(pid_));
   orbit_base::unique_resource detach_on_exit{pid_, [](int32_t pid) {
                                                if (DetachAndContinueProcess(pid).has_error()) {
                                                  ORBIT_ERROR("Detaching from %i", pid);
@@ -292,10 +293,8 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
   orbit_base::unique_resource close_on_exit{
       &capstone_handle, [](csh* capstone_handle) { cs_close(capstone_handle); }};
 
-  OUTCOME_TRY(ExecuteInProcess(pid_, absl::bit_cast<void*>(start_new_capture_function_address_)));
-  // StartNewFunction could (and will) spawn new threads. Stop those too, as the assumption here is
-  // that the target process is completely stopped.
-  OUTCOME_TRY(AttachAndStopNewThreadsOfProcess(pid_, std::move(already_attached_tids)));
+  OUTCOME_TRY(ExecuteInProcess(pid_, absl::bit_cast<void*>(start_new_capture_function_address_),
+                               orbit_base::CaptureTimestampNs()));
 
   OUTCOME_TRY(EnsureTrampolinesWritable());
 

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -134,8 +134,8 @@ bool& GetIsInPayload() {
 
 }  // namespace
 
-void StartNewCapture() {
-  current_capture_start_timestamp_ns = CaptureTimestampNs();
+void StartNewCapture(uint64_t capture_start_timestamp_ns) {
+  current_capture_start_timestamp_ns = capture_start_timestamp_ns;
 
   // If the library has just been injected, initialize the
   // LockFreeUserSpaceInstrumentationEventProducer and establish the connection to OrbitService now

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
@@ -7,8 +7,9 @@
 
 #include <cstdint>
 
-// Needs to be called when the capture starts.
-extern "C" void StartNewCapture();
+// Needs to be called when a capture starts. `capture_start_timestamp_ns` should be a current
+// timestamp as obtained from orbit_base::CaptureTimestampNs.
+extern "C" void StartNewCapture(uint64_t capture_start_timestamp_ns);
 
 // Payload called on entry of an instrumented function. Needs to record the return address of the
 // function (in order to have it available in `ExitPayload`) and the stack pointer (i.e., the


### PR DESCRIPTION
Previously the timestamp was obtained from within the target process.
This is not needed (can be done in OrbitService) and potentially
dangerous since it is done in a halted thread and it is not entirely
clear if the call is reentrant.

Since StartNewCapture is not spawning any new threads anymore we can
remove the call to AttachAndStopNewThreadsOfProcess.

Bug: b/232684803
Test: Unit tests plus manual runs.