### PR TITLE
Allow manual nightly releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ name: release
 on:
   schedule:
   - cron: '0 6 * * 4'
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
For now, no options can be provided.
In the future, we can consider adding a tag/version manually.