### PR TITLE
Integrate symbol loading fallback into symbol loading logic in OrbitApp

### DIFF
--- a/src/DataViews/include/DataViews/SymbolLoadingState.h
+++ b/src/DataViews/include/DataViews/SymbolLoadingState.h
@@ -56,10 +56,13 @@ struct SymbolLoadingState {
       case kLoaded:
         return "Debug symbols for this module have been loaded successfully.";
       case kFallback:
-        return "No debug symbols could be found for this module. Nonetheless, some substitute "
-               "information could still be extracted from the module itself, namely from symbols "
-               "for dynamic linking and/or from stack unwinding information. Note that this "
-               "information might be inaccurate.";
+        return "No debug symbols could be found for this module.\n"
+               "Nonetheless, some substitute information could still be extracted from the module "
+               "itself,\n"
+               "namely from symbols for dynamic linking and/or from stack unwinding "
+               "information.\n"
+               "\n"
+               "Note that this information might be inaccurate.";
     }
     ORBIT_UNREACHABLE();
   }

--- a/src/ObjectUtils/ObjectFile.cpp
+++ b/src/ObjectUtils/ObjectFile.cpp
@@ -31,7 +31,8 @@ ErrorMessageOr<std::unique_ptr<ObjectFile>> CreateObjectFile(
       llvm::object::ObjectFile::createObjectFile(file_path_llvm);
 
   if (!object_file_or_error) {
-    return ErrorMessage(absl::StrFormat("Unable to load object file \"%s\": %s", file_path.string(),
+    return ErrorMessage(absl::StrFormat("Unable to load object file \"%s\": %s.",
+                                        file_path.string(),
                                         llvm::toString(object_file_or_error.takeError())));
   }
 

--- a/src/ObjectUtils/PdbFileLlvm.cpp
+++ b/src/ObjectUtils/PdbFileLlvm.cpp
@@ -415,15 +415,15 @@ ErrorMessageOr<std::unique_ptr<PdbFile>> PdbFileLlvm::CreatePdbFile(
   llvm::Error error =
       llvm::pdb::loadDataForPDB(llvm::pdb::PDB_ReaderType::Native, pdb_path, session);
   if (error) {
-    return ErrorMessage(absl::StrFormat("Unable to load PDB file %s with error: %s",
-                                        file_path.string(), llvm::toString(std::move(error))));
+    return ErrorMessage(absl::StrFormat("Unable to load PDB file \"%s\": %s", file_path.string(),
+                                        llvm::toString(std::move(error))));
   }
 
   // We need the debug info stream to retrieve the correct age information (which is used in the
   // build-id). See: https://github.com/llvm/llvm-project/issues/57300
   if (!PdbHasDbiStream(session.get())) {
-    return ErrorMessage(
-        absl::StrFormat("Unable to load PDB file %s: PDB has no Dbi Stream", file_path.string()));
+    return ErrorMessage(absl::StrFormat("Unable to load PDB file \"%s\": PDB has no Dbi Stream.",
+                                        file_path.string()));
   }
 
   return absl::WrapUnique<PdbFileLlvm>(

--- a/src/ObjectUtils/SymbolsFile.cpp
+++ b/src/ObjectUtils/SymbolsFile.cpp
@@ -22,12 +22,12 @@ ErrorMessageOr<std::unique_ptr<SymbolsFile>> CreateSymbolsFile(
     const std::filesystem::path& file_path, const ObjectFileInfo& object_file_info) {
   ORBIT_SCOPE_FUNCTION;
   std::string error_message{
-      absl::StrFormat("Unable to create symbols file from \"%s\":", file_path.string())};
+      absl::StrFormat("Unable to create symbols file from \"%s\": ", file_path.string())};
 
   OUTCOME_TRY(auto file_exists, orbit_base::FileOrDirectoryExists(file_path));
 
   if (!file_exists) {
-    error_message.append("\n* File does not exist.");
+    error_message.append("File does not exist.");
     return ErrorMessage{error_message};
   }
 
@@ -36,11 +36,11 @@ ErrorMessageOr<std::unique_ptr<SymbolsFile>> CreateSymbolsFile(
     if (object_file_or_error.value()->HasDebugSymbols()) {
       return std::move(object_file_or_error.value());
     }
-    error_message.append("\n* File does not contain symbols.");
+    error_message.append("File does not contain symbols.");
     return ErrorMessage{error_message};
   }
 
-  error_message.append(absl::StrFormat("\n* File cannot be read as an object file: %s",
+  error_message.append(absl::StrFormat("File cannot be read as an object file: %s",
                                        object_file_or_error.error().message()));
 
   ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_or_error =
@@ -48,7 +48,7 @@ ErrorMessageOr<std::unique_ptr<SymbolsFile>> CreateSymbolsFile(
 
   if (pdb_file_or_error.has_value()) return std::move(pdb_file_or_error.value());
 
-  error_message.append(absl::StrFormat("\n* File cannot be read as a PDB file: %s",
+  error_message.append(absl::StrFormat(" File also cannot be read as a PDB file: %s",
                                        pdb_file_or_error.error().message()));
 
   return ErrorMessage{error_message};

--- a/src/ObjectUtils/SymbolsFileTest.cpp
+++ b/src/ObjectUtils/SymbolsFileTest.cpp
@@ -58,7 +58,7 @@ TEST(SymbolsFile, FailToCreateSymbolsFile) {
   auto text_file = CreateSymbolsFile(path_to_text_file, ObjectFileInfo{0x10000});
   EXPECT_THAT(text_file, HasError("Unable to create symbols file"));
   EXPECT_THAT(text_file, HasError("File cannot be read as an object file"));
-  EXPECT_THAT(text_file, HasError("File cannot be read as a PDB file"));
+  EXPECT_THAT(text_file, HasError("File also cannot be read as a PDB file"));
 
   const std::filesystem::path invalid_path = orbit_test::GetTestdataDir() / "non_existing_file";
   auto invalid_file = CreateSymbolsFile(invalid_path, ObjectFileInfo{0x10000});

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -203,7 +203,7 @@ elseif(TARGET OpenGL::GL)
 endif()
 
 if(WIN32)
-  target_compile_options(OrbitGl PRIVATE "$<$<CONFIG:Debug>:/bigobj>")
+  target_compile_options(OrbitGl PRIVATE /bigobj)
 endif()
 
 

--- a/src/ProcessService/ProcessServiceUtils.cpp
+++ b/src/ProcessService/ProcessServiceUtils.cpp
@@ -334,10 +334,10 @@ ErrorMessageOr<orbit_base::NotFoundOr<fs::path>> FindSymbolsFilePath(
   }
 
   std::string not_found_message_for_client{absl::StrFormat(
-      "Unable to find debug symbols on the instance for module \"%s\".", module_path)};
+      "Unable to find debug symbols on the instance for module \"%s\"", module_path)};
   if (!not_found_messages.empty()) {
-    absl::StrAppend(&not_found_message_for_client, "\nDetails:\n* ",
-                    absl::StrJoin(not_found_messages, "\n* "));
+    absl::StrAppend(&not_found_message_for_client, ":\n  * ",
+                    absl::StrJoin(not_found_messages, "\n  * "));
   }
   return orbit_base::NotFound{not_found_message_for_client};
 }

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -255,6 +255,12 @@ TEST(SymbolHelper, FindSymbolsInCacheBySize) {
     const auto result = symbol_helper.FindSymbolsInCache(file_name, file_size.value() + 1);
     EXPECT_THAT(result, HasError("File size doesn't match"));
   }
+  {
+    // File doesn't exist.
+    const fs::path file_name = "non-existing_file";
+    const auto result = symbol_helper.FindSymbolsInCache(file_name, 42);
+    EXPECT_THAT(result, HasError("Unable to find symbols in cache"));
+  }
 }
 
 TEST(SymbolHelper, FindSymbolsInCache) {
@@ -301,6 +307,12 @@ TEST(SymbolHelper, FindSymbolsInCache) {
     const fs::path file_name = "dllmain.pdb";
     const auto result = symbol_helper.FindSymbolsInCache(file_name, "non matching build id");
     EXPECT_THAT(result, HasError("has a different build id"));
+  }
+  {
+    // File doesn't exist.
+    const fs::path file_name = "non-existing_file";
+    const auto result = symbol_helper.FindSymbolsInCache(file_name, "unimportant build id");
+    EXPECT_THAT(result, HasError("Unable to find symbols in cache"));
   }
 }
 
@@ -386,7 +398,7 @@ TEST(SymbolHelper, FindObjectInCache) {
     const auto file_size = orbit_base::FileSize(file_path);
     ASSERT_THAT(file_size, HasError(""));
     const auto result = symbol_helper.FindObjectInCache(file_name, "unimportant build id", 42);
-    EXPECT_THAT(result, HasError("Unable to find"));
+    EXPECT_THAT(result, HasError("Unable to find object file in cache"));
   }
 }
 

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -60,7 +60,8 @@ class SymbolHelper : public SymbolCacheInterface {
  private:
   template <typename Verifier>
   ErrorMessageOr<std::filesystem::path> FindSymbolsInCacheImpl(
-      const std::filesystem::path& module_path, Verifier&& verify) const;
+      const std::filesystem::path& module_path, std::string_view searchee_for_error_message,
+      Verifier&& verify) const;
 
   const std::filesystem::path cache_directory_;
   // TODO(b/246743231): Move this out of SymbolHelper in a next refactoring step.

--- a/src/WindowsUtils/FindDebugSymbols.cpp
+++ b/src/WindowsUtils/FindDebugSymbols.cpp
@@ -114,8 +114,7 @@ ErrorMessageOr<std::filesystem::path> FindDebugSymbols(
   std::string error_message_for_client{absl::StrFormat(
       "Unable to find debug symbols on the instance for module \"%s\".", module_path.string())};
   if (!error_messages.empty()) {
-    absl::StrAppend(&error_message_for_client, "\nDetails:\n* ",
-                    absl::StrJoin(error_messages, "\n* "));
+    absl::StrAppend(&error_message_for_client, ":\n  * ", absl::StrJoin(error_messages, "\n  * "));
   }
 
   return ErrorMessage(error_message_for_client);


### PR DESCRIPTION
Primarily, it adds the fallback logic to
`OrbitApp::RetrieveModuleAndLoadSymbols`.
This makes use of the two new `RetrieveModuleSymbolsAndLoadSymbols` and
`RetrieveModuleItselfAndLoadFallbackSymbols`.
And in turns, `RetrieveModuleItselfAndLoadFallbackSymbols` calls the two new
`RetrieveModuleItself` (which also uses `RetrieveModuleItselfFromInstance`) and
`AddFallbackSymbols`..

The formatting of some error messages is improved, in particular nested indented
ones.

Some method declarations are shuffled around in `App.h` for better grouping of
related ones. Also, `RetrieveModule` is renamed to `RetrieveModuleSymbols`.

Finally, `/bigobj` is enabled also for non-debug builds as `App.cpp` got even
larger.

Bug: http://b/245680119

Test: Manual testing with automatic symbol loading and manual reloading in
on modules with various symbol availability and on various scenarios of
connection to the instance.