### PR TITLE
Improve frozen UI on capture loading

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -335,11 +335,14 @@ OrbitApp::OrbitApp(orbit_gl::MainWindowInterface* main_window,
   module_manager_ = std::make_unique<orbit_client_data::ModuleManager>();
   manual_instrumentation_manager_ = std::make_unique<ManualInstrumentationManager>();
 
-  QObject::connect(&update_after_symbol_loading_throttle_, &orbit_qt_utils::Throttle::Triggered,
-                   [this]() {
-                     UpdateAfterSymbolLoading();
-                     FireRefreshCallbacks();
-                   });
+  QObject::connect(
+      &update_after_symbol_loading_throttle_, &orbit_qt_utils::Throttle::Triggered,
+      &update_after_symbol_loading_throttle_,
+      [this]() {
+        UpdateAfterSymbolLoading();
+        FireRefreshCallbacks();
+      },
+      Qt::QueuedConnection);
 }
 
 OrbitApp::~OrbitApp() {


### PR DESCRIPTION
This improves an issue with `update_after_symbol_loading_throttle_` in
OrbitApp. The throttle did not work when the call to
`UpdateAfterSymbolLoading()` (which does post processing) took longer
than the throttle interval (in this case more than 1 second). This is
fixed by using a `Qt::QueuedConnection`, to queue the post processing
instead of executing it directly.

Test: Manual
Bug: http://b/237983515