### PR TITLE
Allow ThreadStateManager to set "waiting for callstack"

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -602,8 +602,8 @@ message ThreadStateSlice {
 
   // The callstacks for the tracepoints get split during processing and
   // originate from a different ProducerCaptureEvent. So the callstacks are not
-  // part of the original ProducerCaptureEvent, but will be added by the
-  // ProducerEventProcessor.
+  // part of the ThreadStateSce contained in the original ProducerCaptureEvent,
+  // but will be added by the ProducerEventProcessor.
   // If callstack collection is disabled, `kNoCallstack` expresses that there
   // is no callstack to wait for.
   // On `kWaitingForCallstack`, the ProducerEventProcessor knows to wait with

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -602,14 +602,13 @@ message ThreadStateSlice {
 
   // The callstacks for the tracepoints get split during processing and
   // originate from a different ProducerCaptureEvent. So the callstacks are not
-  // part of the ThreadStateSce contained in the original ProducerCaptureEvent,
-  // but will be added by the ProducerEventProcessor.
-  // If callstack collection is disabled, `kNoCallstack` expresses that there
-  // is no callstack to wait for.
-  // On `kWaitingForCallstack`, the ProducerEventProcessor knows to wait with
-  // sending this event until the callstack has been received.
-  // Once added a callstack, `kCallstackSet` expresses to the client that there
-  // is a valid callstack id set.
+  // part of the ThreadStateSlice contained in the original
+  // ProducerCaptureEvent, but will be added by the ProducerEventProcessor. If
+  // callstack collection is disabled, `kNoCallstack` expresses that there is no
+  // callstack to wait for. On `kWaitingForCallstack`, the
+  // ProducerEventProcessor knows to wait with sending this event until the
+  // callstack has been received. Once added a callstack, `kCallstackSet`
+  // expresses to the client that there is a valid callstack id set.
   enum CallstackStatus {
     kNoCallstack = 0;
     kWaitingForCallstack = 1;
@@ -620,8 +619,8 @@ message ThreadStateSlice {
   // This is the callstack of the tracepoint that changed the state
   // of the thread and caused this slice to happen. The callstack corresponds to
   // the beginning of the slice.
-  // If the thread state is runnable then this callstack is coming from
-  // wakeup_tid, otherwise it's coming from the same thread.
+  // If the wakeup_reason is kNotApplicable then this callstack is coming from
+  // the same thread, otherwise it's coming from wakeup_tid.
   uint64 switch_out_or_wakeup_callstack_id = 11;
 }
 

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -599,6 +599,28 @@ message ThreadStateSlice {
   // Otherwise, they should be 0 to minimize bandwidth usage.
   uint32 wakeup_tid = 7;
   uint32 wakeup_pid = 8;
+
+  // This is the callstack of the tracepoint that changed the state
+  // of the thread and caused this slice to happen. If the thread
+  // state is runnable then this callstack is coming from wakeup_tid,
+  // otherwise it's coming from the same thread.
+  uint64 triggering_callstack_id = 10;
+
+  // The callstacks for the tracepoints originate from a different event and are
+  // not part of the original ProducerCaptureEvent. They will be added by the
+  // ProducerEventProcessor.
+  // If callstack collection is disabled, `kNoCallstack` expresses, that there
+  // is no callstack to wait for.
+  // On `kWaitingForCallstack`, the ProducerEventProcessor knows, to wait
+  // sending this event until the callstack has been received.
+  // Once added a callstack, `kCallstackSet` expresses to the client, that there
+  // is a valid callstack id set.
+  enum CallstackStatus {
+    kNoCallstack = 0;
+    kWaitingForCallstack = 1;
+    kCallstackSet = 2;
+  }
+  CallstackStatus callstack_status = 11;
 }
 
 message AddressInfo {

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -600,27 +600,29 @@ message ThreadStateSlice {
   uint32 wakeup_tid = 7;
   uint32 wakeup_pid = 8;
 
-  // This is the callstack of the tracepoint that changed the state
-  // of the thread and caused this slice to happen. If the thread
-  // state is runnable then this callstack is coming from wakeup_tid,
-  // otherwise it's coming from the same thread.
-  uint64 triggering_callstack_id = 10;
-
-  // The callstacks for the tracepoints originate from a different event and are
-  // not part of the original ProducerCaptureEvent. They will be added by the
+  // The callstacks for the tracepoints get split during processing and
+  // originate from a different ProducerCaptureEvent. So the callstacks are not
+  // part of the original ProducerCaptureEvent, but will be added by the
   // ProducerEventProcessor.
-  // If callstack collection is disabled, `kNoCallstack` expresses, that there
+  // If callstack collection is disabled, `kNoCallstack` expresses that there
   // is no callstack to wait for.
-  // On `kWaitingForCallstack`, the ProducerEventProcessor knows, to wait
+  // On `kWaitingForCallstack`, the ProducerEventProcessor knows to wait with
   // sending this event until the callstack has been received.
-  // Once added a callstack, `kCallstackSet` expresses to the client, that there
+  // Once added a callstack, `kCallstackSet` expresses to the client that there
   // is a valid callstack id set.
   enum CallstackStatus {
     kNoCallstack = 0;
     kWaitingForCallstack = 1;
     kCallstackSet = 2;
   }
-  CallstackStatus callstack_status = 11;
+  CallstackStatus switch_out_or_wakeup_callstack_status = 10;
+
+  // This is the callstack of the tracepoint that changed the state
+  // of the thread and caused this slice to happen. The callstack corresponds to
+  // the beginning of the slice.
+  // If the thread state is runnable then this callstack is coming from
+  // wakeup_tid, otherwise it's coming from the same thread.
+  uint64 switch_out_or_wakeup_callstack_id = 11;
 }
 
 message AddressInfo {

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -603,12 +603,13 @@ message ThreadStateSlice {
   // The callstacks for the tracepoints get split during processing and
   // originate from a different ProducerCaptureEvent. So the callstacks are not
   // part of the ThreadStateSlice contained in the original
-  // ProducerCaptureEvent, but will be added by the ProducerEventProcessor. If
-  // callstack collection is disabled, `kNoCallstack` expresses that there is no
-  // callstack to wait for. On `kWaitingForCallstack`, the
-  // ProducerEventProcessor knows to wait with sending this event until the
-  // callstack has been received. Once added a callstack, `kCallstackSet`
-  // expresses to the client that there is a valid callstack id set.
+  // ProducerCaptureEvent, but will be added by the ProducerEventProcessor.
+  //  * If callstack collection is disabled, `kNoCallstack` expresses that there
+  //    is no callstack to wait for.
+  //  * On `kWaitingForCallstack`, the ProducerEventProcessor knows to wait with
+  //    sending this event until the callstack has been received.
+  //  * Once added a callstack, `kCallstackSet` expresses to the client that
+  //    there is a valid callstack id set.
   enum CallstackStatus {
     kNoCallstack = 0;
     kWaitingForCallstack = 1;
@@ -620,7 +621,7 @@ message ThreadStateSlice {
   // of the thread and caused this slice to happen. The callstack corresponds to
   // the beginning of the slice.
   // If the wakeup_reason is kNotApplicable then this callstack is coming from
-  // the same thread, otherwise it's coming from wakeup_tid.
+  // the thread this slice belongs to, otherwise it's coming from wakeup_tid.
   uint64 switch_out_or_wakeup_callstack_id = 11;
 }
 

--- a/src/LinuxTracing/ThreadStateManager.h
+++ b/src/LinuxTracing/ThreadStateManager.h
@@ -91,7 +91,7 @@ class ThreadStateManager {
     // to the runnable state.
     pid_t wakeup_tid;
     pid_t wakeup_pid;
-    // We allow the user to collect callstacks on sched_wakeup and sched_switch out events. The next
+    // We allow the user to collect callstacks on sched_wakeup and sched_switch out events. This
     // field indicates if there was a callstack collected together with this open state. The
     // callstack itself gets processed in the UprobesUnwindingVisitor, but this field indicates
     // if we will need to wait for this callstack.

--- a/src/LinuxTracing/ThreadStateManager.h
+++ b/src/LinuxTracing/ThreadStateManager.h
@@ -53,12 +53,12 @@ class ThreadStateManager {
                  pid_t was_created_by_pid);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedWakeup(
       uint64_t timestamp_ns, pid_t tid, pid_t was_unblocked_by_tid, pid_t was_unblocked_by_pid,
-      bool wait_for_callstack = false);
+      bool has_wakeup_callstack = false);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedSwitchIn(
       uint64_t timestamp_ns, pid_t tid);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedSwitchOut(
       uint64_t timestamp_ns, pid_t tid, orbit_grpc_protos::ThreadStateSlice::ThreadState new_state,
-      bool wait_for_callstack = false);
+      bool has_switch_out_callstack = false);
   [[nodiscard]] std::vector<orbit_grpc_protos::ThreadStateSlice> OnCaptureFinished(
       uint64_t timestamp_ns);
 
@@ -71,16 +71,16 @@ class ThreadStateManager {
           wakeup_reason{orbit_grpc_protos::ThreadStateSlice::kNotApplicable},
           wakeup_tid{0},
           wakeup_pid{0},
-          wait_for_callstack{wait_for_callstack} {}
+          has_wakeup_or_switch_out_callstack{wait_for_callstack} {}
     OpenState(orbit_grpc_protos::ThreadStateSlice::ThreadState state, uint64_t begin_timestamp_ns,
               orbit_grpc_protos::ThreadStateSlice::WakeupReason wakeup_reason, pid_t wakeup_tid,
-              pid_t wakeup_pid, bool wait_for_callstack = false)
+              pid_t wakeup_pid, bool has_wakeup_or_switch_out_callstack = false)
         : state{state},
           begin_timestamp_ns{begin_timestamp_ns},
           wakeup_reason{wakeup_reason},
           wakeup_tid{wakeup_tid},
           wakeup_pid{wakeup_pid},
-          wait_for_callstack{wait_for_callstack} {}
+          has_wakeup_or_switch_out_callstack{has_wakeup_or_switch_out_callstack} {}
     orbit_grpc_protos::ThreadStateSlice::ThreadState state;
     uint64_t begin_timestamp_ns;
     // The following field explains the relation between this thread and the thread that woke it up
@@ -91,8 +91,11 @@ class ThreadStateManager {
     // to the runnable state.
     pid_t wakeup_tid;
     pid_t wakeup_pid;
-
-    bool wait_for_callstack;
+    // We allow the user to collect callstacks on sched_wakeup and sched_switch out events. The next
+    // field indicates if there was a callstack collected together with this open state. The
+    // callstack itself gets processed in the UprobesUnwindingVisitor, but this field indicates
+    // if we will need to wait for this callstack.
+    bool has_wakeup_or_switch_out_callstack;
   };
 
   absl::flat_hash_map<pid_t, OpenState> tid_open_states_;

--- a/src/LinuxTracing/ThreadStateManagerTest.cpp
+++ b/src/LinuxTracing/ThreadStateManagerTest.cpp
@@ -19,6 +19,7 @@ using orbit_grpc_protos::ThreadStateSlice;
 namespace orbit_linux_tracing {
 
 constexpr pid_t kWakeupPidTidWhenWakeupReasonNotApplicable = 0;
+constexpr pid_t kSwitchOutOrWakeupCallstackIdNotApplicable = 0;
 
 TEST(ThreadStateManager, OneThread) {
   constexpr pid_t kTid = 42;
@@ -38,7 +39,9 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kInterruptibleSleep);
   ASSERT_TRUE(slice.has_value());
@@ -49,7 +52,9 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedWakeup(400, kTid, kWasUnblockedByTid, kWasUnblockedByPid);
   ASSERT_TRUE(slice.has_value());
@@ -60,7 +65,9 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedSwitchIn(500, kTid);
   ASSERT_TRUE(slice.has_value());
@@ -71,7 +78,9 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(600);
   ASSERT_TRUE(!slices.empty());
@@ -84,7 +93,9 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, NewTask) {
@@ -105,7 +116,9 @@ TEST(ThreadStateManager, NewTask) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kCreated);
   EXPECT_EQ(slice->wakeup_pid(), kWasCreatedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasCreatedByTid);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
@@ -116,7 +129,9 @@ TEST(ThreadStateManager, NewTask) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(400);
   ASSERT_TRUE(!slices.empty());
@@ -129,7 +144,9 @@ TEST(ThreadStateManager, NewTask) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, TwoThreads) {
@@ -153,7 +170,9 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   manager.OnNewTask(250, kTid2, kWasCreatedByTid2, kWasCreatedByPid2);
 
@@ -166,7 +185,9 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedSwitchIn(350, kTid2);
   ASSERT_TRUE(slice.has_value());
@@ -177,7 +198,9 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kCreated);
   EXPECT_EQ(slice->wakeup_pid(), kWasCreatedByPid2);
   EXPECT_EQ(slice->wakeup_tid(), kWasCreatedByTid2);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedWakeup(400, kTid1, kWasUnblockedByTid1, kWasUnblockedByPid1);
   ASSERT_TRUE(slice.has_value());
@@ -188,7 +211,9 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedSwitchOut(450, kTid2, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
@@ -199,7 +224,9 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedSwitchIn(500, kTid1);
   ASSERT_TRUE(slice.has_value());
@@ -210,7 +237,9 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid1);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid1);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(600);
   ASSERT_TRUE(slices.size() >= 2);
@@ -228,7 +257,9 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = slices[1];
   EXPECT_EQ(slice->tid(), kTid2);
@@ -238,7 +269,9 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, SwitchOutAfterInitialStateRunnable) {
@@ -257,7 +290,9 @@ TEST(ThreadStateManager, SwitchOutAfterInitialStateRunnable) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithNewTask) {
@@ -280,7 +315,9 @@ TEST(ThreadStateManager, StaleInitialStateWithNewTask) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kCreated);
   EXPECT_EQ(slice->wakeup_pid(), kWasCreatedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasCreatedByTid);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSchedWakeup) {
@@ -304,7 +341,9 @@ TEST(ThreadStateManager, StaleInitialStateWithSchedWakeup) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSwitchIn) {
@@ -326,7 +365,9 @@ TEST(ThreadStateManager, StaleInitialStateWithSwitchIn) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSwitchOut) {
@@ -350,7 +391,9 @@ TEST(ThreadStateManager, StaleInitialStateWithSwitchOut) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSchedWakeup) {
@@ -372,7 +415,9 @@ TEST(ThreadStateManager, UnknownInitialStateWithSchedWakeup) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSwitchIn) {
@@ -392,7 +437,9 @@ TEST(ThreadStateManager, UnknownInitialStateWithSwitchIn) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSwitchOut) {
@@ -414,7 +461,9 @@ TEST(ThreadStateManager, UnknownInitialStateWithSwitchOut) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, NoStateChangeWithSchedWakeup) {
@@ -438,7 +487,9 @@ TEST(ThreadStateManager, NoStateChangeWithSchedWakeup) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
@@ -457,7 +508,9 @@ TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedSwitchIn(250, kTid);
   EXPECT_FALSE(slice.has_value());
@@ -471,7 +524,9 @@ TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 TEST(ThreadStateManager, SwitchOutAndWakeupWaitForCallstacks) {
@@ -485,7 +540,7 @@ TEST(ThreadStateManager, SwitchOutAndWakeupWaitForCallstacks) {
   manager.OnInitialState(100, kTid, ThreadStateSlice::kRunning);
 
   slice = manager.OnSchedSwitchOut(200, kTid, ThreadStateSlice::kInterruptibleSleep,
-                                   /*wait_for_callstack*/ true);
+                                   /*has_wakeup_or_switch_out_callstack*/ true);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
@@ -494,10 +549,12 @@ TEST(ThreadStateManager, SwitchOutAndWakeupWaitForCallstacks) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedWakeup(300, kTid, kWasUnblockedByTid, kWasUnblockedByPid,
-                                /*wait_for_callstack*/ true);
+                                /*has_wakeup_or_switch_out_callstack*/ true);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -505,7 +562,9 @@ TEST(ThreadStateManager, SwitchOutAndWakeupWaitForCallstacks) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kWaitingForCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kWaitingForCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 
   slice = manager.OnSchedSwitchIn(400, kTid);
   EXPECT_EQ(slice->tid(), kTid);
@@ -515,7 +574,22 @@ TEST(ThreadStateManager, SwitchOutAndWakeupWaitForCallstacks) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid);
-  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kWaitingForCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kWaitingForCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
+
+  slice = manager.OnSchedSwitchOut(600, kTid, ThreadStateSlice::kDead,
+                                   /*has_wakeup_or_switch_out_callstack*/ false);
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->duration_ns(), 200);
+  EXPECT_EQ(slice->end_timestamp_ns(), 600);
+  EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
+  EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_status(),
+            orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+  EXPECT_EQ(slice->switch_out_or_wakeup_callstack_id(), kSwitchOutOrWakeupCallstackIdNotApplicable);
 }
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/ThreadStateManagerTest.cpp
+++ b/src/LinuxTracing/ThreadStateManagerTest.cpp
@@ -38,6 +38,7 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kInterruptibleSleep);
   ASSERT_TRUE(slice.has_value());
