### PR TITLE
Add SymbolDownloadInfo to parse ggp crash-report output

### DIFF
--- a/src/OrbitGgp/AccountTest.cpp
+++ b/src/OrbitGgp/AccountTest.cpp
@@ -12,7 +12,7 @@ namespace orbit_ggp {
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasValue;
 
-TEST(OrbitGgpProject, GetDefaultAccountFromJson) {
+TEST(OrbitGgpAccountTest, GetDefaultAccountFromJson) {
   {  // invalid json
     const auto json = QString("json").toUtf8();
     EXPECT_THAT(Account::GetDefaultAccountFromJson(json), HasError("Unable to parse JSON"));

--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -16,7 +16,8 @@ target_sources(OrbitGgp PUBLIC
           include/OrbitGgp/Instance.h
           include/OrbitGgp/InstanceItemModel.h
           include/OrbitGgp/Project.h
-          include/OrbitGgp/SshInfo.h)
+          include/OrbitGgp/SshInfo.h          
+          include/OrbitGgp/SymbolDownloadInfo.h)
 
 target_sources(OrbitGgp PRIVATE
           Account.cpp
@@ -25,7 +26,8 @@ target_sources(OrbitGgp PRIVATE
           Instance.cpp
           InstanceItemModel.cpp
           Project.cpp
-          SshInfo.cpp)
+          SshInfo.cpp
+          SymbolDownloadInfo.cpp)
 
 target_link_libraries(
   OrbitGgp
@@ -54,6 +56,7 @@ target_sources(OrbitGgpTests PRIVATE
           InstanceItemModelTests.cpp
           ProjectTest.cpp
           SshInfoTests.cpp
+          SymbolDownloadInfoTest.cpp
 )
 
 target_link_libraries(OrbitGgpTests PRIVATE 

--- a/src/OrbitGgp/SymbolDownloadInfo.cpp
+++ b/src/OrbitGgp/SymbolDownloadInfo.cpp
@@ -26,7 +26,7 @@ ErrorMessageOr<SymbolDownloadInfo> CreateFromJson(const QJsonObject& obj) {
 }
 }  // namespace
 
-ErrorMessageOr<QVector<SymbolDownloadInfo>> SymbolDownloadInfo::GetListFromJson(
+ErrorMessageOr<std::vector<SymbolDownloadInfo>> SymbolDownloadInfo::GetListFromJson(
     const QByteArray& json) {
   const QJsonDocument doc = QJsonDocument::fromJson(json);
   if (!doc.isObject()) return ErrorMessage{"Unable to parse JSON: Object expected."};
@@ -40,7 +40,7 @@ ErrorMessageOr<QVector<SymbolDownloadInfo>> SymbolDownloadInfo::GetListFromJson(
   if (!symbols_value.isArray()) return ErrorMessage{"Unable to parse JSON: Array expected."};
 
   const QJsonArray symbols_arr = symbols_value.toArray();
-  QVector<SymbolDownloadInfo> list;
+  std::vector<SymbolDownloadInfo> list;
   for (const QJsonValue& symbol_value : symbols_arr) {
     if (!symbol_value.isObject()) return ErrorMessage{"Unable to parse JSON: Object expected."};
 

--- a/src/OrbitGgp/SymbolDownloadInfo.cpp
+++ b/src/OrbitGgp/SymbolDownloadInfo.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitGgp/SymbolDownloadInfo.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+#include "OrbitBase/Result.h"
+#include "OrbitGgp/Error.h"
+
+namespace orbit_ggp {
+namespace {
+ErrorMessageOr<SymbolDownloadInfo> CreateFromJson(const QJsonObject& obj) {
+  const auto process = [](const QJsonValue& val) -> ErrorMessageOr<QString> {
+    if (!val.isString()) return ErrorMessage{"Unable to parse JSON: String expected."};
+    return val.toString();
+  };
+  OUTCOME_TRY(auto&& file_id, process(obj.value("fileId")));
+  OUTCOME_TRY(auto&& url, process(obj.value("downloadUrl")));
+
+  return SymbolDownloadInfo{file_id, url};
+}
+}  // namespace
+
+ErrorMessageOr<QVector<SymbolDownloadInfo>> SymbolDownloadInfo::GetListFromJson(
+    const QByteArray& json) {
+  const QJsonDocument doc = QJsonDocument::fromJson(json);
+  if (!doc.isObject()) return ErrorMessage{"Unable to parse JSON: Object expected."};
+
+  const QJsonObject symbols_obj = doc.object();
+  if (!symbols_obj.contains("symbols")) {
+    return ErrorMessage{"Unable to parse JSON: \"symbols\" key missing."};
+  }
+
+  const QJsonValue symbols_value = symbols_obj.value("symbols");
+  if (!symbols_value.isArray()) return ErrorMessage{"Unable to parse JSON: Array expected."};
+
+  const QJsonArray symbols_arr = symbols_value.toArray();
+  QVector<SymbolDownloadInfo> list;
+  for (const QJsonValue& symbol_value : symbols_arr) {
+    if (!symbol_value.isObject()) return ErrorMessage{"Unable to parse JSON: Object expected."};
+
+    OUTCOME_TRY(auto&& symbol_download_info, CreateFromJson(symbol_value.toObject()));
+    list.push_back(std::move(symbol_download_info));
+  }
+
+  return list;
+}
+
+}  // namespace orbit_ggp

--- a/src/OrbitGgp/SymbolDownloadInfoTest.cpp
+++ b/src/OrbitGgp/SymbolDownloadInfoTest.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QString>
+#include <QVector>
+
+#include "OrbitBase/Result.h"
+#include "OrbitGgp/SymbolDownloadInfo.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_ggp {
+
+TEST(OrbitGgpSymbolDownloadInfoTest, GetListFromJsonError) {
+  std::vector<QString> test_cases = {// Empty json
+                                     QString("{}"),
+                                     // Invalid json
+                                     QString("json"),
+                                     // One empty json object
+                                     QString(R"(
+{
+ "symbols": [{}]
+} 
+)"),
+                                     // One partial (invalid) element
+                                     QString(R"(
+{
+ "symbols": [
+  {
+   "downloadUrl": "valid_url_for_symbol_0",
+  }
+ ]
+} 
+)"),
+                                     // One valid and one invalid element
+                                     QString(R"(
+{
+ "symbols": [
+  {
+   "downloadUrl": "valid_url_for_symbol_0",
+   "fileId": "symbolFiles/build_id_0/symbol_filename_0"
+  },
+  {
+   "downloadUrl": "valid_url_for_symbol_1",
+   "wrong id identifier": "symbolFiles/build_id_1/symbol_filename_1"
+  }
+ ]
+}       
+)")};
+
+  for (const QString& json : test_cases) {
+    EXPECT_THAT(SymbolDownloadInfo::GetListFromJson(json.toUtf8()),
+                orbit_test_utils::HasError("Unable to parse JSON"));
+  }
+}
+
+TEST(OrbitGgpSymbolDownloadInfoTest, GetListFromJsonSuccess) {
+  // Two valid elements
+  const auto json = QString(R"(
+{
+ "symbols": [
+  {
+   "downloadUrl": "valid_url_for_symbol_0",
+   "fileId": "symbolFiles/build_id_0/symbol_filename_0"
+  },
+  {
+   "downloadUrl": "valid_url_for_symbol_1",
+   "fileId": "symbolFiles/build_id_1/symbol_filename_1"
+  }
+ ]
+}
+)");
+
+  const auto result = SymbolDownloadInfo::GetListFromJson(json.toUtf8());
+  ASSERT_THAT(result, orbit_test_utils::HasNoError());
+  const QVector<SymbolDownloadInfo>& symbols{result.value()};
+  ASSERT_EQ(symbols.size(), 2);
+  EXPECT_EQ(symbols[0].file_id, "symbolFiles/build_id_0/symbol_filename_0");
+  EXPECT_EQ(symbols[0].url, "valid_url_for_symbol_0");
+  EXPECT_EQ(symbols[1].file_id, "symbolFiles/build_id_1/symbol_filename_1");
+  EXPECT_EQ(symbols[1].url, "valid_url_for_symbol_1");
+}
+
+}  // namespace orbit_ggp

--- a/src/OrbitGgp/SymbolDownloadInfoTest.cpp
+++ b/src/OrbitGgp/SymbolDownloadInfoTest.cpp
@@ -4,8 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <QByteArray>
 #include <QString>
-#include <QVector>
 
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/SymbolDownloadInfo.h"
@@ -14,18 +14,18 @@
 namespace orbit_ggp {
 
 TEST(OrbitGgpSymbolDownloadInfoTest, GetListFromJsonError) {
-  std::vector<QString> test_cases = {// Empty json
-                                     QString("{}"),
-                                     // Invalid json
-                                     QString("json"),
-                                     // One empty json object
-                                     QString(R"(
+  std::vector<QByteArray> test_cases = {// Empty json
+                                        QByteArray("{}"),
+                                        // Invalid json
+                                        QByteArray("json"),
+                                        // One empty json object
+                                        QByteArray(R"(
 {
  "symbols": [{}]
 } 
 )"),
-                                     // One partial (invalid) element
-                                     QString(R"(
+                                        // One partial (invalid) element
+                                        QByteArray(R"(
 {
  "symbols": [
   {
@@ -34,8 +34,8 @@ TEST(OrbitGgpSymbolDownloadInfoTest, GetListFromJsonError) {
  ]
 } 
 )"),
-                                     // One valid and one invalid element
-                                     QString(R"(
+                                        // One valid and one invalid element
+                                        QByteArray(R"(
 {
  "symbols": [
   {
@@ -50,15 +50,15 @@ TEST(OrbitGgpSymbolDownloadInfoTest, GetListFromJsonError) {
 }       
 )")};
 
-  for (const QString& json : test_cases) {
-    EXPECT_THAT(SymbolDownloadInfo::GetListFromJson(json.toUtf8()),
+  for (const auto& json : test_cases) {
+    EXPECT_THAT(SymbolDownloadInfo::GetListFromJson(json),
                 orbit_test_utils::HasError("Unable to parse JSON"));
   }
 }
 
 TEST(OrbitGgpSymbolDownloadInfoTest, GetListFromJsonSuccess) {
   // Two valid elements
-  const auto json = QString(R"(
+  const auto json = QByteArray(R"(
 {
  "symbols": [
   {
@@ -73,14 +73,42 @@ TEST(OrbitGgpSymbolDownloadInfoTest, GetListFromJsonSuccess) {
 }
 )");
 
-  const auto result = SymbolDownloadInfo::GetListFromJson(json.toUtf8());
+  const auto result = SymbolDownloadInfo::GetListFromJson(json);
   ASSERT_THAT(result, orbit_test_utils::HasNoError());
-  const QVector<SymbolDownloadInfo>& symbols{result.value()};
+  const std::vector<SymbolDownloadInfo>& symbols{result.value()};
   ASSERT_EQ(symbols.size(), 2);
   EXPECT_EQ(symbols[0].file_id, "symbolFiles/build_id_0/symbol_filename_0");
   EXPECT_EQ(symbols[0].url, "valid_url_for_symbol_0");
   EXPECT_EQ(symbols[1].file_id, "symbolFiles/build_id_1/symbol_filename_1");
   EXPECT_EQ(symbols[1].url, "valid_url_for_symbol_1");
+}
+
+TEST(OrbitGgpSymbolDownloadInfoTest, EqualToOperator) {
+  SymbolDownloadInfo symbol_0;
+  SymbolDownloadInfo symbol_1;
+  EXPECT_TRUE(symbol_0 == symbol_1);
+
+  symbol_0.file_id = "a_symbol_filename";
+  symbol_0.url = "valid_url_for_symbol";
+  EXPECT_FALSE(symbol_0 == symbol_1);
+
+  symbol_1.file_id = "a_symbol_filename";
+  symbol_1.url = "valid_url_for_symbol";
+  EXPECT_TRUE(symbol_0 == symbol_1);
+}
+
+TEST(OrbitGgpSymbolDownloadInfoTest, NotEqualToOperator) {
+  SymbolDownloadInfo symbol_0;
+  SymbolDownloadInfo symbol_1;
+  EXPECT_FALSE(symbol_0 != symbol_1);
+
+  symbol_0.file_id = "a_symbol_filename";
+  symbol_0.url = "valid_url_for_symbol";
+  EXPECT_TRUE(symbol_0 != symbol_1);
+
+  symbol_1.file_id = "a_symbol_filename";
+  symbol_1.url = "valid_url_for_symbol";
+  EXPECT_FALSE(symbol_0 != symbol_1);
 }
 
 }  // namespace orbit_ggp

--- a/src/OrbitGgp/include/OrbitGgp/SymbolDownloadInfo.h
+++ b/src/OrbitGgp/include/OrbitGgp/SymbolDownloadInfo.h
@@ -7,7 +7,7 @@
 
 #include <QByteArray>
 #include <QString>
-#include <QVector>
+#include <vector>
 
 #include "OrbitBase/Result.h"
 
@@ -17,7 +17,18 @@ struct SymbolDownloadInfo {
   QString file_id;
   QString url;
 
-  static ErrorMessageOr<QVector<SymbolDownloadInfo>> GetListFromJson(const QByteArray& json);
+  [[nodiscard]] static ErrorMessageOr<std::vector<SymbolDownloadInfo>> GetListFromJson(
+      const QByteArray& json);
+
+  [[nodiscard]] friend bool operator==(const SymbolDownloadInfo& lhs,
+                                       const SymbolDownloadInfo& rhs) {
+    return (lhs.file_id == rhs.file_id) && (lhs.url == rhs.url);
+  }
+
+  [[nodiscard]] friend bool operator!=(const SymbolDownloadInfo& lhs,
+                                       const SymbolDownloadInfo& rhs) {
+    return !(lhs == rhs);
+  }
 };
 
 }  // namespace orbit_ggp

--- a/src/OrbitGgp/include/OrbitGgp/SymbolDownloadInfo.h
+++ b/src/OrbitGgp/include/OrbitGgp/SymbolDownloadInfo.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GGP_SYMBOL_DOWNLOAD_INFO_H_
+#define ORBIT_GGP_SYMBOL_DOWNLOAD_INFO_H_
+
+#include <QByteArray>
+#include <QString>
+#include <QVector>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_ggp {
+
+struct SymbolDownloadInfo {
+  QString file_id;
+  QString url;
+
+  static ErrorMessageOr<QVector<SymbolDownloadInfo>> GetListFromJson(const QByteArray& json);
+};
+
+}  // namespace orbit_ggp
+
+#endif  // ORBIT_GGP_SYMBOL_DOWNLOAD_INFO_H_


### PR DESCRIPTION
With this change, we added the `SymbolDownloadInfo` struct for parsing
the symbol download URLs related information from the output of `ggp
crash-report download-symbols --show-url` (added in cl/461606448)

Test: Unit test added
Bug: http://b/239167725