### PR TITLE
ListModules Unicode support

### DIFF
--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+﻿# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
@@ -61,6 +61,9 @@ target_link_libraries(WindowsUtils PUBLIC
         CONAN_PKG::abseil)
 
 add_executable(WindowsUtilsTests)
+
+# Intentionally insert a Unicode character in the executable name to test for Unicode support.
+set_target_properties(WindowsUtilsTests PROPERTIES OUTPUT_NAME "WindowsUtilsTests🚀")
 
 target_sources(WindowsUtilsTests PRIVATE
         BusyLoopLauncherTest.cpp

--- a/src/WindowsUtils/ListModulesTest.cpp
+++ b/src/WindowsUtils/ListModulesTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+﻿// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -23,9 +23,9 @@
 
 namespace orbit_windows_utils {
 
-static std::string GetCurrentModuleName() {
+static std::string GetCurrentModuleFullPath() {
   HMODULE module_handle = NULL;
-  GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)GetCurrentModuleName,
+  GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)GetCurrentModuleFullPath,
                     &module_handle);
   ORBIT_CHECK(module_handle);
   wchar_t module_name[MAX_PATH] = {0};
@@ -38,10 +38,13 @@ TEST(ListModules, ContainsCurrentModule) {
   std::vector<Module> modules = ListModules(pid);
   EXPECT_NE(modules.size(), 0);
 
-  std::string this_module_name = GetCurrentModuleName();
+  std::string this_module_full_path = GetCurrentModuleFullPath();
+
   bool found_this_module = false;
   for (const Module& module : modules) {
-    if (module.full_path == this_module_name) {
+    if (module.full_path == this_module_full_path) {
+      constexpr const char* kModuleName = "WindowsUtilsTests🚀.exe";
+      ASSERT_TRUE(module.full_path.find(kModuleName) != std::string::npos);
       found_this_module = true;
       break;
     }


### PR DESCRIPTION
MODULEENTRY32W's module_entry.szExePath does not seem to return 
a valid Unicode string. Use GetModuleFileNameExW explicitly to retrieve
valid Unicode module names.