### PR TITLE
[DRAFT] Give users the option of disabling auto-frame-track + E2E test

### DIFF
--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -8,7 +8,8 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture, FilterTracks, CheckTimers, VerifyTracksExist
+from test_cases.capture_window import Capture, FilterTracks, CheckTimers, SetEnableAutoFrameTrack, VerifyTracksExist
+from test_cases.main_window import EndSession
 from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.live_tab import AddFrameTrack
 """Create a frame track in Orbit using pywinauto.
@@ -34,12 +35,15 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        # Setting enable auto frame track to false to only have the created Frame Track.
+        SetEnableAutoFrameTrack(enable_auto_frame_track=False),
+        # Ending and opening a new session. The auto frame track won't appear.
+        EndSession(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         AddFrameTrack(function_name="DrawFrame"),
-        # TODO(b/239148938): After allowing users to set auto-frame-track to false:
-        #  Instead of allowing duplicates, set auto-frame track to false while capturing.
-        VerifyTracksExist(track_names="Frame track*", allow_duplicates=True),
+        VerifyTracksExist(track_names="Frame track*"),
         CheckTimers(track_name_filter='Frame track*')  # Verify the frame track has timers
     ]
     suite = E2ETestSuite(test_name="Add Frame Track", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -8,7 +8,8 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture, CheckTimers, ExpandTrack
+from test_cases.capture_window import Capture, CheckTimers, ExpandTrack, SetEnableAutoFrameTrack
+from test_cases.main_window import EndSession
 from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument a single function in Orbit using pywinauto.
@@ -33,14 +34,17 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
         WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        # Setting enable auto frame track to false, so there is no hooked functions.
+        SetEnableAutoFrameTrack(enable_auto_frame_track=False),
+        # Ending and opening a new session. New session won't have default frame track neither hooked function.
+        EndSession(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         Capture(),
         CheckTimers(track_name_filter='Scheduler'),
         ExpandTrack(expected_name="gfx"),
         CheckTimers(track_name_filter='gfx_submissions', recursive=True),
         CheckTimers(track_name_filter="All Threads", expect_exists=False),
-        # TODO(b/239148938): After allowing users to set auto-frame-track to false:
-        #  Set auto-frame track to false while capturing and don't expect timers in hello_ggp.
-        CheckTimers(track_name_filter="hello_ggp_stand"),
+        CheckTimers(track_name_filter="hello_ggp_stand", expect_exists=False),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         VerifyScopeTypeAndHitCount(scope_name='DrawFrame',

--- a/contrib/automation_tests/orbit_track_type_visibility.py
+++ b/contrib/automation_tests/orbit_track_type_visibility.py
@@ -8,7 +8,8 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture, VerifyTracksExist, ToggleTrackTypeVisibility, VerifyTracksDoNotExist
+from test_cases.capture_window import Capture, SetEnableAutoFrameTrack, VerifyTracksExist, ToggleTrackTypeVisibility, VerifyTracksDoNotExist
+from test_cases.main_window import EndSession
 """Toggle track type visibility in Orbit using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -32,6 +33,11 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
