### PR TITLE
Use orbit_client_data::ModuleIdentifier

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -62,8 +62,8 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
   std::map<uint64_t, orbit_client_data::ModuleInMemory> modules_in_memory_map =
       process_data.GetMemoryMapCopy();
   for (const auto& [unused_start_address, module_in_memory] : modules_in_memory_map) {
-    const ModuleData* module_data = module_manager.GetModuleByPathAndBuildId(
-        module_in_memory.file_path(), module_in_memory.build_id());
+    const ModuleData* module_data =
+        module_manager.GetModuleByModuleIdentifier(module_in_memory.module_id());
     if (module_data == nullptr) {
       continue;
     }
@@ -122,8 +122,7 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
   for (const auto& [function_id, function] : options.selected_functions) {
     InstrumentedFunction* instrumented_function = capture_options.add_instrumented_functions();
     instrumented_function->set_file_path(function.module_path());
-    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(function.module_path(),
-                                                                        function.module_build_id());
+    const ModuleData* module = module_manager.GetModuleByModuleIdentifier(function.module_id());
     ORBIT_CHECK(module != nullptr);
     instrumented_function->set_file_offset(function.ComputeFileOffset(*module));
     instrumented_function->set_file_build_id(function.module_build_id());
@@ -140,8 +139,7 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
         capture_options.add_functions_to_record_additional_stack_on();
 
     function_to_record_stack_on->set_file_path(function.module_path());
-    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(function.module_path(),
-                                                                        function.module_build_id());
+    const ModuleData* module = module_manager.GetModuleByModuleIdentifier(function.module_id());
     ORBIT_CHECK(module != nullptr);
     function_to_record_stack_on->set_file_offset(function.ComputeFileOffset(*module));
   }

--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -138,8 +138,8 @@ void CaptureData::ComputeVirtualAddressOfInstrumentedFunctionsIfNecessary(
       continue;
     }
 
-    const ModuleData* const module_data = module_manager.GetModuleByPathAndBuildId(
-        instrumented_function.file_path(), instrumented_function.file_build_id());
+    const ModuleData* const module_data = module_manager.GetModuleByModuleIdentifier(
+        ModuleIdentifier{instrumented_function.file_path(), instrumented_function.file_build_id()});
     if (module_data == nullptr) {
       continue;
     }

--- a/src/ClientData/ModuleAndFunctionLookup.cpp
+++ b/src/ClientData/ModuleAndFunctionLookup.cpp
@@ -78,10 +78,10 @@ std::optional<uint64_t> FindFunctionAbsoluteAddressByInstructionAbsoluteAddress(
                                                                                  absolute_address);
 }
 
-const FunctionInfo* FindFunctionByModulePathBuildIdAndVirtualAddress(
-    const ModuleManager& module_manager, const std::string& module_path,
-    const std::string& build_id, uint64_t virtual_address) {
-  const ModuleData* module_data = module_manager.GetModuleByPathAndBuildId(module_path, build_id);
+const FunctionInfo* FindFunctionByModuleIdentifierAndVirtualAddress(
+    const ModuleManager& module_manager, const ModuleIdentifier& module_id,
+    uint64_t virtual_address) {
+  const ModuleData* module_data = module_manager.GetModuleByModuleIdentifier(module_id);
   if (module_data == nullptr) {
     return nullptr;
   }

--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -5,10 +5,12 @@
 #include "ClientData/ProcessData.h"
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 
 #include <cstdint>
 #include <vector>
 
+#include "ClientData/ModuleIdentifier.h"
 #include "GrpcProtos/symbol.pb.h"
 #include "OrbitBase/Result.h"
 #include "absl/strings/str_format.h"
@@ -193,12 +195,11 @@ bool ProcessData::IsModuleLoadedByProcess(const ModuleData* module) const {
                      });
 }
 
