### PR TITLE
Fix CaptureOptionsDialog warning

### DIFF
--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -410,7 +410,7 @@ p, li { white-space: pre-wrap; }
          <property name="title">
           <string>Auto FrameTrack</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_9">
+         <layout class="QVBoxLayout" name="verticalLayout_11">
           <item>
            <widget class="QCheckBox" name="autoFrameTrackCheckBox">
             <property name="toolTip">


### PR DESCRIPTION
During build, Qt warns that `verticalLayout_9` is used more than once. This is fixed by renaming it to verticalLayout_11 (10 is also used).