### PR TITLE
Auto unwrap in Executor

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Executor.h
+++ b/src/OrbitBase/include/OrbitBase/Executor.h
@@ -34,7 +34,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
   // Note: The function object is only executed if `*this` is still alive when the event loop picks
   // up the scheduled task.
   template <typename F>
-  auto Schedule(F&& functor) -> orbit_base::Future<std::decay_t<decltype(functor())>> {
+  auto Schedule(F&& functor) {
     using ReturnType = std::decay_t<decltype(functor())>;
 
     orbit_base::Promise<ReturnType> promise;
@@ -47,7 +47,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
     };
     ScheduleImpl(CreateAction(std::move(function_wrapper)));
 
-    return future;
+    return UnwrapFuture(future);
   }
 
   // ScheduleAfter schedules the continuation `functor` to be executed on `*this` after `future` has
@@ -98,7 +98,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
       helper.Call(continuation);
     }
 
-    return resulting_future;
+    return UnwrapFuture(resulting_future);
   }
 
   // ScheduleAfterIfSuccess schedules the continuation `functor` to be executed on `*this` after
@@ -150,7 +150,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
     };
 
     orbit_base::RegisterContinuationOrCallDirectly(future, std::move(continuation));
-    return resulting_future;
+    return UnwrapFuture(resulting_future);
   }
 
   [[nodiscard]] size_t GetNumberOfWaitingContinuations() const {

--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -260,6 +260,16 @@ class [[nodiscard]] Future<ErrorMessageOr<T>>
     return executor->ScheduleAfterIfSuccess(*this, std::forward<Invocable>(invocable));
   }
 };
+
+template <typename T>
+struct IsFuture : std::false_type {};
+
+template <typename T>
+struct IsFuture<Future<T>> : std::true_type {};
+
+template <typename T>
+constexpr bool kIsFutureV = IsFuture<T>::value;
+
 }  // namespace orbit_base
 
 #endif  // ORBIT_BASE_FUTURE_H_

--- a/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
@@ -36,7 +36,11 @@ class ImmediateExecutor {
     if constexpr (std::is_same_v<ReturnType, void>) {
       invocable();
       return Future<void>{};
+    } else if constexpr (orbit_base::kIsFutureV<ReturnType>) {
+      // If the `invocable` returns a future we can just return that.
+      return invocable();
     } else {
+      // Otherwise we wrap the result into a future.
       return Future<ReturnType>{invocable()};
     }
   }
@@ -56,7 +60,7 @@ class ImmediateExecutor {
     };
 
     orbit_base::RegisterContinuationOrCallDirectly(future, std::move(continuation));
-    return resulting_future;
+    return UnwrapFuture(resulting_future);
   }
 
   template <typename T, typename F>
@@ -75,7 +79,7 @@ class ImmediateExecutor {
     };
 
     orbit_base::RegisterContinuationOrCallDirectly(future, std::move(continuation));
-    return resulting_future;
+    return UnwrapFuture(resulting_future);
   }
 };
 }  // namespace orbit_base

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -1557,7 +1557,7 @@ OrbitApp::RetrieveModuleAndLoadSymbolsAndHandleError(const ModuleData* module) {
   Future<ErrorMessageOr<CanceledOr<void>>> load_future =
       symbol_loader_->RetrieveModuleAndLoadSymbols(module);
 
-  Future<Future<SymbolLoadingAndErrorHandlingResult>> chained_load_future = load_future.Then(
+  return load_future.Then(
       main_thread_executor_,
       [module, this](ErrorMessageOr<CanceledOr<void>> load_result)
           -> Future<SymbolLoadingAndErrorHandlingResult> {
@@ -1581,8 +1581,6 @@ OrbitApp::RetrieveModuleAndLoadSymbolsAndHandleError(const ModuleData* module) {
         }
         ORBIT_UNREACHABLE();
       });
-
-  return orbit_base::UnwrapFuture(chained_load_future);
 }
 
 Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModuleWithDebugInfo(
@@ -1864,7 +1862,7 @@ Future<ErrorMessageOr<void>> OrbitApp::UpdateProcessAndModuleList() {
       });
 
   // `all_modules_reloaded` is a future in a future. So we have to unwrap here.
-  return orbit_base::UnwrapFuture(all_reloaded_modules)
+  return all_reloaded_modules
       .ThenIfSuccess(main_thread_executor_,
                      [this](absl::Span<const ErrorMessageOr<void>> reload_results) {
                        // We ignore whether reloading a particular module failed to preserve the


### PR DESCRIPTION
When first introducing Futures I opted for making unwrapping explicit and see first how the feature is used. Now, after more than a year, I don't see any downside anymore to automatic unwrapping.

How it works
------------

An `Executor` has a `Schedule` function that returns a `Future<T>` with `T` being determined by the return type of the action that gets scheduled. If `T` is of type `Future<U>` then `Schedule` used to return a `Future<Future<U>>`. Now with auto unwrapping, it returns a `Future<U>`.

That means there is no longer a way to observe when the outer future completes (i.e. when the scheduled task finished executing on the executor). But so far there is and never has been a use-case for that in the code base.