### PR TITLE
Add CoffFile::LoadExceptionTableEntriesAsSymbols

### DIFF
--- a/src/ObjectUtils/include/ObjectUtils/CoffFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/CoffFile.h
@@ -34,6 +34,8 @@ class CoffFile : public ObjectFile {
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::ModuleSymbols>
   LoadSymbolsFromExportTable() = 0;
   [[nodiscard]] virtual bool HasExportTable() const = 0;
+  [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::ModuleSymbols>
+  LoadExceptionTableEntriesAsSymbols() = 0;
 
   [[nodiscard]] virtual ErrorMessageOr<PdbDebugInfo> GetDebugPdbInfo() const = 0;
 };


### PR DESCRIPTION
This simply uses `CoffFileImpl::GetUnwindRanges` and turns them into `SymbolInfo`s.
It also indirectly finally adds unit tests for `GetUnwindRanges`.

I decided to assign the arbitrary name `[function@<address>]` right away here. I guess this is mostly for simplicity as it saves other code from having to take care of the empty-name case in multiple places.

Bug: http://b/245680119

Test:
- Unit tests.
- As part of the larger symbol loading fallback prototype.