### PR TITLE
Replace const std::string& by std::string_view

### DIFF
--- a/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -25,7 +25,7 @@ using orbit_grpc_protos::GpuQueueSubmission;
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmission(
     const GpuQueueSubmission& gpu_queue_submission,
     const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
-    const std::function<uint64_t(const std::string& str)>&
+    const std::function<uint64_t(std::string_view str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
   uint32_t thread_id = gpu_queue_submission.meta_info().tid();
   uint64_t pre_submission_cpu_timestamp =
@@ -66,7 +66,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmission(
 }
 std::vector<orbit_client_protos::TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuJob(
     const GpuJob& gpu_job, const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
-    const std::function<uint64_t(const std::string& str)>&
+    const std::function<uint64_t(std::string_view str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
   uint32_t thread_id = gpu_job.tid();
   uint64_t amdgpu_cs_ioctl_time_ns = gpu_job.amdgpu_cs_ioctl_time_ns();
@@ -162,7 +162,7 @@ const GpuJob* GpuQueueSubmissionProcessor::FindMatchingGpuJob(
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmissionWithMatchingGpuJob(
     const GpuQueueSubmission& gpu_queue_submission, const GpuJob& matching_gpu_job,
     const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
-    const std::function<uint64_t(const std::string& str)>&
+    const std::function<uint64_t(std::string_view str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
   std::vector<TimerInfo> result;
   uint64_t timeline_key = matching_gpu_job.timeline_key();
@@ -255,7 +255,7 @@ void GpuQueueSubmissionProcessor::DeleteSavedGpuSubmission(uint32_t thread_id,
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuCommandBuffers(
     const GpuQueueSubmission& gpu_queue_submission, const GpuJob& matching_gpu_job,
     const std::optional<GpuCommandBuffer>& first_command_buffer, uint64_t timeline_hash,
-    const std::function<uint64_t(const std::string& str)>&
+    const std::function<uint64_t(std::string_view str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
   constexpr const char* kCommandBufferLabel = "command buffer";
   uint64_t command_buffer_text_key =
@@ -454,7 +454,7 @@ std::optional<GpuCommandBuffer> GpuQueueSubmissionProcessor::ExtractFirstCommand
 }
 
 bool GpuQueueSubmissionProcessor::TryExtractDXVKVulkanGroupIdFromDebugLabel(
-    const std::string& label, uint64_t* out_group_id) {
+    std::string_view label, uint64_t* out_group_id) {
   // We have special handling for DXVK instrumentation that extracts the encoded group_id from
   // the label's text. The encoding is:
   // 'DXVK__vkFunctionName#GROUP_ID', where 'GROUP_ID' is the group id.

--- a/src/CaptureClient/GpuQueueSubmissionProcessorTest.cpp
+++ b/src/CaptureClient/GpuQueueSubmissionProcessorTest.cpp
@@ -146,7 +146,7 @@ TEST_F(GpuQueueSubmissionProcessorTest, DXVKVulkanDebugMarkerEncodesGroupId) {
 
   bool was_called = false;
   static constexpr uint64_t kCommandBufferTextKey = 1234;
-  auto get_string_hash_and_send_if_necessary_fake = [&was_called](const std::string&
+  auto get_string_hash_and_send_if_necessary_fake = [&was_called](std::string_view
                                                                   /*str*/) -> uint64_t {
     was_called = true;
     return kCommandBufferTextKey;

--- a/src/CaptureClient/include/CaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/GpuQueueSubmissionProcessor.h
@@ -43,7 +43,7 @@ class GpuQueueSubmissionProcessor {
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuQueueSubmission(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
       const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
-      const std::function<uint64_t(const std::string& str)>&
+      const std::function<uint64_t(std::string_view str)>&
           get_string_hash_and_send_to_listener_if_necessary);
 
   // If the matching `GpuQueueSubmission` has already been processed, it converts the
@@ -53,7 +53,7 @@ class GpuQueueSubmissionProcessor {
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuJob(
       const orbit_grpc_protos::GpuJob& gpu_job,
       const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
-      const std::function<uint64_t(const std::string& str)>&
+      const std::function<uint64_t(std::string_view str)>&
           get_string_hash_and_send_to_listener_if_necessary);
 
   // In case we have recorded the submission containing the "begin" of a certain debug marker, we
@@ -68,7 +68,7 @@ class GpuQueueSubmissionProcessor {
   // This function tries to extract the "group id" from the given label, based on this encoding.
   // It returns `true` on success. In this case, the group id will be written to `out_group_id`.
   // In all other cases `false` will be returned.
-  static bool TryExtractDXVKVulkanGroupIdFromDebugLabel(const std::string& label,
+  static bool TryExtractDXVKVulkanGroupIdFromDebugLabel(std::string_view label,
                                                         uint64_t* out_group_id);
 
  private:
@@ -77,7 +77,7 @@ class GpuQueueSubmissionProcessor {
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
       const orbit_grpc_protos::GpuJob& matching_gpu_job,
       const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
-      const std::function<uint64_t(const std::string& str)>&
+      const std::function<uint64_t(std::string_view str)>&
           get_string_hash_and_send_to_listener_if_necessary);
 
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuCommandBuffers(
@@ -85,7 +85,7 @@ class GpuQueueSubmissionProcessor {
       const orbit_grpc_protos::GpuJob& matching_gpu_job,
       const std::optional<orbit_grpc_protos::GpuCommandBuffer>& first_command_buffer,
       uint64_t timeline_hash,
-      const std::function<uint64_t(const std::string& str)>&
+      const std::function<uint64_t(std::string_view str)>&
           get_string_hash_and_send_to_listener_if_necessary);
 
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuDebugMarkers(

--- a/src/CaptureFile/CaptureFileHelpersTest.cpp
+++ b/src/CaptureFile/CaptureFileHelpersTest.cpp
@@ -35,11 +35,11 @@ static constexpr uint64_t kNotAnAnswerKey = 43;
 
 using orbit_grpc_protos::ClientCaptureEvent;
 
-static ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, const std::string& str) {
+static ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, std::string str) {
   ClientCaptureEvent event;
   orbit_grpc_protos::InternedString* interned_string = event.mutable_interned_string();
   interned_string->set_key(key);
-  interned_string->set_intern(str);
+  interned_string->set_intern(std::move(str));
   return event;
 }
 

--- a/src/CaptureFile/CaptureFileOutputStreamTest.cpp
+++ b/src/CaptureFile/CaptureFileOutputStreamTest.cpp
@@ -30,12 +30,12 @@ static constexpr const char* kNotAnAnswerString = "Some odd number, not the answ
 static constexpr uint64_t kAnswerKey = 42;
 static constexpr uint64_t kNotAnAnswerKey = 43;
 
-static orbit_grpc_protos::ClientCaptureEvent CreateInternedStringCaptureEvent(
-    uint64_t key, const std::string& str) {
+static orbit_grpc_protos::ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key,
+                                                                              std::string str) {
   orbit_grpc_protos::ClientCaptureEvent event;
   orbit_grpc_protos::InternedString* interned_string = event.mutable_interned_string();
   interned_string->set_key(key);
-  interned_string->set_intern(str);
+  interned_string->set_intern(std::move(str));
   return event;
 }
 
@@ -54,7 +54,7 @@ TEST(CaptureFileOutputStream, Smoke) {
     ASSERT_FALSE(close_result.has_error()) << close_result.error().message();
   };
 
-  auto check_output_stream_content = [&](const std::string& stream_content) {
+  auto check_output_stream_content = [&](std::string_view stream_content) {
     ASSERT_GT(stream_content.size(), 24);
     ASSERT_EQ(stream_content.substr(0, 4), kFileSignature);
     uint64_t capture_section_offset = 0;

--- a/src/CaptureFile/CaptureFileTest.cpp
+++ b/src/CaptureFile/CaptureFileTest.cpp
@@ -46,11 +46,11 @@ static constexpr uint64_t kNotAnAnswerKey = 43;
 
 using orbit_grpc_protos::ClientCaptureEvent;
 
-static ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, const std::string& str) {
+static ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, std::string str) {
   ClientCaptureEvent event;
   orbit_grpc_protos::InternedString* interned_string = event.mutable_interned_string();
   interned_string->set_key(key);
-  interned_string->set_intern(str);
+  interned_string->set_intern(std::move(str));
   return event;
 }
 

--- a/src/ClientData/CaptureDataTest.cpp
+++ b/src/ClientData/CaptureDataTest.cpp
@@ -170,10 +170,10 @@ static void ExpectStatsEqual(const ScopeStats& actual, const ScopeStats& other) 
 }
 
 void AddInstrumentedFunction(orbit_grpc_protos::CaptureOptions& capture_options,
-                             uint64_t function_id, const std::string& name) {
+                             uint64_t function_id, std::string name) {
   orbit_grpc_protos::InstrumentedFunction* function = capture_options.add_instrumented_functions();
   function->set_function_id(function_id);
-  function->set_function_name(name);
+  function->set_function_name(std::move(name));
 }
 
 [[nodiscard]] orbit_grpc_protos::CaptureStarted CreateCaptureStarted() {

--- a/src/ClientData/ModuleManager.cpp
+++ b/src/ClientData/ModuleManager.cpp
@@ -132,7 +132,7 @@ std::vector<const ModuleData*> ModuleManager::GetAllModuleData() const {
 }
 
 std::vector<const ModuleData*> ModuleManager::GetModulesByFilename(
-    const std::string& filename) const {
+    std::string_view filename) const {
   absl::MutexLock lock(&mutex_);
   std::vector<const ModuleData*> result;
   for (const auto& [module_id, module_data] : module_map_) {

--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -92,8 +92,7 @@ void ProcessData::UpdateModuleInfos(absl::Span<const ModuleInfo> module_infos) {
   ORBIT_DCHECK(IsModuleMapValid(start_address_to_module_in_memory_));
 }
 
-std::vector<std::string> ProcessData::FindModuleBuildIdsByPath(
-    const std::string& module_path) const {
+std::vector<std::string> ProcessData::FindModuleBuildIdsByPath(std::string_view module_path) const {
   absl::MutexLock lock(&mutex_);
   std::set<std::string> build_ids;
 
@@ -160,8 +159,8 @@ ErrorMessageOr<ModuleInMemory> ProcessData::FindModuleByAddress(uint64_t absolut
   return module_in_memory;
 }
 
-std::vector<uint64_t> ProcessData::GetModuleBaseAddresses(const std::string& module_path,
-                                                          const std::string& build_id) const {
+std::vector<uint64_t> ProcessData::GetModuleBaseAddresses(std::string_view module_path,
+                                                          std::string_view build_id) const {
   absl::MutexLock lock(&mutex_);
   std::vector<uint64_t> result;
   for (const auto& [start_address, module_in_memory] : start_address_to_module_in_memory_) {
@@ -172,7 +171,7 @@ std::vector<uint64_t> ProcessData::GetModuleBaseAddresses(const std::string& mod
   return result;
 }
 
-std::vector<ModuleInMemory> ProcessData::FindModulesByFilename(const std::string& filename) const {
+std::vector<ModuleInMemory> ProcessData::FindModulesByFilename(std::string_view filename) const {
   absl::MutexLock lock(&mutex_);
   std::vector<ModuleInMemory> result;
   for (const auto& [unused_start_address, module_in_memory] : start_address_to_module_in_memory_) {

--- a/src/ClientData/ProcessDataTest.cpp
+++ b/src/ClientData/ProcessDataTest.cpp
@@ -584,11 +584,11 @@ class ProcessDataModuleIntersectionTest : public ::testing::Test {
   static constexpr const char* kNewModulePath = "test/file/path";
   static constexpr const char* kNewBuildId = "build_id";
 
-  static ModuleInfo CreateModule(const std::string& module_path, const std::string& build_id,
+  static ModuleInfo CreateModule(std::string module_path, std::string build_id,
                                  uint64_t start_address, uint64_t end_address) {
     ModuleInfo module_info;
-    module_info.set_file_path(module_path);
-    module_info.set_build_id(build_id);
+    module_info.set_file_path(std::move(module_path));
+    module_info.set_build_id(std::move(build_id));
     module_info.set_address_start(start_address);
     module_info.set_address_end(end_address);
     return module_info;

--- a/src/ClientData/ScopeIdProviderTest.cpp
+++ b/src/ClientData/ScopeIdProviderTest.cpp
@@ -31,9 +31,9 @@ namespace orbit_client_data {
 const std::vector<std::string> kNames{"A", "B", "C", "D", "A", "B", "B"};
 
 [[nodiscard]] static orbit_client_protos::TimerInfo MakeTimerInfo(
-    const std::string& name, orbit_client_protos::TimerInfo_Type type) {
+    std::string name, orbit_client_protos::TimerInfo_Type type) {
   orbit_client_protos::TimerInfo timer_info;
-  timer_info.set_api_scope_name(name);
+  timer_info.set_api_scope_name(std::move(name));
   timer_info.set_type(type);
   timer_info.set_function_id(orbit_grpc_protos::kInvalidFunctionId);
   return timer_info;
@@ -128,14 +128,14 @@ const std::array<uint64_t, kFunctionCount> kFunctionSize = {57, 108, 23};
 const std::array<bool, kFunctionCount> kFunctionIsHotpatchable = {false, false, true};
 
 static void AddInstrumentedFunction(orbit_grpc_protos::CaptureOptions& capture_options,
-                                    uint64_t function_id, const std::string& name,
-                                    const std::string& file_path, const std::string& build_id,
-                                    uint64_t virtual_address, uint64_t size, bool is_hotpatchable) {
+                                    uint64_t function_id, std::string name, std::string file_path,
+                                    std::string build_id, uint64_t virtual_address, uint64_t size,
+                                    bool is_hotpatchable) {
   orbit_grpc_protos::InstrumentedFunction* function = capture_options.add_instrumented_functions();
   function->set_function_id(function_id);
-  function->set_function_name(name);
-  function->set_file_path(file_path);
-  function->set_file_build_id(build_id);
+  function->set_function_name(std::move(name));
+  function->set_file_path(std::move(file_path));
+  function->set_file_build_id(std::move(build_id));
   function->set_function_virtual_address(virtual_address);
   function->set_function_size(size);
   function->set_is_hotpatchable(is_hotpatchable);

--- a/src/ClientData/TimerTrackDataIdManager.cpp
+++ b/src/ClientData/TimerTrackDataIdManager.cpp
@@ -59,7 +59,7 @@ uint32_t TimerTrackDataIdManager::GenerateGpuTrackId(uint64_t timeline_hash) {
   return it->second;
 }
 
-uint32_t TimerTrackDataIdManager::GenerateAsyncTrackId(const std::string& name) {
+uint32_t TimerTrackDataIdManager::GenerateAsyncTrackId(std::string_view name) {
   absl::MutexLock lock(&mutex_);
   auto [it, inserted] = async_track_ids_.try_emplace(name, next_track_id_);
   if (inserted) {

--- a/src/ClientData/UserDefinedCaptureDataTest.cpp
+++ b/src/ClientData/UserDefinedCaptureDataTest.cpp
@@ -13,9 +13,13 @@
 
 namespace orbit_client_data {
 
-FunctionInfo CreateFunctionInfo(const std::string& function_name, uint64_t function_address) {
-  FunctionInfo info{"/path/to/module", "build id",    function_address,
-                    /*size=*/16,       function_name, /*is_hotpatchable=*/false};
+FunctionInfo CreateFunctionInfo(std::string function_name, uint64_t function_address) {
+  FunctionInfo info{"/path/to/module",
+                    "build id",
+                    function_address,
+                    /*size=*/16,
+                    std::move(function_name),
+                    /*is_hotpatchable=*/false};
   return info;
 }
 

--- a/src/ClientData/include/ClientData/ModuleManager.h
+++ b/src/ClientData/include/ClientData/ModuleManager.h
@@ -50,7 +50,7 @@ class ModuleManager final {
   [[nodiscard]] std::vector<const ModuleData*> GetAllModuleData() const;
 
   [[nodiscard]] std::vector<const ModuleData*> GetModulesByFilename(
-      const std::string& filename) const;
+      std::string_view filename) const;
 
  private:
   mutable absl::Mutex mutex_;

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -87,22 +87,21 @@ class ProcessData final {
 
   // Returns module base addresses. Note that the same module could be mapped twice in which case
   // this function returns two base addresses. If no module found the function returns empty vector.
-  [[nodiscard]] std::vector<uint64_t> GetModuleBaseAddresses(const std::string& module_path,
-                                                             const std::string& build_id) const;
+  [[nodiscard]] std::vector<uint64_t> GetModuleBaseAddresses(std::string_view module_path,
+                                                             std::string_view build_id) const;
 
   [[nodiscard]] std::map<uint64_t, ModuleInMemory> GetMemoryMapCopy() const;
   [[nodiscard]] std::vector<orbit_symbol_provider::ModuleIdentifier> GetUniqueModuleIdentifiers()
       const;
 
   [[nodiscard]] std::vector<std::string> FindModuleBuildIdsByPath(
-      const std::string& module_path) const;
+      std::string_view module_path) const;
 
   // Returns the list of modules with the given filename. Note this method matches based on the
   // actual filename and not based on the full path.
-  [[nodiscard]] std::vector<ModuleInMemory> FindModulesByFilename(
-      const std::string& filename) const;
+  [[nodiscard]] std::vector<ModuleInMemory> FindModulesByFilename(std::string_view filename) const;
 
-  [[nodiscard]] bool IsModuleLoadedByProcess(const std::string& module_path) const {
+  [[nodiscard]] bool IsModuleLoadedByProcess(std::string_view module_path) const {
     return !FindModuleBuildIdsByPath(module_path).empty();
   }
 

--- a/src/ClientData/include/ClientData/TimerTrackDataIdManager.h
+++ b/src/ClientData/include/ClientData/TimerTrackDataIdManager.h
@@ -29,7 +29,7 @@ class TimerTrackDataIdManager {
   [[nodiscard]] uint32_t GenerateSchedulerTrackId() const { return scheduler_track_id_; }
   [[nodiscard]] uint32_t GenerateFrameTrackId(uint64_t function_id);
   [[nodiscard]] uint32_t GenerateGpuTrackId(uint64_t timeline_hash);
-  [[nodiscard]] uint32_t GenerateAsyncTrackId(const std::string& name);
+  [[nodiscard]] uint32_t GenerateAsyncTrackId(std::string_view name);
   [[nodiscard]] uint32_t GenerateThreadTrackId(uint32_t thread_id);
 
  private:

--- a/src/ClientServices/ProcessClient.cpp
+++ b/src/ClientServices/ProcessClient.cpp
@@ -85,12 +85,12 @@ ErrorMessageOr<std::vector<ModuleInfo>> ProcessClient::LoadModuleList(uint32_t p
 }
 
 ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> ProcessClient::FindDebugInfoFile(
-    const std::string& module_path, absl::Span<const std::string> additional_search_directories) {
+    std::string_view module_path, absl::Span<const std::string> additional_search_directories) {
   ORBIT_SCOPE_FUNCTION;
   GetDebugInfoFileRequest request;
   GetDebugInfoFileResponse response;
 
-  request.set_module_path(module_path);
+  request.set_module_path(module_path.data(), module_path.size());
   *request.mutable_additional_search_directories() = {additional_search_directories.begin(),
                                                       additional_search_directories.end()};
 

--- a/src/ClientServices/ProcessManager.cpp
+++ b/src/ClientServices/ProcessManager.cpp
@@ -42,7 +42,7 @@ class ProcessManagerImpl final : public ProcessManager {
                                                 uint64_t size) override;
 
   ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> FindDebugInfoFile(
-      const std::string& module_path,
+      std::string_view module_path,
       absl::Span<const std::string> additional_search_directories) override;
 
   void Start();
@@ -80,7 +80,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ProcessManagerImpl::LoadModuleList(uint3
 }
 
 ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> ProcessManagerImpl::FindDebugInfoFile(
-    const std::string& module_path, absl::Span<const std::string> additional_search_directories) {
+    std::string_view module_path, absl::Span<const std::string> additional_search_directories) {
   return process_client_->FindDebugInfoFile(module_path, additional_search_directories);
 }
 

--- a/src/ClientServices/include/ClientServices/ProcessClient.h
+++ b/src/ClientServices/include/ClientServices/ProcessClient.h
@@ -37,7 +37,7 @@ class ProcessClient {
       uint32_t pid);
 
   [[nodiscard]] ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> FindDebugInfoFile(
-      const std::string& module_path, absl::Span<const std::string> additional_search_directories);
+      std::string_view module_path, absl::Span<const std::string> additional_search_directories);
 
   [[nodiscard]] ErrorMessageOr<std::string> LoadProcessMemory(uint32_t pid, uint64_t address,
                                                               uint64_t size);

--- a/src/ClientServices/include/ClientServices/ProcessManager.h
+++ b/src/ClientServices/include/ClientServices/ProcessManager.h
@@ -58,7 +58,7 @@ class ProcessManager {
                                                         uint64_t size) = 0;
 
   virtual ErrorMessageOr<orbit_base::NotFoundOr<std::filesystem::path>> FindDebugInfoFile(
-      const std::string& module_path,
+      std::string_view module_path,
       absl::Span<const std::string> additional_search_directories) = 0;
 
   // Note that this method waits for the worker thread to stop, which could

--- a/src/CommandLineUtils/CommandLineUtils.cpp
+++ b/src/CommandLineUtils/CommandLineUtils.cpp
@@ -21,9 +21,9 @@ QStringList ExtractCommandLineFlags(const std::vector<std::string>& command_line
   QStringList command_line_flags;
   absl::flat_hash_set<std::string> positional_arg_set(positional_args.begin(),
                                                       positional_args.end());
-  for (const std::string& command_line_arg : command_line_args) {
+  for (std::string_view command_line_arg : command_line_args) {
     if (!positional_arg_set.contains(command_line_arg)) {
-      command_line_flags << QString::fromStdString(command_line_arg);
+      command_line_flags << QString::fromUtf8(command_line_arg.data(), command_line_arg.size());
     }
   }
   return command_line_flags;

--- a/src/ConfigWidgets/SymbolErrorDialog.cpp
+++ b/src/ConfigWidgets/SymbolErrorDialog.cpp
@@ -19,13 +19,14 @@
 namespace orbit_config_widgets {
 
 SymbolErrorDialog::SymbolErrorDialog(const orbit_client_data::ModuleData* module,
-                                     const std::string& detailed_error, QWidget* parent)
+                                     std::string_view detailed_error, QWidget* parent)
     : QDialog(parent), ui_(std::make_unique<Ui::SymbolErrorDialog>()), module_(module) {
   ORBIT_CHECK(module_ != nullptr);
   ui_->setupUi(this);
   QString module_file_path = QString::fromStdString(module_->file_path());
   ui_->moduleNameLabel->setText(module_file_path);
-  ui_->errorPlainTextEdit->setPlainText(QString::fromStdString(detailed_error));
+  ui_->errorPlainTextEdit->setPlainText(
+      QString::fromUtf8(detailed_error.data(), detailed_error.size()));
 
   // If the module has a build id, or unsafe symbols are allowed, then the user can continue to
   // resolve this error.

--- a/src/ConfigWidgets/SymbolLocationsDialog.cpp
+++ b/src/ConfigWidgets/SymbolLocationsDialog.cpp
@@ -31,6 +31,7 @@
 #include <iterator>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 
@@ -71,19 +72,20 @@ namespace {
 // module_symbol_file_mappings_ map.
 class OverrideMappingItem : public QListWidgetItem {
  public:
-  explicit OverrideMappingItem(const std::string& module_file_path,
+  explicit OverrideMappingItem(std::string_view module_file_path,
                                const std::filesystem::path& symbol_file_path,
                                QListWidget* parent = nullptr)
-      : QListWidgetItem(QIcon(":/actions/alert"),
-                        QString("%1 -> %2")
-                            .arg(QString::fromStdString(module_file_path))
-                            .arg(QString::fromStdString(symbol_file_path.string())),
-                        parent, kOverrideMappingItemType),
+      : QListWidgetItem(
+            QIcon(":/actions/alert"),
+            QString("%1 -> %2")
+                .arg(QString::fromUtf8(module_file_path.data(), module_file_path.size()))
+                .arg(QString::fromStdString(symbol_file_path.string())),
+            parent, kOverrideMappingItemType),
         module_file_path_(module_file_path) {
     setToolTip(
         QString(
             R"(This is a symbol file override. Orbit will always use the symbol file "%1" for the module "%2".)")
-            .arg(QString::fromStdString(module_file_path))
+            .arg(QString::fromUtf8(module_file_path.data(), module_file_path.size()))
             .arg(QString::fromStdString(symbol_file_path.string())));
   }
   std::string module_file_path_;

--- a/src/ConfigWidgets/include/ConfigWidgets/SymbolErrorDialog.h
+++ b/src/ConfigWidgets/include/ConfigWidgets/SymbolErrorDialog.h
@@ -27,7 +27,7 @@ class SymbolErrorDialog : public QDialog {
   enum class Result { kCancel, kTryAgain, kAddSymbolLocation };
 
   explicit SymbolErrorDialog(const orbit_client_data::ModuleData* module,
-                             const std::string& detailed_error, QWidget* parent = nullptr);
+                             std::string_view detailed_error, QWidget* parent = nullptr);
   ~SymbolErrorDialog() override;
   [[nodiscard]] Result Exec();
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -66,13 +66,13 @@ void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
   }
 }
 
-void DataView::OnFilter(const std::string& filter) {
+void DataView::OnFilter(std::string_view filter) {
   filter_ = filter;
   DoFilter();
   OnSort(sorting_column_, {});
 }
 
-void DataView::SetUiFilterString(const std::string& filter) {
+void DataView::SetUiFilterString(std::string_view filter) {
   if (filter_callback_) {
     filter_callback_(filter);
   }
@@ -138,7 +138,7 @@ std::vector<DataView::ActionGroup> DataView::GetContextMenuWithGrouping(
   return menu;
 }
 
-void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,
+void DataView::OnContextMenu(std::string_view action, int /*menu_index*/,
                              const std::vector<int>& item_indices) {
   if (action == kMenuActionLoadSymbols) {
     OnLoadSymbolsRequested(item_indices);

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -66,8 +66,8 @@ void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
   }
 }
 
-void DataView::OnFilter(std::string_view filter) {
-  filter_ = filter;
+void DataView::OnFilter(std::string filter) {
+  filter_ = std::move(filter);
   DoFilter();
   OnSort(sorting_column_, {});
 }

--- a/src/DataViews/DataViewTest.cpp
+++ b/src/DataViews/DataViewTest.cpp
@@ -29,7 +29,7 @@ const std::array<std::string, kValuesNum> kValues = {"a", "b", "c", "d", "e"};
 const std::array<std::string, kValuesNum> kCsvFormattedValues = [] {
   std::array<std::string, kValuesNum> result;
   std::transform(std::begin(kValues), std::end(kValues), std::begin(result),
-                 [](const std::string& value) { return FormatValueForCsv(value); });
+                 [](std::string_view value) { return FormatValueForCsv(value); });
   return result;
 }();
 

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -48,7 +48,7 @@ void CheckSingleAction(const FlattenContextMenu& context_menu, std::string_view 
 
 void CheckCopySelectionIsInvoked(const FlattenContextMenu& context_menu,
                                  const MockAppInterface& app, DataView& view,
-                                 const std::string& expected_clipboard) {
+                                 std::string_view expected_clipboard) {
   const int action_index = GetActionIndexOnMenu(context_menu, kMenuActionCopySelection);
   EXPECT_TRUE(action_index != kInvalidActionIndex);
 
@@ -74,7 +74,7 @@ static void ExpectSameLines(const std::string_view& actual, const std::string_vi
 }
 
 void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const MockAppInterface& app,
-                               DataView& view, const std::string& expected_contents,
+                               DataView& view, std::string_view expected_contents,
                                std::string_view action_name) {
   const int action_index = GetActionIndexOnMenu(context_menu, action_name);
   EXPECT_TRUE(action_index != kInvalidActionIndex);

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -30,10 +30,10 @@ void CheckSingleAction(const FlattenContextMenu& context_menu, std::string_view 
 
 void CheckCopySelectionIsInvoked(const FlattenContextMenu& flatten_context_menu,
                                  const MockAppInterface& app, DataView& view,
-                                 const std::string& expected_clipboard);
+                                 std::string_view expected_clipboard);
 
 void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const MockAppInterface& app,
-                               DataView& view, const std::string& expected_contents,
+                               DataView& view, std::string_view expected_contents,
                                std::string_view action_name = kMenuActionExportToCsv);
 
 void CheckContextMenuOrder(const FlattenContextMenu& context_menu);

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -222,7 +222,7 @@ void FunctionsDataView::DoFilter() {
         std::string module = absl::AsciiStrToLower(
             std::filesystem::path(function->module_path()).filename().string());
 
-        const auto is_token_found = [&name, &module](const std::string& token) {
+        const auto is_token_found = [&name, &module](std::string_view token) {
           return name.find(token) != std::string::npos || module.find(token) != std::string::npos;
         };
 
@@ -248,7 +248,7 @@ void FunctionsDataView::AddFunctions(
   OnDataChanged();
 }
 
-void FunctionsDataView::RemoveFunctionsOfModule(const std::string& module_path) {
+void FunctionsDataView::RemoveFunctionsOfModule(std::string_view module_path) {
   functions_.erase(std::remove_if(functions_.begin(), functions_.end(),
                                   [&module_path](const FunctionInfo* function_info) {
                                     return function_info->module_path() == module_path;

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -372,7 +372,7 @@ void LiveFunctionsDataView::OnIteratorRequested(const std::vector<int>& selectio
   }
 }
 
-void LiveFunctionsDataView::OnJumpToRequested(const std::string& action,
+void LiveFunctionsDataView::OnJumpToRequested(std::string_view action,
                                               const std::vector<int>& selection) {
   ORBIT_CHECK(selection.size() == 1);
   auto scope_id = GetScopeId(selection[0]);
@@ -388,7 +388,7 @@ void LiveFunctionsDataView::OnJumpToRequested(const std::string& action,
 }
 
 [[nodiscard]] ErrorMessageOr<void> LiveFunctionsDataView::WriteEventsToCsv(
-    const std::vector<int>& selection, const std::string& file_path) const {
+    const std::vector<int>& selection, std::string_view file_path) const {
   OUTCOME_TRY(auto fd, orbit_base::OpenFileForWriting(file_path));
 
   // Write header line
@@ -453,7 +453,7 @@ void LiveFunctionsDataView::DoFilter() {
 
     bool match = true;
 
-    for (const std::string& filter_token : tokens) {
+    for (std::string_view filter_token : tokens) {
       if (name.find(filter_token) == std::string::npos) {
         match = false;
         break;

--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -31,10 +31,10 @@ class MockAppInterface : public AppInterface {
   using ScopeId = orbit_client_data::ScopeId;
 
  public:
-  MOCK_METHOD(void, SetClipboard, (const std::string&), (override));
-  MOCK_METHOD(std::string, GetSaveFile, (const std::string& extension), (const, override));
+  MOCK_METHOD(void, SetClipboard, (std::string_view), (override));
+  MOCK_METHOD(std::string, GetSaveFile, (std::string_view extension), (const, override));
 
-  MOCK_METHOD(void, SendErrorToUi, (const std::string& title, const std::string& text), (override));
+  MOCK_METHOD(void, SendErrorToUi, (std::string_view title, std::string_view text), (override));
 
   MOCK_METHOD(orbit_base::Future<ErrorMessageOr<void>>, LoadPreset,
               (const orbit_preset_file::PresetFile&), (override));
@@ -105,7 +105,7 @@ class MockAppInterface : public AppInterface {
               GetConfidenceIntervalEstimator, (), (const, override));
 
   MOCK_METHOD(void, ShowHistogram,
-              (const std::vector<uint64_t>* data, const std::string& function_name,
+              (const std::vector<uint64_t>* data, std::string function_name,
                std::optional<ScopeId> scope_id),
               (override));
 

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -460,7 +460,7 @@ SampledFunction& SamplingReportDataView::GetSampledFunction(unsigned int row) {
   return functions_[indices_[row]];
 }
 
-ErrorMessageOr<void> SamplingReportDataView::WriteStackEventsToCsv(const std::string& file_path) {
+ErrorMessageOr<void> SamplingReportDataView::WriteStackEventsToCsv(std::string_view file_path) {
   OUTCOME_TRY(auto fd, orbit_base::OpenFileForWriting(file_path));
 
   static const std::vector<std::string> kNames{"Thread", "Timestamp (ns)", "Names leaf/foo/main",

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -37,10 +37,10 @@ class AppInterface : public orbit_client_data::CaptureDataHolder {
   virtual ~AppInterface() = default;
 
   // Functions needed by DataView
-  virtual void SetClipboard(const std::string& contents) = 0;
-  [[nodiscard]] virtual std::string GetSaveFile(const std::string& extension) const = 0;
+  virtual void SetClipboard(std::string_view contents) = 0;
+  [[nodiscard]] virtual std::string GetSaveFile(std::string_view extension) const = 0;
 
-  virtual void SendErrorToUi(const std::string& title, const std::string& text) = 0;
+  virtual void SendErrorToUi(std::string_view title, std::string_view text) = 0;
 
   // Functions needed by PresetsDataView
   virtual orbit_base::Future<ErrorMessageOr<void>> LoadPreset(
@@ -112,7 +112,7 @@ class AppInterface : public orbit_client_data::CaptureDataHolder {
   virtual void Disassemble(uint32_t pid, const orbit_client_data::FunctionInfo& function) = 0;
   virtual void ShowSourceCode(const orbit_client_data::FunctionInfo& function) = 0;
 
-  virtual void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
+  virtual void ShowHistogram(const std::vector<uint64_t>* data, std::string scope_name,
                              std::optional<ScopeId> scope_id) = 0;
 
   [[nodiscard]] virtual const orbit_statistics::BinomialConfidenceIntervalEstimator&

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -134,7 +134,7 @@ class DataView {
   virtual std::string GetToolTip(int row, int column) { return GetValue(row, column); }
 
   // Called from UI layer.
-  void OnFilter(std::string_view filter);
+  void OnFilter(std::string filter);
   // Called internally to set the filter string programmatically in the UI.
   void SetUiFilterString(std::string_view filter);
   // Filter callback set from UI layer.

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -79,7 +79,7 @@ template <typename Range>
 ErrorMessageOr<void> WriteLineToCsv(const orbit_base::unique_fd& fd, const Range& cells) {
   std::string header_line = absl::StrJoin(
       cells, kFieldSeparator,
-      [](std::string* out, const std::string& name) { out->append(FormatValueForCsv(name)); });
+      [](std::string* out, std::string_view name) { out->append(FormatValueForCsv(name)); });
   header_line.append(kLineSeparator);
   return orbit_base::WriteFully(fd, header_line);
 }
@@ -134,18 +134,17 @@ class DataView {
   virtual std::string GetToolTip(int row, int column) { return GetValue(row, column); }
 
   // Called from UI layer.
-  void OnFilter(const std::string& filter);
+  void OnFilter(std::string_view filter);
   // Called internally to set the filter string programmatically in the UI.
-  void SetUiFilterString(const std::string& filter);
+  void SetUiFilterString(std::string_view filter);
   // Filter callback set from UI layer.
-  using FilterCallback = std::function<void(const std::string&)>;
+  using FilterCallback = std::function<void(std::string_view)>;
   void SetUiFilterCallback(FilterCallback callback) { filter_callback_ = std::move(callback); }
   virtual void OnRefresh(const std::vector<int>& /*visible_selected_indices*/,
                          const RefreshMode& /*mode*/) {}
 
   void OnSort(int column, std::optional<SortingOrder> new_order);
-  void OnContextMenu(const std::string& action, int menu_index,
-                     const std::vector<int>& item_indices);
+  void OnContextMenu(std::string_view action, int menu_index, const std::vector<int>& item_indices);
   virtual void OnSelect(const std::vector<int>& /*indices*/) {}
   // This method returns the intersection of selected indices and visible indices. The returned
   // value contains 0 or 1 index for a DataView with single selection, and contains 0 or
@@ -181,7 +180,7 @@ class DataView {
   void OnVerifyFramePointersRequested(const std::vector<int>& selection);
   void OnDisassemblyRequested(const std::vector<int>& selection);
   void OnSourceCodeRequested(const std::vector<int>& selection);
-  virtual void OnJumpToRequested(const std::string& /*action*/,
+  virtual void OnJumpToRequested(std::string_view /*action*/,
                                  const std::vector<int>& /*selection*/) {}
   virtual void OnLoadPresetRequested(const std::vector<int>& /*selection*/) {}
   virtual void OnDeletePresetRequested(const std::vector<int>& /*selection*/) {}

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -37,7 +37,7 @@ class FunctionsDataView : public DataView {
   // Note that this class and these methods are not thread-safe and should only be called from the
   // main thread.
   void AddFunctions(std::vector<const orbit_client_data::FunctionInfo*> functions);
-  void RemoveFunctionsOfModule(const std::string& module_path);
+  void RemoveFunctionsOfModule(std::string_view module_path);
   void ClearFunctions();
 
  protected:

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -57,7 +57,7 @@ class LiveFunctionsDataView : public DataView {
   std::optional<int> GetRowFromScopeId(ScopeId scope_id);
 
   void OnIteratorRequested(const std::vector<int>& selection) override;
-  void OnJumpToRequested(const std::string& action, const std::vector<int>& selection) override;
+  void OnJumpToRequested(std::string_view action, const std::vector<int>& selection) override;
   // Export all events (including the function name, thread name and id, start timestamp, end
   // timestamp, and duration) associated with the selected rows in to a CSV file.
   void OnExportEventsToCsvRequested(const std::vector<int>& selection) override;
@@ -111,7 +111,7 @@ class LiveFunctionsDataView : public DataView {
   [[nodiscard]] const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int row) override;
 
   [[nodiscard]] ErrorMessageOr<void> WriteEventsToCsv(const std::vector<int>& selection,
-                                                      const std::string& file_path) const;
+                                                      std::string_view file_path) const;
 
   void UpdateHistogramWithIndices(const std::vector<int>& visible_selected_indices);
 

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -82,7 +82,7 @@ class SamplingReportDataView : public DataView {
   [[nodiscard]] std::string BuildToolTipUnwindErrors(
       const orbit_client_data::SampledFunction& function) const;
 
-  ErrorMessageOr<void> WriteStackEventsToCsv(const std::string& file_path);
+  ErrorMessageOr<void> WriteStackEventsToCsv(std::string_view file_path);
 
   std::vector<orbit_client_data::SampledFunction> functions_;
   // We need to keep user's selected function ids such that if functions_ changes, the

--- a/src/Http/HttpDownloadManagerTest.cpp
+++ b/src/Http/HttpDownloadManagerTest.cpp
@@ -54,7 +54,7 @@ using DownloadResult = ErrorMessageOr<orbit_base::CanceledOr<orbit_base::NotFoun
 
 namespace {
 
-static void VerifyDownloadError(const DownloadResult& result, const std::string& expected_error) {
+static void VerifyDownloadError(const DownloadResult& result, std::string_view expected_error) {
   EXPECT_THAT(result, HasError(expected_error));
 }
 

--- a/src/LinuxCaptureService/ExtractSignalFromMinidump.cpp
+++ b/src/LinuxCaptureService/ExtractSignalFromMinidump.cpp
@@ -50,7 +50,7 @@ struct MDRawExceptionStream {
 };
 
 template <typename T>
-ErrorMessageOr<const T*> DataOrError(const std::string& content, uint64_t offset) {
+ErrorMessageOr<const T*> DataOrError(std::string_view content, uint64_t offset) {
   if (content.size() < offset + sizeof(T)) {
     return ErrorMessage("Unexpected end of data.");
   }
@@ -58,12 +58,12 @@ ErrorMessageOr<const T*> DataOrError(const std::string& content, uint64_t offset
 }
 
 template <typename T>
-ErrorMessageOr<const T*> ArrayElementOrError(const std::string& content, uint64_t offset,
+ErrorMessageOr<const T*> ArrayElementOrError(std::string_view content, uint64_t offset,
                                              uint64_t index) {
   return DataOrError<T>(content, offset + index * sizeof(T));
 }
 
-ErrorMessageOr<int32_t> ParseMinidumpForTerminationSignal(const std::string& content) {
+ErrorMessageOr<int32_t> ParseMinidumpForTerminationSignal(std::string_view content) {
   const uint32_t* stream_count = nullptr;
   OUTCOME_TRY(stream_count, DataOrError<uint32_t>(content, kStreamCountOffset));
   const uint32_t* stream_directory = nullptr;

--- a/src/LinuxTracing/GpuTracepointVisitor.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitor.cpp
@@ -20,8 +20,8 @@ namespace orbit_linux_tracing {
 
 using orbit_grpc_protos::FullGpuJob;
 
-int GpuTracepointVisitor::ComputeDepthForGpuJob(const std::string& timeline,
-                                                uint64_t start_timestamp, uint64_t end_timestamp) {
+int GpuTracepointVisitor::ComputeDepthForGpuJob(std::string_view timeline, uint64_t start_timestamp,
+                                                uint64_t end_timestamp) {
   if (!timeline_to_latest_timestamp_per_depth_.contains(timeline)) {
     timeline_to_latest_timestamp_per_depth_.emplace(timeline, std::vector<uint64_t>{});
   }

--- a/src/LinuxTracing/GpuTracepointVisitor.h
+++ b/src/LinuxTracing/GpuTracepointVisitor.h
@@ -34,7 +34,7 @@ class GpuTracepointVisitor : public PerfEventVisitor {
   // Keys are context, seqno, and timeline.
   using Key = std::tuple<uint32_t, uint32_t, std::string>;
 
-  int ComputeDepthForGpuJob(const std::string& timeline, uint64_t start_timestamp,
+  int ComputeDepthForGpuJob(std::string_view timeline, uint64_t start_timestamp,
                             uint64_t end_timestamp);
 
   void CreateGpuJobAndSendToListenerIfComplete(const Key& key);

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -28,7 +28,7 @@ class GpuTracepointVisitorTest : public ::testing::Test {
 
 AmdgpuCsIoctlPerfEvent MakeFakeAmdgpuCsIoctlPerfEvent(pid_t pid, pid_t tid, uint64_t timestamp_ns,
                                                       uint32_t context, uint32_t seqno,
-                                                      const std::string& timeline) {
+                                                      std::string timeline) {
   return AmdgpuCsIoctlPerfEvent{
       .timestamp = timestamp_ns,
       .data =
@@ -37,35 +37,34 @@ AmdgpuCsIoctlPerfEvent MakeFakeAmdgpuCsIoctlPerfEvent(pid_t pid, pid_t tid, uint
               .tid = tid,
               .context = context,
               .seqno = seqno,
-              .timeline_string = timeline,
+              .timeline_string = std::move(timeline),
           },
   };
 }
 
 AmdgpuSchedRunJobPerfEvent MakeFakeAmdgpuSchedRunJobPerfEvent(uint64_t timestamp_ns,
                                                               uint32_t context, uint32_t seqno,
-                                                              const std::string& timeline) {
+                                                              std::string timeline) {
   return AmdgpuSchedRunJobPerfEvent{
       .timestamp = timestamp_ns,
       .data =
           {
               .context = context,
               .seqno = seqno,
-              .timeline_string = timeline,
+              .timeline_string = std::move(timeline),
           },
   };
 }
 
 DmaFenceSignaledPerfEvent MakeFakeDmaFenceSignaledPerfEvent(uint64_t timestamp_ns, uint32_t context,
-                                                            uint32_t seqno,
-                                                            const std::string& timeline) {
+                                                            uint32_t seqno, std::string timeline) {
   return DmaFenceSignaledPerfEvent{
       .timestamp = timestamp_ns,
       .data =
           {
               .context = context,
               .seqno = seqno,
-              .timeline_string = timeline,
+              .timeline_string = std::move(timeline),
           },
   };
 }

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -60,7 +60,7 @@ class MockLibunwindstackMaps : public LibunwindstackMaps {
  public:
   MOCK_METHOD(std::shared_ptr<unwindstack::MapInfo>, Find, (uint64_t), (override));
   MOCK_METHOD(unwindstack::Maps*, Get, (), (override));
-  MOCK_METHOD(void, AddAndSort, (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&),
+  MOCK_METHOD(void, AddAndSort, (uint64_t, uint64_t, uint64_t, uint64_t, std::string_view),
               (override));
 };
 

--- a/src/LinuxTracing/LibunwindstackMaps.h
+++ b/src/LinuxTracing/LibunwindstackMaps.h
@@ -23,9 +23,9 @@ class LibunwindstackMaps {
   virtual std::shared_ptr<unwindstack::MapInfo> Find(uint64_t pc) = 0;
   virtual unwindstack::Maps* Get() = 0;
   virtual void AddAndSort(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
-                          const std::string& name) = 0;
+                          std::string_view name) = 0;
 
-  static std::unique_ptr<LibunwindstackMaps> ParseMaps(const std::string& maps_buffer);
+  static std::unique_ptr<LibunwindstackMaps> ParseMaps(std::string_view maps_buffer);
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LinuxTracingUtils.h
+++ b/src/LinuxTracing/LinuxTracingUtils.h
@@ -27,9 +27,9 @@ std::optional<char> GetThreadState(pid_t tid);
 
 int GetNumCores();
 
-std::optional<std::string> ExtractCpusetFromCgroup(const std::string& cgroup_content);
+std::optional<std::string> ExtractCpusetFromCgroup(std::string_view cgroup_content);
 
-std::vector<int> ParseCpusetCpus(const std::string& cpuset_cpus_content);
+std::vector<int> ParseCpusetCpus(std::string_view cpuset_cpus_content);
 
 std::vector<int> GetCpusetCpus(pid_t pid);
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorMmapTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorMmapTest.cpp
@@ -36,7 +36,7 @@ class UprobesUnwindingVisitorMmapTest : public ::testing::Test {
     ON_CALL(maps_, Get).WillByDefault([this]() { return real_maps_->Get(); });
     ON_CALL(maps_, AddAndSort)
         .WillByDefault([this](uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
-                              const std::string& name) {
+                              std::string_view name) {
           return real_maps_->AddAndSort(start, end, offset, flags, name);
         });
   }

--- a/src/LinuxTracing/UprobesUnwindingVisitorTestCommon.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTestCommon.h
@@ -25,7 +25,7 @@ class MockLibunwindstackMaps : public LibunwindstackMaps {
  public:
   MOCK_METHOD(std::shared_ptr<unwindstack::MapInfo>, Find, (uint64_t), (override));
   MOCK_METHOD(unwindstack::Maps*, Get, (), (override));
-  MOCK_METHOD(void, AddAndSort, (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&),
+  MOCK_METHOD(void, AddAndSort, (uint64_t, uint64_t, uint64_t, uint64_t, std::string_view),
               (override));
 };
 

--- a/src/Mizar/Mizar.cpp
+++ b/src/Mizar/Mizar.cpp
@@ -47,10 +47,10 @@ using ::orbit_mizar_base::TID;
 ABSL_FLAG(std::string, baseline_path, "", "The path to the baseline capture file");
 ABSL_FLAG(std::string, comparison_path, "", "The path to the comparison capture file");
 
-static std::string ExpandPathHomeFolder(const std::string& path) {
-  const std::string kHomeForderEnvVariable = "HOME";
-  if (path[0] == '~') return getenv(kHomeForderEnvVariable.c_str()) + path.substr(1);
-  return path;
+static std::string ExpandPathHomeFolder(std::string_view path) {
+  constexpr const char* kHomeForderEnvVariable = "HOME";
+  if (path[0] == '~') return std::string{getenv(kHomeForderEnvVariable)}.append(path.substr(1));
+  return std::string{path};
 }
 
 [[nodiscard]] static QString MakeFileName(const std::filesystem::path& path) {

--- a/src/MizarData/BaselineAndComparisonTest.cpp
+++ b/src/MizarData/BaselineAndComparisonTest.cpp
@@ -75,8 +75,8 @@ static std::array<FunctionSymbol, N> MakeFunctionSymbols(
     const std::array<std::string, N>& functions) {
   std::array<FunctionSymbol, N> symbols;
   absl::c_transform(functions, kModuleNames, std::begin(symbols),
-                    [](const std::string& function, const std::string& module) {
-                      return FunctionSymbol{function, module};
+                    [](std::string_view function, std::string_view module) {
+                      return FunctionSymbol{std::string{function}, std::string{module}};
                     });
   return symbols;
 }

--- a/src/MizarData/DummyFunctionSymbolToKeyTest.cpp
+++ b/src/MizarData/DummyFunctionSymbolToKeyTest.cpp
@@ -32,9 +32,9 @@ class SymbolToKey : public DummyFunctionSymbolToKey {
   SymbolToKey() : DummyFunctionSymbolToKey(kNameToKey, kMappableModules) {}
 };
 
-void ExpectCorrectKey(const SymbolToKey& symbol_to_key, const std::string& function_name,
-                      const std::string& module_name) {
-  FunctionSymbol symbol{function_name, module_name};
+void ExpectCorrectKey(const SymbolToKey& symbol_to_key, std::string_view function_name,
+                      std::string_view module_name) {
+  FunctionSymbol symbol{std::string{function_name}, std::string{module_name}};
   const std::string key = symbol_to_key.GetKey(symbol);
   if (kMappableModules->contains(module_name) && kNameToKey->contains(function_name)) {
     EXPECT_EQ(key, kNameToKey->at(function_name));

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -56,7 +56,7 @@ absl::flat_hash_map<AbsoluteAddress, FunctionSymbol> MizarData::AllAddressToFunc
   return result;
 }
 
-[[nodiscard]] static std::string GetFilenameWithoutExtension(const std::string& path) {
+[[nodiscard]] static std::string GetFilenameWithoutExtension(std::string_view path) {
   return std::filesystem::path(path)
       .filename()
       .replace_extension()  // remove extension, so `app.exe` on Windows would match `app` on

--- a/src/MizarModels/include/MizarModels/FrameTrackListModel.h
+++ b/src/MizarModels/include/MizarModels/FrameTrackListModel.h
@@ -107,7 +107,7 @@ class FrameTrackListModelTmpl : public QAbstractListModel {
                       *info);
   }
 
-  [[nodiscard]] QString MakeTooltip(FrameTrackId id, const std::string& name) const {
+  [[nodiscard]] QString MakeTooltip(FrameTrackId id, std::string_view name) const {
     const auto& [wall_clock_time, active_invocation_time] =
         data_->WallClockAndActiveInvocationTimeStats(
             *selected_tids_, id, *start_timestamp_,

--- a/src/MizarWidgets/MizarMainWindow.cpp
+++ b/src/MizarWidgets/MizarMainWindow.cpp
@@ -23,8 +23,9 @@ MizarMainWindow::MizarMainWindow(
   ui_->setupUi(this);
   QObject::connect(ui_->sampling_with_frame_track_widget_,
                    &SamplingWithFrameTrackWidget::ReportError, this,
-                   [this](const std::string& message) {
-                     QMessageBox::critical(this, "Invalid input", QString::fromStdString(message));
+                   [this](std::string_view message) {
+                     QMessageBox::critical(this, "Invalid input",
+                                           QString::fromUtf8(message.data(), message.size()));
                    });
 
   ui_->sampling_with_frame_track_widget_->Init(baseline_and_comparison, baseline_file_name,

--- a/src/OrbitBase/ExecuteCommandLinux.cpp
+++ b/src/OrbitBase/ExecuteCommandLinux.cpp
@@ -8,15 +8,16 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "OrbitBase/Logging.h"
 
 namespace orbit_base {
 
-std::optional<std::string> ExecuteCommand(const std::string& cmd) {
-  std::unique_ptr<FILE, decltype(&pclose)> pipe{popen(cmd.c_str(), "r"), pclose};
+std::optional<std::string> ExecuteCommand(std::string_view cmd) {
+  std::unique_ptr<FILE, decltype(&pclose)> pipe{popen(std::string{cmd}.c_str(), "r"), pclose};
   if (!pipe) {
-    ORBIT_ERROR("Could not open pipe for \"%s\"", cmd.c_str());
+    ORBIT_ERROR("Could not open pipe for \"%s\"", cmd);
     return std::optional<std::string>{};
   }
 

--- a/src/OrbitBase/GetProcAddressWindows.cpp
+++ b/src/OrbitBase/GetProcAddressWindows.cpp
@@ -11,12 +11,14 @@
 
 #include <absl/strings/str_format.h>
 
+#include <string_view>
+
 #include "OrbitBase/GetLastError.h"
 #include "OrbitBase/StringConversion.h"
 
 namespace orbit_base {
 
-ErrorMessageOr<void*> GetProcAddress(const std::string& module, const std::string& function) {
+ErrorMessageOr<void*> GetProcAddress(std::string_view module, std::string_view function) {
   std::wstring w_module = orbit_base::ToStdWString(module);
   HMODULE module_handle = GetModuleHandleW(w_module.c_str());
   if (module_handle == nullptr) {
@@ -25,7 +27,7 @@ ErrorMessageOr<void*> GetProcAddress(const std::string& module, const std::strin
                         module, function, GetLastErrorAsString()));
   }
 
-  void* address = ::GetProcAddress(module_handle, function.c_str());
+  void* address = ::GetProcAddress(module_handle, std::string{function}.c_str());
   if (address == nullptr) {
     return ErrorMessage(absl::StrFormat("Could not find function \"%s\" in module \"%s\": %s",
                                         function, module, GetLastErrorAsString()));

--- a/src/OrbitBase/Logging.cpp
+++ b/src/OrbitBase/Logging.cpp
@@ -82,11 +82,11 @@ void LogStacktrace() {
 
 namespace orbit_base_internal {
 
-void LogToFile(const std::string& message) {
+void LogToFile(std::string_view message) {
   absl::MutexLock lock(&orbit_base::log_file_mutex);
   if (orbit_base::log_file.get() != nullptr) {
     // Ignore any errors that can happen, we cannot do anything about them at this point anyways.
-    std::fwrite(message.c_str(), message.size(), 1, orbit_base::log_file.get());
+    std::fwrite(message.data(), message.size(), 1, orbit_base::log_file.get());
     std::fflush(orbit_base::log_file.get());
   }
 }

--- a/src/OrbitBase/LoggingUtils.cpp
+++ b/src/OrbitBase/LoggingUtils.cpp
@@ -9,6 +9,7 @@
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
 
+#include <string_view>
 #include <system_error>
 
 #include "OrbitBase/Logging.h"
@@ -54,12 +55,13 @@ std::vector<std::filesystem::path> ListFilesRecursivelyIgnoreErrors(
   return files_in_dir;
 }
 
-ErrorMessageOr<absl::Time> ParseLogFileTimestamp(const std::string& log_file_name) {
+ErrorMessageOr<absl::Time> ParseLogFileTimestamp(std::string_view log_file_name) {
   if (log_file_name.size() < kTimestampStartPos + kTimestampStringLength) {
     return ErrorMessage(
         absl::StrFormat("Unable to extract time information from log file: %s", log_file_name));
   }
-  std::string timestamp_string = log_file_name.substr(kTimestampStartPos, kTimestampStringLength);
+  std::string_view timestamp_string =
+      log_file_name.substr(kTimestampStartPos, kTimestampStringLength);
   absl::Time log_file_timestamp;
   std::string parse_time_error;
   if (!absl::ParseTime(kLogFileNameTimeFormat, timestamp_string, absl::UTCTimeZone(),

--- a/src/OrbitBase/LoggingUtils.h
+++ b/src/OrbitBase/LoggingUtils.h
@@ -10,6 +10,7 @@
 
 #include <filesystem>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "OrbitBase/Result.h"
@@ -21,7 +22,7 @@ constexpr const char* kLogFileNameDelimiter = "Orbit-%s-%u.log";
 
 [[nodiscard]] std::vector<std::filesystem::path> ListFilesRecursivelyIgnoreErrors(
     const std::filesystem::path& dir);
-ErrorMessageOr<absl::Time> ParseLogFileTimestamp(const std::string& log_file_name);
+ErrorMessageOr<absl::Time> ParseLogFileTimestamp(std::string_view log_file_name);
 [[nodiscard]] std::vector<std::filesystem::path> FindOldLogFiles(
     const std::vector<std::filesystem::path>& log_file_paths);
 // This function tries to remove files even when an error is returned. If some files are unable to

--- a/src/OrbitBase/include/OrbitBase/ExecuteCommand.h
+++ b/src/OrbitBase/include/OrbitBase/ExecuteCommand.h
@@ -12,7 +12,7 @@ namespace orbit_base {
 
 #if defined(__linux)
 
-std::optional<std::string> ExecuteCommand(const std::string& cmd);
+std::optional<std::string> ExecuteCommand(std::string_view cmd);
 
 #endif  // defined(__linux)
 

--- a/src/OrbitBase/include/OrbitBase/GetProcAddress.h
+++ b/src/OrbitBase/include/OrbitBase/GetProcAddress.h
@@ -15,11 +15,11 @@
 namespace orbit_base {
 
 // Returns the address of a function in the specified loaded module.
-ErrorMessageOr<void*> GetProcAddress(const std::string& module, const std::string& function);
+ErrorMessageOr<void*> GetProcAddress(std::string_view module, std::string_view function);
 
 // Utility function to cast the return of GetProcAddress into the specified function pointer type.
 template <typename FunctionPrototypeT>
-inline FunctionPrototypeT GetProcAddress(const std::string& module, const std::string& function) {
+inline FunctionPrototypeT GetProcAddress(std::string_view module, std::string_view function) {
   auto result = GetProcAddress(module, function);
   if (result.has_error()) {
     ORBIT_ERROR("Calling GetProcAddress: %s", result.error().message());

--- a/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
@@ -23,7 +23,7 @@ namespace orbit_base {
 // Example:
 // Future<std::string> result = thread_pool_->Schedule(/* whatever */);
 // ImmediateExecutor immediate_executor{};
-// Future<void> void_future = result.Then(&immediate_executor, [](const std::string& str) {
+// Future<void> void_future = result.Then(&immediate_executor, [](std::string_view str) {
 //   (void) str;
 // });
 // main_thread_executor_->WaitFor(void_future); // WaitFor only works with Future<void>

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -165,7 +165,7 @@ void LogStacktrace();
 
 namespace orbit_base_internal {
 
-void LogToFile(const std::string& message);
+void LogToFile(std::string_view message);
 
 #ifdef _WIN32
 // Add one indirection so that we can #include <Windows.h> in the .cpp instead of in this header.

--- a/src/OrbitCaptureGgpClient/OrbitCaptureGgpClient.cpp
+++ b/src/OrbitCaptureGgpClient/OrbitCaptureGgpClient.cpp
@@ -12,6 +12,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "GrpcProtos/services_ggp.grpc.pb.h"
@@ -33,7 +34,7 @@ using grpc::Status;
 
 class CaptureClientGgpClient::CaptureClientGgpClientImpl {
  public:
-  void SetupGrpcClient(const std::string& grpc_server_address);
+  void SetupGrpcClient(std::string_view grpc_server_address);
 
   [[nodiscard]] ErrorMessageOr<void> StartCapture();
   [[nodiscard]] ErrorMessageOr<void> StopCapture();
@@ -45,7 +46,7 @@ class CaptureClientGgpClient::CaptureClientGgpClientImpl {
   std::unique_ptr<orbit_grpc_protos::CaptureClientGgpService::Stub> capture_client_ggp_service_;
 };
 
-CaptureClientGgpClient::CaptureClientGgpClient(const std::string& grpc_server_address)
+CaptureClientGgpClient::CaptureClientGgpClient(std::string_view grpc_server_address)
     : pimpl{std::make_unique<CaptureClientGgpClientImpl>()} {
   pimpl->SetupGrpcClient(grpc_server_address);
 }
@@ -85,12 +86,12 @@ CaptureClientGgpClient::CaptureClientGgpClient(CaptureClientGgpClient&&) = defau
 CaptureClientGgpClient& CaptureClientGgpClient::operator=(CaptureClientGgpClient&&) = default;
 
 void CaptureClientGgpClient::CaptureClientGgpClientImpl::SetupGrpcClient(
-    const std::string& grpc_server_address) {
+    std::string_view grpc_server_address) {
   grpc::ChannelArguments channel_arguments;
   channel_arguments.SetMaxReceiveMessageSize(std::numeric_limits<int32_t>::max());
 
   std::shared_ptr<::grpc::Channel> grpc_channel = grpc::CreateCustomChannel(
-      grpc_server_address, grpc::InsecureChannelCredentials(), channel_arguments);
+      std::string{grpc_server_address}, grpc::InsecureChannelCredentials(), channel_arguments);
   if (!grpc_channel) {
     ORBIT_ERROR("Unable to create GRPC channel to %s", grpc_server_address);
     return;

--- a/src/OrbitCaptureGgpClient/include/OrbitCaptureGgpClient/OrbitCaptureGgpClient.h
+++ b/src/OrbitCaptureGgpClient/include/OrbitCaptureGgpClient/OrbitCaptureGgpClient.h
@@ -7,11 +7,12 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CaptureClientGgpClient {
  public:
-  explicit CaptureClientGgpClient(const std::string& grpc_server_address);
+  explicit CaptureClientGgpClient(std::string_view grpc_server_address);
   ~CaptureClientGgpClient();
   CaptureClientGgpClient(CaptureClientGgpClient&&);
   CaptureClientGgpClient& operator=(CaptureClientGgpClient&&);

--- a/src/OrbitCaptureGgpService/main.cpp
+++ b/src/OrbitCaptureGgpService/main.cpp
@@ -36,7 +36,7 @@ ABSL_FLAG(uint64_t, max_local_marker_depth_per_command_buffer, std::numeric_limi
 
 namespace {
 
-std::string GetLogFilePath(const std::string& log_directory) {
+std::string GetLogFilePath(std::string_view log_directory) {
   std::filesystem::path log_directory_path{log_directory};
   std::filesystem::create_directory(log_directory_path);
   const std::string log_file_path = log_directory_path / "OrbitCaptureGgpService.log";

--- a/src/OrbitClientGgp/main.cpp
+++ b/src/OrbitClientGgp/main.cpp
@@ -46,7 +46,7 @@ ABSL_FLAG(uint64_t, max_local_marker_depth_per_command_buffer, std::numeric_limi
 
 namespace {
 
-std::string GetLogFilePath(const std::string& log_directory) {
+std::string GetLogFilePath(std::string_view log_directory) {
   std::filesystem::path log_directory_path{log_directory};
   std::filesystem::create_directory(log_directory_path);
   std::filesystem::path log_file_path = log_directory_path / "OrbitClientGgp.log";

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -16,15 +16,11 @@
 
 namespace orbit_gl {
 
-namespace {
-
-static std::array<std::string, kBasicPageFaultsTrackDimension> CreateSeriesName(
-    const std::string& cgroup_name, const std::string& process_name) {
+[[nodiscard]] static std::array<std::string, kBasicPageFaultsTrackDimension> CreateSeriesName(
+    std::string_view cgroup_name, std::string_view process_name) {
   return {absl::StrFormat("Process [%s]", process_name),
           absl::StrFormat("CGroup [%s]", cgroup_name), "System"};
 }
-
-}  // namespace
 
 static constexpr uint8_t kTrackValueDecimalDigits = 0;
 static constexpr const char* kTrackValueUnits = "";

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -18,30 +18,27 @@
 
 namespace orbit_gl {
 
-namespace {
-const std::string kTrackValueLabelUnit = "MB";
+constexpr std::string_view kTrackValueLabelUnit = "MB";
 
-static std::array<std::string, kCGroupAndProcessMemoryTrackDimension> CreateSeriesName(
-    const std::string& cgroup_name, const std::string& process_name) {
+[[nodiscard]] static std::array<std::string, kCGroupAndProcessMemoryTrackDimension>
+CreateSeriesName(std::string_view cgroup_name, std::string_view process_name) {
   return {absl::StrFormat("Process [%s] RssAnon", process_name), "Other Processes RssAnon",
           absl::StrFormat("CGroup [%s] Mapped File", cgroup_name),
           absl::StrFormat("CGroup [%s] Unused", cgroup_name)};
 }
 
-}  // namespace
-
 static constexpr uint8_t kTrackValueDecimalDigits = 2;
 
 CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
     CaptureViewElement* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
-    orbit_gl::Viewport* viewport, TimeGraphLayout* layout, const std::string& cgroup_name,
+    orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string cgroup_name,
     const orbit_client_data::ModuleManager* module_manager,
     const orbit_client_data::CaptureData* capture_data)
     : MemoryTrack<kCGroupAndProcessMemoryTrackDimension>(
           parent, timeline_info, viewport, layout,
           CreateSeriesName(cgroup_name, capture_data->process_name()), kTrackValueDecimalDigits,
-          kTrackValueLabelUnit, module_manager, capture_data),
-      cgroup_name_(cgroup_name) {
+          std::string{kTrackValueLabelUnit}, module_manager, capture_data),
+      cgroup_name_(std::move(cgroup_name)) {
   // Colors are selected from https://convertingcolors.com/list/avery.html.
   // Use reddish colors for different used memories, yellowish colors for different cached memories
   // and greenish colors for different unused memories.

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -110,9 +110,9 @@ CallTreeUnwindErrors* CallTreeNode::AddAndGetUnwindErrors() {
 
 [[nodiscard]] static CallTreeFunction* GetOrCreateFunctionNode(CallTreeNode* current_node,
                                                                uint64_t frame,
-                                                               const std::string& function_name,
-                                                               const std::string& module_path,
-                                                               const std::string& module_build_id) {
+                                                               std::string_view function_name,
+                                                               std::string_view module_path,
+                                                               std::string_view module_build_id) {
   CallTreeFunction* function_node = current_node->GetFunctionOrNull(frame);
   if (function_node == nullptr) {
     std::string formatted_function_name;
@@ -121,8 +121,9 @@ CallTreeUnwindErrors* CallTreeNode::AddAndGetUnwindErrors() {
     } else {
       formatted_function_name = absl::StrFormat("[unknown@%#llx]", frame);
     }
-    function_node = current_node->AddAndGetFunction(frame, std::move(formatted_function_name),
-                                                    module_path, module_build_id);
+    function_node =
+        current_node->AddAndGetFunction(frame, std::move(formatted_function_name),
+                                        std::string{module_path}, std::string{module_build_id});
   }
   return function_node;
 }
@@ -190,7 +191,7 @@ static void AddUnwindErrorToTopDownThread(
 }
 
 [[nodiscard]] static CallTreeThread* GetOrCreateThreadNode(
-    CallTreeNode* current_node, uint32_t tid, const std::string& process_name,
+    CallTreeNode* current_node, uint32_t tid, std::string_view process_name,
     const absl::flat_hash_map<uint32_t, std::string>& thread_names) {
   CallTreeThread* thread_node = current_node->GetThreadOrNull(tid);
   if (thread_node == nullptr) {

--- a/src/OrbitGl/MajorPageFaultsTrack.cpp
+++ b/src/OrbitGl/MajorPageFaultsTrack.cpp
@@ -7,6 +7,7 @@
 #include <absl/strings/substitute.h>
 
 #include <optional>
+#include <utility>
 
 #include "OrbitBase/Logging.h"
 
@@ -14,11 +15,11 @@ namespace orbit_gl {
 MajorPageFaultsTrack::MajorPageFaultsTrack(Track* parent,
                                            const orbit_gl::TimelineInfoInterface* timeline_info,
                                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                           const std::string& cgroup_name,
+                                           std::string cgroup_name,
                                            uint64_t memory_sampling_period_ms,
                                            const orbit_client_data::ModuleManager* module_manager,
                                            const orbit_client_data::CaptureData* capture_data)
-    : BasicPageFaultsTrack(parent, timeline_info, viewport, layout, cgroup_name,
+    : BasicPageFaultsTrack(parent, timeline_info, viewport, layout, std::move(cgroup_name),
                            memory_sampling_period_ms, module_manager, capture_data) {
   index_of_series_to_highlight_ = static_cast<size_t>(SeriesIndex::kProcess);
 }

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -34,27 +34,25 @@ void MemoryTrack<Dimension>::DoDraw(PrimitiveAssembler& primitive_assembler,
 }
 
 template <size_t Dimension>
-void MemoryTrack<Dimension>::TrySetValueUpperBound(const std::string& pretty_label,
-                                                   double raw_value) {
+void MemoryTrack<Dimension>::TrySetValueUpperBound(std::string pretty_label, double raw_value) {
   double max_series_value = GraphTrack<Dimension>::GetGraphMaxValue();
   if (raw_value < max_series_value) {
     ORBIT_LOG("Fail to set MemoryTrack value upper bound: input value %f < maximum series value %f",
               raw_value, max_series_value);
     return;
   }
-  this->SetValueUpperBound(pretty_label, raw_value);
+  this->SetValueUpperBound(std::move(pretty_label), raw_value);
 }
 
 template <size_t Dimension>
-void MemoryTrack<Dimension>::TrySetValueLowerBound(const std::string& pretty_label,
-                                                   double raw_value) {
+void MemoryTrack<Dimension>::TrySetValueLowerBound(std::string pretty_label, double raw_value) {
   double min_series_value = GraphTrack<Dimension>::GetGraphMinValue();
   if (raw_value > min_series_value) {
     ORBIT_LOG("Fail to set MemoryTrack value lower bound: input value %f > minimum series value %f",
               raw_value, min_series_value);
     return;
   }
-  this->SetValueLowerBound(pretty_label, raw_value);
+  this->SetValueLowerBound(std::move(pretty_label), raw_value);
 }
 
 template <size_t Dimension>

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -20,7 +20,7 @@ namespace orbit_gl {
 PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent,
                                  const orbit_gl::TimelineInfoInterface* timeline_info,
                                  orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                 const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
+                                 std::string cgroup_name, uint64_t memory_sampling_period_ms,
                                  const orbit_client_data::ModuleManager* module_manager,
                                  const orbit_client_data::CaptureData* capture_data)
     : Track(parent, timeline_info, viewport, layout, module_manager, capture_data),
@@ -28,7 +28,7 @@ PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent,
           this, timeline_info, viewport, layout, cgroup_name, memory_sampling_period_ms,
           module_manager, capture_data)},
       minor_page_faults_track_{std::make_shared<MinorPageFaultsTrack>(
-          this, timeline_info, viewport, layout, cgroup_name, memory_sampling_period_ms,
+          this, timeline_info, viewport, layout, std::move(cgroup_name), memory_sampling_period_ms,
           module_manager, capture_data)} {
   // PageFaults track is collapsed by default. The major and minor page faults subtracks are
   // expanded by default, but not shown while the page faults track is collapsed.

--- a/src/OrbitGl/SymbolLoader.cpp
+++ b/src/OrbitGl/SymbolLoader.cpp
@@ -65,7 +65,7 @@ SymbolLoader::SymbolLoader(AppInterface* app_interface, std::thread::id main_thr
   }
 }
 
-void SymbolLoader::DisableDownloadForModule(const std::string& module_path) {
+void SymbolLoader::DisableDownloadForModule(std::string_view module_path) {
   download_disabled_modules_.emplace(module_path);
   orbit_client_symbols::QSettingsBasedStorageManager storage_manager;
   storage_manager.SaveDisabledModulePaths(download_disabled_modules_);
@@ -436,7 +436,7 @@ Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> SymbolLoader::Retrieve
 }
 
 Future<ErrorMessageOr<CanceledOr<std::filesystem::path>>> SymbolLoader::RetrieveModuleFromInstance(
-    const std::string& module_file_path, StopToken stop_token) {
+    std::string_view module_file_path, StopToken stop_token) {
   ORBIT_SCOPE_FUNCTION;
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
 
@@ -762,14 +762,14 @@ Future<ErrorMessageOr<std::filesystem::path>> SymbolLoader::RetrieveModuleWithDe
       });
 }
 
-void SymbolLoader::RequestSymbolDownloadStop(const std::string& module_path) {
+void SymbolLoader::RequestSymbolDownloadStop(std::string_view module_path) {
   ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
   if (symbol_files_currently_downloading_.contains(module_path)) {
     symbol_files_currently_downloading_.at(module_path).stop_source.RequestStop();
   }
 }
 
-bool SymbolLoader::IsModuleDownloading(const std::string& module_path) const {
+bool SymbolLoader::IsModuleDownloading(std::string_view module_path) const {
   ORBIT_CHECK(main_thread_id_ == std::this_thread::get_id());
   return symbol_files_currently_downloading_.contains(module_path);
 }

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -129,8 +129,8 @@ void TrackContainer::UpdateTracksPosition() {
 
 namespace {
 
-[[nodiscard]] std::string GetLabelBetweenIterators(const std::string& function_from,
-                                                   const std::string& function_to) {
+[[nodiscard]] std::string GetLabelBetweenIterators(std::string_view function_from,
+                                                   std::string_view function_to) {
   return absl::StrFormat("%s to %s", function_from, function_to);
 }
 
@@ -152,8 +152,8 @@ std::string GetTimeString(const TimerInfo& timer_a, const TimerInfo& timer_b) {
 
 void TrackContainer::DrawIteratorBox(PrimitiveAssembler& primitive_assembler,
                                      TextRenderer& text_renderer, Vec2 pos, Vec2 size,
-                                     const Color& color, const std::string& label,
-                                     const std::string& time, float text_box_y) {
+                                     const Color& color, std::string_view label,
+                                     std::string_view time, float text_box_y) {
   Quad box = MakeBox(pos, size);
   primitive_assembler.AddBox(box, GlCanvas::kZValueOverlay, color);
 
@@ -344,7 +344,7 @@ void TrackContainer::DrawIncompleteDataIntervals(PrimitiveAssembler& primitive_a
   }
 }
 
-void TrackContainer::SetThreadFilter(const std::string& filter) {
+void TrackContainer::SetThreadFilter(std::string_view filter) {
   track_manager_->SetFilter(filter);
   RequestUpdate();
 }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -178,7 +178,7 @@ void TrackManager::SortTracks() {
   visible_track_list_needs_update_ = true;
 }
 
-void TrackManager::SetFilter(const std::string& filter) {
+void TrackManager::SetFilter(std::string_view filter) {
   filter_ = absl::AsciiStrToLower(filter);
   visible_track_list_needs_update_ = true;
 }
@@ -489,7 +489,7 @@ GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
   return track.get();
 }
 
-VariableTrack* TrackManager::GetOrCreateVariableTrack(const std::string& name) {
+VariableTrack* TrackManager::GetOrCreateVariableTrack(std::string name) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<VariableTrack> track = variable_tracks_[name];
   if (track == nullptr) {
@@ -501,7 +501,7 @@ VariableTrack* TrackManager::GetOrCreateVariableTrack(const std::string& name) {
   return track.get();
 }
 
-AsyncTrack* TrackManager::GetOrCreateAsyncTrack(const std::string& name) {
+AsyncTrack* TrackManager::GetOrCreateAsyncTrack(std::string name) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<AsyncTrack> track = async_tracks_[name];
   if (track == nullptr) {
@@ -511,7 +511,6 @@ AsyncTrack* TrackManager::GetOrCreateAsyncTrack(const std::string& name) {
     async_tracks_[name] = track;
     AddTrack(track);
   }
-
   return track.get();
 }
 
@@ -549,24 +548,24 @@ SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack() {
 }
 
 CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTrack(
-    const std::string& cgroup_name) {
+    std::string_view cgroup_name) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   if (cgroup_and_process_memory_track_ == nullptr) {
     cgroup_and_process_memory_track_ = std::make_shared<CGroupAndProcessMemoryTrack>(
-        track_container_, timeline_info_, viewport_, layout_, cgroup_name, module_manager_,
-        capture_data_);
+        track_container_, timeline_info_, viewport_, layout_, std::string{cgroup_name},
+        module_manager_, capture_data_);
     AddTrack(cgroup_and_process_memory_track_);
   }
 
   return GetCGroupAndProcessMemoryTrack();
 }
 
-PageFaultsTrack* TrackManager::CreateAndGetPageFaultsTrack(const std::string& cgroup_name,
+PageFaultsTrack* TrackManager::CreateAndGetPageFaultsTrack(std::string_view cgroup_name,
                                                            uint64_t memory_sampling_period_ms) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   if (page_faults_track_ == nullptr) {
     page_faults_track_ = std::make_shared<PageFaultsTrack>(
-        track_container_, timeline_info_, viewport_, layout_, cgroup_name,
+        track_container_, timeline_info_, viewport_, layout_, std::string{cgroup_name},
         memory_sampling_period_ms, module_manager_, capture_data_);
     AddTrack(page_faults_track_);
   }

--- a/src/OrbitGl/include/OrbitGl/AnnotationTrack.h
+++ b/src/OrbitGl/include/OrbitGl/AnnotationTrack.h
@@ -28,14 +28,14 @@ class AnnotationTrack {
     return value_lower_bound_;
   }
 
-  void SetWarningThreshold(const std::string& pretty_label, double raw_value) {
-    warning_threshold_ = std::make_pair(pretty_label, raw_value);
+  void SetWarningThreshold(std::string pretty_label, double raw_value) {
+    warning_threshold_ = std::make_pair(std::move(pretty_label), raw_value);
   }
-  virtual void SetValueUpperBound(const std::string& pretty_label, double raw_value) {
-    value_upper_bound_ = std::make_pair(pretty_label, raw_value);
+  virtual void SetValueUpperBound(std::string pretty_label, double raw_value) {
+    value_upper_bound_ = std::make_pair(std::move(pretty_label), raw_value);
   }
-  virtual void SetValueLowerBound(const std::string& pretty_label, double raw_value) {
-    value_lower_bound_ = std::make_pair(pretty_label, raw_value);
+  virtual void SetValueLowerBound(std::string pretty_label, double raw_value) {
+    value_lower_bound_ = std::make_pair(std::move(pretty_label), raw_value);
   }
 
   void DrawAnnotation(orbit_gl::PrimitiveAssembler& primitive_assembler,

--- a/src/OrbitGl/include/OrbitGl/CGroupAndProcessMemoryTrack.h
+++ b/src/OrbitGl/include/OrbitGl/CGroupAndProcessMemoryTrack.h
@@ -30,7 +30,7 @@ class CGroupAndProcessMemoryTrack final
   explicit CGroupAndProcessMemoryTrack(CaptureViewElement* parent,
                                        const orbit_gl::TimelineInfoInterface* timeline_info,
                                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                       const std::string& cgroup_name,
+                                       std::string group_name,
                                        const orbit_client_data::ModuleManager* module_manager,
                                        const orbit_client_data::CaptureData* capture_data);
 

--- a/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
@@ -44,14 +44,14 @@ class MainWindowInterface {
       const std::filesystem::path& file_path, size_t line_number,
       std::optional<std::unique_ptr<orbit_code_report::CodeReport>> code_report) = 0;
   virtual void ShowDisassembly(const orbit_client_data::FunctionInfo& function_info,
-                               const std::string& assembly,
+                               std::string_view assembly,
                                orbit_code_report::DisassemblyReport report) = 0;
 
   enum class CaptureLogSeverity { kInfo, kWarning, kSevereWarning, kError };
   virtual void AppendToCaptureLog(CaptureLogSeverity severity, absl::Duration capture_time,
                                   std::string_view message) = 0;
 
-  virtual void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
+  virtual void ShowHistogram(const std::vector<uint64_t>* data, std::string scope_name,
                              std::optional<ScopeId> scope_id) = 0;
 
   enum class SymbolErrorHandlingResult { kReloadRequired, kSymbolLoadingCancelled };

--- a/src/OrbitGl/include/OrbitGl/MajorPageFaultsTrack.h
+++ b/src/OrbitGl/include/OrbitGl/MajorPageFaultsTrack.h
@@ -25,7 +25,7 @@ class MajorPageFaultsTrack final : public BasicPageFaultsTrack {
  public:
   explicit MajorPageFaultsTrack(Track* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
                                 orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
+                                std::string cgroup_name, uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::ModuleManager* module_manager,
                                 const orbit_client_data::CaptureData* capture_data);
 

--- a/src/OrbitGl/include/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/include/OrbitGl/MemoryTrack.h
@@ -49,8 +49,8 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
 
   [[nodiscard]] Track::Type GetType() const override { return Track::Type::kMemoryTrack; }
 
-  void TrySetValueUpperBound(const std::string& pretty_label, double raw_value);
-  void TrySetValueLowerBound(const std::string& pretty_label, double raw_value);
+  void TrySetValueUpperBound(std::string pretty_label, double raw_value);
+  void TrySetValueLowerBound(std::string pretty_label, double raw_value);
 
  protected:
   void DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,

--- a/src/OrbitGl/include/OrbitGl/MinorPageFaultsTrack.h
+++ b/src/OrbitGl/include/OrbitGl/MinorPageFaultsTrack.h
@@ -25,10 +25,10 @@ class MinorPageFaultsTrack final : public BasicPageFaultsTrack {
  public:
   explicit MinorPageFaultsTrack(Track* parent, const orbit_gl::TimelineInfoInterface* timeline_info,
                                 orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
+                                std::string cgroup_name, uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::ModuleManager* module_manager,
                                 const orbit_client_data::CaptureData* capture_data)
-      : BasicPageFaultsTrack(parent, timeline_info, viewport, layout, cgroup_name,
+      : BasicPageFaultsTrack(parent, timeline_info, viewport, layout, std::move(cgroup_name),
                              memory_sampling_period_ms, module_manager, capture_data) {}
 
   [[nodiscard]] std::string GetName() const override { return "Page Faults: Minor"; }

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -118,11 +118,11 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] absl::Duration GetCaptureTime() const;
   [[nodiscard]] absl::Duration GetCaptureTimeAt(uint64_t timestamp_ns) const;
 
-  [[nodiscard]] std::string GetSaveFile(const std::string& extension) const override;
-  void SetClipboard(const std::string& text) override;
+  [[nodiscard]] std::string GetSaveFile(std::string_view extension) const override;
+  void SetClipboard(std::string_view text) override;
 
-  ErrorMessageOr<void> OnSavePreset(const std::string& file_name);
-  ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
+  ErrorMessageOr<void> OnSavePreset(std::string_view file_name);
+  ErrorMessageOr<void> OnLoadPreset(std::string_view file_name);
   orbit_base::Future<ErrorMessageOr<CaptureOutcome>> LoadCaptureFromFile(
       const std::filesystem::path& file_path);
 
@@ -272,15 +272,15 @@ class OrbitApp final : public DataViewFactory,
   void SetSelectLiveTabCallback(SelectLiveTabCallback callback) {
     select_live_tab_callback_ = std::move(callback);
   }
-  using ErrorMessageCallback = std::function<void(const std::string&, const std::string&)>;
+  using ErrorMessageCallback = std::function<void(std::string_view, std::string_view)>;
   void SetErrorMessageCallback(ErrorMessageCallback callback) {
     error_message_callback_ = std::move(callback);
   }
-  using WarningMessageCallback = std::function<void(const std::string&, const std::string&)>;
+  using WarningMessageCallback = std::function<void(std::string_view, std::string_view)>;
   void SetWarningMessageCallback(WarningMessageCallback callback) {
     warning_message_callback_ = std::move(callback);
   }
-  using InfoMessageCallback = std::function<void(const std::string&, const std::string&)>;
+  using InfoMessageCallback = std::function<void(std::string_view, std::string_view)>;
   void SetInfoMessageCallback(InfoMessageCallback callback) {
     info_message_callback_ = std::move(callback);
   }
@@ -314,24 +314,24 @@ class OrbitApp final : public DataViewFactory,
     timer_selected_callback_ = std::move(callback);
   }
 
-  using SaveFileCallback = std::function<std::string(const std::string& extension)>;
+  using SaveFileCallback = std::function<std::string(std::string_view extension)>;
   void SetSaveFileCallback(SaveFileCallback callback) { save_file_callback_ = std::move(callback); }
   void FireRefreshCallbacks(
       orbit_data_views::DataViewType type = orbit_data_views::DataViewType::kAll);
   void OnModuleListUpdated() override {
     FireRefreshCallbacks(orbit_data_views::DataViewType::kModules);
   }
-  using ClipboardCallback = std::function<void(const std::string&)>;
+  using ClipboardCallback = std::function<void(std::string_view)>;
   void SetClipboardCallback(ClipboardCallback callback) {
     clipboard_callback_ = std::move(callback);
   }
 
   void SendDisassemblyToUi(const orbit_client_data::FunctionInfo& function_info,
                            std::string disassembly, orbit_code_report::DisassemblyReport report);
-  void SendTooltipToUi(const std::string& tooltip);
-  void SendInfoToUi(const std::string& title, const std::string& text);
-  void SendWarningToUi(const std::string& title, const std::string& text);
-  void SendErrorToUi(const std::string& title, const std::string& text) override;
+  void SendTooltipToUi(std::string_view tooltip);
+  void SendInfoToUi(std::string_view title, std::string_view text);
+  void SendWarningToUi(std::string_view title, std::string_view text);
+  void SendErrorToUi(std::string_view title, std::string_view text) override;
 
   orbit_base::Future<void> LoadSymbolsManually(
       absl::Span<const orbit_client_data::ModuleData* const> modules) override;
@@ -356,7 +356,7 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] orbit_data_views::PresetLoadState GetPresetLoadState(
       const orbit_preset_file::PresetFile& preset) const override;
   void ShowPresetInExplorer(const orbit_preset_file::PresetFile& preset) override;
-  void FilterTracks(const std::string& filter);
+  void FilterTracks(std::string_view filter);
 
   void CrashOrbitService(orbit_grpc_protos::CrashOrbitServiceRequest_CrashType crash_type);
 
@@ -539,7 +539,7 @@ class OrbitApp final : public DataViewFactory,
       const orbit_client_data::ModuleData* module) const override;
   void RequestSymbolDownloadStop(
       absl::Span<const orbit_client_data::ModuleData* const> modules) override;
-  void DisableDownloadForModule(const std::string& module_file_path);
+  void DisableDownloadForModule(std::string_view module_file_path);
 
   // Triggers symbol loading for all modules in ModuleManager that are not loaded yet. This is done
   // with a simple prioritization. The module `ggpvlk.so` is queued to be loaded first, the "main
@@ -580,7 +580,7 @@ class OrbitApp final : public DataViewFactory,
       const std::filesystem::path& filename);
   ErrorMessageOr<void> ConvertPresetToNewFormatIfNecessary(
       const orbit_preset_file::PresetFile& preset_file);
-  ErrorMessageOr<void> SavePreset(const std::string& filename);
+  ErrorMessageOr<void> SavePreset(std::string_view filename);
 
   void AddFrameTrack(uint64_t instrumented_function_id);
   void RemoveFrameTrack(uint64_t instrumented_function_id);
@@ -598,7 +598,7 @@ class OrbitApp final : public DataViewFactory,
 
   void RequestUpdatePrimitives();
 
-  void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
+  void ShowHistogram(const std::vector<uint64_t>* data, std::string scope_name,
                      std::optional<ScopeId> scope_id) override;
 
   // Sets CaptureData's selection_callstack_data and selection_post_processed_sampling_data.

--- a/src/OrbitGl/include/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/include/OrbitGl/PageFaultsTrack.h
@@ -39,7 +39,7 @@ class PageFaultsTrack : public Track {
   explicit PageFaultsTrack(CaptureViewElement* parent,
                            const orbit_gl::TimelineInfoInterface* timeline_info,
                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                           const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
+                           std::string cgroup_name, uint64_t memory_sampling_period_ms,
                            const orbit_client_data::ModuleManager* module_manager,
                            const orbit_client_data::CaptureData* capture_data);
 

--- a/src/OrbitGl/include/OrbitGl/SymbolLoader.h
+++ b/src/OrbitGl/include/OrbitGl/SymbolLoader.h
@@ -71,12 +71,12 @@ class SymbolLoader {
   orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleWithDebugInfo(
       const orbit_symbol_provider::ModuleIdentifier& module_id);
 
-  void DisableDownloadForModule(const std::string& module_path);
+  void DisableDownloadForModule(std::string_view module_path);
   void EnableDownloadForModules(const absl::flat_hash_set<std::string>& module_paths);
 
-  void RequestSymbolDownloadStop(const std::string& module_path);
+  void RequestSymbolDownloadStop(std::string_view module_path);
 
-  [[nodiscard]] bool IsModuleDownloading(const std::string& module_path) const;
+  [[nodiscard]] bool IsModuleDownloading(std::string_view module_path) const;
   [[nodiscard]] orbit_data_views::SymbolLoadingState GetSymbolLoadingStateForModule(
       const orbit_client_data::ModuleData* module) const;
   [[nodiscard]] bool IsSymbolLoadingInProgressForModule(
@@ -103,7 +103,7 @@ class SymbolLoader {
   orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
   RetrieveModuleFromRemote(const orbit_symbol_provider::ModuleIdentifier& module_id);
   orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<std::filesystem::path>>>
-  RetrieveModuleFromInstance(const std::string& module_file_path, orbit_base::StopToken stop_token);
+  RetrieveModuleFromInstance(std::string_view module_file_path, orbit_base::StopToken stop_token);
 
   // RetrieveModuleItselfAndLoadFallbackSymbols retrieves the module's binary by calling
   // `RetrieveModuleItself` and afterwards loads the fallback symbols by calling

--- a/src/OrbitGl/include/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraph.h
@@ -161,8 +161,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
     return colors[id % colors.size()];
   }
 
-  [[nodiscard]] static Color GetColor(const std::string& str) {
-    return GetColor(std::hash<std::string>{}(str));
+  [[nodiscard]] static Color GetColor(std::string_view str) {
+    return GetColor(std::hash<std::string_view>{}(str));
   }
 
   [[nodiscard]] uint64_t GetCaptureMin() const { return capture_min_timestamp_; }

--- a/src/OrbitGl/include/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/include/OrbitGl/TrackContainer.h
@@ -53,7 +53,7 @@ class TrackContainer final : public CaptureViewElement {
   void VerticallyMoveIntoView(const orbit_client_protos::TimerInfo& timer_info);
   void VerticallyMoveIntoView(const Track& track);
 
-  void SetThreadFilter(const std::string& filter);
+  void SetThreadFilter(std::string_view filter);
 
   [[nodiscard]] int GetNumVisiblePrimitives() const;
 
@@ -99,8 +99,8 @@ class TrackContainer final : public CaptureViewElement {
                                  orbit_client_data::ThreadStateSliceInfo thread_state_slice,
                                  const Color& arrow_color, PickingMode picking_mode);
   void DrawIteratorBox(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
-                       Vec2 pos, Vec2 size, const Color& color, const std::string& label,
-                       const std::string& time, float text_box_y);
+                       Vec2 pos, Vec2 size, const Color& color, std::string_view label,
+                       std::string_view time, float text_box_y);
   void DrawIncompleteDataIntervals(PrimitiveAssembler& primitive_assembler,
                                    PickingMode picking_mode);
 

--- a/src/OrbitGl/include/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/include/OrbitGl/TrackManager.h
@@ -57,7 +57,7 @@ class TrackManager {
   [[nodiscard]] std::vector<FrameTrack*> GetFrameTracks() const;
 
   void RequestTrackSorting() { sorting_invalidated_ = true; };
-  void SetFilter(const std::string& filter);
+  void SetFilter(std::string_view filter);
 
   void UpdateTrackListForRendering();
 
@@ -71,8 +71,8 @@ class TrackManager {
   ThreadTrack* GetOrCreateThreadTrack(uint32_t tid);
   [[nodiscard]] std::optional<ThreadTrack*> GetThreadTrack(uint32_t tid) const;
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
-  VariableTrack* GetOrCreateVariableTrack(const std::string& name);
-  AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
+  VariableTrack* GetOrCreateVariableTrack(std::string name);
+  AsyncTrack* GetOrCreateAsyncTrack(std::string name);
   FrameTrack* GetOrCreateFrameTrack(uint64_t function_id);
   [[nodiscard]] SystemMemoryTrack* GetSystemMemoryTrack() const {
     return system_memory_track_.get();
@@ -82,9 +82,9 @@ class TrackManager {
     return cgroup_and_process_memory_track_.get();
   }
   [[nodiscard]] CGroupAndProcessMemoryTrack* CreateAndGetCGroupAndProcessMemoryTrack(
-      const std::string& cgroup_name);
+      std::string_view cgroup_name);
   PageFaultsTrack* GetPageFaultsTrack() const { return page_faults_track_.get(); }
-  PageFaultsTrack* CreateAndGetPageFaultsTrack(const std::string& cgroup_name,
+  PageFaultsTrack* CreateAndGetPageFaultsTrack(std::string_view cgroup_name,
                                                uint64_t memory_sampling_period_ms);
 
   [[nodiscard]] bool GetIsDataFromSavedCapture() const { return data_from_saved_capture_; }

--- a/src/OrbitQt/include/OrbitQt/orbiteventiterator.h
+++ b/src/OrbitQt/include/OrbitQt/orbiteventiterator.h
@@ -43,7 +43,7 @@ class OrbitEventIterator : public QFrame {
     delete_button_callback_ = callback;
   }
 
-  void SetFunctionName(const std::string& function);
+  void SetFunctionName(std::string_view function);
   void SetMinMaxTime(uint64_t min_time_us, uint64_t max_time_us);
   void SetCurrentTime(uint64_t current_time_us);
 

--- a/src/OrbitQt/include/OrbitQt/orbitlivefunctions.h
+++ b/src/OrbitQt/include/OrbitQt/orbitlivefunctions.h
@@ -49,7 +49,7 @@ class OrbitLiveFunctions : public QWidget {
   std::optional<LiveFunctionsController*> GetLiveFunctionsController() {
     return live_functions_ ? &live_functions_.value() : nullptr;
   }
-  void ShowHistogram(const std::vector<uint64_t>* data, const std::string& scope_name,
+  void ShowHistogram(const std::vector<uint64_t>* data, std::string scope_name,
                      std::optional<orbit_client_data::ScopeId> scope_id);
 
  signals:

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -91,9 +91,9 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void OnNewBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view);
   void OnNewSelectionBottomUpView(std::unique_ptr<CallTreeView> selection_bottom_up_view);
 
-  std::string OnGetSaveFileName(const std::string& extension);
-  void OnSetClipboard(const std::string& text);
-  void OpenCapture(const std::string& filepath);
+  std::string OnGetSaveFileName(std::string_view extension);
+  void OnSetClipboard(std::string_view text);
+  void OpenCapture(std::string_view filepath);
   void OnCaptureCleared();
 
   Ui::OrbitMainWindow* GetUi() { return ui; }
@@ -109,7 +109,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
       const std::filesystem::path& file_path, size_t line_number,
       std::optional<std::unique_ptr<orbit_code_report::CodeReport>> maybe_code_report) override;
   void ShowDisassembly(const orbit_client_data::FunctionInfo& function_info,
-                       const std::string& assembly,
+                       std::string_view assembly,
                        orbit_code_report::DisassemblyReport report) override;
 
   void AppendToCaptureLog(CaptureLogSeverity severity, absl::Duration capture_time,
@@ -120,7 +120,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
       std::string_view title, std::string_view text,
       std::string_view dont_show_again_setting_key) override;
 
-  void ShowHistogram(const std::vector<uint64_t>* data, const std::string& function_name,
+  void ShowHistogram(const std::vector<uint64_t>* data, std::string function_name,
                      std::optional<ScopeId> function_id) override;
 
   orbit_base::Future<ErrorMessageOr<orbit_base::CanceledOr<void>>> DownloadFileFromInstance(

--- a/src/OrbitQt/include/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/include/OrbitQt/orbittreeview.h
@@ -58,7 +58,7 @@ class OrbitTreeView : public QTreeView {
   void OnSort(int section, Qt::SortOrder order);
   void OnTimer();
   void ShowContextMenu(const QPoint& pos);
-  void OnMenuClicked(const std::string& action, int menu_index);
+  void OnMenuClicked(std::string_view action, int menu_index);
   void OnRangeChanged(int min, int max);
   void OnDoubleClicked(QModelIndex index);
   void OnRowsSelected(std::vector<int>& rows);

--- a/src/OrbitQt/orbitdataviewpanel.cpp
+++ b/src/OrbitQt/orbitdataviewpanel.cpp
@@ -43,7 +43,9 @@ void OrbitDataViewPanel::Initialize(orbit_data_views::DataView* data_view,
     ui_->refreshButton->hide();
   }
 
-  data_view->SetUiFilterCallback([this](const std::string& filter) { SetFilter(filter.c_str()); });
+  data_view->SetUiFilterCallback([this](std::string_view filter) {
+    SetFilter(QString::fromUtf8(filter.data(), filter.size()));
+  });
 }
 
 void OrbitDataViewPanel::Deinitialize() { ui_->treeView->Deinitialize(); }

--- a/src/OrbitQt/orbiteventiterator.cpp
+++ b/src/OrbitQt/orbiteventiterator.cpp
@@ -37,8 +37,8 @@ void OrbitEventIterator::on_DeleteButton_clicked() {
   }
 }
 
-void OrbitEventIterator::SetFunctionName(const std::string& function_name) {
-  ui->Label->setTextWithElision(QString::fromStdString(function_name));
+void OrbitEventIterator::SetFunctionName(std::string_view function_name) {
+  ui->Label->setTextWithElision(QString::fromUtf8(function_name.data(), function_name.size()));
 }
 
 void OrbitEventIterator::SetMinMaxTime(uint64_t min_time, uint64_t max_time) {

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -169,8 +169,7 @@ void OrbitLiveFunctions::OnRowSelected(std::optional<int> row) {
   ui_->data_view_panel_->GetTreeView()->SetIsInternalRefresh(false);
 }
 
-void OrbitLiveFunctions::ShowHistogram(const std::vector<uint64_t>* data,
-                                       const std::string& scope_name,
+void OrbitLiveFunctions::ShowHistogram(const std::vector<uint64_t>* data, std::string scope_name,
                                        std::optional<orbit_client_data::ScopeId> scope_id) {
-  ui_->histogram_widget_->UpdateData(data, scope_name, scope_id);
+  ui_->histogram_widget_->UpdateData(data, std::move(scope_name), scope_id);
 }

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -240,7 +240,7 @@ void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
   context_menu.exec(mapToGlobal(pos));
 }
 
-void OrbitTreeView::OnMenuClicked(const std::string& action, int menu_index) {
+void OrbitTreeView::OnMenuClicked(std::string_view action, int menu_index) {
   if (model_ == nullptr) {
     return;
   }

--- a/src/OrbitSsh/Channel.cpp
+++ b/src/OrbitSsh/Channel.cpp
@@ -36,10 +36,10 @@ outcome::result<Channel> Channel::OpenChannel(Session* session) {
 }
 
 outcome::result<Channel> Channel::OpenTcpIpTunnel(Session* session,
-                                                  const std::string& third_party_host,
+                                                  std::string_view third_party_host,
                                                   int third_party_port) {
   LIBSSH2_CHANNEL* raw_channel_ptr = libssh2_channel_direct_tcpip(
-      session->GetRawSessionPtr(), third_party_host.c_str(), third_party_port);
+      session->GetRawSessionPtr(), std::string{third_party_host}.c_str(), third_party_port);
   if (raw_channel_ptr != nullptr) {
     return outcome::success(Channel{raw_channel_ptr});
   }
@@ -51,8 +51,8 @@ outcome::result<Channel> Channel::OpenTcpIpTunnel(Session* session,
   return static_cast<Error>(last_errno);
 }
 
-outcome::result<void> Channel::Exec(const std::string& command) {
-  const int rc = libssh2_channel_exec(raw_channel_ptr_.get(), command.c_str());
+outcome::result<void> Channel::Exec(std::string_view command) {
+  const int rc = libssh2_channel_exec(raw_channel_ptr_.get(), std::string{command}.c_str());
   if (rc == 0) {
     return outcome::success();
   }

--- a/src/OrbitSsh/LinuxSocket.cpp
+++ b/src/OrbitSsh/LinuxSocket.cpp
@@ -50,8 +50,8 @@ outcome::result<Socket> Socket::Accept() const {
   return Socket{descriptor};
 }
 
-void Socket::PrintWithLastError(const std::string& message) {
-  ORBIT_ERROR("%s: %s", message.c_str(), SafeStrerror(errno));
+void Socket::PrintWithLastError(std::string_view message) {
+  ORBIT_ERROR("%s: %s", message, SafeStrerror(errno));
 }
 
 outcome::result<void> Socket::Shutdown() const {

--- a/src/OrbitSsh/Session.cpp
+++ b/src/OrbitSsh/Session.cpp
@@ -124,23 +124,23 @@ outcome::result<void> Session::MatchKnownHosts(const AddrAndPort& addr_and_port,
   return outcome::success();
 }
 
-outcome::result<void> Session::Authenticate(const std::string& username,
+outcome::result<void> Session::Authenticate(std::string_view username,
                                             const std::filesystem::path& key_path,
-                                            const std::string& pass_phrase) {
+                                            std::string_view pass_phrase) {
   std::filesystem::path public_key_path = key_path;
   public_key_path.replace_filename(key_path.filename().string() + ".pub");
 
   const int rc = libssh2_userauth_publickey_fromfile(
-      raw_session_ptr_.get(), username.c_str(), public_key_path.string().c_str(),
-      key_path.string().c_str(), pass_phrase.c_str());
+      raw_session_ptr_.get(), std::string{username}.c_str(), public_key_path.string().c_str(),
+      key_path.string().c_str(), std::string{pass_phrase}.c_str());
 
   if (rc < 0) return static_cast<Error>(rc);
 
   return outcome::success();
 }
 
-outcome::result<void> Session::Disconnect(const std::string& message) {
-  const int rc = libssh2_session_disconnect(raw_session_ptr_.get(), message.c_str());
+outcome::result<void> Session::Disconnect(std::string_view message) {
+  const int rc = libssh2_session_disconnect(raw_session_ptr_.get(), std::string{message}.c_str());
 
   if (rc < 0) return static_cast<Error>(rc);
 

--- a/src/OrbitSsh/WindowsSocket.cpp
+++ b/src/OrbitSsh/WindowsSocket.cpp
@@ -46,13 +46,13 @@ outcome::result<Socket> Socket::Accept() const {
   return Socket(descriptor);
 }
 
-void Socket::PrintWithLastError(const std::string& message) {
+void Socket::PrintWithLastError(std::string_view message) {
   LPWSTR error_string = nullptr;
   FormatMessage(
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
       nullptr, WSAGetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
       reinterpret_cast<LPWSTR>(&error_string), 0, nullptr);
-  ORBIT_ERROR("%s: %s", message.c_str(), error_string);
+  ORBIT_ERROR("%s: %s", message, error_string);
   LocalFree(error_string);
 }
 

--- a/src/OrbitSsh/include/OrbitSsh/Channel.h
+++ b/src/OrbitSsh/include/OrbitSsh/Channel.h
@@ -24,7 +24,7 @@ class Channel {
   // server. In most cases this third party is a program running on the remote
   // server and therefore third_party_host is 127.0.0.1
   static outcome::result<Channel> OpenTcpIpTunnel(Session* session_ptr,
-                                                  const std::string& third_party_host,
+                                                  std::string_view third_party_host,
                                                   int third_party_port);
   static outcome::result<Channel> OpenChannel(Session* session_ptr);
 
@@ -37,7 +37,7 @@ class Channel {
 
   outcome::result<void> WriteBlocking(std::string_view text);
   outcome::result<int> Write(std::string_view text);
-  outcome::result<void> Exec(const std::string& command);
+  outcome::result<void> Exec(std::string_view command);
   outcome::result<void> SendEOF();
   outcome::result<void> WaitRemoteEOF();
   outcome::result<void> Close();

--- a/src/OrbitSsh/include/OrbitSsh/Session.h
+++ b/src/OrbitSsh/include/OrbitSsh/Session.h
@@ -25,10 +25,10 @@ class Session {
   outcome::result<void> Handshake(Socket* socket_ptr);
   outcome::result<void> MatchKnownHosts(const AddrAndPort& addr_and_port,
                                         const std::filesystem::path& known_hosts_path);
-  outcome::result<void> Authenticate(const std::string& username,
+  outcome::result<void> Authenticate(std::string_view username,
                                      const std::filesystem::path& key_path,
-                                     const std::string& pass_phrase = "");
-  outcome::result<void> Disconnect(const std::string& message = "Disconnecting normally");
+                                     std::string_view pass_phrase = "");
+  outcome::result<void> Disconnect(std::string_view message = "Disconnecting normally");
   [[nodiscard]] LIBSSH2_SESSION* GetRawSessionPtr() const { return raw_session_ptr_.get(); }
   void SetBlocking(bool value);
 

--- a/src/OrbitSsh/include/OrbitSsh/Socket.h
+++ b/src/OrbitSsh/include/OrbitSsh/Socket.h
@@ -45,7 +45,7 @@ class Socket {
 
   static outcome::result<Socket> Create(int domain = AF_INET, int type = SOCK_STREAM,
                                         int protocol = IPPROTO_TCP);
-  static void PrintWithLastError(const std::string& message);
+  static void PrintWithLastError(std::string_view message);
 
   [[nodiscard]] outcome::result<void> Connect(const AddrAndPort& addr_and_port,
                                               int domain = AF_INET) const;

--- a/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.cpp
@@ -70,13 +70,13 @@ uint32_t LayerOptions::GetCaptureLengthSeconds() {
   return kCaptureLengthSecondsDefault;
 }
 
-std::vector<std::string> LayerOptions::BuildOrbitCaptureServiceArgv(const std::string& game_pid) {
+std::vector<std::string> LayerOptions::BuildOrbitCaptureServiceArgv(std::string_view game_pid) {
   std::vector<std::string> argv;
 
   // Set mandatory arguments: service, pid
   argv.push_back(kOrbitCaptureService);
   argv.push_back("-pid");
-  argv.push_back(game_pid);
+  argv.push_back(std::string{game_pid});
 
   // Set arguments that are always provided but can be set by the user
   // Create a log file for OrbitCaptureService; by default kLogDirectory

--- a/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.h
+++ b/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.h
@@ -18,7 +18,7 @@ class LayerOptions {
   void Init();
   double GetFrameTimeThresholdMilliseconds();
   uint32_t GetCaptureLengthSeconds();
-  std::vector<std::string> BuildOrbitCaptureServiceArgv(const std::string&);
+  std::vector<std::string> BuildOrbitCaptureServiceArgv(std::string_view);
 
  private:
   orbit_vulkan_capture_protos::LayerConfig layer_config_;

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
@@ -94,14 +94,15 @@ class VulkanLayerProducerImpl : public VulkanLayerProducer {
   };
 
  private:
-  static uint64_t ComputeStringKey(const std::string& str) { return std::hash<std::string>{}(str); }
+  static uint64_t ComputeStringKey(std::string_view str) {
+    return std::hash<std::string_view>{}(str);
+  }
 
   void ClearStringInternPool() {
     absl::MutexLock lock{&string_keys_sent_mutex_};
     string_keys_sent_.clear();
   }
 
- private:
   LockFreeBufferVulkanLayerProducer lock_free_producer_{this};
 
   absl::flat_hash_set<uint64_t> string_keys_sent_;

--- a/src/PresetFile/PresetFile.cpp
+++ b/src/PresetFile/PresetFile.cpp
@@ -37,9 +37,9 @@ ErrorMessageOr<PresetInfo> ReadPresetFromString(std::string_view content) {
   return preset_info;
 }
 
-ErrorMessageOr<PresetInfoLegacy> ReadLegacyPresetFromString(const std::string& content) {
+ErrorMessageOr<PresetInfoLegacy> ReadLegacyPresetFromString(std::string_view content) {
   PresetInfoLegacy preset_info;
-  if (!preset_info.ParseFromString(content)) {
+  if (!preset_info.ParseFromArray(content.data(), content.size())) {
     return ErrorMessage{"Unable to parse message"};
   }
 

--- a/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
@@ -407,11 +407,11 @@ TEST(ProducerEventProcessor, TwoInternedCallstacksDifferentProducersSameIntern) 
   EXPECT_EQ(sample2.callstack_id(), actual_interned_callstack.key());
 }
 
-static ProducerCaptureEvent CreateInternedStringEvent(uint64_t key, const std::string& str) {
+static ProducerCaptureEvent CreateInternedStringEvent(uint64_t key, std::string str) {
   ProducerCaptureEvent interned_string_event;
   InternedString* interned_string = interned_string_event.mutable_interned_string();
   interned_string->set_key(key);
-  interned_string->set_intern(str);
+  interned_string->set_intern(std::move(str));
   return interned_string_event;
 }
 

--- a/src/ProducerEventProcessor/UploaderClientCaptureEventCollectorTest.cpp
+++ b/src/ProducerEventProcessor/UploaderClientCaptureEventCollectorTest.cpp
@@ -27,10 +27,10 @@ constexpr const char* kAnswerString = "Test Interned String";
 constexpr uint64_t kAnswerKey = 42;
 constexpr size_t kUploadBufferSize = 100;
 
-ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, const std::string& str) {
+ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, std::string str) {
   ClientCaptureEvent event;
   event.mutable_interned_string()->set_key(key);
-  event.mutable_interned_string()->set_intern(str);
+  event.mutable_interned_string()->set_intern(std::move(str));
   return event;
 }
 

--- a/src/ProducerSideService/BuildAndStartProducerSideServerWithUri.h
+++ b/src/ProducerSideService/BuildAndStartProducerSideServerWithUri.h
@@ -11,7 +11,7 @@
 namespace orbit_producer_side_service {
 
 inline ErrorMessageOr<std::unique_ptr<ProducerSideServer>> BuildAndStartProducerSideServerWithUri(
-    const std::string& uri) {
+    std::string_view uri) {
   auto producer_side_server = std::make_unique<ProducerSideServer>();
   ORBIT_LOG("Starting producer-side server at %s", uri);
   if (!producer_side_server->BuildAndStart(uri)) {

--- a/src/ProducerSideService/ProducerSideServer.cpp
+++ b/src/ProducerSideService/ProducerSideServer.cpp
@@ -15,11 +15,11 @@
 
 namespace orbit_producer_side_service {
 
-bool ProducerSideServer::BuildAndStart(const std::string& uri) {
+bool ProducerSideServer::BuildAndStart(std::string_view uri) {
   ORBIT_CHECK(server_ == nullptr);
 
   grpc::ServerBuilder builder;
-  builder.AddListeningPort(uri, grpc::InsecureServerCredentials());
+  builder.AddListeningPort(std::string{uri}, grpc::InsecureServerCredentials());
 
   builder.RegisterService(&producer_side_service_);
 

--- a/src/ProducerSideService/include/ProducerSideService/ProducerSideServer.h
+++ b/src/ProducerSideService/include/ProducerSideService/ProducerSideServer.h
@@ -22,7 +22,7 @@ namespace orbit_producer_side_service {
 // and listens on a socket.
 class ProducerSideServer final : public orbit_capture_service_base::CaptureStartStopListener {
  public:
-  bool BuildAndStart(const std::string& uri);
+  bool BuildAndStart(std::string_view uri);
   void ShutdownAndWait();
 
   void OnCaptureStartRequested(

--- a/src/QtUtils/MainThreadExecutorImplTest.cpp
+++ b/src/QtUtils/MainThreadExecutorImplTest.cpp
@@ -255,11 +255,11 @@ TEST(MainThreadExecutorImpl, ScheduleAfterIfSuccessTwice) {
 
   bool second_called = false;
   auto second_chained_future = executor->ScheduleAfterIfSuccess(
-      first_chained_future, [&first_called, &second_called](const std::string& number) {
+      first_chained_future, [&first_called, &second_called](std::string_view number) {
         EXPECT_TRUE(first_called);
         EXPECT_EQ(number, "42");
         second_called = true;
-        return std::string{"The number is "} + number;
+        return std::string{"The number is "}.append(number);
       });
   EXPECT_FALSE(second_called);
   EXPECT_FALSE(second_chained_future.IsFinished());

--- a/src/SessionSetup/ProcessListWidget.cpp
+++ b/src/SessionSetup/ProcessListWidget.cpp
@@ -90,10 +90,10 @@ void ProcessListWidget::HandleSelectionChanged(const QModelIndex& index) {
   emit ProcessSelected(GetProcessFromIndex(index));
 }
 
-bool ProcessListWidget::TrySelectProcessByName(const std::string& process_name) {
+bool ProcessListWidget::TrySelectProcessByName(std::string_view process_name) {
   QModelIndexList matches = proxy_model_.match(
       proxy_model_.index(0, static_cast<int>(ProcessItemModel::Column::kName)), Qt::DisplayRole,
-      QVariant::fromValue(QString::fromStdString(process_name)));
+      QVariant::fromValue(QString::fromUtf8(process_name.data(), process_name.size())));
 
   if (matches.isEmpty()) return false;
 

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -80,7 +80,7 @@ template <typename Func>
       [loop]() { loop->error(make_error_code(Error::kUserCanceledServiceDeployment)); })};
 }
 
-void PrintAsOrbitService(const std::string& buffer) {
+void PrintAsOrbitService(std::string_view buffer) {
   std::vector<std::string_view> lines = absl::StrSplit(buffer, '\n');
   for (const auto& line : lines) {
     if (!line.empty()) {
@@ -262,7 +262,7 @@ ServiceDeployManager::StartSftpChannel() {
 }
 
 ErrorMessageOr<void> ServiceDeployManager::CopyFileToRemote(
-    const std::string& source, const std::string& dest,
+    std::string_view source, std::string_view dest,
     orbit_ssh_qt::SftpCopyToRemoteOperation::FileMode dest_mode) {
   ORBIT_CHECK(QThread::currentThread() == thread());
   orbit_ssh_qt::SftpCopyToRemoteOperation operation{&session_.value(), sftp_channel_.get()};

--- a/src/SessionSetup/SessionSetupUtils.cpp
+++ b/src/SessionSetup/SessionSetupUtils.cpp
@@ -29,8 +29,8 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port) {
 
 std::unique_ptr<orbit_client_data::ProcessData> TryToFindProcessData(
     std::vector<orbit_grpc_protos::ProcessInfo> process_list,
-    const std::string& process_name_or_path) {
-  std::string shortened_process_name = process_name_or_path.substr(0, kMaxProcessNameLength);
+    std::string_view process_name_or_path) {
+  std::string_view shortened_process_name = process_name_or_path.substr(0, kMaxProcessNameLength);
 
   std::sort(
       process_list.begin(), process_list.end(),

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -125,10 +125,10 @@ void TargetLabel::ChangeToSshTarget(const SshTarget& ssh_target) {
 }
 
 void TargetLabel::ChangeToSshTarget(const orbit_client_data::ProcessData& process,
-                                    const std::string& ssh_target_id) {
+                                    std::string_view ssh_target_id) {
   Clear();
   process_ = QString::fromStdString(process.name());
-  machine_ = QString::fromStdString(ssh_target_id);
+  machine_ = QString::fromUtf8(ssh_target_id.data(), ssh_target_id.size());
   SetProcessCpuUsageInPercent(process.cpu_usage());
   ui_->targetLabel->setVisible(true);
   ui_->fileLabel->setVisible(false);

--- a/src/SessionSetup/include/SessionSetup/ProcessListWidget.h
+++ b/src/SessionSetup/include/SessionSetup/ProcessListWidget.h
@@ -48,7 +48,7 @@ class ProcessListWidget : public QWidget {
 
  private:
   void HandleSelectionChanged(const QModelIndex& index);
-  bool TrySelectProcessByName(const std::string& process_name);
+  bool TrySelectProcessByName(std::string_view process_name);
   void TryConfirm();
 
   std::unique_ptr<Ui::ProcessListWidget> ui_;

--- a/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
+++ b/src/SessionSetup/include/SessionSetup/ServiceDeployManager.h
@@ -101,7 +101,7 @@ class ServiceDeployManager : public QObject {
   ErrorMessageOr<void> ShutdownTask(orbit_ssh_qt::Task* task);
   ErrorMessageOr<void> ShutdownSession(orbit_ssh_qt::Session* session);
   ErrorMessageOr<void> CopyFileToRemote(
-      const std::string& source, const std::string& dest,
+      std::string_view source, std::string_view dest,
       orbit_ssh_qt::SftpCopyToRemoteOperation::FileMode dest_mode);
 
   // TODO(http://b/209807583): With our current integration of libssh2 we can only ever have one

--- a/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupUtils.h
@@ -35,7 +35,7 @@ struct ConnectionTarget {
 [[nodiscard]] std::shared_ptr<grpc::Channel> CreateGrpcChannel(uint16_t port);
 [[nodiscard]] std::unique_ptr<orbit_client_data::ProcessData> TryToFindProcessData(
     std::vector<orbit_grpc_protos::ProcessInfo> process_list,
-    const std::string& process_name_or_path);
+    std::string_view process_name_or_path);
 
 // Split a string of format "orbitprofiler://instance?process
 [[nodiscard]] std::optional<ConnectionTarget> SplitTargetUri(const QString& target_uri);

--- a/src/SessionSetup/include/SessionSetup/TargetLabel.h
+++ b/src/SessionSetup/include/SessionSetup/TargetLabel.h
@@ -34,7 +34,7 @@ class TargetLabel : public QWidget {
   void ChangeToFileTarget(const std::filesystem::path& path);
   void ChangeToSshTarget(const SshTarget& ssh_target);
   void ChangeToSshTarget(const orbit_client_data::ProcessData& process,
-                         const std::string& ssh_target_id);
+                         std::string_view ssh_target_id);
   void ChangeToLocalTarget(const LocalTarget& local_target);
   void ChangeToLocalTarget(const orbit_client_data::ProcessData& process);
   void ChangeToLocalTarget(const orbit_grpc_protos::ProcessInfo& process_info);

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -184,7 +184,7 @@ SymbolHelper::SymbolHelper(std::filesystem::path cache_directory,
           CreateStructuredDebugDirectorySymbolProviders(structured_debug_directories)) {}
 
 ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
-    const fs::path& module_path, const std::string& build_id,
+    const fs::path& module_path, std::string_view build_id,
     const ModuleInfo::ObjectFileType& object_file_type, absl::Span<const fs::path> paths) const {
   ORBIT_SCOPE_FUNCTION;
   if (build_id.empty()) {
@@ -196,7 +196,7 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
   // structured debug directories is only supported for elf files
   if (object_file_type == ModuleInfo::kElfFile) {
     for (const auto& provider : structured_debug_directory_providers_) {
-      const ModuleIdentifier module_id{module_path.string(), build_id};
+      const ModuleIdentifier module_id{module_path.string(), std::string{build_id}};
       const orbit_base::StopSource stop_source;
       orbit_base::Future<SymbolLoadingOutcome> future =
           provider.RetrieveSymbols(module_id, stop_source.GetStopToken());
@@ -256,7 +256,7 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
 }
 
 ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsInCache(const fs::path& module_path,
-                                                          const std::string& build_id) const {
+                                                          std::string_view build_id) const {
   return FindSymbolsInCacheImpl(module_path, "symbols",
                                 [&build_id](const std::filesystem::path& cache_file_path) {
                                   return VerifySymbolFile(cache_file_path, build_id);
@@ -272,7 +272,7 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsInCache(const fs::path& module
 }
 
 ErrorMessageOr<std::filesystem::path> SymbolHelper::FindObjectInCache(
-    const std::filesystem::path& module_path, const std::string& build_id,
+    const std::filesystem::path& module_path, std::string_view build_id,
     uint64_t expected_file_size) const {
   return FindSymbolsInCacheImpl(
       module_path, "object file",

--- a/src/Symbols/SymbolUtils.cpp
+++ b/src/Symbols/SymbolUtils.cpp
@@ -50,7 +50,7 @@ namespace orbit_symbols {
 
 template <typename FileT>
 ErrorMessageOr<void> VerifySymbolOrObjectFileWithBuildId(
-    const std::filesystem::path& symbols_or_object_path, const std::string& build_id,
+    const std::filesystem::path& symbols_or_object_path, std::string_view build_id,
     const std::function<ErrorMessageOr<std::unique_ptr<FileT>>(const std::filesystem::path&)>&
         create_symbols_or_object_file) {
   auto symbols_or_object_file_or_error = create_symbols_or_object_file(symbols_or_object_path);
@@ -87,7 +87,7 @@ static ErrorMessageOr<void> VerifyFileSize(const std::filesystem::path& symbols_
 }
 
 ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
-                                      const std::string& build_id) {
+                                      std::string_view build_id) {
   return VerifySymbolOrObjectFileWithBuildId<orbit_object_utils::SymbolsFile>(
       symbol_file_path, build_id, [](const std::filesystem::path& symbols_path) {
         return CreateSymbolsFile(symbols_path, orbit_object_utils::ObjectFileInfo{});
@@ -108,7 +108,7 @@ ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_p
 }
 
 ErrorMessageOr<void> VerifyObjectFile(const std::filesystem::path& object_file_path,
-                                      const std::string& build_id, uint64_t expected_file_size) {
+                                      std::string_view build_id, uint64_t expected_file_size) {
   OUTCOME_TRY(VerifySymbolOrObjectFileWithBuildId<orbit_object_utils::ObjectFile>(
       object_file_path, build_id, [](const std::filesystem::path& object_path) {
         return orbit_object_utils::CreateObjectFile(object_path);

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -33,15 +33,15 @@ class SymbolHelper : public SymbolCacheInterface {
                         const std::vector<std::filesystem::path>& structured_debug_directories);
 
   ErrorMessageOr<std::filesystem::path> FindSymbolsFileLocally(
-      const std::filesystem::path& module_path, const std::string& build_id,
+      const std::filesystem::path& module_path, std::string_view build_id,
       const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type,
       absl::Span<const std::filesystem::path> paths) const;
   ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(const std::filesystem::path& module_path,
-                                                           const std::string& build_id) const;
+                                                           std::string_view build_id) const;
   ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(const std::filesystem::path& module_path,
                                                            uint64_t expected_file_size) const;
   ErrorMessageOr<std::filesystem::path> FindObjectInCache(const std::filesystem::path& module_path,
-                                                          const std::string& build_id,
+                                                          std::string_view build_id,
                                                           uint64_t expected_file_size) const;
   [[nodiscard]] std::filesystem::path GenerateCachedFilePath(
       const std::filesystem::path& file_path) const override;

--- a/src/Symbols/include/Symbols/SymbolUtils.h
+++ b/src/Symbols/include/Symbols/SymbolUtils.h
@@ -28,7 +28,7 @@ namespace orbit_symbols {
 // the build id of the file with build_id. Returns void if build ids are the same, ErrorMessage
 // otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifySymbolFile(const std::filesystem::path& symbol_file_path,
-                                                    const std::string& build_id);
+                                                    std::string_view build_id);
 // Checks if the file at symbol_file_path can be read as symbol file (elf, coff, pdb) and compares
 // the size of the file with expected_file_size. Returns void if the sizes are the same,
 // ErrorMessage otherwise.
@@ -38,7 +38,7 @@ namespace orbit_symbols {
 // build id and size of the file with build_id and expected_file_size, respectively. Returns void if
 // the build ids and the sizes are the same, ErrorMessage otherwise.
 [[nodiscard]] ErrorMessageOr<void> VerifyObjectFile(const std::filesystem::path& object_file_path,
-                                                    const std::string& build_id,
+                                                    std::string_view build_id,
                                                     uint64_t expected_file_size);
 
 }  // namespace orbit_symbols

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -34,7 +34,7 @@ namespace {
 
 using orbit_test_utils::HasError;
 
-AddressRange AddressRangeFromString(const std::string& string_address) {
+AddressRange AddressRangeFromString(std::string_view string_address) {
   AddressRange result;
   const std::vector<std::string> addresses = absl::StrSplit(string_address, '-');
   if (addresses.size() != 2) {

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -71,9 +71,9 @@ ErrorMessageOr<bool> IsInodeInMapsFile(ino_t inode, pid_t pid) {
   return false;
 }
 
-ErrorMessageOr<ino_t> GetInodeFromFilePath(const std::string& file_path) {
+ErrorMessageOr<ino_t> GetInodeFromFilePath(const std::filesystem::path& file_path) {
   struct stat stat_buf {};
-  if (stat(file_path.c_str(), &stat_buf) != 0) {
+  if (stat(file_path.string().c_str(), &stat_buf) != 0) {
     return ErrorMessage{absl::StrFormat("Failed to obtain inode of '%s'", file_path)};
   }
   return stat_buf.st_ino;
@@ -87,7 +87,7 @@ void OpenUseAndCloseLibrary(pid_t pid) {
   ASSERT_THAT(library_path_or_error, HasNoError());
   std::filesystem::path library_path = std::move(library_path_or_error.value());
 
-  ErrorMessageOr<ino_t> inode_of_library = GetInodeFromFilePath(library_path);
+  ErrorMessageOr<ino_t> inode_of_library = GetInodeFromFilePath(library_path.string());
   ASSERT_THAT(inode_of_library, HasNoError());
 
   // Tracee does not have the dynamic lib loaded, obviously.

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -255,7 +255,7 @@ ErrorMessageOr<void> SetOrbitThreadsInTarget(pid_t pid, const std::vector<Module
 // Given the path of a module in the process, get all loaded instances of that module (usually there
 // will only be one, but a module can be loaded more than once).
 ErrorMessageOr<std::vector<ModuleInfo>> ModulesFromModulePath(
-    const std::vector<ModuleInfo>& modules, const std::string& path,
+    const std::vector<ModuleInfo>& modules, std::string_view path,
     absl::flat_hash_map<std::string, std::vector<ModuleInfo>>* cache_of_modules_from_path) {
   ORBIT_CHECK(cache_of_modules_from_path != nullptr);
   auto cached_modules_from_path_it = cache_of_modules_from_path->find(path);

--- a/src/UtilWidgets/NoticeWidget.cpp
+++ b/src/UtilWidgets/NoticeWidget.cpp
@@ -29,10 +29,10 @@ NoticeWidget::NoticeWidget(QWidget* parent)
   connect(ui_->noticeButton, &QPushButton::clicked, this, &NoticeWidget::ButtonClicked);
 }
 
-void NoticeWidget::Initialize(const std::string& label_text, const std::string& button_text,
+void NoticeWidget::Initialize(std::string_view label_text, std::string_view button_text,
                               const QColor& color) {
-  ui_->noticeLabel->setText(QString::fromStdString(label_text));
-  ui_->noticeButton->setText(QString::fromStdString(button_text));
+  ui_->noticeLabel->setText(QString::fromUtf8(label_text.data(), label_text.size()));
+  ui_->noticeButton->setText(QString::fromUtf8(button_text.data(), button_text.size()));
   setStyleSheet(QString::fromStdString(absl::StrFormat(
       "QWidget#%s{ border-radius: 5px; border: 1px solid palette(text); "
       "background: rgba(%d, %d, %d, %d);}",

--- a/src/UtilWidgets/include/UtilWidgets/NoticeWidget.h
+++ b/src/UtilWidgets/include/UtilWidgets/NoticeWidget.h
@@ -26,8 +26,7 @@ class NoticeWidget : public QWidget {
   explicit NoticeWidget(QWidget* parent = nullptr);
   ~NoticeWidget() override;
 
-  void Initialize(const std::string& label_text, const std::string& button_text,
-                  const QColor& color);
+  void Initialize(std::string_view label_text, std::string_view button_text, const QColor& color);
   void InitializeAsInspection();
 
  signals:


### PR DESCRIPTION
After the introduction of std::string_view in the standard library, there is almost no need anymore to use `const std::string&` on API interfaces. So this change replaces all instances of `const std::string&` on API surfaces by `std::string_view`. See go/totw/1 for more details.

This uncovered quite a few missed opportunities to move a `std::string` instead of copying from a const-ref. So in these cases I replaced the `const std::string&` by `std::string` (by-value parameter).

Note that it gets tricky when an API needs a null terminated string which can't be provided by `std::string_view`, but by `std::string::c_str`. This is mainly the case for POSIX API functions and libunwindstack. I opted for creating temporary strings in these cases, except in very few cases. This is performance-wise not ideal but since all those functions aren't part of the hot path I opted for a consistent API over potentially avoiding some allocations. Also note that this change as a whole reduces the number of temporary allocations by A LOT.

Test: Unit tests, sanitizer builds, and manual tests