### PR TITLE
Add --disable_instance_symbols flag

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -92,3 +92,6 @@ ABSL_FLAG(bool, tracepoint_callstack_collection, false,
           "Enable callstack gathering for tracepoints feature.");
 
 ABSL_FLAG(bool, symbol_store_support, false, "Enable experimental symbol store support.");
+
+// Disables retrieving symbols from the instance. This is intended for symbol store e2e tests.
+ABSL_FLAG(bool, disable_instance_symbols, false, "Disable retrieving symbols from the instance.");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -76,7 +76,10 @@ ABSL_DECLARE_FLAG(bool, time_range_selection);
 // Enables callstack gathering with tracepoints.
 ABSL_DECLARE_FLAG(bool, tracepoint_callstack_collection);
 
-// Enable experimental symbol store support.
+// Enables experimental symbol store support.
 ABSL_DECLARE_FLAG(bool, symbol_store_support);
+
+// Disables retrieving symbols from the instance.
+ABSL_DECLARE_FLAG(bool, disable_instance_symbols);
 
 #endif  // CLIENT_FLAGS_CLIENT_FLAGS_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2046,7 +2046,8 @@ Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::RetrieveModu
             // If --local, Orbit cannot download files from the instance, because no ssh channel
             // exists. We still return an ErrorMessage to enable continuing searching for symbols
             // from other symbol sources.
-            if (absl::GetFlag(FLAGS_local) || !main_window_->IsConnected()) {
+            if (absl::GetFlag(FLAGS_local) || !main_window_->IsConnected() ||
+                absl::GetFlag(FLAGS_disable_instance_symbols)) {
               return {ErrorMessage{"\n- Not able to search for symbols from instance"}};
             }
 


### PR DESCRIPTION
Add a flag to support disabling retrieving symbols from the instance. 
This is intended for the symbol store e2e test. Hence we can clear the 
symbol cache and disable instance symbols, and then check whether 
symbols are retrieved from the symbol store.

Bug: http://b/239167825