### PR TITLE
Fix `kNsinMs` in `SamplingWithFrameTrackInputWidgetBase`

### DIFF
--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
@@ -69,7 +69,7 @@ void SamplingWithFrameTrackInputWidgetBase::OnStartMsChanged(const QString& time
     return;
   }
   bool ok;
-  constexpr uint64_t kNsInMs = 1000;
+  constexpr uint64_t kNsInMs = 1'000'000;
   start_relative_time_ns_ = static_cast<uint64_t>(time_ms.toInt(&ok)) * kNsInMs;
   if (!ok) {
     start_relative_time_ns_ = std::numeric_limits<uint64_t>::max();

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -188,10 +188,10 @@ TEST_F(SamplingWithFrameTrackInputWidgetTest, OnStartMsChangedIsCorrect) {
   ExpectRelativeStartNsIs(0);
 
   start_ms_->setText("123");
-  ExpectRelativeStartNsIs(123000);
+  ExpectRelativeStartNsIs(123'000'000);
 
   start_ms_->setText("0123");
-  ExpectRelativeStartNsIs(123000);
+  ExpectRelativeStartNsIs(123'000'000);
 
   start_ms_->setText("99999999999999999999999999");
   ExpectRelativeStartNsIs(static_cast<uint64_t>(std::numeric_limits<uint64_t>::max()));


### PR DESCRIPTION
There are 1e6 nanoseconds in a millisecond, not 1e3.

Test: Unit
Bug: http://b/238197925