### PR TITLE
Add memory class for multiple stack slices

### DIFF
--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -29,6 +29,8 @@ target_sources(LinuxTracing PRIVATE
         LeafFunctionCallManager.cpp
         LibunwindstackMaps.cpp
         LibunwindstackMaps.h
+        LibunwindstackMultipleOfflineAndProcessMemory.cpp
+        LibunwindstackMultipleOfflineAndProcessMemory.h
         LibunwindstackUnwinder.cpp
         LibunwindstackUnwinder.h
         LinuxTracingUtils.h
@@ -77,6 +79,7 @@ target_sources(LinuxTracingTests PRIVATE
         GpuTracepointVisitorTest.cpp
         LeafFunctionCallManagerTest.cpp
         LibunwindstackMapsTest.cpp
+        LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
         LibunwindstackUnwinderTest.cpp
         LinuxTracingUtilsTest.cpp
         LostAndDiscardedEventVisitorTest.cpp

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
@@ -44,7 +44,7 @@ size_t LibunwindstackMultipleOfflineAndProcessMemory::Read(uint64_t addr, void* 
   return 0;
 }
 
-std::vector<LibunwindstackOfflineMemory>
+std::vector<LibunwindstackMultipleOfflineAndProcessMemory::LibunwindstackOfflineMemory>
 LibunwindstackMultipleOfflineAndProcessMemory::CreateOfflineStackMemories(
     const std::vector<StackSliceView>& stack_slices) {
   std::vector<LibunwindstackOfflineMemory> stack_memories{};

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "LibunwindstackMultipleOfflineAndProcessMemory.h"
+
+#include <absl/base/casts.h>
+
+namespace orbit_linux_tracing {
+size_t LibunwindstackMultipleOfflineAndProcessMemory::Read(uint64_t addr, void* dst, size_t size) {
+  const uint64_t addr_start = addr;
+  const uint64_t addr_end = addr + size;
+
+  bool found_overlap = false;
+
+  // If the requested address range is entirely in the stack sample's address range, read from the
+  // stack buffer.
+  for (LibunwindstackOfflineMemory& stack_slice : stack_memory_slices_) {
+    if (addr_start >= stack_slice.start_address() && addr_end <= stack_slice.end_address()) {
+      return stack_slice.Read(addr, dst, size);
+    }
+
+    // If the requested address range is overlapping with the stack slice, something went wrong.
+    // However, there could be another stack slice that entirely contains the requested address
+    // range later, so don't give up already.
+    if (addr_start >= stack_slice.start_address() || addr_end <= stack_slice.end_address()) {
+      found_overlap = true;
+    }
+  }
+
+  // The requested address range is overlapping with at least one stack slice, but we don't have
+  // the offline memory for the complete range. Something went wrong, so don't read any data.
+  if (found_overlap) {
+    return 0;
+  }
+
+  // If the requested range is entirely disjoint from the stack slices' address range read from
+  // the memory of the process.
+  if (process_memory_ != nullptr) {
+    return process_memory_->Read(addr, dst, size);
+  }
+
+  return 0;
+}
+
+std::vector<LibunwindstackOfflineMemory>
+LibunwindstackMultipleOfflineAndProcessMemory::CreateOfflineMemorySlices(
+    const std::vector<StackSliceView>& stack_slices) {
+  std::vector<LibunwindstackOfflineMemory> stack_memory_slices{};
+  stack_memory_slices.reserve(stack_slices.size());
+  for (const StackSliceView& stack_slice_view : stack_slices) {
+    stack_memory_slices.emplace_back(stack_slice_view);
+  }
+  return stack_memory_slices;
+}
+}  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
@@ -64,6 +64,7 @@ LibunwindstackMultipleOfflineAndProcessMemory::CreateWithProcessMemory(
       new LibunwindstackMultipleOfflineAndProcessMemory(
           unwindstack::Memory::CreateProcessMemoryCached(pid), std::move(stack_memories)));
 }
+
 std::shared_ptr<unwindstack::Memory>
 LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory(
     const std::vector<StackSliceView>& stack_slices) {

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.h
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LINUX_TRACING_LIBUNWINDSTACK_MULTIPLE_OFFLINE_AND_PROCESS_MEMORY_H_
+#define LINUX_TRACING_LIBUNWINDSTACK_MULTIPLE_OFFLINE_AND_PROCESS_MEMORY_H_
+
+#include <absl/base/casts.h>
+#include <unwindstack/Memory.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_linux_tracing {
+
+// This class is a "view" of a stack slice (some copy of process memory). It contains a bare pointer
+// to the array that actually owns the stack data.
+class StackSliceView {
+ public:
+  StackSliceView(uint64_t start_address, uint64_t size, const char* data)
+      : start_address_{start_address}, size_{size}, data_{data} {}
+
+  [[nodiscard]] uint64_t start_address() const { return start_address_; }
+  [[nodiscard]] uint64_t end_address() const { return start_address_ + size_; }
+  [[nodiscard]] uint64_t size() const { return size_; }
+  [[nodiscard]] const char* data() const { return data_; }
+
+ private:
+  uint64_t start_address_;
+  uint64_t size_;
+  const char* data_;
+};
+
+// This class is a thin layer around unwindstack::MemoryOfflineBuffer, that allows querying address
+// and size of the underlying offline memory as well as specifying the memory region as
+// `StackSliceView`.
+class LibunwindstackOfflineMemory : public unwindstack::Memory {
+ public:
+  LibunwindstackOfflineMemory(StackSliceView stack_slice_view)
+      : stack_slice_view_{stack_slice_view},
+        memory_{unwindstack::Memory::CreateOfflineMemory(
+            absl::bit_cast<const uint8_t*>(stack_slice_view.data()),
+            stack_slice_view.start_address(), stack_slice_view.end_address())} {};
+  size_t Read(uint64_t addr, void* dst, size_t size) override {
+    return memory_->Read(addr, dst, size);
+  }
+
+  [[nodiscard]] virtual uint64_t start_address() const { return stack_slice_view_.start_address(); }
+  [[nodiscard]] virtual uint64_t end_address() const { return stack_slice_view_.end_address(); }
+  [[nodiscard]] virtual uint64_t size() const { return stack_slice_view_.size(); }
+
+ private:
+  StackSliceView stack_slice_view_;
+  std::shared_ptr<unwindstack::Memory> memory_;
+};
+
+// This custom implementation of `unwindstack::Memory` carries multiple stack slices, each same as
+// `CreateOfflineMemory` would. When requesting to read an address range, the class will go through
+// the stack slices and if one slice fully contains the requested address range it will read from
+// this stack slice. When requesting an address range outside any of the stack samples,
+// the class falls back to reading from the memory of the process online, as `CreateProcessMemory`
+// would.
+// If the process memory is not specified, the fall back to reading process memory will not be done.
+// Having multiple stack slices allows unwinding callstacks that have multiple stacks involved, such
+// as in the case of Wine system calls.
+// The process memory allows unwinding callstacks that involve virtual modules, such as vDSO.
+class LibunwindstackMultipleOfflineAndProcessMemory : public unwindstack::Memory {
+ public:
+  size_t Read(uint64_t addr, void* dst, size_t size) override;
+
+  LibunwindstackMultipleOfflineAndProcessMemory(
+      std::shared_ptr<Memory> process_memory,
+      std::vector<LibunwindstackOfflineMemory> stack_memory_slices)
+      : process_memory_{std::move(process_memory)},
+        stack_memory_slices_{std::move(std::move(stack_memory_slices))} {}
+
+  static std::shared_ptr<Memory> Create(pid_t pid,
+                                        const std::vector<StackSliceView>& stack_slices) {
+    std::vector<LibunwindstackOfflineMemory> stack_memory_slices =
+        CreateOfflineMemorySlices(stack_slices);
+    return std::make_shared<LibunwindstackMultipleOfflineAndProcessMemory>(
+        unwindstack::Memory::CreateProcessMemoryCached(pid), std::move(stack_memory_slices));
+  }
+
+  static std::shared_ptr<Memory> Create(const std::vector<StackSliceView>& stack_slices) {
+    std::vector<LibunwindstackOfflineMemory> stack_memory_slices =
+        CreateOfflineMemorySlices(stack_slices);
+    return std::make_shared<LibunwindstackMultipleOfflineAndProcessMemory>(
+        nullptr, std::move(stack_memory_slices));
+  }
+
+ private:
+  static std::vector<LibunwindstackOfflineMemory> CreateOfflineMemorySlices(
+      const std::vector<StackSliceView>& stack_slices);
+
+  std::shared_ptr<Memory> process_memory_;
+  std::vector<LibunwindstackOfflineMemory> stack_memory_slices_;
+};
+
+}  // namespace orbit_linux_tracing
+
+#endif  // LINUX_TRACING_LIBUNWINDSTACK_MULTIPLE_OFFLINE_AND_PROCESS_MEMORY_H_

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
@@ -8,8 +8,6 @@
 #include "LibunwindstackMultipleOfflineAndProcessMemory.h"
 #include "OrbitBase/ThreadUtils.h"
 
-using ::testing::Invoke;
-
 namespace orbit_linux_tracing {
 
 TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromOneStackSlice) {
@@ -142,13 +140,6 @@ TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromTestProcess) {
   constexpr uint64_t kStartAddress2 = 0xABCDEF;
   std::vector<char> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
   StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
-
-  std::vector<StackSliceView> stack_slices{stack_slice1, stack_slice2};
-  std::vector<LibunwindstackOfflineMemory> stack_memories{};
-  stack_memories.reserve(stack_slices.size());
-  for (const StackSliceView& stack_slice_view : stack_slices) {
-    stack_memories.emplace_back(stack_slice_view);
-  }
 
   std::vector<char> bytes3{0x09, 0x08, 0x07, 0x06, 0x05};
 

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
@@ -1,0 +1,184 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "LibunwindstackMultipleOfflineAndProcessMemory.h"
+
+using ::testing::Invoke;
+
+namespace orbit_linux_tracing {
+
+namespace {
+class MockProcessMemory : public unwindstack::Memory {
+ public:
+  MOCK_METHOD(size_t, Read, (uint64_t, void*, size_t), (override));
+};
+}  // namespace
+
+TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromOneStackSlice) {
+  constexpr uint64_t kStartAddress = 0xADD8E55;
+  std::vector<char> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
+  StackSliceView stack_slice(kStartAddress, bytes.size(), bytes.data());
+
+  std::shared_ptr<unwindstack::Memory> sut =
+      LibunwindstackMultipleOfflineAndProcessMemory::Create({stack_slice});
+
+  std::array<char, 3> destination{};
+  size_t count_written = sut->Read(kStartAddress + 2, destination.data(), 3);
+
+  ASSERT_EQ(count_written, 3);
+  ASSERT_EQ(destination.size(), 3);
+  EXPECT_EQ(destination[0], 0x20);
+  EXPECT_EQ(destination[1], 0x30);
+  EXPECT_EQ(destination[2], 0x40);
+}
+
+TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromFirstMatchingStackSlice) {
+  constexpr uint64_t kStartAddress1 = 0xADD8E55;
+  std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
+  StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());
+
+  constexpr uint64_t kStartAddress2 = kStartAddress1 + 1;
+  std::vector<char> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
+  StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
+
+  std::shared_ptr<unwindstack::Memory> sut =
+      LibunwindstackMultipleOfflineAndProcessMemory::Create({stack_slice1, stack_slice2});
+
+  std::array<char, 3> destination{};
+  size_t count_written = sut->Read(kStartAddress1 + 2, destination.data(), 3);
+
+  ASSERT_EQ(count_written, 3);
+  ASSERT_EQ(destination.size(), 3);
+  EXPECT_EQ(destination[0], 0x20);
+  EXPECT_EQ(destination[1], 0x30);
+  EXPECT_EQ(destination[2], 0x40);
+}
+
+TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromSecondStackSlice) {
+  constexpr uint64_t kStartAddress1 = 0xADD8E55;
+  std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
+  StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());
+
+  constexpr uint64_t kStartAddress2 = 0xBADADD;
+  std::vector<char> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
+  StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
+
+  std::shared_ptr<unwindstack::Memory> sut =
+      LibunwindstackMultipleOfflineAndProcessMemory::Create({stack_slice1, stack_slice2});
+
+  std::array<char, 3> destination{};
+  size_t count_written = sut->Read(kStartAddress2 + 2, destination.data(), 3);
+
+  ASSERT_EQ(count_written, 3);
+  ASSERT_EQ(destination.size(), 3);
+  EXPECT_EQ(destination[0], 0x13);
+  EXPECT_EQ(destination[1], 0x14);
+  EXPECT_EQ(destination[2], 0x15);
+}
+
+TEST(LibunwindstackMultipleOfflineAndProcessMemory, RequestingToReadWithOverlapReturnsZero) {
+  constexpr uint64_t kStartAddress = 0xADD8E55;
+  std::vector<char> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
+  StackSliceView stack_slice(kStartAddress, bytes.size(), bytes.data());
+
+  std::shared_ptr<unwindstack::Memory> sut =
+      LibunwindstackMultipleOfflineAndProcessMemory::Create({stack_slice});
+
+  std::array<char, 3> destination{};
+  destination.fill(0x11);
+  size_t count_written = sut->Read(kStartAddress - 1, destination.data(), 3);
+
+  ASSERT_EQ(count_written, 0);
+  ASSERT_EQ(destination.size(), 3);
+  EXPECT_EQ(destination[0], 0x11);
+  EXPECT_EQ(destination[1], 0x11);
+  EXPECT_EQ(destination[2], 0x11);
+}
+
+TEST(LibunwindstackMultipleOfflineAndProcessMemory,
+     RequestingToReadUnknownMemoryWithoutProcessReturnsZero) {
+  constexpr uint64_t kStartAddress = 0xADD8E55;
+  std::vector<char> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
+  StackSliceView stack_slice(kStartAddress, bytes.size(), bytes.data());
+
+  std::shared_ptr<unwindstack::Memory> sut =
+      LibunwindstackMultipleOfflineAndProcessMemory::Create({stack_slice});
+
+  std::array<char, 3> destination{};
+  destination.fill(0x11);
+  size_t count_written = sut->Read(0xFE, destination.data(), 3);
+
+  ASSERT_EQ(count_written, 0);
+  ASSERT_EQ(destination.size(), 3);
+  EXPECT_EQ(destination[0], 0x11);
+  EXPECT_EQ(destination[1], 0x11);
+  EXPECT_EQ(destination[2], 0x11);
+}
+
+TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromCompleteMemoryEvenIfOverlapsWithOtherStackSlice) {
+  constexpr uint64_t kStartAddress1 = 0xADD8E55;
+  std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
+  StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());
+
+  constexpr uint64_t kStartAddress2 = kStartAddress1 + 2;
+  std::vector<char> bytes2{0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x77};
+  StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
+
+  std::shared_ptr<unwindstack::Memory> sut =
+      LibunwindstackMultipleOfflineAndProcessMemory::Create({stack_slice1, stack_slice2});
+
+  std::array<char, 3> destination{};
+  size_t count_written = sut->Read(kStartAddress2, destination.data(), 3);
+
+  ASSERT_EQ(count_written, 3);
+  ASSERT_EQ(destination.size(), 3);
+  EXPECT_EQ(destination[0], 0x20);
+  EXPECT_EQ(destination[1], 0x30);
+  EXPECT_EQ(destination[2], 0x40);
+}
+
+TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromProcess) {
+  std::vector<StackSliceView> stack_slices{};
+  constexpr uint64_t kStartAddress1 = 0xADD8E55;
+  std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
+  StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());
+
+  constexpr uint64_t kStartAddress2 = 0xBADADD;
+  std::vector<char> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
+  StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
+
+  std::vector<LibunwindstackOfflineMemory> stack_memory_slices{};
+  stack_memory_slices.reserve(stack_slices.size());
+  for (const StackSliceView& stack_slice_view : stack_slices) {
+    stack_memory_slices.emplace_back(stack_slice_view);
+  }
+
+  std::shared_ptr<MockProcessMemory> process_memory_mock = std::make_shared<MockProcessMemory>();
+  LibunwindstackMultipleOfflineAndProcessMemory sut{process_memory_mock,
+                                                    std::move(stack_memory_slices)};
+
+  std::array<char, 3> destination{};
+  EXPECT_CALL(*process_memory_mock, Read(0xFE, destination.data(), 3))
+      .Times(1)
+      .WillOnce(Invoke([](uint64_t /*addr*/, void* dst, size_t /*size*/) -> size_t {
+        auto destination = absl::bit_cast<char*>(dst);
+        destination[0] = 0x11;
+        destination[1] = 0x22;
+        destination[2] = 0x33;
+        return 3;
+      }));
+
+  size_t count_written = sut.Read(0xFE, destination.data(), 3);
+
+  ASSERT_EQ(count_written, 3);
+  ASSERT_EQ(destination.size(), 3);
+  EXPECT_EQ(destination[0], 0x11);
+  EXPECT_EQ(destination[1], 0x22);
+  EXPECT_EQ(destination[2], 0x33);
+}
+
+}  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
@@ -119,7 +119,8 @@ TEST(LibunwindstackMultipleOfflineAndProcessMemory,
   EXPECT_EQ(destination[2], 0x11);
 }
 
-TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromCompleteMemoryEvenIfOverlapsWithOtherStackSlice) {
+TEST(LibunwindstackMultipleOfflineAndProcessMemory,
+     ReadFromCompleteMemoryEvenIfOverlapsWithOtherStackSlice) {
   constexpr uint64_t kStartAddress1 = 0xADD8E55;
   std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
   StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -20,8 +20,8 @@
 #include <utility>
 #include <vector>
 
-#include "OrbitBase/Result.h"
 #include "LibunwindstackMultipleOfflineAndProcessMemory.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_linux_tracing {
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -21,26 +21,9 @@
 #include <vector>
 
 #include "OrbitBase/Result.h"
+#include "LibunwindstackMultipleOfflineAndProcessMemory.h"
 
 namespace orbit_linux_tracing {
-
-// This class is a "view" of a stack slice (some copy of process memory). It contains a bare pointer
-// to the array that actually owns the stack data.
-class StackSliceView {
- public:
-  StackSliceView(uint64_t start_address, uint64_t size, const char* data)
-      : start_address_{start_address}, size_{size}, data_{data} {}
-
-  [[nodiscard]] uint64_t start_address() const { return start_address_; }
-  [[nodiscard]] uint64_t end_address() const { return start_address_ + size_; }
-  [[nodiscard]] uint64_t size() const { return size_; }
-  [[nodiscard]] const char* data() const { return data_; }
-
- private:
-  uint64_t start_address_;
-  uint64_t size_;
-  const char* data_;
-};
 
 class LibunwindstackResult {
  public:


### PR DESCRIPTION
This adds an implementation of libunwindstack's memory class
that supports offline memory from multiple stack slices.

Test: Unit Test
Bug: http://b/236118579