### PR TITLE
Remove support of `kAllProcessThreadsTid` from `MizarPairedData`

### DIFF
--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -218,28 +218,26 @@ TEST_F(MizarPairedDataTest, ForeachCallstackIsCorrect) {
     actual_ids_fed_to_action.push_back(ids);
   };
 
-  // All threads, all timestamps
-  actual_ids_fed_to_action.clear();
-  mizar_paired_data.ForEachCallstackEvent(TID(orbit_base::kAllProcessThreadsTid), 0, kRelativeTime5,
-                                          action);
-  EXPECT_THAT(actual_ids_fed_to_action,
-              UnorderedElementsAre(kCompleteCallstackIds, kCompleteCallstackIds,
-                                   kInCompleteCallstackIds, kAnotherCompleteCallstackIds));
-
-  // One thread, all timestamps
+  // all timestamps
   actual_ids_fed_to_action.clear();
   mizar_paired_data.ForEachCallstackEvent(kTID, 0, kRelativeTime5, action);
   EXPECT_THAT(
       actual_ids_fed_to_action,
       UnorderedElementsAre(kCompleteCallstackIds, kCompleteCallstackIds, kInCompleteCallstackIds));
 
-  // All threads, some timestamps
   actual_ids_fed_to_action.clear();
-  mizar_paired_data.ForEachCallstackEvent(TID(orbit_base::kAllProcessThreadsTid), kRelativeTime1,
-                                          kRelativeTime5, action);
+  mizar_paired_data.ForEachCallstackEvent(kAnotherTID, 0, kRelativeTime5, action);
+  EXPECT_THAT(actual_ids_fed_to_action, UnorderedElementsAre(kAnotherCompleteCallstackIds));
+
+  //  some timestamps
+  actual_ids_fed_to_action.clear();
+  mizar_paired_data.ForEachCallstackEvent(kTID, kRelativeTime1, kRelativeTime5, action);
   EXPECT_THAT(actual_ids_fed_to_action,
-              UnorderedElementsAre(kCompleteCallstackIds, kInCompleteCallstackIds,
-                                   kAnotherCompleteCallstackIds));
+              UnorderedElementsAre(kCompleteCallstackIds, kInCompleteCallstackIds));
+
+  actual_ids_fed_to_action.clear();
+  mizar_paired_data.ForEachCallstackEvent(kAnotherTID, kRelativeTime1, kRelativeTime5, action);
+  EXPECT_THAT(actual_ids_fed_to_action, UnorderedElementsAre(kAnotherCompleteCallstackIds));
 }
 
 TEST_F(MizarPairedDataTest, ActiveInvocationTimesIsCorrect) {

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -146,13 +146,8 @@ class MizarPairedDataTmpl {
   void ForEachCallstackEventOfTidInTimeRange(TID tid, uint64_t min_timestamp_ns,
                                              uint64_t max_timestamp_ns,
                                              Action&& action_on_callstack_events) const {
-    if (*tid == orbit_base::kAllProcessThreadsTid) {
-      GetCallstackData().ForEachCallstackEventInTimeRange(min_timestamp_ns, max_timestamp_ns,
-                                                          action_on_callstack_events);
-    } else {
-      GetCallstackData().ForEachCallstackEventOfTidInTimeRange(
-          *tid, min_timestamp_ns, max_timestamp_ns, action_on_callstack_events);
-    }
+    GetCallstackData().ForEachCallstackEventOfTidInTimeRange(
+        *tid, min_timestamp_ns, max_timestamp_ns, action_on_callstack_events);
   }
 
   [[nodiscard]] uint64_t CallstackSamplesCount(TID tid, uint64_t min_timestamp_ns,


### PR DESCRIPTION
The support was added for testing only. In presence of GUI
it's not used anymore.

Test: Unit, Manual
Bug: http://b/239393814