### PR TITLE
Stop thread pool in OrbitApp dtor

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -366,6 +366,7 @@ OrbitApp::OrbitApp(orbit_gl::MainWindowInterface* main_window,
 OrbitApp::~OrbitApp() {
   AbortCapture();
   RequestSymbolDownloadStop(module_manager_->GetAllModuleData(), false);
+  thread_pool_->ShutdownAndWait();
 }
 
 void OrbitApp::OnCaptureFinished(const CaptureFinished& capture_finished) {


### PR DESCRIPTION
This hopefully resolves the crashes where module_data was deleted before use in different threads. It is also a good idea in general.

Bug: http://b/248444825