### PR TITLE
Do not use process memory on thread state changes

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -129,7 +129,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   template <typename StackPerfEventDataT>
   bool UnwindStack(const StackPerfEventDataT& event,
-                   orbit_grpc_protos::Callstack* resulting_callstack);
+                   orbit_grpc_protos::Callstack* resulting_callstack,
+                   bool offline_memory_only = false);
 
   TracerListener* listener_;
 


### PR DESCRIPTION
To support vdso and similar modules for unwinding, we allow reading process memory during unwinding.
However, for thread state changes callstacks, we massively limit the captured stack size for performance reasons.

Let's do not read from process in those cases.

Test: Local test