### PR TITLE
Symbol loading outcome

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/Logging.h
         include/OrbitBase/MainThreadExecutor.h
         include/OrbitBase/MakeUniqueForOverwrite.h
+        include/OrbitBase/NotFoundOr.h
         include/OrbitBase/GetProcessIds.h
         include/OrbitBase/Overloaded.h
         include/OrbitBase/Profiling.h
@@ -115,6 +116,7 @@ target_sources(OrbitBaseTests PRIVATE
         FutureHelpersTest.cpp
         ImmediateExecutorTest.cpp
         LoggingUtilsTest.cpp
+        NotFoundOrTest.cpp
         OverloadedTest.cpp
         ProfilingTest.cpp
         PromiseTest.cpp

--- a/src/OrbitBase/NotFoundOrTest.cpp
+++ b/src/OrbitBase/NotFoundOrTest.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest-death-test.h>
 #include <gtest/gtest.h>
 
 #include <memory>

--- a/src/OrbitBase/NotFoundOrTest.cpp
+++ b/src/OrbitBase/NotFoundOrTest.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest-death-test.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/NotFoundOr.h"
+
+namespace orbit_base {
+
+TEST(NotFoundOr, IsNotFound) {
+  // Default constructor is found
+  NotFoundOr<int> not_found_or_int;
+  EXPECT_FALSE(IsNotFound(not_found_or_int));
+
+  not_found_or_int = NotFound{"message"};
+  EXPECT_TRUE(IsNotFound(not_found_or_int));
+
+  not_found_or_int = 5;
+  EXPECT_FALSE(IsNotFound(not_found_or_int));
+
+  NotFoundOr<void> not_found_or_void;
+  EXPECT_FALSE(IsNotFound(not_found_or_void));
+
+  not_found_or_void = NotFound{"message"};
+  EXPECT_TRUE(IsNotFound(not_found_or_void));
+}
+
+TEST(NotFoundOr, GetNotFoundMessage) {
+  NotFoundOr<int> not_found_or_int;
+  EXPECT_DEATH(std::ignore = GetNotFoundMessage(not_found_or_int), "Check failed");
+
+  not_found_or_int = 5;
+  EXPECT_DEATH(std::ignore = GetNotFoundMessage(not_found_or_int), "Check failed");
+
+  const std::string message{"example message"};
+  not_found_or_int = NotFound{message};
+  EXPECT_EQ(GetNotFoundMessage(not_found_or_int), message);
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/NotFoundOrTest.cpp
+++ b/src/OrbitBase/NotFoundOrTest.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest-death-test.h>
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "OrbitBase/NotFoundOr.h"
 
 namespace orbit_base {
@@ -37,6 +39,20 @@ TEST(NotFoundOr, GetNotFoundMessage) {
   const std::string message{"example message"};
   not_found_or_int = NotFound{message};
   EXPECT_EQ(GetNotFoundMessage(not_found_or_int), message);
+}
+
+TEST(NotFoundOr, MoveOnlyType) {
+  // unique_ptr<int>; tests move only type
+  NotFoundOr<std::unique_ptr<int>> not_found_or_unique_ptr;
+
+  EXPECT_FALSE(IsNotFound(not_found_or_unique_ptr));
+
+  not_found_or_unique_ptr = std::make_unique<int>(5);
+  EXPECT_FALSE(IsNotFound(not_found_or_unique_ptr));
+
+  not_found_or_unique_ptr = NotFound{"message"};
+  ASSERT_TRUE(IsNotFound(not_found_or_unique_ptr));
+  EXPECT_EQ(GetNotFoundMessage(not_found_or_unique_ptr), "message");
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/NotFoundOr.h
+++ b/src/OrbitBase/include/OrbitBase/NotFoundOr.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_NOT_FOUND_OR_H_
+#define ORBIT_BASE_NOT_FOUND_OR_H_
+
+#include <string>
+#include <variant>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/VoidToMonostate.h"
+
+namespace orbit_base {
+
+// NotFound type that carries a message
+struct NotFound {
+  explicit NotFound(std::string message) : message(std::move(message)) {}
+  std::string message;
+};
+
+// NotFoundOr can be used as the return type of a search operation, where the search can be
+// unsuccessful and returns a message. Based on std::variant. Check whether a NotFoundOr object is
+// a "not found" result with orbit_base::IsNotFound. Get the message with GetNotFoundMessage.
+template <typename T>
+using NotFoundOr = std::variant<VoidToMonostate_t<T>, NotFound>;
+
+// Free function to check whether a NotFoundOr type is "not found". Abstracts
+// std::holds_alternative
+template <typename T>
+[[nodiscard]] bool IsNotFound(const std::variant<T, NotFound>& not_found_or) {
+  return std::holds_alternative<NotFound>(not_found_or);
+}
+
+// Free function to get the not found message of a NotFoundOr object.
+template <typename T>
+[[nodiscard]] std::string GetNotFoundMessage(const std::variant<T, NotFound>& not_found_or) {
+  ORBIT_CHECK(IsNotFound(not_found_or));
+  return std::get<NotFound>(not_found_or).message;
+}
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_NOT_FOUND_OR_H_

--- a/src/Symbols/CMakeLists.txt
+++ b/src/Symbols/CMakeLists.txt
@@ -8,9 +8,11 @@ add_library(Symbols STATIC)
 
 target_sources(Symbols PRIVATE 
         SymbolHelper.cpp
+        SymbolLoadingOutcome.cpp
         SymbolUtils.cpp)
 target_sources(Symbols PUBLIC 
         include/Symbols/SymbolHelper.h
+        include/Symbols/SymbolLoadingOutcome.h
         include/Symbols/SymbolUtils.h)
 
 target_include_directories(Symbols PUBLIC
@@ -26,6 +28,7 @@ target_link_libraries(Symbols PUBLIC
 add_executable(SymbolsTests)
 target_sources(SymbolsTests PRIVATE 
         SymbolHelperTest.cpp
+        SymbolLoadingOutcomeTest.cpp
         SymbolUtilsTest.cpp)
 target_link_libraries(SymbolsTests PRIVATE Symbols TestUtils GTest::Main)
 register_test(SymbolsTests)

--- a/src/Symbols/SymbolLoadingOutcome.cpp
+++ b/src/Symbols/SymbolLoadingOutcome.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Symbols/SymbolLoadingOutcome.h"
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/NotFoundOr.h"
+
+namespace orbit_symbols {
+
+using orbit_base::NotFoundOr;
+
+bool IsCanceled(const SymbolLoadingOutcome& outcome) {
+  return outcome.has_value() && orbit_base::IsCanceled(outcome.value());
+}
+
+bool IsNotFound(const SymbolLoadingOutcome& outcome) {
+  return outcome.has_value() && !IsCanceled(outcome) &&
+         orbit_base::IsNotFound(std::get<NotFoundOr<SuccessOutcome>>(outcome.value()));
+}
+
+std::string GetNotFoundMessage(const SymbolLoadingOutcome& outcome) {
+  ORBIT_CHECK(IsNotFound(outcome));
+  return orbit_base::GetNotFoundMessage(std::get<NotFoundOr<SuccessOutcome>>(outcome.value()));
+}
+
+bool IsSuccessOutcome(const SymbolLoadingOutcome& outcome) {
+  return outcome.has_value() && !IsCanceled(outcome) && !IsNotFound(outcome) &&
+         std::holds_alternative<SuccessOutcome>(
+             std::get<NotFoundOr<SuccessOutcome>>(outcome.value()));
+}
+
+SuccessOutcome GetSuccessOutcome(const SymbolLoadingOutcome& outcome) {
+  ORBIT_CHECK(IsSuccessOutcome(outcome));
+  return std::get<SuccessOutcome>(std::get<NotFoundOr<SuccessOutcome>>(outcome.value()));
+}
+
+}  // namespace orbit_symbols

--- a/src/Symbols/SymbolLoadingOutcome.cpp
+++ b/src/Symbols/SymbolLoadingOutcome.cpp
@@ -17,23 +17,25 @@ bool IsCanceled(const SymbolLoadingOutcome& outcome) {
 
 bool IsNotFound(const SymbolLoadingOutcome& outcome) {
   return outcome.has_value() && !IsCanceled(outcome) &&
-         orbit_base::IsNotFound(std::get<NotFoundOr<SuccessOutcome>>(outcome.value()));
+         orbit_base::IsNotFound(std::get<NotFoundOr<SymbolLoadingSuccessResult>>(outcome.value()));
 }
 
 std::string GetNotFoundMessage(const SymbolLoadingOutcome& outcome) {
   ORBIT_CHECK(IsNotFound(outcome));
-  return orbit_base::GetNotFoundMessage(std::get<NotFoundOr<SuccessOutcome>>(outcome.value()));
+  return orbit_base::GetNotFoundMessage(
+      std::get<NotFoundOr<SymbolLoadingSuccessResult>>(outcome.value()));
 }
 
-bool IsSuccessOutcome(const SymbolLoadingOutcome& outcome) {
+bool IsSuccessResult(const SymbolLoadingOutcome& outcome) {
   return outcome.has_value() && !IsCanceled(outcome) && !IsNotFound(outcome) &&
-         std::holds_alternative<SuccessOutcome>(
-             std::get<NotFoundOr<SuccessOutcome>>(outcome.value()));
+         std::holds_alternative<SymbolLoadingSuccessResult>(
+             std::get<NotFoundOr<SymbolLoadingSuccessResult>>(outcome.value()));
 }
 
-SuccessOutcome GetSuccessOutcome(const SymbolLoadingOutcome& outcome) {
-  ORBIT_CHECK(IsSuccessOutcome(outcome));
-  return std::get<SuccessOutcome>(std::get<NotFoundOr<SuccessOutcome>>(outcome.value()));
+SymbolLoadingSuccessResult GetSuccessResult(const SymbolLoadingOutcome& outcome) {
+  ORBIT_CHECK(IsSuccessResult(outcome));
+  return std::get<SymbolLoadingSuccessResult>(
+      std::get<NotFoundOr<SymbolLoadingSuccessResult>>(outcome.value()));
 }
 
 }  // namespace orbit_symbols

--- a/src/Symbols/SymbolLoadingOutcomeTest.cpp
+++ b/src/Symbols/SymbolLoadingOutcomeTest.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/CanceledOr.h"
+#include "Symbols/SymbolLoadingOutcome.h"
+
+namespace orbit_symbols {
+
+namespace {
+
+const SuccessOutcome kSuccessOutcome{std::filesystem::path{"/tmp/test/path"},
+                                     SuccessOutcome::SymbolSource::kStadiaInstance,
+                                     SuccessOutcome::SymbolFileSeparation::kDifferentFile};
+
+const orbit_base::NotFound kNotFound{"Did not find symbols"};
+
+}  // namespace
+
+TEST(SymbolLoadingOutcome, IsCanceled) {
+  SymbolLoadingOutcome outcome{orbit_base::Canceled{}};
+  EXPECT_TRUE(IsCanceled(outcome));
+}
+
+TEST(SymbolLoadingOutcome, IsSuccessOutcome) {
+  SymbolLoadingOutcome outcome{kSuccessOutcome};
+  EXPECT_TRUE(IsSuccessOutcome(outcome));
+}
+
+TEST(SymbolLoadingOutcome, GetSuccessOutcome) {
+  SymbolLoadingOutcome outcome{kSuccessOutcome};
+  const SuccessOutcome& success{GetSuccessOutcome(outcome)};
+  EXPECT_EQ(success.path, kSuccessOutcome.path);
+  EXPECT_EQ(success.symbol_source, kSuccessOutcome.symbol_source);
+  EXPECT_EQ(success.symbol_file_separation, kSuccessOutcome.symbol_file_separation);
+}
+
+TEST(SymbolLoadingOutcome, IsNotFound) {
+  SymbolLoadingOutcome outcome{kNotFound};
+  EXPECT_TRUE(IsNotFound(outcome));
+}
+
+TEST(SymbolLoadingOutcome, GetNotFoundMessage) {
+  SymbolLoadingOutcome outcome{kNotFound};
+  EXPECT_EQ(GetNotFoundMessage(outcome), kNotFound.message);
+}
+
+}  // namespace orbit_symbols

--- a/src/Symbols/SymbolLoadingOutcomeTest.cpp
+++ b/src/Symbols/SymbolLoadingOutcomeTest.cpp
@@ -11,9 +11,10 @@ namespace orbit_symbols {
 
 namespace {
 
-const SuccessOutcome kSuccessOutcome{std::filesystem::path{"/tmp/test/path"},
-                                     SuccessOutcome::SymbolSource::kStadiaInstance,
-                                     SuccessOutcome::SymbolFileSeparation::kDifferentFile};
+const SymbolLoadingSuccessResult kSuccessOutcome{
+    std::filesystem::path{"/tmp/test/path"},
+    SymbolLoadingSuccessResult::SymbolSource::kStadiaInstance,
+    SymbolLoadingSuccessResult::SymbolFileSeparation::kDifferentFile};
 
 const orbit_base::NotFound kNotFound{"Did not find symbols"};
 
@@ -24,14 +25,14 @@ TEST(SymbolLoadingOutcome, IsCanceled) {
   EXPECT_TRUE(IsCanceled(outcome));
 }
 
-TEST(SymbolLoadingOutcome, IsSuccessOutcome) {
+TEST(SymbolLoadingOutcome, IsSuccessResult) {
   SymbolLoadingOutcome outcome{kSuccessOutcome};
-  EXPECT_TRUE(IsSuccessOutcome(outcome));
+  EXPECT_TRUE(IsSuccessResult(outcome));
 }
 
-TEST(SymbolLoadingOutcome, GetSuccessOutcome) {
+TEST(SymbolLoadingOutcome, GetSuccessResult) {
   SymbolLoadingOutcome outcome{kSuccessOutcome};
-  const SuccessOutcome& success{GetSuccessOutcome(outcome)};
+  const SymbolLoadingSuccessResult& success{GetSuccessResult(outcome)};
   EXPECT_EQ(success.path, kSuccessOutcome.path);
   EXPECT_EQ(success.symbol_source, kSuccessOutcome.symbol_source);
   EXPECT_EQ(success.symbol_file_separation, kSuccessOutcome.symbol_file_separation);

--- a/src/Symbols/include/Symbols/SymbolLoadingOutcome.h
+++ b/src/Symbols/include/Symbols/SymbolLoadingOutcome.h
@@ -15,7 +15,7 @@
 
 namespace orbit_symbols {
 
-struct SuccessOutcome {
+struct SymbolLoadingSuccessResult {
   enum class SymbolSource {
     kUnknown,
     kOrbitCache,
@@ -26,8 +26,8 @@ struct SuccessOutcome {
   };
   enum class SymbolFileSeparation { kDifferentFile, kModuleFile };
 
-  explicit SuccessOutcome(std::filesystem::path path, SymbolSource symbol_source,
-                          SymbolFileSeparation symbol_file_separation)
+  explicit SymbolLoadingSuccessResult(std::filesystem::path path, SymbolSource symbol_source,
+                                      SymbolFileSeparation symbol_file_separation)
       : path(std::move(path)),
         symbol_source(symbol_source),
         symbol_file_separation(symbol_file_separation) {}
@@ -37,13 +37,13 @@ struct SuccessOutcome {
 };
 
 using SymbolLoadingOutcome =
-    ErrorMessageOr<orbit_base::CanceledOr<orbit_base::NotFoundOr<SuccessOutcome>>>;
+    ErrorMessageOr<orbit_base::CanceledOr<orbit_base::NotFoundOr<SymbolLoadingSuccessResult>>>;
 
 [[nodiscard]] bool IsCanceled(const SymbolLoadingOutcome& outcome);
 [[nodiscard]] bool IsNotFound(const SymbolLoadingOutcome& outcome);
 [[nodiscard]] std::string GetNotFoundMessage(const SymbolLoadingOutcome& outcome);
-[[nodiscard]] bool IsSuccessOutcome(const SymbolLoadingOutcome& outcome);
-[[nodiscard]] SuccessOutcome GetSuccessOutcome(const SymbolLoadingOutcome& outcome);
+[[nodiscard]] bool IsSuccessResult(const SymbolLoadingOutcome& outcome);
+[[nodiscard]] SymbolLoadingSuccessResult GetSuccessResult(const SymbolLoadingOutcome& outcome);
 
 }  // namespace orbit_symbols
 

--- a/src/Symbols/include/Symbols/SymbolLoadingOutcome.h
+++ b/src/Symbols/include/Symbols/SymbolLoadingOutcome.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SYMBOLS_SYMBOL_LOADING_OUTCOME_H_
+#define SYMBOLS_SYMBOL_LOADING_OUTCOME_H_
+
+#include <filesystem>
+#include <variant>
+
+#include "OrbitBase/CanceledOr.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/NotFoundOr.h"
+#include "OrbitBase/Result.h"
+
+namespace orbit_symbols {
+
+struct SuccessOutcome {
+  enum class SymbolSource {
+    kUnknown,
+    kOrbitCache,
+    kLocalStadiaSdk,
+    kStadiaInstance,
+    kSymbolLocationsDialog,
+    kAdditionalSymbolPathsFlag
+  };
+  enum class SymbolFileSeparation { kDifferentFile, kModuleFile };
+
+  explicit SuccessOutcome(std::filesystem::path path, SymbolSource symbol_source,
+                          SymbolFileSeparation symbol_file_separation)
+      : path(std::move(path)),
+        symbol_source(symbol_source),
+        symbol_file_separation(symbol_file_separation) {}
+  std::filesystem::path path;
+  SymbolSource symbol_source;
+  SymbolFileSeparation symbol_file_separation;
+};
+
+using SymbolLoadingOutcome =
+    ErrorMessageOr<orbit_base::CanceledOr<orbit_base::NotFoundOr<SuccessOutcome>>>;
+
+[[nodiscard]] bool IsCanceled(const SymbolLoadingOutcome& outcome);
+[[nodiscard]] bool IsNotFound(const SymbolLoadingOutcome& outcome);
+[[nodiscard]] std::string GetNotFoundMessage(const SymbolLoadingOutcome& outcome);
+[[nodiscard]] bool IsSuccessOutcome(const SymbolLoadingOutcome& outcome);
+[[nodiscard]] SuccessOutcome GetSuccessOutcome(const SymbolLoadingOutcome& outcome);
+
+}  // namespace orbit_symbols
+
+#endif  // SYMBOLS_SYMBOL_LOADING_OUTCOME_H_


### PR DESCRIPTION
Explanations in the commit messages. 

Putting these 2 commits up together, to show how NotFoundOr<> will be used. It can/will be also used for similar return types. Even more context here: https://github.com/antonrohr/orbit/tree/more_symbol_loading_metrics

I am not sure if this deep-ish nesting of `Or<>` types is a good idea. I am open for alternative suggestions.