### PR TITLE
De-duplicate code around PairedData::ActiveInvocationTimes calls

### DIFF
--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -17,6 +17,7 @@
 
 #include "BaselineAndComparisonHelper.h"
 #include "ClientData/ScopeId.h"
+#include "ClientData/ScopeStats.h"
 #include "MizarBase/BaselineOrComparison.h"
 #include "MizarBase/SampledFunctionId.h"
 #include "MizarBase/Time.h"
@@ -107,13 +108,15 @@ const absl::flat_hash_map<SFID, std::string> kSfidToName = MakeMap(kSfids, kBase
 const std::vector<std::vector<SFID>> kCallstacks = {
     std::vector<SFID>{kSfidThird, kSfidSecond, kSfidFirst}, {kSfidSecond}, {}};
 
-const std::vector<RelativeTimeNs> kFrameTrackActiveTimes = [] {
-  const std::vector<uint64_t> kRaw = {300, 100, 200};
-  std::vector<RelativeTimeNs> result;
-  absl::c_transform(kRaw, std::back_inserter(result),
-                    [](uint64_t value) { return RelativeTimeNs(value); });
+const orbit_client_data::ScopeStats kNonEmptyScopeStats = [] {
+  orbit_client_data::ScopeStats result;
+  for (uint64_t time : {300, 100, 200}) {
+    result.UpdateStats(time);
+  }
   return result;
 }();
+
+constexpr orbit_client_data::ScopeStats kEmptyScopeStats;
 
 constexpr double kStatistic = 1.234;
 constexpr std::array<double, kSfidCount> kPvalues = {0.01, 0.02, 0.05};
@@ -130,9 +133,8 @@ namespace {
 class MockPairedData {
  public:
   explicit MockPairedData(std::vector<std::vector<SFID>> callstacks,
-                          std::vector<RelativeTimeNs> frame_track_active_times)
-      : callstacks_(std::move(callstacks)),
-        frame_track_active_times_(std::move(frame_track_active_times)) {}
+                          orbit_client_data::ScopeStats frame_track_stats)
+      : callstacks_(std::move(callstacks)), frame_track_stats_(frame_track_stats) {}
 
   template <typename Action>
   void ForEachCallstackEvent(TID /*tid*/, RelativeTimeNs /*min_timestamp*/,
@@ -140,16 +142,16 @@ class MockPairedData {
     std::for_each(std::begin(callstacks_), std::end(callstacks_), std::forward<Action>(action));
   }
 
-  [[nodiscard]] std::vector<RelativeTimeNs> ActiveInvocationTimes(
+  [[nodiscard]] orbit_client_data::ScopeStats ActiveInvocationTimeStats(
       const absl::flat_hash_set<TID>& /*tids*/, FrameTrackId /*frame_track_scope_id*/,
       RelativeTimeNs /*min_relative_timestamp_ns*/,
       RelativeTimeNs /*max_relative_timestamp_ns*/) const {
-    return frame_track_active_times_;
+    return frame_track_stats_;
   };
 
  private:
   std::vector<std::vector<SFID>> callstacks_;
-  std::vector<RelativeTimeNs> frame_track_active_times_;
+  orbit_client_data::ScopeStats frame_track_stats_;
 };
 
 class MockFunctionTimeComparator {
@@ -179,10 +181,17 @@ class MockFunctionTimeComparator {
   return result;
 }
 
+static void ExpectScopeStatsEq(const orbit_client_data::ScopeStats a,
+                               const orbit_client_data::ScopeStats b) {
+  EXPECT_EQ(a.ComputeAverageTimeNs(), b.ComputeAverageTimeNs());
+  constexpr double kTolerance = 1e-3;
+  EXPECT_THAT(a.variance_ns(), DoubleNear(b.variance_ns(), kTolerance));
+  EXPECT_EQ(a.count(), b.count());
+}
+
 TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
-  auto full = MakeBaseline<MockPairedData>(kCallstacks, kFrameTrackActiveTimes);
-  auto empty = MakeComparison<MockPairedData>(std::vector<std::vector<SFID>>{},
-                                              std::vector<RelativeTimeNs>{});
+  auto full = MakeBaseline<MockPairedData>(kCallstacks, kNonEmptyScopeStats);
+  auto empty = MakeComparison<MockPairedData>(std::vector<std::vector<SFID>>{}, kEmptyScopeStats);
 
   BaselineAndComparisonTmpl<MockPairedData, MockFunctionTimeComparator, MockCorrection> bac(
       std::move(full), std::move(empty), {kSfidToName});
@@ -217,18 +226,8 @@ TEST(BaselineAndComparisonTest, MakeSamplingWithFrameTrackReportIsCorrect) {
                 DoubleNear(kSfidToCorrectedPvalue.at(sfid), kTolerance));
   }
 
-  constexpr uint64_t kExpectedFullActiveFrameTime = 200;
-  EXPECT_EQ(report.GetBaselineFrameTrackStats()->ComputeAverageTimeNs(),
-            kExpectedFullActiveFrameTime);
-  EXPECT_EQ(report.GetComparisonFrameTrackStats()->ComputeAverageTimeNs(), 0);
-
-  constexpr double kExpectedFullActiveFrameTimeVariance = 6666.66666;
-  EXPECT_THAT(report.GetBaselineFrameTrackStats()->variance_ns(),
-              DoubleNear(kExpectedFullActiveFrameTimeVariance, 1e-3));
-  EXPECT_THAT(report.GetComparisonFrameTrackStats()->variance_ns(), DoubleNear(0, 1e-3));
-
-  EXPECT_EQ(report.GetBaselineFrameTrackStats()->count(), kFrameTrackActiveTimes.size());
-  EXPECT_EQ(report.GetComparisonFrameTrackStats()->count(), 0);
+  ExpectScopeStatsEq(*report.GetBaselineFrameTrackStats(), kNonEmptyScopeStats);
+  ExpectScopeStatsEq(*report.GetComparisonFrameTrackStats(), kEmptyScopeStats);
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -183,9 +183,8 @@ class MockFunctionTimeComparator {
 
 static void ExpectScopeStatsEq(const orbit_client_data::ScopeStats a,
                                const orbit_client_data::ScopeStats b) {
-  EXPECT_EQ(a.ComputeAverageTimeNs(), b.ComputeAverageTimeNs());
-  constexpr double kTolerance = 1e-3;
-  EXPECT_THAT(a.variance_ns(), DoubleNear(b.variance_ns(), kTolerance));
+  EXPECT_EQ(a.ComputeAverageTimeNs(), b.ComputeAverageTimeNs()); 
+  EXPECT_EQ(a.variance_ns(), b.variance_ns());
   EXPECT_EQ(a.count(), b.count());
 }
 

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -183,7 +183,7 @@ class MockFunctionTimeComparator {
 
 static void ExpectScopeStatsEq(const orbit_client_data::ScopeStats a,
                                const orbit_client_data::ScopeStats b) {
-  EXPECT_EQ(a.ComputeAverageTimeNs(), b.ComputeAverageTimeNs()); 
+  EXPECT_EQ(a.ComputeAverageTimeNs(), b.ComputeAverageTimeNs());
   EXPECT_EQ(a.variance_ns(), b.variance_ns());
   EXPECT_EQ(a.count(), b.count());
 }

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -264,8 +264,7 @@ TEST_F(MizarPairedDataTest, ForeachCallstackIsCorrect) {
   EXPECT_THAT(actual_ids_fed_to_action, UnorderedElementsAre(kAnotherCompleteCallstackIds));
 }
 
-const auto kExpectedInvocationTimes = {Times(kSamplingPeriod, uint64_t{2}),
-                                       Times(kSamplingPeriod, uint64_t{2})};
+const auto kExpectedInvocationTimes = {Times(kSamplingPeriod, 2), Times(kSamplingPeriod, 2)};
 
 TEST_F(MizarPairedDataTest, ActiveInvocationTimesIsCorrect) {
   MizarPairedDataUnderTest mizar_paired_data(std::move(data_), kAddressToId);

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -264,7 +264,8 @@ TEST_F(MizarPairedDataTest, ForeachCallstackIsCorrect) {
   EXPECT_THAT(actual_ids_fed_to_action, UnorderedElementsAre(kAnotherCompleteCallstackIds));
 }
 
-const auto kExpectedInvocationTimes = {Times(kSamplingPeriod, 2), Times(kSamplingPeriod, 2)};
+const auto kExpectedInvocationTimes = {Times(kSamplingPeriod, uint64_t{2}),
+                                       Times(kSamplingPeriod, uint64_t{2})};
 
 TEST_F(MizarPairedDataTest, ActiveInvocationTimesIsCorrect) {
   MizarPairedDataUnderTest mizar_paired_data(std::move(data_), kAddressToId);

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -95,16 +95,10 @@ class BaselineAndComparisonTmpl {
     return corrected;
   }
 
-  // TODO (b/242839338) Duplicated code. See FrameTrackListModel
   [[nodiscard]] static orbit_client_data::ScopeStats MakeFrameTrackStats(
       const PairedData& data, const HalfOfSamplingWithFrameTrackReportConfig& config) {
-    const std::vector<RelativeTimeNs> active_invocation_times = data.ActiveInvocationTimes(
-        config.tids, config.frame_track_id, config.start_relative, config.EndRelative());
-    orbit_client_data::ScopeStats stats;
-    for (const RelativeTimeNs active_invocation_time : active_invocation_times) {
-      stats.UpdateStats(*active_invocation_time);
-    }
-    return stats;
+    return data.ActiveInvocationTimeStats(config.tids, config.frame_track_id, config.start_relative,
+                                          config.EndRelative());
   }
 
   [[nodiscard]] static SamplingCounts MakeCounts(

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -38,7 +38,7 @@ namespace orbit_mizar_data {
 // This class represents the data loaded from a capture that has been made aware of its counterpart
 // it will be compared against. In particular, it is aware of the functions that has been sampled in
 // the other capture. Also, it is aware of the sampled function ids assigned to the functions.
-template <typename Data, typename FrameTracks>
+template <typename Data, typename FrameTracks, typename FrameTrackStats>
 class MizarPairedDataTmpl {
   using SFID = ::orbit_mizar_base::SFID;
   using TID = ::orbit_mizar_base::TID;
@@ -83,6 +83,18 @@ class MizarPairedDataTmpl {
       result.push_back(Times(sampling_period, callstack_count));
     }
     return result;
+  }
+
+  [[nodiscard]] FrameTrackStats ActiveInvocationTimeStats(const absl::flat_hash_set<TID>& tids,
+                                                          FrameTrackId frame_track_id,
+                                                          RelativeTimeNs min_relative_time,
+                                                          RelativeTimeNs max_relative_time) const {
+    FrameTrackStats stats;
+    for (const RelativeTimeNs active_invocation_time :
+         ActiveInvocationTimes(tids, frame_track_id, min_relative_time, max_relative_time)) {
+      stats.UpdateStats(*active_invocation_time);
+    }
+    return stats;
   }
 
   [[nodiscard]] const absl::flat_hash_map<TID, std::string>& TidToNames() const {
@@ -204,7 +216,8 @@ class MizarPairedDataTmpl {
   absl::flat_hash_map<TID, uint64_t> tid_to_callstack_samples_counts_;
 };
 
-using MizarPairedData = MizarPairedDataTmpl<MizarDataProvider, FrameTrackManager>;
+using MizarPairedData =
+    MizarPairedDataTmpl<MizarDataProvider, FrameTrackManager, orbit_client_data::ScopeStats>;
 
 }  // namespace orbit_mizar_data
 

--- a/src/MizarModels/FrameTrackListModelTest.cpp
+++ b/src/MizarModels/FrameTrackListModelTest.cpp
@@ -31,24 +31,16 @@ using ::testing::UnorderedElementsAreArray;
 
 namespace {
 
-struct MockPairedData {
-  MOCK_METHOD((absl::flat_hash_map<FrameTrackId, FrameTrackInfo>), GetFrameTracks, (), (const));
-  MOCK_METHOD(std::vector<RelativeTimeNs>, ActiveInvocationTimes,
-              (const absl::flat_hash_set<TID>&, FrameTrackId, RelativeTimeNs, RelativeTimeNs),
-              (const));
-};
-
-struct FrameTrackStats {
-  static inline std::vector<RelativeTimeNs> durations_fed_since_last_instantiation_ = {};
-
-  FrameTrackStats() { durations_fed_since_last_instantiation_.clear(); }
-
-  void UpdateStats(uint64_t duration) {
-    durations_fed_since_last_instantiation_.emplace_back(duration);
-  }
-
+struct MockFrameTrackStats {
   MOCK_METHOD(uint64_t, ComputeAverageTimeNs, (), (const));
   MOCK_METHOD(uint64_t, count, (), (const));
+};
+
+struct MockPairedData {
+  MOCK_METHOD((absl::flat_hash_map<FrameTrackId, FrameTrackInfo>), GetFrameTracks, (), (const));
+  MOCK_METHOD(MockFrameTrackStats&, ActiveInvocationTimeStats,
+              (const absl::flat_hash_set<TID>&, FrameTrackId, RelativeTimeNs, RelativeTimeNs),
+              (const));
 };
 
 }  // namespace
@@ -92,44 +84,22 @@ constexpr std::array<std::string_view, kFrameTracksCount> kExpectedShown = {
 const absl::flat_hash_map<FrameTrackId, std::string_view> kIdToExpectedShown =
     MakeMap(kFrameTrackIds, kExpectedShown);
 
-[[nodiscard]] static std::vector<RelativeTimeNs> MakeRelativeTimes(
-    const std::vector<uint64_t>& raw) {
-  std::vector<RelativeTimeNs> result;
-  absl::c_transform(raw, std::back_inserter(result), [](uint64_t t) { return RelativeTimeNs(t); });
-  return result;
-}
-
-const std::array<std::vector<RelativeTimeNs>, kFrameTracksCount> kFrameInvocationTimes = {
-    MakeRelativeTimes({1, 2, 3, 4}), MakeRelativeTimes({10, 20, 30, 40}),
-    MakeRelativeTimes({100, 200, 300, 400}), MakeRelativeTimes({1000, 2000, 3000, 4000, 123456})};
-
-const absl::flat_hash_map<FrameTrackId, std::vector<RelativeTimeNs>> kIdToFrameInvocationTimes =
-    MakeMap(kFrameTrackIds, kFrameInvocationTimes);
-
 TEST(FrameTrackListModelTest, NoFrameTracks) {
   MockPairedData data;
 
   absl::flat_hash_set<TID> tids = {};
   RelativeTimeNs start(123);
 
-  FrameTrackListModelTmpl<MockPairedData, FrameTrackStats> model(&data, &tids, &start);
+  FrameTrackListModelTmpl<MockPairedData> model(&data, &tids, &start);
   EXPECT_EQ(model.rowCount(), 0);
 }
 
 TEST(FrameTrackListModelTest, TestDisplayTooltipAndIdRoles) {
   MockPairedData data;
-  EXPECT_CALL(data, ActiveInvocationTimes)
-      .WillRepeatedly(Invoke([](const absl::flat_hash_set<TID>& tids, FrameTrackId id,
-                                RelativeTimeNs start, RelativeTimeNs end) {
-        EXPECT_EQ(tids, kTids);
-        EXPECT_EQ(start, kStart);
-        EXPECT_EQ(end, kEnd);
-
-        return kIdToFrameInvocationTimes.at(id);
-      }));
+  MockFrameTrackStats stats;
   EXPECT_CALL(data, GetFrameTracks).WillRepeatedly(Return(kFrameTracks));
 
-  FrameTrackListModelTmpl<MockPairedData, FrameTrackStats> model(&data, &kTids, &kStart);
+  FrameTrackListModelTmpl<MockPairedData> model(&data, &kTids, &kStart);
 
   ASSERT_EQ(model.rowCount(), kFrameTracksCount);
 
@@ -142,9 +112,20 @@ TEST(FrameTrackListModelTest, TestDisplayTooltipAndIdRoles) {
     const auto actual_shown = model.data(index, Qt::DisplayRole).value<QString>();
     EXPECT_EQ(actual_shown.toStdString(), kIdToExpectedShown.at(actual_id));
 
+    EXPECT_CALL(stats, ComputeAverageTimeNs).Times(1);
+    EXPECT_CALL(stats, count).Times(1);
+    EXPECT_CALL(data, ActiveInvocationTimeStats)
+        .WillOnce(Invoke([&stats, &actual_id](const absl::flat_hash_set<TID>& tids, FrameTrackId id,
+                                              RelativeTimeNs start,
+                                              RelativeTimeNs end) -> MockFrameTrackStats& {
+          EXPECT_EQ(tids, kTids);
+          EXPECT_EQ(start, kStart);
+          EXPECT_EQ(end, kEnd);
+          EXPECT_EQ(id, actual_id);
+
+          return stats;
+        }));
     std::ignore = model.data(index, Qt::ToolTipRole);
-    EXPECT_THAT(FrameTrackStats::durations_fed_since_last_instantiation_,
-                UnorderedElementsAreArray(kIdToFrameInvocationTimes.at(actual_id)));
   }
 }
 

--- a/src/MizarModels/include/MizarModels/FrameTrackListModel.h
+++ b/src/MizarModels/include/MizarModels/FrameTrackListModel.h
@@ -17,6 +17,7 @@
 #include "MizarBase/ThreadId.h"
 #include "MizarBase/Time.h"
 #include "MizarData/FrameTrack.h"
+#include "MizarData/MizarPairedData.h"
 #include "OrbitBase/Overloaded.h"
 #include "OrbitBase/Sort.h"
 
@@ -26,7 +27,7 @@ namespace orbit_mizar_models {
 
 constexpr int kFrameTrackIdRole = Qt::UserRole + 1;
 
-template <typename PairedData, typename FrameTrackStats>
+template <typename PairedData>
 class FrameTrackListModelTmpl : public QAbstractListModel {
   using FrameTrackId = ::orbit_mizar_data::FrameTrackId;
   using FrameTrackInfo = ::orbit_mizar_data::FrameTrackInfo;
@@ -106,16 +107,10 @@ class FrameTrackListModelTmpl : public QAbstractListModel {
                       *info);
   }
 
-  // TODO (b/242839338) Duplicated code. See BaselineAndComparison::MakeFrameTrackStats
   [[nodiscard]] QString MakeTooltip(FrameTrackId id, const std::string& name) const {
-    const std::vector<RelativeTimeNs> active_invocation_times = data_->ActiveInvocationTimes(
+    const auto& stats = data_->ActiveInvocationTimeStats(
         *selected_tids_, id, *start_timestamp_,
         orbit_mizar_base::RelativeTimeNs(std::numeric_limits<uint64_t>::max()));
-
-    FrameTrackStats stats;
-    for (const RelativeTimeNs active_invocation_time : active_invocation_times) {
-      stats.UpdateStats(*active_invocation_time);
-    }
 
     constexpr double kNsInMs = 1e6;
     const double average_ms = stats.ComputeAverageTimeNs() / kNsInMs;

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -19,6 +19,7 @@
 
 #include "ClientData/ScopeId.h"
 #include "ClientData/ScopeInfo.h"
+#include "ClientData/ScopeStats.h"
 #include "MizarBase/ThreadId.h"
 #include "MizarBase/Time.h"
 #include "MizarData/FrameTrack.h"
@@ -48,7 +49,7 @@ class MockPairedData {
   MOCK_METHOD((const absl::flat_hash_map<TID, std::uint64_t>&), TidToCallstackSampleCounts, (),
               (const));
   MOCK_METHOD((absl::flat_hash_map<FrameTrackId, FrameTrackInfo>), GetFrameTracks, (), (const));
-  MOCK_METHOD(std::vector<RelativeTimeNs>, ActiveInvocationTimes,
+  MOCK_METHOD(orbit_client_data::ScopeStats, ActiveInvocationTimeStats,
               (const absl::flat_hash_set<TID>&, FrameTrackId, RelativeTimeNs, RelativeTimeNs),
               (const));
 };

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackInputWidget.h
@@ -131,8 +131,7 @@ class SamplingWithFrameTrackInputWidgetTmpl : public SamplingWithFrameTrackInput
   }
 
   void InitFrameTrackList(const PairedData& data) {
-    auto model = std::make_unique<
-        orbit_mizar_models::FrameTrackListModelTmpl<PairedData, orbit_client_data::ScopeStats>>(
+    auto model = std::make_unique<orbit_mizar_models::FrameTrackListModelTmpl<PairedData>>(
         &data, &selected_tids_, &start_timestamp_, parent());
 
     GetFrameTrackList()->setModel(model.release());


### PR DESCRIPTION
MizarPairedData now provider ActiveInvocationTimeSctats method

Tets: Unit, Manual
Bug: http://b/242839338