### PR TITLE
Create a method to consistently draw boxes in OrbitGl

### DIFF
--- a/src/OrbitGl/MockTimelineInfo.h
+++ b/src/OrbitGl/MockTimelineInfo.h
@@ -51,6 +51,12 @@ class MockTimelineInfo : public TimelineInfoInterface {
     max_capture_ns_ = std::max(max_capture_ns_, max_tick);
   }
 
+  [[nodiscard]] std::pair<float, float> GetBoxPosXAndWidthFromTicks(
+      uint64_t start_tick, uint64_t end_tick) const override {
+    float start_x = GetWorldFromTick(start_tick);
+    float end_x = GetWorldFromTick(end_tick);
+    return {start_x, end_x - start_x};
+  }
   MOCK_METHOD(void, ZoomTime, (int, double), (override));
 
  private:

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -299,6 +299,7 @@ void ThreadStateBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
 
         auto [box_start_x, box_width] = timeline_info_->GetBoxPosXAndWidthFromTicks(
             slice.begin_timestamp_ns(), slice.end_timestamp_ns());
+
         const Vec2 pos{box_start_x, GetPos()[1]};
         const Vec2 size{box_width, GetHeight()};
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -297,12 +297,10 @@ void ThreadStateBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
           return;
         }
 
-        const float x0 = timeline_info_->GetWorldFromTick(slice.begin_timestamp_ns());
-        const float x1 = timeline_info_->GetWorldFromTick(slice.end_timestamp_ns());
-        const float width = x1 - x0;
-
-        const Vec2 pos{x0, GetPos()[1]};
-        const Vec2 size{width, GetHeight()};
+        auto [box_start_x, box_width] = timeline_info_->GetBoxPosXAndWidthFromTicks(
+            slice.begin_timestamp_ns(), slice.end_timestamp_ns());
+        const Vec2 pos{box_start_x, GetPos()[1]};
+        const Vec2 size{box_width, GetHeight()};
 
         if (slice == app_->hovered_thread_state_slice() ||
             slice == app_->selected_thread_state_slice()) {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -76,6 +76,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] double GetMinTimeUs() const override { return min_time_us_; }
   [[nodiscard]] double GetMaxTimeUs() const override { return max_time_us_; }
   [[nodiscard]] uint64_t GetCaptureTimeSpanNs() const override;
+  [[nodiscard]] std::pair<float, float> GetBoxPosXAndWidthFromTicks(
+      uint64_t start_tick, uint64_t end_tick) const override;
 
   void UpdateCaptureMinMaxTimestamps();
 

--- a/src/OrbitGl/TimelineInfoInterface.h
+++ b/src/OrbitGl/TimelineInfoInterface.h
@@ -25,6 +25,10 @@ class TimelineInfoInterface {
   [[nodiscard]] virtual double GetMaxTimeUs() const = 0;
 
   virtual void ZoomTime(int zoom_delta, double center_time_ratio) = 0;
+  // Translation from start and end ticks to box position and width, to be consistently used across
+  // CaptureViewElements. It will extend boxes to the border of the pixels.
+  [[nodiscard]] virtual std::pair<float, float> GetBoxPosXAndWidthFromTicks(
+      uint64_t start_tick, uint64_t end_tick) const = 0;
 
   [[nodiscard]] virtual uint64_t GetCaptureTimeSpanNs() const = 0;
 };


### PR DESCRIPTION
In this PR we are just moving a method to draw boxes from SchedulerTrack to TimelineInfoInterface. 
This will help to solve the glitches when drawing boxes in the Capture Window (for example, see 
https://github.com/google/orbit/pull/4127 for ThreadTracks). The implementation of this method
will extend the box to the pixel borders as it's doing in the SchedulerTrack.  

This method is needed for ThreadStates (https://github.com/google/orbit/pull/4274), to draw
consistently after applying the pixel rendering optimization.

Test: Load a capture, everything looks as expected.