### PR TITLE
Make DataView::GetToolTip return DataView::GetValue by default

### DIFF
--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -94,14 +94,20 @@ std::string CallstackDataView::GetValue(int row, int column) {
   }
 }
 
-std::string CallstackDataView::GetToolTip(int row, int /*column*/) {
+std::string CallstackDataView::GetToolTip(int row, int column) {
+  if (column != kColumnName) {
+    return DataView::GetToolTip(row, column);
+  }
   CallstackDataViewFrame frame = GetFrameFromRow(row);
+  const std::string& function_name =
+      frame.function != nullptr ? frame.function->pretty_name() : frame.fallback_name;
   if (functions_to_highlight_.find(frame.address) != functions_to_highlight_.end()) {
     return absl::StrFormat(
-        "Functions marked with %s are part of the selection in the sampling report above",
-        CallstackDataView::kHighlightedFunctionString);
+        "%s\n\nFunctions marked with %s are part of the selection in the sampling report above",
+        function_name, CallstackDataView::kHighlightedFunctionString);
+  } else {
+    return function_name;
   }
-  return "";
 }
 
 const std::string CallstackDataView::kHighlightedFunctionString = "➜ ";

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -599,14 +599,16 @@ std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrum
   return app_->GetCaptureData().GetScopeInfo(scope_id);
 }
 
-std::string LiveFunctionsDataView::GetToolTip(int /*row*/, int column) {
-  if (column != kColumnType) return "";
-  return "Notation:\n"
-         "D — Dynamically instrumented function\n"
-         "MS — Synchronous manually instrumented scope\n"
-         "MA — Asynchronous manually instrumented scope\n"
-         "H — The function will be hooked in the next capture\n"
-         "F — Frame track enabled";
+std::string LiveFunctionsDataView::GetToolTip(int row, int column) {
+  if (column == kColumnType) {
+    return "Notation:\n"
+           "D — Dynamically instrumented function\n"
+           "MS — Synchronous manually instrumented scope\n"
+           "MA — Asynchronous manually instrumented scope\n"
+           "H — The function will be hooked in the next capture\n"
+           "F — Frame track enabled";
+  }
+  return DataView::GetToolTip(row, column);
 }
 
 [[nodiscard]] std::vector<ScopeId> LiveFunctionsDataView::FetchMissingScopeIds() const {

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -77,7 +77,7 @@ TEST_F(PresetsDataViewTest, CheckLabelAndColorForLoadStates) {
   // GetPresetLoadState is called once per `GetValue`, `GetToolTip` and `GetDisplayColor` call.
   auto load_state = PresetLoadState::kLoadable;
   EXPECT_CALL(app_, GetPresetLoadState)
-      .Times(11)
+      .Times(13)
       .WillRepeatedly(testing::ReturnPointee(&load_state));
 
   orbit_client_protos::PresetInfo preset_info0{};
@@ -87,23 +87,26 @@ TEST_F(PresetsDataViewTest, CheckLabelAndColorForLoadStates) {
   EXPECT_EQ(view_.GetNumElements(), 1);
 
   load_state = PresetLoadState::kLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(PresetsDataView::kLoadedPresetBlankString, "Yes"));
-  EXPECT_TRUE(view_.GetToolTip(0, 0).empty());
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(PresetsDataView::kNotLoadedPresetPrefix, "Yes"));
+  EXPECT_EQ(view_.GetToolTip(0, 0),
+            absl::StrCat("Yes", PresetsDataView::kNotLoadedPresetTooltipSuffix));
   Color color_loadable_state{};
   view_.GetDisplayColor(0, 0, color_loadable_state.r, color_loadable_state.g,
                         color_loadable_state.b);
 
   load_state = PresetLoadState::kNotLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(PresetsDataView::kLoadedPresetBlankString, "No"));
-  EXPECT_FALSE(view_.GetToolTip(0, 0).empty());
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(PresetsDataView::kNotLoadedPresetPrefix, "No"));
+  EXPECT_EQ(view_.GetToolTip(0, 0),
+            absl::StrCat("No", PresetsDataView::kNotLoadedPresetTooltipSuffix));
   Color color_not_loadable_state{};
   view_.GetDisplayColor(0, 0, color_not_loadable_state.r, color_not_loadable_state.g,
                         color_not_loadable_state.b);
 
   load_state = PresetLoadState::kPartiallyLoadable;
   EXPECT_EQ(view_.GetValue(0, 0),
-            absl::StrCat(PresetsDataView::kLoadedPresetBlankString, "Partially"));
-  EXPECT_TRUE(view_.GetToolTip(0, 0).empty());
+            absl::StrCat(PresetsDataView::kNotLoadedPresetPrefix, "Partially"));
+  EXPECT_EQ(view_.GetToolTip(0, 0),
+            absl::StrCat("Partially", PresetsDataView::kNotLoadedPresetTooltipSuffix));
   Color color_partially_loadable_state{};
   view_.GetDisplayColor(0, 0, color_partially_loadable_state.r, color_partially_loadable_state.g,
                         color_partially_loadable_state.b);
