### PR TITLE
Fix introspection crash

### DIFF
--- a/src/ClientData/include/ClientData/CaptureDataHolder.h
+++ b/src/ClientData/include/ClientData/CaptureDataHolder.h
@@ -39,6 +39,12 @@ class CaptureDataHolder {
     return *capture_data_;
   }
 
+  [[nodiscard]] std::optional<ScopeId> ProvideScopeId(
+      const orbit_client_protos::TimerInfo& timer_info) const {
+    if (capture_data_ == nullptr) return std::nullopt;
+    return capture_data_->ProvideScopeId(timer_info);
+  }
+
   [[nodiscard]] virtual bool HasCaptureData() const { return static_cast<bool>(capture_data_); }
 
  protected:

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -2210,7 +2210,7 @@ const orbit_client_protos::TimerInfo* OrbitApp::selected_timer() const {
 void OrbitApp::SelectTimer(const orbit_client_protos::TimerInfo* timer_info) {
   data_manager_->set_selected_timer(timer_info);
   const std::optional<ScopeId> scope_id =
-      timer_info != nullptr ? GetCaptureData().ProvideScopeId(*timer_info) : std::nullopt;
+      timer_info != nullptr ? ProvideScopeId(*timer_info) : std::nullopt;
   data_manager_->set_highlighted_scope_id(scope_id);
 
   const uint64_t group_id = timer_info != nullptr ? timer_info->group_id() : kOrbitDefaultGroupId;
@@ -2229,7 +2229,7 @@ std::optional<ScopeId> OrbitApp::GetScopeIdToHighlight() const {
   const orbit_client_protos::TimerInfo* timer_info = selected_timer();
 
   if (timer_info == nullptr) return GetHighlightedScopeId();
-  return GetCaptureData().ProvideScopeId(*timer_info);
+  return ProvideScopeId(*timer_info);
 }
 
 uint64_t OrbitApp::GetGroupIdToHighlight() const {

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -181,7 +181,7 @@ std::string ThreadTrack::GetBoxTooltip(const PrimitiveAssembler& primitive_assem
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
   if (!app_->HasCaptureData()) return TimerTrack::IsTimerActive(timer_info);
-  const std::optional<ScopeId> scope_id = app_->GetCaptureData().ProvideScopeId(timer_info);
+  const std::optional<ScopeId> scope_id = app_->ProvideScopeId(timer_info);
   return scope_id.has_value() ? app_->IsScopeVisible(scope_id.value()) : false;
 }
 
@@ -217,8 +217,7 @@ float ThreadTrack::GetDefaultBoxHeight() const {
 }
 
 Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, const internal::DrawData& draw_data) {
-  const std::optional<ScopeId> scope_id =
-      app_->HasCaptureData() ? app_->GetCaptureData().ProvideScopeId(timer_info) : std::nullopt;
+  const std::optional<ScopeId> scope_id = app_->ProvideScopeId(timer_info);
   const uint64_t group_id = timer_info.group_id();
   const bool is_selected = &timer_info == draw_data.selected_timer;
   const bool is_scope_id_highlighted =

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -193,7 +193,7 @@ bool TimerTrack::DrawTimer(TextRenderer& text_renderer, const TimerInfo* prev_ti
     }
   }
 
-  std::optional<ScopeId> scope_id = app_->GetCaptureData().ProvideScopeId(*current_timer_info);
+  std::optional<ScopeId> scope_id = app_->ProvideScopeId(*current_timer_info);
   uint64_t group_id = current_timer_info->group_id();
 
   bool is_selected = current_timer_info == draw_data.selected_timer;
@@ -421,7 +421,7 @@ bool TimerTrack::ShouldHaveBorder(
     const TimerInfo* timer, const std::optional<orbit_statistics::HistogramSelectionRange>& range,
     float width) const {
   if ((!range.has_value() || width < kMinimalWidthToHaveBorder || !app_->HasCaptureData()) ||
-      (app_->GetCaptureData().ProvideScopeId(*timer) != app_->GetHighlightedScopeId())) {
+      (app_->ProvideScopeId(*timer) != app_->GetHighlightedScopeId())) {
     return false;
   }
   const uint64_t duration = timer->end() - timer->start();

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1353,7 +1353,7 @@ void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerIn
   if (timer_info != nullptr) {
     ORBIT_CHECK(is_live_function_data_view_initialized);
 
-    if (const std::optional<ScopeId> scope_id = app_->GetCaptureData().ProvideScopeId(*timer_info);
+    if (const std::optional<ScopeId> scope_id = app_->ProvideScopeId(*timer_info);
         scope_id.has_value()) {
       selected_row = live_functions_data_view->GetRowFromScopeId(scope_id.value());
       live_functions_data_view->UpdateSelectedFunctionId();


### PR DESCRIPTION
There is a weird pattern in `CaptureDataHolder` that returns a reference from a pointer that could be null. It seems there is already a plan to fix this pattern (b/234095077), but in the meantime Orbit sometimes crashes when selecting timers in the introspection window. This PR adds a `ProvideScopeId` method to `CaptureDataHolder` which checks that `capture_data_` is valid before dereferencing it and otherwise returns std::nullopt.