### PR TITLE
Deactivate timers outside of time range selection

### DIFF
--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -348,7 +348,7 @@ void DataManager::ClearSelectionTimeRange() {
   selection_time_range_.reset();
 }
 
-std::optional<TimeRange> DataManager::GetSelectionTimeRange() const {
+const std::optional<TimeRange>& DataManager::GetSelectionTimeRange() const {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
   return selection_time_range_;
 }

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -338,26 +338,19 @@ DataManager::thread_state_change_callstack_collection() const {
   return thread_state_change_callstack_collection_;
 }
 
-void DataManager::SetTimeRangeSelection(uint64_t start, uint64_t end) {
+void DataManager::SetSelectionTimeRange(const TimeRange& time_range) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  time_range_selection_start_ = start;
-  time_range_selection_end_ = end;
+  selection_time_range_ = time_range;
 }
 
-void DataManager::ClearTimeRangeSelection() {
+void DataManager::ClearSelectionTimeRange() {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  time_range_selection_start_ = std::numeric_limits<uint64_t>::min();
-  time_range_selection_end_ = std::numeric_limits<uint64_t>::max();
+  selection_time_range_.reset();
 }
 
-uint64_t DataManager::GetTimeRangeSelectionStart() const {
+std::optional<TimeRange> DataManager::GetSelectionTimeRange() const {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  return time_range_selection_start_;
-}
-
-uint64_t DataManager::GetTimeRangeSelectionEnd() const {
-  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  return time_range_selection_end_;
+  return selection_time_range_;
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/DataManager.cpp
+++ b/src/ClientData/DataManager.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/container/flat_hash_set.h>
 
+#include <limits>
 #include <utility>
 
 #include "ClientProtos/capture_data.pb.h"
@@ -335,6 +336,28 @@ void DataManager::set_thread_state_change_callstack_collection(
 orbit_grpc_protos::CaptureOptions::ThreadStateChangeCallStackCollection
 DataManager::thread_state_change_callstack_collection() const {
   return thread_state_change_callstack_collection_;
+}
+
+void DataManager::SetTimeRangeSelection(uint64_t start, uint64_t end) {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  time_range_selection_start_ = start;
+  time_range_selection_end_ = end;
+}
+
+void DataManager::ClearTimeRangeSelection() {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  time_range_selection_start_ = std::numeric_limits<uint64_t>::min();
+  time_range_selection_end_ = std::numeric_limits<uint64_t>::max();
+}
+
+uint64_t DataManager::GetTimeRangeSelectionStart() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return time_range_selection_start_;
+}
+
+uint64_t DataManager::GetTimeRangeSelectionEnd() const {
+  ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
+  return time_range_selection_end_;
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/DataManagerTest.cpp
+++ b/src/ClientData/DataManagerTest.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <exception>
+#include <limits>
 #include <optional>
 #include <string>
 #include <thread>
@@ -115,6 +116,25 @@ TEST(DataManager, CanOnlyBeUsedFromTheMainThread) {
                                             WineSyscallHandlingMethod::kNoSpecialHandling);
   CallMethodOnDifferentThreadAndExpectDeath(data_manager,
                                             &DataManager::wine_syscall_handling_method);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::GetTimeRangeSelectionStart);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::GetTimeRangeSelectionEnd);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::ClearTimeRangeSelection);
+  CallMethodOnDifferentThreadAndExpectDeath(data_manager, &DataManager::SetTimeRangeSelection, 0,
+                                            5);
+}
+
+TEST(DataManager, TimeRangeSelection) {
+  DataManager data_manager;
+  EXPECT_EQ(data_manager.GetTimeRangeSelectionStart(), std::numeric_limits<uint64_t>::min());
+  EXPECT_EQ(data_manager.GetTimeRangeSelectionEnd(), std::numeric_limits<uint64_t>::max());
+
+  data_manager.SetTimeRangeSelection(5, 10);
+  EXPECT_EQ(data_manager.GetTimeRangeSelectionStart(), 5);
+  EXPECT_EQ(data_manager.GetTimeRangeSelectionEnd(), 10);
+
+  data_manager.ClearTimeRangeSelection();
+  EXPECT_EQ(data_manager.GetTimeRangeSelectionStart(), std::numeric_limits<uint64_t>::min());
+  EXPECT_EQ(data_manager.GetTimeRangeSelectionEnd(), std::numeric_limits<uint64_t>::max());
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -29,6 +29,18 @@
 
 namespace orbit_client_data {
 
+// TimeRange represents an inclusive time range. A timer is only considered within the time range if
+// it is fully enclosed in it.
+struct TimeRange {
+  TimeRange(uint64_t start, uint64_t end)
+      : start(std::min(start, end)), end(std::max(start, end)) {}
+  [[nodiscard]] bool IsTimerInRange(const orbit_client_protos::TimerInfo& timer) const {
+    return timer.start() >= start && timer.end() <= end;
+  }
+  uint64_t start;
+  uint64_t end;
+};
+
 // This class is responsible for storing and navigating data on the client side.
 // Note that every method of this class should be called on the main thread.
 class DataManager final {
@@ -70,10 +82,9 @@ class DataManager final {
   [[nodiscard]] bool IsFrameTrackEnabled(const FunctionInfo& function) const;
   void ClearUserDefinedCaptureData();
 
-  void SetTimeRangeSelection(uint64_t start, uint64_t end);
-  void ClearTimeRangeSelection();
-  [[nodiscard]] uint64_t GetTimeRangeSelectionStart() const;
-  [[nodiscard]] uint64_t GetTimeRangeSelectionEnd() const;
+  void SetSelectionTimeRange(const TimeRange& time_range);
+  void ClearSelectionTimeRange();
+  [[nodiscard]] std::optional<TimeRange> GetSelectionTimeRange() const;
 
   [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const;
 
@@ -172,8 +183,7 @@ class DataManager final {
   uint64_t memory_sampling_period_ms_ = 10;
   uint64_t memory_warning_threshold_kb_ = 8ULL * 1024 * 1024;
 
-  uint64_t time_range_selection_start_ = std::numeric_limits<uint64_t>::min();
-  uint64_t time_range_selection_end_ = std::numeric_limits<uint64_t>::max();
+  std::optional<TimeRange> selection_time_range_;
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -70,6 +70,11 @@ class DataManager final {
   [[nodiscard]] bool IsFrameTrackEnabled(const FunctionInfo& function) const;
   void ClearUserDefinedCaptureData();
 
+  void SetTimeRangeSelection(uint64_t start, uint64_t end);
+  void ClearTimeRangeSelection();
+  [[nodiscard]] uint64_t GetTimeRangeSelectionStart() const;
+  [[nodiscard]] uint64_t GetTimeRangeSelectionEnd() const;
+
   [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const;
 
   void set_collect_scheduler_info(bool collect_scheduler_info);
@@ -166,6 +171,9 @@ class DataManager final {
   bool collect_memory_info_ = false;
   uint64_t memory_sampling_period_ms_ = 10;
   uint64_t memory_warning_threshold_kb_ = 8ULL * 1024 * 1024;
+
+  uint64_t time_range_selection_start_ = std::numeric_limits<uint64_t>::min();
+  uint64_t time_range_selection_end_ = std::numeric_limits<uint64_t>::max();
 };
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/DataManager.h
+++ b/src/ClientData/include/ClientData/DataManager.h
@@ -25,6 +25,7 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "GrpcProtos/capture.pb.h"
 #include "GrpcProtos/tracepoint.pb.h"
+#include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
 
 namespace orbit_client_data {
@@ -32,10 +33,9 @@ namespace orbit_client_data {
 // TimeRange represents an inclusive time range. A timer is only considered within the time range if
 // it is fully enclosed in it.
 struct TimeRange {
-  TimeRange(uint64_t start, uint64_t end)
-      : start(std::min(start, end)), end(std::max(start, end)) {}
+  TimeRange(uint64_t start, uint64_t end) : start(start), end(end) { ORBIT_CHECK(start <= end); }
   [[nodiscard]] bool IsTimerInRange(const orbit_client_protos::TimerInfo& timer) const {
-    return timer.start() >= start && timer.end() <= end;
+    return start <= timer.start() && timer.end() <= end;
   }
   uint64_t start;
   uint64_t end;
@@ -84,7 +84,7 @@ class DataManager final {
 
   void SetSelectionTimeRange(const TimeRange& time_range);
   void ClearSelectionTimeRange();
-  [[nodiscard]] std::optional<TimeRange> GetSelectionTimeRange() const;
+  [[nodiscard]] const std::optional<TimeRange>& GetSelectionTimeRange() const;
 
   [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const;
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -293,7 +293,8 @@ void CaptureWindow::RightUp() {
     if (select_start_pos_world_[0] == select_stop_pos_world_[0]) {
       app_->ClearTimeRangeSelection();
     } else {
-      app_->OnTimeRangeSelection(TimeRange(select_start_time_, select_stop_time_));
+      app_->OnTimeRangeSelection(TimeRange(std::min(select_start_time_, select_stop_time_),
+                                           std::max(select_start_time_, select_stop_time_)));
     }
   }
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -54,6 +54,7 @@ using orbit_accessibility::AccessibleInterface;
 using orbit_accessibility::AccessibleWidgetBridge;
 
 using orbit_client_data::CaptureData;
+using orbit_client_data::TimeRange;
 using orbit_gl::Batcher;
 using orbit_gl::CaptureViewElement;
 using orbit_gl::ModifierKeys;
@@ -292,8 +293,7 @@ void CaptureWindow::RightUp() {
     if (select_start_pos_world_[0] == select_stop_pos_world_[0]) {
       app_->ClearTimeRangeSelection();
     } else {
-      app_->OnTimeRangeSelection(std::min(select_start_time_, select_stop_time_),
-                                 std::max(select_start_time_, select_stop_time_));
+      app_->OnTimeRangeSelection(TimeRange(select_start_time_, select_stop_time_));
     }
   }
 

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -2159,7 +2159,7 @@ void OrbitApp::SetVisibleScopeIds(absl::flat_hash_set<ScopeId> visible_scope_ids
 }
 
 bool OrbitApp::IsTimerActive(const TimerInfo& timer) const {
-  const std::optional<TimeRange> time_range = data_manager_->GetSelectionTimeRange();
+  const std::optional<TimeRange>& time_range = data_manager_->GetSelectionTimeRange();
   if (time_range.has_value() && !time_range.value().IsTimerInRange(timer)) {
     return false;
   }

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -49,7 +49,6 @@
 #include "CaptureFile/CaptureFileHelpers.h"
 #include "ClientData/CallstackData.h"
 #include "ClientData/CallstackInfo.h"
-#include "ClientData/LinuxAddressInfo.h"
 #include "ClientData/ModuleData.h"
 #include "ClientData/ModuleManager.h"
 #include "ClientData/PostProcessedSamplingData.h"
@@ -120,7 +119,6 @@
 using orbit_base::CanceledOr;
 using orbit_base::Future;
 using orbit_base::NotFoundOr;
-using orbit_base::StopToken;
 
 using orbit_capture_client::CaptureClient;
 using orbit_capture_client::CaptureEventProcessor;
@@ -134,7 +132,6 @@ using orbit_client_data::CallstackEvent;
 using orbit_client_data::CallstackInfo;
 using orbit_client_data::CaptureData;
 using orbit_client_data::FunctionInfo;
-using orbit_client_data::LinuxAddressInfo;
 using orbit_client_data::ModuleData;
 using orbit_client_data::PostProcessedSamplingData;
 using orbit_client_data::ProcessData;
@@ -143,6 +140,7 @@ using orbit_client_data::ScopeId;
 using orbit_client_data::ScopeStats;
 using orbit_client_data::ThreadID;
 using orbit_client_data::ThreadStateSliceInfo;
+using orbit_client_data::TimeRange;
 using orbit_client_data::TimerBlock;
 using orbit_client_data::TimerChain;
 using orbit_client_data::TracepointInfoSet;
@@ -168,10 +166,7 @@ using orbit_gl::MainWindowInterface;
 
 using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::CaptureOptions;
-using orbit_grpc_protos::CaptureStarted;
-using orbit_grpc_protos::ClientCaptureEvent;
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType;
-using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::TracepointInfo;
 
@@ -2164,13 +2159,15 @@ void OrbitApp::SetVisibleScopeIds(absl::flat_hash_set<ScopeId> visible_scope_ids
 }
 
 bool OrbitApp::IsTimerActive(const TimerInfo& timer) const {
+  const std::optional<TimeRange> time_range = data_manager_->GetSelectionTimeRange();
+  if (time_range.has_value() && !time_range.value().IsTimerInRange(timer)) {
+    return false;
+  }
   const std::optional<ScopeId> scope_id = GetCaptureData().ProvideScopeId(timer);
   if (!scope_id.has_value()) {
     return false;
   }
-  return data_manager_->IsScopeVisible(scope_id.value()) &&
-         timer.start() >= data_manager_->GetTimeRangeSelectionStart() &&
-         timer.end() <= data_manager_->GetTimeRangeSelectionEnd();
+  return data_manager_->IsScopeVisible(scope_id.value());
 }
 
 std::optional<ScopeId> OrbitApp::GetHighlightedScopeId() const {
@@ -2811,20 +2808,21 @@ const ProcessData& OrbitApp::GetConnectedOrLoadedProcess() const {
   return *process_ptr;
 }
 
-void OrbitApp::OnTimeRangeSelection(uint64_t min, uint64_t max) {
+void OrbitApp::OnTimeRangeSelection(TimeRange time_range) {
   ClearAllSelections();
 
   auto selected_callstack_events =
-      GetCaptureData().GetCallstackData().GetCallstackEventsInTimeRange(min, max);
+      GetCaptureData().GetCallstackData().GetCallstackEventsInTimeRange(time_range.start,
+                                                                        time_range.end);
   SetCaptureDataSelectionFields(selected_callstack_events, /*origin_is_multiple_threads=*/true);
 
   main_window_->SetLiveTabScopeStatsCollection(
-      GetCaptureData().CreateScopeStatsCollection(min, max));
+      GetCaptureData().CreateScopeStatsCollection(time_range.start, time_range.end));
   SetTopDownView(GetCaptureData().selection_post_processed_sampling_data());
   SetBottomUpView(GetCaptureData().selection_post_processed_sampling_data());
   SetSamplingReport(&GetCaptureData().selection_callstack_data(),
                     &GetCaptureData().selection_post_processed_sampling_data());
-  data_manager_->SetTimeRangeSelection(min, max);
+  data_manager_->SetSelectionTimeRange(time_range);
 
   FireRefreshCallbacks();
 }
@@ -2837,7 +2835,7 @@ void OrbitApp::ClearTimeRangeSelection() {
   SetBottomUpView(GetCaptureData().post_processed_sampling_data());
   SetSamplingReport(&GetCaptureData().GetCallstackData(),
                     &GetCaptureData().post_processed_sampling_data());
-  data_manager_->ClearTimeRangeSelection();
+  data_manager_->ClearSelectionTimeRange();
 
   FireRefreshCallbacks();
 }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -181,8 +181,7 @@ std::string ThreadTrack::GetBoxTooltip(const PrimitiveAssembler& primitive_assem
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
   if (!app_->HasCaptureData()) return TimerTrack::IsTimerActive(timer_info);
-  const std::optional<ScopeId> scope_id = app_->ProvideScopeId(timer_info);
-  return scope_id.has_value() ? app_->IsScopeVisible(scope_id.value()) : false;
+  return app_->IsTimerActive(timer_info);
 }
 
 bool ThreadTrack::IsTrackSelected() const {

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -484,7 +484,7 @@ class OrbitApp final : public DataViewFactory,
   // list of auto-loadable presets.
   void AddDefaultFrameTrackOrLogError();
 
-  void OnTimeRangeSelection(uint64_t min, uint64_t max);
+  void OnTimeRangeSelection(orbit_client_data::TimeRange time_range);
   void ClearTimeRangeSelection();
 
  private:

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -374,7 +374,7 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] bool IsFunctionSelected(uint64_t absolute_address) const;
 
   void SetVisibleScopeIds(absl::flat_hash_set<ScopeId> visible_scope_ids) override;
-  [[nodiscard]] bool IsScopeVisible(ScopeId scope_id) const;
+  [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const;
 
   [[nodiscard]] std::optional<ScopeId> GetHighlightedScopeId() const override;
   void SetHighlightedScopeId(std::optional<ScopeId> highlighted_scope_id) override;


### PR DESCRIPTION
To make it clear which timers are in/out of the time range selection, only color the ones that are within it. This works well when combined with filtering as well.

This change is hidden behind --time_range_selection.

Screenshot: https://screenshot.googleplex.com/9Bdb5NUVSarYx7Z

Bug: http://b/240112049