### PR TITLE
Add ScopeId value check in LiveFunctionsDataView

### DIFF
--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -244,6 +244,7 @@ class CaptureData {
   [[nodiscard]] std::optional<ScopeId> ProvideScopeId(
       const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::vector<ScopeId> GetAllProvidedScopeIds() const;
+  [[nodiscard]] ScopeId GetMaxId() const { return scope_id_provider_->GetMaxId(); }
   [[nodiscard]] const ScopeInfo& GetScopeInfo(ScopeId scope_id) const;
   [[nodiscard]] std::optional<ScopeId> FunctionIdToScopeId(uint64_t function_id) const;
   [[nodiscard]] uint64_t ScopeIdToFunctionId(ScopeId scope_id) const;

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -28,6 +28,10 @@ class ScopeIdProvider {
   [[nodiscard]] virtual std::optional<ScopeId> FunctionIdToScopeId(uint64_t function_id) const = 0;
   [[nodiscard]] virtual uint64_t ScopeIdToFunctionId(ScopeId scope_id) const = 0;
 
+  // TODO(b/243122633) The method is added in the hope to investigate the crash via additional
+  // runtime checks. When the bug is resolved, the method should be removed.
+  [[nodiscard]] virtual ScopeId GetMaxId() const = 0;
+
   [[nodiscard]] virtual std::optional<ScopeId> ProvideId(const TimerInfo& timer_info) = 0;
 
   [[nodiscard]] virtual std::vector<ScopeId> GetAllProvidedScopeIds() const = 0;
@@ -48,6 +52,11 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
 
   [[nodiscard]] std::optional<ScopeId> FunctionIdToScopeId(uint64_t function_id) const override;
   [[nodiscard]] uint64_t ScopeIdToFunctionId(ScopeId scope_id) const override;
+
+  [[nodiscard]] ScopeId GetMaxId() const override {
+    absl::ReaderMutexLock reader_lock{&mutex_};
+    return ScopeId(next_id_ - 1);
+  }
 
   [[nodiscard]] std::optional<ScopeId> ProvideId(const TimerInfo& timer_info) override;
 

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -235,6 +235,8 @@ class LiveFunctionsDataViewTest : public testing::Test {
         capture_data_(GenerateTestCaptureData(&module_manager_)) {
     EXPECT_CALL(app_, GetModuleManager()).WillRepeatedly(Return(&module_manager_));
     EXPECT_CALL(app_, GetMutableModuleManager()).WillRepeatedly(Return(&module_manager_));
+    EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
     view_.Init();
     for (size_t i = 0; i < kNumFunctions; i++) {
@@ -279,9 +281,6 @@ TEST_F(LiveFunctionsDataViewTest, HasValidDefaultSortingColumn) {
 TEST_F(LiveFunctionsDataViewTest, ColumnValuesAreCorrect) {
   AddFunctionsByIndices({0});
 
-  EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
-
   // The selected column will be tested separately.
   EXPECT_EQ(view_.GetValue(0, kColumnName), kPrettyNames[0]);
   EXPECT_EQ(view_.GetValue(0, kColumnModule), kModulePaths[0]);
@@ -297,8 +296,6 @@ TEST_F(LiveFunctionsDataViewTest, ColumnValuesAreCorrect) {
 TEST_F(LiveFunctionsDataViewTest, ColumnSelectedShowsRightResults) {
   bool function_selected = false;
   bool frame_track_enabled = false;
-  EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
   EXPECT_CALL(app_, IsFunctionSelected(testing::A<const orbit_client_data::FunctionInfo&>()))
       .WillRepeatedly(testing::ReturnPointee(&function_selected));
   // The following code guarantees the appearance of frame track icon is determined by
@@ -361,7 +358,6 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     }
     return std::nullopt;
   };
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
   EXPECT_CALL(app_, IsCaptureConnected).WillRepeatedly(testing::ReturnPointee(&capture_connected));
   EXPECT_CALL(app_, IsCapturing).WillRepeatedly(testing::ReturnPointee(&is_capturing));
   EXPECT_CALL(app_, IsFunctionSelected(testing::A<const orbit_client_data::FunctionInfo&>()))
@@ -459,8 +455,6 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
 TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
   bool function_selected = false;
   bool frame_track_enabled = false;
-  EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
   EXPECT_CALL(app_, IsCaptureConnected).WillRepeatedly(testing::Return(true));
   EXPECT_CALL(app_, IsFunctionSelected(testing::A<const orbit_client_data::FunctionInfo&>()))
       .WillRepeatedly(testing::ReturnPointee(&function_selected));
@@ -507,7 +501,6 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
     for (size_t i = 0; i < kNumThreads; ++i) {
       capture_data_->AddOrAssignThreadName(kThreadIds[i], kThreadNames[i]);
     }
-    EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
     std::string expected_contents("\"Name\",\"Thread\",\"Start\",\"End\",\"Duration (ns)\"\r\n");
     for (size_t i = 0; i < kNumTimers; ++i) {
@@ -678,8 +671,6 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
 
 TEST_F(LiveFunctionsDataViewTest, FilteringShowsRightResults) {
   AddFunctionsByIndices({0, 1, 2});
-  EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
   // Filtering by function display name with single token
   {
@@ -724,9 +715,6 @@ TEST_F(LiveFunctionsDataViewTest, UpdateHighlightedFunctionsOnSelect) {
 
   EXPECT_CALL(app_, DeselectTimer).Times(3);
   EXPECT_CALL(app_, GetHighlightedScopeId).Times(3);
-  EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
-
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
   // Single selection will hightlight the selected function
   {
@@ -764,8 +752,6 @@ TEST_F(LiveFunctionsDataViewTest, UpdateHighlightedFunctionsOnSelect) {
 
 TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
   AddFunctionsByIndices({0, 1, 2});
-  EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
   using ViewRowEntry = std::array<std::string, kNumColumns>;
   std::vector<ViewRowEntry> view_entries;
@@ -867,12 +853,9 @@ TEST_F(LiveFunctionsDataViewTest, OnRefreshWithNoIndicesResetsHistogram) {
 }
 
 TEST_F(LiveFunctionsDataViewTest, HistogramIsProperlyUpdated) {
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
   EXPECT_CALL(app_, ProvideScopeId).WillRepeatedly(Invoke([&](const TimerInfo& timer) {
     return timer.function_id();
   }));
-  EXPECT_CALL(app_, HasCaptureData).WillRepeatedly(testing::Return(true));
-  EXPECT_CALL(app_, GetCaptureData).WillRepeatedly(testing::ReturnRef(*capture_data_));
 
   view_.OnDataChanged();
   AddFunctionsByIndices({0});

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -21,6 +21,7 @@
 #include "DataViews/DataView.h"
 #include "DataViews/LiveFunctionsInterface.h"
 #include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_data_views {
@@ -130,7 +131,12 @@ class LiveFunctionsDataView : public DataView {
     };
   }
 
-  void AddToIndices(ScopeId scope_id) { indices_.push_back(*scope_id); }
+  void AddToIndices(ScopeId scope_id) {
+    ORBIT_CHECK(app_->HasCaptureData());
+    const ScopeId max_scope_id = app_->GetCaptureData().GetMaxId();
+    ORBIT_CHECK(scope_id <= max_scope_id);
+    indices_.push_back(*scope_id);
+  }
 
   [[nodiscard]] std::vector<ScopeId> FetchMissingScopeIds() const;
 


### PR DESCRIPTION
The minidump and the callstack available for the recent crash could not
shed light on the nature of the issue. To that end it was decided
to add an explicit check upon adding a ScopeId to
`LiveFunctionsDataView::idices_`. That's it, we verify the id to be
in the range of the ids issued by `ScopeIdProvider`.

Test: Unit, Manual
Bug: http://b/243122633