### PR TITLE
 Add orbit_uprobes_wine.py E2E test script

### DIFF
--- a/contrib/automation_tests/orbit_uprobes_wine.py
+++ b/contrib/automation_tests/orbit_uprobes_wine.py
@@ -1,0 +1,61 @@
+"""
+Copyright (c) 2022 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.capture_log import VerifyCaptureLogContains
+from test_cases.capture_window import Capture, CheckTimers
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
+from test_cases.live_tab import VerifyScopeTypeAndHitCount
+"""Instrument functions using uprobes on Wine.
+
+Before this script is run there needs to be a gamelet reserved and our version
+of "triangle.exe" with the `Render` function made `__declspec(noinline)` has to
+be started.
+
+The script requires absl and pywinauto. Since pywinauto requires the bitness of
+the python installation to match the bitness of the program under test, it needs
+to be run from 64 bit python.
+
+This automation script covers a basic workflow:
+ - connect to a gamelet, select a process running on Wine, load debug symbols
+ - instrument a function from a PE with FileAlignment multiple of the page size
+ - instrument a function from a PE with FileAlignment lower than the page size
+ - take a capture using uprobes for dynamic instrumentation
+ - verify the first hooked function is recorded
+ - verify the second function has no hits and gives a corresponding warning in the Capture Log
+"""
+
+
+def main(argv):
+    test_cases = [
+        ConnectToStadiaInstance(),
+        FilterAndSelectFirstProcess(process_filter="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="d3d11.dll"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
+        FilterAndHookFunction(
+            function_search_string="dxvk::vk::Presenter::presentImage{ }d3d11.dll"),
+        FilterAndHookFunction(function_search_string="Render{ }triangle.exe"),
+        Capture(user_space_instrumentation=False),
+        CheckTimers(track_name_filter="dxvk-submit"),
+        VerifyScopeTypeAndHitCount(scope_name="dxvk::vk::Presenter::presentImage",
+                                   scope_type="D",
+                                   min_hits=1000,
+                                   max_hits=15000),
+        VerifyScopeTypeAndHitCount(scope_name="Render", scope_type="D", min_hits=0, max_hits=0),
+        VerifyCaptureLogContains(expected_content=[
+            "Uprobes likely failed to instrument some functions:",
+            "Function \"Render()\" belonging to module \"/mnt/developer/d3d11_triangle_orbit_api/triangle.exe\" is not (always) loaded into a file mapping."
+        ])
+    ]
+    suite = E2ETestSuite(test_name="Uprobes on Wine", test_cases=test_cases)
+    suite.execute()
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/contrib/automation_tests/orbit_uprobes_wine.py
+++ b/contrib/automation_tests/orbit_uprobes_wine.py
@@ -45,8 +45,8 @@ def main(argv):
         CheckTimers(track_name_filter="dxvk-submit"),
         VerifyScopeTypeAndHitCount(scope_name="dxvk::vk::Presenter::presentImage",
                                    scope_type="D",
-                                   min_hits=1000,
-                                   max_hits=15000),
+                                   min_hits=700,
+                                   max_hits=70000),
         VerifyScopeTypeAndHitCount(scope_name="Render", scope_type="D", min_hits=0, max_hits=0),
         VerifyCaptureLogContains(expected_content=[
             "Uprobes likely failed to instrument some functions:",

--- a/contrib/automation_tests/orbit_user_space_instrumentation_silenus.py
+++ b/contrib/automation_tests/orbit_user_space_instrumentation_silenus.py
@@ -39,8 +39,8 @@ def main(argv):
         CheckTimers(track_name_filter="triangle.exe", require_all=False),
         VerifyScopeTypeAndHitCount(scope_name="Render",
                                    scope_type="D",
-                                   min_hits=1000,
-                                   max_hits=15000),
+                                   min_hits=700,
+                                   max_hits=70000),
     ]
     suite = E2ETestSuite(test_name="User Space Instrumentation on Silenus", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/test_cases/capture_log.py
+++ b/contrib/automation_tests/test_cases/capture_log.py
@@ -1,0 +1,32 @@
+"""
+Copyright (c) 2022 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+import logging
+from typing import Iterable
+
+from core.orbit_e2e import E2ETestCase
+
+
+class VerifyCaptureLogContains(E2ETestCase):
+    """
+    Verify that all the listed strings appear in the Capture Log.
+    """
+
+    def _execute(self, expected_content: str or Iterable[str]):
+        if isinstance(expected_content, str):
+            expected_content = [expected_content]
+
+        capture_log_button = self.find_control('CheckBox', 'CaptureLogButton')
+        if not capture_log_button.get_toggle_state():
+            logging.info("Showing the Capture Log")
+            capture_log_button.click_input()
+
+        capture_log_text_edit = self.find_control('Edit', 'CaptureLogTextEdit')
+        capture_log_content = capture_log_text_edit.window_text()
+
+        for expected_string in expected_content:
+            logging.info(f"Looking for '{expected_string}' in Capture Log")
+            self.expect_true(expected_string in capture_log_content,
+                             f"'{expected_string}' is in Capture Log")

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -552,6 +552,7 @@ void OrbitMainWindow::SetupStatusBarLogButton() {
   }();
 
   capture_log_button_ = new QPushButton("Capture Log", statusBar());  // NOLINT
+  capture_log_button_->setAccessibleName("CaptureLogButton");
   capture_log_button_->setEnabled(false);
   capture_log_button_->setCheckable(true);
   capture_log_button_->setIcon(icon);

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -362,6 +362,9 @@ QPushButton:disabled {
          </property>
          <item>
           <widget class="QTextEdit" name="captureLogTextEdit">
+           <property name="accessibleName">
+            <string>CaptureLogTextEdit</string>
+           </property>
            <property name="tabStopDistance">
             <double>100.000000000000000</double>
            </property>


### PR DESCRIPTION
This test verifies uprobes on `triangle.exe` running on Wine. It instruments two
functions, one from a Wine PE that has file alignment compatible with `mmap`'s
file mappings, and one from `triangle.exe`, which doesn't have file alignment
compatible with `mmap`'s file mappings.
We expect the first function to be recorded and the second one to have no hits,
but with a corresponding warning showing up in the Capture Log.

Bug: http://b/232072696

Test: Ran locally.