### PR TITLE
Expose stack dump size for callstacks on thread states

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -56,10 +56,16 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
 
   QObject::connect(ui_->threadStateCheckBox, qOverload<bool>(&QCheckBox::toggled),
                    ui_->threadStateChangeCallstackCollectionCheckBox, &QCheckBox::setEnabled);
+  QObject::connect(ui_->threadStateCheckBox, qOverload<bool>(&QCheckBox::toggled),
+                   ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget, [this](bool checked) {
+                     ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget->setEnabled(
+                         checked && ui_->threadStateChangeCallstackCollectionCheckBox->isChecked());
+                   });
   QObject::connect(ui_->threadStateChangeCallstackCollectionCheckBox,
                    qOverload<bool>(&QCheckBox::toggled),
                    ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget, [this](bool checked) {
-                     ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget->setEnabled(checked);
+                     ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget->setEnabled(
+                         checked && ui_->threadStateCheckBox->isChecked());
                    });
 
   ui_->samplingPeriodMsLabel->setEnabled(ui_->samplingCheckBox->isChecked());
@@ -84,9 +90,10 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
       ui_->threadStateCheckBox->isChecked());
 
   ui_->threadStateChangeCallstackMaxCopyRawStackSizeSpinBox->setValue(
-      kThreadStateChangeCallstackMaxCopyRawStackSizeDefaultValue);
+      kThreadStateChangeMaxCopyRawStackSizeDefaultValue);
   ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget->setEnabled(
-      ui_->threadStateChangeCallstackCollectionCheckBox->isChecked());
+      ui_->threadStateChangeCallstackCollectionCheckBox->isChecked() &&
+      ui_->threadStateCheckBox->isChecked());
 
   if (!absl::GetFlag(FLAGS_auto_frame_track)) {
     ui_->autoFrameTrackGroupBox->hide();

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -56,6 +56,11 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
 
   QObject::connect(ui_->threadStateCheckBox, qOverload<bool>(&QCheckBox::toggled),
                    ui_->threadStateChangeCallstackCollectionCheckBox, &QCheckBox::setEnabled);
+  QObject::connect(ui_->threadStateChangeCallstackCollectionCheckBox,
+                   qOverload<bool>(&QCheckBox::toggled),
+                   ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget, [this](bool checked) {
+                     ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget->setEnabled(checked);
+                   });
 
   ui_->samplingPeriodMsLabel->setEnabled(ui_->samplingCheckBox->isChecked());
   ui_->samplingPeriodMsDoubleSpinBox->setEnabled(ui_->samplingCheckBox->isChecked());
@@ -78,6 +83,11 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   ui_->threadStateChangeCallstackCollectionCheckBox->setEnabled(
       ui_->threadStateCheckBox->isChecked());
 
+  ui_->threadStateChangeCallstackMaxCopyRawStackSizeSpinBox->setValue(
+      kThreadStateChangeCallstackMaxCopyRawStackSizeDefaultValue);
+  ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget->setEnabled(
+      ui_->threadStateChangeCallstackCollectionCheckBox->isChecked());
+
   if (!absl::GetFlag(FLAGS_auto_frame_track)) {
     ui_->autoFrameTrackGroupBox->hide();
   }
@@ -97,6 +107,7 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
 
   if (!absl::GetFlag(FLAGS_tracepoint_callstack_collection)) {
     ui_->threadStateChangeCallstackCollectionCheckBox->hide();
+    ui_->threadStateChangeCallstackMaxCopyRawStackSizeWidget->hide();
   }
 }
 
