### PR TITLE
[Draft] Fix manual instrumentation in the context of pid namespaces.

### DIFF
--- a/src/ApiUtils/Event.cpp
+++ b/src/ApiUtils/Event.cpp
@@ -178,4 +178,78 @@ void FillProducerCaptureEventFromApiEvent(
   ORBIT_UNREACHABLE();
 }
 
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiScopeStart& scope_start, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_scope_start();
+  scope_start.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiScopeStop& scope_stop, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_scope_stop();
+  scope_stop.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiScopeStartAsync& scope_start_async,
+    orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_scope_start_async();
+  scope_start_async.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiScopeStopAsync& scope_stop_async,
+    orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_scope_stop_async();
+  scope_stop_async.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiStringEvent& string_event, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_string_event();
+  string_event.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackDouble& track_double, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_track_double();
+  track_double.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackFloat& track_float, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_track_float();
+  track_float.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackInt& track_int, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_track_int();
+  track_int.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackInt64& track_int64, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_track_int64();
+  track_int64.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackUint& track_uint, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_track_uint();
+  track_uint.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackUint64& track_uint64, orbit_grpc_protos::ProducerCaptureEvent* capture_event) {
+  auto* api_event = capture_event->mutable_introspection_api_track_uint64();
+  track_uint64.CopyToGrpcProto(api_event);
+}
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const std::monostate& /*monostate*/,
+    orbit_grpc_protos::ProducerCaptureEvent* /*capture_event*/) {
+  ORBIT_UNREACHABLE();
+}
+
 }  // namespace orbit_api

--- a/src/ApiUtils/include/ApiUtils/Event.h
+++ b/src/ApiUtils/include/ApiUtils/Event.h
@@ -244,6 +244,47 @@ void FillProducerCaptureEventFromApiEvent(
     const std::monostate& /*monostate*/,
     orbit_grpc_protos::ProducerCaptureEvent* /*capture_event*/);
 
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiScopeStart& scope_start, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiScopeStop& scope_stop, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiScopeStartAsync& scope_start_async,
+    orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiScopeStopAsync& scope_stop_async,
+    orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiStringEvent& string_event, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackDouble& track_double, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackFloat& track_float, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackInt& track_int, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackInt64& track_int64, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackUint& track_uint, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const ApiTrackUint64& track_uint64, orbit_grpc_protos::ProducerCaptureEvent* capture_event);
+
+// The variant type `ApiEventVariant` requires to contain `std::monostate` in order to be default-
+// constructable. However, that state is never expected to be called in the visitor.
+void FillIntrospectionProducerCaptureEventFromApiEvent(
+    const std::monostate& /*monostate*/,
+    orbit_grpc_protos::ProducerCaptureEvent* /*capture_event*/);
+
 }  // namespace orbit_api
 
 #endif  // ORBIT_API_UTILS_EVENT_H_

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -857,6 +857,17 @@ message OutOfOrderEventsDiscardedEvent {
   uint64 end_timestamp_ns = 2;
 }
 
