### PR TITLE
Remove unused field

### DIFF
--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -137,8 +137,7 @@ static ErrorMessageOr<void> FindAndLoadSymbols(orbit_symbols::SymbolHelper& symb
                                                orbit_client_data::ModuleData& module_data) {
   OUTCOME_TRY(const auto symbols_path, FindSymbolsPath(symbol_helper, module_data));
 
-  orbit_object_utils::ObjectFileInfo object_file_info{module_data.load_bias(),
-                                                      module_data.executable_segment_offset()};
+  orbit_object_utils::ObjectFileInfo object_file_info{module_data.load_bias()};
   OUTCOME_TRY(orbit_grpc_protos::ModuleSymbols symbols,
               orbit_symbols::SymbolHelper::LoadSymbolsFromFile(symbols_path, object_file_info));
   module_data.AddSymbols(symbols);

--- a/src/ObjectUtils/PdbFileDiaTest.cpp
+++ b/src/ObjectUtils/PdbFileDiaTest.cpp
@@ -17,7 +17,7 @@ TEST(PdbFileDiaTest, CreatePdbDoesNotFailOnCoInitializeWhenAlreadyInitialized) {
   HRESULT result = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
   ASSERT_TRUE(result == S_OK || result == S_FALSE);
   ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result1 =
-      PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
+      PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
   ASSERT_THAT(pdb_file_result1, HasNoError());
   CoUninitialize();
 }
@@ -27,7 +27,7 @@ TEST(PdbFileDiaTest, PdbFileProperlyUninitializesComLibrary) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
   {
     ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result =
-        PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
+        PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
     ASSERT_THAT(pdb_file_result, HasNoError());
   }
 

--- a/src/ObjectUtils/PdbFileTest.h
+++ b/src/ObjectUtils/PdbFileTest.h
@@ -38,7 +38,7 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
   ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result =
-      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
+      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
   ASSERT_THAT(pdb_file_result, HasNoError());
   std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
   auto symbols_result = pdb_file->LoadDebugSymbols();
@@ -188,7 +188,7 @@ TYPED_TEST_P(PdbFileTest, CanObtainGuidAndAgeFromPdbAndDll) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
-      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
+      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
   ASSERT_THAT(pdb_file_result, HasNoError());
   std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
 
@@ -212,7 +212,7 @@ TYPED_TEST_P(PdbFileTest, CreatePdbFailsOnNonPdbFile) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.dll";
 
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
-      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000, 0x1000});
+      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
   EXPECT_THAT(pdb_file_result, HasError("Unable to load PDB file"));
 }
 

