### PR TITLE
Fix usage of absl::bit_cast

### DIFF
--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -526,10 +526,12 @@ void AppendRestoreCode(MachineCode& trampoline) {
 
   // Relocate addresses encoded in the trampoline.
   for (size_t pos : relocateable_addresses) {
-    const uint64_t address_in_trampoline = *absl::bit_cast<uint64_t*>(trampoline_code.data() + pos);
+    uint64_t address_in_trampoline{};
+    std::memcpy(&address_in_trampoline, trampoline_code.data() + pos,
+                sizeof(address_in_trampoline));
     auto it = relocation_map.find(address_in_trampoline);
     if (it != relocation_map.end()) {
-      *absl::bit_cast<uint64_t*>(trampoline_code.data() + pos) = it->second;
+      std::memcpy(trampoline_code.data() + pos, &it->second, sizeof(it->second));
     }
   }
 


### PR DESCRIPTION
`absl::bit_cast` (and the `std::bit_cast`) have to be used "by value". If they are used to convert pointers, it's not more than a fancy `reinterpret_cast` and that's what we want to avoid.

So this commit fixes two usages of bit_cast that were pointers.

Unfortunately for the second one we can't use bit_cast and I had to fall back to calling `std::memcpy` directly to avoid any kind of UB.

This has been found by Address and UB Sanitizer™.