### PR TITLE
Replace string_view by string in lambda captures

### DIFF
--- a/src/DataViews/MockAppInterface.h
+++ b/src/DataViews/MockAppInterface.h
@@ -34,7 +34,7 @@ class MockAppInterface : public AppInterface {
   MOCK_METHOD(void, SetClipboard, (std::string_view), (override));
   MOCK_METHOD(std::string, GetSaveFile, (std::string_view extension), (const, override));
 
-  MOCK_METHOD(void, SendErrorToUi, (std::string_view title, std::string_view text), (override));
+  MOCK_METHOD(void, SendErrorToUi, (std::string title, std::string text), (override));
 
   MOCK_METHOD(orbit_base::Future<ErrorMessageOr<void>>, LoadPreset,
               (const orbit_preset_file::PresetFile&), (override));

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -40,7 +40,7 @@ class AppInterface : public orbit_client_data::CaptureDataHolder {
   virtual void SetClipboard(std::string_view contents) = 0;
   [[nodiscard]] virtual std::string GetSaveFile(std::string_view extension) const = 0;
 
-  virtual void SendErrorToUi(std::string_view title, std::string_view text) = 0;
+  virtual void SendErrorToUi(std::string title, std::string text) = 0;
 
   // Functions needed by PresetsDataView
   virtual orbit_base::Future<ErrorMessageOr<void>> LoadPreset(

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -1524,19 +1524,20 @@ void OrbitApp::SendDisassemblyToUi(const orbit_client_data::FunctionInfo& functi
   });
 }
 
-void OrbitApp::SendTooltipToUi(std::string_view tooltip) {
-  main_thread_executor_->Schedule([this, tooltip] { main_window_->ShowTooltip(tooltip); });
+void OrbitApp::SendTooltipToUi(std::string tooltip) {
+  main_thread_executor_->Schedule(
+      [this, tooltip = std::move(tooltip)] { main_window_->ShowTooltip(tooltip); });
 }
 
-void OrbitApp::SendWarningToUi(std::string_view title, std::string_view text) {
-  main_thread_executor_->Schedule([this, title, text] {
+void OrbitApp::SendWarningToUi(std::string title, std::string text) {
+  main_thread_executor_->Schedule([this, title = std::move(title), text = std::move(text)] {
     ORBIT_CHECK(warning_message_callback_);
     warning_message_callback_(title, text);
   });
 }
 
-void OrbitApp::SendErrorToUi(std::string_view title, std::string_view text) {
-  main_thread_executor_->Schedule([this, title, text] {
+void OrbitApp::SendErrorToUi(std::string title, std::string text) {
+  main_thread_executor_->Schedule([this, title = std::move(title), text = std::move(text)] {
     ORBIT_CHECK(error_message_callback_);
     error_message_callback_(title, text);
   });

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -323,9 +323,9 @@ class OrbitApp final : public DataViewFactory,
 
   void SendDisassemblyToUi(const orbit_client_data::FunctionInfo& function_info,
                            std::string disassembly, orbit_code_report::DisassemblyReport report);
-  void SendTooltipToUi(std::string_view tooltip);
-  void SendWarningToUi(std::string_view title, std::string_view text);
-  void SendErrorToUi(std::string_view title, std::string_view text) override;
+  void SendTooltipToUi(std::string tooltip);
+  void SendWarningToUi(std::string title, std::string text);
+  void SendErrorToUi(std::string title, std::string text) override;
 
   orbit_base::Future<void> LoadSymbolsManually(
       absl::Span<const orbit_client_data::ModuleData* const> modules) override;


### PR DESCRIPTION
These lambda are executed asynchronously which means the data the string_views point to will be out of scope when they get accessed.

To solve this we have to make a copy of the strings and store the copy in the closure until they get executed.