### PR TITLE
Fix GraphTrack arrow boxes being too height

### DIFF
--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -164,7 +164,6 @@ void GraphTrack<Dimension>::DrawMouseLabel(PrimitiveAssembler& primitive_assembl
   const float kTextRightMargin = kTextLeftMargin;
   const float kTextTopMargin = layout_->GetTextOffset();
   const float kTextBottomMargin = kTextTopMargin;
-  const float kSpaceBetweenLines = layout_->GetTextOffset();
   const Color kBlack(0, 0, 0, 255);
   const Color kTransparentWhite(255, 255, 255, 180);
 
@@ -182,8 +181,7 @@ void GraphTrack<Dimension>::DrawMouseLabel(PrimitiveAssembler& primitive_assembl
   for (const std::string& line : lines) {
     text_width = std::max(text_width, text_renderer.GetStringWidth(line.c_str(), font_size));
   }
-  float single_line_height = text_renderer.GetStringHeight(text.c_str(), font_size);
-  float text_height = single_line_height * lines.size() + kSpaceBetweenLines * (lines.size() - 1);
+  float text_height = text_renderer.GetStringHeight(text.c_str(), font_size);
   Vec2 text_box_size(text_width, text_height);
 
   float arrow_width = text_box_size[1] / 2.f;


### PR DESCRIPTION
In this PR we are fixing arrow boxes in GraphTrack. After investigating, seems to be that before we were calculating the height of the text manually (because GetStringHeight() didn't count multi-lines).

Since now GetStringHeight() is returning the correct height, the visible height was the square, and then the box was incredible big.

New Screenshot: http://screenshot/4B4n4ZggDKau4Ga