### PR TITLE
Add metrics for auto frame track feature

### DIFF
--- a/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
+++ b/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
@@ -42,6 +42,7 @@ struct ClientCaptureOptions {
   bool enable_introspection = false;
   bool record_arguments = false;
   bool record_return_values = false;
+  bool enable_auto_frame_track = false;
 };
 
 }  // namespace orbit_capture_client

--- a/src/MetricsUploader/CaptureMetric.cpp
+++ b/src/MetricsUploader/CaptureMetric.cpp
@@ -30,6 +30,7 @@ CaptureMetric::CaptureMetric(MetricsUploader* uploader, const CaptureStartData& 
   capture_data_.set_dynamic_instrumentation_method(start_data.dynamic_instrumentation_method);
   capture_data_.set_callstack_samples_per_second(start_data.callstack_samples_per_second);
   capture_data_.set_callstack_unwinding_method(start_data.callstack_unwinding_method);
+  capture_data_.set_auto_frame_track(start_data.auto_frame_track);
 }
 
 void CaptureMetric::SetCaptureCompleteData(const CaptureCompleteData& complete_data) {

--- a/src/MetricsUploader/CaptureMetricTest.cpp
+++ b/src/MetricsUploader/CaptureMetricTest.cpp
@@ -25,7 +25,13 @@ constexpr CaptureStartData kTestStartData{
     OrbitCaptureData_LibOrbitVulkanLayer_LIB_LOADED /*lib_orbit_vulkan_layer*/,
     OrbitCaptureData_LocalMarkerDepthPerCommandBuffer_LIMITED /*local_marker_depth_per_command_buffer*/
     ,
-    11 /*max_local_marker_depth_per_command_buffer*/
+    11 /*max_local_marker_depth_per_command_buffer*/,
+    OrbitCaptureData_DynamicInstrumentationMethod_DYNAMIC_INSTRUMENTATION_METHOD_KERNEL /*dynamic_instrumentation_method*/
+    ,
+    12 /*callstack_samples_per_second*/,
+    OrbitCaptureData_CallstackUnwindingMethod_CALLSTACK_UNWINDING_METHOD_DWARF /*callstack_unwinding_method*/
+    ,
+    OrbitCaptureData_AutoFrameTrack_AUTO_FRAME_TRACK_ENABLED /*auto_frame_track*/
 };
 
 const CaptureCompleteData kTestCompleteData{
@@ -58,7 +64,12 @@ bool HasSameCaptureStartData(const OrbitCaptureData& capture_data,
          capture_data.local_marker_depth_per_command_buffer() ==
              start_data.local_marker_depth_per_command_buffer &&
          capture_data.max_local_marker_depth_per_command_buffer() ==
-             start_data.max_local_marker_depth_per_command_buffer;
+             start_data.max_local_marker_depth_per_command_buffer &&
+         capture_data.dynamic_instrumentation_method() ==
+             start_data.dynamic_instrumentation_method &&
+         capture_data.callstack_samples_per_second() == start_data.callstack_samples_per_second &&
+         capture_data.callstack_unwinding_method() == start_data.callstack_unwinding_method &&
+         capture_data.auto_frame_track() == start_data.auto_frame_track;
 }
 
 bool HasSameCaptureCompleteData(const OrbitCaptureData& capture_data,

--- a/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
@@ -34,6 +34,8 @@ struct CaptureStartData {
   orbit_metrics_uploader::OrbitCaptureData_CallstackUnwindingMethod callstack_unwinding_method =
       orbit_metrics_uploader::
           OrbitCaptureData_CallstackUnwindingMethod_CALLSTACK_UNWINDING_METHOD_UNKNOWN;
+  orbit_metrics_uploader::OrbitCaptureData_AutoFrameTrack auto_frame_track =
+      orbit_metrics_uploader::OrbitCaptureData_AutoFrameTrack_AUTO_FRAME_TRACK_UNKNOWN;
 };
 
 struct CaptureCompleteData {

--- a/src/MetricsUploader/orbit_log_event.proto
+++ b/src/MetricsUploader/orbit_log_event.proto
@@ -98,7 +98,7 @@ message OrbitLogEvent {
 // instrumented functions and information that is available at capture stop,
 // like duration of the capture. It is sent when the user stops the capture, or
 // when the capture is aborted because of an error.
-// NextID: 31
+// NextID: 32
 message OrbitCaptureData {
   // Duration of the capture in milliseconds. This is a measure of time from
   // when the user started a capture until the user ends it.
@@ -279,4 +279,12 @@ message OrbitCaptureData {
     TARGET_PROCESS_TERMINATION_SIGNAL_INTERNAL_ERROR = 33;
   };
   TargetProcessTerminationSignal target_process_termination_signal = 30;
+
+  // Whether the automatic addition of a frame track is enabled or not.
+  enum AutoFrameTrack {
+    AUTO_FRAME_TRACK_UNKNOWN = 0;
+    AUTO_FRAME_TRACK_ENABLED = 1;
+    AUTO_FRAME_TRACK_DISABLED = 2;
+  }
+  AutoFrameTrack auto_frame_track = 31;
 }


### PR DESCRIPTION
Following the same pattern that ThreadStates user settings.

In addition I'm updating CaptureMetricTest with the last added 
metrics (callstack related and dynamic instrumentation method).

Bugs: http://b/239830391 & http://b/242032350
Test: Run unit test.