### PR TITLE
Use NotFoundOr for GetDebugInfoFile

### DIFF
--- a/src/ClientServices/ProcessManager.cpp
+++ b/src/ClientServices/ProcessManager.cpp
@@ -45,7 +45,7 @@ class ProcessManagerImpl final : public ProcessManager {
 
   ErrorMessageOr<std::string> LoadNullTerminatedString(uint32_t pid, uint64_t address) override;
 
-  ErrorMessageOr<std::string> FindDebugInfoFile(
+  ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> FindDebugInfoFile(
       const std::string& module_path,
       absl::Span<const std::string> additional_search_directories) override;
 
@@ -83,7 +83,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ProcessManagerImpl::LoadModuleList(uint3
   return process_client_->LoadModuleList(pid);
 }
 
-ErrorMessageOr<std::string> ProcessManagerImpl::FindDebugInfoFile(
+ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> ProcessManagerImpl::FindDebugInfoFile(
     const std::string& module_path, absl::Span<const std::string> additional_search_directories) {
   return process_client_->FindDebugInfoFile(module_path, additional_search_directories);
 }

--- a/src/ClientServices/include/ClientServices/ProcessClient.h
+++ b/src/ClientServices/include/ClientServices/ProcessClient.h
@@ -10,14 +10,17 @@
 #include <stdint.h>
 
 #include <chrono>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "GrpcProtos/module.pb.h"
 #include "GrpcProtos/process.pb.h"
 #include "GrpcProtos/services.grpc.pb.h"
+#include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_client_services {
@@ -33,7 +36,7 @@ class ProcessClient {
   [[nodiscard]] ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(
       uint32_t pid);
 
-  [[nodiscard]] ErrorMessageOr<std::string> FindDebugInfoFile(
+  [[nodiscard]] ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> FindDebugInfoFile(
       const std::string& module_path, absl::Span<const std::string> additional_search_directories);
 
   [[nodiscard]] ErrorMessageOr<std::string> LoadProcessMemory(uint32_t pid, uint64_t address,

--- a/src/ClientServices/include/ClientServices/ProcessManager.h
+++ b/src/ClientServices/include/ClientServices/ProcessManager.h
@@ -10,6 +10,7 @@
 #include <grpcpp/grpcpp.h>
 #include <stdint.h>
 
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
@@ -19,6 +20,7 @@
 #include "GrpcProtos/module.pb.h"
 #include "GrpcProtos/process.pb.h"
 #include "GrpcProtos/symbol.pb.h"
+#include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 #include "absl/synchronization/mutex.h"
 
@@ -57,7 +59,7 @@ class ProcessManager {
 
   virtual ErrorMessageOr<std::string> LoadNullTerminatedString(uint32_t pid, uint64_t address) = 0;
 
-  virtual ErrorMessageOr<std::string> FindDebugInfoFile(
+  virtual ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> FindDebugInfoFile(
       const std::string& module_path,
       absl::Span<const std::string> additional_search_directories) = 0;
 

--- a/src/OrbitBase/include/OrbitBase/NotFoundOr.h
+++ b/src/OrbitBase/include/OrbitBase/NotFoundOr.h
@@ -34,9 +34,30 @@ template <typename T>
 
 // Free function to get the not found message of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] std::string GetNotFoundMessage(const std::variant<T, NotFound>& not_found_or) {
+[[nodiscard]] const std::string& GetNotFoundMessage(const std::variant<T, NotFound>& not_found_or) {
   ORBIT_CHECK(IsNotFound(not_found_or));
   return std::get<NotFound>(not_found_or).message;
+}
+
+// Free function with move semantics to get the not found message of a NotFoundOr object.
+template <typename T>
+[[nodiscard]] std::string&& GetNotFoundMessage(std::variant<T, NotFound>&& not_found_or) {
+  ORBIT_CHECK(IsNotFound(not_found_or));
+  return std::move(std::get<NotFound>(std::move(not_found_or)).message);
+}
+
+// Free function to get the "found" content of a NotFoundOr object.
+template <typename T>
+[[nodiscard]] const T& GetFound(const std::variant<T, NotFound>& not_found_or) {
+  ORBIT_CHECK(!IsNotFound(not_found_or));
+  return std::get<T>(not_found_or);
+}
+
+// Free function with move semantics to get the "found" content of a NotFoundOr object.
+template <typename T>
+[[nodiscard]] T&& GetFound(std::variant<T, NotFound>&& not_found_or) {
+  ORBIT_CHECK(!IsNotFound(not_found_or));
+  return std::get<T>(std::move(not_found_or));
 }
 
 }  // namespace orbit_base

--- a/src/ProcessService/BUILD
+++ b/src/ProcessService/BUILD
@@ -41,5 +41,6 @@ orbit_cc_test(
         "//src/GrpcProtos:tracepoint_cc_proto",
         "//src/OrbitBase",
         "//src/TestUtils",
+        "@com_google_absl//absl/strings",
     ],
 )

--- a/src/ProcessService/ProcessServiceUtils.h
+++ b/src/ProcessService/ProcessServiceUtils.h
@@ -20,6 +20,7 @@
 #include "GrpcProtos/module.pb.h"
 #include "GrpcProtos/services.pb.h"
 #include "GrpcProtos/tracepoint.pb.h"
+#include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 #include "ProcessService/CpuTime.h"
 
@@ -28,7 +29,9 @@ namespace orbit_process_service {
 std::optional<orbit_process_service_internal::TotalCpuTime> GetCumulativeTotalCpuTime();
 std::optional<orbit_process_service_internal::Jiffies> GetCumulativeCpuTimeFromProcess(pid_t pid);
 
-ErrorMessageOr<std::filesystem::path> FindSymbolsFilePath(
+// Searches on the instance for a symbols file. This can have 3 outcomes, an error, not found or
+// success. In the success case it returns the symbol file path.
+ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> FindSymbolsFilePath(
     const orbit_grpc_protos::GetDebugInfoFileRequest& request);
 bool ReadProcessMemory(uint32_t pid, uintptr_t address, void* buffer, uint64_t size,
                        uint64_t* num_bytes_read);

--- a/src/SymbolProvider/BUILD
+++ b/src/SymbolProvider/BUILD
@@ -22,6 +22,7 @@ orbit_cc_test(
     name = "SymbolProviderTests",
     deps = [
         ":SymbolProvider",
+        "//src/OrbitBase",
         "@com_google_absl//absl/hash:hash_testing_no_google3",
     ],
 )

--- a/src/SymbolProvider/SymbolLoadingOutcome.cpp
+++ b/src/SymbolProvider/SymbolLoadingOutcome.cpp
@@ -34,8 +34,7 @@ bool IsSuccessResult(const SymbolLoadingOutcome& outcome) {
 
 SymbolLoadingSuccessResult GetSuccessResult(const SymbolLoadingOutcome& outcome) {
   ORBIT_CHECK(IsSuccessResult(outcome));
-  return std::get<SymbolLoadingSuccessResult>(
-      std::get<NotFoundOr<SymbolLoadingSuccessResult>>(outcome.value()));
+  return orbit_base::GetFound(std::get<NotFoundOr<SymbolLoadingSuccessResult>>(outcome.value()));
 }
 
 }  // namespace orbit_symbol_provider


### PR DESCRIPTION
This changes the search for a symbols file on the instance to differentiate between an actual error occurring and the symbols not being found. This changes all the parts that are involved up to OrbitApp. The communication protos do not need to be changed, because the status is transmitted via the internal gRPC status class. This will later be used to send different metrics, whether this was found or an error occurred.

Test: Partially unit tests; manual test: clean cache, start Orbit, check that symbol downloading still works.
Bug: http://b/231455031