### PR TITLE
Remove support for non system Qt

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -21,11 +21,11 @@ class OrbitConan(ConanFile):
     description = "C/C++ Performance Profiler"
     settings = "os", "compiler", "build_type", "arch"
     generators = ["cmake_multi", "CMakeDeps"]
-    options = {"system_qt": [True, False], "with_gui": [True, False],
+    options = {"with_gui": [True, False],
                "fPIC": [True, False],
                "run_tests": [True, False],
                "build_target": "ANY"}
-    default_options = {"system_qt": True, "with_gui": True,
+    default_options = {"with_gui": True,
                        "fPIC": True,
                        "run_tests": True,
                        "build_target": None}
@@ -66,9 +66,6 @@ class OrbitConan(ConanFile):
             self.requires("imgui/1.88")
             self.requires("libssh2/1.10.0")
 
-            if not self.options.system_qt:
-                self.requires("qt/5.15.6")
-
 
     def configure(self):
         if self.settings.os != "Windows" and not self.options.fPIC:
@@ -80,23 +77,6 @@ class OrbitConan(ConanFile):
                 "We don't actively support building the UI for 32bit platforms. Please remove this check in conanfile.py if you still want to do so!")
 
         self.options["gtest"].no_main = True
-
-        if self.options.with_gui:
-
-            if not self.options.system_qt:
-                self.options["qt"].shared = True
-                self.options["qt"].with_sqlite3 = False
-                self.options["qt"].with_mysql = False
-                self.options["qt"].with_pq = False
-                self.options["qt"].with_odbc = False
-                self.options["qt"].with_sdl2 = False
-                self.options["qt"].with_openal = False
-
-                if self.settings.os == "Windows":
-                    self.options["qt"].qttools = True
-                    self.options["qt"].with_glib = False
-                    self.options["qt"].with_harfbuzz = False
-                    self.options["qt"].opengl = "dynamic"
 
 
     def build(self):
@@ -162,17 +142,6 @@ class OrbitConan(ConanFile):
         self.copy("OrbitFakeClient", src="bin/", dst="bin")
         self.copy("OrbitFakeClient.debug", src="bin/", dst="bin")
         self.copy("msdia140.dll", src="bin/", dst="bin")
-
-        if not self.options.system_qt:
-            orbit_executable = "Orbit.exe" if self.settings.os == "Windows" else "Orbit"
-            self.run("windeployqt --pdb --no-angle {}".format(orbit_executable), cwd=os.path.join(self.package_folder, "bin"), run_environment=True)
-
-            # Package Visual C++ and C Runtime
-            vcvars = tools.vcvars_dict(self)
-            if 'VCToolsRedistDir' in vcvars:
-                arch = 'x64' if self.settings.arch == 'x86_64' else 'x86'
-                src_path = os.path.join(vcvars['VCToolsRedistDir'], arch, 'Microsoft.VC142.CRT')
-                self.copy("*.dll", src=src_path, dst="bin")
 
 
     def deploy(self):


### PR DESCRIPTION
We don't support and/or test this code path. And it simplifies the conanfile quite a bit. Let's remove it.