### PR TITLE
Add a simple hard-coded FunctionSymbolToKey for d3d11

### DIFF
--- a/src/MizarData/BaselineAndComparisonHelper.h
+++ b/src/MizarData/BaselineAndComparisonHelper.h
@@ -13,7 +13,7 @@
 #include <tuple>
 #include <utility>
 
-#include "FunctionSymbolToKeyExactNameMatch.h"
+#include "DummyFunctionSymbolToKey.h"
 #include "MizarBase/AbsoluteAddress.h"
 #include "MizarBase/BaselineOrComparison.h"
 #include "MizarBase/FunctionSymbols.h"
@@ -116,7 +116,7 @@ class BaselineAndComparisonHelperTmpl {
 
 // The instantiation used in production
 using BaselineAndComparisonHelper =
-    BaselineAndComparisonHelperTmpl<FunctionSymbolToKeyExactNameMatch, std::string>;
+    BaselineAndComparisonHelperTmpl<D3D11DummyFunctionSymbolToKey, std::string>;
 
 }  // namespace orbit_mizar_data
 

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 target_sources(MizarData PRIVATE
                 BaselineAndComparison.cpp
                 BaselineAndComparisonHelper.h
+                DummyFunctionSymbolToKey.h
                 FunctionSymbolToKeyExactNameMatch.h
                 GetCallstackSamplingIntervals.cpp
                 MizarData.cpp)
@@ -41,6 +42,7 @@ add_executable(MizarDataTests)
 
 target_sources(MizarDataTests PRIVATE
                 BaselineAndComparisonTest.cpp
+                DummyFunctionSymbolToKeyTest.cpp
                 GetCallstackSamplingIntervalsTest.cpp
                 FrameTrackManagerTest.cpp
                 MizarDataTest.cpp

--- a/src/MizarData/CMakeLists.txt
+++ b/src/MizarData/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(MizarData PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 target_sources(MizarData PRIVATE
                 BaselineAndComparison.cpp
                 BaselineAndComparisonHelper.h
+                DummyFunctionSymbolToKey.cpp
                 DummyFunctionSymbolToKey.h
                 FunctionSymbolToKeyExactNameMatch.h
                 GetCallstackSamplingIntervals.cpp

--- a/src/MizarData/DummyFunctionSymbolToKey.cpp
+++ b/src/MizarData/DummyFunctionSymbolToKey.cpp
@@ -22,7 +22,8 @@ std::string DummyFunctionSymbolToKey::GetKey(const FunctionSymbol& symbol) const
   return symbol.function_name;
 }
 
-const auto* D3D11DummyFunctionSymbolToKey::kDirectXToDxvkNames =
+const absl::flat_hash_map<std::string,
+                          std::string>* D3D11DummyFunctionSymbolToKey::kDirectXToDxvkNames =
     new absl::flat_hash_map<std::string, std::string>{
         {"CContext::TID3D11DeviceContext_ClearRenderTargetView_<1>",
          "dxvk::D3D11DeviceContext::ClearRenderTargetView(ID3D11RenderTargetView*, float const*)"},
@@ -39,7 +40,7 @@ const auto* D3D11DummyFunctionSymbolToKey::kDirectXToDxvkNames =
          "dxvk::D3D11SwapChain::Present(unsigned int, unsigned int, DXGI_PRESENT_PARAMETERS "
          "const*)"}};
 
-const auto* D3D11DummyFunctionSymbolToKey::kMappableModules =
+const absl::flat_hash_set<std::string>* D3D11DummyFunctionSymbolToKey::kMappableModules =
     new absl::flat_hash_set<std::string>{"d3d11", "dxgi"};
 
 }  // namespace orbit_mizar_data

