### PR TITLE
Fix Mizar crash on no frame track available

### DIFF
--- a/src/MizarWidgets/MizarMainWindow.cpp
+++ b/src/MizarWidgets/MizarMainWindow.cpp
@@ -20,14 +20,14 @@ MizarMainWindow::MizarMainWindow(
     QWidget* parent)
     : QMainWindow(parent), ui_(std::make_unique<Ui::MainWindow>()) {
   ui_->setupUi(this);
-  ui_->sampling_with_frame_track_widget_->Init(baseline_and_comparison, baseline_file_name,
-                                               comparison_file_name);
-
   QObject::connect(ui_->sampling_with_frame_track_widget_,
                    &SamplingWithFrameTrackWidget::ReportError, this,
                    [this](const std::string& message) {
                      QMessageBox::critical(this, "Invalid input", QString::fromStdString(message));
                    });
+
+  ui_->sampling_with_frame_track_widget_->Init(baseline_and_comparison, baseline_file_name,
+                                               comparison_file_name);
 }
 
 MizarMainWindow::~MizarMainWindow() = default;

--- a/src/MizarWidgets/SamplingWithFrameTrackWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackWidget.cpp
@@ -4,8 +4,6 @@
 
 #include "MizarWidgets/SamplingWithFrameTrackWidget.h"
 
-#include <absl/functional/bind_front.h>
-
 #include <QObject>
 #include <QWidget>
 #include <memory>

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackWidget.h
@@ -55,9 +55,10 @@ class SamplingWithFrameTrackWidget : public QWidget {
   [[nodiscard]] Baseline<SamplingWithFrameTrackInputWidget*> GetBaselineInput() const;
   [[nodiscard]] Comparison<SamplingWithFrameTrackInputWidget*> GetComparisonInput() const;
   [[nodiscard]] bool IsMultiplicityCorrectionEnabled() const;
-  [[nodiscard]] bool IsDataValid(const orbit_mizar_data::MizarPairedData& data,
-                                 std::string_view data_title) const;
   void OnSignificanceLevelSelected(int index);
+  [[nodiscard]] static ErrorMessageOr<void> IsDataValid(
+      const orbit_mizar_data::MizarPairedData& data, std::string_view data_title);
+  void ProcessDataValidationOutcome(const ErrorMessageOr<void>& outcome) const;
 
   const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison_;
   std::unique_ptr<Ui::SamplingWithFrameTrackWidget> ui_;

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackWidget.h
@@ -5,6 +5,8 @@
 #ifndef MIZAR_WIDGETS_SAMPLING_WITH_FRAME_TRACK_WIDGET_H_
 #define MIZAR_WIDGETS_SAMPLING_WITH_FRAME_TRACK_WIDGET_H_
 
+#include <absl/strings/str_format.h>
+
 #include <QObject>
 #include <QStringLiteral>
 #include <QWidget>
@@ -14,6 +16,7 @@
 #include "MizarBase/BaselineOrComparison.h"
 #include "MizarBase/Titles.h"
 #include "MizarData/BaselineAndComparison.h"
+#include "MizarData/MizarPairedData.h"
 #include "MizarWidgets/MizarMainWindow.h"
 #include "MizarWidgets/SamplingWithFrameTrackReportConfigValidator.h"
 #include "SamplingWithFrameTrackInputWidget.h"
@@ -46,12 +49,14 @@ class SamplingWithFrameTrackWidget : public QWidget {
   void OnUpdateButtonClicked();
 
  signals:
-  void ReportError(const std::string& message);
+  void ReportError(const std::string& message) const;
 
  private:
   [[nodiscard]] Baseline<SamplingWithFrameTrackInputWidget*> GetBaselineInput() const;
   [[nodiscard]] Comparison<SamplingWithFrameTrackInputWidget*> GetComparisonInput() const;
   [[nodiscard]] bool IsMultiplicityCorrectionEnabled() const;
+  [[nodiscard]] bool IsDataValid(const orbit_mizar_data::MizarPairedData& data,
+                                 std::string_view data_title) const;
   void OnSignificanceLevelSelected(int index);
 
   const orbit_mizar_data::BaselineAndComparison* baseline_and_comparison_;


### PR DESCRIPTION
If a capture has no frame track, an error message is shown on
startup and the `Update` button is disabled.

Test: Manual
Bug: http://b/240671648