### PR TITLE
Add SymbolAbsoluteAddressToVirtualAddress

### DIFF
--- a/src/ObjectUtils/Address.cpp
+++ b/src/ObjectUtils/Address.cpp
@@ -26,6 +26,18 @@ uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
          orbit_base::AlignDown<kPageSize>(module_executable_section_offset);
 }
 
+uint64_t SymbolAbsoluteAddressToVirtualAddress(uint64_t absolute_address,
+                                               uint64_t module_base_address,
+                                               uint64_t module_load_bias,
+                                               uint64_t module_executable_section_offset) {
+  ORBIT_CHECK((module_base_address % kPageSize) == 0);
+  ORBIT_CHECK((module_load_bias % kPageSize) == 0);
+  ORBIT_CHECK(absolute_address >=
+              (module_base_address + module_executable_section_offset % kPageSize));
+  return absolute_address - module_base_address + module_load_bias +
+         orbit_base::AlignDown<kPageSize>(module_executable_section_offset);
+}
+
 uint64_t SymbolOffsetToAbsoluteAddress(uint64_t symbol_address, uint64_t module_base_address,
                                        uint64_t module_executable_section_offset) {
   return SymbolVirtualAddressToAbsoluteAddress(symbol_address, module_base_address,

--- a/src/ObjectUtils/AddressTest.cpp
+++ b/src/ObjectUtils/AddressTest.cpp
@@ -16,14 +16,32 @@ TEST(Address, SymbolVirtualAddressToAbsoluteAddress) {
   EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x10, 0x1000, 0, 0), 0x1010);
   EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x1010, 0x2000, 0x1000, 0), 0x2010);
   EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x100, 0x1000, 0, 0xFF), 0x1100);
-  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5000, 0x1000, 0x10FF), 0x4100);
+  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x2100, 0x5000, 0x1000, 0x10FF), 0x5100);
 
   // Invalid input
-  EXPECT_DEATH((void)SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5001, 0x1000, 0x10FF),
+  EXPECT_DEATH(std::ignore = SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5001, 0x1000, 0x10FF),
                "Check failed");
-  EXPECT_DEATH((void)SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5001, 0x1001, 0x10FF),
+  EXPECT_DEATH(std::ignore = SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5001, 0x1001, 0x10FF),
                "Check failed");
-  EXPECT_DEATH((void)SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5000, 0x1001, 0x10FF),
+  EXPECT_DEATH(std::ignore = SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5000, 0x1001, 0x10FF),
+               "Check failed");
+}
+
+TEST(Address, SymbolAbsoluteAddressToVirtualAddress) {
+  EXPECT_EQ(SymbolAbsoluteAddressToVirtualAddress(0x1010, 0x1000, 0, 0), 0x10);
+  EXPECT_EQ(SymbolAbsoluteAddressToVirtualAddress(0x2010, 0x2000, 0x1000, 0), 0x1010);
+  EXPECT_EQ(SymbolAbsoluteAddressToVirtualAddress(0x1100, 0x1000, 0, 0xFF), 0x100);
+  EXPECT_EQ(SymbolAbsoluteAddressToVirtualAddress(0x5100, 0x5000, 0x1000, 0x10FF), 0x2100);
+
+  // Invalid input
+  EXPECT_DEATH(std::ignore = SymbolAbsoluteAddressToVirtualAddress(0x5100, 0x5001, 0x1000, 0x10FF),
+               "Check failed");
+  EXPECT_DEATH(std::ignore = SymbolAbsoluteAddressToVirtualAddress(0x5100, 0x5001, 0x1001, 0x10FF),
+               "Check failed");
+  EXPECT_DEATH(std::ignore = SymbolAbsoluteAddressToVirtualAddress(0x5100, 0x5000, 0x1001, 0x10FF),
+               "Check failed");
+
+  EXPECT_DEATH(std::ignore = SymbolAbsoluteAddressToVirtualAddress(0x5005, 0x5000, 0x1000, 0x1010),
                "Check failed");
 }
 
@@ -34,7 +52,7 @@ TEST(Address, SymbolOffsetToAbsoluteAddress) {
   EXPECT_EQ(SymbolOffsetToAbsoluteAddress(0x1100, 0x5000, 0x10FF), 0x5100);
 
   // Invalid input
-  EXPECT_DEATH((void)SymbolOffsetToAbsoluteAddress(0x1100, 0x5001, 0x10FF), "Check failed");
+  EXPECT_DEATH(std::ignore = SymbolOffsetToAbsoluteAddress(0x1100, 0x5001, 0x10FF), "Check failed");
 }
 
 TEST(Address, SymbolAbsoluteAddressToOffset) {
@@ -44,9 +62,10 @@ TEST(Address, SymbolAbsoluteAddressToOffset) {
   EXPECT_EQ(SymbolAbsoluteAddressToOffset(0x10005, 0x10000, 0x0), 0x5);
 
   // Invalid input
-  EXPECT_DEATH((void)SymbolAbsoluteAddressToOffset(0xE005, 0x10000, 0x0), "Check failed");
-  EXPECT_DEATH((void)SymbolAbsoluteAddressToOffset(0x1E005, 0x10020, 0x0), "Check failed");
-  EXPECT_DEATH((void)SymbolAbsoluteAddressToOffset(0x10005, 0x10000, 0x1010), "Check failed");
+  EXPECT_DEATH(std::ignore = SymbolAbsoluteAddressToOffset(0xE005, 0x10000, 0x0), "Check failed");
+  EXPECT_DEATH(std::ignore = SymbolAbsoluteAddressToOffset(0x1E005, 0x10020, 0x0), "Check failed");
+  EXPECT_DEATH(std::ignore = SymbolAbsoluteAddressToOffset(0x10005, 0x10000, 0x1010),
+               "Check failed");
 }
 
 }  // namespace orbit_object_utils

--- a/src/ObjectUtils/include/ObjectUtils/Address.h
+++ b/src/ObjectUtils/include/ObjectUtils/Address.h
@@ -17,6 +17,10 @@ static constexpr uint64_t kPageSize = 0x1000;
     uint64_t symbol_address, uint64_t module_base_address, uint64_t module_load_bias,
     uint64_t module_executable_section_offset);
 
+[[nodiscard]] uint64_t SymbolAbsoluteAddressToVirtualAddress(
+    uint64_t absolute_address, uint64_t module_base_address, uint64_t module_load_bias,
+    uint64_t module_executable_section_offset);
+
 [[nodiscard]] uint64_t SymbolOffsetToAbsoluteAddress(uint64_t symbol_address,
                                                      uint64_t module_base_address,
                                                      uint64_t module_executable_section_offset);


### PR DESCRIPTION
The idea is to use it in place of `SymbolAbsoluteAddressToOffset`, whose
implementation is specific to ELF files.

Bug: http://b/235824531

Test: Add unit tests.