### PR TITLE
Improve CaptureFile

### DIFF
--- a/src/CaptureFile/CaptureFileHelpers.cpp
+++ b/src/CaptureFile/CaptureFileHelpers.cpp
@@ -7,6 +7,8 @@
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 
 #include "CaptureFile/CaptureFile.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/MakeUniqueForOverwrite.h"
 
 namespace orbit_capture_file {
 

--- a/src/CaptureFile/CaptureFileTest.cpp
+++ b/src/CaptureFile/CaptureFileTest.cpp
@@ -112,7 +112,7 @@ class CaptureFileTest : public CaptureFileHeaderTest {
     capture_file_ = std::move(capture_file_or_error.value());
   }
 
-  void VerifySectionReadable(uint64_t section_index, size_t section_size) {
+  void VerifySectionIsReadable(uint64_t section_index, size_t section_size) {
     EXPECT_EQ(capture_file_->GetSectionList()[section_index].size, section_size);
     std::vector<char> data;
     data.reserve(section_size);
@@ -126,18 +126,11 @@ class CaptureFileTest : public CaptureFileHeaderTest {
 
     const uint64_t last_section_index = capture_file_->GetSectionList().size() - 1;
 
-    const CaptureFileSection section_list_entry =
-        capture_file_->GetSectionList()[last_section_index];
-    EXPECT_EQ(section_list_entry.type, kSectionTypeUserData);
-    EXPECT_EQ(section_list_entry.size, user_data_section_size);
-
-    EXPECT_EQ(capture_file_->FindSectionByType(kSectionTypeUserData), last_section_index);
-
     ASSERT_EQ(capture_file_->FindAllSectionsByType(kSectionTypeUserData).size(), 1);
     EXPECT_EQ(capture_file_->FindAllSectionsByType(kSectionTypeUserData).front(),
               last_section_index);
 
-    VerifySectionReadable(last_section_index, user_data_section_size);
+    VerifySectionIsReadable(last_section_index, user_data_section_size);
   }
 
  protected:

--- a/src/CaptureFile/FORMAT.md
+++ b/src/CaptureFile/FORMAT.md
@@ -6,23 +6,23 @@ This document describes capture file format for Orbit.
 
 ## File structure
 
-The file consists of multiple sections. Most of the sections are optional and
-may not be present in the file. The header and Capture Section are the only mandatory sections.
+The file consists of multiple sections. The Header and Capture Section are mandatory sections.
+Other additional sections are optional and may not be present in the file.
 
-| Section              |           |
-|----------------------|-----------|
-| Header               | mandatory | 
-| Capture Section      | mandatory |
-| Additional Section 1 | optional  |
-| ...                  | optional  |
-| Additional Section N | optional  |
-| Section List         | optional  |
-| User Data Section    | optional  |
+| Section                                   |           |
+|-------------------------------------------|-----------|
+| Header                                    | mandatory | 
+| Capture Section                           | mandatory |
+| Additional (read-only) Section 1          | optional  |
+| ...                                       | optional  |
+| Additional (read-only) Section N          | optional  |
+| Section List                              | optional  |
+| Additional (read-write) User Data Section | optional  |
 
-Note that the file has the following order. The Header has to go first. The Capture Section is second. 
+Note that the file has the following order. The Header has to go first. The Capture Section is second.
 Then come N additional read-only sections. Afterwards comes the Section List and last the User Data
-Section. Note that the section list only contains the additional sections and the user data section. 
-The [USER_DATA](#user_data) is a read-write section.
+Section. Note that the section list only contains the additional sections (including the user data
+section). The [USER_DATA](#user_data) is a read-write section.
 
 ### Header
 

--- a/src/CaptureFile/FORMAT.md
+++ b/src/CaptureFile/FORMAT.md
@@ -9,19 +9,20 @@ This document describes capture file format for Orbit.
 The file consists of multiple sections. Most of the sections are optional and
 may not be present in the file. The header and Capture Section are the only mandatory sections.
 
-| Section                 |           |
-|-------------------------|-----------|
-| Header                  | mandatory | 
-| Capture Section         | mandatory |
-| Additional Section 1    | optional  |
-| ...                     | optional  |
-| Additional Section N    | optional  |
-| Additional Section List | optional  |
+| Section              |           |
+|----------------------|-----------|
+| Header               | mandatory | 
+| Capture Section      | mandatory |
+| Additional Section 1 | optional  |
+| ...                  | optional  |
+| Additional Section N | optional  |
+| Section List         | optional  |
+| User Data Section    | optional  |
 
-Note that the Header Section has to go first but other than that all other read-only section may appear
-in any order (note that [USER_DATA](#user_data) is a read-write section and is always placed at the end of file).
-This includes the CaptureSection, the code reading this file shouldn't rely on read-only sections appearing
-in any particular order.
+Note that the file has the following order. The Header has to go first. The Capture Section is second. 
+Then come N additional read-only sections. Afterwards comes the Section List and last the User Data
+Section. Note that the section list only contains the additional sections and the user data section. 
+The [USER_DATA](#user_data) is a read-write section.
 
 ### Header
 
@@ -76,4 +77,4 @@ after this section including the section list itself.
 
 #### How the protobuf messages are written
 All protobuf messages in sections are prepended by the Varint32 message size, even if
-the section contains only one protbuf message.
+the section contains only one protobuf message.


### PR DESCRIPTION
Several smaller changes to improve the current CaptureFile class. An error in CaptureFile::AddUserDataSection is made more explicit and the documentation is changed accordingly. CaptureFile::FindAllSectionsByType is added and used in CaptureFileTest. Also the CaptureFile tests are made stricter regarding the user data section being the last section.

Bug: part of http://b/251778797

**This does not change any functionality of CaptureFile.** However, the changes to `CaptureFile::AddUserDataSection` could theoretically result in an error message instead of an abort (ORBIT_CHECK). But this code path is currently not used anywhere.