### PR TITLE
Add end-to-end test script orbit_load_symbols.py

### DIFF
--- a/contrib/automation_tests/orbit_add_iterator.py
+++ b/contrib/automation_tests/orbit_add_iterator.py
@@ -3,6 +3,13 @@ Copyright (c) 2020 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndHookFunction
+from test_cases.capture_window import Capture
+from test_cases.live_tab import AddIterator
 """Add a function iterator in Orbit using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -20,20 +27,12 @@ This automation script covers a basic workflow:
  - in the "Live" tab, add an iterator for the instrumented function
 """
 
-from absl import app
-
-from core.orbit_e2e import E2ETestSuite
-from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
-from test_cases.capture_window import Capture
-from test_cases.live_tab import AddIterator
-
 
 def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="hello_ggp"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         AddIterator(function_name="DrawFrame")

--- a/contrib/automation_tests/orbit_bottom_up.py
+++ b/contrib/automation_tests/orbit_bottom_up.py
@@ -10,7 +10,7 @@ from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
 from test_cases.bottom_up_tab import VerifyHelloGgpBottomUpContents
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState
 """Inspect the bottom-up view in Orbit using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -34,8 +34,8 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string='libc-2.24'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string='libdrm.so.2'),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string='libc-2.24'),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string='libdrm.so.2'),
         Capture(frame_pointer_unwinding=False),
         VerifyHelloGgpBottomUpContents(),
         Capture(frame_pointer_unwinding=True, sampling_period_ms=0.1),

--- a/contrib/automation_tests/orbit_capture_compatibility.py
+++ b/contrib/automation_tests/orbit_capture_compatibility.py
@@ -10,7 +10,7 @@ from test_cases.capture_window import Capture
 from test_cases.connection_window import ConnectToStadiaInstance, FilterAndSelectFirstProcess, LoadCapture
 from test_cases.live_tab import VerifyOneFunctionWasHit
 from test_cases.main_window import DismissDialog, RenameMoveCaptureFile
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState
 """Verify Capture compatibility
 
 This script contains functionality to record a capture with one (new) version of Orbit and then
@@ -33,14 +33,14 @@ to be run from 64 bit python.
 def main(argv):
     if len(argv) < 3:
         raise RuntimeError(
-            "Missing argument: You need to pass 2 arguments. The first is `record_capture` or " \
+            "Missing argument: You need to pass 2 arguments. The first is `record_capture` or "
             "`load_capture` and the second a path to save/load the capture file"
         )
     if argv[1] == "record_capture":
         test_cases = [
             ConnectToStadiaInstance(),
             FilterAndSelectFirstProcess(process_filter='hello_'),
-            WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+            WaitForLoadingSymbolsAndCheckModuleState(module_search_string="hello_ggp"),
             Capture(length_in_seconds=5),
             VerifyOneFunctionWasHit(function_name_contains="vulkan"),
             RenameMoveCaptureFile(new_capture_path=argv[2])

--- a/contrib/automation_tests/orbit_capture_repeatedly.py
+++ b/contrib/automation_tests/orbit_capture_repeatedly.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CaptureRepeatedly
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndEnableFrameTrackForFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndEnableFrameTrackForFunction
 """Repeatedly take very short captures using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -32,9 +32,9 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="hello_ggp"),
         FilterAndEnableFrameTrackForFunction(function_search_string='DrawFrame'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="libvulkan.so.1"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="libvulkan.so.1"),
         FilterAndEnableFrameTrackForFunction(function_search_string='vkQueuePresentKHR'),
         Capture(length_in_seconds=1),
         CaptureRepeatedly(number_of_f5_presses=200)

--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -10,7 +10,7 @@ from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, FilterTracks, CheckTimers, SetEnableAutoFrameTrack, VerifyTracksExist
 from test_cases.main_window import EndSession
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndHookFunction
 from test_cases.live_tab import AddFrameTrack
 """Create a frame track in Orbit using pywinauto.
 
@@ -34,7 +34,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="hello_ggp"),
         # Setting enable auto frame track to false to only have the created Frame Track.
         SetEnableAutoFrameTrack(enable_auto_frame_track=False),
         # Ending and opening a new session. The auto frame track won't appear.

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -10,7 +10,7 @@ from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CheckTimers, ExpandTrack, SetEnableAutoFrameTrack
 from test_cases.main_window import EndSession
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument a single function in Orbit using pywinauto.
 
