### PR TITLE
Optimize Callstack Thread Bar by only rendering one per pixel

### DIFF
--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -104,6 +104,7 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
   float z = GlCanvas::kZValueEvent;
   float track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const bool picking = picking_mode != PickingMode::kNone;
+  uint32_t resolution_in_pixels = viewport_->WorldToScreen({GetWidth(), 0})[0];
 
   const Color kWhite(255, 255, 255, 255);
   const Color kGreenSelection(0, 255, 0, 255);
@@ -125,11 +126,11 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
     };
 
     if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
-      capture_data_->GetCallstackData().ForEachCallstackEventInTimeRange(
-          min_tick, max_tick, action_on_callstack_events);
+      capture_data_->GetCallstackData().ForEachCallstackEventInTimeRangeDiscretized(
+          min_tick, max_tick, resolution_in_pixels, action_on_callstack_events);
     } else {
-      capture_data_->GetCallstackData().ForEachCallstackEventOfTidInTimeRange(
-          GetThreadId(), min_tick, max_tick, action_on_callstack_events);
+      capture_data_->GetCallstackData().ForEachCallstackEventOfTidInTimeRangeDiscretized(
+          GetThreadId(), min_tick, max_tick, resolution_in_pixels, action_on_callstack_events);
     }
 
     // Draw selected callstack samples.


### PR DESCRIPTION
In this PR we are following the plan designed in
go/stadia-orbit-rendering-60fps for CallstackThreadBar.

We are basically going through pixels instead of all the callstacks. The new methods were renamed by adding "Discretized", I'm not sure if this is the best name but I wanted to be consistent with the optimization in SchedulerTrack and ThreadTrack.

Just because these modified lines, in the 5-min capture presented in the design doc we are archieving around 2.5x improvement overall (measured in Linux, from 750ms to 300ms):
Before: http://screenshot/7edKS46zphJVxAL
After: http://screenshot/3qsQLTqLqZXUjgs

Bug: http://b/253414641.
Test: Load 5 min capture.