### PR TITLE
Use functions instead of operators for Typedefs

### DIFF
--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -119,14 +119,14 @@ const std::unique_ptr<orbit_client_data::CallstackData> kCallstackData = [] {
 
   callstack_data->AddCallstackEvent({kCaptureStart->value, kCompleteCallstackId, *kTID});
   callstack_data->AddCallstackEvent(
-      {(kCaptureStart + kRelativeTime1)->value, kCompleteCallstackId, *kTID});
+      {Add(kCaptureStart, kRelativeTime1)->value, kCompleteCallstackId, *kTID});
   callstack_data->AddCallstackEvent(
-      {(kCaptureStart + kRelativeTime3)->value, kInCompleteCallstackId, *kTID});
+      {Add(kCaptureStart, kRelativeTime3)->value, kInCompleteCallstackId, *kTID});
   callstack_data->AddCallstackEvent(
-      {(kCaptureStart + kRelativeTime4)->value, kAnotherCompleteCallstackId, *kAnotherTID});
+      {Add(kCaptureStart, kRelativeTime4)->value, kAnotherCompleteCallstackId, *kAnotherTID});
 
-  callstack_data->AddCallstackEvent(
-      {(kCaptureStart + kRelativeTimeTooLate)->value, kAnotherCompleteCallstackId, *kNamelessTID});
+  callstack_data->AddCallstackEvent({Add(kCaptureStart, kRelativeTimeTooLate)->value,
+                                     kAnotherCompleteCallstackId, *kNamelessTID});
 
   return callstack_data;
 }();
@@ -152,8 +152,8 @@ const std::vector<SFID> kAnotherCompleteCallstackIds =
 
 namespace {
 
-const std::vector<TimestampNs> kStarts = {kCaptureStart, kCaptureStart + kRelativeTime2,
-                                          kCaptureStart + kRelativeTime5};
+const std::vector<TimestampNs> kStarts = {kCaptureStart, Add(kCaptureStart, kRelativeTime2),
+                                          Add(kCaptureStart, kRelativeTime5)};
 
 class MockFrameTrackManager {
  public:
@@ -257,8 +257,8 @@ TEST_F(MizarPairedDataTest, ActiveInvocationTimesIsCorrect) {
       mizar_paired_data.ActiveInvocationTimes(
           {kTID, kAnotherTID}, FrameTrackId(ScopeId(1)), MakeRelativeTimeNs(0),
           MakeRelativeTimeNs(std::numeric_limits<uint64_t>::max()));
-  EXPECT_THAT(actual_active_invocation_times,
-              ElementsAre(kSamplingPeriod * uint64_t{2}, kSamplingPeriod * uint64_t{2}));
+  EXPECT_THAT(actual_active_invocation_times, ElementsAre(Times(kSamplingPeriod, uint64_t{2}),
+                                                          Times(kSamplingPeriod, uint64_t{2})));
 }
 
 TEST_F(MizarPairedDataTest, TidToNamesIsCorrect) {

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -78,7 +78,7 @@ class MizarPairedDataTmpl {
             return CallstackSamplesCount(tid, frame_starts[i], frame_starts[i + 1]);
           });
 
-      result.push_back(sampling_period * callstack_count);
+      result.push_back(Times(sampling_period, callstack_count));
     }
     return result;
   }
@@ -123,8 +123,8 @@ class MizarPairedDataTmpl {
   }
 
   [[nodiscard]] RelativeTimeNs CaptureDurationNs() const {
-    return orbit_mizar_base::MakeTimestampNs(GetCallstackData().max_time()) -
-           data_->GetCaptureStartTimestampNs();
+    return Sub(orbit_mizar_base::MakeTimestampNs(GetCallstackData().max_time()),
+               data_->GetCaptureStartTimestampNs());
   }
 
  private:
@@ -162,7 +162,7 @@ class MizarPairedDataTmpl {
   }
 
   [[nodiscard]] TimestampNs ToAbsoluteTimestamp(RelativeTimeNs relative_time) const {
-    return data_->GetCaptureStartTimestampNs() + relative_time;
+    return Add(data_->GetCaptureStartTimestampNs(), relative_time);
   }
 
   [[nodiscard]] std::pair<TimestampNs, TimestampNs> RelativeToAbsoluteTimestampRange(

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -45,7 +45,7 @@ class HalfOfSamplingWithFrameTrackReportConfig {
         duration(orbit_mizar_base::MakeRelativeTimeNs(std::numeric_limits<uint64_t>::max())),
         frame_track_id(frame_track_id) {}
 
-  [[nodiscard]] RelativeTimeNs EndRelative() const { return start_relative + duration; }
+  [[nodiscard]] RelativeTimeNs EndRelative() const { return Add(start_relative, duration); }
 
   absl::flat_hash_set<TID> tids{};
   RelativeTimeNs start_relative{};  // nanoseconds elapsed since capture start

--- a/src/MizarWidgets/SamplingWithFrameTrackReportConfigValidatorTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackReportConfigValidatorTest.cpp
@@ -87,7 +87,7 @@ TEST(SamplingWithFrameTrackReportConfigValidator, IsCorrect) {
   EXPECT_THAT(validator.Validate(
                   &bac,
                   orbit_mizar_base::MakeBaseline<HalfConfig>(
-                      absl::flat_hash_set<TID>{TID(1)}, kBaselineCaptureDuration + kOneNs, kId),
+                      absl::flat_hash_set<TID>{TID(1)}, Add(kBaselineCaptureDuration, kOneNs), kId),
                   orbit_mizar_base::MakeComparison<HalfConfig>(absl::flat_hash_set<TID>{TID(1)},
                                                                kStart, kId)),
               HasError("Baseline: Start > capture duration"));
@@ -96,8 +96,8 @@ TEST(SamplingWithFrameTrackReportConfigValidator, IsCorrect) {
       validator.Validate(
           &bac,
           orbit_mizar_base::MakeBaseline<HalfConfig>(absl::flat_hash_set<TID>{TID(1)}, kStart, kId),
-          orbit_mizar_base::MakeComparison<HalfConfig>(absl::flat_hash_set<TID>{TID(1)},
-                                                       kComparisonCaptureDuration + kOneNs, kId)),
+          orbit_mizar_base::MakeComparison<HalfConfig>(
+              absl::flat_hash_set<TID>{TID(1)}, Add(kComparisonCaptureDuration, kOneNs), kId)),
       HasError("Comparison: Start > capture duration"));
 }
 

