### PR TITLE
Add auto frame track at most once per session

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -706,6 +706,9 @@ class OrbitApp final : public DataViewFactory,
   // ONLY access this from the main thread.
   absl::flat_hash_set<std::string> download_disabled_modules_;
 
+  // A boolean information about if the default Frame Track was added in the current session.
+  bool default_frame_track_was_added_ = false;
+
   orbit_string_manager::StringManager string_manager_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
 


### PR DESCRIPTION
In this PR we are addressing the issue of a FrameTrack being re-added
after being manually erased by the user. The FrameTrack will appear
again in the next session unless the user unselect the option in
user-settings.

Discussed in http://go/stadia-orbit-auto-frame-track-alignment.

Bug: http://b/239675491

Test:
1- Start a session, take a capture, auto frame track is there.
2- Manually erase it, check Frame Track is not there anymore in the
following captures.

PS: It could be nice to have an E2E tests that plays both with the auto
frame track user setting (turning it on and off) and erasing manually
the FrameTrack, but IMO it will mean adding a new E2E tests and I'm not
sure if its a priority. Let me know if you have a different opinion.