### PR TITLE
Update old conan packages

### DIFF
--- a/cmake/Findabsl.cmake
+++ b/cmake/Findabsl.cmake
@@ -2,6 +2,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+find_package(absl CONFIG)
+
+if(absl_FOUND)
+  return()
+endif()
+
+message("Abseil not found via CMake. Probably not a Conan build. Using the copy from third_party/")
+
 set(ABSL_PROPAGATE_CXX_STD ON)
 add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/abseil-cpp)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,6 @@ class OrbitConan(ConanFile):
                        "fPIC": True,
                        "run_tests": True,
                        "build_target": None}
-    _orbit_channel = "orbitdeps/stable"
     exports_sources = "CMakeLists.txt", "Orbit*", "bin/*", "cmake/*", "third_party/*", "LICENSE"
 
     def _version(self):
@@ -47,33 +46,29 @@ class OrbitConan(ConanFile):
             del self.options.fPIC
 
     def build_requirements(self):
-        self.build_requires('protoc_installer/3.9.1@bincrafters/stable#0')
-        self.build_requires('grpc_codegen/1.27.3@{}'.format(self._orbit_channel))
+        self.build_requires('protobuf/3.21.4')
+        self.build_requires('grpc/1.48.0')
         self.build_requires('gtest/1.11.0', force_host_context=True)
 
     def requirements(self):
-        self.requires("abseil/20211102.0")
-        self.requires("bzip2/1.0.8", override=True)
+        self.requires("abseil/20220623.0")
         self.requires("capstone/4.0.2")
-        self.requires("grpc/1.27.3@{}".format(self._orbit_channel))
-        self.requires("c-ares/1.15.0", override=True)
-        self.requires("llvm-core/12.0.0@{}".format(self._orbit_channel))
-        self.requires("openssl/1.1.1k", override=True)
-        self.requires("outcome/2.2.0")
+        self.requires("grpc/1.48.0")
+        self.requires("llvm-core/12.0.0@orbitdeps/stable")
+        self.requires("outcome/2.2.3")
         if self.settings.os != "Windows":
             self.requires("volk/1.2.170")
             self.requires("vulkan-headers/1.1.114.0")
-        self.requires("zlib/1.2.11#9e0c292b60ce77402bd9be60dd68266f", override=True)
+        self.requires("zlib/1.2.12", override=True)
 
         if self.options.with_gui:
-            self.requires("freetype/2.10.0@bincrafters/stable#0")
+            self.requires("freetype/2.12.1")
             self.requires("glad/0.1.34")
-            self.requires("imgui/1.85")
-            self.requires("libpng/1.6.37@bincrafters/stable#0", override=True)
-            self.requires("libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf")
+            self.requires("imgui/1.88")
+            self.requires("libssh2/1.10.0")
 
             if not self.options.system_qt:
-                self.requires("qt/5.15.1@{}#e659e981368e4baba1a201b75ddb89b6".format(self._orbit_channel))
+                self.requires("qt/5.15.6")
 
 
     def configure(self):
@@ -93,9 +88,6 @@ class OrbitConan(ConanFile):
         if self.options.with_gui:
 
             if not self.options.system_qt:
-                self.options["qt"].qtwebengine = True
-                self.options["qt"].qtwebchannel = True
-                self.options["qt"].qtwebsockets = True
                 self.options["qt"].shared = True
                 self.options["qt"].with_sqlite3 = False
                 self.options["qt"].with_mysql = False

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -117,7 +117,7 @@ if [ -n "$1" ]; then
   # That's a temporary solution. The docker containers should have the
   # correct version of conan already preinstalled. This step will be removed
   # when the docker containers are restructured and versioned.