+message TidNamespaceMapping {
+  uint32 tid_in_target_process_namespace = 1;
+  uint32 tid_in_root_namespace = 2;
+}
+
+message TidNamespaceMappingSnapshot {
+  uint64 timestamp_ns = 1;
+  uint32 pid_in_root_namespace = 2;
+  repeated TidNamespaceMapping tid_namespace_mappings = 3;
+}
+
 message ClientCaptureEvent {
   reserved 20, 23, 28, 29, 30;
 
@@ -928,7 +939,7 @@ message ProducerCaptureEvent {
     // numbers starting with 16.
     //
     // Next high-frequency ID: 15.
-    // Next lower-frequency ID: 51
+    // Next lower-frequency ID: 64
     //
     // Please keep these alphabetically ordered.
     ApiEvent api_event = 10;
@@ -965,6 +976,17 @@ message ProducerCaptureEvent {
     GpuQueueSubmission gpu_queue_submission = 6;
     InternedCallstack interned_callstack = 7;
     InternedString interned_string = 18;
+    ApiScopeStart introspection_api_scope_start = 53;
+    ApiScopeStartAsync introspection_api_scope_start_async = 54;
+    ApiScopeStop introspection_api_scope_stop = 55;
+    ApiScopeStopAsync introspection_api_scope_stop_async = 56;
+    ApiStringEvent introspection_api_string_event = 57;
+    ApiTrackDouble introspection_api_track_double = 58;
+    ApiTrackFloat introspection_api_track_float = 59;
+    ApiTrackInt introspection_api_track_int = 60;
+    ApiTrackInt64 introspection_api_track_int64 = 61;
+    ApiTrackUint introspection_api_track_uint = 62;
+    ApiTrackUint64 introspection_api_track_uint64 = 63;
     LostPerfRecordsEvent lost_perf_records_event = 34;
     MemoryUsageEvent memory_usage_event = 29;
     ModulesSnapshot modules_snapshot = 25;
@@ -976,6 +998,8 @@ message ProducerCaptureEvent {
     ThreadNamesSnapshot thread_names_snapshot = 24;
     ThreadStateSlice thread_state_slice = 9;
     ThreadStateSliceCallstack thread_state_slice_callstack = 50;
+    TidNamespaceMapping tid_namespace_mapping = 51;
+    TidNamespaceMappingSnapshot tid_namespace_mapping_snapshot = 52;
     WarningEvent warning_event = 30;
     WarningInstrumentingWithUprobesEvent
         warning_instrumenting_with_uprobes_event = 49;

--- a/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
@@ -84,7 +84,8 @@ CreateIntrospectionListener(ProducerEventProcessor* producer_event_processor) {
         ProducerCaptureEvent capture_event;
         std::visit(
             [&capture_event](const auto& api_event) {
-              orbit_api::FillProducerCaptureEventFromApiEvent(api_event, &capture_event);
+              orbit_api::FillIntrospectionProducerCaptureEventFromApiEvent(api_event,
+                                                                           &capture_event);
             },
             api_event_variant);
         producer_event_processor->ProcessEvent(orbit_grpc_protos::kIntrospectionProducerId,

--- a/src/LinuxCaptureService/TracingHandler.cpp
+++ b/src/LinuxCaptureService/TracingHandler.cpp
@@ -151,4 +151,18 @@ void TracingHandler::OnWarningInstrumentingWithUprobesEvent(
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
+void TracingHandler::OnTidNamespaceMapping(
+    orbit_grpc_protos::TidNamespaceMapping tid_namespace_mapping) {
+  orbit_grpc_protos::ProducerCaptureEvent event;
+  *event.mutable_tid_namespace_mapping() = std::move(tid_namespace_mapping);
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
+}
+
+void TracingHandler::OnTidNamespaceMappingSnapshot(
+    orbit_grpc_protos::TidNamespaceMappingSnapshot tid_namespace_mapping_snapshot) {
+  orbit_grpc_protos::ProducerCaptureEvent event;
+  *event.mutable_tid_namespace_mapping_snapshot() = std::move(tid_namespace_mapping_snapshot);
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
+}
+
 }  // namespace orbit_linux_capture_service

--- a/src/LinuxCaptureService/TracingHandler.h
+++ b/src/LinuxCaptureService/TracingHandler.h
@@ -65,6 +65,10 @@ class TracingHandler : public orbit_linux_tracing::TracerListener {
   void OnWarningInstrumentingWithUprobesEvent(
       orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
           warning_instrumenting_with_uprobes_event) override;
+  virtual void OnTidNamespaceMapping(
+      orbit_grpc_protos::TidNamespaceMapping tid_namespace_mapping) override;
+  virtual void OnTidNamespaceMappingSnapshot(
+      orbit_grpc_protos::TidNamespaceMappingSnapshot tid_namespace_mapping_snapshot) override;
 
   void ProcessFunctionEntry(const orbit_grpc_protos::FunctionEntry& function_entry) {
     tracer_->ProcessFunctionEntry(function_entry);

--- a/src/LinuxTracing/MockTracerListener.h
+++ b/src/LinuxTracing/MockTracerListener.h
@@ -31,6 +31,9 @@ class MockTracerListener : public TracerListener {
               (orbit_grpc_protos::OutOfOrderEventsDiscardedEvent), (override));
   MOCK_METHOD(void, OnWarningInstrumentingWithUprobesEvent,
               (orbit_grpc_protos::WarningInstrumentingWithUprobesEvent), (override));
+  MOCK_METHOD(void, OnTidNamespaceMapping, (orbit_grpc_protos::TidNamespaceMapping), (override));
+  MOCK_METHOD(void, OnTidNamespaceMappingSnapshot, (orbit_grpc_protos::TidNamespaceMappingSnapshot),
+              (override));
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -35,6 +35,10 @@ class TracerListener {
   virtual void OnWarningInstrumentingWithUprobesEvent(
       orbit_grpc_protos::WarningInstrumentingWithUprobesEvent
           warning_instrumenting_with_uprobes_event) = 0;
+  virtual void OnTidNamespaceMapping(
+      orbit_grpc_protos::TidNamespaceMapping tid_namespace_mapping) = 0;
+  virtual void OnTidNamespaceMappingSnapshot(
+      orbit_grpc_protos::TidNamespaceMappingSnapshot tid_namespace_mapping_snapshot) = 0;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
@@ -1936,20 +1936,43 @@ TEST(ProducerEventProcessor, ApiScopeStart) {
   api_scope_start->set_encoded_name_7(kEncodedName7);
   api_scope_start->set_encoded_name_8(kEncodedName8);
   api_scope_start->add_encoded_name_additional(kEncodedNameAdditional1);
-
-  ApiScopeStart api_scope_start_copy = *api_scope_start;
+  ProducerCaptureEvent producer_capture_event_introspection;
+  *producer_capture_event_introspection.mutable_introspection_api_scope_start() = *api_scope_start;
+  const ApiScopeStart api_scope_start_copy = *api_scope_start;
 
   MockClientCaptureEventCollector collector;
   auto producer_event_processor = ProducerEventProcessor::Create(&collector);
   SetTidNamespaceMappingSnapshotInProducerEventProcessor(producer_event_processor.get(),
-                                                         {{kPid1, kPid1}, {kTid1, kTid1}});
+                                                         {{kPid1, kPid2}, {kTid1, kTid2}});
   ClientCaptureEvent client_capture_event;
   EXPECT_CALL(collector, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
 
   producer_event_processor->ProcessEvent(kDefaultProducerId, std::move(producer_capture_event));
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStart);
   const ApiScopeStart& actual_event = client_capture_event.api_scope_start();
-  EXPECT_TRUE(MessageDifferencer::Equivalent(api_scope_start_copy, actual_event));
+  EXPECT_EQ(kPid2, actual_event.pid());
+  EXPECT_EQ(kTid2, actual_event.tid());
+  EXPECT_EQ(kTimestampNs1, actual_event.timestamp_ns());
+  EXPECT_EQ(kColor1, actual_event.color_rgba());
+  EXPECT_EQ(kGroupId1, actual_event.group_id());
+  EXPECT_EQ(kEncodedName1, actual_event.encoded_name_1());
+  EXPECT_EQ(kEncodedName2, actual_event.encoded_name_2());
+  EXPECT_EQ(kEncodedName3, actual_event.encoded_name_3());
+  EXPECT_EQ(kEncodedName4, actual_event.encoded_name_4());
+  EXPECT_EQ(kEncodedName5, actual_event.encoded_name_5());
+  EXPECT_EQ(kEncodedName6, actual_event.encoded_name_6());
+  EXPECT_EQ(kEncodedName7, actual_event.encoded_name_7());
+  EXPECT_EQ(kEncodedName8, actual_event.encoded_name_8());
+  EXPECT_EQ(kEncodedNameAdditional1, actual_event.encoded_name_additional());
+  testing::Mock::VerifyAndClearExpectations(&collector);
+
+  EXPECT_CALL(collector, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+  producer_event_processor->ProcessEvent(kDefaultProducerId,
+                                         std::move(producer_capture_event_introspection));
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStart);
+  const ApiScopeStart& actual_event_introspection = client_capture_event.api_scope_start();
+  testing::Mock::VerifyAndClearExpectations(&collector);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_scope_start_copy, actual_event_introspection));
 }
 
 TEST(ProducerEventProcessor, ApiScopeStop) {
@@ -1958,19 +1981,31 @@ TEST(ProducerEventProcessor, ApiScopeStop) {
   api_scope_stop->set_pid(kPid1);
   api_scope_stop->set_tid(kTid1);
   api_scope_stop->set_timestamp_ns(kTimestampNs1);
-  ApiScopeStop api_scope_stop_copy = *api_scope_stop;
+  ProducerCaptureEvent producer_capture_event_introspection;
+  *producer_capture_event_introspection.mutable_introspection_api_scope_stop() = *api_scope_stop;
+  const ApiScopeStop api_scope_stop_copy = *api_scope_stop;
 
   MockClientCaptureEventCollector collector;
   auto producer_event_processor = ProducerEventProcessor::Create(&collector);
   SetTidNamespaceMappingSnapshotInProducerEventProcessor(producer_event_processor.get(),
-                                                         {{kPid1, kPid1}, {kTid1, kTid1}});
+                                                         {{kPid1, kPid2}, {kTid1, kTid2}});
   ClientCaptureEvent client_capture_event;
   EXPECT_CALL(collector, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
 
   producer_event_processor->ProcessEvent(kDefaultProducerId, std::move(producer_capture_event));
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStop);
   const ApiScopeStop& actual_event = client_capture_event.api_scope_stop();
-  EXPECT_TRUE(MessageDifferencer::Equivalent(api_scope_stop_copy, actual_event));
+  EXPECT_EQ(kPid2, actual_event.pid());
+  EXPECT_EQ(kTid2, actual_event.tid());
+  EXPECT_EQ(kTimestampNs1, actual_event.timestamp_ns());
+  testing::Mock::VerifyAndClearExpectations(&collector);
+
+  EXPECT_CALL(collector, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+  producer_event_processor->ProcessEvent(kDefaultProducerId,
+                                         std::move(producer_capture_event_introspection));
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStop);
+  const ApiScopeStop& actual_event_introspection = client_capture_event.api_scope_stop();
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_scope_stop_copy, actual_event_introspection));
 }
 
 TEST(ProducerEventProcessor, ApiScopeStartAsync) {


### PR DESCRIPTION
Previously pids/tids from events obtained from our manual instrumentation api contained the pid/tid form the namespace in which the target process is running.
With this PR we translate these pids/tids into the root namespace before sending them to the client.

This requires a knowledge of the tid mapping in ProducerEventProcessor. At the beginning of the capture a snapshot containing the data for all existing threads is send. During the capture the mapping is updated as threads are created.

Since the arrivial of manual instrumentation events and the update of the tid mapping are asyncronous we need to buffer manual instrumentation events that are not (yet) translatable. As threads become known to the tid mapping we clear out the buffers. The order of manual instrumentation events from a specific thread is unchanged.

Finally, the introspection events need to bypass the above mechanism: the tids from the root namespace.