### PR TITLE
Change SymbolProvider to support SymbolLoadingOutcome

### DIFF
--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
@@ -96,7 +96,7 @@ TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleSuccess) {
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
       .Then(executor_.get(), [this](const SymbolLoadingOutcome& result) {
-        EXPECT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
+        ASSERT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
         SymbolLoadingSuccessResult success_result = orbit_symbol_provider::GetSuccessResult(result);
         EXPECT_EQ(success_result.path,
                   symbol_cache_.GenerateCachedFilePath(kValidModuleId.file_path));
@@ -119,7 +119,9 @@ TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleNotFound) {
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(module_id, stop_source.GetStopToken())
       .Then(executor_.get(), [](const SymbolLoadingOutcome& result) {
-        EXPECT_TRUE(orbit_symbol_provider::IsNotFound(result));
+        ASSERT_TRUE(orbit_symbol_provider::IsNotFound(result));
+        EXPECT_EQ(orbit_symbol_provider::GetNotFoundMessage(result),
+                  "Symbols not found in Microsoft symbol server");
 
         QCoreApplication::exit();
       });

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
@@ -25,6 +25,8 @@ using orbit_base::CanceledOr;
 using orbit_base::Future;
 using orbit_base::NotFoundOr;
 using orbit_symbol_provider::ModuleIdentifier;
+using orbit_symbol_provider::SymbolLoadingOutcome;
+using orbit_symbol_provider::SymbolLoadingSuccessResult;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;
 using ::testing::_;
@@ -93,11 +95,13 @@ TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleSuccess) {
 
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
-      .Then(executor_.get(), [this](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
-        EXPECT_THAT(result, HasNoError());
-        EXPECT_FALSE(IsCanceled(result.value()));
-        const auto& local_file_path = orbit_base::GetNotCanceled(result.value());
-        EXPECT_EQ(local_file_path, symbol_cache_.GenerateCachedFilePath(kValidModuleId.file_path));
+      .Then(executor_.get(), [this](const SymbolLoadingOutcome& result) {
+        EXPECT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
+        SymbolLoadingSuccessResult success_result = orbit_symbol_provider::GetSuccessResult(result);
+        EXPECT_EQ(success_result.path,
+                  symbol_cache_.GenerateCachedFilePath(kValidModuleId.file_path));
+        EXPECT_EQ(success_result.symbol_source,
+                  SymbolLoadingSuccessResult::SymbolSource::kMicrosoftSymbolServer);
 
         QCoreApplication::exit();
       });
@@ -114,8 +118,8 @@ TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleNotFound) {
 
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(module_id, stop_source.GetStopToken())
-      .Then(executor_.get(), [](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
-        EXPECT_THAT(result, HasError("not found"));
+      .Then(executor_.get(), [](const SymbolLoadingOutcome& result) {
+        EXPECT_TRUE(orbit_symbol_provider::IsNotFound(result));
 
         QCoreApplication::exit();
       });
@@ -130,9 +134,8 @@ TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleCanceled) {
   // case.
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
-      .Then(executor_.get(), [](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
-        EXPECT_THAT(result, HasNoError());
-        EXPECT_TRUE(IsCanceled(result.value()));
+      .Then(executor_.get(), [](const SymbolLoadingOutcome& result) {
+        EXPECT_TRUE(orbit_symbol_provider::IsCanceled(result));
 
         QCoreApplication::exit();
       });
@@ -146,7 +149,7 @@ TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleError) {
 
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
-      .Then(executor_.get(), [error_msg](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
+      .Then(executor_.get(), [error_msg](const SymbolLoadingOutcome& result) {
         EXPECT_THAT(result, HasError(error_msg));
 
         QCoreApplication::exit();

--- a/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.cpp
+++ b/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.cpp
@@ -16,6 +16,8 @@ using orbit_base::CanceledOr;
 using orbit_base::Future;
 using orbit_base::NotFoundOr;
 using orbit_ggp::SymbolDownloadInfo;
+using orbit_symbol_provider::SymbolLoadingOutcome;
+using orbit_symbol_provider::SymbolLoadingSuccessResult;
 
 namespace orbit_remote_symbol_provider {
 
@@ -31,24 +33,19 @@ StadiaSymbolStoreSymbolProvider::StadiaSymbolStoreSymbolProvider(
   ORBIT_CHECK(ggp_client != nullptr);
 }
 
-// TODO(b/245522908): Treat NotFound as error message now. We will better handle the NotFound case
-// when changing symbol provider to return SymbolLoadingOutcome.
-Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>>
-StadiaSymbolStoreSymbolProvider::RetrieveSymbols(
+Future<SymbolLoadingOutcome> StadiaSymbolStoreSymbolProvider::RetrieveSymbols(
     const orbit_symbol_provider::ModuleIdentifier& module_id, orbit_base::StopToken stop_token) {
   std::filesystem::path module_path(module_id.file_path);
-  orbit_ggp::Client::SymbolDownloadQuery query = {module_path.filename().string(),
-                                                  module_id.build_id};
+  auto call_ggp_future = ggp_client_->GetSymbolDownloadInfoAsync(
+      {module_path.filename().string(), module_id.build_id});
 
-  return orbit_base::UnwrapFuture(ggp_client_->GetSymbolDownloadInfoAsync(query).ThenIfSuccess(
+  return orbit_base::UnwrapFuture(call_ggp_future.ThenIfSuccess(
       main_thread_executor_.get(),
       [this, module_file_path = module_id.file_path, stop_token = std::move(stop_token)](
           const NotFoundOr<SymbolDownloadInfo>& call_ggp_result) mutable
-      -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
-        // TODO(b/245522908): Change to return NotFound as soon as SymbolProvider supports
-        // SymbolLoadingOutcome
+      -> Future<SymbolLoadingOutcome> {
         if (orbit_base::IsNotFound(call_ggp_result)) {
-          return ErrorMessage{"Symbols not found in Stadia symbol store"};
+          return {orbit_base::NotFound{"Symbols not found in Stadia symbol store"}};
         }
 
         SymbolDownloadInfo download_info = orbit_base::GetFound(call_ggp_result);
@@ -58,15 +55,16 @@ StadiaSymbolStoreSymbolProvider::RetrieveSymbols(
         return download_manager_->Download(std::move(url), save_file_path, std::move(stop_token))
             .ThenIfSuccess(
                 main_thread_executor_.get(),
-                [save_file_path =
-                     std::move(save_file_path)](CanceledOr<NotFoundOr<void>> download_result)
-                    -> CanceledOr<std::filesystem::path> {
+                [save_file_path = std::move(save_file_path)](
+                    CanceledOr<NotFoundOr<void>> download_result) -> SymbolLoadingOutcome {
                   if (orbit_base::IsCanceled(download_result)) return {orbit_base::Canceled{}};
 
                   // If symbol not found in Stadia symbol store, no download url will be generated.
                   ORBIT_CHECK(!orbit_base::IsNotFound(orbit_base::GetNotCanceled(download_result)));
 
-                  return {save_file_path};
+                  return {SymbolLoadingSuccessResult{
+                      save_file_path, SymbolLoadingSuccessResult::SymbolSource::kStadiaSymbolStore,
+                      SymbolLoadingSuccessResult::SymbolFileSeparation::kDifferentFile}};
                 });
       }));
 }

--- a/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProviderTest.cpp
@@ -116,7 +116,7 @@ TEST_F(StadiaSymbolStoreSymbolProviderTest, RetrieveModuleSuccess) {
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
       .Then(executor_.get(), [this](const SymbolLoadingOutcome& result) {
-        EXPECT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
+        ASSERT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
         SymbolLoadingSuccessResult success_result = orbit_symbol_provider::GetSuccessResult(result);
         EXPECT_EQ(success_result.path,
                   symbol_cache_.GenerateCachedFilePath(kValidModuleId.file_path));
@@ -168,7 +168,9 @@ TEST_F(StadiaSymbolStoreSymbolProviderTest, RetrieveModuleNotFound) {
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(module_id, stop_source.GetStopToken())
       .Then(executor_.get(), [](const SymbolLoadingOutcome& result) {
-        EXPECT_TRUE(orbit_symbol_provider::IsNotFound(result));
+        ASSERT_TRUE(orbit_symbol_provider::IsNotFound(result));
+        EXPECT_EQ(orbit_symbol_provider::GetNotFoundMessage(result),
+                  "Symbols not found in Stadia symbol store");
 
         QCoreApplication::exit();
       });

--- a/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProviderTest.cpp
@@ -28,6 +28,8 @@ using orbit_base::NotFoundOr;
 using orbit_ggp::SymbolDownloadInfo;
 using SymbolDownloadQuery = orbit_ggp::Client::SymbolDownloadQuery;
 using orbit_symbol_provider::ModuleIdentifier;
+using orbit_symbol_provider::SymbolLoadingOutcome;
+using orbit_symbol_provider::SymbolLoadingSuccessResult;
 using orbit_test_utils::HasError;
 using orbit_test_utils::HasNoError;
 using ::testing::_;
@@ -113,11 +115,13 @@ TEST_F(StadiaSymbolStoreSymbolProviderTest, RetrieveModuleSuccess) {
 
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
-      .Then(executor_.get(), [this](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
-        EXPECT_THAT(result, HasNoError());
-        EXPECT_FALSE(IsCanceled(result.value()));
-        const auto& local_file_path = orbit_base::GetNotCanceled(result.value());
-        EXPECT_EQ(local_file_path, symbol_cache_.GenerateCachedFilePath(kValidModuleId.file_path));
+      .Then(executor_.get(), [this](const SymbolLoadingOutcome& result) {
+        EXPECT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
+        SymbolLoadingSuccessResult success_result = orbit_symbol_provider::GetSuccessResult(result);
+        EXPECT_EQ(success_result.path,
+                  symbol_cache_.GenerateCachedFilePath(kValidModuleId.file_path));
+        EXPECT_EQ(success_result.symbol_source,
+                  SymbolLoadingSuccessResult::SymbolSource::kStadiaSymbolStore);
 
         QCoreApplication::exit();
       });
@@ -133,9 +137,8 @@ TEST_F(StadiaSymbolStoreSymbolProviderTest, RetrieveModuleCanceled) {
   // case.
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
-      .Then(executor_.get(), [](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
-        EXPECT_THAT(result, HasNoError());
-        EXPECT_TRUE(IsCanceled(result.value()));
+      .Then(executor_.get(), [](const SymbolLoadingOutcome& result) {
+        EXPECT_TRUE(orbit_symbol_provider::IsCanceled(result));
 
         QCoreApplication::exit();
       });
@@ -149,7 +152,7 @@ TEST_F(StadiaSymbolStoreSymbolProviderTest, RetrieveModuleDownloadError) {
 
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
-      .Then(executor_.get(), [](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
+      .Then(executor_.get(), [](const SymbolLoadingOutcome& result) {
         EXPECT_THAT(result, HasError(kFailedToDownloadMsg));
 
         QCoreApplication::exit();
@@ -164,8 +167,8 @@ TEST_F(StadiaSymbolStoreSymbolProviderTest, RetrieveModuleNotFound) {
   const ModuleIdentifier module_id{"module/path/to/some_module_name", "some_build_id"};
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(module_id, stop_source.GetStopToken())
-      .Then(executor_.get(), [](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
-        EXPECT_THAT(result, HasError("not found"));
+      .Then(executor_.get(), [](const SymbolLoadingOutcome& result) {
+        EXPECT_TRUE(orbit_symbol_provider::IsNotFound(result));
 
         QCoreApplication::exit();
       });
@@ -178,7 +181,7 @@ TEST_F(StadiaSymbolStoreSymbolProviderTest, RetrieveModuleTimeout) {
 
   orbit_base::StopSource stop_source{};
   symbol_provider_.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
-      .Then(executor_.get(), [](ErrorMessageOr<CanceledOr<std::filesystem::path>> result) {
+      .Then(executor_.get(), [](const SymbolLoadingOutcome& result) {
         EXPECT_THAT(result, HasError(kGgpTimeoutMsg));
 
         QCoreApplication::exit();

--- a/src/RemoteSymbolProvider/include/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h
+++ b/src/RemoteSymbolProvider/include/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h
@@ -7,6 +7,7 @@
 
 #include "Http/HttpDownloadManager.h"
 #include "QtUtils/MainThreadExecutorImpl.h"
+#include "SymbolProvider/SymbolLoadingOutcome.h"
 #include "SymbolProvider/SymbolProvider.h"
 #include "Symbols/SymbolCacheInterface.h"
 
@@ -17,9 +18,9 @@ class MicrosoftSymbolServerSymbolProvider : public orbit_symbol_provider::Symbol
   explicit MicrosoftSymbolServerSymbolProvider(orbit_symbols::SymbolCacheInterface* symbol_cache,
                                                orbit_http::DownloadManager* download_manager);
 
-  [[nodiscard]] orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
-  RetrieveSymbols(const orbit_symbol_provider::ModuleIdentifier& module_id,
-                  orbit_base::StopToken stop_token) override;
+  [[nodiscard]] orbit_base::Future<orbit_symbol_provider::SymbolLoadingOutcome> RetrieveSymbols(
+      const orbit_symbol_provider::ModuleIdentifier& module_id,
+      orbit_base::StopToken stop_token) override;
 
  private:
   [[nodiscard]] std::string GetDownloadUrl(

--- a/src/RemoteSymbolProvider/include/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.h
+++ b/src/RemoteSymbolProvider/include/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.h
@@ -8,6 +8,7 @@
 #include "Http/DownloadManager.h"
 #include "OrbitGgp/Client.h"
 #include "QtUtils/MainThreadExecutorImpl.h"
+#include "SymbolProvider/SymbolLoadingOutcome.h"
 #include "SymbolProvider/SymbolProvider.h"
 #include "Symbols/SymbolCacheInterface.h"
 
@@ -19,9 +20,9 @@ class StadiaSymbolStoreSymbolProvider : public orbit_symbol_provider::SymbolProv
                                            orbit_http::DownloadManager* download_manager,
                                            orbit_ggp::Client* ggp_client);
 
-  [[nodiscard]] orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
-  RetrieveSymbols(const orbit_symbol_provider::ModuleIdentifier& module_id,
-                  orbit_base::StopToken stop_token) override;
+  [[nodiscard]] orbit_base::Future<orbit_symbol_provider::SymbolLoadingOutcome> RetrieveSymbols(
+      const orbit_symbol_provider::ModuleIdentifier& module_id,
+      orbit_base::StopToken stop_token) override;
 
  private:
   orbit_symbols::SymbolCacheInterface* symbol_cache_;

--- a/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
+++ b/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
@@ -9,6 +9,7 @@
 #include "OrbitBase/Result.h"
 #include "OrbitBase/StopToken.h"
 #include "SymbolProvider/ModuleIdentifier.h"
+#include "SymbolProvider/SymbolLoadingOutcome.h"
 
 namespace orbit_symbol_provider {
 
@@ -18,13 +19,8 @@ class SymbolProvider {
  public:
   virtual ~SymbolProvider() = default;
 
-  // Retrieve symbols for the provided module from the SymbolProvider's symbol source. Return:
-  // - A local file path if successfully retrieve symbols;
-  // - A Canceled if the retrieve operation is canceled via the stop_token;
-  // - An ErrorMassage if symbols are not found or error occurs while retrieving symbols.
-  [[nodiscard]] virtual orbit_base::Future<
-      ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
-  RetrieveSymbols(const ModuleIdentifier& module_id, orbit_base::StopToken stop_token) = 0;
+  [[nodiscard]] virtual orbit_base::Future<SymbolLoadingOutcome> RetrieveSymbols(
+      const ModuleIdentifier& module_id, orbit_base::StopToken stop_token) = 0;
 };
 
 }  // namespace orbit_symbol_provider


### PR DESCRIPTION
With this change, we updated the `SymbolProvider`s to return `SymbolLoadingOutcome` as the result of retrieving modules.

Bug:  http://b/245522908
Test:  Unit tests