### PR TITLE
Add SessionSetup::OrbitServiceInstance class

### DIFF
--- a/src/SessionSetup/CMakeLists.txt
+++ b/src/SessionSetup/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
           include/SessionSetup/DeploymentConfigurations.h
           include/SessionSetup/DoubleClickableLabel.h
           include/SessionSetup/Error.h
+          include/SessionSetup/OrbitServiceInstance.h
           include/SessionSetup/OverlayWidget.h
           include/SessionSetup/OtherUserDialog.h
           include/SessionSetup/PersistentStorage.h
@@ -38,6 +39,7 @@ target_sources(
           ConnectToTargetDialog.ui
           DeploymentConfigurations.cpp
           Error.cpp
+          OrbitServiceInstance.cpp
           OtherUserDialog.cpp
           OtherUserDialog.ui
           OverlayWidget.cpp
@@ -86,6 +88,7 @@ target_sources(
           DoubleClickableLabelTest.cpp
           PersistentStorageTest.cpp
           ProcessItemModelTest.cpp
+          OrbitServiceInstanceTest.cpp
           OtherUserDialogTest.cpp
           RetrieveInstancesTest.cpp
           RetrieveInstancesWidgetTest.cpp

--- a/src/SessionSetup/OrbitServiceInstance.cpp
+++ b/src/SessionSetup/OrbitServiceInstance.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SessionSetup/OrbitServiceInstance.h"
+
+#include <absl/strings/str_format.h>
+
+#include <QCoreApplication>
+#include <QMetaEnum>
+#include <QProcess>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
+
+namespace orbit_session_setup {
+
+constexpr int kWaitTimeInMilliSeconds = 2000;
+
+class OrbitServiceInstanceImpl : public OrbitServiceInstance {
+ public:
+  explicit OrbitServiceInstanceImpl(const QString& program, const QStringList& arguments);
+  ~OrbitServiceInstanceImpl() override;
+
+  [[nodiscard]] bool IsRunning() const override;
+  [[nodiscard]] ErrorMessageOr<void> Shutdown() override;
+
+  [[nodiscard]] ErrorMessageOr<void> Start();
+
+ private:
+  [[nodiscard]] std::string GetStateErrorAndOutput();
+
+  QProcess process_;
+  QMetaObject::Connection finished_connection_;
+};
+
+ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> OrbitServiceInstance::Create(
+    const QString& program, const QStringList& arguments) {
+  auto instance = std::make_unique<OrbitServiceInstanceImpl>(program, arguments);
+  OUTCOME_TRY(instance->Start());
+
+  return std::move(instance);
+}
+
+ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> OrbitServiceInstance::CreatePrivileged() {
+  const QString orbit_service_path = QCoreApplication::applicationDirPath() + "/OrbitService";
+  return OrbitServiceInstance::Create("/usr/bin/pkexec", {orbit_service_path});
+}
+
+OrbitServiceInstanceImpl::OrbitServiceInstanceImpl(const QString& program,
+                                                   const QStringList& arguments) {
+  process_.setProgram(program);
+  process_.setArguments(arguments);
+}
+
+OrbitServiceInstanceImpl::~OrbitServiceInstanceImpl() {
+  if (!IsRunning()) return;
+
+  ErrorMessageOr<void> shutdown_result = Shutdown();
+
+  if (shutdown_result.has_error()) {
+    ORBIT_ERROR("OrbitService shutdown error: %s", shutdown_result.error().message());
+  }
+}
+
+bool OrbitServiceInstanceImpl::IsRunning() const {
+  return process_.state() == QProcess::ProcessState::Running;
+}
+
+ErrorMessageOr<void> OrbitServiceInstanceImpl::Shutdown() {
+  if (!IsRunning()) {
+    return ErrorMessage{"Unable to shutdown OrbitService, process is not running."};
+  }
+
+  QObject::disconnect(finished_connection_);
+
+  // This sends EOF, which signals to OrbitService to shut itself down.
+  process_.closeWriteChannel();
+
+  bool wait_finished_result = process_.waitForFinished(kWaitTimeInMilliSeconds);
+  if (!wait_finished_result) {
+    return ErrorMessage{"The OrbitService shutdown attempt failed."};
+  }
+  return outcome::success();
+}
+
+ErrorMessageOr<void> OrbitServiceInstanceImpl::Start() {
+  if (IsRunning()) {
+    return ErrorMessage{"Unable to start OrbitService, process is already running."};
+  }
+
+  process_.start();
+
+  bool wait_started_result = process_.waitForStarted(kWaitTimeInMilliSeconds);
+  if (!wait_started_result || !IsRunning()) {
+    return ErrorMessage{
+        absl::StrFormat("Unable to start OrbitService. Details:\n%s", GetStateErrorAndOutput())};
+  }
+
+  QObject::connect(&process_, &QProcess::errorOccurred, this,
+                   [this](const QProcess::ProcessError& error) {
+                     emit ErrorOccurred(
+                         QString("OrbitService process error occurred, description: %1")
+                             .arg(QMetaEnum::fromType<QProcess::ProcessError>().valueToKey(error)));
+                   });
+
+  finished_connection_ = QObject::connect(
+      &process_, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
+      [this](int exit_code, QProcess::ExitStatus exit_status) {
+        // If the process crashed, QProcess::errorOccurred is emitted. Hence a crash does not need
+        // to be handled here.
+        if (exit_status == QProcess::CrashExit) return;
+
+        emit ErrorOccurred(
+            QString("OrbitService process ended unexpectedly. exit code: %1").arg(exit_code));
+      });
+
+  QObject::connect(&process_, &QProcess::readyReadStandardOutput, this,
+                   [this]() { ORBIT_LOG("%s", process_.readAllStandardOutput().toStdString()); });
+
+  QObject::connect(&process_, &QProcess::readyReadStandardError, this,
+                   [this]() { ORBIT_LOG("%s", process_.readAllStandardError().toStdString()); });
+
+  return outcome::success();
+}
+
+std::string OrbitServiceInstanceImpl::GetStateErrorAndOutput() {
+  return absl::StrFormat("Process state: %s\nProcess error: %s\nstdout: %s\nstderr: %s\n",
+                         QMetaEnum::fromType<QProcess::ProcessState>().valueToKey(process_.state()),
+                         QMetaEnum::fromType<QProcess::ProcessError>().valueToKey(process_.error()),
+                         process_.readAllStandardOutput().toStdString(),
+                         process_.readAllStandardError().toStdString());
+}
+
+}  // namespace orbit_session_setup

--- a/src/SessionSetup/OrbitServiceInstance.cpp
+++ b/src/SessionSetup/OrbitServiceInstance.cpp
@@ -31,7 +31,7 @@ class OrbitServiceInstanceImpl : public OrbitServiceInstance {
   [[nodiscard]] ErrorMessageOr<void> Start();
 
  private:
-  [[nodiscard]] std::string GetStateErrorAndOutput();
+  [[nodiscard]] std::string ReadStateErrorAndOutput();
 
   QProcess process_;
   QMetaObject::Connection finished_connection_;
@@ -47,7 +47,7 @@ ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> OrbitServiceInstance::Crea
 
 ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> OrbitServiceInstance::CreatePrivileged() {
   const QString orbit_service_path = QCoreApplication::applicationDirPath() + "/OrbitService";
-  return OrbitServiceInstance::Create("/usr/bin/pkexec", {orbit_service_path});
+  return OrbitServiceInstance::Create("pkexec", {orbit_service_path});
 }
 
 OrbitServiceInstanceImpl::OrbitServiceInstanceImpl(const QString& program,
@@ -97,7 +97,7 @@ ErrorMessageOr<void> OrbitServiceInstanceImpl::Start() {
   bool wait_started_result = process_.waitForStarted(kWaitTimeInMilliSeconds);
   if (!wait_started_result || !IsRunning()) {
     return ErrorMessage{
-        absl::StrFormat("Unable to start OrbitService. Details:\n%s", GetStateErrorAndOutput())};
+        absl::StrFormat("Unable to start OrbitService. Details:\n%s", ReadStateErrorAndOutput())};
   }
 
   QObject::connect(&process_, &QProcess::errorOccurred, this,
@@ -127,7 +127,7 @@ ErrorMessageOr<void> OrbitServiceInstanceImpl::Start() {
   return outcome::success();
 }
 
-std::string OrbitServiceInstanceImpl::GetStateErrorAndOutput() {
+std::string OrbitServiceInstanceImpl::ReadStateErrorAndOutput() {
   return absl::StrFormat("Process state: %s\nProcess error: %s\nstdout: %s\nstderr: %s\n",
                          QMetaEnum::fromType<QProcess::ProcessState>().valueToKey(process_.state()),
                          QMetaEnum::fromType<QProcess::ProcessError>().valueToKey(process_.error()),

--- a/src/SessionSetup/OrbitServiceInstanceTest.cpp
+++ b/src/SessionSetup/OrbitServiceInstanceTest.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <QCoreApplication>

--- a/src/SessionSetup/OrbitServiceInstanceTest.cpp
+++ b/src/SessionSetup/OrbitServiceInstanceTest.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <memory>
+
+#include "OrbitBase/Result.h"
+#include "SessionSetup/OrbitServiceInstance.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_session_setup {
+
+using orbit_test_utils::HasNoError;
+
+TEST(OrbitServiceInstance, CreateAndShutdown) {
+  const QString orbit_service_path = QCoreApplication::applicationDirPath() + "/OrbitService";
+  ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> instance_or_error =
+      OrbitServiceInstance::Create(orbit_service_path, {});
+
+  ASSERT_THAT(instance_or_error, HasNoError());
+
+  OrbitServiceInstance& instance = *instance_or_error.value();
+  EXPECT_TRUE(instance.IsRunning());
+
+  QSignalSpy spy{&instance, &OrbitServiceInstance::ErrorOccurred};
+
+  EXPECT_THAT(instance.Shutdown(), HasNoError());
+
+  EXPECT_EQ(spy.count(), 0);
+}
+
+TEST(OrbitServiceInstance, ProcessEndsUnexpectedly) {
+  ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> instance_or_error =
+      OrbitServiceInstance::Create("sleep", {"0.1"});  // sleep 100 ms
+  ASSERT_THAT(instance_or_error, HasNoError());
+
+  OrbitServiceInstance& instance = *instance_or_error.value();
+  EXPECT_TRUE(instance.IsRunning());
+
+  bool lambda_called = false;
+  QObject::connect(&instance, &OrbitServiceInstance::ErrorOccurred, [&](const QString& message) {
+    EXPECT_THAT(message.toStdString(), testing::HasSubstr("ended unexpectedly. exit code: 0"));
+    lambda_called = true;
+    QCoreApplication::exit();
+  });
+
+  QCoreApplication::exec();
+  EXPECT_TRUE(lambda_called);
+}
+
+}  // namespace orbit_session_setup

--- a/src/SessionSetup/include/SessionSetup/OrbitServiceInstance.h
+++ b/src/SessionSetup/include/SessionSetup/OrbitServiceInstance.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SESSION_SETUP_ORBIT_SERVICE_INSTANCE_H_
+#define SESSION_SETUP_ORBIT_SERVICE_INSTANCE_H_
+
+#include <QObject>
+#include <QString>
+#include <filesystem>
+#include <memory>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_session_setup {
+
+// Abstracts a continuously running QProcess for using OrbitService on the client.
+class OrbitServiceInstance : public QObject {
+  Q_OBJECT;
+
+ public:
+  virtual ~OrbitServiceInstance() = default;
+  [[nodiscard]] virtual bool IsRunning() const = 0;
+  // Sends EOF to OrbitService and blocks until OrbitService ended.
+  [[nodiscard]] virtual ErrorMessageOr<void> Shutdown() = 0;
+
+  // Starts an OrbitService that is located next to client executable via pkexec. Blocks until
+  // pkexec has started.
+  [[nodiscard]] static ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> CreatePrivileged();
+  // Creates and starts `program` with `arguments`. Used for testing. Blocks until `program` has
+  // started.
+  [[nodiscard]] static ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> Create(
+      const QString& program, const QStringList& arguments);
+
+ signals:
+  // ErrorOccurred is emitted when an error with the process occurred _or_ when the process ends
+  // unexpected.
+  void ErrorOccurred(QString message);
+};
+
+}  // namespace orbit_session_setup
+
+#endif  // SESSION_SETUP_ORBIT_SERVICE_INSTANCE_H_


### PR DESCRIPTION
This class will be used in the next PR to start OrbitService from Orbit Client. 

To get an idea how this will be used: https://github.com/antonrohr/orbit/tree/test_exec_orbitservice (still work left todo around UI and error handling).

