### PR TITLE
Use "uint8_t*" instead of "char*" to represent stack data

### DIFF
--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -153,7 +153,7 @@ CallchainSamplePerfEventData BuildFakeCallchainSamplePerfEventData(
       .pid = 10,
       .tid = 11,
       .regs = make_unique_for_overwrite<perf_event_sample_regs_user_all>(),
-      .data = make_unique_for_overwrite<char[]>(13)};
+      .data = make_unique_for_overwrite<uint8_t[]>(13)};
   event_data.SetIps(callchain);
   if (callchain.size() > 1) {
     // Set the first non-kernel address as IP.

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.h
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.h
@@ -20,18 +20,18 @@ namespace orbit_linux_tracing {
 // to the array that actually owns the stack data.
 class StackSliceView {
  public:
-  StackSliceView(uint64_t start_address, uint64_t size, const char* data)
+  StackSliceView(uint64_t start_address, uint64_t size, const uint8_t* data)
       : start_address_{start_address}, size_{size}, data_{data} {}
 
   [[nodiscard]] uint64_t start_address() const { return start_address_; }
   [[nodiscard]] uint64_t end_address() const { return start_address_ + size_; }
   [[nodiscard]] uint64_t size() const { return size_; }
-  [[nodiscard]] const char* data() const { return data_; }
+  [[nodiscard]] const uint8_t* data() const { return data_; }
 
  private:
   uint64_t start_address_;
   uint64_t size_;
-  const char* data_;
+  const uint8_t* data_;
 };
 
 // This custom implementation of `unwindstack::Memory` carries multiple stack slices, each same as

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemoryTest.cpp
@@ -12,13 +12,13 @@ namespace orbit_linux_tracing {
 
 TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromOneStackSlice) {
   constexpr uint64_t kStartAddress = 0xADD8E55;
-  std::vector<char> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
+  std::vector<uint8_t> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
   StackSliceView stack_slice(kStartAddress, bytes.size(), bytes.data());
 
   std::shared_ptr<unwindstack::Memory> sut =
       LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory({stack_slice});
 
-  std::array<char, 3> destination{};
+  std::array<uint8_t, 3> destination{};
   size_t read_count = sut->Read(kStartAddress + 2, destination.data(), 3);
 
   ASSERT_EQ(read_count, 3);
@@ -29,18 +29,18 @@ TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromOneStackSlice) {
 
 TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromFirstMatchingStackSlice) {
   constexpr uint64_t kStartAddress1 = 0xADD8E55;
-  std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
+  std::vector<uint8_t> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
   StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());
 
   constexpr uint64_t kStartAddress2 = 0xABCDEF;
-  std::vector<char> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
+  std::vector<uint8_t> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
   StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
 
   std::shared_ptr<unwindstack::Memory> sut =
       LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory(
           {stack_slice1, stack_slice2});
 
-  std::array<char, 3> destination{};
+  std::array<uint8_t, 3> destination{};
   size_t read_count = sut->Read(kStartAddress1 + 2, destination.data(), 3);
 
   ASSERT_EQ(read_count, 3);
@@ -51,18 +51,18 @@ TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromFirstMatchingStackSl
 
 TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromSecondStackSlice) {
   constexpr uint64_t kStartAddress1 = 0xADD8E55;
-  std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
+  std::vector<uint8_t> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
   StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());
 
   constexpr uint64_t kStartAddress2 = 0xABCDEF;
-  std::vector<char> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
+  std::vector<uint8_t> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
   StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
 
   std::shared_ptr<unwindstack::Memory> sut =
       LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory(
           {stack_slice1, stack_slice2});
 
-  std::array<char, 3> destination{};
+  std::array<uint8_t, 3> destination{};
   size_t read_count = sut->Read(kStartAddress2 + 2, destination.data(), 3);
 
   ASSERT_EQ(read_count, 3);
@@ -74,13 +74,13 @@ TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromSecondStackSlice) {
 TEST(LibunwindstackMultipleOfflineAndProcessMemory,
      RequestingToReadWithPartialIntersectionReturnsZero) {
   constexpr uint64_t kStartAddress = 0xADD8E55;
-  std::vector<char> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
+  std::vector<uint8_t> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
   StackSliceView stack_slice(kStartAddress, bytes.size(), bytes.data());
 
   std::shared_ptr<unwindstack::Memory> sut =
       LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory({stack_slice});
 
-  std::array<char, 3> destination{};
+  std::array<uint8_t, 3> destination{};
   destination.fill(0x11);
   size_t read_count = sut->Read(kStartAddress - 1, destination.data(), 3);
 
@@ -93,13 +93,13 @@ TEST(LibunwindstackMultipleOfflineAndProcessMemory,
 TEST(LibunwindstackMultipleOfflineAndProcessMemory,
      RequestingToReadUnknownMemoryWithoutProcessReturnsZero) {
   constexpr uint64_t kStartAddress = 0xADD8E55;
-  std::vector<char> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
+  std::vector<uint8_t> bytes{0x01, 0x10, 0x20, 0x30, 0x40};
   StackSliceView stack_slice(kStartAddress, bytes.size(), bytes.data());
 
   std::shared_ptr<unwindstack::Memory> sut =
       LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory({stack_slice});
 
-  std::array<char, 3> destination{};
+  std::array<uint8_t, 3> destination{};
   destination.fill(0x11);
   size_t read_count = sut->Read(0xFE, destination.data(), 3);
 
@@ -112,18 +112,18 @@ TEST(LibunwindstackMultipleOfflineAndProcessMemory,
 TEST(LibunwindstackMultipleOfflineAndProcessMemory,
      ReadFromCompleteMemoryEvenIfPartiallyIntersectsWithOtherStackSlice) {
   constexpr uint64_t kStartAddress1 = 0xADD8E55;
-  std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
+  std::vector<uint8_t> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
   StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());
 
   constexpr uint64_t kStartAddress2 = kStartAddress1 - 2;
-  std::vector<char> bytes2{0x0a, 0x0b, 0x0c, 0x0d, 0x0f, 0x10, 0x01};
+  std::vector<uint8_t> bytes2{0x0a, 0x0b, 0x0c, 0x0d, 0x0f, 0x10, 0x01};
   StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
 
   std::shared_ptr<unwindstack::Memory> sut =
       LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory(
           {stack_slice1, stack_slice2});
 
-  std::array<char, 3> destination{};
+  std::array<uint8_t, 3> destination{};
   size_t read_count = sut->Read(kStartAddress2, destination.data(), 3);
 
   ASSERT_EQ(read_count, 3);
@@ -134,11 +134,11 @@ TEST(LibunwindstackMultipleOfflineAndProcessMemory,
 
 TEST(LibunwindstackMultipleOfflineAndProcessMemory, ReadFromTestProcess) {
   constexpr uint64_t kStartAddress1 = 0xADD8E55;
-  std::vector<char> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
+  std::vector<uint8_t> bytes1{0x01, 0x10, 0x20, 0x30, 0x40};
   StackSliceView stack_slice1(kStartAddress1, bytes1.size(), bytes1.data());
 
   constexpr uint64_t kStartAddress2 = 0xABCDEF;
-  std::vector<char> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
+  std::vector<uint8_t> bytes2{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
   StackSliceView stack_slice2(kStartAddress2, bytes2.size(), bytes2.data());
 
   std::vector<char> bytes3{0x09, 0x08, 0x07, 0x06, 0x05};

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -66,18 +66,18 @@ struct StackSamplePerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
     return perf_event_sample_regs_user_all_to_register_array(*regs);
   }
-  [[nodiscard]] const char* GetStackData() const { return data.get(); }
+  [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   // Handing out this non const pointer makes the stack data mutable even if the
   // StackSamplePerfEvent is const.  This mutablility is needed in
   // UprobesReturnAddressManager::PatchSample.
-  [[nodiscard]] char* GetMutableStackData() const { return data.get(); }
+  [[nodiscard]] uint8_t* GetMutableStackData() const { return data.get(); }
   [[nodiscard]] uint64_t GetStackSize() const { return dyn_size; }
 
   pid_t pid;
   pid_t tid;
   std::unique_ptr<perf_event_sample_regs_user_all> regs;
   uint64_t dyn_size;
-  std::unique_ptr<char[]> data;
+  std::unique_ptr<uint8_t[]> data;
 };
 using StackSamplePerfEvent = TypedPerfEvent<StackSamplePerfEventData>;
 
@@ -87,7 +87,7 @@ struct CallchainSamplePerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
     return perf_event_sample_regs_user_all_to_register_array(*regs);
   }
-  [[nodiscard]] const char* GetStackData() const { return data.get(); }
+  [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   void SetIps(const std::vector<uint64_t>& new_ips) const {
     ips_size = new_ips.size();
     ips = make_unique_for_overwrite<uint64_t[]>(ips_size);
@@ -104,7 +104,7 @@ struct CallchainSamplePerfEventData {
   mutable uint64_t ips_size;
   mutable std::unique_ptr<uint64_t[]> ips;
   std::unique_ptr<perf_event_sample_regs_user_all> regs;
-  std::unique_ptr<char[]> data;
+  std::unique_ptr<uint8_t[]> data;
 };
 using CallchainSamplePerfEvent = TypedPerfEvent<CallchainSamplePerfEventData>;
 
@@ -139,7 +139,7 @@ struct UprobesWithStackPerfEventData {
   // This mutablility allows moving the data out of this class in the UprobesUnwindingVisitor even
   // if we only have a const reference there. This requires the explicit knowledge that there is
   // only one visitor being applied to this event.
-  mutable std::unique_ptr<char[]> data;
+  mutable std::unique_ptr<uint8_t[]> data;
 };
 using UprobesWithStackPerfEvent = TypedPerfEvent<UprobesWithStackPerfEventData>;
 

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -186,7 +186,7 @@ StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffe
               .tid = static_cast<pid_t>(sample_id.tid),
               .regs = make_unique_for_overwrite<perf_event_sample_regs_user_all>(),
               .dyn_size = dyn_size,
-              .data = make_unique_for_overwrite<char[]>(dyn_size),
+              .data = make_unique_for_overwrite<uint8_t[]>(dyn_size),
           },
   };
 
@@ -250,7 +250,7 @@ CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ri
               .ips_size = nr,
               .ips = make_unique_for_overwrite<uint64_t[]>(nr),
               .regs = make_unique_for_overwrite<perf_event_sample_regs_user_all>(),
-              .data = make_unique_for_overwrite<char[]>(dyn_size),
+              .data = make_unique_for_overwrite<uint8_t[]>(dyn_size),
           },
   };
 
@@ -311,7 +311,7 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
               .tid = static_cast<pid_t>(sample_id.tid),
               .regs = regs,
               .dyn_size = dyn_size,
-              .data = make_unique_for_overwrite<char[]>(dyn_size),
+              .data = make_unique_for_overwrite<uint8_t[]>(dyn_size),
           },
   };
   ring_buffer->ReadRawAtOffset(event.data.data.get(), offset_of_data, dyn_size);

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -101,7 +101,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   struct StackSlice {
     uint64_t start_address;
     uint64_t size;
-    std::unique_ptr<char[]> data;
+    std::unique_ptr<uint8_t[]> data;
   };
 
   void OnUprobes(uint64_t timestamp_ns, pid_t tid, uint32_t cpu, uint64_t sp, uint64_t ip,

--- a/src/LinuxTracing/UprobesUnwindingVisitorSampleTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorSampleTest.cpp
@@ -214,7 +214,7 @@ StackSamplePerfEvent BuildFakeStackSamplePerfEvent() {
               .tid = 11,
               .regs = std::make_unique<perf_event_sample_regs_user_all>(),
               .dyn_size = kStackSize,
-              .data = std::make_unique<char[]>(kStackSize),
+              .data = std::make_unique<uint8_t[]>(kStackSize),
           },
   };
 }
@@ -228,7 +228,7 @@ CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(const std::vector<uin
               .pid = 10,
               .tid = 11,
               .regs = std::make_unique<perf_event_sample_regs_user_all>(),
-              .data = std::make_unique<char[]>(kStackSize),
+              .data = std::make_unique<uint8_t[]>(kStackSize),
           },
   };
   event.data.SetIps(callchain);
