### PR TITLE
Make "Iterators" tab active when "Add Iterator(s)" is invoked

### DIFF
--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -138,6 +138,8 @@ void OrbitLiveFunctions::AddIterator(size_t id, const FunctionInfo* function) {
 
   dynamic_cast<QBoxLayout*>(ui_->iteratorFrame->layout())
       ->insertWidget(ui_->iteratorFrame->layout()->count() - 1, iterator_ui);
+
+  ui_->tabWidget->setCurrentWidget(ui_->iterators_tab);
 }
 
 QLineEdit* OrbitLiveFunctions::GetFilterLineEdit() {


### PR DESCRIPTION
By default, the "Histrogram" tab is active. So when the user was
adding an iterator, nothing in the UI was changing. This fixes
that.

Tests: Manual
Bug: http://b/232060011