### PR TITLE
Use libvulkan in Auto-frame-track if ggpvlk is not available

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2536,8 +2536,11 @@ Future<void> OrbitApp::AddDefaultFrameTrackOrLogError() {
       orbit_base::GetExecutableDir() / "autopresets";
   const std::filesystem::path stadia_default_preset_path =
       default_auto_preset_folder_path / "stadia-default-frame-track.opr";
+  const std::filesystem::path linux_default_preset_path =
+      default_auto_preset_folder_path / "linux-default-frame-track.opr";
 
-  std::vector<std::filesystem::path> auto_preset_paths = {stadia_default_preset_path};
+  std::vector<std::filesystem::path> auto_preset_paths = {stadia_default_preset_path,
+                                                          linux_default_preset_path};
 
   // Each preset in auto_preset_paths contains a FrameTrack that users might be interested in
   // loading by default. Orbit will try to load automatically just the first loadable preset from

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -188,8 +188,8 @@ target_link_libraries(
          gte::gte)
 
 add_custom_command(TARGET OrbitGl POST_BUILD COMMAND ${CMAKE_COMMAND}
-                   -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/stadia-default-frame-track.opr
-                   ${CMAKE_BINARY_DIR}/bin/autopresets/stadia-default-frame-track.opr)
+                   -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/resources
+                   ${CMAKE_BINARY_DIR}/bin/autopresets)
 
 if(TARGET OpenGL::GLX AND TARGET OpenGL::OpenGL)
   target_link_libraries(OrbitGl PUBLIC OpenGL::GLX)

--- a/src/OrbitGl/resources/linux-default-frame-track.opr
+++ b/src/OrbitGl/resources/linux-default-frame-track.opr
@@ -1,0 +1,8 @@
+# ORBIT preset file
+modules {
+  key: "/usr/local/cloudcast/lib/libvulkan.so.1"
+  value {
+    function_names: "vkQueuePresentKHR"
+    frame_track_function_names: "vkQueuePresentKHR"
+  }
+}


### PR DESCRIPTION
PR in draft since "`/usr/local/cloudcast/lib/libvulkan.so.1`" is an internal route we use, We might need to refactor preset files to just include the name of the library (here `libvulkan.so`)

In this PR we are shipping a preset file that uses libvulkan in the
case that the module ggpvlk is not available (for example, linux
outside stadia).

We will anyway wait for the downloading of ggpvlk.

Bug: http://b/239150184

Test: Created a signed build and testing everything works as before.