@@ -48,6 +49,7 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedWakeup(400, kTid, kWasUnblockedByTid, kWasUnblockedByPid);
   ASSERT_TRUE(slice.has_value());
@@ -58,6 +60,7 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedSwitchIn(500, kTid);
   ASSERT_TRUE(slice.has_value());
@@ -68,6 +71,7 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(600);
   ASSERT_TRUE(!slices.empty());
@@ -80,6 +84,7 @@ TEST(ThreadStateManager, OneThread) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, NewTask) {
@@ -100,6 +105,7 @@ TEST(ThreadStateManager, NewTask) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kCreated);
   EXPECT_EQ(slice->wakeup_pid(), kWasCreatedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasCreatedByTid);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
@@ -110,6 +116,7 @@ TEST(ThreadStateManager, NewTask) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(400);
   ASSERT_TRUE(!slices.empty());
@@ -122,6 +129,7 @@ TEST(ThreadStateManager, NewTask) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, TwoThreads) {
@@ -145,6 +153,7 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   manager.OnNewTask(250, kTid2, kWasCreatedByTid2, kWasCreatedByPid2);
 
@@ -157,6 +166,7 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedSwitchIn(350, kTid2);
   ASSERT_TRUE(slice.has_value());
@@ -167,6 +177,7 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kCreated);
   EXPECT_EQ(slice->wakeup_pid(), kWasCreatedByPid2);
   EXPECT_EQ(slice->wakeup_tid(), kWasCreatedByTid2);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedWakeup(400, kTid1, kWasUnblockedByTid1, kWasUnblockedByPid1);
   ASSERT_TRUE(slice.has_value());
