### PR TITLE
Improve font placement.

### DIFF
--- a/src/OrbitGl/QtTextRenderer.cpp
+++ b/src/OrbitGl/QtTextRenderer.cpp
@@ -48,13 +48,20 @@ float GetYOffsetFromAlignment(QtTextRenderer::VAlign alignment, float height) {
 }
 
 float GetXOffsetFromAlignment(QtTextRenderer::HAlign alignment, float width) {
+  // kOffset is a hack to compensate for subtle differences in the placement of the rendered text
+  // under Linux and Windows. Setting kOffset == 0 under Windows results in texts starting left of
+  // the interval border for unknown reason.
+  constexpr float kOffset = 0.f;
+#ifdef _WIN32
+  kOffset = 2.f;
+#endif
   switch (alignment) {
     case QtTextRenderer::HAlign::Left:
-      return 0.f;
+      return kOffset + 0.f;
     case QtTextRenderer::HAlign::Centered:
-      return -0.5f * width;
+      return kOffset - 0.5f * width;
     case QtTextRenderer::HAlign::Right:
-      return -width;
+      return kOffset - width;
     default:
       ORBIT_UNREACHABLE();
   }

--- a/src/OrbitGl/QtTextRenderer.cpp
+++ b/src/OrbitGl/QtTextRenderer.cpp
@@ -50,10 +50,11 @@ float GetYOffsetFromAlignment(QtTextRenderer::VAlign alignment, float height) {
 float GetXOffsetFromAlignment(QtTextRenderer::HAlign alignment, float width) {
   // kOffset is a hack to compensate for subtle differences in the placement of the rendered text
   // under Linux and Windows. Setting kOffset == 0 under Windows results in texts starting left of
-  // the interval border for unknown reason.
-  constexpr float kOffset = 0.f;
+  // the interval border for unknown reasons (also see https://github.com/google/orbit/issues/4627).
 #ifdef _WIN32
-  kOffset = 2.f;
+  constexpr float kOffset = 2.f;
+#else
+  constexpr float kOffset = 0.f;
 #endif
   switch (alignment) {
     case QtTextRenderer::HAlign::Left:


### PR DESCRIPTION
For unknown reasons the placement of the fonts in the timer intervals is a bit off under Windows. Compare https://github.com/google/orbit/issues/4627.

This addmittedly is a hack to compensate for these differences. It would probably be cleaner to either understand the root cause or to subtract a margin from the timer box and render the text inside that. But this is a quick fix and it solves the issue.