### PR TITLE
Revise CanceledOr and NotFoundOr

### DIFF
--- a/src/OrbitBase/CanceledOrTest.cpp
+++ b/src/OrbitBase/CanceledOrTest.cpp
@@ -32,8 +32,6 @@ TEST(CanceledOrInt, NotCanceled) {
   EXPECT_FALSE(int_or_canceled.IsCanceled());
   EXPECT_EQ(int_or_canceled.GetValue(), 42);
   EXPECT_EQ(static_cast<const CanceledOr<int>&>(int_or_canceled).GetValue(), 42);
-  // NOLINTNEXTLINE(performance-move-const-arg)
-  EXPECT_EQ(std::move(int_or_canceled).GetValue(), 42);
 }
 
 TEST(CanceledOrInt, Canceled) {
@@ -49,7 +47,8 @@ TEST(CanceledOrUniqueInt, NotCanceled) {
   EXPECT_EQ(*unique_int_or_canceled.GetValue(), 42);
   EXPECT_EQ(
       *static_cast<const CanceledOr<std::unique_ptr<int>>&>(unique_int_or_canceled).GetValue(), 42);
-  EXPECT_EQ(*std::move(unique_int_or_canceled).GetValue(), 42);
+  std::unique_ptr<int> value = std::move(unique_int_or_canceled).GetValue();
+  EXPECT_THAT(value, testing::Pointee(42));
 }
 
 TEST(CanceledOrUniqueInt, Canceled) {

--- a/src/OrbitBase/CanceledOrTest.cpp
+++ b/src/OrbitBase/CanceledOrTest.cpp
@@ -47,7 +47,8 @@ TEST(CanceledOrUniqueInt, NotCanceled) {
   EXPECT_TRUE(unique_int_or_canceled.HasValue());
   EXPECT_FALSE(unique_int_or_canceled.IsCanceled());
   EXPECT_EQ(*unique_int_or_canceled.GetValue(), 42);
-  EXPECT_EQ(*static_cast<const CanceledOr<std::unique_ptr<int>>&>(unique_int_or_canceled).GetValue(), 42);
+  EXPECT_EQ(
+      *static_cast<const CanceledOr<std::unique_ptr<int>>&>(unique_int_or_canceled).GetValue(), 42);
   EXPECT_EQ(*std::move(unique_int_or_canceled).GetValue(), 42);
 }
 

--- a/src/OrbitBase/CanceledOrTest.cpp
+++ b/src/OrbitBase/CanceledOrTest.cpp
@@ -14,29 +14,45 @@
 
 namespace orbit_base {
 
-TEST(CanceledOr, Construct) {
+TEST(CanceledOrVoid, NotCanceled) {
   CanceledOr<void> void_or_canceled{};
   EXPECT_TRUE(void_or_canceled.HasValue());
   EXPECT_FALSE(void_or_canceled.IsCanceled());
+}
 
-  void_or_canceled = Canceled{};
+TEST(CanceledOrVoid, Canceled) {
+  CanceledOr<void> void_or_canceled{Canceled{}};
   EXPECT_FALSE(void_or_canceled.HasValue());
   EXPECT_TRUE(void_or_canceled.IsCanceled());
+}
 
+TEST(CanceledOrInt, NotCanceled) {
   CanceledOr<int> int_or_canceled{42};
   EXPECT_TRUE(int_or_canceled.HasValue());
   EXPECT_FALSE(int_or_canceled.IsCanceled());
   EXPECT_EQ(int_or_canceled.GetValue(), 42);
+  EXPECT_EQ(static_cast<const CanceledOr<int>&>(int_or_canceled).GetValue(), 42);
+  // NOLINTNEXTLINE(performance-move-const-arg)
+  EXPECT_EQ(std::move(int_or_canceled).GetValue(), 42);
+}
 
-  int_or_canceled = Canceled{};
+TEST(CanceledOrInt, Canceled) {
+  CanceledOr<int> int_or_canceled{Canceled{}};
   EXPECT_FALSE(int_or_canceled.HasValue());
   EXPECT_TRUE(int_or_canceled.IsCanceled());
+}
 
+TEST(CanceledOrUniqueInt, NotCanceled) {
   CanceledOr<std::unique_ptr<int>> unique_int_or_canceled{std::make_unique<int>(42)};
   EXPECT_TRUE(unique_int_or_canceled.HasValue());
   EXPECT_FALSE(unique_int_or_canceled.IsCanceled());
-  EXPECT_THAT(unique_int_or_canceled.GetValue(), testing::Pointee(42));
+  EXPECT_EQ(*unique_int_or_canceled.GetValue(), 42);
+  EXPECT_EQ(*static_cast<const CanceledOr<std::unique_ptr<int>>&>(unique_int_or_canceled).GetValue(), 42);
+  EXPECT_EQ(*std::move(unique_int_or_canceled).GetValue(), 42);
+}
 
+TEST(CanceledOrUniqueInt, Canceled) {
+  CanceledOr<std::unique_ptr<int>> unique_int_or_canceled{Canceled{}};
   unique_int_or_canceled = Canceled{};
   EXPECT_FALSE(unique_int_or_canceled.HasValue());
   EXPECT_TRUE(unique_int_or_canceled.IsCanceled());

--- a/src/OrbitBase/CanceledOrTest.cpp
+++ b/src/OrbitBase/CanceledOrTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -12,6 +13,34 @@
 #include "OrbitBase/CanceledOr.h"
 
 namespace orbit_base {
+
+TEST(CanceledOr, Construct) {
+  CanceledOr<void> void_or_canceled{};
+  EXPECT_TRUE(void_or_canceled.HasValue());
+  EXPECT_FALSE(void_or_canceled.IsCanceled());
+
+  void_or_canceled = Canceled{};
+  EXPECT_FALSE(void_or_canceled.HasValue());
+  EXPECT_TRUE(void_or_canceled.IsCanceled());
+
+  CanceledOr<int> int_or_canceled{42};
+  EXPECT_TRUE(int_or_canceled.HasValue());
+  EXPECT_FALSE(int_or_canceled.IsCanceled());
+  EXPECT_EQ(int_or_canceled.GetValue(), 42);
+
+  int_or_canceled = Canceled{};
+  EXPECT_FALSE(int_or_canceled.HasValue());
+  EXPECT_TRUE(int_or_canceled.IsCanceled());
+
+  CanceledOr<std::unique_ptr<int>> unique_int_or_canceled{std::make_unique<int>(42)};
+  EXPECT_TRUE(unique_int_or_canceled.HasValue());
+  EXPECT_FALSE(unique_int_or_canceled.IsCanceled());
+  EXPECT_THAT(unique_int_or_canceled.GetValue(), testing::Pointee(42));
+
+  unique_int_or_canceled = Canceled{};
+  EXPECT_FALSE(unique_int_or_canceled.HasValue());
+  EXPECT_TRUE(unique_int_or_canceled.IsCanceled());
+}
 
 TEST(CanceledOr, IsCanceled) {
   // Default constructed is NOT canceled

--- a/src/OrbitBase/NotFoundOrTest.cpp
+++ b/src/OrbitBase/NotFoundOrTest.cpp
@@ -36,8 +36,6 @@ TEST(NotFoundOrInt, Found) {
   EXPECT_FALSE(int_or_canceled.IsNotFound());
   EXPECT_EQ(int_or_canceled.GetValue(), 42);
   EXPECT_EQ(static_cast<const NotFoundOr<int>&>(int_or_canceled).GetValue(), 42);
-  // NOLINTNEXTLINE(performance-move-const-arg)
-  EXPECT_EQ(std::move(int_or_canceled).GetValue(), 42);
 }
 
 TEST(NotFoundOrInt, NotFound) {
@@ -54,7 +52,8 @@ TEST(NotFoundOrUniqueInt, Found) {
   EXPECT_EQ(*unique_int_or_canceled.GetValue(), 42);
   EXPECT_EQ(
       *static_cast<const NotFoundOr<std::unique_ptr<int>>&>(unique_int_or_canceled).GetValue(), 42);
-  EXPECT_EQ(*std::move(unique_int_or_canceled).GetValue(), 42);
+  std::unique_ptr<int> value = std::move(unique_int_or_canceled).GetValue();
+  EXPECT_THAT(value, testing::Pointee(42));
 }
 
 TEST(NotFoundOrUniqueInt, NotFound) {

--- a/src/OrbitBase/NotFoundOrTest.cpp
+++ b/src/OrbitBase/NotFoundOrTest.cpp
@@ -15,32 +15,55 @@
 
 namespace orbit_base {
 
-TEST(NotFoundOr, Construct) {
-  NotFoundOr<void> void_or_not_found{};
-  EXPECT_TRUE(void_or_not_found.HasValue());
-  EXPECT_FALSE(void_or_not_found.IsNotFound());
+static constexpr std::string_view kArbitraryErrorMessage{"Something went wrong"};
 
-  void_or_not_found = NotFound{"Message"};
-  EXPECT_FALSE(void_or_not_found.HasValue());
-  EXPECT_TRUE(void_or_not_found.IsNotFound());
+TEST(NotFoundOrVoid, Found) {
+  NotFoundOr<void> void_or_canceled{};
+  EXPECT_TRUE(void_or_canceled.HasValue());
+  EXPECT_FALSE(void_or_canceled.IsNotFound());
+}
 
-  NotFoundOr<int> int_or_not_found{42};
-  EXPECT_TRUE(int_or_not_found.HasValue());
-  EXPECT_FALSE(int_or_not_found.IsNotFound());
-  EXPECT_EQ(int_or_not_found.GetValue(), 42);
+TEST(NotFoundOrVoid, NotFound) {
+  NotFoundOr<void> void_or_canceled{NotFound{std::string{kArbitraryErrorMessage}}};
+  EXPECT_FALSE(void_or_canceled.HasValue());
+  EXPECT_TRUE(void_or_canceled.IsNotFound());
+  EXPECT_THAT(void_or_canceled.GetNotFound().message, kArbitraryErrorMessage);
+}
 
-  int_or_not_found = NotFound{"Message"};
-  EXPECT_FALSE(int_or_not_found.HasValue());
-  EXPECT_TRUE(int_or_not_found.IsNotFound());
+TEST(NotFoundOrInt, Found) {
+  NotFoundOr<int> int_or_canceled{42};
+  EXPECT_TRUE(int_or_canceled.HasValue());
+  EXPECT_FALSE(int_or_canceled.IsNotFound());
+  EXPECT_EQ(int_or_canceled.GetValue(), 42);
+  EXPECT_EQ(static_cast<const NotFoundOr<int>&>(int_or_canceled).GetValue(), 42);
+  // NOLINTNEXTLINE(performance-move-const-arg)
+  EXPECT_EQ(std::move(int_or_canceled).GetValue(), 42);
+}
 
-  NotFoundOr<std::unique_ptr<int>> unique_int_or_not_found{std::make_unique<int>(42)};
-  EXPECT_TRUE(unique_int_or_not_found.HasValue());
-  EXPECT_FALSE(unique_int_or_not_found.IsNotFound());
-  EXPECT_THAT(unique_int_or_not_found.GetValue(), testing::Pointee(42));
+TEST(NotFoundOrInt, NotFound) {
+  NotFoundOr<int> int_or_canceled{NotFound{std::string{kArbitraryErrorMessage}}};
+  EXPECT_FALSE(int_or_canceled.HasValue());
+  EXPECT_TRUE(int_or_canceled.IsNotFound());
+  EXPECT_THAT(int_or_canceled.GetNotFound().message, kArbitraryErrorMessage);
+}
 
-  unique_int_or_not_found = NotFound{"Message"};
-  EXPECT_FALSE(unique_int_or_not_found.HasValue());
-  EXPECT_TRUE(unique_int_or_not_found.IsNotFound());
+TEST(NotFoundOrUniqueInt, Found) {
+  NotFoundOr<std::unique_ptr<int>> unique_int_or_canceled{std::make_unique<int>(42)};
+  EXPECT_TRUE(unique_int_or_canceled.HasValue());
+  EXPECT_FALSE(unique_int_or_canceled.IsNotFound());
+  EXPECT_EQ(*unique_int_or_canceled.GetValue(), 42);
+  EXPECT_EQ(
+      *static_cast<const NotFoundOr<std::unique_ptr<int>>&>(unique_int_or_canceled).GetValue(), 42);
+  EXPECT_EQ(*std::move(unique_int_or_canceled).GetValue(), 42);
+}
+
+TEST(NotFoundOrUniqueInt, NotFound) {
+  NotFoundOr<std::unique_ptr<int>> unique_int_or_canceled{
+      NotFound{std::string{kArbitraryErrorMessage}}};
+  unique_int_or_canceled = NotFound{std::string{kArbitraryErrorMessage}};
+  EXPECT_FALSE(unique_int_or_canceled.HasValue());
+  EXPECT_TRUE(unique_int_or_canceled.IsNotFound());
+  EXPECT_THAT(unique_int_or_canceled.GetNotFound().message, kArbitraryErrorMessage);
 }
 
 TEST(NotFoundOr, IsNotFound) {

--- a/src/OrbitBase/NotFoundOrTest.cpp
+++ b/src/OrbitBase/NotFoundOrTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -13,6 +14,34 @@
 #include "OrbitBase/NotFoundOr.h"
 
 namespace orbit_base {
+
+TEST(NotFoundOr, Construct) {
+  NotFoundOr<void> void_or_not_found{};
+  EXPECT_TRUE(void_or_not_found.HasValue());
+  EXPECT_FALSE(void_or_not_found.IsNotFound());
+
+  void_or_not_found = NotFound{"Message"};
+  EXPECT_FALSE(void_or_not_found.HasValue());
+  EXPECT_TRUE(void_or_not_found.IsNotFound());
+
+  NotFoundOr<int> int_or_not_found{42};
+  EXPECT_TRUE(int_or_not_found.HasValue());
+  EXPECT_FALSE(int_or_not_found.IsNotFound());
+  EXPECT_EQ(int_or_not_found.GetValue(), 42);
+
+  int_or_not_found = NotFound{"Message"};
+  EXPECT_FALSE(int_or_not_found.HasValue());
+  EXPECT_TRUE(int_or_not_found.IsNotFound());
+
+  NotFoundOr<std::unique_ptr<int>> unique_int_or_not_found{std::make_unique<int>(42)};
+  EXPECT_TRUE(unique_int_or_not_found.HasValue());
+  EXPECT_FALSE(unique_int_or_not_found.IsNotFound());
+  EXPECT_THAT(unique_int_or_not_found.GetValue(), testing::Pointee(42));
+
+  unique_int_or_not_found = NotFound{"Message"};
+  EXPECT_FALSE(unique_int_or_not_found.HasValue());
+  EXPECT_TRUE(unique_int_or_not_found.IsNotFound());
+}
 
 TEST(NotFoundOr, IsNotFound) {
   // Default constructor is found

--- a/src/OrbitBase/include/OrbitBase/CanceledOr.h
+++ b/src/OrbitBase/include/OrbitBase/CanceledOr.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_BASE_CANCELED_OR_H_
 #define ORBIT_BASE_CANCELED_OR_H_
 
+#include <utility>
 #include <variant>
 
 #include "OrbitBase/Logging.h"
@@ -17,30 +18,45 @@ struct Canceled {};
 
 // CanceledOr can be used as the return type of an cancelable operation. Based on std::variant.
 // Check whether CanceledOr object is canceled, use orbit_base::IsCanceled. Get the value of a non
-// canceled CanceledOr with std::get<T>().
+// canceled CanceledOr with the `GetValue` member function or the `GetNotCanceled` free function.
+//
+// `CanceledOr<T>` is implemented by privately deriving from `std::variant`. This allows us to take
+// advantage of std::variant's carefully crafted constructors while still keeping std::variant an
+// implementation detail. Implementing those constructors by hand would add a lot of complexity.
 template <typename T>
-using CanceledOr = std::variant<VoidToMonostate_t<T>, Canceled>;
+class CanceledOr : private std::variant<VoidToMonostate_t<T>, Canceled> {
+ public:
+  using Value = VoidToMonostate_t<T>;
 
-// Free function to quickly check whether a CanceledOr type is canceled. Abstracts
-// std::holds_alternative
+  [[nodiscard]] bool HasValue() const { return this->index() == 0; }
+  [[nodiscard]] bool IsCanceled() const { return !HasValue(); }
+
+  [[nodiscard]] const Value& GetValue() const& { return std::get<0>(*this); }
+  [[nodiscard]] const Value& GetValue() const&& { return std::get<0>(*this); }
+  [[nodiscard]] Value GetValue() && { return std::get<0>(std::move(*this)); }
+
+  using std::variant<Value, Canceled>::variant;
+  using std::variant<Value, Canceled>::operator=;
+};
+
+// Free function to quickly check whether a CanceledOr type is canceled.
 template <typename T>
-[[nodiscard]] bool IsCanceled(const std::variant<T, Canceled>& canceled_or) {
-  return std::holds_alternative<Canceled>(canceled_or);
+[[nodiscard]] bool IsCanceled(const CanceledOr<T>& canceled_or) {
+  return canceled_or.IsCanceled();
 }
 
-// Free function to get the "Not canceled" content of a CanceledOr object. Abstracts std::get
+// Free function to get the "Not canceled" content of a CanceledOr object.
 template <typename T>
-[[nodiscard]] const T& GetNotCanceled(const std::variant<T, Canceled>& canceled_or) {
+[[nodiscard]] const T& GetNotCanceled(const CanceledOr<T>& canceled_or) {
   ORBIT_CHECK(!IsCanceled(canceled_or));
-  return std::get<T>(canceled_or);
+  return canceled_or.GetValue();
 }
 
 // Free function with move semantics to get the "Not canceled" content of a CanceledOr object.
-// Abstracts std::get
 template <typename T>
-[[nodiscard]] T&& GetNotCanceled(std::variant<T, Canceled>&& canceled_or) {
+[[nodiscard]] T GetNotCanceled(CanceledOr<T>&& canceled_or) {
   ORBIT_CHECK(!IsCanceled(canceled_or));
-  return std::get<T>(std::move(canceled_or));
+  return std::move(canceled_or).GetValue();
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/CanceledOr.h
+++ b/src/OrbitBase/include/OrbitBase/CanceledOr.h
@@ -32,8 +32,8 @@ class CanceledOr : private std::variant<VoidToMonostate_t<T>, Canceled> {
   [[nodiscard]] bool IsCanceled() const { return !HasValue(); }
 
   [[nodiscard]] const Value& GetValue() const& { return std::get<0>(*this); }
-  [[nodiscard]] const Value& GetValue() const&& { return std::get<0>(*this); }
-  [[nodiscard]] Value GetValue() && { return std::get<0>(std::move(*this)); }
+  [[nodiscard]] const Value&& GetValue() const&& { return std::get<0>(*this); }
+  [[nodiscard]] Value&& GetValue() && { return std::get<0>(std::move(*this)); }
 
   using std::variant<Value, Canceled>::variant;
   using std::variant<Value, Canceled>::operator=;
@@ -54,7 +54,7 @@ template <typename T>
 
 // Free function with move semantics to get the "Not canceled" content of a CanceledOr object.
 template <typename T>
-[[nodiscard]] T GetNotCanceled(CanceledOr<T>&& canceled_or) {
+[[nodiscard]] T&& GetNotCanceled(CanceledOr<T>&& canceled_or) {
   ORBIT_CHECK(!IsCanceled(canceled_or));
   return std::move(canceled_or).GetValue();
 }

--- a/src/OrbitBase/include/OrbitBase/NotFoundOr.h
+++ b/src/OrbitBase/include/OrbitBase/NotFoundOr.h
@@ -36,11 +36,11 @@ class NotFoundOr : private std::variant<VoidToMonostate_t<T>, NotFound> {
 
   [[nodiscard]] const Value& GetValue() const& { return std::get<0>(*this); }
   [[nodiscard]] const Value& GetValue() const&& { return std::get<0>(*this); }
-  [[nodiscard]] Value GetValue() && { return std::get<0>(std::move(*this)); }
+  [[nodiscard]] Value&& GetValue() && { return std::get<0>(std::move(*this)); }
 
   [[nodiscard]] const NotFound& GetNotFound() const& { return std::get<1>(*this); }
   [[nodiscard]] const NotFound& GetNotFound() const&& { return std::get<1>(*this); }
-  [[nodiscard]] NotFound GetNotFound() && { return std::get<1>(std::move(*this)); }
+  [[nodiscard]] NotFound&& GetNotFound() && { return std::get<1>(std::move(*this)); }
 
   using std::variant<Value, NotFound>::variant;
   using std::variant<Value, NotFound>::operator=;
@@ -75,7 +75,7 @@ template <typename T>
 
 // Free function with move semantics to get the "found" content of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] T GetFound(NotFoundOr<T>&& not_found_or) {
+[[nodiscard]] T&& GetFound(NotFoundOr<T>&& not_found_or) {
   ORBIT_CHECK(!IsNotFound(not_found_or));
   return std::move(not_found_or).GetValue();
 }

--- a/src/OrbitBase/include/OrbitBase/NotFoundOr.h
+++ b/src/OrbitBase/include/OrbitBase/NotFoundOr.h
@@ -35,11 +35,11 @@ class NotFoundOr : private std::variant<VoidToMonostate_t<T>, NotFound> {
   [[nodiscard]] bool IsNotFound() const { return !HasValue(); }
 
   [[nodiscard]] const Value& GetValue() const& { return std::get<0>(*this); }
-  [[nodiscard]] const Value& GetValue() const&& { return std::get<0>(*this); }
+  [[nodiscard]] const Value&& GetValue() const&& { return std::get<0>(*this); }
   [[nodiscard]] Value&& GetValue() && { return std::get<0>(std::move(*this)); }
 
   [[nodiscard]] const NotFound& GetNotFound() const& { return std::get<1>(*this); }
-  [[nodiscard]] const NotFound& GetNotFound() const&& { return std::get<1>(*this); }
+  [[nodiscard]] const NotFound&& GetNotFound() const&& { return std::get<1>(*this); }
   [[nodiscard]] NotFound&& GetNotFound() && { return std::get<1>(std::move(*this)); }
 
   using std::variant<Value, NotFound>::variant;

--- a/src/OrbitBase/include/OrbitBase/NotFoundOr.h
+++ b/src/OrbitBase/include/OrbitBase/NotFoundOr.h
@@ -20,44 +20,64 @@ struct NotFound {
 };
 
 // NotFoundOr can be used as the return type of a search operation, where the search can be
-// unsuccessful and returns a message. Based on std::variant. Check whether a NotFoundOr object is
+// unsuccessful and returns a message. Check whether a NotFoundOr object is
 // a "not found" result with orbit_base::IsNotFound. Get the message with GetNotFoundMessage.
+//
+// `NotFoundOr<T>` is implemented by privately deriving from `std::variant`. This allows us to take
+// advantage of std::variant's carefully crafted constructors while still keeping std::variant an
+// implementation detail. Implementing those constructors by hand would add a lot of complexity.
 template <typename T>
-using NotFoundOr = std::variant<VoidToMonostate_t<T>, NotFound>;
+class NotFoundOr : private std::variant<VoidToMonostate_t<T>, NotFound> {
+ public:
+  using Value = VoidToMonostate_t<T>;
 
-// Free function to check whether a NotFoundOr type is "not found". Abstracts
-// std::holds_alternative
+  [[nodiscard]] bool HasValue() const { return this->index() == 0; }
+  [[nodiscard]] bool IsNotFound() const { return !HasValue(); }
+
+  [[nodiscard]] const Value& GetValue() const& { return std::get<0>(*this); }
+  [[nodiscard]] const Value& GetValue() const&& { return std::get<0>(*this); }
+  [[nodiscard]] Value GetValue() && { return std::get<0>(std::move(*this)); }
+
+  [[nodiscard]] const NotFound& GetNotFound() const& { return std::get<1>(*this); }
+  [[nodiscard]] const NotFound& GetNotFound() const&& { return std::get<1>(*this); }
+  [[nodiscard]] NotFound GetNotFound() && { return std::get<1>(std::move(*this)); }
+
+  using std::variant<Value, NotFound>::variant;
+  using std::variant<Value, NotFound>::operator=;
+};
+
+// Free function to check whether a NotFoundOr type is "not found".
 template <typename T>
-[[nodiscard]] bool IsNotFound(const std::variant<T, NotFound>& not_found_or) {
-  return std::holds_alternative<NotFound>(not_found_or);
+[[nodiscard]] bool IsNotFound(const NotFoundOr<T>& not_found_or) {
+  return not_found_or.IsNotFound();
 }
 
 // Free function to get the not found message of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] const std::string& GetNotFoundMessage(const std::variant<T, NotFound>& not_found_or) {
+[[nodiscard]] const std::string& GetNotFoundMessage(const NotFoundOr<T>& not_found_or) {
   ORBIT_CHECK(IsNotFound(not_found_or));
-  return std::get<NotFound>(not_found_or).message;
+  return not_found_or.GetNotFound().message;
 }
 
 // Free function with move semantics to get the not found message of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] std::string&& GetNotFoundMessage(std::variant<T, NotFound>&& not_found_or) {
+[[nodiscard]] std::string GetNotFoundMessage(NotFoundOr<T>&& not_found_or) {
   ORBIT_CHECK(IsNotFound(not_found_or));
-  return std::move(std::get<NotFound>(std::move(not_found_or)).message);
+  return std::move(not_found_or).GetNotFound().message;
 }
 
 // Free function to get the "found" content of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] const T& GetFound(const std::variant<T, NotFound>& not_found_or) {
+[[nodiscard]] const T& GetFound(const NotFoundOr<T>& not_found_or) {
   ORBIT_CHECK(!IsNotFound(not_found_or));
-  return std::get<T>(not_found_or);
+  return not_found_or.GetValue();
 }
 
 // Free function with move semantics to get the "found" content of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] T&& GetFound(std::variant<T, NotFound>&& not_found_or) {
+[[nodiscard]] T GetFound(NotFoundOr<T>&& not_found_or) {
   ORBIT_CHECK(!IsNotFound(not_found_or));
-  return std::get<T>(std::move(not_found_or));
+  return std::move(not_found_or).GetValue();
 }
 
 }  // namespace orbit_base

--- a/src/SymbolProvider/SymbolLoadingOutcome.cpp
+++ b/src/SymbolProvider/SymbolLoadingOutcome.cpp
@@ -4,15 +4,11 @@
 
 #include "SymbolProvider/SymbolLoadingOutcome.h"
 
-#include <variant>
-
 #include "OrbitBase/CanceledOr.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/NotFoundOr.h"
 
 namespace orbit_symbol_provider {
-
-using orbit_base::NotFoundOr;
 
 bool IsCanceled(const SymbolLoadingOutcome& outcome) {
   return outcome.has_value() && orbit_base::IsCanceled(outcome.value());
@@ -30,8 +26,7 @@ std::string GetNotFoundMessage(const SymbolLoadingOutcome& outcome) {
 
 bool IsSuccessResult(const SymbolLoadingOutcome& outcome) {
   return outcome.has_value() && !IsCanceled(outcome) && !IsNotFound(outcome) &&
-         std::holds_alternative<SymbolLoadingSuccessResult>(
-             orbit_base::GetNotCanceled(outcome.value()));
+         outcome.value().GetValue().HasValue();
 }
 
 SymbolLoadingSuccessResult GetSuccessResult(const SymbolLoadingOutcome& outcome) {


### PR DESCRIPTION
Both `CanceledOr<T>` and `NotFoundOr<T>` are type aliases for `std::variant<VoidToMonostate_t<T>, Canceled resp. NotFound>`.

Due to the necessary `VoidToMonostate_t<T>` type trait in there, automatic type deduction for function overloads does not work.

A function `template<typename T> void foo(const CanceledOr<T>&);` would not be considered in overload resolution because `T` cannot be deduced.

This greatly limits the usage of `CanceledOr` and `NotFoundOr` in generic code.

To fix that this change makes both type aliases proper types. These types privately inherit from `std::variant<VoidToMonostate_t<T>, Canceled resp. NotFound>`. Hence we can still re-use all the advantages from `std::variant` (like the properly SFINAEd constructors) while keeping the implementation complexity low. (This was the main reason for using `std::variant` in the first place.

At some point we probably wanna have a generic wrapper that can be the basis for both these, but this is out of scope of this fix.