### PR TITLE
Add UI for tracepoint callstack collection

### DIFF
--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -315,4 +315,15 @@ uint64_t DataManager::memory_warning_threshold_kb() const {
   return memory_warning_threshold_kb_;
 }
 
+void DataManager::set_tracepoint_callstack_method(
+    orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  tracepoint_callstack_method_ = tracepoint_callstack_method;
+}
+
+orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
+DataManager::tracepoint_callstack_method() const {
+  return tracepoint_callstack_method_;
+}
+
 }  // namespace orbit_client_data

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -315,15 +315,27 @@ uint64_t DataManager::memory_warning_threshold_kb() const {
   return memory_warning_threshold_kb_;
 }
 
-void DataManager::set_tracepoint_callstack_method(
-    orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method) {
+void DataManager::set_thread_state_change_callstack_method(
+    orbit_grpc_protos::CaptureOptions::UnwindingMethod thread_state_change_callstack_method) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  tracepoint_callstack_method_ = tracepoint_callstack_method;
+  thread_state_change_callstack_method_ = thread_state_change_callstack_method;
 }
 
-orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
-DataManager::tracepoint_callstack_method() const {
-  return tracepoint_callstack_method_;
+orbit_grpc_protos::CaptureOptions::UnwindingMethod
+DataManager::thread_state_change_callstack_method() const {
+  return thread_state_change_callstack_method_;
+}
+
+void DataManager::set_thread_state_change_callstack_collection(
+    orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
+        thread_state_change_callstack_collection) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  thread_state_change_callstack_collection_ = thread_state_change_callstack_collection;
+}
+
+orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
+DataManager::thread_state_change_callstack_collection() const {
+  return thread_state_change_callstack_collection_;
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -85,10 +85,16 @@ class DataManager final {
   void set_enable_introspection(bool enable_introspection);
   [[nodiscard]] bool enable_introspection() const;
 
-  void set_tracepoint_callstack_method(
-      orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method);
-  [[nodiscard]] orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
-  tracepoint_callstack_method() const;
+  void set_thread_state_change_callstack_method(
+      orbit_grpc_protos::CaptureOptions::UnwindingMethod thread_state_change_callstack_method);
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod
+  thread_state_change_callstack_method() const;
+
+  void set_thread_state_change_callstack_collection(
+      orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
+          thread_state_change_callstack_collection);
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
+  thread_state_change_callstack_collection() const;
 
   void set_dynamic_instrumentation_method(
       orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod method);
@@ -147,7 +153,9 @@ class DataManager final {
   bool enable_api_ = false;
   bool enable_introspection_ = false;
   orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod dynamic_instrumentation_method_{};
-  orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method_{};
+  orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
+      thread_state_change_callstack_collection_{};
+  orbit_grpc_protos::CaptureOptions::UnwindingMethod thread_state_change_callstack_method_{};
   WineSyscallHandlingMethod wine_syscall_handling_method_{};
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
   double samples_per_second_ = 0;

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -85,6 +85,11 @@ class DataManager final {
   void set_enable_introspection(bool enable_introspection);
   [[nodiscard]] bool enable_introspection() const;
 
+  void set_tracepoint_callstack_method(
+      orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method);
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
+  tracepoint_callstack_method() const;
+
   void set_dynamic_instrumentation_method(
       orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod method);
   [[nodiscard]] orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod
@@ -142,6 +147,7 @@ class DataManager final {
   bool enable_api_ = false;
   bool enable_introspection_ = false;
   orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod dynamic_instrumentation_method_{};
+  orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method_{};
   WineSyscallHandlingMethod wine_syscall_handling_method_{};
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
   double samples_per_second_ = 0;

--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -87,3 +87,6 @@ ABSL_FLAG(
 ABSL_FLAG(bool, auto_frame_track, true, "Automatically add the default Frame Track.");
 
 ABSL_FLAG(bool, time_range_selection, false, "Enable time range selection feature.");
+
+ABSL_FLAG(bool, tracepoint_callstack_collection, false,
+          "Enable callstack gathering for tracepoints feature.");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -73,4 +73,7 @@ ABSL_DECLARE_FLAG(bool, auto_frame_track);
 // Enables time range selection feature.
 ABSL_DECLARE_FLAG(bool, time_range_selection);
 
+// Enables callstack gathering with tracepoints.
+ABSL_DECLARE_FLAG(bool, tracepoint_callstack_collection);
+
 #endif  // CLIENT_FLAGS_CLIENT_FLAGS_H_

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -106,7 +106,8 @@ message CaptureOptions {
     kThreadStateChangeCallStackCollection = 2;
   }
 
-  ThreadStateChangeCallStackCollection thread_state_change_call_stack_collection = 15;
+  ThreadStateChangeCallStackCollection 
+      thread_state_change_call_stack_collection = 15;
   UnwindingMethod thread_state_change_call_stack_unwinding_method = 21;
 }
 

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -106,7 +106,7 @@ message CaptureOptions {
     kThreadStateChangeCallStackCollection = 2;
   }
 
-  ThreadStateChangeCallStackCollection 
+  ThreadStateChangeCallStackCollection
       thread_state_change_call_stack_collection = 21;
   UnwindingMethod thread_state_change_call_stack_unwinding_method = 22;
 }

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -100,7 +100,7 @@ message CaptureOptions {
 
   bool enable_api = 14;
 
-  enum TracepointCallstackMethod{
+  enum TracepointCallstackMethod {
     kTracepointCallstackMethodUnspecified = 0;
     kPureTracepoint = 1;
     kFramePointersTracepoint = 2;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -99,6 +99,15 @@ message CaptureOptions {
   repeated ApiFunction api_functions = 13;
 
   bool enable_api = 14;
+
+  enum TracepointCallstackMethod{
+    kTracepointCallstackMethodUnspecified = 0;
+    kPureTracepoint = 1;
+    kFramePointersTracepoint = 2;
+    kDWARFTracepoint = 3;
+  }
+
+  TracepointCallstackMethod tracepoint_callstack_method = 15;
 }
 
 // For CaptureEvents with a duration, excluding for now GPU-related ones, we

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -100,14 +100,14 @@ message CaptureOptions {
 
   bool enable_api = 14;
 
-  enum TracepointCallstackMethod {
-    kTracepointCallstackMethodUnspecified = 0;
-    kPureTracepoint = 1;
-    kFramePointersTracepoint = 2;
-    kDWARFTracepoint = 3;
+  enum ThreadStateChangeCallStackCollection {
+    kThreadStateChangeCallStackCollectionUnspecified = 0;
+    kNoThreadStateChangeCallStackCollection = 1;
+    kThreadStateChangeCallStackCollection = 2;
   }
 
-  TracepointCallstackMethod tracepoint_callstack_method = 15;
+  ThreadStateChangeCallStackCollection thread_state_change_call_stack_collection = 15;
+  UnwindingMethod thread_state_change_call_stack_unwinding_method = 21;
 }
 
 // For CaptureEvents with a duration, excluding for now GPU-related ones, we

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -107,8 +107,8 @@ message CaptureOptions {
   }
 
   ThreadStateChangeCallStackCollection 
-      thread_state_change_call_stack_collection = 15;
-  UnwindingMethod thread_state_change_call_stack_unwinding_method = 21;
+      thread_state_change_call_stack_collection = 21;
+  UnwindingMethod thread_state_change_call_stack_unwinding_method = 22;
 }
 
 // For CaptureEvents with a duration, excluding for now GPU-related ones, we

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -455,13 +455,23 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const {
     return GetCaptureData().memory_warning_threshold_kb();
   }
-  [[nodiscard]] orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
-  GetTracepointCallstackMethod() const {
-    return data_manager_->tracepoint_callstack_method();
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod
+  GetThreadStateChangeCallstackMethod() const {
+    return data_manager_->thread_state_change_callstack_method();
   }
-  void SetTracepointCallstackMethod(
-      orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method) {
-    data_manager_->set_tracepoint_callstack_method(tracepoint_callstack_method);
+  void SetThreadStateChangeCallstackMethod(
+      orbit_grpc_protos::CaptureOptions::UnwindingMethod thread_state_change_callstack_method) {
+    data_manager_->set_thread_state_change_callstack_method(thread_state_change_callstack_method);
+  }
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
+  GetThreadStateChangeCallstackCollection() const {
+    return data_manager_->thread_state_change_callstack_collection();
+  }
+  void SetThreadStateChangeCallstackCollection(
+      orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
+          thread_state_change_callstack_collection) {
+    data_manager_->set_thread_state_change_callstack_collection(
+        thread_state_change_callstack_collection);
   }
 
   // TODO(kuebler): Move them to a separate controller at some point

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -455,6 +455,14 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const {
     return GetCaptureData().memory_warning_threshold_kb();
   }
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
+  GetTracepointCallstackMethod() const {
+    return data_manager_->tracepoint_callstack_method();
+  }
+  void SetTracepointCallstackMethod(
+      orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method) {
+    data_manager_->set_tracepoint_callstack_method(tracepoint_callstack_method);
+  }
 
   // TODO(kuebler): Move them to a separate controller at some point
   void SelectFunction(const orbit_client_data::FunctionInfo& func) override;

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -241,9 +241,13 @@ void CaptureOptionsDialog::SetThreadStateChangeCallstackMethod(
       ui_->threadStateChangeCallstackDWARFMethodRadioButton->setChecked(false);
       break;
     case CaptureOptions::kDwarf:
-    default:
-      ui_->threadStateChangeCallstackDWARFMethodRadioButton->setChecked(true);
       ui_->threadStateChangeCallstackFramepointersMethodRadioButton->setChecked(false);
+      ui_->threadStateChangeCallstackDWARFMethodRadioButton->setChecked(true);
+      break;
+    default:
+      ORBIT_ERROR(
+          "thread_state_change_callstack_method is undefined in "
+          "SetThreadStateChangeCallstackMethod");
       break;
   }
 }
@@ -256,7 +260,7 @@ CaptureOptionsDialog::GetThreadStateChangeCallstackMethod() const {
   if (ui_->threadStateChangeCallstackDWARFMethodRadioButton->isChecked()) {
     return CaptureOptions::kDwarf;
   }
-  return CaptureOptions::kDwarf;
+  return CaptureOptions::kUndefined;
 }
 
 void CaptureOptionsDialog::SetWineSyscallHandlingMethod(

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -88,6 +88,13 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   ui_->memorySamplingPeriodMsLineEdit->setValidator(new UInt64Validator(
       1, std::numeric_limits<uint64_t>::max(), ui_->memorySamplingPeriodMsLineEdit));
   ui_->memoryWarningThresholdKbLineEdit->setValidator(&uint64_validator_);
+  ui_->tracepointCallstackCollectionCheckBox->setEnabled(ui_->threadStateCheckBox->isChecked());
+  ui_->tracepointCallstackDWARFMethodRadioButton->setEnabled(
+      ui_->threadStateCheckBox->isChecked() &&
+      ui_->tracepointCallstackCollectionCheckBox->isChecked());
+  ui_->tracepointCallstackFramepointersMethodRadioButton->setEnabled(
+      ui_->threadStateCheckBox->isChecked() &&
+      ui_->tracepointCallstackCollectionCheckBox->isChecked());
 
   if (!absl::GetFlag(FLAGS_auto_frame_track)) {
     ui_->autoFrameTrackGroupBox->hide();

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -61,12 +61,12 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] bool GetCollectThreadStates() const;
   void SetTraceGpuSubmissions(bool trace_gpu_submissions);
   [[nodiscard]] bool GetTraceGpuSubmissions() const;
-  void SetPureOrNotTracepoint(bool is_pure);
-  [[nodiscard]] bool GetPureOrNotTracepoint() const;
-  void SetTracepointCallstackMethod(
-      orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method);
-  [[nodiscard]] orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
-  GetTracepointCallstackMethod() const;
+  void SetEnableCallStackCollectionOnThreadStateChanges(bool check);
+  [[nodiscard]] bool GetEnableCallStackCollectionOnThreadStateChanges() const;
+  void SetThreadStateChangeCallstackMethod(
+      orbit_grpc_protos::CaptureOptions::UnwindingMethod thread_state_change_callstack_method);
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod
+  GetThreadStateChangeCallstackMethod() const;
   void SetEnableApi(bool enable_api);
   [[nodiscard]] bool GetEnableApi() const;
   void SetDynamicInstrumentationMethod(
@@ -101,9 +101,11 @@ class CaptureOptionsDialog : public QDialog {
   static constexpr orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod
       kDynamicInstrumentationMethodDefaultValue =
           orbit_grpc_protos::CaptureOptions::kUserSpaceInstrumentation;
-  static constexpr bool kIsPureTracepointDefault = true;
-  static constexpr orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
-      kTracepointCallstackMethodDefaultValue = orbit_grpc_protos::CaptureOptions::kPureTracepoint;
+  static constexpr orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
+      kThreadStateChangeCallStackCollectionDefaultValue =
+          orbit_grpc_protos::CaptureOptions::kNoThreadStateChangeCallStackCollection;
+  static constexpr orbit_grpc_protos::CaptureOptions::UnwindingMethod
+      kThreadStateChangeCallStackMethodDefaultValue = orbit_grpc_protos::CaptureOptions::kUndefined;
   static constexpr uint64_t kLocalMarkerDepthDefaultValue = 0;
   static constexpr orbit_client_data::WineSyscallHandlingMethod
       kWineSyscallHandlingMethodDefaultValue =

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -61,6 +61,12 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] bool GetCollectThreadStates() const;
   void SetTraceGpuSubmissions(bool trace_gpu_submissions);
   [[nodiscard]] bool GetTraceGpuSubmissions() const;
+  void SetPureOrNotTracepoint(bool is_pure);
+  [[nodiscard]] bool GetPureOrNotTracepoint() const;
+  void SetTracepointCallstackMethod(
+      orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod tracepoint_callstack_method);
+  [[nodiscard]] orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
+  GetTracepointCallstackMethod() const;
   void SetEnableApi(bool enable_api);
   [[nodiscard]] bool GetEnableApi() const;
   void SetDynamicInstrumentationMethod(
@@ -95,6 +101,9 @@ class CaptureOptionsDialog : public QDialog {
   static constexpr orbit_grpc_protos::CaptureOptions::DynamicInstrumentationMethod
       kDynamicInstrumentationMethodDefaultValue =
           orbit_grpc_protos::CaptureOptions::kUserSpaceInstrumentation;
+  static constexpr bool kIsPureTracepointDefault = true;
+  static constexpr orbit_grpc_protos::CaptureOptions::TracepointCallstackMethod
+      kTracepointCallstackMethodDefaultValue = orbit_grpc_protos::CaptureOptions::kPureTracepoint;
   static constexpr uint64_t kLocalMarkerDepthDefaultValue = 0;
   static constexpr orbit_client_data::WineSyscallHandlingMethod
       kWineSyscallHandlingMethodDefaultValue =

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -543,6 +543,9 @@ p, li { white-space: pre-wrap; }
           </item>
           <item>
            <widget class="QCheckBox" name="threadStateChangeCallstackCollectionCheckBox">
+            <property name="toolTip">
+             <string>This allows capturing call stacks when threads change their states</string>
+            </property>
             <property name="text">
              <string>Collect call stacks on thread state changes</string>
             </property>
@@ -556,8 +559,11 @@ p, li { white-space: pre-wrap; }
             <property name="enabled">
              <bool>true</bool>
             </property>
+            <property name="toolTip">
+             <string>This chooses the unwinding method to be used to unwind call stacks gathered at thead state changes</string>
+            </property>
             <property name="title">
-             <string>Unwinding method</string>
+             <string>Thread state change call stacks unwinding method</string>
             </property>
             <property name="checkable">
              <bool>false</bool>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -542,7 +542,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="tracepointCallstackCollectionCheckBox">
+           <widget class="QCheckBox" name="threadStateChangeCallstackCollectionCheckBox">
             <property name="text">
              <string>Collect call stacks on thread state changes</string>
             </property>
@@ -552,7 +552,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="tracepointUnwindingMethodGroupBox">
+           <widget class="QGroupBox" name="threadStateChangeCallstackUnwindingMethodGroupBox">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -564,7 +564,7 @@ p, li { white-space: pre-wrap; }
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_16">
              <item>
-              <widget class="QRadioButton" name="tracepointCallstackDWARFMethodRadioButton">
+              <widget class="QRadioButton" name="threadStateChangeCallstackDWARFMethodRadioButton">
                <property name="text">
                 <string>DWARF</string>
                </property>
@@ -574,7 +574,7 @@ p, li { white-space: pre-wrap; }
               </widget>
              </item>
              <item>
-              <widget class="QRadioButton" name="tracepointCallstackFramepointersMethodRadioButton">
+              <widget class="QRadioButton" name="threadStateChangeCallstackFramepointersMethodRadioButton">
                <property name="text">
                 <string>Frame pointers</string>
                </property>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -66,9 +66,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-435</y>
         <width>502</width>
-        <height>990</height>
+        <height>1190</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -363,17 +363,17 @@ p, li { white-space: pre-wrap; }
           <property name="bottomMargin">
            <number>9</number>
           </property>
-           <item>
-             <widget class="QRadioButton" name="userSpaceRadioButton">
-               <property name="accessibleName">
-                 <string>UserSpaceInstrumentationRadioButton</string>
-               </property>
-               <property name="text">
-                 <string>Orbit</string>
-               </property>
-             </widget>
-           </item>
-           <item>
+          <item>
+           <widget class="QRadioButton" name="userSpaceRadioButton">
+            <property name="accessibleName">
+             <string>UserSpaceInstrumentationRadioButton</string>
+            </property>
+            <property name="text">
+             <string>Orbit</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QRadioButton" name="uprobesRadioButton">
             <property name="accessibleName">
              <string>UprobesRadioButton</string>
@@ -539,6 +539,48 @@ p, li { white-space: pre-wrap; }
             <property name="text">
              <string>Collect thread states</string>
             </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="tracepointCallstackCollectionCheckBox">
+            <property name="text">
+             <string>Collect call stacks on thread state changes</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="tracepointUnwindingMethodGroupBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="title">
+             <string>Unwinding method</string>
+            </property>
+            <property name="checkable">
+             <bool>false</bool>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_16">
+             <item>
+              <widget class="QRadioButton" name="tracepointCallstackDWARFMethodRadioButton">
+               <property name="text">
+                <string>DWARF</string>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="tracepointCallstackFramepointersMethodRadioButton">
+               <property name="text">
+                <string>Frame pointers</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -232,6 +232,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kMemorySamplingPeriodMsSettingKey;
   static const QString kMemoryWarningThresholdKbSettingKey;
   static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;
+  static const QString kIsPureTracepoint;
+  static const QString kTracepointCallstackCollectionMethod;
   static const QString kMaxLocalMarkerDepthPerCommandBufferSettingsKey;
   static const QString kMainWindowGeometrySettingKey;
   static const QString kMainWindowStateSettingKey;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -232,8 +232,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kMemorySamplingPeriodMsSettingKey;
   static const QString kMemoryWarningThresholdKbSettingKey;
   static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;
-  static const QString kIsPureTracepoint;
-  static const QString kTracepointCallstackCollectionMethod;
+  static const QString kEnableCallStackCollectionOnThreadStateChanges;
+  static const QString kCallStackCollectionOnThreadStateChangesMethod;
   static const QString kMaxLocalMarkerDepthPerCommandBufferSettingsKey;
   static const QString kMainWindowGeometrySettingKey;
   static const QString kMainWindowStateSettingKey;


### PR DESCRIPTION
This PR adds capture options that allow you to choose between different (if any) unwinding methods for the tracepoint call stack collection feature. The options are hidden behind the `tracepoint_callstack_collection` flag. Currently, choosing these options doesn't do anything as the feature is not completely implemented yet.

Bug: http://b/242681490

Screenshot: http://screenshot/8m9QmvkuVY5qJvE.png 