### PR TITLE
Tidy up OrbitGLWidget

### DIFF
--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// clang-format off
+// This needs to be included first
+#include <glad/glad.h>
+// clang-format on
+
 #include "orbitglwidget.h"
 
 #include <stddef.h>
@@ -11,18 +16,16 @@
 #include <QCharRef>
 #include <QCursor>
 #include <QFlags>
-#include <QImage>
-#include <QImageWriter>
 #include <QMenu>
+#include <QMetaEnum>
 #include <QMouseEvent>
 #include <QOpenGLContext>
-#include <QOpenGLDebugMessage>
 #include <QPainter>
 #include <QRect>
 #include <QSignalMapper>
 #include <QSurfaceFormat>
-#include <QtCore>
 #include <algorithm>
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -39,11 +42,16 @@ OrbitGLWidget::OrbitGLWidget(QWidget* parent) : QOpenGLWidget(parent) {
   ORBIT_LOG("OpenGL version requested: %i.%i", requested_format.majorVersion(),
             requested_format.minorVersion());
   gl_canvas_ = nullptr;
-  debug_logger_ = nullptr;
   setFocusPolicy(Qt::WheelFocus);
   setMouseTracking(true);
   setUpdateBehavior(QOpenGLWidget::PartialUpdate);
   installEventFilter(this);
+
+  QObject::connect(&update_timer_, &QTimer::timeout, &update_timer_, [this]() {
+    ORBIT_CHECK(gl_canvas_ != nullptr);  // This timer is only running when gl_canvas_ exists.
+    if (!gl_canvas_->IsRedrawNeeded()) return;
+    update();
+  });
 }
 
 bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
@@ -59,34 +67,19 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
   return false;
 }
 
-void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window,
-                               OrbitApp* app, TimeGraphLayout* time_graph_layout) {
+void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitApp* app,
+                               TimeGraphLayout* time_graph_layout) {
   gl_canvas_ = GlCanvas::Create(canvas_type, app, time_graph_layout);
-
-  if (main_window) {
-    main_window->RegisterGlWidget(this);
-  }
+  constexpr std::chrono::milliseconds kUpdatePeriod{16};  // ...ms - that's roughly 60 FPS.
+  update_timer_.start(kUpdatePeriod);
 }
 
