### PR TITLE
Fix console output of Orbit if it is started from a console.

### DIFF
--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -221,6 +221,13 @@ static void LogCommandLine(int argc, char* argv[]) {
 }
 
 int main(int argc, char* argv[]) {
+#ifdef _WIN32
+  if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+    freopen("CONOUT$", "w", stdout);
+    freopen("CONOUT$", "w", stderr);
+  }
+#endif
+
   absl::SetProgramUsageMessage("CPU Profiler");
   absl::SetFlagsUsageConfig(absl::FlagsUsageConfig{{}, {}, {}, &orbit_version::GetBuildReport, {}});
   std::vector<char*> positional_args = absl::ParseCommandLine(argc, argv);


### PR DESCRIPTION
"--version_for_testing" flag takes a filename. Orbit will write its
version information into this file and exit immediatly.

Bug: http://b/238426836
Test: Local run.