### PR TITLE
Refactor ConsumeUprobeWithStackPerfEvent

### DIFF
--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -140,7 +140,7 @@ struct UprobesWithStackPerfEventData {
   uint64_t stream_id;
   pid_t pid;
   pid_t tid;
-  perf_event_sample_regs_user_sp regs;
+  uint64_t sp;
 
   uint64_t dyn_size;
   // This mutablility allows moving the data out of this class in the UprobesUnwindingVisitor even

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -355,56 +355,31 @@ CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ri
 
 UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                           const perf_event_header& header) {
-  // We expect the following layout of the perf event:
-  //  struct {
-  //    struct perf_event_header header;
-  //    u64 sample_id;          /* if PERF_SAMPLE_IDENTIFIER */
-  //    u32 pid, tid;           /* if PERF_SAMPLE_TID */
-  //    u64 time;               /* if PERF_SAMPLE_TIME */
-  //    u64 stream_id;          /* if PERF_SAMPLE_STREAM_ID */
-  //    u32 cpu, res;           /* if PERF_SAMPLE_CPU */
-  //    u64 abi;                /* if PERF_SAMPLE_REGS_USER */
-  //    u64 regs[weight(mask)]; /* if PERF_SAMPLE_REGS_USER */
-  //    u64 size;               /* if PERF_SAMPLE_STACK_USER */
-  //    char data[size];        /* if PERF_SAMPLE_STACK_USER */
-  //    u64 dyn_size;           /* if PERF_SAMPLE_STACK_USER && size != 0 */
-  //  };
-  // Unfortunately, the value of `size` is not constant, so we need to compute the offsets by hand,
-  // rather than relying on a struct.
+  // The flags here are in sync with uprobes_with_stack_and_sp_event_open in PerfEventOpen.
+  // TODO(b/242020362): use the same perf_event_attr object from
+  // uprobes_with_stack_and_sp_event_open
+  const perf_event_attr flags{
+      .sample_type =
+          PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
+      .sample_regs_user = SAMPLE_REGS_USER_SP,
+  };
 
-  size_t offset_of_size = offsetof(perf_event_sp_stack_user_sample_fixed, regs) +
-                          sizeof(perf_event_sample_regs_user_sp);
-  size_t offset_of_data = offset_of_size + sizeof(uint64_t);
-
-  uint64_t size = 0;
-  ring_buffer->ReadValueAtOffset(&size, offset_of_size);
-
-  size_t offset_of_dyn_size = offset_of_data + (size * sizeof(char));
-
-  uint64_t dyn_size = 0;
-  ring_buffer->ReadValueAtOffset(&dyn_size, offset_of_dyn_size);
-
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  ring_buffer->ReadValueAtOffset(&sample_id,
-                                 offsetof(perf_event_sp_stack_user_sample_fixed, sample_id));
-
-  perf_event_sample_regs_user_sp regs;
-  ring_buffer->ReadValueAtOffset(&regs, offsetof(perf_event_sp_stack_user_sample_fixed, regs));
+  PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
   UprobesWithStackPerfEvent event{
-      .timestamp = sample_id.time,
+      .timestamp = res.time,
       .ordered_stream = PerfEventOrderedStream::FileDescriptor(ring_buffer->GetFileDescriptor()),
       .data =
           {
-              .stream_id = sample_id.stream_id,
-              .pid = static_cast<pid_t>(sample_id.pid),
-              .tid = static_cast<pid_t>(sample_id.tid),
-              .regs = regs,
-              .dyn_size = dyn_size,
-              .data = make_unique_for_overwrite<uint8_t[]>(dyn_size),
+              .stream_id = res.stream_id,
+              .pid = static_cast<pid_t>(res.pid),
+              .tid = static_cast<pid_t>(res.tid),
+              .sp = res.regs[0],
+              .dyn_size = res.dyn_size,
+              .data = std::move(res.stack_data),
           },
   };
-  ring_buffer->ReadRawAtOffset(event.data.data.get(), offset_of_data, dyn_size);
+
   ring_buffer->SkipRecord(header);
   return event;
 }

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -496,7 +496,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
 
 void UprobesUnwindingVisitor::Visit(uint64_t /*event_timestamp*/,
                                     const UprobesWithStackPerfEventData& event_data) {
-  StackSlice stack_slice{.start_address = event_data.regs.sp,
+  StackSlice stack_slice{.start_address = event_data.sp,
                          .size = event_data.dyn_size,
                          .data = std::move(event_data.data)};
   absl::flat_hash_map<uint64_t, StackSlice>& stream_id_to_stack =

--- a/src/LinuxTracing/UprobesUnwindingVisitorSampleTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorSampleTest.cpp
@@ -1015,11 +1015,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesUserSpaceStack) {
               .stream_id = 1,
               .pid = event.data.pid,
               .tid = event.data.tid,
-              .regs =
-                  {
-                      .abi = PERF_SAMPLE_REGS_ABI_64,
-                      .sp = kUserStackPointer,
-                  },
+              .sp = kUserStackPointer,
               .dyn_size = kUserStackSize,
               .data = std::make_unique<uint8_t[]>(kUserStackSize),
           },
@@ -1102,11 +1098,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesLatestUserSpaceCal
               .stream_id = 1,
               .pid = event.data.pid,
               .tid = event.data.tid,
-              .regs =
-                  {
-                      .abi = PERF_SAMPLE_REGS_ABI_64,
-                      .sp = kUserStackPointerOld,
-                  },
+              .sp = kUserStackPointerOld,
               .dyn_size = kUserStackSizeOld,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeOld),
           },
