### PR TITLE
Introduce Conan build profiles

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -55,6 +55,14 @@ function conan_create_profile($profile) {
   }
 }
 
+# That's the profile that is used for tools that run on the build machine (Nasm, CMake, Ninja, etc.)
+$build_profile = "default_release"
+if (-not (conan_profile_exists $build_profile)) {
+  Write-Host "Creating conan profile $profile"
+  conan_create_profile $profile
+}
+
+
 $profiles = if ($args.Count) { $args } else { @("default_relwithdebinfo") }
 
 foreach ($profile in $profiles) {
@@ -66,7 +74,7 @@ foreach ($profile in $profiles) {
  
   Write-Host "Building Orbit in build_$profile/ with conan profile $profile"
 
-  & $conan.Path install -if build_$profile\ --build outdated -pr $profile -u "$PSScriptRoot"
+  & $conan.Path install -if build_$profile\ --build outdated -pr:b $build_profile -pr:h $profile -u "$PSScriptRoot"
 
   if ($LastExitCode -ne 0) {
     Throw "Error while running conan install."

--- a/build.sh
+++ b/build.sh
@@ -45,12 +45,15 @@ function conan_profile_exists {
   return $?
 }
 
+# That's the profile that is used for tools that run on the build machine (Nasm, CMake, Ninja, etc.)
+readonly build_profile="default_release"
+conan_profile_exists "${build_profile}" || create_conan_profile "${build_profile}"
 
 for profile in ${profiles[@]}; do
-  if [ "$profile" == "default_release" -o "$profile" == "default_debug" -o "$profile" == "default_relwithdebinfo" ]; then
+  if [[ $profile == default_* ]]; then
     conan_profile_exists "$profile" || create_conan_profile "$profile"
   fi
 
-  conan install -pr $profile -if build_$profile/ --build outdated "$DIR" || exit $?
+  conan install -pr:b "${build_profile}" -pr:h $profile -if build_$profile/ --build outdated "$DIR" || exit $?
   conan build -bf build_$profile/ "$DIR" || exit $?
 done


### PR DESCRIPTION
I wanted to do this for a while, but wasn't able due to bugs in the lockfile implementation. Since we got rid of lockfiles we can enable build profiles.

Build profiles allow to define a separate Conan profile for all build requirements (things that are supposed to run on the build machine like code generators, build systems, etc.).

This has the advantage that Conan maintains two build graphs and packages in those two build graphs don't need to match. (The openssl package that is used by CMake will be indepdendent from the one used by gRPC.)