### PR TITLE
Give users the option of disabling auto-frame-track

### DIFF
--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -275,6 +275,16 @@ uint64_t DataManager::max_local_marker_depth_per_command_buffer() const {
   return max_local_marker_depth_per_command_buffer_;
 }
 
+void DataManager::set_enable_auto_frame_track(bool enable_auto_frame_track) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  enable_auto_frame_track_ = enable_auto_frame_track;
+}
+
+bool DataManager::enable_auto_frame_track() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return enable_auto_frame_track_;
+}
+
 void DataManager::set_collect_memory_info(bool collect_memory_info) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   collect_memory_info_ = collect_memory_info;

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -106,6 +106,9 @@ class DataManager final {
       uint64_t max_local_marker_depth_per_command_buffer);
   [[nodiscard]] uint64_t max_local_marker_depth_per_command_buffer() const;
 
+  void set_enable_auto_frame_track(bool enable_auto_frame_track);
+  [[nodiscard]] bool enable_auto_frame_track() const;
+
   void set_collect_memory_info(bool collect_memory_info);
   [[nodiscard]] bool collect_memory_info() const;
 
@@ -145,6 +148,7 @@ class DataManager final {
   uint16_t stack_dump_size_ = 0;
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_{};
 
+  bool enable_auto_frame_track_ = false;
   bool collect_memory_info_ = false;
   uint64_t memory_sampling_period_ms_ = 10;
   uint64_t memory_warning_threshold_kb_ = 8ULL * 1024 * 1024;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2504,7 +2504,7 @@ Future<std::vector<ErrorMessageOr<CanceledOr<void>>>> OrbitApp::LoadAllSymbols()
 
     loading_futures.push_back(RetrieveModuleAndLoadSymbols(module));
   }
-  if (absl::GetFlag(FLAGS_auto_frame_track)) {
+  if (GetEnableAutoFrameTrack()) {
     // Orbit will try to add the default frame track while loading all symbols.
     std::ignore = AddDefaultFrameTrackOrLogError();
   }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -440,6 +440,12 @@ class OrbitApp final : public DataViewFactory,
   void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
 
+  void SetEnableAutoFrameTrack(bool enable_auto_frame_track) {
+    data_manager_->set_enable_auto_frame_track(enable_auto_frame_track);
+  }
+  [[nodiscard]] bool GetEnableAutoFrameTrack() const {
+    return data_manager_->enable_auto_frame_track();
+  }
   void SetCollectMemoryInfo(bool collect_memory_info) {
     data_manager_->set_collect_memory_info(collect_memory_info);
   }

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -68,6 +68,11 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   ui_->memorySamplingPeriodMsLineEdit->setValidator(new UInt64Validator(
       1, std::numeric_limits<uint64_t>::max(), ui_->memorySamplingPeriodMsLineEdit));
   ui_->memoryWarningThresholdKbLineEdit->setValidator(&uint64_validator_);
+
+  if (!absl::GetFlag(FLAGS_auto_frame_track)) {
+    ui_->autoFrameTrackGroupBox->hide();
+  }
+
   if (!absl::GetFlag(FLAGS_enable_warning_threshold)) {
     ui_->memoryWarningThresholdKbLabel->hide();
     ui_->memoryWarningThresholdKbLineEdit->hide();
@@ -252,6 +257,14 @@ void CaptureOptionsDialog::ResetLocalMarkerDepthLineEdit() {
   if (ui_->localMarkerDepthLineEdit->text().isEmpty()) {
     ui_->localMarkerDepthLineEdit->setText(QString::number(kLocalMarkerDepthDefaultValue));
   }
+}
+
+void CaptureOptionsDialog::SetEnableAutoFrameTrack(bool enable_auto_frame_track) {
+  ui_->autoFrameTrackCheckBox->setChecked(enable_auto_frame_track);
+}
+
+bool CaptureOptionsDialog::GetEnableAutoFrameTrack() const {
+  return ui_->autoFrameTrackCheckBox->isChecked();
 }
 
 void CaptureOptionsDialog::SetCollectMemoryInfo(bool collect_memory_info) {

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -78,6 +78,8 @@ class CaptureOptionsDialog : public QDialog {
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t local_marker_depth_per_command_buffer);
   [[nodiscard]] uint64_t GetMaxLocalMarkerDepthPerCommandBuffer() const;
 
+  void SetEnableAutoFrameTrack(bool enable_auto_frame_track);
+  [[nodiscard]] bool GetEnableAutoFrameTrack() const;
   void SetCollectMemoryInfo(bool collect_memory_info);
   [[nodiscard]] bool GetCollectMemoryInfo() const;
   void SetMemorySamplingPeriodMs(uint64_t memory_sampling_period_ms);

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -406,6 +406,28 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="autoFrameTrackGroupBox">
+         <property name="title">
+          <string>Auto FrameTrack</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <widget class="QCheckBox" name="autoFrameTrackCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A frame track will be added when enabling this option at the start of every session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="accessibleName">
+             <string>AutoFrameTrackCheckBox</string>
+            </property>
+            <property name="text">
+             <string>Automatically add the default frame track</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="memoryTracingGroupBox">
          <property name="title">
           <string>Memory tracing</string>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -414,13 +414,13 @@ p, li { white-space: pre-wrap; }
           <item>
            <widget class="QCheckBox" name="autoFrameTrackCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A frame track will be added when enabling this option at the start of every session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A frame track will be added when enabling this option at the start of every session. Disabling this option will not remove any existing frame track for the current session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="accessibleName">
              <string>AutoFrameTrackCheckBox</string>
             </property>
             <property name="text">
-             <string>Automatically add the default frame track</string>
+             <string>Automatically add a render frame track by default ⓘ</string>
             </property>
            </widget>
           </item>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1096,6 +1096,7 @@ const QString OrbitMainWindow::kMaxCopyRawStackSizeSettingKey{"MaxCopyRawStackSi
 const QString OrbitMainWindow::kCollectSchedulerInfoSettingKey{"CollectSchedulerInfo"};
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
 const QString OrbitMainWindow::kTraceGpuSubmissionsSettingKey{"TraceGpuSubmissions"};
+const QString OrbitMainWindow::kEnableAutoFrameTrack{"EnableAutoFrameTrack"};
 const QString OrbitMainWindow::kCollectMemoryInfoSettingKey{"CollectMemoryInfo"};
 const QString OrbitMainWindow::kEnableApiSettingKey{"EnableApi"};
 const QString OrbitMainWindow::kEnableIntrospectionSettingKey{"EnableIntrospection"};
@@ -1183,6 +1184,11 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
                      orbit_qt::CaptureOptionsDialog::kWineSyscallHandlingMethodDefaultValue))
           .toInt());
   app_->SetWineSyscallHandlingMethod(wine_syscall_handling_method);
+
+  bool default_state_auto_frame_track = absl::GetFlag(FLAGS_auto_frame_track);
+  bool enable_auto_frame_track =
+      settings.value(kEnableAutoFrameTrack, default_state_auto_frame_track).toBool();
+  app_->SetEnableAutoFrameTrack(enable_auto_frame_track);
 
   bool collect_memory_info = settings.value(kCollectMemoryInfoSettingKey, false).toBool();
   app_->SetCollectMemoryInfo(collect_memory_info);
@@ -1273,6 +1279,9 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   }
   dialog.SetWineSyscallHandlingMethod(wine_syscall_handling_method);
 
