### PR TITLE
Extract symbol loading code from OrbitApp into new SymbolLoader class

### DIFF
--- a/src/ClientSymbols/QSettingsBasedStorageManager.cpp
+++ b/src/ClientSymbols/QSettingsBasedStorageManager.cpp
@@ -75,7 +75,8 @@ ModuleSymbolFileMappings QSettingsBasedStorageManager::LoadModuleSymbolFileMappi
   return mappings;
 }
 
-void QSettingsBasedStorageManager::SaveDisabledModulePaths(absl::flat_hash_set<std::string> paths) {
+void QSettingsBasedStorageManager::SaveDisabledModulePaths(
+    const absl::flat_hash_set<std::string>& paths) {
   settings_.beginWriteArray(kDisabledModulesKey, static_cast<int>(paths.size()));
   int index = 0;
   for (const auto& path : paths) {

--- a/src/ClientSymbols/include/ClientSymbols/PersistentStorageManager.h
+++ b/src/ClientSymbols/include/ClientSymbols/PersistentStorageManager.h
@@ -31,7 +31,7 @@ class PersistentStorageManager {
   virtual void SaveModuleSymbolFileMappings(const ModuleSymbolFileMappings& mappings) = 0;
   [[nodiscard]] virtual ModuleSymbolFileMappings LoadModuleSymbolFileMappings() = 0;
 
-  virtual void SaveDisabledModulePaths(absl::flat_hash_set<std::string> paths) = 0;
+  virtual void SaveDisabledModulePaths(const absl::flat_hash_set<std::string>& paths) = 0;
   [[nodiscard]] virtual absl::flat_hash_set<std::string> LoadDisabledModulePaths() = 0;
 
   // Symbol store related settings.

--- a/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
+++ b/src/ClientSymbols/include/ClientSymbols/QSettingsBasedStorageManager.h
@@ -29,7 +29,7 @@ class QSettingsBasedStorageManager : public PersistentStorageManager {
   [[nodiscard]] std::vector<std::filesystem::path> LoadPaths() override;
   void SaveModuleSymbolFileMappings(const ModuleSymbolFileMappings& mappings) override;
   [[nodiscard]] ModuleSymbolFileMappings LoadModuleSymbolFileMappings() override;
-  void SaveDisabledModulePaths(absl::flat_hash_set<std::string> paths) override;
+  void SaveDisabledModulePaths(const absl::flat_hash_set<std::string>& paths) override;
   [[nodiscard]] absl::flat_hash_set<std::string> LoadDisabledModulePaths() override;
 
   void SaveEnableStadiaSymbolStore(bool enable_stadia_symbol_store) override;

--- a/src/ConfigWidgets/SymbolLocationsDialogTest.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialogTest.cpp
@@ -41,7 +41,7 @@ class MockPersistentStorageManager : public orbit_client_symbols::PersistentStor
   MOCK_METHOD(std::vector<std::filesystem::path>, LoadPaths, (), (override));
   MOCK_METHOD(void, SaveModuleSymbolFileMappings, (const ModuleSymbolFileMappings&), (override));
   MOCK_METHOD((ModuleSymbolFileMappings), LoadModuleSymbolFileMappings, (), (override));
-  MOCK_METHOD(void, SaveDisabledModulePaths, (absl::flat_hash_set<std::string>), (override));
+  MOCK_METHOD(void, SaveDisabledModulePaths, (const absl::flat_hash_set<std::string>&), (override));
   MOCK_METHOD(absl::flat_hash_set<std::string>, LoadDisabledModulePaths, (), (override));
   MOCK_METHOD(void, SaveEnableStadiaSymbolStore, (bool), (override));
   MOCK_METHOD(bool, LoadEnableStadiaSymbolStore, (), (override));

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -8,7 +8,6 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/flags/declare.h>
 #include <absl/flags/flag.h>
-#include <absl/flags/internal/flag.h>
 #include <absl/strings/match.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
@@ -257,34 +256,6 @@ orbit_metrics_uploader::CaptureStartData CreateCaptureStartData(
   return capture_start_data;
 }
 
-std::vector<std::filesystem::path> GetAllSymbolPaths() {
-  orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-  std::vector<std::filesystem::path> all_paths = storage_manager.LoadPaths();
-  std::vector<std::string> temp_paths = absl::GetFlag(FLAGS_additional_symbol_paths);
-  all_paths.insert(all_paths.end(), temp_paths.begin(), temp_paths.end());
-  return all_paths;
-}
-
-ErrorMessageOr<std::optional<std::filesystem::path>> GetOverrideSymbolFileForModule(
-    const ModuleData& module_data) {
-  orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-  absl::flat_hash_map<std::string, std::filesystem::path> mappings =
-      storage_manager.LoadModuleSymbolFileMappings();
-  if (!mappings.contains(module_data.file_path())) return std::nullopt;
-
-  std::filesystem::path symbol_file_path = mappings[module_data.file_path()];
-
-  OUTCOME_TRY(bool file_exists, orbit_base::FileOrDirectoryExists(symbol_file_path));
-
-  if (!file_exists) {
-    return ErrorMessage{absl::StrFormat(
-        R"(A symbol file override is in place for module "%s", but the symbols file "%s" does not exist.)",
-        module_data.file_path(), symbol_file_path.string())};
-  }
-
-  return symbol_file_path;
-}
-
 // Searches through an inout modules list for a module which paths contains path_substring. If one
 // is found the module is erased from the modules list and returned. If not found, std::nullopt is
 // returned.
@@ -303,8 +274,8 @@ ErrorMessageOr<std::optional<std::filesystem::path>> GetOverrideSymbolFileForMod
 
 // Sorts a vector of modules with a prioritization list of module path substrings. This is done in a
 // simple fashion by iterating through the prio_substrings list and searching for each substring in
-// the the modules list (substring is contained in module path). If a module is found, it is amended
-// to the result vector. After iterating through the prio_substring list, all remaining (not found)
+// the modules list (substring is contained in module path). If a module is found, it is amended to
+// the result vector. After iterating through the prio_substring list, all remaining (not found)
 // modules are added to the result vector.
 [[nodiscard]] std::vector<const ModuleData*> SortModuleListWithPrioritizationList(
     std::vector<const ModuleData*> modules, absl::Span<std::string_view const> prio_substrings) {
@@ -359,8 +330,6 @@ OrbitApp::OrbitApp(orbit_gl::MainWindowInterface* main_window,
         FireRefreshCallbacks();
       },
       Qt::QueuedConnection);
-
-  if (absl::GetFlag(FLAGS_symbol_store_support)) InitRemoteSymbolProviders();
 }
 
 OrbitApp::~OrbitApp() {
@@ -824,13 +793,13 @@ std::unique_ptr<OrbitApp> OrbitApp::Create(
 }
 
 void OrbitApp::PostInit(bool is_connected) {
+  symbol_loader_.emplace(this, main_thread_id_, thread_pool_.get(), main_thread_executor_,
+                         process_manager_, metrics_uploader_);
+
   if (is_connected) {
     ORBIT_CHECK(process_manager_ != nullptr);
 
     capture_client_ = std::make_unique<CaptureClient>(grpc_channel_);
-
-    orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-    download_disabled_modules_ = storage_manager.LoadDisabledModulePaths();
 
     if (GetTargetProcess() != nullptr) {
       std::ignore = UpdateProcessAndModuleList();
@@ -868,21 +837,6 @@ void OrbitApp::PostInit(bool is_connected) {
       FireRefreshCallbacks(DataViewType::kTracepoints);
     });
   });
-}
-
-void OrbitApp::InitRemoteSymbolProviders() {
-  download_manager_.emplace();
-
-  auto client_result = orbit_ggp::CreateClient();
-  if (client_result.has_error()) {
-    ORBIT_ERROR("Error creating ggp client: %s\nStadia symbol provider won't be created.",
-                client_result.error().message());
-  } else {
-    ggp_client_ = std::move(client_result.value());
-    stadia_symbol_provider_.emplace(&symbol_helper_, &*download_manager_, ggp_client_.get());
-  }
-
-  microsoft_symbol_provider_.emplace(&symbol_helper_, &*download_manager_);
 }
 
 static std::vector<std::filesystem::path> ListRegularFilesWithExtension(
@@ -1021,7 +975,7 @@ void OrbitApp::Disassemble(uint32_t pid, const FunctionInfo& function) {
   thread_pool_->Schedule([this, metric = std::move(metric),
                           absolute_address = absolute_address.value(), is_64_bit, pid,
                           function]() mutable {
-    auto result = GetProcessManager()->LoadProcessMemory(pid, absolute_address, function.size());
+    auto result = process_manager_->LoadProcessMemory(pid, absolute_address, function.size());
     if (!result.has_value()) {
       SendErrorToUi("Error reading memory",
                     absl::StrFormat("Could not read process memory: %s.", result.error().message()),
@@ -1064,7 +1018,7 @@ void OrbitApp::ShowSourceCode(const orbit_client_data::FunctionInfo& function) {
 
   const ModuleData* module = GetModuleByModuleIdentifier(function.module_id());
 
-  auto loaded_module = RetrieveModuleWithDebugInfo(module);
+  auto loaded_module = RetrieveModuleWithDebugInfo(module->module_id());
 
   (void)loaded_module.Then(main_thread_executor_, [this, module, function,
                                                    metric = std::move(metric)](
@@ -1309,7 +1263,7 @@ ErrorMessageOr<void> OrbitApp::OnSavePreset(const std::string& filename) {
     return save_result.error();
   }
   ListPresets();
-  Refresh(DataViewType::kPresets);
+  FireRefreshCallbacks(DataViewType::kPresets);
   return outcome::success();
 }
 
@@ -1346,11 +1300,10 @@ ErrorMessageOr<PresetFile> OrbitApp::ReadPresetFromFile(const std::filesystem::p
 ErrorMessageOr<void> OrbitApp::OnLoadPreset(const std::string& filename) {
   OUTCOME_TRY(auto&& preset_file, ReadPresetFromFile(filename));
   (void)LoadPreset(preset_file)
-      .ThenIfSuccess(main_thread_executor_,
-                     [this, preset_file_path = std::move(preset_file.file_path())]() {
-                       ORBIT_CHECK(presets_data_view_ != nullptr);
-                       presets_data_view_->OnLoadPresetSuccessful(preset_file_path);
-                     });
+      .ThenIfSuccess(main_thread_executor_, [this, preset_file_path = preset_file.file_path()]() {
+        ORBIT_CHECK(presets_data_view_ != nullptr);
+        presets_data_view_->OnLoadPresetSuccessful(preset_file_path);
+      });
   return outcome::success();
 }
 
@@ -1816,24 +1769,27 @@ Future<void> OrbitApp::LoadSymbolsManually(absl::Span<const ModuleData* const> m
   std::vector<Future<void>> futures;
   futures.reserve(modules_set.size());
 
+  absl::flat_hash_set<std::string> module_paths;
+  for (const auto& module : modules_set) {
+    module_paths.emplace(module->file_path());
+  }
+  symbol_loader_->EnableDownloadForModules(module_paths);
+
   orbit_base::ImmediateExecutor immediate_executor;
   for (const auto& module : modules_set) {
-    download_disabled_modules_.erase(module->file_path());
-
     // Explicitly do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
         &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
-  orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-  storage_manager.SaveDisabledModulePaths(download_disabled_modules_);
 
   return orbit_base::WhenAll(futures);
 }
 
 Future<OrbitApp::SymbolLoadingAndErrorHandlingResult>
 OrbitApp::RetrieveModuleAndLoadSymbolsAndHandleError(const ModuleData* module) {
-  Future<ErrorMessageOr<CanceledOr<void>>> load_future = RetrieveModuleAndLoadSymbols(module);
+  Future<ErrorMessageOr<CanceledOr<void>>> load_future =
+      symbol_loader_->RetrieveModuleAndLoadSymbols(module);
 
   Future<Future<SymbolLoadingAndErrorHandlingResult>> chained_load_future = load_future.Then(
       main_thread_executor_,
@@ -1873,678 +1829,9 @@ OrbitApp::RetrieveModuleAndLoadSymbolsAndHandleError(const ModuleData* module) {
   return orbit_base::UnwrapFuture(chained_load_future);
 }
 
-Future<ErrorMessageOr<CanceledOr<void>>> OrbitApp::RetrieveModuleAndLoadSymbols(
-    const ModuleData* module_data) {
-  ORBIT_SCOPE_FUNCTION;
-  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
-  ORBIT_CHECK(module_data != nullptr);
-
-  // TODO(b/231455031): Make sure this scoped metric gets the state CANCELLED when the user stops
-  // the download.
-  ScopedMetric metric(metrics_uploader_, OrbitLogEvent::ORBIT_SYMBOL_LOAD);
-
-  const ModuleIdentifier module_id = module_data->module_id();
-
-  modules_with_symbol_loading_error_.erase(module_id);
-
-  if (module_data->AreDebugSymbolsLoaded()) return {outcome::success()};
-
-  const auto it = symbols_currently_loading_.find(module_id);
-  if (it != symbols_currently_loading_.end()) {
-    return it->second;
-  }
-
-  Future<ErrorMessageOr<CanceledOr<void>>> retrieve_module_symbols_and_load_symbols_future =
-      RetrieveModuleSymbolsAndLoadSymbols(module_id);
-
-  Future<ErrorMessageOr<CanceledOr<void>>> retrieve_module_itself_and_load_fallback_symbols_future =
-      orbit_base::UnwrapFuture(retrieve_module_symbols_and_load_symbols_future.Then(
-          main_thread_executor_,
-          [this, module_id](const ErrorMessageOr<CanceledOr<void>>&
-                                retrieve_module_symbols_and_load_symbols_result)
-              -> Future<ErrorMessageOr<CanceledOr<void>>> {
-            if (retrieve_module_symbols_and_load_symbols_result.has_value()) {
-              return {retrieve_module_symbols_and_load_symbols_result};
-            }
-
-            const ModuleData* module_data = GetModuleByModuleIdentifier(module_id);
-            if (module_data == nullptr) {
-              return {ErrorMessage{
-                  absl::StrFormat("Module \"%s\" was not found.", module_id.file_path)}};
-            }
-            // Report the error if loading debug symbols fails when the fallback symbols are already
-            // loaded. This happens when choosing "Load Symbols" on a module that has already
-            // "Symbols: Partial".
-            if (module_data->AreAtLeastFallbackSymbolsLoaded()) {
-              return {retrieve_module_symbols_and_load_symbols_result};
-            }
-
-            return RetrieveModuleItselfAndLoadFallbackSymbols(module_id, module_data->file_size())
-                .Then(main_thread_executor_,
-                      [module_id,
-                       previous_message =
-                           retrieve_module_symbols_and_load_symbols_result.error().message()](
-                          const ErrorMessageOr<CanceledOr<void>>&
-                              retrieve_module_itself_and_load_fallback_symbols_result) mutable
-                      -> ErrorMessageOr<CanceledOr<void>> {
-                        if (retrieve_module_itself_and_load_fallback_symbols_result.has_value()) {
-                          return retrieve_module_itself_and_load_fallback_symbols_result;
-                        }
-
-                        // Merge the two ErrorMessages if everything fails.
-                        return ErrorMessage{absl::StrFormat(
-                            "%s\n\nAlso: %s", previous_message,
-                            retrieve_module_itself_and_load_fallback_symbols_result.error()
-                                .message())};
-                      });
-          }));
-
-  retrieve_module_itself_and_load_fallback_symbols_future.Then(
-      main_thread_executor_, [this, metric = std::move(metric),
-                              module_id](const ErrorMessageOr<CanceledOr<void>>& result) mutable {
-        if (result.has_error()) {
-          modules_with_symbol_loading_error_.emplace(module_id);
-          metric.SetStatusCode(OrbitLogEvent::INTERNAL_ERROR);
-        }
-        symbols_currently_loading_.erase(module_id);
-        FireRefreshCallbacks(orbit_data_views::DataViewType::kModules);
-      });
-
-  symbols_currently_loading_.emplace(module_id,
-                                     retrieve_module_itself_and_load_fallback_symbols_future);
-  FireRefreshCallbacks(orbit_data_views::DataViewType::kModules);
-
-  return retrieve_module_itself_and_load_fallback_symbols_future;
-}
-
-Future<ErrorMessageOr<CanceledOr<void>>> OrbitApp::RetrieveModuleSymbolsAndLoadSymbols(
-    const ModuleIdentifier& module_id) {
-  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_module_symbols_future =
-      RetrieveModuleSymbols(module_id);
-
-  return orbit_base::UnwrapFuture(retrieve_module_symbols_future.Then(
-      main_thread_executor_,
-      [this, module_id](const ErrorMessageOr<CanceledOr<std::filesystem::path>>& retrieve_result)
-          -> Future<ErrorMessageOr<CanceledOr<void>>> {
-        if (retrieve_result.has_error()) {
-          return ErrorMessage{absl::StrFormat("Could not load debug symbols for \"%s\": %s",
-                                              module_id.file_path,
-                                              retrieve_result.error().message())};
-        }
-        if (orbit_base::IsCanceled(retrieve_result.value())) {
-          return {orbit_base::Canceled{}};
-        }
-        const std::filesystem::path& local_file_path =
-            orbit_base::GetNotCanceled(retrieve_result.value());
-
-        orbit_base::ImmediateExecutor executor;
-        return LoadSymbols(local_file_path, module_id)
-            .ThenIfSuccess(&executor, []() -> CanceledOr<void> { return CanceledOr<void>{}; });
-      }));
-}
-
-Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::RetrieveModuleSymbols(
-    const ModuleIdentifier& module_id) {
-  ORBIT_SCOPE_FUNCTION;
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-
-  const ModuleData* module_data = GetModuleByModuleIdentifier(module_id);
-  if (module_data == nullptr) {
-    return {ErrorMessage{absl::StrFormat("Module \"%s\" was not found.", module_id.file_path)}};
-  }
-
-  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_from_local_future =
-      FindModuleLocally(module_data)
-          .Then(main_thread_executor_,
-                [module_id](const ErrorMessageOr<std::filesystem::path>& retrieve_result)
-                    -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-                  if (retrieve_result.has_value()) return {retrieve_result.value()};
-
-                  return {ErrorMessage{absl::StrFormat(
-                      "Failed to find symbols for module \"%s\" with build_id=\"%s\":\n"
-                      "- %s",
-                      module_id.file_path, module_id.build_id, retrieve_result.error().message())}};
-                });
-
-  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_from_remote_future =
-      orbit_base::UnwrapFuture(retrieve_from_local_future.Then(
-          main_thread_executor_,
-          [this, module_id](
-              const ErrorMessageOr<CanceledOr<std::filesystem::path>>& previous_result) mutable
-          -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
-            if (download_disabled_modules_.contains(module_id.file_path)) return previous_result;
-
-            if (previous_result.has_value()) return {previous_result.value()};
-
-            return RetrieveModuleFromRemote(module_id).Then(
-                main_thread_executor_,
-                [module_id, current_message = previous_result.error().message()](
-                    const ErrorMessageOr<CanceledOr<std::filesystem::path>>&
-                        retrieve_result) mutable
-                -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-                  if (retrieve_result.has_value()) return retrieve_result;
-
-                  current_message.append(retrieve_result.error().message());
-                  return ErrorMessage{current_message};
-                });
-          }));
-
-  return retrieve_from_remote_future;
-}
-
-static ErrorMessageOr<std::filesystem::path> FindModuleLocallyImpl(
-    const orbit_symbols::SymbolHelper& symbol_helper, const ModuleData& module_data) {
-  ORBIT_SCOPE_FUNCTION;
-  if (absl::GetFlag(FLAGS_enable_unsafe_symbols)) {
-    // First checkout if a symbol file override exists and if it does, use it
-    OUTCOME_TRY(std::optional<std::filesystem::path> overriden_symbols_file,
-                GetOverrideSymbolFileForModule(module_data));
-    if (overriden_symbols_file.has_value()) return overriden_symbols_file.value();
-  }
-
-  if (module_data.build_id().empty()) {
-    return ErrorMessage(
-        absl::StrFormat("Unable to find local symbols for module \"%s\": build id is empty.",
-                        module_data.file_path()));
-  }
-
-  // Note that the bullet points in the ErrorMessage constructed by this function are indented (by
-  // one level). This is because the caller of this function integrates this ErrorMessage into an
-  // ErrorMessage that also has bullet points (with no indentation, i.e., at top level).
-
-  std::string error_message;
-  {
-    std::vector<std::filesystem::path> search_paths = GetAllSymbolPaths();
-    std::filesystem::path module_path(module_data.file_path());
-    search_paths.emplace_back(module_path.parent_path());
-
-    const auto symbols_path =
-        symbol_helper.FindSymbolsFileLocally(module_data.file_path(), module_data.build_id(),
-                                             module_data.object_file_type(), search_paths);
-    if (symbols_path.has_value()) {
-      ORBIT_LOG(
-          "Found symbols for module \"%s\" in user provided symbol folder. Symbols filename: "
-          "\"%s\"",
-          module_data.file_path(), symbols_path.value().string());
-      return symbols_path.value();
-    }
-    error_message += "\n  * " + symbols_path.error().message();
-  }
-  {
-    const auto symbols_path =
-        symbol_helper.FindSymbolsInCache(module_data.file_path(), module_data.build_id());
-    if (symbols_path.has_value()) {
-      ORBIT_LOG("Found symbols for module \"%s\" in cache. Symbols filename: \"%s\"",
-                module_data.file_path(), symbols_path.value().string());
-      return symbols_path.value();
-    }
-    error_message += "\n  * " + symbols_path.error().message();
-  }
-  if (absl::GetFlag(FLAGS_local)) {
-    const auto symbols_included_in_module =
-        orbit_symbols::VerifySymbolFile(module_data.file_path(), module_data.build_id());
-    if (symbols_included_in_module.has_value()) {
-      ORBIT_LOG("Found symbols included in module: \"%s\"", module_data.file_path());
-      return module_data.file_path();
-    }
-    error_message += "\n  * Symbols are not included in module file: " +
-                     symbols_included_in_module.error().message();
-  }
-
-  error_message = absl::StrFormat("Did not find local symbols for module \"%s\": %s",
-                                  module_data.file_path(), error_message);
-  ORBIT_LOG("%s", error_message);
-  return ErrorMessage(error_message);
-}
-
-Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::FindModuleLocally(
-    const ModuleData* module_data) {
-  ORBIT_SCOPE_FUNCTION;
-  return thread_pool_->Schedule([this, module_data]() -> ErrorMessageOr<std::filesystem::path> {
-    return FindModuleLocallyImpl(symbol_helper_, *module_data);
-  });
-}
-
-[[nodiscard]] static Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>>
-ConvertSymbolProviderRetrieveFuture(const Future<SymbolLoadingOutcome>& future,
-                                    orbit_base::Executor* executor,
-                                    std::string symbol_provider_name, std::string error_msg) {
-  return future.Then(
-      executor,
-      [symbol_provider_name = std::move(symbol_provider_name),
-       error_msg = std::move(error_msg)](const SymbolLoadingOutcome& retrieve_result) mutable
-      -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-        if (orbit_symbol_provider::IsSuccessResult(retrieve_result)) {
-          return orbit_symbol_provider::GetSuccessResult(retrieve_result).path;
-        }
-
-        if (orbit_symbol_provider::IsCanceled(retrieve_result)) return orbit_base::Canceled{};
-
-        error_msg.append(
-            absl::StrFormat("\n- Did not find symbols from %s: %s", symbol_provider_name,
-                            orbit_symbol_provider::IsNotFound(retrieve_result)
-                                ? orbit_symbol_provider::GetNotFoundMessage(retrieve_result)
-                                : retrieve_result.error().message()));
-        return ErrorMessage{error_msg};
-      });
-};
-
-Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::RetrieveModuleFromRemote(
-    const ModuleIdentifier& module_id) {
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-
-  if (const auto it = symbol_files_currently_downloading_.find(module_id.file_path);
-      it != symbol_files_currently_downloading_.end()) {
-    return it->second.future;
-  }
-
-  orbit_base::StopSource stop_source;
-
-  using SymbolRetrieveResult = ErrorMessageOr<CanceledOr<std::filesystem::path>>;
-  Future<SymbolRetrieveResult> retrieve_from_instance_future = orbit_base::UnwrapFuture(
-      main_thread_executor_->Schedule([this, module_id,
-                                       stop_token = stop_source.GetStopToken()]() mutable
-                                      -> Future<SymbolRetrieveResult> {
-        // If --local, Orbit cannot download files from the instance, because no ssh channel
-        // exists. We still return an ErrorMessage to enable continuing searching for symbols
-        // from other symbol sources.
-        if (absl::GetFlag(FLAGS_local) || !main_window_->IsConnected() ||
-            absl::GetFlag(FLAGS_disable_instance_symbols)) {
-          return {ErrorMessage{"\n- Not able to search for symbols on the instance."}};
-        }
-
-        return RetrieveModuleFromInstance(module_id.file_path, std::move(stop_token))
-            .Then(main_thread_executor_,
-                  [](const SymbolRetrieveResult& retrieve_result) mutable -> SymbolRetrieveResult {
-                    if (retrieve_result.has_value()) return retrieve_result;
-
-                    return ErrorMessage{
-                        absl::StrFormat("\n- Did not find symbols on the instance: %s",
-                                        retrieve_result.error().message())};
-                  });
-      }));
-
-  Future<SymbolRetrieveResult> retrieve_from_stadia_future =
-      orbit_base::UnwrapFuture(retrieve_from_instance_future.Then(
-          main_thread_executor_,
-          [this, module_id, stop_token = stop_source.GetStopToken()](
-              const SymbolRetrieveResult& previous_result) mutable -> Future<SymbolRetrieveResult> {
-            if (orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-                stadia_symbol_provider_ == std::nullopt ||
-                !storage_manager.LoadEnableStadiaSymbolStore()) {
-              return {previous_result};
-            }
-
-            if (previous_result.has_value()) return {previous_result.value()};
-
-            return ConvertSymbolProviderRetrieveFuture(
-                stadia_symbol_provider_->RetrieveSymbols(module_id, std::move(stop_token)),
-                main_thread_executor_, "Stadia symbol store", previous_result.error().message());
-          }));
-
-  Future<SymbolRetrieveResult> retrieve_from_microsoft_future =
-      orbit_base::UnwrapFuture(retrieve_from_stadia_future.Then(
-          main_thread_executor_,
-          [this, module_id, stop_token = stop_source.GetStopToken()](
-              const SymbolRetrieveResult& previous_result) mutable -> Future<SymbolRetrieveResult> {
-            if (orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-                microsoft_symbol_provider_ == std::nullopt ||
-                !storage_manager.LoadEnableMicrosoftSymbolServer()) {
-              return {previous_result};
-            }
-
-            if (previous_result.has_value()) return {previous_result.value()};
-
-            return ConvertSymbolProviderRetrieveFuture(
-                microsoft_symbol_provider_->RetrieveSymbols(module_id, std::move(stop_token)),
-                main_thread_executor_, "Microsoft symbol server",
-                previous_result.error().message());
-          }));
-
-  symbol_files_currently_downloading_.emplace(
-      module_id.file_path,
-      OrbitApp::ModuleDownloadOperation{std::move(stop_source), retrieve_from_microsoft_future});
-  FireRefreshCallbacks(orbit_data_views::DataViewType::kModules);
-  retrieve_from_microsoft_future.Then(
-      main_thread_executor_,
-      [this, module_file_path = module_id.file_path](const SymbolRetrieveResult& /*result*/) {
-        symbol_files_currently_downloading_.erase(module_file_path);
-        FireRefreshCallbacks(orbit_data_views::DataViewType::kModules);
-      });
-
-  return retrieve_from_microsoft_future;
-}
-
-Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::RetrieveModuleFromInstance(
-    const std::string& module_file_path, StopToken stop_token) {
-  ORBIT_SCOPE_FUNCTION;
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-
-  Future<ErrorMessageOr<NotFoundOr<std::filesystem::path>>> check_file_on_remote =
-      thread_pool_->Schedule(
-          [process_manager = GetProcessManager(),
-           module_file_path]() -> ErrorMessageOr<NotFoundOr<std::filesystem::path>> {
-            std::vector<std::string> additional_instance_folder;
-            if (!absl::GetFlag(FLAGS_instance_symbols_folder).empty()) {
-              additional_instance_folder.emplace_back(absl::GetFlag(FLAGS_instance_symbols_folder));
-            }
-            return process_manager->FindDebugInfoFile(module_file_path, additional_instance_folder);
-          });
-
-  auto download_file = [this, module_file_path, stop_token = std::move(stop_token)](
-                           const NotFoundOr<std::filesystem::path>& remote_search_outcome) mutable
-      -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
-    // TODO(b/231455031): For now, we treat the ErrorMessage and the NotFound the same way.
-    if (orbit_base::IsNotFound(remote_search_outcome)) {
-      return {ErrorMessage{orbit_base::GetNotFoundMessage(remote_search_outcome)}};
-    }
-    const std::filesystem::path& remote_debug_file_path =
-        orbit_base::GetFound(remote_search_outcome);
-    ORBIT_LOG("Found symbols file on the remote: \"%s\" - loading it using scp...",
-              remote_debug_file_path.string());
-
-    const std::filesystem::path local_debug_file_path =
-        symbol_helper_.GenerateCachedFilePath(module_file_path);
-
-    const std::chrono::time_point<std::chrono::steady_clock> copy_begin =
-        std::chrono::steady_clock::now();
-    ORBIT_LOG("Copying \"%s\" started", remote_debug_file_path.string());
-    Future<ErrorMessageOr<CanceledOr<void>>> copy_result = main_window_->DownloadFileFromInstance(
-        remote_debug_file_path, local_debug_file_path, std::move(stop_token));
-
-    orbit_base::ImmediateExecutor immediate_executor{};
-    return copy_result.Then(&immediate_executor,
-                            [remote_debug_file_path, local_debug_file_path,
-                             copy_begin](ErrorMessageOr<CanceledOr<void>> sftp_result)
-                                -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-                              if (sftp_result.has_error()) {
-                                return ErrorMessage{absl::StrFormat(
-                                    "Could not copy debug info file from the remote: %s",
-                                    sftp_result.error().message())};
-                              }
-                              if (orbit_base::IsCanceled(sftp_result.value())) {
-                                return orbit_base::Canceled{};
-                              }
-                              const auto duration =
-                                  std::chrono::duration_cast<std::chrono::milliseconds>(
-                                      std::chrono::steady_clock::now() - copy_begin);
-                              ORBIT_LOG("Copying \"%s\" took %.3f ms",
-                                        remote_debug_file_path.string(), duration.count());
-                              return local_debug_file_path;
-                            });
-  };
-
-  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> chained_result_future = UnwrapFuture(
-      check_file_on_remote.ThenIfSuccess(main_thread_executor_, std::move(download_file)));
-
-  return chained_result_future;
-}
-
-Future<ErrorMessageOr<CanceledOr<void>>> OrbitApp::RetrieveModuleItselfAndLoadFallbackSymbols(
-    const ModuleIdentifier& module_id, uint64_t module_file_size) {
-  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_module_itself_future =
-      RetrieveModuleItself(module_id, module_file_size);
-
-  return orbit_base::UnwrapFuture(retrieve_module_itself_future.Then(
-      main_thread_executor_,
-      [this, module_id](const ErrorMessageOr<CanceledOr<std::filesystem::path>>& retrieve_result)
-          -> Future<ErrorMessageOr<CanceledOr<void>>> {
-        if (retrieve_result.has_error()) {
-          return ErrorMessage{absl::StrFormat("Could not load fallback symbols for \"%s\": %s",
-                                              module_id.file_path,
-                                              retrieve_result.error().message())};
-        }
-        if (orbit_base::IsCanceled(retrieve_result.value())) {
-          return {orbit_base::Canceled{}};
-        }
-        const std::filesystem::path& local_file_path =
-            orbit_base::GetNotCanceled(retrieve_result.value());
-
-        orbit_base::ImmediateExecutor executor;
-        return LoadFallbackSymbols(local_file_path, module_id)
-            .ThenIfSuccess(&executor, []() -> CanceledOr<void> { return CanceledOr<void>{}; });
-      }));
-}
-
-Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> OrbitApp::RetrieveModuleItself(
-    const ModuleIdentifier& module_id, uint64_t module_file_size) {
-  ORBIT_SCOPE_FUNCTION;
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-
-  // Note that the bullet points in the ErrorMessage constructed by this function are indented (by
-  // one level). This is because the caller of this method integrates this ErrorMessage into an
-  // ErrorMessage that also has bullet points (with no indentation, i.e., at top level).
-
-  auto find_in_cache_or_locally =
-      [this, module_id, module_file_size]() -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-    std::string error_message;
-    {
-      auto object_in_cache = symbol_helper_.FindObjectInCache(module_id.file_path,
-                                                              module_id.build_id, module_file_size);
-      if (object_in_cache.has_value()) {
-        ORBIT_LOG("Found module file \"%s\" itself in cache", module_id.file_path);
-        return {object_in_cache.value()};
-      }
-      error_message += absl::StrFormat("\n  * Could not find module file itself in cache: %s",
-                                       object_in_cache.error().message());
-    }
-    if (absl::GetFlag(FLAGS_local)) {
-      auto verify_object_file_result = orbit_symbols::VerifyObjectFile(
-          module_id.file_path, module_id.build_id, module_file_size);
-      if (verify_object_file_result.has_value()) {
-        ORBIT_LOG("Found module file \"%s\" itself locally", module_id.file_path);
-        return module_id.file_path;
-      }
-      error_message += "\n  * Could not find module file itself locally.";
-    }
-    return ErrorMessage{error_message};
-  };
-
-  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> find_in_cache_or_locally_future =
-      thread_pool_->Schedule(find_in_cache_or_locally);
-
-  auto retrieve_from_instance = [this,
-                                 module_id](const ErrorMessageOr<CanceledOr<std::filesystem::path>>&
-                                                find_in_cache_or_locally_result) mutable
-      -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
-    if (download_disabled_modules_.contains(module_id.file_path)) {
-      return find_in_cache_or_locally_result;
-    }
-    if (find_in_cache_or_locally_result.has_value()) {
-      return {find_in_cache_or_locally_result};
-    }
-
-    if (absl::GetFlag(FLAGS_local) || !main_window_->IsConnected() ||
-        absl::GetFlag(FLAGS_disable_instance_symbols)) {
-      return {ErrorMessage{
-          absl::StrFormat("%s\n  * Could not search for module file itself on the instance.",
-                          find_in_cache_or_locally_result.error().message())}};
-    }
-
-    return RetrieveModuleItselfFromInstance(module_id).Then(
-        main_thread_executor_,
-        [current_message = find_in_cache_or_locally_result.error().message()](
-            const ErrorMessageOr<CanceledOr<std::filesystem::path>>& retrieve_from_instance_result)
-            -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-          if (retrieve_from_instance_result.has_error()) {
-            return ErrorMessage{absl::StrFormat("%s\n  * %s", current_message,
-                                                retrieve_from_instance_result.error().message())};
-          }
-          return retrieve_from_instance_result;
-        });
-  };
-
-  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_from_instance_future =
-      orbit_base::UnwrapFuture(find_in_cache_or_locally_future.Then(
-          main_thread_executor_, std::move(retrieve_from_instance)));
-
-  return retrieve_from_instance_future;
-}
-
-Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>>
-OrbitApp::RetrieveModuleItselfFromInstance(const ModuleIdentifier& module_id) {
-  ORBIT_SCOPE_FUNCTION;
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-
-  if (const auto it = symbol_files_currently_downloading_.find(module_id.file_path);
-      it != symbol_files_currently_downloading_.end()) {
-    return it->second.future;
-  }
-
-  orbit_base::StopSource stop_source;
-
-  auto download = [this, module_id, stop_token = stop_source.GetStopToken()]() mutable
-      -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
-    ORBIT_LOG("Copying module file \"%s\" itself using scp...", module_id.file_path);
-    const std::filesystem::path cache_path =
-        symbol_helper_.GenerateCachedFilePath(module_id.file_path);
-    const std::chrono::time_point<std::chrono::steady_clock> copy_begin =
-        std::chrono::steady_clock::now();
-    Future<ErrorMessageOr<CanceledOr<void>>> copy_result = main_window_->DownloadFileFromInstance(
-        module_id.file_path, cache_path, std::move(stop_token));
-
-    orbit_base::ImmediateExecutor immediate_executor{};
-    return copy_result.Then(
-        &immediate_executor,
-        [module_id, cache_path, copy_begin](ErrorMessageOr<CanceledOr<void>> sftp_result)
-            -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
-          if (sftp_result.has_error()) {
-            return ErrorMessage{absl::StrFormat("Could not copy module file from the remote: %s",
-                                                sftp_result.error().message())};
-          }
-          if (orbit_base::IsCanceled(sftp_result.value())) {
-            return orbit_base::Canceled{};
-          }
-          const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::steady_clock::now() - copy_begin);
-          ORBIT_LOG("Copying \"%s\" took %.3f ms", module_id.file_path, duration.count());
-          return cache_path;
-        });
-  };
-
-  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> download_future =
-      UnwrapFuture(thread_pool_->Schedule(std::move(download)));
-
-  symbol_files_currently_downloading_.emplace(
-      module_id.file_path,
-      OrbitApp::ModuleDownloadOperation{std::move(stop_source), download_future});
-  FireRefreshCallbacks(orbit_data_views::DataViewType::kModules);
-  download_future.Then(main_thread_executor_,
-                       [this, module_file_path = module_id.file_path](
-                           const ErrorMessageOr<CanceledOr<std::filesystem::path>>& /*result*/) {
-                         symbol_files_currently_downloading_.erase(module_file_path);
-                         FireRefreshCallbacks(orbit_data_views::DataViewType::kModules);
-                       });
-  return download_future;
-}
-
-Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModuleWithDebugInfo(
-    const ModuleData* module_data) {
-  return RetrieveModuleWithDebugInfo(module_data->module_id());
-}
-
 Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModuleWithDebugInfo(
     const ModuleIdentifier& module_id) {
-  auto loaded_module = RetrieveModuleSymbols(module_id);
-  return loaded_module.ThenIfSuccess(
-      main_thread_executor_,
-      [this, module_path = module_id.file_path](
-          const CanceledOr<std::filesystem::path>& local_file_path_or_canceled)
-          -> ErrorMessageOr<std::filesystem::path> {
-        if (orbit_base::IsCanceled(local_file_path_or_canceled)) {
-          return ErrorMessage{"User canceled loading."};
-        }
-        const std::filesystem::path& local_file_path =
-            orbit_base::GetNotCanceled(local_file_path_or_canceled);
-
-        auto elf_file = orbit_object_utils::CreateElfFile(local_file_path);
-
-        if (elf_file.has_error()) return elf_file.error();
-
-        if (elf_file.value()->HasDebugInfo()) return local_file_path;
-
-        if (!elf_file.value()->HasGnuDebuglink()) {
-          return ErrorMessage{
-              absl::StrFormat("Module \"%s\" neither includes debug info, nor does it contain "
-                              "a .gnu_debuglink section which could refer to a separate debug "
-                              "info file.",
-                              module_path)};
-        }
-
-        const auto debuglink = elf_file.value()->GetGnuDebugLinkInfo().value();
-        ErrorMessageOr<std::filesystem::path> local_debuginfo_path =
-            symbol_helper_.FindDebugInfoFileLocally(debuglink.path.filename().string(),
-                                                    debuglink.crc32_checksum, GetAllSymbolPaths());
-        if (local_debuginfo_path.has_error()) {
-          return ErrorMessage{absl::StrFormat(
-              "Module \"%s\" doesn't include debug info, and a separate debuginfo file wasn't "
-              "found on this machine, when searching the folders from the Symbol Locations. Please "
-              "make sure that the debuginfo file can be found in one of the added folders. "
-              "According to the .gnu_debuglink section, the debuginfo file must be called \"%s\".",
-              module_path, debuglink.path.string())};
-        }
-
-        elf_file = orbit_object_utils::CreateElfFile(local_debuginfo_path.value());
-        if (elf_file.has_error()) return elf_file.error();
-        return local_debuginfo_path;
-      });
-}
-
-Future<ErrorMessageOr<void>> OrbitApp::LoadSymbols(const std::filesystem::path& symbols_path,
-                                                   const ModuleIdentifier& module_id) {
-  ORBIT_SCOPE_FUNCTION;
-
-  auto load_symbols_from_file_future = thread_pool_->Schedule(
-      [this, symbols_path, module_id]() -> ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> {
-        const ModuleData* module_data = GetModuleByModuleIdentifier(module_id);
-        orbit_object_utils::ObjectFileInfo object_file_info{module_data->load_bias()};
-        ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> symbols_or_error =
-            orbit_symbols::SymbolHelper::LoadSymbolsFromFile(symbols_path, object_file_info);
-        if (symbols_or_error.has_value()) return symbols_or_error;
-        return {ErrorMessage{absl::StrFormat("Could not load debug symbols from \"%s\": %s",
-                                             symbols_path.string(),
-                                             symbols_or_error.error().message())}};
-      });
-
-  auto add_symbols_future = load_symbols_from_file_future.ThenIfSuccess(
-      main_thread_executor_,
-      [this,
-       module_id](const orbit_grpc_protos::ModuleSymbols& symbols) mutable -> ErrorMessageOr<void> {
-        AddSymbols(module_id, symbols);
-        ORBIT_LOG("Successfully loaded %d symbols for \"%s\"", symbols.symbol_infos_size(),
-                  module_id.file_path);
-        return outcome::success();
-      });
-
-  return add_symbols_future;
-}
-
-Future<ErrorMessageOr<void>> OrbitApp::LoadFallbackSymbols(const std::filesystem::path& object_path,
-                                                           const ModuleIdentifier& module_id) {
-  ORBIT_SCOPE_FUNCTION;
-
-  auto load_fallback_symbols_future =
-      thread_pool_->Schedule([object_path]() -> ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> {
-        ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> fallback_symbols_or_error =
-            orbit_symbols::SymbolHelper::LoadFallbackSymbolsFromFile(object_path);
-        if (fallback_symbols_or_error.has_value()) return fallback_symbols_or_error;
-        return {ErrorMessage{
-            absl::StrFormat("Could not load symbols from dynamic linking and/or stack unwinding "
-                            "information as symbols from \"%s\": %s",
-                            object_path.string(), fallback_symbols_or_error.error().message())}};
-      });
-
-  auto add_fallback_symbols_future = load_fallback_symbols_future.ThenIfSuccess(
-      main_thread_executor_,
-      [this,
-       module_id](const orbit_grpc_protos::ModuleSymbols& symbols) mutable -> ErrorMessageOr<void> {
-        AddFallbackSymbols(module_id, symbols);
-        ORBIT_LOG("Successfully loaded %d fallback symbols for \"%s\"", symbols.symbol_infos_size(),
-                  module_id.file_path);
-        return outcome::success();
-      });
-
-  return add_fallback_symbols_future;
+  return symbol_loader_->RetrieveModuleWithDebugInfo(module_id);
 }
 
 void OrbitApp::AddSymbols(const ModuleIdentifier& module_id,
@@ -2660,7 +1947,7 @@ Future<ErrorMessageOr<void>> OrbitApp::LoadPresetModule(const std::filesystem::p
     return outcome::success();
   };
 
-  return RetrieveModuleAndLoadSymbols(module_data)
+  return symbol_loader_->RetrieveModuleAndLoadSymbols(module_data)
       .Then(main_thread_executor_, std::move(handle_hooks_and_frame_tracks));
 }
 
@@ -2816,7 +2103,7 @@ Future<ErrorMessageOr<void>> OrbitApp::UpdateProcessAndModuleList() {
   functions_data_view_->ClearFunctions();
 
   auto module_infos = thread_pool_->Schedule(
-      [this] { return GetProcessManager()->LoadModuleList(GetTargetProcess()->pid()); });
+      [this] { return process_manager_->LoadModuleList(GetTargetProcess()->pid()); });
 
   auto all_reloaded_modules = module_infos.ThenIfSuccess(
       main_thread_executor_,
@@ -2863,7 +2150,7 @@ Future<std::vector<ErrorMessageOr<CanceledOr<void>>>> OrbitApp::LoadAllSymbols()
   for (const ModuleData* module : sorted_module_list) {
     if (module->AreDebugSymbolsLoaded()) continue;
 
-    loading_futures.push_back(RetrieveModuleAndLoadSymbols(module));
+    loading_futures.push_back(symbol_loader_->RetrieveModuleAndLoadSymbols(module));
   }
   if (data_manager_->enable_auto_frame_track()) {
     // Orbit will try to add the default frame track while loading all symbols.
@@ -3001,7 +2288,7 @@ Future<std::vector<ErrorMessageOr<void>>> OrbitApp::ReloadModules(
         std::move(frame_track_function_hashes_map[module_to_reload->file_path()]);
 
     auto reloaded_module =
-        RetrieveModuleAndLoadSymbols(module_to_reload)
+        symbol_loader_->RetrieveModuleAndLoadSymbols(module_to_reload)
             .ThenIfSuccess(main_thread_executor_, [this, module_to_reload,
                                                    hooked_functions = std::move(hooked_functions),
                                                    frame_tracks = std::move(frame_tracks)](
@@ -3725,48 +3012,30 @@ void OrbitApp::ShowHistogram(const std::vector<uint64_t>* data, const std::strin
   main_window_->ShowHistogram(data, scope_name, scope_id);
 }
 
+orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> OrbitApp::DownloadFileFromInstance(
+    std::filesystem::path path_on_instance, std::filesystem::path local_path,
+    orbit_base::StopToken stop_token) {
+  return main_window_->DownloadFileFromInstance(path_on_instance, local_path,
+                                                std::move(stop_token));
+}
+
 [[nodiscard]] bool OrbitApp::IsModuleDownloading(const ModuleData* module) const {
   ORBIT_CHECK(module != nullptr);
   ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
-  return symbol_files_currently_downloading_.contains(module->file_path());
+  return symbol_loader_->IsModuleDownloading(module->file_path());
 }
 
 SymbolLoadingState OrbitApp::GetSymbolLoadingStateForModule(const ModuleData* module) const {
   ORBIT_CHECK(module != nullptr);
   ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
-
-  if (IsModuleDownloading(module)) return SymbolLoadingState::kDownloading;
-
-  ModuleIdentifier module_id = module->module_id();
-  if (symbols_currently_loading_.contains(module_id)) {
-    return SymbolLoadingState::kLoading;
-  }
-
-  switch (module->GetLoadedSymbolsCompleteness()) {
-    case ModuleData::SymbolCompleteness::kNoSymbols:
-      break;
-    case ModuleData::SymbolCompleteness::kDynamicLinkingAndUnwindInfo:
-      return SymbolLoadingState::kFallback;
-    case ModuleData::SymbolCompleteness::kDebugSymbols:
-      return SymbolLoadingState::kLoaded;
-  }
-
-  if (download_disabled_modules_.contains(module->file_path())) {
-    return SymbolLoadingState::kDisabled;
-  }
-
-  if (modules_with_symbol_loading_error_.contains(module_id)) {
-    return SymbolLoadingState::kError;
-  }
-
-  return SymbolLoadingState::kUnknown;
+  return symbol_loader_->GetSymbolLoadingStateForModule(module);
 }
 
 bool OrbitApp::IsSymbolLoadingInProgressForModule(
     const orbit_client_data::ModuleData* module) const {
   ORBIT_CHECK(module != nullptr);
   ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
-  return symbols_currently_loading_.contains(module->module_id());
+  return symbol_loader_->IsSymbolLoadingInProgressForModule(module->module_id());
 }
 
 void OrbitApp::RequestSymbolDownloadStop(absl::Span<const ModuleData* const> modules,
@@ -3774,7 +3043,7 @@ void OrbitApp::RequestSymbolDownloadStop(absl::Span<const ModuleData* const> mod
   ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
 
   for (const auto* module : modules) {
-    if (!symbol_files_currently_downloading_.contains(module->file_path())) {
+    if (!symbol_loader_->IsModuleDownloading(module->file_path())) {
       // Download already ended
       continue;
     }
@@ -3783,17 +3052,21 @@ void OrbitApp::RequestSymbolDownloadStop(absl::Span<const ModuleData* const> mod
       if (orbit_base::IsCanceled(canceled_or)) continue;
     }
 
-    if (!symbol_files_currently_downloading_.contains(module->file_path())) {
+    if (!symbol_loader_->IsModuleDownloading(module->file_path())) {
       // Download already ended (while user was looking at the dialog)
       continue;
     }
-    symbol_files_currently_downloading_.at(module->file_path()).stop_source.RequestStop();
+    symbol_loader_->RequestSymbolDownloadStop(module->file_path());
   }
 }
 
 void OrbitApp::RequestSymbolDownloadStop(
     absl::Span<const orbit_client_data::ModuleData* const> modules) {
   RequestSymbolDownloadStop(modules, true);
+}
+
+void OrbitApp::DisableDownloadForModule(const std::string& module_file_path) {
+  symbol_loader_->DisableDownloadForModule(module_file_path);
 }
 
 const ProcessData& OrbitApp::GetConnectedOrLoadedProcess() const {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -705,22 +705,10 @@ class OrbitApp final : public DataViewFactory,
   // ONLY access this from the main thread.
   absl::flat_hash_map<std::string, ModuleDownloadOperation> symbol_files_currently_downloading_;
 
-  // Map of "module ID" (file path and build ID) to symbol file retrieving future, that holds all
-  // symbol retrieving operations currently in progress. (Retrieving here means finding locally or
-  // downloading from the instance). Since downloading a symbols file can be part of the retrieval,
-  // if a module ID is contained in symbol_files_currently_downloading_, it is also contained in
-  // symbol_files_currently_being_retrieved_.
-  // ONLY access this from the main thread.
-  absl::flat_hash_map<
-      orbit_symbol_provider::ModuleIdentifier,
-      orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>>
-      symbol_files_currently_being_retrieved_;
-
   // Map of "module ID" (file path and build ID) to symbol loading future, that holds all symbol
-  // loading operations that are currently in progress. Since retrieving and downloading a file can
-  // be part of the overall symbol loading process, if a module ID is contained in
-  // symbol_files_currently_being_retrieved_ or symbol_files_currently_downloading_, it is also
-  // contained in symbols_currently_loading_.
+  // loading operations that are currently in progress. Since downloading a file can be part of the
+  // overall symbol loading process, if a module ID is contained in
+  // symbol_files_currently_downloading_, it is also contained in symbols_currently_loading_.
   // ONLY access this from the main thread.
   absl::flat_hash_map<orbit_symbol_provider::ModuleIdentifier,
                       orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>>

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -63,6 +63,7 @@ target_sources(
          SchedulingStats.h
          ShortenStringWithEllipsis.h
          SimpleTimings.h
+         SymbolLoader.h
          SystemMemoryTrack.h
          TextRenderer.h
          TextRendererInterface.h
@@ -136,6 +137,7 @@ target_sources(
           SchedulerTrack.cpp
           SchedulingStats.cpp
           SimpleTimings.cpp
+          SymbolLoader.cpp
           SystemMemoryTrack.cpp
           TimeGraph.cpp
           TimeGraphLayout.cpp

--- a/src/OrbitGl/SymbolLoader.cpp
+++ b/src/OrbitGl/SymbolLoader.cpp
@@ -36,8 +36,8 @@ using orbit_symbol_provider::SymbolLoadingOutcome;
 
 namespace orbit_gl {
 
-SymbolLoader::SymbolLoader(SymbolLoader::AppInterface* app_interface,
-                           std::thread::id main_thread_id, orbit_base::ThreadPool* thread_pool,
+SymbolLoader::SymbolLoader(AppInterface* app_interface, std::thread::id main_thread_id,
+                           orbit_base::ThreadPool* thread_pool,
                            orbit_base::MainThreadExecutor* main_thread_executor,
                            orbit_client_services::ProcessManager* process_manager,
                            orbit_metrics_uploader::MetricsUploader* metrics_uploader)

--- a/src/OrbitGl/SymbolLoader.cpp
+++ b/src/OrbitGl/SymbolLoader.cpp
@@ -1,0 +1,839 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SymbolLoader.h"
+
+#include <absl/flags/flag.h>
+
+#include "ClientFlags/ClientFlags.h"
+#include "ClientSymbols/QSettingsBasedStorageManager.h"
+#include "Introspection/Introspection.h"
+#include "MetricsUploader/ScopedMetric.h"
+#include "MetricsUploader/orbit_log_event.pb.h"
+#include "ObjectUtils/ElfFile.h"
+#include "OrbitBase/File.h"
+#include "OrbitBase/ImmediateExecutor.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/StopToken.h"
+#include "SymbolProvider/SymbolLoadingOutcome.h"
+#include "Symbols/SymbolUtils.h"
+
+using orbit_base::CanceledOr;
+using orbit_base::Future;
+using orbit_base::NotFoundOr;
+using orbit_base::StopToken;
+
+using orbit_client_data::ModuleData;
+
+using orbit_data_views::SymbolLoadingState;
+
+using orbit_metrics_uploader::OrbitLogEvent;
+using orbit_metrics_uploader::ScopedMetric;
+
+using orbit_symbol_provider::ModuleIdentifier;
+using orbit_symbol_provider::SymbolLoadingOutcome;
+
+namespace orbit_gl {
+
+SymbolLoader::SymbolLoader(SymbolLoader::AppInterface* app_interface,
+                           std::thread::id main_thread_id, orbit_base::ThreadPool* thread_pool,
+                           orbit_base::MainThreadExecutor* main_thread_executor,
+                           orbit_client_services::ProcessManager* process_manager,
+                           orbit_metrics_uploader::MetricsUploader* metrics_uploader)
+    : app_interface_{app_interface},
+      main_thread_id_{main_thread_id},
+      thread_pool_{thread_pool},
+      main_thread_executor_{main_thread_executor},
+      process_manager_{process_manager},
+      metrics_uploader_{metrics_uploader} {
+  ORBIT_CHECK(app_interface_ != nullptr);
+  ORBIT_CHECK(thread_pool_ != nullptr);
+  ORBIT_CHECK(main_thread_executor_ != nullptr);
+  ORBIT_CHECK(metrics_uploader_ != nullptr);
+
+  orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+  download_disabled_modules_ = storage_manager.LoadDisabledModulePaths();
+
+  if (absl::GetFlag(FLAGS_symbol_store_support)) {
+    InitRemoteSymbolProviders();
+  }
+}
+
+void SymbolLoader::DisableDownloadForModule(const std::string& module_path) {
+  download_disabled_modules_.emplace(module_path);
+  orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+  storage_manager.SaveDisabledModulePaths(download_disabled_modules_);
+}
+
+void SymbolLoader::EnableDownloadForModules(const absl::flat_hash_set<std::string>& module_paths) {
+  for (const std::string& module_path : module_paths) {
+    download_disabled_modules_.erase(module_path);
+  }
+  orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+  storage_manager.SaveDisabledModulePaths(download_disabled_modules_);
+}
+
+void SymbolLoader::InitRemoteSymbolProviders() {
+  download_manager_.emplace();
+
+  auto client_result = orbit_ggp::CreateClient();
+  if (client_result.has_error()) {
+    ORBIT_ERROR("Error creating ggp client: %s\nStadia symbol provider won't be created.",
+                client_result.error().message());
+  } else {
+    ggp_client_ = std::move(client_result.value());
+    stadia_symbol_provider_.emplace(&symbol_helper_, &*download_manager_, ggp_client_.get());
+  }
+
+  microsoft_symbol_provider_.emplace(&symbol_helper_, &*download_manager_);
+}
+
+Future<ErrorMessageOr<CanceledOr<void>>> SymbolLoader::RetrieveModuleAndLoadSymbols(
+    const orbit_client_data::ModuleData* module_data) {
+  ORBIT_SCOPE_FUNCTION;
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  ORBIT_CHECK(module_data != nullptr);
+
+  // TODO(b/231455031): Make sure this scoped metric gets the state CANCELLED when the user stops
+  //  the download.
+  ScopedMetric metric(metrics_uploader_, OrbitLogEvent::ORBIT_SYMBOL_LOAD);
+
+  const ModuleIdentifier module_id = module_data->module_id();
+
+  modules_with_symbol_loading_error_.erase(module_id);
+
+  if (module_data->AreDebugSymbolsLoaded()) return {outcome::success()};
+
+  const auto it = symbols_currently_loading_.find(module_id);
+  if (it != symbols_currently_loading_.end()) {
+    return it->second;
+  }
+
+  Future<ErrorMessageOr<CanceledOr<void>>> retrieve_module_symbols_and_load_symbols_future =
+      RetrieveModuleSymbolsAndLoadSymbols(module_id);
+
+  Future<ErrorMessageOr<CanceledOr<void>>> retrieve_module_itself_and_load_fallback_symbols_future =
+      orbit_base::UnwrapFuture(retrieve_module_symbols_and_load_symbols_future.Then(
+          main_thread_executor_,
+          [this, module_id](const ErrorMessageOr<CanceledOr<void>>&
+                                retrieve_module_symbols_and_load_symbols_result)
+              -> Future<ErrorMessageOr<CanceledOr<void>>> {
+            if (retrieve_module_symbols_and_load_symbols_result.has_value()) {
+              return {retrieve_module_symbols_and_load_symbols_result};
+            }
+
+            const ModuleData* module_data = app_interface_->GetModuleByModuleIdentifier(module_id);
+            if (module_data == nullptr) {
+              return {ErrorMessage{
+                  absl::StrFormat("Module \"%s\" was not found.", module_id.file_path)}};
+            }
+            // Report the error if loading debug symbols fails when the fallback symbols are already
+            // loaded. This happens when choosing "Load Symbols" on a module that has already
+            // "Symbols: Partial".
+            if (module_data->AreAtLeastFallbackSymbolsLoaded()) {
+              return {retrieve_module_symbols_and_load_symbols_result};
+            }
+
+            return RetrieveModuleItselfAndLoadFallbackSymbols(module_id, module_data->file_size())
+                .Then(main_thread_executor_,
+                      [module_id,
+                       previous_message =
+                           retrieve_module_symbols_and_load_symbols_result.error().message()](
+                          const ErrorMessageOr<CanceledOr<void>>&
+                              retrieve_module_itself_and_load_fallback_symbols_result) mutable
+                      -> ErrorMessageOr<CanceledOr<void>> {
+                        if (retrieve_module_itself_and_load_fallback_symbols_result.has_value()) {
+                          return retrieve_module_itself_and_load_fallback_symbols_result;
+                        }
+
+                        // Merge the two ErrorMessages if everything fails.
+                        return ErrorMessage{absl::StrFormat(
+                            "%s\n\nAlso: %s", previous_message,
+                            retrieve_module_itself_and_load_fallback_symbols_result.error()
+                                .message())};
+                      });
+          }));
+
+  retrieve_module_itself_and_load_fallback_symbols_future.Then(
+      main_thread_executor_, [this, metric = std::move(metric),
+                              module_id](const ErrorMessageOr<CanceledOr<void>>& result) mutable {
+        if (result.has_error()) {
+          modules_with_symbol_loading_error_.emplace(module_id);
+          metric.SetStatusCode(OrbitLogEvent::INTERNAL_ERROR);
+        }
+        symbols_currently_loading_.erase(module_id);
+        app_interface_->OnModuleListUpdated();
+      });
+
+  symbols_currently_loading_.emplace(module_id,
+                                     retrieve_module_itself_and_load_fallback_symbols_future);
+  app_interface_->OnModuleListUpdated();
+
+  return retrieve_module_itself_and_load_fallback_symbols_future;
+}
+
+Future<ErrorMessageOr<CanceledOr<void>>> SymbolLoader::RetrieveModuleSymbolsAndLoadSymbols(
+    const ModuleIdentifier& module_id) {
+  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_module_symbols_future =
+      RetrieveModuleSymbols(module_id);
+
+  return orbit_base::UnwrapFuture(retrieve_module_symbols_future.Then(
+      main_thread_executor_,
+      [this, module_id](const ErrorMessageOr<CanceledOr<std::filesystem::path>>& retrieve_result)
+          -> Future<ErrorMessageOr<CanceledOr<void>>> {
+        if (retrieve_result.has_error()) {
+          return ErrorMessage{absl::StrFormat("Could not load debug symbols for \"%s\": %s",
+                                              module_id.file_path,
+                                              retrieve_result.error().message())};
+        }
+        if (orbit_base::IsCanceled(retrieve_result.value())) {
+          return {orbit_base::Canceled{}};
+        }
+        const std::filesystem::path& local_file_path =
+            orbit_base::GetNotCanceled(retrieve_result.value());
+
+        orbit_base::ImmediateExecutor executor;
+        return LoadSymbols(local_file_path, module_id)
+            .ThenIfSuccess(&executor, []() -> CanceledOr<void> { return CanceledOr<void>{}; });
+      }));
+}
+
+Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> SymbolLoader::RetrieveModuleSymbols(
+    const ModuleIdentifier& module_id) {
+  ORBIT_SCOPE_FUNCTION;
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+
+  const ModuleData* module_data = app_interface_->GetModuleByModuleIdentifier(module_id);
+  if (module_data == nullptr) {
+    return {ErrorMessage{absl::StrFormat("Module \"%s\" was not found.", module_id.file_path)}};
+  }
+
+  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_from_local_future =
+      FindModuleLocally(module_data)
+          .Then(main_thread_executor_,
+                [module_id](const ErrorMessageOr<std::filesystem::path>& retrieve_result)
+                    -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+                  if (retrieve_result.has_value()) return {retrieve_result.value()};
+
+                  return {ErrorMessage{absl::StrFormat(
+                      "Failed to find symbols for module \"%s\" with build_id=\"%s\":\n"
+                      "- %s",
+                      module_id.file_path, module_id.build_id, retrieve_result.error().message())}};
+                });
+
+  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_from_remote_future =
+      orbit_base::UnwrapFuture(retrieve_from_local_future.Then(
+          main_thread_executor_,
+          [this, module_id](
+              const ErrorMessageOr<CanceledOr<std::filesystem::path>>& previous_result) mutable
+          -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
+            if (download_disabled_modules_.contains(module_id.file_path)) return previous_result;
+
+            if (previous_result.has_value()) return {previous_result.value()};
+
+            return RetrieveModuleFromRemote(module_id).Then(
+                main_thread_executor_,
+                [module_id, current_message = previous_result.error().message()](
+                    const ErrorMessageOr<CanceledOr<std::filesystem::path>>&
+                        retrieve_result) mutable
+                -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+                  if (retrieve_result.has_value()) return retrieve_result;
+
+                  current_message.append(retrieve_result.error().message());
+                  return ErrorMessage{current_message};
+                });
+          }));
+
+  return retrieve_from_remote_future;
+}
+
+[[nodiscard]] static std::vector<std::filesystem::path> GetAllSymbolPaths() {
+  orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+  std::vector<std::filesystem::path> all_paths = storage_manager.LoadPaths();
+  std::vector<std::string> temp_paths = absl::GetFlag(FLAGS_additional_symbol_paths);
+  all_paths.insert(all_paths.end(), temp_paths.begin(), temp_paths.end());
+  return all_paths;
+}
+
+static ErrorMessageOr<std::optional<std::filesystem::path>> GetOverrideSymbolFileForModule(
+    const ModuleData& module_data) {
+  orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+  absl::flat_hash_map<std::string, std::filesystem::path> mappings =
+      storage_manager.LoadModuleSymbolFileMappings();
+  if (!mappings.contains(module_data.file_path())) return std::nullopt;
+
+  std::filesystem::path symbol_file_path = mappings[module_data.file_path()];
+
+  OUTCOME_TRY(bool file_exists, orbit_base::FileOrDirectoryExists(symbol_file_path));
+
+  if (!file_exists) {
+    return ErrorMessage{absl::StrFormat(
+        R"(A symbol file override is in place for module "%s", but the symbols file "%s" does not exist.)",
+        module_data.file_path(), symbol_file_path.string())};
+  }
+
+  return symbol_file_path;
+}
+
+static ErrorMessageOr<std::filesystem::path> FindModuleLocallyImpl(
+    const orbit_symbols::SymbolHelper& symbol_helper, const ModuleData& module_data) {
+  ORBIT_SCOPE_FUNCTION;
+  if (absl::GetFlag(FLAGS_enable_unsafe_symbols)) {
+    // First checkout if a symbol file override exists and if it does, use it
+    OUTCOME_TRY(std::optional<std::filesystem::path> overriden_symbols_file,
+                GetOverrideSymbolFileForModule(module_data));
+    if (overriden_symbols_file.has_value()) return overriden_symbols_file.value();
+  }
+
+  if (module_data.build_id().empty()) {
+    return ErrorMessage(
+        absl::StrFormat("Unable to find local symbols for module \"%s\": build id is empty.",
+                        module_data.file_path()));
+  }
+
+  // Note that the bullet points in the ErrorMessage constructed by this function are indented (by
+  // one level). This is because the caller of this function integrates this ErrorMessage into an
+  // ErrorMessage that also has bullet points (with no indentation, i.e., at top level).
+
+  std::string error_message;
+  {
+    std::vector<std::filesystem::path> search_paths = GetAllSymbolPaths();
+    std::filesystem::path module_path(module_data.file_path());
+    search_paths.emplace_back(module_path.parent_path());
+
+    const auto symbols_path =
+        symbol_helper.FindSymbolsFileLocally(module_data.file_path(), module_data.build_id(),
+                                             module_data.object_file_type(), search_paths);
+    if (symbols_path.has_value()) {
+      ORBIT_LOG(
+          "Found symbols for module \"%s\" in user provided symbol folder. Symbols filename: "
+          "\"%s\"",
+          module_data.file_path(), symbols_path.value().string());
+      return symbols_path.value();
+    }
+    error_message += "\n  * " + symbols_path.error().message();
+  }
+  {
+    const auto symbols_path =
+        symbol_helper.FindSymbolsInCache(module_data.file_path(), module_data.build_id());
+    if (symbols_path.has_value()) {
+      ORBIT_LOG("Found symbols for module \"%s\" in cache. Symbols filename: \"%s\"",
+                module_data.file_path(), symbols_path.value().string());
+      return symbols_path.value();
+    }
+    error_message += "\n  * " + symbols_path.error().message();
+  }
+  if (absl::GetFlag(FLAGS_local)) {
+    const auto symbols_included_in_module =
+        orbit_symbols::VerifySymbolFile(module_data.file_path(), module_data.build_id());
+    if (symbols_included_in_module.has_value()) {
+      ORBIT_LOG("Found symbols included in module: \"%s\"", module_data.file_path());
+      return module_data.file_path();
+    }
+    error_message += "\n  * Symbols are not included in module file: " +
+                     symbols_included_in_module.error().message();
+  }
+
+  error_message = absl::StrFormat("Did not find local symbols for module \"%s\": %s",
+                                  module_data.file_path(), error_message);
+  ORBIT_LOG("%s", error_message);
+  return ErrorMessage(error_message);
+}
+
+Future<ErrorMessageOr<std::filesystem::path>> SymbolLoader::FindModuleLocally(
+    const ModuleData* module_data) {
+  ORBIT_SCOPE_FUNCTION;
+  return thread_pool_->Schedule([this, module_data]() -> ErrorMessageOr<std::filesystem::path> {
+    return FindModuleLocallyImpl(symbol_helper_, *module_data);
+  });
+}
+
+static Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>>
+ConvertSymbolProviderRetrieveFuture(const Future<SymbolLoadingOutcome>& future,
+                                    orbit_base::Executor* executor,
+                                    std::string symbol_provider_name, std::string error_msg) {
+  return future.Then(
+      executor,
+      [symbol_provider_name = std::move(symbol_provider_name),
+       error_msg = std::move(error_msg)](const SymbolLoadingOutcome& retrieve_result) mutable
+      -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+        if (orbit_symbol_provider::IsSuccessResult(retrieve_result)) {
+          return orbit_symbol_provider::GetSuccessResult(retrieve_result).path;
+        }
+
+        if (orbit_symbol_provider::IsCanceled(retrieve_result)) return orbit_base::Canceled{};
+
+        error_msg.append(
+            absl::StrFormat("\n- Did not find symbols from %s: %s", symbol_provider_name,
+                            orbit_symbol_provider::IsNotFound(retrieve_result)
+                                ? orbit_symbol_provider::GetNotFoundMessage(retrieve_result)
+                                : retrieve_result.error().message()));
+        return ErrorMessage{error_msg};
+      });
+};
+
+Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> SymbolLoader::RetrieveModuleFromRemote(
+    const ModuleIdentifier& module_id) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+
+  if (const auto it = symbol_files_currently_downloading_.find(module_id.file_path);
+      it != symbol_files_currently_downloading_.end()) {
+    return it->second.future;
+  }
+
+  orbit_base::StopSource stop_source;
+
+  using SymbolRetrieveResult = ErrorMessageOr<CanceledOr<std::filesystem::path>>;
+  Future<SymbolRetrieveResult> retrieve_from_instance_future = orbit_base::UnwrapFuture(
+      main_thread_executor_->Schedule([this, module_id,
+                                       stop_token = stop_source.GetStopToken()]() mutable
+                                      -> Future<SymbolRetrieveResult> {
+        // If --local, Orbit cannot download files from the instance, because no ssh channel
+        // exists. We still return an ErrorMessage to enable continuing searching for symbols
+        // from other symbol sources.
+        if (absl::GetFlag(FLAGS_local) || !app_interface_->IsConnected() ||
+            absl::GetFlag(FLAGS_disable_instance_symbols)) {
+          return {ErrorMessage{"\n- Not able to search for symbols on the instance."}};
+        }
+
+        return RetrieveModuleFromInstance(module_id.file_path, std::move(stop_token))
+            .Then(main_thread_executor_,
+                  [](const SymbolRetrieveResult& retrieve_result) mutable -> SymbolRetrieveResult {
+                    if (retrieve_result.has_value()) return retrieve_result;
+
+                    return ErrorMessage{
+                        absl::StrFormat("\n- Did not find symbols on the instance: %s",
+                                        retrieve_result.error().message())};
+                  });
+      }));
+
+  Future<SymbolRetrieveResult> retrieve_from_stadia_future =
+      orbit_base::UnwrapFuture(retrieve_from_instance_future.Then(
+          main_thread_executor_,
+          [this, module_id, stop_token = stop_source.GetStopToken()](
+              const SymbolRetrieveResult& previous_result) mutable -> Future<SymbolRetrieveResult> {
+            if (orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+                stadia_symbol_provider_ == std::nullopt ||
+                !storage_manager.LoadEnableStadiaSymbolStore()) {
+              return {previous_result};
+            }
+
+            if (previous_result.has_value()) return {previous_result.value()};
+
+            return ConvertSymbolProviderRetrieveFuture(
+                stadia_symbol_provider_->RetrieveSymbols(module_id, std::move(stop_token)),
+                main_thread_executor_, "Stadia symbol store", previous_result.error().message());
+          }));
+
+  Future<SymbolRetrieveResult> retrieve_from_microsoft_future =
+      orbit_base::UnwrapFuture(retrieve_from_stadia_future.Then(
+          main_thread_executor_,
+          [this, module_id, stop_token = stop_source.GetStopToken()](
+              const SymbolRetrieveResult& previous_result) mutable -> Future<SymbolRetrieveResult> {
+            if (orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
+                microsoft_symbol_provider_ == std::nullopt ||
+                !storage_manager.LoadEnableMicrosoftSymbolServer()) {
+              return {previous_result};
+            }
+
+            if (previous_result.has_value()) return {previous_result.value()};
+
+            return ConvertSymbolProviderRetrieveFuture(
+                microsoft_symbol_provider_->RetrieveSymbols(module_id, std::move(stop_token)),
+                main_thread_executor_, "Microsoft symbol server",
+                previous_result.error().message());
+          }));
+
+  symbol_files_currently_downloading_.emplace(
+      module_id.file_path,
+      ModuleDownloadOperation{std::move(stop_source), retrieve_from_microsoft_future});
+  app_interface_->OnModuleListUpdated();
+  retrieve_from_microsoft_future.Then(
+      main_thread_executor_,
+      [this, module_file_path = module_id.file_path](const SymbolRetrieveResult& /*result*/) {
+        symbol_files_currently_downloading_.erase(module_file_path);
+        app_interface_->OnModuleListUpdated();
+      });
+
+  return retrieve_from_microsoft_future;
+}
+
+Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> SymbolLoader::RetrieveModuleFromInstance(
+    const std::string& module_file_path, StopToken stop_token) {
+  ORBIT_SCOPE_FUNCTION;
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+
+  Future<ErrorMessageOr<NotFoundOr<std::filesystem::path>>> check_file_on_remote =
+      thread_pool_->Schedule(
+          [this, module_file_path]() -> ErrorMessageOr<NotFoundOr<std::filesystem::path>> {
+            std::vector<std::string> additional_instance_folder;
+            if (!absl::GetFlag(FLAGS_instance_symbols_folder).empty()) {
+              additional_instance_folder.emplace_back(absl::GetFlag(FLAGS_instance_symbols_folder));
+            }
+            ORBIT_CHECK(process_manager_ != nullptr);
+            return process_manager_->FindDebugInfoFile(module_file_path,
+                                                       additional_instance_folder);
+          });
+
+  auto download_file = [this, module_file_path, stop_token = std::move(stop_token)](
+                           const NotFoundOr<std::filesystem::path>& remote_search_outcome) mutable
+      -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
+    // TODO(b/231455031): For now, we treat the ErrorMessage and the NotFound the same way.
+    if (orbit_base::IsNotFound(remote_search_outcome)) {
+      return {ErrorMessage{orbit_base::GetNotFoundMessage(remote_search_outcome)}};
+    }
+    const std::filesystem::path& remote_debug_file_path =
+        orbit_base::GetFound(remote_search_outcome);
+    ORBIT_LOG("Found symbols file on the remote: \"%s\" - loading it using scp...",
+              remote_debug_file_path.string());
+
+    const std::filesystem::path local_debug_file_path =
+        symbol_helper_.GenerateCachedFilePath(module_file_path);
+
+    const std::chrono::time_point<std::chrono::steady_clock> copy_begin =
+        std::chrono::steady_clock::now();
+    ORBIT_LOG("Copying \"%s\" started", remote_debug_file_path.string());
+    Future<ErrorMessageOr<CanceledOr<void>>> copy_result = app_interface_->DownloadFileFromInstance(
+        remote_debug_file_path, local_debug_file_path, std::move(stop_token));
+
+    orbit_base::ImmediateExecutor immediate_executor{};
+    return copy_result.Then(&immediate_executor,
+                            [remote_debug_file_path, local_debug_file_path,
+                             copy_begin](ErrorMessageOr<CanceledOr<void>> sftp_result)
+                                -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+                              if (sftp_result.has_error()) {
+                                return ErrorMessage{absl::StrFormat(
+                                    "Could not copy debug info file from the remote: %s",
+                                    sftp_result.error().message())};
+                              }
+                              if (orbit_base::IsCanceled(sftp_result.value())) {
+                                return orbit_base::Canceled{};
+                              }
+                              const auto duration =
+                                  std::chrono::duration_cast<std::chrono::milliseconds>(
+                                      std::chrono::steady_clock::now() - copy_begin);
+                              ORBIT_LOG("Copying \"%s\" took %.3f ms",
+                                        remote_debug_file_path.string(), duration.count());
+                              return local_debug_file_path;
+                            });
+  };
+
+  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> chained_result_future = UnwrapFuture(
+      check_file_on_remote.ThenIfSuccess(main_thread_executor_, std::move(download_file)));
+
+  return chained_result_future;
+}
+
+Future<ErrorMessageOr<CanceledOr<void>>> SymbolLoader::RetrieveModuleItselfAndLoadFallbackSymbols(
+    const ModuleIdentifier& module_id, uint64_t module_file_size) {
+  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_module_itself_future =
+      RetrieveModuleItself(module_id, module_file_size);
+
+  return orbit_base::UnwrapFuture(retrieve_module_itself_future.Then(
+      main_thread_executor_,
+      [this, module_id](const ErrorMessageOr<CanceledOr<std::filesystem::path>>& retrieve_result)
+          -> Future<ErrorMessageOr<CanceledOr<void>>> {
+        if (retrieve_result.has_error()) {
+          return ErrorMessage{absl::StrFormat("Could not load fallback symbols for \"%s\": %s",
+                                              module_id.file_path,
+                                              retrieve_result.error().message())};
+        }
+        if (orbit_base::IsCanceled(retrieve_result.value())) {
+          return {orbit_base::Canceled{}};
+        }
+        const std::filesystem::path& local_file_path =
+            orbit_base::GetNotCanceled(retrieve_result.value());
+
+        orbit_base::ImmediateExecutor executor;
+        return LoadFallbackSymbols(local_file_path, module_id)
+            .ThenIfSuccess(&executor, []() -> CanceledOr<void> { return CanceledOr<void>{}; });
+      }));
+}
+
+Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> SymbolLoader::RetrieveModuleItself(
+    const ModuleIdentifier& module_id, uint64_t module_file_size) {
+  ORBIT_SCOPE_FUNCTION;
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+
+  // Note that the bullet points in the ErrorMessage constructed by this function are indented (by
+  // one level). This is because the caller of this method integrates this ErrorMessage into an
+  // ErrorMessage that also has bullet points (with no indentation, i.e., at top level).
+
+  auto find_in_cache_or_locally =
+      [this, module_id, module_file_size]() -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+    std::string error_message;
+    {
+      auto object_in_cache = symbol_helper_.FindObjectInCache(module_id.file_path,
+                                                              module_id.build_id, module_file_size);
+      if (object_in_cache.has_value()) {
+        ORBIT_LOG("Found module file \"%s\" itself in cache", module_id.file_path);
+        return {object_in_cache.value()};
+      }
+      error_message += absl::StrFormat("\n  * Could not find module file itself in cache: %s",
+                                       object_in_cache.error().message());
+    }
+    if (absl::GetFlag(FLAGS_local)) {
+      auto verify_object_file_result = orbit_symbols::VerifyObjectFile(
+          module_id.file_path, module_id.build_id, module_file_size);
+      if (verify_object_file_result.has_value()) {
+        ORBIT_LOG("Found module file \"%s\" itself locally", module_id.file_path);
+        return module_id.file_path;
+      }
+      error_message += "\n  * Could not find module file itself locally.";
+    }
+    return ErrorMessage{error_message};
+  };
+
+  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> find_in_cache_or_locally_future =
+      thread_pool_->Schedule(find_in_cache_or_locally);
+
+  auto retrieve_from_instance = [this,
+                                 module_id](const ErrorMessageOr<CanceledOr<std::filesystem::path>>&
+                                                find_in_cache_or_locally_result) mutable
+      -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
+    if (download_disabled_modules_.contains(module_id.file_path)) {
+      return find_in_cache_or_locally_result;
+    }
+    if (find_in_cache_or_locally_result.has_value()) {
+      return {find_in_cache_or_locally_result};
+    }
+
+    if (absl::GetFlag(FLAGS_local) || !app_interface_->IsConnected() ||
+        absl::GetFlag(FLAGS_disable_instance_symbols)) {
+      return {ErrorMessage{
+          absl::StrFormat("%s\n  * Could not search for module file itself on the instance.",
+                          find_in_cache_or_locally_result.error().message())}};
+    }
+
+    return RetrieveModuleItselfFromInstance(module_id).Then(
+        main_thread_executor_,
+        [current_message = find_in_cache_or_locally_result.error().message()](
+            const ErrorMessageOr<CanceledOr<std::filesystem::path>>& retrieve_from_instance_result)
+            -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+          if (retrieve_from_instance_result.has_error()) {
+            return ErrorMessage{absl::StrFormat("%s\n  * %s", current_message,
+                                                retrieve_from_instance_result.error().message())};
+          }
+          return retrieve_from_instance_result;
+        });
+  };
+
+  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> retrieve_from_instance_future =
+      orbit_base::UnwrapFuture(find_in_cache_or_locally_future.Then(
+          main_thread_executor_, std::move(retrieve_from_instance)));
+
+  return retrieve_from_instance_future;
+}
+
+Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>>
+SymbolLoader::RetrieveModuleItselfFromInstance(const ModuleIdentifier& module_id) {
+  ORBIT_SCOPE_FUNCTION;
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+
+  if (const auto it = symbol_files_currently_downloading_.find(module_id.file_path);
+      it != symbol_files_currently_downloading_.end()) {
+    return it->second.future;
+  }
+
+  orbit_base::StopSource stop_source;
+
+  auto download = [this, module_id, stop_token = stop_source.GetStopToken()]() mutable
+      -> Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> {
+    ORBIT_LOG("Copying module file \"%s\" itself using scp...", module_id.file_path);
+    const std::filesystem::path cache_path =
+        symbol_helper_.GenerateCachedFilePath(module_id.file_path);
+    const std::chrono::time_point<std::chrono::steady_clock> copy_begin =
+        std::chrono::steady_clock::now();
+    Future<ErrorMessageOr<CanceledOr<void>>> copy_result = app_interface_->DownloadFileFromInstance(
+        module_id.file_path, cache_path, std::move(stop_token));
+
+    orbit_base::ImmediateExecutor immediate_executor{};
+    return copy_result.Then(
+        &immediate_executor,
+        [module_id, cache_path, copy_begin](ErrorMessageOr<CanceledOr<void>> sftp_result)
+            -> ErrorMessageOr<CanceledOr<std::filesystem::path>> {
+          if (sftp_result.has_error()) {
+            return ErrorMessage{absl::StrFormat("Could not copy module file from the remote: %s",
+                                                sftp_result.error().message())};
+          }
+          if (orbit_base::IsCanceled(sftp_result.value())) {
+            return orbit_base::Canceled{};
+          }
+          const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - copy_begin);
+          ORBIT_LOG("Copying \"%s\" took %.3f ms", module_id.file_path, duration.count());
+          return cache_path;
+        });
+  };
+
+  Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> download_future =
+      UnwrapFuture(thread_pool_->Schedule(std::move(download)));
+
+  symbol_files_currently_downloading_.emplace(
+      module_id.file_path, ModuleDownloadOperation{std::move(stop_source), download_future});
+  app_interface_->OnModuleListUpdated();
+  download_future.Then(main_thread_executor_,
+                       [this, module_file_path = module_id.file_path](
+                           const ErrorMessageOr<CanceledOr<std::filesystem::path>>& /*result*/) {
+                         symbol_files_currently_downloading_.erase(module_file_path);
+                         app_interface_->OnModuleListUpdated();
+                       });
+  return download_future;
+}
+
+Future<ErrorMessageOr<void>> SymbolLoader::LoadSymbols(const std::filesystem::path& symbols_path,
+                                                       const ModuleIdentifier& module_id) {
+  ORBIT_SCOPE_FUNCTION;
+
+  auto load_symbols_from_file_future = thread_pool_->Schedule(
+      [this, symbols_path, module_id]() -> ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> {
+        const ModuleData* module_data = app_interface_->GetModuleByModuleIdentifier(module_id);
+        orbit_object_utils::ObjectFileInfo object_file_info{module_data->load_bias()};
+        ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> symbols_or_error =
+            orbit_symbols::SymbolHelper::LoadSymbolsFromFile(symbols_path, object_file_info);
+        if (symbols_or_error.has_value()) return symbols_or_error;
+        return {ErrorMessage{absl::StrFormat("Could not load debug symbols from \"%s\": %s",
+                                             symbols_path.string(),
+                                             symbols_or_error.error().message())}};
+      });
+
+  auto add_symbols_future = load_symbols_from_file_future.ThenIfSuccess(
+      main_thread_executor_,
+      [this,
+       module_id](const orbit_grpc_protos::ModuleSymbols& symbols) mutable -> ErrorMessageOr<void> {
+        app_interface_->AddSymbols(module_id, symbols);
+        ORBIT_LOG("Successfully loaded %d symbols for \"%s\"", symbols.symbol_infos_size(),
+                  module_id.file_path);
+        return outcome::success();
+      });
+
+  return add_symbols_future;
+}
+
+Future<ErrorMessageOr<void>> SymbolLoader::LoadFallbackSymbols(
+    const std::filesystem::path& object_path, const ModuleIdentifier& module_id) {
+  ORBIT_SCOPE_FUNCTION;
+
+  auto load_fallback_symbols_future =
+      thread_pool_->Schedule([object_path]() -> ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> {
+        ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> fallback_symbols_or_error =
+            orbit_symbols::SymbolHelper::LoadFallbackSymbolsFromFile(object_path);
+        if (fallback_symbols_or_error.has_value()) return fallback_symbols_or_error;
+        return {ErrorMessage{
+            absl::StrFormat("Could not load symbols from dynamic linking and/or stack unwinding "
+                            "information as symbols from \"%s\": %s",
+                            object_path.string(), fallback_symbols_or_error.error().message())}};
+      });
+
+  auto add_fallback_symbols_future = load_fallback_symbols_future.ThenIfSuccess(
+      main_thread_executor_,
+      [this,
+       module_id](const orbit_grpc_protos::ModuleSymbols& symbols) mutable -> ErrorMessageOr<void> {
+        app_interface_->AddFallbackSymbols(module_id, symbols);
+        ORBIT_LOG("Successfully loaded %d fallback symbols for \"%s\"", symbols.symbol_infos_size(),
+                  module_id.file_path);
+        return outcome::success();
+      });
+
+  return add_fallback_symbols_future;
+}
+
+Future<ErrorMessageOr<std::filesystem::path>> SymbolLoader::RetrieveModuleWithDebugInfo(
+    const ModuleIdentifier& module_id) {
+  auto loaded_module = RetrieveModuleSymbols(module_id);
+  return loaded_module.ThenIfSuccess(
+      main_thread_executor_,
+      [this, module_path = module_id.file_path](
+          const CanceledOr<std::filesystem::path>& local_file_path_or_canceled)
+          -> ErrorMessageOr<std::filesystem::path> {
+        if (orbit_base::IsCanceled(local_file_path_or_canceled)) {
+          return ErrorMessage{"User canceled loading."};
+        }
+        const std::filesystem::path& local_file_path =
+            orbit_base::GetNotCanceled(local_file_path_or_canceled);
+
+        auto elf_file = orbit_object_utils::CreateElfFile(local_file_path);
+
+        if (elf_file.has_error()) return elf_file.error();
+
+        if (elf_file.value()->HasDebugInfo()) return local_file_path;
+
+        if (!elf_file.value()->HasGnuDebuglink()) {
+          return ErrorMessage{
+              absl::StrFormat("Module \"%s\" neither includes debug info, nor does it contain "
+                              "a .gnu_debuglink section which could refer to a separate debug "
+                              "info file.",
+                              module_path)};
+        }
+
+        const auto debuglink = elf_file.value()->GetGnuDebugLinkInfo().value();
+        ErrorMessageOr<std::filesystem::path> local_debuginfo_path =
+            symbol_helper_.FindDebugInfoFileLocally(debuglink.path.filename().string(),
+                                                    debuglink.crc32_checksum, GetAllSymbolPaths());
+        if (local_debuginfo_path.has_error()) {
+          return ErrorMessage{absl::StrFormat(
+              "Module \"%s\" doesn't include debug info, and a separate debuginfo file wasn't "
+              "found on this machine, when searching the folders from the Symbol Locations. Please "
+              "make sure that the debuginfo file can be found in one of the added folders. "
+              "According to the .gnu_debuglink section, the debuginfo file must be called \"%s\".",
+              module_path, debuglink.path.string())};
+        }
+
+        elf_file = orbit_object_utils::CreateElfFile(local_debuginfo_path.value());
+        if (elf_file.has_error()) return elf_file.error();
+        return local_debuginfo_path;
+      });
+}
+
+void SymbolLoader::RequestSymbolDownloadStop(const std::string& module_path) {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  if (symbol_files_currently_downloading_.contains(module_path)) {
+    symbol_files_currently_downloading_.at(module_path).stop_source.RequestStop();
+  }
+}
+
+bool SymbolLoader::IsModuleDownloading(const std::string& module_path) const {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  return symbol_files_currently_downloading_.contains(module_path);
+}
+
+orbit_data_views::SymbolLoadingState SymbolLoader::GetSymbolLoadingStateForModule(
+    const orbit_client_data::ModuleData* module) const {
+  ORBIT_CHECK(module != nullptr);
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+
+  if (IsModuleDownloading(module->file_path())) return SymbolLoadingState::kDownloading;
+
+  ModuleIdentifier module_id = module->module_id();
+  if (symbols_currently_loading_.contains(module_id)) {
+    return SymbolLoadingState::kLoading;
+  }
+
+  switch (module->GetLoadedSymbolsCompleteness()) {
+    case ModuleData::SymbolCompleteness::kNoSymbols:
+      break;
+    case ModuleData::SymbolCompleteness::kDynamicLinkingAndUnwindInfo:
+      return SymbolLoadingState::kFallback;
+    case ModuleData::SymbolCompleteness::kDebugSymbols:
+      return SymbolLoadingState::kLoaded;
+  }
+
+  if (download_disabled_modules_.contains(module->file_path())) {
+    return SymbolLoadingState::kDisabled;
+  }
+
+  if (modules_with_symbol_loading_error_.contains(module_id)) {
+    return SymbolLoadingState::kError;
+  }
+
+  return SymbolLoadingState::kUnknown;
+}
+
+bool SymbolLoader::IsSymbolLoadingInProgressForModule(
+    const orbit_symbol_provider::ModuleIdentifier& module_id) const {
+  ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
+  return symbols_currently_loading_.contains(module_id);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/SymbolLoader.h
+++ b/src/OrbitGl/SymbolLoader.h
@@ -50,7 +50,7 @@ class SymbolLoader {
                                     const orbit_grpc_protos::ModuleSymbols& fallback_symbols) = 0;
   };
 
-  SymbolLoader(SymbolLoader::AppInterface* app_interface, std::thread::id main_thread_id,
+  SymbolLoader(AppInterface* app_interface, std::thread::id main_thread_id,
                orbit_base::ThreadPool* thread_pool,
                orbit_base::MainThreadExecutor* main_thread_executor,
                orbit_client_services::ProcessManager* process_manager,
@@ -102,7 +102,7 @@ class SymbolLoader {
   RetrieveModuleFromInstance(const std::string& module_file_path, orbit_base::StopToken stop_token);
 
   // RetrieveModuleItselfAndLoadFallbackSymbols retrieves the module's binary by calling
-  // `RetrieveModuleItself` and afterwards load the fallback symbols by calling
+  // `RetrieveModuleItself` and afterwards loads the fallback symbols by calling
   // `LoadFallbackSymbols`.
   orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>
   RetrieveModuleItselfAndLoadFallbackSymbols(
@@ -120,7 +120,7 @@ class SymbolLoader {
       const std::filesystem::path& object_path,
       const orbit_symbol_provider::ModuleIdentifier& module_id);
 
-  SymbolLoader::AppInterface* app_interface_;
+  AppInterface* app_interface_;
   std::thread::id main_thread_id_;
   orbit_base::ThreadPool* thread_pool_;
   orbit_base::MainThreadExecutor* main_thread_executor_;

--- a/src/OrbitGl/SymbolLoader.h
+++ b/src/OrbitGl/SymbolLoader.h
@@ -1,0 +1,167 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_SYMBOL_LOADER_H_
+#define ORBIT_GL_SYMBOL_LOADER_H_
+
+#include <absl/container/flat_hash_set.h>
+
+#include <filesystem>
+
+#include "ClientData/ModuleData.h"
+#include "ClientServices/ProcessManager.h"
+#include "DataViews/SymbolLoadingState.h"
+#include "GrpcProtos/symbol.pb.h"
+#include "Http/HttpDownloadManager.h"
+#include "MetricsUploader/MetricsUploader.h"
+#include "OrbitBase/CanceledOr.h"
+#include "OrbitBase/Future.h"
+#include "OrbitBase/MainThreadExecutor.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/StopSource.h"
+#include "OrbitBase/ThreadPool.h"
+#include "OrbitGgp/Client.h"
+#include "OrbitPaths/Paths.h"
+#include "RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h"
+#include "RemoteSymbolProvider/StadiaSymbolStoreSymbolProvider.h"
+#include "SymbolProvider/ModuleIdentifier.h"
+#include "Symbols/SymbolHelper.h"
+
+namespace orbit_gl {
+
+class SymbolLoader {
+ public:
+  class AppInterface {
+   public:
+    virtual ~AppInterface() = default;
+
+    [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleByModuleIdentifier(
+        const orbit_symbol_provider::ModuleIdentifier& module_id) const = 0;
+    [[nodiscard]] virtual bool IsConnected() const = 0;
+    virtual orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>
+    DownloadFileFromInstance(std::filesystem::path path_on_instance,
+                             std::filesystem::path local_path,
+                             orbit_base::StopToken stop_token) = 0;
+    virtual void OnModuleListUpdated() = 0;
+    virtual void AddSymbols(const orbit_symbol_provider::ModuleIdentifier& module_id,
+                            const orbit_grpc_protos::ModuleSymbols& module_symbols) = 0;
+    virtual void AddFallbackSymbols(const orbit_symbol_provider::ModuleIdentifier& module_id,
+                                    const orbit_grpc_protos::ModuleSymbols& fallback_symbols) = 0;
+  };
+
+  SymbolLoader(SymbolLoader::AppInterface* app_interface, std::thread::id main_thread_id,
+               orbit_base::ThreadPool* thread_pool,
+               orbit_base::MainThreadExecutor* main_thread_executor,
+               orbit_client_services::ProcessManager* process_manager,
+               orbit_metrics_uploader::MetricsUploader* metrics_uploader);
+
+  // RetrieveModuleAndLoadSymbols tries to retrieve and load the module symbols by calling
+  // `RetrieveModuleSymbolsAndLoadSymbols`. If this fails, it falls back on
+  // `RetrieveModuleItselfAndLoadFallbackSymbols`.
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> RetrieveModuleAndLoadSymbols(
+      const orbit_client_data::ModuleData* module_data);
+
+  // This method is pretty similar to `RetrieveModuleSymbols`, but it also requires debug
+  // information to be present.
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleWithDebugInfo(
+      const orbit_symbol_provider::ModuleIdentifier& module_id);
+
+  void DisableDownloadForModule(const std::string& module_path);
+  void EnableDownloadForModules(const absl::flat_hash_set<std::string>& module_paths);
+
+  void RequestSymbolDownloadStop(const std::string& module_path);
+
+  [[nodiscard]] bool IsModuleDownloading(const std::string& module_path) const;
+  [[nodiscard]] orbit_data_views::SymbolLoadingState GetSymbolLoadingStateForModule(
+      const orbit_client_data::ModuleData* module) const;
+  [[nodiscard]] bool IsSymbolLoadingInProgressForModule(
+      const orbit_symbol_provider::ModuleIdentifier& module_id) const;
+
+ private:
+  struct ModuleDownloadOperation {
+    orbit_base::StopSource stop_source;
+    orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>> future;
+  };
+
+  void InitRemoteSymbolProviders();
+
+  // RetrieveModuleSymbolsAndLoadSymbols retrieves the module symbols by calling
+  // `RetrieveModuleSymbols` and afterwards loads the symbols by calling `LoadSymbols`.
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>
+  RetrieveModuleSymbolsAndLoadSymbols(const orbit_symbol_provider::ModuleIdentifier& module_id);
+  // RetrieveModuleSymbols retrieves a module file and returns the local file path (potentially from
+  // the local cache). Only modules with a .symtab section will be considered.
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
+  RetrieveModuleSymbols(const orbit_symbol_provider::ModuleIdentifier& module_id);
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> FindModuleLocally(
+      const orbit_client_data::ModuleData* module_data);
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
+  RetrieveModuleFromRemote(const orbit_symbol_provider::ModuleIdentifier& module_id);
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
+  RetrieveModuleFromInstance(const std::string& module_file_path, orbit_base::StopToken stop_token);
+
+  // RetrieveModuleItselfAndLoadFallbackSymbols retrieves the module's binary by calling
+  // `RetrieveModuleItself` and afterwards load the fallback symbols by calling
+  // `LoadFallbackSymbols`.
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>
+  RetrieveModuleItselfAndLoadFallbackSymbols(
+      const orbit_symbol_provider::ModuleIdentifier& module_id, uint64_t module_file_size);
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
+  RetrieveModuleItself(const orbit_symbol_provider::ModuleIdentifier& module_id,
+                       uint64_t module_file_size);
+  orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
+  RetrieveModuleItselfFromInstance(const orbit_symbol_provider::ModuleIdentifier& module_id);
+
+  orbit_base::Future<ErrorMessageOr<void>> LoadSymbols(
+      const std::filesystem::path& symbols_path,
+      const orbit_symbol_provider::ModuleIdentifier& module_id);
+  orbit_base::Future<ErrorMessageOr<void>> LoadFallbackSymbols(
+      const std::filesystem::path& object_path,
+      const orbit_symbol_provider::ModuleIdentifier& module_id);
+
+  SymbolLoader::AppInterface* app_interface_;
+  std::thread::id main_thread_id_;
+  orbit_base::ThreadPool* thread_pool_;
+  orbit_base::MainThreadExecutor* main_thread_executor_;
+  orbit_client_services::ProcessManager* process_manager_;
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
+
+  orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDirUnsafe()};
+
+  // TODO(b/243520787) The SymbolProvider related logic should be moved to the ProxySymbolProvider
+  //  as planned in our symbol refactoring discussion.
+  std::optional<orbit_http::HttpDownloadManager> download_manager_;
+  std::unique_ptr<orbit_ggp::Client> ggp_client_;
+  std::optional<orbit_remote_symbol_provider::StadiaSymbolStoreSymbolProvider>
+      stadia_symbol_provider_ = std::nullopt;
+  std::optional<orbit_remote_symbol_provider::MicrosoftSymbolServerSymbolProvider>
+      microsoft_symbol_provider_ = std::nullopt;
+
+  // Map of module file path to download operation future, that holds all symbol downloads that
+  // are currently in progress.
+  // ONLY access this from the main thread.
+  absl::flat_hash_map<std::string, ModuleDownloadOperation> symbol_files_currently_downloading_;
+
+  // Map of "module ID" (file path and build ID) to symbol loading future, that holds all symbol
+  // loading operations that are currently in progress. Since downloading a file can be part of the
+  // overall symbol loading process, if a module ID is contained in
+  // symbol_files_currently_downloading_, it is also contained in symbols_currently_loading_.
+  // ONLY access this from the main thread.
+  absl::flat_hash_map<orbit_symbol_provider::ModuleIdentifier,
+                      orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>>
+      symbols_currently_loading_;
+
+  // Set of modules where a symbol loading error has occurred. The module identifier consists of
+  // file path and build ID.
+  // ONLY access this from the main thread.
+  absl::flat_hash_set<orbit_symbol_provider::ModuleIdentifier> modules_with_symbol_loading_error_;
+
+  // Set of modules for which the download is disabled.
+  // ONLY access this from the main thread.
+  absl::flat_hash_set<std::string> download_disabled_modules_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_SYMBOL_LOADER_H_

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -2032,11 +2032,8 @@ orbit_base::CanceledOr<void> OrbitMainWindow::DisplayStopDownloadDialog(
     case Result::kStopAndDisable: {
       metrics_uploader_->SendLogEvent(
           orbit_metrics_uploader::OrbitLogEvent::ORBIT_SYMBOL_DOWNLOAD_DISABLED_BY_USER);
-      orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
-      absl::flat_hash_set<std::string> disabled_modules = storage_manager.LoadDisabledModulePaths();
-      disabled_modules.emplace(module->file_path());
-      storage_manager.SaveDisabledModulePaths(disabled_modules);
-      [[fallthrough]];
+      app_->DisableDownloadForModule(module->file_path());
+      break;
     }
     case Result::kStop:
       break;


### PR DESCRIPTION
The main goal is to reduce the size of `OrbitApp`. `OrbitApp` now uses the new
`SymbolLoader`, which calls into `OrbitApp` through the
`SymbolLoader::AppInterface` interface.
A couple of extra methods need to be added to `OrbitApp` for the communication
between `SymbolLoader` and `OrbitMainWindow`.

Test: Auto symbol loading on Trata and locally. Also try manual loading for
errors (rather, "Partial" cases) and try stopping the download of a module.