### PR TITLE
Introduce TemporaryDirectory

### DIFF
--- a/src/OrbitBase/include/OrbitBase/UniqueResource.h
+++ b/src/OrbitBase/include/OrbitBase/UniqueResource.h
@@ -52,7 +52,7 @@ class unique_resource {
 
   ~unique_resource() { RunDeleter(); }
 
-  Resource get() const { return resource_.value(); }
+  const Resource& get() const { return resource_.value(); }
   Deleter& get_deleter() { return deleter_; }
   const Deleter& get_deleter() const { return deleter_; }
 

--- a/src/TestUtils/CMakeLists.txt
+++ b/src/TestUtils/CMakeLists.txt
@@ -8,10 +8,12 @@ add_library(TestUtils STATIC)
 target_sources(TestUtils PUBLIC
   include/TestUtils/ContainerHelpers.h
   include/TestUtils/SaveRangeFromArg.h
+  include/TestUtils/TemporaryDirectory.h
   include/TestUtils/TemporaryFile.h
   include/TestUtils/TestUtils.h)
 
 target_sources(TestUtils PRIVATE
+  TemporaryDirectory.cpp
   TemporaryFile.cpp)
 
 target_include_directories(TestUtils PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -27,6 +29,7 @@ target_link_libraries(TestUtils PUBLIC
 add_executable(TestUtilsTests
   ContainerHelpersTest.cpp
   SaveRangeFromArgTest.cpp
+  TemporaryDirectoryTest.cpp
   TemporaryFileTest.cpp
   TestUtilsTest.cpp)
 target_link_libraries(TestUtilsTests PRIVATE TestUtils GTest::Main)

--- a/src/TestUtils/TemporaryDirectory.cpp
+++ b/src/TestUtils/TemporaryDirectory.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TestUtils/TemporaryDirectory.h"
+
+#include <absl/strings/str_format.h>
+#include <absl/synchronization/mutex.h>
+
+#include <filesystem>
+#include <limits>
+#include <random>
+#include <system_error>
+
+#include "OrbitBase/File.h"
+#include "OrbitBase/Result.h"
+
+namespace orbit_test_utils {
+
+[[nodiscard]] static uint32_t Get4BytesOfRandomness() {
+  // Since we keep the mersenne twister engine in static storage, we have to ensure thread safety.
+  static absl::Mutex mutex{};
+  absl::MutexLock lock{&mutex};
+
+  static std::random_device random_device{};
+  static std::mt19937 gen{random_device()};
+  static std::uniform_int_distribution<uint32_t> distribution{std::numeric_limits<uint32_t>::min(),
+                                                              std::numeric_limits<uint32_t>::max()};
+  return distribution(gen);
+}
+
+ErrorMessageOr<TemporaryDirectory> TemporaryDirectory::Create() {
+  std::error_code error_code{};
+  std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(error_code);
+  if (error_code) return ErrorMessage{error_code};
+
+  constexpr int kTries = 10;
+  for (int i = 0; i < kTries; ++i) {
+    std::filesystem::path unique_path =
+        tmp_dir / absl::StrFormat("orbit_%08X", Get4BytesOfRandomness());
+    OUTCOME_TRY(bool exists, orbit_base::FileOrDirectoryExists(unique_path));
+    if (exists) continue;
+
+    OUTCOME_TRY(orbit_base::CreateDirectories(unique_path));
+    return TemporaryDirectory{std::move(unique_path)};
+  }
+
+  return ErrorMessage{"Failed to create a temporary directory."};
+}
+
+void TemporaryDirectory::DirectoryDeleter::operator()(const std::filesystem::path& dir) const {
+  std::error_code error{};
+  std::filesystem::remove_all(dir, error);
+  std::ignore = error;  // Since this is running in a destructor we can't handle the error here.
+}
+
+}  // namespace orbit_test_utils

--- a/src/TestUtils/TemporaryDirectoryTest.cpp
+++ b/src/TestUtils/TemporaryDirectoryTest.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "OrbitBase/File.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/WriteStringToFile.h"
+#include "TestUtils/TemporaryDirectory.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_test_utils {
+
+TEST(TemporaryDirectory, CreatesAndDeletesDirectory) {
+  auto maybe_directory = TemporaryDirectory::Create();
+  ASSERT_THAT(maybe_directory, HasNoError());
+
+  std::filesystem::path directory_path = maybe_directory.value().GetDirectoryPath();
+
+  EXPECT_THAT(orbit_base::IsDirectory(directory_path), HasValue(true));
+  maybe_directory = ErrorMessage{};  // This ends the scope of the TemporaryDirectory instance
+  EXPECT_THAT(orbit_base::FileOrDirectoryExists(directory_path), HasValue(false));
+}
+
+TEST(TemporaryDirectory, IsInitiallyEmpty) {
+  auto maybe_directory = TemporaryDirectory::Create();
+  ASSERT_THAT(maybe_directory, HasNoError());
+
+  std::filesystem::path directory_path = maybe_directory.value().GetDirectoryPath();
+  EXPECT_THAT(orbit_base::ListFilesInDirectory(directory_path), HasValue(testing::IsEmpty()));
+}
+
+TEST(TemporaryDirectory, CanCreateFileInTemporaryDirectoryAndDeletesIt) {
+  auto maybe_directory = TemporaryDirectory::Create();
+  ASSERT_THAT(maybe_directory, HasNoError());
+
+  std::filesystem::path directory_path = maybe_directory.value().GetDirectoryPath();
+  std::filesystem::path arbitrary_file_path = directory_path / "hello.txt";
+
+  EXPECT_THAT(orbit_base::WriteStringToFile(arbitrary_file_path, "Some contents."), HasNoError());
+
+  maybe_directory = ErrorMessage{};  // This ends the scope of the TemporaryDirectory instance
+  EXPECT_THAT(orbit_base::FileOrDirectoryExists(arbitrary_file_path), HasValue(false));
+}
+
+TEST(TemporaryDirectory, Move) {
+  auto maybe_directory = TemporaryDirectory::Create();
+  ASSERT_THAT(maybe_directory, HasNoError());
+
+  std::filesystem::path directory_path = maybe_directory.value().GetDirectoryPath();
+  EXPECT_THAT(orbit_base::IsDirectory(directory_path), HasValue(true));
+
+  {
+    TemporaryDirectory other = std::move(maybe_directory.value());
+    EXPECT_THAT(orbit_base::IsDirectory(directory_path), HasValue(true));
+
+    // We end the lifetime of the moved-from object here. The directory should still be there.
+    maybe_directory = ErrorMessage{};
+    EXPECT_THAT(orbit_base::IsDirectory(directory_path), HasValue(true));
+  }
+
+  EXPECT_THAT(orbit_base::FileOrDirectoryExists(directory_path), HasValue(false));
+}
+
+}  // namespace orbit_test_utils

--- a/src/TestUtils/include/TestUtils/TemporaryDirectory.h
+++ b/src/TestUtils/include/TestUtils/TemporaryDirectory.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_TEST_UTILS_TEMPORARY_DIRECTORY_H_
+#define ORBIT_TEST_UTILS_TEMPORARY_DIRECTORY_H_
+
+#include <filesystem>
+#include <utility>
+
+#include "OrbitBase/Result.h"
+#include "OrbitBase/UniqueResource.h"
+
+namespace orbit_test_utils {
+// Creates a temporary directory that tests can assume to be exclusive and initially empty. The
+// directory and all the files inside will also be automatically deleted when an instance of
+// `TemporaryDir` gets out of scope.
+class TemporaryDirectory final {
+ public:
+  [[nodiscard]] const std::filesystem::path& GetDirectoryPath() const { return dir_.get(); }
+
+  // Call this function to create a new temporary directory.
+  static ErrorMessageOr<TemporaryDirectory> Create();
+
+ private:
+  explicit TemporaryDirectory(std::filesystem::path dir) : dir_{std::move(dir)} {}
+
+  struct DirectoryDeleter {
+    void operator()(const std::filesystem::path& dir) const;
+  };
+  orbit_base::unique_resource<std::filesystem::path, DirectoryDeleter> dir_;
+};
+
+}  // namespace orbit_test_utils
+
+#endif  // ORBIT_TEST_UTILS_TEMPORARY_DIRECTORY_H_


### PR DESCRIPTION
A lot of our tests use TemporaryFile to create a temporary file, but end up calling `CloseAndRemove` right away and then re-use the file path.

`TemporaryFile` is not really made for that use case. There is no guarantee, that once closing a file, the same file path is not used from something else.

The better solution is to introduce a TemporaryDirectory which any test case can own exclusively. It can create arbitrary file paths in this directory and test their file path based APIs.

All tests that rely on file descriptors can and should still use TemporaryFile.

Note that the usage of this tool will come in a separate PR.