### PR TITLE
Move ReadMaps from LinuxTracingUtils to ReadLinuxMaps

### DIFF
--- a/src/LinuxTracing/LinuxTracingUtils.cpp
+++ b/src/LinuxTracing/LinuxTracingUtils.cpp
@@ -40,16 +40,6 @@ using orbit_module_utils::LinuxMemoryMapping;
 
 namespace orbit_linux_tracing {
 
-std::string ReadMaps(pid_t pid) {
-  std::string maps_filename = absl::StrFormat("/proc/%d/maps", pid);
-  ErrorMessageOr<std::string> maps_content_or_error = orbit_base::ReadFileToString(maps_filename);
-  if (maps_content_or_error.has_error()) {
-    return {};
-  }
-
-  return maps_content_or_error.value();
-}
-
 std::optional<char> GetThreadState(pid_t tid) {
   fs::path stat{fs::path{"/proc"} / std::to_string(tid) / "stat"};
   if (!fs::exists(stat)) {

--- a/src/LinuxTracing/LinuxTracingUtils.h
+++ b/src/LinuxTracing/LinuxTracingUtils.h
@@ -18,8 +18,6 @@
 
 namespace orbit_linux_tracing {
 
-std::string ReadMaps(pid_t pid);
-
 // The association between a character and a thread state is documented at
 // https://man7.org/linux/man-pages/man5/proc.5.html in the "/proc/[pid]/stat" section,
 // and at https://www.man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES.

--- a/src/LinuxTracing/LinuxTracingUtilsTest.cpp
+++ b/src/LinuxTracing/LinuxTracingUtilsTest.cpp
@@ -190,7 +190,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages, NoModules) {
       MakeInstrumentedFunction(2, "/path/to/elf", "bar()", 0x56290, 0x55290)};
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), {}, instrumented_functions);
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), {}, instrumented_functions);
 
   EXPECT_EQ(function_ids_to_error_messages.size(), 2);
 
@@ -221,7 +221,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages, NoFunctionsToInstrume
   };
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), modules, {});
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), modules, {});
 
   EXPECT_EQ(function_ids_to_error_messages.size(), 0);
 }
@@ -241,7 +241,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages, ModuleInMapsAndFuncti
       MakeInstrumentedFunction(2, "/path/to/elf", "bar()", 0x56290, 0x55290)};
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), modules, instrumented_functions);
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), modules, instrumented_functions);
 
   EXPECT_EQ(function_ids_to_error_messages.size(), 0);
 }
@@ -261,7 +261,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages, ModuleInMapsButFuncti
       MakeInstrumentedFunction(2, "/path/to/elf", "bar()", 0x56290, 0x55290)};
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), modules, instrumented_functions);
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), modules, instrumented_functions);
 
   ASSERT_EQ(function_ids_to_error_messages.size(), 1);
   const auto& [function_id, error_message] = *function_ids_to_error_messages.begin();
@@ -286,7 +286,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages, ModuleInMapsButFuncti
       MakeInstrumentedFunction(2, "/path/to/elf", "high_address()", 0x101000, 0x100000)};
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), modules, instrumented_functions);
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), modules, instrumented_functions);
 
   ASSERT_EQ(function_ids_to_error_messages.size(), 1);
   const auto& [function_id, error_message] = *function_ids_to_error_messages.begin();
@@ -316,7 +316,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages,
       MakeInstrumentedFunction(2, "/path/to/elf", "bar()", 0x56290, 0x55290)};
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), modules, instrumented_functions);
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), modules, instrumented_functions);
 
   ASSERT_EQ(function_ids_to_error_messages.size(), 1);
   const auto& [function_id, error_message] = *function_ids_to_error_messages.begin();
@@ -345,7 +345,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages,
       MakeInstrumentedFunction(2, "/path/to/elf", "bar()", 0x56290, 0x55290)};
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), modules, instrumented_functions);
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), modules, instrumented_functions);
 
   ASSERT_EQ(function_ids_to_error_messages.size(), 1);
   const auto& [function_id, error_message] = *function_ids_to_error_messages.begin();
