### PR TITLE
Update game cgroup name for the tooltip

### DIFF
--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -114,7 +114,7 @@ std::string CGroupAndProcessMemoryTrack::GetLegendTooltips(size_t legend_index) 
 std::string CGroupAndProcessMemoryTrack::GetValueUpperBoundTooltip() const {
   // The developer instances have all of the same cgroup limits as the production instances, except
   // the game cgroup limit. More detailed information can be found in go/gamelet-ram-budget.
-  const std::string kGameCGroupName = "game";
+  const std::string kGameCGroupName = "user.slice/user-1000.slice/game";
   constexpr float kGameCGroupLimitGB = 7;
 
   if (cgroup_name_ != kGameCGroupName) return "";


### PR DESCRIPTION
As we changed to run game in the new cgroup "user.slice/user-1000.slice/game",
we change the game cgroup name used in Orbit.

Bug: http://b/234827603