### PR TITLE
Clear function selection on new data in live tab

### DIFF
--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -176,5 +176,6 @@ void OrbitLiveFunctions::ShowHistogram(const std::vector<uint64_t>* data, std::s
 
 void OrbitLiveFunctions::SetScopeStatsCollection(
     std::shared_ptr<const orbit_client_data::ScopeStatsCollection> scope_collection) {
+  ui_->data_view_panel_->GetTreeView()->selectionModel()->clearSelection();
   live_functions_->SetScopeStatsCollection(std::move(scope_collection));
 }


### PR DESCRIPTION
This selection is on row which can change if the data changes and causes odd results.

Bug: http://b/240112049