### PR TITLE
Add WarningInstrumentingWithUprobesEvent, unused for now

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -72,6 +72,11 @@ class MockCaptureListener : public CaptureListener {
       void, OnErrorsWithPerfEventOpenEvent,
       (orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/),
       (override));
+  MOCK_METHOD(
+      void, OnWarningInstrumentingWithUprobesEvent,
+      (orbit_grpc_protos::
+           WarningInstrumentingWithUprobesEvent /*warning_instrumenting_with_uprobes_event*/),
+      (override));
   MOCK_METHOD(void, OnErrorEnablingOrbitApiEvent,
               (orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/),
               (override));

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -87,6 +87,9 @@ class CaptureEventProcessorForListener : public CaptureEventProcessor {
       const orbit_grpc_protos::ClockResolutionEvent& clock_resolution_event);
   void ProcessErrorsWithPerfEventOpenEvent(
       const orbit_grpc_protos::ErrorsWithPerfEventOpenEvent& errors_with_perf_event_open_event);
+  void ProcessWarningInstrumentingWithUprobesEvent(
+      const orbit_grpc_protos::WarningInstrumentingWithUprobesEvent&
+          warning_instrumenting_with_uprobes_event);
   void ProcessErrorEnablingOrbitApiEvent(
       const orbit_grpc_protos::ErrorEnablingOrbitApiEvent& error_enabling_orbit_api_event);
   void ProcessErrorEnablingUserSpaceInstrumentationEvent(
@@ -230,6 +233,9 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
     case ClientCaptureEvent::kErrorsWithPerfEventOpenEvent:
       ProcessErrorsWithPerfEventOpenEvent(event.errors_with_perf_event_open_event());
       break;
+    case ClientCaptureEvent::kWarningInstrumentingWithUprobesEvent:
+      ProcessWarningInstrumentingWithUprobesEvent(event.warning_instrumenting_with_uprobes_event());
+      break;
     case ClientCaptureEvent::kErrorEnablingOrbitApiEvent:
       ProcessErrorEnablingOrbitApiEvent(event.error_enabling_orbit_api_event());
       break;
@@ -252,8 +258,6 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
       break;
     case ClientCaptureEvent::EVENT_NOT_SET:
       ORBIT_ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");
-      break;
-    default:
       break;
   }
 }