-std::vector<std::pair<std::string, std::string>> ProcessData::GetUniqueModulesPathAndBuildId()
-    const {
+std::vector<ModuleIdentifier> ProcessData::GetUniqueModuleIdentifiers() const {
   absl::MutexLock lock(&mutex_);
-  std::set<std::pair<std::string, std::string>> module_keys;
+  absl::flat_hash_set<ModuleIdentifier> module_keys;
   for (const auto& [unused_address, module_in_memory] : start_address_to_module_in_memory_) {
-    module_keys.insert(std::make_pair(module_in_memory.file_path(), module_in_memory.build_id()));
+    module_keys.insert(module_in_memory.module_id());
   }
 
   return {module_keys.begin(), module_keys.end()};

--- a/src/ClientData/ProcessDataTest.cpp
+++ b/src/ClientData/ProcessDataTest.cpp
@@ -484,10 +484,10 @@ TEST(ProcessData, GetUniqueModulesPathAndBuildIds) {
   process.UpdateModuleInfos(module_infos);
   process.AddOrUpdateModuleInfo(module_info_3);
 
-  auto keys = process.GetUniqueModulesPathAndBuildId();
-  ASSERT_EQ(keys.size(), 2);
-  EXPECT_THAT(keys, testing::ElementsAre(testing::Pair(file_path_1, build_id_1),
-                                         testing::Pair(file_path_2, build_id_2)));
+  auto module_ids = process.GetUniqueModuleIdentifiers();
+  ASSERT_EQ(module_ids.size(), 2);
+  EXPECT_THAT(module_ids, testing::ElementsAre(ModuleIdentifier{file_path_1, build_id_1},
+                                               ModuleIdentifier{file_path_2, build_id_2}));
 }
 
 TEST(ProcessData, RemapModule) {

--- a/src/ClientData/ProcessDataTest.cpp
+++ b/src/ClientData/ProcessDataTest.cpp
@@ -486,8 +486,8 @@ TEST(ProcessData, GetUniqueModulesPathAndBuildIds) {
 
   auto module_ids = process.GetUniqueModuleIdentifiers();
   ASSERT_EQ(module_ids.size(), 2);
-  EXPECT_THAT(module_ids, testing::ElementsAre(ModuleIdentifier{file_path_1, build_id_1},
-                                               ModuleIdentifier{file_path_2, build_id_2}));
+  EXPECT_THAT(module_ids, testing::UnorderedElementsAre(ModuleIdentifier{file_path_1, build_id_1},
+                                                        ModuleIdentifier{file_path_2, build_id_2}));
 }
 
 TEST(ProcessData, RemapModule) {

--- a/src/ClientData/include/ClientData/FunctionInfo.h
+++ b/src/ClientData/include/ClientData/FunctionInfo.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <utility>
 
+#include "ClientData/ModuleIdentifier.h"
 #include "GrpcProtos/symbol.pb.h"
 
 namespace orbit_client_data {
@@ -39,6 +40,9 @@ class FunctionInfo {
 
   [[nodiscard]] const std::string& module_path() const { return module_path_; }
   [[nodiscard]] const std::string& module_build_id() const { return module_build_id_; }
+  [[nodiscard]] ModuleIdentifier module_id() const {
+    return ModuleIdentifier{module_path(), module_build_id()};
+  }
   // The virtual address as specified in the object file.
   [[nodiscard]] uint64_t address() const { return address_; }
   [[nodiscard]] uint64_t size() const { return size_; }

--- a/src/ClientData/include/ClientData/ModuleAndFunctionLookup.h
+++ b/src/ClientData/include/ClientData/ModuleAndFunctionLookup.h
@@ -6,6 +6,7 @@
 #define CLIENT_DATA_MODULE_AND_FUNCTION_LOOKUP_H_
 
 #include "CaptureData.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "FunctionInfo.h"
 #include "ModuleManager.h"
 #include "ProcessData.h"
@@ -22,9 +23,9 @@ const std::string kUnknownFunctionOrModuleName{"???"};
     const ModuleManager& module_manager, const CaptureData& capture_data,
     uint64_t absolute_address);
 
-[[nodiscard]] const FunctionInfo* FindFunctionByModulePathBuildIdAndVirtualAddress(
-    const ModuleManager& module_manager, const std::string& module_path,
-    const std::string& build_id, uint64_t virtual_address);
+[[nodiscard]] const FunctionInfo* FindFunctionByModuleIdentifierAndVirtualAddress(
+    const ModuleManager& module_manager, const ModuleIdentifier& module_id,
+    uint64_t virtual_address);
 
 [[nodiscard]] const std::string& GetModulePathByAddress(const ModuleManager& module_manager,
                                                         const CaptureData& capture_data,

--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "ClientData/FunctionInfo.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "GrpcProtos/module.pb.h"
 #include "GrpcProtos/symbol.pb.h"
 #include "absl/container/flat_hash_map.h"
@@ -38,6 +39,9 @@ class ModuleData final {
   }
   [[nodiscard]] uint64_t executable_segment_offset() const {
     return module_info_.executable_segment_offset();
+  }
+  [[nodiscard]] ModuleIdentifier module_id() const {
+    return ModuleIdentifier{file_path(), build_id()};
   }
   [[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> GetObjectSegments() const;
   [[nodiscard]] uint64_t ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_address) const;

--- a/src/ClientData/include/ClientData/ModuleManager.h
+++ b/src/ClientData/include/ClientData/ModuleManager.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "ClientData/ModuleData.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "ClientData/ProcessData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/module.pb.h"
@@ -27,10 +28,9 @@ class ModuleManager final {
   [[nodiscard]] ModuleData* GetMutableModuleByModuleInMemoryAndAbsoluteAddress(
       const ModuleInMemory& module_in_memory, uint64_t absolute_address);
 
-  [[nodiscard]] const ModuleData* GetModuleByPathAndBuildId(const std::string& path,
-                                                            const std::string& build_id) const;
-  [[nodiscard]] ModuleData* GetMutableModuleByPathAndBuildId(const std::string& path,
-                                                             const std::string& build_id);
+  [[nodiscard]] const ModuleData* GetModuleByModuleIdentifier(
+      const ModuleIdentifier& module_id) const;
+  [[nodiscard]] ModuleData* GetMutableModuleByModuleIdentifier(const ModuleIdentifier& module_id);
   // Add new modules for the module_infos that do not exist yet, and update the modules that do
   // exist. If the update changed the module in a way that symbols were not valid anymore, the
   // symbols are discarded aka the module is not loaded anymore. This method returns the list of
@@ -51,8 +51,8 @@ class ModuleManager final {
  private:
   mutable absl::Mutex mutex_;
   // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
-  // Map of <path, build_id> -> ModuleData
-  absl::node_hash_map<std::pair<std::string, std::string>, ModuleData> module_map_;
+  // Map of ModuleIdentifier -> ModuleData (ModuleIdentifier is file_path and build_id)
+  absl::node_hash_map<ModuleIdentifier, ModuleData> module_map_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "ClientData/ModuleData.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "GrpcProtos/module.pb.h"
 #include "GrpcProtos/process.pb.h"
 #include "GrpcProtos/symbol.pb.h"
@@ -39,6 +40,9 @@ class ModuleInMemory {
   [[nodiscard]] uint64_t end() const { return end_; }
   [[nodiscard]] const std::string& file_path() const { return file_path_; }
   [[nodiscard]] const std::string& build_id() const { return build_id_; }
+  [[nodiscard]] ModuleIdentifier module_id() const {
+    return ModuleIdentifier{file_path(), build_id()};
+  }
   [[nodiscard]] std::string FormattedAddressRange() const {
     return absl::StrFormat("[%016x - %016x]", start_, end_);
   }
@@ -84,8 +88,7 @@ class ProcessData final {
                                                              const std::string& build_id) const;
 
   [[nodiscard]] std::map<uint64_t, ModuleInMemory> GetMemoryMapCopy() const;
-  [[nodiscard]] std::vector<std::pair<std::string, std::string>> GetUniqueModulesPathAndBuildId()
-      const;
+  [[nodiscard]] std::vector<ModuleIdentifier> GetUniqueModuleIdentifiers() const;
 
   [[nodiscard]] std::vector<std::string> FindModuleBuildIdsByPath(
       const std::string& module_path) const;

--- a/src/CodeReport/DisassemblerTest.cpp
+++ b/src/CodeReport/DisassemblerTest.cpp
@@ -56,8 +56,8 @@ TEST(Disassembler, DisassembleWithSymbols) {
 
   orbit_client_data::ModuleManager module_manager{};
   (void)module_manager.AddOrUpdateModules({module_info});
-  orbit_client_data::ModuleData* module_data =
-      module_manager.GetMutableModuleByPathAndBuildId(kFilePath, kBuildId);
+  orbit_client_data::ModuleData* module_data = module_manager.GetMutableModuleByModuleIdentifier(
+      orbit_client_data::ModuleIdentifier{kFilePath, kBuildId});
 
   orbit_grpc_protos::ModuleSymbols symbols;
   orbit_grpc_protos::SymbolInfo* symbol = symbols.add_symbol_infos();

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -114,7 +114,8 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
       module_symbols.mutable_symbol_infos()->Add(std::move(symbol_info));
 
       orbit_client_data::ModuleData* module_data =
-          module_manager->GetMutableModuleByPathAndBuildId(kModulePaths[i], kModuleBuildIds[i]);
+          module_manager->GetMutableModuleByModuleIdentifier(
+              orbit_client_data::ModuleIdentifier{kModulePaths[i], kModuleBuildIds[i]});
       module_data->AddSymbols(module_symbols);
     }
   }

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -258,8 +258,8 @@ TEST_F(FunctionsDataViewTest, FrameTrackSelectionAppearsInFirstColumnWhenACaptur
   symbol_info.set_size(functions_[0].size());
   orbit_grpc_protos::ModuleSymbols module_symbols;
   module_symbols.mutable_symbol_infos()->Add(std::move(symbol_info));
-  orbit_client_data::ModuleData* module_data = module_manager.GetMutableModuleByPathAndBuildId(
-      functions_[0].module_path(), functions_[0].module_build_id());
+  orbit_client_data::ModuleData* module_data =
+      module_manager.GetMutableModuleByModuleIdentifier(functions_[0].module_id());
   module_data->AddSymbols(module_symbols);
 
   orbit_grpc_protos::CaptureStarted capture_started{};

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -30,6 +30,7 @@
 #include "ClientData/CaptureData.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ModuleAndFunctionLookup.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "ClientData/ScopeId.h"
 #include "ClientData/ScopeInfo.h"
 #include "ClientData/ScopeStats.h"
@@ -51,6 +52,7 @@
 using orbit_client_data::CaptureData;
 using orbit_client_data::FunctionInfo;
 using orbit_client_data::ModuleData;
+using orbit_client_data::ModuleIdentifier;
 using orbit_client_data::ModuleManager;
 using orbit_client_data::ScopeId;
 using orbit_client_data::ScopeStats;
@@ -501,9 +503,10 @@ void LiveFunctionsDataView::OnDataChanged() {
     const FunctionInfo* function_info_from_capture_data;
 
     function_info_from_capture_data =
-        orbit_client_data::FindFunctionByModulePathBuildIdAndVirtualAddress(
-            *module_manager, instrumented_function.file_path(),
-            instrumented_function.file_build_id(),
+        orbit_client_data::FindFunctionByModuleIdentifierAndVirtualAddress(
+            *module_manager,
+            ModuleIdentifier{instrumented_function.file_path(),
+                             instrumented_function.file_build_id()},
             instrumented_function.function_virtual_address());
 
     // This could happen because module has not yet been updated, it also
@@ -577,8 +580,8 @@ std::optional<int> LiveFunctionsDataView::GetRowFromScopeId(ScopeId scope_id) {
 
 std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrumentedFunction(
     const InstrumentedFunction& instrumented_function) {
-  const ModuleData* module_data = app_->GetModuleByPathAndBuildId(
-      instrumented_function.file_path(), instrumented_function.file_build_id());
+  const ModuleData* module_data = app_->GetModuleByModuleIdentifier(
+      ModuleIdentifier{instrumented_function.file_path(), instrumented_function.file_build_id()});
   if (module_data == nullptr) {
     return std::nullopt;
   }

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -185,8 +185,8 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
     orbit_grpc_protos::ModuleSymbols module_symbols;
     module_symbols.mutable_symbol_infos()->Add(std::move(symbol_info));
 
-    orbit_client_data::ModuleData* module_data =
-        module_manager->GetMutableModuleByPathAndBuildId(kModulePaths[i], kBuildIds[i]);
+    orbit_client_data::ModuleData* module_data = module_manager->GetMutableModuleByModuleIdentifier(
+        orbit_client_data::ModuleIdentifier{kModulePaths[i], kBuildIds[i]});
     module_data->AddSymbols(module_symbols);
 
     const FunctionInfo& function = *module_data->FindFunctionByVirtualAddress(kAddresses[i], true);

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -14,6 +14,7 @@
 #include "ClientData/CaptureData.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ModuleData.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "ClientData/ProcessData.h"
 #include "ClientData/ScopeId.h"
 #include "ClientProtos/capture_data.pb.h"
@@ -76,10 +77,10 @@ class MockAppInterface : public AppInterface {
 
   MOCK_METHOD(const orbit_client_data::ProcessData*, GetTargetProcess, (), (const, override));
 
-  MOCK_METHOD(const orbit_client_data::ModuleData*, GetModuleByPathAndBuildId,
-              (const std::string&, const std::string&), (const, override));
-  MOCK_METHOD(orbit_client_data::ModuleData*, GetMutableModuleByPathAndBuildId,
-              (const std::string&, const std::string&), (override));
+  MOCK_METHOD(const orbit_client_data::ModuleData*, GetModuleByModuleIdentifier,
+              (const orbit_client_data::ModuleIdentifier&), (const, override));
+  MOCK_METHOD(orbit_client_data::ModuleData*, GetMutableModuleByModuleIdentifier,
+              (const orbit_client_data::ModuleIdentifier&), (override));
   MOCK_METHOD(orbit_base::Future<void>, LoadSymbolsManually,
               (absl::Span<const orbit_client_data::ModuleData* const>), (override));
 

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -255,12 +255,11 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
   auto memory_map = process->GetMemoryMapCopy();
   indices_.clear();
   for (const auto& [start_address, module_in_memory] : memory_map) {
-    ModuleData* module = app_->GetMutableModuleByPathAndBuildId(module_in_memory.file_path(),
-                                                                module_in_memory.build_id());
+    ModuleData* module = app_->GetMutableModuleByModuleIdentifier(module_in_memory.module_id());
 
     // The module here cannot be a nullptr, because the call
-    // `app_->GetMutableModuleByPathAndBuildId` is relaying the call to
-    // `ModuleManager::GetMutableModuleByPathAndBuildId` and ModuleManager never deletes modules,
+    // `app_->GetMutableModuleByModuleIdentifier` is relaying the call to
+    // `ModuleManager::GetMutableModuleByModuleIdentifier` and ModuleManager never deletes modules,
     // only changes modules or adds new modules. And the memory_map cannot contain modules that are
     // not yet in ModuleManager, since these two locations get updated simultaneously.
     ORBIT_CHECK(module != nullptr);

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -79,8 +79,7 @@ class ModulesDataViewTest : public testing::Test {
       ORBIT_CHECK(index < kNumModules);
       view_.AddModule(
           modules_in_memory_[index].start(),
-          module_manager_.GetMutableModuleByPathAndBuildId(modules_in_memory_[index].file_path(),
-                                                           modules_in_memory_[index].build_id()),
+          module_manager_.GetMutableModuleByModuleIdentifier(modules_in_memory_[index].module_id()),
           modules_in_memory_[index]);
     }
   }
@@ -134,8 +133,8 @@ TEST_F(ModulesDataViewTest, ContextMenuEntriesArePresent) {
   // Load Symbols should be disabled when module is loaded successfully.
 
   const ModuleInMemory& module_in_memory = modules_in_memory_[kIndex];
-  ModuleData* module = module_manager_.GetMutableModuleByPathAndBuildId(
-      module_in_memory.file_path(), module_in_memory.build_id());
+  ModuleData* module =
+      module_manager_.GetMutableModuleByModuleIdentifier(module_in_memory.module_id());
   module->AddSymbols({});
   EXPECT_TRUE(module->is_loaded());
 
@@ -243,8 +242,8 @@ TEST_F(ModulesDataViewTest, ColumnSortingShowsRightResults) {
   using ViewRowEntry = std::array<std::string, kNumColumns>;
   std::vector<ViewRowEntry> view_entries;
   for (const ModuleInMemory& module_in_memory : modules_in_memory_) {
-    const ModuleData* module = module_manager_.GetMutableModuleByPathAndBuildId(
-        module_in_memory.file_path(), module_in_memory.build_id());
+    const ModuleData* module =
+        module_manager_.GetMutableModuleByModuleIdentifier(module_in_memory.module_id());
 
     ViewRowEntry entry;
     entry[kColumnName] = module->name();
@@ -308,8 +307,8 @@ TEST_F(ModulesDataViewTest, ColumnSortingShowsRightResults) {
 TEST_F(ModulesDataViewTest, SymbolLoadingColumnContent) {
   constexpr int kIndex = 0;
   AddModulesByIndices({kIndex});
-  const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
-      modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
+  const ModuleData* module =
+      module_manager_.GetModuleByModuleIdentifier(modules_in_memory_[kIndex].module_id());
 
   auto get_content_for = [this, module](SymbolLoadingState state) -> std::string {
     EXPECT_CALL(app_, GetSymbolLoadingStateForModule(module)).WillOnce(testing::Return(state));
@@ -327,8 +326,8 @@ TEST_F(ModulesDataViewTest, SymbolLoadingColumnContent) {
 TEST_F(ModulesDataViewTest, SymbolLoadingColor) {
   constexpr int kIndex = 0;
   AddModulesByIndices({kIndex});
-  const ModuleData* module = module_manager_.GetModuleByPathAndBuildId(
-      modules_in_memory_[kIndex].file_path(), modules_in_memory_[kIndex].build_id());
+  const ModuleData* module =
+      module_manager_.GetModuleByModuleIdentifier(modules_in_memory_[kIndex].module_id());
 
   auto check_color_correct_for = [this, module](SymbolLoadingState state) {
     uint8_t red = 0;

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -40,6 +40,7 @@
 using orbit_client_data::CaptureData;
 using orbit_client_data::FunctionInfo;
 using orbit_client_data::ModuleData;
+using orbit_client_data::ModuleIdentifier;
 using orbit_client_data::ModuleManager;
 using orbit_client_data::ProcessData;
 using orbit_client_data::SampledFunction;
@@ -206,8 +207,7 @@ const FunctionInfo* SamplingReportDataView::GetFunctionInfoFromRow(int row) {
   return sampled_function.function;
 }
 
-std::optional<std::pair<std::string, std::string>>
-SamplingReportDataView::GetModulePathAndBuildIdFromRow(int row) const {
+std::optional<ModuleIdentifier> SamplingReportDataView::GetModuleIdentifierFromRow(int row) const {
   const ProcessData* process = app_->GetCaptureData().process();
   ORBIT_CHECK(process != nullptr);
 
@@ -219,7 +219,7 @@ SamplingReportDataView::GetModulePathAndBuildIdFromRow(int row) const {
     return std::nullopt;
   }
 
-  return std::make_pair(result.value().file_path(), result.value().build_id());
+  return result.value().module_id();
 }
 
 DataView::ActionStatus SamplingReportDataView::GetActionStatus(
@@ -268,12 +268,10 @@ DataView::ActionStatus SamplingReportDataView::GetActionStatus(
 }
 
 ModuleData* SamplingReportDataView::GetModuleDataFromRow(int row) const {
-  std::optional<std::pair<std::string, std::string>> module_path_and_build_id =
-      GetModulePathAndBuildIdFromRow(row);
-  if (!module_path_and_build_id.has_value()) return nullptr;
+  std::optional<ModuleIdentifier> module_id_opt = GetModuleIdentifierFromRow(row);
+  if (!module_id_opt.has_value()) return nullptr;
 
-  return app_->GetMutableModuleByPathAndBuildId(module_path_and_build_id.value().first,
-                                                module_path_and_build_id.value().second);
+  return app_->GetMutableModuleByModuleIdentifier(module_id_opt.value());
 }
 
 void SamplingReportDataView::UpdateSelectedIndicesAndFunctionIds(

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -15,6 +15,7 @@
 #include "ClientData/CaptureDataHolder.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ModuleData.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "ClientData/PostProcessedSamplingData.h"
 #include "ClientData/ProcessData.h"
 #include "ClientProtos/capture_data.pb.h"
@@ -92,10 +93,10 @@ class AppInterface : public orbit_client_data::CaptureDataHolder {
 
   [[nodiscard]] virtual const orbit_client_data::ProcessData* GetTargetProcess() const = 0;
 
-  [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleByPathAndBuildId(
-      const std::string& path, const std::string& build_id) const = 0;
-  [[nodiscard]] virtual orbit_client_data::ModuleData* GetMutableModuleByPathAndBuildId(
-      const std::string& path, const std::string& build_id) = 0;
+  [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleByModuleIdentifier(
+      const orbit_client_data::ModuleIdentifier& module_id) const = 0;
+  [[nodiscard]] virtual orbit_client_data::ModuleData* GetMutableModuleByModuleIdentifier(
+      const orbit_client_data::ModuleIdentifier& module_id) = 0;
   virtual orbit_base::Future<void> LoadSymbolsManually(
       absl::Span<const orbit_client_data::ModuleData* const> modules) = 0;
 

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -11,6 +11,7 @@
 
 #include "ClientData/CallstackType.h"
 #include "ClientData/FunctionInfo.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "ClientData/PostProcessedSamplingData.h"
 #include "ClientModel/SamplingDataPostProcessor.h"
 #include "ClientProtos/capture_data.pb.h"
@@ -59,7 +60,7 @@ class SamplingReportDataView : public DataView {
   void DoFilter() override;
   const orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row) const;
   orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row);
-  [[nodiscard]] std::optional<std::pair<std::string, std::string>> GetModulePathAndBuildIdFromRow(
+  [[nodiscard]] std::optional<orbit_client_data::ModuleIdentifier> GetModuleIdentifierFromRow(
       int row) const;
 
  private:

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -227,7 +227,9 @@ void ManipulateModuleManagerToAddFunctionFromFunctionPrefixInSymtabIfExists(
   orbit_grpc_protos::ModuleSymbols module_symbols;
   module_symbols.mutable_symbol_infos()->Add(std::move(symbol_info));
 
-  module_manager->GetMutableModuleByPathAndBuildId(file_path, build_id)->AddSymbols(module_symbols);
+  module_manager
+      ->GetMutableModuleByModuleIdentifier(orbit_client_data::ModuleIdentifier{file_path, build_id})
+      ->AddSymbols(module_symbols);
 }
 
 uint32_t ReadPidFromFile(const std::string& file_path) {

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -80,8 +80,7 @@ void MizarData::UpdateModules(const std::vector<orbit_grpc_protos::ModuleInfo>& 
 void MizarData::LoadSymbolsForAllModules() {
   for (const orbit_client_data::ModuleData* module_data : module_manager_->GetAllModuleData()) {
     orbit_client_data::ModuleData* mutable_module_data =
-        module_manager_->GetMutableModuleByPathAndBuildId(module_data->file_path(),
-                                                          module_data->build_id());
+        module_manager_->GetMutableModuleByModuleIdentifier(module_data->module_id());
     LoadSymbols(*mutable_module_data);
   }
 }

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -24,6 +24,7 @@
 #include "CaptureClient/CaptureClient.h"
 #include "CaptureClient/CaptureListener.h"
 #include "ClientData/FunctionInfo.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "ClientData/ProcessData.h"
 #include "ClientModel/CaptureSerializer.h"
 #include "ClientModel/SamplingDataPostProcessor.h"
@@ -199,8 +200,8 @@ ErrorMessageOr<void> ClientGgp::LoadModuleAndSymbols() {
 
   // Process name can be arbitrary so we use the path to find the module corresponding to the binary
   // of target_process_
-  main_module_ = module_manager_.GetMutableModuleByPathAndBuildId(target_process_->full_path(),
-                                                                  target_process_build_id);
+  main_module_ = module_manager_.GetMutableModuleByModuleIdentifier(
+      orbit_client_data::ModuleIdentifier{target_process_->full_path(), target_process_build_id});
   if (main_module_ == nullptr) {
     return ErrorMessage("Error: Module corresponding to process binary not found");
   }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2554,7 +2554,7 @@ void OrbitApp::RefreshUIAfterModuleReload() {
   modules_data_view_->UpdateModules(GetTargetProcess());
 
   functions_data_view_->ClearFunctions();
-auto module_ids = GetTargetProcess()->GetUniqueModuleIdentifiers();
+  auto module_ids = GetTargetProcess()->GetUniqueModuleIdentifiers();
   for (const ModuleIdentifier& module_id : module_ids) {
     ModuleData* module = GetMutableModuleByModuleIdentifier(module_id);
     if (module->is_loaded()) {

--- a/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
@@ -29,7 +29,7 @@ void AnnotatingSourceCodeDialog::AddAnnotatingSourceCode(
   SetStatusMessage("Loading source location information", std::nullopt);
 
   ORBIT_CHECK(function_info_.has_value());
-  retrieve_module_with_debug_info_(function_info_->module_path(), function_info_->module_build_id())
+  retrieve_module_with_debug_info_(function_info_->module_id())
       .Then(main_thread_executor_.get(),
             [this](const ErrorMessageOr<std::filesystem::path>& local_file_path_or_error) {
               HandleDebugInfo(local_file_path_or_error);

--- a/src/OrbitQt/AnnotatingSourceCodeDialog.h
+++ b/src/OrbitQt/AnnotatingSourceCodeDialog.h
@@ -14,6 +14,7 @@
 
 #include "App.h"
 #include "ClientData/FunctionInfo.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "CodeReport/AnnotatingLine.h"
 #include "CodeReport/DisassemblyReport.h"
 #include "CodeViewer/FontSizeInEm.h"
@@ -48,8 +49,8 @@ class AnnotatingSourceCodeDialog : public orbit_code_viewer::Dialog {
 
   // Same interface as OrbitApp::RetrieveModuleWithDebugInfo;
   using RetrieveModuleWithDebugInfoCallback =
-      std::function<orbit_base::Future<ErrorMessageOr<std::filesystem::path>>(const std::string&,
-                                                                              const std::string&)>;
+      std::function<orbit_base::Future<ErrorMessageOr<std::filesystem::path>>(
+          const orbit_client_data::ModuleIdentifier&)>;
 
   void SetDisassemblyCodeReport(orbit_code_report::DisassemblyReport report) {
     report_ = std::move(report);

--- a/src/OrbitQt/AnnotatingSourceCodeDialogTest.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialogTest.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 
 #include "AnnotatingSourceCodeDialog.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "CodeReport/AnnotateDisassembly.h"
 #include "CodeReport/AnnotatingLine.h"
@@ -80,7 +81,7 @@ TEST(AnnotatingSourceCodeDialog, SmokeTest) {
   dialog.SetDisassemblyCodeReport(std::move(report));
 
   bool callback_called = false;
-  dialog.AddAnnotatingSourceCode(function_info, [&](const std::string&, const std::string&) {
+  dialog.AddAnnotatingSourceCode(function_info, [&](const orbit_client_data::ModuleIdentifier&) {
     callback_called = true;
     return orbit_base::Future<ErrorMessageOr<std::filesystem::path>>{file_path};
   });

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -73,6 +73,7 @@
 #include "CaptureClient/CaptureListener.h"
 #include "CaptureOptionsDialog.h"
 #include "ClientData/CaptureData.h"
+#include "ClientData/ModuleIdentifier.h"
 #include "ClientData/ProcessData.h"
 #include "ClientData/ScopeId.h"
 #include "ClientFlags/ClientFlags.h"
@@ -1867,10 +1868,10 @@ void OrbitMainWindow::ShowDisassembly(const orbit_client_data::FunctionInfo& fun
   QPointer<orbit_qt::AnnotatingSourceCodeDialog> dialog_ptr =
       OpenAndDeleteOnClose(std::move(dialog));
 
-  dialog_ptr->AddAnnotatingSourceCode(
-      function_info, [this](const std::string& module_path, const std::string& build_id) {
-        return app_->RetrieveModuleWithDebugInfo(module_path, build_id);
-      });
+  dialog_ptr->AddAnnotatingSourceCode(function_info,
+                                      [this](const orbit_client_data::ModuleIdentifier& module_id) {
+                                        return app_->RetrieveModuleWithDebugInfo(module_id);
+                                      });
 }
 
 void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Duration capture_time,


### PR DESCRIPTION
This uses the struct `ModuleIdentifier` in (almost) all places where
beforehand module path and build id was used separately. This occurred
mainly as `std::pair<std::string, std::string>` as key in maps. Or
parameters in the form of `const std::string& module_path, const
std::string& build_id`.

Test: Compiles and Unit tests are still green.
Bug: http://b/234586730

Sorry that this is one big change, but I did not find a reasonable way to split this up.