### PR TITLE
Avoid leak in ExecuteProcessTest

### DIFF
--- a/src/QtUtils/ExecuteProcessTest.cpp
+++ b/src/QtUtils/ExecuteProcessTest.cpp
@@ -374,7 +374,7 @@ TEST(QtUtilsExecuteProcess, TimeoutAndParentGetsDeletedRace) {
     QTimer::singleShot(5, QCoreApplication::instance(), &QCoreApplication::quit);
   });
 
-  QTimer::singleShot(100 /*ms*/, parent_object.get(), [&]() { parent_object.reset(); });
+  QTimer::singleShot(/*ms=*/100, parent_object.get(), [&]() { parent_object.reset(); });
 
   QCoreApplication::exec();
 


### PR DESCRIPTION
This avoids leaking `parent_object` by keeping it in a unique_ptr.

This has been found by Address and UB Sanitizer™.