### PR TITLE
Add OrbitApp::InitRemoteSymbolProviders

### DIFF
--- a/src/Http/include/Http/HttpDownloadManager.h
+++ b/src/Http/include/Http/HttpDownloadManager.h
@@ -21,7 +21,6 @@
 namespace orbit_http {
 
 class HttpDownloadManager : public QObject, public DownloadManager {
-  Q_OBJECT
  public:
   explicit HttpDownloadManager(QObject* parent = nullptr) : QObject(parent) {}
   ~HttpDownloadManager() override;

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -172,20 +172,23 @@ target_link_libraries(
          DataViews
          DisplayFormats
          GrpcProtos
+         Http
          MetricsUploader
          OrbitAccessibility
          OrbitBase
+         OrbitGgp
          OrbitPaths
          PresetFile
          StringManager
-         Qt5::Gui
+         RemoteSymbolProvider
          SymbolProvider
          Symbols
          CONAN_PKG::freetype-gl
          CONAN_PKG::freetype
          CONAN_PKG::glad
          CONAN_PKG::imgui
-         gte::gte)
+         gte::gte
+         Qt5::Gui)
 
 add_custom_command(TARGET OrbitGl POST_BUILD COMMAND ${CMAKE_COMMAND}
                    -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/stadia-default-frame-track.opr

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.cpp
@@ -18,7 +18,7 @@ using orbit_symbol_provider::SymbolLoadingSuccessResult;
 namespace orbit_remote_symbol_provider {
 
 MicrosoftSymbolServerSymbolProvider::MicrosoftSymbolServerSymbolProvider(
-    orbit_symbols::SymbolCacheInterface* symbol_cache,
+    const orbit_symbols::SymbolCacheInterface* symbol_cache,
     orbit_http::DownloadManager* download_manager)
     : symbol_cache_(symbol_cache),
       download_manager_(download_manager),

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
@@ -81,7 +81,7 @@ class MicrosoftSymbolServerSymbolProviderTest : public testing::Test {
   }
 
  protected:
-  orbit_symbols::MockSymbolCache symbol_cache_;
+  const orbit_symbols::MockSymbolCache symbol_cache_;
   MicrosoftSymbolServerSymbolProvider symbol_provider_;
   std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor_;
 

--- a/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.cpp
+++ b/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.cpp
@@ -21,7 +21,7 @@ using orbit_symbol_provider::SymbolLoadingSuccessResult;
 namespace orbit_remote_symbol_provider {
 
 StadiaSymbolStoreSymbolProvider::StadiaSymbolStoreSymbolProvider(
-    orbit_symbols::SymbolCacheInterface* symbol_cache,
+    const orbit_symbols::SymbolCacheInterface* symbol_cache,
     orbit_http::DownloadManager* download_manager, orbit_ggp::Client* ggp_client)
     : symbol_cache_(symbol_cache),
       download_manager_(download_manager),

--- a/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/StadiaSymbolStoreSymbolProviderTest.cpp
@@ -99,7 +99,7 @@ class StadiaSymbolStoreSymbolProviderTest : public testing::Test {
   }
 
  protected:
-  orbit_symbols::MockSymbolCache symbol_cache_;
+  const orbit_symbols::MockSymbolCache symbol_cache_;
   StadiaSymbolStoreSymbolProvider symbol_provider_;
   std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor_;
 

--- a/src/RemoteSymbolProvider/include/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h
+++ b/src/RemoteSymbolProvider/include/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h
@@ -15,8 +15,9 @@ namespace orbit_remote_symbol_provider {
 
 class MicrosoftSymbolServerSymbolProvider : public orbit_symbol_provider::SymbolProvider {
  public:
-  explicit MicrosoftSymbolServerSymbolProvider(orbit_symbols::SymbolCacheInterface* symbol_cache,
-                                               orbit_http::DownloadManager* download_manager);
+  explicit MicrosoftSymbolServerSymbolProvider(
+      const orbit_symbols::SymbolCacheInterface* symbol_cache,
+      orbit_http::DownloadManager* download_manager);
 
   [[nodiscard]] orbit_base::Future<orbit_symbol_provider::SymbolLoadingOutcome> RetrieveSymbols(
       const orbit_symbol_provider::ModuleIdentifier& module_id,
@@ -26,7 +27,7 @@ class MicrosoftSymbolServerSymbolProvider : public orbit_symbol_provider::Symbol
   [[nodiscard]] static std::string GetDownloadUrl(
       const orbit_symbol_provider::ModuleIdentifier& module_id);
 
-  orbit_symbols::SymbolCacheInterface* symbol_cache_;
+  const orbit_symbols::SymbolCacheInterface* symbol_cache_;
   orbit_http::DownloadManager* download_manager_;
   std::shared_ptr<orbit_base::MainThreadExecutor> main_thread_executor_;
 };

--- a/src/RemoteSymbolProvider/include/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.h
+++ b/src/RemoteSymbolProvider/include/RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.h
@@ -16,7 +16,7 @@ namespace orbit_remote_symbol_provider {
 
 class StadiaSymbolStoreSymbolProvider : public orbit_symbol_provider::SymbolProvider {
  public:
-  explicit StadiaSymbolStoreSymbolProvider(orbit_symbols::SymbolCacheInterface* symbol_cache,
+  explicit StadiaSymbolStoreSymbolProvider(const orbit_symbols::SymbolCacheInterface* symbol_cache,
                                            orbit_http::DownloadManager* download_manager,
                                            orbit_ggp::Client* ggp_client);
 
@@ -25,7 +25,7 @@ class StadiaSymbolStoreSymbolProvider : public orbit_symbol_provider::SymbolProv
       orbit_base::StopToken stop_token) const override;
 
  private:
-  orbit_symbols::SymbolCacheInterface* symbol_cache_;
+  const orbit_symbols::SymbolCacheInterface* symbol_cache_;
   orbit_http::DownloadManager* download_manager_;
   orbit_ggp::Client* ggp_client_;
   std::shared_ptr<orbit_base::MainThreadExecutor> main_thread_executor_;


### PR DESCRIPTION
Add Stadia and Microsoft symbol providers to OrbitApp and also add the InitRemoteSymbolProviders method to set them up.

Bug: http://b/245524099