--- a/src/MizarData/DummyFunctionSymbolToKey.cpp
+++ b/src/MizarData/DummyFunctionSymbolToKey.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "DummyFunctionSymbolToKey.h"
+
+#include <string>
+
+#include "MizarBase/FunctionSymbols.h"
+
+using ::orbit_mizar_base::FunctionSymbol;
+
+namespace orbit_mizar_data {
+
+std::string DummyFunctionSymbolToKey::GetKey(const FunctionSymbol& symbol) const {
+  if (mappable_modules_->contains(symbol.module_file_name)) {
+    if (const auto it = function_name_to_key_->find(symbol.function_name);
+        it != function_name_to_key_->end()) {
+      return it->second;
+    }
+  }
+  return symbol.function_name;
+}
+
+const auto* D3D11DummyFunctionSymbolToKey::kDirectXToDxvkNames =
+    new absl::flat_hash_map<std::string, std::string>{
+        {"CContext::TID3D11DeviceContext_ClearRenderTargetView_<1>",
+         "dxvk::D3D11DeviceContext::ClearRenderTargetView(ID3D11RenderTargetView*, float const*)"},
+        {"CContext::TID3D11DeviceContext_SetShader_<1,0>",
+         "dxvk::D3D11DeviceContext::PSSetShader(ID3D11PixelShader*, ID3D11ClassInstance* const*, "
+         "unsigned int)"},
+        {"CContext::TID3D11DeviceContext_Draw_<9>(ID3D11DeviceContext5 *,unsigned int,unsigned "
+         "int)",
+         "dxvk::D3D11DeviceContext::Draw(unsigned int, unsigned int)"},
+        {"CContext::TID3D11DeviceContext_SetShader_<1,4>",
+         "dxvk::D3D11DeviceContext::VSSetShader(ID3D11VertexShader*, ID3D11ClassInstance* const*, "
+         "unsigned int)"},
+        {"CDXGISwapChain::Present",
+         "dxvk::D3D11SwapChain::Present(unsigned int, unsigned int, DXGI_PRESENT_PARAMETERS "
+         "const*)"}};
+
+const auto* D3D11DummyFunctionSymbolToKey::kMappableModules =
+    new absl::flat_hash_set<std::string>{"d3d11", "dxgi"};
+
+}  // namespace orbit_mizar_data

--- a/src/MizarData/DummyFunctionSymbolToKey.h
+++ b/src/MizarData/DummyFunctionSymbolToKey.h
@@ -12,48 +12,35 @@
 
 #include "MizarBase/FunctionSymbols.h"
 
-namespace orbit_mizar_data_internal {
-static const auto* kDirectXToDxvkNames = new absl::flat_hash_map<std::string, std::string>{
-    {"CContext::TID3D11DeviceContext_ClearRenderTargetView_<1>",
-     "dxvk::D3D11DeviceContext::ClearRenderTargetView(ID3D11RenderTargetView*, float const*)"},
-    {"CContext::TID3D11DeviceContext_SetShader_<1,0>",
-     "dxvk::D3D11DeviceContext::PSSetShader(ID3D11PixelShader*, ID3D11ClassInstance* const*, "
-     "unsigned int)"},
-    {"CContext::TID3D11DeviceContext_Draw_<9>(ID3D11DeviceContext5 *,unsigned int,unsigned int)",
-     "dxvk::D3D11DeviceContext::Draw(unsigned int, unsigned int)"},
-    {"CContext::TID3D11DeviceContext_SetShader_<1,4>",
-     "dxvk::D3D11DeviceContext::VSSetShader(ID3D11VertexShader*, ID3D11ClassInstance* const*, "
-     "unsigned int)"},
-    {"CDXGISwapChain::Present",
-     "dxvk::D3D11SwapChain::Present(unsigned int, unsigned int, DXGI_PRESENT_PARAMETERS const*)"}};
-
-static const auto* kMappableModules = new absl::flat_hash_set<std::string>{"d3d11", "dxgi"};
-
-}  // namespace orbit_mizar_data_internal
-
 namespace orbit_mizar_data {
 
 // If a function comes from `mappableModules`, the key from `functionNameToKey` is returned if
 // present. Defaulting to the function name as the key.
-template <auto& functionNameToKey, auto& mappableModules>
 class DummyFunctionSymbolToKey {
   using FunctionSymbol = ::orbit_mizar_base::FunctionSymbol;
 
  public:
-  [[nodiscard]] std::string GetKey(const FunctionSymbol& symbol) const {
-    if (mappableModules->contains(symbol.module_file_name)) {
-      if (const auto it = functionNameToKey->find(symbol.function_name);
-          it != functionNameToKey->end()) {
-        return it->second;
-      }
-    }
-    return symbol.function_name;
-  }
+  DummyFunctionSymbolToKey(
+      const absl::flat_hash_map<std::string, std::string>* function_name_to_key,
+      const absl::flat_hash_set<std::string>* mappable_modules)
+      : function_name_to_key_(function_name_to_key), mappable_modules_(mappable_modules) {}
+
+  [[nodiscard]] std::string GetKey(const FunctionSymbol& symbol) const;
+
+ private:
+  const absl::flat_hash_map<std::string, std::string>* function_name_to_key_;
+  const absl::flat_hash_set<std::string>* mappable_modules_;
 };
 
-using D3D11DummyFunctionSymbolToKey =
-    DummyFunctionSymbolToKey<orbit_mizar_data_internal::kDirectXToDxvkNames,
-                             orbit_mizar_data_internal::kMappableModules>;
+class D3D11DummyFunctionSymbolToKey : public DummyFunctionSymbolToKey {
+ public:
+  D3D11DummyFunctionSymbolToKey()
+      : DummyFunctionSymbolToKey(kDirectXToDxvkNames, kMappableModules) {}
+
+ private:
+  static const absl::flat_hash_map<std::string, std::string>* kDirectXToDxvkNames;
+  static const absl::flat_hash_set<std::string>* kMappableModules;
+};
 
 }  // namespace orbit_mizar_data
 

