### PR TITLE
Add CaptureWindowDebugInterface

### DIFF
--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -14,6 +14,7 @@
 #include "Batcher.h"
 #include "CaptureClient/AppInterface.h"
 #include "CaptureStats.h"
+#include "CaptureWindowDebugInterface.h"
 #include "GlCanvas.h"
 #include "PickingManager.h"
 #include "SimpleTimings.h"
@@ -23,7 +24,7 @@
 
 class OrbitApp;
 
-class CaptureWindow : public GlCanvas {
+class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterface {
  public:
   explicit CaptureWindow(OrbitApp* app,
                          orbit_capture_client::CaptureControlInterface* capture_control);
@@ -57,6 +58,10 @@ class CaptureWindow : public GlCanvas {
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_.get(); }
   void CreateTimeGraph(orbit_client_data::CaptureData* capture_data);
   void ClearTimeGraph() { time_graph_.reset(nullptr); }
+
+  [[nodiscard]] std::string GetCaptureInfo() const override;
+  [[nodiscard]] std::string GetPerformanceInfo() const override;
+  [[nodiscard]] std::string GetSelectionSummary() const override;
 
  protected:
   void Draw(QPainter* painter) override;

--- a/src/OrbitGl/CaptureWindowDebugInterface.h
+++ b/src/OrbitGl/CaptureWindowDebugInterface.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_CAPTURE_WINDOW_DEBUG_INTERACE_H_
+#define ORBIT_GL_CAPTURE_WINDOW_DEBUG_INTERACE_H_
+
+#include <string>
+
+namespace orbit_gl {
+// Exposes some debug information from a CaptureWindow. All pieces are targeting developers of
+// Orbit and are not meant for the user of the tool.
+class CaptureWindowDebugInterface {
+ public:
+  [[nodiscard]] virtual std::string GetCaptureInfo() const = 0;
+  [[nodiscard]] virtual std::string GetPerformanceInfo() const = 0;
+  [[nodiscard]] virtual std::string GetSelectionSummary() const = 0;
+
+  virtual ~CaptureWindowDebugInterface() = default;
+};
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_CAPTURE_WINDOW_DEBUG_INTERFACE_H_


### PR DESCRIPTION
This is adding the CaptureWindowDebugInterface and implementing it for CaptureWindow.

There are 3 getter in the interface that return various pieces of information about the state of the capture window.
It is meant for developing purposes only and is going to replace the `RenderImGuiDebugUI` method in CaptureWindow which is compiling the same pieces of information. The logic is basically a copy of what currently is in `RenderImGuiDebugUI`.