### PR TITLE
Improve orbit_loaded_top_down_bottom_up_test.py

### DIFF
--- a/contrib/automation_tests/test_cases/bottom_up_tab.py
+++ b/contrib/automation_tests/test_cases/bottom_up_tab.py
@@ -81,6 +81,10 @@ class VerifyBottomUpContentForLoadedCapture(E2ETestCase):
             logging.info("Switched to 'Bottom-Up (selection)' tab")
             return self.find_control('Group', 'selectionBottomUpTab')
 
+    def _collapse_tree(self, tree_view_table: Table):
+        tree_view_table.get_item_at(0, 0).click_input(button='right')
+        self.find_context_menu_item("Collapse all").click_input()
+
     HIDDEN_COLUMNS = {2}
 
     def _verify_columns(self, tree_view_table):
@@ -124,7 +128,7 @@ class VerifyBottomUpContentForLoadedCapture(E2ETestCase):
     def _verify_rows_when_node_recursively_expanded(self, tree_view_table):
         logging.info("Recursively expanding a node of the bottom-up view")
         tree_view_table.get_item_at(0, 0).click_input(button='right')
-        self.find_context_menu_item('Expand recursively').click_input()
+        self.find_context_menu_item('Expand recursively\tALT+Click').click_input()
 
         expected_first_leaf_descendant_count = 50
         self._verify_row_count(tree_view_table,
@@ -205,8 +209,11 @@ class VerifyBottomUpContentForLoadedCapture(E2ETestCase):
         self._verify_columns(tree_view_table)
         self._verify_rows_when_tree_collapsed(tree_view_table)
         self._verify_rows_when_node_expanded(tree_view_table)
+        self._collapse_tree(tree_view_table)
         self._verify_rows_when_node_recursively_expanded(tree_view_table)
+        self._collapse_tree(tree_view_table)
         self._verify_rows_when_tree_expanded(tree_view_table)
+        self._collapse_tree(tree_view_table)
         self._verify_rows_on_search(tab, tree_view_table)
 
 

--- a/contrib/automation_tests/test_cases/top_down_tab.py
+++ b/contrib/automation_tests/test_cases/top_down_tab.py
@@ -110,6 +110,10 @@ class VerifyTopDownContentForLoadedCapture(E2ETestCase):
             logging.info("Switched to 'Top-Down (selection)' tab")
             return self.find_control('Group', 'selectionTopDownTab')
 
+    def _collapse_tree(self, tree_view_table: Table):
+        tree_view_table.get_item_at(0, 0).click_input(button='right')
+        self.find_context_menu_item("Collapse all").click_input()
+
     def _verify_columns(self, tree_view_table):
         self.expect_eq(tree_view_table.get_column_count(), 6, "Top-down view has 6 columns")
 
@@ -167,7 +171,7 @@ class VerifyTopDownContentForLoadedCapture(E2ETestCase):
     def _verify_rows_when_thread_recursively_expanded(self, tree_view_table):
         logging.info("Recursively expanding a thread of the top-down view")
         tree_view_table.get_item_at(1, 0).click_input(button='right')
-        self.find_context_menu_item('Expand recursively').click_input()
+        self.find_context_menu_item('Expand recursively\tALT+Click').click_input()
         expected_first_thread_descendant_count = 20
         self._verify_row_count(tree_view_table,
                                self.EXPECTED_THREAD_COUNT + expected_first_thread_descendant_count)
@@ -249,8 +253,11 @@ class VerifyTopDownContentForLoadedCapture(E2ETestCase):
         self._verify_columns(tree_view_table)
         self._verify_rows_when_tree_collapsed(tree_view_table)
         self._verify_rows_when_thread_and_errors_expanded(tree_view_table)
+        self._collapse_tree(tree_view_table)
         self._verify_rows_when_thread_recursively_expanded(tree_view_table)
+        self._collapse_tree(tree_view_table)
         self._verify_rows_when_tree_expanded(tree_view_table)
+        self._collapse_tree(tree_view_table)
         self._verify_rows_on_search(tab, tree_view_table)
 
 


### PR DESCRIPTION
Collapse the tree between the different phases of the test, so that each is
independent from the previous ones. This had shown to be a problem as
http://b/232211219 should have been caught by the test but wasn't.

Bug: http://b/232215760

Test:
- Ran locally.
- Removed fix from https://github.com/google/orbit/pull/3698, ran locally,
  verified it catches the issue described in http://b/232211219.