### PR TITLE
Add integration test for Microsoft symbol provider

### DIFF
--- a/src/RemoteSymbolProvider/CMakeLists.txt
+++ b/src/RemoteSymbolProvider/CMakeLists.txt
@@ -27,13 +27,16 @@ target_link_libraries(RemoteSymbolProvider PUBLIC
 add_executable(RemoteSymbolProviderTests)
 
 target_sources(RemoteSymbolProviderTests PRIVATE
+    MicrosoftSymbolServerSymbolProviderIntegrationTest.cpp
     MicrosoftSymbolServerSymbolProviderTest.cpp
     StadiaSymbolStoreSymbolProviderTest.cpp)
 
 target_link_libraries(RemoteSymbolProviderTests PRIVATE
+    GrpcProtos
+    ObjectUtils
+    RemoteSymbolProvider
     TestUtils
     Qt5::Core
-    RemoteSymbolProvider
     GTest::QtCoreMain)
 
 register_test(RemoteSymbolProviderTests)

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderIntegrationTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderIntegrationTest.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/strings/str_replace.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+
+#include "GrpcProtos/symbol.pb.h"
+#include "Http/HttpDownloadManager.h"
+#include "ObjectUtils/SymbolsFile.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/StopSource.h"
+#include "OrbitBase/TemporaryFile.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
+#include "RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h"
+#include "SymbolProvider/SymbolLoadingOutcome.h"
+#include "Symbols/MockSymbolCache.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_remote_symbol_provider {
+
+using orbit_grpc_protos::SymbolInfo;
+using orbit_test_utils::HasNoError;
+
+TEST(MicrosoftSymbolServerSymbolProviderIntegrationTest, RetrieveWindowsPdbAndLoadDebugSymbols) {
+  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
+  ASSERT_THAT(temporary_file_or_error, HasNoError());
+  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
+  ASSERT_TRUE(temporary_file.file_path().has_parent_path());
+  const std::filesystem::path kSymbolCacheDir = temporary_file.file_path().parent_path();
+
+  orbit_symbols::MockSymbolCache symbol_cache;
+  EXPECT_CALL(symbol_cache, GenerateCachedFilePath)
+      .WillRepeatedly([&kSymbolCacheDir](const std::filesystem::path& module_file_path) {
+        auto file_name = absl::StrReplaceAll(module_file_path.string(), {{"/", "_"}});
+        return kSymbolCacheDir / file_name;
+      });
+
+  orbit_http::HttpDownloadManager download_manager{};
+  MicrosoftSymbolServerSymbolProvider symbol_provider{&symbol_cache, &download_manager};
+
+  std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor{
+      orbit_qt_utils::MainThreadExecutorImpl::Create()};
+
+  const std::string kValidModuleName{"d3d11.pdb"};
+  const std::string kValidModuleBuildId{"FF5440275BFED43A86CC2B1F287A72151"};
+  orbit_symbol_provider::ModuleIdentifier kValidModuleId{kValidModuleName, kValidModuleBuildId};
+
+  orbit_base::StopSource stop_source{};
+
+  symbol_provider.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
+      .Then(executor.get(), [](const orbit_symbol_provider::SymbolLoadingOutcome& result) {
+        ASSERT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
+        orbit_symbol_provider::SymbolLoadingSuccessResult success_result =
+            orbit_symbol_provider::GetSuccessResult(result);
+
+        auto exists_or_error = orbit_base::FileExists(success_result.path);
+        ASSERT_THAT(exists_or_error, HasNoError());
+        EXPECT_TRUE(exists_or_error.value());
+
+        constexpr uint64_t kLoadBias = 0x10000;
+        auto symbols_file_or_error = orbit_object_utils::CreateSymbolsFile(
+            success_result.path, orbit_object_utils::ObjectFileInfo{kLoadBias});
+        ASSERT_THAT(symbols_file_or_error, HasNoError());
+
+        auto symbols_result = symbols_file_or_error.value()->LoadDebugSymbols();
+        ASSERT_THAT(symbols_result, HasNoError());
+
+        absl::flat_hash_map<uint64_t, const SymbolInfo*> symbol_infos_by_address;
+        for (const SymbolInfo& symbol_info : symbols_result.value().symbol_infos()) {
+          symbol_infos_by_address.emplace(symbol_info.address(), &symbol_info);
+        }
+
+        {
+          const SymbolInfo* symbol = symbol_infos_by_address[0x4aa90 + kLoadBias];
+          ASSERT_NE(symbol, nullptr);
+          EXPECT_EQ(symbol->demangled_name(), "D3D11CreateDevice");
+          EXPECT_EQ(symbol->size(), 0x100);
+        }
+
+        {
+          const SymbolInfo* symbol = symbol_infos_by_address[0x3a800 + kLoadBias];
+          ASSERT_NE(symbol, nullptr);
+          EXPECT_EQ(symbol->demangled_name(), "CContext::ValidateReclaimResources");
+          EXPECT_EQ(symbol->size(), 0x100);
+        }
+
+        auto removed_or_error = orbit_base::RemoveFile(success_result.path);
+        ASSERT_THAT(removed_or_error, HasNoError());
+        EXPECT_TRUE(removed_or_error.value());
+
+        QCoreApplication::exit();
+      });
+
+  QCoreApplication::exec();
+}
+
+}  // namespace orbit_remote_symbol_provider


### PR DESCRIPTION
This change adds the integration test for the MicrosoftSymbolServerSymbolProvider. It will first download a symbols file from the Microsoft public symbol server and then verify whether we can load debug symbols from the file.

Bug: http://b/239167825