### PR TITLE
De-templatise `GetSamplingCounts` and `GetFrameTrackStats` getters

### DIFF
--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -98,22 +98,22 @@ int main(int argc, char** argv) {
               kFrameTrackScopeId));
 
   for (const auto& [sfid, name] : bac.sfid_to_name()) {
-    const uint64_t baseline_cnt = report.GetSamplingCounts<Baseline>()->GetExclusiveCount(sfid);
-    const uint64_t comparison_cnt = report.GetSamplingCounts<Comparison>()->GetExclusiveCount(sfid);
+    const uint64_t baseline_cnt = report.GetBaselineSamplingCounts()->GetExclusiveCount(sfid);
+    const uint64_t comparison_cnt = report.GetComparisonSamplingCounts()->GetExclusiveCount(sfid);
     const double pvalue = report.GetComparisonResult(sfid).pvalue;
     if (pvalue < 0.05) {
       ORBIT_LOG("%s %.2f %s %u %u", name, pvalue, static_cast<std::string>(sfid), baseline_cnt,
                 comparison_cnt);
     }
   }
-  ORBIT_LOG("Callstack count %u vs %u ", report.GetSamplingCounts<Baseline>()->GetTotalCallstacks(),
-            report.GetSamplingCounts<Comparison>()->GetTotalCallstacks());
+  ORBIT_LOG("Callstack count %u vs %u ", report.GetBaselineSamplingCounts()->GetTotalCallstacks(),
+            report.GetComparisonSamplingCounts()->GetTotalCallstacks());
   ORBIT_LOG("Total number of common names %u  ", bac.sfid_to_name().size());
   ORBIT_LOG("Baseline mean frametime %u ns, stddev %u",
-            report.GetFrameTrackStats<Baseline>()->ComputeAverageTimeNs(),
-            report.GetFrameTrackStats<Baseline>()->ComputeStdDevNs());
+            report.GetBaselineFrameTrackStats()->ComputeAverageTimeNs(),
+            report.GetBaselineFrameTrackStats()->ComputeStdDevNs());
   ORBIT_LOG("Comparison mean frametime %u ns, stddev %u",
-            report.GetFrameTrackStats<Comparison>()->ComputeAverageTimeNs(),
-            report.GetFrameTrackStats<Comparison>()->ComputeStdDevNs());
+            report.GetComparisonFrameTrackStats()->ComputeAverageTimeNs(),
+            report.GetComparisonFrameTrackStats()->ComputeStdDevNs());
   return 0;
 }

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -172,20 +172,20 @@ TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
       MakeComparison<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
           absl::flat_hash_set<uint32_t>{orbit_base::kAllProcessThreadsTid}, 0, 1, 1));
 
-  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetTotalCallstacks(), kCallstacks.size());
+  EXPECT_EQ(report.GetBaselineSamplingCounts()->GetTotalCallstacks(), kCallstacks.size());
 
-  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetExclusiveCount(kSfidFirst), 0);
-  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetExclusiveCount(kSfidSecond), 1);
-  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetExclusiveCount(kSfidThird), 1);
+  EXPECT_EQ(report.GetBaselineSamplingCounts()->GetExclusiveCount(kSfidFirst), 0);
+  EXPECT_EQ(report.GetBaselineSamplingCounts()->GetExclusiveCount(kSfidSecond), 1);
+  EXPECT_EQ(report.GetBaselineSamplingCounts()->GetExclusiveCount(kSfidThird), 1);
 
-  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetInclusiveCount(kSfidFirst), 1);
-  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetInclusiveCount(kSfidSecond), 2);
-  EXPECT_EQ(report.GetSamplingCounts<Baseline>()->GetInclusiveCount(kSfidThird), 1);
+  EXPECT_EQ(report.GetBaselineSamplingCounts()->GetInclusiveCount(kSfidFirst), 1);
+  EXPECT_EQ(report.GetBaselineSamplingCounts()->GetInclusiveCount(kSfidSecond), 2);
+  EXPECT_EQ(report.GetBaselineSamplingCounts()->GetInclusiveCount(kSfidThird), 1);
 