@@ -650,6 +654,13 @@ void CaptureEventProcessorForListener::ProcessClockResolutionEvent(
 void CaptureEventProcessorForListener::ProcessErrorsWithPerfEventOpenEvent(
     const orbit_grpc_protos::ErrorsWithPerfEventOpenEvent& errors_with_perf_event_open_event) {
   capture_listener_->OnErrorsWithPerfEventOpenEvent(errors_with_perf_event_open_event);
+}
+
+void CaptureEventProcessorForListener::ProcessWarningInstrumentingWithUprobesEvent(
+    const orbit_grpc_protos::WarningInstrumentingWithUprobesEvent&
+        warning_instrumenting_with_uprobes_event) {
+  capture_listener_->OnWarningInstrumentingWithUprobesEvent(
+      warning_instrumenting_with_uprobes_event);
 }
 
 void CaptureEventProcessorForListener::ProcessErrorEnablingOrbitApiEvent(

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -58,6 +58,9 @@ class MyCaptureListener : public CaptureListener {
   void OnErrorsWithPerfEventOpenEvent(
       orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/)
       override {}
+  void OnWarningInstrumentingWithUprobesEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+      /*warning_instrumenting_with_uprobes_event*/) override {}
   void OnErrorEnablingOrbitApiEvent(
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {}
   void OnErrorEnablingUserSpaceInstrumentationEvent(

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -111,6 +111,11 @@ class MockCaptureListener : public CaptureListener {
       void, OnErrorsWithPerfEventOpenEvent,
       (orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/),
       (override));
+  MOCK_METHOD(
+      void, OnWarningInstrumentingWithUprobesEvent,
+      (orbit_grpc_protos::
+           WarningInstrumentingWithUprobesEvent /*warning_instrumenting_with_uprobes_event*/),
+      (override));
   MOCK_METHOD(void, OnErrorEnablingOrbitApiEvent,
               (orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/),
               (override));

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -65,6 +65,9 @@ class CaptureListener {
       orbit_grpc_protos::ClockResolutionEvent clock_resolution_event) = 0;
   virtual void OnErrorsWithPerfEventOpenEvent(
       orbit_grpc_protos::ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event) = 0;
+  virtual void OnWarningInstrumentingWithUprobesEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+          warning_instrumenting_with_uprobes_event) = 0;
   virtual void OnErrorEnablingOrbitApiEvent(
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) = 0;
   virtual void OnErrorEnablingUserSpaceInstrumentationEvent(

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -748,6 +748,12 @@ message ErrorsWithPerfEventOpenEvent {
   repeated bytes failed_to_open = 2;
 }
 
+message WarningInstrumentingWithUprobesEvent {
+  uint64 timestamp_ns = 1;
+  repeated FunctionThatFailedToBeInstrumented
+      functions_that_failed_to_instrument = 2;
+}
+
 message LostPerfRecordsEvent {
   uint64 duration_ns = 1;
   uint64 end_timestamp_ns = 2;
@@ -768,7 +774,7 @@ message ClientCaptureEvent {
     // numbers starting with 16.
     //
     // Next high-frequency ID: 12
-    // Next lower-frequency ID: 50
+    // Next lower-frequency ID: 51
     // Please keep these alphabetically ordered.
 
     // Even though AddressInfo is a high-frequency event
@@ -813,6 +819,8 @@ message ClientCaptureEvent {
     ThreadStateSlice thread_state_slice = 7;
     TracepointEvent tracepoint_event = 8;
     WarningEvent warning_event = 32;
+    WarningInstrumentingWithUprobesEvent
+        warning_instrumenting_with_uprobes_event = 50;
     WarningInstrumentingWithUserSpaceInstrumentationEvent
         warning_instrumenting_with_user_space_instrumentation_event = 48;
   }
@@ -827,7 +835,7 @@ message ProducerCaptureEvent {
     // numbers starting with 16.
     //
     // Next high-frequency ID: 15.
-    // Next lower-frequency ID: 49
+    // Next lower-frequency ID: 50
     //
     // Please keep these alphabetically ordered.
     ApiEvent api_event = 10;
@@ -875,6 +883,8 @@ message ProducerCaptureEvent {
     ThreadNamesSnapshot thread_names_snapshot = 24;
     ThreadStateSlice thread_state_slice = 9;
     WarningEvent warning_event = 30;
+    WarningInstrumentingWithUprobesEvent
+        warning_instrumenting_with_uprobes_event = 49;
     WarningInstrumentingWithUserSpaceInstrumentationEvent
         warning_instrumenting_with_user_space_instrumentation_event = 47;
   }

--- a/src/LinuxCaptureService/TracingHandler.cpp
+++ b/src/LinuxCaptureService/TracingHandler.cpp
@@ -135,4 +135,13 @@ void TracingHandler::OnOutOfOrderEventsDiscardedEvent(
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
+void TracingHandler::OnWarningInstrumentingWithUprobesEvent(
+    orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+        warning_instrumenting_with_uprobes_event) {
+  orbit_grpc_protos::ProducerCaptureEvent event;
+  *event.mutable_warning_instrumenting_with_uprobes_event() =
+      std::move(warning_instrumenting_with_uprobes_event);
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
+}
+
 }  // namespace orbit_linux_capture_service

--- a/src/LinuxCaptureService/TracingHandler.h
+++ b/src/LinuxCaptureService/TracingHandler.h
@@ -61,6 +61,9 @@ class TracingHandler : public orbit_linux_tracing::TracerListener {
       orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) override;
   void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent
                                             out_of_order_events_discarded_event) override;
+  void OnWarningInstrumentingWithUprobesEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+          warning_instrumenting_with_uprobes_event) override;
 
   void ProcessFunctionEntry(const orbit_grpc_protos::FunctionEntry& function_entry) {
     tracer_->ProcessFunctionEntry(function_entry);

--- a/src/LinuxTracing/MockTracerListener.h
+++ b/src/LinuxTracing/MockTracerListener.h
@@ -27,6 +27,8 @@ class MockTracerListener : public TracerListener {
   MOCK_METHOD(void, OnLostPerfRecordsEvent, (orbit_grpc_protos::LostPerfRecordsEvent), (override));
   MOCK_METHOD(void, OnOutOfOrderEventsDiscardedEvent,
               (orbit_grpc_protos::OutOfOrderEventsDiscardedEvent), (override));
+  MOCK_METHOD(void, OnWarningInstrumentingWithUprobesEvent,
+              (orbit_grpc_protos::WarningInstrumentingWithUprobesEvent), (override));
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -30,6 +30,9 @@ class TracerListener {
       orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) = 0;
   virtual void OnOutOfOrderEventsDiscardedEvent(
       orbit_grpc_protos::OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event) = 0;
+  virtual void OnWarningInstrumentingWithUprobesEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+          warning_instrumenting_with_uprobes_event) = 0;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -89,6 +89,9 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
   void OnErrorsWithPerfEventOpenEvent(
       orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/)
       override {}
+  void OnWarningInstrumentingWithUprobesEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+      /*warning_instrumenting_with_uprobes_event*/) override {}
   void OnErrorEnablingOrbitApiEvent(
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {}
   void OnErrorEnablingUserSpaceInstrumentationEvent(

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -674,6 +674,13 @@ void OrbitApp::OnErrorsWithPerfEventOpenEvent(
   });
 }
 
+void OrbitApp::OnWarningInstrumentingWithUprobesEvent(
+    orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+    /*warning_instrumenting_with_uprobes_event*/) {
+  // TODO(b/232072696): Display WarningInstrumentingWithUprobesEvent in the Capture Log.
+  ORBIT_UNREACHABLE();
+}
+
 void OrbitApp::OnErrorEnablingOrbitApiEvent(
     orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) {
   main_thread_executor_->Schedule(

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -181,6 +181,9 @@ class OrbitApp final : public DataViewFactory,
       orbit_grpc_protos::ClockResolutionEvent clock_resolution_event) override;
   void OnErrorsWithPerfEventOpenEvent(
       orbit_grpc_protos::ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event) override;
+  void OnWarningInstrumentingWithUprobesEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+          warning_instrumenting_with_uprobes_event) override;
   void OnErrorEnablingOrbitApiEvent(
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) override;
   void OnErrorEnablingUserSpaceInstrumentationEvent(

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -172,6 +172,11 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
       override {
     ORBIT_UNREACHABLE();
   }
+  void OnWarningInstrumentingWithUprobesEvent(
+      orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
+      /*warning_instrumenting_with_uprobes_event*/) override {
+    ORBIT_UNREACHABLE();
+  }
   void OnErrorEnablingOrbitApiEvent(
       orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {
     ORBIT_UNREACHABLE();

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -55,6 +55,7 @@ using orbit_grpc_protos::ThreadNamesSnapshot;
 using orbit_grpc_protos::ThreadStateSlice;
 using orbit_grpc_protos::TracepointEvent;
 using orbit_grpc_protos::WarningEvent;
+using orbit_grpc_protos::WarningInstrumentingWithUprobesEvent;
 using orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent;
 
 namespace orbit_producer_event_processor {
@@ -147,6 +148,8 @@ class ProducerEventProcessorImpl : public ProducerEventProcessor {
   void ProcessThreadNamesSnapshotAndTransferOwnership(ThreadNamesSnapshot* thread_names_snapshot);
   void ProcessThreadStateSliceAndTransferOwnership(ThreadStateSlice* thread_state_slice);
   void ProcessWarningEventAndTransferOwnership(WarningEvent* warning_event);
+  void ProcessWarningInstrumentingWithUprobesEventAndTransferOwnership(
+      WarningInstrumentingWithUprobesEvent* warning_event);
   void ProcessWarningInstrumentingWithUserSpaceInstrumentationEventAndTransferOwnership(
       WarningInstrumentingWithUserSpaceInstrumentationEvent* warning_event);
 
@@ -545,6 +548,13 @@ void ProducerEventProcessorImpl::ProcessWarningEventAndTransferOwnership(
   client_capture_event_collector_->AddEvent(std::move(event));
 }
 
+void ProducerEventProcessorImpl::ProcessWarningInstrumentingWithUprobesEventAndTransferOwnership(
+    WarningInstrumentingWithUprobesEvent* warning_event) {
+  ClientCaptureEvent event;
+  event.set_allocated_warning_instrumenting_with_uprobes_event(warning_event);
+  client_capture_event_collector_->AddEvent(std::move(event));
+}
+
 void ProducerEventProcessorImpl::
     ProcessWarningInstrumentingWithUserSpaceInstrumentationEventAndTransferOwnership(
         WarningInstrumentingWithUserSpaceInstrumentationEvent* warning_event) {
@@ -679,6 +689,10 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
       break;
     case ProducerCaptureEvent::kWarningEvent:
       ProcessWarningEventAndTransferOwnership(event.release_warning_event());
+      break;
+    case ProducerCaptureEvent::kWarningInstrumentingWithUprobesEvent:
+      ProcessWarningInstrumentingWithUprobesEventAndTransferOwnership(
+          event.release_warning_instrumenting_with_uprobes_event());
       break;
     case ProducerCaptureEvent::kWarningInstrumentingWithUserSpaceInstrumentationEvent:
       ProcessWarningInstrumentingWithUserSpaceInstrumentationEventAndTransferOwnership(


### PR DESCRIPTION
This is very similar to `WarningInstrumentingWithUserSpaceInstrumentationEvent`
and it reuses `FunctionThatFailedToBeInstrumented`.
This will record whether a function cannot be instrumented with uprobes (because
a file mapping with the function's module and file offset doesn't exist).

Screenshot from full prototype: http://screen/Bio3seyMgy5bMue

Bug: http://b/232072696

Test:
- Build.
- As part of the full prototype that also produces them: try to instrument
  some functions with uprobes from the "unaligned" `triangle.exe` and verify the
  message in the "Capture Log".