### PR TITLE
Apply "readability-identifier-naming" clang-tidy check

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -58,7 +58,7 @@ namespace {
 std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager& module_manager,
                                           const orbit_client_data::ProcessData& process_data) {
   // We have a different function name for each supported platform.
-  static const std::vector<std::string> kOrbitApiGetFunctionTableAddressPrefixes{
+  static const std::vector<std::string> orbit_api_get_function_table_address_prefixes{
       orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix,
       orbit_api_utils::kOrbitApiGetFunctionTableAddressWinPrefix};
   std::vector<ApiFunction> api_functions;
@@ -71,7 +71,7 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
       continue;
     }
     for (const std::string& orbit_api_get_function_table_address_prefix :
-         kOrbitApiGetFunctionTableAddressPrefixes) {
+         orbit_api_get_function_table_address_prefixes) {
       for (size_t i = 0; i <= kOrbitApiVersion; ++i) {
         std::string function_name =
             absl::StrFormat("%s%u", orbit_api_get_function_table_address_prefix, i);

--- a/src/CaptureFileInfo/CaptureFileInfoTest.cpp
+++ b/src/CaptureFileInfo/CaptureFileInfoTest.cpp
@@ -18,16 +18,16 @@
 namespace orbit_capture_file_info {
 
 TEST(CaptureFileInfo, PathConstructor) {
-  const QString kParentPath{"this/is/a/test/path/"};
-  const QString kFileName{"example file name.extension"};
-  const QString kFullPath{kParentPath + kFileName};
-  const absl::Duration kCaptureLength{absl::Seconds(10)};
+  const QString parent_path{"this/is/a/test/path/"};
+  const QString file_name{"example file name.extension"};
+  const QString full_path{parent_path + file_name};
+  const absl::Duration capture_length{absl::Seconds(10)};
 
-  CaptureFileInfo capture_file_info{kFullPath, kCaptureLength};
+  CaptureFileInfo capture_file_info{full_path, capture_length};
 
-  EXPECT_EQ(capture_file_info.FilePath(), kFullPath);
-  EXPECT_EQ(capture_file_info.FileName(), kFileName);
-  EXPECT_EQ(capture_file_info.CaptureLength().value(), kCaptureLength);
+  EXPECT_EQ(capture_file_info.FilePath(), full_path);
+  EXPECT_EQ(capture_file_info.FileName(), file_name);
+  EXPECT_EQ(capture_file_info.CaptureLength().value(), capture_length);
 
   // LastUsed() before or equal to now.
   EXPECT_LE(capture_file_info.LastUsed(), QDateTime::currentDateTime());
@@ -38,17 +38,17 @@ TEST(CaptureFileInfo, PathConstructor) {
 }
 
 TEST(CaptureFileInfo, PathLastUsedConstructor) {
-  const QString kParentPath{"this/is/a/test/path/"};
-  const QString kFileName{"example file name.extension"};
-  const QString kFullPath{kParentPath + kFileName};
+  const QString parent_path{"this/is/a/test/path/"};
+  const QString file_name{"example file name.extension"};
+  const QString full_path{parent_path + file_name};
   const QDateTime last_used = QDateTime::fromMSecsSinceEpoch(1600000000000);
-  const absl::Duration kCaptureLength{absl::Seconds(5)};
+  const absl::Duration capture_length{absl::Seconds(5)};
 
-  CaptureFileInfo capture_file_info{kFullPath, last_used, kCaptureLength};
+  CaptureFileInfo capture_file_info{full_path, last_used, capture_length};
 
-  EXPECT_EQ(capture_file_info.FilePath(), kFullPath);
-  EXPECT_EQ(capture_file_info.FileName(), kFileName);
-  EXPECT_EQ(capture_file_info.CaptureLength().value(), kCaptureLength);
+  EXPECT_EQ(capture_file_info.FilePath(), full_path);
+  EXPECT_EQ(capture_file_info.FileName(), file_name);
+  EXPECT_EQ(capture_file_info.CaptureLength().value(), capture_length);
 
   EXPECT_EQ(capture_file_info.LastUsed(), last_used);
 
@@ -56,22 +56,22 @@ TEST(CaptureFileInfo, PathLastUsedConstructor) {
 }
 
 TEST(CaptureFileInfo, FullInfoConstructorAndIsOutOfSync) {
-  const std::filesystem::path kTestFullPath = orbit_test::GetTestdataDir() / "test_file.orbit";
-  const QDateTime kLastUsed = QDateTime::fromMSecsSinceEpoch(1600000000000);
-  const QDateTime kLastModified = QDateTime::fromMSecsSinceEpoch(1500000000000);
-  const uint64_t kFileSize = 1234;
-  const absl::Duration kCaptureLength{absl::Seconds(5)};
+  const std::filesystem::path test_full_path = orbit_test::GetTestdataDir() / "test_file.orbit";
+  const QDateTime last_used = QDateTime::fromMSecsSinceEpoch(1600000000000);
+  const QDateTime last_modified = QDateTime::fromMSecsSinceEpoch(1500000000000);
+  const uint64_t file_size = 1234;
+  const absl::Duration capture_length{absl::Seconds(5)};
 
-  CaptureFileInfo capture_file_info{QString::fromStdString(kTestFullPath.string()), kLastUsed,
-                                    kLastModified, kFileSize, kCaptureLength};
+  CaptureFileInfo capture_file_info{QString::fromStdString(test_full_path.string()), last_used,
+                                    last_modified, file_size, capture_length};
 
-  EXPECT_EQ(capture_file_info.FilePath(), QString::fromStdString(kTestFullPath.string()));
+  EXPECT_EQ(capture_file_info.FilePath(), QString::fromStdString(test_full_path.string()));
   EXPECT_EQ(capture_file_info.FileName(),
-            QString::fromStdString(kTestFullPath.filename().string()));
-  EXPECT_EQ(capture_file_info.LastUsed(), kLastUsed);
-  EXPECT_EQ(capture_file_info.LastModified(), kLastModified);
-  EXPECT_EQ(capture_file_info.FileSize(), kFileSize);
-  EXPECT_EQ(capture_file_info.CaptureLength().value(), kCaptureLength);
+            QString::fromStdString(test_full_path.filename().string()));
+  EXPECT_EQ(capture_file_info.LastUsed(), last_used);
+  EXPECT_EQ(capture_file_info.LastModified(), last_modified);
+  EXPECT_EQ(capture_file_info.FileSize(), file_size);
+  EXPECT_EQ(capture_file_info.CaptureLength().value(), capture_length);
 
   // The file size and the last modified time we provided to construct the CaptureFileInfo do not
   // match with the information retrieved from the file system. Hence they are out of sync with the

--- a/src/ClientData/FastRenderingUtilsTest.cpp
+++ b/src/ClientData/FastRenderingUtilsTest.cpp
@@ -21,9 +21,9 @@ TEST_P(GetPixelNumberTest, FirstPixel) {
   const uint32_t resolution = GetParam();
   EXPECT_EQ(GetPixelNumber(kStartNs, resolution, kStartNs, kEndNs), 0);
 
-  const uint64_t kLastNsForFirstPixel = kStartNs + (kEndNs - kStartNs - 1) / resolution;
-  EXPECT_EQ(GetPixelNumber(kLastNsForFirstPixel, resolution, kStartNs, kEndNs), 0);
-  EXPECT_EQ(GetPixelNumber(kLastNsForFirstPixel + 1, resolution, kStartNs, kEndNs), 1);
+  const uint64_t last_ns_for_first_pixel = kStartNs + (kEndNs - kStartNs - 1) / resolution;
+  EXPECT_EQ(GetPixelNumber(last_ns_for_first_pixel, resolution, kStartNs, kEndNs), 0);
+  EXPECT_EQ(GetPixelNumber(last_ns_for_first_pixel + 1, resolution, kStartNs, kEndNs), 1);
 }
 
 TEST_P(GetPixelNumberTest, LastPixel) {
@@ -36,7 +36,7 @@ INSTANTIATE_TEST_SUITE_P(GetPixelNumberTests, GetPixelNumberTest, testing::Value
 
 TEST_P(GetNextPixelBoundaryTimeNsTest, TimestampsAreInRange) {
   const uint32_t resolution = GetParam();
-  constexpr uint64_t visible_ns = kEndNs - kStartNs;  // 100
+  constexpr uint64_t kVisibleNs = kEndNs - kStartNs;  // 100
 
   // Calculates `ceil(dividend / divisor)` only using integers assuming dividend and divisor are not
   // 0.
@@ -47,7 +47,7 @@ TEST_P(GetNextPixelBoundaryTimeNsTest, TimestampsAreInRange) {
   constexpr uint32_t kNumberOfTestedTimestamps = 200;
   constexpr uint64_t kStep = (kEndNs - kStartNs - 1) / kNumberOfTestedTimestamps + 1;
   // The max number of nanoseconds per pixel can be calculated using a ceil function.
-  const uint64_t max_nanoseconds_per_pixel = rounding_up_division(visible_ns, resolution);
+  const uint64_t max_nanoseconds_per_pixel = rounding_up_division(kVisibleNs, resolution);
   for (uint64_t timestamp_ns = kStartNs; timestamp_ns < kEndNs; timestamp_ns += kStep) {
     const uint64_t next_pixel_ns =
         GetNextPixelBoundaryTimeNs(timestamp_ns, resolution, kStartNs, kEndNs);

--- a/src/ClientData/ModuleAndFunctionLookupTest.cpp
+++ b/src/ClientData/ModuleAndFunctionLookupTest.cpp
@@ -25,7 +25,7 @@ namespace orbit_client_data {
 TEST(ModuleAndFunctionLookup, FindFunctionByModulePathBuildIdAndVirtualAddress) {
   constexpr const char* kModuleFilePath = "/path/to/module";
   constexpr const char* kModuleBuildId = "build_id";
-  const orbit_symbol_provider::ModuleIdentifier kModuleId{kModuleFilePath, kModuleBuildId};
+  const orbit_symbol_provider::ModuleIdentifier module_id{kModuleFilePath, kModuleBuildId};
 
   constexpr const char* kFunctionName = "foo()";
   constexpr uint64_t kFunctionVirtualAddress = 0x3000;
@@ -33,7 +33,7 @@ TEST(ModuleAndFunctionLookup, FindFunctionByModulePathBuildIdAndVirtualAddress) 
   ModuleManager module_manager;
 
   const FunctionInfo* function_info = FindFunctionByModuleIdentifierAndVirtualAddress(
-      module_manager, kModuleId, kFunctionVirtualAddress);
+      module_manager, module_id, kFunctionVirtualAddress);
   EXPECT_EQ(function_info, nullptr);
 
   ModuleInfo module_info;
@@ -42,7 +42,7 @@ TEST(ModuleAndFunctionLookup, FindFunctionByModulePathBuildIdAndVirtualAddress) 
 
   std::ignore = module_manager.AddOrUpdateModules({module_info});
 
-  function_info = FindFunctionByModuleIdentifierAndVirtualAddress(module_manager, kModuleId,
+  function_info = FindFunctionByModuleIdentifierAndVirtualAddress(module_manager, module_id,
                                                                   kFunctionVirtualAddress);
   EXPECT_EQ(function_info, nullptr);
 
@@ -50,10 +50,10 @@ TEST(ModuleAndFunctionLookup, FindFunctionByModulePathBuildIdAndVirtualAddress) 
   SymbolInfo* symbol_info = module_symbols.add_symbol_infos();
   symbol_info->set_demangled_name(kFunctionName);
   symbol_info->set_address(kFunctionVirtualAddress);
-  ModuleData* module_data = module_manager.GetMutableModuleByModuleIdentifier(kModuleId);
+  ModuleData* module_data = module_manager.GetMutableModuleByModuleIdentifier(module_id);
   module_data->AddSymbols(module_symbols);
 
-  function_info = FindFunctionByModuleIdentifierAndVirtualAddress(module_manager, kModuleId,
+  function_info = FindFunctionByModuleIdentifierAndVirtualAddress(module_manager, module_id,
                                                                   kFunctionVirtualAddress);
   ASSERT_NE(function_info, nullptr);
   EXPECT_EQ(function_info->pretty_name(), kFunctionName);

--- a/src/ClientData/ModuleDataTest.cpp
+++ b/src/ClientData/ModuleDataTest.cpp
@@ -29,7 +29,7 @@ TEST(ModuleData, Constructor) {
   object_segment.set_size_in_file(0x2FFF);
   object_segment.set_address(0x1000);
   object_segment.set_size_in_memory(0x3000);
-  constexpr ModuleInfo::ObjectFileType object_file_type = ModuleInfo::kElfFile;
+  constexpr ModuleInfo::ObjectFileType kObjectFileType = ModuleInfo::kElfFile;
 
   ModuleInfo module_info{};
   module_info.set_name(kName);
@@ -38,7 +38,7 @@ TEST(ModuleData, Constructor) {
   module_info.set_build_id(kBuildId);
   module_info.set_load_bias(kLoadBias);
   *module_info.add_object_segments() = object_segment;
-  module_info.set_object_file_type(object_file_type);
+  module_info.set_object_file_type(kObjectFileType);
 
   ModuleData module{module_info};
 
@@ -47,7 +47,7 @@ TEST(ModuleData, Constructor) {
   EXPECT_EQ(module.file_size(), kFileSize);
   EXPECT_EQ(module.build_id(), kBuildId);
   EXPECT_EQ(module.load_bias(), kLoadBias);
-  EXPECT_EQ(module.object_file_type(), object_file_type);
+  EXPECT_EQ(module.object_file_type(), kObjectFileType);
   ASSERT_EQ(module.GetObjectSegments().size(), 1);
   EXPECT_EQ(module.GetObjectSegments()[0].offset_in_file(), object_segment.offset_in_file());
   EXPECT_EQ(module.GetObjectSegments()[0].size_in_file(), object_segment.size_in_file());
@@ -267,7 +267,7 @@ TEST(ModuleData, UpdateIfChangedAndNotLoaded) {
   constexpr uint64_t kFileSize = 1000;
   constexpr const char* kBuildId = "";
   constexpr uint64_t kLoadBias = 4000;
-  ModuleInfo::ObjectFileType kObjectFileType = ModuleInfo::kElfFile;
+  ModuleInfo::ObjectFileType object_file_type = ModuleInfo::kElfFile;
 
   ModuleInfo module_info{};
   module_info.set_name(kName);
@@ -275,7 +275,7 @@ TEST(ModuleData, UpdateIfChangedAndNotLoaded) {
   module_info.set_file_size(kFileSize);
   module_info.set_build_id(kBuildId);
   module_info.set_load_bias(kLoadBias);
-  module_info.set_object_file_type(kObjectFileType);
+  module_info.set_object_file_type(object_file_type);
 
   ModuleData module{module_info};
   EXPECT_EQ(module.name(), kName);
@@ -283,7 +283,7 @@ TEST(ModuleData, UpdateIfChangedAndNotLoaded) {
   EXPECT_EQ(module.file_size(), kFileSize);
   EXPECT_EQ(module.build_id(), kBuildId);
   EXPECT_EQ(module.load_bias(), kLoadBias);
-  EXPECT_EQ(module.object_file_type(), kObjectFileType);
+  EXPECT_EQ(module.object_file_type(), object_file_type);
   EXPECT_EQ(module.GetLoadedSymbolsCompleteness(), ModuleData::SymbolCompleteness::kNoSymbols);
   EXPECT_EQ(module.GetFunctions().size(), 0);
 

--- a/src/ClientData/ScopeTreeTimerDataTest.cpp
+++ b/src/ClientData/ScopeTreeTimerDataTest.cpp
@@ -155,8 +155,8 @@ TEST(ScopeTreeTimerData, GetTimersAtDepthOptimized) {
   // Left, right and down timers
   AddTimersInScopeTreeTimerDataTest(scope_tree_timer_data);
 
-  uint32_t kOnePixel = 1;
-  uint32_t kNormalResolution = 1000;
+  constexpr uint32_t kOnePixel = 1;
+  constexpr uint32_t kNormalResolution = 1000;
 
   auto verify_size = [&scope_tree_timer_data](uint32_t depth, uint32_t resolution,
                                               uint64_t start_ns, uint64_t end_ns,

--- a/src/ClientData/ThreadTrackDataProviderTest.cpp
+++ b/src/ClientData/ThreadTrackDataProviderTest.cpp
@@ -72,8 +72,8 @@ TEST(ThreadTrackDataProvider, EmptyWhenCreated) {
 }
 
 TEST(ThreadTrackDataProvider, InsertAndGetTimer) {
-  const uint64_t kTimerStart = 2;
-  const uint64_t kTimerEnd = 5;
+  constexpr uint64_t kTimerStart = 2;
+  constexpr uint64_t kTimerEnd = 5;
   ThreadTrackDataProvider thread_track_data_provider;
 
   TimerInfo timer_info;
@@ -94,8 +94,8 @@ TEST(ThreadTrackDataProvider, InsertAndGetTimer) {
 }
 
 TEST(ThreadTrackDataProvider, OnCaptureComplete) {
-  const uint64_t kTimerStart = 2;
-  const uint64_t kTimerEnd = 5;
+  constexpr uint64_t kTimerStart = 2;
+  constexpr uint64_t kTimerEnd = 5;
   // ScopeTree: Need OnCaptureComplete to process the data when loading a capture.
   ThreadTrackDataProvider thread_track_data_provider(true);
 

--- a/src/ClientData/TimerTrackDataIdManagerTest.cpp
+++ b/src/ClientData/TimerTrackDataIdManagerTest.cpp
@@ -39,13 +39,13 @@ TEST(ThreadTrackDataProvider, DifferentTypesDifferentIds) {
   TimerTrackDataIdManager timer_track_data_id_manager;
   constexpr uint64_t kSharedId = 42;
   constexpr uint64_t kAnotherId = 43;
-  const std::string kAsyncTrackName = "Example Name";
+  const std::string async_track_name = "Example Name";
 
   uint32_t scheduler_track_id = timer_track_data_id_manager.GenerateSchedulerTrackId();
   uint32_t thread_track_id = timer_track_data_id_manager.GenerateThreadTrackId(kSharedId);
   uint32_t frame_track_id = timer_track_data_id_manager.GenerateFrameTrackId(kSharedId);
   uint32_t gpu_track_id = timer_track_data_id_manager.GenerateGpuTrackId(kSharedId);
-  uint32_t async_track_id = timer_track_data_id_manager.GenerateAsyncTrackId(kAsyncTrackName);
+  uint32_t async_track_id = timer_track_data_id_manager.GenerateAsyncTrackId(async_track_name);
 
   std::set<uint32_t> used_ids;
   used_ids.insert(scheduler_track_id);

--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -504,18 +504,18 @@ void Viewer::HighlightCurrentLine() {
 }
 
 int Viewer::WidthPercentageColumn() const {
-  const QString kWidestPercentage = "100.00 %";
-  return StringWidthInPixels(fontMetrics(), kWidestPercentage);
+  const QString widest_percentage = "100.00 %";
+  return StringWidthInPixels(fontMetrics(), widest_percentage);
 }
 
 int Viewer::WidthSampleCounterColumn() const {
-  const QString kSampleColumnTitle = "Samples";
-  return StringWidthInPixels(fontMetrics(), kSampleColumnTitle);
+  const QString sample_column_title = "Samples";
+  return StringWidthInPixels(fontMetrics(), sample_column_title);
 }
 
 int Viewer::WidthMarginBetweenColumns() const {
-  const QString kTwoSpaces = "  ";
-  return StringWidthInPixels(fontMetrics(), kTwoSpaces);
+  const QString two_spaces = "  ";
+  return StringWidthInPixels(fontMetrics(), two_spaces);
 }
 
 int Viewer::TopWidgetHeight() const { return fontMetrics().height(); }

--- a/src/CommandLineUtils/CommandLineUtils.cpp
+++ b/src/CommandLineUtils/CommandLineUtils.cpp
@@ -32,7 +32,7 @@ QStringList ExtractCommandLineFlags(absl::Span<const std::string> command_line_a
 
 QStringList RemoveFlagsNotPassedToMainWindow(const QStringList& flags) {
   QStringList result;
-  const std::array kDoNotPassTheseFlags{
+  const std::array do_not_pass_these_flags{
       absl::GetFlagReflectionHandle(FLAGS_ssh_hostname).Name(),
       absl::GetFlagReflectionHandle(FLAGS_ssh_port).Name(),
       absl::GetFlagReflectionHandle(FLAGS_ssh_user).Name(),
@@ -43,7 +43,7 @@ QStringList RemoveFlagsNotPassedToMainWindow(const QStringList& flags) {
   for (const auto& flag : flags) {
     bool ignore_this_flag = false;
 
-    for (auto ignore_flag : kDoNotPassTheseFlags) {
+    for (auto ignore_flag : do_not_pass_these_flags) {
       const QString flag_cmd_format =
           QString("-%1=").arg(QString::fromStdString(std::string{ignore_flag}));
       if (flag.contains(flag_cmd_format)) {

--- a/src/ConfigWidgets/StopSymbolDownloadDialogTest.cpp
+++ b/src/ConfigWidgets/StopSymbolDownloadDialogTest.cpp
@@ -69,10 +69,10 @@ TEST_F(StopSymbolDownloadDialogTest, StopDownload) {
 }
 
 TEST_F(StopSymbolDownloadDialogTest, StopDownloadAndDisable) {
-  auto* rememberCheckBox = dialog_.findChild<QCheckBox*>("rememberCheckBox");
-  ASSERT_NE(rememberCheckBox, nullptr);
+  auto* remember_check_box = dialog_.findChild<QCheckBox*>("rememberCheckBox");
+  ASSERT_NE(remember_check_box, nullptr);
 
-  rememberCheckBox->setCheckState(Qt::Checked);
+  remember_check_box->setCheckState(Qt::Checked);
 
   QMetaObject::invokeMethod(
       &dialog_, [this] { QTest::mouseClick(stop_button_, Qt::LeftButton); }, Qt::QueuedConnection);

--- a/src/Containers/BlockChainTest.cpp
+++ b/src/Containers/BlockChainTest.cpp
@@ -93,23 +93,23 @@ TEST(BlockChain, Clear) {
 }
 
 TEST(BlockChain, ElementIteration) {
-  constexpr const int v1 = 5;
-  constexpr const int v2 = 10;
-  constexpr const int v3 = 15;
+  constexpr const int kV1 = 5;
+  constexpr const int kV2 = 10;
+  constexpr const int kV3 = 15;
 
   BlockChain<int, 1024> chain;
 
-  chain.emplace_back(v1);
-  chain.emplace_back(v2);
-  chain.emplace_back(v3);
+  chain.emplace_back(kV1);
+  chain.emplace_back(kV2);
+  chain.emplace_back(kV3);
 
   // Note that only the "++it" operator is supported
   auto it = chain.begin();
-  EXPECT_EQ(*it, v1);
+  EXPECT_EQ(*it, kV1);
   ++it;
-  EXPECT_EQ(*it, v2);
+  EXPECT_EQ(*it, kV2);
   ++it;
-  EXPECT_EQ(*it, v3);
+  EXPECT_EQ(*it, kV3);
   ++it;
   // ... and also only !=, not ==
   EXPECT_FALSE(it != chain.end());
@@ -167,33 +167,33 @@ TEST(BlockChain, Reset) {
   BlockChain<int, 1024> chain;
   chain.push_back_n(5, 1024 * 3);
   EXPECT_GT(chain.size(), 0);
-  const Block<int, 1024>* blockPtr[] = {chain.root(), nullptr, nullptr};
-  blockPtr[1] = blockPtr[0]->next();
-  blockPtr[2] = blockPtr[1]->next();
+  const Block<int, 1024>* block_ptr[] = {chain.root(), nullptr, nullptr};
+  block_ptr[1] = block_ptr[0]->next();
+  block_ptr[2] = block_ptr[1]->next();
 
   // Tests below rely quite a lot on the internals of BlockChain, but this
   // seems the easiest way to actually test re-usage of the block pointers
   chain.Reset();
   EXPECT_EQ(chain.size(), 0);
-  EXPECT_EQ(blockPtr[0]->size(), 0);
-  EXPECT_EQ(blockPtr[1]->size(), 0);
-  EXPECT_EQ(blockPtr[2]->size(), 0);
+  EXPECT_EQ(block_ptr[0]->size(), 0);
+  EXPECT_EQ(block_ptr[1]->size(), 0);
+  EXPECT_EQ(block_ptr[2]->size(), 0);
 
   chain.push_back_n(10, 1024);
   EXPECT_GT(chain.size(), 0);
   EXPECT_EQ(chain.root()->data()[0], 10);
-  EXPECT_EQ(chain.root(), blockPtr[0]);
-  EXPECT_EQ(chain.root()->next(), blockPtr[1]);
-  EXPECT_EQ(blockPtr[1]->size(), 0);
+  EXPECT_EQ(chain.root(), block_ptr[0]);
+  EXPECT_EQ(chain.root()->next(), block_ptr[1]);
+  EXPECT_EQ(block_ptr[1]->size(), 0);
 
   chain.push_back_n(10, 1024);
-  EXPECT_EQ(chain.root()->next(), blockPtr[1]);
-  EXPECT_EQ(blockPtr[1]->size(), 1024);
-  EXPECT_EQ(blockPtr[2]->size(), 0);
+  EXPECT_EQ(chain.root()->next(), block_ptr[1]);
+  EXPECT_EQ(block_ptr[1]->size(), 1024);
+  EXPECT_EQ(block_ptr[2]->size(), 0);
 
   chain.push_back_n(10, 1024);
-  EXPECT_EQ(chain.root()->next()->next(), blockPtr[2]);
-  EXPECT_EQ(blockPtr[2]->size(), 1024);
+  EXPECT_EQ(chain.root()->next()->next(), block_ptr[2]);
+  EXPECT_EQ(block_ptr[2]->size(), 1024);
 }
 
 TEST(BlockChain, MovableType) {

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -150,10 +150,10 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
   }
 
   constexpr int32_t kProcessId = 42;
-  const std::string kExecutablePath = "/path/to/text.exe";
+  const std::string executable_path = "/path/to/text.exe";
   orbit_grpc_protos::CaptureStarted capture_started{};
   capture_started.set_process_id(kProcessId);
-  capture_started.set_executable_path(kExecutablePath);
+  capture_started.set_executable_path(executable_path);
 
   auto capture_data =
       std::make_unique<CaptureData>(capture_started, std::nullopt, absl::flat_hash_set<uint64_t>{},
@@ -320,7 +320,7 @@ TEST_F(CallstackDataViewTest, ColumnSelectedShowsRightResults) {
 }
 
 TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
-  const std::vector<uint64_t> kCallstackFrameAddresses{
+  const std::vector<uint64_t> callstack_frame_addresses{
       // Corresponding CallstackDataViewFrame: frame.module             frame.function
       0x3140,  //                                module 0 (loaded)        function 0 (selected)
       0x9260,  //                                module 1 (loaded)        function 1 (not selected)
@@ -329,7 +329,7 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       0x2200,  //                                module 4 (not loaded)    nullptr
   };
   const std::vector<bool> kFrameModuleNotNull{true, true, false, true, true};
-  const std::vector<bool> kFrameFunctionNotNull{true, true, false, false, false};
+  const std::vector<bool> frame_function_not_null{true, true, false, false, false};
 
   bool capture_connected;
   std::vector<bool> functions_selected{true, false, true, true, false};
@@ -364,7 +364,7 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     ContextMenuEntry select = ContextMenuEntry::kDisabled;
     ContextMenuEntry unselect = ContextMenuEntry::kDisabled;
     for (int selected_index : selected_indices) {
-      if (kFrameFunctionNotNull[selected_index] && capture_connected) {
+      if (frame_function_not_null[selected_index] && capture_connected) {
         // Source code and disassembly actions are available if and only if: 1) capture is connected
         // and 2) there exists a function that is not null.
         source_code_or_disassembly = ContextMenuEntry::kEnabled;
@@ -394,7 +394,7 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     CheckSingleAction(context_menu, kMenuActionUnselect, unselect);
   };
 
-  SetCallstackFromFrames(kCallstackFrameAddresses);
+  SetCallstackFromFrames(callstack_frame_addresses);
 
   capture_connected = false;
   verify_context_menu_action_availability({0});

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -61,10 +61,10 @@ void CheckCopySelectionIsInvoked(const FlattenContextMenu& context_menu,
 }
 
 static void ExpectSameLines(const std::string_view& actual, const std::string_view& expected) {
-  static const std::string kDelimeter = "\r\n";
+  static const std::string delimeter = "\r\n";
 
-  std::vector<std::string_view> actual_lines = absl::StrSplit(actual, kDelimeter);
-  std::vector<std::string_view> expected_lines = absl::StrSplit(expected, kDelimeter);
+  std::vector<std::string_view> actual_lines = absl::StrSplit(actual, delimeter);
+  std::vector<std::string_view> expected_lines = absl::StrSplit(expected, delimeter);
   EXPECT_THAT(actual_lines, testing::UnorderedElementsAreArray(expected_lines));
 }
 

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -392,10 +392,10 @@ void LiveFunctionsDataView::OnJumpToRequested(std::string_view action,
 
   // Write header line
   constexpr size_t kNumColumns = 5;
-  const std::array<std::string, kNumColumns> kNames{"Name", "Thread", "Start", "End",
-                                                    "Duration (ns)"};
+  const std::array<std::string, kNumColumns> names{"Name", "Thread", "Start", "End",
+                                                   "Duration (ns)"};
 
-  OUTCOME_TRY(WriteLineToCsv(fd, kNames));
+  OUTCOME_TRY(WriteLineToCsv(fd, names));
 
   absl::flat_hash_set<ScopeId> selected_scope_ids;
   std::transform(std::begin(selection), std::end(selection),

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -464,11 +464,11 @@ SampledFunction& SamplingReportDataView::GetSampledFunction(unsigned int row) {
 ErrorMessageOr<void> SamplingReportDataView::WriteStackEventsToCsv(std::string_view file_path) {
   OUTCOME_TRY(auto fd, orbit_base::OpenFileForWriting(file_path));
 
-  static const std::vector<std::string> kNames{"Thread", "Timestamp (ns)", "Names leaf/foo/main",
-                                               "Addresses leaf_addr/foo_addr/main_addr"};
+  static const std::vector<std::string> names{"Thread", "Timestamp (ns)", "Names leaf/foo/main",
+                                              "Addresses leaf_addr/foo_addr/main_addr"};
   constexpr std::string_view kFramesSeparator = "/";
 
-  OUTCOME_TRY(WriteLineToCsv(fd, kNames));
+  OUTCOME_TRY(WriteLineToCsv(fd, names));
   const orbit_client_data::CallstackData& callstack_data = sampling_report_->GetCallstackData();
 
   const std::vector<orbit_client_data::CallstackEvent> callstack_events =

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -254,10 +254,10 @@ std::unique_ptr<CaptureData> GenerateTestCaptureData(
   }
 
   constexpr int32_t kProcessId = 42;
-  const std::string kExecutablePath = "/path/to/text.exe";
+  const std::string executable_path = "/path/to/text.exe";
   orbit_grpc_protos::CaptureStarted capture_started{};
   capture_started.set_process_id(kProcessId);
-  capture_started.set_executable_path(kExecutablePath);
+  capture_started.set_executable_path(executable_path);
 
   auto capture_data =
       std::make_unique<CaptureData>(capture_started, std::nullopt, absl::flat_hash_set<uint64_t>{},

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -421,27 +421,27 @@ int main(int argc, char* argv[]) {
     // Instrument vkQueuePresentKHR, if possible.
     // Some application don't call libVulkan library directly; instead, they just query the
     // function addresses and use those. So let's just instrument the `ggpvlk QueuePresentKHR`
-    static const std::string kGgpvlkModuleName = "ggpvlk.so";
-    static const std::string kQueuePresentFunctionName{
+    static const std::string ggpvlk_module_name = "ggpvlk.so";
+    static const std::string queue_present_function_name{
         "yeti::internal::vulkan::(anonymous namespace)::QueuePresentKHR(VkQueue_T*, "
         "VkPresentInfoKHR const*)"};
 
     std::string libvulkan_file_path;
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
-      if (module.soname() == kGgpvlkModuleName) {
+      if (module.soname() == ggpvlk_module_name) {
         libvulkan_file_path = module.file_path();
         break;
       }
     }
     if (!libvulkan_file_path.empty()) {
-      ORBIT_LOG("%s found: instrumenting %s", kGgpvlkModuleName, kQueuePresentFunctionName);
+      ORBIT_LOG("%s found: instrumenting %s", ggpvlk_module_name, queue_present_function_name);
       ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromFunctionNameInDebugSymbols(
           &module_manager, &options.selected_functions, libvulkan_file_path,
-          kQueuePresentFunctionName,
+          queue_present_function_name,
           orbit_fake_client::FakeCaptureEventProcessor::kFrameBoundaryFunctionId);
-      ORBIT_LOG("%s instrumented", kQueuePresentFunctionName);
+      ORBIT_LOG("%s instrumented", queue_present_function_name);
     } else {
-      ORBIT_LOG("%s not found", kGgpvlkModuleName);
+      ORBIT_LOG("%s not found", ggpvlk_module_name);
     }
   }
 

--- a/src/Http/HttpDownloadOperation.cpp
+++ b/src/Http/HttpDownloadOperation.cpp
@@ -22,21 +22,21 @@ void HttpDownloadOperation::UpdateState(State state, std::optional<std::string> 
   ORBIT_CHECK((state == State::kError) == maybe_error_msg.has_value());
   state_ = state;
 
-  const std::string kDownloadDetails =
+  const std::string download_details =
       absl::StrFormat("from %s to %s", url_, save_file_path_.string());
 
   switch (state) {
     case State::kInitial:
       break;
     case State::kStarted:
-      ORBIT_LOG("Started downloading %s.\n", kDownloadDetails);
+      ORBIT_LOG("Started downloading %s.\n", download_details);
       break;
     case State::kCancelled:
-      ORBIT_LOG("Cancelled downloading %s.\n", kDownloadDetails);
+      ORBIT_LOG("Cancelled downloading %s.\n", download_details);
       emit finished(state, std::nullopt);
       break;
     case State::kDone:
-      ORBIT_LOG("Succeeded to download %s.\n", kDownloadDetails);
+      ORBIT_LOG("Succeeded to download %s.\n", download_details);
       emit finished(state, std::nullopt);
       break;
     case State::kNotFound:
@@ -44,7 +44,7 @@ void HttpDownloadOperation::UpdateState(State state, std::optional<std::string> 
       emit finished(state, std::nullopt);
       break;
     case State::kError:
-      ORBIT_LOG("Failed to download %s:\n%s", kDownloadDetails, maybe_error_msg.value());
+      ORBIT_LOG("Failed to download %s:\n%s", download_details, maybe_error_msg.value());
       emit finished(state, maybe_error_msg);
       break;
   }

--- a/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
@@ -163,8 +163,8 @@ class ProducerEventProcessorHijackingFunctionEntryExitForLinuxTracing
 
 absl::flat_hash_set<std::string> ListFileNamesOfAllMinidumps() {
   absl::flat_hash_set<std::string> result;
-  const std::string kCoreDirectory = "/usr/local/cloudcast/core";
-  auto error_or_core_files = orbit_base::ListFilesInDirectory(kCoreDirectory);
+  const std::string core_directory = "/usr/local/cloudcast/core";
+  auto error_or_core_files = orbit_base::ListFilesInDirectory(core_directory);
   if (!error_or_core_files.has_error()) {
     const std::regex check_if_minidump_file(absl::StrFormat(R"(.*\.[0-9]+\.core\.dmp)"));
     for (const std::filesystem::path& path : error_or_core_files.value()) {
@@ -204,8 +204,8 @@ TargetProcessStateAfterCapture GetTargetProcessStateAfterCapture(
   }
 
   // Check whether we find a minidump. Otherwise we assume the process ended gracefully.
-  const std::string kCoreDirectory = "/usr/local/cloudcast/core";
-  auto error_or_core_files = orbit_base::ListFilesInDirectory(kCoreDirectory);
+  const std::string core_directory = "/usr/local/cloudcast/core";
+  auto error_or_core_files = orbit_base::ListFilesInDirectory(core_directory);
   if (error_or_core_files.has_error()) {
     // We can't access the directory with the core files; we return an error state.
     return result;

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -124,22 +124,22 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedWithAllThreePerfEvents) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job, GpuJobEq(expected_gpu_job));
@@ -150,23 +150,23 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedEvenWithOutOfOrderPerfEvents1) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
       .Accept(&visitor_);
   EXPECT_THAT(actual_gpu_job, GpuJobEq(expected_gpu_job));
 }
@@ -176,22 +176,22 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedEvenWithOutOfOrderPerfEvents2) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
   EXPECT_THAT(actual_gpu_job, GpuJobEq(expected_gpu_job));
 }
@@ -201,19 +201,18 @@ TEST_F(GpuTracepointVisitorTest, NoJobBecauseOfMismatchingContext) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampD = 300;
 
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(0);
 
-  PerfEvent{
-      MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext + 1, kSeqno, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext + 1, kSeqno, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
 }
 
@@ -222,17 +221,17 @@ TEST_F(GpuTracepointVisitorTest, NoJobBecauseOfMismatchingSeqno) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampD = 300;
 
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(0);
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno + 1, kTimeline)}
-      .Accept(&visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno + 1, timeline)}.Accept(
+      &visitor_);
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
 }
 
@@ -241,17 +240,17 @@ TEST_F(GpuTracepointVisitorTest, NoJobBecauseOfMismatchingTimeline) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampD = 300;
 
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(0);
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline + "1")}
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline + "1")}
       .Accept(&visitor_);
 }
 
@@ -261,7 +260,7 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingByCo
   static constexpr uint32_t kContext1 = 1;
   static constexpr uint32_t kContext2 = 2;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -273,10 +272,10 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingByCo
   static constexpr uint64_t kTimestampD2 = kNsDistanceForSameDepth + 500;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext1, kSeqno, kTimeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext1, kSeqno, timeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext2, kSeqno, kTimeline, 0, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext2, kSeqno, timeline, 0, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -285,18 +284,18 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingByCo
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext1, kSeqno, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext1, kSeqno, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext1, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext1, kSeqno, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext1, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext1, kSeqno, timeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext2, kSeqno, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext2, kSeqno, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext2, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext2, kSeqno, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext2, kSeqno, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext2, kSeqno, timeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -309,7 +308,7 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingBySe
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -321,10 +320,10 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingBySe
   static constexpr uint64_t kTimestampD2 = kNsDistanceForSameDepth + 500;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 0, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 0, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -333,18 +332,18 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingBySe
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -356,18 +355,18 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsButOnDifferentTimelines) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string kTimeline1 = "timeline1";
-  static const std::string kTimeline2 = "timeline2";
+  static const std::string timeline1 = "timeline1";
+  static const std::string timeline2 = "timeline2";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline1, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline1, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline2, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline2, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -376,18 +375,18 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsButOnDifferentTimelines) {
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline1)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline1)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline1)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline1)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline1)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline1)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline2)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline2)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline2)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline2)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline2)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline2)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -400,7 +399,7 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithDifferentDepthsBecause
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -411,10 +410,10 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithDifferentDepthsBecause
   static constexpr uint64_t kTimestampD2 = 600;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 1, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -423,18 +422,18 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithDifferentDepthsBecause
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -447,7 +446,7 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithImmediateHwExecution) {
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -458,10 +457,10 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithImmediateHwExecution) {
   static constexpr uint64_t kTimestampD2 = 410;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 1, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -470,18 +469,18 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithImmediateHwExecution) {
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -494,7 +493,7 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithDelayedHwExecution) {
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -505,10 +504,10 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithDelayedHwExecution) {
   static constexpr uint64_t kTimestampD2 = 400;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 1, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -517,18 +516,18 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithDelayedHwExecution) {
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -542,7 +541,7 @@ TEST_F(GpuTracepointVisitorTest,
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string kTimeline = "timeline";
+  static const std::string timeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampD1 = 300;
@@ -556,10 +555,10 @@ TEST_F(GpuTracepointVisitorTest,
   static constexpr uint64_t kTimestampC1 = kTimestampD2;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 1, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 1, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 0, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 0, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -569,17 +568,17 @@ TEST_F(GpuTracepointVisitorTest,
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -131,7 +131,8 @@ class MemoryTracingIntegrationTestFixture {
 
 void VerifyOrderAndContentOfEvents(absl::Span<const ProducerCaptureEvent> events,
                                    uint64_t sampling_period_ns) {
-  const auto kMemoryEventsTimeDifferenceTolerance = static_cast<uint64_t>(sampling_period_ns * 0.2);
+  const auto memory_events_time_difference_tolerance =
+      static_cast<uint64_t>(sampling_period_ns * 0.2);
   uint64_t previous_memory_usage_event_timestamp_ns = 0;
 
   for (const auto& event : events) {
@@ -183,7 +184,7 @@ void VerifyOrderAndContentOfEvents(absl::Span<const ProducerCaptureEvent> events
     // Verify that the memory events in the same memory_usage_event are sampled at very close time.
     uint64_t max_timestamp = *std::max_element(timestamps.begin(), timestamps.end());
     uint64_t min_timestamp = *std::min_element(timestamps.begin(), timestamps.end());
-    EXPECT_LE(max_timestamp - min_timestamp, kMemoryEventsTimeDifferenceTolerance);
+    EXPECT_LE(max_timestamp - min_timestamp, memory_events_time_difference_tolerance);
   }
 }
 
@@ -203,17 +204,17 @@ void VerifyEventCounts(absl::Span<const ProducerCaptureEvent> events, size_t exp
 }  // namespace
 
 TEST(MemoryTracingIntegrationTest, MemoryTracing) {
-  const uint64_t kMemorySamplingPeriodNs = absl::Milliseconds(100) / absl::Nanoseconds(1);
-  const size_t kPeriodCounts = 10;
+  const uint64_t memory_sampling_period_ns = absl::Milliseconds(100) / absl::Nanoseconds(1);
+  const size_t period_counts = 10;
 
-  MemoryTracingIntegrationTestFixture fixture(kMemorySamplingPeriodNs);
+  MemoryTracingIntegrationTestFixture fixture(memory_sampling_period_ns);
 
-  absl::Duration tracing_period = absl::Nanoseconds(kMemorySamplingPeriodNs * kPeriodCounts);
+  absl::Duration tracing_period = absl::Nanoseconds(memory_sampling_period_ns * period_counts);
   std::vector<ProducerCaptureEvent> events = TraceAndGetEvents(&fixture, tracing_period);
 
-  VerifyOrderAndContentOfEvents(events, kMemorySamplingPeriodNs);
+  VerifyOrderAndContentOfEvents(events, memory_sampling_period_ns);
 
-  VerifyEventCounts(events, kPeriodCounts);
+  VerifyEventCounts(events, period_counts);
 }
 
 }  // namespace orbit_memory_tracing

--- a/src/MemoryTracing/MemoryTracingUtils.cpp
+++ b/src/MemoryTracing/MemoryTracingUtils.cpp
@@ -120,9 +120,9 @@ ErrorMessageOr<SystemMemoryUsage> GetSystemMemoryUsage() {
   SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
   system_memory_usage.set_timestamp_ns(orbit_base::CaptureTimestampNs());
 
-  const std::string kSystemMemoryUsageFilename = "/proc/meminfo";
+  const std::string system_memory_usage_filename = "/proc/meminfo";
   ErrorMessageOr<std::string> reading_result =
-      orbit_base::ReadFileToString(kSystemMemoryUsageFilename);
+      orbit_base::ReadFileToString(system_memory_usage_filename);
   if (reading_result.has_error()) {
     ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
@@ -130,19 +130,19 @@ ErrorMessageOr<SystemMemoryUsage> GetSystemMemoryUsage() {
   ErrorMessageOr<void> updating_result =
       UpdateSystemMemoryUsageFromMemInfo(reading_result.value(), &system_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Updating SystemMemoryUsage from %s: %s", kSystemMemoryUsageFilename,
+    ORBIT_ERROR("Updating SystemMemoryUsage from %s: %s", system_memory_usage_filename,
                 updating_result.error().message());
   }
 
-  const std::string kSystemPageFaultsFilename = "/proc/vmstat";
-  reading_result = orbit_base::ReadFileToString(kSystemPageFaultsFilename);
+  const std::string system_page_faults_filename = "/proc/vmstat";
+  reading_result = orbit_base::ReadFileToString(system_page_faults_filename);
   if (reading_result.has_error()) {
     ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
   }
   updating_result = UpdateSystemMemoryUsageFromVmStat(reading_result.value(), &system_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Updating SystemMemoryUsage from %s: %s", kSystemPageFaultsFilename,
+    ORBIT_ERROR("Updating SystemMemoryUsage from %s: %s", system_page_faults_filename,
                 updating_result.error().message());
   }
 
@@ -220,9 +220,9 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) {
   process_memory_usage.set_pid(pid);
   process_memory_usage.set_timestamp_ns(orbit_base::CaptureTimestampNs());
 
-  const std::string kProcessPageFaultsFilename = absl::StrFormat("/proc/%d/stat", pid);
+  const std::string process_page_faults_filename = absl::StrFormat("/proc/%d/stat", pid);
   ErrorMessageOr<std::string> reading_result =
-      orbit_base::ReadFileToString(kProcessPageFaultsFilename);
+      orbit_base::ReadFileToString(process_page_faults_filename);
   if (reading_result.has_error()) {
     ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
@@ -230,12 +230,12 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) {
   ErrorMessageOr<void> updating_result =
       UpdateProcessMemoryUsageFromProcessStat(reading_result.value(), &process_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Updating ProcessMemoryUsage from %s: %s", kProcessPageFaultsFilename,
+    ORBIT_ERROR("Updating ProcessMemoryUsage from %s: %s", process_page_faults_filename,
                 updating_result.error().message());
   }
 
-  const std::string kProcessMemoryUsageFilename = absl::StrFormat("/proc/%u/status", pid);
-  reading_result = orbit_base::ReadFileToString(kProcessMemoryUsageFilename);
+  const std::string process_memory_usage_filename = absl::StrFormat("/proc/%u/status", pid);
+  reading_result = orbit_base::ReadFileToString(process_memory_usage_filename);
   if (reading_result.has_error()) {
     ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
@@ -243,7 +243,7 @@ ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(pid_t pid) {
   ErrorMessageOr<int64_t> extracting_result =
       ExtractRssAnonFromProcessStatus(reading_result.value());
   if (extracting_result.has_error()) {
-    ORBIT_ERROR("Extracting process RssAnon from %s: %s", kProcessMemoryUsageFilename,
+    ORBIT_ERROR("Extracting process RssAnon from %s: %s", process_memory_usage_filename,
                 extracting_result.error().message());
   } else {
     process_memory_usage.set_rss_anon_kb(extracting_result.value());
@@ -345,9 +345,9 @@ ErrorMessageOr<void> UpdateCGroupMemoryUsageFromMemoryStat(std::string_view memo
 ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
   uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
 
-  const std::string kProcessCGroupsFilename = absl::StrFormat("/proc/%d/cgroup", pid);
+  const std::string process_c_groups_filename = absl::StrFormat("/proc/%d/cgroup", pid);
   ErrorMessageOr<std::string> reading_result =
-      orbit_base::ReadFileToString(kProcessCGroupsFilename);
+      orbit_base::ReadFileToString(process_c_groups_filename);
   if (reading_result.has_error()) {
     ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
@@ -364,9 +364,9 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
   cgroup_memory_usage.set_cgroup_name(cgroup_name);
   cgroup_memory_usage.set_timestamp_ns(current_timestamp_ns);
 
-  const std::string kCGroupMemoryLimitFilename =
+  const std::string c_group_memory_limit_filename =
       absl::StrFormat("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", cgroup_name);
-  reading_result = orbit_base::ReadFileToString(kCGroupMemoryLimitFilename);
+  reading_result = orbit_base::ReadFileToString(c_group_memory_limit_filename);
   if (reading_result.has_error()) {
     ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
@@ -374,13 +374,13 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
   ErrorMessageOr<void> updating_result =
       UpdateCGroupMemoryUsageFromMemoryLimitInBytes(reading_result.value(), &cgroup_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Updating CGroupMemoryUsage from %s: %s", kCGroupMemoryLimitFilename,
+    ORBIT_ERROR("Updating CGroupMemoryUsage from %s: %s", c_group_memory_limit_filename,
                 updating_result.error().message());
   }
 
-  const std::string kCGroupMemoryUsageAndPageFaultsFilename =
+  const std::string c_group_memory_usage_and_page_faults_filename =
       absl::StrFormat("/sys/fs/cgroup/memory/%s/memory.stat", cgroup_name);
-  reading_result = orbit_base::ReadFileToString(kCGroupMemoryUsageAndPageFaultsFilename);
+  reading_result = orbit_base::ReadFileToString(c_group_memory_usage_and_page_faults_filename);
   if (reading_result.has_error()) {
     ORBIT_ERROR("%s", reading_result.error().message());
     return reading_result.error();
@@ -388,8 +388,8 @@ ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(pid_t pid) {
   updating_result =
       UpdateCGroupMemoryUsageFromMemoryStat(reading_result.value(), &cgroup_memory_usage);
   if (updating_result.has_error()) {
-    ORBIT_ERROR("Updating CGroupMemoryUsage from %s: %s", kCGroupMemoryUsageAndPageFaultsFilename,
-                updating_result.error().message());
+    ORBIT_ERROR("Updating CGroupMemoryUsage from %s: %s",
+                c_group_memory_usage_and_page_faults_filename, updating_result.error().message());
   }
 
   return cgroup_memory_usage;

--- a/src/MemoryTracing/MemoryTracingUtilsTest.cpp
+++ b/src/MemoryTracing/MemoryTracingUtilsTest.cpp
@@ -28,13 +28,13 @@ MATCHER_P(MemoryProtoEq, expected, "") {
 namespace orbit_memory_tracing {
 
 TEST(MemoryUtils, UpdateSystemMemoryUsageFromMemInfo) {
-  const int kMemTotal = 16396576;
-  const int kMemFree = 11493816;
-  const int kMemAvailable = 14378752;
-  const int kBuffers = 71540;
-  const int kCached = 3042860;
+  const int mem_total = 16396576;
+  const int mem_free = 11493816;
+  const int mem_available = 14378752;
+  const int buffers = 71540;
+  const int cached = 3042860;
 
-  const std::string kValidMeminfo =
+  const std::string valid_meminfo =
       absl::Substitute(R"(MemTotal:       $0 kB
 MemFree:        $1 kB
 MemAvailable:   $2 kB
@@ -86,61 +86,61 @@ Hugetlb:               0 kB
 DirectMap4k:      201960 kB
 DirectMap2M:     5040128 kB
 DirectMap1G:    13631488 kB)",
-                       kMemTotal, kMemFree, kMemAvailable, kBuffers, kCached);
+                       mem_total, mem_free, mem_available, buffers, cached);
 
-  const std::string kPartialMeminfo = absl::Substitute(R"(MemTotal:       $0 kB
+  const std::string partial_meminfo = absl::Substitute(R"(MemTotal:       $0 kB
 MemFree:        $1 kB
 SwapCached:      0 kB)",
-                                                       kMemTotal, kMemFree);
+                                                       mem_total, mem_free);
 
-  const std::string kEmptyMeminfo = "";
+  const std::string empty_meminfo = "";
 
   {
-    const SystemMemoryUsage kExpectedSystemMemoryUsage = [] {
+    const SystemMemoryUsage expected_system_memory_usage = [] {
       SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
-      system_memory_usage.set_total_kb(kMemTotal);
-      system_memory_usage.set_free_kb(kMemFree);
-      system_memory_usage.set_available_kb(kMemAvailable);
-      system_memory_usage.set_buffers_kb(kBuffers);
-      system_memory_usage.set_cached_kb(kCached);
+      system_memory_usage.set_total_kb(mem_total);
+      system_memory_usage.set_free_kb(mem_free);
+      system_memory_usage.set_available_kb(mem_available);
+      system_memory_usage.set_buffers_kb(buffers);
+      system_memory_usage.set_cached_kb(cached);
       return system_memory_usage;
     }();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateSystemMemoryUsageFromMemInfo(kValidMeminfo, &system_memory_usage);
+        UpdateSystemMemoryUsageFromMemInfo(valid_meminfo, &system_memory_usage);
     EXPECT_FALSE(updating_result.has_error());
-    EXPECT_THAT(system_memory_usage, MemoryProtoEq(kExpectedSystemMemoryUsage));
+    EXPECT_THAT(system_memory_usage, MemoryProtoEq(expected_system_memory_usage));
   }
 
   {
-    const SystemMemoryUsage kExpectedSystemMemoryUsage = [] {
+    const SystemMemoryUsage expected_system_memory_usage = [] {
       SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
-      system_memory_usage.set_total_kb(kMemTotal);
-      system_memory_usage.set_free_kb(kMemFree);
+      system_memory_usage.set_total_kb(mem_total);
+      system_memory_usage.set_free_kb(mem_free);
       return system_memory_usage;
     }();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateSystemMemoryUsageFromMemInfo(kPartialMeminfo, &system_memory_usage);
+        UpdateSystemMemoryUsageFromMemInfo(partial_meminfo, &system_memory_usage);
     EXPECT_FALSE(updating_result.has_error());
-    EXPECT_THAT(system_memory_usage, MemoryProtoEq(kExpectedSystemMemoryUsage));
+    EXPECT_THAT(system_memory_usage, MemoryProtoEq(expected_system_memory_usage));
   }
 
   {
-    const SystemMemoryUsage kExpectedSystemMemoryUsage = CreateAndInitializeSystemMemoryUsage();
+    const SystemMemoryUsage expected_system_memory_usage = CreateAndInitializeSystemMemoryUsage();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateSystemMemoryUsageFromMemInfo(kEmptyMeminfo, &system_memory_usage);
+        UpdateSystemMemoryUsageFromMemInfo(empty_meminfo, &system_memory_usage);
     EXPECT_TRUE(updating_result.has_error());
-    EXPECT_THAT(system_memory_usage, MemoryProtoEq(kExpectedSystemMemoryUsage));
+    EXPECT_THAT(system_memory_usage, MemoryProtoEq(expected_system_memory_usage));
   }
 }
 
 TEST(MemoryUtils, UpdateSystemMemoryUsageFromVmStat) {
-  const int kPageFaults = 123456789;
-  const int kMajorPageFaults = 123456;
+  const int page_faults = 123456789;
+  const int major_page_faults = 123456;
 
-  const std::string kValidProcVmStat = absl::Substitute(R"(nr_free_pages 2258933
+  const std::string valid_proc_vm_stat = absl::Substitute(R"(nr_free_pages 2258933
 nr_zone_inactive_anon 655781
 nr_zone_active_anon 265654
 nr_zone_inactive_file 103608
@@ -294,96 +294,98 @@ balloon_migrate 3482
 swap_ra 277950
 swap_ra_hit 207052
 nr_unstable 0)",
-                                                        kPageFaults, kMajorPageFaults);
+                                                          page_faults, major_page_faults);
 
-  const std::string kPartialProcVmStat = absl::Substitute(R"(pgfault $0)", kPageFaults);
+  const std::string partial_proc_vm_stat = absl::Substitute(R"(pgfault $0)", page_faults);
 
-  const std::string kEmptyProcVmStat = "";
+  const std::string empty_proc_vm_stat = "";
 
   {
-    const SystemMemoryUsage kExpectedSystemMemoryUsage = [] {
+    const SystemMemoryUsage expected_system_memory_usage = [] {
       SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
-      system_memory_usage.set_pgfault(kPageFaults);
-      system_memory_usage.set_pgmajfault(kMajorPageFaults);
+      system_memory_usage.set_pgfault(page_faults);
+      system_memory_usage.set_pgmajfault(major_page_faults);
       return system_memory_usage;
     }();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateSystemMemoryUsageFromVmStat(kValidProcVmStat, &system_memory_usage);
+        UpdateSystemMemoryUsageFromVmStat(valid_proc_vm_stat, &system_memory_usage);
     EXPECT_FALSE(updating_result.has_error());
-    EXPECT_THAT(system_memory_usage, MemoryProtoEq(kExpectedSystemMemoryUsage));
+    EXPECT_THAT(system_memory_usage, MemoryProtoEq(expected_system_memory_usage));
   }
 
   {
-    const SystemMemoryUsage kExpectedSystemMemoryUsage = [] {
+    const SystemMemoryUsage expected_system_memory_usage = [] {
       SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
-      system_memory_usage.set_pgfault(kPageFaults);
+      system_memory_usage.set_pgfault(page_faults);
       return system_memory_usage;
     }();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateSystemMemoryUsageFromVmStat(kPartialProcVmStat, &system_memory_usage);
+        UpdateSystemMemoryUsageFromVmStat(partial_proc_vm_stat, &system_memory_usage);
     EXPECT_FALSE(updating_result.has_error());
-    EXPECT_THAT(system_memory_usage, MemoryProtoEq(kExpectedSystemMemoryUsage));
+    EXPECT_THAT(system_memory_usage, MemoryProtoEq(expected_system_memory_usage));
   }
 
   {
-    const SystemMemoryUsage kExpectedSystemMemoryUsage = CreateAndInitializeSystemMemoryUsage();
+    const SystemMemoryUsage expected_system_memory_usage = CreateAndInitializeSystemMemoryUsage();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateSystemMemoryUsageFromVmStat(kEmptyProcVmStat, &system_memory_usage);
+        UpdateSystemMemoryUsageFromVmStat(empty_proc_vm_stat, &system_memory_usage);
     EXPECT_TRUE(updating_result.has_error());
-    EXPECT_THAT(system_memory_usage, MemoryProtoEq(kExpectedSystemMemoryUsage));
+    EXPECT_THAT(system_memory_usage, MemoryProtoEq(expected_system_memory_usage));
   }
 }
 
 TEST(MemoryUtils, UpdateProcessMemoryUsageFromProcessStat) {
-  const int kMinorPageFaults = 20;
-  const int kMajorPageFaults = 1;
+  const int minor_page_faults = 20;
+  const int major_page_faults = 1;
 
-  const std::string kValidProcessStat = absl::Substitute(
+  const std::string valid_process_stat = absl::Substitute(
       R"(9562 (TargetProcess) S 9561 9561 9561 0 -1 123456789 $0 3173 $1 0 7 18 1 7 20 0 10 0 123456789 123456789 2793 123456789 1 1 0 0 0 0 0 0 2 0 0 0 17 6 0 0 0 0 0 0 0 0 0 0 0 0 0)",
-      kMinorPageFaults, kMajorPageFaults);
-  const std::string kPartialProcessStat = R"(9562 (TargetProcess) S 9561 9561 9561)";
-  const std::string kEmptyProcessStat = "";
+      minor_page_faults, major_page_faults);
+  const std::string partial_process_stat = R"(9562 (TargetProcess) S 9561 9561 9561)";
+  const std::string empty_process_stat = "";
 
   {
-    const ProcessMemoryUsage kExpectedProcessMemoryUsage = [] {
+    const ProcessMemoryUsage expected_process_memory_usage = [] {
       ProcessMemoryUsage process_memory_usage = CreateAndInitializeProcessMemoryUsage();
-      process_memory_usage.set_minflt(kMinorPageFaults);
-      process_memory_usage.set_majflt(kMajorPageFaults);
+      process_memory_usage.set_minflt(minor_page_faults);
+      process_memory_usage.set_majflt(major_page_faults);
       return process_memory_usage;
     }();
     ProcessMemoryUsage process_memory_usage = CreateAndInitializeProcessMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateProcessMemoryUsageFromProcessStat(kValidProcessStat, &process_memory_usage);
+        UpdateProcessMemoryUsageFromProcessStat(valid_process_stat, &process_memory_usage);
     EXPECT_FALSE(updating_result.has_error());
-    EXPECT_THAT(process_memory_usage, MemoryProtoEq(kExpectedProcessMemoryUsage));
+    EXPECT_THAT(process_memory_usage, MemoryProtoEq(expected_process_memory_usage));
   }
 
   {
-    const ProcessMemoryUsage kExpectedProcessMemoryUsage = CreateAndInitializeProcessMemoryUsage();
+    const ProcessMemoryUsage expected_process_memory_usage =
+        CreateAndInitializeProcessMemoryUsage();
     ProcessMemoryUsage process_memory_usage = CreateAndInitializeProcessMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateProcessMemoryUsageFromProcessStat(kPartialProcessStat, &process_memory_usage);
+        UpdateProcessMemoryUsageFromProcessStat(partial_process_stat, &process_memory_usage);
     EXPECT_TRUE(updating_result.has_error());
-    EXPECT_THAT(process_memory_usage, MemoryProtoEq(kExpectedProcessMemoryUsage));
+    EXPECT_THAT(process_memory_usage, MemoryProtoEq(expected_process_memory_usage));
   }
 
   {
-    const ProcessMemoryUsage kExpectedProcessMemoryUsage = CreateAndInitializeProcessMemoryUsage();
+    const ProcessMemoryUsage expected_process_memory_usage =
+        CreateAndInitializeProcessMemoryUsage();
     ProcessMemoryUsage process_memory_usage = CreateAndInitializeProcessMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateProcessMemoryUsageFromProcessStat(kEmptyProcessStat, &process_memory_usage);
+        UpdateProcessMemoryUsageFromProcessStat(empty_process_stat, &process_memory_usage);
     EXPECT_TRUE(updating_result.has_error());
-    EXPECT_THAT(process_memory_usage, MemoryProtoEq(kExpectedProcessMemoryUsage));
+    EXPECT_THAT(process_memory_usage, MemoryProtoEq(expected_process_memory_usage));
   }
 }
 
 TEST(MemoryUtils, ExtractRssAnonFromProcessStatus) {
-  const int kRssAnonKb = 10264;
+  const int rss_anon_kb = 10264;
 
-  const std::string kValidProcessStatus = absl::Substitute(
+  const std::string valid_process_status = absl::Substitute(
       R"(Name:   bash
 Umask:  0022
 State:  S (sleeping)
@@ -439,36 +441,36 @@ Mems_allowed:   1
 Mems_allowed_list:      0
 voluntary_ctxt_switches:        150
 nonvoluntary_ctxt_switches:     545)",
-      kRssAnonKb);
-  const std::string kPartialProcessStatus = R"(Name:   bash
+      rss_anon_kb);
+  const std::string partial_process_status = R"(Name:   bash
 Umask:  0022
 State:  S (sleeping))";
-  const std::string kEmptyProcessStatus = "";
+  const std::string empty_process_status = "";
 
   {
     ErrorMessageOr<int64_t> extracting_result =
-        ExtractRssAnonFromProcessStatus(kValidProcessStatus);
+        ExtractRssAnonFromProcessStatus(valid_process_status);
     EXPECT_FALSE(extracting_result.has_error());
-    EXPECT_EQ(extracting_result.value(), kRssAnonKb);
+    EXPECT_EQ(extracting_result.value(), rss_anon_kb);
   }
 
   {
     ErrorMessageOr<int64_t> extracting_result =
-        ExtractRssAnonFromProcessStatus(kPartialProcessStatus);
+        ExtractRssAnonFromProcessStatus(partial_process_status);
     EXPECT_TRUE(extracting_result.has_error());
   }
 
   {
     ErrorMessageOr<int64_t> extracting_result =
-        ExtractRssAnonFromProcessStatus(kEmptyProcessStatus);
+        ExtractRssAnonFromProcessStatus(empty_process_status);
     EXPECT_TRUE(extracting_result.has_error());
   }
 }
 
 TEST(MemoryUtil, GetProcessMemoryCGroupName) {
-  const std::string kCGroupName = "user.slice/user-1000.slice";
+  const std::string c_group_name = "user.slice/user-1000.slice";
 
-  const std::string kValidProcessCGroup = absl::Substitute(R"(10:memory:/$0
+  const std::string valid_process_c_group = absl::Substitute(R"(10:memory:/$0
 9:blkio:/user.slice/user-1000.slice
 8:net_cls,net_prio:/
 7:cpu,cpuacct:/user.slice/user-1000.slice
@@ -478,42 +480,42 @@ TEST(MemoryUtil, GetProcessMemoryCGroupName) {
 3:pids:/user.slice/user-1000.slice
 2:devices:/user.slice/user-1000.slice
 1:name=systemd:/user.slice/user-1000.slice/session-3.scope)",
-                                                           kCGroupName);
+                                                             c_group_name);
 
-  const std::string kPartialProcessCGroup = R"(3:pids:/user.slice/user-1000.slice
+  const std::string partial_process_c_group = R"(3:pids:/user.slice/user-1000.slice
 2:devices:/user.slice/user-1000.slice
 1:name=systemd:/user.slice/user-1000.slice/session-3.scope)";
 
-  const std::string kEmptyProcessCGroup = "";
+  const std::string empty_process_c_group = "";
 
   {
-    std::string parsing_result = GetProcessMemoryCGroupName(kValidProcessCGroup);
-    EXPECT_EQ(parsing_result, kCGroupName);
+    std::string parsing_result = GetProcessMemoryCGroupName(valid_process_c_group);
+    EXPECT_EQ(parsing_result, c_group_name);
   }
 
   {
-    std::string parsing_result = GetProcessMemoryCGroupName(kPartialProcessCGroup);
+    std::string parsing_result = GetProcessMemoryCGroupName(partial_process_c_group);
     EXPECT_TRUE(parsing_result.empty());
   }
 
   {
-    std::string parsing_result = GetProcessMemoryCGroupName(kEmptyProcessCGroup);
+    std::string parsing_result = GetProcessMemoryCGroupName(empty_process_c_group);
     EXPECT_TRUE(parsing_result.empty());
   }
 }
 
 TEST(MemoryUtils, UpdateCGroupMemoryUsageFromMemoryStat) {
-  const int kRssInBytes = 245760;
-  const int KMappedFileInBytes = 1234;
-  const int kPageFaults = 1425;
-  const int kMajorPageFaults = 1;
-  const int kUnevictableInBytes = 0;
-  const int kInactiveAnonInBytes = 16384;
-  const int kActiveAnonInBytes = 253952;
-  const int kInactiveFileInBytes = 3678;
-  const int kActiveFileInBytes = 12288;
+  const int rss_in_bytes = 245760;
+  const int mapped_file_in_bytes = 1234;
+  const int page_faults = 1425;
+  const int major_page_faults = 1;
+  const int unevictable_in_bytes = 0;
+  const int inactive_anon_in_bytes = 16384;
+  const int active_anon_in_bytes = 253952;
+  const int inactive_file_in_bytes = 3678;
+  const int active_file_in_bytes = 12288;
 
-  const std::string kValidCGroupMemoryStatus = absl::Substitute(
+  const std::string valid_c_group_memory_status = absl::Substitute(
       R"(cache 36864
 rss $0
 rss_huge 0
@@ -547,52 +549,52 @@ total_active_anon 253952
 total_inactive_file 0
 total_active_file 12288
 total_unevictable 0)",
-      kRssInBytes, KMappedFileInBytes, kPageFaults, kMajorPageFaults, kUnevictableInBytes,
-      kInactiveAnonInBytes, kActiveAnonInBytes, kInactiveFileInBytes, kActiveFileInBytes);
+      rss_in_bytes, mapped_file_in_bytes, page_faults, major_page_faults, unevictable_in_bytes,
+      inactive_anon_in_bytes, active_anon_in_bytes, inactive_file_in_bytes, active_file_in_bytes);
 
-  const std::string kPartialCGroupMemoryStatus = R"(cache 36864
+  const std::string partial_c_group_memory_status = R"(cache 36864
 rss_huge 0)";
 
-  const std::string kEmptyCGroupMemoryStatus = "";
+  const std::string empty_c_group_memory_status = "";
 
   {
-    const CGroupMemoryUsage kExpectedCGroupMemoryUsage = [] {
+    const CGroupMemoryUsage expected_c_group_memory_usage = [] {
       CGroupMemoryUsage cgroup_memory_usage = CreateAndInitializeCGroupMemoryUsage();
-      cgroup_memory_usage.set_rss_bytes(kRssInBytes);
-      cgroup_memory_usage.set_mapped_file_bytes(KMappedFileInBytes);
-      cgroup_memory_usage.set_pgfault(kPageFaults);
-      cgroup_memory_usage.set_pgmajfault(kMajorPageFaults);
-      cgroup_memory_usage.set_unevictable_bytes(kUnevictableInBytes);
-      cgroup_memory_usage.set_inactive_anon_bytes(kInactiveAnonInBytes);
-      cgroup_memory_usage.set_active_anon_bytes(kActiveAnonInBytes);
-      cgroup_memory_usage.set_inactive_file_bytes(kInactiveFileInBytes);
-      cgroup_memory_usage.set_active_file_bytes(kActiveFileInBytes);
+      cgroup_memory_usage.set_rss_bytes(rss_in_bytes);
+      cgroup_memory_usage.set_mapped_file_bytes(mapped_file_in_bytes);
+      cgroup_memory_usage.set_pgfault(page_faults);
+      cgroup_memory_usage.set_pgmajfault(major_page_faults);
+      cgroup_memory_usage.set_unevictable_bytes(unevictable_in_bytes);
+      cgroup_memory_usage.set_inactive_anon_bytes(inactive_anon_in_bytes);
+      cgroup_memory_usage.set_active_anon_bytes(active_anon_in_bytes);
+      cgroup_memory_usage.set_inactive_file_bytes(inactive_file_in_bytes);
+      cgroup_memory_usage.set_active_file_bytes(active_file_in_bytes);
       return cgroup_memory_usage;
     }();
 
     CGroupMemoryUsage cgroup_memory_usage = CreateAndInitializeCGroupMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateCGroupMemoryUsageFromMemoryStat(kValidCGroupMemoryStatus, &cgroup_memory_usage);
+        UpdateCGroupMemoryUsageFromMemoryStat(valid_c_group_memory_status, &cgroup_memory_usage);
     EXPECT_FALSE(updating_result.has_error());
-    EXPECT_THAT(cgroup_memory_usage, MemoryProtoEq(kExpectedCGroupMemoryUsage));
+    EXPECT_THAT(cgroup_memory_usage, MemoryProtoEq(expected_c_group_memory_usage));
   }
 
   {
-    const CGroupMemoryUsage kExpectedCGroupMemoryUsage = CreateAndInitializeCGroupMemoryUsage();
+    const CGroupMemoryUsage expected_c_group_memory_usage = CreateAndInitializeCGroupMemoryUsage();
     CGroupMemoryUsage cgroup_memory_usage = CreateAndInitializeCGroupMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateCGroupMemoryUsageFromMemoryStat(kPartialCGroupMemoryStatus, &cgroup_memory_usage);
+        UpdateCGroupMemoryUsageFromMemoryStat(partial_c_group_memory_status, &cgroup_memory_usage);
     EXPECT_FALSE(updating_result.has_error());
-    EXPECT_THAT(cgroup_memory_usage, MemoryProtoEq(kExpectedCGroupMemoryUsage));
+    EXPECT_THAT(cgroup_memory_usage, MemoryProtoEq(expected_c_group_memory_usage));
   }
 
   {
-    const CGroupMemoryUsage kExpectedCGroupMemoryUsage = CreateAndInitializeCGroupMemoryUsage();
+    const CGroupMemoryUsage expected_c_group_memory_usage = CreateAndInitializeCGroupMemoryUsage();
     CGroupMemoryUsage cgroup_memory_usage = CreateAndInitializeCGroupMemoryUsage();
     ErrorMessageOr<void> updating_result =
-        UpdateCGroupMemoryUsageFromMemoryStat(kEmptyCGroupMemoryStatus, &cgroup_memory_usage);
+        UpdateCGroupMemoryUsageFromMemoryStat(empty_c_group_memory_status, &cgroup_memory_usage);
     EXPECT_TRUE(updating_result.has_error());
-    EXPECT_THAT(cgroup_memory_usage, MemoryProtoEq(kExpectedCGroupMemoryUsage));
+    EXPECT_THAT(cgroup_memory_usage, MemoryProtoEq(expected_c_group_memory_usage));
   }
 }
 

--- a/src/MemoryTracing/MemoryTracingUtilsTest.cpp
+++ b/src/MemoryTracing/MemoryTracingUtilsTest.cpp
@@ -28,11 +28,11 @@ MATCHER_P(MemoryProtoEq, expected, "") {
 namespace orbit_memory_tracing {
 
 TEST(MemoryUtils, UpdateSystemMemoryUsageFromMemInfo) {
-  const int mem_total = 16396576;
-  const int mem_free = 11493816;
-  const int mem_available = 14378752;
-  const int buffers = 71540;
-  const int cached = 3042860;
+  constexpr int kMemTotal = 16396576;
+  constexpr int kMemFree = 11493816;
+  constexpr int kMemAvailable = 14378752;
+  constexpr int kBuffers = 71540;
+  constexpr int kCached = 3042860;
 
   const std::string valid_meminfo =
       absl::Substitute(R"(MemTotal:       $0 kB
@@ -86,23 +86,23 @@ Hugetlb:               0 kB
 DirectMap4k:      201960 kB
 DirectMap2M:     5040128 kB
 DirectMap1G:    13631488 kB)",
-                       mem_total, mem_free, mem_available, buffers, cached);
+                       kMemTotal, kMemFree, kMemAvailable, kBuffers, kCached);
 
   const std::string partial_meminfo = absl::Substitute(R"(MemTotal:       $0 kB
 MemFree:        $1 kB
 SwapCached:      0 kB)",
-                                                       mem_total, mem_free);
+                                                       kMemTotal, kMemFree);
 
   const std::string empty_meminfo = "";
 
   {
     const SystemMemoryUsage expected_system_memory_usage = [] {
       SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
-      system_memory_usage.set_total_kb(mem_total);
-      system_memory_usage.set_free_kb(mem_free);
-      system_memory_usage.set_available_kb(mem_available);
-      system_memory_usage.set_buffers_kb(buffers);
-      system_memory_usage.set_cached_kb(cached);
+      system_memory_usage.set_total_kb(kMemTotal);
+      system_memory_usage.set_free_kb(kMemFree);
+      system_memory_usage.set_available_kb(kMemAvailable);
+      system_memory_usage.set_buffers_kb(kBuffers);
+      system_memory_usage.set_cached_kb(kCached);
       return system_memory_usage;
     }();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
@@ -115,8 +115,8 @@ SwapCached:      0 kB)",
   {
     const SystemMemoryUsage expected_system_memory_usage = [] {
       SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
-      system_memory_usage.set_total_kb(mem_total);
-      system_memory_usage.set_free_kb(mem_free);
+      system_memory_usage.set_total_kb(kMemTotal);
+      system_memory_usage.set_free_kb(kMemFree);
       return system_memory_usage;
     }();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
@@ -137,8 +137,8 @@ SwapCached:      0 kB)",
 }
 
 TEST(MemoryUtils, UpdateSystemMemoryUsageFromVmStat) {
-  const int page_faults = 123456789;
-  const int major_page_faults = 123456;
+  constexpr int kPageFaults = 123456789;
+  constexpr int kMajorPageFaults = 123456;
 
   const std::string valid_proc_vm_stat = absl::Substitute(R"(nr_free_pages 2258933
 nr_zone_inactive_anon 655781
@@ -294,17 +294,17 @@ balloon_migrate 3482
 swap_ra 277950
 swap_ra_hit 207052
 nr_unstable 0)",
-                                                          page_faults, major_page_faults);
+                                                          kPageFaults, kMajorPageFaults);
 
-  const std::string partial_proc_vm_stat = absl::Substitute(R"(pgfault $0)", page_faults);
+  const std::string partial_proc_vm_stat = absl::Substitute(R"(pgfault $0)", kPageFaults);
 
   const std::string empty_proc_vm_stat = "";
 
   {
     const SystemMemoryUsage expected_system_memory_usage = [] {
       SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
-      system_memory_usage.set_pgfault(page_faults);
-      system_memory_usage.set_pgmajfault(major_page_faults);
+      system_memory_usage.set_pgfault(kPageFaults);
+      system_memory_usage.set_pgmajfault(kMajorPageFaults);
       return system_memory_usage;
     }();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
@@ -317,7 +317,7 @@ nr_unstable 0)",
   {
     const SystemMemoryUsage expected_system_memory_usage = [] {
       SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
-      system_memory_usage.set_pgfault(page_faults);
+      system_memory_usage.set_pgfault(kPageFaults);
       return system_memory_usage;
     }();
     SystemMemoryUsage system_memory_usage = CreateAndInitializeSystemMemoryUsage();
@@ -338,20 +338,20 @@ nr_unstable 0)",
 }
 
 TEST(MemoryUtils, UpdateProcessMemoryUsageFromProcessStat) {
-  const int minor_page_faults = 20;
-  const int major_page_faults = 1;
+  constexpr int kMinorPageFaults = 20;
+  constexpr int kMajorPageFaults = 1;
 
   const std::string valid_process_stat = absl::Substitute(
       R"(9562 (TargetProcess) S 9561 9561 9561 0 -1 123456789 $0 3173 $1 0 7 18 1 7 20 0 10 0 123456789 123456789 2793 123456789 1 1 0 0 0 0 0 0 2 0 0 0 17 6 0 0 0 0 0 0 0 0 0 0 0 0 0)",
-      minor_page_faults, major_page_faults);
+      kMinorPageFaults, kMajorPageFaults);
   const std::string partial_process_stat = R"(9562 (TargetProcess) S 9561 9561 9561)";
   const std::string empty_process_stat = "";
 
   {
     const ProcessMemoryUsage expected_process_memory_usage = [] {
       ProcessMemoryUsage process_memory_usage = CreateAndInitializeProcessMemoryUsage();
-      process_memory_usage.set_minflt(minor_page_faults);
-      process_memory_usage.set_majflt(major_page_faults);
+      process_memory_usage.set_minflt(kMinorPageFaults);
+      process_memory_usage.set_majflt(kMajorPageFaults);
       return process_memory_usage;
     }();
     ProcessMemoryUsage process_memory_usage = CreateAndInitializeProcessMemoryUsage();
@@ -383,7 +383,7 @@ TEST(MemoryUtils, UpdateProcessMemoryUsageFromProcessStat) {
 }
 
 TEST(MemoryUtils, ExtractRssAnonFromProcessStatus) {
-  const int rss_anon_kb = 10264;
+  constexpr int kRssAnonKb = 10264;
 
   const std::string valid_process_status = absl::Substitute(
       R"(Name:   bash
@@ -441,7 +441,7 @@ Mems_allowed:   1
 Mems_allowed_list:      0
 voluntary_ctxt_switches:        150
 nonvoluntary_ctxt_switches:     545)",
-      rss_anon_kb);
+      kRssAnonKb);
   const std::string partial_process_status = R"(Name:   bash
 Umask:  0022
 State:  S (sleeping))";
@@ -451,7 +451,7 @@ State:  S (sleeping))";
     ErrorMessageOr<int64_t> extracting_result =
         ExtractRssAnonFromProcessStatus(valid_process_status);
     EXPECT_FALSE(extracting_result.has_error());
-    EXPECT_EQ(extracting_result.value(), rss_anon_kb);
+    EXPECT_EQ(extracting_result.value(), kRssAnonKb);
   }
 
   {
@@ -505,15 +505,15 @@ TEST(MemoryUtil, GetProcessMemoryCGroupName) {
 }
 
 TEST(MemoryUtils, UpdateCGroupMemoryUsageFromMemoryStat) {
-  const int rss_in_bytes = 245760;
-  const int mapped_file_in_bytes = 1234;
-  const int page_faults = 1425;
-  const int major_page_faults = 1;
-  const int unevictable_in_bytes = 0;
-  const int inactive_anon_in_bytes = 16384;
-  const int active_anon_in_bytes = 253952;
-  const int inactive_file_in_bytes = 3678;
-  const int active_file_in_bytes = 12288;
+  constexpr int kRssInBytes = 245760;
+  constexpr int kMappedFileInBytes = 1234;
+  constexpr int kPageFaults = 1425;
+  constexpr int kMajorPageFaults = 1;
+  constexpr int kUnevictableInBytes = 0;
+  constexpr int kInactiveAnonInBytes = 16384;
+  constexpr int kActiveAnonInBytes = 253952;
+  constexpr int kInactiveFileInBytes = 3678;
+  constexpr int kActiveFileInBytes = 12288;
 
   const std::string valid_c_group_memory_status = absl::Substitute(
       R"(cache 36864
@@ -549,8 +549,8 @@ total_active_anon 253952
 total_inactive_file 0
 total_active_file 12288
 total_unevictable 0)",
-      rss_in_bytes, mapped_file_in_bytes, page_faults, major_page_faults, unevictable_in_bytes,
-      inactive_anon_in_bytes, active_anon_in_bytes, inactive_file_in_bytes, active_file_in_bytes);
+      kRssInBytes, kMappedFileInBytes, kPageFaults, kMajorPageFaults, kUnevictableInBytes,
+      kInactiveAnonInBytes, kActiveAnonInBytes, kInactiveFileInBytes, kActiveFileInBytes);
 
   const std::string partial_c_group_memory_status = R"(cache 36864
 rss_huge 0)";
@@ -560,15 +560,15 @@ rss_huge 0)";
   {
     const CGroupMemoryUsage expected_c_group_memory_usage = [] {
       CGroupMemoryUsage cgroup_memory_usage = CreateAndInitializeCGroupMemoryUsage();
-      cgroup_memory_usage.set_rss_bytes(rss_in_bytes);
-      cgroup_memory_usage.set_mapped_file_bytes(mapped_file_in_bytes);
-      cgroup_memory_usage.set_pgfault(page_faults);
-      cgroup_memory_usage.set_pgmajfault(major_page_faults);
-      cgroup_memory_usage.set_unevictable_bytes(unevictable_in_bytes);
-      cgroup_memory_usage.set_inactive_anon_bytes(inactive_anon_in_bytes);
-      cgroup_memory_usage.set_active_anon_bytes(active_anon_in_bytes);
-      cgroup_memory_usage.set_inactive_file_bytes(inactive_file_in_bytes);
-      cgroup_memory_usage.set_active_file_bytes(active_file_in_bytes);
+      cgroup_memory_usage.set_rss_bytes(kRssInBytes);
+      cgroup_memory_usage.set_mapped_file_bytes(kMappedFileInBytes);
+      cgroup_memory_usage.set_pgfault(kPageFaults);
+      cgroup_memory_usage.set_pgmajfault(kMajorPageFaults);
+      cgroup_memory_usage.set_unevictable_bytes(kUnevictableInBytes);
+      cgroup_memory_usage.set_inactive_anon_bytes(kInactiveAnonInBytes);
+      cgroup_memory_usage.set_active_anon_bytes(kActiveAnonInBytes);
+      cgroup_memory_usage.set_inactive_file_bytes(kInactiveFileInBytes);
+      cgroup_memory_usage.set_active_file_bytes(kActiveFileInBytes);
       return cgroup_memory_usage;
     }();
 

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -159,8 +159,8 @@ class SamplingWithFrameTrackInputWidgetTest : public ::testing::Test {
     EXPECT_EQ(widget_->MakeConfig().frame_track_id, frame_track_id);
   }
 
-  void ExpectRelativeStartNsIs(uint64_t start_relative_ns_) const {
-    EXPECT_EQ(*widget_->MakeConfig().start_relative, start_relative_ns_);
+  void ExpectRelativeStartNsIs(uint64_t start_relative_ns) const {
+    EXPECT_EQ(*widget_->MakeConfig().start_relative, start_relative_ns);
   }
 
   MockPairedData data_;

--- a/src/OrbitBase/LoggingUtilsTest.cpp
+++ b/src/OrbitBase/LoggingUtilsTest.cpp
@@ -30,32 +30,32 @@ std::filesystem::path GenerateTestLogFilePath(const absl::Time& timestamp) {
 }  // namespace
 
 TEST(LoggingUtils, ParseLogFileTimestamp) {
-  const std::string kFilenameInvalidNoTimestamp = "sfsdf-.log ";
-  const std::string kFilenameInvalidValidTimestampWrongFormat =
+  const std::string filename_invalid_no_timestamp = "sfsdf-.log ";
+  const std::string filename_invalid_valid_timestamp_wrong_format =
       "Orbitfoobar-2021_01_31_00_00_00-.log";
-  const std::string kFilenameValid = "Orbit-2021_01_31_10_21_33-7188.log";
+  const std::string filename_valid = "Orbit-2021_01_31_10_21_33-7188.log";
 
   {
     ErrorMessageOr<absl::Time> timestamp_or_error =
-        ParseLogFileTimestamp(kFilenameInvalidNoTimestamp);
+        ParseLogFileTimestamp(filename_invalid_no_timestamp);
     ASSERT_TRUE(timestamp_or_error.has_error());
     EXPECT_EQ(timestamp_or_error.error().message(),
               absl::StrFormat("Unable to extract time information from log file: %s",
-                              kFilenameInvalidNoTimestamp));
+                              filename_invalid_no_timestamp));
   }
 
   {
     ErrorMessageOr<absl::Time> timestamp_or_error =
-        ParseLogFileTimestamp(kFilenameInvalidValidTimestampWrongFormat);
+        ParseLogFileTimestamp(filename_invalid_valid_timestamp_wrong_format);
     ASSERT_TRUE(timestamp_or_error.has_error());
     EXPECT_THAT(
         timestamp_or_error.error().message(),
         testing::HasSubstr(absl::StrFormat("Error while parsing time information from log file %s",
-                                           kFilenameInvalidValidTimestampWrongFormat)));
+                                           filename_invalid_valid_timestamp_wrong_format)));
   }
 
   {
-    ErrorMessageOr<absl::Time> timestamp_or_error = ParseLogFileTimestamp(kFilenameValid);
+    ErrorMessageOr<absl::Time> timestamp_or_error = ParseLogFileTimestamp(filename_valid);
     absl::Time expected_result =
         absl::FromCivil(absl::CivilSecond(2021, 1, 31, 10, 21, 33), absl::UTCTimeZone());
     ASSERT_FALSE(timestamp_or_error.has_error()) << timestamp_or_error.error().message();

--- a/src/OrbitBase/SortTest.cpp
+++ b/src/OrbitBase/SortTest.cpp
@@ -22,7 +22,7 @@ struct Struct {
   }
 };
 
-constexpr auto projection = [](const Struct& s) -> int { return s.value; };
+constexpr auto kProjection = [](const Struct& s) -> int { return s.value; };
 }  // namespace
 
 namespace orbit_base {
@@ -45,7 +45,7 @@ static void ExpectSortIsCorrect(MySort my_sort, StdSort std_sort) {
 
 TEST(SortTest, SortIsCorrect) {
   ExpectSortIsCorrect(
-      [](auto& structs) { orbit_base::sort(std::begin(structs), std::end(structs), projection); },
+      [](auto& structs) { orbit_base::sort(std::begin(structs), std::end(structs), kProjection); },
       [](auto& structs) {
         std::sort(std::begin(structs), std::end(structs),
                   [](const auto& a, const auto& b) { return a.value < b.value; });
@@ -53,7 +53,7 @@ TEST(SortTest, SortIsCorrect) {
 
   ExpectSortIsCorrect(
       [](auto& structs) {
-        orbit_base::sort(std::begin(structs), std::end(structs), projection, std::greater<>{});
+        orbit_base::sort(std::begin(structs), std::end(structs), kProjection, std::greater<>{});
       },
       [](auto& structs) {
         std::sort(std::begin(structs), std::end(structs),
@@ -62,7 +62,7 @@ TEST(SortTest, SortIsCorrect) {
 
   ExpectSortIsCorrect(
       [](auto& structs) {
-        orbit_base::stable_sort(std::begin(structs), std::end(structs), projection);
+        orbit_base::stable_sort(std::begin(structs), std::end(structs), kProjection);
       },
       [](auto& structs) {
         std::stable_sort(std::begin(structs), std::end(structs),
@@ -71,7 +71,7 @@ TEST(SortTest, SortIsCorrect) {
 
   ExpectSortIsCorrect(
       [](auto& structs) {
-        orbit_base::stable_sort(std::begin(structs), std::end(structs), projection,
+        orbit_base::stable_sort(std::begin(structs), std::end(structs), kProjection,
                                 std::greater<>{});
       },
       [](auto& structs) {

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -72,7 +72,7 @@ TEST(ThreadUtils, GetThreadName) {
   absl::Mutex mutex;
   uint32_t other_tid = 0;
   bool other_name_read = false;
-  constexpr const char* kThreadName = "OtherThread";
+  static constexpr const char* kThreadName = "OtherThread";
 
   std::thread other_thread{[&mutex, &other_tid, &other_name_read] {
     orbit_base::SetCurrentThreadName(kThreadName);

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -33,7 +33,7 @@ TEST(ThreadUtils, GetCurrentThreadId) {
 
 TEST(ThreadUtils, GetSetCurrentThreadShortName) {
   // Set thread name of exactly 15 characters. This should work on both Linux and Windows.
-  static const char* kThreadName = "123456789012345";
+  constexpr const char* kThreadName = "123456789012345";
   orbit_base::SetCurrentThreadName(kThreadName);
   std::string thread_name = orbit_base::GetThreadName(orbit_base::GetCurrentThreadId());
   EXPECT_EQ(kThreadName, thread_name);
@@ -45,7 +45,7 @@ TEST(ThreadUtils, GetSetCurrentThreadLongName) {
 
   // Set thread name longer than 15 characters. The Linux version will truncate the name to 15
   // characters.
-  static const char* kLongThreadName = "1234567890123456";
+  constexpr const char* kLongThreadName = "1234567890123456";
   EXPECT_GT(strlen(kLongThreadName), kMaxNonZeroCharactersLinux);
   orbit_base::SetCurrentThreadName(kLongThreadName);
   std::string long_thread_name = orbit_base::GetThreadName(orbit_base::GetCurrentThreadId());
@@ -62,7 +62,7 @@ TEST(ThreadUtils, GetSetCurrentThreadLongName) {
 
 TEST(ThreadUtils, GetSetCurrentThreadEmptyName) {
   // Set thread name of exactly 15 characters. This should work on both Linux and Windows.
-  static const char* kEmptyThreadName = "";
+  constexpr const char* kEmptyThreadName = "";
   orbit_base::SetCurrentThreadName(kEmptyThreadName);
   std::string thread_name = orbit_base::GetThreadName(orbit_base::GetCurrentThreadId());
   EXPECT_EQ(kEmptyThreadName, thread_name);
@@ -72,7 +72,7 @@ TEST(ThreadUtils, GetThreadName) {
   absl::Mutex mutex;
   uint32_t other_tid = 0;
   bool other_name_read = false;
-  static const char* kThreadName = "OtherThread";
+  constexpr const char* kThreadName = "OtherThread";
 
   std::thread other_thread{[&mutex, &other_tid, &other_name_read] {
     orbit_base::SetCurrentThreadName(kThreadName);

--- a/src/OrbitBase/TypedefTest.cpp
+++ b/src/OrbitBase/TypedefTest.cpp
@@ -61,7 +61,7 @@ TEST(TypedefTest, DefaultConstructorInitializesPrimitives) {
 }
 
 TEST(TypedefTest, CanInstantiate) {
-  const int kConstInt = 1;
+  constexpr int kConstInt = 1;
   MyType<int> wrapper_of_const(kConstInt);
   EXPECT_EQ(*wrapper_of_const, kConstInt);
 
@@ -102,7 +102,7 @@ TEST(TypedefTest, CanInstantiate) {
 }
 
 TEST(TypedefTest, ImplicitConversionIsCorrect) {
-  const int kValue = 1;
+  constexpr int kValue = 1;
 
   {
     const MyType<B> wrapped_b(B{{kValue}});
@@ -169,8 +169,8 @@ TEST(TypedefTest, ImplicitConversionIsCorrect) {
 }
 
 TEST(TypedefTest, AssignmentIsCorrect) {
-  const int kValue = 1;
-  const int kValueOther = 2;
+  constexpr int kValue = 1;
+  constexpr int kValueOther = 2;
   {
     MyType<A> wrapped_a(A{kValue});
     MyType<A> wrapped_a_other(A{kValueOther});
@@ -222,16 +222,16 @@ TEST(TypedefTest, AssignmentIsCorrect) {
 }
 
 TEST(TypedefTest, CallIsCorrect) {
-  const int kFirst = 1;
-  const int kSecond = 2;
-  const int kSum = kFirst + kSecond;
+  constexpr int kFirst = 1;
+  constexpr int kSecond = 2;
+  constexpr int kSum = kFirst + kSecond;
 
-  const MyType<int> kFirstWrapped(kFirst);
-  const MyType<int> kSecondWrapped(kSecond);
+  const MyType<int> first_wrapped(kFirst);
+  const MyType<int> second_wrapped(kSecond);
 
   {
     auto add = [](int i, int j) { return i + j; };
-    const MyType<int> sum_wrapped = LiftAndApply(add, kFirstWrapped, kSecondWrapped);
+    const MyType<int> sum_wrapped = LiftAndApply(add, first_wrapped, second_wrapped);
     EXPECT_EQ(*sum_wrapped, kSum);
   }
 
@@ -263,7 +263,7 @@ TEST(TypedefTest, CallIsCorrect) {
     auto add = [](const int& i, int&& j) { return i + j; };
 
     MyType<int> second(kSecond);
-    const MyType<int> sum_wrapped = LiftAndApply(add, kFirstWrapped, std::move(second));
+    const MyType<int> sum_wrapped = LiftAndApply(add, first_wrapped, std::move(second));
     EXPECT_EQ(*sum_wrapped, kSum);
   }
 
@@ -277,12 +277,12 @@ TEST(TypedefTest, CallIsCorrect) {
 
   {
     auto add = [](const int& i, const int& j) { return i + j; };
-    const MyType<int> sum_wrapped = LiftAndApply(add, kFirstWrapped, kSecondWrapped);
+    const MyType<int> sum_wrapped = LiftAndApply(add, first_wrapped, second_wrapped);
     EXPECT_EQ(*sum_wrapped, kSum);
   }
 
   {
-    const MyType<int> sum_wrapped = LiftAndApply(Sum, kFirstWrapped, kSecondWrapped);
+    const MyType<int> sum_wrapped = LiftAndApply(Sum, first_wrapped, second_wrapped);
     EXPECT_EQ(*sum_wrapped, kSum);
   }
 
@@ -293,7 +293,7 @@ TEST(TypedefTest, CallIsCorrect) {
       was_called = true;
       was_called_with = i;
     };
-    const MyType<void> void_wrapped = LiftAndApply(returns_void, kFirstWrapped);
+    const MyType<void> void_wrapped = LiftAndApply(returns_void, first_wrapped);
     std::ignore = void_wrapped;
     EXPECT_TRUE(was_called);
     EXPECT_EQ(was_called_with, kFirst);
@@ -344,9 +344,9 @@ constexpr int kAValue = 1;
 constexpr int kBValue = 2;
 
 TEST(Typedef, WrapperWithArithmeticsHasTimesScalar) {
-  constexpr WrapperWithArithmetics<int> a(kAValue);
-  constexpr WrapperWithArithmetics<int> result = Times(a, kBValue);
-  EXPECT_EQ(*result, kAValue * kBValue);
+  constexpr WrapperWithArithmetics<int> kA(kAValue);
+  constexpr WrapperWithArithmetics<int> kResult = Times(kA, kBValue);
+  EXPECT_EQ(*kResult, kAValue * kBValue);
 }
 
 TEST(Typedef, WrapperWithArithmeticsHasPlus) {
@@ -358,12 +358,12 @@ TEST(Typedef, WrapperWithArithmeticsHasPlus) {
 TEST(Typedef, WrapperWithArithmeticsHasPlusAndMinusAndPromotes) {
   constexpr int kInt = 1;
   constexpr float kFloat = 0.5;
-  constexpr WrapperWithArithmetics<int> a(kInt);
-  constexpr WrapperWithArithmetics<float> b(kFloat);
-  constexpr WrapperWithArithmetics<float> sum = Add(a, b);
-  constexpr WrapperWithArithmetics<float> diff = Sub(a, b);
-  EXPECT_EQ(*sum, kInt + kFloat);
-  EXPECT_EQ(*diff, kInt - kFloat);
+  constexpr WrapperWithArithmetics<int> kA(kInt);
+  constexpr WrapperWithArithmetics<float> kB(kFloat);
+  constexpr WrapperWithArithmetics<float> kSum = Add(kA, kB);
+  constexpr WrapperWithArithmetics<float> kDiff = Sub(kA, kB);
+  EXPECT_EQ(*kSum, kInt + kFloat);
+  EXPECT_EQ(*kDiff, kInt - kFloat);
 }
 
 TEST(Typedef, WrapperWithArithmeticsHasPlusAndConvertsArgument) {

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -124,16 +124,16 @@ std::string AsyncTrack::GetTimesliceText(const TimerInfo& timer_info) const {
 Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, bool is_highlighted,
                                 const internal::DrawData& /*draw_data*/) const {
   ORBIT_CHECK(timer_info.type() == TimerInfo::kApiScopeAsync);
-  const Color kInactiveColor(100, 100, 100, 255);
-  const Color kSelectionColor(0, 128, 255, 255);
+  const Color inactive_color(100, 100, 100, 255);
+  const Color selection_color(0, 128, 255, 255);
   if (is_highlighted) {
     return TimerTrack::kHighlightColor;
   }
   if (is_selected) {
-    return kSelectionColor;
+    return selection_color;
   }
   if (!IsTimerActive(timer_info)) {
-    return kInactiveColor;
+    return inactive_color;
   }
 
   if (timer_info.has_color()) {

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -101,13 +101,13 @@ void BasicPageFaultsTrack::DrawSingleSeriesEntry(
   if (!index_of_series_to_highlight_.has_value()) return;
   if (prev_normalized_values[index_of_series_to_highlight_.value()] == 0) return;
 
-  const Color kHightlightingColor(231, 68, 53, 100);
+  const Color highlighting_color(231, 68, 53, 100);
   float x0 = timeline_info_->GetWorldFromTick(start_tick);
   float width = timeline_info_->GetWorldFromTick(end_tick) - x0;
   float content_height = GetGraphContentHeight();
   float y0 = GetGraphContentBottomY() - GetGraphContentHeight();
   primitive_assembler.AddShadedBox(Vec2(x0, y0), Vec2(width, content_height), z,
-                                   kHightlightingColor);
+                                   highlighting_color);
 }
 
 bool BasicPageFaultsTrack::IsCollapsed() const {

--- a/src/OrbitGl/BatcherTest.cpp
+++ b/src/OrbitGl/BatcherTest.cpp
@@ -25,13 +25,13 @@ TEST(Batcher, GetBatcherId) {
 TEST(Batcher, Translations) {
   MockBatcher batcher;
 
-  const Vec3 kFakeTranslation1{1, 2, 3};
-  const uint32_t kNumStackTranslations = 10;
+  const Vec3 fake_translation1{1, 2, 3};
+  const uint32_t num_stack_translations = 10;
 
-  for (uint32_t i = 0; i < kNumStackTranslations; i++) {
-    batcher.PushTranslation(kFakeTranslation1[0], kFakeTranslation1[1], kFakeTranslation1[2]);
+  for (uint32_t i = 0; i < num_stack_translations; i++) {
+    batcher.PushTranslation(fake_translation1[0], fake_translation1[1], fake_translation1[2]);
   }
-  for (uint32_t i = 0; i < kNumStackTranslations; i++) {
+  for (uint32_t i = 0; i < num_stack_translations; i++) {
     batcher.PopTranslation();
   }
 

--- a/src/OrbitGl/Button.cpp
+++ b/src/OrbitGl/Button.cpp
@@ -20,14 +20,14 @@ namespace {
 constexpr float kGradientFactor = 0.25f;
 
 [[nodiscard]] Color GetLighterColor(const Color& color) {
-  const float kLocalGradientFactor = 1.0f + kGradientFactor;
+  constexpr float kLocalGradientFactor = 1.0f + kGradientFactor;
   return {static_cast<unsigned char>(color[0] * kLocalGradientFactor),
           static_cast<unsigned char>(color[1] * kLocalGradientFactor),
           static_cast<unsigned char>(color[2] * kLocalGradientFactor), 255};
 }
 
 [[nodiscard]] Color GetDarkerColor(const Color& color) {
-  const float kLocalGradientFactor = 1.0f - kGradientFactor;
+  constexpr float kLocalGradientFactor = 1.0f - kGradientFactor;
   return {static_cast<unsigned char>(color[0] * kLocalGradientFactor),
           static_cast<unsigned char>(color[1] * kLocalGradientFactor),
           static_cast<unsigned char>(color[2] * kLocalGradientFactor), 255};
@@ -90,44 +90,44 @@ void Button::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& /*tex
   const Vec2 pos = GetPos();
   const Vec2 size = GetSize();
 
-  const Color kHighlightColor(75, 75, 75, 255);
-  const Color kBaseColor(68, 68, 68, 255);
-  const Color kDarkBorderColor = GetDarkerColor(kBaseColor);
-  const Color kLightBorderColor = GetLighterColor(kBaseColor);
+  const Color highlight_color(75, 75, 75, 255);
+  const Color base_color(68, 68, 68, 255);
+  const Color dark_border_color = GetDarkerColor(base_color);
+  const Color k_light_border_color = GetLighterColor(base_color);
 
-  const Vec2 kBorderSize = Vec2(1.f, 1.f);
+  const Vec2 border_size = Vec2(1.f, 1.f);
 
   Vec2 pos_w_border = pos;
   Vec2 size_w_border = size;
 
   // Dark border
-  primitive_assembler.AddBox(MakeBox(pos_w_border, size_w_border), z, kDarkBorderColor,
+  primitive_assembler.AddBox(MakeBox(pos_w_border, size_w_border), z, dark_border_color,
                              shared_from_this());
-  pos_w_border += kBorderSize;
-  size_w_border -= kBorderSize + kBorderSize;
+  pos_w_border += border_size;
+  size_w_border -= border_size + border_size;
 
   // Light border
-  primitive_assembler.AddBox(MakeBox(pos_w_border, size_w_border), z, kLightBorderColor,
+  primitive_assembler.AddBox(MakeBox(pos_w_border, size_w_border), z, k_light_border_color,
                              shared_from_this());
-  pos_w_border += kBorderSize;
-  size_w_border -= kBorderSize + kBorderSize;
+  pos_w_border += border_size;
+  size_w_border -= border_size + border_size;
 
   // Button itself
-  const Color slider_color = IsMouseOver() ? kHighlightColor : kBaseColor;
+  const Color slider_color = IsMouseOver() ? highlight_color : base_color;
   primitive_assembler.AddShadedBox(pos_w_border, size_w_border, z, slider_color, shared_from_this(),
                                    ShadingDirection::kTopToBottom);
   DrawSymbol(primitive_assembler);
 }
 
 void Button::DrawSymbol(PrimitiveAssembler& primitive_assembler) {
-  const Color kSymbolBaseColor(191, 191, 192, 255);
-  const Color kSymbolHighlightColor(255, 255, 255, 255);
+  const Color symbol_base_color(191, 191, 192, 255);
+  const Color symbol_highlight_color(255, 255, 255, 255);
   // Symbol width and the padding are related to the size of the button, so they can scale
   // proportionally if the button size changes.
   const float symbol_padding_size = GetWidth() / 5.f;
   const float symbol_width = GetWidth() / 5.f;
 
-  Color symbol_color = IsMouseOver() ? kSymbolHighlightColor : kSymbolBaseColor;
+  Color symbol_color = IsMouseOver() ? symbol_highlight_color : symbol_base_color;
 
   switch (symbol_type_) {
     case SymbolType::kNoSymbol:

--- a/src/OrbitGl/ButtonTest.cpp
+++ b/src/OrbitGl/ButtonTest.cpp
@@ -77,11 +77,11 @@ TEST(Button, SizeCannotBeZero) {
 
 TEST(Button, NameWorksAsExpected) {
   orbit_gl::CaptureViewElementTester tester;
-  const std::string kName = "UnitTest";
+  const std::string name = "UnitTest";
   std::shared_ptr<Button> button =
-      std::make_shared<Button>(nullptr, tester.GetViewport(), tester.GetLayout(), kName);
+      std::make_shared<Button>(nullptr, tester.GetViewport(), tester.GetLayout(), name);
 
-  EXPECT_EQ(button->GetName(), kName);
+  EXPECT_EQ(button->GetName(), name);
 }
 
 TEST(Button, MouseReleaseCallback) {
@@ -118,11 +118,11 @@ TEST(Button, Rendering) {
   std::shared_ptr<Button> button =
       std::make_shared<Button>(nullptr, tester.GetViewport(), tester.GetLayout());
 
-  const Vec2 kSize(400, 50);
-  const Vec2 kPos(10, 10);
-  button->SetWidth(kSize[0]);
-  button->SetHeight(kSize[1]);
-  button->SetPos(kPos[0], kPos[1]);
+  const Vec2 size(400, 50);
+  const Vec2 pos(10, 10);
+  button->SetWidth(size[0]);
+  button->SetHeight(size[1]);
+  button->SetPos(pos[0], pos[1]);
 
   tester.SimulateDrawLoop(button.get(), true, false);
 
@@ -132,7 +132,7 @@ TEST(Button, Rendering) {
   // I don't really care how the button is represented, but I expect at least a single box to be
   // drawn.
   EXPECT_GE(batcher.GetNumBoxes(), 1);
-  EXPECT_TRUE(batcher.IsEverythingInsideRectangle(kPos, kSize));
+  EXPECT_TRUE(batcher.IsEverythingInsideRectangle(pos, size));
   EXPECT_TRUE(
       batcher.IsEverythingBetweenZLayers(GlCanvas::kZValueButtonBg, GlCanvas::kZValueButton));
 

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -43,17 +43,18 @@ CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
   // Colors are selected from https://convertingcolors.com/list/avery.html.
   // Use reddish colors for different used memories, yellowish colors for different cached memories
   // and greenish colors for different unused memories.
-  const std::array<Color, kCGroupAndProcessMemoryTrackDimension> kCGroupAndProcessMemoryTrackColors{
-      Color(231, 68, 53, 255),    // red
-      Color(185, 117, 181, 255),  // purple
-      Color(246, 196, 0, 255),    // orange
-      Color(87, 166, 74, 255)     // green
-  };
-  SetSeriesColors(kCGroupAndProcessMemoryTrackColors);
+  const std::array<Color, kCGroupAndProcessMemoryTrackDimension>
+      c_group_and_process_memory_traccolors{
+          Color(231, 68, 53, 255),    // red
+          Color(185, 117, 181, 255),  // purple
+          Color(246, 196, 0, 255),    // orange
+          Color(87, 166, 74, 255)     // green
+      };
+  SetSeriesColors(c_group_and_process_memory_traccolors);
 
-  const std::string kValueLowerBoundLabel = "Minimum: 0 GB";
+  const std::string value_lower_bound_label = "Minimum: 0 GB";
   constexpr double kValueLowerBoundRawValue = 0.0;
-  TrySetValueLowerBound(kValueLowerBoundLabel, kValueLowerBoundRawValue);
+  TrySetValueLowerBound(value_lower_bound_label, kValueLowerBoundRawValue);
 }
 
 std::string CGroupAndProcessMemoryTrack::GetName() const {
@@ -67,12 +68,12 @@ std::string CGroupAndProcessMemoryTrack::GetTooltip() const {
 }
 
 void CGroupAndProcessMemoryTrack::TrySetValueUpperBound(double cgroup_limit_mb) {
-  const std::string kValueUpperBoundLabel =
+  const std::string value_upper_bound_label =
       absl::StrFormat("CGroup [%s] Memory Limit", cgroup_name_);
   constexpr uint64_t kMegabytesToBytes = 1024 * 1024;
   std::string pretty_size = orbit_display_formats::GetDisplaySize(
       static_cast<uint64_t>(cgroup_limit_mb * kMegabytesToBytes));
-  std::string pretty_label = absl::StrFormat("%s: %s", kValueUpperBoundLabel, pretty_size);
+  std::string pretty_label = absl::StrFormat("%s: %s", value_upper_bound_label, pretty_size);
   MemoryTrack<kCGroupAndProcessMemoryTrackDimension>::TrySetValueUpperBound(pretty_label,
                                                                             cgroup_limit_mb);
 }
@@ -112,15 +113,15 @@ std::string CGroupAndProcessMemoryTrack::GetLegendTooltips(size_t legend_index) 
 std::string CGroupAndProcessMemoryTrack::GetValueUpperBoundTooltip() const {
   // The developer instances have all of the same cgroup limits as the production instances, except
   // the game cgroup limit. More detailed information can be found in go/gamelet-ram-budget.
-  std::string_view kGameCGroupName = "user.slice/user-1000.slice/game";
+  std::string_view game_c_group_name = "user.slice/user-1000.slice/game";
   constexpr float kGameCGroupLimitGB = 7;
 
-  if (cgroup_name_ != kGameCGroupName) return "";
+  if (cgroup_name_ != game_c_group_name) return "";
   return absl::StrFormat(
       "<b>The memory production limit of the %s cgroup is %.2fGB</b>.<br/><br/>"
       "<i>To launch game with the production cgroup limits, add the flag "
       "'--enforce-production-ram' to the 'ggp run' command</i>.",
-      kGameCGroupName, kGameCGroupLimitGB);
+      game_c_group_name, kGameCGroupLimitGB);
 }
 
 void CGroupAndProcessMemoryTrack::OnCgroupAndProcessMemoryInfo(

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -112,9 +112,9 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
   const bool picking = picking_mode != PickingMode::kNone;
   uint32_t resolution_in_pixels = viewport_->WorldToScreen({GetWidth(), 0})[0];
 
-  const Color kWhite(255, 255, 255, 255);
-  const Color kGreenSelection(0, 255, 0, 255);
-  const Color kGreyError(160, 160, 160, 255);
+  const Color white(255, 255, 255, 255);
+  const Color green_selection(0, 255, 0, 255);
+  const Color grey_error(160, 160, 160, 255);
   ORBIT_CHECK(capture_data_ != nullptr);
 
   if (!picking) {
@@ -123,10 +123,10 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
       const auto& [pos_x, unused_size_x] = timeline_info_->GetBoxPosXAndWidthFromTicks(time, time);
-      Color color = kWhite;
+      Color color = white;
       if (capture_data_->GetCallstackData().GetCallstack(event.callstack_id())->type() !=
           CallstackType::kComplete) {
-        color = kGreyError;
+        color = grey_error;
       }
       primitive_assembler.AddVerticalLine({pos_x, GetPos()[1]}, track_height, z, color);
     };
@@ -144,7 +144,7 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
       const uint64_t time = event.timestamp_ns();
       ORBIT_CHECK(time >= min_tick && time <= max_tick);
       const auto& [pos_x, unused_size_x] = timeline_info_->GetBoxPosXAndWidthFromTicks(time, time);
-      primitive_assembler.AddVerticalLine({pos_x, GetPos()[1]}, track_height, z, kGreenSelection);
+      primitive_assembler.AddVerticalLine({pos_x, GetPos()[1]}, track_height, z, green_selection);
     };
     const orbit_client_data::CallstackData& selection_callstack_data =
         capture_data_->selection_callstack_data();
@@ -174,7 +174,7 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
             return GetSampleTooltip(primitive_assembler, id);
           });
       user_data->custom_data_ = &event;
-      primitive_assembler.AddShadedBox(pos, size, z, kGreenSelection, std::move(user_data));
+      primitive_assembler.AddShadedBox(pos, size, z, green_selection, std::move(user_data));
     };
     if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
       capture_data_->GetCallstackData().ForEachCallstackEventInTimeRangeDiscretized(

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -99,10 +99,10 @@ class UnitTestCaptureViewContainerElement : public CaptureViewElementMock {
 };
 
 TEST(CaptureViewElementTesterTest, PassesAllTestsOnExistingElement) {
-  const int kChildCount = 2;
+  const int child_count = 2;
   CaptureViewElementTester tester;
   UnitTestCaptureViewContainerElement container_elem(nullptr, tester.GetViewport(),
-                                                     tester.GetLayout(), kChildCount);
+                                                     tester.GetLayout(), child_count);
   tester.RunTests(&container_elem);
 }
 
@@ -124,8 +124,8 @@ TEST(CaptureViewElement, ContainsPointRecursively) {
 }
 
 TEST(CaptureViewElement, ContainsPointRecursivelyForElementsOutsideOfTheParent) {
-  const int kChildCount = 2;
-  UnitTestCaptureViewContainerElement elem(nullptr, &kViewport, &kLayout, kChildCount);
+  const int child_count = 2;
+  UnitTestCaptureViewContainerElement elem(nullptr, &kViewport, &kLayout, child_count);
 
   CaptureViewElement* child0 = elem.GetAllChildren()[0];
 
@@ -136,33 +136,33 @@ TEST(CaptureViewElement, ContainsPointRecursivelyForElementsOutsideOfTheParent) 
 }
 
 TEST(CaptureViewElement, IsMouseOver) {
-  const int kChildCount = 2;
-  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, kChildCount);
+  const int child_count = 2;
+  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, child_count);
 
-  const Vec2 kPosOutside(-1, -1);
-  const Vec2 kPosBetweenChildren(10, kLeafElementHeight + 1);
-  const Vec2 kPosOnChild1(10, kLeafElementHeight + kMarginAfterChild);
+  const Vec2 pos_outside(-1, -1);
+  const Vec2 pos_between_children(10, kLeafElementHeight + 1);
+  const Vec2 pos_on_child1(10, kLeafElementHeight + kMarginAfterChild);
 
   CaptureViewElement* child0 = container_elem.GetAllChildren()[0];
   CaptureViewElement* child1 = container_elem.GetAllChildren()[1];
 
   // Mouse move and leave events should update IsMouseOver() flag.
   EXPECT_EQ(container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseMove, kPosOutside}),
+                CaptureViewElement::MouseEventType::kMouseMove, pos_outside}),
             CaptureViewElement::EventResult::kIgnored);
   EXPECT_FALSE(container_elem.IsMouseOver());
   EXPECT_FALSE(child0->IsMouseOver());
   EXPECT_FALSE(child1->IsMouseOver());
 
   EXPECT_EQ(container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseMove, kPosBetweenChildren}),
+                CaptureViewElement::MouseEventType::kMouseMove, pos_between_children}),
             CaptureViewElement::EventResult::kIgnored);
   EXPECT_TRUE(container_elem.IsMouseOver());
   EXPECT_FALSE(child0->IsMouseOver());
   EXPECT_FALSE(child1->IsMouseOver());
 
   EXPECT_EQ(container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseMove, kPosOnChild1}),
+                CaptureViewElement::MouseEventType::kMouseMove, pos_on_child1}),
             CaptureViewElement::EventResult::kIgnored);
   EXPECT_TRUE(container_elem.IsMouseOver());
   EXPECT_FALSE(child0->IsMouseOver());
@@ -179,7 +179,7 @@ TEST(CaptureViewElement, IsMouseOver) {
   // this flag to highlight some elements, but we only want to highlight them when we move the mouse
   // without clicking any button.
   EXPECT_EQ(container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseMove, kPosOnChild1, /*left=*/true}),
+                CaptureViewElement::MouseEventType::kMouseMove, pos_on_child1, /*left=*/true}),
             CaptureViewElement::EventResult::kIgnored);
   EXPECT_FALSE(container_elem.IsMouseOver());
   EXPECT_FALSE(child0->IsMouseOver());
@@ -191,18 +191,18 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
   using ::testing::Exactly;
   using ::testing::Return;
 
-  const int kChildCount = 3;
-  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, kChildCount);
+  const int child_count = 3;
+  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, child_count);
 
   static_assert(kMarginAfterChild > 0);
 
-  const Vec2 kPosOutside(-1, -1);
-  const Vec2 kPosBetweenChildren(10, kLeafElementHeight + 1);
-  const Vec2 kPosOnChild0(10, kLeafElementHeight - 1);
-  const Vec2 kPosOnChild1(10, kLeafElementHeight + kMarginAfterChild);
-  const Vec2 kPosOnChild2(10, (kLeafElementHeight + kMarginAfterChild) * 2);
+  const Vec2 pos_outside(-1, -1);
+  const Vec2 pos_between_children(10, kLeafElementHeight + 1);
+  const Vec2 pos_on_child0(10, kLeafElementHeight - 1);
+  const Vec2 pos_on_child1(10, kLeafElementHeight + kMarginAfterChild);
+  const Vec2 pos_on_child2(10, (kLeafElementHeight + kMarginAfterChild) * 2);
 
-  const int kDelta = 1;
+  const int delta = 1;
 
   CaptureViewElementMock* child0 =
       dynamic_cast<CaptureViewElementMock*>(container_elem.GetAllChildren()[0]);
@@ -213,35 +213,35 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
 
   // Expect the parent to catch all mouse wheel events of children 0 and 1, but not those of child 2
   // since child 2 actually handles the event
-  EXPECT_CALL(container_elem, OnMouseWheel(_, kDelta, _))
+  EXPECT_CALL(container_elem, OnMouseWheel(_, delta, _))
       .Times(Exactly(3))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kIgnored));
 
-  EXPECT_CALL(*child0, OnMouseWheel(_, kDelta, _))
+  EXPECT_CALL(*child0, OnMouseWheel(_, delta, _))
       .Times(Exactly(1))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kIgnored));
-  EXPECT_CALL(*child1, OnMouseWheel(_, kDelta, _))
+  EXPECT_CALL(*child1, OnMouseWheel(_, delta, _))
       .Times(Exactly(1))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kIgnored));
-  EXPECT_CALL(*child2, OnMouseWheel(_, kDelta, _))
+  EXPECT_CALL(*child2, OnMouseWheel(_, delta, _))
       .Times(Exactly(1))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kHandled));
 
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseWheelUp, kPosOutside}));
+                CaptureViewElement::MouseEventType::kMouseWheelUp, pos_outside}));
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseWheelUp, kPosBetweenChildren}));
+                CaptureViewElement::MouseEventType::kMouseWheelUp, pos_between_children}));
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseWheelUp, kPosOnChild0}));
+                CaptureViewElement::MouseEventType::kMouseWheelUp, pos_on_child0}));
   EXPECT_EQ(CaptureViewElement::EventResult::kIgnored,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseWheelUp, kPosOnChild1}));
+                CaptureViewElement::MouseEventType::kMouseWheelUp, pos_on_child1}));
   EXPECT_EQ(CaptureViewElement::EventResult::kHandled,
             container_elem.HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseWheelUp, kPosOnChild2}));
+                CaptureViewElement::MouseEventType::kMouseWheelUp, pos_on_child2}));
 }
 
 TEST(CaptureViewElement, RequestUpdateBubblesUpAndIsClearedAfterDrawLoop) {

--- a/src/OrbitGl/CaptureViewElementTest.cpp
+++ b/src/OrbitGl/CaptureViewElementTest.cpp
@@ -99,10 +99,10 @@ class UnitTestCaptureViewContainerElement : public CaptureViewElementMock {
 };
 
 TEST(CaptureViewElementTesterTest, PassesAllTestsOnExistingElement) {
-  const int child_count = 2;
+  constexpr int kChildCount = 2;
   CaptureViewElementTester tester;
   UnitTestCaptureViewContainerElement container_elem(nullptr, tester.GetViewport(),
-                                                     tester.GetLayout(), child_count);
+                                                     tester.GetLayout(), kChildCount);
   tester.RunTests(&container_elem);
 }
 
@@ -124,8 +124,8 @@ TEST(CaptureViewElement, ContainsPointRecursively) {
 }
 
 TEST(CaptureViewElement, ContainsPointRecursivelyForElementsOutsideOfTheParent) {
-  const int child_count = 2;
-  UnitTestCaptureViewContainerElement elem(nullptr, &kViewport, &kLayout, child_count);
+  constexpr int kChildCount = 2;
+  UnitTestCaptureViewContainerElement elem(nullptr, &kViewport, &kLayout, kChildCount);
 
   CaptureViewElement* child0 = elem.GetAllChildren()[0];
 
@@ -136,8 +136,8 @@ TEST(CaptureViewElement, ContainsPointRecursivelyForElementsOutsideOfTheParent) 
 }
 
 TEST(CaptureViewElement, IsMouseOver) {
-  const int child_count = 2;
-  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, child_count);
+  constexpr int kChildCount = 2;
+  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, kChildCount);
 
   const Vec2 pos_outside(-1, -1);
   const Vec2 pos_between_children(10, kLeafElementHeight + 1);
@@ -191,8 +191,8 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
   using ::testing::Exactly;
   using ::testing::Return;
 
-  const int child_count = 3;
-  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, child_count);
+  constexpr int kChildCount = 3;
+  UnitTestCaptureViewContainerElement container_elem(nullptr, &kViewport, &kLayout, kChildCount);
 
   static_assert(kMarginAfterChild > 0);
 
@@ -202,7 +202,7 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
   const Vec2 pos_on_child1(10, kLeafElementHeight + kMarginAfterChild);
   const Vec2 pos_on_child2(10, (kLeafElementHeight + kMarginAfterChild) * 2);
 
-  const int delta = 1;
+  constexpr int kDelta = 1;
 
   CaptureViewElementMock* child0 =
       dynamic_cast<CaptureViewElementMock*>(container_elem.GetAllChildren()[0]);
@@ -213,17 +213,17 @@ TEST(CaptureViewElement, MouseWheelEventRecursesToCorrectChildren) {
 
   // Expect the parent to catch all mouse wheel events of children 0 and 1, but not those of child 2
   // since child 2 actually handles the event
-  EXPECT_CALL(container_elem, OnMouseWheel(_, delta, _))
+  EXPECT_CALL(container_elem, OnMouseWheel(_, kDelta, _))
       .Times(Exactly(3))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kIgnored));
 
-  EXPECT_CALL(*child0, OnMouseWheel(_, delta, _))
+  EXPECT_CALL(*child0, OnMouseWheel(_, kDelta, _))
       .Times(Exactly(1))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kIgnored));
-  EXPECT_CALL(*child1, OnMouseWheel(_, delta, _))
+  EXPECT_CALL(*child1, OnMouseWheel(_, kDelta, _))
       .Times(Exactly(1))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kIgnored));
-  EXPECT_CALL(*child2, OnMouseWheel(_, delta, _))
+  EXPECT_CALL(*child2, OnMouseWheel(_, kDelta, _))
       .Times(Exactly(1))
       .WillRepeatedly(Return(CaptureViewElement::EventResult::kHandled));
 

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -59,27 +59,28 @@ void orbit_gl::CaptureViewElementTester::SimulateDrawLoopAndCheckFlags(CaptureVi
 
 void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(
     CaptureViewElement* element) {
-  const float width = 100, updated_width = 50;
+  constexpr float kWidth = 100;
+  constexpr float kUpdatedWidth = 50;
   std::unordered_map<CaptureViewElement*, float> old_widths;
   for (auto& child : element->GetAllChildren()) {
     old_widths[child] = child->GetWidth();
   }
 
-  element->SetWidth(width);
+  element->SetWidth(kWidth);
   for (auto& child : element->GetAllChildren()) {
     if ((child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) !=
         0u) {
-      EXPECT_EQ(width, child->GetWidth());
+      EXPECT_EQ(kWidth, child->GetWidth());
     } else {
       EXPECT_EQ(old_widths[child], child->GetWidth());
     }
   }
 
-  element->SetWidth(updated_width);
+  element->SetWidth(kUpdatedWidth);
   for (auto& child : element->GetAllChildren()) {
     if ((child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) !=
         0u) {
-      EXPECT_EQ(updated_width, child->GetWidth());
+      EXPECT_EQ(kUpdatedWidth, child->GetWidth());
     } else {
       EXPECT_EQ(old_widths[child], child->GetWidth());
     }

--- a/src/OrbitGl/CaptureViewElementTester.cpp
+++ b/src/OrbitGl/CaptureViewElementTester.cpp
@@ -24,14 +24,14 @@ void orbit_gl::CaptureViewElementTester::CheckDrawFlags(CaptureViewElement* elem
 }
 
 void orbit_gl::CaptureViewElementTester::SimulatePreRender(CaptureViewElement* element) {
-  const int kMaxLayoutLoops = layout_.GetMaxLayoutingLoops();
+  const int max_layout_loops = layout_.GetMaxLayoutingLoops();
   int layout_loops = 0;
 
   do {
     element->UpdateLayout();
-  } while (++layout_loops < kMaxLayoutLoops && element->HasLayoutChanged());
+  } while (++layout_loops < max_layout_loops && element->HasLayoutChanged());
 
-  EXPECT_LT(layout_loops, kMaxLayoutLoops);
+  EXPECT_LT(layout_loops, max_layout_loops);
 }
 
 void orbit_gl::CaptureViewElementTester::SimulateDrawLoop(CaptureViewElement* element, bool draw,
@@ -59,27 +59,27 @@ void orbit_gl::CaptureViewElementTester::SimulateDrawLoopAndCheckFlags(CaptureVi
 
 void orbit_gl::CaptureViewElementTester::TestWidthPropagationToChildren(
     CaptureViewElement* element) {
-  const float kWidth = 100, kUpdatedWidth = 50;
+  const float width = 100, updated_width = 50;
   std::unordered_map<CaptureViewElement*, float> old_widths;
   for (auto& child : element->GetAllChildren()) {
     old_widths[child] = child->GetWidth();
   }
 
-  element->SetWidth(kWidth);
+  element->SetWidth(width);
   for (auto& child : element->GetAllChildren()) {
     if ((child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) !=
         0u) {
-      EXPECT_EQ(kWidth, child->GetWidth());
+      EXPECT_EQ(width, child->GetWidth());
     } else {
       EXPECT_EQ(old_widths[child], child->GetWidth());
     }
   }
 
-  element->SetWidth(kUpdatedWidth);
+  element->SetWidth(updated_width);
   for (auto& child : element->GetAllChildren()) {
     if ((child->GetLayoutFlags() & CaptureViewElement::LayoutFlags::kScaleHorizontallyWithParent) !=
         0u) {
-      EXPECT_EQ(kUpdatedWidth, child->GetWidth());
+      EXPECT_EQ(updated_width, child->GetWidth());
     } else {
       EXPECT_EQ(old_widths[child], child->GetWidth());
     }

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -117,7 +117,7 @@ void CaptureWindow::PreRender() {
     // the root element (time graph) of the tree.
     // During loading or capturing, only a single layouting loop is executed as we're
     // streaming in data from a seperate thread (for performance reasons)
-    const int kMaxLayoutLoops =
+    const int max_layout_loops =
         (app_ != nullptr && (app_->IsCapturing() || app_->IsLoadingCapture()))
             ? 1
             : time_graph_layout_->GetMaxLayoutingLoops();
@@ -125,7 +125,7 @@ void CaptureWindow::PreRender() {
     // TODO (b/229222095) Log when the max loop count is exceeded
     do {
       time_graph_->UpdateLayout();
-    } while (++layout_loops < kMaxLayoutLoops && time_graph_->HasLayoutChanged());
+    } while (++layout_loops < max_layout_loops && time_graph_->HasLayoutChanged());
   }
 }
 
@@ -358,9 +358,9 @@ void CaptureWindow::MouseWheelMovedHorizontally(int x, int y, int delta, bool ct
 
 void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt) {
   GlCanvas::KeyPressed(key_code, ctrl, shift, alt);
-  const float kPanRatioPerLeftAndRightArrowKeys = 0.1f;
-  const float kScrollingRatioPerUpAndDownArrowKeys = 0.05f;
-  const float kScrollingRatioPerPageUpAndDown = 0.9f;
+  const float pan_ratio_per_left_and_right_arrow_keys = 0.1f;
+  const float scrolling_ratio_per_up_and_down_arrow_keys = 0.05f;
+  const float scrolling_ratio_per_page_up_and_down = 0.9f;
 
   // TODO(b/234116147): Move this part to TimeGraph and manage events similarly to HandleMouseEvent.
   switch (key_code) {
@@ -370,10 +370,10 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
       }
       break;
     case 'A':
-      Pan(kPanRatioPerLeftAndRightArrowKeys);
+      Pan(pan_ratio_per_left_and_right_arrow_keys);
       break;
     case 'D':
-      Pan(-kPanRatioPerLeftAndRightArrowKeys);
+      Pan(-pan_ratio_per_left_and_right_arrow_keys);
       break;
     case 'W':
       ZoomHorizontally(1, mouse_move_pos_screen_[0]);
@@ -389,7 +389,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
     case 18:  // Left
       if (time_graph_ == nullptr) return;
       if (app_ == nullptr || app_->selected_timer() == nullptr) {
-        Pan(kPanRatioPerLeftAndRightArrowKeys);
+        Pan(pan_ratio_per_left_and_right_arrow_keys);
       } else if (shift) {
         time_graph_->JumpToNeighborTimer(app_->selected_timer(),
                                          TimeGraph::JumpDirection::kPrevious,
@@ -407,7 +407,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
     case 20:  // Right
       if (time_graph_ == nullptr) return;
       if (app_ == nullptr || app_->selected_timer() == nullptr) {
-        Pan(-kPanRatioPerLeftAndRightArrowKeys);
+        Pan(-pan_ratio_per_left_and_right_arrow_keys);
       } else if (shift) {
         time_graph_->JumpToNeighborTimer(app_->selected_timer(), TimeGraph::JumpDirection::kNext,
                                          TimeGraph::JumpScope::kSameFunction);
@@ -423,7 +423,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
       if (time_graph_ == nullptr) return;
       if (app_ == nullptr || app_->selected_timer() == nullptr) {
         time_graph_->GetTrackContainer()->IncrementVerticalScroll(
-            /*ratio=*/kScrollingRatioPerUpAndDownArrowKeys);
+            /*ratio=*/scrolling_ratio_per_up_and_down_arrow_keys);
       } else {
         time_graph_->JumpToNeighborTimer(app_->selected_timer(), TimeGraph::JumpDirection::kTop,
                                          TimeGraph::JumpScope::kSameThread);
@@ -433,7 +433,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
       if (time_graph_ == nullptr) return;
       if (app_ == nullptr || app_->selected_timer() == nullptr) {
         time_graph_->GetTrackContainer()->IncrementVerticalScroll(
-            /*ratio=*/-kScrollingRatioPerUpAndDownArrowKeys);
+            /*ratio=*/-scrolling_ratio_per_up_and_down_arrow_keys);
       } else {
         time_graph_->JumpToNeighborTimer(app_->selected_timer(), TimeGraph::JumpDirection::kDown,
                                          TimeGraph::JumpScope::kSameThread);
@@ -442,12 +442,12 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
     case 22:  // Page Up
       if (time_graph_ == nullptr) return;
       time_graph_->GetTrackContainer()->IncrementVerticalScroll(
-          /*ratio=*/kScrollingRatioPerPageUpAndDown);
+          /*ratio=*/scrolling_ratio_per_page_up_and_down);
       break;
     case 23:  // Page Down
       if (time_graph_ == nullptr) return;
       time_graph_->GetTrackContainer()->IncrementVerticalScroll(
-          /*ratio=*/-kScrollingRatioPerPageUpAndDown);
+          /*ratio=*/-scrolling_ratio_per_page_up_and_down);
       break;
     // Adding ']' here such that with e.g. German keyboards the ctrl+"+" shortcut works.
     // The '=' is added such that on English keyboards the combination works without the shift key.
@@ -695,11 +695,11 @@ void CaptureWindow::RenderHelpUi() {
       {time_graph_layout_->GetFontSize(), Color(255, 255, 255, 255), -1.f /*max_size*/},
       &text_bounding_box_pos, &text_bounding_box_size);
 
-  const Color kBoxColor(50, 50, 50, 243);
-  const float kMargin = 15.f;
-  const float kRoundingRadius = 20.f;
+  const Color box_color(50, 50, 50, 243);
+  const float margin = 15.f;
+  const float rounding_radius = 20.f;
   primitive_assembler_.AddRoundedBox(text_bounding_box_pos, text_bounding_box_size,
-                                     GlCanvas::kZValueUi, kRoundingRadius, kBoxColor, kMargin);
+                                     GlCanvas::kZValueUi, rounding_radius, box_color, margin);
 }
 
 const char* CaptureWindow::GetHelpText() const {

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -358,9 +358,9 @@ void CaptureWindow::MouseWheelMovedHorizontally(int x, int y, int delta, bool ct
 
 void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt) {
   GlCanvas::KeyPressed(key_code, ctrl, shift, alt);
-  const float pan_ratio_per_left_and_right_arrow_keys = 0.1f;
-  const float scrolling_ratio_per_up_and_down_arrow_keys = 0.05f;
-  const float scrolling_ratio_per_page_up_and_down = 0.9f;
+  constexpr float kPanRatioPerLeftAndRightArrowKeys = 0.1f;
+  constexpr float kScrollingRatioPerUpAndDownArrowKeys = 0.05f;
+  constexpr float kScrollingRatioPerPageUpAndDown = 0.9f;
 
   // TODO(b/234116147): Move this part to TimeGraph and manage events similarly to HandleMouseEvent.
   switch (key_code) {
@@ -370,10 +370,10 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
       }
       break;
     case 'A':
-      Pan(pan_ratio_per_left_and_right_arrow_keys);
+      Pan(kPanRatioPerLeftAndRightArrowKeys);
       break;
     case 'D':
-      Pan(-pan_ratio_per_left_and_right_arrow_keys);
+      Pan(-kPanRatioPerLeftAndRightArrowKeys);
       break;
     case 'W':
       ZoomHorizontally(1, mouse_move_pos_screen_[0]);
@@ -389,7 +389,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
     case 18:  // Left
       if (time_graph_ == nullptr) return;
       if (app_ == nullptr || app_->selected_timer() == nullptr) {
-        Pan(pan_ratio_per_left_and_right_arrow_keys);
+        Pan(kPanRatioPerLeftAndRightArrowKeys);
       } else if (shift) {
         time_graph_->JumpToNeighborTimer(app_->selected_timer(),
                                          TimeGraph::JumpDirection::kPrevious,
@@ -407,7 +407,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
     case 20:  // Right
       if (time_graph_ == nullptr) return;
       if (app_ == nullptr || app_->selected_timer() == nullptr) {
-        Pan(-pan_ratio_per_left_and_right_arrow_keys);
+        Pan(-kPanRatioPerLeftAndRightArrowKeys);
       } else if (shift) {
         time_graph_->JumpToNeighborTimer(app_->selected_timer(), TimeGraph::JumpDirection::kNext,
                                          TimeGraph::JumpScope::kSameFunction);
@@ -423,7 +423,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
       if (time_graph_ == nullptr) return;
       if (app_ == nullptr || app_->selected_timer() == nullptr) {
         time_graph_->GetTrackContainer()->IncrementVerticalScroll(
-            /*ratio=*/scrolling_ratio_per_up_and_down_arrow_keys);
+            /*ratio=*/kScrollingRatioPerUpAndDownArrowKeys);
       } else {
         time_graph_->JumpToNeighborTimer(app_->selected_timer(), TimeGraph::JumpDirection::kTop,
                                          TimeGraph::JumpScope::kSameThread);
@@ -433,7 +433,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
       if (time_graph_ == nullptr) return;
       if (app_ == nullptr || app_->selected_timer() == nullptr) {
         time_graph_->GetTrackContainer()->IncrementVerticalScroll(
-            /*ratio=*/-scrolling_ratio_per_up_and_down_arrow_keys);
+            /*ratio=*/-kScrollingRatioPerUpAndDownArrowKeys);
       } else {
         time_graph_->JumpToNeighborTimer(app_->selected_timer(), TimeGraph::JumpDirection::kDown,
                                          TimeGraph::JumpScope::kSameThread);
@@ -442,12 +442,12 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
     case 22:  // Page Up
       if (time_graph_ == nullptr) return;
       time_graph_->GetTrackContainer()->IncrementVerticalScroll(
-          /*ratio=*/scrolling_ratio_per_page_up_and_down);
+          /*ratio=*/kScrollingRatioPerPageUpAndDown);
       break;
     case 23:  // Page Down
       if (time_graph_ == nullptr) return;
       time_graph_->GetTrackContainer()->IncrementVerticalScroll(
-          /*ratio=*/-scrolling_ratio_per_page_up_and_down);
+          /*ratio=*/-kScrollingRatioPerPageUpAndDown);
       break;
     // Adding ']' here such that with e.g. German keyboards the ctrl+"+" shortcut works.
     // The '=' is added such that on English keyboards the combination works without the shift key.
@@ -696,10 +696,10 @@ void CaptureWindow::RenderHelpUi() {
       &text_bounding_box_pos, &text_bounding_box_size);
 
   const Color box_color(50, 50, 50, 243);
-  const float margin = 15.f;
-  const float rounding_radius = 20.f;
+  constexpr float kMargin = 15.f;
+  constexpr float kRoundingRadius = 20.f;
   primitive_assembler_.AddRoundedBox(text_bounding_box_pos, text_bounding_box_size,
-                                     GlCanvas::kZValueUi, rounding_radius, box_color, margin);
+                                     GlCanvas::kZValueUi, kRoundingRadius, box_color, kMargin);
 }
 
 const char* CaptureWindow::GetHelpText() const {

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -150,11 +150,11 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksInTheMiddleOfTimeline) {
   capture_window_.PreRender();
   ExpectInitialState();
   TimelineUi* timeline_ui = capture_window_.GetTimeGraph()->GetTimelineUi();
-  const Vec2i kTimelineSize = capture_window_.GetViewport().WorldToScreen(timeline_ui->GetSize());
-  const Vec2i kTimelinePos = capture_window_.GetViewport().WorldToScreen(timeline_ui->GetPos());
+  const Vec2i timeline_size = capture_window_.GetViewport().WorldToScreen(timeline_ui->GetSize());
+  const Vec2i timeline_pos = capture_window_.GetViewport().WorldToScreen(timeline_ui->GetPos());
 
-  int x = kTimelinePos[0] + kTimelineSize[0] / 2;
-  int y = kTimelinePos[1] + kTimelineSize[1] / 2;
+  int x = timeline_pos[0] + timeline_size[0] / 2;
+  int y = timeline_pos[1] + timeline_size[1] / 2;
 
   capture_window_.MouseWheelMoved(x, y, 1, /*ctrl=*/false);
   capture_window_.PreRender();
@@ -178,17 +178,17 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksInTheMiddleOfTimeline) {
 TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtRandomPositions) {
   capture_window_.PreRender();
   ExpectInitialState();
-  const Vec2i kTimelineSize = capture_window_.GetViewport().WorldToScreen(
+  const Vec2i timeline_size = capture_window_.GetViewport().WorldToScreen(
       capture_window_.GetTimeGraph()->GetTimelineUi()->GetSize());
 
   std::random_device rd;
   std::mt19937 mt(rd());
-  std::uniform_int_distribution<int> dist(0, kTimelineSize[0]);
+  std::uniform_int_distribution<int> dist(0, timeline_size[0]);
 
   constexpr int kNumTries = 100;
   for (int i = 0; i < kNumTries; ++i) {
     const int x = dist(mt);
-    const int y = kTimelineSize[1] - kBottomSafetyMargin;
+    const int y = timeline_size[1] - kBottomSafetyMargin;
 
     // Zoom in twice, then zoom out twice. Check that the intermediate states match
     capture_window_.MouseWheelMoved(x, y, 1, /*ctrl=*/true);
@@ -244,11 +244,11 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheRightOfTimeline) {
   ExpectInitialState();
 
   TimelineUi* timeline_ui = capture_window_.GetTimeGraph()->GetTimelineUi();
-  const Vec2i kTimelineSize = capture_window_.GetViewport().WorldToScreen(timeline_ui->GetSize());
-  const Vec2i kTimelinePos = capture_window_.GetViewport().WorldToScreen(timeline_ui->GetPos());
+  const Vec2i timeline_size = capture_window_.GetViewport().WorldToScreen(timeline_ui->GetSize());
+  const Vec2i timeline_pos = capture_window_.GetViewport().WorldToScreen(timeline_ui->GetPos());
 
-  int x = kTimelinePos[0] + kTimelineSize[0];
-  int y = kTimelinePos[1] + kTimelineSize[1] / 2;
+  int x = timeline_pos[0] + timeline_size[0];
+  int y = timeline_pos[1] + timeline_size[1] / 2;
 
   capture_window_.MouseWheelMoved(x, y, 1, /*ctrl=*/true);
   capture_window_.PreRender();
@@ -273,11 +273,11 @@ TEST_F(NavigationTestCaptureWindow, ZoomTimeWorksAtTheLeftOfTimeline) {
   capture_window_.PreRender();
   ExpectInitialState();
 
-  const Vec2i kTimelinePos = capture_window_.GetViewport().WorldToScreen(
+  const Vec2i timeline_pos = capture_window_.GetViewport().WorldToScreen(
       capture_window_.GetTimeGraph()->GetTimelineUi()->GetPos());
 
-  int x = kTimelinePos[0];
-  int y = kTimelinePos[1];
+  int x = timeline_pos[0];
+  int y = timeline_pos[1];
 
   capture_window_.MouseWheelMoved(x, y, 1, /*ctrl=*/false);
   capture_window_.PreRender();
@@ -302,10 +302,10 @@ TEST_F(NavigationTestCaptureWindow, VerticalZoomWorksAsExpected) {
   capture_window_.PreRender();
   ExpectInitialState();
 
-  const Vec2i kTimeGraphSize =
+  const Vec2i time_graph_size =
       capture_window_.GetViewport().WorldToScreen(capture_window_.GetTimeGraph()->GetSize());
-  int x = kTimeGraphSize[0] / 2;
-  int y = kTimeGraphSize[1] - kBottomSafetyMargin;
+  int x = time_graph_size[0] / 2;
+  int y = time_graph_size[1] - kBottomSafetyMargin;
   capture_window_.MouseMoved(x, y, /*left=*/false, /*right=*/false, /*middle=*/false);
 
   float old_height =
@@ -348,21 +348,21 @@ TEST_F(NavigationTestCaptureWindow, PanTimeWorksAsExpected) {
   EXPECT_NEAR(capture_window_.GetTimeGraph()->GetHorizontalSlider()->GetPosRatio(), 0.0, kEpsilon);
   EXPECT_NEAR(capture_window_.GetTimeGraph()->GetMinTimeUs(), 0.0, kEpsilon);
 
-  const int kRightArrowKeyCode = 20;
-  const int kLeftArrowKeyCode = 18;
-  capture_window_.KeyPressed(kRightArrowKeyCode, false, false, false);
+  const int right_arrow_key_code = 20;
+  const int left_arrow_key_code = 18;
+  capture_window_.KeyPressed(right_arrow_key_code, false, false, false);
   capture_window_.PreRender();
   EXPECT_GT(capture_window_.GetTimeGraph()->GetHorizontalSlider()->GetPosRatio(), 0.0);
   EXPECT_GT(capture_window_.GetTimeGraph()->GetMinTimeUs(), 0.0);
 
   double min_time_us_after_right_arrow = capture_window_.GetTimeGraph()->GetMinTimeUs();
-  capture_window_.KeyPressed(kRightArrowKeyCode, false, false, false);
-  capture_window_.KeyPressed(kLeftArrowKeyCode, false, false, false);
+  capture_window_.KeyPressed(right_arrow_key_code, false, false, false);
+  capture_window_.KeyPressed(left_arrow_key_code, false, false, false);
   // A right arrow key pressed followed by a left one should return to the original position.
   EXPECT_NEAR(min_time_us_after_right_arrow, capture_window_.GetTimeGraph()->GetMinTimeUs(),
               kEpsilon);
 
-  capture_window_.KeyPressed(kLeftArrowKeyCode, false, false, false);
+  capture_window_.KeyPressed(left_arrow_key_code, false, false, false);
   capture_window_.PreRender();
   EXPECT_NEAR(capture_window_.GetTimeGraph()->GetHorizontalSlider()->GetPosRatio(), 0.0, kEpsilon);
   EXPECT_NEAR(capture_window_.GetTimeGraph()->GetMinTimeUs(), 0.0, kEpsilon);

--- a/src/OrbitGl/CoreMathTest.cpp
+++ b/src/OrbitGl/CoreMathTest.cpp
@@ -27,39 +27,39 @@ TYPED_TEST(ClosedIntervalTest, Intersects) {
   EXPECT_FALSE((ClosedInterval<Type>{0, 1}.Intersects(ClosedInterval<Type>{2, 3})));
   EXPECT_FALSE((ClosedInterval<Type>{2, 3}.Intersects(ClosedInterval<Type>{0, 1})));
 
-  const ClosedInterval<Type> kSmallClosedInterval{0, 3};
-  EXPECT_TRUE(kSmallClosedInterval.Intersects(ClosedInterval<Type>{1, 1}));
-  EXPECT_TRUE(kSmallClosedInterval.Intersects(ClosedInterval<Type>{3, 3}));
-  EXPECT_FALSE(kSmallClosedInterval.Intersects(ClosedInterval<Type>{4, 4}));
+  const ClosedInterval<Type> small_closed_interval{0, 3};
+  EXPECT_TRUE(small_closed_interval.Intersects(ClosedInterval<Type>{1, 1}));
+  EXPECT_TRUE(small_closed_interval.Intersects(ClosedInterval<Type>{3, 3}));
+  EXPECT_FALSE(small_closed_interval.Intersects(ClosedInterval<Type>{4, 4}));
 }
 
 TYPED_TEST(ClosedIntervalTest, Contains) {
   using Type = typename TestFixture::MyParamType;
-  const ClosedInterval<Type> kSmallClosedInterval{0, 3};
-  EXPECT_FALSE(kSmallClosedInterval.Contains(-1));
-  EXPECT_TRUE(kSmallClosedInterval.Contains(0));
-  EXPECT_TRUE(kSmallClosedInterval.Contains(1));
-  EXPECT_TRUE(kSmallClosedInterval.Contains(3));
-  EXPECT_FALSE(kSmallClosedInterval.Contains(4));
+  const ClosedInterval<Type> small_closed_interval{0, 3};
+  EXPECT_FALSE(small_closed_interval.Contains(-1));
+  EXPECT_TRUE(small_closed_interval.Contains(0));
+  EXPECT_TRUE(small_closed_interval.Contains(1));
+  EXPECT_TRUE(small_closed_interval.Contains(3));
+  EXPECT_FALSE(small_closed_interval.Contains(4));
 
   EXPECT_TRUE((ClosedInterval<Type>{1, 1}.Contains(1)));
   EXPECT_FALSE((ClosedInterval<Type>{1, 1}.Contains(2)));
 }
 
 TEST(CoreMath, IsInsideRectangle) {
-  const Vec2 kFakeRectangleTopLeft{5, 5};
-  const Vec2 kFakeRectangleSize{2, 2};
+  const Vec2 fake_rectangle_top_left{5, 5};
+  const Vec2 fake_rectangle_size{2, 2};
   // Test the 4 conditions for the sides of the rectangle and the center.
-  EXPECT_FALSE(IsInsideRectangle({4, 6}, kFakeRectangleTopLeft, kFakeRectangleSize));
-  EXPECT_FALSE(IsInsideRectangle({6, 4}, kFakeRectangleTopLeft, kFakeRectangleSize));
-  EXPECT_FALSE(IsInsideRectangle({6, 8}, kFakeRectangleTopLeft, kFakeRectangleSize));
-  EXPECT_FALSE(IsInsideRectangle({8, 6}, kFakeRectangleTopLeft, kFakeRectangleSize));
+  EXPECT_FALSE(IsInsideRectangle({4, 6}, fake_rectangle_top_left, fake_rectangle_size));
+  EXPECT_FALSE(IsInsideRectangle({6, 4}, fake_rectangle_top_left, fake_rectangle_size));
+  EXPECT_FALSE(IsInsideRectangle({6, 8}, fake_rectangle_top_left, fake_rectangle_size));
+  EXPECT_FALSE(IsInsideRectangle({8, 6}, fake_rectangle_top_left, fake_rectangle_size));
 
-  EXPECT_TRUE(IsInsideRectangle({5, 5}, kFakeRectangleTopLeft, kFakeRectangleSize));
-  EXPECT_TRUE(IsInsideRectangle({5, 7}, kFakeRectangleTopLeft, kFakeRectangleSize));
-  EXPECT_TRUE(IsInsideRectangle({7, 5}, kFakeRectangleTopLeft, kFakeRectangleSize));
-  EXPECT_TRUE(IsInsideRectangle({7, 7}, kFakeRectangleTopLeft, kFakeRectangleSize));
-  EXPECT_TRUE(IsInsideRectangle({6, 6}, kFakeRectangleTopLeft, kFakeRectangleSize));
+  EXPECT_TRUE(IsInsideRectangle({5, 5}, fake_rectangle_top_left, fake_rectangle_size));
+  EXPECT_TRUE(IsInsideRectangle({5, 7}, fake_rectangle_top_left, fake_rectangle_size));
+  EXPECT_TRUE(IsInsideRectangle({7, 5}, fake_rectangle_top_left, fake_rectangle_size));
+  EXPECT_TRUE(IsInsideRectangle({7, 7}, fake_rectangle_top_left, fake_rectangle_size));
+  EXPECT_TRUE(IsInsideRectangle({6, 6}, fake_rectangle_top_left, fake_rectangle_size));
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/FormatCallstackForTooltip.cpp
+++ b/src/OrbitGl/FormatCallstackForTooltip.cpp
@@ -39,15 +39,16 @@ struct UnformattedModuleAndFunctionName {
     const orbit_client_data::CaptureData& capture_data,
     const orbit_client_data::ModuleManager& module_manager) {
   if (frame_index >= callstack.frames().size()) {
-    static const UnformattedModuleAndFunctionName kFrameIndexTooLargeModuleAndFunctionName = [] {
-      UnformattedModuleAndFunctionName module_and_function_name;
-      module_and_function_name.module_name = orbit_client_data::kUnknownFunctionOrModuleName;
-      module_and_function_name.module_is_unknown = true;
-      module_and_function_name.function_name = orbit_client_data::kUnknownFunctionOrModuleName;
-      module_and_function_name.function_is_unknown = true;
-      return module_and_function_name;
-    }();
-    return kFrameIndexTooLargeModuleAndFunctionName;
+    static const UnformattedModuleAndFunctionName frame_index_too_large_module_and_function_name =
+        [] {
+          UnformattedModuleAndFunctionName module_and_function_name;
+          module_and_function_name.module_name = orbit_client_data::kUnknownFunctionOrModuleName;
+          module_and_function_name.module_is_unknown = true;
+          module_and_function_name.function_name = orbit_client_data::kUnknownFunctionOrModuleName;
+          module_and_function_name.function_is_unknown = true;
+          return module_and_function_name;
+        }();
+    return frame_index_too_large_module_and_function_name;
   }
 
   const uint64_t address = callstack.frames()[frame_index];
@@ -135,15 +136,15 @@ std::string FormatCallstackForTooltip(const orbit_client_data::CallstackInfo& ca
       continue;
     }
 
-    static const std::string kModuleFunctionSeparator{" | "};
+    static const std::string module_function_separator{" | "};
     const UnformattedModuleAndFunctionName module_and_function_name =
         SafeGetModuleAndFunctionName(callstack, frame_index, capture_data, module_manager);
     const std::string formatted_module_name = FormatModuleName(module_and_function_name);
     const std::string formatted_function_name = FormatFunctionName(
         module_and_function_name, max_line_length - module_and_function_name.module_name.size() -
-                                      kModuleFunctionSeparator.size());
+                                      module_function_separator.size());
     const std::string formatted_module_and_function_name =
-        absl::StrCat(formatted_module_name, kModuleFunctionSeparator, formatted_function_name);
+        absl::StrCat(formatted_module_name, module_function_separator, formatted_function_name);
     // The first frame is always correct.
     if (callstack.IsUnwindingError() && frame_index > 0) {
       result += absl::StrFormat("<span style=\"color:%s;\">%s</span><br/>", kUnwindErrorColorString,

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -215,8 +215,8 @@ void FrameTrack::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& t
                         const DrawContext& draw_context) {
   TimerTrack::DoDraw(primitive_assembler, text_renderer, draw_context);
 
-  const Color kWhiteColor(255, 255, 255, 255);
-  const Color kBlackColor(0, 0, 0, 255);
+  const Color white_color(255, 255, 255, 255);
+  const Color black_color(0, 0, 0, 255);
   const Vec2 pos = GetPos();
 
   const float x = pos[0];
@@ -233,11 +233,11 @@ void FrameTrack::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& t
   Vec2 white_text_box_position(pos[0] + layout_->GetRightMargin(), y);
 
   primitive_assembler.AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z,
-                              kWhiteColor);
+                              white_color);
   primitive_assembler.AddLine(Vec2(white_text_box_position[0] + string_width, y), to, text_z,
-                              kWhiteColor);
+                              white_color);
 
-  TextRenderer::TextFormatting formatting{font_size, kWhiteColor, string_width};
+  TextRenderer::TextFormatting formatting{font_size, white_color, string_width};
   formatting.valign = TextRenderer::VAlign::Middle;
 
   text_renderer.AddText(label.c_str(), white_text_box_position[0], white_text_box_position[1],

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -19,8 +19,6 @@
 
 namespace orbit_gl {
 
-const float GlSlider::kGradientFactor = 0.25f;
-
 CaptureViewElement::EventResult GlSlider::OnMouseEnter() {
   EventResult event_result = CaptureViewElement::OnMouseEnter();
   if (QGuiApplication::instance() != nullptr) {
@@ -86,17 +84,17 @@ void GlSlider::SetNormalizedLength(float length_ratio)  // [0,1]
 }
 
 Color GlSlider::GetLighterColor(const Color& color) {
-  const float local_gradient_factor = 1.0f + kGradientFactor;
-  return {static_cast<unsigned char>(color[0] * local_gradient_factor),
-          static_cast<unsigned char>(color[1] * local_gradient_factor),
-          static_cast<unsigned char>(color[2] * local_gradient_factor), 255};
+  constexpr float kLocalGradientFactor = 1.0f + kGradientFactor;
+  return {static_cast<unsigned char>(color[0] * kLocalGradientFactor),
+          static_cast<unsigned char>(color[1] * kLocalGradientFactor),
+          static_cast<unsigned char>(color[2] * kLocalGradientFactor), 255};
 }
 
 Color GlSlider::GetDarkerColor(const Color& color) {
-  const float local_gradient_factor = 1.0f - kGradientFactor;
-  return {static_cast<unsigned char>(color[0] * local_gradient_factor),
-          static_cast<unsigned char>(color[1] * local_gradient_factor),
-          static_cast<unsigned char>(color[2] * local_gradient_factor), 255};
+  constexpr float kLocalGradientFactor = 1.0f - kGradientFactor;
+  return {static_cast<unsigned char>(color[0] * kLocalGradientFactor),
+          static_cast<unsigned char>(color[1] * kLocalGradientFactor),
+          static_cast<unsigned char>(color[2] * kLocalGradientFactor), 255};
 }
 
 void GlSlider::OnDrag(int x, int y) {
@@ -166,10 +164,10 @@ void GlSlider::OnPick(int x, int y) {
 void GlSlider::DrawBackground(PrimitiveAssembler& primitive_assembler, float x, float y,
                               float width, float height) {
   const Color dark_border_color = GetDarkerColor(bar_color_);
-  const float epsilon = 0.0001f;
+  constexpr float kEpsilon = 0.0001f;
 
   Quad border_box = MakeBox(Vec2(x, y), Vec2(width, height));
-  primitive_assembler.AddBox(border_box, GlCanvas::kZValueButtonBg - epsilon, dark_border_color,
+  primitive_assembler.AddBox(border_box, GlCanvas::kZValueButtonBg - kEpsilon, dark_border_color,
                              shared_from_this());
 
   Quad bar_box = MakeBox(Vec2(x + 1.f, y + 1.f), Vec2(width - 2.f, height - 2.f));
@@ -183,29 +181,29 @@ void GlSlider::DrawSlider(PrimitiveAssembler& primitive_assembler, float x, floa
   Color color = (IsMouseOver() && PosIsInSlider(mouse_pos_cur_)) ? selected_color_ : slider_color_;
   const Color dark_border_color = GetDarkerColor(bar_color_);
   const Color light_border_color = GetLighterColor(color);
-  const float epsilon = 0.0001f;
+  constexpr float kEpsilon = 0.0001f;
 
   Quad dark_border_box = MakeBox(Vec2(x, y), Vec2(width, height));
 
-  primitive_assembler.AddBox(dark_border_box, GlCanvas::kZValueButton - 2 * epsilon,
+  primitive_assembler.AddBox(dark_border_box, GlCanvas::kZValueButton - 2 * kEpsilon,
                              dark_border_color, shared_from_this());
 
   Quad light_border_box = MakeBox(Vec2(x + 1.f, y + 1.f), Vec2(width - 2.f, height - 2.f));
 
-  primitive_assembler.AddBox(light_border_box, GlCanvas::kZValueButton - epsilon,
+  primitive_assembler.AddBox(light_border_box, GlCanvas::kZValueButton - kEpsilon,
                              light_border_color, shared_from_this());
 
   // Slider itself
-  const float slider_offset = 2.f;
+  constexpr float kSliderOffset = 2.f;
   if (!is_picked) {
     primitive_assembler.AddShadedBox(
-        Vec2(x + slider_offset, y + slider_offset),
-        Vec2(width - 2.f * slider_offset, height - 2.f * slider_offset), GlCanvas::kZValueButton,
+        Vec2(x + kSliderOffset, y + kSliderOffset),
+        Vec2(width - 2.f * kSliderOffset, height - 2.f * kSliderOffset), GlCanvas::kZValueButton,
         color, shared_from_this(), shading_direction);
   } else {
     primitive_assembler.AddBox(
-        MakeBox(Vec2(x + slider_offset, y + slider_offset),
-                Vec2(width - 2.f * slider_offset, height - 2.f * slider_offset)),
+        MakeBox(Vec2(x + kSliderOffset, y + kSliderOffset),
+                Vec2(width - 2.f * kSliderOffset, height - 2.f * kSliderOffset)),
         GlCanvas::kZValueButton, slider_color_, shared_from_this());
   }
 }
@@ -299,33 +297,33 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
   ShadingDirection shading_direction = ShadingDirection::kTopToBottom;
   DrawSlider(primitive_assembler, start, 0, slider_width, GetSliderWidth(), shading_direction);
 
-  const float epsilon = 0.0001f;
+  constexpr float kEpsilon = 0.0001f;
 
   // Left / right resize arrows and separator
-  const float height_factor = 2.f;
+  constexpr float kHeightFactor = 2.f;
   // Triangle is 3 pixels smaller than the area - there is a 2 pixel border around the scrollbar,
   // and there is no margin between the border and the triangle to make it as big as possible.
   // On the other side, there is a 1 pixel margin between the triangle and the vertical line
   float tri_size = GetSliderResizeMargin() - 3.f;
-  tri_size = std::min(tri_size, GetSliderWidth() - tri_size * height_factor - 2.f);
-  const float tri_y_offset = (GetSliderWidth() - tri_size * height_factor) / 2.f;
+  tri_size = std::min(tri_size, GetSliderWidth() - tri_size * kHeightFactor - 2.f);
+  const float tri_y_offset = (GetSliderWidth() - tri_size * kHeightFactor) / 2.f;
   const Color white = GetLighterColor(GetLighterColor(bar_color_));
-  const float z = GlCanvas::kZValueButton + 2 * epsilon;
+  const float z = GlCanvas::kZValueButton + 2 * kEpsilon;
   const float x = start;
   const float width = slider_width;
 
   primitive_assembler.AddTriangle(
-      Triangle(Vec2(x + width - tri_size - 2.f, height_factor * tri_size + tri_y_offset),
-               Vec2(x + width - 2.f, tri_y_offset + height_factor / 2.f * tri_size),
+      Triangle(Vec2(x + width - tri_size - 2.f, kHeightFactor * tri_size + tri_y_offset),
+               Vec2(x + width - 2.f, tri_y_offset + kHeightFactor / 2.f * tri_size),
                Vec2(x + width - tri_size - 2.f, tri_y_offset)),
       z, white, shared_from_this());
   primitive_assembler.AddVerticalLine(Vec2(x + width - GetSliderResizeMargin(), 2.f),
                                       GetSliderWidth() - 4.f, z, white, shared_from_this());
 
   primitive_assembler.AddTriangle(
-      Triangle(Vec2(x + tri_size + 2.f, height_factor * tri_size + tri_y_offset),
+      Triangle(Vec2(x + tri_size + 2.f, kHeightFactor * tri_size + tri_y_offset),
                Vec2(x + tri_size + 2.f, tri_y_offset),
-               Vec2(x + 2.f, tri_y_offset + height_factor / 2.f * tri_size)),
+               Vec2(x + 2.f, tri_y_offset + kHeightFactor / 2.f * tri_size)),
       z, white, shared_from_this());
   primitive_assembler.AddVerticalLine(Vec2(x + GetSliderResizeMargin() + 1, 2.f),
                                       GetSliderWidth() - 4.f, z, white, shared_from_this());
@@ -336,12 +334,12 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
     if (drag_type_ == DragType::kScaleMax) {
       primitive_assembler.AddShadedBox(Vec2(x + width - GetSliderResizeMargin(), 2),
                                        Vec2(GetSliderResizeMargin() - 2, GetSliderWidth() - 4),
-                                       GlCanvas::kZValueButton + epsilon, selected_color_,
+                                       GlCanvas::kZValueButton + kEpsilon, selected_color_,
                                        ShadingDirection::kTopToBottom);
     } else if (drag_type_ == DragType::kScaleMin) {
       primitive_assembler.AddShadedBox(
           Vec2(x + 2, 2), Vec2(GetSliderResizeMargin() - 2, GetSliderWidth() - 4),
-          GlCanvas::kZValueButton + epsilon, selected_color_, ShadingDirection::kTopToBottom);
+          GlCanvas::kZValueButton + kEpsilon, selected_color_, ShadingDirection::kTopToBottom);
     }
   }
 

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -86,17 +86,17 @@ void GlSlider::SetNormalizedLength(float length_ratio)  // [0,1]
 }
 
 Color GlSlider::GetLighterColor(const Color& color) {
-  const float kLocalGradientFactor = 1.0f + kGradientFactor;
-  return {static_cast<unsigned char>(color[0] * kLocalGradientFactor),
-          static_cast<unsigned char>(color[1] * kLocalGradientFactor),
-          static_cast<unsigned char>(color[2] * kLocalGradientFactor), 255};
+  const float local_gradient_factor = 1.0f + kGradientFactor;
+  return {static_cast<unsigned char>(color[0] * local_gradient_factor),
+          static_cast<unsigned char>(color[1] * local_gradient_factor),
+          static_cast<unsigned char>(color[2] * local_gradient_factor), 255};
 }
 
 Color GlSlider::GetDarkerColor(const Color& color) {
-  const float kLocalGradientFactor = 1.0f - kGradientFactor;
-  return {static_cast<unsigned char>(color[0] * kLocalGradientFactor),
-          static_cast<unsigned char>(color[1] * kLocalGradientFactor),
-          static_cast<unsigned char>(color[2] * kLocalGradientFactor), 255};
+  const float local_gradient_factor = 1.0f - kGradientFactor;
+  return {static_cast<unsigned char>(color[0] * local_gradient_factor),
+          static_cast<unsigned char>(color[1] * local_gradient_factor),
+          static_cast<unsigned char>(color[2] * local_gradient_factor), 255};
 }
 
 void GlSlider::OnDrag(int x, int y) {
@@ -166,10 +166,10 @@ void GlSlider::OnPick(int x, int y) {
 void GlSlider::DrawBackground(PrimitiveAssembler& primitive_assembler, float x, float y,
                               float width, float height) {
   const Color dark_border_color = GetDarkerColor(bar_color_);
-  const float kEpsilon = 0.0001f;
+  const float epsilon = 0.0001f;
 
   Quad border_box = MakeBox(Vec2(x, y), Vec2(width, height));
-  primitive_assembler.AddBox(border_box, GlCanvas::kZValueButtonBg - kEpsilon, dark_border_color,
+  primitive_assembler.AddBox(border_box, GlCanvas::kZValueButtonBg - epsilon, dark_border_color,
                              shared_from_this());
 
   Quad bar_box = MakeBox(Vec2(x + 1.f, y + 1.f), Vec2(width - 2.f, height - 2.f));
@@ -183,29 +183,29 @@ void GlSlider::DrawSlider(PrimitiveAssembler& primitive_assembler, float x, floa
   Color color = (IsMouseOver() && PosIsInSlider(mouse_pos_cur_)) ? selected_color_ : slider_color_;
   const Color dark_border_color = GetDarkerColor(bar_color_);
   const Color light_border_color = GetLighterColor(color);
-  const float kEpsilon = 0.0001f;
+  const float epsilon = 0.0001f;
 
   Quad dark_border_box = MakeBox(Vec2(x, y), Vec2(width, height));
 
-  primitive_assembler.AddBox(dark_border_box, GlCanvas::kZValueButton - 2 * kEpsilon,
+  primitive_assembler.AddBox(dark_border_box, GlCanvas::kZValueButton - 2 * epsilon,
                              dark_border_color, shared_from_this());
 
   Quad light_border_box = MakeBox(Vec2(x + 1.f, y + 1.f), Vec2(width - 2.f, height - 2.f));
 
-  primitive_assembler.AddBox(light_border_box, GlCanvas::kZValueButton - kEpsilon,
+  primitive_assembler.AddBox(light_border_box, GlCanvas::kZValueButton - epsilon,
                              light_border_color, shared_from_this());
 
   // Slider itself
-  const float kSliderOffset = 2.f;
+  const float slider_offset = 2.f;
   if (!is_picked) {
     primitive_assembler.AddShadedBox(
-        Vec2(x + kSliderOffset, y + kSliderOffset),
-        Vec2(width - 2.f * kSliderOffset, height - 2.f * kSliderOffset), GlCanvas::kZValueButton,
+        Vec2(x + slider_offset, y + slider_offset),
+        Vec2(width - 2.f * slider_offset, height - 2.f * slider_offset), GlCanvas::kZValueButton,
         color, shared_from_this(), shading_direction);
   } else {
     primitive_assembler.AddBox(
-        MakeBox(Vec2(x + kSliderOffset, y + kSliderOffset),
-                Vec2(width - 2.f * kSliderOffset, height - 2.f * kSliderOffset)),
+        MakeBox(Vec2(x + slider_offset, y + slider_offset),
+                Vec2(width - 2.f * slider_offset, height - 2.f * slider_offset)),
         GlCanvas::kZValueButton, slider_color_, shared_from_this());
   }
 }
@@ -299,36 +299,36 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
   ShadingDirection shading_direction = ShadingDirection::kTopToBottom;
   DrawSlider(primitive_assembler, start, 0, slider_width, GetSliderWidth(), shading_direction);
 
-  const float kEpsilon = 0.0001f;
+  const float epsilon = 0.0001f;
 
   // Left / right resize arrows and separator
-  const float kHeightFactor = 2.f;
+  const float height_factor = 2.f;
   // Triangle is 3 pixels smaller than the area - there is a 2 pixel border around the scrollbar,
   // and there is no margin between the border and the triangle to make it as big as possible.
   // On the other side, there is a 1 pixel margin between the triangle and the vertical line
   float tri_size = GetSliderResizeMargin() - 3.f;
-  tri_size = std::min(tri_size, GetSliderWidth() - tri_size * kHeightFactor - 2.f);
-  const float tri_y_offset = (GetSliderWidth() - tri_size * kHeightFactor) / 2.f;
-  const Color kWhite = GetLighterColor(GetLighterColor(bar_color_));
-  const float z = GlCanvas::kZValueButton + 2 * kEpsilon;
+  tri_size = std::min(tri_size, GetSliderWidth() - tri_size * height_factor - 2.f);
+  const float tri_y_offset = (GetSliderWidth() - tri_size * height_factor) / 2.f;
+  const Color white = GetLighterColor(GetLighterColor(bar_color_));
+  const float z = GlCanvas::kZValueButton + 2 * epsilon;
   const float x = start;
   const float width = slider_width;
 
   primitive_assembler.AddTriangle(
-      Triangle(Vec2(x + width - tri_size - 2.f, kHeightFactor * tri_size + tri_y_offset),
-               Vec2(x + width - 2.f, tri_y_offset + kHeightFactor / 2.f * tri_size),
+      Triangle(Vec2(x + width - tri_size - 2.f, height_factor * tri_size + tri_y_offset),
+               Vec2(x + width - 2.f, tri_y_offset + height_factor / 2.f * tri_size),
                Vec2(x + width - tri_size - 2.f, tri_y_offset)),
-      z, kWhite, shared_from_this());
+      z, white, shared_from_this());
   primitive_assembler.AddVerticalLine(Vec2(x + width - GetSliderResizeMargin(), 2.f),
-                                      GetSliderWidth() - 4.f, z, kWhite, shared_from_this());
+                                      GetSliderWidth() - 4.f, z, white, shared_from_this());
 
   primitive_assembler.AddTriangle(
-      Triangle(Vec2(x + tri_size + 2.f, kHeightFactor * tri_size + tri_y_offset),
+      Triangle(Vec2(x + tri_size + 2.f, height_factor * tri_size + tri_y_offset),
                Vec2(x + tri_size + 2.f, tri_y_offset),
-               Vec2(x + 2.f, tri_y_offset + kHeightFactor / 2.f * tri_size)),
-      z, kWhite, shared_from_this());
+               Vec2(x + 2.f, tri_y_offset + height_factor / 2.f * tri_size)),
+      z, white, shared_from_this());
   primitive_assembler.AddVerticalLine(Vec2(x + GetSliderResizeMargin() + 1, 2.f),
-                                      GetSliderWidth() - 4.f, z, kWhite, shared_from_this());
+                                      GetSliderWidth() - 4.f, z, white, shared_from_this());
 
   // Highlight the scale part of the slider
   bool is_picked = primitive_assembler.GetPickingManager()->IsThisElementPicked(this);
@@ -336,12 +336,12 @@ void GlHorizontalSlider::DoDraw(PrimitiveAssembler& primitive_assembler,
     if (drag_type_ == DragType::kScaleMax) {
       primitive_assembler.AddShadedBox(Vec2(x + width - GetSliderResizeMargin(), 2),
                                        Vec2(GetSliderResizeMargin() - 2, GetSliderWidth() - 4),
-                                       GlCanvas::kZValueButton + kEpsilon, selected_color_,
+                                       GlCanvas::kZValueButton + epsilon, selected_color_,
                                        ShadingDirection::kTopToBottom);
     } else if (drag_type_ == DragType::kScaleMin) {
       primitive_assembler.AddShadedBox(
           Vec2(x + 2, 2), Vec2(GetSliderResizeMargin() - 2, GetSliderWidth() - 4),
-          GlCanvas::kZValueButton + kEpsilon, selected_color_, ShadingDirection::kTopToBottom);
+          GlCanvas::kZValueButton + epsilon, selected_color_, ShadingDirection::kTopToBottom);
     }
   }
 

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -48,16 +48,16 @@ Color GpuDebugMarkerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_se
                                          bool is_highlighted,
                                          const internal::DrawData& /*draw_data*/) const {
   ORBIT_CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
-  const Color kInactiveColor(100, 100, 100, 255);
-  const Color kSelectionColor(0, 128, 255, 255);
+  const Color inactive_color(100, 100, 100, 255);
+  const Color selection_color(0, 128, 255, 255);
   if (is_highlighted) {
     return TimerTrack::kHighlightColor;
   }
   if (is_selected) {
-    return kSelectionColor;
+    return selection_color;
   }
   if (!IsTimerActive(timer_info)) {
-    return kInactiveColor;
+    return inactive_color;
   }
   if (timer_info.has_color()) {
     ORBIT_CHECK(timer_info.color().red() < 256);

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -78,16 +78,16 @@ bool GpuSubmissionTrack::IsTimerActive(const TimerInfo& timer_info) const {
 Color GpuSubmissionTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
                                         bool is_highlighted,
                                         const internal::DrawData& /*draw_data*/) const {
-  const Color kInactiveColor(100, 100, 100, 255);
-  const Color kSelectionColor(0, 128, 255, 255);
+  const Color inactive_color(100, 100, 100, 255);
+  const Color selection_color(0, 128, 255, 255);
   if (is_highlighted) {
     return TimerTrack::kHighlightColor;
   }
   if (is_selected) {
-    return kSelectionColor;
+    return selection_color;
   }
   if (!IsTimerActive(timer_info)) {
-    return kInactiveColor;
+    return inactive_color;
   }
   if (timer_info.has_color()) {
     ORBIT_CHECK(timer_info.color().red() < 256);

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -70,8 +70,8 @@ float GraphTrack<Dimension>::GetLegendHeight() const {
   if (!HasLegend()) return 0;
 
   // Legend size should be smaller than all regular textboxes across Orbit.
-  const float kLegendHeight = layout_->GetTextBoxHeight() / 2.f;
-  return kLegendHeight;
+  const float legend_height = layout_->GetTextBoxHeight() / 2.f;
+  return legend_height;
 }
 
 template <size_t Dimension>
@@ -85,8 +85,8 @@ void GraphTrack<Dimension>::DoDraw(PrimitiveAssembler& primitive_assembler,
   if (!HasLegend()) return;
 
   // Draw legends
-  const Color kWhite(255, 255, 255, 255);
-  DrawLegend(primitive_assembler, text_renderer, series_.GetSeriesNames(), kWhite);
+  const Color white(255, 255, 255, 255);
+  DrawLegend(primitive_assembler, text_renderer, series_.GetSeriesNames(), white);
 }
 
 template <size_t Dimension>
@@ -167,12 +167,12 @@ void GraphTrack<Dimension>::DrawMouseLabel(PrimitiveAssembler& primitive_assembl
                                            const DrawContext& draw_context) {
   if (!draw_context.current_mouse_tick.has_value()) return;
 
-  const float kTextLeftMargin = 2.f;
-  const float kTextRightMargin = kTextLeftMargin;
-  const float kTextTopMargin = layout_->GetTextOffset();
-  const float kTextBottomMargin = kTextTopMargin;
-  const Color kBlack(0, 0, 0, 255);
-  const Color kTransparentWhite(255, 255, 255, 180);
+  const float text_left_margin = 2.f;
+  const float text_right_margin = text_left_margin;
+  const float text_top_margin = layout_->GetTextOffset();
+  const float text_bottom_margin = text_top_margin;
+  const Color black(0, 0, 0, 255);
+  const Color transparent_white(255, 255, 255, 180);
 
   uint64_t current_mouse_time_ns = draw_context.current_mouse_tick.value();
   const std::array<double, Dimension>& values =
@@ -192,33 +192,33 @@ void GraphTrack<Dimension>::DrawMouseLabel(PrimitiveAssembler& primitive_assembl
   Vec2 text_box_size(text_width, text_height);
 
   float arrow_width = text_box_size[1] / 2.f;
-  Vec2 arrow_box_size(text_box_size[0] + kTextLeftMargin + kTextRightMargin,
-                      text_box_size[1] + kTextTopMargin + kTextBottomMargin);
+  Vec2 arrow_box_size(text_box_size[0] + text_left_margin + text_right_margin,
+                      text_box_size[1] + text_top_margin + text_bottom_margin);
   bool arrow_is_left_directed = target_point_pos[0] < arrow_box_size[0] + arrow_width;
   Vec2 text_box_position(
       target_point_pos[0] + (arrow_is_left_directed
-                                 ? arrow_width + kTextLeftMargin
-                                 : -arrow_width - kTextRightMargin - text_box_size[0]),
+                                 ? arrow_width + text_left_margin
+                                 : -arrow_width - text_right_margin - text_box_size[0]),
       target_point_pos[1] - text_box_size[1] / 2.f);
 
   float label_z = GlCanvas::kZValueTrackLabel;
   text_renderer.AddText(text.c_str(), text_box_position[0], text_box_position[1], label_z,
-                        {font_size, kBlack, text_box_size[0]});
+                        {font_size, black, text_box_size[0]});
 
-  Vec2 arrow_box_position(text_box_position[0] - kTextLeftMargin,
-                          text_box_position[1] - kTextBottomMargin);
+  Vec2 arrow_box_position(text_box_position[0] - text_left_margin,
+                          text_box_position[1] - text_bottom_margin);
   Quad arrow_text_box = MakeBox(arrow_box_position, arrow_box_size);
   Vec2 arrow_extra_point(target_point_pos[0], target_point_pos[1]);
 
-  primitive_assembler.AddBox(arrow_text_box, label_z, kTransparentWhite);
+  primitive_assembler.AddBox(arrow_text_box, label_z, transparent_white);
   if (arrow_is_left_directed) {
     primitive_assembler.AddTriangle(
         Triangle(arrow_text_box.vertices[0], arrow_text_box.vertices[1], arrow_extra_point),
-        label_z, kTransparentWhite);
+        label_z, transparent_white);
   } else {
     primitive_assembler.AddTriangle(
         Triangle(arrow_text_box.vertices[2], arrow_text_box.vertices[3], arrow_extra_point),
-        label_z, kTransparentWhite);
+        label_z, transparent_white);
   }
 }
 
@@ -227,21 +227,21 @@ void GraphTrack<Dimension>::DrawLegend(PrimitiveAssembler& primitive_assembler,
                                        TextRenderer& text_renderer,
                                        const std::array<std::string, Dimension>& series_names,
                                        const Color& legend_text_color) {
-  const float kSpaceBetweenLegendSymbolAndText = layout_->GetGenericFixedSpacerWidth();
-  const float kSpaceBetweenLegendEntries = layout_->GetGenericFixedSpacerWidth() * 2;
+  const float space_between_legend_symbol_and_text = layout_->GetGenericFixedSpacerWidth();
+  const float space_between_legend_entries = layout_->GetGenericFixedSpacerWidth() * 2;
   const float legend_symbol_height = GetLegendHeight();
   const float legend_symbol_width = legend_symbol_height;
   float x0 = GetPos()[0] + layout_->GetRightMargin();
   const float y0 =
       header_->GetPos()[1] + header_->GetHeight() + layout_->GetTrackContentTopMargin();
   uint32_t font_size = GetLegendFontSize(indentation_level_);
-  const Color kFullyTransparent(255, 255, 255, 0);
+  const Color fully_transparent(255, 255, 255, 0);
 
   float text_z = GlCanvas::kZValueTrackText;
   for (size_t i = 0; i < Dimension; ++i) {
     primitive_assembler.AddShadedBox(Vec2(x0, y0), Vec2(legend_symbol_width, legend_symbol_height),
                                      text_z, GetColor(i));
-    x0 += legend_symbol_width + kSpaceBetweenLegendSymbolAndText;
+    x0 += legend_symbol_width + space_between_legend_symbol_and_text;
 
     const float legend_text_width =
         text_renderer.GetStringWidth(series_names[i].c_str(), font_size);
@@ -254,10 +254,10 @@ void GraphTrack<Dimension>::DrawLegend(PrimitiveAssembler& primitive_assembler,
                           formatting);
     auto user_data = std::make_unique<PickingUserData>(
         nullptr, [this, i](PickingId /*id*/) { return GetLegendTooltips(i); });
-    primitive_assembler.AddShadedBox(Vec2(x0, y0), legend_text_box_size, text_z, kFullyTransparent,
+    primitive_assembler.AddShadedBox(Vec2(x0, y0), legend_text_box_size, text_z, fully_transparent,
                                      std::move(user_data));
 
-    x0 += legend_text_width + kSpaceBetweenLegendEntries;
+    x0 += legend_text_width + space_between_legend_entries;
   }
 }
 

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -304,8 +304,8 @@ void PrimitiveAssembler::AddQuadBorder(const Quad& quad, float z, const Color& c
 
 void PrimitiveAssembler::GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors,
                                               ShadingDirection shading_direction) {
-  const float gradient_coeff = 0.94f;
-  Vec3 dark = Vec3(color[0], color[1], color[2]) * gradient_coeff;
+  constexpr float kGradientCoeff = 0.94f;
+  Vec3 dark = Vec3(color[0], color[1], color[2]) * kGradientCoeff;
   Color dark_color = Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
                            static_cast<uint8_t>(dark[2]), color[3]);
 

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -304,8 +304,8 @@ void PrimitiveAssembler::AddQuadBorder(const Quad& quad, float z, const Color& c
 
 void PrimitiveAssembler::GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors,
                                               ShadingDirection shading_direction) {
-  const float kGradientCoeff = 0.94f;
-  Vec3 dark = Vec3(color[0], color[1], color[2]) * kGradientCoeff;
+  const float gradient_coeff = 0.94f;
+  Vec3 dark = Vec3(color[0], color[1], color[2]) * gradient_coeff;
   Color dark_color = Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
                            static_cast<uint8_t>(dark[2]), color[3]);
 

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -78,7 +78,7 @@ TEST(PrimitiveAssembler, BasicAdditions) {
   constexpr uint32_t kNumBoxes = 3;
 
   // Lines
-  float kLineSize = 5.;
+  constexpr float kLineSize = 5.;
   primitive_assembler_tester.AddLine(kTopLeft, kBottomLeft, 0, kFakeColor);
   primitive_assembler_tester.AddLine(kTopLeft, kBottomLeft, 0, kFakeColor, pickable);
   primitive_assembler_tester.AddVerticalLine(kTopLeft, kLineSize, 0, kFakeColor);
@@ -86,16 +86,16 @@ TEST(PrimitiveAssembler, BasicAdditions) {
   EXPECT_EQ(primitive_assembler_tester.GetNumLines(), kNumLines);
 
   // Triangles
-  Triangle kFakeTriangle{kTopLeft, kTopRight, kBottomRight};
-  primitive_assembler_tester.AddTriangle(kFakeTriangle, 0, kFakeColor);
-  primitive_assembler_tester.AddTriangle(kFakeTriangle, 0, kFakeColor, pickable);
+  const Triangle fake_triangle{kTopLeft, kTopRight, kBottomRight};
+  primitive_assembler_tester.AddTriangle(fake_triangle, 0, kFakeColor);
+  primitive_assembler_tester.AddTriangle(fake_triangle, 0, kFakeColor, pickable);
   EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), kNumTriangles);
 
   // Boxes
-  Quad kFakeBox{std::array<Vec2, 4>{kTopLeft, kTopRight, kBottomRight, kBottomLeft}};
-  primitive_assembler_tester.AddBox(kFakeBox, 0, {kFakeColor, kFakeColor, kFakeColor, kFakeColor});
-  primitive_assembler_tester.AddBox(kFakeBox, 0, kFakeColor);
-  primitive_assembler_tester.AddBox(kFakeBox, 0, kFakeColor, pickable);
+  const Quad fake_box{std::array<Vec2, 4>{kTopLeft, kTopRight, kBottomRight, kBottomLeft}};
+  primitive_assembler_tester.AddBox(fake_box, 0, {kFakeColor, kFakeColor, kFakeColor, kFakeColor});
+  primitive_assembler_tester.AddBox(fake_box, 0, kFakeColor);
+  primitive_assembler_tester.AddBox(fake_box, 0, kFakeColor, pickable);
   EXPECT_EQ(primitive_assembler_tester.GetNumBoxes(), kNumBoxes);
   EXPECT_EQ(primitive_assembler_tester.GetNumElements(), kNumLines + kNumTriangles + kNumBoxes);
   EXPECT_TRUE(primitive_assembler_tester.IsEverythingInsideRectangle(kTopLeft, kBoxSize));
@@ -135,9 +135,9 @@ TEST(PrimitiveAssembler, ComplexShapes) {
 
   // TODO(b/227744958) This should probably be removed and AddBox should be used instead
   // AddShadedTrapezium -> 2 Triangles
-  Vec2 kTopCentred = {(kTopLeft[0] + kTopRight[0]) / 2.f, kTopLeft[1]};
+  const Vec2 top_centred = {(kTopLeft[0] + kTopRight[0]) / 2.f, kTopLeft[1]};
   primitive_assembler_tester.AddShadedTrapezium(
-      Quad{{kTopLeft, kTopCentred, kBottomRight, kBottomLeft}}, 0, kFakeColor,
+      Quad{{kTopLeft, top_centred, kBottomRight, kBottomLeft}}, 0, kFakeColor,
       std::make_unique<PickingUserData>());
   EXPECT_EQ(primitive_assembler_tester.GetNumTriangles(), 2);
   EXPECT_EQ(primitive_assembler_tester.GetNumElements(), 2);

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -112,9 +112,9 @@ template <typename SliderClass, int dim>
 static void TestDragType() {
   auto [slider, viewport, tester] = Setup<SliderClass>();
 
-  const float kPos = 0.5f;
-  const float kSize = 0.5f;
-  const int kOffset = 2;
+  constexpr float kPos = 0.5f;
+  constexpr float kSize = 0.5f;
+  constexpr int kOffset = 2;
 
   int drag_count = 0;
   float pos = kPos;
@@ -189,17 +189,17 @@ static void TestScroll(float slider_length = 0.25) {
   // Use different scales for x and y to make sure dims are chosen correctly
   int scale = static_cast<int>(std::pow(10, dim));
   float pos;
-  const int kOffset = 2;
+  constexpr int kOffset = 2;
 
   slider->SetDragCallback([&](float ratio) { pos = ratio; });
   slider->SetNormalizedLength(slider_length);
 
   PickDragRelease<dim>(*slider, kOffset);
   EXPECT_LT(pos, 0.5f);
-  const float kCurPos = pos;
+  const float cur_pos = pos;
 
   PickDragRelease<dim>(*slider, 100 * scale - kOffset);
-  EXPECT_GT(pos, kCurPos);
+  EXPECT_GT(pos, cur_pos);
 }
 
 TEST(Slider, Scroll) {
@@ -265,7 +265,7 @@ static void TestScaling() {
 
   float size = 0.5f;
   float pos = 0.5f;
-  const int kOffset = 2;
+  constexpr int kOffset = 2;
 
   // Use different scales for x and y to make sure dims are chosen correctly
   int scale = static_cast<int>(std::pow(10, dim));
@@ -327,7 +327,7 @@ static void TestBreakScaling() {
 
   float pos;
   float len;
-  const int kOffset = 2;
+  constexpr int kOffset = 2;
 
   // Use different scales for x and y to make sure dims are chosen correctly
   int scale = static_cast<int>(std::pow(10, dim));
@@ -384,16 +384,16 @@ TEST(Slider, MouseMoveRequestRedraw) {
   // true. Simulate a draw loop to reinitialize the draw flags before testing their values below.
   tester.SimulateDrawLoop(slider.get(), true, true);
 
-  Vec2 kPosInSlider = slider->GetPos();
+  Vec2 pos_in_slider = slider->GetPos();
 
   // Any mouse move or mouse leave should trigger a redraw in the slider.
   EXPECT_EQ(slider->HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
+                CaptureViewElement::MouseEventType::kMouseMove, pos_in_slider}),
             CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
 
   EXPECT_EQ(slider->HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
+                CaptureViewElement::MouseEventType::kMouseMove, pos_in_slider}),
             CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
 
@@ -403,7 +403,7 @@ TEST(Slider, MouseMoveRequestRedraw) {
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
 
   EXPECT_EQ(slider->HandleMouseEvent(CaptureViewElement::MouseEvent{
-                CaptureViewElement::MouseEventType::kMouseMove, kPosInSlider}),
+                CaptureViewElement::MouseEventType::kMouseMove, pos_in_slider}),
             CaptureViewElement::EventResult::kIgnored);
   tester.SimulateDrawLoopAndCheckFlags(slider.get(), true, false);
 }

--- a/src/OrbitGl/SystemMemoryTrack.cpp
+++ b/src/OrbitGl/SystemMemoryTrack.cpp
@@ -36,16 +36,16 @@ SystemMemoryTrack::SystemMemoryTrack(CaptureViewElement* parent,
   // Colors are selected from https://convertingcolors.com/list/avery.html.
   // Use reddish colors for different used memories, yellowish colors for different cached memories
   // and greenish colors for different unused memories.
-  const std::array<Color, kSystemMemoryTrackDimension> kSystemMemoryTrackColors{
+  const std::array<Color, kSystemMemoryTrackDimension> system_memory_track_colors{
       Color(231, 68, 53, 255),  // red
       Color(246, 196, 0, 255),  // orange
       Color(87, 166, 74, 255)   // green
   };
-  SetSeriesColors(kSystemMemoryTrackColors);
+  SetSeriesColors(system_memory_track_colors);
 
-  const std::string kValueLowerBoundLabel = "Minimum: 0 GB";
+  const std::string value_lower_bound_label = "Minimum: 0 GB";
   constexpr double kValueLowerBoundRawValue = 0.0;
-  TrySetValueLowerBound(kValueLowerBoundLabel, kValueLowerBoundRawValue);
+  TrySetValueLowerBound(value_lower_bound_label, kValueLowerBoundRawValue);
 }
 
 std::string SystemMemoryTrack::GetName() const {
@@ -57,18 +57,18 @@ std::string SystemMemoryTrack::GetTooltip() const {
 }
 
 void SystemMemoryTrack::TrySetValueUpperBound(double total_mb) {
-  const std::string kValueUpperBoundLabel = "System Memory Total";
+  const std::string value_upper_bound_label = "System Memory Total";
   std::string pretty_size =
       orbit_display_formats::GetDisplaySize(static_cast<uint64_t>(total_mb * kMegabytesToBytes));
-  std::string pretty_label = absl::StrFormat("%s: %s", kValueUpperBoundLabel, pretty_size);
+  std::string pretty_label = absl::StrFormat("%s: %s", value_upper_bound_label, pretty_size);
   MemoryTrack<kSystemMemoryTrackDimension>::TrySetValueUpperBound(pretty_label, total_mb);
 }
 
 void SystemMemoryTrack::SetWarningThreshold(double warning_threshold_mb) {
-  const std::string kWarningThresholdLabel = "Production Limit";
+  const std::string warning_threshold_label = "Production Limit";
   std::string pretty_size = orbit_display_formats::GetDisplaySize(
       static_cast<uint64_t>(warning_threshold_mb * kMegabytesToBytes));
-  std::string pretty_label = absl::StrFormat("%s: %s", kWarningThresholdLabel, pretty_size);
+  std::string pretty_label = absl::StrFormat("%s: %s", warning_threshold_label, pretty_size);
   MemoryTrack<kSystemMemoryTrackDimension>::SetWarningThreshold(pretty_label, warning_threshold_mb);
 }
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -68,41 +68,41 @@ void ThreadStateBar::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
 
   // Draw a transparent track just for clicking.
   Quad box = MakeBox(GetPos(), Vec2(GetWidth(), GetHeight()));
-  static const Color kTransparent{0, 0, 0, 0};
-  primitive_assembler.AddBox(box, thread_state_bar_z, kTransparent, shared_from_this());
+  static const Color transparent{0, 0, 0, 0};
+  primitive_assembler.AddBox(box, thread_state_bar_z, transparent, shared_from_this());
 }
 
 static Color GetThreadStateColor(ThreadStateSlice::ThreadState state) {
-  static const Color kGreen500{76, 175, 80, 255};
-  static const Color kBlue500{33, 150, 243, 255};
-  static const Color kGray600{117, 117, 117, 255};
-  static const Color kOrange500{255, 152, 0, 255};
-  static const Color kRed500{244, 67, 54, 255};
-  static const Color kPurple500{156, 39, 176, 255};
-  static const Color kBlack{0, 0, 0, 255};
-  static const Color kBrown500{121, 85, 72, 255};
+  static const Color green500{76, 175, 80, 255};
+  static const Color blue500{33, 150, 243, 255};
+  static const Color gray600{117, 117, 117, 255};
+  static const Color orange500{255, 152, 0, 255};
+  static const Color red500{244, 67, 54, 255};
+  static const Color purple500{156, 39, 176, 255};
+  static const Color black{0, 0, 0, 255};
+  static const Color brown500{121, 85, 72, 255};
 
   switch (state) {
     case ThreadStateSlice::kRunning:
-      return kGreen500;
+      return green500;
     case ThreadStateSlice::kRunnable:
-      return kBlue500;
+      return blue500;
     case ThreadStateSlice::kInterruptibleSleep:
-      return kGray600;
+      return gray600;
     case ThreadStateSlice::kUninterruptibleSleep:
-      return kOrange500;
+      return orange500;
     case ThreadStateSlice::kStopped:
-      return kRed500;
+      return red500;
     case ThreadStateSlice::kTraced:
-      return kPurple500;
+      return purple500;
     case ThreadStateSlice::kDead:
       [[fallthrough]];
     case ThreadStateSlice::kZombie:
-      return kBlack;
+      return black;
     case ThreadStateSlice::kParked:
       [[fallthrough]];
     case ThreadStateSlice::kIdle:
-      return kBrown500;
+      return brown500;
     default:
       ORBIT_UNREACHABLE();
   }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -228,16 +228,16 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, const internal::Dr
 
 Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, bool is_highlighted,
                                  const internal::DrawData& /*draw_data*/) const {
-  const Color kInactiveColor(100, 100, 100, 255);
-  const Color kSelectionColor(0, 128, 255, 255);
+  const Color inactive_color(100, 100, 100, 255);
+  const Color selection_color(0, 128, 255, 255);
   if (is_highlighted) {
     return TimerTrack::kHighlightColor;
   }
   if (is_selected) {
-    return kSelectionColor;
+    return selection_color;
   }
   if (!IsTimerActive(timer_info)) {
-    return kInactiveColor;
+    return inactive_color;
   }
 
   std::optional<Color> user_color = GetUserColor(timer_info);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -395,7 +395,7 @@ void TimeGraph::ProcessPageFaultsInfo(const orbit_client_data::PageFaultsInfo& p
 orbit_gl::CaptureViewElement::EventResult TimeGraph::OnMouseWheel(
     const Vec2& mouse_pos, int delta, const orbit_gl::ModifierKeys& modifiers) {
   if (delta == 0) return EventResult::kIgnored;
-  const float kScrollingRatioPerDelta = 0.05f;
+  constexpr float kScrollingRatioPerDelta = 0.05f;
 
   if (modifiers.ctrl) {
     double mouse_ratio = (mouse_pos[0] - GetTimelinePos()[0]) / GetTimelineWidth();
@@ -868,10 +868,10 @@ void TimeGraph::DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
   // Vertical green line at mouse x position.
   if (draw_context.picking_mode == PickingMode::kNone &&
       draw_context.current_mouse_tick.has_value()) {
-    const Color kGreenLineColor{0, 255, 0, 127};
+    const Color green_line_color{0, 255, 0, 127};
     Vec2 green_line_pos = {GetWorldFromTick(draw_context.current_mouse_tick.value()), GetPos()[1]};
     primitive_assembler.AddVerticalLine(green_line_pos, GetHeight(), GlCanvas::kZValueUi,
-                                        kGreenLineColor);
+                                        green_line_color);
   }
 
   // TODO(http://b/217719000): We are drawing boxes in margin positions because some elements are

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -119,40 +119,40 @@ TEST_F(UnitTestTimeGraph, MouseWheel) {
 
   double original_time_window_us = time_graph->GetTimeWindowUs();
   const orbit_gl::TimelineUi* timeline_ui = time_graph->GetTimelineUi();
-  const Vec2 kLeftmostTimelineMousePosition = timeline_ui->GetPos();
+  const Vec2 leftmost_timeline_mouse_position = timeline_ui->GetPos();
 
   // The interactive area starts at the position of the timeline.
-  const Vec2 kInteractiveAreaPos = {timeline_ui->GetPos()[0], timeline_ui->GetPos()[1]};
+  const Vec2 interactive_area_pos = {timeline_ui->GetPos()[0], timeline_ui->GetPos()[1]};
   // That area is the size of the timeline in X and extends to the size of the timegraph in Y.
-  const Vec2 kInteractiveAreaSize = {timeline_ui->GetSize()[0], time_graph->GetSize()[1]};
+  const Vec2 interactive_area_size = {timeline_ui->GetSize()[0], time_graph->GetSize()[1]};
   // Mouse position in the center of the interactive area.
-  const Vec2 kCenteredMousePosition{kInteractiveAreaPos[0] + kInteractiveAreaSize[0] / 2.f,
-                                    kInteractiveAreaPos[1] + kInteractiveAreaSize[1] / 2.f};
+  const Vec2 centered_mouse_position{interactive_area_pos[0] + interactive_area_size[0] / 2.f,
+                                    interactive_area_pos[1] + interactive_area_size[1] / 2.f};
 
-  MouseWheelUp(kCenteredMousePosition, /*ctrl=*/false);
+  MouseWheelUp(centered_mouse_position, /*ctrl=*/false);
 
   // MouseWheel should scroll when ctrl is not pressed and therefore not modify the time_window.
   // TODO(b/233855224): Test that vertical panning works as expected.
   EXPECT_EQ(original_time_window_us, time_graph->GetTimeWindowUs());
 
-  MouseWheelUp(kCenteredMousePosition, /*ctrl=*/true);
+  MouseWheelUp(centered_mouse_position, /*ctrl=*/true);
 
   // With ctrl modifier, mouseWheel in the center should modify the time window.
   EXPECT_GT(original_time_window_us, time_graph->GetTimeWindowUs());
 
   // MouseWheelDown should revert the previous MouseWheelUp.
-  MouseWheelDown(kCenteredMousePosition, /*ctrl=*/true);
+  MouseWheelDown(centered_mouse_position, /*ctrl=*/true);
   EXPECT_DOUBLE_EQ(original_time_window_us, time_graph->GetTimeWindowUs());
 
   // In the timeline, mouseWheel should also modify the time window. In addition, if the mouse is on
   // the leftmost position, the minimum visible timestamp shouldn't change.
   double min_visible_ns = time_graph->GetMinTimeUs();
-  MouseWheelUp(kLeftmostTimelineMousePosition, /*ctrl=*/false);
+  MouseWheelUp(leftmost_timeline_mouse_position, /*ctrl=*/false);
   EXPECT_GT(original_time_window_us, time_graph->GetTimeWindowUs());
   EXPECT_EQ(min_visible_ns, time_graph->GetMinTimeUs());
 
   // Again, MouseWheelDown in the Timeline should revert the previous change.
-  MouseWheelDown(kLeftmostTimelineMousePosition, /*ctrl=*/false);
+  MouseWheelDown(leftmost_timeline_mouse_position, /*ctrl=*/false);
   EXPECT_DOUBLE_EQ(original_time_window_us, time_graph->GetTimeWindowUs());
   EXPECT_EQ(min_visible_ns, time_graph->GetMinTimeUs());
 }

--- a/src/OrbitGl/TimeGraphTest.cpp
+++ b/src/OrbitGl/TimeGraphTest.cpp
@@ -127,7 +127,7 @@ TEST_F(UnitTestTimeGraph, MouseWheel) {
   const Vec2 interactive_area_size = {timeline_ui->GetSize()[0], time_graph->GetSize()[1]};
   // Mouse position in the center of the interactive area.
   const Vec2 centered_mouse_position{interactive_area_pos[0] + interactive_area_size[0] / 2.f,
-                                    interactive_area_pos[1] + interactive_area_size[1] / 2.f};
+                                     interactive_area_pos[1] + interactive_area_size[1] / 2.f};
 
   MouseWheelUp(centered_mouse_position, /*ctrl=*/false);
 

--- a/src/OrbitGl/TimelineUiTest.cpp
+++ b/src/OrbitGl/TimelineUiTest.cpp
@@ -104,15 +104,15 @@ class TimelineUiTest : public TimelineUi {
                                                          GlCanvas::kZValueTimeBarLabel));
 
     // The label is the only thing that can be out of the expected space for the timeline.
-    const char* kOneMonthLabel = "730:00:00.000000000";
-    const float kMaxLabelWidth =
+    constexpr const char* kOneMonthLabel = "730:00:00.000000000";
+    const float max_label_width =
         mock_text_renderer_.GetStringWidth(kOneMonthLabel, layout_->GetFontSize());
-    const Vec2 kExpectedMinPos{GetPos()[0] - kMaxLabelWidth, GetPos()[1]};
-    const Vec2 kExpectedMaxPos{GetPos() + Vec2{GetSize()[0] + kMaxLabelWidth, GetSize()[1]}};
-    EXPECT_TRUE(mock_text_renderer_.IsTextInsideRectangle(kExpectedMinPos,
-                                                          kExpectedMaxPos - kExpectedMinPos));
-    EXPECT_TRUE(mock_batcher_.IsEverythingInsideRectangle(kExpectedMinPos,
-                                                          kExpectedMaxPos - kExpectedMinPos));
+    const Vec2 expected_min_pos{GetPos()[0] - max_label_width, GetPos()[1]};
+    const Vec2 expected_max_pos{GetPos() + Vec2{GetSize()[0] + max_label_width, GetSize()[1]}};
+    EXPECT_TRUE(mock_text_renderer_.IsTextInsideRectangle(expected_min_pos,
+                                                          expected_max_pos - expected_min_pos));
+    EXPECT_TRUE(mock_batcher_.IsEverythingInsideRectangle(expected_min_pos,
+                                                          expected_max_pos - expected_min_pos));
   }
 
   void TestDraw(uint64_t min_tick, uint64_t max_tick, std::optional<uint64_t> mouse_tick) {
@@ -125,11 +125,11 @@ class TimelineUiTest : public TimelineUi {
     Draw(primitive_assembler_, mock_text_renderer_, context);
 
     // One box and one label, both at kZValueTimeBarMouseLabel position.
-    const int kNumMouseLabels = mouse_tick.has_value() ? 1 : 0;
+    const int num_mouse_labels = mouse_tick.has_value() ? 1 : 0;
 
-    EXPECT_EQ(mock_batcher_.GetNumBoxes(), kNumMouseLabels);
-    EXPECT_EQ(mock_batcher_.GetNumElements(), kNumMouseLabels);
-    EXPECT_EQ(mock_text_renderer_.GetNumAddTextCalls(), kNumMouseLabels);
+    EXPECT_EQ(mock_batcher_.GetNumBoxes(), num_mouse_labels);
+    EXPECT_EQ(mock_batcher_.GetNumElements(), num_mouse_labels);
+    EXPECT_EQ(mock_text_renderer_.GetNumAddTextCalls(), num_mouse_labels);
 
     EXPECT_TRUE(mock_text_renderer_.IsTextBetweenZLayers(GlCanvas::kZValueTimeBarMouseLabel,
                                                          GlCanvas::kZValueTimeBarMouseLabel));
@@ -186,8 +186,8 @@ TEST(TimelineUi, Draw) {
   Viewport viewport(width, 0);
   TimelineUiTest timeline_ui_test(&mock_timeline_info, &viewport, &layout);
 
-  const uint64_t kMinTick = 0;
-  const uint64_t kMaxTick = 1000;
+  constexpr uint64_t kMinTick = 0;
+  constexpr uint64_t kMaxTick = 1000;
 
   // Testing different positions of the mouse in the screen. It is expected that mouse_tick is
   // between than min_tick and max_tick or either nullopt.

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -103,11 +103,11 @@ void TimerTrack::DrawTimesliceText(TextRenderer& text_renderer,
 
   const std::string elapsed_time = GetDisplayTime(timer);
   const auto elapsed_time_length = elapsed_time.length();
-  const Color kTextWhite(255, 255, 255, 255);
+  const Color text_white(255, 255, 255, 255);
   float pos_x = std::max(box_pos[0], min_x);
   float max_size = box_pos[0] + box_size[0] - pos_x;
 
-  TextRenderer::TextFormatting formatting{layout_->GetFontSize(), kTextWhite, max_size};
+  TextRenderer::TextFormatting formatting{layout_->GetFontSize(), text_white, max_size};
   formatting.valign = TextRenderer::VAlign::Bottom;
 
   text_renderer.AddTextTrailingCharsPrioritized(

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -65,9 +65,9 @@ void TracepointThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assem
   float track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const bool picking = picking_mode != PickingMode::kNone;
 
-  const Color kWhite(255, 255, 255, 255);
-  const Color kWhiteTransparent(255, 255, 255, 190);
-  const Color kGrey(128, 128, 128, 255);
+  const Color white(255, 255, 255, 255);
+  const Color white_transparent(255, 255, 255, 190);
+  const Color grey(128, 128, 128, 255);
 
   ORBIT_CHECK(capture_data_ != nullptr);
 
@@ -79,14 +79,14 @@ void TracepointThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assem
           float radius = track_height / 4;
           const Vec2 pos(timeline_info_->GetWorldFromTick(time), GetPos()[1]);
           if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
-            const Color color = tracepoint.pid() == capture_data_->process_id() ? kGrey : kWhite;
+            const Color color = tracepoint.pid() == capture_data_->process_id() ? grey : white;
             primitive_assembler.AddVerticalLine(pos, -track_height, z, color);
           } else {
-            primitive_assembler.AddVerticalLine(pos, -radius, z, kWhiteTransparent);
+            primitive_assembler.AddVerticalLine(pos, -radius, z, white_transparent);
             primitive_assembler.AddVerticalLine(Vec2(pos[0], pos[1] - track_height), radius, z,
-                                                kWhiteTransparent);
+                                                white_transparent);
             primitive_assembler.AddCircle(Vec2(pos[0], pos[1] - track_height / 2), radius, z,
-                                          kWhiteTransparent);
+                                          white_transparent);
           }
         });
 
@@ -106,7 +106,7 @@ void TracepointThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assem
                 return GetTracepointTooltip(primitive_assembler, id);
               });
           user_data->custom_data_ = &tracepoint;
-          primitive_assembler.AddShadedBox(pos, size, z, kWhite, std::move(user_data));
+          primitive_assembler.AddShadedBox(pos, size, z, white, std::move(user_data));
         });
   }
 }

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -124,12 +124,12 @@ Color Track::GetTrackBackgroundColor() const {
 
   if (GetProcessId() != orbit_base::kInvalidProcessId && GetProcessId() != capture_process_id &&
       GetType() != Type::kSchedulerTrack) {
-    const Color kExternalProcessColor(30, 30, 40, 255);
-    return kExternalProcessColor;
+    const Color external_process_color(30, 30, 40, 255);
+    return external_process_color;
   }
 
-  const Color kDarkGrey(50, 50, 50, 255);
-  return kDarkGrey;
+  const Color dark_grey(50, 50, 50, 255);
+  return dark_grey;
 }
 
 bool Track::ShouldBeRendered() const {

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -143,9 +143,9 @@ std::string GetTimeString(const TimerInfo& timer_a, const TimerInfo& timer_b) {
 
 [[nodiscard]] Color GetIteratorBoxColor(uint64_t index) {
   constexpr uint64_t kNumColors = 2;
-  const Color kLightBlueGray = Color(177, 203, 250, 60);
-  const Color kMidBlueGray = Color(81, 102, 157, 60);
-  Color colors[kNumColors] = {kLightBlueGray, kMidBlueGray};
+  const Color light_blue_gray = Color(177, 203, 250, 60);
+  const Color mid_blue_gray = Color(81, 102, 157, 60);
+  Color colors[kNumColors] = {light_blue_gray, mid_blue_gray};
   return colors[index % kNumColors];
 }
 
@@ -162,10 +162,10 @@ void TrackContainer::DrawIteratorBox(PrimitiveAssembler& primitive_assembler,
 
   float max_size = size[0];
 
-  const Color kBlack(0, 0, 0, 255);
+  const Color black(0, 0, 0, 255);
   float text_width = text_renderer.AddTextTrailingCharsPrioritized(
       text.c_str(), pos[0], text_box_y + layout_->GetTextOffset(), GlCanvas::kZValueOverlayLabel,
-      {layout_->GetFontSize(), kBlack, max_size}, time.length());
+      {layout_->GetFontSize(), black, max_size}, time.length());
 
   float box_height = layout_->GetTextBoxHeight();
   Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), box_height);
@@ -173,8 +173,8 @@ void TrackContainer::DrawIteratorBox(PrimitiveAssembler& primitive_assembler,
 
   Quad white_box = MakeBox(white_box_position, white_box_size);
 
-  const Color kWhite(255, 255, 255, 255);
-  primitive_assembler.AddBox(white_box, GlCanvas::kZValueOverlayLabel, kWhite);
+  const Color white(255, 255, 255, 255);
+  primitive_assembler.AddBox(white_box, GlCanvas::kZValueOverlayLabel, white);
 
   Vec2 line_from(pos[0] + white_box_size[0], white_box_position[1] + box_height / 2.f);
   Vec2 line_to(pos[0] + size[0], white_box_position[1] + box_height / 2.f);
@@ -275,8 +275,8 @@ void TrackContainer::DrawOverlay(PrimitiveAssembler& primitive_assembler,
 
     // We do not want the overall box to add any color, so we just set alpha to
     // 0.
-    const Color kColorBlackTransparent(0, 0, 0, 0);
-    DrawIteratorBox(primitive_assembler, text_renderer, pos, size, kColorBlackTransparent, label,
+    const Color color_black_transparent(0, 0, 0, 0);
+    DrawIteratorBox(primitive_assembler, text_renderer, pos, size, color_black_transparent, label,
                     time, text_y);
   }
 }
@@ -339,8 +339,8 @@ void TrackContainer::DrawIncompleteDataIntervals(PrimitiveAssembler& primitive_a
       });
     }
 
-    static const Color kIncompleteDataIntervalOrange{255, 128, 0, 32};
-    primitive_assembler.AddBox(MakeBox(pos, size), z_value, kIncompleteDataIntervalOrange,
+    static const Color incomplete_data_interval_orange{255, 128, 0, 32};
+    primitive_assembler.AddBox(MakeBox(pos, size), z_value, incomplete_data_interval_orange,
                                std::move(user_data));
   }
 }
@@ -435,14 +435,14 @@ void TrackContainer::DrawThreadDependencyArrow(
 void TrackContainer::DrawThreadDependency(PrimitiveAssembler& primitive_assembler,
                                           PickingMode picking_mode) {
   if (app_->selected_thread_state_slice() != std::nullopt) {
-    const Color kSelectedSliceArrowColor{255, 255, 255, 255};
+    const Color selected_slice_arrow_color{255, 255, 255, 255};
     DrawThreadDependencyArrow(primitive_assembler, app_->selected_thread_state_slice().value(),
-                              kSelectedSliceArrowColor, picking_mode);
+                              selected_slice_arrow_color, picking_mode);
   }
   if (app_->hovered_thread_state_slice() != std::nullopt) {
-    const Color kHoveredSliceArrowColor{255, 255, 255, 64};
+    const Color hovered_slice_arrow_color{255, 255, 255, 64};
     DrawThreadDependencyArrow(primitive_assembler, app_->hovered_thread_state_slice().value(),
-                              kHoveredSliceArrowColor, picking_mode);
+                              hovered_slice_arrow_color, picking_mode);
   }
 }
 

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -101,10 +101,10 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
   font_size = (font_size * (10 - capped_indentation_level)) / 10;
   float label_offset_x = layout_->GetTrackLabelOffsetX();
 
-  const Color kColor =
+  const Color color =
       track_->IsTrackSelected() ? GlCanvas::kTabTextColorSelected : Color(255, 255, 255, 255);
 
-  TextRenderer::TextFormatting formatting{font_size, kColor, label_width - label_offset_x};
+  TextRenderer::TextFormatting formatting{font_size, color, label_width - label_offset_x};
   formatting.valign = TextRenderer::VAlign::Middle;
 
   text_renderer.AddTextTrailingCharsPrioritized(

--- a/src/OrbitGl/TrackHeaderTest.cpp
+++ b/src/OrbitGl/TrackHeaderTest.cpp
@@ -44,7 +44,7 @@ TEST(TrackHeader, TrackHeaderDragsTheTrack) {
   CaptureViewElementTester tester;
 
   MockTrack track;
-  const int kDelta = 5;
+  constexpr int kDelta = 5;
 
   EXPECT_CALL(track, DragBy(kDelta)).Times(Exactly(2));
   EXPECT_CALL(track, Draggable()).Times(Exactly(2)).WillRepeatedly(Return(true));
@@ -62,7 +62,7 @@ TEST(TrackHeader, TrackHeaderDoesNotDragNonDraggableTracks) {
   CaptureViewElementTester tester;
 
   MockTrack track;
-  const int kDelta = 5;
+  constexpr int kDelta = 5;
 
   EXPECT_CALL(track, DragBy(kDelta)).Times(Exactly(0));
   EXPECT_CALL(track, Draggable()).Times(Exactly(2)).WillRepeatedly(Return(false));

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -31,15 +31,15 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
   const float z = GlCanvas::kZValueTrack;
 
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
-  const Color kWhite(255, 255, 255, 255);
-  const Color kGrey(100, 100, 100, 255);
-  Color color = is_collapsible_ ? kWhite : kGrey;
+  const Color white(255, 255, 255, 255);
+  const Color grey(100, 100, 100, 255);
+  Color color = is_collapsible_ ? white : grey;
 
   // Draw triangle.
   const Vec2 midpoint = GetPos() + Vec2(GetWidth() / 2, GetHeight() / 2);
   const float triangle_side_length = std::min(GetWidth(), GetHeight());
-  const float kCos30 = std::sqrt(3.f) / 2;
-  const float triangle_height = triangle_side_length * kCos30;
+  const float cos30 = std::sqrt(3.f) / 2;
+  const float triangle_height = triangle_side_length * cos30;
 
   const float half_triangle_height = std::ceil(triangle_height / 2);
   const float half_triangle_side_length = triangle_side_length / 2;

--- a/src/OrbitGl/include/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/include/OrbitGl/GlSlider.h
@@ -88,7 +88,7 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
     return value * LenToPixel(1.0f - length_ratio_);
   }
 
-  constexpr float kGradientFactor = 0.25f;
+  static constexpr float kGradientFactor = 0.25f;
   const bool is_vertical_;
 
   TimelineInfoInterface* timeline_info_;

--- a/src/OrbitGl/include/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/include/OrbitGl/GlSlider.h
@@ -88,7 +88,7 @@ class GlSlider : public CaptureViewElement, public std::enable_shared_from_this<
     return value * LenToPixel(1.0f - length_ratio_);
   }
 
-  static const float kGradientFactor;
+  constexpr float kGradientFactor = 0.25f;
   const bool is_vertical_;
 
   TimelineInfoInterface* timeline_info_;

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -201,15 +201,15 @@ QVariant CallTreeViewItemModel::GetForegroundRoleData(const QModelIndex& index) 
 
   if ((unwind_errors_item != nullptr || unwind_error_type_item != nullptr) &&
       index.column() == kThreadOrFunction) {
-    static const QColor kUnwindErrorsColor{QColor::fromRgb(255, 128, 0)};
-    return kUnwindErrorsColor;
+    static const QColor unwind_errors_color{QColor::fromRgb(255, 128, 0)};
+    return unwind_errors_color;
   }
 
   const auto* parent_is_unwind_error_type_item =
       dynamic_cast<const CallTreeUnwindErrorType*>(item->parent());
   if (parent_is_unwind_error_type_item != nullptr && index.column() == kThreadOrFunction) {
-    static const QColor kUnwindErrorFunctionColor{Qt::lightGray};
-    return kUnwindErrorFunctionColor;
+    static const QColor unwind_error_function_color{Qt::lightGray};
+    return unwind_error_function_color;
   }
   return {};
 }

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -671,14 +671,14 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
   bool enable_copy = ui_->callTreeTreeView->selectionModel()->hasSelection();
 
   QMenu menu{ui_->callTreeTreeView};
-  static const QString kAltClickShortcut = QStringLiteral("\tALT+Click");
+  static const QString alt_click_shortcut = QStringLiteral("\tALT+Click");
   bool is_expanded = ui_->callTreeTreeView->isExpanded(index);
   QString action_expand_recursively = (!is_expanded && enable_expand_recursively)
-                                          ? kActionExpandRecursively + kAltClickShortcut
+                                          ? kActionExpandRecursively + alt_click_shortcut
                                           : kActionExpandRecursively;
   menu.addAction(action_expand_recursively)->setEnabled(enable_expand_recursively);
   QString action_collapse_recursively = (is_expanded && enable_collapse_recursively)
-                                            ? kActionCollapseRecursively + kAltClickShortcut
+                                            ? kActionCollapseRecursively + alt_click_shortcut
                                             : kActionCollapseRecursively;
   menu.addAction(action_collapse_recursively)->setEnabled(enable_collapse_recursively);
   menu.addAction(kActionCollapseChildrenRecursively)->setEnabled(enable_collapse_recursively);
@@ -899,14 +899,14 @@ QVariant CallTreeWidget::HookedIdentityProxyModel::data(const QModelIndex& index
   }
 
   if (role == Qt::ToolTipRole) {
-    static const QString kTooltipHookedPrefix = QStringLiteral("[HOOKED] ");
-    return kTooltipHookedPrefix + data.toString();
+    static const QString tooltip_hooked_prefix = QStringLiteral("[HOOKED] ");
+    return tooltip_hooked_prefix + data.toString();
   }
-  static const QString kDisplayHookedPrefix =
+  static const QString display_hooked_prefix =
       QStringLiteral("[") +
       QString::fromStdString(orbit_data_views::FunctionsDataView::kSelectedFunctionString) +
       QStringLiteral("] ");
-  return kDisplayHookedPrefix + data.toString();
+  return display_hooked_prefix + data.toString();
 }
 
 void CallTreeWidget::ProgressBarItemDelegate::paint(QPainter* painter,

--- a/src/OrbitQt/ElidedLabel.cpp
+++ b/src/OrbitQt/ElidedLabel.cpp
@@ -14,12 +14,12 @@ void ElidedLabel::paintEvent(QPaintEvent* event) {
   QFontMetrics metrics = painter.fontMetrics();
 
   const QString content = text_;
-  QTextLayout textLayout(content, painter.font());
+  QTextLayout text_layout(content, painter.font());
 
-  textLayout.beginLayout();
+  text_layout.beginLayout();
   QString elided_text = metrics.elidedText(content, elision_mode_, width() - 10);
   painter.drawText(QPoint(0, metrics.ascent()), elided_text);
-  textLayout.endLayout();
+  text_layout.endLayout();
   QLabel::paintEvent(event);
 }
 

--- a/src/OrbitQt/TrackTypeItemModelTest.cpp
+++ b/src/OrbitQt/TrackTypeItemModelTest.cpp
@@ -71,18 +71,18 @@ TEST_F(TrackTypeItemModelTest, ReadAndWriteData) {
   EXPECT_TRUE(found_row >= 0);
   constexpr int kNameCol = static_cast<int>(TrackTypeItemModel::Column::kName);
   constexpr int kVisCol = static_cast<int>(TrackTypeItemModel::Column::kVisibility);
-  QModelIndex kNameIndex = model_.index(found_row, kNameCol);
-  QModelIndex kVisIndex = model_.index(found_row, kVisCol);
+  QModelIndex name_index = model_.index(found_row, kNameCol);
+  QModelIndex vis_index = model_.index(found_row, kVisCol);
 
   // Check the colum contents:
   // - Expect the "name" column to be non-empty
   // - Expect the "visibility" column to be checked depending on the visibility
-  EXPECT_NE("", model_.data(kNameIndex, Qt::DisplayRole).toString());
-  EXPECT_EQ(Qt::Checked, model_.data(kVisIndex, Qt::CheckStateRole).value<Qt::CheckState>());
+  EXPECT_NE("", model_.data(name_index, Qt::DisplayRole).toString());
+  EXPECT_EQ(Qt::Checked, model_.data(vis_index, Qt::CheckStateRole).value<Qt::CheckState>());
 
   // When track visibility changes, the check state changes as well
   track_manager_.SetTrackTypeVisibility(Track::Type::kThreadTrack, false);
-  EXPECT_EQ(Qt::Unchecked, model_.data(kVisIndex, Qt::CheckStateRole).value<Qt::CheckState>());
+  EXPECT_EQ(Qt::Unchecked, model_.data(vis_index, Qt::CheckStateRole).value<Qt::CheckState>());
 }
 
 TEST_F(TrackTypeItemModelTest, ViewInteraction) {

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1718,10 +1718,10 @@ void OrbitMainWindow::SetTarget(const orbit_session_setup::FileTarget& target) {
 }
 
 void OrbitMainWindow::UpdateTargetLabelPosition() {
-  const int kMenuWidth = 300;
-  const int kMaxLabelWidth = width() - kMenuWidth;
+  constexpr int kMenuWidth = 300;
+  const int max_label_width = width() - kMenuWidth;
 
-  target_widget_->setMaximumWidth(kMaxLabelWidth);
+  target_widget_->setMaximumWidth(max_label_width);
   target_widget_->adjustSize();
 
   int target_widget_width = target_widget_->width();

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -75,38 +75,38 @@ void OrbitSamplingReport::Initialize(orbit_data_views::DataView* callstack_data_
     tab->setObjectName(QStringLiteral("samplingReportThreadTab"));
     tab->setAccessibleName(QStringLiteral("SamplingReportThreadTab"));
 
-    auto* gridLayout_2 = new QGridLayout(tab);
-    gridLayout_2->setObjectName(QStringLiteral("gridLayout_2"));
-    auto* treeView = new OrbitDataViewPanel(tab);
-    treeView->SetDataModel(&report_data_view);
+    auto* grid_layout_2 = new QGridLayout(tab);
+    grid_layout_2->setObjectName(QStringLiteral("gridLayout_2"));
+    auto* tree_view = new OrbitDataViewPanel(tab);
+    tree_view->SetDataModel(&report_data_view);
 
     if (!report_data_view.IsSortingAllowed()) {
-      treeView->GetTreeView()->setSortingEnabled(false);
+      tree_view->GetTreeView()->setSortingEnabled(false);
     } else {
       int column = report_data_view.GetDefaultSortingColumn();
       Qt::SortOrder order = report_data_view.GetColumns()[column].initial_order ==
                                     orbit_data_views::DataView::SortingOrder::kAscending
                                 ? Qt::AscendingOrder
                                 : Qt::DescendingOrder;
-      treeView->GetTreeView()->sortByColumn(column, order);
+      tree_view->GetTreeView()->sortByColumn(column, order);
     }
 
-    treeView->setObjectName(QStringLiteral("samplingReportDataView"));
-    treeView->setAccessibleName(QStringLiteral("SamplingReportDataView"));
-    gridLayout_2->addWidget(treeView, 0, 0, 1, 1);
-    treeView->Initialize(&report_data_view, SelectionType::kExtended, FontType::kDefault);
+    tree_view->setObjectName(QStringLiteral("samplingReportDataView"));
+    tree_view->setAccessibleName(QStringLiteral("SamplingReportDataView"));
+    grid_layout_2->addWidget(tree_view, 0, 0, 1, 1);
+    tree_view->Initialize(&report_data_view, SelectionType::kExtended, FontType::kDefault);
     {
       ORBIT_SCOPE("resizeSections");
-      treeView->GetTreeView()->header()->resizeSections(QHeaderView::ResizeToContents);
+      tree_view->GetTreeView()->header()->resizeSections(QHeaderView::ResizeToContents);
     }
-    treeView->GetTreeView()->SetIsMultiSelection(true);
+    tree_view->GetTreeView()->SetIsMultiSelection(true);
 
-    treeView->Link(ui_->CallstackTreeView);
+    tree_view->Link(ui_->CallstackTreeView);
 
     // This is hack - it is needed to update ui when data changes
     // TODO: Remove this once model is implemented properly and there
     //  is no need for manual updates.
-    orbit_data_views_.push_back(treeView);
+    orbit_data_views_.push_back(tree_view);
 
     uint32_t thread_id = report_data_view.GetThreadID();
     // Report any thread that contains more than 5% unwinding errors.
@@ -122,7 +122,7 @@ void OrbitSamplingReport::Initialize(orbit_data_views::DataView* callstack_data_
       notice_box->Initialize(label, "Hide", kRed);
       QObject::connect(notice_box, &orbit_util_widgets::NoticeWidget::ButtonClicked, notice_box,
                        [notice_box]() { notice_box->hide(); });
-      gridLayout_2->addWidget(notice_box, 1, 0);
+      grid_layout_2->addWidget(notice_box, 1, 0);
     }
 
     ui_->tabWidget->addTab(tab, QString::fromStdString(report_data_view.GetName()));

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -356,7 +356,7 @@ void OrbitTreeView::OnRefreshButtonClicked() {
   }
 }
 
-void OrbitTreeView::columnResized(int column, int /*oldSize*/, int newSize) {
+void OrbitTreeView::columnResized(int column, int /*oldSize*/, int new_size) {
   // We'd need to run this only when a column is being resized directly, not when the entire table
   // is being resized and in turn triggers column resize events, otherwise the ratios can be set
   // to 0 when shrinking the table width to 0 which we can't recover from. For this reason,
@@ -365,6 +365,6 @@ void OrbitTreeView::columnResized(int column, int /*oldSize*/, int newSize) {
   // resizing.
   if (maintain_user_column_ratios_ && (column_ratios_.size() != 0u)) {
     ORBIT_CHECK(column < static_cast<int>(column_ratios_.size()));
-    column_ratios_[column] = static_cast<float>(newSize) / size().width();
+    column_ratios_[column] = static_cast<float>(new_size) / size().width();
   }
 }

--- a/src/OrbitSshQt/Task.cpp
+++ b/src/OrbitSshQt/Task.cpp
@@ -68,7 +68,7 @@ outcome::result<void> Task::run() {
     // read stdout
     bool added_new_data_to_read_buffer = false;
     while (true) {
-      const size_t kChunkSize = 8192;
+      constexpr size_t kChunkSize = 8192;
       auto result = channel_->ReadStdOut(kChunkSize);
 
       if (!result && !orbit_ssh::ShouldITryAgain(result)) {
@@ -97,7 +97,7 @@ outcome::result<void> Task::run() {
     // read stderr
     added_new_data_to_read_buffer = false;
     while (true) {
-      const size_t kChunkSize = 8192;
+      constexpr size_t kChunkSize = 8192;
       auto result = channel_->ReadStdErr(kChunkSize);
 
       if (!result && !orbit_ssh::ShouldITryAgain(result)) {

--- a/src/OrbitSshQt/Tunnel.cpp
+++ b/src/OrbitSshQt/Tunnel.cpp
@@ -186,7 +186,7 @@ outcome::result<void> Tunnel::shutdown() {
 outcome::result<void> Tunnel::readFromChannel() {
   ORBIT_SCOPE_FUNCTION;
   while (true) {
-    const size_t kChunkSize = 1024 * 1024;
+    constexpr size_t kChunkSize = 1024 * 1024;
     const auto result = channel_->ReadStdOut(kChunkSize);
 
     if (!result && !orbit_ssh::ShouldITryAgain(result)) {

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -32,8 +32,8 @@ OrbitTestImpl::OrbitTestImpl(uint32_t num_threads, uint32_t recurse_depth, uint3
 }
 
 void OrbitTestImpl::Init() {
-  const size_t kMinNumWorkers = 10;
-  const size_t kMaxNumWorkers = 100;
+  constexpr size_t kMinNumWorkers = 10;
+  constexpr size_t kMaxNumWorkers = 100;
   thread_pool_ =
       orbit_base::ThreadPool::Create(kMinNumWorkers, kMaxNumWorkers, absl::Milliseconds(500));
 }

--- a/src/OrbitVulkanLayer/EntryPoints.cpp
+++ b/src/OrbitVulkanLayer/EntryPoints.cpp
@@ -120,8 +120,8 @@ VKAPI_ATTR VkResult VKAPI_CALL OrbitResetCommandBuffer(VkCommandBuffer command_b
 }
 
 VKAPI_ATTR void VKAPI_CALL OrbitGetDeviceQueue(VkDevice device, uint32_t queue_family_index,
-                                               uint32_t queue_index, VkQueue* pQueue) {
-  controller.OnGetDeviceQueue(device, queue_family_index, queue_index, pQueue);
+                                               uint32_t queue_index, VkQueue* p_queue) {
+  controller.OnGetDeviceQueue(device, queue_family_index, queue_index, p_queue);
 }
 
 VKAPI_ATTR void VKAPI_CALL OrbitGetDeviceQueue2(VkDevice device,

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -1044,10 +1044,10 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmis
       };
 
   const char* text = "Text";
-  constexpr uint64_t expected_text_key = 111;
+  constexpr uint64_t kExpectedTextKey = 111;
   auto mock_intern_string_if_necessary_and_get_key = [&text](const std::string& str) {
     EXPECT_STREQ(text, str.c_str());
-    return expected_text_key;
+    return kExpectedTextKey;
   };
   EXPECT_CALL(*producer_, InternStringIfNecessaryAndGetKey)
       .Times(1)
@@ -1083,7 +1083,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmis
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission.completed_markers(0);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp3, expected_text_key, expected_color, 0);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp3, kExpectedTextKey, expected_color, 0);
   ExpectDebugMarkerBeginEq(actual_debug_marker, kTimestamp2, pre_submit_time, post_submit_time, tid,
                            pid);
 }
@@ -1104,10 +1104,10 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenBeginNotCaptured)
       };
 
   const char* text = "Text";
-  constexpr uint64_t expected_text_key = 111;
+  constexpr uint64_t kExpectedTextKey = 111;
   auto mock_intern_string_if_necessary_and_get_key = [&text](const std::string& str) {
     EXPECT_STREQ(text, str.c_str());
-    return expected_text_key;
+    return kExpectedTextKey;
   };
   EXPECT_CALL(*producer_, InternStringIfNecessaryAndGetKey)
       .Times(1)
@@ -1138,7 +1138,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenBeginNotCaptured)
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission.completed_markers(0);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp1, expected_text_key, expected_color, 0);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp1, kExpectedTextKey, expected_color, 0);
   EXPECT_FALSE(actual_debug_marker.has_begin_marker());
 }
 
@@ -1159,15 +1159,15 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNestedDebugMarkerTimestampsForAComplete
 
   const std::string text_outer = "Outer";
   const std::string text_inner = "Inner";
-  constexpr uint64_t expected_text_key_outer = 111;
-  constexpr uint64_t expected_text_key_inner = 112;
+  constexpr uint64_t kExpectedTextKeyOuter = 111;
+  constexpr uint64_t kExpectedTextKeyInner = 112;
   auto mock_intern_string_if_necessary_and_get_key = [&text_outer,
                                                       &text_inner](const std::string& str) {
     if (str == text_outer) {
-      return expected_text_key_outer;
+      return kExpectedTextKeyOuter;
     }
     if (str == text_inner) {
-      return expected_text_key_inner;
+      return kExpectedTextKeyInner;
     }
     ORBIT_UNREACHABLE();
   };
@@ -1210,12 +1210,12 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNestedDebugMarkerTimestampsForAComplete
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
       actual_queue_submission.completed_markers(1);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp5, expected_text_key_outer,
+  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp5, kExpectedTextKeyOuter,
                          expected_color, 0);
   ExpectDebugMarkerBeginEq(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
                            post_submit_time, tid, pid);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker_inner, kTimestamp4, expected_text_key_inner,
+  ExpectDebugMarkerEndEq(actual_debug_marker_inner, kTimestamp4, kExpectedTextKeyInner,
                          expected_color, 1);
   ExpectDebugMarkerBeginEq(actual_debug_marker_inner, kTimestamp3, pre_submit_time,
                            post_submit_time, tid, pid);
@@ -1239,15 +1239,15 @@ TEST_F(SubmissionTrackerTest,
 
   const std::string text_outer = "Outer";
   const std::string text_inner = "Inner";
-  constexpr uint64_t expected_text_key_outer = 111;
-  constexpr uint64_t expected_text_key_inner = 112;
+  constexpr uint64_t kExpectedTextKeyOuter = 111;
+  constexpr uint64_t kExpectedTextKeyInner = 112;
   auto mock_intern_string_if_necessary_and_get_key = [&text_outer,
                                                       &text_inner](const std::string& str) {
     if (str == text_outer) {
-      return expected_text_key_outer;
+      return kExpectedTextKeyOuter;
     }
     if (str == text_inner) {
-      return expected_text_key_inner;
+      return kExpectedTextKeyInner;
     }
     ORBIT_UNREACHABLE();
   };
@@ -1289,11 +1289,11 @@ TEST_F(SubmissionTrackerTest,
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
       actual_queue_submission.completed_markers(1);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp3, expected_text_key_outer,
+  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp3, kExpectedTextKeyOuter,
                          expected_color, 0);
   EXPECT_FALSE(actual_debug_marker_outer.has_begin_marker());
 
-  ExpectDebugMarkerEndEq(actual_debug_marker_inner, kTimestamp2, expected_text_key_inner,
+  ExpectDebugMarkerEndEq(actual_debug_marker_inner, kTimestamp2, kExpectedTextKeyInner,
                          expected_color, 1);
   ExpectDebugMarkerBeginEq(actual_debug_marker_inner, kTimestamp1, pre_submit_time,
                            post_submit_time, tid, pid);
@@ -1323,10 +1323,10 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
       };
 
   const char* text = "Text";
-  constexpr uint64_t expected_text_key = 111;
+  constexpr uint64_t kExpectedTextKey = 111;
   auto mock_intern_string_if_necessary_and_get_key = [&text](const std::string& str) {
     EXPECT_STREQ(text, str.c_str());
-    return expected_text_key;
+    return kExpectedTextKey;
   };
   EXPECT_CALL(*producer_, InternStringIfNecessaryAndGetKey)
       .Times(1)
@@ -1388,7 +1388,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission_2.completed_markers(0);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp5, expected_text_key, expected_color, 0);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp5, kExpectedTextKey, expected_color, 0);
   ExpectDebugMarkerBeginEq(actual_debug_marker, kTimestamp2, pre_submit_time_1, post_submit_time_1,
                            tid, pid);
 }
@@ -1418,10 +1418,10 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhen
       };
 
   const char* text = "Text";
-  constexpr uint64_t expected_text_key = 111;
+  constexpr uint64_t kExpectedTextKey = 111;
   auto mock_intern_string_if_necessary_and_get_key = [&text](const std::string& str) {
     EXPECT_STREQ(text, str.c_str());
-    return expected_text_key;
+    return kExpectedTextKey;
   };
   EXPECT_CALL(*producer_, InternStringIfNecessaryAndGetKey)
       .Times(1)
@@ -1477,7 +1477,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhen
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission_2.completed_markers(0);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp3, expected_text_key, expected_color, 0);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp3, kExpectedTextKey, expected_color, 0);
   EXPECT_FALSE(actual_debug_marker.has_begin_marker());
 }
 
@@ -1591,10 +1591,10 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBuffer) {
 
   const std::string text_outer = "Outer";
   const std::string text_inner = "Inner";
-  constexpr uint64_t expected_text_key_outer = 111;
+  constexpr uint64_t kExpectedTextKeyOuter = 111;
   auto mock_intern_string_if_necessary_and_get_key = [&text_outer](const std::string& str) {
     if (str == text_outer) {
-      return expected_text_key_outer;
+      return kExpectedTextKeyOuter;
     }
     ORBIT_UNREACHABLE();
   };
@@ -1635,7 +1635,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBuffer) {
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
       actual_queue_submission.completed_markers(0);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp3, expected_text_key_outer,
+  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp3, kExpectedTextKeyOuter,
                          expected_color, 0);
   ExpectDebugMarkerBeginEq(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
                            post_submit_time, tid, pid);
@@ -1675,10 +1675,10 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
 
   const std::string text_outer = "Outer";
   const std::string text_inner = "Inner";
-  constexpr uint64_t expected_outer_text_key = 111;
+  constexpr uint64_t kExpectedOuterTextKey = 111;
   auto mock_intern_string_if_necessary_and_get_key = [&text_outer](const std::string& str) {
     EXPECT_EQ(text_outer, str);
-    return expected_outer_text_key;
+    return kExpectedOuterTextKey;
   };
   EXPECT_CALL(*producer_, InternStringIfNecessaryAndGetKey)
       .Times(1)
@@ -1744,7 +1744,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission_2.completed_markers(0);
 
-  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp6, expected_outer_text_key, expected_color,
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp6, kExpectedOuterTextKey, expected_color,
                          0);
   ExpectDebugMarkerBeginEq(actual_debug_marker, kTimestamp2, pre_submit_time_1, post_submit_time_1,
                            tid, pid);

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -567,15 +567,15 @@ TEST_F(VulkanLayerControllerTest, WillDumpPidOnCreateInstance) {
                                    .ppEnabledExtensionNames = nullptr};
 
   VkInstance created_instance;
-  constexpr const char* filename = "pid.txt";
-  setenv("ORBIT_VULKAN_LAYER_PID_FILE", filename, /*overwrite*/ 1);
+  constexpr const char* kFilename = "pid.txt";
+  setenv("ORBIT_VULKAN_LAYER_PID_FILE", kFilename, /*overwrite*/ 1);
   VkResult result = controller->OnCreateInstance(&create_info, nullptr, &created_instance);
   uint32_t pid = orbit_base::GetCurrentProcessId();
-  ErrorMessageOr<std::string> pid_or_error = orbit_base::ReadFileToString(filename);
+  ErrorMessageOr<std::string> pid_or_error = orbit_base::ReadFileToString(kFilename);
   EXPECT_FALSE(pid_or_error.has_error());
   EXPECT_EQ(pid_or_error.value(), absl::StrFormat("%u", pid));
   EXPECT_EQ(result, VK_SUCCESS);
-  ErrorMessageOr<bool> removed_or_error = orbit_base::RemoveFile(filename);
+  ErrorMessageOr<bool> removed_or_error = orbit_base::RemoveFile(kFilename);
   EXPECT_FALSE(removed_or_error.has_error());
 }
 
@@ -620,8 +620,8 @@ TEST_F(VulkanLayerControllerTest, DumpProcessIdFailsOnCreateInstanceByNonExisten
                                    .ppEnabledExtensionNames = nullptr};
 
   VkInstance created_instance;
-  constexpr const char* filename = "i_dont_exists_dir/pid.txt";
-  setenv("ORBIT_VULKAN_LAYER_PID_FILE", filename, /*overwrite*/ 1);
+  constexpr const char* kFilename = "i_dont_exists_dir/pid.txt";
+  setenv("ORBIT_VULKAN_LAYER_PID_FILE", kFilename, /*overwrite*/ 1);
   [[maybe_unused]] VkResult result = VK_SUCCESS;
   EXPECT_DEATH(result = controller->OnCreateInstance(&create_info, nullptr, &created_instance),
                "Opening \"i_dont_exists_dir/pid.txt\": Unable to open file "
@@ -669,8 +669,8 @@ TEST_F(VulkanLayerControllerTest, DumpProcessIdFailsOnCreateInstanceByInvalidFil
                                    .ppEnabledExtensionNames = nullptr};
 
   VkInstance created_instance;
-  constexpr const char* filename = "tmpdir/";
-  setenv("ORBIT_VULKAN_LAYER_PID_FILE", filename, /*overwrite*/ 1);
+  constexpr const char* kFilename = "tmpdir/";
+  setenv("ORBIT_VULKAN_LAYER_PID_FILE", kFilename, /*overwrite*/ 1);
   [[maybe_unused]] VkResult result = VK_SUCCESS;
   EXPECT_DEATH(result = controller->OnCreateInstance(&create_info, nullptr, &created_instance),
                "Opening \"tmpdir/\": Unable to open file \"tmpdir/\": Is a directory");

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderIntegrationTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderIntegrationTest.cpp
@@ -43,13 +43,13 @@ TEST(MicrosoftSymbolServerSymbolProviderIntegrationTest, RetrieveWindowsPdbAndLo
   ASSERT_THAT(temporary_file_or_error, HasNoError());
   orbit_test_utils::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
   ASSERT_TRUE(temporary_file.file_path().has_parent_path());
-  const std::filesystem::path kSymbolCacheDir = temporary_file.file_path().parent_path();
+  const std::filesystem::path symbol_cache_dir = temporary_file.file_path().parent_path();
 
   orbit_symbols::MockSymbolCache symbol_cache;
   EXPECT_CALL(symbol_cache, GenerateCachedFilePath)
-      .WillRepeatedly([&kSymbolCacheDir](const std::filesystem::path& module_file_path) {
+      .WillRepeatedly([&symbol_cache_dir](const std::filesystem::path& module_file_path) {
         auto file_name = absl::StrReplaceAll(module_file_path.string(), {{"/", "_"}});
-        return kSymbolCacheDir / file_name;
+        return symbol_cache_dir / file_name;
       });
 
   orbit_http::HttpDownloadManager download_manager{};
@@ -58,13 +58,13 @@ TEST(MicrosoftSymbolServerSymbolProviderIntegrationTest, RetrieveWindowsPdbAndLo
   std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor{
       orbit_qt_utils::MainThreadExecutorImpl::Create()};
 
-  const std::string kValidModuleName{"d3d11.pdb"};
-  const std::string kValidModuleBuildId{"FF5440275BFED43A86CC2B1F287A72151"};
-  orbit_symbol_provider::ModuleIdentifier kValidModuleId{kValidModuleName, kValidModuleBuildId};
+  const std::string valid_module_name{"d3d11.pdb"};
+  const std::string valid_module_build_id{"FF5440275BFED43A86CC2B1F287A72151"};
+  orbit_symbol_provider::ModuleIdentifier valid_module_id{valid_module_name, valid_module_build_id};
 
   orbit_base::StopSource stop_source{};
 
-  symbol_provider.RetrieveSymbols(kValidModuleId, stop_source.GetStopToken())
+  symbol_provider.RetrieveSymbols(valid_module_id, stop_source.GetStopToken())
       .Then(executor.get(), [](const orbit_symbol_provider::SymbolLoadingOutcome& result) {
         ASSERT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
         orbit_symbol_provider::SymbolLoadingSuccessResult success_result =

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -49,21 +49,21 @@ QPixmap ColorizeIcon(const QPixmap& pixmap, const QColor& color) {
 }
 
 QPixmap GetGreenConnectedIcon() {
-  const static QPixmap kGreenConnectedIcon =
+  const static QPixmap green_connected_icon =
       ColorizeIcon(QPixmap{":/actions/connected"}, kGreenColor);
-  return kGreenConnectedIcon;
+  return green_connected_icon;
 }
 
 QPixmap GetOrangeDisconnectedIcon() {
-  const static QPixmap kOrangeDisconnectedIcon =
+  const static QPixmap orange_disconnected_icon =
       ColorizeIcon(QPixmap{":/actions/alert"}, kOrangeColor);
-  return kOrangeDisconnectedIcon;
+  return orange_disconnected_icon;
 }
 
 QPixmap GetRedDisconnectedIcon() {
-  const static QPixmap kRedDisconnectedIcon =
+  const static QPixmap red_disconnected_icon =
       ColorizeIcon(QPixmap{":/actions/disconnected"}, kRedColor);
-  return kRedDisconnectedIcon;
+  return red_disconnected_icon;
 }
 
 }  // namespace

--- a/src/Style/Style.cpp
+++ b/src/Style/Style.cpp
@@ -14,38 +14,38 @@ namespace orbit_style {
 void ApplyStyle(QApplication* app) {
   QApplication::setStyle(QStyleFactory::create("Fusion"));
 
-  QPalette darkPalette;
-  darkPalette.setColor(QPalette::Window, QColor(53, 53, 53));
-  darkPalette.setColor(QPalette::WindowText, Qt::white);
-  darkPalette.setColor(QPalette::Base, QColor(25, 25, 25));
-  darkPalette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
-  darkPalette.setColor(QPalette::ToolTipBase, Qt::white);
-  darkPalette.setColor(QPalette::ToolTipText, Qt::white);
-  darkPalette.setColor(QPalette::Text, Qt::white);
-  darkPalette.setColor(QPalette::Button, QColor(53, 53, 53));
-  darkPalette.setColor(QPalette::ButtonText, Qt::white);
-  darkPalette.setColor(QPalette::BrightText, Qt::red);
-  darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
-  darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
-  darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+  QPalette dark_palette;
+  dark_palette.setColor(QPalette::Window, QColor(53, 53, 53));
+  dark_palette.setColor(QPalette::WindowText, Qt::white);
+  dark_palette.setColor(QPalette::Base, QColor(25, 25, 25));
+  dark_palette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
+  dark_palette.setColor(QPalette::ToolTipBase, Qt::white);
+  dark_palette.setColor(QPalette::ToolTipText, Qt::white);
+  dark_palette.setColor(QPalette::Text, Qt::white);
+  dark_palette.setColor(QPalette::Button, QColor(53, 53, 53));
+  dark_palette.setColor(QPalette::ButtonText, Qt::white);
+  dark_palette.setColor(QPalette::BrightText, Qt::red);
+  dark_palette.setColor(QPalette::Link, QColor(42, 130, 218));
+  dark_palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+  dark_palette.setColor(QPalette::HighlightedText, Qt::black);
 
   QColor light_gray{160, 160, 160};
   QColor dark_gray{90, 90, 90};
   QColor darker_gray{80, 80, 80};
-  darkPalette.setColor(QPalette::Disabled, QPalette::Window, dark_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, light_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::Base, darker_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::AlternateBase, dark_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::ToolTipBase, dark_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::ToolTipText, light_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::Text, light_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::Button, darker_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, light_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::BrightText, light_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::Link, light_gray);
-  darkPalette.setColor(QPalette::Disabled, QPalette::Highlight, dark_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::Window, dark_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::WindowText, light_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::Base, darker_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::AlternateBase, dark_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::ToolTipBase, dark_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::ToolTipText, light_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::Text, light_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::Button, darker_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::ButtonText, light_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::BrightText, light_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::Link, light_gray);
+  dark_palette.setColor(QPalette::Disabled, QPalette::Highlight, dark_gray);
 
-  QApplication::setPalette(darkPalette);
+  QApplication::setPalette(dark_palette);
   app->setStyleSheet(
       "QToolTip { color: #ffffff; background-color: #2a82da; border: 1px "
       "solid white; }"

--- a/src/TracepointService/ReadTracepointsTest.cpp
+++ b/src/TracepointService/ReadTracepointsTest.cpp
@@ -38,18 +38,18 @@ TEST(ServiceUtils, CategoriesTracepoints) {
                  [](const TracepointInfo& value) { return value.category(); });
 
   ASSERT_FALSE(categories.empty());
-  static const std::array<std::string, 10> kCategoriesAvailable = {
+  static const std::array<std::string, 10> categories_available = {
       "sched",    "task",    "module",       "signal",     "sock",
       "syscalls", "migrate", "raw_syscalls", "exceptions", "iomap"};
 
-  static const std::array<std::string, 3> kCategoriesUnavailable = {"orbit", "profiler",
+  static const std::array<std::string, 3> categories_unavailable = {"orbit", "profiler",
                                                                     "instrumentation"};
 
-  for (const std::string& category_available : kCategoriesAvailable) {
+  for (const std::string& category_available : categories_available) {
     ASSERT_TRUE(find(categories.begin(), categories.end(), category_available) != categories.end());
   }
 
-  for (const std::string& category_unavailable : kCategoriesUnavailable) {
+  for (const std::string& category_unavailable : categories_unavailable) {
     ASSERT_TRUE(find(categories.begin(), categories.end(), category_unavailable) ==
                 categories.end());
   }
@@ -69,18 +69,18 @@ TEST(ServiceUtils, NamesTracepoints) {
                  [](const TracepointInfo& value) { return value.name(); });
 
   ASSERT_FALSE(names.empty());
-  static const std::array<std::string, 10> kNamesAvailable = {
+  static const std::array<std::string, 10> names_available = {
       "sched_switch", "sched_wakeup",    "sched_process_fork", "sched_waking", "task_rename",
       "task_newtask", "signal_generate", "signal_deliver",     "timer_init",   "timer_start"};
 
-  static const std::array<std::string, 5> kNamesUnavailable = {
+  static const std::array<std::string, 5> names_unavailable = {
       "orbit", "profiler", "instrumentation", "enable", "filter"};
 
-  for (const std::string& name_available : kNamesAvailable) {
+  for (const std::string& name_available : names_available) {
     ASSERT_TRUE(find(names.begin(), names.end(), name_available) != names.end());
   }
 
-  for (const std::string& name_unavailable : kNamesUnavailable) {
+  for (const std::string& name_unavailable : names_unavailable) {
     ASSERT_TRUE(find(names.begin(), names.end(), name_unavailable) == names.end());
   }
 }

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -216,8 +216,8 @@ TEST(InjectLibraryInTraceeTest, NonExistingLibrary) {
   const std::vector<orbit_grpc_protos::ModuleInfo>& modules = modules_or_error.value();
 
   // Try to load non existing dynamic lib into tracee.
-  const std::string kNonExistingLibName = "libNotFound.so";
-  auto library_handle_or_error = DlmopenInTracee(pid, modules, kNonExistingLibName, RTLD_NOW,
+  const std::string non_existing_lib_name = "libNotFound.so";
+  auto library_handle_or_error = DlmopenInTracee(pid, modules, non_existing_lib_name, RTLD_NOW,
                                                  LinkerNamespace::kCreateNewNamespace);
   ASSERT_THAT(library_handle_or_error, HasError("Library does not exist at"));
 

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -211,7 +211,7 @@ ErrorMessageOr<std::vector<pid_t>> GetNewOrbitThreads(
   // happened in the real target processes.
   // We choose a three second (300 x 10 ms) timeout and query the existing threads every 10 ms.
   constexpr int kNumberOfRetries = 300;
-  std::chrono::milliseconds waiting_period{10};
+  constexpr std::chrono::milliseconds kWaitingPeriod{10};
   std::vector<pid_t> orbit_threads;
   std::multiset<std::string> orbit_threads_names;
   int count = 0;
@@ -220,7 +220,7 @@ ErrorMessageOr<std::vector<pid_t>> GetNewOrbitThreads(
       return ErrorMessage(
           "Unable to find threads spawned by library injected for user space instrumentation.");
     }
-    std::this_thread::sleep_for(waiting_period);
+    std::this_thread::sleep_for(kWaitingPeriod);
     orbit_threads.clear();
     orbit_threads_names.clear();
     const auto tids = orbit_base::GetTidsOfProcess(pid);

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -103,7 +103,7 @@ ErrorMessageOr<bool> AlreadyInjected(absl::Span<const ModuleInfo> modules) {
 // a situation where instrumenting the functions below would lead to a recursive call into the
 // instrumentation. We just skip these and leave instrumenting them to the kernel/uprobe fallback.
 bool IsBlocklisted(std::string_view function_name) {
-  static const absl::flat_hash_set<std::string> kBlocklist{
+  static const absl::flat_hash_set<std::string> blocklist{
       "__GI___libc_malloc",
       "__GI___libc_free",
       "get_free_list",
@@ -131,7 +131,7 @@ bool IsBlocklisted(std::string_view function_name) {
       // instruction.
       "__GI_memcpy",
   };
-  return kBlocklist.contains(function_name);
+  return blocklist.contains(function_name);
 }
 
 // MachineCodeForCloneCall creates the code to spawn a new thread inside the target process by using
@@ -196,9 +196,9 @@ ErrorMessageOr<void> WaitForThreadToExit(pid_t pid, pid_t tid) {
 // These are the names of the threads that will be spawned when
 // liborbituserspaceinstrumentation.so is injected into the target process.
 std::multiset<std::string> GetExpectedOrbitThreadNames() {
-  static const std::multiset<std::string> kThreadNames{
+  static const std::multiset<std::string> thread_names{
       "default-executo", "resolver-execut", "grpc_global_tim", "ConnectRcvCmds", "ForwarderThread"};
-  return kThreadNames;
+  return thread_names;
 }
 
 ErrorMessageOr<std::vector<pid_t>> GetNewOrbitThreads(
@@ -211,7 +211,7 @@ ErrorMessageOr<std::vector<pid_t>> GetNewOrbitThreads(
   // happened in the real target processes.
   // We choose a three second (300 x 10 ms) timeout and query the existing threads every 10 ms.
   constexpr int kNumberOfRetries = 300;
-  std::chrono::milliseconds kWaitingPeriod{10};
+  std::chrono::milliseconds waiting_period{10};
   std::vector<pid_t> orbit_threads;
   std::multiset<std::string> orbit_threads_names;
   int count = 0;
@@ -220,7 +220,7 @@ ErrorMessageOr<std::vector<pid_t>> GetNewOrbitThreads(
       return ErrorMessage(
           "Unable to find threads spawned by library injected for user space instrumentation.");
     }
-    std::this_thread::sleep_for(kWaitingPeriod);
+    std::this_thread::sleep_for(waiting_period);
     orbit_threads.clear();
     orbit_threads_names.clear();
     const auto tids = orbit_base::GetTidsOfProcess(pid);

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -119,7 +119,7 @@ class LockFreeUserSpaceInstrumentationEventProducer
 
  private:
   template <class>
-  [[maybe_unused]] static constexpr bool always_false_v = false;
+  [[maybe_unused]] static constexpr bool kAlwaysFalseV = false;
 };
 
 LockFreeUserSpaceInstrumentationEventProducer& GetCaptureEventProducer() {

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -86,47 +86,47 @@ TEST(TrampolineTest, DoAddressRangesOverlap) {
 }
 
 TEST(TrampolineTest, LowestIntersectingAddressRange) {
-  const std::vector<AddressRange> kAllRanges = {{0, 5}, {20, 30}, {40, 60}};
+  const std::vector<AddressRange> all_ranges = {{0, 5}, {20, 30}, {40, 60}};
 
   EXPECT_FALSE(LowestIntersectingAddressRange({}, {0, 60}).has_value());
 
-  EXPECT_EQ(0, LowestIntersectingAddressRange(kAllRanges, {1, 2}));
-  EXPECT_EQ(1, LowestIntersectingAddressRange(kAllRanges, {21, 22}));
-  EXPECT_EQ(2, LowestIntersectingAddressRange(kAllRanges, {51, 52}));
+  EXPECT_EQ(0, LowestIntersectingAddressRange(all_ranges, {1, 2}));
+  EXPECT_EQ(1, LowestIntersectingAddressRange(all_ranges, {21, 22}));
+  EXPECT_EQ(2, LowestIntersectingAddressRange(all_ranges, {51, 52}));
 
-  EXPECT_EQ(0, LowestIntersectingAddressRange(kAllRanges, {3, 6}));
-  EXPECT_EQ(1, LowestIntersectingAddressRange(kAllRanges, {19, 22}));
-  EXPECT_EQ(2, LowestIntersectingAddressRange(kAllRanges, {30, 52}));
+  EXPECT_EQ(0, LowestIntersectingAddressRange(all_ranges, {3, 6}));
+  EXPECT_EQ(1, LowestIntersectingAddressRange(all_ranges, {19, 22}));
+  EXPECT_EQ(2, LowestIntersectingAddressRange(all_ranges, {30, 52}));
 
-  EXPECT_EQ(0, LowestIntersectingAddressRange(kAllRanges, {4, 72}));
-  EXPECT_EQ(1, LowestIntersectingAddressRange(kAllRanges, {29, 52}));
-  EXPECT_EQ(2, LowestIntersectingAddressRange(kAllRanges, {59, 72}));
+  EXPECT_EQ(0, LowestIntersectingAddressRange(all_ranges, {4, 72}));
+  EXPECT_EQ(1, LowestIntersectingAddressRange(all_ranges, {29, 52}));
+  EXPECT_EQ(2, LowestIntersectingAddressRange(all_ranges, {59, 72}));
 
-  EXPECT_FALSE(LowestIntersectingAddressRange(kAllRanges, {5, 20}).has_value());
-  EXPECT_FALSE(LowestIntersectingAddressRange(kAllRanges, {30, 40}).has_value());
-  EXPECT_FALSE(LowestIntersectingAddressRange(kAllRanges, {60, 80}).has_value());
+  EXPECT_FALSE(LowestIntersectingAddressRange(all_ranges, {5, 20}).has_value());
+  EXPECT_FALSE(LowestIntersectingAddressRange(all_ranges, {30, 40}).has_value());
+  EXPECT_FALSE(LowestIntersectingAddressRange(all_ranges, {60, 80}).has_value());
 }
 
 TEST(TrampolineTest, HighestIntersectingAddressRange) {
-  std::vector<AddressRange> kAllRanges = {{0, 5}, {20, 30}, {40, 60}};
+  const std::vector<AddressRange> all_ranges = {{0, 5}, {20, 30}, {40, 60}};
 
   EXPECT_FALSE(HighestIntersectingAddressRange({}, {0, 60}).has_value());
 
-  EXPECT_EQ(0, HighestIntersectingAddressRange(kAllRanges, {1, 2}));
-  EXPECT_EQ(1, HighestIntersectingAddressRange(kAllRanges, {21, 22}));
-  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {51, 52}));
+  EXPECT_EQ(0, HighestIntersectingAddressRange(all_ranges, {1, 2}));
+  EXPECT_EQ(1, HighestIntersectingAddressRange(all_ranges, {21, 22}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(all_ranges, {51, 52}));
 
-  EXPECT_EQ(0, HighestIntersectingAddressRange(kAllRanges, {3, 6}));
-  EXPECT_EQ(1, HighestIntersectingAddressRange(kAllRanges, {19, 22}));
-  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {30, 52}));
+  EXPECT_EQ(0, HighestIntersectingAddressRange(all_ranges, {3, 6}));
+  EXPECT_EQ(1, HighestIntersectingAddressRange(all_ranges, {19, 22}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(all_ranges, {30, 52}));
 
-  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {4, 72}));
-  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {29, 52}));
-  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {59, 72}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(all_ranges, {4, 72}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(all_ranges, {29, 52}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(all_ranges, {59, 72}));
 
-  EXPECT_FALSE(HighestIntersectingAddressRange(kAllRanges, {5, 20}).has_value());
-  EXPECT_FALSE(HighestIntersectingAddressRange(kAllRanges, {30, 40}).has_value());
-  EXPECT_FALSE(HighestIntersectingAddressRange(kAllRanges, {60, 80}).has_value());
+  EXPECT_FALSE(HighestIntersectingAddressRange(all_ranges, {5, 20}).has_value());
+  EXPECT_FALSE(HighestIntersectingAddressRange(all_ranges, {30, 40}).has_value());
+  EXPECT_FALSE(HighestIntersectingAddressRange(all_ranges, {60, 80}).has_value());
 }
 
 TEST(TrampolineTest, FindAddressRangeForTrampoline) {
@@ -137,52 +137,52 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
   constexpr uint64_t kOneGb = 0x40000000;
 
   // Trivial placement to the left.
-  const std::vector<AddressRange> kUnavailableRanges1 = {
+  const std::vector<AddressRange> unavailable_ranges1 = {
       {0, k64Kb}, {kOneGb, 2 * kOneGb}, {3 * kOneGb, 4 * kOneGb}};
   auto address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges1, {kOneGb, 2 * kOneGb}, k256Mb);
+      FindAddressRangeForTrampoline(unavailable_ranges1, {kOneGb, 2 * kOneGb}, k256Mb);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(kOneGb - k256Mb, address_range_or_error.value().start);
 
   // Placement to the left just fits.
-  const std::vector<AddressRange> kUnavailableRanges2 = {
+  const std::vector<AddressRange> unavailable_ranges2 = {
       {0, k64Kb}, {k256Mb, kOneGb}, {3 * kOneGb, 4 * kOneGb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges2, {k256Mb, kOneGb}, k256Mb - k64Kb);
+      FindAddressRangeForTrampoline(unavailable_ranges2, {k256Mb, kOneGb}, k256Mb - k64Kb);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(k64Kb, address_range_or_error.value().start);
 
   // Placement to the left fails due to page alignment. So we place to the right which fits
   // trivially.
-  const std::vector<AddressRange> kUnavailableRanges3 = {
+  const std::vector<AddressRange> unavailable_ranges3 = {
       {0, k64Kb + 1}, {k256Mb, kOneGb}, {3 * kOneGb, 4 * kOneGb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges3, {k256Mb, kOneGb}, k256Mb - k64Kb - 5);
+      FindAddressRangeForTrampoline(unavailable_ranges3, {k256Mb, kOneGb}, k256Mb - k64Kb - 5);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(kOneGb, address_range_or_error.value().start);
 
   // Placement to the left just fits but only after a few hops.
-  const std::vector<AddressRange> kUnavailableRanges4 = {
+  const std::vector<AddressRange> unavailable_ranges4 = {
       {0, k64Kb},  // this is the gap that just fits
       {k64Kb + kOneMb, 6 * kOneMb},
       {6 * kOneMb + kOneMb - 1, 7 * kOneMb},
       {7 * kOneMb + kOneMb - 1, 8 * kOneMb},
       {8 * kOneMb + kOneMb - 1, 9 * kOneMb}};
   address_range_or_error = FindAddressRangeForTrampoline(
-      kUnavailableRanges4, {8 * kOneMb + kOneMb - 1, 9 * kOneMb}, kOneMb);
+      unavailable_ranges4, {8 * kOneMb + kOneMb - 1, 9 * kOneMb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(k64Kb, address_range_or_error.value().start);
 
   // No space to the left but trivial placement to the right.
-  const std::vector<AddressRange> kUnavailableRanges5 = {
+  const std::vector<AddressRange> unavailable_ranges5 = {
       {0, k64Kb}, {kOneMb, kOneGb}, {5 * kOneGb, 6 * kOneGb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges5, {kOneMb, kOneGb}, kOneMb);
+      FindAddressRangeForTrampoline(unavailable_ranges5, {kOneMb, kOneGb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
   EXPECT_EQ(kOneGb, address_range_or_error.value().start);
 
   // No space to the left but placement to the right works after a few hops.
-  const std::vector<AddressRange> kUnavailableRanges6 = {
+  const std::vector<AddressRange> unavailable_ranges6 = {
       {0, k64Kb},
       {kOneMb, kOneGb},
       {kOneGb + 0x01 * kOneMb - 1, kOneGb + 0x10 * kOneMb},
@@ -190,13 +190,13 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
       {kOneGb + 0x21 * kOneMb - 1, kOneGb + 0x30 * kOneMb},
       {kOneGb + 0x31 * kOneMb - 1, kOneGb + 0x40 * kOneMb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges6, {kOneMb, kOneGb}, kOneMb);
+      FindAddressRangeForTrampoline(unavailable_ranges6, {kOneMb, kOneGb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
   EXPECT_EQ(kOneGb + 0x40 * kOneMb, address_range_or_error.value().start);
 
   // No space to the left and the last segment nearly fills up the 64 bit address space. So no
   // placement is possible.
-  const std::vector<AddressRange> kUnavailableRanges7 = {
+  const std::vector<AddressRange> unavailable_ranges7 = {
       {0, k64Kb},
       {kOneMb, k256Mb},
       {1 * k256Mb + kOneMb - 1, 2 * k256Mb},
@@ -205,19 +205,19 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
       {4 * k256Mb + kOneMb + 2, 5 * k256Mb},
       {5 * k256Mb + kOneMb - 1, 0xffffffffffffffff - kOneMb / 2}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges7, {kOneMb, k256Mb}, kOneMb);
+      FindAddressRangeForTrampoline(unavailable_ranges7, {kOneMb, k256Mb}, kOneMb);
   ASSERT_TRUE(address_range_or_error.has_error());
 
   // There is no sufficiently large gap in the mappings in the 2GB below the code segment. So the
   // trampoline is placed above the code segment. Also we test that the trampoline starts at the
   // next memory page above last taken segment.
-  const std::vector<AddressRange> kUnavailableRanges8 = {
+  const std::vector<AddressRange> unavailable_ranges8 = {
       {0, k64Kb},  // huge gap here, but it's too far away
       {0x10 * kOneGb, 0x11 * kOneGb},
       {0x11 * kOneGb + kOneMb - 1, 0x12 * kOneGb},
       {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb + 42}};
   address_range_or_error = FindAddressRangeForTrampoline(
-      kUnavailableRanges8, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
+      unavailable_ranges8, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
   constexpr uint64_t kPageSize = 4096;
   constexpr uint64_t kNextPage =
@@ -226,7 +226,7 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
 
   // There is no sufficiently large gap in the mappings in the 2GB below the code segment. And there
   // also is no gap large enough in the 2GB above the code segment. So no placement is possible.
-  const std::vector<AddressRange> kUnavailableRanges9 = {
+  const std::vector<AddressRange> unavailable_ranges9 = {
       {0, k64Kb},  // huge gap here, but it's too far away
       {0x10 * kOneGb + kOneMb - 1, 0x11 * kOneGb},
       {0x11 * kOneGb + kOneMb - 1, 0x12 * kOneGb},
@@ -234,13 +234,13 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
       {0x12 * kOneGb + 3 * kOneMb - 1, 0x13 * kOneGb + 1},
       {0x13 * kOneGb + kOneMb + 42, 0x14 * kOneGb}};
   address_range_or_error = FindAddressRangeForTrampoline(
-      kUnavailableRanges9, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
+      unavailable_ranges9, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
   ASSERT_TRUE(address_range_or_error.has_error());
 
   // Fail on malformed input: first address range does not start at zero.
-  const std::vector<AddressRange> kUnavailableRanges10 = {{k64Kb, kOneGb}};
+  const std::vector<AddressRange> unavailable_ranges10 = {{k64Kb, kOneGb}};
   EXPECT_DEATH(
-      auto result = FindAddressRangeForTrampoline(kUnavailableRanges10, {k64Kb, kOneGb}, kOneMb),
+      auto result = FindAddressRangeForTrampoline(unavailable_ranges10, {k64Kb, kOneGb}, kOneMb),
       "needs to start at zero");
 
   // Placement to the left fails since the requested memory chunk is too big. So we place to the
@@ -248,27 +248,27 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
   // The special case here is that the requested memory size (k256Mb + k64Kb) is larger than the
   // left interval border of the second interval (k256Mb). This produced an artithmetic overflow in
   // a previous version of the algorithm.
-  const std::vector<AddressRange> kUnavailableRanges11 = {{0, k64Kb}, {k256Mb, kOneGb}};
+  const std::vector<AddressRange> unavailable_ranges11 = {{0, k64Kb}, {k256Mb, kOneGb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges11, {k256Mb, kOneGb}, k256Mb + k64Kb);
+      FindAddressRangeForTrampoline(unavailable_ranges11, {k256Mb, kOneGb}, k256Mb + k64Kb);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(kOneGb, address_range_or_error.value().start);
 
   // Placement to the left fails, placement to the right fails also because we are close to the end
   // of the address space. This produced an artithmetic overflow in a previous version of the
   // algorithm.
-  const std::vector<AddressRange> kUnavailableRanges12 = {
+  const std::vector<AddressRange> unavailable_ranges12 = {
       {0, k64Kb},
       {UINT64_MAX - 10 * kOneGb, UINT64_MAX - k64Kb - 1},
       {UINT64_MAX - k64Kb, UINT64_MAX - k1Kb}};
   address_range_or_error = FindAddressRangeForTrampoline(
-      kUnavailableRanges12, {UINT64_MAX - k64Kb, UINT64_MAX - k1Kb}, k64Kb);
+      unavailable_ranges12, {UINT64_MAX - k64Kb, UINT64_MAX - k1Kb}, k64Kb);
   ASSERT_THAT(address_range_or_error, HasError("No place to fit"));
 
   // We can not fit anything close to a range larger than 2GB.
-  const std::vector<AddressRange> kUnavailableRanges13 = {{0, k64Kb}, {kOneGb, 4 * kOneGb}};
+  const std::vector<AddressRange> unavailable_ranges13 = {{0, k64Kb}, {kOneGb, 4 * kOneGb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges13, {kOneGb, 4 * kOneGb}, k64Kb);
+      FindAddressRangeForTrampoline(unavailable_ranges13, {kOneGb, 4 * kOneGb}, k64Kb);
   ASSERT_THAT(address_range_or_error, HasError("No place to fit"));
 }
 
@@ -326,8 +326,8 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
 TEST(TrampolineTest, AddressDifferenceAsInt32) {
   // Result of the difference is negative; in the first case it just fits, the second case
   // overflows.
-  const uint64_t kAddr1 = 0x6012345612345678;
-  const uint64_t kAddr2Larger = kAddr1 - std::numeric_limits<int32_t>::min();
+  constexpr uint64_t kAddr1 = 0x6012345612345678;
+  constexpr uint64_t kAddr2Larger = kAddr1 - std::numeric_limits<int32_t>::min();
   auto result = AddressDifferenceAsInt32(kAddr1, kAddr2Larger);
   ASSERT_THAT(result, HasNoError());
   EXPECT_EQ(std::numeric_limits<int32_t>::min(), result.value());
@@ -344,8 +344,8 @@ TEST(TrampolineTest, AddressDifferenceAsInt32) {
   EXPECT_THAT(result, HasError("Difference is larger than +2GB"));
 
   // Result of the difference does not even fit into a int64. We handle that gracefully as well.
-  const uint64_t kAddrHigh = 0xf234567812345678;
-  const uint64_t kAddrLow = kAddrHigh - 0xe234567812345678;
+  constexpr uint64_t kAddrHigh = 0xf234567812345678;
+  constexpr uint64_t kAddrLow = kAddrHigh - 0xe234567812345678;
   result = AddressDifferenceAsInt32(kAddrHigh, kAddrLow);
   EXPECT_THAT(result, HasError("Difference is larger than +2GB"));
   result = AddressDifferenceAsInt32(kAddrLow, kAddrHigh);
@@ -388,7 +388,7 @@ TEST_F(RelocateInstructionTest, RipRelativeAddressing) {
   code.AppendBytes({0x48, 0x83, 0x05}).AppendImmediate32(kOffset).AppendBytes({0x01});
   Disassemble(code);
 
-  uint64_t kOriginalAddress = 0x0100000000;
+  constexpr uint64_t kOriginalAddress = 0x0100000000;
   ErrorMessageOr<RelocatedInstruction> result =
       RelocateInstruction(instruction_, kOriginalAddress, kOriginalAddress + kOffset - 0x123456);
   ASSERT_THAT(result, HasValue());


### PR DESCRIPTION
Let's agree on naming: Only constexpr is "kCamelCase", all the other variables should be snake_case. That is a bit annoying for "static const" variables, that are effectively also constants, but clang-tidy does not support that, yet.

This change does intentionally not touch method names, yet. There will be likely a follow-up for that.

This needs to be reviewed a bit more carefully. At some places, I switched to constexpr, when appropriate, or added a const modifier.

Test: Compile