+  bool default_state_auto_frame_track = absl::GetFlag(FLAGS_auto_frame_track);
+  dialog.SetEnableAutoFrameTrack(
+      settings.value(kEnableAutoFrameTrack, default_state_auto_frame_track).toBool());
   dialog.SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
   dialog.SetMemorySamplingPeriodMs(
       settings
@@ -1314,6 +1323,7 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
                     static_cast<int>(dialog.GetDynamicInstrumentationMethod()));
   settings.setValue(kWineSyscallHandlingMethodSettingKey,
                     static_cast<int>(dialog.GetWineSyscallHandlingMethod()));
+  settings.setValue(kEnableAutoFrameTrack, dialog.GetEnableAutoFrameTrack());
   settings.setValue(kCollectMemoryInfoSettingKey, dialog.GetCollectMemoryInfo());
   settings.setValue(kMemorySamplingPeriodMsSettingKey,
                     QString::number(dialog.GetMemorySamplingPeriodMs()));

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -218,6 +218,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kCollectSchedulerInfoSettingKey;
   static const QString kCollectThreadStatesSettingKey;
   static const QString kTraceGpuSubmissionsSettingKey;
+  static const QString kEnableAutoFrameTrack;
   static const QString kCollectMemoryInfoSettingKey;
   static const QString kEnableApiSettingKey;
   static const QString kEnableIntrospectionSettingKey;


### PR DESCRIPTION
In this PR we are including an option to disable auto frame track in
user settings (by default true) as it was discussed in
go/stadia-orbit-auto-frame-track-alignment. The option is related
about Orbit adding automatically the default Frame Track at the start
of the session.

The logic is a bit more complex as it seems.
 - The option is true by default.
 - Setting the flag to false won't erase the already added default frame
   track. It will apply for the next session.
 - Setting the flag to true will add the frame track during the next
   LoadAllSymbols call. This will be modified in a future commit, I
   think we should add it as soon as possible (by actually triggering
   AddDefaultFrameTrack method) but only once (so users are able to
   erase it manually: TODO tracked in http://b/239675491), but I'm open
   to suggestions if you think that we should only add it in the next
   session to be consistent.

http://screenshot/BYU8NuWCCr3h93u

Bug: http://b/239148938
Test: Started/ended sessions flipping the option and took several
captures. Modified E2E tests (https://github.com/google/orbit/pull/3998)
and run them manually. In progress: Creating a signed build and triggering 
E2E tests. 