### PR TITLE
Make module's display name consistent

### DIFF
--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -246,7 +246,8 @@ std::tuple<QString, QString> SymbolLocationsDialog::GetFilePickerConfig() const 
   const ModuleData& module{*module_.value()};
 
   QString caption =
-      QString("Select symbol file for module %1").arg(QString::fromStdString(module.name()));
+      QString("Select symbol file for module %1")
+          .arg(QString::fromStdString(std::filesystem::path(module.file_path()).filename()));
 
   switch (module.object_file_type()) {
     case ModuleInfo::kElfFile:
@@ -411,7 +412,8 @@ void SymbolLocationsDialog::SetUpModuleHeadlineLabel() {
   ORBIT_CHECK(module_.has_value());
   ui_->moduleHeadlineLabel->setVisible(true);
   ui_->moduleHeadlineLabel->setText(
-      QString(kModuleHeadlineLabel).arg(QString::fromStdString(module_.value()->name())));
+      QString(kModuleHeadlineLabel)
+          .arg(QString::fromStdString(std::filesystem::path(module_.value()->file_path()).filename())));
 }
 
 void SymbolLocationsDialog::DisableAddFolder() {
@@ -421,7 +423,7 @@ void SymbolLocationsDialog::DisableAddFolder() {
   ui_->addFolderButton->setToolTip(
       QString("Module %1 does not have a build ID. For modules without build ID, Orbit cannot find "
               "symbols in folders.")
-          .arg(QString::fromStdString(module_.value()->name())));
+          .arg(QString::fromStdString(std::filesystem::path(module_.value()->file_path()).filename())));
 }
 
 void SymbolLocationsDialog::SetUpInfoLabel() {

--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -247,7 +247,7 @@ std::tuple<QString, QString> SymbolLocationsDialog::GetFilePickerConfig() const 
 
   QString caption =
       QString("Select symbol file for module %1")
-          .arg(QString::fromStdString(std::filesystem::path(module.file_path()).filename()));
+          .arg(QString::fromStdString(std::filesystem::path(module.file_path()).filename().string()));
 
   switch (module.object_file_type()) {
     case ModuleInfo::kElfFile:
@@ -414,7 +414,7 @@ void SymbolLocationsDialog::SetUpModuleHeadlineLabel() {
   ui_->moduleHeadlineLabel->setText(
       QString(kModuleHeadlineLabel)
           .arg(QString::fromStdString(
-              std::filesystem::path(module_.value()->file_path()).filename())));
+              std::filesystem::path(module_.value()->file_path()).filename().string())));
 }
 
 void SymbolLocationsDialog::DisableAddFolder() {
@@ -425,7 +425,7 @@ void SymbolLocationsDialog::DisableAddFolder() {
       QString("Module %1 does not have a build ID. For modules without build ID, Orbit cannot find "
               "symbols in folders.")
           .arg(QString::fromStdString(
-              std::filesystem::path(module_.value()->file_path()).filename())));
+              std::filesystem::path(module_.value()->file_path()).filename().string())));
 }
 
 void SymbolLocationsDialog::SetUpInfoLabel() {

--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -245,9 +245,9 @@ std::tuple<QString, QString> SymbolLocationsDialog::GetFilePickerConfig() const 
 
   const ModuleData& module{*module_.value()};
 
-  QString caption =
-      QString("Select symbol file for module %1")
-          .arg(QString::fromStdString(std::filesystem::path(module.file_path()).filename().string()));
+  QString caption = QString("Select symbol file for module %1")
+                        .arg(QString::fromStdString(
+                            std::filesystem::path(module.file_path()).filename().string()));
 
   switch (module.object_file_type()) {
     case ModuleInfo::kElfFile:

--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -413,7 +413,8 @@ void SymbolLocationsDialog::SetUpModuleHeadlineLabel() {
   ui_->moduleHeadlineLabel->setVisible(true);
   ui_->moduleHeadlineLabel->setText(
       QString(kModuleHeadlineLabel)
-          .arg(QString::fromStdString(std::filesystem::path(module_.value()->file_path()).filename())));
+          .arg(QString::fromStdString(
+              std::filesystem::path(module_.value()->file_path()).filename())));
 }
 
 void SymbolLocationsDialog::DisableAddFolder() {
@@ -423,7 +424,8 @@ void SymbolLocationsDialog::DisableAddFolder() {
   ui_->addFolderButton->setToolTip(
       QString("Module %1 does not have a build ID. For modules without build ID, Orbit cannot find "
               "symbols in folders.")
-          .arg(QString::fromStdString(std::filesystem::path(module_.value()->file_path()).filename())));
+          .arg(QString::fromStdString(
+              std::filesystem::path(module_.value()->file_path()).filename())));
 }
 
 void SymbolLocationsDialog::SetUpInfoLabel() {

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -55,7 +55,6 @@ std::string CallstackDataView::GetValue(int row, int column) {
 
   CallstackDataViewFrame frame = GetFrameFromRow(row);
   const FunctionInfo* function = frame.function;
-  const ModuleData* module = frame.module;
 
   switch (column) {
     case kColumnSelected:
@@ -76,9 +75,6 @@ std::string CallstackDataView::GetValue(int row, int column) {
               : std::filesystem::path(function->module_path()).filename().string();
       if (!module_name.empty()) {
         return module_name;
-      }
-      if (module != nullptr) {
-        return module->name();
       }
       const CaptureData& capture_data = app_->GetCaptureData();
       const ModuleManager* module_manager = app_->GetModuleManager();

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -139,7 +139,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
     case kColumnStdDev:
       return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.ComputeStdDevNs()));
     case kColumnModule:
-      return function == nullptr ? "" : std::filesystem::path(function->module_path()).filename();
+      return function == nullptr ? "" : std::filesystem::path(function->module_path()).filename().string();
     case kColumnAddress:
       return function == nullptr ? "" : absl::StrFormat("%#x", function->address());
     default:

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -139,7 +139,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
     case kColumnStdDev:
       return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.ComputeStdDevNs()));
     case kColumnModule:
-      return function == nullptr ? "" : function->module_path();
+      return function == nullptr ? "" : std::filesystem::path(function->module_path()).filename();
     case kColumnAddress:
       return function == nullptr ? "" : absl::StrFormat("%#x", function->address());
     default:

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -139,7 +139,9 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
     case kColumnStdDev:
       return orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats.ComputeStdDevNs()));
     case kColumnModule:
