### PR TITLE
Update setting storage manager to save symbol store settings

### DIFF
--- a/src/ClientSymbols/QSettingsBasedStorageManager.cpp
+++ b/src/ClientSymbols/QSettingsBasedStorageManager.cpp
@@ -18,6 +18,8 @@ constexpr const char* kModuleSymbolFileMappingSymbolFileKey =
     "module_symbol_file_mapping_symbol_file_key";
 constexpr const char* kDisabledModulesKey = "disabled_modules_key";
 constexpr const char* kDisabledModuleKey = "disabled_module_key";
+constexpr const char* kEnableStadiaSymbolStoreKey = "enable_stadia_symbol_store_key";
+constexpr const char* kEnableMicrosoftSymbolServerKey = "enable_microsoft_symbol_server_key";
 
 namespace orbit_client_symbols {
 
@@ -56,8 +58,7 @@ void QSettingsBasedStorageManager::SaveModuleSymbolFileMappings(
   settings_.endArray();
 }
 
-[[nodiscard]] ModuleSymbolFileMappings
-QSettingsBasedStorageManager::LoadModuleSymbolFileMappings() {
+ModuleSymbolFileMappings QSettingsBasedStorageManager::LoadModuleSymbolFileMappings() {
   const int size = settings_.beginReadArray(kModuleSymbolFileMappingKey);
   ModuleSymbolFileMappings mappings;
   mappings.reserve(size);
@@ -85,8 +86,7 @@ void QSettingsBasedStorageManager::SaveDisabledModulePaths(absl::flat_hash_set<s
   settings_.endArray();
 }
 
-[[nodiscard]] absl::flat_hash_set<std::string>
-QSettingsBasedStorageManager::LoadDisabledModulePaths() {
+absl::flat_hash_set<std::string> QSettingsBasedStorageManager::LoadDisabledModulePaths() {
   const int size = settings_.beginReadArray(kDisabledModulesKey);
   absl::flat_hash_set<std::string> paths;
   paths.reserve(size);
@@ -96,6 +96,23 @@ QSettingsBasedStorageManager::LoadDisabledModulePaths() {
   }
   settings_.endArray();
   return paths;
+}
+
+void QSettingsBasedStorageManager::SaveEnableStadiaSymbolStore(bool enable_stadia_symbol_store) {
+  settings_.setValue(kEnableStadiaSymbolStoreKey, enable_stadia_symbol_store);
+}
+
+bool QSettingsBasedStorageManager::LoadEnableStadiaSymbolStore() {
+  return settings_.value(kEnableStadiaSymbolStoreKey, false).toBool();
+}
+
+void QSettingsBasedStorageManager::SaveEnableMicrosoftSymbolServer(
+    bool enable_microsoft_symbol_server) {
+  settings_.setValue(kEnableMicrosoftSymbolServerKey, enable_microsoft_symbol_server);
+}
+
+bool QSettingsBasedStorageManager::LoadEnableMicrosoftSymbolServer() {
+  return settings_.value(kEnableMicrosoftSymbolServerKey, false).toBool();
 }
 
 }  // namespace orbit_client_symbols

--- a/src/ClientSymbols/include/ClientSymbols/PersistentStorageManager.h
+++ b/src/ClientSymbols/include/ClientSymbols/PersistentStorageManager.h
@@ -33,6 +33,16 @@ class PersistentStorageManager {
 
   virtual void SaveDisabledModulePaths(absl::flat_hash_set<std::string> paths) = 0;
   [[nodiscard]] virtual absl::flat_hash_set<std::string> LoadDisabledModulePaths() = 0;
+
+  // Symbol store related settings.
+  // Now we only save two booleans to indicate whether Stadia and Microsoft symbol stores are
+  // enabled or not. Once we support user specified symbol cache and (or) user defined symbol store,
+  // we need to save the symbol store related settings in some other way, for instance, a hash map.
+  virtual void SaveEnableStadiaSymbolStore(bool enable_stadia_symbol_store) = 0;
+  [[nodiscard]] virtual bool LoadEnableStadiaSymbolStore() = 0;
+
+  virtual void SaveEnableMicrosoftSymbolServer(bool enable_microsoft_symbol_server) = 0;
+  [[nodiscard]] virtual bool LoadEnableMicrosoftSymbolServer() = 0;
 };
 
 }  // namespace orbit_client_symbols

--- a/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
+++ b/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
@@ -32,6 +32,11 @@ class QSettingsBasedStorageManager : public PersistentStorageManager {
   void SaveDisabledModulePaths(absl::flat_hash_set<std::string> paths) override;
   [[nodiscard]] absl::flat_hash_set<std::string> LoadDisabledModulePaths() override;
 
+  void SaveEnableStadiaSymbolStore(bool enable_stadia_symbol_store) override;
+  [[nodiscard]] bool LoadEnableStadiaSymbolStore() override;
+  void SaveEnableMicrosoftSymbolServer(bool enable_microsoft_symbol_server) override;
+  [[nodiscard]] bool LoadEnableMicrosoftSymbolServer() override;
+
  private:
   QSettings settings_;
 };

--- a/src/ConfigWidgets/SymbolLocationsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialogTest.cpp
@@ -43,6 +43,10 @@ class MockPersistentStorageManager : public orbit_client_symbols::PersistentStor
   MOCK_METHOD((ModuleSymbolFileMappings), LoadModuleSymbolFileMappings, (), (override));
   MOCK_METHOD(void, SaveDisabledModulePaths, (absl::flat_hash_set<std::string>), (override));
   MOCK_METHOD(absl::flat_hash_set<std::string>, LoadDisabledModulePaths, (), (override));
+  MOCK_METHOD(void, SaveEnableStadiaSymbolStore, (bool), (override));
+  MOCK_METHOD(bool, LoadEnableStadiaSymbolStore, (), (override));
+  MOCK_METHOD(void, SaveEnableMicrosoftSymbolServer, (bool), (override));
+  MOCK_METHOD(bool, LoadEnableMicrosoftSymbolServer, (), (override));
 };
 
 class SymbolLocationsDialogTest : public ::testing::Test {


### PR DESCRIPTION
With this change, we update the QSettingsBasedStorageManager to support saving / loading the booleans for enabling / disabling the Stadia and Microsoft symbol stores.

Bug: http://b/239166878