### PR TITLE
Try to get more consistent naming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,6 +48,10 @@ CheckOptions:
     value:           'CamelCase'
   - key:             readability-identifier-naming.ConstexprVariablePrefix
     value:           'k'
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.StaticConstantPrefix
+    value:           'k'
   - key:             readability-identifier-naming.EnumCase
     value:           'CamelCase'
   - key:             readability-identifier-naming.EnumConstantCase

--- a/src/Api/OrbitApiVersions.h
+++ b/src/Api/OrbitApiVersions.h
@@ -12,7 +12,7 @@
 
 // In particular, these are the versions older than the current one.
 
-struct orbit_api_v0 {
+struct orbit_api_v0 {  // NOLINT(readability-identifier-naming)
   uint32_t enabled;
   uint32_t initialized;
   void (*start)(const char* name, orbit_api_color color);
@@ -28,7 +28,7 @@ struct orbit_api_v0 {
   void (*track_double)(const char* name, double value, orbit_api_color color);
 };
 
-struct orbit_api_v1 {
+struct orbit_api_v1 {  // NOLINT(readability-identifier-naming)
   uint32_t enabled;
   uint32_t initialized;
   void (*start)(const char* name, orbit_api_color color, uint64_t group_id,
@@ -52,7 +52,7 @@ struct orbit_api_v1 {
 // version, because we want the Windows layout to be available to us in liborbit.so when dealing
 // with a Windows binary running on Wine.
 
-struct orbit_api_win_v2 {
+struct orbit_api_win_v2 {  // NOLINT(readability-identifier-naming)
   uint32_t enabled;
   uint32_t initialized;
   __attribute__((ms_abi)) void (*start)(const char* name, orbit_api_color color, uint64_t group_id,

--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -314,7 +314,7 @@ extern "C" {
 #endif
 
 // Material Design Colors #500
-typedef enum {
+typedef enum {  // NOLINT(modernize-use-using)
   kOrbitColorAuto = 0x00000000,
   kOrbitColorRed = 0xf44336ff,
   kOrbitColorPink = 0xe91e63ff,
@@ -342,7 +342,7 @@ enum { kOrbitCallerAddressAuto = 0ULL };
 
 enum { kOrbitApiVersion = 2 };
 
-struct orbit_api_v2 {
+struct orbit_api_v2 {  // NOLINT(readability-identifier-naming)
   uint32_t enabled;
   uint32_t initialized;
   void (*start)(const char* name, orbit_api_color color, uint64_t group_id,

--- a/src/ApiInterface/include/ApiInterface/Orbit.h
+++ b/src/ApiInterface/include/ApiInterface/Orbit.h
@@ -314,7 +314,7 @@ extern "C" {
 #endif
 
 // Material Design Colors #500
-typedef enum {  // NOLINT(modernize-use-using)
+typedef enum {  // NOLINT(modernize-use-using): This is C code.
   kOrbitColorAuto = 0x00000000,
   kOrbitColorRed = 0xf44336ff,
   kOrbitColorPink = 0xe91e63ff,

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -58,7 +58,7 @@ namespace {
 std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager& module_manager,
                                           const orbit_client_data::ProcessData& process_data) {
   // We have a different function name for each supported platform.
-  static const std::vector<std::string> orbit_api_get_function_table_address_prefixes{
+  static const std::vector<std::string> kOrbitApiGetFunctionTableAddressPrefixes{
       orbit_api_utils::kOrbitApiGetFunctionTableAddressPrefix,
       orbit_api_utils::kOrbitApiGetFunctionTableAddressWinPrefix};
   std::vector<ApiFunction> api_functions;
@@ -71,7 +71,7 @@ std::vector<ApiFunction> FindApiFunctions(const orbit_client_data::ModuleManager
       continue;
     }
     for (const std::string& orbit_api_get_function_table_address_prefix :
-         orbit_api_get_function_table_address_prefixes) {
+         kOrbitApiGetFunctionTableAddressPrefixes) {
       for (size_t i = 0; i <= kOrbitApiVersion; ++i) {
         std::string function_name =
             absl::StrFormat("%s%u", orbit_api_get_function_table_address_prefix, i);

--- a/src/CaptureFile/CaptureFile.cpp
+++ b/src/CaptureFile/CaptureFile.cpp
@@ -38,7 +38,7 @@ namespace orbit_capture_file {
 
 namespace {
 
-using orbit_base::unique_fd;
+using orbit_base::UniqueFd;
 
 constexpr uint64_t kMaxNumberOfSections = std::numeric_limits<uint16_t>::max();
 
@@ -107,7 +107,7 @@ class CaptureFileImpl : public CaptureFile {
   ErrorMessageOr<bool> ContainsValidUserDataSection() const;
 
   std::filesystem::path file_path_;
-  unique_fd fd_;
+  UniqueFd fd_;
   CaptureFileHeader header_{};
 
   // This is used for boundary checks so that we do not end up
@@ -123,7 +123,7 @@ class CaptureFileImpl : public CaptureFile {
   std::vector<CaptureFileSection> section_list_;
 };
 
-ErrorMessageOr<uint64_t> GetEndOfFileOffset(const unique_fd& fd) {
+ErrorMessageOr<uint64_t> GetEndOfFileOffset(const UniqueFd& fd) {
 #if defined(_WIN32)
   int64_t end_of_file = _lseeki64(fd.get(), 0, SEEK_END);
 #else

--- a/src/CaptureFile/CaptureFileOutputStream.cpp
+++ b/src/CaptureFile/CaptureFileOutputStream.cpp
@@ -57,7 +57,7 @@ class CaptureFileOutputStreamImpl final : public CaptureFileOutputStream {
   OutputType output_type_;
 
   std::filesystem::path path_;
-  orbit_base::unique_fd fd_;
+  orbit_base::UniqueFd fd_;
   BufferOutputStream* output_buffer_ = nullptr;
   std::unique_ptr<google::protobuf::io::ZeroCopyOutputStream> zero_copy_output_stream_;
   std::optional<google::protobuf::io::CodedOutputStream> coded_output_;

--- a/src/CaptureFile/FileFragmentInputStream.h
+++ b/src/CaptureFile/FileFragmentInputStream.h
@@ -26,7 +26,7 @@ namespace orbit_capture_file_internal {
 // https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream
 class FileFragmentInputStream : public google::protobuf::io::ZeroCopyInputStream {
  public:
-  explicit FileFragmentInputStream(const orbit_base::unique_fd& fd, uint64_t file_offset,
+  explicit FileFragmentInputStream(const orbit_base::UniqueFd& fd, uint64_t file_offset,
                                    uint64_t size, size_t block_size = 1 << 16)
       : fd_{fd},
         file_fragments_start_{file_offset},
@@ -51,7 +51,7 @@ class FileFragmentInputStream : public google::protobuf::io::ZeroCopyInputStream
   [[nodiscard]] std::optional<ErrorMessage> GetLastError() const { return last_error_; }
 
  private:
-  const orbit_base::unique_fd& fd_;
+  const orbit_base::UniqueFd& fd_;
   const uint64_t file_fragments_start_;
   const uint64_t file_fragments_end_;
   std::vector<uint8_t> buffer_;

--- a/src/CaptureFile/ProtoSectionInputStreamImpl.h
+++ b/src/CaptureFile/ProtoSectionInputStreamImpl.h
@@ -23,7 +23,7 @@ namespace orbit_capture_file_internal {
 // This class is used to read proto messages from a section of capture file.
 class ProtoSectionInputStreamImpl : public orbit_capture_file::ProtoSectionInputStream {
  public:
-  explicit ProtoSectionInputStreamImpl(orbit_base::unique_fd& fd, uint64_t capture_section_offset,
+  explicit ProtoSectionInputStreamImpl(orbit_base::UniqueFd& fd, uint64_t capture_section_offset,
                                        uint64_t capture_section_size)
       : fd_{fd},
         file_fragment_input_stream_{fd_, capture_section_offset, capture_section_size},
@@ -38,7 +38,7 @@ class ProtoSectionInputStreamImpl : public orbit_capture_file::ProtoSectionInput
   static constexpr int kCodedInputStreamReinitializationThreshold =
       kCodedInputStreamTotalBytesLimit / 2;
 
-  orbit_base::unique_fd& fd_;
+  orbit_base::UniqueFd& fd_;
   FileFragmentInputStream file_fragment_input_stream_;
   std::optional<google::protobuf::io::CodedInputStream> coded_input_stream_;
 };

--- a/src/ClientData/TimerDataTest.cpp
+++ b/src/ClientData/TimerDataTest.cpp
@@ -238,8 +238,8 @@ TEST(TimerData, GetTimersAtDepthDiscretized) {
   // Left, right and down timers
   std::unique_ptr<TimerData> timer_data = GetTimersDifferentDepths();
 
-  uint32_t kOnePixel = 1;
-  uint32_t kNormalResolution = 1000;
+  constexpr uint32_t kOnePixel = 1;
+  constexpr uint32_t kNormalResolution = 1000;
 
   auto verify_size = [&timer_data](uint32_t depth, uint32_t resolution, uint64_t start_ns,
                                    uint64_t end_ns, size_t expected_size) {

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -111,9 +111,9 @@ class CaptureData {
   }
 
   [[nodiscard]] const std::string& GetThreadName(uint32_t thread_id) const {
-    static const std::string empty_string;
+    static const std::string kEmptyString;
     auto it = thread_names_.find(thread_id);
-    return it != thread_names_.end() ? it->second : empty_string;
+    return it != thread_names_.end() ? it->second : kEmptyString;
   }
 
   void AddOrAssignThreadName(uint32_t thread_id, std::string thread_name) {

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -111,9 +111,9 @@ class CaptureData {
   }
 
   [[nodiscard]] const std::string& GetThreadName(uint32_t thread_id) const {
-    static const std::string kEmptyString;
+    static const std::string empty_string;
     auto it = thread_names_.find(thread_id);
-    return it != thread_names_.end() ? it->second : kEmptyString;
+    return it != thread_names_.end() ? it->second : empty_string;
   }
 
   void AddOrAssignThreadName(uint32_t thread_id, std::string thread_name) {

--- a/src/Containers/include/Containers/ScopeTree.h
+++ b/src/Containers/include/Containers/ScopeTree.h
@@ -109,8 +109,8 @@ class ScopeTree {
 
 template <typename ScopeT>
 ScopeTree<ScopeT>::ScopeTree() {
-  static ScopeT kDefaultScope;
-  root_ = CreateNode(&kDefaultScope);
+  static ScopeT default_scope;
+  root_ = CreateNode(&default_scope);
   ordered_nodes_by_depth_[0].emplace(0, root_);
 }
 

--- a/src/DataViews/CallstackDataView.cpp
+++ b/src/DataViews/CallstackDataView.cpp
@@ -37,7 +37,7 @@ namespace orbit_data_views {
 CallstackDataView::CallstackDataView(AppInterface* app) : DataView(DataViewType::kCallstack, app) {}
 
 const std::vector<DataView::Column>& CallstackDataView::GetColumns() {
-  static const std::vector<Column> columns = [] {
+  static const std::vector<Column> kColumns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     columns[kColumnSelected] = {"Hooked", .0f, SortingOrder::kDescending};
@@ -47,7 +47,7 @@ const std::vector<DataView::Column>& CallstackDataView::GetColumns() {
     columns[kColumnAddress] = {"Sampled Address", .0f, SortingOrder::kAscending};
     return columns;
   }();
-  return columns;
+  return kColumns;
 }
 
 std::string CallstackDataView::GetValue(int row, int column) {

--- a/src/DataViews/CallstackDataViewTest.cpp
+++ b/src/DataViews/CallstackDataViewTest.cpp
@@ -328,8 +328,8 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
       0x5250,  //                                module 3 (loaded)        nullptr
       0x2200,  //                                module 4 (not loaded)    nullptr
   };
-  const std::vector<bool> kFrameModuleNotNull{true, true, false, true, true};
-  const std::vector<bool> frame_function_not_null{true, true, false, false, false};
+  static const std::vector<bool> kFrameModuleNotNull{true, true, false, true, true};
+  static const std::vector<bool> kFrameFunctionNotNull{true, true, false, false, false};
 
   bool capture_connected = false;
   std::vector<bool> functions_selected{true, false, true, true, false};
@@ -364,7 +364,7 @@ TEST_F(CallstackDataViewTest, ContextMenuEntriesArePresentCorrectly) {
     ContextMenuEntry select = ContextMenuEntry::kDisabled;
     ContextMenuEntry unselect = ContextMenuEntry::kDisabled;
     for (int selected_index : selected_indices) {
-      if (frame_function_not_null[selected_index] && capture_connected) {
+      if (kFrameFunctionNotNull[selected_index] && capture_connected) {
         // Source code and disassembly actions are available if and only if: 1) capture is connected
         // and 2) there exists a function that is not null.
         source_code_or_disassembly = ContextMenuEntry::kEnabled;

--- a/src/DataViews/DataViewTestUtils.cpp
+++ b/src/DataViews/DataViewTestUtils.cpp
@@ -61,10 +61,10 @@ void CheckCopySelectionIsInvoked(const FlattenContextMenu& context_menu,
 }
 
 static void ExpectSameLines(const std::string_view& actual, const std::string_view& expected) {
-  static const std::string delimeter = "\r\n";
+  static const std::string kDelimeter = "\r\n";
 
-  std::vector<std::string_view> actual_lines = absl::StrSplit(actual, delimeter);
-  std::vector<std::string_view> expected_lines = absl::StrSplit(expected, delimeter);
+  std::vector<std::string_view> actual_lines = absl::StrSplit(actual, kDelimeter);
+  std::vector<std::string_view> expected_lines = absl::StrSplit(expected, kDelimeter);
   EXPECT_THAT(actual_lines, testing::UnorderedElementsAreArray(expected_lines));
 }
 

--- a/src/DataViews/FunctionsDataView.cpp
+++ b/src/DataViews/FunctionsDataView.cpp
@@ -42,7 +42,7 @@ const std::string FunctionsDataView::kApiScopeAsyncTypeString = "MA";
 const std::string FunctionsDataView::kDynamicallyInstrumentedFunctionTypeString = "D";
 
 const std::vector<DataView::Column>& FunctionsDataView::GetColumns() {
-  static const std::vector<Column> columns = [] {
+  static const std::vector<Column> kColumns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     columns[kColumnSelected] = {"Hooked", .0f, SortingOrder::kDescending};
@@ -52,7 +52,7 @@ const std::vector<DataView::Column>& FunctionsDataView::GetColumns() {
     columns[kColumnAddressInModule] = {"Address in module", .0f, SortingOrder::kAscending};
     return columns;
   }();
-  return columns;
+  return kColumns;
 }
 
 bool FunctionsDataView::ShouldShowSelectedFunctionIcon(AppInterface* app,

--- a/src/DataViews/LiveFunctionsDataView.cpp
+++ b/src/DataViews/LiveFunctionsDataView.cpp
@@ -67,7 +67,7 @@ LiveFunctionsDataView::LiveFunctionsDataView(LiveFunctionsInterface* live_functi
 }
 
 const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
-  static const std::vector<Column> columns = [] {
+  static const std::vector<Column> kColumns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     columns[kColumnType] = {"Type", .0f, SortingOrder::kDescending};
@@ -82,7 +82,7 @@ const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
     columns[kColumnAddress] = {"Address", .1f, SortingOrder::kAscending};
     return columns;
   }();
-  return columns;
+  return kColumns;
 }
 
 [[nodiscard]] static std::string BuildTypePartOfTypeColumnString(

--- a/src/DataViews/ModulesDataView.cpp
+++ b/src/DataViews/ModulesDataView.cpp
@@ -37,7 +37,7 @@ namespace orbit_data_views {
 ModulesDataView::ModulesDataView(AppInterface* app) : DataView(DataViewType::kModules, app) {}
 
 const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
-  static const std::vector<Column> columns = [] {
+  static const std::vector<Column> kColumns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     columns[kColumnSymbols] = {"Symbols", .175f, SortingOrder::kDescending};
@@ -47,7 +47,7 @@ const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
     columns[kColumnFileSize] = {"File Size", .1f, SortingOrder::kDescending};
     return columns;
   }();
-  return columns;
+  return kColumns;
 }
 
 std::string ModulesDataView::GetValue(int row, int col) {

--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -101,7 +101,7 @@ std::string PresetsDataView::GetModuleAndFunctionCountList(absl::Span<const Modu
 }
 
 const std::vector<DataView::Column>& PresetsDataView::GetColumns() {
-  static const std::vector<Column> columns = [] {
+  static const std::vector<Column> kColumns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     columns[kColumnLoadState] = {kLoadableColumnName, kLoadableColumnWidth,
@@ -114,7 +114,7 @@ const std::vector<DataView::Column>& PresetsDataView::GetColumns() {
                                     SortingOrder::kDescending};
     return columns;
   }();
-  return columns;
+  return kColumns;
 }
 
 std::string PresetsDataView::GetValue(int row, int column) {

--- a/src/DataViews/SamplingReportDataView.cpp
+++ b/src/DataViews/SamplingReportDataView.cpp
@@ -59,7 +59,7 @@ SamplingReportDataView::SamplingReportDataView(AppInterface* app)
     : DataView(DataViewType::kSampling, app) {}
 
 const std::vector<DataView::Column>& SamplingReportDataView::GetColumns() {
-  static const std::vector<Column> columns = [] {
+  static const std::vector<Column> kColumns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     columns[kColumnSelected] = {"Hooked", .0f, SortingOrder::kDescending};
@@ -71,7 +71,7 @@ const std::vector<DataView::Column>& SamplingReportDataView::GetColumns() {
     columns[kColumnUnwindErrors] = {"Unwind errors, %", .0f, SortingOrder::kDescending};
     return columns;
   }();
-  return columns;
+  return kColumns;
 }
 
 [[nodiscard]] std::string SamplingReportDataView::BuildPercentageString(float percentage) const {
@@ -464,11 +464,11 @@ SampledFunction& SamplingReportDataView::GetSampledFunction(unsigned int row) {
 ErrorMessageOr<void> SamplingReportDataView::WriteStackEventsToCsv(std::string_view file_path) {
   OUTCOME_TRY(auto fd, orbit_base::OpenFileForWriting(file_path));
 
-  static const std::vector<std::string> names{"Thread", "Timestamp (ns)", "Names leaf/foo/main",
-                                              "Addresses leaf_addr/foo_addr/main_addr"};
+  static const std::vector<std::string> kNames{"Thread", "Timestamp (ns)", "Names leaf/foo/main",
+                                               "Addresses leaf_addr/foo_addr/main_addr"};
   constexpr std::string_view kFramesSeparator = "/";
 
-  OUTCOME_TRY(WriteLineToCsv(fd, names));
+  OUTCOME_TRY(WriteLineToCsv(fd, kNames));
   const orbit_client_data::CallstackData& callstack_data = sampling_report_->GetCallstackData();
 
   const std::vector<orbit_client_data::CallstackEvent> callstack_events =

--- a/src/DataViews/include/DataViews/DataView.h
+++ b/src/DataViews/include/DataViews/DataView.h
@@ -76,7 +76,7 @@ static constexpr std::string_view kLineSeparator = "\r\n";
 std::string FormatValueForCsv(std::string_view value);
 
 template <typename Range>
-ErrorMessageOr<void> WriteLineToCsv(const orbit_base::unique_fd& fd, const Range& cells) {
+ErrorMessageOr<void> WriteLineToCsv(const orbit_base::UniqueFd& fd, const Range& cells) {
   std::string header_line = absl::StrJoin(
       cells, kFieldSeparator,
       [](std::string* out, std::string_view name) { out->append(FormatValueForCsv(name)); });

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -421,27 +421,27 @@ int main(int argc, char* argv[]) {
     // Instrument vkQueuePresentKHR, if possible.
     // Some application don't call libVulkan library directly; instead, they just query the
     // function addresses and use those. So let's just instrument the `ggpvlk QueuePresentKHR`
-    static const std::string ggpvlk_module_name = "ggpvlk.so";
-    static const std::string queue_present_function_name{
+    static const std::string kGgpvlkModuleName = "ggpvlk.so";
+    static const std::string kQueuePresentFunctionName{
         "yeti::internal::vulkan::(anonymous namespace)::QueuePresentKHR(VkQueue_T*, "
         "VkPresentInfoKHR const*)"};
 
     std::string libvulkan_file_path;
     for (const orbit_grpc_protos::ModuleInfo& module : modules_or_error.value()) {
-      if (module.soname() == ggpvlk_module_name) {
+      if (module.soname() == kGgpvlkModuleName) {
         libvulkan_file_path = module.file_path();
         break;
       }
     }
     if (!libvulkan_file_path.empty()) {
-      ORBIT_LOG("%s found: instrumenting %s", ggpvlk_module_name, queue_present_function_name);
+      ORBIT_LOG("%s found: instrumenting %s", kGgpvlkModuleName, kQueuePresentFunctionName);
       ManipulateModuleManagerAndSelectedFunctionsToAddInstrumentedFunctionFromFunctionNameInDebugSymbols(
           &module_manager, &options.selected_functions, libvulkan_file_path,
-          queue_present_function_name,
+          kQueuePresentFunctionName,
           orbit_fake_client::FakeCaptureEventProcessor::kFrameBoundaryFunctionId);
-      ORBIT_LOG("%s instrumented", queue_present_function_name);
+      ORBIT_LOG("%s instrumented", kQueuePresentFunctionName);
     } else {
-      ORBIT_LOG("%s not found", ggpvlk_module_name);
+      ORBIT_LOG("%s not found", kGgpvlkModuleName);
     }
   }
 

--- a/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
@@ -277,10 +277,10 @@ LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
         }
       }};
 
-  static const uint64_t mem_total_bytes = GetPhysicalMemoryInBytes();
-  static const uint64_t watchdog_threshold_bytes = mem_total_bytes / 2;
+  static const uint64_t kMemTotalBytes = GetPhysicalMemoryInBytes();
+  static const uint64_t kWatchdogThresholdBytes = kMemTotalBytes / 2;
   ORBIT_LOG("Starting memory watchdog with threshold %u B because total physical memory is %u B",
-            watchdog_threshold_bytes, mem_total_bytes);
+            kWatchdogThresholdBytes, kMemTotalBytes);
   while (true) {
     {
       absl::MutexLock lock{stop_capture_mutex.get()};
@@ -298,7 +298,7 @@ LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
       ORBIT_ERROR_ONCE("Reading resident set size of OrbitService");
       continue;
     }
-    if (rss_bytes.value() > watchdog_threshold_bytes) {
+    if (rss_bytes.value() > kWatchdogThresholdBytes) {
       ORBIT_LOG("Memory threshold exceeded: stopping capture (and stopping memory watchdog)");
       absl::MutexLock lock{stop_capture_mutex.get()};
       *stop_capture = true;

--- a/src/LinuxCaptureService/MemoryWatchdog.cpp
+++ b/src/LinuxCaptureService/MemoryWatchdog.cpp
@@ -49,18 +49,18 @@ std::optional<uint64_t> ExtractRssInPagesFromProcPidStat(std::string_view proc_p
 }
 
 std::optional<uint64_t> ReadRssInBytesFromProcPidStat() {
-  static const pid_t pid = getpid();
-  static const std::string proc_pid_stat_filename = absl::StrFormat("/proc/%d/stat", pid);
+  static const pid_t kPid = getpid();
+  static const std::string kProcPidStatFilename = absl::StrFormat("/proc/%d/stat", kPid);
 
-  ErrorMessageOr<std::string> error_or_stat = orbit_base::ReadFileToString(proc_pid_stat_filename);
+  ErrorMessageOr<std::string> error_or_stat = orbit_base::ReadFileToString(kProcPidStatFilename);
   if (error_or_stat.has_error()) {
-    ORBIT_ERROR_ONCE("Reading \"%s\": %s", proc_pid_stat_filename, error_or_stat.error().message());
+    ORBIT_ERROR_ONCE("Reading \"%s\": %s", kProcPidStatFilename, error_or_stat.error().message());
     return std::nullopt;
   }
 
   std::optional<uint64_t> rss_pages = ExtractRssInPagesFromProcPidStat(error_or_stat.value());
   if (!rss_pages.has_value()) {
-    ORBIT_ERROR_ONCE("Extracting rss from \"%s\"", proc_pid_stat_filename);
+    ORBIT_ERROR_ONCE("Extracting rss from \"%s\"", kProcPidStatFilename);
     return std::nullopt;
   }
 

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -124,22 +124,22 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedWithAllThreePerfEvents) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job, GpuJobEq(expected_gpu_job));
@@ -150,23 +150,23 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedEvenWithOutOfOrderPerfEvents1) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
       .Accept(&visitor_);
   EXPECT_THAT(actual_gpu_job, GpuJobEq(expected_gpu_job));
 }
@@ -176,22 +176,22 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedEvenWithOutOfOrderPerfEvents2) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
   EXPECT_THAT(actual_gpu_job, GpuJobEq(expected_gpu_job));
 }
@@ -201,18 +201,19 @@ TEST_F(GpuTracepointVisitorTest, NoJobBecauseOfMismatchingContext) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampD = 300;
 
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(0);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext + 1, kSeqno, timeline)}
+  PerfEvent{
+      MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext + 1, kSeqno, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
 }
 
@@ -221,17 +222,17 @@ TEST_F(GpuTracepointVisitorTest, NoJobBecauseOfMismatchingSeqno) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampD = 300;
 
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(0);
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno + 1, timeline)}.Accept(
-      &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno + 1, kTimeline)}
+      .Accept(&visitor_);
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
 }
 
@@ -240,17 +241,17 @@ TEST_F(GpuTracepointVisitorTest, NoJobBecauseOfMismatchingTimeline) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampD = 300;
 
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(0);
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline + "1")}
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline + "1")}
       .Accept(&visitor_);
 }
 
@@ -260,7 +261,7 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingByCo
   static constexpr uint32_t kContext1 = 1;
   static constexpr uint32_t kContext2 = 2;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -272,10 +273,10 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingByCo
   static constexpr uint64_t kTimestampD2 = kNsDistanceForSameDepth + 500;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext1, kSeqno, timeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext1, kSeqno, kTimeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext2, kSeqno, timeline, 0, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext2, kSeqno, kTimeline, 0, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -284,18 +285,18 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingByCo
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext1, kSeqno, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext1, kSeqno, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext1, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext1, kSeqno, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext1, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext1, kSeqno, kTimeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext2, kSeqno, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext2, kSeqno, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext2, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext2, kSeqno, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext2, kSeqno, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext2, kSeqno, kTimeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -308,7 +309,7 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingBySe
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -320,10 +321,10 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingBySe
   static constexpr uint64_t kTimestampD2 = kNsDistanceForSameDepth + 500;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 0, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 0, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -332,18 +333,18 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingBySe
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -355,18 +356,18 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsButOnDifferentTimelines) {
   static constexpr pid_t kTid = 42;
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno = 10;
-  static const std::string timeline1 = "timeline1";
-  static const std::string timeline2 = "timeline2";
+  static const std::string kTimeline1 = "timeline1";
+  static const std::string kTimeline2 = "timeline2";
   static constexpr uint64_t kTimestampA = 100;
   static constexpr uint64_t kTimestampB = 200;
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline1, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline1, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno, timeline2, 0, kTimestampA, kTimestampB, kTimestampC,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno, kTimeline2, 0, kTimestampA, kTimestampB, kTimestampC,
                  kTimestampD);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -375,18 +376,18 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsButOnDifferentTimelines) {
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline1)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline1)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline1)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline1)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline1)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline1)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, timeline2)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA, kContext, kSeqno, kTimeline2)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, timeline2)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline2)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, timeline2)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline2)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -399,7 +400,7 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithDifferentDepthsBecause
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -410,10 +411,10 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithDifferentDepthsBecause
   static constexpr uint64_t kTimestampD2 = 600;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 1, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -422,18 +423,18 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithDifferentDepthsBecause
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -446,7 +447,7 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithImmediateHwExecution) {
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -457,10 +458,10 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithImmediateHwExecution) {
   static constexpr uint64_t kTimestampD2 = 410;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 1, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -469,18 +470,18 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithImmediateHwExecution) {
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -493,7 +494,7 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithDelayedHwExecution) {
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampC1 = kTimestampB1;
@@ -504,10 +505,10 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithDelayedHwExecution) {
   static constexpr uint64_t kTimestampD2 = 400;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 0, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 1, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -516,18 +517,18 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithDelayedHwExecution) {
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));
@@ -541,7 +542,7 @@ TEST_F(GpuTracepointVisitorTest,
   static constexpr uint32_t kContext = 1;
   static constexpr uint32_t kSeqno1 = 10;
   static constexpr uint32_t kSeqno2 = 20;
-  static const std::string timeline = "timeline";
+  static const std::string kTimeline = "timeline";
   static constexpr uint64_t kTimestampA1 = 100;
   static constexpr uint64_t kTimestampB1 = 200;
   static constexpr uint64_t kTimestampD1 = 300;
@@ -555,10 +556,10 @@ TEST_F(GpuTracepointVisitorTest,
   static constexpr uint64_t kTimestampC1 = kTimestampD2;
 
   orbit_grpc_protos::FullGpuJob expected_gpu_job1 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno1, timeline, 1, kTimestampA1, kTimestampB1,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno1, kTimeline, 1, kTimestampA1, kTimestampB1,
                  kTimestampC1, kTimestampD1);
   orbit_grpc_protos::FullGpuJob expected_gpu_job2 =
-      MakeGpuJob(kPid, kTid, kContext, kSeqno2, timeline, 0, kTimestampA2, kTimestampB2,
+      MakeGpuJob(kPid, kTid, kContext, kSeqno2, kTimeline, 0, kTimestampA2, kTimestampB2,
                  kTimestampC2, kTimestampD2);
   orbit_grpc_protos::FullGpuJob actual_gpu_job1;
   orbit_grpc_protos::FullGpuJob actual_gpu_job2;
@@ -568,17 +569,17 @@ TEST_F(GpuTracepointVisitorTest,
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job2))
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1));
 
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA1, kContext, kSeqno1, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, timeline)}
+  PerfEvent{MakeFakeAmdgpuCsIoctlPerfEvent(kPid, kTid, kTimestampA2, kContext, kSeqno2, kTimeline)}
       .Accept(&visitor_);
-  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD2, kContext, kSeqno2, kTimeline)}.Accept(
       &visitor_);
-  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, timeline)}.Accept(
+  PerfEvent{MakeFakeDmaFenceSignaledPerfEvent(kTimestampD1, kContext, kSeqno1, kTimeline)}.Accept(
       &visitor_);
 
   EXPECT_THAT(actual_gpu_job1, GpuJobEq(expected_gpu_job1));

--- a/src/LinuxTracing/KernelTracepoints.h
+++ b/src/LinuxTracing/KernelTracepoints.h
@@ -10,15 +10,15 @@
 // Format is based on the content of the event's format file:
 // /sys/kernel/debug/tracing/events/<category>/<name>/format
 
-struct __attribute__((__packed__)) tracepoint_common {
+struct __attribute__((__packed__)) TracepointCommon {
   uint16_t common_type;
   uint8_t common_flags;
   uint8_t common_preempt_count;
   int32_t common_pid;
 };
 
-struct __attribute__((__packed__)) task_newtask_tracepoint {
-  tracepoint_common common;
+struct __attribute__((__packed__)) TaskNewtaskTracepoint {
+  TracepointCommon common;
   int32_t pid;
   char comm[16];
   uint64_t clone_flags;
@@ -26,10 +26,10 @@ struct __attribute__((__packed__)) task_newtask_tracepoint {
   char reserved[14];  // These bytes are not documented in the format file.
 };
 
-static_assert(sizeof(task_newtask_tracepoint) == 52);
+static_assert(sizeof(TaskNewtaskTracepoint) == 52);
 
-struct __attribute__((__packed__)) task_rename_tracepoint {
-  tracepoint_common common;
+struct __attribute__((__packed__)) TaskRenameTracepoint {
+  TracepointCommon common;
   int32_t pid;
   char oldcomm[16];
   char newcomm[16];
@@ -37,10 +37,10 @@ struct __attribute__((__packed__)) task_rename_tracepoint {
   char reserved[6];  // These bytes are not documented in the format file.
 };
 
-static_assert(sizeof(task_rename_tracepoint) == 52);
+static_assert(sizeof(TaskRenameTracepoint) == 52);
 
-struct __attribute__((__packed__)) sched_switch_tracepoint {
-  tracepoint_common common;
+struct __attribute__((__packed__)) SchedSwitchTracepoint {
+  TracepointCommon common;
   char prev_comm[16];
   int32_t prev_pid;
   int32_t prev_prio;
@@ -51,10 +51,10 @@ struct __attribute__((__packed__)) sched_switch_tracepoint {
   char reserved[4];  // These bytes are not documented in the format file.
 };
 
-static_assert(sizeof(sched_switch_tracepoint) == 68);
+static_assert(sizeof(SchedSwitchTracepoint) == 68);
 
-struct __attribute__((__packed__)) sched_wakeup_tracepoint_fixed {
-  tracepoint_common common;
+struct __attribute__((__packed__)) SchedWakeupTracepointFixed {
+  TracepointCommon common;
   char comm[16];
   int32_t pid;
   int32_t prio;
@@ -74,10 +74,10 @@ struct __attribute__((__packed__)) sched_wakeup_tracepoint_fixed {
   // not assume a fixed size.
 };
 
-static_assert(sizeof(sched_wakeup_tracepoint_fixed) == 32);
+static_assert(sizeof(SchedWakeupTracepointFixed) == 32);
 
-struct __attribute__((__packed__)) amdgpu_cs_ioctl_tracepoint {
-  tracepoint_common common;
+struct __attribute__((__packed__)) AmdgpuCsIoctlTracepoint {
+  TracepointCommon common;
   uint64_t sched_job_id;
   int32_t timeline;
   uint32_t context;
@@ -87,8 +87,8 @@ struct __attribute__((__packed__)) amdgpu_cs_ioctl_tracepoint {
   uint32_t num_ibs;
 };
 
-struct __attribute__((__packed__)) amdgpu_sched_run_job_tracepoint {
-  tracepoint_common common;
+struct __attribute__((__packed__)) AmdgpuSchedRunJobTracepoint {
+  TracepointCommon common;
   uint64_t sched_job_id;
   int32_t timeline;
   uint32_t context;
@@ -97,8 +97,8 @@ struct __attribute__((__packed__)) amdgpu_sched_run_job_tracepoint {
   uint32_t num_ibs;
 };
 
-struct __attribute__((__packed__)) dma_fence_signaled_tracepoint {
-  tracepoint_common common;
+struct __attribute__((__packed__)) DmaFenceSignaledTracepoint {
+  TracepointCommon common;
   int32_t driver;
   int32_t timeline;
   uint32_t context;

--- a/src/LinuxTracing/KernelTracepoints.h
+++ b/src/LinuxTracing/KernelTracepoints.h
@@ -10,15 +10,15 @@
 // Format is based on the content of the event's format file:
 // /sys/kernel/debug/tracing/events/<category>/<name>/format
 
-struct __attribute__((__packed__)) TracepointCommon {
+struct __attribute__((__packed__)) CommonTracepointData {
   uint16_t common_type;
   uint8_t common_flags;
   uint8_t common_preempt_count;
   int32_t common_pid;
 };
 
-struct __attribute__((__packed__)) TaskNewtaskTracepoint {
-  TracepointCommon common;
+struct __attribute__((__packed__)) TaskNewtaskTracepointData {
+  CommonTracepointData common;
   int32_t pid;
   char comm[16];
   uint64_t clone_flags;
@@ -26,10 +26,10 @@ struct __attribute__((__packed__)) TaskNewtaskTracepoint {
   char reserved[14];  // These bytes are not documented in the format file.
 };
 
-static_assert(sizeof(TaskNewtaskTracepoint) == 52);
+static_assert(sizeof(TaskNewtaskTracepointData) == 52);
 
-struct __attribute__((__packed__)) TaskRenameTracepoint {
-  TracepointCommon common;
+struct __attribute__((__packed__)) TaskRenameTracepointData {
+  CommonTracepointData common;
   int32_t pid;
   char oldcomm[16];
   char newcomm[16];
@@ -37,10 +37,10 @@ struct __attribute__((__packed__)) TaskRenameTracepoint {
   char reserved[6];  // These bytes are not documented in the format file.
 };
 
-static_assert(sizeof(TaskRenameTracepoint) == 52);
+static_assert(sizeof(TaskRenameTracepointData) == 52);
 
-struct __attribute__((__packed__)) SchedSwitchTracepoint {
-  TracepointCommon common;
+struct __attribute__((__packed__)) SchedSwitchTracepointData {
+  CommonTracepointData common;
   char prev_comm[16];
   int32_t prev_pid;
   int32_t prev_prio;
@@ -51,10 +51,10 @@ struct __attribute__((__packed__)) SchedSwitchTracepoint {
   char reserved[4];  // These bytes are not documented in the format file.
 };
 
-static_assert(sizeof(SchedSwitchTracepoint) == 68);
+static_assert(sizeof(SchedSwitchTracepointData) == 68);
 
-struct __attribute__((__packed__)) SchedWakeupTracepointFixed {
-  TracepointCommon common;
+struct __attribute__((__packed__)) SchedWakeupTracepointDataFixed {
+  CommonTracepointData common;
   char comm[16];
   int32_t pid;
   int32_t prio;
@@ -74,10 +74,10 @@ struct __attribute__((__packed__)) SchedWakeupTracepointFixed {
   // not assume a fixed size.
 };
 
-static_assert(sizeof(SchedWakeupTracepointFixed) == 32);
+static_assert(sizeof(SchedWakeupTracepointDataFixed) == 32);
 
-struct __attribute__((__packed__)) AmdgpuCsIoctlTracepoint {
-  TracepointCommon common;
+struct __attribute__((__packed__)) AmdgpuCsIoctlTracepointData {
+  CommonTracepointData common;
   uint64_t sched_job_id;
   int32_t timeline;
   uint32_t context;
@@ -87,8 +87,8 @@ struct __attribute__((__packed__)) AmdgpuCsIoctlTracepoint {
   uint32_t num_ibs;
 };
 
-struct __attribute__((__packed__)) AmdgpuSchedRunJobTracepoint {
-  TracepointCommon common;
+struct __attribute__((__packed__)) AmdgpuSchedRunJobTracepointData {
+  CommonTracepointData common;
   uint64_t sched_job_id;
   int32_t timeline;
   uint32_t context;
@@ -97,8 +97,8 @@ struct __attribute__((__packed__)) AmdgpuSchedRunJobTracepoint {
   uint32_t num_ibs;
 };
 
-struct __attribute__((__packed__)) DmaFenceSignaledTracepoint {
-  TracepointCommon common;
+struct __attribute__((__packed__)) DmaFenceSignaledTracepointData {
+  CommonTracepointData common;
   int32_t driver;
   int32_t timeline;
   uint32_t context;

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -56,7 +56,7 @@ namespace orbit_linux_tracing {
 
 namespace {
 
-constexpr uint64_t kTotalNumOfRegisters = sizeof(PerfEventSampleRegsUserAll) / sizeof(uint64_t);
+constexpr uint64_t kTotalNumOfRegisters = sizeof(RingBufferSampleRegsUserAll) / sizeof(uint64_t);
 
 class MockLibunwindstackMaps : public LibunwindstackMaps {
  public:
@@ -170,7 +170,7 @@ CallchainSamplePerfEventData BuildFakeCallchainSamplePerfEventData(
 
   if (callchain.size() > 1) {
     // Set the first non-kernel address as IP.
-    PerfEventSampleRegsUserAll regs{};
+    RingBufferSampleRegsUserAll regs{};
     regs.ip = callchain[1];
     std::memcpy(event_data.regs.get(), &regs, sizeof(regs));
   }
@@ -188,7 +188,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnTooSm
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  PerfEventSampleRegsUserAll regs{};
+  RingBufferSampleRegsUserAll regs{};
   regs.bp = 2 * kStackDumpSize;
   regs.sp = 0;
   regs.ip = kTargetAddress1;
@@ -238,7 +238,7 @@ TEST_F(
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  PerfEventSampleRegsUserAll regs{};
+  RingBufferSampleRegsUserAll regs{};
   regs.bp = 2 * kStackDumpSize;
   regs.sp = 0;
   regs.ip = kTargetAddress1;
@@ -292,7 +292,7 @@ TEST_F(LeafFunctionCallManagerTest,
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  PerfEventSampleRegsUserAll regs{};
+  RingBufferSampleRegsUserAll regs{};
   regs.bp = 2 * kStackDumpSize;
   regs.sp = 0;
   regs.ip = kTargetAddress1;
@@ -320,7 +320,7 @@ TEST_F(LeafFunctionCallManagerTest,
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  PerfEventSampleRegsUserAll regs{};
+  RingBufferSampleRegsUserAll regs{};
   regs.bp = 2 * kStackDumpSize;
   regs.sp = 0;
   regs.ip = kTargetAddress1;
@@ -347,7 +347,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnUnwin
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  PerfEventSampleRegsUserAll regs{};
+  RingBufferSampleRegsUserAll regs{};
   regs.bp = kStackDumpSize / 2;
   regs.sp = 10;
   regs.ip = kTargetAddress1;
@@ -434,7 +434,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnNoFra
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
   // bp < sp indicates that bp was used as general purpose register
-  PerfEventSampleRegsUserAll regs{};
+  RingBufferSampleRegsUserAll regs{};
   regs.bp = 1;
   regs.sp = 10;
   regs.ip = kTargetAddress1;
@@ -499,7 +499,7 @@ TEST_F(LeafFunctionCallManagerTest,
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  PerfEventSampleRegsUserAll regs{};
+  RingBufferSampleRegsUserAll regs{};
   regs.bp = kStackDumpSize / 2;
   regs.sp = 10;
   regs.ip = kTargetAddress1;
@@ -549,7 +549,7 @@ TEST_F(LeafFunctionCallManagerTest,
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  PerfEventSampleRegsUserAll regs{};
+  RingBufferSampleRegsUserAll regs{};
   regs.bp = kStackDumpSize / 2;
   regs.sp = 10;
   regs.ip = kTargetAddress1;

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -56,8 +56,7 @@ namespace orbit_linux_tracing {
 
 namespace {
 
-constexpr uint64_t kTotalNumOfRegisters =
-    sizeof(perf_event_sample_regs_user_all) / sizeof(uint64_t);
+constexpr uint64_t kTotalNumOfRegisters = sizeof(PerfEventSampleRegsUserAll) / sizeof(uint64_t);
 
 class MockLibunwindstackMaps : public LibunwindstackMaps {
  public:
@@ -171,7 +170,7 @@ CallchainSamplePerfEventData BuildFakeCallchainSamplePerfEventData(
 
   if (callchain.size() > 1) {
     // Set the first non-kernel address as IP.
-    perf_event_sample_regs_user_all regs{};
+    PerfEventSampleRegsUserAll regs{};
     regs.ip = callchain[1];
     std::memcpy(event_data.regs.get(), &regs, sizeof(regs));
   }
@@ -189,7 +188,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnTooSm
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  perf_event_sample_regs_user_all regs{};
+  PerfEventSampleRegsUserAll regs{};
   regs.bp = 2 * kStackDumpSize;
   regs.sp = 0;
   regs.ip = kTargetAddress1;
@@ -239,7 +238,7 @@ TEST_F(
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  perf_event_sample_regs_user_all regs{};
+  PerfEventSampleRegsUserAll regs{};
   regs.bp = 2 * kStackDumpSize;
   regs.sp = 0;
   regs.ip = kTargetAddress1;
@@ -293,7 +292,7 @@ TEST_F(LeafFunctionCallManagerTest,
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  perf_event_sample_regs_user_all regs{};
+  PerfEventSampleRegsUserAll regs{};
   regs.bp = 2 * kStackDumpSize;
   regs.sp = 0;
   regs.ip = kTargetAddress1;
@@ -321,7 +320,7 @@ TEST_F(LeafFunctionCallManagerTest,
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  perf_event_sample_regs_user_all regs{};
+  PerfEventSampleRegsUserAll regs{};
   regs.bp = 2 * kStackDumpSize;
   regs.sp = 0;
   regs.ip = kTargetAddress1;
@@ -348,7 +347,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnUnwin
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  perf_event_sample_regs_user_all regs{};
+  PerfEventSampleRegsUserAll regs{};
   regs.bp = kStackDumpSize / 2;
   regs.sp = 10;
   regs.ip = kTargetAddress1;
@@ -435,7 +434,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnNoFra
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
   // bp < sp indicates that bp was used as general purpose register
-  perf_event_sample_regs_user_all regs{};
+  PerfEventSampleRegsUserAll regs{};
   regs.bp = 1;
   regs.sp = 10;
   regs.ip = kTargetAddress1;
@@ -500,7 +499,7 @@ TEST_F(LeafFunctionCallManagerTest,
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  perf_event_sample_regs_user_all regs{};
+  PerfEventSampleRegsUserAll regs{};
   regs.bp = kStackDumpSize / 2;
   regs.sp = 10;
   regs.ip = kTargetAddress1;
@@ -550,7 +549,7 @@ TEST_F(LeafFunctionCallManagerTest,
   callchain.push_back(kTargetAddress3 + 1);
 
   CallchainSamplePerfEventData event_data = BuildFakeCallchainSamplePerfEventData(callchain);
-  perf_event_sample_regs_user_all regs{};
+  PerfEventSampleRegsUserAll regs{};
   regs.bp = kStackDumpSize / 2;
   regs.sp = 10;
   regs.ip = kTargetAddress1;

--- a/src/LinuxTracing/PerfEvent.cpp
+++ b/src/LinuxTracing/PerfEvent.cpp
@@ -9,7 +9,7 @@
 namespace orbit_linux_tracing {
 
 std::array<uint64_t, PERF_REG_X86_64_MAX> perf_event_sample_regs_user_all_to_register_array(
-    const PerfEventSampleRegsUserAll& regs) {
+    const RingBufferSampleRegsUserAll& regs) {
   std::array<uint64_t, PERF_REG_X86_64_MAX> registers{};
   registers[PERF_REG_X86_AX] = regs.ax;
   registers[PERF_REG_X86_BX] = regs.bx;

--- a/src/LinuxTracing/PerfEvent.cpp
+++ b/src/LinuxTracing/PerfEvent.cpp
@@ -9,7 +9,7 @@
 namespace orbit_linux_tracing {
 
 std::array<uint64_t, PERF_REG_X86_64_MAX> perf_event_sample_regs_user_all_to_register_array(
-    const perf_event_sample_regs_user_all& regs) {
+    const PerfEventSampleRegsUserAll& regs) {
   std::array<uint64_t, PERF_REG_X86_64_MAX> registers{};
   registers[PERF_REG_X86_AX] = regs.ax;
   registers[PERF_REG_X86_BX] = regs.bx;

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -28,7 +28,7 @@ namespace orbit_linux_tracing {
 class PerfEventVisitor;
 
 [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX>
-perf_event_sample_regs_user_all_to_register_array(const perf_event_sample_regs_user_all& regs);
+perf_event_sample_regs_user_all_to_register_array(const PerfEventSampleRegsUserAll& regs);
 
 // This template class holds data from a specific perf_event_open event, based on the type argument.
 // The top-level fields (`timestamp` and `ordered_in_file_descriptor`) are common to all events,
@@ -65,8 +65,8 @@ struct DiscardedPerfEventData {
 using DiscardedPerfEvent = TypedPerfEvent<DiscardedPerfEventData>;
 
 struct StackSamplePerfEventData {
-  [[nodiscard]] const perf_event_sample_regs_user_all& GetRegisters() const {
-    return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
+  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
@@ -91,8 +91,8 @@ using StackSamplePerfEvent = TypedPerfEvent<StackSamplePerfEventData>;
 struct CallchainSamplePerfEventData {
   [[nodiscard]] const uint64_t* GetCallchain() const { return ips.get(); }
   [[nodiscard]] uint64_t GetCallchainSize() const { return ips_size; }
-  [[nodiscard]] const perf_event_sample_regs_user_all& GetRegisters() const {
-    return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
+  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
@@ -137,13 +137,13 @@ struct UprobesWithArgumentsPerfEventData {
   uint32_t cpu;
   uint64_t function_id = orbit_grpc_protos::kInvalidFunctionId;
   uint64_t return_address;
-  perf_event_sample_regs_user_sp_ip_arguments regs;
+  PerfEventSampleRegsUserSpIpArguments regs;
 };
 using UprobesWithArgumentsPerfEvent = TypedPerfEvent<UprobesWithArgumentsPerfEventData>;
 
 struct UprobesWithStackPerfEventData {
-  [[nodiscard]] const perf_event_sample_regs_user_sp& GetRegisters() const {
-    return *absl::bit_cast<const perf_event_sample_regs_user_sp*>(regs.get());
+  [[nodiscard]] const PerfEventSampleRegsUserSp& GetRegisters() const {
+    return *absl::bit_cast<const PerfEventSampleRegsUserSp*>(regs.get());
   }
   uint64_t stream_id;
   pid_t pid;
@@ -270,8 +270,8 @@ struct SchedWakeupWithCallchainPerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
-  [[nodiscard]] const perf_event_sample_regs_user_all& GetRegisters() const {
-    return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
+  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   void SetIps(absl::Span<const uint64_t> new_ips) const {
@@ -303,8 +303,8 @@ struct SchedSwitchWithCallchainPerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
-  [[nodiscard]] const perf_event_sample_regs_user_all& GetRegisters() const {
-    return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
+  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   void SetIps(absl::Span<const uint64_t> new_ips) const {
@@ -336,8 +336,8 @@ struct SchedWakeupWithStackPerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
-  [[nodiscard]] const perf_event_sample_regs_user_all& GetRegisters() const {
-    return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
+  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   // Handing out this non const pointer makes the stack data mutable even if the
@@ -361,8 +361,8 @@ struct SchedSwitchWithStackPerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
-  [[nodiscard]] const perf_event_sample_regs_user_all& GetRegisters() const {
-    return *absl::bit_cast<const perf_event_sample_regs_user_all*>(regs.get());
+  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   // Handing out this non const pointer makes the stack data mutable even if the

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -28,7 +28,7 @@ namespace orbit_linux_tracing {
 class PerfEventVisitor;
 
 [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX>
-perf_event_sample_regs_user_all_to_register_array(const PerfEventSampleRegsUserAll& regs);
+perf_event_sample_regs_user_all_to_register_array(const RingBufferSampleRegsUserAll& regs);
 
 // This template class holds data from a specific perf_event_open event, based on the type argument.
 // The top-level fields (`timestamp` and `ordered_in_file_descriptor`) are common to all events,
@@ -65,8 +65,8 @@ struct DiscardedPerfEventData {
 using DiscardedPerfEvent = TypedPerfEvent<DiscardedPerfEventData>;
 
 struct StackSamplePerfEventData {
-  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
-    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
+  [[nodiscard]] const RingBufferSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const RingBufferSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
@@ -91,8 +91,8 @@ using StackSamplePerfEvent = TypedPerfEvent<StackSamplePerfEventData>;
 struct CallchainSamplePerfEventData {
   [[nodiscard]] const uint64_t* GetCallchain() const { return ips.get(); }
   [[nodiscard]] uint64_t GetCallchainSize() const { return ips_size; }
-  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
-    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
+  [[nodiscard]] const RingBufferSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const RingBufferSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
@@ -137,13 +137,13 @@ struct UprobesWithArgumentsPerfEventData {
   uint32_t cpu;
   uint64_t function_id = orbit_grpc_protos::kInvalidFunctionId;
   uint64_t return_address;
-  PerfEventSampleRegsUserSpIpArguments regs;
+  RingBufferSampleRegsUserSpIpArguments regs;
 };
 using UprobesWithArgumentsPerfEvent = TypedPerfEvent<UprobesWithArgumentsPerfEventData>;
 
 struct UprobesWithStackPerfEventData {
-  [[nodiscard]] const PerfEventSampleRegsUserSp& GetRegisters() const {
-    return *absl::bit_cast<const PerfEventSampleRegsUserSp*>(regs.get());
+  [[nodiscard]] const RingBufferSampleRegsUserSp& GetRegisters() const {
+    return *absl::bit_cast<const RingBufferSampleRegsUserSp*>(regs.get());
   }
   uint64_t stream_id;
   pid_t pid;
@@ -270,8 +270,8 @@ struct SchedWakeupWithCallchainPerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
-  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
-    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
+  [[nodiscard]] const RingBufferSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const RingBufferSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   void SetIps(absl::Span<const uint64_t> new_ips) const {
@@ -303,8 +303,8 @@ struct SchedSwitchWithCallchainPerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
-  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
-    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
+  [[nodiscard]] const RingBufferSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const RingBufferSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   void SetIps(absl::Span<const uint64_t> new_ips) const {
@@ -336,8 +336,8 @@ struct SchedWakeupWithStackPerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
-  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
-    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
+  [[nodiscard]] const RingBufferSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const RingBufferSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   // Handing out this non const pointer makes the stack data mutable even if the
@@ -361,8 +361,8 @@ struct SchedSwitchWithStackPerfEventData {
   [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegistersAsArray() const {
     return perf_event_sample_regs_user_all_to_register_array(GetRegisters());
   }
-  [[nodiscard]] const PerfEventSampleRegsUserAll& GetRegisters() const {
-    return *absl::bit_cast<const PerfEventSampleRegsUserAll*>(regs.get());
+  [[nodiscard]] const RingBufferSampleRegsUserAll& GetRegisters() const {
+    return *absl::bit_cast<const RingBufferSampleRegsUserAll*>(regs.get());
   }
   [[nodiscard]] const uint8_t* GetStackData() const { return data.get(); }
   // Handing out this non const pointer makes the stack data mutable even if the

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -25,7 +25,7 @@ perf_event_attr generic_event_attr() {
   pe.clockid = orbit_base::kOrbitCaptureClock;
   pe.sample_id_all = 1;  // Also include timestamps for lost events.
   pe.disabled = 1;
-  pe.sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU;
+  pe.sample_type = kSampleTypeTidTimeStreamidCpu;
 
   return pe;
 }
@@ -78,7 +78,7 @@ int stack_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu, uint16_t
   pe.config = PERF_COUNT_SW_CPU_CLOCK;
   pe.sample_period = period_ns;
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
-  pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  pe.sample_regs_user = kSampleRegsUserAll;
 
   pe.sample_stack_user = stack_dump_size;
 
@@ -99,7 +99,7 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu,
   // Also capture a small part of the stack and the registers to allow patching the callers of
   // leaf functions. This is done by unwinding the first two frame using DWARF.
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
-  pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  pe.sample_regs_user = kSampleRegsUserAll;
   pe.sample_stack_user = stack_dump_size;
 
   return generic_event_open(&pe, pid, cpu);
@@ -110,11 +110,11 @@ int uprobes_retaddr_event_open(const char* module, uint64_t function_offset, pid
   perf_event_attr pe = uprobe_event_attr(module, function_offset);
   pe.config &= ~1ULL;
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
-  pe.sample_regs_user = SAMPLE_REGS_USER_SP_IP;
+  pe.sample_regs_user = kSampleRegsUserSpIp;
 
   // Only get the very top of the stack, where the return address has been pushed.
   // We record it as it is about to be hijacked by the installation of the uretprobe.
-  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_8BYTES;
+  pe.sample_stack_user = kSampleStackUserSize8Bytes;
 
   return generic_event_open(&pe, pid, cpu);
 }
@@ -124,7 +124,7 @@ int uprobes_with_stack_and_sp_event_open(const char* module, uint64_t function_o
   perf_event_attr pe = uprobe_event_attr(module, function_offset);
   pe.config &= ~1ULL;
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
-  pe.sample_regs_user = SAMPLE_REGS_USER_SP;
+  pe.sample_regs_user = kSampleRegsUserSp;
 
   pe.sample_stack_user = stack_dump_size;
 
@@ -136,8 +136,8 @@ int uprobes_retaddr_args_event_open(const char* module, uint64_t function_offset
   perf_event_attr pe = uprobe_event_attr(module, function_offset);
   pe.config &= ~1ULL;
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
-  pe.sample_regs_user = SAMPLE_REGS_USER_SP_IP_ARGUMENTS;
-  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_8BYTES;
+  pe.sample_regs_user = kSampleRegsUserSpIpArguments;
+  pe.sample_stack_user = kSampleStackUserSize8Bytes;
 
   return generic_event_open(&pe, pid, cpu);
 }
@@ -155,7 +155,7 @@ int uretprobes_retval_event_open(const char* module, uint64_t function_offset, p
   pe.config |= 1;  // Set bit 0 of config for uretprobe.
 
   pe.sample_type |= PERF_SAMPLE_REGS_USER;
-  pe.sample_regs_user = SAMPLE_REGS_USER_AX;
+  pe.sample_regs_user = kSampleRegsUserAx;
 
   return generic_event_open(&pe, pid, cpu);
 }
@@ -210,7 +210,7 @@ int tracepoint_with_callchain_event_open(const char* tracepoint_category,
   // Also capture a small part of the stack and the registers to allow patching the callers of
   // leaf functions. This is done by unwinding the first two frame using DWARF.
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
-  pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  pe.sample_regs_user = kSampleRegsUserAll;
   pe.sample_stack_user = stack_dump_size;
 
   return generic_event_open(&pe, pid, cpu);
@@ -226,7 +226,7 @@ int tracepoint_with_stack_event_open(const char* tracepoint_category, const char
   pe.type = PERF_TYPE_TRACEPOINT;
   pe.config = tp_id;
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | PERF_SAMPLE_RAW;
-  pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  pe.sample_regs_user = kSampleRegsUserAll;
 
   pe.sample_stack_user = stack_dump_size;
 

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -65,14 +65,14 @@ inline uint64_t perf_event_get_id(int file_descriptor) {
 
 // This must be in sync with struct perf_event_sample_id_tid_time_streamid_cpu
 // in PerfEventRecords.h.
-static constexpr uint64_t SAMPLE_TYPE_TID_TIME_STREAMID_CPU =
+static constexpr uint64_t kSampleTypeTidTimeStreamidCpu =
     PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_STREAM_ID | PERF_SAMPLE_CPU;
 
 // Sample all registers: they might all be necessary for DWARF-based stack
 // unwinding.
 // This must be in sync with struct perf_event_sample_regs_user_all in
 // PerfEventRecords.h.
-static constexpr uint64_t SAMPLE_REGS_USER_ALL =
+static constexpr uint64_t kSampleRegsUserAll =
     (1lu << PERF_REG_X86_AX) | (1lu << PERF_REG_X86_BX) | (1lu << PERF_REG_X86_CX) |
     (1lu << PERF_REG_X86_DX) | (1lu << PERF_REG_X86_SI) | (1lu << PERF_REG_X86_DI) |
     (1lu << PERF_REG_X86_BP) | (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP) |
@@ -83,26 +83,25 @@ static constexpr uint64_t SAMPLE_REGS_USER_ALL =
 
 // This must be in sync with struct perf_event_ax_sample in
 // PerfEventRecords.h.
-static constexpr uint64_t SAMPLE_REGS_USER_AX = (1lu << PERF_REG_X86_AX);
+static constexpr uint64_t kSampleRegsUserAx = (1lu << PERF_REG_X86_AX);
 
 // This must be in sync with struct perf_event_sample_regs_user_sp_ip
 // in PerfEventRecords.h.
-static constexpr uint64_t SAMPLE_REGS_USER_SP_IP =
-    (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP);
+static constexpr uint64_t kSampleRegsUserSpIp = (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP);
 
 // This must be in sync with struct perf_event_sample_regs_user_sp
 // in PerfEventRecords.h.
-static constexpr uint64_t SAMPLE_REGS_USER_SP = (1lu << PERF_REG_X86_SP);
+static constexpr uint64_t kSampleRegsUserSp = (1lu << PERF_REG_X86_SP);
 
 // This must be in sync with struct perf_event_sample_regs_user_sp_ip_arguments
 // in PerfEventRecords.h.
-static constexpr uint64_t SAMPLE_REGS_USER_SP_IP_ARGUMENTS =
+static constexpr uint64_t kSampleRegsUserSpIpArguments =
     (1lu << PERF_REG_X86_CX) | (1lu << PERF_REG_X86_DX) | (1lu << PERF_REG_X86_SI) |
     (1lu << PERF_REG_X86_DI) | (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP) |
     (1lu << PERF_REG_X86_R8) | (1lu << PERF_REG_X86_R9);
 
 static_assert(sizeof(void*) == 8);
-static constexpr uint16_t SAMPLE_STACK_USER_SIZE_8BYTES = 8;
+static constexpr uint16_t kSampleStackUserSize8Bytes = 8;
 
 // Max to pass to perf_event_open without getting an error is (1u << 16u) - 8,
 // because the kernel stores this in a short and because of alignment reasons.

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -73,7 +73,7 @@ struct PerfRecordSample {
                                                           perf_event_attr flags,
                                                           bool copy_stack_related_data = true) {
   ORBIT_CHECK(header.size >
-              sizeof(perf_event_header) + sizeof(perf_event_sample_id_tid_time_streamid_cpu));
+              sizeof(perf_event_header) + sizeof(PerfEventSampleIdTidTimeStreamidCpu));
 
   PerfRecordSample event{};
   int current_offset = 0;
@@ -190,12 +190,12 @@ struct PerfRecordSample {
 }
 
 void ReadPerfSampleIdAll(PerfEventRingBuffer* ring_buffer, const perf_event_header& header,
-                         perf_event_sample_id_tid_time_streamid_cpu* sample_id) {
+                         PerfEventSampleIdTidTimeStreamidCpu* sample_id) {
   ORBIT_CHECK(sample_id != nullptr);
   ORBIT_CHECK(header.size >
-              sizeof(perf_event_header) + sizeof(perf_event_sample_id_tid_time_streamid_cpu));
+              sizeof(perf_event_header) + sizeof(PerfEventSampleIdTidTimeStreamidCpu));
   // sample_id_all is always the last field in the event
-  uint64_t offset = header.size - sizeof(perf_event_sample_id_tid_time_streamid_cpu);
+  uint64_t offset = header.size - sizeof(PerfEventSampleIdTidTimeStreamidCpu);
   ring_buffer->ReadValueAtOffset(sample_id, offset);
 }
 
@@ -203,10 +203,9 @@ uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer) {
   uint64_t time{};
   // All PERF_RECORD_SAMPLEs start with
   //   perf_event_header header;
-  //   perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  //   PerfEventSampleIdTidTimeStreamidCpu sample_id;
   ring_buffer->ReadValueAtOffset(
-      &time,
-      sizeof(perf_event_header) + offsetof(perf_event_sample_id_tid_time_streamid_cpu, time));
+      &time, sizeof(perf_event_header) + offsetof(PerfEventSampleIdTidTimeStreamidCpu, time));
   return time;
 }
 
@@ -214,10 +213,10 @@ uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer) {
   uint64_t stream_id{};
   // All PERF_RECORD_SAMPLEs start with
   //   perf_event_header header;
-  //   perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  //   PerfEventSampleIdTidTimeStreamidCpu sample_id;
   ring_buffer->ReadValueAtOffset(
       &stream_id,
-      sizeof(perf_event_header) + offsetof(perf_event_sample_id_tid_time_streamid_cpu, stream_id));
+      sizeof(perf_event_header) + offsetof(PerfEventSampleIdTidTimeStreamidCpu, stream_id));
   return stream_id;
 }
 
@@ -225,20 +224,19 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
   pid_t pid{};
   // All PERF_RECORD_SAMPLEs start with
   //   perf_event_header header;
-  //   perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  //   PerfEventSampleIdTidTimeStreamidCpu sample_id;
   ring_buffer->ReadValueAtOffset(
-      &pid, sizeof(perf_event_header) + offsetof(perf_event_sample_id_tid_time_streamid_cpu, pid));
+      &pid, sizeof(perf_event_header) + offsetof(PerfEventSampleIdTidTimeStreamidCpu, pid));
   return pid;
 }
 
 uint64_t ReadThrottleUnthrottleRecordTime(PerfEventRingBuffer* ring_buffer) {
-  // Note that perf_event_throttle_unthrottle::time and
-  // perf_event_sample_id_tid_time_streamid_cpu::time differ a bit. Use the latter as we use that
+  // Note that PerfEventThrottleUnthrottle::time and
+  // PerfEventSampleIdTidTimeStreamidCpu::time differ a bit. Use the latter as we use that
   // for all other events.
   uint64_t time{};
-  ring_buffer->ReadValueAtOffset(&time,
-                                 offsetof(perf_event_throttle_unthrottle, sample_id) +
-                                     offsetof(perf_event_sample_id_tid_time_streamid_cpu, time));
+  ring_buffer->ReadValueAtOffset(&time, offsetof(PerfEventThrottleUnthrottle, sample_id) +
+                                            offsetof(PerfEventSampleIdTidTimeStreamidCpu, time));
   return time;
 }
 
@@ -256,18 +254,18 @@ MmapPerfEvent ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
   // };
   // Because of filename, the layout is not fixed.
 
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
   ReadPerfSampleIdAll(ring_buffer, header, &sample_id);
 
-  perf_event_mmap_up_to_pgoff mmap_event;
+  PerfEventMmapUpToPgoff mmap_event;
   ring_buffer->ReadValueAtOffset(&mmap_event, 0);
 
   // read filename
-  size_t filename_offset = sizeof(perf_event_mmap_up_to_pgoff);
+  size_t filename_offset = sizeof(PerfEventMmapUpToPgoff);
   // strictly > because filename is null-terminated string
-  ORBIT_CHECK(header.size > (filename_offset + sizeof(perf_event_sample_id_tid_time_streamid_cpu)));
+  ORBIT_CHECK(header.size > (filename_offset + sizeof(PerfEventSampleIdTidTimeStreamidCpu)));
   size_t filename_size =
-      header.size - filename_offset - sizeof(perf_event_sample_id_tid_time_streamid_cpu);
+      header.size - filename_offset - sizeof(PerfEventSampleIdTidTimeStreamidCpu);
   std::vector<char> filename_vector(filename_size);
   ring_buffer->ReadRawAtOffset(&filename_vector[0], filename_offset, filename_size);
   // This is a bit paranoid but you never know
@@ -313,9 +311,8 @@ StackSamplePerfEvent ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffe
   // The flags here are in sync with stack_sample_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from stack_sample_event_open
   const perf_event_attr flags{
-      .sample_type =
-          PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
-      .sample_regs_user = SAMPLE_REGS_USER_ALL,
+      .sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | kSampleTypeTidTimeStreamidCpu,
+      .sample_regs_user = kSampleRegsUserAll,
   };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
@@ -343,8 +340,8 @@ CallchainSamplePerfEvent ConsumeCallchainSamplePerfEvent(PerfEventRingBuffer* ri
   // TODO(b/242020362): use the same perf_event_attr object from callchain_sample_event_open
   const perf_event_attr flags{
       .sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | PERF_SAMPLE_CALLCHAIN |
-                     SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
-      .sample_regs_user = SAMPLE_REGS_USER_ALL,
+                     kSampleTypeTidTimeStreamidCpu,
+      .sample_regs_user = kSampleRegsUserAll,
   };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
@@ -373,9 +370,8 @@ UprobesWithStackPerfEvent ConsumeUprobeWithStackPerfEvent(PerfEventRingBuffer* r
   // TODO(b/242020362): use the same perf_event_attr object from
   // uprobes_with_stack_and_sp_event_open
   const perf_event_attr flags{
-      .sample_type =
-          PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
-      .sample_regs_user = SAMPLE_REGS_USER_SP,
+      .sample_type = PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER | kSampleTypeTidTimeStreamidCpu,
+      .sample_regs_user = kSampleRegsUserSp,
   };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
@@ -403,7 +399,7 @@ GenericTracepointPerfEvent ConsumeGenericTracepointPerfEvent(PerfEventRingBuffer
   // The flags here are in sync with generic_event_attr in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from generic_event_attr
   const perf_event_attr flags{
-      .sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
+      .sample_type = kSampleTypeTidTimeStreamidCpu,
   };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
@@ -428,13 +424,13 @@ SchedWakeupPerfEvent ConsumeSchedWakeupPerfEvent(PerfEventRingBuffer* ring_buffe
   // The flags here are in sync with tracepoint_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from tracepoint_event_open
   const perf_event_attr flags{
-      .sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU,
+      .sample_type = PERF_SAMPLE_RAW | kSampleTypeTidTimeStreamidCpu,
   };
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags);
 
-  sched_wakeup_tracepoint_fixed sched_wakeup;
-  std::memcpy(&sched_wakeup, res.raw_data.get(), sizeof(sched_wakeup_tracepoint_fixed));
+  SchedWakeupTracepointFixed sched_wakeup;
+  std::memcpy(&sched_wakeup, res.raw_data.get(), sizeof(SchedWakeupTracepointFixed));
 
   ring_buffer->SkipRecord(header);
   return SchedWakeupPerfEvent{
@@ -458,14 +454,14 @@ PerfEvent ConsumeSchedWakeupWithOrWithoutCallchainPerfEvent(PerfEventRingBuffer*
   // TODO(b/242020362): use the same perf_event_attr object from
   // tracepoint_with_callchain_event_open
   const perf_event_attr flags{.sample_type = PERF_SAMPLE_CALLCHAIN | PERF_SAMPLE_RAW |
-                                             SAMPLE_TYPE_TID_TIME_STREAMID_CPU |
-                                             PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER,
-                              .sample_regs_user = SAMPLE_REGS_USER_ALL};
+                                             kSampleTypeTidTimeStreamidCpu | PERF_SAMPLE_REGS_USER |
+                                             PERF_SAMPLE_STACK_USER,
+                              .sample_regs_user = kSampleRegsUserAll};
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags, copy_stack_related_data);
 
-  sched_wakeup_tracepoint_fixed sched_wakeup;
-  std::memcpy(&sched_wakeup, res.raw_data.get(), sizeof(sched_wakeup_tracepoint_fixed));
+  SchedWakeupTracepointFixed sched_wakeup;
+  std::memcpy(&sched_wakeup, res.raw_data.get(), sizeof(SchedWakeupTracepointFixed));
 
   ring_buffer->SkipRecord(header);
 
@@ -507,14 +503,14 @@ PerfEvent ConsumeSchedWakeupWithOrWithoutStackPerfEvent(PerfEventRingBuffer* rin
   // The flags here are in sync with tracepoint_with_stack_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from
   // tracepoint_with_stack_event_open
-  const perf_event_attr flags{.sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU |
+  const perf_event_attr flags{.sample_type = PERF_SAMPLE_RAW | kSampleTypeTidTimeStreamidCpu |
                                              PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER,
-                              .sample_regs_user = SAMPLE_REGS_USER_ALL};
+                              .sample_regs_user = kSampleRegsUserAll};
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags, copy_stack_related_data);
 
-  sched_wakeup_tracepoint_fixed sched_wakeup;
-  std::memcpy(&sched_wakeup, res.raw_data.get(), sizeof(sched_wakeup_tracepoint_fixed));
+  SchedWakeupTracepointFixed sched_wakeup;
+  std::memcpy(&sched_wakeup, res.raw_data.get(), sizeof(SchedWakeupTracepointFixed));
 
   ring_buffer->SkipRecord(header);
 
@@ -557,14 +553,14 @@ PerfEvent ConsumeSchedSwitchWithOrWithoutStackPerfEvent(PerfEventRingBuffer* rin
   // The flags here are in sync with tracepoint_with_stack_event_open in PerfEventOpen.
   // TODO(b/242020362): use the same perf_event_attr object from
   // tracepoint_with_stack_event_open
-  const perf_event_attr flags{.sample_type = PERF_SAMPLE_RAW | SAMPLE_TYPE_TID_TIME_STREAMID_CPU |
+  const perf_event_attr flags{.sample_type = PERF_SAMPLE_RAW | kSampleTypeTidTimeStreamidCpu |
                                              PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER,
-                              .sample_regs_user = SAMPLE_REGS_USER_ALL};
+                              .sample_regs_user = kSampleRegsUserAll};
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags, copy_stack_related_data);
 
-  sched_switch_tracepoint sched_switch;
-  std::memcpy(&sched_switch, res.raw_data.get(), sizeof(sched_switch_tracepoint));
+  SchedSwitchTracepoint sched_switch;
+  std::memcpy(&sched_switch, res.raw_data.get(), sizeof(SchedSwitchTracepoint));
 
   ring_buffer->SkipRecord(header);
 
@@ -616,14 +612,14 @@ PerfEvent ConsumeSchedSwitchWithOrWithoutCallchainPerfEvent(PerfEventRingBuffer*
   // TODO(b/242020362): use the same perf_event_attr object from
   // tracepoint_with_callchain_event_open
   const perf_event_attr flags{.sample_type = PERF_SAMPLE_CALLCHAIN | PERF_SAMPLE_RAW |
-                                             SAMPLE_TYPE_TID_TIME_STREAMID_CPU |
-                                             PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER,
-                              .sample_regs_user = SAMPLE_REGS_USER_ALL};
+                                             kSampleTypeTidTimeStreamidCpu | PERF_SAMPLE_REGS_USER |
+                                             PERF_SAMPLE_STACK_USER,
+                              .sample_regs_user = kSampleRegsUserAll};
 
   PerfRecordSample res = ConsumeRecordSample(ring_buffer, header, flags, copy_stack_related_data);
 
-  sched_switch_tracepoint sched_switch;
-  std::memcpy(&sched_switch, res.raw_data.get(), sizeof(sched_switch_tracepoint));
+  SchedSwitchTracepoint sched_switch;
+  std::memcpy(&sched_switch, res.raw_data.get(), sizeof(SchedSwitchTracepoint));
 
   ring_buffer->SkipRecord(header);
 
@@ -666,16 +662,16 @@ template <typename EventType, typename StructType>
 [[nodiscard]] EventType ConsumeGpuEvent(PerfEventRingBuffer* ring_buffer,
                                         const perf_event_header& header) {
   uint32_t tracepoint_size{};
-  ring_buffer->ReadValueAtOffset(&tracepoint_size, offsetof(perf_event_raw_sample_fixed, size));
+  ring_buffer->ReadValueAtOffset(&tracepoint_size, offsetof(PerfEventRawSampleFixed, size));
 
-  perf_event_raw_sample_fixed ring_buffer_record;
-  ring_buffer->ReadRawAtOffset(&ring_buffer_record, 0, sizeof(perf_event_raw_sample_fixed));
+  PerfEventRawSampleFixed ring_buffer_record;
+  ring_buffer->ReadRawAtOffset(&ring_buffer_record, 0, sizeof(PerfEventRawSampleFixed));
 
   std::unique_ptr<uint8_t[]> tracepoint_data =
       make_unique_for_overwrite<uint8_t[]>(tracepoint_size);
   ring_buffer->ReadRawAtOffset(
       tracepoint_data.get(),
-      offsetof(perf_event_raw_sample_fixed, size) + sizeof(perf_event_raw_sample_fixed::size),
+      offsetof(PerfEventRawSampleFixed, size) + sizeof(PerfEventRawSampleFixed::size),
       tracepoint_size);
   const StructType& typed_tracepoint_data =
       *reinterpret_cast<const StructType*>(tracepoint_data.get());
@@ -708,19 +704,19 @@ template <typename EventType, typename StructType>
 
 AmdgpuCsIoctlPerfEvent ConsumeAmdgpuCsIoctlPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                      const perf_event_header& header) {
-  return ConsumeGpuEvent<AmdgpuCsIoctlPerfEvent, amdgpu_cs_ioctl_tracepoint>(ring_buffer, header);
+  return ConsumeGpuEvent<AmdgpuCsIoctlPerfEvent, AmdgpuCsIoctlTracepoint>(ring_buffer, header);
 }
 
 AmdgpuSchedRunJobPerfEvent ConsumeAmdgpuSchedRunJobPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                              const perf_event_header& header) {
-  return ConsumeGpuEvent<AmdgpuSchedRunJobPerfEvent, amdgpu_sched_run_job_tracepoint>(ring_buffer,
-                                                                                      header);
+  return ConsumeGpuEvent<AmdgpuSchedRunJobPerfEvent, AmdgpuSchedRunJobTracepoint>(ring_buffer,
+                                                                                  header);
 }
 
 DmaFenceSignaledPerfEvent ConsumeDmaFenceSignaledPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                            const perf_event_header& header) {
-  return ConsumeGpuEvent<DmaFenceSignaledPerfEvent, dma_fence_signaled_tracepoint>(ring_buffer,
-                                                                                   header);
+  return ConsumeGpuEvent<DmaFenceSignaledPerfEvent, DmaFenceSignaledTracepoint>(ring_buffer,
+                                                                                header);
 }
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/PerfEventReaders.h
+++ b/src/LinuxTracing/PerfEventReaders.h
@@ -21,7 +21,7 @@ namespace orbit_linux_tracing {
 // This function reads sample_id, which is always the last field
 // in the perf event record unless it is PERF_RECORD_SAMPLE.
 void ReadPerfSampleIdAll(PerfEventRingBuffer* ring_buffer, const perf_event_header& header,
-                         PerfEventSampleIdTidTimeStreamidCpu* sample_id);
+                         RingBufferSampleIdTidTimeStreamidCpu* sample_id);
 
 [[nodiscard]] uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer);
 

--- a/src/LinuxTracing/PerfEventReaders.h
+++ b/src/LinuxTracing/PerfEventReaders.h
@@ -21,7 +21,7 @@ namespace orbit_linux_tracing {
 // This function reads sample_id, which is always the last field
 // in the perf event record unless it is PERF_RECORD_SAMPLE.
 void ReadPerfSampleIdAll(PerfEventRingBuffer* ring_buffer, const perf_event_header& header,
-                         perf_event_sample_id_tid_time_streamid_cpu* sample_id);
+                         PerfEventSampleIdTidTimeStreamidCpu* sample_id);
 
 [[nodiscard]] uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer);
 

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -11,25 +11,25 @@
 
 namespace orbit_linux_tracing {
 
-// This struct must be in sync with the SAMPLE_TYPE_TID_TIME_STREAMID_CPU in PerfEventOpen.h, as the
+// This struct must be in sync with the `kSampleTypeTidTimeStreamidCpu` in PerfEventOpen.h, as the
 // bits set in perf_event_attr::sample_type determine the fields this struct should have.
-struct __attribute__((__packed__)) PerfEventSampleIdTidTimeStreamidCpu {
+struct __attribute__((__packed__)) RingBufferSampleIdTidTimeStreamidCpu {
   uint32_t pid, tid;  /* if PERF_SAMPLE_TID */
   uint64_t time;      /* if PERF_SAMPLE_TIME */
   uint64_t stream_id; /* if PERF_SAMPLE_STREAM_ID */
   uint32_t cpu, res;  /* if PERF_SAMPLE_CPU */
 };
 
-struct __attribute__((__packed__)) PerfEventForkExit {
+struct __attribute__((__packed__)) RingBufferForkExit {
   perf_event_header header;
   uint32_t pid, ppid;
   uint32_t tid, ptid;
   uint64_t time;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_ALL in PerfEventOpen.h.
-struct __attribute__((__packed__)) PerfEventSampleRegsUserAll {
+// This struct must be in sync with the `kSampleRegsUserAll` in PerfEventOpen.h.
+struct __attribute__((__packed__)) RingBufferSampleRegsUserAll {
   uint64_t ax;
   uint64_t bx;
   uint64_t cx;
@@ -52,26 +52,26 @@ struct __attribute__((__packed__)) PerfEventSampleRegsUserAll {
   uint64_t r15;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_AX in PerfEventOpen.h.
-struct __attribute__((__packed__)) PerfEventSampleRegsUserAx {
+// This struct must be in sync with the `kSampleRegsUserAx` in PerfEventOpen.h.
+struct __attribute__((__packed__)) RingBufferSampleRegsUserAx {
   uint64_t abi;
   uint64_t ax;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_SP_IP in PerfEventOpen.h.
-struct __attribute__((__packed__)) PerfEventSampleRegsUserSpIp {
+// This struct must be in sync with the `kSampleRegsUserSpIp` in PerfEventOpen.h.
+struct __attribute__((__packed__)) RingBufferSampleRegsUserSpIp {
   uint64_t abi;
   uint64_t sp;
   uint64_t ip;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_SP in PerfEventOpen.h.
-struct __attribute__((__packed__)) PerfEventSampleRegsUserSp {
+// This struct must be in sync with the `kSampleRegsUserSp` in PerfEventOpen.h.
+struct __attribute__((__packed__)) RingBufferSampleRegsUserSp {
   uint64_t sp;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_USER_SP_IP_ARGUMENTS in PerfEventOpen.h.
-struct __attribute__((__packed__)) PerfEventSampleRegsUserSpIpArguments {
+// This struct must be in sync with the `kSampleRegsUserSpIpArguments` in PerfEventOpen.h.
+struct __attribute__((__packed__)) RingBufferSampleRegsUserSpIpArguments {
   uint64_t abi;
   uint64_t cx;
   uint64_t dx;
@@ -83,75 +83,75 @@ struct __attribute__((__packed__)) PerfEventSampleRegsUserSpIpArguments {
   uint64_t r9;
 };
 
-struct __attribute__((__packed__)) PerfEventSampleStackUser8bytes {
+struct __attribute__((__packed__)) RingBufferSampleStackUser8bytes {
   uint64_t size;
   uint64_t top8bytes;
   uint64_t dyn_size;
 };
 
-struct __attribute__((__packed__)) PerfEventStackSampleFixed {
+struct __attribute__((__packed__)) RingBufferStackSampleFixed {
   perf_event_header header;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
   uint64_t abi;
-  PerfEventSampleRegsUserAll regs;
+  RingBufferSampleRegsUserAll regs;
   // Following this field there are the following fields, which we read dynamically:
   // uint64_t size;                     /* if PERF_SAMPLE_STACK_USER */
   // char data[SAMPLE_STACK_USER_SIZE]; /* if PERF_SAMPLE_STACK_USER */
   // uint64_t dyn_size;                 /* if PERF_SAMPLE_STACK_USER && size != 0 */
 };
 
-struct __attribute__((__packed__)) PerfEventSpIpArguments8bytesSample {
+struct __attribute__((__packed__)) RingBufferSpIpArguments8bytesSample {
   perf_event_header header;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
-  PerfEventSampleRegsUserSpIpArguments regs;
-  PerfEventSampleStackUser8bytes stack;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleRegsUserSpIpArguments regs;
+  RingBufferSampleStackUser8bytes stack;
 };
 
-struct __attribute__((__packed__)) PerfEventSpIp8bytesSample {
+struct __attribute__((__packed__)) RingBufferSpIp8bytesSample {
   perf_event_header header;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
-  PerfEventSampleRegsUserSpIp regs;
-  PerfEventSampleStackUser8bytes stack;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleRegsUserSpIp regs;
+  RingBufferSampleStackUser8bytes stack;
 };
 
-struct __attribute__((__packed__)) PerfEventSpStackUserSampleFixed {
+struct __attribute__((__packed__)) RingBufferSpStackUserSampleFixed {
   perf_event_header header;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
   uint64_t abi;
-  PerfEventSampleRegsUserSp regs;
+  RingBufferSampleRegsUserSp regs;
   // Following this field there are the following fields, which we read dynamically:
   // uint64_t size;                     /* if PERF_SAMPLE_STACK_USER */
   // char data[SAMPLE_STACK_USER_SIZE]; /* if PERF_SAMPLE_STACK_USER */
   // uint64_t dyn_size;                 /* if PERF_SAMPLE_STACK_USER && size != 0 */
 };
 
-struct __attribute__((__packed__)) PerfEventEmptySample {
+struct __attribute__((__packed__)) RingBufferEmptySample {
   perf_event_header header;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
 };
 
-struct __attribute__((__packed__)) PerfEventAxSample {
+struct __attribute__((__packed__)) RingBufferAxSample {
   perf_event_header header;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
-  PerfEventSampleRegsUserAx regs;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleRegsUserAx regs;
 };
 
 template <typename TracepointT>
-struct __attribute__((__packed__)) PerfEventRawSample {
+struct __attribute__((__packed__)) RingBufferRawSample {
   perf_event_header header;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
   uint32_t size;
   TracepointT data;
 };
 
-struct __attribute__((__packed__)) PerfEventRawSampleFixed {
+struct __attribute__((__packed__)) RingBufferRawSampleFixed {
   perf_event_header header;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
   uint32_t size;
   // The rest of the sample is a char[size] that we read dynamically.
 };
 
-struct __attribute__((__packed__)) PerfEventMmapUpToPgoff {
+struct __attribute__((__packed__)) RingBufferMmapUpToPgoff {
   perf_event_header header;
   uint32_t pid;
   uint32_t tid;
@@ -159,22 +159,22 @@ struct __attribute__((__packed__)) PerfEventMmapUpToPgoff {
   uint64_t length;
   uint64_t page_offset;
   // OMITTED: char filename[]
-  // OMITTED: perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  // OMITTED: RingBufferSampleIdTidTimeStreamidCpu sample_id;
 };
 
-struct __attribute__((__packed__)) PerfEventLost {
+struct __attribute__((__packed__)) RingBufferLost {
   perf_event_header header;
   uint64_t id;
   uint64_t lost;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
 };
 
-struct __attribute__((__packed__)) PerfEventThrottleUnthrottle {
+struct __attribute__((__packed__)) RingBufferThrottleUnthrottle {
   perf_event_header header;
   uint64_t time;
   uint64_t id;
   uint64_t lost;
-  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  RingBufferSampleIdTidTimeStreamidCpu sample_id;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -13,23 +13,23 @@ namespace orbit_linux_tracing {
 
 // This struct must be in sync with the SAMPLE_TYPE_TID_TIME_STREAMID_CPU in PerfEventOpen.h, as the
 // bits set in perf_event_attr::sample_type determine the fields this struct should have.
-struct __attribute__((__packed__)) perf_event_sample_id_tid_time_streamid_cpu {
+struct __attribute__((__packed__)) PerfEventSampleIdTidTimeStreamidCpu {
   uint32_t pid, tid;  /* if PERF_SAMPLE_TID */
   uint64_t time;      /* if PERF_SAMPLE_TIME */
   uint64_t stream_id; /* if PERF_SAMPLE_STREAM_ID */
   uint32_t cpu, res;  /* if PERF_SAMPLE_CPU */
 };
 
-struct __attribute__((__packed__)) perf_event_fork_exit {
+struct __attribute__((__packed__)) PerfEventForkExit {
   perf_event_header header;
   uint32_t pid, ppid;
   uint32_t tid, ptid;
   uint64_t time;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
 };
 
 // This struct must be in sync with the SAMPLE_REGS_USER_ALL in PerfEventOpen.h.
-struct __attribute__((__packed__)) perf_event_sample_regs_user_all {
+struct __attribute__((__packed__)) PerfEventSampleRegsUserAll {
   uint64_t ax;
   uint64_t bx;
   uint64_t cx;
@@ -53,25 +53,25 @@ struct __attribute__((__packed__)) perf_event_sample_regs_user_all {
 };
 
 // This struct must be in sync with the SAMPLE_REGS_USER_AX in PerfEventOpen.h.
-struct __attribute__((__packed__)) perf_event_sample_regs_user_ax {
+struct __attribute__((__packed__)) PerfEventSampleRegsUserAx {
   uint64_t abi;
   uint64_t ax;
 };
 
 // This struct must be in sync with the SAMPLE_REGS_USER_SP_IP in PerfEventOpen.h.
-struct __attribute__((__packed__)) perf_event_sample_regs_user_sp_ip {
+struct __attribute__((__packed__)) PerfEventSampleRegsUserSpIp {
   uint64_t abi;
   uint64_t sp;
   uint64_t ip;
 };
 
 // This struct must be in sync with the SAMPLE_REGS_USER_SP in PerfEventOpen.h.
-struct __attribute__((__packed__)) perf_event_sample_regs_user_sp {
+struct __attribute__((__packed__)) PerfEventSampleRegsUserSp {
   uint64_t sp;
 };
 
 // This struct must be in sync with the SAMPLE_REGS_USER_SP_IP_ARGUMENTS in PerfEventOpen.h.
-struct __attribute__((__packed__)) perf_event_sample_regs_user_sp_ip_arguments {
+struct __attribute__((__packed__)) PerfEventSampleRegsUserSpIpArguments {
   uint64_t abi;
   uint64_t cx;
   uint64_t dx;
@@ -83,75 +83,75 @@ struct __attribute__((__packed__)) perf_event_sample_regs_user_sp_ip_arguments {
   uint64_t r9;
 };
 
-struct __attribute__((__packed__)) perf_event_sample_stack_user_8bytes {
+struct __attribute__((__packed__)) PerfEventSampleStackUser8bytes {
   uint64_t size;
   uint64_t top8bytes;
   uint64_t dyn_size;
 };
 
-struct __attribute__((__packed__)) perf_event_stack_sample_fixed {
+struct __attribute__((__packed__)) PerfEventStackSampleFixed {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
   uint64_t abi;
-  perf_event_sample_regs_user_all regs;
+  PerfEventSampleRegsUserAll regs;
   // Following this field there are the following fields, which we read dynamically:
   // uint64_t size;                     /* if PERF_SAMPLE_STACK_USER */
   // char data[SAMPLE_STACK_USER_SIZE]; /* if PERF_SAMPLE_STACK_USER */
   // uint64_t dyn_size;                 /* if PERF_SAMPLE_STACK_USER && size != 0 */
 };
 
-struct __attribute__((__packed__)) perf_event_sp_ip_arguments_8bytes_sample {
+struct __attribute__((__packed__)) PerfEventSpIpArguments8bytesSample {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  perf_event_sample_regs_user_sp_ip_arguments regs;
-  perf_event_sample_stack_user_8bytes stack;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  PerfEventSampleRegsUserSpIpArguments regs;
+  PerfEventSampleStackUser8bytes stack;
 };
 
-struct __attribute__((__packed__)) perf_event_sp_ip_8bytes_sample {
+struct __attribute__((__packed__)) PerfEventSpIp8bytesSample {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  perf_event_sample_regs_user_sp_ip regs;
-  perf_event_sample_stack_user_8bytes stack;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  PerfEventSampleRegsUserSpIp regs;
+  PerfEventSampleStackUser8bytes stack;
 };
 
-struct __attribute__((__packed__)) perf_event_sp_stack_user_sample_fixed {
+struct __attribute__((__packed__)) PerfEventSpStackUserSampleFixed {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
   uint64_t abi;
-  perf_event_sample_regs_user_sp regs;
+  PerfEventSampleRegsUserSp regs;
   // Following this field there are the following fields, which we read dynamically:
   // uint64_t size;                     /* if PERF_SAMPLE_STACK_USER */
   // char data[SAMPLE_STACK_USER_SIZE]; /* if PERF_SAMPLE_STACK_USER */
   // uint64_t dyn_size;                 /* if PERF_SAMPLE_STACK_USER && size != 0 */
 };
 
-struct __attribute__((__packed__)) perf_event_empty_sample {
+struct __attribute__((__packed__)) PerfEventEmptySample {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
 };
 
-struct __attribute__((__packed__)) perf_event_ax_sample {
+struct __attribute__((__packed__)) PerfEventAxSample {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  perf_event_sample_regs_user_ax regs;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
+  PerfEventSampleRegsUserAx regs;
 };
 
 template <typename TracepointT>
-struct __attribute__((__packed__)) perf_event_raw_sample {
+struct __attribute__((__packed__)) PerfEventRawSample {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
   uint32_t size;
   TracepointT data;
 };
 
-struct __attribute__((__packed__)) perf_event_raw_sample_fixed {
+struct __attribute__((__packed__)) PerfEventRawSampleFixed {
   perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
   uint32_t size;
   // The rest of the sample is a char[size] that we read dynamically.
 };
 
-struct __attribute__((__packed__)) perf_event_mmap_up_to_pgoff {
+struct __attribute__((__packed__)) PerfEventMmapUpToPgoff {
   perf_event_header header;
   uint32_t pid;
   uint32_t tid;
@@ -162,19 +162,19 @@ struct __attribute__((__packed__)) perf_event_mmap_up_to_pgoff {
   // OMITTED: perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
-struct __attribute__((__packed__)) perf_event_lost {
+struct __attribute__((__packed__)) PerfEventLost {
   perf_event_header header;
   uint64_t id;
   uint64_t lost;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
 };
 
-struct __attribute__((__packed__)) perf_event_throttle_unthrottle {
+struct __attribute__((__packed__)) PerfEventThrottleUnthrottle {
   perf_event_header header;
   uint64_t time;
   uint64_t id;
   uint64_t lost;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  PerfEventSampleIdTidTimeStreamidCpu sample_id;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/TracerImpl.h
+++ b/src/LinuxTracing/TracerImpl.h
@@ -124,24 +124,23 @@ class TracerImpl : public Tracer {
 
   // Number of records to read consecutively from a perf_event_open ring buffer
   // before switching to another one.
-  static constexpr int32_t ROUND_ROBIN_POLLING_BATCH_SIZE = 5;
+  static constexpr int32_t kRoundRobinPollingBatchSize = 5;
 
   // These values are supposed to be large enough to accommodate enough events
   // in case TracerThread::Run's thread is not scheduled for a few tens of
   // milliseconds.
-  static constexpr uint64_t UPROBES_RING_BUFFER_SIZE_KB = 8 * 1024;
-  static constexpr uint64_t MMAP_TASK_RING_BUFFER_SIZE_KB = 64;
-  static constexpr uint64_t SAMPLING_RING_BUFFER_SIZE_KB = 16 * 1024;
-  static constexpr uint64_t THREAD_NAMES_RING_BUFFER_SIZE_KB = 64;
-  static constexpr uint64_t CONTEXT_SWITCHES_AND_THREAD_STATE_RING_BUFFER_SIZE_KB = 2 * 1024;
-  static constexpr uint64_t CONTEXT_SWITCHES_AND_THREAD_STATE_WITH_STACKS_RING_BUFFER_SIZE_KB =
-      64 * 1024;
-  static constexpr uint64_t GPU_TRACING_RING_BUFFER_SIZE_KB = 256;
-  static constexpr uint64_t INSTRUMENTED_TRACEPOINTS_RING_BUFFER_SIZE_KB = 8 * 1024;
-  static constexpr uint64_t UPROBES_WITH_STACK_RING_BUFFER_SIZE_KB = 64 * 1024;
+  static constexpr uint64_t kUprobesRingBufferSizeKb = 8 * 1024;
+  static constexpr uint64_t kMmapTaskRingBufferSizeKb = 64;
+  static constexpr uint64_t kSamplingRingBufferSizeKb = 16 * 1024;
+  static constexpr uint64_t kThreadNamesRingBufferSizeKb = 64;
+  static constexpr uint64_t kContextSwitchesAndThreadStateRingBufferSizeKb = 2 * 1024;
+  static constexpr uint64_t kContextSwitchesAndThreadStateWithStacksRingBufferSizeKb = 64 * 1024;
+  static constexpr uint64_t kGpuTracingRingBufferSizeKb = 256;
+  static constexpr uint64_t kInstrumentedTracepointsRingBufferSizeKb = 8 * 1024;
+  static constexpr uint64_t kUprobesWithStackRingBufferSizeKb = 64 * 1024;
 
-  static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 5000;
-  static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 5000;
+  static constexpr uint32_t kIdleTimeOnEmptyRingBuffersUs = 5000;
+  static constexpr uint32_t kIdleTimeOnEmptyDeferredEventsUs = 5000;
 
   bool trace_context_switches_;
   bool introspection_enabled_;
@@ -243,10 +242,10 @@ class TracerImpl : public Tracer {
     std::atomic<uint64_t> thread_state_count = 0;
   };
 
-  static constexpr uint64_t EVENT_STATS_WINDOW_S = 5;
+  static constexpr uint64_t kEventStatsWindowS = 5;
   EventStats stats_{};
 
-  static constexpr uint64_t NS_PER_SECOND = 1'000'000'000;
+  static constexpr uint64_t kNsPerSecond = 1'000'000'000;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/UprobesFunctionCallManager.h
+++ b/src/LinuxTracing/UprobesFunctionCallManager.h
@@ -29,7 +29,7 @@ class UprobesFunctionCallManager {
   UprobesFunctionCallManager& operator=(UprobesFunctionCallManager&&) = default;
 
   void ProcessFunctionEntry(pid_t tid, uint64_t function_id, uint64_t begin_timestamp,
-                            std::optional<perf_event_sample_regs_user_sp_ip_arguments> regs) {
+                            std::optional<PerfEventSampleRegsUserSpIpArguments> regs) {
     std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_[tid];
     stack_of_open_functions.emplace_back(function_id, begin_timestamp, regs);
   }
@@ -75,11 +75,11 @@ class UprobesFunctionCallManager {
  private:
   struct OpenFunction {
     OpenFunction(uint64_t function_id, uint64_t begin_timestamp,
-                 std::optional<perf_event_sample_regs_user_sp_ip_arguments> regs)
+                 std::optional<PerfEventSampleRegsUserSpIpArguments> regs)
         : function_id{function_id}, begin_timestamp{begin_timestamp}, registers{regs} {}
     uint64_t function_id;
     uint64_t begin_timestamp;
-    std::optional<perf_event_sample_regs_user_sp_ip_arguments> registers;
+    std::optional<PerfEventSampleRegsUserSpIpArguments> registers;
   };
 
   // This map keeps the stack of the dynamically-instrumented functions entered.

--- a/src/LinuxTracing/UprobesFunctionCallManager.h
+++ b/src/LinuxTracing/UprobesFunctionCallManager.h
@@ -29,7 +29,7 @@ class UprobesFunctionCallManager {
   UprobesFunctionCallManager& operator=(UprobesFunctionCallManager&&) = default;
 
   void ProcessFunctionEntry(pid_t tid, uint64_t function_id, uint64_t begin_timestamp,
-                            std::optional<PerfEventSampleRegsUserSpIpArguments> regs) {
+                            std::optional<RingBufferSampleRegsUserSpIpArguments> regs) {
     std::vector<OpenFunction>& stack_of_open_functions = tid_to_stack_of_open_functions_[tid];
     stack_of_open_functions.emplace_back(function_id, begin_timestamp, regs);
   }
@@ -75,11 +75,11 @@ class UprobesFunctionCallManager {
  private:
   struct OpenFunction {
     OpenFunction(uint64_t function_id, uint64_t begin_timestamp,
-                 std::optional<PerfEventSampleRegsUserSpIpArguments> regs)
+                 std::optional<RingBufferSampleRegsUserSpIpArguments> regs)
         : function_id{function_id}, begin_timestamp{begin_timestamp}, registers{regs} {}
     uint64_t function_id;
     uint64_t begin_timestamp;
-    std::optional<PerfEventSampleRegsUserSpIpArguments> registers;
+    std::optional<RingBufferSampleRegsUserSpIpArguments> registers;
   };
 
   // This map keeps the stack of the dynamically-instrumented functions entered.

--- a/src/LinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -20,7 +20,7 @@ using ::testing::ElementsAre;
 
 namespace orbit_linux_tracing {
 
-static constexpr perf_event_sample_regs_user_sp_ip_arguments kRegisters{
+static constexpr PerfEventSampleRegsUserSpIpArguments kRegisters{
     .abi = PERF_SAMPLE_REGS_ABI_64,
     .cx = 4,
     .dx = 3,

--- a/src/LinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -20,7 +20,7 @@ using ::testing::ElementsAre;
 
 namespace orbit_linux_tracing {
 
-static constexpr PerfEventSampleRegsUserSpIpArguments kRegisters{
+static constexpr RingBufferSampleRegsUserSpIpArguments kRegisters{
     .abi = PERF_SAMPLE_REGS_ABI_64,
     .cx = 4,
     .dx = 3,

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -497,7 +497,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
 
 void UprobesUnwindingVisitor::OnUprobes(
     uint64_t timestamp_ns, pid_t tid, uint32_t cpu, uint64_t sp, uint64_t ip,
-    uint64_t return_address, std::optional<perf_event_sample_regs_user_sp_ip_arguments> registers,
+    uint64_t return_address, std::optional<PerfEventSampleRegsUserSpIpArguments> registers,
     uint64_t function_id) {
   ORBIT_CHECK(listener_ != nullptr);
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -497,7 +497,7 @@ void UprobesUnwindingVisitor::Visit(uint64_t event_timestamp,
 
 void UprobesUnwindingVisitor::OnUprobes(
     uint64_t timestamp_ns, pid_t tid, uint32_t cpu, uint64_t sp, uint64_t ip,
-    uint64_t return_address, std::optional<PerfEventSampleRegsUserSpIpArguments> registers,
+    uint64_t return_address, std::optional<RingBufferSampleRegsUserSpIpArguments> registers,
     uint64_t function_id) {
   ORBIT_CHECK(listener_ != nullptr);
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -118,7 +118,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   void OnUprobes(uint64_t timestamp_ns, pid_t tid, uint32_t cpu, uint64_t sp, uint64_t ip,
                  uint64_t return_address,
-                 std::optional<perf_event_sample_regs_user_sp_ip_arguments> registers,
+                 std::optional<PerfEventSampleRegsUserSpIpArguments> registers,
                  uint64_t function_id);
   void OnUretprobes(uint64_t timestamp_ns, pid_t pid, pid_t tid, std::optional<uint64_t> ax);
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -118,7 +118,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   void OnUprobes(uint64_t timestamp_ns, pid_t tid, uint32_t cpu, uint64_t sp, uint64_t ip,
                  uint64_t return_address,
-                 std::optional<PerfEventSampleRegsUserSpIpArguments> registers,
+                 std::optional<RingBufferSampleRegsUserSpIpArguments> registers,
                  uint64_t function_id);
   void OnUretprobes(uint64_t timestamp_ns, pid_t pid, pid_t tid, std::optional<uint64_t> ax);
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
@@ -132,8 +132,7 @@ class UprobesUnwindingVisitorCallchainTest : public ::testing::Test {
 };
 
 CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(absl::Span<const uint64_t> callchain) {
-  constexpr uint64_t kTotalNumOfRegisters =
-      sizeof(perf_event_sample_regs_user_all) / sizeof(uint64_t);
+  constexpr uint64_t kTotalNumOfRegisters = sizeof(PerfEventSampleRegsUserAll) / sizeof(uint64_t);
 
   constexpr uint64_t kStackSize = 13;
   CallchainSamplePerfEvent event{

--- a/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
@@ -132,7 +132,7 @@ class UprobesUnwindingVisitorCallchainTest : public ::testing::Test {
 };
 
 CallchainSamplePerfEvent BuildFakeCallchainSamplePerfEvent(absl::Span<const uint64_t> callchain) {
-  constexpr uint64_t kTotalNumOfRegisters = sizeof(PerfEventSampleRegsUserAll) / sizeof(uint64_t);
+  constexpr uint64_t kTotalNumOfRegisters = sizeof(RingBufferSampleRegsUserAll) / sizeof(uint64_t);
 
   constexpr uint64_t kStackSize = 13;
   CallchainSamplePerfEvent event{

--- a/src/LinuxTracing/UprobesUnwindingVisitorDwarfUnwindingTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorDwarfUnwindingTest.cpp
@@ -190,7 +190,7 @@ class UprobesUnwindingVisitorDwarfUnwindingTestBase : public ::testing::Test {
       kNonExecutableMapsStart, kNonExecutableMapsEnd, 0, PROT_EXEC | PROT_READ, kNonExecutableName);
 
   static constexpr uint64_t kNumOfSpRegisters =
-      sizeof(perf_event_sample_regs_user_sp) / sizeof(uint64_t);
+      sizeof(PerfEventSampleRegsUserSp) / sizeof(uint64_t);
 };
 
 template <typename>
@@ -199,8 +199,7 @@ class UprobesUnwindingVisitorDwarfUnwindingTest
 
 template <typename PerfEventType>
 PerfEventType BuildFakePerfEventWithStack() {
-  constexpr uint64_t kTotalNumOfRegisters =
-      sizeof(perf_event_sample_regs_user_all) / sizeof(uint64_t);
+  constexpr uint64_t kTotalNumOfRegisters = sizeof(PerfEventSampleRegsUserAll) / sizeof(uint64_t);
 
   constexpr uint64_t kStackSize = 13;
   PerfEventType result{
@@ -1317,7 +1316,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest, VisitStackSampleUsesUser
               .data = std::make_unique<uint8_t[]>(kUserStackSize),
           },
   };
-  perf_event_sample_regs_user_sp sp_regs{};
+  PerfEventSampleRegsUserSp sp_regs{};
   sp_regs.sp = kUserStackPointer;
   std::memcpy(user_stack_event.data.regs.get(), &sp_regs, sizeof(sp_regs));
   uint8_t* user_stack_data = user_stack_event.data.data.get();
@@ -1434,7 +1433,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeOld),
           },
   };
-  perf_event_sample_regs_user_sp sp_regs1{};
+  PerfEventSampleRegsUserSp sp_regs1{};
   sp_regs1.sp = kUserStackPointerOld;
   std::memcpy(user_stack_event_old.data.regs.get(), &sp_regs1, sizeof(sp_regs1));
   PerfEvent{std::move(user_stack_event_old)}.Accept(&this->visitor_);
@@ -1453,7 +1452,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeNew),
           },
   };
-  perf_event_sample_regs_user_sp sp_regs2{};
+  PerfEventSampleRegsUserSp sp_regs2{};
   sp_regs2.sp = kUserStackPointerNew;
   std::memcpy(user_stack_event_new.data.regs.get(), &sp_regs2, sizeof(sp_regs2));
   uint8_t* user_stack_data = user_stack_event_new.data.data.get();
@@ -1571,7 +1570,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeSameThread),
           },
   };
-  perf_event_sample_regs_user_sp sp_regs1{};
+  PerfEventSampleRegsUserSp sp_regs1{};
   sp_regs1.sp = kUserStackPointerSameThread;
   std::memcpy(user_stack_event_same_thread.data.regs.get(), &sp_regs1, sizeof(sp_regs1));
   uint8_t* user_stack_data = user_stack_event_same_thread.data.data.get();
@@ -1591,7 +1590,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeOtherThread),
           },
   };
-  perf_event_sample_regs_user_sp sp_regs2{};
+  PerfEventSampleRegsUserSp sp_regs2{};
   sp_regs2.sp = kUserStackPointerOtherThread;
   std::memcpy(user_stack_event_other_thread.data.regs.get(), &sp_regs2, sizeof(sp_regs2));
   PerfEvent{std::move(user_stack_event_other_thread)}.Accept(&this->visitor_);
@@ -1708,7 +1707,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSize1),
           },
   };
-  perf_event_sample_regs_user_sp sp_regs1{};
+  PerfEventSampleRegsUserSp sp_regs1{};
   sp_regs1.sp = kUserStackPointer1;
   std::memcpy(user_stack_event1.data.regs.get(), &sp_regs1, sizeof(sp_regs1));
   uint8_t* user_stack_data1 = user_stack_event1.data.data.get();
@@ -1728,7 +1727,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSize2),
           },
   };
-  perf_event_sample_regs_user_sp sp_regs2{};
+  PerfEventSampleRegsUserSp sp_regs2{};
   sp_regs2.sp = kUserStackPointer2;
   std::memcpy(user_stack_event2.data.regs.get(), &sp_regs2, sizeof(sp_regs2));
   uint8_t* user_stack_data2 = user_stack_event2.data.data.get();

--- a/src/LinuxTracing/UprobesUnwindingVisitorDwarfUnwindingTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorDwarfUnwindingTest.cpp
@@ -190,7 +190,7 @@ class UprobesUnwindingVisitorDwarfUnwindingTestBase : public ::testing::Test {
       kNonExecutableMapsStart, kNonExecutableMapsEnd, 0, PROT_EXEC | PROT_READ, kNonExecutableName);
 
   static constexpr uint64_t kNumOfSpRegisters =
-      sizeof(PerfEventSampleRegsUserSp) / sizeof(uint64_t);
+      sizeof(RingBufferSampleRegsUserSp) / sizeof(uint64_t);
 };
 
 template <typename>
@@ -199,7 +199,7 @@ class UprobesUnwindingVisitorDwarfUnwindingTest
 
 template <typename PerfEventType>
 PerfEventType BuildFakePerfEventWithStack() {
-  constexpr uint64_t kTotalNumOfRegisters = sizeof(PerfEventSampleRegsUserAll) / sizeof(uint64_t);
+  constexpr uint64_t kTotalNumOfRegisters = sizeof(RingBufferSampleRegsUserAll) / sizeof(uint64_t);
 
   constexpr uint64_t kStackSize = 13;
   PerfEventType result{
@@ -1316,7 +1316,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest, VisitStackSampleUsesUser
               .data = std::make_unique<uint8_t[]>(kUserStackSize),
           },
   };
-  PerfEventSampleRegsUserSp sp_regs{};
+  RingBufferSampleRegsUserSp sp_regs{};
   sp_regs.sp = kUserStackPointer;
   std::memcpy(user_stack_event.data.regs.get(), &sp_regs, sizeof(sp_regs));
   uint8_t* user_stack_data = user_stack_event.data.data.get();
@@ -1433,7 +1433,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeOld),
           },
   };
-  PerfEventSampleRegsUserSp sp_regs1{};
+  RingBufferSampleRegsUserSp sp_regs1{};
   sp_regs1.sp = kUserStackPointerOld;
   std::memcpy(user_stack_event_old.data.regs.get(), &sp_regs1, sizeof(sp_regs1));
   PerfEvent{std::move(user_stack_event_old)}.Accept(&this->visitor_);
@@ -1452,7 +1452,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeNew),
           },
   };
-  PerfEventSampleRegsUserSp sp_regs2{};
+  RingBufferSampleRegsUserSp sp_regs2{};
   sp_regs2.sp = kUserStackPointerNew;
   std::memcpy(user_stack_event_new.data.regs.get(), &sp_regs2, sizeof(sp_regs2));
   uint8_t* user_stack_data = user_stack_event_new.data.data.get();
@@ -1570,7 +1570,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeSameThread),
           },
   };
-  PerfEventSampleRegsUserSp sp_regs1{};
+  RingBufferSampleRegsUserSp sp_regs1{};
   sp_regs1.sp = kUserStackPointerSameThread;
   std::memcpy(user_stack_event_same_thread.data.regs.get(), &sp_regs1, sizeof(sp_regs1));
   uint8_t* user_stack_data = user_stack_event_same_thread.data.data.get();
@@ -1590,7 +1590,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSizeOtherThread),
           },
   };
-  PerfEventSampleRegsUserSp sp_regs2{};
+  RingBufferSampleRegsUserSp sp_regs2{};
   sp_regs2.sp = kUserStackPointerOtherThread;
   std::memcpy(user_stack_event_other_thread.data.regs.get(), &sp_regs2, sizeof(sp_regs2));
   PerfEvent{std::move(user_stack_event_other_thread)}.Accept(&this->visitor_);
@@ -1707,7 +1707,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSize1),
           },
   };
-  PerfEventSampleRegsUserSp sp_regs1{};
+  RingBufferSampleRegsUserSp sp_regs1{};
   sp_regs1.sp = kUserStackPointer1;
   std::memcpy(user_stack_event1.data.regs.get(), &sp_regs1, sizeof(sp_regs1));
   uint8_t* user_stack_data1 = user_stack_event1.data.data.get();
@@ -1727,7 +1727,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
               .data = std::make_unique<uint8_t[]>(kUserStackSize2),
           },
   };
-  PerfEventSampleRegsUserSp sp_regs2{};
+  RingBufferSampleRegsUserSp sp_regs2{};
   sp_regs2.sp = kUserStackPointer2;
   std::memcpy(user_stack_event2.data.regs.get(), &sp_regs2, sizeof(sp_regs2));
   uint8_t* user_stack_data2 = user_stack_event2.data.data.get();

--- a/src/MizarData/FrameTrackManagerTest.cpp
+++ b/src/MizarData/FrameTrackManagerTest.cpp
@@ -143,7 +143,7 @@ static std::pair<std::vector<ScopeInfo>, std::vector<PresentEvent::Source>> Deco
   std::vector<PresentEvent::Source> etw_sources;
 
   for (const auto& [unused_id, info] : id_to_infos) {
-    std::visit(orbit_base::overloaded{
+    std::visit(orbit_base::Overloaded{
                    [&scope_id_infos](const ScopeInfo& info) { scope_id_infos.push_back(info); },
                    [&etw_sources](PresentEvent::Source source) { etw_sources.push_back(source); }},
                *info);
@@ -177,7 +177,7 @@ class ExpectFrameTracksHasFrameStartsForScopes : public ::testing::Test {
                                                                  TimestampNs max_start) {
     for (const auto& [id, info] : frame_track_manager_.GetFrameTracks()) {
       std::vector<TimestampNs> expected_frame_starts = std::visit(
-          orbit_base::overloaded{
+          orbit_base::Overloaded{
               [](const ScopeInfo& info) { return kScopeInfoToFrameStarts.at(info); },
               [min_start, max_start](PresentEvent::Source source) {
                 std::vector<TimestampNs> filtered_time_list;

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -121,10 +121,10 @@ static ErrorMessageOr<std::filesystem::path> SearchSymbolsPathInOrbitSearchPaths
     const orbit_symbols::SymbolHelper& symbol_helper,
     const orbit_client_data::ModuleData& module_data) {
   // These are the constants used by Orbit Client. This way we read its configs.
-  static const QString orbit_organization = QStringLiteral("The Orbit Authors");
-  static const QString orbit_app_name = QStringLiteral("orbitprofiler");
-  orbit_client_symbols::QSettingsBasedStorageManager storage_manager(orbit_organization,
-                                                                     orbit_app_name);
+  static const QString kOrbitOrganization = QStringLiteral("The Orbit Authors");
+  static const QString kOrbitAppName = QStringLiteral("orbitprofiler");
+  orbit_client_symbols::QSettingsBasedStorageManager storage_manager(kOrbitOrganization,
+                                                                     kOrbitAppName);
   return symbol_helper.FindSymbolsFileLocally(module_data.file_path(), module_data.build_id(),
                                               module_data.object_file_type(),
                                               storage_manager.LoadPaths());

--- a/src/MizarData/include/MizarData/FrameTrackManager.h
+++ b/src/MizarData/include/MizarData/FrameTrackManager.h
@@ -45,7 +45,7 @@ class FrameTrackManagerTmpl {
   [[nodiscard]] std::vector<TimestampNs> GetFrameStarts(FrameTrackId id, TimestampNs min_start,
                                                         TimestampNs max_start) const {
     std::vector<TimestampNs> result = std::visit(
-        orbit_base::overloaded{
+        orbit_base::Overloaded{
             absl::bind_front(&FrameTrackManagerTmpl::GetScopeFrameStarts, this, min_start,
                              max_start),
             absl::bind_front(&FrameTrackManagerTmpl::GetEtwFrameStarts, this, min_start, max_start),

--- a/src/MizarModels/include/MizarModels/FrameTrackListModel.h
+++ b/src/MizarModels/include/MizarModels/FrameTrackListModel.h
@@ -103,7 +103,7 @@ class FrameTrackListModelTmpl : public QAbstractListModel {
   }
 
   [[nodiscard]] static std::string MakeDisplayedName(const FrameTrackInfo& info) {
-    return std::visit(orbit_base::overloaded{&MakeFrameTrackString, &PresentEventSourceName},
+    return std::visit(orbit_base::Overloaded{&MakeFrameTrackString, &PresentEventSourceName},
                       *info);
   }
 

--- a/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
+++ b/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
@@ -109,7 +109,7 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
 
   [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation,
                                     int role = Qt::DisplayRole) const override {
-    static const absl::flat_hash_map<Column, QString> column_names = {
+    static const absl::flat_hash_map<Column, QString> kColumnNames = {
         {Column::kFunctionName, "Function"},
         {Column::kBaselineExclusivePercent, "Baseline, %"},
         {Column::kBaselineExclusiveTimePerFrame, "Baseline (per frame), us"},
@@ -124,7 +124,7 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
       return {};
     }
 
-    return column_names.at(static_cast<Column>(section));
+    return kColumnNames.at(static_cast<Column>(section));
   }
 
  private:

--- a/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
+++ b/src/MizarModels/include/MizarModels/SamplingWithFrameTrackReportModel.h
@@ -109,7 +109,7 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
 
   [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation,
                                     int role = Qt::DisplayRole) const override {
-    static const absl::flat_hash_map<Column, QString> kColumnNames = {
+    static const absl::flat_hash_map<Column, QString> column_names = {
         {Column::kFunctionName, "Function"},
         {Column::kBaselineExclusivePercent, "Baseline, %"},
         {Column::kBaselineExclusiveTimePerFrame, "Baseline (per frame), us"},
@@ -124,7 +124,7 @@ class SamplingWithFrameTrackReportModelTmpl : public QAbstractTableModel {
       return {};
     }
 
-    return kColumnNames.at(static_cast<Column>(section));
+    return column_names.at(static_cast<Column>(section));
   }
 
  private:

--- a/src/ObjectUtils/ElfFile.cpp
+++ b/src/ObjectUtils/ElfFile.cpp
@@ -894,7 +894,7 @@ ErrorMessageOr<std::unique_ptr<ElfFile>> CreateElfFile(
 
 ErrorMessageOr<uint32_t> ElfFile::CalculateDebuglinkChecksum(
     const std::filesystem::path& file_path) {
-  ErrorMessageOr<orbit_base::unique_fd> fd_or_error = orbit_base::OpenFileForReading(file_path);
+  ErrorMessageOr<orbit_base::UniqueFd> fd_or_error = orbit_base::OpenFileForReading(file_path);
 
   if (fd_or_error.has_error()) {
     return fd_or_error.error();

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
@@ -50,15 +50,15 @@ enum class AccessibilityRole {
  * QT-definitions
  */
 enum class AccessibilityState : uint64_t {
-  Normal = 0,            // NOLINT(readability-identifier-naming)
-  Disabled = 1,          // NOLINT(readability-identifier-naming)
-  Focusable = 1 << 2,    // NOLINT(readability-identifier-naming)
-  Focused = 1 << 3,      // NOLINT(readability-identifier-naming)
-  Expanded = 1 << 11,    // NOLINT(readability-identifier-naming)
-  Collapsed = 1 << 12,   // NOLINT(readability-identifier-naming)
-  Expandable = 1 << 14,  // NOLINT(readability-identifier-naming)
-  Offscreen = 1 << 18,   // NOLINT(readability-identifier-naming)
-  Movable = 1 << 20      // NOLINT(readability-identifier-naming)
+  kNormal = 0,
+  kDisabled = 1,
+  kFocusable = 1 << 2,
+  kFocused = 1 << 3,
+  kExpanded = 1 << 11,
+  kCollapsed = 1 << 12,
+  kExpandable = 1 << 14,
+  kOffscreen = 1 << 18,
+  kMovable = 1 << 20
 };
 
 inline AccessibilityState operator|(AccessibilityState lhs, AccessibilityState rhs) {

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
@@ -50,15 +50,15 @@ enum class AccessibilityRole {
  * QT-definitions
  */
 enum class AccessibilityState : uint64_t {
-  Normal = 0,
-  Disabled = 1,
-  Focusable = 1 << 2,
-  Focused = 1 << 3,
-  Expanded = 1 << 11,
-  Collapsed = 1 << 12,
-  Expandable = 1 << 14,
-  Offscreen = 1 << 18,
-  Movable = 1 << 20
+  Normal = 0,            // NOLINT(readability-identifier-naming)
+  Disabled = 1,          // NOLINT(readability-identifier-naming)
+  Focusable = 1 << 2,    // NOLINT(readability-identifier-naming)
+  Focused = 1 << 3,      // NOLINT(readability-identifier-naming)
+  Expanded = 1 << 11,    // NOLINT(readability-identifier-naming)
+  Collapsed = 1 << 12,   // NOLINT(readability-identifier-naming)
+  Expandable = 1 << 14,  // NOLINT(readability-identifier-naming)
+  Offscreen = 1 << 18,   // NOLINT(readability-identifier-naming)
+  Movable = 1 << 20      // NOLINT(readability-identifier-naming)
 };
 
 inline AccessibilityState operator|(AccessibilityState lhs, AccessibilityState rhs) {

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleWidgetBridge.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleWidgetBridge.h
@@ -29,7 +29,7 @@ class AccessibleWidgetBridge : public AccessibleInterface {
   }
   [[nodiscard]] AccessibilityRect AccessibleRect() const override { return {}; }
   [[nodiscard]] AccessibilityState AccessibleState() const override {
-    return AccessibilityState::Normal;
+    return AccessibilityState::kNormal;
   }
 };
 

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -36,18 +36,18 @@ namespace orbit_base {
 using ::testing::HasSubstr;
 
 TEST(File, DefaultUniqueFdIsInvalidDescriptor) {
-  unique_fd fd;
+  UniqueFd fd;
   EXPECT_FALSE(fd.valid());
 }
 
 TEST(File, EmptyUnuqueFdCanBeReleased) {
-  unique_fd fd;
+  UniqueFd fd;
   fd.release();
   EXPECT_FALSE(fd.valid());
 }
 
 TEST(File, MoveAssingToExisingUniqueFd) {
-  unique_fd fd;
+  UniqueFd fd;
 
   auto fd_or_error = OpenFileForReading(orbit_test::GetTestdataDir() / "textfile.bin");
 
@@ -64,7 +64,7 @@ TEST(File, MoveAssingToExisingUniqueFd) {
 TEST(File, UniqueFdSelfMove) {
   auto fd_or_error = OpenFileForReading(orbit_test::GetTestdataDir() / "textfile.bin");
   ASSERT_TRUE(fd_or_error.has_value()) << fd_or_error.error().message();
-  unique_fd valid_fd{std::move(fd_or_error.value())};
+  UniqueFd valid_fd{std::move(fd_or_error.value())};
 
   valid_fd = std::move(valid_fd);
 
@@ -75,7 +75,7 @@ TEST(File, UniqueFdSelfMove) {
 #endif  // __GNUC__
 
 TEST(File, AcccessInvalidUniqueFd) {
-  unique_fd fd;
+  UniqueFd fd;
   EXPECT_FALSE(fd.valid());
   EXPECT_DEATH((void)fd.get(), "");
 
@@ -131,7 +131,7 @@ TEST(File, WriteFullySmoke) {
   ASSERT_FALSE(write_result_or_error.has_error()) << write_result_or_error.error().message();
 
   // Read back and compare content.
-  ErrorMessageOr<unique_fd> fd_or_error = OpenFileForReading(temporary_file.file_path().string());
+  ErrorMessageOr<UniqueFd> fd_or_error = OpenFileForReading(temporary_file.file_path().string());
   ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
   std::array<char, 64> read_back = {};
   ErrorMessageOr<size_t> result_or_error =
@@ -154,7 +154,7 @@ TEST(File, WriteFullyAtOffsetSmoke) {
 
   // Read back and compare content.
   std::array<char, 64> read_back = {};
-  ErrorMessageOr<unique_fd> fd_or_error = OpenFileForReading(temporary_file.file_path().string());
+  ErrorMessageOr<UniqueFd> fd_or_error = OpenFileForReading(temporary_file.file_path().string());
   ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
   ErrorMessageOr<size_t> result_or_error = ReadFully(fd_or_error.value(), read_back.data(), 64);
   ASSERT_FALSE(result_or_error.has_error()) << result_or_error.error().message();

--- a/src/OrbitBase/OverloadedTest.cpp
+++ b/src/OrbitBase/OverloadedTest.cpp
@@ -27,7 +27,7 @@ std::string_view FromString(std::string /*unused*/) { return kString; }
 std::string_view FromInt(int /*unused*/) { return kInt; }
 
 TEST(OverloadedTest, TwoLambdas) {
-  const auto overloaded_lambda = overloaded{kFromInt, kFromString};
+  const auto overloaded_lambda = Overloaded{kFromInt, kFromString};
   EXPECT_EQ(overloaded_lambda(1), kInt);
   EXPECT_EQ(overloaded_lambda("foo"), kString);
 }
@@ -36,13 +36,13 @@ constexpr std::string_view kTwoStrings = "two strings";
 
 TEST(OverloadedTest, TwoLambdasOnePolymorphic) {
   const auto overloaded_lambda =
-      overloaded{[](auto /*unused*/, auto /*unused*/) { return kTwoStrings; }, kFromTwoInts};
+      Overloaded{[](auto /*unused*/, auto /*unused*/) { return kTwoStrings; }, kFromTwoInts};
   EXPECT_EQ(overloaded_lambda(1, 1), kTwoInts);
   EXPECT_EQ(overloaded_lambda("foo", "bar"), kTwoStrings);
 }
 
 TEST(OverloadedTest, StackedOverloaded) {
-  const auto overloaded_lambda = overloaded{overloaded{kFromInt, kFromString}, kFromTwoInts};
+  const auto overloaded_lambda = Overloaded{Overloaded{kFromInt, kFromString}, kFromTwoInts};
   EXPECT_EQ(overloaded_lambda(1, 1), kTwoInts);
   EXPECT_EQ(overloaded_lambda(1), kInt);
   EXPECT_EQ(overloaded_lambda("foo"), kString);
@@ -50,41 +50,41 @@ TEST(OverloadedTest, StackedOverloaded) {
 
 TEST(OverloadedTest, MoveOnlyArgumentLambda) {
   const auto lambda = [](std::unique_ptr<int> /*unused*/) { return kInt; };
-  const auto overloaded_lambda = overloaded{lambda};
+  const auto overloaded_lambda = Overloaded{lambda};
   auto int_ptr = std::make_unique<int>(1);
   EXPECT_EQ(overloaded_lambda(std::move(int_ptr)), kInt);
 }
 
 TEST(OverloadedTest, TwoLambdasWithOneAndTwoArguments) {
-  const auto overloaded_lambda = overloaded{kFromInt, kFromTwoInts};
+  const auto overloaded_lambda = Overloaded{kFromInt, kFromTwoInts};
   EXPECT_EQ(overloaded_lambda(1), kInt);
   EXPECT_EQ(overloaded_lambda(1, 1), kTwoInts);
 }
 
 TEST(OverloadedTest, MutableAndImmutableLambdas) {
-  auto overloaded_lambda = overloaded{kFromIntMutable, kFromString};
+  auto overloaded_lambda = Overloaded{kFromIntMutable, kFromString};
   EXPECT_EQ(overloaded_lambda(1), kInt);
   EXPECT_EQ(overloaded_lambda("foo"), kString);
 }
 
 TEST(OverloadedTest, SingleLambda) {
-  const auto overloaded_lambda = overloaded{kFromInt};
+  const auto overloaded_lambda = Overloaded{kFromInt};
   EXPECT_EQ(overloaded_lambda(1), kInt);
 }
 
 TEST(OverloadedTest, SingleFreeFunction) {
-  const auto overloaded_lambda = overloaded{&FromString};
+  const auto overloaded_lambda = Overloaded{&FromString};
   EXPECT_EQ(overloaded_lambda("foo"), kString);
 }
 
 TEST(OverloadedTest, TwoFreeFunctions) {
-  const auto overloaded_lambda = overloaded{&FromString, &FromInt};
+  const auto overloaded_lambda = Overloaded{&FromString, &FromInt};
   EXPECT_EQ(overloaded_lambda(1), kInt);
   EXPECT_EQ(overloaded_lambda("foo"), kString);
 }
 
 TEST(OverloadedTest, FreeFunctionAndLambda) {
-  const auto overloaded_lambda = overloaded{&FromString, kFromInt};
+  const auto overloaded_lambda = Overloaded{&FromString, kFromInt};
   EXPECT_EQ(overloaded_lambda(1), kInt);
   EXPECT_EQ(overloaded_lambda("foo"), kString);
 }

--- a/src/OrbitBase/ReadFileToString.cpp
+++ b/src/OrbitBase/ReadFileToString.cpp
@@ -29,12 +29,12 @@
 namespace orbit_base {
 
 ErrorMessageOr<std::string> ReadFileToString(const std::filesystem::path& file_name) {
-  ErrorMessageOr<unique_fd> fd_or_error = OpenFileForReading(file_name);
+  ErrorMessageOr<UniqueFd> fd_or_error = OpenFileForReading(file_name);
   if (fd_or_error.has_error()) {
     return fd_or_error.error();
   }
 
-  const unique_fd& fd = fd_or_error.value();
+  const UniqueFd& fd = fd_or_error.value();
 
   std::string result;
 

--- a/src/OrbitBase/WriteStringToFile.cpp
+++ b/src/OrbitBase/WriteStringToFile.cpp
@@ -15,12 +15,12 @@ namespace orbit_base {
 
 ErrorMessageOr<void> WriteStringToFile(const std::filesystem::path& file_name,
                                        std::string_view content) {
-  ErrorMessageOr<unique_fd> fd_or_error = OpenFileForWriting(file_name);
+  ErrorMessageOr<UniqueFd> fd_or_error = OpenFileForWriting(file_name);
   if (fd_or_error.has_error()) {
     return fd_or_error.error();
   }
 
-  const unique_fd& fd = fd_or_error.value();
+  const UniqueFd& fd = fd_or_error.value();
 
   ErrorMessageOr<void> result = WriteFully(fd, content);
   if (result.has_error()) {

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -27,18 +27,18 @@ namespace orbit_base {
 
 constexpr int kInvalidFd = -1;
 
-class unique_fd {
+class UniqueFd {
  public:
-  constexpr unique_fd() = default;
-  constexpr explicit unique_fd(int fd) : fd_{fd} {}
-  ~unique_fd() { release(); }
+  constexpr UniqueFd() = default;
+  constexpr explicit UniqueFd(int fd) : fd_{fd} {}
+  ~UniqueFd() { release(); }
 
-  unique_fd(const unique_fd&) = delete;
-  unique_fd& operator=(const unique_fd&) = delete;
+  UniqueFd(const UniqueFd&) = delete;
+  UniqueFd& operator=(const UniqueFd&) = delete;
 
-  constexpr unique_fd(unique_fd&& other) : fd_{other.fd_} { other.fd_ = kInvalidFd; }
+  constexpr UniqueFd(UniqueFd&& other) : fd_{other.fd_} { other.fd_ = kInvalidFd; }
 
-  unique_fd& operator=(unique_fd&& other) {
+  UniqueFd& operator=(UniqueFd&& other) {
     if (&other == this) return *this;
 
     reset(other.fd_);
@@ -73,21 +73,21 @@ class unique_fd {
 // different subroutines for Windows/Linux. They also translate errors to
 // ErrorMessageOr<T>.
 
-ErrorMessageOr<unique_fd> OpenFileForReading(const std::filesystem::path& path);
+ErrorMessageOr<UniqueFd> OpenFileForReading(const std::filesystem::path& path);
 
-ErrorMessageOr<unique_fd> OpenFileForWriting(const std::filesystem::path& path);
+ErrorMessageOr<UniqueFd> OpenFileForWriting(const std::filesystem::path& path);
 
-ErrorMessageOr<unique_fd> OpenNewFileForWriting(const std::filesystem::path& path);
+ErrorMessageOr<UniqueFd> OpenNewFileForWriting(const std::filesystem::path& path);
 
-ErrorMessageOr<unique_fd> OpenNewFileForReadWrite(const std::filesystem::path& path);
+ErrorMessageOr<UniqueFd> OpenNewFileForReadWrite(const std::filesystem::path& path);
 
-ErrorMessageOr<unique_fd> OpenExistingFileForReadWrite(const std::filesystem::path& path);
+ErrorMessageOr<UniqueFd> OpenExistingFileForReadWrite(const std::filesystem::path& path);
 
-ErrorMessageOr<void> WriteFully(const unique_fd& fd, const void* data, size_t size);
+ErrorMessageOr<void> WriteFully(const UniqueFd& fd, const void* data, size_t size);
 
-ErrorMessageOr<void> WriteFully(const unique_fd& fd, std::string_view content);
+ErrorMessageOr<void> WriteFully(const UniqueFd& fd, std::string_view content);
 
-ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer, size_t size,
+ErrorMessageOr<void> WriteFullyAtOffset(const UniqueFd& fd, const void* buffer, size_t size,
                                         int64_t offset);
 
 // Tries to read 'size' bytes from the file to the buffer, returns actual
@@ -96,15 +96,15 @@ ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer,
 //
 // Use this function only for reading from files. This function is not supposed to be
 // used for non-blocking reads from sockets/pipes - it does not handle EAGAIN.
-ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size);
+ErrorMessageOr<size_t> ReadFully(const UniqueFd& fd, void* buffer, size_t size);
 
 // Same as above but tries to read from an offset. The file referenced by fd must be capable of
 // seeking. The same limitation for non-blocking reads as above applies here.
-ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size_t size,
+ErrorMessageOr<size_t> ReadFullyAtOffset(const UniqueFd& fd, void* buffer, size_t size,
                                          int64_t offset);
 
 template <typename T>
-ErrorMessageOr<T> ReadFullyAtOffset(const unique_fd& fd, int64_t offset) {
+ErrorMessageOr<T> ReadFullyAtOffset(const UniqueFd& fd, int64_t offset) {
   T value;
   auto size_or_error = ReadFullyAtOffset(fd, &value, sizeof(value), offset);
   if (size_or_error.has_error()) {

--- a/src/OrbitBase/include/OrbitBase/Overloaded.h
+++ b/src/OrbitBase/include/OrbitBase/Overloaded.h
@@ -48,12 +48,12 @@ namespace orbit_base {
 // Extended `overloaded` trick from https://en.cppreference.com/w/cpp/utility/variant/visit
 // Also handles function pointers.
 template <typename... Ts>
-struct overloaded : orbit_base_internal::WithParen<Ts>... {
+struct Overloaded : orbit_base_internal::WithParen<Ts>... {
   using orbit_base_internal::WithParen<Ts>::operator()...;
 };
 
 template <typename... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
+Overloaded(Ts...) -> Overloaded<Ts...>;
 
 }  // namespace orbit_base
 

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -109,21 +109,21 @@ AccessibilityState AccessibleTrack::AccessibleState() const {
 
   using State = AccessibilityState;
 
-  State result = State::Normal | State::Focusable | State::Movable;
+  State result = State::kNormal | State::kFocusable | State::kMovable;
   if (track_->IsTrackSelected()) {
-    result |= State::Focused;
+    result |= State::kFocused;
   }
   if (track_->IsCollapsible()) {
-    result |= State::Expandable;
+    result |= State::kExpandable;
     if (track_->IsCollapsed()) {
-      result |= State::Collapsed;
+      result |= State::kCollapsed;
     } else {
-      result |= State::Expanded;
+      result |= State::kExpanded;
     }
   }
 
   if (AccessibleRect().height == 0) {
-    result |= State::Offscreen;
+    result |= State::kOffscreen;
   }
   return result;
 }

--- a/src/OrbitGl/AccessibleTriangleToggle.cpp
+++ b/src/OrbitGl/AccessibleTriangleToggle.cpp
@@ -18,9 +18,9 @@ AccessibleTriangleToggle::AccessibleTriangleToggle(TriangleToggle* triangle_togg
 
 orbit_accessibility::AccessibilityState AccessibleTriangleToggle::AccessibleState() const {
   if (triangle_toggle_->IsCollapsible()) {
-    return orbit_accessibility::AccessibilityState::Normal;
+    return orbit_accessibility::AccessibilityState::kNormal;
   }
-  return orbit_accessibility::AccessibilityState::Disabled;
+  return orbit_accessibility::AccessibilityState::kDisabled;
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -233,11 +233,11 @@ bool CallstackThreadBar::IsEmpty() const {
 
 std::string CallstackThreadBar::GetSampleTooltip(const PrimitiveAssembler& primitive_assembler,
                                                  PickingId id) const {
-  static const std::string unknown_return_text = "Function call information missing";
+  static const std::string kUnknownReturnText = "Function call information missing";
 
   const PickingUserData* user_data = primitive_assembler.GetUserData(id);
   if (user_data == nullptr || user_data->custom_data_ == nullptr) {
-    return unknown_return_text;
+    return kUnknownReturnText;
   }
 
   ORBIT_CHECK(capture_data_ != nullptr);
@@ -247,7 +247,7 @@ std::string CallstackThreadBar::GetSampleTooltip(const PrimitiveAssembler& primi
   uint64_t callstack_id = callstack_event->callstack_id();
   const CallstackInfo* callstack = callstack_data.GetCallstack(callstack_id);
   if (callstack == nullptr) {
-    return unknown_return_text;
+    return kUnknownReturnText;
   }
 
   FormattedModuleAndFunctionName innermost_module_and_function_name =

--- a/src/OrbitGl/FormatCallstackForTooltip.cpp
+++ b/src/OrbitGl/FormatCallstackForTooltip.cpp
@@ -39,16 +39,15 @@ struct UnformattedModuleAndFunctionName {
     const orbit_client_data::CaptureData& capture_data,
     const orbit_client_data::ModuleManager& module_manager) {
   if (frame_index >= callstack.frames().size()) {
-    static const UnformattedModuleAndFunctionName frame_index_too_large_module_and_function_name =
-        [] {
-          UnformattedModuleAndFunctionName module_and_function_name;
-          module_and_function_name.module_name = orbit_client_data::kUnknownFunctionOrModuleName;
-          module_and_function_name.module_is_unknown = true;
-          module_and_function_name.function_name = orbit_client_data::kUnknownFunctionOrModuleName;
-          module_and_function_name.function_is_unknown = true;
-          return module_and_function_name;
-        }();
-    return frame_index_too_large_module_and_function_name;
+    static const UnformattedModuleAndFunctionName kFrameIndexTooLargeModuleAndFunctionName = [] {
+      UnformattedModuleAndFunctionName module_and_function_name;
+      module_and_function_name.module_name = orbit_client_data::kUnknownFunctionOrModuleName;
+      module_and_function_name.module_is_unknown = true;
+      module_and_function_name.function_name = orbit_client_data::kUnknownFunctionOrModuleName;
+      module_and_function_name.function_is_unknown = true;
+      return module_and_function_name;
+    }();
+    return kFrameIndexTooLargeModuleAndFunctionName;
   }
 
   const uint64_t address = callstack.frames()[frame_index];
@@ -136,15 +135,15 @@ std::string FormatCallstackForTooltip(const orbit_client_data::CallstackInfo& ca
       continue;
     }
 
-    static const std::string module_function_separator{" | "};
+    static const std::string kModuleFunctionSeparator{" | "};
     const UnformattedModuleAndFunctionName module_and_function_name =
         SafeGetModuleAndFunctionName(callstack, frame_index, capture_data, module_manager);
     const std::string formatted_module_name = FormatModuleName(module_and_function_name);
     const std::string formatted_function_name = FormatFunctionName(
         module_and_function_name, max_line_length - module_and_function_name.module_name.size() -
-                                      module_function_separator.size());
+                                      kModuleFunctionSeparator.size());
     const std::string formatted_module_and_function_name =
-        absl::StrCat(formatted_module_name, module_function_separator, formatted_function_name);
+        absl::StrCat(formatted_module_name, kModuleFunctionSeparator, formatted_function_name);
     // The first frame is always correct.
     if (callstack.IsUnwindingError() && frame_index > 0) {
       result += absl::StrFormat("<span style=\"color:%s;\">%s</span><br/>", kUnwindErrorColorString,

--- a/src/OrbitGl/ThreadBar.cpp
+++ b/src/OrbitGl/ThreadBar.cpp
@@ -11,7 +11,7 @@ namespace orbit_gl {
 std::unique_ptr<orbit_accessibility::AccessibleInterface> ThreadBar::CreateAccessibleInterface() {
   return std::make_unique<AccessibleCaptureViewElement>(
       this, GetName(), orbit_accessibility::AccessibilityRole::Pane,
-      orbit_accessibility::AccessibilityState::Focusable);
+      orbit_accessibility::AccessibilityState::kFocusable);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -68,41 +68,41 @@ void ThreadStateBar::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
 
   // Draw a transparent track just for clicking.
   Quad box = MakeBox(GetPos(), Vec2(GetWidth(), GetHeight()));
-  static const Color transparent{0, 0, 0, 0};
-  primitive_assembler.AddBox(box, thread_state_bar_z, transparent, shared_from_this());
+  static const Color kTransparent{0, 0, 0, 0};
+  primitive_assembler.AddBox(box, thread_state_bar_z, kTransparent, shared_from_this());
 }
 
 static Color GetThreadStateColor(ThreadStateSlice::ThreadState state) {
-  static const Color green500{76, 175, 80, 255};
-  static const Color blue500{33, 150, 243, 255};
-  static const Color gray600{117, 117, 117, 255};
-  static const Color orange500{255, 152, 0, 255};
-  static const Color red500{244, 67, 54, 255};
-  static const Color purple500{156, 39, 176, 255};
-  static const Color black{0, 0, 0, 255};
-  static const Color brown500{121, 85, 72, 255};
+  static const Color kGreen500{76, 175, 80, 255};
+  static const Color kBlue500{33, 150, 243, 255};
+  static const Color kGray600{117, 117, 117, 255};
+  static const Color kOrange500{255, 152, 0, 255};
+  static const Color kRed500{244, 67, 54, 255};
+  static const Color kPurple500{156, 39, 176, 255};
+  static const Color kBlack{0, 0, 0, 255};
+  static const Color kBrown500{121, 85, 72, 255};
 
   switch (state) {
     case ThreadStateSlice::kRunning:
-      return green500;
+      return kGreen500;
     case ThreadStateSlice::kRunnable:
-      return blue500;
+      return kBlue500;
     case ThreadStateSlice::kInterruptibleSleep:
-      return gray600;
+      return kGray600;
     case ThreadStateSlice::kUninterruptibleSleep:
-      return orange500;
+      return kOrange500;
     case ThreadStateSlice::kStopped:
-      return red500;
+      return kRed500;
     case ThreadStateSlice::kTraced:
-      return purple500;
+      return kPurple500;
     case ThreadStateSlice::kDead:
       [[fallthrough]];
     case ThreadStateSlice::kZombie:
-      return black;
+      return kBlack;
     case ThreadStateSlice::kParked:
       [[fallthrough]];
     case ThreadStateSlice::kIdle:
-      return brown500;
+      return kBrown500;
     default:
       ORBIT_UNREACHABLE();
   }

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -499,7 +499,7 @@ std::unique_ptr<orbit_accessibility::AccessibleInterface>
 TrackContainer::CreateAccessibleInterface() {
   return std::make_unique<AccessibleCaptureViewElement>(
       this, "TrackContainer", orbit_accessibility::AccessibilityRole::Pane,
-      orbit_accessibility::AccessibilityState::Focusable);
+      orbit_accessibility::AccessibilityState::kFocusable);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TrackContainer.cpp
+++ b/src/OrbitGl/TrackContainer.cpp
@@ -339,8 +339,8 @@ void TrackContainer::DrawIncompleteDataIntervals(PrimitiveAssembler& primitive_a
       });
     }
 
-    static const Color incomplete_data_interval_orange{255, 128, 0, 32};
-    primitive_assembler.AddBox(MakeBox(pos, size), z_value, incomplete_data_interval_orange,
+    static const Color kIncompleteDataIntervalOrange{255, 128, 0, 32};
+    primitive_assembler.AddBox(MakeBox(pos, size), z_value, kIncompleteDataIntervalOrange,
                                std::move(user_data));
   }
 }

--- a/src/OrbitGl/include/OrbitGl/AccessibleCaptureViewElement.h
+++ b/src/OrbitGl/include/OrbitGl/AccessibleCaptureViewElement.h
@@ -20,7 +20,7 @@ class AccessibleCaptureViewElement : public orbit_accessibility::AccessibleInter
                                         orbit_accessibility::AccessibilityRole accessible_role =
                                             orbit_accessibility::AccessibilityRole::Pane,
                                         orbit_accessibility::AccessibilityState accessible_state =
-                                            orbit_accessibility::AccessibilityState::Normal)
+                                            orbit_accessibility::AccessibilityState::kNormal)
       : accessible_name_(std::move(accessible_name)),
         accessible_role_(accessible_role),
         accessible_state_(accessible_state),

--- a/src/OrbitGl/include/OrbitGl/AccessibleTimeGraph.h
+++ b/src/OrbitGl/include/OrbitGl/AccessibleTimeGraph.h
@@ -17,7 +17,7 @@ class AccessibleTimeGraph : public AccessibleCaptureViewElement {
   explicit AccessibleTimeGraph(TimeGraph* time_graph)
       : AccessibleCaptureViewElement(time_graph, "TimeGraph",
                                      orbit_accessibility::AccessibilityRole::Graphic,
-                                     orbit_accessibility::AccessibilityState::Focusable),
+                                     orbit_accessibility::AccessibilityState::kFocusable),
         time_graph_(time_graph) {}
   [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleParent() const override {
     return time_graph_->GetAccessibleParent()->GetOrCreateAccessibleInterface();

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -201,15 +201,15 @@ QVariant CallTreeViewItemModel::GetForegroundRoleData(const QModelIndex& index) 
 
   if ((unwind_errors_item != nullptr || unwind_error_type_item != nullptr) &&
       index.column() == kThreadOrFunction) {
-    static const QColor unwind_errors_color{QColor::fromRgb(255, 128, 0)};
-    return unwind_errors_color;
+    static const QColor kUnwindErrorsColor{QColor::fromRgb(255, 128, 0)};
+    return kUnwindErrorsColor;
   }
 
   const auto* parent_is_unwind_error_type_item =
       dynamic_cast<const CallTreeUnwindErrorType*>(item->parent());
   if (parent_is_unwind_error_type_item != nullptr && index.column() == kThreadOrFunction) {
-    static const QColor unwind_error_function_color{Qt::lightGray};
-    return unwind_error_function_color;
+    static const QColor kUnwindErrorFunctionColor{Qt::lightGray};
+    return kUnwindErrorFunctionColor;
   }
   return {};
 }

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -671,14 +671,14 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
   bool enable_copy = ui_->callTreeTreeView->selectionModel()->hasSelection();
 
   QMenu menu{ui_->callTreeTreeView};
-  static const QString alt_click_shortcut = QStringLiteral("\tALT+Click");
+  static const QString kAltClickShortcut = QStringLiteral("\tALT+Click");
   bool is_expanded = ui_->callTreeTreeView->isExpanded(index);
   QString action_expand_recursively = (!is_expanded && enable_expand_recursively)
-                                          ? kActionExpandRecursively + alt_click_shortcut
+                                          ? kActionExpandRecursively + kAltClickShortcut
                                           : kActionExpandRecursively;
   menu.addAction(action_expand_recursively)->setEnabled(enable_expand_recursively);
   QString action_collapse_recursively = (is_expanded && enable_collapse_recursively)
-                                            ? kActionCollapseRecursively + alt_click_shortcut
+                                            ? kActionCollapseRecursively + kAltClickShortcut
                                             : kActionCollapseRecursively;
   menu.addAction(action_collapse_recursively)->setEnabled(enable_collapse_recursively);
   menu.addAction(kActionCollapseChildrenRecursively)->setEnabled(enable_collapse_recursively);
@@ -899,14 +899,14 @@ QVariant CallTreeWidget::HookedIdentityProxyModel::data(const QModelIndex& index
   }
 
   if (role == Qt::ToolTipRole) {
-    static const QString tooltip_hooked_prefix = QStringLiteral("[HOOKED] ");
-    return tooltip_hooked_prefix + data.toString();
+    static const QString kTooltipHookedPrefix = QStringLiteral("[HOOKED] ");
+    return kTooltipHookedPrefix + data.toString();
   }
-  static const QString display_hooked_prefix =
+  static const QString kDisplayHookedPrefix =
       QStringLiteral("[") +
       QString::fromStdString(orbit_data_views::FunctionsDataView::kSelectedFunctionString) +
       QStringLiteral("] ");
-  return display_hooked_prefix + data.toString();
+  return kDisplayHookedPrefix + data.toString();
 }
 
 void CallTreeWidget::ProgressBarItemDelegate::paint(QPainter* painter,

--- a/src/OrbitQt/include/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/include/OrbitQt/orbittreeview.h
@@ -55,7 +55,7 @@ class OrbitTreeView : public QTreeView {
   // TODO(https://github.com/google/orbit/issues/4589): Connect slots via code and not via UI files,
   // and remove the "public slots" specifier
  public slots:  // NOLINT(readability-redundant-access-specifiers)
-  void columnResized(int column, int oldSize, int newSize);
+  void columnResized(int column, int old_size, int new_size);
 
   // TODO(https://github.com/google/orbit/issues/4589): Connect slots via code and not via UI files,
   // and remove the "public slots" specifier

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -508,7 +508,7 @@ void OrbitMainWindow::SetupStatusBarLogButton() {
   capture_log_layout->setContentsMargins(0, 0, 9, 0);
   capture_log_widget->setLayout(capture_log_layout);
 
-  static const QIcon icon = [] {
+  static const QIcon kIcon = [] {
     QIcon icon;
     QPixmap expand_up_pixmap = QPixmap{":/actions/expand_up"};
     QPixmap expand_down_pixmap = QPixmap{":/actions/expand_down"};
@@ -531,7 +531,7 @@ void OrbitMainWindow::SetupStatusBarLogButton() {
   capture_log_button_->setAccessibleName("CaptureLogButton");
   capture_log_button_->setEnabled(false);
   capture_log_button_->setCheckable(true);
-  capture_log_button_->setIcon(icon);
+  capture_log_button_->setIcon(kIcon);
   capture_log_button_->setStyleSheet(
       "padding-left: 11; padding-right: 11; padding-top: 2; padding-bottom: 2;");
   capture_log_layout->addWidget(capture_log_button_);

--- a/src/OrbitTest/OrbitTestImpl.cpp
+++ b/src/OrbitTest/OrbitTestImpl.cpp
@@ -110,9 +110,9 @@ static void ORBIT_NOINLINE SleepFor2Ms() {
 }
 
 static void ExecuteTask(uint32_t id) {
-  static const std::vector<uint32_t> sleep_times_ms = {10, 200, 20,  300, 60,  100, 150,
-                                                       20, 30,  320, 380, 400, 450, 500};
-  uint32_t sleep_time = sleep_times_ms[id % sleep_times_ms.size()];
+  static const std::vector<uint32_t> kSleepTimesMs = {10, 200, 20,  300, 60,  100, 150,
+                                                      20, 30,  320, 380, 400, 450, 500};
+  uint32_t sleep_time = kSleepTimesMs[id % kSleepTimesMs.size()];
   std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time));
   std::string str = absl::StrFormat(
       "This is a very long dynamic string: The quick brown fox jumps over the lazy dog. This "

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -643,7 +643,7 @@ class VulkanLayerController {
     }
     uint32_t pid = orbit_base::GetCurrentProcessId();
     ORBIT_LOG("Writing PID of %u to \"%s\"", pid, pid_file);
-    ErrorMessageOr<orbit_base::unique_fd> error_or_file = orbit_base::OpenFileForWriting(pid_file);
+    ErrorMessageOr<orbit_base::UniqueFd> error_or_file = orbit_base::OpenFileForWriting(pid_file);
     ORBIT_FAIL_IF(error_or_file.has_error(), "Opening \"%s\": %s", pid_file,
                   error_or_file.error().message());
     ErrorMessageOr<void> result =

--- a/src/QtUtils/include/QtUtils/AssertNoQtLogWarnings.h
+++ b/src/QtUtils/include/QtUtils/AssertNoQtLogWarnings.h
@@ -24,27 +24,27 @@ namespace orbit_qt_utils {
 class AssertNoQtLogWarnings {
   static void MessageHandlerTest(QtMsgType type, const QMessageLogContext& context,
                                  const QString& msg) {
-    static bool NO_WARNING_MSG = true;
-    QByteArray localMsg = msg.toLocal8Bit();
+    static bool no_warning_msg = true;
+    QByteArray local_msg = msg.toLocal8Bit();
     const char* file = context.file != nullptr ? context.file : "";
     const char* function = context.function != nullptr ? context.function : "";
     switch (type) {
       case QtDebugMsg:
-        ORBIT_LOG("Qt debug message: %s (%s:%u, %s)", localMsg.constData(), file, context.line,
+        ORBIT_LOG("Qt debug message: %s (%s:%u, %s)", local_msg.constData(), file, context.line,
                   function);
         break;
       case QtInfoMsg:
-        ORBIT_LOG("Qt info message: %s (%s:%u, %s)", localMsg.constData(), file, context.line,
+        ORBIT_LOG("Qt info message: %s (%s:%u, %s)", local_msg.constData(), file, context.line,
                   function);
         break;
       case QtWarningMsg:
-        EXPECT_EQ(false, NO_WARNING_MSG) << msg.toStdString();
+        EXPECT_EQ(false, no_warning_msg) << msg.toStdString();
         break;
       case QtCriticalMsg:
-        EXPECT_EQ(false, NO_WARNING_MSG) << msg.toStdString();
+        EXPECT_EQ(false, no_warning_msg) << msg.toStdString();
         break;
       case QtFatalMsg:
-        EXPECT_EQ(false, NO_WARNING_MSG) << msg.toStdString();
+        EXPECT_EQ(false, no_warning_msg) << msg.toStdString();
         break;
     }
   }

--- a/src/QtUtils/include/QtUtils/AssertNoQtLogWarnings.h
+++ b/src/QtUtils/include/QtUtils/AssertNoQtLogWarnings.h
@@ -24,7 +24,6 @@ namespace orbit_qt_utils {
 class AssertNoQtLogWarnings {
   static void MessageHandlerTest(QtMsgType type, const QMessageLogContext& context,
                                  const QString& msg) {
-    static bool no_warning_msg = true;
     QByteArray local_msg = msg.toLocal8Bit();
     const char* file = context.file != nullptr ? context.file : "";
     const char* function = context.function != nullptr ? context.function : "";
@@ -38,13 +37,13 @@ class AssertNoQtLogWarnings {
                   function);
         break;
       case QtWarningMsg:
-        EXPECT_EQ(false, no_warning_msg) << msg.toStdString();
+        FAIL() << msg.toStdString();
         break;
       case QtCriticalMsg:
-        EXPECT_EQ(false, no_warning_msg) << msg.toStdString();
+        FAIL() << msg.toStdString();
         break;
       case QtFatalMsg:
-        EXPECT_EQ(false, no_warning_msg) << msg.toStdString();
+        FAIL() << msg.toStdString();
         break;
     }
   }

--- a/src/QtUtils/include/QtUtils/EventLoop.h
+++ b/src/QtUtils/include/QtUtils/EventLoop.h
@@ -69,7 +69,9 @@ class EventLoop : public QObject {
   bool processEvents(ProcessEventsFlags flags = ProcessEventsFlag::AllEvents) {
     return loop_.processEvents(flags);
   }
-  void processEvents(ProcessEventsFlags flags, int maxTime) { loop_.processEvents(flags, maxTime); }
+  void processEvents(ProcessEventsFlags flags, int max_time) {
+    loop_.processEvents(flags, max_time);
+  }
 
  private:
   std::optional<ErrorMessageOr<int>> result_;

--- a/src/SessionSetup/TargetLabel.cpp
+++ b/src/SessionSetup/TargetLabel.cpp
@@ -49,21 +49,21 @@ QPixmap ColorizeIcon(const QPixmap& pixmap, const QColor& color) {
 }
 
 QPixmap GetGreenConnectedIcon() {
-  const static QPixmap green_connected_icon =
+  const static QPixmap kGreenConnectedIcon =
       ColorizeIcon(QPixmap{":/actions/connected"}, kGreenColor);
-  return green_connected_icon;
+  return kGreenConnectedIcon;
 }
 
 QPixmap GetOrangeDisconnectedIcon() {
-  const static QPixmap orange_disconnected_icon =
+  const static QPixmap kOrangeDisconnectedIcon =
       ColorizeIcon(QPixmap{":/actions/alert"}, kOrangeColor);
-  return orange_disconnected_icon;
+  return kOrangeDisconnectedIcon;
 }
 
 QPixmap GetRedDisconnectedIcon() {
-  const static QPixmap red_disconnected_icon =
+  const static QPixmap kRedDisconnectedIcon =
       ColorizeIcon(QPixmap{":/actions/disconnected"}, kRedColor);
-  return red_disconnected_icon;
+  return kRedDisconnectedIcon;
 }
 
 }  // namespace

--- a/src/TestUtils/TemporaryFile.cpp
+++ b/src/TestUtils/TemporaryFile.cpp
@@ -48,7 +48,7 @@ ErrorMessageOr<void> TemporaryFile::Init(std::string_view prefix) {
         absl::StrFormat("Unable to create a temporary file: %s", SafeStrerror(errno))};
   }
 
-  fd_ = orbit_base::unique_fd(fd);
+  fd_ = orbit_base::UniqueFd(fd);
 #elif defined(_WIN32)
   // _mktemp_s expects the `size` to include the NULL character at the end.
   errno_t errnum = _mktemp_s(file_path.data(), file_path.size() + 1);

--- a/src/TestUtils/include/TestUtils/TemporaryFile.h
+++ b/src/TestUtils/include/TestUtils/TemporaryFile.h
@@ -40,7 +40,7 @@ class TemporaryFile final {
 
   void CloseAndRemove();
 
-  [[nodiscard]] const orbit_base::unique_fd& fd() const { return fd_; }
+  [[nodiscard]] const orbit_base::UniqueFd& fd() const { return fd_; }
   [[nodiscard]] const std::filesystem::path& file_path() const { return file_path_; }
 
   // Call this function to create a new temporary file. The `prefix` is a component that is
@@ -52,7 +52,7 @@ class TemporaryFile final {
   TemporaryFile() = default;
   ErrorMessageOr<void> Init(std::string_view prefix);
 
-  orbit_base::unique_fd fd_;
+  orbit_base::UniqueFd fd_;
   std::filesystem::path file_path_;
 };
 

--- a/src/TracepointService/ReadTracepointsTest.cpp
+++ b/src/TracepointService/ReadTracepointsTest.cpp
@@ -38,18 +38,18 @@ TEST(ServiceUtils, CategoriesTracepoints) {
                  [](const TracepointInfo& value) { return value.category(); });
 
   ASSERT_FALSE(categories.empty());
-  static const std::array<std::string, 10> categories_available = {
+  static const std::array<std::string, 10> kCategoriesAvailable = {
       "sched",    "task",    "module",       "signal",     "sock",
       "syscalls", "migrate", "raw_syscalls", "exceptions", "iomap"};
 
-  static const std::array<std::string, 3> categories_unavailable = {"orbit", "profiler",
+  static const std::array<std::string, 3> kCategoriesUnavailable = {"orbit", "profiler",
                                                                     "instrumentation"};
 
-  for (const std::string& category_available : categories_available) {
+  for (const std::string& category_available : kCategoriesAvailable) {
     ASSERT_TRUE(find(categories.begin(), categories.end(), category_available) != categories.end());
   }
 
-  for (const std::string& category_unavailable : categories_unavailable) {
+  for (const std::string& category_unavailable : kCategoriesUnavailable) {
     ASSERT_TRUE(find(categories.begin(), categories.end(), category_unavailable) ==
                 categories.end());
   }
@@ -69,18 +69,18 @@ TEST(ServiceUtils, NamesTracepoints) {
                  [](const TracepointInfo& value) { return value.name(); });
 
   ASSERT_FALSE(names.empty());
-  static const std::array<std::string, 10> names_available = {
+  static const std::array<std::string, 10> kNamesAvailable = {
       "sched_switch", "sched_wakeup",    "sched_process_fork", "sched_waking", "task_rename",
       "task_newtask", "signal_generate", "signal_deliver",     "timer_init",   "timer_start"};
 
-  static const std::array<std::string, 5> names_unavailable = {
+  static const std::array<std::string, 5> kNamesUnavailable = {
       "orbit", "profiler", "instrumentation", "enable", "filter"};
 
-  for (const std::string& name_available : names_available) {
+  for (const std::string& name_available : kNamesAvailable) {
     ASSERT_TRUE(find(names.begin(), names.end(), name_available) != names.end());
   }
 
-  for (const std::string& name_unavailable : names_unavailable) {
+  for (const std::string& name_unavailable : kNamesUnavailable) {
     ASSERT_TRUE(find(names.begin(), names.end(), name_unavailable) == names.end());
   }
 }

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -103,7 +103,7 @@ ErrorMessageOr<bool> AlreadyInjected(absl::Span<const ModuleInfo> modules) {
 // a situation where instrumenting the functions below would lead to a recursive call into the
 // instrumentation. We just skip these and leave instrumenting them to the kernel/uprobe fallback.
 bool IsBlocklisted(std::string_view function_name) {
-  static const absl::flat_hash_set<std::string> blocklist{
+  static const absl::flat_hash_set<std::string> kBlocklist{
       "__GI___libc_malloc",
       "__GI___libc_free",
       "get_free_list",
@@ -131,7 +131,7 @@ bool IsBlocklisted(std::string_view function_name) {
       // instruction.
       "__GI_memcpy",
   };
-  return blocklist.contains(function_name);
+  return kBlocklist.contains(function_name);
 }
 
 // MachineCodeForCloneCall creates the code to spawn a new thread inside the target process by using
@@ -196,9 +196,9 @@ ErrorMessageOr<void> WaitForThreadToExit(pid_t pid, pid_t tid) {
 // These are the names of the threads that will be spawned when
 // liborbituserspaceinstrumentation.so is injected into the target process.
 std::multiset<std::string> GetExpectedOrbitThreadNames() {
-  static const std::multiset<std::string> thread_names{
+  static const std::multiset<std::string> kThreadNames{
       "default-executo", "resolver-execut", "grpc_global_tim", "ConnectRcvCmds", "ForwarderThread"};
-  return thread_names;
+  return kThreadNames;
 }
 
 ErrorMessageOr<std::vector<pid_t>> GetNewOrbitThreads(

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -95,7 +95,7 @@ class LockFreeUserSpaceInstrumentationEventProducer
         google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
 
     std::visit(
-        orbit_base::overloaded{[capture_event](const FunctionEntry& raw_event) -> void {
+        orbit_base::Overloaded{[capture_event](const FunctionEntry& raw_event) -> void {
                                  orbit_grpc_protos::FunctionEntry* function_entry =
                                      capture_event->mutable_function_entry();
                                  function_entry->set_pid(raw_event.pid);

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -169,10 +169,10 @@ bool& GetIsInPayload() {
   }
   is_in_payload = true;
 
-  thread_local const pid_t tid = orbit_base::GetCurrentThreadIdNative();
+  thread_local const pid_t kTid = orbit_base::GetCurrentThreadIdNative();
 
-  if (tid == orbit_threads[0] || tid == orbit_threads[1] || tid == orbit_threads[2] ||
-      tid == orbit_threads[3] || tid == orbit_threads[4] || tid == orbit_threads[5]) {
+  if (kTid == orbit_threads[0] || kTid == orbit_threads[1] || kTid == orbit_threads[2] ||
+      kTid == orbit_threads[3] || kTid == orbit_threads[4] || kTid == orbit_threads[5]) {
     is_in_payload = false;
     return;
   }
@@ -183,9 +183,9 @@ bool& GetIsInPayload() {
   open_function_call_stack.emplace(return_address, timestamp_on_entry_ns);
 
   if (GetCaptureEventProducer().IsCapturing()) {
-    static const uint32_t pid = orbit_base::GetCurrentProcessId();
+    static const uint32_t kPid = orbit_base::GetCurrentProcessId();
     GetCaptureEventProducer().EnqueueIntermediateEvent(
-        FunctionEntry{pid, orbit_base::FromNativeThreadId(tid), function_id, stack_pointer,
+        FunctionEntry{kPid, orbit_base::FromNativeThreadId(kTid), function_id, stack_pointer,
                       return_address, timestamp_on_entry_ns});
   }
 

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -1150,7 +1150,7 @@ ErrorMessageOr<RelocatedInstruction> RelocateInstruction(cs_insn* instruction, u
 
 uint64_t GetMaxTrampolineSize() {
   // The maximum size of a trampoline is constant. So the calculation can be cached on first call.
-  static const uint64_t trampoline_size = []() -> uint64_t {
+  static const uint64_t kTrampolineSize = []() -> uint64_t {
     MachineCode unused_code;
     AppendBackupCode(unused_code);
     AppendCallToEntryPayload(/*entry_payload_function_address=*/0,
@@ -1166,7 +1166,7 @@ uint64_t GetMaxTrampolineSize() {
     return static_cast<uint64_t>(((unused_code.GetResultAsVector().size() + 31) / 32) * 32);
   }();
 
-  return trampoline_size;
+  return kTrampolineSize;
 }
 
 ErrorMessageOr<uint64_t> CreateTrampoline(pid_t pid, uint64_t function_address,
@@ -1209,13 +1209,13 @@ ErrorMessageOr<uint64_t> CreateTrampoline(pid_t pid, uint64_t function_address,
 
 uint64_t GetReturnTrampolineSize() {
   // The size is constant. So the calculation can be cached on first call.
-  static const uint64_t return_trampoline_size = []() -> uint64_t {
+  static const uint64_t kReturnTrampolineSize = []() -> uint64_t {
     MachineCode unused_code;
     AppendCallToExitPayloadAndJumpToReturnAddress(/*exit_payload_function_address=*/0, unused_code);
     return static_cast<uint64_t>(((unused_code.GetResultAsVector().size() + 31) / 32) * 32);
   }();
 
-  return return_trampoline_size;
+  return kReturnTrampolineSize;
 }
 
 ErrorMessageOr<void> CreateReturnTrampoline(pid_t pid, uint64_t exit_payload_function_address,

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -336,11 +336,11 @@ TEST(TrampolineTest, AddressDifferenceAsInt32) {
 
   // Result of the difference is positive; in the first case it just fits, the second case
   // overflows.
-  const uint64_t addr2_smaller = kAddr1 - std::numeric_limits<int32_t>::max();
-  result = AddressDifferenceAsInt32(kAddr1, addr2_smaller);
+  constexpr uint64_t kAddr2Smaller = kAddr1 - std::numeric_limits<int32_t>::max();
+  result = AddressDifferenceAsInt32(kAddr1, kAddr2Smaller);
   ASSERT_THAT(result, HasNoError());
   EXPECT_EQ(std::numeric_limits<int32_t>::max(), result.value());
-  result = AddressDifferenceAsInt32(kAddr1, addr2_smaller - 1);
+  result = AddressDifferenceAsInt32(kAddr1, kAddr2Smaller - 1);
   EXPECT_THAT(result, HasError("Difference is larger than +2GB"));
 
   // Result of the difference does not even fit into a int64. We handle that gracefully as well.

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -336,11 +336,11 @@ TEST(TrampolineTest, AddressDifferenceAsInt32) {
 
   // Result of the difference is positive; in the first case it just fits, the second case
   // overflows.
-  const uint64_t kAddr2Smaller = kAddr1 - std::numeric_limits<int32_t>::max();
-  result = AddressDifferenceAsInt32(kAddr1, kAddr2Smaller);
+  const uint64_t addr2_smaller = kAddr1 - std::numeric_limits<int32_t>::max();
+  result = AddressDifferenceAsInt32(kAddr1, addr2_smaller);
   ASSERT_THAT(result, HasNoError());
   EXPECT_EQ(std::numeric_limits<int32_t>::max(), result.value());
-  result = AddressDifferenceAsInt32(kAddr1, kAddr2Smaller - 1);
+  result = AddressDifferenceAsInt32(kAddr1, addr2_smaller - 1);
   EXPECT_THAT(result, HasError("Difference is larger than +2GB"));
 
   // Result of the difference does not even fit into a int64. We handle that gracefully as well.


### PR DESCRIPTION
This might be a controversial one. It applies our clang-tidy defined naming scheme (which currently does not include function names). However, clang-tidy was not able to apply changes across compilation units, so there is a lot of manual work done.

Please review with care. Thanks.

Test: Compile & Run tests