### PR TITLE
Clean up label inside Button class

### DIFF
--- a/src/OrbitGl/AccessibleButton.h
+++ b/src/OrbitGl/AccessibleButton.h
@@ -17,7 +17,7 @@ class AccessibleButton : public AccessibleCaptureViewElement {
         button_(button) {
     ORBIT_CHECK(button_ != nullptr);
   }
-  [[nodiscard]] std::string AccessibleName() const override { return button_->GetLabel(); }
+  [[nodiscard]] std::string AccessibleName() const override { return button_->GetName(); }
 
  private:
   const Button* button_;

--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -29,9 +29,9 @@ constexpr float kGradientFactor = 0.25f;
 namespace orbit_gl {
 
 Button::Button(CaptureViewElement* parent, const Viewport* viewport, const TimeGraphLayout* layout,
-               std::string label, SymbolType symbol_type)
+               std::string name, SymbolType symbol_type)
     : CaptureViewElement(parent, viewport, layout),
-      label_(std::move(label)),
+      name_(std::move(name)),
       symbol_type_{symbol_type} {
   SetWidth(layout->GetMinButtonSize());
   SetHeight(layout->GetMinButtonSize());
@@ -54,13 +54,6 @@ void Button::SetHeight(float height) {
 
   height_ = height;
   RequestUpdate();
-}
-
-void Button::SetLabel(const std::string& label) {
-  if (label_ == label) return;
-
-  label_ = label;
-  RequestUpdate(RequestUpdateScope::kDraw);
 }
 
 void Button::SetMouseReleaseCallback(MouseReleaseCallback callback) {

--- a/src/OrbitGl/Button.h
+++ b/src/OrbitGl/Button.h
@@ -18,7 +18,7 @@ class Button : public CaptureViewElement, public std::enable_shared_from_this<Bu
  public:
   enum class SymbolType { kNoSymbol, kPlusSymbol, kMinusSymbol };
   explicit Button(CaptureViewElement* parent, const Viewport* viewport,
-                  const TimeGraphLayout* layout, std::string label = "",
+                  const TimeGraphLayout* layout, std::string name = "",
                   SymbolType symbol_type = SymbolType::kNoSymbol);
 
   [[nodiscard]] float GetHeight() const override { return height_; }
@@ -26,8 +26,7 @@ class Button : public CaptureViewElement, public std::enable_shared_from_this<Bu
 
   void SetHeight(float height);
 
-  void SetLabel(const std::string& label);
-  [[nodiscard]] const std::string& GetLabel() const { return label_; }
+  [[nodiscard]] const std::string& GetName() const { return name_; }
 
   using MouseReleaseCallback = std::function<void(Button*)>;
   void SetMouseReleaseCallback(MouseReleaseCallback callback);
@@ -47,7 +46,7 @@ class Button : public CaptureViewElement, public std::enable_shared_from_this<Bu
   CreateAccessibleInterface() override;
 
   float height_ = 0.f;
-  std::string label_;
+  std::string name_;
   SymbolType symbol_type_;
 
   MouseReleaseCallback mouse_release_callback_ = nullptr;

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -64,19 +64,13 @@ TEST(Button, SizeCannotBeZero) {
   EXPECT_EQ(button->GetHeight(), tester.GetLayout()->GetMinButtonSize());
 }
 
-TEST(Button, LabelWorksAsExpected) {
+TEST(Button, NameWorksAsExpected) {
   orbit_gl::CaptureViewElementTester tester;
+  const std::string kName = "UnitTest";
   std::shared_ptr<Button> button =
-      std::make_shared<Button>(nullptr, tester.GetViewport(), tester.GetLayout());
+      std::make_shared<Button>(nullptr, tester.GetViewport(), tester.GetLayout(), kName);
 
-  tester.SimulateDrawLoopAndCheckFlags(button.get(), true, true);
-
-  const std::string kLabel = "UnitTest";
-  button->SetLabel(kLabel);
-
-  tester.SimulateDrawLoopAndCheckFlags(button.get(), true, false);
-
-  EXPECT_EQ(button->GetLabel(), kLabel);
+  EXPECT_EQ(button->GetName(), kName);
 }
 
 TEST(Button, MouseReleaseCallback) {
@@ -113,7 +107,6 @@ TEST(Button, Rendering) {
   std::shared_ptr<Button> button =
       std::make_shared<Button>(nullptr, tester.GetViewport(), tester.GetLayout());
 
-  button->SetLabel("Test");
   const Vec2 kSize(400, 50);
   const Vec2 kPos(10, 10);
   button->SetWidth(kSize[0]);


### PR DESCRIPTION
It was used to print a label inside the button but it's not used anymore, so it's replaced by name_ that is just used in the AccessibleButton class.

I also erased SetLabel/Name method and updated the test accordingly.

Test: Unit-Test.
Bug: http://b/237983090