### PR TITLE
Disable Conan trace file

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -49,13 +49,6 @@ if [ -n "$1" ]; then
   fi
 
   function cleanup {
-    if [[ $? != 0 ]]; then
-      # An error occured, we will print out the conan trace:
-      echo -e "\n\n---------- CONAN TRACE ----------"
-      cat ${REPO_ROOT}/build/conan_trace.log
-      echo -e "---------------------------------\n\n"
-    fi
-
     # Delete all unnecessary files from the src/-directory.
     # Kokoro would copy them otherwise before applying the artifacts regex
     echo "Delete all unnecessary files from the src/-directory."
@@ -70,7 +63,6 @@ if [ -n "$1" ]; then
                             ! -path "${REPO_ROOT}" \
                             ! -path "${REPO_ROOT}/kokoro*" \
                             ! -path "${REPO_ROOT}/build" \
-                            ! -path "${REPO_ROOT}/build/conan_trace.log" \
                             ! -path "${REPO_ROOT}/build/package*"\
                             -delete
       echo "Cleanup for coverage_clang9 done."
@@ -83,7 +75,6 @@ if [ -n "$1" ]; then
                             ! -path "${REPO_ROOT}" \
                             ! -path "${REPO_ROOT}/kokoro*" \
                             ! -path "${REPO_ROOT}/build" \
-                            ! -path "${REPO_ROOT}/build/conan_trace.log" \
                             ! -path "${REPO_ROOT}/build/testresults*"\
                             -delete
       echo "Cleanup for presubmit done."
@@ -139,9 +130,6 @@ if [ -n "$1" ]; then
 
   # Building Orbit
   mkdir -p "${REPO_ROOT}/build/"
-
-  # Enabling Conan Tracing
-  export CONAN_TRACE_FILE="${REPO_ROOT}/build/conan_trace.log"
 
   if [[ $CONAN_PROFILE == ggp_* ]]; then
     readonly PACKAGING_OPTION="-o debian_packaging=True"

--- a/kokoro/builds/linux/clang11_debug/common.cfg
+++ b/kokoro/builds/linux/clang11_debug/common.cfg
@@ -10,10 +10,3 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
-
-action {
-  define_artifacts {
-    regex: "github/orbitprofiler/build/conan_trace.log"
-    strip_prefix: "github/orbitprofiler/build"
-  }
-}

--- a/kokoro/builds/linux/clang7_relwithdebinfo/common.cfg
+++ b/kokoro/builds/linux/clang7_relwithdebinfo/common.cfg
@@ -10,10 +10,3 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
-
-action {
-  define_artifacts {
-    regex: "github/orbitprofiler/build/conan_trace.log"
-    strip_prefix: "github/orbitprofiler/build"
-  }
-}

--- a/kokoro/builds/linux/clang9_debug/common.cfg
+++ b/kokoro/builds/linux/clang9_debug/common.cfg
@@ -10,10 +10,3 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
-
-action {
-  define_artifacts {
-    regex: "github/orbitprofiler/build/conan_trace.log"
-    strip_prefix: "github/orbitprofiler/build"
-  }
-}

--- a/kokoro/builds/linux/coverage_clang9/common.cfg
+++ b/kokoro/builds/linux/coverage_clang9/common.cfg
@@ -10,10 +10,3 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
-
-action {
-  define_artifacts {
-    regex: "github/orbitprofiler/build/conan_trace.log"
-    strip_prefix: "github/orbitprofiler/build"
-  }
-}

--- a/kokoro/builds/linux/gcc10_release/common.cfg
+++ b/kokoro/builds/linux/gcc10_release/common.cfg
@@ -10,10 +10,3 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
-
-action {
-  define_artifacts {
-    regex: "github/orbitprofiler/build/conan_trace.log"
-    strip_prefix: "github/orbitprofiler/build"
-  }
-}

--- a/kokoro/builds/linux/gcc9_relwithdebinfo/common.cfg
+++ b/kokoro/builds/linux/gcc9_relwithdebinfo/common.cfg
@@ -10,10 +10,3 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
-
-action {
-  define_artifacts {
-    regex: "github/orbitprofiler/build/conan_trace.log"
-    strip_prefix: "github/orbitprofiler/build"
-  }
-}

--- a/kokoro/builds/linux/ggp_relwithdebinfo/common.cfg
+++ b/kokoro/builds/linux/ggp_relwithdebinfo/common.cfg
@@ -10,10 +10,3 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
-
-action {
-  define_artifacts {
-    regex: "github/orbitprofiler/build/conan_trace.log"
-    strip_prefix: "github/orbitprofiler/build"
-  }
-}

--- a/kokoro/builds/windows/msvc2019_relwithdebinfo/common.cfg
+++ b/kokoro/builds/windows/msvc2019_relwithdebinfo/common.cfg
@@ -10,10 +10,3 @@ action {
     strip_prefix: "github/orbitprofiler/build/package"
   }
 }
-
-action {
-  define_artifacts {
-    regex: "github/orbitprofiler/build/conan_trace.log"
-    strip_prefix: "github/orbitprofiler/build"
-  }
-}


### PR DESCRIPTION
We had enabled Conan tracing to analyze a networking issue which has
already been fixed for quite a while now.

Since the trace clutters the build log, let's disable it again.