### PR TITLE
Move NextPixel free function to the interface

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(ClientData PRIVATE
         ThreadTrackDataProvider.cpp
         TimerChain.cpp
         TimerData.cpp
+        TimerDataInterface.cpp
         TimerTrackDataIdManager.cpp
         TimestampIntervalSet.cpp
         TracepointData.cpp

--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -71,31 +71,6 @@ std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers
   return all_timers_at_depth;
 }
 
-[[nodiscard]] static inline uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns,
-                                                                uint32_t resolution,
-                                                                uint64_t start_ns,
-                                                                uint64_t end_ns) {
-  uint64_t current_ns_from_start = current_timestamp_ns - start_ns;
-  uint64_t total_ns = end_ns - start_ns;
-
-  // Given a resolution of 4000 pixels, we can capture for 53 days without overflowing.
-  uint64_t current_pixel = (current_ns_from_start * resolution) / total_ns;
-  uint64_t next_pixel = current_pixel + 1;
-
-  // To calculate the timestamp of a pixel boundary, we round to the left similar to how it works in
-  // other parts of Orbit.
-  uint64_t next_pixel_ns_from_min = total_ns * next_pixel / resolution;
-
-  // Border case when we have a lot of pixels who have the same timestamp (because the number of
-  // pixels is less than the nanoseconds in screen). In this case, as we've already drawn in the
-  // current_timestamp, the next pixel to draw should have the next timestamp.
-  if (next_pixel_ns_from_min == current_ns_from_start) {
-    next_pixel_ns_from_min = current_ns_from_start + 1;
-  }
-
-  return start_ns + next_pixel_ns_from_min;
-}
-
 std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimersAtDepthDiscretized(
     uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const {
   // The query is for the interval [start_ns, end_ns], but it's easier to work with the close-open

--- a/src/ClientData/TimerDataInterface.cpp
+++ b/src/ClientData/TimerDataInterface.cpp
@@ -6,9 +6,8 @@
 
 namespace orbit_client_data {
 
-[[nodiscard]] uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns,
-                                                  uint32_t resolution, uint64_t start_ns,
-                                                  uint64_t end_ns) {
+uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns, uint32_t resolution,
+                                    uint64_t start_ns, uint64_t end_ns) {
   uint64_t current_ns_from_start = current_timestamp_ns - start_ns;
   uint64_t total_ns = end_ns - start_ns;
 

--- a/src/ClientData/TimerDataInterface.cpp
+++ b/src/ClientData/TimerDataInterface.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ClientData/TimerDataInterface.h"
+
+namespace orbit_client_data {
+
+[[nodiscard]] uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns,
+                                                  uint32_t resolution, uint64_t start_ns,
+                                                  uint64_t end_ns) {
+  uint64_t current_ns_from_start = current_timestamp_ns - start_ns;
+  uint64_t total_ns = end_ns - start_ns;
+
+  // Given a resolution of 4000 pixels, we can capture for 53 days without overflowing.
+  uint64_t current_pixel = (current_ns_from_start * resolution) / total_ns;
+  uint64_t next_pixel = current_pixel + 1;
+
+  // To calculate the timestamp of a pixel boundary, we round to the left similar to how it works in
+  // other parts of Orbit.
+  uint64_t next_pixel_ns_from_min = total_ns * next_pixel / resolution;
+
+  // Border case when we have a lot of pixels who have the same timestamp (because the number of
+  // pixels is less than the nanoseconds in screen). In this case, as we've already drawn in the
+  // current_timestamp, the next pixel to draw should have the next timestamp.
+  if (next_pixel_ns_from_min == current_ns_from_start) {
+    next_pixel_ns_from_min = current_ns_from_start + 1;
+  }
+
+  return start_ns + next_pixel_ns_from_min;
+}
+
+}  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/TimerDataInterface.h
+++ b/src/ClientData/include/ClientData/TimerDataInterface.h
@@ -19,6 +19,12 @@ struct TimerMetadata {
   uint32_t process_id;
 };
 
+// Free Function that will be used for any implementation of
+// TimerDataInterface::GetTimersAtDepthDiscretized to get the next pixel timestamp.
+[[nodiscard]] uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns,
+                                                  uint32_t resolution, uint64_t start_ns,
+                                                  uint64_t end_ns);
+
 // Interface to be use by TimerDataProvider to access data from TimerTracks.
 class TimerDataInterface {
  public:


### PR DESCRIPTION
GetNextPixelBoundaryTimeNs free function will be needed for any
implementation of TimerDataInterface (GetTimersAtDepthDiscretized will
use it to get the boundary of the pixels), so in this PR we are moving
this function to the common interface.

I also considered creating an utility file, but I think that it makes
sense to have it in TimerDataInterface.

Bugs: http://b/242971217 & http://b/242971304
Test: Compile.