### PR TITLE
Avoid sending version comparison warning to UI

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -441,10 +441,10 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
         orbit_version::Version current_version = orbit_version::GetVersion();
         if (capture_version > current_version) {
           std::string warning_message = absl::Substitute(
-              "The capture was taken with Orbit version $0.$1, which is higher than the "
-              "current version. Please open the capture using Orbit v$0.$1 or above.",
+              "The capture was taken with Orbit version $0.$1, which is higher than the current "
+              "version. Please use Orbit v$0.$1 or above to ensure all features are supported.",
               capture_version.major_version, capture_version.minor_version);
-          main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kSevereWarning,
+          main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kWarning,
                                            absl::ZeroDuration(), warning_message);
         }
         absl::MutexLock lock(&mutex);

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -446,7 +446,6 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
               capture_version.major_version, capture_version.minor_version);
           main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kSevereWarning,
                                            absl::ZeroDuration(), warning_message);
-          SendWarningToUi("Capture", warning_message);
         }
         absl::MutexLock lock(&mutex);
         initialization_complete = true;


### PR DESCRIPTION
We changed to stop sending user the warning message that the capture is
taken by a newer version.

When we load a capture, we already compare the capture format version in
`OrbitApp::LoadCaptureFromFile` (to be specific, when we call
`CaptureFile::OpenForReadWrite`, it will check the capture file version while
reading the header).
This should be enough for comparing the version compatibility.

Bug: http://b/237747877