### PR TITLE
Add a function to primitive assembler that draws vertical arrows

### DIFF
--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -57,7 +57,7 @@ void DataManager::set_selected_thread_id(uint32_t thread_id) {
 void DataManager::set_selected_thread_state_slice(
     std::optional<orbit_client_data::ThreadStateSliceInfo> selected_thread_state_slice) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  selected_thread_state_slice_ = std::move(selected_thread_state_slice);
+  selected_thread_state_slice_ = selected_thread_state_slice;
 }
 
 void DataManager::set_selected_timer(const orbit_client_protos::TimerInfo* timer_info) {

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -244,9 +244,9 @@ void PrimitiveAssembler::AddCircle(const Vec2& position, float radius, float z, 
   }
 }
 
-void PrimitiveAssembler::AddVerticalArrow(float x, float start_y, float end_y, float z, uint width,
-                                          float head_length_ratio, float head_width_ratio,
-                                          Color color) {
+void PrimitiveAssembler::AddVerticalArrow(float x, float start_y, float end_y, float z,
+                                          uint32_t width, float head_length_ratio,
+                                          float head_width_ratio, Color color) {
   float min_y = std::min(start_y, end_y);
   float max_y = std::max(start_y, end_y);
 

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -8,6 +8,9 @@
 #include <math.h>
 #include <stddef.h>
 
+#include <array>
+
+#include "CoreMath.h"
 #include "Geometry.h"
 
 namespace orbit_gl {
@@ -239,6 +242,29 @@ void PrimitiveAssembler::AddCircle(const Vec2& position, float radius, float z, 
     AddTriangle(triangle, z, color);
     prev_point = new_point;
   }
+}
+
+void PrimitiveAssembler::AddVerticalArrow(float x, float start_y, float end_y, float z, uint width,
+                                          float head_length_ratio, float head_width_ratio,
+                                          Color color) {
+  float min_y = std::min(start_y, end_y);
+  float max_y = std::max(start_y, end_y);
+
+  float head_length = std::abs(start_y - end_y) * head_length_ratio;
+  if (max_y == end_y) {
+    head_length = -head_length;
+  }
+  float head_width = width * head_width_ratio;
+  Triangle arrow_head(Vec2(x, end_y), Vec2(x - head_width, end_y + head_length),
+                      Vec2(x + head_width, end_y + head_length));
+  AddTriangle(arrow_head, z, color);
+
+  min_y = std::min(start_y, end_y + head_length);
+  max_y = std::max(start_y, end_y + head_length);
+  std::array<Vec2, 4> box_vertices{Vec2(x - width, min_y), Vec2(x - width, max_y),
+                                   Vec2(x + width, max_y), Vec2(x + width, min_y)};
+  Quad arrow_body(box_vertices);
+  AddBox(arrow_body, z, color);
 }
 
 void PrimitiveAssembler::AddQuadBorder(const Quad& quad, float z, const Color& color,

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -98,6 +98,8 @@ class PrimitiveAssembler {
 
   void AddCircle(const Vec2& position, float radius, float z, Color color);
 
+  void AddVerticalArrow(float x, float y_start, float y_end, float z, uint width, float head_length_ratio, float head_width_ratio, Color color);
+
   void StartNewFrame();
 
   [[nodiscard]] PickingManager* GetPickingManager() const { return picking_manager_; }

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -98,7 +98,8 @@ class PrimitiveAssembler {
 
   void AddCircle(const Vec2& position, float radius, float z, Color color);
 
-  void AddVerticalArrow(float x, float y_start, float y_end, float z, uint width, float head_length_ratio, float head_width_ratio, Color color);
+  void AddVerticalArrow(float x, float y_start, float y_end, float z, uint width,
+                        float head_length_ratio, float head_width_ratio, Color color);
 
   void StartNewFrame();
 

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -98,7 +98,7 @@ class PrimitiveAssembler {
 
   void AddCircle(const Vec2& position, float radius, float z, Color color);
 
-  void AddVerticalArrow(float x, float y_start, float y_end, float z, uint width,
+  void AddVerticalArrow(float x, float y_start, float y_end, float z, uint32_t width,
                         float head_length_ratio, float head_width_ratio, Color color);
 
   void StartNewFrame();

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -96,11 +96,25 @@ class PrimitiveAssembler {
   void AddQuadBorder(const Quad& quad, float z, const Color& color,
                      std::unique_ptr<orbit_gl::PickingUserData> user_data);
 
-  void AddCircle(const Vec2& position, float radius, float z, Color color);
+  void AddCircle(const Vec2& position, float radius, float z, const Color& color);
 
   enum class ArrowDirection { kUp, kDown };
-  void AddVerticalArrow(Vec2 starting_pos, Vec2 size, float z, Color color,
-                        ArrowDirection arrow_direction, Vec2 head_size = Vec2{5, 4});
+  //
+  //   ⸢¯¯¯¯¯⸣ = arrow_body_size[0]
+  //   ⎡¯¯X¯¯⎤     ⎤
+  //   |     |     |
+  //   |     |     |  = arrow_body_size[1]
+  //   |     |     ⎦
+  //  \¯¯¯¯¯¯¯/  ⎤
+  //   \     /   |
+  //    \   /    | = arrow_head_size[1]
+  //     \ /     ⎦
+  //      ˅
+  //  ⸤________⸥ = arrow_head_size[0]
+  //
+  // x is starting_pos
+  void AddVerticalArrow(Vec2 starting_pos, Vec2 arrow_body_size, Vec2 arrow_head_size, float z,
+                        const Color& color, ArrowDirection arrow_direction);
 
   void StartNewFrame();
 

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -98,8 +98,9 @@ class PrimitiveAssembler {
 
   void AddCircle(const Vec2& position, float radius, float z, Color color);
 
-  void AddVerticalArrow(float x, float y_start, float y_end, float z, uint32_t width,
-                        float head_length_ratio, float head_width_ratio, Color color);
+  enum class ArrowDirection { kUp, kDown };
+  void AddVerticalArrow(Vec2 starting_pos, Vec2 size, float z, Color color,
+                        ArrowDirection arrow_direction, Vec2 head_size = Vec2{5, 4});
 
   void StartNewFrame();
 

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "CoreMath.h"
 #include "MockBatcher.h"
 #include "PickingManagerTest.h"
 #include "PrimitiveAssembler.h"
@@ -18,8 +19,9 @@ const Vec2 kTopRight{5, 0};
 const Vec2 kBottomRight{5, 5};
 const Vec2 kBottomLeft{0, 5};
 const Vec2 kBoxSize{5, 5};
-const Vec2 kArrowSize{2, 4};
-const Vec2 kArrowHeadSize{3, 2};
+const Vec2 kArrowStartingPos{5, 5};
+const Vec2 kArrowBodySize{2, 4};
+const Vec2 kArrowHeadSize{4, 2};
 
 class PrimitiveAssemblerTester : public PrimitiveAssembler {
  public:
@@ -154,28 +156,31 @@ TEST(PrimitiveAssembler, ComplexShapes) {
 
   primitive_assembler_tester.StartNewFrame();
 
-  // Draw arrow pointing down
-  primitive_assembler_tester.AddVerticalArrow(kBottomRight, kArrowSize, 0, kFakeColor,
-                                              PrimitiveAssembler::ArrowDirection::kDown,
-                                              kArrowHeadSize);
+  // AddVerticalArrow (arrow pointing down) -> 1 box and 1 Triangle
+  primitive_assembler_tester.AddVerticalArrow(kArrowStartingPos, kArrowBodySize, kArrowHeadSize, 0,
+                                              kFakeColor,
+                                              PrimitiveAssembler::ArrowDirection::kDown);
+  float arrow_width1 = std::max(kArrowHeadSize[0], kArrowBodySize[0]);
+  float arrow_height1 = kArrowHeadSize[1] + kArrowBodySize[1];
   EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), 1);
   EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 0);
   EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), 1);
   EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(
-      kBottomRight - Vec2{kArrowHeadSize[0], 0}, Vec2{2 * kArrowHeadSize[0], kArrowSize[1]}));
+      kArrowStartingPos - Vec2{arrow_width1 / 2, 0}, Vec2{arrow_width1, arrow_height1}));
 
   primitive_assembler_tester.StartNewFrame();
 
-  // Draw arrow pointing up
-  primitive_assembler_tester.AddVerticalArrow(kBottomRight, kArrowSize, 0, kFakeColor,
-                                              PrimitiveAssembler::ArrowDirection::kUp,
-                                              kArrowHeadSize);
+  // AddVerticalArrow (arrow pointing up) -> 1 box and 1 Triangle
+  primitive_assembler_tester.AddVerticalArrow(kArrowStartingPos, kArrowBodySize, kArrowHeadSize, 0,
+                                              kFakeColor, PrimitiveAssembler::ArrowDirection::kUp);
+  float arrow_width2 = std::max(kArrowHeadSize[0], kArrowBodySize[0]);
+  float arrow_height2 = kArrowHeadSize[1] + kArrowBodySize[1];
   EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), 1);
   EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 0);
   EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), 1);
   EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(
-      kBottomRight - Vec2{kArrowHeadSize[0], kArrowSize[1]},
-      Vec2{2 * kArrowHeadSize[0], kArrowSize[1]}));
+      kArrowStartingPos - Vec2{arrow_width2 / 2, arrow_height2},
+      Vec2{arrow_width2, arrow_height2}));
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -18,6 +18,8 @@ const Vec2 kTopRight{5, 0};
 const Vec2 kBottomRight{5, 5};
 const Vec2 kBottomLeft{0, 5};
 const Vec2 kBoxSize{5, 5};
