### PR TITLE
Fix autopresets copy error

### DIFF
--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -66,7 +66,8 @@ if (WIN32)
 target_link_libraries(ObjectUtils PUBLIC DIASDK::DIASDK)
 
 add_custom_command(TARGET ObjectUtils POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${DIASDK_DLL} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${DIASDK_DLL}" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/")
 endif()
 
 add_executable(ObjectUtilsTests)


### PR DESCRIPTION
When building a clean build on Windows the build aborted with an error saying that it can't copy the autopreset to the bin/ subdirectory. The problem was that already a file with the name `bin` existed.

It turned out this was the also copied DIA SDK DLL. The solution is to create the directory explicitly.