### PR TITLE
Fix include bug introduced by IWYU

### DIFF
--- a/contrib/iwyu/orbit.imp
+++ b/contrib/iwyu/orbit.imp
@@ -126,7 +126,7 @@
   # Qt adjustments - There is an auto-generated mapping file for Qt. Just put adjustments here.
   { "include": ["<QtCore/qglobal.h>", "private", "<QtGlobal>", "public"] },
   { "include": ["<QtCore/qobjectdefs.h>", "private", "<QMetaObject>", "public"] },
-  { "include": ["<GtGui/qopengl.h>", "private", "<QOpenGLFunctions>", "public"] },
+  { "include": ["<QtGui/qopengl.h>", "private", "<QOpenGLFunctions>", "public"] },
   { "include": ["<qtestmouse.h>", "private", "<QTest>", "public"] },
   { "include": ["<qtestkeyboard.h>", "private", "<QTest>", "public"] },
   { "include": ["<qtestsupport_core.h>", "private", "<QTest>", "public"] },

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -5,9 +5,9 @@
 #include "GlCanvas.h"
 
 #include <GteVector.h>
-#include <QtGui/qopengl.h>
 #include <stdint.h>
 
+#include <QOpenGLFunctions>
 #include <array>
 #include <cstdint>
 #include <cstring>

--- a/src/OrbitGl/OpenGlBatcher.cpp
+++ b/src/OrbitGl/OpenGlBatcher.cpp
@@ -7,9 +7,9 @@
 #include <CoreMath.h>
 #include <GteVector.h>
 #include <GteVector2.h>
-#include <QtGui/qopengl.h>
 #include <stddef.h>
 
+#include <QOpenGLFunctions>
 #include <algorithm>
 #include <utility>
 

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -4,13 +4,12 @@
 
 #include "orbitglwidget.h"
 
-#include <QtGui/qopengl.h>
-
 #include <QCharRef>
 #include <QFlags>
 #include <QMetaEnum>
 #include <QMouseEvent>
 #include <QOpenGLContext>
+#include <QOpenGLFunctions>
 #include <QPainter>
 #include <QRect>
 #include <QSurfaceFormat>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -4,7 +4,6 @@
 
 #include "orbitmainwindow.h"
 
-#include <QtGui/qopengl.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/flags/internal/flag.h>
 


### PR DESCRIPTION
Replaces some includes by its public counterpart. This didn't happen on the first run of iwyu because the mapping rule had a typo.