### PR TITLE
Make PageFaultsInfo a struct rather than a Timer

### DIFF
--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -35,6 +35,7 @@ class MyCaptureListener : public CaptureListener {
   void OnTimer(const TimerInfo& /*timer_info*/) override {}
   void OnCgroupAndProcessMemoryInfo(const orbit_client_data::CgroupAndProcessMemoryInfo&
                                     /*cgroup_and_process_memory_info*/) override {}
+  void OnPageFaultsInfo(const orbit_client_data::PageFaultsInfo& /*page_faults_info*/) override {}
   void OnKeyAndString(uint64_t /*key*/, std::string /*str*/) override {}
   void OnUniqueCallstack(uint64_t /*callstack_id*/, CallstackInfo /*callstack*/) override {}
   void OnCallstackEvent(CallstackEvent /*callstack_event*/) override {}

--- a/src/CaptureClient/MockCaptureListener.h
+++ b/src/CaptureClient/MockCaptureListener.h
@@ -21,6 +21,7 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnTimer, (const orbit_client_protos::TimerInfo&), (override));
   MOCK_METHOD(void, OnCgroupAndProcessMemoryInfo,
               (const orbit_client_data::CgroupAndProcessMemoryInfo&), (override));
+  MOCK_METHOD(void, OnPageFaultsInfo, (const orbit_client_data::PageFaultsInfo&), (override));
   MOCK_METHOD(void, OnKeyAndString, (uint64_t, std::string), (override));
   MOCK_METHOD(void, OnUniqueCallstack, (uint64_t, orbit_client_data::CallstackInfo), (override));
   MOCK_METHOD(void, OnCallstackEvent, (orbit_client_data::CallstackEvent), (override));

--- a/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
@@ -42,16 +42,6 @@ class CaptureEventProcessor {
     kCachedKb = 4,
     kEnd = 5
   };
-  enum class PageFaultsEncodingIndex {
-    kSystemPageFaults = 0,
-    kSystemMajorPageFaults = 1,
-    kCGroupNameHash = 2,
-    kCGroupPageFaults = 3,
-    kCGroupMajorPageFaults = 4,
-    kProcessMinorPageFaults = 5,
-    kProcessMajorPageFaults = 6,
-    kEnd = 7
-  };
 };
 
 }  // namespace orbit_capture_client

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -15,6 +15,7 @@
 #include "ClientData/CallstackInfo.h"
 #include "ClientData/CgroupAndProcessMemoryInfo.h"
 #include "ClientData/LinuxAddressInfo.h"
+#include "ClientData/PageFaultsInfo.h"
 #include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientData/TracepointEventInfo.h"
 #include "ClientData/TracepointInfo.h"
