### PR TITLE
Remove subclass from CaptureWindow test

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -76,7 +76,9 @@ class AccessibleCaptureWindow : public AccessibleWidgetBridge {
 
 using orbit_client_protos::TimerInfo;
 
-CaptureWindow::CaptureWindow(OrbitApp* app) : GlCanvas(), app_{app}, capture_client_app_{app} {
+CaptureWindow::CaptureWindow(
+    OrbitApp* app, orbit_capture_client::CaptureControlInterface* capture_control_interface)
+    : app_{app}, capture_client_app_{capture_control_interface} {
   draw_help_ = true;
 
   scoped_frame_times_[kTimingDraw] = std::make_unique<orbit_gl::SimpleTimings>(30);

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -18,13 +18,15 @@
 #include "PickingManager.h"
 #include "SimpleTimings.h"
 #include "TimeGraph.h"
+#include "TimeGraphLayout.h"
 #include "absl/container/btree_map.h"
 
 class OrbitApp;
 
 class CaptureWindow : public GlCanvas {
  public:
-  explicit CaptureWindow(OrbitApp* app);
+  explicit CaptureWindow(OrbitApp* app,
+                         orbit_capture_client::CaptureControlInterface* capture_control);
 
   void PreRender() override;
 

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -91,12 +91,14 @@ GlCanvas::~GlCanvas() {
 std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, OrbitApp* app) {
   switch (canvas_type) {
     case CanvasType::kCaptureWindow: {
-      auto main_capture_window = std::make_unique<CaptureWindow>(app);
+      auto main_capture_window =
+          std::make_unique<CaptureWindow>(app, /*.capture_control_interface = */ app);
       app->SetCaptureWindow(main_capture_window.get());
       return main_capture_window;
     }
     case CanvasType::kIntrospectionWindow: {
-      auto introspection_window = std::make_unique<IntrospectionWindow>(app);
+      auto introspection_window =
+          std::make_unique<IntrospectionWindow>(app, /*.capture_control_interface = */ app);
       app->SetIntrospectionWindow(introspection_window.get());
       return introspection_window;
     }

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -92,13 +92,13 @@ std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, OrbitApp* app
   switch (canvas_type) {
     case CanvasType::kCaptureWindow: {
       auto main_capture_window =
-          std::make_unique<CaptureWindow>(app, /*.capture_control_interface = */ app);
+          std::make_unique<CaptureWindow>(app, /* capture_control_interface = */ app);
       app->SetCaptureWindow(main_capture_window.get());
       return main_capture_window;
     }
     case CanvasType::kIntrospectionWindow: {
       auto introspection_window =
-          std::make_unique<IntrospectionWindow>(app, /*.capture_control_interface = */ app);
+          std::make_unique<IntrospectionWindow>(app, /* capture_control_interface = */ app);
       app->SetIntrospectionWindow(introspection_window.get());
       return introspection_window;
     }

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -5,6 +5,7 @@
 #include "IntrospectionWindow.h"
 
 #include "App.h"
+#include "CaptureClient/AppInterface.h"
 #include "ClientData/CallstackEvent.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "ImGuiOrbit.h"
@@ -204,8 +205,9 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
 
 }  // namespace
 
-IntrospectionWindow::IntrospectionWindow(OrbitApp* app)
-    : CaptureWindow(app),
+IntrospectionWindow::IntrospectionWindow(
+    OrbitApp* app, orbit_capture_client::CaptureControlInterface* capture_control)
+    : CaptureWindow(app, capture_control),
       capture_listener_{std::make_unique<IntrospectionCaptureListener>(this)},
       api_event_processor_{capture_listener_.get()} {
   // Create CaptureData.

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "CaptureClient/ApiEventProcessor.h"
+#include "CaptureClient/AppInterface.h"
 #include "CaptureWindow.h"
 #include "ClientData/CaptureData.h"
 #include "Introspection/Introspection.h"
@@ -18,7 +19,8 @@ class OrbitApp;
 
 class IntrospectionWindow : public CaptureWindow {
  public:
-  explicit IntrospectionWindow(OrbitApp* app);
+  explicit IntrospectionWindow(OrbitApp* app,
+                               orbit_capture_client::CaptureControlInterface* capture_control);
   ~IntrospectionWindow() override;
   void ToggleRecording() override;
   void RenderImGuiDebugUI() override;


### PR DESCRIPTION
It's not needed anymore to subclass the `CaptureWindow` class, just to implement the test. So this removes the subclassing and makes CaptureWindow a member in the test fixture. This leads to better decoupling and prevents future changes from relying on internals to be testable.