### PR TITLE
Replace DebugTabWidget

### DIFF
--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -294,11 +294,6 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   // to a file, it is not connected and this bool is false. This is also false when the connection
   // broke.
   bool is_connected_ = false;
-
-  // TODO(beckerhe): These are just temporary and will be removed once the new TimeGraphLayoutWidget
-  // is integrated.
-  orbit_gl::StaticTimeGraphLayout capture_window_time_graph_layout_;
-  orbit_gl::StaticTimeGraphLayout introspection_window_time_graph_layout_;
 };
 
 #endif  // ORBIT_QT_ORBIT_MAIN_WINDOW_H_

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -273,7 +273,7 @@ QPushButton:disabled {
           <item row="1" column="0">
            <widget class="OrbitSamplingReport" name="inspectionReport" native="true">
             <property name="visible">
-              <bool>false</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -345,7 +345,7 @@ QPushButton:disabled {
          </attribute>
          <layout class="QGridLayout" name="gridLayout_4">
           <item row="0" column="0">
-           <widget class="OrbitGLWidget" name="debugOpenGLWidget"/>
+           <widget class="orbit_qt::DebugTabWidget" name="debugTabWidget" native="true"/>
           </item>
          </layout>
         </widget>
@@ -749,10 +749,15 @@ It used to also contain captures and presets, but these were moved to the User D
    <header>TrackConfigurationWidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>orbit_qt::DebugTabWidget</class>
+   <extends>QWidget</extends>
+   <header>DebugTabWidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources>
   <include location="../../icons/orbiticons.qrc"/>
-  <include location="../../images/orbitimages.qrc"/>
  </resources>
  <connections/>
  <slots>


### PR DESCRIPTION
This replace the old kDebug GlCanvas by the new Qt-based DebugTabWidget.

This allows to remove ImGui and simplify the code architecture and the build.

This is how it looks like in Orbit: http://screenshot/jqntmJV3eerWaEV