### PR TITLE
More bugfixes in build scripts

### DIFF
--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -41,7 +41,7 @@ Please install Python and make it available in the path.
 
   $conan_version = (conan --version).split(" ")[2]
 
-  if (Check-Conan-Version-Sufficient $conan_version $conan_version_required) {
+  if (!Check-Conan-Version-Sufficient $conan_version $conan_version_required) {
     Write-Host "Your conan version $conan_version is too old. Let's try to update it."
     pip3 install --upgrade conan==$conan_version_required
     if ($LastExitCode -ne 0) {

--- a/build.ps1
+++ b/build.ps1
@@ -62,7 +62,7 @@ if (-not (conan_profile_exists $build_profile)) {
 }
 
 
-$profiles = if ($args.Count) { $args } else { @("default_relwithdebinfo") }
+$profiles = if ($args.Count) { $args } else { @("default_release") }
 
 foreach ($profile in $profiles) {
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ fi
 
 readonly CONAN
 
-default_profiles=( default_relwithdebinfo )
+default_profiles=( default_release )
 
 if [ "$#" -eq 0 ]; then
   profiles=( "${default_profiles[@]}" )


### PR DESCRIPTION
1. `install.sh` had no `set -eu` and was calling `conan` directly.
2. `bootstrap-orbit.ps1` had an inverted conan version check.
3. `build.sh` and `build.ps` now build `default_release` by default. This will help reducing build times for first timers because there are packages for the release config in Conan Center, but not for `RelWithDebInfo`.