### PR TITLE
Replace usages of const std::vector<T>& in parameters

### DIFF
--- a/src/CaptureEventProducer/LockFreeBufferCaptureEventProducerTest.cpp
+++ b/src/CaptureEventProducer/LockFreeBufferCaptureEventProducerTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <google/protobuf/arena.h>
 #include <grpcpp/grpcpp.h>
@@ -95,7 +96,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, EnqueueIntermediateEventIfCapturi
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -147,7 +148,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, EnqueueIntermediateEvent) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -203,7 +204,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, DuplicatedCommands) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -304,7 +305,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, ServiceDisconnects) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -344,7 +345,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, DisconnectAndReconnect) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));

--- a/src/CaptureEventProducer/LockFreeBufferCaptureEventProducerTest.cpp
+++ b/src/CaptureEventProducer/LockFreeBufferCaptureEventProducerTest.cpp
@@ -96,7 +96,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, EnqueueIntermediateEventIfCapturi
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                         absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -148,7 +148,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, EnqueueIntermediateEvent) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                         absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -204,7 +204,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, DuplicatedCommands) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                         absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -305,7 +305,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, ServiceDisconnects) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                         absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -345,7 +345,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, DisconnectAndReconnect) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                         absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));

--- a/src/CaptureFile/CaptureFile.cpp
+++ b/src/CaptureFile/CaptureFile.cpp
@@ -5,6 +5,7 @@
 #include "CaptureFile/CaptureFile.h"
 
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
@@ -90,7 +91,7 @@ class CaptureFileImpl : public CaptureFile {
   ErrorMessageOr<void> ReadHeader();
   ErrorMessageOr<void> ReadSectionList();
   ErrorMessageOr<void> CalculateCaptureSectionSize();
-  ErrorMessageOr<void> WriteSectionList(const std::vector<CaptureFileSection>& section_list,
+  ErrorMessageOr<void> WriteSectionList(absl::Span<CaptureFileSection const> section_list,
                                         uint64_t offset);
   [[nodiscard]] bool IsThereSectionWithOffsetAfterSectionList() const;
   // Calculates where the current content of the file ends. This is the position where new data can
@@ -445,7 +446,7 @@ ErrorMessageOr<void> orbit_capture_file::CaptureFileImpl::ExtendSection(uint64_t
 }
 
 ErrorMessageOr<void> CaptureFileImpl::WriteSectionList(
-    const std::vector<CaptureFileSection>& section_list, uint64_t offset) {
+    absl::Span<CaptureFileSection const> section_list, uint64_t offset) {
   uint64_t number_of_sections = section_list.size();
   // first write new section list at new offset
   OUTCOME_TRY(

--- a/src/CaptureFile/CaptureFile.cpp
+++ b/src/CaptureFile/CaptureFile.cpp
@@ -91,7 +91,7 @@ class CaptureFileImpl : public CaptureFile {
   ErrorMessageOr<void> ReadHeader();
   ErrorMessageOr<void> ReadSectionList();
   ErrorMessageOr<void> CalculateCaptureSectionSize();
-  ErrorMessageOr<void> WriteSectionList(absl::Span<CaptureFileSection const> section_list,
+  ErrorMessageOr<void> WriteSectionList(absl::Span<const CaptureFileSection> section_list,
                                         uint64_t offset);
   [[nodiscard]] bool IsThereSectionWithOffsetAfterSectionList() const;
   // Calculates where the current content of the file ends. This is the position where new data can
@@ -446,7 +446,7 @@ ErrorMessageOr<void> orbit_capture_file::CaptureFileImpl::ExtendSection(uint64_t
 }
 
 ErrorMessageOr<void> CaptureFileImpl::WriteSectionList(
-    absl::Span<CaptureFileSection const> section_list, uint64_t offset) {
+    absl::Span<const CaptureFileSection> section_list, uint64_t offset) {
   uint64_t number_of_sections = section_list.size();
   // first write new section list at new offset
   OUTCOME_TRY(

--- a/src/ClientData/CallstackDataTest.cpp
+++ b/src/ClientData/CallstackDataTest.cpp
@@ -6,6 +6,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/functional/bind_front.h>
 #include <absl/functional/function_ref.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/src/ClientData/PostProcessedSamplingData.cpp
+++ b/src/ClientData/PostProcessedSamplingData.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <absl/types/span.h>
 #include <stddef.h>
 
 #include <algorithm>
@@ -70,7 +71,7 @@ static std::multimap<int, uint64_t> SortCallstacksByCount(const ThreadSampleData
 }
 
 std::multimap<int, uint64_t> PostProcessedSamplingData::GetCallstacksFromFunctionAddresses(
-    const std::vector<uint64_t>& function_addresses, uint32_t thread_id) const {
+    absl::Span<uint64_t const> function_addresses, uint32_t thread_id) const {
   const auto& sample_data_it = thread_id_to_sample_data_.find(thread_id);
   if (sample_data_it == thread_id_to_sample_data_.end()) {
     return {};
@@ -92,7 +93,7 @@ std::multimap<int, uint64_t> PostProcessedSamplingData::GetCallstacksFromFunctio
 
 std::unique_ptr<SortedCallstackReport>
 PostProcessedSamplingData::GetSortedCallstackReportFromFunctionAddresses(
-    const std::vector<uint64_t>& function_addresses, uint32_t thread_id) const {
+    absl::Span<uint64_t const> function_addresses, uint32_t thread_id) const {
   std::unique_ptr<SortedCallstackReport> report = std::make_unique<SortedCallstackReport>();
   std::multimap<int, uint64_t> count_to_callstack_id =
       GetCallstacksFromFunctionAddresses(function_addresses, thread_id);

--- a/src/ClientData/PostProcessedSamplingData.cpp
+++ b/src/ClientData/PostProcessedSamplingData.cpp
@@ -71,7 +71,7 @@ static std::multimap<int, uint64_t> SortCallstacksByCount(const ThreadSampleData
 }
 
 std::multimap<int, uint64_t> PostProcessedSamplingData::GetCallstacksFromFunctionAddresses(
-    absl::Span<uint64_t const> function_addresses, uint32_t thread_id) const {
+    absl::Span<const uint64_t> function_addresses, uint32_t thread_id) const {
   const auto& sample_data_it = thread_id_to_sample_data_.find(thread_id);
   if (sample_data_it == thread_id_to_sample_data_.end()) {
     return {};
@@ -93,7 +93,7 @@ std::multimap<int, uint64_t> PostProcessedSamplingData::GetCallstacksFromFunctio
 
 std::unique_ptr<SortedCallstackReport>
 PostProcessedSamplingData::GetSortedCallstackReportFromFunctionAddresses(
-    absl::Span<uint64_t const> function_addresses, uint32_t thread_id) const {
+    absl::Span<const uint64_t> function_addresses, uint32_t thread_id) const {
   std::unique_ptr<SortedCallstackReport> report = std::make_unique<SortedCallstackReport>();
   std::multimap<int, uint64_t> count_to_callstack_id =
       GetCallstacksFromFunctionAddresses(function_addresses, thread_id);

--- a/src/ClientData/ScopeIdProviderTest.cpp
+++ b/src/ClientData/ScopeIdProviderTest.cpp
@@ -4,6 +4,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <absl/types/span.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
 
@@ -41,15 +42,15 @@ const std::vector<std::string> kNames{"A", "B", "C", "D", "A", "B", "B"};
 }
 
 [[nodiscard]] static std::vector<orbit_client_protos::TimerInfo> MakeTimerInfos(
-    const std::vector<std::string>& names, orbit_client_protos::TimerInfo_Type type) {
+    absl::Span<std::string const> names, orbit_client_protos::TimerInfo_Type type) {
   std::vector<orbit_client_protos::TimerInfo> timer_infos;
   std::transform(std::begin(names), std::end(names), std::back_inserter(timer_infos),
                  [type](const auto& name) { return MakeTimerInfo(name, type); });
   return timer_infos;
 }
 
-static void AssertNameToIdIsBijective(const std::vector<orbit_client_protos::TimerInfo>& timers,
-                                      const std::vector<ScopeId>& ids) {
+static void AssertNameToIdIsBijective(absl::Span<orbit_client_protos::TimerInfo const> timers,
+                                      absl::Span<ScopeId const> ids) {
   absl::flat_hash_map<std::string, ScopeId> name_to_id;
   for (size_t i = 0; i < timers.size(); ++i) {
     name_to_id[timers[i].api_scope_name()] = ids[i];
@@ -64,7 +65,7 @@ static void AssertNameToIdIsBijective(const std::vector<orbit_client_protos::Tim
 }
 
 static std::vector<ScopeId> GetIds(ScopeIdProvider* id_provider,
-                                   const std::vector<orbit_client_protos::TimerInfo>& timers) {
+                                   absl::Span<orbit_client_protos::TimerInfo const> timers) {
   std::vector<ScopeId> ids;
   std::transform(
       std::begin(timers), std::end(timers), std::back_inserter(ids),

--- a/src/ClientData/ScopeIdProviderTest.cpp
+++ b/src/ClientData/ScopeIdProviderTest.cpp
@@ -42,15 +42,15 @@ const std::vector<std::string> kNames{"A", "B", "C", "D", "A", "B", "B"};
 }
 
 [[nodiscard]] static std::vector<orbit_client_protos::TimerInfo> MakeTimerInfos(
-    absl::Span<std::string const> names, orbit_client_protos::TimerInfo_Type type) {
+    absl::Span<const std::string> names, orbit_client_protos::TimerInfo_Type type) {
   std::vector<orbit_client_protos::TimerInfo> timer_infos;
   std::transform(std::begin(names), std::end(names), std::back_inserter(timer_infos),
                  [type](const auto& name) { return MakeTimerInfo(name, type); });
   return timer_infos;
 }
 
-static void AssertNameToIdIsBijective(absl::Span<orbit_client_protos::TimerInfo const> timers,
-                                      absl::Span<ScopeId const> ids) {
+static void AssertNameToIdIsBijective(absl::Span<const orbit_client_protos::TimerInfo> timers,
+                                      absl::Span<const ScopeId> ids) {
   absl::flat_hash_map<std::string, ScopeId> name_to_id;
   for (size_t i = 0; i < timers.size(); ++i) {
     name_to_id[timers[i].api_scope_name()] = ids[i];
@@ -65,7 +65,7 @@ static void AssertNameToIdIsBijective(absl::Span<orbit_client_protos::TimerInfo 
 }
 
 static std::vector<ScopeId> GetIds(ScopeIdProvider* id_provider,
-                                   absl::Span<orbit_client_protos::TimerInfo const> timers) {
+                                   absl::Span<const orbit_client_protos::TimerInfo> timers) {
   std::vector<ScopeId> ids;
   std::transform(
       std::begin(timers), std::end(timers), std::back_inserter(ids),

--- a/src/ClientData/ScopeStatsCollection.cpp
+++ b/src/ClientData/ScopeStatsCollection.cpp
@@ -7,6 +7,8 @@
 
 #include <absl/algorithm/container.h>
 #include <absl/meta/type_traits.h>
+#include <absl/types/span.h>
+#include <stdint.h>
 
 #include <iterator>
 #include <optional>
@@ -20,7 +22,7 @@ namespace orbit_client_data {
 static const ScopeStats kDefaultScopeStats;
 
 ScopeStatsCollection::ScopeStatsCollection(ScopeIdProvider& scope_id_provider,
-                                           const std::vector<const TimerInfo*>& timers) {
+                                           absl::Span<const TimerInfo* const> timers) {
   for (const TimerInfo* timer : timers) {
     std::optional<ScopeId> scope_id = scope_id_provider.ProvideId(*timer);
     if (scope_id.has_value()) {

--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -100,7 +100,7 @@ class PostProcessedSamplingData {
   [[nodiscard]] const CallstackInfo& GetResolvedCallstack(uint64_t sampled_callstack_id) const;
 
   [[nodiscard]] std::unique_ptr<SortedCallstackReport>
-  GetSortedCallstackReportFromFunctionAddresses(absl::Span<uint64_t const> function_addresses,
+  GetSortedCallstackReportFromFunctionAddresses(absl::Span<const uint64_t> function_addresses,
                                                 uint32_t thread_id) const;
 
   [[nodiscard]] std::vector<const ThreadSampleData*> GetSortedThreadSampleData() const;
@@ -111,7 +111,7 @@ class PostProcessedSamplingData {
 
  private:
   [[nodiscard]] std::multimap<int, uint64_t> GetCallstacksFromFunctionAddresses(
-      absl::Span<uint64_t const> function_addresses, uint32_t thread_id) const;
+      absl::Span<const uint64_t> function_addresses, uint32_t thread_id) const;
 
   absl::flat_hash_map<uint32_t, ThreadSampleData> thread_id_to_sample_data_;
   absl::flat_hash_map<uint64_t, CallstackInfo> id_to_resolved_callstack_;

--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 
 #include <cstdint>
 #include <map>
@@ -99,7 +100,7 @@ class PostProcessedSamplingData {
   [[nodiscard]] const CallstackInfo& GetResolvedCallstack(uint64_t sampled_callstack_id) const;
 
   [[nodiscard]] std::unique_ptr<SortedCallstackReport>
-  GetSortedCallstackReportFromFunctionAddresses(const std::vector<uint64_t>& function_addresses,
+  GetSortedCallstackReportFromFunctionAddresses(absl::Span<uint64_t const> function_addresses,
                                                 uint32_t thread_id) const;
 
   [[nodiscard]] std::vector<const ThreadSampleData*> GetSortedThreadSampleData() const;
@@ -110,7 +111,7 @@ class PostProcessedSamplingData {
 
  private:
   [[nodiscard]] std::multimap<int, uint64_t> GetCallstacksFromFunctionAddresses(
-      const std::vector<uint64_t>& function_addresses, uint32_t thread_id) const;
+      absl::Span<uint64_t const> function_addresses, uint32_t thread_id) const;
 
   absl::flat_hash_map<uint32_t, ThreadSampleData> thread_id_to_sample_data_;
   absl::flat_hash_map<uint64_t, CallstackInfo> id_to_resolved_callstack_;

--- a/src/ClientData/include/ClientData/ScopeStatsCollection.h
+++ b/src/ClientData/include/ClientData/ScopeStatsCollection.h
@@ -8,6 +8,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 
 #include <cstdint>
 #include <vector>
@@ -26,7 +27,7 @@ class ScopeStatsCollection {
  public:
   explicit ScopeStatsCollection() = default;
   explicit ScopeStatsCollection(ScopeIdProvider& scope_id_provider,
-                                const std::vector<const TimerInfo*>& timers);
+                                absl::Span<const TimerInfo* const> timers);
 
   [[nodiscard]] std::vector<ScopeId> GetAllProvidedScopeIds() const;
   [[nodiscard]] const ScopeStats& GetScopeStatsOrDefault(ScopeId scope_id) const;

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -4,6 +4,7 @@
 
 #include <absl/container/flat_hash_set.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -115,7 +116,7 @@ MATCHER_P(CallstackIdToCallstackEventsEq, that, "") {
 }
 
 SortedCallstackReport MakeSortedCallstackReport(
-    const std::vector<std::pair<int, uint64_t>>& counts_and_callstack_ids) {
+    absl::Span<std::pair<int, uint64_t> const> counts_and_callstack_ids) {
   SortedCallstackReport report{};
   for (const auto& [count, callstack_id] : counts_and_callstack_ids) {
     report.total_callstack_count += count;
@@ -167,7 +168,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   CaptureData capture_data_{CaptureStarted{}, std::filesystem::path{},
                             absl::flat_hash_set<uint64_t>{}, CaptureData::DataSource::kLiveCapture};
 
-  void AddCallstackInfo(uint64_t callstack_id, const std::vector<uint64_t>& callstack_frames,
+  void AddCallstackInfo(uint64_t callstack_id, absl::Span<uint64_t const> callstack_frames,
                         CallstackType callstack_type) {
     CallstackInfo callstack_info{{callstack_frames.begin(), callstack_frames.end()},
                                  callstack_type};

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -116,7 +116,7 @@ MATCHER_P(CallstackIdToCallstackEventsEq, that, "") {
 }
 
 SortedCallstackReport MakeSortedCallstackReport(
-    absl::Span<std::pair<int, uint64_t> const> counts_and_callstack_ids) {
+    absl::Span<const std::pair<int, uint64_t>> counts_and_callstack_ids) {
   SortedCallstackReport report{};
   for (const auto& [count, callstack_id] : counts_and_callstack_ids) {
     report.total_callstack_count += count;
@@ -168,7 +168,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
   CaptureData capture_data_{CaptureStarted{}, std::filesystem::path{},
                             absl::flat_hash_set<uint64_t>{}, CaptureData::DataSource::kLiveCapture};
 
-  void AddCallstackInfo(uint64_t callstack_id, absl::Span<uint64_t const> callstack_frames,
+  void AddCallstackInfo(uint64_t callstack_id, absl::Span<const uint64_t> callstack_frames,
                         CallstackType callstack_type) {
     CallstackInfo callstack_info{{callstack_frames.begin(), callstack_frames.end()},
                                  callstack_type};

--- a/src/CommandLineUtils/CommandLineUtils.cpp
+++ b/src/CommandLineUtils/CommandLineUtils.cpp
@@ -17,7 +17,7 @@
 
 namespace orbit_command_line_utils {
 
-QStringList ExtractCommandLineFlags(absl::Span<std::string const> command_line_args,
+QStringList ExtractCommandLineFlags(absl::Span<const std::string> command_line_args,
                                     absl::Span<char* const> positional_args) {
   QStringList command_line_flags;
   absl::flat_hash_set<std::string> positional_arg_set(positional_args.begin(),

--- a/src/CommandLineUtils/CommandLineUtils.cpp
+++ b/src/CommandLineUtils/CommandLineUtils.cpp
@@ -7,6 +7,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/flags/commandlineflag.h>
 #include <absl/flags/flag.h>
+#include <absl/types/span.h>
 
 #include <QString>
 #include <array>
@@ -16,8 +17,8 @@
 
 namespace orbit_command_line_utils {
 
-QStringList ExtractCommandLineFlags(const std::vector<std::string>& command_line_args,
-                                    const std::vector<char*>& positional_args) {
+QStringList ExtractCommandLineFlags(absl::Span<std::string const> command_line_args,
+                                    absl::Span<char* const> positional_args) {
   QStringList command_line_flags;
   absl::flat_hash_set<std::string> positional_arg_set(positional_args.begin(),
                                                       positional_args.end());

--- a/src/CommandLineUtils/include/CommandLineUtils/CommandLineUtils.h
+++ b/src/CommandLineUtils/include/CommandLineUtils/CommandLineUtils.h
@@ -15,7 +15,7 @@ namespace orbit_command_line_utils {
 
 // Extract command line flags by filtering the positional arguments out from the command line
 // arguments.
-QStringList ExtractCommandLineFlags(absl::Span<std::string const> command_line_args,
+QStringList ExtractCommandLineFlags(absl::Span<const std::string> command_line_args,
                                     absl::Span<char* const> positional_args);
 QStringList RemoveFlagsNotPassedToMainWindow(const QStringList& flags);
 

--- a/src/CommandLineUtils/include/CommandLineUtils/CommandLineUtils.h
+++ b/src/CommandLineUtils/include/CommandLineUtils/CommandLineUtils.h
@@ -5,6 +5,8 @@
 #ifndef COMMAND_LINE_UTILS_COMMAND_LINE_UTILS_H__
 #define COMMAND_LINE_UTILS_COMMAND_LINE_UTILS_H__
 
+#include <absl/types/span.h>
+
 #include <QStringList>
 #include <string>
 #include <vector>
@@ -13,8 +15,8 @@ namespace orbit_command_line_utils {
 
 // Extract command line flags by filtering the positional arguments out from the command line
 // arguments.
-QStringList ExtractCommandLineFlags(const std::vector<std::string>& command_line_args,
-                                    const std::vector<char*>& positional_args);
+QStringList ExtractCommandLineFlags(absl::Span<std::string const> command_line_args,
+                                    absl::Span<char* const> positional_args);
 QStringList RemoveFlagsNotPassedToMainWindow(const QStringList& flags);
 
 }  // namespace orbit_command_line_utils

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -9,6 +9,7 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
+#include <absl/types/span.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -111,8 +112,9 @@ const std::string CallstackDataView::kHighlightedFunctionString = "➜ ";
 const std::string CallstackDataView::kHighlightedFunctionBlankString =
     std::string(kHighlightedFunctionString.size(), ' ');
 
-DataView::ActionStatus CallstackDataView::GetActionStatus(
-    std::string_view action, int clicked_index, const std::vector<int>& selected_indices) {
+DataView::ActionStatus CallstackDataView::GetActionStatus(std::string_view action,
+                                                          int clicked_index,
+                                                          absl::Span<int const> selected_indices) {
   bool is_capture_connected = app_->IsCaptureConnected(app_->GetCaptureData());
   if (!is_capture_connected &&
       (action == kMenuActionSelect || action == kMenuActionUnselect ||

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -114,7 +114,7 @@ const std::string CallstackDataView::kHighlightedFunctionBlankString =
 
 DataView::ActionStatus CallstackDataView::GetActionStatus(std::string_view action,
                                                           int clicked_index,
-                                                          absl::Span<int const> selected_indices) {
+                                                          absl::Span<const int> selected_indices) {
   bool is_capture_connected = app_->IsCaptureConnected(app_->GetCaptureData());
   if (!is_capture_connected &&
       (action == kMenuActionSelect || action == kMenuActionUnselect ||

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -85,7 +85,7 @@ void DataView::OnDataChanged() {
 }
 
 DataView::ActionStatus DataView::GetActionStatus(std::string_view action, int /* clicked_index */,
-                                                 absl::Span<int const> /* selected_indices */) {
+                                                 absl::Span<const int> /* selected_indices */) {
   if (action == kMenuActionCopySelection || action == kMenuActionExportToCsv) {
     return ActionStatus::kVisibleAndEnabled;
   }
@@ -94,7 +94,7 @@ DataView::ActionStatus DataView::GetActionStatus(std::string_view action, int /*
 }
 
 std::vector<DataView::ActionGroup> DataView::GetContextMenuWithGrouping(
-    int clicked_index, absl::Span<int const> selected_indices) {
+    int clicked_index, absl::Span<const int> selected_indices) {
   // GetContextmenuWithGrouping is called when OrbitTreeView::indexAt returns a valid index and
   // hence the selected_indices retrieved from OrbitTreeView::selectionModel()->selectedIndexes()
   // should not be empty.
@@ -139,7 +139,7 @@ std::vector<DataView::ActionGroup> DataView::GetContextMenuWithGrouping(
 }
 
 void DataView::OnContextMenu(std::string_view action, int /*menu_index*/,
-                             absl::Span<int const> item_indices) {
+                             absl::Span<const int> item_indices) {
   if (action == kMenuActionLoadSymbols) {
     OnLoadSymbolsRequested(item_indices);
   } else if (action == kMenuActionStopDownload) {
@@ -189,7 +189,7 @@ std::vector<int> DataView::GetVisibleSelectedIndices() {
   return visible_selected_indices;
 }
 
-void DataView::OnLoadSymbolsRequested(absl::Span<int const> selection) {
+void DataView::OnLoadSymbolsRequested(absl::Span<const int> selection) {
   std::vector<const ModuleData*> modules_to_load;
   for (int index : selection) {
     const ModuleData* module_data = GetModuleDataFromRow(index);
@@ -200,7 +200,7 @@ void DataView::OnLoadSymbolsRequested(absl::Span<int const> selection) {
   app_->LoadSymbolsManually(modules_to_load);
 }
 
-void DataView::OnStopDownloadRequested(absl::Span<int const> selection) {
+void DataView::OnStopDownloadRequested(absl::Span<const int> selection) {
   std::vector<const ModuleData*> modules_to_stop;
   for (int index : selection) {
     const ModuleData* module = GetModuleDataFromRow(index);
@@ -212,7 +212,7 @@ void DataView::OnStopDownloadRequested(absl::Span<int const> selection) {
   app_->RequestSymbolDownloadStop(modules_to_stop);
 }
 
-void DataView::OnSelectRequested(absl::Span<int const> selection) {
+void DataView::OnSelectRequested(absl::Span<const int> selection) {
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     // Only hook functions for which we have symbols loaded.
@@ -222,7 +222,7 @@ void DataView::OnSelectRequested(absl::Span<int const> selection) {
   }
 }
 
-void DataView::OnUnselectRequested(absl::Span<int const> selection) {
+void DataView::OnUnselectRequested(absl::Span<const int> selection) {
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     // If the frame belongs to a function for which no symbol is loaded 'function' is nullptr and
@@ -239,7 +239,7 @@ void DataView::OnUnselectRequested(absl::Span<int const> selection) {
   }
 }
 
-void DataView::OnEnableFrameTrackRequested(absl::Span<int const> selection) {
+void DataView::OnEnableFrameTrackRequested(absl::Span<const int> selection) {
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     if (function == nullptr) continue;
@@ -256,7 +256,7 @@ void DataView::OnEnableFrameTrackRequested(absl::Span<int const> selection) {
   }
 }
 
-void DataView::OnDisableFrameTrackRequested(absl::Span<int const> selection) {
+void DataView::OnDisableFrameTrackRequested(absl::Span<const int> selection) {
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     if (function == nullptr) continue;
@@ -269,7 +269,7 @@ void DataView::OnDisableFrameTrackRequested(absl::Span<int const> selection) {
   }
 }
 
-void DataView::OnDisassemblyRequested(absl::Span<int const> selection) {
+void DataView::OnDisassemblyRequested(absl::Span<const int> selection) {
   const ProcessData* process_data = app_->GetTargetProcess();
   const uint32_t pid =
       process_data == nullptr ? app_->GetCaptureData().process_id() : process_data->pid();
@@ -284,7 +284,7 @@ void DataView::OnDisassemblyRequested(absl::Span<int const> selection) {
   }
 }
 
-void DataView::OnSourceCodeRequested(absl::Span<int const> selection) {
+void DataView::OnSourceCodeRequested(absl::Span<const int> selection) {
   constexpr int kMaxNumberOfWindowsToOpen = 10;
   int j = 0;
   for (int i : selection) {
@@ -327,7 +327,7 @@ void DataView::OnExportToCsvRequested() {
   ReportErrorIfAny(ExportToCsv(save_file), kMenuActionExportToCsv);
 }
 
-void DataView::OnCopySelectionRequested(absl::Span<int const> selection) {
+void DataView::OnCopySelectionRequested(absl::Span<const int> selection) {
   constexpr const char* kFieldSeparator = "\t";
   constexpr const char* kLineSeparator = "\n";
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_replace.h>
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <algorithm>
@@ -84,7 +85,7 @@ void DataView::OnDataChanged() {
 }
 
 DataView::ActionStatus DataView::GetActionStatus(std::string_view action, int /* clicked_index */,
-                                                 const std::vector<int>& /* selected_indices */) {
+                                                 absl::Span<int const> /* selected_indices */) {
   if (action == kMenuActionCopySelection || action == kMenuActionExportToCsv) {
     return ActionStatus::kVisibleAndEnabled;
   }
@@ -93,7 +94,7 @@ DataView::ActionStatus DataView::GetActionStatus(std::string_view action, int /*
 }
 
 std::vector<DataView::ActionGroup> DataView::GetContextMenuWithGrouping(
-    int clicked_index, const std::vector<int>& selected_indices) {
+    int clicked_index, absl::Span<int const> selected_indices) {
   // GetContextmenuWithGrouping is called when OrbitTreeView::indexAt returns a valid index and
   // hence the selected_indices retrieved from OrbitTreeView::selectionModel()->selectedIndexes()
   // should not be empty.
@@ -138,7 +139,7 @@ std::vector<DataView::ActionGroup> DataView::GetContextMenuWithGrouping(
 }
 
 void DataView::OnContextMenu(std::string_view action, int /*menu_index*/,
-                             const std::vector<int>& item_indices) {
+                             absl::Span<int const> item_indices) {
   if (action == kMenuActionLoadSymbols) {
     OnLoadSymbolsRequested(item_indices);
   } else if (action == kMenuActionStopDownload) {
@@ -188,7 +189,7 @@ std::vector<int> DataView::GetVisibleSelectedIndices() {
   return visible_selected_indices;
 }
 
-void DataView::OnLoadSymbolsRequested(const std::vector<int>& selection) {
+void DataView::OnLoadSymbolsRequested(absl::Span<int const> selection) {
   std::vector<const ModuleData*> modules_to_load;
   for (int index : selection) {
     const ModuleData* module_data = GetModuleDataFromRow(index);
@@ -199,7 +200,7 @@ void DataView::OnLoadSymbolsRequested(const std::vector<int>& selection) {
   app_->LoadSymbolsManually(modules_to_load);
 }
 
-void DataView::OnStopDownloadRequested(const std::vector<int>& selection) {
+void DataView::OnStopDownloadRequested(absl::Span<int const> selection) {
   std::vector<const ModuleData*> modules_to_stop;
   for (int index : selection) {
     const ModuleData* module = GetModuleDataFromRow(index);
@@ -211,7 +212,7 @@ void DataView::OnStopDownloadRequested(const std::vector<int>& selection) {
   app_->RequestSymbolDownloadStop(modules_to_stop);
 }
 
-void DataView::OnSelectRequested(const std::vector<int>& selection) {
+void DataView::OnSelectRequested(absl::Span<int const> selection) {
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     // Only hook functions for which we have symbols loaded.
@@ -221,7 +222,7 @@ void DataView::OnSelectRequested(const std::vector<int>& selection) {
   }
 }
 
-void DataView::OnUnselectRequested(const std::vector<int>& selection) {
+void DataView::OnUnselectRequested(absl::Span<int const> selection) {
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     // If the frame belongs to a function for which no symbol is loaded 'function' is nullptr and
@@ -238,7 +239,7 @@ void DataView::OnUnselectRequested(const std::vector<int>& selection) {
   }
 }
 
-void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
+void DataView::OnEnableFrameTrackRequested(absl::Span<int const> selection) {
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     if (function == nullptr) continue;
@@ -255,7 +256,7 @@ void DataView::OnEnableFrameTrackRequested(const std::vector<int>& selection) {
   }
 }
 
-void DataView::OnDisableFrameTrackRequested(const std::vector<int>& selection) {
+void DataView::OnDisableFrameTrackRequested(absl::Span<int const> selection) {
   for (int i : selection) {
     const FunctionInfo* function = GetFunctionInfoFromRow(i);
     if (function == nullptr) continue;
@@ -268,7 +269,7 @@ void DataView::OnDisableFrameTrackRequested(const std::vector<int>& selection) {
   }
 }
 
-void DataView::OnDisassemblyRequested(const std::vector<int>& selection) {
+void DataView::OnDisassemblyRequested(absl::Span<int const> selection) {
   const ProcessData* process_data = app_->GetTargetProcess();
   const uint32_t pid =
       process_data == nullptr ? app_->GetCaptureData().process_id() : process_data->pid();
@@ -283,7 +284,7 @@ void DataView::OnDisassemblyRequested(const std::vector<int>& selection) {
   }
 }
 
-void DataView::OnSourceCodeRequested(const std::vector<int>& selection) {
+void DataView::OnSourceCodeRequested(absl::Span<int const> selection) {
   constexpr int kMaxNumberOfWindowsToOpen = 10;
   int j = 0;
   for (int i : selection) {
@@ -326,7 +327,7 @@ void DataView::OnExportToCsvRequested() {
   ReportErrorIfAny(ExportToCsv(save_file), kMenuActionExportToCsv);
 }
 
-void DataView::OnCopySelectionRequested(const std::vector<int>& selection) {
+void DataView::OnCopySelectionRequested(absl::Span<int const> selection) {
   constexpr const char* kFieldSeparator = "\t";
   constexpr const char* kLineSeparator = "\n";
 

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -126,7 +126,7 @@ void CheckContextMenuOrder(const FlattenContextMenu& context_menu) {
 }
 
 FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
-    absl::Span<DataView::ActionGroup const> menu_with_grouping) {
+    absl::Span<const DataView::ActionGroup> menu_with_grouping) {
   FlattenContextMenu menu;
   for (const DataView::ActionGroup& action_group : menu_with_grouping) {
     for (const auto& action : action_group) menu.push_back(action);

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -5,6 +5,7 @@
 #include "DataViewTestUtils.h"
 
 #include <absl/strings/str_split.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -125,7 +126,7 @@ void CheckContextMenuOrder(const FlattenContextMenu& context_menu) {
 }
 
 FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
-    const std::vector<DataView::ActionGroup>& menu_with_grouping) {
+    absl::Span<DataView::ActionGroup const> menu_with_grouping) {
   FlattenContextMenu menu;
   for (const DataView::ActionGroup& action_group : menu_with_grouping) {
     for (const auto& action : action_group) menu.push_back(action);

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -41,7 +41,7 @@ void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const Moc
 void CheckContextMenuOrder(const FlattenContextMenu& context_menu);
 
 [[nodiscard]] FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
-    absl::Span<DataView::ActionGroup const> menu_with_grouping);
+    absl::Span<const DataView::ActionGroup> menu_with_grouping);
 
 orbit_test_utils::TemporaryFile GetTemporaryFilePath();
 

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -5,6 +5,8 @@
 #ifndef DATA_VIEWS_DATA_VIEW_TEST_UTILS_H_
 #define DATA_VIEWS_DATA_VIEW_TEST_UTILS_H_
 
+#include <absl/types/span.h>
+
 #include <algorithm>
 #include <string>
 #include <string_view>
@@ -39,7 +41,7 @@ void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const Moc
 void CheckContextMenuOrder(const FlattenContextMenu& context_menu);
 
 [[nodiscard]] FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
-    const std::vector<DataView::ActionGroup>& menu_with_grouping);
+    absl::Span<DataView::ActionGroup const> menu_with_grouping);
 
 orbit_test_utils::TemporaryFile GetTemporaryFilePath();
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -167,7 +167,7 @@ void FunctionsDataView::DoSort() {
 
 DataView::ActionStatus FunctionsDataView::GetActionStatus(std::string_view action,
                                                           int clicked_index,
-                                                          absl::Span<int const> selected_indices) {
+                                                          absl::Span<const int> selected_indices) {
   if (action == kMenuActionDisassembly || action == kMenuActionSourceCode) {
     return ActionStatus::kVisibleAndEnabled;
   }

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -165,8 +165,9 @@ void FunctionsDataView::DoSort() {
   }
 }
 
-DataView::ActionStatus FunctionsDataView::GetActionStatus(
-    std::string_view action, int clicked_index, const std::vector<int>& selected_indices) {
+DataView::ActionStatus FunctionsDataView::GetActionStatus(std::string_view action,
+                                                          int clicked_index,
+                                                          absl::Span<int const> selected_indices) {
   if (action == kMenuActionDisassembly || action == kMenuActionSourceCode) {
     return ActionStatus::kVisibleAndEnabled;
   }

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -407,7 +407,7 @@ TEST_F(FunctionsDataViewTest, ContextMenuEntriesChangeOnFunctionState) {
 
   view_.AddFunctions({&functions_[0], &functions_[1], &functions_[2]});
 
-  auto verify_context_menu_action_availability = [&](absl::Span<int const> selected_indices) {
+  auto verify_context_menu_action_availability = [&](absl::Span<const int> selected_indices) {
     FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
         view_.GetContextMenuWithGrouping(0, selected_indices));
 

--- a/src/DataViews/FunctionsDataViewTest.cpp
+++ b/src/DataViews/FunctionsDataViewTest.cpp
@@ -5,6 +5,7 @@
 #include <absl/hash/hash.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
@@ -406,7 +407,7 @@ TEST_F(FunctionsDataViewTest, ContextMenuEntriesChangeOnFunctionState) {
 
   view_.AddFunctions({&functions_[0], &functions_[1], &functions_[2]});
 
-  auto verify_context_menu_action_availability = [&](const std::vector<int>& selected_indices) {
+  auto verify_context_menu_action_availability = [&](absl::Span<int const> selected_indices) {
     FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
         view_.GetContextMenuWithGrouping(0, selected_indices));
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -153,7 +153,7 @@ std::vector<int> LiveFunctionsDataView::GetVisibleSelectedIndices() {
   return {visible_selected_index.value()};
 }
 
-void LiveFunctionsDataView::UpdateHighlightedFunctionId(absl::Span<int const> rows) {
+void LiveFunctionsDataView::UpdateHighlightedFunctionId(absl::Span<const int> rows) {
   app_->DeselectTimer();
   if (rows.empty()) {
     app_->SetHighlightedScopeId(std::nullopt);
@@ -167,7 +167,7 @@ void LiveFunctionsDataView::UpdateSelectedFunctionId() {
 }
 
 void LiveFunctionsDataView::UpdateHistogramWithIndices(
-    absl::Span<int const> visible_selected_indices) {
+    absl::Span<const int> visible_selected_indices) {
   std::vector<ScopeId> scope_ids;
   std::transform(std::begin(visible_selected_indices), std::end(visible_selected_indices),
                  std::back_inserter(scope_ids),
@@ -176,7 +176,7 @@ void LiveFunctionsDataView::UpdateHistogramWithIndices(
   UpdateHistogramWithScopeIds(scope_ids);
 }
 
-void LiveFunctionsDataView::UpdateHistogramWithScopeIds(absl::Span<ScopeId const> scope_ids) {
+void LiveFunctionsDataView::UpdateHistogramWithScopeIds(absl::Span<const ScopeId> scope_ids) {
   const std::vector<uint64_t>* timer_durations =
       (app_->HasCaptureData() && !scope_ids.empty())
           ? app_->GetCaptureData().GetSortedTimerDurationsForScopeId(scope_ids[0])
@@ -192,7 +192,7 @@ void LiveFunctionsDataView::UpdateHistogramWithScopeIds(absl::Span<ScopeId const
   app_->ShowHistogram(timer_durations, scope_name, scope_id);
 }
 
-void LiveFunctionsDataView::OnSelect(absl::Span<int const> rows) {
+void LiveFunctionsDataView::OnSelect(absl::Span<const int> rows) {
   UpdateHighlightedFunctionId(rows);
   UpdateSelectedFunctionId();
 
@@ -279,7 +279,7 @@ void LiveFunctionsDataView::DoSort() {
 }
 
 DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
-    std::string_view action, int clicked_index, absl::Span<int const> selected_indices) {
+    std::string_view action, int clicked_index, absl::Span<const int> selected_indices) {
   if (action == kMenuActionExportEventsToCsv) return ActionStatus::kVisibleAndEnabled;
 
   const CaptureData& capture_data = app_->GetCaptureData();
@@ -358,7 +358,7 @@ DataView::ActionStatus LiveFunctionsDataView::GetActionStatus(
   return enabled_for_any ? ActionStatus::kVisibleAndEnabled : ActionStatus::kVisibleButDisabled;
 }
 
-void LiveFunctionsDataView::OnIteratorRequested(absl::Span<int const> selection) {
+void LiveFunctionsDataView::OnIteratorRequested(absl::Span<const int> selection) {
   for (int i : selection) {
     ScopeId scope_id = GetScopeId(i);
     const FunctionInfo* function_info = GetFunctionInfoFromRow(i);
@@ -372,7 +372,7 @@ void LiveFunctionsDataView::OnIteratorRequested(absl::Span<int const> selection)
 }
 
 void LiveFunctionsDataView::OnJumpToRequested(std::string_view action,
-                                              absl::Span<int const> selection) {
+                                              absl::Span<const int> selection) {
   ORBIT_CHECK(selection.size() == 1);
   auto scope_id = GetScopeId(selection[0]);
   if (action == kMenuActionJumpToFirst) {
@@ -387,7 +387,7 @@ void LiveFunctionsDataView::OnJumpToRequested(std::string_view action,
 }
 
 [[nodiscard]] ErrorMessageOr<void> LiveFunctionsDataView::WriteEventsToCsv(
-    absl::Span<int const> selection, std::string_view file_path) const {
+    absl::Span<const int> selection, std::string_view file_path) const {
   OUTCOME_TRY(auto fd, orbit_base::OpenFileForWriting(file_path));
 
   // Write header line
@@ -429,7 +429,7 @@ void LiveFunctionsDataView::OnJumpToRequested(std::string_view action,
   return outcome::success();
 }
 
-void LiveFunctionsDataView::OnExportEventsToCsvRequested(absl::Span<int const> selection) {
+void LiveFunctionsDataView::OnExportEventsToCsvRequested(absl::Span<const int> selection) {
   std::string file_path = app_->GetSaveFile(".csv");
   if (file_path.empty()) return;
 
@@ -502,7 +502,7 @@ void LiveFunctionsDataView::OnTimer() {
   OnSort(sorting_column_, {});
 }
 
-void LiveFunctionsDataView::OnRefresh(absl::Span<int const> visible_selected_indices,
+void LiveFunctionsDataView::OnRefresh(absl::Span<const int> visible_selected_indices,
                                       const RefreshMode& mode) {
   if (mode == RefreshMode::kOnFilter || mode == RefreshMode::kOnSort) {
     UpdateHighlightedFunctionId(visible_selected_indices);

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -265,7 +265,7 @@ class LiveFunctionsDataViewTest : public testing::Test {
     }
   }
 
-  void AddFunctionsByIndices(absl::Span<size_t const> indices) {
+  void AddFunctionsByIndices(absl::Span<const size_t> indices) {
     std::set index_set(indices.begin(), indices.end());
     for (size_t index : index_set) {
       ORBIT_CHECK(index < kNumFunctions);

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -7,6 +7,7 @@
 #include <absl/hash/hash.h>
 #include <absl/strings/str_format.h>
 #include <absl/time/time.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
@@ -264,7 +265,7 @@ class LiveFunctionsDataViewTest : public testing::Test {
     }
   }
 
-  void AddFunctionsByIndices(const std::vector<size_t>& indices) {
+  void AddFunctionsByIndices(absl::Span<size_t const> indices) {
     std::set index_set(indices.begin(), indices.end());
     for (size_t index : index_set) {
       ORBIT_CHECK(index < kNumFunctions);

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -132,7 +132,7 @@ void ModulesDataView::DoSort() {
 }
 
 DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action, int clicked_index,
-                                                        absl::Span<int const> selected_indices) {
+                                                        absl::Span<const int> selected_indices) {
   // transform selected_indices into modules
   std::vector<const ModuleData*> modules;
   modules.reserve(selected_indices.size());

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -10,6 +10,7 @@
 #include <absl/strings/match.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <algorithm>
@@ -131,7 +132,7 @@ void ModulesDataView::DoSort() {
 }
 
 DataView::ActionStatus ModulesDataView::GetActionStatus(std::string_view action, int clicked_index,
-                                                        const std::vector<int>& selected_indices) {
+                                                        absl::Span<int const> selected_indices) {
   // transform selected_indices into modules
   std::vector<const ModuleData*> modules;
   modules.reserve(selected_indices.size());

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
@@ -80,7 +81,7 @@ class ModulesDataViewTest : public testing::Test {
     }
   }
 
-  void AddModulesByIndices(const std::vector<size_t>& indices) {
+  void AddModulesByIndices(absl::Span<size_t const> indices) {
     std::set index_set(indices.begin(), indices.end());
     for (size_t index : index_set) {
       ORBIT_CHECK(index < kNumModules);

--- a/src/DataViews/ModulesDataViewTest.cpp
+++ b/src/DataViews/ModulesDataViewTest.cpp
@@ -81,7 +81,7 @@ class ModulesDataViewTest : public testing::Test {
     }
   }
 
-  void AddModulesByIndices(absl::Span<size_t const> indices) {
+  void AddModulesByIndices(absl::Span<const size_t> indices) {
     std::set index_set(indices.begin(), indices.end());
     for (size_t index : index_set) {
       ORBIT_CHECK(index < kNumModules);

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -9,6 +9,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
+#include <absl/types/span.h>
 #include <errno.h>
 
 #include <algorithm>
@@ -81,19 +82,19 @@ PresetsDataView::PresetsDataView(AppInterface* app)
     : DataView(DataViewType::kPresets, app),
       main_thread_executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()) {}
 
-std::string PresetsDataView::GetModulesList(const std::vector<ModuleView>& modules) {
+std::string PresetsDataView::GetModulesList(absl::Span<ModuleView const> modules) {
   return absl::StrJoin(modules, "\n", [](std::string* out, const ModuleView& module) {
     absl::StrAppend(out, module.module_name);
   });
 }
 
-std::string PresetsDataView::GetFunctionCountList(const std::vector<ModuleView>& modules) {
+std::string PresetsDataView::GetFunctionCountList(absl::Span<ModuleView const> modules) {
   return absl::StrJoin(modules, "\n", [](std::string* out, const ModuleView& module) {
     absl::StrAppend(out, module.function_count);
   });
 }
 
-std::string PresetsDataView::GetModuleAndFunctionCountList(const std::vector<ModuleView>& modules) {
+std::string PresetsDataView::GetModuleAndFunctionCountList(absl::Span<ModuleView const> modules) {
   return absl::StrJoin(modules, "\n", [](std::string* out, const ModuleView& module) {
     absl::StrAppendFormat(out, "%s: %u function(s)", module.module_name, module.function_count);
   });
@@ -184,7 +185,7 @@ void PresetsDataView::DoSort() {
 }
 
 DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action, int clicked_index,
-                                                        const std::vector<int>& selected_indices) {
+                                                        absl::Span<int const> selected_indices) {
   // Note that the UI already enforces a single selection.
   ORBIT_CHECK(selected_indices.size() == 1);
 
@@ -202,7 +203,7 @@ DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action,
   }
 }
 
-void PresetsDataView::OnLoadPresetRequested(const std::vector<int>& selection) {
+void PresetsDataView::OnLoadPresetRequested(absl::Span<int const> selection) {
   PresetFile& preset = GetMutablePreset(selection[0]);
   (void)app_->LoadPreset(preset).ThenIfSuccess(main_thread_executor_.get(),
                                                [this, preset_file_path = preset.file_path()]() {
@@ -210,7 +211,7 @@ void PresetsDataView::OnLoadPresetRequested(const std::vector<int>& selection) {
                                                });
 }
 
-void PresetsDataView::OnDeletePresetRequested(const std::vector<int>& selection) {
+void PresetsDataView::OnDeletePresetRequested(absl::Span<int const> selection) {
   int row = selection[0];
   const PresetFile& preset = GetPreset(row);
   const std::string& filename = preset.file_path().string();
@@ -225,7 +226,7 @@ void PresetsDataView::OnDeletePresetRequested(const std::vector<int>& selection)
   }
 }
 
-void PresetsDataView::OnShowInExplorerRequested(const std::vector<int>& selection) {
+void PresetsDataView::OnShowInExplorerRequested(absl::Span<int const> selection) {
   const PresetFile& preset = GetPreset(selection[0]);
   app_->ShowPresetInExplorer(preset);
 }

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -82,19 +82,19 @@ PresetsDataView::PresetsDataView(AppInterface* app)
     : DataView(DataViewType::kPresets, app),
       main_thread_executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()) {}
 
-std::string PresetsDataView::GetModulesList(absl::Span<ModuleView const> modules) {
+std::string PresetsDataView::GetModulesList(absl::Span<const ModuleView> modules) {
   return absl::StrJoin(modules, "\n", [](std::string* out, const ModuleView& module) {
     absl::StrAppend(out, module.module_name);
   });
 }
 
-std::string PresetsDataView::GetFunctionCountList(absl::Span<ModuleView const> modules) {
+std::string PresetsDataView::GetFunctionCountList(absl::Span<const ModuleView> modules) {
   return absl::StrJoin(modules, "\n", [](std::string* out, const ModuleView& module) {
     absl::StrAppend(out, module.function_count);
   });
 }
 
-std::string PresetsDataView::GetModuleAndFunctionCountList(absl::Span<ModuleView const> modules) {
+std::string PresetsDataView::GetModuleAndFunctionCountList(absl::Span<const ModuleView> modules) {
   return absl::StrJoin(modules, "\n", [](std::string* out, const ModuleView& module) {
     absl::StrAppendFormat(out, "%s: %u function(s)", module.module_name, module.function_count);
   });
@@ -185,7 +185,7 @@ void PresetsDataView::DoSort() {
 }
 
 DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action, int clicked_index,
-                                                        absl::Span<int const> selected_indices) {
+                                                        absl::Span<const int> selected_indices) {
   // Note that the UI already enforces a single selection.
   ORBIT_CHECK(selected_indices.size() == 1);
 
@@ -203,7 +203,7 @@ DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action,
   }
 }
 
-void PresetsDataView::OnLoadPresetRequested(absl::Span<int const> selection) {
+void PresetsDataView::OnLoadPresetRequested(absl::Span<const int> selection) {
   PresetFile& preset = GetMutablePreset(selection[0]);
   (void)app_->LoadPreset(preset).ThenIfSuccess(main_thread_executor_.get(),
                                                [this, preset_file_path = preset.file_path()]() {
@@ -211,7 +211,7 @@ void PresetsDataView::OnLoadPresetRequested(absl::Span<int const> selection) {
                                                });
 }
 
-void PresetsDataView::OnDeletePresetRequested(absl::Span<int const> selection) {
+void PresetsDataView::OnDeletePresetRequested(absl::Span<const int> selection) {
   int row = selection[0];
   const PresetFile& preset = GetPreset(row);
   const std::string& filename = preset.file_path().string();
@@ -226,7 +226,7 @@ void PresetsDataView::OnDeletePresetRequested(absl::Span<int const> selection) {
   }
 }
 
-void PresetsDataView::OnShowInExplorerRequested(absl::Span<int const> selection) {
+void PresetsDataView::OnShowInExplorerRequested(absl::Span<const int> selection) {
   const PresetFile& preset = GetPreset(selection[0]);
   app_->ShowPresetInExplorer(preset);
 }

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -328,7 +328,7 @@ void SamplingReportDataView::LinkDataView(DataView* data_view) {
 }
 
 void SamplingReportDataView::SetSampledFunctions(absl::Span<const SampledFunction> functions) {
-  functions_ = functions;
+  functions_.assign(functions.begin(), functions.end());
   RestoreSelectedIndicesAfterFunctionsChanged();
 
   size_t num_functions = functions_.size();

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -229,7 +229,7 @@ std::optional<ModuleIdentifier> SamplingReportDataView::GetModuleIdentifierFromR
 }
 
 DataView::ActionStatus SamplingReportDataView::GetActionStatus(
-    std::string_view action, int clicked_index, absl::Span<int const> selected_indices) {
+    std::string_view action, int clicked_index, absl::Span<const int> selected_indices) {
   if (action == kMenuActionLoadSymbols) {
     for (int index : selected_indices) {
       const ModuleData* module = GetModuleDataFromRow(index);
@@ -283,7 +283,7 @@ ModuleData* SamplingReportDataView::GetModuleDataFromRow(int row) const {
 }
 
 void SamplingReportDataView::UpdateSelectedIndicesAndFunctionIds(
-    absl::Span<int const> selected_indices) {
+    absl::Span<const int> selected_indices) {
   selected_indices_.clear();
   selected_function_ids_.clear();
   for (int row : selected_indices) {
@@ -302,7 +302,7 @@ void SamplingReportDataView::RestoreSelectedIndicesAfterFunctionsChanged() {
 }
 
 void SamplingReportDataView::UpdateVisibleSelectedAddressesAndTid(
-    absl::Span<int const> visible_selected_indices) {
+    absl::Span<const int> visible_selected_indices) {
   absl::flat_hash_set<uint64_t> addresses;
   for (int index : visible_selected_indices) {
     addresses.insert(GetSampledFunction(index).absolute_address);
@@ -310,12 +310,12 @@ void SamplingReportDataView::UpdateVisibleSelectedAddressesAndTid(
   sampling_report_->OnSelectAddresses(addresses, tid_);
 }
 
-void SamplingReportDataView::OnSelect(absl::Span<int const> indices) {
+void SamplingReportDataView::OnSelect(absl::Span<const int> indices) {
   UpdateSelectedIndicesAndFunctionIds(indices);
   UpdateVisibleSelectedAddressesAndTid(indices);
 }
 
-void SamplingReportDataView::OnRefresh(absl::Span<int const> visible_selected_indices,
+void SamplingReportDataView::OnRefresh(absl::Span<const int> visible_selected_indices,
                                        const RefreshMode& mode) {
   if (mode != RefreshMode::kOnFilter && mode != RefreshMode::kOnSort) return;
   UpdateVisibleSelectedAddressesAndTid(visible_selected_indices);
@@ -327,7 +327,7 @@ void SamplingReportDataView::LinkDataView(DataView* data_view) {
   sampling_report_->SetCallstackDataView(static_cast<CallstackDataView*>(data_view));
 }
 
-void SamplingReportDataView::SetSampledFunctions(absl::Span<SampledFunction const> functions) {
+void SamplingReportDataView::SetSampledFunctions(absl::Span<const SampledFunction> functions) {
   functions_ = functions;
   RestoreSelectedIndicesAfterFunctionsChanged();
 
@@ -515,7 +515,7 @@ ErrorMessageOr<void> SamplingReportDataView::WriteStackEventsToCsv(std::string_v
 
 // The argument `selection` is ignored as the selected functions are more conveniently obtained as
 // `sampling_report_->GetSelectedCallstackIds()`
-void SamplingReportDataView::OnExportEventsToCsvRequested(absl::Span<int const> /*selection*/) {
+void SamplingReportDataView::OnExportEventsToCsvRequested(absl::Span<const int> /*selection*/) {
   std::string file_path = app_->GetSaveFile(".csv");
   if (file_path.empty()) return;
 

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -146,11 +146,12 @@ const std::vector<orbit_client_data::CallstackInfo> kCallstackInfos = [] {
                             kSampledAbsoluteAddresses[2]},
       std::vector<uint64_t>{kSampledAbsoluteAddresses[2], kSampledAbsoluteAddresses[1]}};
   std::vector<orbit_client_data::CallstackInfo> result;
-  std::transform(std::begin(array_of_vectors_of_frames), std::end(array_of_vectors_of_frames),
-                 std::back_inserter(result),
-                 [](absl::Span<uint64_t const> frames) -> orbit_client_data::CallstackInfo {
-                   return {frames, orbit_client_data::CallstackType::kComplete};
-                 });
+  std::transform(
+      std::begin(array_of_vectors_of_frames), std::end(array_of_vectors_of_frames),
+      std::back_inserter(result),
+      [](absl::Span<uint64_t const> frames) -> orbit_client_data::CallstackInfo {
+        return {{frames.begin(), frames.end()}, orbit_client_data::CallstackType::kComplete};
+      });
   return result;
 }();
 constexpr std::array<uint64_t, kCallstackInfoNum> kTimestamps = {123456, 456789, 789456};

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -411,7 +411,7 @@ class SamplingReportDataViewTest : public testing::Test {
     view_.SetSamplingReport(&sampling_report_);
   }
 
-  void AddFunctionsByIndices(absl::Span<size_t const> indices) {
+  void AddFunctionsByIndices(absl::Span<const size_t> indices) {
     std::vector<SampledFunction> functions_to_add;
     for (size_t index : indices) {
       ORBIT_CHECK(index < kNumFunctions);
@@ -506,7 +506,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       });
 
   auto get_context_menu_from_selected_indices =
-      [&](absl::Span<int const> selected_indices) -> FlattenContextMenu {
+      [&](absl::Span<const int> selected_indices) -> FlattenContextMenu {
     std::vector<int> selected_rows;
     for (int index : selected_indices) {
       for (int row = 0, row_counts = view_.GetNumElements(); row < row_counts; row++) {
@@ -520,7 +520,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         view_.GetContextMenuWithGrouping(0, selected_rows));
   };
 
-  auto verify_context_menu_action_availability = [&](absl::Span<int const> selected_indices) {
+  auto verify_context_menu_action_availability = [&](absl::Span<const int> selected_indices) {
     FlattenContextMenu context_menu = get_context_menu_from_selected_indices(selected_indices);
 
     // Common actions should always be available.

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -6,6 +6,7 @@
 #include <absl/hash/hash.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -147,7 +148,7 @@ const std::vector<orbit_client_data::CallstackInfo> kCallstackInfos = [] {
   std::vector<orbit_client_data::CallstackInfo> result;
   std::transform(std::begin(array_of_vectors_of_frames), std::end(array_of_vectors_of_frames),
                  std::back_inserter(result),
-                 [](const std::vector<uint64_t>& frames) -> orbit_client_data::CallstackInfo {
+                 [](absl::Span<uint64_t const> frames) -> orbit_client_data::CallstackInfo {
                    return {frames, orbit_client_data::CallstackType::kComplete};
                  });
   return result;
@@ -410,7 +411,7 @@ class SamplingReportDataViewTest : public testing::Test {
     view_.SetSamplingReport(&sampling_report_);
   }
 
-  void AddFunctionsByIndices(const std::vector<size_t>& indices) {
+  void AddFunctionsByIndices(absl::Span<size_t const> indices) {
     std::vector<SampledFunction> functions_to_add;
     for (size_t index : indices) {
       ORBIT_CHECK(index < kNumFunctions);
@@ -505,7 +506,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       });
 
   auto get_context_menu_from_selected_indices =
-      [&](const std::vector<int>& selected_indices) -> FlattenContextMenu {
+      [&](absl::Span<int const> selected_indices) -> FlattenContextMenu {
     std::vector<int> selected_rows;
     for (int index : selected_indices) {
       for (int row = 0, row_counts = view_.GetNumElements(); row < row_counts; row++) {
@@ -519,7 +520,7 @@ TEST_F(SamplingReportDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         view_.GetContextMenuWithGrouping(0, selected_rows));
   };
 
-  auto verify_context_menu_action_availability = [&](const std::vector<int>& selected_indices) {
+  auto verify_context_menu_action_availability = [&](absl::Span<int const> selected_indices) {
     FlattenContextMenu context_menu = get_context_menu_from_selected_indices(selected_indices);
 
     // Common actions should always be available.

--- a/src/DataViews/TracepointsDataView.cpp
+++ b/src/DataViews/TracepointsDataView.cpp
@@ -102,7 +102,7 @@ void TracepointsDataView::DoFilter() {
 }
 
 DataView::ActionStatus TracepointsDataView::GetActionStatus(
-    std::string_view action, int clicked_index, absl::Span<int const> selected_indices) {
+    std::string_view action, int clicked_index, absl::Span<const int> selected_indices) {
   std::function<bool(const TracepointInfo&)> is_visible_action_enabled;
   if (action == kMenuActionSelect) {
     is_visible_action_enabled = [this](const TracepointInfo& tracepoint) {
@@ -125,19 +125,19 @@ DataView::ActionStatus TracepointsDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-void TracepointsDataView::OnSelectRequested(absl::Span<int const> selection) {
+void TracepointsDataView::OnSelectRequested(absl::Span<const int> selection) {
   for (int i : selection) {
     app_->SelectTracepoint(GetTracepoint(i));
   }
 }
 
-void TracepointsDataView::OnUnselectRequested(absl::Span<int const> selection) {
+void TracepointsDataView::OnUnselectRequested(absl::Span<const int> selection) {
   for (int i : selection) {
     app_->DeselectTracepoint(GetTracepoint(i));
   }
 }
 
-void TracepointsDataView::SetTracepoints(absl::Span<TracepointInfo const> tracepoints) {
+void TracepointsDataView::SetTracepoints(absl::Span<const TracepointInfo> tracepoints) {
   tracepoints_.assign(tracepoints.cbegin(), tracepoints.cend());
 
   indices_.resize(tracepoints_.size());

--- a/src/DataViews/TracepointsDataView.cpp
+++ b/src/DataViews/TracepointsDataView.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_split.h>
+#include <absl/types/span.h>
 #include <stddef.h>
 
 #include <algorithm>
@@ -101,7 +102,7 @@ void TracepointsDataView::DoFilter() {
 }
 
 DataView::ActionStatus TracepointsDataView::GetActionStatus(
-    std::string_view action, int clicked_index, const std::vector<int>& selected_indices) {
+    std::string_view action, int clicked_index, absl::Span<int const> selected_indices) {
   std::function<bool(const TracepointInfo&)> is_visible_action_enabled;
   if (action == kMenuActionSelect) {
     is_visible_action_enabled = [this](const TracepointInfo& tracepoint) {
@@ -124,19 +125,19 @@ DataView::ActionStatus TracepointsDataView::GetActionStatus(
   return ActionStatus::kVisibleButDisabled;
 }
 
-void TracepointsDataView::OnSelectRequested(const std::vector<int>& selection) {
+void TracepointsDataView::OnSelectRequested(absl::Span<int const> selection) {
   for (int i : selection) {
     app_->SelectTracepoint(GetTracepoint(i));
   }
 }
 
-void TracepointsDataView::OnUnselectRequested(const std::vector<int>& selection) {
+void TracepointsDataView::OnUnselectRequested(absl::Span<int const> selection) {
   for (int i : selection) {
     app_->DeselectTracepoint(GetTracepoint(i));
   }
 }
 
-void TracepointsDataView::SetTracepoints(const std::vector<TracepointInfo>& tracepoints) {
+void TracepointsDataView::SetTracepoints(absl::Span<TracepointInfo const> tracepoints) {
   tracepoints_.assign(tracepoints.cbegin(), tracepoints.cend());
 
   indices_.resize(tracepoints_.size());

--- a/src/DataViews/TracepointsDataViewTest.cpp
+++ b/src/DataViews/TracepointsDataViewTest.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
@@ -64,7 +65,7 @@ class TracepointsDataViewTest : public testing::Test {
     }
   }
 
-  void SetTracepointsByIndices(const std::vector<size_t>& indices) {
+  void SetTracepointsByIndices(absl::Span<size_t const> indices) {
     std::vector<TracepointInfo> tracepoints_to_add;
     for (size_t index : indices) {
       ORBIT_CHECK(index < kNumTracepoints);
@@ -124,7 +125,7 @@ TEST_F(TracepointsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         return tracepoints_selected.at(index.value());
       });
 
-  auto verify_context_menu_action_availability = [&](const std::vector<int>& selected_indices) {
+  auto verify_context_menu_action_availability = [&](absl::Span<int const> selected_indices) {
     FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
         view_.GetContextMenuWithGrouping(0, selected_indices));
 

--- a/src/DataViews/TracepointsDataViewTest.cpp
+++ b/src/DataViews/TracepointsDataViewTest.cpp
@@ -65,7 +65,7 @@ class TracepointsDataViewTest : public testing::Test {
     }
   }
 
-  void SetTracepointsByIndices(absl::Span<size_t const> indices) {
+  void SetTracepointsByIndices(absl::Span<const size_t> indices) {
     std::vector<TracepointInfo> tracepoints_to_add;
     for (size_t index : indices) {
       ORBIT_CHECK(index < kNumTracepoints);
@@ -125,7 +125,7 @@ TEST_F(TracepointsDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         return tracepoints_selected.at(index.value());
       });
 
-  auto verify_context_menu_action_availability = [&](absl::Span<int const> selected_indices) {
+  auto verify_context_menu_action_availability = [&](absl::Span<const int> selected_indices) {
     FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
         view_.GetContextMenuWithGrouping(0, selected_indices));
 

--- a/src/DataViews/include/DataViews/CallstackDataView.h
+++ b/src/DataViews/include/DataViews/CallstackDataView.h
@@ -6,6 +6,7 @@
 #define DATA_VIEWS_CALLSTACK_DATA_VIEW_H_
 
 #include <absl/container/flat_hash_set.h>
+#include <absl/types/span.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -86,7 +87,7 @@ class CallstackDataView : public DataView {
   };
 
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             const std::vector<int>& selected_indices) override;
+                                             absl::Span<int const> selected_indices) override;
 
  private:
   [[nodiscard]] const orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {

--- a/src/DataViews/include/DataViews/CallstackDataView.h
+++ b/src/DataViews/include/DataViews/CallstackDataView.h
@@ -87,7 +87,7 @@ class CallstackDataView : public DataView {
   };
 
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             absl::Span<int const> selected_indices) override;
+                                             absl::Span<const int> selected_indices) override;
 
  private:
   [[nodiscard]] const orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override {

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -127,7 +127,7 @@ class DataView {
   virtual bool IsSortingAllowed() { return true; }
   virtual int GetDefaultSortingColumn() { return 0; }
   std::vector<ActionGroup> GetContextMenuWithGrouping(int clicked_index,
-                                                      absl::Span<int const> selected_indices);
+                                                      absl::Span<const int> selected_indices);
   virtual size_t GetNumElements() { return indices_.size(); }
   virtual std::string GetValue(int /*row*/, int /*column*/) { return ""; }
   virtual std::string GetValueForCopy(int row, int column) { return GetValue(row, column); }
@@ -140,12 +140,12 @@ class DataView {
   // Filter callback set from UI layer.
   using FilterCallback = std::function<void(std::string_view)>;
   void SetUiFilterCallback(FilterCallback callback) { filter_callback_ = std::move(callback); }
-  virtual void OnRefresh(absl::Span<int const> /*visible_selected_indices*/,
+  virtual void OnRefresh(absl::Span<const int> /*visible_selected_indices*/,
                          const RefreshMode& /*mode*/) {}
 
   void OnSort(int column, std::optional<SortingOrder> new_order);
-  void OnContextMenu(std::string_view action, int menu_index, absl::Span<int const> item_indices);
-  virtual void OnSelect(absl::Span<int const> /*indices*/) {}
+  void OnContextMenu(std::string_view action, int menu_index, absl::Span<const int> item_indices);
+  virtual void OnSelect(absl::Span<const int> /*indices*/) {}
   // This method returns the intersection of selected indices and visible indices. The returned
   // value contains 0 or 1 index for a DataView with single selection, and contains 0 or
   // multiple indices for a DataView with multi-selection.
@@ -170,23 +170,23 @@ class DataView {
   [[nodiscard]] DataViewType GetType() const { return type_; }
   [[nodiscard]] virtual bool ResetOnRefresh() const { return true; }
 
-  void OnLoadSymbolsRequested(absl::Span<int const> selection);
-  void OnStopDownloadRequested(absl::Span<int const> selection);
-  virtual void OnSelectRequested(absl::Span<int const> selection);
-  virtual void OnUnselectRequested(absl::Span<int const> selection);
-  void OnEnableFrameTrackRequested(absl::Span<int const> selection);
-  void OnDisableFrameTrackRequested(absl::Span<int const> selection);
-  virtual void OnIteratorRequested(absl::Span<int const> /*selection*/) {}
-  void OnDisassemblyRequested(absl::Span<int const> selection);
-  void OnSourceCodeRequested(absl::Span<int const> selection);
-  virtual void OnJumpToRequested(std::string_view /*action*/, absl::Span<int const> /*selection*/) {
+  void OnLoadSymbolsRequested(absl::Span<const int> selection);
+  void OnStopDownloadRequested(absl::Span<const int> selection);
+  virtual void OnSelectRequested(absl::Span<const int> selection);
+  virtual void OnUnselectRequested(absl::Span<const int> selection);
+  void OnEnableFrameTrackRequested(absl::Span<const int> selection);
+  void OnDisableFrameTrackRequested(absl::Span<const int> selection);
+  virtual void OnIteratorRequested(absl::Span<const int> /*selection*/) {}
+  void OnDisassemblyRequested(absl::Span<const int> selection);
+  void OnSourceCodeRequested(absl::Span<const int> selection);
+  virtual void OnJumpToRequested(std::string_view /*action*/, absl::Span<const int> /*selection*/) {
   }
-  virtual void OnLoadPresetRequested(absl::Span<int const> /*selection*/) {}
-  virtual void OnDeletePresetRequested(absl::Span<int const> /*selection*/) {}
-  virtual void OnShowInExplorerRequested(absl::Span<int const> /*selection*/) {}
-  void OnCopySelectionRequested(absl::Span<int const> selection);
+  virtual void OnLoadPresetRequested(absl::Span<const int> /*selection*/) {}
+  virtual void OnDeletePresetRequested(absl::Span<const int> /*selection*/) {}
+  virtual void OnShowInExplorerRequested(absl::Span<const int> /*selection*/) {}
+  void OnCopySelectionRequested(absl::Span<const int> selection);
   void OnExportToCsvRequested();
-  virtual void OnExportEventsToCsvRequested(absl::Span<int const> /*selection*/) {}
+  virtual void OnExportEventsToCsvRequested(absl::Span<const int> /*selection*/) {}
 
  protected:
   [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleDataFromRow(
@@ -209,7 +209,7 @@ class DataView {
 
   enum class ActionStatus { kInvisible, kVisibleButDisabled, kVisibleAndEnabled };
   [[nodiscard]] virtual ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                                     absl::Span<int const> selected_indices);
+                                                     absl::Span<const int> selected_indices);
 
   void InitSortingOrders();
   virtual void DoSort() {}

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -9,6 +9,7 @@
 #include <absl/hash/hash.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
+#include <absl/types/span.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -126,7 +127,7 @@ class DataView {
   virtual bool IsSortingAllowed() { return true; }
   virtual int GetDefaultSortingColumn() { return 0; }
   std::vector<ActionGroup> GetContextMenuWithGrouping(int clicked_index,
-                                                      const std::vector<int>& selected_indices);
+                                                      absl::Span<int const> selected_indices);
   virtual size_t GetNumElements() { return indices_.size(); }
   virtual std::string GetValue(int /*row*/, int /*column*/) { return ""; }
   virtual std::string GetValueForCopy(int row, int column) { return GetValue(row, column); }
@@ -139,12 +140,12 @@ class DataView {
   // Filter callback set from UI layer.
   using FilterCallback = std::function<void(std::string_view)>;
   void SetUiFilterCallback(FilterCallback callback) { filter_callback_ = std::move(callback); }
-  virtual void OnRefresh(const std::vector<int>& /*visible_selected_indices*/,
+  virtual void OnRefresh(absl::Span<int const> /*visible_selected_indices*/,
                          const RefreshMode& /*mode*/) {}
 
   void OnSort(int column, std::optional<SortingOrder> new_order);
-  void OnContextMenu(std::string_view action, int menu_index, const std::vector<int>& item_indices);
-  virtual void OnSelect(const std::vector<int>& /*indices*/) {}
+  void OnContextMenu(std::string_view action, int menu_index, absl::Span<int const> item_indices);
+  virtual void OnSelect(absl::Span<int const> /*indices*/) {}
   // This method returns the intersection of selected indices and visible indices. The returned
   // value contains 0 or 1 index for a DataView with single selection, and contains 0 or
   // multiple indices for a DataView with multi-selection.
@@ -169,23 +170,23 @@ class DataView {
   [[nodiscard]] DataViewType GetType() const { return type_; }
   [[nodiscard]] virtual bool ResetOnRefresh() const { return true; }
 
-  void OnLoadSymbolsRequested(const std::vector<int>& selection);
-  void OnStopDownloadRequested(const std::vector<int>& selection);
-  virtual void OnSelectRequested(const std::vector<int>& selection);
-  virtual void OnUnselectRequested(const std::vector<int>& selection);
-  void OnEnableFrameTrackRequested(const std::vector<int>& selection);
-  void OnDisableFrameTrackRequested(const std::vector<int>& selection);
-  virtual void OnIteratorRequested(const std::vector<int>& /*selection*/) {}
-  void OnDisassemblyRequested(const std::vector<int>& selection);
-  void OnSourceCodeRequested(const std::vector<int>& selection);
-  virtual void OnJumpToRequested(std::string_view /*action*/,
-                                 const std::vector<int>& /*selection*/) {}
-  virtual void OnLoadPresetRequested(const std::vector<int>& /*selection*/) {}
-  virtual void OnDeletePresetRequested(const std::vector<int>& /*selection*/) {}
-  virtual void OnShowInExplorerRequested(const std::vector<int>& /*selection*/) {}
-  void OnCopySelectionRequested(const std::vector<int>& selection);
+  void OnLoadSymbolsRequested(absl::Span<int const> selection);
+  void OnStopDownloadRequested(absl::Span<int const> selection);
+  virtual void OnSelectRequested(absl::Span<int const> selection);
+  virtual void OnUnselectRequested(absl::Span<int const> selection);
+  void OnEnableFrameTrackRequested(absl::Span<int const> selection);
+  void OnDisableFrameTrackRequested(absl::Span<int const> selection);
+  virtual void OnIteratorRequested(absl::Span<int const> /*selection*/) {}
+  void OnDisassemblyRequested(absl::Span<int const> selection);
+  void OnSourceCodeRequested(absl::Span<int const> selection);
+  virtual void OnJumpToRequested(std::string_view /*action*/, absl::Span<int const> /*selection*/) {
+  }
+  virtual void OnLoadPresetRequested(absl::Span<int const> /*selection*/) {}
+  virtual void OnDeletePresetRequested(absl::Span<int const> /*selection*/) {}
+  virtual void OnShowInExplorerRequested(absl::Span<int const> /*selection*/) {}
+  void OnCopySelectionRequested(absl::Span<int const> selection);
   void OnExportToCsvRequested();
-  virtual void OnExportEventsToCsvRequested(const std::vector<int>& /*selection*/) {}
+  virtual void OnExportEventsToCsvRequested(absl::Span<int const> /*selection*/) {}
 
  protected:
   [[nodiscard]] virtual const orbit_client_data::ModuleData* GetModuleDataFromRow(
@@ -208,7 +209,7 @@ class DataView {
 
   enum class ActionStatus { kInvisible, kVisibleButDisabled, kVisibleAndEnabled };
   [[nodiscard]] virtual ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                                     const std::vector<int>& selected_indices);
+                                                     absl::Span<int const> selected_indices);
 
   void InitSortingOrders();
   virtual void DoSort() {}

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -44,7 +44,7 @@ class FunctionsDataView : public DataView {
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             absl::Span<int const> selected_indices) override;
+                                             absl::Span<const int> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/FunctionsDataView.h
+++ b/src/DataViews/include/DataViews/FunctionsDataView.h
@@ -5,6 +5,8 @@
 #ifndef DATA_VIEWS_FUNCTIONS_DATA_VIEW_H_
 #define DATA_VIEWS_FUNCTIONS_DATA_VIEW_H_
 
+#include <absl/types/span.h>
+
 #include <string>
 #include <string_view>
 #include <vector>
@@ -42,7 +44,7 @@ class FunctionsDataView : public DataView {
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             const std::vector<int>& selected_indices) override;
+                                             absl::Span<int const> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -47,23 +47,23 @@ class LiveFunctionsDataView : public DataView {
   // As we allow single selection on Live tab, this method returns either an empty vector or a
   // single-value vector.
   std::vector<int> GetVisibleSelectedIndices() override;
-  void UpdateHighlightedFunctionId(absl::Span<int const> rows);
+  void UpdateHighlightedFunctionId(absl::Span<const int> rows);
   void UpdateSelectedFunctionId();
 
-  void OnSelect(absl::Span<int const> rows) override;
+  void OnSelect(absl::Span<const int> rows) override;
   void OnDataChanged() override;
   void OnTimer() override;
-  void OnRefresh(absl::Span<int const> visible_selected_indices, const RefreshMode& mode) override;
+  void OnRefresh(absl::Span<const int> visible_selected_indices, const RefreshMode& mode) override;
   [[nodiscard]] bool ResetOnRefresh() const override { return false; }
   std::optional<int> GetRowFromScopeId(ScopeId scope_id);
 
-  void OnIteratorRequested(absl::Span<int const> selection) override;
-  void OnJumpToRequested(std::string_view action, absl::Span<int const> selection) override;
+  void OnIteratorRequested(absl::Span<const int> selection) override;
+  void OnJumpToRequested(std::string_view action, absl::Span<const int> selection) override;
   // Export all events (including the function name, thread name and id, start timestamp, end
   // timestamp, and duration) associated with the selected rows in to a CSV file.
-  void OnExportEventsToCsvRequested(absl::Span<int const> selection) override;
+  void OnExportEventsToCsvRequested(absl::Span<const int> selection) override;
 
-  void UpdateHistogramWithScopeIds(absl::Span<ScopeId const> scope_ids);
+  void UpdateHistogramWithScopeIds(absl::Span<const ScopeId> scope_ids);
 
   std::string GetToolTip(int /*row*/, int column) override;
 
@@ -76,7 +76,7 @@ class LiveFunctionsDataView : public DataView {
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             absl::Span<int const> selected_indices) override;
+                                             absl::Span<const int> selected_indices) override;
   void DoFilter() override;
   void DoSort() override;
   [[nodiscard]] ScopeId GetScopeId(uint32_t row) const;
@@ -111,10 +111,10 @@ class LiveFunctionsDataView : public DataView {
   // pointer to the corresponding FunctionInfo is returned. `nullptr` is returned otherwise.
   [[nodiscard]] const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int row) override;
 
-  [[nodiscard]] ErrorMessageOr<void> WriteEventsToCsv(absl::Span<int const> selection,
+  [[nodiscard]] ErrorMessageOr<void> WriteEventsToCsv(absl::Span<const int> selection,
                                                       std::string_view file_path) const;
 
-  void UpdateHistogramWithIndices(absl::Span<int const> visible_selected_indices);
+  void UpdateHistogramWithIndices(absl::Span<const int> visible_selected_indices);
 
   template <typename ValueGetterType>
   [[nodiscard]] std::function<bool(ScopeId, ScopeId)> MakeSorter(ValueGetterType getter,

--- a/src/DataViews/include/DataViews/LiveFunctionsDataView.h
+++ b/src/DataViews/include/DataViews/LiveFunctionsDataView.h
@@ -7,6 +7,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <algorithm>
@@ -46,24 +47,23 @@ class LiveFunctionsDataView : public DataView {
   // As we allow single selection on Live tab, this method returns either an empty vector or a
   // single-value vector.
   std::vector<int> GetVisibleSelectedIndices() override;
-  void UpdateHighlightedFunctionId(const std::vector<int>& rows);
+  void UpdateHighlightedFunctionId(absl::Span<int const> rows);
   void UpdateSelectedFunctionId();
 
-  void OnSelect(const std::vector<int>& rows) override;
+  void OnSelect(absl::Span<int const> rows) override;
   void OnDataChanged() override;
   void OnTimer() override;
-  void OnRefresh(const std::vector<int>& visible_selected_indices,
-                 const RefreshMode& mode) override;
+  void OnRefresh(absl::Span<int const> visible_selected_indices, const RefreshMode& mode) override;
   [[nodiscard]] bool ResetOnRefresh() const override { return false; }
   std::optional<int> GetRowFromScopeId(ScopeId scope_id);
 
-  void OnIteratorRequested(const std::vector<int>& selection) override;
-  void OnJumpToRequested(std::string_view action, const std::vector<int>& selection) override;
+  void OnIteratorRequested(absl::Span<int const> selection) override;
+  void OnJumpToRequested(std::string_view action, absl::Span<int const> selection) override;
   // Export all events (including the function name, thread name and id, start timestamp, end
   // timestamp, and duration) associated with the selected rows in to a CSV file.
-  void OnExportEventsToCsvRequested(const std::vector<int>& selection) override;
+  void OnExportEventsToCsvRequested(absl::Span<int const> selection) override;
 
-  void UpdateHistogramWithScopeIds(const std::vector<ScopeId>& scope_ids);
+  void UpdateHistogramWithScopeIds(absl::Span<ScopeId const> scope_ids);
 
   std::string GetToolTip(int /*row*/, int column) override;
 
@@ -76,7 +76,7 @@ class LiveFunctionsDataView : public DataView {
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             const std::vector<int>& selected_indices) override;
+                                             absl::Span<int const> selected_indices) override;
   void DoFilter() override;
   void DoSort() override;
   [[nodiscard]] ScopeId GetScopeId(uint32_t row) const;
@@ -111,10 +111,10 @@ class LiveFunctionsDataView : public DataView {
   // pointer to the corresponding FunctionInfo is returned. `nullptr` is returned otherwise.
   [[nodiscard]] const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int row) override;
 
-  [[nodiscard]] ErrorMessageOr<void> WriteEventsToCsv(const std::vector<int>& selection,
+  [[nodiscard]] ErrorMessageOr<void> WriteEventsToCsv(absl::Span<int const> selection,
                                                       std::string_view file_path) const;
 
-  void UpdateHistogramWithIndices(const std::vector<int>& visible_selected_indices);
+  void UpdateHistogramWithIndices(absl::Span<int const> visible_selected_indices);
 
   template <typename ValueGetterType>
   [[nodiscard]] std::function<bool(ScopeId, ScopeId)> MakeSorter(ValueGetterType getter,

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -42,7 +42,7 @@ class ModulesDataView : public DataView {
                  orbit_client_data::ModuleInMemory module_in_memory);
   void UpdateModules(const orbit_client_data::ProcessData* process);
 
-  void OnSelect(absl::Span<int const> rows) override {
+  void OnSelect(absl::Span<const int> rows) override {
     selected_indices_.clear();
     for (int row : rows) {
       selected_indices_.insert(static_cast<int>(indices_.at(row)));
@@ -51,7 +51,7 @@ class ModulesDataView : public DataView {
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             absl::Span<int const> selected_indices) override;
+                                             absl::Span<const int> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/ModulesDataView.h
+++ b/src/DataViews/include/DataViews/ModulesDataView.h
@@ -7,6 +7,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <cstdint>
@@ -41,7 +42,7 @@ class ModulesDataView : public DataView {
                  orbit_client_data::ModuleInMemory module_in_memory);
   void UpdateModules(const orbit_client_data::ProcessData* process);
 
-  void OnSelect(const std::vector<int>& rows) override {
+  void OnSelect(absl::Span<int const> rows) override {
     selected_indices_.clear();
     for (int row : rows) {
       selected_indices_.insert(static_cast<int>(indices_.at(row)));
@@ -50,7 +51,7 @@ class ModulesDataView : public DataView {
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             const std::vector<int>& selected_indices) override;
+                                             absl::Span<int const> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -5,6 +5,7 @@
 #ifndef DATA_VIEWS_PRESETS_DATA_VIEW_H_
 #define DATA_VIEWS_PRESETS_DATA_VIEW_H_
 
+#include <absl/types/span.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -41,9 +42,9 @@ class PresetsDataView : public DataView {
 
   void SetPresets(std::vector<orbit_preset_file::PresetFile> presets);
 
-  void OnLoadPresetRequested(const std::vector<int>& selection) override;
-  void OnDeletePresetRequested(const std::vector<int>& selection) override;
-  void OnShowInExplorerRequested(const std::vector<int>& selection) override;
+  void OnLoadPresetRequested(absl::Span<int const> selection) override;
+  void OnDeletePresetRequested(absl::Span<int const> selection) override;
+  void OnShowInExplorerRequested(absl::Span<int const> selection) override;
   void OnLoadPresetSuccessful(const std::filesystem::path& preset_file_path);
 
   static constexpr std::string_view kLoadedPresetPrefix{"* "};
@@ -60,13 +61,13 @@ class PresetsDataView : public DataView {
   };
 
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             const std::vector<int>& selected_indices) override;
+                                             absl::Span<int const> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
-  [[nodiscard]] static std::string GetModulesList(const std::vector<ModuleView>& modules);
-  [[nodiscard]] static std::string GetFunctionCountList(const std::vector<ModuleView>& modules);
+  [[nodiscard]] static std::string GetModulesList(absl::Span<ModuleView const> modules);
+  [[nodiscard]] static std::string GetFunctionCountList(absl::Span<ModuleView const> modules);
   [[nodiscard]] static std::string GetModuleAndFunctionCountList(
-      const std::vector<ModuleView>& modules);
+      absl::Span<ModuleView const> modules);
   [[nodiscard]] const orbit_preset_file::PresetFile& GetPreset(unsigned int row) const;
   [[nodiscard]] const std::vector<ModuleView>& GetModules(uint32_t row) const;
 

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -42,9 +42,9 @@ class PresetsDataView : public DataView {
 
   void SetPresets(std::vector<orbit_preset_file::PresetFile> presets);
 
-  void OnLoadPresetRequested(absl::Span<int const> selection) override;
-  void OnDeletePresetRequested(absl::Span<int const> selection) override;
-  void OnShowInExplorerRequested(absl::Span<int const> selection) override;
+  void OnLoadPresetRequested(absl::Span<const int> selection) override;
+  void OnDeletePresetRequested(absl::Span<const int> selection) override;
+  void OnShowInExplorerRequested(absl::Span<const int> selection) override;
   void OnLoadPresetSuccessful(const std::filesystem::path& preset_file_path);
 
   static constexpr std::string_view kLoadedPresetPrefix{"* "};
@@ -61,13 +61,13 @@ class PresetsDataView : public DataView {
   };
 
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             absl::Span<int const> selected_indices) override;
+                                             absl::Span<const int> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
-  [[nodiscard]] static std::string GetModulesList(absl::Span<ModuleView const> modules);
-  [[nodiscard]] static std::string GetFunctionCountList(absl::Span<ModuleView const> modules);
+  [[nodiscard]] static std::string GetModulesList(absl::Span<const ModuleView> modules);
+  [[nodiscard]] static std::string GetFunctionCountList(absl::Span<const ModuleView> modules);
   [[nodiscard]] static std::string GetModuleAndFunctionCountList(
-      absl::Span<ModuleView const> modules);
+      absl::Span<const ModuleView> modules);
   [[nodiscard]] const orbit_preset_file::PresetFile& GetPreset(unsigned int row) const;
   [[nodiscard]] const std::vector<ModuleView>& GetModules(uint32_t row) const;
 

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -42,23 +42,23 @@ class SamplingReportDataView : public DataView {
   std::string GetToolTip(int /*row*/, int /*column*/) override;
   const std::string& GetName() { return name_; }
 
-  void OnSelect(absl::Span<int const> indices) override;
-  void OnRefresh(absl::Span<int const> visible_selected_indices, const RefreshMode& mode) override;
+  void OnSelect(absl::Span<const int> indices) override;
+  void OnRefresh(absl::Span<const int> visible_selected_indices, const RefreshMode& mode) override;
 
   void LinkDataView(DataView* data_view) override;
   void SetSamplingReport(SamplingReportInterface* sampling_report) {
     sampling_report_ = sampling_report;
   }
-  void SetSampledFunctions(absl::Span<orbit_client_data::SampledFunction const> functions);
+  void SetSampledFunctions(absl::Span<const orbit_client_data::SampledFunction> functions);
   void SetThreadID(orbit_client_data::ThreadID tid);
   void SetStackEventsCount(uint32_t stack_events_count);
   orbit_client_data::ThreadID GetThreadID() const { return tid_; }
 
-  void OnExportEventsToCsvRequested(absl::Span<int const> selection) override;
+  void OnExportEventsToCsvRequested(absl::Span<const int> selection) override;
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             absl::Span<int const> selected_indices) override;
+                                             absl::Span<const int> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
   const orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row) const;
@@ -70,10 +70,10 @@ class SamplingReportDataView : public DataView {
   [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override;
   [[nodiscard]] const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int row) override;
 
-  void UpdateSelectedIndicesAndFunctionIds(absl::Span<int const> selected_indices);
+  void UpdateSelectedIndicesAndFunctionIds(absl::Span<const int> selected_indices);
   void RestoreSelectedIndicesAfterFunctionsChanged();
   // The callstack view will be updated according to the visible selected addresses and thread id.
-  void UpdateVisibleSelectedAddressesAndTid(absl::Span<int const> visible_selected_indices);
+  void UpdateVisibleSelectedAddressesAndTid(absl::Span<const int> visible_selected_indices);
 
   [[nodiscard]] std::string BuildPercentageString(float percentage) const;
 

--- a/src/DataViews/include/DataViews/SamplingReportDataView.h
+++ b/src/DataViews/include/DataViews/SamplingReportDataView.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <absl/container/flat_hash_set.h>
+#include <absl/types/span.h>
 
 #include <cstdint>
 #include <optional>
@@ -41,24 +42,23 @@ class SamplingReportDataView : public DataView {
   std::string GetToolTip(int /*row*/, int /*column*/) override;
   const std::string& GetName() { return name_; }
 
-  void OnSelect(const std::vector<int>& indices) override;
-  void OnRefresh(const std::vector<int>& visible_selected_indices,
-                 const RefreshMode& mode) override;
+  void OnSelect(absl::Span<int const> indices) override;
+  void OnRefresh(absl::Span<int const> visible_selected_indices, const RefreshMode& mode) override;
 
   void LinkDataView(DataView* data_view) override;
   void SetSamplingReport(SamplingReportInterface* sampling_report) {
     sampling_report_ = sampling_report;
   }
-  void SetSampledFunctions(const std::vector<orbit_client_data::SampledFunction>& functions);
+  void SetSampledFunctions(absl::Span<orbit_client_data::SampledFunction const> functions);
   void SetThreadID(orbit_client_data::ThreadID tid);
   void SetStackEventsCount(uint32_t stack_events_count);
   orbit_client_data::ThreadID GetThreadID() const { return tid_; }
 
-  void OnExportEventsToCsvRequested(const std::vector<int>& selection) override;
+  void OnExportEventsToCsvRequested(absl::Span<int const> selection) override;
 
  protected:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             const std::vector<int>& selected_indices) override;
+                                             absl::Span<int const> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
   const orbit_client_data::SampledFunction& GetSampledFunction(unsigned int row) const;
@@ -70,10 +70,10 @@ class SamplingReportDataView : public DataView {
   [[nodiscard]] orbit_client_data::ModuleData* GetModuleDataFromRow(int row) const override;
   [[nodiscard]] const orbit_client_data::FunctionInfo* GetFunctionInfoFromRow(int row) override;
 
-  void UpdateSelectedIndicesAndFunctionIds(const std::vector<int>& selected_indices);
+  void UpdateSelectedIndicesAndFunctionIds(absl::Span<int const> selected_indices);
   void RestoreSelectedIndicesAfterFunctionsChanged();
   // The callstack view will be updated according to the visible selected addresses and thread id.
-  void UpdateVisibleSelectedAddressesAndTid(const std::vector<int>& visible_selected_indices);
+  void UpdateVisibleSelectedAddressesAndTid(absl::Span<int const> visible_selected_indices);
 
   [[nodiscard]] std::string BuildPercentageString(float percentage) const;
 

--- a/src/DataViews/include/DataViews/TracepointsDataView.h
+++ b/src/DataViews/include/DataViews/TracepointsDataView.h
@@ -27,14 +27,14 @@ class TracepointsDataView : public DataView {
   int GetDefaultSortingColumn() override { return kColumnCategory; }
   std::string GetValue(int row, int column) override;
 
-  void OnSelectRequested(absl::Span<int const> selection) override;
-  void OnUnselectRequested(absl::Span<int const> selection) override;
+  void OnSelectRequested(absl::Span<const int> selection) override;
+  void OnUnselectRequested(absl::Span<const int> selection) override;
 
-  void SetTracepoints(absl::Span<orbit_grpc_protos::TracepointInfo const> tracepoints);
+  void SetTracepoints(absl::Span<const orbit_grpc_protos::TracepointInfo> tracepoints);
 
  private:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             absl::Span<int const> selected_indices) override;
+                                             absl::Span<const int> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/DataViews/include/DataViews/TracepointsDataView.h
+++ b/src/DataViews/include/DataViews/TracepointsDataView.h
@@ -5,6 +5,7 @@
 #ifndef DATA_VIEWS_TRACEPOINTS_DATA_VIEW_H_
 #define DATA_VIEWS_TRACEPOINTS_DATA_VIEW_H_
 
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <deque>
@@ -26,14 +27,14 @@ class TracepointsDataView : public DataView {
   int GetDefaultSortingColumn() override { return kColumnCategory; }
   std::string GetValue(int row, int column) override;
 
-  void OnSelectRequested(const std::vector<int>& selection) override;
-  void OnUnselectRequested(const std::vector<int>& selection) override;
+  void OnSelectRequested(absl::Span<int const> selection) override;
+  void OnUnselectRequested(absl::Span<int const> selection) override;
 
-  void SetTracepoints(const std::vector<orbit_grpc_protos::TracepointInfo>& tracepoints);
+  void SetTracepoints(absl::Span<orbit_grpc_protos::TracepointInfo const> tracepoints);
 
  private:
   [[nodiscard]] ActionStatus GetActionStatus(std::string_view action, int clicked_index,
-                                             const std::vector<int>& selected_indices) override;
+                                             absl::Span<int const> selected_indices) override;
   void DoSort() override;
   void DoFilter() override;
 

--- a/src/FakeClient/GraphicsCaptureEventProcessor.h
+++ b/src/FakeClient/GraphicsCaptureEventProcessor.h
@@ -5,6 +5,8 @@
 #ifndef FAKE_CLIENT_GRAPHICS_CAPTURE_EVENT_PROCESSOR_H_
 #define FAKE_CLIENT_GRAPHICS_CAPTURE_EVENT_PROCESSOR_H_
 
+#include <absl/types/span.h>
+
 #include <cstdint>
 
 #include "CaptureClient/CaptureEventProcessor.h"
@@ -148,7 +150,7 @@ class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventP
   }
 
   static void PrintCommandBufferTimestamps(
-      const std::vector<CommandBufferTimestamps>& command_buffers_timestamps) {
+      absl::Span<CommandBufferTimestamps const> command_buffers_timestamps) {
     for (size_t i = 0; i < command_buffers_timestamps.size(); ++i) {
       const uint64_t begin_timestamp_ns = command_buffers_timestamps[i].begin;
       const uint64_t end_timestamp_ns = command_buffers_timestamps[i].end;

--- a/src/FakeClient/GraphicsCaptureEventProcessor.h
+++ b/src/FakeClient/GraphicsCaptureEventProcessor.h
@@ -150,7 +150,7 @@ class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventP
   }
 
   static void PrintCommandBufferTimestamps(
-      absl::Span<CommandBufferTimestamps const> command_buffers_timestamps) {
+      absl::Span<const CommandBufferTimestamps> command_buffers_timestamps) {
     for (size_t i = 0; i < command_buffers_timestamps.size(); ++i) {
       const uint64_t begin_timestamp_ns = command_buffers_timestamps[i].begin;
       const uint64_t end_timestamp_ns = command_buffers_timestamps[i].end;

--- a/src/FakeProducerSideService/include/FakeProducerSideService/FakeProducerSideService.h
+++ b/src/FakeProducerSideService/include/FakeProducerSideService/FakeProducerSideService.h
@@ -114,7 +114,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
   void ReAllowRpc() { rpc_allowed_ = true; }
 
   MOCK_METHOD(void, OnCaptureEventsReceived,
-              (absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events), ());
+              (absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events), ());
   MOCK_METHOD(void, OnAllEventsSentReceived, (), ());
 
  private:

--- a/src/FakeProducerSideService/include/FakeProducerSideService/FakeProducerSideService.h
+++ b/src/FakeProducerSideService/include/FakeProducerSideService/FakeProducerSideService.h
@@ -6,6 +6,7 @@
 #define FAKE_PRODUCER_SIDE_SERVICE_FAKE_PRODUCER_SIDE_SERVICE_H_
 
 #include <absl/synchronization/mutex.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 #include <gtest/gtest.h>
@@ -113,7 +114,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
   void ReAllowRpc() { rpc_allowed_ = true; }
 
   MOCK_METHOD(void, OnCaptureEventsReceived,
-              (const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events), ());
+              (absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events), ());
   MOCK_METHOD(void, OnAllEventsSentReceived, (), ());
 
  private:

--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(LinuxTracing PUBLIC
         ModuleUtils
         ObjectUtils
         OrbitBase
+        TestUtils
         absl::flat_hash_map
         absl::flat_hash_set
         absl::meta

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -70,7 +70,7 @@ class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
  public:
   MOCK_METHOD(LibunwindstackResult, Unwind,
               (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
-               absl::Span<StackSliceView const>, bool, size_t),
+               absl::Span<const StackSliceView>, bool, size_t),
               (override));
   MOCK_METHOD(std::optional<bool>, HasFramePointerSet, (uint64_t, pid_t, unwindstack::Maps*),
               (override));
@@ -159,7 +159,7 @@ class LeafFunctionCallManagerTest : public ::testing::Test {
 };
 
 CallchainSamplePerfEventData BuildFakeCallchainSamplePerfEventData(
-    absl::Span<uint64_t const> callchain) {
+    absl::Span<const uint64_t> callchain) {
   CallchainSamplePerfEventData event_data{
       .pid = 10,
       .tid = 11,

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/types/span.h>
 #include <asm/perf_regs.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -69,7 +70,7 @@ class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
  public:
   MOCK_METHOD(LibunwindstackResult, Unwind,
               (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
-               const std::vector<StackSliceView>&, bool, size_t),
+               absl::Span<StackSliceView const>, bool, size_t),
               (override));
   MOCK_METHOD(std::optional<bool>, HasFramePointerSet, (uint64_t, pid_t, unwindstack::Maps*),
               (override));
@@ -158,7 +159,7 @@ class LeafFunctionCallManagerTest : public ::testing::Test {
 };
 
 CallchainSamplePerfEventData BuildFakeCallchainSamplePerfEventData(
-    const std::vector<uint64_t>& callchain) {
+    absl::Span<uint64_t const> callchain) {
   CallchainSamplePerfEventData event_data{
       .pid = 10,
       .tid = 11,

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -32,10 +32,12 @@
 #include "OrbitBase/MakeUniqueForOverwrite.h"
 #include "PerfEvent.h"
 #include "PerfEventRecords.h"
+#include "TestUtils/SaveRangeFromArg.h"
 #include "unwindstack/MachineX86_64.h"
 #include "unwindstack/Regs.h"
 #include "unwindstack/RegsX86_64.h"
 
+using ::orbit_test_utils::SaveRangeFromArg;
 using ::testing::_;
 using ::testing::AllOf;
 using ::testing::DoAll;
@@ -47,7 +49,6 @@ using ::testing::Lt;
 using ::testing::NotNull;
 using ::testing::Property;
 using ::testing::Return;
-using ::testing::SaveArg;
 
 using orbit_grpc_protos::Callstack;
 
@@ -211,7 +212,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnTooSm
   EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, _, 1))
       .Times(1)
       .WillOnce(
-          DoAll(SaveArg<3>(&actual_stack_slices),
+          DoAll(orbit_test_utils::SaveRangeFromArg<3>(&actual_stack_slices),
                 Return(LibunwindstackResult{
                     {kFrame1}, libunwindstack_regs, unwindstack::ErrorCode::ERROR_INVALID_MAP})));
 
@@ -261,7 +262,7 @@ TEST_F(
   EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, _, 1))
       .Times(1)
       .WillOnce(
-          DoAll(SaveArg<3>(&actual_stack_slices),
+          DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                 Return(LibunwindstackResult{
                     {kFrame1}, libunwindstack_regs, unwindstack::ErrorCode::ERROR_INVALID_MAP})));
 
@@ -367,7 +368,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnUnwin
   std::vector<StackSliceView> actual_stack_slices;
   EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, _, 1))
       .Times(1)
-      .WillOnce(DoAll(SaveArg<3>(&actual_stack_slices),
+      .WillOnce(DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                       Return(LibunwindstackResult{
                           {}, libunwindstack_regs, unwindstack::ErrorCode::ERROR_INVALID_MAP})));
 
@@ -404,7 +405,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnUnwin
   EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, _, 1))
       .Times(1)
       .WillOnce(
-          DoAll(SaveArg<3>(&actual_stack_slices),
+          DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                 Return(LibunwindstackResult{
                     {kFrame1}, libunwindstack_regs, unwindstack::ErrorCode::ERROR_INVALID_MAP})));
 
@@ -472,7 +473,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnNoFra
   EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, _, 1))
       .Times(1)
       .WillOnce(
-          DoAll(SaveArg<3>(&actual_stack_slices),
+          DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                 Return(LibunwindstackResult{
                     {kFrame1}, libunwindstack_regs, unwindstack::ErrorCode::ERROR_INVALID_MAP})));
 
@@ -522,7 +523,7 @@ TEST_F(LeafFunctionCallManagerTest,
   EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, _, 1))
       .Times(1)
       .WillOnce(
-          DoAll(SaveArg<3>(&actual_stack_slices),
+          DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                 Return(LibunwindstackResult{
                     {kFrame1}, libunwindstack_regs, unwindstack::ErrorCode::ERROR_INVALID_MAP})));
 
@@ -570,7 +571,7 @@ TEST_F(LeafFunctionCallManagerTest,
   EXPECT_CALL(unwinder_, Unwind(event_data.pid, &fake_maps, _, _, _, 1))
       .Times(1)
       .WillOnce(
-          DoAll(SaveArg<3>(&actual_stack_slices),
+          DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                 Return(LibunwindstackResult{
                     {kFrame1}, libunwindstack_regs, unwindstack::ErrorCode::ERROR_INVALID_MAP})));
 

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
@@ -4,6 +4,8 @@
 
 #include "LibunwindstackMultipleOfflineAndProcessMemory.h"
 
+#include <absl/types/span.h>
+
 #include "unwindstack/Memory.h"
 
 namespace orbit_linux_tracing {
@@ -46,7 +48,7 @@ size_t LibunwindstackMultipleOfflineAndProcessMemory::Read(uint64_t addr, void* 
 
 std::vector<LibunwindstackMultipleOfflineAndProcessMemory::LibunwindstackOfflineMemory>
 LibunwindstackMultipleOfflineAndProcessMemory::CreateOfflineStackMemories(
-    const std::vector<StackSliceView>& stack_slices) {
+    absl::Span<StackSliceView const> stack_slices) {
   std::vector<LibunwindstackOfflineMemory> stack_memories{};
   stack_memories.reserve(stack_slices.size());
   for (const StackSliceView& stack_slice_view : stack_slices) {
@@ -57,7 +59,7 @@ LibunwindstackMultipleOfflineAndProcessMemory::CreateOfflineStackMemories(
 
 std::shared_ptr<unwindstack::Memory>
 LibunwindstackMultipleOfflineAndProcessMemory::CreateWithProcessMemory(
-    pid_t pid, const std::vector<StackSliceView>& stack_slices) {
+    pid_t pid, absl::Span<StackSliceView const> stack_slices) {
   std::vector<LibunwindstackOfflineMemory> stack_memories =
       CreateOfflineStackMemories(stack_slices);
   return std::shared_ptr<LibunwindstackMultipleOfflineAndProcessMemory>(
@@ -67,7 +69,7 @@ LibunwindstackMultipleOfflineAndProcessMemory::CreateWithProcessMemory(
 
 std::shared_ptr<unwindstack::Memory>
 LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory(
-    const std::vector<StackSliceView>& stack_slices) {
+    absl::Span<StackSliceView const> stack_slices) {
   std::vector<LibunwindstackOfflineMemory> stack_memories =
       CreateOfflineStackMemories(stack_slices);
   return std::shared_ptr<LibunwindstackMultipleOfflineAndProcessMemory>(

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.cpp
@@ -48,7 +48,7 @@ size_t LibunwindstackMultipleOfflineAndProcessMemory::Read(uint64_t addr, void* 
 
 std::vector<LibunwindstackMultipleOfflineAndProcessMemory::LibunwindstackOfflineMemory>
 LibunwindstackMultipleOfflineAndProcessMemory::CreateOfflineStackMemories(
-    absl::Span<StackSliceView const> stack_slices) {
+    absl::Span<const StackSliceView> stack_slices) {
   std::vector<LibunwindstackOfflineMemory> stack_memories{};
   stack_memories.reserve(stack_slices.size());
   for (const StackSliceView& stack_slice_view : stack_slices) {
@@ -59,7 +59,7 @@ LibunwindstackMultipleOfflineAndProcessMemory::CreateOfflineStackMemories(
 
 std::shared_ptr<unwindstack::Memory>
 LibunwindstackMultipleOfflineAndProcessMemory::CreateWithProcessMemory(
-    pid_t pid, absl::Span<StackSliceView const> stack_slices) {
+    pid_t pid, absl::Span<const StackSliceView> stack_slices) {
   std::vector<LibunwindstackOfflineMemory> stack_memories =
       CreateOfflineStackMemories(stack_slices);
   return std::shared_ptr<LibunwindstackMultipleOfflineAndProcessMemory>(
@@ -69,7 +69,7 @@ LibunwindstackMultipleOfflineAndProcessMemory::CreateWithProcessMemory(
 
 std::shared_ptr<unwindstack::Memory>
 LibunwindstackMultipleOfflineAndProcessMemory::CreateWithoutProcessMemory(
-    absl::Span<StackSliceView const> stack_slices) {
+    absl::Span<const StackSliceView> stack_slices) {
   std::vector<LibunwindstackOfflineMemory> stack_memories =
       CreateOfflineStackMemories(stack_slices);
   return std::shared_ptr<LibunwindstackMultipleOfflineAndProcessMemory>(

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.h
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.h
@@ -51,10 +51,10 @@ class LibunwindstackMultipleOfflineAndProcessMemory : public unwindstack::Memory
   size_t Read(uint64_t addr, void* dst, size_t size) override;
 
   static std::shared_ptr<Memory> CreateWithProcessMemory(
-      pid_t pid, absl::Span<StackSliceView const> stack_slices);
+      pid_t pid, absl::Span<const StackSliceView> stack_slices);
 
   static std::shared_ptr<Memory> CreateWithoutProcessMemory(
-      absl::Span<StackSliceView const> stack_slices);
+      absl::Span<const StackSliceView> stack_slices);
 
  private:
   // This class is a thin layer around unwindstack::MemoryOfflineBuffer, that allows querying
@@ -87,7 +87,7 @@ class LibunwindstackMultipleOfflineAndProcessMemory : public unwindstack::Memory
         stack_memories_{std::move(std::move(stack_memories))} {}
 
   static std::vector<LibunwindstackOfflineMemory> CreateOfflineStackMemories(
-      absl::Span<StackSliceView const> stack_slices);
+      absl::Span<const StackSliceView> stack_slices);
 
   std::shared_ptr<Memory> process_memory_;
   std::vector<LibunwindstackOfflineMemory> stack_memories_;

--- a/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.h
+++ b/src/LinuxTracing/LibunwindstackMultipleOfflineAndProcessMemory.h
@@ -6,6 +6,7 @@
 #define LINUX_TRACING_LIBUNWINDSTACK_MULTIPLE_OFFLINE_AND_PROCESS_MEMORY_H_
 
 #include <absl/base/casts.h>
+#include <absl/types/span.h>
 #include <stdint.h>
 #include <sys/types.h>
 #include <unwindstack/Memory.h>
@@ -50,10 +51,10 @@ class LibunwindstackMultipleOfflineAndProcessMemory : public unwindstack::Memory
   size_t Read(uint64_t addr, void* dst, size_t size) override;
 
   static std::shared_ptr<Memory> CreateWithProcessMemory(
-      pid_t pid, const std::vector<StackSliceView>& stack_slices);
+      pid_t pid, absl::Span<StackSliceView const> stack_slices);
 
   static std::shared_ptr<Memory> CreateWithoutProcessMemory(
-      const std::vector<StackSliceView>& stack_slices);
+      absl::Span<StackSliceView const> stack_slices);
 
  private:
   // This class is a thin layer around unwindstack::MemoryOfflineBuffer, that allows querying
@@ -86,7 +87,7 @@ class LibunwindstackMultipleOfflineAndProcessMemory : public unwindstack::Memory
         stack_memories_{std::move(std::move(stack_memories))} {}
 
   static std::vector<LibunwindstackOfflineMemory> CreateOfflineStackMemories(
-      const std::vector<StackSliceView>& stack_slices);
+      absl::Span<StackSliceView const> stack_slices);
 
   std::shared_ptr<Memory> process_memory_;
   std::vector<LibunwindstackOfflineMemory> stack_memories_;

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -41,7 +41,7 @@ class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
             absolute_address_to_size_of_functions_to_stop_at} {}
   LibunwindstackResult Unwind(pid_t pid, unwindstack::Maps* maps,
                               const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-                              absl::Span<StackSliceView const> stack_slices,
+                              absl::Span<const StackSliceView> stack_slices,
                               bool offline_memory_only = false,
                               size_t max_frames = kDefaultMaxFrames) override;
 
@@ -69,7 +69,7 @@ const std::array<size_t, unwindstack::X86_64_REG_LAST>
 
 LibunwindstackResult LibunwindstackUnwinderImpl::Unwind(
     pid_t pid, unwindstack::Maps* maps, const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-    absl::Span<StackSliceView const> stack_slices, bool offline_memory_only, size_t max_frames) {
+    absl::Span<const StackSliceView> stack_slices, bool offline_memory_only, size_t max_frames) {
   unwindstack::RegsX86_64 regs{};
   for (size_t perf_reg = 0; perf_reg < unwindstack::X86_64_REG_LAST; ++perf_reg) {
     regs[perf_reg] = perf_regs.at(kUnwindstackRegsToPerfRegs[perf_reg]);

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -4,6 +4,7 @@
 
 #include "LibunwindstackUnwinder.h"
 
+#include <absl/types/span.h>
 #include <unwindstack/Error.h>
 #include <unwindstack/Memory.h>
 #include <unwindstack/Regs.h>
@@ -40,7 +41,7 @@ class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
             absolute_address_to_size_of_functions_to_stop_at} {}
   LibunwindstackResult Unwind(pid_t pid, unwindstack::Maps* maps,
                               const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-                              const std::vector<StackSliceView>& stack_slices,
+                              absl::Span<StackSliceView const> stack_slices,
                               bool offline_memory_only = false,
                               size_t max_frames = kDefaultMaxFrames) override;
 
@@ -68,7 +69,7 @@ const std::array<size_t, unwindstack::X86_64_REG_LAST>
 
 LibunwindstackResult LibunwindstackUnwinderImpl::Unwind(
     pid_t pid, unwindstack::Maps* maps, const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-    const std::vector<StackSliceView>& stack_slices, bool offline_memory_only, size_t max_frames) {
+    absl::Span<StackSliceView const> stack_slices, bool offline_memory_only, size_t max_frames) {
   unwindstack::RegsX86_64 regs{};
   for (size_t perf_reg = 0; perf_reg < unwindstack::X86_64_REG_LAST; ++perf_reg) {
     regs[perf_reg] = perf_regs.at(kUnwindstackRegsToPerfRegs[perf_reg]);

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -5,6 +5,7 @@
 #ifndef LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 #define LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 
+#include <absl/types/span.h>
 #include <asm/perf_regs.h>
 #include <sys/types.h>
 #include <unwindstack/Error.h>
@@ -55,7 +56,7 @@ class LibunwindstackUnwinder {
 
   virtual LibunwindstackResult Unwind(pid_t pid, unwindstack::Maps* maps,
                                       const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-                                      const std::vector<StackSliceView>& stack_slices,
+                                      absl::Span<StackSliceView const> stack_slices,
                                       bool offline_memory_only = false,
                                       size_t max_frames = kDefaultMaxFrames) = 0;
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -56,7 +56,7 @@ class LibunwindstackUnwinder {
 
   virtual LibunwindstackResult Unwind(pid_t pid, unwindstack::Maps* maps,
                                       const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-                                      absl::Span<StackSliceView const> stack_slices,
+                                      absl::Span<const StackSliceView> stack_slices,
                                       bool offline_memory_only = false,
                                       size_t max_frames = kDefaultMaxFrames) = 0;
 

--- a/src/LinuxTracing/LinuxTracingUtils.cpp
+++ b/src/LinuxTracing/LinuxTracingUtils.cpp
@@ -229,8 +229,8 @@ bool SetMaxOpenFilesSoftLimit(uint64_t soft_limit) {
 // the file from 0x400 to 0x1000 (i.e., with RVAs from 0x1000 to 0x1c00). But those functions are
 // mapped again in the anonymous map, and that's where they actually have their absolute address,
 // i.e., where they actually get executed.
-static bool FunctionIsAlwaysInFileMapping(absl::Span<LinuxMemoryMapping const> file_path_maps,
-                                          absl::Span<ModuleInfo const> file_path_modules,
+static bool FunctionIsAlwaysInFileMapping(absl::Span<const LinuxMemoryMapping> file_path_maps,
+                                          absl::Span<const ModuleInfo> file_path_modules,
                                           const InstrumentedFunction& function) {
   for (const ModuleInfo& module : file_path_modules) {
     ORBIT_CHECK(module.file_path() == function.file_path());
@@ -253,8 +253,8 @@ static bool FunctionIsAlwaysInFileMapping(absl::Span<LinuxMemoryMapping const> f
 }
 
 std::map<uint64_t, std::string> FindFunctionsThatUprobesCannotInstrumentWithMessages(
-    absl::Span<LinuxMemoryMapping const> maps, absl::Span<ModuleInfo const> modules,
-    absl::Span<InstrumentedFunction const> functions) {
+    absl::Span<const LinuxMemoryMapping> maps, absl::Span<const ModuleInfo> modules,
+    absl::Span<const InstrumentedFunction> functions) {
   absl::flat_hash_map<std::string, std::vector<LinuxMemoryMapping>> file_paths_to_maps;
   for (const LinuxMemoryMapping& map : maps) {
     if (map.inode() == 0 || map.pathname().empty()) continue;

--- a/src/LinuxTracing/LinuxTracingUtils.cpp
+++ b/src/LinuxTracing/LinuxTracingUtils.cpp
@@ -10,6 +10,7 @@
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
+#include <absl/types/span.h>
 #include <errno.h>
 #include <sys/resource.h>
 
@@ -228,8 +229,8 @@ bool SetMaxOpenFilesSoftLimit(uint64_t soft_limit) {
 // the file from 0x400 to 0x1000 (i.e., with RVAs from 0x1000 to 0x1c00). But those functions are
 // mapped again in the anonymous map, and that's where they actually have their absolute address,
 // i.e., where they actually get executed.
-static bool FunctionIsAlwaysInFileMapping(const std::vector<LinuxMemoryMapping>& file_path_maps,
-                                          const std::vector<ModuleInfo>& file_path_modules,
+static bool FunctionIsAlwaysInFileMapping(absl::Span<LinuxMemoryMapping const> file_path_maps,
+                                          absl::Span<ModuleInfo const> file_path_modules,
                                           const InstrumentedFunction& function) {
   for (const ModuleInfo& module : file_path_modules) {
     ORBIT_CHECK(module.file_path() == function.file_path());
@@ -252,8 +253,8 @@ static bool FunctionIsAlwaysInFileMapping(const std::vector<LinuxMemoryMapping>&
 }
 
 std::map<uint64_t, std::string> FindFunctionsThatUprobesCannotInstrumentWithMessages(
-    const std::vector<LinuxMemoryMapping>& maps, const std::vector<ModuleInfo>& modules,
-    const std::vector<InstrumentedFunction>& functions) {
+    absl::Span<LinuxMemoryMapping const> maps, absl::Span<ModuleInfo const> modules,
+    absl::Span<InstrumentedFunction const> functions) {
   absl::flat_hash_map<std::string, std::vector<LinuxMemoryMapping>> file_paths_to_maps;
   for (const LinuxMemoryMapping& map : maps) {
     if (map.inode() == 0 || map.pathname().empty()) continue;

--- a/src/LinuxTracing/LinuxTracingUtils.h
+++ b/src/LinuxTracing/LinuxTracingUtils.h
@@ -76,9 +76,9 @@ inline size_t GetPageSize() {
 // Returns an std::map (so that the order by function id is preserved) from function id to a message
 // describing the issue for that function.
 [[nodiscard]] std::map<uint64_t, std::string> FindFunctionsThatUprobesCannotInstrumentWithMessages(
-    absl::Span<orbit_module_utils::LinuxMemoryMapping const> maps,
-    absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
-    absl::Span<orbit_grpc_protos::InstrumentedFunction const> functions);
+    absl::Span<const orbit_module_utils::LinuxMemoryMapping> maps,
+    absl::Span<const orbit_grpc_protos::ModuleInfo> modules,
+    absl::Span<const orbit_grpc_protos::InstrumentedFunction> functions);
 
 }  // namespace orbit_linux_tracing
 

--- a/src/LinuxTracing/LinuxTracingUtils.h
+++ b/src/LinuxTracing/LinuxTracingUtils.h
@@ -5,6 +5,7 @@
 #ifndef LINUX_TRACING_LINUX_TRACING_UTILS_H_
 #define LINUX_TRACING_LINUX_TRACING_UTILS_H_
 
+#include <absl/types/span.h>
 #include <stdint.h>
 #include <unistd.h>
 
@@ -75,9 +76,9 @@ inline size_t GetPageSize() {
 // Returns an std::map (so that the order by function id is preserved) from function id to a message
 // describing the issue for that function.
 [[nodiscard]] std::map<uint64_t, std::string> FindFunctionsThatUprobesCannotInstrumentWithMessages(
-    const std::vector<orbit_module_utils::LinuxMemoryMapping>& maps,
-    const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
-    const std::vector<orbit_grpc_protos::InstrumentedFunction>& functions);
+    absl::Span<orbit_module_utils::LinuxMemoryMapping const> maps,
+    absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
+    absl::Span<orbit_grpc_protos::InstrumentedFunction const> functions);
 
 }  // namespace orbit_linux_tracing
 

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -6,6 +6,7 @@
 #define LINUX_TRACING_PERF_EVENT_H_
 
 #include <absl/base/casts.h>
+#include <absl/types/span.h>
 #include <asm/perf_regs.h>
 #include <string.h>
 #include <sys/types.h>
@@ -97,7 +98,7 @@ struct CallchainSamplePerfEventData {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
-  void SetIps(const std::vector<uint64_t>& new_ips) const {
+  void SetIps(absl::Span<uint64_t const> new_ips) const {
     ips_size = new_ips.size();
     ips = make_unique_for_overwrite<uint64_t[]>(ips_size);
     memcpy(ips.get(), new_ips.data(), ips_size * sizeof(uint64_t));
@@ -273,7 +274,7 @@ struct SchedWakeupWithCallchainPerfEventData {
     return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
-  void SetIps(const std::vector<uint64_t>& new_ips) const {
+  void SetIps(absl::Span<uint64_t const> new_ips) const {
     ips_size = new_ips.size();
     ips = make_unique_for_overwrite<uint64_t[]>(ips_size);
     memcpy(ips.get(), new_ips.data(), ips_size * sizeof(uint64_t));
@@ -306,7 +307,7 @@ struct SchedSwitchWithCallchainPerfEventData {
     return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
-  void SetIps(const std::vector<uint64_t>& new_ips) const {
+  void SetIps(absl::Span<uint64_t const> new_ips) const {
     ips_size = new_ips.size();
     ips = make_unique_for_overwrite<uint64_t[]>(ips_size);
     memcpy(ips.get(), new_ips.data(), ips_size * sizeof(uint64_t));

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -98,7 +98,7 @@ struct CallchainSamplePerfEventData {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
-  void SetIps(absl::Span<uint64_t const> new_ips) const {
+  void SetIps(absl::Span<const uint64_t> new_ips) const {
     ips_size = new_ips.size();
     ips = make_unique_for_overwrite<uint64_t[]>(ips_size);
     memcpy(ips.get(), new_ips.data(), ips_size * sizeof(uint64_t));
@@ -274,7 +274,7 @@ struct SchedWakeupWithCallchainPerfEventData {
     return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
-  void SetIps(absl::Span<uint64_t const> new_ips) const {
+  void SetIps(absl::Span<const uint64_t> new_ips) const {
     ips_size = new_ips.size();
     ips = make_unique_for_overwrite<uint64_t[]>(ips_size);
     memcpy(ips.get(), new_ips.data(), ips_size * sizeof(uint64_t));
@@ -307,7 +307,7 @@ struct SchedSwitchWithCallchainPerfEventData {
     return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
-  void SetIps(absl::Span<uint64_t const> new_ips) const {
+  void SetIps(absl::Span<const uint64_t> new_ips) const {
     ips_size = new_ips.size();
     ips = make_unique_for_overwrite<uint64_t[]>(ips_size);
     memcpy(ips.get(), new_ips.data(), ips_size * sizeof(uint64_t));

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -11,6 +11,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
 #include <absl/synchronization/mutex.h>
+#include <absl/types/span.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -185,7 +186,7 @@ void TracerImpl::ProcessFunctionExit(const orbit_grpc_protos::FunctionExit& func
   DeferEvent(event);
 }
 
-static void CloseFileDescriptors(const std::vector<int>& fds) {
+static void CloseFileDescriptors(absl::Span<int const> fds) {
   for (int fd : fds) {
     close(fd);
   }
@@ -242,7 +243,7 @@ void TracerImpl::InitUprobesEventVisitor() {
 }
 
 bool TracerImpl::OpenUprobes(const orbit_grpc_protos::InstrumentedFunction& function,
-                             const std::vector<int32_t>& cpus,
+                             absl::Span<int32_t const> cpus,
                              absl::flat_hash_map<int32_t, int>* fds_per_cpu) {
   ORBIT_SCOPE_FUNCTION;
   const char* module = function.file_path().c_str();
@@ -265,7 +266,7 @@ bool TracerImpl::OpenUprobes(const orbit_grpc_protos::InstrumentedFunction& func
 }
 
 bool TracerImpl::OpenUretprobes(const orbit_grpc_protos::InstrumentedFunction& function,
-                                const std::vector<int32_t>& cpus,
+                                absl::Span<int32_t const> cpus,
                                 absl::flat_hash_map<int32_t, int>* fds_per_cpu) {
   ORBIT_SCOPE_FUNCTION;
   const char* module = function.file_path().c_str();
@@ -319,7 +320,7 @@ void TracerImpl::AddUretprobesFileDescriptors(
   }
 }
 
-bool TracerImpl::OpenUserSpaceProbes(const std::vector<int32_t>& cpus) {
+bool TracerImpl::OpenUserSpaceProbes(absl::Span<int32_t const> cpus) {
   ORBIT_SCOPE_FUNCTION;
   bool uprobes_event_open_errors = false;
 
@@ -355,7 +356,7 @@ bool TracerImpl::OpenUserSpaceProbes(const std::vector<int32_t>& cpus) {
 
 bool TracerImpl::OpenUprobesWithStack(
     const orbit_grpc_protos::FunctionToRecordAdditionalStackOn& function,
-    const std::vector<int32_t>& cpus, absl::flat_hash_map<int32_t, int>* fds_per_cpu) {
+    absl::Span<int32_t const> cpus, absl::flat_hash_map<int32_t, int>* fds_per_cpu) {
   ORBIT_SCOPE_FUNCTION;
   const char* module = function.file_path().c_str();
   const uint64_t offset = function.file_offset();
@@ -372,7 +373,7 @@ bool TracerImpl::OpenUprobesWithStack(
   return true;
 }
 
-bool TracerImpl::OpenUprobesToRecordAdditionalStackOn(const std::vector<int32_t>& cpus) {
+bool TracerImpl::OpenUprobesToRecordAdditionalStackOn(absl::Span<int32_t const> cpus) {
   ORBIT_SCOPE_FUNCTION;
   bool uprobes_event_open_errors = false;
   absl::flat_hash_map<int32_t, int> fds_per_cpu_for_redirection{};
@@ -399,7 +400,7 @@ bool TracerImpl::OpenUprobesToRecordAdditionalStackOn(const std::vector<int32_t>
   return !uprobes_event_open_errors;
 }
 
-bool TracerImpl::OpenMmapTask(const std::vector<int32_t>& cpus) {
+bool TracerImpl::OpenMmapTask(absl::Span<int32_t const> cpus) {
   ORBIT_SCOPE_FUNCTION;
   std::vector<int> mmap_task_tracing_fds;
   std::vector<PerfEventRingBuffer> mmap_task_ring_buffers;
@@ -427,7 +428,7 @@ bool TracerImpl::OpenMmapTask(const std::vector<int32_t>& cpus) {
   return true;
 }
 
-bool TracerImpl::OpenSampling(const std::vector<int32_t>& cpus) {
+bool TracerImpl::OpenSampling(absl::Span<int32_t const> cpus) {
   ORBIT_SCOPE_FUNCTION;
   ORBIT_CHECK(sampling_period_ns_.has_value());
   ORBIT_CHECK(unwinding_method_ == CaptureOptions::kFramePointers ||
@@ -498,7 +499,7 @@ struct TracepointToOpen {
 }  // namespace
 
 static bool OpenFileDescriptorsAndRingBuffersForAllTracepoints(
-    const std::vector<TracepointToOpen>& tracepoints_to_open, const std::vector<int32_t>& cpus,
+    absl::Span<TracepointToOpen const> tracepoints_to_open, absl::Span<int32_t const> cpus,
     std::vector<int>* tracing_fds, uint64_t ring_buffer_size_kb,
     absl::flat_hash_map<int32_t, int>* tracepoint_ring_buffer_fds_per_cpu_for_redirection,
     std::vector<PerfEventRingBuffer>* ring_buffers, uint32_t stack_dump_size = 0,
@@ -575,7 +576,7 @@ static bool OpenFileDescriptorsAndRingBuffersForAllTracepoints(
   return true;
 }
 
-bool TracerImpl::OpenThreadNameTracepoints(const std::vector<int32_t>& cpus) {
+bool TracerImpl::OpenThreadNameTracepoints(absl::Span<int32_t const> cpus) {
   ORBIT_SCOPE_FUNCTION;
   absl::flat_hash_map<int32_t, int> thread_name_tracepoint_ring_buffer_fds_per_cpu;
   return OpenFileDescriptorsAndRingBuffersForAllTracepoints(
@@ -601,7 +602,7 @@ void TracerImpl::InitSwitchesStatesNamesVisitor() {
   event_processor_.AddVisitor(switches_states_names_visitor_.get());
 }
 
-bool TracerImpl::OpenContextSwitchAndThreadStateTracepoints(const std::vector<int32_t>& cpus) {
+bool TracerImpl::OpenContextSwitchAndThreadStateTracepoints(absl::Span<int32_t const> cpus) {
   ORBIT_SCOPE_FUNCTION;
   std::vector<TracepointToOpen> tracepoints_to_open;
   absl::flat_hash_set<uint64_t>* current_sched_switch_ids = &sched_switch_ids_;
@@ -661,7 +662,7 @@ void TracerImpl::InitGpuTracepointEventVisitor() {
 // same timeline, context, and seqno.
 // We have to record events system-wide (per CPU) to ensure we record all relevant events.
 // This method returns true on success, otherwise false.
-bool TracerImpl::OpenGpuTracepoints(const std::vector<int32_t>& cpus) {
+bool TracerImpl::OpenGpuTracepoints(absl::Span<int32_t const> cpus) {
   ORBIT_SCOPE_FUNCTION;
   absl::flat_hash_map<int32_t, int> gpu_tracepoint_ring_buffer_fds_per_cpu;
   return OpenFileDescriptorsAndRingBuffersForAllTracepoints(
@@ -672,7 +673,7 @@ bool TracerImpl::OpenGpuTracepoints(const std::vector<int32_t>& cpus) {
       &ring_buffers_);
 }
 
-bool TracerImpl::OpenInstrumentedTracepoints(const std::vector<int32_t>& cpus) {
+bool TracerImpl::OpenInstrumentedTracepoints(absl::Span<int32_t const> cpus) {
   ORBIT_SCOPE_FUNCTION;
   bool tracepoint_event_open_errors = false;
   absl::flat_hash_map<int32_t, int> tracepoint_ring_buffer_fds_per_cpu;

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -68,18 +68,18 @@ class TracerImpl : public Tracer {
   void Shutdown();
   void ProcessOneRecord(PerfEventRingBuffer* ring_buffer);
   void InitUprobesEventVisitor();
-  bool OpenUserSpaceProbes(absl::Span<int32_t const> cpus);
-  bool OpenUprobesToRecordAdditionalStackOn(absl::Span<int32_t const> cpus);
+  bool OpenUserSpaceProbes(absl::Span<const int32_t> cpus);
+  bool OpenUprobesToRecordAdditionalStackOn(absl::Span<const int32_t> cpus);
   bool OpenUprobes(const orbit_grpc_protos::InstrumentedFunction& function,
-                   absl::Span<int32_t const> cpus, absl::flat_hash_map<int32_t, int>* fds_per_cpu);
+                   absl::Span<const int32_t> cpus, absl::flat_hash_map<int32_t, int>* fds_per_cpu);
   bool OpenUprobesWithStack(const orbit_grpc_protos::FunctionToRecordAdditionalStackOn& function,
-                            absl::Span<int32_t const> cpus,
+                            absl::Span<const int32_t> cpus,
                             absl::flat_hash_map<int32_t, int>* fds_per_cpu);
   bool OpenUretprobes(const orbit_grpc_protos::InstrumentedFunction& function,
-                      absl::Span<int32_t const> cpus,
+                      absl::Span<const int32_t> cpus,
                       absl::flat_hash_map<int32_t, int>* fds_per_cpu);
-  bool OpenMmapTask(absl::Span<int32_t const> cpus);
-  bool OpenSampling(absl::Span<int32_t const> cpus);
+  bool OpenMmapTask(absl::Span<const int32_t> cpus);
+  bool OpenSampling(absl::Span<const int32_t> cpus);
 
   void AddUprobesFileDescriptors(const absl::flat_hash_map<int32_t, int>& uprobes_fds_per_cpu,
                                  const orbit_grpc_protos::InstrumentedFunction& function);
@@ -87,14 +87,14 @@ class TracerImpl : public Tracer {
   void AddUretprobesFileDescriptors(const absl::flat_hash_map<int32_t, int>& uretprobes_fds_per_cpu,
                                     const orbit_grpc_protos::InstrumentedFunction& function);
 
-  bool OpenThreadNameTracepoints(absl::Span<int32_t const> cpus);
+  bool OpenThreadNameTracepoints(absl::Span<const int32_t> cpus);
   void InitSwitchesStatesNamesVisitor();
-  bool OpenContextSwitchAndThreadStateTracepoints(absl::Span<int32_t const> cpus);
+  bool OpenContextSwitchAndThreadStateTracepoints(absl::Span<const int32_t> cpus);
 
   void InitGpuTracepointEventVisitor();
-  bool OpenGpuTracepoints(absl::Span<int32_t const> cpus);
+  bool OpenGpuTracepoints(absl::Span<const int32_t> cpus);
 
-  bool OpenInstrumentedTracepoints(absl::Span<int32_t const> cpus);
+  bool OpenInstrumentedTracepoints(absl::Span<const int32_t> cpus);
 
   void InitLostAndDiscardedEventVisitor();
 

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -9,6 +9,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/synchronization/mutex.h>
+#include <absl/types/span.h>
 #include <linux/perf_event.h>
 #include <sys/types.h>
 
@@ -67,19 +68,18 @@ class TracerImpl : public Tracer {
   void Shutdown();
   void ProcessOneRecord(PerfEventRingBuffer* ring_buffer);
   void InitUprobesEventVisitor();
-  bool OpenUserSpaceProbes(const std::vector<int32_t>& cpus);
-  bool OpenUprobesToRecordAdditionalStackOn(const std::vector<int32_t>& cpus);
+  bool OpenUserSpaceProbes(absl::Span<int32_t const> cpus);
+  bool OpenUprobesToRecordAdditionalStackOn(absl::Span<int32_t const> cpus);
   bool OpenUprobes(const orbit_grpc_protos::InstrumentedFunction& function,
-                   const std::vector<int32_t>& cpus,
-                   absl::flat_hash_map<int32_t, int>* fds_per_cpu);
+                   absl::Span<int32_t const> cpus, absl::flat_hash_map<int32_t, int>* fds_per_cpu);
   bool OpenUprobesWithStack(const orbit_grpc_protos::FunctionToRecordAdditionalStackOn& function,
-                            const std::vector<int32_t>& cpus,
+                            absl::Span<int32_t const> cpus,
                             absl::flat_hash_map<int32_t, int>* fds_per_cpu);
   bool OpenUretprobes(const orbit_grpc_protos::InstrumentedFunction& function,
-                      const std::vector<int32_t>& cpus,
+                      absl::Span<int32_t const> cpus,
                       absl::flat_hash_map<int32_t, int>* fds_per_cpu);
-  bool OpenMmapTask(const std::vector<int32_t>& cpus);
-  bool OpenSampling(const std::vector<int32_t>& cpus);
+  bool OpenMmapTask(absl::Span<int32_t const> cpus);
+  bool OpenSampling(absl::Span<int32_t const> cpus);
 
   void AddUprobesFileDescriptors(const absl::flat_hash_map<int32_t, int>& uprobes_fds_per_cpu,
                                  const orbit_grpc_protos::InstrumentedFunction& function);
@@ -87,14 +87,14 @@ class TracerImpl : public Tracer {
   void AddUretprobesFileDescriptors(const absl::flat_hash_map<int32_t, int>& uretprobes_fds_per_cpu,
                                     const orbit_grpc_protos::InstrumentedFunction& function);
 
-  bool OpenThreadNameTracepoints(const std::vector<int32_t>& cpus);
+  bool OpenThreadNameTracepoints(absl::Span<int32_t const> cpus);
   void InitSwitchesStatesNamesVisitor();
-  bool OpenContextSwitchAndThreadStateTracepoints(const std::vector<int32_t>& cpus);
+  bool OpenContextSwitchAndThreadStateTracepoints(absl::Span<int32_t const> cpus);
 
   void InitGpuTracepointEventVisitor();
-  bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
+  bool OpenGpuTracepoints(absl::Span<int32_t const> cpus);
 
-  bool OpenInstrumentedTracepoints(const std::vector<int32_t>& cpus);
+  bool OpenInstrumentedTracepoints(absl::Span<int32_t const> cpus);
 
   void InitLostAndDiscardedEventVisitor();
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -41,7 +41,7 @@ using orbit_grpc_protos::FunctionCall;
 using orbit_grpc_protos::ThreadStateSliceCallstack;
 
 static bool CallstackIsInUserSpaceInstrumentation(
-    absl::Span<unwindstack::FrameData const> frames,
+    absl::Span<const unwindstack::FrameData> frames,
     const UserSpaceInstrumentationAddresses& user_space_instrumentation_addresses) {
   ORBIT_CHECK(!frames.empty());
 
@@ -309,7 +309,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
   thread_state_slice_callstack.set_thread_state_slice_tid(event_data.prev_tid);
   thread_state_slice_callstack.set_timestamp_ns(event_timestamp);
 
-  bool const success = UnwindStack(event_data, thread_state_slice_callstack.mutable_callstack(),
+  const bool success = UnwindStack(event_data, thread_state_slice_callstack.mutable_callstack(),
                                    /*offline_memory_only=*/true);
 
   if (!success) {
@@ -485,7 +485,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
   thread_state_slice_callstack.set_thread_state_slice_tid(event_data.prev_tid);
   thread_state_slice_callstack.set_timestamp_ns(event_timestamp);
 
-  bool const success =
+  const bool success =
       VisitCallchainEvent(event_data, thread_state_slice_callstack.mutable_callstack());
 
   if (!success) {

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -4,6 +4,7 @@
 
 #include "UprobesUnwindingVisitor.h"
 
+#include <absl/types/span.h>
 #include <sys/mman.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Object.h>
@@ -40,7 +41,7 @@ using orbit_grpc_protos::FunctionCall;
 using orbit_grpc_protos::ThreadStateSliceCallstack;
 
 static bool CallstackIsInUserSpaceInstrumentation(
-    const std::vector<unwindstack::FrameData>& frames,
+    absl::Span<unwindstack::FrameData const> frames,
     const UserSpaceInstrumentationAddresses& user_space_instrumentation_addresses) {
   ORBIT_CHECK(!frames.empty());
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
@@ -131,7 +131,7 @@ class UprobesUnwindingVisitorCallchainTest : public ::testing::Test {
                                    PROT_EXEC | PROT_READ, kNonExecutableName);
 };
 
-CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(absl::Span<uint64_t const> callchain) {
+CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(absl::Span<const uint64_t> callchain) {
   constexpr uint64_t kTotalNumOfRegisters =
       sizeof(perf_event_sample_regs_user_all) / sizeof(uint64_t);
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sys/mman.h>
@@ -130,7 +131,7 @@ class UprobesUnwindingVisitorCallchainTest : public ::testing::Test {
                                    PROT_EXEC | PROT_READ, kNonExecutableName);
 };
 
-CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(const std::vector<uint64_t>& callchain) {
+CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(absl::Span<uint64_t const> callchain) {
   constexpr uint64_t kTotalNumOfRegisters =
       sizeof(perf_event_sample_regs_user_all) / sizeof(uint64_t);
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorDwarfUnwindingTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorDwarfUnwindingTest.cpp
@@ -28,10 +28,13 @@
 #include "MockTracerListener.h"
 #include "PerfEvent.h"
 #include "PerfEventRecords.h"
+#include "TestUtils/SaveRangeFromArg.h"
 #include "UprobesFunctionCallManager.h"
 #include "UprobesUnwindingVisitor.h"
 #include "UprobesUnwindingVisitorTestCommon.h"
 #include "unwindstack/SharedString.h"
+
+using orbit_test_utils::SaveRangeFromArg;
 
 namespace orbit_linux_tracing {
 
@@ -242,7 +245,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
                                       ::testing::_, ::testing::_, ::testing::_))
       .Times(1)
       .WillOnce(
-          ::testing::DoAll(::testing::SaveArg<3>(&actual_stack_slices),
+          ::testing::DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                            ::testing::Return(LibunwindstackResult{
                                libunwindstack_callstack, {}, unwindstack::ErrorCode::ERROR_NONE})));
 
@@ -1271,7 +1274,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest, VisitStackSampleUsesUser
                                       ::testing::_, ::testing::_, ::testing::_))
       .Times(1)
       .WillOnce(
-          ::testing::DoAll(::testing::SaveArg<3>(&actual_stack_slices),
+          ::testing::DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                            ::testing::Return(LibunwindstackResult{
                                libunwindstack_callstack, {}, unwindstack::ErrorCode::ERROR_NONE})));
 
@@ -1388,7 +1391,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
                                       ::testing::_, ::testing::_, ::testing::_))
       .Times(1)
       .WillOnce(
-          ::testing::DoAll(::testing::SaveArg<3>(&actual_stack_slices),
+          ::testing::DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                            ::testing::Return(LibunwindstackResult{
                                libunwindstack_callstack, {}, unwindstack::ErrorCode::ERROR_NONE})));
 
@@ -1525,7 +1528,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
                                       ::testing::_, ::testing::_, ::testing::_))
       .Times(1)
       .WillOnce(
-          ::testing::DoAll(::testing::SaveArg<3>(&actual_stack_slices),
+          ::testing::DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                            ::testing::Return(LibunwindstackResult{
                                libunwindstack_callstack, {}, unwindstack::ErrorCode::ERROR_NONE})));
 
@@ -1662,7 +1665,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
                                       ::testing::_, ::testing::_, ::testing::_))
       .Times(1)
       .WillOnce(
-          ::testing::DoAll(::testing::SaveArg<3>(&actual_stack_slices),
+          ::testing::DoAll(SaveRangeFromArg<3>(&actual_stack_slices),
                            ::testing::Return(LibunwindstackResult{
                                libunwindstack_callstack, {}, unwindstack::ErrorCode::ERROR_NONE})));
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorTestCommon.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTestCommon.h
@@ -34,7 +34,7 @@ class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
  public:
   MOCK_METHOD(LibunwindstackResult, Unwind,
               (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
-               absl::Span<StackSliceView const>, bool, size_t),
+               absl::Span<const StackSliceView>, bool, size_t),
               (override));
   MOCK_METHOD(std::optional<bool>, HasFramePointerSet, (uint64_t, pid_t, unwindstack::Maps*),
               (override));

--- a/src/LinuxTracing/UprobesUnwindingVisitorTestCommon.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTestCommon.h
@@ -5,6 +5,7 @@
 #ifndef LINUX_TRACING_UPROBES_UNWINDING_VISITOR_TEST_COMMON_H_
 #define LINUX_TRACING_UPROBES_UNWINDING_VISITOR_TEST_COMMON_H_
 
+#include <absl/types/span.h>
 #include <asm/perf_regs.h>
 #include <gmock/gmock.h>
 #include <unwindstack/MapInfo.h>
@@ -33,7 +34,7 @@ class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
  public:
   MOCK_METHOD(LibunwindstackResult, Unwind,
               (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
-               const std::vector<StackSliceView>&, bool, size_t),
+               absl::Span<StackSliceView const>, bool, size_t),
               (override));
   MOCK_METHOD(std::optional<bool>, HasFramePointerSet, (uint64_t, pid_t, unwindstack::Maps*),
               (override));

--- a/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/strings/match.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
@@ -69,7 +70,7 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
 }
 
 void VerifyFunctionCallsOfPuppetOuterAndInnerFunction(
-    const std::vector<orbit_grpc_protos::FunctionCall>& function_calls, uint32_t pid,
+    absl::Span<orbit_grpc_protos::FunctionCall const> function_calls, uint32_t pid,
     uint64_t outer_function_id, uint64_t inner_function_id,
     bool expect_return_value_and_registers) {
   for (const orbit_grpc_protos::FunctionCall& function_call : function_calls) {

--- a/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestCommons.cpp
@@ -70,7 +70,7 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
 }
 
 void VerifyFunctionCallsOfPuppetOuterAndInnerFunction(
-    absl::Span<orbit_grpc_protos::FunctionCall const> function_calls, uint32_t pid,
+    absl::Span<const orbit_grpc_protos::FunctionCall> function_calls, uint32_t pid,
     uint64_t outer_function_id, uint64_t inner_function_id,
     bool expect_return_value_and_registers) {
   for (const orbit_grpc_protos::FunctionCall& function_call : function_calls) {

--- a/src/LinuxTracingIntegrationTests/IntegrationTestCommons.h
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestCommons.h
@@ -5,6 +5,7 @@
 #ifndef LINUX_TRACING_INTEGRATION_TESTS_INTEGRATION_TEST_COMMONS_H_
 #define LINUX_TRACING_INTEGRATION_TESTS_INTEGRATION_TEST_COMMONS_H_
 
+#include <absl/types/span.h>
 #include <sys/types.h>
 
 #include "GrpcProtos/capture.pb.h"
@@ -22,7 +23,7 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
 // dynamically instrumenting `IntegrationTestPuppet`'s functions `OuterFunctionToInstrument` and
 // `InnerFunctionToInstrument`.
 void VerifyFunctionCallsOfPuppetOuterAndInnerFunction(
-    const std::vector<orbit_grpc_protos::FunctionCall>& function_calls, uint32_t pid,
+    absl::Span<orbit_grpc_protos::FunctionCall const> function_calls, uint32_t pid,
     uint64_t outer_function_id, uint64_t inner_function_id, bool expect_return_value_and_registers);
 
 }  // namespace orbit_linux_tracing_integration_tests

--- a/src/LinuxTracingIntegrationTests/IntegrationTestCommons.h
+++ b/src/LinuxTracingIntegrationTests/IntegrationTestCommons.h
@@ -23,7 +23,7 @@ void AddPuppetOuterAndInnerFunctionToCaptureOptions(
 // dynamically instrumenting `IntegrationTestPuppet`'s functions `OuterFunctionToInstrument` and
 // `InnerFunctionToInstrument`.
 void VerifyFunctionCallsOfPuppetOuterAndInnerFunction(
-    absl::Span<orbit_grpc_protos::FunctionCall const> function_calls, uint32_t pid,
+    absl::Span<const orbit_grpc_protos::FunctionCall> function_calls, uint32_t pid,
     uint64_t outer_function_id, uint64_t inner_function_id, bool expect_return_value_and_registers);
 
 }  // namespace orbit_linux_tracing_integration_tests

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -341,7 +341,7 @@ using PuppetConstants = IntegrationTestPuppetConstants;
   return fixture->StopTracingAndGetEvents();
 }
 
-void VerifyOrderOfAllEvents(absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+void VerifyOrderOfAllEvents(absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
   uint64_t previous_event_timestamp_ns = 0;
   for (const auto& event : events) {
     // Please keep the cases alphabetically ordered, as in the definition of the
@@ -473,7 +473,7 @@ void VerifyOrderOfAllEvents(absl::Span<orbit_grpc_protos::ProducerCaptureEvent c
 }
 
 void VerifyNoLostOrDiscardedEvents(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
   for (const orbit_grpc_protos::ProducerCaptureEvent& event : events) {
     EXPECT_FALSE(event.has_lost_perf_records_event());
     EXPECT_FALSE(event.has_out_of_order_events_discarded_event());
@@ -481,7 +481,7 @@ void VerifyNoLostOrDiscardedEvents(
 }
 
 void VerifyErrorsWithPerfEventOpenEvent(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
   bool errors_with_perf_event_open_event_found = false;
   for (const auto& event : events) {
     if (event.has_errors_with_perf_event_open_event()) {
@@ -493,7 +493,7 @@ void VerifyErrorsWithPerfEventOpenEvent(
 }
 
 void VerifyNoWarningInstrumentingWithUprobesEvents(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
   for (const orbit_grpc_protos::ProducerCaptureEvent& event : events) {
     EXPECT_FALSE(event.has_warning_instrumenting_with_uprobes_event());
   }
@@ -543,7 +543,7 @@ TEST(LinuxTracingIntegrationTest, SchedulingSlices) {
 }
 
 void VerifyFunctionCallsOfOuterAndInnerFunction(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events, uint32_t pid,
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events, uint32_t pid,
     uint64_t outer_function_id, uint64_t inner_function_id) {
   std::vector<orbit_grpc_protos::FunctionCall> function_calls;
   for (const orbit_grpc_protos::ProducerCaptureEvent& event : events) {
@@ -623,7 +623,7 @@ GetOuterAndInnerFunctionVirtualAddressRanges(pid_t pid) {
 }
 
 absl::flat_hash_set<uint64_t> VerifyAndGetAddressInfosWithOuterAndInnerFunction(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events,
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events,
     const std::filesystem::path& executable_path,
     std::pair<uint64_t, uint64_t> outer_function_virtual_address_range,
     std::pair<uint64_t, uint64_t> inner_function_virtual_address_range) {
@@ -660,7 +660,7 @@ absl::flat_hash_set<uint64_t> VerifyAndGetAddressInfosWithOuterAndInnerFunction(
 }
 
 void VerifyCallstackSamplesWithOuterAndInnerFunction(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events, uint32_t pid,
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events, uint32_t pid,
     std::pair<uint64_t, uint64_t> outer_function_virtual_address_range,
     std::pair<uint64_t, uint64_t> inner_function_virtual_address_range, double sampling_rate,
     const absl::flat_hash_set<uint64_t>* address_infos_received, bool unwound_with_frame_pointers) {
@@ -749,7 +749,7 @@ void VerifyCallstackSamplesWithOuterAndInnerFunction(
 }
 
 void VerifyCallstackSamplesWithOuterAndInnerFunctionForDwarfUnwinding(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events, uint32_t pid,
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events, uint32_t pid,
     std::pair<uint64_t, uint64_t> outer_function_virtual_address_range,
     std::pair<uint64_t, uint64_t> inner_function_virtual_address_range, double sampling_rate,
     const absl::flat_hash_set<uint64_t>* address_infos_received) {
@@ -759,7 +759,7 @@ void VerifyCallstackSamplesWithOuterAndInnerFunctionForDwarfUnwinding(
 }
 
 void VerifyCallstackSamplesWithOuterAndInnerFunctionForFramePointerUnwinding(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events, uint32_t pid,
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events, uint32_t pid,
     std::pair<uint64_t, uint64_t> outer_function_virtual_address_range,
     std::pair<uint64_t, uint64_t> inner_function_virtual_address_range, double sampling_rate,
     const absl::flat_hash_set<uint64_t>* address_infos_received) {
@@ -843,7 +843,7 @@ TEST(LinuxTracingIntegrationTest, CallstackSamplesTogetherWithFunctionCalls) {
       inner_function_virtual_address_range, sampling_rate, &address_infos_received);
 }
 
-void VerifyNoAddressInfos(absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+void VerifyNoAddressInfos(absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
   for (const auto& event : events) {
     EXPECT_NE(event.event_case(), orbit_grpc_protos::ProducerCaptureEvent::kFullAddressInfo);
   }

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -9,6 +9,7 @@
 #include <absl/synchronization/mutex.h>
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sys/types.h>
@@ -340,7 +341,7 @@ using PuppetConstants = IntegrationTestPuppetConstants;
   return fixture->StopTracingAndGetEvents();
 }
 
-void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+void VerifyOrderOfAllEvents(absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
   uint64_t previous_event_timestamp_ns = 0;
   for (const auto& event : events) {
     // Please keep the cases alphabetically ordered, as in the definition of the
@@ -472,7 +473,7 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
 }
 
 void VerifyNoLostOrDiscardedEvents(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
   for (const orbit_grpc_protos::ProducerCaptureEvent& event : events) {
     EXPECT_FALSE(event.has_lost_perf_records_event());
     EXPECT_FALSE(event.has_out_of_order_events_discarded_event());
@@ -480,7 +481,7 @@ void VerifyNoLostOrDiscardedEvents(
 }
 
 void VerifyErrorsWithPerfEventOpenEvent(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
   bool errors_with_perf_event_open_event_found = false;
   for (const auto& event : events) {
     if (event.has_errors_with_perf_event_open_event()) {
@@ -492,7 +493,7 @@ void VerifyErrorsWithPerfEventOpenEvent(
 }
 
 void VerifyNoWarningInstrumentingWithUprobesEvents(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
   for (const orbit_grpc_protos::ProducerCaptureEvent& event : events) {
     EXPECT_FALSE(event.has_warning_instrumenting_with_uprobes_event());
   }
@@ -542,7 +543,7 @@ TEST(LinuxTracingIntegrationTest, SchedulingSlices) {
 }
 
 void VerifyFunctionCallsOfOuterAndInnerFunction(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events, uint32_t pid,
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events, uint32_t pid,
     uint64_t outer_function_id, uint64_t inner_function_id) {
   std::vector<orbit_grpc_protos::FunctionCall> function_calls;
   for (const orbit_grpc_protos::ProducerCaptureEvent& event : events) {
@@ -622,7 +623,7 @@ GetOuterAndInnerFunctionVirtualAddressRanges(pid_t pid) {
 }
 
 absl::flat_hash_set<uint64_t> VerifyAndGetAddressInfosWithOuterAndInnerFunction(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events,
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events,
     const std::filesystem::path& executable_path,
     std::pair<uint64_t, uint64_t> outer_function_virtual_address_range,
     std::pair<uint64_t, uint64_t> inner_function_virtual_address_range) {
@@ -659,7 +660,7 @@ absl::flat_hash_set<uint64_t> VerifyAndGetAddressInfosWithOuterAndInnerFunction(
 }
 
 void VerifyCallstackSamplesWithOuterAndInnerFunction(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events, uint32_t pid,
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events, uint32_t pid,
     std::pair<uint64_t, uint64_t> outer_function_virtual_address_range,
     std::pair<uint64_t, uint64_t> inner_function_virtual_address_range, double sampling_rate,
     const absl::flat_hash_set<uint64_t>* address_infos_received, bool unwound_with_frame_pointers) {
@@ -748,7 +749,7 @@ void VerifyCallstackSamplesWithOuterAndInnerFunction(
 }
 
 void VerifyCallstackSamplesWithOuterAndInnerFunctionForDwarfUnwinding(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events, uint32_t pid,
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events, uint32_t pid,
     std::pair<uint64_t, uint64_t> outer_function_virtual_address_range,
     std::pair<uint64_t, uint64_t> inner_function_virtual_address_range, double sampling_rate,
     const absl::flat_hash_set<uint64_t>* address_infos_received) {
@@ -758,7 +759,7 @@ void VerifyCallstackSamplesWithOuterAndInnerFunctionForDwarfUnwinding(
 }
 
 void VerifyCallstackSamplesWithOuterAndInnerFunctionForFramePointerUnwinding(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events, uint32_t pid,
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events, uint32_t pid,
     std::pair<uint64_t, uint64_t> outer_function_virtual_address_range,
     std::pair<uint64_t, uint64_t> inner_function_virtual_address_range, double sampling_rate,
     const absl::flat_hash_set<uint64_t>* address_infos_received) {
@@ -842,7 +843,7 @@ TEST(LinuxTracingIntegrationTest, CallstackSamplesTogetherWithFunctionCalls) {
       inner_function_virtual_address_range, sampling_rate, &address_infos_received);
 }
 
-void VerifyNoAddressInfos(const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+void VerifyNoAddressInfos(absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
   for (const auto& event : events) {
     EXPECT_NE(event.event_case(), orbit_grpc_protos::ProducerCaptureEvent::kFullAddressInfo);
   }

--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -249,7 +249,7 @@ static void VerifyCaptureFinishedEvent(const ClientCaptureEvent& event) {
   EXPECT_EQ(capture_finished.error_message(), "");
 }
 
-static void VerifyInitialAndFinalEvents(absl::Span<ClientCaptureEvent const> events,
+static void VerifyInitialAndFinalEvents(absl::Span<const ClientCaptureEvent> events,
                                         const CaptureOptions& original_capture_options) {
   ASSERT_GE(events.size(), 3);
   VerifyCaptureStartedEvent(events.front(), original_capture_options);
@@ -257,7 +257,7 @@ static void VerifyInitialAndFinalEvents(absl::Span<ClientCaptureEvent const> eve
   VerifyCaptureFinishedEvent(events.back());
 }
 
-static void VerifyErrorEvents(absl::Span<ClientCaptureEvent const> events) {
+static void VerifyErrorEvents(absl::Span<const ClientCaptureEvent> events) {
   bool errors_with_perf_event_open_event_found = false;
   for (const ClientCaptureEvent& event : events) {
     EXPECT_NE(event.event_case(), ClientCaptureEvent::kErrorEnablingOrbitApiEvent);
@@ -283,7 +283,7 @@ TEST(OrbitServiceIntegrationTest, CaptureSmoke) {
   VerifyErrorEvents(events);
 }
 
-static void VerifyFunctionCallsOfOuterAndInnerFunction(absl::Span<ClientCaptureEvent const> events,
+static void VerifyFunctionCallsOfOuterAndInnerFunction(absl::Span<const ClientCaptureEvent> events,
                                                        uint32_t pid, uint64_t outer_function_id,
                                                        uint64_t inner_function_id) {
   std::vector<orbit_grpc_protos::FunctionCall> function_calls;

--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -6,6 +6,7 @@
 #include <absl/strings/match.h>
 #include <absl/strings/str_format.h>
 #include <absl/synchronization/mutex.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/security/credentials.h>
@@ -248,7 +249,7 @@ static void VerifyCaptureFinishedEvent(const ClientCaptureEvent& event) {
   EXPECT_EQ(capture_finished.error_message(), "");
 }
 
-static void VerifyInitialAndFinalEvents(const std::vector<ClientCaptureEvent>& events,
+static void VerifyInitialAndFinalEvents(absl::Span<ClientCaptureEvent const> events,
                                         const CaptureOptions& original_capture_options) {
   ASSERT_GE(events.size(), 3);
   VerifyCaptureStartedEvent(events.front(), original_capture_options);
@@ -256,7 +257,7 @@ static void VerifyInitialAndFinalEvents(const std::vector<ClientCaptureEvent>& e
   VerifyCaptureFinishedEvent(events.back());
 }
 
-static void VerifyErrorEvents(const std::vector<ClientCaptureEvent>& events) {
+static void VerifyErrorEvents(absl::Span<ClientCaptureEvent const> events) {
   bool errors_with_perf_event_open_event_found = false;
   for (const ClientCaptureEvent& event : events) {
     EXPECT_NE(event.event_case(), ClientCaptureEvent::kErrorEnablingOrbitApiEvent);
@@ -282,9 +283,9 @@ TEST(OrbitServiceIntegrationTest, CaptureSmoke) {
   VerifyErrorEvents(events);
 }
 
-static void VerifyFunctionCallsOfOuterAndInnerFunction(
-    const std::vector<ClientCaptureEvent>& events, uint32_t pid, uint64_t outer_function_id,
-    uint64_t inner_function_id) {
+static void VerifyFunctionCallsOfOuterAndInnerFunction(absl::Span<ClientCaptureEvent const> events,
+                                                       uint32_t pid, uint64_t outer_function_id,
+                                                       uint64_t inner_function_id) {
   std::vector<orbit_grpc_protos::FunctionCall> function_calls;
   for (const ClientCaptureEvent& event : events) {
     if (!event.has_function_call()) {

--- a/src/MemoryTracing/MemoryInfoListener.cpp
+++ b/src/MemoryTracing/MemoryInfoListener.cpp
@@ -4,6 +4,8 @@
 
 #include "MemoryTracing/MemoryInfoListener.h"
 
+#include <absl/types/span.h>
+
 #include <algorithm>
 #include <utility>
 #include <vector>
@@ -19,7 +21,7 @@ namespace orbit_memory_tracing {
 
 // This method computes the arithmetic mean of input timestamps.
 [[nodiscard]] static uint64_t GetSynchronizedSamplingTimestamp(
-    const std::vector<uint64_t>& sampling_timestamps) {
+    absl::Span<uint64_t const> sampling_timestamps) {
   uint64_t offset = *std::min_element(sampling_timestamps.begin(), sampling_timestamps.end());
   uint64_t sum = 0;
   for (uint64_t timestamp : sampling_timestamps) sum += timestamp - offset;

--- a/src/MemoryTracing/MemoryInfoListener.cpp
+++ b/src/MemoryTracing/MemoryInfoListener.cpp
@@ -21,7 +21,7 @@ namespace orbit_memory_tracing {
 
 // This method computes the arithmetic mean of input timestamps.
 [[nodiscard]] static uint64_t GetSynchronizedSamplingTimestamp(
-    absl::Span<uint64_t const> sampling_timestamps) {
+    absl::Span<const uint64_t> sampling_timestamps) {
   uint64_t offset = *std::min_element(sampling_timestamps.begin(), sampling_timestamps.end());
   uint64_t sum = 0;
   for (uint64_t timestamp : sampling_timestamps) sum += timestamp - offset;

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -5,6 +5,7 @@
 #include <absl/synchronization/mutex.h>
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
+#include <absl/types/span.h>
 #include <gtest/gtest.h>
 #include <sys/types.h>
 
@@ -128,7 +129,7 @@ class MemoryTracingIntegrationTestFixture {
   return fixture->StopTracingAndGetEvents();
 }
 
-void VerifyOrderAndContentOfEvents(const std::vector<ProducerCaptureEvent>& events,
+void VerifyOrderAndContentOfEvents(absl::Span<ProducerCaptureEvent const> events,
                                    uint64_t sampling_period_ns) {
   const uint64_t kMemoryEventsTimeDifferenceTolerance =
       static_cast<uint64_t>(sampling_period_ns * 0.2);
@@ -189,7 +190,7 @@ void VerifyOrderAndContentOfEvents(const std::vector<ProducerCaptureEvent>& even
 
 // Verify whether the memory_sampling_period_ns_ works as expected by checking the number of
 // received events.
-void VerifyEventCounts(const std::vector<ProducerCaptureEvent>& events, size_t expected_counts) {
+void VerifyEventCounts(absl::Span<ProducerCaptureEvent const> events, size_t expected_counts) {
   constexpr size_t kEventCountsErrorTolerance = 2;
 
   size_t num_received_events = 0;

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -129,7 +129,7 @@ class MemoryTracingIntegrationTestFixture {
   return fixture->StopTracingAndGetEvents();
 }
 
-void VerifyOrderAndContentOfEvents(absl::Span<ProducerCaptureEvent const> events,
+void VerifyOrderAndContentOfEvents(absl::Span<const ProducerCaptureEvent> events,
                                    uint64_t sampling_period_ns) {
   const uint64_t kMemoryEventsTimeDifferenceTolerance =
       static_cast<uint64_t>(sampling_period_ns * 0.2);
@@ -190,7 +190,7 @@ void VerifyOrderAndContentOfEvents(absl::Span<ProducerCaptureEvent const> events
 
 // Verify whether the memory_sampling_period_ns_ works as expected by checking the number of
 // received events.
-void VerifyEventCounts(absl::Span<ProducerCaptureEvent const> events, size_t expected_counts) {
+void VerifyEventCounts(absl::Span<const ProducerCaptureEvent> events, size_t expected_counts) {
   constexpr size_t kEventCountsErrorTolerance = 2;
 
   size_t num_received_events = 0;

--- a/src/MizarBase/include/MizarBase/AbsoluteAddress.h
+++ b/src/MizarBase/include/MizarBase/AbsoluteAddress.h
@@ -18,7 +18,7 @@ struct AbsoluteAddressTag {};
 using AbsoluteAddress = orbit_base::Typedef<AbsoluteAddressTag, const uint64_t>;
 
 template <typename Action>
-inline void ForEachFrame(absl::Span<uint64_t const> frames, Action&& action) {
+inline void ForEachFrame(absl::Span<const uint64_t> frames, Action&& action) {
   for (const uint64_t raw_address : frames) {
     std::invoke(action, AbsoluteAddress(raw_address));
   }

--- a/src/MizarBase/include/MizarBase/AbsoluteAddress.h
+++ b/src/MizarBase/include/MizarBase/AbsoluteAddress.h
@@ -5,6 +5,8 @@
 #ifndef MIZAR_BASE_ABSOLUTE_ADDRESS_H_
 #define MIZAR_BASE_ABSOLUTE_ADDRESS_H_
 
+#include <absl/types/span.h>
+
 #include <functional>
 
 #include "OrbitBase/Typedef.h"
@@ -16,7 +18,7 @@ struct AbsoluteAddressTag {};
 using AbsoluteAddress = orbit_base::Typedef<AbsoluteAddressTag, const uint64_t>;
 
 template <typename Action>
-inline void ForEachFrame(const std::vector<uint64_t>& frames, Action&& action) {
+inline void ForEachFrame(absl::Span<uint64_t const> frames, Action&& action) {
   for (const uint64_t raw_address : frames) {
     std::invoke(action, AbsoluteAddress(raw_address));
   }

--- a/src/MizarData/FrameTrackManagerTest.cpp
+++ b/src/MizarData/FrameTrackManagerTest.cpp
@@ -4,6 +4,7 @@
 
 #include <absl/algorithm/container.h>
 #include <absl/container/flat_hash_map.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -67,7 +68,7 @@ static const std::vector<orbit_client_data::ScopeInfo> kScopeInfos = {
     {"Foo", orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction},
     {"Bar", orbit_client_data::ScopeType::kApiScope}};
 
-static std::vector<TimestampNs> MakeTimestamps(const std::vector<uint64_t>& raw) {
+static std::vector<TimestampNs> MakeTimestamps(absl::Span<uint64_t const> raw) {
   std::vector<TimestampNs> result;
   absl::c_transform(raw, std::back_inserter(result),
                     [](uint64_t value) { return TimestampNs(value); });
@@ -80,7 +81,7 @@ static const std::vector<std::vector<TimestampNs>> kScopeFrameTrackStartLists = 
     kFirstScopeStarts, kSecondScopeStarts};
 
 // Re-wrap the values form `TimestampNs` into `TimerInfos`
-static std::vector<TimerInfo> ToTimerInfos(const std::vector<TimestampNs>& starts) {
+static std::vector<TimerInfo> ToTimerInfos(absl::Span<TimestampNs const> starts) {
   std::vector<TimerInfo> result;
   std::transform(std::begin(starts), std::end(starts), std::back_inserter(result),
                  [](TimestampNs start) {
@@ -94,7 +95,7 @@ static std::vector<TimerInfo> ToTimerInfos(const std::vector<TimestampNs>& start
 static const std::vector<TimerInfo> kFirstScopeTimers = ToTimerInfos(kFirstScopeStarts);
 static const std::vector<TimerInfo> kSecondScopeTimers = ToTimerInfos(kSecondScopeStarts);
 
-static std::vector<const TimerInfo*> MakePtrs(const std::vector<TimerInfo>& timers) {
+static std::vector<const TimerInfo*> MakePtrs(absl::Span<TimerInfo const> timers) {
   std::vector<const TimerInfo*> result;
   std::transform(std::begin(timers), std::end(timers), std::back_inserter(result),
                  [](const TimerInfo& timer) { return &timer; });
@@ -115,7 +116,7 @@ static const absl::flat_hash_map<ScopeInfo, std::vector<TimestampNs>> kScopeInfo
 static const std::vector<TimestampNs> kDxgiFrameStarts = MakeTimestamps({10, 1, 2, 4, 20});
 static const std::vector<TimestampNs> kD3d9FrameStarts = MakeTimestamps({100, 10, 20, 40, 200});
 
-static std::vector<PresentEvent> MakePresentEvent(const std::vector<TimestampNs>& starts) {
+static std::vector<PresentEvent> MakePresentEvent(absl::Span<TimestampNs const> starts) {
   std::vector<PresentEvent> result;
   std::transform(std::begin(starts), std::end(starts), std::back_inserter(result),
                  [](const TimestampNs start) {
@@ -197,8 +198,8 @@ class ExpectFrameTracksHasFrameStartsForScopes : public ::testing::Test {
   }
 
   void ExpectGetFrameTracksIsCorrect(
-      const std::vector<orbit_client_data::ScopeInfo>& expected_scope_info,
-      const std::vector<PresentEvent::Source>& expected_etw_sources) {
+      absl::Span<orbit_client_data::ScopeInfo const> expected_scope_info,
+      absl::Span<PresentEvent::Source const> expected_etw_sources) {
     const auto [scope_infos, etw_sources] = DecomposeSources(frame_track_manager_.GetFrameTracks());
 
     EXPECT_THAT(scope_infos, UnorderedElementsAreArray(expected_scope_info));

--- a/src/MizarData/FrameTrackManagerTest.cpp
+++ b/src/MizarData/FrameTrackManagerTest.cpp
@@ -68,7 +68,7 @@ static const std::vector<orbit_client_data::ScopeInfo> kScopeInfos = {
     {"Foo", orbit_client_data::ScopeType::kDynamicallyInstrumentedFunction},
     {"Bar", orbit_client_data::ScopeType::kApiScope}};
 
-static std::vector<TimestampNs> MakeTimestamps(absl::Span<uint64_t const> raw) {
+static std::vector<TimestampNs> MakeTimestamps(absl::Span<const uint64_t> raw) {
   std::vector<TimestampNs> result;
   absl::c_transform(raw, std::back_inserter(result),
                     [](uint64_t value) { return TimestampNs(value); });
@@ -81,7 +81,7 @@ static const std::vector<std::vector<TimestampNs>> kScopeFrameTrackStartLists = 
     kFirstScopeStarts, kSecondScopeStarts};
 
 // Re-wrap the values form `TimestampNs` into `TimerInfos`
-static std::vector<TimerInfo> ToTimerInfos(absl::Span<TimestampNs const> starts) {
+static std::vector<TimerInfo> ToTimerInfos(absl::Span<const TimestampNs> starts) {
   std::vector<TimerInfo> result;
   std::transform(std::begin(starts), std::end(starts), std::back_inserter(result),
                  [](TimestampNs start) {
@@ -95,7 +95,7 @@ static std::vector<TimerInfo> ToTimerInfos(absl::Span<TimestampNs const> starts)
 static const std::vector<TimerInfo> kFirstScopeTimers = ToTimerInfos(kFirstScopeStarts);
 static const std::vector<TimerInfo> kSecondScopeTimers = ToTimerInfos(kSecondScopeStarts);
 
-static std::vector<const TimerInfo*> MakePtrs(absl::Span<TimerInfo const> timers) {
+static std::vector<const TimerInfo*> MakePtrs(absl::Span<const TimerInfo> timers) {
   std::vector<const TimerInfo*> result;
   std::transform(std::begin(timers), std::end(timers), std::back_inserter(result),
                  [](const TimerInfo& timer) { return &timer; });
@@ -116,7 +116,7 @@ static const absl::flat_hash_map<ScopeInfo, std::vector<TimestampNs>> kScopeInfo
 static const std::vector<TimestampNs> kDxgiFrameStarts = MakeTimestamps({10, 1, 2, 4, 20});
 static const std::vector<TimestampNs> kD3d9FrameStarts = MakeTimestamps({100, 10, 20, 40, 200});
 
-static std::vector<PresentEvent> MakePresentEvent(absl::Span<TimestampNs const> starts) {
+static std::vector<PresentEvent> MakePresentEvent(absl::Span<const TimestampNs> starts) {
   std::vector<PresentEvent> result;
   std::transform(std::begin(starts), std::end(starts), std::back_inserter(result),
                  [](const TimestampNs start) {
@@ -198,8 +198,8 @@ class ExpectFrameTracksHasFrameStartsForScopes : public ::testing::Test {
   }
 
   void ExpectGetFrameTracksIsCorrect(
-      absl::Span<orbit_client_data::ScopeInfo const> expected_scope_info,
-      absl::Span<PresentEvent::Source const> expected_etw_sources) {
+      absl::Span<const orbit_client_data::ScopeInfo> expected_scope_info,
+      absl::Span<const PresentEvent::Source> expected_etw_sources) {
     const auto [scope_infos, etw_sources] = DecomposeSources(frame_track_manager_.GetFrameTracks());
 
     EXPECT_THAT(scope_infos, UnorderedElementsAreArray(expected_scope_info));

--- a/src/MizarData/GetCallstackSamplingIntervalsTest.cpp
+++ b/src/MizarData/GetCallstackSamplingIntervalsTest.cpp
@@ -46,7 +46,7 @@ const orbit_client_data::CallstackInfo kCallstackInfo({},
                                                       orbit_client_data::CallstackType::kComplete);
 
 [[nodiscard]] static std::vector<uint64_t> GetExpectedIntervals(
-    absl::Span<uint64_t const> timestamps) {
+    absl::Span<const uint64_t> timestamps) {
   std::vector<uint64_t> intervals;
   for (size_t i = 1; i < timestamps.size(); ++i) {
     intervals.push_back(timestamps[i] - timestamps[i - 1]);
@@ -60,7 +60,7 @@ class GetCallstackSamplingIntervalsTest : public ::testing::Test {
     callstack_data_->AddUniqueCallstack(kCallstackSampleId, kCallstackInfo);
   }
 
-  void PopulateCallstackData(absl::Span<uint64_t const> timestamps, TID tid) const {
+  void PopulateCallstackData(absl::Span<const uint64_t> timestamps, TID tid) const {
     for (const uint64_t timestamp : timestamps) {
       callstack_data_->AddCallstackEvent({timestamp, kCallstackSampleId, *tid});
     }

--- a/src/MizarData/GetCallstackSamplingIntervalsTest.cpp
+++ b/src/MizarData/GetCallstackSamplingIntervalsTest.cpp
@@ -4,6 +4,7 @@
 
 #include <absl/container/flat_hash_set.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
@@ -45,7 +46,7 @@ const orbit_client_data::CallstackInfo kCallstackInfo({},
                                                       orbit_client_data::CallstackType::kComplete);
 
 [[nodiscard]] static std::vector<uint64_t> GetExpectedIntervals(
-    const std::vector<uint64_t>& timestamps) {
+    absl::Span<uint64_t const> timestamps) {
   std::vector<uint64_t> intervals;
   for (size_t i = 1; i < timestamps.size(); ++i) {
     intervals.push_back(timestamps[i] - timestamps[i - 1]);
@@ -59,7 +60,7 @@ class GetCallstackSamplingIntervalsTest : public ::testing::Test {
     callstack_data_->AddUniqueCallstack(kCallstackSampleId, kCallstackInfo);
   }
 
-  void PopulateCallstackData(const std::vector<uint64_t>& timestamps, TID tid) const {
+  void PopulateCallstackData(absl::Span<uint64_t const> timestamps, TID tid) const {
     for (const uint64_t timestamp : timestamps) {
       callstack_data_->AddCallstackEvent({timestamp, kCallstackSampleId, *tid});
     }

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -5,6 +5,7 @@
 #include "MizarData/MizarData.h"
 
 #include <absl/container/flat_hash_set.h>
+#include <absl/types/span.h>
 
 #include <QString>
 #include <QStringLiteral>
@@ -100,7 +101,7 @@ std::optional<std::string> MizarData::GetFunctionNameFromAddress(AbsoluteAddress
   return name;
 }
 
-void MizarData::UpdateModules(const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos) {
+void MizarData::UpdateModules(absl::Span<orbit_grpc_protos::ModuleInfo const> module_infos) {
   for (const auto* not_updated_module :
        module_manager_->AddOrUpdateNotLoadedModules(module_infos)) {
     ORBIT_LOG("Module %s is not updated", not_updated_module->file_path());

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -101,7 +101,7 @@ std::optional<std::string> MizarData::GetFunctionNameFromAddress(AbsoluteAddress
   return name;
 }
 
-void MizarData::UpdateModules(absl::Span<orbit_grpc_protos::ModuleInfo const> module_infos) {
+void MizarData::UpdateModules(absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos) {
   for (const auto* not_updated_module :
        module_manager_->AddOrUpdateNotLoadedModules(module_infos)) {
     ORBIT_LOG("Module %s is not updated", not_updated_module->file_path());

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -4,6 +4,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
@@ -160,7 +161,7 @@ const absl::flat_hash_map<TID, uint64_t> kTidToCallstackCount = {
     {kTID, 3}, {kAnotherTID, 1}, {kNamelessTID, 1}};
 
 [[nodiscard]] static std::vector<SampledFunctionId> SFIDsForCallstacks(
-    const std::vector<uint64_t>& addresses) {
+    absl::Span<uint64_t const> addresses) {
   std::vector<AbsoluteAddress> good_addresses;
   ForEachFrame(addresses, [&good_addresses](AbsoluteAddress address) {
     if (kAddressToId.contains(address)) {

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -161,7 +161,7 @@ const absl::flat_hash_map<TID, uint64_t> kTidToCallstackCount = {
     {kTID, 3}, {kAnotherTID, 1}, {kNamelessTID, 1}};
 
 [[nodiscard]] static std::vector<SampledFunctionId> SFIDsForCallstacks(
-    absl::Span<uint64_t const> addresses) {
+    absl::Span<const uint64_t> addresses) {
   std::vector<AbsoluteAddress> good_addresses;
   ForEachFrame(addresses, [&good_addresses](AbsoluteAddress address) {
     if (kAddressToId.contains(address)) {

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <algorithm>
@@ -120,7 +121,7 @@ class BaselineAndComparisonTmpl {
     absl::flat_hash_map<SFID, InclusiveAndExclusive> counts;
     for (const TID tid : config.tids) {
       data.ForEachCallstackEvent(tid, config.start_relative, config.EndRelative(),
-                                 [&total_callstacks, &counts](const std::vector<SFID>& callstack) {
+                                 [&total_callstacks, &counts](absl::Span<SFID const> callstack) {
                                    total_callstacks++;
                                    if (callstack.empty()) return;
                                    for (const SFID sfid : callstack) {

--- a/src/MizarData/include/MizarData/BaselineAndComparison.h
+++ b/src/MizarData/include/MizarData/BaselineAndComparison.h
@@ -121,7 +121,7 @@ class BaselineAndComparisonTmpl {
     absl::flat_hash_map<SFID, InclusiveAndExclusive> counts;
     for (const TID tid : config.tids) {
       data.ForEachCallstackEvent(tid, config.start_relative, config.EndRelative(),
-                                 [&total_callstacks, &counts](absl::Span<SFID const> callstack) {
+                                 [&total_callstacks, &counts](absl::Span<const SFID> callstack) {
                                    total_callstacks++;
                                    if (callstack.empty()) return;
                                    for (const SFID sfid : callstack) {

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -143,7 +143,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
                                         /*out_of_order_events_discarded_event*/) override {}
 
  private:
-  void UpdateModules(absl::Span<orbit_grpc_protos::ModuleInfo const> module_infos);
+  void UpdateModules(absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
 
   void LoadSymbolsForAllModules();
 

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <filesystem>
@@ -142,7 +143,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
                                         /*out_of_order_events_discarded_event*/) override {}
 
  private:
-  void UpdateModules(const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
+  void UpdateModules(absl::Span<orbit_grpc_protos::ModuleInfo const> module_infos);
 
   void LoadSymbolsForAllModules();
 

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -225,7 +225,7 @@ class MizarPairedDataTmpl {
     return CallstackWithSFIDs(callstack->frames());
   }
 
-  [[nodiscard]] std::vector<SFID> CallstackWithSFIDs(absl::Span<uint64_t const> frames) const {
+  [[nodiscard]] std::vector<SFID> CallstackWithSFIDs(absl::Span<const uint64_t> frames) const {
     std::vector<SFID> result;
     orbit_mizar_base::ForEachFrame(frames, [this, &result](AbsoluteAddress address) {
       if (auto it = address_to_sfid_.find(address); it != address_to_sfid_.end()) {

--- a/src/MizarData/include/MizarData/MizarPairedData.h
+++ b/src/MizarData/include/MizarData/MizarPairedData.h
@@ -7,6 +7,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <absl/types/span.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -224,7 +225,7 @@ class MizarPairedDataTmpl {
     return CallstackWithSFIDs(callstack->frames());
   }
 
-  [[nodiscard]] std::vector<SFID> CallstackWithSFIDs(const std::vector<uint64_t>& frames) const {
+  [[nodiscard]] std::vector<SFID> CallstackWithSFIDs(absl::Span<uint64_t const> frames) const {
     std::vector<SFID> result;
     orbit_mizar_base::ForEachFrame(frames, [this, &result](AbsoluteAddress address) {
       if (auto it = address_to_sfid_.find(address); it != address_to_sfid_.end()) {

--- a/src/ModuleUtils/ReadLinuxModules.cpp
+++ b/src/ModuleUtils/ReadLinuxModules.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/strings/match.h>
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 #include <stdint.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -262,7 +263,7 @@ class FileMappedIntoMemory {
 };
 }  // namespace
 
-std::vector<ModuleInfo> ReadModulesFromMaps(const std::vector<LinuxMemoryMapping>& maps) {
+std::vector<ModuleInfo> ReadModulesFromMaps(absl::Span<LinuxMemoryMapping const> maps) {
   std::vector<ModuleInfo> result;
 
   std::optional<FileMappedIntoMemory> last_file_mapped_into_memory;

--- a/src/ModuleUtils/ReadLinuxModules.cpp
+++ b/src/ModuleUtils/ReadLinuxModules.cpp
@@ -263,7 +263,7 @@ class FileMappedIntoMemory {
 };
 }  // namespace
 
-std::vector<ModuleInfo> ReadModulesFromMaps(absl::Span<LinuxMemoryMapping const> maps) {
+std::vector<ModuleInfo> ReadModulesFromMaps(absl::Span<const LinuxMemoryMapping> maps) {
   std::vector<ModuleInfo> result;
 
   std::optional<FileMappedIntoMemory> last_file_mapped_into_memory;

--- a/src/ModuleUtils/include/ModuleUtils/ReadLinuxModules.h
+++ b/src/ModuleUtils/include/ModuleUtils/ReadLinuxModules.h
@@ -27,7 +27,7 @@ ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModule(const std::filesystem
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(pid_t pid);
 
 [[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo> ReadModulesFromMaps(
-    absl::Span<LinuxMemoryMapping const> maps);
+    absl::Span<const LinuxMemoryMapping> maps);
 
 }  // namespace orbit_module_utils
 

--- a/src/ModuleUtils/include/ModuleUtils/ReadLinuxModules.h
+++ b/src/ModuleUtils/include/ModuleUtils/ReadLinuxModules.h
@@ -7,6 +7,7 @@
 
 #ifdef __linux
 
+#include <absl/types/span.h>
 #include <stdint.h>
 #include <unistd.h>
 
@@ -26,7 +27,7 @@ ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModule(const std::filesystem
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(pid_t pid);
 
 [[nodiscard]] std::vector<orbit_grpc_protos::ModuleInfo> ReadModulesFromMaps(
-    const std::vector<LinuxMemoryMapping>& maps);
+    absl::Span<LinuxMemoryMapping const> maps);
 
 }  // namespace orbit_module_utils
 

--- a/src/OrbitBase/ChunkTest.cpp
+++ b/src/OrbitBase/ChunkTest.cpp
@@ -20,7 +20,7 @@ namespace {
 // Tests that all elements of input array are accounted for by the spans and that the spans don't
 // overflow.
 template <typename T>
-void TestChunksCoverage(absl::Span<T const> test_vector, absl::Span<absl::Span<T> const> chunks) {
+void TestChunksCoverage(absl::Span<const T> test_vector, absl::Span<const absl::Span<T>> chunks) {
   const T* element = test_vector.data();
   for (const absl::Span<T>& chunk : chunks) {
     EXPECT_EQ(element, chunk.data());

--- a/src/OrbitBase/ChunkTest.cpp
+++ b/src/OrbitBase/ChunkTest.cpp
@@ -38,7 +38,7 @@ TEST(SpanUtils, SpansCoverage) {
   constexpr size_t kNumElements = 1024;
   std::vector<uint32_t> counters(kNumElements);
   for (size_t i = 0; i < 32; ++i) {
-    TestChunksCoverage(counters, CreateChunksOfSize(counters, i));
+    TestChunksCoverage<uint32_t>(counters, CreateChunksOfSize(counters, i));
   }
 }
 

--- a/src/OrbitBase/ChunkTest.cpp
+++ b/src/OrbitBase/ChunkTest.cpp
@@ -20,8 +20,7 @@ namespace {
 // Tests that all elements of input array are accounted for by the spans and that the spans don't
 // overflow.
 template <typename T>
-void TestChunksCoverage(const std::vector<T>& test_vector,
-                        const std::vector<absl::Span<T>>& chunks) {
+void TestChunksCoverage(absl::Span<T const> test_vector, absl::Span<absl::Span<T> const> chunks) {
   const T* element = test_vector.data();
   for (const absl::Span<T>& chunk : chunks) {
     EXPECT_EQ(element, chunk.data());

--- a/src/OrbitBase/LoggingUtils.cpp
+++ b/src/OrbitBase/LoggingUtils.cpp
@@ -8,6 +8,7 @@
 #include <absl/strings/str_format.h>
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
+#include <absl/types/span.h>
 
 #include <string>
 #include <string_view>
@@ -75,7 +76,7 @@ ErrorMessageOr<absl::Time> ParseLogFileTimestamp(std::string_view log_file_name)
 }
 
 std::vector<std::filesystem::path> FindOldLogFiles(
-    const std::vector<std::filesystem::path>& file_paths) {
+    absl::Span<std::filesystem::path const> file_paths) {
   std::vector<std::filesystem::path> old_files;
   absl::Time expiration_time = absl::Now() - kLogFileLifetime;
   for (const std::filesystem::path& log_file_path : file_paths) {
@@ -92,7 +93,7 @@ std::vector<std::filesystem::path> FindOldLogFiles(
   return old_files;
 }
 
-ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& file_paths) {
+ErrorMessageOr<void> RemoveFiles(absl::Span<std::filesystem::path const> file_paths) {
   std::string error_message;
   for (const auto& file_path : file_paths) {
     std::error_code file_remove_error;

--- a/src/OrbitBase/LoggingUtils.cpp
+++ b/src/OrbitBase/LoggingUtils.cpp
@@ -76,7 +76,7 @@ ErrorMessageOr<absl::Time> ParseLogFileTimestamp(std::string_view log_file_name)
 }
 
 std::vector<std::filesystem::path> FindOldLogFiles(
-    absl::Span<std::filesystem::path const> file_paths) {
+    absl::Span<const std::filesystem::path> file_paths) {
   std::vector<std::filesystem::path> old_files;
   absl::Time expiration_time = absl::Now() - kLogFileLifetime;
   for (const std::filesystem::path& log_file_path : file_paths) {
@@ -93,7 +93,7 @@ std::vector<std::filesystem::path> FindOldLogFiles(
   return old_files;
 }
 
-ErrorMessageOr<void> RemoveFiles(absl::Span<std::filesystem::path const> file_paths) {
+ErrorMessageOr<void> RemoveFiles(absl::Span<const std::filesystem::path> file_paths) {
   std::string error_message;
   for (const auto& file_path : file_paths) {
     std::error_code file_remove_error;

--- a/src/OrbitBase/LoggingUtils.h
+++ b/src/OrbitBase/LoggingUtils.h
@@ -25,11 +25,11 @@ constexpr const char* kLogFileNameDelimiter = "Orbit-%s-%u.log";
     const std::filesystem::path& dir);
 ErrorMessageOr<absl::Time> ParseLogFileTimestamp(std::string_view log_file_name);
 [[nodiscard]] std::vector<std::filesystem::path> FindOldLogFiles(
-    absl::Span<std::filesystem::path const> log_file_paths);
+    absl::Span<const std::filesystem::path> log_file_paths);
 // This function tries to remove files even when an error is returned. If some files are unable to
 // remove, it returns an error message to record names of those functions and details about the
 // remove failures.
-ErrorMessageOr<void> RemoveFiles(absl::Span<std::filesystem::path const> file_paths);
+ErrorMessageOr<void> RemoveFiles(absl::Span<const std::filesystem::path> file_paths);
 
 }  // namespace orbit_base_internal
 #endif  // ORBIT_BASE_LOGGING_UTILS_H_

--- a/src/OrbitBase/LoggingUtils.h
+++ b/src/OrbitBase/LoggingUtils.h
@@ -7,6 +7,7 @@
 
 #include <absl/strings/str_format.h>
 #include <absl/time/time.h>
+#include <absl/types/span.h>
 
 #include <filesystem>
 #include <string>
@@ -24,11 +25,11 @@ constexpr const char* kLogFileNameDelimiter = "Orbit-%s-%u.log";
     const std::filesystem::path& dir);
 ErrorMessageOr<absl::Time> ParseLogFileTimestamp(std::string_view log_file_name);
 [[nodiscard]] std::vector<std::filesystem::path> FindOldLogFiles(
-    const std::vector<std::filesystem::path>& log_file_paths);
+    absl::Span<std::filesystem::path const> log_file_paths);
 // This function tries to remove files even when an error is returned. If some files are unable to
 // remove, it returns an error message to record names of those functions and details about the
 // remove failures.
-ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& file_paths);
+ErrorMessageOr<void> RemoveFiles(absl::Span<std::filesystem::path const> file_paths);
 
 }  // namespace orbit_base_internal
 #endif  // ORBIT_BASE_LOGGING_UTILS_H_

--- a/src/OrbitCaptureGgpClient/OrbitCaptureGgpClient.cpp
+++ b/src/OrbitCaptureGgpClient/OrbitCaptureGgpClient.cpp
@@ -40,7 +40,7 @@ class CaptureClientGgpClient::CaptureClientGgpClientImpl {
   [[nodiscard]] ErrorMessageOr<void> StartCapture();
   [[nodiscard]] ErrorMessageOr<void> StopCapture();
   [[nodiscard]] ErrorMessageOr<void> UpdateSelectedFunctions(
-      absl::Span<std::string const> selected_functions);
+      absl::Span<const std::string> selected_functions);
   void ShutdownService();
 
  private:
@@ -71,7 +71,7 @@ int CaptureClientGgpClient::StopCapture() {
 }
 
 int CaptureClientGgpClient::UpdateSelectedFunctions(
-    absl::Span<std::string const> selected_functions) {
+    absl::Span<const std::string> selected_functions) {
   ErrorMessageOr<void> result = pimpl->UpdateSelectedFunctions(selected_functions);
   if (result.has_error()) {
     ORBIT_ERROR("Not possible to update functions %s", result.error().message());
@@ -134,7 +134,7 @@ ErrorMessageOr<void> CaptureClientGgpClient::CaptureClientGgpClientImpl::StopCap
 }
 
 ErrorMessageOr<void> CaptureClientGgpClient::CaptureClientGgpClientImpl::UpdateSelectedFunctions(
-    absl::Span<std::string const> selected_functions) {
+    absl::Span<const std::string> selected_functions) {
   UpdateSelectedFunctionsRequest request;
   UpdateSelectedFunctionsResponse response;
   auto context = std::make_unique<ClientContext>();

--- a/src/OrbitCaptureGgpClient/OrbitCaptureGgpClient.cpp
+++ b/src/OrbitCaptureGgpClient/OrbitCaptureGgpClient.cpp
@@ -4,6 +4,7 @@
 
 #include "OrbitCaptureGgpClient/OrbitCaptureGgpClient.h"
 
+#include <absl/types/span.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/support/channel_arguments.h>
@@ -39,7 +40,7 @@ class CaptureClientGgpClient::CaptureClientGgpClientImpl {
   [[nodiscard]] ErrorMessageOr<void> StartCapture();
   [[nodiscard]] ErrorMessageOr<void> StopCapture();
   [[nodiscard]] ErrorMessageOr<void> UpdateSelectedFunctions(
-      const std::vector<std::string>& selected_functions);
+      absl::Span<std::string const> selected_functions);
   void ShutdownService();
 
  private:
@@ -70,7 +71,7 @@ int CaptureClientGgpClient::StopCapture() {
 }
 
 int CaptureClientGgpClient::UpdateSelectedFunctions(
-    const std::vector<std::string>& selected_functions) {
+    absl::Span<std::string const> selected_functions) {
   ErrorMessageOr<void> result = pimpl->UpdateSelectedFunctions(selected_functions);
   if (result.has_error()) {
     ORBIT_ERROR("Not possible to update functions %s", result.error().message());
@@ -133,7 +134,7 @@ ErrorMessageOr<void> CaptureClientGgpClient::CaptureClientGgpClientImpl::StopCap
 }
 
 ErrorMessageOr<void> CaptureClientGgpClient::CaptureClientGgpClientImpl::UpdateSelectedFunctions(
-    const std::vector<std::string>& selected_functions) {
+    absl::Span<std::string const> selected_functions) {
   UpdateSelectedFunctionsRequest request;
   UpdateSelectedFunctionsResponse response;
   auto context = std::make_unique<ClientContext>();

--- a/src/OrbitCaptureGgpClient/include/OrbitCaptureGgpClient/OrbitCaptureGgpClient.h
+++ b/src/OrbitCaptureGgpClient/include/OrbitCaptureGgpClient/OrbitCaptureGgpClient.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_CAPTURE_GGP_CLIENT_ORBIT_CAPTURE_GGP_CLIENT_H_
 #define ORBIT_CAPTURE_GGP_CLIENT_ORBIT_CAPTURE_GGP_CLIENT_H_
 
+#include <absl/types/span.h>
+
 #include <memory>
 #include <string>
 #include <string_view>
@@ -19,7 +21,7 @@ class CaptureClientGgpClient {
 
   int StartCapture();
   int StopCapture();
-  int UpdateSelectedFunctions(const std::vector<std::string>& selected_functions);
+  int UpdateSelectedFunctions(absl::Span<std::string const> selected_functions);
   void ShutdownService();
 
  private:

--- a/src/OrbitCaptureGgpClient/include/OrbitCaptureGgpClient/OrbitCaptureGgpClient.h
+++ b/src/OrbitCaptureGgpClient/include/OrbitCaptureGgpClient/OrbitCaptureGgpClient.h
@@ -21,7 +21,7 @@ class CaptureClientGgpClient {
 
   int StartCapture();
   int StopCapture();
-  int UpdateSelectedFunctions(absl::Span<std::string const> selected_functions);
+  int UpdateSelectedFunctions(absl::Span<const std::string> selected_functions);
   void ShutdownService();
 
  private:

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -140,7 +140,7 @@ CallTreeUnwindErrors* CallTreeNode::AddAndGetUnwindErrors() {
 
 static void AddCallstackToTopDownThread(
     CallTreeThread* thread_node, const CallstackInfo& resolved_callstack,
-    absl::Span<orbit_client_data::CallstackEvent const> callstack_events,
+    absl::Span<const orbit_client_data::CallstackEvent> callstack_events,
     const ModuleManager& module_manager, const CaptureData& capture_data) {
   uint64_t callstack_sample_count = callstack_events.size();
 
@@ -164,7 +164,7 @@ static void AddCallstackToTopDownThread(
 
 static void AddUnwindErrorToTopDownThread(
     CallTreeThread* thread_node, const CallstackInfo& resolved_callstack,
-    absl::Span<orbit_client_data::CallstackEvent const> callstack_events,
+    absl::Span<const orbit_client_data::CallstackEvent> callstack_events,
     const ModuleManager& module_manager, const CaptureData& capture_data) {
   CallTreeUnwindErrors* unwind_errors_node = thread_node->GetUnwindErrorsOrNull();
   if (unwind_errors_node == nullptr) {

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -8,6 +8,7 @@
 #include <absl/container/node_hash_map.h>
 #include <absl/meta/type_traits.h>
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 
 #include <string_view>
 
@@ -139,7 +140,7 @@ CallTreeUnwindErrors* CallTreeNode::AddAndGetUnwindErrors() {
 
 static void AddCallstackToTopDownThread(
     CallTreeThread* thread_node, const CallstackInfo& resolved_callstack,
-    const std::vector<orbit_client_data::CallstackEvent>& callstack_events,
+    absl::Span<orbit_client_data::CallstackEvent const> callstack_events,
     const ModuleManager& module_manager, const CaptureData& capture_data) {
   uint64_t callstack_sample_count = callstack_events.size();
 
@@ -163,7 +164,7 @@ static void AddCallstackToTopDownThread(
 
 static void AddUnwindErrorToTopDownThread(
     CallTreeThread* thread_node, const CallstackInfo& resolved_callstack,
-    const std::vector<orbit_client_data::CallstackEvent>& callstack_events,
+    absl::Span<orbit_client_data::CallstackEvent const> callstack_events,
     const ModuleManager& module_manager, const CaptureData& capture_data) {
   CallTreeUnwindErrors* unwind_errors_node = thread_node->GetUnwindErrorsOrNull();
   if (unwind_errors_node == nullptr) {

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -237,7 +237,7 @@ orbit_data_views::PresetLoadState GetPresetLoadStateForProcess(const PresetFile&
 // the result vector. After iterating through the prio_substring list, all remaining (not found)
 // modules are added to the result vector.
 [[nodiscard]] std::vector<const ModuleData*> SortModuleListWithPrioritizationList(
-    std::vector<const ModuleData*> modules, absl::Span<std::string_view const> prio_substrings) {
+    std::vector<const ModuleData*> modules, absl::Span<const std::string_view> prio_substrings) {
   std::vector<const ModuleData*> prioritized_modules;
   prioritized_modules.reserve(modules.size());
 
@@ -1880,14 +1880,14 @@ Future<ErrorMessageOr<void>> OrbitApp::UpdateProcessAndModuleList() {
       [this] { return process_manager_->LoadModuleList(GetTargetProcess()->pid()); });
 
   auto all_reloaded_modules = module_infos.ThenIfSuccess(
-      main_thread_executor_, [this](absl::Span<orbit_grpc_protos::ModuleInfo const> module_infos) {
+      main_thread_executor_, [this](absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos) {
         return ReloadModules(module_infos);
       });
 
   // `all_modules_reloaded` is a future in a future. So we have to unwrap here.
   return orbit_base::UnwrapFuture(all_reloaded_modules)
       .ThenIfSuccess(main_thread_executor_,
-                     [this](absl::Span<ErrorMessageOr<void> const> reload_results) {
+                     [this](absl::Span<const ErrorMessageOr<void>> reload_results) {
                        // We ignore whether reloading a particular module failed to preserve the
                        // behaviour from before refactoring this. This can be changed in the future.
                        std::ignore = reload_results;
@@ -2264,7 +2264,7 @@ uint64_t OrbitApp::GetGroupIdToHighlight() const {
 }
 
 void OrbitApp::SetCaptureDataSelectionFields(
-    absl::Span<CallstackEvent const> selected_callstack_events, bool origin_is_multiple_threads) {
+    absl::Span<const CallstackEvent> selected_callstack_events, bool origin_is_multiple_threads) {
   const CallstackData& callstack_data = GetCaptureData().GetCallstackData();
   std::unique_ptr<CallstackData> selection_callstack_data = std::make_unique<CallstackData>();
   for (const CallstackEvent& event : selected_callstack_events) {
@@ -2281,7 +2281,7 @@ void OrbitApp::SetCaptureDataSelectionFields(
       std::move(selection_post_processed_sampling_data));
 }
 
-void OrbitApp::SelectCallstackEvents(absl::Span<CallstackEvent const> selected_callstack_events,
+void OrbitApp::SelectCallstackEvents(absl::Span<const CallstackEvent> selected_callstack_events,
                                      bool origin_is_multiple_threads) {
   main_window_->ClearCallstackInspection();
   SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
@@ -2294,7 +2294,7 @@ void OrbitApp::SelectCallstackEvents(absl::Span<CallstackEvent const> selected_c
                      /*has_summary*/ origin_is_multiple_threads);
 }
 
-void OrbitApp::InspectCallstackEvents(absl::Span<CallstackEvent const> selected_callstack_events,
+void OrbitApp::InspectCallstackEvents(absl::Span<const CallstackEvent> selected_callstack_events,
                                       bool origin_is_multiple_threads) {
   SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
   std::unique_ptr<SamplingReport> report =

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -16,6 +16,7 @@
 #include <absl/synchronization/mutex.h>
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
+#include <absl/types/span.h>
 #include <errno.h>
 #include <google/protobuf/stubs/port.h>
 #include <stdio.h>
@@ -1879,15 +1880,14 @@ Future<ErrorMessageOr<void>> OrbitApp::UpdateProcessAndModuleList() {
       [this] { return process_manager_->LoadModuleList(GetTargetProcess()->pid()); });
 
   auto all_reloaded_modules = module_infos.ThenIfSuccess(
-      main_thread_executor_,
-      [this](const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos) {
+      main_thread_executor_, [this](absl::Span<orbit_grpc_protos::ModuleInfo const> module_infos) {
         return ReloadModules(module_infos);
       });
 
   // `all_modules_reloaded` is a future in a future. So we have to unwrap here.
   return orbit_base::UnwrapFuture(all_reloaded_modules)
       .ThenIfSuccess(main_thread_executor_,
-                     [this](const std::vector<ErrorMessageOr<void>>& reload_results) {
+                     [this](absl::Span<ErrorMessageOr<void> const> reload_results) {
                        // We ignore whether reloading a particular module failed to preserve the
                        // behaviour from before refactoring this. This can be changed in the future.
                        std::ignore = reload_results;
@@ -2264,7 +2264,7 @@ uint64_t OrbitApp::GetGroupIdToHighlight() const {
 }
 
 void OrbitApp::SetCaptureDataSelectionFields(
-    const std::vector<CallstackEvent>& selected_callstack_events, bool origin_is_multiple_threads) {
+    absl::Span<CallstackEvent const> selected_callstack_events, bool origin_is_multiple_threads) {
   const CallstackData& callstack_data = GetCaptureData().GetCallstackData();
   std::unique_ptr<CallstackData> selection_callstack_data = std::make_unique<CallstackData>();
   for (const CallstackEvent& event : selected_callstack_events) {
@@ -2281,7 +2281,7 @@ void OrbitApp::SetCaptureDataSelectionFields(
       std::move(selection_post_processed_sampling_data));
 }
 
-void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
+void OrbitApp::SelectCallstackEvents(absl::Span<CallstackEvent const> selected_callstack_events,
                                      bool origin_is_multiple_threads) {
   main_window_->ClearCallstackInspection();
   SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
@@ -2294,7 +2294,7 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
                      /*has_summary*/ origin_is_multiple_threads);
 }
 
-void OrbitApp::InspectCallstackEvents(const std::vector<CallstackEvent>& selected_callstack_events,
+void OrbitApp::InspectCallstackEvents(absl::Span<CallstackEvent const> selected_callstack_events,
                                       bool origin_is_multiple_threads) {
   SetCaptureDataSelectionFields(selected_callstack_events, origin_is_multiple_threads);
   std::unique_ptr<SamplingReport> report =

--- a/src/OrbitGl/SchedulingStats.cpp
+++ b/src/OrbitGl/SchedulingStats.cpp
@@ -5,6 +5,7 @@
 #include "OrbitGl/SchedulingStats.h"
 
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 
 #include <algorithm>
 
@@ -15,7 +16,7 @@ using orbit_client_protos::TimerInfo;
 
 static constexpr double kNsToMs = 1 / 1000000.0;
 
-SchedulingStats::SchedulingStats(const std::vector<const TimerInfo*>& scheduling_scopes,
+SchedulingStats::SchedulingStats(absl::Span<const TimerInfo* const> scheduling_scopes,
                                  const ThreadNameProvider& thread_name_provider, uint64_t start_ns,
                                  uint64_t end_ns) {
   time_range_ms_ = static_cast<double>(end_ns - start_ns) * kNsToMs;

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -7,6 +7,7 @@
 #include <GteVector.h>
 #include <absl/flags/flag.h>
 #include <absl/time/time.h>
+#include <absl/types/span.h>
 
 #include <algorithm>
 #include <optional>
@@ -151,7 +152,7 @@ float TimelineUi::GetTickWorldXPos(uint64_t tick_ns) const {
 }
 
 std::vector<uint64_t> TimelineUi::GetTicksForNonOverlappingLabels(
-    TextRenderer& text_renderer, const std::vector<uint64_t>& all_major_ticks) const {
+    TextRenderer& text_renderer, absl::Span<uint64_t const> all_major_ticks) const {
   if (all_major_ticks.size() <= 1) return all_major_ticks;
   uint64_t ns_between_major_ticks = all_major_ticks[1] - all_major_ticks[0];
 
@@ -176,7 +177,7 @@ std::vector<uint64_t> TimelineUi::GetTicksForNonOverlappingLabels(
 }
 
 bool TimelineUi::WillLabelsOverlap(TextRenderer& text_renderer,
-                                   const std::vector<uint64_t>& tick_list) const {
+                                   absl::Span<uint64_t const> tick_list) const {
   if (tick_list.size() <= 1) return false;
   float distance_between_labels = GetTickWorldXPos(tick_list[1]) - GetTickWorldXPos(tick_list[0]);
   for (auto tick_ns : tick_list) {

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -153,14 +153,14 @@ float TimelineUi::GetTickWorldXPos(uint64_t tick_ns) const {
 
 std::vector<uint64_t> TimelineUi::GetTicksForNonOverlappingLabels(
     TextRenderer& text_renderer, absl::Span<const uint64_t> all_major_ticks) const {
-  if (all_major_ticks.size() <= 1) return all_major_ticks;
+  if (all_major_ticks.size() <= 1) return {all_major_ticks.begin(), all_major_ticks.end()};
   uint64_t ns_between_major_ticks = all_major_ticks[1] - all_major_ticks[0];
 
   // In general, all major tick labels will fit in screen. In extreme cases with long labels
   // and small screens, we will skip the same number of labels in between visible ones for
   // consistency.
   int num_consecutive_skipped_labels = 0;
-  std::vector<uint64_t> visible_labels = all_major_ticks;
+  std::vector<uint64_t> visible_labels{all_major_ticks.begin(), all_major_ticks.end()};
   while (WillLabelsOverlap(text_renderer, visible_labels)) {
     visible_labels.clear();
     num_consecutive_skipped_labels++;

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -152,7 +152,7 @@ float TimelineUi::GetTickWorldXPos(uint64_t tick_ns) const {
 }
 
 std::vector<uint64_t> TimelineUi::GetTicksForNonOverlappingLabels(
-    TextRenderer& text_renderer, absl::Span<uint64_t const> all_major_ticks) const {
+    TextRenderer& text_renderer, absl::Span<const uint64_t> all_major_ticks) const {
   if (all_major_ticks.size() <= 1) return all_major_ticks;
   uint64_t ns_between_major_ticks = all_major_ticks[1] - all_major_ticks[0];
 
@@ -177,7 +177,7 @@ std::vector<uint64_t> TimelineUi::GetTicksForNonOverlappingLabels(
 }
 
 bool TimelineUi::WillLabelsOverlap(TextRenderer& text_renderer,
-                                   absl::Span<uint64_t const> tick_list) const {
+                                   absl::Span<const uint64_t> tick_list) const {
   if (tick_list.size() <= 1) return false;
   float distance_between_labels = GetTickWorldXPos(tick_list[1]) - GetTickWorldXPos(tick_list[0]);
   for (auto tick_ns : tick_list) {

--- a/src/OrbitGl/TrackRenderHelper.cpp
+++ b/src/OrbitGl/TrackRenderHelper.cpp
@@ -6,6 +6,7 @@
 
 #include <GteVector.h>
 #include <GteVector2.h>
+#include <absl/types/span.h>
 #include <stddef.h>
 
 #include <cmath>
@@ -14,7 +15,7 @@
 
 namespace {
 
-std::vector<Vec2> RotatePoints(const std::vector<Vec2>& points, float rotation) {
+std::vector<Vec2> RotatePoints(absl::Span<Vec2 const> points, float rotation) {
   float cos_r = std::cos(kPiFloat * rotation / 180.f);
   float sin_r = std::sin(kPiFloat * rotation / 180.f);
   std::vector<Vec2> result;
@@ -45,7 +46,7 @@ std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
   return points;
 }
 
-void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, const std::vector<Vec2>& points,
+void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, absl::Span<Vec2 const> points,
                      const Vec2& pos, const Color& color, float rotation, float z,
                      std::shared_ptr<Pickable> pickable) {
   if (points.size() < 3) {

--- a/src/OrbitGl/TrackRenderHelper.cpp
+++ b/src/OrbitGl/TrackRenderHelper.cpp
@@ -15,7 +15,7 @@
 
 namespace {
 
-std::vector<Vec2> RotatePoints(absl::Span<Vec2 const> points, float rotation) {
+std::vector<Vec2> RotatePoints(absl::Span<const Vec2> points, float rotation) {
   float cos_r = std::cos(kPiFloat * rotation / 180.f);
   float sin_r = std::sin(kPiFloat * rotation / 180.f);
   std::vector<Vec2> result;
@@ -46,7 +46,7 @@ std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
   return points;
 }
 
-void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, absl::Span<Vec2 const> points,
+void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, absl::Span<const Vec2> points,
                      const Vec2& pos, const Color& color, float rotation, float z,
                      std::shared_ptr<Pickable> pickable) {
   if (points.size() < 3) {

--- a/src/OrbitGl/include/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/include/OrbitGl/CallTreeView.h
@@ -94,7 +94,7 @@ class CallTreeNode {
   }
 
   void AddExclusiveCallstackEvents(
-      absl::Span<orbit_client_data::CallstackEvent const> callstack_events) {
+      absl::Span<const orbit_client_data::CallstackEvent> callstack_events) {
     exclusive_callstack_events_.insert(exclusive_callstack_events_.end(), callstack_events.begin(),
                                        callstack_events.end());
   }

--- a/src/OrbitGl/include/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/include/OrbitGl/CallTreeView.h
@@ -7,6 +7,7 @@
 
 #include <absl/container/node_hash_map.h>
 #include <absl/hash/hash.h>
+#include <absl/types/span.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -93,7 +94,7 @@ class CallTreeNode {
   }
 
   void AddExclusiveCallstackEvents(
-      const std::vector<orbit_client_data::CallstackEvent>& callstack_events) {
+      absl::Span<orbit_client_data::CallstackEvent const> callstack_events) {
     exclusive_callstack_events_.insert(exclusive_callstack_events_.end(), callstack_events.begin(),
                                        callstack_events.end());
   }

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -466,10 +466,10 @@ class OrbitApp final : public DataViewFactory,
   // origin_is_multiple_threads defines if the selection is specific to a single thread,
   // or spans across multiple threads.
   void SelectCallstackEvents(
-      absl::Span<orbit_client_data::CallstackEvent const> selected_callstack_events,
+      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events,
       bool origin_is_multiple_threads);
   void InspectCallstackEvents(
-      absl::Span<orbit_client_data::CallstackEvent const> selected_callstack_events,
+      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events,
       bool origin_is_multiple_threads);
   void ClearInspection();
 
@@ -599,7 +599,7 @@ class OrbitApp final : public DataViewFactory,
 
   // Sets CaptureData's selection_callstack_data and selection_post_processed_sampling_data.
   void SetCaptureDataSelectionFields(
-      absl::Span<orbit_client_data::CallstackEvent const> selected_callstack_events,
+      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events,
       bool origin_is_multiple_threads);
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -466,10 +466,10 @@ class OrbitApp final : public DataViewFactory,
   // origin_is_multiple_threads defines if the selection is specific to a single thread,
   // or spans across multiple threads.
   void SelectCallstackEvents(
-      const std::vector<orbit_client_data::CallstackEvent>& selected_callstack_events,
+      absl::Span<orbit_client_data::CallstackEvent const> selected_callstack_events,
       bool origin_is_multiple_threads);
   void InspectCallstackEvents(
-      const std::vector<orbit_client_data::CallstackEvent>& selected_callstack_events,
+      absl::Span<orbit_client_data::CallstackEvent const> selected_callstack_events,
       bool origin_is_multiple_threads);
   void ClearInspection();
 
@@ -599,7 +599,7 @@ class OrbitApp final : public DataViewFactory,
 
   // Sets CaptureData's selection_callstack_data and selection_post_processed_sampling_data.
   void SetCaptureDataSelectionFields(
-      const std::vector<orbit_client_data::CallstackEvent>& selected_callstack_events,
+      absl::Span<orbit_client_data::CallstackEvent const> selected_callstack_events,
       bool origin_is_multiple_threads);
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;

--- a/src/OrbitGl/include/OrbitGl/SchedulingStats.h
+++ b/src/OrbitGl/include/OrbitGl/SchedulingStats.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_SCHEDULING_STATS_H_
 #define ORBIT_GL_SCHEDULING_STATS_H_
 
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <functional>
@@ -27,7 +28,7 @@ class SchedulingStats {
   using ThreadNameProvider = std::function<std::string(int32_t)>;
 
   SchedulingStats() = delete;
-  SchedulingStats(const std::vector<const orbit_client_protos::TimerInfo*>& scheduling_scopes,
+  SchedulingStats(absl::Span<const orbit_client_protos::TimerInfo* const> scheduling_scopes,
                   const ThreadNameProvider& thread_name_provider, uint64_t start_ns,
                   uint64_t end_ns);
 

--- a/src/OrbitGl/include/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/include/OrbitGl/TimelineUi.h
@@ -61,9 +61,9 @@ class TimelineUi : public CaptureViewElement {
                         uint64_t mouse_tick_ns) const;
   [[nodiscard]] std::string GetLabel(uint64_t tick_ns, uint32_t number_of_decimal_places) const;
   [[nodiscard]] std::vector<uint64_t> GetTicksForNonOverlappingLabels(
-      TextRenderer& text_renderer, absl::Span<uint64_t const> all_major_ticks) const;
+      TextRenderer& text_renderer, absl::Span<const uint64_t> all_major_ticks) const;
   [[nodiscard]] bool WillLabelsOverlap(TextRenderer& text_renderer,
-                                       absl::Span<uint64_t const> tick_list) const;
+                                       absl::Span<const uint64_t> tick_list) const;
   [[nodiscard]] float GetTickWorldXPos(uint64_t tick_ns) const;
   [[nodiscard]] uint32_t GetNumDecimalsInLabels() const { return num_decimals_in_labels_; }
   void UpdateNumDecimalsInLabels(uint64_t min_timestamp_ns, uint64_t max_timestamp_ns);

--- a/src/OrbitGl/include/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/include/OrbitGl/TimelineUi.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_TIMELINE_UI_H_
 #define ORBIT_GL_TIMELINE_UI_H_
 
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <memory>
@@ -60,9 +61,9 @@ class TimelineUi : public CaptureViewElement {
                         uint64_t mouse_tick_ns) const;
   [[nodiscard]] std::string GetLabel(uint64_t tick_ns, uint32_t number_of_decimal_places) const;
   [[nodiscard]] std::vector<uint64_t> GetTicksForNonOverlappingLabels(
-      TextRenderer& text_renderer, const std::vector<uint64_t>& all_major_ticks) const;
+      TextRenderer& text_renderer, absl::Span<uint64_t const> all_major_ticks) const;
   [[nodiscard]] bool WillLabelsOverlap(TextRenderer& text_renderer,
-                                       const std::vector<uint64_t>& tick_list) const;
+                                       absl::Span<uint64_t const> tick_list) const;
   [[nodiscard]] float GetTickWorldXPos(uint64_t tick_ns) const;
   [[nodiscard]] uint32_t GetNumDecimalsInLabels() const { return num_decimals_in_labels_; }
   void UpdateNumDecimalsInLabels(uint64_t min_timestamp_ns, uint64_t max_timestamp_ns);

--- a/src/OrbitGl/include/OrbitGl/TrackRenderHelper.h
+++ b/src/OrbitGl/include/OrbitGl/TrackRenderHelper.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_TRACK_RENDER_HELPER_H_
 #define ORBIT_GL_TRACK_RENDER_HELPER_H_
 
+#include <absl/types/span.h>
 #include <stdint.h>
 
 #include <memory>
@@ -16,7 +17,7 @@
 
 // Contains free functions used to render track elements such as rounded corners.
 namespace orbit_gl {
-void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, const std::vector<Vec2>& points,
+void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, absl::Span<Vec2 const> points,
                      const Vec2& pos, const Color& color, float rotation, float z,
                      std::shared_ptr<Pickable> pickable);
 [[nodiscard]] std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides);

--- a/src/OrbitGl/include/OrbitGl/TrackRenderHelper.h
+++ b/src/OrbitGl/include/OrbitGl/TrackRenderHelper.h
@@ -17,7 +17,7 @@
 
 // Contains free functions used to render track elements such as rounded corners.
 namespace orbit_gl {
-void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, absl::Span<Vec2 const> points,
+void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, absl::Span<const Vec2> points,
                      const Vec2& pos, const Color& color, float rotation, float z,
                      std::shared_ptr<Pickable> pickable);
 [[nodiscard]] std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides);

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -763,7 +763,8 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
     app_->InspectCallstackEvents(
         // This copies the content of the absl::flat_hash_set into a std::vector. We consider this
         // fine in order to keep OrbitApp::InspectCallstackEvents as simple as it is now.
-        {selected_callstack_events.begin(), selected_callstack_events.end()},
+        std::vector<orbit_client_data::CallstackEvent>{selected_callstack_events.begin(),
+                                                       selected_callstack_events.end()},
         origin_is_multiple_threads);
   } else if (action->text() == kActionSelectCallstacks) {
     absl::flat_hash_set<orbit_client_data::CallstackEvent> selected_callstack_events =
@@ -778,7 +779,8 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
     app_->SelectCallstackEvents(
         // This copies the content of the absl::flat_hash_set into a std::vector. We consider this
         // fine in order to keep OrbitApp::SelectCallstackEvents as simple as it is now.
-        {selected_callstack_events.begin(), selected_callstack_events.end()},
+        std::vector<orbit_client_data::CallstackEvent>{selected_callstack_events.begin(),
+                                                       selected_callstack_events.end()},
         origin_is_multiple_threads);
   } else if (action->text() == kActionCopySelection) {
     app_->SetClipboard(BuildStringFromIndices(

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -521,7 +521,7 @@ static void CollapseChildrenRecursively(QTreeView* tree_view, const QModelIndex&
 }
 
 static std::vector<ModuleData*> GetModulesFromIndices(OrbitApp* app,
-                                                      absl::Span<QModelIndex const> indices) {
+                                                      absl::Span<const QModelIndex> indices) {
   absl::flat_hash_set<ModuleIdentifier> unique_module_ids;
   for (const auto& index : indices) {
     const QModelIndex model_index =
@@ -544,7 +544,7 @@ static std::vector<ModuleData*> GetModulesFromIndices(OrbitApp* app,
 }
 
 static std::vector<const FunctionInfo*> GetFunctionsFromIndices(
-    OrbitApp* app, absl::Span<QModelIndex const> indices) {
+    OrbitApp* app, absl::Span<const QModelIndex> indices) {
   absl::flat_hash_set<const FunctionInfo*> functions_set;
   const CaptureData& capture_data = app->GetCaptureData();
   const ModuleManager* module_manager = app->GetModuleManager();
@@ -594,7 +594,7 @@ static void GetCallstackEventsUnderSelectionRecursively(
 }
 
 static absl::flat_hash_set<orbit_client_data::CallstackEvent> GetCallstackEventsUnderSelection(
-    absl::Span<QModelIndex const> indices) {
+    absl::Span<const QModelIndex> indices) {
   // We can have duplicate CallstackEvents in the selection, e.g., with the top-down view when
   // selecting both from the "(all threads)" tree and other single-thread trees. Hence the set.
   absl::flat_hash_set<orbit_client_data::CallstackEvent> callstack_events;

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -8,6 +8,7 @@
 #include <absl/flags/flag.h>
 #include <absl/hash/hash.h>
 #include <absl/strings/match.h>
+#include <absl/types/span.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -520,7 +521,7 @@ static void CollapseChildrenRecursively(QTreeView* tree_view, const QModelIndex&
 }
 
 static std::vector<ModuleData*> GetModulesFromIndices(OrbitApp* app,
-                                                      const std::vector<QModelIndex>& indices) {
+                                                      absl::Span<QModelIndex const> indices) {
   absl::flat_hash_set<ModuleIdentifier> unique_module_ids;
   for (const auto& index : indices) {
     const QModelIndex model_index =
@@ -543,7 +544,7 @@ static std::vector<ModuleData*> GetModulesFromIndices(OrbitApp* app,
 }
 
 static std::vector<const FunctionInfo*> GetFunctionsFromIndices(
-    OrbitApp* app, const std::vector<QModelIndex>& indices) {
+    OrbitApp* app, absl::Span<QModelIndex const> indices) {
   absl::flat_hash_set<const FunctionInfo*> functions_set;
   const CaptureData& capture_data = app->GetCaptureData();
   const ModuleManager* module_manager = app->GetModuleManager();
@@ -593,7 +594,7 @@ static void GetCallstackEventsUnderSelectionRecursively(
 }
 
 static absl::flat_hash_set<orbit_client_data::CallstackEvent> GetCallstackEventsUnderSelection(
-    const std::vector<QModelIndex>& indices) {
+    absl::Span<QModelIndex const> indices) {
   // We can have duplicate CallstackEvents in the selection, e.g., with the top-down view when
   // selecting both from the "(all threads)" tree and other single-thread trees. Hence the set.
   absl::flat_hash_set<orbit_client_data::CallstackEvent> callstack_events;

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -130,7 +130,7 @@ static void DrawVerticalLine(QPainter& painter, const QPoint& start, int length)
 // Hence, we choose the step leading to the number of ticks closest to `optimal_tick_count`.
 // If the available tick count is either 0 or 1, the step yielding zero ticks may be returned.
 [[nodiscard]] static TickStep ChooseBestStep(double min, double max,
-                                             const std::vector<TickStep>& steps,
+                                             absl::Span<TickStep const> steps,
                                              uint32_t optimal_tick_count) {
   std::optional<TickStep> best_step;
   int best_deviation = std::numeric_limits<int>::max();
@@ -156,7 +156,7 @@ struct Ticks {
 };
 }  // namespace
 
-[[nodiscard]] static Ticks MakeTicksFromValues(const std::vector<double>& values, int precision) {
+[[nodiscard]] static Ticks MakeTicksFromValues(absl::Span<double const> values, int precision) {
   std::vector<QString> labels;
   std::transform(
       std::begin(values), std::end(values), std::back_inserter(labels),
@@ -164,7 +164,7 @@ struct Ticks {
   return {labels, values, precision};
 }
 
-[[nodiscard]] static Ticks MakeTicks(double min, double max, const std::vector<TickStep>& steps,
+[[nodiscard]] static Ticks MakeTicks(double min, double max, absl::Span<TickStep const> steps,
                                      uint32_t optimal_tick_count) {
   TickStep step = ChooseBestStep(min, max, steps, optimal_tick_count);
   std::vector<double> values = MakeLabelValues(min, max, step.value);

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -156,12 +156,12 @@ struct Ticks {
 };
 }  // namespace
 
-[[nodiscard]] static Ticks MakeTicksFromValues(absl::Span<const double> values, int precision) {
+[[nodiscard]] static Ticks MakeTicksFromValues(std::vector<double> values, int precision) {
   std::vector<QString> labels;
   std::transform(
       std::begin(values), std::end(values), std::back_inserter(labels),
       [precision](const double value) { return QString::number(value, 'f', precision); });
-  return {labels, values, precision};
+  return {labels, std::move(values), precision};
 }
 
 [[nodiscard]] static Ticks MakeTicks(double min, double max, absl::Span<const TickStep> steps,

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -130,7 +130,7 @@ static void DrawVerticalLine(QPainter& painter, const QPoint& start, int length)
 // Hence, we choose the step leading to the number of ticks closest to `optimal_tick_count`.
 // If the available tick count is either 0 or 1, the step yielding zero ticks may be returned.
 [[nodiscard]] static TickStep ChooseBestStep(double min, double max,
-                                             absl::Span<TickStep const> steps,
+                                             absl::Span<const TickStep> steps,
                                              uint32_t optimal_tick_count) {
   std::optional<TickStep> best_step;
   int best_deviation = std::numeric_limits<int>::max();
@@ -156,7 +156,7 @@ struct Ticks {
 };
 }  // namespace
 
-[[nodiscard]] static Ticks MakeTicksFromValues(absl::Span<double const> values, int precision) {
+[[nodiscard]] static Ticks MakeTicksFromValues(absl::Span<const double> values, int precision) {
   std::vector<QString> labels;
   std::transform(
       std::begin(values), std::end(values), std::back_inserter(labels),
@@ -164,7 +164,7 @@ struct Ticks {
   return {labels, values, precision};
 }
 
-[[nodiscard]] static Ticks MakeTicks(double min, double max, absl::Span<TickStep const> steps,
+[[nodiscard]] static Ticks MakeTicks(double min, double max, absl::Span<const TickStep> steps,
                                      uint32_t optimal_tick_count) {
   TickStep step = ChooseBestStep(min, max, steps, optimal_tick_count);
   std::vector<double> values = MakeLabelValues(min, max, step.value);

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -219,7 +219,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   void UpdateTargetLabelPosition();
 
-  void OnProcessListUpdated(absl::Span<orbit_grpc_protos::ProcessInfo const> processes);
+  void OnProcessListUpdated(absl::Span<const orbit_grpc_protos::ProcessInfo> processes);
 
   void ExecuteSymbolLocationsDialog(std::optional<const orbit_client_data::ModuleData*> module);
 

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -6,6 +6,7 @@
 #define ORBIT_QT_ORBIT_MAIN_WINDOW_H_
 
 #include <absl/time/time.h>
+#include <absl/types/span.h>
 #include <stddef.h>
 
 #include <QApplication>
@@ -218,7 +219,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   void UpdateTargetLabelPosition();
 
-  void OnProcessListUpdated(const std::vector<orbit_grpc_protos::ProcessInfo>& processes);
+  void OnProcessListUpdated(absl::Span<orbit_grpc_protos::ProcessInfo const> processes);
 
   void ExecuteSymbolLocationsDialog(std::optional<const orbit_client_data::ModuleData*> module);
 

--- a/src/OrbitQt/include/OrbitQt/orbittablemodel.h
+++ b/src/OrbitQt/include/OrbitQt/orbittablemodel.h
@@ -48,7 +48,7 @@ class OrbitTableModel : public QAbstractTableModel {
 
   void OnTimer();
   void OnFilter(const QString& filter);
-  void OnRowsSelected(absl::Span<int const> rows);
+  void OnRowsSelected(absl::Span<const int> rows);
 
  protected:
   orbit_data_views::DataView* data_view_;

--- a/src/OrbitQt/include/OrbitQt/orbittablemodel.h
+++ b/src/OrbitQt/include/OrbitQt/orbittablemodel.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_QT_ORBIT_TABLE_MODEL_H_
 #define ORBIT_QT_ORBIT_TABLE_MODEL_H_
 
+#include <absl/types/span.h>
+
 #include <QAbstractTableModel>
 #include <QFlags>
 #include <QModelIndex>
@@ -46,7 +48,7 @@ class OrbitTableModel : public QAbstractTableModel {
 
   void OnTimer();
   void OnFilter(const QString& filter);
-  void OnRowsSelected(const std::vector<int>& rows);
+  void OnRowsSelected(absl::Span<int const> rows);
 
  protected:
   orbit_data_views::DataView* data_view_;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1770,7 +1770,7 @@ void OrbitMainWindow::UpdateTargetLabelPosition() {
 }
 
 void OrbitMainWindow::OnProcessListUpdated(
-    absl::Span<orbit_grpc_protos::ProcessInfo const> processes) {
+    absl::Span<const orbit_grpc_protos::ProcessInfo> processes) {
   const auto is_current_process = [this](const auto& process) {
     const orbit_client_data::ProcessData* const target_process = app_->GetTargetProcess();
     return target_process != nullptr && process.pid() == app_->GetTargetProcess()->pid();

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -8,6 +8,7 @@
 #include <absl/flags/flag.h>
 #include <absl/strings/match.h>
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 
 #include <QAction>
 #include <QApplication>
@@ -746,7 +747,7 @@ void OrbitMainWindow::UpdateActiveTabsAfterSelection(bool selection_has_samples)
   // Automatically switch between (complete capture) report and selection report tabs
   // if applicable
   auto show_corresponding_selection_tab = [this, capture_parent, selection_has_samples](
-                                              const std::vector<QWidget*>& report_tabs,
+                                              absl::Span<QWidget* const> report_tabs,
                                               QWidget* selection_tab) {
     QTabWidget* selection_parent = FindParentTabWidget(selection_tab);
 
@@ -1769,7 +1770,7 @@ void OrbitMainWindow::UpdateTargetLabelPosition() {
 }
 
 void OrbitMainWindow::OnProcessListUpdated(
-    const std::vector<orbit_grpc_protos::ProcessInfo>& processes) {
+    absl::Span<orbit_grpc_protos::ProcessInfo const> processes) {
   const auto is_current_process = [this](const auto& process) {
     const orbit_client_data::ProcessData* const target_process = app_->GetTargetProcess();
     return target_process != nullptr && process.pid() == app_->GetTargetProcess()->pid();

--- a/src/OrbitQt/orbittablemodel.cpp
+++ b/src/OrbitQt/orbittablemodel.cpp
@@ -4,6 +4,8 @@
 
 #include "OrbitQt/orbittablemodel.h"
 
+#include <absl/types/span.h>
+
 #include <QColor>
 #include <string>
 #include <vector>
@@ -100,4 +102,4 @@ void OrbitTableModel::OnFilter(const QString& filter) {
   data_view_->OnFilter(filter.toStdString());
 }
 
-void OrbitTableModel::OnRowsSelected(const std::vector<int>& rows) { data_view_->OnSelect(rows); }
+void OrbitTableModel::OnRowsSelected(absl::Span<int const> rows) { data_view_->OnSelect(rows); }

--- a/src/OrbitQt/orbittablemodel.cpp
+++ b/src/OrbitQt/orbittablemodel.cpp
@@ -102,4 +102,4 @@ void OrbitTableModel::OnFilter(const QString& filter) {
   data_view_->OnFilter(filter.toStdString());
 }
 
-void OrbitTableModel::OnRowsSelected(absl::Span<int const> rows) { data_view_->OnSelect(rows); }
+void OrbitTableModel::OnRowsSelected(absl::Span<const int> rows) { data_view_->OnSelect(rows); }

--- a/src/OrbitVulkanLayer/TimerQueryPool.h
+++ b/src/OrbitVulkanLayer/TimerQueryPool.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/synchronization/mutex.h>
+#include <absl/types/span.h>
 #include <vulkan/vulkan.h>
 
 #include <fstream>
@@ -145,7 +146,7 @@ class TimerQueryPool {
   // Note that the pool must be initialized using `InitializeTimerQueryPool` before.
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
-  void MarkQuerySlotsDoneReading(VkDevice device, const std::vector<uint32_t>& slot_indices) {
+  void MarkQuerySlotsDoneReading(VkDevice device, absl::Span<uint32_t const> slot_indices) {
     if (slot_indices.empty()) {
       return;
     }
@@ -180,7 +181,7 @@ class TimerQueryPool {
   // Note that the pool must be initialized using `InitializeTimerQueryPool` before.
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
-  void MarkQuerySlotsForReset(VkDevice device, const std::vector<uint32_t>& slot_indices) {
+  void MarkQuerySlotsForReset(VkDevice device, absl::Span<uint32_t const> slot_indices) {
     if (slot_indices.empty()) {
       return;
     }
@@ -212,7 +213,7 @@ class TimerQueryPool {
   // Note that the pool must be initialized using `InitializeTimerQueryPool` before.
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
-  void RollbackPendingQuerySlots(VkDevice device, const std::vector<uint32_t>& slot_indices) {
+  void RollbackPendingQuerySlots(VkDevice device, absl::Span<uint32_t const> slot_indices) {
     if (slot_indices.empty()) {
       return;
     }

--- a/src/OrbitVulkanLayer/TimerQueryPool.h
+++ b/src/OrbitVulkanLayer/TimerQueryPool.h
@@ -146,7 +146,7 @@ class TimerQueryPool {
   // Note that the pool must be initialized using `InitializeTimerQueryPool` before.
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
-  void MarkQuerySlotsDoneReading(VkDevice device, absl::Span<uint32_t const> slot_indices) {
+  void MarkQuerySlotsDoneReading(VkDevice device, absl::Span<const uint32_t> slot_indices) {
     if (slot_indices.empty()) {
       return;
     }
@@ -181,7 +181,7 @@ class TimerQueryPool {
   // Note that the pool must be initialized using `InitializeTimerQueryPool` before.
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
-  void MarkQuerySlotsForReset(VkDevice device, absl::Span<uint32_t const> slot_indices) {
+  void MarkQuerySlotsForReset(VkDevice device, absl::Span<const uint32_t> slot_indices) {
     if (slot_indices.empty()) {
       return;
     }
@@ -213,7 +213,7 @@ class TimerQueryPool {
   // Note that the pool must be initialized using `InitializeTimerQueryPool` before.
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
-  void RollbackPendingQuerySlots(VkDevice device, absl::Span<uint32_t const> slot_indices) {
+  void RollbackPendingQuerySlots(VkDevice device, absl::Span<const uint32_t> slot_indices) {
     if (slot_indices.empty()) {
       return;
     }

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
@@ -205,7 +205,7 @@ TEST_F(VulkanLayerProducerImplTest, EnqueueCaptureEvent) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                         absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -249,8 +249,8 @@ TEST_F(VulkanLayerProducerImplTest, EnqueueCaptureEvent) {
 }
 
 static void ExpectInternedStrings(
-    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> actual_events,
-    absl::Span<std::pair<std::string, uint64_t> const> expected_interns) {
+    absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> actual_events,
+    absl::Span<const std::pair<std::string, uint64_t> > expected_interns) {
   ASSERT_EQ(actual_events.size(), expected_interns.size());
   for (size_t i = 0; i < actual_events.size(); ++i) {
     ASSERT_EQ(actual_events[i].event_case(),
@@ -275,7 +275,7 @@ TEST_F(VulkanLayerProducerImplTest, InternStringIfNecessaryAndGetKey) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                          absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
@@ -343,7 +343,7 @@ TEST_F(VulkanLayerProducerImplTest, DontSendInternTwice) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(1)
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                          absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
@@ -391,7 +391,7 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                          absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
@@ -444,7 +444,7 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                          absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
@@ -532,7 +532,7 @@ TEST_F(VulkanLayerProducerImplTest, InternOnlyWhenCapturing) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
+                          absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/synchronization/mutex.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/support/channel_arguments.h>
@@ -204,7 +205,7 @@ TEST_F(VulkanLayerProducerImplTest, EnqueueCaptureEvent) {
   std::atomic<uint64_t> capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                         absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -248,8 +249,8 @@ TEST_F(VulkanLayerProducerImplTest, EnqueueCaptureEvent) {
 }
 
 static void ExpectInternedStrings(
-    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& actual_events,
-    const std::vector<std::pair<std::string, uint64_t>>& expected_interns) {
+    absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> actual_events,
+    absl::Span<std::pair<std::string, uint64_t> const> expected_interns) {
   ASSERT_EQ(actual_events.size(), expected_interns.size());
   for (size_t i = 0; i < actual_events.size(); ++i) {
     ASSERT_EQ(actual_events[i].event_case(),
@@ -274,7 +275,7 @@ TEST_F(VulkanLayerProducerImplTest, InternStringIfNecessaryAndGetKey) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
@@ -342,7 +343,7 @@ TEST_F(VulkanLayerProducerImplTest, DontSendInternTwice) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(1)
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
@@ -390,7 +391,7 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
@@ -443,7 +444,7 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
@@ -531,7 +532,7 @@ TEST_F(VulkanLayerProducerImplTest, InternOnlyWhenCapturing) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
-                          const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
+                          absl::Span<orbit_grpc_protos::ProducerCaptureEvent const> events) {
         absl::MutexLock lock{&events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -165,7 +165,7 @@ FindStructuredDebugDirectorySymbolProviders() {
 
 // TODO(b/246743231): Remove this function when not needed anymore.
 [[nodiscard]] static std::vector<StructuredDebugDirectorySymbolProvider>
-CreateStructuredDebugDirectorySymbolProviders(absl::Span<std::filesystem::path const> paths) {
+CreateStructuredDebugDirectorySymbolProviders(absl::Span<const std::filesystem::path> paths) {
   std::vector<StructuredDebugDirectorySymbolProvider> result;
   result.reserve(paths.size());
   for (const auto& path : paths) {
@@ -179,7 +179,7 @@ SymbolHelper::SymbolHelper(fs::path cache_directory)
       structured_debug_directory_providers_(FindStructuredDebugDirectorySymbolProviders()) {}
 
 SymbolHelper::SymbolHelper(std::filesystem::path cache_directory,
-                           absl::Span<std::filesystem::path const> structured_debug_directories)
+                           absl::Span<const std::filesystem::path> structured_debug_directories)
     : cache_directory_(std::move(cache_directory)),
       structured_debug_directory_providers_(
           CreateStructuredDebugDirectorySymbolProviders(structured_debug_directories)) {}

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -165,7 +165,7 @@ FindStructuredDebugDirectorySymbolProviders() {
 
 // TODO(b/246743231): Remove this function when not needed anymore.
 [[nodiscard]] static std::vector<StructuredDebugDirectorySymbolProvider>
-CreateStructuredDebugDirectorySymbolProviders(const std::vector<std::filesystem::path>& paths) {
+CreateStructuredDebugDirectorySymbolProviders(absl::Span<std::filesystem::path const> paths) {
   std::vector<StructuredDebugDirectorySymbolProvider> result;
   result.reserve(paths.size());
   for (const auto& path : paths) {
@@ -179,7 +179,7 @@ SymbolHelper::SymbolHelper(fs::path cache_directory)
       structured_debug_directory_providers_(FindStructuredDebugDirectorySymbolProviders()) {}
 
 SymbolHelper::SymbolHelper(std::filesystem::path cache_directory,
-                           const std::vector<std::filesystem::path>& structured_debug_directories)
+                           absl::Span<std::filesystem::path const> structured_debug_directories)
     : cache_directory_(std::move(cache_directory)),
       structured_debug_directory_providers_(
           CreateStructuredDebugDirectorySymbolProviders(structured_debug_directories)) {}

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -30,7 +30,7 @@ class SymbolHelper : public SymbolCacheInterface {
  public:
   explicit SymbolHelper(std::filesystem::path cache_directory);
   explicit SymbolHelper(std::filesystem::path cache_directory,
-                        absl::Span<std::filesystem::path const> structured_debug_directories);
+                        absl::Span<const std::filesystem::path> structured_debug_directories);
 
   ErrorMessageOr<std::filesystem::path> FindSymbolsFileLocally(
       const std::filesystem::path& module_path, std::string_view build_id,

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -30,7 +30,7 @@ class SymbolHelper : public SymbolCacheInterface {
  public:
   explicit SymbolHelper(std::filesystem::path cache_directory);
   explicit SymbolHelper(std::filesystem::path cache_directory,
-                        const std::vector<std::filesystem::path>& structured_debug_directories);
+                        absl::Span<std::filesystem::path const> structured_debug_directories);
 
   ErrorMessageOr<std::filesystem::path> FindSymbolsFileLocally(
       const std::filesystem::path& module_path, std::string_view build_id,

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -39,7 +39,7 @@ using orbit_base::ReadFileToString;
 }
 
 [[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t start_address,
-                                                      absl::Span<uint8_t const> bytes) {
+                                                      absl::Span<const uint8_t> bytes) {
   ORBIT_CHECK(!bytes.empty());
 
   OUTCOME_TRY(auto&& fd, orbit_base::OpenFileForWriting(absl::StrFormat("/proc/%d/mem", pid)));

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -7,6 +7,7 @@
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
+#include <absl/types/span.h>
 
 #include <string>
 
@@ -38,7 +39,7 @@ using orbit_base::ReadFileToString;
 }
 
 [[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t start_address,
-                                                      const std::vector<uint8_t>& bytes) {
+                                                      absl::Span<uint8_t const> bytes) {
   ORBIT_CHECK(!bytes.empty());
 
   OUTCOME_TRY(auto&& fd, orbit_base::OpenFileForWriting(absl::StrFormat("/proc/%d/mem", pid)));

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -5,6 +5,7 @@
 #ifndef USER_SPACE_INSTRUMENTATION_ACCESS_TRACEES_MEMORY_H_
 #define USER_SPACE_INSTRUMENTATION_ACCESS_TRACEES_MEMORY_H_
 
+#include <absl/types/span.h>
 #include <sys/types.h>
 
 #include <cstdint>
@@ -24,7 +25,7 @@ namespace orbit_user_space_instrumentation {
 // Write `bytes` into memory of process `pid` starting from `start_address`.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
 [[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t start_address,
-                                                      const std::vector<uint8_t>& bytes);
+                                                      absl::Span<uint8_t const> bytes);
 
 // Returns the address range of an executable memory region. One options is usually the second line
 // in the `maps` file corresponding to the code of the process we look at. However we don't really

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -25,7 +25,7 @@ namespace orbit_user_space_instrumentation {
 // Write `bytes` into memory of process `pid` starting from `start_address`.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
 [[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t start_address,
-                                                      absl::Span<uint8_t const> bytes);
+                                                      absl::Span<const uint8_t> bytes);
 
 // Returns the address range of an executable memory region. One options is usually the second line
 // in the `maps` file corresponding to the code of the process we look at. However we don't really

--- a/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
@@ -5,6 +5,7 @@
 #include "UserSpaceInstrumentation/ExecuteInProcess.h"
 
 #include <absl/base/casts.h>
+#include <absl/types/span.h>
 
 #include <memory>
 
@@ -63,7 +64,7 @@ ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* function_address, uin
 }
 
 ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid,
-                                          const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
+                                          absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
                                           void* library_handle, std::string_view function,
                                           uint64_t param_0, uint64_t param_1, uint64_t param_2,
                                           uint64_t param_3, uint64_t param_4, uint64_t param_5) {

--- a/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
@@ -64,7 +64,7 @@ ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* function_address, uin
 }
 
 ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid,
-                                          absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
+                                          absl::Span<const orbit_grpc_protos::ModuleInfo> modules,
                                           void* library_handle, std::string_view function,
                                           uint64_t param_0, uint64_t param_1, uint64_t param_2,
                                           uint64_t param_3, uint64_t param_4, uint64_t param_5) {

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
@@ -5,6 +5,7 @@
 #include "FindFunctionAddress.h"
 
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 
 #include <memory>
 #include <string>
@@ -16,7 +17,7 @@
 namespace orbit_user_space_instrumentation {
 
 ErrorMessageOr<uint64_t> FindFunctionAddress(
-    const std::vector<orbit_grpc_protos::ModuleInfo>& modules, std::string_view module_soname,
+    absl::Span<orbit_grpc_protos::ModuleInfo const> modules, std::string_view module_soname,
     std::string_view function_name) {
   std::string module_file_path;
   uint64_t module_base_address = 0;

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
@@ -17,7 +17,7 @@
 namespace orbit_user_space_instrumentation {
 
 ErrorMessageOr<uint64_t> FindFunctionAddress(
-    absl::Span<orbit_grpc_protos::ModuleInfo const> modules, std::string_view module_soname,
+    absl::Span<const orbit_grpc_protos::ModuleInfo> modules, std::string_view module_soname,
     std::string_view function_name) {
   std::string module_file_path;
   uint64_t module_base_address = 0;

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.h
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.h
@@ -5,6 +5,7 @@
 #ifndef USER_SPACE_INSTRUMENTATION_FIND_FUNCTION_ADDRESS_H_
 #define USER_SPACE_INSTRUMENTATION_FIND_FUNCTION_ADDRESS_H_
 
+#include <absl/types/span.h>
 #include <sys/types.h>
 
 #include <cstdint>
@@ -22,7 +23,7 @@ namespace orbit_user_space_instrumentation {
 // (compare https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html) of the module
 // exactly.
 [[nodiscard]] ErrorMessageOr<uint64_t> FindFunctionAddress(
-    const std::vector<orbit_grpc_protos::ModuleInfo>& modules, std::string_view module_soname,
+    absl::Span<orbit_grpc_protos::ModuleInfo const> modules, std::string_view module_soname,
     std::string_view function_name);
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.h
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.h
@@ -23,7 +23,7 @@ namespace orbit_user_space_instrumentation {
 // (compare https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html) of the module
 // exactly.
 [[nodiscard]] ErrorMessageOr<uint64_t> FindFunctionAddress(
-    absl::Span<orbit_grpc_protos::ModuleInfo const> modules, std::string_view module_soname,
+    absl::Span<const orbit_grpc_protos::ModuleInfo> modules, std::string_view module_soname,
     std::string_view function_name);
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -55,7 +55,7 @@ constexpr FunctionLocatorView kDlcloseFallbackInLibc{kLibcSoname, "__libc_dlclos
 // FindFunctionAddress, does but accepts a list of module and function names and returns
 // the address of the first found function.
 ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
-    const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
+    absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
     absl::Span<const FunctionLocatorView> function_locators) {
   std::string error_message;
 
@@ -85,7 +85,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
 }  // namespace
 
 [[nodiscard]] ErrorMessageOr<void*> DlmopenInTracee(
-    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
+    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
     const std::filesystem::path& path, uint32_t flag, LinkerNamespace linker_namespace) {
   // Make sure file exists.
   auto file_exists_or_error = orbit_base::FileOrDirectoryExists(path);
@@ -147,7 +147,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
 }
 
 [[nodiscard]] ErrorMessageOr<void*> DlsymInTracee(
-    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* handle,
+    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* handle,
     std::string_view symbol) {
   // Figure out address of dlsym.
   OUTCOME_TRY(auto&& dlsym_address,
@@ -201,7 +201,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
 }
 
 [[nodiscard]] ErrorMessageOr<void> DlcloseInTracee(
-    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* handle) {
+    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* handle) {
   // Figure out address of dlclose.
   OUTCOME_TRY(auto&& dlclose_address,
               FindFunctionAddressWithFallback(

--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -55,7 +55,7 @@ constexpr FunctionLocatorView kDlcloseFallbackInLibc{kLibcSoname, "__libc_dlclos
 // FindFunctionAddress, does but accepts a list of module and function names and returns
 // the address of the first found function.
 ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
-    absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
+    absl::Span<const orbit_grpc_protos::ModuleInfo> modules,
     absl::Span<const FunctionLocatorView> function_locators) {
   std::string error_message;
 
@@ -85,7 +85,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
 }  // namespace
 
 [[nodiscard]] ErrorMessageOr<void*> DlmopenInTracee(
-    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
+    pid_t pid, absl::Span<const orbit_grpc_protos::ModuleInfo> modules,
     const std::filesystem::path& path, uint32_t flag, LinkerNamespace linker_namespace) {
   // Make sure file exists.
   auto file_exists_or_error = orbit_base::FileOrDirectoryExists(path);
@@ -147,7 +147,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
 }
 
 [[nodiscard]] ErrorMessageOr<void*> DlsymInTracee(
-    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* handle,
+    pid_t pid, absl::Span<const orbit_grpc_protos::ModuleInfo> modules, void* handle,
     std::string_view symbol) {
   // Figure out address of dlsym.
   OUTCOME_TRY(auto&& dlsym_address,
@@ -201,7 +201,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(
 }
 
 [[nodiscard]] ErrorMessageOr<void> DlcloseInTracee(
-    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* handle) {
+    pid_t pid, absl::Span<const orbit_grpc_protos::ModuleInfo> modules, void* handle) {
   // Figure out address of dlclose.
   OUTCOME_TRY(auto&& dlclose_address,
               FindFunctionAddressWithFallback(

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -90,7 +90,7 @@ bool ProcessWithPidExists(pid_t pid) {
 }
 
 // Returns true if liborbituserspaceinstrumentation.so is present in target process.
-ErrorMessageOr<bool> AlreadyInjected(absl::Span<ModuleInfo const> modules) {
+ErrorMessageOr<bool> AlreadyInjected(absl::Span<const ModuleInfo> modules) {
   for (const ModuleInfo& module : modules) {
     if (module.name() == kLibName) {
       return true;
@@ -139,7 +139,7 @@ bool IsBlocklisted(std::string_view function_name) {
 // Note that calling the result of the clone call a "thread" is a bit of a misnomer: We
 // do not create a new data structure for thread local storage but use the one of the thread we
 // halted.
-ErrorMessageOr<MachineCode> MachineCodeForCloneCall(pid_t pid, absl::Span<ModuleInfo const> modules,
+ErrorMessageOr<MachineCode> MachineCodeForCloneCall(pid_t pid, absl::Span<const ModuleInfo> modules,
                                                     void* library_handle, uint64_t top_of_stack) {
   constexpr uint64_t kCloneFlags =
       CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM;
@@ -239,7 +239,7 @@ ErrorMessageOr<std::vector<pid_t>> GetNewOrbitThreads(
   return orbit_threads;
 }
 
-ErrorMessageOr<void> SetOrbitThreadsInTarget(pid_t pid, absl::Span<ModuleInfo const> modules,
+ErrorMessageOr<void> SetOrbitThreadsInTarget(pid_t pid, absl::Span<const ModuleInfo> modules,
                                              void* library_handle,
                                              const std::vector<pid_t>& orbit_threads) {
   ORBIT_CHECK(orbit_threads.size() == GetExpectedOrbitThreadNames().size());
@@ -255,7 +255,7 @@ ErrorMessageOr<void> SetOrbitThreadsInTarget(pid_t pid, absl::Span<ModuleInfo co
 // Given the path of a module in the process, get all loaded instances of that module (usually there
 // will only be one, but a module can be loaded more than once).
 ErrorMessageOr<std::vector<ModuleInfo>> ModulesFromModulePath(
-    absl::Span<ModuleInfo const> modules, std::string_view path,
+    absl::Span<const ModuleInfo> modules, std::string_view path,
     absl::flat_hash_map<std::string, std::vector<ModuleInfo>>* cache_of_modules_from_path) {
   ORBIT_CHECK(cache_of_modules_from_path != nullptr);
   auto cached_modules_from_path_it = cache_of_modules_from_path->find(path);
@@ -290,14 +290,14 @@ class InstrumentedProcess {
   ~InstrumentedProcess() = default;
 
   [[nodiscard]] static ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> Create(
-      pid_t pid, absl::Span<ModuleInfo const> modules);
+      pid_t pid, absl::Span<const ModuleInfo> modules);
 
   // Instruments the functions capture_options.instrumented_functions. Returns a set of
   // function_id's of successfully instrumented functions, a map of function_id's to errors for
   // functions that couldn't be instrumented, the address ranges dedicated to trampolines, and the
   // map name of the injected library.
   [[nodiscard]] ErrorMessageOr<InstrumentationManager::InstrumentationResult> InstrumentFunctions(
-      const CaptureOptions& capture_options, absl::Span<ModuleInfo const> modules);
+      const CaptureOptions& capture_options, absl::Span<const ModuleInfo> modules);
 
   // Removes the instrumentation for all functions in capture_options.instrumented_functions that
   // have been instrumented previously.
@@ -373,7 +373,7 @@ class InstrumentedProcess {
 };
 
 ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create(
-    pid_t pid, absl::Span<ModuleInfo const> modules) {
+    pid_t pid, absl::Span<const ModuleInfo> modules) {
   std::unique_ptr<InstrumentedProcess> process(new InstrumentedProcess());
   process->pid_ = pid;
   ORBIT_LOG("Starting to instrument process with pid %d", pid);
@@ -493,7 +493,7 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
 
 ErrorMessageOr<InstrumentationManager::InstrumentationResult>
 InstrumentedProcess::InstrumentFunctions(const CaptureOptions& capture_options,
-                                         absl::Span<ModuleInfo const> modules) {
+                                         absl::Span<const ModuleInfo> modules) {
   ORBIT_LOG("Instrumenting functions in process %d", pid_);
   OUTCOME_TRY(AttachAndStopProcess(pid_));
   orbit_base::unique_resource detach_on_exit{pid_, [](int32_t pid) {

--- a/src/UserSpaceInstrumentation/MachineCode.cpp
+++ b/src/UserSpaceInstrumentation/MachineCode.cpp
@@ -5,10 +5,11 @@
 #include "MachineCode.h"
 
 #include <absl/base/casts.h>
+#include <absl/types/span.h>
 
 namespace orbit_user_space_instrumentation {
 
-MachineCode& MachineCode::AppendBytes(const std::vector<uint8_t>& data) {
+MachineCode& MachineCode::AppendBytes(absl::Span<uint8_t const> data) {
   data_.insert(data_.end(), data.begin(), data.end());
   return *this;
 }

--- a/src/UserSpaceInstrumentation/MachineCode.cpp
+++ b/src/UserSpaceInstrumentation/MachineCode.cpp
@@ -9,7 +9,7 @@
 
 namespace orbit_user_space_instrumentation {
 
-MachineCode& MachineCode::AppendBytes(absl::Span<uint8_t const> data) {
+MachineCode& MachineCode::AppendBytes(absl::Span<const uint8_t> data) {
   data_.insert(data_.end(), data.begin(), data.end());
   return *this;
 }

--- a/src/UserSpaceInstrumentation/MachineCode.h
+++ b/src/UserSpaceInstrumentation/MachineCode.h
@@ -24,7 +24,7 @@ namespace orbit_user_space_instrumentation {
 //
 class MachineCode {
  public:
-  MachineCode& AppendBytes(absl::Span<uint8_t const> data);
+  MachineCode& AppendBytes(absl::Span<const uint8_t> data);
   MachineCode& AppendImmediate64(uint64_t data);
   MachineCode& AppendImmediate32(uint32_t data);
   MachineCode& AppendImmediate32(int32_t data);

--- a/src/UserSpaceInstrumentation/MachineCode.h
+++ b/src/UserSpaceInstrumentation/MachineCode.h
@@ -5,6 +5,8 @@
 #ifndef USER_SPACE_INSTRUMENTATION_MACHINE_CODE_H_
 #define USER_SPACE_INSTRUMENTATION_MACHINE_CODE_H_
 
+#include <absl/types/span.h>
+
 #include <cstdint>
 #include <vector>
 
@@ -22,7 +24,7 @@ namespace orbit_user_space_instrumentation {
 //
 class MachineCode {
  public:
-  MachineCode& AppendBytes(const std::vector<uint8_t>& data);
+  MachineCode& AppendBytes(absl::Span<uint8_t const> data);
   MachineCode& AppendImmediate64(uint64_t data);
   MachineCode& AppendImmediate32(uint32_t data);
   MachineCode& AppendImmediate32(int32_t data);

--- a/src/UserSpaceInstrumentation/TestUtils.cpp
+++ b/src/UserSpaceInstrumentation/TestUtils.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 #include <capstone/capstone.h>
 #include <unistd.h>
 
@@ -109,7 +110,7 @@ FunctionLocation FindFunctionOrDie(std::string_view function_name) {
   ORBIT_FATAL("FindFunctionOrDie hasn't found a function '%s'", function_name);
 }
 
-void DumpDisassembly(const std::vector<uint8_t>& code, uint64_t start_address) {
+void DumpDisassembly(absl::Span<uint8_t const> code, uint64_t start_address) {
   // Init Capstone disassembler.
   csh capstone_handle = 0;
   cs_err error_code = cs_open(CS_ARCH_X86, CS_MODE_64, &capstone_handle);

--- a/src/UserSpaceInstrumentation/TestUtils.cpp
+++ b/src/UserSpaceInstrumentation/TestUtils.cpp
@@ -110,7 +110,7 @@ FunctionLocation FindFunctionOrDie(std::string_view function_name) {
   ORBIT_FATAL("FindFunctionOrDie hasn't found a function '%s'", function_name);
 }
 
-void DumpDisassembly(absl::Span<uint8_t const> code, uint64_t start_address) {
+void DumpDisassembly(absl::Span<const uint8_t> code, uint64_t start_address) {
   // Init Capstone disassembler.
   csh capstone_handle = 0;
   cs_err error_code = cs_open(CS_ARCH_X86, CS_MODE_64, &capstone_handle);

--- a/src/UserSpaceInstrumentation/TestUtils.h
+++ b/src/UserSpaceInstrumentation/TestUtils.h
@@ -5,6 +5,8 @@
 #ifndef USER_SPACE_INSTRUMENTATION_TEST_UTILS_H_
 #define USER_SPACE_INSTRUMENTATION_TEST_UTILS_H_
 
+#include <absl/types/span.h>
+
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -30,7 +32,7 @@ AddressRange GetFunctionAbsoluteAddressRangeOrDie(std::string_view function_name
 // This is for debugging only. Disassembles the `code` and dumps it into the log. `start_address` is
 // the address of the code in virtual memory. If this is not applicable or you don't have it just
 // hand over zero.
-void DumpDisassembly(const std::vector<uint8_t>& code, uint64_t start_address);
+void DumpDisassembly(absl::Span<uint8_t const> code, uint64_t start_address);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/TestUtils.h
+++ b/src/UserSpaceInstrumentation/TestUtils.h
@@ -32,7 +32,7 @@ AddressRange GetFunctionAbsoluteAddressRangeOrDie(std::string_view function_name
 // This is for debugging only. Disassembles the `code` and dumps it into the log. `start_address` is
 // the address of the code in virtual memory. If this is not applicable or you don't have it just
 // hand over zero.
-void DumpDisassembly(absl::Span<uint8_t const> code, uint64_t start_address);
+void DumpDisassembly(absl::Span<const uint8_t> code, uint64_t start_address);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -11,6 +11,7 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
+#include <absl/types/span.h>
 #include <capstone/capstone.h>
 #include <capstone/x86.h>
 #include <cpuid.h>
@@ -76,7 +77,7 @@ constexpr uint64_t kOffsetOfFunctionIdInCallToEntryPayload = 178;
   return __get_cpuid(0x01, &eax, &ebx, &ecx, &edx) && (ecx & bit_AVX);
 }
 
-[[nodiscard]] std::string BytesAsString(const std::vector<uint8_t>& code) {
+[[nodiscard]] std::string BytesAsString(absl::Span<uint8_t const> code) {
   std::string result;
   for (const auto& c : code) {
     result.append(absl::StrFormat("%0.2x ", c));
@@ -95,7 +96,7 @@ constexpr uint64_t kOffsetOfFunctionIdInCallToEntryPayload = 178;
 // However analysing existing code shows that many of the problematic jumps are in small functions
 // that are written in assembly. These are detected by the function below.
 bool CheckForRelativeJumpIntoFirstFiveBytes(uint64_t function_address,
-                                            const std::vector<uint8_t>& function,
+                                            absl::Span<uint8_t const> function,
                                             csh capstone_handle) {
   cs_insn* instruction = cs_malloc(capstone_handle);
   ORBIT_FAIL_IF(instruction == nullptr, "Failed to allocate memory for capstone disassembler.");
@@ -489,7 +490,7 @@ void AppendRestoreCode(MachineCode& trampoline) {
 // one are included (function_address will contain a valid instruction - the jump into the
 // trampoline - when we are done).
 [[nodiscard]] ErrorMessageOr<uint64_t> AppendRelocatedPrologueCode(
-    uint64_t function_address, const std::vector<uint8_t>& function, uint64_t trampoline_address,
+    uint64_t function_address, absl::Span<uint8_t const> function, uint64_t trampoline_address,
     csh capstone_handle, absl::flat_hash_map<uint64_t, uint64_t>& global_relocation_map,
     MachineCode& trampoline) {
   cs_insn* instruction = cs_malloc(capstone_handle);
@@ -860,7 +861,7 @@ bool DoAddressRangesOverlap(const AddressRange& a, const AddressRange& b) {
   return !(b.end <= a.start || b.start >= a.end);
 }
 
-std::optional<size_t> LowestIntersectingAddressRange(const std::vector<AddressRange>& ranges_sorted,
+std::optional<size_t> LowestIntersectingAddressRange(absl::Span<AddressRange const> ranges_sorted,
                                                      const AddressRange& range) {
   for (size_t i = 0; i < ranges_sorted.size(); i++) {
     if (DoAddressRangesOverlap(ranges_sorted[i], range)) {
@@ -870,8 +871,8 @@ std::optional<size_t> LowestIntersectingAddressRange(const std::vector<AddressRa
   return std::nullopt;
 }
 
-std::optional<size_t> HighestIntersectingAddressRange(
-    const std::vector<AddressRange>& ranges_sorted, const AddressRange& range) {
+std::optional<size_t> HighestIntersectingAddressRange(absl::Span<AddressRange const> ranges_sorted,
+                                                      const AddressRange& range) {
   for (int i = ranges_sorted.size() - 1; i >= 0; i--) {
     if (DoAddressRangesOverlap(ranges_sorted[i], range)) {
       return i;
@@ -919,7 +920,7 @@ ErrorMessageOr<std::vector<AddressRange>> GetUnavailableAddressRanges(pid_t pid)
 }
 
 ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
-    const std::vector<AddressRange>& unavailable_ranges, const AddressRange& code_range,
+    absl::Span<AddressRange const> unavailable_ranges, const AddressRange& code_range,
     uint64_t size) {
   constexpr uint64_t kMax32BitOffset = INT32_MAX;
   constexpr uint64_t kMax64BitAddress = UINT64_MAX;
@@ -1170,7 +1171,7 @@ uint64_t GetMaxTrampolineSize() {
 }
 
 ErrorMessageOr<uint64_t> CreateTrampoline(pid_t pid, uint64_t function_address,
-                                          const std::vector<uint8_t>& function,
+                                          absl::Span<uint8_t const> function,
                                           uint64_t trampoline_address,
                                           uint64_t entry_payload_function_address,
                                           uint64_t return_trampoline_address, csh capstone_handle,

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -30,13 +30,13 @@ namespace orbit_user_space_instrumentation {
 // `ranges_sorted` needs to contain non-overlapping ranges in ascending order (as provided by
 // `GetUnavailableAddressRanges`).
 [[nodiscard]] std::optional<size_t> LowestIntersectingAddressRange(
-    absl::Span<AddressRange const> ranges_sorted, const AddressRange& range);
+    absl::Span<const AddressRange> ranges_sorted, const AddressRange& range);
 
 // Returns the index of the highest range in `ranges_sorted` that is intersecting with `range`.
 // `ranges_sorted` needs to contain non-overlapping ranges in ascending order (as provided by
 // `GetUnavailableAddressRanges`).
 [[nodiscard]] std::optional<size_t> HighestIntersectingAddressRange(
-    absl::Span<AddressRange const> ranges_sorted, const AddressRange& range);
+    absl::Span<const AddressRange> ranges_sorted, const AddressRange& range);
 
 // Parses the /proc/pid/maps file of a process and returns all the taken address ranges (joining
 // directly neighboring ones). We also add a range [0, /proc/sys/vm/mmap_min_addr] to block the
@@ -51,7 +51,7 @@ namespace orbit_user_space_instrumentation {
 // `unavailable_ranges` needs to contain non-overlapping ranges in ascending order; the smallest
 // range needs to start at zero (as provided by `GetUnavailableAddressRanges`).
 [[nodiscard]] ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
-    absl::Span<AddressRange const> unavailable_ranges, const AddressRange& code_range,
+    absl::Span<const AddressRange> unavailable_ranges, const AddressRange& code_range,
     uint64_t size);
 
 // Allocates `size` bytes in the tracee close to `code_range`. The memory segment will be placed
@@ -132,7 +132,7 @@ struct RelocatedInstruction {
 // value is the address of the first instruction not relocated into the trampoline (i.e. the address
 // the trampoline jump back to).
 [[nodiscard]] ErrorMessageOr<uint64_t> CreateTrampoline(
-    pid_t pid, uint64_t function_address, absl::Span<uint8_t const> function,
+    pid_t pid, uint64_t function_address, absl::Span<const uint8_t> function,
     uint64_t trampoline_address, uint64_t entry_payload_function_address,
     uint64_t return_trampoline_address, csh capstone_handle,
     absl::flat_hash_map<uint64_t, uint64_t>& relocation_map);

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -6,6 +6,7 @@
 #define USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/types/span.h>
 #include <capstone/capstone.h>
 #include <stddef.h>
 #include <sys/types.h>
@@ -29,13 +30,13 @@ namespace orbit_user_space_instrumentation {
 // `ranges_sorted` needs to contain non-overlapping ranges in ascending order (as provided by
 // `GetUnavailableAddressRanges`).
 [[nodiscard]] std::optional<size_t> LowestIntersectingAddressRange(
-    const std::vector<AddressRange>& ranges_sorted, const AddressRange& range);
+    absl::Span<AddressRange const> ranges_sorted, const AddressRange& range);
 
 // Returns the index of the highest range in `ranges_sorted` that is intersecting with `range`.
 // `ranges_sorted` needs to contain non-overlapping ranges in ascending order (as provided by
 // `GetUnavailableAddressRanges`).
 [[nodiscard]] std::optional<size_t> HighestIntersectingAddressRange(
-    const std::vector<AddressRange>& ranges_sorted, const AddressRange& range);
+    absl::Span<AddressRange const> ranges_sorted, const AddressRange& range);
 
 // Parses the /proc/pid/maps file of a process and returns all the taken address ranges (joining
 // directly neighboring ones). We also add a range [0, /proc/sys/vm/mmap_min_addr] to block the
@@ -50,7 +51,7 @@ namespace orbit_user_space_instrumentation {
 // `unavailable_ranges` needs to contain non-overlapping ranges in ascending order; the smallest
 // range needs to start at zero (as provided by `GetUnavailableAddressRanges`).
 [[nodiscard]] ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
-    const std::vector<AddressRange>& unavailable_ranges, const AddressRange& code_range,
+    absl::Span<AddressRange const> unavailable_ranges, const AddressRange& code_range,
     uint64_t size);
 
 // Allocates `size` bytes in the tracee close to `code_range`. The memory segment will be placed
@@ -131,7 +132,7 @@ struct RelocatedInstruction {
 // value is the address of the first instruction not relocated into the trampoline (i.e. the address
 // the trampoline jump back to).
 [[nodiscard]] ErrorMessageOr<uint64_t> CreateTrampoline(
-    pid_t pid, uint64_t function_address, const std::vector<uint8_t>& function,
+    pid_t pid, uint64_t function_address, absl::Span<uint8_t const> function,
     uint64_t trampoline_address, uint64_t entry_payload_function_address,
     uint64_t return_trampoline_address, csh capstone_handle,
     absl::flat_hash_map<uint64_t, uint64_t>& relocation_map);

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/ExecuteInProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/ExecuteInProcess.h
@@ -30,7 +30,7 @@ namespace orbit_user_space_instrumentation {
 // Assumes that the library identified by `library_handle` is loaded into this process using
 // `DlopenInTracee`.
 [[nodiscard]] ErrorMessageOr<uint64_t> ExecuteInProcess(
-    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* library_handle,
+    pid_t pid, absl::Span<const orbit_grpc_protos::ModuleInfo> modules, void* library_handle,
     std::string_view function, uint64_t param_1 = 0, uint64_t param_2 = 0, uint64_t param_3 = 0,
     uint64_t param_4 = 0, uint64_t param_5 = 0, uint64_t param_6 = 0);
 

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/ExecuteInProcess.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/ExecuteInProcess.h
@@ -5,6 +5,7 @@
 #ifndef USER_SPACE_INSTRUMENTATION_EXECUTE_IN_PROCESS_H_
 #define USER_SPACE_INSTRUMENTATION_EXECUTE_IN_PROCESS_H_
 
+#include <absl/types/span.h>
 #include <sys/types.h>
 
 #include <cstdint>
@@ -29,7 +30,7 @@ namespace orbit_user_space_instrumentation {
 // Assumes that the library identified by `library_handle` is loaded into this process using
 // `DlopenInTracee`.
 [[nodiscard]] ErrorMessageOr<uint64_t> ExecuteInProcess(
-    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* library_handle,
+    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* library_handle,
     std::string_view function, uint64_t param_1 = 0, uint64_t param_2 = 0, uint64_t param_3 = 0,
     uint64_t param_4 = 0, uint64_t param_5 = 0, uint64_t param_6 = 0);
 

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
@@ -29,13 +29,13 @@ enum class LinkerNamespace { kUseInitialNamespace, kCreateNewNamespace };
 // functions offered by libdl as documented e.g. here: https://linux.die.net/man/3/dlopen. We rely
 // on either libdl or libc being loaded into the tracee.
 [[nodiscard]] ErrorMessageOr<void*> DlmopenInTracee(
-    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
+    pid_t pid, absl::Span<const orbit_grpc_protos::ModuleInfo> modules,
     const std::filesystem::path& path, uint32_t flag, LinkerNamespace linker_namespace);
 [[nodiscard]] ErrorMessageOr<void*> DlsymInTracee(
-    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* handle,
+    pid_t pid, absl::Span<const orbit_grpc_protos::ModuleInfo> modules, void* handle,
     std::string_view symbol);
 [[nodiscard]] ErrorMessageOr<void> DlcloseInTracee(
-    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* handle);
+    pid_t pid, absl::Span<const orbit_grpc_protos::ModuleInfo> modules, void* handle);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/InjectLibraryInTracee.h
@@ -5,6 +5,7 @@
 #ifndef USER_SPACE_INSTRUMENTATION_INJECT_LIBRARY_IN_TRACEE_H_
 #define USER_SPACE_INSTRUMENTATION_INJECT_LIBRARY_IN_TRACEE_H_
 
+#include <absl/types/span.h>
 #include <dlfcn.h>  // IWYU pragma: keep
 #include <sys/types.h>
 
@@ -28,13 +29,13 @@ enum class LinkerNamespace { kUseInitialNamespace, kCreateNewNamespace };
 // functions offered by libdl as documented e.g. here: https://linux.die.net/man/3/dlopen. We rely
 // on either libdl or libc being loaded into the tracee.
 [[nodiscard]] ErrorMessageOr<void*> DlmopenInTracee(
-    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules,
+    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules,
     const std::filesystem::path& path, uint32_t flag, LinkerNamespace linker_namespace);
 [[nodiscard]] ErrorMessageOr<void*> DlsymInTracee(
-    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* handle,
+    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* handle,
     std::string_view symbol);
 [[nodiscard]] ErrorMessageOr<void> DlcloseInTracee(
-    pid_t pid, const std::vector<orbit_grpc_protos::ModuleInfo>& modules, void* handle);
+    pid_t pid, absl::Span<orbit_grpc_protos::ModuleInfo const> modules, void* handle);
 
 }  // namespace orbit_user_space_instrumentation
 


### PR DESCRIPTION
Replace usages of const std::vector<T>& in parameters
    
This replaces the usage of `const std::vector<T>&` in function
parameters by `absl::Span<T const>`.
    
Using Span has the advantage that the caller can pass in any consecutive range
of elements - a std::array for example. It also makes potentially
expensive copies more explicit. More details here: http://go/totw/93

There are two commits. The first one only contains mechanical changes (done by clang-tidy).
All the less trivial manual changes are in the second commit. When reviewing you probably want
to review the second commit more thoroughly than the first one.