### PR TITLE
Add SymbolProvider interface

### DIFF
--- a/src/SymbolProvider/BUILD
+++ b/src/SymbolProvider/BUILD
@@ -13,6 +13,9 @@ licenses(["notice"])
 
 orbit_cc_library(
     name = "SymbolProvider",
+    deps = [
+        "//src/OrbitBase",
+    ],
 )
 
 orbit_cc_test(

--- a/src/SymbolProvider/CMakeLists.txt
+++ b/src/SymbolProvider/CMakeLists.txt
@@ -6,10 +6,14 @@ project(SymbolProvider)
 add_library(SymbolProvider INTERFACE)
 
 target_sources(SymbolProvider INTERFACE
-        include/SymbolProvider/ModuleIdentifier.h)
+        include/SymbolProvider/ModuleIdentifier.h
+        include/SymbolProvider/SymbolProvider.h)
 
 target_include_directories(SymbolProvider INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/include)
+
+target_link_libraries(SymbolProvider INTERFACE
+        OrbitBase)
 
 add_executable(SymbolProviderTests)
 

--- a/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
+++ b/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
@@ -14,15 +14,9 @@ namespace orbit_symbol_provider {
 
 // "SymbolProvider" supports retrieving symbols for the provided module from its symbol source, and
 // provides the local file path where symbols are cached if retrieval succeeded.
-// It also allows to query whether module symbols can be found in its symbol source.
 class SymbolProvider {
  public:
   virtual ~SymbolProvider() = default;
-
-  // Search for symbols for the provided module in the SymbolProvider's symbol source. Return an
-  // ErrorMessage if error occurs or symbols are not found, void otherwise.
-  [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<void>> FindSymbols(
-      const ModuleIdentifier& module_id) = 0;
 
   // Retrieve symbols for the provided module from the SymbolProvider's symbol source. Return:
   // - A local file path if successfully retrieve symbols;

--- a/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
+++ b/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
@@ -19,14 +19,15 @@ class SymbolProvider {
  public:
   virtual ~SymbolProvider() = default;
 
-  // Search for symbols for the provided module in the SymbolProvider's symbol source. Return true
-  // if found.
-  [[nodiscard]] virtual orbit_base::Future<bool> FindSymbols(const ModuleIdentifier& module_id) = 0;
+  // Search for symbols for the provided module in the SymbolProvider's symbol source. Return an
+  // ErrorMessage if error occurs or symbols are not found, void otherwise.
+  [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<void>> FindSymbols(
+      const ModuleIdentifier& module_id) = 0;
 
   // Retrieve symbols for the provided module from the SymbolProvider's symbol source. Return:
   // - A local file path if successfully retrieve symbols;
   // - A Canceled if the retrieve operation is canceled via the stop_token;
-  // - A ErrorMassage if symbols are not found or error occurs while retrieving symbols.
+  // - An ErrorMassage if symbols are not found or error occurs while retrieving symbols.
   [[nodiscard]] virtual orbit_base::Future<
       ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
   RetrieveSymbols(const ModuleIdentifier& module_id, orbit_base::StopToken stop_token) = 0;

--- a/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
+++ b/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
@@ -19,12 +19,6 @@ class SymbolProvider {
  public:
   virtual ~SymbolProvider() = default;
 
-  SymbolProvider(SymbolProvider&& other) = default;
-  SymbolProvider& operator=(SymbolProvider&& other) = default;
-
-  SymbolProvider(const SymbolProvider&) = delete;
-  SymbolProvider& operator=(const SymbolProvider&) = delete;
-
   // Search for symbols for the provided module in the SymbolProvider's symbol source. Return true
   // if found.
   [[nodiscard]] virtual orbit_base::Future<bool> FindSymbols(const ModuleIdentifier& module_id) = 0;

--- a/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
+++ b/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SYMBOL_PROVIDER_SYMBOL_PROVIDER_H_
+#define SYMBOL_PROVIDER_SYMBOL_PROVIDER_H_
+
+#include "OrbitBase/CanceledOr.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/StopToken.h"
+#include "SymbolProvider/ModuleIdentifier.h"
+
+namespace orbit_symbol_provider {
+
+// "SymbolProvider" supports retrieving symbols for the provided module from its symbol source, and
+// provides the local file path where symbols are cached if retrieval succeeded.
+// It also allows to query whether module symbols can be found in its symbol source.
+class SymbolProvider {
+ public:
+  virtual ~SymbolProvider() = default;
+
+  SymbolProvider(SymbolProvider&& other) = default;
+  SymbolProvider& operator=(SymbolProvider&& other) = default;
+
+  SymbolProvider(const SymbolProvider&) = delete;
+  SymbolProvider& operator=(const SymbolProvider&) = delete;
+
+  // Search for symbols for the provided module in the SymbolProvider's symbol source. Return true
+  // if found.
+  [[nodiscard]] virtual orbit_base::Future<bool> FindSymbols(const ModuleIdentifier& module_id) = 0;
+
+  // Retrieve symbols for the provided module from the SymbolProvider's symbol source. Return:
+  // - A local file path if successfully retrieve symbols;
+  // - A Canceled if the retrieve operation is canceled via the stop_token;
+  // - A ErrorMassage if symbols are not found or error occurs while retrieving symbols.
+  [[nodiscard]] virtual orbit_base::Future<
+      ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
+  RetrieveSymbols(const ModuleIdentifier& module_id, orbit_base::StopToken stop_token) = 0;
+};
+
+}  // namespace orbit_symbol_provider
+
+#endif  // SYMBOL_PROVIDER_SYMBOL_PROVIDER_H_


### PR DESCRIPTION
With this change, we added the `SymbolProvider` interface which supports
retrieving symbols for the given module from its symbol source, as well as
querying whether symbols can be found from its symbol source.

Bug: http://b/243520787