### PR TITLE
Fix capture window flickering when loading a new font

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -535,6 +535,7 @@ void CaptureWindow::RenderAllLayers(QPainter* painter) {
 
     // The painter is in "native painting mode" all the time and we merely leave it for rendering
     // the text here. Compare GlCanvas::Render - that's where we enter native painting.
+    CleanupGlState();
     painter->endNativePainting();
 
     if (picking_mode_ == PickingMode::kNone) {
@@ -543,6 +544,7 @@ void CaptureWindow::RenderAllLayers(QPainter* painter) {
     }
 
     painter->beginNativePainting();
+    PrepareGlState();
   }
 }
 

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -237,6 +237,8 @@ void GlCanvas::PrepareGlState() {
   picking_mode_ != PickingMode::kNone ? glDisable(GL_BLEND) : glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glUseProgram(0);
 }
 
 void GlCanvas::CleanupGlState() { glPopAttrib(); }
@@ -256,9 +258,6 @@ void GlCanvas::Render(QPainter* painter, int width, int height) {
   PrepareGlViewport();
 
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-  glBindTexture(GL_TEXTURE_2D, 0);
-  glUseProgram(0);
 
   // Clear text renderer
   text_renderer_.Init();


### PR DESCRIPTION
In this PR we are fixing the flickering that appeared when QT-TextRenderer was introduced and that was noticeable at the beginning of a session.

After an investigation, turned to be that the cause was that when QT loaded a new font, it messes the openGL state and nothing else was being drawn in that frame.

So, in this PR:
 - We are calling CleanupGlState() & PrepareGlState() in between QT-TextRendering and native GL-ShadeRendering (for each layer).
 - Including these lines in PrepareGlState():
    - glBindTexture(GL_TEXTURE_2D, 0); -> This line fixed the issue.
    - glUseProgram(0); They were called before at the beginning anyways, but not in between QT and native GL rendering and they should be part of PrepareGLState().

Screenshot of the flickering: http://screenshot/7StjuKsDojuyS7j. Nothing after kZValueTrackText was rendered in native GL.

Test: Loaded a capture, everything works. Take a capture, no flickering either.