### PR TITLE
Add top-down/bottom-up inspections

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -85,3 +85,5 @@ ABSL_FLAG(
     "try turning automatic symbol loading off (--auto_symbol_loading=false)");
 
 ABSL_FLAG(bool, auto_frame_track, true, "Automatically add the default Frame Track.");
+
+ABSL_FLAG(bool, time_range_selection, false, "Enable time range selection feature.");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -70,4 +70,7 @@ ABSL_DECLARE_FLAG(bool, auto_symbol_loading);
 
 ABSL_DECLARE_FLAG(bool, auto_frame_track);
 
+// Enables time range selection feature.
+ABSL_DECLARE_FLAG(bool, time_range_selection);
+
 #endif  // CLIENT_FLAGS_CLIENT_FLAGS_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2853,19 +2853,19 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
 void OrbitApp::InspectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
                                       bool origin_is_multiple_threads) {
   SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
-  main_window_->SetInspection(CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
-                                  GetCaptureData().selection_post_processed_sampling_data(),
-                                  *module_manager_, GetCaptureData()),
-                              CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
-                                  GetCaptureData().selection_post_processed_sampling_data(),
-                                  *module_manager_, GetCaptureData()));
+  main_window_->SetCallTreeInspection(CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
+                                          GetCaptureData().selection_post_processed_sampling_data(),
+                                          *module_manager_, GetCaptureData()),
+                                      CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
+                                          GetCaptureData().selection_post_processed_sampling_data(),
+                                          *module_manager_, GetCaptureData()));
   FireRefreshCallbacks();
 }
 
 void OrbitApp::ClearInspection() {
   SetCaptureDataSelectionFields(std::vector<CallstackEvent>(),
                                 /*origin_is_multiple_threads*/ false);
-  main_window_->ClearInspection();
+  main_window_->ClearCallTreeInspection();
   FireRefreshCallbacks();
 }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2852,19 +2852,14 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
 
 void OrbitApp::InspectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
                                       bool origin_is_multiple_threads) {
-  if (absl::GetFlag(FLAGS_time_range_selection)) {
-    SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
-    main_window_->SetTopDownInspection(CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
-        GetCaptureData().selection_post_processed_sampling_data(), *module_manager_,
-        GetCaptureData()));
-    main_window_->SetBottomUpInspection(
-        CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
-            GetCaptureData().selection_post_processed_sampling_data(), *module_manager_,
-            GetCaptureData()));
-    FireRefreshCallbacks();
-  } else {
-    SelectCallstackEvents(selected_callstack_events, origin_is_multiple_threads);
-  }
+  SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
+  main_window_->SetInspection(CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
+                                  GetCaptureData().selection_post_processed_sampling_data(),
+                                  *module_manager_, GetCaptureData()),
+                              CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
+                                  GetCaptureData().selection_post_processed_sampling_data(),
+                                  *module_manager_, GetCaptureData()));
+  FireRefreshCallbacks();
 }
 
 void OrbitApp::ClearInspection() {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -497,6 +497,10 @@ class OrbitApp final : public DataViewFactory,
   void SelectCallstackEvents(
       const std::vector<orbit_client_data::CallstackEvent>& selected_callstack_events,
       bool origin_is_multiple_threads);
+  void InspectCallstackEvents(
+      const std::vector<orbit_client_data::CallstackEvent>& selected_callstack_events,
+      bool origin_is_multiple_threads);
+  void ClearInspection();
 
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& info) override;
   void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint) override;
@@ -615,6 +619,10 @@ class OrbitApp final : public DataViewFactory,
 
   void RequestSymbolDownloadStop(absl::Span<const orbit_client_data::ModuleData* const> modules,
                                  bool show_dialog);
