### PR TITLE
Make Windows paths compatible with Linux client

### DIFF
--- a/src/WindowsUtils/ListModules.cpp
+++ b/src/WindowsUtils/ListModules.cpp
@@ -5,6 +5,7 @@
 #include "WindowsUtils/ListModules.h"
 
 #include <absl/base/casts.h>
+#include <absl/strings/str_replace.h>
 #include <windows.h>
 
 #include <filesystem>
@@ -52,6 +53,7 @@ std::vector<Module> ListModules(uint32_t pid) {
   do {
     std::string build_id;
     std::string module_path = orbit_base::ToStdString(module_entry.szExePath);
+    module_path = absl::StrReplaceAll(module_path, {{"\\", "/"}});
     auto coff_file_or_error = orbit_object_utils::CreateCoffFile(module_path);
     std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> sections;
     uint64_t load_bias = 0;

--- a/src/WindowsUtils/ListModulesTest.cpp
+++ b/src/WindowsUtils/ListModulesTest.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/strings/str_format.h>
+#include <absl/strings/str_replace.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <windows.h>
@@ -30,7 +31,7 @@ static std::string GetCurrentModuleName() {
   ORBIT_CHECK(module_handle);
   wchar_t module_name[MAX_PATH] = {0};
   GetModuleFileNameW(module_handle, module_name, MAX_PATH);
-  return orbit_base::ToStdString(module_name);
+  return absl::StrReplaceAll(orbit_base::ToStdString(module_name), {{"\\", "/"}});
 }
 
 TEST(ListModules, ContainsCurrentModule) {


### PR DESCRIPTION
Windows supports both, forward and backward slashes, while on
Linux, only backward slashes can be used. As a result,
std::filesystem operations (such as filename) won't work
on Linux if the path is coming from Windows.

We avoid that problem, by also using forward slashes on Windows.

Test: Run test and check different views on the Windows capture.
Bug: http://b/244526158