@@ -1122,11 +1114,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesLatestUserSpaceCal
               .stream_id = 1,
               .pid = event.data.pid,
               .tid = event.data.tid,
-              .regs =
-                  {
-                      .abi = PERF_SAMPLE_REGS_ABI_64,
-                      .sp = kUserStackPointerNew,
-                  },
+              .sp = kUserStackPointerNew,
               .dyn_size = kUserStackSizeNew,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeNew),
           },
@@ -1210,11 +1198,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest,
               .stream_id = 1,
               .pid = event.data.pid,
               .tid = event.data.tid,
-              .regs =
-                  {
-                      .abi = PERF_SAMPLE_REGS_ABI_64,
-                      .sp = kUserStackPointerSameThread,
-                  },
+              .sp = kUserStackPointerSameThread,
               .dyn_size = kUserStackSizeSameThread,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeSameThread),
           },
@@ -1231,11 +1215,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest,
               .stream_id = 1,
               .pid = event.data.pid,
               .tid = event.data.tid + 1,
-              .regs =
-                  {
-                      .abi = PERF_SAMPLE_REGS_ABI_64,
-                      .sp = kUserStackPointerOtherThread,
-                  },
+              .sp = kUserStackPointerOtherThread,
               .dyn_size = kUserStackSizeOtherThread,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeOtherThread),
           },
@@ -1318,11 +1298,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesUserStackMemoryFro
               .stream_id = 1,
               .pid = event.data.pid,
               .tid = event.data.tid,
-              .regs =
-                  {
-                      .abi = PERF_SAMPLE_REGS_ABI_64,
-                      .sp = kUserStackPointer1,
-                  },
+              .sp = kUserStackPointer1,
               .dyn_size = kUserStackSize1,
               .data = std::make_unique<uint8_t[]>(kUserStackSize1),
           },
@@ -1339,11 +1315,7 @@ TEST_F(UprobesUnwindingVisitorSampleTest, VisitStackSampleUsesUserStackMemoryFro
               .stream_id = 2,
               .pid = event.data.pid,
               .tid = event.data.tid,
-              .regs =
-                  {
-                      .abi = PERF_SAMPLE_REGS_ABI_64,
-                      .sp = kUserStackPointer2,
-                  },
+              .sp = kUserStackPointer2,
               .dyn_size = kUserStackSize2,
               .data = std::make_unique<uint8_t[]>(kUserStackSize2),
           },


### PR DESCRIPTION
Refactoring a function in PerfEventReaders to use the new ConsumeSampleRecord function.

Part of the bug: http://b/241339791

Testing will be confirmed by @florian-kuebler 