### PR TITLE
fix unintilized bug caused by make_unique_for_overwrite

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitorSampleTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorSampleTest.cpp
@@ -215,7 +215,7 @@ StackSamplePerfEvent BuildFakeStackSamplePerfEvent() {
           {
               .pid = 10,
               .tid = 11,
-              .regs = make_unique_for_overwrite<uint64_t[]>(kTotalNumOfRegisters),
+              .regs = std::make_unique<uint64_t[]>(kTotalNumOfRegisters),
               .dyn_size = kStackSize,
               .data = std::make_unique<uint8_t[]>(kStackSize),
           },
@@ -230,7 +230,7 @@ CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(const std::vector<uin
           {
               .pid = 10,
               .tid = 11,
-              .regs = make_unique_for_overwrite<uint64_t[]>(kTotalNumOfRegisters),
+              .regs = std::make_unique<uint64_t[]>(kTotalNumOfRegisters),
               .data = std::make_unique<uint8_t[]>(kStackSize),
           },
   };


### PR DESCRIPTION
This PR fixes a bug use_of_uninitialized_value runtime error. It is caused by using `make_unique_for_overwrite` instead of `make_unique` which causes uninitialized values.

Bug: http://b/241880512