### PR TITLE
Remove `NonWrappingNanoseconds` from Mizar

### DIFF
--- a/src/MizarBase/include/MizarBase/Time.h
+++ b/src/MizarBase/include/MizarBase/Time.h
@@ -13,13 +13,13 @@
 
 namespace orbit_mizar_base_internal {
 
-static inline uint64_t NonWrappingSum(uint64_t a, uint64_t b) {
+inline uint64_t NonWrappingSum(uint64_t a, uint64_t b) {
   const uint64_t sum = a + b;
   if (sum < a || sum < b) return std::numeric_limits<uint64_t>::max();
   return sum;
 }
 
-static inline uint64_t AbortingOnUnderflowSub(uint64_t a, uint64_t b) {
+inline uint64_t AbortingOnUnderflowSub(uint64_t a, uint64_t b) {
   ORBIT_CHECK(a >= b);
   return a - b;
 }

--- a/src/MizarBase/include/MizarBase/Time.h
+++ b/src/MizarBase/include/MizarBase/Time.h
@@ -11,55 +11,36 @@
 #include "OrbitBase/Typedef.h"
 #include "stdint.h"
 
+namespace orbit_mizar_base_internal {
+
+static inline uint64_t NonWrappingSum(uint64_t a, uint64_t b) {
+  const uint64_t sum = a + b;
+  if (sum < a || sum < b) return std::numeric_limits<uint64_t>::max();
+  return sum;
+}
+
+static inline uint64_t AbortingOnUnderflowSub(uint64_t a, uint64_t b) {
+  ORBIT_CHECK(a >= b);
+  return a - b;
+}
+
+}  // namespace orbit_mizar_base_internal
+
 namespace orbit_mizar_base {
 
-// wraps `uint64_t` bears semantics of time in nanoseconds and implements a non-wrapping addition
-// TODO(b/242038718) Remove and rely on the explicitly allowed Typedefs arithmetics customisation
-struct NonWrappingNanoseconds {
-  friend NonWrappingNanoseconds operator+(NonWrappingNanoseconds a, NonWrappingNanoseconds b) {
-    const uint64_t sum = a.value + b.value;
-    if (sum < a.value || sum < b.value) return {std::numeric_limits<uint64_t>::max()};
-    return {sum};
-  }
-
-  friend NonWrappingNanoseconds operator-(NonWrappingNanoseconds a, NonWrappingNanoseconds b) {
-    ORBIT_CHECK(a.value >= b.value);
-    return {a.value - b.value};
-  }
-
-  friend NonWrappingNanoseconds operator*(NonWrappingNanoseconds a, uint64_t times) {
-    if (std::numeric_limits<uint64_t>::max() / times < a.value) {
-      return {std::numeric_limits<uint64_t>::max()};
-    }
-    return {a.value * times};
-  }
-
-  friend bool operator<(NonWrappingNanoseconds a, NonWrappingNanoseconds b) {
-    return a.value < b.value;
-  }
-
-  friend bool operator==(NonWrappingNanoseconds a, NonWrappingNanoseconds b) {
-    return a.value == b.value;
-  }
-
-  uint64_t value;
-};
-
-struct RelativeTimestampTag : orbit_base::PlusTag<RelativeTimestampTag>,
-                              orbit_base::TimesScalarTag<uint64_t> {};
+struct RelativeTimestampTag
+    : orbit_base::PlusTag<RelativeTimestampTag, orbit_mizar_base_internal::NonWrappingSum>,
+      orbit_base::TimesScalarTag<uint64_t> {};
 
 // Represents the time passed since the capture start
-using RelativeTimeNs = orbit_base::Typedef<RelativeTimestampTag, NonWrappingNanoseconds>;
+using RelativeTimeNs = orbit_base::Typedef<RelativeTimestampTag, uint64_t>;
 
-constexpr RelativeTimeNs MakeRelativeTimeNs(uint64_t t) { return RelativeTimeNs(std::in_place, t); }
-
-struct TimestampNsTag : orbit_base::MinusTag<RelativeTimestampTag>,
-                        orbit_base::PlusTag<RelativeTimestampTag> {};
+struct TimestampNsTag
+    : orbit_base::MinusTag<RelativeTimestampTag, orbit_mizar_base_internal::AbortingOnUnderflowSub>,
+      orbit_base::PlusTag<RelativeTimestampTag, orbit_mizar_base_internal::NonWrappingSum> {};
 
 // Absolute timestamp of the capture start in nanos
-using TimestampNs = orbit_base::Typedef<TimestampNsTag, NonWrappingNanoseconds>;
-
-constexpr TimestampNs MakeTimestampNs(uint64_t t) { return TimestampNs(std::in_place, t); }
+using TimestampNs = orbit_base::Typedef<TimestampNsTag, uint64_t>;
 
 }  // namespace orbit_mizar_base
 

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -30,7 +30,6 @@ using ::orbit_mizar_base::Baseline;
 using ::orbit_mizar_base::Comparison;
 using ::orbit_mizar_base::MakeBaseline;
 using ::orbit_mizar_base::MakeComparison;
-using ::orbit_mizar_base::MakeRelativeTimeNs;
 using ::orbit_mizar_base::RelativeTimeNs;
 using ::orbit_mizar_base::SFID;
 using ::orbit_mizar_base::TID;
@@ -100,7 +99,8 @@ const std::vector<std::vector<SFID>> kCallstacks = {
 const std::vector<RelativeTimeNs> kFrameTrackActiveTimes = [] {
   const std::vector<uint64_t> kRaw = {300, 100, 200};
   std::vector<RelativeTimeNs> result;
-  absl::c_transform(kRaw, std::back_inserter(result), MakeRelativeTimeNs);
+  absl::c_transform(kRaw, std::back_inserter(result),
+                    [](uint64_t value) { return RelativeTimeNs(value); });
   return result;
 }();
 
@@ -177,10 +177,10 @@ TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
       std::move(full), std::move(empty), {kSfidToName});
   const SamplingWithFrameTrackComparisonReport report = bac.MakeSamplingWithFrameTrackReport(
       MakeBaseline<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
-          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, MakeRelativeTimeNs(0),
+          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, RelativeTimeNs(0),
           FrameTrackId(ScopeId(1))),
       MakeComparison<orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig>(
-          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, MakeRelativeTimeNs(0),
+          absl::flat_hash_set<TID>{TID(orbit_base::kAllProcessThreadsTid)}, RelativeTimeNs(0),
           FrameTrackId(ScopeId(1))));
 
   EXPECT_EQ(report.GetBaselineSamplingCounts()->GetTotalCallstacks(), kCallstacks.size());

--- a/src/MizarData/FrameTrackManagerTest.cpp
+++ b/src/MizarData/FrameTrackManagerTest.cpp
@@ -19,7 +19,6 @@ using ::orbit_client_data::ScopeId;
 using ::orbit_client_data::ScopeInfo;
 using ::orbit_client_protos::TimerInfo;
 using ::orbit_grpc_protos::PresentEvent;
-using ::orbit_mizar_base::MakeTimestampNs;
 using ::orbit_mizar_base::TimestampNs;
 using ::orbit_test_utils::MakeMap;
 using ::testing::ElementsAreArray;
@@ -59,7 +58,8 @@ static const std::vector<orbit_client_data::ScopeInfo> kScopeInfos = {
 
 static std::vector<TimestampNs> MakeTimestamps(const std::vector<uint64_t>& raw) {
   std::vector<TimestampNs> result;
-  absl::c_transform(raw, std::back_inserter(result), MakeTimestampNs);
+  absl::c_transform(raw, std::back_inserter(result),
+                    [](uint64_t value) { return TimestampNs(value); });
   return result;
 }
 
@@ -74,7 +74,7 @@ static std::vector<TimerInfo> ToTimerInfos(const std::vector<TimestampNs>& start
   std::transform(std::begin(starts), std::end(starts), std::back_inserter(result),
                  [](TimestampNs start) {
                    TimerInfo timer;
-                   timer.set_start(start->value);
+                   timer.set_start(*start);
                    return timer;
                  });
   return result;
@@ -109,7 +109,7 @@ static std::vector<PresentEvent> MakePresentEvent(const std::vector<TimestampNs>
   std::transform(std::begin(starts), std::end(starts), std::back_inserter(result),
                  [](const TimestampNs start) {
                    PresentEvent event;
-                   event.set_begin_timestamp_ns(start->value);
+                   event.set_begin_timestamp_ns(*start);
                    return event;
                  });
   return result;
@@ -214,7 +214,7 @@ TEST_F(ExpectFrameTracksHasFrameStartsForScopes, FrameTracksAreCorrectForScopesA
 
   // Filtering of scopes w.r.t min/max timestamp is handles by Capture data, it is not covered
   // in the test, hence we just pass zeroes. The MockCaptureData ignores these anyway.
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(0), MakeTimestampNs(0));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(0), TimestampNs(0));
 }
 
 TEST_F(ExpectFrameTracksHasFrameStartsForScopes, FrameTracksAreCorrectForEtwsAndNoScopes) {
@@ -224,22 +224,14 @@ TEST_F(ExpectFrameTracksHasFrameStartsForScopes, FrameTracksAreCorrectForEtwsAnd
 
   // The arguments are chosen w.r.t the values used in kFirstScopeStarts, kSecondScopeStarts,
   // kDxgiFrameStarts and kD3d9FrameStarts
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(0),
-                                                            MakeTimestampNs(15));
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(0),
-                                                            MakeTimestampNs(50));
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(0),
-                                                            MakeTimestampNs(300));
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(3),
-                                                            MakeTimestampNs(15));
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(15),
-                                                            MakeTimestampNs(50));
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(50),
-                                                            MakeTimestampNs(300));
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(50),
-                                                            MakeTimestampNs(3000));
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(1000),
-                                                            MakeTimestampNs(3000));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(0), TimestampNs(15));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(0), TimestampNs(50));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(0), TimestampNs(300));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(3), TimestampNs(15));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(15), TimestampNs(50));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(50), TimestampNs(300));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(50), TimestampNs(3000));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(1000), TimestampNs(3000));
 }
 
 TEST_F(ExpectFrameTracksHasFrameStartsForScopes, FrameTracksAreCorrectForEtwsAndScopes) {
@@ -248,8 +240,7 @@ TEST_F(ExpectFrameTracksHasFrameStartsForScopes, FrameTracksAreCorrectForEtwsAnd
 
   ExpectGetFrameTracksIsCorrect(kScopeInfos, kEtwSources);
 
-  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(MakeTimestampNs(0),
-                                                            MakeTimestampNs(300));
+  ExpectGetFrameTracksReturnsExpectedValueForEachFrameTrack(TimestampNs(0), TimestampNs(300));
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -101,7 +101,7 @@ class BaselineAndComparisonTmpl {
         config.tids, config.frame_track_id, config.start_relative, config.EndRelative());
     orbit_client_data::ScopeStats stats;
     for (const RelativeTimeNs active_invocation_time : active_invocation_times) {
-      stats.UpdateStats(active_invocation_time->value);
+      stats.UpdateStats(*active_invocation_time);
     }
     return stats;
   }

--- a/src/MizarData/include/MizarData/FrameTrackManager.h
+++ b/src/MizarData/include/MizarData/FrameTrackManager.h
@@ -60,12 +60,12 @@ class FrameTrackManagerTmpl {
                                                              TimestampNs max_start,
                                                              ScopeId scope_id) const {
     const std::vector<const TimerInfo*> timers =
-        GetCaptureData().GetTimersForScope(scope_id, min_start->value, max_start->value);
+        GetCaptureData().GetTimersForScope(scope_id, *min_start, *max_start);
 
     std::vector<TimestampNs> result;
     result.reserve(timers.size());
     absl::c_transform(timers, std::back_inserter(result), [](const TimerInfo* timer) {
-      return orbit_mizar_base::MakeTimestampNs(timer->start());
+      return orbit_mizar_base::TimestampNs(timer->start());
     });
     return result;
   }
@@ -82,7 +82,7 @@ class FrameTrackManagerTmpl {
     std::vector<TimestampNs> result;
     const std::vector<PresentEvent>& events = it->second;
     for (const PresentEvent& event : events) {
-      const TimestampNs event_start = orbit_mizar_base::MakeTimestampNs(event.begin_timestamp_ns());
+      const TimestampNs event_start = orbit_mizar_base::TimestampNs(event.begin_timestamp_ns());
       if (min_start <= event_start && event_start <= max_start) {
         result.push_back(event_start);
       }

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -56,14 +56,14 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
       uint64_t address) const override;
 
   [[nodiscard]] orbit_mizar_base::TimestampNs GetCaptureStartTimestampNs() const override {
-    return orbit_mizar_base::MakeTimestampNs(
+    return orbit_mizar_base::TimestampNs(
         GetCaptureData().GetCaptureStarted().capture_start_timestamp_ns());
   }
 
   [[nodiscard]] RelativeTimeNs GetNominalSamplingPeriodNs() const override {
     const double samples_per_second =
         GetCaptureData().GetCaptureStarted().capture_options().samples_per_second();
-    return orbit_mizar_base::MakeRelativeTimeNs(
+    return orbit_mizar_base::RelativeTimeNs(
         static_cast<uint64_t>(1'000'000'000 / samples_per_second));
   }
 

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -123,7 +123,7 @@ class MizarPairedDataTmpl {
   }
 
   [[nodiscard]] RelativeTimeNs CaptureDurationNs() const {
-    return orbit_mizar_base::MakeTimestampNs(GetCallstackData().max_time()) -
+    return orbit_mizar_base::TimestampNs(GetCallstackData().max_time()) -
            data_->GetCaptureStartTimestampNs();
   }
 
@@ -150,7 +150,7 @@ class MizarPairedDataTmpl {
                                              TimestampNs max_timestamp_ns,
                                              Action&& action_on_callstack_events) const {
     GetCallstackData().ForEachCallstackEventOfTidInTimeRange(
-        *tid, min_timestamp_ns->value, max_timestamp_ns->value, action_on_callstack_events);
+        *tid, *min_timestamp_ns, *max_timestamp_ns, action_on_callstack_events);
   }
 
   [[nodiscard]] uint64_t CallstackSamplesCount(TID tid, TimestampNs min_timestamp_ns,

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -42,7 +42,7 @@ class HalfOfSamplingWithFrameTrackReportConfig {
                                                     FrameTrackId frame_track_id)
       : tids(std::move(tids)),
         start_relative(start),
-        duration(orbit_mizar_base::MakeRelativeTimeNs(std::numeric_limits<uint64_t>::max())),
+        duration(orbit_mizar_base::RelativeTimeNs(std::numeric_limits<uint64_t>::max())),
         frame_track_id(frame_track_id) {}
 
   [[nodiscard]] RelativeTimeNs EndRelative() const { return start_relative + duration; }

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidget.cpp
@@ -86,7 +86,7 @@ static uint64_t ParseStartNs(const QString& time_ms) {
 }
 
 void SamplingWithFrameTrackInputWidgetBase::OnStartMsChanged(const QString& time_ms) {
-  start_timestamp_ = orbit_mizar_base::MakeRelativeTimeNs(ParseStartNs(time_ms));
+  start_timestamp_ = RelativeTimeNs(ParseStartNs(time_ms));
 }
 
 SamplingWithFrameTrackInputWidgetBase::~SamplingWithFrameTrackInputWidgetBase() = default;

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -143,7 +143,7 @@ class SamplingWithFrameTrackInputWidgetTest : public ::testing::Test {
   }
 
   void ExpectRelativeStartNsIs(uint64_t start_relative_ns_) const {
-    EXPECT_EQ(widget_->MakeConfig().start_relative->value, start_relative_ns_);
+    EXPECT_EQ(*widget_->MakeConfig().start_relative, start_relative_ns_);
   }
 
   MockPairedData data_;

--- a/src/MizarWidgets/SamplingWithFrameTrackReportConfigValidatorTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackReportConfigValidatorTest.cpp
@@ -17,10 +17,9 @@
 
 using ::orbit_mizar_base::Baseline;
 using ::orbit_mizar_base::Comparison;
-using ::orbit_mizar_base::MakeRelativeTimeNs;
 using ::orbit_mizar_base::RelativeTimeNs;
 using ::orbit_mizar_base::TID;
-using orbit_mizar_base::TimestampNs;
+using ::orbit_mizar_base::TimestampNs;
 using ::orbit_mizar_data::FrameTrackId;
 using ::orbit_mizar_data::FrameTrackInfo;
 using ::orbit_test_utils::HasError;
@@ -45,8 +44,8 @@ class MockBaselineAndComparison {
 
 namespace orbit_mizar_widgets {
 
-constexpr RelativeTimeNs kBaselineCaptureDuration = MakeRelativeTimeNs(123456);
-constexpr RelativeTimeNs kComparisonCaptureDuration = MakeRelativeTimeNs(234567);
+constexpr RelativeTimeNs kBaselineCaptureDuration(123456);
+constexpr RelativeTimeNs kComparisonCaptureDuration(234567);
 
 using HalfConfig = orbit_mizar_data::HalfOfSamplingWithFrameTrackReportConfig;
 
@@ -66,7 +65,7 @@ TEST(SamplingWithFrameTrackReportConfigValidator, IsCorrect) {
       validator{};
 
   constexpr FrameTrackId kId(orbit_client_data::ScopeId(0));
-  constexpr RelativeTimeNs kStart = MakeRelativeTimeNs(0);
+  constexpr RelativeTimeNs kStart(0);
 
   EXPECT_THAT(
       validator.Validate(
@@ -82,7 +81,7 @@ TEST(SamplingWithFrameTrackReportConfigValidator, IsCorrect) {
                                                        kId)),
       HasError("Baseline: No threads selected"));
 
-  constexpr RelativeTimeNs kOneNs = MakeRelativeTimeNs(1);
+  constexpr RelativeTimeNs kOneNs(1);
 
   EXPECT_THAT(validator.Validate(
                   &bac,

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -78,7 +78,7 @@ class SamplingWithFrameTrackInputWidgetBase : public QWidget {
   FrameTrackId frame_track_id_{};
 
   // std::numeric_limits<uint64_t>::max() ns corresponds to malformed input
-  RelativeTimeNs start_timestamp_ = orbit_mizar_base::MakeRelativeTimeNs(0);
+  RelativeTimeNs start_timestamp_{0};
 };
 
 template <typename PairedData>


### PR DESCRIPTION
This makes the code rely on Typedef operator customization instead.

Test: Compile, Unit, Manual
Bug: http://b/242038718