### PR TITLE
Move QRC file into Orbit main target

### DIFF
--- a/src/Orbit/CMakeLists.txt
+++ b/src/Orbit/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(Orbit)
 target_sources(
     Orbit
     PRIVATE main.cpp
+    ../../icons/orbiticons.qrc
 )
 
 target_link_libraries(Orbit PRIVATE
@@ -20,6 +21,7 @@ target_link_libraries(Orbit PRIVATE
         absl::flags_parse
         absl::flags_usage)
 target_include_directories(Orbit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(Orbit PROPERTIES AUTORCC ON)
 
 if(WIN32)
   set_target_properties(Orbit PROPERTIES WIN32_EXECUTABLE ON)

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -76,8 +76,7 @@ target_sources(
           TimeGraphLayoutWidget.cpp
           TrackConfigurationWidget.cpp
           TrackConfigurationWidget.ui
-          TrackTypeItemModel.cpp
-          ../../icons/orbiticons.qrc)
+          TrackTypeItemModel.cpp)
 
 target_include_directories(OrbitQt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(OrbitQt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -106,7 +105,6 @@ target_link_libraries(
 
 set_target_properties(OrbitQt PROPERTIES AUTOMOC ON)
 set_target_properties(OrbitQt PROPERTIES AUTOUIC ON)
-set_target_properties(OrbitQt PROPERTIES AUTORCC ON)
 iwyu_add_dependency(OrbitQt)
 
 if(WIN32)


### PR DESCRIPTION
Since OrbitQt is now a static library, the linker will remove all unused symbols - including the embedded icons.

The solution is to not include the icons in the OrbitQt target, but in the Orbit target.

This should bring the icons back into Orbit - at least it works for me.

Fixes: #4509