### PR TITLE
Change position & size calculation of triangle toggle

### DIFF
--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -120,10 +120,10 @@ void TrackHeader::UpdateCollapseToggle() {
   const float x0 = GetPos()[0] + layout_->GetTrackTabOffset() +
                    layout_->GetTrackIndentOffset() * track_->GetIndentationLevel();
   const float button_offset = layout_->GetCollapseButtonOffset();
-  const float toggle_y_pos = GetPos()[1] + half_label_height;
+  const float size = layout_->GetCollapseButtonSize(track_->GetIndentationLevel());
+  const float toggle_y_pos = GetPos()[1] + half_label_height - size / 2;
   Vec2 toggle_pos = Vec2(x0 + button_offset, toggle_y_pos);
 
-  float size = layout_->GetCollapseButtonSize(track_->GetIndentationLevel());
   collapse_toggle_->SetWidth(size);
   collapse_toggle_->SetHeight(size);
   collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1]);

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -34,32 +34,29 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
   Color color = is_collapsible_ ? kWhite : kGrey;
 
   // Draw triangle.
-  const Vec2 pos = GetPos();
-  if (!picking) {
-    Vec2 midpoint = GetPos() + Vec2(GetWidth() / 2, GetHeight() / 2);
+  const Vec2 midpoint = GetPos() + Vec2(GetWidth() / 2, GetHeight() / 2);
+  const float triangle_side_length = std::min(GetWidth(), GetHeight());
+  const float triangle_height = triangle_side_length * sqrtf(3.f) * 0.5f;
 
+  const float half_triangle_height = std::ceilf(triangle_height / 2);
+  const float half_triangle_side_length = triangle_side_length / 2;
+
+  if (!picking) {
     Triangle triangle;
     if (is_collapsed_) {
-      const float triangle_height = sqrtf(3.f) * GetWidth() * 0.5f;
-      const float half_triangle_base_width = 0.5f * GetHeight();
-      const float half_triangle_height = std::ceilf(triangle_height / 2);
-
-      triangle = Triangle(midpoint + Vec2(-half_triangle_height, half_triangle_base_width),
-                          midpoint + Vec2(-half_triangle_height, -half_triangle_base_width),
+      triangle = Triangle(midpoint + Vec2(-half_triangle_height, half_triangle_side_length),
+                          midpoint + Vec2(-half_triangle_height, -half_triangle_side_length),
                           midpoint + Vec2(half_triangle_height, 0.f));
     } else {
-      const float triangle_height = sqrtf(3.f) * GetHeight() * 0.5f;
-      const float half_triangle_base_width = 0.5f * GetWidth();
-      const float half_triangle_height = std::ceilf(triangle_height / 2);
-
-      triangle = Triangle(midpoint + Vec2(half_triangle_base_width, -half_triangle_height),
-                          midpoint + Vec2(-half_triangle_base_width, -half_triangle_height),
+      triangle = Triangle(midpoint + Vec2(half_triangle_side_length, -half_triangle_height),
+                          midpoint + Vec2(-half_triangle_side_length, -half_triangle_height),
                           midpoint + Vec2(0.f, half_triangle_height));
     }
     primitive_assembler.AddTriangle(triangle, z, color, shared_from_this());
   } else {
     // When picking, draw a big square for easier picking.
-    Quad box = MakeBox(Vec2(pos[0], pos[1]), GetSize());
+    Quad box = MakeBox(midpoint - Vec2(half_triangle_side_length, half_triangle_side_length),
+                       Vec2(triangle_side_length, triangle_side_length));
     primitive_assembler.AddBox(box, z, color, shared_from_this());
   }
 }

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -36,9 +36,10 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
   // Draw triangle.
   const Vec2 midpoint = GetPos() + Vec2(GetWidth() / 2, GetHeight() / 2);
   const float triangle_side_length = std::min(GetWidth(), GetHeight());
-  const float triangle_height = triangle_side_length * sqrtf(3.f) * 0.5f;
+  const float kCos30 = sqrtf(3.f) / 2;
+  const float triangle_height = triangle_side_length * kCos30;
 
-  const float half_triangle_height = std::ceilf(triangle_height / 2);
+  const float half_triangle_height = ceilf(triangle_height / 2);
   const float half_triangle_side_length = triangle_side_length / 2;
 
   if (!picking) {

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -34,31 +34,32 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
   Color color = is_collapsible_ ? kWhite : kGrey;
 
   // Draw triangle.
-  static float half_sqrt_three = 0.5f * sqrtf(3.f);
-  float half_triangle_base_width = 0.5f * GetWidth();
-  float half_triangle_height = half_sqrt_three * 0.5f * GetHeight();
-
   const Vec2 pos = GetPos();
   if (!picking) {
-    Vec2 position(pos[0], pos[1]);
+    Vec2 midpoint = GetPos() + Vec2(GetWidth() / 2, GetHeight() / 2);
 
     Triangle triangle;
     if (is_collapsed_) {
-      triangle = Triangle(position + Vec2(-half_triangle_height, half_triangle_base_width),
-                          position + Vec2(-half_triangle_height, -half_triangle_base_width),
-                          position + Vec2(half_triangle_base_width, 0.f));
+      const float triangle_height = sqrtf(3.f) * GetWidth() * 0.5f;
+      const float half_triangle_base_width = 0.5f * GetHeight();
+      const float half_triangle_height = std::ceilf(triangle_height / 2);
+
+      triangle = Triangle(midpoint + Vec2(-half_triangle_height, half_triangle_base_width),
+                          midpoint + Vec2(-half_triangle_height, -half_triangle_base_width),
+                          midpoint + Vec2(half_triangle_height, 0.f));
     } else {
-      triangle = Triangle(position + Vec2(half_triangle_base_width, -half_triangle_height),
-                          position + Vec2(-half_triangle_base_width, -half_triangle_height),
-                          position + Vec2(0.f, half_triangle_base_width));
+      const float triangle_height = sqrtf(3.f) * GetHeight() * 0.5f;
+      const float half_triangle_base_width = 0.5f * GetWidth();
+      const float half_triangle_height = std::ceilf(triangle_height / 2);
+
+      triangle = Triangle(midpoint + Vec2(half_triangle_base_width, -half_triangle_height),
+                          midpoint + Vec2(-half_triangle_base_width, -half_triangle_height),
+                          midpoint + Vec2(0.f, half_triangle_height));
     }
     primitive_assembler.AddTriangle(triangle, z, color, shared_from_this());
   } else {
     // When picking, draw a big square for easier picking.
-    float original_width = 2 * half_triangle_base_width;
-    float large_width = 2 * original_width;
-    Quad box = MakeBox(Vec2(pos[0] - original_width, pos[1] - original_width),
-                       Vec2(large_width, large_width));
+    Quad box = MakeBox(Vec2(pos[0], pos[1]), GetSize());
     primitive_assembler.AddBox(box, z, color, shared_from_this());
   }
 }


### PR DESCRIPTION
Previously, pos() of the triangle toggle was incorrectly set to the
midpoint of the triangle, and the calculation did not take width /
height into account correctly in the collapsed case (with() was always
assumed to be the baseline of the triangle).

Test: Ran affected E2E tests
Bug: b/236939337