### PR TITLE
Move to clang-format-14

### DIFF
--- a/contrib/hooks/clang-format-pre-commit.sh
+++ b/contrib/hooks/clang-format-pre-commit.sh
@@ -9,7 +9,7 @@
 # After the formatting has been applied, it will ask you which changes should
 
 echo "Formatting all changed files now..."
-git clang-format-9 -f
+git clang-format-14 -f
 # Only show this to the user of there are unstaged changes.
 if ! (git diff -- --quiet)
 then

--- a/run_clang_format.sh
+++ b/run_clang_format.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2020 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-clang_format_path="/usr/bin/clang-format-9";
+clang_format_path="/usr/bin/clang-format-14";
 
 # If we are running in git bash this is the default location:
 if  [ -f "/c/Program Files/LLVM/bin/clang-format.exe" ]; then

--- a/src/ApiLoader/EnableInTraceeWindows.cpp
+++ b/src/ApiLoader/EnableInTraceeWindows.cpp
@@ -8,8 +8,8 @@
 
 #include <absl/strings/match.h>
 
-#include "ApiUtils/GetFunctionTableAddressPrefix.h"
 #include "ApiUtils/ApiEnableInfo.h"
+#include "ApiUtils/GetFunctionTableAddressPrefix.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "WindowsUtils/DllInjection.h"

