### PR TITLE
Cache FindFunctionByAddress

### DIFF
--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -84,6 +84,8 @@ class ModuleData final {
   SymbolCompleteness loaded_symbols_completeness_ ABSL_GUARDED_BY(mutex_) =
       SymbolCompleteness::kNoSymbols;
   std::map<uint64_t, std::unique_ptr<FunctionInfo>> functions_ ABSL_GUARDED_BY(mutex_);
+  mutable absl::flat_hash_map<uint64_t, FunctionInfo*> absolute_address_to_function_info_cache_
+      ABSL_GUARDED_BY(mutex_);
   absl::flat_hash_map<std::string_view, FunctionInfo*> name_to_function_info_map_
       ABSL_GUARDED_BY(mutex_);
 


### PR DESCRIPTION
When creating the different sampling views, there
are a lot of querries to FindFunctionByAddress, which is performing a binary search.

This change saves the results such that the binary search happens only once per address.

Measuring improvements here is kinda hard, as there are many things that rely together. This change alone
is "only" about a 1.05x speedup. However, combined with PR #4686, as well as some further caching, we get ~2x.

Test: Tested on 5-min capture
Bug: http://b/264437402