### PR TITLE
Use orbit_base::Result to implement CanceledOr/NotFoundOr

### DIFF
--- a/src/OrbitBase/CanceledOrTest.cpp
+++ b/src/OrbitBase/CanceledOrTest.cpp
@@ -14,8 +14,7 @@
 namespace orbit_base {
 
 TEST(CanceledOr, IsCanceled) {
-  // Default constructed is NOT canceled
-  CanceledOr<int> canceled_or_int;
+  CanceledOr<int> canceled_or_int{0};
   EXPECT_FALSE(IsCanceled(canceled_or_int));
 
   canceled_or_int = Canceled{};
@@ -24,8 +23,7 @@ TEST(CanceledOr, IsCanceled) {
   canceled_or_int = 5;
   EXPECT_FALSE(IsCanceled(canceled_or_int));
 
-  // Default constructed is NOT canceled
-  CanceledOr<void> canceled_or_void;
+  CanceledOr<void> canceled_or_void{outcome::success()};
   EXPECT_FALSE(IsCanceled(canceled_or_void));
 
   canceled_or_void = Canceled{};

--- a/src/OrbitBase/NotFoundOrTest.cpp
+++ b/src/OrbitBase/NotFoundOrTest.cpp
@@ -16,7 +16,7 @@ namespace orbit_base {
 
 TEST(NotFoundOr, IsNotFound) {
   // Default constructor is found
-  NotFoundOr<int> not_found_or_int;
+  NotFoundOr<int> not_found_or_int{0};
   EXPECT_FALSE(IsNotFound(not_found_or_int));
 
   not_found_or_int = NotFound{"message"};
@@ -25,7 +25,7 @@ TEST(NotFoundOr, IsNotFound) {
   not_found_or_int = 5;
   EXPECT_FALSE(IsNotFound(not_found_or_int));
 
-  NotFoundOr<void> not_found_or_void;
+  NotFoundOr<void> not_found_or_void{outcome::success()};
   EXPECT_FALSE(IsNotFound(not_found_or_void));
 
   not_found_or_void = NotFound{"message"};
@@ -33,7 +33,7 @@ TEST(NotFoundOr, IsNotFound) {
 }
 
 TEST(NotFoundOr, GetNotFoundMessage) {
-  NotFoundOr<int> not_found_or_int;
+  NotFoundOr<int> not_found_or_int{0};
   EXPECT_DEATH(std::ignore = GetNotFoundMessage(not_found_or_int), "Check failed");
 
   not_found_or_int = 5;
@@ -61,7 +61,7 @@ TEST(NotFoundOr, GetFound) {
 
 TEST(NotFoundOr, MoveOnlyType) {
   // unique_ptr<int>; tests move only type
-  NotFoundOr<std::unique_ptr<int>> not_found_or_unique_ptr;
+  NotFoundOr<std::unique_ptr<int>> not_found_or_unique_ptr{std::unique_ptr<int>{}};
 
   EXPECT_FALSE(IsNotFound(not_found_or_unique_ptr));
 

--- a/src/OrbitBase/include/OrbitBase/NotFoundOr.h
+++ b/src/OrbitBase/include/OrbitBase/NotFoundOr.h
@@ -6,10 +6,10 @@
 #define ORBIT_BASE_NOT_FOUND_OR_H_
 
 #include <string>
-#include <variant>
+#include <utility>
 
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/VoidToMonostate.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_base {
 
@@ -20,44 +20,44 @@ struct NotFound {
 };
 
 // NotFoundOr can be used as the return type of a search operation, where the search can be
-// unsuccessful and returns a message. Based on std::variant. Check whether a NotFoundOr object is
-// a "not found" result with orbit_base::IsNotFound. Get the message with GetNotFoundMessage.
+// unsuccessful and returns a message. Check whether a NotFoundOr object is
+// a "not found" result with either `.has_error()` or `orbit_base::IsNotFound`.
+// Get the message with `GetNotFoundMessage(const NotFoundOr<T>&)`.
 template <typename T>
-using NotFoundOr = std::variant<VoidToMonostate_t<T>, NotFound>;
+using NotFoundOr = Result<T, NotFound>;
 
-// Free function to check whether a NotFoundOr type is "not found". Abstracts
-// std::holds_alternative
+// Free function to check whether a NotFoundOr type is "not found".
 template <typename T>
-[[nodiscard]] bool IsNotFound(const std::variant<T, NotFound>& not_found_or) {
-  return std::holds_alternative<NotFound>(not_found_or);
+[[nodiscard]] bool IsNotFound(const NotFoundOr<T>& not_found_or) {
+  return not_found_or.has_error();
 }
 
 // Free function to get the not found message of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] const std::string& GetNotFoundMessage(const std::variant<T, NotFound>& not_found_or) {
+[[nodiscard]] const std::string& GetNotFoundMessage(const NotFoundOr<T>& not_found_or) {
   ORBIT_CHECK(IsNotFound(not_found_or));
-  return std::get<NotFound>(not_found_or).message;
+  return not_found_or.error().message;
 }
 
 // Free function with move semantics to get the not found message of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] std::string&& GetNotFoundMessage(std::variant<T, NotFound>&& not_found_or) {
+[[nodiscard]] std::string&& GetNotFoundMessage(NotFoundOr<T>&& not_found_or) {
   ORBIT_CHECK(IsNotFound(not_found_or));
-  return std::move(std::get<NotFound>(std::move(not_found_or)).message);
+  return std::move(not_found_or).error().message;
 }
 
 // Free function to get the "found" content of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] const T& GetFound(const std::variant<T, NotFound>& not_found_or) {
+[[nodiscard]] const T& GetFound(const NotFoundOr<T>& not_found_or) {
   ORBIT_CHECK(!IsNotFound(not_found_or));
-  return std::get<T>(not_found_or);
+  return not_found_or.value();
 }
 
 // Free function with move semantics to get the "found" content of a NotFoundOr object.
 template <typename T>
-[[nodiscard]] T&& GetFound(std::variant<T, NotFound>&& not_found_or) {
+[[nodiscard]] T&& GetFound(NotFoundOr<T>&& not_found_or) {
   ORBIT_CHECK(!IsNotFound(not_found_or));
-  return std::get<T>(std::move(not_found_or));
+  return std::move(not_found_or).value();
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/NotFoundOr.h
+++ b/src/OrbitBase/include/OrbitBase/NotFoundOr.h
@@ -15,7 +15,7 @@ namespace orbit_base {
 
 // NotFound type that carries a message
 struct NotFound {
-  explicit NotFound(std::string message) : message(std::move(message)) {}
+  explicit NotFound(std::string message = "") : message(std::move(message)) {}
   std::string message;
 };
 

--- a/src/OrbitGl/SymbolLoader.cpp
+++ b/src/OrbitGl/SymbolLoader.cpp
@@ -187,7 +187,9 @@ Future<ErrorMessageOr<CanceledOr<void>>> SymbolLoader::RetrieveModuleSymbolsAndL
 
         orbit_base::ImmediateExecutor executor;
         return LoadSymbols(local_file_path, module_id)
-            .ThenIfSuccess(&executor, []() -> CanceledOr<void> { return CanceledOr<void>{}; });
+            .ThenIfSuccess(&executor, []() -> CanceledOr<void> {
+              return CanceledOr<void>{outcome::success()};
+            });
       });
 }
 
@@ -518,7 +520,9 @@ Future<ErrorMessageOr<CanceledOr<void>>> SymbolLoader::RetrieveModuleItselfAndLo
 
         orbit_base::ImmediateExecutor executor;
         return LoadFallbackSymbols(local_file_path, module_id)
-            .ThenIfSuccess(&executor, []() -> CanceledOr<void> { return CanceledOr<void>{}; });
+            .ThenIfSuccess(&executor, []() -> CanceledOr<void> {
+              return CanceledOr<void>{outcome::success()};
+            });
       });
 }
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1959,20 +1959,17 @@ orbit_base::CanceledOr<void> OrbitMainWindow::DisplayStopDownloadDialog(
   StopSymbolDownloadDialog dialog{module};
   Result dialog_result = dialog.Exec();
 
-  orbit_base::CanceledOr<void> return_canceled_or;
   switch (dialog_result) {
     case Result::kCancel:
-      return_canceled_or = orbit_base::Canceled{};
-      break;
-    case Result::kStopAndDisable: {
+      return orbit_base::Canceled{};
+    case Result::kStopAndDisable:
       app_->DisableDownloadForModule(module->file_path());
-      break;
-    }
+      return outcome::success();
     case Result::kStop:
-      break;
+      return outcome::success();
   }
 
-  return return_canceled_or;
+  ORBIT_UNREACHABLE();
 }
 
 void OrbitMainWindow::SetLiveTabScopeStatsCollection(

--- a/src/SymbolProvider/SymbolLoadingOutcome.cpp
+++ b/src/SymbolProvider/SymbolLoadingOutcome.cpp
@@ -29,9 +29,7 @@ std::string GetNotFoundMessage(const SymbolLoadingOutcome& outcome) {
 }
 
 bool IsSuccessResult(const SymbolLoadingOutcome& outcome) {
-  return outcome.has_value() && !IsCanceled(outcome) && !IsNotFound(outcome) &&
-         std::holds_alternative<SymbolLoadingSuccessResult>(
-             orbit_base::GetNotCanceled(outcome.value()));
+  return outcome.has_value() && !IsCanceled(outcome) && !IsNotFound(outcome);
 }
 
 SymbolLoadingSuccessResult GetSuccessResult(const SymbolLoadingOutcome& outcome) {


### PR DESCRIPTION
This is an alternative implementation of #4669. I'd like to know what you think about it.

It is using `Result<T,E>` (what we also use for `ErrorMessageOr<T>`) to implement `CanceledOr<T> = Result<T,Canceled>` and `NotFoundOr<T> = Result<T,NotFound>`.

There are some behavioural changes though: `Result` disables its generic constructor if the list of arguments would form a valid construction for both the value and the error type. This is also true for the default construction. That means `CanceledOr/NotFoundOr` can't have the same default construction behaviour as before - which is probably a good thing though.