### PR TITLE
Fix bug in Timertrack::GetYFromDepth subclasses

### DIFF
--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -110,8 +110,7 @@ std::string GpuDebugMarkerTrack::GetBoxTooltip(const PrimitiveAssembler& primiti
           .c_str());
 }
 
-float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
-  uint32_t depth = timer_info.depth();
+float GpuDebugMarkerTrack::GetYFromDepth(uint32_t depth) const {
   if (IsCollapsed()) {
     depth = 0;
   }

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -47,8 +47,7 @@ class GpuDebugMarkerTrack final : public TimerTrack {
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] bool IsCollapsible() const override { return GetDepth() > 1; }
 
-  [[nodiscard]] float GetYFromTimer(
-      const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
   [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
                                     bool is_highlighted,

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -88,11 +88,10 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
   return orbit_gl::GetThreadColor(timer_info.thread_id());
 }
 
-float SchedulerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
-  uint32_t num_gaps = timer_info.depth();
+float SchedulerTrack::GetYFromDepth(uint32_t depth) const {
   return GetPos()[1] + GetHeightAboveTimers() +
-         (layout_->GetTextCoresHeight() * static_cast<float>(timer_info.depth())) +
-         num_gaps * layout_->GetSpaceBetweenCores();
+         (layout_->GetTextCoresHeight() * static_cast<float>(depth)) +
+         depth * layout_->GetSpaceBetweenCores();
 }
 
 std::vector<const orbit_client_protos::TimerInfo*> SchedulerTrack::GetScopesInRange(

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -39,8 +39,7 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] bool IsCollapsible() const override { return false; }
 
   [[nodiscard]] float GetDefaultBoxHeight() const override { return layout_->GetTextCoresHeight(); }
-  [[nodiscard]] float GetYFromTimer(
-      const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetScopesInRange(
       uint64_t start_ns, uint64_t end_ns) const;
 


### PR DESCRIPTION
While implementing an optimization in SchedulerTrack I found a strange
bug while using GetYFromDepth(). This method was not retuning the
expected Y.

The solution is just override this method instead of GetYFromTimer,
since GetYFromTimer is just calling GetYFromDepth. Actually
GetYFromTimer exists just because timers have variable size in
FrameTrack, which makes things over-complicated and it's symptom of
a bad design. FrameTrack shouldn't inherit from TimerTrack (and maybe
TimerTrack should be a way smaller class or even don't exist -
http://b/203181055)

Anyway, in this PR we are just fixing this for Scheduler and
GpuDebugMarkerTrack. GpuSubmissionTrack has a really weird logic about
how to calculate depth that I don't want to touch. We spoke with FlorianK
several months ago and I will leave it as it is for now. Let me know if you 
want me to add a TODO.

Bug: http://b/242971304
Test: Load a capture, everything works as expected.