### PR TITLE
Allow for explicit Typedef arithmetics customization

### DIFF
--- a/src/MizarBase/include/MizarBase/Time.h
+++ b/src/MizarBase/include/MizarBase/Time.h
@@ -14,6 +14,7 @@
 namespace orbit_mizar_base {
 
 // wraps `uint64_t` bears semantics of time in nanoseconds and implements a non-wrapping addition
+// TODO(b/242038718) Remove and rely on the explicitly allowed Typedefs arithmetics customisation
 struct NonWrappingNanoseconds {
   friend NonWrappingNanoseconds operator+(NonWrappingNanoseconds a, NonWrappingNanoseconds b) {
     const uint64_t sum = a.value + b.value;

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -198,7 +198,7 @@ auto operator-(First&& lhs, Second&& rhs) {
 };
 
 // When the `Tag` inherits from the struct, the `Typedef<Tag, T>` supports multiplication by
-// `Scalar` via `operator*`. By default, `operator*(T, Scalar)` is used.The behaviour may
+// `Scalar` via `operator*`. By default, `operator*(T, Scalar)` is used. The behaviour may
 // be overriden via supplying an instance of a functor or a function pointer as the second template
 // parameter.
 template <typename Scalar, auto& TimesScalarFun = orbit_base_internal::kDefaultTimes>

--- a/src/OrbitBase/include/OrbitBase/TypedefUtils.h
+++ b/src/OrbitBase/include/OrbitBase/TypedefUtils.h
@@ -6,6 +6,7 @@
 #define ORBIT_BASE_TYPEDEF_UTILS_H_
 
 #include <type_traits>
+#include <utility>
 
 namespace orbit_base_internal {
 
@@ -14,6 +15,39 @@ using EnableIfUConvertibleToT = std::enable_if_t<std::is_convertible_v<U, T>>;
 
 template <typename T, typename U>
 using EnableIfUNotConvertibleToT = std::enable_if_t<!std::is_convertible_v<U, T>>;
+
+template <typename OtherSummandTag>
+struct PlusTagBase {};
+
+struct DefaultPlus {
+  template <typename T, typename U>
+  auto operator()(T&& t, U&& u) const {
+    return std::forward<T>(t) + std::forward<U>(u);
+  }
+};
+
+constexpr DefaultPlus kDefaultPlus{};
+
+struct DefaultMinus {
+  template <typename T, typename U>
+  auto operator()(T&& t, U&& u) const {
+    return std::forward<T>(t) - std::forward<U>(u);
+  }
+};
+
+constexpr DefaultMinus kDefaultMinus{};
+
+struct DefaultTimes {
+  template <typename T, typename U>
+  auto operator()(T&& t, U&& u) const {
+    return std::forward<T>(t) * std::forward<U>(u);
+  }
+};
+
+constexpr DefaultTimes kDefaultTimes;
+
+template <typename Scalar>
+struct TimesScalarTagBase {};
 
 }  // namespace orbit_base_internal
 

--- a/src/OrbitBase/include/OrbitBase/TypedefUtils.h
+++ b/src/OrbitBase/include/OrbitBase/TypedefUtils.h
@@ -26,7 +26,7 @@ struct DefaultPlus {
   }
 };
 
-constexpr DefaultPlus kDefaultPlus{};
+constexpr DefaultPlus kDefaultPlus;
 
 struct DefaultMinus {
   template <typename T, typename U>
@@ -35,7 +35,7 @@ struct DefaultMinus {
   }
 };
 
-constexpr DefaultMinus kDefaultMinus{};
+constexpr DefaultMinus kDefaultMinus;
 
 struct DefaultTimes {
   template <typename T, typename U>


### PR DESCRIPTION
Currently, Typedef arithmetics relies on the operators defined
for the raw types. In the absence of such, or in case of a need
to overload the behaviour, the only option is to wrap the raw type
into an intermediate type.

This adds customization via adding another template parameter for the
arithmetics-enabling Tags.

Bug: http://b/242038642
Test: Compile, Unit