### PR TITLE
Don't show errors related to AutoFrameTrack

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2568,6 +2568,8 @@ Future<void> OrbitApp::AddDefaultFrameTrackOrLogError() {
               }
             });
       }
+      return {};
+    }
   }
   std::string error_message =
       "It was not possible to add a frame track automatically, because none of the presets "

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -377,6 +377,7 @@ class OrbitApp final : public DataViewFactory,
   void UpdateAfterSymbolLoadingThrottled();
   void UpdateAfterCaptureCleared();
 
+  // Load the functions and add frame tracks from a particular module of a preset file.
   orbit_base::Future<ErrorMessageOr<void>> LoadPresetModule(
       const std::filesystem::path& module_path, const orbit_preset_file::PresetFile& preset_file);
   orbit_base::Future<ErrorMessageOr<void>> LoadPreset(


### PR DESCRIPTION
In this PR we are not showing in the UI the errors from the auto added
frame track. These errors are appearing when the user doesn't wait for
the needed modules to be loaded automatically before taking a capture.
For example, an error was making the capture loading test to fail
(http://b/240382344): http://screenshot/3ztNqiMp4Mm5xwV.

To solve the issue we are using directly LoadPresetModule to load the
modules (all the shipped auto-preset have only one frame track and
therefore just one module). In case that the user modifies the file, the
behavior is unexpected and multiple errors might appear, and we are logging
all of them.

Bug: http://b/240402941
Test:
1- Manually start a capture before modules were loaded. No errors.
2- Wait modules to be loaded and take another capture. The frame track
appears automatically.