### PR TITLE
Switch auto_symbol_loading flag

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -77,4 +77,9 @@ ABSL_FLAG(bool, clear_settings, false,
 ABSL_FLAG(bool, iso_timestamps, true, "Show timestamps using ISO-8601 format.");
 
 ABSL_FLAG(bool, enable_unsafe_symbols, false,
-          "Enable the possibility to use symbol files that do not have a matching build ID");
+          "Enable the possibility to use symbol files that do not have a matching build ID.");
+
+ABSL_FLAG(
+    bool, auto_symbol_loading, true,
+    "Enable automatic symbol loading. This is turned on by default. If Orbit becomes unresponsive, "
+    "try turning automatic symbol loading off (--auto_symbol_loading=false)");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -65,4 +65,7 @@ ABSL_DECLARE_FLAG(bool, iso_timestamps);
 // Enables to use symbol files without a build id, or with a mismatching build ID
 ABSL_DECLARE_FLAG(bool, enable_unsafe_symbols);
 
+// Enables automatic symbol loading
+ABSL_DECLARE_FLAG(bool, auto_symbol_loading);
+
 #endif  // CLIENT_FLAGS_CLIENT_FLAGS_H_

--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -425,7 +425,8 @@ void SymbolLocationsDialog::DisableAddFolder() {
 }
 
 void SymbolLocationsDialog::SetUpInfoLabel() {
-  QString label_text = absl::GetFlag(FLAGS_devmode) ? kNewInfoLabelTemplate : kOldInfoLabelTemplate;
+  QString label_text =
+      absl::GetFlag(FLAGS_auto_symbol_loading) ? kNewInfoLabelTemplate : kOldInfoLabelTemplate;
   if (allow_unsafe_symbols_) {
     label_text = label_text.arg(kInfoLabelArgumentWithBuildIdOverride);
   } else {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -3151,7 +3151,6 @@ SymbolLoadingState OrbitApp::GetSymbolLoadingStateForModule(const ModuleData* mo
   if (modules_with_symbol_loading_error_.contains(module_id)) {
     return SymbolLoadingState::kError;
   }
-  // TODO(b/202140068) add missing error and disabled case
 
   return SymbolLoadingState::kUnknown;
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -494,7 +494,7 @@ Future<void> OrbitApp::OnCaptureComplete() {
 
         FireRefreshCallbacks();
 
-        if (IsDevMode()) {
+        if (absl::GetFlag(FLAGS_auto_symbol_loading)) {
           std::ignore = LoadAllSymbols();
         }
       });
@@ -507,7 +507,7 @@ Future<void> OrbitApp::OnCaptureCancelled() {
     capture_failed_callback_();
 
     ClearCapture();
-    if (IsDevMode()) {
+    if (absl::GetFlag(FLAGS_auto_symbol_loading)) {
       std::ignore = LoadAllSymbols();
     }
   });
@@ -522,7 +522,7 @@ Future<void> OrbitApp::OnCaptureFailed(ErrorMessage error_message) {
 
         ClearCapture();
         SendErrorToUi("Error in capture", error_message.message());
-        if (IsDevMode()) {
+        if (absl::GetFlag(FLAGS_auto_symbol_loading)) {
           std::ignore = LoadAllSymbols();
         }
       });
@@ -1418,7 +1418,7 @@ void OrbitApp::StartCapture() {
     return;
   }
 
-  if (IsDevMode()) {
+  if (absl::GetFlag(FLAGS_auto_symbol_loading)) {
     RequestSymbolDownloadStop(module_manager_->GetAllModuleData(), false);
   }
 
@@ -2361,7 +2361,7 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::UpdateProcessAndModuleList() 
                      })
       .ThenIfSuccess(main_thread_executor_,
                      [this]() {
-                       if (IsDevMode()) {
+                       if (absl::GetFlag(FLAGS_auto_symbol_loading)) {
                          std::ignore = LoadAllSymbols();
                        }
                      })
@@ -2723,8 +2723,8 @@ orbit_data_views::DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kModules:
       if (!modules_data_view_) {
-        modules_data_view_ =
-            DataView::CreateAndInit<ModulesDataView>(this, metrics_uploader_, IsDevMode());
+        modules_data_view_ = DataView::CreateAndInit<ModulesDataView>(
+            this, metrics_uploader_, absl::GetFlag(FLAGS_auto_symbol_loading));
         panels_.push_back(modules_data_view_.get());
       }
       return modules_data_view_.get();

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1477,7 +1477,7 @@ void OrbitMainWindow::ExecuteSymbolLocationsDialog(
 
 void OrbitMainWindow::on_actionSymbolLocationsDialog_triggered() {
   ExecuteSymbolLocationsDialog(std::nullopt);
-  if (app_->IsDevMode()) {
+  if (absl::GetFlag(FLAGS_auto_symbol_loading)) {
     std::ignore = app_->LoadAllSymbols();
   }
 }


### PR DESCRIPTION
    Add and use auto_symbol_loading flag
    
    Add auto_symbol_loading flag and use it to guard everything related to
    auto symbol loading that was hidden behind devmode before. This flag
    is true on default
    
    Test: Start Orbit without devmode or auto_symbol_loading and compare to
    Orbit started with --auto_symbol_loading=false
    Bug: http://b/202140068