### PR TITLE
Use the new TemporaryDirectory

### DIFF
--- a/src/CaptureFile/CaptureFileHelpersTest.cpp
+++ b/src/CaptureFile/CaptureFileHelpersTest.cpp
@@ -20,6 +20,7 @@
 #include "ClientProtos/user_defined_capture_info.pb.h"
 #include "GrpcProtos/capture.pb.h"
 #include "OrbitBase/Result.h"
+#include "TestUtils/TemporaryDirectory.h"
 #include "TestUtils/TemporaryFile.h"
 #include "TestUtils/TestUtils.h"
 
@@ -44,12 +45,11 @@ static ClientCaptureEvent CreateInternedStringCaptureEvent(uint64_t key, std::st
 }
 
 TEST(CaptureFileHelpers, CreateCaptureFileAndWriteUserData) {
-  auto temporary_file_or_error = orbit_test_utils::TemporaryFile::Create();
-  ASSERT_THAT(temporary_file_or_error, HasNoError());
-  orbit_test_utils::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
+  auto temporary_dir_or_error = orbit_test_utils::TemporaryDirectory::Create();
+  ASSERT_THAT(temporary_dir_or_error, HasNoError());
+  orbit_test_utils::TemporaryDirectory temporary_dir = std::move(temporary_dir_or_error.value());
 
-  const std::filesystem::path& file_path = temporary_file.file_path();
-  temporary_file.CloseAndRemove();
+  const std::filesystem::path file_path = temporary_dir.GetDirectoryPath() / "capture.orbit";
 
   auto output_stream_or_error = CaptureFileOutputStream::Create(file_path);
   ASSERT_THAT(output_stream_or_error, HasNoError());

--- a/src/CaptureFile/CaptureFileOutputStreamTest.cpp
+++ b/src/CaptureFile/CaptureFileOutputStreamTest.cpp
@@ -22,7 +22,7 @@
 #include "GrpcProtos/capture.pb.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
-#include "TestUtils/TemporaryFile.h"
+#include "TestUtils/TemporaryDirectory.h"
 
 namespace orbit_capture_file {
 
@@ -91,12 +91,13 @@ TEST(CaptureFileOutputStream, Smoke) {
 
   // Test the case of outputting capture file content to a file
   {
-    auto temporary_file_or_error = orbit_test_utils::TemporaryFile::Create();
-    ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-    orbit_test_utils::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-    temporary_file.CloseAndRemove();
+    auto temporary_dir_or_error = orbit_test_utils::TemporaryDirectory::Create();
+    ASSERT_TRUE(temporary_dir_or_error.has_value()) << temporary_dir_or_error.error().message();
+    orbit_test_utils::TemporaryDirectory temporary_directory =
+        std::move(temporary_dir_or_error.value());
 
-    std::string temp_file_name = temporary_file.file_path().string();
+    std::string temp_file_name =
+        (temporary_directory.GetDirectoryPath() / "capture.orbit").string();
     auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
     ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();
 
@@ -143,12 +144,11 @@ TEST(CaptureFileOutputStream, WriteAfterClose) {
 
   // Test the case of outputting capture file content to a file
   {
-    auto temporary_file_or_error = orbit_test_utils::TemporaryFile::Create();
-    ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
-    orbit_test_utils::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
-    temporary_file.CloseAndRemove();
+    auto temporary_dir_or_error = orbit_test_utils::TemporaryDirectory::Create();
+    ASSERT_TRUE(temporary_dir_or_error.has_value()) << temporary_dir_or_error.error().message();
+    orbit_test_utils::TemporaryDirectory temporary_dir = std::move(temporary_dir_or_error.value());
 
-    std::string temp_file_name = temporary_file.file_path().string();
+    std::string temp_file_name = (temporary_dir.GetDirectoryPath() / "capture.orbit").string();
     auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
     ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();
     std::unique_ptr<CaptureFileOutputStream> output_stream =

--- a/src/DataViews/DataViewTest.cpp
+++ b/src/DataViews/DataViewTest.cpp
@@ -18,6 +18,7 @@
 #include "DataViews/DataView.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
+#include "TestUtils/TemporaryDirectory.h"
 #include "TestUtils/TemporaryFile.h"
 #include "TestUtils/TestUtils.h"
 
@@ -51,7 +52,8 @@ TEST(DataView, FormatValueForCsvEscapesQuotesInString) {
 }
 
 TEST(DataView, WriteLineToCsvIsCorrect) {
-  orbit_test_utils::TemporaryFile temporary_file = orbit_data_views::GetTemporaryFilePath();
+  orbit_test_utils::TemporaryFile temporary_file = orbit_data_views::GetTemporaryFile();
+
   EXPECT_THAT(orbit_data_views::WriteLineToCsv(temporary_file.fd(), kValues),
               orbit_test_utils::HasNoError());
 

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -15,7 +15,7 @@
 
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
-#include "TestUtils/TemporaryFile.h"
+#include "TestUtils/TemporaryDirectory.h"
 #include "TestUtils/TestUtils.h"
 
 namespace orbit_data_views {
@@ -68,11 +68,18 @@ static void ExpectSameLines(const std::string_view& actual, const std::string_vi
   EXPECT_THAT(actual_lines, testing::UnorderedElementsAreArray(expected_lines));
 }
 
-[[nodiscard]] orbit_test_utils::TemporaryFile GetTemporaryFilePath() {
+orbit_test_utils::TemporaryFile GetTemporaryFile() {
   ErrorMessageOr<orbit_test_utils::TemporaryFile> temporary_file_or_error =
       orbit_test_utils::TemporaryFile::Create();
   EXPECT_THAT(temporary_file_or_error, orbit_test_utils::HasNoError());
   return std::move(temporary_file_or_error.value());
+}
+
+orbit_test_utils::TemporaryDirectory GetTemporaryDirectory() {
+  ErrorMessageOr<orbit_test_utils::TemporaryDirectory> temporary_dir_or_error =
+      orbit_test_utils::TemporaryDirectory::Create();
+  EXPECT_THAT(temporary_dir_or_error, orbit_test_utils::HasNoError());
+  return std::move(temporary_dir_or_error.value());
 }
 
 void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const MockAppInterface& app,
@@ -81,20 +88,13 @@ void CheckExportToCsvIsInvoked(const FlattenContextMenu& context_menu, const Moc
   const int action_index = GetActionIndexOnMenu(context_menu, action_name);
   EXPECT_TRUE(action_index != kInvalidActionIndex);
 
-  orbit_test_utils::TemporaryFile temporary_file = GetTemporaryFilePath();
+  orbit_test_utils::TemporaryDirectory temporary_dir = GetTemporaryDirectory();
+  std::filesystem::path temporary_file_path = temporary_dir.GetDirectoryPath() / "test.txt";
 
-  // We actually only need a temporary file path, so let's call `CloseAndRemove` and reuse the
-  // filepath. The TemporaryFile instance will still take care of deleting our new file when it
-  // gets out of scope.
-  temporary_file.CloseAndRemove();
-
-  EXPECT_CALL(app, GetSaveFile)
-      .Times(1)
-      .WillOnce(testing::Return(temporary_file.file_path().string()));
+  EXPECT_CALL(app, GetSaveFile).Times(1).WillOnce(testing::Return(temporary_file_path.string()));
   view.OnContextMenu(std::string{action_name}, action_index, {0});
 
-  ErrorMessageOr<std::string> contents_or_error =
-      orbit_base::ReadFileToString(temporary_file.file_path());
+  ErrorMessageOr<std::string> contents_or_error = orbit_base::ReadFileToString(temporary_file_path);
   ASSERT_THAT(contents_or_error, orbit_test_utils::HasNoError());
 
   ExpectSameLines(contents_or_error.value(), expected_contents);

--- a/src/DataViews/DataViewTestUtils.h
+++ b/src/DataViews/DataViewTestUtils.h
@@ -14,6 +14,7 @@
 
 #include "DataViews/DataView.h"
 #include "MockAppInterface.h"
+#include "TestUtils/TemporaryDirectory.h"
 #include "TestUtils/TemporaryFile.h"
 
 namespace orbit_data_views {
@@ -43,7 +44,8 @@ void CheckContextMenuOrder(const FlattenContextMenu& context_menu);
 [[nodiscard]] FlattenContextMenu FlattenContextMenuWithGroupingAndCheckOrder(
     absl::Span<const DataView::ActionGroup> menu_with_grouping);
 
-orbit_test_utils::TemporaryFile GetTemporaryFilePath();
+[[nodiscard]] orbit_test_utils::TemporaryDirectory GetTemporaryDirectory();
+[[nodiscard]] orbit_test_utils::TemporaryFile GetTemporaryFile();
 
 }  // namespace orbit_data_views
 

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -26,20 +26,10 @@
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Result.h"
 #include "PresetFile/PresetFile.h"
-#include "TestUtils/TemporaryFile.h"
+#include "TestUtils/TemporaryDirectory.h"
 #include "TestUtils/TestUtils.h"
 
-using orbit_data_views::CheckCopySelectionIsInvoked;
-using orbit_data_views::CheckExportToCsvIsInvoked;
 using orbit_data_views::FlattenContextMenu;
-using orbit_data_views::FlattenContextMenuWithGroupingAndCheckOrder;
-using orbit_data_views::GetActionIndexOnMenu;
-using orbit_data_views::kInvalidActionIndex;
-using orbit_data_views::kMenuActionCopySelection;
-using orbit_data_views::kMenuActionDeletePreset;
-using orbit_data_views::kMenuActionExportToCsv;
-using orbit_data_views::kMenuActionLoadPreset;
-using orbit_data_views::kMenuActionShowInExplorer;
 
 namespace {
 // This is just a helper type to handle colors. Note that Color from `OrbitGl/CoreMath.h` is not
@@ -265,11 +255,11 @@ TEST_F(PresetsDataViewTest, CheckInvokedContextMenuActions) {
       .Times(testing::AnyNumber())
       .WillRepeatedly(testing::Return(PresetLoadState::kLoadable));
 
-  auto temporary_preset_file = orbit_test_utils::TemporaryFile::Create();
-  ASSERT_THAT(temporary_preset_file, orbit_test_utils::HasNoError());
-  temporary_preset_file.value().CloseAndRemove();
+  auto temporary_dir = orbit_test_utils::TemporaryDirectory::Create();
+  ASSERT_THAT(temporary_dir, orbit_test_utils::HasNoError());
 
-  const std::filesystem::path preset_filename0 = temporary_preset_file.value().file_path();
+  const std::filesystem::path preset_filename0 =
+      temporary_dir.value().GetDirectoryPath() / "preset0.orbit";
   orbit_preset_file::PresetFile preset_file0{preset_filename0, orbit_client_protos::PresetInfo{}};
   ASSERT_THAT(preset_file0.SaveToFile(), orbit_test_utils::HasNoError());
   auto date_modified = orbit_base::GetFileDateModified(preset_filename0);


### PR DESCRIPTION
So far we only had `TemporaryFile` which creates and opens a temporary file and deletes it when the instance gets out of scope. The intention is that users of `TemporaryFile` operate on the file descriptor provided by the type.

But we have many APIs that operate on file names, not on file descriptors. To "solve" that problem tests for these APIs call `TemporaryFile::CloseAndRemove` to delete the file and then use the file name that is provided by `TemporaryFile::file_path`. The problem is that this file path is not guaranteed to be free after CloseAndRemove has been called (also pointed out here: https://en.cppreference.com/w/cpp/io/c/tmpnam)

Not sure how often this problem really occurs but I had test failures due to that in the past. The solution is to move these tests over to `TemporaryDirectory` which is a new tool. It offers a temporary directory that is cleaned up when the instance gets out of scope.