### PR TITLE
Filter tags for version string generation

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -39,7 +39,7 @@ function(DoGenerateVersionFile OUTPUT_FILE INPUT_FILE GIT_COMMIT_STATE_FILE
          COMMIT_HASH)
   file(WRITE "${GIT_COMMIT_STATE_FILE}" "${COMMIT_HASH}")
   execute_process(
-    COMMAND "${GIT_COMMAND}" "describe" "--always"
+    COMMAND "${GIT_COMMAND}" "describe" "--always" "--match" "1.*"
     WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
     OUTPUT_VARIABLE VERSION_STRING
     OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class OrbitConan(ConanFile):
     def _version(self):
         if not self.version:
             buf = StringIO()
-            self.run("git describe --always --dirty", output=buf)
+            self.run("git describe --always --dirty  --match 1.*", output=buf)
             self.version = buf.getvalue().strip()
             if self.version[0] == 'v':
                 self.version = self.version[1:]


### PR DESCRIPTION
Now that our nightly release job adds tags for the releases starting with "nightly",
our version computation can not simply find the latest tag, but needs to find the
latest "1.*" tag.

Test: OrbitVersionTest