@@ -371,7 +371,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages,
       MakeInstrumentedFunction(2, "/path/to/elf", "bar()", 0x56290, 0x55290)};
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), modules, instrumented_functions);
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), modules, instrumented_functions);
 
   ASSERT_EQ(function_ids_to_error_messages.size(), 1);
   const auto& [function_id, error_message] = *function_ids_to_error_messages.begin();
@@ -395,7 +395,7 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages, ModuleNotInMaps) {
       MakeInstrumentedFunction(2, "/path/to/elf", "bar()", 0x56290, 0x55290)};
   const std::map<uint64_t, std::string> function_ids_to_error_messages =
       FindFunctionsThatUprobesCannotInstrumentWithMessages(
-          orbit_module_utils::ReadMaps(kProcPidMapsContent), modules, instrumented_functions);
+          orbit_module_utils::ParseMaps(kProcPidMapsContent), modules, instrumented_functions);
 
   ASSERT_EQ(function_ids_to_error_messages.size(), 1);
   const auto& [function_id, error_message] = *function_ids_to_error_messages.begin();

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -589,7 +589,7 @@ FindExecutableAddressRangeForSameFileFromFirstMapInfo(
 // each new executable file mapping we would send a ModuleUpdateEvent with the address range and
 // file for that mapping.
 //
-// But just like for orbit_object_utils::ParseMapsIntoModules, things are more complicated. We
+// But just like for orbit_object_utils::ReadModulesFromMaps, things are more complicated. We
 // observed that in some cases a single loadable segment of an ELF file or a single executable
 // section of a PE can be loaded into memory with multiple adjacent file mappings. In addition, some
 // PEs can have multiple executable sections. And finally, the executable sections (and all other
@@ -607,7 +607,7 @@ FindExecutableAddressRangeForSameFileFromFirstMapInfo(
 //   module; if the module is a PE, we also have to consider anonymous mappings and detect whether
 //   they actually belong to the PE.
 //
-// Note that, just like in orbit_object_utils::ParseMapsIntoModules:
+// Note that, just like in orbit_object_utils::ReadModulesFromMaps:
 // - The ModuleInfo in the ModuleUpdateEvent will carry executable_segment_offset with the
 //   assumption that the value of ObjectFile::GetExecutableSegmentOffset correspond to the *first*
 //   executable mapping.

--- a/src/ModuleUtils/ReadLinuxMaps.cpp
+++ b/src/ModuleUtils/ReadLinuxMaps.cpp
@@ -18,13 +18,13 @@
 
 namespace orbit_module_utils {
 
-ErrorMessageOr<std::vector<LinuxMemoryMapping>> ReadMaps(pid_t pid) {
+ErrorMessageOr<std::string> ReadMaps(pid_t pid) {
   const std::filesystem::path proc_pid_maps_path{absl::StrFormat("/proc/%i/maps", pid)};
   OUTCOME_TRY(auto&& proc_pid_maps_content, orbit_base::ReadFileToString(proc_pid_maps_path));
-  return ReadMaps(proc_pid_maps_content);
+  return std::move(proc_pid_maps_content);
 }
 
-std::vector<LinuxMemoryMapping> ReadMaps(std::string_view proc_pid_maps_content) {
+std::vector<LinuxMemoryMapping> ParseMaps(std::string_view proc_pid_maps_content) {
   const std::vector<std::string> proc_pid_maps_lines = absl::StrSplit(proc_pid_maps_content, '\n');
   std::vector<LinuxMemoryMapping> result;
 
@@ -61,6 +61,11 @@ std::vector<LinuxMemoryMapping> ReadMaps(std::string_view proc_pid_maps_content)
   }
 
   return result;
+}
+
+ErrorMessageOr<std::vector<LinuxMemoryMapping>> ReadAndParseMaps(pid_t pid) {
+  OUTCOME_TRY(auto&& proc_pid_maps_content, ReadMaps(pid));
+  return ParseMaps(proc_pid_maps_content);
 }
 
 }  // namespace orbit_module_utils

--- a/src/ModuleUtils/ReadLinuxModules.cpp
+++ b/src/ModuleUtils/ReadLinuxModules.cpp
@@ -85,8 +85,8 @@ ErrorMessageOr<ModuleInfo> CreateModule(const std::filesystem::path& module_path
 }
 
 ErrorMessageOr<std::vector<ModuleInfo>> ReadModules(pid_t pid) {
-  OUTCOME_TRY(auto&& maps, ReadMaps(pid));
-  return ParseMapsIntoModules(maps);
+  OUTCOME_TRY(auto&& maps, ReadAndParseMaps(pid));
+  return ReadModulesFromMaps(maps);
 }
 
 namespace {
@@ -131,7 +131,7 @@ namespace {
 // expect contains the PE (based on the start address of the file mapping that contains the headers
 // and based on the PE's SizeOfImage), we can be confident that this mapping also belongs to the PE.
 //
-// This class contains logic to help ParseMapsIntoModules with keeping track of the executable maps
+// This class contains logic to help ReadModulesFromMaps with keeping track of the executable maps
 // of a module, and with detecting anonymous executable maps that belong to a PE. The intended usage
 // is as follows:
 // - Create a new instance of this class when a new file is encountered while parsing
@@ -259,7 +259,7 @@ class FileMappedIntoMemory {
 };
 }  // namespace
 
-std::vector<ModuleInfo> ParseMapsIntoModules(const std::vector<LinuxMemoryMapping>& maps) {
+std::vector<ModuleInfo> ReadModulesFromMaps(const std::vector<LinuxMemoryMapping>& maps) {
   std::vector<ModuleInfo> result;
 
   std::optional<FileMappedIntoMemory> last_file_mapped_into_memory;

--- a/src/ModuleUtils/ReadLinuxModulesTest.cpp
+++ b/src/ModuleUtils/ReadLinuxModulesTest.cpp
@@ -153,12 +153,12 @@ TEST(ReadLinuxModules, ReadModules) {
   EXPECT_GT(result.value().size(), 0);
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesEmptyData) {
-  const auto result = ParseMapsIntoModules(ReadMaps(""));
+TEST(ReadLinuxModules, ReadModulesFromMapsEmptyData) {
+  const auto result = ReadModulesFromMaps(ParseMaps(""));
   EXPECT_EQ(result.size(), 0);
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModules1) {
+TEST(ReadLinuxModules, ReadModulesFromMaps1) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path hello_world_path = test_path / "hello_world_elf";
   const std::filesystem::path text_file = test_path / "textfile.txt";
@@ -171,11 +171,11 @@ TEST(ReadLinuxModules, ParseMapsIntoModules1) {
       "7f6874290000-7f6874297000 r-xp 00000000 fe:01 661214                     /dev/zero\n"
       "7f6874290001-7f6874297002 r-dp 00000000 fe:01 661214                     %s\n",
       hello_world_path, text_file)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   EXPECT_EQ(result.size(), 1);
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModules2) {
+TEST(ReadLinuxModules, ReadModulesFromMaps2) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path hello_world_path = test_path / "hello_world_elf";
   const std::filesystem::path no_symbols_path = test_path / "no_symbols_elf";
@@ -189,7 +189,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModules2) {
       "800000000000-800000001000 r-xp 00009000 fe:01 661216                     %2$s\n",
       hello_world_path, no_symbols_path)};
 
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 2);
 
   const ModuleInfo& hello_module_info = result[0];
@@ -220,7 +220,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModules2) {
   EXPECT_EQ(no_symbols_module_info.object_segments()[0].size_in_memory(), 0xa40);
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesWithSpacesInPath) {
+TEST(ReadLinuxModules, ReadModulesFromMapsWithSpacesInPath) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   ErrorMessageOr<std::string> elf_contents_or_error =
       orbit_base::ReadFileToString(test_path / "hello_world_elf");
@@ -237,7 +237,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesWithSpacesInPath) {
   const std::string proc_pid_maps_content{absl::StrFormat(
       "7f6874290000-7f6874297000 r-xp 00000000 fe:01 661214                     %s\n",
       hello_world_elf_temporary.file_path())};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 1);
 
   const ModuleInfo& hello_module_info = result[0];
@@ -252,7 +252,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesWithSpacesInPath) {
   VerifyObjectSegmentsForHelloWorldElf(hello_module_info.object_segments());
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesElfWithMultipleExecutableMaps) {
+TEST(ReadLinuxModules, ReadModulesFromMapsElfWithMultipleExecutableMaps) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path hello_world_path = test_path / "hello_world_elf";
 
@@ -263,7 +263,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesElfWithMultipleExecutableMaps) {
                       "103000-104000 rw-p 00000000 00:00 0 \n"
                       "104000-105000 r-xp 00000000 01:02 42    %1$s\n",
                       hello_world_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 1);
 
   const ModuleInfo& hello_module_info = result[0];
@@ -278,7 +278,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesElfWithMultipleExecutableMaps) {
   VerifyObjectSegmentsForHelloWorldElf(hello_module_info.object_segments());
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedNotAnonymously) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeTextMappedNotAnonymously) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";  // SizeOfImage = 0x20000
 
@@ -286,7 +286,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedNotAnonymously) {
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
                       "101000-103000 r-xp 00001000 01:02 42    %1$s\n",
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 1);
 
   const orbit_grpc_protos::ModuleInfo& libtest_module_info = result[0];
