### PR TITLE
Save bandwidth with 0 wakeup_tid/pid if wakeup_reason is kNotApplicable

### DIFF
--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -573,9 +573,9 @@ void CaptureEventProcessorForListener::ProcessThreadStateSlice(
       thread_state_slice.thread_state(),
       thread_state_slice.end_timestamp_ns() - thread_state_slice.duration_ns(),
       thread_state_slice.end_timestamp_ns(),
+      FromGrpcWakeupReasonToInfoWakeupReason(thread_state_slice.wakeup_reason()),
       thread_state_slice.wakeup_tid(),
       thread_state_slice.wakeup_pid(),
-      FromGrpcWakeupReasonToInfoWakeupReason(thread_state_slice.wakeup_reason()),
   };
 
   gpu_queue_submission_processor_.UpdateBeginCaptureTime(slice_info.begin_timestamp_ns());

--- a/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
+++ b/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
@@ -21,15 +21,15 @@ class ThreadStateSliceInfo {
   explicit ThreadStateSliceInfo(uint32_t tid,
                                 orbit_grpc_protos::ThreadStateSlice::ThreadState thread_state,
                                 uint64_t begin_timestamp_ns, uint64_t end_timestamp_ns,
-                                uint32_t wakeup_tid, uint32_t wakeup_pid,
-                                WakeupReason wakeup_reason)
+                                WakeupReason wakeup_reason, uint32_t wakeup_tid,
+                                uint32_t wakeup_pid)
       : tid_{tid},
-        wakeup_tid_(wakeup_tid),
-        wakeup_pid_{wakeup_pid},
-        wakeup_reason_{wakeup_reason},
         thread_state_{thread_state},
         begin_timestamp_ns_{begin_timestamp_ns},
-        end_timestamp_ns_{end_timestamp_ns} {}
+        end_timestamp_ns_{end_timestamp_ns},
+        wakeup_reason_{wakeup_reason},
+        wakeup_tid_(wakeup_tid),
+        wakeup_pid_{wakeup_pid} {}
 
   [[nodiscard]] uint32_t tid() const { return tid_; }
   [[nodiscard]] uint32_t wakeup_tid() const { return wakeup_tid_; }
