### PR TITLE
Use absl::flat_hash_map for primitive_buffers_by_layer_

### DIFF
--- a/src/OrbitGl/OpenGlBatcher.h
+++ b/src/OrbitGl/OpenGlBatcher.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_GL_OPEN_GL_BATCHER_H_
 #define ORBIT_GL_OPEN_GL_BATCHER_H_
 
+#include <absl/container/flat_hash_map.h>
+
 #include <algorithm>
 #include <array>
 #include <iterator>
@@ -98,7 +100,11 @@ class OpenGlBatcher : public Batcher {
   [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const override;
 
  protected:
-  std::unordered_map<float, orbit_gl_internal::PrimitiveBuffers> primitive_buffers_by_layer_;
+  [[nodiscard]] orbit_gl_internal::PrimitiveBuffers* GetOrCreatePrimitiveBuffersForLayer(
+      float layer);
+
+  absl::flat_hash_map<float, std::unique_ptr<orbit_gl_internal::PrimitiveBuffers>>
+      primitive_buffers_by_layer_;
   std::vector<std::unique_ptr<PickingUserData>> user_data_;
 
  private:

--- a/src/OrbitGl/OpenGlBatcherTest.cpp
+++ b/src/OrbitGl/OpenGlBatcherTest.cpp
@@ -53,7 +53,7 @@ class FakeOpenGlBatcher : public OpenGlBatcher {
   // buffers. Only a single color per element will be appended
   // (start point for line, first vertex for triangle and box)
   void DrawLayer(float layer, bool picking = false) const override {
-    auto& buffer = primitive_buffers_by_layer_.at(layer);
+    auto& buffer = *primitive_buffers_by_layer_.at(layer).get();
     if (picking) {
       for (auto it = buffer.line_buffer.picking_colors_.begin();
            it != buffer.line_buffer.picking_colors_.end();) {
@@ -100,7 +100,7 @@ class FakeOpenGlBatcher : public OpenGlBatcher {
   }
 
   const orbit_gl_internal::PrimitiveBuffers& GetInternalBuffers(float layer) const {
-    return primitive_buffers_by_layer_.at(layer);
+    return *primitive_buffers_by_layer_.at(layer).get();
   }
 
  private:


### PR DESCRIPTION
Make sure primitive buffers are not moved when primitive_buffers_by_layer_ is resized.
Also replace std::unordered_map by absl::flat_hash_map.

Tests: Took a capture.