### PR TITLE
Fix book keeping in ModuleData

### DIFF
--- a/src/ClientData/ModuleData.cpp
+++ b/src/ClientData/ModuleData.cpp
@@ -138,6 +138,7 @@ bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo new_module_info) {
             module_info_.file_path());
   functions_.clear();
   hash_to_function_map_.clear();
+  name_to_function_info_map_.clear();
   loaded_symbols_completeness_ = SymbolCompleteness::kNoSymbols;
 
   return true;
@@ -235,6 +236,7 @@ void ModuleData::AddSymbolsInternal(const orbit_grpc_protos::ModuleSymbols& modu
   ORBIT_CHECK(loaded_symbols_completeness_ < completeness);
   functions_.clear();
   hash_to_function_map_.clear();
+  name_to_function_info_map_.clear();
 
   uint32_t address_reuse_counter = 0;
   uint32_t name_reuse_counter = 0;


### PR DESCRIPTION
`name_to_function_info_map_` is a lookup table into `functions_` - similar to `hash_to_function_info_map_`.

But the former was not properly cleared when `functions_` got cleared. This is particularly a problem because `name_to_function_into_map_` uses `std::string_view` as keys with string data living in `functions_`.

This was found using Address and UB Sanitizer™.