### PR TITLE
Automatically add a Frame Track for QueuePresentKHR if available

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -83,3 +83,5 @@ ABSL_FLAG(
     bool, auto_symbol_loading, true,
     "Enable automatic symbol loading. This is turned on by default. If Orbit becomes unresponsive, "
     "try turning automatic symbol loading off (--auto_symbol_loading=false)");
+
+ABSL_FLAG(bool, auto_frame_track, false, "Automatically add the default Frame Track.");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -68,4 +68,6 @@ ABSL_DECLARE_FLAG(bool, enable_unsafe_symbols);
 // Enables automatic symbol loading
 ABSL_DECLARE_FLAG(bool, auto_symbol_loading);
 
+ABSL_DECLARE_FLAG(bool, auto_frame_track);
+
 #endif  // CLIENT_FLAGS_CLIENT_FLAGS_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -80,6 +80,7 @@
 #include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
 #include "OrbitBase/CanceledOr.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/FutureHelpers.h"
@@ -2481,8 +2482,45 @@ Future<std::vector<ErrorMessageOr<CanceledOr<void>>>> OrbitApp::LoadAllSymbols()
 
     loading_futures.push_back(RetrieveModuleAndLoadSymbols(module));
   }
+  if (absl::GetFlag(FLAGS_auto_frame_track)) {
+    // Orbit will try to add the default frame track while loading all symbols.
+    std::ignore = AddDefaultFrameTrack();
+  }
 
   return orbit_base::WhenAll(absl::MakeConstSpan(loading_futures));
