### PR TITLE
Disable warning when including LLVM headers

### DIFF
--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -6,7 +6,6 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
-#include <llvm/Demangle/Demangle.h>
 
 #include <string>
 #include <utility>
@@ -22,6 +21,11 @@
 #include "GrpcProtos/Constants.h"
 #include "GrpcProtos/capture.pb.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/Demangle/Demangle.h>
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_capture_client {
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -12,7 +12,6 @@
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
 #include <absl/time/time.h>
-#include <llvm/Demangle/Demangle.h>
 #include <stddef.h>
 
 #include <algorithm>
@@ -46,7 +45,12 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadUtils.h"
+#include "OrbitBase/WarningSuppression.h"
 #include "Statistics/Histogram.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/Demangle/Demangle.h>
+ORBIT_LLVM_INCLUDE_END
 
 using orbit_client_data::CaptureData;
 using orbit_client_data::FunctionInfo;
@@ -569,7 +573,7 @@ const FunctionInfo* LiveFunctionsDataView::GetFunctionInfoFromRow(int row) {
 std::optional<int> LiveFunctionsDataView::GetRowFromScopeId(ScopeId scope_id) {
   for (size_t function_row = 0; function_row < indices_.size(); function_row++) {
     if (GetScopeId(function_row) == scope_id) {
-      return function_row;
+      return static_cast<int>(function_row);
     }
   }
   return std::nullopt;

--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -6,13 +6,6 @@
 
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
-#include <llvm/DebugInfo/DWARF/DWARFContext.h>
-#include <llvm/Demangle/Demangle.h>
-#include <llvm/Object/Binary.h>
-#include <llvm/Object/COFF.h>
-#include <llvm/Object/CVDebugRecord.h>
-#include <llvm/Object/ObjectFile.h>
-#include <llvm/Support/Error.h>
 
 #include <system_error>
 
@@ -22,6 +15,17 @@
 #include "ObjectUtils/WindowsBuildIdUtils.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/DebugInfo/DWARF/DWARFContext.h>
+#include <llvm/Demangle/Demangle.h>
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/COFF.h>
+#include <llvm/Object/CVDebugRecord.h>
+#include <llvm/Object/ObjectFile.h>
+#include <llvm/Support/Error.h>
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_object_utils {
 

--- a/src/ObjectUtils/ElfFile.cpp
+++ b/src/ObjectUtils/ElfFile.cpp
@@ -7,6 +7,22 @@
 #include <absl/base/casts.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "GrpcProtos/module.pb.h"
+#include "GrpcProtos/symbol.pb.h"
+#include "Introspection/Introspection.h"
+#include "OrbitBase/File.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ReadFileToString.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ADT/Twine.h>
@@ -31,19 +47,7 @@
 #include <llvm/Support/Error.h>
 #include <llvm/Support/MathExtras.h>
 #include <llvm/Support/MemoryBuffer.h>
-
-#include <cstdint>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-#include "GrpcProtos/module.pb.h"
-#include "GrpcProtos/symbol.pb.h"
-#include "Introspection/Introspection.h"
-#include "OrbitBase/File.h"
-#include "OrbitBase/Logging.h"
-#include "OrbitBase/ReadFileToString.h"
-#include "OrbitBase/Result.h"
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_object_utils {
 

--- a/src/ObjectUtils/ObjectFile.cpp
+++ b/src/ObjectUtils/ObjectFile.cpp
@@ -5,8 +5,6 @@
 #include "ObjectUtils/ObjectFile.h"
 
 #include <absl/strings/str_format.h>
-#include <llvm/Object/Binary.h>
-#include <llvm/Object/ObjectFile.h>
 
 #include <filesystem>
 #include <memory>
@@ -17,6 +15,12 @@
 #include "ObjectUtils/CoffFile.h"
 #include "ObjectUtils/ElfFile.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/ObjectFile.h>
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_object_utils {
 

--- a/src/ObjectUtils/PdbFileDia.cpp
+++ b/src/ObjectUtils/PdbFileDia.cpp
@@ -6,7 +6,6 @@
 
 #include <absl/memory/memory.h>
 #include <diacreate.h>
-#include <llvm/Demangle/Demangle.h>
 #include <winerror.h>
 
 #include "Introspection/Introspection.h"
@@ -14,6 +13,11 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/StringConversion.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/Demangle/Demangle.h>
+ORBIT_LLVM_INCLUDE_END
 
 using orbit_grpc_protos::ModuleSymbols;
 using orbit_grpc_protos::SymbolInfo;

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -6,10 +6,6 @@
 
 #include <absl/memory/memory.h>
 #include <absl/strings/str_cat.h>
-#include <llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h>
-#include <llvm/DebugInfo/CodeView/TypeDeserializer.h>
-#include <llvm/DebugInfo/CodeView/TypeRecord.h>
-#include <llvm/DebugInfo/PDB/Native/TpiStream.h>
 
 #include <memory>
 
@@ -17,6 +13,14 @@
 #include "ObjectUtils/CoffFile.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h>
+#include <llvm/DebugInfo/CodeView/TypeDeserializer.h>
+#include <llvm/DebugInfo/CodeView/TypeRecord.h>
+#include <llvm/DebugInfo/PDB/Native/TpiStream.h>
+ORBIT_LLVM_INCLUDE_END
 
 using orbit_grpc_protos::ModuleSymbols;
 using orbit_grpc_protos::SymbolInfo;

--- a/src/ObjectUtils/PdbFileLlvm.h
+++ b/src/ObjectUtils/PdbFileLlvm.h
@@ -5,6 +5,16 @@
 #ifndef OBJECT_UTILS_PDB_FILE_LLVM_H_
 #define OBJECT_UTILS_PDB_FILE_LLVM_H_
 
+#include <array>
+#include <filesystem>
+
+#include "GrpcProtos/symbol.pb.h"
+#include "ObjectUtils/PdbFile.h"
+#include "ObjectUtils/WindowsBuildIdUtils.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
 #include <llvm/DebugInfo/CodeView/CVSymbolVisitor.h>
 #include <llvm/DebugInfo/CodeView/CodeView.h>
 #include <llvm/DebugInfo/CodeView/GUID.h>
@@ -20,14 +30,7 @@
 #include <llvm/DebugInfo/PDB/PDBSymbolExe.h>
 #include <llvm/DebugInfo/PDB/PDBTypes.h>
 #include <llvm/Demangle/Demangle.h>
-
-#include <array>
-#include <filesystem>
-
-#include "GrpcProtos/symbol.pb.h"
-#include "ObjectUtils/PdbFile.h"
-#include "ObjectUtils/WindowsBuildIdUtils.h"
-#include "OrbitBase/Result.h"
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_object_utils {
 

--- a/src/ObjectUtils/include/ObjectUtils/CoffFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/CoffFile.h
@@ -5,9 +5,6 @@
 #ifndef OBJECT_UTILS_COFF_FILE_H_
 #define OBJECT_UTILS_COFF_FILE_H_
 
-#include <llvm/Object/Binary.h>
-#include <llvm/Object/ObjectFile.h>
-
 #include <array>
 #include <filesystem>
 #include <memory>
@@ -16,6 +13,12 @@
 #include "GrpcProtos/symbol.pb.h"
 #include "ObjectUtils/ObjectFile.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/ObjectFile.h>
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_object_utils {
 

--- a/src/ObjectUtils/include/ObjectUtils/ElfFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ElfFile.h
@@ -17,8 +17,12 @@
 #include "GrpcProtos/symbol.pb.h"
 #include "ObjectFile.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_object_utils {
 

--- a/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
@@ -5,9 +5,6 @@
 #ifndef OBJECT_UTILS_OBJECT_FILE_H_
 #define OBJECT_UTILS_OBJECT_FILE_H_
 
-#include <llvm/Object/Binary.h>
-#include <llvm/Object/ObjectFile.h>
-
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -16,6 +13,12 @@
 #include "GrpcProtos/symbol.pb.h"
 #include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/ObjectFile.h>
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_object_utils {
 

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/TypedefUtils.h
         include/OrbitBase/UniqueResource.h
         include/OrbitBase/VoidToMonostate.h
+        include/OrbitBase/WarningSuppression.h
         include/OrbitBase/WhenAll.h
         include/OrbitBase/WhenAny.h
         include/OrbitBase/WriteStringToFile.h)

--- a/src/OrbitBase/include/OrbitBase/WarningSuppression.h
+++ b/src/OrbitBase/include/OrbitBase/WarningSuppression.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_WARNING_SUPPRESSION_H_
+#define ORBIT_BASE_WARNING_SUPPRESSION_H_
+
+#ifdef _WIN32
+
+// Disabling "destructor was implicitly defined as deleted" warning when including LLVM headers
+// (b/241025245).
+#define ORBIT_LLVM_INCLUDE_BEGIN _Pragma("warning(push)") _Pragma("warning(disable : 4624)")
+#define ORBIT_LLVM_INCLUDE_END _Pragma("warning(pop)")
+
+#else
+
+#define ORBIT_LLVM_INCLUDE_BEGIN
+#define ORBIT_LLVM_INCLUDE_END
+
+#endif
+
+#endif  // ORBIT_BASE_WARNING_SUPPRESSION_H_

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -11,8 +11,6 @@
 #include <absl/strings/str_replace.h>
 #include <absl/strings/str_split.h>
 #include <absl/types/span.h>
-#include <llvm/Object/Binary.h>
-#include <llvm/Object/ObjectFile.h>
 
 #include <algorithm>
 #include <filesystem>
@@ -30,8 +28,14 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
 #include "OrbitBase/WriteStringToFile.h"
 #include "Symbols/SymbolUtils.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/ObjectFile.h>
+ORBIT_LLVM_INCLUDE_END
 
 using orbit_grpc_protos::ModuleSymbols;
 

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -6,8 +6,6 @@
 #define SYMBOLS_SYMBOL_HELPER_H_
 
 #include <absl/types/span.h>
-#include <llvm/Object/Binary.h>
-#include <llvm/Object/ObjectFile.h>
 
 #include <filesystem>
 #include <string>
@@ -20,6 +18,12 @@
 #include "Introspection/Introspection.h"
 #include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/WarningSuppression.h"
+
+ORBIT_LLVM_INCLUDE_BEGIN
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/ObjectFile.h>
+ORBIT_LLVM_INCLUDE_END
 
 namespace orbit_symbols {
 


### PR DESCRIPTION
On Windows, we are spammed with "destructor was implicitly defined as
deleted" warnings. Disable the warning when including headers from LLVM.

We should see if a newer LLVM version fixes the issue (b/241025245)