### PR TITLE
Return futures in Task and Tunnel's public methods

### DIFF
--- a/src/OrbitSshQt/SftpCopyToRemoteOperationTest.cpp
+++ b/src/OrbitSshQt/SftpCopyToRemoteOperationTest.cpp
@@ -13,12 +13,16 @@
 #include "OrbitSshQt/SftpCopyToLocalOperation.h"
 #include "OrbitSshQt/SftpCopyToRemoteOperation.h"
 #include "OrbitSshQt/Task.h"
+#include "QtTestUtils/WaitFor.h"
 #include "SftpTestFixture.h"
 #include "Test/Path.h"
 #include "TestUtils/TemporaryDirectory.h"
 #include "TestUtils/TestUtils.h"
 
 namespace orbit_ssh_qt {
+using orbit_qt_test_utils::WaitFor;
+using orbit_qt_test_utils::YieldsResult;
+using orbit_test_utils::HasNoError;
 
 using SftpCopyToRemoteOperationTest = SftpTestFixture;
 
@@ -37,17 +41,8 @@ TEST_F(SftpCopyToRemoteOperationTest, Upload) {
 
   Task task{GetSession(), "cmp /home/loginuser/plain.txt /home/loginuser/upload.txt"};
   QSignalSpy finished_signal{&task, &orbit_ssh_qt::Task::finished};
-  task.Start();
-
-  if (!task.IsStarted()) {
-    QSignalSpy started_signal{&task, &orbit_ssh_qt::Task::started};
-    EXPECT_TRUE(started_signal.wait());
-  }
-
-  if (!task.IsStopped()) {
-    QSignalSpy stopped_signal{&task, &orbit_ssh_qt::Task::stopped};
-    EXPECT_TRUE(stopped_signal.wait());
-  }
+  EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
+  EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));
 
   ASSERT_EQ(finished_signal.size(), 1);
   // Return value 0 means there was no difference in the two compared files. Hence the upload

--- a/src/OrbitSshQt/TaskTest.cpp
+++ b/src/OrbitSshQt/TaskTest.cpp
@@ -32,7 +32,7 @@ TEST_F(SshTaskTest, ReturnCode) {
   EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
   EXPECT_EQ(started_signal.size(), 1);
 
-  // ServiceDeployManager relies on the fact that Task::Stop triggers a `stopped()` signal even when
+  // `ServiceDeployManager` relies on the fact that `Task::Stop` triggers a `stopped()` signal even when
   // the task has already been stopped through other means. So we test that the signal has been
   // emitted at least one more time after calling `Stop`.
   const int number_of_stopped_signals_before_calling_stop = stopped_signal.size();

--- a/src/OrbitSshQt/TaskTest.cpp
+++ b/src/OrbitSshQt/TaskTest.cpp
@@ -32,8 +32,8 @@ TEST_F(SshTaskTest, ReturnCode) {
   EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
   EXPECT_EQ(started_signal.size(), 1);
 
-  // `ServiceDeployManager` relies on the fact that `Task::Stop` triggers a `stopped()` signal even when
-  // the task has already been stopped through other means. So we test that the signal has been
+  // `ServiceDeployManager` relies on the fact that `Task::Stop` triggers a `stopped()` signal even
+  // when the task has already been stopped through other means. So we test that the signal has been
   // emitted at least one more time after calling `Stop`.
   const int number_of_stopped_signals_before_calling_stop = stopped_signal.size();
   EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));

--- a/src/OrbitSshQt/TaskTest.cpp
+++ b/src/OrbitSshQt/TaskTest.cpp
@@ -3,53 +3,52 @@
 // found in the LICENSE file.
 
 #include <absl/algorithm/container.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <QSignalSpy>
 #include <QTest>
 #include <numeric>
 
+#include "OrbitBase/WhenAll.h"
 #include "OrbitSshQt/Task.h"
+#include "QtTestUtils/WaitFor.h"
 #include "SshTestFixture.h"