@@ -177,6 +188,7 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedSwitchOut(450, kTid2, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
@@ -187,6 +199,7 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedSwitchIn(500, kTid1);
   ASSERT_TRUE(slice.has_value());
@@ -197,6 +210,7 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid1);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid1);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(600);
   ASSERT_TRUE(slices.size() >= 2);
@@ -214,6 +228,7 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = slices[1];
   EXPECT_EQ(slice->tid(), kTid2);
@@ -223,6 +238,7 @@ TEST(ThreadStateManager, TwoThreads) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, SwitchOutAfterInitialStateRunnable) {
@@ -241,6 +257,7 @@ TEST(ThreadStateManager, SwitchOutAfterInitialStateRunnable) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithNewTask) {
@@ -263,6 +280,7 @@ TEST(ThreadStateManager, StaleInitialStateWithNewTask) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kCreated);
   EXPECT_EQ(slice->wakeup_pid(), kWasCreatedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasCreatedByTid);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSchedWakeup) {
@@ -286,6 +304,7 @@ TEST(ThreadStateManager, StaleInitialStateWithSchedWakeup) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSwitchIn) {
@@ -307,6 +326,7 @@ TEST(ThreadStateManager, StaleInitialStateWithSwitchIn) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSwitchOut) {
@@ -330,6 +350,7 @@ TEST(ThreadStateManager, StaleInitialStateWithSwitchOut) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSchedWakeup) {
@@ -351,6 +372,7 @@ TEST(ThreadStateManager, UnknownInitialStateWithSchedWakeup) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
   EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid);
   EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSwitchIn) {
@@ -370,6 +392,7 @@ TEST(ThreadStateManager, UnknownInitialStateWithSwitchIn) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSwitchOut) {
@@ -391,6 +414,7 @@ TEST(ThreadStateManager, UnknownInitialStateWithSwitchOut) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, NoStateChangeWithSchedWakeup) {
@@ -414,6 +438,7 @@ TEST(ThreadStateManager, NoStateChangeWithSchedWakeup) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 }
 
 TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
