### PR TITLE
Make PeCoffUnwindInfos::GetUnwindInfo return a pointer to an UnwindInfo

### DIFF
--- a/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.cpp
@@ -267,7 +267,7 @@ bool PeCoffUnwindInfoEvaluatorImpl::Eval(Memory* process_memory, Regs* regs,
   }
 
   if (unwind_info.HasChainedInfo()) {
-    UnwindInfo chained_unwind_info;
+    UnwindInfo* chained_unwind_info;
     if (!unwind_infos->GetUnwindInfo(unwind_info.chained_info.unwind_info_offset,
                                      &chained_unwind_info)) {
       return false;
@@ -275,7 +275,7 @@ bool PeCoffUnwindInfoEvaluatorImpl::Eval(Memory* process_memory, Regs* regs,
 
     // We have to chain all unwind operations that are in the chained info, so we pass the max
     // uint64_t value as code offset.
-    return Eval(process_memory, regs, chained_unwind_info, unwind_infos,
+    return Eval(process_memory, regs, *chained_unwind_info, unwind_infos,
                 std::numeric_limits<uint64_t>::max());
   }
 

--- a/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.cpp
+++ b/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.cpp
@@ -53,7 +53,7 @@ bool PeCoffUnwindInfoUnwinderX86_64::Step(uint64_t pc, uint64_t pc_adjustment, R
     return true;
   }
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   if (!unwind_infos_->GetUnwindInfo(function_at_pc.unwind_info_offset, &unwind_info)) {
     last_error_ = unwind_infos_->GetLastError();
     return false;
@@ -75,7 +75,7 @@ bool PeCoffUnwindInfoUnwinderX86_64::Step(uint64_t pc, uint64_t pc_adjustment, R
   // Conveniently, we know we are unwinding the innermost frame if and only if pc_adjustment == 0
   // (the value is 1 for all other frames).
   uint64_t current_offset_from_start = pc_rva - function_at_pc.start_address;
-  if (pc_adjustment == 0 && current_offset_from_start > unwind_info.prolog_size) {
+  if (pc_adjustment == 0 && current_offset_from_start > unwind_info->prolog_size) {
     bool is_in_epilog;
     // If 'DetectAndHandleEpilog' fails with an error, we have to return here.
     if (!epilog_->DetectAndHandleEpilog(function_at_pc.start_address, function_at_pc.end_address,
@@ -90,7 +90,7 @@ bool PeCoffUnwindInfoUnwinderX86_64::Step(uint64_t pc, uint64_t pc_adjustment, R
     }
   }
 
-  if (!unwind_info_evaluator_->Eval(process_memory, regs, unwind_info, unwind_infos_.get(),
+  if (!unwind_info_evaluator_->Eval(process_memory, regs, *unwind_info, unwind_infos_.get(),
                                     current_offset_from_start)) {
     last_error_ = unwind_info_evaluator_->GetLastError();
     return false;

--- a/third_party/libunwindstack/PeCoffUnwindInfos.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.h
@@ -68,9 +68,9 @@ struct UnwindInfo {
 
 class PeCoffUnwindInfos {
  public:
-  virtual ~PeCoffUnwindInfos() {}
+  virtual ~PeCoffUnwindInfos() = default;
 
-  virtual bool GetUnwindInfo(uint64_t unwind_info_rva, UnwindInfo* unwind_info) = 0;
+  virtual bool GetUnwindInfo(uint64_t unwind_info_rva, UnwindInfo** unwind_info) = 0;
   ErrorData GetLastError() const { return last_error_; }
 
  protected:

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfoEvaluatorTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfoEvaluatorTest.cpp
@@ -36,7 +36,7 @@ class MockPeCoffUnwindInfos : public PeCoffUnwindInfos {
  public:
   MockPeCoffUnwindInfos() {}
 
-  MOCK_METHOD(bool, GetUnwindInfo, (uint64_t, UnwindInfo*), (override));
+  MOCK_METHOD(bool, GetUnwindInfo, (uint64_t, UnwindInfo**), (override));
 };
 
 class PeCoffUnwindInfoEvaluatorTest : public ::testing::Test {
@@ -1078,8 +1078,8 @@ TEST_F(PeCoffUnwindInfoEvaluatorTest, succeeds_with_correct_chained_info) {
   constexpr uint32_t kChainedInfoVmAddress = 0x3000;
 
   EXPECT_CALL(mock_unwind_infos_, GetUnwindInfo(kChainedInfoVmAddress, testing::_))
-      .WillOnce([chained_info](uint64_t, UnwindInfo* unwind_info_result) {
-        *unwind_info_result = chained_info;
+      .WillOnce([&chained_info](uint64_t, UnwindInfo** unwind_info_result) {
+        *unwind_info_result = &chained_info;
         return true;
       });
 
@@ -1116,8 +1116,8 @@ TEST_F(PeCoffUnwindInfoEvaluatorTest, succeeds_with_correct_chained_info) {
   // Also validate that we skip the inner unwind info successfully if code offset is before the
   // unwind op. The chained info still must be executed in its entirety.
   EXPECT_CALL(mock_unwind_infos_, GetUnwindInfo(kChainedInfoVmAddress, testing::_))
-      .WillOnce([chained_info](uint64_t, UnwindInfo* unwind_info_result) {
-        *unwind_info_result = chained_info;
+      .WillOnce([&chained_info](uint64_t, UnwindInfo** unwind_info_result) {
+        *unwind_info_result = &chained_info;
         return true;
       });
 
@@ -1130,7 +1130,7 @@ TEST_F(PeCoffUnwindInfoEvaluatorTest, succeeds_with_correct_chained_info) {
 TEST_F(PeCoffUnwindInfoEvaluatorTest, fails_when_getting_chained_info_fails) {
   constexpr uint32_t kChainedInfoVmAddress = 0x3000;
   EXPECT_CALL(mock_unwind_infos_, GetUnwindInfo(kChainedInfoVmAddress, testing::_))
-      .WillOnce([](uint64_t, UnwindInfo*) { return false; });
+      .WillOnce([](uint64_t, UnwindInfo**) { return false; });
 
   UnwindInfo unwind_info;
   StackFrameOptions options;

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfoUnwinderX86_64Test.cpp
@@ -42,7 +42,7 @@ class MockPeCoffRuntimeFunctions : public PeCoffRuntimeFunctions {
 
 class MockPeCoffUnwindInfos : public PeCoffUnwindInfos {
  public:
-  MOCK_METHOD(bool, GetUnwindInfo, (uint64_t, UnwindInfo*), (override));
+  MOCK_METHOD(bool, GetUnwindInfo, (uint64_t, UnwindInfo**), (override));
 };
 
 class MockPeCoffEpilog : public PeCoffEpilog {
@@ -148,12 +148,13 @@ TEST(PeCoffUnwindInfoUnwinderX86_64Test,
       });
 
   std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
-  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info) {
-    UnwindInfo info;
-    info.prolog_size = 0x16;
-    *unwind_info = info;
-    return true;
-  });
+  UnwindInfo unwind_info_to_return;
+  unwind_info_to_return.prolog_size = 0x16;
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo)
+      .WillOnce([&unwind_info_to_return](uint64_t, UnwindInfo** unwind_info) {
+        *unwind_info = &unwind_info_to_return;
+        return true;
+      });
 
   std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
   EXPECT_CALL(*epilog, DetectAndHandleEpilog)
@@ -195,12 +196,13 @@ TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_fails_if_error_occurs_in_epilog_de
       });
 
   std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
-  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info) {
-    UnwindInfo info;
-    info.prolog_size = 0x16;
-    *unwind_info = info;
-    return true;
-  });
+  UnwindInfo unwind_info_to_return;
+  unwind_info_to_return.prolog_size = 0x16;
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo)
+      .WillOnce([&unwind_info_to_return](uint64_t, UnwindInfo** unwind_info) {
+        *unwind_info = &unwind_info_to_return;
+        return true;
+      });
 
   std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
   epilog->FailWithError(ERROR_MEMORY_INVALID);
@@ -243,12 +245,13 @@ TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_succeeds_if_eval_succeeds_inside_o
       });
 
   std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
-  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info_result) {
-    UnwindInfo info;
-    info.prolog_size = 0x20;
-    *unwind_info_result = info;
-    return true;
-  });
+  UnwindInfo unwind_info_to_return;
+  unwind_info_to_return.prolog_size = 0x20;
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo)
+      .WillOnce([&unwind_info_to_return](uint64_t, UnwindInfo** unwind_info) {
+        *unwind_info = &unwind_info_to_return;
+        return true;
+      });
 
   std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
   EXPECT_CALL(*epilog, DetectAndHandleEpilog).Times(0);
@@ -294,12 +297,13 @@ TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_succeeds_if_eval_succeeds_outside_
       });
 
   std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
-  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info_result) {
-    UnwindInfo info;
-    info.prolog_size = 0x8;
-    *unwind_info_result = info;
-    return true;
-  });
+  UnwindInfo unwind_info_to_return;
+  unwind_info_to_return.prolog_size = 0x8;
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo)
+      .WillOnce([&unwind_info_to_return](uint64_t, UnwindInfo** unwind_info) {
+        *unwind_info = &unwind_info_to_return;
+        return true;
+      });
 
   std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
   EXPECT_CALL(*epilog, DetectAndHandleEpilog)
@@ -346,12 +350,13 @@ TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_fails_if_eval_fails_inside_of_prol
       });
 
   std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
-  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info_result) {
-    UnwindInfo info;
-    info.prolog_size = 0x20;
-    *unwind_info_result = info;
-    return true;
-  });
+  UnwindInfo unwind_info_to_return;
+  unwind_info_to_return.prolog_size = 0x20;
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo)
+      .WillOnce([&unwind_info_to_return](uint64_t, UnwindInfo** unwind_info) {
+        *unwind_info = &unwind_info_to_return;
+        return true;
+      });
 
   std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
   EXPECT_CALL(*epilog, DetectAndHandleEpilog).Times(0);
