### PR TITLE
Make MizarData yield `address -> (function name, module name)` map

### DIFF
--- a/src/MizarData/BaselineAndComparison.cpp
+++ b/src/MizarData/BaselineAndComparison.cpp
@@ -20,8 +20,8 @@ namespace orbit_mizar_data {
 
 orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(
     std::unique_ptr<MizarDataProvider> baseline, std::unique_ptr<MizarDataProvider> comparison) {
-  auto [baseline_address_sfid, comparison_address_to_sfid, sfid_to_name] =
-      AssignSampledFunctionIds(baseline->AllAddressToName(), comparison->AllAddressToName());
+  auto [baseline_address_sfid, comparison_address_to_sfid, sfid_to_name] = AssignSampledFunctionIds(
+      baseline->AllAddressToFunctionSymbol(), comparison->AllAddressToFunctionSymbol());
 
   return {orbit_mizar_base::MakeBaseline<MizarPairedData>(std::move(baseline),
                                                           std::move(baseline_address_sfid)),

--- a/src/MizarData/BaselineAndComparisonHelper.h
+++ b/src/MizarData/BaselineAndComparisonHelper.h
@@ -13,6 +13,7 @@
 
 #include "MizarBase/AbsoluteAddress.h"
 #include "MizarBase/SampledFunctionId.h"
+#include "MizarData/MizarDataProvider.h"
 
 namespace orbit_mizar_data {
 
@@ -25,10 +26,10 @@ struct AddressToIdAndIdToName {
 };
 
 [[nodiscard]] AddressToIdAndIdToName AssignSampledFunctionIds(
-    const absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, std::string>&
-        baseline_address_to_name,
-    const absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, std::string>&
-        comparison_address_to_name);
+    const absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, FunctionSymbol>&
+        baseline_address_to_symbol,
+    const absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, FunctionSymbol>&
+        comparison_address_to_symbol);
 
 }  // namespace orbit_mizar_data
 

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -53,7 +53,7 @@ absl::flat_hash_map<AbsoluteAddress, FunctionSymbol> MizarData::AllAddressToFunc
 }
 
 [[nodiscard]] static std::string GetFilename(const std::string& path) {
-  return std::filesystem::path(path).filename().replace_extension();
+  return std::filesystem::path(path).filename().replace_extension().string();
 }
 
 [[nodiscard]] std::string MizarData::GetModuleFileName(AbsoluteAddress address) const {

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -127,7 +127,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
 
   void LoadSymbols(orbit_client_data::ModuleData& module_data);
 
-  [[nodiscard]] std::string GetModuleFileName(AbsoluteAddress address) const;
+  [[nodiscard]] std::string GetModuleFilenameWithoutExtension(AbsoluteAddress address) const;
 
   std::unique_ptr<orbit_client_data::ModuleManager> module_manager_;
   orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDirUnsafe()};

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -51,7 +51,8 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
     return source_to_present_events_;
   }
 
-  [[nodiscard]] absl::flat_hash_map<AbsoluteAddress, std::string> AllAddressToName() const override;
+  [[nodiscard]] absl::flat_hash_map<AbsoluteAddress, FunctionSymbol> AllAddressToFunctionSymbol()
+      const override;
 
   [[nodiscard]] std::optional<std::string> GetFunctionNameFromAddress(
       AbsoluteAddress address) const override;
@@ -84,6 +85,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
 
   void OnModuleUpdate(uint64_t /*timestamp_ns*/,
                       orbit_grpc_protos::ModuleInfo module_info) override {
+    GetMutableCaptureData().mutable_process()->AddOrUpdateModuleInfo(module_info);
     UpdateModules({module_info});
   }
   void OnModulesSnapshot(uint64_t /*timestamp_ns*/,
@@ -124,6 +126,8 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
   void LoadSymbolsForAllModules();
 
   void LoadSymbols(orbit_client_data::ModuleData& module_data);
+
+  [[nodiscard]] std::string GetModuleFileName(AbsoluteAddress address) const;
 
   std::unique_ptr<orbit_client_data::ModuleManager> module_manager_;
   orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDirUnsafe()};

--- a/src/MizarData/include/MizarData/MizarDataProvider.h
+++ b/src/MizarData/include/MizarData/MizarDataProvider.h
@@ -17,6 +17,11 @@
 
 namespace orbit_mizar_data {
 
+struct FunctionSymbol {
+  std::string function_name;
+  std::string module_file_name;
+};
+
 // Handles one of the two datasets Mizar operates on
 class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
   using AbsoluteAddress = ::orbit_mizar_base::AbsoluteAddress;
@@ -38,8 +43,8 @@ class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
 
   [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(
       AbsoluteAddress address) const = 0;
-  [[nodiscard]] virtual absl::flat_hash_map<AbsoluteAddress, std::string> AllAddressToName()
-      const = 0;
+  [[nodiscard]] virtual absl::flat_hash_map<AbsoluteAddress, FunctionSymbol>
+  AllAddressToFunctionSymbol() const = 0;
 
   [[nodiscard]] virtual orbit_mizar_base::TimestampNs GetCaptureStartTimestampNs() const = 0;
 


### PR DESCRIPTION
The previously present `address -> function name` is replaced with
the needed one. We pull the module names from `LinuxAddresInfo`s
and `ProcessData`.

For now, the module names remain unused.

Bug: http://b/246934733
Test: Manual, Unit