### PR TITLE
Verify that pdata bounds are valid for the underlying file

### DIFF
--- a/third_party/libunwindstack/MapInfo.cpp
+++ b/third_party/libunwindstack/MapInfo.cpp
@@ -349,7 +349,9 @@ Memory* MapInfo::CreateMemory(const std::shared_ptr<Memory>& process_memory) {
 
   if (!name().empty() && IsPotentiallyPeCoffFile(name())) {
     Memory* memory = GetFileMemory();
-    // Return even if this is a nullptr: for PEs we only support creating the memory from file.
+    // Return even if this is a nullptr: for MapInfo instances with a filename of a PE/COFF file,
+    // we only support creating the memory from file. Anonymously mapped sections of a PE/COFF
+    // file are handled below.
     return memory;
   }
 

--- a/third_party/libunwindstack/PeCoffRuntimeFunctions.cpp
+++ b/third_party/libunwindstack/PeCoffRuntimeFunctions.cpp
@@ -16,6 +16,8 @@
 
 #include "PeCoffRuntimeFunctions.h"
 
+#include <unwindstack/Log.h>
+
 #include <memory>
 
 namespace unwindstack {
@@ -46,6 +48,17 @@ bool PeCoffRuntimeFunctionsImpl::Init(uint64_t pdata_begin, uint64_t pdata_end) 
   const uint64_t pdata_size = pdata_end - pdata_begin;
   if (pdata_size % sizeof(RuntimeFunction) != 0) {
     last_error_.code = ERROR_INVALID_COFF;
+    return false;
+  }
+
+  // pdata_begin and pdata_end are read from the file itself and should be considered
+  // untrusted data. We verify whether the end falls within the file. If it does, then
+  // the begin also falls within the file.
+  uint8_t last_byte_of_pdata_section;
+  pe_coff_memory_.set_cur_offset(pdata_end - 1);
+  if (!pe_coff_memory_.GetFully(&last_byte_of_pdata_section, 1)) {
+    last_error_.code = ERROR_INVALID_COFF;
+    Log::Error("Bounds for .pdata section are incorrect.");
     return false;
   }
 


### PR DESCRIPTION
The bounds for the pdata section are read from the PE/COFF file itself,
which means they are untrusted data. We add a check to verify that the
bounds fall within the underlying PE/COFF file. This also ensures that
we do not allocate absurdly large memory regions to hold the
RUNTIME_FUNCTIONS structs, which led to an OOM issue found by oss-fuzz.

Tested: Unit tests; ran fuzzer testcase to verify OOM issue is fixed.
Bug: http://b/240099508