### PR TITLE
Remove ModulesDataView::new_ui_ and related ifs

### DIFF
--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -57,7 +57,7 @@ std::string GetExpectedDisplayFileSizeByIndex(size_t index) {
 
 class ModulesDataViewTest : public testing::Test {
  public:
-  explicit ModulesDataViewTest() : view_{&app_, &metrics_uploader_, true} {
+  explicit ModulesDataViewTest() : view_{&app_, &metrics_uploader_} {
     view_.Init();
     for (size_t i = 0; i < kNumModules; i++) {
       ModuleInMemory module_in_memory{kStartAddresses[i], kEndAddresses[i], kFilePaths[i],

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -21,7 +21,7 @@ namespace orbit_data_views {
 class ModulesDataView : public DataView {
  public:
   explicit ModulesDataView(AppInterface* app,
-                           orbit_metrics_uploader::MetricsUploader* metrics_uploader, bool new_ui);
+                           orbit_metrics_uploader::MetricsUploader* metrics_uploader);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnFileSize; }
@@ -57,13 +57,6 @@ class ModulesDataView : public DataView {
   }
   [[nodiscard]] std::string GetSymbolLoadingStateForModuleString(
       const orbit_client_data::ModuleData* module);
-
-  // TODO(b/202140068) Remove this method when new ui is activated
-  [[nodiscard, deprecated]] DataView::ActionStatus OldUiGetActionStatus(
-      std::string_view action, int clicked_index, const std::vector<int>& selected_indices);
-
-  // TODO(b/202140068) remove when auto symbol loading is released
-  bool new_ui_;
 
   absl::flat_hash_map<uint64_t, orbit_client_data::ModuleInMemory>
       start_address_to_module_in_memory_;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2962,8 +2962,7 @@ orbit_data_views::DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kModules:
       if (!modules_data_view_) {
-        modules_data_view_ = DataView::CreateAndInit<ModulesDataView>(
-            this, metrics_uploader_, absl::GetFlag(FLAGS_auto_symbol_loading));
+        modules_data_view_ = DataView::CreateAndInit<ModulesDataView>(this, metrics_uploader_);
         panels_.push_back(modules_data_view_.get());
       }
       return modules_data_view_.get();


### PR DESCRIPTION
This was set to false when `--auto_symbol_loading=false`. However, the new ui works just fine when auto symbol loading is off. So let's remove the code related to the old ui as we are not testing it and we don't need it.

Bug: http://b/202140068

Test: Start Orbit on a game, play around with "Modules" list.