### PR TITLE
Make StatusListener a shared pointer

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2851,6 +2851,7 @@ bool OrbitApp::IsLoadingCapture() const {
 }
 
 ScopedStatus OrbitApp::CreateScopedStatus(const std::string& initial_message) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return ScopedStatus{GetMainThreadExecutor()->weak_from_this(), status_listener_, initial_message};
 }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2851,8 +2851,6 @@ bool OrbitApp::IsLoadingCapture() const {
 }
 
 ScopedStatus OrbitApp::CreateScopedStatus(const std::string& initial_message) {
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  ORBIT_CHECK(status_listener_ != nullptr);
   return ScopedStatus{GetMainThreadExecutor()->weak_from_this(), status_listener_, initial_message};
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -314,7 +314,9 @@ class OrbitApp final : public DataViewFactory,
     clipboard_callback_ = std::move(callback);
   }
 
-  void SetStatusListener(StatusListener* listener) { status_listener_ = listener; }
+  void SetStatusListener(std::weak_ptr<StatusListener> listener) {
+    status_listener_ = std::move(listener);
+  }
 
   void SendDisassemblyToUi(const orbit_client_data::FunctionInfo& function_info,
                            std::string disassembly, orbit_code_report::DisassemblyReport report);
@@ -689,7 +691,7 @@ class OrbitApp final : public DataViewFactory,
 
   const orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDir()};
 
-  StatusListener* status_listener_ = nullptr;
+  std::weak_ptr<StatusListener> status_listener_;
 
   orbit_client_data::ProcessData* process_ = nullptr;
 

--- a/src/OrbitGl/ScopedStatus.h
+++ b/src/OrbitGl/ScopedStatus.h
@@ -45,6 +45,7 @@ class ScopedStatus final {
     data_->main_thread_id = std::this_thread::get_id();
 
     std::shared_ptr<StatusListener> status_listener = data_->status_listener.lock();
+    if (status_listener == nullptr) return;
     data_->status_id = status_listener->AddStatus(status_message);
   }
 

