### PR TITLE
Add ModuleData::SymbolCompleteness and ModuleData::AddFallbackSymbols

### DIFF
--- a/src/ClientData/ModuleData.cpp
+++ b/src/ClientData/ModuleData.cpp
@@ -17,76 +17,68 @@ using orbit_grpc_protos::ModuleInfo;
 
 namespace orbit_client_data {
 
-ModuleData::ModuleData(ModuleInfo module_info)
-    : name_(std::move(*module_info.mutable_name())),
-      file_path_(std::move(*module_info.mutable_file_path())),
-      file_size_{module_info.file_size()},
-      build_id_{std::move(*module_info.mutable_build_id())},
-      load_bias_{module_info.load_bias()},
-      object_file_type_{module_info.object_file_type()},
-      executable_segment_offset_{module_info.executable_segment_offset()},
-      object_segments_{module_info.object_segments().begin(), module_info.object_segments().end()} {
-}
-
-orbit_symbol_provider::ModuleIdentifier ModuleData::module_id() const {
-  absl::MutexLock lock(&mutex_);
-  return orbit_symbol_provider::ModuleIdentifier{file_path_, build_id_};
-}
-
-const std::vector<ModuleInfo::ObjectSegment>& ModuleData::GetObjectSegments() const {
-  absl::MutexLock lock(&mutex_);
-  return object_segments_;
-}
+ModuleData::ModuleData(ModuleInfo module_info) : module_info_{std::move(module_info)} {}
 
 const std::string& ModuleData::name() const {
   absl::MutexLock lock(&mutex_);
-  return name_;
+  return module_info_.name();
 }
 
 const std::string& ModuleData::file_path() const {
   absl::MutexLock lock(&mutex_);
-  return file_path_;
+  return module_info_.file_path();
 }
 
 uint64_t ModuleData::file_size() const {
   absl::MutexLock lock(&mutex_);
-  return file_size_;
+  return module_info_.file_size();
 }
 
 const std::string& ModuleData::build_id() const {
   absl::MutexLock lock(&mutex_);
-  return build_id_;
+  return module_info_.build_id();
 }
 
 uint64_t ModuleData::load_bias() const {
   absl::MutexLock lock(&mutex_);
-  return load_bias_;
-}
-
-ModuleInfo::ObjectFileType ModuleData::object_file_type() const {
-  absl::MutexLock lock(&mutex_);
-  return object_file_type_;
+  return module_info_.load_bias();
 }
 
 uint64_t ModuleData::executable_segment_offset() const {
   absl::MutexLock lock(&mutex_);
-  return executable_segment_offset_;
+  return module_info_.executable_segment_offset();
+}
+
+ModuleInfo::ObjectFileType ModuleData::object_file_type() const {
+  absl::MutexLock lock(&mutex_);
+  return module_info_.object_file_type();
+}
+
+std::vector<ModuleInfo::ObjectSegment> ModuleData::GetObjectSegments() const {
+  absl::MutexLock lock(&mutex_);
+  return {module_info_.object_segments().begin(), module_info_.object_segments().end()};
+}
+
+orbit_symbol_provider::ModuleIdentifier ModuleData::module_id() const {
+  absl::MutexLock lock(&mutex_);
+  return orbit_symbol_provider::ModuleIdentifier{module_info_.file_path(), module_info_.build_id()};
 }
 
 uint64_t ModuleData::ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_address) const {
   absl::MutexLock lock(&mutex_);
 
-  if (object_file_type_ == orbit_grpc_protos::ModuleInfo::kElfFile) {
+  if (module_info_.object_file_type() == orbit_grpc_protos::ModuleInfo::kElfFile) {
     // For ELF files, we define the load bias as the difference between the executable loadable
     // segment's address and its offset. So note how, for the executable loadable segment (which we
     // assume functions belong to), this computation and the generic one below are equivalent:
     // load_bias = executable_loadable_segment_address - executable_loadable_segment_offset
     // function_address - load_bias = function_address - executable_loadable_segment_address +
     //                                executable_loadable_segment_offset
-    return virtual_address - load_bias_;
+    return virtual_address - module_info_.load_bias();
   }
 
-  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment : object_segments_) {
+  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment :
+       module_info_.object_segments()) {
     if (segment.address() <= virtual_address &&
         virtual_address < segment.address() + segment.size_in_memory()) {
       return virtual_address - segment.address() + segment.offset_in_file();
@@ -94,64 +86,55 @@ uint64_t ModuleData::ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_ad
   }
 
   // Fall back to the ELF-specific computation if we didn't find a containing segment.
-  return virtual_address - load_bias_;
+  return virtual_address - module_info_.load_bias();
 }
 
 uint64_t ModuleData::ConvertFromOffsetInFileToVirtualAddress(uint64_t offset_in_file) const {
   absl::MutexLock lock(&mutex_);
 
-  if (object_file_type_ == orbit_grpc_protos::ModuleInfo::kElfFile) {
-    return offset_in_file + load_bias_;
+  if (module_info_.object_file_type() == orbit_grpc_protos::ModuleInfo::kElfFile) {
+    return offset_in_file + module_info_.load_bias();
   }
 
-  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment : object_segments_) {
+  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment :
+       module_info_.object_segments()) {
     if (segment.offset_in_file() <= offset_in_file &&
         offset_in_file < segment.offset_in_file() + segment.size_in_file()) {
       return offset_in_file - segment.offset_in_file() + segment.address();
     }
   }
 
-  return offset_in_file + load_bias_;
+  return offset_in_file + module_info_.load_bias();
 }
 
-bool ModuleData::NeedsUpdate(const orbit_grpc_protos::ModuleInfo& info) const {
+bool ModuleData::NeedsUpdate(const orbit_grpc_protos::ModuleInfo& new_module_info) const {
   mutex_.AssertHeld();
-  return name_ != info.name() || file_size_ != info.file_size() || load_bias_ != info.load_bias();
+  return module_info_.name() != new_module_info.name() ||
+         module_info_.file_size() != new_module_info.file_size() ||
+         module_info_.load_bias() != new_module_info.load_bias();
 }
 
-void ModuleData::UpdateFromModuleInfo(ModuleInfo module_info) {
-  mutex_.AssertHeld();
-  name_ = std::move(*module_info.mutable_name());
-  file_path_ = std::move(*module_info.mutable_file_path());
-  file_size_ = module_info.file_size();
-  build_id_ = std::move(*module_info.mutable_build_id());
-  load_bias_ = module_info.load_bias();
-  object_file_type_ = module_info.object_file_type();
-  executable_segment_offset_ = module_info.executable_segment_offset();
-  object_segments_ = {module_info.object_segments().begin(), module_info.object_segments().end()};
-}
-
-bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo info) {
+bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo new_module_info) {
   absl::MutexLock lock(&mutex_);
 
-  ORBIT_CHECK(file_path_ == info.file_path());
-  ORBIT_CHECK(build_id_ == info.build_id());
-  ORBIT_CHECK(object_file_type_ == info.object_file_type());
+  ORBIT_CHECK(module_info_.file_path() == new_module_info.file_path());
+  ORBIT_CHECK(module_info_.build_id() == new_module_info.build_id());
+  ORBIT_CHECK(module_info_.object_file_type() == new_module_info.object_file_type());
 
-  if (!NeedsUpdate(info)) return false;
+  if (!NeedsUpdate(new_module_info)) return false;
 
   // The update only makes sense if build_id is empty.
-  ORBIT_CHECK(build_id_.empty());
+  ORBIT_CHECK(module_info_.build_id().empty());
 
-  UpdateFromModuleInfo(std::move(info));
+  module_info_ = std::move(new_module_info);
 
   ORBIT_LOG("WARNING: Module \"%s\" changed and will be updated (it does not have build_id).",
-            file_path_);
+            module_info_.file_path());
 
   if (loaded_symbols_completeness_ <= SymbolCompleteness::kNoSymbols) return false;
 
   ORBIT_LOG("Module %s contained symbols. Because the module changed, those are now removed.",
-            file_path_);
+            module_info_.file_path());
   functions_.clear();
   hash_to_function_map_.clear();
   loaded_symbols_completeness_ = SymbolCompleteness::kNoSymbols;
@@ -159,21 +142,21 @@ bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo info) {
   return true;
 }
 
