### PR TITLE
Use unicode string for CaptureStarted event

### DIFF
--- a/src/CaptureServiceBase/CommonProducerCaptureEventBuilders.cpp
+++ b/src/CaptureServiceBase/CommonProducerCaptureEventBuilders.cpp
@@ -54,7 +54,7 @@ ProducerCaptureEvent CreateCaptureStartedEvent(const CaptureOptions& capture_opt
 
   if (executable_path_or_error.has_value()) {
     const std::filesystem::path& executable_path = executable_path_or_error.value();
-    capture_started->set_executable_path(executable_path.string());
+    capture_started->set_executable_path(executable_path.u8string());
 
     ErrorMessageOr<std::string> build_id_or_error = ErrorMessage("");
     if (executable_path.extension() == ".exe") {
@@ -66,7 +66,7 @@ ProducerCaptureEvent CreateCaptureStartedEvent(const CaptureOptions& capture_opt
     if (build_id_or_error.has_value()) {
       capture_started->set_executable_build_id(build_id_or_error.value());
     } else {
-      ORBIT_ERROR("Unable to find build id for module \"%s\": %s", executable_path.string(),
+      ORBIT_ERROR("Unable to find build id for module \"%s\": %s", executable_path.u8string(),
                   build_id_or_error.error().message());
     }
   } else {


### PR DESCRIPTION
On Windows, if we don't explicitly use the "path::u8string()" function when
we have a unicode character in the path, we end up with a broken string 
and grpc fails.