### PR TITLE
Add & integrate ProcessListWidget

### DIFF
--- a/src/SessionSetup/CMakeLists.txt
+++ b/src/SessionSetup/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
           include/SessionSetup/OtherUserDialog.h
           include/SessionSetup/ProcessItemModel.h
           include/SessionSetup/ProcessLauncherWidget.h
+          include/SessionSetup/ProcessListWidget.h
           include/SessionSetup/ServiceDeployManager.h
           include/SessionSetup/SessionSetupDialog.h
           include/SessionSetup/SessionSetupUtils.h
@@ -47,6 +48,8 @@ target_sources(
           ProcessItemModel.cpp
           ProcessLauncherWidget.cpp
           ProcessLauncherWidget.ui
+          ProcessListWidget.cpp
+          ProcessListWidget.ui
           ServiceDeployManager.cpp
           SessionSetupDialog.cpp
           SessionSetupDialog.ui
@@ -85,6 +88,7 @@ target_sources(
           OrbitServiceInstanceTest.cpp
           OtherUserDialogTest.cpp
           ProcessItemModelTest.cpp
+          ProcessListWidgetTest.cpp
           SessionSetupDialogTest.cpp
           SessionSetupUtilsTest.cpp
           TargetLabelTest.cpp)

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -84,10 +84,9 @@ void ConnectToTargetDialog::OnProcessListUpdate(
       TryToFindProcessData(process_list, target_.process_name_or_path.toStdString());
 
   if (matching_process != nullptr) {
-    process_manager_->SetProcessListUpdateListener(nullptr);
-    target_configuration_ =
-        orbit_session_setup::SshTarget(std::move(ssh_connection_.value()),
-                                       std::move(process_manager_), std::move(matching_process));
+    ssh_connection_->GetProcessManager()->SetProcessListUpdateListener(nullptr);
+    target_configuration_ = orbit_session_setup::SshTarget(std::move(ssh_connection_.value()),
+                                                           std::move(matching_process));
     accept();
   }
 }
@@ -112,9 +111,7 @@ ErrorMessageOr<void> ConnectToTargetDialog::DeployOrbitServiceAndSetupProcessMan
                                                        std::move(service_deploy_manager),
                                                        std::move(grpc_channel));
 
