### PR TITLE
Add PresentEvent grpc message

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -61,6 +61,7 @@ class MockCaptureListener : public CaptureListener {
               (uint64_t /*timestamp_ns*/,
                std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/),
               (override));
+  MOCK_METHOD(void, OnPresentEvent, (const orbit_grpc_protos::PresentEvent&), (override));
   MOCK_METHOD(void, OnApiStringEvent, (const orbit_client_data::ApiStringEvent&), (override));
   MOCK_METHOD(void, OnApiTrackValue, (const orbit_client_data::ApiTrackValue&), (override));
   MOCK_METHOD(void, OnWarningEvent, (orbit_grpc_protos::WarningEvent /*warning_event*/),

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -71,6 +71,7 @@ class CaptureEventProcessorForListener : public CaptureEventProcessor {
   void ProcessInternedString(orbit_grpc_protos::InternedString interned_string);
   void ProcessModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update);
   void ProcessModulesSnapshot(const orbit_grpc_protos::ModulesSnapshot& modules_snapshot);
+  void ProcessPresentEvent(const orbit_grpc_protos::PresentEvent& present_event);
   void ProcessGpuJob(const orbit_grpc_protos::GpuJob& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);
   void ProcessThreadNamesSnapshot(
@@ -171,6 +172,9 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
       break;
     case ClientCaptureEvent::kModulesSnapshot:
       ProcessModulesSnapshot(event.modules_snapshot());
+      break;
+    case ClientCaptureEvent::kPresentEvent:
+      ProcessPresentEvent(event.present_event());
       break;
     case ClientCaptureEvent::kThreadNamesSnapshot:
       ProcessThreadNamesSnapshot(event.thread_names_snapshot());
@@ -347,6 +351,11 @@ void CaptureEventProcessorForListener::ProcessModulesSnapshot(
   capture_listener_->OnModulesSnapshot(
       modules_snapshot.timestamp_ns(),
       {modules_snapshot.modules().begin(), modules_snapshot.modules().end()});
+}
+
+void CaptureEventProcessorForListener::ProcessPresentEvent(
+    const orbit_grpc_protos::PresentEvent& present_event) {
+  capture_listener_->OnPresentEvent(present_event);
 }
 
 void CaptureEventProcessorForListener::ProcessGpuJob(const GpuJob& gpu_job) {

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -49,6 +49,7 @@ class MyCaptureListener : public CaptureListener {
                       orbit_grpc_protos::ModuleInfo /*module_info*/) override {}
   void OnModulesSnapshot(uint64_t /*timestamp_ns*/,
                          std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/) override {}
+  void OnPresentEvent(const orbit_grpc_protos::PresentEvent& /*present_event*/) override {}
   void OnApiStringEvent(const orbit_client_data::ApiStringEvent& /*api_string_event*/) override {}
   void OnApiTrackValue(const orbit_client_data::ApiTrackValue& /*api_track_value*/) override {}
   void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {}

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -59,6 +59,7 @@ using orbit_grpc_protos::LostPerfRecordsEvent;
 using orbit_grpc_protos::MemoryUsageEvent;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::OutOfOrderEventsDiscardedEvent;
+using orbit_grpc_protos::PresentEvent;
 using orbit_grpc_protos::ProcessMemoryUsage;
 using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::SystemMemoryUsage;
@@ -99,6 +100,7 @@ class MockCaptureListener : public CaptureListener {
               (override));
   MOCK_METHOD(void, OnModulesSnapshot,
               (uint64_t /*timestamp_ns*/, std::vector<ModuleInfo> /*module_infos*/), (override));
+  MOCK_METHOD(void, OnPresentEvent, (const PresentEvent&), (override));
   MOCK_METHOD(void, OnApiStringEvent, (const ApiStringEvent&), (override));
   MOCK_METHOD(void, OnApiTrackValue, (const ApiTrackValue&), (override));
   MOCK_METHOD(void, OnWarningEvent, (orbit_grpc_protos::WarningEvent /*warning_event*/),

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -158,6 +158,30 @@ TEST(CaptureEventProcessor, CanHandleSchedulingSlices) {
   EXPECT_EQ(actual_timer.type(), TimerInfo::kCoreActivity);
 }
 
+TEST(CaptureEventProcessor, CanHandlePresentEvent) {
+  MockCaptureListener listener;
+  auto event_processor =
+      CaptureEventProcessor::CreateForCaptureListener(&listener, std::filesystem::path{}, {});
+
+  ClientCaptureEvent event;
+  PresentEvent* present_event = event.mutable_present_event();
+  present_event->set_pid(42);
+  present_event->set_tid(24);
+  present_event->set_begin_timestamp_ns(100);
+  present_event->set_duration_ns(97);
+  present_event->set_source(PresentEvent::kD3d9);
+
+  PresentEvent actual_present_event;
+  EXPECT_CALL(listener, OnPresentEvent).Times(1).WillOnce(SaveArg<0>(&actual_present_event));
+  event_processor->ProcessEvent(event);
+
+  EXPECT_EQ(actual_present_event.pid(), present_event->pid());
+  EXPECT_EQ(actual_present_event.tid(), present_event->tid());
+  EXPECT_EQ(actual_present_event.begin_timestamp_ns(), present_event->begin_timestamp_ns());
+  EXPECT_EQ(actual_present_event.duration_ns(), present_event->duration_ns());
+  EXPECT_EQ(actual_present_event.source(), present_event->source());
+}
+
 static InternedCallstack* AddAndInitializeInternedCallstack(ClientCaptureEvent& event) {
   InternedCallstack* interned_callstack = event.mutable_interned_callstack();
   interned_callstack->set_key(1);

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -52,6 +52,7 @@ class CaptureListener {
   virtual void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) = 0;
   virtual void OnModulesSnapshot(uint64_t timestamp_ns,
                                  std::vector<orbit_grpc_protos::ModuleInfo> module_infos) = 0;
+  virtual void OnPresentEvent(const orbit_grpc_protos::PresentEvent& present_event) = 0;
   virtual void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) = 0;
   virtual void OnUniqueTracepointInfo(uint64_t tracepoint_id,

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -517,6 +517,23 @@ message GpuDebugMarker {
   Color color = 5;
 }
 
+message PresentEvent {
+  uint32 pid = 1;
+  uint32 tid = 2;
+
+  // Unlike other events, we choose the (start_timestamp_ns, duration_ns) pair
+  // as some present "start" events don't have a corresponding "stop".
+  uint64 begin_timestamp_ns = 3;
+  uint64 duration_ns = 4;
+
+  enum Source {
+    kUnknown = 0;
+    kDxgi = 1;
+    kD3d9 = 2;
+  }
+  Source source = 5;
+}
+
 message Color {
   // Color ranges are [0.f, 1.f] for the following fields.
   float red = 1;
@@ -749,7 +766,7 @@ message ClientCaptureEvent {
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
-    // Next high-frequency ID: 12
+    // Next high-frequency ID: 13
     // Next lower-frequency ID: 49
     // Please keep these alphabetically ordered.
 
@@ -788,6 +805,7 @@ message ClientCaptureEvent {
     ModulesSnapshot modules_snapshot = 25;
     ModuleUpdateEvent module_update_event = 21;
     OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event = 37;
+    PresentEvent present_event = 12;
     SchedulingSlice scheduling_slice = 6;
     ThreadName thread_name = 22;
     ThreadNamesSnapshot thread_names_snapshot = 26;
@@ -807,7 +825,7 @@ message ProducerCaptureEvent {
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
-    // Next high-frequency ID: 15
+    // Next high-frequency ID: No high-frequency index left.
     // Next lower-frequency ID: 48
     //
     // Please keep these alphabetically ordered.
@@ -850,6 +868,7 @@ message ProducerCaptureEvent {
     ModulesSnapshot modules_snapshot = 25;
     ModuleUpdateEvent module_update_event = 20;
     OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event = 35;
+    PresentEvent present_event = 15;
     SchedulingSlice scheduling_slice = 8;
     ThreadName thread_name = 21;
     ThreadNamesSnapshot thread_names_snapshot = 24;

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -402,6 +402,8 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         EXPECT_GE(event.module_update_event().timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.module_update_event().timestamp_ns();
         break;
+      case orbit_grpc_protos::ProducerCaptureEvent::kPresentEvent:
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kOutOfOrderEventsDiscardedEvent:
         EXPECT_GE(event.out_of_order_events_discarded_event().end_timestamp_ns(),
                   previous_event_timestamp_ns);

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -78,6 +78,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
                          std::vector<orbit_grpc_protos::ModuleInfo> module_infos) override {
     UpdateModules(module_infos);
   }
+  void OnPresentEvent(const orbit_grpc_protos::PresentEvent&) override {}
   void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo /*thread_state_slice*/) override {
   }
   void OnApiStringEvent(const orbit_client_data::ApiStringEvent& /*unused*/) override {}

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -607,6 +607,8 @@ void OrbitApp::OnModulesSnapshot(uint64_t /*timestamp_ns*/, std::vector<ModuleIn
   main_thread_executor_->Schedule([this]() { FireRefreshCallbacks(DataViewType::kLiveFunctions); });
 }
 
+void OrbitApp::OnPresentEvent(const orbit_grpc_protos::PresentEvent& /*present_event*/) {}
+
 void OrbitApp::OnWarningEvent(orbit_grpc_protos::WarningEvent warning_event) {
   main_thread_executor_->Schedule([this, warning_event = std::move(warning_event)]() {
     main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kWarning,

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -173,6 +173,7 @@ class OrbitApp final : public DataViewFactory,
   void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) override;
   void OnModulesSnapshot(uint64_t timestamp_ns,
                          std::vector<orbit_grpc_protos::ModuleInfo> module_infos) override;
+  void OnPresentEvent(const orbit_grpc_protos::PresentEvent& present_event) override;
   void OnApiStringEvent(const orbit_client_data::ApiStringEvent& api_string_event) override;
   void OnApiTrackValue(const orbit_client_data::ApiTrackValue& api_track_value) override;
   void OnWarningEvent(orbit_grpc_protos::WarningEvent warning_event) override;

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -159,6 +159,7 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
                          std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/) override {
     ORBIT_UNREACHABLE();
   }
+  void OnPresentEvent(const orbit_grpc_protos::PresentEvent&) override { ORBIT_UNREACHABLE(); }
   void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {
     ORBIT_UNREACHABLE();
   }

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -47,6 +47,7 @@ using orbit_grpc_protos::MemoryUsageEvent;
 using orbit_grpc_protos::ModulesSnapshot;
 using orbit_grpc_protos::ModuleUpdateEvent;
 using orbit_grpc_protos::OutOfOrderEventsDiscardedEvent;
+using orbit_grpc_protos::PresentEvent;
 using orbit_grpc_protos::ProducerCaptureEvent;
 using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::ThreadName;
@@ -140,6 +141,7 @@ class ProducerEventProcessorImpl : public ProducerEventProcessor {
   void ProcessModuleUpdateEventAndTransferOwnership(ModuleUpdateEvent* module_update_event);
   void ProcessOutOfOrderEventsDiscardedEventAndTransferOwnership(
       OutOfOrderEventsDiscardedEvent* out_of_order_events_discarded_event);
+  void ProcessPresentEventAndTransferOwnership(PresentEvent* present_event);
   void ProcessSchedulingSliceAndTransferOwnership(SchedulingSlice* scheduling_slice);
   void ProcessThreadNameAndTransferOwnership(ThreadName* thread_name);
   void ProcessThreadNamesSnapshotAndTransferOwnership(ThreadNamesSnapshot* thread_names_snapshot);
@@ -502,6 +504,13 @@ void ProducerEventProcessorImpl::ProcessOutOfOrderEventsDiscardedEventAndTransfe
   client_capture_event_collector_->AddEvent(std::move(event));
 }
 
+void ProducerEventProcessorImpl::ProcessPresentEventAndTransferOwnership(
+    PresentEvent* present_event) {
+  ClientCaptureEvent event;
+  event.set_allocated_present_event(present_event);
+  client_capture_event_collector_->AddEvent(std::move(event));
+}
+
 void ProducerEventProcessorImpl::ProcessSchedulingSliceAndTransferOwnership(
     SchedulingSlice* scheduling_slice) {
   ClientCaptureEvent event;
@@ -652,6 +661,9 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
     case ProducerCaptureEvent::kOutOfOrderEventsDiscardedEvent:
       ProcessOutOfOrderEventsDiscardedEventAndTransferOwnership(
           event.release_out_of_order_events_discarded_event());
+      break;
+    case ProducerCaptureEvent::kPresentEvent:
+      ProcessPresentEventAndTransferOwnership(event.release_present_event());
       break;
     case ProducerCaptureEvent::kSchedulingSlice:
       ProcessSchedulingSliceAndTransferOwnership(event.release_scheduling_slice());

--- a/src/WindowsCaptureService/TracingHandler.cpp
+++ b/src/WindowsCaptureService/TracingHandler.cpp
@@ -70,4 +70,10 @@ void TracingHandler::OnModulesSnapshot(orbit_grpc_protos::ModulesSnapshot module
   producer_event_processor_->ProcessEvent(kWindowsTracingProducerId, std::move(event));
 }
 
+void TracingHandler::OnPresentEvent(orbit_grpc_protos::PresentEvent present_event) {
+  ProducerCaptureEvent event;
+  *event.mutable_present_event() = std::move(present_event);
+  producer_event_processor_->ProcessEvent(kWindowsTracingProducerId, std::move(event));
+}
+
 }  // namespace orbit_windows_capture_service

--- a/src/WindowsCaptureService/TracingHandler.h
+++ b/src/WindowsCaptureService/TracingHandler.h
@@ -44,6 +44,7 @@ class TracingHandler : public orbit_windows_tracing::TracerListener {
   void OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) override;
   void OnModulesSnapshot(orbit_grpc_protos::ModulesSnapshot modules_snapshot) override;
   void OnThreadNamesSnapshot(orbit_grpc_protos::ThreadNamesSnapshot thread_names_snapshot) override;
+  void OnPresentEvent(orbit_grpc_protos::PresentEvent present_event) override;
 
  private:
   orbit_producer_event_processor::ProducerEventProcessor* producer_event_processor_;

--- a/src/WindowsTracing/ContextSwitchManagerTest.cpp
+++ b/src/WindowsTracing/ContextSwitchManagerTest.cpp
@@ -21,6 +21,7 @@ class MockTracerListener : public orbit_windows_tracing::TracerListener {
   MOCK_METHOD(void, OnModulesSnapshot, (orbit_grpc_protos::ModulesSnapshot), (override));
   MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
   MOCK_METHOD(void, OnThreadNamesSnapshot, (orbit_grpc_protos::ThreadNamesSnapshot), (override));
+  MOCK_METHOD(void, OnPresentEvent, (orbit_grpc_protos::PresentEvent present_event), (override));
 };
 
 TEST(ContextSwitch, ListenerIsCalled) {

--- a/src/WindowsTracing/include/WindowsTracing/TracerListener.h
+++ b/src/WindowsTracing/include/WindowsTracing/TracerListener.h
@@ -20,6 +20,7 @@ class TracerListener {
   virtual void OnModulesSnapshot(orbit_grpc_protos::ModulesSnapshot modules_snapshot) = 0;
   virtual void OnThreadNamesSnapshot(
       orbit_grpc_protos::ThreadNamesSnapshot thread_names_snapshot) = 0;
+  virtual void OnPresentEvent(orbit_grpc_protos::PresentEvent present_event) = 0;
 };
 
 }  // namespace orbit_windows_tracing


### PR DESCRIPTION
"PresentEvent" objects represent events related to swap chain presentation 
on Windows. They will be generated by the GraphicsEtwProvider, see #3790 
for more context.

Tests: compilation, end-to-end feature works in #3790