### PR TITLE
Add `operator+` for `Typedef`

### DIFF
--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -5,6 +5,7 @@
 #include <absl/hash/hash_testing.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <tuple>
@@ -322,6 +323,38 @@ TEST(Typedef, ComparisonIsCorrect) {
   EXPECT_LE(MyType<int>(kLesser), MyType<int>(kGreater));
   EXPECT_LT(MyType<int>(kLesser), MyType<int>(kGreater));
   EXPECT_GT(MyType<int>(kGreater), MyType<int>(kLesser));
+}
+
+struct WrapperWithPlusTag : PlusTag {};
+
+template <typename T>
+struct WrapperWithPlus : Typedef<WrapperWithPlusTag, T> {
+  using Typedef<WrapperWithPlusTag, T>::Typedef;
+};
+
+TEST(Typedef, WrapperWithPlusHasPlus) {
+  constexpr int kAValue = 1;
+  constexpr int kBValue = 2;
+  WrapperWithPlus<int> a(kAValue);
+  WrapperWithPlus<int> b(kBValue);
+  EXPECT_EQ(*(a + b), kAValue + kBValue);
+}
+
+TEST(Typedef, WrapperWithPlusHasPlusAndPromotes) {
+  constexpr int kInt = 1;
+  constexpr float kFloat = 0.5;
+  WrapperWithPlus<int> a(kInt);
+  WrapperWithPlus<float> b(kFloat);
+  WrapperWithPlus<float> result = a + b;
+  EXPECT_EQ(*result, kInt + kFloat);
+}
+
+TEST(Typedef, WrapperWithPlusHasPlusAndConvertsArgument) {
+  constexpr std::chrono::nanoseconds kNanos(1000);
+  constexpr std::chrono::microseconds kMicros(1);
+  WrapperWithPlus<std::chrono::nanoseconds> a(kNanos);
+  WrapperWithPlus<std::chrono::microseconds> b(kMicros);
+  EXPECT_EQ(*(a + b), kNanos + kMicros);
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -328,9 +328,7 @@ TEST(Typedef, ComparisonIsCorrect) {
 struct WrapperWithPlusTag : PlusTag {};
 
 template <typename T>
-struct WrapperWithPlus : Typedef<WrapperWithPlusTag, T> {
-  using Typedef<WrapperWithPlusTag, T>::Typedef;
-};
+using WrapperWithPlus = Typedef<WrapperWithPlusTag, T>;
 
 TEST(Typedef, WrapperWithPlusHasPlus) {
   constexpr int kAValue = 1;

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -66,7 +66,7 @@ class Typedef {
 
   template <typename... Args>
   constexpr explicit Typedef(std::in_place_t, Args&&... args)
-      : value_(T(std::forward<T>(args)...)) {}
+      : value_(T(std::forward<Args>(args)...)) {}
 
   constexpr Typedef() : value_{} {}
 
@@ -148,7 +148,8 @@ template <typename First, typename Second, typename FirstDecayed = std::decay_t<
               std::is_same_v<typename FirstDecayed::Tag, typename SecondDecayed::Tag>>,
           typename = std::enable_if_t<std::is_base_of_v<PlusTag, Tag>>>
 auto operator+(First&& lhs, Second&& rhs) {
-  return Typedef<Tag, decltype(*lhs + *rhs)>(*lhs + *rhs);
+  return Typedef<Tag, decltype(*std::forward<First>(lhs) + *std::forward<Second>(rhs))>(
+      *std::forward<First>(lhs) + *std::forward<Second>(rhs));
 };
 
 // Say, we have a pair of typedefs.

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -148,8 +148,7 @@ template <typename First, typename Second, typename FirstDecayed = std::decay_t<
               std::is_same_v<typename FirstDecayed::Tag, typename SecondDecayed::Tag>>,
           typename = std::enable_if_t<std::is_base_of_v<PlusTag, Tag>>>
 auto operator+(First&& lhs, Second&& rhs) {
-  const auto result = *lhs + *rhs;
-  return Typedef<Tag, decltype(result)>(result);
+  return Typedef<Tag, decltype(*lhs + *rhs)>(*lhs + *rhs);
 };
 
 // Say, we have a pair of typedefs.

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -139,6 +139,19 @@ class Typedef {
 template <typename Tag>
 class Typedef<Tag, void> {};
 
+// When the `Tag` is inherits from the struct, the `Typedef<Tag, T>` supports `operator+`
+struct PlusTag {};
+
+template <typename First, typename Second, typename FirstDecayed = std::decay_t<First>,
+          typename SecondDecayed = std::decay_t<Second>, typename Tag = typename FirstDecayed::Tag,
+          typename = std::enable_if_t<
+              std::is_same_v<typename FirstDecayed::Tag, typename SecondDecayed::Tag>>,
+          typename = std::enable_if_t<std::is_base_of_v<PlusTag, Tag>>>
+auto operator+(First&& lhs, Second&& rhs) {
+  const auto result = *lhs + *rhs;
+  return Typedef<Tag, decltype(result)>(result);
+};
+
 // Say, we have a pair of typedefs.
 // ```
 // const MyType<int> kFirstWrapped(1);


### PR DESCRIPTION
This adds `PlusTag`. The Typedefs of Tag that inherits from
`PlusTag` have `operator+` enabled.

Test: Unit
Bug: http://b/241077964