### PR TITLE
Remove --local flag

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -144,22 +144,21 @@ script will not be able to install conan for you.)
 Like mentioned before, the collector currently only works for Linux. So the following
 only applies there:
 
-To obtain scheduling information, the collector needs to run as root:
+1. Start Orbit via 
+```bash
+./build_default_relwithdebinfo/bin/Orbit
+```
+2. Start OrbitService by clicking the button `Start OrbitService`. To obtain scheduling
+   information, the collector needs to run as root, hence this will prompt you for a
+	 password (via [pkexec](https://linux.die.net/man/1/pkexec)). Alternatively, you can 
+	 start OrbitService yourself:
 
 ```bash
 sudo ./build_default_relwithdebinfo/bin/OrbitService # Start the collector
 ```
 
-After the collector runs you can start the frontend from a different shell.
-
-```bash
-./build_default_relwithdebinfo/bin/Orbit --local
-```
-
 The frontend currently has no graphical user interface to connect to a generic
-remote instance. Only Stadia is supported as a special case. That's why you need
-to start the frontend in `--local` mode. This will instruct Orbit to connect to the
-service at `localhost` on port `44765`.
+remote instance. Only Stadia is supported as a special case. 
 
 If you needed remote profiling support you could tunnel the mentioned TCP port through
 a SSH connection to an arbitrary Linux server. There are plans on adding generic

--- a/contrib/vscode/launch.json
+++ b/contrib/vscode/launch.json
@@ -21,9 +21,6 @@
       "type": "cppdbg",
       "request": "launch",
       "program": "${workspaceFolder}/build_default_relwithdebinfo/bin/Orbit",
-      "args": [
-        "--local",
-      ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build_default_relwithdebinfo/bin/",
       "environment": [],

--- a/run.sh
+++ b/run.sh
@@ -5,4 +5,4 @@
 
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-exec $DIR/build_default_relwithdebinfo/bin/Orbit --local
+exec $DIR/build_default_relwithdebinfo/bin/Orbit

--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -18,7 +18,6 @@ ABSL_FLAG(std::string, collector_root_password, "", "Collector's machine root pa
 
 ABSL_FLAG(uint16_t, grpc_port, 44765,
           "The service's GRPC server port (use default value if unsure)");
-ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 
 ABSL_FLAG(std::string, process_name, "",
           "Automatically select and connect to the specified process");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -21,8 +21,6 @@ ABSL_DECLARE_FLAG(std::string, collector_root_password);
 
 ABSL_DECLARE_FLAG(uint16_t, grpc_port);
 
-ABSL_DECLARE_FLAG(bool, local);
-
 ABSL_DECLARE_FLAG(std::string, process_name);
 
 // TODO(b/160549506): Remove this flag once it can be specified in the ui.

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -502,6 +502,8 @@ class OrbitApp final : public DataViewFactory,
   }
 
   [[nodiscard]] bool IsConnected() const override { return main_window_->IsConnected(); }
+  [[nodiscard]] bool IsLocalTarget() const override { return main_window_->IsLocalTarget(); }
+
   orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> DownloadFileFromInstance(
       std::filesystem::path path_on_instance, std::filesystem::path local_path,
       orbit_base::StopToken stop_token) override;

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -75,6 +75,7 @@ class MainWindowInterface {
   virtual void ClearCallstackInspection() = 0;
 
   virtual bool IsConnected() = 0;
+  virtual bool IsLocalTarget() = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -75,7 +75,7 @@ class MainWindowInterface {
   virtual void ClearCallstackInspection() = 0;
 
   virtual bool IsConnected() = 0;
-  virtual bool IsLocalTarget() = 0;
+  [[nodiscard]] virtual bool IsLocalTarget() const = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/SymbolLoader.cpp
+++ b/src/OrbitGl/SymbolLoader.cpp
@@ -379,9 +379,9 @@ Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> SymbolLoader::Retrieve
       main_thread_executor_->Schedule([this, module_id,
                                        stop_token = stop_source.GetStopToken()]() mutable
                                       -> Future<SymbolRetrieveResult> {
-        // If --local, Orbit cannot download files from the instance, because no ssh channel
-        // exists. We still return an ErrorMessage to enable continuing searching for symbols
-        // from other symbol sources.
+        // If Orbit is in local profiling mode, it cannot download files from the instance, because
+        // no ssh channel exists. We still return an ErrorMessage to enable continuing searching for
+        // symbols from other symbol sources.
         if (app_interface_->IsLocalTarget() || !app_interface_->IsConnected() ||
             absl::GetFlag(FLAGS_disable_instance_symbols)) {
           return {ErrorMessage{"\n- Not able to search for symbols on the instance."}};

--- a/src/OrbitGl/SymbolLoader.h
+++ b/src/OrbitGl/SymbolLoader.h
@@ -38,6 +38,7 @@ class SymbolLoader {
     [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleByModuleIdentifier(
         const orbit_symbol_provider::ModuleIdentifier& module_id) const = 0;
     [[nodiscard]] virtual bool IsConnected() const = 0;
+    [[nodiscard]] virtual bool IsLocalTarget() const = 0;
     virtual orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>>
     DownloadFileFromInstance(std::filesystem::path path_on_instance,
                              std::filesystem::path local_path,

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -134,7 +134,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   bool IsConnected() override { return is_connected_; }
 
-  bool IsLocalTarget() override {
+  [[nodiscard]] bool IsLocalTarget() const override {
     return std::holds_alternative<orbit_session_setup::LocalTarget>(target_configuration_);
   }
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -28,6 +28,7 @@
 #include <string_view>
 #include <system_error>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "App.h"
@@ -44,6 +45,7 @@
 #include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/MainThreadExecutor.h"
+#include "SessionSetup/TargetConfiguration.h"
 #include "SessionSetup/TargetLabel.h"
 #include "orbitglwidget.h"
 
@@ -131,6 +133,10 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void ClearCallstackInspection() override;
 
   bool IsConnected() override { return is_connected_; }
+
+  bool IsLocalTarget() override {
+    return std::holds_alternative<orbit_session_setup::LocalTarget>(target_configuration_);
+  }
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -115,8 +115,6 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
   ui_->processesTableView->verticalHeader()->setDefaultSectionSize(kProcessesRowHeight);
   ui_->processesTableView->verticalHeader()->setVisible(false);
 
-  ui_->localProfilingWidget->setVisible(absl::GetFlag(FLAGS_local));
-
   QObject::connect(ui_->processesTableView->selectionModel(), &QItemSelectionModel::currentChanged,
                    this, &SessionSetupDialog::ProcessSelectionChanged);
   QObject::connect(ui_->processesTableView, &QTableView::doubleClicked, this, &QDialog::accept);
@@ -139,7 +137,7 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
 }
 
 void SessionSetupDialog::SetStateMachineInitialState() {
-  if (absl::GetFlag(FLAGS_local)) {
+  if (ui_->localProfilingWidget->IsActive()) {
     state_machine_.setInitialState(&state_local_);
   } else if (ui_->stadiaWidget->IsActive()) {
     state_machine_.setInitialState(&state_stadia_);


### PR DESCRIPTION
This makes the "local profiling" visible on default. Some symbol loading functionality changes depending on whether the profiling target is local or remote (mainly around downloading symbols). To keep that, the method IsLocalTarget is introduced.