### PR TITLE
Fix crash in Cloud Collector

### DIFF
--- a/src/CaptureServiceBase/CaptureServiceBase.cpp
+++ b/src/CaptureServiceBase/CaptureServiceBase.cpp
@@ -75,6 +75,9 @@ void CaptureServiceBase::FinalizeEventProcessing(
     CaptureFinished::TerminationSignal target_process_termination_signal) {
   ProducerCaptureEvent capture_finished;
   switch (stop_capture_reason) {
+    case StopCaptureReason::kUnknown:
+      capture_finished = CreateFailedCaptureFinishedEvent("Capture stopped due to unknown reason.");
+      break;
     case StopCaptureReason::kClientStop:
     case StopCaptureReason::kGuestOrcStop:
       capture_finished = CreateSuccessfulCaptureFinishedEvent();

--- a/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
@@ -52,7 +52,7 @@ void CloudCollectorStartStopCaptureRequestWaiter::StopCapture(
     CaptureServiceBase::StopCaptureReason stop_capture_reason) {
   absl::MutexLock lock(&mutex_);
   ORBIT_LOG("Stop capture requested");
-  stop_capture_reason_ = std::move(stop_capture_reason);
+  stop_capture_reason_ = stop_capture_reason;
   stop_requested_ = true;
 }
 

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -26,6 +26,7 @@ class CaptureServiceBase {
 
   enum class CaptureInitializationResult { kSuccess, kAlreadyInProgress };
   enum class StopCaptureReason {
+    kUnknown,
     kClientStop,
     kMemoryWatchdog,
     kExceededMaxDurationLimit,

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -9,6 +9,7 @@
 #include <absl/synchronization/mutex.h>
 #include <absl/time/time.h>
 
+#include "CaptureServiceBase/CaptureServiceBase.h"
 #include "CaptureServiceBase/StopCaptureRequestWaiter.h"
 #include "GrpcProtos/capture.pb.h"
 
@@ -37,7 +38,8 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StopCaptureRequestWai
   orbit_grpc_protos::CaptureOptions capture_options_ ABSL_GUARDED_BY(mutex_);
   bool start_requested_ ABSL_GUARDED_BY(mutex_) = false;
 
-  CaptureServiceBase::StopCaptureReason stop_capture_reason_ ABSL_GUARDED_BY(mutex_);
+  CaptureServiceBase::StopCaptureReason stop_capture_reason_ ABSL_GUARDED_BY(mutex_) =
+      CaptureServiceBase::StopCaptureReason::kUnknown;
   bool stop_requested_ ABSL_GUARDED_BY(mutex_) = false;
 
   std::optional<absl::Duration> max_capture_duration_;

--- a/src/CaptureServiceBase/include/CaptureServiceBase/StopCaptureReasonToString.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/StopCaptureReasonToString.h
@@ -12,9 +12,11 @@
 
 namespace orbit_capture_service_base {
 
-[[nodiscard]] std::string StopCaptureReasonToString(
+[[nodiscard]] inline std::string StopCaptureReasonToString(
     CaptureServiceBase::StopCaptureReason stop_capture_reason) {
   switch (stop_capture_reason) {
+    case CaptureServiceBase::StopCaptureReason::kUnknown:
+      return "unknown";
     case CaptureServiceBase::StopCaptureReason::kClientStop:
       return "client_stop";
     case CaptureServiceBase::StopCaptureReason::kMemoryWatchdog:


### PR DESCRIPTION
There is a crash that seems to be caused by an unitialized enum variable in
`CloudCollectorStartStopCaptureRequestWaiter`. `stop_capture_reason_`
seems not to be set. I don't really understand why, but I also don't
understand the code.

My fix is to introduce a `kUnknown` enum value for the
`StopCaptureReason` and initialize the member with this value. That's
not great but it should at least save us from crashes.

BUG: http://b/240533627