### PR TITLE
Minimize calls to ReadModules in UserSpaceInstrumentation

### DIFF
--- a/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
@@ -60,11 +60,12 @@ ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* function_address, uin
   return return_value;
 }
 
-ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* library_handle,
-                                          std::string_view function, uint64_t param_0,
-                                          uint64_t param_1, uint64_t param_2, uint64_t param_3,
-                                          uint64_t param_4, uint64_t param_5) {
-  OUTCOME_TRY(auto&& function_address, DlsymInTracee(pid, library_handle, function));
+ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid,
+                                          const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
+                                          void* library_handle, std::string_view function,
+                                          uint64_t param_0, uint64_t param_1, uint64_t param_2,
+                                          uint64_t param_3, uint64_t param_4, uint64_t param_5) {
+  OUTCOME_TRY(auto&& function_address, DlsymInTracee(pid, modules, library_handle, function));
   return ExecuteInProcess(pid, function_address, param_0, param_1, param_2, param_3, param_4,
                           param_5);
 }

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.h
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.h
@@ -9,7 +9,9 @@
 
 #include <cstdint>
 #include <string_view>
+#include <vector>
 
+#include "GrpcProtos/module.pb.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_user_space_instrumentation {
@@ -19,9 +21,9 @@ namespace orbit_user_space_instrumentation {
 // The function name has to match the symbol name exactly. The module name needs match the soname
 // (compare https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html) of the module
 // exactly.
-[[nodiscard]] ErrorMessageOr<uint64_t> FindFunctionAddress(pid_t pid,
-                                                           std::string_view module_soname,
-                                                           std::string_view function_name);
+[[nodiscard]] ErrorMessageOr<uint64_t> FindFunctionAddress(
+    const std::vector<orbit_grpc_protos::ModuleInfo>& modules, std::string_view module_soname,
+    std::string_view function_name);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -81,8 +81,7 @@ bool ProcessWithPidExists(pid_t pid) {
 }
 
 // Returns true if liborbituserspaceinstrumentation.so is present in target process.
-ErrorMessageOr<bool> AlreadyInjected(pid_t pid) {
-  OUTCOME_TRY(auto&& modules, orbit_module_utils::ReadModules(pid));
+ErrorMessageOr<bool> AlreadyInjected(const std::vector<ModuleInfo>& modules) {
   for (const ModuleInfo& module : modules) {
     if (module.name() == kLibName) {
       return true;
@@ -133,15 +132,16 @@ bool IsBlocklisted(std::string_view function_name) {
 // Note that calling the result of the clone call a "thread" is a bit of a misnomer: We
 // do not create a new data structure for thread local storage but use the one of the thread we
 // halted.
-ErrorMessageOr<MachineCode> MachineCodeForCloneCall(pid_t pid, void* library_handle,
-                                                    uint64_t top_of_stack) {
+ErrorMessageOr<MachineCode> MachineCodeForCloneCall(pid_t pid,
+                                                    const std::vector<ModuleInfo>& modules,
+                                                    void* library_handle, uint64_t top_of_stack) {
   constexpr uint64_t kCloneFlags =
       CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM;
   constexpr uint32_t kSyscallNumberClone = 0x38;
   constexpr uint32_t kSyscallNumberExit = 0x3c;
   constexpr const char* kInitializeInstrumentationFunctionName = "InitializeInstrumentation";
   OUTCOME_TRY(void* initialize_instrumentation_function_address,
-              DlsymInTracee(pid, library_handle, kInitializeInstrumentationFunctionName));
+              DlsymInTracee(pid, modules, library_handle, kInitializeInstrumentationFunctionName));
   MachineCode code;
   code.AppendBytes({0x48, 0xbf})
       .AppendImmediate64(kCloneFlags)  // mov rdi, kCloneFlags
@@ -234,12 +234,13 @@ ErrorMessageOr<std::vector<pid_t>> GetNewOrbitThreads(
   return orbit_threads;
 }
 
-ErrorMessageOr<void> SetOrbitThreadsInTarget(pid_t pid, void* library_handle,
+ErrorMessageOr<void> SetOrbitThreadsInTarget(pid_t pid, const std::vector<ModuleInfo>& modules,
+                                             void* library_handle,
                                              const std::vector<pid_t>& orbit_threads) {
   ORBIT_CHECK(orbit_threads.size() == GetExpectedOrbitThreadNames().size());
   constexpr const char* kSetOrbitThreadsFunctionName = "SetOrbitThreads";
   OUTCOME_TRY(void* set_orbit_threads_function_address,
-              DlsymInTracee(pid, library_handle, kSetOrbitThreadsFunctionName));
+              DlsymInTracee(pid, modules, library_handle, kSetOrbitThreadsFunctionName));
   OUTCOME_TRY(ExecuteInProcess(pid, set_orbit_threads_function_address, orbit_threads[0],
                                orbit_threads[1], orbit_threads[2], orbit_threads[3],
                                orbit_threads[4], orbit_threads[5]));
@@ -262,14 +263,14 @@ class InstrumentedProcess {
   ~InstrumentedProcess() = default;
 
   [[nodiscard]] static ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> Create(
-      const CaptureOptions& capture_options);
+      pid_t pid, const std::vector<ModuleInfo>& modules);
 
   // Instruments the functions capture_options.instrumented_functions. Returns a set of
   // function_id's of successfully instrumented functions, a map of function_id's to errors for
   // functions that couldn't be instrumented, the address ranges dedicated to trampolines, and the
   // map name of the injected library.
   [[nodiscard]] ErrorMessageOr<InstrumentationManager::InstrumentationResult> InstrumentFunctions(
-      const CaptureOptions& capture_options);
+      const CaptureOptions& capture_options, const std::vector<ModuleInfo>& modules);
 
   // Removes the instrumentation for all functions in capture_options.instrumented_functions that
   // have been instrumented previously.
@@ -293,7 +294,8 @@ class InstrumentedProcess {
   [[nodiscard]] ErrorMessageOr<void> EnsureTrampolinesWritable();
   [[nodiscard]] ErrorMessageOr<void> EnsureTrampolinesExecutable();
 
-  [[nodiscard]] ErrorMessageOr<std::vector<ModuleInfo>> ModulesFromModulePath(std::string path);
+  [[nodiscard]] ErrorMessageOr<std::vector<ModuleInfo>> ModulesFromModulePath(
+      const std::vector<ModuleInfo>& modules, std::string path);
 
   // Returns a vector of the address ranges dedicated to all entry trampolines for this process. The
   // number of address ranges is usually very small as kTrampolinesPerChunk is high.
@@ -351,9 +353,8 @@ class InstrumentedProcess {
 };
 
 ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create(
-    const CaptureOptions& capture_options) {
+    pid_t pid, const std::vector<ModuleInfo>& modules) {
   std::unique_ptr<InstrumentedProcess> process(new InstrumentedProcess());
-  const pid_t pid = orbit_base::ToNativeProcessId(capture_options.pid());
   process->pid_ = pid;
   ORBIT_LOG("Starting to instrument process with pid %d", pid);
   OUTCOME_TRY(AttachAndStopProcess(pid));
@@ -386,9 +387,9 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
   // The initialization part that we will skip is responsible for setting up the communication with
   // OrbitService and identifying the threads created in that process. All of that already happened
   // in the previous run.
-  OUTCOME_TRY(const bool already_injected, AlreadyInjected(pid));
+  OUTCOME_TRY(const bool already_injected, AlreadyInjected(modules));
 
-  auto library_handle_or_error = DlopenInTracee(pid, library_path, RTLD_NOW);
+  auto library_handle_or_error = DlopenInTracee(pid, modules, library_path, RTLD_NOW);
   if (library_handle_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Unable to open library in tracee: %s",
                                         library_handle_or_error.error().message()));
@@ -401,15 +402,15 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
   constexpr const char* kEntryPayloadFunctionName = "EntryPayload";
   constexpr const char* kExitPayloadFunctionName = "ExitPayload";
   OUTCOME_TRY(void* start_new_capture_function_address,
-              DlsymInTracee(pid, library_handle, kStartNewCaptureFunctionName));
+              DlsymInTracee(pid, modules, library_handle, kStartNewCaptureFunctionName));
   process->start_new_capture_function_address_ =
       absl::bit_cast<uint64_t>(start_new_capture_function_address);
   OUTCOME_TRY(void* entry_payload_function_address,
-              DlsymInTracee(pid, library_handle, kEntryPayloadFunctionName));
+              DlsymInTracee(pid, modules, library_handle, kEntryPayloadFunctionName));
   process->entry_payload_function_address_ =
       absl::bit_cast<uint64_t>(entry_payload_function_address);
   OUTCOME_TRY(void* exit_payload_function_address,
-              DlsymInTracee(pid, library_handle, kExitPayloadFunctionName));
+              DlsymInTracee(pid, modules, library_handle, kExitPayloadFunctionName));
   process->exit_payload_function_address_ = absl::bit_cast<uint64_t>(exit_payload_function_address);
 
   // Get memory, create the return trampoline and make it executable.
@@ -438,7 +439,7 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
   constexpr uint64_t kStackSize = 8ULL * 1024ULL * 1024ULL;
   OUTCOME_TRY(auto&& thread_stack_memory, MemoryInTracee::Create(pid, 0, kStackSize));
   const uint64_t top_of_stack = thread_stack_memory->GetAddress() + kStackSize;
-  OUTCOME_TRY(auto&& code, MachineCodeForCloneCall(pid, library_handle, top_of_stack));
+  OUTCOME_TRY(auto&& code, MachineCodeForCloneCall(pid, modules, library_handle, top_of_stack));
   const uint64_t code_size = code.GetResultAsVector().size();
   OUTCOME_TRY(auto&& code_memory, MemoryInTracee::Create(pid, 0, code_size));
   OUTCOME_TRY(auto&& init_thread_tid, ExecuteMachineCode(*code_memory, code));
@@ -460,7 +461,7 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
                                                    ORBIT_ERROR("Detaching from %i", pid);
                                                  }
                                                }};
-  OUTCOME_TRY(SetOrbitThreadsInTarget(pid, library_handle, orbit_threads));
+  OUTCOME_TRY(SetOrbitThreadsInTarget(pid, modules, library_handle, orbit_threads));
   OUTCOME_TRY(thread_stack_memory->Free());
   OUTCOME_TRY(code_memory->Free());
 
@@ -470,7 +471,8 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
 }
 
 ErrorMessageOr<InstrumentationManager::InstrumentationResult>
-InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) {
+InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options,
+                                         const std::vector<ModuleInfo>& modules) {
   ORBIT_LOG("Instrumenting functions in process %d", pid_);
   OUTCOME_TRY(AttachAndStopProcess(pid_));
   orbit_base::unique_resource detach_on_exit{pid_, [](int32_t pid) {
@@ -524,8 +526,8 @@ InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options) 
     }
     // Get all modules with the right path (usually one, but might be more) and get a function
     // address to instrument for each of them.
-    OUTCOME_TRY(auto&& modules, ModulesFromModulePath(function.file_path()));
-    for (const auto& module : modules) {
+    OUTCOME_TRY(auto&& function_modules, ModulesFromModulePath(modules, function.file_path()));
+    for (const auto& module : function_modules) {
       const uint64_t function_address = orbit_module_utils::SymbolVirtualAddressToAbsoluteAddress(
           function.function_virtual_address(), module.address_start(), module.load_bias(),
           module.executable_segment_offset());
@@ -663,10 +665,9 @@ ErrorMessageOr<void> InstrumentedProcess::ReleaseMostRecentlyAllocatedTrampoline
 }
 
 ErrorMessageOr<std::vector<ModuleInfo>> InstrumentedProcess::ModulesFromModulePath(
-    std::string path) {
+    const std::vector<ModuleInfo>& modules, std::string path) {
   if (!modules_from_path_.contains(path)) {
     std::vector<ModuleInfo> result;
-    OUTCOME_TRY(auto&& modules, orbit_module_utils::ReadModules(pid_));
     for (const ModuleInfo& module : modules) {
       if (module.file_path() == path) {
         result.push_back(module);
@@ -730,12 +731,18 @@ ErrorMessageOr<InstrumentationManager::InstrumentationResult>
 InstrumentationManager::InstrumentProcess(const CaptureOptions& capture_options) {
   const pid_t pid = orbit_base::ToNativeProcessId(capture_options.pid());
 
+  OUTCOME_TRY(auto&& exists, orbit_base::FileExists(absl::StrFormat("/proc/%d", pid)));
+  if (!exists) {
+    return ErrorMessage(absl::StrFormat("There is no process with pid %d.", pid));
+  }
+
   // If the user tries to instrument this instance of OrbitService we can't use user space
   // instrumentation: We would need to attach to / stop our own process.
   if (pid == getpid()) {
     return ErrorMessage("The target process is OrbitService itself.");
   }
 
+  OUTCOME_TRY(auto&& modules, orbit_module_utils::ReadModules(pid));
   if (!process_map_.contains(pid)) {
     // Delete entries belonging to processes that are not running anymore.
     auto it = process_map_.begin();
@@ -747,7 +754,7 @@ InstrumentationManager::InstrumentProcess(const CaptureOptions& capture_options)
       }
     }
 
-    auto process_or_error = InstrumentedProcess::Create(capture_options);
+    auto process_or_error = InstrumentedProcess::Create(pid, modules);
     if (process_or_error.has_error()) {
       return ErrorMessage(absl::StrFormat("Unable to initialize process %d: %s", pid,
                                           process_or_error.error().message()));
@@ -755,7 +762,7 @@ InstrumentationManager::InstrumentProcess(const CaptureOptions& capture_options)
     process_map_.emplace(pid, std::move(process_or_error.value()));
   }
   OUTCOME_TRY(auto&& instrumentation_result,
-              process_map_[pid]->InstrumentFunctions(capture_options));
+              process_map_[pid]->InstrumentFunctions(capture_options, modules));
 
   return std::move(instrumentation_result);
 }

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/ExecuteInProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/ExecuteInProcess.h
@@ -9,7 +9,9 @@
 
 #include <cstdint>
 #include <string_view>
+#include <vector>
 
+#include "GrpcProtos/module.pb.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_user_space_instrumentation {
@@ -26,11 +28,10 @@ namespace orbit_user_space_instrumentation {
 // As above but the function to be called is identified by the handle to the library and its name.
 // Assumes that the library identified by `library_handle` is loaded into this process using
 // `DlopenInTracee`.
-[[nodiscard]] ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* library_handle,
-                                                        std::string_view function,
-                                                        uint64_t param_1 = 0, uint64_t param_2 = 0,
-                                                        uint64_t param_3 = 0, uint64_t param_4 = 0,
-                                                        uint64_t param_5 = 0, uint64_t param_6 = 0);
+[[nodiscard]] ErrorMessageOr<uint64_t> ExecuteInProcess(
+    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* library_handle,
+    std::string_view function, uint64_t param_1 = 0, uint64_t param_2 = 0, uint64_t param_3 = 0,
+    uint64_t param_4 = 0, uint64_t param_5 = 0, uint64_t param_6 = 0);
 
 // Like ExecuteInProcess, but the function is assumed to have Microsoft x64 calling convention. This
 // can be used when the target process was built for Windows (e.g., it is running under Wine).

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
@@ -11,7 +11,9 @@
 #include <cstdint>
 #include <filesystem>
 #include <string_view>
+#include <vector>
 
+#include "GrpcProtos/module.pb.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_user_space_instrumentation {
@@ -19,10 +21,14 @@ namespace orbit_user_space_instrumentation {
 // Open, use, and close dynamic library in the tracee. The functions here resemble the respective
 // functions offered by libdl as documented e.g. here: https://linux.die.net/man/3/dlopen. We rely
 // on either libdl or libc being loaded into the tracee.
-[[nodiscard]] ErrorMessageOr<void*> DlopenInTracee(pid_t pid, const std::filesystem::path& path,
-                                                   uint32_t flag);
-[[nodiscard]] ErrorMessageOr<void*> DlsymInTracee(pid_t pid, void* handle, std::string_view symbol);
-[[nodiscard]] ErrorMessageOr<void> DlcloseInTracee(pid_t pid, void* handle);
+[[nodiscard]] ErrorMessageOr<void*> DlopenInTracee(
+    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
+    const std::filesystem::path& path, uint32_t flag);
+[[nodiscard]] ErrorMessageOr<void*> DlsymInTracee(
+    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* handle,
+    std::string_view symbol);
+[[nodiscard]] ErrorMessageOr<void> DlcloseInTracee(
+    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* handle);
 
 }  // namespace orbit_user_space_instrumentation
 


### PR DESCRIPTION
`ReadModules` is an expensive operation: it reads and parses the maps, it opens
and parses object files, and it prints plenty of information to the logs (which
made this very visible).
Previously, we were calling it in every function that needed the modules. Also,
the number of calls was growing with the number of instrumented modules.
Now we try to call it as few times as possible and pass the result down. Of
course this adds a parameter to various functions.

Test: Capture with user space instrumentation and manual instrumentation. Verify
they work and verify from the logs that the number of calls to `ReadModules` is
now reduced.