### PR TITLE
Remove using from PdbFileTest.h

### DIFF
--- a/src/ObjectUtils/PdbFileDiaTest.cpp
+++ b/src/ObjectUtils/PdbFileDiaTest.cpp
@@ -7,18 +7,18 @@
 // Must be included after PdbFileTest.h
 #include "PdbFileDia.h"
 
-using orbit_object_utils::PdbFileDia;
-
-INSTANTIATE_TYPED_TEST_SUITE_P(PdbFileDiaTest, PdbFileTest, ::testing::Types<PdbFileDia>);
+INSTANTIATE_TYPED_TEST_SUITE_P(PdbFileDiaTest, PdbFileTest,
+                               ::testing::Types<orbit_object_utils::PdbFileDia>);
 
 // This test is specific to using the DIA SDK to load PDB files.
 TEST(PdbFileDiaTest, CreatePdbDoesNotFailOnCoInitializeWhenAlreadyInitialized) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
   HRESULT result = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
   ASSERT_TRUE(result == S_OK || result == S_FALSE);
-  ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result1 =
-      PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
-  ASSERT_THAT(pdb_file_result1, HasNoError());
+  ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result1 =
+      orbit_object_utils::PdbFileDia::CreatePdbFile(
+          file_path_pdb, orbit_object_utils::ObjectFileInfo{0x180000000});
+  ASSERT_THAT(pdb_file_result1, orbit_test_utils::HasNoError());
   CoUninitialize();
 }
 
@@ -26,9 +26,10 @@ TEST(PdbFileDiaTest, CreatePdbDoesNotFailOnCoInitializeWhenAlreadyInitialized) {
 TEST(PdbFileDiaTest, PdbFileProperlyUninitializesComLibrary) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
   {
-    ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result =
-        PdbFileDia::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
-    ASSERT_THAT(pdb_file_result, HasNoError());
+    ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
+        orbit_object_utils::PdbFileDia::CreatePdbFile(
+            file_path_pdb, orbit_object_utils::ObjectFileInfo{0x180000000});
+    ASSERT_THAT(pdb_file_result, orbit_test_utils::HasNoError());
   }
 
   HRESULT result = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);

--- a/src/ObjectUtils/PdbFileTest.h
+++ b/src/ObjectUtils/PdbFileTest.h
@@ -16,16 +16,6 @@
 #include "Test/Path.h"
 #include "TestUtils/TestUtils.h"
 
-using orbit_grpc_protos::SymbolInfo;
-using orbit_object_utils::CreateCoffFile;
-using orbit_object_utils::ObjectFileInfo;
-using orbit_object_utils::PdbDebugInfo;
-using orbit_object_utils::PdbFile;
-using orbit_test_utils::HasError;
-using orbit_test_utils::HasNoError;
-using ::testing::AnyOf;
-using ::testing::ElementsAre;
-
 template <typename T>
 class PdbFileTest : public testing::Test {
  public:
@@ -36,24 +26,24 @@ TYPED_TEST_SUITE_P(PdbFileTest);
 TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
-  ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result =
-      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
-  ASSERT_THAT(pdb_file_result, HasNoError());
+  ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
+      TypeParam::CreatePdbFile(file_path_pdb, orbit_object_utils::ObjectFileInfo{0x180000000});
+  ASSERT_THAT(pdb_file_result, orbit_test_utils::HasNoError());
   std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
   auto symbols_result = pdb_file->LoadDebugSymbols();
-  ASSERT_THAT(symbols_result, HasNoError());
+  ASSERT_THAT(symbols_result, orbit_test_utils::HasNoError());
 
   auto symbols = std::move(symbols_result.value());
 
-  absl::flat_hash_map<uint64_t, const SymbolInfo*> symbol_infos_by_address;
-  for (const SymbolInfo& symbol_info : symbols.symbol_infos()) {
+  absl::flat_hash_map<uint64_t, const orbit_grpc_protos::SymbolInfo*> symbol_infos_by_address;
+  for (const orbit_grpc_protos::SymbolInfo& symbol_info : symbols.symbol_infos()) {
     symbol_infos_by_address.emplace(symbol_info.address(), &symbol_info);
   }
 
   ASSERT_EQ(symbol_infos_by_address.size(), 5552);
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000eea0];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000eea0];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "PrintHelloWorldInternal()");
     EXPECT_EQ(symbol->address(), 0x18000eea0);
@@ -61,7 +51,7 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000eee0];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000eee0];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "PrintHelloWorld()");
     EXPECT_EQ(symbol->address(), 0x18000eee0);
