### PR TITLE
Remove second consecutive resizeSections operation

### DIFF
--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -102,10 +102,6 @@ void OrbitSamplingReport::Initialize(
     tree_view->setAccessibleName(QStringLiteral("SamplingReportDataView"));
     grid_layout_2->addWidget(tree_view, 0, 0, 1, 1);
     tree_view->Initialize(&report_data_view, SelectionType::kExtended, FontType::kDefault);
-    {
-      ORBIT_SCOPE("resizeSections");
-      tree_view->GetTreeView()->header()->resizeSections(QHeaderView::ResizeToContents);
-    }
     tree_view->GetTreeView()->SetIsMultiSelection(true);
 
     tree_view->Link(ui_->CallstackTreeView);


### PR DESCRIPTION
Resizing the sections of an OrbitTreeView is actually very expensive for large data views (e.g. many samples), as Qt runs over all the entries and calculates the text width.

This expensive operation was done always twice in a row for the sampling report, as the data view panal
already performs the exact same call in the
Initialize method.

Removing this calls gains a 1.2x speedup when generating the data views.

This change is not (yet) improving the sizing of
the columns itself.

Test: Measure a capture with many samples.