### PR TITLE
Assure that visible tracks are only accessed in the main thread

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -46,8 +46,9 @@ namespace orbit_gl {
 TrackManager::TrackManager(TrackContainer* track_container, TimelineInfoInterface* timeline_info,
                            Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
                            const orbit_client_data::ModuleManager* module_manager,
-                           orbit_client_data::CaptureData* capture_data, std::thread::id thread_id)
-    : main_thread_id_(thread_id),
+                           orbit_client_data::CaptureData* capture_data,
+                           std::thread::id main_thread_id)
+    : main_thread_id_(main_thread_id),
       viewport_(viewport),
       layout_(layout),
       module_manager_(module_manager),

--- a/src/OrbitGl/include/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/include/OrbitGl/TrackManager.h
@@ -54,7 +54,7 @@ class TrackManager {
                         Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
                         const orbit_client_data::ModuleManager* module_manager,
                         orbit_client_data::CaptureData* capture_data,
-                        std::thread::id thread_id = std::this_thread::get_id());
+                        std::thread::id main_thread_id = std::this_thread::get_id());
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
   [[nodiscard]] const std::vector<Track*>& GetVisibleTracks() const { return visible_tracks_; }


### PR DESCRIPTION
In this PR we are fixing a bug. `AddFrameTrack()` was executed in the capture_thread but was modifying the sorted_tracks_ array that should be only modified in the main_thread. Since sorting was executed once per second, I don't expect to have had a single issue in the past but it's better to fix it.

So, in this PR we are doing a few things:
- Assure all methods access `visible_tracks_` and `sorted_tracks` only in the `main_thread_`.
- Delay the insertion of FrameTracks in a similar way that we delay its deletion. 
  - We use a new `pending_frame_tracks` which is also locked by the mutex. 
- `all_tracks_` include all the tracks now (frame tracks included).
- Improve our comments to explain which containers are accessed by both threads and which one should be accessed only by `main_thread_`.

Test: Load a capture.