### PR TITLE
Add tests to the GetNextPixel utility method

### DIFF
--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -89,21 +89,22 @@ target_sources(ClientDataTests PRIVATE
         CallstackDataTest.cpp
         CaptureDataTest.cpp
         DataManagerTest.cpp
-        ScopeIdProviderTest.cpp
         FunctionInfoTest.cpp
         ModuleAndFunctionLookupTest.cpp
         ModuleDataTest.cpp
         ModuleIdentifierTest.cpp
         ModuleManagerTest.cpp
         ProcessDataTest.cpp
+        ScopeIdProviderTest.cpp
         ScopeInfoTest.cpp
         ScopeTreeTimerDataTest.cpp
         ThreadTrackDataManagerTest.cpp
         ThreadTrackDataProviderTest.cpp
+        TimerDataTest.cpp
+        TimerDataInterfaceTest.cpp
         TimerTrackDataIdManagerTest.cpp
         TimestampIntervalSetTest.cpp
         TracepointDataTest.cpp
-        TimerDataTest.cpp
         UserDefinedCaptureDataTest.cpp)
 
 target_link_libraries(ClientDataTests PRIVATE

--- a/src/ClientData/TimerDataInterface.cpp
+++ b/src/ClientData/TimerDataInterface.cpp
@@ -15,16 +15,9 @@ uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns, uint32_t reso
   uint64_t current_pixel = (current_ns_from_start * resolution) / total_ns;
   uint64_t next_pixel = current_pixel + 1;
 
-  // To calculate the timestamp of a pixel boundary, we round to the left similar to how it works in
-  // other parts of Orbit.
-  uint64_t next_pixel_ns_from_min = total_ns * next_pixel / resolution;
-
-  // Border case when we have a lot of pixels who have the same timestamp (because the number of
-  // pixels is less than the nanoseconds in screen). In this case, as we've already drawn in the
-  // current_timestamp, the next pixel to draw should have the next timestamp.
-  if (next_pixel_ns_from_min == current_ns_from_start) {
-    next_pixel_ns_from_min = current_ns_from_start + 1;
-  }
+  // To calculate the timestamp of a pixel boundary, we make a ceiling to be consistent to how we
+  // calculate current_pixel.
+  uint64_t next_pixel_ns_from_min = (total_ns * next_pixel + resolution - 1) / resolution;
 
   return start_ns + next_pixel_ns_from_min;
 }

--- a/src/ClientData/TimerDataInterface.cpp
+++ b/src/ClientData/TimerDataInterface.cpp
@@ -15,7 +15,8 @@ uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns, uint32_t reso
   uint64_t current_pixel = (current_ns_from_start * resolution) / total_ns;
   uint64_t next_pixel = current_pixel + 1;
 
-  // Calculates `ceil(dividend / divisor)` only using integers assuming dividend is not 0.
+  // Calculates `ceil(dividend / divisor)` only using integers assuming dividend and divisor are not
+  // 0.
   const auto rounding_up_division = [](uint64_t dividend, uint64_t divisor) -> uint64_t {
     return 1 + (dividend - 1) / divisor;
   };

--- a/src/ClientData/TimerDataInterface.cpp
+++ b/src/ClientData/TimerDataInterface.cpp
@@ -15,9 +15,14 @@ uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns, uint32_t reso
   uint64_t current_pixel = (current_ns_from_start * resolution) / total_ns;
   uint64_t next_pixel = current_pixel + 1;
 
-  // To calculate the timestamp of a pixel boundary, we make a ceiling to be consistent to how we
-  // calculate current_pixel.
-  uint64_t next_pixel_ns_from_min = (total_ns * next_pixel + resolution - 1) / resolution;
+  // Calculates `ceil(dividend / divisor)` only using integers assuming dividend is not 0.
+  const auto rounding_up_division = [](uint64_t dividend, uint64_t divisor) -> uint64_t {
+    return 1 + (dividend - 1) / divisor;
+  };
+
+  // To calculate the timestamp of a pixel boundary, we make a cross-multiplication rounding_up to
+  // be consistent to how we calculate current_pixel.
+  uint64_t next_pixel_ns_from_min = rounding_up_division(total_ns * next_pixel, resolution);
 
   return start_ns + next_pixel_ns_from_min;
 }

