### PR TITLE
Throttle calls of UpdateAfterSymbolLoading

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -332,6 +332,9 @@ OrbitApp::OrbitApp(orbit_gl::MainWindowInterface* main_window,
   data_manager_ = std::make_unique<orbit_client_data::DataManager>(main_thread_id_);
   module_manager_ = std::make_unique<orbit_client_data::ModuleManager>();
   manual_instrumentation_manager_ = std::make_unique<ManualInstrumentationManager>();
+
+  QObject::connect(&update_after_symbol_loading_throttle_, &orbit_qt_utils::Throttle::Triggered,
+                   [this]() { UpdateAfterSymbolLoading(); });
 }
 
 OrbitApp::~OrbitApp() { AbortCapture(); }
@@ -2071,8 +2074,7 @@ void OrbitApp::AddSymbols(const std::filesystem::path& module_file_path,
               module_data->file_path());
   }
 
-  UpdateAfterSymbolLoading();
-  FireRefreshCallbacks();
+  UpdateAfterSymbolLoadingThrottled();
 }
 
 orbit_base::Future<ErrorMessageOr<void>> OrbitApp::LoadSymbols(
@@ -2691,7 +2693,10 @@ void OrbitApp::UpdateAfterSymbolLoading() {
   SetSelectionBottomUpView(capture_data.selection_post_processed_sampling_data(), capture_data);
   selection_report_->UpdateReport(&capture_data.selection_callstack_data(),
                                   &capture_data.selection_post_processed_sampling_data());
+  FireRefreshCallbacks();
 }
+
+void OrbitApp::UpdateAfterSymbolLoadingThrottled() { update_after_symbol_loading_throttle_.Fire(); }
 
 void OrbitApp::UpdateAfterCaptureCleared() {
   PostProcessedSamplingData empty_post_processed_sampling_data;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2074,6 +2074,7 @@ void OrbitApp::AddSymbols(const std::filesystem::path& module_file_path,
               module_data->file_path());
   }
 
+  FireRefreshCallbacks(DataViewType::kModules);
   UpdateAfterSymbolLoadingThrottled();
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -12,6 +12,7 @@
 #include <grpcpp/channel.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -82,6 +83,7 @@
 #include "OrbitBase/StopToken.h"
 #include "OrbitBase/ThreadPool.h"
 #include "OrbitPaths/Paths.h"
+#include "QtUtils/Throttle.h"
 #include "SamplingReport.h"
 #include "ScopedStatus.h"
 #include "Statistics/BinomialConfidenceInterval.h"
@@ -362,6 +364,7 @@ class OrbitApp final : public DataViewFactory,
   void RefreshUIAfterModuleReload();
 
   void UpdateAfterSymbolLoading();
+  void UpdateAfterSymbolLoadingThrottled();
   void UpdateAfterCaptureCleared();
 
   orbit_base::Future<ErrorMessageOr<void>> LoadPresetModule(
@@ -707,6 +710,9 @@ class OrbitApp final : public DataViewFactory,
   const orbit_statistics::WilsonBinomialConfidenceIntervalEstimator confidence_interval_estimator_;
 
   std::optional<orbit_statistics::HistogramSelectionRange> histogram_selection_range_;
+
+  static constexpr std::chrono::milliseconds kMaxPostProcessingInterval{1000};
+  orbit_qt_utils::Throttle update_after_symbol_loading_throttle_{kMaxPostProcessingInterval};
 };
 
 #endif  // ORBIT_GL_APP_H_


### PR DESCRIPTION
This avoids that multiple subsequent calls to `UpdateAfterSymbolLoading`
block the UI and do the very same post processing over and over again.

The updates will be limited to at most once per second. If multiple
updates get requested during the same interval the will be combined and
only a single update will be executed after the second has passed.

This means when loading a capture post processing usually happens twice.
Once after the first module has been loaded, and once a second later when usually all other modules have finished loading.
Previously this happended once per module.

Test: Manual on Windows, with captures and live runs