### PR TITLE
Fix crashes when multiple Vulkan layers are loaded

### DIFF
--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -709,7 +709,6 @@ class VulkanLayerController {
                                                const char* extension_name,
                                                std::vector<std::string>* output) {
     auto raw_enumerate_device_extension_properties_function =
-        // Pass a valid instance, as following the spec. we are not allowed to use nullptr here.
         absl::bit_cast<PFN_vkEnumerateDeviceExtensionProperties>(
             dispatch_table_.EnumerateDeviceExtensionProperties(physical_device));
     auto enumerate_device_extension_properties =

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -728,6 +728,12 @@ TEST_F(
     return VK_SUCCESS;
   };
 
+  EXPECT_CALL(*dispatch_table, EnumerateDeviceExtensionProperties)
+      .Times(1)
+      .WillOnce(Invoke([](VkPhysicalDevice /*device*/) -> PFN_vkEnumerateDeviceExtensionProperties {
+        return kFakeEnumerateDeviceExtensionProperties;
+      }));
+
   PFN_vkGetDeviceProcAddr fake_get_device_proc_addr =
       +[](VkDevice /*device*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
@@ -735,9 +741,6 @@ TEST_F(
       +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkCreateDevice") == 0) {
       return absl::bit_cast<PFN_vkVoidFunction>(kMockDriverCreateDevice);
-    }
-    if (strcmp(name, "vkEnumerateDeviceExtensionProperties") == 0) {
-      return absl::bit_cast<PFN_vkVoidFunction>(kFakeEnumerateDeviceExtensionProperties);
     }
     return nullptr;
   };


### PR DESCRIPTION
They were two conception problems when in vkCreateDevice
that may lead to a crash when another Vulkan layer gets
loaded.

1. Calling vkGetInstanceProcAddr with VK_NULL_HANDLE
In order to call vkCreateDevice down the chain, we
retrieve the function pointer using the vkGetInstanceProcAddr
function for vkCreateDevice.
As we did not care about the instance, we pass in "VK_NULL_HANDLE",
as described in the Vulkan layer tutorial and almost all other
Vulkan layer. However, vkCreateDevice is not a global function,
but an instance function, so per API, this call will return
a nullptr and the subsequent call to the function pointer will
fail. While most ICDs and layers will return the right function
pointer anyways, Renderdoc returns null in that case.

So we do the right thing, and call vkGetInstanceProcAddr with
the actual instance.

2. `u.pLayerInfo->pfnNextGetInstanceProcAddr` is not always
   returning the function pointer down the chain.
For most instance functions, like "vkEnumerateDeviceExtensionProperties"
the Vulkan loader assumes that after the "vkCreateInstance" call
you are not doing another lookup using the pfnNextGetInstanceProcAddr
pointer, but instead create a dispatch table.
If layer A is before our Vulkan layer, we might end up in
getting the function pointer of layer A and fail.

So we use the cached dispatch table instead.
Some more context can be found in http://b/243079253.

Test: load the Vulkan layer together with RenderDoc on a couple
      of games.

Bug: http://b/243079253