### PR TITLE
Silence clang-tidy in ORBIT_CHECK macro

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -61,4 +61,6 @@ CheckOptions:
     value:           'CamelCase'
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '1'
+  - key:             cppcoreguidelines-avoid-do-while.IgnoreMacros
+    value:           'true'
 ...

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -130,7 +130,7 @@ struct FuzzingException {};
 #elif defined(_WIN32)
 #define ORBIT_INTERNAL_PLATFORM_LOG(message)        \
   do {                                              \
-    fprintf(stderr, "%s", message);                 \
+    (void)std::fputs(message, stderr);              \
     orbit_base_internal::OutputToDebugger(message); \
     orbit_base_internal::LogToFile(message);        \
   } while (0)
@@ -142,7 +142,7 @@ struct FuzzingException {};
 #else
 #define ORBIT_INTERNAL_PLATFORM_LOG(message) \
   do {                                       \
-    fprintf(stderr, "%s", message);          \
+    (void)std::fputs(message, stderr);       \
     orbit_base_internal::LogToFile(message); \
   } while (0)
 #define ORBIT_INTERNAL_PLATFORM_ABORT() abort()


### PR DESCRIPTION
First this is disabling the avoid-do-while-loop check for macros because it's a common way to create macro the behaves like a function (expects a semicolon at the end).

Second this is explicitly ignoring the return value of the `fprintf` to silence another check about using return values. It also adds `std::` to this functions and replaces it by the more suitable and faster `fputs` function.