### PR TITLE
Refactor CaptureFileTest

### DIFF
--- a/src/CaptureFile/BUILD
+++ b/src/CaptureFile/BUILD
@@ -27,6 +27,7 @@ orbit_cc_test(
     name = "CaptureFileTests",
     deps = [
         ":CaptureFile",
+        "//src/GrpcProtos:capture_cc_proto",
         "//src/OrbitBase",
         "//src/TestUtils",
         "@com_google_absl//absl/base",

--- a/src/CaptureFile/CaptureFileTest.cpp
+++ b/src/CaptureFile/CaptureFileTest.cpp
@@ -6,11 +6,18 @@
 #include <gmock/gmock.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <gtest/gtest.h>
-#include <stdint.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
 
 #include "CaptureFile/CaptureFile.h"
 #include "CaptureFile/CaptureFileOutputStream.h"
-#include "CaptureFileConstants.h"
+#include "CaptureFile/CaptureFileSection.h"
+#include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/File.h"
+#include "OrbitBase/MakeUniqueForOverwrite.h"
+#include "OrbitBase/Result.h"
 #include "OrbitBase/TemporaryFile.h"
 #include "TestUtils/TestUtils.h"
 
@@ -27,7 +34,6 @@ static constexpr uint64_t kAnswerKey = 42;
 static constexpr uint64_t kNotAnAnswerKey = 43;
 
 using orbit_grpc_protos::ClientCaptureEvent;
-using testing::HasSubstr;
 
 static ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, const std::string& str) {
   ClientCaptureEvent event;
@@ -37,116 +43,96 @@ static ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, const s
   return event;
 }
 
-TEST(CaptureFile, CreateCaptureFileAndReadMainSection) {
-  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-
-  std::string temp_file_name = temporary_file.file_path().string();
-  temporary_file.CloseAndRemove();
-
-  auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
-  ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();
-
-  std::unique_ptr<CaptureFileOutputStream> output_stream =
-      std::move(output_stream_or_error.value());
-
-  EXPECT_TRUE(output_stream->IsOpen());
-
-  orbit_grpc_protos::ClientCaptureEvent event1 =
-      CreateInternedStringCaptureEvent(kAnswerKey, kAnswerString);
-  orbit_grpc_protos::ClientCaptureEvent event2 =
-      CreateInternedStringCaptureEvent(kNotAnAnswerKey, kNotAnAnswerString);
-
-  auto write_result = output_stream->WriteCaptureEvent(event1);
-  ASSERT_FALSE(write_result.has_error()) << write_result.error().message();
-  write_result = output_stream->WriteCaptureEvent(event2);
-  ASSERT_FALSE(write_result.has_error()) << write_result.error().message();
-  auto close_result = output_stream->Close();
-  ASSERT_FALSE(close_result.has_error()) << close_result.error().message();
-
-  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
-  ASSERT_TRUE(capture_file_or_error.has_value()) << capture_file_or_error.error().message();
-  std::unique_ptr<CaptureFile> capture_file = std::move(capture_file_or_error.value());
-
-  auto capture_section = capture_file->CreateCaptureSectionInputStream();
-
-  {
-    ClientCaptureEvent event;
-    ASSERT_THAT(capture_section->ReadMessage(&event), HasNoError());
-    ASSERT_EQ(event.event_case(), ClientCaptureEvent::kInternedString);
-    EXPECT_EQ(event.interned_string().key(), kAnswerKey);
-    EXPECT_EQ(event.interned_string().intern(), kAnswerString);
+class CaptureFileHeaderTest : public testing::Test {
+ public:
+  void SetUp() override {
+    // ASSERT_THAT cannot be used in the constructor, hence this work is done in SetUp.
+    auto tmp_file_or_error = orbit_base::TemporaryFile::Create();
+    ASSERT_THAT(tmp_file_or_error, HasNoError());
+    temporary_file_ =
+        std::make_unique<orbit_base::TemporaryFile>(std::move(tmp_file_or_error.value()));
   }
 
-  {
-    ClientCaptureEvent event;
-    ASSERT_THAT(capture_section->ReadMessage(&event), HasNoError());
-    ASSERT_EQ(event.event_case(), ClientCaptureEvent::kInternedString);
-    EXPECT_EQ(event.interned_string().key(), kNotAnAnswerKey);
-    EXPECT_EQ(event.interned_string().intern(), kNotAnAnswerString);
+ protected:
+  std::unique_ptr<orbit_base::TemporaryFile> temporary_file_;
+};
+
+class CaptureFileTest : public CaptureFileHeaderTest {
+ public:
+  explicit CaptureFileTest()
+      : test_event_1(CreateInternedStringCaptureEvent(kAnswerKey, kAnswerString)),
+        test_event_2(CreateInternedStringCaptureEvent(kNotAnAnswerKey, kNotAnAnswerString)) {}
+  void SetUp() override {
+    CaptureFileHeaderTest::SetUp();
+    temporary_file_->CloseAndRemove();
+
+    AddCaptureSection();
+    OpenTemporayFileAsCaptureFile();
   }
+  void AddCaptureSection() {
+    auto output_stream_or_error =
+        CaptureFileOutputStream::Create(temporary_file_->file_path().string());
+    ASSERT_THAT(output_stream_or_error, HasNoError());
+    auto output_stream = std::move(output_stream_or_error.value());
+
+    ASSERT_TRUE(output_stream->IsOpen());
+
+    ASSERT_THAT(output_stream->WriteCaptureEvent(test_event_1), HasNoError());
+    ASSERT_THAT(output_stream->WriteCaptureEvent(test_event_2), HasNoError());
+    ASSERT_THAT(output_stream->Close(), HasNoError());
+  }
+  static void VerifyEventEquals(const ClientCaptureEvent& lhs, const ClientCaptureEvent& rhs) {
+    ASSERT_EQ(lhs.event_case(), ClientCaptureEvent::kInternedString);
+    ASSERT_EQ(rhs.event_case(), ClientCaptureEvent::kInternedString);
+    EXPECT_EQ(lhs.interned_string().key(), rhs.interned_string().key());
+    EXPECT_EQ(lhs.interned_string().intern(), rhs.interned_string().intern());
+  }
+  void VerifyCaptureSectionContent(
+      const std::unique_ptr<ProtoSectionInputStream>& capture_section) {
+    {
+      ClientCaptureEvent event;
+      ASSERT_THAT(capture_section->ReadMessage(&event), HasNoError());
+      VerifyEventEquals(event, test_event_1);
+    }
+
+    {
+      ClientCaptureEvent event;
+      ASSERT_THAT(capture_section->ReadMessage(&event), HasNoError());
+      VerifyEventEquals(event, test_event_2);
+    }
+  }
+  void OpenTemporayFileAsCaptureFile() {
+    auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file_->file_path());
+    ASSERT_THAT(capture_file_or_error, HasNoError());
+    capture_file_ = std::move(capture_file_or_error.value());
+  }
+
+ protected:
+  std::unique_ptr<CaptureFile> capture_file_;
+
+ private:
+  const ClientCaptureEvent test_event_1;
+  const ClientCaptureEvent test_event_2;
+};
+
+TEST_F(CaptureFileTest, CreateCaptureFileAndReadMainSection) {
+  auto capture_section = capture_file_->CreateCaptureSectionInputStream();
+
+  VerifyCaptureSectionContent(capture_section);
 }
 
-TEST(CaptureFile, CreateCaptureFileWriteAdditionalSectionAndReadMainSection) {
-  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-
-  std::string temp_file_name = temporary_file.file_path().string();
-  temporary_file.CloseAndRemove();
-
-  auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
-  ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();
-
-  std::unique_ptr<CaptureFileOutputStream> output_stream =
-      std::move(output_stream_or_error.value());
-
-  EXPECT_TRUE(output_stream->IsOpen());
-
-  orbit_grpc_protos::ClientCaptureEvent event1 =
-      CreateInternedStringCaptureEvent(kAnswerKey, kAnswerString);
-  orbit_grpc_protos::ClientCaptureEvent event2 =
-      CreateInternedStringCaptureEvent(kNotAnAnswerKey, kNotAnAnswerString);
-
-  auto write_result = output_stream->WriteCaptureEvent(event1);
-  ASSERT_FALSE(write_result.has_error()) << write_result.error().message();
-  write_result = output_stream->WriteCaptureEvent(event2);
-  ASSERT_FALSE(write_result.has_error()) << write_result.error().message();
-  auto close_result = output_stream->Close();
-  ASSERT_FALSE(close_result.has_error()) << close_result.error().message();
-
-  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
-  ASSERT_TRUE(capture_file_or_error.has_value()) << capture_file_or_error.error().message();
-  std::unique_ptr<CaptureFile> capture_file = std::move(capture_file_or_error.value());
-
-  auto section_number_or_error = capture_file->AddUserDataSection(333);
-  ASSERT_TRUE(section_number_or_error.has_value()) << section_number_or_error.error().message();
-  ASSERT_EQ(capture_file->GetSectionList().size(), 1);
+TEST_F(CaptureFileTest, CreateCaptureFileWriteAdditionalSectionAndReadMainSection) {
+  auto section_number_or_error = capture_file_->AddUserDataSection(333);
+  ASSERT_THAT(section_number_or_error, HasNoError());
+  ASSERT_EQ(capture_file_->GetSectionList().size(), 1);
   EXPECT_EQ(section_number_or_error.value(), 0);
-  capture_file.reset();
 
-  capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
-  ASSERT_TRUE(capture_file_or_error.has_value()) << capture_file_or_error.error().message();
-  capture_file = std::move(capture_file_or_error.value());
+  // Reopen the file to make sure this information was saved
+  OpenTemporayFileAsCaptureFile();
 
-  auto capture_section = capture_file->CreateCaptureSectionInputStream();
+  auto capture_section = capture_file_->CreateCaptureSectionInputStream();
 
-  {
-    ClientCaptureEvent event;
-    ASSERT_THAT(capture_section->ReadMessage(&event), HasNoError());
-    ASSERT_EQ(event.event_case(), ClientCaptureEvent::kInternedString);
-    EXPECT_EQ(event.interned_string().key(), kAnswerKey);
-    EXPECT_EQ(event.interned_string().intern(), kAnswerString);
-  }
-
-  {
-    ClientCaptureEvent event;
-    ASSERT_THAT(capture_section->ReadMessage(&event), HasNoError());
-    ASSERT_EQ(event.event_case(), ClientCaptureEvent::kInternedString);
-    EXPECT_EQ(event.interned_string().key(), kNotAnAnswerKey);
-    EXPECT_EQ(event.interned_string().intern(), kNotAnAnswerString);
-  }
+  VerifyCaptureSectionContent(capture_section);
 
   // Read beyond the last message to see if we are just reading zeros as
   // empty messages and then correctly return an end of section error.
@@ -167,38 +153,8 @@ TEST(CaptureFile, CreateCaptureFileWriteAdditionalSectionAndReadMainSection) {
   FAIL() << "More empty messages at end of section than expected.";
 }
 
-TEST(CaptureFile, CreateCaptureFileAndAddSection) {
-  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-
-  std::string temp_file_name = temporary_file.file_path().string();
-  temporary_file.CloseAndRemove();
-
-  auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
-  ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();
-
-  std::unique_ptr<CaptureFileOutputStream> output_stream =
-      std::move(output_stream_or_error.value());
-
-  EXPECT_TRUE(output_stream->IsOpen());
-
-  orbit_grpc_protos::ClientCaptureEvent event1 =
-      CreateInternedStringCaptureEvent(kAnswerKey, kAnswerString);
-  orbit_grpc_protos::ClientCaptureEvent event2 =
-      CreateInternedStringCaptureEvent(kNotAnAnswerKey, kNotAnAnswerString);
-
-  auto write_result = output_stream->WriteCaptureEvent(event1);
-  ASSERT_FALSE(write_result.has_error()) << write_result.error().message();
-  write_result = output_stream->WriteCaptureEvent(event2);
-  ASSERT_FALSE(write_result.has_error()) << write_result.error().message();
-  auto close_result = output_stream->Close();
-  ASSERT_FALSE(close_result.has_error()) << close_result.error().message();
-
-  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
-  ASSERT_TRUE(capture_file_or_error.has_value()) << capture_file_or_error.error().message();
-  std::unique_ptr<CaptureFile> capture_file = std::move(capture_file_or_error.value());
-  EXPECT_EQ(capture_file->GetSectionList().size(), 0);
+TEST_F(CaptureFileTest, CreateCaptureFileAndAddUserDataSection) {
+  EXPECT_EQ(capture_file_->GetSectionList().size(), 0);
 
   uint64_t buf_size;
   {
@@ -213,58 +169,54 @@ TEST(CaptureFile, CreateCaptureFileAndAddSection) {
     google::protobuf::io::CodedOutputStream coded_output_stream(&array_output_stream);
     coded_output_stream.WriteVarint32(event.ByteSizeLong());
     ASSERT_TRUE(event.SerializeToCodedStream(&coded_output_stream));
-    auto section_number_or_error = capture_file->AddUserDataSection(buf_size);
-    ASSERT_THAT(section_number_or_error, HasValue());
-    ASSERT_EQ(capture_file->GetSectionList().size(), 1);
-    EXPECT_EQ(section_number_or_error.value(), 0);
+    auto section_number_or_error = capture_file_->AddUserDataSection(buf_size);
+    ASSERT_THAT(section_number_or_error, HasValue(0));
+    ASSERT_EQ(capture_file_->GetSectionList().size(), 1);
 
-    EXPECT_EQ(capture_file->FindSectionByType(kSectionTypeUserData), 0);
+    EXPECT_EQ(capture_file_->FindSectionByType(kSectionTypeUserData), 0);
     // Write something to the section
-    std::string something{"something"};
+    const std::string something{"something"};
     constexpr uint64_t kOffsetInSection = 5;
     auto write_to_section_result =
-        capture_file->WriteToSection(0, kOffsetInSection, something.c_str(), something.size());
+        capture_file_->WriteToSection(0, kOffsetInSection, something.c_str(), something.size());
     ASSERT_THAT(write_to_section_result, HasNoError());
 
     {
       std::string content;
       content.resize(something.size());
       auto read_result =
-          capture_file->ReadFromSection(0, kOffsetInSection, content.data(), something.size());
+          capture_file_->ReadFromSection(0, kOffsetInSection, content.data(), something.size());
       ASSERT_THAT(read_result, HasNoError());
       EXPECT_EQ(content, something);
     }
 
     ASSERT_THAT(
-        capture_file->WriteToSection(section_number_or_error.value(), 0, buf.get(), buf_size),
+        capture_file_->WriteToSection(section_number_or_error.value(), 0, buf.get(), buf_size),
         HasNoError());
   }
 
   {
-    const auto& capture_file_section = capture_file->GetSectionList()[0];
+    const auto& capture_file_section = capture_file_->GetSectionList()[0];
     EXPECT_EQ(capture_file_section.size, buf_size);
     EXPECT_GT(capture_file_section.offset, 0);
     EXPECT_EQ(capture_file_section.type, kSectionTypeUserData);
   }
 
   // Reopen the file to make sure this information was saved
-  capture_file.reset();
+  OpenTemporayFileAsCaptureFile();
 
-  capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
-  ASSERT_TRUE(capture_file_or_error.has_value()) << capture_file_or_error.error().message();
-  capture_file = std::move(capture_file_or_error.value());
-  EXPECT_EQ(capture_file->GetSectionList().size(), 1);
+  EXPECT_EQ(capture_file_->GetSectionList().size(), 1);
   {
-    const auto& capture_file_section = capture_file->GetSectionList()[0];
+    const auto& capture_file_section = capture_file_->GetSectionList()[0];
     EXPECT_EQ(capture_file_section.type, kSectionTypeUserData);
     EXPECT_GT(capture_file_section.offset, 0);
     EXPECT_EQ(capture_file_section.size, buf_size);
   }
 
-  ASSERT_EQ(capture_file->FindSectionByType(kSectionTypeUserData), 0);
+  ASSERT_EQ(capture_file_->FindSectionByType(kSectionTypeUserData), 0);
 
   {
-    auto section_input_stream = capture_file->CreateProtoSectionInputStream(0);
+    auto section_input_stream = capture_file_->CreateProtoSectionInputStream(0);
     ASSERT_NE(section_input_stream.get(), nullptr);
     ClientCaptureEvent event_from_file;
     ASSERT_THAT(section_input_stream->ReadMessage(&event_from_file), HasNoError());
@@ -274,27 +226,18 @@ TEST(CaptureFile, CreateCaptureFileAndAddSection) {
   }
 }
 
-TEST(CaptureFile, OpenCaptureFileInvalidSignature) {
-  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-
+TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidSignature) {
   auto write_result =
-      orbit_base::WriteFully(temporary_file.fd(), "This is not an Orbit Capture File");
+      orbit_base::WriteFully(temporary_file_->fd(), "This is not an Orbit Capture File");
 
-  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
-  ASSERT_TRUE(capture_file_or_error.has_error());
-  EXPECT_EQ(capture_file_or_error.error().message(), "Invalid file signature");
+  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file_->file_path());
+  EXPECT_THAT(capture_file_or_error, HasError("Invalid file signature"));
 }
 
-TEST(CaptureFile, OpenCaptureFileTooSmall) {
-  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
+TEST_F(CaptureFileHeaderTest, OpenCaptureFileTooSmall) {
+  auto write_result = orbit_base::WriteFully(temporary_file_->fd(), "ups");
 
-  auto write_result = orbit_base::WriteFully(temporary_file.fd(), "ups");
-
-  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
+  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file_->file_path());
   EXPECT_THAT(capture_file_or_error, HasError("Failed to read the file signature"));
 }
 
@@ -310,50 +253,38 @@ static std::string CreateHeader(uint32_t version, uint64_t capture_section_offse
   return header;
 }
 
-TEST(CaptureFile, OpenCaptureFileInvalidVersion) {
-  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-
+TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidVersion) {
   std::string header = CreateHeader(0, 0, 0);
 
-  auto write_result = orbit_base::WriteFully(temporary_file.fd(), header);
+  auto write_result = orbit_base::WriteFully(temporary_file_->fd(), header);
 
-  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
+  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file_->file_path());
   EXPECT_THAT(capture_file_or_error, HasError("Incompatible version 0, expected 1"));
 }
 
-TEST(CaptureFile, OpenCaptureFileInvalidSectionListSize) {
-  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-
+TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidSectionListSize) {
   std::string header = CreateHeader(1, 24, 32);
   header.append(std::string_view{"12345678", 8});
   constexpr uint64_t kSectionListSize = 10;
   header.append(
       std::string_view{absl::bit_cast<const char*>(&kSectionListSize), sizeof(kSectionListSize)});
 
-  auto write_result = orbit_base::WriteFully(temporary_file.fd(), header);
+  auto write_result = orbit_base::WriteFully(temporary_file_->fd(), header);
 
-  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
+  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file_->file_path());
   EXPECT_THAT(capture_file_or_error, HasError("Unexpected EOF while reading section list"));
 }
 
-TEST(CaptureFile, OpenCaptureFileInvalidSectionListSizeTooLarge) {
-  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-
+TEST_F(CaptureFileHeaderTest, OpenCaptureFileInvalidSectionListSizeTooLarge) {
   std::string header = CreateHeader(1, 24, 32);
   header.append(std::string_view{"12345678", 8});
   constexpr uint64_t kSectionListSize = 65'536;
   header.append(
       std::string_view{absl::bit_cast<const char*>(&kSectionListSize), sizeof(kSectionListSize)});
 
-  auto write_result = orbit_base::WriteFully(temporary_file.fd(), header);
+  auto write_result = orbit_base::WriteFully(temporary_file_->fd(), header);
 
-  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
+  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file_->file_path());
   EXPECT_THAT(capture_file_or_error, HasError("The section list is too large"));
 }
 


### PR DESCRIPTION
This does not change functionality, just uses test fixtures to dedup code and use EXPECT_THAT where appropriate.