### PR TITLE
Add basic CMake install routine

### DIFF
--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -30,3 +30,13 @@ target_link_libraries(Api PUBLIC
         ProducerSideChannel)
 
 strip_symbols(Api)
+
+if (WIN32)
+install(TARGETS Api
+        CONFIGURATIONS Release
+        RUNTIME DESTINATION /opt/orbitprofiler)
+else()
+install(TARGETS Api
+        CONFIGURATIONS Release
+        LIBRARY DESTINATION /opt/orbitprofiler)
+endif()

--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -31,11 +31,7 @@ target_link_libraries(Api PUBLIC
 
 strip_symbols(Api)
 
-if (WIN32)
-install(TARGETS Api
-        CONFIGURATIONS Release
-        RUNTIME DESTINATION /opt/orbitprofiler)
-else()
+if (NOT WIN32)
 install(TARGETS Api
         CONFIGURATIONS Release
         LIBRARY DESTINATION /opt/orbitprofiler)

--- a/src/ApiInterface/CMakeLists.txt
+++ b/src/ApiInterface/CMakeLists.txt
@@ -12,6 +12,13 @@ target_sources(ApiInterface INTERFACE
 target_include_directories(ApiInterface INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/include)
 
+set_target_properties(ApiInterface PROPERTIES
+        PUBLIC_HEADER include/ApiInterface/Orbit.h)
+
+install(TARGETS ApiInterface
+        CONFIGURATIONS Release
+        PUBLIC_HEADER DESTINATION /opt/orbitprofiler)
+
 
 # This needs to be an executable because we also need to verify linking.
 add_executable(ApiHeaderBuildsInCTest)

--- a/src/ApiInterface/CMakeLists.txt
+++ b/src/ApiInterface/CMakeLists.txt
@@ -15,10 +15,11 @@ target_include_directories(ApiInterface INTERFACE
 set_target_properties(ApiInterface PROPERTIES
         PUBLIC_HEADER include/ApiInterface/Orbit.h)
 
+if (NOT WIN32)
 install(TARGETS ApiInterface
         CONFIGURATIONS Release
         PUBLIC_HEADER DESTINATION /opt/orbitprofiler)
-
+endif()
 
 # This needs to be an executable because we also need to verify linking.
 add_executable(ApiHeaderBuildsInCTest)

--- a/src/Orbit/CMakeLists.txt
+++ b/src/Orbit/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 
 strip_symbols(Orbit)
 
+if (NOT WIN32)
 install(TARGETS Orbit
         CONFIGURATIONS Release
         RUNTIME DESTINATION /opt/orbitprofiler)
@@ -47,3 +48,4 @@ install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/fonts"
         DESTINATION /opt/orbitprofiler)
 install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/shaders"
         DESTINATION /opt/orbitprofiler)
+endif()

--- a/src/Orbit/CMakeLists.txt
+++ b/src/Orbit/CMakeLists.txt
@@ -38,3 +38,12 @@ if(WIN32)
 endif()
 
 strip_symbols(Orbit)
+
+install(TARGETS Orbit
+        CONFIGURATIONS Release
+        RUNTIME DESTINATION /opt/orbitprofiler)
+
+install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/fonts"
+        DESTINATION /opt/orbitprofiler)
+install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/shaders"
+        DESTINATION /opt/orbitprofiler)

--- a/src/OrbitVulkanLayer/CMakeLists.txt
+++ b/src/OrbitVulkanLayer/CMakeLists.txt
@@ -53,6 +53,11 @@ target_link_libraries(OrbitVulkanLayer PRIVATE
 
 strip_symbols(OrbitVulkanLayer)
 
+install(TARGETS OrbitVulkanLayer
+        CONFIGURATIONS Release
+        LIBRARY DESTINATION /opt/orbitprofiler)
+
+
 add_executable(OrbitVulkanLayerTests)
 
 target_sources(OrbitVulkanLayerTests PRIVATE

--- a/src/OrbitVulkanLayer/CMakeLists.txt
+++ b/src/OrbitVulkanLayer/CMakeLists.txt
@@ -53,10 +53,11 @@ target_link_libraries(OrbitVulkanLayer PRIVATE
 
 strip_symbols(OrbitVulkanLayer)
 
+if (NOT WIN32)
 install(TARGETS OrbitVulkanLayer
         CONFIGURATIONS Release
         LIBRARY DESTINATION /opt/orbitprofiler)
-
+endif()
 
 add_executable(OrbitVulkanLayerTests)
 

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -46,6 +46,8 @@ target_link_libraries(OrbitService PRIVATE
 
 strip_symbols(OrbitService)
 
+if (NOT WIN32)
 install(TARGETS OrbitService
         CONFIGURATIONS Release
         RUNTIME DESTINATION /opt/orbitprofiler)
+endif()

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -45,3 +45,7 @@ target_link_libraries(OrbitService PRIVATE
   absl::flags_parse)
 
 strip_symbols(OrbitService)
+
+install(TARGETS OrbitService
+        CONFIGURATIONS Release
+        RUNTIME DESTINATION /opt/orbitprofiler)

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -88,6 +88,10 @@ target_link_libraries(OrbitUserSpaceInstrumentation PUBLIC
 
 strip_symbols(OrbitUserSpaceInstrumentation)
 
+install(TARGETS OrbitUserSpaceInstrumentation
+        CONFIGURATIONS Release
+        LIBRARY DESTINATION /opt/orbitprofiler)
+
 # This test lib is merely used in UserSpaceInstrumentationTests below. The
 # binary libUserSpaceInstrumentationTestLib.so created from this target is used
 # to test the injection mechanism.

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -88,9 +88,11 @@ target_link_libraries(OrbitUserSpaceInstrumentation PUBLIC
 
 strip_symbols(OrbitUserSpaceInstrumentation)
 
+if (NOT WIN32)
 install(TARGETS OrbitUserSpaceInstrumentation
         CONFIGURATIONS Release
         LIBRARY DESTINATION /opt/orbitprofiler)
+endif()
 
 # This test lib is merely used in UserSpaceInstrumentationTests below. The
 # binary libUserSpaceInstrumentationTestLib.so created from this target is used


### PR DESCRIPTION
This is the first step of making Orbit "installable". It installs all "relevant" files into "/opt/orbitprofiler".

The targets that get installed are:
- Orbit + the necessary "shaders" and "font" directories
- OrbitService
- UserSpaceInstrumentation
- liborbit (manual instrumentation)
- OrbitVulkanLayer
- Orbit.h

Test: run install locally. Perform local profiling.