### PR TITLE
Thread dependency visualization

### DIFF
--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -14,7 +14,6 @@
 #include "CallstackThreadBar.h"
 #include "ClientData/ThreadTrackDataProvider.h"
 #include "ClientProtos/capture_data.pb.h"
-#include "Containers/ScopeTree.h"
 #include "CoreMath.h"
 #include "PickingManager.h"
 #include "ThreadStateBar.h"
@@ -55,6 +54,8 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] uint64_t GetMaxTime() const override {
     return thread_track_data_provider_->GetMaxTime(thread_id_);
   }
+  [[nodiscard]] Vec2 GetThreadStateBarPos() const { return thread_state_bar_->GetPos(); }
+  [[nodiscard]] float GetThreadStateBarHeight() const { return thread_state_bar_->GetHeight(); }
   [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -54,8 +54,6 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] uint64_t GetMaxTime() const override {
     return thread_track_data_provider_->GetMaxTime(thread_id_);
   }
-  [[nodiscard]] Vec2 GetThreadStateBarPos() const { return thread_state_bar_->GetPos(); }
-  [[nodiscard]] float GetThreadStateBarHeight() const { return thread_state_bar_->GetHeight(); }
   [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
@@ -79,6 +77,9 @@ class ThreadTrack final : public TimerTrack {
   }
 
   [[nodiscard]] bool IsCollapsible() const override { return GetDepth() > 1; }
+
+  [[nodiscard]] Vec2 GetThreadStateBarPos() const { return thread_state_bar_->GetPos(); }
+  [[nodiscard]] float GetThreadStateBarHeight() const { return thread_state_bar_->GetHeight(); }
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
 

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -45,6 +45,9 @@ TimeGraphLayout::TimeGraphLayout() {
   scale_ = 1.f;
   time_bar_height_ = 30.f;
   font_size_ = 14;
+  thread_dependency_arrow_head_width_ = 16;
+  thread_dependency_arrow_head_height_ = 15;
+  thread_dependency_arrow_body_width_ = 4;
 };
 
 #define FLOAT_SLIDER(x) FLOAT_SLIDER_MIN_MAX(x, 0, 100.f)
@@ -74,6 +77,9 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(track_tab_offset_);
   FLOAT_SLIDER(track_indent_offset_);
   FLOAT_SLIDER(collapse_button_size_);
+  FLOAT_SLIDER(thread_dependency_arrow_head_width_);
+  FLOAT_SLIDER(thread_dependency_arrow_head_height_);
+  FLOAT_SLIDER(thread_dependency_arrow_body_width_);
   FLOAT_SLIDER(collapse_button_decrease_per_indentation_);
 
   FLOAT_SLIDER(collapse_button_offset_);

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -53,6 +53,15 @@ class TimeGraphLayout {
   float GetSpaceBetweenThreadPanes() const { return space_between_thread_panes_ * scale_; }
   float GetSpaceBetweenSubtracks() const { return space_between_subtracks_ * scale_; }
   float GetGenericFixedSpacerWidth() const { return generic_fixed_spacer_width_; }
+  float GetThreadDependencyArrowHeadWidth() const {
+    return thread_dependency_arrow_head_width_ * scale_;
+  }
+  float GetThreadDependencyArrowHeadHeight() const {
+    return thread_dependency_arrow_head_height_ * scale_;
+  }
+  float GetThreadDependencyArrowBodyWidth() const {
+    return thread_dependency_arrow_body_width_ * scale_;
+  }
   float GetScale() const { return scale_; }
   void SetScale(float value) { scale_ = std::clamp(value, kMinScale, kMaxScale); }
   void SetDrawProperties(bool value) { draw_properties_ = value; }
@@ -89,6 +98,9 @@ class TimeGraphLayout {
   float min_button_size_;
   float button_width_;
   float button_height_;
+  float thread_dependency_arrow_head_width_;
+  float thread_dependency_arrow_head_height_;
+  float thread_dependency_arrow_body_width_;
 
   uint32_t font_size_;
 

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -409,10 +409,10 @@ void TrackContainer::DrawThreadDependency(PrimitiveAssembler& primitive_assemble
       start_arrow_track->GetThreadStateBarPos()[1] + kOffsetToGetCenterOfEndingThreadStateBar;
   float y_end =
       end_arrow_track->GetThreadStateBarPos()[1] + kOffsetToGetCenterOfStartingThreadStateBar;
-  float whole_length = std::abs(y_end - y_start);
-  float body_length = whole_length - layout_->GetThreadDependencyArrowHeadHeight();
+  float whole_height = std::abs(y_end - y_start);
+  float body_height = whole_height - layout_->GetThreadDependencyArrowHeadHeight();
   Vec2 arrow_start_pos{x, y_start};
-  Vec2 arrow_body_size{layout_->GetThreadDependencyArrowBodyWidth(), body_length};
+  Vec2 arrow_body_size{layout_->GetThreadDependencyArrowBodyWidth(), body_height};
   Vec2 arrow_head_size{layout_->GetThreadDependencyArrowHeadWidth(),
                        layout_->GetThreadDependencyArrowHeadHeight()};
   PrimitiveAssembler::ArrowDirection arrow_direction =

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -409,15 +409,15 @@ void TrackContainer::DrawThreadDependencyArrow(PrimitiveAssembler& primitive_ass
   float end_arrow_y =
       end_arrow_track->GetThreadStateBarPos()[1] + end_arrow_thread_state_half_height;
   float arrow_total_height = std::abs(end_arrow_y - start_arrow_y);
-  float body_height = arrow_total_height - layout_->GetThreadDependencyArrowHeadHeight();
+  float arrow_body_height = arrow_total_height - layout_->GetThreadDependencyArrowHeadHeight();
   PrimitiveAssembler::ArrowDirection arrow_direction =
       start_arrow_y < end_arrow_y ? PrimitiveAssembler::ArrowDirection::kDown
                                   : PrimitiveAssembler::ArrowDirection::kUp;
   primitive_assembler.AddVerticalArrow(
-      Vec2{x, start_arrow_y}, Vec2{layout_->GetThreadDependencyArrowBodyWidth(), body_height},
+      Vec2{x, start_arrow_y}, Vec2{layout_->GetThreadDependencyArrowBodyWidth(), arrow_body_height},
       Vec2{layout_->GetThreadDependencyArrowHeadWidth(),
            layout_->GetThreadDependencyArrowHeadHeight()},
-      IntrospectionWindow::kZValueOverlay, kArrowColor, arrow_direction);
+      GlCanvas::kZValueOverlay, kArrowColor, arrow_direction);
 }
 
 void TrackContainer::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -400,8 +400,9 @@ void TrackContainer::DrawThreadDependencyArrow(PrimitiveAssembler& primitive_ass
   }
 
   const Color kArrowColor(255, 255, 255, 255);
-  const float start_arrow_thread_state_half_height = end_arrow_track->GetThreadStateBarHeight() / 2;
-  const float end_arrow_thread_state_half_height = start_arrow_track->GetThreadStateBarHeight() / 2;
+  const float start_arrow_thread_state_half_height =
+      start_arrow_track->GetThreadStateBarHeight() / 2;
+  const float end_arrow_thread_state_half_height = end_arrow_track->GetThreadStateBarHeight() / 2;
   float x = timeline_info_->GetWorldFromTick(thread_state_slice->begin_timestamp_ns());
   float start_arrow_y =
       start_arrow_track->GetThreadStateBarPos()[1] + start_arrow_thread_state_half_height;

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -12,8 +12,6 @@
 #include <vector>
 
 #include "CaptureViewElement.h"
-#include "ClientData/CaptureData.h"
-#include "ClientData/TimerChain.h"
 #include "TimeGraphLayout.h"
 #include "Track.h"
 #include "TrackManager.h"
@@ -81,6 +79,7 @@ class TrackContainer final : public CaptureViewElement {
  private:
   void DrawOverlay(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                    PickingMode picking_mode);
+  void DrawThreadDependency(PrimitiveAssembler& primitive_assembler, PickingMode picking_mode);
   void DrawIteratorBox(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                        Vec2 pos, Vec2 size, const Color& color, const std::string& label,
                        const std::string& time, float text_box_y);
@@ -99,6 +98,8 @@ class TrackContainer final : public CaptureViewElement {
   const orbit_client_data::CaptureData* capture_data_ = nullptr;
 
   const TimelineInfoInterface* timeline_info_;
+
+  OrbitApp* app_ = nullptr;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/TrackContainer.h
@@ -79,7 +79,7 @@ class TrackContainer final : public CaptureViewElement {
  private:
   void DrawOverlay(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                    PickingMode picking_mode);
-  void DrawThreadDependency(PrimitiveAssembler& primitive_assembler, PickingMode picking_mode);
+  void DrawThreadDependencyArrow(PrimitiveAssembler& primitive_assembler, PickingMode picking_mode);
   void DrawIteratorBox(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                        Vec2 pos, Vec2 size, const Color& color, const std::string& label,
                        const std::string& time, float text_box_y);


### PR DESCRIPTION
Selecting a runnable thread state slice, draws an arrow between the beginning of the slice and the thread that caused that slice to become runnable. The arrow is only drawn if the information is available and the thread responsible for the wakeup is in the capture view window.

Bug: http://b/236945046

Screenshot: http://screenshot/8xXMxfrqrQFZ4TD.png