### PR TITLE
Use size of underlying memory region to check size parsed from PE/COFF

### DIFF
--- a/third_party/libunwindstack/MapInfo.cpp
+++ b/third_party/libunwindstack/MapInfo.cpp
@@ -349,7 +349,7 @@ Memory* MapInfo::CreateMemory(const std::shared_ptr<Memory>& process_memory) {
 
   if (!name().empty() && IsPotentiallyPeCoffFile(name())) {
     Memory* memory = GetFileMemory();
-    // Return even if this is a nullptr: for PEs we only support creating the memory from file.
+    // Return even if this is a nullptr: for PEs with a filename we only support creating the memory from file.
     return memory;
   }
 

--- a/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
+++ b/third_party/libunwindstack/include/unwindstack/PeCoffInterface.h
@@ -136,7 +136,6 @@ class PeCoffMemory {
 
   uint64_t cur_offset() { return cur_offset_; }
   void set_cur_offset(uint64_t cur_offset) { cur_offset_ = cur_offset; }
-
  private:
   Memory* memory_;
   uint64_t cur_offset_;


### PR DESCRIPTION
We add a size check against an upper bound to avoid allocating memory for incorrectly sized, large sections. Since the size data is parsed from the file, this otherwise can lead to out-of-memory issues. This change only addresses the one issue identified by oss-fuzz as detailed here: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47123. There are probably other places where similar checks could be added.

The generic `Memory` class in libunwindstack does not have a concept of size, however some derived classes have clearly defined bounds (file size, buffer with start and end). Since we are passing around generic `Memory` pointers, we add a virtual method that provides an upper bound on the size. This upper bound is set to the maximum representable number in the address type used (e.g. 8 bytes) for "unbounded memory", for other memory types it is set to the known upper bound (e.g. end minus start). 

Tested: Unit tests; ran fuzzer against testcase, does not fail anymore.
Bug: http://b/240099508