--- a/src/ObjectUtils/SymbolsFileTest.cpp
+++ b/src/ObjectUtils/SymbolsFileTest.cpp
@@ -18,15 +18,13 @@ TEST(SymbolsFile, CreateSymbolsFileFromElf) {
   const std::filesystem::path elf_with_symbols_path =
       orbit_test::GetTestdataDir() / "hello_world_elf";
 
-  auto valid_symbols_file =
-      CreateSymbolsFile(elf_with_symbols_path, ObjectFileInfo{0x10000});
+  auto valid_symbols_file = CreateSymbolsFile(elf_with_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   const std::filesystem::path elf_without_symbols_path =
       orbit_test::GetTestdataDir() / "no_symbols_elf";
 
-  auto invalid_symbols_file =
-      CreateSymbolsFile(elf_without_symbols_path, ObjectFileInfo{0x10000});
+  auto invalid_symbols_file = CreateSymbolsFile(elf_without_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(invalid_symbols_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(invalid_symbols_file, HasError("File does not contain symbols."));
 }
@@ -34,15 +32,13 @@ TEST(SymbolsFile, CreateSymbolsFileFromElf) {
 TEST(SymbolsFile, CreateSymbolsFileFromCoff) {
   const std::filesystem::path coff_with_symbols_path = orbit_test::GetTestdataDir() / "libtest.dll";
 
-  auto valid_symbols_file =
-      CreateSymbolsFile(coff_with_symbols_path, ObjectFileInfo{0x10000});
+  auto valid_symbols_file = CreateSymbolsFile(coff_with_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   const std::filesystem::path coff_without_symbols_path =
       orbit_test::GetTestdataDir() / "dllmain.dll";
 
-  auto invalid_symbols_file =
-      CreateSymbolsFile(coff_without_symbols_path, ObjectFileInfo{0x10000});
+  auto invalid_symbols_file = CreateSymbolsFile(coff_without_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(invalid_symbols_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(invalid_symbols_file, HasError("File does not contain symbols."));
 }
@@ -50,8 +46,7 @@ TEST(SymbolsFile, CreateSymbolsFileFromCoff) {
 TEST(SymbolsFile, CreateSymbolsFileFromPdb) {
   const std::filesystem::path pwd_with_symbols_path = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
-  auto valid_symbols_file =
-      CreateSymbolsFile(pwd_with_symbols_path, ObjectFileInfo{0x10000});
+  auto valid_symbols_file = CreateSymbolsFile(pwd_with_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   // pdb file always contains symbols, so a test for not containing symbols is not necessary

--- a/src/ObjectUtils/SymbolsFileTest.cpp
+++ b/src/ObjectUtils/SymbolsFileTest.cpp
@@ -19,14 +19,14 @@ TEST(SymbolsFile, CreateSymbolsFileFromElf) {
       orbit_test::GetTestdataDir() / "hello_world_elf";
 
   auto valid_symbols_file =
-      CreateSymbolsFile(elf_with_symbols_path, ObjectFileInfo{0x10000, 0x1000});
+      CreateSymbolsFile(elf_with_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   const std::filesystem::path elf_without_symbols_path =
       orbit_test::GetTestdataDir() / "no_symbols_elf";
 
   auto invalid_symbols_file =
-      CreateSymbolsFile(elf_without_symbols_path, ObjectFileInfo{0x10000, 0x1000});
+      CreateSymbolsFile(elf_without_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(invalid_symbols_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(invalid_symbols_file, HasError("File does not contain symbols."));
 }
@@ -35,14 +35,14 @@ TEST(SymbolsFile, CreateSymbolsFileFromCoff) {
   const std::filesystem::path coff_with_symbols_path = orbit_test::GetTestdataDir() / "libtest.dll";
 
   auto valid_symbols_file =
-      CreateSymbolsFile(coff_with_symbols_path, ObjectFileInfo{0x10000, 0x1000});
+      CreateSymbolsFile(coff_with_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   const std::filesystem::path coff_without_symbols_path =
       orbit_test::GetTestdataDir() / "dllmain.dll";
 
   auto invalid_symbols_file =
-      CreateSymbolsFile(coff_without_symbols_path, ObjectFileInfo{0x10000, 0x1000});
+      CreateSymbolsFile(coff_without_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(invalid_symbols_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(invalid_symbols_file, HasError("File does not contain symbols."));
 }
@@ -51,7 +51,7 @@ TEST(SymbolsFile, CreateSymbolsFileFromPdb) {
   const std::filesystem::path pwd_with_symbols_path = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
   auto valid_symbols_file =
-      CreateSymbolsFile(pwd_with_symbols_path, ObjectFileInfo{0x10000, 0x1000});
+      CreateSymbolsFile(pwd_with_symbols_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(valid_symbols_file, HasNoError());
 
   // pdb file always contains symbols, so a test for not containing symbols is not necessary
@@ -60,13 +60,13 @@ TEST(SymbolsFile, CreateSymbolsFileFromPdb) {
 TEST(SymbolsFile, FailToCreateSymbolsFile) {
   const std::filesystem::path path_to_text_file = orbit_test::GetTestdataDir() / "textfile.txt";
 
-  auto text_file = CreateSymbolsFile(path_to_text_file, ObjectFileInfo{0x10000, 0x1000});
+  auto text_file = CreateSymbolsFile(path_to_text_file, ObjectFileInfo{0x10000});
   EXPECT_THAT(text_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(text_file, HasError("File cannot be read as an object file"));
   EXPECT_THAT(text_file, HasError("File cannot be read as a pdb file"));
 
   const std::filesystem::path invalid_path = orbit_test::GetTestdataDir() / "non_existing_file";
-  auto invalid_file = CreateSymbolsFile(invalid_path, ObjectFileInfo{0x10000, 0x1000});
+  auto invalid_file = CreateSymbolsFile(invalid_path, ObjectFileInfo{0x10000});
   EXPECT_THAT(invalid_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(invalid_file, HasError("File does not exist"));
 }

--- a/src/ObjectUtils/include/ObjectUtils/SymbolsFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/SymbolsFile.h
@@ -18,11 +18,6 @@ struct ObjectFileInfo {
   // For ELF, this is the load bias of the executable segment. For PE/COFF, we use ImageBase here,
   // so that our address computations are consistent between what we do for ELF and for COFF.
   uint64_t load_bias = 0;
-  // This is the offset of the executable segment when loaded into memory. For ELF, as we defined
-  // the load bias based on the executable segment, this is also the offset of the executable
-  // segment in the file. For PE/COFF, this is in general different from the offset of the .text
-  // section in the file.
-  uint64_t executable_segment_offset = 0;
 };
 
 class SymbolsFile {

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -218,8 +218,7 @@ ErrorMessageOr<void> ClientGgp::LoadModuleAndSymbols() {
               process_client_->FindDebugInfoFile(module_path, {}));
   ORBIT_LOG("Found file: %s", main_executable_debug_file);
   ORBIT_LOG("Loading symbols");
-  orbit_object_utils::ObjectFileInfo object_file_info{main_module_->load_bias(),
-                                                      main_module_->executable_segment_offset()};
+  orbit_object_utils::ObjectFileInfo object_file_info{main_module_->load_bias()};
   OUTCOME_TRY(auto&& symbols, orbit_symbols::SymbolHelper::LoadSymbolsFromFile(
                                   main_executable_debug_file, object_file_info));
   main_module_->AddSymbols(symbols);

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2196,13 +2196,11 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::LoadSymbols(
     const std::filesystem::path& symbols_path, const ModuleIdentifier& module_id) {
   ORBIT_SCOPE_FUNCTION;
 
-  auto load_symbols_from_file =
-      thread_pool_->Schedule([this, symbols_path, module_id]() {
-        const ModuleData* module_data = GetModuleByModuleIdentifier(module_id);
-        orbit_object_utils::ObjectFileInfo object_file_info{
-            module_data->load_bias(), module_data->executable_segment_offset()};
-        return orbit_symbols::SymbolHelper::LoadSymbolsFromFile(symbols_path, object_file_info);
-      });
+  auto load_symbols_from_file = thread_pool_->Schedule([this, symbols_path, module_id]() {
+    const ModuleData* module_data = GetModuleByModuleIdentifier(module_id);
+    orbit_object_utils::ObjectFileInfo object_file_info{module_data->load_bias()};
+    return orbit_symbols::SymbolHelper::LoadSymbolsFromFile(symbols_path, object_file_info);
+  });
 
   auto add_symbols = [this, module_id](const ErrorMessageOr<orbit_grpc_protos::ModuleSymbols>&
                                            symbols_result) mutable -> ErrorMessageOr<void> {

--- a/src/ProcessService/ProcessServiceUtils.cpp
+++ b/src/ProcessService/ProcessServiceUtils.cpp
@@ -290,8 +290,7 @@ ErrorMessageOr<fs::path> FindSymbolsFilePath(
     }
 
     orbit_object_utils::ObjectFileInfo object_file_info{
-        object_file_or_error.value()->GetLoadBias(),
-        object_file_or_error.value()->GetExecutableSegmentOffset()};
+        object_file_or_error.value()->GetLoadBias()};
     auto symbols_file_or_error = CreateSymbolsFile(search_path, object_file_info);
     if (symbols_file_or_error.has_error()) {
       error_messages.push_back(symbols_file_or_error.error().message());

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -301,8 +301,7 @@ TEST(SymbolHelper, LoadSymbolsFromFile) {
   // .debug contains symbols
   {
     const fs::path file_path = testdata_directory / "no_symbols_elf.debug";
-    const auto result =
-        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
+    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000});
 
     ASSERT_THAT(result, HasValue());
     const ModuleSymbols& symbols = result.value();
@@ -313,8 +312,7 @@ TEST(SymbolHelper, LoadSymbolsFromFile) {
   // .pdb contains symbols
   {
     const fs::path file_path = testdata_directory / "dllmain.pdb";
-    const auto result =
-        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
+    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000});
 
     ASSERT_THAT(result, HasValue());
     const ModuleSymbols& symbols = result.value();
@@ -325,24 +323,21 @@ TEST(SymbolHelper, LoadSymbolsFromFile) {
   // elf does not contain symbols
   {
     const fs::path file_path = testdata_directory / "no_symbols_elf";
-    const auto result =
-        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
+    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000});
     EXPECT_THAT(result, HasError("does not contain symbols"));
   }
 
   // coff does not contain symbols
   {
     const fs::path file_path = testdata_directory / "dllmain.dll";
-    const auto result =
-        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
+    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000});
     EXPECT_THAT(result, HasError("does not contain symbols"));
   }
 
   // invalid file
   {
     const fs::path file_path = testdata_directory / "file_does_not_exist";
-    const auto result =
-        SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000, 0x1000});
+    const auto result = SymbolHelper::LoadSymbolsFromFile(file_path, ObjectFileInfo{0x10000});
     EXPECT_THAT(result, HasError("Unable to create symbols file"));
     EXPECT_THAT(result, HasError("File does not exist"));
   }

--- a/src/WindowsUtils/FindDebugSymbols.cpp
+++ b/src/WindowsUtils/FindDebugSymbols.cpp
@@ -83,8 +83,7 @@ ErrorMessageOr<std::filesystem::path> FindDebugSymbols(
       continue;
     }
 
-    orbit_object_utils::ObjectFileInfo object_file_info{object_file->GetLoadBias(),
-                                                        object_file->GetExecutableSegmentOffset()};
+    orbit_object_utils::ObjectFileInfo object_file_info{object_file->GetLoadBias()};
 
     ErrorMessageOr<std::unique_ptr<SymbolsFile>> symbols_file_or_error =
         CreateSymbolsFile(search_path, object_file_info);


### PR DESCRIPTION
This removes the by now unused "executable_segment_offset" field
from the "ObjectFileInfo" struct. This field became unused with
\#4075.

For now, we keep the struct and have it only contain the load
bias. We might want to change that at some later point in
time though.

Test: Compile