### PR TITLE
Make Android base libraries compile with non-clang compilers

### DIFF
--- a/third_party/libbase/include/android-base/silent_death_test.h
+++ b/third_party/libbase/include/android-base/silent_death_test.h
@@ -34,7 +34,8 @@ class SilentDeathTest : public testing::Test {
   virtual void SetUp() {
     // Suppress debuggerd stack traces. Too slow.
     for (int signo : {SIGABRT, SIGBUS, SIGSEGV, SIGSYS}) {
-      struct sigaction64 action = {.sa_handler = SIG_DFL};
+      struct sigaction64 action = {};
+      action.sa_handler = SIG_DFL;
       sigaction64(signo, &action, &previous_);
     }
   }

--- a/third_party/libbase/logging.cpp
+++ b/third_party/libbase/logging.cpp
@@ -58,6 +58,10 @@
 
 #include "logging_splitters.h"
 
+#ifndef __clang__
+#define __builtin_available(arg1,arg2) false
+#endif
+
 namespace android {
 namespace base {
 
@@ -310,6 +314,7 @@ void DefaultAborter(const char* abort_message) {
   abort();
 }
 
+#ifdef __ANDROID__
 static void LogdLogChunk(LogId id, LogSeverity severity, const char* tag, const char* message) {
   int32_t lg_id = LogIdTolog_id_t(id);
   int32_t priority = LogSeverityToPriority(severity);
@@ -333,6 +338,7 @@ void LogdLogger::operator()(LogId id, LogSeverity severity, const char* tag, con
 
   SplitByLogdChunks(id, severity, tag, file, line, message, LogdLogChunk);
 }
+#endif
 
 void InitLogging(char* argv[], LogFunction&& logger, AbortFunction&& aborter) {
   SetLogger(std::forward<LogFunction>(logger));

--- a/third_party/liblog/logger.h
+++ b/third_party/liblog/logger.h
@@ -16,7 +16,12 @@
 
 #pragma once
 
+#ifdef __cplusplus
+#include <atomic>
+using std::atomic_int;
+#else
 #include <stdatomic.h>
+#endif
 #include <sys/cdefs.h>
 
 #include <log/log.h>


### PR DESCRIPTION
These are the changes we had previously applied as well to the Android base libraries. I'm adding them now as a separate commit such that we can distinguish them from the original code.

The patches come from `third_party/conan/recipes/libunwindstack-android-dependencies/patches`.