### PR TITLE
Add instrospection scopes for time range selection

### DIFF
--- a/src/ClientData/ScopeStatsCollection.cpp
+++ b/src/ClientData/ScopeStatsCollection.cpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <utility>
 
+#include "ApiInterface/Orbit.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Typedef.h"
 
@@ -21,6 +22,7 @@ static const ScopeStats kDefaultScopeStats;
 
 ScopeStatsCollection::ScopeStatsCollection(ScopeIdProvider& scope_id_provider,
                                            absl::Span<const TimerInfo* const> timers) {
+  ORBIT_SCOPE_WITH_COLOR("ScopeStatsCollection", kOrbitColorDeepPurple);
   for (const TimerInfo* timer : timers) {
     std::optional<ScopeId> scope_id = scope_id_provider.ProvideId(*timer);
     if (scope_id.has_value()) {
@@ -73,6 +75,7 @@ const std::vector<uint64_t>* ScopeStatsCollection::GetSortedTimerDurationsForSco
 }
 
 void ScopeStatsCollection::OnCaptureComplete() {
+  ORBIT_SCOPE_WITH_COLOR("ScopeStatsCollection::OnCaptureComplete", kOrbitColorDeepOrange);
   if (timer_durations_are_sorted_) return;
 
   for (auto& [unused_id, timer_durations] : scope_id_to_timer_durations_) {

--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -63,6 +63,7 @@ std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers
 
 std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimersAtDepthExclusive(
     uint32_t depth, uint64_t start_ns, uint64_t end_ns) const {
+  ORBIT_SCOPE_WITH_COLOR("GetTimersAtDepthExclusive", kOrbitColorGreen);
   std::vector<const orbit_client_protos::TimerInfo*> all_timers_at_depth;
   absl::MutexLock lock(&scope_tree_mutex_);
 

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -2840,6 +2840,7 @@ void OrbitApp::ClearThreadAndTimeRangeSelection() {
 }
 
 void OrbitApp::OnThreadOrTimeRangeSelectionChange() {
+  ORBIT_SCOPE_WITH_COLOR("OrbitApp::OnThreadOrTimeRangeSelectionChange", kOrbitColorLime);
   if (!HasCaptureData() || !absl::GetFlag(FLAGS_time_range_selection)) return;
 
   ClearSelectionTabs();


### PR DESCRIPTION
In this PR we are just adding introspection scopes for the slowest functions when an user executes a time range selection in a long capture. They might be useful to test performance improvements for that method. 

Colors are not visible in Introspection, probably a recent bug.

Bug: http://b/264439413
Screenshot: http://screenshot/7HX3rsV2X3xUbV6