### PR TITLE
Clean up Conan config

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -48,25 +48,29 @@ class OrbitConan(ConanFile):
             del self.options.fPIC
 
     def build_requirements(self):
-        if not self.options.with_system_deps: self.build_requires('protobuf/3.21.4')
-        if not self.options.with_system_deps: self.build_requires('grpc/1.48.0')
-        if not self.options.with_system_deps: self.build_requires('gtest/1.11.0', force_host_context=True)
+        if self.options.with_system_deps: return
+        self.build_requires('protobuf/3.21.4')
+        self.build_requires('grpc/1.48.0')
+        self.build_requires('gtest/1.11.0', force_host_context=True)
 
     def requirements(self):
-        if not self.options.with_system_deps: self.requires("abseil/20220623.0")
-        if not self.options.with_system_deps: self.requires("capstone/4.0.2")
-        if not self.options.with_system_deps: self.requires("grpc/1.48.0")
-        if not self.options.with_system_deps: self.requires("outcome/2.2.3")
+        if self.options.with_system_deps: return
+
+        self.requires("abseil/20220623.0")
+        self.requires("capstone/4.0.2")
+        self.requires("grpc/1.48.0")
+        self.requires("outcome/2.2.3")
         if self.settings.os != "Windows":
-            if not self.options.with_system_deps: self.requires("volk/1.3.224.1")
-            if not self.options.with_system_deps: self.requires("vulkan-headers/1.3.224.1")
-            if not self.options.with_system_deps: self.requires("vulkan-validationlayers/1.3.224.1")
+            self.requires("volk/1.3.224.1")
+            self.requires("vulkan-headers/1.3.224.1")
+            self.requires("vulkan-validationlayers/1.3.224.1")
         self.requires("zlib/1.2.12", override=True)
+        self.requires("openssl/1.1.1s", override=True)
 
         if self.options.with_gui:
-            if not self.options.with_system_deps: self.requires("glad/0.1.34")
-            if not self.options.with_system_deps: self.requires("imgui/1.88")
-            if not self.options.with_system_deps: self.requires("libssh2/1.10.0")
+            self.requires("glad/0.1.34")
+            self.requires("imgui/1.88")
+            self.requires("libssh2/1.10.0")
 
 
     def configure(self):

--- a/third_party/conan/configs/install.ps1
+++ b/third_party/conan/configs/install.ps1
@@ -4,64 +4,6 @@
 
 $conan = Get-Command conan -ErrorAction Stop
 
-function conan_disable_public_remotes() {
-  $remotes = "bintray", "conan-center"
-  foreach ($remote in $remotes) {
-    $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","disable",$remote
-    if ($process.ExitCode -ne 0) { Throw "Error while disabling conan-remote $remote." }
-  }
-}
-
 # Installs conan config (build settings, public remotes, conan profiles, conan options). Have a look in \third_party\conan\configs\windows for more information.
 $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "config","install","$PSScriptRoot\windows"
 if ($process.ExitCode -ne 0) { Throw "Error while installing conan config." }
-
-if (Test-Path Env:ORBIT_OVERRIDE_ARTIFACTORY_URL) {
-  Write-Host "Artifactory override detected. Adjusting remotes..."
-
-  $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","add","-i","0","-f","artifactory",$Env:ORBIT_OVERRIDE_ARTIFACTORY_URL
-  if ($process.ExitCode -ne 0) { Throw "Error while adding conan remote." }
-
-  conan_disable_public_remotes
-} else {
-  try {
-    $response = Invoke-WebRequest -URI http://invalid-hostname.internal/ -ErrorAction Ignore -MaximumRedirection 0 -UseBasicParsing
-    Write-Host "Detected catch-all DNS configuration. Using public remotes for conan."
-    exit
-  } catch {
-    # If we jump into this catch-block, that means there is no catch-all DNS.
-  }
-
-  try {
-    $response = Invoke-WebRequest -URI http://artifactory.internal/ -ErrorAction Ignore -MaximumRedirection 0 -UseBasicParsing
-    Write-Host "CI machine detected. Adjusting remotes..."
-
-    $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","add","-i","0","-f","artifactory","http://artifactory.internal/artifactory/api/conan/conan"
-    if ($process.ExitCode -ne 0) { Throw "Error while adding conan remote." }
-
-    conan_disable_public_remotes
-
-    if (Test-Path -Path "$PSScriptRoot\windows_ci") {
-      Write-Host "Found CI-specific Conan config. Installing that as well..."
-      $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "config", "install", "$PSScriptRoot\windows_ci"
-      if ($process.ExitCode -ne 0) { Throw "Error while installing conan config." }
-    }
-  } catch {
-    try {
-      $response = Invoke-WebRequest -URI http://orbit-artifactory/ -ErrorAction Ignore -MaximumRedirection 0 -UseBasicParsing
-      Write-Host "Internal machine detected. Adjusting remotes..."
-
-      $location = $response.Headers['Location'].Split("/")[2]
-
-      $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","add","-i","0","-f","artifactory","http://$location/artifactory/api/conan/conan"
-      if ($process.ExitCode -ne 0) { Throw "Error while adding conan remote." }
-
-      $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "config","set","proxies.http=`"$location=http://127.0.0.2:999`""
-      if ($process.ExitCode -ne 0) { Throw "Error while adding proxy setting to conan." }
-
-      conan_disable_public_remotes
-    } catch {
-      Write-Host "Using public remotes for conan."
-    }
-  }
-}

