### PR TITLE
Pass thread state slice's callstack down to the client

### DIFF
--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -119,7 +119,7 @@ class CaptureEventProcessorForListener : public CaptureEventProcessor {
   std::optional<std::filesystem::path> file_path_;
   absl::flat_hash_set<uint64_t> frame_track_function_ids_;
 
-  absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;
+  absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool_;
   absl::flat_hash_map<uint64_t, std::string> string_intern_pool_;
   CaptureListener* capture_listener_ = nullptr;
 
@@ -291,17 +291,17 @@ void CaptureEventProcessorForListener::ProcessSchedulingSlice(
 
 void CaptureEventProcessorForListener::ProcessInternedCallstack(
     InternedCallstack interned_callstack) {
-  if (callstack_intern_pool.contains(interned_callstack.key())) {
+  if (callstack_intern_pool_.contains(interned_callstack.key())) {
     ORBIT_ERROR("Overwriting InternedCallstack with key %llu", interned_callstack.key());
   }
-  callstack_intern_pool.emplace(interned_callstack.key(),
-                                std::move(*interned_callstack.mutable_intern()));
+  callstack_intern_pool_.emplace(interned_callstack.key(),
+                                 std::move(*interned_callstack.mutable_intern()));
 }
 
 void CaptureEventProcessorForListener::ProcessCallstackSample(
     const CallstackSample& callstack_sample) {
   uint64_t callstack_id = callstack_sample.callstack_id();
-  Callstack callstack = callstack_intern_pool[callstack_id];
+  Callstack callstack = callstack_intern_pool_[callstack_id];
 
   SendCallstackToListenerIfNecessary(callstack_id, callstack);
 
@@ -602,7 +602,9 @@ void CaptureEventProcessorForListener::ProcessThreadStateSlice(
   if (thread_state_slice.switch_out_or_wakeup_callstack_status() ==
       ThreadStateSlice::kCallstackSet) {
     uint64_t callstack_id = thread_state_slice.switch_out_or_wakeup_callstack_id();
-    Callstack callstack = callstack_intern_pool.at(callstack_id);
+    auto callstack_it = callstack_intern_pool_.find(callstack_id);
+    ORBIT_CHECK(callstack_it != callstack_intern_pool_.end());
+    const Callstack& callstack = callstack_it->second;
 
     SendCallstackToListenerIfNecessary(callstack_id, callstack);
   }

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -583,7 +583,7 @@ void CaptureEventProcessorForListener::ProcessThreadStateSlice(
     const ThreadStateSlice& thread_state_slice) {
   ORBIT_CHECK(thread_state_slice.switch_out_or_wakeup_callstack_status() !=
               ThreadStateSlice::kWaitingForCallstack);
-  std::optional<uint64_t> triggering_callstack_id =
+  std::optional<uint64_t> switch_out_or_wakeup_callstack_id =
       (thread_state_slice.switch_out_or_wakeup_callstack_status() ==
        ThreadStateSlice::kCallstackSet)
           ? std::make_optional<uint64_t>(thread_state_slice.switch_out_or_wakeup_callstack_id())
@@ -596,7 +596,7 @@ void CaptureEventProcessorForListener::ProcessThreadStateSlice(
       FromGrpcWakeupReasonToInfoWakeupReason(thread_state_slice.wakeup_reason()),
       thread_state_slice.wakeup_tid(),
       thread_state_slice.wakeup_pid(),
-      triggering_callstack_id,
+      switch_out_or_wakeup_callstack_id,
   };
 
   if (thread_state_slice.switch_out_or_wakeup_callstack_status() ==

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -1103,7 +1103,7 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginJobRecorded) {
                            kTimelineKey, actual_marker_key);
 }
 
-TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {
+TEST(CaptureEventProcessor, CanHandleThreadStateSlicesWithoutCallstacks) {
   MockCaptureListener listener;
   auto event_processor =
       CaptureEventProcessor::CreateForCaptureListener(&listener, std::filesystem::path{}, {});
@@ -1115,6 +1115,9 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {
   running_thread_state_slice->set_pid(14);
   running_thread_state_slice->set_tid(24);
   running_thread_state_slice->set_thread_state(ThreadStateSlice::kRunning);
+  running_thread_state_slice->set_switch_out_or_wakeup_callstack_status(
+      ThreadStateSlice::kNoCallstack);
+  running_thread_state_slice->set_switch_out_or_wakeup_callstack_id(0);
 
   ClientCaptureEvent runnable_event;
   ThreadStateSlice* runnable_thread_state_slice = runnable_event.mutable_thread_state_slice();
@@ -1123,6 +1126,9 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {
   runnable_thread_state_slice->set_pid(14);
   runnable_thread_state_slice->set_tid(24);
   runnable_thread_state_slice->set_thread_state(ThreadStateSlice::kRunnable);
+  runnable_thread_state_slice->set_switch_out_or_wakeup_callstack_status(
+      ThreadStateSlice::kNoCallstack);
+  runnable_thread_state_slice->set_switch_out_or_wakeup_callstack_id(0);
 
   ClientCaptureEvent dead_event;
   ThreadStateSlice* dead_thread_state_slice = dead_event.mutable_thread_state_slice();
@@ -1131,6 +1137,9 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {
   dead_thread_state_slice->set_pid(14);
   dead_thread_state_slice->set_tid(24);
   dead_thread_state_slice->set_thread_state(ThreadStateSlice::kDead);
+  dead_thread_state_slice->set_switch_out_or_wakeup_callstack_status(
+      ThreadStateSlice::kNoCallstack);
+  running_thread_state_slice->set_switch_out_or_wakeup_callstack_id(0);
 
   std::optional<ThreadStateSliceInfo> actual_running_thread_state_slice_info{};
   std::optional<ThreadStateSliceInfo> actual_runnable_thread_state_slice_info{};
@@ -1153,6 +1162,7 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {
             running_thread_state_slice->end_timestamp_ns());
   EXPECT_EQ(actual_running_thread_state_slice_info->tid(), running_thread_state_slice->tid());
   EXPECT_EQ(actual_running_thread_state_slice_info->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(actual_running_thread_state_slice_info->triggering_callstack_id(), std::nullopt);
 
   ASSERT_TRUE(actual_runnable_thread_state_slice_info.has_value());
   EXPECT_EQ(
@@ -1162,6 +1172,7 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {
             runnable_thread_state_slice->end_timestamp_ns());
   EXPECT_EQ(actual_runnable_thread_state_slice_info->tid(), runnable_thread_state_slice->tid());
   EXPECT_EQ(actual_runnable_thread_state_slice_info->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(actual_runnable_thread_state_slice_info->triggering_callstack_id(), std::nullopt);
 
   ASSERT_TRUE(actual_dead_thread_state_slice_info.has_value());
   EXPECT_EQ(actual_dead_thread_state_slice_info->begin_timestamp_ns(),
@@ -1170,6 +1181,110 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {
             dead_thread_state_slice->end_timestamp_ns());
   EXPECT_EQ(actual_dead_thread_state_slice_info->tid(), dead_thread_state_slice->tid());
   EXPECT_EQ(actual_dead_thread_state_slice_info->thread_state(), ThreadStateSlice::kDead);
+  EXPECT_EQ(actual_dead_thread_state_slice_info->triggering_callstack_id(), std::nullopt);
+}
+
+TEST(CaptureEventProcessor, DeathOnThreadStateSlicesWithUnknownCallstack) {
+  MockCaptureListener listener;
+  auto event_processor =
+      CaptureEventProcessor::CreateForCaptureListener(&listener, std::filesystem::path{}, {});
+
+  constexpr uint64_t kCallstackId = 24;
+
+  ClientCaptureEvent thread_state_slice_without_known_callstack_id_event;
+  ThreadStateSlice* thread_state_slice_without_known_callstack_id =
+      thread_state_slice_without_known_callstack_id_event.mutable_thread_state_slice();
+  thread_state_slice_without_known_callstack_id->set_duration_ns(100);
+  thread_state_slice_without_known_callstack_id->set_end_timestamp_ns(200);
+  thread_state_slice_without_known_callstack_id->set_pid(14);
+  thread_state_slice_without_known_callstack_id->set_tid(24);
+  thread_state_slice_without_known_callstack_id->set_thread_state(ThreadStateSlice::kRunnable);
+  thread_state_slice_without_known_callstack_id->set_switch_out_or_wakeup_callstack_status(
+      ThreadStateSlice::kCallstackSet);
+  thread_state_slice_without_known_callstack_id->set_switch_out_or_wakeup_callstack_id(
+      kCallstackId);
+
+  ClientCaptureEvent thread_state_slice_waiting_for_callstack_event;
+  ThreadStateSlice* thread_state_slice_waiting_for_callstack =
+      thread_state_slice_waiting_for_callstack_event.mutable_thread_state_slice();
+  thread_state_slice_waiting_for_callstack->set_duration_ns(100);
+  thread_state_slice_waiting_for_callstack->set_end_timestamp_ns(200);
+  thread_state_slice_waiting_for_callstack->set_pid(14);
+  thread_state_slice_waiting_for_callstack->set_tid(24);
+  thread_state_slice_waiting_for_callstack->set_thread_state(ThreadStateSlice::kInterruptibleSleep);
+  thread_state_slice_waiting_for_callstack->set_switch_out_or_wakeup_callstack_status(
+      ThreadStateSlice::kWaitingForCallstack);
+  thread_state_slice_waiting_for_callstack->set_switch_out_or_wakeup_callstack_id(0);
+
+  EXPECT_CALL(listener, OnUniqueCallstack).Times(0);
+  EXPECT_CALL(listener, OnThreadStateSlice).Times(0);
+
+  EXPECT_DEATH(event_processor->ProcessEvent(thread_state_slice_without_known_callstack_id_event),
+               "");
+  EXPECT_DEATH(event_processor->ProcessEvent(thread_state_slice_waiting_for_callstack_event), "");
+}
+
+TEST(CaptureEventProcessor, CanHandleThreadStateSlicesWithCallstacks) {
+  MockCaptureListener listener;
+  auto event_processor =
+      CaptureEventProcessor::CreateForCaptureListener(&listener, std::filesystem::path{}, {});
+
+  constexpr uint64_t kCallstackId = 24;
+  constexpr uint64_t kFrame1 = 1;
+  constexpr uint64_t kFrame2 = 2;
+  constexpr uint64_t kFrame3 = 3;
+
+  ClientCaptureEvent interned_callstack_event;
+  InternedCallstack* interned_callstack = interned_callstack_event.mutable_interned_callstack();
+  interned_callstack->set_key(kCallstackId);
+  interned_callstack->mutable_intern()->add_pcs(kFrame1);
+  interned_callstack->mutable_intern()->add_pcs(kFrame2);
+  interned_callstack->mutable_intern()->add_pcs(kFrame3);
+  interned_callstack->mutable_intern()->set_type(orbit_grpc_protos::Callstack::kComplete);
+
+  ClientCaptureEvent runnable_event;
+  ThreadStateSlice* runnable_thread_state_slice = runnable_event.mutable_thread_state_slice();
+  runnable_thread_state_slice->set_duration_ns(100);
+  runnable_thread_state_slice->set_end_timestamp_ns(200);
+  runnable_thread_state_slice->set_pid(14);
+  runnable_thread_state_slice->set_tid(24);
+  runnable_thread_state_slice->set_thread_state(ThreadStateSlice::kRunnable);
+  runnable_thread_state_slice->set_switch_out_or_wakeup_callstack_status(
+      ThreadStateSlice::kCallstackSet);
+  runnable_thread_state_slice->set_switch_out_or_wakeup_callstack_id(kCallstackId);
+
+  std::optional<uint64_t> actual_callstack_id;
+  std::optional<CallstackInfo> actual_callstack;
+  EXPECT_CALL(listener, OnUniqueCallstack)
+      .Times(1)
+      .WillOnce(DoAll(SaveArg<0>(&actual_callstack_id), SaveArg<1>(&actual_callstack)));
+
+  std::optional<ThreadStateSliceInfo> actual_runnable_thread_state_slice_info{};
+  EXPECT_CALL(listener, OnThreadStateSlice)
+      .Times(1)
+      .WillOnce(SaveArg<0>(&actual_runnable_thread_state_slice_info));
+
+  event_processor->ProcessEvent(interned_callstack_event);
+  event_processor->ProcessEvent(runnable_event);
+
+  ASSERT_TRUE(actual_callstack_id.has_value());
+  ASSERT_TRUE(actual_callstack.has_value());
+  EXPECT_EQ(actual_callstack_id.value(), kCallstackId);
+  EXPECT_EQ(actual_callstack->type(), orbit_client_data::CallstackType::kComplete);
+  EXPECT_EQ(actual_callstack->frames().size(), 3);
+  EXPECT_EQ(actual_callstack->frames()[0], kFrame1);
+  EXPECT_EQ(actual_callstack->frames()[1], kFrame2);
+  EXPECT_EQ(actual_callstack->frames()[2], kFrame3);
+
+  ASSERT_TRUE(actual_runnable_thread_state_slice_info.has_value());
+  EXPECT_EQ(
+      actual_runnable_thread_state_slice_info->begin_timestamp_ns(),
+      runnable_thread_state_slice->end_timestamp_ns() - runnable_thread_state_slice->duration_ns());
+  EXPECT_EQ(actual_runnable_thread_state_slice_info->end_timestamp_ns(),
+            runnable_thread_state_slice->end_timestamp_ns());
+  EXPECT_EQ(actual_runnable_thread_state_slice_info->tid(), runnable_thread_state_slice->tid());
+  EXPECT_EQ(actual_runnable_thread_state_slice_info->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(actual_runnable_thread_state_slice_info->triggering_callstack_id(), kCallstackId);
 }
 
 TEST(CaptureEventProcessor, CanHandleWarningEvents) {

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -1162,7 +1162,8 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlicesWithoutCallstacks) {
             running_thread_state_slice->end_timestamp_ns());
   EXPECT_EQ(actual_running_thread_state_slice_info->tid(), running_thread_state_slice->tid());
   EXPECT_EQ(actual_running_thread_state_slice_info->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(actual_running_thread_state_slice_info->triggering_callstack_id(), std::nullopt);
+  EXPECT_EQ(actual_running_thread_state_slice_info->switch_out_or_wakeup_callstack_id(),
+            std::nullopt);
 
   ASSERT_TRUE(actual_runnable_thread_state_slice_info.has_value());
   EXPECT_EQ(
@@ -1172,7 +1173,8 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlicesWithoutCallstacks) {
             runnable_thread_state_slice->end_timestamp_ns());
   EXPECT_EQ(actual_runnable_thread_state_slice_info->tid(), runnable_thread_state_slice->tid());
   EXPECT_EQ(actual_runnable_thread_state_slice_info->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(actual_runnable_thread_state_slice_info->triggering_callstack_id(), std::nullopt);
+  EXPECT_EQ(actual_runnable_thread_state_slice_info->switch_out_or_wakeup_callstack_id(),
+            std::nullopt);
 
   ASSERT_TRUE(actual_dead_thread_state_slice_info.has_value());
   EXPECT_EQ(actual_dead_thread_state_slice_info->begin_timestamp_ns(),
@@ -1181,7 +1183,7 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlicesWithoutCallstacks) {
             dead_thread_state_slice->end_timestamp_ns());
   EXPECT_EQ(actual_dead_thread_state_slice_info->tid(), dead_thread_state_slice->tid());
   EXPECT_EQ(actual_dead_thread_state_slice_info->thread_state(), ThreadStateSlice::kDead);
-  EXPECT_EQ(actual_dead_thread_state_slice_info->triggering_callstack_id(), std::nullopt);
+  EXPECT_EQ(actual_dead_thread_state_slice_info->switch_out_or_wakeup_callstack_id(), std::nullopt);
 }
 
 TEST(CaptureEventProcessor, DeathOnThreadStateSlicesWithUnknownCallstack) {
@@ -1242,8 +1244,9 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlicesWithCallstacks) {
   interned_callstack->mutable_intern()->add_pcs(kFrame3);
   interned_callstack->mutable_intern()->set_type(orbit_grpc_protos::Callstack::kComplete);
 
-  ClientCaptureEvent runnable_event;
-  ThreadStateSlice* runnable_thread_state_slice = runnable_event.mutable_thread_state_slice();
+  ClientCaptureEvent runnable_thread_state_slice_event;
+  ThreadStateSlice* runnable_thread_state_slice =
+      runnable_thread_state_slice_event.mutable_thread_state_slice();
   runnable_thread_state_slice->set_duration_ns(100);
   runnable_thread_state_slice->set_end_timestamp_ns(200);
   runnable_thread_state_slice->set_pid(14);
@@ -1265,7 +1268,7 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlicesWithCallstacks) {
       .WillOnce(SaveArg<0>(&actual_runnable_thread_state_slice_info));
 
   event_processor->ProcessEvent(interned_callstack_event);
-  event_processor->ProcessEvent(runnable_event);
+  event_processor->ProcessEvent(runnable_thread_state_slice_event);
 
   ASSERT_TRUE(actual_callstack_id.has_value());
   ASSERT_TRUE(actual_callstack.has_value());
@@ -1284,7 +1287,8 @@ TEST(CaptureEventProcessor, CanHandleThreadStateSlicesWithCallstacks) {
             runnable_thread_state_slice->end_timestamp_ns());
   EXPECT_EQ(actual_runnable_thread_state_slice_info->tid(), runnable_thread_state_slice->tid());
   EXPECT_EQ(actual_runnable_thread_state_slice_info->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(actual_runnable_thread_state_slice_info->triggering_callstack_id(), kCallstackId);
+  EXPECT_EQ(actual_runnable_thread_state_slice_info->switch_out_or_wakeup_callstack_id(),
+            kCallstackId);
 }
 
 TEST(CaptureEventProcessor, CanHandleWarningEvents) {

--- a/src/ClientData/CaptureDataTest.cpp
+++ b/src/ClientData/CaptureDataTest.cpp
@@ -62,23 +62,42 @@ constexpr uint64_t kEnTimestamp3 = 200;
 constexpr uint32_t kWakeupTid = 4200;
 constexpr uint32_t kWakeupPid = 420;
 constexpr uint32_t kInvalidPidAndTid = 0;
+constexpr std::optional<uint64_t> kNoCallstackId = std::nullopt;
+constexpr uint64_t kCallstackId1 = 24;
+constexpr uint64_t kCallstackId3 = 25;
 
-const ThreadStateSliceInfo kSlice1{
-    kFirstTid,        orbit_grpc_protos::ThreadStateSlice::kInterruptibleSleep, kStTimestamp1,
-    kEnTimestamp1,    ThreadStateSliceInfo::WakeupReason::kNotApplicable,       kInvalidPidAndTid,
-    kInvalidPidAndTid};
-const ThreadStateSliceInfo kSlice2{
-    kFirstTid,     orbit_grpc_protos::ThreadStateSlice::kRunnable, kStTimestamp2,
-    kEnTimestamp2, ThreadStateSliceInfo::WakeupReason::kUnblocked, kWakeupTid,
-    kWakeupPid};
-const ThreadStateSliceInfo kSlice3{
-    kFirstTid,        orbit_grpc_protos::ThreadStateSlice::kRunning,      kStTimestamp3,
-    kEnTimestamp3,    ThreadStateSliceInfo::WakeupReason::kNotApplicable, kInvalidPidAndTid,
-    kInvalidPidAndTid};
-const ThreadStateSliceInfo kSlice4{
-    kSecondTid,       orbit_grpc_protos::ThreadStateSlice::kInterruptibleSleep, kStTimestamp1,
-    kEnTimestamp1,    ThreadStateSliceInfo::WakeupReason::kNotApplicable,       kInvalidPidAndTid,
-    kInvalidPidAndTid};
+const ThreadStateSliceInfo kSlice1{kFirstTid,
+                                   orbit_grpc_protos::ThreadStateSlice::kInterruptibleSleep,
+                                   kStTimestamp1,
+                                   kEnTimestamp1,
+                                   ThreadStateSliceInfo::WakeupReason::kNotApplicable,
+                                   kInvalidPidAndTid,
+                                   kInvalidPidAndTid,
+                                   kNoCallstackId};
+const ThreadStateSliceInfo kSlice2{kFirstTid,
+                                   orbit_grpc_protos::ThreadStateSlice::kRunnable,
+                                   kStTimestamp2,
+                                   kEnTimestamp2,
+                                   ThreadStateSliceInfo::WakeupReason::kUnblocked,
+                                   kWakeupTid,
+                                   kWakeupPid,
+                                   kCallstackId1};
+const ThreadStateSliceInfo kSlice3{kFirstTid,
+                                   orbit_grpc_protos::ThreadStateSlice::kRunning,
+                                   kStTimestamp3,
+                                   kEnTimestamp3,
+                                   ThreadStateSliceInfo::WakeupReason::kNotApplicable,
+                                   kInvalidPidAndTid,
+                                   kInvalidPidAndTid,
+                                   kNoCallstackId};
+const ThreadStateSliceInfo kSlice4{kSecondTid,
+                                   orbit_grpc_protos::ThreadStateSlice::kInterruptibleSleep,
+                                   kStTimestamp1,
+                                   kEnTimestamp1,
+                                   ThreadStateSliceInfo::WakeupReason::kNotApplicable,
+                                   kInvalidPidAndTid,
+                                   kInvalidPidAndTid,
+                                   kCallstackId3};
 
 static const std::array<uint64_t, kTimerCount> kDurations = [] {
   std::array<uint64_t, kTimerCount> result;

--- a/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
+++ b/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
@@ -22,21 +22,25 @@ class ThreadStateSliceInfo {
                                 orbit_grpc_protos::ThreadStateSlice::ThreadState thread_state,
                                 uint64_t begin_timestamp_ns, uint64_t end_timestamp_ns,
                                 WakeupReason wakeup_reason, uint32_t wakeup_tid,
-                                uint32_t wakeup_pid)
+                                uint32_t wakeup_pid,
+                                std::optional<uint64_t> triggering_callstack_id)
       : tid_{tid},
         thread_state_{thread_state},
         begin_timestamp_ns_{begin_timestamp_ns},
         end_timestamp_ns_{end_timestamp_ns},
         wakeup_reason_{wakeup_reason},
         wakeup_tid_(wakeup_tid),
-        wakeup_pid_{wakeup_pid} {}
+        wakeup_pid_{wakeup_pid},
+        triggering_callstack_id_{triggering_callstack_id} {}
 
   [[nodiscard]] friend bool operator==(const ThreadStateSliceInfo& lhs,
                                        const ThreadStateSliceInfo& rhs) {
     return std::tie(lhs.tid_, lhs.thread_state_, lhs.begin_timestamp_ns_, lhs.end_timestamp_ns_,
-                    lhs.wakeup_tid_, lhs.wakeup_pid_, lhs.wakeup_reason_) ==
+                    lhs.wakeup_tid_, lhs.wakeup_pid_, lhs.wakeup_reason_,
+                    lhs.triggering_callstack_id_) ==
            std::tie(rhs.tid_, rhs.thread_state_, rhs.begin_timestamp_ns_, rhs.end_timestamp_ns_,
-                    rhs.wakeup_tid_, rhs.wakeup_pid_, rhs.wakeup_reason_);
+                    rhs.wakeup_tid_, rhs.wakeup_pid_, rhs.wakeup_reason_,
+                    rhs.triggering_callstack_id_);
   }
   [[nodiscard]] friend bool operator!=(const ThreadStateSliceInfo& lhs,
                                        const ThreadStateSliceInfo& rhs) {
@@ -52,6 +56,9 @@ class ThreadStateSliceInfo {
   }
   [[nodiscard]] uint64_t begin_timestamp_ns() const { return begin_timestamp_ns_; }
   [[nodiscard]] uint64_t end_timestamp_ns() const { return end_timestamp_ns_; }
+  [[nodiscard]] std::optional<uint64_t> triggering_callstack_id() const {
+    return triggering_callstack_id_;
+  }
 
  private:
   // pid is absent as we don't yet get that information from the service.
@@ -62,6 +69,7 @@ class ThreadStateSliceInfo {
   WakeupReason wakeup_reason_;
   uint32_t wakeup_tid_;
   uint32_t wakeup_pid_;
+  std::optional<uint64_t> triggering_callstack_id_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
+++ b/src/ClientData/include/ClientData/ThreadStateSliceInfo.h
@@ -23,7 +23,7 @@ class ThreadStateSliceInfo {
                                 uint64_t begin_timestamp_ns, uint64_t end_timestamp_ns,
                                 WakeupReason wakeup_reason, uint32_t wakeup_tid,
                                 uint32_t wakeup_pid,
-                                std::optional<uint64_t> triggering_callstack_id)
+                                std::optional<uint64_t> switch_out_or_wakeup_callstack_id)
       : tid_{tid},
         thread_state_{thread_state},
         begin_timestamp_ns_{begin_timestamp_ns},
@@ -31,16 +31,16 @@ class ThreadStateSliceInfo {
         wakeup_reason_{wakeup_reason},
         wakeup_tid_(wakeup_tid),
         wakeup_pid_{wakeup_pid},
-        triggering_callstack_id_{triggering_callstack_id} {}
+        switch_out_or_wakeup_callstack_id_{switch_out_or_wakeup_callstack_id} {}
 
   [[nodiscard]] friend bool operator==(const ThreadStateSliceInfo& lhs,
                                        const ThreadStateSliceInfo& rhs) {
     return std::tie(lhs.tid_, lhs.thread_state_, lhs.begin_timestamp_ns_, lhs.end_timestamp_ns_,
                     lhs.wakeup_tid_, lhs.wakeup_pid_, lhs.wakeup_reason_,
-                    lhs.triggering_callstack_id_) ==
+                    lhs.switch_out_or_wakeup_callstack_id_) ==
            std::tie(rhs.tid_, rhs.thread_state_, rhs.begin_timestamp_ns_, rhs.end_timestamp_ns_,
                     rhs.wakeup_tid_, rhs.wakeup_pid_, rhs.wakeup_reason_,
-                    rhs.triggering_callstack_id_);
+                    rhs.switch_out_or_wakeup_callstack_id_);
   }
   [[nodiscard]] friend bool operator!=(const ThreadStateSliceInfo& lhs,
                                        const ThreadStateSliceInfo& rhs) {
@@ -56,8 +56,8 @@ class ThreadStateSliceInfo {
   }
   [[nodiscard]] uint64_t begin_timestamp_ns() const { return begin_timestamp_ns_; }
   [[nodiscard]] uint64_t end_timestamp_ns() const { return end_timestamp_ns_; }
-  [[nodiscard]] std::optional<uint64_t> triggering_callstack_id() const {
-    return triggering_callstack_id_;
+  [[nodiscard]] std::optional<uint64_t> switch_out_or_wakeup_callstack_id() const {
+    return switch_out_or_wakeup_callstack_id_;
   }
 
  private:
@@ -69,7 +69,7 @@ class ThreadStateSliceInfo {
   WakeupReason wakeup_reason_;
   uint32_t wakeup_tid_;
   uint32_t wakeup_pid_;
-  std::optional<uint64_t> triggering_callstack_id_;
+  std::optional<uint64_t> switch_out_or_wakeup_callstack_id_;
 };
 
 }  // namespace orbit_client_data


### PR DESCRIPTION
For CaptureClientEvents with thread state slices that have a callstack id associated with it, we are now storing the callstack id in the ThreadStateSliceInfo.

We are also using the same de-duplication of the callstacks on the client that we are using for callstack events.

Test: Unit test
Bug: http://b/235554760