### PR TITLE
Only copy stack relevant data if needed

### DIFF
--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -159,7 +159,7 @@ struct PerfRecordSample {
     if (event.abi != PERF_SAMPLE_REGS_ABI_NONE) {
       const int num_of_regs = std::bitset<64>(flags.sample_regs_user).count();
       if (copy_stack_related_data) {
-        event.regs = make_unique_for_overwrite<uint64_t[]>(num_of_regs * sizeof(uint64_t));
+        event.regs = make_unique_for_overwrite<uint64_t[]>(num_of_regs);
         ring_buffer->ReadRawAtOffset(event.regs.get(), current_offset,
                                      num_of_regs * sizeof(uint64_t));
       }

--- a/src/LinuxTracing/PerfEventReaders.h
+++ b/src/LinuxTracing/PerfEventReaders.h
@@ -56,10 +56,12 @@ SchedSwitchWithCallchainPerfEvent ConsumeSchedSwitchWithCallchainPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 PerfEvent ConsumeSchedSwitchWithOrWithoutStackPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                        const perf_event_header& header);
+                                                        const perf_event_header& header,
+                                                        bool copy_stack_related_data);
 
 PerfEvent ConsumeSchedWakeupWithOrWithoutStackPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                                        const perf_event_header& header);
+                                                        const perf_event_header& header,
+                                                        bool copy_stack_related_data);
 
 AmdgpuCsIoctlPerfEvent ConsumeAmdgpuCsIoctlPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                      const perf_event_header& header);

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -1394,14 +1394,18 @@ uint64_t TracerImpl::ProcessSampleEventAndReturnTimestamp(const perf_event_heade
     // TODO(b/243510000): the implementation of this case will be added later
 
   } else if (is_sched_switch_with_stack) {
-    // TODO(b/245529464): Avoid copying the stack if the record is from another process
-    PerfEvent event = ConsumeSchedSwitchWithOrWithoutStackPerfEvent(ring_buffer, header);
+    pid_t pid = ReadSampleRecordPid(ring_buffer);
+    bool copy_stack_related_data = pid == target_pid_;
+    PerfEvent event =
+        ConsumeSchedSwitchWithOrWithoutStackPerfEvent(ring_buffer, header, copy_stack_related_data);
     DeferEvent(std::move(event));
     ++stats_.sched_switch_count;
 
   } else if (is_sched_wakeup_with_stack) {
-    // TODO(b/245529464): Avoid copying the stack if the record is from another process
-    PerfEvent event = ConsumeSchedWakeupWithOrWithoutStackPerfEvent(ring_buffer, header);
+    pid_t pid = ReadSampleRecordPid(ring_buffer);
+    bool copy_stack_related_data = pid == target_pid_;
+    PerfEvent event =
+        ConsumeSchedWakeupWithOrWithoutStackPerfEvent(ring_buffer, header, copy_stack_related_data);
     DeferEvent(std::move(event));
 
   } else if (is_amdgpu_cs_ioctl_event) {


### PR DESCRIPTION
Collecting callstacks on thread state tracepoints introduces quite some overhead. Finally, we are only interested in callstacks that belong to our process. So we can save us from copying that data out of the ring buffer.

Profiling OrbitService showed, that copying the callstack data was (and still is) the biggest chunk of work
when profiling with callstack on thread state
tracepoints.

Bug: http://b/245529464
Test: Test E2E prototype