### PR TITLE
Disable the "Wine" group box on frame- pointer unwinding

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -59,6 +59,8 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   ui_->maxCopyRawStackSizeSpinBox->setValue(kMaxCopyRawStackSizeDefaultValue);
   ui_->maxCopyRawStackSizeWidget->setEnabled(ui_->framePointerUnwindingRadioButton->isChecked());
 
+  ui_->wineGroupBox->setEnabled(ui_->dwarfUnwindingRadioButton->isChecked());
+
   ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);
 
   ui_->memorySamplingPeriodMsLabel->setEnabled(ui_->collectMemoryInfoCheckBox->isChecked());


### PR DESCRIPTION
We already disabled the group box when switching to
frame-pointer unwinding. Now we also disable it when
frame-pointer unwinding was set in the QSettings.

Test: Open capture options with frame pointers saved
as unwinding option.
Bug: http://b/239810990