### PR TITLE
Remove uses of CaptureData::instrumented_functions

### DIFF
--- a/src/ClientData/ModuleAndFunctionLookup.cpp
+++ b/src/ClientData/ModuleAndFunctionLookup.cpp
@@ -158,15 +158,4 @@ const FunctionInfo* FindFunctionByAddress(const ProcessData& process,
                                                                     absolute_address);
 }
 
-std::optional<uint64_t> FindInstrumentedFunctionIdSlow(const CaptureData& capture_data,
-                                                       const FunctionInfo& function_info) {
-  for (const auto& [function_id, candidate_function] : capture_data.instrumented_functions()) {
-    if (candidate_function.file_path() == function_info.module_path() &&
-        candidate_function.function_virtual_address() == function_info.address()) {
-      return function_id;
-    }
-  }
-  return std::nullopt;
-}
-
 }  // namespace orbit_client_data

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -159,4 +159,15 @@ void NameEqualityScopeIdProvider::UpdateFunctionInfoAddress(
   }
 }
 
+std::optional<uint64_t> NameEqualityScopeIdProvider::FindFunctionIdSlow(
+    const FunctionInfo& function_info) const {
+  for (const auto& [scope_id, candidate_function] : scope_id_to_function_info_) {
+    if (candidate_function.module_path() == function_info.module_path() &&
+        candidate_function.address() == function_info.address()) {
+      return ScopeIdToFunctionId(scope_id);
+    }
+  }
+  return std::nullopt;
+}
+
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -64,11 +64,6 @@ class CaptureData {
   [[nodiscard]] const orbit_client_data::ProcessData* process() const { return &process_; }
   [[nodiscard]] orbit_client_data::ProcessData* mutable_process() { return &process_; }
 
-  [[nodiscard]] const absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction>&
-  instrumented_functions() const {
-    return instrumented_functions_;
-  }
-
   [[nodiscard]] uint64_t GetMemorySamplingPeriodNs() const {
     return capture_started_.capture_options().memory_sampling_period_ns();
   }
@@ -79,8 +74,8 @@ class CaptureData {
     memory_warning_threshold_kb_ = memory_warning_threshold_kb;
   }
 
-  [[nodiscard]] const orbit_grpc_protos::InstrumentedFunction* GetInstrumentedFunctionById(
-      uint64_t function_id) const;
+  [[nodiscard]] const FunctionInfo* GetFunctionInfoById(uint64_t function_id) const;
+  [[nodiscard]] std::optional<uint64_t> FindFunctionIdSlow(const FunctionInfo& function_info) const;
 
   const FunctionInfo* GetFunctionInfoByScopeId(ScopeId scope_id) const;
 

--- a/src/ClientData/include/ClientData/MockScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/MockScopeIdProvider.h
@@ -25,6 +25,8 @@ class MockScopeIdProvider : public ScopeIdProvider {
   MOCK_METHOD(const FunctionInfo*, GetFunctionInfo, (ScopeId), (const, override));
   MOCK_METHOD(void, UpdateFunctionInfoAddress, (orbit_grpc_protos::InstrumentedFunction),
               (override));
+  MOCK_METHOD(std::optional<uint64_t>, FindFunctionIdSlow, (const FunctionInfo&),
+              (const, override));
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/ModuleAndFunctionLookup.h
+++ b/src/ClientData/include/ClientData/ModuleAndFunctionLookup.h
@@ -42,9 +42,6 @@ FindModulePathAndBuildIdByAddress(const ModuleManager& module_manager,
 [[nodiscard]] const orbit_client_data::ModuleData* FindModuleByAddress(
     const ProcessData& process, const ModuleManager& module_manager, uint64_t absolute_address);
 
-[[nodiscard]] std::optional<uint64_t> FindInstrumentedFunctionIdSlow(
-    const CaptureData& capture_data, const FunctionInfo& function_info);
-
 }  // namespace orbit_client_data
 
 #endif  // CLIENT_DATA_MODULE_AND_FUNCTION_LOOKUP_H_

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -40,6 +40,10 @@ class ScopeIdProvider {
   [[nodiscard]] virtual const ScopeInfo& GetScopeInfo(ScopeId scope_id) const = 0;
 
   [[nodiscard]] virtual const FunctionInfo* GetFunctionInfo(ScopeId scope_id) const = 0;
+
+  [[nodiscard]] virtual std::optional<uint64_t> FindFunctionIdSlow(
+      const FunctionInfo& function_info) const = 0;
+
   virtual void UpdateFunctionInfoAddress(
       orbit_grpc_protos::InstrumentedFunction instrumented_function) = 0;
 };
@@ -70,6 +74,10 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   [[nodiscard]] const ScopeInfo& GetScopeInfo(ScopeId scope_id) const override;
 
   [[nodiscard]] const FunctionInfo* GetFunctionInfo(ScopeId scope_id) const override;
+
+  [[nodiscard]] std::optional<uint64_t> FindFunctionIdSlow(
+      const FunctionInfo& function_info) const override;
+
   void UpdateFunctionInfoAddress(
       orbit_grpc_protos::InstrumentedFunction instrumented_function) override;
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -70,9 +70,8 @@ bool FunctionsDataView::ShouldShowFrameTrackIcon(AppInterface* app, const Functi
     return false;
   }
 
-  const CaptureData& capture_data = app->GetCaptureData();
   std::optional<uint64_t> instrumented_function_id =
-      orbit_client_data::FindInstrumentedFunctionIdSlow(capture_data, function);
+      app->GetCaptureData().FindFunctionIdSlow(function);
 
   return instrumented_function_id &&
          app->HasFrameTrackInCaptureData(instrumented_function_id.value());

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -474,8 +474,6 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] bool IsFunctionSelected(
       const orbit_client_data::SampledFunction& func) const override;
   [[nodiscard]] bool IsFunctionSelected(uint64_t absolute_address) const;
-  [[nodiscard]] const orbit_grpc_protos::InstrumentedFunction* GetInstrumentedFunction(
-      uint64_t function_id) const;
 
   void SetVisibleScopeIds(absl::flat_hash_set<ScopeId> visible_scope_ids) override;
   [[nodiscard]] bool IsScopeVisible(ScopeId scope_id) const;

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -114,7 +114,7 @@ class NavigationTestCaptureWindow : public CaptureWindow, public testing::Test {
   void AddTimers() {
     auto timers = TrackTestData::GenerateTimers();
     for (auto& timer : timers) {
-      time_graph_->ProcessTimer(timer, nullptr);
+      time_graph_->ProcessTimer(timer);
     }
   }
 };

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -11,9 +11,8 @@
 #include <string>
 #include <vector>
 
-#include "CallstackThreadBar.h"
+#include "ClientData/FunctionInfo.h"
 #include "ClientData/ScopeStats.h"
-#include "ClientData/TimerChain.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "CoreMath.h"
 #include "PickingManager.h"
@@ -27,17 +26,17 @@ class FrameTrack : public TimerTrack {
  public:
   explicit FrameTrack(CaptureViewElement* parent,
                       const orbit_gl::TimelineInfoInterface* timeline_info,
-                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                      orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
+                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout, uint64_t function_id,
+                      orbit_client_data::FunctionInfo function, OrbitApp* app,
                       const orbit_client_data::ModuleManager* module_manager,
                       const orbit_client_data::CaptureData* capture_data,
                       orbit_client_data::TimerData* timer_data);
 
   [[nodiscard]] std::string GetName() const override {
-    return absl::StrFormat("Frame track based on %s", function_.function_name());
+    return absl::StrFormat("Frame track based on %s", function_.pretty_name());
   }
   [[nodiscard]] Type GetType() const override { return Type::kFrameTrack; }
-  [[nodiscard]] uint64_t GetFunctionId() const { return function_.function_id(); }
+  [[nodiscard]] uint64_t GetFunctionId() const { return function_id_; }
   [[nodiscard]] bool IsCollapsible() const override {
     return GetCappedMaximumToAverageRatio() > 0.f;
   }
@@ -74,7 +73,8 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] float GetMaximumBoxHeight() const;
   [[nodiscard]] float GetAverageBoxHeight() const;
 
-  orbit_grpc_protos::InstrumentedFunction function_;
+  uint64_t function_id_;
+  orbit_client_data::FunctionInfo function_;
   orbit_client_data::ScopeStats stats_;
 };
 

