### PR TITLE
Add "Wine Syscall Handling Method" to the client

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -125,6 +125,17 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
     instrumented_function->set_record_return_value(options.record_return_values);
   }
 
+  for (const auto& [function_id, function] : options.functions_to_record_additional_stack_on) {
+    orbit_grpc_protos::FunctionToRecordAdditionalStackOn* function_to_record_stack_on =
+        capture_options.add_functions_to_record_additional_stack_on();
+
+    function_to_record_stack_on->set_file_path(function.module_path());
+    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(function.module_path(),
+                                                                        function.module_build_id());
+    ORBIT_CHECK(module != nullptr);
+    function_to_record_stack_on->set_file_offset(function.FileOffset(module->load_bias()));
+  }
+
   for (const auto& tracepoint : options.selected_tracepoints) {
     TracepointInfo* instrumented_tracepoint = capture_options.add_instrumented_tracepoint();
     instrumented_tracepoint->set_category(tracepoint.category());

--- a/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
+++ b/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
@@ -18,6 +18,8 @@ struct ClientCaptureOptions {
   uint32_t process_id = 0;
 
   absl::flat_hash_map<uint64_t, orbit_client_data::FunctionInfo> selected_functions;
+  absl::flat_hash_map<uint64_t, orbit_client_data::FunctionInfo>
+      functions_to_record_additional_stack_on;
   orbit_client_data::TracepointInfoSet selected_tracepoints;
   std::map<uint64_t, uint64_t> absolute_address_to_size_of_functions_to_stop_unwinding_at;
 

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -46,7 +46,8 @@ target_sources(ClientData PUBLIC
         include/ClientData/TracepointData.h
         include/ClientData/TracepointEventInfo.h
         include/ClientData/TracepointInfo.h
-        include/ClientData/UserDefinedCaptureData.h)
+        include/ClientData/UserDefinedCaptureData.h
+        include/ClientData/WineSyscallHandlingMethod.h)
 
 target_sources(ClientData PRIVATE
         CallstackData.cpp

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -215,6 +215,16 @@ DataManager::dynamic_instrumentation_method() const {
   return dynamic_instrumentation_method_;
 }
 
+void DataManager::set_wine_syscall_handling_method(WineSyscallHandlingMethod method) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  wine_syscall_handling_method_ = method;
+}
+
+WineSyscallHandlingMethod DataManager::wine_syscall_handling_method() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return wine_syscall_handling_method_;
+}
+
 void DataManager::set_samples_per_second(double samples_per_second) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   samples_per_second_ = samples_per_second;

--- a/src/ClientData/DataManagerTest.cpp
+++ b/src/ClientData/DataManagerTest.cpp
@@ -97,7 +97,7 @@ TEST(DataManager, CanOnlyBeUsedFromTheMainThread) {
                                             &DataManager::memory_warning_threshold_kb);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager,
                                             &DataManager::set_wine_syscall_handling_method,
-                                            WineSyscallHandlingMethod::NoSpecialHandling);
+                                            WineSyscallHandlingMethod::kNoSpecialHandling);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager,
                                             &DataManager::wine_syscall_handling_method);
 }

--- a/src/ClientData/DataManagerTest.cpp
+++ b/src/ClientData/DataManagerTest.cpp
@@ -95,6 +95,11 @@ TEST(DataManager, CanOnlyBeUsedFromTheMainThread) {
                                             &DataManager::set_memory_warning_threshold_kb, 0);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager,
                                             &DataManager::memory_warning_threshold_kb);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager,
+                                            &DataManager::set_wine_syscall_handling_method,
+                                            WineSyscallHandlingMethod::NoSpecialHandling);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager,
+                                            &DataManager::wine_syscall_handling_method);
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -19,6 +19,7 @@
 #include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/UserDefinedCaptureData.h"
+#include "ClientData/WineSyscallHandlingMethod.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/capture.pb.h"
 #include "GrpcProtos/tracepoint.pb.h"