@@ -146,6 +157,18 @@ void CaptureOptionsDialog::SetMaxCopyRawStackSize(uint16_t stack_dump_size) {
 
 uint16_t CaptureOptionsDialog::GetMaxCopyRawStackSize() const {
   uint16_t result = ui_->maxCopyRawStackSizeSpinBox->value();
+  ORBIT_CHECK(result % 8 == 0);
+  return result;
+}
+
+void CaptureOptionsDialog::SetThreadStateChangeCallstackMaxCopyRawStackSize(
+    uint16_t stack_dump_size) {
+  ORBIT_CHECK(stack_dump_size % 8 == 0);
+  ui_->threadStateChangeCallstackMaxCopyRawStackSizeSpinBox->setValue(stack_dump_size);
+}
+
+uint16_t CaptureOptionsDialog::GetThreadStateChangeCallstackMaxCopyRawStackSize() const {
+  uint16_t result = ui_->threadStateChangeCallstackMaxCopyRawStackSizeSpinBox->value();
   ORBIT_CHECK(result % 8 == 0);
   return result;
 }

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -113,7 +113,7 @@ class CaptureOptionsDialog : public QDialog {
   // `PerfEventOpen.cpp`).
   static constexpr uint16_t kMaxCopyRawStackSizeMaxValue = 65000;
   static constexpr uint16_t kMaxCopyRawStackSizeDefaultValue = 512;
-  static constexpr uint16_t kThreadStateChangeCallstackMaxCopyRawStackSizeDefaultValue = 256;
+  static constexpr uint16_t kThreadStateChangeMaxCopyRawStackSizeDefaultValue = 256;
 
  public slots:
   void ResetLocalMarkerDepthLineEdit();

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -55,6 +55,8 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] orbit_grpc_protos::CaptureOptions::UnwindingMethod GetUnwindingMethod() const;
   void SetMaxCopyRawStackSize(uint16_t stack_dump_size);
   [[nodiscard]] uint16_t GetMaxCopyRawStackSize() const;
+  void SetThreadStateChangeCallstackMaxCopyRawStackSize(uint16_t stack_dump_size);
+  [[nodiscard]] uint16_t GetThreadStateChangeCallstackMaxCopyRawStackSize() const;
   void SetCollectSchedulerInfo(bool collect_scheduler_info);
   [[nodiscard]] bool GetCollectSchedulerInfo() const;
   void SetCollectThreadStates(bool collect_thread_state);
@@ -111,6 +113,7 @@ class CaptureOptionsDialog : public QDialog {
   // `PerfEventOpen.cpp`).
   static constexpr uint16_t kMaxCopyRawStackSizeMaxValue = 65000;
   static constexpr uint16_t kMaxCopyRawStackSizeDefaultValue = 512;
+  static constexpr uint16_t kThreadStateChangeCallstackMaxCopyRawStackSizeDefaultValue = 256;
 
  public slots:
   void ResetLocalMarkerDepthLineEdit();

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -66,7 +66,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-430</y>
+        <y>-351</y>
         <width>502</width>
         <height>1136</height>
        </rect>
@@ -572,7 +572,7 @@ p, li { white-space: pre-wrap; }
              <item>
               <widget class="QLabel" name="threadStateChangeCallstackMaxCopyRawStackSizeLabel">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In order to compute the callstack on thread state changes, we need to copy a portion of the raw stack. Specify how much data Orbit should maximally copy. A smaller value reduces the number of computed call frames, but also reduces the performance overhead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In order to compute the callstack on thread state changes, we need to copy a portion of the raw stack. Specify how much data Orbit should maximally copy. A smaller value reduces the number of computed call frames, but also reduces the performance overhead.&lt;/p&gt;&lt;p&gt;The default value is 256 bytes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
                 <string>Max raw stack size to copy (multiple of 8 Bytes):</string>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -66,9 +66,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-430</y>
         <width>502</width>
-        <height>1098</height>
+        <height>1136</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -544,14 +544,74 @@ p, li { white-space: pre-wrap; }
           <item>
            <widget class="QCheckBox" name="threadStateChangeCallstackCollectionCheckBox">
             <property name="toolTip">
-             <string>This allows capturing call stacks when threads change their states</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This allows capturing callstacks when threads become runnable or stop running.&lt;/p&gt;&lt;p&gt;Collecting callstacks on thread state changes introduces significant performance overhead. Consider reducing the &lt;span style=&quot; font-style:italic;&quot;&gt;raw stack size to copy&lt;/span&gt; below.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
-             <string>Collect call stacks on thread state changes</string>
+             <string>Collect callstacks on thread state changes (expensive) ⓘ</string>
             </property>
             <property name="checked">
              <bool>true</bool>
             </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="threadStateChangeCallstackMaxCopyRawStackSizeWidget" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <property name="leftMargin">
+              <number>20</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="threadStateChangeCallstackMaxCopyRawStackSizeLabel">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In order to compute the callstack on thread state changes, we need to copy a portion of the raw stack. Specify how much data Orbit should maximally copy. A smaller value reduces the number of computed call frames, but also reduces the performance overhead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Max raw stack size to copy (multiple of 8 Bytes):</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="orbit_qt::MultipleOfSpinBox" name="threadStateChangeCallstackMaxCopyRawStackSizeSpinBox">
+               <property name="accessibleName">
+                <string>ThreadStateChangeCallstackMaxCopyRawStackSizeSpinBox</string>
+               </property>
+               <property name="minimum">
+                <number>16</number>
+               </property>
+               <property name="maximum">
+                <number>65528</number>
+               </property>
+               <property name="singleStep">
+                <number>8</number>
+               </property>
+               <property name="value">
+                <number>256</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="threadStateChangeCallstackMaxCopyRawStackSizeHorizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1187,9 +1187,9 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
 
     uint16_t stack_dump_size = static_cast<uint16_t>(
         settings
-            .value(kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey,
-                   orbit_qt::CaptureOptionsDialog::
-                       kThreadStateChangeCallstackMaxCopyRawStackSizeDefaultValue)
+            .value(
+                kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey,
+                orbit_qt::CaptureOptionsDialog::kThreadStateChangeMaxCopyRawStackSizeDefaultValue)
             .toUInt());
     app_->SetThreadStateChangeCallstackStackDumpSize(stack_dump_size);
   } else {
@@ -1351,9 +1351,9 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
 
     dialog.SetThreadStateChangeCallstackMaxCopyRawStackSize(static_cast<uint16_t>(
         settings
-            .value(kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey,
-                   orbit_qt::CaptureOptionsDialog::
-                       kThreadStateChangeCallstackMaxCopyRawStackSizeDefaultValue)
+            .value(
+                kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey,
+                orbit_qt::CaptureOptionsDialog::kThreadStateChangeMaxCopyRawStackSizeDefaultValue)
             .toUInt()));
   }
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1108,6 +1108,8 @@ const QString OrbitMainWindow::kLimitLocalMarkerDepthPerCommandBufferSettingsKey
     "LimitLocalMarkerDepthPerCommandBuffer"};
 const QString OrbitMainWindow::kEnableCallStackCollectionOnThreadStateChanges{
     "EnableCallStackCollectionOnThreadStateChanges"};
