### PR TITLE
Modify the preset tests to wait for symbol loading

### DIFF
--- a/contrib/automation_tests/orbit_load_presets.py
+++ b/contrib/automation_tests/orbit_load_presets.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import LoadAndVerifyHelloGgpPreset
+from test_cases.symbols_tab import LoadAndVerifyHelloGgpPreset, WaitForLoadingSymbolsAndVerifyCache
 """Apply two presets in Orbit using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -27,6 +27,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
+        WaitForLoadingSymbolsAndVerifyCache(),
         LoadAndVerifyHelloGgpPreset()
     ]
     suite = E2ETestSuite(test_name="Load Preset", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_load_presets_2.py
+++ b/contrib/automation_tests/orbit_load_presets_2.py
@@ -8,7 +8,8 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import FilterAndHookFunction, SavePreset, UnhookAllFunctions, LoadPreset, VerifyFunctionHooked, VerifyPresetStatus, PresetStatus, VerifyModuleLoaded
+from test_cases.symbols_tab import FilterAndHookFunction, SavePreset, UnhookAllFunctions, LoadPreset, \
+    VerifyFunctionHooked, VerifyPresetStatus, PresetStatus, WaitForLoadingSymbolsAndVerifyCache
 from test_cases.capture_window import Capture
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 from test_cases.main_window import EndSession
@@ -37,6 +38,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
+        WaitForLoadingSymbolsAndVerifyCache(),
         # Load presets and verify the respective functions get hooked.
         LoadPreset(preset_name='draw_frame_in_hello_ggp_1_68'),
         VerifyFunctionHooked(function_search_string='DrawFrame'),
@@ -79,10 +81,9 @@ def main(argv):
         VerifyPresetStatus(preset_name='partially_loadable',
                            expected_status=PresetStatus.PARTIALLY_LOADABLE),
         VerifyPresetStatus(preset_name='not_loadable', expected_status=PresetStatus.NOT_LOADABLE),
-        # Load a partially loadable preset and check that the symbols for the module get loaded.
+        # Load a partially loadable preset
         LoadPreset(preset_name='partially_loadable'),
         VerifyFunctionHooked(function_search_string='__GI___clock_gettime'),
-        VerifyModuleLoaded(module_search_string="libc-"),
     ]
     suite = E2ETestSuite(test_name="Load Preset", test_cases=test_cases)
     suite.execute()


### PR DESCRIPTION
Add `WaitForLoadingSymbolsAndVerifyCache` to the preset tests.

This could use some slight cleanup in the future: We're now using
`WaitForLoadingSymbolsAndVerifyCache` everywhere, but this test is
doing more than it needs to do. We should split the "wait for symbol
loading" functionality so it can be used separately from verifying the
cache status, but I'd do this in a follow-up.