### PR TITLE
Move GlCanvas creation out of OrbitGLWidget and GlCanvas

### DIFF
--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -81,28 +81,6 @@ GlCanvas::GlCanvas()
   ResetHoverTimer();
 }
 
-std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, OrbitApp* app,
-                                           TimeGraphLayout* time_graph_layout) {
-  switch (canvas_type) {
-    case CanvasType::kCaptureWindow: {
-      auto main_capture_window = std::make_unique<CaptureWindow>(
-          app, /* capture_control_interface = */ app, time_graph_layout);
-      app->SetCaptureWindow(main_capture_window.get());
-      return main_capture_window;
-    }
-    case CanvasType::kIntrospectionWindow: {
-      auto introspection_window = std::make_unique<IntrospectionWindow>(
-          app, /* capture_control_interface = */ app, time_graph_layout);
-      app->SetIntrospectionWindow(introspection_window.get());
-      return introspection_window;
-    }
-    case CanvasType::kDebug:
-      return std::make_unique<GlCanvas>();
-    default:
-      ORBIT_UNREACHABLE();
-  }
-}
-
 bool GlCanvas::IsRedrawNeeded() const {
   return redraw_requested_ ||
          (is_mouse_over_ && can_hover_ && hover_timer_.ElapsedMillis() > hover_delay_ms_) ||

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -19,20 +19,13 @@
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
 #include "QtTextRenderer.h"
-#include "TimeGraphLayout.h"
 #include "Timer.h"
 #include "Viewport.h"
-
-class OrbitApp;
 
 class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
  public:
   explicit GlCanvas();
   virtual ~GlCanvas() = default;
-
-  enum class CanvasType { kCaptureWindow, kIntrospectionWindow, kDebug };
-  static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, OrbitApp* app,
-                                          TimeGraphLayout* time_graph_layout);
 
   void Resize(int width, int height);
   void Render(QPainter* painter, int width, int height);
@@ -146,7 +139,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   orbit_gl::PrimitiveAssembler primitive_assembler_;
 
  private:
-  [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleInterface>
+  [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
   void Pick(PickingMode picking_mode, int x, int y);
   virtual void HandlePickedElement(PickingMode /*picking_mode*/, PickingId /*picking_id*/,

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -67,9 +67,8 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
   return false;
 }
 
-void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitApp* app,
-                               TimeGraphLayout* time_graph_layout) {
-  gl_canvas_ = GlCanvas::Create(canvas_type, app, time_graph_layout);
+void OrbitGLWidget::Initialize(std::unique_ptr<GlCanvas> gl_canvas) {
+  gl_canvas_ = std::move(gl_canvas);
   constexpr std::chrono::milliseconds kUpdatePeriod{16};  // ...ms - that's roughly 60 FPS.
   update_timer_.start(kUpdatePeriod);
 }

--- a/src/OrbitQt/orbitglwidget.h
+++ b/src/OrbitQt/orbitglwidget.h
@@ -26,8 +26,7 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
 
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
-  void Initialize(GlCanvas::CanvasType canvas_type, OrbitApp* app,
-                  TimeGraphLayout* time_graph_layout);
+  void Initialize(std::unique_ptr<GlCanvas> gl_canvas);
   void Deinitialize();
   [[nodiscard]] GlCanvas* GetCanvas() { return gl_canvas_.get(); }
   [[nodiscard]] const GlCanvas* GetCanvas() const { return gl_canvas_.get(); }


### PR DESCRIPTION
That means GlCanvas won't need to know about its subclasses, so it removes a cyclic dependency.

It also allows OrbitMainWindow to get access to the CaptureWindow without the need for a dynamic cast.

Test: Manual on Linux