@@ -33,7 +33,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="hello_ggp"),
         # Setting enable auto frame track to false, so there is no hooked functions.
         SetEnableAutoFrameTrack(enable_auto_frame_track=False),
         # Ending and opening a new session. New session won't have default frame track neither hooked function.

--- a/contrib/automation_tests/orbit_instrument_libs.py
+++ b/contrib/automation_tests/orbit_instrument_libs.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite, E2ETestCase
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookMultipleFunctions
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndHookMultipleFunctions
 from test_cases.live_tab import VerifyOneFunctionWasHit
 """Instrument function from libggp.
 
@@ -43,7 +43,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="libggp"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="libggp"),
         FilterAndHookMultipleFunctions(function_search_string='GgpIssueFrameToken_v'),
         Capture(),
         VerifyOneFunctionWasHit(function_name_contains='GgpIssueFrameToken_v',

--- a/contrib/automation_tests/orbit_load_symbols.py
+++ b/contrib/automation_tests/orbit_load_symbols.py
@@ -1,0 +1,54 @@
+"""
+Copyright (c) 2022 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
+from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols, MODULE_STATE_PARTIAL, VerifySymbolsLoaded, \
+    WaitForLoadingSymbolsAndCheckModule, WaitForLoadingSymbolsAndCheckNoErrors
+from test_cases.symbol_locations import ClearAllSymbolLocations
+"""
+Test symbol loading.
+
+Before this script is run there needs to be a gamelet reserved and
+"no_symbols_elf" has to be started (can be downloaded from GCS).
+
+The script requires absl and pywinauto. Since pywinauto requires the bitness of
+the python installation to match the bitness of the program under test, it needs
+to be run from 64 bit python.
+
+This automation script covers a basic workflow:
+ - connect to a gamelet
+ - delete all symbol locations
+ - verify no modules have symbols in the "Error" state
+ - verify symbols for "libc" are in the "Loaded" state, and functions are present
+ - verify symbols for "no_symbols_elf" are in the "Partial" state, and functions are present
+ - verify manual symbol loading for "no_symbols_elf" is possible but fails
+"""
+
+
+def main(argv):
+    test_cases = [
+        ConnectToStadiaInstance(),
+        FilterAndSelectFirstProcess(process_filter='no_symbols_elf'),
+        ClearSymbolCache(),
+        ClearAllSymbolLocations(),
+        WaitForLoadingSymbolsAndCheckNoErrors(),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="libc"),
+        VerifySymbolsLoaded(symbol_search_string="fprintf{ }libc"),
+        WaitForLoadingSymbolsAndCheckModule(module_search_string="no_symbols_elf",
+                                            expected_state=MODULE_STATE_PARTIAL),
+        VerifySymbolsLoaded(
+            symbol_search_string="[function@0x2974]{ }no_symbols_elf"),  # Corresponds to `main`.
+        LoadSymbols(module_search_string="no_symbols_elf", expect_fail=True),
+    ]
+    suite = E2ETestSuite(test_name="Custom symbol locations", test_cases=test_cases)
+    suite.execute()
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/contrib/automation_tests/orbit_load_symbols.py
+++ b/contrib/automation_tests/orbit_load_symbols.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols, MODULE_STATE_PARTIAL, VerifySymbolsLoaded, \
-    WaitForLoadingSymbolsAndCheckModule, WaitForLoadingSymbolsAndCheckNoErrors
+    WaitForLoadingSymbolsAndCheckModuleState, WaitForLoadingSymbolsAndCheckNoErrorStates
 from test_cases.symbol_locations import ClearAllSymbolLocations
 """
 Test symbol loading.
@@ -37,11 +37,11 @@ def main(argv):
         FilterAndSelectFirstProcess(process_filter='no_symbols_elf'),
         ClearSymbolCache(),
         ClearAllSymbolLocations(),
-        WaitForLoadingSymbolsAndCheckNoErrors(),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="libc"),
+        WaitForLoadingSymbolsAndCheckNoErrorStates(),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="libc"),
         VerifySymbolsLoaded(symbol_search_string="fprintf{ }libc"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="no_symbols_elf",
-                                            expected_state=MODULE_STATE_PARTIAL),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="no_symbols_elf",
+                                                 expected_state=MODULE_STATE_PARTIAL),
         VerifySymbolsLoaded(
             symbol_search_string="[function@0x2974]{ }no_symbols_elf"),  # Corresponds to `main`.
         LoadSymbols(module_search_string="no_symbols_elf", expect_fail=True),

--- a/contrib/automation_tests/orbit_load_symbols.py
+++ b/contrib/automation_tests/orbit_load_symbols.py
@@ -23,7 +23,7 @@ to be run from 64 bit python.
 
 This automation script covers a basic workflow:
  - connect to a gamelet
- - delete all symbol locations
+ - clear symbol cache and delete all symbol locations
  - verify no modules have symbols in the "Error" state
  - verify symbols for "libc" are in the "Loaded" state, and functions are present
  - verify symbols for "no_symbols_elf" are in the "Partial" state, and functions are present
@@ -46,7 +46,7 @@ def main(argv):
             symbol_search_string="[function@0x2974]{ }no_symbols_elf"),  # Corresponds to `main`.
         LoadSymbols(module_search_string="no_symbols_elf", expect_fail=True),
     ]
-    suite = E2ETestSuite(test_name="Custom symbol locations", test_cases=test_cases)
+    suite = E2ETestSuite(test_name="Automatic symbol loading", test_cases=test_cases)
     suite.execute()
 
 

--- a/contrib/automation_tests/orbit_load_symbols_pecoff.py
+++ b/contrib/automation_tests/orbit_load_symbols_pecoff.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState
 from test_cases.symbols_tab import VerifySymbolsLoaded
 """Load symbols for PE/COFF modules.
 