@@ -119,10 +122,14 @@ TEST_F(PresetsDataViewTest, CheckLabelAndColorForLoadStates) {
   view_.SetPresets({preset_file0});
 
   load_state = PresetLoadState::kLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetString, "Yes"));
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(PresetsDataView::kLoadedPresetPrefix, "Yes"));
+  EXPECT_EQ(view_.GetToolTip(0, 0),
+            absl::StrCat("Yes", PresetsDataView::kLoadedPresetTooltipSuffix));
 
   load_state = PresetLoadState::kPartiallyLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetString, "Partially"));
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(PresetsDataView::kLoadedPresetPrefix, "Partially"));
+  EXPECT_EQ(view_.GetToolTip(0, 0),
+            absl::StrCat("Partially", PresetsDataView::kLoadedPresetTooltipSuffix));
 }
 
 TEST_F(PresetsDataViewTest, PresetNameIsFileName) {

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -87,21 +87,22 @@ TEST_F(PresetsDataViewTest, CheckLabelAndColorForLoadStates) {
   EXPECT_EQ(view_.GetNumElements(), 1);
 
   load_state = PresetLoadState::kLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetBlankString, "Yes"));
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(PresetsDataView::kLoadedPresetBlankString, "Yes"));
   EXPECT_TRUE(view_.GetToolTip(0, 0).empty());
   Color color_loadable_state{};
   view_.GetDisplayColor(0, 0, color_loadable_state.r, color_loadable_state.g,
                         color_loadable_state.b);
 
   load_state = PresetLoadState::kNotLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetBlankString, "No"));
+  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(PresetsDataView::kLoadedPresetBlankString, "No"));
   EXPECT_FALSE(view_.GetToolTip(0, 0).empty());
   Color color_not_loadable_state{};
   view_.GetDisplayColor(0, 0, color_not_loadable_state.r, color_not_loadable_state.g,
                         color_not_loadable_state.b);
 
   load_state = PresetLoadState::kPartiallyLoadable;
-  EXPECT_EQ(view_.GetValue(0, 0), absl::StrCat(view_.kLoadedPresetBlankString, "Partially"));
+  EXPECT_EQ(view_.GetValue(0, 0),
+            absl::StrCat(PresetsDataView::kLoadedPresetBlankString, "Partially"));
   EXPECT_TRUE(view_.GetToolTip(0, 0).empty());
   Color color_partially_loadable_state{};
   view_.GetDisplayColor(0, 0, color_partially_loadable_state.r, color_partially_loadable_state.g,

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -412,7 +412,7 @@ std::string SamplingReportDataView::GetToolTip(int row, int column) {
     case kColumnUnwindErrors:
       return BuildToolTipUnwindErrors(function);
     default:
-      return "";
+      return DataView::GetToolTip(row, column);
   }
 }
 

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -279,7 +279,14 @@ std::string GetExpectedDisplayInclusiveByIndex(size_t index, bool for_copy = fal
                          kConfidenceIntervalLongerSectionLength * 100.0f);
 }
 
