### PR TITLE
fix outline not drawing correctly

### DIFF
--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -226,7 +226,7 @@ void ThreadStateBar::DrawThreadStateSliceOutline(PrimitiveAssembler& primitive_a
       Vec2{left_x, bottom_y},
   };
   Quad outline{outline_points};
-  primitive_assembler.AddQuadBorder(outline, GlCanvas::kZValueBoxBorder, outline_color);
+  primitive_assembler.AddQuadBorder(outline, GlCanvas::kZValueOverlay, outline_color);
 }
 
 void ThreadStateBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,


### PR DESCRIPTION
This fixes the thread state slice outline being drawn under the thread state bar.

Screenshot: http://screenshot/8Zc9nG5aQwCx7Mp.png