### PR TITLE
Use absl::Mutex in TrackManager

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -86,7 +86,7 @@ std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
 }
 
 void TrackManager::SortTracks() {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   // Gather all tracks regardless of the process in sorted order
   std::vector<Track*> all_processes_sorted_tracks;
 
@@ -361,7 +361,7 @@ void TrackManager::AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track)
 }
 
 void TrackManager::RemoveFrameTrack(uint64_t function_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   deleted_tracks_.push_back(frame_tracks_[function_id]);
   frame_tracks_.erase(function_id);
 
@@ -440,7 +440,7 @@ Track* TrackManager::GetOrCreateTrackFromTimerInfo(const TimerInfo& timer_info) 
 }
 
 SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   if (scheduler_track_ == nullptr) {
     auto [unused, timer_data] = capture_data_->CreateTimerData();
     scheduler_track_ =
@@ -452,7 +452,7 @@ SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {
 }
 
 ThreadTrack* TrackManager::GetOrCreateThreadTrack(uint32_t tid) {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   return GetOrCreateThreadTrackInternal(tid);
 }
 
@@ -480,7 +480,7 @@ std::optional<ThreadTrack*> TrackManager::GetThreadTrack(uint32_t tid) const {
 }
 
 GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   std::string timeline =
       app_->GetStringManager()->Get(timeline_hash).value_or(std::to_string(timeline_hash));
   std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline];