+const QString OrbitMainWindow::kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey{
+    "ThreadStateChangeCallstackMaxCopyRawStackSizeSetting"};
 const QString OrbitMainWindow::kMaxLocalMarkerDepthPerCommandBufferSettingsKey{
     "MaxLocalMarkerDepthPerCommandBuffer"};
 const QString OrbitMainWindow::kMainWindowGeometrySettingKey{"MainWindowGeometry"};
@@ -1182,9 +1184,19 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
       app_->SetThreadStateChangeCallstackCollection(
           CaptureOptions::kThreadStateChangeCallStackCollectionUnspecified);
     }
+
+    uint16_t stack_dump_size = static_cast<uint16_t>(
+        settings
+            .value(kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey,
+                   orbit_qt::CaptureOptionsDialog::
+                       kThreadStateChangeCallstackMaxCopyRawStackSizeDefaultValue)
+            .toUInt());
+    app_->SetThreadStateChangeCallstackStackDumpSize(stack_dump_size);
   } else {
     app_->SetThreadStateChangeCallstackCollection(
         CaptureOptions::kThreadStateChangeCallStackCollectionUnspecified);
+
+    app_->SetThreadStateChangeCallstackStackDumpSize(std::numeric_limits<uint16_t>::max());
   }
   DynamicInstrumentationMethod instrumentation_method = static_cast<DynamicInstrumentationMethod>(
       settings
@@ -1325,22 +1337,24 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
                  QVariant::fromValue(orbit_qt::CaptureOptionsDialog::kLocalMarkerDepthDefaultValue))
           .toULongLong());
 
