### PR TITLE
Fix flakyness in e2e test for track interaction.

### DIFF
--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -16,10 +16,9 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         Capture(),
-        # "sdma0" is not present on the DevKits, instead there is "vce0", so this tests for "sdma0 or vce0"
-        VerifyTracksExist(track_names=[
-            "Scheduler", ("*sdma0*", "*vce0*"), "gfx", "All Threads", "hello_ggp_stand"
-        ]),
+        VerifyTracksExist(track_names=["Scheduler", "gfx", "All Threads", "hello_ggp_stand"]),
+        # We check for either "sdma0" or "vce0", to exist. Both are connected to the encoding of video frames.
+        VerifyTracksExist(track_names=[("*sdma0*", "*vce0*")], allow_duplicates=True),
         SelectTrack(track_index=0, expect_failure=True),  # Scheduler track cannot be selected
         SelectTrack(track_index=4),
         # TODO(b/233028574): SelectTrack doesn't release the clicked track properly and can't be followed


### PR DESCRIPTION
Previously we checked for the existance of exactly one tracks containing
"sdma0" or "vce0".
Now we check if at least one is there. See http://b/236637073.

Test: Local run of the test.
Bug: http://b/236637073