-bool ModuleData::UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo info) {
+bool ModuleData::UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo new_module_info) {
   absl::MutexLock lock(&mutex_);
 
-  ORBIT_CHECK(file_path_ == info.file_path());
-  ORBIT_CHECK(build_id_ == info.build_id());
-  ORBIT_CHECK(object_file_type_ == info.object_file_type());
+  ORBIT_CHECK(module_info_.file_path() == new_module_info.file_path());
+  ORBIT_CHECK(module_info_.build_id() == new_module_info.build_id());
+  ORBIT_CHECK(module_info_.object_file_type() == new_module_info.object_file_type());
 
-  if (!NeedsUpdate(info)) return true;
+  if (!NeedsUpdate(new_module_info)) return true;
 
   // The update only makes sense if build_id is empty.
-  ORBIT_CHECK(build_id_.empty());
+  ORBIT_CHECK(module_info_.build_id().empty());
 
   if (loaded_symbols_completeness_ > SymbolCompleteness::kNoSymbols) return false;
 
-  UpdateFromModuleInfo(std::move(info));
+  module_info_ = std::move(new_module_info);
   return true;
 }
 
@@ -256,7 +239,8 @@ void ModuleData::AddSymbolsInternal(const orbit_grpc_protos::ModuleSymbols& modu
   uint32_t name_reuse_counter = 0;
   for (const orbit_grpc_protos::SymbolInfo& symbol_info : module_symbols.symbol_infos()) {
     auto [inserted_it, success_functions] = functions_.try_emplace(
-        symbol_info.address(), std::make_unique<FunctionInfo>(symbol_info, file_path_, build_id_));
+        symbol_info.address(), std::make_unique<FunctionInfo>(symbol_info, module_info_.file_path(),
+                                                              module_info_.build_id()));
     FunctionInfo* function = inserted_it->second.get();
     // It happens that the same address has multiple symbol names associated
     // with it. For example: (all the same address)
@@ -282,14 +266,14 @@ void ModuleData::AddSymbolsInternal(const orbit_grpc_protos::ModuleSymbols& modu
   }
   if (address_reuse_counter != 0) {
     ORBIT_LOG("Warning: %d absolute addresses are used by more than one symbol for \"%s\"",
-              address_reuse_counter, name_);
+              address_reuse_counter, module_info_.name());
   }
   if (name_reuse_counter != 0) {
     ORBIT_LOG(
         "Warning: %d function name collisions happened (functions with the same demangled name) "
         "for \"%s\". This is currently not supported by presets, since presets are based on the "
         "demangled name.",
-        name_reuse_counter, name_);
+        name_reuse_counter, module_info_.name());
   }
 
   loaded_symbols_completeness_ = completeness;

--- a/src/ClientData/ModuleData.cpp
+++ b/src/ClientData/ModuleData.cpp
@@ -17,26 +17,76 @@ using orbit_grpc_protos::ModuleInfo;
 
 namespace orbit_client_data {
 
-std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> ModuleData::GetObjectSegments() const {
+ModuleData::ModuleData(ModuleInfo module_info)
+    : name_(std::move(*module_info.mutable_name())),
+      file_path_(std::move(*module_info.mutable_file_path())),
+      file_size_{module_info.file_size()},
+      build_id_{std::move(*module_info.mutable_build_id())},
+      load_bias_{module_info.load_bias()},
+      object_file_type_{module_info.object_file_type()},
+      executable_segment_offset_{module_info.executable_segment_offset()},
+      object_segments_{module_info.object_segments().begin(), module_info.object_segments().end()} {
+}
+
+orbit_symbol_provider::ModuleIdentifier ModuleData::module_id() const {
   absl::MutexLock lock(&mutex_);
-  return {module_info_.object_segments().begin(), module_info_.object_segments().end()};
+  return orbit_symbol_provider::ModuleIdentifier{file_path_, build_id_};
+}
+
+const std::vector<ModuleInfo::ObjectSegment>& ModuleData::GetObjectSegments() const {
+  absl::MutexLock lock(&mutex_);
+  return object_segments_;
+}
+
+const std::string& ModuleData::name() const {
+  absl::MutexLock lock(&mutex_);
+  return name_;
+}
+
+const std::string& ModuleData::file_path() const {
+  absl::MutexLock lock(&mutex_);
+  return file_path_;
+}
+
+uint64_t ModuleData::file_size() const {
+  absl::MutexLock lock(&mutex_);
+  return file_size_;
+}
+
+const std::string& ModuleData::build_id() const {
+  absl::MutexLock lock(&mutex_);
+  return build_id_;
+}
+
+uint64_t ModuleData::load_bias() const {
+  absl::MutexLock lock(&mutex_);
+  return load_bias_;
+}
+
+ModuleInfo::ObjectFileType ModuleData::object_file_type() const {
+  absl::MutexLock lock(&mutex_);
+  return object_file_type_;
+}
+
+uint64_t ModuleData::executable_segment_offset() const {
+  absl::MutexLock lock(&mutex_);
+  return executable_segment_offset_;
 }
 
 uint64_t ModuleData::ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_address) const {
   absl::MutexLock lock(&mutex_);
 
-  if (object_file_type() == orbit_grpc_protos::ModuleInfo::kElfFile) {
+  if (object_file_type_ == orbit_grpc_protos::ModuleInfo::kElfFile) {
     // For ELF files, we define the load bias as the difference between the executable loadable
     // segment's address and its offset. So note how, for the executable loadable segment (which we
     // assume functions belong to), this computation and the generic one below are equivalent:
     // load_bias = executable_loadable_segment_address - executable_loadable_segment_offset
     // function_address - load_bias = function_address - executable_loadable_segment_address +
     //                                executable_loadable_segment_offset
-    return virtual_address - load_bias();
+    return virtual_address - load_bias_;
   }
 
-  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment :
-       module_info_.object_segments()) {
+  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment : object_segments_) {
     if (segment.address() <= virtual_address &&
         virtual_address < segment.address() + segment.size_in_memory()) {
       return virtual_address - segment.address() + segment.offset_in_file();
@@ -44,53 +94,64 @@ uint64_t ModuleData::ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_ad
   }
 
   // Fall back to the ELF-specific computation if we didn't find a containing segment.
-  return virtual_address - load_bias();
+  return virtual_address - load_bias_;
 }
 
 uint64_t ModuleData::ConvertFromOffsetInFileToVirtualAddress(uint64_t offset_in_file) const {
   absl::MutexLock lock(&mutex_);
 
-  if (object_file_type() == orbit_grpc_protos::ModuleInfo::kElfFile) {
-    return offset_in_file + load_bias();
+  if (object_file_type_ == orbit_grpc_protos::ModuleInfo::kElfFile) {
+    return offset_in_file + load_bias_;
   }
 
-  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment :
-       module_info_.object_segments()) {
+  for (const orbit_grpc_protos::ModuleInfo::ObjectSegment& segment : object_segments_) {
     if (segment.offset_in_file() <= offset_in_file &&
         offset_in_file < segment.offset_in_file() + segment.size_in_file()) {
       return offset_in_file - segment.offset_in_file() + segment.address();
     }
   }
 
-  return offset_in_file + load_bias();
+  return offset_in_file + load_bias_;
 }
 
 bool ModuleData::NeedsUpdate(const orbit_grpc_protos::ModuleInfo& info) const {
-  return name() != info.name() || file_size() != info.file_size() ||
-         load_bias() != info.load_bias();
+  mutex_.AssertHeld();
+  return name_ != info.name() || file_size_ != info.file_size() || load_bias_ != info.load_bias();
+}
+
+void ModuleData::UpdateFromModuleInfo(ModuleInfo module_info) {
+  mutex_.AssertHeld();
+  name_ = std::move(*module_info.mutable_name());
+  file_path_ = std::move(*module_info.mutable_file_path());
+  file_size_ = module_info.file_size();
+  build_id_ = std::move(*module_info.mutable_build_id());
+  load_bias_ = module_info.load_bias();
+  object_file_type_ = module_info.object_file_type();
+  executable_segment_offset_ = module_info.executable_segment_offset();
+  object_segments_ = {module_info.object_segments().begin(), module_info.object_segments().end()};
 }
 
 bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo info) {
   absl::MutexLock lock(&mutex_);
 
-  ORBIT_CHECK(file_path() == info.file_path());
-  ORBIT_CHECK(build_id() == info.build_id());
-  ORBIT_CHECK(object_file_type() == info.object_file_type());
+  ORBIT_CHECK(file_path_ == info.file_path());
+  ORBIT_CHECK(build_id_ == info.build_id());
+  ORBIT_CHECK(object_file_type_ == info.object_file_type());
 
   if (!NeedsUpdate(info)) return false;
 
   // The update only makes sense if build_id is empty.
-  ORBIT_CHECK(build_id().empty());
+  ORBIT_CHECK(build_id_.empty());
 
-  module_info_ = std::move(info);
+  UpdateFromModuleInfo(std::move(info));
 
   ORBIT_LOG("WARNING: Module \"%s\" changed and will be updated (it does not have build_id).",
-            file_path());
+            file_path_);
 
   if (loaded_symbols_completeness_ <= SymbolCompleteness::kNoSymbols) return false;
 
   ORBIT_LOG("Module %s contained symbols. Because the module changed, those are now removed.",
-            file_path());
+            file_path_);
   functions_.clear();
   hash_to_function_map_.clear();
   loaded_symbols_completeness_ = SymbolCompleteness::kNoSymbols;
@@ -101,18 +162,18 @@ bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo info) {
 bool ModuleData::UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo info) {
   absl::MutexLock lock(&mutex_);
 
-  ORBIT_CHECK(file_path() == info.file_path());
-  ORBIT_CHECK(build_id() == info.build_id());
-  ORBIT_CHECK(object_file_type() == info.object_file_type());
+  ORBIT_CHECK(file_path_ == info.file_path());
+  ORBIT_CHECK(build_id_ == info.build_id());
+  ORBIT_CHECK(object_file_type_ == info.object_file_type());
 
   if (!NeedsUpdate(info)) return true;
 
   // The update only makes sense if build_id is empty.
-  ORBIT_CHECK(build_id().empty());
+  ORBIT_CHECK(build_id_.empty());
 
   if (loaded_symbols_completeness_ > SymbolCompleteness::kNoSymbols) return false;
 
-  module_info_ = std::move(info);
+  UpdateFromModuleInfo(std::move(info));
   return true;
 }
 
