### PR TITLE
Make the default ctor of `Typedef` initialise the primitives

### DIFF
--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -50,6 +50,11 @@ using MyType = Typedef<MyTypeTag, T>;
 template <typename T>
 using MyConstType = Typedef<MyTypeTag, const T>;
 
+TEST(TypedefTest, DefaultConstructorInitializesPrimitives) {
+  MyType<int> wrapped;
+  EXPECT_EQ(*wrapped, 0);
+}
+
 TEST(TypedefTest, CanInstantiate) {
   const int kConstInt = 1;
   MyType<int> wrapper_of_const(kConstInt);

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -68,7 +68,7 @@ class Typedef {
   constexpr explicit Typedef(std::in_place_t, Args&&... args)
       : value_(T(std::forward<T>(args)...)) {}
 
-  constexpr Typedef() = default;
+  constexpr Typedef() : value_{} {}
 
   constexpr Typedef(const Typedef& other) = default;
   constexpr Typedef(Typedef&& other) = default;


### PR DESCRIPTION
Test: Unit, Compile
Bug: http://b/240116670