### PR TITLE
`ModuleUpdateEvent`s consider multiple executable sections/maps

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitorMmapTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorMmapTest.cpp
@@ -60,6 +60,16 @@ class UprobesUnwindingVisitorMmapTest : public ::testing::Test {
   MockLeafFunctionCallManager leaf_function_call_manager_{128};
 };
 
+constexpr uint64_t kTargetFpFileSize = 27824;
+constexpr const char* kTargetFpBuildId = "d7e2447f79faa88528dd0d130ac7cc5f168ca090";
+constexpr uint64_t kTargetFpLoadBias = 0;
+constexpr uint64_t kTargetFpExecutableSegmentOffset = 0x1000;
+
+constexpr uint64_t kLibtestDllFileSize = 96441;
+constexpr const char* kLibtestDllBuildId = "";
+constexpr uint64_t kLibtestDllImageBase = 0x62640000;
+constexpr uint64_t kLibtestDllBaseOfCode = 0x1000;
+
 }  // namespace
 
 TEST_F(UprobesUnwindingVisitorMmapTest,
@@ -121,6 +131,7 @@ TEST_F(UprobesUnwindingVisitorMmapTest,
   EXPECT_CALL(maps_, AddAndSort(0x55bf53c22000, 0x55bf53c24000, 0x1000, PROT_READ | PROT_EXEC,
                                 test_binary_path))
       .Times(1);
+  EXPECT_CALL(maps_, Find(0x55bf53c22000)).Times(1);
   orbit_grpc_protos::ModuleUpdateEvent actual_module_update;
   EXPECT_CALL(listener_, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
   PerfEvent(std::move(file_mmap_event)).Accept(&visitor_);
@@ -128,12 +139,13 @@ TEST_F(UprobesUnwindingVisitorMmapTest,
   EXPECT_EQ(actual_module_update.timestamp_ns(), 3);
   EXPECT_EQ(actual_module_update.module().name(), "target_fp");
   EXPECT_EQ(actual_module_update.module().file_path(), test_binary_path);
-  EXPECT_EQ(actual_module_update.module().file_size(), 27824);
+  EXPECT_EQ(actual_module_update.module().file_size(), kTargetFpFileSize);
   EXPECT_EQ(actual_module_update.module().address_start(), 0x55bf53c22000);
   EXPECT_EQ(actual_module_update.module().address_end(), 0x55bf53c24000);
-  EXPECT_EQ(actual_module_update.module().build_id(), "d7e2447f79faa88528dd0d130ac7cc5f168ca090");
-  EXPECT_EQ(actual_module_update.module().load_bias(), 0);
-  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), 0x1000);
+  EXPECT_EQ(actual_module_update.module().build_id(), kTargetFpBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kTargetFpLoadBias);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(),
+            kTargetFpExecutableSegmentOffset);
   EXPECT_EQ(actual_module_update.module().soname(), "");
   EXPECT_EQ(actual_module_update.module().object_file_type(),
             orbit_grpc_protos::ModuleInfo::kElfFile);
@@ -174,11 +186,150 @@ TEST_F(UprobesUnwindingVisitorMmapTest,
   EXPECT_CALL(maps_, AddAndSort(0x7f4b0cabe000, 0x7f4b0cad5000, 0x3000, PROT_READ | PROT_EXEC,
                                 "/path/to/nothing"))
       .Times(1);
+  EXPECT_CALL(maps_, Find(0x7f4b0cabe000)).Times(1);
   PerfEvent(std::move(bad_file_mmap_event)).Accept(&visitor_);
 }
 
 TEST_F(UprobesUnwindingVisitorMmapTest,
-       VisitMmapPerfEventSendsModuleUpdatesFromPeCoffTextSectionInAnonExecMap) {
+       VisitMmapPerfEventSendsModuleUpdatesForElfWithTextSplitAcrossTwoMaps) {
+  const std::string test_binary_path = (orbit_test::GetTestdataDir() / "target_fp").string();
+
+  // 56224057e000-56224057f000 r--p 00000000 fe:00 60425802    /path/to/target_fp    <--
+  MmapPerfEvent segment1_mmap_data_event{
+      .timestamp = 1,
+      .data =
+          {
+              .address = 0x56224057e000,
+              .length = 0x1000,
+              .page_offset = 0,
+              .filename = test_binary_path,
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x56224057e000, 0x56224057f000, 0, PROT_READ, test_binary_path))
+      .Times(1);
+  PerfEvent(std::move(segment1_mmap_data_event)).Accept(&visitor_);
+
+  // 56224057e000-56224057f000 r--p 00000000 fe:00 60425802    /path/to/target_fp
+  // 56224057f000-562240580000 r-xp 00001000 fe:00 60425802    /path/to/target_fp    <--
+  MmapPerfEvent segment2_part1_mmap_event{
+      .timestamp = 2,
+      .data =
+          {
+              .address = 0x56224057f000,
+              .length = 0x1000,
+              .page_offset = 0x1000,
+              .filename = test_binary_path,
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x56224057f000, 0x562240580000, 0x1000, PROT_READ | PROT_EXEC,
+                                test_binary_path))
+      .Times(1);
+  EXPECT_CALL(maps_, Find(0x56224057f000)).Times(1);
+  orbit_grpc_protos::ModuleUpdateEvent actual_module_update;
+  EXPECT_CALL(listener_, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
+  PerfEvent(std::move(segment2_part1_mmap_event)).Accept(&visitor_);
+  EXPECT_EQ(actual_module_update.pid(), kPid);
+  EXPECT_EQ(actual_module_update.timestamp_ns(), 2);
+  EXPECT_EQ(actual_module_update.module().name(), "target_fp");
+  EXPECT_EQ(actual_module_update.module().file_path(), test_binary_path);
+  EXPECT_EQ(actual_module_update.module().file_size(), kTargetFpFileSize);
+  EXPECT_EQ(actual_module_update.module().address_start(), 0x56224057f000);
+  EXPECT_EQ(actual_module_update.module().address_end(), 0x562240580000);
+  EXPECT_EQ(actual_module_update.module().build_id(), kTargetFpBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kTargetFpLoadBias);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(),
+            kTargetFpExecutableSegmentOffset);
+  EXPECT_EQ(actual_module_update.module().soname(), "");
+  EXPECT_EQ(actual_module_update.module().object_file_type(),
+            orbit_grpc_protos::ModuleInfo::kElfFile);
+
+  // 56224057e000-56224057f000 r--p 00000000 fe:00 60425802    /path/to/target_fp
+  // 56224057f000-562240580000 r-xp 00001000 fe:00 60425802    /path/to/target_fp
+  // 562240580000-562240581000 r-xp 00002000 fe:00 60425802    /path/to/target_fp    <--
+  MmapPerfEvent segment2_part2_mmap_event{
+      .timestamp = 3,
+      .data =
+          {
+              .address = 0x562240580000,
+              .length = 0x1000,
+              .page_offset = 0x2000,
+              .filename = test_binary_path,
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x562240580000, 0x562240581000, 0x2000, PROT_READ | PROT_EXEC,
+                                test_binary_path))
+      .Times(1);
+  EXPECT_CALL(maps_, Find(0x562240580000)).Times(1);
+  EXPECT_CALL(listener_, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
+  PerfEvent(std::move(segment2_part2_mmap_event)).Accept(&visitor_);
+  EXPECT_EQ(actual_module_update.pid(), kPid);
+  EXPECT_EQ(actual_module_update.timestamp_ns(), 3);
+  EXPECT_EQ(actual_module_update.module().name(), "target_fp");
+  EXPECT_EQ(actual_module_update.module().file_path(), test_binary_path);
+  EXPECT_EQ(actual_module_update.module().file_size(), kTargetFpFileSize);
+  EXPECT_EQ(actual_module_update.module().address_start(),
+            0x56224057f000);  // Starts at the previous mapping, as intended.
+  EXPECT_EQ(actual_module_update.module().address_end(), 0x562240581000);
+  EXPECT_EQ(actual_module_update.module().build_id(), kTargetFpBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kTargetFpLoadBias);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(),
+            kTargetFpExecutableSegmentOffset);
+  EXPECT_EQ(actual_module_update.module().soname(), "");
+  EXPECT_EQ(actual_module_update.module().object_file_type(),
+            orbit_grpc_protos::ModuleInfo::kElfFile);
+
+  // 56224057e000-56224057f000 r--p 00000000 fe:00 60425802    /path/to/target_fp
+  // 56224057f000-562240580000 r-xp 00001000 fe:00 60425802    /path/to/target_fp
+  // 562240580000-562240581000 r-xp 00002000 fe:00 60425802    /path/to/target_fp
+  // 562240581000-562240583000 r--p 00003000 fe:00 60425802    /path/to/target_fp    <--
+  MmapPerfEvent segment3_mmap_data_event{
+      .timestamp = 4,
+      .data =
+          {
+              .address = 0x562240581000,
+              .length = 0x2000,
+              .page_offset = 0x3000,
+              .filename = test_binary_path,
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_,
+              AddAndSort(0x562240581000, 0x562240583000, 0x3000, PROT_READ, test_binary_path))
+      .Times(1);
+  PerfEvent(std::move(segment3_mmap_data_event)).Accept(&visitor_);
+
+  // 56224057e000-56224057f000 r--p 00000000 fe:00 60425802    /path/to/target_fp
+  // 56224057f000-562240580000 r-xp 00001000 fe:00 60425802    /path/to/target_fp
+  // 562240580000-562240581000 r-xp 00002000 fe:00 60425802    /path/to/target_fp
+  // 562240581000-562240583000 r--p 00003000 fe:00 60425802    /path/to/target_fp
+  // 562240583000-562240584000 rw-p 00004000 fe:00 60425802    /path/to/target_fp    <--
+  MmapPerfEvent segment4_mmap_data_event{
+      .timestamp = 5,
+      .data =
+          {
+              .address = 0x562240583000,
+              .length = 0x1000,
+              .page_offset = 0x4000,
+              .filename = test_binary_path,
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_,
+              AddAndSort(0x562240583000, 0x562240584000, 0x4000, PROT_READ, test_binary_path))
+      .Times(1);
+  PerfEvent(std::move(segment4_mmap_data_event)).Accept(&visitor_);
+}
+
+TEST_F(UprobesUnwindingVisitorMmapTest,
+       VisitMmapPerfEventSendsModuleUpdatesForPeTextSectionInAnonExecMap) {
   const std::string libtest_path = (orbit_test::GetTestdataDir() / "libtest.dll").string();
 
   // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
@@ -219,15 +370,478 @@ TEST_F(UprobesUnwindingVisitorMmapTest,
   EXPECT_EQ(actual_module_update.timestamp_ns(), 2);
   EXPECT_EQ(actual_module_update.module().name(), "libtest.dll");
   EXPECT_EQ(actual_module_update.module().file_path(), libtest_path);
-  EXPECT_EQ(actual_module_update.module().file_size(), 96441);
+  EXPECT_EQ(actual_module_update.module().file_size(), kLibtestDllFileSize);
   EXPECT_EQ(actual_module_update.module().address_start(), 0x101000);
   EXPECT_EQ(actual_module_update.module().address_end(), 0x103000);
-  EXPECT_EQ(actual_module_update.module().build_id(), "");
-  EXPECT_EQ(actual_module_update.module().load_bias(), 0x62640000);
-  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), 0x1000);
+  EXPECT_EQ(actual_module_update.module().build_id(), kLibtestDllBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kLibtestDllImageBase);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), kLibtestDllBaseOfCode);
   EXPECT_EQ(actual_module_update.module().soname(), "");
   EXPECT_EQ(actual_module_update.module().object_file_type(),
             orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+TEST_F(UprobesUnwindingVisitorMmapTest,
+       VisitMmapPerfEventSendsModuleUpdatesForPeExecutableSectionsInBothFileAndAnonMaps) {
+  const std::string libtest_path = (orbit_test::GetTestdataDir() / "libtest.dll").string();
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll    <--
+  MmapPerfEvent mmap_data_event1{
+      .timestamp = 1,
+      .data =
+          {
+              .address = 0x100000,
+              .length = 0x1000,
+              .page_offset = 0,
+              .filename = libtest_path,
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x100000, 0x101000, 0, PROT_READ, libtest_path)).Times(1);
+  PerfEvent(std::move(mmap_data_event1)).Accept(&visitor_);
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-102000 r-xp 00000000 00:00 0                             <--
+  MmapPerfEvent mmap_event2{
+      .timestamp = 2,
+      .data =
+          {
+              .address = 0x101000,
+              .length = 0x1000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x101000, 0x102000, 0, PROT_READ | PROT_EXEC, "")).Times(1);
+  EXPECT_CALL(maps_, Find(0x101000)).Times(1);
+  orbit_grpc_protos::ModuleUpdateEvent actual_module_update;
+  EXPECT_CALL(listener_, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
+  PerfEvent(std::move(mmap_event2)).Accept(&visitor_);
+  EXPECT_EQ(actual_module_update.pid(), kPid);
+  EXPECT_EQ(actual_module_update.timestamp_ns(), 2);
+  EXPECT_EQ(actual_module_update.module().name(), "libtest.dll");
+  EXPECT_EQ(actual_module_update.module().file_path(), libtest_path);
+  EXPECT_EQ(actual_module_update.module().file_size(), kLibtestDllFileSize);
+  EXPECT_EQ(actual_module_update.module().address_start(), 0x101000);
+  EXPECT_EQ(actual_module_update.module().address_end(), 0x102000);
+  EXPECT_EQ(actual_module_update.module().build_id(), kLibtestDllBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kLibtestDllImageBase);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), kLibtestDllBaseOfCode);
+  EXPECT_EQ(actual_module_update.module().soname(), "");
+  EXPECT_EQ(actual_module_update.module().object_file_type(),
+            orbit_grpc_protos::ModuleInfo::kCoffFile);
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-102000 r-xp 00000000 00:00 0
+  // 102000-103000 r-xp 00002000 01:02 42    /path/to/libtest.dll    <--
+  MmapPerfEvent mmap_event3{
+      .timestamp = 3,
+      .data =
+          {
+              .address = 0x102000,
+              .length = 0x1000,
+              .page_offset = 0x2000,
+              .filename = libtest_path,
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x102000, 0x103000, 0x2000, PROT_READ | PROT_EXEC, libtest_path))
+      .Times(1);
+  EXPECT_CALL(maps_, Find(0x102000)).Times(1);
+  EXPECT_CALL(listener_, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
+  PerfEvent(std::move(mmap_event3)).Accept(&visitor_);
+  EXPECT_EQ(actual_module_update.pid(), kPid);
+  EXPECT_EQ(actual_module_update.timestamp_ns(), 3);
+  EXPECT_EQ(actual_module_update.module().name(), "libtest.dll");
+  EXPECT_EQ(actual_module_update.module().file_path(), libtest_path);
+  EXPECT_EQ(actual_module_update.module().file_size(), kLibtestDllFileSize);
+  EXPECT_EQ(actual_module_update.module().address_start(),
+            0x101000);  // Also includes the previous mapping, as intended.
+  EXPECT_EQ(actual_module_update.module().address_end(), 0x103000);
+  EXPECT_EQ(actual_module_update.module().build_id(), kLibtestDllBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kLibtestDllImageBase);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), kLibtestDllBaseOfCode);
+  EXPECT_EQ(actual_module_update.module().soname(), "");
+  EXPECT_EQ(actual_module_update.module().object_file_type(),
+            orbit_grpc_protos::ModuleInfo::kCoffFile);
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-102000 r-xp 00000000 00:00 0
+  // 102000-103000 r-xp 00002000 01:02 42    /path/to/libtest.dll
+  // 103000-104000 r--p 00003000 01:02 42    /path/to/libtest.dll    <--
+  MmapPerfEvent mmap_data_event4{
+      .timestamp = 4,
+      .data =
+          {
+              .address = 0x103000,
+              .length = 0x1000,
+              .page_offset = 0x3000,
+              .filename = libtest_path,
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x103000, 0x104000, 0x3000, PROT_READ, libtest_path)).Times(1);
+  PerfEvent(std::move(mmap_data_event4)).Accept(&visitor_);
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-102000 r-xp 00000000 00:00 0
+  // 102000-103000 r-xp 00002000 01:02 42    /path/to/libtest.dll
+  // 103000-104000 r--p 00003000 01:02 42    /path/to/libtest.dll
+  // 104000-105000 r-xp 00000000 00:00 0                             <--
+  MmapPerfEvent mmap_event5{
+      .timestamp = 5,
+      .data =
+          {
+              .address = 0x104000,
+              .length = 0x1000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x104000, 0x105000, 0, PROT_READ | PROT_EXEC, "")).Times(1);
+  EXPECT_CALL(maps_, Find(0x104000)).Times(1);
+  EXPECT_CALL(listener_, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
+  PerfEvent(std::move(mmap_event5)).Accept(&visitor_);
+  EXPECT_EQ(actual_module_update.pid(), kPid);
+  EXPECT_EQ(actual_module_update.timestamp_ns(), 5);
+  EXPECT_EQ(actual_module_update.module().name(), "libtest.dll");
+  EXPECT_EQ(actual_module_update.module().file_path(), libtest_path);
+  EXPECT_EQ(actual_module_update.module().file_size(), kLibtestDllFileSize);
+  EXPECT_EQ(actual_module_update.module().address_start(),
+            0x101000);  // Also includes the previous two executable mappings, as intended.
+  EXPECT_EQ(actual_module_update.module().address_end(), 0x105000);
+  EXPECT_EQ(actual_module_update.module().build_id(), kLibtestDllBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kLibtestDllImageBase);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), kLibtestDllBaseOfCode);
+  EXPECT_EQ(actual_module_update.module().soname(), "");
+  EXPECT_EQ(actual_module_update.module().object_file_type(),
+            orbit_grpc_protos::ModuleInfo::kCoffFile);
+}
+
+// This test simulates the sequence of PERF_RECORD_MMAPs caused by Wine's virtual_map_image
+// (https://github.com/wine-mirror/wine/blob/dfeded6460ce067fe1c0540306c2964a170bed2a/dlls/ntdll/unix/virtual.c#L2467)
+// on a PE with SizeOfImage is 0x20000, BaseOfCode is 0x1000, and six sections, the first of
+// which executable, and the third of which writeable. The sequence of events was also deduced by
+// observing the events generated by Wine mapping triangle.exe.
+TEST_F(UprobesUnwindingVisitorMmapTest, VisitMmapPerfEventSendsModuleUpdatesForPeMappedByWine) {
+  const std::string libtest_path = (orbit_test::GetTestdataDir() / "libtest.dll").string();
+
+  // The following PERF_RECORD_MMAP(s) are caused by:
+  // map_view
+  // https://github.com/wine-mirror/wine/blob/dfeded6460ce067fe1c0540306c2964a170bed2a/dlls/ntdll/unix/virtual.c#L1936
+
+  // 100000-120000 rwxp 00000000 00:00 0    <--
+  MmapPerfEvent whole_file_mmap_event{
+      .timestamp = 1,
+      .data =
+          {
+              .address = 0x100000,
+              .length = 0x20000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x100000, 0x120000, 0, PROT_READ | PROT_EXEC, "")).Times(1);
+  EXPECT_CALL(maps_, Find(0x100000)).Times(1);
+  PerfEvent(std::move(whole_file_mmap_event)).Accept(&visitor_);
+
+  // The following PERF_RECORD_MMAP(s) are caused by:
+  // map_image_into_view's /* map the header */
+  // https://github.com/wine-mirror/wine/blob/dfeded6460ce067fe1c0540306c2964a170bed2a/dlls/ntdll/unix/virtual.c#L2238
+
+  // 100000-101000 rwxp 00000000 01:02 42    /path/to/libtest.dll    <--
+  // 101000-120000 rwxp 00000000 00:00 0
+  MmapPerfEvent headers_mmap_event{
+      .timestamp = 2,
+      .data =
+          {
+              .address = 0x100000,
+              .length = 0x1000,
+              .page_offset = 0,
+              .filename = libtest_path,
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x100000, 0x101000, 0, PROT_READ | PROT_EXEC, libtest_path))
+      .Times(1);
+  EXPECT_CALL(maps_, Find(0x100000)).Times(1);
+  orbit_grpc_protos::ModuleUpdateEvent actual_module_update;
+  EXPECT_CALL(listener_, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
+  PerfEvent(std::move(headers_mmap_event)).Accept(&visitor_);
+  EXPECT_EQ(actual_module_update.pid(), kPid);
+  EXPECT_EQ(actual_module_update.timestamp_ns(), 2);
+  EXPECT_EQ(actual_module_update.module().name(), "libtest.dll");
+  EXPECT_EQ(actual_module_update.module().file_path(), libtest_path);
+  EXPECT_EQ(actual_module_update.module().file_size(), kLibtestDllFileSize);
+  EXPECT_EQ(actual_module_update.module().address_start(), 0x100000);
+  EXPECT_EQ(actual_module_update.module().address_end(),
+            0x120000);  // Also includes the next mapping, as intended.
+  EXPECT_EQ(actual_module_update.module().build_id(), kLibtestDllBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kLibtestDllImageBase);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), kLibtestDllBaseOfCode);
+  EXPECT_EQ(actual_module_update.module().soname(), "");
+  EXPECT_EQ(actual_module_update.module().object_file_type(),
+            orbit_grpc_protos::ModuleInfo::kCoffFile);
+
+  // The following PERF_RECORD_MMAP(s) are caused by:
+  // map_image_into_view's /* map all the sections */
+  // https://github.com/wine-mirror/wine/blob/dfeded6460ce067fe1c0540306c2964a170bed2a/dlls/ntdll/unix/virtual.c#L2288
+
+  // 100000-101000 rwxp 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-103000 rw-p 00000000 00:00 0                             <--
+  // 103000-120000 rwxp 00000000 00:00 0
+  MmapPerfEvent section1_mmap_data_event{
+      .timestamp = 3,
+      .data =
+          {
+              .address = 0x101000,
+              .length = 0x2000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x101000, 0x103000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section1_mmap_data_event)).Accept(&visitor_);
+
+  // 100000-101000 rwxp 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-105000 rw-p 00000000 00:00 0                             <--
+  // 105000-120000 rwxp 00000000 00:00 0
+  MmapPerfEvent section2_mmap_data_event{
+      .timestamp = 4,
+      .data =
+          {
+              .address = 0x101000,
+              .length = 0x4000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x101000, 0x105000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section2_mmap_data_event)).Accept(&visitor_);
+
+  // 100000-101000 rwxp 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-106000 rw-p 00000000 00:00 0                             <--
+  // 106000-120000 rwxp 00000000 00:00 0
+  MmapPerfEvent section3_mmap_data_event{
+      .timestamp = 5,
+      .data =
+          {
+              .address = 0x101000,
+              .length = 0x5000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x101000, 0x106000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section3_mmap_data_event)).Accept(&visitor_);
+
+  // 100000-101000 rwxp 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-107000 rw-p 00000000 00:00 0                             <--
+  // 107000-120000 rwxp 00000000 00:00 0
+  MmapPerfEvent section4_mmap_data_event{
+      .timestamp = 6,
+      .data =
+          {
+              .address = 0x101000,
+              .length = 0x6000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x101000, 0x107000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section4_mmap_data_event)).Accept(&visitor_);
+
+  // 100000-101000 rwxp 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-11f000 rw-p 00000000 00:00 0                             <--
+  // 11f000-120000 rwxp 00000000 00:00 0
+  MmapPerfEvent section5_mmap_data_event{
+      .timestamp = 7,
+      .data =
+          {
+              .address = 0x101000,
+              .length = 0x1e000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x101000, 0x11f000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section5_mmap_data_event)).Accept(&visitor_);
+
+  // 100000-101000 rwxp 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-120000 rw-p 00000000 00:00 0                             <--
+  MmapPerfEvent section6_mmap_data_event{
+      .timestamp = 8,
+      .data =
+          {
+              .address = 0x101000,
+              .length = 0x1f000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x101000, 0x120000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section6_mmap_data_event)).Accept(&visitor_);
+
+  // The following PERF_RECORD_MMAP(s) are caused by:
+  // map_image_into_view's /* set the image protections */
+  // https://github.com/wine-mirror/wine/blob/dfeded6460ce067fe1c0540306c2964a170bed2a/dlls/ntdll/unix/virtual.c#L2378
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll    <--
+  // 101000-120000 rw-p 00000000 00:00 0
+  MmapPerfEvent headers_protection_mmap_data_event{
+      .timestamp = 9,
+      .data =
+          {
+              .address = 0x100000,
+              .length = 0x1000,
+              .page_offset = 0,
+              .filename = libtest_path,
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x100000, 0x101000, 0, PROT_READ, libtest_path)).Times(1);
+  PerfEvent(std::move(headers_protection_mmap_data_event)).Accept(&visitor_);
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-103000 r-xp 00000000 00:00 0                             <--
+  // 103000-120000 rw-p 00000000 00:00 0
+  MmapPerfEvent section1_protection_mmap_event{
+      .timestamp = 10,
+      .data =
+          {
+              .address = 0x101000,
+              .length = 0x2000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = true,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x101000, 0x103000, 0, PROT_READ | PROT_EXEC, "")).Times(1);
+  EXPECT_CALL(maps_, Find(0x101000)).Times(1);
+  EXPECT_CALL(listener_, OnModuleUpdate).Times(1).WillOnce(SaveArg<0>(&actual_module_update));
+  PerfEvent(std::move(section1_protection_mmap_event)).Accept(&visitor_);
+  EXPECT_EQ(actual_module_update.pid(), kPid);
+  EXPECT_EQ(actual_module_update.timestamp_ns(), 10);
+  EXPECT_EQ(actual_module_update.module().name(), "libtest.dll");
+  EXPECT_EQ(actual_module_update.module().file_path(), libtest_path);
+  EXPECT_EQ(actual_module_update.module().file_size(), kLibtestDllFileSize);
+  // Finally, this is the correct address range, now that only the mapping that actually corresponds
+  // to the executable section is left.
+  EXPECT_EQ(actual_module_update.module().address_start(), 0x101000);
+  EXPECT_EQ(actual_module_update.module().address_end(), 0x103000);
+  EXPECT_EQ(actual_module_update.module().build_id(), kLibtestDllBuildId);
+  EXPECT_EQ(actual_module_update.module().load_bias(), kLibtestDllImageBase);
+  EXPECT_EQ(actual_module_update.module().executable_segment_offset(), kLibtestDllBaseOfCode);
+  EXPECT_EQ(actual_module_update.module().soname(), "");
+  EXPECT_EQ(actual_module_update.module().object_file_type(),
+            orbit_grpc_protos::ModuleInfo::kCoffFile);
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-103000 r-xp 00000000 00:00 0
+  // 103000-105000 r--p 00000000 00:00 0                             <--
+  // 105000-120000 rw-p 00000000 00:00 0
+  MmapPerfEvent section2_protection_mmap_data_event{
+      .timestamp = 11,
+      .data =
+          {
+              .address = 0x103000,
+              .length = 0x2000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x103000, 0x105000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section2_protection_mmap_data_event)).Accept(&visitor_);
+
+  // Map for section 3 is already writeable so no protection change event is generated.
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-103000 r-xp 00000000 00:00 0
+  // 103000-105000 r--p 00000000 00:00 0
+  // 105000-106000 rw-p 00000000 00:00 0
+  // 106000-107000 r--p 00000000 00:00 0                             <--
+  // 107000-120000 rw-p 00000000 00:00 0
+  MmapPerfEvent section4_protection_mmap_data_event{
+      .timestamp = 12,
+      .data =
+          {
+              .address = 0x106000,
+              .length = 0x1000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x106000, 0x107000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section4_protection_mmap_data_event)).Accept(&visitor_);
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-103000 r-xp 00000000 00:00 0
+  // 103000-105000 r--p 00000000 00:00 0
+  // 105000-106000 rw-p 00000000 00:00 0
+  // 106000-11F000 r--p 00000000 00:00 0                             <--
+  // 11F000-120000 rw-p 00000000 00:00 0
+  MmapPerfEvent section5_protection_mmap_data_event{
+      .timestamp = 13,
+      .data =
+          {
+              .address = 0x106000,
+              .length = 0x19000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x106000, 0x11F000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section5_protection_mmap_data_event)).Accept(&visitor_);
+
+  // 100000-101000 r--p 00000000 01:02 42    /path/to/libtest.dll
+  // 101000-103000 r-xp 00000000 00:00 0
+  // 103000-105000 r--p 00000000 00:00 0
+  // 105000-106000 rw-p 00000000 00:00 0
+  // 106000-120000 r--p 00000000 00:00 0                             <--
+  MmapPerfEvent section6_protection_mmap_data_event{
+      .timestamp = 14,
+      .data =
+          {
+              .address = 0x106000,
+              .length = 0x1a000,
+              .page_offset = 0,
+              .filename = "",
+              .executable = false,
+              .pid = kPid,
+          },
+  };
+  EXPECT_CALL(maps_, AddAndSort(0x106000, 0x120000, 0, PROT_READ, "")).Times(1);
+  PerfEvent(std::move(section6_protection_mmap_data_event)).Accept(&visitor_);
 }
 
 }  // namespace orbit_linux_tracing


