### PR TITLE
Make orbit_case::Append more generic

### DIFF
--- a/src/OrbitBase/AppendTest.cpp
+++ b/src/OrbitBase/AppendTest.cpp
@@ -13,14 +13,20 @@
 
 namespace orbit_base {
 
-TEST(Append, SourceIsVariable) {
+TEST(Append, SourceIsVectorVariable) {
   std::vector<std::string> dest{"a", "b"};
   std::vector<std::string> source{"c", "d", "e"};
   Append(dest, source);
   EXPECT_THAT(dest, ::testing::ElementsAre("a", "b", "c", "d", "e"));
 }
 
-TEST(Append, SourceIsTemporary) {
+TEST(Append, SourceIsTemporaryVector) {
+  std::vector<std::string> dest{"a", "b"};
+  Append(dest, std::vector<std::string>{"c", "d", "e"});
+  EXPECT_THAT(dest, ::testing::ElementsAre("a", "b", "c", "d", "e"));
+}
+
+TEST(Append, SourceIsInitializerList) {
   std::vector<std::string> dest{"a", "b"};
   Append(dest, {"c", "d", "e"});
   EXPECT_THAT(dest, ::testing::ElementsAre("a", "b", "c", "d", "e"));

--- a/src/OrbitBase/include/OrbitBase/Append.h
+++ b/src/OrbitBase/include/OrbitBase/Append.h
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <initializer_list>
+#include <type_traits>
 #include <vector>
 
 #ifndef ORBIT_BASE_APPEND_H_
@@ -9,9 +11,23 @@
 
 namespace orbit_base {
 
-template <class T>
-void Append(std::vector<T>& dest, const std::vector<T>& source) {
-  dest.insert(std::end(dest), std::begin(source), std::end(source));
+// Append adds the elements given by the range in the second argument to the back of the vector
+// given in the first argument. The range can be anything that defines `Range::value_type` and has
+// cbegin and cend iterators.
+template <class T, class Range,
+          class = typename std::enable_if_t<std::is_convertible_v<typename Range::value_type, T>>>
+void Append(std::vector<T>& dest, const Range& source) {
+  using std::cbegin;
+  using std::cend;
+  dest.insert(std::end(dest), cbegin(source), cend(source));
+}
+
+// This overload makes initializer lists as the second argument work.
+template <class T, class U, class = typename std::enable_if_t<std::is_convertible_v<U, T>>>
+void Append(std::vector<T>& dest, std::initializer_list<U> source) {
+  using std::cbegin;
+  using std::cend;
+  dest.insert(std::end(dest), cbegin(source), cend(source));
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/Append.h
+++ b/src/OrbitBase/include/OrbitBase/Append.h
@@ -14,8 +14,9 @@ namespace orbit_base {
 // Append adds the elements given by the range in the second argument to the back of the vector
 // given in the first argument. The range can be anything that defines `Range::value_type` and has
 // cbegin and cend iterators.
-template <class T, class Range,
-          class = typename std::enable_if_t<std::is_convertible_v<typename Range::value_type, T>>>
+template <
+    typename T, typename Range,
+    typename = typename std::enable_if_t<std::is_convertible_v<typename Range::value_type, T>>>
 void Append(std::vector<T>& dest, const Range& source) {
   using std::cbegin;
   using std::cend;
@@ -23,7 +24,7 @@ void Append(std::vector<T>& dest, const Range& source) {
 }
 
 // This overload makes initializer lists as the second argument work.
-template <class T, class U, class = typename std::enable_if_t<std::is_convertible_v<U, T>>>
+template <typename T, typename U, typename = typename std::enable_if_t<std::is_convertible_v<U, T>>>
 void Append(std::vector<T>& dest, std::initializer_list<U> source) {
   using std::cbegin;
   using std::cend;


### PR DESCRIPTION
`Append` used to only accept `const std::vector<T>&` as the source of elements that should be appended. This change makes `Append` also work with other sources - notably with `absl::Span<T const>`.

This is in preparation to replacing all usages of `const std::vector<T>&` as function parameter types by `absl::Span<T const>`.