### PR TITLE
Fix update requests for thread states mouse-over

### DIFF
--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -328,18 +328,21 @@ void ThreadStateBar::OnPick(int x, int y) {
   Vec2 world_coords = viewport_->ScreenToWorld(Vec2i(x, y));
   std::optional<ThreadStateSliceInfo> clicked_slice = FindSliceFromWorldCoords(world_coords);
   app_->set_selected_thread_state_slice(clicked_slice);
+  RequestUpdate(RequestUpdateScope::kDrawAndUpdatePrimitives);
 }
 
 EventResult ThreadStateBar::OnMouseMove(const Vec2& mouse_pos) {
   EventResult event_result = CaptureViewElement::OnMouseMove(mouse_pos);
   std::optional<ThreadStateSliceInfo> hovered_slice = FindSliceFromWorldCoords(mouse_pos);
   app_->set_hovered_thread_state_slice(hovered_slice);
+  RequestUpdate(RequestUpdateScope::kDrawAndUpdatePrimitives);
   return event_result;
 }
 
 EventResult ThreadStateBar::OnMouseLeave() {
   EventResult event_result = CaptureViewElement::OnMouseLeave();
   app_->set_hovered_thread_state_slice(std::nullopt);
+  RequestUpdate(RequestUpdateScope::kDrawAndUpdatePrimitives);
   return event_result;
 }
 


### PR DESCRIPTION
Any changes that require redraw of a `CaptureViewElement` should call
`RequestUpdate()`. This was missing in the mouse-over handler of the
`ThreadStateBar`.

This will currently not change anything about the behavior, as the call to 
`app_->set_selected_thread_state_slice` already forces a complete redraw
of the capture window. In the future, we would like to move to a state where
partial redraws are possible, and thus it's not enough to force this globally.