### PR TITLE
More Windows build fixes

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -15,6 +15,10 @@
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 
+#ifdef _WIN32
+#include "ApiUtils/ApiEnableInfo.h"
+#endif
+
 namespace {
 orbit_api::LockFreeApiEventProducer& GetCaptureEventProducer() {
   static orbit_api::LockFreeApiEventProducer producer;

--- a/src/CaptureClient/CMakeLists.txt
+++ b/src/CaptureClient/CMakeLists.txt
@@ -38,6 +38,10 @@ target_link_libraries(CaptureClient PUBLIC
         GrpcProtos
         Introspection)
 
+if(WIN32)
+  target_compile_features(CaptureClient PRIVATE cxx_std_20)
+endif()
+
 add_fuzzer(CaptureEventProcessorProcessEventsFuzzer CaptureEventProcessorProcessEventsFuzzer.cpp)
 target_link_libraries(CaptureEventProcessorProcessEventsFuzzer
         PRIVATE CaptureClient FuzzingUtils)

--- a/src/CaptureFile/CaptureFile.cpp
+++ b/src/CaptureFile/CaptureFile.cpp
@@ -5,11 +5,8 @@
 #include "CaptureFile/CaptureFile.h"
 
 #include <absl/strings/str_format.h>
-#include <errno.h>
-#include <fcntl.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
-#include <unistd.h>
 
 #include <algorithm>
 #include <array>
@@ -30,6 +27,12 @@
 #include "OrbitBase/Result.h"
 #include "OrbitBase/SafeStrerror.h"
 #include "ProtoSectionInputStreamImpl.h"
+
+#ifdef __linux
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 namespace orbit_capture_file {
 

--- a/src/OrbitBase/LoggingWindows.cpp
+++ b/src/OrbitBase/LoggingWindows.cpp
@@ -6,10 +6,10 @@
 
 #include "OrbitBase/StringConversion.h"
 
-namespace orbit_base {
+namespace orbit_base_internal {
 
 void OutputToDebugger(const char* str) {
   std::wstring str_w = orbit_base::ToStdWString(str);
   ::OutputDebugStringW(str_w.c_str());
 }
-}  // namespace orbit_base
+}  // namespace orbit_base_internal

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -8,9 +8,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
 #include <absl/strings/strip.h>
-#include <fcntl.h>
 #include <stdint.h>
-#include <unistd.h>
 
 #include <chrono>
 #include <cstdio>
@@ -25,6 +23,11 @@
 #include "OrbitVersion/OrbitVersion.h"
 #include "ProducerSideService/BuildAndStartProducerSideServer.h"
 #include "ProducerSideService/ProducerSideServer.h"
+
+#ifdef __linux
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 using orbit_producer_side_service::ProducerSideServer;
 


### PR DESCRIPTION
This mainly fixes includes (and enable C++20 for the CaptureClient module which is needed for designated initializers.)