### PR TITLE
Send stack dump size for thread state callstacks

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -108,6 +108,8 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
   ORBIT_CHECK(options.unwinding_method != CaptureOptions::kUndefined);
   capture_options.set_unwinding_method(options.unwinding_method);
   capture_options.set_stack_dump_size(options.stack_dump_size);
+  capture_options.set_thread_state_change_callstack_stack_dump_size(
+      options.thread_state_change_callstack_stack_dump_size);
   capture_options.set_samples_per_second(options.samples_per_second);
 
   capture_options.set_collect_memory_info(options.collect_memory_info);

--- a/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
+++ b/src/CaptureClient/include/CaptureClient/ClientCaptureOptions.h
@@ -34,6 +34,7 @@ struct ClientCaptureOptions {
           orbit_grpc_protos::CaptureOptions::kThreadStateChangeCallStackCollectionUnspecified;
 
   uint16_t stack_dump_size = 0;
+  uint16_t thread_state_change_callstack_stack_dump_size = 0;
   uint64_t max_local_marker_depth_per_command_buffer = 0;
   uint64_t memory_sampling_period_ms = 0;
   double samples_per_second = 0;

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -254,6 +254,16 @@ uint16_t DataManager::stack_dump_size() const {
   return stack_dump_size_;
 }
 
+void DataManager::set_thread_state_change_callstack_stack_dump_size(uint16_t stack_dump_size) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  thread_state_change_callstack_stack_dump_size_ = stack_dump_size;
+}
+
+uint16_t DataManager::thread_state_change_callstack_stack_dump_size() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return thread_state_change_callstack_stack_dump_size_;
+}
+
 void DataManager::set_unwinding_method(orbit_grpc_protos::CaptureOptions::UnwindingMethod method) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   unwinding_method_ = method;

--- a/src/ClientData/DataManagerTest.cpp
+++ b/src/ClientData/DataManagerTest.cpp
@@ -80,6 +80,10 @@ TEST(DataManager, CanOnlyBeUsedFromTheMainThread) {
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::samples_per_second);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_stack_dump_size, 0);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::stack_dump_size);
+  CallMethodOnDifferentThreadAndExpectDeath(
+      data_manager, &DataManager::set_thread_state_change_callstack_stack_dump_size, 0);
+  CallMethodOnDifferentThreadAndExpectDeath(
+      data_manager, &DataManager::thread_state_change_callstack_stack_dump_size);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::set_unwinding_method,
                                             orbit_grpc_protos::CaptureOptions::kUndefined);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::unwinding_method);

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -102,6 +102,9 @@ class DataManager final {
   void set_stack_dump_size(uint16_t stack_dump_size);
   [[nodiscard]] uint16_t stack_dump_size() const;
 
+  void set_thread_state_change_callstack_stack_dump_size(uint16_t stack_dump_size);
+  [[nodiscard]] uint16_t thread_state_change_callstack_stack_dump_size() const;
+
   void set_unwinding_method(orbit_grpc_protos::CaptureOptions::UnwindingMethod method);
   [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method() const;
 
@@ -154,6 +157,7 @@ class DataManager final {
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
   double samples_per_second_ = 0;
   uint16_t stack_dump_size_ = 0;
+  uint16_t thread_state_change_callstack_stack_dump_size_ = 0;
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_{};
 
   bool enable_auto_frame_track_ = false;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1603,6 +1603,8 @@ void OrbitApp::StartCapture() {
   options.dynamic_instrumentation_method = data_manager_->dynamic_instrumentation_method();
   options.samples_per_second = data_manager_->samples_per_second();
   options.stack_dump_size = data_manager_->stack_dump_size();
+  options.thread_state_change_callstack_stack_dump_size =
+      data_manager_->thread_state_change_callstack_stack_dump_size();
   options.unwinding_method = data_manager_->unwinding_method();
   options.max_local_marker_depth_per_command_buffer =
       data_manager_->max_local_marker_depth_per_command_buffer();
@@ -2807,6 +2809,10 @@ void OrbitApp::SetStackDumpSize(uint16_t stack_dump_size) {
 
 void OrbitApp::SetUnwindingMethod(UnwindingMethod unwinding_method) {
   data_manager_->set_unwinding_method(unwinding_method);
+}
+
+void OrbitApp::SetThreadStateChangeCallstackStackDumpSize(uint16_t stack_dump_size) {
+  data_manager_->set_thread_state_change_callstack_stack_dump_size(stack_dump_size);
 }
 
 void OrbitApp::SetMaxLocalMarkerDepthPerCommandBuffer(

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -437,6 +437,7 @@ class OrbitApp final : public DataViewFactory,
   void SetWineSyscallHandlingMethod(orbit_client_data::WineSyscallHandlingMethod method);
   void SetSamplesPerSecond(double samples_per_second);
   void SetStackDumpSize(uint16_t stack_dump_size);
+  void SetThreadStateChangeCallstackStackDumpSize(uint16_t stack_dump_size);
   void SetUnwindingMethod(orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
   void SetEnableAutoFrameTrack(bool enable_auto_frame_track);


### PR DESCRIPTION
This adds the data member in DataManager and send the content to get capture start.

It is still missing the exposure in the capture options.

Test: Full e2e prototype
Bug: http://b/243510345