### PR TITLE
Provide a variadic alternative to the two-alternative Visit

### DIFF
--- a/src/MizarData/include/MizarData/FrameTrack.h
+++ b/src/MizarData/include/MizarData/FrameTrack.h
@@ -29,24 +29,6 @@ using FrameTrackInfo =
     orbit_base::Typedef<FrameTrackInfoTag, std::variant<orbit_client_data::ScopeInfo,
                                                         orbit_grpc_protos::PresentEvent::Source>>;
 
-// The function allows for more convenient calls to `std::visit`.
-template <typename Tag, typename First, typename Second, typename ActionOnFirst,
-          typename ActionOnSecond>
-auto Visit(ActionOnFirst&& action_on_first, ActionOnSecond&& action_on_second,
-           const orbit_base::Typedef<Tag, std::variant<First, Second>>& host) {
-  return std::visit(
-      [&action_on_first, &action_on_second](const auto& alternative) {
-        using Alternative = std::decay_t<decltype(alternative)>;
-        if constexpr (std::is_same_v<Alternative, First>) {
-          return std::invoke(std::forward<ActionOnFirst>(action_on_first), alternative);
-        }
-        if constexpr (std::is_same_v<Alternative, Second>) {
-          return std::invoke(std::forward<ActionOnSecond>(action_on_second), alternative);
-        }
-      },
-      *host);
-}
-
 }  // namespace orbit_mizar_data
 
 #endif  // MIZAR_DATA_MIZAR_FRAME_TRACK_H_

--- a/src/MizarData/include/MizarData/FrameTrackManager.h
+++ b/src/MizarData/include/MizarData/FrameTrackManager.h
@@ -12,6 +12,7 @@
 #include "MizarData/FrameTrack.h"
 #include "MizarData/MizarData.h"
 #include "MizarData/MizarDataProvider.h"
