### PR TITLE
Remove GRPC Server Reflection Plugin

### DIFF
--- a/src/OrbitCaptureGgpService/OrbitCaptureGgpService.cpp
+++ b/src/OrbitCaptureGgpService/OrbitCaptureGgpService.cpp
@@ -5,7 +5,6 @@
 #include "OrbitCaptureGgpService.h"
 
 #include <absl/strings/str_format.h>
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/security/server_credentials.h>
@@ -26,7 +25,6 @@ void OrbitCaptureGgpService::RunServer() {
   CaptureClientGgpServiceImpl ggp_capture_service;
 
   grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 
   ORBIT_LOG("Starting gRPC capture ggp server at %s", server_address);
   ServerBuilder builder;

--- a/src/Service/OrbitGrpcServer.cpp
+++ b/src/Service/OrbitGrpcServer.cpp
@@ -4,7 +4,6 @@
 
 #include "OrbitGrpcServer.h"
 
-#include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/security/server_credentials.h>
@@ -67,7 +66,6 @@ class OrbitGrpcServerImpl final : public OrbitGrpcServer {
 
 bool OrbitGrpcServerImpl::Init(std::string_view server_address, bool dev_mode) {
   grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 
   grpc::ServerBuilder builder;
 


### PR DESCRIPTION
The reflection plugin allows listing available RPCs on a client. We don't need that and it complicates the build because it requires us linking against `libgrpc++_reflection` which is not available on all systems.

Test: Tried profiling manually. 