### PR TITLE
Compile UserSpaceInstrumentation lib with hidden symbols

### DIFF
--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -59,6 +59,8 @@ add_library(OrbitUserSpaceInstrumentation SHARED)
 # The linker flags mark all symbols coming from libraries as private and ensure that they will be hidden in the shared library.
 # The visibility properties ensure that symbols coming from this module's source files are considered private unless
 # explicitly marked visible in the source code file.
+# This avoids functions and types that we don't want to explicitly expose leaking into the target process and avoids
+# them potentially being used outside of this library.
 set_target_properties(OrbitUserSpaceInstrumentation PROPERTIES OUTPUT_NAME "orbituserspaceinstrumentation"
                                                                LINK_FLAGS "-Wl,--exclude-libs,ALL"
                                                                C_VISIBILITY_PRESET hidden

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -56,7 +56,14 @@ target_link_libraries(UserSpaceInstrumentation PUBLIC
 # executed on function entry/exit of an instrumented function.
 add_library(OrbitUserSpaceInstrumentation SHARED)
 
-set_target_properties(OrbitUserSpaceInstrumentation PROPERTIES OUTPUT_NAME "orbituserspaceinstrumentation")
+# The linker flags mark all symbols coming from libraries as private and ensure that they will be hidden in the shared library.
+# The visibility properties ensure that symbols coming from this module's source files are considered private unless
+# explicitly marked visible in the source code file.
+set_target_properties(OrbitUserSpaceInstrumentation PROPERTIES OUTPUT_NAME "orbituserspaceinstrumentation"
+                                                               LINK_FLAGS "-Wl,--exclude-libs,ALL"
+                                                               C_VISIBILITY_PRESET hidden
+                                                               CXX_VISIBILITY_PRESET hidden
+                                                               VISIBILITY_INLINES_HIDDEN 1)
 
 target_include_directories(OrbitUserSpaceInstrumentation PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -59,8 +59,8 @@ add_library(OrbitUserSpaceInstrumentation SHARED)
 # The linker flags mark all symbols coming from libraries as private and ensure that they will be hidden in the shared library.
 # The visibility properties ensure that symbols coming from this module's source files are considered private unless
 # explicitly marked visible in the source code file.
-# This avoids functions and types that we don't want to explicitly expose leaking into the target process and avoids
-# them potentially being used outside of this library.
+# This prevents functions and types that we don't want to explicitly expose from leaking into the target process and from
+# potentially being used outside of this library.
 set_target_properties(OrbitUserSpaceInstrumentation PROPERTIES OUTPUT_NAME "orbituserspaceinstrumentation"
                                                                LINK_FLAGS "-Wl,--exclude-libs,ALL"
                                                                C_VISIBILITY_PRESET hidden

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -133,6 +133,10 @@ bool& GetIsInPayload() {
 
 }  // namespace
 
+// NOTE: All symbols defined here have private linker visibility by default. Symbols that
+// need to be visible to the tracee must be marked with `[[gnu::visibility("default")]]`. Check
+// out the CMakeLists.txt file for more information.
+
 // Initialize the LockFreeUserSpaceInstrumentationEventProducer and establish the connection to
 // OrbitService.
 [[gnu::visibility("default")]] void InitializeInstrumentation() { GetCaptureEventProducer(); }

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -135,9 +135,10 @@ bool& GetIsInPayload() {
 
 // Initialize the LockFreeUserSpaceInstrumentationEventProducer and establish the connection to
 // OrbitService.
-void InitializeInstrumentation() { GetCaptureEventProducer(); }
+[[gnu::visibility("default")]] void InitializeInstrumentation() { GetCaptureEventProducer(); }
 
-void SetOrbitThreads(pid_t tid_0, pid_t tid_1, pid_t tid_2, pid_t tid_3, pid_t tid_4, pid_t tid_5) {
+[[gnu::visibility("default")]] void SetOrbitThreads(pid_t tid_0, pid_t tid_1, pid_t tid_2,
+                                                    pid_t tid_3, pid_t tid_4, pid_t tid_5) {
   orbit_threads[0] = tid_0;
   orbit_threads[1] = tid_1;
   orbit_threads[2] = tid_2;
@@ -146,12 +147,13 @@ void SetOrbitThreads(pid_t tid_0, pid_t tid_1, pid_t tid_2, pid_t tid_3, pid_t t
   orbit_threads[5] = tid_5;
 }
 
-void StartNewCapture(uint64_t capture_start_timestamp_ns) {
+[[gnu::visibility("default")]] void StartNewCapture(uint64_t capture_start_timestamp_ns) {
   current_capture_start_timestamp_ns = capture_start_timestamp_ns;
 }
 
-void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_pointer,
-                  uint64_t return_trampoline_address) {
+[[gnu::visibility("default")]] void EntryPayload(uint64_t return_address, uint64_t function_id,
+                                                 uint64_t stack_pointer,
+                                                 uint64_t return_trampoline_address) {
   bool& is_in_payload = GetIsInPayload();
   // If something in the callgraph below `EntryPayload` or `ExitPayload` was instrumented we need to
   // break the cycle here otherwise we would crash in an infinite recursion.
@@ -186,7 +188,7 @@ void EntryPayload(uint64_t return_address, uint64_t function_id, uint64_t stack_
   is_in_payload = false;
 }
 
-uint64_t ExitPayload() {
+[[gnu::visibility("default")]] uint64_t ExitPayload() {
   bool& is_in_payload = GetIsInPayload();
   is_in_payload = true;
 


### PR DESCRIPTION
This reduces the number of exported symbols to 5:

```
_init
_fini
EntryPayload
ExitPayload
StartNewCapture
InitializeInstrumentation
SetOrbitThreads
```

(Ref: http://gpaste/4822527755943936)

Previously there were hundreds of symbols from all dependencies leaking
into the game binary when injecting the library which could have caused
problems if the dynamic linker decided to use a wrong symbol.

This also reduces the size of the library from 6.5 MiB to 5 MiB.

Bug: http://b/238961475