### PR TITLE
Clean up module dependencies

### DIFF
--- a/src/CodeViewer/CMakeLists.txt
+++ b/src/CodeViewer/CMakeLists.txt
@@ -10,7 +10,6 @@ add_library(CodeViewer STATIC)
 target_include_directories(CodeViewer PUBLIC include/)
 target_link_libraries(CodeViewer PUBLIC CodeReport
                                         OrbitBase
-                                        OrbitGl
                                         SyntaxHighlighter
                                         Qt5::Widgets)
 

--- a/src/CommandLineUtils/CMakeLists.txt
+++ b/src/CommandLineUtils/CMakeLists.txt
@@ -16,8 +16,7 @@ target_sources(
   PRIVATE include/CommandLineUtils/CommandLineUtils.h
 )
 
-target_link_libraries(CommandLineUtils PUBLIC
-        OrbitQt)
+target_link_libraries(CommandLineUtils PUBLIC Qt5::Core ClientFlags CONAN_PKG::abseil)
 target_include_directories(CommandLineUtils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_executable(CommandLineUtilsTests)

--- a/src/ConfigWidgets/CMakeLists.txt
+++ b/src/ConfigWidgets/CMakeLists.txt
@@ -9,7 +9,10 @@ add_library(ConfigWidgets STATIC)
 
 target_include_directories(ConfigWidgets PUBLIC include/)
 target_include_directories(ConfigWidgets PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(ConfigWidgets PUBLIC ClientFlags
+target_link_libraries(ConfigWidgets PUBLIC ClientData
+                                           ClientFlags
+                                           ClientSymbols
+                                           MetricsUploader
                                            OrbitBase
                                            SourcePathsMapping
                                            CONAN_PKG::abseil

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -16,7 +16,6 @@
 #include "ClientData/CaptureData.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/ModuleAndFunctionLookup.h"
-#include "CoreMath.h"
 #include "DataViews/DataViewType.h"
 #include "DataViews/FunctionsDataView.h"
 #include "OrbitBase/Append.h"
@@ -216,7 +215,7 @@ bool CallstackDataView::GetDisplayColor(int row, int /*column*/, unsigned char& 
                                         unsigned char& green, unsigned char& blue) {
   // Row "0" refers to the program counter and is always "correct".
   if (callstack_->IsUnwindingError() && row != 0) {
-    static const Color kUnwindingErrorColor{255, 128, 0, 255};
+    constexpr std::array<unsigned char, 3> kUnwindingErrorColor{255, 128, 0};
     red = kUnwindingErrorColor[0];
     green = kUnwindingErrorColor[1];
     blue = kUnwindingErrorColor[2];

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -4,6 +4,7 @@
 
 #include "orbitsamplingreport.h"
 
+#include <QColor>
 #include <QGridLayout>
 #include <QHeaderView>
 #include <QItemSelectionModel>
@@ -31,9 +32,7 @@
 #include "types.h"
 #include "ui_orbitsamplingreport.h"
 
-namespace {
-const Color kRed = Color{255, 0, 0, 26};
-}  // namespace
+const QColor kRed{255, 0, 0, 26};
 
 OrbitSamplingReport::OrbitSamplingReport(QWidget* parent)
     : QWidget(parent), ui_(new Ui::OrbitSamplingReport) {

--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -8,7 +8,7 @@ project(QtUtils)
 add_library(QtUtils STATIC)
 
 target_include_directories(QtUtils PUBLIC include/)
-target_link_libraries(QtUtils PUBLIC OrbitBase OrbitGl Qt5::Core CONAN_PKG::abseil GTest::GTest)
+target_link_libraries(QtUtils PUBLIC Introspection OrbitBase Qt5::Core CONAN_PKG::abseil GTest::GTest)
 
 target_sources(QtUtils PUBLIC include/QtUtils/AssertNoQtLogWarnings.h
                               include/QtUtils/CreateTimeout.h
@@ -36,5 +36,5 @@ target_sources(QtUtilsTests PRIVATE CreateTimeoutTest.cpp
                                     FutureWatcherTest.cpp
                                     MainThreadExecutorImplTest.cpp
                                     ThrottleTest.cpp)
-target_link_libraries(QtUtilsTests PRIVATE ClientFlags TestUtils QtUtils GTest::QtCoreMain)
+target_link_libraries(QtUtilsTests PRIVATE TestUtils QtUtils GTest::QtCoreMain)
 register_test(QtUtilsTests)

--- a/src/QtUtils/ExecuteProcessTest.cpp
+++ b/src/QtUtils/ExecuteProcessTest.cpp
@@ -6,8 +6,8 @@
 #include <absl/time/time.h>
 #include <gtest/gtest.h>
 
-#include <QApplication>
 #include <QByteArray>
+#include <QCoreApplication>
 #include <QObject>
 #include <QTimer>
 #include <memory>
@@ -33,7 +33,7 @@ TEST(QtUtilsExecuteProcess, ProgramNotFound) {
   std::shared_ptr<MainThreadExecutor> mte = MainThreadExecutorImpl::Create();
 
   Future<ErrorMessageOr<QByteArray>> future =
-      ExecuteProcess("non_existing_process", QStringList{}, QApplication::instance());
+      ExecuteProcess("non_existing_process", QStringList{}, QCoreApplication::instance());
 
   bool lambda_was_called = false;
   future.Then(mte.get(), [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
@@ -42,10 +42,10 @@ TEST(QtUtilsExecuteProcess, ProgramNotFound) {
     EXPECT_THAT(result, HasError("Error occurred while executing process"));
     EXPECT_THAT(result, HasError("non_existing_process"));
     EXPECT_THAT(result, HasError("FailedToStart"));
-    QApplication::exit();
+    QCoreApplication::exit();
   });
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -58,17 +58,17 @@ TEST(QtUtilsExecuteProcess, ReturnsFailExitCode) {
       QString::fromStdString((orbit_base::GetExecutableDir() / "FakeCliProgram").string());
 
   Future<ErrorMessageOr<QByteArray>> future =
-      ExecuteProcess(program, QStringList{"--exit_code", "240"}, QApplication::instance());
+      ExecuteProcess(program, QStringList{"--exit_code", "240"}, QCoreApplication::instance());
 
   bool lambda_was_called = false;
   future.Then(mte.get(), [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
     EXPECT_FALSE(lambda_was_called);
     lambda_was_called = true;
     EXPECT_THAT(result, HasError("failed with exit code: 240"));
-    QApplication::exit();
+    QCoreApplication::exit();
   });
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -81,7 +81,7 @@ TEST(QtUtilsExecuteProcess, Succeeds) {
       QString::fromStdString((orbit_base::GetExecutableDir() / "FakeCliProgram").string());
 
   Future<ErrorMessageOr<QByteArray>> future =
-      ExecuteProcess(program, QStringList{}, QApplication::instance());
+      ExecuteProcess(program, QStringList{}, QCoreApplication::instance());
 
   bool lambda_was_called = false;
   future.Then(mte.get(), [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
@@ -89,10 +89,10 @@ TEST(QtUtilsExecuteProcess, Succeeds) {
     lambda_was_called = true;
     ASSERT_THAT(result, HasValue());
     EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Some example output"));
-    QApplication::exit();
+    QCoreApplication::exit();
   });
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -113,10 +113,10 @@ TEST(QtUtilsExecuteProcess, SucceedsWithoutParent) {
     lambda_was_called = true;
     ASSERT_THAT(result, HasValue());
     EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Some example output"));
-    QApplication::exit();
+    QCoreApplication::exit();
   });
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -129,7 +129,7 @@ TEST(QtUtilsExecuteProcess, SucceedsWithSleep) {
       QString::fromStdString((orbit_base::GetExecutableDir() / "FakeCliProgram").string());
 
   Future<ErrorMessageOr<QByteArray>> future =
-      ExecuteProcess(program, QStringList{"--sleep_for_ms", "200"}, QApplication::instance());
+      ExecuteProcess(program, QStringList{"--sleep_for_ms", "200"}, QCoreApplication::instance());
 
   bool lambda_was_called = false;
   future.Then(mte.get(), [&lambda_was_called](const ErrorMessageOr<QByteArray>& result) {
@@ -138,10 +138,10 @@ TEST(QtUtilsExecuteProcess, SucceedsWithSleep) {
     ASSERT_THAT(result, HasValue());
     EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Some example output"));
     EXPECT_TRUE(absl::StrContains(result.value().toStdString(), "Slept for 200ms"));
-    QApplication::exit();
+    QCoreApplication::exit();
   });
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -154,7 +154,7 @@ TEST(QtUtilsExecuteProcess, FailsBecauseOfTimeout) {
       QString::fromStdString((orbit_base::GetExecutableDir() / "FakeCliProgram").string());
 
   Future<ErrorMessageOr<QByteArray>> future =
-      ExecuteProcess(program, QStringList{"--sleep_for_ms", "200"}, QApplication::instance(),
+      ExecuteProcess(program, QStringList{"--sleep_for_ms", "200"}, QCoreApplication::instance(),
                      absl::Milliseconds(100));
 
   bool lambda_was_called = false;
@@ -165,10 +165,10 @@ TEST(QtUtilsExecuteProcess, FailsBecauseOfTimeout) {
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
-    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+    QTimer::singleShot(5, QCoreApplication::instance(), &QCoreApplication::quit);
   });
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -181,7 +181,7 @@ TEST(QtUtilsExecuteProcess, FailsBecauseOfTimeoutWithValueZero) {
       QString::fromStdString((orbit_base::GetExecutableDir() / "FakeCliProgram").string());
 
   Future<ErrorMessageOr<QByteArray>> future =
-      ExecuteProcess(program, QStringList{"--sleep_for_ms", "200"}, QApplication::instance(),
+      ExecuteProcess(program, QStringList{"--sleep_for_ms", "200"}, QCoreApplication::instance(),
                      absl::ZeroDuration());
 
   bool lambda_was_called = false;
@@ -192,10 +192,10 @@ TEST(QtUtilsExecuteProcess, FailsBecauseOfTimeoutWithValueZero) {
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
-    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+    QTimer::singleShot(5, QCoreApplication::instance(), &QCoreApplication::quit);
   });
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -221,11 +221,11 @@ TEST(QtUtilsExecuteProcess, ParentGetsDeletedImmediately) {
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
-    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+    QTimer::singleShot(5, QCoreApplication::instance(), &QCoreApplication::quit);
   });
   parent_object->deleteLater();
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -251,12 +251,12 @@ TEST(QtUtilsExecuteProcess, ParentGetsDeletedWhileExecuting) {
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
-    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+    QTimer::singleShot(5, QCoreApplication::instance(), &QCoreApplication::quit);
   });
 
   QTimer::singleShot(100, parent_object, &QObject::deleteLater);
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -271,7 +271,7 @@ TEST(QtUtilsExecuteProcess, ProcessFinishAndTimeoutRace) {
   // Note the sleep for the process and the timer timeout are both 100ms. This means the outcome can
   // be either a success or timeout.
   Future<ErrorMessageOr<QByteArray>> future =
-      ExecuteProcess(program, QStringList{"--sleep_for_ms", "100"}, QApplication::instance(),
+      ExecuteProcess(program, QStringList{"--sleep_for_ms", "100"}, QCoreApplication::instance(),
                      absl::Milliseconds(100));
 
   bool lambda_was_called = false;
@@ -289,10 +289,10 @@ TEST(QtUtilsExecuteProcess, ProcessFinishAndTimeoutRace) {
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
-    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+    QTimer::singleShot(5, QCoreApplication::instance(), &QCoreApplication::quit);
   });
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -326,12 +326,12 @@ TEST(QtUtilsExecuteProcess, ProcessFinishAndParentGetsDeletedRace) {
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
-    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+    QTimer::singleShot(5, QCoreApplication::instance(), &QCoreApplication::quit);
   });
 
   QTimer::singleShot(100, parent_object, &QObject::deleteLater);
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }
@@ -366,12 +366,12 @@ TEST(QtUtilsExecuteProcess, TimeoutAndParentGetsDeletedRace) {
 
     // QApplication is not quit immediately here, to allow clean up (killing and deletion of the
     // process), which is queued in the event loop.
-    QTimer::singleShot(5, QApplication::instance(), &QApplication::quit);
+    QTimer::singleShot(5, QCoreApplication::instance(), &QCoreApplication::quit);
   });
 
   QTimer::singleShot(100, parent_object, &QObject::deleteLater);
 
-  QApplication::exec();
+  QCoreApplication::exec();
 
   EXPECT_TRUE(lambda_was_called);
 }

--- a/src/UtilWidgets/NoticeWidget.cpp
+++ b/src/UtilWidgets/NoticeWidget.cpp
@@ -13,11 +13,10 @@
 #include <QStyleOption>
 #include <QWidget>
 
-#include "CoreMath.h"
 #include "ui_NoticeWidget.h"
 
 namespace {
-const Color kGreen{0, 255, 0, 26};
+const QColor kGreen{0, 255, 0, 26};
 }  // namespace
 namespace orbit_util_widgets {
 
@@ -30,13 +29,13 @@ NoticeWidget::NoticeWidget(QWidget* parent)
 }
 
 void NoticeWidget::Initialize(const std::string& label_text, const std::string& button_text,
-                              const Color& color) {
+                              const QColor& color) {
   ui_->noticeLabel->setText(QString::fromStdString(label_text));
   ui_->noticeButton->setText(QString::fromStdString(button_text));
-  setStyleSheet(QString::fromStdString(
-      absl::StrFormat("QWidget#%s{ border-radius: 5px; border: 1px solid palette(text); "
-                      "background: rgba(%d, %d, %d, %d);}",
-                      objectName().toStdString(), color[0], color[1], color[2], color[3])));
+  setStyleSheet(QString::fromStdString(absl::StrFormat(
+      "QWidget#%s{ border-radius: 5px; border: 1px solid palette(text); "
+      "background: rgba(%d, %d, %d, %d);}",
+      objectName().toStdString(), color.red(), color.green(), color.blue(), color.alpha())));
 }
 
 void NoticeWidget::InitializeAsInspection() {

--- a/src/UtilWidgets/include/UtilWidgets/NoticeWidget.h
+++ b/src/UtilWidgets/include/UtilWidgets/NoticeWidget.h
@@ -5,12 +5,11 @@
 #ifndef UTIL_WIDGETS_NOTICE_WIDGET_H_
 #define UTIL_WIDGETS_NOTICE_WIDGET_H_
 
+#include <QColor>
 #include <QPaintEvent>
 #include <QWidget>
 #include <memory>
 #include <string>
-
-#include "CoreMath.h"
 
 namespace Ui {
 class NoticeWidget;
@@ -26,7 +25,7 @@ class NoticeWidget : public QWidget {
   ~NoticeWidget() override;
 
   void Initialize(const std::string& label_text, const std::string& button_text,
-                  const Color& color);
+                  const QColor& color);
   void InitializeAsInspection();
 
  signals:


### PR DESCRIPTION
Somehow OrbitGl sneaked as a dependency into QtUtils which led to a bunch of circular dependencies (i.e. OrbitGl -> DataViews -> QtUtils -> OrbitGl).

Removing the circular dependency required to remove some header usages that are not available anymore (i.e. CoreMath.h can't be used in DataViews, QApplication can't be used in QtUtilsTests).

Test: Compiles, Unit tests