### PR TITLE
Treat warnings as errors on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,11 @@ if (MSVC)
   add_compile_options("/MP")
   # Set source and execution character sets to UTF-8.
   add_compile_options("/utf-8")
+  # Set warning level for external includes.
+  string(APPEND CMAKE_CXX_FLAGS " /experimental:external /external:anglebrackets /external:W0")
+  string(APPEND CMAKE_C_FLAGS " /experimental:external /external:anglebrackets /external:W0")
+  # Treat all compiler warnings as errors.
+  add_compile_options("/WX")
 endif()
 
 if(WIN32)

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -224,7 +224,7 @@ class DataView {
   int sorting_column_ = 0;
   std::string filter_;
   int update_period_ms_;
-  absl::flat_hash_set<uint64_t> selected_indices_;
+  absl::flat_hash_set<int> selected_indices_;
   DataViewType type_;
 
   AppInterface* app_ = nullptr;

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -224,7 +224,7 @@ class DataView {
   int sorting_column_ = 0;
   std::string filter_;
   int update_period_ms_;
-  absl::flat_hash_set<int> selected_indices_;
+  absl::flat_hash_set<uint64_t> selected_indices_;
   DataViewType type_;
 
   AppInterface* app_ = nullptr;


### PR DESCRIPTION
Treat warnings as errors on Windows using the "/WX" compiler flag.
We also silence warnings of external includes using the "/external" flag.

Please only consider the second commit which is only touching 
CMakeLists.txt

This replaces #4037, thanks for the suggestion @beckerhe .

Tests: compiled.