### PR TITLE
Add git as Debian build dependency

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -77,7 +77,7 @@ function(DoGenerateVersionFile OUTPUT_FILE INPUT_FILE GIT_COMMIT_STATE_FILE
 endfunction()
 
 if(IN_VERSION_CHECK)
-  find_program(GIT_COMMAND git)
+  find_program(GIT_COMMAND git REQUIRED)
 
   execute_process(
     COMMAND "${GIT_COMMAND}" "show" "-s" "--format=%H"

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,8 @@ Build-Depends: cmake,
   qtbase5-dev,
   libgtest-dev,
   libgmock-dev,
-  libprotobuf-dev
+  libprotobuf-dev,
+  git
 Standards-Version: 4.5.1
 Homepage: <https://github.com/google/orbit>
 Rules-Requires-Root: no


### PR DESCRIPTION
Our version string generation (which happens at compile time) relies on git. So we need git as debian build time dependency.

Test: "glinux-build ."