### PR DESCRIPTION
`UprobesUnwindingVisitor` uses `PERF_RECORD_MMAP` events to keep
`unwindstack::Maps` up to date for unwinding, but also to send
`ModuleUpdateEvent`s to the client. Before, it was assuming a one-to-one
relationship between executable maps and modules. In particular for games
running under Wine, we have seen that this is sometimes not the case, both for
ELF files (even with a single executable loadable segment) and for PEs (and PEs
can also simply have multiple executable sections).

Now, we try to send `ModuleUpdateEvent`s with an address range that covers all
the executable mappings for the same file, similarly to
https://github.com/google/orbit/pull/3786. In order to do this, we have to also
look at the existing maps around the new one.

And as usual, for PEs we also have to consider executable sections mapped into
anonymous executable maps, for which we take advantage of the existing logic in
`unwindstack::MapInfo::GetFileMemoryFromAnonExecMapIfPeCoffTextSection`,
as was already the case after https://github.com/google/orbit/pull/3667.

Bug: http://b/235481314
Bug: http://b/235480245

Test:
- Extend `UprobesUnwindingVisitorMmapTest`.
- Tried by capturing unaligned `triangle.exe` from the beginning by setting
  `LD_PRELOAD=libdebugger_preload.so`. Verified that the callstacks make sense.