### PR TITLE
Tid translation for target processes running in a separate namespace.

### DIFF
--- a/src/LinuxTracing/KernelTracepoints.h
+++ b/src/LinuxTracing/KernelTracepoints.h
@@ -105,4 +105,10 @@ struct __attribute__((__packed__)) dma_fence_signaled_tracepoint {
   uint32_t seqno;
 };
 
+struct __attribute__((__packed__)) syscall_exit_tracepoint {
+  tracepoint_common common;
+  uint64_t syscall_nr;
+  uint64_t ret;
+};
+
 #endif  // LINUX_TRACING_KERNEL_TRACEPOINTS_H_

--- a/src/LinuxTracing/LinuxTracingUtils.cpp
+++ b/src/LinuxTracing/LinuxTracingUtils.cpp
@@ -28,6 +28,7 @@
 #include "ModuleUtils/ReadLinuxMaps.h"
 #include "ModuleUtils/VirtualAndAbsoluteAddresses.h"
 #include "OrbitBase/ExecuteCommand.h"
+#include "OrbitBase/GetProcessIds.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/SafeStrerror.h"
@@ -331,6 +332,38 @@ std::map<uint64_t, std::string> FindFunctionsThatUprobesCannotInstrumentWithMess
   }
 
   return function_ids_to_error_messages;
+}
+
+absl::flat_hash_map<pid_t, pid_t> RetrieveInitialTidToRootNamespaceTidMapping(pid_t target_pid) {
+  absl::flat_hash_map<pid_t, pid_t> tid_mapping;
+  for (pid_t tid : orbit_base::GetTidsOfProcess(target_pid)) {
+    const std::string status_file_name = absl::StrFormat("/proc/%d/status", tid);
+    auto reading_result = orbit_base::ReadFileToString(status_file_name);
+    if (reading_result.has_error()) {
+      // This means the thread exited before we were able to read the status file. It is fine to
+      // just skip this thread.
+      continue;
+    }
+    const std::vector<std::string> lines =
+        absl::StrSplit(reading_result.value(), '\n', absl::SkipEmpty());
+    for (std::string_view line : lines) {
+      if (!absl::StartsWith(line, "NSpid:")) continue;
+      // The line in the status file looks like this:
+      // NSpid:  pid pid_1 ... pid_n
+      // where pid is the pid in the root namespace, pid_1 is the pid in the first nested namespace
+      // and pid_n is the pid in the innermost namespace.
+      const std::vector<std::string> splits =
+          absl::StrSplit(line, absl::ByAnyChar(": \t"), absl::SkipWhitespace{});
+      uint32_t tid_in_target_process_namespace = 0;
+      if (!absl::SimpleAtoi(splits.back(), &tid_in_target_process_namespace)) {
+        ORBIT_ERROR("Line in %s starting with 'NSpid:' did not end with a pid. Entire line was: %s",
+                    status_file_name, line);
+        break;
+      }
+      tid_mapping[tid_in_target_process_namespace] = tid;
+    }
+  }
+  return tid_mapping;
 }
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LinuxTracingUtils.h
+++ b/src/LinuxTracing/LinuxTracingUtils.h
@@ -80,7 +80,7 @@ inline size_t GetPageSize() {
 // Returns the map of tids in the target process namespace to the corresponding tids in the root
 // namespace.
 [[nodiscard]] absl::flat_hash_map<pid_t, pid_t> RetrieveInitialTidToRootNamespaceTidMapping(
-    pid_t target_pid);
+    pid_t pid_in_root_namespace);
 
 }  // namespace orbit_linux_tracing
 

--- a/src/LinuxTracing/LinuxTracingUtils.h
+++ b/src/LinuxTracing/LinuxTracingUtils.h
@@ -5,6 +5,7 @@
 #ifndef LINUX_TRACING_LINUX_TRACING_UTILS_H_
 #define LINUX_TRACING_LINUX_TRACING_UTILS_H_
 
+#include <absl/container/flat_hash_map.h>
 #include <unistd.h>
 
 #include <ctime>
@@ -75,6 +76,11 @@ inline size_t GetPageSize() {
     const std::vector<orbit_module_utils::LinuxMemoryMapping>& maps,
     const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
     const std::vector<orbit_grpc_protos::InstrumentedFunction>& functions);
