### PR TITLE
Implement operator+ for Typedefs of different Tag

### DIFF
--- a/src/MizarBase/include/MizarBase/Time.h
+++ b/src/MizarBase/include/MizarBase/Time.h
@@ -12,7 +12,7 @@
 
 namespace orbit_mizar_base {
 
-struct RelativeTimestampTag : orbit_base::PlusTag {};
+struct RelativeTimestampTag : orbit_base::PlusTag<RelativeTimestampTag> {};
 
 // wraps `uint64_t` bears semantics of time in nanoseconds and implements a non-wrapping addition
 struct NonWrappingNanoseconds {

--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -325,7 +325,7 @@ TEST(Typedef, ComparisonIsCorrect) {
   EXPECT_GT(MyType<int>(kGreater), MyType<int>(kLesser));
 }
 
-struct WrapperWithPlusTag : PlusTag {};
+struct WrapperWithPlusTag : PlusTag<WrapperWithPlusTag> {};
 
 template <typename T>
 using WrapperWithPlus = Typedef<WrapperWithPlusTag, T>;
@@ -386,7 +386,7 @@ TEST(Typedef, WrapperWithPlusHasPlusForMoveOnlyType) {
 }
 
 struct DistanceTag {};
-struct CoordinateTag : MinusTag<DistanceTag> {};
+struct CoordinateTag : MinusTag<DistanceTag>, PlusTag<DistanceTag> {};
 
 template <typename T>
 using Distance = Typedef<DistanceTag, T>;
@@ -401,6 +401,21 @@ TEST(Typedef, CoordinateHasMinusForMoveOnlyType) {
   Distance<MoveOnlyInt> distance = std::move(a) - std::move(b);
 
   EXPECT_EQ(distance->value, kAValue - kBValue);
+}
+
+TEST(Typedef, CoordinateHasPlusForMoveOnlyType) {
+  {
+    Coordinate<MoveOnlyInt> origin(std::in_place, kAValue);
+    Distance<MoveOnlyInt> distance(std::in_place, kBValue);
+    Coordinate<MoveOnlyInt> coordinate = std::move(origin) + std::move(distance);
+    EXPECT_EQ(coordinate->value, kAValue + kBValue);
+  }
+  {
+    Coordinate<MoveOnlyInt> origin(std::in_place, kAValue);
+    Distance<MoveOnlyInt> distance(std::in_place, kBValue);
+    Coordinate<MoveOnlyInt> coordinate = std::move(distance) + std::move(origin);
+    EXPECT_EQ(coordinate->value, kAValue + kBValue);
+  }
 }
 
 template <typename Scalar>

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -136,7 +136,7 @@ template <typename Tag>
 class Typedef<Tag, void> {};
 
 // When the `Tag` inherits from the struct, the `Typedef<Tag, T>` supports `operator+` with other
-// `Typedef<OtherSummandTag, T>`. The result is wrapped into `Typedef<Tag, T>`.
+// `Typedef<OtherSummandTag, T>`. The result is wrapped into a Typedef of tag `Tag`.
 template <typename OtherSummandTag>
 struct PlusTag {
   using PlusOtherSummandTag = OtherSummandTag;
@@ -157,7 +157,8 @@ template <typename First, typename Second, typename FirstDecayed = std::decay_t<
           typename SecondTag = typename SecondDecayed::Tag,
           typename = std::enable_if_t<!std::is_base_of_v<PlusTag<SecondTag>, FirstTag>>>
 auto operator+(First&& lhs, Second&& rhs) {
-  return std::forward<Second>(rhs) + std::forward<First>(lhs);
+  return Typedef<SecondTag, decltype(*std::forward<First>(lhs) + *std::forward<Second>(rhs))>(
+      *std::forward<First>(lhs) + *std::forward<Second>(rhs));
 };
 
 // When the `Tag` inherits from the struct, the `Typedef<Tag, T>` `operator-`. The result will be

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -135,17 +135,29 @@ class Typedef {
 template <typename Tag>
 class Typedef<Tag, void> {};
 
-// When the `Tag` inherits from the struct, the `Typedef<Tag, T>` supports `operator+`
-struct PlusTag {};
+// When the `Tag` inherits from the struct, the `Typedef<Tag, T>` supports `operator+` with other
+// `Typedef<OtherSummandTag, T>`. The result is wrapped into `Typedef<Tag, T>`.
+template <typename OtherSummandTag>
+struct PlusTag {
+  using PlusOtherSummandTag = OtherSummandTag;
+};
 
 template <typename First, typename Second, typename FirstDecayed = std::decay_t<First>,
           typename SecondDecayed = std::decay_t<Second>, typename Tag = typename FirstDecayed::Tag,
           typename = std::enable_if_t<
-              std::is_same_v<typename FirstDecayed::Tag, typename SecondDecayed::Tag>>,
-          typename = std::enable_if_t<std::is_base_of_v<PlusTag, Tag>>>
+              std::is_same_v<typename Tag::PlusOtherSummandTag, typename SecondDecayed::Tag>>>
 auto operator+(First&& lhs, Second&& rhs) {
   return Typedef<Tag, decltype(*std::forward<First>(lhs) + *std::forward<Second>(rhs))>(
       *std::forward<First>(lhs) + *std::forward<Second>(rhs));
+};
+
+template <typename First, typename Second, typename FirstDecayed = std::decay_t<First>,
+          typename SecondDecayed = std::decay_t<Second>,
+          typename FirstTag = typename FirstDecayed::Tag,
+          typename SecondTag = typename SecondDecayed::Tag,
+          typename = std::enable_if_t<!std::is_base_of_v<PlusTag<SecondTag>, FirstTag>>>
+auto operator+(First&& lhs, Second&& rhs) {
+  return std::forward<Second>(rhs) + std::forward<First>(lhs);
 };
 
 // When the `Tag` inherits from the struct, the `Typedef<Tag, T>` `operator-`. The result will be


### PR DESCRIPTION
This would allow for symmetry with `operator-`

Bug: http://b/241776644
Test: Compile, Unit