### PR TITLE
Add enable symbol store checkboxes to ui

### DIFF
--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -34,16 +34,10 @@ constexpr const char* kOverrideWarningText =
     "The Build ID in the file you selected does not match. This may lead to unexpected behavior in "
     "Orbit.<br />Override to use this file.";
 constexpr const char* kNewInfoLabelTemplate =
-    "<p>Orbit loads most symbols automatically. Add folders and files to the symbol locations "
-    "Orbit loads from:</p><p><b>Add Folder</b> to add a symbol location. The symbol files' "
+    "<p>Orbit loads from:</p><p><b>Add Folder</b> to add a symbol location. The symbol files' "
     "filenames and build IDs must match the module's name and build ID. Supported file extensions "
     "are “.so”, “.debug”, “.so.debug”, “.dll” and “.pdb”.</p><p><b>Add File</b> to load from a "
     "symbol file with a different filename%1</p>";
-constexpr const char* kSymbolStoreInfo =
-    "<p>If enable searching for symbols in Stadia symbol store / Microsoft symbol server, Orbit "
-    "also supports retrieving symbols from Stadia symbol store / Microsoft symbol server. Note "
-    "that <b>the module's name and build ID will be used to request symbols from symbol "
-    "stores</b>.</p>";
 constexpr const char* kInfoLabelArgumentNoBuildIdOverride = " or extension.";
 constexpr const char* kInfoLabelArgumentWithBuildIdOverride = ", extension or build ID.";
 constexpr QListWidgetItem::ItemType kOverrideMappingItemType = QListWidgetItem::ItemType::UserType;
