### PR TITLE
Add MetricsUploader::SendSymbolLoadEvent

### DIFF
--- a/src/ConfigWidgets/SymbolLocationsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialogTest.cpp
@@ -23,7 +23,7 @@
 #include "ClientSymbols/PersistentStorageManager.h"
 #include "ConfigWidgets/SymbolLocationsDialog.h"
 #include "GrpcProtos/module.pb.h"
-#include "MetricsUploader/ScopedMetric.h"
+#include "MetricsUploader/MockMetricsUploader.h"
 #include "MetricsUploader/orbit_log_event.pb.h"
 #include "Test/Path.h"
 #include "TestUtils/TestUtils.h"
@@ -43,25 +43,6 @@ class MockPersistentStorageManager : public orbit_client_symbols::PersistentStor
   MOCK_METHOD((ModuleSymbolFileMappings), LoadModuleSymbolFileMappings, (), (override));
   MOCK_METHOD(void, SaveDisabledModulePaths, (absl::flat_hash_set<std::string>), (override));
   MOCK_METHOD(absl::flat_hash_set<std::string>, LoadDisabledModulePaths, (), (override));
-};
-
-class MockMetricsUploader : public orbit_metrics_uploader::MetricsUploader {
- public:
-  MOCK_METHOD(bool, SendLogEvent,
-              (orbit_metrics_uploader::OrbitLogEvent_LogEventType /*log_event_type*/), (override));
-  MOCK_METHOD(bool, SendLogEvent,
-              (orbit_metrics_uploader::OrbitLogEvent_LogEventType /*log_event_type*/,
-               std::chrono::milliseconds /*event_duration*/),
-              (override));
-  MOCK_METHOD(bool, SendLogEvent,
-              (orbit_metrics_uploader::OrbitLogEvent_LogEventType /*log_event_type*/,
-               std::chrono::milliseconds /*event_duration*/,
-               OrbitLogEvent::StatusCode /*status_code*/),
-              (override));
-  MOCK_METHOD(bool, SendCaptureEvent,
-              (orbit_metrics_uploader::OrbitCaptureData /*capture data*/,
-               OrbitLogEvent::StatusCode /*status_code*/),
-              (override));
 };
 
 class SymbolLocationsDialogTest : public ::testing::Test {
@@ -139,7 +120,7 @@ class SymbolLocationsDialogTest : public ::testing::Test {
   }
 
   MockPersistentStorageManager mock_storage_manager_;
-  MockMetricsUploader mock_uploader_;
+  orbit_metrics_uploader::MockMetricsUploader mock_uploader_;
 };
 
 TEST_F(SymbolLocationsDialogTest, ConstructEmpty) {

--- a/src/MetricsUploader/CMakeLists.txt
+++ b/src/MetricsUploader/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_LIST_DIR}/incl
 target_sources(MetricsUploader PUBLIC include/MetricsUploader/CaptureMetric.h
                                       include/MetricsUploader/MetricsUploader.h
                                       include/MetricsUploader/MetricsUploaderStub.h
+                                      include/MetricsUploader/MockMetricsUploader.h
                                       include/MetricsUploader/Result.h
                                       include/MetricsUploader/ScopedMetric.h
                                PRIVATE CaptureMetric.cpp

--- a/src/MetricsUploader/CaptureMetricTest.cpp
+++ b/src/MetricsUploader/CaptureMetricTest.cpp
@@ -9,7 +9,7 @@
 #include <thread>
 
 #include "MetricsUploader/CaptureMetric.h"
-#include "MetricsUploader/MetricsUploader.h"
+#include "MetricsUploader/MockMetricsUploader.h"
 #include "MetricsUploader/orbit_log_event.pb.h"
 #include "Test/Path.h"
 
@@ -101,25 +101,8 @@ bool HasSameCaptureCompleteData(const OrbitCaptureData& capture_data,
 using ::testing::_;
 using ::testing::Ge;
 
-class MockUploader : public MetricsUploader {
- public:
-  MOCK_METHOD(bool, SendLogEvent, (OrbitLogEvent_LogEventType /*log_event_type*/), (override));
-  MOCK_METHOD(bool, SendLogEvent,
-              (OrbitLogEvent_LogEventType /*log_event_type*/,
-               std::chrono::milliseconds /*event_duration*/),
-              (override));
-  MOCK_METHOD(bool, SendLogEvent,
-              (OrbitLogEvent_LogEventType /*log_event_type*/,
-               std::chrono::milliseconds /*event_duration*/,
-               OrbitLogEvent::StatusCode /*status_code*/),
-              (override));
-  MOCK_METHOD(bool, SendCaptureEvent,
-              (OrbitCaptureData /*capture data*/, OrbitLogEvent::StatusCode /*status_code*/),
-              (override));
-};
-
 TEST(CaptureMetric, SendCaptureFailed) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   EXPECT_CALL(uploader, SendCaptureEvent(_, _))
       .Times(1)
@@ -139,7 +122,7 @@ TEST(CaptureMetric, SendCaptureFailed) {
 }
 
 TEST(CaptureMetric, SendCaptureCancelled) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   EXPECT_CALL(uploader, SendCaptureEvent(_, _))
       .Times(1)
@@ -159,7 +142,7 @@ TEST(CaptureMetric, SendCaptureCancelled) {
 }
 
 TEST(CaptureMetric, SendCaptureSucceeded) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   EXPECT_CALL(uploader, SendCaptureEvent(_, _))
       .Times(1)
@@ -178,7 +161,7 @@ TEST(CaptureMetric, SendCaptureSucceeded) {
 }
 
 TEST(CaptureMetric, SendCaptureSucceededWithoutCompleteData) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   EXPECT_CALL(uploader, SendCaptureEvent(_, _))
       .Times(1)
@@ -197,7 +180,7 @@ TEST(CaptureMetric, SendCaptureSucceededWithoutCompleteData) {
 }
 
 TEST(CaptureMetric, SendCaptureWithFile) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   constexpr uint64_t kTestFileSize = 10;
 
@@ -222,7 +205,7 @@ TEST(CaptureMetric, SendCaptureWithFile) {
 }
 
 TEST(CaptureMetric, SendCaptureWithoutFile) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   EXPECT_CALL(uploader, SendCaptureEvent(_, _))
       .Times(1)

--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -43,6 +43,9 @@ class MetricsUploaderImpl : public MetricsUploader {
                     OrbitLogEvent::StatusCode status_code) override;
   bool SendCaptureEvent(OrbitCaptureData capture_data,
                         OrbitLogEvent::StatusCode status_code) override;
+  bool SendSymbolLoadEvent(OrbitPerModuleSymbolLoadData symbol_load_data,
+                           std::chrono::milliseconds event_duration,
+                           OrbitLogEvent::StatusCode status_code) override;
 
  private:
   [[nodiscard]] bool FillAndSendLogEvent(OrbitLogEvent partial_filled_event) const;
@@ -252,6 +255,17 @@ bool MetricsUploaderImpl::SendCaptureEvent(OrbitCaptureData capture_data,
   OrbitLogEvent log_event;
   log_event.set_log_event_type(OrbitLogEvent::ORBIT_CAPTURE_END);
   *log_event.mutable_orbit_capture_data() = std::move(capture_data);
+  log_event.set_status_code(status_code);
+  return FillAndSendLogEvent(log_event);
+}
+
+bool MetricsUploaderImpl::SendSymbolLoadEvent(OrbitPerModuleSymbolLoadData symbol_load_data,
+                                              std::chrono::milliseconds event_duration,
+                                              OrbitLogEvent::StatusCode status_code) {
+  OrbitLogEvent log_event;
+  log_event.set_log_event_type(OrbitLogEvent::ORBIT_SYMBOL_LOAD_V2);
+  *log_event.mutable_orbit_per_module_symbol_load_data() = std::move(symbol_load_data);
+  log_event.set_event_duration_milliseconds(event_duration.count());
   log_event.set_status_code(status_code);
   return FillAndSendLogEvent(log_event);
 }

--- a/src/MetricsUploader/ScopedMetricTest.cpp
+++ b/src/MetricsUploader/ScopedMetricTest.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 
 #include "MetricsUploader/MetricsUploader.h"
+#include "MetricsUploader/MockMetricsUploader.h"
 #include "MetricsUploader/ScopedMetric.h"
 
 namespace orbit_metrics_uploader {
@@ -18,27 +19,10 @@ using ::testing::AllOf;
 using ::testing::Ge;
 using ::testing::Lt;
 
-class MockUploader : public MetricsUploader {
- public:
-  MOCK_METHOD(bool, SendLogEvent, (OrbitLogEvent::LogEventType /*log_event_type*/), (override));
-  MOCK_METHOD(bool, SendLogEvent,
-              (OrbitLogEvent::LogEventType /*log_event_type*/,
-               std::chrono::milliseconds /*event_duration*/),
-              (override));
-  MOCK_METHOD(bool, SendLogEvent,
-              (OrbitLogEvent::LogEventType /*log_event_type*/,
-               std::chrono::milliseconds /*event_duration*/,
-               OrbitLogEvent::StatusCode /*status_code*/),
-              (override));
-  MOCK_METHOD(bool, SendCaptureEvent,
-              (OrbitCaptureData /*capture data*/, OrbitLogEvent::StatusCode /*status_code*/),
-              (override));
-};
-
 TEST(ScopedMetric, Constructor) {
   { ScopedMetric metric{nullptr, OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN}; }
 
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   EXPECT_CALL(uploader,
               SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN, _, OrbitLogEvent::SUCCESS))
@@ -48,7 +32,7 @@ TEST(ScopedMetric, Constructor) {
 }
 
 TEST(ScopedMetric, SetStatusCode) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   EXPECT_CALL(uploader,
               SendLogEvent(OrbitLogEvent::ORBIT_MAIN_WINDOW_OPEN, _, OrbitLogEvent::CANCELLED))
@@ -61,7 +45,7 @@ TEST(ScopedMetric, SetStatusCode) {
 }
 
 TEST(ScopedMetric, Sleep) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   std::chrono::milliseconds sleep_time{1};
 
@@ -76,7 +60,7 @@ TEST(ScopedMetric, Sleep) {
 }
 
 TEST(ScopedMetric, MoveAndSleep) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   std::chrono::milliseconds sleep_time{1};
 
@@ -93,7 +77,7 @@ TEST(ScopedMetric, MoveAndSleep) {
 }
 
 TEST(ScopedMetric, PauseAndResume) {
-  MockUploader uploader{};
+  MockMetricsUploader uploader{};
 
   std::chrono::milliseconds sleep_time{200};
 

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -62,6 +62,12 @@ class MetricsUploader {
   // Returns true on success and false otherwise
   virtual bool SendCaptureEvent(OrbitCaptureData capture_data,
                                 OrbitLogEvent::StatusCode status_code) = 0;
+
+  // Send a ORBIT_SYMBOL_LOAD_V2 log event with an attached OrbitPerModuleSymbolLoadData message, an
+  // event duration and a status code. Returns true on success and false otherwise.
+  virtual bool SendSymbolLoadEvent(OrbitPerModuleSymbolLoadData symbol_load_data,
+                                   std::chrono::milliseconds event_duration,
+                                   OrbitLogEvent::StatusCode status_code) = 0;
 };
 
 [[nodiscard]] ErrorMessageOr<std::string> GenerateUUID();

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploaderStub.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploaderStub.h
@@ -28,6 +28,11 @@ class MetricsUploaderStub : public MetricsUploader {
                         OrbitLogEvent::StatusCode /*status_code*/) override {
     return false;
   }
+  bool SendSymbolLoadEvent(OrbitPerModuleSymbolLoadData /*symbol_load_data*/,
+                           std::chrono::milliseconds /*event_duration*/,
+                           OrbitLogEvent::StatusCode /*status_code*/) override {
+    return false;
+  }
 };
 
 }  // namespace orbit_metrics_uploader

--- a/src/MetricsUploader/include/MetricsUploader/MockMetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MockMetricsUploader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/MetricsUploader/include/MetricsUploader/MockMetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MockMetricsUploader.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+
+#include "MetricsUploader/MetricsUploader.h"
+#include "MetricsUploader/orbit_log_event.pb.h"
+
+namespace orbit_metrics_uploader {
+
+class MockMetricsUploader : public MetricsUploader {
+ public:
+  MOCK_METHOD(bool, SendLogEvent, (OrbitLogEvent::LogEventType /*log_event_type*/), (override));
+  MOCK_METHOD(bool, SendLogEvent,
+              (OrbitLogEvent::LogEventType /*log_event_type*/,
+               std::chrono::milliseconds /*event_duration*/),
+              (override));
+  MOCK_METHOD(bool, SendLogEvent,
+              (OrbitLogEvent::LogEventType /*log_event_type*/,
+               std::chrono::milliseconds /*event_duration*/,
+               OrbitLogEvent::StatusCode /*status_code*/),
+              (override));
+  MOCK_METHOD(bool, SendCaptureEvent,
+              (OrbitCaptureData /*capture data*/, OrbitLogEvent::StatusCode /*status_code*/),
+              (override));
+  MOCK_METHOD(bool, SendSymbolLoadEvent,
+              (OrbitPerModuleSymbolLoadData /*symbol_load_data*/,
+               std::chrono::milliseconds /*event_duration*/,
+               OrbitLogEvent::StatusCode /*status_code*/),
+              (override));
+};
+
+}  // namespace orbit_metrics_uploader


### PR DESCRIPTION
This adds MetricsUploader::SendSymbolLoadEvent for the new log message
OrbitPerModuleSymbolLoadData. It also extracts MockMetricsUploader into
its own file for deduplication.

Bug: http://b/231455031