### PR TITLE
Add StopCaptureReason for the early upload failure

### DIFF
--- a/src/CaptureServiceBase/CaptureServiceBase.cpp
+++ b/src/CaptureServiceBase/CaptureServiceBase.cpp
@@ -93,6 +93,9 @@ void CaptureServiceBase::FinalizeEventProcessing(
     case StopCaptureReason::kGuestOrcConnectionFailure:
       capture_finished = CreateFailedCaptureFinishedEvent("Connection with GuestOrc failed.");
       break;
+    case StopCaptureReason::kUploadFailure:
+      capture_finished = CreateFailedCaptureFinishedEvent("Upload failed early.");
+      break;
   }
 
   capture_finished.mutable_capture_finished()->set_target_process_state_after_capture(

--- a/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
+++ b/src/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.cpp
@@ -33,6 +33,11 @@ void CloudCollectorStartStopCaptureRequestWaiter::StartCapture(CaptureOptions ca
   start_requested_ = true;
 }
 
+bool CloudCollectorStartStopCaptureRequestWaiter::IsStartRequested() const {
+  absl::MutexLock lock(&mutex_);
+  return start_requested_;
+}
+
 CaptureServiceBase::StopCaptureReason
 CloudCollectorStartStopCaptureRequestWaiter::WaitForStopCaptureRequest() {
   absl::MutexLock lock(&mutex_);

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CaptureServiceBase.h
@@ -32,6 +32,7 @@ class CaptureServiceBase {
     kExceededMaxDurationLimit,
     kGuestOrcStop,
     kGuestOrcConnectionFailure,
+    kUploadFailure,
   };
 
   [[nodiscard]] CaptureInitializationResult InitializeCapture(

--- a/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/CloudCollectorStartStopCaptureRequestWaiter.h
@@ -26,6 +26,7 @@ class CloudCollectorStartStopCaptureRequestWaiter : public StopCaptureRequestWai
   // latter case, it will return an error message.
   [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::CaptureOptions> WaitForStartCaptureRequest();
   void StartCapture(orbit_grpc_protos::CaptureOptions capture_options);
+  [[nodiscard]] bool IsStartRequested() const;
 
   // WaitForStopCaptureRequest is blocked until StopCapture is called.
   [[nodiscard]] CaptureServiceBase::StopCaptureReason WaitForStopCaptureRequest() override;

--- a/src/CaptureServiceBase/include/CaptureServiceBase/StopCaptureReasonToString.h
+++ b/src/CaptureServiceBase/include/CaptureServiceBase/StopCaptureReasonToString.h
@@ -27,6 +27,8 @@ namespace orbit_capture_service_base {
       return "guestorc_stop";
     case CaptureServiceBase::StopCaptureReason::kGuestOrcConnectionFailure:
       return "guestorc_connection_failure";
+    case CaptureServiceBase::StopCaptureReason::kUploadFailure:
+      return "upload_failure";
   }
 
   ORBIT_UNREACHABLE();


### PR DESCRIPTION
With this change, we add a StopCaptureReason for the early upload
failure. The CloudCollector will call StopCapture with this reason if
the upload fails early and no stop is called yet.

Bug: http://b/240533627