### PR TITLE
Display WarningInstrumentingWithUprobesEvents

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -684,6 +684,10 @@ void OrbitApp::OnWarningInstrumentingWithUprobesEvent(
          warning_instrumenting_with_uprobes_event.functions_that_failed_to_instrument()) {
       absl::StrAppend(&message, "* ", function.error_message(), "\n");
     }
+    absl::StrAppend(&message,
+                    "\nConsider choosing the method \"Orbit\" for dynamic instrumentation in the "
+                    "Capture Options dialog.\n");
+
     main_window_->AppendToCaptureLog(
         MainWindowInterface::CaptureLogSeverity::kWarning,
         GetCaptureTimeAt(warning_instrumenting_with_uprobes_event.timestamp_ns()), message);
@@ -729,7 +733,7 @@ void OrbitApp::OnErrorEnablingUserSpaceInstrumentationEvent(
 void OrbitApp::OnWarningInstrumentingWithUserSpaceInstrumentationEvent(
     orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent warning_event) {
   main_thread_executor_->Schedule([this, warning_event = std::move(warning_event)]() {
-    std::string message = "Failed to instrument some functions with the Orbit method:\n";
+    std::string message = "Failed to instrument some functions with the \"Orbit\" method:\n";
     for (const auto& function : warning_event.functions_that_failed_to_instrument()) {
       absl::StrAppend(&message, "* ", function.error_message(), "\n");
     }


### PR DESCRIPTION
Print the warning into the "Capture Log", similarly to how it's done for
`WarningInstrumentingWithUserSpaceInstrumentationEvent`.
Note that these events are not yet produced.

Screenshot from full prototype: http://screen/Bio3seyMgy5bMue

Bug: http://b/232072696

Test: As part of the full prototype that also produces them: try to instrument
some functions with uprobes from the "unaligned" `triangle.exe` and verify the
message in the "Capture Log".