### PR TITLE
Use imported copy of Abseil

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ find_package(concurrentqueue REQUIRED)
 find_package(gte REQUIRED)
 find_package(libprotobuf-mutator REQUIRED)
 find_package(LZMA REQUIRED)
+find_package(absl REQUIRED)
 
 if(WITH_GUI)
   find_package(OpenGL REQUIRED)

--- a/cmake/Findabsl.cmake
+++ b/cmake/Findabsl.cmake
@@ -1,0 +1,46 @@
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set(ABSL_PROPAGATE_CXX_STD ON)
+add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/abseil-cpp)
+
+if(NOT MSVC)
+  target_compile_options(absl_exponential_biased PRIVATE
+    -Wno-error=float-conversion
+  )
+
+  target_compile_options(absl_log_internal_conditions PRIVATE
+    -Wno-error=float-conversion
+  )
+
+  target_compile_options(absl_malloc_internal PRIVATE
+    -Wno-error=old-style-cast
+  )
+
+  target_compile_options(absl_time_zone PRIVATE
+    -Wno-error=format-nonliteral
+  )
+
+  target_compile_options(absl_stacktrace PRIVATE
+    -Wno-error=old-style-cast
+    -Wno-error=format-nonliteral
+  )
+
+  target_compile_options(absl_strings PRIVATE
+    -Wno-error=float-conversion
+  )
+
+  target_compile_options(absl_str_format_internal PRIVATE
+    -Wno-error=float-conversion
+    -Wno-error=format-nonliteral
+  )
+
+  target_compile_options(absl_time PRIVATE
+    -Wno-error=float-conversion
+  )
+
+  target_compile_options(absl_symbolize PRIVATE
+    -Wno-error=old-style-cast
+  )
+endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,7 +20,7 @@ class OrbitConan(ConanFile):
     url = "https://github.com/pierricgimmig/orbitprofiler.git"
     description = "C/C++ Performance Profiler"
     settings = "os", "compiler", "build_type", "arch"
-    generators = ["cmake_multi"]
+    generators = ["cmake_multi", "CMakeDeps"]
     options = {"system_qt": [True, False], "with_gui": [True, False],
                "fPIC": [True, False],
                "run_tests": [True, False],

--- a/src/CaptureEventProducer/CMakeLists.txt
+++ b/src/CaptureEventProducer/CMakeLists.txt
@@ -21,7 +21,8 @@ target_link_libraries(CaptureEventProducer PUBLIC
         OrbitBase
         OrbitServiceLib
         concurrentqueue::concurrentqueue
-        CONAN_PKG::abseil)
+        absl::time
+        absl::synchronization)
 
 add_executable(CaptureEventProducerTests)
 

--- a/src/CaptureFile/CMakeLists.txt
+++ b/src/CaptureFile/CMakeLists.txt
@@ -51,7 +51,8 @@ target_link_libraries(
   CaptureFileTests
   PRIVATE CaptureFile
           TestUtils
-          GTest::Main
-          CONAN_PKG::abseil)
+          absl::base
+          absl::synchronization
+          GTest::Main)
 
 register_test(CaptureFileTests)

