### PR TITLE
Add SymbolFinder

### DIFF
--- a/src/ClientSymbols/CMakeLists.txt
+++ b/src/ClientSymbols/CMakeLists.txt
@@ -8,7 +8,8 @@ project(ClientSymbols)
 add_library(ClientSymbols STATIC)
 
 target_include_directories(ClientSymbols PUBLIC include/)
-target_link_libraries(ClientSymbols PUBLIC 
+target_link_libraries(ClientSymbols PUBLIC
+        ClientData 
         CONAN_PKG::abseil
         OrbitBase        
         Qt5::Core)

--- a/src/ClientSymbols/CMakeLists.txt
+++ b/src/ClientSymbols/CMakeLists.txt
@@ -9,15 +9,18 @@ add_library(ClientSymbols STATIC)
 
 target_include_directories(ClientSymbols PUBLIC include/)
 target_link_libraries(ClientSymbols PUBLIC 
-        CONAN_PKG::abseil        
+        CONAN_PKG::abseil
+        OrbitBase        
         Qt5::Core)
 
 target_sources(ClientSymbols PUBLIC 
         include/ClientSymbols/PersistentStorageManager.h
-        include/ClientSymbols/QSettingsBasedStorageManager.h)
+        include/ClientSymbols/QSettingsBasedStorageManager.h        
+        include/ClientSymbols/SymbolFinder.h)
 
 target_sources(ClientSymbols PRIVATE 
-        QSettingsBasedStorageManager.cpp)
+        QSettingsBasedStorageManager.cpp
+        SymbolFinder.cpp)
 
 add_executable(ClientSymbolsTests)
 target_sources(ClientSymbolsTests PRIVATE 

--- a/src/ClientSymbols/SymbolFinder.cpp
+++ b/src/ClientSymbols/SymbolFinder.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ClientSymbols/SymbolFinder.h"
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_client_symbols {
+
+std::optional<SymbolFinder::SymbolFindingResult> SymbolFinder::GetDownloadingResultByModulePath(
+    const std::string& module_file_path) const {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  const auto it = symbol_files_currently_downloading_.find(module_file_path);
+  if (it == symbol_files_currently_downloading_.end()) return std::nullopt;
+
+  return it->second.future;
+}
+
+bool SymbolFinder::IsModuleDownloading(const std::string& module_file_path) const {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  return symbol_files_currently_downloading_.contains(module_file_path);
+}
+
+void SymbolFinder::StopModuleDownloading(const std::string& module_file_path) {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+
+  if (!symbol_files_currently_downloading_.contains(module_file_path)) return;
+  symbol_files_currently_downloading_.at(module_file_path).stop_source.RequestStop();
+}
+
+void SymbolFinder::AddToCurrentlyDownloading(std::string module_file_path,
+                                             ModuleDownloadOperation download_operation) {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  symbol_files_currently_downloading_.emplace(std::move(module_file_path),
+                                              std::move(download_operation));
+}
+
+void SymbolFinder::RemoveFromCurrentlyDownloading(const std::string& module_file_path) {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  symbol_files_currently_downloading_.erase(module_file_path);
+}
+
+}  // namespace orbit_client_symbols

--- a/src/ClientSymbols/SymbolFinder.cpp
+++ b/src/ClientSymbols/SymbolFinder.cpp
@@ -6,6 +6,8 @@
 
 #include "OrbitBase/Logging.h"
 
+using orbit_client_data::ModuleIdentifier;
+
 namespace orbit_client_symbols {
 
 std::optional<SymbolFinder::SymbolFindingResult> SymbolFinder::GetDownloadingResultByModulePath(
@@ -39,6 +41,27 @@ void SymbolFinder::AddToCurrentlyDownloading(std::string module_file_path,
 void SymbolFinder::RemoveFromCurrentlyDownloading(const std::string& module_file_path) {
   ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
   symbol_files_currently_downloading_.erase(module_file_path);
+}
+
+std::optional<SymbolFinder::SymbolFindingResult> SymbolFinder::GetRetrievingResultForModule(
+    const ModuleIdentifier& module_id) const {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  const auto it = symbol_files_currently_retrieving_.find(module_id);
+  if (it == symbol_files_currently_retrieving_.end()) return std::nullopt;
+
+  return it->second;
+}
+
+void SymbolFinder::AddToCurrentlyRetrieving(ModuleIdentifier module_id,
+                                            SymbolFindingResult finding_result) {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  symbol_files_currently_retrieving_.emplace(std::move(module_id), std::move(finding_result));
+}
+
+void SymbolFinder::RemoveFromCurrentlyRetrieving(
+    const orbit_client_data::ModuleIdentifier& module_id) {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  symbol_files_currently_retrieving_.erase(module_id);
 }
 
 }  // namespace orbit_client_symbols

--- a/src/ClientSymbols/SymbolFinder.cpp
+++ b/src/ClientSymbols/SymbolFinder.cpp
@@ -64,4 +64,24 @@ void SymbolFinder::RemoveFromCurrentlyRetrieving(
   symbol_files_currently_retrieving_.erase(module_id);
 }
 
+bool SymbolFinder::IsModuleDownloadDisabled(const std::string& module_file_path) const {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  return download_disabled_modules_.contains(module_file_path);
+}
+
+absl::flat_hash_set<std::string> SymbolFinder::GetDownloadDisabledModules() const {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  return download_disabled_modules_;
+}
+
+void SymbolFinder::SetDownloadDisabledModules(absl::flat_hash_set<std::string> module_paths) {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  download_disabled_modules_ = std::move(module_paths);
+}
+
+void SymbolFinder::RemoveFromCurrentlyDownloadDisabled(const std::string& module_file_path) {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  download_disabled_modules_.erase(module_file_path);
+}
+
 }  // namespace orbit_client_symbols

--- a/src/ClientSymbols/include/ClientSymbols/SymbolFinder.h
+++ b/src/ClientSymbols/include/ClientSymbols/SymbolFinder.h
@@ -6,6 +6,7 @@
 #define CLIENT_SYMBOLS_SYMBOL_FINDER_H_
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 
 #include <thread>
 
@@ -49,6 +50,13 @@ class SymbolFinder {
                                 SymbolFindingResult finding_result);
   void RemoveFromCurrentlyRetrieving(const orbit_client_data::ModuleIdentifier& module_id);
 
+  // The following methods access download_disabled_modules_ and verify whether the call is from
+  // main thread.
+  [[nodiscard]] bool IsModuleDownloadDisabled(const std::string& module_file_path) const;
+  [[nodiscard]] absl::flat_hash_set<std::string> GetDownloadDisabledModules() const;
+  void SetDownloadDisabledModules(absl::flat_hash_set<std::string> module_paths);
+  void RemoveFromCurrentlyDownloadDisabled(const std::string& module_file_path);
+
  private:
   const std::thread::id main_thread_id_;
 
@@ -65,6 +73,10 @@ class SymbolFinder {
   // ONLY access this from the main thread.
   absl::flat_hash_map<orbit_client_data::ModuleIdentifier, SymbolFindingResult>
       symbol_files_currently_retrieving_;
+
+  // Set of module file paths for the modules which the download is disabled.
+  // ONLY access this from the main thread.
+  absl::flat_hash_set<std::string> download_disabled_modules_;
 };
 
 }  // namespace orbit_client_symbols

--- a/src/ClientSymbols/include/ClientSymbols/SymbolFinder.h
+++ b/src/ClientSymbols/include/ClientSymbols/SymbolFinder.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_SYMBOLS_SYMBOL_FINDER_H_
+#define CLIENT_SYMBOLS_SYMBOL_FINDER_H_
+
+#include <absl/container/flat_hash_map.h>
+
+#include <thread>
+
+#include "OrbitBase/CanceledOr.h"
+#include "OrbitBase/Future.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/StopSource.h"
+
+namespace orbit_client_symbols {
+
+class SymbolFinder {
+ public:
+  explicit SymbolFinder(std::thread::id thread_id) : main_thread_id_(thread_id) {}
+
+  using SymbolFindingResult =
+      orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>;
+
+  struct ModuleDownloadOperation {
+    orbit_base::StopSource stop_source;
+    SymbolFindingResult future;
+  };
+
+  // The following methods access symbol_files_currently_downloading_ and verify whether the call is
+  // from main thread.
+  [[nodiscard]] std::optional<SymbolFindingResult> GetDownloadingResultByModulePath(
+      const std::string& module_file_path) const;
+  [[nodiscard]] bool IsModuleDownloading(const std::string& module_file_path) const;
+  // Stop the downloading operation if the module is currently being downloaded;
+  // otherwise, do nothing.
+  void StopModuleDownloading(const std::string& module_file_path);
+  void AddToCurrentlyDownloading(std::string module_file_path,
+                                 ModuleDownloadOperation download_operation);
+  void RemoveFromCurrentlyDownloading(const std::string& module_file_path);
+
+ private:
+  const std::thread::id main_thread_id_;
+
+  // Map of module file path to download operation future, that holds all symbol downloads that
+  // are currently in progress.
+  // ONLY access this from the main thread.
+  absl::flat_hash_map<std::string, ModuleDownloadOperation> symbol_files_currently_downloading_;
+};
+
+}  // namespace orbit_client_symbols
+
+#endif  // CLIENT_SYMBOLS_SYMBOL_FINDER_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -830,7 +830,7 @@ void OrbitApp::PostInit(bool is_connected) {
     capture_client_ = std::make_unique<CaptureClient>(grpc_channel_);
 
     orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-    download_disabled_modules_ = storage_manager.LoadDisabledModulePaths();
+    symbol_finder_->SetDownloadDisabledModules(storage_manager.LoadDisabledModulePaths());
 
     if (GetTargetProcess() != nullptr) {
       std::ignore = UpdateProcessAndModuleList();
@@ -1880,7 +1880,7 @@ orbit_base::Future<void> OrbitApp::LoadSymbolsManually(
 
   orbit_base::ImmediateExecutor immediate_executor;
   for (const auto& module : modules_set) {
-    download_disabled_modules_.erase(module->file_path());
+    symbol_finder_->RemoveFromCurrentlyDownloadDisabled(module->file_path());
 
     // Explicitly do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
@@ -1888,7 +1888,7 @@ orbit_base::Future<void> OrbitApp::LoadSymbolsManually(
     futures.emplace_back(std::move(future));
   }
   orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-  storage_manager.SaveDisabledModulePaths(download_disabled_modules_);
+  storage_manager.SaveDisabledModulePaths(symbol_finder_->GetDownloadDisabledModules());
 
   return orbit_base::WhenAll(futures);
 }
@@ -2014,7 +2014,7 @@ orbit_base::Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::
   // TODO(b/177304549): [new UI] maybe come up with a better indicator whether orbit is connected
   // than process_manager != nullptr
   if (absl::GetFlag(FLAGS_local) || GetProcessManager() == nullptr ||
-      download_disabled_modules_.contains(module_id.file_path)) {
+      symbol_finder_->IsModuleDownloadDisabled(module_id.file_path)) {
     orbit_base::ImmediateExecutor executor;
     return local_symbols_future.ThenIfSuccess(
         &executor, [](const std::filesystem::path& result) -> CanceledOr<std::filesystem::path> {
@@ -3377,7 +3377,7 @@ SymbolLoadingState OrbitApp::GetSymbolLoadingStateForModule(const ModuleData* mo
 
   if (module->is_loaded()) return SymbolLoadingState::kLoaded;
 
-  if (download_disabled_modules_.contains(module->file_path())) {
+  if (symbol_finder_->IsModuleDownloadDisabled(module->file_path())) {
     return SymbolLoadingState::kDisabled;
   }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -52,6 +52,7 @@
 #include "ClientServices/CrashManager.h"
 #include "ClientServices/ProcessManager.h"
 #include "ClientServices/TracepointServiceClient.h"
+#include "ClientSymbols/SymbolFinder.h"
 #include "CodeReport/DisassemblyReport.h"
 #include "DataViewFactory.h"
 #include "DataViews/AppInterface.h"
@@ -673,15 +674,6 @@ class OrbitApp final : public DataViewFactory,
   std::shared_ptr<SamplingReport> sampling_report_;
   std::shared_ptr<SamplingReport> selection_report_ = nullptr;
 
-  struct ModuleDownloadOperation {
-    orbit_base::StopSource stop_source;
-    orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>> future;
-  };
-  // Map of module file path to download operation future, that holds all symbol downloads that
-  // are currently in progress.
-  // ONLY access this from the main thread.
-  absl::flat_hash_map<std::string, ModuleDownloadOperation> symbol_files_currently_downloading_;
-
   // Map of "module ID" (file path and build ID) to symbol file retrieving future, that holds all
   // symbol retrieving operations currently in progress. (Retrieving here means finding locally or
   // downloading from the instance). Since downloading a symbols file can be part of the retrieval,
@@ -730,6 +722,7 @@ class OrbitApp final : public DataViewFactory,
   std::unique_ptr<ManualInstrumentationManager> manual_instrumentation_manager_;
 
   const orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDirUnsafe()};
+  std::unique_ptr<orbit_client_symbols::SymbolFinder> symbol_finder_;
 
   orbit_client_data::ProcessData* process_ = nullptr;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -689,10 +689,6 @@ class OrbitApp final : public DataViewFactory,
   // ONLY access this from the main thread.
   absl::flat_hash_set<orbit_client_data::ModuleIdentifier> modules_with_symbol_loading_error_;
 
-  // Set of modules for which the download is disabled.
-  // ONLY access this from the main thread.
-  absl::flat_hash_set<std::string> download_disabled_modules_;
-
   // A boolean information about if the default Frame Track was added in the current session.
   bool default_frame_track_was_added_ = false;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -674,21 +674,10 @@ class OrbitApp final : public DataViewFactory,
   std::shared_ptr<SamplingReport> sampling_report_;
   std::shared_ptr<SamplingReport> selection_report_ = nullptr;
 
-  // Map of "module ID" (file path and build ID) to symbol file retrieving future, that holds all
-  // symbol retrieving operations currently in progress. (Retrieving here means finding locally or
-  // downloading from the instance). Since downloading a symbols file can be part of the retrieval,
-  // if a module ID is contained in symbol_files_currently_downloading_, it is also contained in
-  // symbol_files_currently_being_retrieved_.
-  // ONLY access this from the main thread.
-  absl::flat_hash_map<
-      orbit_client_data::ModuleIdentifier,
-      orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>>
-      symbol_files_currently_being_retrieved_;
-
   // Map of "module ID" (file path and build ID) to symbol loading future, that holds all symbol
   // loading operations that are currently in progress. Since retrieving and downloading a file can
   // be part of the overall symbol loading process, if a module ID is contained in
-  // symbol_files_currently_being_retrieved_ or symbol_files_currently_downloading_, it is also
+  // symbol_files_currently_retrieving_ or symbol_files_currently_downloading_, it is also
   // contained in symbols_currently_loading_.
   // ONLY access this from the main thread.
   absl::flat_hash_map<orbit_client_data::ModuleIdentifier,


### PR DESCRIPTION
With this change, we created the `SymbolFinder` class and moved
`symbol_files_currently_downloading` from `OrbitApp` to `SymbolFinder`.

This is the first PR for the symbol loading refactoring. All the logic
for retrieving a local symbol file path for a given module will be moved
from `OrbitApp` to `SymbolFinder` gradually.

Bug: http://b/243520787