### PR TITLE
Fix ownership in CodeViewer

### DIFF
--- a/src/CodeViewer/ViewerTest.cpp
+++ b/src/CodeViewer/ViewerTest.cpp
@@ -293,11 +293,15 @@ TEST(Viewer, Smoke) {
   QApplication::processEvents();
 
   // We also send a wheel event to trigger the scaling code.
-  auto wheel_event = std::make_unique<QWheelEvent>(
-      QPointF{viewer.geometry().center()}, QPointF{viewer.geometry().center()}, QPoint{},
-      QPoint{42, 42}, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier,
-      Qt::NoScrollPhase, false);
-  QApplication::sendEvent(&viewer, wheel_event.release());
+  QWheelEvent wheel_event{QPointF{viewer.geometry().center()},
+                          QPointF{viewer.geometry().center()},
+                          QPoint{},
+                          QPoint{42, 42},
+                          Qt::MouseButton::NoButton,
+                          Qt::KeyboardModifier::NoModifier,
+                          Qt::NoScrollPhase,
+                          false};
+  QApplication::sendEvent(&viewer, &wheel_event);
 
   QApplication::processEvents();
 }


### PR DESCRIPTION
QApplication::sendEvent doesn't take ownership of the event because it doesn't need to (it's processed synchronously).

So the call to `unique_ptr::release` leads to a memory leak.

Solution: event on the stack and passed as a simple pointer to the stack value.

This problem was found using Address and UB Sanitizer™.