### PR TITLE
Add memory measurements for the Batcher

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -669,6 +669,10 @@ std::string CaptureWindow::GetPerformanceInfo() const {
     absl::StrAppendFormat(&performance_info, "Max time for %s: %f ms\n", item.first,
                           item.second->GetMaxTimeMs());
   }
+  if (time_graph_ != nullptr) {
+    absl::StrAppendFormat(&performance_info, "TimeGraph Batcher Memory: %.2f MB\n", 
+      static_cast<float>(time_graph_->GetBatcher().GetReservedMemorySize()) / 1024 / 1024);
+  }
   return performance_info;
 }
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -670,8 +670,9 @@ std::string CaptureWindow::GetPerformanceInfo() const {
                           item.second->GetMaxTimeMs());
   }
   if (time_graph_ != nullptr) {
-    absl::StrAppendFormat(&performance_info, "TimeGraph Batcher Memory: %.2f MB\n", 
-      static_cast<float>(time_graph_->GetBatcher().GetReservedMemorySize()) / 1024 / 1024);
+    absl::StrAppendFormat(
+        &performance_info, "TimeGraph Batcher Memory: %.2f MB\n",
+        static_cast<float>(time_graph_->GetBatcher().GetReservedMemorySize()) / 1024 / 1024);
   }
   return performance_info;
 }

--- a/src/OrbitGl/OpenGlBatcher.cpp
+++ b/src/OrbitGl/OpenGlBatcher.cpp
@@ -201,24 +201,24 @@ const PickingUserData* OpenGlBatcher::GetUserData(PickingId id) const {
   ORBIT_UNREACHABLE();
 }
 
