### PR TITLE
Add times-by-scalar for `Typedef`s

### DIFF
--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -382,7 +382,7 @@ TEST(Typedef, WrapperWithPlusHasPlusForMoveOnlyType) {
 }
 
 template <typename Scalar>
-struct WrapperWithTimesScalarTag : TimesScalar<Scalar> {};
+struct WrapperWithTimesScalarTag : TimesScalarTag<Scalar> {};
 
 template <typename T, typename Scalar>
 using WrapperWithTimesScalar = Typedef<WrapperWithTimesScalarTag<Scalar>, T>;

--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -367,6 +367,10 @@ struct MoveOnlyInt {
     return MoveOnlyInt(a.value + b.value);
   }
 
+  [[nodiscard]] friend MoveOnlyInt operator*(const MoveOnlyInt& a, std::unique_ptr<int> times) {
+    return MoveOnlyInt(a.value * (*times));
+  }
+
   int value;
 };
 
@@ -376,4 +380,25 @@ TEST(Typedef, WrapperWithPlusHasPlusForMoveOnlyType) {
 
   EXPECT_EQ((std::move(a_wrapped) + std::move(b_wrapped))->value, kAValue + kBValue);
 }
+
+template <typename Scalar>
+struct WrapperWithTimesScalarTag : TimesScalar<Scalar> {};
+
+template <typename T, typename Scalar>
+using WrapperWithTimesScalar = Typedef<WrapperWithTimesScalarTag<Scalar>, T>;
+
+TEST(Typedef, WrapperWithTimesScalarIntTimesFloat) {
+  WrapperWithTimesScalar<int, double> wrapped(2);
+  WrapperWithTimesScalar<double, double> half_of_wrapped = wrapped * 0.5;
+  EXPECT_EQ(*half_of_wrapped, 2 * 0.5);
+}
+
+TEST(Typedef, WrapperWithTimesScalarMoveOnly) {
+  WrapperWithTimesScalar<MoveOnlyInt, std::unique_ptr<int>> wrapped(std::in_place, kAValue);
+  auto times = std::make_unique<int>(kBValue);
+  WrapperWithTimesScalar<MoveOnlyInt, std::unique_ptr<int>> result =
+      std::move(wrapped) * std::move(times);
+  EXPECT_EQ(result->value, kAValue * kBValue);
+}
+
 }  // namespace orbit_base

