### PR TITLE
Make TimeGraphLayout an interface

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(
          GraphTrackDataAggregator.h
          Images.h
          ImGuiOrbit.h
+         ImGuiTimeGraphLayout.h
          IntrospectionWindow.h
          LineGraphTrack.h
          LiveFunctionsController.h
@@ -64,6 +65,7 @@ target_sources(
          SchedulingStats.h
          ShortenStringWithEllipsis.h
          SimpleTimings.h
+         StaticTimeGraphLayout.h
          SymbolLoader.h
          SystemMemoryTrack.h
          TextRenderer.h
@@ -123,6 +125,7 @@ target_sources(
           GraphTrack.cpp
           GraphTrackDataAggregator.cpp
           ImGuiOrbit.cpp
+          ImGuiTimeGraphLayout.cpp
           IntrospectionWindow.cpp
           LineGraphTrack.cpp
           LiveFunctionsController.cpp
@@ -142,7 +145,6 @@ target_sources(
           SymbolLoader.cpp
           SystemMemoryTrack.cpp
           TimeGraph.cpp
-          TimeGraphLayout.cpp
           TimelineTicks.cpp
           TimelineUi.cpp
           TimerInfosIterator.cpp

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -105,7 +105,7 @@ TEST(CaptureViewElementTesterTest, PassesAllTestsOnExistingElement) {
 }
 
 const Viewport kViewport(100, 100);
-const TimeGraphLayout kLayout;
+const StaticTimeGraphLayout kLayout;
 
 TEST(CaptureViewElement, ContainsPointRecursively) {
   UnitTestCaptureViewLeafElement elem(nullptr, &kViewport, &kLayout);

--- a/src/OrbitGl/CaptureViewElementTester.h
+++ b/src/OrbitGl/CaptureViewElementTester.h
@@ -63,7 +63,7 @@ class CaptureViewElementTester {
 
  protected:
   Viewport viewport_ = Viewport(100, 100);
-  orbit_gl::StaticTimeGraphLayout layout_;
+  StaticTimeGraphLayout layout_;
 
  private:
   void TestWidthPropagationToChildren(CaptureViewElement* element);

--- a/src/OrbitGl/CaptureViewElementTester.h
+++ b/src/OrbitGl/CaptureViewElementTester.h
@@ -10,6 +10,7 @@
 #include "MockTextRenderer.h"
 #include "PickingManager.h"
 #include "PrimitiveAssembler.h"
+#include "StaticTimeGraphLayout.h"
 
 namespace orbit_gl {
 
@@ -62,7 +63,7 @@ class CaptureViewElementTester {
 
  protected:
   Viewport viewport_ = Viewport(100, 100);
-  TimeGraphLayout layout_;
+  orbit_gl::StaticTimeGraphLayout layout_;
 
  private:
   void TestWidthPropagationToChildren(CaptureViewElement* element);

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -591,7 +591,7 @@ void CaptureWindow::RequestUpdatePrimitives() {
 
 void CaptureWindow::RenderImGuiDebugUI() {
   if (ImGui::CollapsingHeader("Layout Properties")) {
-    if (time_graph_ != nullptr && time_graph_->GetLayout().DrawProperties()) {
+    if (time_graph_ != nullptr && time_graph_->GetImGuiLayout().DrawProperties()) {
       RequestUpdatePrimitives();
     }
 

--- a/src/OrbitGl/ImGuiTimeGraphLayout.cpp
+++ b/src/OrbitGl/ImGuiTimeGraphLayout.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ImGuiTimeGraphLayout.cpp
+++ b/src/OrbitGl/ImGuiTimeGraphLayout.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "TimeGraphLayout.h"
+#include "ImGuiTimeGraphLayout.h"
 
 #include <imgui.h>
 
@@ -10,7 +10,9 @@
 
 #include "OrbitBase/ThreadConstants.h"
 
-TimeGraphLayout::TimeGraphLayout() {
+namespace orbit_gl {
+
+ImGuiTimeGraphLayout::ImGuiTimeGraphLayout() {
   text_box_height_ = 20.f;
   core_height_ = 10.f;
   thread_state_track_height_ = 6.0f;
@@ -58,7 +60,7 @@ TimeGraphLayout::TimeGraphLayout() {
     needs_redraw = true;                      \
   }
 
-bool TimeGraphLayout::DrawProperties() {
+bool ImGuiTimeGraphLayout::DrawProperties() {
   bool needs_redraw = false;
   FLOAT_SLIDER(track_label_offset_x_);
   FLOAT_SLIDER(text_box_height_);
@@ -106,7 +108,7 @@ bool TimeGraphLayout::DrawProperties() {
   return needs_redraw;
 }
 
-float TimeGraphLayout::GetCollapseButtonSize(int indentation_level) const {
+float ImGuiTimeGraphLayout::GetCollapseButtonSize(int indentation_level) const {
   float button_size_without_scaling =
       collapse_button_size_ -
       collapse_button_decrease_per_indentation_ * static_cast<float>(indentation_level);
@@ -115,7 +117,7 @@ float TimeGraphLayout::GetCollapseButtonSize(int indentation_level) const {
   return button_size_without_scaling * std::sqrt(scale_);
 }
 
-float TimeGraphLayout::GetEventTrackHeightFromTid(uint32_t tid) const {
+float ImGuiTimeGraphLayout::GetEventTrackHeightFromTid(uint32_t tid) const {
   float height = GetEventTrackHeight();
   if (tid == orbit_base::kAllProcessThreadsTid) {
     height *= GetAllThreadsEventTrackScale();
@@ -123,8 +125,10 @@ float TimeGraphLayout::GetEventTrackHeightFromTid(uint32_t tid) const {
   return height;
 }
 
-float TimeGraphLayout::GetSliderResizeMargin() const {
+float ImGuiTimeGraphLayout::GetSliderResizeMargin() const {
   // The resize part of the slider is 1/3 of the min length.
-  const float kRatioMinSliderLengthResizePart = 3.f;
+  constexpr float kRatioMinSliderLengthResizePart = 3.f;
   return GetMinSliderLength() / kRatioMinSliderLengthResizePart;
 }
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/ImGuiTimeGraphLayout.h
+++ b/src/OrbitGl/ImGuiTimeGraphLayout.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ImGuiTimeGraphLayout.h
+++ b/src/OrbitGl/ImGuiTimeGraphLayout.h
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_IM_GUI_TIME_GRAPH_LAYOUT_H_
+#define ORBIT_GL_IM_GUI_TIME_GRAPH_LAYOUT_H_
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <cmath>
+
+#include "TimeGraphLayout.h"
+
+namespace orbit_gl {
+class ImGuiTimeGraphLayout : public TimeGraphLayout {
+ public:
+  ImGuiTimeGraphLayout();
+
+  constexpr static float kMinScale = 0.333f;
+  constexpr static float kMaxScale = 3.f;
+
+  [[nodiscard]] float GetTextBoxHeight() const override { return text_box_height_ * scale_; }
+  [[nodiscard]] float GetTextCoresHeight() const override { return core_height_ * scale_; }
+  [[nodiscard]] float GetThreadStateTrackHeight() const override {
+    return thread_state_track_height_ * scale_;
+  }
+  [[nodiscard]] float GetEventTrackHeightFromTid(uint32_t tid) const override;
+  [[nodiscard]] float GetVariableTrackHeight() const override {
+    return variable_track_height_ * scale_;
+  }
+  [[nodiscard]] float GetTrackContentBottomMargin() const override {
+    return track_content_bottom_margin_ * scale_;
+  }
+  [[nodiscard]] float GetTrackContentTopMargin() const override {
+    return track_content_top_margin_ * scale_;
+  }
+  [[nodiscard]] float GetTrackLabelOffsetX() const override { return track_label_offset_x_; }
+  [[nodiscard]] float GetSliderWidth() const override { return slider_width_ * scale_; }
+  [[nodiscard]] float GetMinSliderLength() const override { return min_slider_length_ * scale_; }
+  [[nodiscard]] float GetSliderResizeMargin() const override;
+  [[nodiscard]] float GetTimeBarHeight() const override { return time_bar_height_ * scale_; }
+  [[nodiscard]] float GetTrackTabWidth() const override { return track_tab_width_; }
+  [[nodiscard]] float GetTrackTabHeight() const override { return track_tab_height_ * scale_; }
+  [[nodiscard]] float GetTrackTabOffset() const override { return track_tab_offset_; }
+  [[nodiscard]] float GetTrackIndentOffset() const override { return track_indent_offset_; }
+  [[nodiscard]] float GetCollapseButtonSize(int indentation_level) const override;
+  [[nodiscard]] float GetCollapseButtonOffset() const override { return collapse_button_offset_; }
+  [[nodiscard]] float GetRoundingRadius() const override { return rounding_radius_ * scale_; }
+  [[nodiscard]] float GetRoundingNumSides() const override { return rounding_num_sides_; }
+  [[nodiscard]] float GetTextOffset() const override { return text_offset_ * scale_; }
+  [[nodiscard]] float GetRightMargin() const override { return right_margin_ * scale_; }
+  [[nodiscard]] float GetMinButtonSize() const override { return min_button_size_; }
+  [[nodiscard]] float GetButtonWidth() const override { return button_width_ * scale_; }
+  [[nodiscard]] float GetButtonHeight() const override { return button_height_ * scale_; }
+  [[nodiscard]] float GetSpaceBetweenTracks() const override {
+    return space_between_tracks_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenTracksAndTimeline() const override {
+    return space_between_tracks_and_timeline_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenCores() const override {
+    return space_between_cores_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenGpuDepths() const override {
+    return space_between_gpu_depths_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenThreadPanes() const override {
+    return space_between_thread_panes_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenSubtracks() const override {
+    return space_between_subtracks_ * scale_;
+  }
+  [[nodiscard]] float GetGenericFixedSpacerWidth() const override {
+    return generic_fixed_spacer_width_;
+  }
+  [[nodiscard]] float GetThreadDependencyArrowHeadWidth() const override {
+    return thread_dependency_arrow_head_width_ * scale_;
+  }
+  [[nodiscard]] float GetThreadDependencyArrowHeadHeight() const override {
+    return thread_dependency_arrow_head_height_ * scale_;
+  }
+  [[nodiscard]] float GetThreadDependencyArrowBodyWidth() const override {
+    return thread_dependency_arrow_body_width_ * scale_;
+  }
+  [[nodiscard]] float GetScale() const override { return scale_; }
+  void SetScale(float value) override { scale_ = std::clamp(value, kMinScale, kMaxScale); }
+  void SetDrawProperties(bool value) { draw_properties_ = value; }
+  bool DrawProperties();
+  [[nodiscard]] bool GetDrawTrackBackground() const override { return draw_track_background_; }
+  [[nodiscard]] uint32_t GetFontSize() const override { return std::lround(font_size_ * scale_); }
+
+  [[nodiscard]] int GetMaxLayoutingLoops() const override { return max_layouting_loops_; }
+
+ protected:
+  float text_box_height_;
+  float core_height_;
+  float thread_state_track_height_;
+  float event_track_height_;
+  float all_threads_event_track_scale_;
+  float variable_track_height_;
+  float track_content_bottom_margin_;
+  float track_content_top_margin_;
+  float track_label_offset_x_;
+  float slider_width_;
+  float min_slider_length_;
+  float time_bar_height_;
+  float track_tab_width_;
+  float track_tab_height_;
+  float track_tab_offset_;
+  float track_indent_offset_;
+  float collapse_button_offset_;
+  float collapse_button_size_;
+  float collapse_button_decrease_per_indentation_;
+  float rounding_radius_;
+  float rounding_num_sides_;
+  float text_offset_;
+  float right_margin_;
+  float min_button_size_;
+  float button_width_;
+  float button_height_;
+  float thread_dependency_arrow_head_width_;
+  float thread_dependency_arrow_head_height_;
+  float thread_dependency_arrow_body_width_;
+
+  uint32_t font_size_;
+
+  float space_between_cores_;
+  float space_between_gpu_depths_;
+  float space_between_tracks_;
+  float space_between_tracks_and_timeline_;
+  float space_between_thread_panes_;
+  float space_between_subtracks_;
+  float generic_fixed_spacer_width_;
+
+  float toolbar_icon_height_;
+  float scale_;
+
+  bool draw_properties_ = false;
+  bool draw_track_background_ = true;
+
+  int max_layouting_loops_ = 10;
+
+ private:
+  [[nodiscard]] float GetEventTrackHeight() const { return event_track_height_ * scale_; }
+  [[nodiscard]] float GetAllThreadsEventTrackScale() const {
+    return all_threads_event_track_scale_;
+  }
+};
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_IM_GUI_TIME_GRAPH_LAYOUT_H_

--- a/src/OrbitGl/ImGuiTimeGraphLayout.h
+++ b/src/OrbitGl/ImGuiTimeGraphLayout.h
@@ -13,6 +13,9 @@
 #include "TimeGraphLayout.h"
 
 namespace orbit_gl {
+// The ImGui TimeGraphLayout is an implementation of TimeGraphLayout where all properties can be
+// changed through an ImGui interface with controls for each parameter. This simplifies experimented
+// with layout changes.
 class ImGuiTimeGraphLayout : public TimeGraphLayout {
  public:
   ImGuiTimeGraphLayout();

--- a/src/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/StaticTimeGraphLayout.h
@@ -14,6 +14,8 @@
 #include "TimeGraphLayout.h"
 
 namespace orbit_gl {
+// This class implements a TimeGraphLayout where all properties are static values that can't be
+// changed. This class is mainly for tests that need some TimeGraphLayout.
 class StaticTimeGraphLayout : public TimeGraphLayout {
  public:
   constexpr static float kMinScale = 0.333f;

--- a/src/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/StaticTimeGraphLayout.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -19,136 +19,133 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   constexpr static float kMinScale = 0.333f;
   constexpr static float kMaxScale = 3.f;
 
-  [[nodiscard]] float GetTextBoxHeight() const override { return text_box_height_ * scale_; }
-  [[nodiscard]] float GetTextCoresHeight() const override { return core_height_ * scale_; }
+  [[nodiscard]] float GetTextBoxHeight() const override { return kTextBoxHeight * scale_; }
+  [[nodiscard]] float GetTextCoresHeight() const override { return kCoreHeight * scale_; }
   [[nodiscard]] float GetThreadStateTrackHeight() const override {
-    return thread_state_track_height_ * scale_;
+    return kThreadStateTrackHeight * scale_;
   }
   [[nodiscard]] float GetEventTrackHeightFromTid(uint32_t tid) const override {
-    float height = event_track_height_ * scale_;
+    float height = kEventTrackHeight * scale_;
     if (tid == orbit_base::kAllProcessThreadsTid) {
-      height *= all_threads_event_track_scale_;
+      height *= kAllThreadsEventTrackScale;
     }
     return height;
   }
   [[nodiscard]] float GetVariableTrackHeight() const override {
-    return variable_track_height_ * scale_;
+    return kVariableTrackHeight * scale_;
   }
   [[nodiscard]] float GetTrackContentBottomMargin() const override {
-    return track_content_bottom_margin_ * scale_;
+    return kTrackContentBottomMargin * scale_;
   }
   [[nodiscard]] float GetTrackContentTopMargin() const override {
-    return track_content_top_margin_ * scale_;
+    return kTrackContentTopMargin * scale_;
   }
-  [[nodiscard]] float GetTrackLabelOffsetX() const override { return track_label_offset_x_; }
-  [[nodiscard]] float GetSliderWidth() const override { return slider_width_ * scale_; }
-  [[nodiscard]] float GetMinSliderLength() const override { return min_slider_length_ * scale_; }
+  [[nodiscard]] float GetTrackLabelOffsetX() const override { return kTrackLabelOffsetX; }
+  [[nodiscard]] float GetSliderWidth() const override { return kSliderWidth * scale_; }
+  [[nodiscard]] float GetMinSliderLength() const override { return kMinSliderLength * scale_; }
   [[nodiscard]] float GetSliderResizeMargin() const override {
     // The resize part of the slider is 1/3 of the min length.
     constexpr float kRatioMinSliderLengthResizePart = 3.f;
     return GetMinSliderLength() / kRatioMinSliderLengthResizePart;
   }
-  [[nodiscard]] float GetTimeBarHeight() const override { return time_bar_height_ * scale_; }
-  [[nodiscard]] float GetTrackTabWidth() const override { return track_tab_width_; }
-  [[nodiscard]] float GetTrackTabHeight() const override { return track_tab_height_ * scale_; }
-  [[nodiscard]] float GetTrackTabOffset() const override { return track_tab_offset_; }
-  [[nodiscard]] float GetTrackIndentOffset() const override { return track_indent_offset_; }
+  [[nodiscard]] float GetTimeBarHeight() const override { return kTimeBarHeight * scale_; }
+  [[nodiscard]] float GetTrackTabWidth() const override { return kTrackTabWidth; }
+  [[nodiscard]] float GetTrackTabHeight() const override { return kTrackTabHeight * scale_; }
+  [[nodiscard]] float GetTrackTabOffset() const override { return kTrackTabOffset; }
+  [[nodiscard]] float GetTrackIndentOffset() const override { return kTrackIndentOffset; }
   [[nodiscard]] float GetCollapseButtonSize(int indentation_level) const override {
     float button_size_without_scaling =
-        collapse_button_size_ -
-        collapse_button_decrease_per_indentation_ * static_cast<float>(indentation_level);
+        kCollapseButtonSize -
+        kCollapseButtonDecreasePerIndentation * static_cast<float>(indentation_level);
 
     // We want the button to scale slower than other elements, so we use sqrt() function.
     return button_size_without_scaling * std::sqrt(scale_);
   }
-  [[nodiscard]] float GetCollapseButtonOffset() const override { return collapse_button_offset_; }
-  [[nodiscard]] float GetRoundingRadius() const override { return rounding_radius_ * scale_; }
-  [[nodiscard]] float GetRoundingNumSides() const override { return rounding_num_sides_; }
-  [[nodiscard]] float GetTextOffset() const override { return text_offset_ * scale_; }
-  [[nodiscard]] float GetRightMargin() const override { return right_margin_ * scale_; }
-  [[nodiscard]] float GetMinButtonSize() const override { return min_button_size_; }
-  [[nodiscard]] float GetButtonWidth() const override { return button_width_ * scale_; }
-  [[nodiscard]] float GetButtonHeight() const override { return button_height_ * scale_; }
+  [[nodiscard]] float GetCollapseButtonOffset() const override { return kCollapseButtonOffset; }
+  [[nodiscard]] float GetRoundingRadius() const override { return kRoundingRadius * scale_; }
+  [[nodiscard]] float GetRoundingNumSides() const override { return kRoundingNumSides; }
+  [[nodiscard]] float GetTextOffset() const override { return kTextOffset * scale_; }
+  [[nodiscard]] float GetRightMargin() const override { return kRightMargin * scale_; }
+  [[nodiscard]] float GetMinButtonSize() const override { return kMinButtonSize; }
+  [[nodiscard]] float GetButtonWidth() const override { return kButtonWidth * scale_; }
+  [[nodiscard]] float GetButtonHeight() const override { return kButtonHeight * scale_; }
   [[nodiscard]] float GetSpaceBetweenTracks() const override {
-    return space_between_tracks_ * scale_;
+    return kSpaceBetweenTracks * scale_;
   }
   [[nodiscard]] float GetSpaceBetweenTracksAndTimeline() const override {
-    return space_between_tracks_and_timeline_ * scale_;
+    return kSpaceBetweenTracksAndTimeline * scale_;
   }
-  [[nodiscard]] float GetSpaceBetweenCores() const override {
-    return space_between_cores_ * scale_;
-  }
+  [[nodiscard]] float GetSpaceBetweenCores() const override { return kSpaceBetweenCores * scale_; }
   [[nodiscard]] float GetSpaceBetweenGpuDepths() const override {
-    return space_between_gpu_depths_ * scale_;
+    return kSpaceBetweenGpuDepths * scale_;
   }
   [[nodiscard]] float GetSpaceBetweenThreadPanes() const override {
-    return space_between_thread_panes_ * scale_;
+    return kSpaceBetweenThreadPanes * scale_;
   }
   [[nodiscard]] float GetSpaceBetweenSubtracks() const override {
-    return space_between_subtracks_ * scale_;
+    return kSpaceBetweenSubtracks * scale_;
   }
   [[nodiscard]] float GetGenericFixedSpacerWidth() const override {
-    return generic_fixed_spacer_width_;
+    return kGenericFixedSpacerWidth;
   }
   [[nodiscard]] float GetThreadDependencyArrowHeadWidth() const override {
-    return thread_dependency_arrow_head_width_ * scale_;
+    return kThreadDependencyArrowHeadWidth * scale_;
   }
   [[nodiscard]] float GetThreadDependencyArrowHeadHeight() const override {
-    return thread_dependency_arrow_head_height_ * scale_;
+    return kThreadDependencyArrowHeadHeight * scale_;
   }
   [[nodiscard]] float GetThreadDependencyArrowBodyWidth() const override {
-    return thread_dependency_arrow_body_width_ * scale_;
+    return kThreadDependencyArrowBodyWidth * scale_;
   }
   [[nodiscard]] float GetScale() const override { return scale_; }
   void SetScale(float value) override { scale_ = std::clamp(value, kMinScale, kMaxScale); }
-  [[nodiscard]] bool GetDrawTrackBackground() const override { return draw_track_background_; }
-  [[nodiscard]] uint32_t GetFontSize() const override { return std::lround(font_size_ * scale_); }
+  [[nodiscard]] bool GetDrawTrackBackground() const override { return kDrawTrackBackground; }
+  [[nodiscard]] uint32_t GetFontSize() const override { return std::lround(kFontSize * scale_); }
 
-  [[nodiscard]] int GetMaxLayoutingLoops() const override { return max_layouting_loops_; }
+  [[nodiscard]] int GetMaxLayoutingLoops() const override { return kMaxLayoutingLoops; }
 
  private:
-  float text_box_height_ = 20.f;
-  float core_height_ = 10.f;
-  float thread_state_track_height_ = 6.0f;
-  float event_track_height_ = 10.f;
-  float all_threads_event_track_scale_ = 2.f;
-  float variable_track_height_ = 20.f;
-  float track_content_bottom_margin_ = 5.f;
-  float track_content_top_margin_ = 5.f;
-  float space_between_cores_ = 2.f;
-  float space_between_gpu_depths_ = 2.f;
-  float space_between_tracks_ = 10.f;
-  float space_between_tracks_and_timeline_ = 10.f;
-  float space_between_thread_panes_ = 5.f;
-  float space_between_subtracks_ = 0.f;
-  float track_label_offset_x_ = 30.f;
-  float slider_width_ = 15.f;
-  float min_slider_length_ = 20.f;
-  float track_tab_width_ = 350.f;
-  float track_tab_height_ = 25.f;
-  float track_tab_offset_ = 0.f;
-  float track_indent_offset_ = 5.f;
-  float collapse_button_offset_ = 15.f;
-  float collapse_button_size_ = 10.f;
-  float collapse_button_decrease_per_indentation_ = 2.f;
-  float rounding_radius_ = 8.f;
-  float rounding_num_sides_ = 16;
-  float text_offset_ = 5.f;
-  float right_margin_ = 10.f;
-  float min_button_size_ = 5.f;
-  float button_width_ = 15.f;
-  float button_height_ = 15.f;
-  float generic_fixed_spacer_width_ = 10.f;
+  constexpr static float kTextBoxHeight = 20.f;
+  constexpr static float kCoreHeight = 10.f;
+  constexpr static float kThreadStateTrackHeight = 6.0f;
+  constexpr static float kEventTrackHeight = 10.f;
+  constexpr static float kAllThreadsEventTrackScale = 2.f;
+  constexpr static float kVariableTrackHeight = 20.f;
+  constexpr static float kTrackContentBottomMargin = 5.f;
+  constexpr static float kTrackContentTopMargin = 5.f;
+  constexpr static float kSpaceBetweenCores = 2.f;
+  constexpr static float kSpaceBetweenGpuDepths = 2.f;
+  constexpr static float kSpaceBetweenTracks = 10.f;
+  constexpr static float kSpaceBetweenTracksAndTimeline = 10.f;
+  constexpr static float kSpaceBetweenThreadPanes = 5.f;
+  constexpr static float kSpaceBetweenSubtracks = 0.f;
+  constexpr static float kTrackLabelOffsetX = 30.f;
+  constexpr static float kSliderWidth = 15.f;
+  constexpr static float kMinSliderLength = 20.f;
+  constexpr static float kTrackTabWidth = 350.f;
+  constexpr static float kTrackTabHeight = 25.f;
+  constexpr static float kTrackTabOffset = 0.f;
+  constexpr static float kTrackIndentOffset = 5.f;
+  constexpr static float kCollapseButtonOffset = 15.f;
+  constexpr static float kCollapseButtonSize = 10.f;
+  constexpr static float kCollapseButtonDecreasePerIndentation = 2.f;
+  constexpr static float kRoundingRadius = 8.f;
+  constexpr static float kRoundingNumSides = 16;
+  constexpr static float kTextOffset = 5.f;
+  constexpr static float kRightMargin = 10.f;
+  constexpr static float kMinButtonSize = 5.f;
+  constexpr static float kButtonWidth = 15.f;
+  constexpr static float kButtonHeight = 15.f;
+  constexpr static float kGenericFixedSpacerWidth = 10.f;
+  constexpr static float kTimeBarHeight = 30.f;
+  constexpr static uint32_t kFontSize = 14;
+  constexpr static float kThreadDependencyArrowHeadWidth = 16;
+  constexpr static float kThreadDependencyArrowHeadHeight = 15;
+  constexpr static float kThreadDependencyArrowBodyWidth = 4;
+  constexpr static bool kDrawTrackBackground = true;
+  constexpr static int kMaxLayoutingLoops = 10;
+
   float scale_ = 1.f;
-  float time_bar_height_ = 30.f;
-  uint32_t font_size_ = 14;
-  float thread_dependency_arrow_head_width_ = 16;
-  float thread_dependency_arrow_head_height_ = 15;
-  float thread_dependency_arrow_body_width_ = 4;
-
-  bool draw_track_background_ = true;
-
-  int max_layouting_loops_ = 10;
 };
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/StaticTimeGraphLayout.h
@@ -1,0 +1,155 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_STATIC_TIME_GRAPH_LAYOUT_H_
+#define ORBIT_GL_STATIC_TIME_GRAPH_LAYOUT_H_
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <cmath>
+
+#include "OrbitBase/ThreadConstants.h"
+#include "TimeGraphLayout.h"
+
+namespace orbit_gl {
+class StaticTimeGraphLayout : public TimeGraphLayout {
+ public:
+  constexpr static float kMinScale = 0.333f;
+  constexpr static float kMaxScale = 3.f;
+
+  [[nodiscard]] float GetTextBoxHeight() const override { return text_box_height_ * scale_; }
+  [[nodiscard]] float GetTextCoresHeight() const override { return core_height_ * scale_; }
+  [[nodiscard]] float GetThreadStateTrackHeight() const override {
+    return thread_state_track_height_ * scale_;
+  }
+  [[nodiscard]] float GetEventTrackHeightFromTid(uint32_t tid) const override {
+    float height = event_track_height_ * scale_;
+    if (tid == orbit_base::kAllProcessThreadsTid) {
+      height *= all_threads_event_track_scale_;
+    }
+    return height;
+  }
+  [[nodiscard]] float GetVariableTrackHeight() const override {
+    return variable_track_height_ * scale_;
+  }
+  [[nodiscard]] float GetTrackContentBottomMargin() const override {
+    return track_content_bottom_margin_ * scale_;
+  }
+  [[nodiscard]] float GetTrackContentTopMargin() const override {
+    return track_content_top_margin_ * scale_;
+  }
+  [[nodiscard]] float GetTrackLabelOffsetX() const override { return track_label_offset_x_; }
+  [[nodiscard]] float GetSliderWidth() const override { return slider_width_ * scale_; }
+  [[nodiscard]] float GetMinSliderLength() const override { return min_slider_length_ * scale_; }
+  [[nodiscard]] float GetSliderResizeMargin() const override {
+    // The resize part of the slider is 1/3 of the min length.
+    constexpr float kRatioMinSliderLengthResizePart = 3.f;
+    return GetMinSliderLength() / kRatioMinSliderLengthResizePart;
+  }
+  [[nodiscard]] float GetTimeBarHeight() const override { return time_bar_height_ * scale_; }
+  [[nodiscard]] float GetTrackTabWidth() const override { return track_tab_width_; }
+  [[nodiscard]] float GetTrackTabHeight() const override { return track_tab_height_ * scale_; }
+  [[nodiscard]] float GetTrackTabOffset() const override { return track_tab_offset_; }
+  [[nodiscard]] float GetTrackIndentOffset() const override { return track_indent_offset_; }
+  [[nodiscard]] float GetCollapseButtonSize(int indentation_level) const override {
+    float button_size_without_scaling =
+        collapse_button_size_ -
+        collapse_button_decrease_per_indentation_ * static_cast<float>(indentation_level);
+
+    // We want the button to scale slower than other elements, so we use sqrt() function.
+    return button_size_without_scaling * std::sqrt(scale_);
+  }
+  [[nodiscard]] float GetCollapseButtonOffset() const override { return collapse_button_offset_; }
+  [[nodiscard]] float GetRoundingRadius() const override { return rounding_radius_ * scale_; }
+  [[nodiscard]] float GetRoundingNumSides() const override { return rounding_num_sides_; }
+  [[nodiscard]] float GetTextOffset() const override { return text_offset_ * scale_; }
+  [[nodiscard]] float GetRightMargin() const override { return right_margin_ * scale_; }
+  [[nodiscard]] float GetMinButtonSize() const override { return min_button_size_; }
+  [[nodiscard]] float GetButtonWidth() const override { return button_width_ * scale_; }
+  [[nodiscard]] float GetButtonHeight() const override { return button_height_ * scale_; }
+  [[nodiscard]] float GetSpaceBetweenTracks() const override {
+    return space_between_tracks_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenTracksAndTimeline() const override {
+    return space_between_tracks_and_timeline_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenCores() const override {
+    return space_between_cores_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenGpuDepths() const override {
+    return space_between_gpu_depths_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenThreadPanes() const override {
+    return space_between_thread_panes_ * scale_;
+  }
+  [[nodiscard]] float GetSpaceBetweenSubtracks() const override {
+    return space_between_subtracks_ * scale_;
+  }
+  [[nodiscard]] float GetGenericFixedSpacerWidth() const override {
+    return generic_fixed_spacer_width_;
+  }
+  [[nodiscard]] float GetThreadDependencyArrowHeadWidth() const override {
+    return thread_dependency_arrow_head_width_ * scale_;
+  }
+  [[nodiscard]] float GetThreadDependencyArrowHeadHeight() const override {
+    return thread_dependency_arrow_head_height_ * scale_;
+  }
+  [[nodiscard]] float GetThreadDependencyArrowBodyWidth() const override {
+    return thread_dependency_arrow_body_width_ * scale_;
+  }
+  [[nodiscard]] float GetScale() const override { return scale_; }
+  void SetScale(float value) override { scale_ = std::clamp(value, kMinScale, kMaxScale); }
+  [[nodiscard]] bool GetDrawTrackBackground() const override { return draw_track_background_; }
+  [[nodiscard]] uint32_t GetFontSize() const override { return std::lround(font_size_ * scale_); }
+
+  [[nodiscard]] int GetMaxLayoutingLoops() const override { return max_layouting_loops_; }
+
+ private:
+  float text_box_height_ = 20.f;
+  float core_height_ = 10.f;
+  float thread_state_track_height_ = 6.0f;
+  float event_track_height_ = 10.f;
+  float all_threads_event_track_scale_ = 2.f;
+  float variable_track_height_ = 20.f;
+  float track_content_bottom_margin_ = 5.f;
+  float track_content_top_margin_ = 5.f;
+  float space_between_cores_ = 2.f;
+  float space_between_gpu_depths_ = 2.f;
+  float space_between_tracks_ = 10.f;
+  float space_between_tracks_and_timeline_ = 10.f;
+  float space_between_thread_panes_ = 5.f;
+  float space_between_subtracks_ = 0.f;
+  float track_label_offset_x_ = 30.f;
+  float slider_width_ = 15.f;
+  float min_slider_length_ = 20.f;
+  float track_tab_width_ = 350.f;
+  float track_tab_height_ = 25.f;
+  float track_tab_offset_ = 0.f;
+  float track_indent_offset_ = 5.f;
+  float collapse_button_offset_ = 15.f;
+  float collapse_button_size_ = 10.f;
+  float collapse_button_decrease_per_indentation_ = 2.f;
+  float rounding_radius_ = 8.f;
+  float rounding_num_sides_ = 16;
+  float text_offset_ = 5.f;
+  float right_margin_ = 10.f;
+  float min_button_size_ = 5.f;
+  float button_width_ = 15.f;
+  float button_height_ = 15.f;
+  float generic_fixed_spacer_width_ = 10.f;
+  float scale_ = 1.f;
+  float time_bar_height_ = 30.f;
+  uint32_t font_size_ = 14;
+  float thread_dependency_arrow_head_width_ = 16;
+  float thread_dependency_arrow_head_height_ = 15;
+  float thread_dependency_arrow_body_width_ = 4;
+
+  bool draw_track_background_ = true;
+
+  int max_layouting_loops_ = 10;
+};
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_STATIC_TIME_GRAPH_LAYOUT_H_

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -18,12 +18,12 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "CoreMath.h"
 #include "GlSlider.h"
+#include "ImGuiTimeGraphLayout.h"
 #include "ManualInstrumentationManager.h"
 #include "OpenGlBatcher.h"
 #include "OpenGlTextRenderer.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
-#include "TimeGraphLayout.h"
 #include "TimelineInfoInterface.h"
 #include "TimelineUi.h"
 #include "TrackContainer.h"
@@ -127,7 +127,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] orbit_gl::Batcher& GetBatcher() { return batcher_; }
 
   [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
-  [[nodiscard]] TimeGraphLayout& GetLayout() { return layout_; }
+  [[nodiscard]] orbit_gl::ImGuiTimeGraphLayout& GetImGuiLayout() { return layout_; }
 
   [[nodiscard]] static Color GetColor(uint32_t id) {
     constexpr unsigned char kAlpha = 255;
@@ -211,7 +211,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   uint64_t capture_min_timestamp_ = std::numeric_limits<uint64_t>::max();
   uint64_t capture_max_timestamp_ = 0;
 
-  TimeGraphLayout layout_;
+  orbit_gl::ImGuiTimeGraphLayout layout_;
 
   orbit_gl::OpenGlBatcher batcher_;
   orbit_gl::PrimitiveAssembler primitive_assembler_;

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -7,120 +7,50 @@
 
 #include <stdint.h>
 
-#include <algorithm>
-#include <cmath>
-
-#include "OrbitBase/ThreadConstants.h"
-
 class TimeGraphLayout {
  public:
-  TimeGraphLayout();
+  [[nodiscard]] virtual float GetTextBoxHeight() const = 0;
+  [[nodiscard]] virtual float GetTextCoresHeight() const = 0;
+  [[nodiscard]] virtual float GetThreadStateTrackHeight() const = 0;
+  [[nodiscard]] virtual float GetEventTrackHeightFromTid(uint32_t tid) const = 0;
+  [[nodiscard]] virtual float GetVariableTrackHeight() const = 0;
+  [[nodiscard]] virtual float GetTrackContentBottomMargin() const = 0;
+  [[nodiscard]] virtual float GetTrackContentTopMargin() const = 0;
+  [[nodiscard]] virtual float GetTrackLabelOffsetX() const = 0;
+  [[nodiscard]] virtual float GetSliderWidth() const = 0;
+  [[nodiscard]] virtual float GetMinSliderLength() const = 0;
+  [[nodiscard]] virtual float GetSliderResizeMargin() const = 0;
+  [[nodiscard]] virtual float GetTimeBarHeight() const = 0;
+  [[nodiscard]] virtual float GetTrackTabWidth() const = 0;
+  [[nodiscard]] virtual float GetTrackTabHeight() const = 0;
+  [[nodiscard]] virtual float GetTrackTabOffset() const = 0;
+  [[nodiscard]] virtual float GetTrackIndentOffset() const = 0;
+  [[nodiscard]] virtual float GetCollapseButtonSize(int indentation_level) const = 0;
+  [[nodiscard]] virtual float GetCollapseButtonOffset() const = 0;
+  [[nodiscard]] virtual float GetRoundingRadius() const = 0;
+  [[nodiscard]] virtual float GetRoundingNumSides() const = 0;
+  [[nodiscard]] virtual float GetTextOffset() const = 0;
+  [[nodiscard]] virtual float GetRightMargin() const = 0;
+  [[nodiscard]] virtual float GetMinButtonSize() const = 0;
+  [[nodiscard]] virtual float GetButtonWidth() const = 0;
+  [[nodiscard]] virtual float GetButtonHeight() const = 0;
+  [[nodiscard]] virtual float GetSpaceBetweenTracks() const = 0;
+  [[nodiscard]] virtual float GetSpaceBetweenTracksAndTimeline() const = 0;
+  [[nodiscard]] virtual float GetSpaceBetweenCores() const = 0;
+  [[nodiscard]] virtual float GetSpaceBetweenGpuDepths() const = 0;
+  [[nodiscard]] virtual float GetSpaceBetweenThreadPanes() const = 0;
+  [[nodiscard]] virtual float GetSpaceBetweenSubtracks() const = 0;
+  [[nodiscard]] virtual float GetGenericFixedSpacerWidth() const = 0;
+  [[nodiscard]] virtual float GetThreadDependencyArrowHeadWidth() const = 0;
+  [[nodiscard]] virtual float GetThreadDependencyArrowHeadHeight() const = 0;
+  [[nodiscard]] virtual float GetThreadDependencyArrowBodyWidth() const = 0;
+  [[nodiscard]] virtual float GetScale() const = 0;
+  [[nodiscard]] virtual bool GetDrawTrackBackground() const = 0;
+  [[nodiscard]] virtual uint32_t GetFontSize() const = 0;
+  [[nodiscard]] virtual int GetMaxLayoutingLoops() const = 0;
+  virtual void SetScale(float value) = 0;
 
-  const float kMinScale = 0.333f;
-  const float kMaxScale = 3.f;
-
-  float GetTextBoxHeight() const { return text_box_height_ * scale_; }
-  float GetTextCoresHeight() const { return core_height_ * scale_; }
-  float GetThreadStateTrackHeight() const { return thread_state_track_height_ * scale_; }
-  float GetEventTrackHeightFromTid(uint32_t tid = orbit_base::kInvalidThreadId) const;
-  float GetVariableTrackHeight() const { return variable_track_height_ * scale_; }
-  float GetTrackContentBottomMargin() const { return track_content_bottom_margin_ * scale_; }
-  float GetTrackContentTopMargin() const { return track_content_top_margin_ * scale_; }
-  float GetTrackLabelOffsetX() const { return track_label_offset_x_; }
-  float GetSliderWidth() const { return slider_width_ * scale_; }
-  float GetMinSliderLength() const { return min_slider_length_ * scale_; }
-  float GetSliderResizeMargin() const;
-  float GetTimeBarHeight() const { return time_bar_height_ * scale_; }
-  float GetTrackTabWidth() const { return track_tab_width_; }
-  float GetTrackTabHeight() const { return track_tab_height_ * scale_; }
-  float GetTrackTabOffset() const { return track_tab_offset_; }
-  float GetTrackIndentOffset() const { return track_indent_offset_; }
-  float GetCollapseButtonSize(int indentation_level) const;
-  float GetCollapseButtonOffset() const { return collapse_button_offset_; }
-  float GetRoundingRadius() const { return rounding_radius_ * scale_; }
-  float GetRoundingNumSides() const { return rounding_num_sides_; }
-  float GetTextOffset() const { return text_offset_ * scale_; }
-  float GetRightMargin() const { return right_margin_ * scale_; }
-  float GetMinButtonSize() const { return min_button_size_; }
-  float GetButtonWidth() const { return button_width_ * scale_; }
-  float GetButtonHeight() const { return button_height_ * scale_; }
-  float GetSpaceBetweenTracks() const { return space_between_tracks_ * scale_; }
-  float GetSpaceBetweenTracksAndTimeline() const {
-    return space_between_tracks_and_timeline_ * scale_;
-  }
-  float GetSpaceBetweenCores() const { return space_between_cores_ * scale_; }
-  float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }
-  float GetSpaceBetweenThreadPanes() const { return space_between_thread_panes_ * scale_; }
-  float GetSpaceBetweenSubtracks() const { return space_between_subtracks_ * scale_; }
-  float GetGenericFixedSpacerWidth() const { return generic_fixed_spacer_width_; }
-  float GetThreadDependencyArrowHeadWidth() const {
-    return thread_dependency_arrow_head_width_ * scale_;
-  }
-  float GetThreadDependencyArrowHeadHeight() const {
-    return thread_dependency_arrow_head_height_ * scale_;
-  }
-  float GetThreadDependencyArrowBodyWidth() const {
-    return thread_dependency_arrow_body_width_ * scale_;
-  }
-  float GetScale() const { return scale_; }
-  void SetScale(float value) { scale_ = std::clamp(value, kMinScale, kMaxScale); }
-  bool DrawProperties();
-  bool GetDrawTrackBackground() const { return draw_track_background_; }
-  uint32_t GetFontSize() const { return std::lround(font_size_ * scale_); }
-
-  int GetMaxLayoutingLoops() const { return max_layouting_loops_; }
-
- protected:
-  float text_box_height_;
-  float core_height_;
-  float thread_state_track_height_;
-  float event_track_height_;
-  float all_threads_event_track_scale_;
-  float variable_track_height_;
-  float track_content_bottom_margin_;
-  float track_content_top_margin_;
-  float track_label_offset_x_;
-  float slider_width_;
-  float min_slider_length_;
-  float time_bar_height_;
-  float track_tab_width_;
-  float track_tab_height_;
-  float track_tab_offset_;
-  float track_indent_offset_;
-  float collapse_button_offset_;
-  float collapse_button_size_;
-  float collapse_button_decrease_per_indentation_;
-  float rounding_radius_;
-  float rounding_num_sides_;
-  float text_offset_;
-  float right_margin_;
-  float min_button_size_;
-  float button_width_;
-  float button_height_;
-  float thread_dependency_arrow_head_width_;
-  float thread_dependency_arrow_head_height_;
-  float thread_dependency_arrow_body_width_;
-
-  uint32_t font_size_;
-
-  float space_between_cores_;
-  float space_between_gpu_depths_;
-  float space_between_tracks_;
-  float space_between_tracks_and_timeline_;
-  float space_between_thread_panes_;
-  float space_between_subtracks_;
-  float generic_fixed_spacer_width_;
-
-  float toolbar_icon_height_;
-  float scale_;
-
-  bool draw_track_background_ = true;
-
-  int max_layouting_loops_ = 10;
-
- private:
-  float GetEventTrackHeight() const { return event_track_height_ * scale_; }
-  float GetAllThreadsEventTrackScale() const { return all_threads_event_track_scale_; }
+  ~TimeGraphLayout() = default;
 };
 
 #endif  // ORBIT_GL_TIME_GRAPH_LAYOUT_H_

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -64,7 +64,6 @@ class TimeGraphLayout {
   }
   float GetScale() const { return scale_; }
   void SetScale(float value) { scale_ = std::clamp(value, kMinScale, kMaxScale); }
-  void SetDrawProperties(bool value) { draw_properties_ = value; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return draw_track_background_; }
   uint32_t GetFontSize() const { return std::lround(font_size_ * scale_); }
@@ -115,7 +114,6 @@ class TimeGraphLayout {
   float toolbar_icon_height_;
   float scale_;
 
-  bool draw_properties_ = false;
   bool draw_track_background_ = true;
 
   int max_layouting_loops_ = 10;

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -11,6 +11,7 @@
 #include "MockBatcher.h"
 #include "MockTextRenderer.h"
 #include "MockTimelineInfo.h"
+#include "StaticTimeGraphLayout.h"
 #include "TimelineUi.h"
 #include "Viewport.h"
 
@@ -137,7 +138,7 @@ static void TestUpdatePrimitivesWithSeveralRanges(int world_width) {
   MockTimelineInfo mock_timeline_info;
   mock_timeline_info.SetWorldWidth(world_width);
 
-  TimeGraphLayout layout;
+  StaticTimeGraphLayout layout;
   Viewport viewport(world_width, 0);
   TimelineUiTest timeline_ui_test(&mock_timeline_info, &viewport, &layout);
   timeline_ui_test.TestUpdatePrimitives(0, 100);
@@ -170,7 +171,7 @@ TEST(TimelineUi, Draw) {
   MockTimelineInfo mock_timeline_info;
   mock_timeline_info.SetWorldWidth(width);
 
-  TimeGraphLayout layout;
+  StaticTimeGraphLayout layout;
   Viewport viewport(width, 0);
   TimelineUiTest timeline_ui_test(&mock_timeline_info, &viewport, &layout);
 
@@ -196,7 +197,7 @@ TEST(TimelineUi, OnMouseWheel) {
   MockTimelineInfo mock_timeline_info;
   mock_timeline_info.SetWorldWidth(width);
 
-  TimeGraphLayout layout;
+  StaticTimeGraphLayout layout;
   Viewport viewport(width, 0);
   TimelineUiTest timeline_ui_test(&mock_timeline_info, &viewport, &layout);
   const Vec2 pos_inside_timeline = timeline_ui_test.GetPos();

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -7,6 +7,7 @@
 #include "ClientData/ModuleManager.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/capture.pb.h"
+#include "StaticTimeGraphLayout.h"
 #include "TimeGraph.h"
 #include "Track.h"
 #include "TrackManager.h"
@@ -54,7 +55,7 @@ class TrackManagerTest : public ::testing::Test {
     capture_data_->UpdateScopeStats(timer);
   }
 
-  TimeGraphLayout layout_;
+  orbit_gl::StaticTimeGraphLayout layout_;
   std::unique_ptr<orbit_client_data::CaptureData> capture_data_;
   TrackManager track_manager_;
 };

--- a/src/OrbitQt/TrackTypeItemModelTest.cpp
+++ b/src/OrbitQt/TrackTypeItemModelTest.cpp
@@ -12,7 +12,7 @@
 #include <string>
 
 #include "QtUtils/AssertNoQtLogWarnings.h"
-#include "TimeGraphLayout.h"
+#include "StaticTimeGraphLayout.h"
 #include "TrackManager.h"
 #include "TrackTestData.h"
 #include "TrackTypeItemModel.h"
@@ -43,7 +43,7 @@ class TrackTypeItemModelTest : public ::testing::Test {
   orbit_qt_utils::AssertNoQtLogWarnings log_qt_test_;
   TrackTypeItemModel model_;
 
-  TimeGraphLayout layout_;
+  orbit_gl::StaticTimeGraphLayout layout_;
   std::unique_ptr<orbit_client_data::CaptureData> capture_data_ =
       orbit_gl::TrackTestData::GenerateTestCaptureData();
   orbit_gl::TrackManager track_manager_ = orbit_gl::TrackManager(


### PR DESCRIPTION
TimeGraphLayout used to mix two things:

1. Keeping the state for all the layout properties
2. Drawing widget elements to change those layout properties

This commits is changing that.

1. TimeGraphLayout becomes an interfaces
2. What used to be TimeGraphLayout is now called ImGuiTimeGraphLayout
3. There is also a StaticTimeGraphLayout which can be used for tests.

The whole purpose of this is to replace ImGui by a QtTimeGraphLayout
which uses Qt widgets so that we don't need ImGui anymore.
