### PR TITLE
Support gRPC and protobuf as system dependencies

### DIFF
--- a/cmake/Findabsl.cmake
+++ b/cmake/Findabsl.cmake
@@ -2,13 +2,17 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-find_package(absl CONFIG)
+# We are skipping system-provided versions of Abseil here because
+# they are usually compiled in C++11 mode while we need Abseil compiled
+# in C++17 mode. Ideally we would check whether the provided Abseil version
+# was compiled in C++17 mode instead of discarding it right away.
+find_package(absl CONFIG NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
 
 if(absl_FOUND)
   return()
 endif()
 
-message("Abseil not found via CMake. Probably not a Conan build. Using the copy from third_party/")
+message("Abseil not found via find_package. Probably not a Conan build. Using the copy from third_party/")
 
 set(ABSL_PROPAGATE_CXX_STD ON)
 add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/abseil-cpp)

--- a/cmake/FindgRPC.cmake
+++ b/cmake/FindgRPC.cmake
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+find_package(gRPC CONFIG QUIET)
+
+if(TARGET gRPC::gRPC)
+  return()
+endif()
+
+message(STATUS "gRPC not found via find_package. Trying PkgConfig...")
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GRPC REQUIRED IMPORTED_TARGET grpc++_unsecure)
+target_link_libraries(PkgConfig::GRPC INTERFACE protobuf::protobuf)
+add_library(grpc::grpc ALIAS PkgConfig::GRPC)

--- a/cmake/Findprotobuf.cmake
+++ b/cmake/Findprotobuf.cmake
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+find_package(protobuf CONFIG QUIET)
+
+if(TARGET protobuf::protobuf)
+  return()
+endif()
+
+message(STATUS "Protobuf not found via find_package. Trying PkgConfig...")
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PROTOBUF REQUIRED IMPORTED_TARGET protobuf)
+add_library(protobuf::protobuf ALIAS PkgConfig::PROTOBUF)

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,14 +48,14 @@ class OrbitConan(ConanFile):
             del self.options.fPIC
 
     def build_requirements(self):
-        self.build_requires('protobuf/3.21.4')
-        self.build_requires('grpc/1.48.0')
-        self.build_requires('gtest/1.11.0', force_host_context=True)
+        if not self.options.with_system_deps: self.build_requires('protobuf/3.21.4')
+        if not self.options.with_system_deps: self.build_requires('grpc/1.48.0')
+        if not self.options.with_system_deps: self.build_requires('gtest/1.11.0', force_host_context=True)
 
     def requirements(self):
-        self.requires("abseil/20220623.0")
+        if not self.options.with_system_deps: self.requires("abseil/20220623.0")
         if not self.options.with_system_deps: self.requires("capstone/4.0.2")
-        self.requires("grpc/1.48.0")
+        if not self.options.with_system_deps: self.requires("grpc/1.48.0")
         if not self.options.with_system_deps: self.requires("outcome/2.2.3")
         if self.settings.os != "Windows":
             if not self.options.with_system_deps: self.requires("volk/1.3.224.1")

--- a/src/ApiLoader/EnableInTraceeLinux.cpp
+++ b/src/ApiLoader/EnableInTraceeLinux.cpp
@@ -32,7 +32,7 @@ using orbit_user_space_instrumentation::AnyThreadIsInStrictSeccompMode;
 using orbit_user_space_instrumentation::AttachAndStopNewThreadsOfProcess;
 using orbit_user_space_instrumentation::AttachAndStopProcess;
 using orbit_user_space_instrumentation::DetachAndContinueProcess;
-using orbit_user_space_instrumentation::DlopenInTracee;
+using orbit_user_space_instrumentation::DlmopenInTracee;
 using orbit_user_space_instrumentation::DlsymInTracee;
 using orbit_user_space_instrumentation::ExecuteInProcess;
 using orbit_user_space_instrumentation::ExecuteInProcessWithMicrosoftCallingConvention;
