### PR TITLE
Remove KInvalidScopeId

### DIFF
--- a/src/ClientData/CaptureDataTest.cpp
+++ b/src/ClientData/CaptureDataTest.cpp
@@ -37,6 +37,7 @@ constexpr size_t kTimersForSecondId = 2;
 constexpr size_t kTimerCount = kTimersForFirstId + kTimersForSecondId;
 constexpr ScopeId kFirstId{1};
 constexpr ScopeId kSecondId{2};
+constexpr ScopeId kUnobservedId{123};
 const std::string kFirstName = "foo()";
 const std::string kSecondName = "bar()";
 constexpr std::array<ScopeId, kTimerCount> kTimerIds = {kFirstId, kFirstId, kFirstId, kSecondId,
@@ -248,7 +249,7 @@ TEST_F(CaptureDataTest, UpdateTimerDurationsIsCorrect) {
   EXPECT_EQ(*durations_second, std::vector(std::begin(kSortedDurationsForSecondId),
                                            std::end(kSortedDurationsForSecondId)));
 
-  EXPECT_THAT(capture_data_.GetSortedTimerDurationsForScopeId(kInvalidScopeId), testing::IsNull());
+  EXPECT_THAT(capture_data_.GetSortedTimerDurationsForScopeId(kUnobservedId), testing::IsNull());
 }
 
 TEST_F(CaptureDataTest, FindThreadStateSliceInfoFromTimestamp) {

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -39,7 +39,7 @@ void DataManager::set_visible_scope_ids(absl::flat_hash_set<ScopeId> visible_sco
   visible_scope_ids_ = std::move(visible_scope_ids);
 }
 
-void DataManager::set_highlighted_scope_id(ScopeId highlighted_scope_id) {
+void DataManager::set_highlighted_scope_id(std::optional<ScopeId> highlighted_scope_id) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   highlighted_scope_id_ = highlighted_scope_id;
 }
@@ -86,7 +86,7 @@ bool DataManager::IsScopeVisible(ScopeId scope_id) const {
   return visible_scope_ids_.contains(scope_id);
 }
 
-ScopeId DataManager::highlighted_scope_id() const {
+std::optional<ScopeId> DataManager::highlighted_scope_id() const {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return highlighted_scope_id_;
 }

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -46,7 +47,9 @@ std::unique_ptr<NameEqualityScopeIdProvider> NameEqualityScopeIdProvider::Create
       max_id + 1, std::move(scope_info_to_id), std::move(scope_id_to_info)));
 }
 
-ScopeId NameEqualityScopeIdProvider::FunctionIdToScopeId(uint64_t function_id) const {
+std::optional<ScopeId> NameEqualityScopeIdProvider::FunctionIdToScopeId(
+    uint64_t function_id) const {
+  if (function_id == orbit_grpc_protos::kInvalidFunctionId) return std::nullopt;
   return ScopeId(function_id);
 }
 
@@ -65,10 +68,10 @@ ScopeId NameEqualityScopeIdProvider::FunctionIdToScopeId(uint64_t function_id) c
   }
 }
 
