### PR TITLE
Add & use ComputeVirtualAddressOfInstrumentedFunctionsIfNecessary

### DIFF
--- a/src/ClientData/ModuleAndFunctionLookupTest.cpp
+++ b/src/ClientData/ModuleAndFunctionLookupTest.cpp
@@ -16,47 +16,6 @@ using orbit_grpc_protos::SymbolInfo;
 
 namespace orbit_client_data {
 
-TEST(ModuleAndFunctionLookup, FindFunctionByModulePathBuildIdAndOffset) {
-  constexpr const char* kModuleFilePath = "/path/to/module";
-  constexpr const char* kModuleBuildId = "build_id";
-  constexpr uint64_t kModuleLoadBias = 0x1000;
-
-  constexpr const char* kFunctionName = "foo()";
-  constexpr uint64_t kFunctionVirtualAddress = 0x3000;
-  constexpr uint64_t kFunctionOffset = kFunctionVirtualAddress - kModuleLoadBias;
-
-  ModuleManager module_manager;
-
-  const FunctionInfo* function_info = FindFunctionByModulePathBuildIdAndOffset(
-      module_manager, kModuleFilePath, kModuleBuildId, kFunctionOffset);
-  EXPECT_EQ(function_info, nullptr);
-
-  ModuleInfo module_info;
-  module_info.set_file_path(kModuleFilePath);
-  module_info.set_build_id(kModuleBuildId);
-  module_info.set_load_bias(kModuleLoadBias);
-
-  std::ignore = module_manager.AddOrUpdateModules({module_info});
-
-  function_info = FindFunctionByModulePathBuildIdAndOffset(module_manager, kModuleFilePath,
-                                                           kModuleBuildId, kFunctionOffset);
-  EXPECT_EQ(function_info, nullptr);
-
-  ModuleSymbols module_symbols;
-  SymbolInfo* symbol_info = module_symbols.add_symbol_infos();
-  symbol_info->set_demangled_name(kFunctionName);
-  symbol_info->set_address(kFunctionVirtualAddress);
-  ModuleData* module_data =
-      module_manager.GetMutableModuleByPathAndBuildId(kModuleFilePath, kModuleBuildId);
-  module_data->AddSymbols(module_symbols);
-
-  function_info = FindFunctionByModulePathBuildIdAndOffset(module_manager, kModuleFilePath,
-                                                           kModuleBuildId, kFunctionOffset);
-  ASSERT_NE(function_info, nullptr);
-  EXPECT_EQ(function_info->pretty_name(), kFunctionName);
-  EXPECT_EQ(function_info->address(), kFunctionVirtualAddress);
-}
-
 TEST(ModuleAndFunctionLookup, FindFunctionByModulePathBuildIdAndVirtualAddress) {
   constexpr const char* kModuleFilePath = "/path/to/module";
   constexpr const char* kModuleBuildId = "build_id";

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -84,6 +84,8 @@ class CaptureData {
   [[nodiscard]] const orbit_grpc_protos::InstrumentedFunction* GetInstrumentedFunctionById(
       uint64_t function_id) const;
 
+  void ComputeVirtualAddressOfInstrumentedFunctionsIfNecessary(const ModuleManager& module_manager);
+
   [[nodiscard]] uint32_t process_id() const;
 
   [[nodiscard]] std::string process_name() const;

--- a/src/ClientData/include/ClientData/ModuleAndFunctionLookup.h
+++ b/src/ClientData/include/ClientData/ModuleAndFunctionLookup.h
@@ -22,12 +22,6 @@ const std::string kUnknownFunctionOrModuleName{"???"};
     const ModuleManager& module_manager, const CaptureData& capture_data,
     uint64_t absolute_address);
 
-// Prefer FindFunctionByModulePathBuildIdAndVirtualAddress, which doesn't need to convert from
-// offset in file to virtual address.
-[[nodiscard, deprecated]] const FunctionInfo* FindFunctionByModulePathBuildIdAndOffset(
-    const ModuleManager& module_manager, const std::string& module_path,
-    const std::string& build_id, uint64_t offset);
-
 [[nodiscard]] const FunctionInfo* FindFunctionByModulePathBuildIdAndVirtualAddress(
     const ModuleManager& module_manager, const std::string& module_path,
     const std::string& build_id, uint64_t virtual_address);
@@ -48,8 +42,7 @@ FindModulePathAndBuildIdByAddress(const ModuleManager& module_manager,
     const ProcessData& process, const ModuleManager& module_manager, uint64_t absolute_address);
 
 [[nodiscard]] std::optional<uint64_t> FindInstrumentedFunctionIdSlow(
-    const ModuleManager& module_manager, const CaptureData& capture_data,
-    const FunctionInfo& function);
+    const CaptureData& capture_data, const FunctionInfo& function_info);
 
 }  // namespace orbit_client_data
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -71,9 +71,8 @@ bool FunctionsDataView::ShouldShowFrameTrackIcon(AppInterface* app, const Functi
   }
 
   const CaptureData& capture_data = app->GetCaptureData();
