### PR TITLE
Adapt connect_to_target test to use instance ID

### DIFF
--- a/contrib/automation_tests/core/common_controls.py
+++ b/contrib/automation_tests/core/common_controls.py
@@ -4,8 +4,13 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
 
+import time
+from math import floor
+
+from pywinauto import Application
 from pywinauto.base_wrapper import BaseWrapper
 from pywinauto.controls.uiawrapper import UIAWrapper, UIAElementInfo
+from pywinauto import mouse
 
 from core.orbit_e2e import find_control
 
@@ -96,3 +101,23 @@ class DataViewPanel:
 
     def find_first_item_row(self, text: str, column: int, partial_match=False) -> int:
         return self._table_obj.find_first_item_row(text, column, partial_match)
+
+
+def get_tooltip(app: Application, control: BaseWrapper) -> str:
+    old_window_handle = app.top_window().handle
+
+    rectangle = control.rectangle()
+    position = (rectangle.left + floor((rectangle.right - rectangle.left) / 2),
+                rectangle.top + floor((rectangle.bottom - rectangle.top) / 2))
+
+    control.set_focus()
+    mouse.move(position)
+    mouse.move((position[0] + 1, position[1]))
+    time.sleep(2)
+
+    tooltip = app.top_window()
+    # If the top window didn't change, the control does not have a tooltip
+    if old_window_handle != tooltip.handle:
+        return tooltip.texts()[0] if tooltip.texts() else ""
+    else:
+        return ""

--- a/contrib/automation_tests/orbit_connect_to_target.py
+++ b/contrib/automation_tests/orbit_connect_to_target.py
@@ -14,7 +14,7 @@ Verifies existence and contents of the ConnectToTargetDialog, and takes a short
 capture once the main window appears.
 
 IMPORTANT: Unlike other scripts, this script expects a single unnamed parameter
-that specifies the ID or label of the instance Orbit is expected to connect to.
+that specifies the ID of the instance Orbit is expected to connect to.
 This is required because the script cannot know the instance name before it is 
 reserved by our E2E test infrastructure.
 
@@ -39,8 +39,8 @@ def main(argv):
                            "the expected instance ID or label.")
 
     test_cases = [
-        WaitForConnectionToTargetInstanceAndProcess(expected_instance=argv[1],
-                                                    expected_process="hello_ggp_stand"),
+        WaitForConnectionToTargetInstanceAndProcess(expected_instance_id=argv[1],
+                                                    expected_process_path="/mnt/developer/hello_ggp_standalone"),
         Capture(),
         VerifyTracksExist(track_names=["hello_ggp_stand"])
     ]

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -9,11 +9,12 @@ import os
 import tempfile
 import shutil
 
-from typing import List, Iterable
+from typing import Iterable
 from pywinauto.application import Application
 from pywinauto.keyboard import send_keys
 
 from core.orbit_e2e import E2ETestCase, OrbitE2EError, wait_for_condition
+from core.common_controls import get_tooltip
 
 
 def _wait_for_main_window(application: Application, timeout=30):
@@ -338,14 +339,13 @@ class WaitForConnectionToTargetInstanceAndProcess(E2ETestCase):
     Waits for the main window to appear and checks the contents of the target label.
     """
 
-    def _execute(self, expected_instance: str, expected_process: str):
+    def _execute(self, expected_instance_id: str, expected_process_path: str):
         _wait_for_main_window(self.suite.application, timeout=120)
         # As there is a new top window (Orbit main window), we need to update the top window.
         self.suite.top_window(True)
 
-        # Check the target label
-        target_widget = self.find_control('Group', 'Target')
-        stadia_target = self.find_control('Group', 'Stadia target', parent=target_widget)
-        label = stadia_target.descendants(control_type='Text')[-1]
-        self.expect_true(label.texts()[0].startswith(expected_process), 'Found expected instance')
-        self.expect_true(label.texts()[0].endswith(expected_instance), 'Found expected process')
+        # Check the target label: The full process path and instance should be in the tooltip
+        stadia_target = self.find_control('Group', 'Stadia target')
+        tooltip = get_tooltip(self.suite.application, stadia_target)
+        self.expect_true(expected_process_path in tooltip, 'Found expected process')
+        self.expect_true(expected_instance_id in tooltip, 'Found expected instance')


### PR DESCRIPTION
The test can't be executed by the CI as it is written currently since
the go-code does not have access to the instance display name, but this
is the only information displayed in the main window to verify the
correct instance.

With this change, functionality to read tooltips is added, and the test
uses the target_label tooltip to check the contained instance id and
process path.

Bug: b/232251224
Test: E2E tests