@@ -303,7 +303,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedNotAnonymously) {
   VerifyObjectSegmentsForLibTestDll(libtest_module_info.object_segments());
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedNotAnonymouslyWithMultipleExecutableMaps) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeTextMappedNotAnonymouslyWithMultipleExecutableMaps) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -314,7 +314,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedNotAnonymouslyWithMultipl
                       "103000-104000 rw-p 00000000 00:00 0 \n"
                       "104000-105000 r-xp 00000000 01:02 42    %1$s\n",
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 1);
 
   const orbit_grpc_protos::ModuleInfo& libtest_module_info = result[0];
@@ -331,7 +331,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedNotAnonymouslyWithMultipl
   VerifyObjectSegmentsForLibTestDll(libtest_module_info.object_segments());
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymously) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeTextMappedAnonymously) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -339,7 +339,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymously) {
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %1$s\n"
                       "101000-103000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 1);
 
   const orbit_grpc_protos::ModuleInfo& libtest_module_info = result[0];
@@ -356,7 +356,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymously) {
   VerifyObjectSegmentsForLibTestDll(libtest_module_info.object_segments());
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyWithMultipleExecutableMaps) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeTextMappedAnonymouslyWithMultipleExecutableMaps) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -368,7 +368,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyWithMultipleEx
                       "104000-105000 r-xp 00000000 00:00 0 \n"
                       "105000-121000 r-xp 00000000 00:00 0 \n",  // Beyond SizeOfImage.
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 1);
 
   const orbit_grpc_protos::ModuleInfo& libtest_module_info = result[0];
