### PR TITLE
Deprecate unsafe paths

### DIFF
--- a/src/CaptureFileInfo/LoadCaptureWidget.cpp
+++ b/src/CaptureFileInfo/LoadCaptureWidget.cpp
@@ -30,7 +30,7 @@ LoadCaptureWidget::LoadCaptureWidget(QWidget* parent)
   Manager manager;
 
   if (manager.GetCaptureFileInfos().empty()) {
-    (void)manager.FillFromDirectory(orbit_paths::CreateOrGetCaptureDir());
+    (void)manager.FillFromDirectory(orbit_paths::CreateOrGetCaptureDirUnsafe());
   }
 
   item_model_.SetCaptureFileInfos(manager.GetCaptureFileInfos());
@@ -117,9 +117,9 @@ void LoadCaptureWidget::showEvent(QShowEvent* event) {
 }
 
 void LoadCaptureWidget::SelectViaFilePicker() {
-  QFileDialog file_picker(this, "Open Capture...",
-                          QString::fromStdString(orbit_paths::CreateOrGetCaptureDir().string()),
-                          "*.orbit");
+  QFileDialog file_picker(
+      this, "Open Capture...",
+      QString::fromStdString(orbit_paths::CreateOrGetCaptureDirUnsafe().string()), "*.orbit");
   file_picker.setFileMode(QFileDialog::ExistingFile);
   file_picker.setLabelText(QFileDialog::Accept, "Start Session");
 

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -108,7 +108,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
   void LoadSymbols(orbit_client_data::ModuleData& module_data);
 
   std::unique_ptr<orbit_client_data::ModuleManager> module_manager_;
-  orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDir()};
+  orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDirUnsafe()};
 };
 
 }  // namespace orbit_mizar_data

