### PR TITLE
Build a Debian Package Nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
              debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
              --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache       \
+             --preserve-envvar=GITHUB_WORKSPACE                    \
              --preserve-envvar=CCACHE_BASEDIR                      \
              --preserve-envvar=CCACHE_DIR                          \
              --preserve-envvar=CCACHE_COMPRESS                     \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-name: build-and-test
+name: release
 on:
   schedule:
   - cron: '0 7 * * *'
@@ -34,6 +34,7 @@ jobs:
            sudo apt update &&                             \
            sudo apt install --yes --no-install-recommends \
            build-essential                                \
+           devscripts                                     \
            cmake                                          \
            ccache                                         \
            libboost-dev                                   \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
              -b
       - name: CCache Stats
         run: ccache -s
+      - run: ls -la .
       - name: Archive Debian Packages
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,4 +75,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: debian-packages
-          path: *.deb
+          path: | 
+            *.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: '0'
           path: workspace
-      - run: cd workspace/orbit
+      - run: cd workspace
       - name: Install dependencies
         run: |
            sudo apt update &&                             \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,4 +75,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: debian-packages
-          path: workspace
+          path: *.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+name: build-and-test
+on:
+  schedule:
+  - cron: '0 7 * * *'
+  # This is for testing the action only.
+  pull_request:
+    branches:
+    - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-debian-package:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    env:
+      CCACHE_BASEDIR: "${GITHUB_WORKSPACE}"
+      CCACHE_DIR: "${GITHUB_WORKSPACE}/.ccache"
+      CCACHE_COMPRESS: "true"
+      CCACHE_COMPRESSLEVEL: "6"
+      CCACHE_MAXSIZE: "400M"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: Install dependencies
+        run: |
+           sudo apt update &&                             \
+           sudo apt install --yes --no-install-recommends \
+           build-essential                                \
+           cmake                                          \
+           ccache                                         \
+           libboost-dev                                   \
+           libcapstone-dev                                \
+           libgrpc++-dev                                  \
+           libssh2-1-dev                                  \
+           vulkan-validationlayers-dev                    \
+           libz-dev                                       \
+           llvm-dev                                       \
+           libfreetype6-dev                               \
+           libimgui-dev                                   \
+           protobuf-compiler-grpc                         \
+           pkg-config                                     \
+           libvulkan-volk-dev                             \
+           libvulkan-dev                                  \
+           libopengl-dev                                  \
+           libglx-dev                                     \
+           mesa-common-dev                                \
+           qtbase5-dev                                    \
+           libgtest-dev                                   \
+           libgmock-dev                                   \
+           git                                            \
+           libprotobuf-dev
+      - run: mkdir build && cd build
+      - name: Save CCache Timestamp
+        id: ccache_timestamp
+        run: echo "timestamp=$(date +%m-%d-%Y--%H:%M:%S)" >> $GITHUB_OUTPUT
+      - name: Setup CCache Files
+        uses: actions/cache@v3
+        with:
+          path: .ccache
+          key: ccache-${{ steps.ccache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ccache-
+      - run: ccache -p
+      - run: ccache -z
+      - name: Build Debian Package
+        run: debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache -b
+      - name: CCache Stats
+        run: ccache -s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
       CCACHE_COMPRESSLEVEL: "6"
       CCACHE_MAXSIZE: "400M"
     steps:
-      - run: ls .
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
@@ -43,8 +42,8 @@ jobs:
            equivs                                         \
            fakeroot
       - name: Install Debian Build Dependencies
-        run: cd workspace && ls . && sudo mk-build-deps --install debian/control
-      - run: mkdir build && cd build
+        working-directory: ./workspace
+        run: sudo mk-build-deps --install debian/control
       - name: Save CCache Timestamp
         id: ccache_timestamp
         run: echo "timestamp=$(date +%m-%d-%Y--%H:%M:%S)" >> $GITHUB_OUTPUT
@@ -59,6 +58,7 @@ jobs:
       - run: ccache -p
       - run: ccache -z
       - name: Build Debian Package
+        working-directory: ./workspace
         run: debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
              --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache       \
              --preserve-envvar=CCACHE_BASEDIR                      \
@@ -73,4 +73,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: debian-packages
-          path: ..
+          path: workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ name: release
 on:
   schedule:
   - cron: '0 7 * * 1,3,5'
-  # This is for testing the action only.
-  pull_request:
-    branches:
-    - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - run: ccache -z
       - name: Build Debian Package
         working-directory: ./workspace
-        run: debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
+        run: yes | debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
              --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache       \
              --preserve-envvar=CCACHE_BASEDIR                      \
              --preserve-envvar=CCACHE_DIR                          \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,7 @@ jobs:
         with:
           fetch-depth: '0'
           path: orbit
-      - run: ls .
-      - run: ls orbit
+      - run: cd orbit
       - name: Install dependencies
         run: |
            sudo apt update &&                             \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           key: debian-ccache-${{ steps.ccache_timestamp.outputs.timestamp }}
           restore-keys: |
             debian-ccache-
+            ccache-
       - run: ccache -p
       - run: ccache -z
       - name: Build Debian Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,9 @@ jobs:
       - run: ccache -p
       - run: ccache -z
       - name: Build Debian Package
-        #working-directory: ./workspace
-        run: cd workspace && yes | debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
+        working-directory: ./workspace
+        run: |
+             debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
              --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache       \
              --preserve-envvar=CCACHE_BASEDIR                      \
              --preserve-envvar=CCACHE_DIR                          \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,13 @@ jobs:
       CCACHE_COMPRESSLEVEL: "6"
       CCACHE_MAXSIZE: "400M"
     steps:
+      - run: ls .
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
+          path: orbit
+      - run: ls .
+      - run: ls orbit
       - name: Install dependencies
         run: |
            sudo apt update &&                             \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           fetch-depth: '0'
           path: workspace
-      - run: cd workspace
       - name: Install dependencies
         run: |
            sudo apt update &&                             \
@@ -44,7 +43,7 @@ jobs:
            equivs                                         \
            fakeroot
       - name: Install Debian Build Dependencies
-        run: ls . && sudo mk-build-deps --install debian/control
+        run: cd workspace && ls . && sudo mk-build-deps --install debian/control
       - run: mkdir build && cd build
       - name: Save CCache Timestamp
         id: ccache_timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           fetch-depth: '0'
           path: orbit
       - run: cd orbit
+      - run: ls .
       - name: Install dependencies
         run: |
            sudo apt update &&                             \
@@ -44,7 +45,7 @@ jobs:
            equivs                                         \
            fakeroot
       - name: Install Debian Build Dependencies
-        run: ls && sudo mk-build-deps --install debian/control
+        run: ls . && sudo mk-build-deps --install debian/control
       - run: mkdir build && cd build
       - name: Save CCache Timestamp
         id: ccache_timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@
 name: release
 on:
   schedule:
-  - cron: '0 7 * * *'
+  - cron: '0 7 * * 1,3,5'
   # This is for testing the action only.
   pull_request:
     branches:
@@ -50,12 +50,17 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .ccache
-          key: ccache-${{ steps.ccache_timestamp.outputs.timestamp }}
+          key: debian-ccache-${{ steps.ccache_timestamp.outputs.timestamp }}
           restore-keys: |
-            ccache-
+            debian-ccache-
       - run: ccache -p
       - run: ccache -z
       - name: Build Debian Package
         run: debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache -b
       - name: CCache Stats
         run: ccache -s
+      - name: Archive Debian Packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: debian-packages
+          path: ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-          path: orbit
-      - run: cd orbit
-      - run: ls .
+          path: workspace
+      - run: cd workspace/orbit
       - name: Install dependencies
         run: |
            sudo apt update &&                             \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,14 @@ jobs:
       - run: ccache -p
       - run: ccache -z
       - name: Build Debian Package
-        run: debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache -b
+        run: debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
+             --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache       \
+             --preserve-envvar=CCACHE_BASEDIR                      \
+             --preserve-envvar=CCACHE_DIR                          \
+             --preserve-envvar=CCACHE_COMPRESS                     \
+             --preserve-envvar=CCACHE_COMPRESSLEVEL                \
+             --preserve-envvar=CCACHE_MAXSIZE                      \
+             -b
       - name: CCache Stats
         run: ccache -s
       - name: Archive Debian Packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
            equivs                                         \
            fakeroot
       - name: Install Debian Build Dependencies
-        run: sudo mk-build-deps --install debian/control
+        run: ls && sudo mk-build-deps --install debian/control
       - run: mkdir build && cd build
       - name: Save CCache Timestamp
         id: ccache_timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
            equivs                                         \
            fakeroot
       - name: Install Debian Build Dependencies
-        run: mk-build-deps --install debian/control
+        run: sudo mk-build-deps --install debian/control
       - run: mkdir build && cd build
       - name: Save CCache Timestamp
         id: ccache_timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
            cmake                                          \
            ccache                                         \
            git                                            \
+           equivs
       - name: Install Debian Build Dependencies
         run: mk-build-deps --install debian/control
       - run: mkdir build && cd build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,27 +37,9 @@ jobs:
            devscripts                                     \
            cmake                                          \
            ccache                                         \
-           libboost-dev                                   \
-           libcapstone-dev                                \
-           libgrpc++-dev                                  \
-           libssh2-1-dev                                  \
-           vulkan-validationlayers-dev                    \
-           libz-dev                                       \
-           llvm-dev                                       \
-           libfreetype6-dev                               \
-           libimgui-dev                                   \
-           protobuf-compiler-grpc                         \
-           pkg-config                                     \
-           libvulkan-volk-dev                             \
-           libvulkan-dev                                  \
-           libopengl-dev                                  \
-           libglx-dev                                     \
-           mesa-common-dev                                \
-           qtbase5-dev                                    \
-           libgtest-dev                                   \
-           libgmock-dev                                   \
            git                                            \
-           libprotobuf-dev
+      - name: Install Debian Build Dependencies
+        run: mk-build-deps --install debian/control
       - run: mkdir build && cd build
       - name: Save CCache Timestamp
         id: ccache_timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
       - run: ccache -p
       - run: ccache -z
       - name: Build Debian Package
-        working-directory: ./workspace
-        run: yes | debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
+        #working-directory: ./workspace
+        run: cd workspace && yes | debuild --set-envvar=CMAKE_C_COMPILER_LAUNCHER=ccache \
              --set-envvar=CMAKE_CXX_COMPILER_LAUNCHER=ccache       \
              --preserve-envvar=CCACHE_BASEDIR                      \
              --preserve-envvar=CCACHE_DIR                          \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
            cmake                                          \
            ccache                                         \
            git                                            \
-           equivs
+           equivs                                         \
+           fakeroot
       - name: Install Debian Build Dependencies
         run: mk-build-deps --install debian/control
       - run: mkdir build && cd build

--- a/debian/rules
+++ b/debian/rules
@@ -7,3 +7,6 @@ override_dh_auto_configure:
 	dh_auto_configure --                                                                              \
 	      -DCMAKE_CXX_FLAGS="-march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" \
 	      -DCMAKE_BUILD_TYPE=Release
+
+override_dh_auto_build:
+  dh_auto_build -- VERBOSE=1

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,3 @@ override_dh_auto_configure:
 	dh_auto_configure --                                                                              \
 	      -DCMAKE_CXX_FLAGS="-march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" \
 	      -DCMAKE_BUILD_TYPE=Release
-
-override_dh_auto_build:
-	dh_auto_build -- VERBOSE=1

--- a/debian/rules
+++ b/debian/rules
@@ -9,4 +9,4 @@ override_dh_auto_configure:
 	      -DCMAKE_BUILD_TYPE=Release
 
 override_dh_auto_build:
-  dh_auto_build -- VERBOSE=1
+	dh_auto_build -- VERBOSE=1


### PR DESCRIPTION
This is adding a Github Action that will once a day perform a Debian package build. So far, it will not upload any artifacts.

Note: For testing reasons, this will now also trigger on a PR to main (hoping that it will trigger with this PR).

Test: Check CI