@@ -175,16 +236,18 @@ bool ModuleData::AreAtLeastFallbackSymbolsLoaded() const {
 }
 
 void ModuleData::AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols) {
+  absl::MutexLock lock(&mutex_);
   AddSymbolsInternal(module_symbols, SymbolCompleteness::kDebugSymbols);
 }
 
 void ModuleData::AddFallbackSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols) {
+  absl::MutexLock lock(&mutex_);
   AddSymbolsInternal(module_symbols, SymbolCompleteness::kDynamicLinkingAndUnwindInfo);
 }
 
 void ModuleData::AddSymbolsInternal(const orbit_grpc_protos::ModuleSymbols& module_symbols,
                                     ModuleData::SymbolCompleteness completeness) {
-  absl::MutexLock lock(&mutex_);
+  mutex_.AssertHeld();
   ORBIT_CHECK(loaded_symbols_completeness_ < completeness);
   functions_.clear();
   hash_to_function_map_.clear();
@@ -193,8 +256,7 @@ void ModuleData::AddSymbolsInternal(const orbit_grpc_protos::ModuleSymbols& modu
   uint32_t name_reuse_counter = 0;
   for (const orbit_grpc_protos::SymbolInfo& symbol_info : module_symbols.symbol_infos()) {
     auto [inserted_it, success_functions] = functions_.try_emplace(
-        symbol_info.address(),
-        std::make_unique<FunctionInfo>(symbol_info, file_path(), build_id()));
+        symbol_info.address(), std::make_unique<FunctionInfo>(symbol_info, file_path_, build_id_));
     FunctionInfo* function = inserted_it->second.get();
     // It happens that the same address has multiple symbol names associated
     // with it. For example: (all the same address)
@@ -220,14 +282,14 @@ void ModuleData::AddSymbolsInternal(const orbit_grpc_protos::ModuleSymbols& modu
   }
   if (address_reuse_counter != 0) {
     ORBIT_LOG("Warning: %d absolute addresses are used by more than one symbol for \"%s\"",
-              address_reuse_counter, name());
+              address_reuse_counter, name_);
   }
   if (name_reuse_counter != 0) {
     ORBIT_LOG(
         "Warning: %d function name collisions happened (functions with the same demangled name) "
         "for \"%s\". This is currently not supported by presets, since presets are based on the "
         "demangled name.",
-        name_reuse_counter, name());
+        name_reuse_counter, name_);
   }
 
   loaded_symbols_completeness_ = completeness;

