### PR TITLE
Disable another test on Windows

### DIFF
--- a/src/QtUtils/ThrottleTest.cpp
+++ b/src/QtUtils/ThrottleTest.cpp
@@ -71,6 +71,10 @@ TEST(Throttle, SecondImmediateFireLeadsToDelayedTrigger) {
 }
 
 TEST(Throttle, SecondDelayedFireLeadsToImmediateTrigger) {
+// TODO(https://github.com/google/orbit/issues/4503): Enable test again.
+#ifdef _WIN32
+  GTEST_SKIP();
+#endif
   Throttle throttle{kStandardDelay};
 
   MockReceiver receiver{};


### PR DESCRIPTION
This test also seem to be flaky, and needs investigation. Temporarily disabling it.