### PR TITLE
Add SymbolHelper::LoadFallbackSymbolsFromFile

### DIFF
--- a/src/ObjectUtils/ObjectFile.cpp
+++ b/src/ObjectUtils/ObjectFile.cpp
@@ -31,7 +31,7 @@ ErrorMessageOr<std::unique_ptr<ObjectFile>> CreateObjectFile(
       llvm::object::ObjectFile::createObjectFile(file_path_llvm);
 
   if (!object_file_or_error) {
-    return ErrorMessage(absl::StrFormat("Unable to load ELF file \"%s\": %s", file_path.string(),
+    return ErrorMessage(absl::StrFormat("Unable to load object file \"%s\": %s", file_path.string(),
                                         llvm::toString(object_file_or_error.takeError())));
   }
 

--- a/src/ProcessService/ProcessServiceUtilsTest.cpp
+++ b/src/ProcessService/ProcessServiceUtilsTest.cpp
@@ -120,13 +120,13 @@ TEST(ProcessServiceUtils, FindSymbolsFilePath) {
     EXPECT_EQ(result_path, symbols_path);
   }
 
-  {  // non existing module (elf_file)
+  {  // non existing module
     const std::filesystem::path module_path = test_directory / "not_existing_file";
     GetDebugInfoFileRequest request;
     request.set_module_path(module_path.string());
     request.add_additional_search_directories(test_directory);
     const ErrorMessageOr<NotFoundOr<std::filesystem::path>> result = FindSymbolsFilePath(request);
-    EXPECT_THAT(result, HasError("Unable to load ELF file"));
+    EXPECT_THAT(result, HasError("Unable to load object file"));
   }
 
   {  // elf - no build id, but does include symbols

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -24,6 +24,7 @@
 
 #include "Introspection/Introspection.h"
 #include "ObjectUtils/ElfFile.h"
+#include "ObjectUtils/ObjectFile.h"
 #include "ObjectUtils/SymbolsFile.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/File.h"
@@ -42,6 +43,7 @@ using orbit_grpc_protos::ModuleSymbols;
 
 namespace fs = std::filesystem;
 using orbit_grpc_protos::ModuleInfo;
+using orbit_object_utils::CreateObjectFile;
 using orbit_object_utils::CreateSymbolsFile;
 using orbit_object_utils::ElfFile;
 using orbit_object_utils::ObjectFileInfo;
@@ -277,6 +279,15 @@ ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsFromFile(
 
   OUTCOME_TRY(auto symbols_file, CreateSymbolsFile(file_path, object_file_info));
   return symbols_file->LoadDebugSymbols();
+}
+
+ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> SymbolHelper::LoadFallbackSymbolsFromFile(
+    const std::filesystem::path& file_path) {
+  ORBIT_SCOPE_FUNCTION;
+  ORBIT_SCOPED_TIMED_LOG("LoadFallbackSymbolsFromFile: %s", file_path.string());
+
+  OUTCOME_TRY(auto object_file, CreateObjectFile(file_path));
+  return object_file->LoadDynamicLinkingSymbolsAndUnwindRangesAsSymbols();
 }
 
 fs::path SymbolHelper::GenerateCachedFilePath(const fs::path& file_path) const {

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -373,7 +373,7 @@ TEST(SymbolHelper, LoadFallbackSymbolsFromFile) {
     const fs::path file_path = testdata_directory / "file_does_not_exist";
     const auto result = SymbolHelper::LoadFallbackSymbolsFromFile(file_path);
     EXPECT_THAT(result, HasError("Unable to load object file"));
-    EXPECT_THAT(result, HasError("No such file or directory"));
+    EXPECT_THAT(result, HasError("such file or directory"));
   }
 }
 

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -42,6 +42,8 @@ class SymbolHelper : public SymbolCacheInterface {
   static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
       const std::filesystem::path& file_path,
       const orbit_object_utils::ObjectFileInfo& object_file_info);
+  static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadFallbackSymbolsFromFile(
+      const std::filesystem::path& file_path);
   [[nodiscard]] std::filesystem::path GenerateCachedFilePath(
       const std::filesystem::path& file_path) const override;
 


### PR DESCRIPTION
This will be used in the context of the "fallback symbols" to load, well, those "symbols". It's simply the counterpart of `LoadSymbolsFromFile` and calls `ObjectFile::LoadDynamicLinkingSymbolsAndUnwindRangesAsSymbols`.

Bug: http://b/245680119

Test:
- New unit tests.
- As part of the larger symbol loading fallback prototype.