### PR TITLE
Re-enable the LLVM Conan dependency

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -27,7 +27,7 @@ done
 
 readonly REQUIRED_PACKAGES=( build-essential libglu1-mesa-dev mesa-common-dev \
                              libxmu-dev libxi-dev libopengl-dev qtbase5-dev \
-                             libxxf86vm-dev python3-pip llvm-dev libboost-dev )
+                             libxxf86vm-dev python3-pip libboost-dev )
 
 function add_ubuntu_universe_repo {
   sudo add-apt-repository universe

--- a/conanfile.py
+++ b/conanfile.py
@@ -60,6 +60,7 @@ class OrbitConan(ConanFile):
         self.requires("capstone/4.0.2")
         self.requires("grpc/1.48.0")
         self.requires("outcome/2.2.3")
+        self.requires("llvm-core/13.0.0")
         if self.settings.os != "Windows":
             self.requires("volk/1.3.224.1")
             self.requires("vulkan-headers/1.3.224.1")


### PR DESCRIPTION
There was a bug in the llvm-core Conan recipe which prevented us from using the upstream recipe. This is fixed now so we can go back to offering LLVM through Conan (which helps the Windows build and the oss-fuzz build).