+
+// Returns the map of tids in the target process namespace to the corresponding tids in the root
+// namespace.
+[[nodiscard]] absl::flat_hash_map<pid_t, pid_t> RetrieveInitialTidToRootNamespaceTidMapping(
+    pid_t target_pid);
 
 }  // namespace orbit_linux_tracing
 

--- a/src/LinuxTracing/LinuxTracingUtilsTest.cpp
+++ b/src/LinuxTracing/LinuxTracingUtilsTest.cpp
@@ -405,4 +405,13 @@ TEST(FindFunctionsThatUprobesCannotInstrumentWithMessages, ModuleNotInMaps) {
                                "not loaded by the process."));
 }
 
+TEST(RetrieveInitialTidToRootNamespaceTidMapping, TrivialMapFromTestProcess) {
+  const pid_t pid = orbit_base::ToNativeThreadId(orbit_base::GetCurrentProcessId());
+  const auto tid_mappings = RetrieveInitialTidToRootNamespaceTidMapping(pid);
+  EXPECT_FALSE(tid_mappings.empty());
+  for (const auto& tid_mapping : tid_mappings) {
+    EXPECT_EQ(tid_mapping.first, tid_mapping.second);
+  }
+}
+
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -377,6 +377,14 @@ struct SchedSwitchWithStackPerfEventData {
 };
 using SchedSwitchWithStackPerfEvent = TypedPerfEvent<SchedSwitchWithStackPerfEventData>;
 
+struct CloneExitPerfEventData {
+  // The tid of the thread invoking clone (in the root namespace).
+  pid_t tid;
+  // The return value of clone. This is the tid of the new thread (in the target process namespace).
+  pid_t ret_tid;
+};
+using CloneExitPerfEvent = TypedPerfEvent<CloneExitPerfEventData>;
+
 // This struct holds the data we need from any of the possible perf_event_open events that we
 // collect. The top-level fields (`timestamp` and `ordered_in_file_descriptor`) are common to all
 // events, while each of the possible `...PerfEventData`s in the `std::variant` contains the data
@@ -411,7 +419,7 @@ struct PerfEvent {
                TaskRenamePerfEventData, SchedSwitchPerfEventData, SchedWakeupPerfEventData,
                SchedSwitchWithStackPerfEventData, SchedWakeupWithStackPerfEventData,
                AmdgpuCsIoctlPerfEventData, AmdgpuSchedRunJobPerfEventData,
-               DmaFenceSignaledPerfEventData>
+               DmaFenceSignaledPerfEventData, CloneExitPerfEventData>
       data;
 
   void Accept(PerfEventVisitor* visitor) const;

--- a/src/LinuxTracing/PerfEventReaders.h
+++ b/src/LinuxTracing/PerfEventReaders.h
@@ -69,6 +69,9 @@ AmdgpuSchedRunJobPerfEvent ConsumeAmdgpuSchedRunJobPerfEvent(PerfEventRingBuffer
 
 DmaFenceSignaledPerfEvent ConsumeDmaFenceSignaledPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                            const perf_event_header& header);
+
+CloneExitPerfEvent ConsumeCloneExitPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                             const perf_event_header& header);
 }  // namespace orbit_linux_tracing
 
 #endif  // LINUX_TRACING_PERF_EVENT_READERS_H_

--- a/src/LinuxTracing/PerfEventVisitor.h
+++ b/src/LinuxTracing/PerfEventVisitor.h
@@ -53,6 +53,7 @@ class PerfEventVisitor {
                      const DmaFenceSignaledPerfEventData& /*event_data*/) {}
   virtual void Visit(uint64_t /*event_timestamp*/,
                      const GenericTracepointPerfEventData& /*event_data*/) {}
