### PR TITLE
Include GetTimersAtDepthDiscretized in TimerDataInterface

### DIFF
--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -39,12 +39,8 @@ class ScopeTreeTimerData final : public TimerDataInterface {
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepth(
       uint32_t depth, uint64_t start_ns = std::numeric_limits<uint64_t>::min(),
       uint64_t end_ns = std::numeric_limits<uint64_t>::max()) const;
-  // This method avoids returning two timers that map to the same pixel in the screen, so is
-  // especially useful when there are many timers in the screen (zooming-out for example).
-  // The overall complexity is O(log(num_timers) * resolution). Resolution should be the number
-  // of pixels-width where timers will be drawn.
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthDiscretized(
-      uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const;
+      uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const override;
 
   // Metadata queries
   [[nodiscard]] bool IsEmpty() const override { return GetNumberOfTimers() == 0; };

--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -32,6 +32,8 @@ class TimerData final : public TimerDataInterface {
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthDiscretized(
       uint32_t /*depth*/, uint32_t /*resolution*/, uint64_t /*start_ns*/,
       uint64_t /*end_ns*/) const override {
+    // TODO(b/242971217): Implement TimerData rendering optimization when timers are ordered.
+    ORBIT_UNREACHABLE();
     return {};
   };
 

--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -29,6 +29,12 @@ class TimerData final : public TimerDataInterface {
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
       uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const override;
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthDiscretized(
+      uint32_t /*depth*/, uint32_t /*resolution*/, uint64_t /*start_ns*/,
+      uint64_t /*end_ns*/) const override {
+    return {};
+  };
+
   // Metadata queries
   [[nodiscard]] bool IsEmpty() const override { return GetNumberOfTimers() == 0; }
   [[nodiscard]] size_t GetNumberOfTimers() const override { return num_timers_; }

--- a/src/ClientData/include/ClientData/TimerDataInterface.h
+++ b/src/ClientData/include/ClientData/TimerDataInterface.h
@@ -31,6 +31,13 @@ class TimerDataInterface {
   [[nodiscard]] virtual std::vector<const TimerChain*> GetChains() const = 0;
   [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t min_tick, uint64_t max_tick) const = 0;
+  // This optimized method avoids returning two timers that map to the same pixel in the screen, so
+  // is especially useful when there are many timers in the screen (zooming-out for example).
+  // It assures to return at least one timer per occupied pixel. The overall complexity is
+  // O(log(num_timers) * resolution) where resolution is the number of pixels_width.
+  [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*>
+  GetTimersAtDepthDiscretized(uint32_t depth, uint32_t resolution, uint64_t start_ns,
+                              uint64_t end_ns) const = 0;
 
   // Metadata queries
   [[nodiscard]] virtual bool IsEmpty() const = 0;


### PR DESCRIPTION
Similar to in ScopeTreeTimerData, this query will be used for rendering
optimization. In this PR we are just adding it to TimerDataInterface
without providing an implementation in TimerData.

Bug: http://b/242971217