### PR TITLE
Avoid UB due to struct packing

### DIFF
--- a/src/UserSpaceInstrumentation/RegisterState.h
+++ b/src/UserSpaceInstrumentation/RegisterState.h
@@ -71,8 +71,8 @@ static_assert(sizeof(GeneralPurposeRegisters64) == 216,
               "GeneralPurposeRegisters64 is not 216 bytes of size");
 
 union GeneralPurposeRegisters {
-  GeneralPurposeRegisters64 x86_64;
   GeneralPurposeRegisters32 x86_32;
+  GeneralPurposeRegisters64 x86_64;
 };
 
 struct MmsAs80BitFloat {
@@ -82,11 +82,9 @@ struct MmsAs80BitFloat {
 static_assert(offsetof(MmsAs80BitFloat, sign_exp) == sizeof(MmsAs80BitFloat::mantissa),
               "MmsAs80BitFloat is not properly aligned.");
 
-struct MmsRegister {
-  union {
-    std::array<uint8_t, 10> bytes;
-    MmsAs80BitFloat as_float;
-  };
+union MmsRegister {
+  std::array<uint8_t, 10> bytes;
+  MmsAs80BitFloat as_float;
 };
 static_assert(sizeof(MmsRegister) == 16, "MmsRegister is not 16 bytes of size");
 

--- a/src/UserSpaceInstrumentation/RegisterState.h
+++ b/src/UserSpaceInstrumentation/RegisterState.h
@@ -16,13 +16,6 @@
 
 namespace orbit_user_space_instrumentation {
 
-// The structs below are defined to match the memory layout of the binary blobs containing the
-// register state of the cpu (as returned by the kernel). They should not used directly - see
-// comment on class "RegisterState" below.
-#define PACKED_START _Pragma("pack(push, 1)")
-#define PACKED_END _Pragma("pack(pop)")
-
-PACKED_START
 struct GeneralPurposeRegisters32 {
   uint32_t ebx;
   uint32_t ecx;
@@ -42,6 +35,8 @@ struct GeneralPurposeRegisters32 {
   uint32_t esp;
   uint32_t xss;
 };
+static_assert(sizeof(GeneralPurposeRegisters32) == 68,
+              "GeneralPurposeRegisters32 is not 68 bytes of size");
 
 struct GeneralPurposeRegisters64 {
   uint64_t r15;
@@ -72,24 +67,26 @@ struct GeneralPurposeRegisters64 {
   uint64_t fs;
   uint64_t gs;
 };
+static_assert(sizeof(GeneralPurposeRegisters64) == 216,
+              "GeneralPurposeRegisters64 is not 216 bytes of size");
 
 union GeneralPurposeRegisters {
-  GeneralPurposeRegisters32 x86_32;
   GeneralPurposeRegisters64 x86_64;
+  GeneralPurposeRegisters32 x86_32;
 };
 
 struct MmsAs80BitFloat {
   uint64_t mantissa;
   uint16_t sign_exp;
 };
-static_assert(sizeof(MmsAs80BitFloat) == 10, "MmsAsFloat is not 10 bytes of size");
+static_assert(offsetof(MmsAs80BitFloat, sign_exp) == sizeof(MmsAs80BitFloat::mantissa),
+              "MmsAs80BitFloat is not properly aligned.");
 
 struct MmsRegister {
   union {
     std::array<uint8_t, 10> bytes;
     MmsAs80BitFloat as_float;
   };
-  std::array<uint8_t, 6> reserved;
 };
 static_assert(sizeof(MmsRegister) == 16, "MmsRegister is not 16 bytes of size");
 
@@ -147,10 +144,6 @@ struct YmmHiRegister {
 struct YmmHi {
   std::array<YmmHiRegister, 16> ymm;
 };
-PACKED_END
-
-#undef PACKED_START
-#undef PACKED_END
 
 // Backup, modify and restore register state of a halted thread.
 //


### PR DESCRIPTION
Struct packing messes with alignment of fields and accessing member fields out of its usual alignment is undefined behaviour in C++.

The code usually works nonetheless because x86 supports out of alignment reads and write - they are just slow. (ARM does not BTW and would trap here).

Luckily we can just avoid having struct packing here. (The layout of these data structures has been designed to avoid any kind of alignment issue.)

The result will be that we avoid UB and that the code potentially is faster (which is not relevant here at all though).

This has been found using Address and UB Sanitizer™.