### PR TITLE
Add utilties to find the user's SSH config

### DIFF
--- a/src/OrbitSsh/CMakeLists.txt
+++ b/src/OrbitSsh/CMakeLists.txt
@@ -27,7 +27,9 @@ target_sources(
   OrbitSsh
   PRIVATE Channel.cpp
           Context.cpp
+          Credentials.cpp
           Error.cpp
+          HomeEnvironmentVariable.h
           KnownHostsError.cpp
           LibSsh2Utils.cpp
           Session.cpp
@@ -50,13 +52,22 @@ if(WIN32)
   target_compile_definitions(OrbitSsh PUBLIC WIN32_LEAN_AND_MEAN)
   target_compile_definitions(OrbitSsh PUBLIC -D_WIN32_WINNT=0x0700)
   target_compile_definitions(OrbitSsh PUBLIC -DNTDDI_VERSION=0x06030000)
+
+  # This is needed for the designated initializers. We don't enable this
+  # in general to not break the build for old GCC and clang compilers for
+  # no reason.
+  target_compile_features(OrbitSsh PUBLIC cxx_std_20)
 endif()
 
-# tests
 add_executable(OrbitSshTests)
-target_sources(OrbitSshTests PRIVATE SocketTests.cpp ContextTests.cpp)
+target_sources(OrbitSshTests PRIVATE
+  ContextTests.cpp
+  CredentialsTest.cpp
+  SocketTests.cpp)
 
-target_link_libraries(OrbitSshTests PRIVATE OrbitSsh Libssh2::libssh2
-                                            GTest::Main)
+target_link_libraries(OrbitSshTests PRIVATE
+  OrbitSsh
+  TestUtils
+  GTest::Main)
 
 register_test(OrbitSshTests PROPERTIES TIMEOUT 10)

--- a/src/OrbitSsh/Credentials.cpp
+++ b/src/OrbitSsh/Credentials.cpp
@@ -1,9 +1,10 @@
-// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 #include "OrbitSsh/Credentials.h"
 
+#include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
 
 #include <filesystem>
@@ -17,9 +18,10 @@ namespace orbit_ssh {
 ErrorMessageOr<std::filesystem::path> GetUsersSshConfigDirectory() {
   const char* const home_directory_env_var = std::getenv(kHomeEnvironmentVariable);
   if (home_directory_env_var == nullptr) {
-    return ErrorMessage{
-        "Could not determine the user's home directory location. Environment variable 'HOME' "
-        "doesn't exist."};
+    return ErrorMessage{absl::StrFormat(
+        "Could not determine the user's home directory location. Environment variable '%s' "
+        "doesn't exist.",
+        kHomeEnvironmentVariable)};
   }
 
   std::filesystem::path home_directory{home_directory_env_var};
@@ -27,9 +29,9 @@ ErrorMessageOr<std::filesystem::path> GetUsersSshConfigDirectory() {
 
   if (!home_dir_exists) {
     return ErrorMessage{absl::StrFormat(
-        "The user's home directory given by then 'HOME' environment variable does either not exist "
+        "The user's home directory given by the '%s' environment variable does not exist "
         "or is not a directory. Tried the following directory: %s",
-        home_directory.string())};
+        kHomeEnvironmentVariable, home_directory.string())};
   }
 
   std::filesystem::path ssh_config_directory = home_directory / ".ssh";

--- a/src/OrbitSsh/Credentials.cpp
+++ b/src/OrbitSsh/Credentials.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitSsh/Credentials.h"
+
+#include <absl/strings/str_join.h>
+
+#include <filesystem>
+
+#include "HomeEnvironmentVariable.h"
+#include "OrbitBase/File.h"
+#include "OrbitBase/Result.h"
+
+namespace orbit_ssh {
+
+ErrorMessageOr<std::filesystem::path> GetUsersSshConfigDirectory() {
+  const char* const home_directory_env_var = std::getenv(kHomeEnvironmentVariable);
+  if (home_directory_env_var == nullptr) {
+    return ErrorMessage{
+        "Could not determine the user's home directory location. Environment variable 'HOME' "
+        "doesn't exist."};
+  }
+
+  std::filesystem::path home_directory{home_directory_env_var};
+  OUTCOME_TRY(bool home_dir_exists, orbit_base::IsDirectory(home_directory));
+
+  if (!home_dir_exists) {
+    return ErrorMessage{absl::StrFormat(
+        "The user's home directory given by then 'HOME' environment variable does either not exist "
+        "or is not a directory. Tried the following directory: %s",
+        home_directory.string())};
+  }
+
+  std::filesystem::path ssh_config_directory = home_directory / ".ssh";
+  OUTCOME_TRY(bool ssh_config_dir_exists, orbit_base::IsDirectory(ssh_config_directory));
+  if (!ssh_config_dir_exists) {
+    return ErrorMessage{absl::StrFormat(
+        "Could not find the user's SSH config directory. Tried the following directory: %s",
+        ssh_config_directory.string())};
+  }
+
+  return ssh_config_directory;
+}
+
+ErrorMessageOr<Credentials> FindUsersCredentials(const std::filesystem::path& ssh_config_directory,
+                                                 AddrAndPort addr_and_port, std::string username) {
+  constexpr std::array kValidSshKeyFilenames{
+      std::string_view{"id_ed25519"}, std::string_view{"id_ecdsa"}, std::string_view{"id_dsa"},
+      std::string_view{"id_rsa"}};
+
+  std::vector<std::filesystem::path> key_files;
+
+  for (const auto& filename : kValidSshKeyFilenames) {
+    std::filesystem::path path = ssh_config_directory / filename;
+
+    auto result = orbit_base::IsRegularFile(path);
+    if (result.has_error() || !result.value()) continue;
+
+    key_files.emplace_back(path);
+  }
+
+  if (key_files.empty()) {
+    return ErrorMessage{
+        absl::StrFormat("No valid and/or supported SSH key files found! Checked files: %s/{%s}",
+                        ssh_config_directory.string(), absl::StrJoin(kValidSshKeyFilenames, "|"))};
+  }
+
+  std::filesystem::path known_hosts_path = ssh_config_directory / "known_hosts";
+  auto known_hosts_result = orbit_base::IsRegularFile(known_hosts_path);
+  if (known_hosts_result.has_error() || !known_hosts_result.value()) {
+    return ErrorMessage{
+        absl::StrFormat("No known_hosts file found. Tried %s", known_hosts_path.string())};
+  }
+
+  return Credentials{.addr_and_port = std::move(addr_and_port),
+                     .user = std::move(username),
+                     .known_hosts_path = std::move(known_hosts_path),
+                     .key_paths = std::move(key_files)};
+}
+
+}  // namespace orbit_ssh

--- a/src/OrbitSsh/CredentialsTest.cpp
+++ b/src/OrbitSsh/CredentialsTest.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+
+#include <memory>
+#include <utility>
+
+#include "HomeEnvironmentVariable.h"
+#include "OrbitBase/Result.h"
+#include "OrbitSsh/AddrAndPort.h"
+#include "OrbitSsh/Credentials.h"
+#include "Test/Path.h"
+#include "TestUtils/TestUtils.h"
+
+namespace orbit_ssh {
+using orbit_test_utils::HasError;
+using orbit_test_utils::HasValue;
+using testing::Field;
+using testing::UnorderedElementsAre;
+
+TEST(GetUsersSshConfigDirectory, FindsSshDirectory) {
+  std::string original_home_env_var_value = [&]() {
+    const char* env = std::getenv(kHomeEnvironmentVariable);
+    EXPECT_THAT(env, testing::Ne(nullptr));
+    return std::string{env != nullptr ? env : ""};
+  }();
+
+#ifdef _WIN32
+  EXPECT_THAT(_putenv_s(kHomeEnvironmentVariable, orbit_test::GetTestdataDir().string().c_str()),
+              0);
+#else
+  EXPECT_THAT(setenv(kHomeEnvironmentVariable, orbit_test::GetTestdataDir().string().c_str(), 1),
+              0);
+#endif
+
+  EXPECT_THAT(GetUsersSshConfigDirectory(),
+              orbit_test_utils::HasValue(orbit_test::GetTestdataDir() / ".ssh"));
+
+  // Reset HOME environment variable
+#ifdef _WIN32
+  EXPECT_THAT(_putenv_s(kHomeEnvironmentVariable, original_home_env_var_value.c_str()), 0);
+#else
+  EXPECT_THAT(setenv(kHomeEnvironmentVariable, original_home_env_var_value.c_str(), 1), 0);
+#endif
+}
+
+TEST(FindUsersCredentials, AcceptsValidSshConfigDir) {
+  AddrAndPort addr_and_port{"host", 1024};
+  const std::string username{"nodody"};
+
+  const std::filesystem::path ssh_config_dir = orbit_test::GetTestdataDir() / "valid_ssh_config";
+  auto result = FindUsersCredentials(ssh_config_dir, addr_and_port, username);
+
+  EXPECT_THAT(result, HasValue(Field(&Credentials::addr_and_port, addr_and_port)));
+  EXPECT_THAT(result, HasValue(Field(&Credentials::user, username)));
+  EXPECT_THAT(result,
+              HasValue(Field(&Credentials::known_hosts_path, ssh_config_dir / "known_hosts")));
+  EXPECT_THAT(result, HasValue(Field(&Credentials::key_paths,
+                                     UnorderedElementsAre(ssh_config_dir / "id_ecdsa",
+                                                          ssh_config_dir / "id_rsa"))));
+}
+
+TEST(FindUsersCredentials, FailsWhenKnownHostsMissing) {
+  AddrAndPort addr_and_port{"host", 1024};
+  const std::string username{"nodody"};
+
+  const std::filesystem::path ssh_config_dir =
+      orbit_test::GetTestdataDir() / "missing_known_hosts_ssh_config";
+  auto result = FindUsersCredentials(ssh_config_dir, addr_and_port, username);
+
+  EXPECT_THAT(result, HasError("No known_hosts file found"));
+}
+
+TEST(FindUsersCredentials, FailsWhenNoKeyFound) {
+  AddrAndPort addr_and_port{"host", 1024};
+  const std::string username{"nodody"};
+
+  const std::filesystem::path ssh_config_dir =
+      orbit_test::GetTestdataDir() / "missing_key_ssh_config";
+  auto result = FindUsersCredentials(ssh_config_dir, addr_and_port, username);
+
+  EXPECT_THAT(result, HasError("No valid and/or supported SSH key files found"));
+}
+
+}  // namespace orbit_ssh

--- a/src/OrbitSsh/HomeEnvironmentVariable.h
+++ b/src/OrbitSsh/HomeEnvironmentVariable.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <string_view>
+
+namespace orbit_ssh {
+
+// Contains the name of the environment variable that represents the home directory (depending on
+// the platform). This environment variable is guaranteed to exist by the respective platform
+// (unless someone messed with the environment variables).
+#ifdef _WIN32
+constexpr const char* kHomeEnvironmentVariable = "USERPROFILE";
+#else
+constexpr const char* kHomeEnvironmentVariable = "HOME";
+#endif
+}  // namespace orbit_ssh

--- a/src/OrbitSsh/include/OrbitSsh/Credentials.h
+++ b/src/OrbitSsh/include/OrbitSsh/Credentials.h
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <string>
 
+#include "OrbitBase/Result.h"
 #include "OrbitSsh/AddrAndPort.h"
 
 namespace orbit_ssh {
@@ -18,6 +19,18 @@ struct Credentials {
   std::filesystem::path known_hosts_path;
   std::vector<std::filesystem::path> key_paths;
 };
+
+// Returns the path to the `~/.ssh` directory inside the user's home directory. Returns an error if
+// the directory doesn't exist, but if it does no further checks are performed. Use
+// `FindUsersCredentials` below to check whether the `.ssh` directory contains the necessary files.
+ErrorMessageOr<std::filesystem::path> GetUsersSshConfigDirectory();
+
+// Constructs an instance of `Credentials` with the given address, port and username, and all the
+// supported SSH keys found in `ssh_config_directory`. Returns an error if no supported key was
+// found. It also requires a `known_hosts` file to exist since we currently don't support writing to
+// or creating known_hosts files. This might change in the future.
+ErrorMessageOr<Credentials> FindUsersCredentials(const std::filesystem::path& ssh_config_directory,
+                                                 AddrAndPort addr_and_port, std::string username);
 
 }  // namespace orbit_ssh
 

--- a/src/OrbitSsh/testdata/.ssh/placeholder.txt
+++ b/src/OrbitSsh/testdata/.ssh/placeholder.txt
@@ -1,0 +1,1 @@
+# Just a placeholder file. We only need the directory to exist.

--- a/src/OrbitSsh/testdata/missing_key_ssh_config/known_hosts
+++ b/src/OrbitSsh/testdata/missing_key_ssh_config/known_hosts
@@ -1,0 +1,1 @@
+# Contents is not validated. Just existence of the file

--- a/src/OrbitSsh/testdata/missing_known_hosts_ssh_config/id_ecdsa
+++ b/src/OrbitSsh/testdata/missing_known_hosts_ssh_config/id_ecdsa
@@ -1,0 +1,1 @@
+# Contents is not validated. Just existence of the file

--- a/src/OrbitSsh/testdata/missing_known_hosts_ssh_config/id_rsa
+++ b/src/OrbitSsh/testdata/missing_known_hosts_ssh_config/id_rsa
@@ -1,0 +1,1 @@
+# Contents is not validated. Just existence of the file

--- a/src/OrbitSsh/testdata/valid_ssh_config/id_ecdsa
+++ b/src/OrbitSsh/testdata/valid_ssh_config/id_ecdsa
@@ -1,0 +1,1 @@
+# Contents is not validated. Just existence of the file

--- a/src/OrbitSsh/testdata/valid_ssh_config/id_rsa
+++ b/src/OrbitSsh/testdata/valid_ssh_config/id_rsa
@@ -1,0 +1,1 @@
+# Contents is not validated. Just existence of the file

--- a/src/OrbitSsh/testdata/valid_ssh_config/known_hosts
+++ b/src/OrbitSsh/testdata/valid_ssh_config/known_hosts
@@ -1,0 +1,1 @@
+# Contents is not validated. Just existence of the file


### PR DESCRIPTION
There is a new function that produces an instance of `orbit_ssh::Credentials` based on the private keys available in the users .ssh config directory.