### PR TITLE
Add the MockClient for orbit_ggp::Client

### DIFF
--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(OrbitGgp PUBLIC
           include/OrbitGgp/Error.h
           include/OrbitGgp/Instance.h
           include/OrbitGgp/InstanceItemModel.h
+          include/OrbitGgp/MockClient.h
           include/OrbitGgp/Project.h
           include/OrbitGgp/SshInfo.h          
           include/OrbitGgp/SymbolDownloadInfo.h)

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -15,13 +15,13 @@
 #include <string>
 #include <vector>
 
-#include "Account.h"
-#include "Instance.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Result.h"
+#include "OrbitGgp/Account.h"
+#include "OrbitGgp/Instance.h"
 #include "OrbitGgp/Project.h"
+#include "OrbitGgp/SshInfo.h"
 #include "OrbitGgp/SymbolDownloadInfo.h"
-#include "SshInfo.h"
 
 namespace orbit_ggp {
 

--- a/src/OrbitGgp/include/OrbitGgp/MockClient.h
+++ b/src/OrbitGgp/include/OrbitGgp/MockClient.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GGP_MOCK_CLIENT_H_
+#define ORBIT_GGP_MOCK_CLIENT_H_
+
+#include <gmock/gmock.h>
+
+#include <QString>
+#include <QVector>
+#include <optional>
+
+#include "OrbitBase/Future.h"
+#include "OrbitBase/Result.h"
+#include "OrbitGgp/Client.h"
+
+namespace orbit_ggp {
+class MockClient : public Client {
+ public:
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<QVector<Instance>>>, GetInstancesAsync,
+              (Client::InstanceListScope /*scope*/, std::optional<Project> /*project*/),
+              (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<QVector<Instance>>>, GetInstancesAsync,
+              (Client::InstanceListScope /*scope*/, std::optional<Project> /*project*/,
+               int /*retry*/),
+              (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<SshInfo>>, GetSshInfoAsync,
+              (const QString& /*instance_id*/, std::optional<Project> /*project*/), (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<SshInfo>>, GetSshInfoAsync,
+              (const QString& /*instance_id*/, std::optional<Project> /*project*/, int /*retry*/),
+              (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<QVector<Project>>>, GetProjectsAsync, (),
+              (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<Project>>, GetDefaultProjectAsync, (), (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<Instance>>, DescribeInstanceAsync,
+              (const QString& /*instance_id*/), (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<Account>>, GetDefaultAccountAsync, (), (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>>,
+              GetSymbolDownloadInfoAsync, ((const std::vector<Client::SymbolDownloadQuery>&)),
+              (override));
+};
+}  // namespace orbit_ggp
+
+#endif  // ORBIT_GGP_MOCK_CLIENT_H_

--- a/src/SessionSetup/RetrieveInstancesTest.cpp
+++ b/src/SessionSetup/RetrieveInstancesTest.cpp
@@ -14,9 +14,8 @@
 #include "OrbitBase/Future.h"
 #include "OrbitBase/MainThreadExecutor.h"
 #include "OrbitBase/Result.h"
-#include "OrbitGgp/Client.h"
+#include "OrbitGgp/MockClient.h"
 #include "OrbitGgp/Project.h"
-#include "OrbitGgp/SymbolDownloadInfo.h"
 #include "QtUtils/MainThreadExecutorImpl.h"
 #include "SessionSetup/RetrieveInstances.h"
 #include "TestUtils/TestUtils.h"
@@ -31,30 +30,6 @@ using orbit_ggp::SshInfo;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasValue;
 using testing::Return;
-
-class MockGgpClient : public orbit_ggp::Client {
- public:
-  MOCK_METHOD(Future<ErrorMessageOr<QVector<Instance>>>, GetInstancesAsync,
-              (Client::InstanceListScope /*scope*/, std::optional<Project> /*project*/),
-              (override));
-  MOCK_METHOD(Future<ErrorMessageOr<QVector<Instance>>>, GetInstancesAsync,
-              (Client::InstanceListScope /*scope*/, std::optional<Project> /*project*/,
-               int /*retry*/),
-              (override));
-  MOCK_METHOD(Future<ErrorMessageOr<SshInfo>>, GetSshInfoAsync,
-              (const QString& /*instance_id*/, std::optional<Project> /*project*/), (override));
-  MOCK_METHOD(Future<ErrorMessageOr<SshInfo>>, GetSshInfoAsync,
-              (const QString& /*instance_id*/, std::optional<Project> /*project*/, int /*retry*/),
-              (override));
-  MOCK_METHOD(Future<ErrorMessageOr<QVector<Project>>>, GetProjectsAsync, (), (override));
-  MOCK_METHOD(Future<ErrorMessageOr<Project>>, GetDefaultProjectAsync, (), (override));
-  MOCK_METHOD(Future<ErrorMessageOr<Instance>>, DescribeInstanceAsync,
-              (const QString& /*instance_id*/), (override));
-  MOCK_METHOD(Future<ErrorMessageOr<orbit_ggp::Account>>, GetDefaultAccountAsync, (), (override));
-  MOCK_METHOD(Future<ErrorMessageOr<std::vector<orbit_ggp::SymbolDownloadInfo>>>,
-              GetSymbolDownloadInfoAsync, ((const std::vector<Client::SymbolDownloadQuery>&)),
-              (override));
-};
 
 namespace {
 
@@ -112,7 +87,7 @@ class RetrieveInstancesTest : public testing::Test {
   }
 
  protected:
-  MockGgpClient mock_ggp_;
+  orbit_ggp::MockClient mock_ggp_;
   std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor_;
   std::unique_ptr<RetrieveInstances> retrieve_instances_;
 };


### PR DESCRIPTION
Move the MockClient out from RetrievelInstancesTests such that the
RemoteSymbolProviderTests can also use it.

Bug: http://b/239167821