### PR TITLE
Add DebugTabWidget

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
           CaptureWindowDebugWidget.h
           CustomSignalsTreeView.h
           CutoutWidget.h
+          DebugTabWidget.h
           ElidedLabel.h
           FilterPanelWidget.h
           FilterPanelWidgetAction.h
@@ -48,6 +49,8 @@ target_sources(
           CaptureOptionsDialog.ui
           CaptureWindowDebugWidget.cpp
           CaptureWindowDebugWidget.ui
+          DebugTabWidget.cpp
+          DebugTabWidget.ui
           ElidedLabel.cpp
           FilterPanelWidget.cpp
           FilterPanelWidgetAction.cpp
@@ -121,6 +124,7 @@ target_sources(OrbitQtTests
                 AnnotatingSourceCodeDialogTest.cpp
                 CallTreeViewItemModelTest.cpp
                 CaptureWindowDebugWidgetTest.cpp
+                DebugTabWidgetTest.cpp
                 HistogramWidgetTest.cpp
                 MultipleOfValidatorTest.cpp
                 TimeGraphLayoutWidgetTest.cpp

--- a/src/OrbitQt/DebugTabWidget.cpp
+++ b/src/OrbitQt/DebugTabWidget.cpp
@@ -55,11 +55,11 @@ void DebugTabWidget::ResetIntrospectionWindowDebugInterface() {
   ui_->tabWidget->setTabEnabled(kIntrospectionTabIndex, false);
 }
 
-TimeGraphLayout* DebugTabWidget::GetTimeGraphLayoutForTheCaptureWindow() const {
+TimeGraphLayout* DebugTabWidget::GetCaptureWindowTimeGraphLayout() const {
   return ui_->captureWindowDebugWidget->GetTimeGraphLayout();
 }
 
-TimeGraphLayout* DebugTabWidget::GetTimeGraphLayoutForTheIntrospectionWindow() const {
+TimeGraphLayout* DebugTabWidget::GetIntrospectionWindowTimeGraphLayout() const {
   return ui_->introspectionWindowDebugWidget->GetTimeGraphLayout();
 }
 

--- a/src/OrbitQt/DebugTabWidget.cpp
+++ b/src/OrbitQt/DebugTabWidget.cpp
@@ -20,8 +20,8 @@ constexpr int kIntrospectionTabIndex = 1;
 DebugTabWidget::DebugTabWidget(QWidget* parent)
     : QWidget{parent}, ui_{std::make_unique<Ui::DebugTabWidget>()} {
   ui_->setupUi(this);
-  ui_->tabWidget->setTabEnabled(kCaptureWindowTabIndex, false);
   ui_->tabWidget->setTabEnabled(kIntrospectionTabIndex, false);
+  ui_->tabWidget->setTabEnabled(kCaptureWindowTabIndex, false);
 
   QObject::connect(ui_->captureWindowDebugWidget,
                    &CaptureWindowDebugWidget::AnyLayoutPropertyChanged, this,

--- a/src/OrbitQt/DebugTabWidget.cpp
+++ b/src/OrbitQt/DebugTabWidget.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "DebugTabWidget.h"
+
+#include <QObject>
+#include <QWidget>
+#include <memory>
+
+#include "CaptureWindowDebugWidget.h"
+#include "TimeGraphLayout.h"
+#include "ui_DebugTabWidget.h"
+
+namespace orbit_qt {
+
+constexpr int kCaptureWindowTabIndex = 0;
+constexpr int kIntrospectionTabIndex = 1;
+
+DebugTabWidget::DebugTabWidget(QWidget* parent)
+    : QWidget{parent}, ui_{std::make_unique<Ui::DebugTabWidget>()} {
+  ui_->setupUi(this);
+  ui_->tabWidget->setTabEnabled(kCaptureWindowTabIndex, false);
+  ui_->tabWidget->setTabEnabled(kIntrospectionTabIndex, false);
+
+  QObject::connect(ui_->captureWindowDebugWidget,
+                   &CaptureWindowDebugWidget::AnyLayoutPropertyChanged, this,
+                   [this]() { emit AnyCaptureWindowPropertyChanged(); });
+  QObject::connect(ui_->introspectionWindowDebugWidget,
+                   &CaptureWindowDebugWidget::AnyLayoutPropertyChanged, this,
+                   [this]() { emit AnyIntrospectionWindowPropertyChanged(); });
+}
+
+DebugTabWidget::~DebugTabWidget() = default;
+
+void DebugTabWidget::SetCaptureWindowDebugInterface(
+    const orbit_gl::CaptureWindowDebugInterface* interface) {
+  ui_->captureWindowDebugWidget->SetCaptureWindowDebugInterface(interface);
+  ui_->tabWidget->setTabEnabled(kCaptureWindowTabIndex, interface != nullptr);
+}
+
+void DebugTabWidget::ResetCaptureWindowDebugInterface() {
+  ui_->captureWindowDebugWidget->ResetCaptureWindowDebugInterface();
+  ui_->tabWidget->setTabEnabled(kCaptureWindowTabIndex, false);
+}
+
+void DebugTabWidget::SetIntrospectionWindowDebugInterface(
+    const orbit_gl::CaptureWindowDebugInterface* interface) {
+  ui_->introspectionWindowDebugWidget->SetCaptureWindowDebugInterface(interface);
+  ui_->tabWidget->setTabEnabled(kIntrospectionTabIndex, interface != nullptr);
+}
+
+void DebugTabWidget::ResetIntrospectionWindowDebugInterface() {
+  ui_->introspectionWindowDebugWidget->ResetCaptureWindowDebugInterface();
+  ui_->tabWidget->setTabEnabled(kIntrospectionTabIndex, false);
+}
+
+TimeGraphLayout* DebugTabWidget::GetTimeGraphLayoutForTheCaptureWindow() const {
+  return ui_->captureWindowDebugWidget->GetTimeGraphLayout();
+}
+
+TimeGraphLayout* DebugTabWidget::GetTimeGraphLayoutForTheIntrospectionWindow() const {
+  return ui_->introspectionWindowDebugWidget->GetTimeGraphLayout();
+}
+
+}  // namespace orbit_qt

--- a/src/OrbitQt/DebugTabWidget.h
+++ b/src/OrbitQt/DebugTabWidget.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_DEBUG_TAB_WIDGET_H_
+#define ORBIT_QT_DEBUG_TAB_WIDGET_H_
+
+#include <QWidget>
+#include <memory>
+
+#include "CaptureWindowDebugInterface.h"
+#include "TimeGraphLayout.h"
+
+namespace Ui {
+class DebugTabWidget;
+}
+
+namespace orbit_qt {
+
+// The debug tab widget is the main widget of the debug tab. It itself has 2 nested tabs, one for
+// the capture windows, and one for the introspection window.
+class DebugTabWidget : public QWidget {
+  Q_OBJECT
+
+ public:
+  explicit DebugTabWidget(QWidget* parent = nullptr);
+  ~DebugTabWidget() override;
+
+  [[nodiscard]] TimeGraphLayout* GetTimeGraphLayoutForTheCaptureWindow() const;
+  [[nodiscard]] TimeGraphLayout* GetTimeGraphLayoutForTheIntrospectionWindow() const;
+
+  void SetCaptureWindowDebugInterface(const orbit_gl::CaptureWindowDebugInterface* interface);
+  void ResetCaptureWindowDebugInterface();
+
+  void SetIntrospectionWindowDebugInterface(const orbit_gl::CaptureWindowDebugInterface* interface);
+  void ResetIntrospectionWindowDebugInterface();
+
+ private:
+  std::unique_ptr<Ui::DebugTabWidget> ui_;
+
+ signals:
+  void AnyCaptureWindowPropertyChanged();
+  void AnyIntrospectionWindowPropertyChanged();
+};
+}  // namespace orbit_qt
+
+#endif  // ORBIT_QT_DEBUG_TAB_WIDGET_H_

--- a/src/OrbitQt/DebugTabWidget.h
+++ b/src/OrbitQt/DebugTabWidget.h
@@ -26,8 +26,8 @@ class DebugTabWidget : public QWidget {
   explicit DebugTabWidget(QWidget* parent = nullptr);
   ~DebugTabWidget() override;
 
-  [[nodiscard]] TimeGraphLayout* GetTimeGraphLayoutForTheCaptureWindow() const;
-  [[nodiscard]] TimeGraphLayout* GetTimeGraphLayoutForTheIntrospectionWindow() const;
+  [[nodiscard]] TimeGraphLayout* GetCaptureWindowTimeGraphLayout() const;
+  [[nodiscard]] TimeGraphLayout* GetIntrospectionWindowTimeGraphLayout() const;
 
   void SetCaptureWindowDebugInterface(const orbit_gl::CaptureWindowDebugInterface* interface);
   void ResetCaptureWindowDebugInterface();

--- a/src/OrbitQt/DebugTabWidget.ui
+++ b/src/OrbitQt/DebugTabWidget.ui
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DebugTabWidget</class>
+ <widget class="QWidget" name="DebugTabWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="captureWindowTab">
+      <attribute name="title">
+       <string>Capture Window</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="orbit_qt::CaptureWindowDebugWidget" name="captureWindowDebugWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="introspectionWindowTab">
+      <attribute name="title">
+       <string>Introspection Window</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <widget class="orbit_qt::CaptureWindowDebugWidget" name="introspectionWindowDebugWidget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>orbit_qt::CaptureWindowDebugWidget</class>
+   <extends>QWidget</extends>
+   <header>CaptureWindowDebugWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/OrbitQt/DebugTabWidgetTest.cpp
+++ b/src/OrbitQt/DebugTabWidgetTest.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QSignalSpy>
+#include <QSlider>
+#include <QTabWidget>
+#include <QTest>
+
+#include "CaptureWindowDebugInterface.h"
+#include "CaptureWindowDebugWidget.h"
+#include "DebugTabWidget.h"
+
+namespace {
+class MockCaptureWindowDebugInterface : public orbit_gl::CaptureWindowDebugInterface {
+ public:
+  MOCK_METHOD(std::string, GetCaptureInfo, (), (const, override));
+  MOCK_METHOD(std::string, GetPerformanceInfo, (), (const, override));
+  MOCK_METHOD(std::string, GetSelectionSummary, (), (const, override));
+};
+}  // namespace
+
+TEST(DebugTabWidget, NestedTabsEnabled) {
+  MockCaptureWindowDebugInterface debug_interface{};
+  EXPECT_CALL(debug_interface, GetCaptureInfo())
+      .WillRepeatedly(testing::Return("This is the capture info."));
+  EXPECT_CALL(debug_interface, GetPerformanceInfo())
+      .WillRepeatedly(testing::Return("This is the performance info."));
+  EXPECT_CALL(debug_interface, GetSelectionSummary())
+      .WillRepeatedly(testing::Return("This is the selection summary."));
+
+  orbit_qt::DebugTabWidget widget{};
+
+  const auto* tab_widget = widget.findChild<QTabWidget*>("tabWidget");
+  EXPECT_EQ(tab_widget->count(), 2);
+
+  EXPECT_FALSE(tab_widget->isTabEnabled(0));
+  EXPECT_FALSE(tab_widget->isTabEnabled(1));
+
+  widget.SetCaptureWindowDebugInterface(&debug_interface);
+  EXPECT_TRUE(tab_widget->isTabEnabled(0));
+  EXPECT_FALSE(tab_widget->isTabEnabled(1));
+
+  widget.SetIntrospectionWindowDebugInterface(&debug_interface);
+  EXPECT_TRUE(tab_widget->isTabEnabled(0));
+  EXPECT_TRUE(tab_widget->isTabEnabled(1));
+
+  widget.ResetCaptureWindowDebugInterface();
+  EXPECT_FALSE(tab_widget->isTabEnabled(0));
+  EXPECT_TRUE(tab_widget->isTabEnabled(1));
+
+  widget.ResetIntrospectionWindowDebugInterface();
+  EXPECT_FALSE(tab_widget->isTabEnabled(0));
+  EXPECT_FALSE(tab_widget->isTabEnabled(1));
+}
+
+TEST(DebugTabWidget, GetTimeGraphLayout) {
+  orbit_qt::DebugTabWidget widget{};
+
+  // The widget should offer a time graph layout for the capture window
+  auto* capture_window_time_graph_layout = widget.GetTimeGraphLayoutForTheCaptureWindow();
+  EXPECT_NE(capture_window_time_graph_layout, nullptr);
+
+  // The widget should offer a time graph layout for the introspection window
+  auto* introspection_window_time_graph_layout =
+      widget.GetTimeGraphLayoutForTheIntrospectionWindow();
+  EXPECT_NE(introspection_window_time_graph_layout, nullptr);
+
+  // The debug tab widget has two signals which fire when any of the properties in the two time
+  // graph layouts changes.
+  QSignalSpy capture_window_spy{&widget,
+                                &orbit_qt::DebugTabWidget::AnyCaptureWindowPropertyChanged};
+  QSignalSpy introspection_window_spy{
+      &widget, &orbit_qt::DebugTabWidget::AnyIntrospectionWindowPropertyChanged};
+
+  // To change a property we need to make a change using one of the control sliders.
+  const auto* capture_window_debug_widget =
+      widget.findChild<orbit_qt::CaptureWindowDebugWidget*>("captureWindowDebugWidget");
+  ASSERT_NE(capture_window_debug_widget, nullptr);
+
+  auto* capture_window_text_box_height_slider =
+      capture_window_debug_widget->findChild<QSlider*>("slider_text_box_height_");
+  ASSERT_NE(capture_window_text_box_height_slider, nullptr);
+
+  // We trigger a property change and check whether the correct signal has fired.
+  capture_window_text_box_height_slider->setValue(100.f);
+  EXPECT_EQ(capture_window_spy.size(), 1);
+  EXPECT_EQ(introspection_window_spy.size(), 0);
+  capture_window_spy.clear();
+  introspection_window_spy.clear();
+
+  const auto* introspection_window_debug_widget =
+      widget.findChild<orbit_qt::CaptureWindowDebugWidget*>("introspectionWindowDebugWidget");
+  ASSERT_NE(introspection_window_debug_widget, nullptr);
+
+  auto* introspection_window_text_box_height_slider =
+      introspection_window_debug_widget->findChild<QSlider*>("slider_text_box_height_");
+  ASSERT_NE(introspection_window_text_box_height_slider, nullptr);
+
+  // We trigger another property change and check whether the correct signal has fired.
+  introspection_window_text_box_height_slider->setValue(100.f);
+  EXPECT_EQ(capture_window_spy.size(), 0);
+  EXPECT_EQ(introspection_window_spy.size(), 1);
+}
+
+// Use command line options `--gtest_filter=DebugTabWidget.DISABLED_Demo
+// --gtest_also_run_disabled_tests` to run this demo.
+TEST(DebugTabWidget, DISABLED_Demo) {
+  MockCaptureWindowDebugInterface debug_interface{};
+  EXPECT_CALL(debug_interface, GetCaptureInfo())
+      .WillRepeatedly(testing::Return("This is the capture info."));
+  EXPECT_CALL(debug_interface, GetPerformanceInfo())
+      .WillRepeatedly(testing::Return("This is the performance info."));
+  EXPECT_CALL(debug_interface, GetSelectionSummary())
+      .WillRepeatedly(testing::Return("This is the selection summary."));
+
+  orbit_qt::DebugTabWidget widget{};
+  widget.SetCaptureWindowDebugInterface(&debug_interface);
+  widget.SetIntrospectionWindowDebugInterface(&debug_interface);
+  widget.show();
+
+  QApplication::exec();
+  SUCCEED();
+}

--- a/src/OrbitQt/DebugTabWidgetTest.cpp
+++ b/src/OrbitQt/DebugTabWidgetTest.cpp
@@ -62,13 +62,10 @@ TEST(DebugTabWidget, GetTimeGraphLayout) {
   orbit_qt::DebugTabWidget widget{};
 
   // The widget should offer a time graph layout for the capture window
-  auto* capture_window_time_graph_layout = widget.GetTimeGraphLayoutForTheCaptureWindow();
-  EXPECT_NE(capture_window_time_graph_layout, nullptr);
+  EXPECT_NE(widget.GetCaptureWindowTimeGraphLayout(), nullptr);
 
   // The widget should offer a time graph layout for the introspection window
-  auto* introspection_window_time_graph_layout =
-      widget.GetTimeGraphLayoutForTheIntrospectionWindow();
-  EXPECT_NE(introspection_window_time_graph_layout, nullptr);
+  EXPECT_NE(widget.GetIntrospectionWindowTimeGraphLayout(), nullptr);
 
   // The debug tab widget has two signals which fire when any of the properties in the two time
   // graph layouts changes.


### PR DESCRIPTION
This widget combines two capture window debug widgets in a tab widget (as it was before):
- one for the real capture window
- one for the introspection window

It is a replacement for the ImGui rendered debug canvas that we currently use.

Note that replacing the current debug tab is not part of this commit and will follow in a separate one.