--- a/src/MizarData/DummyFunctionSymbolToKey.h
+++ b/src/MizarData/DummyFunctionSymbolToKey.h
@@ -33,7 +33,8 @@ static const auto* kMappableModules = new absl::flat_hash_set<std::string>{"d3d1
 
 namespace orbit_mizar_data {
 
-//
+// If a function comes from `mappableModules`, the key from `functionNameToKey` is returned if
+// present. Defaulting to the function name as the key.
 template <auto& functionNameToKey, auto& mappableModules>
 class DummyFunctionSymbolToKey {
   using FunctionSymbol = ::orbit_mizar_base::FunctionSymbol;

--- a/src/MizarData/DummyFunctionSymbolToKey.h
+++ b/src/MizarData/DummyFunctionSymbolToKey.h
@@ -13,7 +13,7 @@
 #include "MizarBase/FunctionSymbols.h"
 
 namespace orbit_mizar_data_internal {
-static const absl::flat_hash_map<std::string, std::string> kDirectXToDxvkNames = {
+static const auto* kDirectXToDxvkNames = new absl::flat_hash_map<std::string, std::string>{
     {"CContext::TID3D11DeviceContext_ClearRenderTargetView_<1>",
      "dxvk::D3D11DeviceContext::ClearRenderTargetView(ID3D11RenderTargetView*, float const*)"},
     {"CContext::TID3D11DeviceContext_SetShader_<1,0>",
@@ -27,7 +27,7 @@ static const absl::flat_hash_map<std::string, std::string> kDirectXToDxvkNames =
     {"CDXGISwapChain::Present",
      "dxvk::D3D11SwapChain::Present(unsigned int, unsigned int, DXGI_PRESENT_PARAMETERS const*)"}};
 
-static const absl::flat_hash_set<std::string> kMappableModules = {"d3d11", "dxgi"};
+static const auto* kMappableModules = new absl::flat_hash_set<std::string>{"d3d11", "dxgi"};
 
 }  // namespace orbit_mizar_data_internal
 
@@ -40,9 +40,9 @@ class DummyFunctionSymbolToKey {
 
  public:
   [[nodiscard]] std::string GetKey(const FunctionSymbol& symbol) const {
-    if (mappableModules.contains(symbol.module_file_name)) {
-      if (const auto it = functionNameToKey.find(symbol.function_name);
-          it != functionNameToKey.end()) {
+    if (mappableModules->contains(symbol.module_file_name)) {
+      if (const auto it = functionNameToKey->find(symbol.function_name);
+          it != functionNameToKey->end()) {
         return it->second;
       }
     }

--- a/src/MizarData/DummyFunctionSymbolToKey.h
+++ b/src/MizarData/DummyFunctionSymbolToKey.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MIZAR_DATA_DUMMY_FUNCTION_SYMBOL_TO_KEY_H_
+#define MIZAR_DATA_DUMMY_FUNCTION_SYMBOL_TO_KEY_H_
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+
+#include <string>
+
+#include "MizarBase/FunctionSymbols.h"
+
+namespace orbit_mizar_data_internal {
+static const absl::flat_hash_map<std::string, std::string> kDirectXToDxvkNames = {
+    {"CContext::TID3D11DeviceContext_ClearRenderTargetView_<1>",
+     "dxvk::D3D11DeviceContext::ClearRenderTargetView(ID3D11RenderTargetView*, float const*)"},
+    {"CContext::TID3D11DeviceContext_SetShader_<1,0>",
+     "dxvk::D3D11DeviceContext::PSSetShader(ID3D11PixelShader*, ID3D11ClassInstance* const*, "
+     "unsigned int)"},
+    {"CContext::TID3D11DeviceContext_Draw_<9>(ID3D11DeviceContext5 *,unsigned int,unsigned int)",
+     "dxvk::D3D11DeviceContext::Draw(unsigned int, unsigned int)"},
+    {"CContext::TID3D11DeviceContext_SetShader_<1,4>",
+     "dxvk::D3D11DeviceContext::VSSetShader(ID3D11VertexShader*, ID3D11ClassInstance* const*, "
+     "unsigned int)"},
+    {"CDXGISwapChain::Present",
+     "dxvk::D3D11SwapChain::Present(unsigned int, unsigned int, DXGI_PRESENT_PARAMETERS const*)"}};
+
+static const absl::flat_hash_set<std::string> kMappableModules = {"d3d11", "dxgi"};
+
+}  // namespace orbit_mizar_data_internal
+
+namespace orbit_mizar_data {
+
+//
+template <auto& functionNameToKey, auto& mappableModules>
+class DummyFunctionSymbolToKey {
+  using FunctionSymbol = ::orbit_mizar_base::FunctionSymbol;
+
+ public:
+  [[nodiscard]] std::string GetKey(const FunctionSymbol& symbol) const {
+    if (mappableModules.contains(symbol.module_file_name)) {
+      if (const auto it = functionNameToKey.find(symbol.function_name);
+          it != functionNameToKey.end()) {
+        return it->second;
+      }
+    }
+    return symbol.function_name;
+  }
+};
+
+using D3D11DummyFunctionSymbolToKey =
+    DummyFunctionSymbolToKey<orbit_mizar_data_internal::kDirectXToDxvkNames,
+                             orbit_mizar_data_internal::kMappableModules>;
+
+}  // namespace orbit_mizar_data
+
+#endif  // MIZAR_DATA_DUMMY_FUNCTION_SYMBOL_TO_KEY_H_

--- a/src/MizarData/DummyFunctionSymbolToKeyTest.cpp
+++ b/src/MizarData/DummyFunctionSymbolToKeyTest.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "DummyFunctionSymbolToKey.h"
+#include "MizarBase/FunctionSymbols.h"
+
+using ::orbit_mizar_base::FunctionSymbol;
+
+namespace orbit_mizar_data {
+
+const std::string kMappedFunction = "foo";
+const std::string kAnotherMappedFunction = "boo";
+const std::string kNotMappedFunction = "bar";
+
+static const absl::flat_hash_map<std::string, std::string> kNameToKey{
+    {kMappedFunction, "key1"}, {kAnotherMappedFunction, "key2"}};
+
+const std::string kMappableModuleName = "mappable";
+const std::string kNonMappableModuleName = "nonmappable";
+static const absl::flat_hash_set<std::string> kMappableModules = {kMappableModuleName};
+
+using SymbolToKey = DummyFunctionSymbolToKey<kNameToKey, kMappableModules>;
+
+void ExpectCorrectKey(const SymbolToKey& symbol_to_key, const std::string& function_name,
+                      const std::string& module_name) {
+  FunctionSymbol symbol{function_name, module_name};
+  const std::string key = symbol_to_key.GetKey(symbol);
+  if (kMappableModules.contains(module_name) && kNameToKey.contains(function_name)) {
+    EXPECT_EQ(key, kNameToKey.at(function_name));
+  } else {
+    EXPECT_EQ(key, function_name);
+  }
+}
+
+TEST(DummyFunctionSymbolToKey, GetKey) {
+  DummyFunctionSymbolToKey<kNameToKey, kMappableModules> symbol_to_key;
+
+  for (const std::string& function :
+       {kMappedFunction, kAnotherMappedFunction, kNonMappableModuleName}) {
+    for (const std::string& module : {kMappableModuleName, kNonMappableModuleName}) {
+      ExpectCorrectKey(symbol_to_key, function, module);
+    }
+  }
+}
+
+}  // namespace orbit_mizar_data

--- a/src/MizarData/DummyFunctionSymbolToKeyTest.cpp
+++ b/src/MizarData/DummyFunctionSymbolToKeyTest.cpp
@@ -18,12 +18,12 @@ const std::string kMappedFunction = "foo";
 const std::string kAnotherMappedFunction = "boo";
 const std::string kNotMappedFunction = "bar";
 
-static const absl::flat_hash_map<std::string, std::string> kNameToKey{
+static const auto* kNameToKey = new absl::flat_hash_map<std::string, std::string>{
     {kMappedFunction, "key1"}, {kAnotherMappedFunction, "key2"}};
 
 const std::string kMappableModuleName = "mappable";
 const std::string kNonMappableModuleName = "nonmappable";
-static const absl::flat_hash_set<std::string> kMappableModules = {kMappableModuleName};
+static const auto* kMappableModules = new absl::flat_hash_set<std::string>{kMappableModuleName};
 
 using SymbolToKey = DummyFunctionSymbolToKey<kNameToKey, kMappableModules>;
 
@@ -31,8 +31,8 @@ void ExpectCorrectKey(const SymbolToKey& symbol_to_key, const std::string& funct
                       const std::string& module_name) {
   FunctionSymbol symbol{function_name, module_name};
   const std::string key = symbol_to_key.GetKey(symbol);
-  if (kMappableModules.contains(module_name) && kNameToKey.contains(function_name)) {
-    EXPECT_EQ(key, kNameToKey.at(function_name));
+  if (kMappableModules->contains(module_name) && kNameToKey->contains(function_name)) {
+    EXPECT_EQ(key, kNameToKey->at(function_name));
   } else {
     EXPECT_EQ(key, function_name);
   }

--- a/src/MizarData/DummyFunctionSymbolToKeyTest.cpp
+++ b/src/MizarData/DummyFunctionSymbolToKeyTest.cpp
@@ -25,7 +25,10 @@ const std::string kMappableModuleName = "mappable";
 const std::string kNonMappableModuleName = "nonmappable";
 static const auto* kMappableModules = new absl::flat_hash_set<std::string>{kMappableModuleName};
 
-using SymbolToKey = DummyFunctionSymbolToKey<kNameToKey, kMappableModules>;
+class SymbolToKey : public DummyFunctionSymbolToKey {
+ public:
+  SymbolToKey() : DummyFunctionSymbolToKey(kNameToKey, kMappableModules) {}
+};
 
 void ExpectCorrectKey(const SymbolToKey& symbol_to_key, const std::string& function_name,
                       const std::string& module_name) {
@@ -39,7 +42,7 @@ void ExpectCorrectKey(const SymbolToKey& symbol_to_key, const std::string& funct
 }
 
 TEST(DummyFunctionSymbolToKey, GetKey) {
-  DummyFunctionSymbolToKey<kNameToKey, kMappableModules> symbol_to_key;
+  SymbolToKey symbol_to_key;
 
   for (const std::string& function :
        {kMappedFunction, kAnotherMappedFunction, kNonMappableModuleName}) {


### PR DESCRIPTION
It is supposed to help match functions on windows
and linux for the simplest apps.

Test: Unit, Manual
Bug: http://b/248296409