@@ -69,80 +59,80 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000ef00];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000ef00];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "PrintString(const char*)");
     EXPECT_EQ(symbol->address(), 0x18000ef00);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000ef20];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000ef20];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "TakesVolatileInt(volatile int)");
     EXPECT_EQ(symbol->address(), 0x18000ef20);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000ef50];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000ef50];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "TakesFooReference(Foo&)");
     EXPECT_EQ(symbol->address(), 0x18000ef50);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000ef80];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000ef80];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "TakesFooRValueReference(Foo&&)");
     EXPECT_EQ(symbol->address(), 0x18000ef80);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000efb0];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000efb0];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "TakesConstPtrToInt(int* const)");
     EXPECT_EQ(symbol->address(), 0x18000efb0);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000efe0];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000efe0];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "TakesReferenceToIntPtr(int*&)");
     EXPECT_EQ(symbol->address(), 0x18000efe0);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000f010];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000f010];
     ASSERT_NE(symbol, nullptr);
     // LLVM does not handle function pointers correctly, thus we also accept the wrong
     // strings here.
-    EXPECT_THAT(symbol->demangled_name(), AnyOf("TakesVoidFunctionPointer(void (*)(int))",
-                                                "TakesVoidFunctionPointer(void (int)*)"));
+    EXPECT_THAT(symbol->demangled_name(), testing::AnyOf("TakesVoidFunctionPointer(void (*)(int))",
+                                                         "TakesVoidFunctionPointer(void (int)*)"));
     EXPECT_EQ(symbol->address(), 0x18000f010);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000f030];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000f030];
     ASSERT_NE(symbol, nullptr);
     // LLVM does not handle function pointers correctly, thus we also accept the wrong
     // strings here.
-    EXPECT_THAT(symbol->demangled_name(), AnyOf("TakesCharFunctionPointer(char (*)(int))",
-                                                "TakesCharFunctionPointer(char (int)*)"));
+    EXPECT_THAT(symbol->demangled_name(), testing::AnyOf("TakesCharFunctionPointer(char (*)(int))",
+                                                         "TakesCharFunctionPointer(char (int)*)"));
     EXPECT_EQ(symbol->address(), 0x18000f030);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000f060];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000f060];
     ASSERT_NE(symbol, nullptr);
     // LLVM does not handle function pointers correctly, thus we also accept the wrong
     // strings here.
     EXPECT_THAT(symbol->demangled_name(),
-                AnyOf("TakesMemberFunctionPointer(const char* (Foo::*)(int), Foo)",
-                      "TakesMemberFunctionPointer(const char* Foo::(int) Foo::*, Foo)"));
+                testing::AnyOf("TakesMemberFunctionPointer(const char* (Foo::*)(int), Foo)",
+                               "TakesMemberFunctionPointer(const char* Foo::(int) Foo::*, Foo)"));
     EXPECT_EQ(symbol->address(), 0x18000f060);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000f090];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000f090];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(),
               "TakesVolatilePointerToConstUnsignedChar(const unsigned char* volatile)");
@@ -150,7 +140,7 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000f0b0];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000f0b0];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(),
               "TakesVolatileConstPtrToVolatileConstChar(const volatile char* const volatile)");
@@ -158,25 +148,26 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000f0d0];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000f0d0];
     ASSERT_NE(symbol, nullptr);
     // LLVM does not handle function pointers correctly, thus we also accept the wrong
     // strings here.
-    EXPECT_THAT(symbol->demangled_name(),
-                AnyOf("TakesConstPointerToConstFunctionPointer(char (* const* const)(int))",
-                      "TakesConstPointerToConstFunctionPointer(char (int)* const* const)"));
+    EXPECT_THAT(
+        symbol->demangled_name(),
+        testing::AnyOf("TakesConstPointerToConstFunctionPointer(char (* const* const)(int))",
+                       "TakesConstPointerToConstFunctionPointer(char (int)* const* const)"));
     EXPECT_EQ(symbol->address(), 0x18000f0d0);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000f100];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000f100];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "TakesVariableArguments(int, <no type>)");
     EXPECT_EQ(symbol->address(), 0x18000f100);
   }
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x18000f1b0];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x18000f1b0];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "TakesUserTypeInNamespace(A::FooA, A::B::FooAB)");
     EXPECT_EQ(symbol->address(), 0x18000f1b0);