--- a/src/ClientFlags/CMakeLists.txt
+++ b/src/ClientFlags/CMakeLists.txt
@@ -14,4 +14,4 @@ target_include_directories(ClientFlags PUBLIC
 
 target_compile_options(ClientFlags PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(ClientFlags PUBLIC cxx_std_17)
-target_link_libraries(ClientFlags PUBLIC CONAN_PKG::abseil)
+target_link_libraries(ClientFlags PUBLIC absl::flags)

--- a/src/ClientSymbols/CMakeLists.txt
+++ b/src/ClientSymbols/CMakeLists.txt
@@ -9,7 +9,10 @@ add_library(ClientSymbols STATIC)
 
 target_include_directories(ClientSymbols PUBLIC include/)
 target_link_libraries(ClientSymbols PUBLIC 
-        CONAN_PKG::abseil        
+        absl::flat_hash_map
+        absl::flat_hash_set
+        absl::hash
+        absl::span
         Qt5::Core)
 
 target_sources(ClientSymbols PUBLIC 

--- a/src/CodeReport/CMakeLists.txt
+++ b/src/CodeReport/CMakeLists.txt
@@ -12,7 +12,8 @@ target_link_libraries(CodeReport PUBLIC OrbitBase
                                         ClientData
                                         GrpcProtos
                                         ObjectUtils
-                                        CONAN_PKG::abseil
+                                        absl::flat_hash_map
+                                        absl::strings
                                         CONAN_PKG::capstone)
 
 target_sources(CodeReport PUBLIC include/CodeReport/AnnotateDisassembly.h

--- a/src/CommandLineUtils/CMakeLists.txt
+++ b/src/CommandLineUtils/CMakeLists.txt
@@ -16,7 +16,7 @@ target_sources(
   PRIVATE include/CommandLineUtils/CommandLineUtils.h
 )
 
-target_link_libraries(CommandLineUtils PUBLIC Qt5::Core ClientFlags CONAN_PKG::abseil)
+target_link_libraries(CommandLineUtils PUBLIC Qt5::Core ClientFlags absl::flags absl::flat_hash_set)
 target_include_directories(CommandLineUtils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_executable(CommandLineUtilsTests)

--- a/src/ConfigWidgets/CMakeLists.txt
+++ b/src/ConfigWidgets/CMakeLists.txt
@@ -14,7 +14,9 @@ target_link_libraries(ConfigWidgets PUBLIC ClientData
                                            ClientSymbols
                                            OrbitBase
                                            SourcePathsMapping
-                                           CONAN_PKG::abseil
+                                           absl::flags
+                                           absl::flat_hash_set
+                                           absl::str_format
                                            Qt5::Core
                                            Qt5::Gui
                                            Qt5::Widgets)

--- a/src/DataViews/CMakeLists.txt
+++ b/src/DataViews/CMakeLists.txt
@@ -47,7 +47,12 @@ target_link_libraries(DataViews PUBLIC
         QtUtils
         Statistics
         SymbolProvider
-        CONAN_PKG::abseil)
+        absl::flags
+        absl::flat_hash_map
+        absl::span
+        absl::strings
+        absl::str_format
+        absl::time)
 
 add_executable(DataViewsTests)
 target_sources(DataViewsTests PRIVATE CallstackDataViewTest.cpp

--- a/src/DisplayFormats/CMakeLists.txt
+++ b/src/DisplayFormats/CMakeLists.txt
@@ -18,7 +18,8 @@ target_sources(DisplayFormats PRIVATE
 
 target_link_libraries(DisplayFormats PUBLIC
         OrbitBase
-        CONAN_PKG::abseil)
+        absl::str_format
+        absl::time)
 
 
 add_executable(DisplayFormatsTests)

--- a/src/FakeClient/CMakeLists.txt
+++ b/src/FakeClient/CMakeLists.txt
@@ -15,7 +15,6 @@ target_sources(OrbitFakeClient PRIVATE
         GraphicsCaptureEventProcessor.h)
 
 target_link_libraries(OrbitFakeClient PRIVATE
-        CONAN_PKG::abseil
         ApiUtils
         CaptureClient
         ClientData
@@ -24,6 +23,12 @@ target_link_libraries(OrbitFakeClient PRIVATE
         ModuleUtils
         ObjectUtils
         OrbitBase
-        SymbolProvider)
+        SymbolProvider
+        absl::flags
+        absl::flags_usage
+        absl::flags_parse
+        absl::flat_hash_map
+        absl::strings
+        absl::time)
 
 strip_symbols(OrbitFakeClient)

--- a/src/FramePointerValidator/CMakeLists.txt
+++ b/src/FramePointerValidator/CMakeLists.txt
@@ -25,7 +25,6 @@ target_sources(FramePointerValidator PRIVATE
 target_link_libraries(FramePointerValidator PUBLIC
         GrpcProtos
         OrbitBase
-        CONAN_PKG::abseil
         CONAN_PKG::capstone)
 
 add_executable(FramePointerValidatorTests)
@@ -39,7 +38,6 @@ target_link_libraries(FramePointerValidatorTests PRIVATE
         ObjectUtils
         OrbitBase
         GTest::Main
-        CONAN_PKG::abseil
         CONAN_PKG::capstone)
 
 register_test(FramePointerValidatorTests)

--- a/src/Introspection/CMakeLists.txt
+++ b/src/Introspection/CMakeLists.txt
@@ -31,6 +31,8 @@ target_link_libraries(IntrospectionTests PRIVATE
         Introspection
         OrbitBase
         GTest::Main
-        CONAN_PKG::abseil)
+        absl::base
+        absl::flat_hash_map
+        absl::synchronization)
 
 register_test(IntrospectionTests)

--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -71,7 +71,12 @@ target_link_libraries(LinuxTracing PUBLIC
         ModuleUtils
         ObjectUtils
         OrbitBase
-        CONAN_PKG::abseil)
+        absl::flat_hash_map
+        absl::flat_hash_set
+        absl::meta
+        absl::str_format
+        absl::strings
+        absl::synchronization)
 
 add_executable(LinuxTracingTests)
 

--- a/src/LinuxTracingIntegrationTests/CMakeLists.txt
+++ b/src/LinuxTracingIntegrationTests/CMakeLists.txt
@@ -39,7 +39,11 @@ target_link_libraries(IntegrationTestCommons PUBLIC
         OrbitBase
         OffscreenRenderingVulkanTutorialLib
         GTest::GTest
-        CONAN_PKG::abseil)
+        absl::base
+        absl::time
+        absl::flat_hash_set
+        absl::strings
+        absl::synchronization)
 
 
 add_executable(LinuxTracingIntegrationTests)
@@ -55,7 +59,11 @@ target_link_libraries(LinuxTracingIntegrationTests PRIVATE
         OrbitBase
         GTest::GTest
         GTest::Main
-        CONAN_PKG::abseil)
+        absl::base
+        absl::time
+        absl::flat_hash_set
+        absl::strings
+        absl::synchronization)
 
 strip_symbols(LinuxTracingIntegrationTests)
 
@@ -80,7 +88,11 @@ target_link_libraries(OrbitServiceIntegrationTests PRIVATE
         OrbitVersion
         GTest::GTest
         GTest::Main
-        CONAN_PKG::abseil)
+        absl::base
+        absl::time
+        absl::flat_hash_set
+        absl::strings
+        absl::synchronization)
 
 strip_symbols(OrbitServiceIntegrationTests)
 

--- a/src/MemoryTracing/CMakeLists.txt
+++ b/src/MemoryTracing/CMakeLists.txt
@@ -26,7 +26,11 @@ target_sources(MemoryTracing PRIVATE
 target_link_libraries(MemoryTracing PUBLIC
         GrpcProtos
         OrbitBase
-        CONAN_PKG::abseil)
+        absl::flat_hash_map
+        absl::time
+        absl::str_format
+        absl::strings
+        absl::synchronization)
 
 add_executable(MemoryTracingTests)
 

--- a/src/Mizar/CMakeLists.txt
+++ b/src/Mizar/CMakeLists.txt
@@ -27,4 +27,6 @@ target_link_libraries(Mizar
         MizarWidgets
         OrbitBase
         Threads::Threads
+        absl::flags
+        absl::flags_parse
 )

--- a/src/ModuleUtils/CMakeLists.txt
+++ b/src/ModuleUtils/CMakeLists.txt
@@ -32,7 +32,8 @@ target_link_libraries(ModuleUtils PUBLIC
         GrpcProtos
         ObjectUtils
         OrbitBase
-        CONAN_PKG::abseil)
+        absl::str_format
+        absl::strings)
 
 add_executable(ModuleUtilsTests)
 
