### PR TITLE
Change <math.h> to <cmath>

### DIFF
--- a/src/LinuxTracingIntegrationTests/IntegrationTestPuppetSharedObject.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestPuppetSharedObject.cpp
@@ -11,7 +11,7 @@ extern "C" double function_that_works_for_a_considerable_amount_of_time() {
   double result = 2;
 
   for (size_t i = 0; i < 10'000'000; ++i) {
-    result = sqrt(result + 1.0);
+    result = std::sqrt(result + 1.0);
   }
 
   return result;

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include <array>
+#include <cmath>
 #include <thread>
 #include <utility>
 
@@ -734,8 +735,8 @@ void VerifyCallstackSamplesWithOuterAndInnerFunction(
             (last_matching_callstack_timestamp_ns - first_matching_callstack_timestamp_ns) / 1e6);
   constexpr double kMinExpectedScheduledRelativeTime = 0.67;
   const auto min_expected_matching_callstack_count = static_cast<uint64_t>(
-      floor((last_matching_callstack_timestamp_ns - first_matching_callstack_timestamp_ns) / 1e9 *
-            sampling_rate * kMinExpectedScheduledRelativeTime));
+      std::floor((last_matching_callstack_timestamp_ns - first_matching_callstack_timestamp_ns) /
+                 1e9 * sampling_rate * kMinExpectedScheduledRelativeTime));
   EXPECT_GE(matching_callstack_count, min_expected_matching_callstack_count);
 }
 

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -7,7 +7,6 @@
 #include <GteVector.h>
 #include <absl/base/casts.h>
 #include <glad/glad.h>
-#include <math.h>
 
 #include "AccessibleInterfaceProvider.h"
 #include "App.h"

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -5,11 +5,11 @@
 #include "GlSlider.h"
 
 #include <GteVector.h>
-#include <math.h>
 
 #include <QCursor>
 #include <QGuiApplication>
 #include <algorithm>
+#include <cmath>
 
 #include "Geometry.h"
 #include "GlCanvas.h"
@@ -258,7 +258,7 @@ void GlVerticalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
   primitive_assembler.PushTranslation(static_cast<int>(GetPos()[0]), static_cast<int>(GetPos()[1]));
 
   float bar_pixel_len = GetBarPixelLength();
-  float slider_height = ceilf(length_ratio_ * bar_pixel_len);
+  float slider_height = std::ceil(length_ratio_ * bar_pixel_len);
   float non_slider_height = bar_pixel_len - slider_height;
 
   const Color dark_border_color = GetDarkerColor(bar_color_);
@@ -266,7 +266,7 @@ void GlVerticalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
   // Background
   DrawBackground(primitive_assembler, 0, 0, GetSliderWidth(), bar_pixel_len);
 
-  float start = ceilf(pos_ratio_ * non_slider_height);
+  float start = std::ceil(pos_ratio_ * non_slider_height);
 
   ShadingDirection shading_direction = ShadingDirection::kRightToLeft;
   DrawSlider(primitive_assembler, 0, start, GetSliderWidth(), slider_height, shading_direction);
@@ -288,12 +288,12 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
   primitive_assembler.PushTranslation(static_cast<int>(GetPos()[0]), static_cast<int>(GetPos()[1]));
 
   float bar_pixel_len = GetBarPixelLength();
-  float slider_width = ceilf(length_ratio_ * bar_pixel_len);
+  float slider_width = std::ceil(length_ratio_ * bar_pixel_len);
   float non_slider_width = bar_pixel_len - slider_width;
 
   DrawBackground(primitive_assembler, 0, 0, bar_pixel_len, GetSliderWidth());
 
-  float start = floorf(pos_ratio_ * non_slider_width);
+  float start = std::floor(pos_ratio_ * non_slider_width);
 
   ShadingDirection shading_direction = ShadingDirection::kTopToBottom;
   DrawSlider(primitive_assembler, start, 0, slider_width, GetSliderWidth(), shading_direction);

