### PR TITLE
Move SymbolLoadingOutcome to SymbolProvider

### DIFF
--- a/src/SymbolProvider/CMakeLists.txt
+++ b/src/SymbolProvider/CMakeLists.txt
@@ -3,22 +3,27 @@
 # found in the LICENSE file.
 
 project(SymbolProvider)
-add_library(SymbolProvider INTERFACE)
+add_library(SymbolProvider STATIC)
 
-target_sources(SymbolProvider INTERFACE
+target_sources(SymbolProvider PRIVATE
+        SymbolLoadingOutcome.cpp)
+
+target_sources(SymbolProvider PUBLIC
         include/SymbolProvider/ModuleIdentifier.h
+        include/SymbolProvider/SymbolLoadingOutcome.h
         include/SymbolProvider/SymbolProvider.h)
 
-target_include_directories(SymbolProvider INTERFACE
+target_include_directories(SymbolProvider PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(SymbolProvider INTERFACE
+target_link_libraries(SymbolProvider PUBLIC
         OrbitBase)
 
 add_executable(SymbolProviderTests)
 
 target_sources(SymbolProviderTests PRIVATE 
-        ModuleIdentifierTest.cpp)
+        ModuleIdentifierTest.cpp
+        SymbolLoadingOutcomeTest.cpp)
 
 target_link_libraries(SymbolProviderTests PRIVATE 
         SymbolProvider 

--- a/src/SymbolProvider/SymbolLoadingOutcome.cpp
+++ b/src/SymbolProvider/SymbolLoadingOutcome.cpp
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "Symbols/SymbolLoadingOutcome.h"
+#include "SymbolProvider/SymbolLoadingOutcome.h"
 
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/NotFoundOr.h"
 
-namespace orbit_symbols {
+namespace orbit_symbol_provider {
 
 using orbit_base::NotFoundOr;
 
@@ -38,4 +38,4 @@ SymbolLoadingSuccessResult GetSuccessResult(const SymbolLoadingOutcome& outcome)
       std::get<NotFoundOr<SymbolLoadingSuccessResult>>(outcome.value()));
 }
 
-}  // namespace orbit_symbols
+}  // namespace orbit_symbol_provider

--- a/src/SymbolProvider/SymbolLoadingOutcomeTest.cpp
+++ b/src/SymbolProvider/SymbolLoadingOutcomeTest.cpp
@@ -5,9 +5,9 @@
 #include <gtest/gtest.h>
 
 #include "OrbitBase/CanceledOr.h"
-#include "Symbols/SymbolLoadingOutcome.h"
+#include "SymbolProvider/SymbolLoadingOutcome.h"
 
-namespace orbit_symbols {
+namespace orbit_symbol_provider {
 
 namespace {
 
@@ -48,4 +48,4 @@ TEST(SymbolLoadingOutcome, GetNotFoundMessage) {
   EXPECT_EQ(GetNotFoundMessage(outcome), kNotFound.message);
 }
 
-}  // namespace orbit_symbols
+}  // namespace orbit_symbol_provider

--- a/src/SymbolProvider/include/SymbolProvider/SymbolLoadingOutcome.h
+++ b/src/SymbolProvider/include/SymbolProvider/SymbolLoadingOutcome.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef SYMBOLS_SYMBOL_LOADING_OUTCOME_H_
-#define SYMBOLS_SYMBOL_LOADING_OUTCOME_H_
+#ifndef SYMBOL_PROVIDER_SYMBOL_LOADING_OUTCOME_H_
+#define SYMBOL_PROVIDER_SYMBOL_LOADING_OUTCOME_H_
 
 #include <filesystem>
 #include <variant>
@@ -13,7 +13,7 @@
 #include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 
-namespace orbit_symbols {
+namespace orbit_symbol_provider {
 
 struct SymbolLoadingSuccessResult {
   enum class SymbolSource {
@@ -48,6 +48,6 @@ using SymbolLoadingOutcome =
 [[nodiscard]] bool IsSuccessResult(const SymbolLoadingOutcome& outcome);
 [[nodiscard]] SymbolLoadingSuccessResult GetSuccessResult(const SymbolLoadingOutcome& outcome);
 
-}  // namespace orbit_symbols
+}  // namespace orbit_symbol_provider
 
-#endif  // SYMBOLS_SYMBOL_LOADING_OUTCOME_H_
+#endif  // SYMBOL_PROVIDER_SYMBOL_LOADING_OUTCOME_H_

--- a/src/Symbols/CMakeLists.txt
+++ b/src/Symbols/CMakeLists.txt
@@ -8,13 +8,11 @@ add_library(Symbols STATIC)
 
 target_sources(Symbols PRIVATE
         SymbolHelper.cpp
-        SymbolLoadingOutcome.cpp
         SymbolUtils.cpp)
 target_sources(Symbols PUBLIC
         include/Symbols/MockSymbolCache.h
         include/Symbols/SymbolCacheInterface.h
         include/Symbols/SymbolHelper.h
-        include/Symbols/SymbolLoadingOutcome.h
         include/Symbols/SymbolUtils.h)
 
 target_include_directories(Symbols PUBLIC
@@ -30,7 +28,6 @@ target_link_libraries(Symbols PUBLIC
 add_executable(SymbolsTests)
 target_sources(SymbolsTests PRIVATE
         SymbolHelperTest.cpp
-        SymbolLoadingOutcomeTest.cpp
         SymbolUtilsTest.cpp)
 target_link_libraries(SymbolsTests PRIVATE Symbols TestUtils GTest::Main)
 register_test(SymbolsTests)


### PR DESCRIPTION
SymbolProvider will use SymbolLoadingOutcome.
To avoid the cross dependency between the Symbols and SymbolProvider modules, 
we now move SymbolLoadingOutcome to SymbolProvider.

We till need to think better naming and arrangement for the Symbols and SymbolProvider modules.

Bug: http://b/245522908