@@ -393,12 +398,13 @@ TEST(PeCoffUnwindInfoUnwinderX86_64Test,
       });
 
   std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
-  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info_result) {
-    UnwindInfo info;
-    info.prolog_size = 0x8;
-    *unwind_info_result = info;
-    return true;
-  });
+  UnwindInfo unwind_info_to_return;
+  unwind_info_to_return.prolog_size = 0x8;
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo)
+      .WillOnce([&unwind_info_to_return](uint64_t, UnwindInfo** unwind_info) {
+        *unwind_info = &unwind_info_to_return;
+        return true;
+      });
 
   std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
   EXPECT_CALL(*epilog, DetectAndHandleEpilog).Times(0);
@@ -444,12 +450,13 @@ TEST(PeCoffUnwindInfoUnwinderX86_64Test, step_fails_after_eval_if_return_address
       });
 
   std::unique_ptr<MockPeCoffUnwindInfos> unwind_infos = std::make_unique<MockPeCoffUnwindInfos>();
-  EXPECT_CALL(*unwind_infos, GetUnwindInfo).WillOnce([](uint64_t, UnwindInfo* unwind_info_result) {
-    UnwindInfo info;
-    info.prolog_size = 0x20;
-    *unwind_info_result = info;
-    return true;
-  });
+  UnwindInfo unwind_info_to_return;
+  unwind_info_to_return.prolog_size = 0x20;
+  EXPECT_CALL(*unwind_infos, GetUnwindInfo)
+      .WillOnce([&unwind_info_to_return](uint64_t, UnwindInfo** unwind_info) {
+        *unwind_info = &unwind_info_to_return;
+        return true;
+      });
 
   std::unique_ptr<MockPeCoffEpilog> epilog = std::make_unique<MockPeCoffEpilog>();
   EXPECT_CALL(*epilog, DetectAndHandleEpilog).Times(0);