-  EXPECT_EQ(report.GetSamplingCounts<Comparison>()->GetTotalCallstacks(), 0);
+  EXPECT_EQ(report.GetComparisonSamplingCounts()->GetTotalCallstacks(), 0);
   for (const SFID sfid : kSfids) {
-    EXPECT_EQ(report.GetSamplingCounts<Comparison>()->GetExclusiveCount(sfid), 0);
-    EXPECT_EQ(report.GetSamplingCounts<Comparison>()->GetInclusiveCount(sfid), 0);
+    EXPECT_EQ(report.GetComparisonSamplingCounts()->GetExclusiveCount(sfid), 0);
+    EXPECT_EQ(report.GetComparisonSamplingCounts()->GetInclusiveCount(sfid), 0);
 
     ComparisonResult comparision_result = report.GetComparisonResult(sfid);
     constexpr double kTolerance = 1e-6;
@@ -194,17 +194,17 @@ TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
   }
 
   constexpr uint64_t kExpectedFullActiveFrameTime = 200;
-  EXPECT_EQ(report.GetFrameTrackStats<Baseline>()->ComputeAverageTimeNs(),
+  EXPECT_EQ(report.GetBaselineFrameTrackStats()->ComputeAverageTimeNs(),
             kExpectedFullActiveFrameTime);
-  EXPECT_EQ(report.GetFrameTrackStats<Comparison>()->ComputeAverageTimeNs(), 0);
+  EXPECT_EQ(report.GetComparisonFrameTrackStats()->ComputeAverageTimeNs(), 0);
 
   constexpr double kExpectedFullActiveFrameTimeVariance = 6666.66666;
-  EXPECT_THAT(report.GetFrameTrackStats<Baseline>()->variance_ns(),
+  EXPECT_THAT(report.GetBaselineFrameTrackStats()->variance_ns(),
               DoubleNear(kExpectedFullActiveFrameTimeVariance, 1e-3));
-  EXPECT_THAT(report.GetFrameTrackStats<Comparison>()->variance_ns(), DoubleNear(0, 1e-3));
+  EXPECT_THAT(report.GetComparisonFrameTrackStats()->variance_ns(), DoubleNear(0, 1e-3));
 
-  EXPECT_EQ(report.GetFrameTrackStats<Baseline>()->count(), kFrameTrackActiveTimes.size());
-  EXPECT_EQ(report.GetFrameTrackStats<Comparison>()->count(), 0);
+  EXPECT_EQ(report.GetBaselineFrameTrackStats()->count(), kFrameTrackActiveTimes.size());
+  EXPECT_EQ(report.GetComparisonFrameTrackStats()->count(), 0);
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -102,25 +102,19 @@ class SamplingWithFrameTrackComparisonReport {
         comparison_frame_track_stats_(std::move(comparison_frame_track_stats)),
         fid_to_comparison_results_(std::move(fid_to_comparison_results)) {}
 
-  // TODO(b/236714217) de-template the getter
-  template <template <typename> typename Wrapper>
-  const Wrapper<SamplingCounts>& GetSamplingCounts() const {
-    if constexpr (std::is_same_v<Wrapper<SamplingCounts>, Baseline<SamplingCounts>>) {
-      return baseline_sampling_counts_;
-    } else {
-      return comparison_sampling_counts_;
-    }
+  [[nodiscard]] const Baseline<SamplingCounts>& GetBaselineSamplingCounts() const {
+    return baseline_sampling_counts_;
+  }
+  [[nodiscard]] const Comparison<SamplingCounts>& GetComparisonSamplingCounts() const {
+    return comparison_sampling_counts_;
   }
 
-  // TODO(b/236714217) de-template the getter
-  template <template <typename> typename Wrapper>
-  const Wrapper<orbit_client_data::ScopeStats>& GetFrameTrackStats() const {
-    if constexpr (std::is_same_v<Wrapper<orbit_client_data::ScopeStats>,
-                                 Baseline<orbit_client_data::ScopeStats>>) {
-      return baseline_frame_track_stats_;
-    } else {
-      return comparison_frame_track_stats_;
-    }
+  [[nodiscard]] const Baseline<orbit_client_data::ScopeStats>& GetBaselineFrameTrackStats() const {
+    return baseline_frame_track_stats_;
+  }
+  [[nodiscard]] const Comparison<orbit_client_data::ScopeStats>& GetComparisonFrameTrackStats()
+      const {
+    return comparison_frame_track_stats_;
   }
 
   [[nodiscard]] const ComparisonResult& GetComparisonResult(SFID sfid) const {


### PR DESCRIPTION
This just makes 4 normal getters out of two templatised.

Test: Unit
Bug: http://b/236714217