### PR TITLE
Split LinuxMap into ReadMaps and ReadModules

### DIFF
--- a/src/ApiLoader/EnableInTraceeLinux.cpp
+++ b/src/ApiLoader/EnableInTraceeLinux.cpp
@@ -14,7 +14,7 @@
 
 #include "ApiUtils/GetFunctionTableAddressPrefix.h"
 #include "ObjectUtils/Address.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadUtils.h"

--- a/src/ApiLoader/EnableInTraceeLinux.cpp
+++ b/src/ApiLoader/EnableInTraceeLinux.cpp
@@ -14,7 +14,6 @@
 
 #include "ApiUtils/GetFunctionTableAddressPrefix.h"
 #include "ObjectUtils/Address.h"
-#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadUtils.h"

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -30,7 +30,7 @@
 #include "GrpcProtos/Constants.h"
 #include "GrpcProtos/capture.pb.h"
 #include "ObjectUtils/ElfFile.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -31,7 +31,7 @@
 #include "LibunwindstackUnwinder.h"
 #include "LinuxTracing/TracerListener.h"
 #include "LinuxTracingUtils.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/GetProcessIds.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadUtils.h"

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -22,7 +22,7 @@
 #include "GrpcProtos/capture.pb.h"
 #include "GrpcProtos/module.pb.h"
 #include "LeafFunctionCallManager.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 