@@ -46,6 +47,7 @@ class CaptureListener {
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
   virtual void OnCgroupAndProcessMemoryInfo(
       const orbit_client_data::CgroupAndProcessMemoryInfo& cgroup_and_process_memory_info) = 0;
+  virtual void OnPageFaultsInfo(const orbit_client_data::PageFaultsInfo& page_faults_info) = 0;
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;
   virtual void OnUniqueCallstack(uint64_t callstack_id,
                                  orbit_client_data::CallstackInfo callstack) = 0;

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(ClientData PUBLIC
         include/ClientData/ModuleAndFunctionLookup.h
         include/ClientData/ModuleData.h
         include/ClientData/ModuleManager.h
+        include/ClientData/PageFaultsInfo.h
         include/ClientData/PostProcessedSamplingData.h
         include/ClientData/ProcessData.h
         include/ClientData/ScopeId.h

--- a/src/ClientData/TimerTrackDataIdManager.cpp
+++ b/src/ClientData/TimerTrackDataIdManager.cpp
@@ -32,7 +32,6 @@ uint32_t TimerTrackDataIdManager::GenerateTrackIdFromTimerInfo(const TimerInfo& 
     case TimerInfo::kApiScopeAsync:
       return GenerateAsyncTrackId(timer_info.api_scope_name());
     case TimerInfo::kSystemMemoryUsage:
-    case TimerInfo::kPageFaults:
     case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MIN_SENTINEL_DO_NOT_USE_:
     case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MAX_SENTINEL_DO_NOT_USE_:
       ORBIT_UNREACHABLE();

--- a/src/ClientData/include/ClientData/CgroupAndProcessMemoryInfo.h
+++ b/src/ClientData/include/ClientData/CgroupAndProcessMemoryInfo.h
@@ -8,6 +8,8 @@
 #include <cstdint>
 #include <optional>
 
+#include "GrpcProtos/Constants.h"
+
 namespace orbit_client_data {
 
 struct CgroupAndProcessMemoryInfo {
@@ -19,9 +21,10 @@ struct CgroupAndProcessMemoryInfo {
   int64_t process_rss_anon_kb;
 
   [[nodiscard]] bool HasMissingInfo() const {
-    constexpr int64_t kMissingInfo = -1;
-    return cgroup_limit_bytes == kMissingInfo || cgroup_rss_bytes == kMissingInfo ||
-           cgroup_mapped_file_bytes == kMissingInfo || process_rss_anon_kb == kMissingInfo;
+    return cgroup_limit_bytes == orbit_grpc_protos::kMissingInfo ||
+           cgroup_rss_bytes == orbit_grpc_protos::kMissingInfo ||
+           cgroup_mapped_file_bytes == orbit_grpc_protos::kMissingInfo ||
+           process_rss_anon_kb == orbit_grpc_protos::kMissingInfo;
   }
 };
 

--- a/src/ClientData/include/ClientData/PageFaultsInfo.h
+++ b/src/ClientData/include/ClientData/PageFaultsInfo.h
@@ -1,10 +1,13 @@
 // Copyright (c) 2022 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 #ifndef CLIENT_DATA_PAGE_FAULTS_INFO_H_
 #define CLIENT_DATA_PAGE_FAULTS_INFO_H_
 
 #include <cstdint>
+
+#include "GrpcProtos/Constants.h"
 
 namespace orbit_client_data {
 
@@ -19,18 +22,18 @@ struct PageFaultsInfo {
   int64_t process_major_page_faults;
 
   [[nodiscard]] bool HasMajorPageFaultsInfo() const {
-    return system_major_page_faults != kMissingInfo && cgroup_major_page_faults != kMissingInfo &&
-           process_major_page_faults != kMissingInfo;
+    return system_major_page_faults != orbit_grpc_protos::kMissingInfo &&
+           cgroup_major_page_faults != orbit_grpc_protos::kMissingInfo &&
+           process_major_page_faults != orbit_grpc_protos::kMissingInfo;
   }
 
   [[nodiscard]] bool HasMinorPageFaultsInfo() const {
-    return system_page_faults != kMissingInfo && system_major_page_faults != kMissingInfo &&
-           cgroup_page_faults != kMissingInfo && cgroup_major_page_faults != kMissingInfo &&
-           process_minor_page_faults != kMissingInfo;
+    return system_page_faults != orbit_grpc_protos::kMissingInfo &&
+           system_major_page_faults != orbit_grpc_protos::kMissingInfo &&
+           cgroup_page_faults != orbit_grpc_protos::kMissingInfo &&
+           cgroup_major_page_faults != orbit_grpc_protos::kMissingInfo &&
+           process_minor_page_faults != orbit_grpc_protos::kMissingInfo;
   }
-
- private:
-  static constexpr int64_t kMissingInfo = -1;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/PageFaultsInfo.h
+++ b/src/ClientData/include/ClientData/PageFaultsInfo.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef CLIENT_DATA_PAGE_FAULTS_INFO_H_
+#define CLIENT_DATA_PAGE_FAULTS_INFO_H_
+
+#include <cstdint>
+
+namespace orbit_client_data {
+
+struct PageFaultsInfo {
+  uint64_t timestamp_ns;
+  int64_t system_page_faults;
+  int64_t system_major_page_faults;
+  uint64_t cgroup_name_hash;
+  int64_t cgroup_page_faults;
+  int64_t cgroup_major_page_faults;
+  int64_t process_minor_page_faults;
+  int64_t process_major_page_faults;
+
+  [[nodiscard]] bool HasMajorPageFaultsInfo() const {
+    return system_major_page_faults != kMissingInfo && cgroup_major_page_faults != kMissingInfo &&
+           process_major_page_faults != kMissingInfo;
+  }
+
+  [[nodiscard]] bool HasMinorPageFaultsInfo() const {
+    return system_page_faults != kMissingInfo && system_major_page_faults != kMissingInfo &&
+           cgroup_page_faults != kMissingInfo && cgroup_major_page_faults != kMissingInfo &&
+           process_minor_page_faults != kMissingInfo;
+  }
+
+ private:
+  static constexpr int64_t kMissingInfo = -1;
+};
+
+}  // namespace orbit_client_data
+
+#endif  // CLIENT_DATA_PAGE_FAULTS_INFO_H_

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -15,7 +15,7 @@ message TimerInfo {
   uint32 depth = 5;
 
   enum Type {
-    reserved 2, 9;
+    reserved 2, 9, 10;
     kNone = 0;
     kCoreActivity = 1;
     kGpuActivity = 3;
@@ -24,7 +24,6 @@ message TimerInfo {
     kGpuDebugMarker = 6;
     kApiEvent = 7;
     kSystemMemoryUsage = 8;
-    kPageFaults = 10;
     kApiScope = 11;
     kApiScopeAsync = 12;
   }

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -94,6 +94,8 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
   // The following events are ignored, as we only load D, MS and sampling data.
   void OnCgroupAndProcessMemoryInfo(const orbit_client_data::CgroupAndProcessMemoryInfo&
                                     /*cgroup_and_process_memory_info*/) override {}
+  void OnPageFaultsInfo(const orbit_client_data::PageFaultsInfo&
+                        /*page_faults_info*/) override {}
   void OnKeyAndString(uint64_t /*key*/, std::string /*str*/) override {}
   void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo /*thread_state_slice*/) override {
   }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -477,6 +477,10 @@ void OrbitApp::OnCgroupAndProcessMemoryInfo(
   GetMutableTimeGraph()->ProcessCgroupAndProcessMemoryInfo(cgroup_and_process_memory_info);
 }
 
+void OrbitApp::OnPageFaultsInfo(const orbit_client_data::PageFaultsInfo& page_faults_info) {
+  GetMutableTimeGraph()->ProcessPageFaultsInfo(page_faults_info);
+}
+
 void OrbitApp::OnApiStringEvent(const orbit_client_data::ApiStringEvent& api_string_event) {
   GetMutableTimeGraph()->ProcessApiStringEvent(api_string_event);
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -154,6 +154,7 @@ class OrbitApp final : public DataViewFactory,
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnCgroupAndProcessMemoryInfo(
       const orbit_client_data::CgroupAndProcessMemoryInfo& cgroup_and_process_memory_info) override;
+  void OnPageFaultsInfo(const orbit_client_data::PageFaultsInfo& page_faults_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
 
   void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) override;

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -117,6 +117,10 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
         cgroup_and_process_memory_info);
   }
 
+  void OnPageFaultsInfo(const orbit_client_data::PageFaultsInfo& page_faults_info) override {
+    introspection_window_->GetTimeGraph()->ProcessPageFaultsInfo(page_faults_info);
+  }
+
   void OnApiStringEvent(const orbit_client_data::ApiStringEvent& api_string_event) override {
     introspection_window_->GetTimeGraph()->ProcessApiStringEvent(api_string_event);
   }

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -5,7 +5,7 @@
 #ifndef ORBIT_GL_PAGE_FAULTS_TRACK_H_
 #define ORBIT_GL_PAGE_FAULTS_TRACK_H_
 
-#include "ClientProtos/capture_data.pb.h"
+#include "ClientData/PageFaultsInfo.h"
 #include "MajorPageFaultsTrack.h"
 #include "MinorPageFaultsTrack.h"
 #include "Track.h"
@@ -37,7 +37,7 @@ class PageFaultsTrack : public Track {
   [[nodiscard]] bool IsCollapsible() const override { return true; }
   [[nodiscard]] std::vector<CaptureViewElement*> GetAllChildren() const override;
 
-  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+  void OnPageFaultsInfo(const orbit_client_data::PageFaultsInfo& page_faults_info);
 
   void AddValuesAndUpdateAnnotationsForMajorPageFaultsSubtrack(
       uint64_t timestamp_ns, const std::array<double, kBasicPageFaultsTrackDimension>& values) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -313,10 +313,6 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info) {
       ProcessSystemMemoryTrackingTimer(timer_info);
       break;
     }
-    case TimerInfo::kPageFaults: {
-      ProcessPageFaultsTrackingTimer(timer_info);
-      break;
-    }
     case TimerInfo::kNone: {
       // TODO (http://b/198135618): Create tracks only before drawing.
       track_manager->GetOrCreateThreadTrack(timer_info.thread_id());
@@ -379,10 +375,9 @@ void TimeGraph::ProcessCgroupAndProcessMemoryInfo(
   track->OnCgroupAndProcessMemoryInfo(cgroup_and_process_memory_info);
 }
 
-void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
-  uint64_t cgroup_name_hash = timer_info.registers(
-      static_cast<size_t>(CaptureEventProcessor::PageFaultsEncodingIndex::kCGroupNameHash));
-  std::string cgroup_name = app_->GetStringManager()->Get(cgroup_name_hash).value_or("");
+void TimeGraph::ProcessPageFaultsInfo(const orbit_client_data::PageFaultsInfo& page_faults_info) {
+  std::string cgroup_name =
+      app_->GetStringManager()->Get(page_faults_info.cgroup_name_hash).value_or("");
   if (cgroup_name.empty()) return;
 
   PageFaultsTrack* track = GetTrackManager()->GetPageFaultsTrack();
@@ -391,7 +386,7 @@ void TimeGraph::ProcessPageFaultsTrackingTimer(const TimerInfo& timer_info) {
     track = GetTrackManager()->CreateAndGetPageFaultsTrack(cgroup_name, memory_sampling_period_ms);
   }
   ORBIT_CHECK(track != nullptr);
-  track->OnTimer(timer_info);
+  track->OnPageFaultsInfo(page_faults_info);
 }
 
 orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -15,6 +15,7 @@
 #include "ClientData/ApiTrackValue.h"
 #include "ClientData/CaptureData.h"
 #include "ClientData/CgroupAndProcessMemoryInfo.h"
+#include "ClientData/PageFaultsInfo.h"
 #include "ClientData/ScopeId.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "CoreMath.h"
@@ -50,6 +51,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessCgroupAndProcessMemoryInfo(
       const orbit_client_data::CgroupAndProcessMemoryInfo& cgroup_and_process_memory_info);
+  void ProcessPageFaultsInfo(const orbit_client_data::PageFaultsInfo& page_faults_info);
   void ProcessApiStringEvent(const orbit_client_data::ApiStringEvent& string_event);
   void ProcessApiTrackValueEvent(const orbit_client_data::ApiTrackValue& track_event);
 
@@ -174,7 +176,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   CreateAccessibleInterface() override;
   void ProcessAsyncTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessSystemMemoryTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
-  void ProcessPageFaultsTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
 
   std::shared_ptr<orbit_gl::GlSlider> horizontal_slider_;
   std::shared_ptr<orbit_gl::GlSlider> vertical_slider_;

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -426,8 +426,6 @@ Track* TrackManager::GetOrCreateTrackFromTimerInfo(const TimerInfo& timer_info) 
       return GetOrCreateAsyncTrack(timer_info.api_scope_name());
     case TimerInfo::kSystemMemoryUsage:
       return GetSystemMemoryTrack();
-    case TimerInfo::kPageFaults:
-      return GetPageFaultsTrack();
     case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MIN_SENTINEL_DO_NOT_USE_:
     case orbit_client_protos::TimerInfo_Type_TimerInfo_Type_INT_MAX_SENTINEL_DO_NOT_USE_:
       ORBIT_UNREACHABLE();


### PR DESCRIPTION
This follows #4417 for the page fault info.

Test: Take a capture with page fault info.
Bug: http://b/192335025