### PR TITLE
Return from PeCoff::Step if object is invalid

### DIFF
--- a/third_party/libunwindstack/PeCoff.cpp
+++ b/third_party/libunwindstack/PeCoff.cpp
@@ -167,6 +167,9 @@ bool PeCoff::StepIfSignalHandler(uint64_t, Regs*, Memory*) {
 
 bool PeCoff::Step(uint64_t rel_pc, uint64_t pc_adjustment, Regs* regs, Memory* process_memory,
                   bool* finished, bool* is_signal_frame) {
+  if (!valid_) {
+    return false;
+  }
   // Lock during the step which can update information in the object.
   std::lock_guard<std::mutex> guard(lock_);
   return interface_->Step(rel_pc, pc_adjustment, regs, process_memory, finished, is_signal_frame);

--- a/third_party/libunwindstack/tests/PeCoffTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffTest.cpp
@@ -263,6 +263,13 @@ TYPED_TEST(PeCoffTest, zero_size_of_image_for_invalid) {
   EXPECT_EQ(coff.GetSizeOfImage(), 0);
 }
 
+TYPED_TEST(PeCoffTest, step_fails_for_invalid) {
+  PeCoff coff(new MemoryFake);
+  EXPECT_FALSE(coff.Init());
+  EXPECT_FALSE(coff.valid());
+  EXPECT_FALSE(coff.Step(0x2000, 0, nullptr, nullptr, nullptr, nullptr));
+}
+
 TYPED_TEST(PeCoffTest, step_if_signal_handler_returns_false) {
   this->GetFake()->Init();
   FakePeCoff coff(this->ReleaseMemory());
@@ -273,6 +280,7 @@ TYPED_TEST(PeCoffTest, step_if_signal_handler_returns_false) {
 TYPED_TEST(PeCoffTest, step_succeeds_when_interface_step_succeeds) {
   this->GetFake()->Init();
   FakePeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
   MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
   EXPECT_CALL(*mock_interface, Step(0x2000, 0, nullptr, nullptr, nullptr, nullptr))
       .WillOnce(::testing::Return(true));
@@ -283,6 +291,7 @@ TYPED_TEST(PeCoffTest, step_succeeds_when_interface_step_succeeds) {
 TYPED_TEST(PeCoffTest, steps_fails_when_interface_step_fails) {
   this->GetFake()->Init();
   FakePeCoff coff(this->ReleaseMemory());
+  EXPECT_TRUE(coff.Init());
   MockPeCoffInterface* mock_interface = new MockPeCoffInterface;
   EXPECT_CALL(*mock_interface, Step(0x2000, 0, nullptr, nullptr, nullptr, nullptr))
       .WillOnce(::testing::Return(false));


### PR DESCRIPTION
When we can't initialize the PeCoffInterface member of PeCoff, the
PeCoff instance is marked as invalid and the interface member is reset
to a nullptr. This leads to a crash when trying to carry out a step in
such a case. Analogously to the Elf case, we return from PeCoff::Step
if the object is marked as invalid. Adjusted tests to match this
changed behavior.

Tested: Unit tests; tested on game.
Bug: http://b/237649102