### PR TITLE
Add thread dependency visulization

### DIFF
--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -98,6 +98,10 @@ class PrimitiveAssembler {
 
   void AddCircle(const Vec2& position, float radius, float z, Color color);
 
+  enum class ArrowDirection { kUp, kDown };
+  void AddVerticalArrow(Vec2 starting_pos, Vec2 size, float z, Color color,
+                        ArrowDirection arrow_direction, Vec2 head_size = Vec2{7, 7});
+
   void StartNewFrame();
 
   [[nodiscard]] PickingManager* GetPickingManager() const { return picking_manager_; }

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -13,7 +13,6 @@
 
 #include "CaptureViewElement.h"
 #include "ClientData/CaptureData.h"
-#include "ClientData/TimerChain.h"
 #include "TimeGraphLayout.h"
 #include "Track.h"
 #include "TrackManager.h"
@@ -81,6 +80,7 @@ class TrackContainer final : public CaptureViewElement {
  private:
   void DrawOverlay(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                    PickingMode picking_mode);
+  void DrawThreadDependency(PrimitiveAssembler& primitive_assembler, PickingMode picking_mode);
   void DrawIteratorBox(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                        Vec2 pos, Vec2 size, const Color& color, const std::string& label,
                        const std::string& time, float text_box_y);
@@ -99,6 +99,8 @@ class TrackContainer final : public CaptureViewElement {
   const orbit_client_data::CaptureData* capture_data_ = nullptr;
 
   const TimelineInfoInterface* timeline_info_;
+
+  OrbitApp* app_ = nullptr;
 };
 
 }  // namespace orbit_gl


### PR DESCRIPTION
Integrate the draw arrow function and the selected thread state slice together to draw arrows between dependent threads when clicking on a runnable thread state slice.

Arrows are only drawn if the wakeup thread is present in the capture view.

Bug: http://b/236945046

Screenshot: http://screenshot/8neEokykH62mZbu.png