### PR TITLE
Add readers to consume tracepoints with callstacks

### DIFF
--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -193,7 +193,7 @@ void ReadPerfSampleIdAll(PerfEventRingBuffer* ring_buffer, const perf_event_head
   ring_buffer->ReadValueAtOffset(sample_id, offset);
 }
 
-uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer) {
+[[nodiscard]] uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer) {
   uint64_t time;
   // All PERF_RECORD_SAMPLEs start with
   //   perf_event_header header;
@@ -204,7 +204,7 @@ uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer) {
   return time;
 }
 
-uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer) {
+[[nodiscard]] uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer) {
   uint64_t stream_id;
   // All PERF_RECORD_SAMPLEs start with
   //   perf_event_header header;
@@ -215,7 +215,7 @@ uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer) {
   return stream_id;
 }
 
-pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
+[[nodiscard]] pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
   pid_t pid;
   // All PERF_RECORD_SAMPLEs start with
   //   perf_event_header header;
@@ -225,7 +225,7 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
   return pid;
 }
 
-uint64_t ReadThrottleUnthrottleRecordTime(PerfEventRingBuffer* ring_buffer) {
+[[nodiscard]] uint64_t ReadThrottleUnthrottleRecordTime(PerfEventRingBuffer* ring_buffer) {
   // Note that perf_event_throttle_unthrottle::time and
   // perf_event_sample_id_tid_time_streamid_cpu::time differ a bit. Use the latter as we use that
   // for all other events.
@@ -236,8 +236,8 @@ uint64_t ReadThrottleUnthrottleRecordTime(PerfEventRingBuffer* ring_buffer) {
   return time;
 }
 
-MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                   const perf_event_header& header) {
+[[nodiscard]] MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                 const perf_event_header& header) {
   // Mmap records have the following layout:
   // struct {
   //   struct perf_event_header header;
@@ -302,8 +302,8 @@ MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
   };
 }
 
-StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                 const perf_event_header& header) {
+[[nodiscard]] StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                               const perf_event_header& header) {
   // The flags here are in sync with stack_sample_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from stack_sample_event_open
   const perf_event_attr flags{
@@ -331,8 +331,8 @@ StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffe
   return event;
 }
 
-CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                         const perf_event_header& header) {
+[[nodiscard]] CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // The flags here are in sync with callchain_sample_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from callchain_sample_event_open
   const perf_event_attr flags{
@@ -361,8 +361,8 @@ CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ri
   return event;
 }
 
-UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                          const perf_event_header& header) {
+[[nodiscard]] UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // The flags here are in sync with uprobes_with_stack_and_sp_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from
   // uprobes_with_stack_and_sp_event_open
@@ -392,8 +392,8 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
   return event;
 }
 
-GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                             const perf_event_header& header) {
+[[nodiscard]] GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // The flags here are in sync with generic_event_attr in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from generic_event_attr
   const perf_event_attr flags{
@@ -417,8 +417,8 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
   return event;
 }
 
-SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                 const perf_event_header& header) {
+[[nodiscard]] SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                               const perf_event_header& header) {
   // The flags here are in sync with tracepoint_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from tracepoint_event_open
   const perf_event_attr flags{
@@ -445,7 +445,7 @@ SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffe
   };
 }
 
-SchedWakeupWithCallchainPerfEvent ConsumeSchedWakeupWithCallchainPerfEvent(
+[[nodiscard]] SchedWakeupWithCallchainPerfEvent ConsumeSchedWakeupWithCallchainPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // The flags here are in sync with tracepoint_with_callchain_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from
@@ -479,7 +479,7 @@ SchedWakeupWithCallchainPerfEvent ConsumeSchedWakeupWithCallchainPerfEvent(
   };
 }
 
-SchedWakeupWithStackPerfEvent ConsumeSchedWakeupWithStackPerfEvent(
+[[nodiscard]] SchedWakeupWithStackPerfEvent ConsumeSchedWakeupWithStackPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // The flags here are in sync with tracepoint_with_stack_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from
@@ -511,7 +511,7 @@ SchedWakeupWithStackPerfEvent ConsumeSchedWakeupWithStackPerfEvent(
   };
 }
 
-SchedSwitchWithStackPerfEvent ConsumeSchedSwitchWithStackPerfEvent(
+[[nodiscard]] SchedSwitchWithStackPerfEvent ConsumeSchedSwitchWithStackPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // The flags here are in sync with tracepoint_with_stack_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from
@@ -549,7 +549,7 @@ SchedSwitchWithStackPerfEvent ConsumeSchedSwitchWithStackPerfEvent(
   };
 }
 
