### PR TITLE
Add thread state slice selection capabilities

### DIFF
--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -57,7 +57,7 @@ void DataManager::set_selected_thread_id(uint32_t thread_id) {
 void DataManager::set_selected_thread_state_slice(
     std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  selected_thread_state_slice_ = selected_thread_state_slice;
+  selected_thread_state_slice_ = std::move(selected_thread_state_slice);
 }
 
 void DataManager::set_selected_timer(const orbit_client_protos::TimerInfo* timer_info) {

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -54,7 +54,8 @@ void DataManager::set_selected_thread_id(uint32_t thread_id) {
   selected_thread_id_ = thread_id;
 }
 
-void DataManager::set_selected_thread_state_slice(std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice) {
+void DataManager::set_selected_thread_state_slice(
+    std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_thread_state_slice_ = selected_thread_state_slice;
 }
@@ -94,7 +95,8 @@ uint32_t DataManager::selected_thread_id() const {
   return selected_thread_id_;
 }
 
-std::optional<orbit_client_data::ThreadStateSliceInfo> DataManager::selected_thread_state_slice() const {
+std::optional<orbit_client_data::ThreadStateSliceInfo> DataManager::selected_thread_state_slice()
+    const {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_thread_state_slice_;
 }

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -54,6 +54,11 @@ void DataManager::set_selected_thread_id(uint32_t thread_id) {
   selected_thread_id_ = thread_id;
 }
 
+void DataManager::set_selected_thread_state_slice(std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  selected_thread_state_slice_ = selected_thread_state_slice;
+}
+
 void DataManager::set_selected_timer(const orbit_client_protos::TimerInfo* timer_info) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_timer_ = timer_info;
@@ -87,6 +92,11 @@ uint64_t DataManager::highlighted_group_id() const {
 uint32_t DataManager::selected_thread_id() const {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_thread_id_;
+}
+
+std::optional<orbit_client_data::ThreadStateSliceInfo> DataManager::selected_thread_state_slice() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return selected_thread_state_slice_;
 }
 
 const orbit_client_protos::TimerInfo* DataManager::selected_timer() const {

--- a/src/ClientData/DataManagerTest.cpp
+++ b/src/ClientData/DataManagerTest.cpp
@@ -4,12 +4,12 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <thread>
 #include <vector>
 
 #include "ClientData/DataManager.h"
 #include "GrpcProtos/capture.pb.h"
-#include "OrbitBase/ThreadUtils.h"
 
 namespace orbit_client_data {
 
@@ -34,6 +34,8 @@ TEST(DataManager, CanOnlyBeUsedFromTheMainThread) {
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_highlighted_group_id,
                                             0);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_selected_thread_id, 0);
+  CallMethodOnDifferentThreadAndExpectDeath(
+      data_manager, &DataManager::set_selected_thread_state_slice, std::nullopt);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_selected_timer,
                                             nullptr);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::SelectTracepoint,

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -16,13 +16,13 @@
 #include "ApiInterface/Orbit.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ScopeIdConstants.h"
+#include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/UserDefinedCaptureData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/capture.pb.h"
 #include "GrpcProtos/tracepoint.pb.h"
 #include "OrbitBase/ThreadConstants.h"
-#include "ClientData/ThreadStateSliceInfo.h"
 
 namespace orbit_client_data {
 
@@ -40,7 +40,8 @@ class DataManager final {
   void set_highlighted_scope_id(uint64_t highlighted_function_id);
   void set_highlighted_group_id(uint64_t highlighted_group_id);
   void set_selected_thread_id(uint32_t thread_id);
-  void set_selected_thread_state_slice(std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice);
+  void set_selected_thread_state_slice(
+      std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice);
   void set_selected_timer(const orbit_client_protos::TimerInfo* timer_info);
 
   [[nodiscard]] bool IsFunctionSelected(const FunctionInfo& function) const;
@@ -49,7 +50,8 @@ class DataManager final {
   [[nodiscard]] uint64_t highlighted_scope_id() const;
   [[nodiscard]] uint64_t highlighted_group_id() const;
   [[nodiscard]] uint32_t selected_thread_id() const;
-  [[nodiscard]] std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice() const;
+  [[nodiscard]] std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice()
+      const;
   [[nodiscard]] const orbit_client_protos::TimerInfo* selected_timer() const;
 
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info);

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -120,7 +120,7 @@ class DataManager final {
 
   uint32_t selected_thread_id_ = orbit_base::kInvalidThreadId;
   const orbit_client_protos::TimerInfo* selected_timer_ = nullptr;
-  std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice_{std::nullopt};
+  std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice_;
 
   // DataManager needs a copy of this so that we can persist user choices like frame tracks between
   // captures.

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -9,6 +9,7 @@
 #include <absl/container/node_hash_map.h>
 
 #include <cstdint>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -18,10 +19,10 @@
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/UserDefinedCaptureData.h"
 #include "ClientProtos/capture_data.pb.h"
-#include "GrpcProtos/Constants.h"
 #include "GrpcProtos/capture.pb.h"
 #include "GrpcProtos/tracepoint.pb.h"
 #include "OrbitBase/ThreadConstants.h"
+#include "ClientData/ThreadStateSliceInfo.h"
 
 namespace orbit_client_data {
 
@@ -39,6 +40,7 @@ class DataManager final {
   void set_highlighted_scope_id(uint64_t highlighted_function_id);
   void set_highlighted_group_id(uint64_t highlighted_group_id);
   void set_selected_thread_id(uint32_t thread_id);
+  void set_selected_thread_state_slice(std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice);
   void set_selected_timer(const orbit_client_protos::TimerInfo* timer_info);
 
   [[nodiscard]] bool IsFunctionSelected(const FunctionInfo& function) const;
@@ -47,6 +49,7 @@ class DataManager final {
   [[nodiscard]] uint64_t highlighted_scope_id() const;
   [[nodiscard]] uint64_t highlighted_group_id() const;
   [[nodiscard]] uint32_t selected_thread_id() const;
+  [[nodiscard]] std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice() const;
   [[nodiscard]] const orbit_client_protos::TimerInfo* selected_timer() const;
 
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info);
@@ -134,6 +137,8 @@ class DataManager final {
   bool collect_memory_info_ = false;
   uint64_t memory_sampling_period_ms_ = 10;
   uint64_t memory_warning_threshold_kb_ = 8ULL * 1024 * 1024;
+
+  std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice_{std::nullopt};
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -120,6 +120,7 @@ class DataManager final {
 
   uint32_t selected_thread_id_ = orbit_base::kInvalidThreadId;
   const orbit_client_protos::TimerInfo* selected_timer_ = nullptr;
+  std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice_{std::nullopt};
 
   // DataManager needs a copy of this so that we can persist user choices like frame tracks between
   // captures.
@@ -139,8 +140,6 @@ class DataManager final {
   bool collect_memory_info_ = false;
   uint64_t memory_sampling_period_ms_ = 10;
   uint64_t memory_warning_threshold_kb_ = 8ULL * 1024 * 1024;
-
-  std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice_{std::nullopt};
 };
 
 }  // namespace orbit_client_data

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2649,6 +2649,13 @@ void OrbitApp::set_selected_thread_id(ThreadID thread_id) {
   return data_manager_->set_selected_thread_id(thread_id);
 }
 
+std::optional<orbit_client_data::ThreadStateSliceInfo> OrbitApp::selected_thread_state_slice() const { return data_manager_->selected_thread_state_slice(); }
+
+void OrbitApp::set_selected_thread_state_slice(std::optional<orbit_client_data::ThreadStateSliceInfo> thread_state_slice) {
+  RequestUpdatePrimitives();
+  return data_manager_->set_selected_thread_state_slice(thread_state_slice);
+}
+
 const orbit_client_protos::TimerInfo* OrbitApp::selected_timer() const {
   return data_manager_->selected_timer();
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2649,9 +2649,13 @@ void OrbitApp::set_selected_thread_id(ThreadID thread_id) {
   return data_manager_->set_selected_thread_id(thread_id);
 }
 
-std::optional<orbit_client_data::ThreadStateSliceInfo> OrbitApp::selected_thread_state_slice() const { return data_manager_->selected_thread_state_slice(); }
+std::optional<orbit_client_data::ThreadStateSliceInfo> OrbitApp::selected_thread_state_slice()
+    const {
+  return data_manager_->selected_thread_state_slice();
+}
 
-void OrbitApp::set_selected_thread_state_slice(std::optional<orbit_client_data::ThreadStateSliceInfo> thread_state_slice) {
+void OrbitApp::set_selected_thread_state_slice(
+    std::optional<orbit_client_data::ThreadStateSliceInfo> thread_state_slice) {
   RequestUpdatePrimitives();
   return data_manager_->set_selected_thread_state_slice(thread_state_slice);
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2657,7 +2657,7 @@ std::optional<orbit_client_data::ThreadStateSliceInfo> OrbitApp::selected_thread
 void OrbitApp::set_selected_thread_state_slice(
     std::optional<orbit_client_data::ThreadStateSliceInfo> thread_state_slice) {
   RequestUpdatePrimitives();
-  return data_manager_->set_selected_thread_state_slice(thread_state_slice);
+  data_manager_->set_selected_thread_state_slice(thread_state_slice);
 }
 
 const orbit_client_protos::TimerInfo* OrbitApp::selected_timer() const {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -464,8 +464,10 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] orbit_client_data::ThreadID selected_thread_id() const;
   void set_selected_thread_id(orbit_client_data::ThreadID thread_id);
 
-  [[nodiscard]] std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice() const;
-  void set_selected_thread_state_slice(std::optional<orbit_client_data::ThreadStateSliceInfo> thread_state_slice);
+  [[nodiscard]] std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice()
+      const;
+  void set_selected_thread_state_slice(
+      std::optional<orbit_client_data::ThreadStateSliceInfo> thread_state_slice);
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* selected_timer() const;
   void SelectTimer(const orbit_client_protos::TimerInfo* timer_info);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -464,6 +464,9 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] orbit_client_data::ThreadID selected_thread_id() const;
   void set_selected_thread_id(orbit_client_data::ThreadID thread_id);
 
+  [[nodiscard]] std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice() const;
+  void set_selected_thread_state_slice(std::optional<orbit_client_data::ThreadStateSliceInfo> thread_state_slice);
+
   [[nodiscard]] const orbit_client_protos::TimerInfo* selected_timer() const;
   void SelectTimer(const orbit_client_protos::TimerInfo* timer_info);
   void DeselectTimer() override;

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -14,11 +14,11 @@
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <optional>
 #include <ostream>
 #include <string_view>
 #include <tuple>
 
-#include "AccessibleTimeGraph.h"
 #include "App.h"
 #include "CaptureViewElement.h"
 #include "ClientData/CallstackData.h"
@@ -168,6 +168,7 @@ void CaptureWindow::LeftUp() {
   if (!click_was_drag_ && background_clicked_) {
     app_->SelectTimer(nullptr);
     app_->set_selected_thread_id(orbit_base::kAllProcessThreadsTid);
+    app_->set_selected_thread_state_slice(std::nullopt);
     RequestUpdatePrimitives();
   }
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -269,12 +269,12 @@ void ThreadStateBar::OnPick(int x, int y) {
   ThreadBar::OnPick(x, y);
   app_->set_selected_thread_id(GetThreadId());
 
-  Vec2i screen_clicked_cords = Vec2i(x, y);
-  float clicked_world_x = viewport_->ScreenToWorld(screen_clicked_cords)[0];
-  uint64_t clicked_timestamp = timeline_info_->GetTickFromWorld(clicked_world_x);
-  std::optional<ThreadStateSliceInfo> clicked_slice =
-      capture_data_->FindThreadStateSliceInfoFromTimestamp(GetThreadId(), clicked_timestamp);
-  app_->set_selected_thread_state_slice(clicked_slice);
+  Vec2i screen_click_pos = Vec2i(x, y);
+  float world_click_pos_x = viewport_->ScreenToWorld(screen_click_pos)[0];
+  uint64_t click_timestamp = timeline_info_->GetTickFromWorld(world_click_pos_x);
+  std::optional<ThreadStateSliceInfo> click_slice =
+      capture_data_->FindThreadStateSliceInfoFromTimestamp(GetThreadId(), click_timestamp);
+  app_->set_selected_thread_state_slice(click_slice);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -7,11 +7,13 @@
 #include <absl/strings/str_format.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
 #include "App.h"
 #include "CaptureViewElement.h"
+#include "ClientData/CallstackType.h"
 #include "ClientData/CaptureData.h"
 #include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientProtos/capture_data.pb.h"
@@ -266,6 +268,12 @@ void ThreadStateBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
 void ThreadStateBar::OnPick(int x, int y) {
   ThreadBar::OnPick(x, y);
   app_->set_selected_thread_id(GetThreadId());
+
+  Vec2i screen_cords = Vec2i(x, y);
+  float clicked_x = viewport_->ScreenToWorld(screen_cords)[0];
+  uint64_t clicked_timestamp = timeline_info_->GetTickFromWorld(clicked_x);
+  std::optional<ThreadStateSliceInfo> clicked_slice = capture_data_->FindThreadStateSliceInfoFromTimestamp(GetThreadId(), clicked_timestamp);
+  app_->set_selected_thread_state_slice(clicked_slice);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -269,9 +269,9 @@ void ThreadStateBar::OnPick(int x, int y) {
   ThreadBar::OnPick(x, y);
   app_->set_selected_thread_id(GetThreadId());
 
-  Vec2i screen_cords = Vec2i(x, y);
-  float clicked_x = viewport_->ScreenToWorld(screen_cords)[0];
-  uint64_t clicked_timestamp = timeline_info_->GetTickFromWorld(clicked_x);
+  Vec2i screen_clicked_cords = Vec2i(x, y);
+  float clicked_world_x = viewport_->ScreenToWorld(screen_clicked_cords)[0];
+  uint64_t clicked_timestamp = timeline_info_->GetTickFromWorld(clicked_world_x);
   std::optional<ThreadStateSliceInfo> clicked_slice =
       capture_data_->FindThreadStateSliceInfoFromTimestamp(GetThreadId(), clicked_timestamp);
   app_->set_selected_thread_state_slice(clicked_slice);

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -272,7 +272,8 @@ void ThreadStateBar::OnPick(int x, int y) {
   Vec2i screen_cords = Vec2i(x, y);
   float clicked_x = viewport_->ScreenToWorld(screen_cords)[0];
   uint64_t clicked_timestamp = timeline_info_->GetTickFromWorld(clicked_x);
-  std::optional<ThreadStateSliceInfo> clicked_slice = capture_data_->FindThreadStateSliceInfoFromTimestamp(GetThreadId(), clicked_timestamp);
+  std::optional<ThreadStateSliceInfo> clicked_slice =
+      capture_data_->FindThreadStateSliceInfoFromTimestamp(GetThreadId(), clicked_timestamp);
   app_->set_selected_thread_state_slice(clicked_slice);
 }
 


### PR DESCRIPTION
Now, orbit app saves which thread state slice is selected by the user when the user clicks on a thread state slice and deselects it when pressing on the background.

http://b/236944854