### PR TITLE
Remove GCC Debug Build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,12 +33,6 @@ jobs:
             cxx: "g++"
         }
         - {
-          name: "GCC Debug",
-          build_type: 'Debug',
-          cc: "gcc",
-          cxx: "g++"
-        }
-        - {
             name: "Clang Release",
             build_type: 'Release',
             cc: "clang",


### PR DESCRIPTION
Caching for this build does not work as good as expected and the build is still pretty slow.

Test: CI