@@ -1018,15 +1018,15 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesUserSpaceStack) {
                       .sp = kUserStackPointer,
                   },
               .dyn_size = kUserStackSize,
-              .data = std::make_unique<char[]>(kUserStackSize),
+              .data = std::make_unique<uint8_t[]>(kUserStackSize),
           },
   };
-  char* user_stack_data = user_stack_event.data.data.get();
+  uint8_t* user_stack_data = user_stack_event.data.data.get();
   PerfEvent{std::move(user_stack_event)}.Accept(&visitor_);
 
   uint64_t dyn_size = event.data.dyn_size;
   uint64_t sp = event.data.regs->sp;
-  char* stack_data = event.data.data.get();
+  uint8_t* stack_data = event.data.data.get();
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
   EXPECT_THAT(actual_stack_slices,
@@ -1105,7 +1105,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesLatestUserSpaceCal
                       .sp = kUserStackPointerOld,
                   },
               .dyn_size = kUserStackSizeOld,
-              .data = std::make_unique<char[]>(kUserStackSizeOld),
+              .data = std::make_unique<uint8_t[]>(kUserStackSizeOld),
           },
   };
   PerfEvent{std::move(user_stack_event_old)}.Accept(&visitor_);
@@ -1125,15 +1125,15 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesLatestUserSpaceCal
                       .sp = kUserStackPointerNew,
                   },
               .dyn_size = kUserStackSizeNew,
