### PR TITLE
Add NotFound state for HttpDownloadOperation

### DIFF
--- a/src/Http/HttpDownloadManager.cpp
+++ b/src/Http/HttpDownloadManager.cpp
@@ -43,6 +43,10 @@ orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> HttpDownloadMan
       case HttpDownloadOperation::State::kError:
         promise.SetResult(ErrorMessage{std::move(maybe_error_msg.value())});
         break;
+      case HttpDownloadOperation::State::kNotFound:
+        // TODO(b/245723551): Change to return orbit_base::NotFound for the not found case.
+        promise.SetResult(ErrorMessage{"File not found"});
+        break;
       case HttpDownloadOperation::State::kStarted:
       case HttpDownloadOperation::State::kInitial:
         ORBIT_UNREACHABLE();

--- a/src/Http/HttpDownloadOperation.cpp
+++ b/src/Http/HttpDownloadOperation.cpp
@@ -18,23 +18,29 @@ void HttpDownloadOperation::UpdateState(State state, std::optional<std::string> 
   ORBIT_CHECK((state == State::kError) == maybe_error_msg.has_value());
   state_ = state;
 
+  const std::string kDownloadDetails =
+      absl::StrFormat("from %s to %s", url_, save_file_path_.string());
+
   switch (state) {
     case State::kInitial:
       break;
     case State::kStarted:
-      ORBIT_LOG("Started downloading from %s to %s.\n", url_, save_file_path_.string());
+      ORBIT_LOG("Started downloading %s.\n", kDownloadDetails);
       break;
     case State::kCancelled:
-      ORBIT_LOG("Cancelled downloading from %s to %s.\n", url_, save_file_path_.string());
+      ORBIT_LOG("Cancelled downloading %s.\n", kDownloadDetails);
       emit finished(state, std::nullopt);
       break;
     case State::kDone:
-      ORBIT_LOG("Succeeded to download from %s to %s.\n", url_, save_file_path_.string());
+      ORBIT_LOG("Succeeded to download %s.\n", kDownloadDetails);
+      emit finished(state, std::nullopt);
+      break;
+    case State::kNotFound:
+      ORBIT_LOG("Remote file %s not found.", url_);
       emit finished(state, std::nullopt);
       break;
     case State::kError:
-      ORBIT_LOG("Failed to download from %s to %s:\n%s", url_, save_file_path_.string(),
-                maybe_error_msg.value());
+      ORBIT_LOG("Failed to download %s:\n%s", kDownloadDetails, maybe_error_msg.value());
       emit finished(state, maybe_error_msg);
       break;
   }
@@ -49,6 +55,9 @@ void HttpDownloadOperation::OnDownloadFinished() {
   } else if (reply_->error() == QNetworkReply::OperationCanceledError) {
     output_.remove();
     UpdateState(State::kCancelled, std::nullopt);
+  } else if (reply_->error() == QNetworkReply::ContentNotFoundError) {
+    output_.remove();
+    UpdateState(State::kNotFound, std::nullopt);
   } else {
     output_.remove();
     UpdateState(State::kError,

--- a/src/Http/HttpDownloadOperation.h
+++ b/src/Http/HttpDownloadOperation.h
@@ -33,6 +33,7 @@ class HttpDownloadOperation : public QObject {
     kStarted,
     kCancelled,
     kDone,
+    kNotFound,
     kError,
   };
 


### PR DESCRIPTION
Add HttpDownloadOperation::State::kNotFound.
If the QNetworkReply gives a ContentNotFoundError, then HttpDownloadOperation will update the state to kNotFound.
This is the first step to change HttpDownloadManager to give a NotFound for the not found case.

Bug: http://b/245723551