### PR TITLE
Integrate ETW frame tracks into Mizar

### DIFF
--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -122,7 +122,7 @@ class MockPairedData {
   }
 
   [[nodiscard]] std::vector<uint64_t> ActiveInvocationTimes(
-      const absl::flat_hash_set<TID>& /*tids*/, orbit_client_data::ScopeId /*frame_track_scope_id*/,
+      const absl::flat_hash_set<TID>& /*tids*/, FrameTrackId /*frame_track_scope_id*/,
       uint64_t /*min_relative_timestamp_ns*/, uint64_t /*max_relative_timestamp_ns*/) const {
     return frame_track_active_times_;
   };
@@ -168,9 +168,11 @@ TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
       std::move(full), std::move(empty), {kSfidToName});
   const SamplingWithFrameTrackComparisonReport report = bac.MakeSamplingWithFrameTrackReport(
       MakeBaseline<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
-          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, 0, 1, ScopeId(1)),
+          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, 0, 1,
+          FrameTrackId(ScopeId(1))),
       MakeComparison<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
-          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, 0, 1, ScopeId(1)));
+          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, 0, 1,
+          FrameTrackId(ScopeId(1))));
 
   EXPECT_EQ(report.GetBaselineSamplingCounts()->GetTotalCallstacks(), kCallstacks.size());
 

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(MizarData STATIC)
 
 target_sources(MizarData PUBLIC
          include/MizarData/BaselineAndComparison.h
+         include/MizarData/FrameTrack.h
+         include/MizarData/FrameTrackManager.h
          include/MizarData/MizarData.h
          include/MizarData/MizarDataProvider.h
          include/MizarData/MizarPairedData.h

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -150,9 +150,9 @@ const std::vector<FrameStartNs> kStarts = {FrameStartNs(kCaptureStart),
 
 class MockFrameTrackManager {
  public:
-  static inline const MockMizarData* passed_data{};
+  static inline const MockMizarData* passed_data_{};
 
-  explicit MockFrameTrackManager(const MockMizarData* data) { passed_data = data; }
+  explicit MockFrameTrackManager(const MockMizarData* data) { passed_data_ = data; }
 
   [[nodiscard]] std::vector<FrameStartNs> GetFrameStarts(FrameTrackId, FrameStartNs,
                                                          FrameStartNs) const {
@@ -209,7 +209,7 @@ TEST_F(MizarPairedDataTest, FrameTrackManagerIsProperlyInitialized) {
   MizarPairedDataTmpl<MockMizarData, MockFrameTrackManager> mizar_paired_data(std::move(data_),
                                                                               kAddressToId);
 
-  EXPECT_EQ(&MockFrameTrackManager::passed_data->GetCaptureData(), capture_data_ptr);
+  EXPECT_EQ(&MockFrameTrackManager::passed_data_->GetCaptureData(), capture_data_ptr);
 }
 
 TEST_F(MizarPairedDataTest, ForeachCallstackIsCorrect) {

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -97,7 +97,7 @@ class BaselineAndComparisonTmpl {
   [[nodiscard]] static orbit_client_data::ScopeStats MakeFrameTrackStats(
       const PairedData& data, const HalfOfSamplingWithFrameTrackReportConfig& config) {
     const std::vector<uint64_t> active_invocation_times = data.ActiveInvocationTimes(
-        config.tids, config.frame_track_scope_id, config.start_relative_ns,
+        config.tids, config.frame_track_id, config.start_relative_ns,
         NonWrappingAddition(config.start_relative_ns, config.duration_ns));
     orbit_client_data::ScopeStats stats;
     for (const uint64_t active_invocation_time : active_invocation_times) {

--- a/src/MizarData/include/MizarData/FrameTrack.h
+++ b/src/MizarData/include/MizarData/FrameTrack.h
@@ -30,11 +30,10 @@ using FrameTrackInfo =
                                                         orbit_grpc_protos::PresentEvent::Source>>;
 
 // The function allows for more convenient calls to `std::visit`.
-// `Host` is a `Typedef` wrapping an `std::variant<First, Second>`.
-template <typename First, typename Second, typename Host, typename ActionOnFirst,
+template <typename Tag, typename First, typename Second, typename ActionOnFirst,
           typename ActionOnSecond>
-auto Visit(ActionOnFirst&& action_on_scope_info, ActionOnSecond&& action_on_etw_source,
-           Host&& host) {
+auto visit(ActionOnFirst&& action_on_scope_info, ActionOnSecond&& action_on_etw_source,
+           const orbit_base::Typedef<Tag, std::variant<First, Second>>& host) {
   return std::visit(
       [&action_on_scope_info, &action_on_etw_source](const auto& info) {
         using InfoT = std::decay_t<decltype(info)>;
@@ -45,23 +44,7 @@ auto Visit(ActionOnFirst&& action_on_scope_info, ActionOnSecond&& action_on_etw_
           return std::invoke(std::forward<ActionOnSecond>(action_on_etw_source), info);
         }
       },
-      *std::forward<Host>(host));
-}
-
-template <typename ActionOnScopeInfo, typename ActionOnEtwSource>
-auto Visit(ActionOnScopeInfo&& action_on_scope_info, ActionOnEtwSource&& action_on_etw_source,
-           const FrameTrackInfo& info) {
-  return Visit<orbit_client_data::ScopeInfo, orbit_grpc_protos::PresentEvent::Source>(
-      std::forward<ActionOnScopeInfo>(action_on_scope_info),
-      std::forward<ActionOnEtwSource>(action_on_etw_source), info);
-}
-
-template <typename ActionOnScopeId, typename ActionOnEtwSource>
-auto Visit(ActionOnScopeId&& action_on_scope_id, ActionOnEtwSource&& action_on_etw_source,
-           const FrameTrackId& id) {
-  return Visit<orbit_client_data::ScopeId, orbit_grpc_protos::PresentEvent::Source>(
-      std::forward<ActionOnScopeId>(action_on_scope_id),
-      std::forward<ActionOnEtwSource>(action_on_etw_source), id);
+      *host);
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/FrameTrack.h
+++ b/src/MizarData/include/MizarData/FrameTrack.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_MIZAR_FRAME_TRACK_H_
+#define MIZAR_DATA_MIZAR_FRAME_TRACK_H_
+
+#include "ClientData/ScopeId.h"
+#include "ClientData/ScopeInfo.h"
+#include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/Typedef.h"
+#include "stdint.h"
+
+namespace orbit_mizar_data {
+
+struct FrameTrackIdTag {};
+// The type is used identify a frame track in Mizar. It can be either ETW or a scope.
+using FrameTrackId =
+    orbit_base::Typedef<FrameTrackIdTag, std::variant<orbit_client_data::ScopeId,
+                                                      orbit_grpc_protos::PresentEvent::Source>>;
+
+struct FrameStartNsTag {};
+// Absolute timestamp of the capture start in nanos
+using FrameStartNs = orbit_base::Typedef<FrameStartNsTag, uint64_t>;
+
+struct FrameTrackInfoTag {};
+// The class describes a frame track
+using FrameTrackInfo =
+    orbit_base::Typedef<FrameTrackInfoTag, std::variant<orbit_client_data::ScopeInfo,
+                                                        orbit_grpc_protos::PresentEvent::Source>>;
+
+// The function allows for more convenient calls to `std::visit`.
+// `Host` is a `Typedef` wrapping an `std::variant<First, Second>`.
+template <typename First, typename Second, typename Host, typename ActionOnFirst,
+          typename ActionOnSecond>
+auto Visit(ActionOnFirst&& action_on_scope_info, ActionOnSecond&& action_on_etw_source,
+           Host&& host) {
+  return std::visit(
+      [&action_on_scope_info, &action_on_etw_source](const auto& info) {
+        using InfoT = std::decay_t<decltype(info)>;
+        if constexpr (std::is_same_v<InfoT, First>) {
+          return std::invoke(action_on_scope_info, info);
+        }
+        if constexpr (std::is_same_v<InfoT, Second>) {
+          return std::invoke(action_on_etw_source, info);
+        }
+      },
+      *std::forward<Host>(host));
+}
+
+template <typename ActionOnScopeInfo, typename ActionOnEtwSource>
+auto Visit(ActionOnScopeInfo&& action_on_scope_info, ActionOnEtwSource&& action_on_etw_source,
+           const FrameTrackInfo& info) {
+  return Visit<orbit_client_data::ScopeInfo, orbit_grpc_protos::PresentEvent::Source>(
+      std::forward<ActionOnScopeInfo>(action_on_scope_info),
+      std::forward<ActionOnEtwSource>(action_on_etw_source), info);
+}
+
+template <typename ActionOnScopeId, typename ActionOnEtwSource>
+auto Visit(ActionOnScopeId&& action_on_scope_id, ActionOnEtwSource&& action_on_etw_source,
+           const FrameTrackId& id) {
+  return Visit<orbit_client_data::ScopeId, orbit_grpc_protos::PresentEvent::Source>(
+      std::forward<ActionOnScopeId>(action_on_scope_id),
+      std::forward<ActionOnEtwSource>(action_on_etw_source), id);
+}
+
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_MIZAR_FRAME_TRACK_H_

--- a/src/MizarData/include/MizarData/FrameTrack.h
+++ b/src/MizarData/include/MizarData/FrameTrack.h
@@ -39,10 +39,10 @@ auto Visit(ActionOnFirst&& action_on_scope_info, ActionOnSecond&& action_on_etw_
       [&action_on_scope_info, &action_on_etw_source](const auto& info) {
         using InfoT = std::decay_t<decltype(info)>;
         if constexpr (std::is_same_v<InfoT, First>) {
-          return std::invoke(action_on_scope_info, info);
+          return std::invoke(std::forward<ActionOnFirst>(action_on_scope_info), info);
         }
         if constexpr (std::is_same_v<InfoT, Second>) {
-          return std::invoke(action_on_etw_source, info);
+          return std::invoke(std::forward<ActionOnSecond>(action_on_etw_source), info);
         }
       },
       *std::forward<Host>(host));

--- a/src/MizarData/include/MizarData/FrameTrack.h
+++ b/src/MizarData/include/MizarData/FrameTrack.h
@@ -32,7 +32,7 @@ using FrameTrackInfo =
 // The function allows for more convenient calls to `std::visit`.
 template <typename Tag, typename First, typename Second, typename ActionOnFirst,
           typename ActionOnSecond>
-auto visit(ActionOnFirst&& action_on_scope_info, ActionOnSecond&& action_on_etw_source,
+auto Visit(ActionOnFirst&& action_on_scope_info, ActionOnSecond&& action_on_etw_source,
            const orbit_base::Typedef<Tag, std::variant<First, Second>>& host) {
   return std::visit(
       [&action_on_scope_info, &action_on_etw_source](const auto& info) {

--- a/src/MizarData/include/MizarData/FrameTrack.h
+++ b/src/MizarData/include/MizarData/FrameTrack.h
@@ -32,16 +32,16 @@ using FrameTrackInfo =
 // The function allows for more convenient calls to `std::visit`.
 template <typename Tag, typename First, typename Second, typename ActionOnFirst,
           typename ActionOnSecond>
-auto Visit(ActionOnFirst&& action_on_scope_info, ActionOnSecond&& action_on_etw_source,
+auto Visit(ActionOnFirst&& action_on_first, ActionOnSecond&& action_on_second,
            const orbit_base::Typedef<Tag, std::variant<First, Second>>& host) {
   return std::visit(
-      [&action_on_scope_info, &action_on_etw_source](const auto& info) {
-        using InfoT = std::decay_t<decltype(info)>;
-        if constexpr (std::is_same_v<InfoT, First>) {
-          return std::invoke(std::forward<ActionOnFirst>(action_on_scope_info), info);
+      [&action_on_first, &action_on_second](const auto& alternative) {
+        using Alternative = std::decay_t<decltype(alternative)>;
+        if constexpr (std::is_same_v<Alternative, First>) {
+          return std::invoke(std::forward<ActionOnFirst>(action_on_first), alternative);
         }
-        if constexpr (std::is_same_v<InfoT, Second>) {
-          return std::invoke(std::forward<ActionOnSecond>(action_on_etw_source), info);
+        if constexpr (std::is_same_v<Alternative, Second>) {
+          return std::invoke(std::forward<ActionOnSecond>(action_on_second), alternative);
         }
       },
       *host);

--- a/src/MizarData/include/MizarData/FrameTrackManager.h
+++ b/src/MizarData/include/MizarData/FrameTrackManager.h
@@ -43,7 +43,7 @@ class FrameTrackManagerTmpl {
 
   [[nodiscard]] std::vector<FrameStartNs> GetFrameStarts(FrameTrackId id, FrameStartNs min_start,
                                                          FrameStartNs max_start) const {
-    return Visit(
+    return visit(
         absl::bind_front(&FrameTrackManagerTmpl::GetScopeFrameStarts, this, min_start, max_start),
         absl::bind_front(&FrameTrackManagerTmpl::GetEtwFrameStarts, this, min_start, max_start),
         id);

--- a/src/MizarData/include/MizarData/FrameTrackManager.h
+++ b/src/MizarData/include/MizarData/FrameTrackManager.h
@@ -5,6 +5,7 @@
 #ifndef MIZAR_DATA_MIZAR_FRAME_TRACK_MANAGER_H_
 #define MIZAR_DATA_MIZAR_FRAME_TRACK_MANAGER_H_
 
+#include <absl/algorithm/container.h>
 #include <absl/functional/bind_front.h>
 
 #include "ClientData/CaptureData.h"
@@ -56,8 +57,9 @@ class FrameTrackManagerTmpl {
         GetCaptureData().GetTimersForScope(scope_id, *min_start, *max_start);
 
     std::vector<FrameStartNs> result;
-    std::transform(std::begin(timers), std::end(timers), std::back_inserter(result),
-                   [](const TimerInfo* timer) { return FrameStartNs(timer->start()); });
+    result.reserve(timers.size());
+    absl::c_transform(timers, std::back_inserter(result),
+                      [](const TimerInfo* timer) { return FrameStartNs(timer->start()); });
     return result;
   }
 

--- a/src/MizarData/include/MizarData/FrameTrackManager.h
+++ b/src/MizarData/include/MizarData/FrameTrackManager.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_MIZAR_FRAME_TRACK_MANAGER_H_
+#define MIZAR_DATA_MIZAR_FRAME_TRACK_MANAGER_H_
+
+#include <absl/functional/bind_front.h>
+
+#include "ClientData/CaptureData.h"
+#include "MizarData/FrameTrack.h"
+#include "MizarData/MizarData.h"
+#include "MizarData/MizarDataProvider.h"
+
+namespace orbit_mizar_data {
+
+template <typename Data>
+class FrameTrackManagerTmpl {
+  using ScopeId = ::orbit_client_data::ScopeId;
+  using ScopeType = ::orbit_client_data::ScopeType;
+  using PresentEvent = orbit_grpc_protos::PresentEvent;
+
+ public:
+  explicit FrameTrackManagerTmpl(const Data* data) : data_(data) {}
+
+  [[nodiscard]] absl::flat_hash_map<FrameTrackId, FrameTrackInfo> GetFrameTracks() const {
+    const std::vector<ScopeId> scope_ids = GetCaptureData().GetAllProvidedScopeIds();
+    absl::flat_hash_map<FrameTrackId, FrameTrackInfo> result;
+    for (const ScopeId scope_id : scope_ids) {
+      const orbit_client_data::ScopeInfo scope_info = GetCaptureData().GetScopeInfo(scope_id);
+      if (scope_info.GetType() == ScopeType::kDynamicallyInstrumentedFunction ||
+          scope_info.GetType() == ScopeType::kApiScope) {
+        result.try_emplace(FrameTrackId(scope_id), scope_info);
+      }
+    }
+
+    for (auto& [source, unused_events] : data_->source_to_present_events()) {
+      result.try_emplace(FrameTrackId(source), source);
+    }
+    return result;
+  }
+
+  [[nodiscard]] std::vector<FrameStartNs> GetFrameStarts(FrameTrackId id, FrameStartNs min_start,
+                                                         FrameStartNs max_start) const {
+    return Visit(
+        absl::bind_front(&FrameTrackManagerTmpl::GetScopeFrameStarts, this, min_start, max_start),
+        absl::bind_front(&FrameTrackManagerTmpl::GetEtwFrameStarts, this, min_start, max_start),
+        id);
+  }
+
+ private:
+  [[nodiscard]] std::vector<FrameStartNs> GetScopeFrameStarts(FrameStartNs min_start,
+                                                              FrameStartNs max_start,
+                                                              ScopeId scope_id) const {
+    const std::vector<const TimerInfo*> timers =
+        GetCaptureData().GetTimersForScope(scope_id, *min_start, *max_start);
+
+    std::vector<FrameStartNs> result;
+    std::transform(std::begin(timers), std::end(timers), std::back_inserter(result),
+                   [](const TimerInfo* timer) { return FrameStartNs(timer->start()); });
+    return result;
+  }
+
+  [[nodiscard]] std::vector<FrameStartNs> GetEtwFrameStarts(FrameStartNs min_start,
+                                                            FrameStartNs max_start,
+                                                            PresentEvent::Source etw_source) const {
+    const auto& source_to_present_events = data_->source_to_present_events();
+
+    const auto it = source_to_present_events.find(etw_source);
+    if (it == source_to_present_events.end()) {
+      return {};
+    }
+    std::vector<FrameStartNs> result;
+    const std::vector<PresentEvent>& events = it->second;
+    for (const PresentEvent& event : events) {
+      const FrameStartNs event_start(event.begin_timestamp_ns());
+      if (min_start <= event_start && event_start <= max_start) {
+        result.push_back(event_start);
+      }
+    }
+    return result;
+  }
+
+  const auto& GetCaptureData() const { return data_->GetCaptureData(); }
+
+  const Data* data_;
+};
+
+using FrameTrackManager = FrameTrackManagerTmpl<MizarDataProvider>;
+
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_MIZAR_FRAME_TRACK_MANAGER_H_

--- a/src/MizarData/include/MizarData/FrameTrackManager.h
+++ b/src/MizarData/include/MizarData/FrameTrackManager.h
@@ -43,7 +43,7 @@ class FrameTrackManagerTmpl {
 
   [[nodiscard]] std::vector<FrameStartNs> GetFrameStarts(FrameTrackId id, FrameStartNs min_start,
                                                          FrameStartNs max_start) const {
-    return visit(
+    return Visit(
         absl::bind_front(&FrameTrackManagerTmpl::GetScopeFrameStarts, this, min_start, max_start),
         absl::bind_front(&FrameTrackManagerTmpl::GetEtwFrameStarts, this, min_start, max_start),
         id);

--- a/src/MizarData/include/MizarData/MizarDataProvider.h
+++ b/src/MizarData/include/MizarData/MizarDataProvider.h
@@ -28,6 +28,10 @@ class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
 
   virtual ~MizarDataProvider() = default;
 
+  [[nodiscard]] virtual const absl::flat_hash_map<orbit_grpc_protos::PresentEvent::Source,
+                                                  std::vector<orbit_grpc_protos::PresentEvent>>&
+  source_to_present_events() const = 0;
+
   [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(
       uint64_t address) const = 0;
   [[nodiscard]] virtual absl::flat_hash_map<uint64_t, std::string> AllAddressToName() const = 0;

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -17,6 +17,7 @@
 #include "MizarBase/BaselineOrComparison.h"
 #include "MizarBase/SampledFunctionId.h"
 #include "MizarBase/ThreadId.h"
+#include "MizarData/FrameTrack.h"
 #include "MizarStatistics/ActiveFunctionTimePerFrameComparator.h"
 #include "OrbitBase/Logging.h"
 
@@ -31,21 +32,21 @@ struct CorrectedComparisonResult : public orbit_mizar_statistics::ComparisonResu
 // comparison.
 class HalfOfSamplingWithFrameTrackReportConfig {
   using TID = ::orbit_mizar_base::TID;
-  using ScopeId = ::orbit_client_data::ScopeId;
+  using FrameTrackId = ::orbit_mizar_data::FrameTrackId;
 
  public:
   explicit HalfOfSamplingWithFrameTrackReportConfig(absl::flat_hash_set<TID> tids,
                                                     uint64_t start_ns, uint64_t duration_ns,
-                                                    ScopeId frame_track_scope_id)
+                                                    FrameTrackId frame_track_id)
       : tids(std::move(tids)),
         start_relative_ns(start_ns),
         duration_ns(duration_ns),
-        frame_track_scope_id(frame_track_scope_id) {}
+        frame_track_id(frame_track_id) {}
 
   absl::flat_hash_set<TID> tids{};
   uint64_t start_relative_ns{};  // nanoseconds elapsed since capture start
   uint64_t duration_ns{};
-  ScopeId frame_track_scope_id{};
+  FrameTrackId frame_track_id{};
 };
 
 struct InclusiveAndExclusive {

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
@@ -53,7 +53,7 @@ orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig
 SamplingWithFrameTrackInputWidgetBase::MakeConfig() const {
   return orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig{
       selected_tids_, start_relative_time_ns_, std::numeric_limits<uint64_t>::max(),
-      frame_track_scope_id_};
+      frame_track_id_};
 }
 
 void SamplingWithFrameTrackInputWidgetBase::OnThreadSelectionChanged() {
@@ -65,7 +65,7 @@ void SamplingWithFrameTrackInputWidgetBase::OnThreadSelectionChanged() {
 }
 
 void SamplingWithFrameTrackInputWidgetBase::OnFrameTrackSelectionChanged(int index) {
-  frame_track_scope_id_ = GetFrameTrackList()->itemData(index, kScopeIdRole).value<ScopeId>();
+  frame_track_id_ = GetFrameTrackList()->itemData(index, kFrameTrackIdRole).value<FrameTrackId>();
 }
 
 void SamplingWithFrameTrackInputWidgetBase::OnStartMsChanged(const QString& time_ms) {

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -87,7 +87,8 @@ constexpr std::array<FrameTrackId, kFrameTracksCount> kScopeIdsInExpectedOrder =
 const std::vector<FrameTrackInfo> kFrameTrackInfos = [] {
   std::vector<FrameTrackInfo> result;
   for (size_t i = 0; i < kScopeFrameTracksCount; ++i) {
-    orbit_client_data::ScopeInfo info(std::string(kFrameTrackNames[i]), kScopeInfoTypes[i]);
+    const std::string_view name_view = kFrameTrackNames[i];
+    orbit_client_data::ScopeInfo info(std::string(name_view), kScopeInfoTypes[i]);
     result.emplace_back(info);
   }
   result.emplace_back(PresentEvent::kD3d9);

--- a/src/MizarWidgets/SamplingWithFrameTrackReportConfigValidatorTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackReportConfigValidatorTest.cpp
@@ -8,16 +8,17 @@
 
 #include <QString>
 
-#include "ClientData/ScopeId.h"
 #include "MizarBase/BaselineOrComparison.h"
 #include "MizarBase/Titles.h"
+#include "MizarData/FrameTrack.h"
 #include "MizarWidgets/SamplingWithFrameTrackReportConfigValidator.h"
 #include "TestUtils/TestUtils.h"
 
-using ::orbit_client_data::ScopeId;
 using ::orbit_mizar_base::Baseline;
 using ::orbit_mizar_base::Comparison;
 using ::orbit_mizar_base::TID;
+using ::orbit_mizar_data::FrameTrackId;
+using ::orbit_mizar_data::FrameTrackInfo;
 using ::orbit_test_utils::HasError;
 using ::orbit_test_utils::HasNoError;
 using ::testing::_;
@@ -61,52 +62,54 @@ TEST(SamplingWithFrameTrackReportConfigValidator, IsCorrect) {
   const SamplingWithFrameTrackReportConfigValidatorTmpl<MockBaselineAndComparison, MockPairedData>
       validator{};
 
+  constexpr FrameTrackId kId(orbit_client_data::ScopeId(0));
+
   EXPECT_THAT(validator.Validate(&bac,
                                  orbit_mizar_base::MakeBaseline<HalfConfig>(
                                      absl::flat_hash_set<TID>{TID(1)}, /*start_ns=*/0,
-                                     /*duration_ns=*/0, ScopeId(0)),
+                                     /*duration_ns=*/0, kId),
                                  orbit_mizar_base::MakeComparison<HalfConfig>(
                                      absl::flat_hash_set<TID>{},
-                                     /*start_ns=*/0, /*duration_ns=*/0, ScopeId(0))),
+                                     /*start_ns=*/0, /*duration_ns=*/0, kId)),
               HasError("Comparison: No threads selected"));
 
-  EXPECT_THAT(validator.Validate(&bac,
-                                 orbit_mizar_base::MakeBaseline<HalfConfig>(
-                                     absl::flat_hash_set<TID>{}, /*start_ns=*/0,
-                                     /*duration_ns=*/0, ScopeId(0)),
-                                 orbit_mizar_base::MakeComparison<HalfConfig>(
-                                     absl::flat_hash_set<TID>{TID(1)},
-                                     /*start_ns=*/0, /*duration_ns=*/0, ScopeId(0))),
-              HasError("Baseline: No threads selected"));
+  EXPECT_THAT(
+      validator.Validate(
+          &bac,
+          orbit_mizar_base::MakeBaseline<HalfConfig>(absl::flat_hash_set<TID>{}, /*start_ns=*/0,
+                                                     /*duration_ns=*/0, kId),
+          orbit_mizar_base::MakeComparison<HalfConfig>(absl::flat_hash_set<TID>{TID(1)},
+                                                       /*start_ns=*/0, /*duration_ns=*/0, kId)),
+      HasError("Baseline: No threads selected"));
 
-  EXPECT_THAT(validator.Validate(&bac,
-                                 orbit_mizar_base::MakeBaseline<HalfConfig>(
-                                     absl::flat_hash_set<TID>{TID(1)},
-                                     /*start_ns=*/kBaselineCaptureDuration + 1,
-                                     /*duration_ns=*/0, ScopeId(0)),
-                                 orbit_mizar_base::MakeComparison<HalfConfig>(
-                                     absl::flat_hash_set<TID>{TID(1)},
-                                     /*start_ns=*/0, /*duration_ns=*/0, ScopeId(0))),
-              HasError("Baseline: Start > capture duration"));
+  EXPECT_THAT(
+      validator.Validate(
+          &bac,
+          orbit_mizar_base::MakeBaseline<HalfConfig>(absl::flat_hash_set<TID>{TID(1)},
+                                                     /*start_ns=*/kBaselineCaptureDuration + 1,
+                                                     /*duration_ns=*/0, kId),
+          orbit_mizar_base::MakeComparison<HalfConfig>(absl::flat_hash_set<TID>{TID(1)},
+                                                       /*start_ns=*/0, /*duration_ns=*/0, kId)),
+      HasError("Baseline: Start > capture duration"));
 
   EXPECT_THAT(validator.Validate(&bac,
                                  orbit_mizar_base::MakeBaseline<HalfConfig>(
                                      absl::flat_hash_set<TID>{TID(1)}, /*start_ns=*/0,
-                                     /*duration_ns=*/0, ScopeId(0)),
+                                     /*duration_ns=*/0, kId),
                                  orbit_mizar_base::MakeComparison<HalfConfig>(
                                      absl::flat_hash_set<TID>{TID(1)},
                                      /*start_ns=*/kComparisonCaptureDuration + 1,
-                                     /*duration_ns=*/0, ScopeId(0))),
+                                     /*duration_ns=*/0, kId)),
               HasError("Comparison: Start > capture duration"));
 
   EXPECT_THAT(validator.Validate(&bac,
                                  orbit_mizar_base::MakeBaseline<HalfConfig>(
                                      absl::flat_hash_set<TID>{TID(1)}, /*start_ns=*/0,
-                                     /*duration_ns=*/kBaselineCaptureDuration - 1, ScopeId(0)),
+                                     /*duration_ns=*/kBaselineCaptureDuration - 1, kId),
                                  orbit_mizar_base::MakeComparison<HalfConfig>(
                                      absl::flat_hash_set<TID>{TID(1)},
                                      /*start_ns=*/kComparisonCaptureDuration - 1,
-                                     /*duration_ns=*/0, ScopeId(0))),
+                                     /*duration_ns=*/0, kId)),
               HasNoError());
 }
 

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -7,6 +7,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <absl/functional/bind_front.h>
 #include <absl/strings/str_format.h>
 #include <stdint.h>
 
@@ -20,12 +21,15 @@
 #include <limits>
 #include <memory>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
-#include "ClientData/ScopeId.h"
 #include "ClientData/ScopeInfo.h"
+#include "GrpcProtos/capture.pb.h"
+#include "MizarData/FrameTrack.h"
 #include "MizarData/MizarPairedData.h"
 #include "MizarData/SamplingWithFrameTrackComparisonReport.h"
+#include "OrbitBase/Logging.h"
 #include "OrbitBase/Sort.h"
 
 namespace Ui {
@@ -33,14 +37,14 @@ class SamplingWithFrameTrackInputWidget;
 }
 
 Q_DECLARE_METATYPE(::orbit_mizar_base::TID);
-Q_DECLARE_METATYPE(::orbit_client_data::ScopeId);
+Q_DECLARE_METATYPE(::orbit_mizar_data::FrameTrackId);
 
 namespace orbit_mizar_widgets {
 
 class SamplingWithFrameTrackInputWidgetBase : public QWidget {
   Q_OBJECT
   using TID = ::orbit_mizar_base::TID;
-  using ScopeId = ::orbit_client_data::ScopeId;
+  using FrameTrackId = ::orbit_mizar_data::FrameTrackId;
 
  public:
   ~SamplingWithFrameTrackInputWidgetBase() override;
@@ -56,7 +60,7 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
   std::unique_ptr<Ui::SamplingWithFrameTrackInputWidget> ui_;
 
  protected:
-  enum UserRoles { kTidRole = Qt::UserRole + 1, kScopeIdRole };
+  enum UserRoles { kTidRole = Qt::UserRole + 1, kFrameTrackIdRole };
 
   explicit SamplingWithFrameTrackInputWidgetBase(QWidget* parent = nullptr);
 
@@ -67,7 +71,7 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
 
  private:
   absl::flat_hash_set<TID> selected_tids_;
-  ScopeId frame_track_scope_id_{0};
+  FrameTrackId frame_track_id_{};
 
   // std::numeric_limits<uint64_t>::max() corresponds to malformed input
   uint64_t start_relative_time_ns_ = 0;
@@ -76,7 +80,10 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
 template <typename PairedData>
 class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInputWidgetBase {
   using TID = ::orbit_mizar_base::TID;
-  using ScopeId = ::orbit_client_data::ScopeId;
+  using FrameTrackId = ::orbit_mizar_data::FrameTrackId;
+  using FrameTrackInfo = ::orbit_mizar_data::FrameTrackInfo;
+  using PresentEvent = ::orbit_grpc_protos::PresentEvent;
+  using ScopeInfo = ::orbit_client_data::ScopeInfo;
 
  public:
   SamplingWithFrameTrackInputWidgetTmpl() = delete;
@@ -113,18 +120,29 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
     }
   }
 
-  void InitFrameTrackList(const PairedData& data) {
-    const absl::flat_hash_map<ScopeId, orbit_client_data::ScopeInfo> scope_id_to_info =
-        data.GetFrameTracks();
-    std::vector<std::pair<ScopeId, orbit_client_data::ScopeInfo>> scope_id_to_info_sorted(
-        std::begin(scope_id_to_info), std::end(scope_id_to_info));
-    orbit_base::sort(std::begin(scope_id_to_info_sorted), std::end(scope_id_to_info_sorted),
-                     [](const auto& a) { return a.second.GetName(); });
+  [[nodiscard]] std::string MakeDisplayedName(const FrameTrackInfo& info) const {
+    return Visit(&SamplingWithFrameTrackInputWidgetTmpl::MakeFrameTrackString,
+                 &SamplingWithFrameTrackInputWidgetTmpl::PresentEventSourceName, info);
+  }
 
-    for (size_t i = 0; i < scope_id_to_info_sorted.size(); ++i) {
-      const auto& [scope_id, scope_info] = scope_id_to_info_sorted[i];
-      GetFrameTrackList()->insertItem(i, MakeFrameTrackString(scope_info));
-      GetFrameTrackList()->setItemData(i, QVariant::fromValue(scope_id), kScopeIdRole);
+  void InitFrameTrackList(const PairedData& data) {
+    absl::flat_hash_map<FrameTrackId, FrameTrackInfo> id_to_infos = data.GetFrameTracks();
+    std::vector<std::pair<FrameTrackId, std::string>> id_to_displayed_name;
+    std::transform(std::begin(id_to_infos), std::end(id_to_infos),
+                   std::back_inserter(id_to_displayed_name), [this](const auto& id_to_info) {
+                     const auto [id, info] = id_to_info;
+                     const std::string displayed_name = MakeDisplayedName(info);
+
+                     return std::make_pair(id, displayed_name);
+                   });
+
+    orbit_base::sort(std::begin(id_to_displayed_name), std::end(id_to_displayed_name),
+                     &std::pair<FrameTrackId, std::string>::second);
+
+    for (size_t i = 0; i < id_to_displayed_name.size(); ++i) {
+      const auto& [id, displayed_name] = id_to_displayed_name[i];
+      GetFrameTrackList()->insertItem(i, QString::fromStdString(displayed_name));
+      GetFrameTrackList()->setItemData(i, QVariant::fromValue(id), kFrameTrackIdRole);
     }
     OnFrameTrackSelectionChanged(0);
   }
@@ -134,13 +152,24 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
     GetStartMs()->setText("0");
   }
 
-  [[nodiscard]] static QString MakeFrameTrackString(
+  [[nodiscard]] static std::string MakeFrameTrackString(
       const orbit_client_data::ScopeInfo& scope_info) {
     const std::string_view type_string =
         scope_info.GetType() == orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction
-            ? " D"
-            : "MS";
-    return QString::fromStdString(absl::StrFormat("[%s] %s", type_string, scope_info.GetName()));
+            ? "  D"
+            : " MS";
+    return absl::StrFormat("[%s] %s", type_string, scope_info.GetName());
+  }
+
+  [[nodiscard]] static std::string PresentEventSourceName(PresentEvent::Source source) {
+    switch (source) {
+      case PresentEvent::kD3d9:
+        return "[ETW] D3d9";
+      case PresentEvent::kDxgi:
+        return "[ETW] Dxgi";
+      default:
+        ORBIT_UNREACHABLE();
+    }
   }
 };
 

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -121,7 +121,7 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
   }
 
   [[nodiscard]] std::string MakeDisplayedName(const FrameTrackInfo& info) const {
-    return Visit(&SamplingWithFrameTrackInputWidgetTmpl::MakeFrameTrackString,
+    return visit(&SamplingWithFrameTrackInputWidgetTmpl::MakeFrameTrackString,
                  &SamplingWithFrameTrackInputWidgetTmpl::PresentEventSourceName, info);
   }
 

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -121,7 +121,7 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
   }
 
   [[nodiscard]] std::string MakeDisplayedName(const FrameTrackInfo& info) const {
-    return visit(&SamplingWithFrameTrackInputWidgetTmpl::MakeFrameTrackString,
+    return Visit(&SamplingWithFrameTrackInputWidgetTmpl::MakeFrameTrackString,
                  &SamplingWithFrameTrackInputWidgetTmpl::PresentEventSourceName, info);
   }
 


### PR DESCRIPTION
This introduces (in `FrameTrack.h`) types allowing for the
uniforme handling of `TimerInfo`s and `PresentEvents`s.

The part responsible for trame track data handling is
abstracted out from `MizarPairedData` to `FrameTrackManager`.

ETW frame tracks are now shown on the GUI and can be selected
in the same way D and MS can.

Tets: Manua, Unit
Bug: http://b/239937976