### PR TITLE
Fix segmentation fault in GpuTrackTest

### DIFF
--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -16,6 +16,7 @@
 #include "OrbitGl/OrbitApp.h"
 #include "OrbitGl/TimeGraphLayout.h"
 #include "OrbitGl/Viewport.h"
+#include "StringManager/StringManager.h"
 
 using orbit_client_protos::TimerInfo;
 
@@ -50,9 +51,10 @@ GpuTrack::GpuTrack(CaptureViewElement* parent, const orbit_gl::TimelineInfoInter
                    OrbitApp* app, const orbit_client_data::ModuleManager* module_manager,
                    const orbit_client_data::CaptureData* capture_data,
                    orbit_client_data::TimerData* submission_timer_data,
-                   orbit_client_data::TimerData* marker_timer_data)
+                   orbit_client_data::TimerData* marker_timer_data,
+                   orbit_string_manager::StringManager* string_manager)
     : Track(parent, timeline_info, viewport, layout, module_manager, capture_data),
-      string_manager_{app->GetStringManager()},
+      string_manager_{string_manager},
       submission_track_{std::make_shared<GpuSubmissionTrack>(this, timeline_info, viewport, layout,
                                                              timeline_hash, app, module_manager,
                                                              capture_data, submission_timer_data)},

--- a/src/OrbitGl/GpuTrackTest.cpp
+++ b/src/OrbitGl/GpuTrackTest.cpp
@@ -13,7 +13,7 @@ using orbit_gl::MapGpuTimelineToTrackLabel;
 TEST(GpuTrack, CaptureViewElementWorksAsIntended) {
   orbit_gl::CaptureViewElementTester tester;
   GpuTrack track = GpuTrack(nullptr, nullptr, tester.GetViewport(), tester.GetLayout(), 0, nullptr,
-                            nullptr, nullptr, nullptr, nullptr);
+                            nullptr, nullptr, nullptr, nullptr, nullptr);
   // Expect submission track, marker track, and collapse toggle
   EXPECT_EQ(3ull, track.GetAllChildren().size());
   tester.RunTests(&track);

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -480,9 +480,9 @@ GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
   if (track == nullptr) {
     auto [unused1, submission_timer_data] = capture_data_->CreateTimerData();
     auto [unused2, marker_timer_data] = capture_data_->CreateTimerData();
-    track = std::make_shared<GpuTrack>(track_container_, timeline_info_, viewport_, layout_,
-                                       timeline_hash, app_, module_manager_, capture_data_,
-                                       submission_timer_data, marker_timer_data);
+    track = std::make_shared<GpuTrack>(
+        track_container_, timeline_info_, viewport_, layout_, timeline_hash, app_, module_manager_,
+        capture_data_, submission_timer_data, marker_timer_data, app_->GetStringManager());
     gpu_tracks_[timeline] = track;
     AddTrack(track);
   }

--- a/src/OrbitGl/include/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/include/OrbitGl/GpuTrack.h
@@ -49,7 +49,8 @@ class GpuTrack : public Track {
                     OrbitApp* app, const orbit_client_data::ModuleManager* module_manager,
                     const orbit_client_data::CaptureData* capture_data,
                     orbit_client_data::TimerData* submission_timer_data,
-                    orbit_client_data::TimerData* marker_timer_data);
+                    orbit_client_data::TimerData* marker_timer_data,
+                    orbit_string_manager::StringManager* string_manager);
 
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info);
 


### PR DESCRIPTION
The GpuTrackTest instantiates a `GpuTrack` and has to provide a pointer to `OrbitApp` due to our legacy code structure. Since it is impossible to instantiate a `OrbitApp` in a unit test we pass in a nullptr (assuming the `OrbitApp` instance won't be used).

But that's not entirely true. `GpuTrack` calls `OrbitApp::GetStringManager` to get string manager instance. This leads to a segmentation fault in unoptimized builds.

The solution is to have a separate constructor argument for the string manager.