### PR TITLE
Add SSH server for testing signed deployment

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -174,27 +174,14 @@ jobs:
         with:
           name: clang_tidy_fixes
           path: clang-tidy-fixes.yml
-      - name: Set up simple SSH server (Ubuntu)
-        if: startsWith(matrix.config.os, 'ubuntu')
-        working-directory: ./contrib/docker/ssh_server
-        run: |
-          podman build . -f Dockerfile.simple -t ssh_server_simple
-          echo "Starting Simple SSH Server"
-          podman run -dP --rm --name ssh_server_simple ssh_server_simple
-          SSH_SERVER_SIMPLE_PORT=$(podman port ssh_server_simple 22 | grep 0.0.0.0 | cut -f2 -d:)
-          echo "Determined SSH port of Simple SSH Server: ${SSH_SERVER_SIMPLE_PORT}"
-          echo "SSH_SERVER_SIMPLE_PORT=${SSH_SERVER_SIMPLE_PORT}" >> $GITHUB_ENV
       - name: CMake Test (Ubuntu)
         if: startsWith(matrix.config.os, 'ubuntu')
         working-directory: ./build
         run: |
           CTEST_OUTPUT_ON_FAILURE=1 \
           ARGS="-E IntegrationTest" \
-          ORBIT_TESTING_SSH_SERVER_SIMPLE_ADDRESS="127.0.0.1:${{ env.SSH_SERVER_SIMPLE_PORT }}" \
+          ../contrib/scripts/run_ssh_containers.sh \
           cmake --build . --target test
-      - name: Shut down simple SSH server (Ubuntu)
-        if: startsWith(matrix.config.os, 'ubuntu')
-        run: podman stop ssh_server_simple
       - name: Install conan config (Windows)
         if: startsWith(matrix.config.os, 'windows')
         run: |

--- a/contrib/docker/ssh_server/Dockerfile.signing
+++ b/contrib/docker/ssh_server/Dockerfile.signing
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+# This container allows testing the signed debian package installation workflow.
+
 FROM alpine:3.17
 
 RUN apk add --no-cache openssh sudo socat
@@ -16,10 +18,10 @@ EXPOSE 22
 RUN adduser --disabled-password loginuser && echo 'loginuser:loginpassword' | chpasswd
 COPY id_ed25519.pub /home/loginuser/.ssh/authorized_keys
 
-# This is just a plain text file with some ASCII content that can be used by tests. Mainly needed for the SFTP tests.
-COPY plain.txt /home/loginuser/plain.txt
-
-COPY sudoers /etc/sudoers
+COPY sudoers.signing /etc/sudoers
 RUN chmod 600 /etc/sudoers
+
+COPY install_signed_package.sh /usr/local/cloudcast/sbin/install_signed_package.sh
+RUN chmod 755 /usr/local/cloudcast/sbin/install_signed_package.sh
 
 CMD ["/usr/sbin/sshd", "-D", "-e", "-o", "AllowTcpForwarding=yes"]

--- a/contrib/docker/ssh_server/install_signed_package.sh
+++ b/contrib/docker/ssh_server/install_signed_package.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Copyright (c) 2022 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -eu
+
+# This script only emulates the real behaviour as much as needed.
+# In the real tool the first CLI argument is a path to a debian package.
+# But for testing here we expect this an executable file, that we can copy
+# to the final destination without the need to unpack things.
+#
+# The script also expects a "signature" under $1.asc. We don't expect this
+# to be a real cryptographic signature. Instead the signature is considered
+# valid iff the first line consists of the word "SIGNATURE".
+
+read line <"$1.asc"
+if [ "$line" != "SIGNATURE" ]; then
+  exit 2
+fi
+
+mkdir -p /opt/developer/tools
+cp -v "$1" /opt/developer/tools/OrbitService
+chmod +x /opt/developer/tools/OrbitService

--- a/contrib/docker/ssh_server/sudoers.signing
+++ b/contrib/docker/ssh_server/sudoers.signing
@@ -1,0 +1,2 @@
+loginuser ALL=(ALL:ALL) ALL
+loginuser ALL=(ALL:ALL) NOPASSWD: /usr/local/cloudcast/sbin/install_signed_package.sh *


### PR DESCRIPTION
This also makes use of the new `run_ssh_containers.sh` script on the CI to simplify handling of the containers. Caching of containers using ghcr.io is still missing though.