### PR TITLE
Somes fixes for the Windows build

### DIFF
--- a/src/ClientFlags/CMakeLists.txt
+++ b/src/ClientFlags/CMakeLists.txt
@@ -12,6 +12,4 @@ target_sources(ClientFlags PUBLIC include/ClientFlags/ClientFlags.h)
 target_include_directories(ClientFlags PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_compile_options(ClientFlags PRIVATE ${STRICT_COMPILE_FLAGS})
-target_compile_features(ClientFlags PUBLIC cxx_std_17)
 target_link_libraries(ClientFlags PUBLIC absl::flags)

--- a/src/ConfigWidgets/CMakeLists.txt
+++ b/src/ConfigWidgets/CMakeLists.txt
@@ -51,6 +51,13 @@ target_link_libraries(ConfigWidgetsTests PRIVATE ConfigWidgets
                                                  TestUtils
                                                  GTest::QtGuiMain)
 
+if(WIN32)
+  # This is needed for the designated initializers. We don't enable this
+  # in general to not break the build for old GCC and clang compilers for
+  # no reason.
+  target_compile_features(ConfigWidgetsTests PUBLIC cxx_std_20)
+endif()
+
 if (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen")
   register_test(ConfigWidgetsTests PROPERTIES DISABLED TRUE)
 endif()

--- a/src/OrbitBase/Logging.cpp
+++ b/src/OrbitBase/Logging.cpp
@@ -23,6 +23,8 @@
 #ifdef _WIN32
 #include <Windows.h>
 
+#include "OrbitBase/StringConversion.h"
+
 // Windows does not have TEMP_FAILURE_RETRY, shortcut to expression
 #define TEMP_FAILURE_RETRY(expression) (expression)
 #endif

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -10,6 +10,7 @@
 #include "OrbitBase/GetProcAddress.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/StringConversion.h"
+#include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/ThreadUtils.h"
 
 namespace orbit_base {

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -23,6 +23,7 @@
 
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/StringConversion.h"
 
 ABSL_FLAG(std::string, log_dir, "", "Set directory for the log.");
 

--- a/src/WindowsTracing/CMakeLists.txt
+++ b/src/WindowsTracing/CMakeLists.txt
@@ -11,8 +11,6 @@ add_library(WindowsTracing STATIC)
 target_compile_definitions(WindowsTracing PUBLIC WIN32_LEAN_AND_MEAN)
 target_compile_definitions(WindowsTracing PUBLIC INITGUID)
 
-target_compile_features(WindowsTracing PUBLIC cxx_std_17)
-
 target_include_directories(WindowsTracing PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/WindowsTracing/ContextSwitchManager.cpp
+++ b/src/WindowsTracing/ContextSwitchManager.cpp
@@ -5,6 +5,7 @@
 #include "ContextSwitchManager.h"
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/ThreadUtils.h"
 
 namespace orbit_windows_tracing {

--- a/src/WindowsTracing/ContextSwitchManagerTest.cpp
+++ b/src/WindowsTracing/ContextSwitchManagerTest.cpp
@@ -7,6 +7,7 @@
 
 #include "ContextSwitchManager.h"
 #include "GrpcProtos/capture.pb.h"
+#include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/ThreadUtils.h"
 
 using ::testing::SaveArg;

--- a/src/WindowsUtils/CMakeLists.txt
+++ b/src/WindowsUtils/CMakeLists.txt
@@ -11,8 +11,6 @@ add_library(WindowsUtils STATIC)
 target_compile_definitions(WindowsUtils PUBLIC WIN32_LEAN_AND_MEAN)
 target_compile_definitions(WindowsUtils PUBLIC INITGUID)
 
-target_compile_features(WindowsUtils PUBLIC cxx_std_17)
-
 target_include_directories(WindowsUtils PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/WindowsUtils/ReadProcessMemoryTest.cpp
+++ b/src/WindowsUtils/ReadProcessMemoryTest.cpp
@@ -5,6 +5,7 @@
 #include <absl/base/casts.h>
 #include <gtest/gtest.h>
 
+#include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "WindowsUtils/ReadProcessMemory.h"
 


### PR DESCRIPTION
This is adding some missing includes and marks the ConfigWidgetsTests target requiring C++20 (due to designated initializers).

Note that this not fully fixes the Windows build because users still need to provide a build of LLVM since we still can't use a llvm-core Conan package from ConanCenter (yet).