@@ -29,9 +29,9 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='triangle'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="triangle.exe"),
         VerifySymbolsLoaded(symbol_search_string="wWinMain"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="d3d11.dll"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="d3d11.dll"),
         VerifySymbolsLoaded(symbol_search_string="Present")
     ]
     suite = E2ETestSuite(test_name="Load Symbols PE/COFF", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_manual_instrumentation.py
+++ b/contrib/automation_tests/orbit_manual_instrumentation.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CheckTimers, VerifyTracksDoNotExist, VerifyTracksExist, ToggleCollapsedStateOfAllTracks, FilterTracks
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Test Orbit's manual instrumentation.
 
@@ -47,7 +47,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="OrbitTest"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="OrbitTest"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="OrbitTest"),
         # Take a capture without manual instrumentation and assert that no tracks show up.
         Capture(manual_instrumentation=False),
         VerifyTracksDoNotExist(track_names=tracks),

--- a/contrib/automation_tests/orbit_manual_instrumentation_silenus.py
+++ b/contrib/automation_tests/orbit_manual_instrumentation_silenus.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CheckTimers, FilterTracks, VerifyTracksExist
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState
 """Test Orbit's manual instrumentation on Silenus.
 
 Before this script is run there needs to be a gamelet reserved and the
@@ -31,7 +31,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="triangle.exe"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="triangle.exe"),
         Capture(manual_instrumentation=True),
         VerifyTracksExist(track_names=[
             "Frame time, ms (double)", "Frame time, ms (float)", "Frame time, us (int)",

--- a/contrib/automation_tests/orbit_memory_watchdog.py
+++ b/contrib/automation_tests/orbit_memory_watchdog.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import CaptureAndWaitForInterruptedWarning
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndHookFunction
 """Test that OrbitService stops the capture when it is using too much memory.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -31,7 +31,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="call_foo_repeat"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="call_foo_repeatedly"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="call_foo_repeatedly"),
         FilterAndHookFunction(function_search_string="foo{(}{)}"),
         CaptureAndWaitForInterruptedWarning(user_space_instrumentation=True)
     ]

