### PR TITLE
Improve performance of `ProvideId` method

### DIFF
--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -67,23 +67,8 @@ std::optional<ScopeId> NameEqualityScopeIdProvider::FunctionIdToScopeId(
   return ScopeId(function_id);
 }
 
-[[nodiscard]] static ScopeType ScopeTypeFromTimerInfo(const TimerInfo& timer) {
-  switch (timer.type()) {
-    case TimerInfo::kNone:
-      return timer.function_id() != orbit_grpc_protos::kInvalidFunctionId
-                 ? ScopeType::kDynamicallyInstrumentedFunction
-                 : ScopeType::kInvalid;
-    case TimerInfo::kApiScope:
-      return ScopeType::kApiScope;
-    case TimerInfo::kApiScopeAsync:
-      return ScopeType::kApiScopeAsync;
-    default:
-      return ScopeType::kInvalid;
-  }
-}
-
 std::optional<ScopeId> NameEqualityScopeIdProvider::ProvideId(const TimerInfo& timer_info) {
-  const ScopeType scope_type = ScopeTypeFromTimerInfo(timer_info);
+  const ScopeType scope_type = kScopeTypeFromTimerInfo(timer_info);
 
   if (scope_type == ScopeType::kInvalid) return std::nullopt;
 

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -108,31 +108,6 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   /// TODO(http://b/247467504): Add FunctionInfo to ScopeInfo.
   absl::flat_hash_map<ScopeId, FunctionInfo> scope_id_to_function_info_;
   mutable absl::Mutex mutex_;
-
-  // The code below is an optimized version of the following
-  // ```
-  // static ScopeType ScopeTypeFromTimerInfo(const TimerInfo& timer) {
-  //  switch (timer.type()) {
-  //    case TimerInfo::kNone:
-  //      return timer.function_id() != orbit_grpc_protos::kInvalidFunctionId
-  //                 ? ScopeType::kDynamicallyInstrumentedFunction
-  //                 : ScopeType::kInvalid;
-  //    case TimerInfo::kApiScope:
-  //      return ScopeType::kApiScope;
-  //    case TimerInfo::kApiScopeAsync:
-  //      return ScopeType::kApiScopeAsync;
-  //    default:
-  //      return ScopeType::kInvalid;
-  //  }
-  //}
-  //```
-  static constexpr std::array<int, 14> kTable = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3};
-  static constexpr auto kScopeTypeFromTimerInfo = [](const TimerInfo& timer) -> ScopeType {
-    const int type = timer.type();
-    const int index =
-        type ^ static_cast<int>(timer.function_id() == orbit_grpc_protos::kInvalidFunctionId);
-    return static_cast<ScopeType>(kTable[index]);
-  };
 };
 }  // namespace orbit_client_data
 

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -21,6 +21,7 @@
 #include "ClientData/ScopeInfo.h"
 #include "ClientData/TimerTrackDataIdManager.h"
 #include "ClientProtos/capture_data.pb.h"
+#include "GrpcProtos/Constants.h"
 #include "GrpcProtos/capture.pb.h"
 
 namespace orbit_client_data {
@@ -107,8 +108,32 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   /// TODO(http://b/247467504): Add FunctionInfo to ScopeInfo.
   absl::flat_hash_map<ScopeId, FunctionInfo> scope_id_to_function_info_;
   mutable absl::Mutex mutex_;
-};
 
+  // The code below is an optimized version of the following
+  // ```
+  // static ScopeType ScopeTypeFromTimerInfo(const TimerInfo& timer) {
+  //  switch (timer.type()) {
+  //    case TimerInfo::kNone:
+  //      return timer.function_id() != orbit_grpc_protos::kInvalidFunctionId
+  //                 ? ScopeType::kDynamicallyInstrumentedFunction
+  //                 : ScopeType::kInvalid;
+  //    case TimerInfo::kApiScope:
+  //      return ScopeType::kApiScope;
+  //    case TimerInfo::kApiScopeAsync:
+  //      return ScopeType::kApiScopeAsync;
+  //    default:
+  //      return ScopeType::kInvalid;
+  //  }
+  //}
+  //```
+  static constexpr std::array<int, 14> kTable = {0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3};
+  static constexpr auto kScopeTypeFromTimerInfo = [](const TimerInfo& timer) -> ScopeType {
+    const int type = timer.type();
+    const int index =
+        type ^ static_cast<int>(timer.function_id() != orbit_grpc_protos::kInvalidFunctionId);
+    return static_cast<ScopeType>(kTable[index]);
+  };
+};
 }  // namespace orbit_client_data
 
 #endif  // ORBIT_CLIENT_DATA_API_SCOPE_ID_PROVIDER_H_

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -126,11 +126,11 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   //  }
   //}
   //```
-  static constexpr std::array<int, 14> kTable = {0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3};
+  static constexpr std::array<int, 14> kTable = {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3};
   static constexpr auto kScopeTypeFromTimerInfo = [](const TimerInfo& timer) -> ScopeType {
     const int type = timer.type();
     const int index =
-        type ^ static_cast<int>(timer.function_id() != orbit_grpc_protos::kInvalidFunctionId);
+        type ^ static_cast<int>(timer.function_id() == orbit_grpc_protos::kInvalidFunctionId);
     return static_cast<ScopeType>(kTable[index]);
   };
 };

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -21,7 +21,6 @@
 #include "ClientData/ScopeInfo.h"
 #include "ClientData/TimerTrackDataIdManager.h"
 #include "ClientProtos/capture_data.pb.h"
-#include "GrpcProtos/Constants.h"
 #include "GrpcProtos/capture.pb.h"
 
 namespace orbit_client_data {

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -108,6 +108,7 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   absl::flat_hash_map<ScopeId, FunctionInfo> scope_id_to_function_info_;
   mutable absl::Mutex mutex_;
 };
+
 }  // namespace orbit_client_data
 
 #endif  // ORBIT_CLIENT_DATA_API_SCOPE_ID_PROVIDER_H_


### PR DESCRIPTION
The improvement consists in optimizing `ScopeTypeFromTimerInfo` function which is twofold:

1. The nested branching is replaced by a table and arithmetic operations
2. The function itself is turned into a lambda to facilitate inlining.

The speed-up is measured at the level of 15%.

Test: Unit, manual
Bug: http://b/264439413