### PR TITLE
Fix Executor lifetime handling

### DIFF
--- a/src/OrbitBase/ThreadPool.cpp
+++ b/src/OrbitBase/ThreadPool.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "OrbitBase/Executor.h"
 #include "OrbitBase/Logging.h"
 
 namespace orbit_base {
@@ -46,6 +47,7 @@ class ThreadPoolImpl : public ThreadPool {
 
  private:
   void ScheduleImpl(std::unique_ptr<Action> action) override;
+  [[nodiscard]] Handle GetExecutorHandle() const override { return executor_handle_.Get(); }
   bool ActionsAvailableOrShutdownInitiated();
   // Blocking call - returns nullptr if the worker thread needs to exit.
   std::unique_ptr<Action> TakeAction();
@@ -67,6 +69,8 @@ class ThreadPoolImpl : public ThreadPool {
   size_t idle_threads_;
   bool shutdown_initiated_;
   std::function<void(const std::unique_ptr<Action>&)> run_action_ = nullptr;
+
+  Executor::ScopedHandle executor_handle_{this};
 };
 
 ThreadPoolImpl::ThreadPoolImpl(size_t thread_pool_min_size, size_t thread_pool_max_size,

--- a/src/OrbitBase/include/OrbitBase/SimpleExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/SimpleExecutor.h
@@ -26,6 +26,7 @@ class SimpleExecutor : public Executor {
   explicit SimpleExecutor() = default;
 
   void ScheduleImpl(std::unique_ptr<Action> action) override;
+  [[nodiscard]] Handle GetExecutorHandle() const override { return executor_handle_.Get(); }
 
  public:
   void ExecuteScheduledTasks();
@@ -35,6 +36,7 @@ class SimpleExecutor : public Executor {
  private:
   absl::Mutex mutex_;
   std::deque<std::unique_ptr<Action>> scheduled_tasks_ ABSL_GUARDED_BY(mutex_);
+  Executor::ScopedHandle executor_handle_{this};
 };
 
 }  // namespace orbit_base

--- a/src/QtUtils/MainThreadExecutorImplTest.cpp
+++ b/src/QtUtils/MainThreadExecutorImplTest.cpp
@@ -153,14 +153,16 @@ TEST(MainThreadExecutorImpl, ChainFuturesWithThen) {
 
 TEST(MainThreadExecutorImpl, TrySchedule) {
   auto executor = MainThreadExecutorImpl::Create();
-  const auto result = TrySchedule(executor, []() { QCoreApplication::exit(42); });
+  const auto result =
+      TrySchedule(executor->GetExecutorHandle(), []() { QCoreApplication::exit(42); });
 
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(QCoreApplication::exec(), 42);
 }
 
-TEST(MainThreadExecutorImpl, TryScheduleWithInvalidWeakPtr) {
-  const auto result = TrySchedule(std::weak_ptr<MainThreadExecutor>{}, []() {});
+TEST(MainThreadExecutorImpl, TryScheduleFailing) {
+  MainThreadExecutorImpl::Handle handle = MainThreadExecutorImpl::Create()->GetExecutorHandle();
+  const auto result = TrySchedule(handle, []() {});
   EXPECT_FALSE(result.has_value());
 }
 

--- a/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
+++ b/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
@@ -23,8 +23,6 @@ class MainThreadExecutorImpl : public QObject, public orbit_base::MainThreadExec
   Q_OBJECT
   explicit MainThreadExecutorImpl(QObject* parent = nullptr) : QObject(parent) {}
 
-  void ScheduleImpl(std::unique_ptr<Action> action) override;
-
  public:
   [[nodiscard]] static std::shared_ptr<MainThreadExecutorImpl> Create() {
     return std::shared_ptr<MainThreadExecutorImpl>{new MainThreadExecutorImpl{}};
@@ -41,8 +39,16 @@ class MainThreadExecutorImpl : public QObject, public orbit_base::MainThreadExec
   WaitResult WaitForAll(absl::Span<orbit_base::Future<void>> futures) override;
 
   void AbortWaitingJobs() override;
+
+  [[nodiscard]] Handle GetExecutorHandle() const override { return executor_handle_.Get(); }
+
  signals:
   void AbortRequested();
+
+ private:
+  void ScheduleImpl(std::unique_ptr<Action> action) override;
+
+  ScopedHandle executor_handle_{this};
 };
 
 }  // namespace orbit_qt_utils


### PR DESCRIPTION
The `Executor` type has 2 facilities which might call `Schedule` any moment in time. These are:

- `ScheduleAfter` (member function)
- `TrySchedule` (free function)

Hence `Executor::Schedule` must at the very least be thread-safe, but it can also happen that `ScheduleAfter` or `TrySchedule` try to call `Executor::Schedule` while the executor's lifetime has already ended or worse while the executor's destructor is currently running on a different thread.

We learned about this problem the hard way by a crash found in release testing and quickly fixed it by requiring any `Executor` to be a shared pointer by inherting from `std::enable_shared_from_this`. `ScheduleAfter` and `TrySchedule` would keep a weak pointer of the executor and only call `Schedule` if the executor was still alive.

But this was a hack and easily fails because it is not enforced that the executor is wrapped in a shared pointer. It is also not great type design because this shared pointer was part of the public API of the Executor but the whole point was to abstract away the lifetime complexities.

So this PR fixes it properly by introducing a handle type that keeps a reference to some shared storage. Executors can hand out its handle to `TrySchedule` and `ScheduleAfter`. A handle contains a raw pointer to the executor and a mutex for synchronization purposes.

When an Executor gets destructed it will first invalidate the handle by setting the pointer in the shared storage to nullptr. The shared storage is kept alive as long as any copy of the handle exists, so it takes over the role of the previously exposed shared_ptr. So there can't be any lifetime issues with this approach while not exposing the shared_ptr to the public API.

This allows us to make all executors have automatic storage duration (local stack variables, simple by-value members in classes). This greatly simplifies its usage.

Note that this is not yet removing all the shared_ptr wrappings in the code base. This will come in a separate PR.

Also note there are already tests for all the different lifetime race conditions, so no new tests need to be added. This is just replacing one mechanism by the other.