-  CaptureOptions::ThreadStateChangeCallStackCollection collect_callstack_on_thread_state_change =
-      CaptureOptions::kNoThreadStateChangeCallStackCollection;
   if (absl::GetFlag(FLAGS_tracepoint_callstack_collection)) {
-    collect_callstack_on_thread_state_change = static_cast<
-        CaptureOptions::ThreadStateChangeCallStackCollection>(
-        settings
-            .value(
-                kEnableCallStackCollectionOnThreadStateChanges,
-                orbit_qt::CaptureOptionsDialog::kThreadStateChangeCallStackCollectionDefaultValue)
-            .toInt());
-  }
-
-  if (absl::GetFlag(FLAGS_tracepoint_callstack_collection)) {
+    CaptureOptions::ThreadStateChangeCallStackCollection collect_callstack_on_thread_state_change =
+        static_cast<CaptureOptions::ThreadStateChangeCallStackCollection>(
+            settings
+                .value(kEnableCallStackCollectionOnThreadStateChanges,
+                       orbit_qt::CaptureOptionsDialog::
+                           kThreadStateChangeCallStackCollectionDefaultValue)
+                .toInt());
     dialog.SetEnableCallStackCollectionOnThreadStateChanges(
         collect_callstack_on_thread_state_change ==
         CaptureOptions::kThreadStateChangeCallStackCollection);
+
+    dialog.SetThreadStateChangeCallstackMaxCopyRawStackSize(static_cast<uint16_t>(
+        settings
+            .value(kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey,
+                   orbit_qt::CaptureOptionsDialog::
+                       kThreadStateChangeCallstackMaxCopyRawStackSizeDefaultValue)
+            .toUInt()));
   }
 
   int result = dialog.exec();
@@ -1379,6 +1393,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
         static_cast<int>(dialog.GetEnableCallStackCollectionOnThreadStateChanges()
                              ? CaptureOptions::kThreadStateChangeCallStackCollection
                              : CaptureOptions::kNoThreadStateChangeCallStackCollection));
+    settings.setValue(kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey,
+                      static_cast<int>(dialog.GetThreadStateChangeCallstackMaxCopyRawStackSize()));
   }
   LoadCaptureOptionsIntoApp();
 }

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -235,6 +235,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kMemoryWarningThresholdKbSettingKey;
   static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;
   static const QString kEnableCallStackCollectionOnThreadStateChanges;
+  static const QString kThreadStateChangeCallstackMaxCopyRawStackSizeSettingKey;
   static const QString kMaxLocalMarkerDepthPerCommandBufferSettingsKey;
   static const QString kMainWindowGeometrySettingKey;
   static const QString kMainWindowStateSettingKey;


### PR DESCRIPTION
This is adding the capture option to specify the stack dump size for thread state changes callstacks.

It is still behind a flag.

Screenshot of dialogue:
http://screenshot/3BmDnyabQfnQHSy

Screenshot of tooltip for thread stack callstacks: http://screenshot/8ueTtDkFnMePnvu

Screenshot of tooltip for max stack dump size:
http://screenshot/9x7SCKJxDtNCLnz

Test: Set/Unset and close/reopen orbit. Take a capture
Bug: http://b/243510345