### PR TITLE
Process scheduling tracepoints with stacks in SwitchesStatesNamesVisitor

### DIFF
--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
@@ -14,6 +14,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/ThreadUtils.h"
+#include "PerfEvent.h"
 
 namespace orbit_linux_tracing {
 
@@ -112,11 +113,12 @@ void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
                            event_data.was_created_by_pid);
 }
 
-void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
-                                       const SchedSwitchPerfEventData& event_data) {
-  // Note that context switches with tid 0 are associated with idle CPU, so we never consider them.
-
+template <typename SchedSwitchEventData>
+void SwitchesStatesNamesVisitor::VisitSchedSwitch(uint64_t event_timestamp,
+                                                  const SchedSwitchEventData& event_data,
+                                                  bool wait_for_callstack) {
   // Process the context switch out for scheduling slices.
+  // Note that context switches with tid 0 are associated with idle CPU, so we never consider them.
   if (produce_scheduling_slices_ && event_data.prev_tid != 0) {
     // SchedSwitchPerfEvent::pid (which doesn't come from the tracepoint data, but from the generic
     // field of the PERF_RECORD_SAMPLE) is the pid of the process that the thread being switched out
@@ -149,8 +151,8 @@ void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
   // Process the context switch out for thread state.
   if (event_data.prev_tid != 0 && TidMatchesPidFilter(event_data.prev_tid)) {
     ThreadStateSlice::ThreadState new_state = GetThreadStateFromBits(event_data.prev_state);
-    std::optional<ThreadStateSlice> out_slice =
-        state_manager_.OnSchedSwitchOut(event_timestamp, event_data.prev_tid, new_state);
+    std::optional<ThreadStateSlice> out_slice = state_manager_.OnSchedSwitchOut(
+        event_timestamp, event_data.prev_tid, new_state, wait_for_callstack);
     if (out_slice.has_value()) {
       listener_->OnThreadStateSlice(std::move(out_slice.value()));
       if (thread_state_counter_ != nullptr) {
@@ -173,20 +175,44 @@ void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
 }
 
 void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
-                                       const SchedWakeupPerfEventData& event_data) {
+                                       const SchedSwitchPerfEventData& event_data) {
+  VisitSchedSwitch(event_timestamp, event_data, /*wait_for_callstack=*/false);
+}
+
+void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
+                                       const SchedSwitchWithStackPerfEventData& event_data) {
+  const bool wait_for_callstack = event_data.data != nullptr;
+  VisitSchedSwitch(event_timestamp, event_data, wait_for_callstack);
+}
+
+template <typename SchedWakeupEventData>
+void SwitchesStatesNamesVisitor::VisitSchedWakeup(uint64_t event_timestamp,
+                                                  const SchedWakeupEventData& event_data,
+                                                  bool wait_for_callstack) {
   if (!TidMatchesPidFilter(event_data.woken_tid)) {
     return;
   }
 
   std::optional<ThreadStateSlice> state_slice = state_manager_.OnSchedWakeup(
       event_timestamp, event_data.woken_tid, event_data.was_unblocked_by_tid,
-      event_data.was_unblocked_by_pid);
+      event_data.was_unblocked_by_pid, wait_for_callstack);
   if (state_slice.has_value()) {
     listener_->OnThreadStateSlice(std::move(state_slice.value()));
     if (thread_state_counter_ != nullptr) {
       ++(*thread_state_counter_);
     }
   }
+}
+
+void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
+                                       const SchedWakeupPerfEventData& event_data) {
+  VisitSchedWakeup(event_timestamp, event_data, /*wait_for_callstack=*/false);
+}
+
+void SwitchesStatesNamesVisitor::Visit(uint64_t event_timestamp,
+                                       const SchedWakeupWithStackPerfEventData& event_data) {
+  const bool wait_for_callstack = event_data.data != nullptr;
+  VisitSchedWakeup(event_timestamp, event_data, wait_for_callstack);
 }
 
 void SwitchesStatesNamesVisitor::ProcessRemainingOpenStates(uint64_t timestamp_ns) {

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.h
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.h
@@ -59,6 +59,8 @@ class SwitchesStatesNamesVisitor : public PerfEventVisitor {
   void Visit(uint64_t event_timestamp, const TaskNewtaskPerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const SchedSwitchPerfEventData& event_data) override;
   void Visit(uint64_t timestamp, const SchedWakeupPerfEventData& event_data) override;
+  void Visit(uint64_t timestamp, const SchedWakeupWithStackPerfEventData& event_data) override;
+  void Visit(uint64_t timestamp, const SchedSwitchWithStackPerfEventData& event_data) override;
   void ProcessRemainingOpenStates(uint64_t timestamp_ns);
 
   void Visit(uint64_t event_timestamp, const TaskRenamePerfEventData& event_data) override;
@@ -67,6 +69,13 @@ class SwitchesStatesNamesVisitor : public PerfEventVisitor {
   static std::optional<orbit_grpc_protos::ThreadStateSlice::ThreadState> GetThreadStateFromChar(
       char c);
   static orbit_grpc_protos::ThreadStateSlice::ThreadState GetThreadStateFromBits(uint64_t bits);
+
+  template <typename SchedSwitchEventData>
+  void VisitSchedSwitch(uint64_t timestamp, const SchedSwitchEventData& event_data,
+                        bool wait_for_callstack);
+  template <typename SchedWakeupEventData>
+  void VisitSchedWakeup(uint64_t timestamp, const SchedWakeupEventData& event_data,
+                        bool wait_for_callstack);
 
   TracerListener* listener_;
   std::atomic<uint64_t>* thread_state_counter_ = nullptr;

--- a/src/LinuxTracing/SwitchesStatesNamesVisitorTest.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitorTest.cpp
@@ -154,14 +154,56 @@ SchedSwitchPerfEvent MakeFakeSchedSwitchPerfEvent(uint32_t cpu, pid_t prev_pid_o
   };
 }
 
-SchedWakeupPerfEvent MakeFakeSchedWakeupPerfEvent(pid_t woken_tid, uint64_t timestamp_ns) {
+SchedSwitchWithStackPerfEvent MakeFakeSchedSwitchWithStackPerfEvent(
+    uint32_t cpu, pid_t prev_pid_or_minus_one, pid_t prev_tid, int64_t prev_state_mask,
+    pid_t next_tid, uint64_t timestamp_ns, bool has_stack_data) {
+  SchedSwitchWithStackPerfEvent result{.timestamp = timestamp_ns,
+                                       .data = {
+                                           .cpu = cpu,
+                                           .prev_pid_or_minus_one = prev_pid_or_minus_one,
+                                           .prev_tid = prev_tid,
+                                           .prev_state = prev_state_mask,
+                                           .next_tid = next_tid,
+                                       }};
+  if (has_stack_data) {
+    result.data.regs = make_unique_for_overwrite<uint64_t[]>(12);
+    result.data.dyn_size = 512;
+    result.data.data = make_unique_for_overwrite<uint8_t[]>(512);
+  }
+  return result;
+}
+
+SchedWakeupPerfEvent MakeFakeSchedWakeupPerfEvent(pid_t woken_tid, pid_t was_unblocked_by_tid,
+                                                  pid_t was_unblocked_by_pid,
+                                                  uint64_t timestamp_ns) {
   return SchedWakeupPerfEvent{
       .timestamp = timestamp_ns,
       .data =
           {
               .woken_tid = woken_tid,
+              .was_unblocked_by_tid = was_unblocked_by_tid,
+              .was_unblocked_by_pid = was_unblocked_by_pid,
           },
   };
+}
+
+SchedWakeupWithStackPerfEvent MakeFakeSchedWakeupWithStackPerfEvent(pid_t woken_tid,
+                                                                    pid_t was_unblocked_by_tid,
+                                                                    pid_t was_unblocked_by_pid,
+                                                                    uint64_t timestamp_ns,
+                                                                    bool has_stack_data) {
+  SchedWakeupWithStackPerfEvent result{.timestamp = timestamp_ns,
+                                       .data = {
+                                           .woken_tid = woken_tid,
+                                           .was_unblocked_by_tid = was_unblocked_by_tid,
+                                           .was_unblocked_by_pid = was_unblocked_by_pid,
+                                       }};
+  if (has_stack_data) {
+    result.data.regs = make_unique_for_overwrite<uint64_t[]>(12);
+    result.data.dyn_size = 512;
+    result.data.data = make_unique_for_overwrite<uint8_t[]>(512);
+  }
+  return result;
 }
 
 SchedulingSlice MakeSchedulingSlice(uint32_t pid, uint32_t tid, int32_t core, uint64_t duration_ns,
@@ -185,13 +227,25 @@ SchedulingSlice MakeSchedulingSlice(uint32_t pid, uint32_t tid, int32_t core, ui
                           expected.out_timestamp_ns()));
 }
 
-ThreadStateSlice MakeThreadStateSlice(uint32_t tid, ThreadStateSlice::ThreadState thread_state,
-                                      uint64_t duration_ns, uint64_t end_timestamp_ns) {
+ThreadStateSlice MakeThreadStateSlice(
+    uint32_t tid, ThreadStateSlice::ThreadState thread_state, uint64_t duration_ns,
+    uint64_t end_timestamp_ns,
+    ThreadStateSlice::WakeupReason wakeup_reason = ThreadStateSlice::kNotApplicable,
+    uint32_t wakeup_tid = 0, uint32_t wakeup_pid = 0, bool wait_for_callstack = false) {
   ThreadStateSlice thread_state_slice;
   thread_state_slice.set_tid(tid);
   thread_state_slice.set_thread_state(thread_state);
   thread_state_slice.set_duration_ns(duration_ns);
   thread_state_slice.set_end_timestamp_ns(end_timestamp_ns);
+  thread_state_slice.set_wakeup_reason(wakeup_reason);
+  thread_state_slice.set_wakeup_tid(wakeup_tid);
+  thread_state_slice.set_wakeup_pid(wakeup_pid);
+  if (wait_for_callstack) {
+    thread_state_slice.set_switch_out_or_wakeup_callstack_status(
+        ThreadStateSlice::kWaitingForCallstack);
+  } else {
+    thread_state_slice.set_switch_out_or_wakeup_callstack_status(ThreadStateSlice::kNoCallstack);
+  }
   return thread_state_slice;
 }
 
@@ -201,7 +255,17 @@ ThreadStateSlice MakeThreadStateSlice(uint32_t tid, ThreadStateSlice::ThreadStat
       ::testing::Property("thread_state", &ThreadStateSlice::thread_state, expected.thread_state()),
       ::testing::Property("duration_ns", &ThreadStateSlice::duration_ns, expected.duration_ns()),
       ::testing::Property("end_timestamp_ns", &ThreadStateSlice::end_timestamp_ns,
-                          expected.end_timestamp_ns()));
+                          expected.end_timestamp_ns()),
+      ::testing::Property("wakeup_reason", &ThreadStateSlice::wakeup_reason,
+                          expected.wakeup_reason()),
+      ::testing::Property("wakeup_tid", &ThreadStateSlice::wakeup_tid, expected.wakeup_tid()),
+      ::testing::Property("wakeup_pid", &ThreadStateSlice::wakeup_pid, expected.wakeup_pid()),
+      ::testing::Property("switch_out_or_wakeup_callstack_id",
+                          &ThreadStateSlice::switch_out_or_wakeup_callstack_id,
+                          expected.switch_out_or_wakeup_callstack_id()),
+      ::testing::Property("switch_out_or_wakeup_callstack_status",
+                          &ThreadStateSlice::switch_out_or_wakeup_callstack_status,
+                          expected.switch_out_or_wakeup_callstack_status()));
 }
 
 ThreadName MakeThreadName(uint32_t pid, uint32_t tid, std::string name, uint64_t timestamp_ns) {
@@ -400,7 +464,7 @@ void SwitchesStatesNamesVisitorTest::ProcessFakeEventsForThreadStateTests() {
   visitor_.ProcessInitialState(kStartTimestampNs, kTid3, 'D');
 
   // kPid1, kTid1
-  PerfEvent{MakeFakeSchedWakeupPerfEvent(kTid1, kWakeTimestampNs1)}.Accept(&visitor_);
+  PerfEvent{MakeFakeSchedWakeupPerfEvent(kTid1, 0, 0, kWakeTimestampNs1)}.Accept(&visitor_);
   PerfEvent{MakeFakeSchedSwitchPerfEvent(kCpu1, kPrevTid, kPrevTid, kRunnableStateMask, kTid1,
                                          kInTimestampNs1)}
       .Accept(&visitor_);
@@ -416,10 +480,10 @@ void SwitchesStatesNamesVisitorTest::ProcessFakeEventsForThreadStateTests() {
   PerfEvent{MakeFakeSchedSwitchPerfEvent(kCpu2, kPid1, kTid2, kInterruptibleSleepStateMask,
                                          kNextTid, kOutTimestampNs2)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeSchedWakeupPerfEvent(kTid2, kWakeTimestampNs2)}.Accept(&visitor_);
+  PerfEvent{MakeFakeSchedWakeupPerfEvent(kTid2, kTid1, kPid1, kWakeTimestampNs2)}.Accept(&visitor_);
 
   // kPid2, kTid3
-  PerfEvent{MakeFakeSchedWakeupPerfEvent(kTid3, kWakeTimestampNs3)}.Accept(&visitor_);
+  PerfEvent{MakeFakeSchedWakeupPerfEvent(kTid3, 0, 0, kWakeTimestampNs3)}.Accept(&visitor_);
   PerfEvent{MakeFakeSchedSwitchPerfEvent(kCpu3, kPrevTid, kPrevTid, kRunnableStateMask, kTid3,
                                          kInTimestampNs3)}
       .Accept(&visitor_);
@@ -494,39 +558,96 @@ TEST_F(SwitchesStatesNamesVisitorTest, VariousThreadStateSlicesFromAllPossibleEv
                   ThreadStateSliceEq(MakeThreadStateSlice(
                       kTid1, ThreadStateSlice::kUninterruptibleSleep,
                       kWakeTimestampNs1 - kStartTimestampNs, kWakeTimestampNs1)),
-                  ThreadStateSliceEq(MakeThreadStateSlice(kTid1, ThreadStateSlice::kRunnable,
-                                                          kInTimestampNs1 - kWakeTimestampNs1,
-                                                          kInTimestampNs1)),
+                  ThreadStateSliceEq(MakeThreadStateSlice(
+                      kTid1, ThreadStateSlice::kRunnable, kInTimestampNs1 - kWakeTimestampNs1,
+                      kInTimestampNs1, ThreadStateSlice::kUnblocked, 0, 0)),
                   ThreadStateSliceEq(MakeThreadStateSlice(kTid1, ThreadStateSlice::kRunning,
                                                           kOutTimestampNs1 - kInTimestampNs1,
                                                           kOutTimestampNs1)),
                   ThreadStateSliceEq(MakeThreadStateSlice(kTid1, ThreadStateSlice::kDead,
                                                           kStopTimestampNs - kOutTimestampNs1,
                                                           kStopTimestampNs)),
-                  ThreadStateSliceEq(MakeThreadStateSlice(kTid2, ThreadStateSlice::kRunnable,
-                                                          kInTimestampNs2 - kNewTimestampNs2,
-                                                          kInTimestampNs2)),
+                  ThreadStateSliceEq(MakeThreadStateSlice(
+                      kTid2, ThreadStateSlice::kRunnable, kInTimestampNs2 - kNewTimestampNs2,
+                      kInTimestampNs2, ThreadStateSlice::kCreated, 0, 0)),
                   ThreadStateSliceEq(MakeThreadStateSlice(kTid2, ThreadStateSlice::kRunning,
                                                           kOutTimestampNs2 - kInTimestampNs2,
                                                           kOutTimestampNs2)),
                   ThreadStateSliceEq(MakeThreadStateSlice(
                       kTid2, ThreadStateSlice::kInterruptibleSleep,
                       kWakeTimestampNs2 - kOutTimestampNs2, kWakeTimestampNs2)),
-                  ThreadStateSliceEq(MakeThreadStateSlice(kTid2, ThreadStateSlice::kRunnable,
-                                                          kStopTimestampNs - kWakeTimestampNs2,
-                                                          kStopTimestampNs)),
+                  ThreadStateSliceEq(MakeThreadStateSlice(
+                      kTid2, ThreadStateSlice::kRunnable, kStopTimestampNs - kWakeTimestampNs2,
+                      kStopTimestampNs, ThreadStateSlice::kUnblocked, kTid1, kPid1)),
                   ThreadStateSliceEq(MakeThreadStateSlice(
                       kTid3, ThreadStateSlice::kUninterruptibleSleep,
                       kWakeTimestampNs3 - kStartTimestampNs, kWakeTimestampNs3)),
-                  ThreadStateSliceEq(MakeThreadStateSlice(kTid3, ThreadStateSlice::kRunnable,
-                                                          kInTimestampNs3 - kWakeTimestampNs3,
-                                                          kInTimestampNs3)),
+                  ThreadStateSliceEq(MakeThreadStateSlice(
+                      kTid3, ThreadStateSlice::kRunnable, kInTimestampNs3 - kWakeTimestampNs3,
+                      kInTimestampNs3, ThreadStateSlice::kUnblocked, 0, 0)),
                   ThreadStateSliceEq(MakeThreadStateSlice(kTid3, ThreadStateSlice::kRunning,
                                                           kOutTimestampNs3 - kInTimestampNs3,
                                                           kOutTimestampNs3)),
                   ThreadStateSliceEq(MakeThreadStateSlice(kTid3, ThreadStateSlice::kDead,
                                                           kStopTimestampNs - kOutTimestampNs3,
                                                           kStopTimestampNs))));
+}
+
+TEST_F(SwitchesStatesNamesVisitorTest, VariousThreadStateSlicesOnOneThreadWaitingForCallstacks) {
+  visitor_.SetThreadStatePidFilters({kPid1, kPid2});
+
+  visitor_.ProcessInitialTidToPidAssociation(kTid1, kPid);
+  visitor_.ProcessInitialTidToPidAssociation(kTid2, kPid);
+  PerfEvent{MakeFakeForkPerfEvent(kPid, kTid2)}.Accept(&visitor_);
+
+  std::vector<ThreadStateSlice> actual_thread_state_slices;
+  const auto save_thread_state_slice_arg = [&](ThreadStateSlice actual_thread_state_slice) {
+    actual_thread_state_slices.emplace_back(std::move(actual_thread_state_slice));
+  };
+  EXPECT_CALL(mock_listener_, OnThreadStateSlice)
+      .Times(5)
+      .WillRepeatedly(save_thread_state_slice_arg);
+
+  visitor_.ProcessInitialState(kStartTimestampNs, kTid1, 'D');
+
+  // kPid1, kTid1
+  PerfEvent{MakeFakeSchedWakeupWithStackPerfEvent(kTid1, 0, 0, kWakeTimestampNs1,
+                                                  /*has_stack_data=*/false)}
+      .Accept(&visitor_);
+  PerfEvent{MakeFakeSchedSwitchWithStackPerfEvent(kCpu1, kPrevTid, kPrevTid, kRunnableStateMask,
+                                                  kTid1, kInTimestampNs1, /*has_stack_data=*/false)}
+      .Accept(&visitor_);
+  PerfEvent{MakeFakeSchedSwitchWithStackPerfEvent(kCpu1, kPid1, kTid1, kInterruptibleSleepStateMask,
+                                                  kNextTid, kOutTimestampNs1,
+                                                  /*has_stack_data=*/true)}
+      .Accept(&visitor_);
+  PerfEvent{MakeFakeSchedWakeupWithStackPerfEvent(kTid1, kTid2, kPid1, kWakeTimestampNs2,
+                                                  /*has_stack_data=*/true)}
+      .Accept(&visitor_);
+
+  visitor_.ProcessRemainingOpenStates(kStopTimestampNs);
+
+  EXPECT_EQ(thread_state_counter_, 5);
+  EXPECT_THAT(
+      actual_thread_state_slices,
+      ::testing::ElementsAre(
+          ThreadStateSliceEq(MakeThreadStateSlice(kTid1, ThreadStateSlice::kUninterruptibleSleep,
+                                                  kWakeTimestampNs1 - kStartTimestampNs,
+                                                  kWakeTimestampNs1)),
+          ThreadStateSliceEq(MakeThreadStateSlice(
+              kTid1, ThreadStateSlice::kRunnable, kInTimestampNs1 - kWakeTimestampNs1,
+              kInTimestampNs1, ThreadStateSlice::kUnblocked, 0, 0, /*wait_for_callstack=*/false)),
+          ThreadStateSliceEq(MakeThreadStateSlice(kTid1, ThreadStateSlice::kRunning,
+                                                  kOutTimestampNs1 - kInTimestampNs1,
+                                                  kOutTimestampNs1)),
+          ThreadStateSliceEq(MakeThreadStateSlice(
+              kTid1, ThreadStateSlice::kInterruptibleSleep, kWakeTimestampNs2 - kOutTimestampNs1,
+              kWakeTimestampNs2, ThreadStateSlice::kNotApplicable, 0, 0,
+              /*wait_for_callstack=*/true)),
+          ThreadStateSliceEq(MakeThreadStateSlice(kTid1, ThreadStateSlice::kRunnable,
+                                                  kStopTimestampNs - kWakeTimestampNs2,
+                                                  kStopTimestampNs, ThreadStateSlice::kUnblocked,
+                                                  kTid2, kPid1, /*wait_for_callstack=*/true))));
 }
 
 }  // namespace orbit_linux_tracing


### PR DESCRIPTION
SwitchesStatesNamesVisitor now implements methods to process the wakeup and switch out trace points that contain stack data.

As a result, the thread state events will show up in Orbit, when enabling callstack collection.
The ThreadStateSlices will have the callstack status "waiting" and do not have a thread id, yet.

Follow up:
  * Also handle those events in the uprobes visitor,
  * generate new full callstack events
  * and merge them in the producer event processor

Test: Unit test
Bug: http://b/235554760