### PR TITLE
Refactor a part of PerfEventReaders

### DIFF
--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -296,9 +296,8 @@ MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
 
 StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  // The flags here should be in sync with stack_sample_event_open in
-  // PerfEventOpen.
-  // TODO(): use the same perf_event_attr object from stack_sample_event_open
+  // The flags here are in sync with stack_sample_event_open in PerfEventOpen.
+  // TODO(b/242020362): use the same perf_event_attr object from stack_sample_event_open
   const perf_event_attr flags{
       .sample_type =
           PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
@@ -326,9 +325,8 @@ StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffe
 
 CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                          const perf_event_header& header) {
-  // The flags here should be in sync with callchain_sample_event_open in
-  // PerfEventOpen.
-  // TODO(): use the same perf_event_attr object from callchain_sample_event_open
+  // The flags here are in sync with callchain_sample_event_open in PerfEventOpen.
+  // TODO(b/242020362): use the same perf_event_attr object from callchain_sample_event_open
   const perf_event_attr flags{
       .sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | PERF_SAMPLE_CALLCHAIN |
                      SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
@@ -413,9 +411,8 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
 
 GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                              const perf_event_header& header) {
-  // The flags here should be in sync with generic_event_attr in
-  // PerfEventOpen.
-  // TODO(): use the same perf_event_attr object from generic_event_attr
+  // The flags here are in sync with generic_event_attr in PerfEventOpen.
+  // TODO(b/242020362): use the same perf_event_attr object from generic_event_attr
   const perf_event_attr flags{
       .sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
   };
@@ -439,9 +436,8 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
 
 SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  // The flags here should be in sync with tracepoint_event_open in
-  // PerfEventOpen.
-  // TODO(): use the same perf_event_attr object from tracepoint_event_open
+  // The flags here are in sync with tracepoint_event_open in PerfEventOpen.
+  // TODO(b/242020362): use the same perf_event_attr object from tracepoint_event_open
   const perf_event_attr flags{
       .sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
   };

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -296,11 +296,11 @@ MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
 
 StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  perf_event_attr flags{};
-
-  flags.sample_type =
-      PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
-  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  const perf_event_attr flags{
+      .sample_type =
+          PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
+      .sample_regs_user = SAMPLE_REGS_USER_ALL,
+  };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
@@ -323,11 +323,11 @@ StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffe
 
 CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                          const perf_event_header& header) {
-  perf_event_attr flags{};
-
-  flags.sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | PERF_SAMPLE_CALLCHAIN |
-                      SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
-  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  const perf_event_attr flags{
+      .sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | PERF_SAMPLE_CALLCHAIN |
+                     SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
+      .sample_regs_user = SAMPLE_REGS_USER_ALL,
+  };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
@@ -407,10 +407,9 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
 
 GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                              const perf_event_header& header) {
-  perf_event_attr flags{};
-
-  flags.sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
-  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  const perf_event_attr flags{
+      .sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
+  };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
@@ -431,14 +430,14 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
 
 SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  perf_event_attr flags{};
-
-  flags.sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+  const perf_event_attr flags{
+      .sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
+  };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
   sched_wakeup_tracepoint_fixed sched_wakeup;
-  memcpy(&sched_wakeup, res.raw_data.get(), sizeof(sched_wakeup_tracepoint_fixed));
+  std::memcpy(&sched_wakeup, res.raw_data.get(), sizeof(sched_wakeup_tracepoint_fixed));
 
   ring_buffer->SkipRecord(header);
   return SchedWakeupPerfEvent{

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -68,8 +68,9 @@ struct PerfRecordSample {
   // uint64_t cgroup;                     /* if PERF_SAMPLE_CGROUP */
 };
 
-[[nodiscard]] [[maybe_unused]] static PerfRecordSample ConsumeRecordSample(
-    PerfEventRingBuffer* ring_buffer, const perf_event_header& header, perf_event_attr flags) {
+[[nodiscard]] static PerfRecordSample ConsumeRecordSample(PerfEventRingBuffer* ring_buffer,
+                                                          const perf_event_header& header,
+                                                          perf_event_attr flags) {
   ORBIT_CHECK(header.size >
               sizeof(perf_event_header) + sizeof(perf_event_sample_id_tid_time_streamid_cpu));
 
@@ -295,127 +296,54 @@ MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
 
 StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  // We expect the following layout of the perf event:
-  //  struct {
-  //    struct perf_event_header header;
-  //    u64 sample_id;          /* if PERF_SAMPLE_IDENTIFIER */
-  //    u32 pid, tid;           /* if PERF_SAMPLE_TID */
-  //    u64 time;               /* if PERF_SAMPLE_TIME */
-  //    u64 stream_id;          /* if PERF_SAMPLE_STREAM_ID */
-  //    u32 cpu, res;           /* if PERF_SAMPLE_CPU */
-  //    u64 abi;                /* if PERF_SAMPLE_REGS_USER */
-  //    u64 regs[weight(mask)]; /* if PERF_SAMPLE_REGS_USER */
-  //    u64 size;               /* if PERF_SAMPLE_STACK_USER */
-  //    char data[size];        /* if PERF_SAMPLE_STACK_USER */
-  //    u64 dyn_size;           /* if PERF_SAMPLE_STACK_USER && size != 0 */
-  //  };
-  // Unfortunately, the value of `size` is not constant, so we need to compute the offsets by hand,
-  // rather than relying on a struct.
+  perf_event_attr flags{};
 
-  size_t offset_of_size =
-      offsetof(perf_event_stack_sample_fixed, regs) + sizeof(perf_event_sample_regs_user_all);
-  size_t offset_of_data = offset_of_size + sizeof(uint64_t);
+  flags.sample_type =
+      PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
 
-  uint64_t size = 0;
-  ring_buffer->ReadValueAtOffset(&size, offset_of_size);
-
-  size_t offset_of_dyn_size = offset_of_data + (size * sizeof(char));
-
-  uint64_t dyn_size = 0;
-  ring_buffer->ReadValueAtOffset(&dyn_size, offset_of_dyn_size);
-
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  ring_buffer->ReadValueAtOffset(&sample_id, offsetof(perf_event_stack_sample_fixed, sample_id));
-
-  constexpr uint64_t kTotalNumOfRegisters =
-      sizeof(perf_event_sample_regs_user_all) / sizeof(uint64_t);
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
   StackSamplePerfEvent event{
-      .timestamp = sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
-              .pid = static_cast<pid_t>(sample_id.pid),
-              .tid = static_cast<pid_t>(sample_id.tid),
-              .regs = make_unique_for_overwrite<uint64_t[]>(kTotalNumOfRegisters),
-              .dyn_size = dyn_size,
-              .data = make_unique_for_overwrite<uint8_t[]>(dyn_size),
+              .pid = static_cast<pid_t>(res.pid),
+              .tid = static_cast<pid_t>(res.tid),
+              .regs = std::move(res.regs),
+              .dyn_size = res.dyn_size,
+              .data = std::move(res.stack_data),
           },
   };
 
-  ring_buffer->ReadRawAtOffset(event.data.regs.get(), offsetof(perf_event_stack_sample_fixed, regs),
-                               kTotalNumOfRegisters * sizeof(uint64_t));
-  ring_buffer->ReadValueAtOffset(event.data.regs.get(),
-                                 offsetof(perf_event_stack_sample_fixed, regs));
-  ring_buffer->ReadRawAtOffset(event.data.data.get(), offset_of_data, dyn_size);
   ring_buffer->SkipRecord(header);
   return event;
 }
 
 CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                          const perf_event_header& header) {
-  // We expect the following layout of the perf event:
-  //  struct {
-  //    struct perf_event_header header;
-  //    u64 sample_id;          /* if PERF_SAMPLE_IDENTIFIER */
-  //    u32 pid, tid;           /* if PERF_SAMPLE_TID */
-  //    u64 time;               /* if PERF_SAMPLE_TIME */
-  //    u64 stream_id;          /* if PERF_SAMPLE_STREAM_ID */
-  //    u32 cpu, res;           /* if PERF_SAMPLE_CPU */
-  //    u64 nr;                 /* if PERF_SAMPLE_CALLCHAIN */
-  //    u64 ips[nr];            /* if PERF_SAMPLE_CALLCHAIN */
-  //    u64 abi;                /* if PERF_SAMPLE_REGS_USER */
-  //    u64 regs[weight(mask)]; /* if PERF_SAMPLE_REGS_USER */
-  //    u64 size;               /* if PERF_SAMPLE_STACK_USER */
-  //    char data[size];        /* if PERF_SAMPLE_STACK_USER */
-  //    u64 dyn_size;           /* if PERF_SAMPLE_STACK_USER && size != 0 */
-  //  };
-  // Unfortunately, the number of `ips` is dynamic, so we need to compute the offsets by hand,
-  // rather than relying on a struct.
-  uint64_t nr = 0;
-  ring_buffer->ReadValueAtOffset(&nr, offsetof(perf_event_callchain_sample_fixed, nr));
+  perf_event_attr flags{};
 
-  const uint64_t size_of_ips_in_bytes = nr * sizeof(uint64_t);
+  flags.sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | PERF_SAMPLE_CALLCHAIN |
+                      SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
 
-  const size_t offset_of_ips = offsetof(perf_event_callchain_sample_fixed, nr) +
-                               sizeof(perf_event_callchain_sample_fixed::nr);
-  const size_t offset_of_regs_user_struct = offset_of_ips + size_of_ips_in_bytes + sizeof(uint64_t);
-  // Note that perf_event_sample_regs_user_all contains abi and the regs array.
-  const size_t offset_of_size =
-      offset_of_regs_user_struct + sizeof(perf_event_sample_regs_user_all);
-  const size_t offset_of_data = offset_of_size + sizeof(uint64_t);
-
-  uint64_t size = 0;
-  ring_buffer->ReadRawAtOffset(&size, offset_of_size, sizeof(uint64_t));
-
-  const size_t offset_of_dyn_size = offset_of_data + size;
-  uint64_t dyn_size = 0;
-  ring_buffer->ReadRawAtOffset(&dyn_size, offset_of_dyn_size, sizeof(uint64_t));
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  ring_buffer->ReadValueAtOffset(&sample_id,
-                                 offsetof(perf_event_callchain_sample_fixed, sample_id));
-
-  constexpr uint64_t kTotalNumOfRegisters =
-      sizeof(perf_event_sample_regs_user_all) / sizeof(uint64_t);
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
   CallchainSamplePerfEvent event{
-      .timestamp = sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
-              .pid = static_cast<pid_t>(sample_id.pid),
-              .tid = static_cast<pid_t>(sample_id.tid),
-              .ips_size = nr,
-              .ips = make_unique_for_overwrite<uint64_t[]>(nr),
-              .regs = make_unique_for_overwrite<uint64_t[]>(kTotalNumOfRegisters),
-              .data = make_unique_for_overwrite<uint8_t[]>(dyn_size),
+              .pid = static_cast<pid_t>(res.pid),
+              .tid = static_cast<pid_t>(res.tid),
+              .ips_size = res.ips_size,
+              .ips = std::move(res.ips),
+              .regs = std::move(res.regs),
+              .data = std::move(res.stack_data),
           },
   };
-
-  ring_buffer->ReadRawAtOffset(event.data.ips.get(), offset_of_ips, size_of_ips_in_bytes);
-  ring_buffer->ReadRawAtOffset(event.data.regs.get(), offset_of_regs_user_struct,
-                               sizeof(perf_event_sample_regs_user_all));
-  ring_buffer->ReadRawAtOffset(event.data.data.get(), offset_of_data, dyn_size);
 
   ring_buffer->SkipRecord(header);
   return event;
@@ -479,16 +407,21 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
 
 GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                              const perf_event_header& header) {
-  perf_event_raw_sample_fixed ring_buffer_record;
-  ring_buffer->ReadRawAtOffset(&ring_buffer_record, 0, sizeof(perf_event_raw_sample_fixed));
+  perf_event_attr flags{};
+
+  flags.sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+  flags.sample_regs_user = SAMPLE_REGS_USER_ALL;
+
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
+
   GenericTracepointPerfEvent event{
-      .timestamp = ring_buffer_record.sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
-              .pid = static_cast<pid_t>(ring_buffer_record.sample_id.pid),
-              .tid = static_cast<pid_t>(ring_buffer_record.sample_id.tid),
-              .cpu = ring_buffer_record.sample_id.cpu,
+              .pid = static_cast<pid_t>(res.pid),
+              .tid = static_cast<pid_t>(res.tid),
+              .cpu = res.cpu,
           },
   };
 
@@ -498,31 +431,26 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
 
 SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
-  ORBIT_CHECK(header.size >= sizeof(perf_event_raw_sample_fixed));
-  perf_event_raw_sample_fixed ring_buffer_record;
-  ring_buffer->ReadRawAtOffset(&ring_buffer_record, 0, sizeof(perf_event_raw_sample_fixed));
+  perf_event_attr flags{};
 
-  // The last fields of the sched:sched_wakeup tracepoint aren't always the same, depending on the
-  // kernel version. Fortunately we only need the first fields, which are always the same, so only
-  // read those. See `sched_wakeup_tracepoint_fixed`.
-  ORBIT_CHECK(ring_buffer_record.size >= sizeof(sched_wakeup_tracepoint_fixed));
+  flags.sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
+
   sched_wakeup_tracepoint_fixed sched_wakeup;
-  ring_buffer->ReadRawAtOffset(
-      &sched_wakeup,
-      offsetof(perf_event_raw_sample_fixed, size) + sizeof(perf_event_raw_sample_fixed::size),
-      sizeof(sched_wakeup_tracepoint_fixed));
+  memcpy(&sched_wakeup, res.raw_data.get(), sizeof(sched_wakeup_tracepoint_fixed));
 
   ring_buffer->SkipRecord(header);
   return SchedWakeupPerfEvent{
-      .timestamp = ring_buffer_record.sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
               // The tracepoint format calls the woken tid "data.pid" but it's effectively the
               // thread id.
               .woken_tid = sched_wakeup.pid,
-              .was_unblocked_by_tid = static_cast<pid_t>(ring_buffer_record.sample_id.tid),
-              .was_unblocked_by_pid = static_cast<pid_t>(ring_buffer_record.sample_id.pid),
+              .was_unblocked_by_tid = static_cast<pid_t>(res.tid),
+              .was_unblocked_by_pid = static_cast<pid_t>(res.pid),
           },
   };
 }

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -296,6 +296,9 @@ MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
 
 StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
