### PR TITLE
Avoid dangling reference with old version of outcome

### DIFF
--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackReportConfigValidator.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackReportConfigValidator.h
@@ -34,13 +34,15 @@ class SamplingWithFrameTrackReportConfigValidatorTmpl {
       const BaselineAndComparison* baseline_and_comparison,
       const Baseline<HalfConfig>& baseline_config,
       const Comparison<HalfConfig>& comparison_config) const {
-    OUTCOME_TRY(*LiftAndApply(&ValidateConfig, baseline_config,
-                              baseline_and_comparison->GetBaselineData(),
-                              orbit_mizar_base::QBaselineTitle()));
+    ErrorMessageOr<void> baseline_validation_result =
+        *LiftAndApply(&ValidateConfig, baseline_config, baseline_and_comparison->GetBaselineData(),
+                      orbit_mizar_base::QBaselineTitle());
+    OUTCOME_TRY(baseline_validation_result);
 
-    OUTCOME_TRY(*LiftAndApply(&ValidateConfig, comparison_config,
-                              baseline_and_comparison->GetComparisonData(),
-                              orbit_mizar_base::QComparisonTitle()));
+    ErrorMessageOr<void> comparison_validation_result = *LiftAndApply(
+        &ValidateConfig, comparison_config, baseline_and_comparison->GetComparisonData(),
+        orbit_mizar_base::QComparisonTitle());
+    OUTCOME_TRY(comparison_validation_result);
 
     return outcome::success();
   }


### PR DESCRIPTION
I'm trying to make the code base compatible with old versions of OUTCOME where the OUTCOME_TRY macro was capturing the expression result in a universal reference instead of in a value.

I.e. this
```cpp
auto&& result = (expr);
if (result.has_value()) out = std::move(result.value());
```

instead of this:
```cpp
auto result = (expr);
if (result.has_value()) out = std::move(result).value();
```

This leads to a compile error (dangling reference), when `expr` is returning a reference to a temporary with a shorter lifetime.

This is the case for `LiftApply` because it retruns a `Typedef` containing an `ErrorMessageOr`. The temporary Typedef will be destroyed before `result` (from the example above) gets out of scope.

A fix is to avoid `OUTCOME_TRY` in this case. It's the only location in the code that suffers from this problem.