### PR TITLE
Switch default for instrumentation method.

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -93,7 +93,8 @@ class CaptureOptionsDialog : public QDialog {
   static constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 10;
   static constexpr uint64_t kMemoryWarningThresholdKbDefaultValue = 1024 * 1024 * 8;  // 8Gb
   static constexpr orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod
-      kDynamicInstrumentationMethodDefaultValue = orbit_grpc_protos::CaptureOptions::kKernelUprobes;
+      kDynamicInstrumentationMethodDefaultValue =
+          orbit_grpc_protos::CaptureOptions::kUserSpaceInstrumentation;
   static constexpr uint64_t kLocalMarkerDepthDefaultValue = 0;
   static constexpr orbit_client_data::WineSyscallHandlingMethod
       kWineSyscallHandlingMethodDefaultValue =

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -342,7 +342,7 @@ p, li { white-space: pre-wrap; }
        <item>
         <widget class="QGroupBox" name="dynamicInstrumentationGroupBox">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Method &lt;span style=&quot; font-weight:600;&quot;&gt;Orbit&lt;/span&gt; has lower overhead but is still experimental.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Method &lt;span style=&quot; font-weight:600;&quot;&gt;Orbit&lt;/span&gt; has lower overhead. In some rare cases method &lt;span style=&quot; font-weight:600;&quot;&gt;Kernel (uprobes)&lt;/span&gt;  might be more stable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="title">
           <string>Dynamic instrumentation</string>
@@ -363,23 +363,23 @@ p, li { white-space: pre-wrap; }
           <property name="bottomMargin">
            <number>9</number>
           </property>
-          <item>
+           <item>
+             <widget class="QRadioButton" name="userSpaceRadioButton">
+               <property name="accessibleName">
+                 <string>UserSpaceInstrumentationRadioButton</string>
+               </property>
+               <property name="text">
+                 <string>Orbit</string>
+               </property>
+             </widget>
+           </item>
+           <item>
            <widget class="QRadioButton" name="uprobesRadioButton">
             <property name="accessibleName">
              <string>UprobesRadioButton</string>
             </property>
             <property name="text">
              <string>Kernel (uprobes)</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="userSpaceRadioButton">
-            <property name="accessibleName">
-             <string>UserSpaceInstrumentationRadioButton</string>
-            </property>
-            <property name="text">
-             <string>Orbit | experimental ⓘ</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Default is now user space instrumentation. Also switched order in the capture options dialog and pdated the tool tip.

Bug: b/240278395
Test: Deleted registry entry for the setting. Defaulted to new method.