### PR TITLE
Remove track tab and rounded corners

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -159,7 +159,8 @@ void CaptureWindow::MouseMoved(int x, int y, bool left, bool right, bool middle)
 
   // Update selection timestamps
   if (is_selecting_) {
-    select_stop_time_ = time_graph_->GetTickFromWorld(select_stop_pos_world_[0]);
+    select_stop_time_ = time_graph_->GetTickFromWorld(
+        time_graph_->ClampToTimelineUiElementWorldX(select_stop_pos_world_[0]));
   }
 }
 
@@ -260,7 +261,8 @@ void CaptureWindow::PostRender(QPainter* painter) {
 void CaptureWindow::RightDown(int x, int y) {
   GlCanvas::RightDown(x, y);
   if (time_graph_ != nullptr) {
-    select_start_time_ = time_graph_->GetTickFromWorld(select_start_pos_world_[0]);
+    select_start_time_ = time_graph_->GetTickFromWorld(
+        time_graph_->ClampToTimelineUiElementWorldX(select_start_pos_world_[0]));
   }
 }
 
@@ -725,8 +727,11 @@ void CaptureWindow::RenderSelectionOverlay() {
   uint64_t max_time = std::max(select_start_time_, select_stop_time_);
 
   float from_world = time_graph_->GetWorldFromTick(min_time);
+  from_world = time_graph_->ClampToTimelineUiElementWorldX(from_world);
   float to_world = time_graph_->GetWorldFromTick(max_time);
+  to_world = time_graph_->ClampToTimelineUiElementWorldX(to_world);
   float stop_pos_world = time_graph_->GetWorldFromTick(select_stop_time_);
+  stop_pos_world = time_graph_->ClampToTimelineUiElementWorldX(stop_pos_world);
 
   float size_x = to_world - from_world;
   // TODO(http://b/226401787): Allow green selection overlay to be on top of the Timeline after

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -495,6 +495,13 @@ void CaptureWindow::Draw(QPainter* painter) {
   uint64_t start_time_ns = orbit_base::CaptureTimestampNs();
   bool time_graph_was_redrawn = time_graph_ != nullptr && time_graph_->IsRedrawNeeded();
 
+  if (time_graph_layout_->GetDrawAsIfPicking()) {
+    debug_picking_mode_ = PickingMode::kClick;
+    picking_mode_ = PickingMode::kClick;
+  } else {
+    debug_picking_mode_ = PickingMode::kNone;
+  }
+    
   text_renderer_.Init();
 
   if (ShouldSkipRendering()) {

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -495,11 +495,9 @@ void CaptureWindow::Draw(QPainter* painter) {
   uint64_t start_time_ns = orbit_base::CaptureTimestampNs();
   bool time_graph_was_redrawn = time_graph_ != nullptr && time_graph_->IsRedrawNeeded();
 
-  if (time_graph_layout_->GetDrawAsIfPicking()) {
-    debug_picking_mode_ = PickingMode::kClick;
+  draw_as_if_picking_ = time_graph_layout_->GetDrawAsIfPicking();
+  if (draw_as_if_picking_) {
     picking_mode_ = PickingMode::kClick;
-  } else {
-    debug_picking_mode_ = PickingMode::kNone;
   }
 
   text_renderer_.Init();

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -501,7 +501,7 @@ void CaptureWindow::Draw(QPainter* painter) {
   } else {
     debug_picking_mode_ = PickingMode::kNone;
   }
-    
+
   text_renderer_.Init();
 
   if (ShouldSkipRendering()) {

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -64,7 +64,7 @@ class NavigationTestCaptureWindow : public testing::Test {
     ORBIT_CHECK(capture_window_.GetTimeGraph()->GetTimelineUi()->GetHeight() <
                 kViewportHeight - kBottomSafetyMargin);
     ORBIT_CHECK(capture_window_.GetTimeGraph()->GetTimelineUi()->GetPos()[0] ==
-                time_graph_layout_.GetLeftMargin());
+                time_graph_layout_.GetTrackHeaderWidth());
   }
 
  protected:

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -219,10 +219,10 @@ void FrameTrack::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& t
   const Color black_color(0, 0, 0, 255);
   const Vec2 pos = GetPos();
 
-  const float x = pos[0];
+  const float x = pos[0] + header_->GetWidth();
   const float y = pos[1] + GetHeightAboveTimers() + GetMaximumBoxHeight() - GetAverageBoxHeight();
   Vec2 from(x, y);
-  Vec2 to(x + GetWidth(), y);
+  Vec2 to(pos[0] + GetWidth(), y);
   float text_z = GlCanvas::kZValueTrackText;
 
   std::string avg_time =
@@ -230,7 +230,7 @@ void FrameTrack::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& t
   std::string label = absl::StrFormat("Avg: %s", avg_time);
   uint32_t font_size = layout_->GetFontSize();
   float string_width = text_renderer.GetStringWidth(label.c_str(), font_size);
-  Vec2 white_text_box_position(pos[0] + layout_->GetRightMargin(), y);
+  Vec2 white_text_box_position(x + layout_->GetRightMargin(), y);
 
   primitive_assembler.AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z,
                               white_color);

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -30,6 +30,7 @@ float GlCanvas::kZValueEventBar = 0.03f;
 float GlCanvas::kZValueBox = 0.05f;
 float GlCanvas::kZValueEvent = 0.06f;
 float GlCanvas::kZValueBoxBorder = 0.07f;
+float GlCanvas::kZValueTrackHeader = 0.075f;
 float GlCanvas::kZValueTrackText = 0.08f;
 float GlCanvas::kZValueTrackLabel = 0.09f;
 float GlCanvas::kZValueTimeBar = 0.31f;

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -236,9 +236,7 @@ void GlCanvas::PostRender(QPainter* painter) {
     can_hover_ = false;
   }
 
-  bool is_debug_rendering = debug_picking_mode_ != PickingMode::kNone;
-
-  if (!is_debug_rendering && prev_picking_mode != PickingMode::kNone) {
+  if (!draw_as_if_picking_ && prev_picking_mode != PickingMode::kNone) {
     Pick(prev_picking_mode, mouse_move_pos_screen_[0], mouse_move_pos_screen_[1]);
     GlCanvas::Render(painter, viewport_.GetScreenWidth(), viewport_.GetScreenHeight());
   }

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -236,7 +236,9 @@ void GlCanvas::PostRender(QPainter* painter) {
     can_hover_ = false;
   }
 
-  if (prev_picking_mode != PickingMode::kNone) {
+  bool is_debug_rendering = debug_picking_mode_ != PickingMode::kNone;
+
+  if (!is_debug_rendering && prev_picking_mode != PickingMode::kNone) {
     Pick(prev_picking_mode, mouse_move_pos_screen_[0], mouse_move_pos_screen_[1]);
     GlCanvas::Render(painter, viewport_.GetScreenWidth(), viewport_.GetScreenHeight());
   }

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -112,15 +112,14 @@ float GpuDebugMarkerTrack::GetYFromDepth(uint32_t depth) const {
   if (IsCollapsed()) {
     depth = 0;
   }
-  return GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
-         layout_->GetTextBoxHeight() * depth;
+  return GetPos()[1] + layout_->GetTrackContentTopMargin() + layout_->GetTextBoxHeight() * depth;
 }
 
 float GpuDebugMarkerTrack::GetHeight() const {
   bool collapsed = IsCollapsed();
   uint32_t depth = collapsed ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
-  return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
-         layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
+  return layout_->GetTrackContentTopMargin() + layout_->GetTextBoxHeight() * depth +
+         layout_->GetTrackContentBottomMargin();
 }
 
 bool GpuDebugMarkerTrack::TimerFilter(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -183,9 +183,8 @@ float GpuSubmissionTrack::GetHeight() const {
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
     depth *= 2;
   }
-  return layout_->GetTrackContentTopMargin() +
-         layout_->GetTextBoxHeight() * depth + (num_gaps * layout_->GetSpaceBetweenGpuDepths()) +
-         layout_->GetTrackContentBottomMargin();
+  return layout_->GetTrackContentTopMargin() + layout_->GetTextBoxHeight() * depth +
+         (num_gaps * layout_->GetSpaceBetweenGpuDepths()) + layout_->GetTrackContentBottomMargin();
 }
 
 const TimerInfo* GpuSubmissionTrack::GetLeft(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -183,7 +183,7 @@ float GpuSubmissionTrack::GetHeight() const {
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
     depth *= 2;
   }
-  return header_->GetHeight() + layout_->GetTrackContentTopMargin() +
+  return layout_->GetTrackContentTopMargin() +
          layout_->GetTextBoxHeight() * depth + (num_gaps * layout_->GetSpaceBetweenGpuDepths()) +
          layout_->GetTrackContentBottomMargin();
 }

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -113,14 +113,13 @@ float GpuTrack::GetHeight() const {
   }
   float height = 0;
   if (submission_track_->ShouldBeRendered()) {
-    height += submission_track_->GetHeight();
-    height += layout_->GetSpaceBetweenSubtracks();
+    float additional_height = submission_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
+    height += std::max(additional_height, 2.f * layout_->GetThreadTrackMinimumHeight());
   }
   if (marker_track_->ShouldBeRendered()) {
-    height += marker_track_->GetHeight();
-    height += layout_->GetSpaceBetweenSubtracks();
+    float additional_height = marker_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
+    height += std::max(additional_height, 2.f * layout_->GetThreadTrackMinimumHeight());
   }
-  height = std::max(height, 2.f * layout_->GetThreadTrackMinimumHeight());
   return height;
 }
 

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -95,7 +95,7 @@ void GpuTrack::UpdatePositionOfSubtracks() {
   submission_track_->SetHeadless(false);
   submission_track_->SetIndentationLevel(indentation_level_ + 1);
 
-  float current_y = pos[1] + layout_->GetTrackTabHeight();
+  float current_y = pos[1];
   if (submission_track_->ShouldBeRendered()) {
     current_y += layout_->GetSpaceBetweenSubtracks();
   }
@@ -111,7 +111,7 @@ float GpuTrack::GetHeight() const {
   if (IsCollapsed()) {
     return submission_track_->GetHeight();
   }
-  float height = layout_->GetTrackTabHeight();
+  float height = 0;
   if (submission_track_->ShouldBeRendered()) {
     height += submission_track_->GetHeight();
     height += layout_->GetSpaceBetweenSubtracks();

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -120,6 +120,7 @@ float GpuTrack::GetHeight() const {
     height += marker_track_->GetHeight();
     height += layout_->GetSpaceBetweenSubtracks();
   }
+  height = std::max(height, 2.f * layout_->GetThreadTrackMinimumHeight());
   return height;
 }
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -231,7 +231,7 @@ void GraphTrack<Dimension>::DrawLegend(PrimitiveAssembler& primitive_assembler,
   const float space_between_legend_entries = layout_->GetGenericFixedSpacerWidth() * 2;
   const float legend_symbol_height = GetLegendHeight();
   const float legend_symbol_width = legend_symbol_height;
-  float x0 = GetPos()[0] + +header_->GetWidth() + layout_->GetRightMargin();
+  float x0 = GetPos()[0] + header_->GetWidth() + layout_->GetRightMargin();
   const float y0 = header_->GetPos()[1] + layout_->GetTrackContentTopMargin();
   uint32_t font_size = GetLegendFontSize(indentation_level_);
   const Color fully_transparent(255, 255, 255, 0);

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -100,6 +100,7 @@ void GraphTrack<Dimension>::DoUpdatePrimitives(PrimitiveAssembler& primitive_ass
 
   float content_height = GetGraphContentHeight();
   Vec2 content_pos = GetPos();
+  content_pos[0] += header_->GetWidth();
   Quad box = MakeBox(content_pos, Vec2(GetWidth(), content_height + GetLegendHeight()));
   primitive_assembler.AddBox(box, track_z, GetTrackBackgroundColor(), shared_from_this());
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -61,8 +61,7 @@ float GraphTrack<Dimension>::GetHeight() const {
   float height_above_content =
       GetLegendHeight() + (HasLegend() ? 2.f : 1.f) * layout_->GetTrackContentTopMargin();
 
-  return layout_->GetTrackTabHeight() + height_above_content + GetGraphContentHeight() +
-         layout_->GetTrackContentBottomMargin();
+  return height_above_content + GetGraphContentHeight() + layout_->GetTrackContentBottomMargin();
 }
 
 template <size_t Dimension>
@@ -101,7 +100,6 @@ void GraphTrack<Dimension>::DoUpdatePrimitives(PrimitiveAssembler& primitive_ass
 
   float content_height = GetGraphContentHeight();
   Vec2 content_pos = GetPos();
-  content_pos[1] += layout_->GetTrackTabHeight();
   Quad box = MakeBox(content_pos, Vec2(GetWidth(), content_height + GetLegendHeight()));
   primitive_assembler.AddBox(box, track_z, GetTrackBackgroundColor(), shared_from_this());
 
@@ -194,7 +192,8 @@ void GraphTrack<Dimension>::DrawMouseLabel(PrimitiveAssembler& primitive_assembl
   float arrow_width = text_box_size[1] / 2.f;
   Vec2 arrow_box_size(text_box_size[0] + text_left_margin + text_right_margin,
                       text_box_size[1] + text_top_margin + text_bottom_margin);
-  bool arrow_is_left_directed = target_point_pos[0] < arrow_box_size[0] + arrow_width;
+  bool arrow_is_left_directed =
+      target_point_pos[0] < (header_->GetWidth() + arrow_box_size[0] + arrow_width);
   Vec2 text_box_position(
       target_point_pos[0] + (arrow_is_left_directed
                                  ? arrow_width + text_left_margin

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -231,8 +231,8 @@ void GraphTrack<Dimension>::DrawLegend(PrimitiveAssembler& primitive_assembler,
   const float space_between_legend_entries = layout_->GetGenericFixedSpacerWidth() * 2;
   const float legend_symbol_height = GetLegendHeight();
   const float legend_symbol_width = legend_symbol_height;
-  float x0 = GetPos()[0] + layout_->GetRightMargin();
-  const float y0 = header_->GetPos()[1] + header_->GetHeight() - layout_->GetTextBoxHeight();
+  float x0 = GetPos()[0] + +header_->GetWidth() + layout_->GetRightMargin();
+  const float y0 = header_->GetPos()[1] + layout_->GetTrackContentTopMargin();
   uint32_t font_size = GetLegendFontSize(indentation_level_);
   const Color fully_transparent(255, 255, 255, 0);
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -231,8 +231,7 @@ void GraphTrack<Dimension>::DrawLegend(PrimitiveAssembler& primitive_assembler,
   const float legend_symbol_height = GetLegendHeight();
   const float legend_symbol_width = legend_symbol_height;
   float x0 = GetPos()[0] + layout_->GetRightMargin();
-  const float y0 =
-      header_->GetPos()[1] + header_->GetHeight() + layout_->GetTrackContentTopMargin();
+  const float y0 = header_->GetPos()[1] + header_->GetHeight() - layout_->GetTextBoxHeight();
   uint32_t font_size = GetLegendFontSize(indentation_level_);
   const Color fully_transparent(255, 255, 255, 0);
 

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -45,7 +45,7 @@ float PageFaultsTrack::GetHeight() const {
     return major_page_faults_track_->GetHeight();
   }
 
-  float height = layout_->GetTrackTabHeight();
+  float height = 0;
   if (major_page_faults_track_->ShouldBeRendered()) {
     height += major_page_faults_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
   }
@@ -87,7 +87,7 @@ void PageFaultsTrack::UpdatePositionOfSubtracks() {
   minor_page_faults_track_->SetVisible(true);
   minor_page_faults_track_->SetIndentationLevel(indentation_level_ + 1);
 
-  float current_y = pos[1] + layout_->GetTrackTabHeight();
+  float current_y = pos[1];
   if (major_page_faults_track_->ShouldBeRendered()) {
     current_y += layout_->GetSpaceBetweenSubtracks();
   }

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -71,8 +71,9 @@ void SchedulerTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   visible_timer_count_ = 0;
 
   const internal::DrawData draw_data =
-      GetDrawData(min_tick, max_tick, GetPos()[0], GetWidth(), &primitive_assembler, timeline_info_,
-                  viewport_, IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
+      GetDrawData(min_tick, max_tick, GetPos()[0] + header_->GetWidth(),
+                  GetWidth() - header_->GetWidth(), &primitive_assembler, timeline_info_, viewport_,
+                  IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
                   app_->GetGroupIdToHighlight(), app_->GetHistogramSelectionRange());
 
   const uint32_t resolution_in_pixels = viewport_->WorldToScreen({GetWidth(), 0})[0];

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -327,9 +327,10 @@ float ThreadTrack::GetHeight() const {
   bool gap_between_tracks_and_timers =
       (!thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty()) &&
       (depth > 0);
-  return GetHeightAboveTimers() +
+  float height = GetHeightAboveTimers() +
          (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenThreadPanes() : 0) +
          layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
+  return std::max(height, layout_->GetThreadTrackMinimumHeight());
 }
 
 float ThreadTrack::GetHeightAboveTimers() const {

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -328,8 +328,8 @@ float ThreadTrack::GetHeight() const {
       (!thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty()) &&
       (depth > 0);
   float height = GetHeightAboveTimers() +
-         (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenThreadPanes() : 0) +
-         layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
+                 (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenThreadPanes() : 0) +
+                 layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
   return std::max(height, layout_->GetThreadTrackMinimumHeight());
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -269,20 +269,21 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   const float event_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const float space_between_subtracks = layout_->GetSpaceBetweenThreadPanes();
 
-  const Vec2 pos = GetPos();
+  Vec2 pos = GetPos();
+  pos[0] += header_->GetWidth();
   float current_y = GetPos()[1] + layout_->GetTrackContentTopMargin();
 
-  thread_state_bar_->SetPos(pos[0] + header_->GetWidth(), current_y);
+  thread_state_bar_->SetPos(pos[0], current_y);
   if (thread_state_bar_->ShouldBeRendered()) {
     current_y += (space_between_subtracks + thread_state_track_height);
   }
 
-  event_bar_->SetPos(pos[0] + header_->GetWidth(), current_y);
+  event_bar_->SetPos(pos[0], current_y);
   if (event_bar_->ShouldBeRendered()) {
     current_y += (space_between_subtracks + event_track_height);
   }
 
-  tracepoint_bar_->SetPos(pos[0] + header_->GetWidth(), current_y);
+  tracepoint_bar_->SetPos(pos[0], current_y);
 }
 
 void ThreadTrack::SelectTrack() { app_->set_selected_thread_id(GetThreadId()); }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -35,7 +35,6 @@
 #include "OrbitGl/TimeGraphLayout.h"
 #include "OrbitGl/TimerTrack.h"
 #include "OrbitGl/Track.h"
-#include "OrbitGl/TrackHeader.h"
 #include "OrbitGl/Viewport.h"
 
 using orbit_client_data::FunctionInfo;
@@ -271,8 +270,7 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   const float space_between_subtracks = layout_->GetSpaceBetweenThreadPanes();
 
   const Vec2 pos = GetPos();
-  float current_y =
-      header_->GetPos()[1] + header_->GetHeight() + layout_->GetTrackContentTopMargin();
+  float current_y = GetPos()[1] + layout_->GetTrackContentTopMargin();
 
   thread_state_bar_->SetPos(pos[0], current_y);
   if (thread_state_bar_->ShouldBeRendered()) {
@@ -340,7 +338,7 @@ float ThreadTrack::GetHeightAboveTimers() const {
   const float tracepoint_track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const float space_between_subtracks = layout_->GetSpaceBetweenThreadPanes();
 
-  float header_height = header_->GetHeight() + layout_->GetTrackContentTopMargin();
+  float header_height = layout_->GetTrackContentTopMargin();
   int track_count = 0;
   if (!thread_state_bar_->IsEmpty()) {
     header_height += thread_state_track_height;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -272,17 +272,17 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   const Vec2 pos = GetPos();
   float current_y = GetPos()[1] + layout_->GetTrackContentTopMargin();
 
-  thread_state_bar_->SetPos(pos[0], current_y);
+  thread_state_bar_->SetPos(pos[0] + header_->GetWidth(), current_y);
   if (thread_state_bar_->ShouldBeRendered()) {
     current_y += (space_between_subtracks + thread_state_track_height);
   }
 
-  event_bar_->SetPos(pos[0], current_y);
+  event_bar_->SetPos(pos[0] + header_->GetWidth(), current_y);
   if (event_bar_->ShouldBeRendered()) {
     current_y += (space_between_subtracks + event_track_height);
   }
 
-  tracepoint_bar_->SetPos(pos[0], current_y);
+  tracepoint_bar_->SetPos(pos[0] + header_->GetWidth(), current_y);
 }
 
 void ThreadTrack::SelectTrack() { app_->set_selected_thread_id(GetThreadId()); }
@@ -386,8 +386,9 @@ void ThreadTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   visible_timer_count_ = 0;
 
   const internal::DrawData draw_data =
-      GetDrawData(min_tick, max_tick, GetPos()[0], GetWidth(), &primitive_assembler, timeline_info_,
-                  viewport_, IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
+      GetDrawData(min_tick, max_tick, GetPos()[0] + header_->GetWidth(),
+                  GetWidth() - header_->GetWidth(), &primitive_assembler, timeline_info_, viewport_,
+                  IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
                   app_->GetGroupIdToHighlight(), app_->GetHistogramSelectionRange());
 
   uint64_t resolution_in_pixels = draw_data.viewport->WorldToScreen({draw_data.track_width, 0})[0];

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -882,7 +882,9 @@ void TimeGraph::DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
   // TODO(http://b/217719000): We are drawing boxes in margin positions because some elements are
   // being drawn partially outside the TrackContainer space. This hack is needed until we assure
   // that no element is drawn outside of its parent's area.
-  DrawMarginsBetweenChildren(primitive_assembler);
+  if (layout_->GetDrawTimeGraphMasks()) {
+    DrawMarginsBetweenChildren(primitive_assembler);
+  }
 }
 
 void TimeGraph::DrawMarginsBetweenChildren(

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -895,7 +895,7 @@ void TimeGraph::DrawMarginsBetweenChildren(
 
   // Right margin mask for Timegraph.
   float right_margin_width = GetRightMargin();
-  float right_margin_height = GetHeight() - timeline_ui_->GetHeight();
+  float right_margin_height = GetHeight();
   Vec2 right_margin_pos{GetWidth() - right_margin_width, GetPos()[1]};
   Quad right_margin_box = MakeBox(right_margin_pos, Vec2(right_margin_width, right_margin_height));
   primitive_assembler.AddBox(right_margin_box, GlCanvas::kZValueMargin, GlCanvas::kBackgroundColor);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -426,7 +426,7 @@ float TimeGraph::GetWorldFromTick(uint64_t time) const {
     double start = TicksToMicroseconds(capture_min_timestamp_, time) - min_time_us_;
     double normalized_start = start / time_window_us;
     float pos =
-        layout_->GetLeftMargin() + static_cast<float>(normalized_start * GetTimelineWidth());
+        layout_->GetTrackHeaderWidth() + static_cast<float>(normalized_start * GetTimelineWidth());
     return pos;
   }
 
@@ -720,8 +720,8 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
   float timegraph_current_y = GetPos()[1];
   const float total_right_margin = layout_->GetRightMargin() + vertical_slider_->GetWidth();
 
-  timeline_ui_->SetWidth(GetWidth() - total_right_margin - layout_->GetLeftMargin());
-  timeline_ui_->SetPos(timegraph_current_x + layout_->GetLeftMargin(), timegraph_current_y);
+  timeline_ui_->SetWidth(GetWidth() - total_right_margin - layout_->GetTrackHeaderWidth());
+  timeline_ui_->SetPos(timegraph_current_x + layout_->GetTrackHeaderWidth(), timegraph_current_y);
 
   plus_button_->SetWidth(layout_->GetButtonWidth());
   plus_button_->SetHeight(layout_->GetButtonHeight());
@@ -735,17 +735,16 @@ void TimeGraph::UpdateChildrenPosAndContainerSize() {
   timegraph_current_y += timeline_ui_->GetHeight() + layout_->GetSpaceBetweenTracksAndTimeline();
   track_container_->SetWidth(GetWidth() - total_right_margin);
   track_container_->SetPos(timegraph_current_x, timegraph_current_y);
-  track_container_->SetHeaderWidth(layout_->GetLeftMargin());
 
   vertical_slider_->SetWidth(layout_->GetSliderWidth());
   vertical_slider_->SetPos(GetWidth() - vertical_slider_->GetWidth(), timegraph_current_y);
 
   timegraph_current_y += track_container_->GetHeight();
-  float slider_width = GetWidth() - vertical_slider_->GetWidth() - layout_->GetLeftMargin();
+  float slider_width = GetWidth() - vertical_slider_->GetWidth() - layout_->GetTrackHeaderWidth();
   horizontal_slider_->SetWidth(slider_width);
   // The horizontal slider should be at the bottom of the TimeGraph. Because how OpenGl renders, the
   // way to assure that there is no pixels below the scrollbar is by making a ceiling.
-  horizontal_slider_->SetPos(timegraph_current_x + layout_->GetLeftMargin(),
+  horizontal_slider_->SetPos(timegraph_current_x + layout_->GetTrackHeaderWidth(),
                              std::ceil(GetHeight() - horizontal_slider_->GetHeight()));
 
   // TODO(b/230442062): Refactor this to be part of Slider::UpdateLayout().
@@ -902,7 +901,7 @@ void TimeGraph::DrawMarginsBetweenChildren(
   primitive_assembler.AddBox(right_margin_box, GlCanvas::kZValueMargin, GlCanvas::kBackgroundColor);
 
   // Left margin mask for Timeline.
-  float left_margin_width = layout_->GetLeftMargin();
+  float left_margin_width = layout_->GetTrackHeaderWidth();
   float left_margin_height = timeline_ui_->GetHeight();
   Vec2 left_margin_pos = GetPos();
   Quad left_margin_box = MakeBox(left_margin_pos, Vec2(left_margin_width, left_margin_height));

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -280,8 +280,8 @@ void TimerTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   draw_data.primitive_assembler = &primitive_assembler;
   draw_data.viewport = viewport_;
 
-  draw_data.track_start_x = GetPos()[0];
-  draw_data.track_width = GetWidth();
+  draw_data.track_start_x = GetPos()[0] + header_->GetWidth();
+  draw_data.track_width = GetWidth() - header_->GetWidth();
   draw_data.inv_time_window = 1.0 / timeline_info_->GetTimeWindowUs();
   draw_data.is_collapsed = IsCollapsed();
 
@@ -298,7 +298,7 @@ void TimerTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   // out, many events will be discarded quickly.
   auto time_window_ns = static_cast<uint64_t>(1000 * timeline_info_->GetTimeWindowUs());
   draw_data.ns_per_pixel =
-      static_cast<double>(time_window_ns) / viewport_->WorldToScreen({GetWidth(), 0})[0];
+      static_cast<double>(time_window_ns) / viewport_->WorldToScreen({GetWidth() - header_->GetWidth(), 0})[0];
   draw_data.min_timegraph_tick = timeline_info_->GetTickFromUs(timeline_info_->GetMinTimeUs());
   draw_data.histogram_selection_range = app_->GetHistogramSelectionRange();
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -297,8 +297,8 @@ void TimerTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   // enough that all events are drawn as boxes, this has no effect. When zoomed
   // out, many events will be discarded quickly.
   auto time_window_ns = static_cast<uint64_t>(1000 * timeline_info_->GetTimeWindowUs());
-  draw_data.ns_per_pixel =
-      static_cast<double>(time_window_ns) / viewport_->WorldToScreen({GetWidth() - header_->GetWidth(), 0})[0];
+  draw_data.ns_per_pixel = static_cast<double>(time_window_ns) /
+                           viewport_->WorldToScreen({GetWidth() - header_->GetWidth(), 0})[0];
   draw_data.min_timegraph_tick = timeline_info_->GetTickFromUs(timeline_info_->GetMinTimeUs());
   draw_data.histogram_selection_range = app_->GetHistogramSelectionRange();
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -30,7 +30,6 @@
 #include "OrbitGl/OrbitApp.h"
 #include "OrbitGl/PrimitiveAssembler.h"
 #include "OrbitGl/TimeGraphLayout.h"
-#include "OrbitGl/TrackHeader.h"
 #include "OrbitGl/Viewport.h"
 
 using orbit_client_data::ScopeId;
@@ -378,9 +377,7 @@ std::string TimerTrack::GetBoxTooltip(const PrimitiveAssembler& /*primitive_asse
   return "";
 }
 
-float TimerTrack::GetHeightAboveTimers() const {
-  return header_->GetHeight() + layout_->GetTrackContentTopMargin();
-}
+float TimerTrack::GetHeightAboveTimers() const { return layout_->GetTrackContentTopMargin(); }
 
 internal::DrawData TimerTrack::GetDrawData(
     uint64_t min_tick, uint64_t max_tick, float track_pos_x, float track_width,

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -88,7 +88,7 @@ void Track::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_r
 void Track::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 
-  header_->SetWidth(layout_->GetLeftMargin());
+  header_->SetWidth(layout_->GetTrackHeaderWidth());
   header_->SetPos(GetPos()[0], GetPos()[1]);
   UpdatePositionOfSubtracks();
 }

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -89,6 +89,7 @@ void Track::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 
   header_->SetWidth(layout_->GetTrackHeaderWidth());
+  header_->SetHeight(GetHeight());
   header_->SetPos(GetPos()[0], GetPos()[1]);
   UpdatePositionOfSubtracks();
 }

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -57,57 +57,39 @@ void Track::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_r
 
   const float x0 = GetPos()[0];
   const float y0 = GetPos()[1];
-  const float header_height = header_->GetHeight();
   const float track_z = GlCanvas::kZValueTrack;
 
   Color track_background_color = GetTrackBackgroundColor();
 
   Vec2 track_size = GetSize();
 
-  // Draw rounded corners.
-  float radius = std::min(layout_->GetRoundingRadius(), layout_->GetTrackTabHeight() * 0.5f);
-  auto sides = static_cast<uint32_t>(layout_->GetRoundingNumSides() + 0.5f);
-  auto rounded_corner = orbit_gl::GetRoundedCornerMask(radius, sides);
-
   // This draws the non-tab content of the track. The tab itself is a separate CaptureViewElement
   // child of the track.
   // Note that the top-left corner is not rounded due to the design of the track tab sitting
   // in the top left.
   //
-  // [ Header ] ________________________  content_top_right
-  // |                                  `
-  // |XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
-  // \__________________________________/
-  // content_bottom_left                 content_bottom_right
+  //  ____________________________________________  content_top_right
+  // |         |                                  |
+  // | header  |XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
+  // |_________|__________________________________|
+  //            content_bottom_left                 content_bottom_right
   //
   Vec2 content_bottom_left(x0, y0 + track_size[1]);
   Vec2 content_bottom_right(x0 + track_size[0], y0 + track_size[1]);
 
-  // The track content starts underneath the track header, and we only draw the background
-  // starting
-  // there. This could be prevented by moving the track content into a separate child, but in the
-  // end, the design of track and track header will need to influence each other...
-  Vec2 content_top_right(x0 + track_size[0], y0 + header_height);
-  Vec2 content_top_left(x0, y0 + header_height);
-
-  auto shared_this = shared_from_this();
-  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_bottom_left,
-                            GlCanvas::kBackgroundColor, 0, track_z, shared_this);
-  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_bottom_right,
-                            GlCanvas::kBackgroundColor, -90.f, track_z, shared_this);
-  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_top_right,
-                            GlCanvas::kBackgroundColor, 180.f, track_z, shared_this);
+  Vec2 content_top_right(x0 + track_size[0], y0);
+  Vec2 content_top_left(x0, y0);
 
   // Draw track's content background.
-  Quad box = MakeBox(content_top_left, Vec2(GetWidth(), GetHeight() - header_height));
+  Quad box = MakeBox(content_top_left, Vec2(GetWidth(), GetHeight()));
   primitive_assembler.AddBox(box, track_z, track_background_color, shared_from_this());
 }
 
 void Track::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 
-  header_->SetWidth(layout_->GetTrackTabWidth());
-  header_->SetPos(GetPos()[0] + layout_->GetTrackTabOffset(), GetPos()[1]);
+  header_->SetWidth(layout_->GetLeftMargin());
+  header_->SetPos(GetPos()[0], GetPos()[1]);
   UpdatePositionOfSubtracks();
 }
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -55,7 +55,7 @@ void Track::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_r
   // Same for picking - the track background is not pickable
   if (picking || !draw_background) return;
 
-  const float x0 = GetPos()[0];
+  const float x0 = GetPos()[0] + header_->GetWidth();
   const float y0 = GetPos()[1];
   const float track_z = GlCanvas::kZValueTrack;
 

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -52,7 +52,7 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
   const float indentation_x0 =
       x0 + (track_->GetIndentationLevel() * layout_->GetTrackIndentOffset());
 
-  if (layout_->GetDrawTrackHeaderBackground()) {
+  if (track_->GetIndentationLevel() == 0 && layout_->GetDrawTrackHeaderBackground()) {
     Quad box = MakeBox(Vec2(indentation_x0, y0), Vec2(label_width, label_height));
     primitive_assembler.AddBox(box, track_z, track_->GetTrackBackgroundColor(), shared_from_this());
   }
@@ -80,7 +80,7 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
 
   text_renderer.AddTextTrailingCharsPrioritized(
       track_->GetLabel().c_str(), indentation_x0 + label_offset_x,
-      y0 + layout_->GetTextBoxHeight() * 0.5f, text_z, formatting,
+      y0 + layout_->GetTextBoxHeight() * 0.5f + GetVerticalLabelOffset(), text_z, formatting,
       track_->GetNumberOfPrioritizedTrailingCharacters());
 }
 
@@ -104,12 +104,19 @@ void TrackHeader::UpdateCollapseToggle() {
 
   collapse_toggle_->SetWidth(size);
   collapse_toggle_->SetHeight(size);
-  collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1]);
+  collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1] + GetVerticalLabelOffset());
 
   // Update the "collapsible" property of the triangle toggle to match the same property in the
   // parent track. This makes sure that changes to the track "collapsible" property are correctly
   // disabling the triangle toggle, even if they change during runtime.
   collapse_toggle_->SetIsCollapsible(track_->IsCollapsible());
+}
+
+float TrackHeader::GetVerticalLabelOffset() const {
+  // This offset only affect subtracks, which are a very special case that need refactoring. 
+  // Subtracks are only used for the memory track. The following offset is to avoid overlap between 
+  // the labels of the track and it's subtrack. Subtracks should have their own header altogether.
+  return track_->GetIndentationLevel() > 0 ? layout_->GetTextBoxHeight() : 0.f;
 }
 
 void TrackHeader::OnDrag(int x, int y) {

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -51,8 +51,11 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
 
   const float indentation_x0 =
       x0 + (track_->GetIndentationLevel() * layout_->GetTrackIndentOffset());
-  Quad box = MakeBox(Vec2(indentation_x0, y0), Vec2(label_width, label_height));
-  primitive_assembler.AddBox(box, track_z, track_->GetTrackBackgroundColor(), shared_from_this());
+
+  if (layout_->GetDrawTrackHeaderBackground()) {
+    Quad box = MakeBox(Vec2(indentation_x0, y0), Vec2(label_width, label_height));
+    primitive_assembler.AddBox(box, track_z, track_->GetTrackBackgroundColor(), shared_from_this());
+  }
 
   // Early-out: In picking mode, don't draw the text.
   if (picking) {

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -113,8 +113,8 @@ void TrackHeader::UpdateCollapseToggle() {
 }
 
 float TrackHeader::GetVerticalLabelOffset() const {
-  // This offset only affect subtracks, which are a very special case that need refactoring. 
-  // Subtracks are only used for the memory track. The following offset is to avoid overlap between 
+  // This offset only affect subtracks, which are a very special case that need refactoring.
+  // Subtracks are only used for the memory track. The following offset is to avoid overlap between
   // the labels of the track and it's subtrack. Subtracks should have their own header altogether.
   return track_->GetIndentationLevel() > 0 ? layout_->GetTextBoxHeight() : 0.f;
 }

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -91,7 +91,10 @@ void TrackHeader::UpdateCollapseToggle() {
   const float x0 = GetPos()[0] + layout_->GetTrackIndentOffset() * track_->GetIndentationLevel();
   const float button_offset = layout_->GetCollapseButtonOffset();
   const float size = layout_->GetCollapseButtonSize(track_->GetIndentationLevel());
-  const float toggle_y_pos = GetPos()[1] + layout_->GetTextBoxHeight() * 0.5f;
+  
+  constexpr float kOffsetY = 1.f;
+  const float toggle_y_pos = GetPos()[1] + layout_->GetTextBoxHeight()*0.5f - size*0.5f + kOffsetY;
+  
   Vec2 toggle_pos = Vec2(x0 + button_offset, toggle_y_pos);
 
   collapse_toggle_->SetWidth(size);

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -46,7 +46,7 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
   const float text_z = GlCanvas::kZValueTrackText;
 
   // Draw tab background
-  const float label_height = GetParent()->GetHeight();
+  const float label_height = height_;
   const float label_width = GetWidth();
 
   const float indentation_x0 =
@@ -94,17 +94,16 @@ void TrackHeader::UpdateCollapseToggle() {
   const float x0 = GetPos()[0] + layout_->GetTrackIndentOffset() * track_->GetIndentationLevel();
   const float size = layout_->GetCollapseButtonSize(track_->GetIndentationLevel());
 
-  constexpr float kOffsetX = -0.5f;
   constexpr float kOffsetY = 1.f;
-  const float toggle_x_pos = x0 + layout_->GetCollapseButtonOffset() + kOffsetX;
+  const float toggle_x_pos = x0 + layout_->GetCollapseButtonOffset();
   const float toggle_y_pos =
       GetPos()[1] + layout_->GetTextBoxHeight() * 0.5f - size * 0.5f + kOffsetY;
 
-  Vec2 toggle_pos = Vec2(toggle_x_pos, toggle_y_pos);
+  Vec2 toggle_pos = Vec2(toggle_x_pos, toggle_y_pos + GetVerticalLabelOffset());
 
   collapse_toggle_->SetWidth(size);
   collapse_toggle_->SetHeight(size);
-  collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1] + GetVerticalLabelOffset());
+  collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1]);
 
   // Update the "collapsible" property of the triangle toggle to match the same property in the
   // parent track. This makes sure that changes to the track "collapsible" property are correctly
@@ -116,6 +115,9 @@ float TrackHeader::GetVerticalLabelOffset() const {
   // This offset only affect subtracks, which are a very special case that need refactoring.
   // Subtracks are only used for the memory track. The following offset is to avoid overlap between
   // the labels of the track and it's subtrack. Subtracks should have their own header altogether.
+  if (track_->GetIndentationLevel() > 1) {
+    ORBIT_ERROR_ONCE("Track indentation level is greater than one, layout will be broken.", );
+  }
   return track_->GetIndentationLevel() > 0 ? layout_->GetTextBoxHeight() : 0.f;
 }
 

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -92,13 +92,14 @@ void orbit_gl::TrackHeader::DoUpdateLayout() {
 
 void TrackHeader::UpdateCollapseToggle() {
   const float x0 = GetPos()[0] + layout_->GetTrackIndentOffset() * track_->GetIndentationLevel();
-  const float button_offset = layout_->GetCollapseButtonOffset();
   const float size = layout_->GetCollapseButtonSize(track_->GetIndentationLevel());
   
+  constexpr float kOffsetX = -0.5f;
   constexpr float kOffsetY = 1.f;
+  const float toggle_x_pos = x0 + layout_->GetCollapseButtonOffset() + kOffsetX;
   const float toggle_y_pos = GetPos()[1] + layout_->GetTextBoxHeight()*0.5f - size*0.5f + kOffsetY;
   
-  Vec2 toggle_pos = Vec2(x0 + button_offset, toggle_y_pos);
+  Vec2 toggle_pos = Vec2(toggle_x_pos, toggle_y_pos);
 
   collapse_toggle_->SetWidth(size);
   collapse_toggle_->SetHeight(size);

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -129,4 +129,9 @@ void TrackHeader::OnDrag(int x, int y) {
 
 bool TrackHeader::Draggable() { return track_->Draggable(); }
 
+void TrackHeader::SetHeight(float height) {
+  height_ = height;
+  RequestUpdate();
+}
+
 }  // namespace orbit_gl

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -93,12 +93,13 @@ void orbit_gl::TrackHeader::DoUpdateLayout() {
 void TrackHeader::UpdateCollapseToggle() {
   const float x0 = GetPos()[0] + layout_->GetTrackIndentOffset() * track_->GetIndentationLevel();
   const float size = layout_->GetCollapseButtonSize(track_->GetIndentationLevel());
-  
+
   constexpr float kOffsetX = -0.5f;
   constexpr float kOffsetY = 1.f;
   const float toggle_x_pos = x0 + layout_->GetCollapseButtonOffset() + kOffsetX;
-  const float toggle_y_pos = GetPos()[1] + layout_->GetTextBoxHeight()*0.5f - size*0.5f + kOffsetY;
-  
+  const float toggle_y_pos =
+      GetPos()[1] + layout_->GetTextBoxHeight() * 0.5f - size * 0.5f + kOffsetY;
+
   Vec2 toggle_pos = Vec2(toggle_x_pos, toggle_y_pos);
 
   collapse_toggle_->SetWidth(size);

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -35,31 +35,30 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
   const Color grey(100, 100, 100, 255);
   Color color = is_collapsible_ ? white : grey;
 
-  // Draw triangle.
-  const Vec2 midpoint = GetPos() + Vec2(GetWidth() / 2, GetHeight() / 2);
-  const float triangle_side_length = std::min(GetWidth(), GetHeight());
-  const float cos30 = std::sqrt(3.f) / 2;
-  const float triangle_height = triangle_side_length * cos30;
-
-  const float half_triangle_height = std::ceil(triangle_height / 2);
-  const float half_triangle_side_length = triangle_side_length / 2;
-
   if (!picking) {
-    Triangle triangle;
-    if (is_collapsed_) {
-      triangle = Triangle(midpoint + Vec2(-half_triangle_height, half_triangle_side_length),
-                          midpoint + Vec2(-half_triangle_height, -half_triangle_side_length),
-                          midpoint + Vec2(half_triangle_height, 0.f));
-    } else {
-      triangle = Triangle(midpoint + Vec2(half_triangle_side_length, -half_triangle_height),
-                          midpoint + Vec2(-half_triangle_side_length, -half_triangle_height),
-                          midpoint + Vec2(0.f, half_triangle_height));
+    const float half_width = GetWidth() / 2.f;
+    const float half_height = GetHeight() / 2.f;
+    const Vec2 midpoint = GetPos() + Vec2(half_width, half_height);
+
+    // Down arrow vertices.
+    std::array<Vec2, 6> v = {Vec2{0, 0}, {-1, -1}, {-1, 0}, {0, 1}, {1, 0}, {1, -1}};
+    
+    // Scale and translate vertices, flipping the y direction based on collapse state.
+    Vec2 scale{half_width, is_collapsed_ ? half_height : -half_height};
+    for (Vec2& vertex : v) {
+      vertex = vertex*scale + midpoint;
     }
-    primitive_assembler.AddTriangle(triangle, z, color, shared_from_this());
+
+    // Arrow triangles.
+    std::array<Triangle, 4> triangles = {
+        Triangle{v[0], v[1], v[2]}, {v[0], v[2], v[3]}, {v[0], v[3], v[4]}, {v[0], v[4], v[5]}};
+    
+    for (const auto& triangle : triangles) {
+      primitive_assembler.AddTriangle(triangle, z, color, shared_from_this());
+    }
   } else {
     // When picking, draw a big square for easier picking.
-    Quad box = MakeBox(midpoint - Vec2(half_triangle_side_length, half_triangle_side_length),
-                       Vec2(triangle_side_length, triangle_side_length));
+    Quad box = MakeBox(GetPos(), Vec2(GetWidth(), GetHeight()));
     primitive_assembler.AddBox(box, z, color, shared_from_this());
   }
 }

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -28,7 +28,7 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
                             const DrawContext& draw_context) {
   CaptureViewElement::DoDraw(primitive_assembler, text_renderer, draw_context);
 
-  const float z = GlCanvas::kZValueTrack;
+  const float z = GlCanvas::kZValueTrackText;
 
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
   const Color white(255, 255, 255, 255);

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -42,17 +42,17 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
 
     // Down arrow vertices.
     std::array<Vec2, 6> v = {Vec2{0, 0}, {-1, -1}, {-1, 0}, {0, 1}, {1, 0}, {1, -1}};
-    
+
     // Scale and translate vertices, flipping the y direction based on collapse state.
     Vec2 scale{half_width, is_collapsed_ ? half_height : -half_height};
     for (Vec2& vertex : v) {
-      vertex = vertex*scale + midpoint;
+      vertex = vertex * scale + midpoint;
     }
 
     // Arrow triangles.
     std::array<Triangle, 4> triangles = {
         Triangle{v[0], v[1], v[2]}, {v[0], v[2], v[3]}, {v[0], v[3], v[4]}, {v[0], v[4], v[5]}};
-    
+
     for (const auto& triangle : triangles) {
       primitive_assembler.AddTriangle(triangle, z, color, shared_from_this());
     }

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -35,27 +35,27 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
   const Color grey(100, 100, 100, 255);
   Color color = is_collapsible_ ? white : grey;
 
+  // Draw triangle.
+  const Vec2 midpoint = GetPos() + Vec2(GetWidth() / 2, GetHeight() / 2);
+  const float triangle_side_length = std::min(GetWidth(), GetHeight());
+  const float cos30 = std::sqrt(3.f) / 2;
+  const float triangle_height = triangle_side_length * cos30;
+
+  const float half_triangle_height = std::ceil(triangle_height / 2);
+  const float half_triangle_side_length = triangle_side_length / 2;
+
   if (!picking) {
-    const float half_width = GetWidth() / 2.f;
-    const float half_height = GetHeight() / 2.f;
-    const Vec2 midpoint = GetPos() + Vec2(half_width, half_height);
-
-    // Down arrow vertices.
-    std::array<Vec2, 6> v = {Vec2{0, 0}, {-1, -1}, {-1, 0}, {0, 1}, {1, 0}, {1, -1}};
-
-    // Scale and translate vertices, flipping the y direction based on collapse state.
-    Vec2 scale{half_width, is_collapsed_ ? half_height : -half_height};
-    for (Vec2& vertex : v) {
-      vertex = vertex * scale + midpoint;
+    Triangle triangle;
+    if (is_collapsed_) {
+      triangle = Triangle(midpoint + Vec2(-half_triangle_height, half_triangle_side_length),
+                          midpoint + Vec2(-half_triangle_height, -half_triangle_side_length),
+                          midpoint + Vec2(half_triangle_height, 0.f));
+    } else {
+      triangle = Triangle(midpoint + Vec2(half_triangle_side_length, -half_triangle_height),
+                          midpoint + Vec2(-half_triangle_side_length, -half_triangle_height),
+                          midpoint + Vec2(0.f, half_triangle_height));
     }
-
-    // Arrow triangles.
-    std::array<Triangle, 4> triangles = {
-        Triangle{v[0], v[1], v[2]}, {v[0], v[2], v[3]}, {v[0], v[3], v[4]}, {v[0], v[4], v[5]}};
-
-    for (const auto& triangle : triangles) {
-      primitive_assembler.AddTriangle(triangle, z, color, shared_from_this());
-    }
+    primitive_assembler.AddTriangle(triangle, z, color, shared_from_this());
   } else {
     // When picking, draw a big square for easier picking.
     Quad box = MakeBox(GetPos(), Vec2(GetWidth(), GetHeight()));

--- a/src/OrbitGl/include/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/include/OrbitGl/GlCanvas.h
@@ -72,6 +72,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider, protected QOpenGL
   static float kZValueEventBar;
   static float kZValueBox;
   static float kZValueBoxBorder;
+  static float kZValueTrackHeader;
   static float kZValueEvent;
   static float kZValueTrackText;
   static float kZValueTrackLabel;

--- a/src/OrbitGl/include/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/include/OrbitGl/GlCanvas.h
@@ -117,7 +117,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider, protected QOpenGL
   bool can_hover_ = false;
 
   PickingMode picking_mode_ = PickingMode::kNone;
-  PickingMode debug_picking_mode_ = PickingMode::kNone;
+  bool draw_as_if_picking_ = false;
 
   double ref_time_click_{0.0};
   float track_container_click_scrolling_offset_ = 0;

--- a/src/OrbitGl/include/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/include/OrbitGl/GlCanvas.h
@@ -117,6 +117,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider, protected QOpenGL
   bool can_hover_ = false;
 
   PickingMode picking_mode_ = PickingMode::kNone;
+  PickingMode debug_picking_mode_ = PickingMode::kNone;
 
   double ref_time_click_{0.0};
   float track_container_click_scrolling_offset_ = 0;

--- a/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
@@ -62,6 +62,9 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   [[nodiscard]] float GetRoundingNumSides() const override { return kRoundingNumSides; }
   [[nodiscard]] float GetTextOffset() const override { return kTextOffset * scale_; }
   [[nodiscard]] float GetTrackHeaderWidth() const override { return kLeftMargin * scale_; }
+  [[nodiscard]] float GetThreadTrackMinimumHeight() const override {
+    return kThreadTrackMinHeight * scale_;
+  }
   [[nodiscard]] float GetRightMargin() const override { return kRightMargin * scale_; }
   [[nodiscard]] float GetMinButtonSize() const override { return kMinButtonSize; }
   [[nodiscard]] float GetButtonWidth() const override { return kButtonWidth * scale_; }
@@ -134,6 +137,7 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   constexpr static float kRoundingNumSides = 16;
   constexpr static float kTextOffset = 5.f;
   constexpr static float kLeftMargin = 100.f;
+  constexpr static float kThreadTrackMinHeight = 20.f;
   constexpr static float kRightMargin = 10.f;
   constexpr static float kMinButtonSize = 5.f;
   constexpr static float kButtonWidth = 15.f;

--- a/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
@@ -101,6 +101,9 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
 
   [[nodiscard]] int GetMaxLayoutingLoops() const override { return kMaxLayoutingLoops; }
 
+  [[nodiscard]] bool GetDrawTrackHeaderBackground() const override { return false; }
+  [[nodiscard]] bool GetDrawAsIfPicking() const override { return false; }
+
  private:
   constexpr static float kTextBoxHeight = 20.f;
   constexpr static float kCoreHeight = 10.f;

--- a/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
@@ -105,7 +105,6 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   [[nodiscard]] bool GetDrawAsIfPicking() const override { return false; }
   [[nodiscard]] bool GetDrawTimeGraphMasks() const override { return false; }
 
-
  private:
   constexpr static float kTextBoxHeight = 20.f;
   constexpr static float kCoreHeight = 10.f;

--- a/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
@@ -48,9 +48,6 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
     return GetMinSliderLength() / kRatioMinSliderLengthResizePart;
   }
   [[nodiscard]] float GetTimeBarHeight() const override { return kTimeBarHeight * scale_; }
-  [[nodiscard]] float GetTrackTabWidth() const override { return kTrackTabWidth; }
-  [[nodiscard]] float GetTrackTabHeight() const override { return kTrackTabHeight * scale_; }
-  [[nodiscard]] float GetTrackTabOffset() const override { return kTrackTabOffset; }
   [[nodiscard]] float GetTrackIndentOffset() const override { return kTrackIndentOffset; }
   [[nodiscard]] float GetCollapseButtonSize(int indentation_level) const override {
     float button_size_without_scaling =

--- a/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
@@ -61,7 +61,7 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   [[nodiscard]] float GetRoundingRadius() const override { return kRoundingRadius * scale_; }
   [[nodiscard]] float GetRoundingNumSides() const override { return kRoundingNumSides; }
   [[nodiscard]] float GetTextOffset() const override { return kTextOffset * scale_; }
-  [[nodiscard]] float GetLeftMargin() const override { return kLeftMargin * scale_; }
+  [[nodiscard]] float GetTrackHeaderWidth() const override { return kLeftMargin * scale_; }
   [[nodiscard]] float GetRightMargin() const override { return kRightMargin * scale_; }
   [[nodiscard]] float GetMinButtonSize() const override { return kMinButtonSize; }
   [[nodiscard]] float GetButtonWidth() const override { return kButtonWidth * scale_; }

--- a/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
@@ -103,6 +103,8 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
 
   [[nodiscard]] bool GetDrawTrackHeaderBackground() const override { return false; }
   [[nodiscard]] bool GetDrawAsIfPicking() const override { return false; }
+  [[nodiscard]] bool GetDrawTimeGraphMasks() const override { return false; }
+
 
  private:
   constexpr static float kTextBoxHeight = 20.f;

--- a/src/OrbitGl/include/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraph.h
@@ -100,6 +100,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] uint64_t GetCaptureTimeSpanNs() const override;
   [[nodiscard]] std::pair<float, float> GetBoxPosXAndWidthFromTicks(
       uint64_t start_tick, uint64_t end_tick) const override;
+  [[nodiscard]] float ClampToTimelineUiElementWorldX(float x) const;
 
   void UpdateCaptureMinMaxTimestamps();
 

--- a/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
@@ -20,9 +20,6 @@ class TimeGraphLayout {
   [[nodiscard]] virtual float GetMinSliderLength() const = 0;
   [[nodiscard]] virtual float GetSliderResizeMargin() const = 0;
   [[nodiscard]] virtual float GetTimeBarHeight() const = 0;
-  [[nodiscard]] virtual float GetTrackTabWidth() const = 0;
-  [[nodiscard]] virtual float GetTrackTabHeight() const = 0;
-  [[nodiscard]] virtual float GetTrackTabOffset() const = 0;
   [[nodiscard]] virtual float GetTrackIndentOffset() const = 0;
   [[nodiscard]] virtual float GetCollapseButtonSize(int indentation_level) const = 0;
   [[nodiscard]] virtual float GetCollapseButtonOffset() const = 0;

--- a/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
@@ -43,10 +43,11 @@ class TimeGraphLayout {
   [[nodiscard]] virtual float GetThreadDependencyArrowBodyWidth() const = 0;
   [[nodiscard]] virtual float GetScale() const = 0;
   [[nodiscard]] virtual bool GetDrawTrackBackground() const = 0;
+  [[nodiscard]] virtual bool GetDrawTrackHeaderBackground() const = 0;
   [[nodiscard]] virtual uint32_t GetFontSize() const = 0;
   [[nodiscard]] virtual int GetMaxLayoutingLoops() const = 0;
-  [[nodiscard]] virtual bool GetDrawTrackHeaderBackground() const = 0;
   [[nodiscard]] virtual bool GetDrawAsIfPicking() const = 0;
+  [[nodiscard]] virtual bool GetDrawTimeGraphMasks() const = 0;
   virtual void SetScale(float value) = 0;
 
   ~TimeGraphLayout() = default;

--- a/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
@@ -26,7 +26,7 @@ class TimeGraphLayout {
   [[nodiscard]] virtual float GetRoundingRadius() const = 0;
   [[nodiscard]] virtual float GetRoundingNumSides() const = 0;
   [[nodiscard]] virtual float GetTextOffset() const = 0;
-  [[nodiscard]] virtual float GetLeftMargin() const = 0;
+  [[nodiscard]] virtual float GetTrackHeaderWidth() const = 0;
   [[nodiscard]] virtual float GetRightMargin() const = 0;
   [[nodiscard]] virtual float GetMinButtonSize() const = 0;
   [[nodiscard]] virtual float GetButtonWidth() const = 0;

--- a/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
@@ -27,6 +27,7 @@ class TimeGraphLayout {
   [[nodiscard]] virtual float GetRoundingNumSides() const = 0;
   [[nodiscard]] virtual float GetTextOffset() const = 0;
   [[nodiscard]] virtual float GetTrackHeaderWidth() const = 0;
+  [[nodiscard]] virtual float GetThreadTrackMinimumHeight() const = 0;
   [[nodiscard]] virtual float GetRightMargin() const = 0;
   [[nodiscard]] virtual float GetMinButtonSize() const = 0;
   [[nodiscard]] virtual float GetButtonWidth() const = 0;

--- a/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
@@ -45,6 +45,8 @@ class TimeGraphLayout {
   [[nodiscard]] virtual bool GetDrawTrackBackground() const = 0;
   [[nodiscard]] virtual uint32_t GetFontSize() const = 0;
   [[nodiscard]] virtual int GetMaxLayoutingLoops() const = 0;
+  [[nodiscard]] virtual bool GetDrawTrackHeaderBackground() const = 0;
+  [[nodiscard]] virtual bool GetDrawAsIfPicking() const = 0;
   virtual void SetScale(float value) = 0;
 
   ~TimeGraphLayout() = default;

--- a/src/OrbitGl/include/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/include/OrbitGl/TrackContainer.h
@@ -56,6 +56,7 @@ class TrackContainer final : public CaptureViewElement {
   void VerticallyMoveIntoView(const Track& track);
 
   void SetThreadFilter(std::string_view filter);
+  void SetHeaderWidth(float width) { header_width_ = width; }
 
   [[nodiscard]] int GetNumVisiblePrimitives() const;
 
@@ -112,6 +113,7 @@ class TrackContainer final : public CaptureViewElement {
 
   float vertical_scrolling_offset_ = 0;
   float height_ = 0;
+  float header_width_ = 100.f;
 
   std::unique_ptr<TrackManager> track_manager_;
 

--- a/src/OrbitGl/include/OrbitGl/TrackContainer.h
+++ b/src/OrbitGl/include/OrbitGl/TrackContainer.h
@@ -56,7 +56,6 @@ class TrackContainer final : public CaptureViewElement {
   void VerticallyMoveIntoView(const Track& track);
 
   void SetThreadFilter(std::string_view filter);
-  void SetHeaderWidth(float width) { header_width_ = width; }
 
   [[nodiscard]] int GetNumVisiblePrimitives() const;
 
@@ -113,7 +112,6 @@ class TrackContainer final : public CaptureViewElement {
 
   float vertical_scrolling_offset_ = 0;
   float height_ = 0;
-  float header_width_ = 100.f;
 
   std::unique_ptr<TrackManager> track_manager_;
 

--- a/src/OrbitGl/include/OrbitGl/TrackHeader.h
+++ b/src/OrbitGl/include/OrbitGl/TrackHeader.h
@@ -38,7 +38,7 @@ class TrackHeader : public CaptureViewElement, public std::enable_shared_from_th
 
   [[nodiscard]] float GetHeight() const override { return height_; }
   void SetHeight(float height);
-  
+
   [[nodiscard]] uint32_t GetLayoutFlags() const override { return 0; }
 
   void OnPick(int x, int y) override;

--- a/src/OrbitGl/include/OrbitGl/TrackHeader.h
+++ b/src/OrbitGl/include/OrbitGl/TrackHeader.h
@@ -36,7 +36,9 @@ class TrackHeader : public CaptureViewElement, public std::enable_shared_from_th
   [[nodiscard]] const TriangleToggle* GetCollapseToggle() const { return collapse_toggle_.get(); }
   [[nodiscard]] TriangleToggle* GetCollapseToggle() { return collapse_toggle_.get(); }
 
-  [[nodiscard]] float GetHeight() const override { return GetParent()->GetHeight(); }
+  [[nodiscard]] float GetHeight() const override { return height_; }
+  void SetHeight(float height);
+  
   [[nodiscard]] uint32_t GetLayoutFlags() const override { return 0; }
 
   void OnPick(int x, int y) override;
@@ -67,6 +69,7 @@ class TrackHeader : public CaptureViewElement, public std::enable_shared_from_th
  private:
   std::shared_ptr<TriangleToggle> collapse_toggle_;
   TrackControlInterface* track_;
+  float height_ = 0.f;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/TrackHeader.h
+++ b/src/OrbitGl/include/OrbitGl/TrackHeader.h
@@ -60,6 +60,7 @@ class TrackHeader : public CaptureViewElement, public std::enable_shared_from_th
   void DoUpdateLayout() override;
 
   void UpdateCollapseToggle();
+  float GetVerticalLabelOffset() const;
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 

--- a/src/OrbitGl/include/OrbitGl/TrackHeader.h
+++ b/src/OrbitGl/include/OrbitGl/TrackHeader.h
@@ -36,7 +36,7 @@ class TrackHeader : public CaptureViewElement, public std::enable_shared_from_th
   [[nodiscard]] const TriangleToggle* GetCollapseToggle() const { return collapse_toggle_.get(); }
   [[nodiscard]] TriangleToggle* GetCollapseToggle() { return collapse_toggle_.get(); }
 
-  [[nodiscard]] float GetHeight() const override { return layout_->GetTrackTabHeight(); }
+  [[nodiscard]] float GetHeight() const override { return GetParent()->GetHeight(); }
   [[nodiscard]] uint32_t GetLayoutFlags() const override { return 0; }
 
   void OnPick(int x, int y) override;

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -33,6 +33,7 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&rounding_num_sides_);
   AddWidgetForProperty(&text_offset_);
   AddWidgetForProperty(&track_header_width_);
+  AddWidgetForProperty(&thread_track_minimum_height_);
   AddWidgetForProperty(&right_margin_);
   AddWidgetForProperty(&min_button_size_);
   AddWidgetForProperty(&button_width_);

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -32,7 +32,7 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&rounding_radius_);
   AddWidgetForProperty(&rounding_num_sides_);
   AddWidgetForProperty(&text_offset_);
-  AddWidgetForProperty(&left_margin_);
+  AddWidgetForProperty(&track_header_width_);
   AddWidgetForProperty(&right_margin_);
   AddWidgetForProperty(&min_button_size_);
   AddWidgetForProperty(&button_width_);

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -22,9 +22,6 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&slider_width_);
   AddWidgetForProperty(&min_slider_length_);
   AddWidgetForProperty(&time_bar_height_);
-  AddWidgetForProperty(&track_tab_width_);
-  AddWidgetForProperty(&track_tab_height_);
-  AddWidgetForProperty(&track_tab_offset_);
   AddWidgetForProperty(&track_indent_offset_);
   AddWidgetForProperty(&collapse_button_offset_);
   AddWidgetForProperty(&collapse_button_size_);

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -37,6 +37,13 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&min_button_size_);
   AddWidgetForProperty(&button_width_);
   AddWidgetForProperty(&button_height_);
+  AddWidgetForProperty(&space_between_tracks_);
+  AddWidgetForProperty(&space_between_tracks_and_timeline_);
+  AddWidgetForProperty(&space_between_cores_);
+  AddWidgetForProperty(&space_between_gpu_depths_);
+  AddWidgetForProperty(&space_between_thread_panes_);
+  AddWidgetForProperty(&space_between_subtracks_);
+  AddWidgetForProperty(&generic_fixed_spacer_width_);
   AddWidgetForProperty(&thread_dependency_arrow_head_width_);
   AddWidgetForProperty(&thread_dependency_arrow_head_height_);
   AddWidgetForProperty(&thread_dependency_arrow_body_width_);

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -47,6 +47,9 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&thread_dependency_arrow_head_width_);
   AddWidgetForProperty(&thread_dependency_arrow_head_height_);
   AddWidgetForProperty(&thread_dependency_arrow_body_width_);
+  AddWidgetForProperty(&draw_track_background_);
+  AddWidgetForProperty(&draw_track_header_background_);
+  AddWidgetForProperty(&draw_as_if_picking_);
   AddWidgetForProperty(&scale_);
 }
 

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -49,6 +49,7 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&thread_dependency_arrow_body_width_);
   AddWidgetForProperty(&draw_track_background_);
   AddWidgetForProperty(&draw_track_header_background_);
+  AddWidgetForProperty(&draw_timegraph_masks_);
   AddWidgetForProperty(&draw_as_if_picking_);
   AddWidgetForProperty(&scale_);
 }

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -68,6 +68,9 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   [[nodiscard]] float GetTrackHeaderWidth() const override {
     return track_header_width_.value() * scale_.value();
   }
+  [[nodiscard]] float GetThreadTrackMinimumHeight() const override {
+    return thread_track_minimum_height_.value() * scale_.value();
+  }
   [[nodiscard]] float GetRightMargin() const override {
     return right_margin_.value() * scale_.value();
   }
@@ -237,10 +240,16 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Text Offset:",
   }};
   FloatProperty track_header_width_{{
-      .initial_value = 350.f,
+      .initial_value = 250.f,
       .min = 0.f,
       .max = 1000.f,
       .label = "Track Header Width:",
+  }};
+  FloatProperty thread_track_minimum_height_{{
+      .initial_value = 24.f,
+      .min = 0.f,
+      .max = 100.f,
+      .label = "Minimum Thread Track Height:",
   }};
   FloatProperty right_margin_{{
       .initial_value = 10.f,

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -200,20 +200,6 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .initial_value = 20.f,
       .label = "Minimum Slider Length:",
   }};
-  FloatProperty track_tab_width_{{
-      .initial_value = 350.f,
-      .min = 0.f,
-      .max = 1000.f,
-      .label = "Track Tab Width:",
-  }};
-  FloatProperty track_tab_height_{{
-      .initial_value = 25.f,
-      .label = "Track Tab Height:",
-  }};
-  FloatProperty track_tab_offset_{{
-      .initial_value = 0.f,
-      .label = "Track Tab Offset:",
-  }};
   FloatProperty track_indent_offset_{{
       .initial_value = 5.f,
       .label = "Track Indent Offset:",

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -119,6 +119,9 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
 
   [[nodiscard]] int GetMaxLayoutingLoops() const override { return max_layouting_loops_.value(); }
 
+  [[nodiscard]] bool GetDrawTrackHeaderBackground() const override { return draw_track_header_background_.value(); }
+  [[nodiscard]] bool GetDrawAsIfPicking() const override { return draw_as_if_picking_.value(); }
+
  private:
   FloatProperty text_box_height_{{
       .initial_value = 20.f,
@@ -289,6 +292,10 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Thread Dependency Arrow Head Width:",
   }};
   BoolProperty draw_track_background_{{.initial_value = true, .label = "Draw Track Background"}};
+  BoolProperty draw_track_header_background_{
+      {.initial_value = true, .label = "Draw Track Header Background"}};
+  BoolProperty draw_as_if_picking_{{.initial_value = false, .label = "Draw as if picking"}};
+
   IntProperty max_layouting_loops_{
       {.initial_value = 10, .min = 1, .max = 100, .label = "Max layouting loops:"}};
 };

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -53,11 +53,6 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   [[nodiscard]] float GetTimeBarHeight() const override {
     return time_bar_height_.value() * scale_.value();
   }
-  [[nodiscard]] float GetTrackTabWidth() const override { return track_tab_width_.value(); }
-  [[nodiscard]] float GetTrackTabHeight() const override {
-    return track_tab_height_.value() * scale_.value();
-  }
-  [[nodiscard]] float GetTrackTabOffset() const override { return track_tab_offset_.value(); }
   [[nodiscard]] float GetTrackIndentOffset() const override { return track_indent_offset_.value(); }
   [[nodiscard]] float GetCollapseButtonSize(int indentation_level) const override;
   [[nodiscard]] float GetCollapseButtonOffset() const override {
@@ -167,7 +162,7 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Space between GPU depths:",
   }};
   FloatProperty space_between_tracks_{{
-      .initial_value = 10.f,
+      .initial_value = 2.f,
       .label = "Space between Tracks:",
   }};
   FloatProperty space_between_tracks_and_timeline_{{
@@ -234,7 +229,7 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Text Offset:",
   }};
   FloatProperty left_margin_{{
-      .initial_value = 0.f,
+      .initial_value = 350.f,
       .min = 0.f,
       .max = 1000.f,
       .label = "Left Margin:",

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -113,13 +113,18 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   [[nodiscard]] bool GetDrawTrackBackground() const override {
     return draw_track_background_.value();
   }
+  [[nodiscard]] bool GetDrawTrackHeaderBackground() const override {
+    return draw_track_header_background_.value();
+  }
+  [[nodiscard]] bool GetDrawTimeGraphMasks() const override {
+    return draw_timegraph_masks_.value();
+  }
   [[nodiscard]] uint32_t GetFontSize() const override {
     return std::lround(static_cast<float>(font_size_.value()) * scale_.value());
   }
 
   [[nodiscard]] int GetMaxLayoutingLoops() const override { return max_layouting_loops_.value(); }
 
-  [[nodiscard]] bool GetDrawTrackHeaderBackground() const override { return draw_track_header_background_.value(); }
   [[nodiscard]] bool GetDrawAsIfPicking() const override { return draw_as_if_picking_.value(); }
 
  private:
@@ -294,7 +299,9 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   BoolProperty draw_track_background_{{.initial_value = true, .label = "Draw Track Background"}};
   BoolProperty draw_track_header_background_{
       {.initial_value = true, .label = "Draw Track Header Background"}};
-  BoolProperty draw_as_if_picking_{{.initial_value = false, .label = "Draw as if picking"}};
+  BoolProperty draw_timegraph_masks_{
+      {.initial_value = true, .label = "Draw TimeGraph Masks"}};
+  BoolProperty draw_as_if_picking_{{.initial_value = false, .label = "Draw as if Picking"}};
 
   IntProperty max_layouting_loops_{
       {.initial_value = 10, .min = 1, .max = 100, .label = "Max layouting loops:"}};

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -65,8 +65,8 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   [[nodiscard]] float GetTextOffset() const override {
     return text_offset_.value() * scale_.value();
   }
-  [[nodiscard]] float GetLeftMargin() const override {
-    return left_margin_.value() * scale_.value();
+  [[nodiscard]] float GetTrackHeaderWidth() const override {
+    return track_header_width_.value() * scale_.value();
   }
   [[nodiscard]] float GetRightMargin() const override {
     return right_margin_.value() * scale_.value();
@@ -228,11 +228,11 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .initial_value = 5.f,
       .label = "Text Offset:",
   }};
-  FloatProperty left_margin_{{
+  FloatProperty track_header_width_{{
       .initial_value = 350.f,
       .min = 0.f,
       .max = 1000.f,
-      .label = "Left Margin:",
+      .label = "Track Header Width:",
   }};
   FloatProperty right_margin_{{
       .initial_value = 10.f,

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -208,7 +208,7 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Track Indent Offset:",
   }};
   FloatProperty collapse_button_offset_{{
-      .initial_value = 15.f,
+      .initial_value = 10.f,
       .label = "Collapse Button Offset:",
   }};
   FloatProperty collapse_button_size_{{

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -299,8 +299,7 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   BoolProperty draw_track_background_{{.initial_value = true, .label = "Draw Track Background"}};
   BoolProperty draw_track_header_background_{
       {.initial_value = true, .label = "Draw Track Header Background"}};
-  BoolProperty draw_timegraph_masks_{
-      {.initial_value = true, .label = "Draw TimeGraph Masks"}};
+  BoolProperty draw_timegraph_masks_{{.initial_value = true, .label = "Draw TimeGraph Masks"}};
   BoolProperty draw_as_if_picking_{{.initial_value = false, .label = "Draw as if Picking"}};
 
   IntProperty max_layouting_loops_{


### PR DESCRIPTION
This PR's goal is to gain vertical real-estate by removing track tabs in
favor of a track header that is now aligned with tracks, to their left.
This is also similar to how most track UI applications display tracks. 

Note that there are many things we could do to enhance the look of 
tracks, like fine tuning text and collapsible arrow position, coloring on
hover, better separation of header and track. All those changes are 
welcome but outside the scope of this PR. This basically takes our existing
tabs and moves them to the left of the tracks.

![image](https://user-images.githubusercontent.com/3687222/207090058-536ffe71-f074-49ea-95e7-938cc7fe2342.png)
