### PR TITLE
Allow thread selection alongside time range

### DIFF
--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -265,6 +265,11 @@ class CaptureData {
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
       uint64_t max_tick = std::numeric_limits<uint64_t>::max(), bool exclusive = false) const;
 
+  [[nodiscard]] std::vector<const TimerInfo*> GetAllScopeTimersByTids(
+      const std::vector<uint32_t>& thread_ids, absl::flat_hash_set<ScopeType> types,
+      uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
+      uint64_t max_tick = std::numeric_limits<uint64_t>::max(), bool exclusive = false) const;
+
   [[nodiscard]] std::vector<const TimerInfo*> GetTimersForScope(
       ScopeId scope_id, uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
       uint64_t max_tick = std::numeric_limits<uint64_t>::max()) const;
@@ -277,7 +282,7 @@ class CaptureData {
       int64_t thread_id, uint64_t timestamp) const;
 
   [[nodiscard]] std::unique_ptr<const ScopeStatsCollection> CreateScopeStatsCollection(
-      uint64_t min_tick, uint64_t max_tick) const;
+      uint32_t thread_id, uint64_t min_tick, uint64_t max_tick) const;
   [[nodiscard]] std::shared_ptr<const ScopeStatsCollection> GetAllScopeStatsCollection() const;
 
  private:

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -290,13 +290,11 @@ void CaptureWindow::RightUp() {
     }
   }
 
-  if (absl::GetFlag(FLAGS_time_range_selection)) {
-    if (select_start_pos_world_[0] == select_stop_pos_world_[0]) {
-      app_->ClearTimeRangeSelection();
-    } else {
-      app_->OnTimeRangeSelection(TimeRange(std::min(select_start_time_, select_stop_time_),
-                                           std::max(select_start_time_, select_stop_time_)));
-    }
+  if (select_start_pos_world_[0] == select_stop_pos_world_[0]) {
+    app_->ClearTimeRangeSelection();
+  } else {
+    app_->OnTimeRangeSelection(TimeRange(std::min(select_start_time_, select_stop_time_),
+                                         std::max(select_start_time_, select_stop_time_)));
   }
 
   if (time_graph_ != nullptr) {

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -408,7 +408,7 @@ class OrbitApp final : public DataViewFactory,
       absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events,
       bool origin_is_multiple_threads);
   void ClearInspection();
-  void ClearAllSelections();
+  void ClearSelectionTabs();
 
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint) override;
   void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint) override;
@@ -486,6 +486,8 @@ class OrbitApp final : public DataViewFactory,
 
   void OnTimeRangeSelection(orbit_client_data::TimeRange time_range);
   void ClearTimeRangeSelection();
+  void OnThreadOrTimeRangeSelectionChange();
+  void ClearThreadAndTimeRangeSelection();
 
  private:
   void UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(


### PR DESCRIPTION
This allows users to select a thread either on it's own or in conjunction with a time range selection. The UI needs some improvements to make this more obvious, but the functionality is all there in this PR. It is still hidden behind the flag --time_range_selection so will not affect any current workflows.

Bug: http://b/240111360