### PR TITLE
Add TimeGraphLayoutWidget

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(
           orbittreeview.h
           opengldetect.h
           resource.h
+          TimeGraphLayoutWidget.h
           TrackConfigurationWidget.h
           TrackTypeItemModel.h)
 
@@ -66,6 +67,7 @@ target_sources(
           orbittablemodel.cpp
           orbittreeview.cpp
           opengldetect.cpp
+          TimeGraphLayoutWidget.cpp
           TrackConfigurationWidget.cpp
           TrackConfigurationWidget.ui
           TrackTypeItemModel.cpp
@@ -113,6 +115,7 @@ target_sources(OrbitQtTests
                 CallTreeViewItemModelTest.cpp
                 HistogramWidgetTest.cpp
                 MultipleOfValidatorTest.cpp
+                TimeGraphLayoutWidgetTest.cpp
                 TrackTypeItemModelTest.cpp)
 
 target_include_directories(OrbitQtTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -104,6 +104,10 @@ set_target_properties(OrbitQt PROPERTIES AUTOUIC ON)
 set_target_properties(OrbitQt PROPERTIES AUTORCC ON)
 iwyu_add_dependency(OrbitQt)
 
+if(WIN32)
+  target_compile_features(OrbitQt PUBLIC cxx_std_20)
+endif()
+
 add_executable(OrbitQtTests)
 
 target_sources(OrbitQtTests

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TimeGraphLayoutWidget.h"
+
+#include "OrbitBase/ThreadConstants.h"
+
+namespace orbit_qt {
+
+TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
+    : orbit_config_widgets::PropertyConfigWidget(parent) {
+  AddWidgetForProperty(&text_box_height_);
+  AddWidgetForProperty(&core_height_);
+  AddWidgetForProperty(&thread_state_track_height_);
+  AddWidgetForProperty(&event_track_height_);
+  AddWidgetForProperty(&all_threads_event_track_scale_);
+  AddWidgetForProperty(&variable_track_height_);
+  AddWidgetForProperty(&track_content_bottom_margin_);
+  AddWidgetForProperty(&track_content_top_margin_);
+  AddWidgetForProperty(&track_label_offset_x_);
+  AddWidgetForProperty(&slider_width_);
+  AddWidgetForProperty(&min_slider_length_);
+  AddWidgetForProperty(&time_bar_height_);
+  AddWidgetForProperty(&track_tab_width_);
+  AddWidgetForProperty(&track_tab_height_);
+  AddWidgetForProperty(&track_tab_offset_);
+  AddWidgetForProperty(&track_indent_offset_);
+  AddWidgetForProperty(&collapse_button_offset_);
+  AddWidgetForProperty(&collapse_button_size_);
+  AddWidgetForProperty(&collapse_button_decrease_per_indentation_);
+  AddWidgetForProperty(&rounding_radius_);
+  AddWidgetForProperty(&rounding_num_sides_);
+  AddWidgetForProperty(&text_offset_);
+  AddWidgetForProperty(&right_margin_);
+  AddWidgetForProperty(&min_button_size_);
+  AddWidgetForProperty(&button_width_);
+  AddWidgetForProperty(&button_height_);
+  AddWidgetForProperty(&thread_dependency_arrow_head_width_);
+  AddWidgetForProperty(&thread_dependency_arrow_head_height_);
+  AddWidgetForProperty(&thread_dependency_arrow_body_width_);
+  AddWidgetForProperty(&scale_);
+}
+
+float TimeGraphLayoutWidget::GetCollapseButtonSize(int indentation_level) const {
+  float button_size_without_scaling =
+      collapse_button_size_.value() -
+      collapse_button_decrease_per_indentation_.value() * static_cast<float>(indentation_level);
+
+  // We want the button to scale slower than other elements, so we use sqrt() function.
+  return button_size_without_scaling * std::sqrt(scale_.value());
+}
+
+float TimeGraphLayoutWidget::GetEventTrackHeightFromTid(uint32_t tid) const {
+  float height = event_track_height_.value() * scale_.value();
+  if (tid == orbit_base::kAllProcessThreadsTid) {
+    height *= all_threads_event_track_scale_.value();
+  }
+  return height;
+}
+
+float TimeGraphLayoutWidget::GetSliderResizeMargin() const {
+  // The resize part of the slider is 1/3 of the min length.
+  constexpr float kRatioMinSliderLengthResizePart = 3.f;
+  return GetMinSliderLength() / kRatioMinSliderLengthResizePart;
+}
+
+void TimeGraphLayoutWidget::SetScale(float value) { scale_.SetValue(value); }
+}  // namespace orbit_qt

--- a/src/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/TimeGraphLayoutWidget.h
@@ -1,0 +1,297 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TIME_GRAPH_LAYOUT_WIDGET_H_
+#define TIME_GRAPH_LAYOUT_WIDGET_H_
+
+#include <QWidget>
+#include <cmath>
+#include <string_view>
+
+#include "ConfigWidgets/PropertyConfigWidget.h"
+#include "TimeGraphLayout.h"
+
+namespace orbit_qt {
+
+class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
+                              public TimeGraphLayout {
+  Q_OBJECT
+ public:
+  explicit TimeGraphLayoutWidget(QWidget* parent = nullptr);
+
+  [[nodiscard]] float GetTextBoxHeight() const override {
+    return text_box_height_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetTextCoresHeight() const override {
+    return core_height_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetThreadStateTrackHeight() const override {
+    return thread_state_track_height_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetEventTrackHeightFromTid(uint32_t tid) const override;
+  [[nodiscard]] float GetVariableTrackHeight() const override {
+    return variable_track_height_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetTrackContentBottomMargin() const override {
+    return track_content_bottom_margin_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetTrackContentTopMargin() const override {
+    return track_content_top_margin_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetTrackLabelOffsetX() const override {
+    return track_label_offset_x_.value();
+  }
+  [[nodiscard]] float GetSliderWidth() const override {
+    return slider_width_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetMinSliderLength() const override {
+    return min_slider_length_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetSliderResizeMargin() const override;
+  [[nodiscard]] float GetTimeBarHeight() const override {
+    return time_bar_height_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetTrackTabWidth() const override { return track_tab_width_.value(); }
+  [[nodiscard]] float GetTrackTabHeight() const override {
+    return track_tab_height_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetTrackTabOffset() const override { return track_tab_offset_.value(); }
+  [[nodiscard]] float GetTrackIndentOffset() const override { return track_indent_offset_.value(); }
+  [[nodiscard]] float GetCollapseButtonSize(int indentation_level) const override;
+  [[nodiscard]] float GetCollapseButtonOffset() const override {
+    return collapse_button_offset_.value();
+  }
+  [[nodiscard]] float GetRoundingRadius() const override {
+    return rounding_radius_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetRoundingNumSides() const override { return rounding_num_sides_.value(); }
+  [[nodiscard]] float GetTextOffset() const override {
+    return text_offset_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetRightMargin() const override {
+    return right_margin_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetMinButtonSize() const override { return min_button_size_.value(); }
+  [[nodiscard]] float GetButtonWidth() const override {
+    return button_width_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetButtonHeight() const override {
+    return button_height_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetSpaceBetweenTracks() const override {
+    return space_between_tracks_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetSpaceBetweenTracksAndTimeline() const override {
+    return space_between_tracks_and_timeline_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetSpaceBetweenCores() const override {
+    return space_between_cores_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetSpaceBetweenGpuDepths() const override {
+    return space_between_gpu_depths_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetSpaceBetweenThreadPanes() const override {
+    return space_between_thread_panes_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetSpaceBetweenSubtracks() const override {
+    return space_between_subtracks_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetGenericFixedSpacerWidth() const override {
+    return generic_fixed_spacer_width_.value();
+  }
+  [[nodiscard]] float GetThreadDependencyArrowHeadWidth() const override {
+    return thread_dependency_arrow_head_width_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetThreadDependencyArrowHeadHeight() const override {
+    return thread_dependency_arrow_head_height_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetThreadDependencyArrowBodyWidth() const override {
+    return thread_dependency_arrow_body_width_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetScale() const override { return scale_.value(); }
+  void SetScale(float value) override;
+  [[nodiscard]] bool GetDrawTrackBackground() const override {
+    return draw_track_background_.value();
+  }
+  [[nodiscard]] uint32_t GetFontSize() const override {
+    return std::lround(static_cast<float>(font_size_.value()) * scale_.value());
+  }
+
+  [[nodiscard]] int GetMaxLayoutingLoops() const override { return max_layouting_loops_.value(); }
+
+ private:
+  FloatProperty text_box_height_{{
+      .initial_value = 20.f,
+      .label = "Text Box Height:",
+  }};
+
+  FloatProperty core_height_{{
+      .initial_value = 10.f,
+      .label = "Core Height:",
+  }};
+
+  FloatProperty thread_state_track_height_{{
+      .initial_value = 6.f,
+      .label = "Thread State Track Height:",
+  }};
+
+  FloatProperty event_track_height_{{
+      .initial_value = 10.f,
+      .label = "Event Track Height:",
+  }};
+  FloatProperty all_threads_event_track_scale_{
+      {.initial_value = 2.f, .max = 10.f, .label = "All Threads Event Track Scale:"}};
+  FloatProperty variable_track_height_{{
+      .initial_value = 20.f,
+      .label = "Variable Track Height:",
+  }};
+  FloatProperty track_content_bottom_margin_{{
+      .initial_value = 5.f,
+      .label = "Track Content Bottom Margin:",
+  }};
+  FloatProperty track_content_top_margin_{{
+      .initial_value = 5.f,
+      .label = "Track Content Top Margin:",
+  }};
+  FloatProperty space_between_cores_{{
+      .initial_value = 2.f,
+      .label = "Space between Cores:",
+  }};
+  FloatProperty space_between_gpu_depths_{{
+      .initial_value = 2.f,
+      .label = "Space between GPU depths:",
+  }};
+  FloatProperty space_between_tracks_{{
+      .initial_value = 10.f,
+      .label = "Space between Tracks:",
+  }};
+  FloatProperty space_between_tracks_and_timeline_{{
+      .initial_value = 10.f,
+      .label = "Space between Tracks and Timeline:",
+  }};
+  FloatProperty space_between_thread_panes_{{
+      .initial_value = 5.f,
+      .label = "Space between Thread Panes:",
+  }};
+  FloatProperty space_between_subtracks_{{
+      .initial_value = 0.f,
+      .label = "Space between Subtracks:",
+  }};
+  FloatProperty track_label_offset_x_{{
+      .initial_value = 30.f,
+      .label = "Track Label x-offset:",
+  }};
+  FloatProperty slider_width_{{
+      .initial_value = 15.f,
+      .label = "Slider Width:",
+  }};
+  FloatProperty min_slider_length_{{
+      .initial_value = 20.f,
+      .label = "Minimum Slider Length:",
+  }};
+  FloatProperty track_tab_width_{{
+      .initial_value = 350.f,
+      .min = 0.f,
+      .max = 1000.f,
+      .label = "Track Tab Width:",
+  }};
+  FloatProperty track_tab_height_{{
+      .initial_value = 25.f,
+      .label = "Track Tab Height:",
+  }};
+  FloatProperty track_tab_offset_{{
+      .initial_value = 0.f,
+      .label = "Track Tab Offset:",
+  }};
+  FloatProperty track_indent_offset_{{
+      .initial_value = 5.f,
+      .label = "Track Indent Offset:",
+  }};
+  FloatProperty collapse_button_offset_{{
+      .initial_value = 15.f,
+      .label = "Collapse Button Offset:",
+  }};
+  FloatProperty collapse_button_size_{{
+      .initial_value = 10.f,
+      .label = "Collapse Button Size:",
+  }};
+  FloatProperty collapse_button_decrease_per_indentation_{{
+      .initial_value = 2.f,
+      .label = "Collapse Button decrease per indentation:",
+  }};
+  FloatProperty rounding_radius_{{
+      .initial_value = 8.f,
+      .label = "Rounding Radius:",
+  }};
+  FloatProperty rounding_num_sides_{{.initial_value = 16, .label = "Rounding Num Sides:"}};
+  FloatProperty text_offset_{{
+      .initial_value = 5.f,
+      .label = "Text Offset:",
+  }};
+  FloatProperty right_margin_{{
+      .initial_value = 10.f,
+      .label = "Right Margin:",
+  }};
+  FloatProperty min_button_size_{{
+      .initial_value = 5.f,
+      .label = "Min Button Size:",
+  }};
+
+  constexpr static float kMinButtonSize = 5.f;
+  constexpr static float kMaxButtonSize = 50.f;
+  FloatProperty button_width_{{
+      .initial_value = 15.f,
+      .min = kMinButtonSize,
+      .max = kMaxButtonSize,
+      .label = "Button Width:",
+  }};
+  FloatProperty button_height_{{
+      .initial_value = 15.f,
+      .min = kMinButtonSize,
+      .max = kMaxButtonSize,
+      .label = "Button Height:",
+  }};
+
+  FloatProperty toolbar_icon_height_{{
+      .initial_value = 24.f,
+      .label = "Toolbar Icon Height:",
+  }};
+  FloatProperty generic_fixed_spacer_width_{{
+      .initial_value = 10.f,
+      .label = "Generic fixed Spacer width:",
+  }};
+
+  constexpr static float kMinScale = .1f;
+  constexpr static float kMaxScale = 3.f;
+  FloatProperty scale_{
+      {.initial_value = 1.f, .min = kMinScale, .max = kMaxScale, .label = "Scale:"}};
+
+  FloatProperty time_bar_height_{{
+      .initial_value = 30.f,
+      .label = "Time Bar Height:",
+  }};
+  IntProperty font_size_{{
+      .initial_value = 14,
+      .label = "Font Size:",
+  }};
+  IntProperty thread_dependency_arrow_head_width_{{
+      .initial_value = 16,
+      .label = "Thread Dependency Arrow Head Width:",
+  }};
+  IntProperty thread_dependency_arrow_head_height_{{
+      .initial_value = 15,
+      .label = "Thread Dependency Arrow Head Height:",
+  }};
+  IntProperty thread_dependency_arrow_body_width_{{
+      .initial_value = 4,
+      .label = "Thread Dependency Arrow Head Width:",
+  }};
+  BoolProperty draw_track_background_{{.initial_value = true, .label = "Draw Track Background"}};
+  IntProperty max_layouting_loops_{
+      {.initial_value = 10, .min = 1, .max = 100, .label = "Max layouting loops:"}};
+};
+
+}  // namespace orbit_qt
+
+#endif  // TIME_GRAPH_LAYOUT_WIDGET_H_

--- a/src/OrbitQt/TimeGraphLayoutWidgetTest.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidgetTest.cpp
@@ -6,6 +6,7 @@
 
 #include <QApplication>
 
+#include "OrbitBase/ThreadConstants.h"
 #include "TimeGraphLayoutWidget.h"
 
 TEST(TimeGraphLayoutWidgetTest, SetScale) {
@@ -15,9 +16,19 @@ TEST(TimeGraphLayoutWidgetTest, SetScale) {
 
   const float previous_text_box_height = widget.GetTextBoxHeight();
 
+  constexpr uint32_t kRandomThreadId = 1;
+  const float previous_thread_track_height = widget.GetEventTrackHeightFromTid(kRandomThreadId);
+  const float previous_all_threads_track_height =
+      widget.GetEventTrackHeightFromTid(orbit_base::kAllProcessThreadsTid);
+
   // If the scaling doubles the text box height should double too.
-  widget.SetScale(2.0f * widget.GetScale());
-  EXPECT_FLOAT_EQ(2.0f * previous_text_box_height, widget.GetTextBoxHeight());
+  constexpr float kScaleFactor = 2.0f;
+  widget.SetScale(kScaleFactor * widget.GetScale());
+  EXPECT_FLOAT_EQ(kScaleFactor * previous_text_box_height, widget.GetTextBoxHeight());
+  EXPECT_FLOAT_EQ(kScaleFactor * previous_thread_track_height,
+                  widget.GetEventTrackHeightFromTid(kRandomThreadId));
+  EXPECT_FLOAT_EQ(kScaleFactor * previous_all_threads_track_height,
+                  widget.GetEventTrackHeightFromTid(orbit_base::kAllProcessThreadsTid));
 }
 
 // Start the test binary with `--gtest_filter=TimeGraphLayoutWidgetTest.DISABLED_Demo

--- a/src/OrbitQt/TimeGraphLayoutWidgetTest.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidgetTest.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+
+#include "TimeGraphLayoutWidget.h"
+
+TEST(TimeGraphLayoutWidgetTest, SetScale) {
+  orbit_qt::TimeGraphLayoutWidget widget{};
+  // There is not a lot of logic in the TimeGraphLayoutWidget, but we can at least test the SetScale
+  // function.
+
+  const float previous_text_box_height = widget.GetTextBoxHeight();
+
+  // If the scaling doubles the text box height should double too.
+  widget.SetScale(2.0f * widget.GetScale());
+  EXPECT_FLOAT_EQ(2.0f * previous_text_box_height, widget.GetTextBoxHeight());
+}
+
+// Start the test binary with `--gtest_filter=TimeGraphLayoutWidgetTest.DISABLED_Demo
+// --gtest_also_run_disabled_tests` to run this demo.
+TEST(TimeGraphLayoutWidgetTest, DISABLED_Demo) {
+  orbit_qt::TimeGraphLayoutWidget widget{};
+  widget.show();
+  QApplication::exec();
+  SUCCEED();
+}


### PR DESCRIPTION
This Qt widget will replace the ImGuiTimeGraphLayout. It allows to
change all the layout values using simple controls like sliders and
checkboxes. It implements exactly the same functionality as the ImGui
version.

This is how it looks (be aware that it's not in the Orbit color scheme):
http://screenshot/9CVLqdkRpkpNvS5
