### PR TITLE
[Rebase to RELEASE] Add a sleep before checking a function is hooked

### DIFF
--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -493,6 +493,7 @@ class VerifyFunctionHooked(E2ETestCase):
         functions_dataview.filter.set_focus()
         functions_dataview.filter.set_edit_text('')
         send_keys(function_search_string)
+        wait_for_condition(lambda: functions_dataview.find_first_item_row(function_search_string, 1) is not None)
         row = functions_dataview.find_first_item_row(function_search_string, 1)
         if expect_hooked:
             self.expect_true(


### PR DESCRIPTION
We think that load_preset_2 end is flaky because it takes a bit of time
to update the function list because there are too many after automatic
symbol loading.

So, in this PR we are adding a wait_for_condition to wait for a Row to
appear.

Bug: http://b/237513889.
Test: Run load_preset_2 manually.