### PR TITLE
Work around LLVM's getAge bug

### DIFF
--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -419,6 +419,8 @@ ErrorMessageOr<std::unique_ptr<PdbFile>> PdbFileLlvm::CreatePdbFile(
                                         file_path.string(), llvm::toString(std::move(error))));
   }
 
+  // We need the debug info stream to retrieve the correct age information (which is used in the
+  // build-id). See: https://github.com/llvm/llvm-project/issues/57300
   if (!PdbHasDbiStream(session.get())) {
     return ErrorMessage(
         absl::StrFormat("Unable to load PDB file %s: PDB has no Dbi Stream", file_path.string()));

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -302,6 +302,27 @@ PdbFileLlvm::PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& 
       object_file_info_(object_file_info),
       session_(std::move(session)) {}
 
+std::array<uint8_t, 16> PdbFileLlvm::GetGuid() const {
+  constexpr int kGuidSize = 16;
+  static_assert(kGuidSize == sizeof(llvm::codeview::GUID));
+  std::array<uint8_t, kGuidSize> result;
+  auto global_scope = session_->getGlobalScope();
+  const llvm::codeview::GUID& guid = global_scope->getGuid();
+  std::copy(std::begin(guid.Guid), std::end(guid.Guid), std::begin(result));
+  return result;
+}
+
+uint32_t PdbFileLlvm::GetAge() const {
+  auto* native_session = dynamic_cast<llvm::pdb::NativeSession*>(session_.get());
+  ORBIT_CHECK(native_session != nullptr);
+  llvm::pdb::PDBFile& pdb_file = native_session->getPDBFile();
+  ORBIT_CHECK(pdb_file.hasPDBDbiStream());
+  llvm::Expected<llvm::pdb::DbiStream&> debug_info_stream = pdb_file.getPDBDbiStream();
+  ORBIT_CHECK(debug_info_stream);
+
+  return debug_info_stream->getAge();
+}
+
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> PdbFileLlvm::LoadDebugSymbols() {
   auto* native_session = dynamic_cast<llvm::pdb::NativeSession*>(session_.get());
   ORBIT_CHECK(native_session != nullptr);
@@ -371,6 +392,21 @@ PdbFileLlvm::PdbFileLlvm(std::filesystem::path file_path, const ObjectFileInfo& 
   return module_symbols;
 }
 
+static bool PdbHasDbiStream(llvm::pdb::IPDBSession* session) {
+  ORBIT_CHECK(session != nullptr);
+  auto* native_session = dynamic_cast<llvm::pdb::NativeSession*>(session);
+  ORBIT_CHECK(native_session != nullptr);
+  llvm::pdb::PDBFile& pdb_file = native_session->getPDBFile();
+  if (!pdb_file.hasPDBDbiStream()) {
+    return false;
+  }
+  llvm::Expected<llvm::pdb::DbiStream&> debug_info_stream = pdb_file.getPDBDbiStream();
+  if (!debug_info_stream) {
+    return false;
+  }
+  return true;
+}
+
 ErrorMessageOr<std::unique_ptr<PdbFile>> PdbFileLlvm::CreatePdbFile(
     const std::filesystem::path& file_path, const ObjectFileInfo& object_file_info) {
   std::string file_path_string = file_path.string();
@@ -382,18 +418,12 @@ ErrorMessageOr<std::unique_ptr<PdbFile>> PdbFileLlvm::CreatePdbFile(
     return ErrorMessage(absl::StrFormat("Unable to load PDB file %s with error: %s",
                                         file_path.string(), llvm::toString(std::move(error))));
   }
-  auto* native_session = dynamic_cast<llvm::pdb::NativeSession*>(session.get());
-  ORBIT_CHECK(native_session != nullptr);
-  llvm::pdb::PDBFile& pdb_file = native_session->getPDBFile();
-  const std::string dbi_error_str = absl::StrFormat(
-      "Unable to load PDB file %s with error: PDB has no Dbi Stream", file_path.string());
-  if (!pdb_file.hasPDBDbiStream()) {
-    return ErrorMessage(dbi_error_str);
+
+  if (!PdbHasDbiStream(session.get())) {
+    return ErrorMessage(
+        absl::StrFormat("Unable to load PDB file %s: PDB has no Dbi Stream", file_path.string()));
   }
-  llvm::Expected<llvm::pdb::DbiStream&> debug_info_stream = pdb_file.getPDBDbiStream();
-  if (!debug_info_stream) {
-    return ErrorMessage(dbi_error_str);
-  }
+
   return absl::WrapUnique<PdbFileLlvm>(
       new PdbFileLlvm(file_path, object_file_info, std::move(session)));
 }

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -385,7 +385,8 @@ ErrorMessageOr<std::unique_ptr<PdbFile>> PdbFileLlvm::CreatePdbFile(
   auto* native_session = dynamic_cast<llvm::pdb::NativeSession*>(session.get());
   ORBIT_CHECK(native_session != nullptr);
   llvm::pdb::PDBFile& pdb_file = native_session->getPDBFile();
-  const std::string dbi_error_str = absl::StrFormat("Unable to load PDB file %s with error: PDB has no Dbi Stream", file_path.string());
+  const std::string dbi_error_str = absl::StrFormat(
+      "Unable to load PDB file %s with error: PDB has no Dbi Stream", file_path.string());
   if (!pdb_file.hasPDBDbiStream()) {
     return ErrorMessage(dbi_error_str);
   }

--- a/src/ObjectUtils/PdbFileLlvm.h
+++ b/src/ObjectUtils/PdbFileLlvm.h
@@ -13,9 +13,9 @@
 #include <llvm/DebugInfo/CodeView/SymbolVisitorCallbacks.h>
 #include <llvm/DebugInfo/MSF/MappedBlockStream.h>
 #include <llvm/DebugInfo/PDB/Native/DbiStream.h>
+#include <llvm/DebugInfo/PDB/Native/InfoStream.h>
 #include <llvm/DebugInfo/PDB/Native/ModuleDebugStream.h>
 #include <llvm/DebugInfo/PDB/Native/NativeSession.h>
-#include <llvm/DebugInfo/PDB/Native/InfoStream.h>
 #include <llvm/DebugInfo/PDB/Native/PDBFile.h>
 #include <llvm/DebugInfo/PDB/PDB.h>
 #include <llvm/DebugInfo/PDB/PDBSymbolExe.h>
@@ -28,8 +28,8 @@
 #include "GrpcProtos/symbol.pb.h"
 #include "ObjectUtils/PdbFile.h"
 #include "ObjectUtils/WindowsBuildIdUtils.h"
-#include "OrbitBase/Result.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_object_utils {
 

--- a/src/ObjectUtils/PdbFileLlvm.h
+++ b/src/ObjectUtils/PdbFileLlvm.h
@@ -38,26 +38,10 @@ class PdbFileLlvm : public PdbFile {
   [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadDebugSymbols() override;
   [[nodiscard]] const std::filesystem::path& GetFilePath() const override { return file_path_; }
 
-  [[nodiscard]] std::array<uint8_t, 16> GetGuid() const override {
-    constexpr int kGuidSize = 16;
-    static_assert(kGuidSize == sizeof(llvm::codeview::GUID));
-    std::array<uint8_t, kGuidSize> result;
-    auto global_scope = session_->getGlobalScope();
-    const llvm::codeview::GUID& guid = global_scope->getGuid();
-    std::copy(std::begin(guid.Guid), std::end(guid.Guid), std::begin(result));
-    return result;
-  }
+  [[nodiscard]] std::array<uint8_t, 16> GetGuid() const override;
 
-  [[nodiscard]] uint32_t GetAge() const override {
-    auto* native_session = dynamic_cast<llvm::pdb::NativeSession*>(session_.get());
-    ORBIT_CHECK(native_session != nullptr);
-    llvm::pdb::PDBFile& pdb_file = native_session->getPDBFile();
-    ORBIT_CHECK(pdb_file.hasPDBDbiStream());
-    llvm::Expected<llvm::pdb::DbiStream&> debug_info_stream = pdb_file.getPDBDbiStream();
-    ORBIT_CHECK(debug_info_stream);
+  [[nodiscard]] uint32_t GetAge() const override;
 
-    return debug_info_stream->getAge();
-  }
   [[nodiscard]] std::string GetBuildId() const override {
     return ComputeWindowsBuildId(GetGuid(), GetAge());
   }


### PR DESCRIPTION
Reading the "Age" field in LLVM is actually buggy
(see https://github.com/llvm/llvm-project/issues/57300).

This works arround the issue by reading the age from
the debug info stream, where apearently it has the correct
value.

Test: Try loading a Windows capture on Linux with a
      bunch of Windows pdb files.

Bug: http://b/241379860