### PR TITLE
Add `ggp crash-report download-symbols` to ggp client

### DIFF
--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -75,7 +75,7 @@ class ClientImpl : public Client, public QObject {
   Future<ErrorMessageOr<Instance>> DescribeInstanceAsync(const QString& instance_id) override;
   Future<ErrorMessageOr<Account>> GetDefaultAccountAsync() override;
   Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>> GetSymbolDownloadInfoAsync(
-      const std::vector<std::pair<std::string, std::string>>& module_names_and_build_ids) override;
+      const std::vector<SymbolDownloadQuery>& symbol_download_queries) override;
 
  private:
   const QString ggp_program_;
@@ -213,14 +213,14 @@ Future<ErrorMessageOr<Account>> ClientImpl::GetDefaultAccountAsync() {
 }
 
 Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>> ClientImpl::GetSymbolDownloadInfoAsync(
-    const std::vector<std::pair<std::string, std::string>>& module_names_and_build_ids) {
+    const std::vector<SymbolDownloadQuery>& symbol_download_queries) {
   QStringList arguments{"crash-report", "download-symbols", "-s", "--show-url"};
 
-  for (const auto& module_name_and_build_id : module_names_and_build_ids) {
-    arguments << "--module"
-              << QString("%1/%2")
-                     .arg(QString::fromStdString(module_name_and_build_id.second))
-                     .arg(QString::fromStdString(module_name_and_build_id.first));
+  for (const auto& query : symbol_download_queries) {
+    arguments.push_back("--module");
+    arguments.push_back(QString("%1/%2")
+                            .arg(QString::fromStdString(query.build_id))
+                            .arg(QString::fromStdString(query.module_name)));
   }
 
   orbit_base::ImmediateExecutor executor;

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -29,6 +29,8 @@ using orbit_base::Future;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasValue;
 using SymbolDownloadQuery = orbit_ggp::Client::SymbolDownloadQuery;
+using testing::ElementsAre;
+using testing::FieldsAre;
 
 namespace {
 
@@ -501,25 +503,19 @@ TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfosAsyncWorking) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   std::vector<SymbolDownloadQuery> symbol_download_queries = {{"symbol_filename_0", "build_id_0"},
                                                               {"symbol_filename_2", "build_id_2"}};
   auto future = client.value()->GetSymbolDownloadInfoAsync(symbol_download_queries);
-  future.Then(
-      main_thread_executor_.get(),
-      [&future_is_resolved](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {
-        EXPECT_FALSE(future_is_resolved);
-        future_is_resolved = true;
-        ASSERT_THAT(symbols, HasValue());
-        EXPECT_EQ(symbols.value().size(), 1);
-        EXPECT_EQ(symbols.value()[0].file_id, "symbolFiles/build_id_0/symbol_filename_0");
-        QCoreApplication::exit();
-      });
+  future.Then(main_thread_executor_.get(),
+              [](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {
+                EXPECT_THAT(
+                    symbols,
+                    HasValue(ElementsAre(FieldsAre("symbolFiles/build_id_0/symbol_filename_0",
+                                                   "valid_url_for_symbol_0"))));
+                QCoreApplication::exit();
+              });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfoAsyncTimeout) {
@@ -528,29 +524,21 @@ TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfoAsyncTimeout) {
                              std::chrono::milliseconds{5});
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   std::vector<SymbolDownloadQuery> symbol_download_queries = {{"symbol_filename_0", "build_id_0"}};
   auto future = client.value()->GetSymbolDownloadInfoAsync(symbol_download_queries);
-  future.Then(
-      main_thread_executor_.get(),
-      [&future_is_resolved](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {
-        EXPECT_FALSE(future_is_resolved);
-        future_is_resolved = true;
-        EXPECT_THAT(symbols, HasError("OrbitMockGgpWorking crash-report download-symbols -s "
-                                      "--show-url --module build_id_0/symbol_filename_0"));
-        EXPECT_THAT(symbols, HasError("timed out after 5ms"));
-        QCoreApplication::exit();
-      });
+  future.Then(main_thread_executor_.get(),
+              [](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {
+                EXPECT_THAT(symbols,
+                            HasError("OrbitMockGgpWorking crash-report download-symbols -s "
+                                     "--show-url --module build_id_0/symbol_filename_0"));
+                EXPECT_THAT(symbols, HasError("timed out after 5ms"));
+                QCoreApplication::exit();
+              });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfoAsyncClientGetsDestroyed) {
-  bool future_is_resolved = false;
-
   Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>> future =
       Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>>{ErrorMessage{"Empty Error Message"}};
   {
@@ -561,21 +549,17 @@ TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfoAsyncClientGetsDestroyed) {
     std::vector<SymbolDownloadQuery> symbol_download_queries = {
         {"symbol_filename_0", "build_id_0"}};
     future = client.value()->GetSymbolDownloadInfoAsync(symbol_download_queries);
-    future.Then(
-        main_thread_executor_.get(),
-        [&future_is_resolved](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {
-          EXPECT_FALSE(future_is_resolved);
-          future_is_resolved = true;
-          EXPECT_THAT(symbols, HasError("OrbitMockGgpWorking crash-report download-symbols -s "
-                                        "--show-url --module build_id_0/symbol_filename_0"));
-          EXPECT_THAT(symbols, HasError("killed because the parent object was destroyed"));
-          QCoreApplication::exit();
-        });
+    future.Then(main_thread_executor_.get(),
+                [](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {
+                  EXPECT_THAT(symbols,
+                              HasError("OrbitMockGgpWorking crash-report download-symbols -s "
+                                       "--show-url --module build_id_0/symbol_filename_0"));
+                  EXPECT_THAT(symbols, HasError("killed because the parent object was destroyed"));
+                  QCoreApplication::exit();
+                });
   }
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 }  // namespace orbit_ggp

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -28,6 +28,7 @@ namespace orbit_ggp {
 using orbit_base::Future;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasValue;
+using SymbolDownloadQuery = orbit_ggp::Client::SymbolDownloadQuery;
 
 namespace {
 
@@ -502,9 +503,9 @@ TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfosAsyncWorking) {
 
   bool future_is_resolved = false;
 
-  std::vector<std::pair<std::string, std::string>> module_names_and_build_ids = {
-      {"symbol_filename_0", "build_id_0"}, {"symbol_filename_2", "build_id_2"}};
-  auto future = client.value()->GetSymbolDownloadInfoAsync(module_names_and_build_ids);
+  std::vector<SymbolDownloadQuery> symbol_download_queries = {{"symbol_filename_0", "build_id_0"},
+                                                              {"symbol_filename_2", "build_id_2"}};
+  auto future = client.value()->GetSymbolDownloadInfoAsync(symbol_download_queries);
   future.Then(
       main_thread_executor_.get(),
       [&future_is_resolved](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {
@@ -529,9 +530,8 @@ TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfoAsyncTimeout) {
 
   bool future_is_resolved = false;
 
-  std::vector<std::pair<std::string, std::string>> module_names_and_build_ids = {
-      {"symbol_filename_0", "build_id_0"}};
-  auto future = client.value()->GetSymbolDownloadInfoAsync(module_names_and_build_ids);
+  std::vector<SymbolDownloadQuery> symbol_download_queries = {{"symbol_filename_0", "build_id_0"}};
+  auto future = client.value()->GetSymbolDownloadInfoAsync(symbol_download_queries);
   future.Then(
       main_thread_executor_.get(),
       [&future_is_resolved](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {
@@ -558,9 +558,9 @@ TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfoAsyncClientGetsDestroyed) {
         CreateClient(QString::fromStdString(mock_ggp_working_.string()));
     ASSERT_THAT(client, HasValue());
 
-    std::vector<std::pair<std::string, std::string>> module_names_and_build_ids = {
+    std::vector<SymbolDownloadQuery> symbol_download_queries = {
         {"symbol_filename_0", "build_id_0"}};
-    future = client.value()->GetSymbolDownloadInfoAsync(module_names_and_build_ids);
+    future = client.value()->GetSymbolDownloadInfoAsync(symbol_download_queries);
     future.Then(
         main_thread_executor_.get(),
         [&future_is_resolved](const ErrorMessageOr<std::vector<SymbolDownloadInfo>>& symbols) {

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -66,43 +66,30 @@ TEST_F(OrbitGgpClientTest, GetInstancesAsyncWorking) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   auto future =
       client.value()->GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances, std::nullopt);
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](ErrorMessageOr<QVector<Instance>> instances) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                ASSERT_THAT(instances, HasValue());
-                EXPECT_EQ(instances.value().size(), 2);
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<QVector<Instance>>& instances) {
+    ASSERT_THAT(instances, HasValue());
+    EXPECT_EQ(instances.value().size(), 2);
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetInstancesAsyncWorkingAllReserved) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
   auto future = client.value()->GetInstancesAsync(Client::InstanceListScope::kAllReservedInstances,
                                                   std::nullopt);
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](ErrorMessageOr<QVector<Instance>> instances) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                ASSERT_THAT(instances, HasValue());
-                EXPECT_EQ(instances.value().size(), 2);
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<QVector<Instance>>& instances) {
+    ASSERT_THAT(instances, HasValue());
+    EXPECT_EQ(instances.value().size(), 2);
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetInstancesAsyncWorkingWithProject) {
@@ -110,23 +97,15 @@ TEST_F(OrbitGgpClientTest, GetInstancesAsyncWorkingWithProject) {
   ASSERT_THAT(client, HasValue());
 
   Project project{"display name", "project/test/id"};
-
-  bool future_is_resolved = false;
-
   auto future =
       client.value()->GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances, project);
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](ErrorMessageOr<QVector<Instance>> instances) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                ASSERT_THAT(instances, HasValue());
-                EXPECT_EQ(instances.value().size(), 2);
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<QVector<Instance>>& instances) {
+    ASSERT_THAT(instances, HasValue());
+    EXPECT_EQ(instances.value().size(), 2);
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetInstancesAsyncWorkingAllReservedWithProject) {
@@ -134,23 +113,15 @@ TEST_F(OrbitGgpClientTest, GetInstancesAsyncWorkingAllReservedWithProject) {
   ASSERT_THAT(client, HasValue());
 
   Project project{"display name", "project/test/id"};
-
-  bool future_is_resolved = false;
-
   auto future =
       client.value()->GetInstancesAsync(Client::InstanceListScope::kAllReservedInstances, project);
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](ErrorMessageOr<QVector<Instance>> instances) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                ASSERT_THAT(instances, HasValue());
-                EXPECT_EQ(instances.value().size(), 2);
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<QVector<Instance>>& instances) {
+    ASSERT_THAT(instances, HasValue());
+    EXPECT_EQ(instances.value().size(), 2);
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetInstancesAsyncTimeout) {
@@ -159,26 +130,18 @@ TEST_F(OrbitGgpClientTest, GetInstancesAsyncTimeout) {
                              std::chrono::milliseconds{5});
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
   auto future =
       client.value()->GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances, std::nullopt);
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](const ErrorMessageOr<QVector<Instance>>& instances) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                EXPECT_THAT(instances, HasError("OrbitMockGgpWorking instance list -s"));
-                EXPECT_THAT(instances, HasError("timed out after 5ms"));
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<QVector<Instance>>& instances) {
+    EXPECT_THAT(instances, HasError("OrbitMockGgpWorking instance list -s"));
+    EXPECT_THAT(instances, HasError("timed out after 5ms"));
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetInstancesAsyncClientGetsDestroyed) {
-  bool future_is_resolved = false;
-
   Future<ErrorMessageOr<QVector<Instance>>> future =
       Future<ErrorMessageOr<QVector<Instance>>>{ErrorMessage{"Empty Error Message"}};
   {
@@ -188,19 +151,14 @@ TEST_F(OrbitGgpClientTest, GetInstancesAsyncClientGetsDestroyed) {
 
     future = client.value()->GetInstancesAsync(Client::InstanceListScope::kOnlyOwnInstances,
                                                std::nullopt);
-
     future.Then(main_thread_executor_.get(),
-                [&future_is_resolved](const ErrorMessageOr<QVector<Instance>>& instances_result) {
-                  EXPECT_FALSE(future_is_resolved);
-                  future_is_resolved = true;
+                [](const ErrorMessageOr<QVector<Instance>>& instances_result) {
                   EXPECT_THAT(instances_result, HasError("orbit_ggp::Client no longer exists"));
                   QCoreApplication::exit();
                 });
   }
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetSshInfoAsyncWorking) {
@@ -208,19 +166,13 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncWorking) {
   ASSERT_THAT(client, HasValue());
 
   QString test_instance_id = "instance/test/id";
-
-  bool future_is_resolved = false;
   auto future = client.value()->GetSshInfoAsync(test_instance_id, std::nullopt);
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](const ErrorMessageOr<SshInfo>& ssh_info) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                EXPECT_THAT(ssh_info, HasValue());
-                QCoreApplication::exit();
-              });
-  QCoreApplication::exec();
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<SshInfo>& ssh_info) {
+    EXPECT_THAT(ssh_info, HasValue());
+    QCoreApplication::exit();
+  });
 
-  EXPECT_TRUE(future_is_resolved);
+  QCoreApplication::exec();
 }
 
 TEST_F(OrbitGgpClientTest, GetSshInfoAsyncWorkingWithProject) {
@@ -228,50 +180,34 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncWorkingWithProject) {
   ASSERT_THAT(client, HasValue());
 
   QString test_instance_id = "instance/test/id";
-
   Project project{"display name", "project/test/id"};
-
-  bool future_is_resolved = false;
   auto future = client.value()->GetSshInfoAsync(test_instance_id, project);
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](const ErrorMessageOr<SshInfo>& ssh_info) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                EXPECT_THAT(ssh_info, HasValue());
-                QCoreApplication::exit();
-              });
-  QCoreApplication::exec();
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<SshInfo>& ssh_info) {
+    EXPECT_THAT(ssh_info, HasValue());
+    QCoreApplication::exit();
+  });
 
-  EXPECT_TRUE(future_is_resolved);
+  QCoreApplication::exec();
 }
 
 TEST_F(OrbitGgpClientTest, GetSshInfoAsyncTimeout) {
-  QString test_instance_id = "instance/test/id";
-
   // mock_ggp_working_ has a 50ms sleep, hence waiting for only 5ms should result in a timeout
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()),
                              std::chrono::milliseconds{5});
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
+  QString test_instance_id = "instance/test/id";
   auto future = client.value()->GetSshInfoAsync(test_instance_id, std::nullopt);