+#include "OrbitBase/Overloaded.h"
 
 namespace orbit_mizar_data {
 
@@ -19,7 +20,7 @@ template <typename Data>
 class FrameTrackManagerTmpl {
   using ScopeId = ::orbit_client_data::ScopeId;
   using ScopeType = ::orbit_client_data::ScopeType;
-  using PresentEvent = orbit_grpc_protos::PresentEvent;
+  using PresentEvent = ::orbit_grpc_protos::PresentEvent;
 
  public:
   explicit FrameTrackManagerTmpl(const Data* data) : data_(data) {}
@@ -43,10 +44,13 @@ class FrameTrackManagerTmpl {
 
   [[nodiscard]] std::vector<FrameStartNs> GetFrameStarts(FrameTrackId id, FrameStartNs min_start,
                                                          FrameStartNs max_start) const {
-    return Visit(
-        absl::bind_front(&FrameTrackManagerTmpl::GetScopeFrameStarts, this, min_start, max_start),
-        absl::bind_front(&FrameTrackManagerTmpl::GetEtwFrameStarts, this, min_start, max_start),
-        id);
+    return std::visit(
+        orbit_base::overloaded{
+            absl::bind_front(&FrameTrackManagerTmpl::GetScopeFrameStarts, this, min_start,
+                             max_start),
+            absl::bind_front(&FrameTrackManagerTmpl::GetEtwFrameStarts, this, min_start, max_start),
+        },
+        *id);
   }
 
  private:

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -125,8 +125,10 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
   }
 
   [[nodiscard]] std::string MakeDisplayedName(const FrameTrackInfo& info) const {
-    return Visit(&SamplingWithFrameTrackInputWidgetTmpl::MakeFrameTrackString,
-                 &SamplingWithFrameTrackInputWidgetTmpl::PresentEventSourceName, info);
+    return std::visit(
+        orbit_base::overloaded{&SamplingWithFrameTrackInputWidgetTmpl::MakeFrameTrackString,
+                               &SamplingWithFrameTrackInputWidgetTmpl::PresentEventSourceName},
+        *info);
   }
 
   void InitFrameTrackList(const PairedData& data) {

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/MainThreadExecutor.h
         include/OrbitBase/MakeUniqueForOverwrite.h
         include/OrbitBase/GetProcessIds.h
+        include/OrbitBase/Overloaded.h
         include/OrbitBase/Profiling.h
         include/OrbitBase/Promise.h
         include/OrbitBase/PromiseHelpers.h
@@ -75,23 +76,23 @@ target_sources(OrbitBase PRIVATE
         WriteStringToFile.cpp)
 
 if (WIN32)
-target_sources(OrbitBase PRIVATE
-        include/OrbitBase/GetLastError.h
-        include/OrbitBase/GetProcAddress.h
-        include/OrbitBase/OsVersionWindows.h)
+        target_sources(OrbitBase PRIVATE
+                include/OrbitBase/GetLastError.h
+                include/OrbitBase/GetProcAddress.h
+                include/OrbitBase/OsVersionWindows.h)
 
-target_sources(OrbitBase PRIVATE
-        ExecutablePathWindows.cpp
-        GetLastErrorWindows.cpp
-        GetProcAddressWindows.cpp
-        OsVersionWindows.cpp
-        ThreadUtilsWindows.cpp)
+        target_sources(OrbitBase PRIVATE
+                ExecutablePathWindows.cpp
+                GetLastErrorWindows.cpp
+                GetProcAddressWindows.cpp
+                OsVersionWindows.cpp
+                ThreadUtilsWindows.cpp)
 else()
-target_sources(OrbitBase PRIVATE
-        ExecutablePathLinux.cpp
-        ExecuteCommandLinux.cpp
-        GetProcessIdsLinux.cpp
-        ThreadUtilsLinux.cpp)
+        target_sources(OrbitBase PRIVATE
+                ExecutablePathLinux.cpp
+                ExecuteCommandLinux.cpp
+                GetProcessIdsLinux.cpp
+                ThreadUtilsLinux.cpp)
 endif()
 
 target_link_libraries(OrbitBase PUBLIC
@@ -115,6 +116,7 @@ target_sources(OrbitBaseTests PRIVATE
         FutureHelpersTest.cpp
         ImmediateExecutorTest.cpp
         LoggingUtilsTest.cpp
+        OverloadedTest.cpp
         ProfilingTest.cpp
         PromiseTest.cpp
         PromiseHelpersTest.cpp
@@ -136,22 +138,22 @@ target_sources(OrbitBaseTests PRIVATE
 )
 
 if (WIN32)
-target_sources(OrbitBaseTests PRIVATE
-        GetProcAddressTest.cpp
-        OsVersionWindowsTest.cpp)
+        target_sources(OrbitBaseTests PRIVATE
+                GetProcAddressTest.cpp
+                OsVersionWindowsTest.cpp)
 else()
-target_sources(OrbitBaseTests PRIVATE
-        ExecutablePathLinuxTest.cpp
-        ExecuteCommandLinuxTest.cpp
-        GetProcessIdsLinuxTest.cpp)
+        target_sources(OrbitBaseTests PRIVATE
+                ExecutablePathLinuxTest.cpp
+                ExecuteCommandLinuxTest.cpp
+                GetProcessIdsLinuxTest.cpp)
 endif()
 
 # Threadpool test contains some sleeps we couldn't work around - disable them on the CI
 # since they are flaky there (but they work fine on local workstations).
 if (NOT (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen"))
-target_sources(OrbitBaseTests PRIVATE
-        ThreadPoolTest.cpp
-)
+        target_sources(OrbitBaseTests PRIVATE
+                ThreadPoolTest.cpp
+        )
 endif()
 
 target_link_libraries(OrbitBaseTests PRIVATE

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -76,23 +76,23 @@ target_sources(OrbitBase PRIVATE
         WriteStringToFile.cpp)
 
 if (WIN32)
-        target_sources(OrbitBase PRIVATE
-                include/OrbitBase/GetLastError.h
-                include/OrbitBase/GetProcAddress.h
-                include/OrbitBase/OsVersionWindows.h)
+target_sources(OrbitBase PRIVATE
+        include/OrbitBase/GetLastError.h
+        include/OrbitBase/GetProcAddress.h
+        include/OrbitBase/OsVersionWindows.h)
 
-        target_sources(OrbitBase PRIVATE
-                ExecutablePathWindows.cpp
-                GetLastErrorWindows.cpp
-                GetProcAddressWindows.cpp
-                OsVersionWindows.cpp
-                ThreadUtilsWindows.cpp)
+target_sources(OrbitBase PRIVATE
+        ExecutablePathWindows.cpp
+        GetLastErrorWindows.cpp
+        GetProcAddressWindows.cpp
+        OsVersionWindows.cpp
+        ThreadUtilsWindows.cpp)
 else()
-        target_sources(OrbitBase PRIVATE
-                ExecutablePathLinux.cpp
-                ExecuteCommandLinux.cpp
-                GetProcessIdsLinux.cpp
-                ThreadUtilsLinux.cpp)
+target_sources(OrbitBase PRIVATE
+        ExecutablePathLinux.cpp
+        ExecuteCommandLinux.cpp
+        GetProcessIdsLinux.cpp
+        ThreadUtilsLinux.cpp)
 endif()
 
 target_link_libraries(OrbitBase PUBLIC
@@ -138,22 +138,22 @@ target_sources(OrbitBaseTests PRIVATE
 )
 
 if (WIN32)
-        target_sources(OrbitBaseTests PRIVATE
-                GetProcAddressTest.cpp
-                OsVersionWindowsTest.cpp)
+target_sources(OrbitBaseTests PRIVATE
+        GetProcAddressTest.cpp
+        OsVersionWindowsTest.cpp)
 else()
-        target_sources(OrbitBaseTests PRIVATE
-                ExecutablePathLinuxTest.cpp
-                ExecuteCommandLinuxTest.cpp
-                GetProcessIdsLinuxTest.cpp)
+target_sources(OrbitBaseTests PRIVATE
+        ExecutablePathLinuxTest.cpp
+        ExecuteCommandLinuxTest.cpp
+        GetProcessIdsLinuxTest.cpp)
 endif()
 
 # Threadpool test contains some sleeps we couldn't work around - disable them on the CI
 # since they are flaky there (but they work fine on local workstations).
 if (NOT (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen"))
-        target_sources(OrbitBaseTests PRIVATE
-                ThreadPoolTest.cpp
-        )
+target_sources(OrbitBaseTests PRIVATE
+        ThreadPoolTest.cpp
+)
 endif()
 
 target_link_libraries(OrbitBaseTests PRIVATE

--- a/src/OrbitBase/OverloadedTest.cpp
+++ b/src/OrbitBase/OverloadedTest.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+#include <stdint.h>
+
+#include "OrbitBase/Overloaded.h"
+
+namespace orbit_base {
+
+constexpr std::string_view kInt = "int";
+constexpr std::string_view kString = "string";
+
+constexpr auto kFromInt = [](int /*unused*/) { return kInt; };
+constexpr auto kFromIntMutable = [](int /*unused*/) mutable { return kInt; };
+constexpr auto kFromString = [](std::string /*unused*/) { return kString; };
+
+std::string_view FromString(std::string /*unused*/) { return kString; }
+std::string_view FromInt(int /*unused*/) { return kInt; }
+
+TEST(OverloadedTest, TwoLambdas) {
+  const auto overloaded_lambda = overloaded{kFromInt, kFromString};
+  EXPECT_EQ(overloaded_lambda(1), kInt);
+  EXPECT_EQ(overloaded_lambda("foo"), kString);
+}
+
+TEST(OverloadedTest, MutableAndImmutableLambdas) {
+  const auto overloaded_lambda = overloaded{kFromIntMutable, kFromString};
+  EXPECT_EQ(overloaded_lambda(1), kInt);
+  EXPECT_EQ(overloaded_lambda("foo"), kString);
+}
+
+TEST(OverloadedTest, SingleLambda) {
+  const auto overloaded_lambda = overloaded{kFromInt};
+  EXPECT_EQ(overloaded_lambda(1), kInt);
+}
+
+TEST(OverloadedTest, SingleFreeFunction) {
+  const auto overloaded_lambda = overloaded{&FromString};
+  EXPECT_EQ(overloaded_lambda("foo"), kString);
+}
+
+TEST(OverloadedTest, TwoFreeFunctions) {
+  const auto overloaded_lambda = overloaded{&FromString, &FromInt};
+  EXPECT_EQ(overloaded_lambda(1), kInt);
+  EXPECT_EQ(overloaded_lambda("foo"), kString);
+}
+
+TEST(OverloadedTest, FreeFunctionAndLambda) {
+  const auto overloaded_lambda = overloaded{&FromString, kFromInt};
+  EXPECT_EQ(overloaded_lambda(1), kInt);
+  EXPECT_EQ(overloaded_lambda("foo"), kString);
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/OverloadedTest.cpp
+++ b/src/OrbitBase/OverloadedTest.cpp
@@ -12,9 +12,13 @@ namespace orbit_base {
 constexpr std::string_view kInt = "int";
 constexpr std::string_view kString = "string";
 
+
+constexpr std::string_view kTwoInts = "two ints"; 
+
 constexpr auto kFromInt = [](int /*unused*/) { return kInt; };
-constexpr auto kFromIntMutable = [](int /*unused*/) mutable { return kInt; };
-constexpr auto kFromString = [](std::string /*unused*/) { return kString; };
+constexpr auto kFromTwoInts = [](int /*unused*/, int /*unused*/) { return kTwoInts; };
+auto kFromIntMutable = [](int /*unused*/) mutable { return kInt; };
+constexpr auto kFromString = [](std::string /*unused*/) { return kString; }; 
 
 std::string_view FromString(std::string /*unused*/) { return kString; }
 std::string_view FromInt(int /*unused*/) { return kInt; }
@@ -25,8 +29,15 @@ TEST(OverloadedTest, TwoLambdas) {
   EXPECT_EQ(overloaded_lambda("foo"), kString);
 }
 
+
+TEST(OverloadedTest, TwoLambdasWithOneAndTwoArguments) {
+  const auto overloaded_lambda = overloaded{kFromInt, kFromTwoInts};
+  EXPECT_EQ(overloaded_lambda(1), kInt);
+  EXPECT_EQ(overloaded_lambda(1,1), kTwoInts);
+}
+
 TEST(OverloadedTest, MutableAndImmutableLambdas) {
-  const auto overloaded_lambda = overloaded{kFromIntMutable, kFromString};
+  auto overloaded_lambda = overloaded{kFromIntMutable, kFromString};
   EXPECT_EQ(overloaded_lambda(1), kInt);
   EXPECT_EQ(overloaded_lambda("foo"), kString);
 }

--- a/src/OrbitBase/OverloadedTest.cpp
+++ b/src/OrbitBase/OverloadedTest.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 #include <stdint.h>
 
+#include <memory>
+
 #include "OrbitBase/Overloaded.h"
 
 namespace orbit_base {
@@ -12,13 +14,12 @@ namespace orbit_base {
 constexpr std::string_view kInt = "int";
 constexpr std::string_view kString = "string";
 
-
-constexpr std::string_view kTwoInts = "two ints"; 
+constexpr std::string_view kTwoInts = "two ints";
 
 constexpr auto kFromInt = [](int /*unused*/) { return kInt; };
 constexpr auto kFromTwoInts = [](int /*unused*/, int /*unused*/) { return kTwoInts; };
 auto kFromIntMutable = [](int /*unused*/) mutable { return kInt; };
-constexpr auto kFromString = [](std::string /*unused*/) { return kString; }; 
+constexpr auto kFromString = [](std::string /*unused*/) { return kString; };
 
 std::string_view FromString(std::string /*unused*/) { return kString; }
 std::string_view FromInt(int /*unused*/) { return kInt; }
@@ -29,11 +30,33 @@ TEST(OverloadedTest, TwoLambdas) {
   EXPECT_EQ(overloaded_lambda("foo"), kString);
 }
 
+constexpr std::string_view kTwoStrings = "two strings";
+
+TEST(OverloadedTest, TwoLambdasOnePolymorphic) {
+  const auto overloaded_lambda =
+      overloaded{[](auto /*unused*/, auto /*unused*/) { return kTwoStrings; }, kFromTwoInts};
+  EXPECT_EQ(overloaded_lambda(1, 1), kTwoInts);
+  EXPECT_EQ(overloaded_lambda("foo", "bar"), kTwoStrings);
+}
+
+TEST(OverloadedTest, StackedOverloaded) {
+  const auto overloaded_lambda = overloaded{overloaded{kFromInt, kFromString}, kFromTwoInts};
+  EXPECT_EQ(overloaded_lambda(1, 1), kTwoInts);
+  EXPECT_EQ(overloaded_lambda(1), kInt);
+  EXPECT_EQ(overloaded_lambda("foo"), kString);
+}
+
+TEST(OverloadedTest, MoveOnlyArgumentLambda) {
+  const auto lambda = [](std::unique_ptr<int> /*unused*/) { return kInt; };
+  const auto overloaded_lambda = overloaded{lambda};
+  auto int_ptr = std::make_unique<int>(1);
+  EXPECT_EQ(overloaded_lambda(std::move(int_ptr)), kInt);
+}
 
 TEST(OverloadedTest, TwoLambdasWithOneAndTwoArguments) {
   const auto overloaded_lambda = overloaded{kFromInt, kFromTwoInts};
   EXPECT_EQ(overloaded_lambda(1), kInt);
-  EXPECT_EQ(overloaded_lambda(1,1), kTwoInts);
+  EXPECT_EQ(overloaded_lambda(1, 1), kTwoInts);
 }
 
 TEST(OverloadedTest, MutableAndImmutableLambdas) {

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -5,8 +5,7 @@
 #ifndef ORBIT_BASE_OVERLOADED_H_
 #define ORBIT_BASE_OVERLOADED_H_
 
-#include <functional>
-#include <iostream>
+#include <functional> 
 #include <type_traits>
 #include <utility>
 
@@ -38,7 +37,7 @@ struct HasOperatorParen<T, std::void_t<decltype(&T::operator())>> : std::true_ty
 template <typename T>
 inline constexpr bool kHasOperatorParenV = HasOperatorParen<T>::value;
 
-// If `T` has `operator()` defined, is `T`. Otherwise it is `FunctionPtrWrapper<T>`
+// `T` if `operator()` is defined, otherwise `FunctionPtrWrapper<T>`
 template <typename T>
 using WithParen = std::conditional_t<kHasOperatorParenV<T>, T, FunctionPtrWithParen<T>>;
 

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -54,7 +54,7 @@ struct overloaded : orbit_base_internal::WithParen<Ts>... {
 };
 
 template <class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
+overloaded(Ts...)->overloaded<Ts...>;
 
 }  // namespace orbit_base
 

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -32,10 +32,10 @@ class FunctionPtrWithParen {
 template <typename T, typename = std::void_t<>>
 struct HasOperatorParen : std::false_type {};
 
-template <class T>
+template <typename T>
 struct HasOperatorParen<T, std::void_t<decltype(&T::operator())>> : std::true_type {};
 
-template <class T>
+template <typename T>
 inline constexpr bool kHasParenV = HasOperatorParen<T>::value;
 
 // If `T` has `operator()` defined, is `T`. Otherwise it is `FunctionPtrWrapper<T>`
@@ -48,12 +48,12 @@ namespace orbit_base {
 
 // Extended `overloaded` trick from https://en.cppreference.com/w/cpp/utility/variant/visit
 // Also handles function pointers.
-template <class... Ts>
+template <typename... Ts>
 struct overloaded : orbit_base_internal::WithParen<Ts>... {
   using orbit_base_internal::WithParen<Ts>::operator()...;
 };
 
-template <class... Ts>
+template <typename... Ts>
 overloaded(Ts...)->overloaded<Ts...>;
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -5,7 +5,7 @@
 #ifndef ORBIT_BASE_OVERLOADED_H_
 #define ORBIT_BASE_OVERLOADED_H_
 
-#include <functional> 
+#include <functional>
 #include <type_traits>
 #include <utility>
 

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -18,9 +18,10 @@ class FunctionPtrWithParen {
  public:
   FunctionPtrWithParen(FunctionPtr t) : function_ptr_(t) {}  // NOLINT(google-explicit-constructor)
 
-  template <typename In>
-  auto operator()(In&& in) const -> decltype(std::invoke(std::declval<FunctionPtr>(), in)) {
-    return std::invoke(function_ptr_, std::forward<In>(in));
+  template <typename... In>
+  auto operator()(In&&... in) const
+      -> decltype(std::invoke(std::declval<FunctionPtr>(), std::forward<In>(in)...)) {
+    return std::invoke(function_ptr_, std::forward<In>(in)...);
   }
 
  private:
@@ -29,13 +30,13 @@ class FunctionPtrWithParen {
 
 // Compile-time check if `operator()` is defined for `T`
 template <typename T, typename = std::void_t<>>
-struct HasParen : std::false_type {};
+struct HasOperatorParen : std::false_type {};
 
 template <class T>
-struct HasParen<T, std::void_t<decltype(&T::operator())>> : std::true_type {};
+struct HasOperatorParen<T, std::void_t<decltype(&T::operator())>> : std::true_type {};
 
 template <class T>
-inline constexpr bool kHasParenV = HasParen<T>::value;
+inline constexpr bool kHasParenV = HasOperatorParen<T>::value;
 
 // If `T` has `operator()` defined, is `T`. Otherwise it is `FunctionPtrWrapper<T>`
 template <typename T>

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_OVERLOADED_H_
+#define ORBIT_BASE_OVERLOADED_H_
+
+#include <functional>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+
+namespace orbit_base_internal {
+
+// The class wraps a function pointer, providing `operator()`
+template <typename FunctionPtr>
+class FunctionPtrWithParen {
+ public:
+  FunctionPtrWithParen(FunctionPtr t) : function_ptr_(t) {}  // NOLINT(google-explicit-constructor)
+
+  template <typename In>
+  auto operator()(In&& in) const -> decltype(std::invoke(std::declval<FunctionPtr>(), in)) {
+    return std::invoke(function_ptr_, std::forward<In>(in));
+  }
+
+ private:
+  FunctionPtr function_ptr_;
+};
+
+// Compile-time check if `operator()` is defined for `T`
+template <typename T, typename = std::void_t<>>
+struct HasParen : std::false_type {};
+
+template <class T>
+struct HasParen<T, std::void_t<decltype(&T::operator())>> : std::true_type {};
+
+template <class T>
+inline constexpr bool kHasParenV = HasParen<T>::value;
+
+// If `T` has `operator()` defined, is `T`. Otherwise it is `FunctionPtrWrapper<T>`
+template <typename T>
+using WithParen = std::conditional_t<kHasParenV<T>, T, FunctionPtrWithParen<T>>;
+
+}  // namespace orbit_base_internal
+
+namespace orbit_base {
+
+// Extended `overloaded` trick from https://en.cppreference.com/w/cpp/utility/variant/visit
+// Also handles function pointers.
+template <class... Ts>
+struct overloaded : orbit_base_internal::WithParen<Ts>... {
+  using orbit_base_internal::WithParen<Ts>::operator()...;
+};
+
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_OVERLOADED_H_

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -36,11 +36,11 @@ template <typename T>
 struct HasOperatorParen<T, std::void_t<decltype(&T::operator())>> : std::true_type {};
 
 template <typename T>
-inline constexpr bool kHasParenV = HasOperatorParen<T>::value;
+inline constexpr bool kHasOperatorParenV = HasOperatorParen<T>::value;
 
 // If `T` has `operator()` defined, is `T`. Otherwise it is `FunctionPtrWrapper<T>`
 template <typename T>
-using WithParen = std::conditional_t<kHasParenV<T>, T, FunctionPtrWithParen<T>>;
+using WithParen = std::conditional_t<kHasOperatorParenV<T>, T, FunctionPtrWithParen<T>>;
 
 }  // namespace orbit_base_internal
 
@@ -54,7 +54,7 @@ struct overloaded : orbit_base_internal::WithParen<Ts>... {
 };
 
 template <typename... Ts>
-overloaded(Ts...)->overloaded<Ts...>;
+overloaded(Ts...) -> overloaded<Ts...>;
 
 }  // namespace orbit_base
 

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -54,7 +54,7 @@ struct overloaded : orbit_base_internal::WithParen<Ts>... {
 };
 
 template <typename... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
+overloaded(Ts...)->overloaded<Ts...>;
 
 }  // namespace orbit_base
 


### PR DESCRIPTION
The commit implements `overloaded` trick, that extends the
well-known `overloaded` trick. Now it also handles function
pointers.

Tests: Compile, Manual, Unit
Bug: http://b/240389184