@@ -186,24 +177,24 @@ TYPED_TEST_P(PdbFileTest, LoadDebugSymbols) {
 TYPED_TEST_P(PdbFileTest, LoadsFunctionsOnlyInPublicSymbols) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "libomp.dll.pdb";
 
-  ErrorMessageOr<std::unique_ptr<PdbFile>> pdb_file_result =
-      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0});
-  ASSERT_THAT(pdb_file_result, HasNoError());
+  ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
+      TypeParam::CreatePdbFile(file_path_pdb, orbit_object_utils::ObjectFileInfo{0});
+  ASSERT_THAT(pdb_file_result, orbit_test_utils::HasNoError());
   std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
   auto symbols_result = pdb_file->LoadDebugSymbols();
-  ASSERT_THAT(symbols_result, HasNoError());
+  ASSERT_THAT(symbols_result, orbit_test_utils::HasNoError());
 
   auto symbols = std::move(symbols_result.value());
 
-  absl::flat_hash_map<uint64_t, const SymbolInfo*> symbol_infos_by_address;
-  for (const SymbolInfo& symbol_info : symbols.symbol_infos()) {
+  absl::flat_hash_map<uint64_t, const orbit_grpc_protos::SymbolInfo*> symbol_infos_by_address;
+  for (const orbit_grpc_protos::SymbolInfo& symbol_info : symbols.symbol_infos()) {
     symbol_infos_by_address.emplace(symbol_info.address(), &symbol_info);
   }
 
   ASSERT_EQ(symbol_infos_by_address.size(), 6868);
 
   {
-    const SymbolInfo* symbol = symbol_infos_by_address[0x0F187B];
+    const orbit_grpc_protos::SymbolInfo* symbol = symbol_infos_by_address[0x0F187B];
     ASSERT_NE(symbol, nullptr);
     EXPECT_EQ(symbol->demangled_name(), "FormatMessageW");
     EXPECT_EQ(symbol->address(), 0xF187B);
@@ -215,18 +206,18 @@ TYPED_TEST_P(PdbFileTest, CanObtainGuidAndAgeFromPdbAndDll) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.pdb";
 
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
-      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
-  ASSERT_THAT(pdb_file_result, HasNoError());
+      TypeParam::CreatePdbFile(file_path_pdb, orbit_object_utils::ObjectFileInfo{0x180000000});
+  ASSERT_THAT(pdb_file_result, orbit_test_utils::HasNoError());
   std::unique_ptr<orbit_object_utils::PdbFile> pdb_file = std::move(pdb_file_result.value());
 
   // We load the PDB debug info from the dll to see if it matches the data in the pdb.
   std::filesystem::path file_path = orbit_test::GetTestdataDir() / "dllmain.dll";
 
-  auto coff_file_or_error = CreateCoffFile(file_path);
-  ASSERT_THAT(coff_file_or_error, HasNoError());
+  auto coff_file_or_error = orbit_object_utils::CreateCoffFile(file_path);
+  ASSERT_THAT(coff_file_or_error, orbit_test_utils::HasNoError());
 
   auto pdb_debug_info_or_error = coff_file_or_error.value()->GetDebugPdbInfo();
-  ASSERT_THAT(pdb_debug_info_or_error, HasNoError());
+  ASSERT_THAT(pdb_debug_info_or_error, orbit_test_utils::HasNoError());
 
   EXPECT_EQ(pdb_file->GetAge(), pdb_debug_info_or_error.value().age);
   EXPECT_THAT(pdb_file->GetGuid(), testing::ElementsAreArray(pdb_debug_info_or_error.value().guid));
@@ -239,8 +230,8 @@ TYPED_TEST_P(PdbFileTest, CreatePdbFailsOnNonPdbFile) {
   std::filesystem::path file_path_pdb = orbit_test::GetTestdataDir() / "dllmain.dll";
 
   ErrorMessageOr<std::unique_ptr<orbit_object_utils::PdbFile>> pdb_file_result =
-      TypeParam::CreatePdbFile(file_path_pdb, ObjectFileInfo{0x180000000});
-  EXPECT_THAT(pdb_file_result, HasError("Unable to load PDB file"));
+      TypeParam::CreatePdbFile(file_path_pdb, orbit_object_utils::ObjectFileInfo{0x180000000});
+  EXPECT_THAT(pdb_file_result, orbit_test_utils::HasError("Unable to load PDB file"));
 }
 
 REGISTER_TYPED_TEST_SUITE_P(PdbFileTest, LoadDebugSymbols, LoadsFunctionsOnlyInPublicSymbols,


### PR DESCRIPTION
This is to avoid leaking the using declarations into the global namespace.