-              .data = std::make_unique<char[]>(kUserStackSizeNew),
+              .data = std::make_unique<uint8_t[]>(kUserStackSizeNew),
           },
   };
-  char* user_stack_data = user_stack_event_new.data.data.get();
+  uint8_t* user_stack_data = user_stack_event_new.data.data.get();
   PerfEvent{std::move(user_stack_event_new)}.Accept(&visitor_);
 
   uint64_t dyn_size = event.data.dyn_size;
   uint64_t sp = event.data.regs->sp;
-  char* stack_data = event.data.data.get();
+  uint8_t* stack_data = event.data.data.get();
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
   EXPECT_THAT(actual_stack_slices,
@@ -1213,10 +1213,10 @@ TEST_F(UprobesUnwindingVisitorSampleTest,
                       .sp = kUserStackPointerSameThread,
                   },
               .dyn_size = kUserStackSizeSameThread,
-              .data = std::make_unique<char[]>(kUserStackSizeSameThread),
+              .data = std::make_unique<uint8_t[]>(kUserStackSizeSameThread),
           },
   };
-  char* user_stack_data = user_stack_event_same_thread.data.data.get();
+  uint8_t* user_stack_data = user_stack_event_same_thread.data.data.get();
   PerfEvent{std::move(user_stack_event_same_thread)}.Accept(&visitor_);
 
   constexpr uint64_t kUserStackSizeOtherThread = 1024;
