### PR TITLE
Move socat port number parsing into helper function

### DIFF
--- a/src/SshQtTestUtils/CMakeLists.txt
+++ b/src/SshQtTestUtils/CMakeLists.txt
@@ -5,15 +5,25 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(SshQtTestUtils)
-add_library(SshQtTestUtils INTERFACE)
+add_library(SshQtTestUtils STATIC)
 
-target_include_directories(SshQtTestUtils INTERFACE include/)
-target_link_libraries(SshQtTestUtils INTERFACE
+target_include_directories(SshQtTestUtils PUBLIC include/)
+target_link_libraries(SshQtTestUtils PUBLIC
   OrbitBase
   OrbitSsh
-  OrbitSshQt)
+  OrbitSshQt
+  absl::strings)
+
+target_sources(SshQtTestUtils PRIVATE
+  ParsePortNumberFromSocatOutput.cpp)
 
 target_sources(SshQtTestUtils PUBLIC
+  include/SshQtTestUtils/ParsePortNumberFromSocatOutput.h
   include/SshQtTestUtils/SshSessionTest.h
-  include/SshQtTestUtils/SshTestFixture.h
-  )
+  include/SshQtTestUtils/SshTestFixture.h)
+
+add_executable(SshQtTestUtilsTests
+  ParsePortNumberFromSocatOutputTest.cpp)
+
+target_link_libraries(SshQtTestUtilsTests PRIVATE SshQtTestUtils TestUtils GTest::Main)
+register_test(SshQtTestUtilsTests)

--- a/src/SshQtTestUtils/ParsePortNumberFromSocatOutput.cpp
+++ b/src/SshQtTestUtils/ParsePortNumberFromSocatOutput.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SshQtTestUtils/ParsePortNumberFromSocatOutput.h"
+
+#include <absl/strings/match.h>
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+
+#include <string_view>
+
+namespace orbit_ssh_qt_test_utils {
+
+std::optional<ErrorMessageOr<int>> ParsePortNumberFromSocatOutput(std::string_view socat_output) {
+  // The relevant information is in the first line of the stderr output. So we wait until we have
+  // received the first line break.
+  if (!absl::StrContains(socat_output, '\n')) {
+    return std::nullopt;
+  }
+
+  auto lines = absl::StrSplit(socat_output, '\n');
+  std::string_view first_line = *lines.begin();
+
+  constexpr std::string_view kIpAddress{"0.0.0.0:"};
+  auto ip_location = first_line.find(kIpAddress);
+  if (ip_location == std::string_view::npos) {
+    return ErrorMessage{
+        absl::StrCat("Couldn't find the IP address in the first line: ", first_line)};
+  }
+
+  std::string_view port_as_string = first_line.substr(ip_location + kIpAddress.size());
+  int port{};
+  if (!absl::SimpleAtoi(port_as_string, &port)) {
+    return ErrorMessage{absl::StrCat("Couldn't parse port number. Input was: ", port_as_string)};
+  }
+
+  return port;
+}
+}  // namespace orbit_ssh_qt_test_utils

