### PR TITLE
Parse PDB's public symbols using LLVM

### DIFF
--- a/src/ObjectUtils/BUILD
+++ b/src/ObjectUtils/BUILD
@@ -6,7 +6,7 @@ load("//:orbit.bzl", "orbit_cc_library", "orbit_cc_test")
 
 package(default_visibility = [
     "//:__subpackages__",
-    "//:users",  
+    "//:users",
 ])
 
 licenses(["notice"])
@@ -20,6 +20,7 @@ orbit_cc_library(
         "//src/Introspection",
         "//src/OrbitBase",
         "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",

--- a/src/ObjectUtils/BUILD
+++ b/src/ObjectUtils/BUILD
@@ -20,6 +20,7 @@ orbit_cc_library(
         "//src/Introspection",
         "//src/OrbitBase",
         "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",

--- a/src/ObjectUtils/PdbFileDiaTest.cpp
+++ b/src/ObjectUtils/PdbFileDiaTest.cpp
@@ -36,31 +36,3 @@ TEST(PdbFileDiaTest, PdbFileProperlyUninitializesComLibrary) {
   ASSERT_EQ(result, S_OK);
   CoUninitialize();
 }
-
-TEST(PdbFileDiaTest, LoadsFunctionsOnlyInPublicSymbols) {
-  std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "libomp.dll.pdb";
-
-  ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result =
-      PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0});
-  ASSERT_THAT(pdb_file_result, HasNoError());
-  std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
-  auto symbols_result = pdb_file->LoadDebugSymbols();
-  ASSERT_THAT(symbols_result, HasNoError());
-
-  auto symbols = std::move(symbols_result.value());
-
-  absl::flat_hash_map<uint64_t, const SymbolInfo*> symbol_infos_by_address;
-  for (const SymbolInfo& symbol_info : symbols.symbol_infos()) {
-    symbol_infos_by_address.emplace(symbol_info.address(), &symbol_info);
-  }
-
-  ASSERT_EQ(symbol_infos_by_address.size(), 6868);
-
-  {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x0F187B];
-    ASSERT_NE(symbol, nullptr);
-    EXPECT_EQ(symbol->demangled_name(), "FormatMessageW");
-    EXPECT_EQ(symbol->address(), 0xF187B);
-    EXPECT_EQ(symbol->size(), 6);
-  }
-}


### PR DESCRIPTION
In a PDB file, public symbols are not a real subset of
the module info stream's symbols. There are symbols for
functions (like RtUserThreadStart) that are only present
in the public symbols.

This change adds support for reading public symbols
using LLVM.

Unlike DIA, LLVM is not extrapolating the size information
for the public symbols. Therefore, we try to deduce
this information from the distance to the next
symbol (similar to what we do in the CoffFile).
For the last symbol, we try to find the size information
in the section contribution stream.

Test: Run test + Check on a couple of Windows dlls.
Bug: http://b/221968448