### PR TITLE
Move code for killing processes through SSH into SshQtTestUtils

### DIFF
--- a/src/SshQtTestUtils/CMakeLists.txt
+++ b/src/SshQtTestUtils/CMakeLists.txt
@@ -12,12 +12,17 @@ target_link_libraries(SshQtTestUtils PUBLIC
   OrbitBase
   OrbitSsh
   OrbitSshQt
-  absl::strings)
+  QtTestUtils
+  TestUtils
+  absl::strings
+  Qt5::Test)
 
 target_sources(SshQtTestUtils PRIVATE
+  KillProcessListeningOnTcpPort.cpp
   ParsePortNumberFromSocatOutput.cpp)
 
 target_sources(SshQtTestUtils PUBLIC
+  include/SshQtTestUtils/KillProcessListeningOnTcpPort.h
   include/SshQtTestUtils/ParsePortNumberFromSocatOutput.h
   include/SshQtTestUtils/SshSessionTest.h
   include/SshQtTestUtils/SshTestFixture.h)

--- a/src/SshQtTestUtils/KillProcessListeningOnTcpPort.cpp
+++ b/src/SshQtTestUtils/KillProcessListeningOnTcpPort.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SshQtTestUtils/KillProcessListeningOnTcpPort.h"
+
+#include <QSignalSpy>
+
+#include "OrbitBase/Result.h"
+#include "OrbitSshQt/Session.h"
+#include "OrbitSshQt/Task.h"
+#include "QtTestUtils/WaitFor.h"
+
+namespace orbit_ssh_qt_test_utils {
+
+ErrorMessageOr<void> KillProcessListeningOnTcpPort(orbit_ssh_qt::Session* session, int tcp_port) {
+  orbit_ssh_qt::Task kill_task{session, absl::StrFormat("kill $(fuser %d/tcp)", tcp_port)};
+  QSignalSpy finished_signal{&kill_task, &orbit_ssh_qt::Task::finished};
+  auto start_result = orbit_qt_test_utils::WaitFor(kill_task.Start());
+
+  if (orbit_qt_test_utils::HasTimedOut(start_result)) {
+    return ErrorMessage{"Failed to start `kill`. Start procedure timed out."};
+  }
+  OUTCOME_TRY(orbit_qt_test_utils::GetValue(start_result).value());
+
+  orbit_qt_test_utils::WaitForResult<ErrorMessageOr<void>> stop_result =
+      orbit_qt_test_utils::WaitFor(kill_task.Stop());
+
+  if (orbit_qt_test_utils::HasTimedOut(stop_result)) {
+    return ErrorMessage{"Failed to stop `kill`. Stop procedure timed out."};
+  }
+
+  OUTCOME_TRY(orbit_qt_test_utils::GetValue(stop_result).value());
+
+  if (finished_signal.empty() && !finished_signal.wait()) {
+    return ErrorMessage{"Waiting for finished signal timed out."};
+  }
+
+  const int exit_code = finished_signal[0][0].toInt();
+  if (exit_code != 0) {
+    return ErrorMessage{
+        absl::StrFormat("The `kill` command returned a non-zero exit code: %d", exit_code)};
+  }
+
+  return outcome::success();
+}
+
+}  // namespace orbit_ssh_qt_test_utils

--- a/src/SshQtTestUtils/include/SshQtTestUtils/KillProcessListeningOnTcpPort.h
+++ b/src/SshQtTestUtils/include/SshQtTestUtils/KillProcessListeningOnTcpPort.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_SSH_QT_TEST_UTILS_KILL_PROCESS_LISTENING_ON_TCP_PORT_H_
+#define ORBIT_SSH_QT_TEST_UTILS_KILL_PROCESS_LISTENING_ON_TCP_PORT_H_
+
+#include "OrbitBase/Result.h"
+#include "OrbitSshQt/Session.h"
+
+namespace orbit_ssh_qt_test_utils {
+
+// Launches a task through the given SSH session that kills the process listening on the given TCP
+// port. Reports an error if that fails. Note that also an error is reported if it fails to kill
+// any process.
+ErrorMessageOr<void> KillProcessListeningOnTcpPort(orbit_ssh_qt::Session* session, int tcp_port);
+
+}  // namespace orbit_ssh_qt_test_utils
+
+#endif  // ORBIT_SSH_QT_TEST_UTILS_KILL_PROCESS_LISTENING_ON_TCP_PORT_H_


### PR DESCRIPTION
This is another piece of code that I'm moving from OrbitSshQt into the SshQtTestUtils module such that it can also be used by other tests in other modules.