### PR TITLE
Test the new auto frame track setting in E2E tests

### DIFF
--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -8,7 +8,8 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture, FilterTracks, CheckTimers, VerifyTracksExist
+from test_cases.capture_window import Capture, FilterTracks, CheckTimers, SetEnableAutoFrameTrack, VerifyTracksExist
+from test_cases.main_window import EndSession
 from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.live_tab import AddFrameTrack
 """Create a frame track in Orbit using pywinauto.
@@ -34,12 +35,15 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        # Setting enable auto frame track to false to only have the created Frame Track.
+        SetEnableAutoFrameTrack(enable_auto_frame_track=False),
+        # Ending and opening a new session. The auto frame track won't appear.
+        EndSession(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         AddFrameTrack(function_name="DrawFrame"),
-        # TODO(b/239148938): After allowing users to set auto-frame-track to false:
-        #  Instead of allowing duplicates, set auto-frame track to false while capturing.
-        VerifyTracksExist(track_names="Frame track*", allow_duplicates=True),
+        VerifyTracksExist(track_names="Frame track*"),
         CheckTimers(track_name_filter='Frame track*')  # Verify the frame track has timers
     ]
     suite = E2ETestSuite(test_name="Add Frame Track", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -8,7 +8,8 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture, CheckTimers, ExpandTrack
+from test_cases.capture_window import Capture, CheckTimers, ExpandTrack, SetEnableAutoFrameTrack
+from test_cases.main_window import EndSession
 from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument a single function in Orbit using pywinauto.
@@ -33,14 +34,17 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
         WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        # Setting enable auto frame track to false, so there is no hooked functions.
+        SetEnableAutoFrameTrack(enable_auto_frame_track=False),
+        # Ending and opening a new session. New session won't have default frame track neither hooked function.
+        EndSession(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         Capture(),
         CheckTimers(track_name_filter='Scheduler'),
         ExpandTrack(expected_name="gfx"),
         CheckTimers(track_name_filter='gfx_submissions', recursive=True),
         CheckTimers(track_name_filter="All Threads", expect_exists=False),
-        # TODO(b/239148938): After allowing users to set auto-frame-track to false:
-        #  Set auto-frame track to false while capturing and don't expect timers in hello_ggp.
-        CheckTimers(track_name_filter="hello_ggp_stand"),
+        CheckTimers(track_name_filter="hello_ggp_stand", expect_exists=False),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         VerifyScopeTypeAndHitCount(scope_name='DrawFrame',

--- a/contrib/automation_tests/orbit_track_type_visibility.py
+++ b/contrib/automation_tests/orbit_track_type_visibility.py
@@ -8,7 +8,8 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture, VerifyTracksExist, ToggleTrackTypeVisibility, VerifyTracksDoNotExist
+from test_cases.capture_window import Capture, SetEnableAutoFrameTrack, VerifyTracksExist, ToggleTrackTypeVisibility, VerifyTracksDoNotExist
+from test_cases.main_window import EndSession
 """Toggle track type visibility in Orbit using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -32,6 +33,11 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
