### PR TITLE
Remove sampling_report from OrbitApp

### DIFF
--- a/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
@@ -78,10 +78,11 @@ class MainWindowInterface {
 
   virtual ~MainWindowInterface() = default;
 
-  virtual void SetCallstackInspection(std::unique_ptr<CallTreeView> top_down_view,
-                                      std::unique_ptr<CallTreeView> bottom_up_view,
-                                      orbit_data_views::DataView* callstack_data_view,
-                                      std::unique_ptr<class SamplingReport> report) = 0;
+  virtual void SetCallstackInspection(
+      std::unique_ptr<CallTreeView> top_down_view, std::unique_ptr<CallTreeView> bottom_up_view,
+      orbit_data_views::DataView* callstack_data_view,
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) = 0;
   virtual void ClearCallstackInspection() = 0;
 
   virtual bool IsConnected() = 0;
@@ -94,11 +95,20 @@ class MainWindowInterface {
   virtual void SetBottomUpView(std::unique_ptr<CallTreeView> view) = 0;
   virtual void SetSelectionTopDownView(std::unique_ptr<CallTreeView> view) = 0;
   virtual void SetSelectionBottomUpView(std::unique_ptr<CallTreeView> view) = 0;
-  virtual void SetSamplingReport(orbit_data_views::DataView* callstack_data_view,
-                                 const std::shared_ptr<class SamplingReport>& sampling_report) = 0;
+  virtual void SetSamplingReport(
+      orbit_data_views::DataView* callstack_data_view,
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) = 0;
   virtual void SetSelectionSamplingReport(
       orbit_data_views::DataView* callstack_data_view,
-      const std::shared_ptr<class SamplingReport>& selection_report) = 0;
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) = 0;
+  virtual void UpdateSamplingReport(
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) = 0;
+  virtual void UpdateSelectionReport(
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -49,7 +49,6 @@
 #include "ClientData/SystemMemoryInfo.h"
 #include "ClientData/ThreadStateSliceInfo.h"
 #include "ClientData/TimerChain.h"
-#include "ClientData/TimerTrackDataIdManager.h"
 #include "ClientData/WineSyscallHandlingMethod.h"
 #include "ClientProtos/capture_data.pb.h"
 #include "ClientProtos/preset.pb.h"
@@ -78,15 +77,12 @@
 #include "OrbitBase/Result.h"
 #include "OrbitBase/StopToken.h"
 #include "OrbitBase/ThreadPool.h"
-#include "OrbitGl/CallTreeView.h"
 #include "OrbitGl/CaptureWindow.h"
 #include "OrbitGl/DataViewFactory.h"
 #include "OrbitGl/FrameTrackOnlineProcessor.h"
-#include "OrbitGl/GlCanvas.h"
 #include "OrbitGl/IntrospectionWindow.h"
 #include "OrbitGl/MainWindowInterface.h"
 #include "OrbitGl/ManualInstrumentationManager.h"
-#include "OrbitGl/SamplingReport.h"
 #include "OrbitGl/SymbolLoader.h"
 #include "OrbitGl/TimeGraph.h"
 #include "PresetFile/PresetFile.h"
@@ -151,10 +147,6 @@ class OrbitApp final : public DataViewFactory,
   [[nodiscard]] orbit_client_data::ModuleManager* GetMutableModuleManager() override {
     ORBIT_CHECK(module_manager_ != nullptr);
     return module_manager_.get();
-  }
-
-  [[nodiscard]] bool HasSampleSelection() const {
-    return selection_report_ != nullptr && selection_report_->HasSamples();
   }
 
   void ListPresets();
@@ -560,9 +552,6 @@ class OrbitApp final : public DataViewFactory,
 
   CaptureWindow* capture_window_ = nullptr;
   IntrospectionWindow* introspection_window_ = nullptr;
-
-  std::shared_ptr<SamplingReport> sampling_report_;
-  std::shared_ptr<SamplingReport> selection_report_ = nullptr;
 
   // A boolean information about if the default Frame Track was added in the current session.
   bool default_frame_track_was_added_ = false;

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -83,11 +83,20 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void OnRefreshDataViewPanels(orbit_data_views::DataViewType type);
   void UpdatePanel(orbit_data_views::DataViewType type);
 
-  void SetSamplingReport(orbit_data_views::DataView* callstack_data_view,
-                         const std::shared_ptr<class SamplingReport>& sampling_report) override;
+  void SetSamplingReport(
+      orbit_data_views::DataView* callstack_data_view,
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;
   void SetSelectionSamplingReport(
       orbit_data_views::DataView* callstack_data_view,
-      const std::shared_ptr<class SamplingReport>& selection_report) override;
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;
+  void UpdateSamplingReport(
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;
+  void UpdateSelectionReport(
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;
 
   void SetTopDownView(std::unique_ptr<CallTreeView> top_down_view) override;
   void SetSelectionTopDownView(std::unique_ptr<CallTreeView> selection_top_down_view) override;
@@ -135,10 +144,11 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   orbit_base::CanceledOr<void> DisplayStopDownloadDialog(
       const orbit_client_data::ModuleData* module) override;
 
-  void SetCallstackInspection(std::unique_ptr<CallTreeView> top_down_view,
-                              std::unique_ptr<CallTreeView> bottom_up_view,
-                              orbit_data_views::DataView* callstack_data_view,
-                              std::unique_ptr<class SamplingReport> report) override;
+  void SetCallstackInspection(
+      std::unique_ptr<CallTreeView> top_down_view, std::unique_ptr<CallTreeView> bottom_up_view,
+      orbit_data_views::DataView* callstack_data_view,
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;
 
   void ClearCallstackInspection() override;
 

--- a/src/OrbitQt/include/OrbitQt/orbitsamplingreport.h
+++ b/src/OrbitQt/include/OrbitQt/orbitsamplingreport.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataViews/DataView.h"
+#include "OrbitGl/OrbitApp.h"
 #include "OrbitQt/orbitdataviewpanel.h"
 
 class SamplingReport;
@@ -27,15 +28,27 @@ class OrbitSamplingReport : public QWidget {
   explicit OrbitSamplingReport(QWidget* parent = nullptr);
   ~OrbitSamplingReport() override;
 
-  void Initialize(orbit_data_views::DataView* callstack_data_view,
-                  const std::shared_ptr<class SamplingReport>& report);
+  void Initialize(OrbitApp* app, orbit_data_views::DataView* callstack_data_view,
+                  const orbit_client_data::CallstackData* callstack_data,
+                  const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data);
+
+  void UpdateReport(
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data);
+
   void Deinitialize();
 
   void RefreshCallstackView();
   void RefreshTabs();
 
-  void SetInspection(orbit_data_views::DataView* callstack_data_view,
-                     std::unique_ptr<SamplingReport> report);
+  [[nodiscard]] bool HasSamples() {
+    return sampling_report_ != nullptr && sampling_report_->HasSamples();
+  }
+
+  void SetInspection(
+      OrbitApp* app, orbit_data_views::DataView* callstack_data_view,
+      const orbit_client_data::CallstackData* callstack_data,
+      const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data);
 
  signals:
   void LeaveCallstackInspectionClicked();

--- a/src/OrbitQt/include/OrbitQt/orbitsamplingreport.h
+++ b/src/OrbitQt/include/OrbitQt/orbitsamplingreport.h
@@ -41,7 +41,7 @@ class OrbitSamplingReport : public QWidget {
   void RefreshCallstackView();
   void RefreshTabs();
 
-  [[nodiscard]] bool HasSamples() {
+  [[nodiscard]] bool HasSamples() const {
     return sampling_report_ != nullptr && sampling_report_->HasSamples();
   }
 


### PR DESCRIPTION
SamplingReport is meant to be a controller/ui helper for the Sampling tab and this should not be updated or created in Orbit App.  Instead, only pass the data it needs and that it will not change.