### PR TITLE
Hide setting "collect callstacks on thread states" behind flag

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1337,9 +1337,11 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
             .toInt());
   }
 
-  dialog.SetEnableCallStackCollectionOnThreadStateChanges(
-      collect_callstack_on_thread_state_change ==
-      CaptureOptions::kThreadStateChangeCallStackCollection);
+  if (absl::GetFlag(FLAGS_tracepoint_callstack_collection)) {
+    dialog.SetEnableCallStackCollectionOnThreadStateChanges(
+        collect_callstack_on_thread_state_change ==
+        CaptureOptions::kThreadStateChangeCallStackCollection);
+  }
 
   int result = dialog.exec();
   if (result != QDialog::Accepted) {
@@ -1371,8 +1373,13 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
                     dialog.GetLimitLocalMarkerDepthPerCommandBuffer());
   settings.setValue(kMaxLocalMarkerDepthPerCommandBufferSettingsKey,
                     QString::number(dialog.GetMaxLocalMarkerDepthPerCommandBuffer()));
-  settings.setValue(kEnableCallStackCollectionOnThreadStateChanges,
-                    static_cast<int>(dialog.GetEnableCallStackCollectionOnThreadStateChanges()));
+  if (absl::GetFlag(FLAGS_tracepoint_callstack_collection)) {
+    settings.setValue(
+        kEnableCallStackCollectionOnThreadStateChanges,
+        static_cast<int>(dialog.GetEnableCallStackCollectionOnThreadStateChanges()
+                             ? CaptureOptions::kThreadStateChangeCallStackCollection
+                             : CaptureOptions::kNoThreadStateChangeCallStackCollection));
+  }
   LoadCaptureOptionsIntoApp();
 }
 


### PR DESCRIPTION
While the collection of thread state callstacks is not yet released, we need to hide setting the option behind a flag.

Otherwise, we will used the value from qsettings even if the flag is not set.

Note that this is extracted from #4148.

Test: Set the flag and option save. Reopen without the flag.