### PR TITLE
Fix UserSpaceInstrumentationOnSilenus test

### DIFF
--- a/contrib/automation_tests/orbit_user_space_instrumentation_silenus.py
+++ b/contrib/automation_tests/orbit_user_space_instrumentation_silenus.py
@@ -34,7 +34,7 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="triangle.exe"),
         WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
-        FilterAndHookFunction(function_search_string="Render"),
+        FilterAndHookFunction(function_search_string="Render{ }triangle.exe"),
         Capture(user_space_instrumentation=True),
         CheckTimers(track_name_filter="triangle.exe", require_all=False),
         VerifyScopeTypeAndHitCount(scope_name="Render",


### PR DESCRIPTION
With auto symbol loading, many functions match "Render", so specify the module
name as well.

Bug: http://b/238373628

Test: Ran locally.