-SchedSwitchWithCallchainPerfEvent ConsumeSchedSwitchWithCallchainPerfEventData(
+[[nodiscard]] SchedSwitchWithCallchainPerfEvent ConsumeSchedSwitchWithCallchainPerfEventData(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // The flags here are in sync with tracepoint_with_callchain_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from
@@ -590,7 +590,8 @@ SchedSwitchWithCallchainPerfEvent ConsumeSchedSwitchWithCallchainPerfEventData(
 }
 
 template <typename EventType, typename StructType>
-EventType ConsumeGpuEvent(PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
+[[nodiscard]] EventType ConsumeGpuEvent(PerfEventRingBuffer* ring_buffer,
+                                        const perf_event_header& header) {
   uint32_t tracepoint_size;
   ring_buffer->ReadValueAtOffset(&tracepoint_size, offsetof(perf_event_raw_sample_fixed, size));
 
@@ -632,19 +633,20 @@ EventType ConsumeGpuEvent(PerfEventRingBuffer* ring_buffer, const perf_event_hea
   return event;
 }
 
-AmdgpuCsIoctlPerfEvent ConsumeAmdgpuCsIoctlPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                     const perf_event_header& header) {
+[[nodiscard]] AmdgpuCsIoctlPerfEvent ConsumeAmdgpuCsIoctlPerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   return ConsumeGpuEvent<AmdgpuCsIoctlPerfEvent, amdgpu_cs_ioctl_tracepoint>(ring_buffer, header);
 }
 
-AmdgpuSchedRunJobPerfEvent ConsumeAmdgpuSchedRunJobPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                             const perf_event_header& header) {
+[[nodiscard]] [[nodiscard]] [[nodiscard]] AmdgpuSchedRunJobPerfEvent
+ConsumeAmdgpuSchedRunJobPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                  const perf_event_header& header) {
   return ConsumeGpuEvent<AmdgpuSchedRunJobPerfEvent, amdgpu_sched_run_job_tracepoint>(ring_buffer,
                                                                                       header);
 }
 
-DmaFenceSignaledPerfEvent ConsumeDmaFenceSignaledPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                           const perf_event_header& header) {
+[[nodiscard]] DmaFenceSignaledPerfEvent ConsumeDmaFenceSignaledPerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   return ConsumeGpuEvent<DmaFenceSignaledPerfEvent, dma_fence_signaled_tracepoint>(ring_buffer,
                                                                                    header);
 }

--- a/src/LinuxTracing/PerfEventReaders.h
+++ b/src/LinuxTracing/PerfEventReaders.h
@@ -49,19 +49,17 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
 SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header);
 
-SchedWakeupWithCallchainPerfEvent ConsumeSchedWakeupWithCallchainPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                                   const perf_event_header& header);
+SchedWakeupWithCallchainPerfEvent ConsumeSchedWakeupWithCallchainPerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
-SchedSwitchWithCallchainPerfEvent ConsumeSchedSwitchWithCallchainPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                                   const perf_event_header& header);
+SchedSwitchWithCallchainPerfEvent ConsumeSchedSwitchWithCallchainPerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 SchedSwitchWithStackPerfEvent ConsumeSchedSwitchWithStackPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                           const perf_event_header& header,
-                                                           bool just_get_tracepoint);
+                                                                   const perf_event_header& header);
 
 SchedWakeupWithStackPerfEvent ConsumeSchedWakeupWithStackPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                           const perf_event_header& header,
-                                                           bool just_get_tracepoint);
+                                                                   const perf_event_header& header);
 
 AmdgpuCsIoctlPerfEvent ConsumeAmdgpuCsIoctlPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                      const perf_event_header& header);

--- a/src/LinuxTracing/PerfEventReaders.h
+++ b/src/LinuxTracing/PerfEventReaders.h
@@ -49,6 +49,20 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
 SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                  const perf_event_header& header);
 
+SchedWakeupWithCallchainPerfEvent ConsumeSchedWakeupWithCallchainPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                                   const perf_event_header& header);
+
+SchedSwitchWithCallchainPerfEvent ConsumeSchedSwitchWithCallchainPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                                   const perf_event_header& header);
+
+SchedSwitchWithStackPerfEvent ConsumeSchedSwitchWithStackPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                           const perf_event_header& header,
+                                                           bool just_get_tracepoint);
+
+SchedWakeupWithStackPerfEvent ConsumeSchedWakeupWithStackPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                           const perf_event_header& header,
+                                                           bool just_get_tracepoint);
+
 AmdgpuCsIoctlPerfEvent ConsumeAmdgpuCsIoctlPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                      const perf_event_header& header);
 


### PR DESCRIPTION
This PR adds the readers that will be used to read the new type of events for tracepoint call stack collection.

Bug: http://b/242825690