### PR TITLE
Local profiling widget + Start OrbitService

### DIFF
--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -238,7 +238,9 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   [[nodiscard]] bool ConfirmExit();
   void Exit(int return_code);
 
+  void OnConnectionError(const QString& error_message);
   void OnStadiaConnectionError(std::error_code error);
+  void OnLocalConnectionError(const QString& error_message);
 
   void UpdateCaptureToolbarIconOpacity();
 

--- a/src/SessionSetup/CMakeLists.txt
+++ b/src/SessionSetup/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(SessionSetup STATIC)
 target_sources(
   SessionSetup
   PUBLIC  include/SessionSetup/Connections.h
+          include/SessionSetup/ConnectToLocalWidget.h
           include/SessionSetup/ConnectToStadiaWidget.h
           include/SessionSetup/ConnectToTargetDialog.h
           include/SessionSetup/DeploymentConfigurations.h
@@ -33,7 +34,9 @@ target_include_directories(SessionSetup PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include
 
 target_sources(
   SessionSetup
-  PRIVATE ConnectToStadiaWidget.cpp
+  PRIVATE ConnectToLocalWidget.cpp
+          ConnectToLocalWidget.ui
+          ConnectToStadiaWidget.cpp
           ConnectToStadiaWidget.ui
           ConnectToTargetDialog.cpp
           ConnectToTargetDialog.ui
@@ -84,7 +87,8 @@ add_executable(SessionSetupTests)
 
 target_sources(
   SessionSetupTests
-  PRIVATE ConnectToStadiaWidgetTest.cpp
+  PRIVATE ConnectToLocalWidgetTest.cpp
+          ConnectToStadiaWidgetTest.cpp
           DoubleClickableLabelTest.cpp
           PersistentStorageTest.cpp
           ProcessItemModelTest.cpp

--- a/src/SessionSetup/ConnectToLocalWidget.cpp
+++ b/src/SessionSetup/ConnectToLocalWidget.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SessionSetup/ConnectToLocalWidget.h"
+
+#include <absl/flags/flag.h>
+#include <absl/time/time.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/security/credentials.h>
+#include <grpcpp/support/channel_arguments.h>
+
+#include <QMessageBox>
+#include <QPushButton>
+#include <algorithm>
+#include <memory>
+
+#include "ClientFlags/ClientFlags.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
+#include "SessionSetup/Connections.h"
+#include "ui_ConnectToLocalWidget.h"
+
+namespace orbit_session_setup {
+
+// The destructor needs to be defined here because it needs to see the type
+// `Ui::ConnectToLocalWidget`. The header file only contains a forward declaration.
+ConnectToLocalWidget::~ConnectToLocalWidget() = default;
+
+ConnectToLocalWidget::ConnectToLocalWidget(QWidget* parent)
+    : QWidget(parent),
+      ui_(std::make_unique<Ui::ConnectToLocalWidget>()),
+      local_connection_(
+          grpc::CreateCustomChannel(absl::StrFormat("127.0.0.1:%d", absl::GetFlag(FLAGS_grpc_port)),
+                                    grpc::InsecureChannelCredentials(), grpc::ChannelArguments()),
+          nullptr),
+      check_connection_timer_(this) {
+  ui_->setupUi(this);
+
+  // The following is to make the radioButton behave as if it was part of an exclusive button group
+  // in the parent widget (SessionSetupDialog). If a user clicks on the radioButton and it was
+  // not checked before, it is checked afterwards and this widget sends the activation signal.
+  // SessionSetupDialog reacts to the signal and deactivates the other widgets belonging to that
+  // button group. If a user clicks on a radio button that is already checked, nothing happens, the
+  // button does not get unchecked.
+  QObject::connect(ui_->radioButton, &QRadioButton::clicked, this, [this](bool checked) {
+    if (checked) {
+      emit Activated();
+    } else {
+      ui_->radioButton->setChecked(true);
+    }
+  });
+
+  QObject::connect(ui_->startOrbitServiceButton, &QPushButton::clicked, this,
+                   &ConnectToLocalWidget::OnStartOrbitServiceButtonClicked);
+
+  QObject::connect(&check_connection_timer_, &QTimer::timeout, this, [this]() {
+    if (local_connection_.GetGrpcChannel()->GetState(true) == GRPC_CHANNEL_READY) {
+      ui_->statusLabel->setText("Connected to OrbitService");
+      emit Connected();
+    } else {
+      if (local_connection_.GetOrbitServiceInstance() == nullptr) {
+        ui_->statusLabel->setText("Waiting for OrbitService");
+      } else {
+        ui_->statusLabel->setText("Connecting... to OrbitService");
+      }
+      emit Disconnected();
+    }
+  });
+  check_connection_timer_.start(250);
+}
+
+bool ConnectToLocalWidget::IsActive() const { return ui_->contentFrame->isEnabled(); }
+
+void ConnectToLocalWidget::SetActive(bool value) {
+  ui_->contentFrame->setEnabled(value);
+  ui_->radioButton->setChecked(value);
+}
+
+void ConnectToLocalWidget::SetOrbitServiceInstanceCreateFunction(
+    OrbitServiceInstanceCreator&& creator) {
+  orbit_service_instance_creator_ = std::move(creator);
+  ui_->startOrbitServiceButton->setEnabled(true);
+}
+
+void ConnectToLocalWidget::OnStartOrbitServiceButtonClicked() {
+  ORBIT_CHECK(orbit_service_instance_creator_ != nullptr);
+
+  ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> orbit_service_instance_or_error =
+      orbit_service_instance_creator_();
+
+  if (orbit_service_instance_or_error.has_error()) {
+    QMessageBox::critical(
+        this, "Error while starting OrbitService",
+        QString::fromStdString(orbit_service_instance_or_error.error().message()));
+    return;
+  }
+
+  local_connection_.orbit_service_instance_ = std::move(orbit_service_instance_or_error.value());
+
+  QObject::connect(local_connection_.GetOrbitServiceInstance(),
+                   &OrbitServiceInstance::ErrorOccurred, this, [this](const QString& message) {
+                     QMessageBox::critical(this, "OrbitService Error", message);
+                     local_connection_.orbit_service_instance_ = nullptr;
+                     emit Disconnected();
+                   });
+}
+
+}  // namespace orbit_session_setup

--- a/src/SessionSetup/ConnectToLocalWidget.ui
+++ b/src/SessionSetup/ConnectToLocalWidget.ui
@@ -10,12 +10,6 @@
     <height>51</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <property name="accessibleName">
-   <string>Orbit Profiler</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <property name="leftMargin">
     <number>0</number>
@@ -106,7 +100,7 @@
          <item>
           <widget class="QLabel" name="statusLabel">
            <property name="text">
-            <string></string>
+            <string>connection status placeholder</string>
            </property>
           </widget>
          </item>

--- a/src/SessionSetup/ConnectToLocalWidget.ui
+++ b/src/SessionSetup/ConnectToLocalWidget.ui
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConnectToLocalWidget</class>
+ <widget class="QWidget" name="ConnectToLocalWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>748</width>
+    <height>51</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="accessibleName">
+   <string>Orbit Profiler</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QFrame" name="mainFrame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QRadioButton" name="radioButton">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+         </font>
+        </property>
+        <property name="accessibleName">
+         <string>ConnectToLocal</string>
+        </property>
+        <property name="text">
+         <string>Local profiling</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="contentFrame">
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="startOrbitServiceButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Start OrbitService</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="statusLabel">
+           <property name="text">
+            <string></string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../icons/orbiticons.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/SessionSetup/ConnectToLocalWidgetTest.cpp
+++ b/src/SessionSetup/ConnectToLocalWidgetTest.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-spec-builders.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QFrame>
+#include <QLabel>
+#include <QMessageBox>
+#include <QMetaObject>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QSignalSpy>
+#include <QTest>
+#include <memory>
+
+#include "SessionSetup/ConnectToLocalWidget.h"
+#include "SessionSetup/OrbitServiceInstance.h"
+
+namespace orbit_session_setup {
+
+class MockOrbitServiceInstance : public OrbitServiceInstance {
+ public:
+  MOCK_METHOD(bool, IsRunning, (), (override, const));
+  MOCK_METHOD(ErrorMessageOr<void>, Shutdown, (), (override));
+};
+
+class ConnectToLocalWidgetTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    start_orbit_service_button_ = widget_.findChild<QPushButton*>("startOrbitServiceButton");
+    ASSERT_NE(start_orbit_service_button_, nullptr);
+    status_label_ = widget_.findChild<QLabel*>("statusLabel");
+    ASSERT_NE(status_label_, nullptr);
+    content_frame_ = widget_.findChild<QFrame*>("contentFrame");
+    ASSERT_NE(content_frame_, nullptr);
+    radio_button_ = widget_.findChild<QRadioButton*>("radioButton");
+    ASSERT_NE(radio_button_, nullptr);
+
+    EXPECT_FALSE(start_orbit_service_button_->isEnabled());
+  }
+
+ protected:
+  ConnectToLocalWidget widget_;
+  QPushButton* start_orbit_service_button_;
+  QLabel* status_label_;
+  QFrame* content_frame_;
+  QRadioButton* radio_button_;
+};
+
+TEST_F(ConnectToLocalWidgetTest, IsActiveSetActive) {
+  EXPECT_TRUE(widget_.IsActive());
+  EXPECT_TRUE(content_frame_->isEnabled());
+  EXPECT_TRUE(radio_button_->isEnabled());
+  EXPECT_TRUE(radio_button_->isChecked());
+
+  widget_.SetActive(false);
+  EXPECT_FALSE(content_frame_->isEnabled());
+  EXPECT_TRUE(radio_button_->isEnabled());
+  EXPECT_FALSE(radio_button_->isChecked());
+
+  QSignalSpy spy(&widget_, &ConnectToLocalWidget::Activated);
+
+  QTest::mouseClick(radio_button_, Qt::LeftButton);
+  QCoreApplication::processEvents();
+  EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(ConnectToLocalWidgetTest, OrbitServiceStartedSuccessfullyThenStopped) {
+  bool lambda_called = false;
+  widget_.SetOrbitServiceInstanceCreateFunction(
+      [&lambda_called]() -> ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> {
+        lambda_called = true;
+        return std::make_unique<MockOrbitServiceInstance>();
+      });
+
+  EXPECT_TRUE(start_orbit_service_button_->isEnabled());
+
+  constexpr int kWaitTime = 500;  // Double of the timer interval
+
+  QTest::qWait(kWaitTime);
+  EXPECT_EQ(status_label_->text(), "Waiting for OrbitService");
+
+  QTest::mouseClick(start_orbit_service_button_, Qt::LeftButton);
+
+  EXPECT_TRUE(lambda_called);
+
+  QTest::qWait(kWaitTime);
+  EXPECT_EQ(status_label_->text(), "Connecting... to OrbitService");
+}
+
+TEST_F(ConnectToLocalWidgetTest, OrbitServiceStartError) {
+  bool lambda_called = false;
+  widget_.SetOrbitServiceInstanceCreateFunction(
+      [&lambda_called]() -> ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>> {
+        lambda_called = true;
+        return ErrorMessage{"error"};
+      });
+
+  EXPECT_TRUE(start_orbit_service_button_->isEnabled());
+
+  QMetaObject::invokeMethod(
+      &widget_,
+      [&]() {
+        auto* message_box = widget_.findChild<QMessageBox*>();
+        ASSERT_NE(message_box, nullptr);
+        message_box->close();
+      },
+      Qt::QueuedConnection);
+
+  QTest::mouseClick(start_orbit_service_button_, Qt::LeftButton);
+
+  EXPECT_TRUE(lambda_called);
+}
+
+}  // namespace orbit_session_setup

--- a/src/SessionSetup/SessionSetupDialog.ui
+++ b/src/SessionSetup/SessionSetupDialog.ui
@@ -74,7 +74,7 @@
         <property name="lineWidth">
          <number>0</number>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1">
+        <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,1">
          <property name="rightMargin">
           <number>0</number>
          </property>
@@ -82,64 +82,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QFrame" name="localFrame">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="visible">
-            <bool>true</bool>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_6">
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout">
-              <item>
-               <widget class="QRadioButton" name="localProfilingRadioButton">
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Local profiling</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>0</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QLabel" name="localProfilingStatusMessage">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="orbit_session_setup::ProcessLauncherWidget" name="processLauncherWidget" native="true"/>
-            </item>
-           </layout>
-          </widget>
+          <widget class="orbit_session_setup::ConnectToLocalWidget" name="localProfilingWidget" native="true"/>
          </item>
          <item>
           <widget class="orbit_session_setup::ConnectToStadiaWidget" name="stadiaWidget" native="true"/>
@@ -350,10 +293,9 @@
    <header>SessionSetup/TargetLabel.h</header>
   </customwidget>
   <customwidget>
-   <class>orbit_session_setup::ProcessLauncherWidget</class>
+   <class>orbit_session_setup::ConnectToLocalWidget</class>
    <extends>QWidget</extends>
-   <header>SessionSetup/ProcessLauncherWidget.h</header>
-   <container>1</container>
+   <header>SessionSetup/ConnectToLocalWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/SessionSetup/include/SessionSetup/ConnectToLocalWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToLocalWidget.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SESSION_SETUP_CONNECT_TO_LOCAL_WIDGET_H_
+#define SESSION_SETUP_CONNECT_TO_LOCAL_WIDGET_H_
+
+#include <grpcpp/channel.h>
+
+#include <QWidget>
+#include <functional>
+#include <memory>
+
+#include "GrpcProtos/process.pb.h"
+#include "OrbitBase/Result.h"
+#include "SessionSetup/Connections.h"
+#include "SessionSetup/OrbitServiceInstance.h"
+
+namespace Ui {
+class ConnectToLocalWidget;
+}
+
+namespace orbit_session_setup {
+
+using OrbitServiceInstanceCreator =
+    std::function<ErrorMessageOr<std::unique_ptr<OrbitServiceInstance>>()>;
+
+// ConnectToLocalWidget provides a UI to connect to a running OrbitService and start an OrbitService
+// instance. ConnectToLocalWidget sets up a gRPC channel to localhost with port `--grpc_port` and
+// checks every 250ms whether this channel is connected to OrbitService. If the user clicks the
+// "Start OrbitService" button, a OrbitServiceInstance is set up, to which the gRPC channel can
+// connect to.
+class ConnectToLocalWidget : public QWidget {
+  Q_OBJECT
+  Q_PROPERTY(bool active READ IsActive WRITE SetActive)
+
+ public:
+  explicit ConnectToLocalWidget(QWidget* parent = nullptr);
+  ~ConnectToLocalWidget() override;
+
+  [[nodiscard]] bool IsActive() const;
+
+  void SetOrbitServiceInstanceCreateFunction(OrbitServiceInstanceCreator&& creator);
+
+  void SetConnection(LocalConnection&& connection) { local_connection_ = std::move(connection); }
+  [[nodiscard]] LocalConnection&& TakeConnection() { return std::move(local_connection_); }
+
+  [[nodiscard]] const std::shared_ptr<grpc::Channel>& GetGrpcChannel() const {
+    return local_connection_.GetGrpcChannel();
+  }
+
+ public slots:
+  void SetActive(bool value);
+
+ signals:
+  void Activated();
+  void Connected();
+  void Disconnected();
+
+ private:
+  std::unique_ptr<Ui::ConnectToLocalWidget> ui_;
+  OrbitServiceInstanceCreator orbit_service_instance_creator_ = nullptr;
+  LocalConnection local_connection_;
+  QTimer check_connection_timer_;
+
+  void OnStartOrbitServiceButtonClicked();
+};
+
+}  // namespace orbit_session_setup
+
+#endif  // SESSION_SETUP_CONNECT_TO_LOCAL_WIDGET_H_

--- a/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
@@ -49,8 +49,6 @@ class SessionSetupDialog : public QDialog {
   void SetupLocalProcessManager();
   void TearDownProcessManager();
   void ProcessSelectionChanged(const QModelIndex& current);
-  void ConnectToLocal();
-  void ProcessLaunched(const orbit_grpc_protos::ProcessInfo& process_info);
 
  signals:
   void ProcessSelected();
@@ -66,9 +64,6 @@ class SessionSetupDialog : public QDialog {
 
   std::unique_ptr<orbit_client_data::ProcessData> process_;
   std::unique_ptr<orbit_client_services::ProcessManager> process_manager_;
-
-  std::shared_ptr<grpc::Channel> local_grpc_channel_;
-  uint16_t local_grpc_port_;
 
   std::filesystem::path selected_file_path_;
 

--- a/src/SessionSetup/include/SessionSetup/TargetConfiguration.h
+++ b/src/SessionSetup/include/SessionSetup/TargetConfiguration.h
@@ -58,7 +58,7 @@ class LocalTarget {
   explicit LocalTarget(LocalConnection&& connection,
                        std::unique_ptr<orbit_client_services::ProcessManager> process_manager,
                        std::unique_ptr<orbit_client_data::ProcessData> process)
-      : connection_(connection),
+      : connection_(std::move(connection)),
         process_manager_(std::move(process_manager)),
         process_(std::move(process)) {
     ORBIT_CHECK(process_manager_ != nullptr);


### PR DESCRIPTION
This PR adds and uses a new widget for connecting to a locally running OrbitService and starting an OrbitServiceInstance. 

This PR is split up into 3 commits only for ease of review. The commits do not compile on its own, only together. They do contain meaningful commit messages with some explanation. 

To test this, start Orbit with `--local` and then either start OrbitService yourself, or use the UI to start it. 

Note: Since local profiling is now its own widget, the state machine in SessionSetupDialog can be simplified quite a bit, but this is not done in this PR. 