### PR TITLE
Optimize rendering of ThreadStateBar

### DIFF
--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -127,7 +127,7 @@ class CaptureData {
       uint32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
       const std::function<void(const ThreadStateSliceInfo&)>& action) const;
 
-  // Similar to the previous one, but does not iterate for more than one slice per pixel.
+  // Similar to the previous one, but does not iterate over more than one slice per pixel.
   void ForEachThreadStateSliceIntersectingTimeRangeDiscretized(
       uint32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp, uint32_t resolution,
       const std::function<void(const ThreadStateSliceInfo&)>& action) const;

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -127,6 +127,11 @@ class CaptureData {
       uint32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
       const std::function<void(const ThreadStateSliceInfo&)>& action) const;
 
+  // Similar to the previous one, but does not iterate for more than one slice per pixel.
+  void ForEachThreadStateSliceIntersectingTimeRangeDiscretized(
+      uint32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp, uint32_t resolution,
+      const std::function<void(const ThreadStateSliceInfo&)>& action) const;
+
   [[nodiscard]] const ScopeStats& GetScopeStatsOrDefault(ScopeId scope_id) const;
 
   void UpdateScopeStats(const TimerInfo& timer_info);


### PR DESCRIPTION
In this PR we are following the plan designed in go/stadia-orbit-rendering-60fps for ThreadStates. We are optimizing its rendering by iterating through pixels as we recently implemented for both SchedulerTrack (https://github.com/google/orbit/pull/4156) and CallstackThreadBar (https://github.com/google/orbit/pull/4271).

The implementation is quite similar to CallstackThreadBar:
- ForEach...Discretized method in CaptureData who iterates through pixels using lower_bound queries.
- UnitTests in CaptureDataTest.
- A completely simplified implementation in ThreadStateBar that use the new method instead of having its own implementation

As a result we are rendering each ThreadStateBar up to 4x times faster (1.2ms instead of 4.8ms for some with several events) when zooming-out in the 5-min capture introduced in the design doc.

Overall rendering time (5min capture - 1200 pixels width - fully zoomed out, fully scaled so every Track is rendered):
Before: ~175.999ms (http://screenshot/crXutG4s66CSETh)
After: ~118.819ms (http://screenshot/9YyvGUmkk8Paeuv)
Improvement: ~67.5%

The new visual appearence can be seen here: http://screenshot/6iLSpkSr5QJc3Ka
We are also fixing an issue. Before this PR blue slices has bigger priority to be rendered and were more visible misleading the user (Border case: http://screenshot/5CNdZd89H5wn9pi). Now we are taking the first one at each pixel. This isn't perfect (because anti-aliasing), but it's still better than the current implementation.

Bug: http://b/253429871
Test: Load a capture. Zoom-out entirely, zoom-in to the maximum. See ThreadStates rendering looks as it's expected.