-namespace { 
-  template<class T, uint32_t size>
-  size_t CalculateBlockChainMemory(const orbit_containers::BlockChain<T, size>& chain) {
-    size_t result = 0;
-    
-    auto block = chain.root();
-    while (block != nullptr) {
-      result += size * sizeof(T);
-      block = block->next();
-    }
+namespace {
+template <class T, uint32_t size>
+size_t CalculateBlockChainMemory(const orbit_containers::BlockChain<T, size>& chain) {
+  size_t result = 0;
 
-    return result;
+  auto block = chain.root();
+  while (block != nullptr) {
+    result += size * sizeof(T);
+    block = block->next();
   }
+
+  return result;
 }
+}  // namespace
 
 [[nodiscard]] size_t OpenGlBatcher::GetReservedMemorySize() const {
   size_t result = 0;
-  for (auto& layer: primitive_buffers_by_layer_) {
+  for (auto& layer : primitive_buffers_by_layer_) {
     result += CalculateBlockChainMemory(layer.second.box_buffer.boxes_);
     result += CalculateBlockChainMemory(layer.second.box_buffer.picking_colors_);
     result += CalculateBlockChainMemory(layer.second.box_buffer.colors_);

--- a/src/OrbitGl/OpenGlBatcher.cpp
+++ b/src/OrbitGl/OpenGlBatcher.cpp
@@ -201,4 +201,36 @@ const PickingUserData* OpenGlBatcher::GetUserData(PickingId id) const {
   ORBIT_UNREACHABLE();
 }
 
+namespace { 
+  template<class T, uint32_t size>
+  size_t CalculateBlockChainMemory(const orbit_containers::BlockChain<T, size>& chain) {
+    size_t result = 0;
+    
+    auto block = chain.root();
+    while (block != nullptr) {
+      result += size * sizeof(T);
+      block = block->next();
+    }
+
+    return result;
+  }
+}
+
+[[nodiscard]] size_t OpenGlBatcher::GetReservedMemorySize() const {
+  size_t result = 0;
+  for (auto& layer: primitive_buffers_by_layer_) {
+    result += CalculateBlockChainMemory(layer.second.box_buffer.boxes_);
+    result += CalculateBlockChainMemory(layer.second.box_buffer.picking_colors_);
+    result += CalculateBlockChainMemory(layer.second.box_buffer.colors_);
+    result += CalculateBlockChainMemory(layer.second.line_buffer.lines_);
+    result += CalculateBlockChainMemory(layer.second.line_buffer.picking_colors_);
+    result += CalculateBlockChainMemory(layer.second.line_buffer.colors_);
+    result += CalculateBlockChainMemory(layer.second.triangle_buffer.triangles_);
+    result += CalculateBlockChainMemory(layer.second.triangle_buffer.picking_colors_);
+    result += CalculateBlockChainMemory(layer.second.triangle_buffer.colors_);
+  }
+
+  return result;
+}
+
 }  // namespace orbit_gl

--- a/src/OrbitGl/OpenGlBatcherTest.cpp
+++ b/src/OrbitGl/OpenGlBatcherTest.cpp
@@ -275,4 +275,43 @@ TEST(OpenGlBatcher, TranslationsAreAutomaticallyAdded) {
   ASSERT_DEATH(batcher.PopTranslation(), "Check failed");
 }
 
+// Verifies the correctness of the required memory reported by the batcher
+// This test depends a lot on internal knowledge of the batcher and blockchain
+// structure - it may be fine to deactivate it at some point in the future
+// when we change the Batcher, but for now it helps to assure we're tracking
+// and reporting memory allocations correctly.
+TEST(OpenGlBatcher, ReservedMemoryIsReportedCorrectly) {
+  FakeOpenGlBatcher batcher(BatcherId::kUi);
+
+  const size_t kExpectedBoxBlockSize = orbit_gl_internal::BoxBuffer::NUM_BOXES_PER_BLOCK * (sizeof(Quad) + 8 * sizeof(Color));
+  const size_t kExpectedLineBlockSize = orbit_gl_internal::LineBuffer::NUM_LINES_PER_BLOCK * (sizeof(Line) + 4 * sizeof(Color));
+  const size_t kExpectedTriangleBlockSize = orbit_gl_internal::TriangleBuffer::NUM_TRIANGLES_PER_BLOCK * (sizeof(Triangle) + 6 * sizeof(Color));
+
+  EXPECT_EQ(batcher.GetReservedMemorySize(), 0);
+  batcher.AddBoxHelper(MakeBox(Vec2(0, 0), Vec2(1, 1)), 0, Color(255, 0, 0, 255));
+
+  size_t total_size = kExpectedBoxBlockSize + kExpectedLineBlockSize + kExpectedTriangleBlockSize;
+  // This should have added a block in the box blockchain for the box geometry, picking color, and regular color
+  // However, the block chain directly allocates the first block for all types of geometry,
+  // so we also expect the lines and triangle blocks to exist.
+  EXPECT_EQ(batcher.GetReservedMemorySize(), total_size);
+
+  batcher.AddLineHelper(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255));
+  batcher.AddTriangleHelper(Triangle(Vec2(0, 0), Vec2(0, 1), Vec2(1, 0)), 0, Color(0, 255, 0, 255));
+
+  // Adding a line and a triangle should only use the already existing blocks
+  EXPECT_EQ(batcher.GetReservedMemorySize(), total_size);
+
+  // Adding more boxes should eventually require a second block
+  for (int i = 0; i < orbit_gl_internal::BoxBuffer::NUM_BOXES_PER_BLOCK; ++i) {
+    batcher.AddBoxHelper(MakeBox(Vec2(0, 0), Vec2(1, 1)), 0, Color(255, 0, 0, 255));
+  }
+  total_size += kExpectedBoxBlockSize;
+  EXPECT_EQ(batcher.GetReservedMemorySize(), total_size);
+
+  // Reset does actually not clear the memory
+  batcher.ResetElements();
+  EXPECT_EQ(batcher.GetReservedMemorySize(), total_size);
+}
+
 }  // namespace orbit_gl

--- a/src/OrbitGl/OpenGlBatcherTest.cpp
+++ b/src/OrbitGl/OpenGlBatcherTest.cpp
@@ -283,17 +283,21 @@ TEST(OpenGlBatcher, TranslationsAreAutomaticallyAdded) {
 TEST(OpenGlBatcher, ReservedMemoryIsReportedCorrectly) {
   FakeOpenGlBatcher batcher(BatcherId::kUi);
 
-  const size_t kExpectedBoxBlockSize = orbit_gl_internal::BoxBuffer::NUM_BOXES_PER_BLOCK * (sizeof(Quad) + 8 * sizeof(Color));
-  const size_t kExpectedLineBlockSize = orbit_gl_internal::LineBuffer::NUM_LINES_PER_BLOCK * (sizeof(Line) + 4 * sizeof(Color));
-  const size_t kExpectedTriangleBlockSize = orbit_gl_internal::TriangleBuffer::NUM_TRIANGLES_PER_BLOCK * (sizeof(Triangle) + 6 * sizeof(Color));
+  const size_t kExpectedBoxBlockSize =
+      orbit_gl_internal::BoxBuffer::NUM_BOXES_PER_BLOCK * (sizeof(Quad) + 8 * sizeof(Color));
+  const size_t kExpectedLineBlockSize =
+      orbit_gl_internal::LineBuffer::NUM_LINES_PER_BLOCK * (sizeof(Line) + 4 * sizeof(Color));
+  const size_t kExpectedTriangleBlockSize =
+      orbit_gl_internal::TriangleBuffer::NUM_TRIANGLES_PER_BLOCK *
+      (sizeof(Triangle) + 6 * sizeof(Color));
 
   EXPECT_EQ(batcher.GetReservedMemorySize(), 0);
   batcher.AddBoxHelper(MakeBox(Vec2(0, 0), Vec2(1, 1)), 0, Color(255, 0, 0, 255));
 
   size_t total_size = kExpectedBoxBlockSize + kExpectedLineBlockSize + kExpectedTriangleBlockSize;
-  // This should have added a block in the box blockchain for the box geometry, picking color, and regular color
-  // However, the block chain directly allocates the first block for all types of geometry,
-  // so we also expect the lines and triangle blocks to exist.
+  // This should have added a block in the box blockchain for the box geometry, picking color, and
+  // regular color However, the block chain directly allocates the first block for all types of
+  // geometry, so we also expect the lines and triangle blocks to exist.
   EXPECT_EQ(batcher.GetReservedMemorySize(), total_size);
 
   batcher.AddLineHelper(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255));

--- a/src/OrbitGl/include/OrbitGl/Batcher.h
+++ b/src/OrbitGl/include/OrbitGl/Batcher.h
@@ -23,6 +23,8 @@ class Batcher : public BatcherInterface {
   void PushTranslation(float x, float y, float z = 0.f) { translations_.PushTranslation(x, y, z); }
   void PopTranslation() { translations_.PopTranslation(); }
 
+  [[nodiscard]] virtual size_t GetReservedMemorySize() const = 0;
+
  protected:
   orbit_gl::TranslationStack translations_;
 

--- a/src/OrbitGl/include/OrbitGl/MockBatcher.h
+++ b/src/OrbitGl/include/OrbitGl/MockBatcher.h
@@ -45,6 +45,8 @@ class MockBatcher : public Batcher {
 
   void DrawLayer(float /*layer*/, bool /*picking*/) override {}
 
+  [[nodiscard]] size_t GetReservedMemorySize() const override { return 0; };
+
   [[nodiscard]] const PickingUserData* GetUserData(PickingId /*id*/) const override {
     return nullptr;
   }

--- a/src/OrbitGl/include/OrbitGl/OpenGlBatcher.h
+++ b/src/OrbitGl/include/OrbitGl/OpenGlBatcher.h
@@ -104,6 +104,8 @@ class OpenGlBatcher : public Batcher, protected QOpenGLFunctions {
 
   [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const override;
 
+  [[nodiscard]] size_t GetReservedMemorySize() const override;
+
  protected:
   std::unordered_map<float, orbit_gl_internal::PrimitiveBuffers> primitive_buffers_by_layer_;
   std::vector<std::unique_ptr<PickingUserData>> user_data_;

--- a/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
@@ -61,11 +61,9 @@ class PrimitiveAssembler {
   void PushTranslation(float x, float y, float z = 0.f) { batcher_->PushTranslation(x, y, z); }
   void PopTranslation() { batcher_->PopTranslation(); }
 
-  void AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
-  [[nodiscard]] size_t GetReservedMemorySize() const {
-    return batcher_->GetReservedMemorySize(); };
+  [[nodiscard]] size_t GetReservedMemorySize() const { return batcher_->GetReservedMemorySize(); };
 
-  void AddLine(Vec2 from, Vec2 to, float z, const Color& color,
+  void AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddVerticalLine(const Vec2& pos, float size, float z, const Color& color,
                        std::unique_ptr<PickingUserData> user_data = nullptr);

--- a/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
@@ -125,8 +125,7 @@ class PrimitiveAssembler {
 
   void StartNewFrame();
 
-  [[nodiscard]] PickingManager* GetPickingManager() const {
-    return picking_manager_; }
+  [[nodiscard]] PickingManager* GetPickingManager() const { return picking_manager_; }
   [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const {
     return batcher_->GetUserData(id);
   }
@@ -135,8 +134,7 @@ class PrimitiveAssembler {
   static constexpr uint32_t kNumArcSides = 16;
 
  private:
-  [[nodiscard]] BatcherId GetBatcherId() const {
-    return batcher_->GetBatcherId(); }
+  [[nodiscard]] BatcherId GetBatcherId() const { return batcher_->GetBatcherId(); }
 
   void AddBottomLeftRoundedCorner(const Vec2& pos, float radius, float z, const Color& color);
   void AddTopLeftRoundedCorner(const Vec2& pos, float radius, float z, const Color& color);

--- a/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
@@ -62,7 +62,8 @@ class PrimitiveAssembler {
   void PopTranslation() { batcher_->PopTranslation(); }
 
   void AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
-  [[nodiscard]] size_t GetReservedMemorySize() const { return batcher_->GetReservedMemorySize(); };
+  [[nodiscard]] size_t GetReservedMemorySize() const {
+    return batcher_->GetReservedMemorySize(); };
 
   void AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                std::unique_ptr<PickingUserData> user_data = nullptr);
@@ -126,7 +127,8 @@ class PrimitiveAssembler {
 
   void StartNewFrame();
 
-  [[nodiscard]] PickingManager* GetPickingManager() const { return picking_manager_; }
+  [[nodiscard]] PickingManager* GetPickingManager() const {
+    return picking_manager_; }
   [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const {
     return batcher_->GetUserData(id);
   }
@@ -135,7 +137,8 @@ class PrimitiveAssembler {
   static constexpr uint32_t kNumArcSides = 16;
 
  private:
-  [[nodiscard]] BatcherId GetBatcherId() const { return batcher_->GetBatcherId(); }
+  [[nodiscard]] BatcherId GetBatcherId() const {
+    return batcher_->GetBatcherId(); }
 
   void AddBottomLeftRoundedCorner(const Vec2& pos, float radius, float z, const Color& color);
   void AddTopLeftRoundedCorner(const Vec2& pos, float radius, float z, const Color& color);

--- a/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
@@ -62,6 +62,9 @@ class PrimitiveAssembler {
   void PopTranslation() { batcher_->PopTranslation(); }
 
   void AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
+  [[nodiscard]] size_t GetReservedMemorySize() const { return batcher_->GetReservedMemorySize(); };
+
+  void AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddVerticalLine(const Vec2& pos, float size, float z, const Color& color,
                        std::unique_ptr<PickingUserData> user_data = nullptr);


### PR DESCRIPTION
Add information about Batcher memory requirements to the debug output.
This reports the actual memory required by all of our BlockChain structures
(geometry, colors, and picking information) including the empty space in the
blocks.

Currently only the memory required by the TimeGraph batcher is reported
as this is the critical one (it contains all the timers). It's easy to add the UI
batcher in the future if needed.