### PR TITLE
Add support for libssh2 as a system dependency

### DIFF
--- a/cmake/FindLibssh2.cmake
+++ b/cmake/FindLibssh2.cmake
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+find_package(Libssh2 CONFIG)
+
+if(TARGET Libssh2::libssh2)
+  return()
+endif()
+
+message(STATUS "Libssh2 not found through find_package. Trying via pkg-config...")
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBSSH2 REQUIRED IMPORTED_TARGET libssh2)
+add_library(Libssh2::libssh2 ALIAS PkgConfig::LIBSSH2)

--- a/conanfile.py
+++ b/conanfile.py
@@ -66,7 +66,7 @@ class OrbitConan(ConanFile):
             self.requires("freetype/2.12.1")
             self.requires("glad/0.1.34")
             self.requires("imgui/1.88")
-            self.requires("libssh2/1.10.0")
+            if not self.options.with_system_deps: self.requires("libssh2/1.10.0")
 
 
     def configure(self):


### PR DESCRIPTION
The clang7 presubmit build is compiling with the with_system_deps option and confirms that it works with libssh2 from Ubuntu.