### PR TITLE
Modify text for connecting to OrbitService

### DIFF
--- a/src/SessionSetup/ConnectToLocalWidget.cpp
+++ b/src/SessionSetup/ConnectToLocalWidget.cpp
@@ -62,7 +62,7 @@ ConnectToLocalWidget::ConnectToLocalWidget(QWidget* parent)
       if (local_connection_.GetOrbitServiceInstance() == nullptr) {
         ui_->statusLabel->setText("Waiting for OrbitService");
       } else {
-        ui_->statusLabel->setText("Connecting... to OrbitService");
+        ui_->statusLabel->setText("Connecting to OrbitService ...");
       }
       emit Disconnected();
     }

--- a/src/SessionSetup/ConnectToLocalWidgetTest.cpp
+++ b/src/SessionSetup/ConnectToLocalWidgetTest.cpp
@@ -88,7 +88,7 @@ TEST_F(ConnectToLocalWidgetTest, OrbitServiceStartedSuccessfullyThenStopped) {
   EXPECT_TRUE(lambda_called);
 
   QTest::qWait(kWaitTime);
-  EXPECT_EQ(status_label_->text(), "Connecting... to OrbitService");
+  EXPECT_EQ(status_label_->text(), "Connecting to OrbitService ...");
 }
 
 TEST_F(ConnectToLocalWidgetTest, OrbitServiceStartError) {


### PR DESCRIPTION
It used to be "Connecting ... to OrbitService" and now it is "Connecting to OrbitService ...".

Screenshot: http://screenshot/7gKFkHZsZTYUw3u