@@ -48,7 +49,6 @@ endif()
 target_link_libraries(ModuleUtilsTests PRIVATE
         ModuleUtils
         TestUtils
-        GTest::Main
-        CONAN_PKG::abseil)
+        GTest::Main)
 
 register_test(ModuleUtilsTests)

--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -46,7 +46,15 @@ target_link_libraries(
   PUBLIC GrpcProtos
          OrbitBase
          Introspection
-         CONAN_PKG::abseil
+         absl::base
+         absl::flat_hash_map
+         absl::flat_hash_set
+         absl::memory
+         absl::str_format
+         absl::strings
+         absl::synchronization
+         absl::time
+         absl::span
          CONAN_PKG::llvm-core)
 
 if (WIN32)
@@ -77,8 +85,7 @@ target_link_libraries(
   PRIVATE ObjectUtils
           TestUtils
           GTest::Main
-          CONAN_PKG::llvm-core
-          CONAN_PKG::abseil)
+          CONAN_PKG::llvm-core)
 
 register_test(ObjectUtilsTests)
 

--- a/src/Orbit/CMakeLists.txt
+++ b/src/Orbit/CMakeLists.txt
@@ -15,7 +15,10 @@ target_link_libraries(Orbit PRIVATE
         ClientFlags
         CommandLineUtils
         OrbitQt
-        Style)
+        Style
+        absl::flags
+        absl::flags_parse
+        absl::flags_usage)
 target_include_directories(Orbit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(WIN32)

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -95,8 +95,13 @@ target_sources(OrbitBase PRIVATE
 endif()
 
 target_link_libraries(OrbitBase PUBLIC
-        CONAN_PKG::abseil
         CONAN_PKG::outcome
+        absl::base
+        absl::flat_hash_map
+        absl::strings
+        absl::str_format
+        absl::synchronization
+        absl::time
         std::filesystem)
 
 add_executable(OrbitBaseTests)

--- a/src/OrbitCaptureGgpClient/CMakeLists.txt
+++ b/src/OrbitCaptureGgpClient/CMakeLists.txt
@@ -25,6 +25,7 @@ project(OrbitCaptureGgpClient)
 add_executable(OrbitCaptureGgpClient main.cpp)
 
 target_link_libraries(OrbitCaptureGgpClient PRIVATE 
-    OrbitCaptureGgpClientLib)
+    OrbitCaptureGgpClientLib
+    absl::flags_parse)
 
 strip_symbols(OrbitCaptureGgpClient)

--- a/src/OrbitCaptureGgpService/CMakeLists.txt
+++ b/src/OrbitCaptureGgpService/CMakeLists.txt
@@ -19,5 +19,8 @@ target_sources(OrbitCaptureGgpService PRIVATE
 target_link_libraries(OrbitCaptureGgpService PUBLIC
         GrpcProtos
         OrbitBase
-        OrbitClientGgpLib)
+        OrbitClientGgpLib
+        absl::flags
+        absl::flags_parse
+        absl::flags_usage)
 

--- a/src/OrbitClientGgp/CMakeLists.txt
+++ b/src/OrbitClientGgp/CMakeLists.txt
@@ -34,6 +34,9 @@ project(OrbitClientGgp)
 add_executable(OrbitClientGgp main.cpp)
 
 target_link_libraries(OrbitClientGgp PRIVATE 
-    OrbitClientGgpLib)
+    OrbitClientGgpLib
+    absl::flags
+    absl::flags_parse
+    absl::flags_usage)
 
 strip_symbols(OrbitClientGgp)

