### PR TITLE
Introduce with_system_deps Conan option

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -24,11 +24,13 @@ class OrbitConan(ConanFile):
     options = {"with_gui": [True, False],
                "fPIC": [True, False],
                "run_tests": [True, False],
-               "build_target": "ANY"}
+               "build_target": "ANY",
+               "with_system_deps": [True, False]}
     default_options = {"with_gui": True,
                        "fPIC": True,
                        "run_tests": True,
-                       "build_target": None}
+                       "build_target": None,
+                       "with_system_deps": False}
     exports_sources = "CMakeLists.txt", "Orbit*", "bin/*", "cmake/*", "third_party/*", "LICENSE"
 
     def _version(self):

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -15,7 +15,8 @@ if [ -z "${CONAN_PROFILE}" ]; then
   declare -A profile_mapping=( \
     [ggp_relwithdebinfo]=skip \
     [msvc2019_relwithdebinfo]=skip \
-    [clang7_relwithdebinfo]=skip \
+    # We re-use the clang7 job to test the build with system dependencies until the other CI is up
+    [clang7_relwithdebinfo]=clang11_release_system_deps \
     [gcc9_relwithdebinfo]=skip \
     [iwyu]=skip \
     [coverage_clang9]=coverage_clang11 \

--- a/third_party/conan/configs/linux/profiles/clang11_release_system_deps
+++ b/third_party/conan/configs/linux/profiles/clang11_release_system_deps
@@ -1,0 +1,7 @@
+include(clang11_common)
+
+[settings]
+build_type=Release
+
+[options]
+OrbitProfiler:with_system_deps=True

--- a/third_party/conan/docker/digests.sh
+++ b/third_party/conan/docker/digests.sh
@@ -17,6 +17,7 @@ declare -rA docker_image_digest_mapping=(
   [clang9_relwithdebinfo]="gcr.io/orbitprofiler/clang9_release@sha256:02f1a69425bcf6039e309da82c1bcf4aa2aabbe1d45e4b481579b08b76f2a29d" \
   [clang9_debug]="gcr.io/orbitprofiler/clang9_debug@sha256:02f1a69425bcf6039e309da82c1bcf4aa2aabbe1d45e4b481579b08b76f2a29d" \
   [clang11_release]="gcr.io/orbitprofiler/clang11_debug@sha256:161a84fc066a6c6182a2c89b1f2eeff3354aa383ebc270dce600d4943f2880dc" \
+  [clang11_release_system_deps]="gcr.io/orbitprofiler/clang11_debug@sha256:161a84fc066a6c6182a2c89b1f2eeff3354aa383ebc270dce600d4943f2880dc" \
   [clang11_relwithdebinfo]="gcr.io/orbitprofiler/clang11_debug@sha256:161a84fc066a6c6182a2c89b1f2eeff3354aa383ebc270dce600d4943f2880dc" \
   [clang11_debug]="gcr.io/orbitprofiler/clang11_debug@sha256:161a84fc066a6c6182a2c89b1f2eeff3354aa383ebc270dce600d4943f2880dc" \
   [coverage_clang9]="gcr.io/orbitprofiler/coverage_clang9@sha256:4117216d27fe353879d36b5f3cbeadf6a4bb2f3ef4c0508b25ee4451f4b9e165" \


### PR DESCRIPTION
This option will allow to build Orbit (from Conan) but linked against
system dependencies for all dependencies that support that. So far that
is none of the Conan dependencies, but they will all be added one after
the other in subsequent PRs.
    
This PR also sets up the clang7 presubmit job as a "with system
dependencies" job such that we can test both build modes with the CI.

PR #4317 is an example on how this will look like.