@@ -81,7 +81,7 @@ ErrorMessageOr<void> SetApiEnabledInTracee(const CaptureOptions& capture_options
   OUTCOME_TRY(auto&& liborbit_path, GetLibOrbitPath());
   ORBIT_LOG("Injecting library \"%s\" into process %d", liborbit_path, pid);
   OUTCOME_TRY(auto&& modules, orbit_module_utils::ReadModules(pid));
-  OUTCOME_TRY(auto&& handle, DlopenInTracee(pid, modules, liborbit_path, RTLD_NOW));
+  OUTCOME_TRY(auto&& handle, DlmopenInTracee(pid, modules, liborbit_path, RTLD_NOW));
   ORBIT_LOG("Resolving function pointers in injected library");
   constexpr const char* kSetEnabledFunction = "orbit_api_set_enabled";
   OUTCOME_TRY(auto&& orbit_api_set_enabled_function,

--- a/src/ApiLoader/EnableInTraceeLinux.cpp
+++ b/src/ApiLoader/EnableInTraceeLinux.cpp
@@ -36,6 +36,7 @@ using orbit_user_space_instrumentation::DlmopenInTracee;
 using orbit_user_space_instrumentation::DlsymInTracee;
 using orbit_user_space_instrumentation::ExecuteInProcess;
 using orbit_user_space_instrumentation::ExecuteInProcessWithMicrosoftCallingConvention;
+using orbit_user_space_instrumentation::LinkerNamespace;
 
 namespace {
 
@@ -81,7 +82,8 @@ ErrorMessageOr<void> SetApiEnabledInTracee(const CaptureOptions& capture_options
   OUTCOME_TRY(auto&& liborbit_path, GetLibOrbitPath());
   ORBIT_LOG("Injecting library \"%s\" into process %d", liborbit_path, pid);
   OUTCOME_TRY(auto&& modules, orbit_module_utils::ReadModules(pid));
-  OUTCOME_TRY(auto&& handle, DlmopenInTracee(pid, modules, liborbit_path, RTLD_NOW));
+  OUTCOME_TRY(auto&& handle, DlmopenInTracee(pid, modules, liborbit_path, RTLD_NOW,
+                                             LinkerNamespace::kUseInitialNamespace));
   ORBIT_LOG("Resolving function pointers in injected library");
   constexpr const char* kSetEnabledFunction = "orbit_api_set_enabled";
   OUTCOME_TRY(auto&& orbit_api_set_enabled_function,

--- a/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
@@ -52,7 +52,7 @@ class ExecuteInProcessTest : public testing::Test {
     auto modules_or_error = orbit_module_utils::ReadModules(pid_);
     ORBIT_CHECK(modules_or_error.has_value());
     auto library_handle_or_error =
-        DlopenInTracee(pid_, modules_or_error.value(), library_path, RTLD_NOW);
+        DlmopenInTracee(pid_, modules_or_error.value(), library_path, RTLD_NOW);
     ORBIT_CHECK(library_handle_or_error.has_value());
     library_handle_ = library_handle_or_error.value();
   }

--- a/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcessTest.cpp
@@ -51,8 +51,8 @@ class ExecuteInProcessTest : public testing::Test {
     // Load dynamic lib into tracee.
     auto modules_or_error = orbit_module_utils::ReadModules(pid_);
     ORBIT_CHECK(modules_or_error.has_value());
-    auto library_handle_or_error =
-        DlmopenInTracee(pid_, modules_or_error.value(), library_path, RTLD_NOW);
+    auto library_handle_or_error = DlmopenInTracee(pid_, modules_or_error.value(), library_path,
+                                                   RTLD_NOW, LinkerNamespace::kCreateNewNamespace);
     ORBIT_CHECK(library_handle_or_error.has_value());
     library_handle_ = library_handle_or_error.value();
   }

--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -41,10 +41,6 @@ struct FunctionLocatorView {
 constexpr FunctionLocatorView kDlmopenInLibdl{kLibdlSoname, "dlmopen"};
 constexpr FunctionLocatorView kDlmopenInLibc{kLibcSoname, "dlmopen"};
 
-constexpr FunctionLocatorView kDlopenInLibdl{kLibdlSoname, "dlopen"};
-constexpr FunctionLocatorView kDlopenInLibc{kLibcSoname, "dlopen"};
-constexpr FunctionLocatorView kDlopenFallbackInLibc{kLibcSoname, "__libc_dlopen_mode"};
-
 constexpr FunctionLocatorView kDlsymInLibdl{kLibdlSoname, "dlsym"};
 constexpr FunctionLocatorView kDlsymInLibc{kLibcSoname, "dlsym"};
 constexpr FunctionLocatorView kDlsymFallbackInLibc{kLibcSoname, "__libc_dlsym"};
@@ -86,7 +82,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
 
 }  // namespace
 
-[[nodiscard]] ErrorMessageOr<void*> DlopenInTracee(
+[[nodiscard]] ErrorMessageOr<void*> DlmopenInTracee(
     pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
     const std::filesystem::path& path, uint32_t flag) {
   // Make sure file exists.
@@ -99,20 +95,8 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
     return ErrorMessage(absl::StrFormat("Library does not exist at \"%s\"", path));
   }
 
-  // We will first look for dlmopen. If that function is not available we will fall back to dlopen.
-  // Both are handled in separate calls to FindFunctionAddressWithFallback because they have
-  // different function signatures.
-  ErrorMessageOr<uint64_t> dlmopen_address_or_error =
-      FindFunctionAddressWithFallback(modules, {kDlmopenInLibdl, kDlmopenInLibc});
-
-  std::optional<uint64_t> potentially_dlopen_address{};
-
-  if (!dlmopen_address_or_error.has_value()) {
-    // Figure out address of dlopen.
-    OUTCOME_TRY(potentially_dlopen_address,
-                FindFunctionAddressWithFallback(
-                    modules, {kDlopenInLibdl, kDlopenInLibc, kDlopenFallbackInLibc}));
-  }
+  OUTCOME_TRY(const uint64_t dlmopen_address,
+              FindFunctionAddressWithFallback(modules, {kDlmopenInLibdl, kDlmopenInLibc}));
 
   // Allocate small memory area in the tracee. This is used for the code and the path name.
   const uint64_t path_length = path.string().length() + 1;  // Include terminating zero.
@@ -130,60 +114,35 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
   const uint64_t so_path_address = code_memory->GetAddress() + kCodeScratchPadSize;
   OUTCOME_TRY(WriteTraceesMemory(pid, so_path_address, path_as_vector));
 
+  constexpr Lmid_t kLmid = LM_ID_NEWLM;
+
+  // We want to do the following in the tracee:
+  // return_value = dlmopen(lmid, path, flag)
+  // The calling convention is to put the parameters in registers rdi, rsi, and rdx.
+  // So the lmid goes to rdi, the address of the file path goes to rsi, and the flag argument
+  // goes into rcx. Then we load
+  // the address of dlmopen into rax and do the call. Assembly in Intel syntax (destination
+  // first), machine code on the right:
+
+  // movabsq rdi, lmid                48 bf lmid
+  // movabsq rsi, so_path_address     48 be so_path_address
+  // movl    edx, flag                ba flag
+  // movabsq rax, dlopen_address      48 b8 dlopen_address
+  // call    rax                      ff d0
+  // int3                             cc
   MachineCode code{};
+  code.AppendBytes({0x48, 0xbf})
+      .AppendImmediate64(kLmid)
+      .AppendBytes({0x48, 0xbe})
+      .AppendImmediate64(so_path_address)
+      .AppendBytes({0xba})
+      .AppendImmediate32(flag)
+      .AppendBytes({0x48, 0xb8})
+      .AppendImmediate64(dlmopen_address)
+      .AppendBytes({0xff, 0xd0})
+      .AppendBytes({0xcc});
 
-  if (dlmopen_address_or_error.has_value()) {
-    constexpr Lmid_t kLmid = LM_ID_NEWLM;
-
-    // We want to do the following in the tracee:
-    // return_value = dlmopen(lmid, path, flag)
-    // The calling convention is to put the parameters in registers rdi, rsi, and rdx.
-    // So the lmid goes to rdi, the address of the file path goes to rsi, and the flag argument
-    // goes into rcx. Then we load
-    // the address of dlmopen into rax and do the call. Assembly in Intel syntax (destination
-    // first), machine code on the right:
-
-    // movabs rdi, lmid                 48 bf lmid
-    // movabsq rsi, so_path_address     48 be so_path_address
-    // movl edx, flag                   ba flag
-    // movabsq rax, dlopen_address      48 b8 dlopen_address
-    // call rax                         ff d0
-    // int3                             cc
-    code.AppendBytes({0x48, 0xbf})
-        .AppendImmediate64(kLmid)
-        .AppendBytes({0x48, 0xbe})
-        .AppendImmediate64(so_path_address)
-        .AppendBytes({0xba})
-        .AppendImmediate32(flag)
-        .AppendBytes({0x48, 0xb8})
-        .AppendImmediate64(dlmopen_address_or_error.value())
-        .AppendBytes({0xff, 0xd0})
-        .AppendBytes({0xcc});
-
-  } else {
-    // We want to do the following in the tracee:
-    // return_value = dlopen(path, flag);
-    // The calling convention is to put the parameters in registers rdi and rsi.
-    // So the address of the file path goes to rdi. The flag argument goes into rsi. Then we load
-    // the address of dlopen into rax and do the call. Assembly in Intel syntax (destination first),
-    // machine code on the right:
-
-    // movabsq rdi, so_path_address     48 bf so_path_address
-    // movl esi, flag                   be flag
-    // movabsq rax, dlopen_address      48 b8 dlopen_address
-    // call rax                         ff d0
-    // int3                             cc
-    code.AppendBytes({0x48, 0xbf})
-        .AppendImmediate64(so_path_address)
-        .AppendBytes({0xbe})
-        .AppendImmediate32(flag)
-        .AppendBytes({0x48, 0xb8})
-        .AppendImmediate64(potentially_dlopen_address.value())
-        .AppendBytes({0xff, 0xd0})
-        .AppendBytes({0xcc});
-  }
-
-  OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(*code_memory, code));
+  OUTCOME_TRY(uint64_t return_value, ExecuteMachineCode(*code_memory, code));
   return absl::bit_cast<void*>(return_value);
 }
 

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -92,7 +92,8 @@ void OpenUseAndCloseLibrary(pid_t pid) {
   ASSERT_THAT(modules_or_error, orbit_test_utils::HasNoError());
   const std::vector<orbit_grpc_protos::ModuleInfo>& modules = modules_or_error.value();
 
-  auto library_handle_or_error = DlmopenInTracee(pid, modules, library_path, RTLD_NOW);
+  auto library_handle_or_error =
+      DlmopenInTracee(pid, modules, library_path, RTLD_NOW, LinkerNamespace::kCreateNewNamespace);
   ASSERT_TRUE(library_handle_or_error.has_value());
 
   // Tracee now does have the dynamic lib loaded.
@@ -210,7 +211,8 @@ TEST(InjectLibraryInTraceeTest, NonExistingLibrary) {
 
   // Try to load non existing dynamic lib into tracee.
   const std::string kNonExistingLibName = "libNotFound.so";
-  auto library_handle_or_error = DlmopenInTracee(pid, modules, kNonExistingLibName, RTLD_NOW);
+  auto library_handle_or_error = DlmopenInTracee(pid, modules, kNonExistingLibName, RTLD_NOW,
+                                                 LinkerNamespace::kCreateNewNamespace);
   ASSERT_THAT(library_handle_or_error, HasError("Library does not exist at"));
 
   // Continue child process.

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -92,7 +92,7 @@ void OpenUseAndCloseLibrary(pid_t pid) {
   ASSERT_THAT(modules_or_error, orbit_test_utils::HasNoError());
   const std::vector<orbit_grpc_protos::ModuleInfo>& modules = modules_or_error.value();
 
-  auto library_handle_or_error = DlopenInTracee(pid, modules, library_path, RTLD_NOW);
+  auto library_handle_or_error = DlmopenInTracee(pid, modules, library_path, RTLD_NOW);
   ASSERT_TRUE(library_handle_or_error.has_value());
 
   // Tracee now does have the dynamic lib loaded.
@@ -210,7 +210,7 @@ TEST(InjectLibraryInTraceeTest, NonExistingLibrary) {
 
   // Try to load non existing dynamic lib into tracee.
   const std::string kNonExistingLibName = "libNotFound.so";
-  auto library_handle_or_error = DlopenInTracee(pid, modules, kNonExistingLibName, RTLD_NOW);
+  auto library_handle_or_error = DlmopenInTracee(pid, modules, kNonExistingLibName, RTLD_NOW);
   ASSERT_THAT(library_handle_or_error, HasError("Library does not exist at"));
 
   // Continue child process.

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -400,7 +400,7 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
   // in the previous run.
   OUTCOME_TRY(const bool already_injected, AlreadyInjected(modules));
 
-  auto library_handle_or_error = DlopenInTracee(pid, modules, library_path, RTLD_NOW);
+  auto library_handle_or_error = DlmopenInTracee(pid, modules, library_path, RTLD_NOW);
   if (library_handle_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Unable to open library in tracee: %s",
                                         library_handle_or_error.error().message()));

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -400,7 +400,8 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
   // in the previous run.
   OUTCOME_TRY(const bool already_injected, AlreadyInjected(modules));
 
-  auto library_handle_or_error = DlmopenInTracee(pid, modules, library_path, RTLD_NOW);
+  auto library_handle_or_error =
+      DlmopenInTracee(pid, modules, library_path, RTLD_NOW, LinkerNamespace::kCreateNewNamespace);
   if (library_handle_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Unable to open library in tracee: %s",
                                         library_handle_or_error.error().message()));

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -591,7 +591,7 @@ class InstrumentFunctionTest : public testing::Test {
     const std::vector<orbit_grpc_protos::ModuleInfo>& modules = modules_or_error.value();
 
     // Inject the payload for the instrumentation.
-    auto library_handle_or_error = DlopenInTracee(pid_, modules, library_path, RTLD_NOW);
+    auto library_handle_or_error = DlmopenInTracee(pid_, modules, library_path, RTLD_NOW);
     ORBIT_CHECK(library_handle_or_error.has_value());
     void* library_handle = library_handle_or_error.value();
 

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -591,7 +591,8 @@ class InstrumentFunctionTest : public testing::Test {
     const std::vector<orbit_grpc_protos::ModuleInfo>& modules = modules_or_error.value();
 
     // Inject the payload for the instrumentation.
-    auto library_handle_or_error = DlmopenInTracee(pid_, modules, library_path, RTLD_NOW);
+    auto library_handle_or_error = DlmopenInTracee(pid_, modules, library_path, RTLD_NOW,
+                                                   LinkerNamespace::kCreateNewNamespace);
     ORBIT_CHECK(library_handle_or_error.has_value());
     void* library_handle = library_handle_or_error.value();
 

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
@@ -21,7 +21,7 @@ namespace orbit_user_space_instrumentation {
 // Open, use, and close dynamic library in the tracee. The functions here resemble the respective
 // functions offered by libdl as documented e.g. here: https://linux.die.net/man/3/dlopen. We rely
 // on either libdl or libc being loaded into the tracee.
-[[nodiscard]] ErrorMessageOr<void*> DlopenInTracee(
+[[nodiscard]] ErrorMessageOr<void*> DlmopenInTracee(
     pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
     const std::filesystem::path& path, uint32_t flag);
 [[nodiscard]] ErrorMessageOr<void*> DlsymInTracee(

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
@@ -18,12 +18,18 @@
 
 namespace orbit_user_space_instrumentation {
 
+// kUseInitialNamespace means dlmopen will behave like dlopen.
+// You can use kCreateNewNamespace to instruct dlmopen to load all
+// transitive dependencies in a separate namespace which means shared
+// libraries will not be shared with the target process.
+enum class LinkerNamespace { kUseInitialNamespace, kCreateNewNamespace };
+
 // Open, use, and close dynamic library in the tracee. The functions here resemble the respective
 // functions offered by libdl as documented e.g. here: https://linux.die.net/man/3/dlopen. We rely
 // on either libdl or libc being loaded into the tracee.
 [[nodiscard]] ErrorMessageOr<void*> DlmopenInTracee(
     pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
-    const std::filesystem::path& path, uint32_t flag);
+    const std::filesystem::path& path, uint32_t flag, LinkerNamespace linker_namespace);
 [[nodiscard]] ErrorMessageOr<void*> DlsymInTracee(
     pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* handle,
     std::string_view symbol);


### PR DESCRIPTION
This also makes a change to user space instrumentation.

When using gRPC and protobuf from system dependencies we are required to
link dynamically. This messes with our tests because we can't inject the
same proto definitions twice into the same process when both proto
definitions share the same protobuf implementation (which is the case
for dynamic linking of libprotobuf).

To solve that this change reworks the library injection code to use
dlmopen() instead of dlopen and open a new library namespace in the
target process. That means libprotobuf can be loaded twice and both
set of symbols won't interfere. This also helps encapsulating the
instrumentation library better from the target process.