### PR TITLE
Remove log event when disabling non-existing frame tracks

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2883,8 +2883,10 @@ void OrbitApp::EnableFrameTrack(const FunctionInfo& function) {
 }
 
 void OrbitApp::DisableFrameTrack(const FunctionInfo& function) {
-  data_manager_->DisableFrameTrack(function);
-  metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_FRAME_TRACK_DISABLED);
+  if (data_manager_->IsFrameTrackEnabled(function)) {
+    data_manager_->DisableFrameTrack(function);
+    metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_FRAME_TRACK_DISABLED);
+  }
 }
 
 void OrbitApp::AddFrameTrack(const FunctionInfo& function) {
@@ -2959,8 +2961,8 @@ void OrbitApp::RemoveFrameTrack(uint64_t instrumented_function_id) {
     GetMutableCaptureData().DisableFrameTrack(instrumented_function_id);
     GetMutableTimeGraph()->GetTrackContainer()->RemoveFrameTrack(instrumented_function_id);
     TrySaveUserDefinedCaptureInfo();
+    metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_FRAME_TRACK_REMOVED);
   }
-  metrics_uploader_->SendLogEvent(OrbitLogEvent::ORBIT_FRAME_TRACK_REMOVED);
 }
 
 bool OrbitApp::IsFrameTrackEnabled(const FunctionInfo& function) const {


### PR DESCRIPTION
The previous behavior sent a "frame track removed / disabled" event
whenever a user selects multiple methods and unhooks them all as we
were not checking for the existence of a frame track before sending the
event. This also caused E2E tests to fail due to UI freezes.

Bug: b/237519182
Test: Ran the E2E test locally