### PR TITLE
Make TimeGraphLayout a parameter to TimeGraph

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -80,8 +80,11 @@ class AccessibleCaptureWindow : public AccessibleWidgetBridge {
 using orbit_client_protos::TimerInfo;
 
 CaptureWindow::CaptureWindow(
-    OrbitApp* app, orbit_capture_client::CaptureControlInterface* capture_control_interface)
-    : app_{app}, capture_client_app_{capture_control_interface} {
+    OrbitApp* app, orbit_capture_client::CaptureControlInterface* capture_control_interface,
+    TimeGraphLayout* time_graph_layout)
+    : app_{app},
+      capture_client_app_{capture_control_interface},
+      time_graph_layout_{time_graph_layout} {
   draw_help_ = true;
 
   scoped_frame_times_[kTimingDraw] = std::make_unique<orbit_gl::SimpleTimings>(30);
@@ -570,8 +573,8 @@ void CaptureWindow::set_draw_help(bool draw_help) {
 }
 
 void CaptureWindow::CreateTimeGraph(CaptureData* capture_data) {
-  time_graph_ =
-      std::make_unique<TimeGraph>(this, app_, &viewport_, capture_data, &GetPickingManager());
+  time_graph_ = std::make_unique<TimeGraph>(this, app_, &viewport_, capture_data,
+                                            &GetPickingManager(), time_graph_layout_);
 }
 
 Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {
@@ -597,18 +600,6 @@ void CaptureWindow::RequestUpdatePrimitives() {
 }
 
 void CaptureWindow::RenderImGuiDebugUI() {
-  if (ImGui::CollapsingHeader("Layout Properties")) {
-    if (time_graph_ != nullptr && time_graph_->GetImGuiLayout().DrawProperties()) {
-      RequestUpdatePrimitives();
-    }
-
-    static bool draw_text_outline = false;
-    if (ImGui::Checkbox("Draw Text Outline", &draw_text_outline)) {
-      TextRenderer::SetDrawOutline(draw_text_outline);
-      RequestUpdatePrimitives();
-    }
-  }
-
   if (ImGui::CollapsingHeader("Capture Info")) {
     IMGUI_VAR_TO_TEXT(viewport_.GetScreenWidth());
     IMGUI_VAR_TO_TEXT(viewport_.GetScreenHeight());

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -27,7 +27,8 @@ class OrbitApp;
 class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterface {
  public:
   explicit CaptureWindow(OrbitApp* app,
-                         orbit_capture_client::CaptureControlInterface* capture_control);
+                         orbit_capture_client::CaptureControlInterface* capture_control,
+                         TimeGraphLayout* time_graph_layout);
 
   void PreRender() override;
 
@@ -105,6 +106,9 @@ class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterf
   CaptureStats selection_stats_;
 
   absl::btree_map<std::string, std::unique_ptr<orbit_gl::SimpleTimings>> scoped_frame_times_;
+
+ private:
+  TimeGraphLayout* time_graph_layout_ = nullptr;
 };
 
 #endif  // ORBIT_GL_CAPTURE_WINDOW_H_

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -35,7 +35,8 @@ constexpr double kTimeEpsilonUs = 0.0000001;
 
 class NavigationTestCaptureWindow : public testing::Test {
  public:
-  explicit NavigationTestCaptureWindow() : capture_window_{nullptr, &capture_client_app_fake_} {
+  explicit NavigationTestCaptureWindow()
+      : capture_window_{nullptr, &capture_client_app_fake_, &time_graph_layout_} {
     capture_window_.Resize(kViewportWidth, kViewportHeight);
 
     capture_data_ = TrackTestData::GenerateTestCaptureData();

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -15,6 +15,7 @@
 #include "IntrospectionWindow.h"
 #include "OrbitAccessibility/AccessibleWidgetBridge.h"
 #include "OrbitBase/Logging.h"
+#include "TimeGraphLayout.h"
 
 // TODO(b/227341686) z-values should not be of `float` type. E.g. make them `uint`.
 // Tracks: 0.0 - 0.1
@@ -88,17 +89,18 @@ GlCanvas::~GlCanvas() {
   }
 }
 
-std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, OrbitApp* app) {
+std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, OrbitApp* app,
+                                           TimeGraphLayout* time_graph_layout) {
   switch (canvas_type) {
     case CanvasType::kCaptureWindow: {
-      auto main_capture_window =
-          std::make_unique<CaptureWindow>(app, /* capture_control_interface = */ app);
+      auto main_capture_window = std::make_unique<CaptureWindow>(
+          app, /* capture_control_interface = */ app, time_graph_layout);
       app->SetCaptureWindow(main_capture_window.get());
       return main_capture_window;
     }
     case CanvasType::kIntrospectionWindow: {
-      auto introspection_window =
-          std::make_unique<IntrospectionWindow>(app, /* capture_control_interface = */ app);
+      auto introspection_window = std::make_unique<IntrospectionWindow>(
+          app, /* capture_control_interface = */ app, time_graph_layout);
       app->SetIntrospectionWindow(introspection_window.get());
       return introspection_window;
     }

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -22,6 +22,7 @@
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
 #include "QtTextRenderer.h"
+#include "TimeGraphLayout.h"
 #include "Timer.h"
 #include "Viewport.h"
 
@@ -33,7 +34,8 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   virtual ~GlCanvas();
 
   enum class CanvasType { kCaptureWindow, kIntrospectionWindow, kDebug };
-  static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, OrbitApp* app);
+  static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, OrbitApp* app,
+                                          TimeGraphLayout* time_graph_layout);
 
   void Resize(int width, int height);
   void Render(QPainter* painter, int width, int height);

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -10,6 +10,7 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "ImGuiOrbit.h"
 #include "OrbitBase/Logging.h"
+#include "TimeGraphLayout.h"
 
 using orbit_client_data::CaptureData;
 using orbit_grpc_protos::CaptureStarted;
@@ -206,8 +207,9 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
 }  // namespace
 
 IntrospectionWindow::IntrospectionWindow(
-    OrbitApp* app, orbit_capture_client::CaptureControlInterface* capture_control)
-    : CaptureWindow(app, capture_control),
+    OrbitApp* app, orbit_capture_client::CaptureControlInterface* capture_control,
+    TimeGraphLayout* time_graph_layout)
+    : CaptureWindow(app, capture_control, time_graph_layout),
       capture_listener_{std::make_unique<IntrospectionCaptureListener>(this)},
       api_event_processor_{capture_listener_.get()} {
   // Create CaptureData.

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -14,13 +14,15 @@
 #include "CaptureWindow.h"
 #include "ClientData/CaptureData.h"
 #include "Introspection/Introspection.h"
+#include "TimeGraphLayout.h"
 
 class OrbitApp;
 
 class IntrospectionWindow : public CaptureWindow {
  public:
   explicit IntrospectionWindow(OrbitApp* app,
-                               orbit_capture_client::CaptureControlInterface* capture_control);
+                               orbit_capture_client::CaptureControlInterface* capture_control,
+                               TimeGraphLayout* time_graph_layout);
   ~IntrospectionWindow() override;
   void ToggleRecording() override;
   void RenderImGuiDebugUI() override;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -24,6 +24,7 @@
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
 #include "QtTextRenderer.h"
+#include "TimeGraphLayout.h"
 #include "TimelineInfoInterface.h"
 #include "TimelineUi.h"
 #include "TrackContainer.h"
@@ -37,7 +38,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
  public:
   explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
                      orbit_gl::Viewport* viewport, orbit_client_data::CaptureData* capture_data,
-                     PickingManager* picking_manager);
+                     PickingManager* picking_manager, TimeGraphLayout* time_graph_layout);
 
   [[nodiscard]] float GetHeight() const override;
 
@@ -126,8 +127,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] orbit_gl::TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
   [[nodiscard]] orbit_gl::Batcher& GetBatcher() { return batcher_; }
 
-  [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
-  [[nodiscard]] orbit_gl::ImGuiTimeGraphLayout& GetImGuiLayout() { return layout_; }
+  [[nodiscard]] const TimeGraphLayout& GetLayout() const { return *layout_; }
 
   [[nodiscard]] static Color GetColor(uint32_t id) {
     constexpr unsigned char kAlpha = 255;
@@ -211,7 +211,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   uint64_t capture_min_timestamp_ = std::numeric_limits<uint64_t>::max();
   uint64_t capture_max_timestamp_ = 0;
 
-  orbit_gl::ImGuiTimeGraphLayout layout_;
+  TimeGraphLayout* layout_ = nullptr;
 
   orbit_gl::OpenGlBatcher batcher_;
   orbit_gl::PrimitiveAssembler primitive_assembler_;

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "CaptureViewElementTester.h"
+#include "StaticTimeGraphLayout.h"
 #include "TimeGraph.h"
 #include "TrackTestData.h"
 #include "Viewport.h"
@@ -17,7 +18,7 @@ class UnitTestTimeGraph : public testing::Test {
     capture_data_ = TrackTestData::GenerateTestCaptureData();
     viewport_ = std::make_unique<Viewport>(100, 200);
     time_graph_ = std::make_unique<TimeGraph>(nullptr, nullptr, viewport_.get(),
-                                              capture_data_.get(), nullptr);
+                                              capture_data_.get(), nullptr, &time_graph_layout_);
     time_graph_->ZoomAll();
   }
 
@@ -70,6 +71,7 @@ class UnitTestTimeGraph : public testing::Test {
 
  private:
   CaptureViewElementTester tester_;
+  StaticTimeGraphLayout time_graph_layout_;
   std::unique_ptr<TimeGraph> time_graph_;
   std::unique_ptr<Viewport> viewport_;
   std::unique_ptr<orbit_client_data::CaptureData> capture_data_;

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -60,8 +60,8 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
 }
 
 void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window,
-                               OrbitApp* app) {
-  gl_canvas_ = GlCanvas::Create(canvas_type, app);
+                               OrbitApp* app, TimeGraphLayout* time_graph_layout) {
+  gl_canvas_ = GlCanvas::Create(canvas_type, app, time_graph_layout);
 
   if (main_window) {
     main_window->RegisterGlWidget(this);

--- a/src/OrbitQt/orbitglwidget.h
+++ b/src/OrbitQt/orbitglwidget.h
@@ -8,6 +8,8 @@
 #include <glad/glad.h>
 #include <stdint.h>
 
+#include "TimeGraphLayout.h"
+
 // Disable "qopenglfunctions.h is not compatible with GLEW, GLEW defines will be undefined" warning
 // to reduce spam in compilation output. This is a known quirk that doesn't cause any ill effect.
 #ifdef __clang__
@@ -52,7 +54,8 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
 
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
-  void Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window, OrbitApp* app);
+  void Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window, OrbitApp* app,
+                  TimeGraphLayout* time_graph_layout);
   void Deinitialize(OrbitMainWindow* main_window);
   void initializeGL() override;
   void resizeGL(int w, int h) override;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -363,14 +363,15 @@ void OrbitMainWindow::SetupMainWindow() {
       [this](const std::string& extension) { return this->OnGetSaveFileName(extension); });
   app_->SetClipboardCallback([this](const std::string& text) { this->OnSetClipboard(text); });
 
-  ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, this, app_.get());
+  ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, this, app_.get(),
+                                  &capture_window_time_graph_layout_);
 
   app_->SetTimerSelectedCallback([this](const orbit_client_protos::TimerInfo* timer_info) {
     OnTimerSelectionChanged(timer_info);
   });
 
   if (absl::GetFlag(FLAGS_devmode)) {
-    ui->debugOpenGLWidget->Initialize(GlCanvas::CanvasType::kDebug, this, app_.get());
+    ui->debugOpenGLWidget->Initialize(GlCanvas::CanvasType::kDebug, this, app_.get(), nullptr);
     app_->SetDebugCanvas(ui->debugOpenGLWidget->GetCanvas());
   } else {
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->debugTab));
@@ -1379,7 +1380,8 @@ void OrbitMainWindow::on_actionIntrospection_triggered() {
   if (introspection_widget_ == nullptr) {
     introspection_widget_ = std::make_unique<OrbitGLWidget>();
     introspection_widget_->setWindowFlags(Qt::WindowStaysOnTopHint);
-    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, app_.get());
+    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, app_.get(),
+                                      &introspection_window_time_graph_layout_);
     introspection_widget_->installEventFilter(this);
   }
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -47,6 +47,7 @@
 #include "OrbitBase/MainThreadExecutor.h"
 #include "SessionSetup/TargetConfiguration.h"
 #include "SessionSetup/TargetLabel.h"
