### PR TITLE
Update version on "clang-tidy-pr-comments"

### DIFF
--- a/.github/workflows/report-build-and-test.yml
+++ b/.github/workflows/report-build-and-test.yml
@@ -72,7 +72,7 @@ jobs:
         workflow_conclusion: ''
         name: clang_tidy_fixes
         if_no_artifact_found: 'ignore'
-    - uses: platisd/clang-tidy-pr-comments@bc0bb7da034a8317d54e7fe1e819159002f4cc40
+    - uses: platisd/clang-tidy-pr-comments@89ea1b828cdac1a6ec993d225972adea3b8841b6
       if: steps.set_found_files.outputs.found_files == 'true'
       with:
         github_token: ${{ secrets.ORBITPROFILER_BOT_PAT }}


### PR DESCRIPTION
This updates the "clang-tidy-pr-comments" action to have https://github.com/platisd/clang-tidy-pr-comments/pull/43 in.

Test: Tested on fork