-ScopeId NameEqualityScopeIdProvider::ProvideId(const TimerInfo& timer_info) {
+std::optional<ScopeId> NameEqualityScopeIdProvider::ProvideId(const TimerInfo& timer_info) {
   const ScopeType scope_type = ScopeTypeFromTimerInfo(timer_info);
 
-  if (scope_type == ScopeType::kInvalid) return orbit_client_data::kInvalidScopeId;
+  if (scope_type == ScopeType::kInvalid) return std::nullopt;
 
   if (scope_type == ScopeType::kDynamicallyInstrumentedFunction) {
     return FunctionIdToScopeId(timer_info.function_id());

--- a/src/ClientData/ScopeIdProviderTest.cpp
+++ b/src/ClientData/ScopeIdProviderTest.cpp
@@ -4,6 +4,7 @@
 
 #include <absl/container/flat_hash_set.h>
 #include <absl/flags/flag.h>
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -58,8 +59,9 @@ static void AssertNameToIdIsBijective(const std::vector<orbit_client_protos::Tim
 static std::vector<ScopeId> GetIds(ScopeIdProvider* id_provider,
                                    const std::vector<orbit_client_protos::TimerInfo>& timers) {
   std::vector<ScopeId> ids;
-  std::transform(std::begin(timers), std::end(timers), std::back_inserter(ids),
-                 [id_provider](const TimerInfo& timer) { return id_provider->ProvideId(timer); });
+  std::transform(
+      std::begin(timers), std::end(timers), std::back_inserter(ids),
+      [id_provider](const TimerInfo& timer) { return id_provider->ProvideId(timer).value(); });
   return ids;
 }
 
@@ -72,6 +74,21 @@ static void TestProvideId(std::vector<orbit_client_protos::TimerInfo>& timer_inf
   for (size_t i = 0; i < timer_infos.size(); ++i) {
     EXPECT_EQ(id_provider->GetScopeInfo(ids[i]).GetName(), timer_infos[i].api_scope_name());
   }
+}
+
+TEST(NameEqualityScopeIdProviderTest, FunctionIdToScopeIdReturnsNullOptForInvalidFunctionId) {
+  auto id_provider = NameEqualityScopeIdProvider::Create(orbit_grpc_protos::CaptureOptions{});
+  const std::optional<ScopeId> scope_id =
+      id_provider->FunctionIdToScopeId(orbit_grpc_protos::kInvalidFunctionId);
+  EXPECT_TRUE(!scope_id.has_value());
+}
+
+TEST(NameEqualityScopeIdProviderTest, ProvideIdReturnsNullOptForTimeOfInvalidType) {
+  auto id_provider = NameEqualityScopeIdProvider::Create(orbit_grpc_protos::CaptureOptions{});
+  const TimerInfo timer = MakeTimerInfo("invalid", TimerInfo::kCoreActivity);
+
+  const std::optional<ScopeId> scope_id = id_provider->ProvideId(timer);
+  EXPECT_TRUE(!scope_id.has_value());
 }
 
 TEST(NameEqualityScopeIdProviderTest, ProvideIdIsCorrectForApiScope) {
@@ -115,7 +132,7 @@ TEST(NameEqualityScopeIdProviderTest, CreateIsCorrect) {
   auto id_provider = NameEqualityScopeIdProvider::Create(capture_options);
   TimerInfo timer_info = MakeTimerInfo("A", TimerInfo::kApiScope);
 
-  ASSERT_EQ(*id_provider->ProvideId(timer_info),
+  ASSERT_EQ(*id_provider->ProvideId(timer_info).value(),
             *std::max_element(std::begin(kFunctionIds), std::end(kFunctionIds)) + 1);
 
   for (size_t i = 0; i < kFunctionCount; ++i) {

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -239,10 +239,11 @@ class CaptureData {
     return thread_track_data_provider_.get();
   }
 
-  [[nodiscard]] ScopeId ProvideScopeId(const orbit_client_protos::TimerInfo& timer_info) const;
+  [[nodiscard]] std::optional<ScopeId> ProvideScopeId(
+      const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::vector<ScopeId> GetAllProvidedScopeIds() const;
   [[nodiscard]] const ScopeInfo& GetScopeInfo(ScopeId scope_id) const;
-  [[nodiscard]] ScopeId FunctionIdToScopeId(uint64_t function_id) const;
+  [[nodiscard]] std::optional<ScopeId> FunctionIdToScopeId(uint64_t function_id) const;
   [[nodiscard]] uint64_t ScopeIdToFunctionId(ScopeId scope_id) const;
 
   [[nodiscard]] const std::vector<uint64_t>* GetSortedTimerDurationsForScopeId(

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -38,7 +38,7 @@ class DataManager final {
   void DeselectFunction(const FunctionInfo& function);
   void ClearSelectedFunctions();
   void set_visible_scope_ids(absl::flat_hash_set<ScopeId> visible_scope_ids);
-  void set_highlighted_scope_id(ScopeId highlighted_function_id);
+  void set_highlighted_scope_id(std::optional<ScopeId> highlighted_function_id);
   void set_highlighted_group_id(uint64_t highlighted_group_id);
   void set_selected_thread_id(uint32_t thread_id);
   void set_selected_thread_state_slice(
@@ -50,7 +50,7 @@ class DataManager final {
   [[nodiscard]] bool IsFunctionSelected(const FunctionInfo& function) const;
   [[nodiscard]] std::vector<FunctionInfo> GetSelectedFunctions() const;
   [[nodiscard]] bool IsScopeVisible(ScopeId scope_id) const;
-  [[nodiscard]] ScopeId highlighted_scope_id() const;
+  [[nodiscard]] std::optional<ScopeId> highlighted_scope_id() const;
   [[nodiscard]] uint64_t highlighted_group_id() const;
   [[nodiscard]] uint32_t selected_thread_id() const;
   [[nodiscard]] std::optional<ThreadStateSliceInfo> selected_thread_state_slice() const;
@@ -119,7 +119,7 @@ class DataManager final {
   const std::thread::id main_thread_id_;
   absl::flat_hash_set<FunctionInfo> selected_functions_;
   absl::flat_hash_set<ScopeId> visible_scope_ids_;
-  ScopeId highlighted_scope_id_ = kInvalidScopeId;
+  std::optional<ScopeId> highlighted_scope_id_ = std::nullopt;
   uint64_t highlighted_group_id_ = kOrbitDefaultGroupId;
 
   TracepointInfoSet selected_tracepoints_;

--- a/src/ClientData/include/ClientData/ScopeId.h
+++ b/src/ClientData/include/ClientData/ScopeId.h
@@ -19,10 +19,6 @@ using ScopeId = orbit_base::Typedef<ScopeIdTag, const uint64_t>;
 
 static_assert(orbit_base::kHasZeroMemoryOverheadV<ScopeId>);
 
-// We use this constant to identify scopes where we don't have a corresponding Id (see
-// ScopeIdProvider).
-constexpr ScopeId kInvalidScopeId{0};
-
 }  // namespace orbit_client_data
 
 #endif  // ORBIT_CLIENT_DATA_API_SCOPE_ID_H_

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <cstdint>
+#include <optional>
 
 #include "ClientData/ScopeId.h"
 #include "ClientData/ScopeInfo.h"
@@ -22,10 +23,10 @@ class ScopeIdProvider {
  public:
   virtual ~ScopeIdProvider() = default;
 
-  [[nodiscard]] virtual ScopeId FunctionIdToScopeId(uint64_t function_id) const = 0;
+  [[nodiscard]] virtual std::optional<ScopeId> FunctionIdToScopeId(uint64_t function_id) const = 0;
   [[nodiscard]] virtual uint64_t ScopeIdToFunctionId(ScopeId scope_id) const = 0;
 
-  [[nodiscard]] virtual ScopeId ProvideId(const TimerInfo& timer_info) = 0;
+  [[nodiscard]] virtual std::optional<ScopeId> ProvideId(const TimerInfo& timer_info) = 0;
 
   [[nodiscard]] virtual std::vector<ScopeId> GetAllProvidedScopeIds() const = 0;
 
@@ -43,10 +44,10 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   [[nodiscard]] static std::unique_ptr<NameEqualityScopeIdProvider> Create(
       const ::orbit_grpc_protos::CaptureOptions& capture_options);
 
-  [[nodiscard]] ScopeId FunctionIdToScopeId(uint64_t function_id) const override;
+  [[nodiscard]] std::optional<ScopeId> FunctionIdToScopeId(uint64_t function_id) const override;
   [[nodiscard]] uint64_t ScopeIdToFunctionId(ScopeId scope_id) const override;
 
-  [[nodiscard]] ScopeId ProvideId(const TimerInfo& timer_info) override;
+  [[nodiscard]] std::optional<ScopeId> ProvideId(const TimerInfo& timer_info) override;
 
   [[nodiscard]] std::vector<ScopeId> GetAllProvidedScopeIds() const override;
 

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -729,27 +729,33 @@ TEST_F(LiveFunctionsDataViewTest, UpdateHighlightedFunctionsOnSelect) {
 
   // Single selection will hightlight the selected function
   {
-    EXPECT_CALL(app_, SetHighlightedScopeId).Times(1).WillOnce([&](ScopeId highlighted_scope_id) {
-      EXPECT_EQ(highlighted_scope_id, kScopeIds[2]);
-    });
+    EXPECT_CALL(app_, SetHighlightedScopeId)
+        .Times(1)
+        .WillOnce([&](std::optional<ScopeId> highlighted_scope_id) {
+          EXPECT_EQ(highlighted_scope_id, kScopeIds[2]);
+        });
 
     view_.OnSelect({2});
   }
 
   // Multiple selection will hightlight the first selected function
   {
-    EXPECT_CALL(app_, SetHighlightedScopeId).Times(1).WillOnce([&](ScopeId highlighted_scope_id) {
-      EXPECT_EQ(highlighted_scope_id, kScopeIds[1]);
-    });
+    EXPECT_CALL(app_, SetHighlightedScopeId)
+        .Times(1)
+        .WillOnce([&](std::optional<ScopeId> highlighted_scope_id) {
+          EXPECT_EQ(highlighted_scope_id, kScopeIds[1]);
+        });
 
     view_.OnSelect({1, 2});
   }
 
   // Empty selection will clear the function highlighting
   {
-    EXPECT_CALL(app_, SetHighlightedScopeId).Times(1).WillOnce([&](ScopeId highlighted_scope_id) {
-      EXPECT_EQ(highlighted_scope_id, orbit_client_data::kInvalidScopeId);
-    });
+    EXPECT_CALL(app_, SetHighlightedScopeId)
+        .Times(1)
+        .WillOnce([&](std::optional<ScopeId> highlighted_scope_id) {
+          EXPECT_EQ(highlighted_scope_id, std::nullopt);
+        });
 
     view_.OnSelect({});
   }
@@ -847,13 +853,15 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
 }
 
 TEST_F(LiveFunctionsDataViewTest, OnDataChangeResetsHistogram) {
-  EXPECT_CALL(app_, ShowHistogram(nullptr, "", orbit_client_data::kInvalidScopeId)).Times(1);
+  std::optional<ScopeId> nullopt = std::nullopt;
+  EXPECT_CALL(app_, ShowHistogram(nullptr, "", nullopt)).Times(1);
 
   view_.OnDataChanged();
 }
 
 TEST_F(LiveFunctionsDataViewTest, OnRefreshWithNoIndicesResetsHistogram) {
-  EXPECT_CALL(app_, ShowHistogram(nullptr, "", orbit_client_data::kInvalidScopeId)).Times(2);
+  std::optional<ScopeId> nullopt = std::nullopt;
+  EXPECT_CALL(app_, ShowHistogram(nullptr, "", nullopt)).Times(2);
 
   view_.OnRefresh({}, RefreshMode::kOnFilter);
   view_.OnRefresh({}, RefreshMode::kOther);
@@ -870,7 +878,8 @@ TEST_F(LiveFunctionsDataViewTest, HistogramIsProperlyUpdated) {
   view_.OnDataChanged();
   AddFunctionsByIndices({0});
 
-  EXPECT_CALL(app_, ShowHistogram(testing::Pointee(kDurations), kPrettyNames[0], kScopeIds[0]))
+  EXPECT_CALL(app_, ShowHistogram(testing::Pointee(kDurations), kPrettyNames[0],
+                                  std::optional<ScopeId>(kScopeIds[0])))
       .Times(3);
 
   view_.OnRefresh({0}, RefreshMode::kOnFilter);
@@ -880,7 +889,8 @@ TEST_F(LiveFunctionsDataViewTest, HistogramIsProperlyUpdated) {
 
 TEST_F(LiveFunctionsDataViewTest,
        RemoveHistogramWhenUpdatedWithIdOfNonDynamicallyInstrumentedFunction) {
-  EXPECT_CALL(app_, ShowHistogram(nullptr, "", orbit_client_data::kInvalidScopeId)).Times(1);
+  std::optional<ScopeId> nullopt = std::nullopt;
+  EXPECT_CALL(app_, ShowHistogram(nullptr, "", nullopt)).Times(1);
 
   view_.UpdateHistogramWithScopeIds({kNonDynamicallyInstrumentedFunctionId});
 }

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -46,8 +46,9 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(bool, IsFunctionSelected, (const orbit_client_data::SampledFunction&),
               (const, override));
 
-  MOCK_METHOD(ScopeId, GetHighlightedScopeId, (), (const, override));
-  MOCK_METHOD(void, SetHighlightedScopeId, (ScopeId highlighted_scope_id), (override));
+  MOCK_METHOD(std::optional<ScopeId>, GetHighlightedScopeId, (), (const, override));
+  MOCK_METHOD(void, SetHighlightedScopeId, (std::optional<ScopeId> highlighted_scope_id),
+              (override));
   MOCK_METHOD(void, SetVisibleScopeIds, (absl::flat_hash_set<ScopeId> visible_scopes), (override));
   MOCK_METHOD(void, DeselectTimer, (), (override));
   MOCK_METHOD(bool, IsCapturing, (), (const, override));
@@ -104,7 +105,7 @@ class MockAppInterface : public AppInterface {
 
   MOCK_METHOD(void, ShowHistogram,
               (const std::vector<uint64_t>* data, const std::string& function_name,
-               ScopeId scope_id),
+               std::optional<ScopeId> scope_id),
               (override));
 
   MOCK_METHOD(uint64_t, ProvideScopeId, (const orbit_client_protos::TimerInfo& timer_info),

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -55,8 +55,8 @@ class AppInterface : public orbit_client_data::CaptureDataHolder {
   // Functions needed by LiveFunctionsDataView
   enum class JumpToTimerMode { kFirst, kLast, kMin, kMax };
   virtual void JumpToTimerAndZoom(ScopeId scope_id, JumpToTimerMode selection_mode) = 0;
-  [[nodiscard]] virtual ScopeId GetHighlightedScopeId() const = 0;
-  virtual void SetHighlightedScopeId(ScopeId highlighted_scope_id) = 0;
+  [[nodiscard]] virtual std::optional<ScopeId> GetHighlightedScopeId() const = 0;
+  virtual void SetHighlightedScopeId(std::optional<ScopeId> highlighted_scope_id) = 0;
   virtual void SetVisibleScopeIds(absl::flat_hash_set<ScopeId> visible_scope_ids) = 0;
   virtual void DeselectTimer() = 0;
   [[nodiscard]] virtual bool IsCapturing() const = 0;
@@ -112,7 +112,7 @@ class AppInterface : public orbit_client_data::CaptureDataHolder {
   virtual void ShowSourceCode(const orbit_client_data::FunctionInfo& function) = 0;
 
   virtual void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
-                             ScopeId scope_id) = 0;
+                             std::optional<ScopeId> scope_id) = 0;
 
   [[nodiscard]] virtual const orbit_statistics::BinomialConfidenceIntervalEstimator&
   GetConfidenceIntervalEstimator() const = 0;

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -76,7 +76,7 @@ class LiveFunctionsDataView : public DataView {
   // load/finalization this may be optimized via populating it function-wise on user's demand
 
   LiveFunctionsInterface* live_functions_;
-  ScopeId selected_scope_id_;
+  std::optional<ScopeId> selected_scope_id_;
 
   enum ColumnIndex {
     kColumnType,

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -50,10 +50,11 @@ void MizarData::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& captur
 }
 
 void MizarData::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
-  const ScopeId scope_id = GetCaptureData().ProvideScopeId(timer_info);
-  if (scope_id == orbit_client_data::kInvalidScopeId) return;
+  const std::optional<ScopeId> scope_id = GetCaptureData().ProvideScopeId(timer_info);
+  if (!scope_id.has_value()) return;
 
-  const orbit_client_data::ScopeType scope_type = GetCaptureData().GetScopeInfo(scope_id).GetType();
+  const orbit_client_data::ScopeType scope_type =
+      GetCaptureData().GetScopeInfo(scope_id.value()).GetType();
   if (scope_type == orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction ||
       scope_type == orbit_client_data::ScopeType::kApiScope) {
     GetMutableCaptureData().GetThreadTrackDataProvider()->AddTimer(timer_info);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -465,8 +465,8 @@ class OrbitApp final : public DataViewFactory,
   void SetVisibleScopeIds(absl::flat_hash_set<ScopeId> visible_scope_ids) override;
   [[nodiscard]] bool IsScopeVisible(ScopeId scope_id) const;
 
-  [[nodiscard]] ScopeId GetHighlightedScopeId() const override;
-  void SetHighlightedScopeId(ScopeId highlighted_scope_id) override;
+  [[nodiscard]] std::optional<ScopeId> GetHighlightedScopeId() const override;
+  void SetHighlightedScopeId(std::optional<ScopeId> highlighted_scope_id) override;
 
   [[nodiscard]] orbit_client_data::ThreadID selected_thread_id() const;
   void set_selected_thread_id(orbit_client_data::ThreadID thread_id);
@@ -485,7 +485,7 @@ class OrbitApp final : public DataViewFactory,
   void SelectTimer(const orbit_client_protos::TimerInfo* timer_info);
   void DeselectTimer() override;
 
-  [[nodiscard]] ScopeId GetScopeIdToHighlight() const;
+  [[nodiscard]] std::optional<ScopeId> GetScopeIdToHighlight() const;
   [[nodiscard]] uint64_t GetGroupIdToHighlight() const;
 
   // origin_is_multiple_threads defines if the selection is specific to a single thread,
@@ -603,7 +603,7 @@ class OrbitApp final : public DataViewFactory,
   void CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& timer);
 
   void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
-                     ScopeId scope_id) override;
+                     std::optional<ScopeId> scope_id) override;
 
   void RequestSymbolDownloadStop(absl::Span<const orbit_client_data::ModuleData* const> modules,
                                  bool show_dialog);

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -216,11 +216,11 @@ void LiveFunctionsController::AddIterator(ScopeId instrumented_function_scope_id
                                           const FunctionInfo* function) {
   uint64_t iterator_id = next_iterator_id_++;
   const orbit_client_protos::TimerInfo* timer_info = app_->selected_timer();
+  const std::optional<ScopeId> scope_id = FunctionIdToScopeId(timer_info->function_id());
   // If no box is currently selected or the selected box is a different
   // function, we search for the closest box to the current center of the
   // screen.
-  if (!timer_info ||
-      FunctionIdToScopeId(timer_info->function_id()) != instrumented_function_scope_id) {
+  if (!timer_info || scope_id != instrumented_function_scope_id) {
     timer_info = SnapToClosestStart(app_->GetMutableTimeGraph(), instrumented_function_scope_id);
   }
 
@@ -260,7 +260,7 @@ void LiveFunctionsController::Reset() {
   id_to_select_ = orbit_grpc_protos::kInvalidFunctionId;
 }
 
-ScopeId LiveFunctionsController::FunctionIdToScopeId(uint64_t function_id) const {
+std::optional<ScopeId> LiveFunctionsController::FunctionIdToScopeId(uint64_t function_id) const {
   ORBIT_CHECK(app_ != nullptr);
   ORBIT_CHECK(app_->HasCaptureData());
   return app_->GetCaptureData().FunctionIdToScopeId(function_id);

--- a/src/OrbitGl/LiveFunctionsController.h
+++ b/src/OrbitGl/LiveFunctionsController.h
@@ -53,7 +53,7 @@ class LiveFunctionsController : public orbit_data_views::LiveFunctionsInterface 
  private:
   void Move();
 
-  [[nodiscard]] ScopeId FunctionIdToScopeId(uint64_t function_id) const;
+  [[nodiscard]] std::optional<ScopeId> FunctionIdToScopeId(uint64_t function_id) const;
 
   orbit_data_views::LiveFunctionsDataView live_functions_data_view_;
 

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -52,7 +52,7 @@ class MainWindowInterface {
                                   std::string_view message) = 0;
 
   virtual void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
-                             ScopeId scope_id) = 0;
+                             std::optional<ScopeId> scope_id) = 0;
 
   enum class SymbolErrorHandlingResult { kReloadRequired, kSymbolLoadingCancelled };
   virtual SymbolErrorHandlingResult HandleSymbolError(

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -178,7 +178,8 @@ std::string ThreadTrack::GetBoxTooltip(const PrimitiveAssembler& primitive_assem
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
   if (!app_->HasCaptureData()) return TimerTrack::IsTimerActive(timer_info);
-  return app_->IsScopeVisible(app_->GetCaptureData().ProvideScopeId(timer_info));
+  const std::optional<ScopeId> scope_id = app_->GetCaptureData().ProvideScopeId(timer_info);
+  return scope_id.has_value() ? app_->IsScopeVisible(scope_id.value()) : false;
 }
 
 bool ThreadTrack::IsTrackSelected() const {
@@ -213,13 +214,12 @@ float ThreadTrack::GetDefaultBoxHeight() const {
 }
 
 Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, const internal::DrawData& draw_data) {
-  const ScopeId scope_id = app_->HasCaptureData()
-                               ? app_->GetCaptureData().ProvideScopeId(timer_info)
-                               : orbit_client_data::kInvalidScopeId;
+  const std::optional<ScopeId> scope_id =
+      app_->HasCaptureData() ? app_->GetCaptureData().ProvideScopeId(timer_info) : std::nullopt;
   const uint64_t group_id = timer_info.group_id();
   const bool is_selected = &timer_info == draw_data.selected_timer;
   const bool is_scope_id_highlighted =
-      scope_id != orbit_client_data::kInvalidScopeId && scope_id == draw_data.highlighted_scope_id;
+      scope_id.has_value() && scope_id.value() == draw_data.highlighted_scope_id;
   const bool is_group_id_highlighted =
       group_id != kOrbitDefaultGroupId && group_id == draw_data.highlighted_group_id;
   const bool is_highlighted = !is_selected && (is_scope_id_highlighted || is_group_id_highlighted);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -782,7 +782,8 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
     jump_scope = JumpScope::kSameDepth;
   }
   const TimerInfo* goal = nullptr;
-  auto scope_id = capture_data_->ProvideScopeId(*from);
+  const std::optional<ScopeId> scope_id = capture_data_->ProvideScopeId(*from);
+  if (!scope_id.has_value()) return;
   auto current_time = from->end();
   auto thread_id = from->thread_id();
   if (jump_direction == JumpDirection::kPrevious) {
@@ -791,10 +792,10 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
         goal = track_container_->FindPrevious(*from);
         break;
       case JumpScope::kSameFunction:
-        goal = FindPreviousScopeTimer(scope_id, current_time);
+        goal = FindPreviousScopeTimer(scope_id.value(), current_time);
         break;
       case JumpScope::kSameThreadSameFunction:
-        goal = FindPreviousScopeTimer(scope_id, current_time, thread_id);
+        goal = FindPreviousScopeTimer(scope_id.value(), current_time, thread_id);
         break;
       default:
         // Other choices are not implemented.
@@ -807,10 +808,10 @@ void TimeGraph::JumpToNeighborTimer(const TimerInfo* from, JumpDirection jump_di
         goal = track_container_->FindNext(*from);
         break;
       case JumpScope::kSameFunction:
-        goal = FindNextScopeTimer(scope_id, current_time);
+        goal = FindNextScopeTimer(scope_id.value(), current_time);
         break;
       case JumpScope::kSameThreadSameFunction:
-        goal = FindNextScopeTimer(scope_id, current_time, thread_id);
+        goal = FindNextScopeTimer(scope_id.value(), current_time, thread_id);
         break;
       default:
         ORBIT_UNREACHABLE();

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include "ApiInterface/Orbit.h"
@@ -188,12 +189,12 @@ bool TimerTrack::DrawTimer(TextRenderer& text_renderer, const TimerInfo* prev_ti
     }
   }
 
-  ScopeId scope_id = app_->GetCaptureData().ProvideScopeId(*current_timer_info);
+  std::optional<ScopeId> scope_id = app_->GetCaptureData().ProvideScopeId(*current_timer_info);
   uint64_t group_id = current_timer_info->group_id();
 
   bool is_selected = current_timer_info == draw_data.selected_timer;
   bool is_scope_id_highlighted =
-      scope_id != orbit_client_data::kInvalidScopeId && scope_id == draw_data.highlighted_scope_id;
+      scope_id.has_value() && scope_id.value() == draw_data.highlighted_scope_id;
   bool is_group_id_highlighted =
       group_id != kOrbitDefaultGroupId && group_id == draw_data.highlighted_group_id;
   bool is_highlighted = !is_selected && (is_scope_id_highlighted || is_group_id_highlighted);
@@ -381,8 +382,8 @@ internal::DrawData TimerTrack::GetDrawData(
     uint64_t min_tick, uint64_t max_tick, float track_pos_x, float track_width,
     PrimitiveAssembler* primitive_assembler, const orbit_gl::TimelineInfoInterface* timeline_info,
     const orbit_gl::Viewport* viewport, bool is_collapsed,
-    const orbit_client_protos::TimerInfo* selected_timer, ScopeId highlighted_scope_id,
-    uint64_t highlighted_group_id,
+    const orbit_client_protos::TimerInfo* selected_timer,
+    std::optional<ScopeId> highlighted_scope_id, uint64_t highlighted_group_id,
     std::optional<orbit_statistics::HistogramSelectionRange> histogram_selection_range) {
   internal::DrawData draw_data{};
   draw_data.min_tick = min_tick;

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -35,7 +35,7 @@ namespace internal {
 struct DrawData {
   uint64_t min_tick;
   uint64_t max_tick;
-  orbit_client_data::ScopeId highlighted_scope_id;
+  std::optional<orbit_client_data::ScopeId> highlighted_scope_id;
   uint64_t highlighted_group_id;
   double ns_per_pixel;
   uint64_t min_timegraph_tick;
@@ -146,7 +146,7 @@ class TimerTrack : public Track {
       orbit_gl::PrimitiveAssembler* primitive_assembler,
       const orbit_gl::TimelineInfoInterface* timeline_info, const orbit_gl::Viewport* viewport,
       bool is_collapsed, const orbit_client_protos::TimerInfo* selected_timer,
-      ScopeId highlighted_scope_id, uint64_t highlighted_group_id,
+      std::optional<ScopeId> highlighted_scope_id, uint64_t highlighted_group_id,
       std::optional<orbit_statistics::HistogramSelectionRange> histogram_selection_range);
 
   [[nodiscard]] virtual std::string GetBoxTooltip(

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -402,7 +402,7 @@ constexpr uint32_t kSeed = 31;
 }
 
 void HistogramWidget::UpdateData(const std::vector<uint64_t>* data, std::string scope_name,
-                                 ScopeId scope_id) {
+                                 std::optional<ScopeId> scope_id) {
   ORBIT_SCOPE_FUNCTION;
   if (scope_data_.has_value() && scope_data_->id == scope_id) return;
 
@@ -410,11 +410,15 @@ void HistogramWidget::UpdateData(const std::vector<uint64_t>* data, std::string 
   ranges_stack_ = {};
   EmitSignalSelectionRangeChange();
 
-  scope_data_.emplace(data, std::move(scope_name), scope_id);
+  if (scope_id.has_value()) {
+    scope_data_.emplace(data, std::move(scope_name), scope_id.value());
+  } else {
+    scope_data_ = std::nullopt;
+  }
 
-  if (data != nullptr) {
+  if (scope_data_.has_value() && data != nullptr) {
     std::optional<orbit_statistics::Histogram> histogram =
-        orbit_statistics::BuildHistogram(*scope_data_->data);
+        orbit_statistics::BuildHistogram(*scope_data_.value().data);
     if (histogram) {
       histogram_stack_.push(std::move(*histogram));
     }

--- a/src/OrbitQt/HistogramWidget.h
+++ b/src/OrbitQt/HistogramWidget.h
@@ -45,7 +45,7 @@ class HistogramWidget : public QWidget {
   using QWidget::QWidget;
 
   void UpdateData(const std::vector<uint64_t>* data, std::string function_name,
-                  ScopeId function_id);
+                  std::optional<ScopeId> scope_id);
 
   [[nodiscard]] QString GetTitle() const;
 

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -171,6 +171,6 @@ void OrbitLiveFunctions::OnRowSelected(std::optional<int> row) {
 
 void OrbitLiveFunctions::ShowHistogram(const std::vector<uint64_t>* data,
                                        const std::string& scope_name,
-                                       orbit_client_data::ScopeId scope_id) {
+                                       std::optional<orbit_client_data::ScopeId> scope_id) {
   ui->histogram_widget_->UpdateData(data, scope_name, scope_id);
 }

--- a/src/OrbitQt/orbitlivefunctions.h
+++ b/src/OrbitQt/orbitlivefunctions.h
@@ -49,7 +49,7 @@ class OrbitLiveFunctions : public QWidget {
     return live_functions_ ? &live_functions_.value() : nullptr;
   }
   void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
-                     orbit_client_data::ScopeId scope_id);
+                     std::optional<orbit_client_data::ScopeId> scope_id);
 
  signals:
   void SignalSelectionRangeChange(std::optional<orbit_statistics::HistogramSelectionRange>) const;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1358,10 +1358,11 @@ void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerIn
   bool is_live_function_data_view_initialized = live_functions_data_view != nullptr;
   if (timer_info) {
     ORBIT_CHECK(is_live_function_data_view_initialized);
-    const ScopeId scope_id = app_->GetCaptureData().ProvideScopeId(*timer_info);
-    selected_row = live_functions_data_view->GetRowFromScopeId(scope_id);
+    const std::optional<ScopeId> scope_id = app_->GetCaptureData().ProvideScopeId(*timer_info);
+    ORBIT_CHECK(scope_id.has_value());
+    selected_row = live_functions_data_view->GetRowFromScopeId(scope_id.value());
     live_functions_data_view->UpdateSelectedFunctionId();
-    live_functions_data_view->UpdateHistogramWithScopeIds({scope_id});
+    live_functions_data_view->UpdateHistogramWithScopeIds({scope_id.value()});
   } else {
     if (is_live_function_data_view_initialized) {
       live_functions_data_view->UpdateHistogramWithScopeIds({});
@@ -1723,7 +1724,8 @@ void OrbitMainWindow::ShowWarningWithDontShowAgainCheckboxIfNeeded(
 }
 
 void OrbitMainWindow::ShowHistogram(const std::vector<uint64_t>* data,
-                                    const std::string& scope_name, ScopeId scope_id) {
+                                    const std::string& scope_name,
+                                    std::optional<ScopeId> scope_id) {
   ui->liveFunctions->ShowHistogram(data, scope_name, scope_id);
 }
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -123,7 +123,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
       std::string_view dont_show_again_setting_key) override;
 
   void ShowHistogram(const std::vector<uint64_t>* data, const std::string& function_name,
-                     ScopeId function_id) override;
+                     std::optional<ScopeId> function_id) override;
 
   orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> DownloadFileFromInstance(
       std::filesystem::path path_on_instance, std::filesystem::path local_path,


### PR DESCRIPTION
The semantics of an invalid scope id is now beared by
`std::optional<ScopeId>`.

Tests: Compile, Unit, Manual
Bug: http://b/238862756