### PR TITLE
Fix out of bounds access in SetOrbitThreadsInTarget

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <mutex>
@@ -246,9 +247,13 @@ ErrorMessageOr<void> SetOrbitThreadsInTarget(pid_t pid, const std::vector<Module
   constexpr const char* kSetOrbitThreadsFunctionName = "SetOrbitThreads";
   OUTCOME_TRY(void* set_orbit_threads_function_address,
               DlsymInTracee(pid, modules, library_handle, kSetOrbitThreadsFunctionName));
-  OUTCOME_TRY(ExecuteInProcess(pid, set_orbit_threads_function_address, orbit_threads[0],
-                               orbit_threads[1], orbit_threads[2], orbit_threads[3],
-                               orbit_threads[4], orbit_threads[5]));
+  const auto safe_get_tid = [&orbit_threads](size_t index) {
+    if (index < orbit_threads.size()) return orbit_threads.at(index);
+    return -1;
+  };
+  OUTCOME_TRY(ExecuteInProcess(pid, set_orbit_threads_function_address, safe_get_tid(0),
+                               safe_get_tid(1), safe_get_tid(2), safe_get_tid(3), safe_get_tid(4),
+                               safe_get_tid(5)));
   return outcome::success();
 }
 


### PR DESCRIPTION
`SetOrbitThreadsInTarget` calls `SetOrbitThreads` in our user space instrumentation library through ptrace. To keep things simple `SetOrbitThreads` takes a fixed number of parameters which represent the TIDs of the injected threads (mostly from gRPC) to filter out events from them.

The TIDs of the injected threads are determined by comparing a list of TIDs from after the injection to a list from before the injection.

The code assumes that the resulting list contains at least 6 TIDs. But that recently changed. An update to the gRPC library reduced the number of threads and this now leads to an out of bounds access in the hard coded list.

This PR solves that by checking the size of the given list and providing a fall back value of -1 if the number of threads given in the list is shorter than 6.

Note that this still doesn't solve the case when we injected more than 6 threads. To solve this we probably have to change the data structure in the instrumentation library (from an array to a vector or similar) and I am not sure if this affects the performance in any way. That's why this is only fixing the OOB access.