### PR TITLE
Add SingleThreadExecutor

### DIFF
--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -24,11 +24,13 @@ target_sources(QtUtils PUBLIC include/QtUtils/AssertNoQtLogWarnings.h
                               include/QtUtils/ExecuteProcess.h
                               include/QtUtils/FutureWatcher.h
                               include/QtUtils/MainThreadExecutorImpl.h
+                              include/QtUtils/SingleThreadExecutor.h
                               include/QtUtils/Throttle.h)
 
 target_sources(QtUtils PRIVATE ExecuteProcess.cpp
                                FutureWatcher.cpp
                                MainThreadExecutorImpl.cpp
+                               SingleThreadExecutor.cpp
                                Throttle.cpp)
 
 set_target_properties(QtUtils PROPERTIES AUTOMOC ON)
@@ -43,6 +45,7 @@ target_sources(QtUtilsTests PRIVATE CreateTimeoutTest.cpp
                                     ExecuteProcessTest.cpp
                                     FutureWatcherTest.cpp
                                     MainThreadExecutorImplTest.cpp
+                                    SingleThreadExecutorTest.cpp
                                     ThrottleTest.cpp)
-target_link_libraries(QtUtilsTests PRIVATE TestUtils QtUtils GTest::QtCoreMain)
+target_link_libraries(QtUtilsTests PRIVATE TestUtils QtTestUtils QtUtils GTest::QtCoreMain)
 register_test(QtUtilsTests)

--- a/src/QtUtils/SingleThreadExecutor.cpp
+++ b/src/QtUtils/SingleThreadExecutor.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "QtUtils/SingleThreadExecutor.h"
+
+#include <QMetaObject>
+#include <Qt>
+#include <utility>
+
+#include "ApiInterface/Orbit.h"
+#include "OrbitBase/Action.h"
+
+namespace orbit_qt_utils {
+
+SingleThreadExecutor::SingleThreadExecutor(QObject* parent) : QObject{parent} {
+  thread.start();
+  context.moveToThread(&thread);
+}
+
+SingleThreadExecutor::~SingleThreadExecutor() {
+  thread.quit();
+  thread.wait();
+}
+
+void SingleThreadExecutor::ScheduleImpl(std::unique_ptr<Action> action) {
+  QMetaObject::invokeMethod(
+      &context,
+      [action = std::move(action)]() {
+        ORBIT_SCOPE("SingleThreadExecutor Action");
+        action->Execute();
+      },
+      Qt::QueuedConnection);
+}
+
+}  // namespace orbit_qt_utils

--- a/src/QtUtils/SingleThreadExecutorTest.cpp
+++ b/src/QtUtils/SingleThreadExecutorTest.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/types/span.h>
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "OrbitBase/Executor.h"
+#include "OrbitBase/Future.h"
+#include "OrbitBase/Promise.h"
+#include "OrbitBase/Result.h"
+#include "QtTestUtils/WaitFor.h"
+#include "QtUtils/SingleThreadExecutor.h"
+
+namespace orbit_qt_utils {
+
+TEST(SingleThreadExecutor, Schedule) {
+  SingleThreadExecutor executor{};
+
+  QThread* executing_thread{};
+  orbit_base::Future<void> future =
+      executor.Schedule([&]() { executing_thread = QThread::currentThread(); });
+
+  future.Wait();
+  EXPECT_EQ(executing_thread, executor.GetThread());
+}
+
+TEST(SingleThreadExecutor, ScheduleAfterOutOfLifetime) {
+  orbit_base::Promise<void> promise{};
+  orbit_base::Future<void> future{};
+
+  {
+    SingleThreadExecutor executor{};
+    // This schedules a task that is supposed to be executed after the promise completes
+    // But the executor gets destroyed before the promise completes, so we expect the task to never
+    // be executed.
+    future = promise.GetFuture().Then(&executor, []() { FAIL(); });
+  }
+
+  promise.MarkFinished();
+
+  // So this future never completes.
+  EXPECT_THAT(orbit_qt_test_utils::WaitFor(future, std::chrono::milliseconds{10}),
+              orbit_qt_test_utils::YieldsTimeout());
+}
+
+}  // namespace orbit_qt_utils

--- a/src/QtUtils/include/QtUtils/SingleThreadExecutor.h
+++ b/src/QtUtils/include/QtUtils/SingleThreadExecutor.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef QT_UTILS_SINGLE_THREAD_EXECUTOR_H_
+#define QT_UTILS_SINGLE_THREAD_EXECUTOR_H_
+
+#include <QObject>
+#include <QThread>
+#include <memory>
+
+#include "OrbitBase/Action.h"
+#include "OrbitBase/Executor.h"
+
+namespace orbit_qt_utils {
+
+// An implementation of an Executor that schedules tasks on a background thread. Only use this
+// executor when you need your tasks to run on a `QThread`. If not, using the global instance of
+// `orbit_base::ThreadPool` is the better option.
+class SingleThreadExecutor : public QObject, public orbit_base::Executor {
+  Q_OBJECT
+
+ public:
+  explicit SingleThreadExecutor(QObject* parent = nullptr);
+  ~SingleThreadExecutor() override;
+
+  [[nodiscard]] const QThread* GetThread() const { return &thread; }
+  [[nodiscard]] QThread* GetThread() { return &thread; }
+
+  [[nodiscard]] Handle GetExecutorHandle() const override { return executor_handle_.Get(); }
+
+ private:
+  void ScheduleImpl(std::unique_ptr<Action> action) override;
+
+  QThread thread{};
+  QObject context{};
+  ScopedHandle executor_handle_{this};
+};
+
+}  // namespace orbit_qt_utils
+
+#endif  // QT_UTILS_SINGLE_THREAD_EXECUTOR_H_


### PR DESCRIPTION
This is adding a new type of `Executor` where tasks will be scheduled on a single background thread. The Executor is meant for code that interacts with Qt. The background thread is created and managed by a `QThread` which makes it interact well with Qt slots that should also run on the same background QThread.