### PR TITLE
Change orbit_ggp::Client to support not found

### DIFF
--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "OrbitBase/Future.h"
+#include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/Account.h"
 #include "OrbitGgp/Instance.h"
@@ -56,8 +57,9 @@ class Client {
     std::string module_name;
     std::string build_id;
   };
-  [[nodiscard]] virtual orbit_base::Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>>
-  GetSymbolDownloadInfoAsync(const std::vector<SymbolDownloadQuery>& symbol_download_queries) = 0;
+  [[nodiscard]] virtual orbit_base::Future<
+      ErrorMessageOr<orbit_base::NotFoundOr<SymbolDownloadInfo>>>
+  GetSymbolDownloadInfoAsync(const SymbolDownloadQuery& symbol_download_query) = 0;
 };
 
 [[nodiscard]] std::chrono::milliseconds GetClientDefaultTimeoutInMs();

--- a/src/OrbitGgp/include/OrbitGgp/MockClient.h
+++ b/src/OrbitGgp/include/OrbitGgp/MockClient.h
@@ -12,6 +12,7 @@
 #include <optional>
 
 #include "OrbitBase/Future.h"
+#include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 #include "OrbitGgp/Client.h"
 
@@ -36,9 +37,8 @@ class MockClient : public Client {
   MOCK_METHOD(orbit_base::Future<ErrorMessageOr<Instance>>, DescribeInstanceAsync,
               (const QString& /*instance_id*/), (override));
   MOCK_METHOD(orbit_base::Future<ErrorMessageOr<Account>>, GetDefaultAccountAsync, (), (override));
-  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<std::vector<SymbolDownloadInfo>>>,
-              GetSymbolDownloadInfoAsync, ((const std::vector<Client::SymbolDownloadQuery>&)),
-              (override));
+  MOCK_METHOD(orbit_base::Future<ErrorMessageOr<orbit_base::NotFoundOr<SymbolDownloadInfo>>>,
+              GetSymbolDownloadInfoAsync, ((const Client::SymbolDownloadQuery&)), (override));
 };
 }  // namespace orbit_ggp
 

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
@@ -13,7 +13,6 @@
 #include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/StopSource.h"
-#include "OrbitGgp/MockClient.h"
 #include "QtUtils/MainThreadExecutorImpl.h"
 #include "RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h"
 #include "Symbols/MockSymbolCache.h"
@@ -25,8 +24,6 @@ namespace {
 using orbit_base::CanceledOr;
 using orbit_base::Future;
 using orbit_base::NotFoundOr;
-using orbit_ggp::SymbolDownloadInfo;
-using SymbolDownloadQuery = orbit_ggp::Client::SymbolDownloadQuery;
 using orbit_symbol_provider::ModuleIdentifier;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;

--- a/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.cpp
+++ b/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.cpp
@@ -14,6 +14,8 @@
 
 using orbit_base::CanceledOr;
 using orbit_base::Future;
+using orbit_base::NotFoundOr;
+using orbit_ggp::SymbolDownloadInfo;
 
 namespace orbit_remote_symbol_provider {
 
@@ -35,26 +37,29 @@ Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>>
 StadiaSymbolStoreSymbolProvider::RetrieveSymbols(
     const orbit_symbol_provider::ModuleIdentifier& module_id, orbit_base::StopToken stop_token) {
   std::filesystem::path module_path(module_id.file_path);
-  std::vector<orbit_ggp::Client::SymbolDownloadQuery> queries = {
-      {module_path.filename().string(), module_id.build_id}};
+  orbit_ggp::Client::SymbolDownloadQuery query = {module_path.filename().string(),
+                                                  module_id.build_id};
 
   // TODO(b/245920841): Client::GetSymbolDownloadInfoAsync should support returning ErrorMessage and
   // NotFound.
-  return orbit_base::UnwrapFuture(ggp_client_->GetSymbolDownloadInfoAsync(queries).ThenIfSuccess(
+  return orbit_base::UnwrapFuture(ggp_client_->GetSymbolDownloadInfoAsync(query).ThenIfSuccess(
       main_thread_executor_.get(),
       [this, module_file_path = module_id.file_path, stop_token = std::move(stop_token)](
-          const std::vector<orbit_ggp::SymbolDownloadInfo>& download_info) mutable
+          const NotFoundOr<SymbolDownloadInfo>& call_ggp_result) mutable
       -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
-        if (download_info.empty()) return ErrorMessage{"No symbol download info returned."};
+        if (orbit_base::IsNotFound(call_ggp_result)) {
+          return ErrorMessage{"Symbols not found in Stadia symbol store"};
+        }
 
-        std::string url = download_info.front().url.toStdString();
+        SymbolDownloadInfo download_info = orbit_base::GetFound(call_ggp_result);
+        std::string url = download_info.url.toStdString();
         std::filesystem::path save_file_path =
             symbol_cache_->GenerateCachedFilePath(module_file_path);
         return download_manager_->Download(std::move(url), save_file_path, std::move(stop_token))
             .ThenIfSuccess(
                 main_thread_executor_.get(),
-                [save_file_path = std::move(save_file_path)](
-                    CanceledOr<orbit_base::NotFoundOr<void>> download_result)
+                [save_file_path =
+                     std::move(save_file_path)](CanceledOr<NotFoundOr<void>> download_result)
                     -> CanceledOr<std::filesystem::path> {
                   if (orbit_base::IsCanceled(download_result)) return {orbit_base::Canceled{}};
 


### PR DESCRIPTION
We change the orbit_ggp::Client to only support query one module while calling GetSymbolDownloadInfoAsync to get the symbol download url. If failed to get the symbol download url, GetSymbolDownloadInfoAsync then checks the stderr of the ggp call to see whether it is a not found case or some other error cases, and returns NotFound or an error message accordingly.

Bug: http://b/245920841
Test: Unit tests