### PR TITLE
Implement optimized rendering query in TimerData

### DIFF
--- a/src/ClientData/TimerChain.cpp
+++ b/src/ClientData/TimerChain.cpp
@@ -16,6 +16,15 @@ bool TimerBlock::Intersects(uint64_t min, uint64_t max) const {
   return (min <= max_timestamp_ && max >= min_timestamp_);
 }
 
+const orbit_client_protos::TimerInfo* TimerBlock::LowerBound(uint64_t min_ns) const {
+  auto it = std::lower_bound(data_.begin(), data_.end(), min_ns,
+                             [](const orbit_client_protos::TimerInfo& timer_info, uint64_t value) {
+                               return timer_info.end() < value;
+                             });
+  if (it == data_.end()) return nullptr;
+  return &*it;
+}
+
 TimerChain::~TimerChain() {
   // Find last block in chain
   while (current_->next_ != nullptr) {

--- a/src/ClientData/TimerData.cpp
+++ b/src/ClientData/TimerData.cpp
@@ -79,13 +79,13 @@ std::vector<const orbit_client_protos::TimerInfo*> TimerData::GetTimersAtDepthDi
   std::vector<const orbit_client_protos::TimerInfo*> discretized_timers;
   uint64_t next_pixel_start_ns = start_ns;
 
-  // We are iterating through all blocks until we are after end_ns, but we don't have other option
-  // if we use TimerChain.
+  // We are iterating through all blocks until we are after end_ns.
   for (const auto& block : *timers_.at(depth)) {
     if (block.MinTimestamp() >= end_ns) break;
 
     // Several candidate timers might be in the same block.
     while (block.Intersects(next_pixel_start_ns, end_ns) && next_pixel_start_ns < end_ns) {
+      // First timer for which the end timestamp isn't smaller than the start of the next pixel.
       const orbit_client_protos::TimerInfo* timer = block.LowerBound(next_pixel_start_ns);
       if (timer == nullptr || timer->start() >= end_ns) break;
       discretized_timers.push_back(timer);

--- a/src/ClientData/TimerDataTest.cpp
+++ b/src/ClientData/TimerDataTest.cpp
@@ -271,8 +271,11 @@ TEST(TimerData, GetTimersAtDepthDiscretized) {
     verify_size(0, kNormalResolution, kMinTimestamp, kMinTimestamp + 1, 1);
   }
 
-  // Queries with "depth = 1" should just return the down timer (if it is in the range).
+  // Queries with `depth = 1` should just return the down timer (if it is in the range).
   verify_size(1, kNormalResolution, kMinTimestamp, kMaxTimestamp, 1);
+
+  // No timers with `depth = 2` in TimerData.
+  verify_size(2, kNormalResolution, kMinTimestamp, kMaxTimestamp, 0);
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/TimerDataTest.cpp
+++ b/src/ClientData/TimerDataTest.cpp
@@ -226,4 +226,77 @@ TEST(TimerData, GetTimers) {
   CheckGetTimers(GetTimersDifferentDepths());
 }
 
+TEST(TimerData, GetTimersAtDepthDiscretized) {
+  // Left, right and down timers
+  std::unique_ptr<TimerData> timer_data = GetTimersDifferentDepths();
+
+  uint32_t kOnePixel = 1;
+  uint32_t kNormalResolution = 1000;
+
+  // Normal case. Left and right timer are visible.
+  EXPECT_EQ(
+      timer_data->GetTimersAtDepthDiscretized(0, kNormalResolution, kLeftTimerStart, kRightTimerEnd)
+          .size(),
+      2);
+
+  // Range tests.
+  {
+    // No visible timers at the left and right of the visible range.
+    EXPECT_EQ(timer_data->GetTimersAtDepthDiscretized(0, kNormalResolution, 0, kLeftTimerStart - 1)
+                  .size(),
+              0);
+    EXPECT_EQ(timer_data
+                  ->GetTimersAtDepthDiscretized(0, kNormalResolution, kRightTimerEnd + 1,
+                                                kRightTimerEnd + 10)
+                  .size(),
+              0);
+
+    // Only left timer will be visible if the right timer is out of range.
+    EXPECT_EQ(timer_data
+                  ->GetTimersAtDepthDiscretized(0, kNormalResolution, kLeftTimerStart,
+                                                kRightTimerStart - 1)
+                  .size(),
+              1);
+
+    // Only right timer will be visible if the left timer is out of range.
+    EXPECT_EQ(
+        timer_data
+            ->GetTimersAtDepthDiscretized(0, kNormalResolution, kLeftTimerEnd + 1, kRightTimerEnd)
+            .size(),
+        1);
+
+    // Both timers will be visible even if we include them partially.
+    EXPECT_EQ(
+        timer_data
+            ->GetTimersAtDepthDiscretized(0, kNormalResolution, kLeftTimerEnd, kRightTimerStart)
+            .size(),
+        2);
+  }
+
+  // Resolution tests.
+  {
+    // Only one timer will be visible if we have 1 pixel resolution.
+    EXPECT_EQ(timer_data->GetTimersAtDepthDiscretized(0, kOnePixel, kLeftTimerStart, kRightTimerEnd)
+                  .size(),
+              1);
+
+    // Only one timer will be visible if we zoom-out a lot even with a normal resolution.
+    EXPECT_EQ(timer_data->GetTimersAtDepthDiscretized(0, kNormalResolution, 0, 10000000).size(), 1);
+
+    // If there is a timer in the range, we should see it in any resolution.
+    EXPECT_EQ(
+        timer_data->GetTimersAtDepthDiscretized(0, kOnePixel, kLeftTimerStart, kLeftTimerStart + 1)
+            .size(),
+        1);
+    EXPECT_EQ(timer_data
+                  ->GetTimersAtDepthDiscretized(0, kNormalResolution, kLeftTimerStart,
+                                                kLeftTimerStart + 1)
+                  .size(),
+              1);
+  }
+
+  // Down timer
+  EXPECT_EQ(timer_data->GetTimersAtDepthDiscretized(/*depth=*/1, 1000, 0, 1000).size(), 1);
+}
+
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/TimerChain.h
+++ b/src/ClientData/include/ClientData/TimerChain.h
@@ -49,6 +49,7 @@ class TimerBlock {
   // {min, max}_timestamp are the minimum and maximum timestamp of the timers
   // that have so far been added to this block.
   [[nodiscard]] bool Intersects(uint64_t min, uint64_t max) const;
+  [[nodiscard]] uint64_t MinTimestamp() const { return min_timestamp_; }
 
   [[nodiscard]] size_t size() const { return data_.size(); }
   [[nodiscard]] bool at_capacity() const { return size() == kBlockSize; }
@@ -57,15 +58,9 @@ class TimerBlock {
     return data_[idx];
   }
 
-  // Assuming timers are sorted, returns the first one which its end isn't smaller than min_ns.
-  // Return nullptr if there is none.
-  [[nodiscard]] const orbit_client_protos::TimerInfo* LowerBound(uint64_t min_ns) const {
-    auto it = std::lower_bound(data_.begin(), data_.end(), min_ns,
-                               [](const orbit_client_protos::TimerInfo& timer_info,
-                                  uint64_t value) { return timer_info.end() < value; });
-    if (it == data_.end()) return nullptr;
-    return &*it;
-  }
+  // Assuming timers are sorted, returns the first one for which the end timestamp isn't smaller
+  // than min_ns. Return nullptr if there is none.
+  [[nodiscard]] const orbit_client_protos::TimerInfo* LowerBound(uint64_t min_ns) const;
 
  private:
   static constexpr size_t kBlockSize = 1024;

--- a/src/ClientData/include/ClientData/TimerChain.h
+++ b/src/ClientData/include/ClientData/TimerChain.h
@@ -57,6 +57,16 @@ class TimerBlock {
     return data_[idx];
   }
 
+  // Assuming timers are sorted, returns the first one which its end isn't smaller than min_ns.
+  // Return nullptr if there is none.
+  [[nodiscard]] const orbit_client_protos::TimerInfo* LowerBound(uint64_t min_ns) const {
+    auto it = std::lower_bound(data_.begin(), data_.end(), min_ns,
+                               [](const orbit_client_protos::TimerInfo& timer_info,
+                                  uint64_t value) { return timer_info.end() < value; });
+    if (it == data_.end()) return nullptr;
+    return &*it;
+  }
+
  private:
   static constexpr size_t kBlockSize = 1024;
 

--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -15,6 +15,8 @@
 
 namespace orbit_client_data {
 
+// Stores all the timers from a particular TimerTrack and provides queries to get timers in a
+// certain range as well as metadata from them. Timers might be divided in different depths.
 class TimerData final : public TimerDataInterface {
  public:
   const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info,
@@ -29,14 +31,12 @@ class TimerData final : public TimerDataInterface {
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
       uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const override;
-  // This optimized method avoids returning two timers that map to the same pixel in the screen, so
-  // is especially useful when there are many timers in the screen (zooming-out for example).
-  // It assures to return at least one timer per occupied pixel. The overall complexity is
-  // O(log(num_timers) * resolution) where resolution is the number of pixels_width.
-  // TODO(b/200692451): Provide a solution for TimerTrack with intersecting timers.
+  // Returns timers in a particular depth avoiding completely overlapped timers that map to the
+  // same pixels in the screen. It assures to return at least one timer in each occupied pixel. The
+  // overall complexity is faster than GetTimers since it doesn't require going through all timers.
+  // TODO(b/200692451): Provide a better solution for TimerTrack with intersecting timers.
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthDiscretized(
-      uint32_t /*depth*/, uint32_t /*resolution*/, uint64_t /*start_ns*/,
-      uint64_t /*end_ns*/) const override;
+      uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const override;
 
   // Metadata queries
   [[nodiscard]] bool IsEmpty() const override { return GetNumberOfTimers() == 0; }

--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -29,13 +29,14 @@ class TimerData final : public TimerDataInterface {
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
       uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const override;
+  // This optimized method avoids returning two timers that map to the same pixel in the screen, so
+  // is especially useful when there are many timers in the screen (zooming-out for example).
+  // It assures to return at least one timer per occupied pixel. The overall complexity is
+  // O(log(num_timers) * resolution) where resolution is the number of pixels_width.
+  // TODO(b/200692451): Provide a solution for TimerTrack with intersecting timers.
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthDiscretized(
       uint32_t /*depth*/, uint32_t /*resolution*/, uint64_t /*start_ns*/,
-      uint64_t /*end_ns*/) const override {
-    // TODO(b/242971217): Implement TimerData rendering optimization when timers are ordered.
-    ORBIT_UNREACHABLE();
-    return {};
-  };
+      uint64_t /*end_ns*/) const override;
 
   // Metadata queries
   [[nodiscard]] bool IsEmpty() const override { return GetNumberOfTimers() == 0; }

--- a/src/ClientData/include/ClientData/TimerDataInterface.h
+++ b/src/ClientData/include/ClientData/TimerDataInterface.h
@@ -38,10 +38,9 @@ class TimerDataInterface {
   [[nodiscard]] virtual std::vector<const TimerChain*> GetChains() const = 0;
   [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t min_tick, uint64_t max_tick) const = 0;
-  // This optimized method avoids returning two timers that map to the same pixel in the screen, so
-  // is especially useful when there are many timers in the screen (zooming-out for example).
-  // It assures to return at least one timer per occupied pixel. The overall complexity is
-  // O(log(num_timers) * resolution) where resolution is the number of pixels_width.
+  // Returns timers in a particular depth avoiding completely overlapped timers that map to the
+  // same pixels in the screen. It assures to return at least one timer in each occupied pixel. The
+  // overall complexity is faster than GetTimers since it doesn't require going through all timers.
   [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*>
   GetTimersAtDepthDiscretized(uint32_t depth, uint32_t resolution, uint64_t start_ns,
                               uint64_t end_ns) const = 0;


### PR DESCRIPTION
In this PR we are implementing the optimized query in TimerData,
similarly to what we did in ThreadTrack/ScopeTreeTimerData: https://github.com/google/orbit/pull/2929. 
The method was introduced in https://github.com/google/orbit/pull/4107, but not implemented.

Here we are aiming to provide a way to get timers without looping
through all of them for TimerTracks. As it says in TimerDataInterface, 
GetTimersAtDepthDiscretized avoids returning two timers that map to the
same pixel in the screen, so is especially useful when there are many timers
in the screen (zooming-out for example).

The implementation is way similar to ScopeTreeTimerData's one, but it
needs to iterate through blocks in the TimerChain because the data
structure doesn't provide O(1) access (explained in http://b/242970806).

We include a method in TimerChain to get the LowerBound inside a Block),
and we added unit tests for the new query. In a following step, this method
will be used to simplify UpdatePrimitives in SchedulerTrack. We also added
scopes, so the time for the query is measured when using introspection.

Bug: http://b/242971209.
Test: Unit Tests.