### PR TITLE
Ignore all target flags when re-instantiating Orbit

### DIFF
--- a/src/CommandLineUtils/CommandLineUtils.cpp
+++ b/src/CommandLineUtils/CommandLineUtils.cpp
@@ -6,6 +6,9 @@
 
 #include <absl/container/flat_hash_set.h>
 
+#include "ClientFlags/ClientFlags.h"
+#include "absl/flags/flag.h"
+
 namespace orbit_command_line_utils {
 
 QStringList ExtractCommandLineFlags(const std::vector<std::string>& command_line_args,
@@ -21,14 +24,27 @@ QStringList ExtractCommandLineFlags(const std::vector<std::string>& command_line
   return command_line_flags;
 }
 
+// TODO(b/239181650): Add unit tests for this.
 QStringList RemoveFlagsNotPassedToMainWindow(const QStringList& flags) {
   QStringList result;
+  const std::array kDoNotPassTheseFlags{absl::GetFlagReflectionHandle(FLAGS_target_instance).Name(),
+                                        absl::GetFlagReflectionHandle(FLAGS_target_process).Name(),
+                                        absl::GetFlagReflectionHandle(FLAGS_target_uri).Name()};
+
   for (auto flag = flags.begin(); flag != flags.end(); ++flag) {
-    if (flag->startsWith("--connection_target=")) {
-      continue;
+    bool ignore_this_flag = false;
+
+    for (auto ignore_flag : kDoNotPassTheseFlags) {
+      const QString flag_cmd_format =
+          QString("-%1=").arg(QString::fromStdString(std::string{ignore_flag}));
+      if (flag->contains(flag_cmd_format)) {
+        ignore_this_flag = true;
+      }
     }
 
-    result.push_back(*flag);
+    if (!ignore_this_flag) {
+      result.push_back(*flag);
+    }
   }
 
   return result;


### PR DESCRIPTION
When opening a capture file from an Orbit instance that was connected
using --taret_process / --target_instance or --target_uri, loading that
file fails. Orbit starts a new instance and copies all command line
parameters, but the aforementioned parameters should *not* be passed to
the new instance. This was broken when changing the parameter name.

Bug: b/238987946
Test: Manual testing - specify --target_process and --target_instance,
then open a capture