### PR TITLE
Update libunwindstack to c4e572564862727056090d9540641077238f2079

### DIFF
--- a/third_party/libunwindstack/ArmExidx.h
+++ b/third_party/libunwindstack/ArmExidx.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_ARM_EXIDX_H
-#define _LIBUNWINDSTACK_ARM_EXIDX_H
+#pragma once
 
 #include <stdint.h>
 
@@ -122,5 +121,3 @@ class ArmExidx {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_ARM_EXIDX_H

--- a/third_party/libunwindstack/Check.h
+++ b/third_party/libunwindstack/Check.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_CHECK_H
-#define _LIBUNWINDSTACK_CHECK_H
+#pragma once
 
 #include <stdlib.h>
 
@@ -30,5 +29,3 @@ namespace unwindstack {
   }
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_CHECK_H

--- a/third_party/libunwindstack/DexFile.h
+++ b/third_party/libunwindstack/DexFile.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DEX_FILE_H
-#define _LIBUNWINDSTACK_DEX_FILE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -80,5 +79,3 @@ class DexFile {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DEX_FILE_H

--- a/third_party/libunwindstack/DwarfCfa.h
+++ b/third_party/libunwindstack/DwarfCfa.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_CFA_H
-#define _LIBUNWINDSTACK_DWARF_CFA_H
+#pragma once
 
 #include <stdint.h>
 
@@ -270,5 +269,3 @@ class DwarfCfa {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_CFA_H

--- a/third_party/libunwindstack/DwarfDebugFrame.h
+++ b/third_party/libunwindstack/DwarfDebugFrame.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_DEBUG_FRAME_H
-#define _LIBUNWINDSTACK_DWARF_DEBUG_FRAME_H
+#pragma once
 
 #include <stdint.h>
 
@@ -46,5 +45,3 @@ class DwarfDebugFrame : public DwarfSectionImpl<AddressType> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_DEBUG_FRAME_H

--- a/third_party/libunwindstack/DwarfEhFrame.h
+++ b/third_party/libunwindstack/DwarfEhFrame.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_EH_FRAME_H
-#define _LIBUNWINDSTACK_DWARF_EH_FRAME_H
+#pragma once
 
 #include <stdint.h>
 
@@ -45,5 +44,3 @@ class DwarfEhFrame : public DwarfSectionImpl<AddressType> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_EH_FRAME_H

--- a/third_party/libunwindstack/DwarfEhFrameWithHdr.h
+++ b/third_party/libunwindstack/DwarfEhFrameWithHdr.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_EH_FRAME_WITH_HDR_H
-#define _LIBUNWINDSTACK_DWARF_EH_FRAME_WITH_HDR_H
+#pragma once
 
 #include <stdint.h>
 
@@ -84,5 +83,3 @@ class DwarfEhFrameWithHdr : public DwarfSectionImpl<AddressType> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_EH_FRAME_WITH_HDR_H

--- a/third_party/libunwindstack/DwarfEncoding.h
+++ b/third_party/libunwindstack/DwarfEncoding.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_ENCODING_H
-#define _LIBUNWINDSTACK_DWARF_ENCODING_H
+#pragma once
 
 #include <stdint.h>
 
@@ -68,5 +67,3 @@ struct AddressEncodingType<uint64_t> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_ENCODING_H

--- a/third_party/libunwindstack/DwarfOp.cpp
+++ b/third_party/libunwindstack/DwarfOp.cpp
@@ -1817,13 +1817,12 @@ template <typename AddressType>
 bool DwarfOp<AddressType>::op_bra() {
   // Requires one stack element.
   AddressType top = StackPop();
-  int16_t offset = static_cast<int16_t>(OperandAt(0));
-  uint64_t cur_offset;
-  if (top != 0) {
-    cur_offset = memory_->cur_offset() + offset;
-  } else {
-    cur_offset = memory_->cur_offset() - offset;
+  if (top == 0) {
+    return true;
   }
+
+  int16_t offset = static_cast<int16_t>(OperandAt(0));
+  uint64_t cur_offset = memory_->cur_offset() + offset;
   memory_->set_cur_offset(cur_offset);
   return true;
 }

--- a/third_party/libunwindstack/DwarfOp.h
+++ b/third_party/libunwindstack/DwarfOp.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_OP_H
-#define _LIBUNWINDSTACK_DWARF_OP_H
+#pragma once
 
 #include <stdint.h>
 
@@ -140,5 +139,3 @@ class DwarfOp {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_OP_H

--- a/third_party/libunwindstack/ElfInterfaceArm.h
+++ b/third_party/libunwindstack/ElfInterfaceArm.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_ELF_INTERFACE_ARM_H
-#define _LIBUNWINDSTACK_ELF_INTERFACE_ARM_H
+#pragma once
 
 #include <elf.h>
 #include <stdint.h>
@@ -94,5 +93,3 @@ class ElfInterfaceArm : public ElfInterface32 {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_ELF_INTERFACE_ARM_H

--- a/third_party/libunwindstack/GlobalDebugImpl.h
+++ b/third_party/libunwindstack/GlobalDebugImpl.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_GLOBAL_DEBUG_IMPL_H
-#define _LIBUNWINDSTACK_GLOBAL_DEBUG_IMPL_H
+#pragma once
 
 #include <stdint.h>
 #include <string.h>
@@ -435,5 +434,3 @@ std::unique_ptr<GlobalDebugInterface<Symfile>> CreateGlobalDebugImpl(
 }
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_GLOBAL_DEBUG_IMPL_H

--- a/third_party/libunwindstack/MemoryBuffer.h
+++ b/third_party/libunwindstack/MemoryBuffer.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_BUFFER_H
-#define _LIBUNWINDSTACK_MEMORY_BUFFER_H
+#pragma once
 
 #include <stdint.h>
 
@@ -56,5 +55,3 @@ class MemoryBuffer : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_BUFFER_H

--- a/third_party/libunwindstack/MemoryCache.h
+++ b/third_party/libunwindstack/MemoryCache.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_CACHE_H
-#define _LIBUNWINDSTACK_MEMORY_CACHE_H
+#pragma once
 
 #include <pthread.h>
 #include <stdint.h>
@@ -91,5 +90,3 @@ class MemoryThreadCache : public MemoryCacheBase {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_CACHE_H

--- a/third_party/libunwindstack/MemoryFileAtOffset.h
+++ b/third_party/libunwindstack/MemoryFileAtOffset.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_FILE_AT_OFFSET_H
-#define _LIBUNWINDSTACK_MEMORY_FILE_AT_OFFSET_H
+#pragma once
 
 #include <stdint.h>
 
@@ -45,5 +44,3 @@ class MemoryFileAtOffset : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_FILE_AT_OFFSET_H

--- a/third_party/libunwindstack/MemoryLocal.h
+++ b/third_party/libunwindstack/MemoryLocal.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_LOCAL_H
-#define _LIBUNWINDSTACK_MEMORY_LOCAL_H
+#pragma once
 
 #include <stdint.h>
 
@@ -33,5 +32,3 @@ class MemoryLocal : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_LOCAL_H

--- a/third_party/libunwindstack/MemoryOffline.h
+++ b/third_party/libunwindstack/MemoryOffline.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_OFFLINE_H
-#define _LIBUNWINDSTACK_MEMORY_OFFLINE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -58,5 +57,3 @@ class MemoryOfflineParts : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_OFFLINE_H

--- a/third_party/libunwindstack/MemoryOfflineBuffer.h
+++ b/third_party/libunwindstack/MemoryOfflineBuffer.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_OFFLINE_BUFFER_H
-#define _LIBUNWINDSTACK_MEMORY_OFFLINE_BUFFER_H
+#pragma once
 
 #include <stdint.h>
 
@@ -39,5 +38,3 @@ class MemoryOfflineBuffer : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_OFFLINE_BUFFER_H

--- a/third_party/libunwindstack/MemoryRange.h
+++ b/third_party/libunwindstack/MemoryRange.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_RANGE_H
-#define _LIBUNWINDSTACK_MEMORY_RANGE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -62,5 +61,3 @@ class MemoryRanges : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_RANGE_H

--- a/third_party/libunwindstack/MemoryRemote.h
+++ b/third_party/libunwindstack/MemoryRemote.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_REMOTE_H
-#define _LIBUNWINDSTACK_MEMORY_REMOTE_H
+#pragma once
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -42,5 +41,3 @@ class MemoryRemote : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_REMOTE_H

--- a/third_party/libunwindstack/MemoryXz.h
+++ b/third_party/libunwindstack/MemoryXz.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_XZ_H
-#define _LIBUNWINDSTACK_MEMORY_XZ_H
+#pragma once
 
 #include <atomic>
 #include <memory>
@@ -71,5 +70,3 @@ class MemoryXz : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_XZ_H

--- a/third_party/libunwindstack/PeCoffEpilog.h
+++ b/third_party/libunwindstack/PeCoffEpilog.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_EPILOG_H
-#define _LIBUNWINDSTACK_PE_COFF_EPILOG_H
+#pragma once
 
 #include <memory>
 
@@ -57,5 +56,3 @@ std::unique_ptr<PeCoffEpilog> CreatePeCoffEpilog(Memory* object_file_memory,
                                                  std::vector<Section> sections);
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_PE_COFF_EPILOG_H

--- a/third_party/libunwindstack/PeCoffRuntimeFunctions.h
+++ b/third_party/libunwindstack/PeCoffRuntimeFunctions.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H
-#define _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H
+#pragma once
 
 #include <memory>
 #include <vector>
@@ -49,5 +48,3 @@ class PeCoffRuntimeFunctions {
 std::unique_ptr<PeCoffRuntimeFunctions> CreatePeCoffRuntimeFunctions(Memory* object_file_memory);
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_PE_COFF_RUNTIME_FUNCTIONS_H

--- a/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfoEvaluator.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_EVALUATOR_H
-#define _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_EVALUATOR_H
+#pragma once
 
 #include <memory>
 
@@ -61,5 +60,3 @@ class PeCoffUnwindInfoEvaluator {
 std::unique_ptr<PeCoffUnwindInfoEvaluator> CreatePeCoffUnwindInfoEvaluator();
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_EVALUATOR_H

--- a/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfoUnwinderX86_64.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H
-#define _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H
+#pragma once
 
 #include <memory>
 
@@ -67,5 +66,3 @@ class PeCoffUnwindInfoUnwinderX86_64 : public PeCoffNativeUnwinder {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_PE_COFF_UNWIND_INFO_UNWINDER_X86_64_H

--- a/third_party/libunwindstack/PeCoffUnwindInfos.h
+++ b/third_party/libunwindstack/PeCoffUnwindInfos.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_UNWIND_INFOS_H
-#define _LIBUNWINDSTACK_PE_COFF_UNWIND_INFOS_H
+#pragma once
 
 #include <string.h>
 #include <memory>
@@ -81,5 +80,3 @@ std::unique_ptr<PeCoffUnwindInfos> CreatePeCoffUnwindInfos(Memory* object_file_m
                                                            std::vector<Section> sections);
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_PE_COFF_UNWIND_INFOS_H

--- a/third_party/libunwindstack/RegsInfo.h
+++ b/third_party/libunwindstack/RegsInfo.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_INFO_H
-#define _LIBUNWINDSTACK_REGS_INFO_H
+#pragma once
 
 #include <stdint.h>
 
@@ -64,5 +63,3 @@ struct RegsInfo {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_INFO_H

--- a/third_party/libunwindstack/Symbols.h
+++ b/third_party/libunwindstack/Symbols.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_SYMBOLS_H
-#define _LIBUNWINDSTACK_SYMBOLS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -75,5 +74,3 @@ class Symbols {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_SYMBOLS_H

--- a/third_party/libunwindstack/TEST_MAPPING
+++ b/third_party/libunwindstack/TEST_MAPPING
@@ -14,7 +14,7 @@
     }
   ],
 
-  "hwasan-postsubmit": [
+  "hwasan-presubmit": [
     {
       "name": "libunwindstack_unit_test"
     }

--- a/third_party/libunwindstack/ThreadEntry.h
+++ b/third_party/libunwindstack/ThreadEntry.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_THREAD_ENTRY_H
-#define _LIBUNWINDSTACK_THREAD_ENTRY_H
+#pragma once
 
 #include <pthread.h>
 #include <sys/types.h>
@@ -74,5 +73,3 @@ class ThreadEntry {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_THREAD_ENTRY_H

--- a/third_party/libunwindstack/benchmarks/MemoryLocalUnsafe.h
+++ b/third_party/libunwindstack/benchmarks/MemoryLocalUnsafe.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_BENCHMARKS_MEMORY_LOCAL_UNSAFE_H
-#define _LIBUNWINDSTACK_BENCHMARKS_MEMORY_LOCAL_UNSAFE_H
+#pragma once
 
 #include <cstddef>
 #include <cstring>
@@ -39,5 +38,3 @@ class MemoryLocalUnsafe : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_BENCHMARKS_MEMORY_LOCAL_UNSAFE_H

--- a/third_party/libunwindstack/benchmarks/Utils.h
+++ b/third_party/libunwindstack/benchmarks/Utils.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UTILS_H
-#define _LIBUNWINDSTACK_UTILS_H
+#pragma once
 
 #include <benchmark/benchmark.h>
 #include <stdint.h>
@@ -66,5 +65,3 @@ class MemoryTracker {
   // total number of iterations of the ranged for loop across all runs of a single benchmark.
   size_t total_iterations_ = 0;
 };
-
-#endif  // _LIBUNWINDSTACK_UTILS_h

--- a/third_party/libunwindstack/include/GlobalDebugInterface.h
+++ b/third_party/libunwindstack/include/GlobalDebugInterface.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_GLOBAL_DEBUG_INTERFACE_H
-#define _LIBUNWINDSTACK_GLOBAL_DEBUG_INTERFACE_H
+#pragma once
 
 #include <stdint.h>
 #include <memory>
@@ -41,5 +40,3 @@ class GlobalDebugInterface {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_GLOBAL_DEBUG_INTERFACE_H

--- a/third_party/libunwindstack/include/unwindstack/AndroidUnwinder.h
+++ b/third_party/libunwindstack/include/unwindstack/AndroidUnwinder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_ANDROID_UNWINDER_H
-#define _LIBUNWINDSTACK_ANDROID_UNWINDER_H
+#pragma once
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -160,5 +159,3 @@ class AndroidRemoteUnwinder : public AndroidUnwinder {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_ANDROID_UNWINDER_H

--- a/third_party/libunwindstack/include/unwindstack/Arch.h
+++ b/third_party/libunwindstack/include/unwindstack/Arch.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_ARCH_H
-#define _LIBUNWINDSTACK_ARCH_H
+#pragma once
 
 #include <stddef.h>
 
@@ -43,5 +42,3 @@ static inline bool ArchIs32Bit(ArchEnum arch) {
 }
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_ARCH_H

--- a/third_party/libunwindstack/include/unwindstack/DexFiles.h
+++ b/third_party/libunwindstack/include/unwindstack/DexFiles.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DEX_FILES_H
-#define _LIBUNWINDSTACK_DEX_FILES_H
+#pragma once
 
 #include <stdint.h>
 
@@ -36,5 +35,3 @@ std::unique_ptr<DexFiles> CreateDexFiles(ArchEnum arch, std::shared_ptr<Memory>&
                                          std::vector<std::string> search_libs = {});
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DEX_FILES_H

--- a/third_party/libunwindstack/include/unwindstack/DwarfError.h
+++ b/third_party/libunwindstack/include/unwindstack/DwarfError.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_ERROR_H
-#define _LIBUNWINDSTACK_DWARF_ERROR_H
+#pragma once
 
 #include <stdint.h>
 
@@ -40,5 +39,3 @@ struct DwarfErrorData {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_ERROR_H

--- a/third_party/libunwindstack/include/unwindstack/DwarfLocation.h
+++ b/third_party/libunwindstack/include/unwindstack/DwarfLocation.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_LOCATION_H
-#define _LIBUNWINDSTACK_DWARF_LOCATION_H
+#pragma once
 
 #include <stdint.h>
 
@@ -49,5 +48,3 @@ struct DwarfLocations : public std::unordered_map<uint32_t, DwarfLocation> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_LOCATION_H

--- a/third_party/libunwindstack/include/unwindstack/DwarfMemory.h
+++ b/third_party/libunwindstack/include/unwindstack/DwarfMemory.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_MEMORY_H
-#define _LIBUNWINDSTACK_DWARF_MEMORY_H
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -73,5 +72,3 @@ class DwarfMemory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_MEMORY_H

--- a/third_party/libunwindstack/include/unwindstack/DwarfSection.h
+++ b/third_party/libunwindstack/include/unwindstack/DwarfSection.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_SECTION_H
-#define _LIBUNWINDSTACK_DWARF_SECTION_H
+#pragma once
 
 #include <stdint.h>
 
@@ -180,5 +179,3 @@ class DwarfSectionImpl : public DwarfSection {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_SECTION_H

--- a/third_party/libunwindstack/include/unwindstack/DwarfStructs.h
+++ b/third_party/libunwindstack/include/unwindstack/DwarfStructs.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DWARF_STRUCTS_H
-#define _LIBUNWINDSTACK_DWARF_STRUCTS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -51,5 +50,3 @@ struct DwarfFde {
 constexpr uint16_t CFA_REG = static_cast<uint16_t>(-1);
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DWARF_STRUCTS_H

--- a/third_party/libunwindstack/include/unwindstack/Elf.h
+++ b/third_party/libunwindstack/include/unwindstack/Elf.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_ELF_H
-#define _LIBUNWINDSTACK_ELF_H
+#pragma once
 
 #include <stddef.h>
 
@@ -110,5 +109,3 @@ class Elf : public Object {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_ELF_H

--- a/third_party/libunwindstack/include/unwindstack/ElfInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/ElfInterface.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_ELF_INTERFACE_H
-#define _LIBUNWINDSTACK_ELF_INTERFACE_H
+#pragma once
 
 #include <elf.h>
 #include <stdint.h>
@@ -225,5 +224,3 @@ using ElfInterface32 = ElfInterfaceImpl<ElfTypes32>;
 using ElfInterface64 = ElfInterfaceImpl<ElfTypes64>;
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_ELF_INTERFACE_H

--- a/third_party/libunwindstack/include/unwindstack/Error.h
+++ b/third_party/libunwindstack/include/unwindstack/Error.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_ERROR_H
-#define _LIBUNWINDSTACK_ERROR_H
+#pragma once
 
 #include <stdint.h>
 
@@ -91,5 +90,3 @@ struct ErrorData {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_ERROR_H

--- a/third_party/libunwindstack/include/unwindstack/Global.h
+++ b/third_party/libunwindstack/include/unwindstack/Global.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_GLOBAL_H
-#define _LIBUNWINDSTACK_GLOBAL_H
+#pragma once
 
 #include <stdint.h>
 
@@ -59,5 +58,3 @@ class Global {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_GLOBAL_H

--- a/third_party/libunwindstack/include/unwindstack/JitDebug.h
+++ b/third_party/libunwindstack/include/unwindstack/JitDebug.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_JIT_DEBUG_H
-#define _LIBUNWINDSTACK_JIT_DEBUG_H
+#pragma once
 
 #include <stdint.h>
 
@@ -36,5 +35,3 @@ std::unique_ptr<JitDebug> CreateJitDebug(ArchEnum arch, std::shared_ptr<Memory>&
                                          std::vector<std::string> search_libs = {});
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_JIT_DEBUG_H

--- a/third_party/libunwindstack/include/unwindstack/Log.h
+++ b/third_party/libunwindstack/include/unwindstack/Log.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_LOG_H
-#define _LIBUNWINDSTACK_LOG_H
+#pragma once
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -36,5 +35,3 @@ void AsyncSafe(const char* format, ...) __printflike(1, 2);
 }  // namespace Log
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_LOG_H

--- a/third_party/libunwindstack/include/unwindstack/MachineArm.h
+++ b/third_party/libunwindstack/include/unwindstack/MachineArm.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MACHINE_ARM_H
-#define _LIBUNWINDSTACK_MACHINE_ARM_H
+#pragma once
 
 #include <stdint.h>
 
@@ -46,5 +45,3 @@ enum ArmReg : uint16_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MACHINE_ARM_H

--- a/third_party/libunwindstack/include/unwindstack/MachineArm64.h
+++ b/third_party/libunwindstack/include/unwindstack/MachineArm64.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MACHINE_ARM64_H
-#define _LIBUNWINDSTACK_MACHINE_ARM64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -70,5 +69,3 @@ enum Arm64Reg : uint16_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MACHINE_ARM64_H

--- a/third_party/libunwindstack/include/unwindstack/MachineMips.h
+++ b/third_party/libunwindstack/include/unwindstack/MachineMips.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MACHINE_MIPS_H
-#define _LIBUNWINDSTACK_MACHINE_MIPS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -62,5 +61,3 @@ enum MipsReg : uint16_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MACHINE_MIPS_H

--- a/third_party/libunwindstack/include/unwindstack/MachineMips64.h
+++ b/third_party/libunwindstack/include/unwindstack/MachineMips64.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MACHINE_MIPS64_H
-#define _LIBUNWINDSTACK_MACHINE_MIPS64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -62,5 +61,3 @@ enum Mips64Reg : uint16_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MACHINE_MIPS64_H

--- a/third_party/libunwindstack/include/unwindstack/MachineX86.h
+++ b/third_party/libunwindstack/include/unwindstack/MachineX86.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MACHINE_X86_H
-#define _LIBUNWINDSTACK_MACHINE_X86_H
+#pragma once
 
 #include <stdint.h>
 
@@ -47,5 +46,3 @@ enum X86Reg : uint16_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MACHINE_X86_H

--- a/third_party/libunwindstack/include/unwindstack/MachineX86_64.h
+++ b/third_party/libunwindstack/include/unwindstack/MachineX86_64.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MACHINE_X86_64_H
-#define _LIBUNWINDSTACK_MACHINE_X86_64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -48,5 +47,3 @@ enum X86_64Reg : uint16_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MACHINE_X86_64_H

--- a/third_party/libunwindstack/include/unwindstack/MapInfo.h
+++ b/third_party/libunwindstack/include/unwindstack/MapInfo.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MAP_INFO_H
-#define _LIBUNWINDSTACK_MAP_INFO_H
+#pragma once
 
 #include <stdint.h>
 
@@ -248,5 +247,3 @@ class MapInfo {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MAP_INFO_H

--- a/third_party/libunwindstack/include/unwindstack/Maps.h
+++ b/third_party/libunwindstack/include/unwindstack/Maps.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MAPS_H
-#define _LIBUNWINDSTACK_MAPS_H
+#pragma once
 
 #include <pthread.h>
 #include <sys/types.h>
@@ -147,5 +146,3 @@ class FileMaps : public Maps {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MAPS_H

--- a/third_party/libunwindstack/include/unwindstack/Memory.h
+++ b/third_party/libunwindstack/include/unwindstack/Memory.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_MEMORY_H
-#define _LIBUNWINDSTACK_MEMORY_H
+#pragma once
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -71,5 +70,3 @@ class Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_MEMORY_H

--- a/third_party/libunwindstack/include/unwindstack/Object.h
+++ b/third_party/libunwindstack/include/unwindstack/Object.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_OBJECT_H
-#define _LIBUNWINDSTACK_OBJECT_H
+#pragma once
 
 #include <string>
 
@@ -89,5 +88,3 @@ class Object {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_OBJECT_H

--- a/third_party/libunwindstack/include/unwindstack/PeCoff.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoff.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_H
-#define _LIBUNWINDSTACK_PE_COFF_H
+#pragma once
 
 #include <string>
 
@@ -90,5 +89,3 @@ class PeCoff : public Object {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_OBJECT_H

--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_INTERFACE_H
-#define _LIBUNWINDSTACK_PE_COFF_INTERFACE_H
+#pragma once
 
 #include <array>
 #include <optional>
@@ -243,5 +242,3 @@ using PeCoffInterface32 = PeCoffInterfaceImpl<uint32_t>;
 using PeCoffInterface64 = PeCoffInterfaceImpl<uint64_t>;
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_PE_COFF_INTERFACE_H

--- a/third_party/libunwindstack/include/unwindstack/PeCoffNativeUnwinder.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffNativeUnwinder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_NATIVE_UNWINDER_H
-#define _LIBUNWINDSTACK_PE_COFF_NATIVE_UNWINDER_H
+#pragma once
 
 #include <unwindstack/Error.h>
 #include <unwindstack/Memory.h>
@@ -38,5 +37,3 @@ class PeCoffNativeUnwinder {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_PE_COFF_NATIVE_UNWINDER_H

--- a/third_party/libunwindstack/include/unwindstack/Regs.h
+++ b/third_party/libunwindstack/include/unwindstack/Regs.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_H
-#define _LIBUNWINDSTACK_REGS_H
+#pragma once
 
 #include <stdint.h>
 #include <unistd.h>
@@ -124,5 +123,3 @@ class RegsImpl : public Regs {
 uint64_t GetPcAdjustment(uint64_t rel_pc, Object* object, ArchEnum arch);
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_H

--- a/third_party/libunwindstack/include/unwindstack/RegsArm.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsArm.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_ARM_H
-#define _LIBUNWINDSTACK_REGS_ARM_H
+#pragma once
 
 #include <stdint.h>
 
@@ -56,5 +55,3 @@ class RegsArm : public RegsImpl<uint32_t> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_ARM_H

--- a/third_party/libunwindstack/include/unwindstack/RegsArm64.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsArm64.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_ARM64_H
-#define _LIBUNWINDSTACK_REGS_ARM64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -73,5 +72,3 @@ class RegsArm64 : public RegsImpl<uint64_t> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_ARM64_H

--- a/third_party/libunwindstack/include/unwindstack/RegsGetLocal.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsGetLocal.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_GET_LOCAL_H
-#define _LIBUNWINDSTACK_REGS_GET_LOCAL_H
+#pragma once
 
 namespace unwindstack {
 
@@ -91,7 +90,4 @@ inline __attribute__((__always_inline__)) void RegsGetLocal(Regs* regs) {
   AsmGetRegs(regs->RawData());
 }
 
-
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_GET_LOCAL_H

--- a/third_party/libunwindstack/include/unwindstack/RegsMips.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsMips.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_MIPS_H
-#define _LIBUNWINDSTACK_REGS_MIPS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -56,5 +55,3 @@ class RegsMips : public RegsImpl<uint32_t> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_MIPS_H

--- a/third_party/libunwindstack/include/unwindstack/RegsMips64.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsMips64.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_MIPS64_H
-#define _LIBUNWINDSTACK_REGS_MIPS64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -56,5 +55,3 @@ class RegsMips64 : public RegsImpl<uint64_t> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_MIPS64_H

--- a/third_party/libunwindstack/include/unwindstack/RegsX86.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsX86.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_X86_H
-#define _LIBUNWINDSTACK_REGS_X86_H
+#pragma once
 
 #include <stdint.h>
 
@@ -59,5 +58,3 @@ class RegsX86 : public RegsImpl<uint32_t> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_X86_H

--- a/third_party/libunwindstack/include/unwindstack/RegsX86_64.h
+++ b/third_party/libunwindstack/include/unwindstack/RegsX86_64.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_REGS_X86_64_H
-#define _LIBUNWINDSTACK_REGS_X86_64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -59,5 +58,3 @@ class RegsX86_64 : public RegsImpl<uint64_t> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_REGS_X86_64_H

--- a/third_party/libunwindstack/include/unwindstack/SharedString.h
+++ b/third_party/libunwindstack/include/unwindstack/SharedString.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_SHAREDSTRING_H
-#define _LIBUNWINDSTACK_SHAREDSTRING_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -73,4 +72,3 @@ static inline std::string operator+(const char* a, const SharedString& b) {
 }
 
 }  // namespace unwindstack
-#endif  // _LIBUNWINDSTACK_SHAREDSTRING_H

--- a/third_party/libunwindstack/include/unwindstack/UcontextArm.h
+++ b/third_party/libunwindstack/include/unwindstack/UcontextArm.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_UCONTEXT_ARM_H
-#define _LIBUNWINDSTACK_UCONTEXT_ARM_H
+#pragma once
 
 #include <stdint.h>
 
@@ -59,5 +58,3 @@ struct arm_ucontext_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UCONTEXT_ARM_H

--- a/third_party/libunwindstack/include/unwindstack/UcontextArm64.h
+++ b/third_party/libunwindstack/include/unwindstack/UcontextArm64.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_UCONTEXT_ARM64_H
-#define _LIBUNWINDSTACK_UCONTEXT_ARM64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -65,5 +64,3 @@ struct arm64_ucontext_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UCONTEXT_ARM64_H

--- a/third_party/libunwindstack/include/unwindstack/UcontextMips.h
+++ b/third_party/libunwindstack/include/unwindstack/UcontextMips.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_UCONTEXT_MIPS_H
-#define _LIBUNWINDSTACK_UCONTEXT_MIPS_H
+#pragma once
 
 #include <stdint.h>
 
@@ -58,5 +57,3 @@ struct mips_ucontext_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UCONTEXT_MIPS_H

--- a/third_party/libunwindstack/include/unwindstack/UcontextMips64.h
+++ b/third_party/libunwindstack/include/unwindstack/UcontextMips64.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_UCONTEXT_MIPS64_H
-#define _LIBUNWINDSTACK_UCONTEXT_MIPS64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -65,5 +64,3 @@ struct mips64_ucontext_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UCONTEXT_MIPS64_H

--- a/third_party/libunwindstack/include/unwindstack/UcontextX86.h
+++ b/third_party/libunwindstack/include/unwindstack/UcontextX86.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_UCONTEXT_X86_H
-#define _LIBUNWINDSTACK_UCONTEXT_X86_H
+#pragma once
 
 #include <stdint.h>
 
@@ -73,5 +72,3 @@ struct x86_ucontext_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UCONTEXT_X86_H

--- a/third_party/libunwindstack/include/unwindstack/UcontextX86_64.h
+++ b/third_party/libunwindstack/include/unwindstack/UcontextX86_64.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_UCONTEXT_X86_64_H
-#define _LIBUNWINDSTACK_UCONTEXT_X86_64_H
+#pragma once
 
 #include <stdint.h>
 
@@ -78,5 +77,3 @@ struct x86_64_ucontext_t {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UCONTEXT_X86_64_H

--- a/third_party/libunwindstack/include/unwindstack/Unwinder.h
+++ b/third_party/libunwindstack/include/unwindstack/Unwinder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UNWINDER_H
-#define _LIBUNWINDSTACK_UNWINDER_H
+#pragma once
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -202,5 +201,3 @@ class ThreadUnwinder : public UnwinderFromPid {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UNWINDER_H

--- a/third_party/libunwindstack/include/unwindstack/UserArm.h
+++ b/third_party/libunwindstack/include/unwindstack/UserArm.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_USER_ARM_H
-#define _LIBUNWINDSTACK_USER_ARM_H
+#pragma once
 
 namespace unwindstack {
 
@@ -36,5 +35,3 @@ struct arm_user_regs {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_USER_ARM_H

--- a/third_party/libunwindstack/include/unwindstack/UserArm64.h
+++ b/third_party/libunwindstack/include/unwindstack/UserArm64.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_USER_ARM64_H
-#define _LIBUNWINDSTACK_USER_ARM64_H
+#pragma once
 
 namespace unwindstack {
 
@@ -39,5 +38,3 @@ struct arm64_user_regs {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_USER_ARM64_H

--- a/third_party/libunwindstack/include/unwindstack/UserMips.h
+++ b/third_party/libunwindstack/include/unwindstack/UserMips.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_USER_MIPS_H
-#define _LIBUNWINDSTACK_USER_MIPS_H
+#pragma once
 
 namespace unwindstack {
 
@@ -41,5 +40,3 @@ struct mips_user_regs {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_USER_MIPS_H

--- a/third_party/libunwindstack/include/unwindstack/UserMips64.h
+++ b/third_party/libunwindstack/include/unwindstack/UserMips64.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_USER_MIPS64_H
-#define _LIBUNWINDSTACK_USER_MIPS64_H
+#pragma once
 
 namespace unwindstack {
 
@@ -41,5 +40,3 @@ struct mips64_user_regs {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_USER_MIPS64_H

--- a/third_party/libunwindstack/include/unwindstack/UserX86.h
+++ b/third_party/libunwindstack/include/unwindstack/UserX86.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_USER_X86_H
-#define _LIBUNWINDSTACK_USER_X86_H
+#pragma once
 
 namespace unwindstack {
 
@@ -52,5 +51,3 @@ struct x86_user_regs {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_USER_X86_H

--- a/third_party/libunwindstack/include/unwindstack/UserX86_64.h
+++ b/third_party/libunwindstack/include/unwindstack/UserX86_64.h
@@ -26,8 +26,7 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _LIBUNWINDSTACK_USER_X86_64_H
-#define _LIBUNWINDSTACK_USER_X86_64_H
+#pragma once
 
 namespace unwindstack {
 
@@ -62,5 +61,3 @@ struct x86_64_user_regs {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_USER_X86_64_H

--- a/third_party/libunwindstack/tests/DexFileData.h
+++ b/third_party/libunwindstack/tests/DexFileData.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_DEXFILESDATA_H
-#define _LIBUNWINDSTACK_DEXFILESDATA_H
+#pragma once
 
 namespace unwindstack {
 
@@ -41,5 +40,3 @@ static constexpr uint32_t kDexData[] = {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_DEXFILESDATA_H

--- a/third_party/libunwindstack/tests/DwarfOpTest.cpp
+++ b/third_party/libunwindstack/tests/DwarfOpTest.cpp
@@ -1298,7 +1298,7 @@ TYPED_TEST_P(DwarfOpTest, op_bra) {
   ASSERT_TRUE(this->op_->Decode());
   ASSERT_EQ(0x28, this->op_->cur_op());
   ASSERT_EQ(0U, this->op_->StackSize());
-  ASSERT_EQ(offset - 5, this->mem_->cur_offset());
+  ASSERT_EQ(offset, this->mem_->cur_offset());
 
   // Push on a non-zero value with a negative branch.
   this->mem_->set_cur_offset(offset);
@@ -1320,7 +1320,7 @@ TYPED_TEST_P(DwarfOpTest, op_bra) {
   ASSERT_TRUE(this->op_->Decode());
   ASSERT_EQ(0x28, this->op_->cur_op());
   ASSERT_EQ(0U, this->op_->StackSize());
-  ASSERT_EQ(offset + 16, this->mem_->cur_offset());
+  ASSERT_EQ(offset, this->mem_->cur_offset());
 }
 
 TYPED_TEST_P(DwarfOpTest, compare_opcode_stack_error) {

--- a/third_party/libunwindstack/tests/ElfFake.h
+++ b/third_party/libunwindstack/tests/ElfFake.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_TESTS_ELF_FAKE_H
-#define _LIBUNWINDSTACK_TESTS_ELF_FAKE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -152,5 +151,3 @@ class ElfInterfaceArmFake : public ElfInterfaceArm {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_TESTS_ELF_FAKE_H

--- a/third_party/libunwindstack/tests/ElfTestUtils.h
+++ b/third_party/libunwindstack/tests/ElfTestUtils.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_TESTS_ELF_TEST_UTILS_H
-#define _LIBUNWINDSTACK_TESTS_ELF_TEST_UTILS_H
+#pragma once
 
 #include <functional>
 #include <string>
@@ -34,5 +33,3 @@ void TestInitGnuDebugdata(uint32_t elf_class, uint32_t machine_type, bool init_g
 std::string TestGetFileDirectory();
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_TESTS_ELF_TEST_UTILS_H

--- a/third_party/libunwindstack/tests/LogFake.h
+++ b/third_party/libunwindstack/tests/LogFake.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_TESTS_LOG_FAKE_H
-#define _LIBUNWINDSTACK_TESTS_LOG_FAKE_H
+#pragma once
 
 #include <string>
 
@@ -26,5 +25,3 @@ std::string GetFakeLogBuf();
 std::string GetFakeLogPrint();
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_TESTS_LOG_FAKE_H

--- a/third_party/libunwindstack/tests/PeCoffFake.h
+++ b/third_party/libunwindstack/tests/PeCoffFake.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_PE_COFF_FAKE_H
-#define _LIBUNWINDSTACK_PE_COFF_FAKE_H
+#pragma once
 
 #include <MemoryBuffer.h>
 #include "utils/MemoryFake.h"
@@ -125,5 +124,3 @@ class PeCoffFake {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_PE_COFF_FAKE_H

--- a/third_party/libunwindstack/tests/TestUtils.h
+++ b/third_party/libunwindstack/tests/TestUtils.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_TESTS_TEST_UTILS_H
-#define _LIBUNWINDSTACK_TESTS_TEST_UTILS_H
+#pragma once
 
 #include <signal.h>
 #include <stdint.h>
@@ -48,5 +47,3 @@ static inline void DoNotOptimize(Tp const& value) {
 }
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_TESTS_TEST_UTILS_H

--- a/third_party/libunwindstack/tests/fuzz/UnwinderComponentCreator.h
+++ b/third_party/libunwindstack/tests/fuzz/UnwinderComponentCreator.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UNWINDERCOMPONENTCREATOR_H
-#define _LIBUNWINDSTACK_UNWINDERCOMPONENTCREATOR_H
+#pragma once
 
 #include <elf.h>
 #include <sys/mman.h>
@@ -81,4 +80,3 @@ std::unique_ptr<unwindstack::DexFiles> GetDexFiles(FuzzedDataProvider* data_prov
                                                    std::shared_ptr<unwindstack::Memory> memory,
                                                    uint max_libraries, uint max_library_length,
                                                    unwindstack::ArchEnum arch);
-#endif  // _LIBUNWINDSTACK_UNWINDERCOMPONENTCREATOR_H

--- a/third_party/libunwindstack/utils/DwarfSectionImplFake.h
+++ b/third_party/libunwindstack/utils/DwarfSectionImplFake.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UTILS_DWARF_SECTION_IMPL_FAKE_H
-#define _LIBUNWINDSTACK_UTILS_DWARF_SECTION_IMPL_FAKE_H
+#pragma once
 
 #include <unwindstack/DwarfSection.h>
 #include <unwindstack/Memory.h>
@@ -47,5 +46,3 @@ class DwarfSectionImplFake : public DwarfSectionImpl<TypeParam> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UTILS_DWARF_SECTION_IMPL_FAKE_H

--- a/third_party/libunwindstack/utils/MemoryFake.h
+++ b/third_party/libunwindstack/utils/MemoryFake.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UTILS_MEMORY_FAKE_H
-#define _LIBUNWINDSTACK_UTILS_MEMORY_FAKE_H
+#pragma once
 
 #include <stdint.h>
 #include <string.h>
@@ -79,5 +78,3 @@ class MemoryFakeAlwaysReadZero : public Memory {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UTILS_MEMORY_FAKE_H

--- a/third_party/libunwindstack/utils/OfflineUnwindUtils.h
+++ b/third_party/libunwindstack/utils/OfflineUnwindUtils.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UTILS_OFFLINE_UNWIND_UTILS_H
-#define _LIBUNWINDSTACK_UTILS_OFFLINE_UNWIND_UTILS_H
+#pragma once
 
 #include <cstddef>
 #include <filesystem>
@@ -187,5 +186,3 @@ class OfflineUnwindUtils {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UTILS_OFFLINE_UNWIND_UTILS_H

--- a/third_party/libunwindstack/utils/PidUtils.h
+++ b/third_party/libunwindstack/utils/PidUtils.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UTILS_PID_UTILS_H
-#define _LIBUNWINDSTACK_UTILS_PID_UTILS_H
+#pragma once
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -39,5 +38,3 @@ bool Detach(pid_t pid);
 bool RunWhenQuiesced(pid_t pid, bool leave_attached, std::function<PidRunEnum()> fn);
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UTILS_PID_UTILS_H

--- a/third_party/libunwindstack/utils/ProcessTracer.h
+++ b/third_party/libunwindstack/utils/ProcessTracer.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UTILS_PROCESS_TRACER_H
-#define _LIBUNWINDSTACK_UTILS_PROCESS_TRACER_H
+#pragma once
 
 #include <sys/types.h>
 
@@ -87,5 +86,3 @@ class ProcessTracer final {
   pid_t cur_attached_tid_ = kNoThreadAttached;
 };
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UTILS_PROCESS_TRACER_H

--- a/third_party/libunwindstack/utils/RegsFake.h
+++ b/third_party/libunwindstack/utils/RegsFake.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef _LIBUNWINDSTACK_UTILS_REGS_FAKE_H
-#define _LIBUNWINDSTACK_UTILS_REGS_FAKE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -115,5 +114,3 @@ class RegsImplFake : public RegsImpl<TypeParam> {
 };
 
 }  // namespace unwindstack
-
-#endif  // _LIBUNWINDSTACK_UTILS_REGS_FAKE_H


### PR DESCRIPTION
Simple cherry-picking of three commits up to
https://android.googlesource.com/platform/system/unwinding/+/c4e572564862727056090d9540641077238f2079.
But I'm also changing to use `#pragma once` also in the files we added for PE
unwinding.

Bug: http://b/238972027

Test: Build.