### PR TITLE
Fix GCC build by disabling some warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,11 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
                       -Werror=old-style-cast
                       -Werror=unused-parameter
                       -Werror=unused-variable
-                      -Werror=sign-compare)
+                      -Werror=sign-compare
+                      # These seem to be buggy in GCC 11 and 12:
+                      -Wno-maybe-uninitialized
+                      -Wno-uninitialized
+                      -Wno-stringop-overflow)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
These warnings seems to trigger even though there is no problem, so we can't have them treated as errors. The problems seems to be fixed in trunk, but for now let's just disable them.