### PR TITLE
Update the selection overlay look

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -738,23 +738,22 @@ void CaptureWindow::RenderSelectionOverlay() {
 
   if (start_world < select_start_world) {
     Quad box = MakeBox(Vec2(start_world, initial_y_position),
-                      Vec2(select_start_world - start_world, bar_height));
+                       Vec2(select_start_world - start_world, bar_height));
     primitive_assembler_.AddBox(box, GlCanvas::kZValueOverlay, overlay_color);
     if (select_start_world < end_world) {
       primitive_assembler_.AddVerticalLine(Vec2(select_start_world, initial_y_position), bar_height,
-                                        GlCanvas::kZValueOverlay, border_lines_color);
+                                           GlCanvas::kZValueOverlay, border_lines_color);
     }
   }
   if (select_end_world < end_world) {
     Quad box = MakeBox(Vec2(select_end_world, initial_y_position),
-                        Vec2(end_world - select_end_world, bar_height));
+                       Vec2(end_world - select_end_world, bar_height));
     primitive_assembler_.AddBox(box, GlCanvas::kZValueOverlay, overlay_color);
     if (start_world < select_end_world) {
       primitive_assembler_.AddVerticalLine(Vec2(select_end_world, initial_y_position), bar_height,
-                                        GlCanvas::kZValueOverlay, border_lines_color);
+                                           GlCanvas::kZValueOverlay, border_lines_color);
     }
   }
