### PR TITLE
Remove context menu support from GlCanvas

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -253,7 +253,7 @@ void CaptureWindow::RightDown(int x, int y) {
   }
 }
 
-bool CaptureWindow::RightUp() {
+void CaptureWindow::RightUp() {
   if (time_graph_ != nullptr && is_selecting_ &&
       (select_start_pos_world_[0] != select_stop_pos_world_[0]) && ControlPressed()) {
     float min_world = std::min(select_start_pos_world_[0], select_stop_pos_world_[0]);
@@ -283,7 +283,7 @@ bool CaptureWindow::RightUp() {
                                        viewport_.ScreenToWorld(mouse_move_pos_screen_)});
   }
 
-  return GlCanvas::RightUp();
+  GlCanvas::RightUp();
 }
 
 void CaptureWindow::ZoomHorizontally(int delta, int mouse_x) {

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -40,7 +40,7 @@ class CaptureWindow : public GlCanvas, public orbit_gl::CaptureWindowDebugInterf
   void LeftDown(int x, int y) override;
   void LeftUp() override;
   void RightDown(int x, int y) override;
-  bool RightUp() override;
+  void RightUp() override;
   void MouseWheelMoved(int x, int y, int delta, bool ctrl) override;
   void MouseWheelMovedHorizontally(int x, int y, int delta, bool ctrl) override;
   void KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt) override;

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -137,12 +137,9 @@ void GlCanvas::RightDown(int x, int y) {
   RequestRedraw();
 }
 
-bool GlCanvas::RightUp() {
+void GlCanvas::RightUp() {
   is_selecting_ = false;
   RequestRedraw();
-
-  bool show_context_menu = select_start_pos_world_ == select_stop_pos_world_;
-  return show_context_menu;
 }
 
 void GlCanvas::CharEvent(unsigned int /*character*/) { RequestRedraw(); }

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -46,21 +46,14 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider, protected QOpenGL
   virtual void MouseWheelMoved(int x, int y, int delta, bool ctrl);
   virtual void MouseWheelMovedHorizontally(int /*x*/, int /*y*/, int /*delta*/, bool /*ctrl*/) {}
   virtual void RightDown(int x, int y);
-  virtual bool RightUp();
+  virtual void RightUp();
   virtual void MiddleDown(int x, int y) { RightDown(x, y); }
   virtual void MiddleUp() { RightUp(); }
   virtual void CharEvent(unsigned int character);
   virtual void KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt);
   virtual void KeyReleased(unsigned int key_code, bool ctrl, bool shift, bool alt);
 
-  [[nodiscard]] virtual std::vector<std::string> GetContextMenu() {
-    return std::vector<std::string>();
-  }
-  virtual void OnContextMenu(const std::string& /*a_Action*/, int /*a_MenuIndex*/) {}
-
   [[nodiscard]] orbit_gl::TextRenderer& GetTextRenderer() { return text_renderer_; }
-
-  [[nodiscard]] const Vec2i& GetMouseScreenPos() const { return mouse_move_pos_screen_; }
 
   [[nodiscard]] virtual bool IsRedrawNeeded() const;
   void RequestRedraw() { redraw_requested_ = true; }
@@ -144,7 +137,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider, protected QOpenGL
   CreateAccessibleInterface() override;
   void Pick(PickingMode picking_mode, int x, int y);
   virtual void HandlePickedElement(PickingMode /*picking_mode*/, PickingId /*picking_id*/,
-                                   int /*x*/, int /*y*/) {}
+                                   int /*x*/, int /*y*/) = 0;
 };
 
 #endif  // ORBIT_GL_GL_CANVAS_H_

--- a/src/OrbitQt/orbitglwidget.h
+++ b/src/OrbitQt/orbitglwidget.h
@@ -41,14 +41,11 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
   void mouseReleaseEvent(QMouseEvent* event) override;
   void mouseDoubleClickEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
-  void enterEvent(QEvent*) override;
-  void leaveEvent(QEvent*) override;
+  void enterEvent(QEvent* event) override;
+  void leaveEvent(QEvent* event) override;
   void keyPressEvent(QKeyEvent* event) override;
   void keyReleaseEvent(QKeyEvent* event) override;
   void wheelEvent(QWheelEvent* event) override;
-
-  void ShowContextMenu();
-  void OnMenuClicked(int index);
 
   std::unique_ptr<GlCanvas> gl_canvas_;
   QTimer update_timer_;


### PR DESCRIPTION
GlCanvas had context menu support that was only ever used in the debug window (which is not GlCanvas based anymore). So let's remove this untested code.