### PR TITLE
Return futures from orbit_ssh::Session's public methods

### DIFF
--- a/src/OrbitSshQt/CMakeLists.txt
+++ b/src/OrbitSshQt/CMakeLists.txt
@@ -54,5 +54,11 @@ target_sources(OrbitSshQtTests PRIVATE
   TaskTest.cpp
   TunnelTest.cpp)
 
-target_link_libraries(OrbitSshQtTests PUBLIC OrbitSshQt TestUtils GTest::QtCoreMain Qt::Test)
+target_link_libraries(OrbitSshQtTests PUBLIC
+  OrbitSshQt
+  TestUtils
+  QtTestUtils
+  GTest::QtCoreMain
+  Qt::Test)
+
 register_test(OrbitSshQtTests)

--- a/src/OrbitSshQt/Session.cpp
+++ b/src/OrbitSshQt/Session.cpp
@@ -12,7 +12,9 @@
 #include <system_error>
 #include <utility>
 
+#include "OrbitBase/Future.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
 #include "OrbitSsh/Session.h"
 
 namespace orbit_ssh_qt {
@@ -117,7 +119,7 @@ void Session::HandleEagain() {
   }
 }
 
-void Session::ConnectToServer(orbit_ssh::Credentials creds) {
+orbit_base::Future<ErrorMessageOr<void>> Session::ConnectToServer(orbit_ssh::Credentials creds) {
   credentials_ = std::move(creds);
 
   notifiers_ = std::nullopt;
@@ -126,18 +128,16 @@ void Session::ConnectToServer(orbit_ssh::Credentials creds) {
   SetState(State::kDisconnected);
 
   OnEvent();
+  return GetStartedFuture();
 }
 
-Session::DisconnectResult Session::Disconnect() {
+orbit_base::Future<ErrorMessageOr<void>> Session::Disconnect() {
   if (CurrentState() == State::kConnected) {
     SetState(State::kAboutToDisconnect);
     OnEvent();
-    if (IsStopping()) {
-      return DisconnectResult::kDisconnectStarted;
-    }
   }
 
-  return DisconnectResult::kDisconnectedSuccessfully;
+  return GetStoppedFuture();
 }
 
 void Session::SetError(std::error_code e) {

--- a/src/OrbitSshQt/SessionTest.cpp
+++ b/src/OrbitSshQt/SessionTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <QSignalSpy>
@@ -10,25 +11,32 @@
 #include "OrbitSsh/Context.h"
 #include "OrbitSsh/Credentials.h"
 #include "OrbitSshQt/Session.h"
+#include "QtTestUtils/WaitFor.h"
 #include "SshSessionTest.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_ssh_qt {
+using orbit_qt_test_utils::WaitFor;
+using orbit_qt_test_utils::YieldsResult;
+using orbit_test_utils::HasNoError;
+using testing::IsEmpty;
+using testing::Not;
+
 TEST_F(SshSessionTest, Connect) {
   auto context = orbit_ssh::Context::Create();
   ASSERT_TRUE(context);
 
   orbit_ssh_qt::Session session{&context.value()};
+  QSignalSpy started_signal{&session, &Session::started};
+  QSignalSpy stopped_signal{&session, &Session::stopped};
 
-  session.ConnectToServer(GetCredentials());
+  EXPECT_THAT(WaitFor(session.ConnectToServer(GetCredentials())), YieldsResult(HasNoError()));
+  EXPECT_THAT(started_signal, Not(IsEmpty()));
+  EXPECT_THAT(stopped_signal, IsEmpty());
+  started_signal.clear();
 
-  if (!session.IsStarted()) {
-    QSignalSpy started_signal{&session, &orbit_ssh_qt::Session::started};
-    EXPECT_TRUE(started_signal.wait());
-  }
-
-  if (session.Disconnect() != orbit_ssh_qt::Session::DisconnectResult::kDisconnectedSuccessfully) {
-    QSignalSpy stopped_signal{&session, &orbit_ssh_qt::Session::stopped};
-    EXPECT_TRUE(stopped_signal.wait());
-  }
+  EXPECT_THAT(WaitFor(session.Disconnect()), YieldsResult(HasNoError()));
+  EXPECT_THAT(started_signal, IsEmpty());
+  EXPECT_THAT(stopped_signal, Not(IsEmpty()));
 }
 }  // namespace orbit_ssh_qt

--- a/src/OrbitSshQt/SftpChannelTest.cpp
+++ b/src/OrbitSshQt/SftpChannelTest.cpp
@@ -5,6 +5,7 @@
 #include <absl/algorithm/container.h>
 #include <gtest/gtest.h>
 
+#include <QSignalSpy>
 #include <QTest>
 #include <numeric>
 

--- a/src/OrbitSshQt/include/OrbitSshQt/Session.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Session.h
@@ -13,6 +13,7 @@
 #include <system_error>
 #include <utility>
 
+#include "OrbitBase/Future.h"
 #include "OrbitBase/Result.h"
 #include "OrbitSsh/Context.h"
 #include "OrbitSsh/Credentials.h"
@@ -57,9 +58,8 @@ class Session : public StateMachineHelper<Session, details::SessionState> {
   explicit Session(const orbit_ssh::Context* context, QObject* parent = nullptr)
       : StateMachineHelper(parent), context_(context) {}
 
-  void ConnectToServer(orbit_ssh::Credentials creds);
-  enum class DisconnectResult { kDisconnectedSuccessfully, kDisconnectStarted };
-  [[nodiscard]] DisconnectResult Disconnect();
+  orbit_base::Future<ErrorMessageOr<void>> ConnectToServer(orbit_ssh::Credentials creds);
+  [[nodiscard]] orbit_base::Future<ErrorMessageOr<void>> Disconnect();
 
   orbit_ssh::Session* GetRawSession() { return session_ ? &session_.value() : nullptr; }
 

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -654,7 +654,7 @@ ErrorMessageOr<void> ServiceDeployManager::ConnectToServer() {
   auto error_handler = ConnectErrorHandler(&loop, &session_.value(), &Session::errorOccurred);
   auto cancel_handler = ConnectCancelHandler(&loop, this);
 
-  session_->ConnectToServer(credentials_);
+  std::ignore = session_->ConnectToServer(credentials_);
 
   OUTCOME_TRY(MapError(loop.exec(), Error::kCouldNotConnectToServer));
 
@@ -796,9 +796,9 @@ ErrorMessageOr<void> ServiceDeployManager::ShutdownSession(orbit_ssh_qt::Session
   auto error_handler = ConnectQuitHandler(&loop, session, &orbit_ssh_qt::Session::errorOccurred);
   auto cancel_handler = ConnectCancelHandler(&loop, this);
 
-  orbit_ssh_qt::Session::DisconnectResult disconnect_result = session->Disconnect();
+  orbit_base::Future<ErrorMessageOr<void>> disconnect_future = session->Disconnect();
 
-  if (disconnect_result == orbit_ssh_qt::Session::DisconnectResult::kDisconnectStarted) {
+  if (!disconnect_future.IsFinished()) {
     OUTCOME_TRY(loop.exec());
   }
 


### PR DESCRIPTION
This is changing the return type of `ConnectToServer` and `Disconnect` in `orbit_ssh::Session`. These two asynchronous methods now return futurs that complete when the asynchronous operation succeeds or fails.

This also greatly simplifies the tests because it gets simpler to chain asynchronous operations in a synchronous manner.