--- a/contrib/automation_tests/orbit_mixed_unwinding.py
+++ b/contrib/automation_tests/orbit_mixed_unwinding.py
@@ -11,7 +11,7 @@ from test_cases.bottom_up_tab import VerifyBottomUpContentForTriangleExe
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
 from test_cases.sampling_tab import VerifySamplingContentForTriangleExe
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState
 from test_cases.top_down_tab import VerifyTopDownContentForTriangleExe
 """Verify mixed (DWARF and PE/COFF) callstack unwinding by inspecting the "Sampling", "Top-Down", "Bottom-Up" tabs.
 
@@ -37,10 +37,10 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="triangle.exe"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="ntdll.dll"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="kernel32.dll"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="d3d11.dll"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="ntdll.dll"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="kernel32.dll"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="d3d11.dll"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="triangle.exe"),
         Capture(),
         VerifySamplingContentForTriangleExe(),
         VerifyTopDownContentForTriangleExe(),

--- a/contrib/automation_tests/orbit_source_code_view.py
+++ b/contrib/automation_tests/orbit_source_code_view.py
@@ -10,7 +10,7 @@ from absl import flags
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess
 from test_cases.connection_window import ConnectToStadiaInstance
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState
 from test_cases.symbols_tab import ShowSourceCode
 """Show source code for a single function in Orbit using pywinauto.
 
