### PR TITLE
Change HttpDownloadManager to support NotFound

### DIFF
--- a/src/Http/include/Http/DownloadManager.h
+++ b/src/Http/include/Http/DownloadManager.h
@@ -6,6 +6,7 @@
 #define HTTP_DOWNLOAD_MANAGER_H_
 
 #include "OrbitBase/CanceledOr.h"
+#include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/StopToken.h"
 
@@ -15,8 +16,10 @@ class DownloadManager {
  public:
   virtual ~DownloadManager() = default;
 
-  [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> Download(
-      std::string url, std::filesystem::path save_file_path, orbit_base::StopToken stop_token) = 0;
+  [[nodiscard]] virtual orbit_base::Future<
+      ErrorMessageOr<orbit_base::CanceledOr<orbit_base::NotFoundOr<void>>>>
+  Download(std::string url, std::filesystem::path save_file_path,
+           orbit_base::StopToken stop_token) = 0;
 };
 
 }  // namespace orbit_http

--- a/src/Http/include/Http/HttpDownloadManager.h
+++ b/src/Http/include/Http/HttpDownloadManager.h
@@ -7,14 +7,8 @@
 
 #include <QNetworkAccessManager>
 #include <QObject>
-#include <QPointer>
-#include <memory>
 
 #include "Http/DownloadManager.h"
-#include "OrbitBase/CanceledOr.h"
-#include "OrbitBase/Future.h"
-#include "OrbitBase/Result.h"
-#include "OrbitBase/StopToken.h"
 
 namespace orbit_http {
 
@@ -24,9 +18,10 @@ class HttpDownloadManager : public QObject, public DownloadManager {
   explicit HttpDownloadManager(QObject* parent = nullptr) : QObject(parent) {}
   ~HttpDownloadManager() override;
 
-  [[nodiscard]] orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> Download(
-      std::string url, std::filesystem::path save_file_path,
-      orbit_base::StopToken stop_token) override;
+  [[nodiscard]] orbit_base::Future<
+      ErrorMessageOr<orbit_base::CanceledOr<orbit_base::NotFoundOr<void>>>>
+  Download(std::string url, std::filesystem::path save_file_path,
+           orbit_base::StopToken stop_token) override;
 
  private:
   QNetworkAccessManager manager_;

--- a/src/Http/include/Http/HttpDownloadManager.h
+++ b/src/Http/include/Http/HttpDownloadManager.h
@@ -7,8 +7,16 @@
 
 #include <QNetworkAccessManager>
 #include <QObject>
+#include <QString>
+#include <filesystem>
+#include <string>
 
 #include "Http/DownloadManager.h"
+#include "OrbitBase/CanceledOr.h"
+#include "OrbitBase/Future.h"
+#include "OrbitBase/NotFoundOr.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/StopToken.h"
 
 namespace orbit_http {
 

--- a/src/Http/include/Http/MockDownloadManager.h
+++ b/src/Http/include/Http/MockDownloadManager.h
@@ -12,8 +12,9 @@
 namespace orbit_http {
 class MockDownloadManager : public DownloadManager {
  public:
-  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>, Download,
-              (std::string, std::filesystem::path, orbit_base::StopToken), (override));
+  MOCK_METHOD(
+      orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<orbit_base::NotFoundOr<void>>>>,
+      Download, (std::string, std::filesystem::path, orbit_base::StopToken), (override));
 };
 }  // namespace orbit_http
 

--- a/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProviderTest.cpp
@@ -10,6 +10,7 @@
 
 #include "Http/MockDownloadManager.h"
 #include "OrbitBase/CanceledOr.h"
+#include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/StopSource.h"
 #include "OrbitGgp/MockClient.h"
@@ -21,9 +22,9 @@
 namespace orbit_remote_symbol_provider {
 
 namespace {
-using orbit_base::Canceled;
 using orbit_base::CanceledOr;
 using orbit_base::Future;
+using orbit_base::NotFoundOr;
 using orbit_ggp::SymbolDownloadInfo;
 using SymbolDownloadQuery = orbit_ggp::Client::SymbolDownloadQuery;
 using orbit_symbol_provider::ModuleIdentifier;
@@ -84,12 +85,13 @@ class StadiaSymbolStoreSymbolProviderTest : public testing::Test {
         .Times(1)
         .WillOnce([expected_state, error_msg = std::move(error_msg)](
                       std::string /*url*/, std::filesystem::path /*save_file_path*/,
-                      orbit_base::StopToken /*token*/) -> Future<ErrorMessageOr<CanceledOr<void>>> {
+                      orbit_base::StopToken /*token*/)
+                      -> Future<ErrorMessageOr<CanceledOr<NotFoundOr<void>>>> {
           switch (expected_state) {
             case DownloadResultState::kSuccess:
               return {outcome::success()};
             case DownloadResultState::kCanceled:
-              return {Canceled{}};
+              return {orbit_base::Canceled{}};
             case DownloadResultState::kError:
               return {ErrorMessage{error_msg}};
           }


### PR DESCRIPTION
We change the HttpDownloadManager to treat the not found case differently.

Test: Unit tests
Bug: http://b/245522908

Next steps would be change Orbit ggp client to treat symbol not found case differently, 
and change SymbolProvider to use SymbolLoadingOutcome 