### PR TITLE
Refactor perf event readers

### DIFF
--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -52,9 +52,9 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
   ORBIT_CHECK(current_maps != nullptr);
   ORBIT_CHECK(unwinder != nullptr);
 
-  const uint64_t rbp = event_data->GetRegisters()[PERF_REG_X86_BP];
-  const uint64_t rsp = event_data->GetRegisters()[PERF_REG_X86_SP];
-  const uint64_t rip = event_data->GetRegisters()[PERF_REG_X86_IP];
+  const uint64_t rbp = event_data->GetRegisters().bp;
+  const uint64_t rsp = event_data->GetRegisters().sp;
+  const uint64_t rip = event_data->GetRegisters().ip;
 
   if (rbp < rsp) {
     return Callstack::kFramePointerUnwindingError;
@@ -78,11 +78,11 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
   // include the previous frame pointer and the return address) for unwinding. If $rbp does not
   // change from unwinding, we need to patch in the pc after unwinding.
   const uint64_t stack_size = rbp - rsp + 16;
-  StackSliceView stack_slice{event_data->regs->sp, std::min<uint64_t>(stack_size, stack_dump_size_),
+  StackSliceView stack_slice{event_data->GetRegisters().sp, std::min<uint64_t>(stack_size, stack_dump_size_),
                              event_data->data.get()};
   std::vector<StackSliceView> stack_slices{stack_slice};
   const LibunwindstackResult& libunwindstack_result =
-      unwinder->Unwind(event_data->pid, current_maps->Get(), event_data->GetRegisters(),
+      unwinder->Unwind(event_data->pid, current_maps->Get(), event_data->GetRegistersAsArray(),
                        stack_slices, true, /*max_frames=*/1);
 
   // If unwinding a single frame yields a success, we are in the outer-most frame, i.e. we don't

--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -78,7 +78,8 @@ Callstack::CallstackType LeafFunctionCallManager::PatchCallerOfLeafFunction(
   // include the previous frame pointer and the return address) for unwinding. If $rbp does not
   // change from unwinding, we need to patch in the pc after unwinding.
   const uint64_t stack_size = rbp - rsp + 16;
-  StackSliceView stack_slice{event_data->GetRegisters().sp, std::min<uint64_t>(stack_size, stack_dump_size_),
+  StackSliceView stack_slice{event_data->GetRegisters().sp,
+                             std::min<uint64_t>(stack_size, stack_dump_size_),
                              event_data->data.get()};
   std::vector<StackSliceView> stack_slices{stack_slice};
   const LibunwindstackResult& libunwindstack_result =

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -550,11 +550,12 @@ TEST_F(LeafFunctionCallManagerTest,
             leaf_function_call_manager_.PatchCallerOfLeafFunction(&event_data, &maps_, &unwinder_));
 
   EXPECT_THAT(actual_stack_slices,
-              ElementsAre(AllOf(Property("start_address", &StackSliceView::start_address,
-                                         Eq(event_data.GetRegisters().sp)),
-                                Property("size", &StackSliceView::size,
-                                         Eq(event_data.GetRegisters().bp - event_data.GetRegisters().sp + 16)),
-                                Property("data", &StackSliceView::data, NotNull()))));
+              ElementsAre(AllOf(
+                  Property("start_address", &StackSliceView::start_address,
+                           Eq(event_data.GetRegisters().sp)),
+                  Property("size", &StackSliceView::size,
+                           Eq(event_data.GetRegisters().bp - event_data.GetRegisters().sp + 16)),
+                  Property("data", &StackSliceView::data, NotNull()))));
 
   EXPECT_THAT(
       event_data.CopyOfIpsAsVector(),

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -5,6 +5,7 @@
 #ifndef LINUX_TRACING_PERF_EVENT_H_
 #define LINUX_TRACING_PERF_EVENT_H_
 
+#include <absl/base/casts.h>
 #include <asm/perf_regs.h>
 #include <string.h>
 #include <sys/types.h>
@@ -63,8 +64,11 @@ struct DiscardedPerfEventData {
 using DiscardedPerfEvent = TypedPerfEvent<DiscardedPerfEventData>;
 
 struct StackSamplePerfEventData {
-  [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
-    return perf_event_sample_regs_user_all_to_register_array(*regs);
+  [[nodiscard]] const perf_event_sample_regs_user_all& GetRegisters() const {
+    return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
+  }
+  [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
+    return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   // Handing out this non const pointer makes the stack data mutable even if the
@@ -75,7 +79,7 @@ struct StackSamplePerfEventData {
 
   pid_t pid;
   pid_t tid;
-  std::unique_ptr<perf_event_sample_regs_user_all> regs;
+  std::unique_ptr<uint64_t[]> regs;
   uint64_t dyn_size;
   std::unique_ptr<uint8_t[]> data;
 };
@@ -84,8 +88,11 @@ using StackSamplePerfEvent = TypedPerfEvent<StackSamplePerfEventData>;
 struct CallchainSamplePerfEventData {
   [[nodiscard]] const uint64_t* GetCallchain() const { return ips.get(); }
   [[nodiscard]] uint64_t GetCallchainSize() const { return ips_size; }
-  [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
-    return perf_event_sample_regs_user_all_to_register_array(*regs);
+  [[nodiscard]] const perf_event_sample_regs_user_all& GetRegisters() const {
+    return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
+  }
+  [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
+    return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   void SetIps(const std::vector<uint64_t>& new_ips) const {
@@ -103,7 +110,7 @@ struct CallchainSamplePerfEventData {
   // LeafFunctionCallManager::PatchCallerOfLeafFunction.
   mutable uint64_t ips_size;
   mutable std::unique_ptr<uint64_t[]> ips;
-  std::unique_ptr<perf_event_sample_regs_user_all> regs;
+  std::unique_ptr<uint64_t[]> regs;
   std::unique_ptr<uint8_t[]> data;
 };
 using CallchainSamplePerfEvent = TypedPerfEvent<CallchainSamplePerfEventData>;
@@ -251,20 +258,42 @@ using DmaFenceSignaledPerfEvent = TypedPerfEvent<DmaFenceSignaledPerfEventData>;
 
 struct PerfRecordSample {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
 
-  mutable uint64_t ips_size;
-  mutable std::unique_ptr<uint64_t[]> ips;
+  uint64_t sample_id; /* if PERF_SAMPLE_IDENTIFIER */
+  uint64_t ip;        /* if PERF_SAMPLE_IP */
+  uint32_t pid, tid;  /* if PERF_SAMPLE_TID */
+  uint64_t time;      /* if PERF_SAMPLE_TIME */
+  uint64_t addr;      /* if PERF_SAMPLE_ADDR */
+  uint64_t id;        /* if PERF_SAMPLE_ID */
+  uint64_t stream_id; /* if PERF_SAMPLE_STREAM_ID */
+  uint32_t cpu, res;  /* if PERF_SAMPLE_CPU */
+  uint64_t period;    /* if PERF_SAMPLE_PERIOD */
 
-  uint32_t raw_size;
-  std::unique_ptr<uint8_t[]> raw_data;
+  // struct read_format v;                 /* if PERF_SAMPLE_READ */
 
-  uint64_t abi;
-  std::unique_ptr<perf_event_sample_regs_user_all> regs;
+  uint64_t ips_size;                       /* if PERF_SAMPLE_CALLCHAIN */
+  mutable std::unique_ptr<uint64_t[]> ips; /* if PERF_SAMPLE_CALLCHAIN */
 
-  uint64_t stack_size;
-  std::unique_ptr<uint8_t[]> stack_data;
-  uint64_t dyn_size;
+  uint32_t raw_size;                   /* if PERF_SAMPLE_RAW */
+  std::unique_ptr<uint8_t[]> raw_data; /* if PERF_SAMPLE_RAW */
+
+  // uint64_t bnr;                        /* if PERF_SAMPLE_BRANCH_STACK */
+  // struct perf_branch_entry lbr[bnr];   /* if PERF_SAMPLE_BRANCH_STACK */
+
+  uint64_t abi;                     /* if PERF_SAMPLE_REGS_USER */
+  std::unique_ptr<uint64_t[]> regs; /* if PERF_SAMPLE_REGS_USER */
+
+  uint64_t stack_size;                   /* if PERF_SAMPLE_STACK_USER */
+  std::unique_ptr<uint8_t[]> stack_data; /* if PERF_SAMPLE_STACK_USER */
+  uint64_t dyn_size;                     /* if PERF_SAMPLE_STACK_USER && size != 0 */
+
+  // uint64_t weight;                     /* if PERF_SAMPLE_WEIGHT */
+  // uint64_t data_src;                   /* if PERF_SAMPLE_DATA_SRC */
+  // uint64_t transaction;                /* if PERF_SAMPLE_TRANSACTION */
+  // uint64_t abi;                        /* if PERF_SAMPLE_REGS_INTR */
+  // uint64_t regs[weight(mask)];         /* if PERF_SAMPLE_REGS_INTR */
+  // uint64_t phys_addr;                  /* if PERF_SAMPLE_PHYS_ADDR */
+  // uint64_t cgroup;                     /* if PERF_SAMPLE_CGROUP */
 };
 
 // This struct holds the data we need from any of the possible perf_event_open events that we

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -249,6 +249,24 @@ struct DmaFenceSignaledPerfEventData {
 };
 using DmaFenceSignaledPerfEvent = TypedPerfEvent<DmaFenceSignaledPerfEventData>;
 
+struct PerfRecordSample {
+  perf_event_header header;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+
+  mutable uint64_t ips_size;
+  mutable std::unique_ptr<uint64_t[]> ips;
+
+  uint32_t raw_size;
+  std::unique_ptr<uint8_t[]> raw_data;
+
+  uint64_t abi;
+  std::unique_ptr<perf_event_sample_regs_user_all> regs;
+
+  uint64_t stack_size;
+  std::unique_ptr<uint8_t[]> stack_data;
+  uint64_t dyn_size;
+};
+
 // This struct holds the data we need from any of the possible perf_event_open events that we
 // collect. The top-level fields (`timestamp` and `ordered_in_file_descriptor`) are common to all
 // events, while each of the possible `...PerfEventData`s in the `std::variant` contains the data

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -256,6 +256,8 @@ struct DmaFenceSignaledPerfEventData {
 };
 using DmaFenceSignaledPerfEvent = TypedPerfEvent<DmaFenceSignaledPerfEventData>;
 
+// This struct is supposed to resemble the perf_record_sample, all commented out
+// fields are fields we don't currently use anywhere.
 struct PerfRecordSample {
   perf_event_header header;
 

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -18,11 +18,101 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/MakeUniqueForOverwrite.h"
 #include "OrbitBase/ThreadUtils.h"
+#include "PerfEvent.h"
 #include "PerfEventOrderedStream.h"
 #include "PerfEventRecords.h"
 #include "PerfEventRingBuffer.h"
 
 namespace orbit_linux_tracing {
+
+enum class ReadingFlags : int {
+  kReadNone = 0,
+  kReadHeader = (1 << 0),
+  // StandardFields are the fields in perf_event_sample_id_tid_time_streamid_cpu
+  kReadStandardFields = (1 << 1),
+  kReadCallchain = (1 << 2),
+  kReadRaw = (1 << 3),
+  kReadRegsUser = (1 << 4),
+  kReadStackUser = (1 << 5),
+};
+ReadingFlags operator|(ReadingFlags a, ReadingFlags b) {
+  return static_cast<ReadingFlags>(static_cast<int>(a) | static_cast<int>(b));
+}
+ReadingFlags operator&(ReadingFlags a, ReadingFlags b) {
+  return static_cast<ReadingFlags>(static_cast<int>(a) & static_cast<int>(b));
+}
+
+bool is_flag_set(ReadingFlags flag_collection, ReadingFlags flag_to_be_checked) {
+  return (flag_collection & flag_to_be_checked) != ReadingFlags::kReadNone;
+}
+
+PerfRecordSample ConsumeRecordSample(PerfEventRingBuffer* ring_buffer,
+                                     const perf_event_header& header, ReadingFlags flags) {
+  ORBIT_CHECK(header.size >
+              sizeof(perf_event_header) + sizeof(perf_event_sample_id_tid_time_streamid_cpu));
+
+  PerfRecordSample event;
+
+  // Note, the header and the standard fields are always present. These flags are to avoid
+  // unnecssary copying. Even if they're unset that doesn't mean that we can skip them when counting
+  // the offset.
+  if (is_flag_set(flags, ReadingFlags::kReadHeader)) {
+    ring_buffer->ReadRawAtOffset(&event.header, 0, sizeof(perf_event_header));
+  }
+
+  if (is_flag_set(flags, ReadingFlags::kReadStandardFields)) {
+    ring_buffer->ReadRawAtOffset(&event.sample_id, sizeof(perf_event_header),
+                                 sizeof(perf_event_sample_id_tid_time_streamid_cpu));
+  }
+
+  int current_offset =
+      sizeof(perf_event_sample_id_tid_time_streamid_cpu) + sizeof(perf_event_header);
+
+  if (is_flag_set(flags, ReadingFlags::kReadCallchain)) {
+    ring_buffer->ReadRawAtOffset(&event.ips_size, current_offset, sizeof(uint64_t));
+    current_offset += sizeof(uint64_t);
+    event.ips = make_unique_for_overwrite<uint64_t[]>(event.ips_size);
+    ring_buffer->ReadRawAtOffset(event.ips.get(), current_offset,
+                                 event.ips_size * sizeof(uint64_t));
+    current_offset += event.ips_size * sizeof(uint64_t);
+  }
+
+  if (is_flag_set(flags, ReadingFlags::kReadRaw)) {
+    ring_buffer->ReadRawAtOffset(&event.raw_size, current_offset, sizeof(uint32_t));
+    current_offset += sizeof(uint32_t);
+    event.raw_data = make_unique_for_overwrite<uint8_t[]>(event.raw_size);
+    ring_buffer->ReadRawAtOffset(event.raw_data.get(), current_offset,
+                                 event.raw_size * sizeof(uint8_t));
+    current_offset += event.raw_size * sizeof(uint8_t);
+  }
+
+  if (is_flag_set(flags, ReadingFlags::kReadRegsUser)) {
+    ring_buffer->ReadRawAtOffset(&event.abi, current_offset, sizeof(uint64_t));
+    if (event.abi != PERF_SAMPLE_REGS_ABI_NONE) {
+      event.regs = make_unique_for_overwrite<perf_event_sample_regs_user_all>();
+      ring_buffer->ReadRawAtOffset(event.regs.get(), current_offset,
+                                   sizeof(perf_event_sample_regs_user_all));
+      current_offset += sizeof(perf_event_sample_regs_user_all);
+    } else {
+      current_offset += sizeof(uint64_t);
+    }
+  }
+
+  if (is_flag_set(flags, ReadingFlags::kReadStackUser)) {
+    ring_buffer->ReadRawAtOffset(&event.stack_size, current_offset, sizeof(uint64_t));
+    current_offset += sizeof(uint64_t);
+    event.stack_data = make_unique_for_overwrite<uint8_t[]>(event.stack_size);
+    ring_buffer->ReadRawAtOffset(event.stack_data.get(), current_offset,
+                                 event.stack_size * sizeof(uint8_t));
+    current_offset += event.stack_size * sizeof(uint8_t);
+    if (event.stack_size != 0u) {
+      ring_buffer->ReadRawAtOffset(&event.dyn_size, current_offset, sizeof(uint64_t));
+      current_offset += sizeof(uint64_t);
+    }
+  }
+
+  return event;
+}
 
 void ReadPerfSampleIdAll(PerfEventRingBuffer* ring_buffer, const perf_event_header& header,
                          perf_event_sample_id_tid_time_streamid_cpu* sample_id) {

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -252,121 +252,54 @@ MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
 
 StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  // We expect the following layout of the perf event:
-  //  struct {
-  //    struct perf_event_header header;
-  //    u64 sample_id;          /* if PERF_SAMPLE_IDENTIFIER */
-  //    u32 pid, tid;           /* if PERF_SAMPLE_TID */
-  //    u64 time;               /* if PERF_SAMPLE_TIME */
-  //    u64 stream_id;          /* if PERF_SAMPLE_STREAM_ID */
-  //    u32 cpu, res;           /* if PERF_SAMPLE_CPU */
-  //    u64 abi;                /* if PERF_SAMPLE_REGS_USER */
-  //    u64 regs[weight(mask)]; /* if PERF_SAMPLE_REGS_USER */
-  //    u64 size;               /* if PERF_SAMPLE_STACK_USER */
-  //    char data[size];        /* if PERF_SAMPLE_STACK_USER */
-  //    u64 dyn_size;           /* if PERF_SAMPLE_STACK_USER && size != 0 */
-  //  };
-  // Unfortunately, the value of `size` is not constant, so we need to compute the offsets by hand,
-  // rather than relying on a struct.
+  perf_event_attr flags{};
 
-  size_t offset_of_size =
-      offsetof(perf_event_stack_sample_fixed, regs) + sizeof(perf_event_sample_regs_user_all);
-  size_t offset_of_data = offset_of_size + sizeof(uint64_t);
+  flags.sample_type =
+      PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
 
-  uint64_t size = 0;
-  ring_buffer->ReadValueAtOffset(&size, offset_of_size);
-
-  size_t offset_of_dyn_size = offset_of_data + (size * sizeof(char));
-
-  uint64_t dyn_size = 0;
-  ring_buffer->ReadValueAtOffset(&dyn_size, offset_of_dyn_size);
-
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  ring_buffer->ReadValueAtOffset(&sample_id, offsetof(perf_event_stack_sample_fixed, sample_id));
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
   StackSamplePerfEvent event{
-      .timestamp = sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
-              .pid = static_cast<pid_t>(sample_id.pid),
-              .tid = static_cast<pid_t>(sample_id.tid),
-              .regs = make_unique_for_overwrite<uint64_t[]>(20),
-              .dyn_size = dyn_size,
-              .data = make_unique_for_overwrite<uint8_t[]>(dyn_size),
+              .pid = static_cast<pid_t>(res.pid),
+              .tid = static_cast<pid_t>(res.tid),
+              .regs = std::move(res.regs),
+              .dyn_size = res.dyn_size,
+              .data = std::move(res.stack_data),
           },
   };
 
-  ring_buffer->ReadRawAtOffset(event.data.regs.get(), offsetof(perf_event_stack_sample_fixed, regs),
-                               20 * sizeof(uint64_t));
-  ring_buffer->ReadValueAtOffset(event.data.regs.get(),
-                                 offsetof(perf_event_stack_sample_fixed, regs));
-  ring_buffer->ReadRawAtOffset(event.data.data.get(), offset_of_data, dyn_size);
   ring_buffer->SkipRecord(header);
   return event;
 }
 
 CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                          const perf_event_header& header) {
-  // We expect the following layout of the perf event:
-  //  struct {
-  //    struct perf_event_header header;
-  //    u64 sample_id;          /* if PERF_SAMPLE_IDENTIFIER */
-  //    u32 pid, tid;           /* if PERF_SAMPLE_TID */
-  //    u64 time;               /* if PERF_SAMPLE_TIME */
-  //    u64 stream_id;          /* if PERF_SAMPLE_STREAM_ID */
-  //    u32 cpu, res;           /* if PERF_SAMPLE_CPU */
-  //    u64 nr;                 /* if PERF_SAMPLE_CALLCHAIN */
-  //    u64 ips[nr];            /* if PERF_SAMPLE_CALLCHAIN */
-  //    u64 abi;                /* if PERF_SAMPLE_REGS_USER */
-  //    u64 regs[weight(mask)]; /* if PERF_SAMPLE_REGS_USER */
-  //    u64 size;               /* if PERF_SAMPLE_STACK_USER */
-  //    char data[size];        /* if PERF_SAMPLE_STACK_USER */
-  //    u64 dyn_size;           /* if PERF_SAMPLE_STACK_USER && size != 0 */
-  //  };
-  // Unfortunately, the number of `ips` is dynamic, so we need to compute the offsets by hand,
-  // rather than relying on a struct.
-  uint64_t nr = 0;
-  ring_buffer->ReadValueAtOffset(&nr, offsetof(perf_event_callchain_sample_fixed, nr));
+  perf_event_attr flags{};
 
-  const uint64_t size_of_ips_in_bytes = nr * sizeof(uint64_t);
+  flags.sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | PERF_SAMPLE_CALLCHAIN |
+                      SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
 
-  const size_t offset_of_ips = offsetof(perf_event_callchain_sample_fixed, nr) +
-                               sizeof(perf_event_callchain_sample_fixed::nr);
-  const size_t offset_of_regs_user_struct = offset_of_ips + size_of_ips_in_bytes + sizeof(uint64_t);
-  // Note that perf_event_sample_regs_user_all contains abi and the regs array.
-  const size_t offset_of_size =
-      offset_of_regs_user_struct + sizeof(perf_event_sample_regs_user_all);
-  const size_t offset_of_data = offset_of_size + sizeof(uint64_t);
-
-  uint64_t size = 0;
-  ring_buffer->ReadRawAtOffset(&size, offset_of_size, sizeof(uint64_t));
-
-  const size_t offset_of_dyn_size = offset_of_data + size;
-  uint64_t dyn_size = 0;
-  ring_buffer->ReadRawAtOffset(&dyn_size, offset_of_dyn_size, sizeof(uint64_t));
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  ring_buffer->ReadValueAtOffset(&sample_id,
-                                 offsetof(perf_event_callchain_sample_fixed, sample_id));
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
   CallchainSamplePerfEvent event{
-      .timestamp = sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
-              .pid = static_cast<pid_t>(sample_id.pid),
-              .tid = static_cast<pid_t>(sample_id.tid),
-              .ips_size = nr,
-              .ips = make_unique_for_overwrite<uint64_t[]>(nr),
-              .regs = make_unique_for_overwrite<uint64_t[]>(20),
-              .data = make_unique_for_overwrite<uint8_t[]>(dyn_size),
+              .pid = static_cast<pid_t>(res.pid),
+              .tid = static_cast<pid_t>(res.tid),
+              .ips_size = res.ips_size,
+              .ips = std::move(res.ips),
+              .regs = std::move(res.regs),
+              .data = std::move(res.stack_data),
           },
   };
-
-  ring_buffer->ReadRawAtOffset(event.data.ips.get(), offset_of_ips, size_of_ips_in_bytes);
-  ring_buffer->ReadRawAtOffset(event.data.regs.get(), offset_of_regs_user_struct,
-                               sizeof(perf_event_sample_regs_user_all));
-  ring_buffer->ReadRawAtOffset(event.data.data.get(), offset_of_data, dyn_size);
 
   ring_buffer->SkipRecord(header);
   return event;
@@ -430,16 +363,21 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
 
 GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                              const perf_event_header& header) {
-  perf_event_raw_sample_fixed ring_buffer_record;
-  ring_buffer->ReadRawAtOffset(&ring_buffer_record, 0, sizeof(perf_event_raw_sample_fixed));
+  perf_event_attr flags{};
+
+  flags.sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
+
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
+
   GenericTracepointPerfEvent event{
-      .timestamp = ring_buffer_record.sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
-              .pid = static_cast<pid_t>(ring_buffer_record.sample_id.pid),
-              .tid = static_cast<pid_t>(ring_buffer_record.sample_id.tid),
-              .cpu = ring_buffer_record.sample_id.cpu,
+              .pid = static_cast<pid_t>(res.pid),
+              .tid = static_cast<pid_t>(res.tid),
+              .cpu = res.cpu,
           },
   };
 
@@ -449,31 +387,26 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
 
 SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  ORBIT_CHECK(header.size >= sizeof(perf_event_raw_sample_fixed));
-  perf_event_raw_sample_fixed ring_buffer_record;
-  ring_buffer->ReadRawAtOffset(&ring_buffer_record, 0, sizeof(perf_event_raw_sample_fixed));
+  perf_event_attr flags{};
 
-  // The last fields of the sched:sched_wakeup tracepoint aren't always the same, depending on the
-  // kernel version. Fortunately we only need the first fields, which are always the same, so only
-  // read those. See `sched_wakeup_tracepoint_fixed`.
-  ORBIT_CHECK(ring_buffer_record.size >= sizeof(sched_wakeup_tracepoint_fixed));
+  flags.sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
+
   sched_wakeup_tracepoint_fixed sched_wakeup;
-  ring_buffer->ReadRawAtOffset(
-      &sched_wakeup,
-      offsetof(perf_event_raw_sample_fixed, size) + sizeof(perf_event_raw_sample_fixed::size),
-      sizeof(sched_wakeup_tracepoint_fixed));
+  memcpy(&sched_wakeup, res.raw_data.get(), sizeof(sched_wakeup_tracepoint_fixed));
 
   ring_buffer->SkipRecord(header);
   return SchedWakeupPerfEvent{
-      .timestamp = ring_buffer_record.sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
               // The tracepoint format calls the woken tid "data.pid" but it's effectively the
               // thread id.
               .woken_tid = sched_wakeup.pid,
-              .was_unblocked_by_tid = static_cast<pid_t>(ring_buffer_record.sample_id.tid),
-              .was_unblocked_by_pid = static_cast<pid_t>(ring_buffer_record.sample_id.pid),
+              .was_unblocked_by_tid = static_cast<pid_t>(res.tid),
+              .was_unblocked_by_pid = static_cast<pid_t>(res.pid),
           },
   };
 }

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -6,6 +6,7 @@
 #define LINUX_TRACING_PERF_EVENT_RECORDS_H_
 
 #include <cstdint>
+
 #include "PerfEventOpen.h"
 
 namespace orbit_linux_tracing {

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -40,7 +40,7 @@ struct __attribute__((__packed__)) perf_event_fork_exit {
 
 // This struct must be in sync with the SAMPLE_REGS_USER_ALL in PerfEventOpen.h.
 struct __attribute__((__packed__)) perf_event_sample_regs_user_all {
-  uint64_t abi;
+  // uint64_t abi;
   uint64_t ax;
   uint64_t bx;
   uint64_t cx;

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -41,7 +41,6 @@ struct __attribute__((__packed__)) perf_event_fork_exit {
 
 // This struct must be in sync with the SAMPLE_REGS_USER_ALL in PerfEventOpen.h.
 struct __attribute__((__packed__)) perf_event_sample_regs_user_all {
-  // uint64_t abi;
   uint64_t ax;
   uint64_t bx;
   uint64_t cx;

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -5,6 +5,7 @@
 #ifndef LINUX_TRACING_PERF_EVENT_RECORDS_H_
 #define LINUX_TRACING_PERF_EVENT_RECORDS_H_
 
+#include <cstdint>
 #include "PerfEventOpen.h"
 
 namespace orbit_linux_tracing {
@@ -104,6 +105,7 @@ struct __attribute__((__packed__)) perf_event_sample_stack_user_8bytes {
 struct __attribute__((__packed__)) perf_event_stack_sample_fixed {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  uint64_t abi;
   perf_event_sample_regs_user_all regs;
   // Following this field there are the following fields, which we read dynamically:
   // uint64_t size;                     /* if PERF_SAMPLE_STACK_USER */

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -1204,8 +1204,7 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
 
     const size_t size_of_stack_sample = sizeof(perf_event_stack_sample_fixed) +
                                         2 * sizeof(uint64_t) /*size and dyn_size*/ +
-                                        stack_dump_size_ /*data*/
-                                        + sizeof(uint64_t) /*abi*/;
+                                        stack_dump_size_ /*data*/;
 
     if (header.size != size_of_stack_sample) {
       // Skip stack samples that have an unexpected size. These normally have

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -1200,7 +1200,6 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
     ++stats_.uprobes_count;
 
   } else if (is_stack_sample) {
-    ORBIT_LOG("YES...1");
     pid_t pid = ReadSampleRecordPid(ring_buffer);
 
     const size_t size_of_stack_sample = sizeof(perf_event_stack_sample_fixed) +
@@ -1215,12 +1214,10 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
       // always the case: for example, when a process exits while tracing, we
       // might get a stack sample with pid and tid != 0 but still with
       // abi == PERF_SAMPLE_REGS_ABI_NONE and size == 0.
-      ORBIT_LOG("YES...2");
       ring_buffer->SkipRecord(header);
       return timestamp_ns;
     }
     if (pid != target_pid_) {
-      ORBIT_LOG("YES...3");
       ring_buffer->SkipRecord(header);
       return timestamp_ns;
     }
@@ -1228,7 +1225,6 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
     // e.g., with header.misc == PERF_RECORD_MISC_KERNEL,
     // in general they seem to produce valid callstacks.
 
-    ORBIT_LOG("YES...4");
     StackSamplePerfEvent event = ConsumeStackSamplePerfEvent(ring_buffer, header);
     DeferEvent(std::move(event));
     ++stats_.sample_count;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -219,10 +219,10 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
   ORBIT_CHECK(listener_ != nullptr);
   ORBIT_CHECK(current_maps_ != nullptr);
 
-  return_address_manager_->PatchSample(event_data.tid, event_data.GetRegisters()[PERF_REG_X86_SP],
+  return_address_manager_->PatchSample(event_data.tid, event_data.GetRegisters().sp,
                                        event_data.GetMutableStackData(), event_data.GetStackSize());
 
-  StackSliceView event_stack_slice{event_data.regs->sp, event_data.GetStackSize(),
+  StackSliceView event_stack_slice{event_data.GetRegisters().sp, event_data.GetStackSize(),
                                    event_data.data.get()};
   std::vector<StackSliceView> stack_slices{event_stack_slice};
 
@@ -235,7 +235,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
   }
 
   LibunwindstackResult libunwindstack_result = unwinder_->Unwind(
-      event_data.pid, current_maps_->Get(), event_data.GetRegisters(), stack_slices);
+      event_data.pid, current_maps_->Get(), event_data.GetRegistersAsArray(), stack_slices);
 
   if (libunwindstack_result.frames().empty()) {
     // Even with unwinding errors this is not expected because we should at least get the program

--- a/src/LinuxTracing/UprobesUnwindingVisitorSampleTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorSampleTest.cpp
@@ -212,7 +212,7 @@ StackSamplePerfEvent BuildFakeStackSamplePerfEvent() {
           {
               .pid = 10,
               .tid = 11,
-              .regs = std::make_unique<perf_event_sample_regs_user_all>(),
+              .regs = make_unique_for_overwrite<uint64_t[]>(20),
               .dyn_size = kStackSize,
               .data = std::make_unique<uint8_t[]>(kStackSize),
           },
@@ -227,7 +227,7 @@ CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(const std::vector<uin
           {
               .pid = 10,
               .tid = 11,
-              .regs = std::make_unique<perf_event_sample_regs_user_all>(),
+              .regs = make_unique_for_overwrite<uint64_t[]>(20),
               .data = std::make_unique<uint8_t[]>(kStackSize),
           },
   };
@@ -273,7 +273,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest,
                                                       &discarded_samples_in_uretprobes_counter);
 
   uint64_t dyn_size = event.data.dyn_size;
-  uint64_t sp = event.data.regs->sp;
+  uint64_t sp = event.data.GetRegisters().sp;
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
   EXPECT_THAT(actual_stack_slices,
@@ -1025,7 +1025,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesUserSpaceStack) {
   PerfEvent{std::move(user_stack_event)}.Accept(&visitor_);
 
   uint64_t dyn_size = event.data.dyn_size;
-  uint64_t sp = event.data.regs->sp;
+  uint64_t sp = event.data.GetRegisters().sp;
   uint8_t* stack_data = event.data.data.get();
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
@@ -1132,7 +1132,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesLatestUserSpaceCal
   PerfEvent{std::move(user_stack_event_new)}.Accept(&visitor_);
 
   uint64_t dyn_size = event.data.dyn_size;
-  uint64_t sp = event.data.regs->sp;
+  uint64_t sp = event.data.GetRegisters().sp;
   uint8_t* stack_data = event.data.data.get();
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
@@ -1240,7 +1240,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest,
   PerfEvent{std::move(user_stack_event_other_thread)}.Accept(&visitor_);
 
   uint64_t dyn_size = event.data.dyn_size;
-  uint64_t sp = event.data.regs->sp;
+  uint64_t sp = event.data.GetRegisters().sp;
   uint8_t* stack_data = event.data.data.get();
   PerfEvent{std::move(event)}.Accept(&visitor_);
 
@@ -1349,7 +1349,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesUserStackMemoryFro
   PerfEvent{std::move(user_stack_event2)}.Accept(&visitor_);
 
   uint64_t dyn_size = event.data.dyn_size;
-  uint64_t sp = event.data.regs->sp;
+  uint64_t sp = event.data.GetRegisters().sp;
   uint8_t* stack_data = event.data.data.get();
   PerfEvent{std::move(event)}.Accept(&visitor_);
 


### PR DESCRIPTION
This PR will show how the new consumer function will look after using the main consumer `ConsumeRecordSample()`, not all functions were refactored to use `ConsumeRecordSample()`

Bug: http://b/241339791