### PR TITLE
Select timer after thread id

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -240,8 +240,8 @@ void CaptureWindow::SelectTimer(const TimerInfo* timer_info) {
   ORBIT_CHECK(time_graph_ != nullptr);
   if (timer_info == nullptr) return;
 
-  app_->SelectTimer(timer_info);
   app_->set_selected_thread_id(timer_info->thread_id());
+  app_->SelectTimer(timer_info);
 
   if (double_clicking_) {
     // Zoom and center the text_box into the screen.


### PR DESCRIPTION
With --time_range_selection, selecting a thread_id causes the data tabs to update and resets selections. If someone selected a timer & thread at the same time, it will reset the timer selection.  This should have no effect outside of the --time_range_selection flag.

Bug: http://b/240111360