### PR TITLE
Add MainWindowInterface::IsConnected()

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2011,9 +2011,8 @@ orbit_base::Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::
   Future<ErrorMessageOr<std::filesystem::path>> local_symbols_future =
       FindModuleLocally(module_data);
 
-  // TODO(b/177304549): [new UI] maybe come up with a better indicator whether orbit is connected
-  // than process_manager != nullptr
-  if (absl::GetFlag(FLAGS_local) || GetProcessManager() == nullptr ||
+  // If --local, Orbit can not download files from the instance, because no ssh channel exists.
+  if (absl::GetFlag(FLAGS_local) || !main_window_->IsConnected() ||
       download_disabled_modules_.contains(module_id.file_path)) {
     orbit_base::ImmediateExecutor executor;
     return local_symbols_future.ThenIfSuccess(

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -76,6 +76,8 @@ class MainWindowInterface {
                                       orbit_data_views::DataView* callstack_data_view,
                                       std::unique_ptr<class SamplingReport> report) = 0;
   virtual void ClearCallstackInspection() = 0;
+
+  virtual bool IsConnected() = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -138,6 +138,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   void ClearCallstackInspection() override;
 
+  bool IsConnected() override { return is_connected_; }
+
  protected:
   void closeEvent(QCloseEvent* event) override;
   void resizeEvent(QResizeEvent* event) override;


### PR DESCRIPTION
And use it in OrbitApp instead of GetProcessManager() == nullptr

Bug: http://b/177304549