### PR TITLE
Add PropertyConfigWidget

### DIFF
--- a/src/ConfigWidgets/CMakeLists.txt
+++ b/src/ConfigWidgets/CMakeLists.txt
@@ -22,11 +22,13 @@ target_link_libraries(ConfigWidgets PUBLIC ClientData
                                            Qt5::Widgets)
 
 target_sources(
-  ConfigWidgets PUBLIC include/ConfigWidgets/SourcePathsMappingDialog.h
+  ConfigWidgets PUBLIC include/ConfigWidgets/PropertyConfigWidget.h
+                       include/ConfigWidgets/SourcePathsMappingDialog.h
                        include/ConfigWidgets/StopSymbolDownloadDialog.h
                        include/ConfigWidgets/SymbolErrorDialog.h
                        include/ConfigWidgets/SymbolLocationsDialog.h)
-target_sources(ConfigWidgets PRIVATE SourcePathsMappingDialog.cpp
+target_sources(ConfigWidgets PRIVATE PropertyConfigWidget.cpp
+                                     SourcePathsMappingDialog.cpp
                                      SourcePathsMappingDialog.ui
                                      StopSymbolDownloadDialog.cpp
                                      StopSymbolDownloadDialog.ui
@@ -40,7 +42,8 @@ set_target_properties(ConfigWidgets PROPERTIES AUTOUIC ON)
 
 add_executable(ConfigWidgetsTests)
 
-target_sources(ConfigWidgetsTests PRIVATE StopSymbolDownloadDialogTest.cpp
+target_sources(ConfigWidgetsTests PRIVATE PropertyConfigWidgetTest.cpp
+                                          StopSymbolDownloadDialogTest.cpp
                                           SymbolErrorDialogTest.cpp
                                           SymbolLocationsDialogTest.cpp)
 

--- a/src/ConfigWidgets/PropertyConfigWidget.cpp
+++ b/src/ConfigWidgets/PropertyConfigWidget.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ConfigWidgets/PropertyConfigWidget.h"
+
+#include <QCheckBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QSlider>
+#include <QWidget>
+#include <string_view>
+#include <variant>
+
+namespace orbit_config_widgets {
+
+static QString QStringFromStringView(std::string_view sv) {
+  return QString::fromUtf8(sv.data(), sv.size());
+}
+
+// Makes an object name that kind of resembles a C identifier.
+// The output is guaranteed to only contain lower case letters and underscores.
+static QString MakeObjectName(std::string_view input) {
+  auto output = QStringFromStringView(input).trimmed().toLower();
+
+  for (auto& c : output) {
+    if (!c.isLetter()) c = '_';
+  }
+
+  return output;
+}
+
+PropertyConfigWidget::PropertyConfigWidget(QWidget* parent) : QWidget(parent) {
+  layout_ = new QGridLayout(this);  // NOLINT(cppcoreguidelines-owning-memory)
+}
+
+void PropertyConfigWidget::AddWidgetForProperty(FloatProperty* property) {
+  int row = layout_->rowCount();
+
+  auto* name_label = new QLabel(QStringFromStringView(property->definition().label), this);
+  layout_->addWidget(name_label, row, 0, Qt::AlignRight);
+  name_label->setObjectName(
+      QString{"name_label_%1"}.arg(MakeObjectName(property->definition().label)));
+
+  auto* slider = new QSlider(Qt::Horizontal, this);  // NOLINT(cppcoreguidelines-owning-memory)
+  property->value_ = property->definition().initial_value;
+  slider->setMinimum(0);
+  slider->setMaximum(static_cast<int>((property->definition().max - property->definition().min) /
+                                      property->definition().step));
+  slider->setValue(static_cast<int>((property->value_ - property->definition().min) /
+                                    property->definition().step));
+  slider->setSingleStep(1);
+  slider->setObjectName(QString{"slider_%1"}.arg(MakeObjectName(property->definition().label)));
+  layout_->addWidget(slider, row, 1);
+
+  const auto get_value_string = [property](float val) {
+    return QString{"%1%2"}
+        .arg(val, 0, 'f', 2)
+        .arg(QStringFromStringView(property->definition().suffix));
+  };
+
+  auto* value_label = new QLabel(get_value_string(property->definition_.initial_value), this);
+  layout_->addWidget(value_label, row, 2, Qt::AlignRight);
+  value_label->setObjectName(
+      QString{"value_label_%1"}.arg(MakeObjectName(property->definition_.label)));
+
+  QObject::connect(slider, &QSlider::valueChanged, value_label,
+                   [property, get_value_string, value_label](int value) {
+                     const auto new_value = property->definition().min +
+                                            static_cast<float>(value) * property->definition_.step;
+                     if (property->value_ == new_value) return;
+                     property->value_ = new_value;
+                     value_label->setText(get_value_string(property->value_));
+                   });
+
+  property->setter_ = [slider](int value) { slider->setValue(value); };
+}
+
+void PropertyConfigWidget::AddWidgetForProperty(IntProperty* property) {
+  int row = layout_->rowCount();
+
+  auto* name_label = new QLabel(
+      QString::fromUtf8(property->definition_.label.data(), property->definition_.label.size()),
+      this);
+  layout_->addWidget(name_label, row, 0, Qt::AlignRight);
+  name_label->setObjectName(
+      QString{"name_label_%1"}.arg(MakeObjectName(property->definition_.label)));
+
+  auto* slider = new QSlider(Qt::Horizontal, this);  // NOLINT(cppcoreguidelines-owning-memory)
+  property->value_ = property->definition_.initial_value;
+  slider->setMinimum(property->definition().min);
+  slider->setMaximum(property->definition().max);
+  slider->setValue(property->definition_.initial_value);
+  slider->setSingleStep(property->definition_.step);
+  slider->setObjectName(QString{"slider_%1"}.arg(MakeObjectName(property->definition_.label)));
+  layout_->addWidget(slider, row, 1);
+
+  const auto get_value_string = [property](int val) {
+    return QString{"%1%2"}.arg(val).arg(QString::fromUtf8(property->definition_.suffix.data(),
+                                                          property->definition_.suffix.size()));
+  };
+
+  auto* value_label = new QLabel(get_value_string(property->definition_.initial_value), this);
+  layout_->addWidget(value_label, row, 2, Qt::AlignRight);
+  value_label->setObjectName(
+      QString{"value_label_%1"}.arg(MakeObjectName(property->definition_.label)));
+
+  QObject::connect(slider, &QSlider::valueChanged, value_label,
+                   [property, get_value_string, value_label](int value) {
+                     if (value == property->value_) return;
+                     property->value_ = value;
+                     value_label->setText(get_value_string(property->value_));
+                   });
+
+  property->setter_ = [slider](int value) { slider->setValue(value); };
+}
+
+void PropertyConfigWidget::AddWidgetForProperty(BoolProperty* property) {
+  int row = layout_->rowCount();
+
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  auto* checkbox = new QCheckBox(QStringFromStringView(property->definition().label), this);
+  checkbox->setObjectName(QString{"checkbox_%1"}.arg(MakeObjectName(property->definition().label)));
+  property->value_ = property->definition().initial_value;
+  checkbox->setChecked(property->value());
+  layout_->addWidget(checkbox, row, 1);
+
+  QObject::connect(checkbox, &QCheckBox::stateChanged, this, [property](int check_state) {
+    bool new_value = check_state == Qt::Checked;
+    if (property->value() == new_value) return;
+    property->value_ = new_value;
+  });
+
+  property->setter_ = [checkbox](bool checked) { checkbox->setChecked(checked); };
+}
+
+}  // namespace orbit_config_widgets

--- a/src/ConfigWidgets/PropertyConfigWidgetTest.cpp
+++ b/src/ConfigWidgets/PropertyConfigWidgetTest.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QSlider>
+
+#include "ConfigWidgets/PropertyConfigWidget.h"
+
+TEST(FloatProperty, SetValue) {
+  orbit_config_widgets::PropertyConfigWidget::FloatProperty property{
+      {.initial_value = 42.f, .min = 0.f, .max = 100.f, .step = 1.0f, .label = "My label:"}};
+  EXPECT_EQ(property.value(), 42.f);
+
+  property.SetValue(-10.f);
+  EXPECT_EQ(property.value(), 0.f);
+
+  property.SetValue(142.f);
+  EXPECT_EQ(property.value(), 100.f);
+}
+
+TEST(FloatProperty, InitialValueClamping) {
+  orbit_config_widgets::PropertyConfigWidget::FloatProperty property{
+      {.initial_value = 42.f, .min = 55.5f, .max = 100.f, .step = 1.0f, .label = "My label:"}};
+  EXPECT_EQ(property.value(), 55.5);
+}
+
+TEST(IntProperty, SetValue) {
+  orbit_config_widgets::PropertyConfigWidget::IntProperty property{
+      {.initial_value = 42, .min = 0, .max = 100, .step = 1, .label = "My label:"}};
+  EXPECT_EQ(property.value(), 42);
+
+  property.SetValue(-10);
+  EXPECT_EQ(property.value(), 0);
+
+  property.SetValue(142);
+  EXPECT_EQ(property.value(), 100);
+}
+
+TEST(IntProperty, InitialValueClamping) {
+  orbit_config_widgets::PropertyConfigWidget::IntProperty property{
+      {.initial_value = 42, .min = 55, .max = 100, .step = 1, .label = "My label:"}};
+  EXPECT_EQ(property.value(), 55);
+}
+
+TEST(BoolProperty, SetValue) {
+  orbit_config_widgets::PropertyConfigWidget::BoolProperty property{
+      {.initial_value = true, .label = "My label:"}};
+  EXPECT_EQ(property.value(), true);
+
+  property.SetValue(false);
+  EXPECT_EQ(property.value(), false);
+}
+
+TEST(PropertyConfigWidget, AddWidgetForFloatProperty) {
+  orbit_config_widgets::PropertyConfigWidget widget{};
+
+  orbit_config_widgets::PropertyConfigWidget::FloatProperty property{
+      {.initial_value = 42.f, .min = 0.f, .max = 100.f, .step = 1.0f, .label = "My label:"}};
+  widget.AddWidgetForProperty(&property);
+
+  auto* slider = widget.findChild<QSlider*>("slider_my_label_");
+  ASSERT_NE(slider, nullptr);
+
+  EXPECT_EQ(slider->value(), 42);
+
+  // Slider changes adjust the property's value.
+  slider->setValue(78);
+  EXPECT_EQ(property.value(), 78);
+
+  // The slider obeys min and max limits.
+  slider->setValue(142);
+  EXPECT_EQ(property.value(), 100);
+
+  // Programmatic value changes adjust the slider.
+  property.SetValue(42);
+  EXPECT_EQ(slider->value(), 42);
+}
+
+TEST(PropertyConfigWidget, AddWidgetForIntProperty) {
+  orbit_config_widgets::PropertyConfigWidget widget{};
+
+  orbit_config_widgets::PropertyConfigWidget::IntProperty property{
+      {.initial_value = 42, .min = 0, .max = 100, .step = 1, .label = "My label:"}};
+  widget.AddWidgetForProperty(&property);
+
+  auto* slider = widget.findChild<QSlider*>("slider_my_label_");
+  ASSERT_NE(slider, nullptr);
+
+  EXPECT_EQ(slider->value(), 42);
+
+  // Slider changes adjust the property's value.
+  slider->setValue(78);
+  EXPECT_EQ(property.value(), 78);
+
+  // The slider obeys min and max limits.
+  slider->setValue(142);
+  EXPECT_EQ(property.value(), 100);
+
+  // Programmatic value changes adjust the slider.
+  property.SetValue(42);
+  EXPECT_EQ(slider->value(), 42);
+}
+
+TEST(PropertyConfigWidget, AddWidgetForBoolProperty) {
+  orbit_config_widgets::PropertyConfigWidget widget{};
+
+  orbit_config_widgets::PropertyConfigWidget::BoolProperty property{
+      {.initial_value = true, .label = "My label:"}};
+  widget.AddWidgetForProperty(&property);
+
+  auto* checkbox = widget.findChild<QCheckBox*>("checkbox_my_label_");
+  ASSERT_NE(checkbox, nullptr);
+
+  EXPECT_EQ(checkbox->isChecked(), true);
+
+  checkbox->setChecked(false);
+  EXPECT_EQ(property.value(), false);
+
+  property.SetValue(true);
+  EXPECT_EQ(checkbox->isChecked(), true);
+}
+
+// Start the test binary with `--gtest_filter=PropertyConfigWidget.DISABLED_Demo
+// --gtest_also_run_disabled_tests` to run this demo.
+TEST(PropertyConfigWidget, DISABLED_Demo) {
+  orbit_config_widgets::PropertyConfigWidget widget{};
+
+  orbit_config_widgets::PropertyConfigWidget::BoolProperty enable_flux_capacitor{
+      {.initial_value = true, .label = "Enable flux capacitor"}};
+  widget.AddWidgetForProperty(&enable_flux_capacitor);
+
+  orbit_config_widgets::PropertyConfigWidget::FloatProperty warp_factor{
+      {.initial_value = 1.0f, .min = 1.0f, .max = 10.f, .step = 0.1f, .label = "Warp Factor:"}};
+  widget.AddWidgetForProperty(&warp_factor);
+
+  orbit_config_widgets::PropertyConfigWidget::IntProperty answer{
+      {.initial_value = 41,
+       .min = 0,
+       .max = 200,
+       .step = 1,
+       .label = "What you get if you multiply six by nine:"}};
+  widget.AddWidgetForProperty(&answer);
+
+  widget.show();
+  QApplication::exec();
+  SUCCEED();
+}

--- a/src/ConfigWidgets/include/ConfigWidgets/PropertyConfigWidget.h
+++ b/src/ConfigWidgets/include/ConfigWidgets/PropertyConfigWidget.h
@@ -1,0 +1,123 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef PROPERTY_CONFIG_WIDGET_H_
+#define PROPERTY_CONFIG_WIDGET_H_
+
+#include <QGridLayout>
+#include <QWidget>
+#include <algorithm>
+#include <cmath>
+#include <string_view>
+
+namespace orbit_config_widgets {
+
+template <typename ValueType>
+struct PropertyDefinition {
+  static_assert(!std::is_same_v<ValueType, ValueType>,
+                "You tried to define a property for a type that is currently not (yet) supported."
+                "We only support float, int, and bool so far.");
+};
+
+template <typename ValueType>
+class Property;
+
+template <>
+struct PropertyDefinition<float> {
+  float initial_value = 0.f;
+  float min = 0.f;
+  float max = 100.f;
+  float step = 0.1f;
+  std::string_view label;   // This will be printed in front of the slider. It is recommend to add
+                            // a colon at the end of the label.
+  std::string_view suffix;  // This can be a unit like px or mm. It will be appended to the value
+                            // label. Don't forget to add a space before the unit.
+
+  [[nodiscard]] float SanitizeValue(float value) const { return std::clamp(value, min, max); }
+};
+
+template <>
+struct PropertyDefinition<int> {
+  int initial_value = 0;
+  int min = 0;
+  int max = 100;
+  int step = 1;
+  std::string_view label;   // This will be printed in front of the slider. It is recommend to add
+                            // a colon at the end of the label.
+  std::string_view suffix;  // This can be a unit like px or mm. It will be appended to the value
+                            // label. Don't forget to add a space before the unit.
+
+  [[nodiscard]] int SanitizeValue(int value) const { return std::clamp(value, min, max); }
+};
+
+template <>
+struct PropertyDefinition<bool> {
+  bool initial_value = false;
+  std::string_view label;  // This will be the checkbox's label. No colon required here because it
+                           // goes after the checkbox.
+
+  [[nodiscard]] static bool SanitizeValue(bool value) {
+    // Since the data type `bool` exactly represents the allowed set of state, no clamping or
+    // whatever is needed here.
+    return value;
+  }
+};
+
+// This widget offers controls for a list of changeable settings (called properties).
+// For each registered property one control element will be generated.
+// So far we support floating point and integer properties which generate a slider in the widget, as
+// well as boolean properties which generate a checkbox.
+//
+// Check out the Demo in PropertyConfigWidgetTest.cpp to see how it works.
+class PropertyConfigWidget : public QWidget {
+  Q_OBJECT
+ public:
+  explicit PropertyConfigWidget(QWidget* parent = nullptr);
+
+  template <typename ValueType>
+  class Property {
+    friend PropertyConfigWidget;
+
+   public:
+    explicit Property(const PropertyDefinition<ValueType>& definition)
+        : definition_(definition), value_{definition.SanitizeValue(definition.initial_value)} {}
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    [[nodiscard]] ValueType value() const { return value_; }
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    [[nodiscard]] const PropertyDefinition<ValueType>& definition() const { return definition_; }
+
+    void SetValue(ValueType value) {
+      value_ = definition().SanitizeValue(value);
+
+      if (!setter_) return;
+      setter_(std::move(value));
+    }
+
+   private:
+    PropertyDefinition<ValueType> definition_;
+    ValueType value_;
+    std::function<void(ValueType)> setter_;
+  };
+
+  using FloatProperty = Property<float>;
+  using IntProperty = Property<int>;
+  using BoolProperty = Property<bool>;
+
+  // Note, by calling this function you guarantee that `property` stays alive until the end of the
+  // widget's lifetime. Making the properties member variables of a subclass of this widget is
+  // explicitly allowed even though that violates this rules. (We won't use the properties in the
+  // destructor of the widget, so it will be fine.)
+  void AddWidgetForProperty(FloatProperty* property);
+  void AddWidgetForProperty(IntProperty* property);
+  void AddWidgetForProperty(BoolProperty* property);
+
+ private:
+  QGridLayout* layout_;
+};
+
+}  // namespace orbit_config_widgets
+
+#endif  // PROPERTY_CONFIG_WIDGET_H_

--- a/src/ConfigWidgets/include/ConfigWidgets/PropertyConfigWidget.h
+++ b/src/ConfigWidgets/include/ConfigWidgets/PropertyConfigWidget.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef PROPERTY_CONFIG_WIDGET_H_
-#define PROPERTY_CONFIG_WIDGET_H_
+#ifndef CONFIG_WIDGETS_PROPERTY_CONFIG_WIDGET_H_
+#define CONFIG_WIDGETS_PROPERTY_CONFIG_WIDGET_H_
 
 #include <QGridLayout>
 #include <QWidget>
@@ -120,4 +120,4 @@ class PropertyConfigWidget : public QWidget {
 
 }  // namespace orbit_config_widgets
 
-#endif  // PROPERTY_CONFIG_WIDGET_H_
+#endif  // CONFIG_WIDGETS_PROPERTY_CONFIG_WIDGET_H_


### PR DESCRIPTION
The PropertyConfigWidget generates control elements on the fly and acts as a container for them.

The intention is to replace ImGui control elements that currently allow devs to try out a lot of different UI changes.

Demo: https://screenshot.googleplex.com/3F57piHHZPstrdH
