### PR TITLE
Add ModuleInfo::object_segments

### DIFF
--- a/src/ClientData/ModuleDataTest.cpp
+++ b/src/ClientData/ModuleDataTest.cpp
@@ -57,50 +57,49 @@ TEST(ModuleData, Constructor) {
   EXPECT_TRUE(module.GetFunctions().empty());
 }
 
-TEST(ModuleData, ConvertFromVirtualAddressToOffsetInFileAndViceVersa) {
-  {  // ELF file.
-    ModuleInfo::ObjectSegment object_segment;
-    object_segment.set_offset_in_file(0x1000);
-    object_segment.set_size_in_file(0x2FFF);
-    object_segment.set_address(0x101000);
-    object_segment.set_size_in_memory(0x3000);
+TEST(ModuleData, ConvertFromVirtualAddressToOffsetInFileAndViceVersaElf) {
+  ModuleInfo::ObjectSegment object_segment;
+  object_segment.set_offset_in_file(0x1000);
+  object_segment.set_size_in_file(0x2FFF);
+  object_segment.set_address(0x101000);
+  object_segment.set_size_in_memory(0x3000);
 
-    ModuleInfo module_info{};
-    module_info.set_load_bias(0x100000);
-    *module_info.add_object_segments() = object_segment;
-    module_info.set_object_file_type(ModuleInfo::kElfFile);
+  ModuleInfo module_info{};
+  module_info.set_load_bias(0x100000);
+  *module_info.add_object_segments() = object_segment;
+  module_info.set_object_file_type(ModuleInfo::kElfFile);
 
-    ModuleData module{module_info};
-    EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x101100), 0x1100);
-    EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x1100), 0x101100);
-  }
+  ModuleData module{module_info};
+  EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x101100), 0x1100);
+  EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x1100), 0x101100);
+}
 
-  {  // PE/COFF file.
-    ModuleInfo::ObjectSegment object_segment;
-    object_segment.set_offset_in_file(0x200);
-    object_segment.set_size_in_file(0x2FFF);
-    object_segment.set_address(0x101000);
-    object_segment.set_size_in_memory(0x3000);
+TEST(ModuleData, ConvertFromVirtualAddressToOffsetInFileAndViceVersaPe) {
+  ModuleInfo::ObjectSegment object_segment;
+  object_segment.set_offset_in_file(0x200);
+  object_segment.set_size_in_file(0x2FFF);
+  object_segment.set_address(0x101000);
+  object_segment.set_size_in_memory(0x3000);
 
-    ModuleInfo module_info{};
-    module_info.set_load_bias(0x100000);
-    *module_info.add_object_segments() = object_segment;
-    module_info.set_object_file_type(ModuleInfo::kCoffFile);
+  ModuleInfo module_info{};
+  module_info.set_load_bias(0x100000);
+  *module_info.add_object_segments() = object_segment;
+  module_info.set_object_file_type(ModuleInfo::kCoffFile);
 
-    ModuleData module{module_info};
-    EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x101100), 0x300);
-    EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x300), 0x101100);
-  }
+  ModuleData module{module_info};
+  EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x101100), 0x300);
+  EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x300), 0x101100);
+}
 