+#include "TestUtils/TestUtils.h"
 
 namespace orbit_ssh_qt {
+using orbit_qt_test_utils::WaitFor;
+using orbit_qt_test_utils::YieldsResult;
+using orbit_test_utils::HasNoError;
 
 using SshTaskTest = SshTestFixture;
 
 TEST_F(SshTaskTest, ReturnCode) {
   orbit_ssh_qt::Task task{GetSession(), "exit 42"};
   QSignalSpy finished_signal{&task, &orbit_ssh_qt::Task::finished};
-  task.Start();
+  QSignalSpy started_signal{&task, &orbit_ssh_qt::Task::started};
+  QSignalSpy stopped_signal{&task, &orbit_ssh_qt::Task::stopped};
 
-  if (!task.IsStarted()) {
-    QSignalSpy started_signal{&task, &orbit_ssh_qt::Task::started};
-    EXPECT_TRUE(started_signal.wait());
-  }
+  EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
+  EXPECT_EQ(started_signal.size(), 1);
 
-  if (!task.IsStopped()) {
-    QSignalSpy stopped_signal{&task, &orbit_ssh_qt::Task::stopped};
-    EXPECT_TRUE(stopped_signal.wait());
-  }
+  // ServiceDeployManager relies on the fact that Task::Stop triggers a `stopped()` signal even when
+  // the task has already been stopped through other means. So we test that the signal has been
+  // emitted at least one more time after calling `Stop`.
+  const int number_of_stopped_signals_before_calling_stop = stopped_signal.size();
+  EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));
+  EXPECT_GT(stopped_signal.size(), number_of_stopped_signals_before_calling_stop);
 
-  ASSERT_EQ(finished_signal.size(), 1);
-  EXPECT_EQ(finished_signal[0][0].toInt(), 42);
+  EXPECT_THAT(finished_signal, testing::ElementsAre(testing::ElementsAre(QVariant{42})));
 }
 
 TEST_F(SshTaskTest, Stdout) {
   orbit_ssh_qt::Task task{GetSession(), "echo 'Hello World'"};
   QSignalSpy finished_signal{&task, &orbit_ssh_qt::Task::finished};
   QSignalSpy ready_read_signal{&task, &orbit_ssh_qt::Task::readyReadStdOut};
-  task.Start();
 
-  if (!task.IsStarted()) {
-    QSignalSpy started_signal{&task, &orbit_ssh_qt::Task::started};
-    EXPECT_TRUE(started_signal.wait());
-  }
-
-  if (!task.IsStopped()) {
-    QSignalSpy stopped_signal{&task, &orbit_ssh_qt::Task::stopped};
-    EXPECT_TRUE(stopped_signal.wait());
-  }
+  EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
+  EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));
 
   EXPECT_FALSE(ready_read_signal.empty());
   EXPECT_EQ(task.ReadStdOut(), "Hello World\n");
@@ -59,76 +58,75 @@ TEST_F(SshTaskTest, Stderr) {
   orbit_ssh_qt::Task task{GetSession(), "echo 'Hello World' >&2"};
   QSignalSpy finished_signal{&task, &orbit_ssh_qt::Task::finished};
   QSignalSpy ready_read_signal{&task, &orbit_ssh_qt::Task::readyReadStdErr};
-  task.Start();
 
-  if (!task.IsStarted()) {
-    QSignalSpy started_signal{&task, &orbit_ssh_qt::Task::started};
-    EXPECT_TRUE(started_signal.wait());
-  }
+  EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
+  EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));
 
