### PR TITLE
Update samples tab on callstack inspections

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2860,7 +2860,7 @@ void OrbitApp::SetCaptureDataSelectionFields(
 
 void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
                                      bool origin_is_multiple_threads) {
-  ClearInspection();
+  main_window_->ClearCallstackInspection();
   SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
   SetSelectionTopDownView(GetCaptureData().selection_post_processed_sampling_data(),
                           GetCaptureData());
@@ -2874,19 +2874,25 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
 void OrbitApp::InspectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
                                       bool origin_is_multiple_threads) {
   SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
-  main_window_->SetCallTreeInspection(CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
-                                          GetCaptureData().selection_post_processed_sampling_data(),
-                                          *module_manager_, GetCaptureData()),
-                                      CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
-                                          GetCaptureData().selection_post_processed_sampling_data(),
-                                          *module_manager_, GetCaptureData()));
+  auto report = std::make_shared<SamplingReport>(
+      this, &GetCaptureData().selection_callstack_data(),
+      &GetCaptureData().selection_post_processed_sampling_data(), metrics_uploader_,
+      /*generate_summary*/ origin_is_multiple_threads);
+  main_window_->SetCallstackInspection(
+      CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
+          GetCaptureData().selection_post_processed_sampling_data(), *module_manager_,
+          GetCaptureData()),
+      CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
+          GetCaptureData().selection_post_processed_sampling_data(), *module_manager_,
+          GetCaptureData()),
+      GetOrCreateSelectionCallstackDataView(), report);
   FireRefreshCallbacks();
 }
 
 void OrbitApp::ClearInspection() {
   SetCaptureDataSelectionFields(std::vector<CallstackEvent>(),
                                 /*origin_is_multiple_threads*/ false);
-  main_window_->ClearCallTreeInspection();
+  main_window_->ClearCallstackInspection();
   FireRefreshCallbacks();
 }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2874,7 +2874,7 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
 void OrbitApp::InspectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
                                       bool origin_is_multiple_threads) {
   SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
-  auto report = std::make_shared<SamplingReport>(
+  std::unique_ptr<SamplingReport> report = std::make_unique<SamplingReport>(
       this, &GetCaptureData().selection_callstack_data(),
       &GetCaptureData().selection_post_processed_sampling_data(), metrics_uploader_,
       /*generate_summary*/ origin_is_multiple_threads);
@@ -2885,7 +2885,7 @@ void OrbitApp::InspectCallstackEvents(const std::vector<CallstackEvent>& selecte
       CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
           GetCaptureData().selection_post_processed_sampling_data(), *module_manager_,
           GetCaptureData()),
-      GetOrCreateSelectionCallstackDataView(), report);
+      GetOrCreateSelectionCallstackDataView(), std::move(report));
   FireRefreshCallbacks();
 }
 

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -74,7 +74,7 @@ class MainWindowInterface {
   virtual void SetCallstackInspection(std::unique_ptr<CallTreeView> top_down_view,
                                       std::unique_ptr<CallTreeView> bottom_up_view,
                                       orbit_data_views::DataView* callstack_data_view,
-                                      const std::shared_ptr<class SamplingReport>& report) = 0;
+                                      std::unique_ptr<class SamplingReport> report) = 0;
   virtual void ClearCallstackInspection() = 0;
 };
 

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -71,9 +71,11 @@ class MainWindowInterface {
 
   virtual ~MainWindowInterface() = default;
 
-  virtual void SetCallTreeInspection(std::unique_ptr<CallTreeView> top_down_view,
-                                     std::unique_ptr<CallTreeView> bottom_up_view) = 0;
-  virtual void ClearCallTreeInspection() = 0;
+  virtual void SetCallstackInspection(std::unique_ptr<CallTreeView> top_down_view,
+                                      std::unique_ptr<CallTreeView> bottom_up_view,
+                                      orbit_data_views::DataView* callstack_data_view,
+                                      const std::shared_ptr<class SamplingReport>& report) = 0;
+  virtual void ClearCallstackInspection() = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -851,6 +851,8 @@ void OrbitMainWindow::UpdatePanel(DataViewType type) {
       ui->samplingReport->RefreshTabs();
       ui->selectionReport->RefreshCallstackView();
       ui->selectionReport->RefreshTabs();
+      ui->inspectionReport->RefreshCallstackView();
+      ui->inspectionReport->RefreshTabs();
       break;
     default:
       break;
@@ -1903,15 +1905,28 @@ void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Dura
             severity_name);
 }
 
