### PR TITLE
Mark destructor virtual in base class

### DIFF
--- a/src/OrbitGl/AccessibleInterfaceProvider.h
+++ b/src/OrbitGl/AccessibleInterfaceProvider.h
@@ -12,7 +12,7 @@ namespace orbit_gl {
 /* Base class to provide accessibility in the capture window. */
 class AccessibleInterfaceProvider {
  public:
-  explicit AccessibleInterfaceProvider() {}
+  virtual ~AccessibleInterfaceProvider() = default;
 
   [[nodiscard]] orbit_accessibility::AccessibleInterface* GetOrCreateAccessibleInterface();
   [[nodiscard]] const orbit_accessibility::AccessibleInterface* GetAccessibleInterface() const {


### PR DESCRIPTION
The constructor definition is not needed since the compiler generates that automatically, but it's vital that this base class has a virtual destructor.