-  pip3 install conan==1.46.0
+  pip3 install conan==1.53.0
 
   echo "Installing conan configuration (profiles, settings, etc.)..."
   ${REPO_ROOT}/third_party/conan/configs/install.sh ${PUBLIC_BUILD:+--force-public-remotes}

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -188,9 +188,8 @@ ErrorMessageOr<void> WaitForThreadToExit(pid_t pid, pid_t tid) {
 // These are the names of the threads that will be spawned when
 // liborbituserspaceinstrumentation.so is injected into the target process.
 std::multiset<std::string> GetExpectedOrbitThreadNames() {
-  static const std::multiset<std::string> kThreadNames{"default-executo", "resolver-execut",
-                                                       "grpc_global_tim", "grpc_global_tim",
-                                                       "ConnectRcvCmds",  "ForwarderThread"};
+  static const std::multiset<std::string> kThreadNames{
+      "default-executo", "resolver-execut", "grpc_global_tim", "ConnectRcvCmds", "ForwarderThread"};
   return kThreadNames;
 }
 

--- a/third_party/conan/configs/install.sh
+++ b/third_party/conan/configs/install.sh
@@ -45,6 +45,7 @@ if [ "$FORCE_PUBLIC_REMOTES" == "yes" ]; then
   elif [ -n "$ORBIT_OVERRIDE_ARTIFACTORY_URL" ]; then
     echo "Artifactory override detected. Adjusting public remote..."
     conan remote add -i 0 -f artifactory_public "$ORBIT_OVERRIDE_ARTIFACTORY_URL" || exit $?
+    conan remote disable conan-center || exit $?
   else
     LOCATION="$(curl -sI http://orbit-artifactory/ 2>/dev/null)"
 

--- a/third_party/conan/configs/linux/profiles/clang_common
+++ b/third_party/conan/configs/linux/profiles/clang_common
@@ -8,6 +8,8 @@ abseil:compiler=clang
 abseil:compiler.cppstd=17
 gtest:compiler=clang
 gtest:compiler.cppstd=17
+grpc:compiler=clang
+grpc:compiler.cppstd=17
 
 [env]
 gtest:CXXFLAGS=$CXX_FLAGS -std=c++17

--- a/third_party/conan/configs/linux/profiles/cmake_common
+++ b/third_party/conan/configs/linux/profiles/cmake_common
@@ -1,5 +1,4 @@
 [settings]
-cmake_installer:build_type=Release
 cmake:build_type=Release
 cmake:os=Linux
 cmake:os_build=Linux
@@ -7,4 +6,4 @@ cmake:arch=x86_64
 cmake:arch_build=x86_64
 
 [build_requires]
-&: cmake_installer/3.16.3@conan/stable
+&: cmake/3.24.1

--- a/third_party/conan/configs/linux/profiles/gcc_common
+++ b/third_party/conan/configs/linux/profiles/gcc_common
@@ -8,6 +8,8 @@ abseil:compiler=gcc
 abseil:compiler.cppstd=17
 gtest:compiler=gcc
 gtest:compiler.cppstd=17
+grpc:compiler=gcc
+grpc:compiler.cppstd=17
 
 [env]
 gtest:CXXFLAGS=$CXX_FLAGS -std=c++17

--- a/third_party/conan/configs/windows/profiles/cmake_common
+++ b/third_party/conan/configs/windows/profiles/cmake_common
@@ -7,4 +7,4 @@ cmake:arch=x86_64
 cmake:arch_build=x86_64
 
 [build_requires]
-&: cmake_installer/3.16.3@conan/stable
+&: cmake/3.24.1

--- a/third_party/conan/configs/windows/profiles/msvc2019_common
+++ b/third_party/conan/configs/windows/profiles/msvc2019_common
@@ -13,6 +13,8 @@ abseil:compiler=Visual Studio
 abseil:compiler.cppstd=17
 gtest:compiler=Visual Studio
 gtest:compiler.cppstd=17
+grpc:compiler=Visual Studio
+grpc:compiler.cppstd=17
 
 [options]
 OrbitProfiler:system_qt=False


### PR DESCRIPTION
This updates all our dependencies to the latest version available in Conan Center. LLVM-Core is excluded for now because the public recipe has bugs. For example the ZLIB support that we rely on is broken.

This is the next step to achieve 2 goals:

1. Getting rid of custom conan packages
2. Allowing to build Orbit with system dependencies.