### PR TITLE
Process scheduling callstacks in UprobesUnwindingVisitor

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -433,6 +433,19 @@ message FullCallstackSample {
   uint64 timestamp_ns = 4;
 }
 
+message ThreadStateSliceCallstack {
+  // This proto is only used on the service side and will never be seen by the
+  // client. It is the equivalent of a FullCallstackSample for thread state
+  // tracepoint events, that needs further processing outside of
+  // UprobesUnwindingVisitor.
+  // These callstacks will be merged with the events produced by the
+  // SchwitchesStatesNamesVisitor within ProducerEventProcessor, where they'll
+  // go through the same de-duplication as the callstacks from sampling.
+  uint32 thread_state_slice_tid = 1;
+  Callstack callstack = 2;
+  uint64 timestamp_ns = 3;
+}
+
 message InternedString {
   uint64 key = 1;
   // This is a string, we use bytes to avoid UTF-8 validation.
@@ -915,7 +928,7 @@ message ProducerCaptureEvent {
     // numbers starting with 16.
     //
     // Next high-frequency ID: 15.
-    // Next lower-frequency ID: 50
+    // Next lower-frequency ID: 51
     //
     // Please keep these alphabetically ordered.
     ApiEvent api_event = 10;
@@ -962,6 +975,7 @@ message ProducerCaptureEvent {
     ThreadName thread_name = 21;
     ThreadNamesSnapshot thread_names_snapshot = 24;
     ThreadStateSlice thread_state_slice = 9;
+    ThreadStateSliceCallstack thread_state_slice_callstack = 50;
     WarningEvent warning_event = 30;
     WarningInstrumentingWithUprobesEvent
         warning_instrumenting_with_uprobes_event = 49;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -438,7 +438,7 @@ message ThreadStateSliceCallstack {
   // client. It is the equivalent of a FullCallstackSample for thread state
   // tracepoint events, that needs further processing outside of
   // UprobesUnwindingVisitor.
-  // These callstacks will be merged with the events produced by the
+  // These callstacks will be merged with the ThreadStateSlices produced by the
   // SwitchesStatesNamesVisitor within ProducerEventProcessor, where they'll
   // go through the same de-duplication as the callstacks from sampling.
   uint32 thread_state_slice_tid = 1;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -439,7 +439,7 @@ message ThreadStateSliceCallstack {
   // tracepoint events, that needs further processing outside of
   // UprobesUnwindingVisitor.
   // These callstacks will be merged with the events produced by the
-  // SchwitchesStatesNamesVisitor within ProducerEventProcessor, where they'll
+  // SwitchesStatesNamesVisitor within ProducerEventProcessor, where they'll
   // go through the same de-duplication as the callstacks from sampling.
   uint32 thread_state_slice_tid = 1;
   Callstack callstack = 2;

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -76,6 +76,8 @@ struct StackSamplePerfEventData {
   // UprobesReturnAddressManager::PatchSample.
   [[nodiscard]] uint8_t* GetMutableStackData() const { return data.get(); }
   [[nodiscard]] uint64_t GetStackSize() const { return dyn_size; }
+  [[nodiscard]] pid_t GetCallstackPid() const { return pid; }
+  [[nodiscard]] pid_t GetCallstackTid() const { return tid; }
 
   pid_t pid;
   pid_t tid;
@@ -336,6 +338,8 @@ struct SchedWakeupWithStackPerfEventData {
   // UprobesReturnAddressManager::PatchSample.
   [[nodiscard]] uint8_t* GetMutableStackData() const { return data.get(); }
   [[nodiscard]] uint64_t GetStackSize() const { return dyn_size; }
+  [[nodiscard]] pid_t GetCallstackPid() const { return was_unblocked_by_pid; }
+  [[nodiscard]] pid_t GetCallstackTid() const { return was_unblocked_by_tid; }
 
   pid_t woken_tid;
   pid_t was_unblocked_by_tid;
@@ -359,6 +363,8 @@ struct SchedSwitchWithStackPerfEventData {
   // UprobesReturnAddressManager::PatchSample.
   [[nodiscard]] uint8_t* GetMutableStackData() const { return data.get(); }
   [[nodiscard]] uint64_t GetStackSize() const { return dyn_size; }
+  [[nodiscard]] pid_t GetCallstackPid() const { return prev_pid_or_minus_one; }
+  [[nodiscard]] pid_t GetCallstackTid() const { return prev_tid; }
 
   uint32_t cpu;
   pid_t prev_pid_or_minus_one;

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -76,7 +76,7 @@ struct StackSamplePerfEventData {
   // UprobesReturnAddressManager::PatchSample.
   [[nodiscard]] uint8_t* GetMutableStackData() const { return data.get(); }
   [[nodiscard]] uint64_t GetStackSize() const { return dyn_size; }
-  [[nodiscard]] pid_t GetCallstackPid() const { return pid; }
+  [[nodiscard]] pid_t GetCallstackPidOrMinusOne() const { return pid; }
   [[nodiscard]] pid_t GetCallstackTid() const { return tid; }
 
   pid_t pid;
@@ -338,7 +338,7 @@ struct SchedWakeupWithStackPerfEventData {
   // UprobesReturnAddressManager::PatchSample.
   [[nodiscard]] uint8_t* GetMutableStackData() const { return data.get(); }
   [[nodiscard]] uint64_t GetStackSize() const { return dyn_size; }
-  [[nodiscard]] pid_t GetCallstackPid() const { return was_unblocked_by_pid; }
+  [[nodiscard]] pid_t GetCallstackPidOrMinusOne() const { return was_unblocked_by_pid; }
   [[nodiscard]] pid_t GetCallstackTid() const { return was_unblocked_by_tid; }
 
   pid_t woken_tid;
@@ -363,7 +363,7 @@ struct SchedSwitchWithStackPerfEventData {
   // UprobesReturnAddressManager::PatchSample.
   [[nodiscard]] uint8_t* GetMutableStackData() const { return data.get(); }
   [[nodiscard]] uint64_t GetStackSize() const { return dyn_size; }
-  [[nodiscard]] pid_t GetCallstackPid() const { return prev_pid_or_minus_one; }
+  [[nodiscard]] pid_t GetCallstackPidOrMinusOne() const { return prev_pid_or_minus_one; }
   [[nodiscard]] pid_t GetCallstackTid() const { return prev_tid; }
 
   uint32_t cpu;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -277,9 +277,6 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
 
 void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
                                     const SchedWakeupWithStackPerfEventData& event_data) {
-  if (event_data.data == nullptr) {
-    return;
-  }
   ThreadStateSliceCallstack thread_state_slice_callstack;
   thread_state_slice_callstack.set_thread_state_slice_tid(event_data.woken_tid);
   thread_state_slice_callstack.set_timestamp_ns(event_timestamp);
@@ -295,10 +292,6 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
 
 void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
                                     const SchedSwitchWithStackPerfEventData& event_data) {
-  if (event_data.data == nullptr) {
-    return;
-  }
-
   ThreadStateSliceCallstack thread_state_slice_callstack;
   thread_state_slice_callstack.set_thread_state_slice_tid(event_data.prev_tid);
   thread_state_slice_callstack.set_timestamp_ns(event_timestamp);

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -239,7 +239,7 @@ bool UprobesUnwindingVisitor::UnwindStack(const StackPerfEventDataT& event_data,
   }
 
   LibunwindstackResult libunwindstack_result =
-      unwinder_->Unwind(event_data.GetCallstackPid(), current_maps_->Get(),
+      unwinder_->Unwind(event_data.GetCallstackPidOrMinusOne(), current_maps_->Get(),
                         event_data.GetRegistersAsArray(), stack_slices);
 
   if (libunwindstack_result.frames().empty()) {

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -122,7 +122,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   void SendFullAddressInfoToListener(const unwindstack::FrameData& libunwindstack_frame);
 
   template <typename StackPerfEventDataT>
-  bool UnwindStack(const StackPerfEventDataT& event, orbit_grpc_protos::Callstack* callstack);
+  bool UnwindStack(const StackPerfEventDataT& event,
+                   orbit_grpc_protos::Callstack* resulting_callstack);
 
   TracerListener* listener_;
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -82,6 +82,10 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   }
 
   void Visit(uint64_t event_timestamp, const StackSamplePerfEventData& event_data) override;
+  void Visit(uint64_t event_timestamp,
+             const SchedWakeupWithStackPerfEventData& event_data) override;
+  void Visit(uint64_t event_timestamp,
+             const SchedSwitchWithStackPerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const CallchainSamplePerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const UprobesPerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const UprobesWithStackPerfEventData& event_data) override;
@@ -116,6 +120,9 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   ComputeCallstackTypeFromCallchainAndPatch(const CallchainSamplePerfEventData& event_data);
 
   void SendFullAddressInfoToListener(const unwindstack::FrameData& libunwindstack_frame);
+
+  template <typename StackPerfEventDataT>
+  bool UnwindStack(const StackPerfEventDataT& event, orbit_grpc_protos::Callstack* callstack);
 
   TracerListener* listener_;
 

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -14,7 +14,7 @@ class TracerListener {
   virtual ~TracerListener() = default;
   virtual void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) = 0;
   virtual void OnCallstackSample(orbit_grpc_protos::FullCallstackSample callstack_sample) = 0;
-  // TODO(kuebler): Make this pure virtual and add implementations. This is up in the next PR.
+  // TODO(b/235554760): Make this pure virtual and add implementations.
   virtual void OnThreadStateSliceCallstack(
       orbit_grpc_protos::ThreadStateSliceCallstack /*callstack*/) {}
   virtual void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) = 0;

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -14,6 +14,9 @@ class TracerListener {
   virtual ~TracerListener() = default;
   virtual void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) = 0;
   virtual void OnCallstackSample(orbit_grpc_protos::FullCallstackSample callstack_sample) = 0;
+  // TODO(kuebler): Make this pure virtual and add implementations. This is up in the next PR.
+  virtual void OnThreadStateSliceCallstack(
+      orbit_grpc_protos::ThreadStateSliceCallstack /*callstack*/) {}
   virtual void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) = 0;
   virtual void OnGpuJob(orbit_grpc_protos::FullGpuJob gpu_job) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -438,6 +438,9 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         EXPECT_GE(event.thread_state_slice().end_timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.thread_state_slice().end_timestamp_ns();
         break;
+      case orbit_grpc_protos::ProducerCaptureEvent::kThreadStateSliceCallstack:
+        // TODO(b/243515756): Add test for scheduling trace points with callstacks
+        ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kWarningEvent:
         ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kWarningInstrumentingWithUprobesEvent:

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -439,7 +439,7 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         previous_event_timestamp_ns = event.thread_state_slice().end_timestamp_ns();
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kThreadStateSliceCallstack:
-        // TODO(b/243515756): Add test for scheduling trace points with callstacks
+        // TODO(b/243515756): Add test for scheduling tracepoints with callstacks
         ORBIT_UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kWarningEvent:
         ORBIT_UNREACHABLE();

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -688,7 +688,7 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
       ProcessThreadStateSliceAndTransferOwnership(event.release_thread_state_slice());
       break;
     case ProducerCaptureEvent::kThreadStateSliceCallstack:
-      // TODO(kuebler): add processing in the next PR.
+      // TODO(b/235554760): Merge callstacks with the thread state slices.
       break;
     case ProducerCaptureEvent::kWarningEvent:
       ProcessWarningEventAndTransferOwnership(event.release_warning_event());

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -687,6 +687,9 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
     case ProducerCaptureEvent::kThreadStateSlice:
       ProcessThreadStateSliceAndTransferOwnership(event.release_thread_state_slice());
       break;
+    case ProducerCaptureEvent::kThreadStateSliceCallstack:
+      // TODO(kuebler): add processing in the next PR.
+      break;
     case ProducerCaptureEvent::kWarningEvent:
       ProcessWarningEventAndTransferOwnership(event.release_warning_event());
       break;


### PR DESCRIPTION
Similar to the FullCallstackSample, this change introduces a ThreadStateSliceCallstack proto message, that will be generated by the UprobesUnwindingVisitor. It contains a callstack from scheduling tracepoints that will be matched (later) together with a ThreadStateSlice (produced by the same perf event), to be sent to the client.

Bug: http://b/235554760
Test: Unit tests (next PR) and E2E prototype integration