### PR TITLE
Only trigger build CI on relevant files

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,9 +7,23 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - 'CMakeLists.txt'
+      - '**.cmake'
+      - '.github/**'
+      - 'cmake/**'
+      - 'src/**'
+      - 'third_party/**'
   pull_request:
     branches:
       - 'main'
+    paths:
+      - 'CMakeLists.txt'
+      - '**.cmake'
+      - '.github/**'
+      - 'cmake/**'
+      - 'src/**'
+      - 'third_party/**'
   schedule:
   - cron: '0 7 * * *'
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,6 @@ on:
       - 'main'
     paths:
       - 'CMakeLists.txt'
-      - '**.cmake'
       - '.github/**'
       - 'cmake/**'
       - 'src/**'
@@ -19,7 +18,6 @@ on:
       - 'main'
     paths:
       - 'CMakeLists.txt'
-      - '**.cmake'
       - '.github/**'
       - 'cmake/**'
       - 'src/**'


### PR DESCRIPTION
This only triggers the build-and-test jobs when files that influence the build get modiefied.

Test: CI