### PR TITLE
Introspection from entry

### DIFF
--- a/src/ClientFlags/ClientFlags.cpp
+++ b/src/ClientFlags/ClientFlags.cpp
@@ -80,3 +80,6 @@ ABSL_FLAG(std::string, ssh_target_process, "",
           "a SSH connection. This means --ssh_hostname, --ssh_user, --ssh_known_host_path and "
           "--ssh_key_path also need to be specified (--ssh_port will default to 22). If multiple "
           "instances of the same process exist, the one with the highest PID will be chosen.");
+
+// Introspection from entry point.
+ABSL_FLAG(bool, introspect, false, "Introspect from entry point");

--- a/src/ClientFlags/include/ClientFlags/ClientFlags.h
+++ b/src/ClientFlags/include/ClientFlags/ClientFlags.h
@@ -73,4 +73,7 @@ ABSL_DECLARE_FLAG(std::string, ssh_known_host_path);
 ABSL_DECLARE_FLAG(std::string, ssh_key_path);
 ABSL_DECLARE_FLAG(std::string, ssh_target_process);
 
+// Introspection on entry.
+ABSL_DECLARE_FLAG(bool, introspect);
+
 #endif  // CLIENT_FLAGS_CLIENT_FLAGS_H_

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -261,6 +261,8 @@ IntrospectionWindow::IntrospectionWindow(
   capture_data_ = std::make_unique<CaptureData>(capture_started, std::nullopt,
                                                 std::move(frame_track_function_ids),
                                                 CaptureData::DataSource::kLiveCapture);
+  // Start recording on window creation.
+  ToggleRecording();
 }
 
 IntrospectionWindow::~IntrospectionWindow() { StopIntrospection(); }
@@ -276,6 +278,7 @@ const char* IntrospectionWindow::GetHelpText() const {
 bool IntrospectionWindow::IsIntrospecting() const { return introspection_listener_ != nullptr; }
 
 void IntrospectionWindow::StartIntrospection() {
+  ORBIT_LOG("Starting introspection");
   ORBIT_CHECK(!IsIntrospecting());
   set_draw_help(false);
   CreateTimeGraph(capture_data_.get());
@@ -286,7 +289,10 @@ void IntrospectionWindow::StartIntrospection() {
             api_event_variant);
       });
 }
-void IntrospectionWindow::StopIntrospection() { introspection_listener_ = nullptr; }
+void IntrospectionWindow::StopIntrospection() {
+  ORBIT_LOG("Stopping introspection");
+  introspection_listener_ = nullptr;
+}
 
 void IntrospectionWindow::Draw(QPainter* painter) {
   ORBIT_SCOPE_FUNCTION;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -187,6 +187,11 @@ OrbitMainWindow::OrbitMainWindow(TargetConfiguration target_configuration,
       target_configuration_(std::move(target_configuration)) {
   SetupMainWindow();
 
+  // Start introspection from entry.
+  if (absl::GetFlag(FLAGS_introspect)) {
+    on_actionIntrospection_triggered();
+  }
+
   SetupStatusBarLogButton();
   SetupHintFrame();
 
@@ -387,7 +392,7 @@ void OrbitMainWindow::SetupMainWindow() {
   std::filesystem::path icon_file_name = (orbit_base::GetExecutableDir() / "orbit.ico");
   this->setWindowIcon(QIcon(QString::fromStdString(icon_file_name.string())));
 
-  if (!absl::GetFlag(FLAGS_devmode)) {
+  if (!absl::GetFlag(FLAGS_devmode) && !absl::GetFlag(FLAGS_introspect)) {
     ui->actionIntrospection->setVisible(false);
   }
 }


### PR DESCRIPTION
Add `--introspect` option which starts introspection from the capture 
window creation. The goal is to easily profile the startup time that 
can be extremely slow in some cases (#4460)