### PR TITLE
Fix use of wrong vector in RetrieveInstancesWidget

### DIFF
--- a/src/SessionSetup/RetrieveInstancesWidget.cpp
+++ b/src/SessionSetup/RetrieveInstancesWidget.cpp
@@ -143,7 +143,7 @@ void RetrieveInstancesWidget::OnInitialLoadingReturnedSuccess(
   std::sort(projects.begin(), projects.end(),
             [](const Project& p1, const Project& p2) { return p1.display_name < p2.display_name; });
 
-  for (const Project& project : initial_load_result.projects) {
+  for (const Project& project : projects) {
     QString text = project.display_name;
     if (project == initial_load_result.default_project) {
       text.append(" (default)");


### PR DESCRIPTION
This does not actually change any logic, but only improves readability.
It was a mistake before that has now been fixed. For explanation: The
variable `projects` is a reference to `initial_load_result.projects` and
projects is then sorted. Since it is a reference, this actually changes
`initial_load_result` and the code worked before, even when
`initial_load_result` was used after the call to sort. To make this less
confusing, now `projects` is used after the call to sort.

(This could also be done by sorting `initial_load_result.projects` instead of having this new reference `projects`; If someone feels strongly about this, I can also change it)