-  process_manager_ = orbit_client_services::ProcessManager::Create(
-      ssh_connection_.value().GetGrpcChannel(), absl::Milliseconds(1000));
-  process_manager_->SetProcessListUpdateListener(
+  ssh_connection_->GetProcessManager()->SetProcessListUpdateListener(
       [dialog = QPointer<ConnectToTargetDialog>(this)](
           std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
         if (dialog == nullptr) return;

--- a/src/SessionSetup/ProcessItemModel.cpp
+++ b/src/SessionSetup/ProcessItemModel.cpp
@@ -122,7 +122,7 @@ int ProcessItemModel::rowCount(const QModelIndex& parent) const {
   return processes_.size();
 }
 
-void ProcessItemModel::SetProcesses(std::vector<ProcessInfo> new_processes) {
+void ProcessItemModel::SetProcesses(QVector<ProcessInfo> new_processes) {
   orbit_base::sort(new_processes.begin(), new_processes.end(), &ProcessInfo::pid);
 
   auto old_iter = processes_.begin();

--- a/src/SessionSetup/ProcessListWidget.cpp
+++ b/src/SessionSetup/ProcessListWidget.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SessionSetup/ProcessListWidget.h"
+
+#include <QTableView>
+#include <memory>
+
+#include "GrpcProtos/process.pb.h"
+#include "OrbitBase/Logging.h"
+#include "ui_ProcessListWidget.h"
+
+namespace orbit_session_setup {
+
+constexpr int kProcessesRowHeight = 19;
+
+using orbit_grpc_protos::ProcessInfo;
+
+namespace {
+
+ProcessInfo GetProcessFromIndex(const QModelIndex& index) {
+  ORBIT_CHECK(index.isValid());
+  ORBIT_CHECK(index.data(Qt::UserRole).canConvert<const ProcessInfo*>());
+  return *index.data(Qt::UserRole).value<const ProcessInfo*>();
+}
+
+}  // namespace
+
+ProcessListWidget::ProcessListWidget(QWidget* parent)
+    : QWidget(parent), ui_(std::make_unique<Ui::ProcessListWidget>()) {
+  ui_->setupUi(this);
+  ui_->overlay->raise();
+
+  ui_->overlay->SetCancelable(false);
+  ui_->overlay->SetStatusMessage("Loading processes...");
+
+  proxy_model_.setSourceModel(&model_);
+  proxy_model_.setSortRole(Qt::EditRole);
+  proxy_model_.setFilterCaseSensitivity(Qt::CaseInsensitive);
+
+  ui_->tableView->setModel(&proxy_model_);
+  ui_->tableView->setSortingEnabled(true);
+  ui_->tableView->sortByColumn(static_cast<int>(ProcessItemModel::Column::kCpu),
+                               Qt::DescendingOrder);
+  ui_->tableView->horizontalHeader()->setSectionResizeMode(
+      static_cast<int>(ProcessItemModel::Column::kPid), QHeaderView::ResizeToContents);
+  ui_->tableView->horizontalHeader()->setSectionResizeMode(
+      static_cast<int>(ProcessItemModel::Column::kCpu), QHeaderView::ResizeToContents);
+  ui_->tableView->horizontalHeader()->setSectionResizeMode(
+      static_cast<int>(ProcessItemModel::Column::kName), QHeaderView::Stretch);
+  ui_->tableView->verticalHeader()->setDefaultSectionSize(kProcessesRowHeight);
+  ui_->tableView->verticalHeader()->setVisible(false);
+
+  QObject::connect(ui_->tableView->selectionModel(), &QItemSelectionModel::currentChanged, this,
+                   &ProcessListWidget::SelectionChanged);
+  QObject::connect(ui_->tableView, &QTableView::doubleClicked, this,
+                   &ProcessListWidget::TryConfirm);
+  QObject::connect(ui_->filterLineEdit, &QLineEdit::returnPressed, this,
+                   &ProcessListWidget::TryConfirm);
+  QObject::connect(ui_->filterLineEdit, &QLineEdit::textChanged, &proxy_model_,
+                   &QSortFilterProxyModel::setFilterFixedString);
+}
+
+ProcessListWidget::~ProcessListWidget() noexcept = default;
+
+void ProcessListWidget::Clear() {
+  model_.Clear();
+  ui_->overlay->setVisible(false);
+}
+
+std::optional<orbit_grpc_protos::ProcessInfo> ProcessListWidget::GetSelectedProcess() {
+  const QItemSelectionModel* model = ui_->tableView->selectionModel();
+
+  if (!model->hasSelection()) {
+    return std::nullopt;
+  }
+
+  ORBIT_CHECK(!model->selectedRows().empty());
+  return GetProcessFromIndex(model->selectedRows().first());
+}
+
+void ProcessListWidget::SelectionChanged(const QModelIndex& index) {
+  if (!index.isValid()) {
+    emit NoSelection();
+    return;
+  }
+
+  emit ProcessSelected(GetProcessFromIndex(index));
+}
+
+bool ProcessListWidget::TrySelectProcessByName(const std::string& process_name) {
+  QModelIndexList matches = proxy_model_.match(
+      proxy_model_.index(0, static_cast<int>(ProcessItemModel::Column::kName)), Qt::DisplayRole,
+      QVariant::fromValue(QString::fromStdString(process_name)));
+
+  if (matches.isEmpty()) return false;
+
+  ui_->tableView->selectionModel()->setCurrentIndex(
+      matches[0], {QItemSelectionModel::SelectCurrent, QItemSelectionModel::Rows});
+  return true;
+}
+
+void ProcessListWidget::UpdateList(std::vector<ProcessInfo> list) {
+  ui_->overlay->setVisible(false);
+  bool had_processes_before = model_.HasProcesses();
+  model_.SetProcesses(std::move(list));
+
+  // In case there is a selection already, nothing changes but the `Selected` signal is emitted.
+  if (std::optional<ProcessInfo> process_opt = GetSelectedProcess(); process_opt != std::nullopt) {
+    emit ProcessSelected(std::move(process_opt.value()));
+    return;
+  }
+
+  if (!name_to_select_.empty()) {
+    bool success = TrySelectProcessByName(name_to_select_);
+    if (success) {
+      ORBIT_LOG("Selected remembered process with name: %s", name_to_select_);
+      return;
+    }
+  }
+
+  // The first time a list of processes arrives, the cpu utilization values are not valid, since
+  // they are computed as an average since the last time the list was refreshed. Hence return here
+  // and do not perform a selection.
+  if (!had_processes_before) {
+    ui_->overlay->setVisible(true);
+    return;
+  }
+
+  // This selects the first (top most) row. The table is sorted by cpu usage (%) by default, so
+  // unless the user changed the sorting, this will select the process with the highest cpu load
+  ui_->tableView->selectRow(0);
+}
+
+void ProcessListWidget::TryConfirm() {
+  if (ui_->tableView->selectionModel()->hasSelection()) {
+    emit ProcessConfirmed();
+  }
+}
+
+}  // namespace orbit_session_setup

--- a/src/SessionSetup/ProcessListWidget.ui
+++ b/src/SessionSetup/ProcessListWidget.ui
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ProcessListWidget</class>
+ <widget class="QWidget" name="ProcessListWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>379</width>
+    <height>728</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>23</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Select a process</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="filterLineEdit">
+        <property name="accessibleName">
+         <string>FilterProcesses</string>
+        </property>
+        <property name="placeholderText">
+         <string>Filter</string>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTableView" name="tableView">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
+        <property name="accessibleName">
+         <string>ProcessList</string>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="showGrid">
+         <bool>false</bool>
+        </property>
+        <widget class="orbit_session_setup::OverlayWidget" name="overlay" native="true">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>100</width>
+           <height>30</height>
+          </rect>
+         </property>
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+         <property name="accessibleName">
+          <string>ProcessListOverlay</string>
+         </property>
+        </widget>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>orbit_session_setup::OverlayWidget</class>
+   <extends>QWidget</extends>
+   <header>SessionSetup/OverlayWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/SessionSetup/ProcessListWidgetTest.cpp
+++ b/src/SessionSetup/ProcessListWidgetTest.cpp
@@ -1,0 +1,241 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <google/protobuf/util/message_differencer.h>
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QLineEdit>
+#include <QMetaType>
+#include <QSignalSpy>
+#include <QTableView>
+#include <QTest>
+#include <chrono>
+#include <thread>
+
+#include "SessionSetup/OverlayWidget.h"
+#include "SessionSetup/ProcessListWidget.h"
+
+namespace orbit_session_setup {
+
+using orbit_grpc_protos::ProcessInfo;
+
+class ProcessListWidgetTest : public ::testing::Test {
+  void SetUp() override {
+    widget_.show();
+
+    table_view_ = widget_.findChild<QTableView*>("tableView");
+    ASSERT_NE(table_view_, nullptr);
+
+    filter_line_edit_ = widget_.findChild<QLineEdit*>("filterLineEdit");
+    ASSERT_NE(filter_line_edit_, nullptr);
+
+    overlay_ = widget_.findChild<OverlayWidget*>("overlay");
+    ASSERT_NE(overlay_, nullptr);
+
+    test_process_info_1_.set_pid(100);
+    test_process_info_1_.set_name("name1");
+    test_process_info_1_.set_cpu_usage(10.0);
+    test_process_info_1_.set_full_path("full/path/name1");
+    test_process_info_1_.set_command_line("example cmd line call1");
+    test_process_info_1_.set_is_64_bit(true);
+    test_process_info_1_.set_build_id("example build id1");
+
+    test_process_info_2_.set_pid(200);
+    test_process_info_2_.set_name("name2");
+    test_process_info_2_.set_cpu_usage(20.0);
+    test_process_info_2_.set_full_path("full/path/name2");
+    test_process_info_2_.set_command_line("example cmd line call2");
+    test_process_info_2_.set_is_64_bit(true);
+    test_process_info_2_.set_build_id("example build id2");
+  }
+
+ protected:
+  ProcessListWidget widget_;
+  QTableView* table_view_ = nullptr;
+  QLineEdit* filter_line_edit_ = nullptr;
+  OverlayWidget* overlay_ = nullptr;
+  ProcessInfo test_process_info_1_;
+  ProcessInfo test_process_info_2_;
+};
+
+TEST_F(ProcessListWidgetTest, Clear) {
+  // default
+  EXPECT_EQ(table_view_->model()->rowCount(), 0);
+  EXPECT_TRUE(filter_line_edit_->text().isEmpty());
+  EXPECT_FALSE(overlay_->isVisible());
+
+  // Clear at this point does not change anything
+  widget_.Clear();
+  EXPECT_EQ(table_view_->model()->rowCount(), 0);
+  EXPECT_TRUE(filter_line_edit_->text().isEmpty());
+  EXPECT_FALSE(overlay_->isVisible());
+
+  // Clear does not change the filter_line_edit_ content
+  filter_line_edit_->setText("example filter text");
+  widget_.Clear();
+  EXPECT_EQ(filter_line_edit_->text(), "example filter text");
+
+  // reset filter
+  filter_line_edit_->setText({});
+
+  // add test process
+  widget_.UpdateList({test_process_info_1_});
+  EXPECT_EQ(table_view_->model()->rowCount(), 1);
+  // After the first time adding process list, the cpu values are not reliable and therefore
+  // overlay_ is shown.
+  EXPECT_TRUE(overlay_->isVisible());
+
+  // Clear
+  widget_.Clear();
+  EXPECT_EQ(table_view_->model()->rowCount(), 0);
+  EXPECT_FALSE(overlay_->isVisible());
+}
+
+TEST_F(ProcessListWidgetTest, Overlay) {
+  // default
+  EXPECT_FALSE(overlay_->isVisible());
+
+  // overlay visible after first list update
+  widget_.UpdateList({test_process_info_1_});
+  EXPECT_TRUE(overlay_->isVisible());
+
+  // overlay not visible anymore after second list update
+  widget_.UpdateList({test_process_info_1_});
+  EXPECT_FALSE(overlay_->isVisible());
+}
+
+TEST_F(ProcessListWidgetTest, AutoSelection) {
+  QSignalSpy selected_spy(&widget_, &ProcessListWidget::ProcessSelected);
+
+  widget_.UpdateList({test_process_info_1_, test_process_info_2_});
+  // no selection after first update
+  EXPECT_TRUE(selected_spy.empty());
+
+  widget_.UpdateList({test_process_info_1_, test_process_info_2_});
+  // auto selection of one process has happened.
+  ASSERT_EQ(selected_spy.count(), 1);
+  QVariant argument = selected_spy.takeFirst().at(0);
+  ASSERT_TRUE(argument.canConvert<ProcessInfo>());
+  auto process_info = argument.value<ProcessInfo>();
+  // test_process_info_2_ has a higher cpu usage, hence it was selected
+  EXPECT_TRUE(
+      google::protobuf::util::MessageDifferencer::Equals(process_info, test_process_info_2_));
+
+  selected_spy.clear();
+
+  // Updating the list will emit signal again
+  widget_.UpdateList({test_process_info_1_, test_process_info_2_});
+  EXPECT_EQ(selected_spy.count(), 1);
+
+  selected_spy.clear();
+
+  // When the selected process disappears from the list, the next highest cpu process will be
+  // selected. (In the following case process_1 is the only one in the list)
+  widget_.UpdateList({test_process_info_1_});
+  ASSERT_GE(selected_spy.count(), 1);
+  argument = selected_spy.takeFirst().at(0);
+  ASSERT_TRUE(argument.canConvert<ProcessInfo>());
+  process_info = argument.value<ProcessInfo>();
+  EXPECT_TRUE(
+      google::protobuf::util::MessageDifferencer::Equals(process_info, test_process_info_1_));
+}
+
+TEST_F(ProcessListWidgetTest, SetNameToSelect) {
+  QSignalSpy selected_spy(&widget_, &ProcessListWidget::ProcessSelected);
+
+  widget_.SetNameToSelect(test_process_info_1_.name());
+
+  widget_.UpdateList({test_process_info_1_, test_process_info_2_});
+  ASSERT_EQ(selected_spy.count(), 1);
+  QVariant argument = selected_spy.takeFirst().at(0);
+  ASSERT_TRUE(argument.canConvert<ProcessInfo>());
+  auto process_info = argument.value<ProcessInfo>();
+  EXPECT_TRUE(
+      google::protobuf::util::MessageDifferencer::Equals(process_info, test_process_info_1_));
+}
+
+TEST_F(ProcessListWidgetTest, NoSelection) {
+  QSignalSpy no_selection_spy(&widget_, &ProcessListWidget::NoSelection);
+
+  // setup, so there is a selection
+  widget_.SetNameToSelect(test_process_info_1_.name());
+  widget_.UpdateList({test_process_info_1_});
+  EXPECT_EQ(table_view_->model()->rowCount(), 1);
+
+  // deselect on clear
+  widget_.Clear();
+  EXPECT_EQ(no_selection_spy.count(), 1);
+
+  no_selection_spy.clear();
+
+  // setup, so there is a selection
+  widget_.SetNameToSelect(test_process_info_1_.name());
+  widget_.UpdateList({test_process_info_1_});
+  EXPECT_EQ(table_view_->model()->rowCount(), 1);
+
+  // deselect when table is empty because of filtering
+  filter_line_edit_->setText("filter string that does not create match");
+  EXPECT_EQ(table_view_->model()->rowCount(), 0);
+  EXPECT_EQ(no_selection_spy.count(), 1);
+}
+
+TEST_F(ProcessListWidgetTest, UpdateList) {
+  EXPECT_EQ(table_view_->model()->rowCount(), 0);
+
+  widget_.UpdateList({test_process_info_1_});
+  EXPECT_EQ(table_view_->model()->rowCount(), 1);
+
+  widget_.UpdateList({test_process_info_1_});
+  EXPECT_EQ(table_view_->model()->rowCount(), 1);
+
+  widget_.UpdateList({test_process_info_1_, test_process_info_2_});
+  EXPECT_EQ(table_view_->model()->rowCount(), 2);
+
+  widget_.UpdateList({test_process_info_2_});
+  EXPECT_EQ(table_view_->model()->rowCount(), 1);
+}
+
+TEST_F(ProcessListWidgetTest, Confirmed) {
+  QSignalSpy confirmed_spy(&widget_, &ProcessListWidget::ProcessConfirmed);
+
+  // no confirm via enter in filter line, iff a selection hasn't happened yet.
+  QTest::keyClick(filter_line_edit_, Qt::Key::Key_Enter);
+  EXPECT_EQ(confirmed_spy.count(), 0);
+
+  // make auto selection happen
+  QSignalSpy selected_spy(&widget_, &ProcessListWidget::ProcessSelected);
+  widget_.UpdateList({test_process_info_1_});
+  widget_.UpdateList({test_process_info_1_});
+  EXPECT_EQ(selected_spy.count(), 1);
+
+  // no confirm yet
+  EXPECT_EQ(confirmed_spy.count(), 0);
+
+  // confirm via enter
+  QTest::keyClick(filter_line_edit_, Qt::Key::Key_Enter);
+  EXPECT_EQ(confirmed_spy.count(), 1);
+
+  {  // confirm via double click
+
+    // selection_row_box is the rectangle that the selected row is occupying. These coordinates are
+    // relative to the viewport of the table view (table_view_->viewport()).
+    const QRect selected_row_box =
+        table_view_->visualRect(table_view_->selectionModel()->currentIndex());
+
+    // The following does a single mouse click onto the selected row (before the double click
+    // later). This is only necessary when simulating the click via QTest and not when an actual
+    // human is double clicking. The reason for this is not clear to me. Some more information can
+    // be found here:
+    // https://stackoverflow.com/questions/12604739/how-can-you-edit-a-qtableview-cell-from-a-qtest-unit-test
+    QTest::mouseClick(table_view_->viewport(), Qt::MouseButton::LeftButton,
+                      Qt::KeyboardModifier::NoModifier, selected_row_box.center());
+
+    QTest::mouseDClick(table_view_->viewport(), Qt::MouseButton::LeftButton,
+                       Qt::KeyboardModifier::NoModifier, selected_row_box.center());
+    EXPECT_EQ(confirmed_spy.count(), 2);
+  }
+}
+
+}  // namespace orbit_session_setup

--- a/src/SessionSetup/ProcessListWidgetTest.cpp
+++ b/src/SessionSetup/ProcessListWidgetTest.cpp
@@ -145,7 +145,7 @@ TEST_F(ProcessListWidgetTest, AutoSelection) {
 TEST_F(ProcessListWidgetTest, SetNameToSelect) {
   QSignalSpy selected_spy(&widget_, &ProcessListWidget::ProcessSelected);
 
-  widget_.SetNameToSelect(test_process_info_1_.name());
+  widget_.SetProcessNameToSelect(test_process_info_1_.name());
 
   widget_.UpdateList({test_process_info_1_, test_process_info_2_});
   ASSERT_EQ(selected_spy.count(), 1);
@@ -157,10 +157,10 @@ TEST_F(ProcessListWidgetTest, SetNameToSelect) {
 }
 
 TEST_F(ProcessListWidgetTest, NoSelection) {
-  QSignalSpy no_selection_spy(&widget_, &ProcessListWidget::NoSelection);
+  QSignalSpy no_selection_spy(&widget_, &ProcessListWidget::ProcessSelectionCleared);
 
   // setup, so there is a selection
-  widget_.SetNameToSelect(test_process_info_1_.name());
+  widget_.SetProcessNameToSelect(test_process_info_1_.name());
   widget_.UpdateList({test_process_info_1_});
   EXPECT_EQ(table_view_->model()->rowCount(), 1);
 
@@ -171,7 +171,7 @@ TEST_F(ProcessListWidgetTest, NoSelection) {
   no_selection_spy.clear();
 
   // setup, so there is a selection
-  widget_.SetNameToSelect(test_process_info_1_.name());
+  widget_.SetProcessNameToSelect(test_process_info_1_.name());
   widget_.UpdateList({test_process_info_1_});
   EXPECT_EQ(table_view_->model()->rowCount(), 1);
 

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -5,8 +5,6 @@
 #include "SessionSetup/SessionSetupDialog.h"
 
 #include <absl/flags/flag.h>
-#include <absl/time/time.h>
-#include <grpcpp/grpcpp.h>
 
 #include <QButtonGroup>
 #include <QFrame>
@@ -33,8 +31,8 @@
 #include <variant>
 #include <vector>
 
+#include "ClientData/ProcessData.h"
 #include "ClientFlags/ClientFlags.h"
-#include "ClientServices/ProcessManager.h"
 #include "GrpcProtos/process.pb.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
@@ -42,15 +40,10 @@
 #include "SessionSetup/Connections.h"
 #include "SessionSetup/LoadCaptureWidget.h"
 #include "SessionSetup/OrbitServiceInstance.h"
-#include "SessionSetup/OverlayWidget.h"
-#include "SessionSetup/ProcessItemModel.h"
+#include "SessionSetup/ProcessListWidget.h"
 #include "SessionSetup/TargetConfiguration.h"
 #include "SessionSetup/TargetLabel.h"
 #include "ui_SessionSetupDialog.h"
-
-namespace {
-constexpr int kProcessesRowHeight = 19;
-}  // namespace
 
 namespace orbit_session_setup {
 
@@ -69,46 +62,28 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
       state_local_history_(&state_local_),
       state_local_connecting_(&state_local_),
       state_local_connected_(&state_local_),
-      state_local_processes_loading_(&state_local_connected_),
-      state_local_process_selected_(&state_local_connected_),
-      state_local_no_process_selected_(&state_local_connected_) {
+      state_local_no_process_selected_(&state_local_connected_),
+      state_local_process_selected_(&state_local_connected_) {
   ORBIT_CHECK(ssh_connection_artifacts != nullptr);
 
   ui_->setupUi(this);
   ui_->localProfilingWidget->SetOrbitServiceInstanceCreateFunction(
       []() { return OrbitServiceInstance::CreatePrivileged(); });
-  ui_->processesTableOverlay->raise();
 
   state_machine_.setGlobalRestorePolicy(QStateMachine::RestoreProperties);
   SetupFileStates();
   SetupLocalStates();
 
-  process_proxy_model_.setSourceModel(&process_model_);
-  process_proxy_model_.setSortRole(Qt::EditRole);
-  process_proxy_model_.setFilterCaseSensitivity(Qt::CaseInsensitive);
-  ui_->processesTableView->setModel(&process_proxy_model_);
-  ui_->processesTableView->setSortingEnabled(true);
-  ui_->processesTableView->sortByColumn(static_cast<int>(ProcessItemModel::Column::kCpu),
-                                        Qt::DescendingOrder);
-
-  ui_->processesTableView->horizontalHeader()->setSectionResizeMode(
-      static_cast<int>(ProcessItemModel::Column::kPid), QHeaderView::ResizeToContents);
-  ui_->processesTableView->horizontalHeader()->setSectionResizeMode(
-      static_cast<int>(ProcessItemModel::Column::kCpu), QHeaderView::ResizeToContents);
-  ui_->processesTableView->horizontalHeader()->setSectionResizeMode(
-      static_cast<int>(ProcessItemModel::Column::kName), QHeaderView::Stretch);
-  ui_->processesTableView->verticalHeader()->setDefaultSectionSize(kProcessesRowHeight);
-  ui_->processesTableView->verticalHeader()->setVisible(false);
-
-  QObject::connect(ui_->processesTableView->selectionModel(), &QItemSelectionModel::currentChanged,
-                   this, &SessionSetupDialog::ProcessSelectionChanged);
-  QObject::connect(ui_->processesTableView, &QTableView::doubleClicked, this, &QDialog::accept);
-  QObject::connect(ui_->processFilterLineEdit, &QLineEdit::textChanged, &process_proxy_model_,
-                   &QSortFilterProxyModel::setFilterFixedString);
   QObject::connect(ui_->confirmButton, &QPushButton::clicked, this, &QDialog::accept);
   QObject::connect(ui_->loadCaptureWidget, &LoadCaptureWidget::FileSelected, this,
                    [this](std::filesystem::path path) { selected_file_path_ = std::move(path); });
   QObject::connect(ui_->loadCaptureWidget, &LoadCaptureWidget::SelectionConfirmed, this,
+                   &QDialog::accept);
+  QObject::connect(ui_->processListWidget, &ProcessListWidget::ProcessSelected, ui_->targetLabel,
+                   qOverload<const ProcessInfo&>(&TargetLabel::ChangeToLocalTarget));
+  QObject::connect(ui_->processListWidget, &ProcessListWidget::NoSelection, ui_->targetLabel,
+                   &TargetLabel::Clear);
+  QObject::connect(ui_->processListWidget, &ProcessListWidget::ProcessConfirmed, this,
                    &QDialog::accept);
 
   button_group_.addButton(ui_->localProfilingWidget->GetRadioButton());
@@ -122,7 +97,10 @@ SessionSetupDialog::SessionSetupDialog(SshConnectionArtifacts* ssh_connection_ar
   } else {
     state_machine_.setInitialState(&state_local_);
     ui_->localProfilingWidget->GetRadioButton()->setChecked(true);
+    ui_->processListWidget->SetNameToSelect(absl::GetFlag(FLAGS_process_name));
   }
+
+  qRegisterMetaType<std::vector<ProcessInfo>>("std::vector<orbit_grpc_protos::ProcessInfo>");
 }
 
 SessionSetupDialog::~SessionSetupDialog() = default;
@@ -130,25 +108,16 @@ SessionSetupDialog::~SessionSetupDialog() = default;
 std::optional<TargetConfiguration> SessionSetupDialog::Exec() {
   state_machine_.start();
 
-  if (process_manager_ != nullptr) {
-    process_manager_->SetProcessListUpdateListener(
-        [this](std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
-          OnProcessListUpdate(std::move(process_list));
-        });
-  }
-
   int rc = QDialog::exec();
   state_machine_.stop();
 
   if (rc != QDialog::Accepted) return std::nullopt;
 
-  if (process_manager_ != nullptr) {
-    process_manager_->SetProcessListUpdateListener(nullptr);
-  }
-
   if (state_machine_.configuration().contains(&state_local_)) {
-    return LocalTarget(ui_->localProfilingWidget->TakeConnection(), std::move(process_manager_),
-                       std::move(process_));
+    std::optional<ProcessInfo> process_info_opt = ui_->processListWidget->GetSelectedProcess();
+    ORBIT_CHECK(process_info_opt.has_value());
+    return LocalTarget(ui_->localProfilingWidget->TakeConnection(),
+                       std::make_unique<orbit_client_data::ProcessData>(process_info_opt.value()));
   } else if (state_machine_.configuration().contains(&state_file_)) {
     return FileTarget(selected_file_path_);
   } else {
@@ -157,25 +126,11 @@ std::optional<TargetConfiguration> SessionSetupDialog::Exec() {
   }
 }
 
-void SessionSetupDialog::ProcessSelectionChanged(const QModelIndex& current) {
-  emit NoProcessSelected();
-
-  if (!current.isValid()) {
-    process_ = nullptr;
-    return;
-  }
-
-  ORBIT_CHECK(current.data(Qt::UserRole).canConvert<const ProcessInfo*>());
-  process_ = std::make_unique<orbit_client_data::ProcessData>(
-      *current.data(Qt::UserRole).value<const ProcessInfo*>());
-  emit ProcessSelected();
-}
-
 void SessionSetupDialog::SetupLocalStates() {
   // Setup initial and default
   state_local_.setInitialState(&state_local_connecting_);
   state_local_history_.setDefaultState(&state_local_connecting_);
-  state_local_connected_.setInitialState(&state_local_processes_loading_);
+  state_local_connected_.setInitialState(&state_local_no_process_selected_);
 
   // PROPERTIES
   // STATE state_local_
@@ -183,15 +138,6 @@ void SessionSetupDialog::SetupLocalStates() {
   state_local_.assignProperty(
       ui_->confirmButton, "toolTip",
       "Please have a OrbitService run on the local machine and select a process.");
-
-  // STATE state_local_connecting
-  state_local_connecting_.assignProperty(ui_->processesFrame, "enabled", false);
-
-  // STATE state_local_processes_loading_
-  state_local_processes_loading_.assignProperty(ui_->processesTableOverlay, "visible", true);
-  state_local_processes_loading_.assignProperty(ui_->processesTableOverlay, "cancelable", false);
-  state_local_processes_loading_.assignProperty(ui_->processesTableOverlay, "statusMessage",
-                                                "Loading processes...");
 
   // STATE state_local_process_selected_
   state_local_process_selected_.assignProperty(ui_->confirmButton, "enabled", true);
@@ -210,27 +156,17 @@ void SessionSetupDialog::SetupLocalStates() {
   state_local_connected_.addTransition(
       ui_->localProfilingWidget, &ConnectToLocalWidget::Disconnected, &state_local_connecting_);
   QObject::connect(&state_local_connected_, &QState::entered, this,
-                   &SessionSetupDialog::SetupLocalProcessManager);
+                   &SessionSetupDialog::ConnectLocalAndProcessWidget);
   QObject::connect(&state_local_connected_, &QState::exited, this,
-                   &SessionSetupDialog::TearDownProcessManager);
-
-  // STATE state_local_processes_loading_
-  state_local_processes_loading_.addTransition(this, &SessionSetupDialog::ProcessSelected,
-                                               &state_local_process_selected_);
+                   &SessionSetupDialog::DisconnectLocalAndProcessWidget);
 
   // STATE state_local_no_process_selected_
-  state_local_no_process_selected_.addTransition(this, &SessionSetupDialog::ProcessSelected,
-                                                 &state_local_process_selected_);
+  state_local_no_process_selected_.addTransition(
+      ui_->processListWidget, &ProcessListWidget::ProcessSelected, &state_local_process_selected_);
 
   // STATE state_local_process_selected_
-  state_local_process_selected_.addTransition(this, &SessionSetupDialog::NoProcessSelected,
-                                              &state_local_no_process_selected_);
-  QObject::connect(&state_local_process_selected_, &QState::entered, this, [this] {
-    ORBIT_CHECK(process_ != nullptr);
-    ui_->targetLabel->ChangeToLocalTarget(*process_);
-  });
-  QObject::connect(&state_local_process_selected_, &QState::exited, ui_->targetLabel,
-                   &TargetLabel::Clear);
+  state_local_process_selected_.addTransition(
+      ui_->processListWidget, &ProcessListWidget::NoSelection, &state_local_no_process_selected_);
 }
 
 void SessionSetupDialog::SetupFileStates() {
@@ -242,7 +178,7 @@ void SessionSetupDialog::SetupFileStates() {
   // STATE state_file_
   state_file_.assignProperty(ui_->confirmButton, "enabled", false);
   state_file_.assignProperty(ui_->confirmButton, "toolTip", "Please select a capture to load");
-  state_file_.assignProperty(ui_->processesFrame, "enabled", false);
+  state_file_.assignProperty(ui_->processListWidget, "enabled", false);
 
   // STATE state_file_selected_
   state_file_selected_.assignProperty(ui_->confirmButton, "enabled", true);
@@ -261,96 +197,15 @@ void SessionSetupDialog::SetupFileStates() {
   QObject::connect(&state_file_selected_, &QState::exited, ui_->targetLabel, &TargetLabel::Clear);
 }
 
-void SessionSetupDialog::TearDownProcessManager() {
-  process_model_.Clear();
-
-  if (process_manager_ != nullptr) {
-    process_manager_.reset();
-  }
+void SessionSetupDialog::ConnectLocalAndProcessWidget() {
+  QObject::connect(ui_->localProfilingWidget, &ConnectToLocalWidget::ProcessListUpdated,
+                   ui_->processListWidget, &ProcessListWidget::UpdateList);
 }
 
-void SessionSetupDialog::SetupProcessManager(const std::shared_ptr<grpc::Channel>& grpc_channel) {
-  ORBIT_CHECK(grpc_channel != nullptr);
-
-  if (process_manager_ != nullptr) return;
-
-  process_manager_ =
-      orbit_client_services::ProcessManager::Create(grpc_channel, absl::Milliseconds(1000));
-  process_manager_->SetProcessListUpdateListener(
-      [this](std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
-        OnProcessListUpdate(std::move(process_list));
-      });
-}
-
-bool SessionSetupDialog::TrySelectProcessByName(const std::string& process_name) {
-  QModelIndexList matches = process_proxy_model_.match(
-      process_proxy_model_.index(0, static_cast<int>(ProcessItemModel::Column::kName)),
-      Qt::DisplayRole, QVariant::fromValue(QString::fromStdString(process_name)));
-
-  if (matches.isEmpty()) return false;
-
-  ui_->processesTableView->selectionModel()->setCurrentIndex(
-      matches[0], {QItemSelectionModel::SelectCurrent, QItemSelectionModel::Rows});
-  return true;
-}
-
-void SessionSetupDialog::OnProcessListUpdate(
-    std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
-  QMetaObject::invokeMethod(this, [this, process_list = std::move(process_list)]() {
-    bool had_processes_before = process_model_.HasProcesses();
-    process_model_.SetProcesses(process_list);
-    emit ProcessListUpdated();
-
-    // In case there is a selection already, do not change anything, only update the cpu usage
-    if (ui_->processesTableView->selectionModel()->hasSelection()) {
-      const uint32_t selected_process_id = ui_->processesTableView->selectionModel()
-                                               ->selectedRows()[0]
-                                               .data(Qt::UserRole)
-                                               .value<const ProcessInfo*>()
-                                               ->pid();
-      const auto it =
-          std::find_if(process_list.begin(), process_list.end(),
-                       [&](const auto& process) { return process.pid() == selected_process_id; });
-      if (it != process_list.end()) {
-        ui_->targetLabel->SetProcessCpuUsageInPercent(it->cpu_usage());
-      }
-      return;
-    }
-
-    // If process_ != nullptr here, that means it has been moved into the SessionSetupDialog and
-    // the user was using this process before. TrySelectProcessByName attempts to select the process
-    // again if it exists in process_model_.
-    if (process_ != nullptr) {
-      bool success = TrySelectProcessByName(process_->name());
-      if (success) {
-        ORBIT_LOG("Selected remembered process with name: %s", process_->name());
-        return;
-      }
-    }
-
-    if (!absl::GetFlag(FLAGS_process_name).empty()) {
-      bool success = TrySelectProcessByName(absl::GetFlag(FLAGS_process_name));
-      if (success) {
-        ORBIT_LOG("Selected process with name: %s (provided via --process_name flag)",
-                  absl::GetFlag(FLAGS_process_name));
-        accept();
-        return;
-      }
-    }
-
-    // The first time a list of processes arrives, the cpu utilization values are not valid, since
-    // they are computed as an average since the last time the list was refreshed. Hence return here
-    // and do not perform a selection.
-    if (!had_processes_before) return;
-
-    // This selects the first (top most) row. The table is sorted by cpu usage (%) by default, so
-    // unless the user changed the sorting, this will select the process with the highest cpu load
-    ui_->processesTableView->selectRow(0);
-  });
-}
-
-void SessionSetupDialog::SetupLocalProcessManager() {
-  SetupProcessManager(ui_->localProfilingWidget->GetGrpcChannel());
+void SessionSetupDialog::DisconnectLocalAndProcessWidget() {
+  ui_->processListWidget->Clear();
+  QObject::disconnect(ui_->localProfilingWidget, &ConnectToLocalWidget::ProcessListUpdated,
+                      ui_->processListWidget, &ProcessListWidget::UpdateList);
 }
 
 void SessionSetupDialog::SetTargetAndStateMachineInitialState(SshTarget /*target*/) {
@@ -358,10 +213,9 @@ void SessionSetupDialog::SetTargetAndStateMachineInitialState(SshTarget /*target
 }
 
 void SessionSetupDialog::SetTargetAndStateMachineInitialState(LocalTarget target) {
+  ui_->processListWidget->SetNameToSelect(target.process_->name());
   ui_->localProfilingWidget->SetConnection(std::move(target.connection_));
-
-  process_manager_ = std::move(target.process_manager_);
-  process_ = std::move(target.process_);
+  ui_->localProfilingWidget->GetRadioButton()->setChecked(true);
 
   state_local_.setInitialState(&state_local_connected_);
   state_local_history_.setDefaultState(&state_local_connected_);
@@ -369,6 +223,7 @@ void SessionSetupDialog::SetTargetAndStateMachineInitialState(LocalTarget target
 }
 
 void SessionSetupDialog::SetTargetAndStateMachineInitialState(FileTarget target) {
+  ui_->loadCaptureWidget->GetRadioButton()->setChecked(true);
   selected_file_path_ = target.GetCaptureFilePath();
   state_file_.setInitialState(&state_file_selected_);
   state_file_history_.setDefaultState(&state_file_selected_);

--- a/src/SessionSetup/SessionSetupDialog.ui
+++ b/src/SessionSetup/SessionSetupDialog.ui
@@ -41,6 +41,9 @@
    </property>
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout_4" stretch="1,0">
+     <property name="spacing">
+      <number>0</number>
+     </property>
      <property name="leftMargin">
       <number>0</number>
      </property>
@@ -74,11 +77,8 @@
         <property name="lineWidth">
          <number>0</number>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,1">
+        <layout class="QVBoxLayout" name="verticalLayout">
          <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -89,137 +89,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QFrame" name="frame_4">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>2</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <property name="lineWidth">
-         <number>0</number>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>9</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QFrame" name="processesFrame">
-           <property name="accessibleName">
-            <string>ProcessesFrame</string>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_3">
-            <item>
-             <widget class="QLabel" name="selectProcessLabel">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>23</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Select a process</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="processFilterLineEdit">
-              <property name="accessibleName">
-               <string>FilterProcesses</string>
-              </property>
-              <property name="placeholderText">
-               <string>Filter</string>
-              </property>
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QFrame" name="frame2">
-              <layout class="QVBoxLayout" name="verticalLayout_2">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QTableView" name="processesTableView">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="focusPolicy">
-                  <enum>Qt::NoFocus</enum>
-                 </property>
-                 <property name="accessibleName">
-                  <string>ProcessList</string>
-                 </property>
-                 <property name="alternatingRowColors">
-                  <bool>true</bool>
-                 </property>
-                 <property name="selectionMode">
-                  <enum>QAbstractItemView::SingleSelection</enum>
-                 </property>
-                 <property name="selectionBehavior">
-                  <enum>QAbstractItemView::SelectRows</enum>
-                 </property>
-                 <property name="showGrid">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-              <widget class="orbit_session_setup::OverlayWidget" name="processesTableOverlay" native="true">
-               <property name="geometry">
-                <rect>
-                 <x>0</x>
-                 <y>0</y>
-                 <width>100</width>
-                 <height>30</height>
-                </rect>
-               </property>
-               <property name="visible">
-                <bool>false</bool>
-               </property>
-               <property name="accessibleName">
-                <string>ProcessListOverlay</string>
-               </property>
-              </widget>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+       <widget class="orbit_session_setup::ProcessListWidget" name="processListWidget" native="true"/>
       </widget>
      </item>
      <item>
@@ -269,12 +139,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>orbit_session_setup::OverlayWidget</class>
-   <extends>QWidget</extends>
-   <header>SessionSetup/OverlayWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>orbit_session_setup::LoadCaptureWidget</class>
    <extends>QWidget</extends>
    <header>SessionSetup/LoadCaptureWidget.h</header>
@@ -289,26 +153,14 @@
    <extends>QWidget</extends>
    <header>SessionSetup/ConnectToLocalWidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>orbit_session_setup::ProcessListWidget</class>
+   <extends>QWidget</extends>
+   <header>SessionSetup/ProcessListWidget.h</header>
+  </customwidget>
  </customwidgets>
  <resources>
   <include location="../../icons/orbiticons.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>processFilterLineEdit</sender>
-   <signal>returnPressed()</signal>
-   <receiver>confirmButton</receiver>
-   <slot>click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1106</x>
-     <y>64</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>1229</x>
-     <y>693</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -149,6 +149,10 @@ void TargetLabel::ChangeToLocalTarget(const orbit_client_data::ProcessData& proc
   ChangeToLocalTarget(QString::fromStdString(process.name()), process.cpu_usage());
 }
 
+void TargetLabel::ChangeToLocalTarget(const orbit_grpc_protos::ProcessInfo& process_info) {
+  ChangeToLocalTarget(QString::fromStdString(process_info.name()), process_info.cpu_usage());
+}
+
 void TargetLabel::ChangeToLocalTarget(const QString& process_name, double cpu_usage) {
   Clear();
   process_ = process_name;

--- a/src/SessionSetup/include/SessionSetup/ConnectToLocalWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToLocalWidget.h
@@ -11,11 +11,11 @@
 #include <QRadioButton>
 #include <QString>
 #include <QTimer>
+#include <QVector>
 #include <QWidget>
 #include <functional>
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "GrpcProtos/process.pb.h"
 #include "OrbitBase/Result.h"
@@ -57,7 +57,7 @@ class ConnectToLocalWidget : public QWidget {
  signals:
   void Connected();
   void Disconnected();
-  void ProcessListUpdated(std::vector<orbit_grpc_protos::ProcessInfo> process_list);
+  void ProcessListUpdated(QVector<orbit_grpc_protos::ProcessInfo> process_list);
 
  private:
   std::unique_ptr<Ui::ConnectToLocalWidget> ui_;

--- a/src/SessionSetup/include/SessionSetup/ConnectToLocalWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToLocalWidget.h
@@ -15,6 +15,7 @@
 #include <functional>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "GrpcProtos/process.pb.h"
 #include "OrbitBase/Result.h"
@@ -44,7 +45,7 @@ class ConnectToLocalWidget : public QWidget {
 
   void SetOrbitServiceInstanceCreateFunction(OrbitServiceInstanceCreator&& creator);
 
-  void SetConnection(LocalConnection&& connection) { local_connection_ = std::move(connection); }
+  void SetConnection(LocalConnection&& connection);
   [[nodiscard]] LocalConnection&& TakeConnection() { return std::move(local_connection_); }
 
   [[nodiscard]] const std::shared_ptr<grpc::Channel>& GetGrpcChannel() const {
@@ -56,6 +57,7 @@ class ConnectToLocalWidget : public QWidget {
  signals:
   void Connected();
   void Disconnected();
+  void ProcessListUpdated(std::vector<orbit_grpc_protos::ProcessInfo> process_list);
 
  private:
   std::unique_ptr<Ui::ConnectToLocalWidget> ui_;
@@ -64,6 +66,8 @@ class ConnectToLocalWidget : public QWidget {
   QTimer check_connection_timer_;
 
   void OnStartOrbitServiceButtonClicked();
+  void CheckAndSignalConnection();
+  void SetupProcessListUpdater();
 };
 
 }  // namespace orbit_session_setup

--- a/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
@@ -49,7 +49,6 @@ class ConnectToTargetDialog : public QDialog {
   std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> main_thread_executor_;
 
   std::optional<orbit_session_setup::SshConnection> ssh_connection_;
-  std::unique_ptr<orbit_client_services::ProcessManager> process_manager_;
   std::optional<TargetConfiguration> target_configuration_;
 
   void OnProcessListUpdate(std::vector<orbit_grpc_protos::ProcessInfo> process_list);

--- a/src/SessionSetup/include/SessionSetup/ProcessItemModel.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessItemModel.h
@@ -42,5 +42,6 @@ class ProcessItemModel : public QAbstractItemModel {
 }  // namespace orbit_session_setup
 
 Q_DECLARE_METATYPE(const orbit_grpc_protos::ProcessInfo*);
+Q_DECLARE_METATYPE(orbit_grpc_protos::ProcessInfo);
 
 #endif  // SESSION_SETUP_PROCESS_ITEM_MODEL_H_

--- a/src/SessionSetup/include/SessionSetup/ProcessItemModel.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessItemModel.h
@@ -10,8 +10,8 @@
 #include <QObject>
 #include <QString>
 #include <QVariant>
+#include <QVector>
 #include <QtCore>
-#include <vector>
 
 #include "GrpcProtos/process.pb.h"
 
@@ -31,17 +31,16 @@ class ProcessItemModel : public QAbstractItemModel {
   [[nodiscard]] QModelIndex parent(const QModelIndex& parent) const override;
   [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override;
 
-  void SetProcesses(std::vector<orbit_grpc_protos::ProcessInfo> processes);
+  void SetProcesses(QVector<orbit_grpc_protos::ProcessInfo> processes);
   [[nodiscard]] bool HasProcesses() const { return !processes_.empty(); }
   void Clear() { SetProcesses({}); }
 
  private:
-  std::vector<orbit_grpc_protos::ProcessInfo> processes_;
+  QVector<orbit_grpc_protos::ProcessInfo> processes_;
 };
 
 }  // namespace orbit_session_setup
 
 Q_DECLARE_METATYPE(const orbit_grpc_protos::ProcessInfo*);
-Q_DECLARE_METATYPE(orbit_grpc_protos::ProcessInfo);
 
 #endif  // SESSION_SETUP_PROCESS_ITEM_MODEL_H_

--- a/src/SessionSetup/include/SessionSetup/ProcessListWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessListWidget.h
@@ -27,22 +27,27 @@ class ProcessListWidget : public QWidget {
   explicit ProcessListWidget(QWidget* parent = nullptr);
   ~ProcessListWidget() noexcept override;
 
-  void SetNameToSelect(std::string name) { name_to_select_ = std::move(name); }
-  std::optional<orbit_grpc_protos::ProcessInfo> GetSelectedProcess();
+  // `SetProcessNameToSelect` saves a process name that will be selected after the process list is
+  // filled for the first time (via `UpdateList`). This selection also happens when the process list
+  // was cleared (via `Clear`) and is then updated (via `UpdateList`). A call to
+  // `SetProcessNameToSelect` will not clear the selection a user made via the UI.
+  void SetProcessNameToSelect(std::string name) { name_to_select_ = std::move(name); }
+  [[nodiscard]] std::optional<orbit_grpc_protos::ProcessInfo> GetSelectedProcess() const;
 
- public slots:
   void Clear();
-  void UpdateList(std::vector<orbit_grpc_protos::ProcessInfo> list);
+  void UpdateList(QVector<orbit_grpc_protos::ProcessInfo> list);
 
  signals:
-  void NoSelection();
+  void ProcessSelectionCleared();
+  // `ProcessSelected` is emitted when the user selects a process in the UI and after each call to
+  // `UpdateList` when a valid selection exists.
   void ProcessSelected(orbit_grpc_protos::ProcessInfo process_info);
   // `ProcessConfirmed` is emitted when the user confirms the selection from the widget via a double
   // click onto the selected process.
-  void ProcessConfirmed();
+  void ProcessConfirmed(orbit_grpc_protos::ProcessInfo process_info);
 
  private:
-  void SelectionChanged(const QModelIndex& index);
+  void HandleSelectionChanged(const QModelIndex& index);
   bool TrySelectProcessByName(const std::string& process_name);
   void TryConfirm();
 
@@ -53,5 +58,7 @@ class ProcessListWidget : public QWidget {
 };
 
 }  // namespace orbit_session_setup
+
+Q_DECLARE_METATYPE(orbit_grpc_protos::ProcessInfo);
 
 #endif  // SESSION_SETUP_PROCESS_LIST_WIDGET_H_

--- a/src/SessionSetup/include/SessionSetup/ProcessListWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessListWidget.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SESSION_SETUP_PROCESS_LIST_WIDGET_H_
+#define SESSION_SETUP_PROCESS_LIST_WIDGET_H_
+
+#include <QModelIndex>
+#include <QSortFilterProxyModel>
+#include <QWidget>
+#include <memory>
+#include <optional>
+
+#include "GrpcProtos/process.pb.h"
+#include "SessionSetup/ProcessItemModel.h"
+
+namespace Ui {
+class ProcessListWidget;
+}
+
+namespace orbit_session_setup {
+
+class ProcessListWidget : public QWidget {
+  Q_OBJECT
+
+ public:
+  explicit ProcessListWidget(QWidget* parent = nullptr);
+  ~ProcessListWidget() noexcept override;
+
+  void SetNameToSelect(std::string name) { name_to_select_ = std::move(name); }
+  std::optional<orbit_grpc_protos::ProcessInfo> GetSelectedProcess();
+
+ public slots:
+  void Clear();
+  void UpdateList(std::vector<orbit_grpc_protos::ProcessInfo> list);
+
+ signals:
+  void NoSelection();
+  void ProcessSelected(orbit_grpc_protos::ProcessInfo process_info);
+  // `ProcessConfirmed` is emitted when the user confirms the selection from the widget via a double
+  // click onto the selected process.
+  void ProcessConfirmed();
+
+ private:
+  void SelectionChanged(const QModelIndex& index);
+  bool TrySelectProcessByName(const std::string& process_name);
+  void TryConfirm();
+
+  std::unique_ptr<Ui::ProcessListWidget> ui_;
+  ProcessItemModel model_;
+  QSortFilterProxyModel proxy_model_;
+  std::string name_to_select_;
+};
+
+}  // namespace orbit_session_setup
+
+#endif  // SESSION_SETUP_PROCESS_LIST_WIDGET_H_

--- a/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
@@ -24,11 +24,8 @@
 #include <string>
 #include <vector>
 
-#include "ClientData/ProcessData.h"
-#include "ClientServices/ProcessManager.h"
 #include "Connections.h"
 #include "GrpcProtos/process.pb.h"
-#include "ProcessItemModel.h"
 #include "TargetConfiguration.h"
 
 namespace Ui {
@@ -47,9 +44,8 @@ class SessionSetupDialog : public QDialog {
 
   [[nodiscard]] std::optional<TargetConfiguration> Exec();
  private slots:
-  void SetupLocalProcessManager();
-  void TearDownProcessManager();
-  void ProcessSelectionChanged(const QModelIndex& current);
+  void ConnectLocalAndProcessWidget();
+  void DisconnectLocalAndProcessWidget();
 
  signals:
   void ProcessSelected();
@@ -59,12 +55,6 @@ class SessionSetupDialog : public QDialog {
  private:
   std::unique_ptr<Ui::SessionSetupDialog> ui_;
   QButtonGroup button_group_;
-
-  ProcessItemModel process_model_;
-  QSortFilterProxyModel process_proxy_model_;
-
-  std::unique_ptr<orbit_client_data::ProcessData> process_;
-  std::unique_ptr<orbit_client_services::ProcessManager> process_manager_;
 
   std::filesystem::path selected_file_path_;
 
@@ -80,15 +70,11 @@ class SessionSetupDialog : public QDialog {
   QHistoryState state_local_history_;
   QState state_local_connecting_;
   QState state_local_connected_;
-  QState state_local_processes_loading_;
-  QState state_local_process_selected_;
   QState state_local_no_process_selected_;
+  QState state_local_process_selected_;
 
   void SetupFileStates();
   void SetupLocalStates();
-  [[nodiscard]] bool TrySelectProcessByName(const std::string& process_name);
-  void OnProcessListUpdate(std::vector<orbit_grpc_protos::ProcessInfo> process_list);
-  void SetupProcessManager(const std::shared_ptr<grpc::Channel>& grpc_channel);
   void SetTargetAndStateMachineInitialState(SshTarget target);
   void SetTargetAndStateMachineInitialState(LocalTarget target);
   void SetTargetAndStateMachineInitialState(FileTarget target);

--- a/src/SessionSetup/include/SessionSetup/TargetConfiguration.h
+++ b/src/SessionSetup/include/SessionSetup/TargetConfiguration.h
@@ -24,23 +24,15 @@ class SshTarget {
 
  public:
   explicit SshTarget(SshConnection&& connection,
-                     std::unique_ptr<orbit_client_services::ProcessManager> process_manager,
                      std::unique_ptr<orbit_client_data::ProcessData> process)
-      : connection_(std::move(connection)),
-        process_manager_(std::move(process_manager)),
-        process_(std::move(process)) {
-    ORBIT_CHECK(process_manager_ != nullptr);
+      : connection_(std::move(connection)), process_(std::move(process)) {
     ORBIT_CHECK(process_ != nullptr);
   }
   [[nodiscard]] const SshConnection* GetConnection() const { return &connection_; }
-  [[nodiscard]] orbit_client_services::ProcessManager* GetProcessManager() const {
-    return process_manager_.get();
-  }
   [[nodiscard]] orbit_client_data::ProcessData* GetProcess() const { return process_.get(); }
 
  private:
   SshConnection connection_;
-  std::unique_ptr<orbit_client_services::ProcessManager> process_manager_;
   std::unique_ptr<orbit_client_data::ProcessData> process_;
 };
 
@@ -56,23 +48,15 @@ class LocalTarget {
 
  public:
   explicit LocalTarget(LocalConnection&& connection,
-                       std::unique_ptr<orbit_client_services::ProcessManager> process_manager,
                        std::unique_ptr<orbit_client_data::ProcessData> process)
-      : connection_(std::move(connection)),
-        process_manager_(std::move(process_manager)),
-        process_(std::move(process)) {
-    ORBIT_CHECK(process_manager_ != nullptr);
+      : connection_(std::move(connection)), process_(std::move(process)) {
     ORBIT_CHECK(process_ != nullptr);
   }
   [[nodiscard]] const LocalConnection* GetConnection() const { return &connection_; }
-  [[nodiscard]] orbit_client_services::ProcessManager* GetProcessManager() const {
-    return process_manager_.get();
-  }
   [[nodiscard]] orbit_client_data::ProcessData* GetProcess() const { return process_.get(); }
 
  private:
   LocalConnection connection_;
-  std::unique_ptr<orbit_client_services::ProcessManager> process_manager_;
   std::unique_ptr<orbit_client_data::ProcessData> process_;
 };
 

--- a/src/SessionSetup/include/SessionSetup/TargetLabel.h
+++ b/src/SessionSetup/include/SessionSetup/TargetLabel.h
@@ -14,6 +14,7 @@
 #include <optional>
 
 #include "ClientData/ProcessData.h"
+#include "GrpcProtos/process.pb.h"
 #include "TargetConfiguration.h"
 
 namespace Ui {
@@ -36,6 +37,7 @@ class TargetLabel : public QWidget {
                          const std::string& ssh_target_id);
   void ChangeToLocalTarget(const LocalTarget& local_target);
   void ChangeToLocalTarget(const orbit_client_data::ProcessData& process);
+  void ChangeToLocalTarget(const orbit_grpc_protos::ProcessInfo& process_info);
   void ChangeToLocalTarget(const QString& process_name, double cpu_usage);
 
   bool SetProcessCpuUsageInPercent(double cpu_usage);


### PR DESCRIPTION
This integrates ProcessListWidget into SessionSetupDialog, replacing/ moving functionality away from SessionSetupDialog. Then ProcessManager is moved from TargetConfiguration.h into Connections.h, which results in changes to orbitmainwindow, ConnectToLocalWidget and ConnectToTargetDialog. One of the changes to ConnectToLocalWidget is, that now a signal is emitted when a new process list is available.

---
Sorry for this being one big PR. Usually I would have split this up in more reviewable chunks, but I am too lazy/running a bit out of time. 

This does not change the UI from a user perspective. I thought about attaching a screenshot, but it looks exactly as before. 

Regarding testing: I played around quite a bit and tried to do all the obvious things: Reuse connections (end session), kill OrbitService, switch between local profiling and capture from file. Of course this does not mean there can't be any bugs, but I am fairly confident. 

Next step: Widget for ssh connection (wip)