--- a/src/CaptureClient/GpuQueueSubmissionProcessorTest.cpp
+++ b/src/CaptureClient/GpuQueueSubmissionProcessorTest.cpp
@@ -140,7 +140,7 @@ TEST_F(GpuQueueSubmissionProcessorTest, DXVKVulkanDebugMarkerEncodesGroupId) {
 
   bool was_called = false;
   static constexpr uint64_t kCommandBufferTextKey = 1234;
-  auto get_string_hash_and_send_if_necessary_fake = [&was_called](const std::string &
+  auto get_string_hash_and_send_if_necessary_fake = [&was_called](const std::string&
                                                                   /*str*/) -> uint64_t {
     was_called = true;
     return kCommandBufferTextKey;

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -213,7 +213,7 @@ void FunctionsDataView::DoFilter() {
   orbit_base::TaskGroup task_group;
 
   for (size_t i = 0; i < chunks.size(); ++i) {
-    task_group.AddTask([& chunk = chunks[i], &result = task_results[i], this]() {
+    task_group.AddTask([&chunk = chunks[i], &result = task_results[i], this]() {
       ORBIT_SCOPE("FunctionsDataView::DoFilter Task");
       for (const FunctionInfo*& function : chunk) {
         ORBIT_CHECK(function != nullptr);

--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -256,7 +256,7 @@ class [[nodiscard]] Future<ErrorMessageOr<T>>
   // Note: Usually `invocable` won't be executed if `executor` gets destroyed before `*this`
   // completes. Check the docs or implementation of `Executor::ScheduleAfter` to be sure.
   template <typename Executor, typename Invocable>
-  auto ThenIfSuccess(Executor * executor, Invocable && invocable) const {
+  auto ThenIfSuccess(Executor* executor, Invocable&& invocable) const {
     return executor->ScheduleAfterIfSuccess(*this, std::forward<Invocable>(invocable));
   }
 };

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -53,7 +53,7 @@ struct overloaded : orbit_base_internal::WithParen<Ts>... {
 };
 
 template <typename... Ts>
-overloaded(Ts...)->overloaded<Ts...>;
+overloaded(Ts...) -> overloaded<Ts...>;
 
 }  // namespace orbit_base
 

--- a/src/OrbitBase/include/OrbitBase/UniqueResource.h
+++ b/src/OrbitBase/include/OrbitBase/UniqueResource.h
@@ -78,7 +78,7 @@ class unique_resource {
 
 template <typename Resource, typename Deleter>
 unique_resource(Resource, Deleter)
-    ->unique_resource<std::decay_t<Resource>, std::remove_cv_t<Deleter>>;
+    -> unique_resource<std::decay_t<Resource>, std::remove_cv_t<Deleter>>;
 
 }  // namespace orbit_base
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1214,29 +1214,29 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> OrbitApp::LoadCaptureFro
     capture_window_->set_draw_help(false);
   }
   ClearCapture();
-  auto load_future = thread_pool_->Schedule([this, file_path]()
-                                                -> ErrorMessageOr<CaptureListener::CaptureOutcome> {
-    capture_loading_cancellation_requested_ = false;
+  auto load_future = thread_pool_->Schedule(
+      [this, file_path]() -> ErrorMessageOr<CaptureListener::CaptureOutcome> {
+        capture_loading_cancellation_requested_ = false;
 
-    OUTCOME_TRY(const std::unique_ptr<CaptureFile> capture_file,
-                CaptureFile::OpenForReadWrite(file_path));
+        OUTCOME_TRY(const std::unique_ptr<CaptureFile> capture_file,
+                    CaptureFile::OpenForReadWrite(file_path));
 
-    // Set is_loading_capture_ to true for the duration of this scope.
-    data_source_ = CaptureData::DataSource::kLoadedCapture;
-    orbit_base::unique_resource scope_exit{&data_source_,
-                                           [](std::atomic<CaptureData::DataSource>* value) {
-                                             *value = CaptureData::DataSource::kLiveCapture;
-                                           }};
+        // Set is_loading_capture_ to true for the duration of this scope.
+        data_source_ = CaptureData::DataSource::kLoadedCapture;
+        orbit_base::unique_resource scope_exit{&data_source_,
+                                               [](std::atomic<CaptureData::DataSource>* value) {
+                                                 *value = CaptureData::DataSource::kLiveCapture;
+                                               }};
 
-    ErrorMessageOr<CaptureListener::CaptureOutcome> load_result =
-        LoadCapture(this, capture_file.get(), &capture_loading_cancellation_requested_);
+        ErrorMessageOr<CaptureListener::CaptureOutcome> load_result =
+            LoadCapture(this, capture_file.get(), &capture_loading_cancellation_requested_);
 
-    if (load_result.has_value() && load_result.value() == CaptureOutcome::kComplete) {
-      OnCaptureComplete();
-    }
+        if (load_result.has_value() && load_result.value() == CaptureOutcome::kComplete) {
+          OnCaptureComplete();
+        }
 
-    return load_result;
-  });
+        return load_result;
+      });
 
   DoZoom = true;  // TODO: remove global, review logic
 
@@ -1604,7 +1604,7 @@ Future<void> OrbitApp::LoadSymbolsManually(absl::Span<const ModuleData* const> m
   for (const auto& module : modules_set) {
     // Explicitly do not handle the result.
     Future<void> future = RetrieveModuleAndLoadSymbolsAndHandleError(module).Then(
-        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult & /*result*/) -> void {});
+        &immediate_executor, [](const SymbolLoadingAndErrorHandlingResult& /*result*/) -> void {});
     futures.emplace_back(std::move(future));
   }
 

--- a/src/OrbitGl/OpenGlBatcherTest.cpp
+++ b/src/OrbitGl/OpenGlBatcherTest.cpp
@@ -245,7 +245,7 @@ TEST(OpenGlBatcher, TranslationsAreAutomaticallyAdded) {
   const Line3D transformed_expectation{original_expectation.start_point + transform,
                                        original_expectation.end_point + transform};
 
-  const auto first_from_layer = [& batcher = std::as_const(batcher)](float z) {
+  const auto first_from_layer = [&batcher = std::as_const(batcher)](float z) {
     return *batcher.GetInternalBuffers(z).line_buffer.lines_.begin();
   };
 

--- a/src/OrbitVulkanLayer/DispatchTableTest.cpp
+++ b/src/OrbitVulkanLayer/DispatchTableTest.cpp
@@ -18,7 +18,7 @@ TEST(DispatchTable, CanInitializeInstance) {
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
-      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkInstance /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
@@ -29,7 +29,7 @@ TEST(DispatchTable, CannotInitializeInstanceTwice) {
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
-      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkInstance /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
@@ -44,7 +44,7 @@ TEST(DispatchTable, CanRemoveInstance) {
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
-      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkInstance /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
@@ -55,7 +55,7 @@ TEST(DispatchTable, CanReinitializeInstanceAfterRemove) {
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
-      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkInstance /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
@@ -67,7 +67,7 @@ TEST(DispatchTable, CanInitializeDevice) {
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
-      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkDevice /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
@@ -77,7 +77,7 @@ TEST(DispatchTable, CannotInitializeDeviceTwice) {
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
-      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkDevice /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
@@ -90,7 +90,7 @@ TEST(DispatchTable, CanRemoveDevice) {
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
-      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkDevice /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
@@ -101,7 +101,7 @@ TEST(DispatchTable, CanReinitializeDeviceAfterRemove) {
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
-      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkDevice /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
@@ -113,7 +113,7 @@ TEST(DispatchTable, NoDeviceExtensionAvailable) {
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
-      +[](VkDevice /*device*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkDevice /*device*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
@@ -125,7 +125,7 @@ TEST(DispatchTable, NoInstanceExtensionAvailable) {
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
-      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkInstance /*instance*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
@@ -154,13 +154,13 @@ TEST(DispatchTable, CanSupportDeviceDebugUtilsExtension) {
     }
     if (strcmp(name, "vkSetDebugUtilsObjectNameEXT") == 0) {
       PFN_vkSetDebugUtilsObjectNameEXT function =
-          +[](VkDevice /*device*/, const VkDebugUtilsObjectNameInfoEXT *
+          +[](VkDevice /*device*/, const VkDebugUtilsObjectNameInfoEXT*
               /*name_info*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
     if (strcmp(name, "vkSetDebugUtilsObjectTagEXT") == 0) {
       PFN_vkSetDebugUtilsObjectTagEXT function =
-          +[](VkDevice /*device*/, const VkDebugUtilsObjectTagInfoEXT *
+          +[](VkDevice /*device*/, const VkDebugUtilsObjectTagInfoEXT*
               /*tag_info*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -196,7 +196,7 @@ TEST(DispatchTable, CanSupportInstanceDebugUtilsExtension) {
     if (strcmp(name, "vkCreateDebugUtilsMessengerEXT") == 0) {
       PFN_vkCreateDebugUtilsMessengerEXT function =
           +[](VkInstance /*instance*/, const VkDebugUtilsMessengerCreateInfoEXT* /*create_info*/,
-              const VkAllocationCallbacks* /*allocator*/, VkDebugUtilsMessengerEXT *
+              const VkAllocationCallbacks* /*allocator*/, VkDebugUtilsMessengerEXT*
               /*messenger*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -229,7 +229,7 @@ TEST(DispatchTable, CanSupportDebugReportExtension) {
     if (strcmp(name, "vkCreateDebugReportCallbackEXT") == 0) {
       PFN_vkCreateDebugReportCallbackEXT function =
           +[](VkInstance /*instance*/, const VkDebugReportCallbackCreateInfoEXT* /*create_info*/,
-              const VkAllocationCallbacks* /*allocator*/, VkDebugReportCallbackEXT *
+              const VkAllocationCallbacks* /*allocator*/, VkDebugReportCallbackEXT*
               /*messenger*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -277,14 +277,14 @@ TEST(DispatchTable, CanSupportDebugMarkerExtension) {
     }
     if (strcmp(name, "vkDebugMarkerSetObjectTagEXT") == 0) {
       PFN_vkDebugMarkerSetObjectTagEXT function =
-          +[](VkDevice /*device*/, const VkDebugMarkerObjectTagInfoEXT * /*tag_info*/) -> VkResult {
+          +[](VkDevice /*device*/, const VkDebugMarkerObjectTagInfoEXT* /*tag_info*/) -> VkResult {
         return VK_SUCCESS;
       };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
     if (strcmp(name, "vkDebugMarkerSetObjectNameEXT") == 0) {
       PFN_vkDebugMarkerSetObjectNameEXT function =
-          +[](VkDevice /*device*/, const VkDebugMarkerObjectNameInfoEXT *
+          +[](VkDevice /*device*/, const VkDebugMarkerObjectNameInfoEXT*
               /*name_info*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -304,7 +304,7 @@ TEST(DispatchTable, CanCallEnumerateDeviceExtensionProperties) {
     if (strcmp(name, "vkEnumerateDeviceExtensionProperties") == 0) {
       PFN_vkEnumerateDeviceExtensionProperties function =
           +[](VkPhysicalDevice /*physical_device*/, const char* /*layer_name*/,
-              uint32_t* property_count, VkExtensionProperties *
+              uint32_t* property_count, VkExtensionProperties*
               /*properties*/) -> VkResult {
         *property_count = 42;
         return VK_SUCCESS;
@@ -363,7 +363,7 @@ TEST(DispatchTable, CanCallGetInstanceProcAddr) {
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
       +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkGetInstanceProcAddr") == 0) {
-      PFN_vkGetInstanceProcAddr function = +[](VkInstance /*instance*/, const char *
+      PFN_vkGetInstanceProcAddr function = +[](VkInstance /*instance*/, const char*
                                                /*name*/) -> PFN_vkVoidFunction {
         was_called = true;
         return nullptr;
@@ -390,7 +390,7 @@ TEST(DispatchTable, CanCallGetDeviceProcAddr) {
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
       +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkGetDeviceProcAddr") == 0) {
-      PFN_vkGetDeviceProcAddr function = +[](VkDevice /*device*/, const char *
+      PFN_vkGetDeviceProcAddr function = +[](VkDevice /*device*/, const char*
                                              /*name*/) -> PFN_vkVoidFunction {
         was_called = true;
         return nullptr;
@@ -440,7 +440,7 @@ TEST(DispatchTable, CanCallAllocateCommandBuffers) {
     if (strcmp(name, "vkAllocateCommandBuffers") == 0) {
       PFN_vkAllocateCommandBuffers function =
           +[](VkDevice /*device*/, const VkCommandBufferAllocateInfo* /*allocate_info*/,
-              VkCommandBuffer *
+              VkCommandBuffer*
               /*command_buffers*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -489,7 +489,7 @@ TEST(DispatchTable, CanCallBeginCommandBuffer) {
       +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkBeginCommandBuffer") == 0) {
       PFN_vkBeginCommandBuffer function =
-          +[](VkCommandBuffer /*command_buffer*/, const VkCommandBufferBeginInfo *
+          +[](VkCommandBuffer /*command_buffer*/, const VkCommandBufferBeginInfo*
               /*begin_info*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -631,7 +631,7 @@ TEST(DispatchTable, CanCallQueuePresentKHR) {
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
       +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkQueuePresentKHR") == 0) {
-      PFN_vkQueuePresentKHR function = +[](VkQueue /*queue*/, const VkPresentInfoKHR *
+      PFN_vkQueuePresentKHR function = +[](VkQueue /*queue*/, const VkPresentInfoKHR*
                                            /*present_info*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -655,7 +655,7 @@ TEST(DispatchTable, CanCallCreateQueryPool) {
     if (strcmp(name, "vkCreateQueryPool") == 0) {
       PFN_vkCreateQueryPool function =
           +[](VkDevice /*device*/, const VkQueryPoolCreateInfo* /*create_info*/,
-              const VkAllocationCallbacks* /*allocator*/, VkQueryPool *
+              const VkAllocationCallbacks* /*allocator*/, VkQueryPool*
               /*query_pool*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -837,7 +837,7 @@ TEST(DispatchTable, CanCallSetDebugUtilsObjectNameEXT) {
       +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkSetDebugUtilsObjectNameEXT") == 0) {
       PFN_vkSetDebugUtilsObjectNameEXT function =
-          +[](VkDevice /*device*/, const VkDebugUtilsObjectNameInfoEXT *
+          +[](VkDevice /*device*/, const VkDebugUtilsObjectNameInfoEXT*
               /*name_info*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -859,7 +859,7 @@ TEST(DispatchTable, CanCallSetDebugUtilsObjectTagEXT) {
       +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkSetDebugUtilsObjectTagEXT") == 0) {
       PFN_vkSetDebugUtilsObjectTagEXT function =
-          +[](VkDevice /*device*/, const VkDebugUtilsObjectTagInfoEXT *
+          +[](VkDevice /*device*/, const VkDebugUtilsObjectTagInfoEXT*
               /*tag_info*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -955,7 +955,7 @@ TEST(DispatchTable, CanCallCreateDebugUtilsMessengerEXT) {
     if (strcmp(name, "vkCreateDebugUtilsMessengerEXT") == 0) {
       PFN_vkCreateDebugUtilsMessengerEXT function =
           +[](VkInstance /*instance*/, const VkDebugUtilsMessengerCreateInfoEXT* /*create_info*/,
-              const VkAllocationCallbacks* /*allocator*/, VkDebugUtilsMessengerEXT *
+              const VkAllocationCallbacks* /*allocator*/, VkDebugUtilsMessengerEXT*
               /*messenger*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -1030,7 +1030,7 @@ TEST(DispatchTable, CanCallCreateDebugReportCallbackEXT) {
     if (strcmp(name, "vkCreateDebugReportCallbackEXT") == 0) {
       PFN_vkCreateDebugReportCallbackEXT function =
           +[](VkInstance /*instance*/, const VkDebugReportCallbackCreateInfoEXT* /*create_info*/,
-              const VkAllocationCallbacks* /*allocator*/, VkDebugReportCallbackEXT *
+              const VkAllocationCallbacks* /*allocator*/, VkDebugReportCallbackEXT*
               /*messenger*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }
@@ -1182,7 +1182,7 @@ TEST(DispatchTable, CanCallDebugMarkerSetObjectTagEXT) {
       +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkDebugMarkerSetObjectTagEXT") == 0) {
       PFN_vkDebugMarkerSetObjectTagEXT function =
-          +[](VkDevice /*device*/, const VkDebugMarkerObjectTagInfoEXT * /*tag_info*/) -> VkResult {
+          +[](VkDevice /*device*/, const VkDebugMarkerObjectTagInfoEXT* /*tag_info*/) -> VkResult {
         return VK_SUCCESS;
       };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
@@ -1205,7 +1205,7 @@ TEST(DispatchTable, CanCallDebugMarkerSetObjectNameEXT) {
       +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkDebugMarkerSetObjectNameEXT") == 0) {
       PFN_vkDebugMarkerSetObjectNameEXT function =
-          +[](VkDevice /*device*/, const VkDebugMarkerObjectNameInfoEXT *
+          +[](VkDevice /*device*/, const VkDebugMarkerObjectNameInfoEXT*
               /*name_info*/) -> VkResult { return VK_SUCCESS; };
       return absl::bit_cast<PFN_vkVoidFunction>(function);
     }

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -734,7 +734,7 @@ TEST_F(
       }));
 
   PFN_vkGetDeviceProcAddr fake_get_device_proc_addr =
-      +[](VkDevice /*device*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkDevice /*device*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   PFN_vkGetInstanceProcAddr fake_get_instance_proc_addr =
       +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
@@ -808,7 +808,7 @@ TEST_F(VulkanLayerControllerTest,
   };
 
   PFN_vkGetDeviceProcAddr fake_get_device_proc_addr =
-      +[](VkDevice /*device*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+      +[](VkDevice /*device*/, const char* /*name*/) -> PFN_vkVoidFunction { return nullptr; };
 
   PFN_vkGetInstanceProcAddr fake_get_instance_proc_addr =
       +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
@@ -904,7 +904,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsOnResetCommandPoolToSubmissionTracker)
 TEST_F(VulkanLayerControllerTest, ForwardsOnAllocateCommandBuffersToSubmissionTracker) {
   PFN_vkAllocateCommandBuffers fake_allocate_command_buffers =
       +[](VkDevice /*device*/, const VkCommandBufferAllocateInfo* /*allocate_info*/,
-          VkCommandBuffer *
+          VkCommandBuffer*
           /*command_buffers*/) -> VkResult { return VK_SUCCESS; };
   const MockDispatchTable* dispatch_table = controller_.dispatch_table();
   EXPECT_CALL(*dispatch_table, AllocateCommandBuffers)
@@ -946,7 +946,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsOnFreeCommandBuffersToSubmissionTracke
 
 TEST_F(VulkanLayerControllerTest, ForwardsOnBeginCommandBufferToSubmissionTracker) {
   PFN_vkBeginCommandBuffer fake_begin_command_buffer =
-      +[](VkCommandBuffer /*command_buffer*/, const VkCommandBufferBeginInfo *
+      +[](VkCommandBuffer /*command_buffer*/, const VkCommandBufferBeginInfo*
           /*begin_info*/) -> VkResult { return VK_SUCCESS; };
   const MockDispatchTable* dispatch_table = controller_.dispatch_table();
   EXPECT_CALL(*dispatch_table, BeginCommandBuffer)
@@ -1044,7 +1044,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsOnGetQueueSubmitToSubmissionTracker) {
 
 TEST_F(VulkanLayerControllerTest, ForwardsOnQueuePresentKHRToSubmissionTracker) {
   PFN_vkQueuePresentKHR fake_queue_present =
-      +[](VkQueue /*queue*/, const VkPresentInfoKHR * /*present_info*/) -> VkResult {
+      +[](VkQueue /*queue*/, const VkPresentInfoKHR* /*present_info*/) -> VkResult {
     return VK_SUCCESS;
   };
   const MockDispatchTable* dispatch_table = controller_.dispatch_table();
@@ -1234,7 +1234,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsCreateDebugUtilsMessengerEXTIfExtensio
 
   PFN_vkCreateDebugUtilsMessengerEXT fake =
       +[](VkInstance /*instance*/, const VkDebugUtilsMessengerCreateInfoEXT* /*create_info*/,
-          const VkAllocationCallbacks* /*allocator*/, VkDebugUtilsMessengerEXT *
+          const VkAllocationCallbacks* /*allocator*/, VkDebugUtilsMessengerEXT*
           /*messenger*/) -> VkResult { return VK_SUCCESS; };
   EXPECT_CALL(*dispatch_table, CreateDebugUtilsMessengerEXT).Times(1).WillOnce(Return(fake));
   controller_.OnCreateDebugUtilsMessengerEXT(instance, nullptr, nullptr, nullptr);
@@ -1336,7 +1336,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsSetDebugUtilsObjectNameEXTIfExtensionS
       .WillOnce(Return(true));
 
   PFN_vkSetDebugUtilsObjectNameEXT fake =
-      +[](VkDevice /*device*/, const VkDebugUtilsObjectNameInfoEXT * /*name_info*/) -> VkResult {
+      +[](VkDevice /*device*/, const VkDebugUtilsObjectNameInfoEXT* /*name_info*/) -> VkResult {
     return VK_SUCCESS;
   };
   EXPECT_CALL(*dispatch_table, SetDebugUtilsObjectNameEXT).Times(1).WillOnce(Return(fake));
@@ -1358,7 +1358,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsSetDebugUtilsObjectTagEXTIfExtensionSu
       .WillOnce(Return(true));
 
   PFN_vkSetDebugUtilsObjectTagEXT fake =
-      +[](VkDevice /*device*/, const VkDebugUtilsObjectTagInfoEXT * /*tag_info*/) -> VkResult {
+      +[](VkDevice /*device*/, const VkDebugUtilsObjectTagInfoEXT* /*tag_info*/) -> VkResult {
     return VK_SUCCESS;
   };
   EXPECT_CALL(*dispatch_table, SetDebugUtilsObjectTagEXT).Times(1).WillOnce(Return(fake));
@@ -1424,7 +1424,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsDebugMarkerSetObjectNameEXTIfExtension
       .WillOnce(Return(true));
 
   PFN_vkDebugMarkerSetObjectNameEXT fake =
-      +[](VkDevice /*device*/, const VkDebugMarkerObjectNameInfoEXT * /*name_info*/) -> VkResult {
+      +[](VkDevice /*device*/, const VkDebugMarkerObjectNameInfoEXT* /*name_info*/) -> VkResult {
     return VK_SUCCESS;
   };
   EXPECT_CALL(*dispatch_table, DebugMarkerSetObjectNameEXT).Times(1).WillOnce(Return(fake));
@@ -1446,7 +1446,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsDebugMarkerSetObjectTagEXTIfExtensionS
       .WillOnce(Return(true));
 
   PFN_vkDebugMarkerSetObjectTagEXT fake =
-      +[](VkDevice /*device*/, const VkDebugMarkerObjectTagInfoEXT * /*tag*/) -> VkResult {
+      +[](VkDevice /*device*/, const VkDebugMarkerObjectTagInfoEXT* /*tag*/) -> VkResult {
     return VK_SUCCESS;
   };
   EXPECT_CALL(*dispatch_table, DebugMarkerSetObjectTagEXT).Times(1).WillOnce(Return(fake));
@@ -1469,7 +1469,7 @@ TEST_F(VulkanLayerControllerTest, ForwardsCreateDebugReportCallbackEXTIfExtensio
 
   PFN_vkCreateDebugReportCallbackEXT fake =
       +[](VkInstance /*instance*/, const VkDebugReportCallbackCreateInfoEXT* /*create_info*/,
-          const VkAllocationCallbacks* /*allocator*/, VkDebugReportCallbackEXT *
+          const VkAllocationCallbacks* /*allocator*/, VkDebugReportCallbackEXT*
           /*callback*/) -> VkResult { return VK_SUCCESS; };
   EXPECT_CALL(*dispatch_table, CreateDebugReportCallbackEXT).Times(1).WillOnce(Return(fake));
   controller_.OnCreateDebugReportCallbackEXT(instance, nullptr, nullptr, nullptr);

--- a/src/WindowsTracing/GraphicsEtwProvider.cpp
+++ b/src/WindowsTracing/GraphicsEtwProvider.cpp
@@ -9,8 +9,6 @@
 #include <stdint.h>
 // clang-format on
 
-#include <absl/functional/bind_front.h>
-
 #include <PresentData/ETW/Microsoft_Windows_D3D9.h>
 #include <PresentData/ETW/Microsoft_Windows_DXGI.h>
 #include <PresentData/ETW/Microsoft_Windows_Dwm_Core.h>
@@ -18,6 +16,7 @@
 #include <PresentData/ETW/Microsoft_Windows_EventMetadata.h>
 #include <PresentData/ETW/Microsoft_Windows_Win32k.h>
 #include <PresentData/ETW/NT_Process.h>
+#include <absl/functional/bind_front.h>
 
 // clang-format off
 #include <d3d9.h>

--- a/src/WindowsTracing/ListModulesEtwTest.cpp
+++ b/src/WindowsTracing/ListModulesEtwTest.cpp
@@ -13,9 +13,9 @@
 
 #include <vector>
 
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadUtils.h"
-#include "OrbitBase/ExecutablePath.h"
 #include "WindowsTracing/ListModulesEtw.h"
 #include "WindowsUtils/PathConverter.h"
 

--- a/src/WindowsUtils/include/WindowsUtils/BusyLoopUtils.h
+++ b/src/WindowsUtils/include/WindowsUtils/BusyLoopUtils.h
@@ -10,7 +10,9 @@
 // clang-format on
 
 #include <stdint.h>
+
 #include <string>
+
 #include "OrbitBase/Result.h"
 
 namespace orbit_windows_utils {

--- a/src/WindowsUtils/include/WindowsUtils/Debugger.h
+++ b/src/WindowsUtils/include/WindowsUtils/Debugger.h
@@ -10,14 +10,14 @@
 #include <psapi.h>
 // clang-format on
 
-#include "OrbitBase/Promise.h"
-#include "OrbitBase/Result.h"
-#include "WindowsUtils/CreateProcess.h"
-
 #include <filesystem>
 #include <string>
 #include <thread>
 #include <vector>
+
+#include "OrbitBase/Promise.h"
+#include "OrbitBase/Result.h"
+#include "WindowsUtils/CreateProcess.h"
 
 namespace orbit_windows_utils {
 


### PR DESCRIPTION
Apply clang-format to the entire code base, adjusting for changes coming from the clang-format 9 -> 14 migration.