### PR TITLE
Simplify orbit_ssh_qt::Task

### DIFF
--- a/src/OrbitSshQt/SftpCopyToRemoteOperationTest.cpp
+++ b/src/OrbitSshQt/SftpCopyToRemoteOperationTest.cpp
@@ -21,7 +21,7 @@
 namespace orbit_ssh_qt {
 using orbit_qt_test_utils::WaitFor;
 using orbit_qt_test_utils::YieldsResult;
-using orbit_test_utils::HasNoError;
+using orbit_test_utils::HasValue;
 
 using SftpCopyToRemoteOperationTest = SftpTestFixture;
 
@@ -39,13 +39,6 @@ TEST_F(SftpCopyToRemoteOperationTest, Upload) {
   }
 
   Task task{GetSession(), "cmp /home/loginuser/plain.txt /home/loginuser/upload.txt"};
-  QSignalSpy finished_signal{&task, &orbit_ssh_qt::Task::finished};
-  EXPECT_THAT(WaitFor(task.Start()), YieldsResult(HasNoError()));
-  EXPECT_THAT(WaitFor(task.Stop()), YieldsResult(HasNoError()));
-
-  ASSERT_EQ(finished_signal.size(), 1);
-  // Return value 0 means there was no difference in the two compared files. Hence the upload
-  // succeeded.
-  EXPECT_EQ(finished_signal[0][0].toInt(), 0);
+  EXPECT_THAT(WaitFor(task.Execute()), YieldsResult(HasValue(Task::ExitCode{0})));
 }
 }  // namespace orbit_ssh_qt

--- a/src/SshQtTestUtils/KillProcessListeningOnTcpPort.cpp
+++ b/src/SshQtTestUtils/KillProcessListeningOnTcpPort.cpp
@@ -6,9 +6,6 @@
 
 #include <absl/strings/str_format.h>
 
-#include <QList>
-#include <QSignalSpy>
-#include <QVariant>
 #include <optional>
 #include <string>
 
@@ -18,34 +15,17 @@
 #include "QtTestUtils/WaitFor.h"
 
 namespace orbit_ssh_qt_test_utils {
+using orbit_qt_test_utils::ConsiderTimeoutAnError;
+using orbit_qt_test_utils::WaitFor;
+using orbit_ssh_qt::Task;
 
 ErrorMessageOr<void> KillProcessListeningOnTcpPort(orbit_ssh_qt::Session* session, int tcp_port) {
-  orbit_ssh_qt::Task kill_task{session, absl::StrFormat("kill $(fuser %d/tcp)", tcp_port)};
-  QSignalSpy finished_signal{&kill_task, &orbit_ssh_qt::Task::finished};
-  auto start_result = orbit_qt_test_utils::WaitFor(kill_task.Start());
+  Task kill_task{session, absl::StrFormat("kill $(fuser %d/tcp)", tcp_port)};
+  OUTCOME_TRY(Task::ExitCode exit_code, ConsiderTimeoutAnError(WaitFor(kill_task.Execute())));
 
-  if (orbit_qt_test_utils::HasTimedOut(start_result)) {
-    return ErrorMessage{"Failed to start `kill`. Start procedure timed out."};
-  }
-  OUTCOME_TRY(orbit_qt_test_utils::GetValue(start_result).value());
-
-  orbit_qt_test_utils::WaitForResult<ErrorMessageOr<void>> stop_result =
-      orbit_qt_test_utils::WaitFor(kill_task.Stop());
-
-  if (orbit_qt_test_utils::HasTimedOut(stop_result)) {
-    return ErrorMessage{"Failed to stop `kill`. Stop procedure timed out."};
-  }
-
-  OUTCOME_TRY(orbit_qt_test_utils::GetValue(stop_result).value());
-
-  if (finished_signal.empty() && !finished_signal.wait()) {
-    return ErrorMessage{"Waiting for finished signal timed out."};
-  }
-
-  const int exit_code = finished_signal[0][0].toInt();
-  if (exit_code != 0) {
+  if (*exit_code != 0) {
     return ErrorMessage{
-        absl::StrFormat("The `kill` command returned a non-zero exit code: %d", exit_code)};
+        absl::StrFormat("The `kill` command returned a non-zero exit code: %d", *exit_code)};
   }
 
   return outcome::success();


### PR DESCRIPTION
This simplifies the usage of Task in a couple of ways:

1. `Task::Stop()` now returns a future that contains the exit code. No need to check the `finished` signal anymore.
2. There is a new function `Task::Execute()` which first calls `Start()` and then `Stop()` once `Start()` succeeded. That simplifies the usage for tasks that don't run for a long time.

I'm also updating test cases that benefit from the new facilities in `Task`.