### PR TITLE
Use `orbit_base::sort` to sort `Process`- and `ThreadStats`

### DIFF
--- a/src/OrbitGl/SchedulingStats.cpp
+++ b/src/OrbitGl/SchedulingStats.cpp
@@ -8,6 +8,7 @@
 
 #include "CaptureWindow.h"
 #include "ClientProtos/capture_data.pb.h"
+#include "OrbitBase/Sort.h"
 
 using orbit_client_protos::TimerInfo;
 
@@ -47,13 +48,15 @@ SchedulingStats::SchedulingStats(const std::vector<const TimerInfo*>& scheduling
   }
 
   // Sort process stats by time on core.
-  std::sort(process_stats_sorted_by_time_on_core_.begin(),
-            process_stats_sorted_by_time_on_core_.end(), ProcessStatsTimeSorter());
+  orbit_base::sort(process_stats_sorted_by_time_on_core_.begin(),
+                   process_stats_sorted_by_time_on_core_.end(), &ProcessStats::time_on_core_ns,
+                   std::greater<>{});
 
   // Sort thread stats by time on core.
   for (ProcessStats* process_stats : process_stats_sorted_by_time_on_core_) {
-    std::sort(process_stats->thread_stats_sorted_by_time_on_core.begin(),
-              process_stats->thread_stats_sorted_by_time_on_core.end(), ThreadStatsTimeSorter());
+    orbit_base::sort(process_stats->thread_stats_sorted_by_time_on_core.begin(),
+                     process_stats->thread_stats_sorted_by_time_on_core.end(),
+                     &ThreadStats::time_on_core_ns, std::greater<>{});
   }
 }
 

--- a/src/OrbitGl/SchedulingStats.h
+++ b/src/OrbitGl/SchedulingStats.h
@@ -45,18 +45,6 @@ class SchedulingStats {
     std::string process_name;
   };
 
-  struct ProcessStatsTimeSorter {
-    bool operator()(const ProcessStats* a, const ProcessStats* b) const {
-      return a->time_on_core_ns > b->time_on_core_ns;
-    }
-  };
-
-  struct ThreadStatsTimeSorter {
-    bool operator()(const ThreadStats* a, const ThreadStats* b) const {
-      return a->time_on_core_ns > b->time_on_core_ns;
-    }
-  };
-
   double GetTimeRangeMs() const { return time_range_ms_; }
   uint64_t GetTimeOnCoreNs() const { return time_on_core_ns_; }
   const std::map<int32_t, uint64_t>& GetTimeOnCoreNsByCore() const {


### PR DESCRIPTION
This has also allowed to remove two corresponding functors.

Test: Unit, Compile
Bug: http://b/238845466