### PR TITLE
Stop unwinding at __wine_syscall_dispatcher

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -131,6 +131,14 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
     instrumented_tracepoint->set_name(tracepoint.name());
   }
 
+  for (auto [absolute_address, size] :
+       options.absolute_address_to_size_of_functions_to_stop_unwinding_at) {
+    orbit_grpc_protos::FunctionToStopUnwindingAt* function_to_stop_unwinding_at =
+        capture_options.add_functions_to_stop_unwinding_at();
+    function_to_stop_unwinding_at->set_absolute_address(absolute_address);
+    function_to_stop_unwinding_at->set_size(size);
+  }
+
   capture_options.set_enable_api(options.enable_api);
   capture_options.set_enable_introspection(options.enable_introspection);
   ORBIT_CHECK(options.dynamic_instrumentation_method == CaptureOptions::kKernelUprobes ||

--- a/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
+++ b/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
@@ -19,6 +19,7 @@ struct ClientCaptureOptions {
 
   absl::flat_hash_map<uint64_t, orbit_client_data::FunctionInfo> selected_functions;
   orbit_client_data::TracepointInfoSet selected_tracepoints;
+  std::map<uint64_t, uint64_t> absolute_address_to_size_of_functions_to_stop_unwinding_at;
 
   orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod dynamic_instrumentation_method =
       orbit_grpc_protos::CaptureOptions::CaptureOptions::kDynamicInstrumentationMethodUnspecified;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1415,6 +1415,34 @@ static std::unique_ptr<CaptureEventProcessor> CreateCaptureEventProcessor(
   return CaptureEventProcessor::CreateCompositeProcessor(std::move(event_processors));
 }
 
+static void FindAndAddFunctionToStopUnwindingAt(
+    const std::basic_string<char>& function_name, const std::basic_string<char>& module_name,
+    const orbit_client_data::ModuleManager& module_manager, const ProcessData& process,
+    std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_unwinding_at) {
+  std::vector<orbit_client_data::ModuleInMemory> modules =
+      process.FindModulesByFilename(module_name);
+  for (const auto& module_in_memory : modules) {
+    const ModuleData* module_data = module_manager.GetModuleByPathAndBuildId(
+        module_in_memory.file_path(), module_in_memory.build_id());
+
+    const FunctionInfo* function_to_stop_unwinding_at =
+        module_data->FindFunctionFromPrettyName(function_name);
+    if (function_to_stop_unwinding_at == nullptr) {
+      continue;
+    }
+    uint64_t function_absolute_start_address =
+        orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
+            function_to_stop_unwinding_at->address(), module_in_memory.start(),
+            module_data->load_bias(), module_data->executable_segment_offset());
+
+    auto [unused_it, inserted] =
+        absolute_address_to_size_of_functions_to_stop_unwinding_at->insert_or_assign(
+            function_absolute_start_address, function_to_stop_unwinding_at->size());
+    ORBIT_CHECK(inserted);
+    break;
+  }
+}
+
 void OrbitApp::StartCapture() {
   const ProcessData* process = GetTargetProcess();
   if (process == nullptr) {
@@ -1447,30 +1475,19 @@ void OrbitApp::StartCapture() {
     selected_functions_map.insert_or_assign(function_id++, function);
   }
 
+  // With newer Wine/Proton versions, unwinding will fail after `__wine_syscall_dispatcher`
+  // (see go/unwinding_wine_syscall_dispatcher). Unless we mitigate this situation somehow
+  // differently, we at least want to report "complete" callstacks for the "Windows kernel" part
+  // (until `__wine_syscall_dispatcher`). To do so, we look for the absolute address of this
+  // function and sent in to the service as a function to stop unwinding at. The unwinder will
+  // stop on those functions and report the callstacks as "complete".
+  // Note: This requires symbols being loaded. We prioritize loading of the `ntdll.so` and rely on
+  // auto-symbol loading.
   std::map<uint64_t, uint64_t> absolute_address_to_size_of_functions_to_stop_unwinding_at;
   if (!record_user_stack_on_wine_syscall_dispatcher) {
-    std::vector<orbit_client_data::ModuleInMemory> ntdll_modules =
-        process_->FindModulesByFilename(kNtdllSo);
-    for (const auto& module_in_memory : ntdll_modules) {
-      const ModuleData* module_data = module_manager_->GetModuleByPathAndBuildId(
-          module_in_memory.file_path(), module_in_memory.build_id());
-
-      const FunctionInfo* wine_syscall_dispatcher_function =
-          module_data->FindFunctionFromPrettyName(kWineSyscallDispatcher);
-      if (wine_syscall_dispatcher_function == nullptr) {
-        continue;
-      }
-      uint64_t function_absolute_start_address =
-          orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
-              wine_syscall_dispatcher_function->address(), module_in_memory.start(),
-              module_data->load_bias(), module_data->executable_segment_offset());
-
-      auto [unused_it, inserted] =
-          absolute_address_to_size_of_functions_to_stop_unwinding_at.insert_or_assign(
-              function_absolute_start_address, wine_syscall_dispatcher_function->size());
-      ORBIT_CHECK(inserted);
-      break;
-    }
+    FindAndAddFunctionToStopUnwindingAt(
+        kWineSyscallDispatcher, kNtdllSo, *module_manager_, *process_,
+        &absolute_address_to_size_of_functions_to_stop_unwinding_at);
   }
 
   ClientCaptureOptions options;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1416,7 +1416,7 @@ static std::unique_ptr<CaptureEventProcessor> CreateCaptureEventProcessor(
 }
 
 static void FindAndAddFunctionToStopUnwindingAt(
-    const std::basic_string<char>& function_name, const std::basic_string<char>& module_name,
+    const std::string& function_name, const std::string& module_name,
     const orbit_client_data::ModuleManager& module_manager, const ProcessData& process,
     std::map<uint64_t, uint64_t>* absolute_address_to_size_of_functions_to_stop_unwinding_at) {
   std::vector<orbit_client_data::ModuleInMemory> modules =
@@ -1439,7 +1439,6 @@ static void FindAndAddFunctionToStopUnwindingAt(
         absolute_address_to_size_of_functions_to_stop_unwinding_at->insert_or_assign(
             function_absolute_start_address, function_to_stop_unwinding_at->size());
     ORBIT_CHECK(inserted);
-    break;
   }
 }
 
@@ -1479,7 +1478,7 @@ void OrbitApp::StartCapture() {
   // (see go/unwinding_wine_syscall_dispatcher). Unless we mitigate this situation somehow
   // differently, we at least want to report "complete" callstacks for the "Windows kernel" part
   // (until `__wine_syscall_dispatcher`). To do so, we look for the absolute address of this
-  // function and sent in to the service as a function to stop unwinding at. The unwinder will
+  // function and send it to the service as a function to stop unwinding at. The unwinder will
   // stop on those functions and report the callstacks as "complete".
   // Note: This requires symbols being loaded. We prioritize loading of the `ntdll.so` and rely on
   // auto-symbol loading.

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -168,8 +168,8 @@ using UnwindingMethod = orbit_grpc_protos::CaptureOptions::UnwindingMethod;
 namespace {
 
 constexpr const char* kLibOrbitVulkanLayerSoFileName = "libOrbitVulkanLayer.so";
-constexpr const char* kNtdllSo = "ntdll.so";
-constexpr const char* kWineSyscallDispatcher = "__wine_syscall_dispatcher";
+constexpr const char* kNtdllSoFileName = "ntdll.so";
+constexpr const char* kWineSyscallDispatcherFunctionName = "__wine_syscall_dispatcher";
 constexpr std::string_view kGgpVlkModulePathSubstring = "ggpvlk.so";
 
 orbit_data_views::PresetLoadState GetPresetLoadStateForProcess(const PresetFile& preset,
@@ -1485,7 +1485,7 @@ void OrbitApp::StartCapture() {
   std::map<uint64_t, uint64_t> absolute_address_to_size_of_functions_to_stop_unwinding_at;
   if (!record_user_stack_on_wine_syscall_dispatcher) {
     FindAndAddFunctionToStopUnwindingAt(
-        kWineSyscallDispatcher, kNtdllSo, *module_manager_, *process_,
+        kWineSyscallDispatcherFunctionName, kNtdllSoFileName, *module_manager_, *process_,
         &absolute_address_to_size_of_functions_to_stop_unwinding_at);
   }
 
@@ -2431,7 +2431,7 @@ Future<std::vector<ErrorMessageOr<CanceledOr<void>>>> OrbitApp::LoadAllSymbols()
 
   std::vector<const ModuleData*> sorted_module_list = SortModuleListWithPrioritizationList(
       module_manager_->GetAllModuleData(),
-      {kGgpVlkModulePathSubstring, kNtdllSo, process.full_path()});
+      {kGgpVlkModulePathSubstring, kNtdllSoFileName, process.full_path()});
 
   std::vector<Future<ErrorMessageOr<CanceledOr<void>>>> loading_futures;
 


### PR DESCRIPTION
This sends `__wine_syscall_dispatcher` (if loaded by the process) to
the service as a function to stop unwinding at and therefore omits
unwinding errors related to this function.

As the detection of `__wine_syscall_dispatcher` relies on the symbols
for `ntdll.so` being loaded, we prioritize loading of this module.
This also requires auto-symbol loading to be affective.

Follow-up:
Implement a solution that actually allows unwinding through the
dispatcher into the user-space callstack.

Test: Inspect callstacks when profiling on Silenus
Bug: http://b/236121587