### PR TITLE
Move container helper functions used in tests to TestUtils

### DIFF
--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -21,6 +21,7 @@
 #include "MizarData/BaselineAndComparison.h"
 #include "MizarStatistics/ActiveFunctionTimePerFrameComparator.h"
 #include "OrbitBase/ThreadConstants.h"
+#include "TestUtils/ContainerHelpers.h"
 
 using ::orbit_mizar_base::SFID;
 using ::testing::DoubleNear;
@@ -35,6 +36,9 @@ using Comparison = ::orbit_mizar_base::Comparison<T>;
 using ::orbit_mizar_base::MakeBaseline;
 using ::orbit_mizar_base::MakeComparison;
 
+using orbit_test_utils::Commons;
+using orbit_test_utils::MakeMap;
+
 namespace orbit_mizar_data {
 
 constexpr size_t kFunctionNum = 3;
@@ -43,35 +47,8 @@ constexpr std::array<uint64_t, kFunctionNum> kComparisonFunctionAddresses = {0x0
 const std::array<std::string, kFunctionNum> kBaselineFunctionNames = {"foo()", "bar()", "biz()"};
 const std::array<std::string, kFunctionNum> kComparisonFunctionNames = {"foo()", "bar()", "fiz()"};
 
-// TODO(b/237743774) move to TestUtils
-template <typename Container>
-[[nodiscard]] static auto Commons(const Container& a, const Container& b) {
-  using E = typename Container::value_type;
-  using std::begin;
-  using std::end;
-
-  absl::flat_hash_set<E> a_set(begin(a), end(a));
-  std::vector<E> result;
-  std::copy_if(begin(b), end(b), std::back_inserter(result),
-               [&a_set](const E& element) { return a_set.contains(element); });
-  return result;
-}
-
 const std::vector<std::string> kCommonFunctionNames =
     Commons(kBaselineFunctionNames, kComparisonFunctionNames);
-
-template <typename Container, typename AnotherContainer>
-static auto MakeMap(const Container& keys, const AnotherContainer& values) {
-  using K = typename Container::value_type;
-  using V = typename AnotherContainer::value_type;
-  using std::begin;
-  using std::end;
-
-  absl::flat_hash_map<K, V> result;
-  std::transform(begin(keys), end(keys), begin(values), std::inserter(result, std::begin(result)),
-                 [](const K& k, const V& v) { return std::make_pair(k, v); });
-  return result;
-}
 
 const absl::flat_hash_map<uint64_t, std::string> kBaselineAddressToName =
     MakeMap(kBaselineFunctionAddresses, kBaselineFunctionNames);

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -44,5 +44,6 @@ target_sources(MizarDataTests PRIVATE
 target_link_libraries(MizarDataTests PRIVATE GrpcProtos
                                                 MizarData
                                                 GTest::GTest
-                                                GTest::Main)
+                                                GTest::Main
+                                                TestUtils)
 register_test(MizarDataTests)

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -18,6 +18,7 @@
 #include "ClientData/ScopeInfo.h"
 #include "MizarBase/SampledFunctionId.h"
 #include "MizarData/MizarPairedData.h"
+#include "TestUtils/ContainerHelpers.h"
 
 using ::orbit_mizar_base::SFID;
 using ::testing::ElementsAre;
@@ -26,6 +27,8 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::UnorderedElementsAre;
 using ::testing::UnorderedElementsAreArray;
+
+using orbit_test_utils::MakeMap;
 
 namespace {
 
@@ -158,19 +161,6 @@ const std::vector<const orbit_client_protos::TimerInfo*> kTimerPtrs = [] {
 }();
 
 constexpr uint64_t kSamplingPeriod = 10;
-
-template <typename Container, typename AnotherContainer>
-static auto MakeMap(const Container& keys, const AnotherContainer& values) {
-  using K = typename Container::value_type;
-  using V = typename AnotherContainer::value_type;
-  using std::begin;
-  using std::end;
-
-  absl::flat_hash_map<K, V> result;
-  std::transform(begin(keys), end(keys), begin(values), std::inserter(result, std::begin(result)),
-                 [](const K& k, const V& v) { return std::make_pair(k, v); });
-  return result;
-}
 
 const std::vector<uint64_t> kScopeIds = {1, 2, 10, 30};
 const std::vector<orbit_client_data::ScopeInfo> kScopeInfos = {

--- a/src/MizarWidgets/CMakeLists.txt
+++ b/src/MizarWidgets/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(MizarWidgetsTests PRIVATE
   MizarWidgets
   GTest::QtGuiMain
   Qt5::Test
+  TestUtils
 )
 
 if(WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen")

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -17,12 +17,15 @@
 
 #include "ClientData/ScopeInfo.h"
 #include "MizarWidgets/SamplingWithFrameTrackInputWidget.h"
+#include "TestUtils/ContainerHelpers.h"
 
 using testing::ElementsAreArray;
 using testing::NotNull;
 using testing::Return;
 using testing::ReturnRef;
 using testing::UnorderedElementsAreArray;
+
+using orbit_test_utils::MakeMap;
 
 namespace {
 class MockPairedData {
@@ -58,19 +61,6 @@ const std::vector<std::string> kThreadNamesSorted = {
     MakeThreadListItemString(kThreadName, kTid),
     MakeThreadListItemString(kOtherThreadName, kOtherTid)};
 const QString kInputName = QStringLiteral("InputName");
-
-template <typename Container, typename AnotherContainer>
-static auto MakeMap(const Container& keys, const AnotherContainer& values) {
-  using K = typename Container::value_type;
-  using V = typename AnotherContainer::value_type;
-  using std::begin;
-  using std::end;
-
-  absl::flat_hash_map<K, V> result;
-  std::transform(begin(keys), end(keys), begin(values), std::inserter(result, std::begin(result)),
-                 [](const K& k, const V& v) { return std::make_pair(k, v); });
-  return result;
-}
 
 constexpr size_t kFrameTracksCount = 3;
 constexpr std::array<uint64_t, kFrameTracksCount> kScopeIds = {1, 2, 10};

--- a/src/Statistics/CMakeLists.txt
+++ b/src/Statistics/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(StatisticsTests PRIVATE
 target_link_libraries(
   StatisticsTests
   PRIVATE Statistics
-          GTest::Main)
+          GTest::Main
+          TestUtils)
 
 register_test(StatisticsTests)

--- a/src/Statistics/MultiplicityCorrectionTest.cpp
+++ b/src/Statistics/MultiplicityCorrectionTest.cpp
@@ -11,27 +11,17 @@
 #include <vector>
 
 #include "Statistics/MultiplicityCorrection.h"
+#include "TestUtils/ContainerHelpers.h"
 
 namespace orbit_statistics {
 
 using testing::DoubleNear;
 using testing::SizeIs;
 
+using orbit_test_utils::MakeMap;
+
 constexpr size_t kTestsNum = 4;
 constexpr std::array<double, kTestsNum> kPvalues = {0.1, 0.2, 0.3, 0.02};
-
-template <typename Container, typename AnotherContainer>
-static auto MakeMap(const Container& keys, const AnotherContainer& values) {
-  using K = typename Container::value_type;
-  using V = typename AnotherContainer::value_type;
-  using std::begin;
-  using std::end;
-
-  absl::flat_hash_map<K, V> result;
-  std::transform(begin(keys), end(keys), begin(values), std::inserter(result, std::begin(result)),
-                 [](const K& k, const V& v) { return std::make_pair(k, v); });
-  return result;
-}
 
 static void ExpectCorrectedPvaluesEq(const absl::flat_hash_map<int, double>& actual,
                                      const absl::flat_hash_map<int, double>& expected) {

--- a/src/TestUtils/CMakeLists.txt
+++ b/src/TestUtils/CMakeLists.txt
@@ -5,10 +5,14 @@
 cmake_minimum_required(VERSION 3.15)
 
 add_library(TestUtils INTERFACE)
-target_sources(TestUtils INTERFACE include/TestUtils/TestUtils.h)
+target_sources(TestUtils INTERFACE
+  include/TestUtils/TestUtils.h
+  include/TestUtils/ContainerHelpers.h)
 target_include_directories(TestUtils INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 target_link_libraries(TestUtils INTERFACE CONAN_PKG::abseil GTest::GTest)
 
-add_executable(TestUtilsTests TestUtilsTest.cpp)
+add_executable(TestUtilsTests
+  TestUtilsTest.cpp
+  ContainerHelpersTest.cpp)
 target_link_libraries(TestUtilsTests PRIVATE TestUtils GTest::Main)
 register_test(TestUtilsTests)

--- a/src/TestUtils/ContainerHelpersTest.cpp
+++ b/src/TestUtils/ContainerHelpersTest.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/container/flat_hash_map.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+#include "TestUtils/ContainerHelpers.h"
+
+namespace orbit_test_utils {
+
+constexpr auto kKeys = {1, 2, 3};
+constexpr auto kValues = {'a', 'b', 'c', 'd'};
+constexpr std::array<char, kValues.size()> kValueArray{'a', 'b', 'c', 'd'};
+const absl::flat_hash_map<int, char> kExpectedMap = {{1, 'a'}, {2, 'b'}, {3, 'c'}};
+
+using testing::IsEmpty;
+using testing::UnorderedElementsAreArray;
+
+TEST(ContainerHelpersTest, MakeMapIsCorrect) {
+  {
+    auto keys = kKeys;
+    auto values = kValues;
+    EXPECT_THAT(MakeMap(std::move(keys), std::move(values)),
+                UnorderedElementsAreArray(kExpectedMap));
+  }
+
+  {
+    std::vector<int> keys = kKeys;
+    EXPECT_THAT(MakeMap(std::move(keys), kValueArray), UnorderedElementsAreArray(kExpectedMap));
+  }
+
+  {
+    const std::vector<int> keys = kKeys;
+    std::vector<char> values = kValues;
+    EXPECT_THAT(MakeMap(keys, std::move(values)), UnorderedElementsAreArray(kExpectedMap));
+  }
+}
+
+constexpr auto kFirstCollection = {"foo()", "bar()", "biz()"};
+constexpr auto kOtherCollection = {"foo()", "bar()", "fiz()"};
+constexpr std::array<std::string_view, 2> kCommons = {"foo()", "bar()"};
+
+TEST(ContainerHelpersTest, CommonsIsCorrect) {
+  EXPECT_THAT(Commons(kFirstCollection, kOtherCollection), UnorderedElementsAreArray(kCommons));
+
+  EXPECT_THAT(Commons(std::initializer_list<std::string>{}, kOtherCollection), IsEmpty());
+
+  const std::vector<const char*> first_collection = kFirstCollection;
+  EXPECT_THAT(Commons(first_collection, kOtherCollection), UnorderedElementsAreArray(kCommons));
+}
+
+}  // namespace orbit_test_utils

--- a/src/TestUtils/include/TestUtils/ContainerHelpers.h
+++ b/src/TestUtils/include/TestUtils/ContainerHelpers.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TEST_UTILS_CONTAINER_HELPERS_H_
+#define TEST_UTILS_CONTAINER_HELPERS_H_
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+
+namespace orbit_test_utils {
+
+// A helper function that takes two collection (possibly, of different type) and returns a map whose
+// entries are the element-wise pairs of the elements of the two input collections.
+// If the sizes of the collections differ, the excessive elements are ignored.
+template <typename Container, typename AnotherContainer>
+[[nodiscard]] static auto MakeMap(Container&& keys, AnotherContainer&& values) {
+  using K = typename std::decay_t<Container>::value_type;
+  using V = typename std::decay_t<AnotherContainer>::value_type;
+  using std::begin;
+  using std::end;
+
+  absl::flat_hash_map<K, V> result;
+  std::transform(begin(keys), end(keys), begin(values), std::inserter(result, std::begin(result)),
+                 [](const K& k, const V& v) { return std::make_pair(k, v); });
+  return result;
+}
+
+// A helper function that takes two collection (possibly, of different type) that store the elements
+// of the same type. An `std::vector` containing the elements present in both collections is
+// returned.
+template <typename Container, typename AnotherContainer,
+          typename E = typename std::decay_t<Container>::value_type,
+          typename OtherE = typename std::decay_t<AnotherContainer>::value_type,
+          typename = std::enable_if<std::is_same_v<E, OtherE>>>
+[[nodiscard]] static std::vector<E> Commons(Container&& a, AnotherContainer&& b) {
+  using std::begin;
+  using std::end;
+
+  absl::flat_hash_set<E> a_set(begin(a), end(a));
+  std::vector<E> result;
+  std::copy_if(begin(b), end(b), std::back_inserter(result),
+               [&a_set](const E& element) { return a_set.contains(element); });
+  return result;
+}
+
+}  // namespace orbit_test_utils
+
+#endif  // TEST_UTILS_CONTAINER_HELPERS_H_


### PR DESCRIPTION
This moves Commons and MakeMap functions that are used in tests.
Now these functions are documented and tested.

Test: Unit
Bug: http://b/237743774