### PR TITLE
Fix LLVM-based address computation Windows

### DIFF
--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -10,6 +10,7 @@
 #include <llvm/DebugInfo/CodeView/TypeDeserializer.h>
 #include <llvm/DebugInfo/CodeView/TypeRecord.h>
 #include <llvm/DebugInfo/PDB/Native/TpiStream.h>
+#include <llvm/Object/COFF.h>
 
 #include <memory>
 
@@ -32,9 +33,11 @@ namespace {
 class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
  public:
   SymbolInfoVisitor(ModuleSymbols* module_symbols, const ObjectFileInfo& object_file_info,
+                    llvm::FixedStreamArray<llvm::object::coff_section>* section_headers,
                     llvm::pdb::TpiStream* type_info_stream)
       : module_symbols_(module_symbols),
         object_file_info_(object_file_info),
+        section_headers_(section_headers),
         type_info_stream_(type_info_stream) {
     ORBIT_CHECK(module_symbols != nullptr);
     ORBIT_CHECK(type_info_stream != nullptr);
@@ -58,9 +61,10 @@ class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
 
     // The address in PDB files is a relative virtual address (RVA), to make the address compatible
     // with how we do the computation, we need to add both the load bias (ImageBase for COFF) and
-    // the offset of the executable section.
-    symbol_info.set_address(proc.CodeOffset + object_file_info_.load_bias +
-                            object_file_info_.executable_segment_offset);
+    // the offset of the section.
+    ORBIT_CHECK(section_headers_ != nullptr && section_headers_->size() >= proc.Segment);
+    uint64_t section_offset = (*section_headers_)[proc.Segment - 1].VirtualAddress;
+    symbol_info.set_address(proc.CodeOffset + object_file_info_.load_bias + section_offset);
     symbol_info.set_size(proc.CodeSize);
 
     ORBIT_CHECK(module_symbols_ != nullptr);
@@ -127,6 +131,7 @@ class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
 
   ModuleSymbols* module_symbols_;
   ObjectFileInfo object_file_info_;
+  llvm::FixedStreamArray<llvm::object::coff_section>* section_headers_;
   llvm::pdb::TpiStream* type_info_stream_;
 };
 
@@ -160,6 +165,9 @@ PdbFileLlvm::PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& 
   // Given that we check hasPDBTpiStream above, we must get a TpiStream here.
   ORBIT_CHECK(type_info_stream);
 
+  llvm::FixedStreamArray<llvm::object::coff_section> section_headers =
+      debug_info_stream->getSectionHeaders();
+
   const llvm::pdb::DbiModuleList& modules = debug_info_stream->modules();
 
   for (uint32_t index = 0; index < modules.getModuleCount(); ++index) {
@@ -186,7 +194,8 @@ PdbFileLlvm::PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& 
     llvm::codeview::SymbolDeserializer deserializer(nullptr,
                                                     llvm::codeview::CodeViewContainer::Pdb);
     pipeline.addCallbackToPipeline(deserializer);
-    SymbolInfoVisitor symbol_visitor(&module_symbols, object_file_info_, &type_info_stream.get());
+    SymbolInfoVisitor symbol_visitor(&module_symbols, object_file_info_, &section_headers,
+                                     &type_info_stream.get());
     pipeline.addCallbackToPipeline(symbol_visitor);
     llvm::codeview::CVSymbolVisitor visitor(pipeline);
 

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -61,8 +61,11 @@ class SymbolInfoVisitor : public llvm::codeview::SymbolVisitorCallbacks {
 
     // The address in PDB files is a relative virtual address (RVA), to make the address compatible
     // with how we do the computation, we need to add both the load bias (ImageBase for COFF) and
-    // the offset of the section.
-    ORBIT_CHECK(section_headers_ != nullptr && section_headers_->size() >= proc.Segment);
+    // the virtual offset of the section.
+    // Note: The segments are numbered starting at 1 and match what you observe using
+    // `dumpbin /HEADERS`.
+    ORBIT_CHECK(section_headers_ != nullptr && section_headers_->size() >= proc.Segment &&
+                proc.Segment > 0);
     uint64_t section_offset = (*section_headers_)[proc.Segment - 1].VirtualAddress;
     symbol_info.set_address(proc.CodeOffset + object_file_info_.load_bias + section_offset);
     symbol_info.set_size(proc.CodeSize);

--- a/src/WindowsProcessService/ProcessServiceImpl.cpp
+++ b/src/WindowsProcessService/ProcessServiceImpl.cpp
@@ -96,6 +96,7 @@ Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
     module_info->set_address_start(module.address_start);
     module_info->set_address_end(module.address_end);
     module_info->set_build_id(module.build_id);
+    module_info->set_load_bias(module.load_bias);
     module_info->set_object_file_type(ModuleInfo::kCoffFile);
     for (const ModuleInfo::ObjectSegment& section : module.sections) {
       *module_info->add_object_segments() = section;

--- a/src/WindowsTracing/TracerImpl.cpp
+++ b/src/WindowsTracing/TracerImpl.cpp
@@ -62,6 +62,7 @@ void TracerImpl::SendModulesSnapshot() {
     module_info->set_address_start(module.address_start);
     module_info->set_address_end(module.address_end);
     module_info->set_build_id(module.build_id);
+    module_info->set_load_bias(module.load_bias);
     module_info->set_object_file_type(ModuleInfo::kCoffFile);
     for (const ModuleInfo::ObjectSegment& section : module.sections) {
       *module_info->add_object_segments() = section;

--- a/src/WindowsUtils/ListModules.cpp
+++ b/src/WindowsUtils/ListModules.cpp
@@ -54,8 +54,10 @@ std::vector<Module> ListModules(uint32_t pid) {
     std::string module_path = orbit_base::ToStdString(module_entry.szExePath);
     auto coff_file_or_error = orbit_object_utils::CreateCoffFile(module_path);
     std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> sections;
+    uint64_t load_bias = 0;
     if (coff_file_or_error.has_value()) {
       build_id = coff_file_or_error.value()->GetBuildId();
+      load_bias = coff_file_or_error.value()->GetLoadBias();
       sections = coff_file_or_error.value()->GetObjectSegments();
     } else {
       ORBIT_ERROR(
@@ -70,6 +72,7 @@ std::vector<Module> ListModules(uint32_t pid) {
     module.address_start = absl::bit_cast<uint64_t>(module_entry.modBaseAddr);
     module.address_end = module.address_start + module_entry.modBaseSize;
     module.build_id = build_id;
+    module.load_bias = load_bias;
     module.sections = std::move(sections);
 
   } while (Module32Next(module_snap_handle, &module_entry));

--- a/src/WindowsUtils/include/WindowsUtils/ListModules.h
+++ b/src/WindowsUtils/include/WindowsUtils/ListModules.h
@@ -18,6 +18,7 @@ struct Module {
   uint64_t file_size = 0;
   uint64_t address_start = 0;
   uint64_t address_end = 0;
+  uint64_t load_bias = 0;
   std::string build_id;
   std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> sections;
 };


### PR DESCRIPTION
In our LLVM-based pdb file implementation, we compute the
address of a function using the "Offset", the load bias
(image base on Windows) and the executable section offset.
We use the executable section offset is used as the Offset differs
to the RVA by the section offset.

In particular, the executable section offset is used in Linux
as, our module base address will start at the first executable
section. However, on Windows modules start at the beginning of
the file, so the executable section offset needs to set to 0.

This change changes from computing the function address to
lookup the section offset (called Virtual address in LLVM)
on the fly. This also fixes a bug, when multiple executable
sections exists.

In order to be on par, we also set the "load address" (image
base). This way, we will store the "desired virtual address"
instead of the RVA, which is exactly what we do for PE/coff
files on Linux. For all the computations that equals out anyways.

Test: Manually inspect computed addresses
Bug: http://b/242015708