### PR TITLE
Make wine_syscall_dispatcher not selectable.

### DIFF
--- a/src/ClientData/FunctionInfo.cpp
+++ b/src/ClientData/FunctionInfo.cpp
@@ -50,14 +50,14 @@ std::optional<uint64_t> FunctionInfo::GetAbsoluteAddress(const ProcessData& proc
 
 bool FunctionInfo::IsFunctionSelectable() const {
   constexpr const char* kLibOrbitUserSpaceInstrumentation = "liborbituserspaceinstrumentation.so";
-  if (module_path().find(kLibOrbitUserSpaceInstrumentation) != std::string::npos) {
+  if (absl::StrContains(module_path(), kLibOrbitUserSpaceInstrumentation)) {
     return false;
   }
 
   constexpr const char* kNameOfWineSyscallDispatcher = "__wine_syscall_dispatcher";
   constexpr const char* kNameOfWineSyscallDispatcherModule = "ntdll.so";
-  if (pretty_name().find(kNameOfWineSyscallDispatcher) != std::string::npos &&
-      module_path().find(kNameOfWineSyscallDispatcherModule) != std::string::npos) {
+  if (absl::StrContains(pretty_name(), kNameOfWineSyscallDispatcher) &&
+      absl::StrContains(module_path(), kNameOfWineSyscallDispatcherModule)) {
     return false;
   }
 

--- a/src/ClientData/FunctionInfo.cpp
+++ b/src/ClientData/FunctionInfo.cpp
@@ -50,7 +50,18 @@ std::optional<uint64_t> FunctionInfo::GetAbsoluteAddress(const ProcessData& proc
 
 bool FunctionInfo::IsFunctionSelectable() const {
   constexpr const char* kLibOrbitUserSpaceInstrumentation = "liborbituserspaceinstrumentation.so";
-  return module_path().find(kLibOrbitUserSpaceInstrumentation) == std::string::npos;
+  if (module_path().find(kLibOrbitUserSpaceInstrumentation) != std::string::npos) {
+    return false;
+  }
+
+  constexpr const char* kNameOfWineSyscallDispatcher = "__wine_syscall_dispatcher";
+  constexpr const char* kNameOfWineSyscallDispatcherModule = "ntdll.so";
+  if (pretty_name().find(kNameOfWineSyscallDispatcher) != std::string::npos &&
+      module_path().find(kNameOfWineSyscallDispatcherModule) != std::string::npos) {
+    return false;
+  }
+
+  return true;
 }
 
 }  // namespace orbit_client_data


### PR DESCRIPTION
The function does not obey the calling convention and both methods of
instrumentation (kernel or user space) fail here.

Bug: http://b/243496103
Test: Local run.