### PR TITLE
Fix flakyness in TopDownBottomUpOfLoadedCapture.

### DIFF
--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -7,7 +7,6 @@ found in the LICENSE file.
 import logging
 import os
 import tempfile
-import time
 import shutil
 
 from typing import Iterable

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -59,6 +59,7 @@ class LoadCapture(E2ETestCase):
 
         others_button = self.find_control('Button', '...')
         others_button.click_input()
+
         wait_for_condition(lambda: self.find_control('Edit', 'File name:') is not None,
                            max_seconds=120)
         file_name_edit = self.find_control('Edit', 'File name:')

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -59,9 +59,8 @@ class LoadCapture(E2ETestCase):
 
         others_button = self.find_control('Button', '...')
         others_button.click_input()
-        # There is a rare flakyness which causes the file dialog to open slowly: b/242843902
-        time.sleep(10)
-
+        wait_for_condition(lambda: self.find_control('Edit', 'File name:') is not None,
+                           max_seconds=120)
         file_name_edit = self.find_control('Edit', 'File name:')
 
         if not os.path.isabs(capture_file_path):

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -7,6 +7,7 @@ found in the LICENSE file.
 import logging
 import os
 import tempfile
+import time
 import shutil
 
 from typing import Iterable
@@ -58,6 +59,8 @@ class LoadCapture(E2ETestCase):
 
         others_button = self.find_control('Button', '...')
         others_button.click_input()
+        # There is a rare flakyness which causes the file dialog to open slowly: b/242843902
+        time.sleep(10)
 
         file_name_edit = self.find_control('Edit', 'File name:')
 


### PR DESCRIPTION
Merely adding an additional wait of 10s to give the system time to
react.

Bug: http://b/242843902
Test: local run - still works, the wait happens.