### PR TITLE
Fix LiveFunctionsDataView::OnDataChanged early-out

### DIFF
--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -517,7 +517,7 @@ void LiveFunctionsDataView::OnDataChanged() {
     }
 
     if (!function_info.has_value()) {
-      return;
+      continue;
     }
     const std::optional<ScopeId> scope_id = app_->GetCaptureData().FunctionIdToScopeId(function_id);
     ORBIT_CHECK(scope_id.has_value());


### PR DESCRIPTION
A `return` statement would omit calling `DataView::OnDataChanged()` and 
skip the call to `app_->GetCaptureData().GetAllProvidedScopeIds()`. Replace
by `continue` instead. This would cause a Windows API Tracing capture to
not correctly display the live scope stats on capture stop. The data could 
then only be displayed when using the filter bar.