### PR TITLE
Apply "performance-unnecessary-value-param" clang-tidy checks

### DIFF
--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -46,7 +46,7 @@ static const QColor kTextEditForegroundColor{189, 189, 189};
 static const QColor kTitleBackgroundColor{30, 65, 89};
 static const QColor kHeatmapColor{Qt::red};
 
-static int StringWidthInPixels(const QFontMetrics& font_metrics, QString string) {
+static int StringWidthInPixels(const QFontMetrics& font_metrics, const QString& string) {
   return font_metrics.horizontalAdvance(string);
 }
 

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -6,6 +6,7 @@
 #include <absl/hash/hash.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
+#include <absl/types/span.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
@@ -350,7 +351,7 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
         return functions_selected.at(index.value());
       });
 
-  auto verify_context_menu_action_availability = [&](std::vector<int> selected_indices) {
+  auto verify_context_menu_action_availability = [&](absl::Span<const int> selected_indices) {
     FlattenContextMenu context_menu = FlattenContextMenuWithGroupingAndCheckOrder(
         view_.GetContextMenuWithGrouping(0, selected_indices));
 

--- a/src/DataViews/DataView.cpp
+++ b/src/DataViews/DataView.cpp
@@ -101,7 +101,7 @@ std::vector<DataView::ActionGroup> DataView::GetContextMenuWithGrouping(
   ORBIT_CHECK(!selected_indices.empty());
 
   std::vector<ActionGroup> menu;
-  auto try_add_action_group = [&](std::vector<std::string_view> action_names) {
+  auto try_add_action_group = [&](const std::vector<std::string_view>& action_names) {
     ActionGroup action_group;
     for (std::string_view action_name : action_names) {
       switch (GetActionStatus(action_name, clicked_index, selected_indices)) {

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -21,7 +21,7 @@
 namespace orbit_data_views {
 
 int GetActionIndexOnMenu(const FlattenContextMenu& context_menu, std::string_view action_name) {
-  auto matcher = [&action_name](DataView::Action action) {
+  auto matcher = [&action_name](const DataView::Action& action) {
     return action.name == std::string{action_name};
   };
 

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -179,7 +179,7 @@ const std::unique_ptr<const orbit_client_data::CallstackData> kCallstackData = [
              : "???";
 }
 
-[[nodiscard]] std::string BuildExpectedExportEventsToCsvString(std::vector<size_t> indices) {
+[[nodiscard]] std::string BuildExpectedExportEventsToCsvString(const std::vector<size_t>& indices) {
   std::string result =
       "\"Thread\",\"Timestamp (ns)\",\"Names leaf/foo/main\",\"Addresses "
       "leaf_addr/foo_addr/main_addr\"";

--- a/src/LinuxCaptureService/MemoryInfoHandler.cpp
+++ b/src/LinuxCaptureService/MemoryInfoHandler.cpp
@@ -17,7 +17,7 @@
 
 namespace orbit_linux_capture_service {
 
-void MemoryInfoHandler::Start(orbit_grpc_protos::CaptureOptions capture_options) {
+void MemoryInfoHandler::Start(const orbit_grpc_protos::CaptureOptions& capture_options) {
   if (!capture_options.collect_memory_info()) return;
 
   SetSamplingStartTimestampNs(orbit_base::CaptureTimestampNs());

--- a/src/LinuxCaptureService/MemoryInfoHandler.h
+++ b/src/LinuxCaptureService/MemoryInfoHandler.h
@@ -33,7 +33,7 @@ class MemoryInfoHandler : public orbit_memory_tracing::MemoryInfoListener {
   MemoryInfoHandler(MemoryInfoHandler&&) = delete;
   MemoryInfoHandler& operator=(MemoryInfoHandler&&) = delete;
 
-  void Start(orbit_grpc_protos::CaptureOptions capture_options);
+  void Start(const orbit_grpc_protos::CaptureOptions& capture_options);
   void Stop();
 
  private:

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -32,7 +32,7 @@ namespace orbit_linux_tracing {
 class LibunwindstackResult {
  public:
   explicit LibunwindstackResult(
-      std::vector<unwindstack::FrameData> frames, unwindstack::RegsX86_64 regs,
+      std::vector<unwindstack::FrameData> frames, const unwindstack::RegsX86_64& regs,
       unwindstack::ErrorCode error_code = unwindstack::ErrorCode::ERROR_NONE)
       : frames_{std::move(frames)}, regs_{std::move(regs)}, error_code_{error_code} {}
 

--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -261,7 +261,7 @@ TEST_F(MizarPairedDataTest, FrameTrackManagerIsProperlyInitialized) {
 TEST_F(MizarPairedDataTest, ForeachCallstackIsCorrect) {
   MizarPairedDataUnderTest mizar_paired_data(std::move(data_), kAddressToId);
   std::vector<std::vector<SampledFunctionId>> actual_ids_fed_to_action;
-  auto action = [&actual_ids_fed_to_action](const std::vector<SampledFunctionId> ids) {
+  auto action = [&actual_ids_fed_to_action](const std::vector<SampledFunctionId>& ids) {
     actual_ids_fed_to_action.push_back(ids);
   };
 

--- a/src/OrbitBase/OverloadedTest.cpp
+++ b/src/OrbitBase/OverloadedTest.cpp
@@ -21,7 +21,7 @@ constexpr std::string_view kTwoInts = "two ints";
 constexpr auto kFromInt = [](int /*unused*/) { return kInt; };
 constexpr auto kFromTwoInts = [](int /*unused*/, int /*unused*/) { return kTwoInts; };
 auto kFromIntMutable = [](int /*unused*/) mutable { return kInt; };
-constexpr auto kFromString = [](std::string /*unused*/) { return kString; };
+constexpr auto kFromString = [](const std::string& /*unused*/) { return kString; };
 
 std::string_view FromString(std::string /*unused*/) { return kString; }
 std::string_view FromInt(int /*unused*/) { return kInt; }

--- a/src/OrbitBase/ThreadPool.cpp
+++ b/src/OrbitBase/ThreadPool.cpp
@@ -223,7 +223,7 @@ void ThreadPool::InitializeDefaultThreadPool() {
   (void)GetDefaultThreadPool();
 }
 
-void ThreadPool::SetDefaultThreadPool(std::shared_ptr<ThreadPool> thread_pool) {
+void ThreadPool::SetDefaultThreadPool(const std::shared_ptr<ThreadPool>& thread_pool) {
   ORBIT_CHECK(thread_pool != nullptr);
   absl::MutexLock lock(&g_default_thread_pool_mutex);
   ORBIT_CHECK(g_default_thread_pool == nullptr);

--- a/src/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -80,7 +80,7 @@ class ThreadPool : public orbit_base::Executor {
   static void InitializeDefaultThreadPool();
   // Set the default thread pool. This can only be called once and with a non-null thread pool,
   // before any call to "GetDefaultThreadPool()".
-  static void SetDefaultThreadPool(std::shared_ptr<ThreadPool> thread_pool);
+  static void SetDefaultThreadPool(const std::shared_ptr<ThreadPool>& thread_pool);
   // Get the default thread pool. Create one if none was set, as if we had called
   // "InitializeDefaultThreadPool()" explicitly.
   [[nodiscard]] static ThreadPool* GetDefaultThreadPool();

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -157,7 +157,7 @@ bool CaptureViewElement::ContainsPointRecursively(const Vec2& point) const {
 }
 
 CaptureViewElement::EventResult CaptureViewElement::HandleMouseEvent(
-    MouseEvent mouse_event, const ModifierKeys& modifiers) {
+    const MouseEvent& mouse_event, const ModifierKeys& modifiers) {
   Vec2 mouse_pos = mouse_event.mouse_position;
 
   if (mouse_event.event_type != MouseEventType::kMouseLeave &&

--- a/src/OrbitGl/MockBatcher.cpp
+++ b/src/OrbitGl/MockBatcher.cpp
@@ -85,7 +85,7 @@ int MockBatcher::GetNumBoxes() const {
 
 // To check that everything is inside a rectangle, we just need to check the minimum and maximum
 // used coordinates.
-bool MockBatcher::IsEverythingInsideRectangle(Vec2 start, Vec2 size) const {
+bool MockBatcher::IsEverythingInsideRectangle(const Vec2& start, const Vec2& size) const {
   if (GetNumElements() == 0) return true;
   return IsInsideRectangle(min_point_, start, size) && IsInsideRectangle(max_point_, start, size);
 }

--- a/src/OrbitGl/MockTextRenderer.cpp
+++ b/src/OrbitGl/MockTextRenderer.cpp
@@ -96,7 +96,8 @@ float MockTextRenderer::GetStringHeight(const char* /*text*/, uint32_t font_size
   return font_size;
 }
 
-[[nodiscard]] bool MockTextRenderer::IsTextInsideRectangle(Vec2 start, Vec2 size) const {
+[[nodiscard]] bool MockTextRenderer::IsTextInsideRectangle(const Vec2& start,
+                                                           const Vec2& size) const {
   if (GetNumAddTextCalls() == 0) return true;
   return IsInsideRectangle(min_point_, start, size) && IsInsideRectangle(max_point_, start, size);
 }

--- a/src/OrbitGl/OpenGlBatcherTest.cpp
+++ b/src/OrbitGl/OpenGlBatcherTest.cpp
@@ -33,7 +33,7 @@ class FakeOpenGlBatcher : public OpenGlBatcher {
   }
 
   // Auxiliary methods to simplify the addition of lines, boxes and triangles.
-  void AddLineHelper(Vec2 from, Vec2 to, float z, const Color& color,
+  void AddLineHelper(const Vec2& from, const Vec2& to, float z, const Color& color,
                      std::unique_ptr<PickingUserData> user_data = nullptr) {
     Color picking_color = PickingId::ToColor(PickingType::kLine, GetNumElements(), GetBatcherId());
     return AddLine(from, to, z, color, picking_color, std::move(user_data));
@@ -231,7 +231,7 @@ struct Line3D {
   Vec3 end_point;
 };
 
-void LineEq(const Line3D lhs, const Line& rhs) {
+void LineEq(const Line3D& lhs, const Line& rhs) {
   EXPECT_EQ(lhs.start_point[0], rhs.start_point[0]);
   EXPECT_EQ(lhs.start_point[1], rhs.start_point[1]);
 

--- a/src/OrbitGl/PrimitiveAssembler.cpp
+++ b/src/OrbitGl/PrimitiveAssembler.cpp
@@ -19,7 +19,7 @@
 
 namespace orbit_gl {
 
-void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
+void PrimitiveAssembler::AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
                                  std::unique_ptr<PickingUserData> user_data) {
   Color picking_color =
       PickingId::ToColor(PickingType::kLine, batcher_->GetNumElements(), GetBatcherId());
@@ -27,8 +27,8 @@ void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color
   batcher_->AddLine(from, to, z, color, picking_color, std::move(user_data));
 }
 
-void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
-                                 std::shared_ptr<Pickable> pickable) {
+void PrimitiveAssembler::AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
+                                 const std::shared_ptr<Pickable>& pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());
@@ -36,13 +36,13 @@ void PrimitiveAssembler::AddLine(Vec2 from, Vec2 to, float z, const Color& color
   batcher_->AddLine(from, to, z, color, picking_color, nullptr);
 }
 
-void PrimitiveAssembler::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
+void PrimitiveAssembler::AddVerticalLine(const Vec2& pos, float size, float z, const Color& color,
                                          std::unique_ptr<PickingUserData> user_data) {
   AddLine(pos, pos + Vec2(0, size), z, color, std::move(user_data));
 }
 
-void PrimitiveAssembler::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
-                                         std::shared_ptr<Pickable> pickable) {
+void PrimitiveAssembler::AddVerticalLine(const Vec2& pos, float size, float z, const Color& color,
+                                         const std::shared_ptr<Pickable>& pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());
@@ -65,7 +65,7 @@ void PrimitiveAssembler::AddBox(const Quad& box, float z, const Color& color,
 }
 
 void PrimitiveAssembler::AddBox(const Quad& box, float z, const Color& color,
-                                std::shared_ptr<Pickable> pickable) {
+                                const std::shared_ptr<Pickable>& pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());
@@ -75,17 +75,19 @@ void PrimitiveAssembler::AddBox(const Quad& box, float z, const Color& color,
   batcher_->AddBox(box, z, colors, picking_color, nullptr);
 }
 
-void PrimitiveAssembler::AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color) {
+void PrimitiveAssembler::AddShadedBox(const Vec2& pos, const Vec2& size, float z,
+                                      const Color& color) {
   AddShadedBox(pos, size, z, color, std::unique_ptr<PickingUserData>(),
                ShadingDirection::kLeftToRight);
 }
 
-void PrimitiveAssembler::AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
-                                      ShadingDirection shading_direction) {
+void PrimitiveAssembler::AddShadedBox(const Vec2& pos, const Vec2& size, float z,
+                                      const Color& color, ShadingDirection shading_direction) {
   AddShadedBox(pos, size, z, color, std::unique_ptr<PickingUserData>(), shading_direction);
 }
 
-void PrimitiveAssembler::AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
+void PrimitiveAssembler::AddShadedBox(const Vec2& pos, const Vec2& size, float z,
+                                      const Color& color,
                                       std::unique_ptr<PickingUserData> user_data,
                                       ShadingDirection shading_direction) {
   std::array<Color, 4> colors;
@@ -111,7 +113,7 @@ static std::vector<Triangle> GetUnitArcTriangles(float angle_0, float angle_1, u
 }
 
 static void AddRoundedCornerTriangles(PrimitiveAssembler* batcher,
-                                      const std::vector<Triangle> unit_triangles, Vec2 pos,
+                                      const std::vector<Triangle>& unit_triangles, Vec2 pos,
                                       float radius, float z, const Color& color) {
   for (auto& unit_triangle : unit_triangles) {
     Triangle triangle = unit_triangle;
@@ -127,25 +129,25 @@ static void AddRoundedCornerTriangles(PrimitiveAssembler* batcher,
   }
 }
 
-void PrimitiveAssembler::AddBottomLeftRoundedCorner(Vec2 pos, float radius, float z,
+void PrimitiveAssembler::AddBottomLeftRoundedCorner(const Vec2& pos, float radius, float z,
                                                     const Color& color) {
   static auto unit_triangles = GetUnitArcTriangles(kPiFloat, 1.5f * kPiFloat, kNumArcSides);
   AddRoundedCornerTriangles(this, unit_triangles, pos, radius, z, color);
 }
 
-void PrimitiveAssembler::AddTopLeftRoundedCorner(Vec2 pos, float radius, float z,
+void PrimitiveAssembler::AddTopLeftRoundedCorner(const Vec2& pos, float radius, float z,
                                                  const Color& color) {
   static auto unit_triangles = GetUnitArcTriangles(0.5f * kPiFloat, kPiFloat, kNumArcSides);
   AddRoundedCornerTriangles(this, unit_triangles, pos, radius, z, color);
 }
 
-void PrimitiveAssembler::AddTopRightRoundedCorner(Vec2 pos, float radius, float z,
+void PrimitiveAssembler::AddTopRightRoundedCorner(const Vec2& pos, float radius, float z,
                                                   const Color& color) {
   static auto unit_triangles = GetUnitArcTriangles(0, 0.5f * kPiFloat, kNumArcSides);
   AddRoundedCornerTriangles(this, unit_triangles, pos, radius, z, color);
 }
 
-void PrimitiveAssembler::AddBottomRightRoundedCorner(Vec2 pos, float radius, float z,
+void PrimitiveAssembler::AddBottomRightRoundedCorner(const Vec2& pos, float radius, float z,
                                                      const Color& color) {
   static auto unit_triangles = GetUnitArcTriangles(-0.5f * kPiFloat, 0, kNumArcSides);
   AddRoundedCornerTriangles(this, unit_triangles, pos, radius, z, color);
@@ -177,8 +179,8 @@ void PrimitiveAssembler::AddRoundedBox(Vec2 pos, Vec2 size, float z, float radiu
   AddBottomRightRoundedCorner(bottom_right_pos, radius, z, color);
 }
 
-void PrimitiveAssembler::AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
-                                      std::shared_ptr<Pickable> pickable,
+void PrimitiveAssembler::AddShadedBox(const Vec2& pos, const Vec2& size, float z,
+                                      const Color& color, const std::shared_ptr<Pickable>& pickable,
                                       ShadingDirection shading_direction) {
   std::array<Color, 4> colors;
   GetBoxGradientColors(color, &colors, shading_direction);
@@ -196,7 +198,7 @@ void PrimitiveAssembler::AddTriangle(const Triangle& triangle, float z, const Co
 }
 
 void PrimitiveAssembler::AddTriangle(const Triangle& triangle, float z, const Color& color,
-                                     std::shared_ptr<Pickable> pickable) {
+                                     const std::shared_ptr<Pickable>& pickable) {
   ORBIT_CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, GetBatcherId());

--- a/src/OrbitGl/PrimitiveAssemblerTest.cpp
+++ b/src/OrbitGl/PrimitiveAssemblerTest.cpp
@@ -40,7 +40,7 @@ class PrimitiveAssemblerTester : public PrimitiveAssembler {
   [[nodiscard]] uint32_t GetNumTriangles() const { return mock_batcher_.GetNumTriangles(); }
   [[nodiscard]] uint32_t GetNumBoxes() const { return mock_batcher_.GetNumBoxes(); }
   [[nodiscard]] uint32_t GetNumElements() const { return mock_batcher_.GetNumElements(); }
-  [[nodiscard]] bool IsEverythingInsideRectangle(Vec2 pos, Vec2 size) const {
+  [[nodiscard]] bool IsEverythingInsideRectangle(const Vec2& pos, const Vec2& size) const {
     return mock_batcher_.IsEverythingInsideRectangle(pos, size);
   }
 

--- a/src/OrbitGl/TimelineUi.cpp
+++ b/src/OrbitGl/TimelineUi.cpp
@@ -78,7 +78,7 @@ void TimelineUi::RenderBackground(PrimitiveAssembler& primitive_assembler) const
 
 void TimelineUi::RenderLabel(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                              uint64_t tick_ns, uint32_t number_of_decimal_places,
-                             const Color background_color, bool is_mouse_label) const {
+                             const Color& background_color, bool is_mouse_label) const {
   float label_z =
       is_mouse_label ? GlCanvas::kZValueTimeBarMouseLabel : GlCanvas::kZValueTimeBarLabel;
 

--- a/src/OrbitGl/TrackRenderHelper.cpp
+++ b/src/OrbitGl/TrackRenderHelper.cpp
@@ -49,7 +49,7 @@ std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
 
 void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, absl::Span<const Vec2> points,
                      const Vec2& pos, const Color& color, float rotation, float z,
-                     std::shared_ptr<Pickable> pickable) {
+                     const std::shared_ptr<Pickable>& pickable) {
   if (points.size() < 3) {
     return;
   }

--- a/src/OrbitGl/include/OrbitGl/AccessibleCaptureViewElement.h
+++ b/src/OrbitGl/include/OrbitGl/AccessibleCaptureViewElement.h
@@ -6,6 +6,7 @@
 #define ORBIT_GL_ACCESSIBLE_CAPTURE_VIEW_ELEMENT_H_
 
 #include <string>
+#include <utility>
 
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "OrbitBase/Logging.h"
@@ -20,7 +21,7 @@ class AccessibleCaptureViewElement : public orbit_accessibility::AccessibleInter
                                             orbit_accessibility::AccessibilityRole::Pane,
                                         orbit_accessibility::AccessibilityState accessible_state =
                                             orbit_accessibility::AccessibilityState::Normal)
-      : accessible_name_(accessible_name),
+      : accessible_name_(std::move(accessible_name)),
         accessible_role_(accessible_role),
         accessible_state_(accessible_state),
         capture_view_element_(capture_view_element) {

--- a/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/include/OrbitGl/CaptureViewElement.h
@@ -87,7 +87,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   };
 
   enum class EventResult { kHandled, kIgnored };
-  [[nodiscard]] EventResult HandleMouseEvent(MouseEvent mouse_event,
+  [[nodiscard]] EventResult HandleMouseEvent(const MouseEvent& mouse_event,
                                              const ModifierKeys& modifiers = ModifierKeys());
 
   [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }

--- a/src/OrbitGl/include/OrbitGl/Geometry.h
+++ b/src/OrbitGl/include/OrbitGl/Geometry.h
@@ -30,7 +30,7 @@ struct Quad {
 
 struct Triangle {
   Triangle() = default;
-  Triangle(Vec2 v0, Vec2 v1, Vec2 v2) {
+  Triangle(const Vec2& v0, const Vec2& v1, const Vec2& v2) {
     vertices[0] = v0;
     vertices[1] = v1;
     vertices[2] = v2;

--- a/src/OrbitGl/include/OrbitGl/MockBatcher.h
+++ b/src/OrbitGl/include/OrbitGl/MockBatcher.h
@@ -56,7 +56,7 @@ class MockBatcher : public Batcher {
   [[nodiscard]] int GetNumTriangles() const;
   [[nodiscard]] int GetNumBoxes() const;
 
-  [[nodiscard]] bool IsEverythingInsideRectangle(Vec2 start, Vec2 size) const;
+  [[nodiscard]] bool IsEverythingInsideRectangle(const Vec2& start, const Vec2& size) const;
   [[nodiscard]] bool IsEverythingBetweenZLayers(float z_layer_min, float z_layer_max) const;
 
  private:

--- a/src/OrbitGl/include/OrbitGl/MockTextRenderer.h
+++ b/src/OrbitGl/include/OrbitGl/MockTextRenderer.h
@@ -49,7 +49,7 @@ class MockTextRenderer : public TextRenderer {
     return vertical_position_in_add_text.size() <= 1;
   }
   [[nodiscard]] const int GetNumAddTextCalls() const { return num_add_text_calls_; }
-  [[nodiscard]] bool IsTextInsideRectangle(Vec2 start, Vec2 size) const;
+  [[nodiscard]] bool IsTextInsideRectangle(const Vec2& start, const Vec2& size) const;
   [[nodiscard]] bool IsTextBetweenZLayers(float z_layer_min, float z_layer_max) const;
 
  private:

--- a/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
@@ -61,28 +61,30 @@ class PrimitiveAssembler {
   void PushTranslation(float x, float y, float z = 0.f) { batcher_->PushTranslation(x, y, z); }
   void PopTranslation() { batcher_->PopTranslation(); }
 
-  void AddLine(Vec2 from, Vec2 to, float z, const Color& color,
+  void AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
                std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
+  void AddVerticalLine(const Vec2& pos, float size, float z, const Color& color,
                        std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddLine(Vec2 from, Vec2 to, float z, const Color& color, std::shared_ptr<Pickable> pickable);
-  void AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
-                       std::shared_ptr<Pickable> pickable);
+  void AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
+               const std::shared_ptr<Pickable>& pickable);
+  void AddVerticalLine(const Vec2& pos, float size, float z, const Color& color,
+                       const std::shared_ptr<Pickable>& pickable);
 
   void AddBox(const Quad& box, float z, const std::array<Color, 4>& colors,
               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddBox(const Quad& box, float z, const Color& color,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddBox(const Quad& box, float z, const Color& color, std::shared_ptr<Pickable> pickable);
+  void AddBox(const Quad& box, float z, const Color& color,
+              const std::shared_ptr<Pickable>& pickable);
 
-  void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color);
-  void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
+  void AddShadedBox(const Vec2& pos, const Vec2& size, float z, const Color& color);
+  void AddShadedBox(const Vec2& pos, const Vec2& size, float z, const Color& color,
                     ShadingDirection shading_direction);
-  void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
+  void AddShadedBox(const Vec2& pos, const Vec2& size, float z, const Color& color,
                     std::unique_ptr<PickingUserData> user_data,
                     ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
-  void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
-                    std::shared_ptr<Pickable> pickable,
+  void AddShadedBox(const Vec2& pos, const Vec2& size, float z, const Color& color,
+                    const std::shared_ptr<Pickable>& pickable,
                     ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
   void AddRoundedBox(Vec2 pos, Vec2 size, float z, float radius, const Color& color,
                      float margin = 0);
@@ -92,7 +94,7 @@ class PrimitiveAssembler {
                           std::unique_ptr<PickingUserData> user_data,
                           ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
   void AddTriangle(const Triangle& triangle, float z, const Color& color,
-                   std::shared_ptr<Pickable> pickable);
+                   const std::shared_ptr<Pickable>& pickable);
   void AddTriangle(const Triangle& triangle, float z, const Color& color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
 
@@ -132,10 +134,10 @@ class PrimitiveAssembler {
  private:
   [[nodiscard]] BatcherId GetBatcherId() const { return batcher_->GetBatcherId(); }
 
-  void AddBottomLeftRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
-  void AddTopLeftRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
-  void AddTopRightRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
-  void AddBottomRightRoundedCorner(Vec2 pos, float radius, float z, const Color& color);
+  void AddBottomLeftRoundedCorner(const Vec2& pos, float radius, float z, const Color& color);
+  void AddTopLeftRoundedCorner(const Vec2& pos, float radius, float z, const Color& color);
+  void AddTopRightRoundedCorner(const Vec2& pos, float radius, float z, const Color& color);
+  void AddBottomRightRoundedCorner(const Vec2& pos, float radius, float z, const Color& color);
   void AddTriangle(const Triangle& triangle, float z, const Color& color,
                    const Color& picking_color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);

--- a/src/OrbitGl/include/OrbitGl/TimelineUi.h
+++ b/src/OrbitGl/include/OrbitGl/TimelineUi.h
@@ -55,8 +55,8 @@ class TimelineUi : public CaptureViewElement {
                     uint64_t min_timestamp_ns, uint64_t max_timestamp_ns) const;
   void RenderBackground(PrimitiveAssembler& primitive_assembler) const;
   void RenderLabel(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
-                   uint64_t tick_ns, uint32_t number_of_decimal_places, Color background_color,
-                   bool is_mouse_label = false) const;
+                   uint64_t tick_ns, uint32_t number_of_decimal_places,
+                   const Color& background_color, bool is_mouse_label = false) const;
   void RenderMouseLabel(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                         uint64_t mouse_tick_ns) const;
   [[nodiscard]] std::string GetLabel(uint64_t tick_ns, uint32_t number_of_decimal_places) const;

--- a/src/OrbitGl/include/OrbitGl/TrackRenderHelper.h
+++ b/src/OrbitGl/include/OrbitGl/TrackRenderHelper.h
@@ -19,7 +19,7 @@
 namespace orbit_gl {
 void DrawTriangleFan(PrimitiveAssembler& primitive_assembler, absl::Span<const Vec2> points,
                      const Vec2& pos, const Color& color, float rotation, float z,
-                     std::shared_ptr<Pickable> pickable);
+                     const std::shared_ptr<Pickable>& pickable);
 [[nodiscard]] std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides);
 }  // namespace orbit_gl
 

--- a/src/OrbitQt/HistogramWidget.cpp
+++ b/src/OrbitQt/HistogramWidget.cpp
@@ -240,7 +240,7 @@ static void SetBoldFont(QPainter& painter) {
   painter.setFont(font);
 }
 
-static void DrawHoverLabel(QPainter& painter, const QRect& rect, const QString text) {
+static void DrawHoverLabel(QPainter& painter, const QRect& rect, const QString& text) {
   SetBoldFont(painter);
   painter.fillRect(rect, kHoverLabelColor);
   painter.drawText(rect, Qt::AlignCenter, text);
@@ -360,8 +360,8 @@ static void DrawHorizontalHoverLabel(QPainter& painter, const QPoint& axes_inter
   DrawHoverLabel(painter, label_rect, label_text);
 }
 
-static void DrawOneLineOfHint(QPainter& painter, const QString message, const QPoint& bottom_right,
-                              const QColor color) {
+static void DrawOneLineOfHint(QPainter& painter, const QString& message, const QPoint& bottom_right,
+                              const QColor& color) {
   painter.setPen(color);
   const QRect rect(QPoint(0, 0), bottom_right);
   painter.drawText(rect, Qt::AlignRight | Qt::AlignBottom, message);

--- a/src/OrbitSshQt/Task.cpp
+++ b/src/OrbitSshQt/Task.cpp
@@ -19,7 +19,8 @@ constexpr const std::chrono::milliseconds kShutdownTimeoutMs{2000};
 
 namespace orbit_ssh_qt {
 
-Task::Task(Session* session, std::string command) : session_(session), command_(command) {
+Task::Task(Session* session, std::string command)
+    : session_(session), command_(std::move(command)) {
   about_to_shutdown_connection_.emplace(
       QObject::connect(session_, &Session::aboutToShutdown, this, &Task::HandleSessionShutdown));
 }

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -816,7 +816,7 @@ TEST_F(SubmissionTrackerTest, MultipleSubmissionsWontBeOutOfOrder) {
   std::vector<uint32_t> actual_slots_done_reading;
   auto fake_mark_query_slots_done_reading = [&actual_slots_done_reading](
                                                 VkDevice /*device*/,
-                                                const std::vector<uint32_t> slots_to_reset) {
+                                                const std::vector<uint32_t>& slots_to_reset) {
     actual_slots_done_reading.insert(actual_slots_done_reading.end(), slots_to_reset.begin(),
                                      slots_to_reset.end());
   };
@@ -826,7 +826,7 @@ TEST_F(SubmissionTrackerTest, MultipleSubmissionsWontBeOutOfOrder) {
   std::vector<uint32_t> actual_slots_marked_reset;
   auto fake_mark_query_slots_for_reset = [&actual_slots_marked_reset](
                                              VkDevice /*device*/,
-                                             const std::vector<uint32_t> slots_to_reset) {
+                                             const std::vector<uint32_t>& slots_to_reset) {
     actual_slots_marked_reset.insert(actual_slots_marked_reset.end(), slots_to_reset.begin(),
                                      slots_to_reset.end());
   };
@@ -1045,7 +1045,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmis
 
   const char* text = "Text";
   constexpr uint64_t expected_text_key = 111;
-  auto mock_intern_string_if_necessary_and_get_key = [&text](std::string str) {
+  auto mock_intern_string_if_necessary_and_get_key = [&text](const std::string& str) {
     EXPECT_STREQ(text, str.c_str());
     return expected_text_key;
   };
@@ -1105,7 +1105,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenBeginNotCaptured)
 
   const char* text = "Text";
   constexpr uint64_t expected_text_key = 111;
-  auto mock_intern_string_if_necessary_and_get_key = [&text](std::string str) {
+  auto mock_intern_string_if_necessary_and_get_key = [&text](const std::string& str) {
     EXPECT_STREQ(text, str.c_str());
     return expected_text_key;
   };
@@ -1161,7 +1161,8 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNestedDebugMarkerTimestampsForAComplete
   const std::string text_inner = "Inner";
   constexpr uint64_t expected_text_key_outer = 111;
   constexpr uint64_t expected_text_key_inner = 112;
-  auto mock_intern_string_if_necessary_and_get_key = [&text_outer, &text_inner](std::string str) {
+  auto mock_intern_string_if_necessary_and_get_key = [&text_outer,
+                                                      &text_inner](const std::string& str) {
     if (str == text_outer) {
       return expected_text_key_outer;
     }
@@ -1240,7 +1241,8 @@ TEST_F(SubmissionTrackerTest,
   const std::string text_inner = "Inner";
   constexpr uint64_t expected_text_key_outer = 111;
   constexpr uint64_t expected_text_key_inner = 112;
-  auto mock_intern_string_if_necessary_and_get_key = [&text_outer, &text_inner](std::string str) {
+  auto mock_intern_string_if_necessary_and_get_key = [&text_outer,
+                                                      &text_inner](const std::string& str) {
     if (str == text_outer) {
       return expected_text_key_outer;
     }
@@ -1322,7 +1324,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
 
   const char* text = "Text";
   constexpr uint64_t expected_text_key = 111;
-  auto mock_intern_string_if_necessary_and_get_key = [&text](std::string str) {
+  auto mock_intern_string_if_necessary_and_get_key = [&text](const std::string& str) {
     EXPECT_STREQ(text, str.c_str());
     return expected_text_key;
   };
@@ -1417,7 +1419,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhen
 
   const char* text = "Text";
   constexpr uint64_t expected_text_key = 111;
-  auto mock_intern_string_if_necessary_and_get_key = [&text](std::string str) {
+  auto mock_intern_string_if_necessary_and_get_key = [&text](const std::string& str) {
     EXPECT_STREQ(text, str.c_str());
     return expected_text_key;
   };
@@ -1590,7 +1592,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBuffer) {
   const std::string text_outer = "Outer";
   const std::string text_inner = "Inner";
   constexpr uint64_t expected_text_key_outer = 111;
-  auto mock_intern_string_if_necessary_and_get_key = [&text_outer](std::string str) {
+  auto mock_intern_string_if_necessary_and_get_key = [&text_outer](const std::string& str) {
     if (str == text_outer) {
       return expected_text_key_outer;
     }
@@ -1647,7 +1649,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
   std::vector<uint32_t> actual_slots_done_reading;
   auto mock_mark_slots_done_reading = [&actual_slots_done_reading](
                                           VkDevice /*device*/,
-                                          const std::vector<uint32_t> slots_to_reset) {
+                                          const std::vector<uint32_t>& slots_to_reset) {
     actual_slots_done_reading.insert(actual_slots_done_reading.end(), slots_to_reset.begin(),
                                      slots_to_reset.end());
   };
@@ -1657,7 +1659,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
   std::vector<uint32_t> actual_slots_marked_for_reset;
   auto mock_mark_slots_for_reset = [&actual_slots_marked_for_reset](
                                        VkDevice /*device*/,
-                                       const std::vector<uint32_t> slots_to_reset) {
+                                       const std::vector<uint32_t>& slots_to_reset) {
     actual_slots_marked_for_reset.insert(actual_slots_marked_for_reset.end(),
                                          slots_to_reset.begin(), slots_to_reset.end());
   };
@@ -1674,7 +1676,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
   const std::string text_outer = "Outer";
   const std::string text_inner = "Inner";
   constexpr uint64_t expected_outer_text_key = 111;
-  auto mock_intern_string_if_necessary_and_get_key = [&text_outer](std::string str) {
+  auto mock_intern_string_if_necessary_and_get_key = [&text_outer](const std::string& str) {
     EXPECT_EQ(text_outer, str);
     return expected_outer_text_key;
   };

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.cpp
@@ -57,7 +57,7 @@ Future<SymbolLoadingOutcome> MicrosoftSymbolServerSymbolProvider::RetrieveSymbol
       .ThenIfSuccess(
           main_thread_executor_.get(),
           [save_file_path = std::move(save_file_path)](
-              CanceledOr<NotFoundOr<void>> download_result) -> SymbolLoadingOutcome {
+              const CanceledOr<NotFoundOr<void>>& download_result) -> SymbolLoadingOutcome {
             if (orbit_base::IsCanceled(download_result)) return {orbit_base::Canceled{}};
             if (orbit_base::IsNotFound(orbit_base::GetNotCanceled(download_result))) {
               return {orbit_base::NotFound{"Symbols not found in Microsoft symbol server"}};

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderTest.cpp
@@ -71,9 +71,9 @@ class MicrosoftSymbolServerSymbolProviderTest : public testing::Test {
     EXPECT_CALL(download_manager_, Download)
         .Times(1)
         .WillOnce([expected_state, expected_url = std::move(expected_url),
-                   error_msg = std::move(error_msg)](std::string url,
-                                                     std::filesystem::path /*save_file_path*/,
-                                                     orbit_base::StopToken /*token*/)
+                   error_msg = std::move(error_msg)](
+                      const std::string& url, const std::filesystem::path& /*save_file_path*/,
+                      const orbit_base::StopToken& /*token*/)
                       -> Future<ErrorMessageOr<CanceledOr<NotFoundOr<void>>>> {
           EXPECT_EQ(url, expected_url);
 

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -84,7 +84,7 @@ std::optional<TargetConfiguration> ConnectToTargetDialog::Exec() {
 void ConnectToTargetDialog::OnProcessListUpdate(
     std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
   std::unique_ptr<orbit_client_data::ProcessData> matching_process =
-      TryToFindProcessData(process_list, target_.process_name_or_path.toStdString());
+      TryToFindProcessData(std::move(process_list), target_.process_name_or_path.toStdString());
 
   if (matching_process != nullptr) {
     ssh_connection_->GetProcessManager()->SetProcessListUpdateListener(nullptr);

--- a/src/SessionSetup/OtherUserDialog.cpp
+++ b/src/SessionSetup/OtherUserDialog.cpp
@@ -16,7 +16,7 @@ constexpr const char* kRememberKey = "OtherUserDialog.RememberKey";
 
 namespace orbit_session_setup {
 
-OtherUserDialog::OtherUserDialog(QString user_name, QWidget* parent)
+OtherUserDialog::OtherUserDialog(const QString& user_name, QWidget* parent)
     : QDialog(parent), ui_(std::make_unique<Ui::OtherUserDialog>()) {
   ui_->setupUi(this);
   ui_->userLabel->setText(user_name);

--- a/src/SessionSetup/SessionSetupDialog.cpp
+++ b/src/SessionSetup/SessionSetupDialog.cpp
@@ -210,7 +210,7 @@ void SessionSetupDialog::SetTargetAndStateMachineInitialState(LocalTarget target
   state_machine_.setInitialState(&state_local_);
 }
 
-void SessionSetupDialog::SetTargetAndStateMachineInitialState(FileTarget target) {
+void SessionSetupDialog::SetTargetAndStateMachineInitialState(const FileTarget& target) {
   ui_->loadCaptureWidget->GetRadioButton()->setChecked(true);
   selected_file_path_ = target.GetCaptureFilePath();
   state_file_.setInitialState(&state_file_selected_);

--- a/src/SessionSetup/include/SessionSetup/OtherUserDialog.h
+++ b/src/SessionSetup/include/SessionSetup/OtherUserDialog.h
@@ -20,7 +20,7 @@ namespace orbit_session_setup {
 
 class OtherUserDialog : public QDialog {
  public:
-  explicit OtherUserDialog(QString user_name, QWidget* parent = nullptr);
+  explicit OtherUserDialog(const QString& user_name, QWidget* parent = nullptr);
   ~OtherUserDialog() override;
 
   ErrorMessageOr<void> Exec();

--- a/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
+++ b/src/SessionSetup/include/SessionSetup/SessionSetupDialog.h
@@ -77,7 +77,7 @@ class SessionSetupDialog : public QDialog {
   void SetupLocalStates();
   void SetTargetAndStateMachineInitialState(SshTarget target);
   void SetTargetAndStateMachineInitialState(LocalTarget target);
-  void SetTargetAndStateMachineInitialState(FileTarget target);
+  void SetTargetAndStateMachineInitialState(const FileTarget& target);
 };
 
 }  // namespace orbit_session_setup


### PR DESCRIPTION
There was one result of const std::vector& that I changed to absl::Span.

Test: Compile