### PR TITLE
Statically check for Orbit's major version being always one

### DIFF
--- a/src/OrbitVersion/OrbitVersion.cpp.in
+++ b/src/OrbitVersion/OrbitVersion.cpp.in
@@ -16,6 +16,7 @@
 #define OrbitCommitHashStr "@COMMIT_HASH@"
 #define OrbitMajorVersion @MAJOR_VERSION@
 #define OrbitMinorVersion @MINOR_VERSION@
+static_assert(OrbitMajorVersion == 1);
 
 namespace orbit_version {
 

--- a/src/OrbitVersion/OrbitVersionTest.cpp
+++ b/src/OrbitVersion/OrbitVersionTest.cpp
@@ -38,6 +38,4 @@ TEST(OrbitVersion, Compare) {
   EXPECT_FALSE((Version{1, 2} >= Version{2, 1}));
 }
 
-TEST(OrbitVersion, MajorVersionIsAlwaysOne) { EXPECT_EQ(GetVersion().major_version, 1); }
-
 }  // namespace orbit_version


### PR DESCRIPTION
Previously, we checked in a unit test that Orbit's major version is always one, which also checks that the version generation works correctly.

However, if there are issues (e.g. with git not being available), we find them way later than needed. A static check lets us fail early.

Test: Compile