### PR TITLE
Remove shared_ptr from Executor

### DIFF
--- a/src/DataViews/PresetsDataView.cpp
+++ b/src/DataViews/PresetsDataView.cpp
@@ -78,9 +78,7 @@ std::string GetDateModifiedString(const PresetFile& preset) {
 
 namespace orbit_data_views {
 
-PresetsDataView::PresetsDataView(AppInterface* app)
-    : DataView(DataViewType::kPresets, app),
-      main_thread_executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()) {}
+PresetsDataView::PresetsDataView(AppInterface* app) : DataView(DataViewType::kPresets, app) {}
 
 std::string PresetsDataView::GetModulesList(absl::Span<const ModuleView> modules) {
   return absl::StrJoin(modules, "\n", [](std::string* out, const ModuleView& module) {
@@ -203,7 +201,7 @@ DataView::ActionStatus PresetsDataView::GetActionStatus(std::string_view action,
 
 void PresetsDataView::OnLoadPresetRequested(absl::Span<const int> selection) {
   PresetFile& preset = GetMutablePreset(selection[0]);
-  (void)app_->LoadPreset(preset).ThenIfSuccess(main_thread_executor_.get(),
+  (void)app_->LoadPreset(preset).ThenIfSuccess(&main_thread_executor_,
                                                [this, preset_file_path = preset.file_path()]() {
                                                  OnLoadPresetSuccessful(preset_file_path);
                                                });
@@ -232,7 +230,7 @@ void PresetsDataView::OnShowInExplorerRequested(absl::Span<const int> selection)
 void PresetsDataView::OnDoubleClicked(int index) {
   PresetFile& preset = GetMutablePreset(index);
   if (app_->GetPresetLoadState(preset).state != PresetLoadState::kNotLoadable) {
-    (void)app_->LoadPreset(preset).ThenIfSuccess(main_thread_executor_.get(),
+    (void)app_->LoadPreset(preset).ThenIfSuccess(&main_thread_executor_,
                                                  [this, preset_file_path = preset.file_path()]() {
                                                    OnLoadPresetSuccessful(preset_file_path);
                                                  });

--- a/src/DataViews/include/DataViews/PresetsDataView.h
+++ b/src/DataViews/include/DataViews/PresetsDataView.h
@@ -19,8 +19,8 @@
 #include "ClientProtos/preset.pb.h"
 #include "DataViews/AppInterface.h"
 #include "DataViews/DataView.h"
-#include "OrbitBase/MainThreadExecutor.h"
 #include "PresetFile/PresetFile.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
 
 namespace orbit_data_views {
 class PresetsDataView : public DataView {
@@ -86,7 +86,7 @@ class PresetsDataView : public DataView {
  private:
   [[nodiscard]] orbit_preset_file::PresetFile& GetMutablePreset(unsigned int row);
 
-  std::shared_ptr<orbit_base::MainThreadExecutor> main_thread_executor_;
+  orbit_qt_utils::MainThreadExecutorImpl main_thread_executor_;
 };
 
 }  // namespace orbit_data_views

--- a/src/MizarData/MizarData.cpp
+++ b/src/MizarData/MizarData.cpp
@@ -118,8 +118,7 @@ void MizarData::LoadSymbolsForAllModules() {
 }
 
 static ErrorMessageOr<std::filesystem::path> SearchSymbolsPathInOrbitSearchPaths(
-    const orbit_symbols::SymbolHelper& symbol_helper,
-    const orbit_client_data::ModuleData& module_data) {
+    orbit_symbols::SymbolHelper& symbol_helper, const orbit_client_data::ModuleData& module_data) {
   // These are the constants used by Orbit Client. This way we read its configs.
   static const QString kOrbitOrganization = QStringLiteral("The Orbit Authors");
   static const QString kOrbitAppName = QStringLiteral("orbitprofiler");
@@ -136,8 +135,7 @@ static void LogSymbolsFound(std::string_view module_path, std::string_view symbo
 }
 
 static ErrorMessageOr<std::filesystem::path> FindSymbolsPath(
-    const orbit_symbols::SymbolHelper& symbol_helper,
-    const orbit_client_data::ModuleData& module_data) {
+    orbit_symbols::SymbolHelper& symbol_helper, const orbit_client_data::ModuleData& module_data) {
   if (auto symbols_paths_or_error = SearchSymbolsPathInOrbitSearchPaths(symbol_helper, module_data);
       symbols_paths_or_error.has_value()) {
     LogSymbolsFound(module_data.file_path(), symbols_paths_or_error.value().string());

--- a/src/OrbitBase/SimpleExecutor.cpp
+++ b/src/OrbitBase/SimpleExecutor.cpp
@@ -30,9 +30,4 @@ void SimpleExecutor::ExecuteScheduledTasks() {
     scheduled_tasks_.pop_front();
   }
 }
-
-std::shared_ptr<SimpleExecutor> SimpleExecutor::Create() {
-  // NOLINTNEXTLINE
-  return std::shared_ptr<SimpleExecutor>{new SimpleExecutor{}};
-}
 }  // namespace orbit_base

--- a/src/OrbitBase/SimpleExecutorTest.cpp
+++ b/src/OrbitBase/SimpleExecutorTest.cpp
@@ -15,47 +15,47 @@
 namespace orbit_base {
 
 TEST(SimpleExecutor, ScheduledTaskShouldBeCalledSimpleWithVoid) {
-  auto executor = SimpleExecutor::Create();
+  SimpleExecutor executor{};
   bool called = false;
-  auto future = executor->Schedule([&called]() { called = true; });
-  executor->ExecuteScheduledTasks();
+  auto future = executor.Schedule([&called]() { called = true; });
+  executor.ExecuteScheduledTasks();
   EXPECT_TRUE(called);
   EXPECT_TRUE(future.IsFinished());
 }
 
 TEST(SimpleExecutor, ScheduledTaskShouldBeCalledSimpleWithInt) {
-  auto executor = SimpleExecutor::Create();
+  SimpleExecutor executor{};
   bool called = false;
-  auto future = executor->Schedule([&called]() {
+  auto future = executor.Schedule([&called]() {
     called = true;
     return 42;
   });
-  executor->ExecuteScheduledTasks();
+  executor.ExecuteScheduledTasks();
   EXPECT_TRUE(called);
   ASSERT_TRUE(future.IsFinished());
   EXPECT_EQ(future.Get(), 42);
 }
 
 TEST(SimpleExecutor, ChainedTaskedShouldBeCalledSimple) {
-  auto executor = SimpleExecutor::Create();
+  SimpleExecutor executor{};
   bool called = false;
   Promise<void> promise{};
   auto future = promise.GetFuture();
-  auto chained_future = executor->ScheduleAfter(future, [&called]() { called = true; });
+  auto chained_future = executor.ScheduleAfter(future, [&called]() { called = true; });
   EXPECT_FALSE(called);
   EXPECT_FALSE(chained_future.IsFinished());
   promise.MarkFinished();
-  executor->ExecuteScheduledTasks();
+  executor.ExecuteScheduledTasks();
   EXPECT_TRUE(called);
   EXPECT_TRUE(chained_future.IsFinished());
 }
 
 TEST(SimpleExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorVoid) {
-  auto executor = SimpleExecutor::Create();
+  SimpleExecutor executor{};
   bool called = false;
   Promise<ErrorMessageOr<void>> promise{};
   auto future = promise.GetFuture();
-  auto chained_future = executor->ScheduleAfterIfSuccess(future, [&called]() { called = true; });
+  auto chained_future = executor.ScheduleAfterIfSuccess(future, [&called]() { called = true; });
   EXPECT_FALSE(called);
   EXPECT_FALSE(chained_future.IsFinished());
 
@@ -63,7 +63,7 @@ TEST(SimpleExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorVoid) {
   promise.SetResult(ErrorMessage{kErrorMessage});
   EXPECT_TRUE(chained_future.IsFinished());
 
-  executor->ExecuteScheduledTasks();
+  executor.ExecuteScheduledTasks();
   EXPECT_FALSE(called);
   ASSERT_TRUE(chained_future.IsFinished());
   EXPECT_TRUE(chained_future.Get().has_error());
@@ -71,22 +71,22 @@ TEST(SimpleExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorVoid) {
 }
 
 TEST(SimpleExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorInt) {
-  auto executor = SimpleExecutor::Create();
+  SimpleExecutor executor{};
   bool called = false;
   Promise<ErrorMessageOr<int>> promise{};
   auto future = promise.GetFuture();
-  auto chained_future = executor->ScheduleAfterIfSuccess(future, [&called](int value) {
+  auto chained_future = executor.ScheduleAfterIfSuccess(future, [&called](int value) {
     EXPECT_EQ(value, 42);
     called = true;
     return 1 + value;
   });
-  executor->ExecuteScheduledTasks();
+  executor.ExecuteScheduledTasks();
   EXPECT_FALSE(called);
   EXPECT_FALSE(chained_future.IsFinished());
 
   constexpr const char* const kErrorMessage{"Error"};
   promise.SetResult(ErrorMessage{kErrorMessage});
-  executor->ExecuteScheduledTasks();
+  executor.ExecuteScheduledTasks();
   EXPECT_FALSE(called);
   ASSERT_TRUE(chained_future.IsFinished());
   EXPECT_TRUE(chained_future.Get().has_error());
@@ -94,38 +94,38 @@ TEST(SimpleExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorInt) {
 }
 
 TEST(SimpleExecutor, ScheduleAfterIfSuccessCallOnSuccessVoid) {
-  auto executor = SimpleExecutor::Create();
+  SimpleExecutor executor{};
   bool called = false;
   Promise<ErrorMessageOr<void>> promise{};
   auto future = promise.GetFuture();
-  auto chained_future = executor->ScheduleAfterIfSuccess(future, [&called]() { called = true; });
-  executor->ExecuteScheduledTasks();
+  auto chained_future = executor.ScheduleAfterIfSuccess(future, [&called]() { called = true; });
+  executor.ExecuteScheduledTasks();
   EXPECT_FALSE(called);
   EXPECT_FALSE(chained_future.IsFinished());
 
   promise.SetResult(outcome::success());
-  executor->ExecuteScheduledTasks();
+  executor.ExecuteScheduledTasks();
   EXPECT_TRUE(called);
   ASSERT_TRUE(chained_future.IsFinished());
   EXPECT_FALSE(chained_future.Get().has_error());
 }
 
 TEST(SimpleExecutor, ScheduleAfterIfSuccessCallOnSuccessInt) {
-  auto executor = SimpleExecutor::Create();
+  SimpleExecutor executor{};
   bool called = false;
   Promise<ErrorMessageOr<int>> promise{};
   auto future = promise.GetFuture();
-  auto chained_future = executor->ScheduleAfterIfSuccess(future, [&called](int value) {
+  auto chained_future = executor.ScheduleAfterIfSuccess(future, [&called](int value) {
     EXPECT_EQ(value, 42);
     called = true;
     return 1 + value;
   });
-  executor->ExecuteScheduledTasks();
+  executor.ExecuteScheduledTasks();
   EXPECT_FALSE(called);
   EXPECT_FALSE(chained_future.IsFinished());
 
   promise.SetResult(42);
-  executor->ExecuteScheduledTasks();
+  executor.ExecuteScheduledTasks();
   EXPECT_TRUE(called);
   ASSERT_TRUE(chained_future.IsFinished());
   EXPECT_FALSE(chained_future.Get().has_error());

--- a/src/OrbitBase/include/OrbitBase/SimpleExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/SimpleExecutor.h
@@ -23,15 +23,12 @@ namespace orbit_base {
 // until they call `ExecuteScheduledTasks` which will synchronously
 // execute waiting tasks.
 class SimpleExecutor : public Executor {
-  explicit SimpleExecutor() = default;
-
   void ScheduleImpl(std::unique_ptr<Action> action) override;
   [[nodiscard]] Handle GetExecutorHandle() const override { return executor_handle_.Get(); }
 
  public:
+  explicit SimpleExecutor() = default;
   void ExecuteScheduledTasks();
-
-  [[nodiscard]] static std::shared_ptr<SimpleExecutor> Create();
 
  private:
   absl::Mutex mutex_;

--- a/src/OrbitGl/SymbolLoader.cpp
+++ b/src/OrbitGl/SymbolLoader.cpp
@@ -269,7 +269,7 @@ static ErrorMessageOr<std::optional<std::filesystem::path>> GetOverrideSymbolFil
 }
 
 static ErrorMessageOr<std::filesystem::path> FindModuleLocallyImpl(
-    const orbit_symbols::SymbolHelper& symbol_helper, const ModuleData& module_data) {
+    orbit_symbols::SymbolHelper& symbol_helper, const ModuleData& module_data) {
   ORBIT_SCOPE_FUNCTION;
   if (absl::GetFlag(FLAGS_enable_unsafe_symbols)) {
     // First checkout if a symbol file override exists and if it does, use it

--- a/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
+++ b/src/OrbitQt/AnnotatingSourceCodeDialog.cpp
@@ -33,7 +33,7 @@ void AnnotatingSourceCodeDialog::AddAnnotatingSourceCode(
 
   ORBIT_CHECK(function_info_.has_value());
   retrieve_module_with_debug_info_(function_info_->module_id())
-      .Then(main_thread_executor_.get(),
+      .Then(&main_thread_executor_,
             [this](const ErrorMessageOr<std::filesystem::path>& local_file_path_or_error) {
               HandleDebugInfo(local_file_path_or_error);
             });

--- a/src/OrbitQt/include/OrbitQt/AnnotatingSourceCodeDialog.h
+++ b/src/OrbitQt/include/OrbitQt/AnnotatingSourceCodeDialog.h
@@ -91,8 +91,6 @@ class AnnotatingSourceCodeDialog : public orbit_code_viewer::Dialog {
   RetrieveModuleWithDebugInfoCallback retrieve_module_with_debug_info_;
 
   std::chrono::steady_clock::time_point starting_time_ = std::chrono::steady_clock::now();
-  std::shared_ptr<orbit_base::MainThreadExecutor> main_thread_executor_ =
-      orbit_qt_utils::MainThreadExecutorImpl::Create();
 
   enum class ButtonAction { kNone, kChooseFile, kAddAnnotations, kHide };
   ButtonAction awaited_button_action_ = ButtonAction::kNone;
@@ -101,6 +99,9 @@ class AnnotatingSourceCodeDialog : public orbit_code_viewer::Dialog {
   std::unique_ptr<orbit_object_utils::ElfFile> elf_file_;
   orbit_grpc_protos::LineInfo location_info_;
   std::vector<orbit_code_report::AnnotatingLine> annotations_;
+
+  // Keep the executor at the bottom of the list of members, so that it's destroyed first.
+  orbit_qt_utils::MainThreadExecutorImpl main_thread_executor_{};
 };
 
 // This function opens the given dialog and ensures it is deleted when closed.

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -270,7 +270,6 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   std::optional<QString> LoadSourceCode(const std::filesystem::path& file_path);
 
-  std::shared_ptr<orbit_base::MainThreadExecutor> main_thread_executor_;
   std::unique_ptr<OrbitApp> app_;
   Ui::OrbitMainWindow* ui;
   FilterPanelWidgetAction* filter_panel_action_ = nullptr;
@@ -309,6 +308,9 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   // to a file, it is not connected and this bool is false. This is also false when the connection
   // broke.
   bool is_connected_ = false;
+
+  // Keep this at the bottom of the member list, so that it's destroyed first!
+  orbit_qt_utils::MainThreadExecutorImpl main_thread_executor_;
 };
 
 #endif  // ORBIT_QT_ORBIT_MAIN_WINDOW_H_

--- a/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
+++ b/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
@@ -21,12 +21,9 @@ namespace orbit_qt_utils {
 // An implementation of MainThreadExecutor that integrates with Qt's event loop
 class MainThreadExecutorImpl : public QObject, public orbit_base::MainThreadExecutor {
   Q_OBJECT
-  explicit MainThreadExecutorImpl(QObject* parent = nullptr) : QObject(parent) {}
 
  public:
-  [[nodiscard]] static std::shared_ptr<MainThreadExecutorImpl> Create() {
-    return std::shared_ptr<MainThreadExecutorImpl>{new MainThreadExecutorImpl{}};
-  }
+  explicit MainThreadExecutorImpl(QObject* parent = nullptr) : QObject(parent) {}
 
   WaitResult WaitFor(const orbit_base::Future<void>& future,
                      std::chrono::milliseconds timeout) override;

--- a/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderIntegrationTest.cpp
+++ b/src/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProviderIntegrationTest.cpp
@@ -55,8 +55,7 @@ TEST(MicrosoftSymbolServerSymbolProviderIntegrationTest, RetrieveWindowsPdbAndLo
   orbit_http::HttpDownloadManager download_manager{};
   MicrosoftSymbolServerSymbolProvider symbol_provider{&symbol_cache, &download_manager};
 
-  std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> executor{
-      orbit_qt_utils::MainThreadExecutorImpl::Create()};
+  orbit_qt_utils::MainThreadExecutorImpl executor{};
 
   const std::string valid_module_name{"d3d11.pdb"};
   const std::string valid_module_build_id{"FF5440275BFED43A86CC2B1F287A72151"};
@@ -65,7 +64,7 @@ TEST(MicrosoftSymbolServerSymbolProviderIntegrationTest, RetrieveWindowsPdbAndLo
   orbit_base::StopSource stop_source{};
 
   symbol_provider.RetrieveSymbols(valid_module_id, stop_source.GetStopToken())
-      .Then(executor.get(), [](const orbit_symbol_provider::SymbolLoadingOutcome& result) {
+      .Then(&executor, [](const orbit_symbol_provider::SymbolLoadingOutcome& result) {
         ASSERT_TRUE(orbit_symbol_provider::IsSuccessResult(result));
         orbit_symbol_provider::SymbolLoadingSuccessResult success_result =
             orbit_symbol_provider::GetSuccessResult(result);

--- a/src/RemoteSymbolProvider/include/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h
+++ b/src/RemoteSymbolProvider/include/RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h
@@ -12,6 +12,7 @@
 #include "OrbitBase/Future.h"
 #include "OrbitBase/MainThreadExecutor.h"
 #include "OrbitBase/StopToken.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
 #include "SymbolProvider/ModuleIdentifier.h"
 #include "SymbolProvider/SymbolLoadingOutcome.h"
 #include "SymbolProvider/SymbolProvider.h"
@@ -27,7 +28,7 @@ class MicrosoftSymbolServerSymbolProvider : public orbit_symbol_provider::Symbol
 
   [[nodiscard]] orbit_base::Future<orbit_symbol_provider::SymbolLoadingOutcome> RetrieveSymbols(
       const orbit_symbol_provider::ModuleIdentifier& module_id,
-      orbit_base::StopToken stop_token) const override;
+      orbit_base::StopToken stop_token) override;
 
  private:
   [[nodiscard]] static std::string GetDownloadUrl(
@@ -35,7 +36,7 @@ class MicrosoftSymbolServerSymbolProvider : public orbit_symbol_provider::Symbol
 
   const orbit_symbols::SymbolCacheInterface* symbol_cache_;
   orbit_http::DownloadManager* download_manager_;
-  std::shared_ptr<orbit_base::MainThreadExecutor> main_thread_executor_;
+  orbit_qt_utils::MainThreadExecutorImpl main_thread_executor_;
 };
 
 }  // namespace orbit_remote_symbol_provider

--- a/src/SessionSetup/ConnectToTargetDialog.cpp
+++ b/src/SessionSetup/ConnectToTargetDialog.cpp
@@ -38,8 +38,7 @@ ConnectToTargetDialog::ConnectToTargetDialog(SshConnectionArtifacts* ssh_connect
     : QDialog{parent, Qt::Window},
       ui_(std::make_unique<Ui::ConnectToTargetDialog>()),
       ssh_connection_artifacts_(ssh_connection_artifacts),
-      target_(target),
-      main_thread_executor_(orbit_qt_utils::MainThreadExecutorImpl::Create()) {
+      target_(target) {
   ORBIT_CHECK(ssh_connection_artifacts != nullptr);
 
   ui_->setupUi(this);
@@ -51,7 +50,7 @@ ConnectToTargetDialog::ConnectToTargetDialog(SshConnectionArtifacts* ssh_connect
   setFixedSize(window()->sizeHint());
 }
 
-ConnectToTargetDialog::~ConnectToTargetDialog() {}
+ConnectToTargetDialog::~ConnectToTargetDialog() = default;
 
 std::optional<TargetConfiguration> ConnectToTargetDialog::Exec() {
   const std::string status_message =
@@ -64,7 +63,7 @@ std::optional<TargetConfiguration> ConnectToTargetDialog::Exec() {
 
   // The call to `DeployOrbitServiceAndSetupProcessManager` is scheduled on the
   // main thread, so it happens after the dialog is shown (via call to `Exec`).
-  main_thread_executor_->Schedule([this]() {
+  main_thread_executor_.Schedule([this]() {
     ErrorMessageOr<void> deploy_result = DeployOrbitServiceAndSetupProcessManager();
     if (deploy_result.has_error()) {
       LogAndDisplayError(deploy_result.error());

--- a/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
+++ b/src/SessionSetup/include/SessionSetup/ConnectToTargetDialog.h
@@ -46,10 +46,11 @@ class ConnectToTargetDialog : public QDialog {
   SshConnectionArtifacts* ssh_connection_artifacts_;
   ConnectionTarget target_;
 
-  std::shared_ptr<orbit_qt_utils::MainThreadExecutorImpl> main_thread_executor_;
-
   std::optional<orbit_session_setup::SshConnection> ssh_connection_;
   std::optional<TargetConfiguration> target_configuration_;
+
+  // Keep the executor at the bottom of the members, so that it's destructed first!
+  orbit_qt_utils::MainThreadExecutorImpl main_thread_executor_;
 
   void OnProcessListUpdate(std::vector<orbit_grpc_protos::ProcessInfo> process_list);
 

--- a/src/SymbolProvider/StructuredDebugDirectorySymbolProvider.cpp
+++ b/src/SymbolProvider/StructuredDebugDirectorySymbolProvider.cpp
@@ -18,7 +18,7 @@
 namespace orbit_symbol_provider {
 
 orbit_base::Future<SymbolLoadingOutcome> StructuredDebugDirectorySymbolProvider::RetrieveSymbols(
-    const ModuleIdentifier& module_id, orbit_base::StopToken /*stop_token*/) const {
+    const ModuleIdentifier& module_id, orbit_base::StopToken /*stop_token*/) {
   return {FindSymbolFile(module_id.build_id)};
 }
 

--- a/src/SymbolProvider/StructuredDebugDirectorySymbolProviderTest.cpp
+++ b/src/SymbolProvider/StructuredDebugDirectorySymbolProviderTest.cpp
@@ -32,8 +32,8 @@ class StructuredDebugDirectorySymbolProviderTest : public ::testing::Test {
       : symbol_provider_(orbit_test::GetTestdataDir() / "debugstore", kSymbolSource) {}
 
  protected:
-  const StructuredDebugDirectorySymbolProvider symbol_provider_;
-  const orbit_base::StopSource stop_source_;
+  StructuredDebugDirectorySymbolProvider symbol_provider_;
+  orbit_base::StopSource stop_source_;
 };
 
 TEST_F(StructuredDebugDirectorySymbolProviderTest, RetrieveSymbolsSuccessfully) {

--- a/src/SymbolProvider/include/SymbolProvider/StructuredDebugDirectorySymbolProvider.h
+++ b/src/SymbolProvider/include/SymbolProvider/StructuredDebugDirectorySymbolProvider.h
@@ -26,7 +26,7 @@ class StructuredDebugDirectorySymbolProvider : public SymbolProvider {
       : directory_(std::move(directory)), symbol_source_(symbol_source) {}
 
   [[nodiscard]] orbit_base::Future<SymbolLoadingOutcome> RetrieveSymbols(
-      const ModuleIdentifier& module_id, orbit_base::StopToken stop_token) const override;
+      const ModuleIdentifier& module_id, orbit_base::StopToken stop_token) override;
 
  private:
   [[nodiscard]] SymbolLoadingOutcome FindSymbolFile(std::string_view build_id) const;

--- a/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
+++ b/src/SymbolProvider/include/SymbolProvider/SymbolProvider.h
@@ -19,7 +19,7 @@ class SymbolProvider {
   virtual ~SymbolProvider() = default;
 
   [[nodiscard]] virtual orbit_base::Future<SymbolLoadingOutcome> RetrieveSymbols(
-      const ModuleIdentifier& module_id, orbit_base::StopToken stop_token) const = 0;
+      const ModuleIdentifier& module_id, orbit_base::StopToken stop_token) = 0;
 };
 
 }  // namespace orbit_symbol_provider

--- a/src/Symbols/SymbolHelper.cpp
+++ b/src/Symbols/SymbolHelper.cpp
@@ -186,7 +186,7 @@ SymbolHelper::SymbolHelper(std::filesystem::path cache_directory,
 
 ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
     const fs::path& module_path, std::string_view build_id,
-    const ModuleInfo::ObjectFileType& object_file_type, absl::Span<const fs::path> paths) const {
+    const ModuleInfo::ObjectFileType& object_file_type, absl::Span<const fs::path> paths) {
   ORBIT_SCOPE_FUNCTION;
   if (build_id.empty()) {
     return ErrorMessage(absl::StrFormat(
@@ -196,7 +196,7 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsFileLocally(
 
   // structured debug directories is only supported for elf files
   if (object_file_type == ModuleInfo::kElfFile) {
-    for (const auto& provider : structured_debug_directory_providers_) {
+    for (auto& provider : structured_debug_directory_providers_) {
       const ModuleIdentifier module_id{module_path.string(), std::string{build_id}};
       const orbit_base::StopSource stop_source;
       orbit_base::Future<SymbolLoadingOutcome> future =

--- a/src/Symbols/include/Symbols/SymbolHelper.h
+++ b/src/Symbols/include/Symbols/SymbolHelper.h
@@ -35,7 +35,7 @@ class SymbolHelper : public SymbolCacheInterface {
   [[nodiscard]] ErrorMessageOr<std::filesystem::path> FindSymbolsFileLocally(
       const std::filesystem::path& module_path, std::string_view build_id,
       const orbit_grpc_protos::ModuleInfo::ObjectFileType& object_file_type,
-      absl::Span<const std::filesystem::path> paths) const;
+      absl::Span<const std::filesystem::path> paths);
   [[nodiscard]] ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(
       const std::filesystem::path& module_path, std::string_view build_id) const;
   [[nodiscard]] ErrorMessageOr<std::filesystem::path> FindSymbolsInCache(


### PR DESCRIPTION
After #4670 we don't require Executors anymore to be wrapped in a `shared_ptr`. So this change removes all those shared_ptrs and replaces them by values.

This simplifies the code because instances can now be default constructed.

This PR is rather large because it contains a lot of mechanical changes. (Mainly replacing `operator->` by the dot operator). There were also some clang-tidy induced changes to HttpDownloadManagerTest which are unrelated but happened in the same lines of code.

I also had to remove constness from some symbol loading related functions (`SymbolProvider/*`, `Symbols/*`, `OrbitGl/SymbolLoader.cpp`). Otherwise these functions wouldn't be able to Schedule background tasks on a by-value-accessed executor. That's probably the most intrusive change in this PR.