### PR TITLE
Adapt loading symbols in E2E tests to just wait for them

### DIFF
--- a/contrib/automation_tests/orbit_add_iterator.py
+++ b/contrib/automation_tests/orbit_add_iterator.py
@@ -24,7 +24,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.capture_window import Capture
 from test_cases.live_tab import AddIterator
 
@@ -33,7 +33,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
-        LoadSymbols(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         AddIterator(function_name="DrawFrame")

--- a/contrib/automation_tests/orbit_bottom_up.py
+++ b/contrib/automation_tests/orbit_bottom_up.py
@@ -10,7 +10,7 @@ from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
 from test_cases.bottom_up_tab import VerifyHelloGgpBottomUpContents
-from test_cases.symbols_tab import LoadSymbols
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
 """Inspect the bottom-up view in Orbit using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -34,8 +34,8 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        LoadSymbols(module_search_string='libc-2.24'),
-        LoadSymbols(module_search_string='libdrm.so.2'),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string='libc-2.24'),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string='libdrm.so.2'),
         Capture(frame_pointer_unwinding=False),
         VerifyHelloGgpBottomUpContents(),
         Capture(frame_pointer_unwinding=True, sampling_period_ms=0.1),

--- a/contrib/automation_tests/orbit_capture_repeatedly.py
+++ b/contrib/automation_tests/orbit_capture_repeatedly.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CaptureRepeatedly
-from test_cases.symbols_tab import LoadSymbols, FilterAndEnableFrameTrackForFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndEnableFrameTrackForFunction
 """Repeatedly take very short captures using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -32,9 +32,9 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        LoadSymbols(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
         FilterAndEnableFrameTrackForFunction(function_search_string='DrawFrame'),
-        LoadSymbols(module_search_string="libvulkan.so.1"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="libvulkan.so.1"),
         FilterAndEnableFrameTrackForFunction(function_search_string='vkQueuePresentKHR'),
         Capture(length_in_seconds=1),
         CaptureRepeatedly(number_of_f5_presses=200)

--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, FilterTracks, CheckTimers, VerifyTracksExist
-from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.live_tab import AddFrameTrack
 """Create a frame track in Orbit using pywinauto.
 
@@ -33,7 +33,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
-        LoadSymbols(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         AddFrameTrack(function_name="DrawFrame"),

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CheckTimers, ExpandTrack
-from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument a single function in Orbit using pywinauto.
 
@@ -32,7 +32,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        LoadSymbols(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
         Capture(),
         CheckTimers(track_name_filter='Scheduler'),
         ExpandTrack(expected_name="gfx"),

--- a/contrib/automation_tests/orbit_instrument_libs.py
+++ b/contrib/automation_tests/orbit_instrument_libs.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite, E2ETestCase
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
-from test_cases.symbols_tab import LoadSymbols, FilterAndHookMultipleFunctions
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookMultipleFunctions
 from test_cases.live_tab import VerifyOneFunctionWasHit
 """Instrument function from libggp.
 
@@ -43,7 +43,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        LoadSymbols(module_search_string="libggp"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="libggp"),
         FilterAndHookMultipleFunctions(function_search_string='GgpIssueFrameToken_v'),
         Capture(),
         VerifyOneFunctionWasHit(function_name_contains='GgpIssueFrameToken_v',

--- a/contrib/automation_tests/orbit_load_symbols_pecoff.py
+++ b/contrib/automation_tests/orbit_load_symbols_pecoff.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import LoadSymbols
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
 from test_cases.symbols_tab import VerifySymbolsLoaded
 """Load symbols for PE/COFF modules.
 
@@ -29,9 +29,9 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='triangle'),
-        LoadSymbols(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
         VerifySymbolsLoaded(symbol_search_string="wWinMain"),
-        LoadSymbols(module_search_string="d3d11.dll"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="d3d11.dll"),
         VerifySymbolsLoaded(symbol_search_string="Present")
     ]
     suite = E2ETestSuite(test_name="Load Symbols PE/COFF", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_manual_instrumentation.py
+++ b/contrib/automation_tests/orbit_manual_instrumentation.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CheckTimers, VerifyTracksDoNotExist, VerifyTracksExist, ToggleCollapsedStateOfAllTracks, FilterTracks
-from test_cases.symbols_tab import LoadSymbols
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Test Orbit's manual instrumentation.
 
@@ -47,7 +47,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="OrbitTest"),
-        LoadSymbols(module_search_string="OrbitTest"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="OrbitTest"),
         # Take a capture without manual instrumentation and assert that no tracks show up.
         Capture(manual_instrumentation=False),
         VerifyTracksDoNotExist(track_names=tracks),

--- a/contrib/automation_tests/orbit_manual_instrumentation_silenus.py
+++ b/contrib/automation_tests/orbit_manual_instrumentation_silenus.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CheckTimers, CollapseTrack, VerifyTracksExist
-from test_cases.symbols_tab import LoadSymbols
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
 """Test Orbit's manual instrumentation on Silenus.
 
 Before this script is run there needs to be a gamelet reserved and the
@@ -31,7 +31,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="triangle.exe"),
-        LoadSymbols(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
         Capture(manual_instrumentation=True),
         VerifyTracksExist(track_names=[
             "Frame time, ms (double)", "Frame time, ms (float)", "Frame time, us (int)",

--- a/contrib/automation_tests/orbit_memory_watchdog.py
+++ b/contrib/automation_tests/orbit_memory_watchdog.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import CaptureAndWaitForInterruptedWarning
-from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 """Test that OrbitService stops the capture when it is using too much memory.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -31,7 +31,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="call_foo_repeat"),
-        LoadSymbols(module_search_string="call_foo_repeatedly"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="call_foo_repeatedly"),
         FilterAndHookFunction(function_search_string="foo{(}{)}"),
         CaptureAndWaitForInterruptedWarning(user_space_instrumentation=True)
     ]

--- a/contrib/automation_tests/orbit_mixed_unwinding.py
+++ b/contrib/automation_tests/orbit_mixed_unwinding.py
@@ -11,7 +11,7 @@ from test_cases.bottom_up_tab import VerifyBottomUpContentForTriangleExe
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
 from test_cases.sampling_tab import VerifySamplingContentForTriangleExe
-from test_cases.symbols_tab import LoadSymbols
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
 from test_cases.top_down_tab import VerifyTopDownContentForTriangleExe
 """Verify mixed (DWARF and PE/COFF) callstack unwinding by inspecting the "Sampling", "Top-Down", "Bottom-Up" tabs.
 
@@ -37,10 +37,10 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="triangle.exe"),
-        LoadSymbols(module_search_string="ntdll.dll"),
-        LoadSymbols(module_search_string="kernel32.dll"),
-        LoadSymbols(module_search_string="d3d11.dll"),
-        LoadSymbols(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="ntdll.dll"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="kernel32.dll"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="d3d11.dll"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
         Capture(),
         VerifySamplingContentForTriangleExe(),
         VerifyTopDownContentForTriangleExe(),

--- a/contrib/automation_tests/orbit_source_code_view.py
+++ b/contrib/automation_tests/orbit_source_code_view.py
@@ -10,7 +10,7 @@ from absl import flags
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess
 from test_cases.connection_window import ConnectToStadiaInstance
-from test_cases.symbols_tab import LoadSymbols
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
 from test_cases.symbols_tab import ShowSourceCode
 """Show source code for a single function in Orbit using pywinauto.
 
@@ -39,7 +39,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp_c"),
-        LoadSymbols(module_search_string="hello_ggp_c"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp_c"),
         ShowSourceCode(function_search_string="DrawFrame"),
     ]
     suite = E2ETestSuite(test_name="Show Source Code", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_symbol_cache.py
+++ b/contrib/automation_tests/orbit_symbol_cache.py
@@ -8,8 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import LoadAllSymbolsAndVerifyCache, ClearSymbolCache, LoadSymbols, \
-    ForceAndVerifySymbolUpdate
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndVerifyCache, ClearSymbolCache, VerifyModuleLoaded
 from test_cases.main_window import EndSession
 """
 Test symbol loading with and without local caching.
@@ -38,20 +37,15 @@ This automation script covers a basic workflow:
 
 def main(argv):
     test_cases = [
+        ClearSymbolCache(),
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        ClearSymbolCache(),
-        LoadAllSymbolsAndVerifyCache(),
+        WaitForLoadingSymbolsAndVerifyCache(),
+        VerifyModuleLoaded(module_search_string="libggp"),
         EndSession(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        LoadAllSymbolsAndVerifyCache(expected_duration_difference_ratio=0.99),
-        EndSession(),
-        FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        LoadSymbols(module_search_string="libggp"),
-        EndSession(),
-        FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        ForceAndVerifySymbolUpdate(full_module_path="/user/local/cloudcast/lib/libggp.so",
-                                   replace_with_module="/mnt/developer/hello_ggp_standalone")
+        WaitForLoadingSymbolsAndVerifyCache(expected_duration_difference_ratio=0.99),
+        EndSession()
     ]
     suite = E2ETestSuite(test_name="Symbol loading and caching", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/orbit_symbol_locations.py
+++ b/contrib/automation_tests/orbit_symbol_locations.py
@@ -10,7 +10,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import ClearSymbolCache, WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols
 from test_cases.symbol_locations import AddSymbolLocation, ClearAllSymbolLocations, AddSymbolFile
 from test_cases.main_window import EndSession
 """

--- a/contrib/automation_tests/orbit_symbol_locations.py
+++ b/contrib/automation_tests/orbit_symbol_locations.py
@@ -10,7 +10,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols
+from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols, WaitForLoadingSymbolsAndCheckModule
 from test_cases.symbol_locations import AddSymbolLocation, ClearAllSymbolLocations, AddSymbolFile
 from test_cases.main_window import EndSession
 """
@@ -59,14 +59,14 @@ def main(argv):
         AddSymbolLocation(location=stale_path),
         LoadSymbols(module_search_string="no_symbols_elf", expect_fail=True),
         AddSymbolLocation(location=working_path),
-        LoadSymbols(module_search_string="no_symbols_elf"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="no_symbols_elf"),
         ClearAllSymbolLocations(),
         EndSession(),
         FilterAndSelectFirstProcess(process_filter='no_symbols_elf'),
         AddSymbolFile(location=stale_file),
         LoadSymbols(module_search_string="no_symbols_elf", expect_fail=True),
         AddSymbolFile(location=working_file),
-        LoadSymbols(module_search_string="no_symbols_elf"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="no_symbols_elf"),
         ClearAllSymbolLocations()
     ]
     suite = E2ETestSuite(test_name="Custom symbol locations", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_symbol_locations.py
+++ b/contrib/automation_tests/orbit_symbol_locations.py
@@ -10,7 +10,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols
+from test_cases.symbols_tab import ClearSymbolCache, WaitForLoadingSymbolsAndCheckModule
 from test_cases.symbol_locations import AddSymbolLocation, ClearAllSymbolLocations, AddSymbolFile
 from test_cases.main_window import EndSession
 """

--- a/contrib/automation_tests/orbit_top_down.py
+++ b/contrib/automation_tests/orbit_top_down.py
@@ -10,7 +10,7 @@ from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
 from test_cases.top_down_tab import VerifyHelloGgpTopDownContents
-from test_cases.symbols_tab import LoadSymbols
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
 """Inspect the top-down view in Orbit using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -35,8 +35,8 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        LoadSymbols(module_search_string="libc-2.24"),
-        LoadSymbols(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="libc-2.24"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
         Capture(frame_pointer_unwinding=False),
         VerifyHelloGgpTopDownContents(),
         Capture(frame_pointer_unwinding=True),

--- a/contrib/automation_tests/orbit_user_space_instrumentation.py
+++ b/contrib/automation_tests/orbit_user_space_instrumentation.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
-from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument a single function in Orbit using user space instrumentation.
 
@@ -32,7 +32,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        LoadSymbols(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(user_space_instrumentation=True),
         VerifyScopeTypeAndHitCount(scope_name='DrawFrame',

--- a/contrib/automation_tests/orbit_user_space_instrumentation_silenus.py
+++ b/contrib/automation_tests/orbit_user_space_instrumentation_silenus.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CheckTimers
-from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument a single function using user space instrumentation on Silenus.
 
@@ -33,7 +33,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="triangle.exe"),
-        LoadSymbols(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
         FilterAndHookFunction(function_search_string="Render"),
         Capture(user_space_instrumentation=True),
         CheckTimers(track_name_filter="triangle.exe", require_all=False),

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -208,7 +208,8 @@ class WaitForLoadingSymbolsAndVerifyCache(E2ETestCase):
 
 class WaitForLoadingSymbolsAndCheckModule(E2ETestCase):
     """
-    Wait for automatically loading all symbol files and checks if some specific module was loaded.
+    Waits for automatically loading all symbol files and checks if the specified module was loaded
+    successfully.
     """
     def _execute(self, module_search_string: str):
         WaitForLoadingSymbolsAndVerifyCache()

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -76,11 +76,11 @@ class ClearSymbolCache(E2ETestCase):
         self.expect_true(not os.listdir(CACHE_LOCATION), 'Cache is empty')
 
 
-class LoadAllSymbolsAndVerifyCache(E2ETestCase):
+class WaitForLoadingSymbolsAndVerifyCache(E2ETestCase):
     """
-    Loads all symbol files at once and checks if all of them exist in the cache. In addition, this test measures the
-    total duration of symbol loading (estimated), and can fail if the duration differs from the previous run by
-    a limit defined by `expected_duration_difference`.
+    Wait for automatically loading all symbol files and checks if all of them exist in the cache. In addition, this test
+    measures the total duration of symbol loading (estimated), and can fail if the duration differs from the previous
+    run by a limit defined by `expected_duration_difference`.
     """
 
     def __init__(self, **kwargs):
@@ -99,7 +99,6 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
         """
         _show_symbols_and_functions_tabs(self.suite.top_window())
         self._modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
-        self._load_all_modules()
 
         modules_loading_result = self._wait_for_loading_and_collect_errors()
 
@@ -111,14 +110,6 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
         self._verify_all_modules_are_cached(modules)
         logging.info("Done. Loading time: {time:.2f}s, module errors: {errors}".format(
             time=modules_loading_result.time, errors=modules_loading_result.errors))
-
-    def _load_all_modules(self):
-        logging.info("Loading all modules")
-        self._modules_dataview.get_item_at(0, 0).click_input()
-        # Select all
-        send_keys("^a")
-        self._modules_dataview.get_item_at(0, 0).click_input('right')
-        self.find_context_menu_item('Load Symbols').click_input()
 
     def _verify_at_least_one_module_is_loaded(self, modules: List[Module]):
         loaded_modules = [module for module in modules if module.is_loaded]
@@ -215,34 +206,13 @@ class LoadAllSymbolsAndVerifyCache(E2ETestCase):
                     "Last run duration: {last:.2f}s, current run duration: {cur:.2f}s".format(
                         expected=expected_duration, last=last_duration, cur=current_duration))
 
-
-class ForceAndVerifySymbolUpdate(E2ETestCase):
+class WaitForLoadingSymbolsAndCheckModule(E2ETestCase):
     """
-    Replace a symbol file in the cache with another file from the cache. This is used to "invalidate" symbols files
-    and verify that they are downloaded again. Then, load symbols for the replaced file and confirm that the cached
-    file has changed.
+    Wait for automatically loading all symbol files and checks if some specific module was loaded.
     """
-
-    def __execute(self, full_module_path: str, replace_with_module: str):
-        """
-        :param full_module_path: Path to the module on the gamelet
-        :param replace_with_module: Path to another module that is used as a replacement.
-
-        Both modules need to exist in the local cache.
-        """
-        dst_module = os.path.join(CACHE_LOCATION, full_module_path.replace("/", "_"))
-        src_module = os.path.join(CACHE_LOCATION, replace_with_module.replace("/", "_"))
-        old_size = os.stat(dst_module).st_size
-
-        os.unlink(os.path.join(CACHE_LOCATION, dst_module))
-        os.rename(os.path.join(CACHE_LOCATION, src_module), dst_module)
-        assert (os.stat(dst_module).st_size != old_size)
-
-        LoadSymbols(module_search_string=full_module_path).execute(self.suite)
-        self.expect_true(
-            os.stat(dst_module).st_size != old_size,
-            "Module %s has changed in cache after loading symbols" % full_module_path)
-
+    def _execute(self, module_search_string: str):
+        WaitForLoadingSymbolsAndVerifyCache()
+        VerifyModuleLoaded(module_search_string=module_search_string).execute(self.suite)
 
 class LoadSymbols(E2ETestCase):
     """
@@ -378,7 +348,7 @@ class FilterAndEnableFrameTrackForFunction(E2ETestCase):
         functions_dataview.filter.set_focus()
         functions_dataview.filter.set_edit_text('')
         send_keys(function_search_string)
-        wait_for_condition(lambda: functions_dataview.get_row_count() == 1)
+        wait_for_condition(lambda: functions_dataview.get_row_count() >= 1)
         functions_dataview.get_item_at(0, 0).click_input('right')
 
         self.find_context_menu_item('Enable frame track(s)').click_input()


### PR DESCRIPTION
In this PR we are adapting E2E tests to instead of loading symbols
manually, just wait until all the symbols are loaded automatically.

We still will need LoadSymbol method for orbit_symbol_locations E2E
test, since it needs manual symbol loading.

After thinking for a while I decided to leave 2 different methods:
- WaitForLoadingSymbolsAndVerifyCache() that it's doing exactly the same
  than the previously LoadAllSymbolsAndVerifyCache() but without the
  manual loading action (that also changes cache and measures the time).
- WaitForLoadingSymbolsAndCheckModule() that it's doing the proper
  replacement from LoadSymbols and it's waiting to after additionaly 
  checks that the desired module was loaded.

I checked a few E2E test locally and found an issue with the
requirements now that we load all the symbols because there was more
than 1 function that matched with VkQueuePresent, so I relaxed the
requirements for VerifySymbolLoaded to check "at least" one row.

This PR is a bit of draft. I would like to have a review but I need to
- Wait for merging https://github.com/google/orbit/pull/3814 and
  https://github.com/google/orbit/pull/3823.
- Rebase to that PRs.
- Create a signed build and run E2E tests to check that everything is
  working.
- Recalculate.

I expect potential issues in symbol_locations (I didn't test that one
locally yet). Some test could also fail because loading symbols after
a capture. In that case I will add a wait before or after Capture().

TODO: Align with Anton if we need to additionaly test post-symbol
loading and how. We decided that it's a P2 but I think that we should add 
this post-release.

Bug: http://b/236703806
Test:
- symbol_cache E2E pass locally (was simplified).
- add_iterator E2E pass locally.
- tracks E2E fails because devmode has more tracks. It should pass with
the changing of flags.
- capture_repeatedly E2E fails because of http://b/236976315.
- I didn't run symbol_locations. I will try to run it locally tomorrow.