-void OrbitMainWindow::SetCallTreeInspection(std::unique_ptr<CallTreeView> top_down_view,
-                                            std::unique_ptr<CallTreeView> bottom_up_view) {
+void OrbitMainWindow::SetCallstackInspection(std::unique_ptr<CallTreeView> top_down_view,
+                                             std::unique_ptr<CallTreeView> bottom_up_view,
+                                             orbit_data_views::DataView* callstack_data_view,
+                                             const std::shared_ptr<class SamplingReport>& report) {
   ui->topDownWidget->SetInspection(std::move(top_down_view));
   ui->bottomUpWidget->SetInspection(std::move(bottom_up_view));
+
+  ui->samplingReport->hide();
+  ui->inspectionReport->SetInspection(callstack_data_view, report);
+  connect(ui->inspectionReport, &OrbitSamplingReport::leaveCallstackInspectionTriggered, this,
+          &OrbitMainWindow::LeaveCallstackInspectionTriggered);
+  ui->inspectionReport->show();
 }
 
-void OrbitMainWindow::ClearCallTreeInspection() {
+void OrbitMainWindow::LeaveCallstackInspectionTriggered() { app_->ClearInspection(); }
+
+void OrbitMainWindow::ClearCallstackInspection() {
   ui->topDownWidget->ClearInspection();
   ui->bottomUpWidget->ClearInspection();
+  ui->inspectionReport->hide();
+  ui->inspectionReport->Deinitialize();
+  ui->samplingReport->show();
 }
 
 orbit_gl::MainWindowInterface::SymbolErrorHandlingResult OrbitMainWindow::HandleSymbolError(

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1914,12 +1914,10 @@ void OrbitMainWindow::SetCallstackInspection(std::unique_ptr<CallTreeView> top_d
 
   ui->samplingReport->hide();
   ui->inspectionReport->SetInspection(callstack_data_view, std::move(report));
-  connect(ui->inspectionReport, &OrbitSamplingReport::leaveCallstackInspectionTriggered, this,
-          &OrbitMainWindow::LeaveCallstackInspectionTriggered);
+  connect(ui->inspectionReport, &OrbitSamplingReport::LeaveCallstackInspectionClicked, this,
+          [this]() { app_->ClearInspection(); });
   ui->inspectionReport->show();
 }
-
-void OrbitMainWindow::LeaveCallstackInspectionTriggered() { app_->ClearInspection(); }
 
 void OrbitMainWindow::ClearCallstackInspection() {
   ui->topDownWidget->ClearInspection();

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1908,12 +1908,12 @@ void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Dura
 void OrbitMainWindow::SetCallstackInspection(std::unique_ptr<CallTreeView> top_down_view,
                                              std::unique_ptr<CallTreeView> bottom_up_view,
                                              orbit_data_views::DataView* callstack_data_view,
-                                             const std::shared_ptr<class SamplingReport>& report) {
+                                             std::unique_ptr<class SamplingReport> report) {
   ui->topDownWidget->SetInspection(std::move(top_down_view));
   ui->bottomUpWidget->SetInspection(std::move(bottom_up_view));
 
   ui->samplingReport->hide();
-  ui->inspectionReport->SetInspection(callstack_data_view, report);
+  ui->inspectionReport->SetInspection(callstack_data_view, std::move(report));
   connect(ui->inspectionReport, &OrbitSamplingReport::leaveCallstackInspectionTriggered, this,
           &OrbitMainWindow::LeaveCallstackInspectionTriggered);
   ui->inspectionReport->show();

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -137,7 +137,6 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
                               std::unique_ptr<class SamplingReport> report) override;
 
   void ClearCallstackInspection() override;
-  void LeaveCallstackInspectionTriggered();
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -131,10 +131,13 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
       const orbit_client_data::ModuleData* module) override;
 
-  void SetCallTreeInspection(std::unique_ptr<CallTreeView> top_down_view,
-                             std::unique_ptr<CallTreeView> bottom_up_view) override;
+  void SetCallstackInspection(std::unique_ptr<CallTreeView> top_down_view,
+                              std::unique_ptr<CallTreeView> bottom_up_view,
+                              orbit_data_views::DataView* callstack_data_view,
+                              const std::shared_ptr<class SamplingReport>& report) override;
 
-  void ClearCallTreeInspection() override;
+  void ClearCallstackInspection() override;
+  void LeaveCallstackInspectionTriggered();
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -134,7 +134,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void SetCallstackInspection(std::unique_ptr<CallTreeView> top_down_view,
                               std::unique_ptr<CallTreeView> bottom_up_view,
                               orbit_data_views::DataView* callstack_data_view,
-                              const std::shared_ptr<class SamplingReport>& report) override;
+                              std::unique_ptr<class SamplingReport> report) override;
 
   void ClearCallstackInspection() override;
   void LeaveCallstackInspectionTriggered();

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -270,6 +270,13 @@ QPushButton:disabled {
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="OrbitSamplingReport" name="inspectionReport" native="true">
+            <property name="visible">
+              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
         <widget class="QWidget" name="topDownTab">

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -139,6 +139,9 @@ void OrbitSamplingReport::Deinitialize() {
   ui_->CallstackTreeView->Deinitialize();
   orbit_data_views_.clear();
   ui_->tabWidget->clear();
+  if (sampling_report_) {
+    sampling_report_->ClearReport();
+  }
   sampling_report_.reset();
 }
 
@@ -199,9 +202,9 @@ void OrbitSamplingReport::OnLeaveInspectionButtonClicked() {
 }
 
 void OrbitSamplingReport::SetInspection(orbit_data_views::DataView* callstack_data_view,
-                                        const std::shared_ptr<SamplingReport>& report) {
+                                        std::unique_ptr<SamplingReport> report) {
   Deinitialize();
-  Initialize(callstack_data_view, report);
+  Initialize(callstack_data_view, std::move(report));
   connect(ui_->inspectionNoticeButton, &QPushButton::clicked, this,
           &OrbitSamplingReport::OnLeaveInspectionButtonClicked);
   ui_->inspectionNoticeWidget->show();

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -137,6 +137,9 @@ void OrbitSamplingReport::Deinitialize() {
     panel->Deinitialize();
   }
   ui_->CallstackTreeView->Deinitialize();
+  orbit_data_views_.clear();
+  ui_->tabWidget->clear();
+  sampling_report_.reset();
 }
 
 void OrbitSamplingReport::on_NextCallstackButton_clicked() {
@@ -152,6 +155,9 @@ void OrbitSamplingReport::on_PreviousCallstackButton_clicked() {
 }
 
 void OrbitSamplingReport::OnCurrentThreadTabChanged(int current_tab_index) {
+  if (current_tab_index == -1 || current_tab_index >= static_cast<int>(orbit_data_views_.size())) {
+    return;
+  }
   OrbitDataViewPanel* data_view = orbit_data_views_[current_tab_index];
   QModelIndexList index_list = data_view->GetTreeView()->selectionModel()->selectedIndexes();
   std::vector<int> row_list;
@@ -186,4 +192,19 @@ void OrbitSamplingReport::RefreshTabs() {
   for (OrbitDataViewPanel* panel : orbit_data_views_) {
     panel->Refresh();
   }
+}
+
+void OrbitSamplingReport::OnLeaveInspectionButtonClicked() {
+  emit leaveCallstackInspectionTriggered();
+}
+
+void OrbitSamplingReport::SetInspection(orbit_data_views::DataView* callstack_data_view,
+                                        const std::shared_ptr<SamplingReport>& report) {
+  Deinitialize();
+  Initialize(callstack_data_view, report);
+  connect(ui_->inspectionNoticeButton, &QPushButton::clicked, this,
+          &OrbitSamplingReport::OnLeaveInspectionButtonClicked);
+  ui_->inspectionNoticeWidget->show();
+  RefreshCallstackView();
+  RefreshTabs();
 }

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -197,16 +197,12 @@ void OrbitSamplingReport::RefreshTabs() {
   }
 }
 
-void OrbitSamplingReport::OnLeaveInspectionButtonClicked() {
-  emit leaveCallstackInspectionTriggered();
-}
-
 void OrbitSamplingReport::SetInspection(orbit_data_views::DataView* callstack_data_view,
                                         std::unique_ptr<SamplingReport> report) {
   Deinitialize();
   Initialize(callstack_data_view, std::move(report));
   connect(ui_->inspectionNoticeButton, &QPushButton::clicked, this,
-          &OrbitSamplingReport::OnLeaveInspectionButtonClicked);
+          &OrbitSamplingReport::LeaveCallstackInspectionClicked);
   ui_->inspectionNoticeWidget->show();
   RefreshCallstackView();
   RefreshTabs();

--- a/src/OrbitQt/orbitsamplingreport.h
+++ b/src/OrbitQt/orbitsamplingreport.h
@@ -11,7 +11,6 @@
 #include <memory>
 #include <vector>
 
-#include "DataViews/CallstackDataView.h"
 #include "DataViews/DataView.h"
 #include "orbitdataviewpanel.h"
 
@@ -35,10 +34,17 @@ class OrbitSamplingReport : public QWidget {
   void RefreshCallstackView();
   void RefreshTabs();
 
+  void SetInspection(orbit_data_views::DataView* callstack_data_view,
+                     const std::shared_ptr<SamplingReport>& report);
+
+ signals:
+  void leaveCallstackInspectionTriggered();
+
  private slots:
   void on_NextCallstackButton_clicked();
   void on_PreviousCallstackButton_clicked();
   void OnCurrentThreadTabChanged(int current_tab_index);
+  void OnLeaveInspectionButtonClicked();
 
  private:
   Ui::OrbitSamplingReport* ui_;

--- a/src/OrbitQt/orbitsamplingreport.h
+++ b/src/OrbitQt/orbitsamplingreport.h
@@ -35,7 +35,7 @@ class OrbitSamplingReport : public QWidget {
   void RefreshTabs();
 
   void SetInspection(orbit_data_views::DataView* callstack_data_view,
-                     const std::shared_ptr<SamplingReport>& report);
+                     std::unique_ptr<SamplingReport> report);
 
  signals:
   void leaveCallstackInspectionTriggered();

--- a/src/OrbitQt/orbitsamplingreport.h
+++ b/src/OrbitQt/orbitsamplingreport.h
@@ -38,13 +38,12 @@ class OrbitSamplingReport : public QWidget {
                      std::unique_ptr<SamplingReport> report);
 
  signals:
-  void leaveCallstackInspectionTriggered();
+  void LeaveCallstackInspectionClicked();
 
  private slots:
   void on_NextCallstackButton_clicked();
   void on_PreviousCallstackButton_clicked();
   void OnCurrentThreadTabChanged(int current_tab_index);
-  void OnLeaveInspectionButtonClicked();
 
  private:
   Ui::OrbitSamplingReport* ui_;

--- a/src/OrbitQt/orbitsamplingreport.ui
+++ b/src/OrbitQt/orbitsamplingreport.ui
@@ -20,19 +20,39 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
    <item row="0" column="1">
+    <widget class="QWidget" name="inspectionNoticeWidget" native="true">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">.QWidget{ border-radius: 5px; border: 1px solid palette(text) ; background: rgba(0,255,0, 10%);}</string>
+     </property>
+     <layout class="QGridLayout" name="inspectionNoticeLayout">
+      <item row="0" column="1">
+       <widget class="QPushButton" name="inspectionNoticeButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Leave Inspection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="inspectionNoticeLabel">
+        <property name="text">
+         <string>You are currently in an inspection, limiting the tree to specific callstacks.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1">
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -5,8 +5,6 @@
 #include "orbittreeview.h"
 
 #include <glad/glad.h>
-#include <qevent.h>
-#include <qitemselectionmodel.h>
 
 #include <QAbstractItemView>
 #include <QAction>
@@ -21,6 +19,7 @@
 #include <QMenu>
 #include <QModelIndexList>
 #include <QMouseEvent>
+#include <QResizeEvent>
 #include <QScrollBar>
 #include <QSize>
 #include <algorithm>

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -94,7 +94,9 @@ void OrbitTreeView::Initialize(orbit_data_views::DataView* data_view, SelectionT
     const QFont fixed_font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     setFont(fixed_font);
   }
-  // Manually trigger a resize event on Initialization.
+  // After a round of Deinitialize() and Initialize(), the table column sizes get reset and
+  // resizeEvent doesn't get called again. Manually trigger the event here to make sure they get set
+  // properly.
   QResizeEvent event = QResizeEvent(size(), QSize{-1, -1});
   resizeEvent(&event);
 }

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -5,8 +5,8 @@
 #include "orbittreeview.h"
 
 #include <glad/glad.h>
+#include <qevent.h>
 #include <qitemselectionmodel.h>
-#include <stddef.h>
 
 #include <QAbstractItemView>
 #include <QAction>
@@ -24,12 +24,11 @@
 #include <QScrollBar>
 #include <QSize>
 #include <algorithm>
+#include <cstddef>
 #include <set>
 #include <utility>
 
 #include "DataViews/DataView.h"
-#include "DataViews/DataViewType.h"
-#include "orbitglwidget.h"
 
 OrbitTreeView::OrbitTreeView(QWidget* parent) : QTreeView(parent) {
   header()->setSortIndicatorShown(true);
@@ -95,6 +94,9 @@ void OrbitTreeView::Initialize(orbit_data_views::DataView* data_view, SelectionT
     const QFont fixed_font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     setFont(fixed_font);
   }
+  // Manually trigger a resize event on Initialization.
+  QResizeEvent event = QResizeEvent(size(), QSize{-1, -1});
+  resizeEvent(&event);
 }
 
 void OrbitTreeView::Deinitialize() {


### PR DESCRIPTION
This updates the samples tab to show only the samples in an inspection
when an inspection is active.  It also adds a banner (already present in
top-down, bottom-up views) to make it clear that the user is only seeing
a subset of samples and to leave the inspection.

Screenshot: https://screenshot.googleplex.com/479vLTQntLKZhX8

Bug: http://b/240112046