### PR TITLE
Align MockGgp output to new output

### DIFF
--- a/src/OrbitGgp/MockGgp/Working.cpp
+++ b/src/OrbitGgp/MockGgp/Working.cpp
@@ -20,7 +20,7 @@ int GgpVersion(int argc, char* argv[]) {
     return 1;
   }
 
-  std::cout << "12345.1.67.0 Mon 12 Dec 2012 12:12:12 PM UTC" << std::endl;
+  std::cout << "SDK Version:  25157.1.74.0" << std::endl;
   return 0;
 }
 


### PR DESCRIPTION
MockGgp mimics a call to `ggp version`. This output of `ggp version` is
changing with http://cl/413946125. This commit changes the output of
MockGpp to reflect the real ggp.

http://b/240909909