### PR TITLE
Fix glitch in ThreadTimers because intersection

### DIFF
--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -252,7 +252,12 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, 
 
   constexpr uint8_t kOddAlpha = 210;
   if ((timer_info.depth() & 0x1) == 0) {
-    color[3] = kOddAlpha;
+    // The usage of alpha values with possible intersection of timers may lead to a strange visual
+    // behavior where users doesn't understand why some timers "are lighter". Therefore, we
+    // "compute" the odd-alpha manually.
+    for (int i = 0; i < 3; ++i) {
+      color[i] = static_cast<char>(static_cast<int>(color[i]) * kOddAlpha / 255);
+    }
   }
 
   return color;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -250,11 +250,11 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, 
     color = orbit_gl::GetThreadColor(timer_info.thread_id());
   }
 
-  constexpr uint8_t kOddRowColorMultiplier = 210;
+  constexpr float kOddRowColorMultiplier = 210.f / 255.f;
   if ((timer_info.depth() & 0x1) == 0) {
     // We are slightly alternating the colors for thread timers based on their depth.
     for (int i = 0; i < 3; ++i) {
-      color[i] = static_cast<char>(static_cast<int>(color[i]) * kOddRowColorMultiplier / 255);
+      color[i] = static_cast<char>(color[i] * kOddRowColorMultiplier);
     }
   }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -250,13 +250,11 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, 
     color = orbit_gl::GetThreadColor(timer_info.thread_id());
   }
 
-  constexpr uint8_t kOddAlpha = 210;
+  constexpr uint8_t kOddRowColorMultiplier = 210;
   if ((timer_info.depth() & 0x1) == 0) {
-    // The usage of alpha values with possible intersection of timers may lead to a strange visual
-    // behavior where users doesn't understand why some timers "are lighter". Therefore, we
-    // "compute" the odd-alpha manually.
+    // We are slightly alternating the colors for thread timers based on their depth.
     for (int i = 0; i < 3; ++i) {
-      color[i] = static_cast<char>(static_cast<int>(color[i]) * kOddAlpha / 255);
+      color[i] = static_cast<char>(static_cast<int>(color[i]) * kOddRowColorMultiplier / 255);
     }
   }
 


### PR DESCRIPTION
In this PR we are fixing a glitch related to intersection of timers in
ThreadTrack. It's not very visible because our way to render timers but
it will be after extending timers to the border of the pixels.

Basically we are using an alpha to render timer in even depths, to
differentiate of the odd depths, but alpha and intersection doesn't work
as expected and we ended having a lighter color if 2 timers have
intersection in the same pixel.

In this PR we are computing the new color as if we have an alpha but
without using the alpha-value. Therefore, intersection wouldn't be an
issue.

Before: http://screenshot/55KLpRYwkXnRfsY. The lightest part should be
the leftmost pixel even with anti-aliasing.
After: http://screenshot/8Njkfcpywm7kwqz

Bug: http://b/242973688.
Test: Load different captures. Play with them.