+#include "StaticTimeGraphLayout.h"
 #include "orbitglwidget.h"
 
 namespace Ui {
@@ -293,6 +294,11 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   // to a file, it is not connected and this bool is false. This is also false when the connection
   // broke.
   bool is_connected_ = false;
+
+  // TODO(beckerhe): These are just temporary and will be removed once the new TimeGraphLayoutWidget
+  // is integrated.
+  orbit_gl::StaticTimeGraphLayout capture_window_time_graph_layout_;
+  orbit_gl::StaticTimeGraphLayout introspection_window_time_graph_layout_;
 };
 
 #endif  // ORBIT_QT_ORBIT_MAIN_WINDOW_H_


### PR DESCRIPTION
The ImGuiTimeGraphLayout used to live in TimeGraph (as a value). This change makes the TimeGraphLayout a non-owning dependency of TimeGraph - passed in as a constructor argument and hence following dependency injection.

Eventually we want a Qt widget (child element of OrbitMainWindow) provide an implementation of TimeGraphLayout, so we need to pass down the dependency up the hierarchy - meaning:

1. TimeGraph gets the layout from CaptureWindow
2. CaptureWindow gets the layout from its factory function GlCanvas::Create
3. GlCanvas::Create gets the layout from OrbitGLWIdget::Initialize
4. OrbitGLWidget::Initialize is called from OrbitMainWindow, so all is good.

Temporarily OrbitMainWindow passes in instances of the StaticTimeGraphLayout.