### PR TITLE
Propagate both baseline and comparison symbols to Report Model in Mizar

### DIFF
--- a/src/MizarBase/include/MizarBase/BaselineOrComparison.h
+++ b/src/MizarBase/include/MizarBase/BaselineOrComparison.h
@@ -22,12 +22,12 @@ using Comparison = orbit_base::Typedef<ComparisonTag, T>;
 
 template <typename T, typename... Args>
 [[nodiscard]] Baseline<T> MakeBaseline(Args&&... args) {
-  return Baseline<T>(T(std::forward<Args>(args)...));
+  return Baseline<T>(T{std::forward<Args>(args)...});
 }
 
 template <typename T, typename... Args>
 [[nodiscard]] Comparison<T> MakeComparison(Args&&... args) {
-  return Comparison<T>(T(std::forward<Args>(args)...));
+  return Comparison<T>(T{std::forward<Args>(args)...});
 }
 
 }  // namespace orbit_mizar_base

--- a/src/MizarBase/include/MizarBase/FunctionSymbols.h
+++ b/src/MizarBase/include/MizarBase/FunctionSymbols.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_BASE_FUNCTION_SYMBOLS_H_
+#define MIZAR_BASE_FUNCTION_SYMBOLS_H_
+
+#include <string>
+
+#include "MizarBase/BaselineOrComparison.h"
+
+namespace orbit_mizar_base {
+
+struct FunctionSymbol {
+  std::string function_name;
+  std::string module_file_name;
+};
+
+struct BaselineAndComparisonFunctionSymbols {
+  Baseline<FunctionSymbol> baseline_function_symbol;
+  Comparison<FunctionSymbol> comparison_function_symbol;
+};
+
+}  // namespace orbit_mizar_base
+
+#endif  // MIZAR_BASE_FUNCTION_SYMBOLS_H_