--- a/third_party/conan/configs/install.sh
+++ b/third_party/conan/configs/install.sh
@@ -4,15 +4,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-function conan_disable_public_remotes {
-  conan remote disable bintray || return $?
-  conan remote disable conan-center || return $?
-  return 0
-}
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-OPTIONS=$(getopt -o "" -l "force-public-remotes,assume-linux,assume-windows" -- "$@")
+OPTIONS=$(getopt -o "" -l "assume-linux,assume-windows" -- "$@")
 eval set -- "$OPTIONS"
 
 if [ "$(uname -s)" == "Linux" ]; then
@@ -20,11 +14,9 @@ if [ "$(uname -s)" == "Linux" ]; then
 else
   OS="windows"
 fi
-FORCE_PUBLIC_REMOTES=""
 
 while true; do
   case "$1" in
-    --force-public-remotes) FORCE_PUBLIC_REMOTES="yes"; shift;;
     --assume-linux) OS="linux"; shift;;
     --assume-windows) OS="windows"; shift;;
     --) shift; break;;
@@ -34,57 +26,3 @@ done
 # Installs conan config (build settings, public remotes, conan profiles, conan options). Have a look in \third_party\conan\configs\windows for more information.
 conan config install "$DIR/$OS" || exit $?
 
-
-if [ "$FORCE_PUBLIC_REMOTES" == "yes" ]; then
-  if curl -s http://invalid-name.internal/ >/dev/null 2>&1; then
-    echo "Using public remotes for conan."
-  elif curl -s http://artifactory.internal/ >/dev/null 2>&1; then
-    echo "CI machine detected, but forced to use public remotes. Will be using caching proxy of the public remotes though."
-    conan remote add -i 0 -f artifactory "http://artifactory.internal/artifactory/api/conan/conan-public" || exit $?
-    conan_disable_public_remotes || exit $?
-  elif [ -n "$ORBIT_OVERRIDE_ARTIFACTORY_URL" ]; then
-    echo "Artifactory override detected. Adjusting public remote..."
-    conan remote add -i 0 -f artifactory_public "$ORBIT_OVERRIDE_ARTIFACTORY_URL" || exit $?
-    conan remote disable conan-center || exit $?
-  else
-    LOCATION="$(curl -sI http://orbit-artifactory/ 2>/dev/null)"
-
-    if [ $? -eq 0 ]; then
-      echo "Internal machine detected. Adjusting remotes to use internal public mirror..."
-      LOCATION="$(echo "$LOCATION" | grep -e "^Location:" | cut -d ' ' -f 2 | cut -d '/' -f 3)"
-
-      conan remote add -i 0 -f artifactory_public "http://$LOCATION/artifactory/api/conan/conan-public" || exit $?
-      conan config set proxies.http="$LOCATION=http://127.0.0.2:999" || exit $?
-    fi
-  fi
-elif [ -n "$ORBIT_OVERRIDE_ARTIFACTORY_URL" ]; then
-  echo "Artifactory override detected. Adjusting remotes..."
-  conan remote add -i 0 -f artifactory "$ORBIT_OVERRIDE_ARTIFACTORY_URL" || exit $?
-  conan_disable_public_remotes || exit $?
-else
-  if curl -s http://invalid-name.internal/ >/dev/null 2>&1; then
-    echo "Detected catchall-DNS configuration. Using public remotes for conan."
-  elif curl -s http://artifactory.internal/ >/dev/null 2>&1; then
-    echo "CI machine detected. Adjusting remotes..."
-    conan remote add -i 0 -f artifactory "http://artifactory.internal/artifactory/api/conan/conan" || exit $?
-    conan_disable_public_remotes || exit $?
-
-    if [ -d "${DIR}/${OS}_ci" ]; then
-      echo "Found CI-specific Conan config. Installing that as well..."
-      conan config install "${DIR}/${OS}_ci" || exit $?
-    fi
-  else
-    LOCATION="$(curl -sI http://orbit-artifactory/ 2>/dev/null)"
-
-    if [ $? -eq 0 ]; then
-      echo "Internal machine detected. Adjusting remotes..."
-      LOCATION="$(echo "$LOCATION" | grep -e "^Location:" | cut -d ' ' -f 2 | cut -d '/' -f 3)"
-
-      conan remote add -i 0 -f artifactory "http://$LOCATION/artifactory/api/conan/conan" || exit $?
-      conan config set proxies.http="$LOCATION=http://127.0.0.2:999" || exit $?
-      conan_disable_public_remotes || exit $?
-    else
-      echo "Using public remotes for conan."
-    fi
-  fi
-fi

--- a/third_party/conan/configs/linux/remotes.txt
+++ b/third_party/conan/configs/linux/remotes.txt
@@ -1,2 +1,1 @@
-bintray https://orbit.jfrog.io/artifactory/api/conan/orbitdeps True
 conan-center https://center.conan.io True 

--- a/third_party/conan/configs/windows/remotes.txt
+++ b/third_party/conan/configs/windows/remotes.txt
@@ -1,2 +1,1 @@
-bintray https://orbit.jfrog.io/artifactory/api/conan/orbitdeps True
 conan-center https://center.conan.io True 


### PR DESCRIPTION
This removes the custom servers from the Conan since they are not needed anymore. We only rely on public packages.