### PR TITLE
Add IWYU mapping for absl::Flag

### DIFF
--- a/contrib/iwyu/orbit.imp
+++ b/contrib/iwyu/orbit.imp
@@ -115,6 +115,7 @@
   { "include": ["\"absl/base/attributes.h\"", "private", "<absl/base/attributes.h>", "public"] },
   { "include": ["\"absl/base/call_once.h\"", "private", "<absl/base/call_once.h>", "public"] },
   { "include": ["\"absl/base/config.h\"", "private", "<absl/base/config.h>", "public"] },
+  { "symbol":  ["absl::Flag", "private", "<absl/flags/flag.h>", "public"]},
 
   # Hack: iwyu has a bug. It suggests to include <ext/alloc_traits> whenever std::vector::operator[] is used.
   # <ext/alloc_traits> is an implementation detail of libstdc++.


### PR DESCRIPTION
This mapping should hopefully stop IWYU from trying to include <absl/flags/declare.h> which forward declares absl::Flag.