### PR TITLE
Fix samples being drawn in pixel coordinates

### DIFF
--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -140,9 +140,8 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
     auto action_on_selected_callstack_events = [&](const CallstackEvent& event) {
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
-      const Vec2 pos(GetPixelNumber(event.timestamp_ns(), resolution_in_pixels, min_tick, max_tick),
-                     GetPos()[1]);
-      primitive_assembler.AddVerticalLine(pos, track_height, z, kGreenSelection);
+      const auto& [pos_x, unused_size_x] = timeline_info_->GetBoxPosXAndWidthFromTicks(time, time);
+      primitive_assembler.AddVerticalLine({pos_x, GetPos()[1]}, track_height, z, kGreenSelection);
     };
     const orbit_client_data::CallstackData& selection_callstack_data =
         capture_data_->selection_callstack_data();


### PR DESCRIPTION
This PR if fixing a regression from https://github.com/google/orbit/pull/4296.

In that PR we started to use GetPixelNumber because is more precise when drawing lines (based on imprecision of GetWorldFromTick) but we have the issue that we are not converting to world coordinates, so in this PR we are reverting and using the new created method that is used in SchedulerTrack, ThreadTrack and ThreadStates to get the position of the line.

Test: Load a capture, navigate.