@@ -432,6 +457,7 @@ TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
 
   slice = manager.OnSchedSwitchIn(250, kTid);
   EXPECT_FALSE(slice.has_value());
@@ -445,6 +471,51 @@ TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
   EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
   EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
   EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+}
+
+TEST(ThreadStateManager, SwitchOutAndWakeupWaitForCallstacks) {
+  constexpr pid_t kTid = 42;
+  constexpr pid_t kWasUnblockedByTid = 420;
+  constexpr pid_t kWasUnblockedByPid = 4200;
+
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunning);
+
+  slice = manager.OnSchedSwitchOut(200, kTid, ThreadStateSlice::kInterruptibleSleep,
+                                   /*wait_for_callstack*/ true);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->duration_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+  EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
+  EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kNoCallstack);
+
+  slice = manager.OnSchedWakeup(300, kTid, kWasUnblockedByTid, kWasUnblockedByPid,
+                                /*wait_for_callstack*/ true);
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
+  EXPECT_EQ(slice->duration_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 300);
+  EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kNotApplicable);
+  EXPECT_EQ(slice->wakeup_pid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->wakeup_tid(), kWakeupPidTidWhenWakeupReasonNotApplicable);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kWaitingForCallstack);
+
+  slice = manager.OnSchedSwitchIn(400, kTid);
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->duration_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 400);
+  EXPECT_EQ(slice->wakeup_reason(), orbit_grpc_protos::ThreadStateSlice::kUnblocked);
+  EXPECT_EQ(slice->wakeup_pid(), kWasUnblockedByPid);
+  EXPECT_EQ(slice->wakeup_tid(), kWasUnblockedByTid);
+  EXPECT_EQ(slice->callstack_status(), orbit_grpc_protos::ThreadStateSlice::kWaitingForCallstack);
 }
 
 }  // namespace orbit_linux_tracing


### PR DESCRIPTION
The ThreadStateSlice proto now contains two additional fields, a callstack_id (that does not yet get set at all), and a status, that can be either of:
 - no callstack is and will be attached to this slice
 - a callstack will be attached to this slice; wait for it
 - there is a callstack attached (callstack id contains data)

With this change, we allow ThreadStateManager to actually specify that we are waiting for a callstack to be attached later (in the ProducerEventProcessor).
By now, the manager will not yet get called (which will happen in the next PR).

Test: Unit test
Bug: http://b/235554760