-      return function == nullptr ? "" : std::filesystem::path(function->module_path()).filename().string();
+      return function == nullptr
+                 ? ""
+                 : std::filesystem::path(function->module_path()).filename().string();
     case kColumnAddress:
       return function == nullptr ? "" : absl::StrFormat("%#x", function->address());
     default:

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -475,7 +475,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
         GetExpectedDisplayTime(kTotalTimeNs[0]), GetExpectedDisplayTime(kAvgTimeNs[0]),
         GetExpectedDisplayTime(kMinNs[0]), GetExpectedDisplayTime(kMaxNs[0]),
-        GetExpectedDisplayTime(kStdDevNs[0]), std::filesystem::path(kModulePaths[0]).filename(),
+        GetExpectedDisplayTime(kStdDevNs[0]), std::filesystem::path(kModulePaths[0]).filename().string(),
         GetExpectedDisplayAddress(kAddresses[0]));
     CheckCopySelectionIsInvoked(context_menu, app_, view_, expected_clipboard);
   }
@@ -491,7 +491,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
         GetExpectedDisplayTime(kTotalTimeNs[0]), GetExpectedDisplayTime(kAvgTimeNs[0]),
         GetExpectedDisplayTime(kMinNs[0]), GetExpectedDisplayTime(kMaxNs[0]),
-        GetExpectedDisplayTime(kStdDevNs[0]), std::filesystem::path(kModulePaths[0]).filename(),
+        GetExpectedDisplayTime(kStdDevNs[0]), std::filesystem::path(kModulePaths[0]).filename().string(),
         GetExpectedDisplayAddress(kAddresses[0]));
     CheckExportToCsvIsInvoked(context_menu, app_, view_, expected_contents);
   }
@@ -761,7 +761,7 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
 
     ViewRowEntry entry;
     entry[kColumnName] = function.pretty_name();
