### PR TITLE
Integrate symbol providers to OrbitApp

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1817,11 +1817,6 @@ OrbitApp::RetrieveModuleFromRemote(const std::string& module_file_path,
                                    orbit_base::StopToken stop_token) {
   ORBIT_SCOPE_FUNCTION;
 
-  const auto it = symbol_files_currently_downloading_.find(module_file_path);
-  if (it != symbol_files_currently_downloading_.end()) {
-    return it->second.future;
-  }
-
   orbit_base::Future<ErrorMessageOr<NotFoundOr<std::filesystem::path>>> check_file_on_remote =
       thread_pool_->Schedule(
           [process_manager = GetProcessManager(),
@@ -2037,6 +2032,11 @@ orbit_base::Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::
                 });
 
   if (download_disabled_modules_.contains(module_id.file_path)) return retrieve_from_local_future;
+
+  if (const auto it = symbol_files_currently_downloading_.find(module_id.file_path);
+      it != symbol_files_currently_downloading_.end()) {
+    return it->second.future;
+  }
 
   orbit_base::StopSource stop_source;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -590,7 +590,7 @@ class OrbitApp final : public DataViewFactory,
       const orbit_preset_file::PresetFile& preset_file);
 
   [[nodiscard]] orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
-  RetrieveModuleFromRemote(const std::string& module_file_path);
+  RetrieveModuleFromRemote(const std::string& module_file_path, orbit_base::StopToken stop_token);
 
   void SelectFunctionsFromHashes(const orbit_client_data::ModuleData* module,
                                  absl::Span<const uint64_t> function_hashes);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -640,6 +640,10 @@ class OrbitApp final : public DataViewFactory,
   // TODO(b/243520787) The following is temporary. The SymbolProvider related logic SHOULD be moved
   // to the ProxySymbolProvider as planned in our symbol refactoring discussion in b/243520787.
   void InitRemoteSymbolProviders();
+  // TODO(b/243520787) Rename existing `RetrieveModuleFromRemote` as `RetrieveModuleFromInstance`
+  // and rename this `RetrieveModuleViaDownload` to `RetrieveModuleFromRemote`.
+  [[nodiscard]] orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
+  RetrieveModuleViaDownload(const orbit_symbol_provider::ModuleIdentifier& module_id);
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<orbit_client_data::CaptureData::DataSource> data_source_{


### PR DESCRIPTION
This integrate symbol providers to OrbitApp.

We search symbols from different source following the order of
locally, instance, stadia symbol store and microsoft symbol server.
For each symbol source, we will:
- first check whether we will skip searching in this symbol source or not;
if seach in this symbol source
- then check whether we already get the result or canceled from the previous source,
if yes then return previous result; otherwise
- search for symbols in the current symbol source.

Now the Stadia and Microsoft symbol stores are enable / disabled via the
--symbol_store_support flag. We will add UI changes later.

Bug: http://b/245524099
Test: tested manually (start orbit with the `--symbol_store_support` flag, see the symbols get from stadia symbol store in the log). 
Screenshot: http://screenshot/3hhbifQ8MRJtujg

Also if we clear cache and load a capture file, we will able to see symbols downloaded from symbol store.