### PR TITLE
Move `SamplingWithFrameTrackReportModel` to `orbit_mizar_models`

### DIFF
--- a/src/MizarModels/SamplingWithFrameTrackReportModelTest.cpp
+++ b/src/MizarModels/SamplingWithFrameTrackReportModelTest.cpp
@@ -65,7 +65,7 @@ class MockFrameTrackStats {
 
 }  // namespace
 
-namespace orbit_mizar_widgets {
+namespace orbit_mizar_models {
 
 constexpr size_t kFunctionCount = 4;
 constexpr std::array<SFID, kFunctionCount> kSfids = {SFID(1), SFID(2), SFID(3), SFID(4)};
@@ -340,4 +340,4 @@ TEST_F(SamplingWithFrameTrackReportModelTest, PvalueAndIsSignificantAreCorrect) 
                                          /*significance_level=*/0.01);
 }
 
-}  // namespace orbit_mizar_widgets
+}  // namespace orbit_mizar_models

--- a/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
+++ b/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef MIZAR_WIDGETS_SAMPLING_WITH_FRAME_TRACK_REPORT_MODEL_H_
-#define MIZAR_WIDGETS_SAMPLING_WITH_FRAME_TRACK_REPORT_MODEL_H_
+#ifndef MIZAR_MODELS_SAMPLING_WITH_FRAME_TRACK_REPORT_MODEL_H_
+#define MIZAR_MODELS_SAMPLING_WITH_FRAME_TRACK_REPORT_MODEL_H_
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/strings/str_format.h>
@@ -21,7 +21,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Typedef.h"
 
-namespace orbit_mizar_widgets {
+namespace orbit_mizar_models {
 
 // The class implements the model for the instance of `QTableView` owned by
 // `SamplingWithFrameTrackOutputWidget`. It represents the results of comparison based on sampling
@@ -383,6 +383,6 @@ using SamplingWithFrameTrackReportModel =
                                           orbit_mizar_data::SamplingCounts,
                                           orbit_client_data::ScopeStats>;
 
-}  // namespace orbit_mizar_widgets
+}  // namespace orbit_mizar_models
 
-#endif  // MIZAR_WIDGETS_SAMPLING_WITH_FRAME_TRACK_REPORT_MODEL_H_
+#endif  // MIZAR_MODELS_SAMPLING_WITH_FRAME_TRACK_REPORT_MODEL_H_

--- a/src/MizarWidgets/SamplingWithFrameTrackWidget.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackWidget.cpp
@@ -27,7 +27,7 @@ using Report = ::orbit_mizar_data::SamplingWithFrameTrackComparisonReport;
 using ::orbit_mizar_base::kBaselineTitle;
 using ::orbit_mizar_base::kComparisonTitle;
 using FunctionNameToShow =
-    ::orbit_mizar_widgets::SamplingWithFrameTrackReportModel::FunctionNameToShow;
+    ::orbit_mizar_models::SamplingWithFrameTrackReportModel::FunctionNameToShow;
 
 Q_DECLARE_METATYPE(FunctionNameToShow);
 

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackOutputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackOutputWidget.h
@@ -25,7 +25,9 @@ class SamplingWithFrameTrackOutputWidget : public QWidget {
   using Baseline = ::orbit_mizar_base::Baseline<T>;
   template <typename T>
   using Comparison = ::orbit_mizar_base::Comparison<T>;
-  using FunctionNameToShow = SamplingWithFrameTrackReportModel::FunctionNameToShow;
+  using SamplingWithFrameTrackReportModel = ::orbit_mizar_models::SamplingWithFrameTrackReportModel;
+  using FunctionNameToShow =
+      ::orbit_mizar_models::SamplingWithFrameTrackReportModel::FunctionNameToShow;
 
  public:
   explicit SamplingWithFrameTrackOutputWidget(QWidget* parent = nullptr);


### PR DESCRIPTION
When it has been moved from MizarWidgets module, the namespace has not been corrected.

Test: Compile
Bug: http://b/247524447