-  future.Then(main_thread_executor_.get(), [&future_is_resolved](
-                                               const ErrorMessageOr<SshInfo>& ssh_info) {
-    EXPECT_FALSE(future_is_resolved);
-    future_is_resolved = true;
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<SshInfo>& ssh_info) {
     EXPECT_THAT(ssh_info, HasError("OrbitMockGgpWorking ssh init -s --instance instance/test/id"));
     EXPECT_THAT(ssh_info, HasError("timed out after 5ms"));
     QCoreApplication::exit();
   });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetSshInfoAsyncClientGetsDestroyed) {
-  bool future_is_resolved = false;
-
   Future<ErrorMessageOr<SshInfo>> future =
       Future<ErrorMessageOr<SshInfo>>{ErrorMessage{"Empty Error Message"}};
   {
@@ -280,42 +216,28 @@ TEST_F(OrbitGgpClientTest, GetSshInfoAsyncClientGetsDestroyed) {
     ASSERT_THAT(client, HasValue());
 
     QString test_instance_id = "instance/test/id";
-
     future = client.value()->GetSshInfoAsync(test_instance_id, std::nullopt);
-
-    future.Then(main_thread_executor_.get(),
-                [&future_is_resolved](const ErrorMessageOr<SshInfo>& ssh_info_result) {
-                  EXPECT_FALSE(future_is_resolved);
-                  future_is_resolved = true;
-                  EXPECT_THAT(ssh_info_result, HasError("orbit_ggp::Client no longer exists"));
-                  QCoreApplication::exit();
-                });
+    future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<SshInfo>& ssh_info_result) {
+      EXPECT_THAT(ssh_info_result, HasError("orbit_ggp::Client no longer exists"));
+      QCoreApplication::exit();
+    });
   }
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetProjectsAsyncWorking) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   auto future = client.value()->GetProjectsAsync();
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](ErrorMessageOr<QVector<Project>> project) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                ASSERT_THAT(project, HasValue());
-                EXPECT_EQ(project.value().size(), 2);
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<QVector<Project>>& project) {
+    ASSERT_THAT(project, HasValue());
+    EXPECT_EQ(project.value().size(), 2);
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetProjectsAsyncTimeout) {
@@ -324,26 +246,17 @@ TEST_F(OrbitGgpClientTest, GetProjectsAsyncTimeout) {
                              std::chrono::milliseconds{5});
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   auto future = client.value()->GetProjectsAsync();
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](const ErrorMessageOr<QVector<Project>>& projects) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                EXPECT_THAT(projects, HasError("OrbitMockGgpWorking project list -s"));
-                EXPECT_THAT(projects, HasError("timed out after 5ms"));
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<QVector<Project>>& projects) {
+    EXPECT_THAT(projects, HasError("OrbitMockGgpWorking project list -s"));
+    EXPECT_THAT(projects, HasError("timed out after 5ms"));
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetProjectsAsyncClientGetsDestroyed) {
-  bool future_is_resolved = false;
-
   Future<ErrorMessageOr<QVector<Project>>> future =
       Future<ErrorMessageOr<QVector<Project>>>{ErrorMessage{"Empty Error Message"}};
   {
@@ -352,41 +265,27 @@ TEST_F(OrbitGgpClientTest, GetProjectsAsyncClientGetsDestroyed) {
     ASSERT_THAT(client, HasValue());
 
     future = client.value()->GetProjectsAsync();
-
-    future.Then(main_thread_executor_.get(),
-                [&future_is_resolved](const ErrorMessageOr<QVector<Project>>& projects_result) {
-                  EXPECT_FALSE(future_is_resolved);
-                  future_is_resolved = true;
-                  EXPECT_THAT(projects_result,
-                              HasError("killed because the parent object was destroyed"));
-                  QCoreApplication::exit();
-                });
+    future.Then(
+        main_thread_executor_.get(), [](const ErrorMessageOr<QVector<Project>>& projects_result) {
+          EXPECT_THAT(projects_result, HasError("killed because the parent object was destroyed"));
+          QCoreApplication::exit();
+        });
   }
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetDefaultProjectAsyncWorking) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   auto future = client.value()->GetDefaultProjectAsync();
-  future.Then(main_thread_executor_.get(), [&future_is_resolved](ErrorMessageOr<Project> project) {
-    EXPECT_FALSE(future_is_resolved);
-    future_is_resolved = true;
-    ASSERT_THAT(project, HasValue());
-    EXPECT_EQ(project.value().display_name, "Test Project");
-    EXPECT_EQ(project.value().id, "Test Project id");
+  future.Then(main_thread_executor_.get(), [](ErrorMessageOr<Project> project) {
+    EXPECT_THAT(project, HasValue(FieldsAre("Test Project", "Test Project id")));
     QCoreApplication::exit();
   });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetDefaultProjectAsyncTimeout) {
@@ -395,26 +294,17 @@ TEST_F(OrbitGgpClientTest, GetDefaultProjectAsyncTimeout) {
                              std::chrono::milliseconds{5});
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   auto future = client.value()->GetDefaultProjectAsync();
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](const ErrorMessageOr<Project>& project) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                EXPECT_THAT(project, HasError("OrbitMockGgpWorking config describe -s"));
-                EXPECT_THAT(project, HasError("timed out after 5ms"));
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<Project>& project) {
+    EXPECT_THAT(project, HasError("OrbitMockGgpWorking config describe -s"));
+    EXPECT_THAT(project, HasError("timed out after 5ms"));
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetDefaultProjectAsyncClientGetsDestroyed) {
-  bool future_is_resolved = false;
-
   Future<ErrorMessageOr<Project>> future =
       Future<ErrorMessageOr<Project>>{ErrorMessage{"Empty Error Message"}};
   {
@@ -423,80 +313,54 @@ TEST_F(OrbitGgpClientTest, GetDefaultProjectAsyncClientGetsDestroyed) {
     ASSERT_THAT(client, HasValue());
 
     future = client.value()->GetDefaultProjectAsync();
-
-    future.Then(main_thread_executor_.get(),
-                [&future_is_resolved](const ErrorMessageOr<Project>& project) {
-                  EXPECT_FALSE(future_is_resolved);
-                  future_is_resolved = true;
-                  EXPECT_THAT(project, HasError("killed because the parent object was destroyed"));
-                  QCoreApplication::exit();
-                });
+    future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<Project>& project) {
+      EXPECT_THAT(project, HasError("killed because the parent object was destroyed"));
+      QCoreApplication::exit();
+    });
   }
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, DescribeInstanceAsyncWorking) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   auto future = client.value()->DescribeInstanceAsync("id/of/instance1");
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](ErrorMessageOr<Instance> instance) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                ASSERT_THAT(instance, HasValue());
-                EXPECT_EQ("id/of/instance1", instance.value().id);
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<Instance>& instance) {
+    ASSERT_THAT(instance, HasValue());
+    EXPECT_EQ("id/of/instance1", instance.value().id);
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, DescribeInstanceAsyncWorkingForInvalidInstance) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   auto future = client.value()->DescribeInstanceAsync("unknown/instance");
-  future.Then(main_thread_executor_.get(),
-              [&future_is_resolved](ErrorMessageOr<Instance> instance) {
-                EXPECT_FALSE(future_is_resolved);
-                future_is_resolved = true;
-                ASSERT_THAT(instance, HasError("Unable to parse JSON"));
-                QCoreApplication::exit();
-              });
+  future.Then(main_thread_executor_.get(), [](const ErrorMessageOr<Instance>& instance) {
+    ASSERT_THAT(instance, HasError("Unable to parse JSON"));
+    QCoreApplication::exit();
+  });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetAccountAsyncWorking) {
   auto client = CreateClient(QString::fromStdString(mock_ggp_working_.string()));
   ASSERT_THAT(client, HasValue());
 
-  bool future_is_resolved = false;
-
   client.value()->GetDefaultAccountAsync().Then(
-      main_thread_executor_.get(), [&future_is_resolved](ErrorMessageOr<Account> account) {
-        EXPECT_FALSE(future_is_resolved);
-        future_is_resolved = true;
+      main_thread_executor_.get(), [](ErrorMessageOr<Account> account) {
         ASSERT_THAT(account, HasValue());
         EXPECT_EQ(account.value().email, "username@email.com");
         QCoreApplication::exit();
       });
 
   QCoreApplication::exec();
-
-  EXPECT_TRUE(future_is_resolved);
 }
 
 TEST_F(OrbitGgpClientTest, GetSymbolDownloadInfosAsyncWorking) {

--- a/src/OrbitGgp/MockGgp/Working.cpp
+++ b/src/OrbitGgp/MockGgp/Working.cpp
@@ -248,11 +248,10 @@ int GgpCrashReport(int argc, char* argv[]) {
       std::cout << "Flag --module needs an argument" << std::endl;
       return 1;
     }
-    std::string key = argv[i];
+    std::string key = argv[i++];
     if (kValidKeyToSymbolDownloadInfo.find(key) != kValidKeyToSymbolDownloadInfo.end()) {
       symbols_to_output.push_back(kValidKeyToSymbolDownloadInfo.at(key));
     }
-    ++i;
   }
 
   std::string output = R"(

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -51,9 +51,13 @@ class Client {
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Instance>> DescribeInstanceAsync(
       const QString& instance_id) = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Account>> GetDefaultAccountAsync() = 0;
+
+  struct SymbolDownloadQuery {
+    std::string module_name;
+    std::string build_id;
+  };
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>>
-  GetSymbolDownloadInfoAsync(
-      const std::vector<std::pair<std::string, std::string>>& module_names_and_build_ids) = 0;
+  GetSymbolDownloadInfoAsync(const std::vector<SymbolDownloadQuery>& symbol_download_queries) = 0;
 };
 
 [[nodiscard]] std::chrono::milliseconds GetClientDefaultTimeoutInMs();

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -13,12 +13,14 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "Account.h"
 #include "Instance.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/Project.h"
+#include "OrbitGgp/SymbolDownloadInfo.h"
 #include "SshInfo.h"
 
 namespace orbit_ggp {
@@ -28,7 +30,7 @@ constexpr const char* kDefaultGgpProgram{"ggp"};
 class Client {
  public:
   /*
-    InstancesListScope decribes the scope of the instance list command.
+    InstancesListScope describes the scope of the instance list command.
     - kOnlyOwnInstances means only the users owned instances are returned;
     - kAllReservedInstances means all reserved instances.
   */
@@ -49,11 +51,14 @@ class Client {
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Instance>> DescribeInstanceAsync(
       const QString& instance_id) = 0;
   [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<Account>> GetDefaultAccountAsync() = 0;
+  [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>>
+  GetSymbolDownloadInfoAsync(
+      const std::vector<std::pair<std::string, std::string>>& module_names_and_build_ids) = 0;
 };
 
 [[nodiscard]] std::chrono::milliseconds GetClientDefaultTimeoutInMs();
 ErrorMessageOr<std::unique_ptr<Client>> CreateClient(
-    QString ggp_programm = kDefaultGgpProgram,
+    QString ggp_program = kDefaultGgpProgram,
     std::chrono::milliseconds timeout = GetClientDefaultTimeoutInMs());
 
 }  // namespace orbit_ggp

--- a/src/SessionSetup/RetrieveInstancesTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesTest.cpp
@@ -16,6 +16,7 @@
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/Client.h"
 #include "OrbitGgp/Project.h"
+#include "OrbitGgp/SymbolDownloadInfo.h"
 #include "QtUtils/MainThreadExecutorImpl.h"
 #include "SessionSetup/RetrieveInstances.h"
 #include "TestUtils/TestUtils.h"
@@ -50,6 +51,9 @@ class MockGgpClient : public orbit_ggp::Client {
   MOCK_METHOD(Future<ErrorMessageOr<Instance>>, DescribeInstanceAsync,
               (const QString& /*instance_id*/), (override));
   MOCK_METHOD(Future<ErrorMessageOr<orbit_ggp::Account>>, GetDefaultAccountAsync, (), (override));
+  MOCK_METHOD(Future<ErrorMessageOr<std::vector<orbit_ggp::SymbolDownloadInfo>>>,
+              GetSymbolDownloadInfoAsync,
+              ((const std::vector<std::pair<std::string, std::string>>&)), (override));
 };
 
 namespace {

--- a/src/SessionSetup/RetrieveInstancesTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesTest.cpp
@@ -52,8 +52,8 @@ class MockGgpClient : public orbit_ggp::Client {
               (const QString& /*instance_id*/), (override));
   MOCK_METHOD(Future<ErrorMessageOr<orbit_ggp::Account>>, GetDefaultAccountAsync, (), (override));
   MOCK_METHOD(Future<ErrorMessageOr<std::vector<orbit_ggp::SymbolDownloadInfo>>>,
-              GetSymbolDownloadInfoAsync,
-              ((const std::vector<std::pair<std::string, std::string>>&)), (override));
+              GetSymbolDownloadInfoAsync, ((const std::vector<Client::SymbolDownloadQuery>&)),
+              (override));
 };
 
 namespace {


### PR DESCRIPTION
With this change, we updated the orbit_ggp::Client to support calling
`ggp crash-report download-symbols --show-url --module <module_name>/<build_id>`
for getting the symbol download URLs.

Bug: http://b/239167725
Test: Unit test