@@ -44,12 +44,12 @@ class ThreadStateSliceInfo {
  private:
   // pid is absent as we don't yet get that information from the service.
   uint32_t tid_;
-  uint32_t wakeup_tid_;
-  uint32_t wakeup_pid_;
-  WakeupReason wakeup_reason_;
   orbit_grpc_protos::ThreadStateSlice::ThreadState thread_state_;
   uint64_t begin_timestamp_ns_;
   uint64_t end_timestamp_ns_;
+  WakeupReason wakeup_reason_;
+  uint32_t wakeup_tid_;
+  uint32_t wakeup_pid_;
 };
 
 }  // namespace orbit_client_data

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -551,14 +551,16 @@ message ThreadStateSlice {
   uint64 duration_ns = 6;
   uint64 end_timestamp_ns = 5;
 
-  uint32 wakeup_tid = 7;
-  uint32 wakeup_pid = 8;
   enum WakeupReason {
     kNotApplicable = 0;
     kUnblocked = 1;
     kCreated = 2;
   }
   WakeupReason wakeup_reason = 9;
+  // These two fields are only relevant when wakeup_reason != kNotApplicable.
+  // Otherwise, they should be 0 to minimize bandwidth usage.
+  uint32 wakeup_tid = 7;
+  uint32 wakeup_pid = 8;
 }
 
 message AddressInfo {

--- a/src/LinuxTracing/ThreadStateManager.cpp
+++ b/src/LinuxTracing/ThreadStateManager.cpp
@@ -44,8 +44,8 @@ void ThreadStateManager::OnNewTask(uint64_t timestamp_ns, pid_t tid, pid_t was_c
     return;
   }
   tid_open_states_.insert_or_assign(
-      tid, OpenState{kNewState, timestamp_ns, was_created_by_tid, was_created_by_pid,
-                     orbit_grpc_protos::ThreadStateSlice::kCreated});
+      tid, OpenState{kNewState, timestamp_ns, orbit_grpc_protos::ThreadStateSlice::kCreated,
+                     was_created_by_tid, was_created_by_pid});
 }
 
 std::optional<ThreadStateSlice> ThreadStateManager::OnSchedWakeup(uint64_t timestamp_ns, pid_t tid,
@@ -57,8 +57,8 @@ std::optional<ThreadStateSlice> ThreadStateManager::OnSchedWakeup(uint64_t times
   if (open_state_it == tid_open_states_.end()) {
     ORBIT_ERROR("Processed sched:sched_wakeup but previous state of thread %d is unknown", tid);
     tid_open_states_.insert_or_assign(
-        tid, OpenState{kNewState, timestamp_ns, was_unblocked_by_tid, was_unblocked_by_pid,
-                       orbit_grpc_protos::ThreadStateSlice::kUnblocked});
+        tid, OpenState{kNewState, timestamp_ns, orbit_grpc_protos::ThreadStateSlice::kUnblocked,
+                       was_unblocked_by_tid, was_unblocked_by_pid});
     return std::nullopt;
   }
 
@@ -66,8 +66,8 @@ std::optional<ThreadStateSlice> ThreadStateManager::OnSchedWakeup(uint64_t times
   if (timestamp_ns < open_state.begin_timestamp_ns) {
     // As noted above, overwrite the thread state retrieved at the beginning.
     tid_open_states_.insert_or_assign(
-        tid, OpenState{kNewState, timestamp_ns, was_unblocked_by_tid, was_unblocked_by_pid,
-                       orbit_grpc_protos::ThreadStateSlice::kUnblocked});
+        tid, OpenState{kNewState, timestamp_ns, orbit_grpc_protos::ThreadStateSlice::kUnblocked,
+                       was_unblocked_by_tid, was_unblocked_by_pid});
     return std::nullopt;
   }
 
@@ -88,12 +88,12 @@ std::optional<ThreadStateSlice> ThreadStateManager::OnSchedWakeup(uint64_t times
   slice.set_thread_state(open_state.state);
   slice.set_duration_ns(timestamp_ns - open_state.begin_timestamp_ns);
   slice.set_end_timestamp_ns(timestamp_ns);
+  slice.set_wakeup_reason(open_state.wakeup_reason);
   slice.set_wakeup_tid(open_state.wakeup_tid);
   slice.set_wakeup_pid(open_state.wakeup_pid);
-  slice.set_wakeup_reason(open_state.wakeup_reason);
   tid_open_states_.insert_or_assign(
-      tid, OpenState{kNewState, timestamp_ns, was_unblocked_by_tid, was_unblocked_by_pid,
-                     orbit_grpc_protos::ThreadStateSlice::kUnblocked});
+      tid, OpenState{kNewState, timestamp_ns, orbit_grpc_protos::ThreadStateSlice::kUnblocked,
+                     was_unblocked_by_tid, was_unblocked_by_pid});
   return slice;
 }
 
@@ -128,9 +128,9 @@ std::optional<ThreadStateSlice> ThreadStateManager::OnSchedSwitchIn(uint64_t tim
   slice.set_thread_state(open_state.state);
   slice.set_duration_ns(timestamp_ns - open_state.begin_timestamp_ns);
   slice.set_end_timestamp_ns(timestamp_ns);
+  slice.set_wakeup_reason(open_state.wakeup_reason);
   slice.set_wakeup_tid(open_state.wakeup_tid);
   slice.set_wakeup_pid(open_state.wakeup_pid);
-  slice.set_wakeup_reason(open_state.wakeup_reason);
   tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
   return slice;
 }