-
 
   TextRenderer::HAlign alignment = select_stop_pos_world_[0] < select_start_pos_world_[0]
                                        ? TextRenderer::HAlign::Left

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -730,19 +730,31 @@ void CaptureWindow::RenderSelectionOverlay() {
   float initial_y_position = time_graph_layout_->GetTimeBarHeight();
   float bar_height = viewport_.GetWorldHeight() - initial_y_position;
 
-  const Color overlay_color(0, 0, 0, 128);
-  Quad box = MakeBox(Vec2(start_world, initial_y_position),
-                     Vec2(select_start_world - start_world, bar_height));
-  primitive_assembler_.AddBox(box, GlCanvas::kZValueOverlay, overlay_color);
-  Quad box2 = MakeBox(Vec2(select_end_world, initial_y_position),
-                      Vec2(end_world - select_end_world, bar_height));
-  primitive_assembler_.AddBox(box2, GlCanvas::kZValueOverlay, overlay_color);
+  // We are entirely within the selection and do not have to draw any overlay.
+  if (select_start_world < start_world && end_world < select_end_world) return;
 
+  const Color overlay_color(0, 0, 0, 128);
   const Color border_lines_color(255, 255, 255, 255);
-  primitive_assembler_.AddVerticalLine(Vec2(select_start_world, initial_y_position), bar_height,
-                                       GlCanvas::kZValueOverlay, border_lines_color);
-  primitive_assembler_.AddVerticalLine(Vec2(select_end_world, initial_y_position), bar_height,
-                                       GlCanvas::kZValueOverlay, border_lines_color);
+
+  if (start_world < select_start_world) {
+    Quad box = MakeBox(Vec2(start_world, initial_y_position),
+                      Vec2(select_start_world - start_world, bar_height));
+    primitive_assembler_.AddBox(box, GlCanvas::kZValueOverlay, overlay_color);
+    if (select_start_world < end_world) {
+      primitive_assembler_.AddVerticalLine(Vec2(select_start_world, initial_y_position), bar_height,
+                                        GlCanvas::kZValueOverlay, border_lines_color);
+    }
+  }
+  if (select_end_world < end_world) {
+    Quad box = MakeBox(Vec2(select_end_world, initial_y_position),
+                        Vec2(end_world - select_end_world, bar_height));
+    primitive_assembler_.AddBox(box, GlCanvas::kZValueOverlay, overlay_color);
+    if (start_world < select_end_world) {
+      primitive_assembler_.AddVerticalLine(Vec2(select_end_world, initial_y_position), bar_height,
+                                        GlCanvas::kZValueOverlay, border_lines_color);
+    }
+  }
+
 
   TextRenderer::HAlign alignment = select_stop_pos_world_[0] < select_start_pos_world_[0]
                                        ? TextRenderer::HAlign::Left

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -722,22 +722,27 @@ void CaptureWindow::RenderSelectionOverlay() {
   uint64_t min_time = std::min(select_start_time_, select_stop_time_);
   uint64_t max_time = std::max(select_start_time_, select_stop_time_);
 
-  float from_world = time_graph_->GetWorldFromTick(min_time);
-  float to_world = time_graph_->GetWorldFromTick(max_time);
+  float start_world = time_graph_->GetWorldFromUs(time_graph_->GetMinTimeUs());
+  float end_world = time_graph_->GetWorldFromUs(time_graph_->GetMaxTimeUs());
+  float select_start_world = time_graph_->GetWorldFromTick(min_time);
+  float select_end_world = time_graph_->GetWorldFromTick(max_time);
   float stop_pos_world = time_graph_->GetWorldFromTick(select_stop_time_);
-
-  float size_x = to_world - from_world;
-  // TODO(http://b/226401787): Allow green selection overlay to be on top of the Timeline after
-  // modifying its design and how the overlay is drawn
   float initial_y_position = time_graph_layout_->GetTimeBarHeight();
-  Vec2 pos(from_world, initial_y_position);
-  Vec2 size(size_x, viewport_.GetWorldHeight() - initial_y_position);
+  float bar_height = viewport_.GetWorldHeight() - initial_y_position;
 
-  std::string text = orbit_display_formats::GetDisplayTime(TicksToDuration(min_time, max_time));
-  const Color color(0, 128, 0, 128);
+  const Color overlay_color(0, 0, 0, 128);
+  Quad box = MakeBox(Vec2(start_world, initial_y_position),
+                     Vec2(select_start_world - start_world, bar_height));
+  primitive_assembler_.AddBox(box, GlCanvas::kZValueOverlay, overlay_color);
+  Quad box2 = MakeBox(Vec2(select_end_world, initial_y_position),
+                      Vec2(end_world - select_end_world, bar_height));
+  primitive_assembler_.AddBox(box2, GlCanvas::kZValueOverlay, overlay_color);
 
-  Quad box = MakeBox(pos, size);
-  primitive_assembler_.AddBox(box, GlCanvas::kZValueOverlay, color);
+  const Color border_lines_color(255, 255, 255, 255);
+  primitive_assembler_.AddVerticalLine(Vec2(select_start_world, initial_y_position), bar_height,
+                                       GlCanvas::kZValueOverlay, border_lines_color);
+  primitive_assembler_.AddVerticalLine(Vec2(select_end_world, initial_y_position), bar_height,
+                                       GlCanvas::kZValueOverlay, border_lines_color);
 
   TextRenderer::HAlign alignment = select_stop_pos_world_[0] < select_start_pos_world_[0]
                                        ? TextRenderer::HAlign::Left
@@ -746,11 +751,7 @@ void CaptureWindow::RenderSelectionOverlay() {
   formatting.font_size = time_graph_layout_->GetFontSize();
   formatting.color = Color(255, 255, 255, 255);
   formatting.halign = alignment;
-
+  std::string text = orbit_display_formats::GetDisplayTime(TicksToDuration(min_time, max_time));
   text_renderer_.AddText(text.c_str(), stop_pos_world, select_stop_pos_world_[1],
                          GlCanvas::kZValueOverlay, formatting);
-
-  const unsigned char g = 100;
-  Color grey(g, g, g, 255);
-  primitive_assembler_.AddVerticalLine(pos, size[1], GlCanvas::kZValueOverlay, grey);
 }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -865,7 +865,7 @@ void TimeGraph::DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
   ORBIT_SCOPE("TimeGraph::DoDraw");
   CaptureViewElement::DoDraw(primitive_assembler, text_renderer, draw_context);
 
-  // Vertical green line at mouse x position.
+  // Vertical white line at mouse x position.
   if (draw_context.picking_mode == PickingMode::kNone &&
       draw_context.current_mouse_tick.has_value()) {
     const Color white_line_color{255, 255, 255, 127};

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -868,10 +868,10 @@ void TimeGraph::DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
   // Vertical green line at mouse x position.
   if (draw_context.picking_mode == PickingMode::kNone &&
       draw_context.current_mouse_tick.has_value()) {
-    const Color green_line_color{0, 255, 0, 127};
+    const Color white_line_color{255, 255, 255, 127};
     Vec2 green_line_pos = {GetWorldFromTick(draw_context.current_mouse_tick.value()), GetPos()[1]};
     primitive_assembler.AddVerticalLine(green_line_pos, GetHeight(), GlCanvas::kZValueUi,
-                                        green_line_color);
+                                        white_line_color);
   }
 
   // TODO(http://b/217719000): We are drawing boxes in margin positions because some elements are


### PR DESCRIPTION
Rather than having a transparent green overlay on what you're trying to select, this adds a dark overlay over the parts of the window you are _not_ selecting, leaving the selected section clear.  This is particularly useful in conjunction with time range selection, but works well as Orbit is right now as well.

Screenshot: https://screenshot.googleplex.com/7bigbcQz2RzwtNp