@@ -149,8 +143,7 @@ SymbolLocationsDialog::SymbolLocationsDialog(
   ui_->setupUi(this);
   SetUpInfoLabel();
   if (!absl::GetFlag(FLAGS_symbol_store_support)) {
-    ui_->enableStadiaSymbolStoreCheckBox->hide();
-    ui_->enableMicrosoftSymbolServerCheckBox->hide();
+    ui_->symbolStoreGroupBox->hide();
   } else {
     ui_->enableStadiaSymbolStoreCheckBox->setChecked(
         persistent_storage_manager_->LoadEnableStadiaSymbolStore());
@@ -450,7 +443,6 @@ void SymbolLocationsDialog::SetUpInfoLabel() {
   } else {
     label_text = label_text.arg(kInfoLabelArgumentNoBuildIdOverride);
   }
-  if (absl::GetFlag(FLAGS_symbol_store_support)) label_text.append(kSymbolStoreInfo);
   ui_->infoLabel->setText(label_text);
 }
 

--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -29,15 +29,16 @@
 #include "ui_SymbolLocationsDialog.h"
 
 constexpr const char* kFileDialogSavedDirectoryKey = "symbols_file_dialog_saved_directory";
-constexpr const char* kModuleHeadlineLabel = "Add Symbols for <font color=\"#E64646\">%1</font>";
+constexpr const char* kModuleHeadlineLabel =
+    "Orbit was not able to load symbols for <font color=\"#E64646\">%1</font>";
 constexpr const char* kOverrideWarningText =
     "The Build ID in the file you selected does not match. This may lead to unexpected behavior in "
     "Orbit.<br />Override to use this file.";
 constexpr const char* kNewInfoLabelTemplate =
-    "<p>Orbit loads from:</p><p><b>Add Folder</b> to add a symbol location. The symbol files' "
-    "filenames and build IDs must match the module's name and build ID. Supported file extensions "
-    "are “.so”, “.debug”, “.so.debug”, “.dll” and “.pdb”.</p><p><b>Add File</b> to load from a "
-    "symbol file with a different filename%1</p>";
+    "<p>Add folders and files to the symbol locations Orbit loads from:</p><p><b>Add Folder</b> to "
+    "add a symbol location. The symbol files' filenames and build IDs must match the module's name "
+    "and build ID. Supported file extensions are “.so”, “.debug”, “.so.debug”, “.dll” and "
+    "“.pdb”.</p><p><b>Add File</b> to load from a symbol file with a different filename%1</p>";
 constexpr const char* kInfoLabelArgumentNoBuildIdOverride = " or extension.";
 constexpr const char* kInfoLabelArgumentWithBuildIdOverride = ", extension or build ID.";
 constexpr QListWidgetItem::ItemType kOverrideMappingItemType = QListWidgetItem::ItemType::UserType;

--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -35,10 +35,10 @@ constexpr const char* kOverrideWarningText =
     "The Build ID in the file you selected does not match. This may lead to unexpected behavior in "
     "Orbit.<br />Override to use this file.";
 constexpr const char* kNewInfoLabelTemplate =
-    "<p>Add folders and files to the symbol locations Orbit loads from:</p><p><b>Add Folder</b> to "
-    "add a symbol location. The symbol files' filenames and build IDs must match the module's name "
-    "and build ID. Supported file extensions are “.so”, “.debug”, “.so.debug”, “.dll” and "
-    "“.pdb”.</p><p><b>Add File</b> to load from a symbol file with a different filename%1</p>";
+    "<p><b>Add Folder</b> to add a symbol location. The symbol files' filenames and build IDs must "
+    "match the module's name and build ID. Supported file extensions are “.so”, “.debug”, "
+    "“.so.debug”, “.dll” and “.pdb”.</p><p><b>Add File</b> to load from a symbol file with a "
+    "different filename%1</p>";
 constexpr const char* kInfoLabelArgumentNoBuildIdOverride = " or extension.";
 constexpr const char* kInfoLabelArgumentWithBuildIdOverride = ", extension or build ID.";
 constexpr QListWidgetItem::ItemType kOverrideMappingItemType = QListWidgetItem::ItemType::UserType;
@@ -424,6 +424,7 @@ void SymbolLocationsDialog::SetUpModuleHeadlineLabel() {
       QString(kModuleHeadlineLabel)
           .arg(QString::fromStdString(
               std::filesystem::path(module_.value()->file_path()).filename().string())));
+  ui_->line->setVisible(true);
 }
 
 void SymbolLocationsDialog::DisableAddFolder() {

--- a/src/ConfigWidgets/SymbolLocationsDialog.ui
+++ b/src/ConfigWidgets/SymbolLocationsDialog.ui
@@ -22,6 +22,19 @@
     </widget>
    </item>
    <item>
+    <widget class="Line" name="line">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background: #353535</string>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_0">
      <item>
       <widget class="QLabel" name="generalInfoLabel">

--- a/src/ConfigWidgets/SymbolLocationsDialog.ui
+++ b/src/ConfigWidgets/SymbolLocationsDialog.ui
@@ -15,6 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="moduleHeadlineLabel">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_0">
      <item>
       <widget class="QLabel" name="generalInfoLabel">
@@ -25,7 +32,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Orbit loads most symbols automatically.</string>
+        <string>Orbit loads most symbols automatically. Configure additional symbol locations here.</string>
        </property>
        <property name="wordWrap">
         <bool>false</bool>
@@ -69,10 +76,10 @@
    <item>
     <widget class="QGroupBox" name="symbolLocationGroupBox">
      <property name="title">
-      <string>Add folders and files to the symbol locations.</string>
+      <string>Local symbol locations</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="infoLabel">
         <property name="text">
          <string/>
@@ -82,17 +89,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="0" column="0">
        <widget class="QListWidget" name="listWidget"/>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="moduleHeadlineLabel">
-        <property name="visible">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
+      <item row="0" column="1">
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
          <widget class="QPushButton" name="addFolderButton">
@@ -139,7 +139,7 @@
    <item>
     <widget class="QGroupBox" name="symbolStoreGroupBox">
      <property name="title">
-      <string>Enable symbol stores where Orbit can search for symbols.</string>
+      <string>Symbol stores</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_1">
       <item>
@@ -148,7 +148,7 @@
          <string>EnableStadiaSymbolStoreCheckBox</string>
         </property>
         <property name="text">
-         <string>Enable searching for symbols in Stadia symbol store</string>
+         <string>Enable Stadia symbol store</string>
         </property>
        </widget>
       </item>
@@ -158,15 +158,14 @@
          <string>EnableMicrosoftSymbolServerCheckBox</string>
         </property>
         <property name="text">
-         <string>Enable searching for symbols in Microsoft public symbol server</string>
+         <string>Enable Microsoft public symbol server</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QLabel" name="symbolStoreInfoLabel">
         <property name="text">
-         <string>Orbit supports retrieving symbols from Stadia symbol store / Microsoft symbol server if they are enabled.
-Note that the module's name and build ID will be used to request symbols from symbol stores.</string>
+         <string>Orbit supports retrieving symbols from symbol stores. Note that the module's name and build ID will be used to send requests to symbol stores.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/ConfigWidgets/SymbolLocationsDialog.ui
+++ b/src/ConfigWidgets/SymbolLocationsDialog.ui
@@ -17,14 +17,14 @@
    <item row="1" column="0">
     <widget class="QListWidget" name="listWidget"/>
    </item>
-   <item row="4" column="1">
+   <item row="6" column="1">
     <widget class="QPushButton" name="doneButton">
      <property name="text">
       <string>Done</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="5" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QPushButton" name="moreInfoButton">
@@ -51,7 +51,7 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="infoLabel">
      <property name="text">
       <string/>
@@ -102,6 +102,26 @@
      </item>
     </layout>
    </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="enableStadiaSymbolStoreCheckBox">
+     <property name="accessibleName">
+      <string>EnableStadiaSymbolStoreCheckBox</string>
+     </property>
+     <property name="text">
+      <string>Enable searching for symbols in Stadia symbol store</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="enableMicrosoftSymbolServerCheckBox">
+     <property name="accessibleName">
+      <string>EnableMicrosoftSymbolServerCheckBox</string>
+     </property>
+     <property name="text">
+      <string>Enable searching for symbols in Microsoft public symbol server</string>
+     </property>
+    </widget>
+   </item>   
    <item row="0" column="0">
     <widget class="QLabel" name="moduleHeadlineLabel">
      <property name="visible">

--- a/src/ConfigWidgets/SymbolLocationsDialog.ui
+++ b/src/ConfigWidgets/SymbolLocationsDialog.ui
@@ -6,40 +6,55 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>614</width>
+    <width>634</width>
     <height>398</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Symbol Locations</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QListWidget" name="listWidget"/>
-   </item>
-   <item row="6" column="1">
-    <widget class="QPushButton" name="doneButton">
-     <property name="text">
-      <string>Done</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_0">
      <item>
-      <widget class="QPushButton" name="moreInfoButton">
-       <property name="styleSheet">
-        <string notr="true">border: none; color: #4F9CFF; font-weight: bold; text-decoration: underline</string>
+      <widget class="QLabel" name="generalInfoLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="text">
-        <string>More information on symbol loading</string>
+        <string>Orbit loads most symbols automatically.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_2">
+      <widget class="QPushButton" name="moreInfoButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">border: none; color: #4F9CFF; font-weight: bold; text-decoration: underline</string>
+       </property>
+       <property name="text">
+        <string>(learn more)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_0">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -51,83 +66,142 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="infoLabel">
-     <property name="text">
-      <string/>
+   <item>
+    <widget class="QGroupBox" name="symbolLocationGroupBox">
+     <property name="title">
+      <string>Add folders and files to the symbol locations.</string>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="2" column="0">
+       <widget class="QLabel" name="infoLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QListWidget" name="listWidget"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="moduleHeadlineLabel">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QPushButton" name="addFolderButton">
+          <property name="text">
+           <string>Add Folder</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="addFileButton">
+          <property name="text">
+           <string>Add File</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="removeButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Remove</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="1" column="1">
-    <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="symbolStoreGroupBox">
+     <property name="title">
+      <string>Enable symbol stores where Orbit can search for symbols.</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_1">
+      <item>
+       <widget class="QCheckBox" name="enableStadiaSymbolStoreCheckBox">
+        <property name="accessibleName">
+         <string>EnableStadiaSymbolStoreCheckBox</string>
+        </property>
+        <property name="text">
+         <string>Enable searching for symbols in Stadia symbol store</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="enableMicrosoftSymbolServerCheckBox">
+        <property name="accessibleName">
+         <string>EnableMicrosoftSymbolServerCheckBox</string>
+        </property>
+        <property name="text">
+         <string>Enable searching for symbols in Microsoft public symbol server</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="symbolStoreInfoLabel">
+        <property name="text">
+         <string>Orbit supports retrieving symbols from Stadia symbol store / Microsoft symbol server if they are enabled.
+Note that the module's name and build ID will be used to request symbols from symbol stores.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_1">
      <item>
-      <widget class="QPushButton" name="addFolderButton">
-       <property name="text">
-        <string>Add Folder</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="addFileButton">
-       <property name="text">
-        <string>Add File</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="removeButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Remove</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
+      <spacer name="horizontalSpacer_1">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>20</width>
-         <height>40</height>
+         <width>40</width>
+         <height>20</height>
         </size>
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QPushButton" name="doneButton">
+       <property name="text">
+        <string>Done</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item row="2" column="0">
-    <widget class="QCheckBox" name="enableStadiaSymbolStoreCheckBox">
-     <property name="accessibleName">
-      <string>EnableStadiaSymbolStoreCheckBox</string>
-     </property>
-     <property name="text">
-      <string>Enable searching for symbols in Stadia symbol store</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="enableMicrosoftSymbolServerCheckBox">
-     <property name="accessibleName">
-      <string>EnableMicrosoftSymbolServerCheckBox</string>
-     </property>
-     <property name="text">
-      <string>Enable searching for symbols in Microsoft public symbol server</string>
-     </property>
-    </widget>
-   </item>   
-   <item row="0" column="0">
-    <widget class="QLabel" name="moduleHeadlineLabel">
-     <property name="visible">
-      <bool>false</bool>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>
@@ -136,8 +210,6 @@
   <tabstop>addFileButton</tabstop>
   <tabstop>removeButton</tabstop>
   <tabstop>listWidget</tabstop>
-  <tabstop>moreInfoButton</tabstop>
-  <tabstop>doneButton</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2068,9 +2068,11 @@ Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::RetrieveModu
           main_thread_executor_,
           [this, module_id, stop_token = stop_source.GetStopToken()](
               const SymbolRetrieveResult& previous_result) mutable -> Future<SymbolRetrieveResult> {
-            // TODO(b/239166878) Add a boolean to control enable / disable searching in Stadia
-            // symbol store. Enable the user to set it in the symbol location dialog.
-            if (stadia_symbol_provider_ == std::nullopt) return {previous_result};
+            if (orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+                stadia_symbol_provider_ == std::nullopt ||
+                !storage_manager.LoadEnableStadiaSymbolStore()) {
+              return {previous_result};
+            }
 
             if (previous_result.has_value()) return {previous_result.value()};
 
@@ -2084,9 +2086,11 @@ Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::RetrieveModu
           main_thread_executor_,
           [this, module_id, stop_token = stop_source.GetStopToken()](
               const SymbolRetrieveResult& previous_result) mutable -> Future<SymbolRetrieveResult> {
-            // TODO(b/239166878) Add a boolean to control enable / disable searching in Microsoft
-            // symbol server. Enable the user to set it in the symbol location dialog.
-            if (microsoft_symbol_provider_ == std::nullopt) return {previous_result};
+            if (orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+                microsoft_symbol_provider_ == std::nullopt ||
+                !storage_manager.LoadEnableMicrosoftSymbolServer()) {
+              return {previous_result};
+            }
 
             if (previous_result.has_value()) return {previous_result.value()};
 


### PR DESCRIPTION
With this change, we added the checkboxes to enable searching for symbols in Stadia and Microsoft symbol stores in Symbol Locations Dialog.

Bug: http://b/239166878

http://screenshot/9DZ5ag8JRCc6dYA
(The redundant "will be used" has been removed, but I'm to lazy to take a new screenshot 🙈  )