@@ -571,12 +571,13 @@ FindExecutableAddressRangeForSameFileFromFirstMapInfo(
 // each new executable file mapping we would send a ModuleUpdateEvent with the address range and
 // file for that mapping.
 //
-// But just like for orbit_object_utils::ParseMaps, things are more complicated. We observed that in
-// some cases a single loadable segment of an ELF file or a single executable section of a PE can be
-// loaded into memory with multiple adjacent file mappings. In addition, some PEs can have multiple
-// executable sections. And finally, the executable sections (and all other sections) of a PE can
-// have an offset in the file that doesn't fulfill the requirements of mmap for file mappings, in
-// which case Wine has to create an anonymous mapping and copy the section into it.
+// But just like for orbit_object_utils::ParseMapsIntoModules, things are more complicated. We
+// observed that in some cases a single loadable segment of an ELF file or a single executable
+// section of a PE can be loaded into memory with multiple adjacent file mappings. In addition, some
+// PEs can have multiple executable sections. And finally, the executable sections (and all other
+// sections) of a PE can have an offset in the file that doesn't fulfill the requirements of mmap
+// for file mappings, in which case Wine has to create an anonymous mapping and copy the section
+// into it.
 //
 // In all these cases, we want to create a ModuleUpdateEvent with an address range that includes
 // all the executable mappings of the module. To find them, we proceed as follows:
@@ -588,7 +589,7 @@ FindExecutableAddressRangeForSameFileFromFirstMapInfo(
 //   module; if the module is a PE, we also have to consider anonymous mappings and detect whether
 //   they actually belong to the PE.
 //
-// Note that, just like in orbit_object_utils::ParseMaps:
+// Note that, just like in orbit_object_utils::ParseMapsIntoModules:
 // - The ModuleInfo in the ModuleUpdateEvent will carry executable_segment_offset with the
 //   assumption that the value of ObjectFile::GetExecutableSegmentOffset correspond to the *first*
 //   executable mapping.

--- a/src/LinuxTracingIntegrationTests/IntegrationTestUtils.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestUtils.cpp
@@ -9,7 +9,7 @@
 #include "GrpcProtos/module.pb.h"
 #include "GrpcProtos/symbol.pb.h"
 #include "ObjectUtils/ElfFile.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/ThreadUtils.h"
 

--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -12,8 +12,10 @@ target_sources(
   PUBLIC include/ObjectUtils/Address.h
          include/ObjectUtils/CoffFile.h
          include/ObjectUtils/ElfFile.h
+         include/ObjectUtils/ObjectFile.h
          include/ObjectUtils/PdbFile.h
-         include/ObjectUtils/LinuxMap.h
+         include/ObjectUtils/ReadMaps.h
+         include/ObjectUtils/ReadModules.h
          include/ObjectUtils/SymbolsFile.h
          include/ObjectUtils/WindowsBuildIdUtils.h)
 
@@ -31,7 +33,9 @@ target_sources(
         WindowsBuildIdUtils.cpp)
 
 if (NOT WIN32)
-target_sources(ObjectUtils PRIVATE LinuxMap.cpp)
+target_sources(ObjectUtils PRIVATE
+        ReadMaps.cpp
+        ReadModules.cpp)
 else()
 target_sources(
   ObjectUtils
@@ -74,7 +78,9 @@ target_sources(ObjectUtilsTests PRIVATE
 )
 
 if (NOT WIN32)
-target_sources(ObjectUtilsTests PRIVATE LinuxMapTest.cpp)
+target_sources(ObjectUtilsTests PRIVATE
+        ReadMapsTest.cpp
+        ReadModulesTest.cpp)
 else()
 target_sources(ObjectUtilsTests PRIVATE PdbFileDiaTest.cpp)
 endif()

--- a/src/ObjectUtils/ReadMaps.cpp
+++ b/src/ObjectUtils/ReadMaps.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ObjectUtils/ReadMaps.h"
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <vector>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ReadFileToString.h"
+
+namespace orbit_object_utils {
+
+ErrorMessageOr<std::vector<LinuxMemoryMapping>> ReadMaps(pid_t pid) {
+  const std::filesystem::path proc_pid_maps_path{absl::StrFormat("/proc/%i/maps", pid)};
+  OUTCOME_TRY(auto&& proc_pid_maps_content, orbit_base::ReadFileToString(proc_pid_maps_path));
+  return ReadMaps(proc_pid_maps_content);
+}
+
+std::vector<LinuxMemoryMapping> ReadMaps(std::string_view proc_pid_maps_content) {
+  const std::vector<std::string> proc_pid_maps_lines = absl::StrSplit(proc_pid_maps_content, '\n');
+  std::vector<LinuxMemoryMapping> result;
+
+  for (const std::string& line : proc_pid_maps_lines) {
+    // The number of spaces from the inode to the path is variable, and the path can contain spaces,
+    // so we need to limit the number of splits and remove leading spaces from the path separately.
+    std::vector<std::string> tokens = absl::StrSplit(line, absl::MaxSplits(' ', 5));
+    if (tokens.size() < 5) continue;
+    ORBIT_CHECK(tokens.size() == 5 || tokens.size() == 6);
+
+    const std::vector<std::string> start_and_end = absl::StrSplit(tokens[0], '-');
+    if (start_and_end.size() != 2) continue;
+    const uint64_t start = std::stoull(start_and_end[0], nullptr, 16);
+    const uint64_t end = std::stoull(start_and_end[1], nullptr, 16);
+
+    const uint64_t offset = std::stoull(tokens[2], nullptr, 16);
+
+    if (tokens[1].size() < 4) continue;
+    uint64_t perms = 0;
+    if (tokens[1][0] == 'r') perms |= PROT_READ;
+    if (tokens[1][1] == 'w') perms |= PROT_WRITE;
+    if (tokens[1][2] == 'x') perms |= PROT_EXEC;
+
+    uint64_t inode{};
+    if (!absl::SimpleAtoi(tokens[4], &inode)) continue;
+
+    std::string pathname;
+    if (tokens.size() == 6) {
+      absl::StripLeadingAsciiWhitespace(&tokens[5]);
+      pathname = std::move(tokens[5]);
+    }
+
+    result.emplace_back(start, end, perms, offset, inode, std::move(pathname));
+  }
+
+  return result;
+}
+
+}  // namespace orbit_object_utils

--- a/src/ObjectUtils/ReadMapsTest.cpp
+++ b/src/ObjectUtils/ReadMapsTest.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <vector>
+
+#include "ObjectUtils/ReadMaps.h"
+#include "OrbitBase/Result.h"
+#include "TestUtils/TestUtils.h"
+
+using orbit_test_utils::HasNoError;
+
+namespace orbit_object_utils {
+
+TEST(ReadMaps, ReadMapsFromPid) {
+  const ErrorMessageOr<std::vector<LinuxMemoryMapping>> maps = ReadMaps(getpid());
+  EXPECT_THAT(maps, HasNoError());
+  EXPECT_GT(maps.value().size(), 0);
+}
+
+TEST(ReadMaps, ReadMapsFromProcPidMapsContent) {
+  constexpr const char* kProcPidMapsContent{
+      "00400000-00452000 r-xp 00000000 08:02 173521      /usr/bin/dbus-daemon\n"
+      "00e03000-00e24000 rw-p 00000000 00:00 0           [heap]\n"
+      "35b1800000-35b1820000 r-xp 00000000 08:02 135522  /path with spaces\n"
+      "35b1a21000-35b1a22000 rw-p 00000000 00:00 0       \n"};
+  std::vector<LinuxMemoryMapping> maps = ReadMaps(kProcPidMapsContent);
+  ASSERT_EQ(maps.size(), 4);
+
+  EXPECT_EQ(maps[0].start_address(), 0x400000);
+  EXPECT_EQ(maps[0].end_address(), 0x452000);
+  EXPECT_EQ(maps[0].perms(), PROT_READ | PROT_EXEC);
+  EXPECT_EQ(maps[0].inode(), 173521);
+  EXPECT_EQ(maps[0].pathname(), "/usr/bin/dbus-daemon");
+
+  EXPECT_EQ(maps[1].start_address(), 0xe03000);
+  EXPECT_EQ(maps[1].end_address(), 0xe24000);
+  EXPECT_EQ(maps[1].perms(), PROT_READ | PROT_WRITE);
+  EXPECT_EQ(maps[1].inode(), 0);
+  EXPECT_EQ(maps[1].pathname(), "[heap]");
+
+  EXPECT_EQ(maps[2].start_address(), 0x35b1800000);
+  EXPECT_EQ(maps[2].end_address(), 0x35b1820000);
+  EXPECT_EQ(maps[2].perms(), PROT_READ | PROT_EXEC);
+  EXPECT_EQ(maps[2].inode(), 135522);
+  EXPECT_EQ(maps[2].pathname(), "/path with spaces");
+
+  EXPECT_EQ(maps[3].start_address(), 0x35b1a21000);
+  EXPECT_EQ(maps[3].end_address(), 0x35b1a22000);
+  EXPECT_EQ(maps[3].perms(), PROT_READ | PROT_WRITE);
+  EXPECT_EQ(maps[3].inode(), 0);
+  EXPECT_EQ(maps[3].pathname(), "");
+}
+
+TEST(ReadMaps, ReadMapsFromInvalidProcPidMapsContent) {
+  std::vector<LinuxMemoryMapping> maps;
+
+  maps = ReadMaps("");
+  EXPECT_EQ(maps.size(), 0);
+
+  maps = ReadMaps("\n\n");
+  EXPECT_EQ(maps.size(), 0);
+
+  // Missing inode.
+  maps = ReadMaps("00400000-00452000 r-xp 00000000 08:02");
+  EXPECT_EQ(maps.size(), 0);
+
+  // Unexpected protection format.
+  maps = ReadMaps("00400000-00452000 r-x 00000000 08:02 173521      /usr/bin/dbus-daemon");
+  EXPECT_EQ(maps.size(), 0);
+
+  // Non-numeric inode.
+  maps = ReadMaps("00400000-00452000 r-xp 00000000 08:02 173521a      /usr/bin/dbus-daemon\n");
+  EXPECT_EQ(maps.size(), 0);
+}
+
+}  // namespace orbit_object_utils

--- a/src/ObjectUtils/include/ObjectUtils/ReadMaps.h
+++ b/src/ObjectUtils/include/ObjectUtils/ReadMaps.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef OBJECT_UTILS_READ_MAPS_H_
+#define OBJECT_UTILS_READ_MAPS_H_
+
+#ifdef __linux
+
+#include <stdint.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "GrpcProtos/module.pb.h"
+#include "OrbitBase/Result.h"
+
+namespace orbit_object_utils {
+
+// Represents an entry in /proc/[pid]/maps.
+class LinuxMemoryMapping {
+ public:
+  LinuxMemoryMapping(uint64_t start_address, uint64_t end_address, uint64_t perms, uint64_t offset,
+                     uint64_t inode, std::string pathname)
+      : start_address_{start_address},
+        end_address_{end_address},
+        perms_{perms},
+        offset_{offset},
+        inode_{inode},
+        pathname_{std::move(pathname)} {}
+
+  [[nodiscard]] uint64_t start_address() const { return start_address_; }
+  [[nodiscard]] uint64_t end_address() const { return end_address_; }
+  [[nodiscard]] uint64_t perms() const { return perms_; }
+  [[nodiscard]] uint64_t offset() const { return offset_; }
+  [[nodiscard]] uint64_t inode() const { return inode_; }
+  [[nodiscard]] const std::string& pathname() const { return pathname_; }
+
+ private:
+  uint64_t start_address_;
+  uint64_t end_address_;
+  uint64_t perms_;
+  uint64_t offset_;
+  uint64_t inode_;
+  std::string pathname_;
+};
+
+ErrorMessageOr<std::vector<LinuxMemoryMapping>> ReadMaps(pid_t pid);
+
+[[nodiscard]] std::vector<LinuxMemoryMapping> ReadMaps(std::string_view proc_pid_maps_content);
+
+}  // namespace orbit_object_utils
+
+#endif  // __linux
+
+#endif  // OBJECT_UTILS_READ_MAPS_H_

--- a/src/ObjectUtils/include/ObjectUtils/ReadModules.h
+++ b/src/ObjectUtils/include/ObjectUtils/ReadModules.h
@@ -1,20 +1,20 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef OBJECT_UTILS_LINUX_MAP_H_
-#define OBJECT_UTILS_LINUX_MAP_H_
+#ifndef OBJECT_UTILS_READ_MODULES_H_
+#define OBJECT_UTILS_READ_MODULES_H_
+
+#ifdef __linux
 
 #include <stdint.h>
-
-#include <string_view>
-
-#if defined(__linux)
+#include <unistd.h>
 
 #include <filesystem>
 #include <vector>
 
 #include "GrpcProtos/module.pb.h"
+#include "ObjectUtils/ReadMaps.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_object_utils {
@@ -22,11 +22,14 @@ namespace orbit_object_utils {
 ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModule(const std::filesystem::path& module_path,
                                                            uint64_t start_address,
                                                            uint64_t end_address);
-ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(int32_t pid);
-ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ParseMaps(
-    std::string_view proc_maps_data);
+
+ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(pid_t pid);
+
+[[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo> ParseMapsIntoModules(
+    const std::vector<LinuxMemoryMapping>& maps);
 
 }  // namespace orbit_object_utils
 
-#endif  // defined(__linux)
-#endif  // OBJECT_UTILS_LINUX_MAP_H_
+#endif  // __linux
+
+#endif  // OBJECT_UTILS_READ_MODULES_H_

--- a/src/ProcessService/ProcessServiceImpl.cpp
+++ b/src/ProcessService/ProcessServiceImpl.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 #include "GrpcProtos/process.pb.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "ProcessServiceUtils.h"

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
@@ -10,7 +10,7 @@
 
 #include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 
 namespace orbit_user_space_instrumentation {
 

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -23,7 +23,7 @@
 #include "ExecuteMachineCode.h"
 #include "MachineCode.h"
 #include "ObjectUtils/Address.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/GetProcessIds.h"

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -19,7 +19,7 @@
 #include "FindFunctionAddress.h"
 #include "GrpcProtos/capture.pb.h"
 #include "ObjectUtils/ElfFile.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/GetProcessIds.h"
 #include "OrbitBase/Logging.h"

--- a/src/UserSpaceInstrumentation/TestUtils.cpp
+++ b/src/UserSpaceInstrumentation/TestUtils.cpp
@@ -11,7 +11,7 @@
 
 #include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/UniqueResource.h"

--- a/src/UserSpaceInstrumentation/TestUtilsTest.cpp
+++ b/src/UserSpaceInstrumentation/TestUtilsTest.cpp
@@ -14,7 +14,7 @@
 #include "AccessTraceesMemory.h"
 #include "FindFunctionAddress.h"
 #include "ObjectUtils/ElfFile.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "TestUtils.h"

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -31,7 +31,7 @@
 #include "MachineCode.h"
 #include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
-#include "ObjectUtils/LinuxMap.h"
+#include "ObjectUtils/ReadModules.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "TestUtils.h"


### PR DESCRIPTION
`ParseMaps` was performing two tasks inside the same function: list the maps
from `/proc/[pid]/maps`, and list the modules from the list of maps. We split
this in two.
The more practical reason for this change is that I will need the intermediate
result (list of maps) in order to detect whether a function can be instrumented
by uprobes (i.e., whether a file mapping with the function's module and file
offset exists).

Bug: http://b/232072696

Test:
- Unit tests.
- Start Orbit on `triangle.exe`. Verify modules show up correctly.