### PR TITLE
Fix bug in PropertyConfigWidget::SetValue

### DIFF
--- a/src/ConfigWidgets/PropertyConfigWidget.cpp
+++ b/src/ConfigWidgets/PropertyConfigWidget.cpp
@@ -82,7 +82,9 @@ void PropertyConfigWidget::AddWidgetForProperty(FloatProperty* property) {
         emit AnyRegisteredPropertyChangedValue();
       });
 
-  property->setter_ = [slider](int value) { slider->setValue(value); };
+  property->setter_ = [slider, to_slider_value](float value) {
+    slider->setValue(to_slider_value(value));
+  };
 
   auto* reset_button = new QPushButton(QIcon::fromTheme("edit-undo"), QString{}, this);
   layout_->addWidget(reset_button, row, 3, Qt::AlignRight);


### PR DESCRIPTION
The setter for floats was not taking the scaling into account. That's fixed in this PR.

It also makes the test case less trivial so that it would have caught such a problem and hopefully will in the future.