+        # Setting enable auto frame track to true.
+        SetEnableAutoFrameTrack(enable_auto_frame_track=True),
+        # Ending and opening a new session. The auto frame track will appear.
+        EndSession(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         Capture(),
         ToggleTrackTypeVisibility(track_type="Scheduler"),
         VerifyTracksDoNotExist(track_names="Scheduler"),

--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -7,13 +7,19 @@ found in the LICENSE file.
 from absl import app
 
 from core.orbit_e2e import E2ETestSuite
-from test_cases.capture_window import SelectTrack, DeselectTrack, MoveTrack, FilterTracks, VerifyTracksExist, Capture
+from test_cases.capture_window import SelectTrack, DeselectTrack, MoveTrack, FilterTracks, SetEnableAutoFrameTrack, VerifyTracksExist, Capture
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.main_window import EndSession
 
 
 def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
+        # Setting enable auto frame track to true.
+        SetEnableAutoFrameTrack(enable_auto_frame_track=True),
+        # Ending and opening a new session. The auto frame track will appear.
+        EndSession(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         Capture(),
         VerifyTracksExist(

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -29,7 +29,9 @@ class CaptureWindowE2ETestCaseBase(E2ETestCase):
 
     def execute(self, suite: E2ETestSuite):
         self._time_graph = self.find_control('Image', name='TimeGraph', parent=suite.top_window())
-        self._track_container = self.find_control('Pane', name='TrackContainer', parent=self._time_graph)
+        self._track_container = self.find_control('Pane',
+                                                  name='TrackContainer',
+                                                  parent=self._time_graph)
         super().execute(suite=suite)
 
     def _find_tracks(self, name_filter: str = None, recursive: bool = False):
@@ -312,6 +314,17 @@ class CaptureE2ETestCaseBase(E2ETestCase):
         logging.info('Showing capture window')
         self.find_control("TabItem", "Capture").click_input()
 
+    def _show_capture_options_dialog(self):
+        logging.info('Opening "Capture Options" dialog')
+        capture_tab = self.find_control('Group', 'CaptureTab')
+        capture_options_button = self.find_control('Button', 'Capture Options', parent=capture_tab)
+        capture_options_button.click_input()
+
+    def _close_capture_options_dialog(self):
+        logging.info('Saving "Capture Options"')
+        self.find_control('Button', 'OK',
+                          parent=self.find_control('Window', 'Capture Options')).click_input()
+
     def _set_collect_thread_states_capture_option(self, collect_thread_states: bool,
                                                   capture_options_dialog):
         collect_thread_states_checkbox = self.find_control('CheckBox',
@@ -320,6 +333,15 @@ class CaptureE2ETestCaseBase(E2ETestCase):
         if collect_thread_states_checkbox.get_toggle_state() != collect_thread_states:
             logging.info('Toggling "Collect thread states" checkbox')
             collect_thread_states_checkbox.click_input()
+
+    def _set_enable_auto_frame_track_capture_option(self, enable_auto_frame_track: bool,
+                                                    capture_options_dialog):
+        enable_auto_frame_track_checkbox = self.find_control('CheckBox',
+                                                             'AutoFrameTrackCheckBox',
+                                                             parent=capture_options_dialog)
+        if enable_auto_frame_track_checkbox.get_toggle_state() != enable_auto_frame_track:
+            logging.info('Toggling "Auto Frame Track" checkbox')
+            enable_auto_frame_track_checkbox.click_input()
 
     def _set_collect_system_memory_usage_capture_option(self, collect_system_memory_usage,
                                                         capture_options_dialog):
@@ -437,7 +459,8 @@ class CaptureE2ETestCaseBase(E2ETestCase):
     def _verify_existence_of_tracks(self):
         logging.info("Verifying existence of at least one track...")
         track_container = self.find_control('Pane', name='TrackContainer')
-        self.expect_true(len(track_container.children()), 'Track container exists and has at least one child')
+        self.expect_true(len(track_container.children()),
+                         'Track container exists and has at least one child')
 
     def _verify_capture(self):
         self._verify_existence_of_timeline()
@@ -639,6 +662,16 @@ class SelectAllCallstacksFromTrack(CaptureWindowE2ETestCaseBase):
             self.find_control('TabItem', 'Bottom-Up (selection)').is_enabled(),
             "'Bottom-Up (selection)' tab is enabled")
         logging.info("Verified that '(selection)' tabs are enabled")
+
+
+class SetEnableAutoFrameTrack(CaptureE2ETestCaseBase):
+
+    def _execute(self, enable_auto_frame_track: bool):
+        self._show_capture_options_dialog()
+        capture_options_dialog = self.find_control('Window', 'Capture Options')
+        self._set_enable_auto_frame_track_capture_option(enable_auto_frame_track,
+                                                         capture_options_dialog)
+        self._close_capture_options_dialog()
 
 
 class SetAndCheckMemorySamplingPeriod(E2ETestCase):

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -275,6 +275,16 @@ uint64_t DataManager::max_local_marker_depth_per_command_buffer() const {
   return max_local_marker_depth_per_command_buffer_;
 }
 
+void DataManager::set_enable_auto_frame_track(bool enable_auto_frame_track) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  enable_auto_frame_track_ = enable_auto_frame_track;
+}
+
+bool DataManager::enable_auto_frame_track() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return enable_auto_frame_track_;
+}
+
 void DataManager::set_collect_memory_info(bool collect_memory_info) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   collect_memory_info_ = collect_memory_info;

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -106,6 +106,9 @@ class DataManager final {
       uint64_t max_local_marker_depth_per_command_buffer);
   [[nodiscard]] uint64_t max_local_marker_depth_per_command_buffer() const;
 
+  void set_enable_auto_frame_track(bool enable_auto_frame_track);
+  [[nodiscard]] bool enable_auto_frame_track() const;
+
   void set_collect_memory_info(bool collect_memory_info);
   [[nodiscard]] bool collect_memory_info() const;
 
@@ -145,6 +148,7 @@ class DataManager final {
   uint16_t stack_dump_size_ = 0;
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_{};
 
+  bool enable_auto_frame_track_ = false;
   bool collect_memory_info_ = false;
   uint64_t memory_sampling_period_ms_ = 10;
   uint64_t memory_warning_threshold_kb_ = 8ULL * 1024 * 1024;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2504,7 +2504,7 @@ Future<std::vector<ErrorMessageOr<CanceledOr<void>>>> OrbitApp::LoadAllSymbols()
 
     loading_futures.push_back(RetrieveModuleAndLoadSymbols(module));
   }
-  if (absl::GetFlag(FLAGS_auto_frame_track)) {
+  if (GetEnableAutoFrameTrack()) {
     // Orbit will try to add the default frame track while loading all symbols.
     std::ignore = AddDefaultFrameTrackOrLogError();
   }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -440,6 +440,12 @@ class OrbitApp final : public DataViewFactory,
   void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
 
+  void SetEnableAutoFrameTrack(bool enable_auto_frame_track) {
+    data_manager_->set_enable_auto_frame_track(enable_auto_frame_track);
+  }
+  [[nodiscard]] bool GetEnableAutoFrameTrack() const {
+    return data_manager_->enable_auto_frame_track();
+  }
   void SetCollectMemoryInfo(bool collect_memory_info) {
     data_manager_->set_collect_memory_info(collect_memory_info);
   }

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -68,6 +68,11 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   ui_->memorySamplingPeriodMsLineEdit->setValidator(new UInt64Validator(
       1, std::numeric_limits<uint64_t>::max(), ui_->memorySamplingPeriodMsLineEdit));
   ui_->memoryWarningThresholdKbLineEdit->setValidator(&uint64_validator_);
+
+  if (!absl::GetFlag(FLAGS_auto_frame_track)) {
+    ui_->autoFrameTrackGroupBox->hide();
+  }
+
   if (!absl::GetFlag(FLAGS_enable_warning_threshold)) {
     ui_->memoryWarningThresholdKbLabel->hide();
     ui_->memoryWarningThresholdKbLineEdit->hide();
@@ -252,6 +257,14 @@ void CaptureOptionsDialog::ResetLocalMarkerDepthLineEdit() {
   if (ui_->localMarkerDepthLineEdit->text().isEmpty()) {
     ui_->localMarkerDepthLineEdit->setText(QString::number(kLocalMarkerDepthDefaultValue));
   }
+}
+
+void CaptureOptionsDialog::SetEnableAutoFrameTrack(bool enable_auto_frame_track) {
+  ui_->autoFrameTrackCheckBox->setChecked(enable_auto_frame_track);
+}
+
+bool CaptureOptionsDialog::GetEnableAutoFrameTrack() const {
+  return ui_->autoFrameTrackCheckBox->isChecked();
 }
 
 void CaptureOptionsDialog::SetCollectMemoryInfo(bool collect_memory_info) {

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -78,6 +78,8 @@ class CaptureOptionsDialog : public QDialog {
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t local_marker_depth_per_command_buffer);
   [[nodiscard]] uint64_t GetMaxLocalMarkerDepthPerCommandBuffer() const;
 
+  void SetEnableAutoFrameTrack(bool enable_auto_frame_track);
+  [[nodiscard]] bool GetEnableAutoFrameTrack() const;
   void SetCollectMemoryInfo(bool collect_memory_info);
   [[nodiscard]] bool GetCollectMemoryInfo() const;
   void SetMemorySamplingPeriodMs(uint64_t memory_sampling_period_ms);

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -406,6 +406,28 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="autoFrameTrackGroupBox">
+         <property name="title">
+          <string>Auto FrameTrack</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <widget class="QCheckBox" name="autoFrameTrackCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A frame track will be added when enabling this option at the start of every session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="accessibleName">
+             <string>AutoFrameTrackCheckBox</string>
+            </property>
+            <property name="text">
+             <string>Automatically add the default frame track</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="memoryTracingGroupBox">
          <property name="title">
           <string>Memory tracing</string>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1096,6 +1096,7 @@ const QString OrbitMainWindow::kMaxCopyRawStackSizeSettingKey{"MaxCopyRawStackSi
 const QString OrbitMainWindow::kCollectSchedulerInfoSettingKey{"CollectSchedulerInfo"};
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
 const QString OrbitMainWindow::kTraceGpuSubmissionsSettingKey{"TraceGpuSubmissions"};
+const QString OrbitMainWindow::kEnableAutoFrameTrack{"EnableAutoFrameTrack"};
 const QString OrbitMainWindow::kCollectMemoryInfoSettingKey{"CollectMemoryInfo"};
 const QString OrbitMainWindow::kEnableApiSettingKey{"EnableApi"};
 const QString OrbitMainWindow::kEnableIntrospectionSettingKey{"EnableIntrospection"};
@@ -1183,6 +1184,11 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
                      orbit_qt::CaptureOptionsDialog::kWineSyscallHandlingMethodDefaultValue))
           .toInt());
   app_->SetWineSyscallHandlingMethod(wine_syscall_handling_method);
+
+  bool default_state_auto_frame_track = absl::GetFlag(FLAGS_auto_frame_track);
+  bool enable_auto_frame_track =
+      settings.value(kEnableAutoFrameTrack, default_state_auto_frame_track).toBool();
+  app_->SetEnableAutoFrameTrack(enable_auto_frame_track);
 
   bool collect_memory_info = settings.value(kCollectMemoryInfoSettingKey, false).toBool();
   app_->SetCollectMemoryInfo(collect_memory_info);
@@ -1273,6 +1279,9 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   }
   dialog.SetWineSyscallHandlingMethod(wine_syscall_handling_method);
 
+  bool default_state_auto_frame_track = absl::GetFlag(FLAGS_auto_frame_track);
+  dialog.SetEnableAutoFrameTrack(
+      settings.value(kEnableAutoFrameTrack, default_state_auto_frame_track).toBool());
   dialog.SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
   dialog.SetMemorySamplingPeriodMs(
       settings
@@ -1314,6 +1323,7 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
                     static_cast<int>(dialog.GetDynamicInstrumentationMethod()));
   settings.setValue(kWineSyscallHandlingMethodSettingKey,
                     static_cast<int>(dialog.GetWineSyscallHandlingMethod()));
+  settings.setValue(kEnableAutoFrameTrack, dialog.GetEnableAutoFrameTrack());
   settings.setValue(kCollectMemoryInfoSettingKey, dialog.GetCollectMemoryInfo());
   settings.setValue(kMemorySamplingPeriodMsSettingKey,
                     QString::number(dialog.GetMemorySamplingPeriodMs()));

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -218,6 +218,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kCollectSchedulerInfoSettingKey;
   static const QString kCollectThreadStatesSettingKey;
   static const QString kTraceGpuSubmissionsSettingKey;
+  static const QString kEnableAutoFrameTrack;
   static const QString kCollectMemoryInfoSettingKey;
   static const QString kEnableApiSettingKey;
   static const QString kEnableIntrospectionSettingKey;


### PR DESCRIPTION
In this PR we are including an option to disable auto frame track in
user settings (by default true) as it was discussed in
go/stadia-orbit-auto-frame-track-alignment. The option is related
about Orbit adding automatically the default Frame Track at the start
of the session.

The logic is a bit more complex as it seems.
 - The option is true by default.
 - Setting the flag to false won't erase the already added default frame
   track. It will apply for the next session.
 - Setting the flag to true will add the frame track during the next
   LoadAllSymbols call. This will be modified in a future commit, I
   think we should add it as soon as possible (by actually triggering
   AddDefaultFrameTrack method) but only once (so users are able to
   erase it manually: TODO tracked in http://b/239675491), but I'm open
   to suggestions if you think that we should only add it in the next
   session to be consistent.

http://screenshot/AXGNtGHJrScstFQ

Bug: http://b/239148938
Test: Started/ended sessions flipping the option and took several
captures. Also created a signed build and run E2E tests (in progress).