### PR TITLE
Add TID Typedef and use it in Mizar

### DIFF
--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -16,19 +16,17 @@
 #include "CaptureClient/LoadCapture.h"
 #include "CaptureFile/CaptureFile.h"
 #include "MizarBase/BaselineOrComparison.h"
+#include "MizarBase/ThreadId.h"
 #include "MizarData/BaselineAndComparison.h"
 #include "MizarData/MizarData.h"
 #include "MizarWidgets/MizarMainWindow.h"
 #include "OrbitBase/Logging.h"
 
-template <typename T>
-using Baseline = ::orbit_mizar_base::Baseline<T>;
-
-template <typename T>
-using Comparison = ::orbit_mizar_base::Comparison<T>;
-
+using ::orbit_mizar_base::Baseline;
+using ::orbit_mizar_base::Comparison;
 using ::orbit_mizar_base::MakeBaseline;
 using ::orbit_mizar_base::MakeComparison;
+using ::orbit_mizar_base::TID;
 
 [[nodiscard]] static ErrorMessageOr<void> LoadCapture(orbit_mizar_data::MizarData* data,
                                                       std::filesystem::path path) {
@@ -62,8 +60,8 @@ int main(int argc, char** argv) {
       ExpandPathHomeFolder(absl::GetFlag(FLAGS_baseline_path));
   const std::filesystem::path comparison_path =
       ExpandPathHomeFolder(absl::GetFlag(FLAGS_comparison_path));
-  const uint32_t baseline_tid = absl::GetFlag(FLAGS_baseline_tid);
-  const uint32_t comparison_tid = absl::GetFlag(FLAGS_comparison_tid);
+  const TID baseline_tid{absl::GetFlag(FLAGS_baseline_tid)};
+  const TID comparison_tid{absl::GetFlag(FLAGS_comparison_tid)};
 
   constexpr uint64_t kNsInMs = 1'000'000;
   const uint64_t baseline_start_ns = absl::GetFlag(FLAGS_baseline_start_ms) * kNsInMs;
@@ -99,10 +97,10 @@ int main(int argc, char** argv) {
   const orbit_mizar_data::SamplingWithFrameTrackComparisonReport report =
       bac.MakeSamplingWithFrameTrackReport(
           MakeBaseline<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
-              absl::flat_hash_set<uint32_t>{baseline_tid}, baseline_start_ns, kDuration,
+              absl::flat_hash_set<TID>{baseline_tid}, baseline_start_ns, kDuration,
               kFrameTrackScopeId),
           MakeComparison<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
-              absl::flat_hash_set<uint32_t>{comparison_tid}, comparison_start_ns, kDuration,
+              absl::flat_hash_set<TID>{comparison_tid}, comparison_start_ns, kDuration,
               kFrameTrackScopeId));
 
   for (const auto& [sfid, name] : bac.sfid_to_name()) {

--- a/src/MizarBase/CMakeLists.txt
+++ b/src/MizarBase/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(MizarBase INTERFACE)
 
 target_sources(MizarBase INTERFACE
   include/MizarBase/BaselineOrComparison.h
-  include/MizarBase/SampledFunctionId.h)
+  include/MizarBase/SampledFunctionId.h
+  include/MizarBase/ThreadId.h)
 
 target_include_directories(MizarBase INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/MizarBase/include/MizarBase/ThreadId.h
+++ b/src/MizarBase/include/MizarBase/ThreadId.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_BASE_THREAD_ID_H_
+#define MIZAR_BASE_THREAD_ID_H_
+
+#include <stdint.h>
+
+#include "OrbitBase/Typedef.h"
+
+namespace orbit_mizar_base {
+
+struct TIDTag {};
+
+using TID = orbit_base::Typedef<TIDTag, const uint32_t>;
+
+// Making sure we do not waste memory on the abstraction
+static_assert(sizeof(TID) == sizeof(uint32_t));
+
+}  // namespace orbit_mizar_base
+
+#endif  // MIZAR_BASE_THREAD_ID_H_

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -22,18 +22,14 @@
 #include "MizarStatistics/ActiveFunctionTimePerFrameComparator.h"
 #include "OrbitBase/ThreadConstants.h"
 
-using ::orbit_mizar_base::SFID;
-using ::testing::DoubleNear;
-using ::testing::UnorderedElementsAreArray;
-
-template <typename T>
-using Baseline = ::orbit_mizar_base::Baseline<T>;
-
-template <typename T>
-using Comparison = ::orbit_mizar_base::Comparison<T>;
-
+using ::orbit_mizar_base::Baseline;
+using ::orbit_mizar_base::Comparison;
 using ::orbit_mizar_base::MakeBaseline;
 using ::orbit_mizar_base::MakeComparison;
+using ::orbit_mizar_base::SFID;
+using ::orbit_mizar_base::TID;
+using ::testing::DoubleNear;
+using ::testing::UnorderedElementsAreArray;
 
 namespace orbit_mizar_data {
 
@@ -142,13 +138,13 @@ class MockPairedData {
         frame_track_active_times_(std::move(frame_track_active_times)) {}
 
   template <typename Action>
-  void ForEachCallstackEvent(uint32_t /*tid*/, uint64_t /*min_timestamp*/,
-                             uint64_t /*max_timestamp*/, Action&& action) const {
+  void ForEachCallstackEvent(TID /*tid*/, uint64_t /*min_timestamp*/, uint64_t /*max_timestamp*/,
+                             Action&& action) const {
     std::for_each(std::begin(callstacks_), std::end(callstacks_), std::forward<Action>(action));
   }
 
   [[nodiscard]] std::vector<uint64_t> ActiveInvocationTimes(
-      const absl::flat_hash_set<uint32_t>& /*tids*/, uint64_t /*frame_track_scope_id*/,
+      const absl::flat_hash_set<TID>& /*tids*/, uint64_t /*frame_track_scope_id*/,
       uint64_t /*min_relative_timestamp_ns*/, uint64_t /*max_relative_timestamp_ns*/) const {
     return frame_track_active_times_;
   };
@@ -194,9 +190,9 @@ TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
       std::move(full), std::move(empty), {kSfidToName});
   const SamplingWithFrameTrackComparisonReport report = bac.MakeSamplingWithFrameTrackReport(
       MakeBaseline<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
-          absl::flat_hash_set<uint32_t>{orbit_base::kAllProcessThreadsTid}, 0, 1, 1),
+          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, 0, 1, 1),
       MakeComparison<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
-          absl::flat_hash_set<uint32_t>{orbit_base::kAllProcessThreadsTid}, 0, 1, 1));
+          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, 0, 1, 1));
 
   EXPECT_EQ(report.GetBaselineSamplingCounts()->GetTotalCallstacks(), kCallstacks.size());
 

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -32,6 +32,7 @@ class BaselineAndComparisonTmpl {
   template <typename T>
   using Comparison = ::orbit_mizar_base::Comparison<T>;
   using SFID = ::orbit_mizar_base::SFID;
+  using TID = ::orbit_mizar_base::TID;
 
  public:
   BaselineAndComparisonTmpl(Baseline<PairedData> baseline, Comparison<PairedData> comparison,
@@ -109,7 +110,7 @@ class BaselineAndComparisonTmpl {
       const PairedData& data, const HalfOfSamplingWithFrameTrackReportConfig& config) {
     uint64_t total_callstacks = 0;
     absl::flat_hash_map<SFID, InclusiveAndExclusive> counts;
-    for (const uint32_t tid : config.tids) {
+    for (const TID tid : config.tids) {
       data.ForEachCallstackEvent(tid, config.start_relative_ns,
                                  NonWrappingAddition(config.start_relative_ns, config.duration_ns),
                                  [&total_callstacks, &counts](const std::vector<SFID>& callstack) {

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -14,6 +14,7 @@
 #include "ClientData/ScopeStats.h"
 #include "MizarBase/BaselineOrComparison.h"
 #include "MizarBase/SampledFunctionId.h"
+#include "MizarBase/ThreadId.h"
 #include "MizarStatistics/ActiveFunctionTimePerFrameComparator.h"
 #include "OrbitBase/Logging.h"
 
@@ -26,8 +27,11 @@ struct CorrectedComparisonResult : public orbit_mizar_statistics::ComparisonResu
 
 // The struct represents the part of configuration relevant to one of the two captures under
 // comparison.
-struct HalfOfSamplingWithFrameTrackReportConfig {
-  explicit HalfOfSamplingWithFrameTrackReportConfig(absl::flat_hash_set<uint32_t> tids,
+class HalfOfSamplingWithFrameTrackReportConfig {
+  using TID = ::orbit_mizar_base::TID;
+
+ public:
+  explicit HalfOfSamplingWithFrameTrackReportConfig(absl::flat_hash_set<TID> tids,
                                                     uint64_t start_ns, uint64_t duration_ns,
                                                     uint64_t frame_track_scope_id)
       : tids(std::move(tids)),
@@ -35,7 +39,7 @@ struct HalfOfSamplingWithFrameTrackReportConfig {
         duration_ns(duration_ns),
         frame_track_scope_id(frame_track_scope_id) {}
 
-  absl::flat_hash_set<uint32_t> tids{};
+  absl::flat_hash_set<TID> tids{};
   uint64_t start_relative_ns{};  // nanoseconds elapsed since capture start
   uint64_t duration_ns{};
   uint64_t frame_track_scope_id{};

--- a/src/MizarStatistics/ActiveFunctionTimePerFrameComparatorTest.cpp
+++ b/src/MizarStatistics/ActiveFunctionTimePerFrameComparatorTest.cpp
@@ -14,16 +14,12 @@
 #include "MizarBase/SampledFunctionId.h"
 #include "MizarStatistics/ActiveFunctionTimePerFrameComparator.h"
 
+using ::orbit_mizar_base::Baseline;
+using ::orbit_mizar_base::Comparison;
 using ::orbit_mizar_base::SFID;
 using ::testing::DoubleNear;
 using ::testing::IsNan;
 using ::testing::Return;
-
-template <typename T>
-using Baseline = ::orbit_mizar_base::Baseline<T>;
-
-template <typename T>
-using Comparison = ::orbit_mizar_base::Comparison<T>;
 
 namespace {
 class MockCounts {

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
@@ -47,10 +47,9 @@ SamplingWithFrameTrackInputWidgetBase::MakeConfig() const {
 void SamplingWithFrameTrackInputWidgetBase::OnThreadSelectionChanged() {
   selected_tids_.clear();
   const QList<QListWidgetItem*> selected_items = GetThreadList()->selectedItems();
-  std::transform(
-      std::begin(selected_items), std::end(selected_items),
-      std::inserter(selected_tids_, std::begin(selected_tids_)),
-      [](const QListWidgetItem* item) { return item->data(kTidRole).value<uint32_t>(); });
+  std::transform(std::begin(selected_items), std::end(selected_items),
+                 std::inserter(selected_tids_, std::begin(selected_tids_)),
+                 [](const QListWidgetItem* item) { return item->data(kTidRole).value<TID>(); });
 }
 
 void SamplingWithFrameTrackInputWidgetBase::OnFrameTrackSelectionChanged(int index) {

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -16,8 +16,10 @@
 #include <string>
 
 #include "ClientData/ScopeInfo.h"
+#include "MizarBase/ThreadId.h"
 #include "MizarWidgets/SamplingWithFrameTrackInputWidget.h"
 
+using orbit_mizar_base::TID;
 using testing::ElementsAreArray;
 using testing::NotNull;
 using testing::Return;
@@ -27,8 +29,8 @@ using testing::UnorderedElementsAreArray;
 namespace {
 class MockPairedData {
  public:
-  MOCK_METHOD((const absl::flat_hash_map<uint32_t, std::string>&), TidToNames, (), (const));
-  MOCK_METHOD((const absl::flat_hash_map<uint32_t, std::uint64_t>&), TidToCallstackSampleCounts, (),
+  MOCK_METHOD((const absl::flat_hash_map<TID, std::string>&), TidToNames, (), (const));
+  MOCK_METHOD((const absl::flat_hash_map<TID, std::uint64_t>&), TidToCallstackSampleCounts, (),
               (const));
   MOCK_METHOD((const absl::flat_hash_map<uint64_t, orbit_client_data::ScopeInfo>), GetFrameTracks,
               (), (const));
@@ -37,21 +39,21 @@ class MockPairedData {
 
 namespace orbit_mizar_widgets {
 
-constexpr uint32_t kTid = 0x3EAD1;
-constexpr uint32_t kOtherTid = 0x3EAD2;
+constexpr TID kTid(0x3EAD1);
+constexpr TID kOtherTid(0x3EAD2);
 const std::string kThreadName = "Thread";
 const std::string kOtherThreadName = "Other Thread";
 constexpr uint64_t kThreadSamplesCount = 5;
 constexpr uint64_t kOtherThreadSamplesCount = 2;
-const absl::flat_hash_map<uint32_t, std::string> kTidToName = {{kTid, kThreadName},
-                                                               {kOtherTid, kOtherThreadName}};
+const absl::flat_hash_map<TID, std::string> kTidToName = {{kTid, kThreadName},
+                                                          {kOtherTid, kOtherThreadName}};
 
-const absl::flat_hash_map<uint32_t, uint64_t> kTidToCount = {{kTid, kThreadSamplesCount},
-                                                             {kOtherTid, kOtherThreadSamplesCount}};
+const absl::flat_hash_map<TID, uint64_t> kTidToCount = {{kTid, kThreadSamplesCount},
+                                                        {kOtherTid, kOtherThreadSamplesCount}};
 constexpr size_t kThreadCount = 2;
 
-static std::string MakeThreadListItemString(std::string_view name, uint32_t tid) {
-  return absl::StrFormat("[%u] %s", tid, name);
+static std::string MakeThreadListItemString(std::string_view name, TID tid) {
+  return absl::StrFormat("[%u] %s", *tid, name);
 }
 
 const std::vector<std::string> kThreadNamesSorted = {
@@ -129,7 +131,7 @@ class SamplingWithFrameTrackInputWidgetTest : public ::testing::Test {
 
   void ClearThreadListSelection() const { thread_list_->selectionModel()->clearSelection(); }
 
-  void ExpectSelectedTidsAre(std::initializer_list<uint32_t> tids) const {
+  void ExpectSelectedTidsAre(std::initializer_list<TID> tids) const {
     EXPECT_THAT(widget_->MakeConfig().tids, UnorderedElementsAreArray(tids));
   }
 

--- a/src/MizarWidgets/SamplingWithFrameTrackWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackWidget.cpp
@@ -13,13 +13,9 @@
 
 namespace orbit_mizar_widgets {
 
-template <typename T>
-using Baseline = ::orbit_mizar_base::Baseline<T>;
-
-template <typename T>
-using Comparison = ::orbit_mizar_base::Comparison<T>;
-
 using orbit_base::LiftAndApply;
+using ::orbit_mizar_base::Baseline;
+using ::orbit_mizar_base::Comparison;
 
 SamplingWithFrameTrackWidget::SamplingWithFrameTrackWidget(QWidget* parent)
     : QWidget(parent), ui_(std::make_unique<Ui::SamplingWithFrameTrackWidget>()) {

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -28,10 +28,14 @@ namespace Ui {
 class SamplingWithFrameTrackInputWidget;
 }
 
+Q_DECLARE_METATYPE(::orbit_mizar_base::TID);
+
 namespace orbit_mizar_widgets {
 
 class SamplingWithFrameTrackInputWidgetBase : public QWidget {
   Q_OBJECT
+  using TID = ::orbit_mizar_base::TID;
+
  public:
   ~SamplingWithFrameTrackInputWidgetBase() override;
 
@@ -54,12 +58,14 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
   [[nodiscard]] QComboBox* GetFrameTrackList() const;
 
  private:
-  absl::flat_hash_set<uint32_t> selected_tids_;
+  absl::flat_hash_set<TID> selected_tids_;
   uint64_t frame_track_scope_id_ = 0;
 };
 
 template <typename PairedData>
 class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInputWidgetBase {
+  using TID = ::orbit_mizar_base::TID;
+
  public:
   SamplingWithFrameTrackInputWidgetTmpl() = delete;
   explicit SamplingWithFrameTrackInputWidgetTmpl(QWidget* parent)
@@ -79,17 +85,17 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
     QListWidget* list = GetThreadList();
     list->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
-    const absl::flat_hash_map<uint32_t, std::string>& tid_to_name = data.TidToNames();
-    const absl::flat_hash_map<uint32_t, uint64_t>& counts = data.TidToCallstackSampleCounts();
+    const absl::flat_hash_map<TID, std::string>& tid_to_name = data.TidToNames();
+    const absl::flat_hash_map<TID, uint64_t>& counts = data.TidToCallstackSampleCounts();
 
-    std::vector<std::pair<uint32_t, uint64_t>> counts_sorted(std::begin(counts), std::end(counts));
+    std::vector<std::pair<TID, uint64_t>> counts_sorted(std::begin(counts), std::end(counts));
 
     std::sort(std::begin(counts_sorted), std::end(counts_sorted),
               [](const auto& a, const auto& b) { return a.second > b.second; });
     for (const auto& [tid, unused_count] : counts_sorted) {
       auto item = std::make_unique<QListWidgetItem>(
-          QString::fromStdString(absl::StrFormat("[%u] %s", tid, tid_to_name.at(tid))));
-      item->setData(kTidRole, tid);
+          QString::fromStdString(absl::StrFormat("[%u] %s", *tid, tid_to_name.at(tid))));
+      item->setData(kTidRole, QVariant::fromValue(tid));
       list->addItem(item.release());
     }
   }

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -68,6 +68,8 @@ class Typedef {
   constexpr explicit Typedef(std::in_place_t, Args&&... args)
       : value_(T(std::forward<T>(args)...)) {}
 
+  constexpr Typedef() = default;
+
   constexpr Typedef(const Typedef& other) = default;
   constexpr Typedef(Typedef&& other) = default;
 


### PR DESCRIPTION
This is supposed to promote type-safety and redability.

Also, this makes Typedef default-constructible.

Bug: http://237786468
Tests: Compile, Manual, Unit