-  {  // PE/COFF file with no section information, fall back to ELF computation.
-    ModuleInfo module_info{};
-    module_info.set_load_bias(0x100000);
-    module_info.set_object_file_type(ModuleInfo::kCoffFile);
+TEST(ModuleData, ConvertFromVirtualAddressToOffsetInFileAndViceVersaPeNoSections) {
+  // PE/COFF file with no section information, fall back to ELF computation.
+  ModuleInfo module_info{};
+  module_info.set_load_bias(0x100000);
+  module_info.set_object_file_type(ModuleInfo::kCoffFile);
 
-    ModuleData module{module_info};
-    EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x100300), 0x300);
-    EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x300), 0x100300);
-  }
+  ModuleData module{module_info};
+  EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x100300), 0x300);
+  EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x300), 0x100300);
 }
 
 TEST(ModuleData, LoadSymbols) {

--- a/src/ClientData/ModuleDataTest.cpp
+++ b/src/ClientData/ModuleDataTest.cpp
@@ -24,6 +24,11 @@ TEST(ModuleData, Constructor) {
   uint64_t file_size = 1000;
   std::string build_id = "test build id";
   uint64_t load_bias = 4000;
+  ModuleInfo::ObjectSegment object_segment;
+  object_segment.set_offset_in_file(0x200);
+  object_segment.set_size_in_file(0x2FFF);
+  object_segment.set_address(0x1000);
+  object_segment.set_size_in_memory(0x3000);
   ModuleInfo::ObjectFileType object_file_type = ModuleInfo::kElfFile;
 
   ModuleInfo module_info{};
@@ -32,6 +37,7 @@ TEST(ModuleData, Constructor) {
   module_info.set_file_size(file_size);
   module_info.set_build_id(build_id);
   module_info.set_load_bias(load_bias);
+  *module_info.add_object_segments() = object_segment;
   module_info.set_object_file_type(object_file_type);
 
   ModuleData module{module_info};
@@ -42,8 +48,59 @@ TEST(ModuleData, Constructor) {
   EXPECT_EQ(module.build_id(), build_id);
   EXPECT_EQ(module.load_bias(), load_bias);
   EXPECT_EQ(module.object_file_type(), object_file_type);
+  ASSERT_EQ(module.GetObjectSegments().size(), 1);
+  EXPECT_EQ(module.GetObjectSegments()[0].offset_in_file(), object_segment.offset_in_file());
+  EXPECT_EQ(module.GetObjectSegments()[0].size_in_file(), object_segment.size_in_file());
+  EXPECT_EQ(module.GetObjectSegments()[0].address(), object_segment.address());
+  EXPECT_EQ(module.GetObjectSegments()[0].size_in_memory(), object_segment.size_in_memory());
   EXPECT_FALSE(module.is_loaded());
   EXPECT_TRUE(module.GetFunctions().empty());
+}
+
+TEST(ModuleData, ConvertFromVirtualAddressToOffsetInFileAndViceVersa) {
+  {  // ELF file.
+    ModuleInfo::ObjectSegment object_segment;
+    object_segment.set_offset_in_file(0x1000);
+    object_segment.set_size_in_file(0x2FFF);
+    object_segment.set_address(0x101000);
+    object_segment.set_size_in_memory(0x3000);
+
+    ModuleInfo module_info{};
+    module_info.set_load_bias(0x100000);
+    *module_info.add_object_segments() = object_segment;
+    module_info.set_object_file_type(ModuleInfo::kElfFile);
+
+    ModuleData module{module_info};
+    EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x101100), 0x1100);
+    EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x1100), 0x101100);
+  }
+
+  {  // PE/COFF file.
+    ModuleInfo::ObjectSegment object_segment;
+    object_segment.set_offset_in_file(0x200);
+    object_segment.set_size_in_file(0x2FFF);
+    object_segment.set_address(0x101000);
+    object_segment.set_size_in_memory(0x3000);
+
+    ModuleInfo module_info{};
+    module_info.set_load_bias(0x100000);
+    *module_info.add_object_segments() = object_segment;
+    module_info.set_object_file_type(ModuleInfo::kCoffFile);
+
+    ModuleData module{module_info};
+    EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x101100), 0x300);
+    EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x300), 0x101100);
+  }
+
+  {  // PE/COFF file with no section information, fall back to ELF computation.
+    ModuleInfo module_info{};
+    module_info.set_load_bias(0x100000);
+    module_info.set_object_file_type(ModuleInfo::kCoffFile);
+
+    ModuleData module{module_info};
+    EXPECT_EQ(module.ConvertFromVirtualAddressToOffsetInFile(0x100300), 0x300);
+    EXPECT_EQ(module.ConvertFromOffsetInFileToVirtualAddress(0x300), 0x100300);
+  }
 }
 
 TEST(ModuleData, LoadSymbols) {

--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -40,6 +40,10 @@ class ModuleData final {
     return module_info_.executable_segment_offset();
   }
   [[nodiscard]] uint64_t address_start() const { return module_info_.address_start(); }
+  [[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> GetObjectSegments() const;
+  [[nodiscard]] uint64_t ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_address) const;
+  [[nodiscard]] uint64_t ConvertFromOffsetInFileToVirtualAddress(uint64_t offset_in_file) const;
+
   [[nodiscard]] bool is_loaded() const;
   // Returns true of module was unloaded and false otherwise
   [[nodiscard]] bool UpdateIfChangedAndUnload(orbit_grpc_protos::ModuleInfo info);

--- a/src/CodeReport/SourceCodeReportTest.cpp
+++ b/src/CodeReport/SourceCodeReportTest.cpp
@@ -8,6 +8,7 @@
 #include "ClientData/PostProcessedSamplingData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "CodeReport/SourceCodeReport.h"
+#include "GrpcProtos/module.pb.h"
 #include "GrpcProtos/symbol.pb.h"
 #include "ObjectUtils/ObjectFile.h"
 
@@ -19,6 +20,8 @@ class MockElfFile : public orbit_object_utils::ElfFile {
   MOCK_METHOD(uint64_t, GetLoadBias, (), (const, override));
   MOCK_METHOD(uint64_t, GetExecutableSegmentOffset, (), (const, override));
   MOCK_METHOD(uint64_t, GetImageSize, (), (const, override));
+  MOCK_METHOD(const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment>&, GetObjectSegments,
+              (), (const, override));
 
   MOCK_METHOD(bool, HasDynsym, (), (const, override));
   MOCK_METHOD(bool, HasDebugInfo, (), (const, override));

--- a/src/GrpcProtos/module.proto
+++ b/src/GrpcProtos/module.proto
@@ -7,9 +7,10 @@ syntax = "proto3";
 package orbit_grpc_protos;
 
 message ModuleInfo {
+  // NextId: 12
+
   // General purpose name of the module, can be used as a pretty name in the UI.
   // If you need the ELF specific soname, use the field "soname" below.
-  // NextId: 11
   string name = 1;
   string file_path = 2;
   uint64 file_size = 3;
@@ -21,6 +22,14 @@ message ModuleInfo {
   uint64 load_bias = 7;
   uint64 executable_segment_offset = 8;
   string soname = 9;
+
+  message ObjectSegment {
+    uint64 offset_in_file = 1;
+    uint64 size_in_file = 2;
+    uint64 address = 3;
+    uint64 size_in_memory = 4;
+  }
+  repeated ObjectSegment object_segments = 11;
 
   enum ObjectFileType {
     kUnknown = 0;

--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -16,10 +16,10 @@
 #include "absl/strings/ascii.h"
 
 using orbit_grpc_protos::SymbolInfo;
-using orbit_object_utils::CoffFile;
-using orbit_object_utils::CreateCoffFile;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;
+
+namespace orbit_object_utils {
 
 TEST(CoffFile, LoadDebugSymbols) {
   std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libtest.dll";
@@ -154,3 +154,54 @@ TEST(CoffFile, GetLoadBiasAndExecutableSegmentOffsetAndImageSize) {
     EXPECT_EQ(coff_file.GetImageSize(), 0x20000);
   }
 }
+
+TEST(CoffFile, ObjectSegments) {
+  std::filesystem::path file_path = orbit_test::GetTestdataDir() / "dllmain.dll";
+  auto coff_file_or_error = CreateCoffFile(file_path);
+  ASSERT_THAT(coff_file_or_error, HasNoError());
+  const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment>& segments =
+      coff_file_or_error.value()->GetObjectSegments();
+  ASSERT_EQ(segments.size(), 8);
+
+  EXPECT_EQ(segments[0].offset_in_file(), 0x400);
+  EXPECT_EQ(segments[0].size_in_file(), 0xCEA00);
+  EXPECT_EQ(segments[0].address(), 0x180001000);
+  EXPECT_EQ(segments[0].size_in_memory(), 0xCE9E4);
+
+  EXPECT_EQ(segments[1].offset_in_file(), 0xCEE00);
+  EXPECT_EQ(segments[1].size_in_file(), 0x27A00);
+  EXPECT_EQ(segments[1].address(), 0x1800D0000);
+  EXPECT_EQ(segments[1].size_in_memory(), 0x2797D);
+
+  EXPECT_EQ(segments[2].offset_in_file(), 0xF6800);
+  EXPECT_EQ(segments[2].size_in_file(), 0x2800);
+  EXPECT_EQ(segments[2].address(), 0x1800F8000);
+  EXPECT_EQ(segments[2].size_in_memory(), 0x5269);
+
+  EXPECT_EQ(segments[3].offset_in_file(), 0xF9000);
+  EXPECT_EQ(segments[3].size_in_file(), 0x9000);
+  EXPECT_EQ(segments[3].address(), 0x1800FE000);
+  EXPECT_EQ(segments[3].size_in_memory(), 0x8F4C);
+
+  EXPECT_EQ(segments[4].offset_in_file(), 0x102000);
+  EXPECT_EQ(segments[4].size_in_file(), 0x1200);
+  EXPECT_EQ(segments[4].address(), 0x180107000);
+  EXPECT_EQ(segments[4].size_in_memory(), 0x1041);
+
+  EXPECT_EQ(segments[5].offset_in_file(), 0x103200);
+  EXPECT_EQ(segments[5].size_in_file(), 0x200);
+  EXPECT_EQ(segments[5].address(), 0x180109000);
+  EXPECT_EQ(segments[5].size_in_memory(), 0x151);
+
+  EXPECT_EQ(segments[6].offset_in_file(), 0x103400);
+  EXPECT_EQ(segments[6].size_in_file(), 0x400);
+  EXPECT_EQ(segments[6].address(), 0x18010A000);
+  EXPECT_EQ(segments[6].size_in_memory(), 0x222);
+
+  EXPECT_EQ(segments[7].offset_in_file(), 0x103800);
+  EXPECT_EQ(segments[7].size_in_file(), 0x1C00);
+  EXPECT_EQ(segments[7].address(), 0x18010B000);
+  EXPECT_EQ(segments[7].size_in_memory(), 0x1A78);
+}
+
+}  // namespace orbit_object_utils

--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -91,87 +91,83 @@ TEST(ElfFile, LoadSymbolsFromDynsym) {
 }
 
 TEST(ElfFile, LoadBiasAndExecutableSegmentOffsetAndImageSize) {
-  {
-    const std::filesystem::path test_elf_file_dynamic =
-        orbit_test::GetTestdataDir() / "hello_world_elf";
-    auto elf_file_dynamic = CreateElfFile(test_elf_file_dynamic);
-    ASSERT_THAT(elf_file_dynamic, HasNoError());
-    EXPECT_EQ(elf_file_dynamic.value()->GetLoadBias(), 0x0);
-    EXPECT_EQ(elf_file_dynamic.value()->GetExecutableSegmentOffset(), 0x1000);
-    EXPECT_EQ(elf_file_dynamic.value()->GetImageSize(), 0x4038);
-  }
+  const std::filesystem::path test_elf_file_dynamic =
+      orbit_test::GetTestdataDir() / "hello_world_elf";
+  auto elf_file_dynamic = CreateElfFile(test_elf_file_dynamic);
+  ASSERT_THAT(elf_file_dynamic, HasNoError());
+  EXPECT_EQ(elf_file_dynamic.value()->GetLoadBias(), 0x0);
+  EXPECT_EQ(elf_file_dynamic.value()->GetExecutableSegmentOffset(), 0x1000);
+  EXPECT_EQ(elf_file_dynamic.value()->GetImageSize(), 0x4038);
+}
 
-  {
-    const std::filesystem::path test_elf_file_static =
-        orbit_test::GetTestdataDir() / "hello_world_static_elf";
-    auto elf_file_static = CreateElfFile(test_elf_file_static);
-    ASSERT_THAT(elf_file_static, HasNoError());
-    EXPECT_EQ(elf_file_static.value()->GetLoadBias(), 0x400000);
-    EXPECT_EQ(elf_file_static.value()->GetExecutableSegmentOffset(), 0x1000);
-    EXPECT_EQ(elf_file_static.value()->GetImageSize(), 0xaaaa0);
-  }
+TEST(ElfFile, LoadBiasAndExecutableSegmentOffsetAndImageSizeStatic) {
+  const std::filesystem::path test_elf_file_static =
+      orbit_test::GetTestdataDir() / "hello_world_static_elf";
+  auto elf_file_static = CreateElfFile(test_elf_file_static);
+  ASSERT_THAT(elf_file_static, HasNoError());
+  EXPECT_EQ(elf_file_static.value()->GetLoadBias(), 0x400000);
+  EXPECT_EQ(elf_file_static.value()->GetExecutableSegmentOffset(), 0x1000);
+  EXPECT_EQ(elf_file_static.value()->GetImageSize(), 0xaaaa0);
 }
 
 TEST(ElfFile, ObjectSegments) {
-  {
-    const std::filesystem::path test_elf_file_dynamic =
-        orbit_test::GetTestdataDir() / "hello_world_elf";
-    auto elf_file_dynamic = CreateElfFile(test_elf_file_dynamic);
-    ASSERT_THAT(elf_file_dynamic, HasNoError());
-    const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> segments =
-        elf_file_dynamic.value()->GetObjectSegments();
-    ASSERT_EQ(segments.size(), 4);
+  const std::filesystem::path test_elf_file_dynamic =
+      orbit_test::GetTestdataDir() / "hello_world_elf";
+  auto elf_file_dynamic = CreateElfFile(test_elf_file_dynamic);
+  ASSERT_THAT(elf_file_dynamic, HasNoError());
+  const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> segments =
+      elf_file_dynamic.value()->GetObjectSegments();
+  ASSERT_EQ(segments.size(), 4);
 
-    EXPECT_EQ(segments[0].offset_in_file(), 0);
-    EXPECT_EQ(segments[0].size_in_file(), 0x568);
-    EXPECT_EQ(segments[0].address(), 0);
-    EXPECT_EQ(segments[0].size_in_memory(), 0x568);
+  EXPECT_EQ(segments[0].offset_in_file(), 0);
+  EXPECT_EQ(segments[0].size_in_file(), 0x568);
+  EXPECT_EQ(segments[0].address(), 0);
+  EXPECT_EQ(segments[0].size_in_memory(), 0x568);
 
-    EXPECT_EQ(segments[1].offset_in_file(), 0x1000);
-    EXPECT_EQ(segments[1].size_in_file(), 0x1cd);
-    EXPECT_EQ(segments[1].address(), 0x1000);
-    EXPECT_EQ(segments[1].size_in_memory(), 0x1cd);
+  EXPECT_EQ(segments[1].offset_in_file(), 0x1000);
+  EXPECT_EQ(segments[1].size_in_file(), 0x1cd);
+  EXPECT_EQ(segments[1].address(), 0x1000);
+  EXPECT_EQ(segments[1].size_in_memory(), 0x1cd);
 
-    EXPECT_EQ(segments[2].offset_in_file(), 0x2000);
-    EXPECT_EQ(segments[2].size_in_file(), 0x160);
-    EXPECT_EQ(segments[2].address(), 0x2000);
-    EXPECT_EQ(segments[2].size_in_memory(), 0x160);
+  EXPECT_EQ(segments[2].offset_in_file(), 0x2000);
+  EXPECT_EQ(segments[2].size_in_file(), 0x160);
+  EXPECT_EQ(segments[2].address(), 0x2000);
+  EXPECT_EQ(segments[2].size_in_memory(), 0x160);
 
-    EXPECT_EQ(segments[3].offset_in_file(), 0x2de8);
-    EXPECT_EQ(segments[3].size_in_file(), 0x248);
-    EXPECT_EQ(segments[3].address(), 0x3de8);
-    EXPECT_EQ(segments[3].size_in_memory(), 0x250);
-  }
+  EXPECT_EQ(segments[3].offset_in_file(), 0x2de8);
+  EXPECT_EQ(segments[3].size_in_file(), 0x248);
+  EXPECT_EQ(segments[3].address(), 0x3de8);
+  EXPECT_EQ(segments[3].size_in_memory(), 0x250);
+}
 
-  {
-    const std::filesystem::path test_elf_file_static =
-        orbit_test::GetTestdataDir() / "hello_world_static_elf";
-    auto elf_file_static = CreateElfFile(test_elf_file_static);
-    ASSERT_THAT(elf_file_static, HasNoError());
-    const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> segments =
-        elf_file_static.value()->GetObjectSegments();
-    ASSERT_EQ(segments.size(), 4);
+TEST(ElfFile, ObjectSegmentsStatic) {
+  const std::filesystem::path test_elf_file_static =
+      orbit_test::GetTestdataDir() / "hello_world_static_elf";
+  auto elf_file_static = CreateElfFile(test_elf_file_static);
+  ASSERT_THAT(elf_file_static, HasNoError());
+  const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> segments =
+      elf_file_static.value()->GetObjectSegments();
+  ASSERT_EQ(segments.size(), 4);
 
-    EXPECT_EQ(segments[0].offset_in_file(), 0);
-    EXPECT_EQ(segments[0].size_in_file(), 0x4a8);
-    EXPECT_EQ(segments[0].address(), 0x400000);
-    EXPECT_EQ(segments[0].size_in_memory(), 0x4a8);
+  EXPECT_EQ(segments[0].offset_in_file(), 0);
+  EXPECT_EQ(segments[0].size_in_file(), 0x4a8);
+  EXPECT_EQ(segments[0].address(), 0x400000);
+  EXPECT_EQ(segments[0].size_in_memory(), 0x4a8);
 
-    EXPECT_EQ(segments[1].offset_in_file(), 0x1000);
-    EXPECT_EQ(segments[1].size_in_file(), 0x7b4e1);
-    EXPECT_EQ(segments[1].address(), 0x401000);
-    EXPECT_EQ(segments[1].size_in_memory(), 0x7b4e1);
+  EXPECT_EQ(segments[1].offset_in_file(), 0x1000);
+  EXPECT_EQ(segments[1].size_in_file(), 0x7b4e1);
+  EXPECT_EQ(segments[1].address(), 0x401000);
+  EXPECT_EQ(segments[1].size_in_memory(), 0x7b4e1);
 
-    EXPECT_EQ(segments[2].offset_in_file(), 0x7d000);
-    EXPECT_EQ(segments[2].size_in_file(), 0x257f0);
-    EXPECT_EQ(segments[2].address(), 0x47d000);
-    EXPECT_EQ(segments[2].size_in_memory(), 0x257f0);
+  EXPECT_EQ(segments[2].offset_in_file(), 0x7d000);
+  EXPECT_EQ(segments[2].size_in_file(), 0x257f0);
+  EXPECT_EQ(segments[2].address(), 0x47d000);
+  EXPECT_EQ(segments[2].size_in_memory(), 0x257f0);
 
-    EXPECT_EQ(segments[3].offset_in_file(), 0xa3060);
-    EXPECT_EQ(segments[3].size_in_file(), 0x5270);
-    EXPECT_EQ(segments[3].address(), 0x4a4060);
-    EXPECT_EQ(segments[3].size_in_memory(), 0x6a40);
-  }
+  EXPECT_EQ(segments[3].offset_in_file(), 0xa3060);
+  EXPECT_EQ(segments[3].size_in_file(), 0x5270);
+  EXPECT_EQ(segments[3].address(), 0x4a4060);
+  EXPECT_EQ(segments[3].size_in_memory(), 0x6a40);
 }
 
 TEST(ElfFile, CalculateLoadBiasNoProgramHeaders) {

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -68,6 +68,10 @@ ErrorMessageOr<ModuleInfo> CreateModule(const std::filesystem::path& module_path
   module_info.set_build_id(object_file_or_error.value()->GetBuildId());
   module_info.set_executable_segment_offset(
       object_file_or_error.value()->GetExecutableSegmentOffset());
+  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment :
+       object_file_or_error.value()->GetObjectSegments()) {
+    *module_info.add_object_segments() = segment;
+  }
 
   if (object_file_or_error.value()->IsElf()) {
     auto* elf_file = dynamic_cast<ElfFile*>((object_file_or_error.value().get()));

--- a/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 
+#include "GrpcProtos/module.pb.h"
 #include "GrpcProtos/symbol.pb.h"
 #include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/Result.h"
@@ -57,6 +58,12 @@ class ObjectFile : public SymbolsFile {
   // As such, it includes possible gaps--in other words, it can be larger than the sum of the sizes
   // of all sections (for PEs) or loadable segments (for ELF files).
   [[nodiscard]] virtual uint64_t GetImageSize() const = 0;
+
+  // The memory segments in which the object file is loaded when creating the process image.
+  // For ELF files, this corresponds to the loadable segments from the program headers.
+  // For PEs, it corresponds to the sections from the section table.
+  [[nodiscard]] virtual const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment>&
+  GetObjectSegments() const = 0;
 
   [[nodiscard]] virtual bool IsElf() const = 0;
   [[nodiscard]] virtual bool IsCoff() const = 0;

--- a/src/WindowsProcessService/ProcessServiceImpl.cpp
+++ b/src/WindowsProcessService/ProcessServiceImpl.cpp
@@ -96,6 +96,9 @@ Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
     module_info->set_address_end(module.address_end);
     module_info->set_build_id(module.build_id);
     module_info->set_object_file_type(ModuleInfo::kCoffFile);
+    for (const ModuleInfo::ObjectSegment& section : module.sections) {
+      *module_info->add_object_segments() = section;
+    }
   }
 
   return Status::OK;

--- a/src/WindowsTracing/TracerImpl.cpp
+++ b/src/WindowsTracing/TracerImpl.cpp
@@ -63,6 +63,9 @@ void TracerImpl::SendModulesSnapshot() {
     module_info->set_address_end(module.address_end);
     module_info->set_build_id(module.build_id);
     module_info->set_object_file_type(ModuleInfo::kCoffFile);
+    for (const ModuleInfo::ObjectSegment& section : module.sections) {
+      *module_info->add_object_segments() = section;
+    }
   }
 
   listener_->OnModulesSnapshot(std::move(modules_snapshot));

--- a/src/WindowsUtils/include/WindowsUtils/ListModules.h
+++ b/src/WindowsUtils/include/WindowsUtils/ListModules.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include "GrpcProtos/module.pb.h"
+
 namespace orbit_windows_utils {
 
 struct Module {
@@ -17,6 +19,7 @@ struct Module {
   uint64_t address_start = 0;
   uint64_t address_end = 0;
   std::string build_id;
+  std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> sections;
 };
 
 // List all modules of the process identified by "pid".


### PR DESCRIPTION
And add `ModuleData::ConvertFromVirtualAddressToOffsetInFile` and
`ConvertFromOffsetInFileToVirtualAddress`, that use it for PEs. These will be
used in one of the next changes.

All of this is necessary because the conversion between address and offset in
PEs cannot simply use the load bias but needs to find the containing section.

Bug: http://b/235824531

Test: Add unit tests.