### PR TITLE
Fix Coff file build-id generation

### DIFF
--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -296,7 +296,7 @@ TEST(CoffFile, GetsCorrectBuildIdIfPdbInfoIsPresent) {
   auto coff_file_or_error = CreateCoffFile(file_path);
   ASSERT_THAT(coff_file_or_error, HasNoError());
 
-  EXPECT_EQ("4f9ad6af397f504e88fc34477bd0bae3-1", coff_file_or_error.value()->GetBuildId());
+  EXPECT_EQ("afd69a4f7f394e5088fc34477bd0bae3-1", coff_file_or_error.value()->GetBuildId());
 }
 
 TEST(CoffFile, GetsEmptyBuildIdIfPdbInfoIsNotPresent) {

--- a/src/ObjectUtils/WindowsBuildIdUtils.cpp
+++ b/src/ObjectUtils/WindowsBuildIdUtils.cpp
@@ -12,8 +12,18 @@
 namespace orbit_object_utils {
 
 std::string ComputeWindowsBuildId(std::array<uint8_t, 16> guid, uint32_t age) {
+  // We need to shuffle the first 8 bytes of the guid in order to generate a build id that matches
+  // the one we get from dumpbin.exe. It is also the format expected by the Microsoft Symbol Server.
+  // { b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15 } becomes:
+  // { b3, b2, b1, b0, b5, b4, b7, b6, b8, b9, b10, b11, b12, b13, b14, b15 }.
+  constexpr std::array<uint8_t, 8> kIndices = {3, 2, 1, 0, 5, 4, 7, 6};
+  std::array<uint8_t, 16> shuffled_guid = guid;
+  for (size_t i = 0; i < kIndices.size(); ++i) {
+    shuffled_guid[i] = guid[kIndices[i]];
+  }
+
   std::string build_id;
-  for (const uint8_t& byte : guid) {
+  for (const uint8_t& byte : shuffled_guid) {
     absl::StrAppend(&build_id, absl::Hex(byte, absl::kZeroPad2));
   }
 

--- a/src/ObjectUtils/WindowsBuildIdUtilsTest.cpp
+++ b/src/ObjectUtils/WindowsBuildIdUtilsTest.cpp
@@ -29,12 +29,20 @@ TEST(WindowsBuildIdUtils, ComputeWindowsBuildId) {
   }
 
   {
+    std::array<uint8_t, 16> guid{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    uint32_t age = 0;
+
+    std::string build_id = ComputeWindowsBuildId(guid, age);
+    EXPECT_EQ(build_id, "030201000504070608090a0b0c0d0e0f-0");
+  }
+
+  {
     std::array<uint8_t, 16> guid{85,  187, 209, 238, 5,  74,  79,  231,
                                  234, 236, 207, 134, 88, 181, 143, 196};
     uint32_t age = 65;
 
     std::string build_id = ComputeWindowsBuildId(guid, age);
-    EXPECT_EQ(build_id, "55bbd1ee054a4fe7eaeccf8658b58fc4-65");
+    EXPECT_EQ(build_id, "eed1bb554a05e74feaeccf8658b58fc4-65");
   }
 }
 

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.cpp
@@ -4,6 +4,7 @@
 
 #include "RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h"
 
+#include <absl/strings/str_replace.h>
 #include <absl/strings/substitute.h>
 
 #include "OrbitBase/NotFoundOr.h"
@@ -31,8 +32,10 @@ std::string MicrosoftSymbolServerSymbolProvider::GetDownloadUrl(
     const orbit_symbol_provider::ModuleIdentifier& module_id) {
   constexpr std::string_view kUrlToSymbolServer = "https://msdl.microsoft.com/download/symbols";
   std::filesystem::path module_path(module_id.file_path);
-  return absl::Substitute("$0/$1/$2/$1", kUrlToSymbolServer, module_path.filename().string(),
-                          module_id.build_id);
+  std::filesystem::path symbol_filename = module_path.filename();
+  symbol_filename.replace_extension(".pdb");
+  std::string build_id = absl::StrReplaceAll(module_id.build_id, {{"-", ""}});
+  return absl::Substitute("$0/$1/$2/$1", kUrlToSymbolServer, symbol_filename.string(), build_id);
 }
 
 Future<SymbolLoadingOutcome> MicrosoftSymbolServerSymbolProvider::RetrieveSymbols(

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
@@ -38,8 +38,8 @@ const std::string kValidModuleBuildId{"ABCD12345678"};
 const ModuleIdentifier kValidModuleId{absl::StrFormat("module/path/to/%s", kValidModuleName),
                                       kValidModuleBuildId};
 const std::string kValidModuleDownloadUrl{
-    absl::StrFormat("https://msdl.microsoft.com/download/symbols/%s/%s/%s", kValidModuleName,
-                    kValidModuleBuildId, kValidModuleName)};
+    absl::StrFormat("https://msdl.microsoft.com/download/symbols/%s.pdb/%s/%s.pdb",
+                    kValidModuleName, kValidModuleBuildId, kValidModuleName)};
 
 class MicrosoftSymbolServerSymbolProviderTest : public testing::Test {
  public:
@@ -112,8 +112,8 @@ TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleSuccess) {
 TEST_F(MicrosoftSymbolServerSymbolProviderTest, RetrieveModuleNotFound) {
   const ModuleIdentifier module_id{"module/path/to/some_module_name", "some_build_id"};
   const std::string expected_url{
-      "https://msdl.microsoft.com/download/symbols/some_module_name/some_build_id/"
-      "some_module_name"};
+      "https://msdl.microsoft.com/download/symbols/some_module_name.pdb/some_build_id/"
+      "some_module_name.pdb"};
   SetUpDownloadManager(DownloadResultState::kNotFound, expected_url);
 
   orbit_base::StopSource stop_source{};

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -128,7 +128,7 @@ TEST(SymbolHelper, FindSymbolsFileLocally) {
   const std::string no_symbols_elf_build_id = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
   const fs::path dllmain_dll = testdata_directory / "dllmain.dll";
   const fs::path dllmain_pdb = testdata_directory / "dllmain.pdb";
-  const std::string dllmain_build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+  const std::string dllmain_build_id = "92cdaeef73f74ebbbcf213b84f43b322-3";
 
   SymbolHelper symbol_helper("", {});
 
@@ -272,7 +272,7 @@ TEST(SymbolHelper, FindSymbolsInCache) {
     // Same PDB file (smoke test).
     const fs::path file_name = "dllmain.pdb";
     const auto result =
-        symbol_helper.FindSymbolsInCache(file_name, "efaecd92f773bb4ebcf213b84f43b322-3");
+        symbol_helper.FindSymbolsInCache(file_name, "92cdaeef73f74ebbbcf213b84f43b322-3");
     ASSERT_THAT(result, HasValue());
     EXPECT_THAT(result.value(), testdata_directory / file_name);
   }
@@ -287,7 +287,7 @@ TEST(SymbolHelper, FindSymbolsInCache) {
     // COFF file in cache does not have symbols.
     const fs::path file_name = "dllmain.dll";
     const auto result =
-        symbol_helper.FindSymbolsInCache(file_name, "efaecd92f773bb4ebcf213b84f43b322-3");
+        symbol_helper.FindSymbolsInCache(file_name, "92cdaeef73f74ebbbcf213b84f43b322-3");
     EXPECT_THAT(result, HasError("does not contain symbols"));
   }
   {
@@ -345,7 +345,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     const auto file_size = orbit_base::FileSize(file_path);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindObjectInCache(
-        file_name, "efaecd92f773bb4ebcf213b84f43b322-3", file_size.value());
+        file_name, "92cdaeef73f74ebbbcf213b84f43b322-3", file_size.value());
     ASSERT_THAT(result, HasValue());
     EXPECT_EQ(result.value(), file_path);
   }
@@ -366,7 +366,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     const auto file_size = orbit_base::FileSize(file_path);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindObjectInCache(
-        file_name, "efaecd92f773bb4ebcf213b84f43b322-3", file_size.value() + 1);
+        file_name, "92cdaeef73f74ebbbcf213b84f43b322-3", file_size.value() + 1);
     ASSERT_THAT(result, HasError("File size doesn't match"));
   }
   {
@@ -376,7 +376,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     const auto file_size = orbit_base::FileSize(file_path);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = symbol_helper.FindObjectInCache(
-        file_name, "efaecd92f773bb4ebcf213b84f43b322-3", file_size.value());
+        file_name, "92cdaeef73f74ebbbcf213b84f43b322-3", file_size.value());
     EXPECT_THAT(result, HasError("The file was not recognized as a valid object file"));
   }
   {

--- a/src/Symbols/SymbolUtilsTest.cpp
+++ b/src/Symbols/SymbolUtilsTest.cpp
@@ -84,7 +84,7 @@ TEST(SymbolUtils, VerifySymbolFileByBuildId) {
   {
     // PDB file with symbols and matching build id.
     const std::filesystem::path symbols_file = testdata_directory / "dllmain.pdb";
-    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const std::string build_id = "92cdaeef73f74ebbbcf213b84f43b322-3";
     const auto result = VerifySymbolFile(symbols_file, build_id);
     EXPECT_THAT(result, HasValue());
   }
@@ -98,7 +98,7 @@ TEST(SymbolUtils, VerifySymbolFileByBuildId) {
   {
     // COFF file with matching build id, but no symbols.
     const std::filesystem::path symbols_file = testdata_directory / "dllmain.dll";
-    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const std::string build_id = "92cdaeef73f74ebbbcf213b84f43b322-3";
     const auto result = VerifySymbolFile(symbols_file, build_id);
     EXPECT_THAT(result, HasError("does not contain symbols"));
   }
@@ -172,7 +172,7 @@ TEST(SymbolUtils, VerifyObjectFile) {
   {
     // COFF file with matching build id.
     const std::filesystem::path object_file = testdata_directory / "dllmain.dll";
-    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const std::string build_id = "92cdaeef73f74ebbbcf213b84f43b322-3";
     const auto file_size = orbit_base::FileSize(object_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifyObjectFile(object_file, build_id, file_size.value());
@@ -190,7 +190,7 @@ TEST(SymbolUtils, VerifyObjectFile) {
   {
     // COFF file with mis-matching size.
     const std::filesystem::path object_file = testdata_directory / "dllmain.dll";
-    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const std::string build_id = "92cdaeef73f74ebbbcf213b84f43b322-3";
     const auto file_size = orbit_base::FileSize(object_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifyObjectFile(object_file, build_id, file_size.value() + 1);
@@ -199,7 +199,7 @@ TEST(SymbolUtils, VerifyObjectFile) {
   {
     // PDB file.
     const std::filesystem::path object_file = testdata_directory / "dllmain.pdb";
-    const std::string build_id = "efaecd92f773bb4ebcf213b84f43b322-3";
+    const std::string build_id = "92cdaeef73f74ebbbcf213b84f43b322-3";
     const auto file_size = orbit_base::FileSize(object_file);
     ASSERT_THAT(file_size, HasNoError());
     const auto result = VerifyObjectFile(object_file, build_id, file_size.value());


### PR DESCRIPTION
It seems we need to shuffle the first 8 of the 16 guid bytes we read in Coff files
in order to generate build ids that match those we get from dumpbin.exe and
that are expected to query the Microsoft Symbol Server. Documentation on the
subject seems non-existent, but it is mentioned in the "CodeView" section in
http://www.godevtool.com/Other/pdb.htm.

With the change, we can now retrieve symbols for the Windows libraries and the
build-ids we generate match the ones from dumpbin.exe.