### PR TITLE
Revert "Statically check for Orbit's major version being always one (…

### DIFF
--- a/src/OrbitVersion/OrbitVersion.cpp.in
+++ b/src/OrbitVersion/OrbitVersion.cpp.in
@@ -16,7 +16,6 @@
 #define OrbitCommitHashStr "@COMMIT_HASH@"
 #define OrbitMajorVersion @MAJOR_VERSION@
 #define OrbitMinorVersion @MINOR_VERSION@
-static_assert(OrbitMajorVersion == 1);
 
 namespace orbit_version {
 

--- a/src/OrbitVersion/OrbitVersionTest.cpp
+++ b/src/OrbitVersion/OrbitVersionTest.cpp
@@ -40,4 +40,6 @@ TEST(OrbitVersion, Compare) {
   EXPECT_FALSE((Version{1, 2} >= Version{2, 1}));
 }
 
+TEST(OrbitVersion, MajorVersionIsAlwaysOne) { EXPECT_EQ(GetVersion().major_version, 1); }
+
 }  // namespace orbit_version


### PR DESCRIPTION
…#4406)"

This reverts commit d26df65c5df87c32f6b85c050a9e36175091899a.

Unfortunately this turned out to be problematic in a couple of cases:
1. When having a shallow clone of the Git repo, the version can't be determined
2. When building Orbit from the ZIP archive provided by GitHub (as the fuzz build does), the version can also not be determined.

In both cases, we want to be nice and not abort the build.