### PR TITLE
Move summary logic to PostProcessor

### DIFF
--- a/src/ClientModel/include/ClientModel/SamplingDataPostProcessor.h
+++ b/src/ClientModel/include/ClientModel/SamplingDataPostProcessor.h
@@ -14,7 +14,7 @@ namespace orbit_client_model {
 orbit_client_data::PostProcessedSamplingData CreatePostProcessedSamplingData(
     const orbit_client_data::CallstackData& callstack_data,
     const orbit_client_data::CaptureData& capture_data,
-    const orbit_client_data::ModuleManager& module_manager, bool generate_summary = true);
+    const orbit_client_data::ModuleManager& module_manager);
 }  // namespace orbit_client_model
 
 #endif  // CLIENT_MODEL_SAMPLING_DATA_POST_PROCESSOR_H_

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -223,7 +223,7 @@ void CallstackThreadBar::SelectCallstacks() {
           ? capture_data_->GetCallstackData().GetCallstackEventsInTimeRange(t0, t1)
           : capture_data_->GetCallstackData().GetCallstackEventsOfTidInTimeRange(thread_id, t0, t1);
 
-  app_->SelectCallstackEvents(selected_callstack_events, thread_id_is_all_threads);
+  app_->SelectCallstackEvents(selected_callstack_events);
 }
 
 bool CallstackThreadBar::IsEmpty() const {

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -29,12 +29,10 @@ using orbit_client_data::ThreadSampleData;
 
 SamplingReport::SamplingReport(
     OrbitApp* app, const orbit_client_data::CallstackData* callstack_data,
-    const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data,
-    bool has_summary)
+    const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data)
     : app_{app},
       callstack_data_{callstack_data},
-      post_processed_sampling_data_{post_processed_sampling_data},
-      has_summary_{has_summary} {
+      post_processed_sampling_data_{post_processed_sampling_data} {
   ORBIT_SCOPE_FUNCTION;
   ORBIT_SCOPED_TIMED_LOG("SamplingReport::SamplingReport");
   ORBIT_CHECK(callstack_data_ != nullptr);

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -217,8 +217,7 @@ class OrbitApp final : public DataViewFactory,
   void ClearSamplingReport();
   void SetSelectionReport(
       const orbit_client_data::CallstackData* selection_callstack_data,
-      const orbit_client_data::PostProcessedSamplingData* selection_post_processed_sampling_data,
-      bool has_summary);
+      const orbit_client_data::PostProcessedSamplingData* selection_post_processed_sampling_data);
   void ClearSelectionReport();
   void SetTopDownView(const orbit_client_data::PostProcessedSamplingData& post_processed_data);
   void ClearTopDownView();
@@ -402,11 +401,9 @@ class OrbitApp final : public DataViewFactory,
   // origin_is_multiple_threads defines if the selection is specific to a single thread,
   // or spans across multiple threads.
   void SelectCallstackEvents(
-      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events,
-      bool origin_is_multiple_threads);
+      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events);
   void InspectCallstackEvents(
-      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events,
-      bool origin_is_multiple_threads);
+      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events);
   void ClearInspection();
   void ClearSelectionTabs();
 
