### PR TITLE
Fixed warnings about undefined GetThreadColor

### DIFF
--- a/src/OrbitGl/ThreadColor.h
+++ b/src/OrbitGl/ThreadColor.h
@@ -8,6 +8,6 @@
 
 namespace orbit_gl {
 
-[[nodiscard]] inline Color GetThreadColor(uint32_t id);
+[[nodiscard]] Color GetThreadColor(uint32_t id);
 
 }  // namespace orbit_gl


### PR DESCRIPTION
Fixed a bug caused by unnecessary inlining of a function in GetThreadColor.h

Bug: http://b/240293439