--- a/src/SshQtTestUtils/ParsePortNumberFromSocatOutput.cpp
+++ b/src/SshQtTestUtils/ParsePortNumberFromSocatOutput.cpp
@@ -22,14 +22,14 @@ std::optional<ErrorMessageOr<int>> ParsePortNumberFromSocatOutput(std::string_vi
   auto lines = absl::StrSplit(socat_output, '\n');
   std::string_view first_line = *lines.begin();
 
-  constexpr std::string_view kIpAddress{"0.0.0.0:"};
-  auto ip_location = first_line.find(kIpAddress);
+  constexpr std::string_view kIpAddressAndColon{"0.0.0.0:"};
+  auto ip_location = first_line.find(kIpAddressAndColon);
   if (ip_location == std::string_view::npos) {
     return ErrorMessage{
         absl::StrCat("Couldn't find the IP address in the first line: ", first_line)};
   }
 
-  std::string_view port_as_string = first_line.substr(ip_location + kIpAddress.size());
+  std::string_view port_as_string = first_line.substr(ip_location + kIpAddressAndColon.size());
   int port{};
   if (!absl::SimpleAtoi(port_as_string, &port)) {
     return ErrorMessage{absl::StrCat("Couldn't parse port number. Input was: ", port_as_string)};

--- a/src/SshQtTestUtils/ParsePortNumberFromSocatOutputTest.cpp
+++ b/src/SshQtTestUtils/ParsePortNumberFromSocatOutputTest.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string_view>
+
+#include "SshQtTestUtils/ParsePortNumberFromSocatOutput.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_ssh_qt_test_utils {
+
+constexpr std::string_view kReferenceSocatOutput =
+    "2022/12/12 12:12:42 socat[394] N listening on AF=2 0.0.0.0:58747\n";
+constexpr std::array kInvalidSocatOutputs{
+    std::string_view{
+        "2022/12/12 12:12:42 socat[394] N listening on AF=2 0.0.0.0:noport\n"},  // invalid port
+    std::string_view{
+        "2022/12/12 12:12:42 socat[394] N listening on AF=2 0.0.0.058747\n"}};  // Missing colon
+
+TEST(ParsePortNumberFromSocatOutput, IncompleteInput) {
+  auto result = ParsePortNumberFromSocatOutput(
+      kReferenceSocatOutput.substr(0, kReferenceSocatOutput.size() - 1));
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(ParsePortNumberFromSocatOutput, CompleteInput) {
+  auto result = ParsePortNumberFromSocatOutput(kReferenceSocatOutput);
+  EXPECT_TRUE(result.has_value());
+  EXPECT_THAT(result.value(), orbit_test_utils::HasValue(58747));
+}
+
+TEST(ParsePortNumberFromSocatOutput, InvalidInput) {
+  for (const auto invalid_input : kInvalidSocatOutputs) {
+    auto result = ParsePortNumberFromSocatOutput(invalid_input);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->has_error());
+  }
+}
+}  // namespace orbit_ssh_qt_test_utils

--- a/src/SshQtTestUtils/ParsePortNumberFromSocatOutputTest.cpp
+++ b/src/SshQtTestUtils/ParsePortNumberFromSocatOutputTest.cpp
@@ -14,11 +14,6 @@ namespace orbit_ssh_qt_test_utils {
 
 constexpr std::string_view kReferenceSocatOutput =
     "2022/12/12 12:12:42 socat[394] N listening on AF=2 0.0.0.0:58747\n";
-constexpr std::array kInvalidSocatOutputs{
-    std::string_view{
-        "2022/12/12 12:12:42 socat[394] N listening on AF=2 0.0.0.0:noport\n"},  // invalid port
-    std::string_view{
-        "2022/12/12 12:12:42 socat[394] N listening on AF=2 0.0.0.058747\n"}};  // Missing colon
 
 TEST(ParsePortNumberFromSocatOutput, IncompleteInput) {
   auto result = ParsePortNumberFromSocatOutput(
@@ -33,6 +28,12 @@ TEST(ParsePortNumberFromSocatOutput, CompleteInput) {
 }
 
 TEST(ParsePortNumberFromSocatOutput, InvalidInput) {
+  constexpr std::array kInvalidSocatOutputs{
+      std::string_view{
+          "2022/12/12 12:12:42 socat[394] N listening on AF=2 0.0.0.0:noport\n"},  // invalid port
+      std::string_view{
+          "2022/12/12 12:12:42 socat[394] N listening on AF=2 0.0.0.058747\n"}};  // Missing colon
+
   for (const auto invalid_input : kInvalidSocatOutputs) {
     auto result = ParsePortNumberFromSocatOutput(invalid_input);
     ASSERT_TRUE(result.has_value());

--- a/src/SshQtTestUtils/include/SshQtTestUtils/ParsePortNumberFromSocatOutput.h
+++ b/src/SshQtTestUtils/include/SshQtTestUtils/ParsePortNumberFromSocatOutput.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_SSH_QT_TEST_UTILS_PARSE_PORT_NUMBER_FROM_SOCAT_OUTPUT_H_
+#define ORBIT_SSH_QT_TEST_UTILS_PARSE_PORT_NUMBER_FROM_SOCAT_OUTPUT_H_
+
+#include <optional>
+#include <string_view>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_ssh_qt_test_utils {
+
+// If successful this functions returns a port number that has been parsed from the string
+// `socat_output`. If `socat_output` doesn't yet contain the port number this functions returns an
+// empty optional.
+// If an error occurs the functions returns an error message. The intent is that the user retries to
+// call the function until either an error occurs or it yields a port number.
+[[nodiscard]] std::optional<ErrorMessageOr<int>> ParsePortNumberFromSocatOutput(
+    std::string_view socat_output);
+
+}  // namespace orbit_ssh_qt_test_utils
+
+#endif  // ORBIT_SSH_QT_TEST_UTILS_PARSE_PORT_NUMBER_FROM_SOCAT_OUTPUT_H_


### PR DESCRIPTION
This is moving more code into SshQtTestUtils to be able to share it with the upcoming tests for ServiceDeployManager.

It is also adding tests for this parsing code.