--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -389,16 +389,33 @@ using WrapperWithTimesScalar = Typedef<WrapperWithTimesScalarTag<Scalar>, T>;
 
 TEST(Typedef, WrapperWithTimesScalarIntTimesFloat) {
   WrapperWithTimesScalar<int, double> wrapped(2);
-  WrapperWithTimesScalar<double, double> half_of_wrapped = wrapped * 0.5;
-  EXPECT_EQ(*half_of_wrapped, 2 * 0.5);
+  {
+    WrapperWithTimesScalar<double, double> half_of_wrapped = wrapped * 0.5;
+    EXPECT_EQ(*half_of_wrapped, 2 * 0.5);
+  }
+
+  {
+    WrapperWithTimesScalar<double, double> half_of_wrapped = 0.5 * wrapped;
+    EXPECT_EQ(*half_of_wrapped, 2 * 0.5);
+  }
 }
 
 TEST(Typedef, WrapperWithTimesScalarMoveOnly) {
-  WrapperWithTimesScalar<MoveOnlyInt, std::unique_ptr<int>> wrapped(std::in_place, kAValue);
-  auto times = std::make_unique<int>(kBValue);
-  WrapperWithTimesScalar<MoveOnlyInt, std::unique_ptr<int>> result =
-      std::move(wrapped) * std::move(times);
-  EXPECT_EQ(result->value, kAValue * kBValue);
+  {
+    auto times = std::make_unique<int>(kBValue);
+    WrapperWithTimesScalar<MoveOnlyInt, std::unique_ptr<int>> wrapped(std::in_place, kAValue);
+    WrapperWithTimesScalar<MoveOnlyInt, std::unique_ptr<int>> result =
+        std::move(wrapped) * std::move(times);
+    EXPECT_EQ(result->value, kAValue * kBValue);
+  }
+
+  {
+    auto times = std::make_unique<int>(kBValue);
+    WrapperWithTimesScalar<MoveOnlyInt, std::unique_ptr<int>> wrapped(std::in_place, kAValue);
+    WrapperWithTimesScalar<MoveOnlyInt, std::unique_ptr<int>> result =
+        std::move(times) * std::move(wrapped);
+    EXPECT_EQ(result->value, kAValue * kBValue);
+  }
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -139,7 +139,7 @@ class Typedef {
 template <typename Tag>
 class Typedef<Tag, void> {};
 
-// When the `Tag` is inherits from the struct, the `Typedef<Tag, T>` supports `operator+`
+// When the `Tag` inherits from the struct, the `Typedef<Tag, T>` supports `operator+`
 struct PlusTag {};
 
 template <typename First, typename Second, typename FirstDecayed = std::decay_t<First>,
@@ -151,6 +151,19 @@ auto operator+(First&& lhs, Second&& rhs) {
   return Typedef<Tag, decltype(*std::forward<First>(lhs) + *std::forward<Second>(rhs))>(
       *std::forward<First>(lhs) + *std::forward<Second>(rhs));
 };
+
+// When the `Tag` inherits from the struct, the `Typedef<Tag, T>` supports multiplication by
+// `Scalar` via `operator*`
+template <typename Scalar>
+struct TimesScalar {};
+
+template <typename Vector, typename Scalar, typename VectorDecayed = std::decay_t<Vector>,
+          typename ScalarDecayed = std::decay_t<Scalar>, typename Tag = typename VectorDecayed::Tag,
+          typename = std::enable_if_t<std::is_base_of_v<TimesScalar<Scalar>, Tag>>>
+auto operator*(Vector&& vector, Scalar&& scalar) {
+  return Typedef<Tag, decltype(*std::forward<Vector>(vector) * std::forward<Scalar>(scalar))>(
+      *std::forward<Vector>(vector) * std::forward<Scalar>(scalar));
+}
 
 // Say, we have a pair of typedefs.
 // ```

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -165,6 +165,13 @@ auto operator*(Vector&& vector, Scalar&& scalar) {
       *std::forward<Vector>(vector) * std::forward<Scalar>(scalar));
 }
 
+template <typename Vector, typename Scalar, typename VectorDecayed = std::decay_t<Vector>,
+          typename ScalarDecayed = std::decay_t<Scalar>, typename Tag = typename VectorDecayed::Tag,
+          typename = std::enable_if_t<std::is_base_of_v<TimesScalarTag<Scalar>, Tag>>>
+auto operator*(Scalar&& scalar, Vector&& vector) {
+  return std::forward<Vector>(vector) * std::forward<Scalar>(scalar);
+}
+
 // Say, we have a pair of typedefs.
 // ```
 // const MyType<int> kFirstWrapped(1);

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -155,11 +155,11 @@ auto operator+(First&& lhs, Second&& rhs) {
 // When the `Tag` inherits from the struct, the `Typedef<Tag, T>` supports multiplication by
 // `Scalar` via `operator*`
 template <typename Scalar>
-struct TimesScalar {};
+struct TimesScalarTag {};
 
 template <typename Vector, typename Scalar, typename VectorDecayed = std::decay_t<Vector>,
           typename ScalarDecayed = std::decay_t<Scalar>, typename Tag = typename VectorDecayed::Tag,
-          typename = std::enable_if_t<std::is_base_of_v<TimesScalar<Scalar>, Tag>>>
+          typename = std::enable_if_t<std::is_base_of_v<TimesScalarTag<Scalar>, Tag>>>
 auto operator*(Vector&& vector, Scalar&& scalar) {
   return Typedef<Tag, decltype(*std::forward<Vector>(vector) * std::forward<Scalar>(scalar))>(
       *std::forward<Vector>(vector) * std::forward<Scalar>(scalar));


### PR DESCRIPTION
This introduces `TimesScalarTag<Scalar>`. If the `Tag` of
a `Typedef` inherits from it, the latter supports multiplication by
`Scalar`.

Test: Unit
Bug: http://b/241110552