--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -34,6 +34,10 @@ target_link_libraries(
   OrbitGgp
   PRIVATE OrbitBase
           QtUtils
+          absl::flags
+          absl::str_format
+          absl::strings
+          absl::time
           Qt5::Core
 )
 

--- a/src/OrbitPaths/CMakeLists.txt
+++ b/src/OrbitPaths/CMakeLists.txt
@@ -19,7 +19,8 @@ target_sources(OrbitPaths PRIVATE
 
 target_link_libraries(OrbitPaths PUBLIC
         OrbitBase
-        CONAN_PKG::abseil)
+        absl::flags
+        absl::str_format)
 
 add_executable(OrbitPathsTests)
 

--- a/src/OrbitSshQt/CMakeLists.txt
+++ b/src/OrbitSshQt/CMakeLists.txt
@@ -38,7 +38,8 @@ target_link_libraries(OrbitSshQt PUBLIC
         OrbitSsh
         Qt5::Core
         Qt5::Network
-        CONAN_PKG::abseil)
+        absl::base
+        absl::str_format)
 set_target_properties(OrbitSshQt PROPERTIES AUTOMOC ON)
 
 add_executable(OrbitSshQtIntegrationTests)

--- a/src/OrbitVersion/CMakeLists.txt
+++ b/src/OrbitVersion/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(OrbitVersion PUBLIC
 target_sources(OrbitVersion PRIVATE 
         include/OrbitVersion/OrbitVersion.h)
 
-target_link_libraries(OrbitVersion PUBLIC CONAN_PKG::abseil)
+target_link_libraries(OrbitVersion PUBLIC absl::str_format)
 
 include("${CMAKE_SOURCE_DIR}/cmake/version.cmake")
 GenerateVersionFile("${CMAKE_CURRENT_BINARY_DIR}/OrbitVersion.cpp"

--- a/src/PresetFile/CMakeLists.txt
+++ b/src/PresetFile/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(
   PresetFile
   PUBLIC OrbitBase
          ClientProtos
+         absl::strings
          CONAN_PKG::protobuf)
 
 add_executable(PresetFileTests)
@@ -32,7 +33,6 @@ target_link_libraries(
   PresetFileTests
   PRIVATE PresetFile
           TestUtils
-          GTest::Main
-          CONAN_PKG::abseil)
+          GTest::Main)
 
 register_test(PresetFileTests)

--- a/src/ProducerSideChannel/CMakeLists.txt
+++ b/src/ProducerSideChannel/CMakeLists.txt
@@ -12,5 +12,5 @@ target_sources(ProducerSideChannel INTERFACE
 target_include_directories(ProducerSideChannel INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries(ProducerSideChannel INTERFACE
-        CONAN_PKG::abseil
+        absl::str_format
         CONAN_PKG::grpc)

--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -8,7 +8,15 @@ project(QtUtils)
 add_library(QtUtils STATIC)
 
 target_include_directories(QtUtils PUBLIC include/)
-target_link_libraries(QtUtils PUBLIC Introspection OrbitBase Qt5::Core CONAN_PKG::abseil GTest::GTest)
+target_link_libraries(QtUtils PUBLIC
+  Introspection
+  OrbitBase
+  absl::span
+  absl::strings
+  absl::synchronization
+  absl::time
+  Qt5::Core
+  GTest::GTest)
 
 target_sources(QtUtils PUBLIC include/QtUtils/AssertNoQtLogWarnings.h
                               include/QtUtils/CreateTimeout.h
@@ -27,7 +35,7 @@ set_target_properties(QtUtils PROPERTIES AUTOMOC ON)
 
 add_executable(FakeCliProgram)
 target_sources(FakeCliProgram PRIVATE FakeCliProgram/main.cpp)
-target_link_libraries(FakeCliProgram CONAN_PKG::abseil)
+target_link_libraries(FakeCliProgram PUBLIC absl::flags absl::flags_parse)
 
 add_executable(QtUtilsTests)
 target_sources(QtUtilsTests PRIVATE CreateTimeoutTest.cpp

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -38,6 +38,10 @@ endif()
 
 project(OrbitService)
 add_executable(OrbitService main.cpp)
-target_link_libraries(OrbitService PRIVATE OrbitServiceLib)
+target_link_libraries(OrbitService PRIVATE
+  OrbitServiceLib
+  absl::flags
+  absl::flags_usage
+  absl::flags_parse)
 
 strip_symbols(OrbitService)

--- a/src/SessionSetup/CMakeLists.txt
+++ b/src/SessionSetup/CMakeLists.txt
@@ -68,7 +68,10 @@ target_link_libraries(
           OrbitSsh
           OrbitSshQt
           QtUtils
-          CONAN_PKG::abseil
+          absl::flags
+          absl::flat_hash_map
+          absl::str_format
+          absl::strings
           CONAN_PKG::grpc
           Qt5::Widgets)
 

--- a/src/StringManager/CMakeLists.txt
+++ b/src/StringManager/CMakeLists.txt
@@ -17,9 +17,11 @@ target_sources(
 
 target_include_directories(StringManager PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(
-  StringManager
-  PUBLIC OrbitBase)
+target_link_libraries(StringManager PUBLIC
+  OrbitBase
+  absl::flat_hash_map
+  absl::synchronization
+  absl::strings)
 
 add_executable(StringManagerTests)
 
@@ -29,7 +31,6 @@ target_sources(StringManagerTests PRIVATE
 target_link_libraries(
   StringManagerTests
   PRIVATE StringManager
-          GTest::Main
-          CONAN_PKG::abseil)
+          GTest::Main)
 
 register_test(StringManagerTests)

--- a/src/Test/CMakeLists.txt
+++ b/src/Test/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 if(NOT TARGET GTest::QtGuiMain AND TARGET Qt5::Widgets)
   add_library(GTest_QtGuiMain OBJECT EXCLUDE_FROM_ALL test_qtgui_main.cpp Path.cpp)
   target_include_directories(GTest_QtGuiMain PUBLIC include/)
-  target_link_libraries(GTest_QtGuiMain PUBLIC OrbitBase GTest::GTest Qt5::Widgets CONAN_PKG::abseil)
+  target_link_libraries(GTest_QtGuiMain PUBLIC OrbitBase GTest::GTest Qt5::Widgets absl::strings)
   add_library(GTest::QtGuiMain ALIAS GTest_QtGuiMain)
 endif()
 

--- a/src/TestUtils/CMakeLists.txt
+++ b/src/TestUtils/CMakeLists.txt
@@ -9,7 +9,12 @@ target_sources(TestUtils INTERFACE
   include/TestUtils/TestUtils.h
   include/TestUtils/ContainerHelpers.h)
 target_include_directories(TestUtils INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-target_link_libraries(TestUtils INTERFACE CONAN_PKG::abseil GTest::GTest)
+target_link_libraries(TestUtils INTERFACE
+  absl::flat_hash_map
+  absl::flat_hash_set
+  absl::strings
+  absl::str_format
+  GTest::GTest)
 
 add_executable(TestUtilsTests
   TestUtilsTest.cpp

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -50,7 +50,13 @@ target_link_libraries(UserSpaceInstrumentation PUBLIC
         ModuleUtils
         ObjectUtils
         OrbitBase
-        CONAN_PKG::abseil
+        absl::base
+        absl::flat_hash_set
+        absl::span
+        absl::str_format
+        absl::strings
+        absl::synchronization
+        absl::time
         CONAN_PKG::capstone)
 
 # This lib is injected into the target process Orbit is profiling. It is providing the functions
@@ -124,7 +130,6 @@ target_sources(UserSpaceInstrumentationTests PRIVATE
 target_link_libraries(UserSpaceInstrumentationTests PRIVATE
         TestUtils
         UserSpaceInstrumentation
-        CONAN_PKG::abseil
         CONAN_PKG::capstone
         GTest::GTest
         GTest::Main)

--- a/src/UtilWidgets/CMakeLists.txt
+++ b/src/UtilWidgets/CMakeLists.txt
@@ -21,7 +21,7 @@ target_sources(
 target_link_libraries(
   UtilWidgets
   PUBLIC  QtUtils
-          CONAN_PKG::abseil
+          absl::str_format
           Qt5::Widgets)
 
 set_target_properties(UtilWidgets PROPERTIES AUTOMOC ON)

--- a/src/WindowsTracing/CMakeLists.txt
+++ b/src/WindowsTracing/CMakeLists.txt
@@ -47,7 +47,11 @@ target_link_libraries(WindowsTracing PUBLIC
         PresentMon
         WindowsUtils
         krabsetw
-        CONAN_PKG::abseil
+        absl::base
+        absl::bind_front
+        absl::flat_hash_map
+        absl::flat_hash_set
+        absl::str_format
         CONAN_PKG::grpc
         CONAN_PKG::outcome)
 

--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -58,7 +58,11 @@ target_sources(WindowsUtils PRIVATE
 target_link_libraries(WindowsUtils PUBLIC
         ObjectUtils
         OrbitBase
-        CONAN_PKG::abseil)
+        absl::base
+        absl::flat_hash_map
+        absl::str_format
+        absl::strings
+        absl::synchronization)
 
 add_executable(WindowsUtilsTests)
 


### PR DESCRIPTION
This replaces the usage of Abseil from Conan. The main reason for doing this is that we wanna provide a build that works without Conan (for building Linux packages). But Abseil packages in most Linux distributions are compiled in C++11 mode while we need C++17 mode. So for now we will add our own copy of Abseil to the build.