### PR TITLE
Implement logic for the list of threads in Mizar GUI

### DIFF
--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -92,6 +92,7 @@ int main(int argc, char** argv) {
   QApplication::setApplicationName("Mizar comparison tool");
 
   orbit_mizar_widgets::MizarMainWindow main_window;
+  main_window.Init(&bac);
   main_window.show();
   constexpr uint64_t kDuration = std::numeric_limits<uint64_t>::max();
   constexpr uint64_t kFrameTrackScopeId = 1;

--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -91,8 +91,7 @@ int main(int argc, char** argv) {
   QApplication::setOrganizationName("The Orbit Authors");
   QApplication::setApplicationName("Mizar comparison tool");
 
-  orbit_mizar_widgets::MizarMainWindow main_window;
-  main_window.Init(&bac);
+  orbit_mizar_widgets::MizarMainWindow main_window(&bac);
   main_window.show();
   constexpr uint64_t kDuration = std::numeric_limits<uint64_t>::max();
   constexpr uint64_t kFrameTrackScopeId = 1;

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -73,10 +73,10 @@ constexpr uint64_t kRelativeTimeTooLate = 1000;
 constexpr uint32_t kTID = 0x3AD1;
 constexpr uint32_t kAnotherTID = 0x3AD2;
 constexpr uint32_t kNamelessTID = 0x3AD3;
-const std::string kThreadName = "thread";
-const std::string kOtherThreadName = "other thread";
-const absl::flat_hash_map<uint32_t, std::string> kThreadNames = {{kTID, kThreadName},
-                                                                 {kAnotherTID, kOtherThreadName}};
+const std::string_view kThreadName = "thread";
+const std::string_view kOtherThreadName = "other thread";
+const absl::flat_hash_map<uint32_t, std::string> kThreadNames = {
+    {kTID, std::string(kThreadName)}, {kAnotherTID, std::string(kOtherThreadName)}};
 
 const absl::flat_hash_map<uint32_t, std::string> kSampledTidToName = [] {
   auto result = kThreadNames;

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -69,8 +69,8 @@ class BaselineAndComparisonTmpl {
         std::move(sfid_to_corrected_comparison_result));
   }
 
-  const Baseline<PairedData>& GetBaselineData() const { return baseline_; }
-  const Comparison<PairedData>& GetComparisonData() const { return comparison_; }
+  [[nodiscard]] const Baseline<PairedData>& GetBaselineData() const { return baseline_; }
+  [[nodiscard]] const Comparison<PairedData>& GetComparisonData() const { return comparison_; }
 
  private:
   [[nodiscard]] absl::flat_hash_map<SFID, CorrectedComparisonResult> MakeComparisons(

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -69,6 +69,9 @@ class BaselineAndComparisonTmpl {
         std::move(sfid_to_corrected_comparison_result));
   }
 
+  const Baseline<PairedData>& GetBaselineData() const { return baseline_; }
+  const Comparison<PairedData>& GetComparisonData() const { return comparison_; }
+
  private:
   [[nodiscard]] absl::flat_hash_map<SFID, CorrectedComparisonResult> MakeComparisons(
       const FunctionTimeComparator& comparator) const {

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -118,9 +118,8 @@ class MizarPairedDataTmpl {
           if (tid_to_names_.contains(tid)) return;
 
           const auto tid_to_name = thread_names.find(tid);
-          const std::string thread_name =
-              (tid_to_name != thread_names.end()) ? tid_to_name->second : "";
-          tid_to_names_.try_emplace(tid, thread_name);
+          std::string thread_name = (tid_to_name != thread_names.end()) ? tid_to_name->second : "";
+          tid_to_names_.try_emplace(tid, std::move(thread_name));
         });
   }
 

--- a/src/MizarWidgets/CMakeLists.txt
+++ b/src/MizarWidgets/CMakeLists.txt
@@ -29,3 +29,23 @@ target_link_libraries(MizarWidgets
 
 set_target_properties(MizarWidgets PROPERTIES AUTOMOC ON)
 set_target_properties(MizarWidgets PROPERTIES AUTOUIC ON)
+
+add_executable(MizarWidgetsTests)
+
+target_sources(MizarWidgetsTests PRIVATE
+  SamplingWithFrameTrackInputWidgetTest.cpp
+)
+
+target_link_libraries(MizarWidgetsTests PRIVATE
+  MizarWidgets
+  GTest::QtGuiMain
+  Qt5::Test
+)
+
+if(WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen")
+  register_test(MizarWidgetsTests PROPERTIES DISABLED TRUE)
+endif()
+
+if(NOT WIN32)
+  register_test(MizarWidgetsTests PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
+endif()

--- a/src/MizarWidgets/MizarMainWindow.cpp
+++ b/src/MizarWidgets/MizarMainWindow.cpp
@@ -4,15 +4,17 @@
 
 #include "MizarWidgets/MizarMainWindow.h"
 
+#include <QMainWindow>
 #include <memory>
 
 #include "ui_MizarMainWindow.h"
 
 namespace orbit_mizar_widgets {
 
-MizarMainWindow::MizarMainWindow() : ui_(std::make_unique<Ui::MainWindow>()) { ui_->setupUi(this); }
-
-void MizarMainWindow::Init(const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison) {
+MizarMainWindow::MizarMainWindow(
+    const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison, QWidget* parent)
+    : QMainWindow(parent), ui_(std::make_unique<Ui::MainWindow>()) {
+  ui_->setupUi(this);
   ui_->sampling_with_frame_track_widget_->Init(baseline_and_comparison);
 }
 

--- a/src/MizarWidgets/MizarMainWindow.cpp
+++ b/src/MizarWidgets/MizarMainWindow.cpp
@@ -12,6 +12,10 @@ namespace orbit_mizar_widgets {
 
 MizarMainWindow::MizarMainWindow() : ui_(std::make_unique<Ui::MainWindow>()) { ui_->setupUi(this); }
 
+void MizarMainWindow::Init(const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison) {
+  ui_->sampling_with_frame_track_widget_->Init(baseline_and_comparison);
+}
+
 MizarMainWindow::~MizarMainWindow() = default;
 
 }  // namespace orbit_mizar_widgets

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
@@ -43,7 +43,7 @@ void SamplingWithFrameTrackInputWidgetBase::OnThreadSelectionChanged() {
   std::transform(
       std::begin(selected_items), std::end(selected_items),
       std::inserter(selected_tids_, std::begin(selected_tids_)),
-      [this](const QListWidgetItem* item) { return tid_list_widget_items_to_tids_.at(item); });
+      [](const QListWidgetItem* item) { return item->data(kTidRole).value<uint32_t>(); });
 }
 
 SamplingWithFrameTrackInputWidgetBase::~SamplingWithFrameTrackInputWidgetBase() = default;

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
@@ -46,8 +46,6 @@ void SamplingWithFrameTrackInputWidgetBase::OnThreadSelectionChanged() {
       [this](const QListWidgetItem* item) { return tid_list_widget_items_to_tids_.at(item); });
 }
 
-SamplingWithFrameTrackInputWidgetBase::~SamplingWithFrameTrackInputWidgetBase() {
-  disconnect(GetThreadList(), nullptr, nullptr, nullptr);
-}
+SamplingWithFrameTrackInputWidgetBase::~SamplingWithFrameTrackInputWidgetBase() = default;
 
 }  // namespace orbit_mizar_widgets

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <memory>
 
+#include "MizarData/SamplingWithFrameTrackComparisonReport.h"
 #include "ui_SamplingWithFrameTrackInputWidget.h"
 
 namespace orbit_mizar_widgets {
@@ -27,6 +28,13 @@ QLabel* SamplingWithFrameTrackInputWidgetBase::GetTitle() const { return ui_->ti
 
 QListWidget* SamplingWithFrameTrackInputWidgetBase::GetThreadList() const {
   return ui_->thread_list_;
+}
+
+orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig
+SamplingWithFrameTrackInputWidgetBase::MakeConfig() const {
+  return orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig{
+      selected_tids_, 0 /*not implemented yet*/, 0 /*not implemented yet*/,
+      0 /*not implemented yet*/};
 }
 
 void SamplingWithFrameTrackInputWidgetBase::OnThreadSelectionChanged() {

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/str_format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <qlistwidget.h>
+#include <qstringliteral.h>
+
+#include <QApplication>
+#include <QTest>
+#include <string>
+
+#include "MizarWidgets/SamplingWithFrameTrackInputWidget.h"
+
+using testing::NotNull;
+using testing::ReturnRef;
+using testing::UnorderedElementsAreArray;
+
+namespace {
+class MockPairedData {
+ public:
+  MOCK_METHOD((const absl::flat_hash_map<uint32_t, std::string>&), TidToNames, (), (const));
+  MOCK_METHOD((const absl::flat_hash_map<uint32_t, std::uint64_t>&), TidToCallstackSampleCounts, (),
+              (const));
+};
+}  // namespace
+
+namespace orbit_mizar_widgets {
+
+constexpr uint32_t kTid = 0x3EAD1;
+constexpr uint32_t kOtherTid = 0x3EAD2;
+const std::string kThreadName = "Thread";
+const std::string kOtherThreadName = "Other Thread";
+constexpr uint64_t kThreadSamplesCount = 5;
+constexpr uint64_t kOtherThreadSamplesCount = 2;
+const absl::flat_hash_map<uint32_t, std::string> kTidToName = {{kTid, kThreadName},
+                                                               {kOtherTid, kOtherThreadName}};
+
+const absl::flat_hash_map<uint32_t, uint64_t> kTidToCount = {{kTid, kThreadSamplesCount},
+                                                             {kOtherTid, kOtherThreadSamplesCount}};
+constexpr size_t kThreadCount = 2;
+
+static std::string MakeThreadListItemString(std::string_view name, uint32_t tid) {
+  return absl::StrFormat("[%u] %s", tid, name);
+}
+
+const std::vector<std::string> kThreadNamesSorted = {
+    MakeThreadListItemString(kThreadName, kTid),
+    MakeThreadListItemString(kOtherThreadName, kOtherTid)};
+const QString kInputName = QStringLiteral("InputName");
+
+constexpr const char* kOrgName = "The Orbit Authors";
+
+class SamplingWithFrameTrackInputWidgetTest : public ::testing::Test {
+ public:
+  SamplingWithFrameTrackInputWidgetTest()
+      : widget_(std::make_unique<SamplingWithFrameTrackInputWidgetTmpl<MockPairedData>>(nullptr)) {
+    QApplication::setOrganizationName(kOrgName);
+    QApplication::setApplicationName("SamplingWithFrameTrackInputWidgetTest.InitIsCorrect");
+
+    EXPECT_CALL(data_, TidToNames).WillRepeatedly(ReturnRef(kTidToName));
+    EXPECT_CALL(data_, TidToCallstackSampleCounts).WillRepeatedly(ReturnRef(kTidToCount));
+
+    widget_->Init(data_, kInputName);
+
+    title_ = widget_->findChild<QLabel*>("title_");
+    EXPECT_THAT(title_, NotNull());
+
+    thread_list_ = widget_->findChild<QListWidget*>("thread_list_");
+    EXPECT_THAT(thread_list_, NotNull());
+  }
+
+  void SelectThreadListRow(int row) const {
+    thread_list_->selectionModel()->select(thread_list_->model()->index(row, 0),
+                                           QItemSelectionModel::Select);
+  }
+
+  void ClearThreadListSelection() const { thread_list_->selectionModel()->clearSelection(); }
+
+  void ExpectSelectedTidsAre(std::initializer_list<uint32_t> tids) const {
+    EXPECT_THAT(widget_->MakeConfig().tids, UnorderedElementsAreArray(tids));
+  }
+
+  MockPairedData data_;
+  std::unique_ptr<SamplingWithFrameTrackInputWidgetTmpl<MockPairedData>> widget_;
+  QLabel* title_;
+  QListWidget* thread_list_;
+};
+
+TEST_F(SamplingWithFrameTrackInputWidgetTest, InitIsCorrect) {
+  EXPECT_EQ(title_->text(), kInputName);
+
+  EXPECT_EQ(thread_list_->count(), kThreadCount);
+  for (int i = 0; i < thread_list_->count(); ++i) {
+    QListWidgetItem* item = thread_list_->item(i);
+    EXPECT_THAT(item, NotNull());
+    EXPECT_EQ(item->text().toStdString(), kThreadNamesSorted[i]);
+  }
+}
+
+TEST_F(SamplingWithFrameTrackInputWidgetTest, OnThreadSelectionChangedIsCorrect) {
+  SelectThreadListRow(0);
+  ExpectSelectedTidsAre({kTid});
+
+  SelectThreadListRow(1);
+  ExpectSelectedTidsAre({kTid, kOtherTid});
+
+  ClearThreadListSelection();
+  SelectThreadListRow(1);
+  ExpectSelectedTidsAre({kOtherTid});
+}
+
+}  // namespace orbit_mizar_widgets

--- a/src/MizarWidgets/SamplingWithFrameTrackWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackWidget.cpp
@@ -7,7 +7,7 @@
 #include <QWidget>
 #include <memory>
 
-#include "MizarData/MizarPairedData.h"
+#include "MizarData/BaselineAndComparison.h"
 #include "OrbitBase/Typedef.h"
 #include "ui_SamplingWithFrameTrackWidget.h"
 
@@ -24,13 +24,14 @@ using orbit_base::LiftAndApply;
 SamplingWithFrameTrackWidget::SamplingWithFrameTrackWidget(QWidget* parent)
     : QWidget(parent), ui_(std::make_unique<Ui::SamplingWithFrameTrackWidget>()) {
   ui_->setupUi(this);
+}
 
-  LiftAndApply(&SamplingWithFrameTrackInputWidget::Init<>, GetBaselineInput(),
-               Baseline<orbit_mizar_data::MizarPairedData*>(nullptr /*not implemented yet*/),
-               kBaselineTitle);
-  LiftAndApply(&SamplingWithFrameTrackInputWidget::Init<>, GetComparisonInput(),
-               Comparison<orbit_mizar_data::MizarPairedData*>(nullptr /*not implemented yet*/),
-               kComparisonTitle);
+void SamplingWithFrameTrackWidget::Init(
+    const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison) {
+  LiftAndApply(&SamplingWithFrameTrackInputWidget::Init, GetBaselineInput(),
+               baseline_and_comparison->GetBaselineData(), kBaselineTitle);
+  LiftAndApply(&SamplingWithFrameTrackInputWidget::Init, GetComparisonInput(),
+               baseline_and_comparison->GetComparisonData(), kComparisonTitle);
 }
 
 SamplingWithFrameTrackWidget::~SamplingWithFrameTrackWidget() = default;

--- a/src/MizarWidgets/include/MizarWidgets/MizarMainWindow.h
+++ b/src/MizarWidgets/include/MizarWidgets/MizarMainWindow.h
@@ -8,6 +8,8 @@
 #include <QMainWindow>
 #include <memory>
 
+#include "MizarData/BaselineAndComparison.h"
+
 namespace Ui {
 class MainWindow;
 }
@@ -18,6 +20,8 @@ class MizarMainWindow : public QMainWindow {
  public:
   MizarMainWindow();
   ~MizarMainWindow() override;
+
+  void Init(const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison);
 
  private:
   std::unique_ptr<Ui::MainWindow> ui_;

--- a/src/MizarWidgets/include/MizarWidgets/MizarMainWindow.h
+++ b/src/MizarWidgets/include/MizarWidgets/MizarMainWindow.h
@@ -18,10 +18,9 @@ namespace orbit_mizar_widgets {
 
 class MizarMainWindow : public QMainWindow {
  public:
-  MizarMainWindow();
+  explicit MizarMainWindow(const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison,
+                           QWidget* parent = nullptr);
   ~MizarMainWindow() override;
-
-  void Init(const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison);
 
  private:
   std::unique_ptr<Ui::MainWindow> ui_;

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -71,8 +71,8 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
     QListWidget* list = GetThreadList();
     list->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-    absl::flat_hash_map<uint32_t, std::string> tid_to_name = data.TidToNames();
-    absl::flat_hash_map<uint32_t, uint64_t> counts = data.TidToCallstackSampleCounts();
+    const absl::flat_hash_map<uint32_t, std::string>& tid_to_name = data.TidToNames();
+    const absl::flat_hash_map<uint32_t, uint64_t>& counts = data.TidToCallstackSampleCounts();
 
     std::vector<std::pair<uint32_t, uint64_t>> counts_sorted(std::begin(counts), std::end(counts));
 

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -31,14 +31,10 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
  public:
   ~SamplingWithFrameTrackInputWidgetBase() override;
 
+  [[nodiscard]] orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig MakeConfig() const;
+
  public slots:
   void OnThreadSelectionChanged();
-
-  [[nodiscard]] orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig MakeConfig() const {
-    return orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig{
-        selected_tids_, 0 /*not implemented yet*/, 0 /*not implemented yet*/,
-        0 /*not implemented yet*/};
-  }
 
  protected:
   explicit SamplingWithFrameTrackInputWidgetBase(QWidget* parent);

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -13,6 +13,7 @@
 #include <QListWidget>
 #include <QObject>
 #include <QWidget>
+#include <Qt>
 #include <memory>
 #include <string_view>
 #include <vector>
@@ -40,12 +41,12 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
   std::unique_ptr<Ui::SamplingWithFrameTrackInputWidget> ui_;
 
  protected:
-  explicit SamplingWithFrameTrackInputWidgetBase(QWidget* parent);
+  static constexpr uint32_t kTidRole = Qt::UserRole + 1;
+
+  explicit SamplingWithFrameTrackInputWidgetBase(QWidget* parent = nullptr);
 
   [[nodiscard]] QLabel* GetTitle() const;
   [[nodiscard]] QListWidget* GetThreadList() const;
-
-  absl::node_hash_map<std::unique_ptr<QListWidgetItem>, uint32_t> tid_list_widget_items_to_tids_;
 
  private:
   absl::flat_hash_set<uint32_t> selected_tids_;
@@ -78,12 +79,11 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
 
     std::sort(std::begin(counts_sorted), std::end(counts_sorted),
               [](const auto& a, const auto& b) { return a.second > b.second; });
-
     for (const auto& [tid, unused_count] : counts_sorted) {
       auto item = std::make_unique<QListWidgetItem>(
           QString::fromStdString(absl::StrFormat("[%u] %s", tid, tid_to_name.at(tid))));
-      list->addItem(item.get());
-      tid_list_widget_items_to_tids_.try_emplace(std::move(item), tid);
+      item->setData(kTidRole, tid);
+      list->addItem(item.release());
     }
   }
 };

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -5,11 +5,20 @@
 #ifndef MIZAR_WIDGETS_SAMPLING_WITH_FRAME_TRACK_INPUT_WIDGET_H_
 #define MIZAR_WIDGETS_SAMPLING_WITH_FRAME_TRACK_INPUT_WIDGET_H_
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <stdint.h>
+
+#include <QLabel>
+#include <QListWidget>
+#include <QObject>
 #include <QWidget>
 #include <memory>
 #include <string_view>
+#include <vector>
 
 #include "MizarData/MizarPairedData.h"
+#include "MizarData/SamplingWithFrameTrackComparisonReport.h"
 
 namespace Ui {
 class SamplingWithFrameTrackInputWidget;
@@ -17,17 +26,72 @@ class SamplingWithFrameTrackInputWidget;
 
 namespace orbit_mizar_widgets {
 
-class SamplingWithFrameTrackInputWidget : public QWidget {
+class SamplingWithFrameTrackInputWidgetBase : public QWidget {
+  Q_OBJECT
  public:
-  explicit SamplingWithFrameTrackInputWidget(QWidget* parent);
-  ~SamplingWithFrameTrackInputWidget() override;
+  ~SamplingWithFrameTrackInputWidgetBase() override;
 
-  template <typename PairedData = orbit_mizar_data::MizarPairedData>
-  void Init(const PairedData* data, const QString& name);
+ public slots:
+  void OnThreadSelectionChanged();
+
+  [[nodiscard]] orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig MakeConfig() const {
+    return orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig{
+        selected_tids_, 0 /*not implemented yet*/, 0 /*not implemented yet*/,
+        0 /*not implemented yet*/};
+  }
+
+ protected:
+  explicit SamplingWithFrameTrackInputWidgetBase(QWidget* parent);
+
+  [[nodiscard]] QLabel* GetTitle() const;
+  [[nodiscard]] QListWidget* GetThreadList() const;
+
+  absl::node_hash_map<std::unique_ptr<QListWidgetItem>, uint32_t> tid_list_widget_items_to_tids_;
 
  private:
+  absl::flat_hash_set<uint32_t> selected_tids_;
   std::unique_ptr<Ui::SamplingWithFrameTrackInputWidget> ui_;
 };
+
+template <typename PairedData>
+class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInputWidgetBase {
+ public:
+  SamplingWithFrameTrackInputWidgetTmpl() = delete;
+  explicit SamplingWithFrameTrackInputWidgetTmpl(QWidget* parent)
+      : SamplingWithFrameTrackInputWidgetBase(parent) {}
+  ~SamplingWithFrameTrackInputWidgetTmpl() override = default;
+
+  void Init(const PairedData& data, const QString& name) {
+    InitTitle(name);
+    InitThreadList(data);
+  }
+
+ private:
+  void InitTitle(const QString& name) { GetTitle()->setText(name); }
+
+  void InitThreadList(const PairedData& data) {
+    QListWidget* list = GetThreadList();
+    list->setSelectionMode(QAbstractItemView::ExtendedSelection);
+
+    absl::flat_hash_map<uint32_t, std::string> tid_to_name = data.TidToNames();
+    absl::flat_hash_map<uint32_t, uint64_t> counts = data.TidToCallstackSampleCounts();
+
+    std::vector<std::pair<uint32_t, uint64_t>> counts_sorted(std::begin(counts), std::end(counts));
+
+    std::sort(std::begin(counts_sorted), std::end(counts_sorted),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+
+    for (const auto& [tid, unused_count] : counts_sorted) {
+      auto item = std::make_unique<QListWidgetItem>(
+          QString::fromStdString(absl::StrFormat("[%u] %s", tid, tid_to_name.at(tid))));
+      list->addItem(item.get());
+      tid_list_widget_items_to_tids_.try_emplace(std::move(item), tid);
+    }
+  }
+};
+
+using SamplingWithFrameTrackInputWidget =
+    SamplingWithFrameTrackInputWidgetTmpl<orbit_mizar_data::MizarPairedData>;
 
 }  // namespace orbit_mizar_widgets
 

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -36,6 +36,9 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
  public slots:
   void OnThreadSelectionChanged();
 
+ private:
+  std::unique_ptr<Ui::SamplingWithFrameTrackInputWidget> ui_;
+
  protected:
   explicit SamplingWithFrameTrackInputWidgetBase(QWidget* parent);
 
@@ -46,7 +49,6 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
 
  private:
   absl::flat_hash_set<uint32_t> selected_tids_;
-  std::unique_ptr<Ui::SamplingWithFrameTrackInputWidget> ui_;
 };
 
 template <typename PairedData>

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackWidget.h
@@ -27,7 +27,7 @@ class SamplingWithFrameTrackWidget : public QWidget {
   using Comparison = ::orbit_mizar_base::Comparison<T>;
 
  public:
-  explicit SamplingWithFrameTrackWidget(QWidget* parent);
+  explicit SamplingWithFrameTrackWidget(QWidget* parent = nullptr);
   ~SamplingWithFrameTrackWidget() override;
 
   void Init(const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison);

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackWidget.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "MizarBase/BaselineOrComparison.h"
+#include "MizarData/BaselineAndComparison.h"
 #include "SamplingWithFrameTrackInputWidget.h"
 
 namespace Ui {
@@ -28,6 +29,8 @@ class SamplingWithFrameTrackWidget : public QWidget {
  public:
   explicit SamplingWithFrameTrackWidget(QWidget* parent);
   ~SamplingWithFrameTrackWidget() override;
+
+  void Init(const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison);
 
  private:
   [[nodiscard]] Baseline<SamplingWithFrameTrackInputWidget*> GetBaselineInput() const;


### PR DESCRIPTION
The list should show the list of threds we have samples for
in the descending order (that is, just like under the Sampling
tab of Orbit).

Multiple selection is allowed. When selection changes, the
state of SamplingWithFrameTrackInputWidget is updated.

For the sake of testability `SamplingWithFrameTrackInputWidget`
is templatized now. `Q_OBJECT` cannot be templatized, but its base
can, so `SamplingWithFrameTrackInputWidgetBase` was introduced.

Also, some getters are added to `BaselineAndComparison`.

`MizarPairedData` cllects some statistics upon creation now.

Tests: Compile, Unit, Manual
Bug: http://b/237532309