### PR TITLE
Fix GetTimers by returning all visible timers

### DIFF
--- a/src/ClientData/TimerData.cpp
+++ b/src/ClientData/TimerData.cpp
@@ -55,7 +55,7 @@ std::vector<const orbit_client_protos::TimerInfo*> TimerData::GetTimers(uint64_t
       if (!block.Intersects(min_tick, max_tick)) continue;
       for (uint64_t i = 0; i < block.size(); i++) {
         const orbit_client_protos::TimerInfo* timer = &block[i];
-        if (min_tick <= timer->start() && timer->end() <= max_tick) timers.push_back(timer);
+        if (timer->start() <= max_tick && timer->end() >= min_tick) timers.push_back(timer);
       }
     }
   }

--- a/src/ClientData/TimerDataTest.cpp
+++ b/src/ClientData/TimerDataTest.cpp
@@ -112,7 +112,7 @@ TEST(TimerData, AddTimers) {
 }
 
 std::unique_ptr<TimerData> GetOrderedTimersSameDepth() {
-  std::unique_ptr<TimerData> timer_data = std::make_unique<TimerData>();
+  auto timer_data = std::make_unique<TimerData>();
   timer_data->AddTimer(GetLeftTimer());
   timer_data->AddTimer(GetMiddleTimer());
   timer_data->AddTimer(GetRightTimer());
@@ -120,7 +120,7 @@ std::unique_ptr<TimerData> GetOrderedTimersSameDepth() {
 }
 
 std::unique_ptr<TimerData> GetUnorderedTimersSameDepth() {
-  std::unique_ptr<TimerData> timer_data = std::make_unique<TimerData>();
+  auto timer_data = std::make_unique<TimerData>();
   timer_data->AddTimer(GetRightTimer());
   timer_data->AddTimer(GetLeftTimer());
   timer_data->AddTimer(GetMiddleTimer());
@@ -128,7 +128,7 @@ std::unique_ptr<TimerData> GetUnorderedTimersSameDepth() {
 }
 
 std::unique_ptr<TimerData> GetTimersDifferentDepths() {
-  std::unique_ptr<TimerData> timer_data = std::make_unique<TimerData>();
+  auto timer_data = std::make_unique<TimerData>();
   timer_data->AddTimer(GetLeftTimer());
   timer_data->AddTimer(GetRightTimer());
   timer_data->AddTimer(GetDownTimer(), /*depth=*/1);

--- a/src/ClientData/TimerDataTest.cpp
+++ b/src/ClientData/TimerDataTest.cpp
@@ -119,6 +119,22 @@ std::unique_ptr<TimerData> GetOrderedTimersSameDepth() {
   return timer_data;
 }
 
+std::unique_ptr<TimerData> GetUnorderedTimersSameDepth() {
+  std::unique_ptr<TimerData> timer_data = std::make_unique<TimerData>();
+  timer_data->AddTimer(GetRightTimer());
+  timer_data->AddTimer(GetLeftTimer());
+  timer_data->AddTimer(GetMiddleTimer());
+  return timer_data;
+}
+
+std::unique_ptr<TimerData> GetTimersDifferentDepths() {
+  std::unique_ptr<TimerData> timer_data = std::make_unique<TimerData>();
+  timer_data->AddTimer(GetLeftTimer());
+  timer_data->AddTimer(GetRightTimer());
+  timer_data->AddTimer(GetDownTimer(), /*depth=*/1);
+  return timer_data;
+}
+
 // TODO(b/204173036): Make GetFirstAfterStartTime private and test GetLeft/Right/Top/Down instead.
 TEST(TimerData, FindTimers) {
   std::unique_ptr<TimerData> timer_data = GetOrderedTimersSameDepth();
@@ -191,6 +207,23 @@ TEST(TimerData, FindTimers) {
         timer_data->GetFirstBeforeStartTime(std::numeric_limits<uint64_t>::max(), 1);
     EXPECT_EQ(timer_info, nullptr);
   }
+}
+
+void CheckGetTimers(std::unique_ptr<TimerData> timer_data) {
+  EXPECT_EQ(timer_data->GetTimers(0, kLeftTimerStart - 1).size(), 0);
+  EXPECT_EQ(timer_data->GetTimers(kRightTimerEnd + 1, kRightTimerEnd + 10).size(), 0);
+  EXPECT_EQ(timer_data->GetTimers(kLeftTimerStart - 1, kLeftTimerStart + 1).size(), 1);  // left
+  EXPECT_EQ(timer_data->GetTimers(kLeftTimerStart + 1, kLeftTimerEnd).size(), 2);  // left, middle
+  EXPECT_EQ(timer_data->GetTimers(kMiddleTimerStart, kMiddleTimerEnd).size(), 3);
+  EXPECT_EQ(timer_data->GetTimers(kRightTimerStart, kRightTimerEnd).size(), 2);     // middle, right
+  EXPECT_EQ(timer_data->GetTimers(kMiddleTimerEnd + 1, kRightTimerEnd).size(), 1);  // right
+  EXPECT_EQ(timer_data->GetTimers().size(), 3);
+}
+
+TEST(TimerData, GetTimers) {
+  CheckGetTimers(GetOrderedTimersSameDepth());
+  CheckGetTimers(GetUnorderedTimersSameDepth());
+  CheckGetTimers(GetTimersDifferentDepths());
 }
 
 }  // namespace orbit_client_data


### PR DESCRIPTION
In this PR we are making GetTimers from TimerData to return all
visible timers. As far as I know, this method was implemented but
never used (http://b/204173236 - correct me if I am wrong Valeriy).

Since this method will be used to draw timers, it should include the
partially visible as well, similar to what happens with
ScopeTreeTimerData.

In addition, I'm adding tests to the method.

Test: UnitTest
Bug: http://b/204173236