### PR TITLE
Read scheduling tracepoints with callstacks

### DIFF
--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -403,6 +403,7 @@ struct PerfEvent {
                UserSpaceFunctionEntryPerfEventData, UserSpaceFunctionExitPerfEventData,
                MmapPerfEventData, GenericTracepointPerfEventData, TaskNewtaskPerfEventData,
                TaskRenamePerfEventData, SchedSwitchPerfEventData, SchedWakeupPerfEventData,
+               SchedSwitchWithStackPerfEventData, SchedWakeupWithStackPerfEventData,
                AmdgpuCsIoctlPerfEventData, AmdgpuSchedRunJobPerfEventData,
                DmaFenceSignaledPerfEventData>
       data;

--- a/src/LinuxTracing/PerfEventVisitor.h
+++ b/src/LinuxTracing/PerfEventVisitor.h
@@ -42,6 +42,10 @@ class PerfEventVisitor {
   virtual void Visit(uint64_t /*event_timestamp*/, const SchedWakeupPerfEventData& /*event_data*/) {
   }
   virtual void Visit(uint64_t /*event_timestamp*/,
+                     const SchedWakeupWithStackPerfEventData& /*event_data*/) {}
+  virtual void Visit(uint64_t /*event_timestamp*/,
+                     const SchedSwitchWithStackPerfEventData& /*event_data*/) {}
+  virtual void Visit(uint64_t /*event_timestamp*/,
                      const AmdgpuCsIoctlPerfEventData& /*event_data*/) {}
   virtual void Visit(uint64_t /*event_timestamp*/,
                      const AmdgpuSchedRunJobPerfEventData& /*event_data*/) {}

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -615,9 +615,15 @@ bool TracerImpl::OpenContextSwitchAndThreadStateTracepoints(
   }
 
   absl::flat_hash_map<int32_t, int> thread_state_tracepoint_ring_buffer_fds_per_cpu;
+  uint64_t ring_buffer_size;
+  if (thread_state_change_callstack_collection_ ==
+      CaptureOptions::kThreadStateChangeCallStackCollection) {
+    ring_buffer_size = CONTEXT_SWITCHES_AND_THREAD_STATE_WITH_CALLSTACKS_RING_BUFFER_SIZE_KB;
+  } else {
+    ring_buffer_size = CONTEXT_SWITCHES_AND_THREAD_STATE_RING_BUFFER_SIZE_KB;
+  }
   return OpenFileDescriptorsAndRingBuffersForAllTracepoints(
-      tracepoints_to_open, cpus, &tracing_fds_,
-      CONTEXT_SWITCHES_AND_THREAD_STATE_RING_BUFFER_SIZE_KB,
+      tracepoints_to_open, cpus, &tracing_fds_, ring_buffer_size,
       &thread_state_tracepoint_ring_buffer_fds_per_cpu, &ring_buffers_, stack_dump_size_,
       thread_state_change_callstack_collection, unwinding_method);
 }
@@ -1355,16 +1361,23 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
     DeferEvent(event);
 
   } else if (is_sched_switch_with_callchain) {
-    // TODO(mahmooddarwish): the implementation of this case will be implemented later
+    // TODO(b/243510000): the implementation of this case will be added later
 
   } else if (is_sched_wakeup_with_callchain) {
-    // TODO(mahmooddarwish): the implementation of this case will be implemented later
+    // TODO(b/243510000): the implementation of this case will be added later
 
   } else if (is_sched_switch_with_stack) {
-    // TODO(mahmooddarwish): the implementation of this case will be implemented later
+    pid_t pid = ReadSampleRecordPid(ring_buffer);
+    // TODO(b/245529464): Avoid copying the stack if the record is from another process
+    SchedSwitchWithStackPerfEvent event = ConsumeSchedSwitchWithStackPerfEvent(ring_buffer, header);
+    DeferEvent(std::move(event));
+    ++stats_.sched_switch_count;
 
   } else if (is_sched_wakeup_with_stack) {
-    // TODO(mahmooddarwish): the implementation of this case will be implemented later
+    pid_t pid = ReadSampleRecordPid(ring_buffer);
+    // TODO(b/245529464): Avoid copying the stack if the record is from another process
+    SchedWakeupWithStackPerfEvent event = ConsumeSchedWakeupWithStackPerfEvent(ring_buffer, header);
+    DeferEvent(std::move(event));
 
   } else if (is_amdgpu_cs_ioctl_event) {
     AmdgpuCsIoctlPerfEvent event = ConsumeAmdgpuCsIoctlPerfEvent(ring_buffer, header);

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -136,6 +136,8 @@ class TracerImpl : public Tracer {
   static constexpr uint64_t SAMPLING_RING_BUFFER_SIZE_KB = 16 * 1024;
   static constexpr uint64_t THREAD_NAMES_RING_BUFFER_SIZE_KB = 64;
   static constexpr uint64_t CONTEXT_SWITCHES_AND_THREAD_STATE_RING_BUFFER_SIZE_KB = 2 * 1024;
+  static constexpr uint64_t CONTEXT_SWITCHES_AND_THREAD_STATE_WITH_CALLSTACKS_RING_BUFFER_SIZE_KB =
+      64 * 1024;
   static constexpr uint64_t GPU_TRACING_RING_BUFFER_SIZE_KB = 256;
   static constexpr uint64_t INSTRUMENTED_TRACEPOINTS_RING_BUFFER_SIZE_KB = 8 * 1024;
   static constexpr uint64_t UPROBES_WITH_STACK_RING_BUFFER_SIZE_KB = 64 * 1024;


### PR DESCRIPTION
We now read the perf events for scheduling tracepoints with callstacks and send them to the visitors.

So far, the visitor implementation is empty.

Test: Compile
Bug: http://b/235554760