@@ -497,7 +497,7 @@ GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
 }
 
 VariableTrack* TrackManager::GetOrCreateVariableTrack(std::string_view name) {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
 
   auto existing_track = variable_tracks_.find(name);
   if (existing_track != variable_tracks_.end()) return existing_track->second.get();
@@ -510,7 +510,7 @@ VariableTrack* TrackManager::GetOrCreateVariableTrack(std::string_view name) {
 }
 
 AsyncTrack* TrackManager::GetOrCreateAsyncTrack(std::string_view name) {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
 
   auto existing_track = async_tracks_.find(name);
   if (existing_track != async_tracks_.end()) return existing_track->second.get();
@@ -525,7 +525,7 @@ AsyncTrack* TrackManager::GetOrCreateAsyncTrack(std::string_view name) {
 }
 
 FrameTrack* TrackManager::GetOrCreateFrameTrack(uint64_t function_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   if (auto track_it = frame_tracks_.find(function_id); track_it != frame_tracks_.end()) {
     return track_it->second.get();
   }
@@ -562,7 +562,7 @@ PageFaultsTrack* TrackManager::GetPageFaultsTrack() const {
 }
 
 SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack() {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   if (system_memory_track_ == nullptr) {
     system_memory_track_ = std::make_shared<SystemMemoryTrack>(
         track_container_, timeline_info_, viewport_, layout_, module_manager_, capture_data_);
@@ -574,7 +574,7 @@ SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack() {
 
 CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTrack(
     std::string_view cgroup_name) {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   if (cgroup_and_process_memory_track_ == nullptr) {
     cgroup_and_process_memory_track_ = std::make_shared<CGroupAndProcessMemoryTrack>(
         track_container_, timeline_info_, viewport_, layout_, std::string{cgroup_name},
@@ -587,7 +587,7 @@ CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTra
 
 PageFaultsTrack* TrackManager::CreateAndGetPageFaultsTrack(std::string_view cgroup_name,
                                                            uint64_t memory_sampling_period_ms) {
-  absl::MutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(&mutex_);
   if (page_faults_track_ == nullptr) {
     page_faults_track_ = std::make_shared<PageFaultsTrack>(
         track_container_, timeline_info_, viewport_, layout_, std::string{cgroup_name},

--- a/src/OrbitGl/include/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/include/OrbitGl/TrackManager.h
@@ -99,14 +99,15 @@ class TrackManager {
   [[nodiscard]] int FindMovingTrackIndex();
   void UpdateMovingTrackPositionInVisibleTracks();
   void SortTracks();
-  [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks() ABSL_NO_THREAD_SAFETY_ANALYSIS;
-  [[nodiscard]] std::vector<Track*> GetAllTracksNoLock() const ABSL_NO_THREAD_SAFETY_ANALYSIS;
-  ThreadTrack* GetOrCreateThreadTrackNoLock(uint32_t tid) ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks()
+      ABSL_SHARED_LOCKS_REQUIRED(mutex_);
+  [[nodiscard]] std::vector<Track*> GetAllTracksInternal() const ABSL_SHARED_LOCKS_REQUIRED(mutex_);
+  ThreadTrack* GetOrCreateThreadTrackInternal(uint32_t tid) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   // Filter tracks that are already sorted in sorted_tracks_.
   void UpdateVisibleTrackList();
   void DeletePendingTracks();
 
-  void AddTrack(const std::shared_ptr<Track>& track) ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  void AddTrack(const std::shared_ptr<Track>& track) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   void AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track);
 
   // This mutex is needed because two different threads will access the following containers. The

--- a/src/OrbitGl/include/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/include/OrbitGl/TrackManager.h
@@ -76,16 +76,12 @@ class TrackManager {
   VariableTrack* GetOrCreateVariableTrack(std::string_view name);
   AsyncTrack* GetOrCreateAsyncTrack(std::string_view name);
   FrameTrack* GetOrCreateFrameTrack(uint64_t function_id);
-  [[nodiscard]] SystemMemoryTrack* GetSystemMemoryTrack() const {
-    return system_memory_track_.get();
-  }
+  [[nodiscard]] SystemMemoryTrack* GetSystemMemoryTrack() const;
   [[nodiscard]] SystemMemoryTrack* CreateAndGetSystemMemoryTrack();
-  [[nodiscard]] CGroupAndProcessMemoryTrack* GetCGroupAndProcessMemoryTrack() const {
-    return cgroup_and_process_memory_track_.get();
-  }
+  [[nodiscard]] CGroupAndProcessMemoryTrack* GetCGroupAndProcessMemoryTrack() const;
   [[nodiscard]] CGroupAndProcessMemoryTrack* CreateAndGetCGroupAndProcessMemoryTrack(
       std::string_view cgroup_name);
-  PageFaultsTrack* GetPageFaultsTrack() const { return page_faults_track_.get(); }
+  PageFaultsTrack* GetPageFaultsTrack() const;
   PageFaultsTrack* CreateAndGetPageFaultsTrack(std::string_view cgroup_name,
                                                uint64_t memory_sampling_period_ms);
 
@@ -103,31 +99,39 @@ class TrackManager {
   [[nodiscard]] int FindMovingTrackIndex();
   void UpdateMovingTrackPositionInVisibleTracks();
   void SortTracks();
-  [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
+  [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks() ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  [[nodiscard]] std::vector<Track*> GetAllTracksNoLock() const ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  ThreadTrack* GetOrCreateThreadTrackNoLock(uint32_t tid) ABSL_NO_THREAD_SAFETY_ANALYSIS;
   // Filter tracks that are already sorted in sorted_tracks_.
   void UpdateVisibleTrackList();
   void DeletePendingTracks();
 
-  void AddTrack(const std::shared_ptr<Track>& track);
+  void AddTrack(const std::shared_ptr<Track>& track) ABSL_NO_THREAD_SAFETY_ANALYSIS;
   void AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track);
 
-  // TODO(b/174655559): Use absl's mutex here.
-  mutable std::recursive_mutex mutex_;
+  // This mutex is needed because two different threads will access the following containers. The
+  // capture thread will insert tracks and the main thread will read the tracks from the containers
+  // to generate the sorted list of visible tracks.
+  mutable absl::Mutex mutex_;
 
-  std::vector<std::shared_ptr<Track>> all_tracks_;
-  absl::flat_hash_map<uint32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
-  std::map<std::string, std::shared_ptr<AsyncTrack>, std::less<>> async_tracks_;
-  std::map<std::string, std::shared_ptr<VariableTrack>, std::less<>> variable_tracks_;
+  std::vector<std::shared_ptr<Track>> all_tracks_ ABSL_GUARDED_BY(mutex_);
+  absl::flat_hash_map<uint32_t, std::shared_ptr<ThreadTrack>> thread_tracks_
+      ABSL_GUARDED_BY(mutex_);
+  std::map<std::string, std::shared_ptr<AsyncTrack>, std::less<>> async_tracks_
+      ABSL_GUARDED_BY(mutex_);
+  std::map<std::string, std::shared_ptr<VariableTrack>, std::less<>> variable_tracks_
+      ABSL_GUARDED_BY(mutex_);
   // Mapping from timeline to GPU tracks. Timeline name is used for stable ordering. In particular
   // we want the marker tracks next to their queue track. E.g. "gfx" and "gfx_markers" should appear
   // next to each other.
-  std::map<std::string, std::shared_ptr<GpuTrack>> gpu_tracks_;
+  std::map<std::string, std::shared_ptr<GpuTrack>> gpu_tracks_ ABSL_GUARDED_BY(mutex_);
   // Mapping from function id to frame tracks.
-  std::map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
-  std::shared_ptr<SchedulerTrack> scheduler_track_;
-  std::shared_ptr<SystemMemoryTrack> system_memory_track_;
-  std::shared_ptr<CGroupAndProcessMemoryTrack> cgroup_and_process_memory_track_;
-  std::shared_ptr<PageFaultsTrack> page_faults_track_;
+  std::map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_ ABSL_GUARDED_BY(mutex_);
+  std::shared_ptr<SchedulerTrack> scheduler_track_ ABSL_GUARDED_BY(mutex_);
+  std::shared_ptr<SystemMemoryTrack> system_memory_track_ ABSL_GUARDED_BY(mutex_);
+  std::shared_ptr<CGroupAndProcessMemoryTrack> cgroup_and_process_memory_track_
+      ABSL_GUARDED_BY(mutex_);
+  std::shared_ptr<PageFaultsTrack> page_faults_track_ ABSL_GUARDED_BY(mutex_);
 
   // This intermediatly stores tracks that have been deleted from one of the track vectors above
   // so they can safely be removed from the list of sorted and visible tracks.


### PR DESCRIPTION
TrackManager is a class that is not as easy as it should be to navigate. The main complexity lies in the fact that there are two threads that are accessing the class. The capture thread is inserting timers and therefore creating the tracks when needed and the main thread is reading the tracks to sort then and render the visible ones (a detailed picture can be found in http://go/stadia-orbit-track-creation#heading=h.vpgt3chmpmpb).

We had issues in the class because of multi-threading (and currently it seems Daniel found a new one), so in this PR I'm cleaning this class by replacing the recursive_mutex with an absl::Mutex. I don't see how this could solve the crash found by Daniel but at least the class might be easier to understand when looking for the issue.

We were using a recursive_mutex because some public methods were calling another ones where both of then needs the mutex to be locked. But as we don't have recursion, this can be solved by splitting some methods.

In this PR we are:
- Guarding all the containers that needs to be locked (ABSL_GUARDED_BY)
- Locking all the public methods that are accessing the containers.
- Not locking the private methods, as they are only called by the class itself.
- Manually assuring that the locked methods don't call another public method that lock the mutex.

I'm not sure about if the last point is the best thing to do but I feel that this is an improvement, do you have another suggestion?

Test: Load a capture with all kind of tracks. Also take a capture.

