### PR TITLE
Revise build and bootstrap scripts

### DIFF
--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -5,78 +5,47 @@
 $conan_version_required = "1.53.0"
 
 function Check-Conan-Version-Sufficient {
-  $version = $args[0]
-  $required = $args[1]
-
-  $version_major = $version.split(".")[0] -as [int]
-  $required_major = $required.split(".")[0] -as [int]
-  if ($required_major -gt $version_major) {
-    return 1
-  }
-  if ($required_major -lt $version_major) {
-    return 0
-  }
-
-  $version_minor = $version.split(".")[1] -as [int]
-  $required_minor = $required.split(".")[1] -as [int]
-  if ($required_minor -gt $version_minor) {
-    return 1
-  }
-  if ($required_minor -lt $version_minor) {
-    return 0
-  }
-
-  $version_patch = $version.split(".")[2] -as [int]
-  $required_patch = $required.split(".")[2] -as [int]
-  if ($required_patch -gt $version_patch) {
-    return 1
-  }
-  return 0
+  $version = [System.Version]$args[0]
+  $required = [System.Version]$args[1]
+  return $version -ge $required
 }
 
-$conan = Get-Command -ErrorAction Ignore conan
+function conan {
+  & py -3 -m conans.conan $args
+}
+function pip3 {
+  & py -3 -m pip $args
+}
 