+  virtual void Visit(uint64_t /*event_timestamp*/, const CloneExitPerfEventData& /*event_data*/) {}
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -99,6 +99,8 @@ class TracerImpl : public Tracer {
 
   bool OpenInstrumentedTracepoints(const std::vector<int32_t>& cpus);
 
+  bool OpenCloneExitTracepoints(const std::vector<int32_t>& cpus);
+
   void InitLostAndDiscardedEventVisitor();
 
   [[nodiscard]] uint64_t ProcessForkEventAndReturnTimestamp(const perf_event_header& header,
@@ -135,6 +137,7 @@ class TracerImpl : public Tracer {
   static constexpr uint64_t MMAP_TASK_RING_BUFFER_SIZE_KB = 64;
   static constexpr uint64_t SAMPLING_RING_BUFFER_SIZE_KB = 16 * 1024;
   static constexpr uint64_t THREAD_NAMES_RING_BUFFER_SIZE_KB = 64;
+  static constexpr uint64_t CLONE_EXIT_RING_BUFFER_SIZE_KB = 64;
   static constexpr uint64_t CONTEXT_SWITCHES_AND_THREAD_STATE_RING_BUFFER_SIZE_KB = 2 * 1024;
   static constexpr uint64_t CONTEXT_SWITCHES_AND_THREAD_STATE_WITH_STACKS_RING_BUFFER_SIZE_KB =
       64 * 1024;
@@ -191,6 +194,8 @@ class TracerImpl : public Tracer {
   absl::flat_hash_set<uint64_t> amdgpu_cs_ioctl_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_sched_run_job_ids_;
   absl::flat_hash_set<uint64_t> dma_fence_signaled_ids_;
+  absl::flat_hash_set<uint64_t> sys_exit_clone_ids_;
+  absl::flat_hash_set<uint64_t> sys_exit_clone3_ids_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::TracepointInfo> ids_to_tracepoint_info_;
 
   uint64_t effective_capture_start_timestamp_ns_ = 0;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -81,10 +81,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
     samples_in_uretprobes_counter_ = samples_in_uretprobes_counter;
   }
 
-  void SetInitialTidMapping(const std::vector<std::pair<pid_t, pid_t>>& tid_mappings) {
-    for (const auto& tid_mapping : tid_mappings) {
-      tid_to_root_namespace_tid_[tid_mapping.first] = tid_mapping.second;
-    }
+  void SetInitialTidToRootNamespaceTidMapping(absl::flat_hash_map<pid_t, pid_t>&& tid_mappings) {
+    tid_to_root_namespace_tid_ = tid_mappings;
   }
 
   void Visit(uint64_t event_timestamp, const StackSamplePerfEventData& event_data) override;
@@ -105,8 +103,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   void Visit(uint64_t event_timestamp,
              const UserSpaceFunctionExitPerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const MmapPerfEventData& event_data) override;
-  void Visit(uint64_t event_timestamp, const CloneExitPerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const TaskNewtaskPerfEventData& event_data) override;
+  void Visit(uint64_t event_timestamp, const CloneExitPerfEventData& event_data) override;
 
  private:
   // This struct holds a copy of some stack data collected from the target process.

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -81,6 +81,12 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
     samples_in_uretprobes_counter_ = samples_in_uretprobes_counter;
   }
 
+  void SetInitialTidMapping(const std::vector<std::pair<pid_t, pid_t>>& tid_mappings) {
+    for (const auto& tid_mapping : tid_mappings) {
+      tid_to_root_namespace_tid_[tid_mapping.first] = tid_mapping.second;
+    }
+  }
+
   void Visit(uint64_t event_timestamp, const StackSamplePerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp,
              const SchedWakeupWithStackPerfEventData& event_data) override;
@@ -99,6 +105,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   void Visit(uint64_t event_timestamp,
              const UserSpaceFunctionExitPerfEventData& event_data) override;
   void Visit(uint64_t event_timestamp, const MmapPerfEventData& event_data) override;
+  void Visit(uint64_t event_timestamp, const CloneExitPerfEventData& event_data) override;
+  void Visit(uint64_t event_timestamp, const TaskNewtaskPerfEventData& event_data) override;
 
  private:
   // This struct holds a copy of some stack data collected from the target process.
@@ -146,6 +154,15 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   absl::flat_hash_map<pid_t, absl::flat_hash_map<uint64_t, StackSlice>>
       thread_id_stream_id_to_stack_slices_{};
+
+  // tid_to_root_namespace_tid_ holds a mapping from all tids in the target process namespace to the
+  // corresponding tids in the root namespace.
+  // We obtain the initial state of this mapping at the beginning of the capture via
+  // SetInitialTidMapping. During the capture we observe task_newtask and clone{3} tracepoints to
+  // keep track of new threads (new_task_parent_to_root_namespace_tids_ is required for this
+  // bookkeeping).
+  absl::flat_hash_map<pid_t, pid_t> tid_to_root_namespace_tid_;
+  absl::flat_hash_map<pid_t, pid_t> new_task_parent_to_root_namespace_tids_;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -82,7 +82,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   }
 
   void SetInitialTidToRootNamespaceTidMapping(absl::flat_hash_map<pid_t, pid_t>&& tid_mappings) {
-    tid_to_root_namespace_tid_ = tid_mappings;
+    tid_to_root_namespace_tid_ = std::move(tid_mappings);
   }
 
   void Visit(uint64_t event_timestamp, const StackSamplePerfEventData& event_data) override;
@@ -156,11 +156,11 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   // tid_to_root_namespace_tid_ holds a mapping from all tids in the target process namespace to the
   // corresponding tids in the root namespace.
   // We obtain the initial state of this mapping at the beginning of the capture via
-  // SetInitialTidMapping. During the capture we observe task_newtask and clone{3} tracepoints to
-  // keep track of new threads (new_task_parent_to_root_namespace_tids_ is required for this
-  // bookkeeping).
+  // SetInitialTidToRootNamespaceTidMapping. During the capture we observe task_newtask and clone{3}
+  // tracepoints to keep track of new threads
+  // (new_task_root_namespace_parent_tid_to_root_namespace_tid_ is required for this bookkeeping).
   absl::flat_hash_map<pid_t, pid_t> tid_to_root_namespace_tid_;
-  absl::flat_hash_map<pid_t, pid_t> new_task_parent_to_root_namespace_tids_;
+  absl::flat_hash_map<pid_t, pid_t> new_task_root_namespace_parent_tid_to_root_namespace_tid_;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/UprobesUnwindingVisitorDynamicInstrumentationTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorDynamicInstrumentationTest.cpp
@@ -311,8 +311,8 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
   visitor_.SetInitialTidToRootNamespaceTidMapping(
       {{kPidTargetNamespace, kPidRootNamespace}, {kTidTargetNamespace, kTidRootNamespace}});
 
-  constexpr pid_t kPidUnkown = 44;
-  constexpr pid_t kTidUnkown = 45;
+  constexpr pid_t kPidUnknown = 44;
+  constexpr pid_t kTidUnknown = 45;
 
   constexpr pid_t kTidNewTargetNamespace = 54;
   constexpr pid_t kTidNewRootNamespace = 1054;
@@ -364,33 +364,33 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
 
   {
     UserSpaceFunctionEntryPerfEvent function_entry2{
-        .timestamp = 300,
+        .timestamp = 900,
         .data =
             {
-                .pid = kPidUnkown,
-                .tid = kTidUnkown,
+                .pid = kPidUnknown,
+                .tid = kTidUnknown,
                 .function_id = 1,
                 .sp = 0x30,
                 .return_address = 0x02,
             },
     };
 
-    EXPECT_CALL(return_address_manager_, ProcessFunctionEntry(kTidUnkown, 0x30, 0x02)).Times(0);
+    EXPECT_CALL(return_address_manager_, ProcessFunctionEntry(kTidUnknown, 0x30, 0x02)).Times(0);
     PerfEvent{function_entry2}.Accept(&visitor_);
     Mock::VerifyAndClearExpectations(&return_address_manager_);
   }
 
   {
     UserSpaceFunctionExitPerfEvent function_exit2{
-        .timestamp = 800,
+        .timestamp = 1000,
         .data =
             {
-                .pid = kPidUnkown,
-                .tid = kTidUnkown,
+                .pid = kPidUnknown,
+                .tid = kTidUnknown,
             },
     };
 
-    EXPECT_CALL(return_address_manager_, ProcessFunctionExit(kTidUnkown)).Times(0);
+    EXPECT_CALL(return_address_manager_, ProcessFunctionExit(kTidUnknown)).Times(0);
     EXPECT_CALL(listener_, OnFunctionCall).Times(0);
     PerfEvent{function_exit2}.Accept(&visitor_);
     Mock::VerifyAndClearExpectations(&return_address_manager_);
@@ -399,7 +399,7 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
 
   {
     TaskNewtaskPerfEvent task_newtask{
-        .timestamp = 1000,
+        .timestamp = 1100,
         .data =
             {
                 .new_tid = kTidNewRootNamespace,
@@ -408,7 +408,7 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
     };
     PerfEvent{task_newtask}.Accept(&visitor_);
     CloneExitPerfEvent clone_exit_event{
-        .timestamp = 1001,
+        .timestamp = 1101,
         .data =
             {
                 .tid = kTidRootNamespace,

--- a/src/LinuxTracing/UprobesUnwindingVisitorDynamicInstrumentationTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorDynamicInstrumentationTest.cpp
@@ -48,13 +48,9 @@ class UprobesUnwindingVisitorDynamicInstrumentationTest : public ::testing::Test
 
 TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
        VisitDynamicInstrumentationPerfEventsInVariousCombinationsSendsFunctionCalls) {
-  constexpr pid_t kPidTargetNamespace = 1042;
-  constexpr pid_t kTidTargetNamespace = 1043;
   constexpr pid_t kPid = 42;
   constexpr pid_t kTid = 43;
-  visitor_.SetInitialTidMapping({{kPidTargetNamespace, kPid}, {kTidTargetNamespace, kTid}});
-  constexpr pid_t kPidUnkown = 1044;
-  constexpr pid_t kTidUnkown = 1045;
+  visitor_.SetInitialTidToRootNamespaceTidMapping({{kPid, kPid}, {kTid, kTid}});
   constexpr uint32_t kCpu = 1;
 
   {
@@ -111,8 +107,8 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
         .timestamp = 300,
         .data =
             {
-                .pid = kPidTargetNamespace,
-                .tid = kTidTargetNamespace,
+                .pid = kPid,
+                .tid = kTid,
                 .function_id = 3,
                 .sp = 0x30,
                 .return_address = 0x02,
@@ -121,24 +117,6 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
 
     EXPECT_CALL(return_address_manager_, ProcessFunctionEntry(kTid, 0x30, 0x02)).Times(1);
     PerfEvent{function_entry3}.Accept(&visitor_);
-    Mock::VerifyAndClearExpectations(&return_address_manager_);
-  }
-
-  {
-    UserSpaceFunctionEntryPerfEvent function_entry4{
-        .timestamp = 300,
-        .data =
-            {
-                .pid = kPidUnkown,
-                .tid = kTidUnkown,
-                .function_id = 3,
-                .sp = 0x30,
-                .return_address = 0x02,
-            },
-    };
-
-    EXPECT_CALL(return_address_manager_, ProcessFunctionEntry(0, 0x30, 0x02)).Times(0);
-    PerfEvent{function_entry4}.Accept(&visitor_);
     Mock::VerifyAndClearExpectations(&return_address_manager_);
   }
 
@@ -250,8 +228,8 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
         .timestamp = 800,
         .data =
             {
-                .pid = kPidTargetNamespace,
-                .tid = kTidTargetNamespace,
+                .pid = kPid,
+                .tid = kTid,
             },
     };
 
@@ -269,24 +247,6 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
     EXPECT_EQ(actual_function_call.depth(), 2);
     EXPECT_EQ(actual_function_call.return_value(), 0);
     EXPECT_THAT(actual_function_call.registers(), ElementsAre());
-  }
-
-  {
-    UserSpaceFunctionExitPerfEvent function_exit4{
-        .timestamp = 800,
-        .data =
-            {
-                .pid = kPidUnkown,
-                .tid = kTidUnkown,
-            },
-    };
-
-    EXPECT_CALL(return_address_manager_, ProcessFunctionExit(0)).Times(0);
-    orbit_grpc_protos::FunctionCall actual_function_call;
-    EXPECT_CALL(listener_, OnFunctionCall).Times(0);
-    PerfEvent{function_exit4}.Accept(&visitor_);
-    Mock::VerifyAndClearExpectations(&return_address_manager_);
-    Mock::VerifyAndClearExpectations(&listener_);
   }
 
   {
@@ -336,6 +296,167 @@ TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
     EXPECT_EQ(actual_function_call.function_id(), 1);
     EXPECT_EQ(actual_function_call.duration_ns(), 900);
     EXPECT_EQ(actual_function_call.end_timestamp_ns(), 1000);
+    EXPECT_EQ(actual_function_call.depth(), 0);
+    EXPECT_EQ(actual_function_call.return_value(), 0);
+    EXPECT_THAT(actual_function_call.registers(), ElementsAre());
+  }
+}
+
+TEST_F(UprobesUnwindingVisitorDynamicInstrumentationTest,
+       VisitDynamicInstrumentationPerfEventsWithTidNamespaceTranslation) {
+  constexpr pid_t kPidTargetNamespace = 42;
+  constexpr pid_t kTidTargetNamespace = 43;
+  constexpr pid_t kPidRootNamespace = 1042;
+  constexpr pid_t kTidRootNamespace = 1043;
+  visitor_.SetInitialTidToRootNamespaceTidMapping(
+      {{kPidTargetNamespace, kPidRootNamespace}, {kTidTargetNamespace, kTidRootNamespace}});
+
+  constexpr pid_t kPidUnkown = 44;
+  constexpr pid_t kTidUnkown = 45;
+
+  constexpr pid_t kTidNewTargetNamespace = 54;
+  constexpr pid_t kTidNewRootNamespace = 1054;
+
+  {
+    UserSpaceFunctionEntryPerfEvent function_entry1{
+        .timestamp = 300,
+        .data =
+            {
+                .pid = kPidTargetNamespace,
+                .tid = kTidTargetNamespace,
+                .function_id = 1,
+                .sp = 0x30,
+                .return_address = 0x02,
+            },
+    };
+
+    EXPECT_CALL(return_address_manager_, ProcessFunctionEntry(kTidRootNamespace, 0x30, 0x02))
+        .Times(1);
+    PerfEvent{function_entry1}.Accept(&visitor_);
+    Mock::VerifyAndClearExpectations(&return_address_manager_);
+  }
+
+  {
+    UserSpaceFunctionExitPerfEvent function_exit1{
+        .timestamp = 800,
+        .data =
+            {
+                .pid = kPidTargetNamespace,
+                .tid = kTidTargetNamespace,
+            },
+    };
+
+    EXPECT_CALL(return_address_manager_, ProcessFunctionExit(kTidRootNamespace)).Times(1);
+    orbit_grpc_protos::FunctionCall actual_function_call;
+    EXPECT_CALL(listener_, OnFunctionCall).Times(1).WillOnce(SaveArg<0>(&actual_function_call));
+    PerfEvent{function_exit1}.Accept(&visitor_);
+    Mock::VerifyAndClearExpectations(&return_address_manager_);
+    Mock::VerifyAndClearExpectations(&listener_);
+    EXPECT_EQ(actual_function_call.pid(), kPidRootNamespace);
+    EXPECT_EQ(actual_function_call.tid(), kTidRootNamespace);
+    EXPECT_EQ(actual_function_call.function_id(), 1);
+    EXPECT_EQ(actual_function_call.duration_ns(), 500);
+    EXPECT_EQ(actual_function_call.end_timestamp_ns(), 800);
+    EXPECT_EQ(actual_function_call.depth(), 0);
+    EXPECT_EQ(actual_function_call.return_value(), 0);
+    EXPECT_THAT(actual_function_call.registers(), ElementsAre());
+  }
+
+  {
+    UserSpaceFunctionEntryPerfEvent function_entry2{
+        .timestamp = 300,
+        .data =
+            {
+                .pid = kPidUnkown,
+                .tid = kTidUnkown,
+                .function_id = 1,
+                .sp = 0x30,
+                .return_address = 0x02,
+            },
+    };
+
+    EXPECT_CALL(return_address_manager_, ProcessFunctionEntry(kTidUnkown, 0x30, 0x02)).Times(0);
+    PerfEvent{function_entry2}.Accept(&visitor_);
+    Mock::VerifyAndClearExpectations(&return_address_manager_);
+  }
+
+  {
+    UserSpaceFunctionExitPerfEvent function_exit2{
+        .timestamp = 800,
+        .data =
+            {
+                .pid = kPidUnkown,
+                .tid = kTidUnkown,
+            },
+    };
+
+    EXPECT_CALL(return_address_manager_, ProcessFunctionExit(kTidUnkown)).Times(0);
+    EXPECT_CALL(listener_, OnFunctionCall).Times(0);
+    PerfEvent{function_exit2}.Accept(&visitor_);
+    Mock::VerifyAndClearExpectations(&return_address_manager_);
+    Mock::VerifyAndClearExpectations(&listener_);
+  }
+
+  {
+    TaskNewtaskPerfEvent task_newtask{
+        .timestamp = 1000,
+        .data =
+            {
+                .new_tid = kTidNewRootNamespace,
+                .was_created_by_tid = kTidRootNamespace,
+            },
+    };
+    PerfEvent{task_newtask}.Accept(&visitor_);
+    CloneExitPerfEvent clone_exit_event{
+        .timestamp = 1001,
+        .data =
+            {
+                .tid = kTidRootNamespace,
+                .ret_tid = kTidNewTargetNamespace,
+            },
+    };
+    PerfEvent{clone_exit_event}.Accept(&visitor_);
+  }
+
+  {
+    UserSpaceFunctionEntryPerfEvent function_entry3{
+        .timestamp = 1300,
+        .data =
+            {
+                .pid = kPidTargetNamespace,
+                .tid = kTidNewTargetNamespace,
+                .function_id = 3,
+                .sp = 0x30,
+                .return_address = 0x02,
+            },
+    };
+    EXPECT_CALL(return_address_manager_, ProcessFunctionEntry(kTidNewRootNamespace, 0x30, 0x02))
+        .Times(1);
+    PerfEvent{function_entry3}.Accept(&visitor_);
+    Mock::VerifyAndClearExpectations(&return_address_manager_);
+  }
+
+  {
+    UserSpaceFunctionExitPerfEvent function_exit3{
+        .timestamp = 1800,
+        .data =
+            {
+                .pid = kPidTargetNamespace,
+                .tid = kTidNewTargetNamespace,
+            },
+    };
+
+    EXPECT_CALL(return_address_manager_, ProcessFunctionExit(kTidNewRootNamespace)).Times(1);
+    orbit_grpc_protos::FunctionCall actual_function_call;
+    EXPECT_CALL(listener_, OnFunctionCall).Times(1).WillOnce(SaveArg<0>(&actual_function_call));
+    PerfEvent{function_exit3}.Accept(&visitor_);
+    Mock::VerifyAndClearExpectations(&return_address_manager_);
+    Mock::VerifyAndClearExpectations(&listener_);
+    EXPECT_EQ(actual_function_call.pid(), kPidRootNamespace);
+    EXPECT_EQ(actual_function_call.tid(), kTidNewRootNamespace);
+    EXPECT_EQ(actual_function_call.function_id(), 3);
+    EXPECT_EQ(actual_function_call.duration_ns(), 500);
+    EXPECT_EQ(actual_function_call.end_timestamp_ns(), 1800);
     EXPECT_EQ(actual_function_call.depth(), 0);
     EXPECT_EQ(actual_function_call.return_value(), 0);
     EXPECT_THAT(actual_function_call.registers(), ElementsAre());


### PR DESCRIPTION
If the target process is running in a separate namespace thread ids (tids) observed from within the target process are different from the tids observed in the root namespace.

This is a problem for events we obtain from the target process. These are userspace instrumentation (usi), manual instrumentation and the Vulkan layer. This PR is only about usi.

Usi events are obtained for the game, received in
ProducerEventProcessorHijackingFunctionEntryExitForLinuxTracing and piped back into the LinuxTracing code. Finally they are processed by UprobesUnwindingVisitor where they are used to emit FunctionCall's and to help with the call stack handling.

The UprobesUnwindingVisitor needs to translate the tids from inside the UserSpaceFunction{Entry,Exit}PerfEventData events into root namespace tids before handling them.

For that purpose we have the UprobesUnwindingVisitor observe the clone{3} exit tracepoints, the task_newtask tracepoint. By that we are able to keep track of new threads and the tids. Additionally, at the beginning of the capture, we also send the initial state of the tid mapping.