### PR TITLE
Use StructuredDebugDirectorySymbolProvider on remote (#4193)

### DIFF
--- a/src/ProcessService/BUILD
+++ b/src/ProcessService/BUILD
@@ -22,6 +22,7 @@ orbit_cc_library(
         "//src/ModuleUtils",
         "//src/ObjectUtils",
         "//src/OrbitBase",
+        "//src/SymbolProvider",
         "//src/Symbols",
         "@com_github_grpc_grpc//:grpc",
         "@com_github_grpc_grpc//:grpc++",

--- a/src/SymbolProvider/include/SymbolProvider/SymbolLoadingOutcome.h
+++ b/src/SymbolProvider/include/SymbolProvider/SymbolLoadingOutcome.h
@@ -27,6 +27,7 @@ struct SymbolLoadingSuccessResult {
     kMicrosoftSymbolServer,
     kUserDefinedSymbolStore,
     kUsrLibDebugDirectory,
+    kStadiaInstanceUsrLibDebug
   };
   enum class SymbolFileSeparation { kDifferentFile, kModuleFile };
 


### PR DESCRIPTION
Use StructuredDebugDirectorySymbolProvider in OrbitService. This shares more code between service and client.

Bug: http://b/24587946