### PR TITLE
[Already on release] Fix function list update

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -336,7 +336,10 @@ OrbitApp::OrbitApp(orbit_gl::MainWindowInterface* main_window,
   manual_instrumentation_manager_ = std::make_unique<ManualInstrumentationManager>();
 
   QObject::connect(&update_after_symbol_loading_throttle_, &orbit_qt_utils::Throttle::Triggered,
-                   [this]() { UpdateAfterSymbolLoading(); });
+                   [this]() {
+                     UpdateAfterSymbolLoading();
+                     FireRefreshCallbacks();
+                   });
 }
 
 OrbitApp::~OrbitApp() {
@@ -2745,7 +2748,6 @@ void OrbitApp::UpdateAfterSymbolLoading() {
   SetSelectionBottomUpView(capture_data.selection_post_processed_sampling_data(), capture_data);
   selection_report_->UpdateReport(&capture_data.selection_callstack_data(),
                                   &capture_data.selection_post_processed_sampling_data());
-  FireRefreshCallbacks();
 }
 
 void OrbitApp::UpdateAfterSymbolLoadingThrottled() { update_after_symbol_loading_throttle_.Fire(); }


### PR DESCRIPTION
This triggers `FireRefreshCallback` always after
`UpdateAfterSymbolLoading`, instead of inside
`UpdateAfterSymbolLoading`. The call inside of
`UpdateAfterSymbolLoading` happened at the end and only in the case
where a capture data was available. This meant that the function list
was not updated before there was a capture.

Compare: https://github.com/google/orbit/pull/3825/

Test: Start Orbit, let symbols load, function list is updated.
Bug: http://b/237503865