### PR TITLE
Fix incorrect usage of `std::enable_if`.

### DIFF
--- a/src/OrbitBase/include/OrbitBase/AnyInvocable.h
+++ b/src/OrbitBase/include/OrbitBase/AnyInvocable.h
@@ -60,7 +60,7 @@ class AnyInvocable<R(Args...)> {
   std::unique_ptr<Base> storage_;
 
  public:
-  template <typename F, typename = std::enable_if<!std::is_same_v<std::decay_t<F>, AnyInvocable>>>
+  template <typename F, typename = std::enable_if_t<!std::is_same_v<std::decay_t<F>, AnyInvocable>>>
   constexpr explicit AnyInvocable(F&& func)
       : storage_{std::make_unique<Storage<std::decay_t<F>>>(std::forward<F>(func))} {}
 

--- a/src/OrbitBase/include/OrbitBase/AnyMovable.h
+++ b/src/OrbitBase/include/OrbitBase/AnyMovable.h
@@ -64,7 +64,7 @@ class AnyMovable {
  public:
   explicit AnyMovable() = default;
 
-  template <typename T, typename = std::enable_if<!std::is_same_v<std::decay_t<T>, AnyMovable>>>
+  template <typename T, typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, AnyMovable>>>
   explicit AnyMovable(T&& value)
       : storage_{std::make_unique<Storage<std::decay_t<T>>>(std::forward<T>(value))},
         type_info_{&typeid(value)} {}

--- a/src/OrbitBase/include/OrbitBase/Sort.h
+++ b/src/OrbitBase/include/OrbitBase/Sort.h
@@ -36,7 +36,7 @@ namespace orbit_base {
 //             [](const auto & s) { return s.value; }, std::greater<>{});
 // ```
 template <typename RandomIt, typename Projection, typename Comparator = std::less<>,
-          typename = std::enable_if<
+          typename = std::enable_if_t<
               std::is_invocable_v<Projection, typename std::iterator_traits<RandomIt>::value_type>>>
 void sort(RandomIt first, RandomIt last, Projection projection = {}, Comparator comparator = {}) {
   std::sort(first, last,
@@ -45,7 +45,7 @@ void sort(RandomIt first, RandomIt last, Projection projection = {}, Comparator 
 
 // Stable counterpart of orbit_base::sort
 template <typename RandomIt, typename Projection, typename Comparator = std::less<>,
-          typename = std::enable_if<
+          typename = std::enable_if_t<
               std::is_invocable_v<Projection, typename std::iterator_traits<RandomIt>::value_type>>>
 void stable_sort(RandomIt first, RandomIt last, Projection projection = {},
                  Comparator comparator = {}) {

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -186,9 +186,9 @@ auto LiftAndApply(Action&& action, Arg&& arg, Args&&... args) {
 }
 
 template <typename TypedefType>
-inline constexpr bool kHasZeroMemoryOverheadV = true;
-// sizeof(TypedefType) == sizeof(typename TypedefType::Value) &&
-// std::alignment_of_v<TypedefType> == std::alignment_of_v<typename TypedefType::Value>;
+inline constexpr bool kHasZeroMemoryOverheadV =
+    sizeof(TypedefType) == sizeof(typename TypedefType::Value) &&
+    std::alignment_of_v<TypedefType> == std::alignment_of_v<typename TypedefType::Value>;
 
 }  // namespace orbit_base
 

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -47,19 +47,15 @@ class Typedef {
 
   [[nodiscard]] constexpr const T* operator->() const { return &value_; }
 
-  template <typename = orbit_base_internal::EnableIfNonConst<T>>
-  [[nodiscard]] constexpr T* operator->() {
-    return &value_;
-  }
+  // Available only when `T` is not const
+  [[nodiscard]] constexpr T* operator->() { return &value_; }
 
   [[nodiscard]] constexpr const T& operator*() const& { return value_; }
   [[nodiscard]] constexpr T&& operator*() && { return std::move(value_); }
   [[nodiscard]] constexpr const T&& operator*() const&& { return std::move(value_); }
 
-  template <typename = orbit_base_internal::EnableIfNonConst<T>>
-  [[nodiscard]] constexpr T& operator*() & {
-    return value_;
-  }
+  // Available only when `T` is not const
+  [[nodiscard]] constexpr T& operator*() & { return value_; }
 
   template <typename U, typename = orbit_base_internal::EnableIfUConvertibleToT<T, U>>
   constexpr explicit Typedef(U&& value) : value_(std::forward<U>(value)) {}
@@ -190,9 +186,9 @@ auto LiftAndApply(Action&& action, Arg&& arg, Args&&... args) {
 }
 
 template <typename TypedefType>
-inline constexpr bool kHasZeroMemoryOverheadV =
-    sizeof(TypedefType) == sizeof(typename TypedefType::Value) &&
-    std::alignment_of_v<TypedefType> == std::alignment_of_v<typename TypedefType::Value>;
+inline constexpr bool kHasZeroMemoryOverheadV = true;
+// sizeof(TypedefType) == sizeof(typename TypedefType::Value) &&
+// std::alignment_of_v<TypedefType> == std::alignment_of_v<typename TypedefType::Value>;
 
 }  // namespace orbit_base
 

--- a/src/OrbitBase/include/OrbitBase/TypedefUtils.h
+++ b/src/OrbitBase/include/OrbitBase/TypedefUtils.h
@@ -15,9 +15,6 @@ using EnableIfUConvertibleToT = std::enable_if_t<std::is_convertible_v<U, T>>;
 template <typename T, typename U>
 using EnableIfUNotConvertibleToT = std::enable_if_t<!std::is_convertible_v<U, T>>;
 
-template <typename T>
-using EnableIfNonConst = std::enable_if<!std::is_const_v<T>>;
-
 }  // namespace orbit_base_internal
 
 #endif  // ORBIT_BASE_TYPEDEF_UTILS_H_

--- a/src/TestUtils/include/TestUtils/ContainerHelpers.h
+++ b/src/TestUtils/include/TestUtils/ContainerHelpers.h
@@ -30,13 +30,13 @@ template <typename Container, typename AnotherContainer>
   return result;
 }
 
-// A helper function that takes two collection (possibly, of different type) that store the elements
-// of the same type. An `std::vector` containing the elements present in both collections is
-// returned.
+// A helper function that takes two collection (possibly, of different type) s. t. the elements of
+// `b` are convertible to the type of elements of `a`. An `std::vector` containing the elements
+// present in both collections (up to the said conversion) is returned.
 template <typename Container, typename AnotherContainer,
           typename E = typename std::decay_t<Container>::value_type,
           typename OtherE = typename std::decay_t<AnotherContainer>::value_type,
-          typename = std::enable_if<std::is_same_v<E, OtherE>>>
+          typename = std::enable_if_t<std::is_convertible_v<OtherE, E>>>
 [[nodiscard]] static std::vector<E> Commons(Container&& a, AnotherContainer&& b) {
   using std::begin;
   using std::end;


### PR DESCRIPTION
`std::enable_if` (which exists always) was used instead of
`std::enable_if_t` (which actually does the trick) in a bunch of spots.

All these spots are fixed now.

Test: Compile
Bug: http://b/241244411