--- a/src/ClientData/TimerDataInterfaceTest.cpp
+++ b/src/ClientData/TimerDataInterfaceTest.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "ClientData/TimerDataInterface.h"
+
+namespace orbit_client_data {
+
+TEST(TimerData, GetNextPixelBoundaryTimeNs) {
+  const uint64_t kStartNs = 100;
+  const uint64_t kEndNs = 200;
+  uint64_t num_visible_pixels = kEndNs - kStartNs;  // 100
+
+  std::vector<uint32_t> kPixelResolutionsInTest = {1, 20, 30, 50, 100};
+
+  // First we test for different resolutions that the next pixel is greater than the current one but
+  // also not greater than the maximum number of nanoseconds per pixel.
+  for (uint32_t resolution : kPixelResolutionsInTest) {
+    // The max number of nanoseconds per pixel can be calculated using a ceil function.
+    uint32_t max_nanoseconds_per_pixel = (num_visible_pixels + resolution - 1) / resolution;
+    for (uint64_t timestamp_ns = kStartNs; timestamp_ns < kEndNs; timestamp_ns++) {
+      uint64_t next_pixel_ns =
+          GetNextPixelBoundaryTimeNs(timestamp_ns, resolution, kStartNs, kEndNs);
+      EXPECT_GT(next_pixel_ns, timestamp_ns);
+      EXPECT_LE(next_pixel_ns, timestamp_ns + max_nanoseconds_per_pixel);
+    }
+  }
+
+  // Second we test that iterating through visible pixels using GetNextPixelBoundaryTimeNs goes once
+  // per pixel.
+  for (uint32_t resolution : kPixelResolutionsInTest) {
+    int it = 0;
+    uint64_t current_timestamp_ns = kStartNs;
+    while (current_timestamp_ns < kEndNs) {
+      ++it;
+      current_timestamp_ns =
+          GetNextPixelBoundaryTimeNs(current_timestamp_ns, resolution, kStartNs, kEndNs);
+    }
+    EXPECT_EQ(it, resolution);
+  }
+
+  // If there are more visible pixels than visible timestamps, we will have several pixels with the
+  // same timestamp. In this case to avoid an infinite loop, the next pixel timestamp should be
+  // greater than the one queried.
+  EXPECT_EQ(GetNextPixelBoundaryTimeNs(kStartNs, num_visible_pixels * 10, kStartNs, kEndNs),
+            kStartNs + 1);
+}
+
+}  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/TimerDataInterface.h
+++ b/src/ClientData/include/ClientData/TimerDataInterface.h
@@ -20,7 +20,8 @@ struct TimerMetadata {
 };
 
 // Free Function that will be used for any implementation of
-// TimerDataInterface::GetTimersAtDepthDiscretized to get the next pixel timestamp.
+// TimerDataInterface::GetTimersAtDepthDiscretized to get the next pixel timestamp. The query
+// assumes a closed-open interval [start_ns, end_ns), so end_ns is not a visible timestamp.
 [[nodiscard]] uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns,
                                                   uint32_t resolution, uint64_t start_ns,
                                                   uint64_t end_ns);


### PR DESCRIPTION
In this PR we are adding tests to GetNextPixelBoundaryTimeNs() method.

The test showed that the method was not working fully optimal when the
resolution was not a divisor of the number of visible pixel, because it
might visit twice each pixel (the max ns of the left pixel and the
min ns of the right pixel). I fixed it by making a ceiling instead. Now,
the function to get the min_timestamp for a given pixel return a
timestamp that will be assigned to the correct pixel.

Bug: http://b/243628546
Test: Unit Test. Compared visually pre-post state of a loaded capture
  - Pre: http://screenshot/7VWPTMz4SCqLsyf
  - Post: http://screenshot/7MDRgz6ZaxzoAQy