### PR TITLE
Fix a bunch of clang-tidy warnings

### DIFF
--- a/src/OrbitAccessibility/AccessibleInterfaceRegistry.cpp
+++ b/src/OrbitAccessibility/AccessibleInterfaceRegistry.cpp
@@ -13,9 +13,7 @@ AccessibleInterfaceRegistry& AccessibleInterfaceRegistry::Get() {
   return registry;
 }
 
-AccessibleInterfaceRegistry::~AccessibleInterfaceRegistry() {
-  ORBIT_CHECK(interfaces_.size() == 0);
-}
+AccessibleInterfaceRegistry::~AccessibleInterfaceRegistry() { ORBIT_CHECK(interfaces_.empty()); }
 
 void AccessibleInterfaceRegistry::Register(AccessibleInterface* iface) {
   if (!interfaces_.contains(iface)) {
@@ -36,12 +34,12 @@ void AccessibleInterfaceRegistry::Unregister(AccessibleInterface* iface) {
 
 void AccessibleInterfaceRegistry::SetOnRegisterCallback(Callback callback) {
   ORBIT_CHECK(on_registered_ == nullptr);
-  on_registered_ = callback;
+  on_registered_ = std::move(callback);
 }
 
 void AccessibleInterfaceRegistry::SetOnUnregisterCallback(Callback callback) {
   ORBIT_CHECK(on_unregistered_ == nullptr);
-  on_unregistered_ = callback;
+  on_unregistered_ = std::move(callback);
 }
 
 }  // namespace orbit_accessibility

--- a/src/OrbitAccessibility/AccessibleInterfaceRegistryTest.cpp
+++ b/src/OrbitAccessibility/AccessibleInterfaceRegistryTest.cpp
@@ -14,7 +14,7 @@ namespace orbit_accessibility {
 
 TEST(AccessibleInterfaceRegistry, Management) {
   auto impl = std::make_unique<AccessibleObjectFake>(nullptr);
-  auto impl_ptr = impl.get();
+  auto* impl_ptr = impl.get();
   EXPECT_TRUE(AccessibleInterfaceRegistry::Get().Exists(impl_ptr));
   impl.reset();
   EXPECT_FALSE(AccessibleInterfaceRegistry::Get().Exists(impl_ptr));

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
@@ -29,17 +29,17 @@ struct AccessibilityRect {
  * The constants used by QT are the same and, thus, can be translated directly (see QAccessible.h)
  */
 enum class AccessibilityRole {
-  NoRole = 0x00000000,
-  ScrollBar = 0x00000003,
-  Client = 0x0000000A,
-  Document = 0x0000000F,
-  Pane = 0x00000010,
-  Chart = 0x00000011,
-  Grouping = 0x00000014,
-  PageTab = 0x00000025,
-  Graphic = 0x00000028,
-  StaticText = 0x00000029,
-  Button = 0x0000002B
+  NoRole = 0x00000000,      // NOLINT(readability-identifier-naming)
+  ScrollBar = 0x00000003,   // NOLINT(readability-identifier-naming)
+  Client = 0x0000000A,      // NOLINT(readability-identifier-naming)
+  Document = 0x0000000F,    // NOLINT(readability-identifier-naming)
+  Pane = 0x00000010,        // NOLINT(readability-identifier-naming)
+  Chart = 0x00000011,       // NOLINT(readability-identifier-naming)
+  Grouping = 0x00000014,    // NOLINT(readability-identifier-naming)
+  PageTab = 0x00000025,     // NOLINT(readability-identifier-naming)
+  Graphic = 0x00000028,     // NOLINT(readability-identifier-naming)
+  StaticText = 0x00000029,  // NOLINT(readability-identifier-naming)
+  Button = 0x0000002B       // NOLINT(readability-identifier-naming)
 };
 
 /* Selected state constants as required by QAccessible::State, same reasoning as above.

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterfaceRegistry.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterfaceRegistry.h
@@ -34,7 +34,7 @@ class AccessibleInterfaceRegistry {
   static AccessibleInterfaceRegistry& Get();
 
  private:
-  AccessibleInterfaceRegistry(){};
+  AccessibleInterfaceRegistry() = default;
   ~AccessibleInterfaceRegistry();
 
   absl::flat_hash_set<AccessibleInterface*> interfaces_;

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleObjectFake.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleObjectFake.h
@@ -11,8 +11,7 @@ namespace orbit_accessibility {
 
 class AccessibleObjectFake : public AccessibleInterface {
  public:
-  explicit AccessibleObjectFake(AccessibleObjectFake* parent)
-      : AccessibleInterface(), parent_(parent) {}
+  explicit AccessibleObjectFake(AccessibleObjectFake* parent) : parent_(parent) {}
   [[nodiscard]] int AccessibleChildCount() const override { return children_.size(); }
   [[nodiscard]] AccessibleInterface* AccessibleChild(int index) const override {
     return children_[index].get();

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleWidgetBridge.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleWidgetBridge.h
@@ -15,24 +15,20 @@ namespace orbit_accessibility {
  */
 class AccessibleWidgetBridge : public AccessibleInterface {
  public:
-  [[nodiscard]] virtual int AccessibleChildCount() const override { return 0; }
-  [[nodiscard]] virtual const AccessibleInterface* AccessibleChild(int /*index*/) const override {
+  [[nodiscard]] int AccessibleChildCount() const override { return 0; }
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override {
     return nullptr;
   }
-  [[nodiscard]] virtual const AccessibleInterface* AccessibleParent() const override {
-    return nullptr;
-  }
+  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override { return nullptr; }
 
   // The methods below are usually not used and are instead handled by the QtWidget.
   // See the implementation of OpenGlWidgetAccessible in AccessibilityAdapter.cpp!
-  [[nodiscard]] virtual std::string AccessibleName() const override { return ""; };
-  [[nodiscard]] virtual AccessibilityRole AccessibleRole() const override {
+  [[nodiscard]] std::string AccessibleName() const override { return ""; };
+  [[nodiscard]] AccessibilityRole AccessibleRole() const override {
     return AccessibilityRole::Grouping;
   }
-  [[nodiscard]] virtual AccessibilityRect AccessibleRect() const override {
-    return AccessibilityRect();
-  }
-  [[nodiscard]] virtual AccessibilityState AccessibleState() const override {
+  [[nodiscard]] AccessibilityRect AccessibleRect() const override { return {}; }
+  [[nodiscard]] AccessibilityState AccessibleState() const override {
     return AccessibilityState::Normal;
   }
 };

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -63,7 +63,7 @@ using orbit_base::ReadFileToString;
     if (tokens.size() >= 6 && (tokens[5] == "[vsyscall]" || tokens[5] == "[uprobes]")) continue;
     const std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
     if (addresses.size() != 2) continue;
-    AddressRange result;
+    AddressRange result{};
     if (!absl::numbers_internal::safe_strtou64_base(addresses[0], &result.start, 16)) continue;
     if (!absl::numbers_internal::safe_strtou64_base(addresses[1], &result.end, 16)) continue;
     if (exclude_address >= result.start && exclude_address < result.end) continue;

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -7,12 +7,12 @@
 #include <absl/strings/str_split.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <signal.h>
 #include <sys/prctl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <csignal>
 #include <cstdint>
 #include <iterator>
 #include <random>
@@ -35,7 +35,7 @@ namespace {
 using orbit_test_utils::HasError;
 
 AddressRange AddressRangeFromString(std::string_view string_address) {
-  AddressRange result;
+  AddressRange result{};
   const std::vector<std::string> addresses = absl::StrSplit(string_address, '-');
   if (addresses.size() != 2) {
     ORBIT_FATAL("Not an address range: %s", string_address);
@@ -54,7 +54,7 @@ AddressRange AddressRangeFromString(std::string_view string_address) {
   OUTCOME_TRY(auto&& maps, orbit_base::ReadFileToString(absl::StrFormat("/proc/%d/maps", pid)));
   const std::vector<std::string> lines = absl::StrSplit(maps, '\n', absl::SkipEmpty());
   bool is_first = true;
-  AddressRange result;
+  AddressRange result{};
   for (const auto& line : lines) {
     const std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
     if (tokens.size() < 2 || tokens[1].size() != 4) continue;
@@ -210,7 +210,7 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   ORBIT_CHECK(memory_region_or_error.has_value());
   const uint64_t address = memory_region_or_error.value().start;
 
-  constexpr uint64_t kMemorySize = 4 * 1024;
+  constexpr uint64_t kMemorySize = 4u * 1024u;
   auto backup = ReadTraceesMemory(pid, address, kMemorySize);
   ASSERT_TRUE(backup.has_value());
 

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -7,13 +7,13 @@
 #include <absl/base/casts.h>
 #include <absl/strings/str_format.h>
 #include <linux/seccomp.h>
-#include <signal.h>
-#include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
+#include <csignal>
 #include <cstdint>
+#include <cstdlib>
 #include <optional>
 #include <string>
 #include <utility>
@@ -145,7 +145,7 @@ namespace {
   }
   const uint64_t result = return_value.GetGeneralPurposeRegisters()->x86_64.rax;
   // Syscalls return -4095, ..., -1 on failure. And these are actually (-1 * errno)
-  const int64_t result_as_int = absl::bit_cast<int64_t>(result);
+  const auto result_as_int = absl::bit_cast<int64_t>(result);
   if (result_as_int > -4096 && result_as_int < 0) {
     return ErrorMessage(absl::StrFormat("Syscall failed. Return value: %s (%d).%s",
                                         SafeStrerror(-result_as_int), result_as_int,

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -9,14 +9,14 @@
 #include <gtest/gtest.h>
 #include <linux/filter.h>
 #include <linux/seccomp.h>
-#include <signal.h>
-#include <stdint.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include <array>
+#include <csignal>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -93,7 +93,7 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
   ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
   // Allocation fails for invalid process.
-  constexpr uint64_t kMemorySize = 1024 * 1024;
+  constexpr uint64_t kMemorySize = 1024u * 1024u;
   auto my_memory_or_error = MemoryInTracee::Create(-1, 0, kMemorySize);
   EXPECT_THAT(my_memory_or_error, HasError("No such process"));
 
@@ -159,7 +159,7 @@ TEST(AllocateInTraceeTest, AutomaticAllocateAndFree) {
   // Stop the process using our tooling.
   ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
-  constexpr uint64_t kMemorySize = 1024 * 1024;
+  constexpr uint64_t kMemorySize = 1024u * 1024u;
   uint64_t address = 0;
   {
     auto automatic_memory_or_error = AutomaticMemoryInTracee::Create(pid, 0, kMemorySize);
@@ -207,13 +207,13 @@ TEST(AllocateInTraceeTest, SyscallInTraceeFailsBecauseOfStrictSeccompMode) {
   ORBIT_CHECK(close(child_to_parent_pipe[1]) == 0);
 
   // Wait for the child to execute the seccomp syscall.
-  char buf[1];
-  ORBIT_CHECK(read(child_to_parent_pipe[0], buf, 1) == 1);
+  std::array<char, 1> buf{};
+  ORBIT_CHECK(read(child_to_parent_pipe[0], buf.data(), 1) == 1);
 
   // Stop the process using our tooling.
   ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
-  constexpr uint64_t kMemorySize = 1024 * 1024;
+  constexpr uint64_t kMemorySize = 1024u * 1024u;
   // Allocation will fail because of seccomp.
   auto my_memory_or_error = MemoryInTracee::Create(pid, 0, kMemorySize);
   EXPECT_THAT(
@@ -272,13 +272,13 @@ TEST(AllocateInTraceeTest, SyscallInTraceeFailsBecauseOfSeccompFilter) {
   ORBIT_CHECK(close(child_to_parent_pipe[1]) == 0);
 
   // Wait for the child to execute the seccomp syscall.
-  char buf[1];
-  ORBIT_CHECK(read(child_to_parent_pipe[0], buf, 1) == 1);
+  std::array<char, 1> buf{};
+  ORBIT_CHECK(read(child_to_parent_pipe[0], buf.data(), 1) == 1);
 
   // Stop the process using our tooling.
   ORBIT_CHECK(!AttachAndStopProcess(pid).has_error());
 
-  constexpr uint64_t kMemorySize = 1024 * 1024;
+  constexpr uint64_t kMemorySize = 1024u * 1024u;
   // Allocation will fail because of seccomp.
   auto my_memory_or_error = MemoryInTracee::Create(pid, 0, kMemorySize);
   EXPECT_THAT(

--- a/src/UserSpaceInstrumentation/AnyThreadIsInStrictSeccompMode.cpp
+++ b/src/UserSpaceInstrumentation/AnyThreadIsInStrictSeccompMode.cpp
@@ -25,13 +25,12 @@ namespace orbit_user_space_instrumentation {
 // course the target could spawn a thread that switches to strict mode after the start of the
 // capture, but this is the best we can do.
 bool AnyThreadIsInStrictSeccompMode(pid_t pid) {
-  for (pid_t tid : orbit_base::GetTidsOfProcess(pid)) {
+  const std::vector<pid_t>& tids_of_process = orbit_base::GetTidsOfProcess(pid);
+  auto is_seccomp_mode_strict = [](pid_t tid) -> bool {
     const std::optional<int> seccomp_mode = ReadSeccompModeOfThread(tid);
-    if (seccomp_mode.has_value() && seccomp_mode.value() == SECCOMP_MODE_STRICT) {
-      return true;
-    }
-  }
-  return false;
+    return seccomp_mode.has_value() && seccomp_mode.value() == SECCOMP_MODE_STRICT;
+  };
+  return std::any_of(tids_of_process.begin(), tids_of_process.end(), is_seccomp_mode_strict);
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/Attach.cpp
+++ b/src/UserSpaceInstrumentation/Attach.cpp
@@ -7,12 +7,12 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/hash/hash.h>
 #include <absl/strings/str_format.h>
-#include <errno.h>
-#include <stdlib.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
+#include <cerrno>
 #include <chrono>
+#include <cstdlib>
 #include <thread>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
(for files starting with A)

Test: Compile