### PR TITLE
Disable some tests on Windows

### DIFF
--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -595,6 +595,9 @@ TEST(ElfFile, GetDeclarationLocationOfFunction) {
 }
 
 TEST(ElfFile, GetDeclarationLocationOfFunctionLibc) {
+#ifdef _WIN32
+  GTEST_SKIP();
+#endif
   const std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libc.debug";
 
   auto program = CreateElfFile(file_path);
@@ -611,6 +614,9 @@ TEST(ElfFile, GetDeclarationLocationOfFunctionLibc) {
 }
 
 TEST(ElfFile, GetLocationOfFunctionLibc) {
+#ifdef _WIN32
+  GTEST_SKIP();
+#endif
   const std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libc.debug";
 
   auto program = CreateElfFile(file_path);
@@ -627,6 +633,9 @@ TEST(ElfFile, GetLocationOfFunctionLibc) {
 }
 
 TEST(ElfFile, GetLocationOfFunctionNoSubroutine) {
+#ifdef _WIN32
+  GTEST_SKIP();
+#endif
   const std::filesystem::path file_path = orbit_test::GetTestdataDir() / "libc.debug";
 
   auto program = CreateElfFile(file_path);

--- a/src/ObjectUtils/ElfFileTest.cpp
+++ b/src/ObjectUtils/ElfFileTest.cpp
@@ -595,6 +595,7 @@ TEST(ElfFile, GetDeclarationLocationOfFunction) {
 }
 
 TEST(ElfFile, GetDeclarationLocationOfFunctionLibc) {
+// TODO(https://github.com/google/orbit/issues/4502): Enable test again.
 #ifdef _WIN32
   GTEST_SKIP();
 #endif
@@ -614,6 +615,7 @@ TEST(ElfFile, GetDeclarationLocationOfFunctionLibc) {
 }
 
 TEST(ElfFile, GetLocationOfFunctionLibc) {
+// TODO(https://github.com/google/orbit/issues/4502): Enable test again.
 #ifdef _WIN32
   GTEST_SKIP();
 #endif
@@ -633,6 +635,7 @@ TEST(ElfFile, GetLocationOfFunctionLibc) {
 }
 
 TEST(ElfFile, GetLocationOfFunctionNoSubroutine) {
+// TODO(https://github.com/google/orbit/issues/4502): Enable test again.
 #ifdef _WIN32
   GTEST_SKIP();
 #endif

--- a/src/WindowsUtils/ProcessLauncherTest.cpp
+++ b/src/WindowsUtils/ProcessLauncherTest.cpp
@@ -35,6 +35,7 @@ TEST(ProcessLauncher, LaunchProcess) {
 }
 
 TEST(ProcessLauncher, LaunchSuspendResumeProcess) {
+// TODO(https://github.com/google/orbit/issues/4503): Enable test again.
 #ifdef _WIN32
   GTEST_SKIP();
 #endif

--- a/src/WindowsUtils/ProcessLauncherTest.cpp
+++ b/src/WindowsUtils/ProcessLauncherTest.cpp
@@ -35,6 +35,9 @@ TEST(ProcessLauncher, LaunchProcess) {
 }
 
 TEST(ProcessLauncher, LaunchSuspendResumeProcess) {
+#ifdef _WIN32
+  GTEST_SKIP();
+#endif
   ProcessLauncher launcher;
   auto launch_result =
       launcher.LaunchProcess(GetTestExecutablePath(), /*working_directory=*/"", /*arguments=*/"",


### PR DESCRIPTION
Due to #4502 and #4503, some tests are failing on Windows. This change disables the effected tests (until a proper fix is done), such that we can setup the Windows ci.

Test: Build & Run tests