### PR TITLE
Cache FindModuleByAddress

### DIFF
--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -112,6 +112,8 @@ class ProcessData final {
   mutable absl::Mutex mutex_;
   orbit_grpc_protos::ProcessInfo process_info_ ABSL_GUARDED_BY(mutex_);
   std::map<uint64_t, ModuleInMemory> start_address_to_module_in_memory_ ABSL_GUARDED_BY(mutex_);
+  mutable absl::flat_hash_map<uint64_t, ModuleInMemory> absolute_address_to_module_in_memory_cache_
+      ABSL_GUARDED_BY(mutex_);
 };
 
 }  // namespace orbit_client_data


### PR DESCRIPTION
When creating the different sampling views, there
are a lot of querries to FindModuleByAddress, which is performing a binary search.

This change saves the results such that the binary search happens only once per address.

Follow-up: Also do caching for FindFunctionByAddress and similar methods. Those are actually more promesing in terms of performance improvements.

Test: Tested on 5-min capture
Bug: http://b/264437402