### PR TITLE
Fix IWYU-introduced Windows build failure

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -84,6 +84,7 @@ target_sources(OrbitBase PRIVATE
         ExecutablePathWindows.cpp
         GetLastErrorWindows.cpp
         GetProcAddressWindows.cpp
+        LoggingWindows.cpp
         OsVersionWindows.cpp
         ThreadUtilsWindows.cpp)
 else()

--- a/src/OrbitBase/LoggingWindows.cpp
+++ b/src/OrbitBase/LoggingWindows.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <Windows.h>
+
+#include "OrbitBase/StringConversion.h"
+
+namespace orbit_base {
+
+void OutputToDebugger(const char* str) {
+  std::wstring str_w = orbit_base::ToStdWString(str);
+  ::OutputDebugStringW(str_w.c_str());
+}
+}  // namespace orbit_base


### PR DESCRIPTION
This also cleans up the Logging.cpp file. So far we were using the TEMP_FAILURE_RETRY macro which only exists on Linux and polyfilling it for Windows.

But the usage of this macro is not needed because signal interruptions are already handled in the libc IO functions (fopen, fclose, fread, fwrite, etc.)

It would only be needed if we were using Linux syscall wrappers like (open, close read, write, etc.)

So this remove the usage of the retry logic and also moves the Windows only debugger output function into a separate file (as it's our usual policy.)