### PR TITLE
Fix std::forward of callables under loops

### DIFF
--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -57,7 +57,7 @@ class CallstackData {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
       for (const auto& [unused_timestamp, event] : events) {
-        std::invoke(std::forward<Action>(action), event);
+        std::invoke(action, event);
       }
     }
   }
@@ -70,7 +70,7 @@ class CallstackData {
     for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
       for (auto event_it = events.lower_bound(min_timestamp);
            event_it != events.upper_bound(max_timestamp); ++event_it) {
-        std::invoke(std::forward<Action>(action), event_it->second);
+        std::invoke(action, event_it->second);
       }
     }
   }
@@ -87,7 +87,7 @@ class CallstackData {
     const auto& events = tid_and_events_it->second;
     for (auto event_it = events.lower_bound(min_timestamp);
          event_it != events.upper_bound(max_timestamp); ++event_it) {
-      std::invoke(std::forward<Action>(action), event_it->second);
+      std::invoke(action, event_it->second);
     }
   }
 
@@ -109,7 +109,7 @@ class CallstackData {
   void ForEachUniqueCallstack(Action&& action) const {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     for (const auto& [callstack_id, callstack_ptr] : unique_callstacks_) {
-      std::invoke(std::forward<Action>(action), callstack_id, *callstack_ptr);
+      std::invoke(action, callstack_id, *callstack_ptr);
     }
   }
 

--- a/src/MizarBase/include/MizarBase/AbsoluteAddress.h
+++ b/src/MizarBase/include/MizarBase/AbsoluteAddress.h
@@ -18,7 +18,7 @@ using AbsoluteAddress = orbit_base::Typedef<AbsoluteAddressTag, const uint64_t>;
 template <typename Action>
 inline void ForEachFrame(const std::vector<uint64_t>& frames, Action&& action) {
   for (const uint64_t raw_address : frames) {
-    std::invoke(std::forward<Action>(action), AbsoluteAddress(raw_address));
+    std::invoke(action, AbsoluteAddress(raw_address));
   }
 }
 

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -127,7 +127,7 @@ class MizarPairedDataTmpl {
       const orbit_client_data::CallstackInfo* callstack =
           GetCallstackData().GetCallstack(event.callstack_id());
       const std::vector<SFID> sfids = CallstackWithSFIDs(callstack);
-      std::invoke(std::forward<Action>(action), sfids);
+      std::invoke(action, sfids);
     };
 
     const auto [min_timestamp_ns, max_timestamp_ns] =

--- a/src/ObjectUtils/PdbFileDia.cpp
+++ b/src/ObjectUtils/PdbFileDia.cpp
@@ -135,7 +135,7 @@ ErrorMessageOr<void> ForEachSymbolWithSymTag(const enum SymTagEnum& sym_tag,
 
   while (SUCCEEDED(dia_enum_symbols->Next(1, &dia_symbol, &celt)) && (celt == 1)) {
     CComPtr<IDiaSymbol> dia_symbol_com_ptr = dia_symbol;
-    std::invoke(std::forward<Consumer>(consumer), dia_symbol);
+    std::invoke(consumer, dia_symbol);
   }
 
   return outcome::success();


### PR DESCRIPTION
This is meaningless and potentially dangerous in case of a stealing `operator() &&`

Test: Manual, Compile, Unit
Bug: http://b/253203508