### PR TITLE
Add override and remove virtual

### DIFF
--- a/src/CaptureClient/include/CaptureClient/AbstractCaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/AbstractCaptureListener.h
@@ -25,7 +25,7 @@ class AbstractCaptureListener : public CaptureListener {
   AbstractCaptureListener(AbstractCaptureListener&&) = default;
   AbstractCaptureListener& operator=(AbstractCaptureListener&& other) = default;
 
-  virtual ~AbstractCaptureListener() = default;
+  ~AbstractCaptureListener() override = default;
 
   void OnAddressInfo(orbit_client_data::LinuxAddressInfo address_info) override {
     GetMutableCaptureDataFromDerived().InsertAddressInfo(std::move(address_info));

--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -86,7 +86,7 @@ class TimerData final : public TimerDataInterface {
 
   // Unused methods needed in TimerDataInterface
   [[nodiscard]] int64_t GetThreadId() const override { return -1; }
-  virtual void OnCaptureComplete() override {}
+  void OnCaptureComplete() override {}
 
  private:
   void UpdateMinTime(uint64_t min_time);

--- a/src/ClientServices/WindowsProcessLauncherClient.cpp
+++ b/src/ClientServices/WindowsProcessLauncherClient.cpp
@@ -33,7 +33,7 @@ class WindowsProcessLauncherClientImpl : public WindowsProcessLauncherClient {
   explicit WindowsProcessLauncherClientImpl(const std::shared_ptr<grpc::Channel>& channel)
       : windows_process_launcher_service_(
             orbit_grpc_protos::WindowsProcessLauncherService::NewStub(channel)) {}
-  virtual ~WindowsProcessLauncherClientImpl() = default;
+  ~WindowsProcessLauncherClientImpl() override = default;
 
   ErrorMessageOr<orbit_grpc_protos::ProcessInfo> LaunchProcess(
       const orbit_grpc_protos::ProcessToLaunch& process_to_launch) override;

--- a/src/DataViews/include/DataViews/AppInterface.h
+++ b/src/DataViews/include/DataViews/AppInterface.h
@@ -34,7 +34,7 @@ class AppInterface : public orbit_client_data::CaptureDataHolder {
 
  public:
   AppInterface() = default;
-  virtual ~AppInterface() = default;
+  ~AppInterface() override = default;
 
   // Functions needed by DataView
   virtual void SetClipboard(std::string_view contents) = 0;

--- a/src/FakeClient/GraphicsCaptureEventProcessor.h
+++ b/src/FakeClient/GraphicsCaptureEventProcessor.h
@@ -54,7 +54,7 @@ void ForEachCentile(uint32_t num_centiles, const Distribution& distribution,
 // keeping track of the calls to the frame boundary function and GPU queue submissions.
 class GraphicsCaptureEventProcessor : public orbit_capture_client::CaptureEventProcessor {
  public:
-  ~GraphicsCaptureEventProcessor() {
+  ~GraphicsCaptureEventProcessor() override {
     CalculateCpuStats();
     CalculateGpuStats();
     std::filesystem::path file_path(absl::GetFlag(FLAGS_output_path));

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -60,7 +60,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
   MizarData(MizarData&& other) = default;
   MizarData& operator=(MizarData&& other) = delete;
 
-  virtual ~MizarData() = default;
+  ~MizarData() override = default;
 
   [[nodiscard]] const absl::flat_hash_map<PresentEvent::Source, std::vector<PresentEvent>>&
   source_to_present_events() const override {

--- a/src/MizarData/include/MizarData/MizarDataProvider.h
+++ b/src/MizarData/include/MizarData/MizarDataProvider.h
@@ -30,7 +30,7 @@ class MizarDataProvider : public orbit_client_data::CaptureDataHolder {
   MizarDataProvider(MizarDataProvider&&) = default;
   MizarDataProvider& operator=(MizarDataProvider&& other) = default;
 
-  virtual ~MizarDataProvider() = default;
+  ~MizarDataProvider() override = default;
 
   [[nodiscard]] virtual const absl::flat_hash_map<orbit_grpc_protos::PresentEvent::Source,
                                                   std::vector<orbit_grpc_protos::PresentEvent>>&

--- a/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackOutputWidget.h
+++ b/src/MizarWidgets/include/MizarWidgets/SamplingWithFrameTrackOutputWidget.h
@@ -36,7 +36,7 @@ class SamplingWithFrameTrackOutputWidget : public QWidget {
 
  public:
   explicit SamplingWithFrameTrackOutputWidget(QWidget* parent = nullptr);
-  ~SamplingWithFrameTrackOutputWidget();
+  ~SamplingWithFrameTrackOutputWidget() override;
   void UpdateReport(Report report);
 
  public slots:

--- a/src/ObjectUtils/include/ObjectUtils/PdbFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/PdbFile.h
@@ -20,7 +20,7 @@ namespace orbit_object_utils {
 class PdbFile : public SymbolsFile {
  public:
   PdbFile() = default;
-  virtual ~PdbFile() = default;
+  ~PdbFile() override = default;
 
   // GUID and Age are used to match PDB files to objects, similar to build id in the ELF case.
   [[nodiscard]] virtual std::array<uint8_t, 16> GetGuid() const = 0;

--- a/src/OrbitBase/ThreadPool.cpp
+++ b/src/OrbitBase/ThreadPool.cpp
@@ -34,7 +34,7 @@ class ThreadPoolImpl : public ThreadPool {
   explicit ThreadPoolImpl(size_t thread_pool_min_size, size_t thread_pool_max_size,
                           absl::Duration thread_ttl,
                           std::function<void(const std::unique_ptr<Action>&)> run_action);
-  ~ThreadPoolImpl() {
+  ~ThreadPoolImpl() override {
     ShutdownInternal();
     WaitInternal();
   }

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -26,16 +26,16 @@
 namespace orbit_gl {
 
 class CaptureClientAppInterfaceFake : public orbit_capture_client::CaptureControlInterface {
-  [[nodiscard]] orbit_capture_client::CaptureClient::State GetCaptureState() const {
+  [[nodiscard]] orbit_capture_client::CaptureClient::State GetCaptureState() const override {
     return orbit_capture_client::CaptureClient::State::kStopped;
   }
 
-  [[nodiscard]] bool IsCapturing() const { return false; }
+  [[nodiscard]] bool IsCapturing() const override { return false; }
 
-  void StartCapture() {}
-  void StopCapture() {}
-  void AbortCapture() {}
-  void ToggleCapture() {}
+  void StartCapture() override {}
+  void StopCapture() override {}
+  void AbortCapture() override {}
+  void ToggleCapture() override {}
 };
 
 constexpr int kBottomSafetyMargin = 5;

--- a/src/OrbitQt/include/OrbitQt/AccessibilityAdapter.h
+++ b/src/OrbitQt/include/OrbitQt/AccessibilityAdapter.h
@@ -122,7 +122,7 @@ class AccessibilityAdapter : public QAccessibleInterface {
   [[nodiscard]] QRect rect() const override;
   [[nodiscard]] QAccessible::Role role() const override;
 
-  [[nodiscard]] virtual QAccessible::State state() const override {
+  [[nodiscard]] QAccessible::State state() const override {
     static_assert(sizeof(QAccessible::State) == sizeof(orbit_accessibility::AccessibilityState));
     return absl::bit_cast<QAccessible::State>(info_->AccessibleState());
   }

--- a/src/OrbitQt/include/OrbitQt/FilterPanelWidgetAction.h
+++ b/src/OrbitQt/include/OrbitQt/FilterPanelWidgetAction.h
@@ -26,7 +26,7 @@ class FilterPanelWidgetAction : public QWidgetAction {
 
  public:
   explicit FilterPanelWidgetAction(QWidget* parent);
-  QWidget* createWidget(QWidget* parent);
+  QWidget* createWidget(QWidget* parent) override;
 
  signals:
   void FilterFunctionsTextChanged(const QString& text);

--- a/src/SessionSetup/include/SessionSetup/OrbitServiceInstance.h
+++ b/src/SessionSetup/include/SessionSetup/OrbitServiceInstance.h
@@ -20,7 +20,7 @@ class OrbitServiceInstance : public QObject {
   Q_OBJECT;
 
  public:
-  virtual ~OrbitServiceInstance() = default;
+  ~OrbitServiceInstance() override = default;
   [[nodiscard]] virtual bool IsRunning() const = 0;
   // Sends EOF to OrbitService and blocks until OrbitService ended.
   [[nodiscard]] virtual ErrorMessageOr<void> Shutdown() = 0;


### PR DESCRIPTION
These are two clang-tidy checks.
1. Add override to functions overriding another function.
2. Remove virtual to functions overriding another function.

Test: Compile