@@ -96,6 +97,9 @@ class DataManager final {
   void set_unwinding_method(orbit_grpc_protos::CaptureOptions::UnwindingMethod method);
   [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method() const;
 
+  void set_wine_syscall_handling_method(WineSyscallHandlingMethod method);
+  [[nodiscard]] WineSyscallHandlingMethod wine_syscall_handling_method() const;
+
   void set_max_local_marker_depth_per_command_buffer(
       uint64_t max_local_marker_depth_per_command_buffer);
   [[nodiscard]] uint64_t max_local_marker_depth_per_command_buffer() const;
@@ -132,6 +136,7 @@ class DataManager final {
   bool enable_api_ = false;
   bool enable_introspection_ = false;
   orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod dynamic_instrumentation_method_{};
+  WineSyscallHandlingMethod wine_syscall_handling_method_{};
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
   double samples_per_second_ = 0;
   uint16_t stack_dump_size_ = 0;

--- a/src/ClientData/include/ClientData/WineSyscallHandlingMethod.h
+++ b/src/ClientData/include/ClientData/WineSyscallHandlingMethod.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef CLIENT_DATA_WINE_SYSCALL_HANDLING_METHOD_H_
+#define CLIENT_DATA_WINE_SYSCALL_HANDLING_METHOD_H_
+
+#include <cstdint>
+
+namespace orbit_client_data {
+
+// With newer Wine/Proton versions, unwinding will fail after `__wine_syscall_dispatcher`
+// (see go/unwinding_wine_syscall_dispatcher). The main reason for failing is, that the "syscall"
+// implementation of Wine operates on a different stack that the "Windows user-space" stack.
+// We see two conceptual mitigations for those unwinding errors:
+//   1. Tell the unwinder to stop at `__wine_syscall_dispatcher` and report a "complete" callstack.
+//   2. Apply (expensive) special handling to retrieve a copy of the "Windows user-space" stack.
+// For older Wine versions, no special handling is needed at all.
+// We give the user to choose between the different options of mitigation. This enum encodes the
+// respective options.
+enum WineSyscallHandlingMethod : uint8_t { NoSpecialHandling, StopUnwinding, RecordUserStack };
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_WINE_SYSCALL_HANDLING_METHOD_H_

--- a/src/ClientData/include/ClientData/WineSyscallHandlingMethod.h
+++ b/src/ClientData/include/ClientData/WineSyscallHandlingMethod.h
@@ -9,15 +9,19 @@
 namespace orbit_client_data {
 
 // With newer Wine/Proton versions, unwinding will fail after `__wine_syscall_dispatcher`
-// (see go/unwinding_wine_syscall_dispatcher). The main reason for failing is, that the "syscall"
-// implementation of Wine operates on a different stack that the "Windows user-space" stack.
+// (see go/unwinding_wine_syscall_dispatcher). The main reason for failing is that the "syscall"
+// implementation of Wine operates on a different stack than the "Windows user-space" stack.
 // We see two conceptual mitigations for those unwinding errors:
 //   1. Tell the unwinder to stop at `__wine_syscall_dispatcher` and report a "complete" callstack.
 //   2. Apply (expensive) special handling to retrieve a copy of the "Windows user-space" stack.
 // For older Wine versions, no special handling is needed at all.
-// We give the user to choose between the different options of mitigation. This enum encodes the
-// respective options.
-enum WineSyscallHandlingMethod : uint8_t { NoSpecialHandling, StopUnwinding, RecordUserStack };
+// We give the user the ability to choose between the different options of mitigation. This enum
+// encodes the respective options.
+enum class WineSyscallHandlingMethod : uint8_t {
+  kNoSpecialHandling,
+  kStopUnwinding,
+  kRecordUserStack
+};
 
 }  // namespace orbit_client_data
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1503,7 +1503,8 @@ void OrbitApp::StartCapture() {
       if (function_to_record_stack == nullptr) {
         continue;
       }
-      functions_to_record_stack_on.insert_or_assign(function_id++, *function_to_record_stack);
+      functions_to_record_additional_stack_on.insert_or_assign(function_id++,
+                                                               *function_to_record_stack);
     }
   }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1840,7 +1840,7 @@ orbit_base::Future<void> OrbitApp::LoadSymbolsManually(
 
     // Explicitely do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
   orbit_client_symbols::QSettingsBasedStorageManager storage_manager;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -44,6 +44,7 @@
 #include "ClientData/ProcessData.h"
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/UserDefinedCaptureData.h"
+#include "ClientData/WineSyscallHandlingMethod.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "ClientProtos/preset.pb.h"
 #include "ClientServices/CrashManager.h"
@@ -426,6 +427,7 @@ class OrbitApp final : public DataViewFactory,
   void SetEnableIntrospection(bool enable_introspection);
   void SetDynamicInstrumentationMethod(
       orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod method);
+  void SetWineSyscallHandlingMethod(orbit_client_data::WineSyscallHandlingMethod method);
   void SetSamplesPerSecond(double samples_per_second);
   void SetStackDumpSize(uint16_t stack_dump_size);
   void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);


### PR DESCRIPTION
This adds an enum "WineSyscallHandlingMethod" to the client to
specify how to deal with the wine syscalls.
Depending on the value set in DataManager, App will communicate
to the client to stop unwinding at the dispatcher or to
record the user stack at the dispatcher.

The option is not yet exposed to the user and the service
will not yet handle the case to record the user stack.

Test: Manual E2E prototype
Bug: http://b/236118579