### PR TITLE
Add SaveRangeFromArg GMock Action

### DIFF
--- a/src/TestUtils/CMakeLists.txt
+++ b/src/TestUtils/CMakeLists.txt
@@ -6,8 +6,9 @@ cmake_minimum_required(VERSION 3.15)
 
 add_library(TestUtils INTERFACE)
 target_sources(TestUtils INTERFACE
-  include/TestUtils/TestUtils.h
-  include/TestUtils/ContainerHelpers.h)
+  include/TestUtils/ContainerHelpers.h
+  include/TestUtils/SaveRangeFromArg.h
+  include/TestUtils/TestUtils.h)
 target_include_directories(TestUtils INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 target_link_libraries(TestUtils INTERFACE
   absl::flat_hash_map
@@ -17,7 +18,8 @@ target_link_libraries(TestUtils INTERFACE
   GTest::gtest)
 
 add_executable(TestUtilsTests
-  TestUtilsTest.cpp
-  ContainerHelpersTest.cpp)
+  ContainerHelpersTest.cpp
+  SaveRangeFromArgTest.cpp
+  TestUtilsTest.cpp)
 target_link_libraries(TestUtilsTests PRIVATE TestUtils GTest::Main)
 register_test(TestUtilsTests)

--- a/src/TestUtils/SaveRangeFromArgTest.cpp
+++ b/src/TestUtils/SaveRangeFromArgTest.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/types/span.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <set>
+#include <vector>
+
+#include "TestUtils/SaveRangeFromArg.h"
+
+namespace orbit_test_utils {
+
+TEST(SaveRangeFromArg, IntoVector) {
+  std::vector<int> sink{};
+  SaveRangeFromArg<0> (&sink)(absl::Span<int const>{1, 2, 3});
+  EXPECT_THAT(sink, testing::ElementsAre(1, 2, 3));
+
+  SaveRangeFromArg<1> (&sink)("unused", absl::Span<int const>{4, 5, 6});
+  EXPECT_THAT(sink, testing::ElementsAre(4, 5, 6));
+}
+
+TEST(SaveRangeFromArg, IntoSet) {
+  std::set<int> sink{};
+  SaveRangeFromArg<0> (&sink)(absl::Span<int const>{1, 2, 3, 3, 2, 1});
+  EXPECT_THAT(sink, testing::ElementsAre(1, 2, 3));
+
+  SaveRangeFromArg<1> (&sink)("unused", absl::Span<int const>{4, 5, 6, 6, 6});
+  EXPECT_THAT(sink, testing::ElementsAre(4, 5, 6));
+}
+
+}  // namespace orbit_test_utils

--- a/src/TestUtils/include/TestUtils/SaveRangeFromArg.h
+++ b/src/TestUtils/include/TestUtils/SaveRangeFromArg.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TEST_UTILS_SAVE_RANGE_FROM_ARG_H_
+#define TEST_UTILS_SAVE_RANGE_FROM_ARG_H_
+
+#include <stddef.h>
+
+#include <iterator>
+#include <tuple>
+#include <type_traits>
+
+namespace orbit_test_utils {
+
+// SaveRangeFromArg is a GMock action and behaves similar to testing::SaveArg, but expects the
+// argument to be a range (has cbegin and cend iterators) and copies individual elements into a
+// newly constructed object of type decltype(*Ptr). We expect that *Ptr has a constructor that takes
+// two iterators to construct from a range.
+//
+// This is useful if the argument is an absl::Span and we want to store the elements in a
+// std::vector (or any other container that can be constructed from a range - like a std::set for
+// example).
+//
+// The first template argument `k` indicates the we want to save the k-th argument. `k` is
+// 0-indexed.
+//
+// Example:
+// std::vector<int> vec{};
+// EXPECT_CALL(obj, MyFunction).WillOnce(SaveRangeFromArg<2>(&vec));
+//
+template <size_t k, typename Ptr>
+[[nodiscard]] auto SaveRangeFromArg(Ptr dest) {
+  return [dest](const auto&... args) {
+    const auto& kth_arg = std::get<k>(std::tie(args...));
+    using std::cbegin;
+    using std::cend;
+    // Container::assign would be nicer here, but this member function doesn't exist for all kinds
+    // of standard containers (Exists for std::vector but not for std::set for example).
+    *dest = std::decay_t<decltype(*dest)>{cbegin(kth_arg), cend(kth_arg)};
+  };
+}
+
+}  // namespace orbit_test_utils
+
+#endif  // TEST_UTILS_SAVE_RANGE_FROM_ARG_H_


### PR DESCRIPTION
This adds a new GMock action which helps when mocking a function that has an absl::Span as one of the parameters.

If we want to capture this Span argument `testing::SaveArg` is not suitable because it tries to make a copy of the Span which leads to lifetime issues.

This action is a solution because it makes a deep copy of a range into an arbitrary container that can be constructed from a range (can be a vector or a set for example).

This is in preparation to replacing all usages of `const std::vector<T>&` as function parameter types by `absl::Span<T const>`.