### PR TITLE
Fix flakiness in Capture Repeatedly test.

### DIFF
--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -556,6 +556,10 @@ class CaptureRepeatedly(E2ETestCase):
 
         self._stop_capture_if_necessary(capture_tab)
 
+        wait_for_condition(lambda: self.find_control(
+            'Window', 'Finalizing capture', recurse=False, raise_on_failure=False) is None,
+                           max_seconds=120)
+
 
 class CheckThreadStates(CaptureWindowE2ETestCaseBase):
 


### PR DESCRIPTION
Added a wait for the "Finalizing capture" window to close. Sometimes closing Orbit did not work properly since we were sending alt+F4 while this window was still present.