-  const ModuleManager* module_manager = app->GetModuleManager();
   std::optional<uint64_t> instrumented_function_id =
-      orbit_client_data::FindInstrumentedFunctionIdSlow(*module_manager, capture_data, function);
+      orbit_client_data::FindInstrumentedFunctionIdSlow(capture_data, function);
 
   return instrumented_function_id &&
          app->HasFrameTrackInCaptureData(instrumented_function_id.value());

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -500,19 +500,11 @@ void LiveFunctionsDataView::OnDataChanged() {
     const ModuleManager* module_manager = app_->GetModuleManager();
     const FunctionInfo* function_info_from_capture_data;
 
-    // InstrumentedFunction::function_virtual_address() was added in 1.82: if this is not available,
-    // we need to keep using file_offset() to preserve compatibility with older captures.
-    if (instrumented_function.function_virtual_address() == 0) {
-      function_info_from_capture_data = orbit_client_data::FindFunctionByModulePathBuildIdAndOffset(
-          *module_manager, instrumented_function.file_path(), instrumented_function.file_build_id(),
-          instrumented_function.file_offset());
-    } else {
-      function_info_from_capture_data =
-          orbit_client_data::FindFunctionByModulePathBuildIdAndVirtualAddress(
-              *module_manager, instrumented_function.file_path(),
-              instrumented_function.file_build_id(),
-              instrumented_function.function_virtual_address());
-    }
+    function_info_from_capture_data =
+        orbit_client_data::FindFunctionByModulePathBuildIdAndVirtualAddress(
+            *module_manager, instrumented_function.file_path(),
+            instrumented_function.file_build_id(),
+            instrumented_function.function_virtual_address());
 
     // This could happen because module has not yet been updated, it also
     // happens when loading capture. In which case we will try to construct
@@ -598,20 +590,8 @@ std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrum
   const std::string& function_name = GetScopeInfo(scope_id.value()).GetName();
 
   // size is unknown
-  if (instrumented_function.function_virtual_address() == 0) {
-    // InstrumentedFunction::function_virtual_address() was added in 1.82: if this is not available,
-    // we need to keep using file_offset() to preserve compatibility with older captures.
-    // But note that ModuleData::ConvertFromOffsetInFileToVirtualAddress will use the ELF-specific
-    // computation of the virtual address as ModuleInfo::object_segments() was also added in 1.82.
-    return FunctionInfo{
-        instrumented_function.file_path(), instrumented_function.file_build_id(),
-        module_data->ConvertFromOffsetInFileToVirtualAddress(instrumented_function.file_offset()),
-        /*size=*/0, function_name};
-  } else {
-    return FunctionInfo{instrumented_function.file_path(), instrumented_function.file_build_id(),
-                        instrumented_function.function_virtual_address(), /*size=*/0,
-                        function_name};
-  }
+  return FunctionInfo{instrumented_function.file_path(), instrumented_function.file_build_id(),
+                      instrumented_function.function_virtual_address(), /*size=*/0, function_name};
 }
 
 [[nodiscard]] const orbit_client_data::ScopeInfo& LiveFunctionsDataView::GetScopeInfo(


### PR DESCRIPTION
Follow up from https://github.com/google/orbit/pull/3918: instead of checking
whether `InstrumentedFunction::function_virtual_address()` is available in
multiple parts of the code, simply compute it from `file_offset()` right at the
end of the capture if it is not available (in `OrbitApp::OnCaptureComplete`,
where we do other post-processing).

This allows for further clean-ups.

Bug: http://b/235824531

Test:
- Take captures with instrumented functions, both with uprobes and user space
  instrumentation.
- Load an older capture with instrumented functions. Enable and disable frame
  tracks.