### PR TITLE
Save and use additional stack slices for unwinding

### DIFF
--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -130,6 +130,7 @@ struct UprobesWithArgumentsPerfEventData {
 using UprobesWithArgumentsPerfEvent = TypedPerfEvent<UprobesWithArgumentsPerfEventData>;
 
 struct UprobesWithStackPerfEventData {
+  uint64_t stream_id;
   pid_t pid;
   pid_t tid;
   perf_event_sample_regs_user_sp regs;

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -306,6 +306,7 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
+              .stream_id = sample_id.stream_id,
               .pid = static_cast<pid_t>(sample_id.pid),
               .tid = static_cast<pid_t>(sample_id.tid),
               .regs = regs,

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -226,6 +226,14 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
                                    event_data.data.get()};
   std::vector<StackSliceView> stack_slices{event_stack_slice};
 
+  const auto& stream_id_to_user_stack = thread_id_stream_id_to_stack_slices_.find(event_data.tid);
+  if (stream_id_to_user_stack != thread_id_stream_id_to_stack_slices_.end()) {
+    for (const auto& [unused_stream_id, user_stack_slice] : stream_id_to_user_stack->second) {
+      stack_slices.emplace_back(user_stack_slice.start_address_, user_stack_slice.size_,
+                                user_stack_slice.data_.get());
+    }
+  }
+
   LibunwindstackResult libunwindstack_result = unwinder_->Unwind(
       event_data.pid, current_maps_->Get(), event_data.GetRegisters(), stack_slices);
 
@@ -428,6 +436,16 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
   OnUprobes(event_timestamp, event_data.tid, event_data.cpu, event_data.sp, event_data.ip,
             event_data.return_address,
             /*registers=*/std::nullopt, event_data.function_id);
+}
+
+void UprobesUnwindingVisitor::Visit(uint64_t /*event_timestamp*/,
+                                    const UprobesWithStackPerfEventData& event_data) {
+  StackSlice stack_slice{.start_address_ = event_data.regs.sp,
+                         .size_ = event_data.dyn_size,
+                         .data_ = std::move(event_data.data)};
+  absl::flat_hash_map<uint64_t, StackSlice>& stream_id_to_stack =
+      thread_id_stream_id_to_stack_slices_[event_data.tid];
+  stream_id_to_stack.insert_or_assign(event_data.stream_id, std::move(stack_slice));
 }
 
 void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -71,8 +71,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   UprobesUnwindingVisitor(const UprobesUnwindingVisitor&) = delete;
   UprobesUnwindingVisitor& operator=(const UprobesUnwindingVisitor&) = delete;
 
-  UprobesUnwindingVisitor(UprobesUnwindingVisitor&&) = default;
-  UprobesUnwindingVisitor& operator=(UprobesUnwindingVisitor&&) = default;
+  UprobesUnwindingVisitor(UprobesUnwindingVisitor&&) = delete;
+  UprobesUnwindingVisitor& operator=(UprobesUnwindingVisitor&&) = delete;
 
   void SetUnwindErrorsAndDiscardedSamplesCounters(
       std::atomic<uint64_t>* unwind_error_counter,
@@ -84,6 +84,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   void Visit(uint64_t event_timestamp, const StackSamplePerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const CallchainSamplePerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const UprobesPerfEventData& event_data) override;
+  void Visit(uint64_t event_timestamp, const UprobesWithStackPerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp,
              const UprobesWithArgumentsPerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const UretprobesPerfEventData& event_data) override;
@@ -134,6 +135,9 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   absl::flat_hash_map<pid_t, std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>>
       uprobe_sps_ips_cpus_per_thread_{};
   absl::flat_hash_set<uint64_t> known_linux_address_infos_{};
+
+  absl::flat_hash_map<pid_t, absl::flat_hash_map<uint64_t, StackSlice>>
+      thread_id_stream_id_to_stack_slices_{};
 };
 
 }  // namespace orbit_linux_tracing


### PR DESCRIPTION
With this change, we save the stack slices on `UprobesWithStackPerfData`
events by thread id and stream id. On sample events we then pass
all stack slices for the sampled thread id to the unwinder.

This is the last piece to support unwinding through
__wine_syscall_disptacher.

Test: Unit test & E2E test on usual target
Bug: http://b/236118579