-    entry[kColumnModule] = std::filesystem::path(function.module_path()).filename();
+    entry[kColumnModule] = std::filesystem::path(function.module_path()).filename().string();
     entry[kColumnAddress] = GetExpectedDisplayAddress(function.address());
     entry[kColumnCount] = GetExpectedDisplayCount(stats.count());
     string_to_raw_value.insert_or_assign(entry[kColumnCount], stats.count());

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -283,7 +283,7 @@ TEST_F(LiveFunctionsDataViewTest, ColumnValuesAreCorrect) {
 
   // The selected column will be tested separately.
   EXPECT_EQ(view_.GetValue(0, kColumnName), kPrettyNames[0]);
-  EXPECT_EQ(view_.GetValue(0, kColumnModule), kModulePaths[0]);
+  EXPECT_EQ(view_.GetValue(0, kColumnModule), std::filesystem::path(kModulePaths[0]).filename());
   EXPECT_EQ(view_.GetValue(0, kColumnAddress), GetExpectedDisplayAddress(kAddresses[0]));
   EXPECT_EQ(view_.GetValue(0, kColumnCount), GetExpectedDisplayCount(kCounts[0]));
   EXPECT_EQ(view_.GetValue(0, kColumnTimeTotal), GetExpectedDisplayTime(kTotalTimeNs[0]));
@@ -475,7 +475,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
         GetExpectedDisplayTime(kTotalTimeNs[0]), GetExpectedDisplayTime(kAvgTimeNs[0]),
         GetExpectedDisplayTime(kMinNs[0]), GetExpectedDisplayTime(kMaxNs[0]),
-        GetExpectedDisplayTime(kStdDevNs[0]), kModulePaths[0],
+        GetExpectedDisplayTime(kStdDevNs[0]), std::filesystem::path(kModulePaths[0]).filename(),
         GetExpectedDisplayAddress(kAddresses[0]));
     CheckCopySelectionIsInvoked(context_menu, app_, view_, expected_clipboard);
   }
@@ -491,7 +491,7 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
         GetExpectedDisplayTime(kTotalTimeNs[0]), GetExpectedDisplayTime(kAvgTimeNs[0]),
         GetExpectedDisplayTime(kMinNs[0]), GetExpectedDisplayTime(kMaxNs[0]),
-        GetExpectedDisplayTime(kStdDevNs[0]), kModulePaths[0],
+        GetExpectedDisplayTime(kStdDevNs[0]), std::filesystem::path(kModulePaths[0]).filename(),
         GetExpectedDisplayAddress(kAddresses[0]));
     CheckExportToCsvIsInvoked(context_menu, app_, view_, expected_contents);
   }
@@ -761,7 +761,7 @@ TEST_F(LiveFunctionsDataViewTest, ColumnSortingShowsRightResults) {
 
     ViewRowEntry entry;
     entry[kColumnName] = function.pretty_name();
-    entry[kColumnModule] = function.module_path();
+    entry[kColumnModule] = std::filesystem::path(function.module_path()).filename();
     entry[kColumnAddress] = GetExpectedDisplayAddress(function.address());
     entry[kColumnCount] = GetExpectedDisplayCount(stats.count());
     string_to_raw_value.insert_or_assign(entry[kColumnCount], stats.count());

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -475,7 +475,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
         GetExpectedDisplayTime(kTotalTimeNs[0]), GetExpectedDisplayTime(kAvgTimeNs[0]),
         GetExpectedDisplayTime(kMinNs[0]), GetExpectedDisplayTime(kMaxNs[0]),
-        GetExpectedDisplayTime(kStdDevNs[0]), std::filesystem::path(kModulePaths[0]).filename().string(),
+        GetExpectedDisplayTime(kStdDevNs[0]),
+        std::filesystem::path(kModulePaths[0]).filename().string(),
         GetExpectedDisplayAddress(kAddresses[0]));
     CheckCopySelectionIsInvoked(context_menu, app_, view_, expected_clipboard);
   }
@@ -491,7 +492,8 @@ TEST_F(LiveFunctionsDataViewTest, ContextMenuActionsAreInvoked) {
         kPrettyNames[0], GetExpectedDisplayCount(kCounts[0]),
         GetExpectedDisplayTime(kTotalTimeNs[0]), GetExpectedDisplayTime(kAvgTimeNs[0]),
         GetExpectedDisplayTime(kMinNs[0]), GetExpectedDisplayTime(kMaxNs[0]),
-        GetExpectedDisplayTime(kStdDevNs[0]), std::filesystem::path(kModulePaths[0]).filename().string(),
+        GetExpectedDisplayTime(kStdDevNs[0]),
+        std::filesystem::path(kModulePaths[0]).filename().string(),
         GetExpectedDisplayAddress(kAddresses[0]));
     CheckExportToCsvIsInvoked(context_menu, app_, view_, expected_contents);
   }

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -73,7 +73,7 @@ std::string ModulesDataView::GetValue(int row, int col) {
       return module->is_loaded() ? "*" : "";
     }
     case kColumnName:
-      return module->name();
+      return std::filesystem::path(module->file_path()).filename();
     case kColumnPath:
       return module->file_path();
     case kColumnAddressRange:
