### PR TITLE
Fix crash on adding an iterator

### DIFF
--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -216,11 +216,11 @@ void LiveFunctionsController::AddIterator(ScopeId instrumented_function_scope_id
                                           const FunctionInfo* function) {
   uint64_t iterator_id = next_iterator_id_++;
   const orbit_client_protos::TimerInfo* timer_info = app_->selected_timer();
-  const std::optional<ScopeId> scope_id = FunctionIdToScopeId(timer_info->function_id());
   // If no box is currently selected or the selected box is a different
   // function, we search for the closest box to the current center of the
   // screen.
-  if (!timer_info || scope_id != instrumented_function_scope_id) {
+  if (!timer_info ||
+      FunctionIdToScopeId(timer_info->function_id()) != instrumented_function_scope_id) {
     timer_info = SnapToClosestStart(app_->GetMutableTimeGraph(), instrumented_function_scope_id);
   }
 


### PR DESCRIPTION
`TimerInfo*` was being dereferenced before it was checked for null.

Tests: Manual
Bug: http://b/239519861