### PR TITLE
Ship default Frame Track preset file with Orbit

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -272,6 +272,7 @@ chmod -v 4775 /opt/developer/tools/OrbitService
             self.run("dpkg --contents {}.deb".format(basedir))
             shutil.rmtree(basedir)
 
+        self.copy("*", src="bin/autopresets", dst="bin/autopresets", symlinks=True)
         self.copy("*", src="bin/fonts", dst="bin/fonts", symlinks=True)
         self.copy("*", src="bin/shaders", dst="bin/shaders", symlinks=True)
         self.copy("*.pdb", src="bin/", dst="bin")

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -185,6 +185,10 @@ target_link_libraries(
          CONAN_PKG::imgui
          gte::gte)
 
+add_custom_command(TARGET OrbitGl POST_BUILD COMMAND ${CMAKE_COMMAND}
+                   -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/stadia-default-frame-track.opr
+                   ${CMAKE_BINARY_DIR}/bin/autopresets/stadia-default-frame-track.opr)
+
 if(TARGET OpenGL::GLX AND TARGET OpenGL::OpenGL)
   target_link_libraries(OrbitGl PUBLIC OpenGL::GLX)
 elseif(TARGET OpenGL::GL)

--- a/src/OrbitGl/resources/stadia-default-frame-track.opr
+++ b/src/OrbitGl/resources/stadia-default-frame-track.opr
@@ -1,0 +1,8 @@
+# ORBIT preset file
+modules {
+  key: "/usr/local/cloudcast/lib/ggpvlk.so"
+  value {
+    function_names: "yeti::internal::vulkan::(anonymous namespace)::QueuePresentKHR(VkQueue_T*, VkPresentInfoKHR const*)"
+    frame_track_function_names: "yeti::internal::vulkan::(anonymous namespace)::QueuePresentKHR(VkQueue_T*, VkPresentInfoKHR const*)"
+  }
+}


### PR DESCRIPTION
In this PR we are just shipping the default Frame Track preset file for
Stadia. This file will be in the autopreset folder and will be loaded by
default during LoadAllSymbols (https://github.com/google/orbit/pull/3954)

Bug: http://b/239155921

Test: Not tested as nothing has changed. I will test it by running E2E tests
after adapting E2E tests (http://b/239148767) and setting flag to true
 (http://b/239149548).