### PR TITLE
Adapt tooltip for target label

### DIFF
--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -124,7 +124,7 @@ void TargetLabel::ChangeToStadiaTarget(const orbit_client_data::ProcessData& pro
   ui_->targetLabel->setVisible(true);
   ui_->fileLabel->setVisible(false);
 
-  ui_->targetLabel->setToolTip(
+  setToolTip(
       QString{"Connection active.<br/><br/>"
               "Instance: %1 (%2)<br/>"
               "Process: %3 (%4)"}

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -128,7 +128,7 @@ void TargetLabel::ChangeToStadiaTarget(const orbit_client_data::ProcessData& pro
       QString{"Connection active.<br/><br/>"
               "Instance: %1 (%2)<br/>"
               "Process: %3 (%4)"}
-          .arg(instance.display_name, instance.id, QString::fromStdString(process.name()),
+          .arg(instance.display_name, instance.id, process_,
                QString::fromStdString(process.full_path())));
   setAccessibleName("Stadia target");
 }

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -117,18 +117,19 @@ void TargetLabel::ChangeToStadiaTarget(const StadiaTarget& stadia_target) {
 
 void TargetLabel::ChangeToStadiaTarget(const orbit_client_data::ProcessData& process,
                                        const orbit_ggp::Instance& instance) {
-  ChangeToStadiaTarget(QString::fromStdString(process.name()), process.cpu_usage(),
-                       instance.display_name);
-}
-
-void TargetLabel::ChangeToStadiaTarget(const QString& process_name, double cpu_usage,
-                                       const QString& instance_name) {
   Clear();
-  process_ = process_name;
-  machine_ = instance_name;
-  SetProcessCpuUsageInPercent(cpu_usage);
+  process_ = QString::fromStdString(process.name());
+  machine_ = instance.display_name;
+  SetProcessCpuUsageInPercent(process.cpu_usage());
   ui_->targetLabel->setVisible(true);
   ui_->fileLabel->setVisible(false);
+
+  ui_->targetLabel->setToolTip(
+      QString{"Connection active.<br/><br/>"
+              "Instance: %1 (%2)<br/>"
+              "Process: %3 (%4)"}
+          .arg(instance.display_name, instance.id, QString::fromStdString(process.name()),
+               QString::fromStdString(process.full_path())));
   setAccessibleName("Stadia target");
 }
 
@@ -156,7 +157,6 @@ bool TargetLabel::SetProcessCpuUsageInPercent(double cpu_usage) {
   ui_->targetLabel->setText(
       QString{"%1 (%2%) @ %3"}.arg(process_).arg(cpu_usage, 0, 'f', 0).arg(machine_));
   SetColor(kGreenColor);
-  setToolTip({});
   SetIcon(IconType::kGreenConnectedIcon);
   emit SizeChanged();
   return true;

--- a/src/SessionSetup/TargetLabelTest.cpp
+++ b/src/SessionSetup/TargetLabelTest.cpp
@@ -224,13 +224,10 @@ TEST(TargetLabel, SetFile) {
   TargetLabel label{};
   const QColor initial_color = label.GetTargetColor();
 
-  const QString process_name = "test process";
-  const double cpu_usage = 50.1;
-  const QString instance_name = "test instance";
-
   ChangeToFakeStadiaTarget(label);
 
-  EXPECT_EQ(label.GetTargetText(), "test process (50%) @ test instance");
+  EXPECT_EQ(label.GetTargetText(),
+            QString{"%1 (%2) @ %3"}.arg(kProcessName, kCpuUsageDisplay, kInstanceName));
   EXPECT_TRUE(label.GetFileText().isEmpty());
   EXPECT_TRUE(label.GetToolTip().isEmpty());
   EXPECT_NE(label.GetTargetColor(), initial_color);
@@ -241,7 +238,8 @@ TEST(TargetLabel, SetFile) {
   const std::filesystem::path path{"/some/file"};
   label.SetFile(path);
 
-  EXPECT_EQ(label.GetTargetText(), "test process (50%) @ test instance");
+  EXPECT_EQ(label.GetTargetText(),
+            QString{"%1 (%2) @ %3"}.arg(kProcessName, kCpuUsageDisplay, kInstanceName));
   EXPECT_EQ(label.GetFileText(), "file");
   EXPECT_TRUE(label.GetToolTip().isEmpty());
   EXPECT_NE(label.GetTargetColor(), initial_color);

--- a/src/SessionSetup/TargetLabelTest.cpp
+++ b/src/SessionSetup/TargetLabelTest.cpp
@@ -41,9 +41,9 @@ TEST(TargetLabel, ChangeToFileTarget) {
 const char* kProcessName = "test process";
 const char* kInstanceName = "test instance";
 const double kCpuUsage = 50.1;
-const char* kCpuUsageDisplay = "50";
+const char* kCpuUsageDisplay = "50%";
 
-void ChangeToFakeStadiaTarget(TargetLabel& label) {
+static void ChangeToFakeStadiaTarget(TargetLabel& label) {
   orbit_client_data::ProcessData process;
   orbit_grpc_protos::ProcessInfo process_info;
   process_info.set_name(kProcessName);
@@ -53,18 +53,18 @@ void ChangeToFakeStadiaTarget(TargetLabel& label) {
 
   auto maybe_instance =
       orbit_ggp::Instance::CreateFromJson(QString{"{"
-                                                  "displayName: \"%1\", "
-                                                  "id: \"edge/test/instance\", "
-                                                  "ipAddress: \"127.0.0.1\", "
-                                                  "state: \"IN_USE\", "
-                                                  "owner: \"unit@test\", "
-                                                  "lastUpdated: \"2022-07-04T13:22:04Z\", "
-                                                  "pool: \"unit-test-pool\""
+                                                  "\"displayName\": \"%1\", "
+                                                  "\"id\": \"edge/test/instance\", "
+                                                  "\"ipAddress\": \"127.0.0.1\", "
+                                                  "\"state\": \"IN_USE\", "
+                                                  "\"owner\": \"unit@test\", "
+                                                  "\"lastUpdated\": \"2022-07-04T13:22:04Z\", "
+                                                  "\"pool\": \"unit-test-pool\""
                                                   "}"}
                                               .arg(kInstanceName)
                                               .toUtf8());
 
-  assert(maybe_instance.has_value());
+  ASSERT_TRUE(maybe_instance.has_value());
   label.ChangeToStadiaTarget(process, maybe_instance.value());
 }
 
@@ -77,7 +77,8 @@ TEST(TargetLabel, ChangeToStadiaTarget) {
   EXPECT_EQ(label.GetTargetText(),
             QString{"%1 (%2) @ %3"}.arg(kProcessName, kCpuUsageDisplay, kInstanceName));
   EXPECT_TRUE(label.GetFileText().isEmpty());
-  EXPECT_TRUE(label.GetToolTip().isEmpty());
+  EXPECT_TRUE(label.GetToolTip().contains(kProcessName));
+  EXPECT_TRUE(label.GetToolTip().contains(kInstanceName));
   EXPECT_NE(label.GetTargetColor(), initial_color);
   ASSERT_TRUE(label.GetIconType().has_value());
   EXPECT_EQ(label.GetIconType().value(), TargetLabel::IconType::kGreenConnectedIcon);
@@ -228,7 +229,8 @@ TEST(TargetLabel, SetFile) {
   EXPECT_EQ(label.GetTargetText(),
             QString{"%1 (%2) @ %3"}.arg(kProcessName, kCpuUsageDisplay, kInstanceName));
   EXPECT_TRUE(label.GetFileText().isEmpty());
-  EXPECT_TRUE(label.GetToolTip().isEmpty());
+  EXPECT_TRUE(label.GetToolTip().contains(kProcessName));
+  EXPECT_TRUE(label.GetToolTip().contains(kInstanceName));
   EXPECT_NE(label.GetTargetColor(), initial_color);
   ASSERT_TRUE(label.GetIconType().has_value());
   EXPECT_EQ(label.GetIconType().value(), TargetLabel::IconType::kGreenConnectedIcon);
@@ -240,7 +242,8 @@ TEST(TargetLabel, SetFile) {
   EXPECT_EQ(label.GetTargetText(),
             QString{"%1 (%2) @ %3"}.arg(kProcessName, kCpuUsageDisplay, kInstanceName));
   EXPECT_EQ(label.GetFileText(), "file");
-  EXPECT_TRUE(label.GetToolTip().isEmpty());
+  EXPECT_TRUE(label.GetToolTip().contains(kProcessName));
+  EXPECT_TRUE(label.GetToolTip().contains(kInstanceName));
   EXPECT_NE(label.GetTargetColor(), initial_color);
   ASSERT_TRUE(label.GetIconType().has_value());
   EXPECT_EQ(label.GetIconType().value(), TargetLabel::IconType::kGreenConnectedIcon);

--- a/src/SessionSetup/TargetLabelTest.cpp
+++ b/src/SessionSetup/TargetLabelTest.cpp
@@ -51,19 +51,18 @@ void ChangeToFakeStadiaTarget(TargetLabel& label) {
   process_info.set_cpu_usage(kCpuUsage);
   process.SetProcessInfo(process_info);
 
-  auto maybe_instance = orbit_ggp::Instance::CreateFromJson(QString{
-
-      "{"
-      "displayName: \"%1\", "
-      "id: \"edge/test/instance\""
-      "ipAddress: \"127.0.0.1\""
-      "state: \"IN_USE\""
-      "owner: \"unit@test\""
-      "lastUpdated: \"2022-07-04T13:22:04Z\""
-      "pool: \"unit-test-pool\""
-      "}"}
-                                                                .arg(kInstanceName)
-                                                                .toUtf8());
+  auto maybe_instance =
+      orbit_ggp::Instance::CreateFromJson(QString{"{"
+                                                  "displayName: \"%1\", "
+                                                  "id: \"edge/test/instance\", "
+                                                  "ipAddress: \"127.0.0.1\", "
+                                                  "state: \"IN_USE\", "
+                                                  "owner: \"unit@test\", "
+                                                  "lastUpdated: \"2022-07-04T13:22:04Z\", "
+                                                  "pool: \"unit-test-pool\""
+                                                  "}"}
+                                              .arg(kInstanceName)
+                                              .toUtf8());
 
   assert(maybe_instance.has_value());
   label.ChangeToStadiaTarget(process, maybe_instance.value());

--- a/src/SessionSetup/TargetLabelTest.cpp
+++ b/src/SessionSetup/TargetLabelTest.cpp
@@ -10,6 +10,7 @@
 #include "GrpcProtos/process.pb.h"
 #include "OrbitGgp/Instance.h"
 #include "SessionSetup/TargetLabel.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_session_setup {
 
@@ -64,7 +65,7 @@ static void ChangeToFakeStadiaTarget(TargetLabel& label) {
                                               .arg(kInstanceName)
                                               .toUtf8());
 
-  ASSERT_TRUE(maybe_instance.has_value());
+  ASSERT_THAT(maybe_instance, orbit_test_utils::HasValue());
   label.ChangeToStadiaTarget(process, maybe_instance.value());
 }
 

--- a/src/SessionSetup/include/SessionSetup/TargetLabel.h
+++ b/src/SessionSetup/include/SessionSetup/TargetLabel.h
@@ -33,8 +33,6 @@ class TargetLabel : public QWidget {
   void ChangeToStadiaTarget(const StadiaTarget& stadia_target);
   void ChangeToStadiaTarget(const orbit_client_data::ProcessData& process,
                             const orbit_ggp::Instance& instance);
-  void ChangeToStadiaTarget(const QString& process_name, double cpu_usage,
-                            const QString& instance_name);
   void ChangeToLocalTarget(const LocalTarget& local_target);
   void ChangeToLocalTarget(const orbit_client_data::ProcessData& process);
   void ChangeToLocalTarget(const QString& process_name, double cpu_usage);


### PR DESCRIPTION
The target label now shows details about instance and process during an
active connection. This is mainly used in E2E tests so we can verify
the instance ID, but will also help users to make sure they are
profiling the correct process.

Bug: b/232251224
Test: Adapted E2E test (will add in a follow-up PR)