+}
+
+Future<ErrorMessageOr<void>> OrbitApp::AddDefaultFrameTrack() {
+  const std::filesystem::path default_auto_preset_folder_path =
+      orbit_base::GetExecutableDir() / "autopresets";
+  const std::filesystem::path stadia_default_preset_path =
+      default_auto_preset_folder_path / "stadia-default-frame-track.opr";
+
+  std::vector<std::filesystem::path> auto_preset_paths = {stadia_default_preset_path};
+
+  // Each preset in auto_preset_paths contains a FrameTrack that users might be interested in
+  // loading by default. Orbit will try to load automatically the first loadable preset from the
+  // list. If no presets could be loaded, Orbit will just log an error.
+  for (std::filesystem::path preset_path : auto_preset_paths) {
+    const ErrorMessageOr<PresetFile> preset = ReadPresetFromFile(preset_path);
+    // Errors on reading a preset from a file won't be shown, Orbit simply will try the next preset
+    // from the list until someone is loadable.
+    if (preset.has_value() &&
+        GetPresetLoadState(preset.value()).state == orbit_data_views::PresetLoadState::kLoadable) {
+      orbit_base::ImmediateExecutor immediate_executor{};
+      return LoadPreset(preset.value())
+          .Then(&immediate_executor, [](ErrorMessageOr<void> result) -> ErrorMessageOr<void> {
+            if (result.has_value()) {
+              ORBIT_LOG("The default frame track was automatically added.");
+            }
+            return result;
+          });
+    }
+  }
+  std::string error_message =
+      "It was not possible to add a frame track automatically, because its module can't be loaded.";
+  ORBIT_ERROR("%s", error_message);
+  return ErrorMessage(error_message);
 }
 
 void OrbitApp::RefreshUIAfterModuleReload() {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2509,17 +2509,17 @@ Future<void> OrbitApp::AddDefaultFrameTrackOrLogError() {
     if (preset.has_value() &&
         GetPresetLoadState(preset.value()).state == orbit_data_views::PresetLoadState::kLoadable) {
       orbit_base::ImmediateExecutor immediate_executor{};
-      LoadPreset(preset.value()).Then(&immediate_executor, [](ErrorMessageOr<void> result) {
-        if (result.has_error()) {
-          ORBIT_ERROR(
-              "It was not possible to add a frame track automatically. The desired preset couldn't "
-              "be loaded: %s",
-              result.error().message());
-        } else {
-          ORBIT_LOG("The default frame track was automatically added.");
-        }
-      });
-      return {};
+      return LoadPreset(preset.value())
+          .Then(&immediate_executor, [](ErrorMessageOr<void> result) -> void {
+            if (result.has_error()) {
+              ORBIT_ERROR(
+                  "It was not possible to add a frame track automatically. The desired preset "
+                  "couldn't be loaded: %s",
+                  result.error().message());
+            } else {
+              ORBIT_LOG("The default frame track was automatically added.");
+            }
+          });
     }
   }
   std::string error_message =

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2499,12 +2499,13 @@ Future<ErrorMessageOr<void>> OrbitApp::AddDefaultFrameTrack() {
   std::vector<std::filesystem::path> auto_preset_paths = {stadia_default_preset_path};
 
   // Each preset in auto_preset_paths contains a FrameTrack that users might be interested in
-  // loading by default. Orbit will try to load automatically the first loadable preset from the
-  // list. If no presets could be loaded, Orbit will just log an error.
+  // loading by default. Orbit will try to load automatically just the first loadable preset from
+  // the list as we don't want Orbit to automatically add more than one FrameTrack. If no presets
+  // could be loaded, Orbit will log an error.
   for (std::filesystem::path preset_path : auto_preset_paths) {
     const ErrorMessageOr<PresetFile> preset = ReadPresetFromFile(preset_path);
     // Errors on reading a preset from a file won't be shown, Orbit simply will try the next preset
-    // from the list until someone is loadable.
+    // from the list until one of them is loadable.
     if (preset.has_value() &&
         GetPresetLoadState(preset.value()).state == orbit_data_views::PresetLoadState::kLoadable) {
       orbit_base::ImmediateExecutor immediate_executor{};
@@ -2518,7 +2519,9 @@ Future<ErrorMessageOr<void>> OrbitApp::AddDefaultFrameTrack() {
     }
   }
   std::string error_message =
-      "It was not possible to add a frame track automatically, because its module can't be loaded.";
+      "It was not possible to add a frame track automatically, because none of the presets "
+      "available for auto-loading could be loaded. The reason might be that you are not profiling "
+      "a Stadia-game running with Vulkan.";
   ORBIT_ERROR("%s", error_message);
   return ErrorMessage(error_message);
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -556,7 +556,7 @@ class OrbitApp final : public DataViewFactory,
 
   // Automatically add a default Frame Track. It will choose only one frame track from an internal
   // list of auto-loadable presets.
-  orbit_base::Future<ErrorMessageOr<void>> AddDefaultFrameTrack();
+  orbit_base::Future<void> AddDefaultFrameTrackOrLogError();
 
  private:
   void UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -554,6 +554,11 @@ class OrbitApp final : public DataViewFactory,
   // no particular order.
   orbit_base::Future<std::vector<ErrorMessageOr<orbit_base::CanceledOr<void>>>> LoadAllSymbols();
 
+  // Automatically add a default Frame Track. It will choose the function
+  // yeti::internal::vulkan::(anonymous namespace)::QueuePresentKHR from the module `ggpvlk.so` if
+  // available.
+  orbit_base::Future<ErrorMessageOr<void>> AddDefaultFrameTrack();
+
  private:
   void UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(
       absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -554,9 +554,8 @@ class OrbitApp final : public DataViewFactory,
   // no particular order.
   orbit_base::Future<std::vector<ErrorMessageOr<orbit_base::CanceledOr<void>>>> LoadAllSymbols();
 
-  // Automatically add a default Frame Track. It will choose the function
-  // yeti::internal::vulkan::(anonymous namespace)::QueuePresentKHR from the module `ggpvlk.so` if
-  // available.
+  // Automatically add a default Frame Track. It will choose only one frame track from an internal
+  // list of auto-loadable presets.
   orbit_base::Future<ErrorMessageOr<void>> AddDefaultFrameTrack();
 
  private:


### PR DESCRIPTION
In this PR we are adding the logic for automatically adding a FrameTrack
for QueuePresentKHR (ggpvlk.so) if the module is available.

We are including this method as part of LoadAllSymbols, as the plan is
adding a FrameTrack as soon as the symbols for the needed module are
loaded without waiting for all of them. It's also behind a flag that now is 
false and will be turned on after branch but (http://b/239149548).

Test: Locally, set the flag to true and create some preset files locally:
 - Check that the frame-track is added if the module is available.
 - Check nothing happened when the module is not available to be loaded.
 - Check nothing happened when the preset file doesn't exist.
 - Take a capture before the ggpvlk module is loaded, check there is no
   FrameTrack. Stop the capture, wait for the module to be loaded. Take
   another capture. Check the FrameTrack was added.
 - Add another preset file to the list, check the second preset file is
   added only when the first one is not loadable.

Bug: http://b/239148765.

Next steps:
- http://b/239148767 (Adapt E2E tests).
- http://b/239155921 (Ship the default frame track as a file - after
  branch cut).