### PR TITLE
Add default frame track when settings is turned on

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2711,6 +2711,16 @@ void OrbitApp::SetMaxLocalMarkerDepthPerCommandBuffer(
       max_local_marker_depth_per_command_buffer);
 }
 
+void OrbitApp::SetEnableAutoFrameTrack(bool enable_auto_frame_track) {
+  // if the option is true, Orbit will try to add the default frame track as soon as possible. This
+  // might fail because a user can start a capture before the needed symbols are downloaded, so we
+  // are additionaly saving the state for the future.
+  if (enable_auto_frame_track) {
+    std::ignore = AddDefaultFrameTrackOrLogError();
+  }
+  data_manager_->set_enable_auto_frame_track(enable_auto_frame_track);
+}
+
 void OrbitApp::SelectFunction(const orbit_client_data::FunctionInfo& func) {
   ORBIT_LOG("Selected %s (address_=%#x, loaded_module_path_=%s)", func.pretty_name(),
             func.address(), func.module_path());

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2712,7 +2712,7 @@ void OrbitApp::SetMaxLocalMarkerDepthPerCommandBuffer(
 }
 
 void OrbitApp::SetEnableAutoFrameTrack(bool enable_auto_frame_track) {
-  // if the option is true, Orbit will try to add the default frame track as soon as possible. This
+  // If the option is true, Orbit will try to add the default frame track as soon as possible. This
   // might fail because a user can start a capture before the needed symbols are downloaded, so we
   // are additionaly saving the state for the future.
   if (enable_auto_frame_track) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -440,9 +440,7 @@ class OrbitApp final : public DataViewFactory,
   void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
 
-  void SetEnableAutoFrameTrack(bool enable_auto_frame_track) {
-    data_manager_->set_enable_auto_frame_track(enable_auto_frame_track);
-  }
+  void SetEnableAutoFrameTrack(bool enable_auto_frame_track);
   [[nodiscard]] bool GetEnableAutoFrameTrack() const {
     return data_manager_->enable_auto_frame_track();
   }


### PR DESCRIPTION
In this PR we are additionally adding a the default frame track when a
user set the settings on. This was discussed in the doc and with
Ronald and it's just to cover the case about a user who previously set
the option off and wanted to set it on. In that case it would be nice to
have the default frame track as soon as possible.

Bug: http://b/240275500

Test: Manually play with the option. Everything works as expected.