### PR TITLE
Do not expose absolute addresses in ModuleData

### DIFF
--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -44,6 +44,7 @@ class CaptureClient {
       orbit_base::ThreadPool* thread_pool,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor,
       const orbit_client_data::ModuleManager& module_manager,
+      const orbit_client_data::ProcessData& process,
       const ClientCaptureOptions& capture_client_options);
 
   // Returns true if stop was initiated and false otherwise.

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -44,7 +44,7 @@ class CaptureClient {
       orbit_base::ThreadPool* thread_pool,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor,
       const orbit_client_data::ModuleManager& module_manager,
-      const orbit_client_data::ProcessData& process,
+      const orbit_client_data::ProcessData& process_data,
       const ClientCaptureOptions& capture_client_options);
 
   // Returns true if stop was initiated and false otherwise.

--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -39,7 +39,6 @@ class ModuleData final {
   [[nodiscard]] uint64_t executable_segment_offset() const {
     return module_info_.executable_segment_offset();
   }
-  [[nodiscard]] uint64_t address_start() const { return module_info_.address_start(); }
   [[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> GetObjectSegments() const;
   [[nodiscard]] uint64_t ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_address) const;
   [[nodiscard]] uint64_t ConvertFromOffsetInFileToVirtualAddress(uint64_t offset_in_file) const;

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -366,10 +366,14 @@ int main(int argc, char* argv[]) {
       orbit_base::ThreadPool::Create(1, 1, absl::Seconds(1));
 
   orbit_client_data::ModuleManager module_manager;
-  orbit_client_data::ProcessData process;
+  orbit_client_data::ProcessData process_data;
   orbit_grpc_protos::ProcessInfo process_info;
   process_info.set_pid(options.process_id);
-  process.SetProcessInfo(process_info);
+  process_data.SetProcessInfo(process_info);
+  ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
+      orbit_module_utils::ReadModules(options.process_id);
+  ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
+  process_data.UpdateModuleInfos(modules_or_error.value());
   if (instrument_function) {
     constexpr uint64_t kInstrumentedFunctionId = 1;
     ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromOffset(
@@ -378,10 +382,6 @@ int main(int argc, char* argv[]) {
   }
 
   if (options.enable_api) {
-    ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
-        orbit_module_utils::ReadModules(options.process_id);
-    ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
-    process.UpdateModuleInfos(modules_or_error.value());
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
       ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
           &module_manager, module.file_path(),
@@ -400,10 +400,6 @@ int main(int argc, char* argv[]) {
         "yeti::internal::vulkan::(anonymous namespace)::QueuePresentKHR(VkQueue_T*, "
         "VkPresentInfoKHR const*)"};
 
-    ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
-        orbit_module_utils::ReadModules(options.process_id);
-    ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
-    process.UpdateModuleInfos(modules_or_error.value());
     std::string libvulkan_file_path;
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
       if (module.soname() == kGgpvlkModuleName) {
@@ -436,8 +432,9 @@ int main(int argc, char* argv[]) {
       ORBIT_UNREACHABLE();
   }
 
-  auto capture_outcome_future = capture_client.Capture(
-      thread_pool.get(), std::move(capture_event_processor), module_manager, process, options);
+  auto capture_outcome_future =
+      capture_client.Capture(thread_pool.get(), std::move(capture_event_processor), module_manager,
+                             process_datagi, options);
   ORBIT_LOG("Asked to start capture");
 
   absl::Time start_time = absl::Now();

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -432,9 +432,8 @@ int main(int argc, char* argv[]) {
       ORBIT_UNREACHABLE();
   }
 
-  auto capture_outcome_future =
-      capture_client.Capture(thread_pool.get(), std::move(capture_event_processor), module_manager,
-                             process_datagi, options);
+  auto capture_outcome_future = capture_client.Capture(
+      thread_pool.get(), std::move(capture_event_processor), module_manager, process_data, options);
   ORBIT_LOG("Asked to start capture");
 
   absl::Time start_time = absl::Now();

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -366,6 +366,10 @@ int main(int argc, char* argv[]) {
       orbit_base::ThreadPool::Create(1, 1, absl::Seconds(1));
 
   orbit_client_data::ModuleManager module_manager;
+  orbit_client_data::ProcessData process;
+  orbit_grpc_protos::ProcessInfo process_info;
+  process_info.set_pid(options.process_id);
+  process.SetProcessInfo(process_info);
   if (instrument_function) {
     constexpr uint64_t kInstrumentedFunctionId = 1;
     ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromOffset(
@@ -377,6 +381,7 @@ int main(int argc, char* argv[]) {
     ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
         orbit_module_utils::ReadModules(options.process_id);
     ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
+    process.UpdateModuleInfos(modules_or_error.value());
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
       ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
           &module_manager, module.file_path(),
@@ -398,6 +403,7 @@ int main(int argc, char* argv[]) {
     ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> modules_or_error =
         orbit_module_utils::ReadModules(options.process_id);
     ORBIT_FAIL_IF(modules_or_error.has_error(), "%s", modules_or_error.error().message());
+    process.UpdateModuleInfos(modules_or_error.value());
     std::string libvulkan_file_path;
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
       if (module.soname() == kGgpvlkModuleName) {
@@ -431,7 +437,7 @@ int main(int argc, char* argv[]) {
   }
 
   auto capture_outcome_future = capture_client.Capture(
-      thread_pool.get(), std::move(capture_event_processor), module_manager, options);
+      thread_pool.get(), std::move(capture_event_processor), module_manager, process, options);
   ORBIT_LOG("Asked to start capture");
 
   absl::Time start_time = absl::Now();

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -123,8 +123,8 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(orbit_base::ThreadPool* thre
                                             ORBIT_ERROR("%s", error.message());
                                           }));
 
-  Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> result =
-      capture_client_->Capture(thread_pool, std::move(event_processor), module_manager_, options);
+  Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> result = capture_client_->Capture(
+      thread_pool, std::move(event_processor), module_manager_, *target_process_, options);
 
   orbit_base::ImmediateExecutor executor;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1618,7 +1618,7 @@ void OrbitApp::StartCapture() {
       });
 
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
-      thread_pool_.get(), std::move(capture_event_processor), *module_manager_, options);
+      thread_pool_.get(), std::move(capture_event_processor), *module_manager_, *process_, options);
 
   // TODO(b/187250643): Refactor this to be more readable and maybe remove parts that are not needed
   // here (capture cancelled)


### PR DESCRIPTION
ModuleData exists in ModuleManager once per path and build id.
So if a module is loaded twice at two different locations
in memory, there will be only one instance of ModuleData.

Thus, it must not expose any information about where it
is loaded in memory. For this, ProcessData should be
used.

Test: Check manaual instrumentation still works on OrbitTest
Bug: http://b/236710308