### PR TITLE
Apply "readability-named-parameter" clang-tidy fixes

### DIFF
--- a/src/MizarData/MizarPairedDataTest.cpp
+++ b/src/MizarData/MizarPairedDataTest.cpp
@@ -199,8 +199,9 @@ class MockFrameTrackManager {
 
   explicit MockFrameTrackManager(const MockMizarData* data) { passed_data_ = data; }
 
-  [[nodiscard]] static std::vector<TimestampNs> GetFrameStarts(FrameTrackId, TimestampNs,
-                                                               TimestampNs) {
+  [[nodiscard]] static std::vector<TimestampNs> GetFrameStarts(FrameTrackId /*unused*/,
+                                                               TimestampNs /*unused*/,
+                                                               TimestampNs /*unused*/) {
     return kStarts;
   }
 };

--- a/src/MizarData/include/MizarData/MizarData.h
+++ b/src/MizarData/include/MizarData/MizarData.h
@@ -120,7 +120,7 @@ class MizarData : public orbit_capture_client::AbstractCaptureListener<MizarData
   void OnThreadStateSlice(orbit_client_data::ThreadStateSliceInfo /*thread_state_slice*/) override {
   }
   void OnApiStringEvent(const orbit_client_data::ApiStringEvent& /*unused*/) override {}
-  void OnApiTrackValue(const orbit_client_data::ApiTrackValue&) override {}
+  void OnApiTrackValue(const orbit_client_data::ApiTrackValue& /*unused*/) override {}
   void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {}
   void OnClockResolutionEvent(
       orbit_grpc_protos::ClockResolutionEvent /*clock_resolution_event*/) override {}

--- a/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
+++ b/src/MizarWidgets/SamplingWithFrameTrackInputWidgetTest.cpp
@@ -76,8 +76,9 @@ constexpr std::array<FrameTrackId, kFrameTracksCount> kScopeIds = {
 
 class MockFrameTrackListModel : public QAbstractListModel {
  public:
-  MockFrameTrackListModel(const MockPairedData*, const absl::flat_hash_set<TID>*,
-                          const RelativeTimeNs*, QObject* parent)
+  MockFrameTrackListModel(const MockPairedData* /*unused*/,
+                          const absl::flat_hash_set<TID>* /*unused*/,
+                          const RelativeTimeNs* /*unused*/, QObject* parent)
       : QAbstractListModel(parent) {}
 
   [[nodiscard]] int rowCount(const QModelIndex& /*parent*/) const override {

--- a/src/OrbitBase/UniqueResourceTest.cpp
+++ b/src/OrbitBase/UniqueResourceTest.cpp
@@ -11,7 +11,7 @@
 
 #include "OrbitBase/UniqueResource.h"
 
-void my_delete(size_t) {}
+void my_delete(size_t /*unused*/) {}
 
 TEST(UniqueResource, Construct) {
   orbit_base::unique_resource<size_t, void (*)(size_t)> ur1(123, my_delete);

--- a/src/OrbitBase/WhenAllTest.cpp
+++ b/src/OrbitBase/WhenAllTest.cpp
@@ -39,8 +39,8 @@ struct WhenAllTest<void> : testing::Test {
   using ValueType = void;
   using FutureValueType = void;
 
-  static void FinishPromise(Promise<void>* promise, int) { promise->MarkFinished(); }
-  static void VerifyResult(Future<void>*, size_t) {
+  static void FinishPromise(Promise<void>* promise, int /*unused*/) { promise->MarkFinished(); }
+  static void VerifyResult(Future<void>* /*unused*/, size_t /*unused*/) {
     // Nothing to verify when the result type is void
   }
 };

--- a/src/OrbitBase/include/OrbitBase/AnyInvocable.h
+++ b/src/OrbitBase/include/OrbitBase/AnyInvocable.h
@@ -46,7 +46,7 @@ class AnyInvocable<R(Args...)> {
     using Base::Base;
 
     template <typename... Urgs>
-    constexpr explicit Storage(std::in_place_t, Urgs... args)
+    constexpr explicit Storage(std::in_place_t /*unused*/, Urgs... args)
         : value_{std::forward<Urgs>(args)...} {}
 
     constexpr explicit Storage(const T& value) : value_(value) {}

--- a/src/OrbitBase/include/OrbitBase/AnyMovable.h
+++ b/src/OrbitBase/include/OrbitBase/AnyMovable.h
@@ -49,7 +49,7 @@ class AnyMovable {
     using Base::Base;
 
     template <typename... Args>
-    constexpr explicit Storage(std::in_place_t, Args&&... args)
+    constexpr explicit Storage(std::in_place_t /*unused*/, Args&&... args)
         : value_{std::forward<Args>(args)...} {}
 
     constexpr explicit Storage(const T& value) : value_(value) {}
@@ -70,7 +70,7 @@ class AnyMovable {
         type_info_{&typeid(value)} {}
 
   template <typename T, typename... Args>
-  explicit AnyMovable(std::in_place_type_t<T>, Args&&... args)
+  explicit AnyMovable(std::in_place_type_t<T> /*unused*/, Args&&... args)
       : storage_{std::make_unique<Storage<std::decay_t<T>>>(std::in_place,
                                                             std::forward<Args>(args)...)},
         type_info_{&typeid(std::decay_t<T>)} {}
@@ -89,10 +89,10 @@ class AnyMovable {
   [[nodiscard]] const std::type_info& type() const { return *type_info_; }
 
   template <typename T>
-  friend T* any_movable_cast(AnyMovable*);
+  friend T* any_movable_cast(AnyMovable* /*movable*/);
 
   template <typename T>
-  friend const T* any_movable_cast(const AnyMovable*);
+  friend const T* any_movable_cast(const AnyMovable* /*movable*/);
 };
 
 // This is deviating from Google's naming style to be in line with `static_cast` and others.

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -200,7 +200,9 @@ class IntrospectionCaptureListener : public orbit_capture_client::CaptureListene
                          std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/) override {
     ORBIT_UNREACHABLE();
   }
-  void OnPresentEvent(const orbit_grpc_protos::PresentEvent&) override { ORBIT_UNREACHABLE(); }
+  void OnPresentEvent(const orbit_grpc_protos::PresentEvent& /*present_event*/) override {
+    ORBIT_UNREACHABLE();
+  }
   void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {
     ORBIT_UNREACHABLE();
   }

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -148,9 +148,9 @@ void OrbitGLWidget::mouseMoveEvent(QMouseEvent* event) {
   update();
 }
 
-void OrbitGLWidget::enterEvent(QEvent*) { gl_canvas_->SetIsMouseOver(true); }
+void OrbitGLWidget::enterEvent(QEvent* /*event*/) { gl_canvas_->SetIsMouseOver(true); }
 
-void OrbitGLWidget::leaveEvent(QEvent*) { gl_canvas_->SetIsMouseOver(false); }
+void OrbitGLWidget::leaveEvent(QEvent* /*event*/) { gl_canvas_->SetIsMouseOver(false); }
 
 void OrbitGLWidget::keyPressEvent(QKeyEvent* event) {
   if (gl_canvas_) {

--- a/src/OrbitVulkanLayer/DeviceManagerTest.cpp
+++ b/src/OrbitVulkanLayer/DeviceManagerTest.cpp
@@ -40,7 +40,7 @@ TEST(DeviceManager, DevicePropertiesCannotBeQueriedForUntrackedDevices) {
 
 VkPhysicalDeviceProperties physical_device_properties = {
     .apiVersion = 1, .driverVersion = 2, .limits = {.timestampPeriod = 3.14f}};
-static void MockGetPhysicalDeviceProperties(VkPhysicalDevice,
+static void MockGetPhysicalDeviceProperties(VkPhysicalDevice /*physical_device*/,
                                             VkPhysicalDeviceProperties* out_properties) {
   *out_properties = physical_device_properties;
 }


### PR DESCRIPTION
Test: Compile