--- a/src/OrbitGl/OpenGlTextRenderer.cpp
+++ b/src/OrbitGl/OpenGlTextRenderer.cpp
@@ -9,11 +9,11 @@
 #include <freetype-gl/vector.h>
 #include <freetype-gl/vertex-buffer.h>
 #include <limits.h>
-#include <math.h>
 #include <string.h>
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <iosfwd>
@@ -493,7 +493,7 @@ int OpenGlTextRenderer::GetStringWidthScreenSpace(const char* text, uint32_t fon
     if (text[i] == '\n') break;
   }
 
-  return static_cast<int>(ceil(string_width));
+  return static_cast<int>(std::ceil(string_width));
 }
 
 int OpenGlTextRenderer::GetStringHeightScreenSpace(const char* text, uint32_t font_size) {

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -5,10 +5,10 @@
 #include "PrimitiveAssembler.h"
 
 #include <OrbitBase/Logging.h>
-#include <math.h>
 #include <stddef.h>
 
 #include <array>
+#include <cmath>
 
 #include "CoreMath.h"
 #include "Geometry.h"
@@ -95,10 +95,10 @@ static std::vector<Triangle> GetUnitArcTriangles(float angle_0, float angle_1, u
   const Vec2 origin(0, 0);
 
   float increment_radians = std::fabs(angle_1 - angle_0) / static_cast<float>(num_sides);
-  Vec2 last_point(cosf(angle_0), sinf(angle_0));
+  Vec2 last_point(std::cos(angle_0), std::sin(angle_0));
   for (uint32_t i = 1; i <= num_sides; ++i) {
     float angle = angle_0 + static_cast<float>(i) * increment_radians;
-    Vec2 current_point(cosf(angle), sinf(angle));
+    Vec2 current_point(std::cos(angle), std::sin(angle));
     triangles.emplace_back(Triangle(origin, last_point, current_point));
     last_point = current_point;
   }

--- a/src/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/PrimitiveAssembler.h
@@ -5,11 +5,11 @@
 #ifndef ORBIT_GL_PRIMITIVE_ASSEMBLER_H_
 #define ORBIT_GL_PRIMITIVE_ASSEMBLER_H_
 
-#include <math.h>
 #include <stdint.h>
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <string>
@@ -45,8 +45,8 @@ class PrimitiveAssembler {
 
     const float angle = (kPiFloat * 2.f) / kCirclePoints;
     for (int32_t i = 1; i <= kCirclePoints; i++) {
-      float new_x = sinf(angle * i);
-      float new_y = cosf(angle * i);
+      float new_x = std::sin(angle * i);
+      float new_y = std::cos(angle * i);
       circle_points.emplace_back(Vec2(new_x, new_y));
     }
   }

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -8,6 +8,8 @@
 #include <absl/strings/str_format.h>
 #include <stdint.h>
 
+#include <cmath>
+
 #include "App.h"
 #include "ClientData/CaptureData.h"
 #include "ClientProtos/capture_data.pb.h"
@@ -63,8 +65,8 @@ float SchedulerTrack::GetHeight() const {
   //  are temporarily hacking this issue by adding an epsilon.
   // Epsilon for any float in the range of (0, 8092), maximum width for a 8k pixel screen.
   constexpr float kEpsilon = std::numeric_limits<float>::epsilon() * 8092;
-  const float extended_start_x = floorf(start_x + kEpsilon);
-  const float extended_end_x = ceil(end_x + kEpsilon);
+  const float extended_start_x = std::floor(start_x + kEpsilon);
+  const float extended_end_x = std::ceil(end_x + kEpsilon);
   return {extended_start_x, extended_end_x - extended_start_x};
 }
 

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -4,9 +4,9 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <math.h>
 #include <stdint.h>
 
+#include <cmath>
 #include <memory>
 #include <utility>
 
@@ -98,7 +98,7 @@ static void TestDragType() {
   });
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  int scale = static_cast<int>(pow(10, dim));
+  int scale = static_cast<int>(std::pow(10, dim));
 
   PickDragRelease<dim>(*slider, 50 * scale);
   EXPECT_EQ(drag_count, 1);
@@ -154,7 +154,7 @@ static void TestScroll(float slider_length = 0.25) {
   auto [slider, viewport, tester] = Setup<SliderClass>();
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  int scale = static_cast<int>(pow(10, dim));
+  int scale = static_cast<int>(std::pow(10, dim));
   float pos;
   const int kOffset = 2;
 
@@ -179,7 +179,7 @@ static void TestDrag(float slider_length = 0.25) {
   auto [slider, viewport, tester] = Setup<SliderClass>();
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  int scale = static_cast<int>(pow(10, dim));
+  int scale = static_cast<int>(std::pow(10, dim));
   float pos;
 
   slider->SetDragCallback([&](float ratio) { pos = ratio; });
@@ -235,7 +235,7 @@ static void TestScaling() {
   const int kOffset = 2;
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  int scale = static_cast<int>(pow(10, dim));
+  int scale = static_cast<int>(std::pow(10, dim));
 
   slider->SetResizeCallback([&](float start, float end) { size = end - start; });
   slider->SetDragCallback([&](float ratio) { pos = ratio; });
@@ -297,7 +297,7 @@ static void TestBreakScaling() {
   const int kOffset = 2;
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  int scale = static_cast<int>(pow(10, dim));
+  int scale = static_cast<int>(std::pow(10, dim));
 
   // Pick on the right, then drag across the end of the slider
   pos = slider->GetSliderPixelPos();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -11,7 +11,7 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <cstdint>
+#include <cmath>
 #include <limits>
 
 #include "App.h"
@@ -729,7 +729,7 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
   // The horizontal slider should be at the bottom of the TimeGraph. Because how OpenGl renders, the
   // way to assure that there is no pixels below the scrollbar is by making a ceiling.
   horizontal_slider_->SetPos(timegraph_current_x,
-                             ceil(GetHeight() - horizontal_slider_->GetHeight()));
+                             std::ceil(GetHeight() - horizontal_slider_->GetHeight()));
 
   // TODO(b/230442062): Refactor this to be part of Slider::UpdateLayout().
   UpdateHorizontalSliderFromWorld();

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -6,6 +6,8 @@
 
 #include <imgui.h>
 
+#include <cmath>
+
 #include "OrbitBase/ThreadConstants.h"
 
 TimeGraphLayout::TimeGraphLayout() {
@@ -110,7 +112,7 @@ float TimeGraphLayout::GetCollapseButtonSize(int indentation_level) const {
       collapse_button_decrease_per_indentation_ * static_cast<float>(indentation_level);
 
   // We want the button to scale slower than other elements, so we use sqrt() function.
-  return button_size_without_scaling * sqrt(scale_);
+  return button_size_without_scaling * std::sqrt(scale_);
 }
 
 float TimeGraphLayout::GetEventTrackHeightFromTid(uint32_t tid) const {

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -5,10 +5,10 @@
 #ifndef ORBIT_GL_TIME_GRAPH_LAYOUT_H_
 #define ORBIT_GL_TIME_GRAPH_LAYOUT_H_
 
-#include <math.h>
 #include <stdint.h>
 
 #include <algorithm>
+#include <cmath>
 
 #include "OrbitBase/ThreadUtils.h"
 
@@ -67,7 +67,7 @@ class TimeGraphLayout {
   void SetDrawProperties(bool value) { draw_properties_ = value; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return draw_track_background_; }
-  uint32_t GetFontSize() const { return lround(font_size_ * scale_); }
+  uint32_t GetFontSize() const { return std::lround(font_size_ * scale_); }
 
   int GetMaxLayoutingLoops() const { return max_layouting_loops_; }
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -4,7 +4,6 @@
 
 #include "Track.h"
 
-#include <math.h>
 #include <stddef.h>
 
 #include "AccessibleTrack.h"

--- a/src/OrbitGl/TrackRenderHelper.cpp
+++ b/src/OrbitGl/TrackRenderHelper.cpp
@@ -4,11 +4,13 @@
 
 #include "TrackRenderHelper.h"
 
+#include <cmath>
+
 namespace {
 
 std::vector<Vec2> RotatePoints(const std::vector<Vec2>& points, float rotation) {
-  float cos_r = cosf(kPiFloat * rotation / 180.f);
-  float sin_r = sinf(kPiFloat * rotation / 180.f);
+  float cos_r = std::cos(kPiFloat * rotation / 180.f);
+  float sin_r = std::sin(kPiFloat * rotation / 180.f);
   std::vector<Vec2> result;
   for (const Vec2& point : points) {
     float x_rotated = cos_r * point[0] + sin_r * point[1];
@@ -30,7 +32,7 @@ std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
   float increment_radians = 0.5f * kPiFloat / static_cast<float>(num_sides);
   for (uint32_t i = 1; i < num_sides; ++i) {
     float angle = kPiFloat + static_cast<float>(i) * increment_radians;
-    points.emplace_back(radius * cosf(angle) + radius, radius * sinf(angle) + radius);
+    points.emplace_back(radius * std::cos(angle) + radius, radius * std::sin(angle) + radius);
   }
 
   points.emplace_back(radius, 0.f);

--- a/src/OrbitGl/TranslationStack.h
+++ b/src/OrbitGl/TranslationStack.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_TRANSLATION_STACK_H_
 #define ORBIT_GL_TRANSLATION_STACK_H_
 
+#include <cmath>
 #include <vector>
 
 #include "CoreMath.h"
@@ -28,7 +29,7 @@ class TranslationStack {
   [[nodiscard]] LayeredVec2 TranslateXYZAndFloorXY(const LayeredVec2& input) const {
     const Vec2 result_shape = input.xy + current_translation_.xy;
     const float result_z = input.z + current_translation_.z;
-    return {{floorf(result_shape[0]), floorf(result_shape[1])}, result_z};
+    return {{std::floor(result_shape[0]), std::floor(result_shape[1])}, result_z};
   }
 
  private:

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -5,8 +5,8 @@
 #include "TriangleToggle.h"
 
 #include <GteVector.h>
-#include <math.h>
 
+#include <cmath>
 #include <utility>
 
 #include "AccessibleTriangleToggle.h"
@@ -36,10 +36,10 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
   // Draw triangle.
   const Vec2 midpoint = GetPos() + Vec2(GetWidth() / 2, GetHeight() / 2);
   const float triangle_side_length = std::min(GetWidth(), GetHeight());
-  const float kCos30 = sqrtf(3.f) / 2;
+  const float kCos30 = std::sqrt(3.f) / 2;
   const float triangle_height = triangle_side_length * kCos30;
 
-  const float half_triangle_height = ceilf(triangle_height / 2);
+  const float half_triangle_height = std::ceil(triangle_height / 2);
   const float half_triangle_side_length = triangle_side_length / 2;
 
   if (!picking) {

--- a/src/OrbitGl/Viewport.cpp
+++ b/src/OrbitGl/Viewport.cpp
@@ -5,6 +5,7 @@
 #include "Viewport.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "OrbitBase/Logging.h"
 
@@ -45,8 +46,10 @@ Vec2 Viewport::ScreenToWorld(const Vec2i& screen_coords) const {
 
 Vec2i Viewport::WorldToScreen(const Vec2& world_coords) const {
   Vec2i screen_coords;
-  screen_coords[0] = static_cast<int>(floorf(world_coords[0] / world_width_ * GetScreenWidth()));
-  screen_coords[1] = static_cast<int>(floorf(world_coords[1] / world_height_ * GetScreenHeight()));
+  screen_coords[0] =
+      static_cast<int>(std::floor(world_coords[0] / world_width_ * GetScreenWidth()));
+  screen_coords[1] =
+      static_cast<int>(std::floor(world_coords[1] / world_height_ * GetScreenHeight()));
   return screen_coords;
 }
 

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -9,7 +9,6 @@
 #include <absl/flags/flag.h>
 #include <absl/flags/internal/flag.h>
 #include <absl/strings/match.h>
-#include <math.h>
 #include <stdint.h>
 
 #include <QAbstractItemModel>
@@ -32,6 +31,7 @@
 #include <QTimer>
 #include <QTreeView>
 #include <algorithm>
+#include <cmath>
 #include <list>
 #include <memory>
 #include <optional>
@@ -919,16 +919,17 @@ void CallTreeWidget::ProgressBarItemDelegate::paint(QPainter* painter,
   option_progress_bar.palette = option.palette;
   option_progress_bar.minimum = 0;
   option_progress_bar.maximum = 100;
-  option_progress_bar.progress = static_cast<int>(round(inclusive_percent.value()));
+  option_progress_bar.progress = static_cast<int>(std::round(inclusive_percent.value()));
 
   const QColor bar_background_color = option.palette.color(QPalette::Disabled, QPalette::Base);
   option_progress_bar.palette.setColor(QPalette::Base, bar_background_color);
 
   const QColor palette_highlight_color = option.palette.color(QPalette::Highlight);
   static constexpr float kBarColorValueReductionFactor = .3f / .4f;
-  const QColor bar_foreground_color = QColor::fromHsv(
-      palette_highlight_color.hue(), palette_highlight_color.saturation(),
-      static_cast<int>(round(palette_highlight_color.value() * kBarColorValueReductionFactor)));
+  const QColor bar_foreground_color =
+      QColor::fromHsv(palette_highlight_color.hue(), palette_highlight_color.saturation(),
+                      static_cast<int>(std::round(palette_highlight_color.value() *
+                                                  kBarColorValueReductionFactor)));
   option_progress_bar.palette.setColor(QPalette::Highlight, bar_foreground_color);
 
   option_progress_bar.text = index.data(Qt::DisplayRole).toString();

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -171,15 +171,15 @@ void OrbitTestImpl::ManualInstrumentationApiTest() {
 
     [[maybe_unused]] static float float_var = 0.f;
     [[maybe_unused]] static constexpr float kSinfCoeff = 0.1f;
-    ORBIT_FLOAT_WITH_COLOR("float_var", sinf((++float_var) * kSinfCoeff), kOrbitColorPink);
+    ORBIT_FLOAT_WITH_COLOR("float_var", std::sin((++float_var) * kSinfCoeff), kOrbitColorPink);
 
     [[maybe_unused]] static double double_var = 0.0;
     [[maybe_unused]] static constexpr double kCosCoeff = 0.1;
-    ORBIT_DOUBLE_WITH_COLOR("double_var", cos((++double_var) * kCosCoeff), kOrbitColorPurple);
+    ORBIT_DOUBLE_WITH_COLOR("double_var", std::cos((++double_var) * kCosCoeff), kOrbitColorPurple);
 
     for (int i = 0; i < 5; ++i) {
       std::string track_name = absl::StrFormat("DynamicName_%u", i);
-      ORBIT_DOUBLE(track_name.c_str(), cos(double_var * static_cast<double>(i)));
+      ORBIT_DOUBLE(track_name.c_str(), std::cos(double_var * static_cast<double>(i)));
     }
 
     // Async spans.


### PR DESCRIPTION
This changes all files that use the math.h header to now use the cmath header. Methods from that header (e.g. ceil) are now prefixed with std:: (e.g. std::ceil).