-std::string GetExpectedToolTipByIndex(size_t index, int column) {
+std::string GetExpectedToolTipByIndex(size_t index, int column, const ModuleManager& module_manager,
+                                      const CaptureData& capture_data) {
+  if (column == kColumnSelected) {
+    return "";
+  }
+  if (column == kColumnFunctionName) {
+    return GetExpectedDisplayFunctionNameByIndex(index, module_manager, capture_data);
+  }
   if (column == kColumnInclusive || column == kColumnExclusive) {
     const uint32_t raw_count =
         (column == kColumnInclusive) ? kSampledInclusives[index] : kSampledExclusives[index];
@@ -299,6 +306,12 @@ std::string GetExpectedToolTipByIndex(size_t index, int column) {
         kFunctionPrettyNames[index], at_the_top_or_encountered, raw_count, count_type,
         kStackEventsCount, percentage, percentage - kConfidenceIntervalLeftSectionLength * 100.0f,
         percentage + kConfidenceIntervalRightSectionLength * 100.0f);
+  }
+  if (column == kColumnModuleName) {
+    return GetExpectedDisplayModuleNameByIndex(index, module_manager, capture_data);
+  }
+  if (column == kColumnAddress) {
+    return GetExpectedDisplayAddressByIndex(index);
   }
   if (column == kColumnUnwindErrors) {
     const float percentage = kSampledUnwindErrorPercents[index];
@@ -413,7 +426,8 @@ TEST_F(SamplingReportDataViewTest, ToolTipMessageIsCorrect) {
   AddFunctionsByIndices({0});
   view_.SetStackEventsCount(kStackEventsCount);
   for (size_t column = 0; column < kNumColumns; ++column) {
-    EXPECT_EQ(view_.GetToolTip(0, column), GetExpectedToolTipByIndex(0, column));
+    EXPECT_EQ(view_.GetToolTip(0, column),
+              GetExpectedToolTipByIndex(0, column, module_manager_, *capture_data_));
   }
 }
 

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -130,7 +130,7 @@ class DataView {
   virtual size_t GetNumElements() { return indices_.size(); }
   virtual std::string GetValue(int /*row*/, int /*column*/) { return ""; }
   virtual std::string GetValueForCopy(int row, int column) { return GetValue(row, column); }
-  virtual std::string GetToolTip(int /*row*/, int /*column*/) { return ""; }
+  virtual std::string GetToolTip(int row, int column) { return GetValue(row, column); }
 
   // Called from UI layer.
   void OnFilter(const std::string& filter);

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -46,8 +46,10 @@ class PresetsDataView : public DataView {
   void OnShowInExplorerRequested(const std::vector<int>& selection) override;
   void OnLoadPresetSuccessful(const std::filesystem::path& preset_file_path);
 
-  static constexpr std::string_view kLoadedPresetString{"* "};
-  static constexpr std::string_view kLoadedPresetBlankString{"  "};
+  static constexpr std::string_view kLoadedPresetPrefix{"* "};
+  static constexpr std::string_view kNotLoadedPresetPrefix{"  "};
+  static constexpr std::string_view kLoadedPresetTooltipSuffix{" (loaded)"};
+  static constexpr std::string_view kNotLoadedPresetTooltipSuffix{""};
 
  protected:
   struct ModuleView {
@@ -63,6 +65,8 @@ class PresetsDataView : public DataView {
   void DoFilter() override;
   [[nodiscard]] static std::string GetModulesList(const std::vector<ModuleView>& modules);
   [[nodiscard]] static std::string GetFunctionCountList(const std::vector<ModuleView>& modules);
+  [[nodiscard]] static std::string GetModuleAndFunctionCountList(
+      const std::vector<ModuleView>& modules);
   [[nodiscard]] const orbit_preset_file::PresetFile& GetPreset(unsigned int row) const;
   [[nodiscard]] const std::vector<ModuleView>& GetModules(uint32_t row) const;
 


### PR DESCRIPTION
There are plenty of cases where the content of a cell of a `DataView` doesn't
fit in the width of the column. In some cases, even expanding the column is not
enough to reveal the full content, as the `DataView` itself is not wide enough.
We enable tooltips everywhere by making it show the content of the cell by
default.

Test: Take a capture, verify tooltips in all `DataView`s.