-  if (!task.IsStopped()) {
-    QSignalSpy stopped_signal{&task, &orbit_ssh_qt::Task::stopped};
-    EXPECT_TRUE(stopped_signal.wait());
-  }
-
-  EXPECT_FALSE(ready_read_signal.empty());
+  EXPECT_GE(ready_read_signal.size(), 1);
   EXPECT_EQ(task.ReadStdErr(), "Hello World\n");
 }
 
 TEST_F(SshTaskTest, Stdin) {
   orbit_ssh_qt::Task task{GetSession(), "read; echo ${REPLY}"};
   QSignalSpy ready_read_signal{&task, &orbit_ssh_qt::Task::readyReadStdOut};
-  task.Start();
 
-  if (!task.IsStarted()) {
-    QSignalSpy started_signal{&task, &orbit_ssh_qt::Task::started};
-    EXPECT_TRUE(started_signal.wait());
-  }
+  EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
 
   qRegisterMetaType<size_t>("size_t");
   QSignalSpy bytes_written_signal{&task, &orbit_ssh_qt::Task::bytesWritten};
   constexpr std::string_view kInputString{"Hello World\n"};
-  task.Write(kInputString);
+  ASSERT_THAT(WaitFor(task.Write(kInputString)), YieldsResult(HasNoError()));
 
-  // Here we wait until all the bytes are written. Note that there is no guarantee on how many
-  // separate internal writes that takes.
-  ASSERT_TRUE(QTest::qWaitFor([&bytes_written_signal, kInputString]() {
-    const auto add_bytes_written_per_signal = [](size_t sum,
-                                                 const QList<QVariant>& signal_arguments) {
-      return sum + static_cast<size_t>(signal_arguments.first().toInt());
-    };
-    const size_t bytes_written =
-        absl::c_accumulate(bytes_written_signal, size_t{0}, add_bytes_written_per_signal);
-    return bytes_written == kInputString.size();
-  }));
+  EXPECT_EQ(
+      absl::c_accumulate(bytes_written_signal, uint64_t{0},
+                         [](uint64_t lhs, const auto& signal) { return lhs + signal[0].toInt(); }),
+      kInputString.size());
 
-  if (!task.IsStopped()) {
-    QSignalSpy stopped_signal{&task, &orbit_ssh_qt::Task::stopped};
-    EXPECT_TRUE(stopped_signal.wait());
-  }
+  std::string std_out{};
+  QObject::connect(&task, &Task::readyReadStdOut, &task,
+                   [&std_out, &task]() { std_out.append(task.ReadStdOut()); });
 
-  EXPECT_FALSE(ready_read_signal.empty());
-  EXPECT_EQ(task.ReadStdOut(), kInputString);
+  EXPECT_TRUE(QTest::qWaitFor([&std_out, kInputString]() { return std_out == kInputString; }));
+
+  EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));
+}
+
+TEST_F(SshTaskTest, StdinMultipleWrites) {
+  orbit_ssh_qt::Task task{GetSession(), "read"};
+  QSignalSpy ready_read_signal{&task, &orbit_ssh_qt::Task::readyReadStdOut};
+
+  EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
+
+  qRegisterMetaType<size_t>("size_t");
+  QSignalSpy bytes_written_signal{&task, &orbit_ssh_qt::Task::bytesWritten};
+  constexpr std::string_view kInputString{"Hello World\n"};
+
+  // A line breaks make the read command return, so we will only send a line break in the very last
+  // Write call
+  constexpr std::string_view kInputStringNoLineBreak = kInputString.substr(kInputString.size() - 1);
+
+  // We make a few writes here that will be executed asynchronously.
+  std::array futures = {task.Write(kInputStringNoLineBreak), task.Write(kInputStringNoLineBreak),
+                        task.Write(kInputStringNoLineBreak), task.Write(kInputStringNoLineBreak),
+                        task.Write(kInputString)};
+
+  // And here we expect all the writes to complete with no error.
+  EXPECT_THAT(WaitFor(orbit_base::WhenAll<ErrorMessageOr<void>>(futures)),
+              YieldsResult(testing::Each(HasNoError())));
+  EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));
+
+  const uint64_t total_bytes_written =
+      absl::c_accumulate(bytes_written_signal, uint64_t{0},
+                         [](uint64_t lhs, const auto& signal) { return lhs + signal[0].toInt(); });
+  EXPECT_EQ(total_bytes_written, 4 * kInputStringNoLineBreak.size() + kInputString.size());
 }
 
 TEST_F(SshTaskTest, Kill) {
   orbit_ssh_qt::Task task{GetSession(), "read"};
-  task.Start();
-
-  if (!task.IsStarted()) {
-    QSignalSpy started_signal{&task, &orbit_ssh_qt::Task::started};
-    EXPECT_TRUE(started_signal.wait());
-  }
+  EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
 
   QSignalSpy finished_signal{&task, &orbit_ssh_qt::Task::finished};
-  task.Stop();
-
-  if (!task.IsStopped()) {
-    QSignalSpy stopped_signal{&task, &orbit_ssh_qt::Task::stopped};
-    EXPECT_TRUE(stopped_signal.wait());
-  }
-
-  EXPECT_FALSE(finished_signal.empty());
-  EXPECT_EQ(finished_signal[0][0].toInt(), 1);
+  EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));
+  EXPECT_THAT(finished_signal, testing::ElementsAre(testing::ElementsAre(QVariant{1})));
 }
 }  // namespace orbit_ssh_qt

--- a/src/OrbitSshQt/include/OrbitSshQt/Tunnel.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Tunnel.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <system_error>
 
+#include "OrbitBase/Future.h"
 #include "OrbitBase/Result.h"
 #include "OrbitSsh/Channel.h"
 #include "OrbitSshQt/ScopedConnection.h"