@@ -173,9 +173,9 @@ std::optional<ThreadStateSlice> ThreadStateManager::OnSchedSwitchOut(
   slice.set_thread_state(adjusted_open_state_state);
   slice.set_duration_ns(timestamp_ns - open_state.begin_timestamp_ns);
   slice.set_end_timestamp_ns(timestamp_ns);
+  slice.set_wakeup_reason(open_state.wakeup_reason);
   slice.set_wakeup_tid(open_state.wakeup_tid);
   slice.set_wakeup_pid(open_state.wakeup_pid);
-  slice.set_wakeup_reason(open_state.wakeup_reason);
 
   // Note: If the thread exits but the new_state is kZombie instead of kDead,
   // the switch to kDead will never be reported.
@@ -191,9 +191,9 @@ std::vector<ThreadStateSlice> ThreadStateManager::OnCaptureFinished(uint64_t tim
     slice.set_thread_state(open_state.state);
     slice.set_duration_ns(timestamp_ns - open_state.begin_timestamp_ns);
     slice.set_end_timestamp_ns(timestamp_ns);
+    slice.set_wakeup_reason(open_state.wakeup_reason);
     slice.set_wakeup_tid(open_state.wakeup_tid);
     slice.set_wakeup_pid(open_state.wakeup_pid);
-    slice.set_wakeup_reason(open_state.wakeup_reason);
     slices.emplace_back(std::move(slice));
   }
   return slices;

--- a/src/LinuxTracing/ThreadStateManager.h
+++ b/src/LinuxTracing/ThreadStateManager.h
@@ -62,25 +62,30 @@ class ThreadStateManager {
 
  private:
   struct OpenState {
-    OpenState(orbit_grpc_protos::ThreadStateSlice::ThreadState state, uint64_t begin_timestamp_ns,
-              pid_t wakeup_tid = orbit_base::kInvalidThreadId,
-              pid_t wakeup_pid = orbit_base::kInvalidProcessId,
-              orbit_grpc_protos::ThreadStateSlice::WakeupReason wakeup_reason =
-                  orbit_grpc_protos::ThreadStateSlice::kNotApplicable)
+    OpenState(orbit_grpc_protos::ThreadStateSlice::ThreadState state, uint64_t begin_timestamp_ns)
         : state{state},
           begin_timestamp_ns{begin_timestamp_ns},
+          wakeup_reason{orbit_grpc_protos::ThreadStateSlice::kNotApplicable},
+          wakeup_tid{0},
+          wakeup_pid{0} {}
+    OpenState(orbit_grpc_protos::ThreadStateSlice::ThreadState state, uint64_t begin_timestamp_ns,
+              orbit_grpc_protos::ThreadStateSlice::WakeupReason wakeup_reason, pid_t wakeup_tid,
+              pid_t wakeup_pid)
+        : state{state},
+          begin_timestamp_ns{begin_timestamp_ns},
+          wakeup_reason{wakeup_reason},
           wakeup_tid{wakeup_tid},
-          wakeup_pid{wakeup_pid},
-          wakeup_reason{wakeup_reason} {}
+          wakeup_pid{wakeup_pid} {}
     orbit_grpc_protos::ThreadStateSlice::ThreadState state;
     uint64_t begin_timestamp_ns;
-    // The next two fields are optional. We use them to indicate which tid and pid caused the
-    // thread to transition from a non-runnable to a runnable state.
-    pid_t wakeup_tid = orbit_base::kInvalidThreadId;
-    pid_t wakeup_pid = orbit_base::kInvalidProcessId;
-    // The following field explains the relation between this thread and the thread that woke it up.
-    orbit_grpc_protos::ThreadStateSlice::WakeupReason wakeup_reason =
-        orbit_grpc_protos::ThreadStateSlice::kNotApplicable;
+    // The following field explains the relation between this thread and the thread that woke it up
+    // (identified by wakeup_tid and wakeup_pid below).
+    orbit_grpc_protos::ThreadStateSlice::WakeupReason wakeup_reason;
+    // The next two fields are optional, and only meaningful when wakeup_reason != kNotApplicable.
+    // We use them to indicate which tid and pid caused the thread to transition from a non-runnable
+    // to the runnable state.
+    pid_t wakeup_tid;
+    pid_t wakeup_pid;
   };
 
   absl::flat_hash_map<pid_t, OpenState> tid_open_states_;

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -181,8 +181,7 @@ std::string ThreadStateBar::GetThreadStateSliceTooltip(PrimitiveAssembler& primi
       GetThreadStateName(thread_state_slice->thread_state()),
       GetThreadStateDescription(thread_state_slice->thread_state()));
 
-  if (thread_state_slice->wakeup_tid() != orbit_base::kInvalidThreadId &&
-      thread_state_slice->wakeup_reason() != ThreadStateSliceInfo::WakeupReason::kNotApplicable) {
+  if (thread_state_slice->wakeup_reason() != ThreadStateSliceInfo::WakeupReason::kNotApplicable) {
     std::string reason = GetWakeupReason(thread_state_slice->wakeup_reason());
     std::string thread_name = capture_data_->GetThreadName(thread_state_slice->wakeup_tid());
     std::string process_name = capture_data_->GetThreadName(thread_state_slice->wakeup_pid());


### PR DESCRIPTION
`ThreadStateSlice.wakeup_tid`/`pid` are not relevant if
`wakeup_reason == kNotApplicable`. In these cases, set them to 0 so that they
don't get encoded by protobuf, hence saving bandwidth and file size.

Since `wakeup_tid`/`pid` now depend on `wakeup_reason`, move them after
`wakeup_reason` in types and parameter lists.

Bug: http://b/237357657

Test:
- Capture Trata and verify thread state tooltips, in particular of the runnable
  state.
- Take a few 10-second standard captures on Trata with thread state. Monitor
  "Total number of bytes sent" in OrbitService's logs after each capture.
  Without this change: ~47 MB. With this change: ~36 MB.