### PR TITLE
Make SFID "immutable"

### DIFF
--- a/src/MizarBase/include/MizarBase/SampledFunctionId.h
+++ b/src/MizarBase/include/MizarBase/SampledFunctionId.h
@@ -20,7 +20,7 @@ struct SampledFunctionIdTag {};
 // The class represents a sampled function id. These ids are the same for the same function across
 // all the captures.
 // TODO (b/236358265) rename to `SampledFunctionId`.
-using SFID = orbit_base::Typedef<SampledFunctionIdTag, uint64_t>;
+using SFID = orbit_base::Typedef<SampledFunctionIdTag, const uint64_t>;
 
 // Making sure we do not waste memory on the abstraction
 static_assert(sizeof(SFID) == sizeof(uint64_t));

--- a/src/OrbitBase/include/OrbitBase/TypedefUtils.h
+++ b/src/OrbitBase/include/OrbitBase/TypedefUtils.h
@@ -15,6 +15,9 @@ using EnableIfUConvertibleToT = std::enable_if_t<std::is_convertible_v<U, T>>;
 template <typename T, typename U>
 using EnableIfUNotConvertibleToT = std::enable_if_t<!std::is_convertible_v<U, T>>;
 
+template <typename T>
+using EnableIfNonConst = std::enable_if<!std::is_const_v<T>>;
+
 }  // namespace orbit_base_internal
 
 #endif  // ORBIT_BASE_TYPEDEF_UTILS_H_


### PR DESCRIPTION
This changes the definition of SFID to

`using SFID = orbit_base::Typedef<SampledFunctionIdTag, uint64_t>`
adding the const.

The defintion of Typedef is also changed to SFINAE-out the
non-const accessors overloads if `T` is const. The assignment
operator is preserved even for const `T`.

Bug: http://b/237377387
Test: Unit, Compile