@@ -108,7 +108,12 @@ void ModulesDataView::DoSort() {
       sorter = ORBIT_PROC_SORT(is_loaded());
       break;
     case kColumnName:
-      sorter = ORBIT_PROC_SORT(name());
+      sorter = [&](uint64_t a, uint64_t b) {
+        return orbit_data_views_internal::CompareAscendingOrDescending(
+            std::filesystem::path(start_address_to_module_.at(a)->file_path()).filename(),
+            std::filesystem::path(start_address_to_module_.at(b)->file_path()).filename(),
+            ascending);
+      };
       break;
     case kColumnPath:
       sorter = ORBIT_PROC_SORT(file_path());

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -73,7 +73,7 @@ std::string ModulesDataView::GetValue(int row, int col) {
       return module->is_loaded() ? "*" : "";
     }
     case kColumnName:
-      return std::filesystem::path(module->file_path()).filename();
+      return std::filesystem::path(module->file_path()).filename().string();
     case kColumnPath:
       return module->file_path();
     case kColumnAddressRange:

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -59,11 +59,10 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent,
 
   std::string module_name = orbit_client_data::kUnknownFunctionOrModuleName;
   if (timer_info->address_in_function() != 0) {
-    const orbit_client_data::ModuleData* module = orbit_client_data::FindModuleByAddress(
-        *capture_data_->process(), *module_manager_, timer_info->address_in_function());
-    if (module != nullptr) {
-      module_name = module->name();
-    }
+    module_name = std::filesystem::path(
+                      orbit_client_data::GetModulePathByAddress(*module_manager_, *capture_data_,
+                                                                timer_info->address_in_function()))
+                      .filename();
   }
 
   return absl::StrFormat(

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -62,7 +62,8 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent,
     module_name = std::filesystem::path(
                       orbit_client_data::GetModulePathByAddress(*module_manager_, *capture_data_,
                                                                 timer_info->address_in_function()))
-                      .filename().string();
+                      .filename()
+                      .string();
   }
 
   return absl::StrFormat(

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -62,7 +62,7 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent,
     module_name = std::filesystem::path(
                       orbit_client_data::GetModulePathByAddress(*module_manager_, *capture_data_,
                                                                 timer_info->address_in_function()))
-                      .filename();
+                      .filename().string();
   }
 
   return absl::StrFormat(

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -149,11 +149,10 @@ std::string ThreadTrack::GetBoxTooltip(const PrimitiveAssembler& primitive_assem
     module_name = std::filesystem::path(func->file_path()).filename().string();
     function_name = label;
   } else if (timer_info->address_in_function() != 0) {
-    const auto* module = orbit_client_data::FindModuleByAddress(
-        *capture_data_->process(), *module_manager_, timer_info->address_in_function());
-    if (module != nullptr) {
-      module_name = module->name();
-    }
+    module_name = std::filesystem::path(
+                      orbit_client_data::GetModulePathByAddress(*module_manager_, *capture_data_,
+                                                                timer_info->address_in_function()))
+                      .filename();
 
     function_name = orbit_client_data::GetFunctionNameByAddress(*module_manager_, *capture_data_,
                                                                 timer_info->address_in_function());

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -152,7 +152,8 @@ std::string ThreadTrack::GetBoxTooltip(const PrimitiveAssembler& primitive_assem
     module_name = std::filesystem::path(
                       orbit_client_data::GetModulePathByAddress(*module_manager_, *capture_data_,
                                                                 timer_info->address_in_function()))
-                      .filename().string();
+                      .filename()
+                      .string();
 
     function_name = orbit_client_data::GetFunctionNameByAddress(*module_manager_, *capture_data_,
                                                                 timer_info->address_in_function());

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -152,7 +152,7 @@ std::string ThreadTrack::GetBoxTooltip(const PrimitiveAssembler& primitive_assem
     module_name = std::filesystem::path(
                       orbit_client_data::GetModulePathByAddress(*module_manager_, *capture_data_,
                                                                 timer_info->address_in_function()))
-                      .filename();
+                      .filename().string();
 
     function_name = orbit_client_data::GetFunctionNameByAddress(*module_manager_, *capture_data_,
                                                                 timer_info->address_in_function());


### PR DESCRIPTION
Elf files have an entry for the "soname", which might be different
from the filename, in case of semantic versioning.
E.g. for libc, we have "libc.so.6" as "soname" and "libc-2.24.so"
as filename.
For ElfFiles, we report the "soname" as "ModuleData::name".

Within Orbit, we used both, the filename and the soname accross
the codebase in various places.

This change unifies this now, to always use the filename. We
go with the filename for simplicity, as we do not always have
a module at hand in the places.
In practice is should not matter, and should be equally clear
to the user.

Test: Take a capture and inspect all places where we have module
      names.
Bug: http://b/222283082