### PR TITLE
Implement rendering optimization in the Scheduler Track

### DIFF
--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -84,11 +84,11 @@ void SchedulerTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
                   viewport_, IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
                   app_->GetGroupIdToHighlight(), app_->GetHistogramSelectionRange());
 
-  uint32_t resolution_in_pixels = viewport_->WorldToScreen({GetWidth(), 0})[0];
-  float box_height = GetDefaultBoxHeight();
+  const uint32_t resolution_in_pixels = viewport_->WorldToScreen({GetWidth(), 0})[0];
+  const float box_height = GetDefaultBoxHeight();
 
   for (uint32_t depth = 0; depth < GetDepth(); depth++) {
-    float world_timer_y = GetYFromDepth(depth);
+    const float world_timer_y = GetYFromDepth(depth);
     for (const TimerInfo* timer_info : timer_data_->GetTimersAtDepthDiscretized(
              depth, resolution_in_pixels, min_tick, max_tick)) {
       ++visible_timer_count_;


### PR DESCRIPTION
In this PR we are finally using the new rendering optimization in the SchedulerTrack
(as it was planned in http://go/stadia-orbit-timer-rendering-improvements).

We are just implementing for SchedulerTrack to measure and have conclusions, but
in the future we will probably have this optimization by default and only have the
old method for GpuSubmissionTrack (unordered timers - http://b/220680172 and a
different implementation who uses depth in a different way - http://b/221024788)
and GpuDebugMarkers (where timers can overlap and the optimization should be
made taking into account both start and end time - http://b/200692451).

This default implementation is very similar to the one in ThreadTracks (and actually,
they might be merged in the future - http://b/205032296).

The implementation is quite-straightforward but I needed to add a hack because a
precision bug I found in GetWorldFromTick.

I briefly benchmark the optimization locally using the 5-min capture in Infiltrator
without Instrumentation (from here:
https://drive.google.com/file/d/139OouMrL6_gy2hYt3x5mhGo2AcIlAL-S/view?usp=sharing).

* 8 Cores, 614k timers per core in average.
* Zoom-out capture entirely only with the Scheduler Track.
  * Before:
     Time to update primitives in the Scheduler: ~133.2375 ms
  * Now:
     Time to update primitives in the Scheduler (1440p screen): ~17.8464 ms  (7.46x)
     Time to update primitives in the Scheduler (1080p screen): ~15.1746 ms

I also measured using a 1.5 minute capture in cumbia. There are more events in the
Scheduler, so rendering was taking ~229ms and now it takes ~14.9ms (1080p)

Tests:
* Load different captures. See there is a timer in each pixel when zooming-out a lot.
* Zoom-in. Test performance didn't decrease.
* Take a capture, see everything works as expected.
Bug: http://b/242971304