### PR TITLE
Add IsRegularFile to OrbitBase

### DIFF
--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -282,4 +282,14 @@ ErrorMessageOr<bool> IsDirectory(const std::filesystem::path& path) {
   return result;
 }
 
+ErrorMessageOr<bool> IsRegularFile(const std::filesystem::path& path) {
+  std::error_code error;
+  const bool result = std::filesystem::is_regular_file(path, error);
+  if (error) {
+    return ErrorMessage{error.message()};
+  }
+
+  return result;
+}
+
 }  // namespace orbit_base

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -466,4 +466,10 @@ TEST(File, IsDirectory) {
   }
 }
 
+TEST(File, IsRegularFile) {
+  EXPECT_THAT(IsRegularFile(orbit_test::GetTestdataDir()), false);
+  EXPECT_THAT(IsRegularFile(orbit_test::GetTestdataDir() / "textfile.bin"), true);
+  EXPECT_THAT(IsRegularFile("/does/not/exist"), HasError());
+}
+
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -132,6 +132,7 @@ ErrorMessageOr<std::vector<std::filesystem::path>> ListFilesInDirectory(
     const std::filesystem::path& directory);
 ErrorMessageOr<absl::Time> GetFileDateModified(const std::filesystem::path& path);
 ErrorMessageOr<bool> IsDirectory(const std::filesystem::path& path);
+ErrorMessageOr<bool> IsRegularFile(const std::filesystem::path& path);
 
 }  // namespace orbit_base
 


### PR DESCRIPTION
This is adding our usual wrapper for `std::filesystem::is_regular_file`. We already have a few of these wrappers in the same style and this one was missing.