### PR TITLE
Slightly increase "thread state bar height"

### DIFF
--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -11,7 +11,7 @@
 TimeGraphLayout::TimeGraphLayout() {
   text_box_height_ = 20.f;
   core_height_ = 10.f;
-  thread_state_track_height_ = 4.0f;
+  thread_state_track_height_ = 6.0f;
   event_track_height_ = 10.f;
   all_threads_event_track_scale_ = 2.f;
   variable_track_height_ = 20.f;


### PR DESCRIPTION
With the new features for thread dependency anaylsis, the thread state bar becomes much more relevant.

While a major UI/UX rework is needed, this change slightly improves the situation by increasing the height by 2 pixels.

Before:
http://screenshot/4qj2R6Q8y8yJYWu

After:
http://screenshot/8svzW5sGe3F4Tsx

Test: Compile & Run