@@ -541,8 +538,7 @@ class OrbitApp final : public DataViewFactory,
 
   // Sets CaptureData's selection_callstack_data and selection_post_processed_sampling_data.
   void SetCaptureDataSelectionFields(
-      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events,
-      bool origin_is_multiple_threads);
+      absl::Span<const orbit_client_data::CallstackEvent> selected_callstack_events);
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<orbit_client_data::CaptureData::DataSource> data_source_{

--- a/src/OrbitGl/include/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/include/OrbitGl/SamplingReport.h
@@ -32,8 +32,7 @@ class SamplingReport : public orbit_data_views::SamplingReportInterface {
  public:
   explicit SamplingReport(
       OrbitApp* app, const orbit_client_data::CallstackData* callstack_data,
-      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data,
-      bool has_summary = true);
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data);
   void UpdateReport(
       const orbit_client_data::CallstackData* callstack_data,
       const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data);
@@ -54,7 +53,6 @@ class SamplingReport : public orbit_data_views::SamplingReportInterface {
   [[nodiscard]] bool HasCallstacks() const { return selected_sorted_callstack_report_ != nullptr; };
   [[nodiscard]] bool HasSamples() const { return !thread_data_views_.empty(); }
   [[nodiscard]] double ComputeUnwindErrorRatio(uint32_t thread_id) const;
-  [[nodiscard]] bool has_summary() const { return has_summary_; }
   void ClearReport();
   [[nodiscard]] const orbit_client_data::CallstackData& GetCallstackData() const override;
   [[nodiscard]] std::optional<absl::flat_hash_set<uint64_t>> GetSelectedCallstackIds()
@@ -78,7 +76,6 @@ class SamplingReport : public orbit_data_views::SamplingReportInterface {
       nullptr;
   size_t selected_callstack_index_ = 0;
   std::function<void()> ui_refresh_func_;
-  bool has_summary_;
 };
 
 #endif  // ORBIT_GL_SAMPLING_REPORT_H_

--- a/src/OrbitQt/CallTreeViewItemModelTest.cpp
+++ b/src/OrbitQt/CallTreeViewItemModelTest.cpp
@@ -156,8 +156,8 @@ TEST(CallTreeViewItemModel, GetDisplayRoleData) {
   std::unique_ptr<CaptureData> capture_data = GenerateTestCaptureData();
   orbit_client_data::ModuleManager module_manager{};
   orbit_client_data::PostProcessedSamplingData sampling_data =
-      orbit_client_model::CreatePostProcessedSamplingData(
-          capture_data->GetCallstackData(), *capture_data, module_manager);
+      orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
+                                                          *capture_data, module_manager);
 
   auto call_tree_view = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
       sampling_data, module_manager, *capture_data);
@@ -325,8 +325,8 @@ TEST(CallTreeViewItemModel, GetEditRoleData) {
   std::unique_ptr<CaptureData> capture_data = GenerateTestCaptureData();
   orbit_client_data::ModuleManager module_manager{};
   orbit_client_data::PostProcessedSamplingData sampling_data =
-      orbit_client_model::CreatePostProcessedSamplingData(
-          capture_data->GetCallstackData(), *capture_data, module_manager);
+      orbit_client_model::CreatePostProcessedSamplingData(capture_data->GetCallstackData(),
+                                                          *capture_data, module_manager);
 
   auto call_tree_view = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
       sampling_data, module_manager, *capture_data);

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -754,34 +754,20 @@ void CallTreeWidget::OnCustomContextMenuRequested(const QPoint& point) {
     absl::flat_hash_set<orbit_client_data::CallstackEvent> selected_callstack_events =
         GetCallstackEventsUnderSelection(selected_tree_indices);
     ORBIT_CHECK(!selected_callstack_events.empty());
-    bool origin_is_multiple_threads =
-        std::any_of(selected_callstack_events.begin(), selected_callstack_events.end(),
-                    [first_callstack_event = *selected_callstack_events.begin()](
-                        const orbit_client_data::CallstackEvent& callstack_event) -> bool {
-                      return callstack_event.thread_id() != first_callstack_event.thread_id();
-                    });
     app_->InspectCallstackEvents(
         // This copies the content of the absl::flat_hash_set into a std::vector. We consider this
         // fine in order to keep OrbitApp::InspectCallstackEvents as simple as it is now.
         std::vector<orbit_client_data::CallstackEvent>{selected_callstack_events.begin(),
-                                                       selected_callstack_events.end()},
-        origin_is_multiple_threads);
+                                                       selected_callstack_events.end()});
   } else if (action->text() == kActionSelectCallstacks) {
     absl::flat_hash_set<orbit_client_data::CallstackEvent> selected_callstack_events =
         GetCallstackEventsUnderSelection(selected_tree_indices);
     ORBIT_CHECK(!selected_callstack_events.empty());
-    bool origin_is_multiple_threads =
-        std::any_of(selected_callstack_events.begin(), selected_callstack_events.end(),
-                    [first_callstack_event = *selected_callstack_events.begin()](
-                        const orbit_client_data::CallstackEvent& callstack_event) -> bool {
-                      return callstack_event.thread_id() != first_callstack_event.thread_id();
-                    });
     app_->SelectCallstackEvents(
         // This copies the content of the absl::flat_hash_set into a std::vector. We consider this
         // fine in order to keep OrbitApp::SelectCallstackEvents as simple as it is now.
         std::vector<orbit_client_data::CallstackEvent>{selected_callstack_events.begin(),
-                                                       selected_callstack_events.end()},
-        origin_is_multiple_threads);
+                                                       selected_callstack_events.end()});
   } else if (action->text() == kActionCopySelection) {
     app_->SetClipboard(BuildStringFromIndices(
         ui_->callTreeTreeView, ui_->callTreeTreeView->selectionModel()->selectedIndexes()));


### PR DESCRIPTION
Currently, we only calculate the summary if there are more than one thread involved.  In time range selection, like with inspections, we don't whether there is more than one thread involved until we go through all the callstacks selected. This moves the logic for calculating this to one place.

This also removes tests that tested one thread+summary or multiple threads+no summary which isn't supposed to happen in practice.