### PR TITLE
Make OrbitQt "STATIC" rather "OBJECT"

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 project(OrbitQt CXX)
 
-add_library(OrbitQt OBJECT)
+add_library(OrbitQt STATIC)
 
 target_sources(
   OrbitQt


### PR DESCRIPTION
This fixes linking errors on Windows with Ninja and AUTOMOC.

Test: Build on Windows