### PR TITLE
Do not apply majority filtering to functions to stop at

### DIFF
--- a/src/ClientData/CallstackDataTest.cpp
+++ b/src/ClientData/CallstackDataTest.cpp
@@ -100,7 +100,7 @@ TEST(CallstackData, FilterCallstackEventsBasedOnMajorityStart) {
   CallstackEvent event10{time10, non_complete_cs_id, tid_without_supermajority};
   callstack_data.AddCallstackEvent(event10);
 
-  callstack_data.UpdateCallstackTypeBasedOnMajorityStart();
+  callstack_data.UpdateCallstackTypeBasedOnMajorityStart({});
 
   EXPECT_EQ(callstack_data.GetCallstack(cs1_id)->type(), CallstackType::kComplete);
   EXPECT_EQ(callstack_data.GetCallstack(cs2_id)->type(), CallstackType::kComplete);
@@ -122,6 +122,90 @@ TEST(CallstackData, FilterCallstackEventsBasedOnMajorityStart) {
       callstack_data.GetCallstackEventsOfTidInTimeRange(tid_without_supermajority, 0,
                                                         std::numeric_limits<uint64_t>::max()),
       testing::Pointwise(CallstackEventEq(), std::vector<CallstackEvent>{event8, event9, event10}));
+}
+
+TEST(CallstackData, FilterCallstackEventsBasedOnMajorityStartExcludesFunctionToStopUnwindingAt) {
+  CallstackData callstack_data;
+
+  constexpr uint32_t kTid = 42;
+
+  constexpr uint64_t kCloneAddress = 0x10;
+  constexpr uint64_t kBrokenAddress = 0x30;
+  constexpr uint64_t kFunctionToStopUnwindingAtAddress = 0x40;
+
+  const uint64_t cs1_id = 12;
+  const uint64_t cs1_outer = kCloneAddress;
+  const uint64_t cs1_inner = 0x11;
+  CallstackInfo cs1{{cs1_inner, cs1_outer}, CallstackType::kComplete};
+  callstack_data.AddUniqueCallstack(cs1_id, std::move(cs1));
+
+  const uint64_t cs2_id = 13;
+  const uint64_t cs2_outer = kCloneAddress;
+  const uint64_t cs2_inner = 0x21;
+  CallstackInfo cs2{{cs2_inner, cs2_outer}, CallstackType::kComplete};
+  callstack_data.AddUniqueCallstack(cs2_id, std::move(cs2));
+
+  const uint64_t broken_cs_id = 81;
+  const uint64_t broken_cs_outer = kBrokenAddress;
+  const uint64_t broken_cs_inner = 0x31;
+  CallstackInfo broken_cs{{broken_cs_inner, broken_cs_outer}, CallstackType::kComplete};
+  callstack_data.AddUniqueCallstack(broken_cs_id, std::move(broken_cs));
+
+  const uint64_t function_to_stop_unwinding_at_cs_id = 91;
+  const uint64_t function_to_stop_unwinding_at_cs_outer = kFunctionToStopUnwindingAtAddress;
+  const uint64_t function_to_stop_unwinding_at_cs_inner = 0x41;
+  CallstackInfo function_to_stop_unwinding_at_cs{
+      {function_to_stop_unwinding_at_cs_inner, function_to_stop_unwinding_at_cs_outer},
+      CallstackType::kComplete};
+  callstack_data.AddUniqueCallstack(function_to_stop_unwinding_at_cs_id,
+                                    std::move(function_to_stop_unwinding_at_cs));
+
+  const uint64_t time1 = 142;
+  CallstackEvent event1{time1, cs1_id, kTid};
+  callstack_data.AddCallstackEvent(event1);
+
+  const uint64_t time2 = 242;
+  CallstackEvent event2{time2, broken_cs_id, kTid};
+  callstack_data.AddCallstackEvent(event2);
+
+  const uint64_t time3 = 342;
+  CallstackEvent event3{time3, cs2_id, kTid};
+  callstack_data.AddCallstackEvent(event3);
+
+  const uint64_t time4 = 442;
+  CallstackEvent event4{time4, cs1_id, kTid};
+  callstack_data.AddCallstackEvent(event4);
+
+  const uint64_t time5 = 542;
+  CallstackEvent event5{time5, function_to_stop_unwinding_at_cs_id, kTid};
+  callstack_data.AddCallstackEvent(event5);
+
+  const uint64_t time6 = 642;
+  CallstackEvent event6{time6, cs2_id, kTid};
+  callstack_data.AddCallstackEvent(event6);
+
+  const uint64_t time7 = 742;
+  CallstackEvent event7{time7, cs1_id, kTid};
+  callstack_data.AddCallstackEvent(event7);
+
+  const uint64_t time8 = 842;
+  CallstackEvent event8{time8, cs1_id, kTid};
+  callstack_data.AddCallstackEvent(event8);
+
+  callstack_data.UpdateCallstackTypeBasedOnMajorityStart({{kFunctionToStopUnwindingAtAddress, 10}});
+
+  EXPECT_EQ(callstack_data.GetCallstack(cs1_id)->type(), CallstackType::kComplete);
+  EXPECT_EQ(callstack_data.GetCallstack(cs2_id)->type(), CallstackType::kComplete);
+  EXPECT_EQ(callstack_data.GetCallstack(broken_cs_id)->type(),
+            CallstackType::kFilteredByMajorityOutermostFrame);
+  EXPECT_EQ(callstack_data.GetCallstack(function_to_stop_unwinding_at_cs_id)->type(),
+            CallstackType::kComplete);
+
+  EXPECT_THAT(callstack_data.GetCallstackEventsOfTidInTimeRange(
+                  kTid, 0, std::numeric_limits<uint64_t>::max()),
+              testing::Pointwise(CallstackEventEq(),
+                                 std::vector<CallstackEvent>{event1, event2, event3, event4, event5,
+                                                             event6, event7, event8}));
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -19,6 +19,7 @@
 #include "ClientData/CallstackEvent.h"
 #include "ClientData/CallstackInfo.h"
 #include "ClientProtos/capture_data.pb.h"
+#include "ModuleManager.h"
 #include "OrbitBase/Logging.h"
 
 namespace orbit_client_data {
@@ -116,7 +117,9 @@ class CallstackData {
   // update the type of all the kComplete callstacks that have the outermost frame not matching the
   // majority outermost frame. This is a way to filter unwinding errors that were not reported as
   // such.
-  void UpdateCallstackTypeBasedOnMajorityStart();
+  void UpdateCallstackTypeBasedOnMajorityStart(
+      const std::map<uint64_t, uint64_t>&
+          absolute_address_to_size_of_functions_to_stop_unwinding_at);
 
  private:
   [[nodiscard]] std::shared_ptr<CallstackInfo> GetCallstackPtr(uint64_t callstack_id) const;

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -166,7 +166,7 @@ class CaptureData {
     callstack_data_.AddCallstackEvent(std::move(callstack_event));
   }
 
-  void FilterBrokenCallstacks() { callstack_data_.UpdateCallstackTypeBasedOnMajorityStart(); }
+  void FilterBrokenCallstacks();
 
   void AddUniqueTracepointInfo(uint64_t tracepoint_id, TracepointInfo tracepoint_info) {
     tracepoint_data_.AddUniqueTracepointInfo(tracepoint_id, std::move(tracepoint_info));


### PR DESCRIPTION
We may receive callstacks that are marked as "complete", but do not
end in the expected function (start or clone). Therefore, we
implemented a mechanism on the client to filter those callstacks
based on the majority.

Now that we have functions were we request the unwinder to stop at
(__wine_syscall_dispatcher), callstacks ending in those functions to
stop at might either get filtered out, or make the majority (and thus
clone would get filtered out).

With this change, we are excluding the functions to stop unwinding
at, from the calculation.

Bug: http://b/236121587
Test: Unit Test