### PR TITLE
Optimize ModuleManager

### DIFF
--- a/src/ClientData/include/ClientData/ModuleManager.h
+++ b/src/ClientData/include/ClientData/ModuleManager.h
@@ -60,7 +60,10 @@ class ModuleManager final {
   mutable absl::Mutex mutex_;
   // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
   // Map of ModuleIdentifier -> ModuleData (ModuleIdentifier is file_path and build_id)
-  absl::node_hash_map<orbit_symbol_provider::ModuleIdentifier, ModuleData> module_map_;
+  absl::flat_hash_map<orbit_symbol_provider::ModuleIdentifier, std::unique_ptr<ModuleData>>
+      module_map_ ABSL_GUARDED_BY(mutex_);
+  mutable absl::flat_hash_map<uint64_t, ModuleData*> absolute_address_to_module_data_cache_
+      ABSL_GUARDED_BY(mutex_);
 };
 
 }  // namespace orbit_client_data


### PR DESCRIPTION
This change is actually tackling two things:

1. Following http://go/fast/55, we replace the node_hash_map, we used for pointer stability by a flat_hash_map of unique_ptrs.

2. GetModuleByModuleInMemoryAndAbsoluteAddress uses strings as keys, which's hash computation comes with some cost. Absolute address was only used for validation.
We now also cache the modules for an absolute address.

This change alone, is about a 1.15x speedup.

Test: 5-min test capture
Bug: http://b/264437402