--- a/src/OrbitGl/ScopedStatus.h
+++ b/src/OrbitGl/ScopedStatus.h
@@ -37,11 +37,14 @@ class ScopedStatus final {
  public:
   ScopedStatus() = default;
   explicit ScopedStatus(std::weak_ptr<orbit_base::Executor> executor,
-                        StatusListener* status_listener, const std::string& status_message) {
+                        std::weak_ptr<StatusListener> maybe_status_listener,
+                        const std::string& status_message) {
     data_ = std::make_unique<Data>();
     data_->executor = std::move(executor);
-    data_->status_listener = status_listener;
+    data_->status_listener = std::move(maybe_status_listener);
     data_->main_thread_id = std::this_thread::get_id();
+
+    std::shared_ptr<StatusListener> status_listener = data_->status_listener.lock();
     data_->status_id = status_listener->AddStatus(status_message);
   }
 
@@ -65,11 +68,16 @@ class ScopedStatus final {
   void UpdateMessage(const std::string& message) {
     ORBIT_CHECK(data_ != nullptr);
     if (std::this_thread::get_id() == data_->main_thread_id) {
-      data_->status_listener->UpdateStatus(data_->status_id, message);
+      std::shared_ptr<StatusListener> status_listener = data_->status_listener.lock();
+      if (status_listener == nullptr) return;
+      status_listener->UpdateStatus(data_->status_id, message);
     } else {
-      TrySchedule(data_->executor,
-                  [status_id = data_->status_id, status_listener = data_->status_listener,
-                   message] { status_listener->UpdateStatus(status_id, message); });
+      TrySchedule(data_->executor, [status_id = data_->status_id,
+                                    maybe_status_listener = data_->status_listener, message] {
+        std::shared_ptr<StatusListener> status_listener = maybe_status_listener.lock();
+        if (status_listener == nullptr) return;
+        status_listener->UpdateStatus(status_id, message);
+      });
     }
   }
 
@@ -80,10 +88,14 @@ class ScopedStatus final {
     }
 
     if (std::this_thread::get_id() == data_->main_thread_id) {
-      data_->status_listener->ClearStatus(data_->status_id);
+      std::shared_ptr<StatusListener> status_listener = data_->status_listener.lock();
+      if (status_listener == nullptr) return;
+      status_listener->ClearStatus(data_->status_id);
     } else {
       TrySchedule(data_->executor,
-                  [status_listener = data_->status_listener, status_id = data_->status_id] {
+                  [maybe_status_listener = data_->status_listener, status_id = data_->status_id] {
+                    auto status_listener = maybe_status_listener.lock();
+                    if (status_listener == nullptr) return;
                     status_listener->ClearStatus(status_id);
                   });
     }
@@ -95,7 +107,7 @@ class ScopedStatus final {
   // stored in easily movable form.
   struct Data {
     std::weak_ptr<orbit_base::Executor> executor;
-    StatusListener* status_listener = nullptr;
+    std::weak_ptr<StatusListener> status_listener;
     std::thread::id main_thread_id;
     uint64_t status_id = 0;
   };

--- a/src/OrbitGl/ScopedStatusTest.cpp
+++ b/src/OrbitGl/ScopedStatusTest.cpp
@@ -35,28 +35,28 @@ class MockExecutor : public orbit_base::Executor {
 using ::testing::_;
 
 TEST(ScopedStatus, Smoke) {
-  MockStatusListener status_listener{};
+  auto status_listener = std::make_shared<MockStatusListener>();
   auto executor = std::make_shared<MockExecutor>();
-  EXPECT_CALL(status_listener, AddStatus("Initial message")).Times(1);
-  EXPECT_CALL(status_listener, UpdateStatus(_, "Updated message")).Times(1);
-  EXPECT_CALL(status_listener, ClearStatus).Times(1);
+  EXPECT_CALL(*status_listener, AddStatus("Initial message")).Times(1);
+  EXPECT_CALL(*status_listener, UpdateStatus(_, "Updated message")).Times(1);
+  EXPECT_CALL(*status_listener, ClearStatus).Times(1);
   EXPECT_CALL(*executor, ScheduleImpl).Times(0);
 
   {
-    ScopedStatus status(executor, &status_listener, "Initial message");
+    ScopedStatus status(executor, status_listener, "Initial message");
     status.UpdateMessage("Updated message");
   }
 }
 
 TEST(ScopedStatus, UpdateInAnotherThread) {
-  MockStatusListener status_listener{};
+  auto status_listener = std::make_shared<MockStatusListener>();
   auto executor = std::make_shared<MockExecutor>();
-  EXPECT_CALL(status_listener, AddStatus("Initial message")).Times(1);
-  EXPECT_CALL(status_listener, ClearStatus).Times(1);
+  EXPECT_CALL(*status_listener, AddStatus("Initial message")).Times(1);
+  EXPECT_CALL(*status_listener, ClearStatus).Times(1);
   EXPECT_CALL(*executor, ScheduleImpl).Times(1);
 
   {
-    ScopedStatus status(executor, &status_listener, "Initial message");
+    ScopedStatus status(executor, status_listener, "Initial message");
     std::thread thread([&status] { status.UpdateMessage("Updated message"); });
 
     thread.join();
@@ -64,14 +64,14 @@ TEST(ScopedStatus, UpdateInAnotherThread) {
 }
 
 TEST(ScopedStatus, DestroyInAnotherThread) {
-  MockStatusListener status_listener{};
+  auto status_listener = std::make_shared<MockStatusListener>();
   auto executor = std::make_shared<MockExecutor>();
-  EXPECT_CALL(status_listener, AddStatus("Initial message")).Times(1);
-  EXPECT_CALL(status_listener, UpdateStatus(_, "Updated message")).Times(1);
+  EXPECT_CALL(*status_listener, AddStatus("Initial message")).Times(1);
+  EXPECT_CALL(*status_listener, UpdateStatus(_, "Updated message")).Times(1);
   EXPECT_CALL(*executor, ScheduleImpl).Times(1);
 
   {
-    ScopedStatus status(executor, &status_listener, "Initial message");
+    ScopedStatus status(executor, status_listener, "Initial message");
     status.UpdateMessage("Updated message");
     std::thread thread([status = std::move(status)]() {
       // Do nothing
@@ -82,30 +82,30 @@ TEST(ScopedStatus, DestroyInAnotherThread) {
 }
 
 TEST(ScopedStatus, MoveAssignment) {
-  MockStatusListener status_listener{};
+  auto status_listener = std::make_shared<MockStatusListener>();
   auto executor = std::make_shared<MockExecutor>();
-  EXPECT_CALL(status_listener, AddStatus("Initial message 1")).Times(1);
-  EXPECT_CALL(status_listener, AddStatus("Initial message 2")).Times(1);
-  EXPECT_CALL(status_listener, UpdateStatus(_, "Updated message")).Times(1);
-  EXPECT_CALL(status_listener, ClearStatus).Times(2);
+  EXPECT_CALL(*status_listener, AddStatus("Initial message 1")).Times(1);
+  EXPECT_CALL(*status_listener, AddStatus("Initial message 2")).Times(1);
+  EXPECT_CALL(*status_listener, UpdateStatus(_, "Updated message")).Times(1);
+  EXPECT_CALL(*status_listener, ClearStatus).Times(2);
 
   {
-    ScopedStatus status1(executor, &status_listener, "Initial message 1");
-    ScopedStatus status2(executor, &status_listener, "Initial message 2");
+    ScopedStatus status1(executor, status_listener, "Initial message 1");
+    ScopedStatus status2(executor, status_listener, "Initial message 2");
     status1.UpdateMessage("Updated message");
     status1 = std::move(status2);
   }
 }
 
 TEST(ScopedStatus, SelfMoveAssign) {
-  MockStatusListener status_listener{};
+  auto status_listener = std::make_shared<MockStatusListener>();
   auto executor = std::make_shared<MockExecutor>();
-  EXPECT_CALL(status_listener, AddStatus("Initial message")).Times(1);
-  EXPECT_CALL(status_listener, UpdateStatus(_, "Updated message")).Times(1);
-  EXPECT_CALL(status_listener, ClearStatus).Times(1);
+  EXPECT_CALL(*status_listener, AddStatus("Initial message")).Times(1);
+  EXPECT_CALL(*status_listener, UpdateStatus(_, "Updated message")).Times(1);
+  EXPECT_CALL(*status_listener, ClearStatus).Times(1);
 
   {
-    ScopedStatus status1(executor, &status_listener, "Initial message");
+    ScopedStatus status1(executor, status_listener, "Initial message");
     status1.UpdateMessage("Updated message");
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"

--- a/src/OrbitGl/StatusListener.h
+++ b/src/OrbitGl/StatusListener.h
@@ -18,6 +18,11 @@
  *
  * uint64_t status_id = listener->AddStatus("");
  */
+
+#include <stdint.h>
+
+#include <string>
+
 class StatusListener {
  public:
   virtual ~StatusListener() = default;

--- a/src/OrbitQt/StatusListenerImpl.cpp
+++ b/src/OrbitQt/StatusListenerImpl.cpp
@@ -50,8 +50,8 @@ void StatusListenerImpl::UpdateStatus(uint64_t status_id, std::string message) {
   status_messages_.insert_or_assign(status_id, std::move(message));
 }
 
-std::unique_ptr<StatusListener> StatusListenerImpl::Create(QStatusBar* status_bar) {
-  return std::unique_ptr<StatusListener>(new StatusListenerImpl(status_bar));
+std::shared_ptr<StatusListener> StatusListenerImpl::Create(QStatusBar* status_bar) {
+  return std::shared_ptr<StatusListener>(new StatusListenerImpl(status_bar));
 }
 
 uint64_t StatusListenerImpl::GetNextId() {

--- a/src/OrbitQt/StatusListenerImpl.h
+++ b/src/OrbitQt/StatusListenerImpl.h
@@ -21,7 +21,7 @@ class StatusListenerImpl : public StatusListener {
   void ClearStatus(uint64_t status_id) override;
   void UpdateStatus(uint64_t status_id, std::string message) override;
 
-  static std::unique_ptr<StatusListener> Create(QStatusBar* status_bar);
+  static std::shared_ptr<StatusListener> Create(QStatusBar* status_bar);
 
  private:
   explicit StatusListenerImpl(QStatusBar* status_bar) : next_id_{0}, status_bar_(status_bar) {}

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -271,7 +271,7 @@ void OrbitMainWindow::SetupMainWindow() {
 
   status_listener_ = StatusListenerImpl::Create(statusBar());
 
-  app_->SetStatusListener(status_listener_.get());
+  app_->SetStatusListener(status_listener_);
 
   app_->SetCaptureStartedCallback([this](const std::optional<std::filesystem::path>& file_path) {
     // Only set it if this is not empty, we do not want to reset the label when loading from legacy

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -263,7 +263,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   QIcon icon_keyboard_arrow_right_;
 
   // Status listener
-  std::unique_ptr<StatusListener> status_listener_;
+  std::shared_ptr<StatusListener> status_listener_;
 
   struct TabWidgetLayout {
     std::vector<std::pair<QWidget*, QString>> tabs_and_titles;


### PR DESCRIPTION
This allows checking whether the status listener is still alive in a
ScopedStatus object and avoid accessing a listener that has already been
deleted.

Bug: http://b/237746722