### PR TITLE
Fix crash when deleting selection_callstack_data

### DIFF
--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -2830,6 +2830,8 @@ void OrbitApp::ClearTimeRangeSelection() {
 }
 
 void OrbitApp::ClearThreadAndTimeRangeSelection() {
+  SetCaptureDataSelectionFields(std::vector<CallstackEvent>(),
+                                /*origin_is_multiple_threads*/ false);
   main_window_->SetLiveTabScopeStatsCollection(GetCaptureData().GetAllScopeStatsCollection());
   SetTopDownView(GetCaptureData().post_processed_sampling_data());
   SetBottomUpView(GetCaptureData().post_processed_sampling_data());
@@ -2843,8 +2845,7 @@ void OrbitApp::OnThreadOrTimeRangeSelectionChange() {
   ORBIT_SCOPE_WITH_COLOR("OrbitApp::OnThreadOrTimeRangeSelectionChange", kOrbitColorLime);
   if (!HasCaptureData() || !absl::GetFlag(FLAGS_time_range_selection)) return;
 
-  ClearSelectionTabs();
-  ClearInspection();
+  main_window_->ClearCallstackInspection();
 
   uint32_t thread_id = data_manager_->selected_thread_id();
   bool has_time_range = data_manager_->GetSelectionTimeRange().has_value();


### PR DESCRIPTION
I intend to fix this in a better way but it will require a larger overhaul of selection/inspections. These changes will come in a future PR; for now, I am just trying to fix the crash.