+  // The flags here should be in sync with stack_sample_event_open in
+  // PerfEventOpen.
+  // TODO(): use the same perf_event_attr object from stack_sample_event_open
   const perf_event_attr flags{
       .sample_type =
           PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
@@ -323,6 +326,9 @@ StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffe
 
 CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
                                                          const perf_event_header& header) {
+  // The flags here should be in sync with callchain_sample_event_open in
+  // PerfEventOpen.
+  // TODO(): use the same perf_event_attr object from callchain_sample_event_open
   const perf_event_attr flags{
       .sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | PERF_SAMPLE_CALLCHAIN |
                      SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
@@ -407,6 +413,9 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
 
 GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                              const perf_event_header& header) {
+  // The flags here should be in sync with generic_event_attr in
+  // PerfEventOpen.
+  // TODO(): use the same perf_event_attr object from generic_event_attr
   const perf_event_attr flags{
       .sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
   };
@@ -430,6 +439,9 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
 
 SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header) {
+  // The flags here should be in sync with tracepoint_event_open in
+  // PerfEventOpen.
+  // TODO(): use the same perf_event_attr object from tracepoint_event_open
   const perf_event_attr flags{
       .sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
   };


### PR DESCRIPTION
This PR refactors some of the consumer functions in PerfEventReaders to use the new ConsumeRecordSample.

Part of bug: http://b/241339791

Tests: Manual tests (compared scheduler view, tracepoint info, and unwinding error percentages before and after the change on a gamelet) + Ran LinuxTracingIntegrationTests