### PR TITLE
Avoid intentional leak in MemoryWatchdogTest

### DIFF
--- a/src/LinuxCaptureService/MemoryWatchdogTest.cpp
+++ b/src/LinuxCaptureService/MemoryWatchdogTest.cpp
@@ -46,8 +46,9 @@ TEST(MemoryWatchdog, ExtractRssInPagesFromProcPidStatReturnsNulloptWhenRssIsNotP
 }
 
 static void IncreaseRss(uint64_t amount_words) {
-  // The memory leak is intended: if the test is run again in the same process (e.g., with
-  // --gtest_repeat) we want new memory to be allocated, not the previous one to be reused.
+  // The static storage of `allocations` is intended: if the test is run again in the same process
+  // (e.g., with --gtest_repeat) we want new memory to be allocated, not the previous one to be
+  // reused.
   static std::vector<std::unique_ptr<volatile uint64_t[]>> allocations;
   volatile uint64_t* ptr =
       allocations.emplace_back(std::make_unique<volatile uint64_t[]>(amount_words)).get();


### PR DESCRIPTION
Instead of calling malloc and leaking the memory (intentionally) the allocations are now put into a static storage variable, so that they are cleaned up when the application exits and the address sanitizer won't complain.