### PR TITLE
Add ProcessData::FindModulesByFilename

### DIFF
--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -167,6 +167,18 @@ std::vector<uint64_t> ProcessData::GetModuleBaseAddresses(const std::string& mod
   return result;
 }
 
+std::vector<ModuleInMemory> ProcessData::FindModulesByFilename(const std::string& filename) const {
+  absl::MutexLock lock(&mutex_);
+  std::vector<ModuleInMemory> result;
+  for (const auto& [unused_start_address, module_in_memory] : start_address_to_module_in_memory_) {
+    const std::string& file_path = module_in_memory.file_path();
+    if (std::filesystem::path(file_path).filename().string() == filename) {
+      result.push_back(module_in_memory);
+    }
+  }
+  return result;
+}
+
 std::map<uint64_t, ModuleInMemory> ProcessData::GetMemoryMapCopy() const {
   absl::MutexLock lock(&mutex_);
   return start_address_to_module_in_memory_;

--- a/src/ClientData/ProcessDataTest.cpp
+++ b/src/ClientData/ProcessDataTest.cpp
@@ -23,7 +23,10 @@ using orbit_grpc_protos::ProcessInfo;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;
 
+using testing::AllOf;
 using testing::ElementsAre;
+using testing::Property;
+using testing::UnorderedElementsAre;
 
 namespace orbit_client_data {
 
@@ -188,6 +191,75 @@ TEST(ProcessData, FindModuleBuildIdsByPath) {
   EXPECT_THAT(process.FindModuleBuildIdsByPath(kFilePath3), ElementsAre(kBuildId2, kBuildId3));
   EXPECT_FALSE(process.IsModuleLoadedByProcess("not/loaded/module"));
   EXPECT_TRUE(process.FindModuleBuildIdsByPath("not/loaded/module").empty());
+}
+
+TEST(ProcessData, FindModulesByFilename) {
+  constexpr const char* kFileName1 = "file1";
+  constexpr const char* kFilePath1 = "path/to/file1";
+  constexpr const char* kBuildId1 = "buildid1";
+  constexpr uint64_t kStartAddress1 = 0;
+  constexpr uint64_t kEndAddress1 = 10;
+  ModuleInfo module_info_1;
+  module_info_1.set_file_path(kFilePath1);
+  module_info_1.set_build_id(kBuildId1);
+  module_info_1.set_address_start(kStartAddress1);
+  module_info_1.set_address_end(kEndAddress1);
+
+  constexpr const char* kFileName2 = "file2";
+  constexpr const char* kFilePath2 = "path/to/file2";
+  constexpr const char* kBuildId2 = "buildid2";
+  constexpr uint64_t kStartAddress2 = 100;
+  constexpr uint64_t kEndAddress2 = 110;
+  ModuleInfo module_info_2;
+  module_info_2.set_file_path(kFilePath2);
+  module_info_2.set_build_id(kBuildId2);
+  module_info_2.set_address_start(kStartAddress2);
+  module_info_2.set_address_end(kEndAddress2);
+
+  constexpr const char* kFilePath3 = kFilePath2;
+  constexpr const char* kBuildId3 = "kBuildId2";
+  constexpr uint64_t kStartAddress3 = 200;
+  constexpr uint64_t kEndAddress3 = 210;
+  ModuleInfo module_info_3;
+  module_info_3.set_file_path(kFilePath3);
+  module_info_3.set_build_id(kBuildId3);
+  module_info_3.set_address_start(kStartAddress3);
+  module_info_3.set_address_end(kEndAddress3);
+
+  constexpr const char* kFilePath4 = kFilePath2;
+  constexpr const char* kBuildId4 = kBuildId2;
+  constexpr uint64_t kStartAddress4 = 300;
+  constexpr uint64_t kEndAddress4 = 310;
+  ModuleInfo module_info_4;
+  module_info_4.set_file_path(kFilePath4);
+  module_info_4.set_build_id(kBuildId4);
+  module_info_4.set_address_start(kStartAddress4);
+  module_info_4.set_address_end(kEndAddress4);
+
+  std::vector<ModuleInfo> module_infos{module_info_1, module_info_2, module_info_3, module_info_4};
+
+  ProcessData process(ProcessInfo{});
+  process.UpdateModuleInfos(module_infos);
+
+  EXPECT_THAT(process.FindModulesByFilename(kFileName1),
+              UnorderedElementsAre(AllOf(Property(&ModuleInMemory::file_path, kFilePath1),
+                                         Property(&ModuleInMemory::build_id, kBuildId1),
+                                         Property(&ModuleInMemory::start, kStartAddress1),
+                                         Property(&ModuleInMemory::end, kEndAddress1))));
+
+  EXPECT_THAT(process.FindModulesByFilename(kFileName2),
+              UnorderedElementsAre(AllOf(Property(&ModuleInMemory::file_path, kFilePath2),
+                                         Property(&ModuleInMemory::build_id, kBuildId2),
+                                         Property(&ModuleInMemory::start, kStartAddress2),
+                                         Property(&ModuleInMemory::end, kEndAddress2)),
+                                   AllOf(Property(&ModuleInMemory::file_path, kFilePath3),
+                                         Property(&ModuleInMemory::build_id, kBuildId3),
+                                         Property(&ModuleInMemory::start, kStartAddress3),
+                                         Property(&ModuleInMemory::end, kEndAddress3)),
+                                   AllOf(Property(&ModuleInMemory::file_path, kFilePath4),
+                                         Property(&ModuleInMemory::build_id, kBuildId4),
+                                         Property(&ModuleInMemory::start, kStartAddress4),
+                                         Property(&ModuleInMemory::end, kEndAddress4))));
 }
 
 TEST(ProcessData, IsModuleLoadedByProcess) {

--- a/src/ClientData/ProcessDataTest.cpp
+++ b/src/ClientData/ProcessDataTest.cpp
@@ -216,23 +216,20 @@ TEST(ProcessData, FindModulesByFilename) {
   module_info_2.set_address_start(kStartAddress2);
   module_info_2.set_address_end(kEndAddress2);
 
-  constexpr const char* kFilePath3 = kFilePath2;
-  constexpr const char* kBuildId3 = "kBuildId2";
+  constexpr const char* kBuildId3 = "kBuildId3";
   constexpr uint64_t kStartAddress3 = 200;
   constexpr uint64_t kEndAddress3 = 210;
   ModuleInfo module_info_3;
-  module_info_3.set_file_path(kFilePath3);
+  module_info_3.set_file_path(kFilePath2);
   module_info_3.set_build_id(kBuildId3);
   module_info_3.set_address_start(kStartAddress3);
   module_info_3.set_address_end(kEndAddress3);
 
-  constexpr const char* kFilePath4 = kFilePath2;
-  constexpr const char* kBuildId4 = kBuildId2;
   constexpr uint64_t kStartAddress4 = 300;
   constexpr uint64_t kEndAddress4 = 310;
   ModuleInfo module_info_4;
-  module_info_4.set_file_path(kFilePath4);
-  module_info_4.set_build_id(kBuildId4);
+  module_info_4.set_file_path(kFilePath2);
+  module_info_4.set_build_id(kBuildId2);
   module_info_4.set_address_start(kStartAddress4);
   module_info_4.set_address_end(kEndAddress4);
 
@@ -252,12 +249,12 @@ TEST(ProcessData, FindModulesByFilename) {
                                          Property(&ModuleInMemory::build_id, kBuildId2),
                                          Property(&ModuleInMemory::start, kStartAddress2),
                                          Property(&ModuleInMemory::end, kEndAddress2)),
-                                   AllOf(Property(&ModuleInMemory::file_path, kFilePath3),
+                                   AllOf(Property(&ModuleInMemory::file_path, kFilePath2),
                                          Property(&ModuleInMemory::build_id, kBuildId3),
                                          Property(&ModuleInMemory::start, kStartAddress3),
                                          Property(&ModuleInMemory::end, kEndAddress3)),
-                                   AllOf(Property(&ModuleInMemory::file_path, kFilePath4),
-                                         Property(&ModuleInMemory::build_id, kBuildId4),
+                                   AllOf(Property(&ModuleInMemory::file_path, kFilePath2),
+                                         Property(&ModuleInMemory::build_id, kBuildId2),
                                          Property(&ModuleInMemory::start, kStartAddress4),
                                          Property(&ModuleInMemory::end, kEndAddress4))));
 }

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -90,6 +90,8 @@ class ProcessData final {
   [[nodiscard]] std::vector<std::string> FindModuleBuildIdsByPath(
       const std::string& module_path) const;
 
+  [[nodiscard]] std::vector<ModuleInMemory> FindModulesByFilename(const std::string& filename) const;
+
   [[nodiscard]] bool IsModuleLoadedByProcess(const std::string& module_path) const {
     return !FindModuleBuildIdsByPath(module_path).empty();
   }

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -90,7 +90,8 @@ class ProcessData final {
   [[nodiscard]] std::vector<std::string> FindModuleBuildIdsByPath(
       const std::string& module_path) const;
 
-  [[nodiscard]] std::vector<ModuleInMemory> FindModulesByFilename(const std::string& filename) const;
+  [[nodiscard]] std::vector<ModuleInMemory> FindModulesByFilename(
+      const std::string& filename) const;
 
   [[nodiscard]] bool IsModuleLoadedByProcess(const std::string& module_path) const {
     return !FindModuleBuildIdsByPath(module_path).empty();

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -90,6 +90,8 @@ class ProcessData final {
   [[nodiscard]] std::vector<std::string> FindModuleBuildIdsByPath(
       const std::string& module_path) const;
 
+  // Returns the list of modules with the given filename. Note this method matches based on the
+  // actual filename and not based on the full path.
   [[nodiscard]] std::vector<ModuleInMemory> FindModulesByFilename(
       const std::string& filename) const;
 


### PR DESCRIPTION
We will need to know the absolute addresses of certain functions
we want to stop unwinding at (in particular __wine_syscall_dispatcher).

As `FunctionInfo::GetAbsoluteAddress` is deprecated since it does not
cover loading the exact same module twice, we need a way to retrive
the module start addresses from the process.

This change adds a `FindModulesByFileName` function to the process.

Test: Unit test
Bug: http://b/236121587