### PR TITLE
Adapt E2E and turn on --auto-frame-tracks by default

### DIFF
--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -37,7 +37,9 @@ def main(argv):
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         AddFrameTrack(function_name="DrawFrame"),
-        VerifyTracksExist(track_names="Frame track*"),  # Verify there's exactly one frame track
+        # TODO(b/239148938): After allowing users to set auto-frame-track to false:
+        #  Instead of allowing duplicates, set auto-frame track to false while capturing.
+        VerifyTracksExist(track_names="Frame track*", allow_duplicates=True),
         CheckTimers(track_name_filter='Frame track*')  # Verify the frame track has timers
     ]
     suite = E2ETestSuite(test_name="Add Frame Track", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -38,7 +38,9 @@ def main(argv):
         ExpandTrack(expected_name="gfx"),
         CheckTimers(track_name_filter='gfx_submissions', recursive=True),
         CheckTimers(track_name_filter="All Threads", expect_exists=False),
-        CheckTimers(track_name_filter="hello_ggp_stand", expect_exists=False),
+        # TODO(b/239148938): After allowing users to set auto-frame-track to false:
+        #  Set auto-frame track to false while capturing and don't expect timers in hello_ggp.
+        CheckTimers(track_name_filter="hello_ggp_stand"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         VerifyScopeTypeAndHitCount(scope_name='DrawFrame',

--- a/contrib/automation_tests/orbit_track_type_visibility.py
+++ b/contrib/automation_tests/orbit_track_type_visibility.py
@@ -36,7 +36,7 @@ def main(argv):
         ToggleTrackTypeVisibility(track_type="Scheduler"),
         VerifyTracksDoNotExist(track_names="Scheduler"),
 
-        # There should be just one auto-loaded FrameTrack.
+        # There should be exactly one auto loaded frame track.
         VerifyTracksExist(track_names="Frame track*"),
         ToggleTrackTypeVisibility(track_type="Frame Tracks"),
         VerifyTracksDoNotExist(track_names="Frame track*"),

--- a/contrib/automation_tests/orbit_track_type_visibility.py
+++ b/contrib/automation_tests/orbit_track_type_visibility.py
@@ -35,6 +35,11 @@ def main(argv):
         Capture(),
         ToggleTrackTypeVisibility(track_type="Scheduler"),
         VerifyTracksDoNotExist(track_names="Scheduler"),
+
+        # There should be just one auto-loaded FrameTrack.
+        VerifyTracksExist(track_names="Frame track*"),
+        ToggleTrackTypeVisibility(track_type="Frame Tracks"),
+        VerifyTracksDoNotExist(track_names="Frame track*"),
         VerifyTracksExist(track_names="hello_ggp_stand*", allow_duplicates=True),
         ToggleTrackTypeVisibility(track_type="Threads"),
         VerifyTracksDoNotExist(track_names="hello_ggp_stand*"),

--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -16,11 +16,12 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         Capture(),
-        VerifyTracksExist(track_names=["Scheduler", "gfx", "All Threads", "hello_ggp_stand"]),
+        VerifyTracksExist(
+            track_names=["Scheduler", "Frame track*", "gfx", "All Threads", "hello_ggp_stand"]),
         # We check for "sdma0" or "vce0" or both to exist. Both are connected to the encoding of video frames.
         VerifyTracksExist(track_names=[("*sdma0*", "*vce0*")], allow_duplicates=True),
         SelectTrack(track_index=0, expect_failure=True),  # Scheduler track cannot be selected
-        SelectTrack(track_index=4),
+        SelectTrack(track_index=5),  # hello_ggp_stand track can be selected
         # TODO(b/233028574): SelectTrack doesn't release the clicked track properly and can't be followed
         # directly with MoveTrack(). It needs to run DeselectTrack() to release the track before moving
         # tracks.

--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -84,4 +84,4 @@ ABSL_FLAG(
     "Enable automatic symbol loading. This is turned on by default. If Orbit becomes unresponsive, "
     "try turning automatic symbol loading off (--auto_symbol_loading=false)");
 
-ABSL_FLAG(bool, auto_frame_track, false, "Automatically add the default Frame Track.");
+ABSL_FLAG(bool, auto_frame_track, true, "Automatically add the default Frame Track.");


### PR DESCRIPTION
In this PR we are adapting the E2E tests to work with the new automatic
frame track feature and setting the flag true by default.

In the E2E tests basically we are:
 - Allowing temporarily to have 2 frame tracks in the create frame track
   E2E test. We will change it after allowing user to set false to the
   feature.
 - Temporarily expect to have timers when taking a capture in
    instrument_function.
 - Checking visibility of the automatic Frame Track in
   orbit_track_type_visibility.
 - Checking the frame track is visible in orbit_tracks.

Bugs: 
http://b/239148767
http://b/239149548

Test: Run E2E tests with the signed version (http://sponge.corp.google.com/target?id=7010fc8c-0349-5c28-ab3d-1506942f933e&target=//chrome/cloudcast/tools/cli/internal/integrationtest/testrunner/tests:cloudcollector_test&showTestCases=ALL). Iterators tests failed because a crash that it's fixed in parallel.