### PR TITLE
Fix memory leak in SymbolLocationsDialog

### DIFF
--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -242,6 +242,8 @@ void SymbolLocationsDialog::OnRemoveButtonClicked() {
       ORBIT_CHECK(module_symbol_file_mappings_.contains(mapping_item->module_file_path_));
       module_symbol_file_mappings_.erase(mapping_item->module_file_path_);
     }
+
+    // This object is managed by Qt. A "raw" delete is unavoidable.
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     delete selected_item;
   }

--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -242,7 +242,8 @@ void SymbolLocationsDialog::OnRemoveButtonClicked() {
       ORBIT_CHECK(module_symbol_file_mappings_.contains(mapping_item->module_file_path_));
       module_symbol_file_mappings_.erase(mapping_item->module_file_path_);
     }
-    ui_->listWidget->takeItem(ui_->listWidget->row(selected_item));
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    delete selected_item;
   }
 }
 


### PR DESCRIPTION
`QListWidget::takeItem` removes the item from the list and transfer ownership of the `QListWidgetItem` to the caller - similar to `unique_ptr::release`.

But that's not what we want here. We want to remove the item from the list and delete the object representing the item. According to Qt docs this is done by calling delete on the object.

This was found using Address und UB Sanitizer™.