### PR TITLE
Refactor how ScopeId->FunctionInfo is found in LiveTab

### DIFF
--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -17,7 +17,6 @@
 #include "ClientData/ModuleData.h"
 #include "ClientData/ScopeId.h"
 #include "ClientData/ScopeInfo.h"
-#include "ModuleUtils/VirtualAndAbsoluteAddresses.h"
 #include "OrbitBase/Result.h"
 
 using orbit_grpc_protos::CaptureStarted;
@@ -45,8 +44,6 @@ CaptureData::CaptureData(CaptureStarted capture_started,
   process_info.set_name(executable_path.filename().string());
   process_info.set_is_64_bit(true);
   process_.SetProcessInfo(process_info);
-
-  absl::flat_hash_map<uint64_t, FunctionInfo> instrumented_functions;
 
   for (const auto& instrumented_function :
        capture_started_.capture_options().instrumented_functions()) {
@@ -124,6 +121,10 @@ const InstrumentedFunction* CaptureData::GetInstrumentedFunctionById(uint64_t fu
     return nullptr;
   }
   return &instrumented_functions_it->second;
+}
+
+const FunctionInfo* CaptureData::GetFunctionInfoByScopeId(ScopeId scope_id) const {
+  return scope_id_provider_->GetFunctionInfo(scope_id);
 }
 
 // InstrumentedFunction::function_virtual_address() was added in 1.82: if this is not available,

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "ClientData/FunctionInfo.h"
@@ -42,9 +43,9 @@ std::unique_ptr<NameEqualityScopeIdProvider> NameEqualityScopeIdProvider::Create
     const ScopeId scope_id{instrumented_function.function_id()};
     const ScopeInfo scope_info(instrumented_function.function_name(),
                                ScopeType::kDynamicallyInstrumentedFunction);
-    scope_id_to_info.emplace(scope_id, scope_info);
-    scope_info_to_id.emplace(scope_info, scope_id);
-    scope_id_to_function_info.emplace(
+    scope_id_to_info.try_emplace(scope_id, scope_info);
+    scope_info_to_id.try_emplace(scope_info, scope_id);
+    scope_id_to_function_info.try_emplace(
         scope_id,
         FunctionInfo{instrumented_function.file_path(), instrumented_function.file_build_id(),
                      instrumented_function.function_virtual_address(),

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<NameEqualityScopeIdProvider> NameEqualityScopeIdProvider::Create
     scope_id_to_info.try_emplace(scope_id, scope_info);
     scope_info_to_id.try_emplace(scope_info, scope_id);
     scope_id_to_function_info.try_emplace(
-        scope_id, /* piecewise_construct FunctionInfo */ instrumented_function.file_path(),
+        scope_id, /* in-place FunctionInfo construction */ instrumented_function.file_path(),
         instrumented_function.file_build_id(), instrumented_function.function_virtual_address(),
         instrumented_function.function_size(), instrumented_function.function_name());
   }

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -46,10 +46,9 @@ std::unique_ptr<NameEqualityScopeIdProvider> NameEqualityScopeIdProvider::Create
     scope_id_to_info.try_emplace(scope_id, scope_info);
     scope_info_to_id.try_emplace(scope_info, scope_id);
     scope_id_to_function_info.try_emplace(
-        scope_id,
-        FunctionInfo{instrumented_function.file_path(), instrumented_function.file_build_id(),
-                     instrumented_function.function_virtual_address(),
-                     instrumented_function.function_size(), instrumented_function.function_name()});
+        scope_id, /* piecewise_construct FunctionInfo */ instrumented_function.file_path(),
+        instrumented_function.file_build_id(), instrumented_function.function_virtual_address(),
+        instrumented_function.function_size(), instrumented_function.function_name());
   }
 
   return std::unique_ptr<NameEqualityScopeIdProvider>(new NameEqualityScopeIdProvider(

--- a/src/ClientData/ScopeIdProviderTest.cpp
+++ b/src/ClientData/ScopeIdProviderTest.cpp
@@ -115,18 +115,29 @@ TEST(NameEqualityScopeIdProviderTest, SyncAndAsyncScopesOfTheSameNameGetDifferen
 constexpr size_t kFunctionCount = 3;
 constexpr std::array<uint64_t, kFunctionCount> kFunctionIds = {10, 13, 15};
 const std::array<std::string, kFunctionCount> kFunctionNames = {"foo()", "bar()", "baz()"};
+const std::array<std::string, kFunctionCount> kFilePaths = {"path1", "path2", "path3"};
+const std::array<std::string, kFunctionCount> kFileBuildId = {"123", "345", "567"};
+const std::array<uint64_t, kFunctionCount> kFunctionVirtualAddress = {111, 333, 999};
+const std::array<uint64_t, kFunctionCount> kFunctionSize = {57, 108, 23};
 
 static void AddInstrumentedFunction(orbit_grpc_protos::CaptureOptions& capture_options,
-                                    uint64_t function_id, const std::string& name) {
+                                    uint64_t function_id, const std::string& name,
+                                    const std::string& file_path, const std::string& build_id,
+                                    uint64_t virtual_address, uint64_t size) {
   orbit_grpc_protos::InstrumentedFunction* function = capture_options.add_instrumented_functions();
   function->set_function_id(function_id);
   function->set_function_name(name);
+  function->set_file_path(file_path);
+  function->set_file_build_id(build_id);
+  function->set_function_virtual_address(virtual_address);
+  function->set_function_size(size);
 }
 
 TEST(NameEqualityScopeIdProviderTest, CreateIsCorrect) {
   orbit_grpc_protos::CaptureOptions capture_options;
   for (size_t i = 0; i < kFunctionCount; ++i) {
-    AddInstrumentedFunction(capture_options, kFunctionIds[i], kFunctionNames[i]);
+    AddInstrumentedFunction(capture_options, kFunctionIds[i], kFunctionNames[i], kFilePaths[i],
+                            kFileBuildId[i], kFunctionVirtualAddress[i], kFunctionSize[i]);
   }
 
   auto id_provider = NameEqualityScopeIdProvider::Create(capture_options);
@@ -138,6 +149,10 @@ TEST(NameEqualityScopeIdProviderTest, CreateIsCorrect) {
   for (size_t i = 0; i < kFunctionCount; ++i) {
     const ScopeInfo expected{kFunctionNames[i], ScopeType::kDynamicallyInstrumentedFunction};
     EXPECT_EQ(id_provider->GetScopeInfo(ScopeId(kFunctionIds[i])), expected);
+    const FunctionInfo expect_function_info{kFilePaths[i], kFileBuildId[i],
+                                            kFunctionVirtualAddress[i], kFunctionSize[i],
+                                            kFunctionNames[i]};
+    EXPECT_EQ(*id_provider->GetFunctionInfo(ScopeId(kFunctionIds[i])), expect_function_info);
   }
 }
 

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -25,7 +25,6 @@
 #include "ClientData/CallstackInfo.h"
 #include "ClientData/FunctionInfo.h"
 #include "ClientData/LinuxAddressInfo.h"
-#include "ClientData/ModuleData.h"
 #include "ClientData/ModuleManager.h"
 #include "ClientData/PostProcessedSamplingData.h"
 #include "ClientData/ProcessData.h"
@@ -34,11 +33,9 @@
 #include "ClientData/ScopeStats.h"
 #include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientData/ThreadTrackDataProvider.h"
-#include "ClientData/TimerChain.h"
 #include "ClientData/TimerData.h"
 #include "ClientData/TimerDataManager.h"
 #include "ClientData/TimestampIntervalSet.h"
-#include "ClientData/TracepointCustom.h"
 #include "ClientData/TracepointData.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/capture.pb.h"
@@ -83,6 +80,8 @@ class CaptureData {
 
   [[nodiscard]] const orbit_grpc_protos::InstrumentedFunction* GetInstrumentedFunctionById(
       uint64_t function_id) const;
+
+  const FunctionInfo* GetFunctionInfoByScopeId(ScopeId scope_id) const;
 
   void ComputeVirtualAddressOfInstrumentedFunctionsIfNecessary(const ModuleManager& module_manager);
 

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <optional>
 
+#include "ClientData/FunctionInfo.h"
 #include "ClientData/ScopeId.h"
 #include "ClientData/ScopeInfo.h"
 #include "ClientData/TimerTrackDataIdManager.h"
@@ -37,6 +38,8 @@ class ScopeIdProvider {
   [[nodiscard]] virtual std::vector<ScopeId> GetAllProvidedScopeIds() const = 0;
 
   [[nodiscard]] virtual const ScopeInfo& GetScopeInfo(ScopeId scope_id) const = 0;
+
+  [[nodiscard]] virtual const FunctionInfo* GetFunctionInfo(ScopeId scope_id) const = 0;
 };
 
 // This class, unless the timer does already have an id (`function_id`), it assigning an id for
@@ -64,14 +67,18 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
 
   [[nodiscard]] const ScopeInfo& GetScopeInfo(ScopeId scope_id) const override;
 
+  [[nodiscard]] const FunctionInfo* GetFunctionInfo(ScopeId scope_id) const override;
+
  private:
   explicit NameEqualityScopeIdProvider(
       uint64_t start_id, absl::flat_hash_map<const ScopeInfo, ScopeId> scope_info_to_id,
-      absl::flat_hash_map<ScopeId, const ScopeInfo> scope_id_to_info)
+      absl::flat_hash_map<ScopeId, const ScopeInfo> scope_id_to_info,
+      absl::flat_hash_map<ScopeId, const FunctionInfo> scope_id_to_function_info)
       : next_id_(ScopeId(start_id)),
         max_instrumented_function_id_(ScopeId(start_id - 1)),
         scope_info_to_id_(std::move(scope_info_to_id)),
-        scope_id_to_info_(std::move(scope_id_to_info)) {}
+        scope_id_to_info_(std::move(scope_id_to_info)),
+        scope_id_to_function_info_(std::move(scope_id_to_function_info)) {}
 
   [[nodiscard]] std::optional<ScopeId> GetExistingScopeId(const ScopeInfo& scope_info) const
       ABSL_SHARED_LOCKS_REQUIRED(mutex_);
@@ -80,6 +87,7 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   ScopeId max_instrumented_function_id_{};
   absl::flat_hash_map<const ScopeInfo, ScopeId> scope_info_to_id_ ABSL_GUARDED_BY(mutex_);
   absl::flat_hash_map<ScopeId, const ScopeInfo> scope_id_to_info_ ABSL_GUARDED_BY(mutex_);
+  absl::flat_hash_map<ScopeId, const FunctionInfo> scope_id_to_function_info_;
   mutable absl::Mutex mutex_;
 };
 

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -87,6 +87,7 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   ScopeId max_instrumented_function_id_{};
   absl::flat_hash_map<const ScopeInfo, ScopeId> scope_info_to_id_ ABSL_GUARDED_BY(mutex_);
   absl::flat_hash_map<ScopeId, const ScopeInfo> scope_id_to_info_ ABSL_GUARDED_BY(mutex_);
+  /// TODO(http://b/247467504): Add FunctionInfo to ScopeInfo.
   absl::flat_hash_map<ScopeId, const FunctionInfo> scope_id_to_function_info_;
   mutable absl::Mutex mutex_;
 };

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -463,7 +463,7 @@ void LiveFunctionsDataView::DoFilter() {
     }
 
     if (match) {
-      AddToIndices(scope_id);
+      AddScope(scope_id);
     }
   }
 
@@ -486,7 +486,7 @@ void LiveFunctionsDataView::OnDataChanged() {
 
   std::vector<ScopeId> all_scope_ids = app_->GetCaptureData().GetAllProvidedScopeIds();
   for (ScopeId scope_id : all_scope_ids) {
-    AddToIndices(scope_id);
+    AddScope(scope_id);
   }
 
   DataView::OnDataChanged();
@@ -499,7 +499,7 @@ void LiveFunctionsDataView::OnTimer() {
 
   indices_.reserve(indices_.size() + missing_scope_ids.size());
   for (ScopeId scope_id : missing_scope_ids) {
-    AddToIndices(scope_id);
+    AddScope(scope_id);
   }
 
   OnSort(sorting_column_, {});

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -248,7 +248,7 @@ class LiveFunctionsDataViewTest : public testing::Test {
     std::set index_set(indices.begin(), indices.end());
     for (size_t index : index_set) {
       ORBIT_CHECK(index < kNumFunctions);
-      view_.AddToIndices(kScopeIds[index]);
+      view_.AddScope(kScopeIds[index]);
     }
   }
 

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -27,7 +27,6 @@
 #include "DataViews/LiveFunctionsDataView.h"
 #include "DataViews/LiveFunctionsInterface.h"
 #include "DisplayFormats/DisplayFormats.h"
-#include "GrpcProtos/Constants.h"
 #include "GrpcProtos/capture.pb.h"
 #include "MetricsUploader/MetricsUploaderStub.h"
 #include "MockAppInterface.h"
@@ -249,7 +248,7 @@ class LiveFunctionsDataViewTest : public testing::Test {
     std::set index_set(indices.begin(), indices.end());
     for (size_t index : index_set) {
       ORBIT_CHECK(index < kNumFunctions);
-      view_.AddFunction(kScopeIds[index], functions_.at(kScopeIds[index]));
+      view_.AddToIndices(kScopeIds[index]);
     }
   }
 

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -60,7 +60,7 @@ class LiveFunctionsDataView : public DataView {
 
   std::string GetToolTip(int /*row*/, int column) override;
 
-  void AddToIndices(ScopeId scope_id) {
+  void AddScope(ScopeId scope_id) {
     ORBIT_CHECK(app_->HasCaptureData());
     const ScopeId max_scope_id = app_->GetCaptureData().GetMaxId();
     ORBIT_CHECK(scope_id <= max_scope_id);


### PR DESCRIPTION
Move scope_id_to_function_info_ into ScopeIdProvider; all of the required fields for function_info are already there and shouldn't need to be recalculated. GetAllProvidedScopeIds should be a superset of instrumented_functions in CaptureData so we aren't losing any.

This will also help future PRs as my goal here is to simplify where LiveTab gets its data so it can act on a smaller data set rather than all of CaptureData.

Bug: http://b/240112049