### PR TITLE
Add a sleep before checking a function is hooked in E2E

### DIFF
--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -493,7 +493,11 @@ class VerifyFunctionHooked(E2ETestCase):
         functions_dataview.filter.set_focus()
         functions_dataview.filter.set_edit_text('')
         send_keys(function_search_string)
+        # Sleep because the data_views are not optimized and could take a few ms to show the
+        # information. TODO(http://b/191204014): Erase the sleep after data views refactor.
+        time.sleep(0.1)
         row = functions_dataview.find_first_item_row(function_search_string, 1)
+        self.expect_true(row is not None, ('Function "%s" not found.', function_search_string))
         if expect_hooked:
             self.expect_true(
                 selected_function_string in functions_dataview.get_item_at(row, 0).texts()[0],

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -493,11 +493,8 @@ class VerifyFunctionHooked(E2ETestCase):
         functions_dataview.filter.set_focus()
         functions_dataview.filter.set_edit_text('')
         send_keys(function_search_string)
-        # Sleep because the data_views are not optimized and could take a few ms to show the
-        # information. TODO(http://b/191204014): Erase the sleep after data views refactor.
-        time.sleep(0.1)
+        wait_for_condition(lambda: functions_dataview.find_first_item_row(function_search_string, 1) is not None)
         row = functions_dataview.find_first_item_row(function_search_string, 1)
-        self.expect_true(row is not None, ('Function "%s" not found.', function_search_string))
         if expect_hooked:
             self.expect_true(
                 selected_function_string in functions_dataview.get_item_at(row, 0).texts()[0],


### PR DESCRIPTION
We think that load_preset_2 end is flaky because it takes a bit of time
to update the function list because there are too many after automatic
symbol loading.

So, in this PR we are adding a wait_for_condition to wait for a Row to 
appear.

PS: I'm planning to also merge in the release branch if you agree.

Bug: http://b/237513889.
Test: Run load_preset_2 manually.