### PR TITLE
Allow Sampling Model Report to show baseline and comparison names

### DIFF
--- a/src/MizarWidgets/SamplingWithFrameTrackOutputWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackOutputWidget.cpp
@@ -31,7 +31,8 @@ SamplingWithFrameTrackOutputWidget::~SamplingWithFrameTrackOutputWidget() = defa
 
 void SamplingWithFrameTrackOutputWidget::UpdateReport(Report report) {
   model_ = new SamplingWithFrameTrackReportModel(  // NOLINT
-      std::move(report), is_multiplicity_correction_enabled_, confidence_level_, this);
+      std::move(report), is_multiplicity_correction_enabled_, confidence_level_,
+      function_name_to_show_, this);
 
   auto* proxy_model = new QSortFilterProxyModel(this);  // NOLINT
   proxy_model->setSourceModel(model_);

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackOutputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackOutputWidget.h
@@ -44,6 +44,8 @@ class SamplingWithFrameTrackOutputWidget : public QWidget {
   SamplingWithFrameTrackReportModel* model_{};
   bool is_multiplicity_correction_enabled_ = true;
   double confidence_level_ = 0.05;
+  SamplingWithFrameTrackReportModel::FunctionNameToShow function_name_to_show_ =
+      SamplingWithFrameTrackReportModel::FunctionNameToShow::kBaseline;
   std::unique_ptr<Ui::SamplingWithFrameTrackOutputWidget> ui_;
 };
 


### PR DESCRIPTION
As we are preparing for non-equal-name function matching, we need to provide a way to 
visualize both the names that come from the baseline and from the comparison captures.

Tests: Unit
Bug: http://b/247072330