@@ -385,7 +385,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyWithMultipleEx
   VerifyObjectSegmentsForLibTestDll(libtest_module_info.object_segments());
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyInMoreComplexExample) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeTextMappedAnonymouslyInMoreComplexExample) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -402,7 +402,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyInMoreComplexE
                       "108000-109000 r-xp 00000000 00:00 0 \n"  // An executable map.
                       "109000-10A000 r-xp 00000000 01:02 42    /path/to/nothing\n",
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 1);
 
   const orbit_grpc_protos::ModuleInfo& libtest_module_info = result[0];
@@ -419,7 +419,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyInMoreComplexE
   VerifyObjectSegmentsForLibTestDll(libtest_module_info.object_segments());
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyAndFirstMapWithOffset) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeTextMappedAnonymouslyAndFirstMapWithOffset) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -427,11 +427,11 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyAndFirstMapWit
       absl::StrFormat("101000-102000 r--p 00001000 01:02 42    %s\n"
                       "102000-103000 r-xp 00000000 00:00 0 \n",
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   ASSERT_EQ(result.size(), 0);
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedWithWrongName) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeTextMappedWithWrongName) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -439,11 +439,11 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedWithWrongName) {
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
                       "101000-103000 r-xp 00000000 00:00 42    /wrong/path\n",
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   EXPECT_EQ(result.size(), 0);
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeNoExecutableMap) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeNoExecutableMap) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -451,11 +451,11 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeNoExecutableMap) {
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
                       "101000-103000 r--p 00000000 00:00 0 \n",
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   EXPECT_EQ(result.size(), 0);
 }
 
-TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyWithEndBeyondSizeOfImage) {
+TEST(ReadLinuxModules, ReadModulesFromMapsPeTextMappedAnonymouslyWithEndBeyondSizeOfImage) {
   const std::filesystem::path test_path = orbit_test::GetTestdataDir();
   const std::filesystem::path libtest_path = test_path / "libtest.dll";
 
@@ -463,7 +463,7 @@ TEST(ReadLinuxModules, ParseMapsIntoModulesPeTextMappedAnonymouslyWithEndBeyondS
       absl::StrFormat("100000-101000 r--p 00000000 01:02 42    %s\n"
                       "101000-121000 r-xp 00000000 00:00 0 \n",  // Beyond SizeOfImage.
                       libtest_path)};
-  const auto result = ParseMapsIntoModules(ReadMaps(proc_pid_maps_content));
+  const auto result = ReadModulesFromMaps(ParseMaps(proc_pid_maps_content));
   EXPECT_EQ(result.size(), 0);
 }
 

--- a/src/ModuleUtils/include/ModuleUtils/ReadLinuxMaps.h
+++ b/src/ModuleUtils/include/ModuleUtils/ReadLinuxMaps.h
@@ -49,9 +49,11 @@ class LinuxMemoryMapping {
   std::string pathname_;
 };
 
-ErrorMessageOr<std::vector<LinuxMemoryMapping>> ReadMaps(pid_t pid);
+ErrorMessageOr<std::string> ReadMaps(pid_t pid);
 
-[[nodiscard]] std::vector<LinuxMemoryMapping> ReadMaps(std::string_view proc_pid_maps_content);
+[[nodiscard]] std::vector<LinuxMemoryMapping> ParseMaps(std::string_view proc_pid_maps_content);
+
+ErrorMessageOr<std::vector<LinuxMemoryMapping>> ReadAndParseMaps(pid_t pid);
 
 }  // namespace orbit_module_utils
 

--- a/src/ModuleUtils/include/ModuleUtils/ReadLinuxModules.h
+++ b/src/ModuleUtils/include/ModuleUtils/ReadLinuxModules.h
@@ -25,7 +25,7 @@ ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModule(const std::filesystem
 
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(pid_t pid);
 
-[[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo> ParseMapsIntoModules(
+[[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo> ReadModulesFromMaps(
     const std::vector<LinuxMemoryMapping>& maps);
 
 }  // namespace orbit_module_utils


### PR DESCRIPTION
This now seems to be the perfect place for it. Also add a smoke test and make it
return `ErrorMessageOr`.

We have to do some renaming as a consequence to prevent confusion.

The previous `ReadMaps(std::string_view)` becomes `ParseMaps`, also in line with
`LibunwindstackMaps::ParseMaps`. `ReadMaps(pid_t)` becomes `ReadAndParseMaps`.

As with "parse maps" we now mean from text to `LinuxMemoryMapping`s, we change
`ParseMapsIntoModules` to `ReadModulesFromMaps` (in line and contrast with
`ReadModules`, that takes the pid).

Test: Capture `triangle.exe`. Verify modules show up correctly, callstacks make
sense.