### PR TITLE
Optimize LibunwindstackMapsImpl::AddAndSort

### DIFF
--- a/src/LinuxTracing/LibunwindstackMaps.cpp
+++ b/src/LinuxTracing/LibunwindstackMaps.cpp
@@ -34,27 +34,47 @@ void LibunwindstackMapsImpl::AddAndSort(uint64_t start, uint64_t end, uint64_t o
   // manpage of `mmap`: "`MAP_FIXED` [...] If the memory region specified by `addr` and `length`
   // overlaps pages of any existing mapping(s), then the overlapped part of the existing mapping(s)
   // will be discarded."
-  for (auto map_info_it = maps_->begin(); map_info_it != maps_->end();) {
+  // Only then we can add the new map, knowing it will not overlap with any existing one.
+
+  // Start from the first existing MapInfo that ends after the start of the new map. All MapInfos
+  // before that should remain untouched.
+  auto map_info_it =
+      std::upper_bound(maps_->begin(), maps_->end(), start,
+                       [](uint64_t address, const std::shared_ptr<unwindstack::MapInfo>& map_info) {
+                         return address < map_info->end();
+                       });
+
+  while (map_info_it != maps_->end()) {
     std::shared_ptr<unwindstack::MapInfo> map_info = *map_info_it;
-    if (end <= map_info->start() || start >= map_info->end()) {
-      // The new map does not intersect map_info. Keep map_info untouched (do nothing).
-      ++map_info_it;
+    // Because of how we initialized map_info_it.
+    ORBIT_CHECK(map_info->end() > start);
+
+    if (end <= map_info->start()) {
+      // The new map does not intersect map_info and is before it. Keep map_info untouched but add
+      // the new map before it.
+      maps_->Insert(map_info_it, start, end, offset, flags, name);
+      // The new map will not intersect any other existing map, so stop.
+      return;
 
     } else if (start <= map_info->start() && end >= map_info->end()) {
       // The new map encloses map_info. Remove map_info.
       map_info_it = maps_->erase(map_info_it);
 
     } else if (start <= map_info->start()) {
-      // The new map intersects the first part of map_info. Keep the second part of map_info.
       uint64_t new_offset = 0;
       if (!map_info->name().empty() && map_info->name().c_str()[0] != '[') {
         // This was a file mapping: update the offset.
         new_offset = map_info->offset() + (end - map_info->start());
       }
+      // The new map intersects the first part of map_info. Keep the second part of map_info but add
+      // the new map before it.
       map_info_it = maps_->erase(map_info_it);
-      map_info_it = maps_->Insert(map_info_it, end, map_info->end(), new_offset, map_info->flags(),
-                                  map_info->name());
+      map_info_it = maps_->Insert(map_info_it, start, end, offset, flags, name);
       ++map_info_it;
+      maps_->Insert(map_info_it, end, map_info->end(), new_offset, map_info->flags(),
+                    map_info->name());
+      // The new map will not intersect any other existing map, so stop.
+      return;
 
     } else if (end >= map_info->end()) {
       // The new map intersects the second part of map_info. Keep the first part of map_info.
@@ -64,7 +84,8 @@ void LibunwindstackMapsImpl::AddAndSort(uint64_t start, uint64_t end, uint64_t o
       ++map_info_it;
 
     } else {
-      // The new map intersects the central part of map_info.
+      // The new map intersects the central part of map_info. Keep the first and last part of
+      // map_info but add the new map in between.
       ORBIT_CHECK(start > map_info->start() && end < map_info->end());
       map_info_it = maps_->erase(map_info_it);
       {
@@ -74,22 +95,28 @@ void LibunwindstackMapsImpl::AddAndSort(uint64_t start, uint64_t end, uint64_t o
         ++map_info_it;
       }
       {
+        // Add the new map.
+        map_info_it = maps_->Insert(map_info_it, start, end, offset, flags, name);
+        ++map_info_it;
+      }
+      {
         // Keep the last part of map_info.
         uint64_t new_offset = 0;
         if (!map_info->name().empty() && map_info->name().c_str()[0] != '[') {
           // This was a file mapping: update the offset.
           new_offset = map_info->offset() + (end - map_info->start());
         }
-        map_info_it = maps_->Insert(map_info_it, end, map_info->end(), new_offset,
-                                    map_info->flags(), map_info->name());
-        ++map_info_it;
+        maps_->Insert(map_info_it, end, map_info->end(), new_offset, map_info->flags(),
+                      map_info->name());
       }
+      // The new map will not intersect any other existing map, so stop.
+      return;
     }
   }
 
-  // Now add the new map. For simplicity, add at the end and sort.
-  maps_->Add(start, end, offset, flags, name);
-  maps_->Sort();
+  // If the new map has not been added yet, it goes at the end.
+  ORBIT_CHECK(maps_->Total() == 0 || (*(maps_->end() - 1))->end() <= start);
+  maps_->Insert(maps_->end(), start, end, offset, flags, name);
 }
 
 }  // namespace


### PR DESCRIPTION
https://github.com/google/orbit/pull/3649 made `LibunwindstackMaps` correctly
keep track of our snapshot of the target's maps by handling new maps that
overlap with existing ones (because of `MMAP_FIXED`). With
https://github.com/google/orbit/pull/3658 we started collecting
`PERF_RECORD_MMAP` events also for non-executable mappings.

However, the implementation from https://github.com/google/orbit/pull/3649 is
inefficient, and some games running on Wine produce many more `PERF_RECORD_MMAP`
events (for non-executable maps) than anticipated (e.g., ~1500/s). This can make
OrbitService spend most of its CPU time updating its snapshot of the target's
maps.

We optimize this by only looking at the existing `MapInfo`s that could be
affected, and by avoiding the call to `unwindstack::Maps::Sort()`. The average
time of `LibunwindstackMapsImpl::AddAndSort` when capturing the Wine target that
showed this is down from ~300 us to ~5 us.

Bug: http://b/237624581

Test:
- Update unit tests.
- Repeatedly capture the Wine target that showed this, make sure no checks fail.
- Capture unaligned `triangle.exe` from the beginning by setting
  `LD_PRELOAD=libdebugger_preload.so` and verify that the callstacks make sense.