### PR TITLE
Wait for dialog to be closed in E2E tests

### DIFF
--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -556,9 +556,8 @@ class CaptureRepeatedly(E2ETestCase):
 
         self._stop_capture_if_necessary(capture_tab)
 
-        wait_for_condition(lambda: self.find_control(
-            'Window', 'Finalizing capture', recurse=False, raise_on_failure=False) is None,
-                           max_seconds=120)
+        capture_options_button = self.find_control('Button', 'Capture Options', parent=capture_tab)
+        wait_for_condition(lambda: capture_options_button.is_enabled() is True, max_seconds=30)
 
 
 class CheckThreadStates(CaptureWindowE2ETestCaseBase):

--- a/contrib/automation_tests/test_cases/symbol_locations.py
+++ b/contrib/automation_tests/test_cases/symbol_locations.py
@@ -92,5 +92,3 @@ class ClearAllSymbolLocations(E2ETestCase):
         self.expect_eq(0, len(symbol_path_list.descendants(control_type='ListItem')),
                        'List is empty')
         self.find_control('Button', 'Done', parent=ui).click_input()
-        wait_for_condition(
-            lambda: self.find_control('Button', 'Done', parent=ui, raise_on_failure=False) is None)

--- a/contrib/automation_tests/test_cases/symbol_locations.py
+++ b/contrib/automation_tests/test_cases/symbol_locations.py
@@ -92,3 +92,5 @@ class ClearAllSymbolLocations(E2ETestCase):
         self.expect_eq(0, len(symbol_path_list.descendants(control_type='ListItem')),
                        'List is empty')
         self.find_control('Button', 'Done', parent=ui).click_input()
+        wait_for_condition(
+            lambda: self.find_control('Button', 'Done', parent=ui, raise_on_failure=False) is None)


### PR DESCRIPTION
In this PR we are waiting for dialogs to be closed in orbit_capture_repeatedly and orbit_symbol_locations, so Alt+F4 close Orbit and not the dialogs.

For capture_repeatedly we are waiting for the capture option button to be enabled again
(and reverting https://github.com/google/orbit/pull/4173) and for symbol_locations we are waiting 
for the ui dialog to be None.

Test: Run capture_repeatedly locally, trigger E2E test in the signed build.
Bug: http://b/246302999