--- a/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
+++ b/third_party/libunwindstack/tests/PeCoffUnwindInfosTest.cpp
@@ -102,11 +102,11 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_on_well_formed_data_no_ch
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
-  EXPECT_EQ(2, unwind_info.num_codes);
+  EXPECT_EQ(2, unwind_info->num_codes);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_multiple_times) {
@@ -124,18 +124,18 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_multiple_times) {
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
 
   // This should read from the cache, though we don't verify that here. The returned
   // data should be the same, though.
-  UnwindInfo unwind_info2;
+  UnwindInfo* unwind_info2;
   EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info2));
 
-  EXPECT_EQ(unwind_info.version_and_flags, unwind_info2.version_and_flags);
-  EXPECT_EQ(unwind_info.prolog_size, unwind_info2.prolog_size);
-  EXPECT_EQ(unwind_info.num_codes, unwind_info2.num_codes);
-  EXPECT_EQ(unwind_info.frame_register_and_offset, unwind_info2.frame_register_and_offset);
+  EXPECT_EQ(unwind_info->version_and_flags, unwind_info2->version_and_flags);
+  EXPECT_EQ(unwind_info->prolog_size, unwind_info2->prolog_size);
+  EXPECT_EQ(unwind_info->num_codes, unwind_info2->num_codes);
+  EXPECT_EQ(unwind_info->frame_register_and_offset, unwind_info2->frame_register_and_offset);
 }
 
 TEST_F(PeCoffUnwindInfosTest,
@@ -150,11 +150,11 @@ TEST_F(PeCoffUnwindInfosTest,
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
-  EXPECT_EQ(2, unwind_info.num_codes);
+  EXPECT_EQ(2, unwind_info->num_codes);
 }
 
 TEST_F(PeCoffUnwindInfosTest,
@@ -173,11 +173,11 @@ TEST_F(PeCoffUnwindInfosTest,
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
-  EXPECT_EQ(3, unwind_info.num_codes);
+  EXPECT_EQ(3, unwind_info->num_codes);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_with_exception_handler_data) {
@@ -190,11 +190,11 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_with_exception_handler_da
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
-  EXPECT_EQ(2, unwind_info.num_codes);
+  EXPECT_EQ(2, unwind_info->num_codes);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_on_version_2) {
@@ -209,11 +209,11 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_succeeds_on_version_2) {
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_TRUE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_NONE, unwind_infos->GetLastError().code);
 
-  EXPECT_EQ(2, unwind_info.num_codes);
+  EXPECT_EQ(2, unwind_info->num_codes);
 }
 
 TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_bad_version) {
@@ -229,7 +229,7 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_bad_version) {
     std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
         CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-    UnwindInfo unwind_info;
+    UnwindInfo* unwind_info;
     EXPECT_FALSE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
     EXPECT_EQ(ERROR_INVALID_COFF, unwind_infos->GetLastError().code);
   }
