### PR TITLE
Add SymbolHelper::FindObjectInCache and VerifyObjectFile

### DIFF
--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -266,7 +266,7 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsInCache(const fs::path& module
                                                           uint64_t expected_file_size) const {
   return FindSymbolsInCacheImpl(
       module_path, [&expected_file_size](const std::filesystem::path& cache_file_path) {
-        return VerifyFileSize(cache_file_path, expected_file_size);
+        return VerifySymbolFile(cache_file_path, expected_file_size);
       });
 }
 
@@ -277,8 +277,7 @@ ErrorMessageOr<std::filesystem::path> SymbolHelper::FindObjectInCache(
       module_path,
       [&build_id,
        expected_file_size](const std::filesystem::path& cache_file_path) -> ErrorMessageOr<void> {
-        OUTCOME_TRY(VerifyFileSize(cache_file_path, expected_file_size));
-        return VerifyObjectFile(cache_file_path, build_id);
+        return VerifyObjectFile(cache_file_path, build_id, expected_file_size);
       });
 }
 

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -353,7 +353,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     const auto file_size = orbit_base::FileSize(file_path);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindObjectInCache(
-        file_name, "efaecd92f773bb4ebcf213b84f43b322", file_size.value() + 1);
+        file_name, "efaecd92f773bb4ebcf213b84f43b322-3", file_size.value() + 1);
     ASSERT_THAT(result, HasError("File size doesn't match"));
   }
   {

--- a/src/Symbols/SymbolUtils.cpp
+++ b/src/Symbols/SymbolUtils.cpp
@@ -4,6 +4,7 @@
 
 #include "Symbols/SymbolUtils.h"
 
+#include "ObjectUtils/ObjectFile.h"
 #include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
@@ -42,38 +43,55 @@ namespace orbit_symbols {
   return {filename_dot_sym_ext, filename_plus_sym_ext, filename};
 }
 
-ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
-                                      const std::string& module_build_id) {
-  auto symbols_file_or_error =
-      CreateSymbolsFile(symbol_file_path, orbit_object_utils::ObjectFileInfo());
-  if (symbols_file_or_error.has_error()) {
-    return ErrorMessage(absl::StrFormat("Unable to load symbols file \"%s\": %s",
-                                        symbol_file_path.string(),
-                                        symbols_file_or_error.error().message()));
+template <typename FileT>
+ErrorMessageOr<void> VerifySymbolsOrObjectFileImpl(
+    const std::filesystem::path& symbols_or_object_path, const std::string& build_id,
+    const std::function<ErrorMessageOr<std::unique_ptr<FileT>>(const std::filesystem::path&)>&
+        create_symbols_or_object_file) {
+  auto symbols_or_object_file_or_error = create_symbols_or_object_file(symbols_or_object_path);
+  if (symbols_or_object_file_or_error.has_error()) {
+    return ErrorMessage(absl::StrFormat("Unable to load symbols or object file \"%s\": %s",
+                                        symbols_or_object_path.string(),
+                                        symbols_or_object_file_or_error.error().message()));
   }
 
-  const std::unique_ptr<orbit_object_utils::SymbolsFile>& symbols_file{
-      symbols_file_or_error.value()};
+  const std::unique_ptr<FileT>& symbols_or_object_file{symbols_or_object_file_or_error.value()};
 
-  if (symbols_file->GetBuildId().empty()) {
-    return ErrorMessage(absl::StrFormat("Symbols file \"%s\" does not have a build id.",
-                                        symbol_file_path.string()));
+  if (symbols_or_object_file->GetBuildId().empty()) {
+    return ErrorMessage(absl::StrFormat("Symbols or object file \"%s\" does not have a build id.",
+                                        symbols_or_object_path.string()));
   }
 
-  if (symbols_file->GetBuildId() != module_build_id) {
-    return ErrorMessage(
-        absl::StrFormat(R"(Symbols file "%s" has a different build id: "%s" != "%s")",
-                        symbol_file_path.string(), module_build_id, symbols_file->GetBuildId()));
+  if (symbols_or_object_file->GetBuildId() != build_id) {
+    return ErrorMessage(absl::StrFormat(
+        R"(Symbols or object file "%s" has a different build id: "%s" != "%s")",
+        symbols_or_object_path.string(), build_id, symbols_or_object_file->GetBuildId()));
   }
 
   return outcome::success();
 }
 
-ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
-                                      uint64_t expected_file_size) {
-  OUTCOME_TRY(const uint64_t actual_file_size, orbit_base::FileSize(symbol_file_path));
+ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbols_path,
+                                      const std::string& build_id) {
+  return VerifySymbolsOrObjectFileImpl<orbit_object_utils::SymbolsFile>(
+      symbols_path, build_id, [](const std::filesystem::path& object_path) {
+        return CreateSymbolsFile(object_path, orbit_object_utils::ObjectFileInfo{});
+      });
+}
+
+ErrorMessageOr<void> VerifyObjectFile(const std::filesystem::path& object_path,
+                                      const std::string& build_id) {
+  return VerifySymbolsOrObjectFileImpl<orbit_object_utils::ObjectFile>(
+      object_path, build_id, [](const std::filesystem::path& object_path) {
+        return orbit_object_utils::CreateObjectFile(object_path);
+      });
+}
+
+ErrorMessageOr<void> VerifyFileSize(const std::filesystem::path& file_path,
+                                    uint64_t expected_file_size) {
+  OUTCOME_TRY(const uint64_t actual_file_size, orbit_base::FileSize(file_path));
   if (actual_file_size != expected_file_size) {
-    return ErrorMessage(absl::StrFormat("Symbol file size doesn't match. Expected: %u, Actual: %u ",
+    return ErrorMessage(absl::StrFormat("File size doesn't match. Expected: %u, Actual: %u",
                                         expected_file_size, actual_file_size));
   }
   return outcome::success();

--- a/src/Symbols/SymbolUtilsTest.cpp
+++ b/src/Symbols/SymbolUtilsTest.cpp
@@ -12,13 +12,14 @@
 namespace orbit_symbols {
 
 using orbit_test_utils::HasError;
+using orbit_test_utils::HasNoError;
 using orbit_test_utils::HasValue;
 
 TEST(GetStandardSymbolFilenamesForModule, ElfFile) {
   orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type =
       orbit_grpc_protos::ModuleInfo::kElfFile;
   std::filesystem::path directory = std::filesystem::path{"path"} / "to" / "folder";
-  {  // .so file extention
+  {  // .so file extension
     const std::vector<std::filesystem::path> file_names =
         GetStandardSymbolFilenamesForModule(directory / "lib.so", object_file_type);
     EXPECT_THAT(file_names, testing::Contains("lib.debug"));
@@ -26,7 +27,7 @@ TEST(GetStandardSymbolFilenamesForModule, ElfFile) {
     EXPECT_THAT(file_names, testing::Contains("lib.so"));
   }
 
-  {  // generic file extention (.ext)
+  {  // generic file extension (.ext)
     const std::vector<std::filesystem::path> file_names =
         GetStandardSymbolFilenamesForModule(directory / "lib.ext", object_file_type);
     EXPECT_THAT(file_names, testing::Contains("lib.debug"));
@@ -39,7 +40,7 @@ TEST(GetStandardSymbolFilenamesForModule, CoffFile) {
   orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type =
       orbit_grpc_protos::ModuleInfo::kCoffFile;
   std::filesystem::path directory = std::filesystem::path{"C:"} / "path" / "to" / "folder";
-  {  // .dll file extention
+  {  // .dll file extension
     const std::vector<std::filesystem::path> file_names =
         GetStandardSymbolFilenamesForModule(directory / "lib.dll", object_file_type);
     EXPECT_THAT(file_names, testing::Contains("lib.pdb"));
@@ -47,7 +48,7 @@ TEST(GetStandardSymbolFilenamesForModule, CoffFile) {
     EXPECT_THAT(file_names, testing::Contains("lib.pdb"));
   }
 
-  {  // generic file extention (.ext)
+  {  // generic file extension (.ext)
     const std::vector<std::filesystem::path> file_names =
         GetStandardSymbolFilenamesForModule(directory / "lib.ext", object_file_type);
     EXPECT_THAT(file_names, testing::Contains("lib.pdb"));
@@ -56,75 +57,119 @@ TEST(GetStandardSymbolFilenamesForModule, CoffFile) {
   }
 }
 
-TEST(VerifySymbolFile, BuildId) {
+TEST(SymbolUtils, VerifySymbolFile) {
   const std::filesystem::path testdata_directory = orbit_test::GetTestdataDir();
   {
-    // valid elf file containing symbols and matching build id
-    std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf.debug";
-    std::string build_id = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
+    // ELF file with symbols and matching build id.
+    const std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf.debug";
+    const std::string build_id = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
     const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasValue());
+    EXPECT_THAT(result, HasNoError());
   }
   {
-    // valid elf file containing symbols, build id not matching;
-    std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf.debug";
-    std::string build_id = "incorrect build id";
-    const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasError("has a different build id"));
-  }
-  {
-    // valid elf file no symbols and matching build id
-    std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf";
-    std::string build_id = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
-    const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasError("does not contain symbols"));
-  }
-  {
-    // valid pdb file containing symbols and matching build id
-    std::filesystem::path symbols_file = testdata_directory / "dllmain.pdb";
-    std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
-    const auto result = VerifySymbolFile(symbols_file, build_id);
-    EXPECT_THAT(result, HasValue());
-  }
-  {
-    // valid pdb file containing symbols, build id not matching
-    std::filesystem::path symbols_file = testdata_directory / "dllmain.pdb";
-    std::string build_id = "incorrect build id";
+    // ELF file with symbols, but mis-matching build id.
+    const std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf.debug";
+    const std::string build_id = "incorrect build id";
     const auto result = VerifySymbolFile(symbols_file, build_id);
     EXPECT_THAT(result, HasError("has a different build id"));
   }
   {
-    // valid coff file no symbols and matching build id
-    std::filesystem::path symbols_file = testdata_directory / "dllmain.dll";
-    std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    // ELF file with matching build-id, but no symbols.
+    const std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf";
+    const std::string build_id = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
     const auto result = VerifySymbolFile(symbols_file, build_id);
     EXPECT_THAT(result, HasError("does not contain symbols"));
   }
   {
-    // invalid file
-    std::filesystem::path symbols_file = "path/to/invalid_file";
-    std::string build_id = "build id does not matter";
+    // PDB file with symbols and matching build id.
+    const std::filesystem::path symbols_file = testdata_directory / "dllmain.pdb";
+    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const auto result = VerifySymbolFile(symbols_file, build_id);
+    EXPECT_THAT(result, HasValue());
+  }
+  {
+    // PDB file with symbols, but mis-matching build id.
+    const std::filesystem::path symbols_file = testdata_directory / "dllmain.pdb";
+    const std::string build_id = "incorrect build id";
+    const auto result = VerifySymbolFile(symbols_file, build_id);
+    EXPECT_THAT(result, HasError("has a different build id"));
+  }
+  {
+    // COFF file with matching build id, but no symbols.
+    const std::filesystem::path symbols_file = testdata_directory / "dllmain.dll";
+    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const auto result = VerifySymbolFile(symbols_file, build_id);
+    EXPECT_THAT(result, HasError("does not contain symbols"));
+  }
+  {
+    // File doesn't exist.
+    const std::filesystem::path symbols_file = "path/to/invalid_file";
+    const std::string build_id = "build id does not matter";
     const auto result = VerifySymbolFile(symbols_file, build_id);
     EXPECT_THAT(result, HasError("Unable to create symbols file"));
   }
 }
 
-TEST(VerifySymbolFile, FileSize) {
-  constexpr uint64_t kNoSymbolsElfDebugFileSize = 45856;
-  constexpr uint64_t kIncorrectSymbolsFileSize = 123456;
-
+TEST(SymbolUtils, VerifyObjectFile) {
   const std::filesystem::path testdata_directory = orbit_test::GetTestdataDir();
   {
-    // a file of matching file size
-    std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf.debug";
-    const auto result = VerifySymbolFile(symbols_file, kNoSymbolsElfDebugFileSize);
-    EXPECT_THAT(result, HasValue());
+    // ELF file with matching build id.
+    const std::filesystem::path object_file = testdata_directory / "hello_world_elf";
+    const std::string build_id = "d12d54bc5b72ccce54a408bdeda65e2530740ac8";
+    const auto result = VerifyObjectFile(object_file, build_id);
+    EXPECT_THAT(result, HasNoError());
   }
   {
-    // a file of mis-matching file size
+    // ELF file with mis-matching build id.
+    const std::filesystem::path object_file = testdata_directory / "hello_world_elf";
+    const std::string build_id = "incorrect build-id";
+    const auto result = VerifyObjectFile(object_file, build_id);
+    EXPECT_THAT(result, HasError("has a different build id"));
+  }
+  {
+    // COFF file with matching build id.
+    const std::filesystem::path object_file = testdata_directory / "dllmain.dll";
+    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const auto result = VerifyObjectFile(object_file, build_id);
+    EXPECT_THAT(result, HasNoError());
+  }
+  {
+    // COFF file with mis-matching build id.
+    const std::filesystem::path object_file = testdata_directory / "dllmain.dll";
+    const std::string build_id = "incorrect build-id";
+    const auto result = VerifyObjectFile(object_file, build_id);
+    EXPECT_THAT(result, HasError("has a different build id"));
+  }
+  {
+    // PDB file.
+    const std::filesystem::path object_file = testdata_directory / "dllmain.pdb";
+    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const auto result = VerifyObjectFile(object_file, build_id);
+    EXPECT_THAT(result, HasError("The file was not recognized as a valid object file"));
+  }
+  {
+    // File doesn't exist.
+    const std::filesystem::path object_file = "path/to/nothing";
+    const std::string build_id = "build id does not matter";
+    const auto result = VerifyObjectFile(object_file, build_id);
+    EXPECT_THAT(result, HasError("Unable to load object file"));
+  }
+}
+
+TEST(SymbolUtils, VerifyFileSize) {
+  constexpr uint64_t kNoSymbolsElfDebugFileSize = 45856;
+  const std::filesystem::path testdata_directory = orbit_test::GetTestdataDir();
+  {
+    // File of matching file size.
     std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf.debug";
-    const auto result = VerifySymbolFile(symbols_file, kIncorrectSymbolsFileSize);
-    EXPECT_THAT(result, HasError("file size doesn't match"));
+    const auto result = VerifyFileSize(symbols_file, kNoSymbolsElfDebugFileSize);
+    EXPECT_THAT(result, HasNoError());
+  }
+  {
+    // File of mis-matching file size.
+    std::filesystem::path symbols_file = testdata_directory / "no_symbols_elf.debug";
+    const auto result = VerifyFileSize(symbols_file, kNoSymbolsElfDebugFileSize + 1);
+    EXPECT_THAT(result, HasError("File size doesn't match"));
   }
 }
 

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -29,7 +29,7 @@ class SymbolHelper : public SymbolCacheInterface {
  public:
   explicit SymbolHelper(std::filesystem::path cache_directory);
   explicit SymbolHelper(std::filesystem::path cache_directory,
-                        std::vector<std::filesystem::path> structured_debug_directories);
+                        const std::vector<std::filesystem::path>& structured_debug_directories);
 
   ErrorMessageOr<std::filesystem::path> FindSymbolsFileLocally(
       const std::filesystem::path& module_path, const std::string& build_id,
@@ -39,13 +39,17 @@ class SymbolHelper : public SymbolCacheInterface {
                                                            const std::string& build_id) const;
   ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(const std::filesystem::path& module_path,
                                                            uint64_t expected_file_size) const;
+  ErrorMessageOr<std::filesystem::path> FindObjectInCache(const std::filesystem::path& module_path,
+                                                          const std::string& build_id,
+                                                          uint64_t expected_file_size) const;
+  [[nodiscard]] std::filesystem::path GenerateCachedFilePath(
+      const std::filesystem::path& file_path) const override;
+
   static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
       const std::filesystem::path& file_path,
       const orbit_object_utils::ObjectFileInfo& object_file_info);
   static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadFallbackSymbolsFromFile(
       const std::filesystem::path& file_path);
-  [[nodiscard]] std::filesystem::path GenerateCachedFilePath(
-      const std::filesystem::path& file_path) const override;
 
   [[nodiscard]] static bool IsMatchingDebugInfoFile(const std::filesystem::path& file_path,
                                                     uint32_t checksum);

--- a/src/Symbols/include/Symbols/SymbolUtils.h
+++ b/src/Symbols/include/Symbols/SymbolUtils.h
@@ -26,7 +26,7 @@ namespace orbit_symbols {
 // otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
                                                     const std::string& build_id);
-// CChecks if the file at symbol_file_path can be read as symbol file (elf, coff, pdb) and compares
+// Checks if the file at symbol_file_path can be read as symbol file (elf, coff, pdb) and compares
 // the size of the file with expected_file_size. Returns void if the sizes are the same,
 // ErrorMessage otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,

--- a/src/Symbols/include/Symbols/SymbolUtils.h
+++ b/src/Symbols/include/Symbols/SymbolUtils.h
@@ -26,11 +26,15 @@ namespace orbit_symbols {
 // ErrorMessage otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
                                                     const std::string& module_build_id);
-// Checks if the file at symbol_file_path can be read as symbol file (elf, coff, pdb) and compares
-// the size of the file with expected_file_size. Returns void if the sizes are the same ErrorMessage
+// Checks if the file at object_file_path can be read as an object file (elf, coff) and compares the
+// build id of the file with module_build_id. Returns void if build ids are the same, ErrorMessage
 // otherwise.
-[[nodiscard]] ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
-                                                    uint64_t expected_file_size);
+[[nodiscard]] ErrorMessageOr<void> VerifyObjectFile(const std::filesystem::path& object_file_path,
+                                                    const std::string& build_id);
+// Checks if the file at file_path has size expected_file_size. Returns void if the sizes are the
+// same, ErrorMessage otherwise.
+[[nodiscard]] ErrorMessageOr<void> VerifyFileSize(const std::filesystem::path& file_path,
+                                                  uint64_t expected_file_size);
 
 }  // namespace orbit_symbols
 

--- a/src/Symbols/include/Symbols/SymbolUtils.h
+++ b/src/Symbols/include/Symbols/SymbolUtils.h
@@ -22,12 +22,12 @@ namespace orbit_symbols {
     const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type);
 
 // Checks if the file at symbol_file_path can be read as symbol file (elf, coff, pdb) and compares
-// the build id of the file with module_build_id. Returns void if build ids are the same,
-// ErrorMessage otherwise.
+// the build id of the file with build_id. Returns void if build ids are the same, ErrorMessage
+// otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
-                                                    const std::string& module_build_id);
+                                                    const std::string& build_id);
 // Checks if the file at object_file_path can be read as an object file (elf, coff) and compares the
-// build id of the file with module_build_id. Returns void if build ids are the same, ErrorMessage
+// build id of the file with build_id. Returns void if build ids are the same, ErrorMessage
 // otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifyObjectFile(const std::filesystem::path& object_file_path,
                                                     const std::string& build_id);

--- a/src/Symbols/include/Symbols/SymbolUtils.h
+++ b/src/Symbols/include/Symbols/SymbolUtils.h
@@ -26,15 +26,17 @@ namespace orbit_symbols {
 // otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
                                                     const std::string& build_id);
+// CChecks if the file at symbol_file_path can be read as symbol file (elf, coff, pdb) and compares
+// the size of the file with expected_file_size. Returns void if the sizes are the same,
+// ErrorMessage otherwise.
+[[nodiscard]] ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
+                                                    uint64_t expected_file_size);
 // Checks if the file at object_file_path can be read as an object file (elf, coff) and compares the
-// build id of the file with build_id. Returns void if build ids are the same, ErrorMessage
-// otherwise.
+// build id and size of the file with build_id and expected_file_size, respectively. Returns void if
+// the build ids and the sizes are the same, ErrorMessage otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifyObjectFile(const std::filesystem::path& object_file_path,
-                                                    const std::string& build_id);
-// Checks if the file at file_path has size expected_file_size. Returns void if the sizes are the
-// same, ErrorMessage otherwise.
-[[nodiscard]] ErrorMessageOr<void> VerifyFileSize(const std::filesystem::path& file_path,
-                                                  uint64_t expected_file_size);
+                                                    const std::string& build_id,
+                                                    uint64_t expected_file_size);
 
 }  // namespace orbit_symbols
 


### PR DESCRIPTION
`SymbolHelper::FindObjectInCache` looks for the module itself, so it checks both the build-id and the size. The corresponding `VerifyObjectFile` is added as well, which checks for both build id and file size as we want an exact match.

This will be used in the context of the "fallback symbols": when symbols are not available, we cache the module itself. This method will check whether the module is already in the cache (it doesn't need to have symbols) after the whole search for symbols has completed (including in the cache).

Bug: http://b/245680119

Test:
- New unit tests.
- As part of the larger symbol loading fallback prototype.