--- a/src/MizarData/BaselineAndComparison.cpp
+++ b/src/MizarData/BaselineAndComparison.cpp
@@ -20,14 +20,15 @@ namespace orbit_mizar_data {
 
 orbit_mizar_data::BaselineAndComparison CreateBaselineAndComparison(
     std::unique_ptr<MizarDataProvider> baseline, std::unique_ptr<MizarDataProvider> comparison) {
-  auto [baseline_address_sfid, comparison_address_to_sfid, sfid_to_name] = AssignSampledFunctionIds(
-      baseline->AllAddressToFunctionSymbol(), comparison->AllAddressToFunctionSymbol());
+  auto [baseline_address_sfid, comparison_address_to_sfid, sfid_to_symbols] =
+      AssignSampledFunctionIds(baseline->AllAddressToFunctionSymbol(),
+                               comparison->AllAddressToFunctionSymbol());
 
   return {orbit_mizar_base::MakeBaseline<MizarPairedData>(std::move(baseline),
                                                           std::move(baseline_address_sfid)),
           orbit_mizar_base::MakeComparison<MizarPairedData>(std::move(comparison),
                                                             std::move(comparison_address_to_sfid)),
-          std::move(sfid_to_name)};
+          std::move(sfid_to_symbols)};
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonHelper.cpp
+++ b/src/MizarData/BaselineAndComparisonHelper.cpp
@@ -11,6 +11,8 @@
 #include <string>
 
 #include "MizarBase/AbsoluteAddress.h"
+#include "MizarBase/BaselineOrComparison.h"
+#include "MizarBase/FunctionSymbols.h"
 #include "MizarBase/SampledFunctionId.h"
 #include "MizarData/MizarDataProvider.h"
 
@@ -18,15 +20,22 @@ using ::orbit_mizar_base::AbsoluteAddress;
 
 namespace orbit_mizar_data {
 
-using SFID = ::orbit_mizar_base::SFID;
+template <typename T>
+using Baseline = ::orbit_mizar_base::Baseline<T>;
+template <typename T>
+using Comparison = ::orbit_mizar_base::Comparison<T>;
+using ::orbit_mizar_base::BaselineAndComparisonFunctionSymbols;
+using ::orbit_mizar_base::FunctionSymbol;
+using ::orbit_mizar_base::SFID;
 
-[[nodiscard]] static absl::flat_hash_set<std::string> FunctionNamesSet(
+[[nodiscard]] static absl::flat_hash_map<std::string, FunctionSymbol> FunctionNameToSymbol(
     absl::flat_hash_map<AbsoluteAddress, FunctionSymbol> map) {
-  absl::flat_hash_set<std::string> result;
-  std::transform(std::begin(map), std::end(map), std::inserter(result, std::begin(result)),
-                 [](const std::pair<AbsoluteAddress, FunctionSymbol>& pair) {
-                   return pair.second.function_name;
-                 });
+  absl::flat_hash_map<std::string, FunctionSymbol> result;
+  absl::c_transform(map, std::inserter(result, std::begin(result)),
+                    [](const std::pair<AbsoluteAddress, FunctionSymbol>& pair) {
+                      const FunctionSymbol& symbol = pair.second;
+                      return std::make_pair(symbol.function_name, symbol);
+                    });
   return result;
 }
 
@@ -42,21 +51,27 @@ static absl::flat_hash_map<AbsoluteAddress, SFID> AddressToSFID(
   return address_to_sfid;
 }
 
-[[nodiscard]] AddressToIdAndIdToName AssignSampledFunctionIds(
+[[nodiscard]] AddressToIdAndIdToSymbol AssignSampledFunctionIds(
     const absl::flat_hash_map<AbsoluteAddress, FunctionSymbol>& baseline_address_to_symbol,
     const absl::flat_hash_map<AbsoluteAddress, FunctionSymbol>& comparison_address_to_symbol) {
-  absl::flat_hash_set<std::string> baseline_names = FunctionNamesSet(baseline_address_to_symbol);
-  absl::flat_hash_set<std::string> comparison_names =
-      FunctionNamesSet(comparison_address_to_symbol);
+  absl::flat_hash_map<std::string, FunctionSymbol> comparison_names =
+      FunctionNameToSymbol(comparison_address_to_symbol);
 
   absl::flat_hash_map<std::string, SFID> name_to_sfid;
-  absl::flat_hash_map<SFID, std::string> sfid_to_name;
+  absl::flat_hash_map<SFID, BaselineAndComparisonFunctionSymbols> sfid_to_symbols;
 
   SFID next_sfid_value{1};
-  for (const std::string& name : baseline_names) {
-    if (comparison_names.contains(name) && !name_to_sfid.contains(name)) {
+  for (const auto& [address, baseline_function_symbol] : baseline_address_to_symbol) {
+    const std::string& name = baseline_function_symbol.function_name;
+    if (const auto comparison_name_to_symbol_it = comparison_names.find(name);
+        comparison_name_to_symbol_it != comparison_names.end() && !name_to_sfid.contains(name)) {
       name_to_sfid.try_emplace(name, next_sfid_value);
-      sfid_to_name.try_emplace(next_sfid_value, name);
+
+      BaselineAndComparisonFunctionSymbols symbols{
+          Baseline<FunctionSymbol>(baseline_function_symbol),
+          Comparison<FunctionSymbol>(comparison_name_to_symbol_it->second)};
+
+      sfid_to_symbols.try_emplace(next_sfid_value, std::move(symbols));
       ++next_sfid_value;
     }
   }
@@ -67,7 +82,7 @@ static absl::flat_hash_map<AbsoluteAddress, SFID> AddressToSFID(
       AddressToSFID(comparison_address_to_symbol, name_to_sfid);
 
   return {std::move(baseline_address_to_sfid), std::move(comparison_address_to_sfid),
-          std::move(sfid_to_name)};
+          std::move(sfid_to_symbols)};
 }
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/BaselineAndComparisonHelper.h
+++ b/src/MizarData/BaselineAndComparisonHelper.h
@@ -10,25 +10,30 @@
 #include <stdint.h>
 
 #include <string>
+#include <tuple>
 
 #include "MizarBase/AbsoluteAddress.h"
+#include "MizarBase/BaselineOrComparison.h"
+#include "MizarBase/FunctionSymbols.h"
 #include "MizarBase/SampledFunctionId.h"
 #include "MizarData/MizarDataProvider.h"
 
 namespace orbit_mizar_data {
 
-struct AddressToIdAndIdToName {
+struct AddressToIdAndIdToSymbol {
   absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, orbit_mizar_base::SFID>
       baseline_address_to_sfid;
   absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, orbit_mizar_base::SFID>
       comparison_address_to_sfid;
-  absl::flat_hash_map<orbit_mizar_base::SFID, std::string> sfid_to_name;
+  absl::flat_hash_map<orbit_mizar_base::SFID,
+                      orbit_mizar_base::BaselineAndComparisonFunctionSymbols>
+      sfid_to_symbols;
 };
 
-[[nodiscard]] AddressToIdAndIdToName AssignSampledFunctionIds(
-    const absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, FunctionSymbol>&
+[[nodiscard]] AddressToIdAndIdToSymbol AssignSampledFunctionIds(
+    const absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, orbit_mizar_base::FunctionSymbol>&
         baseline_address_to_symbol,
-    const absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, FunctionSymbol>&
+    const absl::flat_hash_map<orbit_mizar_base::AbsoluteAddress, orbit_mizar_base::FunctionSymbol>&
         comparison_address_to_symbol);
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -30,6 +30,7 @@
 
 using ::orbit_mizar_base::AbsoluteAddress;
 using ::orbit_mizar_base::ForEachFrame;
+using ::orbit_mizar_base::FunctionSymbol;
 
 namespace orbit_mizar_data {
 

--- a/src/MizarData/MizarDataTest.cpp
+++ b/src/MizarData/MizarDataTest.cpp
@@ -25,6 +25,7 @@
 #include "MizarData/MizarData.h"
 
 using ::orbit_mizar_base::AbsoluteAddress;
+using ::orbit_mizar_base::FunctionSymbol;
 using ::testing::Invoke;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -34,16 +34,20 @@ class BaselineAndComparisonTmpl {
   using SFID = ::orbit_mizar_base::SFID;
   using TID = ::orbit_mizar_base::TID;
   using RelativeTimeNs = ::orbit_mizar_base::RelativeTimeNs;
+  using BaselineAndComparisonFunctionSymbols =
+      ::orbit_mizar_base::BaselineAndComparisonFunctionSymbols;
 
  public:
-  BaselineAndComparisonTmpl(Baseline<PairedData> baseline, Comparison<PairedData> comparison,
-                            absl::flat_hash_map<SFID, std::string> sfid_to_name)
+  BaselineAndComparisonTmpl(
+      Baseline<PairedData> baseline, Comparison<PairedData> comparison,
+      absl::flat_hash_map<SFID, BaselineAndComparisonFunctionSymbols> sfid_to_symbols)
       : baseline_(std::move(baseline)),
         comparison_(std::move(comparison)),
-        sfid_to_name_(std::move(sfid_to_name)) {}
+        sfid_to_symbols_(std::move(sfid_to_symbols)) {}
 
-  [[nodiscard]] const absl::flat_hash_map<SFID, std::string>& sfid_to_name() const {
-    return sfid_to_name_;
+  [[nodiscard]] const absl::flat_hash_map<SFID, BaselineAndComparisonFunctionSymbols>&
+  sfid_to_symbols() const {
+    return sfid_to_symbols_;
   }
 
   [[nodiscard]] SamplingWithFrameTrackComparisonReport MakeSamplingWithFrameTrackReport(
@@ -68,7 +72,7 @@ class BaselineAndComparisonTmpl {
     return SamplingWithFrameTrackComparisonReport(
         std::move(baseline_sampling_counts), std::move(baseline_frame_stats),
         std::move(comparison_sampling_counts), std::move(comparison_frame_stats),
-        std::move(sfid_to_corrected_comparison_result), &sfid_to_name_);
+        std::move(sfid_to_corrected_comparison_result), &sfid_to_symbols_);
   }
 
   [[nodiscard]] const Baseline<PairedData>& GetBaselineData() const { return baseline_; }
@@ -79,7 +83,7 @@ class BaselineAndComparisonTmpl {
       const FunctionTimeComparator& comparator) const {
     absl::flat_hash_map<SFID, orbit_mizar_statistics::ComparisonResult> results;
     absl::flat_hash_map<SFID, double> pvalues;
-    for (const auto& [sfid, unused_name] : sfid_to_name_) {
+    for (const auto& [sfid, unused_name] : sfid_to_symbols_) {
       orbit_mizar_statistics::ComparisonResult result = comparator.Compare(sfid);
       results.try_emplace(sfid, result);
       pvalues.try_emplace(sfid, result.pvalue);
@@ -122,7 +126,7 @@ class BaselineAndComparisonTmpl {
 
   Baseline<PairedData> baseline_;
   Comparison<PairedData> comparison_;
-  absl::flat_hash_map<SFID, std::string> sfid_to_name_;
+  absl::flat_hash_map<SFID, BaselineAndComparisonFunctionSymbols> sfid_to_symbols_;
 };
 
 using ActiveFunctionTimePerFrameComparator =

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -35,6 +35,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
   using PresentEvent = ::orbit_grpc_protos::PresentEvent;
   using RelativeTimeNs = ::orbit_mizar_base::RelativeTimeNs;
   using AbsoluteAddress = ::orbit_mizar_base::AbsoluteAddress;
+  using FunctionSymbol = ::orbit_mizar_base::FunctionSymbol;
 
  public:
   MizarData() = default;

--- a/src/MizarData/include/MizarData/MizarDataProvider.h
+++ b/src/MizarData/include/MizarData/MizarDataProvider.h
@@ -13,14 +13,10 @@
 #include "ClientData/CaptureData.h"
 #include "ClientData/CaptureDataHolder.h"
 #include "MizarBase/AbsoluteAddress.h"
+#include "MizarBase/FunctionSymbols.h"
 #include "MizarBase/Time.h"
 
 namespace orbit_mizar_data {
-
-struct FunctionSymbol {
-  std::string function_name;
-  std::string module_file_name;
-};
 
 // Handles one of the two datasets Mizar operates on
 class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
@@ -43,7 +39,7 @@ class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
 
   [[nodiscard]] virtual std::optional<std::string> GetFunctionNameFromAddress(
       AbsoluteAddress address) const = 0;
-  [[nodiscard]] virtual absl::flat_hash_map<AbsoluteAddress, FunctionSymbol>
+  [[nodiscard]] virtual absl::flat_hash_map<AbsoluteAddress, orbit_mizar_base::FunctionSymbol>
   AllAddressToFunctionSymbol() const = 0;
 
   [[nodiscard]] virtual orbit_mizar_base::TimestampNs GetCaptureStartTimestampNs() const = 0;

--- a/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
+++ b/src/MizarData/include/MizarData/SamplingWithFrameTrackComparisonReport.h
@@ -15,6 +15,7 @@
 #include "ClientData/ScopeId.h"
 #include "ClientData/ScopeStats.h"
 #include "MizarBase/BaselineOrComparison.h"
+#include "MizarBase/FunctionSymbols.h"
 #include "MizarBase/SampledFunctionId.h"
 #include "MizarBase/ThreadId.h"
 #include "MizarBase/Time.h"
@@ -101,6 +102,8 @@ class SamplingWithFrameTrackComparisonReportTmpl {
   template <typename T>
   using Comparison = ::orbit_mizar_base::Comparison<T>;
   using SFID = ::orbit_mizar_base::SFID;
+  using BaselineAndComparisonFunctionSymbols =
+      ::orbit_mizar_base::BaselineAndComparisonFunctionSymbols;
 
   explicit SamplingWithFrameTrackComparisonReportTmpl(
       Baseline<Counts> baseline_sampling_counts,
@@ -108,13 +111,13 @@ class SamplingWithFrameTrackComparisonReportTmpl {
       Comparison<Counts> comparison_sampling_counts,
       Comparison<FrameTrackStats> comparison_frame_track_stats,
       absl::flat_hash_map<SFID, CorrectedComparisonResult> fid_to_corrected_comparison_results,
-      const absl::flat_hash_map<SFID, std::string>* sfid_to_names)
+      const absl::flat_hash_map<SFID, BaselineAndComparisonFunctionSymbols>* sfid_to_symbol)
       : baseline_sampling_counts_(std::move(baseline_sampling_counts)),
         baseline_frame_track_stats_(std::move(baseline_frame_track_stats)),
         comparison_sampling_counts_(std::move(comparison_sampling_counts)),
         comparison_frame_track_stats_(std::move(comparison_frame_track_stats)),
         fid_to_corrected_comparison_results_(std::move(fid_to_corrected_comparison_results)),
-        sfid_to_names_(sfid_to_names) {}
+        sfid_to_symbols_(sfid_to_symbol) {}
 
   [[nodiscard]] const Baseline<Counts>& GetBaselineSamplingCounts() const {
     return baseline_sampling_counts_;
@@ -134,8 +137,9 @@ class SamplingWithFrameTrackComparisonReportTmpl {
     return fid_to_corrected_comparison_results_.at(sfid);
   }
 
-  [[nodiscard]] const absl::flat_hash_map<SFID, std::string>& GetSfidToNames() const {
-    return *sfid_to_names_;
+  [[nodiscard]] const absl::flat_hash_map<SFID, BaselineAndComparisonFunctionSymbols>&
+  GetSfidToSymbols() const {
+    return *sfid_to_symbols_;
   }
 
  private:
@@ -147,7 +151,7 @@ class SamplingWithFrameTrackComparisonReportTmpl {
 
   absl::flat_hash_map<SFID, CorrectedComparisonResult> fid_to_corrected_comparison_results_;
 
-  const absl::flat_hash_map<SFID, std::string>* sfid_to_names_;
+  const absl::flat_hash_map<SFID, BaselineAndComparisonFunctionSymbols>* sfid_to_symbols_;
 };
 
 // The production code should rely on this alias, changes to RHS are not planned

--- a/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
+++ b/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
@@ -347,7 +347,7 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
   }
 
   [[nodiscard]] const std::string& GetFunctionName(SFID sfid) const {
-    // TODO(b/XXX) make it configurable
+    // TODO(b/247072330) make it configurable
     return report_.GetSfidToSymbols().at(sfid).baseline_function_symbol->function_name;
   }
 

--- a/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
+++ b/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
@@ -57,7 +57,7 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
         report_(std::move(report)),
         is_multiplicity_correction_enabled_(is_multiplicity_correction_enabled),
         significance_level_(significance_level) {
-    for (const auto& [sfid, unused_name] : report_.GetSfidToNames()) {
+    for (const auto& [sfid, unused_symbol] : report_.GetSfidToSymbols()) {
       if (*BaselineExclusiveCount(sfid) > 0 || *ComparisonExclusiveCount(sfid) > 0) {
         sfids_.push_back(sfid);
       }
@@ -191,7 +191,7 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
 
   [[nodiscard]] QVariant MakeTooltip(const QModelIndex& model_index) const {
     const auto& [sfid, column] = MakeIndex(model_index);
-    const std::string* function_name = &report_.GetSfidToNames().at(sfid);
+    const std::string* function_name = &GetFunctionName(sfid);
 
     switch (column) {
       case Column::kFunctionName:
@@ -247,7 +247,7 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
     const auto [sfid, column] = index;
     switch (column) {
       case Column::kFunctionName:
-        return report_.GetSfidToNames().at(sfid);
+        return GetFunctionName(sfid);
       case Column::kIsSignificant:
         return GetPvalue(sfid) < significance_level_ ? "Yes" : "No";
       default:
@@ -344,6 +344,11 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
       default:
         ORBIT_UNREACHABLE();
     }
+  }
+
+  [[nodiscard]] const std::string& GetFunctionName(SFID sfid) const {
+    // TODO(b/XXX) make it configurable
+    return report_.GetSfidToSymbols().at(sfid).baseline_function_symbol->function_name;
   }
 
   Report report_;


### PR DESCRIPTION
As functions of different names could be captures, there should
ultimately be a way to visualize which functions have bee matched.

Hence, we propagate both symbols to the Report Model.

Also, this uses `{}` instead of `()` to initialize the value in
`MakeBaseline` and `MakeComparison`.

Tests: Unit
Bug: http://b/247072002