@@ -240,7 +240,7 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_bad_memory) {
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_FALSE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos->GetLastError().code);
 
@@ -263,7 +263,7 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_incomplete_op_codes_memor
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_FALSE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos->GetLastError().code);
   EXPECT_EQ(expected_error_address, unwind_infos->GetLastError().address);
@@ -282,7 +282,7 @@ TEST_F(PeCoffUnwindInfosTest, get_unwind_info_fails_on_incomplete_chained_info) 
   std::unique_ptr<PeCoffUnwindInfos> unwind_infos(
       CreatePeCoffUnwindInfos(GetMemoryFake(), kSections));
 
-  UnwindInfo unwind_info;
+  UnwindInfo* unwind_info;
   EXPECT_FALSE(unwind_infos->GetUnwindInfo(kVmAddress, &unwind_info));
   EXPECT_EQ(ERROR_MEMORY_INVALID, unwind_infos->GetLastError().code);
   EXPECT_EQ(expected_error_address, unwind_infos->GetLastError().address);

--- a/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
+++ b/third_party/libunwindstack/tests/fuzz/PeCoffUnwindInfosFuzzer.cpp
@@ -39,7 +39,7 @@ void FuzzPeCoffUnwindInfos(const uint8_t* data, size_t size) {
       unwindstack::Section{"all_addresses", kUint32Max, 0, kUint32Max, 0, 0}};
   std::unique_ptr<unwindstack::PeCoffUnwindInfos> pe_coff_unwind_infos(
       CreatePeCoffUnwindInfos(memory.get(), sections));
-  unwindstack::UnwindInfo info;
+  unwindstack::UnwindInfo* info;
   // Try all possible offsets to increase coverage. This will also test the parser
   // running over the end of the memory.
   for (size_t offset = 0; offset < size; ++offset) {


### PR DESCRIPTION
This makes `PeCoffUnwindInfos::GetUnwindInfo` avoid a copy when returning an
`UnwindInfo`. Since this is a complex type, containing in particular a
`std::vector<UnwindCode>`, this is a measurable optimization. In my test, this
makes unwinding a single frame around 10% faster.

Note that `PeCoffUnwindInfosImpl` returns a pointer to an `UnwindInfo` contained
in an `std::unordered_map`. For this container, "references and pointers to
either key or data stored in the container are only invalidated by erasing that
element, even when the corresponding iterator is invalidated", so the returned
pointer stays valid even if another call to `GetUnwindInfo` causes the container
to be rehashed.

Bug: http://b/237625163

Test: Capture complex game running on Wine.