### PR TITLE
Refactor TimerDataTest to make it easy to add new tests

### DIFF
--- a/src/ClientData/TimerDataTest.cpp
+++ b/src/ClientData/TimerDataTest.cpp
@@ -30,18 +30,18 @@ _____________________________
      --------------------
  */
 
-static constexpr uint64_t kLeftTimerStart = 2;
-static constexpr uint64_t kLeftTimerEnd = 6;
-static constexpr uint64_t kMiddleTimerStart = 5;
-static constexpr uint64_t kMiddleTimerEnd = 9;
-static constexpr uint64_t kRightTimerStart = 8;
-static constexpr uint64_t kRightTimerEnd = 12;
-static constexpr uint64_t kNumTimers = 3;
-static constexpr uint64_t kDepth = 2;
-static constexpr uint64_t kMinTimestamp = 2;
-static constexpr uint64_t kMaxTimestamp = 12;
+constexpr uint64_t kLeftTimerStart = 2;
+constexpr uint64_t kLeftTimerEnd = 6;
+constexpr uint64_t kMiddleTimerStart = 5;
+constexpr uint64_t kMiddleTimerEnd = 9;
+constexpr uint64_t kRightTimerStart = 8;
+constexpr uint64_t kRightTimerEnd = 12;
+constexpr uint64_t kNumTimers = 3;
+constexpr uint64_t kDepth = 2;
+constexpr uint64_t kMinTimestamp = 2;
+constexpr uint64_t kMaxTimestamp = 12;
 
-TimerInfo GetLeftTimer() {
+static TimerInfo GetLeftTimer() {
   TimerInfo timer_info_left;
   timer_info_left.set_start(kLeftTimerStart);
   timer_info_left.set_end(kLeftTimerEnd);
@@ -49,7 +49,7 @@ TimerInfo GetLeftTimer() {
   return timer_info_left;
 }
 
-TimerInfo GetRightTimer() {
+static TimerInfo GetRightTimer() {
   TimerInfo timer_info_right;
   timer_info_right.set_start(kRightTimerStart);
   timer_info_right.set_end(kRightTimerEnd);
@@ -57,7 +57,7 @@ TimerInfo GetRightTimer() {
   return timer_info_right;
 }
 
-TimerInfo GetDownTimer() {
+static TimerInfo GetDownTimer() {
   TimerInfo timer_info_down;
   timer_info_down.set_start(kMiddleTimerStart);
   timer_info_down.set_end(kMiddleTimerEnd);
@@ -65,7 +65,7 @@ TimerInfo GetDownTimer() {
   return timer_info_down;
 }
 
-TimerInfo GetMiddleTimer() {
+static TimerInfo GetMiddleTimer() {
   TimerInfo timer_info_middle;
   timer_info_middle.set_start(kMiddleTimerStart);
   timer_info_middle.set_end(kMiddleTimerEnd);

--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -55,7 +55,9 @@ class TimerData final : public TimerDataInterface {
   [[nodiscard]] uint32_t GetDepth() const override { return depth_; }
   [[nodiscard]] uint32_t GetProcessId() const override { return process_id_; }
 
-  // Relative timers queries
+  // Relative timers queries.
+  // TODO(b/221024788): These queries assume Timers are inserted in order and doesn't work for
+  // GpuSubmissionTrack.
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetFirstAfterStartTime(uint64_t time,
                                                                              uint32_t depth) const;
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetFirstBeforeStartTime(uint64_t time,

--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -56,7 +56,7 @@ class TimerData final : public TimerDataInterface {
   [[nodiscard]] uint32_t GetProcessId() const override { return process_id_; }
 
   // Relative timers queries.
-  // TODO(b/221024788): These queries assume Timers are inserted in order and doesn't work for
+  // TODO(b/221024788): These queries assume Timers are inserted in order and don't work for
   // GpuSubmissionTrack.
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetFirstAfterStartTime(uint64_t time,
                                                                              uint32_t depth) const;


### PR DESCRIPTION
This PR is just a refactor of TimerDataTest, so it will be easier to add 
new tests. 
The next PR will add a test for GetTimers() both when timers are 
inserted in-order and not-in-order. 
A following PR will include a new method to get timers in an
optimized way with its corresponding test.

While cleaning this test I found that some queries are assuming timers to
be in ordered so I added a TODO. This might be one of the causes that
arrow keys wasn't working in GpuSubmissionTrack.

Bug: http://b/242971209