+  // Sets CaptureData's selection_callstack_data and selection_post_processed_sampling_data.
+  void SetCaptureDataSelectionFields(
+      const std::vector<orbit_client_data::CallstackEvent>& selected_callstack_events,
+      bool origin_is_multiple_threads);
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<orbit_client_data::CaptureData::DataSource> data_source_{

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -71,8 +71,8 @@ class MainWindowInterface {
 
   virtual ~MainWindowInterface() = default;
 
-  virtual void SetTopDownInspection(std::unique_ptr<CallTreeView> top_down_view) = 0;
-  virtual void SetBottomUpInspection(std::unique_ptr<CallTreeView> bottom_up_view) = 0;
+  virtual void SetInspection(std::unique_ptr<CallTreeView> top_down_view,
+                             std::unique_ptr<CallTreeView> bottom_up_view) = 0;
   virtual void ClearInspection() = 0;
 };
 

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -71,9 +71,9 @@ class MainWindowInterface {
 
   virtual ~MainWindowInterface() = default;
 
-  virtual void SetInspection(std::unique_ptr<CallTreeView> top_down_view,
-                             std::unique_ptr<CallTreeView> bottom_up_view) = 0;
-  virtual void ClearInspection() = 0;
+  virtual void SetCallTreeInspection(std::unique_ptr<CallTreeView> top_down_view,
+                                     std::unique_ptr<CallTreeView> bottom_up_view) = 0;
+  virtual void ClearCallTreeInspection() = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -8,9 +8,11 @@
 #include <stdint.h>
 
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string_view>
 
+#include "CallTreeView.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ModuleData.h"
 #include "ClientData/ScopeId.h"
@@ -21,6 +23,7 @@
 #include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/StopToken.h"
+#include "SamplingReport.h"
 #include "Statistics/Histogram.h"
 
 namespace orbit_gl {
@@ -67,6 +70,10 @@ class MainWindowInterface {
       const orbit_client_data::ModuleData* module) = 0;
 
   virtual ~MainWindowInterface() = default;
+
+  virtual void SetTopDownInspection(std::unique_ptr<CallTreeView> top_down_view) = 0;
+  virtual void SetBottomUpInspection(std::unique_ptr<CallTreeView> bottom_up_view) = 0;
+  virtual void ClearInspection() = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -119,20 +119,6 @@ void CallTreeWidget::SetCallTreeView(std::unique_ptr<CallTreeView> call_tree_vie
   ResizeColumnsIfNecessary();
 }
 
-void CallTreeWidget::SetInspection(std::unique_ptr<CallTreeView> call_tree_view) {
-  ui_->inspectionNoticeWidget->show();
-  inspection_model_ = std::make_unique<CallTreeViewItemModel>(std::move(call_tree_view));
-  hide_values_proxy_model_->setSourceModel(inspection_model_.get());
-  OnSearchTypingFinishedTimerTimout();
-}
-
-void CallTreeWidget::ClearInspection() {
-  ui_->inspectionNoticeWidget->hide();
-  inspection_model_.reset();
-  hide_values_proxy_model_->setSourceModel(model_.get());
-  OnSearchTypingFinishedTimerTimout();
-}
-
 void CallTreeWidget::ClearCallTreeView() {
   hooked_proxy_model_.reset();
   search_proxy_model_.reset();
@@ -239,6 +225,22 @@ void CallTreeWidget::SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_vie
                   std::make_unique<HideValuesForBottomUpProxyModel>(nullptr));
   // Don't show the "Exclusive" column for the bottom-up tree, it provides no useful information.
   ui_->callTreeTreeView->hideColumn(CallTreeViewItemModel::kExclusive);
+}
+
+void CallTreeWidget::SetInspection(std::unique_ptr<CallTreeView> call_tree_view) {
+  ORBIT_CHECK(hide_values_proxy_model_ != nullptr);
+  ui_->inspectionNoticeWidget->show();
+  inspection_model_ = std::make_unique<CallTreeViewItemModel>(std::move(call_tree_view));
+  hide_values_proxy_model_->setSourceModel(inspection_model_.get());
+  OnSearchTypingFinishedTimerTimout();
+}
+
+void CallTreeWidget::ClearInspection() {
+  ORBIT_CHECK(hide_values_proxy_model_ != nullptr);
+  ui_->inspectionNoticeWidget->hide();
+  inspection_model_.reset();
+  hide_values_proxy_model_->setSourceModel(model_.get());
+  OnSearchTypingFinishedTimerTimout();
 }
 
 void CallTreeWidget::resizeEvent(QResizeEvent* /*event*/) {

--- a/src/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/CallTreeWidget.h
@@ -57,6 +57,7 @@ class CallTreeWidget : public QWidget {
   void SetTopDownView(std::unique_ptr<CallTreeView> top_down_view);
   void SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view);
   void ClearCallTreeView();
+  // These methods can only be called after SetTopDownView or SetBottomUpView.
   void SetInspection(std::unique_ptr<CallTreeView> call_tree_view);
   void ClearInspection();
 
@@ -142,11 +143,11 @@ class CallTreeWidget : public QWidget {
   QTimer* search_typing_finished_timer_ = new QTimer{this};
   OrbitApp* app_ = nullptr;
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_ = nullptr;
-  std::unique_ptr<CallTreeViewItemModel> model_;
-  std::unique_ptr<CallTreeViewItemModel> inspection_model_;
-  std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model_;
-  std::unique_ptr<HighlightCustomFilterSortFilterProxyModel> search_proxy_model_;
-  std::unique_ptr<HookedIdentityProxyModel> hooked_proxy_model_;
+  std::unique_ptr<CallTreeViewItemModel> model_ = nullptr;
+  std::unique_ptr<CallTreeViewItemModel> inspection_model_ = nullptr;
+  std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model_ = nullptr;
+  std::unique_ptr<HighlightCustomFilterSortFilterProxyModel> search_proxy_model_ = nullptr;
+  std::unique_ptr<HookedIdentityProxyModel> hooked_proxy_model_ = nullptr;
 
   enum class ColumnResizingState {
     kInitial = 0,        // CallTreeWidget hasn't got its first size set yet

--- a/src/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/CallTreeWidget.h
@@ -57,6 +57,8 @@ class CallTreeWidget : public QWidget {
   void SetTopDownView(std::unique_ptr<CallTreeView> top_down_view);
   void SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view);
   void ClearCallTreeView();
+  void SetInspection(std::unique_ptr<CallTreeView> call_tree_view);
+  void ClearInspection();
 
  protected:
   void resizeEvent(QResizeEvent* event) override;
@@ -69,6 +71,7 @@ class CallTreeWidget : public QWidget {
   void OnSearchLineEditTextEdited(const QString& text);
   void OnSearchTypingFinishedTimerTimout();
   void OnSliderValueChanged(int value);
+  void OnLeaveButtonClicked();
 
  private:
   static const QString kActionExpandRecursively;
@@ -139,6 +142,7 @@ class CallTreeWidget : public QWidget {
   OrbitApp* app_ = nullptr;
   orbit_metrics_uploader::MetricsUploader* metrics_uploader_ = nullptr;
   std::unique_ptr<CallTreeViewItemModel> model_;
+  std::unique_ptr<CallTreeViewItemModel> inspection_model_;
   std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model_;
   std::unique_ptr<HighlightCustomFilterSortFilterProxyModel> search_proxy_model_;
   std::unique_ptr<HookedIdentityProxyModel> hooked_proxy_model_;

--- a/src/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/CallTreeWidget.h
@@ -71,7 +71,7 @@ class CallTreeWidget : public QWidget {
   void OnSearchLineEditTextEdited(const QString& text);
   void OnSearchTypingFinishedTimerTimout();
   void OnSliderValueChanged(int value);
-  void OnLeaveButtonClicked();
+  void OnLeaveInspectionButtonClicked();
 
  private:
   static const QString kActionExpandRecursively;
@@ -84,6 +84,7 @@ class CallTreeWidget : public QWidget {
   static const QString kActionDeselect;
   static const QString kActionDisassembly;
   static const QString kActionSourceCode;
+  static const QString kActionInspectCallstacks;
   static const QString kActionSelectCallstacks;
   static const QString kActionCopySelection;
 

--- a/src/OrbitQt/CallTreeWidget.ui
+++ b/src/OrbitQt/CallTreeWidget.ui
@@ -6,12 +6,31 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>256</width>
-    <height>220</height>
+    <width>691</width>
+    <height>656</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="3" column="0">
+    <widget class="CustomSignalsTreeView" name="callTreeTreeView">
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="8,2">
      <item>
       <widget class="QLineEdit" name="searchLineEdit">
@@ -38,20 +57,33 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <widget class="CustomSignalsTreeView" name="callTreeTreeView">
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
+   <item row="0" column="0">
+    <widget class="QWidget" name="noticeWidget" native="true">
+     <property name="styleSheet">
+      <string notr="true">.QWidget{ border-radius: 5px; border: 1px solid palette(text) ; background: rgba(0,255,0, 10%);}</string>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="1">
+       <widget class="QPushButton" name="noticeButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Leave Inspection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="noticeLabel">
+        <property name="text">
+         <string>You are currently in an inspection, limiting the tree to specific callstacks.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/OrbitQt/CallTreeWidget.ui
+++ b/src/OrbitQt/CallTreeWidget.ui
@@ -58,7 +58,7 @@
     </layout>
    </item>
    <item row="0" column="0">
-    <widget class="QWidget" name="noticeWidget" native="true">
+    <widget class="QWidget" name="inspectionNoticeWidget" native="true">
      <property name="styleSheet">
       <string notr="true">.QWidget{ border-radius: 5px; border: 1px solid palette(text) ; background: rgba(0,255,0, 10%);}</string>
      </property>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -6,6 +6,9 @@
 
 #include <absl/container/flat_hash_set.h>
 #include <absl/flags/declare.h>
+#include <absl/flags/internal/flag.h>
+#include <qgridlayout.h>
+#include <qnamespace.h>
 
 #include <QAbstractButton>
 #include <QAction>
@@ -1894,6 +1897,18 @@ void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Dura
       QString::fromStdString(absl::StrFormat("%s\t%s", pretty_time, message)));
   ORBIT_LOG("\"%s  %s\" with severity %s added to the capture log", pretty_time, message,
             severity_name);
+}
+
+void OrbitMainWindow::SetTopDownInspection(std::unique_ptr<CallTreeView> top_down_view) {
+  ui->topDownWidget->SetInspection(std::move(top_down_view));
+}
+void OrbitMainWindow::SetBottomUpInspection(std::unique_ptr<CallTreeView> bottom_up_view) {
+  ui->bottomUpWidget->SetInspection(std::move(bottom_up_view));
+}
+
+void OrbitMainWindow::ClearInspection() {
+  ui->topDownWidget->ClearInspection();
+  ui->bottomUpWidget->ClearInspection();
 }
 
 orbit_gl::MainWindowInterface::SymbolErrorHandlingResult OrbitMainWindow::HandleSymbolError(

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -7,8 +7,6 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/flags/declare.h>
 #include <absl/flags/internal/flag.h>
-#include <qgridlayout.h>
-#include <qnamespace.h>
 
 #include <QAbstractButton>
 #include <QAction>
@@ -1899,10 +1897,9 @@ void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Dura
             severity_name);
 }
 
-void OrbitMainWindow::SetTopDownInspection(std::unique_ptr<CallTreeView> top_down_view) {
+void OrbitMainWindow::SetInspection(std::unique_ptr<CallTreeView> top_down_view,
+                                    std::unique_ptr<CallTreeView> bottom_up_view) {
   ui->topDownWidget->SetInspection(std::move(top_down_view));
-}
-void OrbitMainWindow::SetBottomUpInspection(std::unique_ptr<CallTreeView> bottom_up_view) {
   ui->bottomUpWidget->SetInspection(std::move(bottom_up_view));
 }
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1897,13 +1897,13 @@ void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Dura
             severity_name);
 }
 
-void OrbitMainWindow::SetInspection(std::unique_ptr<CallTreeView> top_down_view,
-                                    std::unique_ptr<CallTreeView> bottom_up_view) {
+void OrbitMainWindow::SetCallTreeInspection(std::unique_ptr<CallTreeView> top_down_view,
+                                            std::unique_ptr<CallTreeView> bottom_up_view) {
   ui->topDownWidget->SetInspection(std::move(top_down_view));
   ui->bottomUpWidget->SetInspection(std::move(bottom_up_view));
 }
 
-void OrbitMainWindow::ClearInspection() {
+void OrbitMainWindow::ClearCallTreeInspection() {
   ui->topDownWidget->ClearInspection();
   ui->bottomUpWidget->ClearInspection();
 }

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -132,8 +132,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
       const orbit_client_data::ModuleData* module) override;
 
-  void SetTopDownInspection(std::unique_ptr<CallTreeView> top_down_view) override;
-  void SetBottomUpInspection(std::unique_ptr<CallTreeView> bottom_up_view) override;
+  void SetInspection(std::unique_ptr<CallTreeView> top_down_view,
+                     std::unique_ptr<CallTreeView> bottom_up_view) override;
 
   void ClearInspection() override;
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -132,10 +132,10 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
       const orbit_client_data::ModuleData* module) override;
 
-  void SetInspection(std::unique_ptr<CallTreeView> top_down_view,
-                     std::unique_ptr<CallTreeView> bottom_up_view) override;
+  void SetCallTreeInspection(std::unique_ptr<CallTreeView> top_down_view,
+                             std::unique_ptr<CallTreeView> bottom_up_view) override;
 
-  void ClearInspection() override;
+  void ClearCallTreeInspection() override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -132,6 +132,11 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
       const orbit_client_data::ModuleData* module) override;
 
+  void SetTopDownInspection(std::unique_ptr<CallTreeView> top_down_view) override;
+  void SetBottomUpInspection(std::unique_ptr<CallTreeView> bottom_up_view) override;
+
+  void ClearInspection() override;
+
  protected:
   void closeEvent(QCloseEvent* event) override;
   void resizeEvent(QResizeEvent* event) override;

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -270,13 +270,6 @@ QPushButton:disabled {
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="OrbitSamplingReport" name="inspectionReport" native="true">
-            <property name="visible">
-              <bool>false</bool>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="topDownTab">

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -270,6 +270,13 @@ QPushButton:disabled {
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="OrbitSamplingReport" name="inspectionReport" native="true">
+            <property name="visible">
+              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="topDownTab">


### PR DESCRIPTION
When a user chooses to "Select these callstacks" in the context menu in
top-down/bottom-up tabs, this creates the selection within the tab
itself.  It also adds a banner above to show the user that they are
currently in an inspection and give them the option to leave the
inspection.

The effect on the samples tab will be done in an upcoming PR.

These changes are hidden behind the time_range_selection flag.

Screenshot for notice box: https://screenshot.googleplex.com/6xgU94Wm8qapqyR
Bug: http://b/240112046