### PR TITLE
Depend on system LLVM instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ find_package(gte REQUIRED)
 find_package(libprotobuf-mutator REQUIRED)
 find_package(LZMA REQUIRED)
 find_package(absl REQUIRED)
+find_package(LLVM REQUIRED)
 
 if(WITH_GUI)
   find_package(OpenGL REQUIRED)

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -27,7 +27,7 @@ done
 
 readonly REQUIRED_PACKAGES=( build-essential libglu1-mesa-dev mesa-common-dev \
                              libxmu-dev libxi-dev libopengl-dev qtbase5-dev \
-                             libxxf86vm-dev python3-pip )
+                             libxxf86vm-dev python3-pip llvm-dev )
 
 function add_ubuntu_universe_repo {
   sudo add-apt-repository universe

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+
+find_package(LLVM CONFIG 16)
+
+if(NOT LLVM_FOUND)
+  find_package(LLVM CONFIG 15)
+endif()
+
+if(NOT LLVM_FOUND)
+  find_package(LLVM CONFIG 14)
+endif()
+
+if(NOT LLVM_FOUND)
+  find_package(LLVM CONFIG 13)
+endif()
+
+if(NOT LLVM_FOUND)
+  find_package(LLVM CONFIG 12 REQUIRED)
+endif()
+
+add_library(LLVMHeaders INTERFACE IMPORTED)
+target_include_directories(LLVMHeaders INTERFACE ${LLVM_INCLUDE_DIRS})

--- a/conanfile.py
+++ b/conanfile.py
@@ -54,7 +54,6 @@ class OrbitConan(ConanFile):
         self.requires("abseil/20220623.0")
         self.requires("capstone/4.0.2")
         self.requires("grpc/1.48.0")
-        self.requires("llvm-core/12.0.0@orbitdeps/stable")
         self.requires("outcome/2.2.3")
         if self.settings.os != "Windows":
             self.requires("volk/1.2.170")
@@ -81,9 +80,6 @@ class OrbitConan(ConanFile):
                 "We don't actively support building the UI for 32bit platforms. Please remove this check in conanfile.py if you still want to do so!")
 
         self.options["gtest"].no_main = True
-
-        if self.settings.os != "Windows":
-            self.options["llvm-core"].with_xml2 = False
 
         if self.options.with_gui:
 

--- a/src/CaptureClient/CMakeLists.txt
+++ b/src/CaptureClient/CMakeLists.txt
@@ -36,8 +36,7 @@ target_link_libraries(CaptureClient PUBLIC
         CaptureFile
         ClientData
         GrpcProtos
-        Introspection
-        CONAN_PKG::llvm-core)
+        Introspection)
 
 add_fuzzer(CaptureEventProcessorProcessEventsFuzzer CaptureEventProcessorProcessEventsFuzzer.cpp)
 target_link_libraries(CaptureEventProcessorProcessEventsFuzzer

--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -55,7 +55,12 @@ target_link_libraries(
          absl::synchronization
          absl::time
          absl::span
-         CONAN_PKG::llvm-core)
+         LLVMDebugInfoCodeView
+         LLVMDebugInfoDWARF
+         LLVMDebugInfoPDB
+         LLVMHeaders
+         LLVMObject
+         LLVMSymbolize)
 
 if (WIN32)
 target_link_libraries(ObjectUtils PUBLIC DIASDK::DIASDK)
@@ -84,8 +89,7 @@ target_link_libraries(
   ObjectUtilsTests
   PRIVATE ObjectUtils
           TestUtils
-          GTest::Main
-          CONAN_PKG::llvm-core)
+          GTest::Main)
 
 register_test(ObjectUtilsTests)
 


### PR DESCRIPTION
This replaces the conan package `llvm-core`. Instead we use the LLVM version that is installed on the host system.

At this point we will temporarily not support the conan package anymore, because the official conan package has a bug
and does not provide ZLIB support (which we need for compressed debug section). Until this is fixed we will only support
LLVM as a system library.

I'm planning on bringing back LLVM support through Conan once the package has been fixed.