### PR TITLE
Update inactive timer behavior

### DIFF
--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -2221,6 +2221,8 @@ const orbit_client_protos::TimerInfo* OrbitApp::selected_timer() const {
 }
 
 void OrbitApp::SelectTimer(const orbit_client_protos::TimerInfo* timer_info) {
+  if (timer_info != nullptr && !IsTimerActive(*timer_info)) return;
+
   data_manager_->set_selected_timer(timer_info);
   const std::optional<ScopeId> scope_id =
       timer_info != nullptr ? ProvideScopeId(*timer_info) : std::nullopt;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -231,14 +231,14 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected, 
                                  const internal::DrawData& /*draw_data*/) const {
   const Color inactive_color(100, 100, 100, 255);
   const Color selection_color(0, 128, 255, 255);
+  if (!IsTimerActive(timer_info)) {
+    return inactive_color;
+  }
   if (is_highlighted) {
     return TimerTrack::kHighlightColor;
   }
   if (is_selected) {
     return selection_color;
-  }
-  if (!IsTimerActive(timer_info)) {
-    return inactive_color;
   }
 
   std::optional<Color> user_color = GetUserColor(timer_info);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -483,9 +483,11 @@ std::pair<float, float> TimeGraph::GetBoxPosXAndWidthFromTicks(uint64_t start_ti
 // visible.
 void TimeGraph::SelectAndMakeVisible(const TimerInfo* timer_info) {
   ORBIT_CHECK(timer_info != nullptr);
-  app_->SelectTimer(timer_info);
-  HorizontallyMoveIntoView(VisibilityType::kPartlyVisible, *timer_info);
-  track_container_->VerticallyMoveIntoView(*timer_info);
+  if (app_->IsTimerActive(*timer_info)) {
+    app_->SelectTimer(timer_info);
+    HorizontallyMoveIntoView(VisibilityType::kPartlyVisible, *timer_info);
+    track_container_->VerticallyMoveIntoView(*timer_info);
+  }
 }
 
 static bool ThreadMatches(const std::optional<uint32_t>& target_thread_id, const TimerInfo* timer) {


### PR DESCRIPTION
This (1) makes inactive timers unclickable (they aren't in the live tab anyway) and (2) makes the gray coloring take precedent over highlighting selected timers when they aren't a part of a filer or selection.