### PR TITLE
Fix ManualInstrumentationOnSilenus test

### DIFF
--- a/contrib/automation_tests/orbit_manual_instrumentation_silenus.py
+++ b/contrib/automation_tests/orbit_manual_instrumentation_silenus.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture, CheckTimers, CollapseTrack, VerifyTracksExist
+from test_cases.capture_window import Capture, CheckTimers, FilterTracks, VerifyTracksExist
 from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
 """Test Orbit's manual instrumentation on Silenus.
 
@@ -39,8 +39,10 @@ def main(argv):
             "Render (async)"
         ]),
         VerifyTracksExist(track_names="triangle.exe", allow_duplicates=True),
+        FilterTracks(filter_string="Render"),
         CheckTimers(track_name_filter="Render (async)"),
-        # There are multiple tracks with the name of the process, and we can't rename threads on Windows,
+        FilterTracks(filter_string="triangle.exe"),
+        # There can be multiple tracks with the name of the process, and we can't rename threads on Windows,
         # hence `require_all=False`.
         CheckTimers(track_name_filter="triangle.exe", require_all=False),
     ]

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -549,6 +549,8 @@ class CheckThreadStates(CaptureWindowE2ETestCaseBase):
                                  'Track {} has a no thread state pane'.format(track.name))
 
 
+# TODO(b/239396452): Consider filtering the tracks before looking for matching ones in order to avoid failures related
+#  to a track being too far down and hence off-screen.
 class CheckTimers(CaptureWindowE2ETestCaseBase):
 
     def _check_all_tracks(self, tracks, expect_exists):


### PR DESCRIPTION
This test is failing on the test machine on `CheckTimers`.
The cause seems to be that the "triangle.exe" track is too far down and hence
offscreen.
Use `FilterTracks` to make it visible (and do the same for the
"Render (async)" track).

Bug: http://b/239218513

Test: Ran locally with smaller window size.