### PR TITLE
Create tests and optimize rendering of AllThreadsCallstackBar

### DIFF
--- a/src/ClientData/CallstackDataTest.cpp
+++ b/src/ClientData/CallstackDataTest.cpp
@@ -203,37 +203,27 @@ TEST(CallstackData, FilterCallstackEventsBasedOnMajorityStartExcludesFunctionToS
 TEST(CallstackData, ForEachCallstackEventOfTidInTimeRangeDiscretized) {
   CallstackData callstack_data;
 
+  const uint64_t cs_id = 12;
+  CallstackInfo cs{{0x11, 0x10}, CallstackType::kComplete};
+  callstack_data.AddUniqueCallstack(cs_id, std::move(cs));
+
   constexpr uint32_t kTid = 42;
   constexpr uint32_t kAnotherTid = 43;
 
-  constexpr uint64_t kCloneAddress = 0x10;
-
-  const uint64_t cs1_id = 12;
-  const uint64_t cs1_outer = kCloneAddress;
-  const uint64_t cs1_inner = 0x11;
-  CallstackInfo cs1{{cs1_inner, cs1_outer}, CallstackType::kComplete};
-  callstack_data.AddUniqueCallstack(cs1_id, std::move(cs1));
-
-  const uint64_t cs2_id = 13;
-  const uint64_t cs2_outer = kCloneAddress;
-  const uint64_t cs2_inner = 0x21;
-  CallstackInfo cs2{{cs2_inner, cs2_outer}, CallstackType::kComplete};
-  callstack_data.AddUniqueCallstack(cs2_id, std::move(cs2));
-
   const uint64_t time1 = 142;
-  CallstackEvent event1{time1, cs1_id, kTid};
+  CallstackEvent event1{time1, cs_id, kTid};
   callstack_data.AddCallstackEvent(event1);
 
   const uint64_t time2 = 242;
-  CallstackEvent event2{time2, cs2_id, kTid};
+  CallstackEvent event2{time2, cs_id, kTid};
   callstack_data.AddCallstackEvent(event2);
 
   const uint64_t time3 = 342;
-  CallstackEvent event3{time3, cs1_id, kAnotherTid};
+  CallstackEvent event3{time3, cs_id, kAnotherTid};
   callstack_data.AddCallstackEvent(event3);
 
   const uint64_t time4 = 442;
-  CallstackEvent event4{time4, cs2_id, kTid};
+  CallstackEvent event4{time4, cs_id, kTid};
   callstack_data.AddCallstackEvent(event4);
 
   std::vector<CallstackEvent> callstack_list;
@@ -274,37 +264,27 @@ TEST(CallstackData, ForEachCallstackEventOfTidInTimeRangeDiscretized) {
 TEST(CallstackData, ForEachCallstackEventInTimeRangeDiscretized) {
   CallstackData callstack_data;
 
+  const uint64_t cs_id = 12;
+  CallstackInfo cs{{0x11, 0x10}, CallstackType::kComplete};
+  callstack_data.AddUniqueCallstack(cs_id, std::move(cs));
+
   constexpr uint32_t kTid = 42;
   constexpr uint32_t kAnotherTid = 43;
 
-  constexpr uint64_t kCloneAddress = 0x10;
-
-  const uint64_t cs1_id = 12;
-  const uint64_t cs1_outer = kCloneAddress;
-  const uint64_t cs1_inner = 0x11;
-  CallstackInfo cs1{{cs1_inner, cs1_outer}, CallstackType::kComplete};
-  callstack_data.AddUniqueCallstack(cs1_id, std::move(cs1));
-
-  const uint64_t cs2_id = 13;
-  const uint64_t cs2_outer = kCloneAddress;
-  const uint64_t cs2_inner = 0x21;
-  CallstackInfo cs2{{cs2_inner, cs2_outer}, CallstackType::kComplete};
-  callstack_data.AddUniqueCallstack(cs2_id, std::move(cs2));
-
   const uint64_t time1 = 142;
-  CallstackEvent event1{time1, cs1_id, kTid};
+  CallstackEvent event1{time1, cs_id, kTid};
   callstack_data.AddCallstackEvent(event1);
 
   const uint64_t time2 = 242;
-  CallstackEvent event2{time2, cs2_id, kTid};
+  CallstackEvent event2{time2, cs_id, kTid};
   callstack_data.AddCallstackEvent(event2);
 
   const uint64_t time3 = 342;
-  CallstackEvent event3{time3, cs1_id, kAnotherTid};
+  CallstackEvent event3{time3, cs_id, kAnotherTid};
   callstack_data.AddCallstackEvent(event3);
 
   const uint64_t time4 = 442;
-  CallstackEvent event4{time4, cs2_id, kTid};
+  CallstackEvent event4{time4, cs_id, kTid};
   callstack_data.AddCallstackEvent(event4);
 
   std::vector<CallstackEvent> callstack_list;

--- a/src/ClientData/FastRenderingUtils.cpp
+++ b/src/ClientData/FastRenderingUtils.cpp
@@ -6,9 +6,9 @@
 
 namespace orbit_client_data {
 
-uint32_t GetPixelNumber(uint64_t current_timestamp_ns, uint32_t resolution, uint64_t start_ns,
+uint32_t GetPixelNumber(uint64_t timestamp_ns, uint32_t resolution, uint64_t start_ns,
                         uint64_t end_ns) {
-  uint64_t current_ns_from_start = current_timestamp_ns - start_ns;
+  uint64_t current_ns_from_start = timestamp_ns - start_ns;
   uint64_t total_ns = end_ns - start_ns;
 
   // Given a resolution of 4000 pixels, we can capture for 53 days without overflowing.

--- a/src/ClientData/FastRenderingUtils.cpp
+++ b/src/ClientData/FastRenderingUtils.cpp
@@ -6,13 +6,18 @@
 
 namespace orbit_client_data {
 
-uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns, uint32_t resolution,
-                                    uint64_t start_ns, uint64_t end_ns) {
+uint32_t GetPixelNumber(uint64_t current_timestamp_ns, uint32_t resolution, uint64_t start_ns,
+                        uint64_t end_ns) {
   uint64_t current_ns_from_start = current_timestamp_ns - start_ns;
   uint64_t total_ns = end_ns - start_ns;
 
   // Given a resolution of 4000 pixels, we can capture for 53 days without overflowing.
-  uint64_t current_pixel = (current_ns_from_start * resolution) / total_ns;
+  return (current_ns_from_start * resolution) / total_ns;
+}
+
+uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns, uint32_t resolution,
+                                    uint64_t start_ns, uint64_t end_ns) {
+  uint64_t current_pixel = GetPixelNumber(current_timestamp_ns, resolution, start_ns, end_ns);
   uint64_t next_pixel = current_pixel + 1;
 
   // Calculates `ceil(dividend / divisor)` only using integers assuming dividend and divisor are not
@@ -21,6 +26,7 @@ uint64_t GetNextPixelBoundaryTimeNs(uint64_t current_timestamp_ns, uint32_t reso
     return 1 + (dividend - 1) / divisor;
   };
 
+  uint64_t total_ns = end_ns - start_ns;
   // To calculate the timestamp of a pixel boundary, we make a cross-multiplication rounding_up to
   // be consistent to how we calculate current_pixel.
   uint64_t next_pixel_ns_from_min = rounding_up_division(total_ns * next_pixel, resolution);

--- a/src/ClientData/FastRenderingUtilsTest.cpp
+++ b/src/ClientData/FastRenderingUtilsTest.cpp
@@ -12,6 +12,18 @@ constexpr uint64_t kStartNs = 100;
 constexpr uint64_t kEndNs = 200;
 static std::vector<uint32_t> kPixelResolutionsInTest = {1, 20, 30, 50, 100};
 
+TEST(FastRenderingUtils, GetPixelNumber) {
+  for (uint32_t resolution : kPixelResolutionsInTest) {
+    EXPECT_EQ(GetPixelNumber(kStartNs, resolution, kStartNs, kEndNs), 0);
+    EXPECT_EQ(GetPixelNumber(kEndNs - 1, resolution, kStartNs, kEndNs), resolution - 1);
+    EXPECT_EQ(GetPixelNumber(kEndNs, resolution, kStartNs, kEndNs), resolution);
+
+    const uint32_t kLastNsForFirstPixel = kStartNs + (kEndNs - kStartNs - 1) / resolution;
+    EXPECT_EQ(GetPixelNumber(kLastNsForFirstPixel, resolution, kStartNs, kEndNs), 0);
+    EXPECT_EQ(GetPixelNumber(kLastNsForFirstPixel + 1, resolution, kStartNs, kEndNs), 1);
+  }
+}
+
 TEST(GetNextPixelBoundaryTimeNs, TimestampAreInRange) {
   constexpr uint64_t visible_ns = kEndNs - kStartNs;  // 100
 

--- a/src/ClientData/FastRenderingUtilsTest.cpp
+++ b/src/ClientData/FastRenderingUtilsTest.cpp
@@ -10,21 +10,29 @@ namespace orbit_client_data {
 
 constexpr uint64_t kStartNs = 100;
 constexpr uint64_t kEndNs = 200;
-static std::vector<uint32_t> kPixelResolutionsInTest = {1, 20, 30, 50, 100};
 
-TEST(FastRenderingUtils, GetPixelNumber) {
-  for (uint32_t resolution : kPixelResolutionsInTest) {
-    EXPECT_EQ(GetPixelNumber(kStartNs, resolution, kStartNs, kEndNs), 0);
-    EXPECT_EQ(GetPixelNumber(kEndNs - 1, resolution, kStartNs, kEndNs), resolution - 1);
-    EXPECT_EQ(GetPixelNumber(kEndNs, resolution, kStartNs, kEndNs), resolution);
+using GetPixelNumberTest = ::testing::TestWithParam<uint32_t>;
+using GetNextPixelBoundaryTimeNsTest = ::testing::TestWithParam<uint32_t>;
 
-    const uint32_t kLastNsForFirstPixel = kStartNs + (kEndNs - kStartNs - 1) / resolution;
-    EXPECT_EQ(GetPixelNumber(kLastNsForFirstPixel, resolution, kStartNs, kEndNs), 0);
-    EXPECT_EQ(GetPixelNumber(kLastNsForFirstPixel + 1, resolution, kStartNs, kEndNs), 1);
-  }
+TEST_P(GetPixelNumberTest, FirstPixel) {
+  const uint32_t resolution = GetParam();
+  EXPECT_EQ(GetPixelNumber(kStartNs, resolution, kStartNs, kEndNs), 0);
+
+  const uint32_t kLastNsForFirstPixel = kStartNs + (kEndNs - kStartNs - 1) / resolution;
+  EXPECT_EQ(GetPixelNumber(kLastNsForFirstPixel, resolution, kStartNs, kEndNs), 0);
+  EXPECT_EQ(GetPixelNumber(kLastNsForFirstPixel + 1, resolution, kStartNs, kEndNs), 1);
 }
 
-TEST(GetNextPixelBoundaryTimeNs, TimestampAreInRange) {
+TEST_P(GetPixelNumberTest, LastPixel) {
+  const uint32_t resolution = GetParam();
+  EXPECT_EQ(GetPixelNumber(kEndNs - 1, resolution, kStartNs, kEndNs), resolution - 1);
+  EXPECT_EQ(GetPixelNumber(kEndNs, resolution, kStartNs, kEndNs), resolution);
+}
+
+INSTANTIATE_TEST_SUITE_P(GetPixelNumberTests, GetPixelNumberTest, testing::Values(1, 20, 30, 100));
+
+TEST_P(GetNextPixelBoundaryTimeNsTest, TimestampAreInRange) {
+  const uint32_t resolution = GetParam();
   constexpr uint64_t visible_ns = kEndNs - kStartNs;  // 100
 
   // Calculates `ceil(dividend / divisor)` only using integers assuming dividend and divisor are not
@@ -33,35 +41,33 @@ TEST(GetNextPixelBoundaryTimeNs, TimestampAreInRange) {
     return 1 + (dividend - 1) / divisor;
   };
 
-  for (uint32_t resolution : kPixelResolutionsInTest) {
-    // The max number of nanoseconds per pixel can be calculated using a ceil function.
-    const uint64_t max_nanoseconds_per_pixel = rounding_up_division(visible_ns, resolution);
-    for (uint64_t timestamp_ns = kStartNs; timestamp_ns < kEndNs; timestamp_ns++) {
-      const uint64_t next_pixel_ns =
-          GetNextPixelBoundaryTimeNs(timestamp_ns, resolution, kStartNs, kEndNs);
-      // The timestamp of the next pixel should be between the current one and the current plus the
-      // maximum number of nanoseconds per pixel.
-      EXPECT_GT(next_pixel_ns, timestamp_ns);
-      EXPECT_LE(next_pixel_ns, timestamp_ns + max_nanoseconds_per_pixel);
-    }
+  // The max number of nanoseconds per pixel can be calculated using a ceil function.
+  const uint64_t max_nanoseconds_per_pixel = rounding_up_division(visible_ns, resolution);
+  for (uint64_t timestamp_ns = kStartNs; timestamp_ns < kEndNs; timestamp_ns++) {
+    const uint64_t next_pixel_ns =
+        GetNextPixelBoundaryTimeNs(timestamp_ns, resolution, kStartNs, kEndNs);
+    // The timestamp of the next pixel should be between the current one and the current plus the
+    // maximum number of nanoseconds per pixel.
+    EXPECT_GT(next_pixel_ns, timestamp_ns);
+    EXPECT_LE(next_pixel_ns, timestamp_ns + max_nanoseconds_per_pixel);
   }
 }
 
-TEST(GetNextPixelBoundaryTimeNs, NumIterations) {
+TEST_P(GetNextPixelBoundaryTimeNsTest, NumIterations) {
+  const uint32_t resolution = GetParam();
+
   // Iterating through visible pixels using GetNextPixelBoundaryTimeNs should go once per pixel.
-  for (uint32_t resolution : kPixelResolutionsInTest) {
-    uint32_t num_iterations = 0;
-    uint64_t current_timestamp_ns = kStartNs;
-    while (current_timestamp_ns < kEndNs) {
-      ++num_iterations;
-      current_timestamp_ns =
-          GetNextPixelBoundaryTimeNs(current_timestamp_ns, resolution, kStartNs, kEndNs);
-    }
-    EXPECT_EQ(num_iterations, resolution);
+  uint32_t num_iterations = 0;
+  uint64_t current_timestamp_ns = kStartNs;
+  while (current_timestamp_ns < kEndNs) {
+    ++num_iterations;
+    current_timestamp_ns =
+        GetNextPixelBoundaryTimeNs(current_timestamp_ns, resolution, kStartNs, kEndNs);
   }
+  EXPECT_EQ(num_iterations, resolution);
 }
 
-TEST(GetNextPixelBoundaryTimeNs, ExtremeZoomInBorderCase) {
+TEST(GetNextPixelBoundaryTimeNsTest, ExtremeZoomInBorderCase) {
   constexpr uint64_t visible_ns = kEndNs - kStartNs;
 
   // If there are more visible pixels than visible timestamps, we will have several pixels with the
@@ -69,5 +75,8 @@ TEST(GetNextPixelBoundaryTimeNs, ExtremeZoomInBorderCase) {
   // greater than the one queried.
   EXPECT_EQ(GetNextPixelBoundaryTimeNs(kStartNs, visible_ns * 10, kStartNs, kEndNs), kStartNs + 1);
 }
+
+INSTANTIATE_TEST_SUITE_P(GetNextPixelBoundaryTimeNsTests, GetNextPixelBoundaryTimeNsTest,
+                         testing::Values(1, 20, 30, 100));
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -84,21 +84,21 @@ class CallstackData {
   void ForEachCallstackEventInTimeRangeDiscretized(uint64_t min_timestamp, uint64_t max_timestamp,
                                                    uint32_t resolution, Action&& action) const {
     auto get_next_callstack = [&](uint64_t timestamp) -> CallstackEvent {
-      const uint32_t kFakeId = -1;
+      constexpr uint32_t kFakeId = -1;
       CallstackEvent next_callstack{max_timestamp, kFakeId, kFakeId};
       uint32_t current_pixel = GetPixelNumber(timestamp, resolution, min_timestamp, max_timestamp);
       for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
-        auto next_callstack_tid = events.lower_bound(timestamp);
-        if (next_callstack_tid != events.end() &&
-            next_callstack_tid->second.timestamp_ns() < next_callstack.timestamp_ns()) {
+        auto next_callstack_of_tid = events.lower_bound(timestamp);
+        if (next_callstack_of_tid != events.end() &&
+            next_callstack_of_tid->second.timestamp_ns() < next_callstack.timestamp_ns()) {
           // If this callstack will be drawn in the current_pixel, we don't need to search for more
-          // of them, otherwise there could be a callstack in another thread_id that will be draw
+          // of them. Otherwise there could be a callstack in another thread_id that will be draw
           // before, so we need to keep looking.
-          if (GetPixelNumber(next_callstack_tid->first, resolution, min_timestamp, max_timestamp) ==
-              current_pixel) {
-            return next_callstack_tid->second;
+          if (GetPixelNumber(next_callstack_of_tid->first, resolution, min_timestamp,
+                             max_timestamp) == current_pixel) {
+            return next_callstack_of_tid->second;
           }
-          next_callstack = next_callstack_tid->second;
+          next_callstack = next_callstack_of_tid->second;
         }
       }
       return next_callstack;

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -83,32 +83,34 @@ class CallstackData {
   template <typename Action>
   void ForEachCallstackEventInTimeRangeDiscretized(uint64_t min_timestamp, uint64_t max_timestamp,
                                                    uint32_t resolution, Action&& action) const {
-    auto get_next_callstack = [&](uint64_t timestamp) -> CallstackEvent {
-      constexpr uint32_t kFakeId = -1;
-      CallstackEvent next_callstack{max_timestamp, kFakeId, kFakeId};
-      uint32_t current_pixel = GetPixelNumber(timestamp, resolution, min_timestamp, max_timestamp);
+    auto get_next_callstack = [&](uint64_t timestamp) -> std::optional<CallstackEvent> {
+      std::optional<CallstackEvent> next_callstack;
+      const uint32_t current_pixel =
+          GetPixelNumber(timestamp, resolution, min_timestamp, max_timestamp);
       for (const auto& [unused_tid, events] : callstack_events_by_tid_) {
         auto next_callstack_of_tid = events.lower_bound(timestamp);
-        if (next_callstack_of_tid != events.end() &&
-            next_callstack_of_tid->second.timestamp_ns() < next_callstack.timestamp_ns()) {
-          // If this callstack will be drawn in the current_pixel, we don't need to search for more
-          // of them. Otherwise there could be a callstack in another thread_id that will be draw
-          // before, so we need to keep looking.
-          if (GetPixelNumber(next_callstack_of_tid->first, resolution, min_timestamp,
-                             max_timestamp) == current_pixel) {
-            return next_callstack_of_tid->second;
-          }
-          next_callstack = next_callstack_of_tid->second;
+        if (next_callstack_of_tid == events.end() ||
+            (next_callstack.has_value() &&
+             next_callstack.value().timestamp_ns() <= next_callstack_of_tid->second.timestamp_ns()))
+          continue;
+
+        // If this callstack will be drawn in the current_pixel, we don't need to search for more of
+        // them. Otherwise there could be a callstack in another thread_id that will be draw before,
+        // so we need to keep looking.
+        if (GetPixelNumber(next_callstack_of_tid->first, resolution, min_timestamp,
+                           max_timestamp) == current_pixel) {
+          return next_callstack_of_tid->second;
         }
+        next_callstack = next_callstack_of_tid->second;
       }
       return next_callstack;
     };
 
-    for (CallstackEvent next_event_it = get_next_callstack(min_timestamp);
-         next_event_it.timestamp_ns() < max_timestamp;
-         next_event_it = get_next_callstack(GetNextPixelBoundaryTimeNs(
-             next_event_it.timestamp_ns(), resolution, min_timestamp, max_timestamp))) {
-      std::invoke(action, next_event_it);
+    for (std::optional<CallstackEvent> next_callstack = get_next_callstack(min_timestamp);
+         next_callstack.has_value() && next_callstack.value().timestamp_ns() < max_timestamp;
+         next_callstack = get_next_callstack(GetNextPixelBoundaryTimeNs(
+             next_callstack.value().timestamp_ns(), resolution, min_timestamp, max_timestamp))) {
+      std::invoke(action, next_callstack.value());
     }
   }
 

--- a/src/ClientData/include/ClientData/FastRenderingUtils.h
+++ b/src/ClientData/include/ClientData/FastRenderingUtils.h
@@ -14,6 +14,9 @@ namespace orbit_client_data {
                                                   uint32_t resolution, uint64_t start_ns,
                                                   uint64_t end_ns);
 
+[[nodiscard]] uint32_t GetPixelNumber(uint64_t current_timestamp_ns, uint32_t resolution,
+                                      uint64_t start_ns, uint64_t end_ns);
+
 }  // namespace orbit_client_data
 
 #endif  // CLIENT_DATA_FAST_RENDERING_UTILS_H_

--- a/src/ClientData/include/ClientData/FastRenderingUtils.h
+++ b/src/ClientData/include/ClientData/FastRenderingUtils.h
@@ -14,8 +14,10 @@ namespace orbit_client_data {
                                                   uint32_t resolution, uint64_t start_ns,
                                                   uint64_t end_ns);
 
-[[nodiscard]] uint32_t GetPixelNumber(uint64_t current_timestamp_ns, uint32_t resolution,
-                                      uint64_t start_ns, uint64_t end_ns);
+// Free Function that returns the number of the pixel of a particular timestamp. The query
+// assumes a closed-open interval [start_ns, end_ns), so end_ns is not a visible timestamp.
+[[nodiscard]] uint32_t GetPixelNumber(uint64_t timestamp_ns, uint32_t resolution, uint64_t start_ns,
+                                      uint64_t end_ns);
 
 }  // namespace orbit_client_data
 

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -118,8 +118,8 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
     auto action_on_callstack_events = [&](const CallstackEvent& event) {
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(GetPixelNumber(event.timestamp_ns(), resolution_in_pixels, min_tick, max_tick),
-               GetPos()[1]);
+      const Vec2 pos(GetPixelNumber(event.timestamp_ns(), resolution_in_pixels, min_tick, max_tick),
+                     GetPos()[1]);
       Color color = kWhite;
       if (capture_data_->GetCallstackData().GetCallstack(event.callstack_id())->type() !=
           CallstackType::kComplete) {
@@ -140,8 +140,8 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
     auto action_on_selected_callstack_events = [&](const CallstackEvent& event) {
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(GetPixelNumber(event.timestamp_ns(), resolution_in_pixels, min_tick, max_tick),
-               GetPos()[1]);
+      const Vec2 pos(GetPixelNumber(event.timestamp_ns(), resolution_in_pixels, min_tick, max_tick),
+                     GetPos()[1]);
       primitive_assembler.AddVerticalLine(pos, track_height, z, kGreenSelection);
     };
     const orbit_client_data::CallstackData& selection_callstack_data =
@@ -163,9 +163,10 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
     auto action_on_callstack_events = [&, this](const CallstackEvent& event) {
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(GetPixelNumber(time, resolution_in_pixels, min_tick, max_tick) - kPickingBoxOffset,
-               GetPos()[1]);
-      Vec2 size(kPickingBoxWidth, track_height);
+      const Vec2 pos(
+          GetPixelNumber(time, resolution_in_pixels, min_tick, max_tick) - kPickingBoxOffset,
+          GetPos()[1]);
+      const Vec2 size(kPickingBoxWidth, track_height);
       auto user_data = std::make_unique<PickingUserData>(
           nullptr, [this, &primitive_assembler](PickingId id) -> std::string {
             return GetSampleTooltip(primitive_assembler, id);

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -15,6 +15,7 @@
 #include "ClientData/CallstackInfo.h"
 #include "ClientData/CallstackType.h"
 #include "ClientData/CaptureData.h"
+#include "ClientData/FastRenderingUtils.h"
 #include "FormatCallstackForTooltip.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
@@ -31,6 +32,7 @@ using orbit_client_data::CallstackEvent;
 using orbit_client_data::CallstackInfo;
 using orbit_client_data::CallstackType;
 using orbit_client_data::CaptureData;
+using orbit_client_data::GetPixelNumber;
 using orbit_client_data::ThreadID;
 
 namespace orbit_gl {
@@ -116,7 +118,8 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
     auto action_on_callstack_events = [&](const CallstackEvent& event) {
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(timeline_info_->GetWorldFromTick(time), GetPos()[1]);
+      Vec2 pos(GetPixelNumber(event.timestamp_ns(), resolution_in_pixels, min_tick, max_tick),
+               GetPos()[1]);
       Color color = kWhite;
       if (capture_data_->GetCallstackData().GetCallstack(event.callstack_id())->type() !=
           CallstackType::kComplete) {
@@ -137,7 +140,8 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
     auto action_on_selected_callstack_events = [&](const CallstackEvent& event) {
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(timeline_info_->GetWorldFromTick(event.timestamp_ns()), GetPos()[1]);
+      Vec2 pos(GetPixelNumber(event.timestamp_ns(), resolution_in_pixels, min_tick, max_tick),
+               GetPos()[1]);
       primitive_assembler.AddVerticalLine(pos, track_height, z, kGreenSelection);
     };
     const orbit_client_data::CallstackData& selection_callstack_data =
@@ -159,7 +163,8 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
     auto action_on_callstack_events = [&, this](const CallstackEvent& event) {
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
-      Vec2 pos(timeline_info_->GetWorldFromTick(time) - kPickingBoxOffset, GetPos()[1]);
+      Vec2 pos(GetPixelNumber(time, resolution_in_pixels, min_tick, max_tick) - kPickingBoxOffset,
+               GetPos()[1]);
       Vec2 size(kPickingBoxWidth, track_height);
       auto user_data = std::make_unique<PickingUserData>(
           nullptr, [this, &primitive_assembler](PickingId id) -> std::string {


### PR DESCRIPTION
In this PR we are optimizing the rendering of AllThreadsCallstackBar.

In the previous PR (https://github.com/google/orbit/pull/4271), we skip going through and rendering events from the same pixel in a particular thread_id but we were still going once per pixel per thread_id. In this PR we are still iterating through pixels but stopping looking for new callstacks when we have already found some on the current_pixel.

For getting the pixel number I created a method in FastRenderingUtils class, but I also used in CallstackThreadBar since is way more precise. Ideally we should fix these functions (http://b/242973688), but I won't work on that for now. It also makes sense to use GetPixelNumber when we want to render vertical lines.

I found this issue when creating tests for CallstackData (there were no tests before for this method but I should have created them anyway), so I'm including the tests here as well.

Rendering all_thread Track for a 5 min-capture takes:
- Before (https://github.com/google/orbit/pull/4271): >150ms
- After (https://github.com/google/orbit/pull/4271): ~13ms
- Now: ~0.950ms

Rendering callstacks for all Tracks takes 8.6% instead of 11.9% (and before https://github.com/google/orbit/pull/4271 - 66%) . I think that this is enough for our goal.

Test: Load a capture, rendering looks fine. Run Unit tests.
Bugs: http://b/252998254 (GetPixelNumber) & http://b/253414641 (Callstack optimization itself)