--- a/src/ClientData/ModuleDataTest.cpp
+++ b/src/ClientData/ModuleDataTest.cpp
@@ -19,34 +19,34 @@ using orbit_grpc_protos::SymbolInfo;
 namespace orbit_client_data {
 
 TEST(ModuleData, Constructor) {
-  std::string name = "Example Name";
-  std::string file_path = "/test/file/path";
-  uint64_t file_size = 1000;
-  std::string build_id = "test build id";
-  uint64_t load_bias = 4000;
+  constexpr const char* kName = "Example Name";
+  constexpr const char* kFilePath = "/test/file/path";
+  constexpr uint64_t kFileSize = 1000;
+  constexpr const char* kBuildId = "test build id";
+  constexpr uint64_t kLoadBias = 4000;
   ModuleInfo::ObjectSegment object_segment;
   object_segment.set_offset_in_file(0x200);
   object_segment.set_size_in_file(0x2FFF);
   object_segment.set_address(0x1000);
   object_segment.set_size_in_memory(0x3000);
-  ModuleInfo::ObjectFileType object_file_type = ModuleInfo::kElfFile;
+  constexpr ModuleInfo::ObjectFileType object_file_type = ModuleInfo::kElfFile;
 
   ModuleInfo module_info{};
-  module_info.set_name(name);
-  module_info.set_file_path(file_path);
-  module_info.set_file_size(file_size);
-  module_info.set_build_id(build_id);
-  module_info.set_load_bias(load_bias);
+  module_info.set_name(kName);
+  module_info.set_file_path(kFilePath);
+  module_info.set_file_size(kFileSize);
+  module_info.set_build_id(kBuildId);
+  module_info.set_load_bias(kLoadBias);
   *module_info.add_object_segments() = object_segment;
   module_info.set_object_file_type(object_file_type);
 
   ModuleData module{module_info};
 
-  EXPECT_EQ(module.name(), name);
-  EXPECT_EQ(module.file_path(), file_path);
-  EXPECT_EQ(module.file_size(), file_size);
-  EXPECT_EQ(module.build_id(), build_id);
-  EXPECT_EQ(module.load_bias(), load_bias);
+  EXPECT_EQ(module.name(), kName);
+  EXPECT_EQ(module.file_path(), kFilePath);
+  EXPECT_EQ(module.file_size(), kFileSize);
+  EXPECT_EQ(module.build_id(), kBuildId);
+  EXPECT_EQ(module.load_bias(), kLoadBias);
   EXPECT_EQ(module.object_file_type(), object_file_type);
   ASSERT_EQ(module.GetObjectSegments().size(), 1);
   EXPECT_EQ(module.GetObjectSegments()[0].offset_in_file(), object_segment.offset_in_file());
@@ -105,11 +105,11 @@ TEST(ModuleData, ConvertFromVirtualAddressToOffsetInFileAndViceVersaPeNoSections
 }
 
 TEST(ModuleData, AddSymbolsAndAddFallbackSymbols) {
-  // Setup ModuleData.
+  // Set up ModuleData.
   constexpr const char* kBuildId = "build_id";
-  std::string module_file_path = "/test/file/path";
+  constexpr const char* kModuleFilePath = "/test/file/path";
   ModuleInfo module_info{};
-  module_info.set_file_path(module_file_path);
+  module_info.set_file_path(kModuleFilePath);
   module_info.set_build_id(kBuildId);
   ModuleData module{module_info};
 
@@ -128,7 +128,7 @@ TEST(ModuleData, AddSymbolsAndAddFallbackSymbols) {
   const auto verify_get_functions = [&]() {
     const FunctionInfo* function = module.GetFunctions()[0];
     EXPECT_EQ(function->pretty_name(), kSymbolPrettyName);
-    EXPECT_EQ(function->module_path(), module_file_path);
+    EXPECT_EQ(function->module_path(), kModuleFilePath);
     EXPECT_EQ(function->module_build_id(), kBuildId);
     EXPECT_EQ(function->address(), kSymbolAddress);
     EXPECT_EQ(function->size(), kSymbolSize);
@@ -181,28 +181,28 @@ TEST(ModuleData, FindFunctionFromHash) {
 }
 
 TEST(ModuleData, UpdateIfChangedAndUnload) {
-  std::string name = "Example Name";
-  std::string file_path = "/test/file/path";
-  uint64_t file_size = 1000;
-  std::string build_id{};
-  uint64_t load_bias = 4000;
-  ModuleInfo::ObjectFileType object_file_type = ModuleInfo::kElfFile;
+  constexpr const char* kName = "Example Name";
+  constexpr const char* kFilePath = "/test/file/path";
+  constexpr uint64_t kFileSize = 1000;
+  constexpr const char* kBuildId = "";
+  constexpr uint64_t kLoadBias = 4000;
+  constexpr ModuleInfo::ObjectFileType kObjectFileType = ModuleInfo::kElfFile;
 
   ModuleInfo module_info{};
-  module_info.set_name(name);
-  module_info.set_file_path(file_path);
-  module_info.set_file_size(file_size);
-  module_info.set_build_id(build_id);
-  module_info.set_load_bias(load_bias);
-  module_info.set_object_file_type(object_file_type);
+  module_info.set_name(kName);
+  module_info.set_file_path(kFilePath);
+  module_info.set_file_size(kFileSize);
+  module_info.set_build_id(kBuildId);
+  module_info.set_load_bias(kLoadBias);
+  module_info.set_object_file_type(kObjectFileType);
 
   ModuleData module{module_info};
-  EXPECT_EQ(module.name(), name);
-  EXPECT_EQ(module.file_path(), file_path);
-  EXPECT_EQ(module.file_size(), file_size);
-  EXPECT_EQ(module.build_id(), build_id);
-  EXPECT_EQ(module.load_bias(), load_bias);
-  EXPECT_EQ(module.object_file_type(), object_file_type);
+  EXPECT_EQ(module.name(), kName);
+  EXPECT_EQ(module.file_path(), kFilePath);
+  EXPECT_EQ(module.file_size(), kFileSize);
+  EXPECT_EQ(module.build_id(), kBuildId);
+  EXPECT_EQ(module.load_bias(), kLoadBias);
+  EXPECT_EQ(module.object_file_type(), kObjectFileType);
   EXPECT_EQ(module.GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kNoSymbols);
   EXPECT_EQ(module.GetFunctions().size(), 0);
 
@@ -262,28 +262,28 @@ TEST(ModuleData, UpdateIfChangedAndUnload) {
 }
 
 TEST(ModuleData, UpdateIfChangedAndNotLoaded) {
-  std::string name = "Example Name";
-  std::string file_path = "/test/file/path";
-  uint64_t file_size = 1000;
-  std::string build_id{};
-  uint64_t load_bias = 4000;
-  ModuleInfo::ObjectFileType object_file_type = ModuleInfo::kElfFile;
+  constexpr const char* kName = "Example Name";
+  constexpr const char* kFilePath = "/test/file/path";
+  constexpr uint64_t kFileSize = 1000;
+  constexpr const char* kBuildId = "";
+  constexpr uint64_t kLoadBias = 4000;
+  ModuleInfo::ObjectFileType kObjectFileType = ModuleInfo::kElfFile;
 
   ModuleInfo module_info{};
-  module_info.set_name(name);
-  module_info.set_file_path(file_path);
-  module_info.set_file_size(file_size);
-  module_info.set_build_id(build_id);
-  module_info.set_load_bias(load_bias);
-  module_info.set_object_file_type(object_file_type);
+  module_info.set_name(kName);
+  module_info.set_file_path(kFilePath);
+  module_info.set_file_size(kFileSize);
+  module_info.set_build_id(kBuildId);
+  module_info.set_load_bias(kLoadBias);
+  module_info.set_object_file_type(kObjectFileType);
 
   ModuleData module{module_info};
-  EXPECT_EQ(module.name(), name);
-  EXPECT_EQ(module.file_path(), file_path);
-  EXPECT_EQ(module.file_size(), file_size);
-  EXPECT_EQ(module.build_id(), build_id);
-  EXPECT_EQ(module.load_bias(), load_bias);
-  EXPECT_EQ(module.object_file_type(), object_file_type);
+  EXPECT_EQ(module.name(), kName);
+  EXPECT_EQ(module.file_path(), kFilePath);
+  EXPECT_EQ(module.file_size(), kFileSize);
+  EXPECT_EQ(module.build_id(), kBuildId);
+  EXPECT_EQ(module.load_bias(), kLoadBias);
+  EXPECT_EQ(module.object_file_type(), kObjectFileType);
   EXPECT_EQ(module.GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kNoSymbols);
   EXPECT_EQ(module.GetFunctions().size(), 0);
 
@@ -351,29 +351,29 @@ TEST(ModuleData, UpdateIfChangedAndNotLoaded) {
 }
 
 TEST(ModuleData, UpdateIfChangedWithBuildId) {
-  std::string name = "Example Name";
-  std::string file_path = "/test/file/path";
-  uint64_t file_size = 1000;
-  std::string build_id = "build_id_27";
-  uint64_t load_bias = 4000;
-  ModuleInfo::ObjectFileType object_file_type = ModuleInfo::kElfFile;
+  constexpr const char* kName = "Example Name";
+  constexpr const char* kFilePath = "/test/file/path";
+  constexpr uint64_t kFileSize = 1000;
+  constexpr const char* kBuildId = "build_id_27";
+  constexpr uint64_t kLoadBias = 4000;
+  constexpr ModuleInfo::ObjectFileType kObjectFileType = ModuleInfo::kElfFile;
 
   ModuleInfo module_info{};
-  module_info.set_name(name);
-  module_info.set_file_path(file_path);
-  module_info.set_file_size(file_size);
-  module_info.set_build_id(build_id);
-  module_info.set_load_bias(load_bias);
-  module_info.set_object_file_type(object_file_type);
+  module_info.set_name(kName);
+  module_info.set_file_path(kFilePath);
+  module_info.set_file_size(kFileSize);
+  module_info.set_build_id(kBuildId);
+  module_info.set_load_bias(kLoadBias);
+  module_info.set_object_file_type(kObjectFileType);
 
   ModuleData module{module_info};
 
-  EXPECT_EQ(module.name(), name);
-  EXPECT_EQ(module.file_path(), file_path);
-  EXPECT_EQ(module.file_size(), file_size);
-  EXPECT_EQ(module.build_id(), build_id);
-  EXPECT_EQ(module.load_bias(), load_bias);
-  EXPECT_EQ(module.object_file_type(), object_file_type);
+  EXPECT_EQ(module.name(), kName);
+  EXPECT_EQ(module.file_path(), kFilePath);
+  EXPECT_EQ(module.file_size(), kFileSize);
+  EXPECT_EQ(module.build_id(), kBuildId);
+  EXPECT_EQ(module.load_bias(), kLoadBias);
+  EXPECT_EQ(module.object_file_type(), kObjectFileType);
   EXPECT_EQ(module.GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kNoSymbols);
   EXPECT_TRUE(module.GetFunctions().empty());
 

--- a/src/ClientData/ModuleManagerTest.cpp
+++ b/src/ClientData/ModuleManagerTest.cpp
@@ -11,12 +11,10 @@
 #include "ClientData/ModuleData.h"
 #include "ClientData/ModuleManager.h"
 #include "GrpcProtos/module.pb.h"
-#include "GrpcProtos/symbol.pb.h"
 
 namespace orbit_client_data {
 
 using orbit_grpc_protos::ModuleInfo;
-using orbit_grpc_protos::ModuleSymbols;
 using orbit_symbol_provider::ModuleIdentifier;
 
 TEST(ModuleManager, GetModuleByModuleIdentifier) {
@@ -88,9 +86,9 @@ TEST(ModuleManager, GetMutableModuleByModuleIdentifier) {
   EXPECT_EQ(module->build_id(), build_id);
   EXPECT_EQ(module->load_bias(), load_bias);
 
-  EXPECT_FALSE(module->is_loaded());
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kNoSymbols);
   module->AddSymbols({});
-  EXPECT_TRUE(module->is_loaded());
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kDebugSymbols);
 
   EXPECT_EQ(
       module_manager.GetMutableModuleByModuleIdentifier(ModuleIdentifier{"wrong/path", build_id}),
@@ -154,75 +152,95 @@ TEST(ModuleManager, GetModuleByModuleInMemoryAndAddress) {
 }
 
 TEST(ModuleManager, AddOrUpdateModules) {
-  const std::string name = "name of module";
-  const std::string file_path = "path/of/module";
-  const std::string build_id{};
+  constexpr const char* kName = "name of module";
+  constexpr const char* kFilePath = "path/of/module";
+  constexpr const char* kBuildId = "";
   constexpr uint64_t kFileSize = 300;
   constexpr uint64_t kLoadBias = 0x400;
 
   ModuleInfo module_info;
-  module_info.set_name(name);
-  module_info.set_file_path(file_path);
+  module_info.set_name(kName);
+  module_info.set_file_path(kFilePath);
   module_info.set_file_size(kFileSize);
-  module_info.set_build_id(build_id);
+  module_info.set_build_id(kBuildId);
   module_info.set_load_bias(kLoadBias);
 
   ModuleManager module_manager;
   std::vector<ModuleData*> unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 1);
   EXPECT_TRUE(unloaded_modules.empty());
 
   ModuleData* module =
-      module_manager.GetMutableModuleByModuleIdentifier(ModuleIdentifier{file_path, build_id});
+      module_manager.GetMutableModuleByModuleIdentifier(ModuleIdentifier{kFilePath, kBuildId});
 
   ASSERT_NE(module, nullptr);
-  EXPECT_EQ(module->name(), name);
+  EXPECT_EQ(module->name(), kName);
 
-  // change name, this updates the module
+  // Change the name: this updates the module.
   std::string changed_name = "changed name";
   module_info.set_name(changed_name);
 
   unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 1);
   EXPECT_TRUE(unloaded_modules.empty());
 
   ASSERT_NE(module, nullptr);
-  EXPECT_EQ(module->file_path(), file_path);
+  EXPECT_EQ(module->file_path(), kFilePath);
   EXPECT_EQ(module->name(), changed_name);
 
-  // add symbols
-  ModuleSymbols module_symbols;
-  module->AddSymbols(module_symbols);
-  ASSERT_TRUE(module->is_loaded());
-  module_info.set_name("changed name 2");
+  // Add fallback symbols.
+  module->AddFallbackSymbols({});
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(),
+            ModuleData::SymbolCompleteness::kDynamicLinkingAndUnwindInfo);
 
+  // Update the module again.
+  module_info.set_name("changed name 2");
   unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 1);
   ASSERT_EQ(unloaded_modules.size(), 1);
   EXPECT_EQ(unloaded_modules[0]->name(), "changed name 2");
-  EXPECT_FALSE(unloaded_modules[0]->is_loaded());
+  EXPECT_EQ(unloaded_modules[0]->GetLoadedSymbolsCompleteness(),
+            ModuleData::SymbolCompleteness::kNoSymbols);
 
-  // add symbols again
-  module->AddSymbols(module_symbols);
-  ASSERT_TRUE(module->is_loaded());
+  // Add symbols.
+  module->AddSymbols({});
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kDebugSymbols);
 
-  // change build id, this creates new module
+  // Update the module yet again.
+  module_info.set_name("changed name 3");
+  unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 1);
+  ASSERT_EQ(unloaded_modules.size(), 1);
+  EXPECT_EQ(unloaded_modules[0]->name(), "changed name 3");
+  EXPECT_EQ(unloaded_modules[0]->GetLoadedSymbolsCompleteness(),
+            ModuleData::SymbolCompleteness::kNoSymbols);
+
+  // Add symbols again.
+  module->AddSymbols({});
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kDebugSymbols);
+
+  // Change the build id: this creates a new module.
   constexpr const char* kDifferentBuildId = "different build id";
   module_info.set_build_id(kDifferentBuildId);
   unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 2);
   EXPECT_TRUE(unloaded_modules.empty());
 
-  EXPECT_EQ(module->build_id(), build_id);
-  EXPECT_TRUE(module->is_loaded());
+  EXPECT_EQ(module->build_id(), kBuildId);
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kDebugSymbols);
 
-  // change file path & file size and add again (should be added again, because it is now considered
-  // a different module)
+  // Change file path and file size, and add the module again: this creates another new module
+  // because of the different file path.
   std::string different_path = "different/path/of/module";
   module_info.set_file_path(different_path);
   uint64_t different_file_size = 301;
   module_info.set_file_size(different_file_size);
   unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 3);
   EXPECT_TRUE(unloaded_modules.empty());
 
   ASSERT_NE(module, nullptr);
-  EXPECT_EQ(module->file_path(), file_path);
+  EXPECT_EQ(module->file_path(), kFilePath);
   EXPECT_EQ(module->file_size(), kFileSize);
 
   const ModuleData* different_module = module_manager.GetModuleByModuleIdentifier(
@@ -233,17 +251,17 @@ TEST(ModuleManager, AddOrUpdateModules) {
 }
 
 TEST(ModuleManager, AddOrUpdateNotLoadedModules) {
-  const std::string name = "name of module";
-  const std::string file_path = "path/of/module";
-  const std::string build_id{};
+  constexpr const char* kName = "name of module";
+  constexpr const char* kFilePath = "path/of/module";
+  constexpr const char* kBuildId = "";
   constexpr uint64_t kFileSize = 300;
   constexpr uint64_t kLoadBias = 0x400;
 
   ModuleInfo module_info;
-  module_info.set_name(name);
-  module_info.set_file_path(file_path);
+  module_info.set_name(kName);
+  module_info.set_file_path(kFilePath);
   module_info.set_file_size(kFileSize);
-  module_info.set_build_id(build_id);
+  module_info.set_build_id(kBuildId);
   module_info.set_load_bias(kLoadBias);
 
   ModuleManager module_manager;
@@ -252,54 +270,72 @@ TEST(ModuleManager, AddOrUpdateNotLoadedModules) {
   EXPECT_TRUE(not_changed_modules.empty());
 
   ModuleData* module =
-      module_manager.GetMutableModuleByModuleIdentifier(ModuleIdentifier{file_path, build_id});
+      module_manager.GetMutableModuleByModuleIdentifier(ModuleIdentifier{kFilePath, kBuildId});
 
   ASSERT_NE(module, nullptr);
-  EXPECT_EQ(module->name(), name);
+  EXPECT_EQ(module->name(), kName);
 
-  // change name, this updates the module
+  // Change the name: this updates the module.
   std::string changed_name = "changed name";
   module_info.set_name(changed_name);
 
   not_changed_modules = module_manager.AddOrUpdateNotLoadedModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 1);
   EXPECT_TRUE(not_changed_modules.empty());
 
   ASSERT_NE(module, nullptr);
-  EXPECT_EQ(module->file_path(), file_path);
+  EXPECT_EQ(module->file_path(), kFilePath);
   EXPECT_EQ(module->name(), changed_name);
 
-  // add symbols
-  ModuleSymbols module_symbols;
-  module->AddSymbols(module_symbols);
-  ASSERT_TRUE(module->is_loaded());
-  module_info.set_name("changed name 2");
+  // Add fallback symbols and try to update the module: the module won't be updated.
+  module->AddFallbackSymbols({});
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(),
+            ModuleData::SymbolCompleteness::kDynamicLinkingAndUnwindInfo);
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 1);
 
+  module_info.set_name("changed name 2");
   not_changed_modules = module_manager.AddOrUpdateNotLoadedModules({module_info});
   ASSERT_EQ(not_changed_modules.size(), 1);
   EXPECT_EQ(not_changed_modules[0], module);
   EXPECT_EQ(not_changed_modules[0]->name(), changed_name);
-  EXPECT_TRUE(not_changed_modules[0]->is_loaded());
+  EXPECT_EQ(not_changed_modules[0]->GetLoadedSymbolsCompleteness(),
+            ModuleData::SymbolCompleteness::kDynamicLinkingAndUnwindInfo);
 
-  // change build id, this creates new module
+  // Add symbols and try to update the module: the module won't be updated.
+  module->AddSymbols({});
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kDebugSymbols);
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 1);
+
+  module_info.set_name("changed name 2");
+  not_changed_modules = module_manager.AddOrUpdateNotLoadedModules({module_info});
+  ASSERT_EQ(not_changed_modules.size(), 1);
+  EXPECT_EQ(not_changed_modules[0], module);
+  EXPECT_EQ(not_changed_modules[0]->name(), changed_name);
+  EXPECT_EQ(not_changed_modules[0]->GetLoadedSymbolsCompleteness(),
+            ModuleData::SymbolCompleteness::kDebugSymbols);
+
+  // Change the build id: this creates a new module.
   constexpr const char* kDifferentBuildId = "different build id";
   module_info.set_build_id(kDifferentBuildId);
   not_changed_modules = module_manager.AddOrUpdateNotLoadedModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 2);
   EXPECT_TRUE(not_changed_modules.empty());
 
