### PR TITLE
Add ABSL_FLAG -producer_side_server to OrbitService

### DIFF
--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -45,7 +45,9 @@ int OrbitServiceMain() {
   std::atomic<bool> exit_requested = false;
   // OrbitService's loop terminates when EOF is received, no need to manipulate exit_requested.
   ErrorMessageOr<void> error_message =
-      orbit_service::OrbitService{kOrbitServicePort, /*dev_mode=*/false}.Run(&exit_requested);
+      orbit_service::OrbitService{kOrbitServicePort, /*start_producer_side_server=*/true,
+                                  /*dev_mode=*/false}
+          .Run(&exit_requested);
 
   if (error_message.has_error()) {
     ORBIT_LOG("OrbitService finished with an error: %s", error_message.error().message());

--- a/src/ProducerSideService/BuildAndStartProducerSideServerWithUri.h
+++ b/src/ProducerSideService/BuildAndStartProducerSideServerWithUri.h
@@ -10,7 +10,7 @@
 
 namespace orbit_producer_side_service {
 
-ErrorMessageOr<std::unique_ptr<ProducerSideServer>> BuildAndStartProducerSideServerWithUri(
+inline ErrorMessageOr<std::unique_ptr<ProducerSideServer>> BuildAndStartProducerSideServerWithUri(
     const std::string& uri) {
   auto producer_side_server = std::make_unique<ProducerSideServer>();
   ORBIT_LOG("Starting producer-side server at %s", uri);

--- a/src/Service/OrbitService.h
+++ b/src/Service/OrbitService.h
@@ -21,8 +21,10 @@ namespace orbit_service {
 
 class OrbitService {
  public:
-  explicit OrbitService(uint16_t grpc_port, bool dev_mode)
-      : grpc_port_{grpc_port}, dev_mode_{dev_mode} {}
+  explicit OrbitService(uint16_t grpc_port, bool start_producer_side_server, bool dev_mode)
+      : grpc_port_{grpc_port},
+        start_producer_side_server_{start_producer_side_server},
+        dev_mode_{dev_mode} {}
 
   ErrorMessageOr<void> Run(std::atomic<bool>* exit_requested);
 
@@ -30,6 +32,7 @@ class OrbitService {
   [[nodiscard]] bool IsSshWatchdogActive() { return last_stdin_message_ != std::nullopt; }
 
   uint16_t grpc_port_;
+  bool start_producer_side_server_;
   bool dev_mode_;
 
   std::optional<std::chrono::time_point<std::chrono::steady_clock>> last_stdin_message_ =

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -28,6 +28,10 @@
 
 ABSL_FLAG(uint64_t, grpc_port, 44765, "gRPC server port");
 
+ABSL_FLAG(bool, producer_side_server, true,
+          "Start the producer-side server: set it to false if you need to start a second instance "
+          "of OrbitService");
+
 ABSL_FLAG(bool, devmode, false, "Enable developer mode");
 
 namespace {
@@ -94,11 +98,12 @@ int main(int argc, char** argv) {
 
   InstallSigintHandler();
 
-  uint16_t grpc_port = absl::GetFlag(FLAGS_grpc_port);
-  bool dev_mode = absl::GetFlag(FLAGS_devmode);
+  const uint16_t grpc_port = absl::GetFlag(FLAGS_grpc_port);
+  const bool start_producer_side_server = absl::GetFlag(FLAGS_producer_side_server);
+  const bool dev_mode = absl::GetFlag(FLAGS_devmode);
 
   exit_requested = false;
-  orbit_service::OrbitService service{grpc_port, dev_mode};
+  orbit_service::OrbitService service{grpc_port, start_producer_side_server, dev_mode};
   auto result = service.Run(&exit_requested);
 
   if (!result.has_error()) return 0;


### PR DESCRIPTION
The Unix socket on which the producer-side server (which receives data from
Vulkan layer, manual instrumentation, user space instrumentation) listens on is
used to determine whether another instance of OrbitService is already running.

The new `-producer_side_server` flag allows to not start another producer-side
server and to skip this verification when starting another instance of
OrbitService (using a different TCP port for the communication with Orbit UI)
with the purpose of profiling the first instance of OrbitService.

In the end, I decided to go for a "positive" version of the flag with a `true`
default (i.e., `-producer_side_server` instead of `-no_producer_side_server`)
because `bool` Abseil flags already allow a "no" prefix to specify `false`
(i.e., `-noproducer_side_server` is equivalent to
`-producer_side_server=false`).

Test: Take a capture of a "regular" instance of OrbitService with an instance of
OrbitService that uses `-noproducer_side_server` and `-grpc_port`.