--- a/src/OrbitGl/FrameTrackOnlineProcessor.cpp
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.cpp
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "ClientData/CaptureData.h"
-#include "ClientData/FunctionInfo.h"
 #include "TimeGraph.h"
 
 namespace orbit_gl {
@@ -37,10 +36,9 @@ FrameTrackOnlineProcessor::FrameTrackOnlineProcessor(
   }
 }
 
-void FrameTrackOnlineProcessor::ProcessTimer(
-    const orbit_client_protos::TimerInfo& timer_info,
-    const orbit_grpc_protos::InstrumentedFunction& function) {
+void FrameTrackOnlineProcessor::ProcessTimer(const orbit_client_protos::TimerInfo& timer_info) {
   uint64_t function_id = timer_info.function_id();
+
   if (!current_frame_track_function_ids_.contains(function_id)) {
     return;
   }
@@ -54,7 +52,7 @@ void FrameTrackOnlineProcessor::ProcessTimer(
     orbit_client_protos::TimerInfo frame_timer;
     CreateFrameTrackTimer(function_id, previous_timestamp_ns, timer_info.start(),
                           current_frame_index_++, &frame_timer);
-    time_graph_->ProcessTimer(frame_timer, &function);
+    time_graph_->ProcessTimer(frame_timer);
     function_id_to_previous_timestamp_ns_[function_id] = timer_info.start();
   }
 }

--- a/src/OrbitGl/FrameTrackOnlineProcessor.h
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.h
@@ -25,8 +25,7 @@ class FrameTrackOnlineProcessor {
   FrameTrackOnlineProcessor() = default;
   FrameTrackOnlineProcessor(const orbit_client_data::CaptureData& capture_data,
                             TimeGraph* time_graph);
-  void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
-                    const orbit_grpc_protos::InstrumentedFunction& function);
+  void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info);
 
   void AddFrameTrack(uint64_t function_id);
   void RemoveFrameTrack(uint64_t function_id);

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -107,7 +107,7 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
 
  private:
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override {
-    introspection_window_->GetTimeGraph()->ProcessTimer(timer_info, nullptr);
+    introspection_window_->GetTimeGraph()->ProcessTimer(timer_info);
   }
 
   void OnApiStringEvent(const orbit_client_data::ApiStringEvent& api_string_event) override {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -284,7 +284,7 @@ double TimeGraph::GetTime(double ratio) const {
   return min_time_us_ + delta;
 }
 
-void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunction* function) {
+void TimeGraph::ProcessTimer(const TimerInfo& timer_info) {
   TrackManager* track_manager = GetTrackManager();
   // TODO(b/175869409): Change the way to create and get the tracks. Move this part to TrackManager.
   switch (timer_info.type()) {
@@ -298,10 +298,10 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
       break;
     }
     case TimerInfo::kFrame: {
-      if (function == nullptr) {
+      if (timer_info.function_id() == orbit_grpc_protos::kInvalidFunctionId) {
         break;
       }
-      FrameTrack* track = track_manager->GetOrCreateFrameTrack(*function);
+      FrameTrack* track = track_manager->GetOrCreateFrameTrack(timer_info.function_id());
       track->OnTimer(timer_info);
       break;
     }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -46,8 +46,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   void DrawText(float layer);
 
   // TODO(b/214282122): Move Process Timers function outside the UI.
-  void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
-                    const orbit_grpc_protos::InstrumentedFunction* function);
+  void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessApiStringEvent(const orbit_client_data::ApiStringEvent& string_event);
   void ProcessApiTrackValueEvent(const orbit_client_data::ApiTrackValue& track_event);
 

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -18,7 +18,6 @@
 #include "AccessibleCaptureViewElement.h"
 #include "App.h"
 #include "ClientData/ScopeId.h"
-#include "ClientFlags/ClientFlags.h"
 #include "CoreMath.h"
 #include "DisplayFormats/DisplayFormats.h"
 #include "Geometry.h"
@@ -34,6 +33,7 @@
 namespace orbit_gl {
 
 using orbit_client_data::CaptureData;
+using orbit_client_data::FunctionInfo;
 using orbit_client_data::ModuleManager;
 using orbit_client_data::ScopeId;
 using orbit_client_protos::TimerInfo;
@@ -120,10 +120,8 @@ void TrackContainer::UpdateTracksPosition() {
 
 namespace {
 
-[[nodiscard]] std::string GetLabelBetweenIterators(const InstrumentedFunction& function_a,
-                                                   const InstrumentedFunction& function_b) {
-  const std::string& function_from = function_a.function_name();
-  const std::string& function_to = function_b.function_name();
+[[nodiscard]] std::string GetLabelBetweenIterators(const std::string& function_from,
+                                                   const std::string& function_to) {
   return absl::StrFormat("%s to %s", function_from, function_to);
 }
 
@@ -232,13 +230,12 @@ void TrackContainer::DrawOverlay(PrimitiveAssembler& primitive_assembler,
                 iterator_id_to_function_scope_id_.end());
     ScopeId function_a_scope_id = iterator_id_to_function_scope_id_.at(id_a);
     ScopeId function_b_scope_id = iterator_id_to_function_scope_id_.at(id_b);
-    const InstrumentedFunction* function_a = capture_data_->GetInstrumentedFunctionById(
-        capture_data_->ScopeIdToFunctionId(function_a_scope_id));
-    const InstrumentedFunction* function_b = capture_data_->GetInstrumentedFunctionById(
-        capture_data_->ScopeIdToFunctionId(function_b_scope_id));
+    const FunctionInfo* function_a = capture_data_->GetFunctionInfoByScopeId(function_a_scope_id);
+    const FunctionInfo* function_b = capture_data_->GetFunctionInfoByScopeId(function_b_scope_id);
     ORBIT_CHECK(function_a != nullptr);
     ORBIT_CHECK(function_b != nullptr);
-    const std::string& label = GetLabelBetweenIterators(*function_a, *function_b);
+    const std::string& label =
+        GetLabelBetweenIterators(function_a->pretty_name(), function_b->pretty_name());
     const std::string& time = GetTimeString(*timers[k - 1].second, *timers[k].second);
 
     // The height of text is chosen such that the text of the last box drawn is

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -67,7 +67,7 @@ class TrackManager {
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
   VariableTrack* GetOrCreateVariableTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
-  FrameTrack* GetOrCreateFrameTrack(const orbit_grpc_protos::InstrumentedFunction& function);
+  FrameTrack* GetOrCreateFrameTrack(uint64_t function_id);
   [[nodiscard]] SystemMemoryTrack* GetSystemMemoryTrack() const {
     return system_memory_track_.get();
   }

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -41,6 +41,7 @@ class TrackManagerTest : public ::testing::Test {
     timer.set_processor(0);
     timer.set_depth(0);
     timer.set_type(TimerInfo::kCoreActivity);
+    timer.set_function_id(TrackTestData::kFunctionId);
 
     scheduler_track->OnTimer(timer);
     timer.set_type(TimerInfo::kCoreActivity);
@@ -50,6 +51,7 @@ class TrackManagerTest : public ::testing::Test {
     scheduler_track->OnTimer(timer);
     timer.set_type(TimerInfo::kCoreActivity);
     timer_only_thread_track->OnTimer(timer);
+    capture_data_->UpdateScopeStats(timer);
   }
 
   TimeGraphLayout layout_;
@@ -71,8 +73,7 @@ TEST_F(TrackManagerTest, FrameTracksAreReportedWithAllTracks) {
 
   track_manager_.GetOrCreateSchedulerTrack();
   EXPECT_EQ(1ull, track_manager_.GetAllTracks().size());
-  orbit_grpc_protos::InstrumentedFunction function;
-  track_manager_.GetOrCreateFrameTrack(function);
+  track_manager_.GetOrCreateFrameTrack(TrackTestData::kFunctionId);
   EXPECT_EQ(2ull, track_manager_.GetAllTracks().size());
 }
 

--- a/src/OrbitGl/TrackTestData.cpp
+++ b/src/OrbitGl/TrackTestData.cpp
@@ -8,6 +8,7 @@
 #include "ClientData/CallstackInfo.h"
 #include "ClientData/CallstackType.h"
 #include "ClientData/LinuxAddressInfo.h"
+#include "GrpcProtos/capture.pb.h"
 
 using orbit_client_data::CallstackType;
 using orbit_client_data::CaptureData;
@@ -16,9 +17,13 @@ using orbit_client_data::LinuxAddressInfo;
 namespace orbit_gl {
 
 std::unique_ptr<CaptureData> TrackTestData::GenerateTestCaptureData() {
-  auto capture_data = std::make_unique<CaptureData>(orbit_grpc_protos::CaptureStarted{},
-                                                    std::nullopt, absl::flat_hash_set<uint64_t>{},
-                                                    CaptureData::DataSource::kLiveCapture);
+  orbit_grpc_protos::CaptureStarted capture_started;
+  orbit_grpc_protos::InstrumentedFunction* func =
+      capture_started.mutable_capture_options()->mutable_instrumented_functions()->Add();
+  func->set_function_id(kFunctionId);
+  auto capture_data =
+      std::make_unique<CaptureData>(capture_started, std::nullopt, absl::flat_hash_set<uint64_t>{},
+                                    CaptureData::DataSource::kLiveCapture);
 
   // AddressInfo
   LinuxAddressInfo address_info{kInstructionAbsoluteAddress,

--- a/src/OrbitGl/TrackTestData.h
+++ b/src/OrbitGl/TrackTestData.h
@@ -16,6 +16,7 @@ namespace orbit_gl {
 
 struct TrackTestData {
   static constexpr uint64_t kCallstackId = 1;
+  static constexpr uint64_t kFunctionId = 1;
   static constexpr uint64_t kFunctionAbsoluteAddress = 0x30;
   static constexpr uint64_t kInstructionAbsoluteAddress = 0x31;
   static constexpr int32_t kThreadId = 42;


### PR DESCRIPTION
This removes all uses of instrumented_functions_ outside of CaptureData. As this PR has already become really big, removing it entirely will come in a follow up PR that can correctly move and test the logic of ComputeVirtualAddressOfInstrumentedFunctionsIfNecessary into ScopeIdProvider.

This also adds FindFunctionIdSlow to ScopeIdProvider to reduce the changes in this PR. Some of the uses of this function end up going from function_id->function_info->function_id and would be better to refactor so transformations like this don't happen, but this should be done in a follow up PR.

Bug: http://b/249262736