@@ -1234,14 +1234,14 @@ TEST_F(UprobesUnwindingVisitorSampleTest,
                       .sp = kUserStackPointerOtherThread,
                   },
               .dyn_size = kUserStackSizeOtherThread,
-              .data = std::make_unique<char[]>(kUserStackSizeOtherThread),
+              .data = std::make_unique<uint8_t[]>(kUserStackSizeOtherThread),
           },
   };
   PerfEvent{std::move(user_stack_event_other_thread)}.Accept(&visitor_);
 
   uint64_t dyn_size = event.data.dyn_size;
   uint64_t sp = event.data.regs->sp;
-  char* stack_data = event.data.data.get();
+  uint8_t* stack_data = event.data.data.get();
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
   EXPECT_THAT(
@@ -1321,10 +1321,10 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesUserStackMemoryFro
                       .sp = kUserStackPointer1,
                   },
               .dyn_size = kUserStackSize1,
-              .data = std::make_unique<char[]>(kUserStackSize1),
+              .data = std::make_unique<uint8_t[]>(kUserStackSize1),
           },
   };
-  char* user_stack_data1 = user_stack_event1.data.data.get();
+  uint8_t* user_stack_data1 = user_stack_event1.data.data.get();
   PerfEvent{std::move(user_stack_event1)}.Accept(&visitor_);
 
   constexpr uint64_t kUserStackSize2 = 1024;
@@ -1342,15 +1342,15 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesUserStackMemoryFro
                       .sp = kUserStackPointer2,
                   },
               .dyn_size = kUserStackSize2,
-              .data = std::make_unique<char[]>(kUserStackSize2),
+              .data = std::make_unique<uint8_t[]>(kUserStackSize2),
           },
   };
-  char* user_stack_data2 = user_stack_event2.data.data.get();
+  uint8_t* user_stack_data2 = user_stack_event2.data.data.get();
   PerfEvent{std::move(user_stack_event2)}.Accept(&visitor_);
 
   uint64_t dyn_size = event.data.dyn_size;
   uint64_t sp = event.data.regs->sp;
-  char* stack_data = event.data.data.get();
+  uint8_t* stack_data = event.data.data.get();
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
   // We don't guarantee an order for the stack slices of different stream ids. However, the first


### PR DESCRIPTION
We used char* to represent stack data that we copied via
perf_event_open. Now a "const char*" is a C-string and
has a very special semantic, while a uint8_t* reflects more
the fact that we are only looking at bytes.

An effect of this, was that GTest was trying to pretty print
our char* for the testing. However, the data to which the
pointer was pointing to was already freed, and the tests
should just compare the raw pointer.

We fixed this by using "uint8_t*" for stack data that we
collect with perf_event_open.

Test: Unit tests + Take a capture and validate callstacks
Bug: http://b/239510246
Bug: http://b/239510776