--- a/src/MoveFilesToDocuments/MoveFilesProcess.cpp
+++ b/src/MoveFilesToDocuments/MoveFilesProcess.cpp
@@ -83,10 +83,10 @@ void MoveFilesProcess::TryMoveFilesAndRemoveDirIfNeeded(const std::filesystem::p
 
 void MoveFilesProcess::Run() {
   ORBIT_CHECK(QThread::currentThread() == thread());
-  TryMoveFilesAndRemoveDirIfNeeded(orbit_paths::GetPresetDirPriorTo1_66(),
-                                   orbit_paths::CreateOrGetPresetDir());
-  TryMoveFilesAndRemoveDirIfNeeded(orbit_paths::GetCaptureDirPriorTo1_66(),
-                                   orbit_paths::CreateOrGetCaptureDir());
+  TryMoveFilesAndRemoveDirIfNeeded(orbit_paths::GetPresetDirPriorTo1_66Unsafe(),
+                                   orbit_paths::CreateOrGetPresetDirUnsafe());
+  TryMoveFilesAndRemoveDirIfNeeded(orbit_paths::GetCaptureDirPriorTo1_66Unsafe(),
+                                   orbit_paths::CreateOrGetCaptureDirUnsafe());
   if (interruption_requested_) {
     emit processInterrupted();
   } else {

--- a/src/MoveFilesToDocuments/MoveFilesToDocuments.cpp
+++ b/src/MoveFilesToDocuments/MoveFilesToDocuments.cpp
@@ -46,8 +46,8 @@ void TryMoveSavedDataLocationIfNeeded() {
     return;
   }
 
-  if (IsDirectoryEmpty(orbit_paths::GetPresetDirPriorTo1_66()) &&
-      IsDirectoryEmpty(orbit_paths::GetCaptureDirPriorTo1_66())) {
+  if (IsDirectoryEmpty(orbit_paths::GetPresetDirPriorTo1_66Unsafe()) &&
+      IsDirectoryEmpty(orbit_paths::GetCaptureDirPriorTo1_66Unsafe())) {
     return;
   }
 

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -235,12 +235,12 @@ int main(int argc, char* argv[]) {
   // Skip program name in positional_args[0].
   std::vector<std::string> capture_file_paths(positional_args.begin() + 1, positional_args.end());
 
-  std::filesystem::path log_file{orbit_paths::GetLogFilePath()};
+  std::filesystem::path log_file{orbit_paths::GetLogFilePathUnsafe()};
   orbit_base::InitLogFile(log_file);
   ORBIT_LOG("You are running Orbit Profiler version %s", orbit_version::GetVersionString());
   LogCommandLine(argc, argv);
   ErrorMessageOr<void> remove_old_log_result =
-      orbit_base::TryRemoveOldLogFiles(orbit_paths::CreateOrGetLogDir());
+      orbit_base::TryRemoveOldLogFiles(orbit_paths::CreateOrGetLogDirUnsafe());
   if (remove_old_log_result.has_error()) {
     ORBIT_LOG("Warning: Unable to remove some old log files:\n%s",
               remove_old_log_result.error().message());
@@ -272,7 +272,7 @@ int main(int argc, char* argv[]) {
 
   auto crash_handler = std::make_unique<orbit_base::CrashHandler>();
 #ifdef ORBIT_CRASH_HANDLING
-  const std::string dump_path = orbit_paths::CreateOrGetDumpDir().string();
+  const std::string dump_path = orbit_paths::CreateOrGetDumpDirUnsafe().string();
 #ifdef _WIN32
   const char* handler_name = "crashpad_handler.exe";
 #else

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -867,7 +867,7 @@ static std::vector<std::filesystem::path> ListRegularFilesWithExtension(
 
 void OrbitApp::ListPresets() {
   std::vector<std::filesystem::path> preset_filenames =
-      ListRegularFilesWithExtension(orbit_paths::CreateOrGetPresetDir(), ".opr");
+      ListRegularFilesWithExtension(orbit_paths::CreateOrGetPresetDirUnsafe(), ".opr");
   std::vector<PresetFile> presets;
   for (const std::filesystem::path& filename : preset_filenames) {
     ErrorMessageOr<PresetFile> preset_result = ReadPresetFromFile(filename);
@@ -1278,7 +1278,7 @@ ErrorMessageOr<void> OrbitApp::SavePreset(const std::string& filename) {
 
 ErrorMessageOr<PresetFile> OrbitApp::ReadPresetFromFile(const std::filesystem::path& filename) {
   std::filesystem::path file_path =
-      filename.is_absolute() ? filename : orbit_paths::CreateOrGetPresetDir() / filename;
+      filename.is_absolute() ? filename : orbit_paths::CreateOrGetPresetDirUnsafe() / filename;
 
   return orbit_preset_file::ReadPresetFromFile(file_path);
 }
@@ -1383,7 +1383,7 @@ static std::unique_ptr<CaptureEventProcessor> CreateCaptureEventProcessor(
     CaptureListener* listener, const std::string& process_name,
     absl::flat_hash_set<uint64_t> frame_track_function_ids,
     const std::function<void(const ErrorMessage&)>& error_handler) {
-  std::filesystem::path file_path = orbit_paths::CreateOrGetCaptureDir() /
+  std::filesystem::path file_path = orbit_paths::CreateOrGetCaptureDirUnsafe() /
                                     orbit_client_model::capture_serializer::GenerateCaptureFileName(
                                         process_name, absl::Now(), "_autosave");
 
@@ -1401,7 +1401,7 @@ static std::unique_ptr<CaptureEventProcessor> CreateCaptureEventProcessor(
     }
 
     std::string suffix = absl::StrFormat("_autosave(%d)", ++suffix_number);
-    file_path = orbit_paths::CreateOrGetCaptureDir() /
+    file_path = orbit_paths::CreateOrGetCaptureDirUnsafe() /
                 orbit_client_model::capture_serializer::GenerateCaptureFileName(
                     process_name, absl::Now(), suffix);
   }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -704,7 +704,7 @@ class OrbitApp final : public DataViewFactory,
   std::unique_ptr<orbit_client_services::CrashManager> crash_manager_;
   std::unique_ptr<ManualInstrumentationManager> manual_instrumentation_manager_;
 
-  const orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDir()};
+  const orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDirUnsafe()};
 
   std::weak_ptr<StatusListener> status_listener_;
 

--- a/src/OrbitPaths/CMakeLists.txt
+++ b/src/OrbitPaths/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(OrbitPathsTests PRIVATE
 
 target_link_libraries(OrbitPathsTests PRIVATE
         OrbitPaths
+        TestUtils
         GTest::Main)
 
 register_test(OrbitPathsTests)

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -114,7 +114,17 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe() {
 
 std::filesystem::path GetPresetDirPriorTo1_66() { return CreateOrGetOrbitAppDataDir() / "presets"; }
 
+ErrorMessageOr<std::filesystem::path> GetPresetDirPriorTo1_66Safe() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+  return app_data_dir / "presets";
+}
+
 std::filesystem::path GetCaptureDirPriorTo1_66() { return CreateOrGetOrbitAppDataDir() / "output"; }
+
+ErrorMessageOr<std::filesystem::path> GetCaptureDirPriorTo1_66Safe() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+  return app_data_dir / "output";
+}
 
 std::filesystem::path CreateOrGetPresetDir() {
   std::filesystem::path preset_dir = CreateOrGetOrbitUserDataDir() / kPresetsFolderName;

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -85,8 +85,6 @@ std::filesystem::path CreateOrGetCacheDir() {
   return cache_dir;
 }
 
-ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe() {}
-
 std::filesystem::path GetPresetDirPriorTo1_66() { return CreateOrGetOrbitAppDataDir() / "presets"; }
 
 std::filesystem::path GetCaptureDirPriorTo1_66() { return CreateOrGetOrbitAppDataDir() / "output"; }
@@ -123,13 +121,24 @@ std::filesystem::path CreateOrGetDumpDir() {
   return capture_dir;
 }
 
-std::filesystem::path CreateOrGetOrbitAppDataDir() {
+static std::filesystem::path GetOrbitAppDataDir() {
 #ifdef _WIN32
   std::filesystem::path path = std::filesystem::path(GetEnvVar("APPDATA")) / "OrbitProfiler";
 #else
   std::filesystem::path path = std::filesystem::path(GetEnvVar("HOME")) / ".orbitprofiler";
 #endif
+  return path;
+}
+
+std::filesystem::path CreateOrGetOrbitAppDataDir() {
+  std::filesystem::path path = GetOrbitAppDataDir();
   CreateDirectoryOrDie(path);
+  return path;
+}
+
+ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDirSafe() {
+  std::filesystem::path path = GetOrbitAppDataDir();
+  OUTCOME_TRY(CreateDirectoryIfNecessary(path));
   return path;
 }
 

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -26,7 +26,7 @@
 
 ABSL_FLAG(std::string, log_dir, "", "Set directory for the log.");
 
-constexpr std::string_view kOrbitFolderName{"Orbit"};
+constexpr std::string_view kOrbitFolderInDocumentsName{"Orbit"};
 constexpr std::string_view kCapturesFolderName{"captures"};
 constexpr std::string_view kPresetsFolderName{"presets"};
 constexpr std::string_view kCacheFolderName{"cache"};
@@ -59,7 +59,8 @@ static std::string GetEnvVar(const char* variable_name) {
 // Attempts to create a directory if it doesn't exist. Returns success if the creation was
 // successful or it already existed. If an error occurs its logged and returned. The difference to
 // orbit_base::CreateDirectories is the return type and logging.
-static ErrorMessageOr<void> CreateDirectory(const std::filesystem::path& directory) {
+static ErrorMessageOr<void> CreateDirectoryIfItDoesNotExist(
+    const std::filesystem::path& directory) {
   ErrorMessageOr<bool> created_or_error = orbit_base::CreateDirectories(directory);
   if (created_or_error.has_error()) {
     std::string error_message =
@@ -80,94 +81,94 @@ static void CreateDirectoryOrDie(const std::filesystem::path& directory) {
 }
 
 static std::filesystem::path CreateAndGetConfigPath() {
-  std::filesystem::path config_dir = CreateOrGetOrbitAppDataDir() / kConfigFolderName;
+  std::filesystem::path config_dir = CreateOrGetOrbitAppDataDirUnsafe() / kConfigFolderName;
   CreateDirectoryOrDie(config_dir);
   return config_dir;
 }
 
 static ErrorMessageOr<std::filesystem::path> CreateAndGetConfigPathSafe() {
-  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
   std::filesystem::path config_dir = app_data_dir / kConfigFolderName;
-  OUTCOME_TRY(CreateDirectory(config_dir));
+  OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(config_dir));
   return config_dir;
 }
 
-std::filesystem::path GetSymbolsFilePath() {
+std::filesystem::path GetSymbolsFilePathUnsafe() {
   return CreateAndGetConfigPath() / kSymbolPathsFileName;
 }
 
-ErrorMessageOr<std::filesystem::path> GetSymbolsFilePathSafe() {
+ErrorMessageOr<std::filesystem::path> GetSymbolsFilePath() {
   OUTCOME_TRY(std::filesystem::path config_dir, CreateAndGetConfigPathSafe());
   return config_dir / kSymbolPathsFileName;
 }
 
-std::filesystem::path CreateOrGetCacheDir() {
-  std::filesystem::path cache_dir = CreateOrGetOrbitAppDataDir() / kCacheFolderName;
+std::filesystem::path CreateOrGetCacheDirUnsafe() {
+  std::filesystem::path cache_dir = CreateOrGetOrbitAppDataDirUnsafe() / kCacheFolderName;
   CreateDirectoryOrDie(cache_dir);
   return cache_dir;
 }
 
-ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe() {
-  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDir() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
   std::filesystem::path cache_dir = app_data_dir / kCacheFolderName;
-  OUTCOME_TRY(CreateDirectory(cache_dir));
+  OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(cache_dir));
   return cache_dir;
 }
 
-std::filesystem::path GetPresetDirPriorTo1_66() {
-  return CreateOrGetOrbitAppDataDir() / kPresetsFolderName;
+std::filesystem::path GetPresetDirPriorTo1_66Unsafe() {
+  return CreateOrGetOrbitAppDataDirUnsafe() / kPresetsFolderName;
 }
 
-ErrorMessageOr<std::filesystem::path> GetPresetDirPriorTo1_66Safe() {
-  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+ErrorMessageOr<std::filesystem::path> GetPresetDirPriorTo1_66() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
   return app_data_dir / kPresetsFolderName;
 }
 
-std::filesystem::path GetCaptureDirPriorTo1_66() {
-  return CreateOrGetOrbitAppDataDir() / kOutputFolderName;
+std::filesystem::path GetCaptureDirPriorTo1_66Unsafe() {
+  return CreateOrGetOrbitAppDataDirUnsafe() / kOutputFolderName;
 }
 
-ErrorMessageOr<std::filesystem::path> GetCaptureDirPriorTo1_66Safe() {
-  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+ErrorMessageOr<std::filesystem::path> GetCaptureDirPriorTo1_66() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
   return app_data_dir / kOutputFolderName;
 }
 
-std::filesystem::path CreateOrGetPresetDir() {
-  std::filesystem::path preset_dir = CreateOrGetOrbitUserDataDir() / kPresetsFolderName;
+std::filesystem::path CreateOrGetPresetDirUnsafe() {
+  std::filesystem::path preset_dir = CreateOrGetOrbitUserDataDirUnsafe() / kPresetsFolderName;
   CreateDirectoryOrDie(preset_dir);
   return preset_dir;
 }
 
-ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDirSafe() {
-  OUTCOME_TRY(std::filesystem::path user_data_dir, CreateOrGetOrbitUserDataDirSafe());
+ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDir() {
+  OUTCOME_TRY(std::filesystem::path user_data_dir, CreateOrGetOrbitUserDataDir());
   std::filesystem::path preset_dir = user_data_dir / kPresetsFolderName;
-  OUTCOME_TRY(CreateDirectory(preset_dir));
+  OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(preset_dir));
   return preset_dir;
 }
 
-std::filesystem::path CreateOrGetCaptureDir() {
-  std::filesystem::path capture_dir = CreateOrGetOrbitUserDataDir() / kCapturesFolderName;
+std::filesystem::path CreateOrGetCaptureDirUnsafe() {
+  std::filesystem::path capture_dir = CreateOrGetOrbitUserDataDirUnsafe() / kCapturesFolderName;
   CreateDirectoryOrDie(capture_dir);
   return capture_dir;
 }
 
-ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDirSafe() {
-  OUTCOME_TRY(std::filesystem::path user_data_dir, CreateOrGetOrbitUserDataDirSafe());
+ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDir() {
+  OUTCOME_TRY(std::filesystem::path user_data_dir, CreateOrGetOrbitUserDataDir());
   std::filesystem::path capture_dir = user_data_dir / kCapturesFolderName;
-  OUTCOME_TRY(CreateDirectory(capture_dir));
+  OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(capture_dir));
   return capture_dir;
 }
 
-std::filesystem::path CreateOrGetDumpDir() {
-  std::filesystem::path dumps_dir = CreateOrGetOrbitAppDataDir() / kDumpsFolderName;
+std::filesystem::path CreateOrGetDumpDirUnsafe() {
+  std::filesystem::path dumps_dir = CreateOrGetOrbitAppDataDirUnsafe() / kDumpsFolderName;
   CreateDirectoryOrDie(dumps_dir);
   return dumps_dir;
 }
 
-ErrorMessageOr<std::filesystem::path> CreateOrGetDumpDirSafe() {
-  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+ErrorMessageOr<std::filesystem::path> CreateOrGetDumpDir() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
   std::filesystem::path dumps_dir = app_data_dir / kDumpsFolderName;
-  OUTCOME_TRY(CreateDirectory(dumps_dir));
+  OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(dumps_dir));
   return dumps_dir;
 }
 
@@ -180,15 +181,15 @@ static std::filesystem::path GetOrbitAppDataDir() {
   return path;
 }
 
-std::filesystem::path CreateOrGetOrbitAppDataDir() {
+std::filesystem::path CreateOrGetOrbitAppDataDirUnsafe() {
   std::filesystem::path path = GetOrbitAppDataDir();
   CreateDirectoryOrDie(path);
   return path;
 }
 
-ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDirSafe() {
+ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDir() {
   std::filesystem::path path = GetOrbitAppDataDir();
-  OUTCOME_TRY(CreateDirectory(path));
+  OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(path));
   return path;
 }
 
@@ -221,19 +222,19 @@ static std::filesystem::path GetDocumentsPath() {
 #endif
 }
 
-std::filesystem::path CreateOrGetOrbitUserDataDir() {
-  std::filesystem::path path = GetDocumentsPath() / kOrbitFolderName;
+std::filesystem::path CreateOrGetOrbitUserDataDirUnsafe() {
+  std::filesystem::path path = GetDocumentsPath() / kOrbitFolderInDocumentsName;
   CreateDirectoryOrDie(path);
   return path;
 }
 
-ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDirSafe() {
-  std::filesystem::path path = GetDocumentsPath() / kOrbitFolderName;
-  OUTCOME_TRY(CreateDirectory(path));
+ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDir() {
+  std::filesystem::path path = GetDocumentsPath() / kOrbitFolderInDocumentsName;
+  OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(path));
   return path;
 }
 
-static std::optional<std::filesystem::path> GetFlagLogDir() {
+static std::optional<std::filesystem::path> GetLogDirFromFlag() {
   std::filesystem::path logs_dir;
   if (!absl::GetFlag(FLAGS_log_dir).empty()) {
     return std::filesystem::path{absl::GetFlag(FLAGS_log_dir)};
@@ -241,26 +242,26 @@ static std::optional<std::filesystem::path> GetFlagLogDir() {
   return std::nullopt;
 }
 
-std::filesystem::path CreateOrGetLogDir() {
+std::filesystem::path CreateOrGetLogDirUnsafe() {
   std::filesystem::path logs_dir =
-      GetFlagLogDir().value_or(CreateOrGetOrbitAppDataDir() / kLogsFolderName);
+      GetLogDirFromFlag().value_or(CreateOrGetOrbitAppDataDirUnsafe() / kLogsFolderName);
   CreateDirectoryOrDie(logs_dir);
   return logs_dir;
 }
 
-ErrorMessageOr<std::filesystem::path> CreateOrGetLogDirSafe() {
-  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
-  std::filesystem::path logs_dir = GetFlagLogDir().value_or(app_data_dir / kLogsFolderName);
-  OUTCOME_TRY(CreateDirectory(logs_dir));
+ErrorMessageOr<std::filesystem::path> CreateOrGetLogDir() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
+  std::filesystem::path logs_dir = GetLogDirFromFlag().value_or(app_data_dir / kLogsFolderName);
+  OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(logs_dir));
   return logs_dir;
 }
 
-std::filesystem::path GetLogFilePath() {
-  return CreateOrGetLogDir() / orbit_base::GetLogFileName();
+std::filesystem::path GetLogFilePathUnsafe() {
+  return CreateOrGetLogDirUnsafe() / orbit_base::GetLogFileName();
 }
 
-ErrorMessageOr<std::filesystem::path> GetLogFilePathSafe() {
-  OUTCOME_TRY(std::filesystem::path log_dir, CreateOrGetLogDirSafe());
+ErrorMessageOr<std::filesystem::path> GetLogFilePath() {
+  OUTCOME_TRY(std::filesystem::path log_dir, CreateOrGetLogDir());
   return log_dir / orbit_base::GetLogFileName();
 }
 

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -27,6 +27,7 @@ ABSL_FLAG(std::string, log_dir, "", "Set directory for the log.");
 
 constexpr std::string_view kOrbitFolderName{"Orbit"};
 constexpr std::string_view kCapturesFolderName{"captures"};
+constexpr std::string_view kPresetsFolderName{"presets"};
 
 namespace orbit_paths {
 
@@ -84,13 +85,22 @@ std::filesystem::path CreateOrGetCacheDir() {
   return cache_dir;
 }
 
+ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe() {}
+
 std::filesystem::path GetPresetDirPriorTo1_66() { return CreateOrGetOrbitAppDataDir() / "presets"; }
 
 std::filesystem::path GetCaptureDirPriorTo1_66() { return CreateOrGetOrbitAppDataDir() / "output"; }
 
 std::filesystem::path CreateOrGetPresetDir() {
-  std::filesystem::path preset_dir = CreateOrGetOrbitUserDataDir() / "presets";
+  std::filesystem::path preset_dir = CreateOrGetOrbitUserDataDir() / kPresetsFolderName;
   CreateDirectoryOrDie(preset_dir);
+  return preset_dir;
+}
+
+ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDirSafe() {
+  OUTCOME_TRY(std::filesystem::path user_data_dir, CreateOrGetOrbitUserDataDirSafe());
+  std::filesystem::path preset_dir = user_data_dir / kPresetsFolderName;
+  OUTCOME_TRY(CreateDirectoryIfNecessary(preset_dir));
   return preset_dir;
 }
 

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -227,4 +227,9 @@ std::filesystem::path GetLogFilePath() {
   return CreateOrGetLogDir() / orbit_base::GetLogFileName();
 }
 
+ErrorMessageOr<std::filesystem::path> GetLogFilePathSafe() {
+  OUTCOME_TRY(std::filesystem::path log_dir, CreateOrGetLogDirSafe());
+  return log_dir / orbit_base::GetLogFileName();
+}
+
 }  // namespace orbit_paths

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -26,6 +26,7 @@
 ABSL_FLAG(std::string, log_dir, "", "Set directory for the log.");
 
 constexpr std::string_view kOrbitFolderName{"Orbit"};
+constexpr std::string_view kCapturesFolderName{"captures"};
 
 namespace orbit_paths {
 
@@ -94,8 +95,15 @@ std::filesystem::path CreateOrGetPresetDir() {
 }
 
 std::filesystem::path CreateOrGetCaptureDir() {
-  std::filesystem::path capture_dir = CreateOrGetOrbitUserDataDir() / "captures";
+  std::filesystem::path capture_dir = CreateOrGetOrbitUserDataDir() / kCapturesFolderName;
   CreateDirectoryOrDie(capture_dir);
+  return capture_dir;
+}
+
+ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDirSafe() {
+  OUTCOME_TRY(std::filesystem::path user_data_dir, CreateOrGetOrbitUserDataDirSafe());
+  std::filesystem::path capture_dir = user_data_dir / kCapturesFolderName;
+  OUTCOME_TRY(CreateDirectoryIfNecessary(capture_dir));
   return capture_dir;
 }
 

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -80,13 +80,13 @@ static void CreateDirectoryOrDie(const std::filesystem::path& directory) {
   }
 }
 
-static std::filesystem::path CreateAndGetConfigPath() {
+static std::filesystem::path CreateAndGetConfigPathUnsafe() {
   std::filesystem::path config_dir = CreateOrGetOrbitAppDataDirUnsafe() / kConfigFolderName;
   CreateDirectoryOrDie(config_dir);
   return config_dir;
 }
 
-static ErrorMessageOr<std::filesystem::path> CreateAndGetConfigPathSafe() {
+static ErrorMessageOr<std::filesystem::path> CreateAndGetConfigPath() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
   std::filesystem::path config_dir = app_data_dir / kConfigFolderName;
   OUTCOME_TRY(CreateDirectoryIfItDoesNotExist(config_dir));
@@ -94,11 +94,11 @@ static ErrorMessageOr<std::filesystem::path> CreateAndGetConfigPathSafe() {
 }
 
 std::filesystem::path GetSymbolsFilePathUnsafe() {
-  return CreateAndGetConfigPath() / kSymbolPathsFileName;
+  return CreateAndGetConfigPathUnsafe() / kSymbolPathsFileName;
 }
 
 ErrorMessageOr<std::filesystem::path> GetSymbolsFilePath() {
-  OUTCOME_TRY(std::filesystem::path config_dir, CreateAndGetConfigPathSafe());
+  OUTCOME_TRY(std::filesystem::path config_dir, CreateAndGetConfigPath());
   return config_dir / kSymbolPathsFileName;
 }
 

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -32,6 +32,8 @@ constexpr std::string_view kPresetsFolderName{"presets"};
 constexpr std::string_view kCacheFolderName{"cache"};
 constexpr std::string_view kDumpsFolderName{"dumps"};
 constexpr std::string_view kLogsFolderName{"logs"};
+constexpr std::string_view kConfigFolderName{"config"};
+constexpr std::string_view kSymbolPathsFileName{"SymbolPaths.txt"};
 
 namespace orbit_paths {
 
@@ -76,12 +78,26 @@ static void CreateDirectoryOrDie(const std::filesystem::path& directory) {
 }
 
 static std::filesystem::path CreateAndGetConfigPath() {
-  std::filesystem::path config_dir = CreateOrGetOrbitAppDataDir() / "config";
+  std::filesystem::path config_dir = CreateOrGetOrbitAppDataDir() / kConfigFolderName;
   CreateDirectoryOrDie(config_dir);
   return config_dir;
 }
 
-std::filesystem::path GetSymbolsFilePath() { return CreateAndGetConfigPath() / "SymbolPaths.txt"; }
+static ErrorMessageOr<std::filesystem::path> CreateAndGetConfigPathSafe() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+  std::filesystem::path config_dir = app_data_dir / kConfigFolderName;
+  OUTCOME_TRY(CreateDirectoryIfNecessary(config_dir));
+  return config_dir;
+}
+
+std::filesystem::path GetSymbolsFilePath() {
+  return CreateAndGetConfigPath() / kSymbolPathsFileName;
+}
+
+ErrorMessageOr<std::filesystem::path> GetSymbolsFilePathSafe() {
+  OUTCOME_TRY(std::filesystem::path config_dir, CreateAndGetConfigPathSafe());
+  return config_dir / kSymbolPathsFileName;
+}
 
 std::filesystem::path CreateOrGetCacheDir() {
   std::filesystem::path cache_dir = CreateOrGetOrbitAppDataDir() / kCacheFolderName;

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -29,6 +29,7 @@ constexpr std::string_view kOrbitFolderName{"Orbit"};
 constexpr std::string_view kCapturesFolderName{"captures"};
 constexpr std::string_view kPresetsFolderName{"presets"};
 constexpr std::string_view kCacheFolderName{"cache"};
+constexpr std::string_view kDumpsFolderName{"dumps"};
 
 namespace orbit_paths {
 
@@ -124,9 +125,16 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDirSafe() {
 }
 
 std::filesystem::path CreateOrGetDumpDir() {
-  std::filesystem::path capture_dir = CreateOrGetOrbitAppDataDir() / "dumps";
-  CreateDirectoryOrDie(capture_dir);
-  return capture_dir;
+  std::filesystem::path dumps_dir = CreateOrGetOrbitAppDataDir() / kDumpsFolderName;
+  CreateDirectoryOrDie(dumps_dir);
+  return dumps_dir;
+}
+
+ErrorMessageOr<std::filesystem::path> CreateOrGetDumpDirSafe() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+  std::filesystem::path dumps_dir = app_data_dir / kDumpsFolderName;
+  OUTCOME_TRY(CreateDirectoryIfNecessary(dumps_dir));
+  return dumps_dir;
 }
 
 static std::filesystem::path GetOrbitAppDataDir() {

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -28,6 +28,7 @@ ABSL_FLAG(std::string, log_dir, "", "Set directory for the log.");
 constexpr std::string_view kOrbitFolderName{"Orbit"};
 constexpr std::string_view kCapturesFolderName{"captures"};
 constexpr std::string_view kPresetsFolderName{"presets"};
+constexpr std::string_view kCacheFolderName{"cache"};
 
 namespace orbit_paths {
 
@@ -80,8 +81,15 @@ static std::filesystem::path CreateAndGetConfigPath() {
 std::filesystem::path GetSymbolsFilePath() { return CreateAndGetConfigPath() / "SymbolPaths.txt"; }
 
 std::filesystem::path CreateOrGetCacheDir() {
-  std::filesystem::path cache_dir = CreateOrGetOrbitAppDataDir() / "cache";
+  std::filesystem::path cache_dir = CreateOrGetOrbitAppDataDir() / kCacheFolderName;
   CreateDirectoryOrDie(cache_dir);
+  return cache_dir;
+}
+
+ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe() {
+  OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
+  std::filesystem::path cache_dir = app_data_dir / kCacheFolderName;
+  OUTCOME_TRY(CreateDirectoryIfNecessary(cache_dir));
   return cache_dir;
 }
 

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -57,8 +57,9 @@ static std::string GetEnvVar(const char* variable_name) {
 }
 
 // Attempts to create a directory if it doesn't exist. Returns success if the creation was
-// successful or it already existed. If an error occurs its logged and returned.
-static ErrorMessageOr<void> CreateDirectoryIfNecessary(const std::filesystem::path& directory) {
+// successful or it already existed. If an error occurs its logged and returned. The difference to
+// orbit_base::CreateDirectories is the return type and logging.
+static ErrorMessageOr<void> CreateDirectory(const std::filesystem::path& directory) {
   ErrorMessageOr<bool> created_or_error = orbit_base::CreateDirectories(directory);
   if (created_or_error.has_error()) {
     std::string error_message =
@@ -87,7 +88,7 @@ static std::filesystem::path CreateAndGetConfigPath() {
 static ErrorMessageOr<std::filesystem::path> CreateAndGetConfigPathSafe() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
   std::filesystem::path config_dir = app_data_dir / kConfigFolderName;
-  OUTCOME_TRY(CreateDirectoryIfNecessary(config_dir));
+  OUTCOME_TRY(CreateDirectory(config_dir));
   return config_dir;
 }
 
@@ -109,7 +110,7 @@ std::filesystem::path CreateOrGetCacheDir() {
 ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
   std::filesystem::path cache_dir = app_data_dir / kCacheFolderName;
-  OUTCOME_TRY(CreateDirectoryIfNecessary(cache_dir));
+  OUTCOME_TRY(CreateDirectory(cache_dir));
   return cache_dir;
 }
 
@@ -140,7 +141,7 @@ std::filesystem::path CreateOrGetPresetDir() {
 ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDirSafe() {
   OUTCOME_TRY(std::filesystem::path user_data_dir, CreateOrGetOrbitUserDataDirSafe());
   std::filesystem::path preset_dir = user_data_dir / kPresetsFolderName;
-  OUTCOME_TRY(CreateDirectoryIfNecessary(preset_dir));
+  OUTCOME_TRY(CreateDirectory(preset_dir));
   return preset_dir;
 }
 
@@ -153,7 +154,7 @@ std::filesystem::path CreateOrGetCaptureDir() {
 ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDirSafe() {
   OUTCOME_TRY(std::filesystem::path user_data_dir, CreateOrGetOrbitUserDataDirSafe());
   std::filesystem::path capture_dir = user_data_dir / kCapturesFolderName;
-  OUTCOME_TRY(CreateDirectoryIfNecessary(capture_dir));
+  OUTCOME_TRY(CreateDirectory(capture_dir));
   return capture_dir;
 }
 
@@ -166,7 +167,7 @@ std::filesystem::path CreateOrGetDumpDir() {
 ErrorMessageOr<std::filesystem::path> CreateOrGetDumpDirSafe() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
   std::filesystem::path dumps_dir = app_data_dir / kDumpsFolderName;
-  OUTCOME_TRY(CreateDirectoryIfNecessary(dumps_dir));
+  OUTCOME_TRY(CreateDirectory(dumps_dir));
   return dumps_dir;
 }
 
@@ -187,7 +188,7 @@ std::filesystem::path CreateOrGetOrbitAppDataDir() {
 
 ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDirSafe() {
   std::filesystem::path path = GetOrbitAppDataDir();
-  OUTCOME_TRY(CreateDirectoryIfNecessary(path));
+  OUTCOME_TRY(CreateDirectory(path));
   return path;
 }
 
@@ -228,7 +229,7 @@ std::filesystem::path CreateOrGetOrbitUserDataDir() {
 
 ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDirSafe() {
   std::filesystem::path path = GetDocumentsPath() / kOrbitFolderName;
-  OUTCOME_TRY(CreateDirectoryIfNecessary(path));
+  OUTCOME_TRY(CreateDirectory(path));
   return path;
 }
 
@@ -250,7 +251,7 @@ std::filesystem::path CreateOrGetLogDir() {
 ErrorMessageOr<std::filesystem::path> CreateOrGetLogDirSafe() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
   std::filesystem::path logs_dir = GetFlagLogDir().value_or(app_data_dir / kLogsFolderName);
-  OUTCOME_TRY(CreateDirectoryIfNecessary(logs_dir));
+  OUTCOME_TRY(CreateDirectory(logs_dir));
   return logs_dir;
 }
 

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -34,6 +34,7 @@ constexpr std::string_view kDumpsFolderName{"dumps"};
 constexpr std::string_view kLogsFolderName{"logs"};
 constexpr std::string_view kConfigFolderName{"config"};
 constexpr std::string_view kSymbolPathsFileName{"SymbolPaths.txt"};
+constexpr std::string_view kOutputFolderName{"output"};
 
 namespace orbit_paths {
 
@@ -112,18 +113,22 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe() {
   return cache_dir;
 }
 
-std::filesystem::path GetPresetDirPriorTo1_66() { return CreateOrGetOrbitAppDataDir() / "presets"; }
+std::filesystem::path GetPresetDirPriorTo1_66() {
+  return CreateOrGetOrbitAppDataDir() / kPresetsFolderName;
+}
 
 ErrorMessageOr<std::filesystem::path> GetPresetDirPriorTo1_66Safe() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
-  return app_data_dir / "presets";
+  return app_data_dir / kPresetsFolderName;
 }
 
-std::filesystem::path GetCaptureDirPriorTo1_66() { return CreateOrGetOrbitAppDataDir() / "output"; }
+std::filesystem::path GetCaptureDirPriorTo1_66() {
+  return CreateOrGetOrbitAppDataDir() / kOutputFolderName;
+}
 
 ErrorMessageOr<std::filesystem::path> GetCaptureDirPriorTo1_66Safe() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDirSafe());
-  return app_data_dir / "output";
+  return app_data_dir / kOutputFolderName;
 }
 
 std::filesystem::path CreateOrGetPresetDir() {

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -15,10 +15,11 @@
 
 namespace orbit_paths {
 
-TEST(Path, AllAutoCreatedDirsExist) {
-  auto test_fns = {CreateOrGetOrbitAppDataDir, CreateOrGetDumpDir,    CreateOrGetPresetDir,
-                   CreateOrGetCacheDir,        CreateOrGetCaptureDir, CreateOrGetLogDir,
-                   CreateOrGetOrbitUserDataDir};
+TEST(Path, AllAutoCreatedDirsExistUnsafe) {
+  auto test_fns = {CreateOrGetOrbitAppDataDirUnsafe, CreateOrGetDumpDirUnsafe,
+                   CreateOrGetPresetDirUnsafe,       CreateOrGetCacheDirUnsafe,
+                   CreateOrGetCaptureDirUnsafe,      CreateOrGetLogDirUnsafe,
+                   CreateOrGetOrbitUserDataDirUnsafe};
 
   for (auto fn : test_fns) {
     std::filesystem::path path = fn();
@@ -27,14 +28,14 @@ TEST(Path, AllAutoCreatedDirsExist) {
   }
 }
 
-TEST(Path, AllAutoCreatedDirsExistSafe) {
-  auto test_fns = {CreateOrGetOrbitUserDataDirSafe,
-                   CreateOrGetCaptureDirSafe,
-                   CreateOrGetPresetDirSafe,
-                   CreateOrGetOrbitAppDataDirSafe,
-                   CreateOrGetCacheDirSafe,
-                   CreateOrGetDumpDirSafe,
-                   CreateOrGetLogDirSafe};
+TEST(Path, AllAutoCreatedDirsExist) {
+  auto test_fns = {CreateOrGetOrbitUserDataDir,
+                   CreateOrGetCaptureDir,
+                   CreateOrGetPresetDir,
+                   CreateOrGetOrbitAppDataDir,
+                   CreateOrGetCacheDir,
+                   CreateOrGetDumpDir,
+                   CreateOrGetLogDir};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();
@@ -44,7 +45,7 @@ TEST(Path, AllAutoCreatedDirsExistSafe) {
 }
 
 TEST(Paths, AllDirsOfFilesExist) {
-  auto test_fns = {GetLogFilePath, GetSymbolsFilePath};
+  auto test_fns = {GetLogFilePathUnsafe, GetSymbolsFilePathUnsafe};
 
   for (auto fn : test_fns) {
     std::filesystem::path path = fn().parent_path();
@@ -54,7 +55,7 @@ TEST(Paths, AllDirsOfFilesExist) {
 }
 
 TEST(Paths, AllDirsOfFilesExistSafe) {
-  auto test_fns = {GetLogFilePathSafe, GetSymbolsFilePathSafe};
+  auto test_fns = {GetLogFilePath, GetSymbolsFilePath};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -29,7 +29,7 @@ TEST(Path, AllAutoCreatedDirsExist) {
 
 TEST(Path, AllAutoCreatedDirsExistSafe) {
   auto test_fns = {CreateOrGetOrbitUserDataDirSafe, CreateOrGetCaptureDirSafe,
-                   CreateOrGetPresetDirSafe};
+                   CreateOrGetPresetDirSafe, CreateOrGetOrbitAppDataDirSafe};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -14,7 +14,8 @@ namespace orbit_paths {
 
 TEST(Path, AllAutoCreatedDirsExist) {
   auto test_fns = {CreateOrGetOrbitAppDataDir, CreateOrGetDumpDir,    CreateOrGetPresetDir,
-                   CreateOrGetCacheDir,        CreateOrGetCaptureDir, CreateOrGetLogDir};
+                   CreateOrGetCacheDir,        CreateOrGetCaptureDir, CreateOrGetLogDir,
+                   CreateOrGetOrbitUserDataDir};
 
   for (auto fn : test_fns) {
     std::filesystem::path path = fn();

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -28,9 +28,13 @@ TEST(Path, AllAutoCreatedDirsExist) {
 }
 
 TEST(Path, AllAutoCreatedDirsExistSafe) {
-  auto test_fns = {CreateOrGetOrbitUserDataDirSafe, CreateOrGetCaptureDirSafe,
-                   CreateOrGetPresetDirSafe,        CreateOrGetOrbitAppDataDirSafe,
-                   CreateOrGetCacheDirSafe,         CreateOrGetDumpDirSafe};
+  auto test_fns = {CreateOrGetOrbitUserDataDirSafe,
+                   CreateOrGetCaptureDirSafe,
+                   CreateOrGetPresetDirSafe,
+                   CreateOrGetOrbitAppDataDirSafe,
+                   CreateOrGetCacheDirSafe,
+                   CreateOrGetDumpDirSafe,
+                   CreateOrGetLogDirSafe};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -44,7 +44,7 @@ TEST(Path, AllAutoCreatedDirsExistSafe) {
 }
 
 TEST(Paths, AllDirsOfFilesExist) {
-  auto test_fns = {GetLogFilePath};
+  auto test_fns = {GetLogFilePath, GetSymbolsFilePath};
 
   for (auto fn : test_fns) {
     std::filesystem::path path = fn().parent_path();
@@ -54,7 +54,7 @@ TEST(Paths, AllDirsOfFilesExist) {
 }
 
 TEST(Paths, AllDirsOfFilesExistSafe) {
-  auto test_fns = {GetLogFilePathSafe};
+  auto test_fns = {GetLogFilePathSafe, GetSymbolsFilePathSafe};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -53,4 +53,14 @@ TEST(Paths, AllDirsOfFilesExist) {
   }
 }
 
+TEST(Paths, AllDirsOfFilesExistSafe) {
+  auto test_fns = {GetLogFilePathSafe};
+
+  for (auto fn : test_fns) {
+    ErrorMessageOr<std::filesystem::path> path_or_error = fn();
+    ASSERT_THAT(path_or_error, orbit_test_utils::HasValue());
+    EXPECT_TRUE(std::filesystem::is_directory(path_or_error.value().parent_path()));
+  }
+}
+
 }  // namespace orbit_paths

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -44,7 +44,7 @@ TEST(Path, AllAutoCreatedDirsExist) {
   }
 }
 
-TEST(Paths, AllDirsOfFilesExist) {
+TEST(Paths, AllDirsOfFilesExistUnsafe) {
   auto test_fns = {GetLogFilePathUnsafe, GetSymbolsFilePathUnsafe};
 
   for (auto fn : test_fns) {
@@ -54,7 +54,7 @@ TEST(Paths, AllDirsOfFilesExist) {
   }
 }
 
-TEST(Paths, AllDirsOfFilesExistSafe) {
+TEST(Paths, AllDirsOfFilesExist) {
   auto test_fns = {GetLogFilePath, GetSymbolsFilePath};
 
   for (auto fn : test_fns) {

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -2,13 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <filesystem>
 #include <string>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
 #include "OrbitPaths/Paths.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_paths {
 
@@ -21,6 +24,16 @@ TEST(Path, AllAutoCreatedDirsExist) {
     std::filesystem::path path = fn();
     ORBIT_LOG("Testing existence of \"%s\"", path.string());
     EXPECT_TRUE(std::filesystem::is_directory(path));
+  }
+}
+
+TEST(Path, AllAutoCreatedDirsExistSafe) {
+  auto test_fns = {CreateOrGetOrbitUserDataDirSafe};
+
+  for (auto fn : test_fns) {
+    ErrorMessageOr<std::filesystem::path> path_or_error = fn();
+    ASSERT_THAT(path_or_error, orbit_test_utils::HasValue());
+    EXPECT_TRUE(std::filesystem::is_directory(path_or_error.value()));
   }
 }
 

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -28,7 +28,7 @@ TEST(Path, AllAutoCreatedDirsExist) {
 }
 
 TEST(Path, AllAutoCreatedDirsExistSafe) {
-  auto test_fns = {CreateOrGetOrbitUserDataDirSafe};
+  auto test_fns = {CreateOrGetOrbitUserDataDirSafe, CreateOrGetCaptureDirSafe};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -29,7 +29,8 @@ TEST(Path, AllAutoCreatedDirsExist) {
 
 TEST(Path, AllAutoCreatedDirsExistSafe) {
   auto test_fns = {CreateOrGetOrbitUserDataDirSafe, CreateOrGetCaptureDirSafe,
-                   CreateOrGetPresetDirSafe, CreateOrGetOrbitAppDataDirSafe};
+                   CreateOrGetPresetDirSafe, CreateOrGetOrbitAppDataDirSafe,
+                   CreateOrGetCacheDirSafe};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -28,7 +28,8 @@ TEST(Path, AllAutoCreatedDirsExist) {
 }
 
 TEST(Path, AllAutoCreatedDirsExistSafe) {
-  auto test_fns = {CreateOrGetOrbitUserDataDirSafe, CreateOrGetCaptureDirSafe};
+  auto test_fns = {CreateOrGetOrbitUserDataDirSafe, CreateOrGetCaptureDirSafe,
+                   CreateOrGetPresetDirSafe};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -29,8 +29,8 @@ TEST(Path, AllAutoCreatedDirsExist) {
 
 TEST(Path, AllAutoCreatedDirsExistSafe) {
   auto test_fns = {CreateOrGetOrbitUserDataDirSafe, CreateOrGetCaptureDirSafe,
-                   CreateOrGetPresetDirSafe, CreateOrGetOrbitAppDataDirSafe,
-                   CreateOrGetCacheDirSafe};
+                   CreateOrGetPresetDirSafe,        CreateOrGetOrbitAppDataDirSafe,
+                   CreateOrGetCacheDirSafe,         CreateOrGetDumpDirSafe};
 
   for (auto fn : test_fns) {
     ErrorMessageOr<std::filesystem::path> path_or_error = fn();

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -40,7 +40,10 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDirSafe();
 // TODO(b/238986342) Replace deprecated and unsafe function with safe alternative.
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetLogDir();
 ErrorMessageOr<std::filesystem::path> CreateOrGetLogDirSafe();
-[[nodiscard]] std::filesystem::path GetLogFilePath();
+
+// TODO(b/238986108) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path GetLogFilePath();
+ErrorMessageOr<std::filesystem::path> GetLogFilePathSafe();
 
 [[nodiscard]] std::filesystem::path GetPresetDirPriorTo1_66();
 [[nodiscard]] std::filesystem::path GetCaptureDirPriorTo1_66();

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -12,7 +12,10 @@
 namespace orbit_paths {
 
 [[nodiscard]] std::filesystem::path GetSymbolsFilePath();
-[[nodiscard]] std::filesystem::path CreateOrGetCacheDir();
+
+// TODO(b/238986334) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetCacheDir();
+ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe();
 
 // TODO(b/238986330) Replace deprecated and unsafe function with safe alternative.
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetPresetDir();

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -11,7 +11,9 @@
 
 namespace orbit_paths {
 
-[[nodiscard]] std::filesystem::path GetSymbolsFilePath();
+// TODO(b/238986831) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path GetSymbolsFilePath();
+ErrorMessageOr<std::filesystem::path> GetSymbolsFilePathSafe();
 
 // TODO(b/238986334) Replace deprecated and unsafe function with safe alternative.
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetCacheDir();

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -36,7 +36,10 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDirSafe();
 // TODO(b/238985362) Replace deprecated and unsafe function with safe alternative.
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitUserDataDir();
 ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDirSafe();
-[[nodiscard]] std::filesystem::path CreateOrGetLogDir();
+
+// TODO(b/238986342) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetLogDir();
+ErrorMessageOr<std::filesystem::path> CreateOrGetLogDirSafe();
 [[nodiscard]] std::filesystem::path GetLogFilePath();
 
 [[nodiscard]] std::filesystem::path GetPresetDirPriorTo1_66();

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -7,6 +7,8 @@
 
 #include <filesystem>
 
+#include "OrbitBase/Result.h"
+
 namespace orbit_paths {
 
 [[nodiscard]] std::filesystem::path GetSymbolsFilePath();
@@ -15,7 +17,10 @@ namespace orbit_paths {
 [[nodiscard]] std::filesystem::path CreateOrGetCaptureDir();
 [[nodiscard]] std::filesystem::path CreateOrGetDumpDir();
 [[nodiscard]] std::filesystem::path CreateOrGetOrbitAppDataDir();
-[[nodiscard]] std::filesystem::path CreateOrGetOrbitUserDataDir();
+
+// TODO(b/238985362) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitUserDataDir();
+ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDirSafe();
 [[nodiscard]] std::filesystem::path CreateOrGetLogDir();
 [[nodiscard]] std::filesystem::path GetLogFilePath();
 

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -47,8 +47,13 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetLogDirSafe();
 [[nodiscard, deprecated]] std::filesystem::path GetLogFilePath();
 ErrorMessageOr<std::filesystem::path> GetLogFilePathSafe();
 
-[[nodiscard]] std::filesystem::path GetPresetDirPriorTo1_66();
-[[nodiscard]] std::filesystem::path GetCaptureDirPriorTo1_66();
+// TODO(b/238986346) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path GetPresetDirPriorTo1_66();
+ErrorMessageOr<std::filesystem::path> GetPresetDirPriorTo1_66Safe();
+
+// TODO(b/238986348) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path GetCaptureDirPriorTo1_66();
+ErrorMessageOr<std::filesystem::path> GetCaptureDirPriorTo1_66Safe();
 
 }  // namespace orbit_paths
 

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -13,7 +13,10 @@ namespace orbit_paths {
 
 [[nodiscard]] std::filesystem::path GetSymbolsFilePath();
 [[nodiscard]] std::filesystem::path CreateOrGetCacheDir();
-[[nodiscard]] std::filesystem::path CreateOrGetPresetDir();
+
+// TODO(b/238986330) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetPresetDir();
+ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDirSafe();
 
 // TODO(b/239014904) Replace deprecated and unsafe function with safe alternative.
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetCaptureDir();

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -24,7 +24,10 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDirSafe();
 // TODO(b/239014904) Replace deprecated and unsafe function with safe alternative.
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetCaptureDir();
 ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDirSafe();
-[[nodiscard]] std::filesystem::path CreateOrGetDumpDir();
+
+// TODO(b/238986372) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetDumpDir();
+ErrorMessageOr<std::filesystem::path> CreateOrGetDumpDirSafe();
 
 // TODO(b/238986370) Replace deprecated and unsafe function with safe alternative.
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitAppDataDir();

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -12,48 +12,48 @@
 namespace orbit_paths {
 
 // TODO(b/238986831) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path GetSymbolsFilePath();
-ErrorMessageOr<std::filesystem::path> GetSymbolsFilePathSafe();
+[[nodiscard, deprecated]] std::filesystem::path GetSymbolsFilePathUnsafe();
+ErrorMessageOr<std::filesystem::path> GetSymbolsFilePath();
 
 // TODO(b/238986334) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path CreateOrGetCacheDir();
-ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDirSafe();
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetCacheDirUnsafe();
+ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDir();
 
 // TODO(b/238986330) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path CreateOrGetPresetDir();
-ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDirSafe();
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetPresetDirUnsafe();
+ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDir();
 
 // TODO(b/239014904) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path CreateOrGetCaptureDir();
-ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDirSafe();
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetCaptureDirUnsafe();
+ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDir();
 
 // TODO(b/238986372) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path CreateOrGetDumpDir();
-ErrorMessageOr<std::filesystem::path> CreateOrGetDumpDirSafe();
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetDumpDirUnsafe();
+ErrorMessageOr<std::filesystem::path> CreateOrGetDumpDir();
 
 // TODO(b/238986370) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitAppDataDir();
-ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDirSafe();
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitAppDataDirUnsafe();
+ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDir();
 
 // TODO(b/238985362) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitUserDataDir();
-ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDirSafe();
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitUserDataDirUnsafe();
+ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDir();
 
 // TODO(b/238986342) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path CreateOrGetLogDir();
-ErrorMessageOr<std::filesystem::path> CreateOrGetLogDirSafe();
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetLogDirUnsafe();
+ErrorMessageOr<std::filesystem::path> CreateOrGetLogDir();
 
 // TODO(b/238986108) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path GetLogFilePath();
-ErrorMessageOr<std::filesystem::path> GetLogFilePathSafe();
+[[nodiscard, deprecated]] std::filesystem::path GetLogFilePathUnsafe();
+ErrorMessageOr<std::filesystem::path> GetLogFilePath();
 
 // TODO(b/238986346) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path GetPresetDirPriorTo1_66();
-ErrorMessageOr<std::filesystem::path> GetPresetDirPriorTo1_66Safe();
+[[nodiscard, deprecated]] std::filesystem::path GetPresetDirPriorTo1_66Unsafe();
+ErrorMessageOr<std::filesystem::path> GetPresetDirPriorTo1_66();
 
 // TODO(b/238986348) Replace deprecated and unsafe function with safe alternative.
-[[nodiscard, deprecated]] std::filesystem::path GetCaptureDirPriorTo1_66();
-ErrorMessageOr<std::filesystem::path> GetCaptureDirPriorTo1_66Safe();
+[[nodiscard, deprecated]] std::filesystem::path GetCaptureDirPriorTo1_66Unsafe();
+ErrorMessageOr<std::filesystem::path> GetCaptureDirPriorTo1_66();
 
 }  // namespace orbit_paths
 

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -14,7 +14,10 @@ namespace orbit_paths {
 [[nodiscard]] std::filesystem::path GetSymbolsFilePath();
 [[nodiscard]] std::filesystem::path CreateOrGetCacheDir();
 [[nodiscard]] std::filesystem::path CreateOrGetPresetDir();
-[[nodiscard]] std::filesystem::path CreateOrGetCaptureDir();
+
+// TODO(b/239014904) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetCaptureDir();
+ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDirSafe();
 [[nodiscard]] std::filesystem::path CreateOrGetDumpDir();
 [[nodiscard]] std::filesystem::path CreateOrGetOrbitAppDataDir();
 

--- a/src/OrbitPaths/include/OrbitPaths/Paths.h
+++ b/src/OrbitPaths/include/OrbitPaths/Paths.h
@@ -22,7 +22,10 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDirSafe();
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetCaptureDir();
 ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDirSafe();
 [[nodiscard]] std::filesystem::path CreateOrGetDumpDir();
-[[nodiscard]] std::filesystem::path CreateOrGetOrbitAppDataDir();
+
+// TODO(b/238986370) Replace deprecated and unsafe function with safe alternative.
+[[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitAppDataDir();
+ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDirSafe();
 
 // TODO(b/238985362) Replace deprecated and unsafe function with safe alternative.
 [[nodiscard, deprecated]] std::filesystem::path CreateOrGetOrbitUserDataDir();

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -210,11 +210,11 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
   // SymbolPaths.txt deprecation code
   // If file does not exist, do nothing. (It means the user never used an older Orbit version or
   // manually deleted the file)
-  if (!std::filesystem::is_regular_file(orbit_paths::GetSymbolsFilePath())) return;
+  if (!std::filesystem::is_regular_file(orbit_paths::GetSymbolsFilePathUnsafe())) return;
 
   // If it exists, check if it starts with deprecation note.
   ErrorMessageOr<bool> symbol_paths_file_has_depr_note =
-      orbit_symbols::FileStartsWithDeprecationNote(orbit_paths::GetSymbolsFilePath());
+      orbit_symbols::FileStartsWithDeprecationNote(orbit_paths::GetSymbolsFilePathUnsafe());
   if (symbol_paths_file_has_depr_note.has_error()) {
     ORBIT_ERROR("Unable to check SymbolPaths.txt file for depreciation note, error: %s",
                 symbol_paths_file_has_depr_note.error().message());
@@ -234,7 +234,7 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
   absl::flat_hash_set<std::string> already_seen_paths;
   std::vector<std::filesystem::path> dirs_to_save;
 
-  for (const auto& dir : orbit_symbols::ReadSymbolsFile(orbit_paths::GetSymbolsFilePath())) {
+  for (const auto& dir : orbit_symbols::ReadSymbolsFile(orbit_paths::GetSymbolsFilePathUnsafe())) {
     if (!already_seen_paths.contains(dir.string())) {
       already_seen_paths.insert(dir.string());
       dirs_to_save.push_back(dir);
@@ -252,7 +252,7 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
   client_symbols_storage_manager.SavePaths(dirs_to_save);
 
   ErrorMessageOr<void> add_depr_note_result =
-      orbit_symbols::AddDeprecationNoteToFile(orbit_paths::GetSymbolsFilePath());
+      orbit_symbols::AddDeprecationNoteToFile(orbit_paths::GetSymbolsFilePathUnsafe());
   if (add_depr_note_result.has_error()) {
     ORBIT_ERROR("Unable to add deprecation note to SymbolPaths.txt, error: %s",
                 add_depr_note_result.error().message());
@@ -947,7 +947,7 @@ void OrbitMainWindow::on_actionReport_Bug_triggered() {
 }
 
 void OrbitMainWindow::on_actionOpenUserDataDirectory_triggered() {
-  std::string user_data_dir = orbit_paths::CreateOrGetOrbitUserDataDir().string();
+  std::string user_data_dir = orbit_paths::CreateOrGetOrbitUserDataDirUnsafe().string();
   QUrl user_data_url = QUrl::fromLocalFile(QString::fromStdString(user_data_dir));
   if (!QDesktopServices::openUrl(user_data_url)) {
     QMessageBox::critical(this, "Error opening directory",
@@ -956,7 +956,7 @@ void OrbitMainWindow::on_actionOpenUserDataDirectory_triggered() {
 }
 
 void OrbitMainWindow::on_actionOpenAppDataDirectory_triggered() {
-  std::string app_data_dir = orbit_paths::CreateOrGetOrbitAppDataDir().string();
+  std::string app_data_dir = orbit_paths::CreateOrGetOrbitAppDataDirUnsafe().string();
   QUrl app_data_url = QUrl::fromLocalFile(QString::fromStdString(app_data_dir));
   if (!QDesktopServices::openUrl(app_data_url)) {
     QMessageBox::critical(this, "Error opening directory",
@@ -1041,7 +1041,7 @@ void OrbitMainWindow::OnFilterTracksTextChanged(const QString& text) {
 void OrbitMainWindow::on_actionOpen_Preset_triggered() {
   QStringList list = QFileDialog::getOpenFileNames(
       this, "Select a file to open...",
-      QString::fromStdString(orbit_paths::CreateOrGetPresetDir().string()), "*.opr");
+      QString::fromStdString(orbit_paths::CreateOrGetPresetDirUnsafe().string()), "*.opr");
   for (const auto& file : list) {
     ErrorMessageOr<void> result = app_->OnLoadPreset(file.toStdString());
     if (result.has_error()) {
@@ -1057,7 +1057,7 @@ void OrbitMainWindow::on_actionOpen_Preset_triggered() {
 void OrbitMainWindow::on_actionSave_Preset_As_triggered() {
   QString file = QFileDialog::getSaveFileName(
       this, "Specify a file to save...",
-      QString::fromStdString(orbit_paths::CreateOrGetPresetDir().string()), "*.opr");
+      QString::fromStdString(orbit_paths::CreateOrGetPresetDirUnsafe().string()), "*.opr");
   if (file.isEmpty()) {
     return;
   }
@@ -1374,7 +1374,7 @@ void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerIn
 void OrbitMainWindow::on_actionOpen_Capture_triggered() {
   QString file = QFileDialog::getOpenFileName(
       this, "Open capture...",
-      QString::fromStdString(orbit_paths::CreateOrGetCaptureDir().string()), "*.orbit");
+      QString::fromStdString(orbit_paths::CreateOrGetCaptureDirUnsafe().string()), "*.orbit");
   if (file.isEmpty()) {
     return;
   }


### PR DESCRIPTION
This deprecates all unsafe functions in Paths.h and adds a safe version for each that returns `ErrorMessageOr`. This is split up on purpose in several commits, so it's easy to see that no typos happened anywhere. 

The main reason for this is: b/236813935

An upcoming PR will make use of the new `Safe` versions to address that specific crash