### PR TITLE
Make time range selection exclusive

### DIFF
--- a/src/ClientData/ScopeTreeTimerDataTest.cpp
+++ b/src/ClientData/ScopeTreeTimerDataTest.cpp
@@ -121,6 +121,24 @@ TEST(ScopeTreeTimerData, GetTimers) {
   EXPECT_EQ(scope_tree_timer_data.GetTimers().size(), 3);
 }
 
+TEST(ScopeTreeTimerData, GetTimersExclusive) {
+  ScopeTreeTimerData scope_tree_timer_data;
+  AddTimersInScopeTreeTimerDataTest(scope_tree_timer_data);
+  // All timers.
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(kLeftTimerStart - 1, kRightTimerEnd + 1, true).size(),
+            3);
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(kLeftTimerStart, kRightTimerEnd, true).size(), 3);
+  // Cuts off the beginning of the left timer (should not include left timer).
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(kLeftTimerStart + 1, kRightTimerEnd, true).size(), 2);
+  // Cuts off the end of the right timer (should not include right timer).
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(kLeftTimerStart, kRightTimerEnd - 1, true).size(), 1);
+  // Starts and ends within the left timer (includes no timers).
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(kLeftTimerStart + 1, kLeftTimerStart + 2, true).size(),
+            0);
+  // Fully encompasses down timer but not right timer.
+  EXPECT_EQ(scope_tree_timer_data.GetTimers(kDownTimerStart, kDownTimerEnd, true).size(), 1);
+}
+
 TEST(ScopeTreeTimerData, GetTimersAtDepth) {
   ScopeTreeTimerData scope_tree_timer_data;
   AddTimersInScopeTreeTimerDataTest(scope_tree_timer_data);
@@ -206,6 +224,32 @@ TEST(ScopeTreeTimerData, GetTimersAtDepthOptimized) {
     // No timers with `depth = 2` in TimerData.
     verify_size(2, kNormalResolution, kMinTimestamp, kMaxTimestamp, 0);
   }
+}
+
+TEST(ScopeTreeTimerData, GetTimersAtDepthExclusive) {
+  ScopeTreeTimerData scope_tree_timer_data;
+  AddTimersInScopeTreeTimerDataTest(scope_tree_timer_data);
+  // All timers at depth 0.
+  EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthExclusive(0, kLeftTimerStart, kRightTimerEnd + 1)
+                .size(),
+            2);
+  // All timers at depth 1.
+  EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthExclusive(1, kLeftTimerStart, kRightTimerEnd + 1)
+                .size(),
+            1);
+  // Cut off beginning of left timer.
+  EXPECT_EQ(
+      scope_tree_timer_data.GetTimersAtDepthExclusive(0, kLeftTimerStart + 1, kRightTimerEnd + 1)
+          .size(),
+      1);
+  // Cut off right timer from the right.
+  EXPECT_EQ(
+      scope_tree_timer_data.GetTimersAtDepthExclusive(0, kLeftTimerStart, kRightTimerEnd).size(),
+      1);
+  // Cut through both timers.
+  EXPECT_EQ(scope_tree_timer_data.GetTimersAtDepthExclusive(0, kLeftTimerStart + 1, kRightTimerEnd)
+                .size(),
+            0);
 }
 
 TEST(ScopeTreeTimerData, GetLeftRightUpDown) {

--- a/src/ClientData/TimerData.cpp
+++ b/src/ClientData/TimerData.cpp
@@ -51,7 +51,8 @@ const TimerChain* TimerData::GetChain(uint64_t depth) const {
 }
 
 std::vector<const orbit_client_protos::TimerInfo*> TimerData::GetTimers(uint64_t min_tick,
-                                                                        uint64_t max_tick) const {
+                                                                        uint64_t max_tick,
+                                                                        bool exclusive) const {
   ORBIT_SCOPE_WITH_COLOR("GetTimersAtDepthDiscretized", kOrbitColorBlueGrey);
   // TODO(b/204173236): use it in TimerTracks.
   absl::MutexLock lock(&mutex_);
@@ -62,7 +63,11 @@ std::vector<const orbit_client_protos::TimerInfo*> TimerData::GetTimers(uint64_t
       if (!block.Intersects(min_tick, max_tick)) continue;
       for (uint64_t i = 0; i < block.size(); i++) {
         const orbit_client_protos::TimerInfo* timer = &block[i];
-        if (timer->start() <= max_tick && timer->end() >= min_tick) timers.push_back(timer);
+        if (exclusive) {
+          if (timer->end() <= max_tick && timer->start() >= min_tick) timers.push_back(timer);
+        } else {
+          if (timer->start() <= max_tick && timer->end() >= min_tick) timers.push_back(timer);
+        }
       }
     }
   }

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -263,7 +263,7 @@ class CaptureData {
   [[nodiscard]] std::vector<const TimerInfo*> GetAllScopeTimers(
       absl::flat_hash_set<ScopeType> types,
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
-      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max(), bool exclusive = false) const;
 
   [[nodiscard]] std::vector<const TimerInfo*> GetTimersForScope(
       ScopeId scope_id, uint64_t min_tick = std::numeric_limits<uint64_t>::min(),

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -41,8 +41,12 @@ class ScopeTreeTimerData final : public TimerDataInterface {
 
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t start_ns = std::numeric_limits<uint64_t>::min(),
-      uint64_t end_ns = std::numeric_limits<uint64_t>::max()) const override;
+      uint64_t end_ns = std::numeric_limits<uint64_t>::max(),
+      bool exclusive = false) const override;
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepth(
+      uint32_t depth, uint64_t start_ns = std::numeric_limits<uint64_t>::min(),
+      uint64_t end_ns = std::numeric_limits<uint64_t>::max()) const;
+  [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthExclusive(
       uint32_t depth, uint64_t start_ns = std::numeric_limits<uint64_t>::min(),
       uint64_t end_ns = std::numeric_limits<uint64_t>::max()) const;
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimersAtDepthDiscretized(

--- a/src/ClientData/include/ClientData/ThreadTrackDataProvider.h
+++ b/src/ClientData/include/ClientData/ThreadTrackDataProvider.h
@@ -49,8 +49,8 @@ class ThreadTrackDataProvider final {
 
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint32_t thread_id, uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
-      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const {
-    return GetScopeTreeTimerData(thread_id)->GetTimers(min_tick, max_tick);
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max(), bool exclusive = false) const {
+    return GetScopeTreeTimerData(thread_id)->GetTimers(min_tick, max_tick, exclusive);
   }
 
   // This method avoids returning two timers that map to the same pixel, so is especially useful

--- a/src/ClientData/include/ClientData/TimerData.h
+++ b/src/ClientData/include/ClientData/TimerData.h
@@ -39,7 +39,8 @@ class TimerData final : public TimerDataInterface {
   // sortedness is not made use of.
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
-      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const override;
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max(),
+      bool exclusive = false) const override;
   // Returns timers in a particular depth avoiding completely overlapped timers that map to the
   // same pixels in the screen. It assures to return at least one timer in each occupied pixel. The
   // overall complexity is faster than GetTimers since it doesn't require going through all timers.

--- a/src/ClientData/include/ClientData/TimerDataInterface.h
+++ b/src/ClientData/include/ClientData/TimerDataInterface.h
@@ -21,8 +21,11 @@ class TimerDataInterface {
 
   // Timers queries
   [[nodiscard]] virtual std::vector<const TimerChain*> GetChains() const = 0;
+  // Returns all timers contained in [min_tick, max_tick] (always inclusive).
+  // if exclusive=true, excludes timers that start or end outside of the time range.
+  // if exclusive=false, includes all timers that intersect with the time range.
   [[nodiscard]] virtual std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
-      uint64_t min_tick, uint64_t max_tick) const = 0;
+      uint64_t min_tick, uint64_t max_tick, bool exclusive) const = 0;
   // Returns timers in a particular depth avoiding completely overlapped timers that map to the
   // same pixels in the screen. It assures to return at least one timer in each occupied pixel. The
   // overall complexity is faster than GetTimers since it doesn't require going through all timers.

--- a/src/ClientData/include/ClientData/TimerDataManager.h
+++ b/src/ClientData/include/ClientData/TimerDataManager.h
@@ -30,12 +30,12 @@ class TimerDataManager final {
   [[nodiscard]] std::vector<const orbit_client_protos::TimerInfo*> GetTimers(
       orbit_client_protos::TimerInfo_Type type,
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
-      uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const {
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max(), bool exclusive = false) const {
     std::vector<const orbit_client_protos::TimerInfo*> timers;
     absl::MutexLock lock(&mutex_);
     for (const std::unique_ptr<TimerData>& timer_datum : timer_data_) {
       for (const orbit_client_protos::TimerInfo* timer :
-           timer_datum->GetTimers(min_tick, max_tick)) {
+           timer_datum->GetTimers(min_tick, max_tick, exclusive)) {
         if (timer->type() == type) timers.push_back(timer);
       }
     }


### PR DESCRIPTION
This change makes time range selection only include timers that are fully encompassed in the time range (excludes ones that are only partially included in the time range).

Bug: http://b/240112049