-if (!$conan) {
+conan --version >null 2>&1
+
+if ($LastExitCode -ne 0) {
   Write-Host "Conan not found. Trying to install it via python-pip..."
 	
-  $pip3 = Get-Command -ErrorAction Ignore pip3
 	
-  if(!$pip3) {	
+  pip3 --version >null 2>&1
+
+  if ($LastExitCode -ne 0) {
     Write-Error -ErrorAction Stop @"
-It seems you don't have Python3 installed (pip3.exe not found).
-Please install Python or make it available in the path.
-Alternatively you could also just install conan manually and make
-it available in the path.
+It seems you don't have Python3 (or PIP) installed (py -3 -m pip --version fails).
+Please install Python and make it available in the path.
 "@
   }
 
-  & $pip3.Path install conan==$conan_version_required
+  pip3 install --upgrade --user conan==$conan_version_required
   if ($LastExitCode -ne 0) {
-    Throw "Error while installing conan via pip3."
-  }
-    
-  $conan = Get-Command -ErrorAction Ignore conan
-  if (!$conan) {
-    Write-Error -ErrorAction Stop @"
-It seems we installed conan sucessfully, but it is not available
-in the path. Please ensure that your Python user-executable folder is
-in the path and call this script again.
-You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
-"@
+    Throw "Error while installing conan via PIP."
   }
 } else {
   Write-Host "Conan found. Checking version..."
 
-  $conan_version = (& $conan.Path --version).split(" ")[2]
+  $conan_version = (conan --version).split(" ")[2]
 
-  $sufficient = Check-Conan-Version-Sufficient $conan_version $conan_version_required
-  if ($sufficient -ne 0) {
+  if (Check-Conan-Version-Sufficient $conan_version $conan_version_required) {
     Write-Host "Your conan version $conan_version is too old. Let's try to update it."
-    Try {
-      $pip3 = Get-Command pip3
-      & $pip3.Path install --upgrade conan==$conan_version_required
-    } Catch {
-      Throw "Error while upgrading conan via pip3. Probably you have conan installed differently." + 
+    pip3 install --upgrade conan==$conan_version_required
+    if ($LastExitCode -ne 0) {
+      Throw "Error while upgrading conan via PIP. Probably you have conan installed differently." + 
             " Please manually update conan to a at least version $conan_version_required"
     }
 
@@ -87,7 +56,15 @@ You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
 }
 
 # Install conan config
-& "$PSScriptRoot\third_party\conan\configs\install.ps1"
+#
+# We always pass the `-recreate-default-profiles` option here which removes all the previously automatically
+# created default profiles. This avoids problems with stale default profiles which can occur when the OS has been
+# updated and the previous default compiler is not available anymore.
+#
+# All changes made by the user to these profiles will be lost which is not ideal, but when calling bootstrap
+# we expect the user wants a clean and working build no matter what. There is no need to make changes to the
+# default profiles unless you try something out of the order and probably know what you are doing.
+& "$PSScriptRoot\third_party\conan\configs\install.ps1" -recreate_default_profiles
 
 # Start build
 if ($args) {

--- a/third_party/conan/configs/install.ps1
+++ b/third_party/conan/configs/install.ps1
@@ -2,8 +2,24 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-$py = Get-Command py -ErrorAction Stop
+param (
+  [switch]$recreate_default_profiles = $false
+)
 
-# Installs conan config (build settings, public remotes, conan profiles, conan options). Have a look in \third_party\conan\configs\windows for more information.
-$process = Start-Process $py.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "-3","-m","conans.conan","config","install","$PSScriptRoot\windows"
-if ($process.ExitCode -ne 0) { Throw "Error while installing conan config." }
+$conan_dir = if ( $Env:CONAN_USER_HOME ) { $Env:CONAN_USER_HOME } else { "$HOME\.conan" }
+$profiles_dir = "$conan_dir\profiles"
+
+if ($recreate_default_profiles) {
+  Remove-Item $profiles_dir\* -Include default,default_release,default_relwithdebinfo,default_debug -Force
+}
+
+function conan {
+  & py -3 -m conans.conan $args
+}
+
+# Installs conan config (build settings, public remotes, conan profiles, conan options).
+# Have a look in \third_party\conan\configs\windows for more information.
+conan config install "$PSScriptRoot\windows"
+if ($LastExitCode -ne 0) {
+   Throw "Error while installing conan config."
+}

--- a/third_party/conan/configs/install.sh
+++ b/third_party/conan/configs/install.sh
@@ -6,7 +6,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-OPTIONS=$(getopt -o "" -l "assume-linux,assume-windows" -- "$@")
+OPTIONS=$(getopt -o "" -l "assume-linux,assume-windows,recreate-default-profiles" -- "$@")
 eval set -- "$OPTIONS"
 
 if [ "$(uname -s)" == "Linux" ]; then
@@ -15,13 +15,21 @@ else
   OS="windows"
 fi
 
+RECREATE_DEFAULT_PROFILES="no"
+
 while true; do
   case "$1" in
     --assume-linux) OS="linux"; shift;;
     --assume-windows) OS="windows"; shift;;
+    --recreate-default-profiles) RECREATE_DEFAULT_PROFILES="yes"; shift;;
     --) shift; break;;
   esac
 done
+
+if [[ $RECREATE_DEFAULT_PROFILES == "yes" ]]; then
+  readonly profiles_dir="${CONAN_USER_HOME:-~}/.conan/profiles"
+  rm -f "$profiles_dir"/default{,_release,_relwithdebinfo,_debug}
+fi
 
 # Installs conan config (build settings, public remotes, conan profiles, conan options). Have a look in \third_party\conan\configs\windows for more information.
 conan config install "$DIR/$OS" || exit $?


### PR DESCRIPTION
This is doing the following:
1. Unify conan and pip calls. We always useed to have problems when pip installs a package, but the package's binaries were not in the PATH - or even weirder they were in the PATH but another Python installation took precedence and we were calling the wrong version of Conan. We can avoid that by always going through the same launcher, so `python3` on Linux and `py -3` on Windows - no matter if we call pip or conan.

2. Avoid stale default profiles. We often had problems that a user installed Orbit once, and only returned to the project after a long time (weeks or months). If the system has been upgraded in between often the system compiler changes and the old system compiler (hard coded in the default profiles) is not available anymore. The solution is to recreate the default profiles whenever the user calls one of the bootstrap scripts. This also has a disadvantage - because we might overwrite custom changes a user made to the default profiles - but the former problem is far more likely, so in my opinion it's a good tradeoff.

3. The Linux bash script also get the usual `set -euo pipefail` options.

4. There are also additional minor improvements, like the big red warning coming from conan will not be shown anymore when a new profile gets created.

5. There is also now a message been displayed at the end of the build process which tells the user how to start Orbit. This is only shown when a default profile is compiled.

For testing I went through all the code paths at least once - I hope. :crossed_fingers: 