### PR TITLE
Fix flakyness in orbit_tracks e2e test.

### DIFF
--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -27,7 +27,9 @@ def main(argv):
         # We check for "sdma0" or "vce0" or both to exist. Both are connected to the encoding of video frames.
         VerifyTracksExist(track_names=[("*sdma0*", "*vce0*")], allow_duplicates=True),
         SelectTrack(track_index=0, expect_failure=True),  # Scheduler track cannot be selected
-        SelectTrack(track_index=5),  # hello_ggp_stand track can be selected
+        FilterTracks(filter_string="hello"),
+        SelectTrack(track_index=1),  # hello_ggp_stand track can be selected
+        FilterTracks(filter_string=""),
         # TODO(b/233028574): SelectTrack doesn't release the clicked track properly and can't be followed
         # directly with MoveTrack(). It needs to run DeselectTrack() to release the track before moving
         # tracks.


### PR DESCRIPTION
Previously the index of the track we select was relying on a hard coded
index. This caused issues when additional tracks are present.
Now we filter for the name of the track to avoid this.

Bug: http://b/242021909
Test: Local run of the test.