### PR TITLE
Make stack size for thread state slice configurable (on service)

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -167,7 +167,7 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
   auto api_functions = FindApiFunctions(module_manager, process_data);
   *(capture_options.mutable_api_functions()) = {api_functions.begin(), api_functions.end()};
 
-  capture_options.set_thread_state_change_call_stack_collection(
+  capture_options.set_thread_state_change_callstack_collection(
       options.thread_state_change_callstack_collection);
 
   return capture_options;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -50,7 +50,7 @@ message FunctionToRecordAdditionalStackOn {
   uint64 file_offset = 2;
 }
 
-// NextId: 21
+// NextId: 23
 message CaptureOptions {
   reserved 17;
 
@@ -107,7 +107,9 @@ message CaptureOptions {
   }
 
   ThreadStateChangeCallStackCollection
-      thread_state_change_call_stack_collection = 21;
+      thread_state_change_callstack_collection = 21;
+  // Expected to be "uint16".
+  uint32 thread_state_change_callstack_stack_dump_size = 22;
 }
 
 // For CaptureEvents with a duration, excluding for now GPU-related ones, we

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -88,11 +88,7 @@ class TracerImpl : public Tracer {
 
   bool OpenThreadNameTracepoints(const std::vector<int32_t>& cpus);
   void InitSwitchesStatesNamesVisitor();
-  bool OpenContextSwitchAndThreadStateTracepoints(
-      const std::vector<int32_t>& cpus,
-      orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
-          thread_state_change_callstack_collection,
-      orbit_grpc_protos::CaptureOptions::UnwindingMethod thread_state_change_callstack_method);
+  bool OpenContextSwitchAndThreadStateTracepoints(const std::vector<int32_t>& cpus);
 
   void InitGpuTracepointEventVisitor();
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
@@ -156,6 +152,7 @@ class TracerImpl : public Tracer {
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_;
   orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
       thread_state_change_callstack_collection_;
+  uint16_t thread_state_change_callstack_stack_dump_size_;
   std::vector<orbit_grpc_protos::InstrumentedFunction> instrumented_functions_;
   std::vector<orbit_grpc_protos::FunctionToRecordAdditionalStackOn>
       functions_to_record_additional_stack_on_;


### PR DESCRIPTION
Copying stacks for callstacks on thread state slices is the most expensive part on OrbitService. For thread state slices, we don't necesarrily need a complete callstack. We are mostly interested in the 1-3 callers of the lock/unlock calls.

This is different for normal stack sampling, where we need the full callstack for our statistics. Thus, it is desirable to allow the user to specify a different stack size to copy on thread state slices and reduce the overhead, both on the game and on OrbitService.

This change is adding a new field in the capture options to specify the stack dump size for thread states, and passes it down to the perf_event_open calls. The new default is 256.

We also streamline some parameters that were passed instead of using the class member and make stack size 0 if not needed (only for consistency).

We also fixed a typo in the capture options proto.

Test: Profile E2E prototype.
Bug: http://b/243510345