### PR TITLE
Implement copy ctor for Typedef<Tag, T>

### DIFF
--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -51,6 +51,9 @@ TEST(TypedefTest, CanInstantiate) {
   MyType<int> wrapper_of_const(kConstInt);
   EXPECT_EQ(*wrapper_of_const, kConstInt);
 
+  MyType<int> copy_of_wrapper(wrapper_of_const);
+  EXPECT_EQ(*copy_of_wrapper, kConstInt);
+
   constexpr int kConstexprInt = 1;
   MyType<int> wrapper_of_constexpr(kConstexprInt);
   EXPECT_EQ(*wrapper_of_constexpr, kConstexprInt);
@@ -77,10 +80,31 @@ TEST(TypedefTest, ImplicitConversionIsCorrect) {
 
   {
     const MyType<B> wrapped_b(B{{kValue}});
+    const MyType<A> wrapped_a(wrapped_b);
+    EXPECT_EQ(wrapped_a->value, kValue);
+  }
+
+  {
+    const MyType<B> wrapped_b(B{{kValue}});
 
     bool is_called = false;
     int value_called_on{};
     auto take_const_ref = [&is_called, &value_called_on](const MyType<A>& a) {
+      is_called = true;
+      value_called_on = a->value;
+    };
+
+    take_const_ref(wrapped_b);
+    EXPECT_TRUE(is_called);
+    EXPECT_EQ(value_called_on, kValue);
+  }
+
+  {
+    const MyType<B> wrapped_b(B{{kValue}});
+
+    bool is_called = false;
+    int value_called_on{};
+    auto take_const_ref = [&is_called, &value_called_on](const MyType<A> a) {
       is_called = true;
       value_called_on = a->value;
     };

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -44,6 +44,7 @@ class Typedef {
   constexpr explicit Typedef(std::in_place_t, Args&&... args)
       : value_(T(std::forward<T>(args)...)) {}
 
+  constexpr Typedef(const Typedef& other) = default;
   constexpr Typedef(Typedef&& other) = default;
 
   template <typename U, typename = orbit_base_internal::EnableIfUConvertibleToT<T, U>>


### PR DESCRIPTION
The pre-existing template copy ctor is called only
if conversion takes place.

Test: Unit
Bug: http://b/236960047