### PR TITLE
Remove unneeded Qt components from find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,11 +105,7 @@ if(WITH_GUI)
     COMPONENTS Core
                Network
                Test
-               Widgets
-               WebEngine
-               WebEngineWidgets
-               WebSockets
-               WebChannel)
+               Widgets)
 endif()
 
 find_package(Filesystem REQUIRED)

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -27,8 +27,7 @@ done
 
 readonly REQUIRED_PACKAGES=( build-essential libglu1-mesa-dev mesa-common-dev \
                              libxmu-dev libxi-dev libopengl-dev qtbase5-dev \
-                             qtwebengine5-dev libqt5webchannel5-dev \
-                             libqt5websockets5-dev libxxf86vm-dev python3-pip )
+                             libxxf86vm-dev python3-pip )
 
 function add_ubuntu_universe_repo {
   sudo add-apt-repository universe


### PR DESCRIPTION
We didn't use the Web modules for a while. No need to keep them.