-  EXPECT_EQ(module->build_id(), build_id);
-  EXPECT_TRUE(module->is_loaded());
+  EXPECT_EQ(module->build_id(), kBuildId);
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kDebugSymbols);
 
-  // change file path & file size and add again (should be added again, because it is now considered
-  // a different module)
+  // Change file path and file size, and add the module again: this creates another new module
+  // because of the different file path.
   std::string different_path = "different/path/of/module";
   module_info.set_file_path(different_path);
   uint64_t different_file_size = 301;
   module_info.set_file_size(different_file_size);
   not_changed_modules = module_manager.AddOrUpdateNotLoadedModules({module_info});
+  EXPECT_EQ(module_manager.GetAllModuleData().size(), 3);
   EXPECT_TRUE(not_changed_modules.empty());
 
   ASSERT_NE(module, nullptr);
-  EXPECT_EQ(module->file_path(), file_path);
+  EXPECT_EQ(module->file_path(), kFilePath);
   EXPECT_EQ(module->file_size(), kFileSize);
 
   const ModuleData* different_module = module_manager.GetModuleByModuleIdentifier(

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -295,7 +295,7 @@ class CaptureData {
 
   // For each thread, assume sorted by timestamp and not overlapping.
   absl::flat_hash_map<uint32_t, std::vector<ThreadStateSliceInfo>> thread_state_slices_
-      GUARDED_BY(thread_state_slices_mutex_);
+      ABSL_GUARDED_BY(thread_state_slices_mutex_);
   mutable absl::Mutex thread_state_slices_mutex_;
 
   // Only access this field from the main thread.

--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -33,10 +33,9 @@ class ModuleData final {
   [[nodiscard]] uint64_t file_size() const;
   [[nodiscard]] const std::string& build_id() const;
   [[nodiscard]] uint64_t load_bias() const;
-  [[nodiscard]] orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type() const;
   [[nodiscard]] uint64_t executable_segment_offset() const;
-  [[nodiscard]] const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment>& GetObjectSegments()
-      const;
+  [[nodiscard]] orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type() const;
+  [[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> GetObjectSegments() const;
 
   [[nodiscard]] orbit_symbol_provider::ModuleIdentifier module_id() const;
 
@@ -44,11 +43,11 @@ class ModuleData final {
   [[nodiscard]] uint64_t ConvertFromOffsetInFileToVirtualAddress(uint64_t offset_in_file) const;
 
   // Returns true if the module was unloaded (symbols were removed) and false otherwise.
-  [[nodiscard]] bool UpdateIfChangedAndUnload(orbit_grpc_protos::ModuleInfo info);
+  [[nodiscard]] bool UpdateIfChangedAndUnload(orbit_grpc_protos::ModuleInfo new_module_info);
   // This method does not update the module in case symbols are already loaded, even if the module
   // would need to be updated. Returns true if the update was successful or no update was needed,
   // and false if the module cannot be updated because symbols are already loaded.
-  [[nodiscard]] bool UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo info);
+  [[nodiscard]] bool UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo new_module_info);
 
   [[nodiscard]] const FunctionInfo* FindFunctionByVirtualAddress(uint64_t virtual_address,
                                                                  bool is_exact) const;
@@ -69,23 +68,13 @@ class ModuleData final {
   void AddFallbackSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols);
 
  private:
-  [[nodiscard]] bool NeedsUpdate(const orbit_grpc_protos::ModuleInfo& module_info) const;
-  void UpdateFromModuleInfo(orbit_grpc_protos::ModuleInfo module_info);
+  [[nodiscard]] bool NeedsUpdate(const orbit_grpc_protos::ModuleInfo& new_module_info) const;
 
   void AddSymbolsInternal(const orbit_grpc_protos::ModuleSymbols& module_symbols,
                           SymbolCompleteness completeness);
 
   mutable absl::Mutex mutex_;
-
-  std::string name_ ABSL_GUARDED_BY(mutex_);
-  std::string file_path_ ABSL_GUARDED_BY(mutex_);
-  uint64_t file_size_ ABSL_GUARDED_BY(mutex_);
-  std::string build_id_ ABSL_GUARDED_BY(mutex_);
-  uint64_t load_bias_ ABSL_GUARDED_BY(mutex_);
-  orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type_ ABSL_GUARDED_BY(mutex_);
-  uint64_t executable_segment_offset_ ABSL_GUARDED_BY(mutex_);
-  std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> object_segments_
-      ABSL_GUARDED_BY(mutex_);
+  orbit_grpc_protos::ModuleInfo module_info_ ABSL_GUARDED_BY(mutex_);
 
   SymbolCompleteness loaded_symbols_completeness_ ABSL_GUARDED_BY(mutex_) =
       SymbolCompleteness::kNoSymbols;

--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -23,26 +23,23 @@
 
 namespace orbit_client_data {
 
-// Represents information about module on the client
+// Represents information about a module on the client. This class if fully synchronized.
 class ModuleData final {
  public:
-  explicit ModuleData(orbit_grpc_protos::ModuleInfo info) : module_info_(std::move(info)) {}
+  explicit ModuleData(orbit_grpc_protos::ModuleInfo module_info);
 
-  [[nodiscard]] const std::string& name() const { return module_info_.name(); }
-  [[nodiscard]] const std::string& file_path() const { return module_info_.file_path(); }
-  [[nodiscard]] uint64_t file_size() const { return module_info_.file_size(); }
-  [[nodiscard]] const std::string& build_id() const { return module_info_.build_id(); }
-  [[nodiscard]] uint64_t load_bias() const { return module_info_.load_bias(); }
-  [[nodiscard]] orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type() const {
-    return module_info_.object_file_type();
-  }
-  [[nodiscard]] uint64_t executable_segment_offset() const {
-    return module_info_.executable_segment_offset();
-  }
-  [[nodiscard]] orbit_symbol_provider::ModuleIdentifier module_id() const {
-    return orbit_symbol_provider::ModuleIdentifier{file_path(), build_id()};
-  }
-  [[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> GetObjectSegments() const;
+  [[nodiscard]] const std::string& name() const;
+  [[nodiscard]] const std::string& file_path() const;
+  [[nodiscard]] uint64_t file_size() const;
+  [[nodiscard]] const std::string& build_id() const;
+  [[nodiscard]] uint64_t load_bias() const;
+  [[nodiscard]] orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type() const;
+  [[nodiscard]] uint64_t executable_segment_offset() const;
+  [[nodiscard]] const std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment>& GetObjectSegments()
+      const;
+
+  [[nodiscard]] orbit_symbol_provider::ModuleIdentifier module_id() const;
+
   [[nodiscard]] uint64_t ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_address) const;
   [[nodiscard]] uint64_t ConvertFromOffsetInFileToVirtualAddress(uint64_t offset_in_file) const;
 
@@ -72,20 +69,34 @@ class ModuleData final {
   void AddFallbackSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols);
 
  private:
-  [[nodiscard]] bool NeedsUpdate(const orbit_grpc_protos::ModuleInfo& info) const;
+  [[nodiscard]] bool NeedsUpdate(const orbit_grpc_protos::ModuleInfo& module_info) const;
+  void UpdateFromModuleInfo(orbit_grpc_protos::ModuleInfo module_info);
+
   void AddSymbolsInternal(const orbit_grpc_protos::ModuleSymbols& module_symbols,
                           SymbolCompleteness completeness);
 
   mutable absl::Mutex mutex_;
-  orbit_grpc_protos::ModuleInfo module_info_;
-  SymbolCompleteness loaded_symbols_completeness_ = SymbolCompleteness::kNoSymbols;
-  std::map<uint64_t, std::unique_ptr<FunctionInfo>> functions_;
-  absl::flat_hash_map<std::string_view, FunctionInfo*> name_to_function_info_map_;
+
+  std::string name_ ABSL_GUARDED_BY(mutex_);
+  std::string file_path_ ABSL_GUARDED_BY(mutex_);
+  uint64_t file_size_ ABSL_GUARDED_BY(mutex_);
+  std::string build_id_ ABSL_GUARDED_BY(mutex_);
+  uint64_t load_bias_ ABSL_GUARDED_BY(mutex_);
+  orbit_grpc_protos::ModuleInfo::ObjectFileType object_file_type_ ABSL_GUARDED_BY(mutex_);
+  uint64_t executable_segment_offset_ ABSL_GUARDED_BY(mutex_);
+  std::vector<orbit_grpc_protos::ModuleInfo::ObjectSegment> object_segments_
+      ABSL_GUARDED_BY(mutex_);
+
+  SymbolCompleteness loaded_symbols_completeness_ ABSL_GUARDED_BY(mutex_) =
+      SymbolCompleteness::kNoSymbols;
+  std::map<uint64_t, std::unique_ptr<FunctionInfo>> functions_ ABSL_GUARDED_BY(mutex_);
+  absl::flat_hash_map<std::string_view, FunctionInfo*> name_to_function_info_map_
+      ABSL_GUARDED_BY(mutex_);
 
   // TODO(b/168799822): This is a map of hash to function used for preset loading. Currently,
   // presets are based on a hash of the functions pretty name. This should be changed to not use
   // hashes anymore.
-  absl::flat_hash_map<uint64_t, FunctionInfo*> hash_to_function_map_;
+  absl::flat_hash_map<uint64_t, FunctionInfo*> hash_to_function_map_ ABSL_GUARDED_BY(mutex_);
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ModuleManager.h
+++ b/src/ClientData/include/ClientData/ModuleManager.h
@@ -34,13 +34,13 @@ class ModuleManager final {
       const orbit_symbol_provider::ModuleIdentifier& module_id);
   // Add new modules for the module_infos that do not exist yet, and update the modules that do
   // exist. If the update changed the module in a way that symbols were not valid anymore, the
-  // symbols are discarded aka the module is not loaded anymore. This method returns the list of
-  // modules that used to be loaded before the call and are not loaded anymore after the call.
+  // symbols are discarded, i.e., the module is no longer loaded. This method returns the list of
+  // modules that used to be loaded before the call and are no longer loaded after the call.
   [[nodiscard]] std::vector<ModuleData*> AddOrUpdateModules(
       absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
 
-  // Similar to AddOrUpdateModules except it does not update loaded modules.
-  // Retuns the list of modules that it did not update.
+  // Similar to AddOrUpdateModules, except that it does not update modules that already have
+  // symbols. Returns the list of modules that it did not update.
   [[nodiscard]] std::vector<ModuleData*> AddOrUpdateNotLoadedModules(
       absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
 

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -74,7 +74,7 @@ class ScopeTreeTimerData final : public TimerDataInterface {
   const int64_t thread_id_;
   mutable absl::Mutex scope_tree_mutex_;
   orbit_containers::ScopeTree<const orbit_client_protos::TimerInfo> scope_tree_
-      GUARDED_BY(scope_tree_mutex_);
+      ABSL_GUARDED_BY(scope_tree_mutex_);
   ScopeTreeUpdateType scope_tree_update_type_;
 
   TimerData timer_data_;

--- a/src/ClientData/include/ClientData/TimerDataManager.h
+++ b/src/ClientData/include/ClientData/TimerDataManager.h
@@ -44,7 +44,7 @@ class TimerDataManager final {
 
  private:
   mutable absl::Mutex mutex_;
-  std::vector<std::unique_ptr<TimerData>> timer_data_ GUARDED_BY(mutex_);
+  std::vector<std::unique_ptr<TimerData>> timer_data_ ABSL_GUARDED_BY(mutex_);
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/TracepointData.h
+++ b/src/ClientData/include/ClientData/TracepointData.h
@@ -64,12 +64,12 @@ class TracepointData {
   mutable absl::Mutex unique_tracepoints_mutex_;
 
   absl::flat_hash_map<uint32_t, std::map<uint64_t, TracepointEventInfo>>
-      thread_id_to_time_to_tracepoint_ GUARDED_BY(mutex_);
+      thread_id_to_time_to_tracepoint_ ABSL_GUARDED_BY(mutex_);
 
   // Store unique pointers, such that we can hand out pointers to tracepoint infos, without
   // requiring the caller to lock the mutex.
   absl::flat_hash_map<uint64_t, std::unique_ptr<TracepointInfo>> unique_tracepoints_
-      GUARDED_BY(unique_tracepoints_mutex_);
+      ABSL_GUARDED_BY(unique_tracepoints_mutex_);
 };
 
 }  // namespace orbit_client_data

--- a/src/ConfigWidgets/StopSymbolDownloadDialog.ui
+++ b/src/ConfigWidgets/StopSymbolDownloadDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Symbols for this module are still being downloaded</string>
+      <string>Symbols for this module are still being downloaded:</string>
      </property>
     </widget>
    </item>

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -121,7 +121,7 @@ DataView::ActionStatus CallstackDataView::GetActionStatus(
   std::function<bool(const FunctionInfo*, const ModuleData*)> is_visible_action_enabled;
   if (action == kMenuActionLoadSymbols) {
     is_visible_action_enabled = [](const FunctionInfo* /*function*/, const ModuleData* module) {
-      return module != nullptr && !module->is_loaded();
+      return module != nullptr && !module->AreDebugSymbolsLoaded();
     };
 
   } else if (action == kMenuActionSelect) {

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -193,7 +193,7 @@ void DataView::OnLoadSymbolsRequested(const std::vector<int>& selection) {
   std::vector<const ModuleData*> modules_to_load;
   for (int index : selection) {
     const ModuleData* module_data = GetModuleDataFromRow(index);
-    if (module_data != nullptr && !module_data->is_loaded()) {
+    if (module_data != nullptr && !module_data->AreDebugSymbolsLoaded()) {
       modules_to_load.push_back(module_data);
     }
   }

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -50,11 +50,6 @@ const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
   return columns;
 }
 
-std::string ModulesDataView::GetSymbolLoadingStateForModuleString(const ModuleData* module) {
-  SymbolLoadingState loading_state = app_->GetSymbolLoadingStateForModule(module);
-  return loading_state.GetDescription();
-}
-
 std::string ModulesDataView::GetValue(int row, int col) {
   uint64_t start_address = indices_[row];
   const ModuleData* module = start_address_to_module_.at(start_address);
@@ -62,7 +57,7 @@ std::string ModulesDataView::GetValue(int row, int col) {
 
   switch (col) {
     case kColumnSymbols:
-      return GetSymbolLoadingStateForModuleString(module);
+      return app_->GetSymbolLoadingStateForModule(module).GetName();
     case kColumnName:
       return std::filesystem::path(module->file_path()).filename().string();
     case kColumnPath:
@@ -74,6 +69,16 @@ std::string ModulesDataView::GetValue(int row, int col) {
     default:
       return "";
   }
+}
+
+std::string ModulesDataView::GetToolTip(int row, int column) {
+  uint64_t start_address = indices_[row];
+  const ModuleData* module = start_address_to_module_.at(start_address);
+
+  if (column == kColumnSymbols) {
+    return app_->GetSymbolLoadingStateForModule(module).GetDescription();
+  }
+  return DataView::GetToolTip(row, column);
 }
 
 #define ORBIT_PROC_SORT(Member)                                                         \

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -96,7 +96,7 @@ void ModulesDataView::DoSort() {
 
   switch (sorting_column_) {
     case kColumnSymbols:
-      sorter = ORBIT_PROC_SORT(is_loaded());
+      sorter = ORBIT_PROC_SORT(GetLoadedSymbolsCompleteness());
       break;
     case kColumnName:
       sorter = [&](uint64_t a, uint64_t b) {
@@ -143,7 +143,7 @@ DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action,
   if (action == kMenuActionVerifyFramePointers) {
     bool at_least_one_module_is_loaded =
         std::any_of(modules.begin(), modules.end(),
-                    [](const ModuleData* module) { return module->is_loaded(); });
+                    [](const ModuleData* module) { return module->AreDebugSymbolsLoaded(); });
 
     return at_least_one_module_is_loaded ? ActionStatus::kVisibleAndEnabled
                                          : ActionStatus::kVisibleButDisabled;
@@ -151,7 +151,8 @@ DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action,
 
   bool at_least_one_module_can_be_loaded =
       std::any_of(modules.begin(), modules.end(), [this](const ModuleData* module) {
-        return !module->is_loaded() && !app_->IsSymbolLoadingInProgressForModule(module);
+        return !module->AreDebugSymbolsLoaded() &&
+               !app_->IsSymbolLoadingInProgressForModule(module);
       });
 
   bool at_least_one_module_is_downloading =
@@ -183,7 +184,7 @@ DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action,
 
 void ModulesDataView::OnDoubleClicked(int index) {
   ModuleData* module_data = GetModuleDataFromRow(index);
-  if (!module_data->is_loaded()) {
+  if (!module_data->AreDebugSymbolsLoaded()) {
     std::vector<ModuleData*> modules_to_load = {module_data};
     app_->LoadSymbolsManually(modules_to_load);
   }

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -135,9 +135,16 @@ TEST_F(ModulesDataViewTest, ContextMenuEntriesArePresent) {
   const ModuleInMemory& module_in_memory = modules_in_memory_[kIndex];
   ModuleData* module =
       module_manager_.GetMutableModuleByModuleIdentifier(module_in_memory.module_id());
-  module->AddSymbols({});
-  EXPECT_TRUE(module->is_loaded());
 
+  module->AddFallbackSymbols({});
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(),
+            ModuleData::SymbolCompleteness::kDynamicLinkingAndUnwindInfo);
+  context_menu =
+      FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {kIndex}));
+  CheckSingleAction(context_menu, kMenuActionLoadSymbols, ContextMenuEntry::kEnabled);
+
+  module->AddSymbols({});
+  EXPECT_EQ(module->GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kDebugSymbols);
   context_menu =
       FlattenContextMenuWithGroupingAndCheckOrder(view_.GetContextMenuWithGrouping(0, {kIndex}));
   CheckSingleAction(context_menu, kMenuActionLoadSymbols, ContextMenuEntry::kDisabled);

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -227,7 +227,9 @@ DataView::ActionStatus SamplingReportDataView::GetActionStatus(
   if (action == kMenuActionLoadSymbols) {
     for (int index : selected_indices) {
       const ModuleData* module = GetModuleDataFromRow(index);
-      if (module != nullptr && !module->is_loaded()) return ActionStatus::kVisibleAndEnabled;
+      if (module != nullptr && !module->AreDebugSymbolsLoaded()) {
+        return ActionStatus::kVisibleAndEnabled;
+      }
     }
     return ActionStatus::kVisibleButDisabled;
   }

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -26,6 +26,7 @@ class ModulesDataView : public DataView {
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnFileSize; }
   std::string GetValue(int row, int column) override;
+  std::string GetToolTip(int row, int column) override;
 
   void OnDoubleClicked(int index) override;
   bool WantsDisplayColor() override { return true; }
@@ -55,8 +56,6 @@ class ModulesDataView : public DataView {
   [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {
     return start_address_to_module_.at(indices_[row]);
   }
-  [[nodiscard]] std::string GetSymbolLoadingStateForModuleString(
-      const orbit_client_data::ModuleData* module);
 
   absl::flat_hash_map<uint64_t, orbit_client_data::ModuleInMemory>
       start_address_to_module_in_memory_;

--- a/src/DataViews/include/DataViews/SymbolLoadingState.h
+++ b/src/DataViews/include/DataViews/SymbolLoadingState.h
@@ -14,13 +14,13 @@
 namespace orbit_data_views {
 
 // Class to represent the current state of symbol loading for a certain module. Also provides a
-// textual description for each state via GetDescription and a color via GetDisplayColor
+// textual description for each state via GetName and a color via GetDisplayColor
 struct SymbolLoadingState {
   // TODO(b/202140068) remove unknown when not needed anymore
   enum State { kUnknown, kDisabled, kDownloading, kError, kLoading, kLoaded, kFallback } state;
   SymbolLoadingState(State initial_state) : state(initial_state) {}
 
-  [[nodiscard]] std::string GetDescription() const {
+  [[nodiscard]] std::string GetName() const {
     switch (state) {
       case kUnknown:
         return "";
@@ -36,6 +36,30 @@ struct SymbolLoadingState {
         return "Loaded";
       case kFallback:
         return "Partial";
+    }
+    ORBIT_UNREACHABLE();
+  }
+
+  [[nodiscard]] std::string GetDescription() const {
+    switch (state) {
+      case kUnknown:
+        return "";
+      case kDisabled:
+        return "Loading symbols automatically is always disabled for this module.";
+      case kDownloading:
+        return "A file containing symbol information for this module has been found and is being "
+               "downloaded.";
+      case kError:
+        return "No symbols could be found for this module.";
+      case kLoading:
+        return "Symbols for this module are now being loaded from a file.";
+      case kLoaded:
+        return "Debug symbols for this module have been loaded successfully.";
+      case kFallback:
+        return "No debug symbols could be found for this module. Nonetheless, some substitute "
+               "information could still be extracted from the module itself, namely from symbols "
+               "for dynamic linking and/or from stack unwinding information. Note that this "
+               "information might be inaccurate.";
     }
     ORBIT_UNREACHABLE();
   }

--- a/src/DataViews/include/DataViews/SymbolLoadingState.h
+++ b/src/DataViews/include/DataViews/SymbolLoadingState.h
@@ -17,7 +17,7 @@ namespace orbit_data_views {
 // textual description for each state via GetDescription and a color via GetDisplayColor
 struct SymbolLoadingState {
   // TODO(b/202140068) remove unknown when not needed anymore
-  enum State { kUnknown, kDisabled, kDownloading, kError, kLoading, kLoaded } state;
+  enum State { kUnknown, kDisabled, kDownloading, kError, kLoading, kLoaded, kFallback } state;
   SymbolLoadingState(State initial_state) : state(initial_state) {}
 
   [[nodiscard]] std::string GetDescription() const {
@@ -34,6 +34,8 @@ struct SymbolLoadingState {
         return "Loading...";
       case kLoaded:
         return "Loaded";
+      case kFallback:
+        return "Partial";
     }
     ORBIT_UNREACHABLE();
   }
@@ -61,6 +63,12 @@ struct SymbolLoadingState {
       case kError: {
         red = 230;
         green = 70;
+        blue = 70;
+        break;
+      }
+      case kFallback: {
+        red = 230;
+        green = 150;
         blue = 70;
         break;
       }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2623,10 +2623,10 @@ orbit_base::Future<std::vector<ErrorMessageOr<void>>> OrbitApp::ReloadModules(
   absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map;
   for (const FunctionInfo& func : data_manager_->GetSelectedFunctions()) {
     const ModuleData* module = GetModuleByModuleIdentifier(func.module_id());
-    // (A) deselect functions when the module is not loaded by the process anymore
     if (!process->IsModuleLoadedByProcess(module->file_path())) {
+      // (A) deselect functions when the module is not loaded by the process anymore
       data_manager_->DeselectFunction(func);
-    } else if (!module->AreAtLeastFallbackSymbolsLoaded()) {  // TODO: Is this correct?
+    } else if (!module->AreAtLeastFallbackSymbolsLoaded()) {
       // (B) deselect when module does not have functions anymore
       data_manager_->DeselectFunction(func);
       // (C) Save function hashes, so they can be hooked again after reload
@@ -2641,7 +2641,7 @@ orbit_base::Future<std::vector<ErrorMessageOr<void>>> OrbitApp::ReloadModules(
     // loaded by the process.
     if (!process->IsModuleLoadedByProcess(module->file_path())) {
       RemoveFrameTrack(func);
-    } else if (!module->AreAtLeastFallbackSymbolsLoaded()) {  // TODO: Is this correct?
+    } else if (!module->AreAtLeastFallbackSymbolsLoaded()) {
       RemoveFrameTrack(func);
       frame_track_function_hashes_map[module->file_path()].push_back(func.GetPrettyNameHash());
     }

--- a/src/OrbitGl/MultivariateTimeSeries.h
+++ b/src/OrbitGl/MultivariateTimeSeries.h
@@ -136,9 +136,9 @@ class MultivariateTimeSeries {
   }
 
   mutable absl::Mutex mutex_;
-  std::map<uint64_t, std::array<double, Dimension>> time_to_series_values_ GUARDED_BY(mutex_);
-  double min_ GUARDED_BY(mutex_) = std::numeric_limits<double>::max();
-  double max_ GUARDED_BY(mutex_) = std::numeric_limits<double>::lowest();
+  std::map<uint64_t, std::array<double, Dimension>> time_to_series_values_ ABSL_GUARDED_BY(mutex_);
+  double min_ ABSL_GUARDED_BY(mutex_) = std::numeric_limits<double>::max();
+  double max_ ABSL_GUARDED_BY(mutex_) = std::numeric_limits<double>::lowest();
 
   const std::array<std::string, Dimension> series_names_;
   const uint8_t value_decimal_digits_;

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -639,7 +639,7 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
 
   std::vector<ModuleData*> modules_to_load;
   for (const auto& module : GetModulesFromIndices(app_, selected_tree_indices)) {
-    if (!module->is_loaded()) {
+    if (!module->AreDebugSymbolsLoaded()) {
       modules_to_load.push_back(module);
     }
   }

--- a/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
+++ b/src/WindowsUtils/include/WindowsUtils/ProcessLauncher.h
@@ -43,7 +43,7 @@ class ProcessLauncher {
 
   absl::Mutex mutex_;
   absl::flat_hash_map<uint32_t, std::unique_ptr<orbit_windows_utils::BusyLoopLauncher>>
-      busy_loop_launchers_by_pid_ GUARDED_BY(mutex_);
+      busy_loop_launchers_by_pid_ ABSL_GUARDED_BY(mutex_);
 };
 
 }  // namespace orbit_windows_utils


### PR DESCRIPTION
In terms of loaded symbols, previously a `ModuleData` could be in two states: symbols not loaded or symbols loaded (`ModuleData::is_loaded()`).

In the context of the "fallback symbols" we will have three states, represented by the new `ModuleData::SymbolCompleteness`: symbols not loaded, fallback symbols loaded, full debug symbols loaded. `ModuleData::is_loaded()` is replaced by `GetLoadedSymbolsCompleteness()`. We also add the convenience methods `AreDebugSymbolsLoaded()` and `AreAtLeastFallbackSymbolsLoaded()`: in replacing the usages of `is_loaded()`, in some cases we want to use one, in some cases the other.

`ModuleData::AddFallbackSymbols` is added to actually add the "fallback symbols". But note that it is not yet used in this change, only in tests.

Bug: http://b/245680119

Test:
- Extend various unit tests.
- As part of the larger symbol loading fallback prototype.