### PR TITLE
Do not copy values in GetOrderedValuesByDepth

### DIFF
--- a/src/Containers/include/Containers/ScopeTree.h
+++ b/src/Containers/include/Containers/ScopeTree.h
@@ -84,7 +84,7 @@ class ScopeTree {
   [[nodiscard]] size_t Size() const { return nodes_.size(); }
   [[nodiscard]] size_t CountOrderedNodesByDepth() const;
   [[nodiscard]] uint32_t Depth() const;
-  [[nodiscard]] const absl::btree_map<uint64_t /*start time*/, ScopeNodeT*> GetOrderedNodesAtDepth(
+  [[nodiscard]] const absl::btree_map<uint64_t /*start time*/, ScopeNodeT*>& GetOrderedNodesAtDepth(
       uint32_t depth) const;
   [[nodiscard]] const ScopeT* FindFirstScopeAtOrAfterTime(uint32_t depth, uint64_t time) const;
   [[nodiscard]] const ScopeT* FindNextScopeAtDepth(const ScopeT& scope) const;
@@ -148,13 +148,14 @@ const ScopeT* ScopeTree<ScopeT>::FindFirstChild(const ScopeT& scope) const {
   return children.begin()->second->GetScope();
 }
 template <typename ScopeT>
-const absl::btree_map<uint64_t, ScopeNode<ScopeT>*> ScopeTree<ScopeT>::GetOrderedNodesAtDepth(
+const absl::btree_map<uint64_t, ScopeNode<ScopeT>*>& ScopeTree<ScopeT>::GetOrderedNodesAtDepth(
     uint32_t depth) const {
   // Scope Tree includes a dummy node at depth 0 and therefore it's 1-indexed.
   depth++;
 
   if (!GetOrderedNodesByDepth().contains(depth)) {
-    return {};
+    static const absl::btree_map<uint64_t, ScopeNode<ScopeT>*> kEmptyScopes = {};
+    return kEmptyScopes;
   }
   return GetOrderedNodesByDepth().at(depth);
 }


### PR DESCRIPTION
In this PR we are returning a reference to avoid copying values in GetOrderedValuesByDepth. It improves a bit the performance of the time range selection:

Source code view - Before: http://screenshot/9JEKbqNCuGuYRYu 
Source code view - After: http://screenshot/BheSzyhASirFu2a

It's still going slow anyway.

Bug: http://b/264439413

Pair-programmed with Henning