### PR TITLE
Avoid use-after-free in QtUtils::EventLoop

### DIFF
--- a/src/QtUtils/include/QtUtils/EventLoop.h
+++ b/src/QtUtils/include/QtUtils/EventLoop.h
@@ -65,7 +65,6 @@ class EventLoop : public QObject {
   }
   bool isRunning() const { return loop_.isRunning(); }
   void wakeUp() { return loop_.wakeUp(); }
-  bool event(QEvent* event) { return loop_.event(event); }
 
   bool processEvents(ProcessEventsFlags flags = ProcessEventsFlag::AllEvents) {
     return loop_.processEvents(flags);


### PR DESCRIPTION
`EventLoop::event` is a virtual function (even though not properly marked) and might be called by the base class destructor when the `QEventLoop` member variable has already been destroyed.

To avoid this lifetime issue I just removed the override. It's not needed anyway and just gives us headaches.

This problem has been found by Address and UB Sanitizer™.