+        # Setting enable auto frame track to true.
+        SetEnableAutoFrameTrack(enable_auto_frame_track=True),
+        # Ending and opening a new session. The auto frame track will appear.
+        EndSession(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         Capture(),
         ToggleTrackTypeVisibility(track_type="Scheduler"),
         VerifyTracksDoNotExist(track_names="Scheduler"),

--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -7,13 +7,19 @@ found in the LICENSE file.
 from absl import app
 
 from core.orbit_e2e import E2ETestSuite
-from test_cases.capture_window import SelectTrack, DeselectTrack, MoveTrack, FilterTracks, VerifyTracksExist, Capture
+from test_cases.capture_window import SelectTrack, DeselectTrack, MoveTrack, FilterTracks, SetEnableAutoFrameTrack, VerifyTracksExist, Capture
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.main_window import EndSession
 
 
 def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
+        FilterAndSelectFirstProcess(process_filter="hello_ggp"),
+        # Setting enable auto frame track to true.
+        SetEnableAutoFrameTrack(enable_auto_frame_track=True),
+        # Ending and opening a new session. The auto frame track will appear.
+        EndSession(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
         Capture(),
         VerifyTracksExist(

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -29,7 +29,9 @@ class CaptureWindowE2ETestCaseBase(E2ETestCase):
 
     def execute(self, suite: E2ETestSuite):
         self._time_graph = self.find_control('Image', name='TimeGraph', parent=suite.top_window())
-        self._track_container = self.find_control('Pane', name='TrackContainer', parent=self._time_graph)
+        self._track_container = self.find_control('Pane',
+                                                  name='TrackContainer',
+                                                  parent=self._time_graph)
         super().execute(suite=suite)
 
     def _find_tracks(self, name_filter: str = None, recursive: bool = False):
@@ -312,6 +314,17 @@ class CaptureE2ETestCaseBase(E2ETestCase):
         logging.info('Showing capture window')
         self.find_control("TabItem", "Capture").click_input()
 
+    def _show_capture_options_dialog(self):
+        logging.info('Opening "Capture Options" dialog')
+        capture_tab = self.find_control('Group', 'CaptureTab')
+        capture_options_button = self.find_control('Button', 'Capture Options', parent=capture_tab)
+        capture_options_button.click_input()
+
+    def _close_capture_options_dialog(self):
+        logging.info('Saving "Capture Options"')
+        self.find_control('Button', 'OK',
+                          parent=self.find_control('Window', 'Capture Options')).click_input()
+
     def _set_collect_thread_states_capture_option(self, collect_thread_states: bool,
                                                   capture_options_dialog):
         collect_thread_states_checkbox = self.find_control('CheckBox',
@@ -320,6 +333,15 @@ class CaptureE2ETestCaseBase(E2ETestCase):
         if collect_thread_states_checkbox.get_toggle_state() != collect_thread_states:
             logging.info('Toggling "Collect thread states" checkbox')
             collect_thread_states_checkbox.click_input()
+
+    def _set_enable_auto_frame_track_capture_option(self, enable_auto_frame_track: bool,
+                                                    capture_options_dialog):
+        enable_auto_frame_track_checkbox = self.find_control('CheckBox',
+                                                             'AutoFrameTrackCheckBox',
+                                                             parent=capture_options_dialog)
+        if enable_auto_frame_track_checkbox.get_toggle_state() != enable_auto_frame_track:
+            logging.info('Toggling "Auto Frame Track" checkbox')
+            enable_auto_frame_track_checkbox.click_input()
 
     def _set_collect_system_memory_usage_capture_option(self, collect_system_memory_usage,
                                                         capture_options_dialog):
@@ -438,7 +460,8 @@ class CaptureE2ETestCaseBase(E2ETestCase):
     def _verify_existence_of_tracks(self):
         logging.info("Verifying existence of at least one track...")
         track_container = self.find_control('Pane', name='TrackContainer')
-        self.expect_true(len(track_container.children()), 'Track container exists and has at least one child')
+        self.expect_true(len(track_container.children()),
+                         'Track container exists and has at least one child')
 
     def _verify_capture(self):
         self._verify_existence_of_timeline()
@@ -640,6 +663,16 @@ class SelectAllCallstacksFromTrack(CaptureWindowE2ETestCaseBase):
             self.find_control('TabItem', 'Bottom-Up (selection)').is_enabled(),
             "'Bottom-Up (selection)' tab is enabled")
         logging.info("Verified that '(selection)' tabs are enabled")
+
+
+class SetEnableAutoFrameTrack(CaptureE2ETestCaseBase):
+
+    def _execute(self, enable_auto_frame_track: bool):
+        self._show_capture_options_dialog()
+        capture_options_dialog = self.find_control('Window', 'Capture Options')
+        self._set_enable_auto_frame_track_capture_option(enable_auto_frame_track,
+                                                         capture_options_dialog)
+        self._close_capture_options_dialog()
 
 
 class SetAndCheckMemorySamplingPeriod(E2ETestCase):

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -666,6 +666,11 @@ class SelectAllCallstacksFromTrack(CaptureWindowE2ETestCaseBase):
 
 
 class SetEnableAutoFrameTrack(CaptureE2ETestCaseBase):
+    """
+    Set the auto frame track setting option. This is a public method and not a parameter in Capture()
+    because since the already added FrameTrack won't be removed from the current session, the E2E
+    tests will need to end and start a new session before taking the capture.
+    """
 
     def _execute(self, enable_auto_frame_track: bool):
         self._show_capture_options_dialog()


### PR DESCRIPTION
In this PR we are modifying 4 E2E tests to test the new Auto Frame Track
user settings. Two of them are setting the setting to true, and two of
them to false. As this will change the addition of a FrameTrack in the
next session, we are ending the session and starting another one.

Basically I created a new class but most of the used functions were
written in a shared utility class. There is a TODO here, since I didn't
refactor SetAndCheckMemorySamplingPeriod to use these shared methods,
but this will be made in a following PR.

This PR won't be merged before
https://github.com/google/orbit/pull/4001.

Bug: http://b/239148938.

Test: Manually run E2E tests. Created a signed build and run E2E test
for https://github.com/google/orbit/pull/3998 (in progress).