### PR TITLE
Use `orbit_base::sort` in `SamplingDataPostProcessorTest`

### DIFF
--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -134,8 +134,9 @@ MATCHER_P(SortedCallstackReportEq, that, "") {
   orbit_base::sort(rhs_resorted_callstacks_counts.begin(), rhs_resorted_callstacks_counts.end(),
                    callstack_count_projector, std::greater<>{});
 
-  auto callstack_count_equal = [](const CallstackCount& lhs, const CallstackCount& rhs) {
-    return lhs.count == rhs.count && lhs.callstack_id == rhs.callstack_id;
+  auto callstack_count_equal = [&callstack_count_projector](const CallstackCount& lhs,
+                                                            const CallstackCount& rhs) {
+    return callstack_count_projector(lhs) == callstack_count_projector(rhs);
   };
 
   return lhs.total_callstack_count == rhs.total_callstack_count &&

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -128,11 +128,11 @@ MATCHER_P(SortedCallstackReportEq, that, "") {
 
   std::vector<CallstackCount> lhs_resorted_callstacks_counts = lhs.callstack_counts;
   orbit_base::sort(lhs_resorted_callstacks_counts.begin(), lhs_resorted_callstacks_counts.end(),
-                   callstack_count_projector);
+                   callstack_count_projector, std::greater<>{});
 
   std::vector<CallstackCount> rhs_resorted_callstacks_counts = rhs.callstack_counts;
   orbit_base::sort(rhs_resorted_callstacks_counts.begin(), rhs_resorted_callstacks_counts.end(),
-                   callstack_count_projector);
+                   callstack_count_projector, std::greater<>{});
 
   auto callstack_count_equal = [](const CallstackCount& lhs, const CallstackCount& rhs) {
     return lhs.count == rhs.count && lhs.callstack_id == rhs.callstack_id;

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -120,8 +120,8 @@ MATCHER_P(SortedCallstackReportEq, that, "") {
 
   // `SortedCallstackReport::callstacks_counts` is sorted only by `CallstackCount::count` (in
   // descending order), hence the order is not unique. Sort again considering
-  // `CallstackCount::callstack_id`, too, to facilitate the comparison of `SortedCallstackReport`s
-  // for equality.
+  // `CallstackCount::callstack_id`, too  (also descending, it doesn't matter which way), to
+  // facilitate the comparison of `SortedCallstackReport`s for equality.
   auto callstack_count_projector = [](const CallstackCount& callstack_count) {
     return std::make_pair(callstack_count.count, callstack_count.callstack_id);
   };


### PR DESCRIPTION
Test: Unit, Compile
Bug: http://b/238845466