### PR TITLE
Use 'orbit_base::sort' to sort `Instance`s

### DIFF
--- a/src/OrbitGgp/Instance.cpp
+++ b/src/OrbitGgp/Instance.cpp
@@ -82,6 +82,4 @@ ErrorMessageOr<Instance> Instance::CreateFromJson(const QByteArray& json) {
   return GetInstanceFromJson(doc.object());
 }
 
-bool Instance::CmpById(const Instance& lhs, const Instance& rhs) { return lhs.id < rhs.id; }
-
 }  // namespace orbit_ggp

--- a/src/OrbitGgp/InstanceItemModel.cpp
+++ b/src/OrbitGgp/InstanceItemModel.cpp
@@ -12,13 +12,14 @@
 #include <utility>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Sort.h"
 #include "OrbitGgp/Instance.h"
 
 namespace orbit_ggp {
 
 InstanceItemModel::InstanceItemModel(QVector<Instance> instances, QObject* parent)
     : QAbstractItemModel(parent), instances_(std::move(instances)) {
-  std::sort(instances_.begin(), instances_.end(), &Instance::CmpById);
+  orbit_base::sort(instances_.begin(), instances_.end(), &Instance::id);
 }
 
 int InstanceItemModel::columnCount(const QModelIndex& parent) const {
@@ -106,7 +107,7 @@ int InstanceItemModel::rowCount(const QModelIndex& parent) const {
 }
 
 void InstanceItemModel::SetInstances(QVector<Instance> new_instances) {
-  std::sort(new_instances.begin(), new_instances.end(), &Instance::CmpById);
+  orbit_base::sort(new_instances.begin(), new_instances.end(), &Instance::id);
 
   QVector<Instance>& old_instances(instances_);
 

--- a/src/OrbitGgp/InstanceTests.cpp
+++ b/src/OrbitGgp/InstanceTests.cpp
@@ -162,29 +162,6 @@ TEST(InstanceTests, CreateFromJson) {
   }
 }
 
-TEST(InstanceTests, CmpById) {
-  Instance test_instance_0;
-  Instance test_instance_1;
-
-  // Empty id
-  EXPECT_FALSE(Instance::CmpById(test_instance_0, test_instance_1));
-
-  // Same id
-  test_instance_0.id = QString{"id"};
-  test_instance_1.id = QString{"id"};
-  EXPECT_FALSE(Instance::CmpById(test_instance_0, test_instance_1));
-
-  // first < second
-  test_instance_0.id = QString{"id a"};
-  test_instance_1.id = QString{"id b"};
-  EXPECT_TRUE(Instance::CmpById(test_instance_0, test_instance_1));
-
-  // first > second
-  test_instance_0.id = QString{"id b"};
-  test_instance_1.id = QString{"id a"};
-  EXPECT_FALSE(Instance::CmpById(test_instance_0, test_instance_1));
-}
-
 TEST(InstanceTests, EqualToOperator) {
   Instance test_instance_0;
   Instance test_instance_1;

--- a/src/OrbitGgp/include/OrbitGgp/Instance.h
+++ b/src/OrbitGgp/include/OrbitGgp/Instance.h
@@ -27,7 +27,6 @@ struct Instance {
 
   static ErrorMessageOr<QVector<Instance>> GetListFromJson(const QByteArray& json);
   static ErrorMessageOr<Instance> CreateFromJson(const QByteArray& json);
-  static bool CmpById(const Instance& lhs, const Instance& rhs);
 
   friend bool operator==(const Instance& lhs, const Instance& rhs) {
     return std::tie(lhs.display_name, lhs.id, lhs.ip_address, lhs.last_updated, lhs.owner, lhs.pool,


### PR DESCRIPTION
This has made the method `Instance::CmdById` redundant. It's
removed.

Test: Unit, Compile
Bug: http://b/238845466