+const Vec2 kArrowSize{2, 4};
+const Vec2 kArrowHeadSize{3, 2};
 
 class PrimitiveAssemblerTester : public PrimitiveAssembler {
  public:
@@ -149,6 +151,31 @@ TEST(PrimitiveAssembler, ComplexShapes) {
   EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(
       kBottomRight - Vec2{kRoundedRadius, kRoundedRadius},
       {kRoundedRadius * 2.f, kRoundedRadius * 2.f}));
+
+  primitive_assembler_tester.StartNewFrame();
+
+  // Draw arrow pointing down
+  primitive_assembler_tester.AddVerticalArrow(kBottomRight, kArrowSize, 0, kFakeColor,
+                                              PrimitiveAssembler::ArrowDirection::kDown,
+                                              kArrowHeadSize);
+  EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), 1);
+  EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 0);
+  EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), 1);
+  EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(
+      kBottomRight - Vec2{kArrowHeadSize[0], 0}, Vec2{2 * kArrowHeadSize[0], kArrowSize[1]}));
+
+  primitive_assembler_tester.StartNewFrame();
+
+  // Draw arrow point up
+  primitive_assembler_tester.AddVerticalArrow(kBottomRight, kArrowSize, 0, kFakeColor,
+                                              PrimitiveAssembler::ArrowDirection::kUp,
+                                              kArrowHeadSize);
+  EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), 1);
+  EXPECT_EQ(primitive_assembler_tester.GetNumLines(), 0);
+  EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), 1);
+  EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(
+      kBottomRight - Vec2{kArrowHeadSize[0], kArrowSize[1]},
+      Vec2{2 * kArrowHeadSize[0], kArrowSize[1]}));
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -166,7 +166,7 @@ TEST(PrimitiveAssembler, ComplexShapes) {
 
   primitive_assembler_tester.StartNewFrame();
 
-  // Draw arrow point up
+  // Draw arrow pointing up
   primitive_assembler_tester.AddVerticalArrow(kBottomRight, kArrowSize, 0, kFakeColor,
                                               PrimitiveAssembler::ArrowDirection::kUp,
                                               kArrowHeadSize);

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -12,7 +12,6 @@
 #include "CoreMath.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
-#include "OrbitBase/ThreadUtils.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
 #include "TrackRenderHelper.h"


### PR DESCRIPTION
Primitive assembler now has a function that allows drawing vertical arrows, the height, width, head height, and head width ratios are all modifiable.

Bug: http://b/236945179