-void OrbitGLWidget::Deinitialize(OrbitMainWindow* main_window) {
-  if (main_window) {
-    main_window->UnregisterGlWidget(this);
-  }
+void OrbitGLWidget::Deinitialize() {
+  update_timer_.stop();
   gl_canvas_.reset();
 }
 
 void OrbitGLWidget::initializeGL() {
-#if ORBIT_DEBUG_OPEN_GL
-  debug_logger_ = new QOpenGLDebugLogger(this);
-  if (debug_logger_->initialize()) {
-    ORBIT_LOG("GL_DEBUG Debug Logger %s", debug_logger_->metaObject()->className());
-    connect(debug_logger_, SIGNAL(messageLogged(QOpenGLDebugMessage)), this,
-            SLOT(messageLogged(QOpenGLDebugMessage)));
-    debug_logger_->startLogging(QOpenGLDebugLogger::SynchronousLogging);
-  }
-  format().setOption(QSurfaceFormat::DebugContext);
-#endif
-
   initializeOpenGLFunctions();
 
   gladLoadGLLoader([](const char* name) {
@@ -98,95 +91,13 @@ void OrbitGLWidget::initializeGL() {
 }
 
 void OrbitGLWidget::PrintContextInformation() {
-  std::string glType;
-  std::string glVersion;
-  std::string glProfile;
+  std::string_view gl_type = (context()->isOpenGLES()) ? "OpenGL ES" : "OpenGL";
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  std::string_view gl_version = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+  std::string_view gl_profile =
+      QMetaEnum::fromType<QSurfaceFormat::OpenGLContextProfile>().valueToKey(format().profile());
 
-  // Get Version Information
-  glType = (context()->isOpenGLES()) ? "OpenGL ES" : "OpenGL";
-  glVersion = reinterpret_cast<const char*>(glGetString(GL_VERSION));
-
-  // Get Profile Information
-#define CASE(c)           \
-  case QSurfaceFormat::c: \
-    glProfile = #c;       \
-    break
-  switch (format().profile()) {
-    CASE(NoProfile);
-    CASE(CoreProfile);
-    CASE(CompatibilityProfile);
-  }
-#undef CASE
-  ORBIT_LOG(R"(glType="%s", glVersion="%s", glProfile="%s")", glType, glVersion, glProfile);
-}
-
-void OrbitGLWidget::messageLogged(const QOpenGLDebugMessage& msg) {
-  // From: http://www.trentreed.net/topics/cc/
-
-  QString error;
-
-  // Format based on severity
-  switch (msg.severity()) {
-    case QOpenGLDebugMessage::NotificationSeverity:
-      error += "--";
-      break;
-    case QOpenGLDebugMessage::HighSeverity:
-      error += "!!";
-      break;
-    case QOpenGLDebugMessage::MediumSeverity:
-      error += "!~";
-      break;
-    case QOpenGLDebugMessage::LowSeverity:
-      error += "~~";
-      break;
-    default:
-      break;
-  }
-
-  error += " (";
-
-  // Format based on source
-#define CASE(c)                \
-  case QOpenGLDebugMessage::c: \
-    error += #c;               \
-    break
-  switch (msg.source()) {
-    CASE(APISource);
-    CASE(WindowSystemSource);
-    CASE(ShaderCompilerSource);
-    CASE(ThirdPartySource);
-    CASE(ApplicationSource);
-    CASE(OtherSource);
-    CASE(InvalidSource);
-    default:
-      break;
-  }
-#undef CASE
-
-  error += " : ";
-
-  // Format based on type
-#define CASE(c)                \
-  case QOpenGLDebugMessage::c: \
-    error += #c;               \
-    break
-  switch (msg.type()) {
-    CASE(ErrorType);
-    CASE(DeprecatedBehaviorType);
-    CASE(UndefinedBehaviorType);
-    CASE(PortabilityType);
-    CASE(PerformanceType);
-    CASE(OtherType);
-    CASE(MarkerType);
-    CASE(GroupPushType);
-    CASE(GroupPopType);
-    default:
-      break;
-  }
-#undef CASE
-
-  error += ")";
-  ORBIT_LOG("%s\n%s", qPrintable(error), qPrintable(msg.message()));
+  ORBIT_LOG(R"(glType="%s", glVersion="%s", glProfile="%s")", gl_type, gl_version, gl_profile);
 }
 
 void OrbitGLWidget::resizeGL(int w, int h) {
@@ -199,22 +110,11 @@ void OrbitGLWidget::resizeGL(int w, int h) {
 
 void OrbitGLWidget::paintGL() {
   ORBIT_SCOPE_FUNCTION;
-  QPainter painter(this);
 
   if (gl_canvas_) {
+    QPainter painter(this);
     gl_canvas_->Render(&painter, width(), height());
   }
-
-  static volatile bool doScreenShot = false;
-  if (doScreenShot) {
-    TakeScreenShot();
-  }
-}
-
-void OrbitGLWidget::TakeScreenShot() {
-  QImage img = this->grabFramebuffer();
-  QImageWriter writer("screenshot", "jpg");
-  writer.write(img);
 }
 
 void OrbitGLWidget::mousePressEvent(QMouseEvent* event) {
@@ -243,7 +143,7 @@ void OrbitGLWidget::mouseReleaseEvent(QMouseEvent* event) {
 
     if (event->button() == Qt::RightButton) {
       if (gl_canvas_->RightUp()) {
-        showContextMenu();
+        ShowContextMenu();
       }
     }
 
@@ -255,31 +155,33 @@ void OrbitGLWidget::mouseReleaseEvent(QMouseEvent* event) {
   update();
 }
 
-void OrbitGLWidget::showContextMenu() {
+void OrbitGLWidget::ShowContextMenu() {
   std::vector<std::string> menu = gl_canvas_->GetContextMenu();
 
   if (!menu.empty()) {
-    QMenu contextMenu(tr("GlContextMenu"), this);
-    QSignalMapper signalMapper(this);
+    QMenu context_menu(tr("GlContextMenu"), this);
+    QSignalMapper signal_mapper(this);
     std::vector<QAction*> actions;
 
     for (size_t i = 0; i < menu.size(); ++i) {
       actions.push_back(new QAction(QString::fromStdString(menu[i])));
-      connect(actions[i], SIGNAL(triggered()), &signalMapper, SLOT(map()));
-      signalMapper.setMapping(actions[i], i);
-      contextMenu.addAction(actions[i]);
+      QObject::connect(actions[i], &QAction::triggered, &signal_mapper,
+                       qOverload<>(&QSignalMapper::map));
+      signal_mapper.setMapping(actions[i], i);
+      context_menu.addAction(actions[i]);
     }
 
-    connect(&signalMapper, SIGNAL(mapped(int)), this, SLOT(OnMenuClicked(int)));
-    contextMenu.exec(QCursor::pos());
+    QObject::connect(&signal_mapper, &QSignalMapper::mappedInt, this,
+                     &OrbitGLWidget::OnMenuClicked);
+    context_menu.exec(QCursor::pos());
 
     for (QAction* action : actions) delete action;
   }
 }
 
-void OrbitGLWidget::OnMenuClicked(int a_Index) {
+void OrbitGLWidget::OnMenuClicked(int index) {
   const std::vector<std::string>& menu = gl_canvas_->GetContextMenu();
-  gl_canvas_->OnContextMenu(menu[a_Index], a_Index);
+  gl_canvas_->OnContextMenu(menu[index], index);
 }
 
 void OrbitGLWidget::mouseDoubleClickEvent(QMouseEvent* event) {

--- a/src/OrbitQt/orbitglwidget.h
+++ b/src/OrbitQt/orbitglwidget.h
@@ -5,66 +5,39 @@
 #ifndef ORBIT_QT_ORBIT_GL_WIDGET_H_
 #define ORBIT_QT_ORBIT_GL_WIDGET_H_
 
-#include <glad/glad.h>
 #include <stdint.h>
-
-#include "TimeGraphLayout.h"
-
-// Disable "qopenglfunctions.h is not compatible with GLEW, GLEW defines will be undefined" warning
-// to reduce spam in compilation output. This is a known quirk that doesn't cause any ill effect.
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-W#warnings"
-#endif
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcpp"
-#endif
-
-#include <QOpenGLFunctions>
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 #include <QEvent>
 #include <QKeyEvent>
 #include <QMouseEvent>
-#include <QObject>
+#include <QOpenGLFunctions>
 #include <QOpenGLWidget>
-#include <QString>
+#include <QTimer>
 #include <QWheelEvent>
 #include <QWidget>
 #include <memory>
 
+#include "App.h"
 #include "GlCanvas.h"
-
-class OrbitApp;
-class OrbitMainWindow;
-class QOpenGLDebugMessage;
-class QOpenGLDebugLogger;
+#include "TimeGraphLayout.h"
 
 class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
   Q_OBJECT
 
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
-  void Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window, OrbitApp* app,
+  void Initialize(GlCanvas::CanvasType canvas_type, OrbitApp* app,
                   TimeGraphLayout* time_graph_layout);
-  void Deinitialize(OrbitMainWindow* main_window);
+  void Deinitialize();
+  [[nodiscard]] GlCanvas* GetCanvas() { return gl_canvas_.get(); }
+  [[nodiscard]] const GlCanvas* GetCanvas() const { return gl_canvas_.get(); }
+
+ private:
+  void PrintContextInformation();
   void initializeGL() override;
   void resizeGL(int w, int h) override;
   void paintGL() override;
   bool eventFilter(QObject* object, QEvent* event) override;
-  void TakeScreenShot();
-  GlCanvas* GetCanvas() { return gl_canvas_.get(); }
-  void PrintContextInformation();
-
   void mousePressEvent(QMouseEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;
   void mouseDoubleClickEvent(QMouseEvent* event) override;
@@ -75,14 +48,11 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
   void keyReleaseEvent(QKeyEvent* event) override;
   void wheelEvent(QWheelEvent* event) override;
 
- protected slots:
-  void messageLogged(const QOpenGLDebugMessage& msg);
-  void showContextMenu();
-  void OnMenuClicked(int a_Index);
+  void ShowContextMenu();
+  void OnMenuClicked(int index);
 
- private:
   std::unique_ptr<GlCanvas> gl_canvas_;
-  QOpenGLDebugLogger* debug_logger_;
+  QTimer update_timer_;
 };
 
 #endif  // ORBIT_QT_ORBIT_GL_WIDGET_H_

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -364,7 +364,7 @@ void OrbitMainWindow::SetupMainWindow() {
       [this](const std::string& extension) { return this->OnGetSaveFileName(extension); });
   app_->SetClipboardCallback([this](const std::string& text) { this->OnSetClipboard(text); });
 
-  ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, this, app_.get(),
+  ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, app_.get(),
                                   ui->debugTabWidget->GetCaptureWindowTimeGraphLayout());
 
   // TODO(beckerhe): This dynamic cast wrapper is just temporary and will not be needed anymore
@@ -799,7 +799,7 @@ OrbitMainWindow::~OrbitMainWindow() {
   ui->samplingReport->Deinitialize();
   ui->selectionReport->Deinitialize();
 
-  ui->CaptureGLWidget->Deinitialize(this);
+  ui->CaptureGLWidget->Deinitialize();
   ui->PresetsList->Deinitialize();
   ui->FunctionsList->Deinitialize();
   ui->ModulesList->Deinitialize();
@@ -1008,12 +1008,6 @@ void OrbitMainWindow::StartMainTimer() {
 void OrbitMainWindow::OnTimer() {
   ORBIT_SCOPE("OrbitMainWindow::OnTimer");
   app_->MainTick();
-
-  for (OrbitGLWidget* gl_widget : gl_widgets_) {
-    if (gl_widget->GetCanvas() != nullptr && gl_widget->GetCanvas()->IsRedrawNeeded()) {
-      gl_widget->update();
-    }
-  }
 
   if (app_->IsCapturing()) {
     filter_panel_action_->SetTimerLabelText(QString::fromStdString(
@@ -1387,7 +1381,7 @@ void OrbitMainWindow::on_actionIntrospection_triggered() {
   if (introspection_widget_ == nullptr) {
     introspection_widget_ = std::make_unique<OrbitGLWidget>();
     introspection_widget_->setWindowFlags(Qt::WindowStaysOnTopHint);
-    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, app_.get(),
+    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, app_.get(),
                                       ui->debugTabWidget->GetIntrospectionWindowTimeGraphLayout());
     introspection_widget_->installEventFilter(this);
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -66,13 +66,6 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
                            const QStringList& command_line_flags = QStringList());
   ~OrbitMainWindow() override;
 
-  void RegisterGlWidget(OrbitGLWidget* widget) { gl_widgets_.push_back(widget); }
-  void UnregisterGlWidget(OrbitGLWidget* widget) {
-    const auto it = std::find(gl_widgets_.begin(), gl_widgets_.end(), widget);
-    if (it != gl_widgets_.end()) {
-      gl_widgets_.erase(it);
-    }
-  }
   void OnRefreshDataViewPanels(orbit_data_views::DataViewType type);
   void UpdatePanel(orbit_data_views::DataViewType type);
 
@@ -259,7 +252,6 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   Ui::OrbitMainWindow* ui;
   FilterPanelWidgetAction* filter_panel_action_ = nullptr;
   QTimer* main_timer_ = nullptr;
-  std::vector<OrbitGLWidget*> gl_widgets_;
   std::unique_ptr<OrbitGLWidget> introspection_widget_ = nullptr;
   QFrame* hint_frame_ = nullptr;
   orbit_session_setup::TargetLabel* target_label_ = nullptr;


### PR DESCRIPTION
This is doing the following things:

1. Move the rendering timer from OrbitMainWindow into OrbitGlWidget. That means OrbitGLWidgets don't need to be "registered" in OrbitMainWindow anymore, hence more separation, less spaghetti code.
2. Rename functions and variables according to our style guide. (Also some std::string_view introductions)
3. Remove the screenshot function (which is not used anywhere).
4. Remove the OpenGL debug code because a comment indicated that it has been copied from some forum and we might have license problems with it. (It has also been ifdef-ed out for basically forever. Not sure if it even compiles.)
5. Remove forward declarations - they are not needed anymore.
6. Make almost all member functions private. (They were all public before.)