### PR TITLE
Rename States in OrbitSshQt

### DIFF
--- a/src/OrbitSshQt/Session.cpp
+++ b/src/OrbitSshQt/Session.cpp
@@ -19,7 +19,7 @@ namespace orbit_ssh_qt {
 
 outcome::result<void> Session::startup() {
   switch (CurrentState()) {
-    case State::kInitial:
+    case State::kInitialized:
     case State::kDisconnected: {
       OUTCOME_TRY(auto&& socket, orbit_ssh::Socket::Create());
       socket_ = std::move(socket);
@@ -59,9 +59,9 @@ outcome::result<void> Session::startup() {
     }
     case State::kStarted:
     case State::kConnected:
-    case State::kShutdown:
+    case State::kStopping:
     case State::kAboutToDisconnect:
-    case State::kDone:
+    case State::kStopped:
     case State::kError:
       ORBIT_UNREACHABLE();
   }
@@ -71,7 +71,7 @@ outcome::result<void> Session::startup() {
 
 outcome::result<void> Session::shutdown() {
   switch (CurrentState()) {
-    case State::kInitial:
+    case State::kInitialized:
     case State::kDisconnected:
     case State::kSocketCreated:
     case State::kSocketConnected:
@@ -81,16 +81,16 @@ outcome::result<void> Session::shutdown() {
     case State::kStarted:
     case State::kConnected:
       ORBIT_UNREACHABLE();
-    case State::kShutdown:
+    case State::kStopping:
     case State::kAboutToDisconnect: {
       OUTCOME_TRY(session_->Disconnect());
       notifiers_ = std::nullopt;
       socket_ = std::nullopt;
       session_ = std::nullopt;
-      SetState(State::kDone);
+      SetState(State::kStopped);
       ABSL_FALLTHROUGH_INTENDED;
     }
-    case State::kDone:
+    case State::kStopped:
       break;
     case State::kError:
       ORBIT_UNREACHABLE();

--- a/src/OrbitSshQt/SftpCopyToRemoteOperation.cpp
+++ b/src/OrbitSshQt/SftpCopyToRemoteOperation.cpp
@@ -54,7 +54,7 @@ outcome::result<void> SftpCopyToRemoteOperation::startup() {
   }
 
   switch (CurrentState()) {
-    case State::kInitial:
+    case State::kInitialized:
     case State::kNoOperation: {
       local_file_.setFileName(QString::fromStdString(source_.string()));
       const auto open_result = local_file_.open(QIODevice::ReadOnly);
@@ -103,11 +103,11 @@ outcome::result<void> SftpCopyToRemoteOperation::startup() {
     case State::kRemoteFileClosed: {
       local_file_.close();
       about_to_shutdown_connection_ = std::nullopt;
-      SetState(State::kDone);
+      SetState(State::kStopped);
       ABSL_FALLTHROUGH_INTENDED;
     }
-    case State::kShutdown:
-    case State::kDone:
+    case State::kStopping:
+    case State::kStopped:
       break;
     case State::kError:
       ORBIT_UNREACHABLE();

--- a/src/OrbitSshQt/include/OrbitSshQt/Session.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Session.h
@@ -23,7 +23,7 @@
 namespace orbit_ssh_qt {
 namespace details {
 enum class SessionState {
-  kInitial,
+  kInitialized,
   kDisconnected,
   kSocketCreated,
   kSocketConnected,
@@ -32,9 +32,9 @@ enum class SessionState {
   kMatchedKnownHosts,
   kStarted,
   kConnected,
-  kShutdown,
+  kStopping,
   kAboutToDisconnect,
-  kDone,
+  kStopped,
   kError
 };
 }  // namespace details

--- a/src/OrbitSshQt/include/OrbitSshQt/SftpChannel.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpChannel.h
@@ -20,13 +20,13 @@
 namespace orbit_ssh_qt {
 namespace details {
 enum class SftpChannelState {
-  kInitial,
+  kInitialized,
   kNoChannel,
   kStarted,
   kChannelInitialized,
-  kShutdown,
+  kStopping,
   kClosingChannel,
-  kDone,
+  kStopped,
   kError
 };
 }  // namespace details

--- a/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
@@ -24,16 +24,16 @@
 namespace orbit_ssh_qt {
 namespace details {
 enum class SftpCopyToLocalOperationState {
-  kInitial,
+  kInitialized,
   kOpenRemoteFile,
   kOpenLocalFile,
   kStarted,  // This is the running state, where the data transfer happens
-  kShutdown,
+  kStopping,
   kCloseAndDeletePartialFile,
   kCloseLocalFile,
   kCloseRemoteFile,
   kCloseEventConnections,
-  kDone,
+  kStopped,
   kError
 };
 }  // namespace details

--- a/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToRemoteOperation.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToRemoteOperation.h
@@ -24,15 +24,15 @@
 namespace orbit_ssh_qt {
 namespace details {
 enum class SftpCopyToRemoteOperationState {
-  kInitial,
+  kInitialized,
   kNoOperation,
   kStarted,
   kLocalFileOpened,
   kRemoteFileOpened,
   kRemoteFileWritten,
   kRemoteFileClosed,
-  kShutdown,
-  kDone,
+  kStopping,
+  kStopped,
   kError
 };
 }  // namespace details

--- a/src/OrbitSshQt/include/OrbitSshQt/Task.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Task.h
@@ -25,16 +25,17 @@
 namespace orbit_ssh_qt {
 namespace details {
 enum class TaskState {
-  kInitial,
+  kInitialized,
   kNoChannel,
   kChannelInitialized,
   kStarted,
   kCommandRunning,
-  kShutdown,
+  kStopping,
   kSignalEOF,
   kWaitRemoteEOF,
   kSignalChannelClose,
   kWaitChannelClosed,
+  kStopped,
   kChannelClosed,
   kError
 };

--- a/src/OrbitSshQt/include/OrbitSshQt/Tunnel.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Tunnel.h
@@ -26,18 +26,18 @@
 namespace orbit_ssh_qt {
 namespace details {
 enum class TunnelState {
-  kInitial,
+  kInitialized,
   kNoChannel,
   kChannelInitialized,
   kStarted,
   kServerListening,
-  kShutdown,
+  kStopping,
   kFlushing,
   kSendEOF,
   kWaitRemoteEOF,
   kClosingChannel,
   kWaitRemoteClosed,
-  kDone,
+  kStopped,
   kError
 };
 }  // namespace details


### PR DESCRIPTION
This is making the discussed changes to the names of the states in StateMachineHelper. It also introduces the `kStopped` marker which avoid the `PreviousState` hack for the predicates.