### PR TITLE
Add FunctionsDataView::RemoveFunctionsOfModule

### DIFF
--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -28,7 +28,6 @@
 
 using orbit_client_data::CaptureData;
 using orbit_client_data::FunctionInfo;
-using orbit_client_data::ModuleManager;
 
 namespace orbit_data_views {
 
@@ -210,7 +209,7 @@ void FunctionsDataView::DoFilter() {
   ORBIT_SCOPE(absl::StrFormat("FunctionsDataView::DoFilter [%u]", functions_.size()).c_str());
   filter_tokens_ = absl::StrSplit(absl::AsciiStrToLower(filter_), ' ');
 
-  const size_t kNumFunctionsPerTask = 1024;
+  constexpr size_t kNumFunctionsPerTask = 1024;
   std::vector<absl::Span<const FunctionInfo*>> chunks =
       orbit_base::CreateChunksOfSize(functions_, kNumFunctionsPerTask);
   std::vector<std::vector<uint64_t>> task_results(chunks.size());
@@ -248,10 +247,16 @@ void FunctionsDataView::DoFilter() {
 void FunctionsDataView::AddFunctions(
     std::vector<const orbit_client_data::FunctionInfo*> functions) {
   functions_.insert(functions_.end(), functions.begin(), functions.end());
-  indices_.resize(functions_.size());
-  for (size_t i = 0; i < indices_.size(); ++i) {
-    indices_[i] = i;
-  }
+  OnDataChanged();
+}
+
+void FunctionsDataView::RemoveFunctionsOfModule(const std::string& module_path) {
+  functions_.erase(
+      std::remove_if(functions_.begin(), functions_.end(),
+                     [&module_path](const orbit_client_data::FunctionInfo* function_info) {
+                       return function_info->module_path() == module_path;
+                     }),
+      functions_.end());
   OnDataChanged();
 }
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -251,12 +251,11 @@ void FunctionsDataView::AddFunctions(
 }
 
 void FunctionsDataView::RemoveFunctionsOfModule(const std::string& module_path) {
-  functions_.erase(
-      std::remove_if(functions_.begin(), functions_.end(),
-                     [&module_path](const orbit_client_data::FunctionInfo* function_info) {
-                       return function_info->module_path() == module_path;
-                     }),
-      functions_.end());
+  functions_.erase(std::remove_if(functions_.begin(), functions_.end(),
+                                  [&module_path](const FunctionInfo* function_info) {
+                                    return function_info->module_path() == module_path;
+                                  }),
+                   functions_.end());
   OnDataChanged();
 }
 

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -35,6 +35,7 @@ class FunctionsDataView : public DataView {
   std::string GetLabel() override { return "Functions"; }
 
   void AddFunctions(std::vector<const orbit_client_data::FunctionInfo*> functions);
+  void RemoveFunctionsOfModule(const std::string& module_path);
   void ClearFunctions();
 
  protected:

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -34,6 +34,8 @@ class FunctionsDataView : public DataView {
   std::string GetValue(int row, int column) override;
   std::string GetLabel() override { return "Functions"; }
 
+  // Note that this class and these methods are not thread-safe and should only be called from the
+  // main thread.
   void AddFunctions(std::vector<const orbit_client_data::FunctionInfo*> functions);
   void RemoveFunctionsOfModule(const std::string& module_path);
   void ClearFunctions();

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1855,25 +1855,25 @@ OrbitApp::RetrieveModuleFromRemote(const std::string& module_file_path) {
                                                std::move(stop_token));
 
     orbit_base::ImmediateExecutor immediate_executor{};
-    return copy_result.Then(
-        &immediate_executor,
-        [remote_debug_file_path, local_debug_file_path,
-         copy_begin](ErrorMessageOr<CanceledOr<void>> sftp_result)
-            -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-          if (sftp_result.has_error()) {
-            return ErrorMessage{
-                absl::StrFormat("Could not copy debug info file from the remote: %s",
-                                sftp_result.error().message())};
-          }
-          if (orbit_base::IsCanceled(sftp_result.value())) {
-            return orbit_base::Canceled{};
-          }
-          const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::steady_clock::now() - copy_begin);
-          ORBIT_LOG("Copying \"%s\" took %.3f ms", remote_debug_file_path.string(),
-                    duration.count());
-          return local_debug_file_path;
-        });
+    return copy_result.Then(&immediate_executor,
+                            [remote_debug_file_path, local_debug_file_path,
+                             copy_begin](ErrorMessageOr<CanceledOr<void>> sftp_result)
+                                -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+                              if (sftp_result.has_error()) {
+                                return ErrorMessage{absl::StrFormat(
+                                    "Could not copy debug info file from the remote: %s",
+                                    sftp_result.error().message())};
+                              }
+                              if (orbit_base::IsCanceled(sftp_result.value())) {
+                                return orbit_base::Canceled{};
+                              }
+                              const auto duration =
+                                  std::chrono::duration_cast<std::chrono::milliseconds>(
+                                      std::chrono::steady_clock::now() - copy_begin);
+                              ORBIT_LOG("Copying \"%s\" took %.3f ms",
+                                        remote_debug_file_path.string(), duration.count());
+                              return local_debug_file_path;
+                            });
   };
 
   Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> chained_result_future = UnwrapFuture(
@@ -1908,7 +1908,7 @@ orbit_base::Future<void> OrbitApp::LoadSymbolsManually(
 
     // Explicitly do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
   orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
@@ -2583,6 +2583,9 @@ void OrbitApp::AddDefaultFrameTrackOrLogError() {
 void OrbitApp::RefreshUIAfterModuleReload() {
   modules_data_view_->UpdateModules(GetTargetProcess());
 
+  // TODO(b/247069854): Avoid FunctionsDataView::ClearFunctions: use
+  //  FunctionsDataView::RemoveFunctionsOfModule for the modules that changed or are no longer
+  //  loaded, followed by FunctionsDataView::AddFunctions only for the modules that changed.
   functions_data_view_->ClearFunctions();
   auto module_ids = GetTargetProcess()->GetUniqueModuleIdentifiers();
   for (const ModuleIdentifier& module_id : module_ids) {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1855,25 +1855,25 @@ OrbitApp::RetrieveModuleFromRemote(const std::string& module_file_path) {
                                                std::move(stop_token));
 
     orbit_base::ImmediateExecutor immediate_executor{};
-    return copy_result.Then(&immediate_executor,
-                            [remote_debug_file_path, local_debug_file_path,
-                             copy_begin](ErrorMessageOr<CanceledOr<void>> sftp_result)
-                                -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-                              if (sftp_result.has_error()) {
-                                return ErrorMessage{absl::StrFormat(
-                                    "Could not copy debug info file from the remote: %s",
-                                    sftp_result.error().message())};
-                              }
-                              if (orbit_base::IsCanceled(sftp_result.value())) {
-                                return orbit_base::Canceled{};
-                              }
-                              const auto duration =
-                                  std::chrono::duration_cast<std::chrono::milliseconds>(
-                                      std::chrono::steady_clock::now() - copy_begin);
-                              ORBIT_LOG("Copying \"%s\" took %.3f ms",
-                                        remote_debug_file_path.string(), duration.count());
-                              return local_debug_file_path;
-                            });
+    return copy_result.Then(
+        &immediate_executor,
+        [remote_debug_file_path, local_debug_file_path,
+         copy_begin](ErrorMessageOr<CanceledOr<void>> sftp_result)
+            -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+          if (sftp_result.has_error()) {
+            return ErrorMessage{
+                absl::StrFormat("Could not copy debug info file from the remote: %s",
+                                sftp_result.error().message())};
+          }
+          if (orbit_base::IsCanceled(sftp_result.value())) {
+            return orbit_base::Canceled{};
+          }
+          const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - copy_begin);
+          ORBIT_LOG("Copying \"%s\" took %.3f ms", remote_debug_file_path.string(),
+                    duration.count());
+          return local_debug_file_path;
+        });
   };
 
   Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> chained_result_future = UnwrapFuture(
@@ -1908,7 +1908,7 @@ orbit_base::Future<void> OrbitApp::LoadSymbolsManually(
 
     // Explicitly do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
   orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
@@ -2583,9 +2583,6 @@ void OrbitApp::AddDefaultFrameTrackOrLogError() {
 void OrbitApp::RefreshUIAfterModuleReload() {
   modules_data_view_->UpdateModules(GetTargetProcess());
 
-  // TODO(b/247069854): Avoid FunctionsDataView::ClearFunctions: use
-  //  FunctionsDataView::RemoveFunctionsOfModule for the modules that changed or are no longer
-  //  loaded, followed by FunctionsDataView::AddFunctions only for the modules that changed.
   functions_data_view_->ClearFunctions();
   auto module_ids = GetTargetProcess()->GetUniqueModuleIdentifiers();
   for (const ModuleIdentifier& module_id : module_ids) {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2583,6 +2583,9 @@ void OrbitApp::AddDefaultFrameTrackOrLogError() {
 void OrbitApp::RefreshUIAfterModuleReload() {
   modules_data_view_->UpdateModules(GetTargetProcess());
 
+  // TODO(b/247069854): Avoid FunctionsDataView::ClearFunctions: use
+  //  FunctionsDataView::RemoveFunctionsOfModule for the modules that changed or are no longer
+  //  loaded, followed by FunctionsDataView::AddFunctions only for the modules that changed.
   functions_data_view_->ClearFunctions();
   auto module_ids = GetTargetProcess()->GetUniqueModuleIdentifiers();
   for (const ModuleIdentifier& module_id : module_ids) {


### PR DESCRIPTION
This will be used in the context of the "fallback symbols": if these are loaded, but "Load Symbols" is selected and does now find symbols, the "fallback symbols" need to be removed, as they now get completely replaced by the actual symbols.

Also simplify `FunctionsDataView::AddFunctions` because `OnDataChanged` already takes care of the rest (like in `ClearFunctions`).

Bug: http://b/245680119

Test:
- Add unit test.
- As part of the larger symbol loading fallback prototype.