--- a/src/OrbitBase/include/OrbitBase/Typedef.h
+++ b/src/OrbitBase/include/OrbitBase/Typedef.h
@@ -149,24 +149,22 @@ struct PlusTag : public orbit_base_internal::PlusTagBase<OtherSummandTag> {
   }
 };
 
-// TODO(b/242038711) Use functions instead of operators for Typedefs
 template <typename First, typename Second, typename FirstDecayed = std::decay_t<First>,
           typename SecondDecayed = std::decay_t<Second>, typename Tag = typename FirstDecayed::Tag,
           typename = std::enable_if_t<
               std::is_same_v<typename Tag::PlusOtherSummandTag, typename SecondDecayed::Tag>>>
-auto operator+(First&& lhs, Second&& rhs) {
+auto Add(First&& lhs, Second&& rhs) {
   return Typedef<Tag, decltype(Tag::Add(*std::forward<First>(lhs), *std::forward<Second>(rhs)))>(
       Tag::Add(*std::forward<First>(lhs), *std::forward<Second>(rhs)));
 };
 
-// TODO(b/242038711) Use functions instead of operators for Typedefs
 template <
     typename First, typename Second, typename FirstDecayed = std::decay_t<First>,
     typename SecondDecayed = std::decay_t<Second>, typename FirstTag = typename FirstDecayed::Tag,
     typename SecondTag = typename SecondDecayed::Tag,
     typename =
         std::enable_if_t<!std::is_base_of_v<orbit_base_internal::PlusTagBase<SecondTag>, FirstTag>>>
-auto operator+(First&& lhs, Second&& rhs) {
+auto Add(First&& lhs, Second&& rhs) {
   return Typedef<SecondTag,
                  decltype(SecondTag::Add(*std::forward<First>(lhs), *std::forward<Second>(rhs)))>(
       SecondTag::Add(*std::forward<First>(lhs), *std::forward<Second>(rhs)));
@@ -186,12 +184,11 @@ struct MinusTag {
   }
 };
 
-// TODO(b/242038711) Use functions instead of operators for Typedefs
 template <typename First, typename Second, typename FirstDecayed = std::decay_t<First>,
           typename SecondDecayed = std::decay_t<Second>, typename Tag = typename FirstDecayed::Tag,
           typename ResultTag = typename Tag::MinusResultTag,
           typename = std::enable_if_t<std::is_same_v<Tag, typename SecondDecayed::Tag>>>
-auto operator-(First&& lhs, Second&& rhs) {
+auto Sub(First&& lhs, Second&& rhs) {
   return Typedef<ResultTag,
                  decltype(Tag::Sub(*std::forward<First>(lhs), *std::forward<Second>(rhs)))>(
       Tag::Sub(*std::forward<First>(lhs), *std::forward<Second>(rhs)));
@@ -209,23 +206,14 @@ struct TimesScalarTag : orbit_base_internal::TimesScalarTagBase<Scalar> {
   }
 };
 
-// TODO(b/242038711) Use functions instead of operators for Typedefs
 template <typename Vector, typename Scalar, typename VectorDecayed = std::decay_t<Vector>,
           typename ScalarDecayed = std::decay_t<Scalar>, typename Tag = typename VectorDecayed::Tag,
           typename = std::enable_if_t<
               std::is_base_of_v<orbit_base_internal::TimesScalarTagBase<ScalarDecayed>, Tag>>>
-auto operator*(Vector&& vector, Scalar&& scalar) {
+auto Times(Vector&& vector, Scalar&& scalar) {
   return Typedef<Tag, decltype(Tag::TimesScalar(*std::forward<Vector>(vector),
                                                 std::forward<Scalar>(scalar)))>(
       Tag::TimesScalar(*std::forward<Vector>(vector), std::forward<Scalar>(scalar)));
-}
-
-template <typename Vector, typename Scalar, typename VectorDecayed = std::decay_t<Vector>,
-          typename ScalarDecayed = std::decay_t<Scalar>, typename Tag = typename VectorDecayed::Tag,
-          typename = std::enable_if_t<
-              std::is_base_of_v<orbit_base_internal::TimesScalarTagBase<ScalarDecayed>, Tag>>>
-auto operator*(Scalar&& scalar, Vector&& vector) {
-  return std::forward<Vector>(vector) * std::forward<Scalar>(scalar);
 }
 
 // Say, we have a pair of typedefs.


### PR DESCRIPTION
As Typedef arithmetics explicitly enables customisation and `+` for
a Typedef doesn't necessarily mean the same as + for the "raw" types,
the operators are replaced by functions.

Bug: http://b/242038711
Test: Unit, Manual, Compile