### PR TITLE
Add additional rendering statistics

### DIFF
--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -6,7 +6,7 @@
 
 namespace orbit_gl {
 bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs) {
-  return std::memcmp(&lhs, &rhs, sizeof(Batcher::Statistics)) == 0;
+  return std::memcmp(&lhs, &rhs, sizeof(Batcher::Statistics)) != 0;
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitGl/Batcher.h"
+
+namespace orbit_gl {
+bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs) {
+  return std::memcmp(&lhs, &rhs, sizeof(Batcher::Statistics)) == 0;
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -6,7 +6,8 @@
 
 namespace orbit_gl {
 bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs) {
-  return std::memcmp(&lhs, &rhs, sizeof(Batcher::Statistics)) != 0;
+  return lhs.draw_calls == rhs.draw_calls && lhs.reserved_memory == rhs.reserved_memory &&
+         lhs.stored_layers == rhs.stored_layers && lhs.stored_vertices == rhs.stored_vertices;
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -5,9 +5,15 @@
 #include "OrbitGl/Batcher.h"
 
 namespace orbit_gl {
-bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs) {
+bool operator==(const orbit_gl::Batcher::Statistics& lhs,
+                const orbit_gl::Batcher::Statistics& rhs) {
   return lhs.draw_calls == rhs.draw_calls && lhs.reserved_memory == rhs.reserved_memory &&
          lhs.stored_layers == rhs.stored_layers && lhs.stored_vertices == rhs.stored_vertices;
+}
+
+bool operator!=(const orbit_gl::Batcher::Statistics& lhs,
+                const orbit_gl::Batcher::Statistics& rhs) {
+  return !(lhs == rhs);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -99,6 +99,7 @@ target_sources(
           AnnotationTrack.cpp
           AsyncTrack.cpp
           BasicPageFaultsTrack.cpp
+          Batcher.cpp
           Button.cpp
           CallstackThreadBar.cpp
           CallTreeView.cpp

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -663,6 +663,20 @@ std::string CaptureWindow::GetCaptureInfo() const {
   return capture_info;
 }
 
+namespace {
+void AppendBatcherStatistics(std::string& output, const std::string& batcher_name,
+                             const Batcher::Statistics& statistics) {
+  absl::StrAppendFormat(&output, "%s batcher memory: %.2f MB\n", batcher_name,
+                        static_cast<float>(statistics.reserved_memory) / 1024 / 1024);
+  absl::StrAppendFormat(&output, "%s batcher stored vertices: %d\n", batcher_name,
+                        statistics.stored_vertices);
+  absl::StrAppendFormat(&output, "%s batcher stored layers: %d\n", batcher_name,
+                        statistics.stored_layers);
+  absl::StrAppendFormat(&output, "%s batcher draw calls: %d\n", batcher_name,
+                        statistics.draw_calls);
+}
+}  // namespace
+
 std::string CaptureWindow::GetPerformanceInfo() const {
   std::string performance_info;
   for (const auto& item : scoped_frame_times_) {
@@ -674,10 +688,10 @@ std::string CaptureWindow::GetPerformanceInfo() const {
                           item.second->GetMaxTimeMs());
   }
   if (time_graph_ != nullptr) {
-    absl::StrAppendFormat(
-        &performance_info, "TimeGraph Batcher Memory: %.2f MB\n",
-        static_cast<float>(time_graph_->GetBatcher().GetReservedMemorySize()) / 1024 / 1024);
+    AppendBatcherStatistics(performance_info, "TimeGraph",
+                            time_graph_->GetBatcher().GetStatistics());
   }
+  AppendBatcherStatistics(performance_info, "UI", ui_batcher_.GetStatistics());
   return performance_info;
 }
 

--- a/src/OrbitGl/include/OrbitGl/Batcher.h
+++ b/src/OrbitGl/include/OrbitGl/Batcher.h
@@ -32,14 +32,15 @@ class Batcher : public BatcherInterface {
 
   [[nodiscard]] virtual Statistics GetStatistics() const = 0;
 
+  friend bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
+  friend bool operator!=(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
+
  protected:
   orbit_gl::TranslationStack translations_;
 
  private:
   BatcherId batcher_id_;
 };
-
-[[nodiscard]] bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
 
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/include/OrbitGl/Batcher.h
+++ b/src/OrbitGl/include/OrbitGl/Batcher.h
@@ -23,7 +23,14 @@ class Batcher : public BatcherInterface {
   void PushTranslation(float x, float y, float z = 0.f) { translations_.PushTranslation(x, y, z); }
   void PopTranslation() { translations_.PopTranslation(); }
 
-  [[nodiscard]] virtual size_t GetReservedMemorySize() const = 0;
+  struct Statistics {
+    size_t reserved_memory = 0;
+    uint32_t draw_calls = 0;
+    uint32_t stored_layers = 0;
+    uint32_t stored_vertices = 0;
+  };
+
+  [[nodiscard]] virtual Statistics GetStatistics() const = 0;
 
  protected:
   orbit_gl::TranslationStack translations_;
@@ -31,6 +38,8 @@ class Batcher : public BatcherInterface {
  private:
   BatcherId batcher_id_;
 };
+
+[[nodiscard]] bool operator==(const Batcher::Statistics& lhs, const Batcher::Statistics& rhs);
 
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/include/OrbitGl/MockBatcher.h
+++ b/src/OrbitGl/include/OrbitGl/MockBatcher.h
@@ -46,7 +46,7 @@ class MockBatcher : public Batcher {
 
   void DrawLayer(float /*layer*/, bool /*picking*/) override {}
 
-  [[nodiscard]] size_t GetReservedMemorySize() const override { return 0; };
+  [[nodiscard]] Statistics GetStatistics() const override { return {}; }
 
   [[nodiscard]] const PickingUserData* GetUserData(PickingId /*id*/) const override {
     return nullptr;

--- a/src/OrbitGl/include/OrbitGl/OpenGlBatcher.h
+++ b/src/OrbitGl/include/OrbitGl/OpenGlBatcher.h
@@ -105,7 +105,7 @@ class OpenGlBatcher : public Batcher, protected QOpenGLFunctions {
 
   [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const override;
 
-  [[nodiscard]] size_t GetReservedMemorySize() const override;
+  [[nodiscard]] Statistics GetStatistics() const override;
 
  protected:
   std::unordered_map<float, orbit_gl_internal::PrimitiveBuffers> primitive_buffers_by_layer_;

--- a/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
+++ b/src/OrbitGl/include/OrbitGl/PrimitiveAssembler.h
@@ -62,8 +62,6 @@ class PrimitiveAssembler {
   void PushTranslation(float x, float y, float z = 0.f) { batcher_->PushTranslation(x, y, z); }
   void PopTranslation() { batcher_->PopTranslation(); }
 
-  [[nodiscard]] size_t GetReservedMemorySize() const { return batcher_->GetReservedMemorySize(); };
-
   void AddLine(const Vec2& from, const Vec2& to, float z, const Color& color,
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddVerticalLine(const Vec2& pos, float size, float z, const Color& color,


### PR DESCRIPTION
On top of the required memory, this adds several additional statistics to the batchers that will be listed in the debug tab.

This also changes the statistics reporting to return a struct collecting all statistics, so it's easier to extend in the future.