@@ -39,7 +39,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="hello_ggp_c"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp_c"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="hello_ggp_c"),
         ShowSourceCode(function_search_string="DrawFrame"),
     ]
     suite = E2ETestSuite(test_name="Show Source Code", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_stadia_symbol_store.py
+++ b/contrib/automation_tests/orbit_stadia_symbol_store.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols, WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols, WaitForLoadingSymbolsAndCheckModuleState
 from test_cases.symbol_locations import ClearAllSymbolLocations, ToggleEnableStadiaSymbolStore
 from test_cases.main_window import EndSession
 """
@@ -45,7 +45,7 @@ def main(argv):
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
         LoadSymbols(module_search_string="libggp", expect_fail=True),
         ToggleEnableStadiaSymbolStore(enable_stadia_symbol_store=True),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="libggp"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="libggp"),
         ToggleEnableStadiaSymbolStore(enable_stadia_symbol_store=False)
     ]
     suite = E2ETestSuite(test_name="Stadia symbol store", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_symbol_cache.py
+++ b/contrib/automation_tests/orbit_symbol_cache.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndVerifyCache, ClearSymbolCache, VerifyModuleLoaded
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndVerifyCache, ClearSymbolCache, VerifyModuleState
 from test_cases.main_window import EndSession
 """
 Test symbol loading with and without local caching.
@@ -41,7 +41,7 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
         WaitForLoadingSymbolsAndVerifyCache(),
-        VerifyModuleLoaded(module_search_string="libggp"),
+        VerifyModuleState(module_search_string="libggp"),
         EndSession(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
         WaitForLoadingSymbolsAndVerifyCache(expected_duration_difference_ratio=0.99),

--- a/contrib/automation_tests/orbit_symbol_locations.py
+++ b/contrib/automation_tests/orbit_symbol_locations.py
@@ -10,7 +10,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols, WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import ClearSymbolCache, LoadSymbols, WaitForLoadingSymbolsAndCheckModuleState
 from test_cases.symbol_locations import AddSymbolLocation, ClearAllSymbolLocations, AddSymbolFile
 from test_cases.main_window import EndSession
 """
@@ -59,14 +59,14 @@ def main(argv):
         AddSymbolLocation(location=stale_path),
         LoadSymbols(module_search_string="no_symbols_elf", expect_fail=True),
         AddSymbolLocation(location=working_path),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="no_symbols_elf"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="no_symbols_elf"),
         ClearAllSymbolLocations(),
         EndSession(),
         FilterAndSelectFirstProcess(process_filter='no_symbols_elf'),
         AddSymbolFile(location=stale_file),
         LoadSymbols(module_search_string="no_symbols_elf", expect_fail=True),
         AddSymbolFile(location=working_file),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="no_symbols_elf"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="no_symbols_elf"),
         ClearAllSymbolLocations()
     ]
     suite = E2ETestSuite(test_name="Custom symbol locations", test_cases=test_cases)

--- a/contrib/automation_tests/orbit_symbol_locations.py
+++ b/contrib/automation_tests/orbit_symbol_locations.py
@@ -18,7 +18,7 @@ Test symbol loading from custom symbol locations.
 
 Before this script is run there needs to be a gamelet reserved and
 "no_symbols_elf" has to be started (can be downloaded from GCS). 
-Test data needs to be available in  "testdata/symbol_location_tests" (part of our git repo).
+Test data needs to be available in "testdata/symbol_location_tests" (part of our git repo).
 
 The script requires absl and pywinauto. Since pywinauto requires the bitness of
 the python installation to match the bitness of the program under test, it needs

--- a/contrib/automation_tests/orbit_top_down.py
+++ b/contrib/automation_tests/orbit_top_down.py
@@ -10,7 +10,7 @@ from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
 from test_cases.top_down_tab import VerifyHelloGgpTopDownContents
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState
 """Inspect the top-down view in Orbit using pywinauto.
 
 Before this script is run there needs to be a gamelet reserved and
@@ -35,8 +35,8 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_ggp'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="libc-2.24"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="libc-2.24"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="hello_ggp"),
         Capture(frame_pointer_unwinding=False),
         VerifyHelloGgpTopDownContents(),
         Capture(frame_pointer_unwinding=True),

--- a/contrib/automation_tests/orbit_uprobes_wine.py
+++ b/contrib/automation_tests/orbit_uprobes_wine.py
@@ -10,7 +10,7 @@ from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_log import VerifyCaptureLogContains
 from test_cases.capture_window import Capture, CheckTimers
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument functions using uprobes on Wine.
 
@@ -36,8 +36,8 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="triangle.exe"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="d3d11.dll"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="d3d11.dll"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="triangle.exe"),
         FilterAndHookFunction(
             function_search_string="dxvk::vk::Presenter::presentImage{ }d3d11.dll"),
         FilterAndHookFunction(function_search_string="Render{ }triangle.exe"),

--- a/contrib/automation_tests/orbit_user_space_instrumentation.py
+++ b/contrib/automation_tests/orbit_user_space_instrumentation.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument a single function in Orbit using user space instrumentation.
 
@@ -32,7 +32,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="hello_ggp"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="hello_ggp"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(user_space_instrumentation=True),
         VerifyScopeTypeAndHitCount(scope_name='DrawFrame',

--- a/contrib/automation_tests/orbit_user_space_instrumentation_silenus.py
+++ b/contrib/automation_tests/orbit_user_space_instrumentation_silenus.py
@@ -9,7 +9,7 @@ from absl import app
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 from test_cases.capture_window import Capture, CheckTimers
-from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModule, FilterAndHookFunction
+from test_cases.symbols_tab import WaitForLoadingSymbolsAndCheckModuleState, FilterAndHookFunction
 from test_cases.live_tab import VerifyScopeTypeAndHitCount
 """Instrument a single function using user space instrumentation on Silenus.
 
@@ -33,7 +33,7 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="triangle.exe"),
-        WaitForLoadingSymbolsAndCheckModule(module_search_string="triangle.exe"),
+        WaitForLoadingSymbolsAndCheckModuleState(module_search_string="triangle.exe"),
         FilterAndHookFunction(function_search_string="Render{ }triangle.exe"),
         Capture(user_space_instrumentation=True),
         CheckTimers(track_name_filter="triangle.exe", require_all=False),

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -217,13 +217,29 @@ class WaitForLoadingSymbolsAndVerifyCache(E2ETestCase):
 
 class WaitForLoadingSymbolsAndCheckModule(E2ETestCase):
     """
-    Waits for automatically loading all symbol files and checks if the specified module was loaded
-    successfully.
+    Waits for automatically loading all symbol files and checks if the specified module was loaded successfully
+    (or is in the desired "Symbols" state).
     """
 
-    def _execute(self, module_search_string: str):
+    def _execute(self, module_search_string: str, expected_state: str = MODULE_STATE_LOADED):
         _wait_for_loading_and_measure_time(self.suite.top_window())
-        VerifyModuleLoaded(module_search_string=module_search_string).execute(self.suite)
+        VerifyModuleLoaded(module_search_string=module_search_string,
+                           expected_state=expected_state).execute(self.suite)
+
+
+class WaitForLoadingSymbolsAndCheckNoErrors(E2ETestCase):
+    """
+    Waits for automatically loading all symbol files and checks that no module is in the "Error" state.
+    """
+
+    def _execute(self):
+        _wait_for_loading_and_measure_time(self.suite.top_window())
+        logging.info("Verifying that no module is in the 'Error' state...")
+        modules = _gather_module_states(self.suite.top_window())
+        self.expect_true(len(modules) > 0, "At least one module is present")
+        self.expect_eq(sum(module.state == MODULE_STATE_ERROR for module in modules), 0,
+                       "No module is in the 'Error' state")
+        logging.info("Verified that no module is in the 'Error' state")
 
 
 class LoadSymbols(E2ETestCase):
@@ -273,22 +289,21 @@ class LoadSymbols(E2ETestCase):
 
 class VerifyModuleLoaded(E2ETestCase):
     """
-    Verifies whether a module with the given search string is loaded.
+    Verifies whether a module with the given search string is loaded (or in the desired "Symbols" state).
     """
 
-    def _execute(self, module_search_string: str, expect_loaded: bool = True):
+    def _execute(self, module_search_string: str, expected_state: str = MODULE_STATE_LOADED):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
-        logging.info('Start verifying module %s is %s.', module_search_string,
-                     "loaded" if expect_loaded else "not loaded")
+        logging.info('Start verifying module %s is in state %s.', module_search_string,
+                     expected_state)
         modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0, 100)
         modules_dataview.filter.set_focus()
         modules_dataview.filter.set_edit_text('')
         send_keys(module_search_string)
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0)
-        wait_for_condition(
-            lambda: MODULE_STATE_LOADED in modules_dataview.get_item_at(0, 0).texts()[0])
+        wait_for_condition(lambda: expected_state in modules_dataview.get_item_at(0, 0).texts()[0])
 
 
 class VerifySymbolsLoaded(E2ETestCase):
@@ -553,18 +568,18 @@ class LoadPreset(E2ETestCase):
 
             def get_open_file_dialog():
                 return self.find_control(control_type="Window",
-                                        name_contains="Select a file",
-                                        parent=self.suite.top_window(),
-                                        recurse=False)
+                                         name_contains="Select a file",
+                                         parent=self.suite.top_window(),
+                                         recurse=False)
 
             logging.info("Waiting for the file open dialog to appear")
             wait_for_condition(lambda: get_open_file_dialog().is_visible())
             dialog = get_open_file_dialog()
 
             file_edit = self.find_control(control_type="Edit",
-                                name="File name:",
-                                parent=dialog,
-                                recurse=True)
+                                          name="File name:",
+                                          parent=dialog,
+                                          recurse=True)
             file_edit.type_keys(preset_name)
             file_edit.type_keys('{DOWN}{ENTER}')
 

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -215,7 +215,7 @@ class WaitForLoadingSymbolsAndVerifyCache(E2ETestCase):
                         expected=expected_duration, last=last_duration, cur=current_duration))
 
 
-class WaitForLoadingSymbolsAndCheckModule(E2ETestCase):
+class WaitForLoadingSymbolsAndCheckModuleState(E2ETestCase):
     """
     Waits for automatically loading all symbol files and checks if the specified module was loaded successfully
     (or is in the desired "Symbols" state).
@@ -223,11 +223,11 @@ class WaitForLoadingSymbolsAndCheckModule(E2ETestCase):
 
     def _execute(self, module_search_string: str, expected_state: str = MODULE_STATE_LOADED):
         _wait_for_loading_and_measure_time(self.suite.top_window())
-        VerifyModuleLoaded(module_search_string=module_search_string,
-                           expected_state=expected_state).execute(self.suite)
+        VerifyModuleState(module_search_string=module_search_string,
+                          expected_state=expected_state).execute(self.suite)
 
 
-class WaitForLoadingSymbolsAndCheckNoErrors(E2ETestCase):
+class WaitForLoadingSymbolsAndCheckNoErrorStates(E2ETestCase):
     """
     Waits for automatically loading all symbol files and checks that no module is in the "Error" state.
     """
@@ -287,7 +287,7 @@ class LoadSymbols(E2ETestCase):
             VerifySymbolsLoaded(symbol_search_string=module_search_string).execute(self.suite)
 
 
-class VerifyModuleLoaded(E2ETestCase):
+class VerifyModuleState(E2ETestCase):
     """
     Verifies whether a module with the given search string is loaded (or in the desired "Symbols" state).
     """


### PR DESCRIPTION
This is a simple general test for symbol loading, but it's in particular meant to test the new symbol loading fallback.

Bug: http://b/245680119

Test: Ran the new script locally. Also ran orbit_symbol_cache.py locally, since `VerifyModuleLoaded` was edited.