@@ -60,8 +61,8 @@ class Tunnel : public StateMachineHelper<Tunnel, details::TunnelState> {
   explicit Tunnel(Session* session, std::string remote_host, uint16_t remote_port,
                   QObject* parent = nullptr);
 
-  void Start();
-  void Stop();
+  orbit_base::Future<ErrorMessageOr<void>> Start();
+  orbit_base::Future<ErrorMessageOr<void>> Stop();
 
   [[nodiscard]] uint16_t GetListenPort() const {
     return local_server_ ? local_server_->serverPort() : 0;

--- a/src/SessionSetup/ServiceDeployManager.cpp
+++ b/src/SessionSetup/ServiceDeployManager.cpp
@@ -206,7 +206,7 @@ ErrorMessageOr<bool> ServiceDeployManager::CheckIfInstalled() {
 
   auto cancel_handler = ConnectCancelHandler(&loop, this);
 
-  check_if_installed_task.Start();
+  std::ignore = check_if_installed_task.Start();
 
   OUTCOME_TRY(auto&& result, loop.exec());
   ORBIT_LOG("CheckIfInstalled task returned exit code: %d", result);
@@ -234,7 +234,7 @@ ErrorMessageOr<uint16_t> ServiceDeployManager::StartTunnel(
   auto quit_handler = ConnectQuitHandler(&loop, &tunnel->value(), &orbit_ssh_qt::Tunnel::started);
   auto cancel_handler = ConnectCancelHandler(&loop, this);
 
-  tunnel->value().Start();
+  std::ignore = tunnel->value().Start();
 
   OUTCOME_TRY(MapError(loop.exec(), Error::kCouldNotStartTunnel));
 
@@ -513,7 +513,7 @@ ErrorMessageOr<void> ServiceDeployManager::StartOrbitService(
 
   if (std::holds_alternative<BareExecutableAndRootPasswordDeployment>(deployment_config)) {
     const auto& config = std::get<BareExecutableAndRootPasswordDeployment>(deployment_config);
-    orbit_service_task_->Write(absl::StrFormat("%s\n", config.root_password));
+    std::ignore = orbit_service_task_->Write(absl::StrFormat("%s\n", config.root_password));
     // TODO(antonrohr) Check whether the password was incorrect.
     // There are multiple ways of doing this. the best way is probably to have a
     // second task running before OrbitService that sets the SUID bit. It might be
@@ -594,7 +594,7 @@ ErrorMessageOr<void> ServiceDeployManager::StartOrbitService(
     loop.error(ErrorMessage{std::move(error_message)});
   });
 
-  orbit_service_task_->Start();
+  std::ignore = orbit_service_task_->Start();
 
   OUTCOME_TRY(loop.exec());
   QObject::connect(&orbit_service_task_.value(), &orbit_ssh_qt::Task::readyReadStdOut, this,
@@ -633,7 +633,7 @@ ErrorMessageOr<void> ServiceDeployManager::InstallOrbitServicePackage() {
       ConnectErrorHandler(&loop, &install_service_task, &orbit_ssh_qt::Task::errorOccurred);
   auto cancel_handler = ConnectCancelHandler(&loop, this);
 
-  install_service_task.Start();
+  std::ignore = install_service_task.Start();
 
   OUTCOME_TRY(loop.exec());
   return outcome::success();
@@ -669,11 +669,11 @@ ErrorMessageOr<void> ServiceDeployManager::ConnectToServer() {
 
 void ServiceDeployManager::StartWatchdog() {
   ORBIT_CHECK(QThread::currentThread() == thread());
-  orbit_service_task_->Write(kSshWatchdogPassphrase);
+  std::ignore = orbit_service_task_->Write(kSshWatchdogPassphrase);
 
   QObject::connect(&ssh_watchdog_timer_, &QTimer::timeout, [this]() {
     ORBIT_CHECK(orbit_service_task_.has_value());
-    orbit_service_task_->Write(".");
+    std::ignore = orbit_service_task_->Write(".");
   });
 
   ssh_watchdog_timer_.start(kSshWatchdogInterval);
@@ -766,7 +766,7 @@ ErrorMessageOr<void> ServiceDeployManager::ShutdownTunnel(orbit_ssh_qt::Tunnel* 
   auto error_handler = ConnectQuitHandler(&loop, tunnel, &orbit_ssh_qt::Tunnel::errorOccurred);
   auto cancel_handler = ConnectCancelHandler(&loop, this);
 
-  tunnel->Stop();
+  std::ignore = tunnel->Stop();
 
   OUTCOME_TRY(loop.exec());
   return outcome::success();
@@ -781,7 +781,7 @@ ErrorMessageOr<void> ServiceDeployManager::ShutdownTask(orbit_ssh_qt::Task* task
   auto error_handler = ConnectQuitHandler(&loop, task, &orbit_ssh_qt::Task::errorOccurred);
   auto cancel_handler = ConnectCancelHandler(&loop, this);
 
-  task->Stop();
+  std::ignore = task->Stop();
 
   OUTCOME_TRY(loop.exec());
   return outcome::success();


### PR DESCRIPTION
Similar to `orbit_ssh_qt::Session`, this is changing the public methods ot `Task` and `Tunnel` to return futures as far as possible.

This includes:
- `Task::Start`
- `Task::Stop`
- `Task::Write`
- `Tunnel::Start`
- `Tunnel::Stop`

The `Start`/`Stop` methods are trivial because they rely on the facilities provided by `StateMachineHelper`. `Task::Write` is a little more contrived, because it requires `Task` to do some state management.