### PR TITLE
Add a LOG at end of Orbit main()

### DIFF
--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -173,6 +173,7 @@ int RunUiInstance(const DeploymentConfiguration& deployment_configuration,
     ORBIT_UNREACHABLE();
   }
 
+  ORBIT_LOG("End of Orbit main()");
   return 0;
 }
 


### PR DESCRIPTION
This is to better determine whether Orbit crashed when looking at log files.


Good idea or nah?