### PR TITLE
Implement hashing and comparison for `Typedef<Tag, T>`

### DIFF
--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/hash/hash_testing.h>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -234,6 +235,28 @@ TEST(TypedefTest, CallIsCorrect) {
     MyType<Integer> sum_wrapped = LiftAndApply(&Integer::Add, first, second);
     EXPECT_EQ(sum_wrapped->value, kSum);
   }
+}
+
+TEST(Typedef, HashIsCorrect) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      {MyType<int>(1), MyType<int>(0), MyType<int>(-1), MyType<int>(10)}));
+
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+      {MyType<std::string>("A"), MyType<std::string>("B"), MyType<std::string>(""),
+       MyType<std::string>("ABB")}));
+}
+
+TEST(Typedef, ComparisonIsCorrect) {
+  constexpr int kLesser = 1;
+  constexpr int kGreater = 2;
+  EXPECT_EQ(MyType<int>(kLesser), MyType<int>(kLesser));
+  EXPECT_NE(MyType<int>(kLesser), MyType<int>(kGreater));
+  EXPECT_GE(MyType<int>(kLesser), MyType<int>(kLesser));
+  EXPECT_GE(MyType<int>(kGreater), MyType<int>(kLesser));
+  EXPECT_LE(MyType<int>(kLesser), MyType<int>(kLesser));
+  EXPECT_LE(MyType<int>(kLesser), MyType<int>(kGreater));
+  EXPECT_LT(MyType<int>(kLesser), MyType<int>(kGreater));
+  EXPECT_GT(MyType<int>(kGreater), MyType<int>(kLesser));
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -23,6 +23,14 @@ namespace orbit_base {
 // MyType<int> wrapped(1);
 // ```
 // One can access the underlying value with `*` and `->` operators.
+//
+// If `AbslHashValue` is implemented for `T`, it's also implemented for `Typedef<Tag, T>`.
+//
+// If `==` is implemented for `T` and `U`, operators `==` and `!=` are also implemented for
+// `Typedef<Tag, T>` and `Typedef<Tag, U>`.
+//
+// If `<` is implemented for `T` and 'U', operators '<', '>', '<=', '>=' are also
+// implemented for `Typedef<Tag, T>` and `Typedef<Tag, U>`. See TypedefTest.cpp for examples.
 // See TypedefTest.cpp for examples.
 template <typename Tag_, typename T>
 class Typedef {
@@ -73,6 +81,36 @@ class Typedef {
   constexpr Typedef& operator=(Typedef<Tag_, U>&& other) {
     value_ = std::move(*other);
     return *this;
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const Typedef& wrapped) {
+    return H::combine(std::move(h), *wrapped);
+  }
+
+  template <typename U>
+  [[nodiscard]] friend bool operator==(const Typedef& lhs, const Typedef<Tag, U>& rhs) {
+    return *lhs == *rhs;
+  }
+  template <typename U>
+  [[nodiscard]] friend bool operator!=(const Typedef& lhs, const Typedef<Tag, U>& rhs) {
+    return !(lhs == rhs);
+  }
+  template <typename U>
+  [[nodiscard]] friend bool operator<(const Typedef& lhs, const Typedef<Tag, U>& rhs) {
+    return *lhs < *rhs;
+  }
+  template <typename U>
+  [[nodiscard]] friend bool operator>=(const Typedef& lhs, const Typedef<Tag, U>& rhs) {
+    return !(lhs < rhs);
+  }
+  template <typename U>
+  [[nodiscard]] friend bool operator>(const Typedef& lhs, const Typedef<Tag, U>& rhs) {
+    return (lhs >= rhs) && (lhs != rhs);
+  }
+  template <typename U>
+  [[nodiscard]] friend bool operator<=(const Typedef& lhs, const Typedef<Tag, U>& rhs) {
+    return !(lhs > rhs);
   }
 
  private:


### PR DESCRIPTION
Naturally, these implementations are available only if
they are available for `T`.

Test: Unit
Bug: http://b/236966476