### PR TITLE
Remove remnants of the GGP build

### DIFF
--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -92,8 +92,6 @@ You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
 # Start build
 if ($args) {
   & "$PSScriptRoot\build.ps1" $args
-} elseif (& $conan.Path remote list | Select-String -NotMatch "Disabled:" | Select-String "artifactory:") {
-  & "$PSScriptRoot\build.ps1" "default_relwithdebinfo" "ggp_relwithdebinfo"
 } else {
   & "$PSScriptRoot\build.ps1"
 }

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -148,12 +148,7 @@ if [[ $DONT_COMPILE != "yes" ]]; then
   if [ -n "$1" ] ; then
     exec $DIR/build.sh "$@"
   else
-    conan remote list | grep -v 'Disabled:' | grep -e '^artifactory:' > /dev/null 2>&1
-    if [ $? -eq 0 ]; then
-      exec $DIR/build.sh default_relwithdebinfo ggp_relwithdebinfo
-    else
-      exec $DIR/build.sh
-    fi
+    exec $DIR/build.sh
   fi
 fi
 


### PR DESCRIPTION
There were some pointers to the no longer existing GGP build in the bootstrap script. Let's remove them.