### PR TITLE
Replace libprotobuf-mutator conan package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ find_package(Threads REQUIRED)
 find_package(xxHash REQUIRED)
 find_package(concurrentqueue REQUIRED)
 find_package(gte REQUIRED)
+find_package(libprotobuf-mutator REQUIRED)
 
 if(WITH_GUI)
   find_package(OpenGL REQUIRED)

--- a/cmake/Findlibprotobuf-mutator.cmake
+++ b/cmake/Findlibprotobuf-mutator.cmake
@@ -1,0 +1,26 @@
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+add_library(libprotobuf-mutator STATIC)
+
+set(DIR "${CMAKE_SOURCE_DIR}/third_party/libprotobuf-mutator")
+target_include_directories(libprotobuf-mutator SYSTEM PUBLIC "${DIR}" "${DIR}/src/")
+target_sources(libprotobuf-mutator PRIVATE
+  ${DIR}/src/binary_format.cc
+  ${DIR}/src/mutator.cc
+  ${DIR}/src/text_format.cc
+  ${DIR}/src/utf8_fix.cc
+  ${DIR}/src/libfuzzer/libfuzzer_macro.cc
+  ${DIR}/src/libfuzzer/libfuzzer_mutator.cc
+)
+
+if(NOT MSVC)
+  target_compile_options(libprotobuf-mutator PRIVATE
+    -Wno-error=unused-parameter
+  )
+endif()
+
+target_link_libraries(libprotobuf-mutator PRIVATE CONAN_PKG::protobuf)
+
+add_library(libprotobuf-mutator::libprotobuf-mutator ALIAS libprotobuf-mutator)

--- a/conanfile.py
+++ b/conanfile.py
@@ -73,11 +73,9 @@ class OrbitConan(ConanFile):
         self.requires("grpc/1.27.3@{}".format(self._orbit_channel))
         self.requires("c-ares/1.15.0", override=True)
         self.requires("llvm-core/12.0.0@{}".format(self._orbit_channel))
-        self.requires("lzma_sdk/19.00@orbitdeps/stable#a7bc173325d7463a0757dee5b08bf7fd", override=True)
+        self.requires("lzma_sdk/19.00@orbitdeps/stable#a7bc173325d7463a0757dee5b08bf7fd")
         self.requires("openssl/1.1.1k", override=True)
         self.requires("outcome/2.2.0")
-        self.requires(
-            "libprotobuf-mutator/20200506@{}#90ce749ca62b40e9c061d20fae4410e0".format(self._orbit_channel))
         if self.settings.os != "Windows":
             self.requires(
                 "libunwindstack-android-dependencies/20210709@{}".format(self._orbit_channel))

--- a/src/FuzzingUtils/CMakeLists.txt
+++ b/src/FuzzingUtils/CMakeLists.txt
@@ -9,4 +9,4 @@ target_sources(FuzzingUtils INTERFACE
         include/FuzzingUtils/ProtoFuzzer.h
         include/FuzzingUtils/Fuzzer.h)
 target_include_directories(FuzzingUtils INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-target_link_libraries(FuzzingUtils INTERFACE OrbitBase CONAN_PKG::libprotobuf-mutator)
+target_link_libraries(FuzzingUtils INTERFACE OrbitBase libprotobuf-mutator::libprotobuf-mutator)


### PR DESCRIPTION
This uses the internal copy in third_party instead of the conan package which we want to get rid of.