### PR TITLE
Optimize rendering of text for timers.

### DIFF
--- a/src/OrbitGl/QtTextRenderer.cpp
+++ b/src/OrbitGl/QtTextRenderer.cpp
@@ -39,11 +39,11 @@ namespace {
 // Applying the heuristic below to the result from the lookup reliably yields a fairly tight upper
 // bound for the true width of the rendered string. Don't try to make sense of the formula - it is
 // just a line fitted to example data.
-inline int MaximumHeuristic(int width, int length, uint32_t font_size) {
+[[nodiscard]] int MaximumHeuristic(int width, int length, uint32_t font_size) {
   return 2 + (length * static_cast<int>(font_size)) / (12 * 14) + width;
 }
 
-float GetYOffsetFromAlignment(QtTextRenderer::VAlign alignment, float height) {
+[[nodiscard]] float GetYOffsetFromAlignment(QtTextRenderer::VAlign alignment, float height) {
   switch (alignment) {
     case QtTextRenderer::VAlign::Top:
       return 0.f;
@@ -61,7 +61,7 @@ float GetYOffsetFromAlignment(QtTextRenderer::VAlign alignment, float height) {
   }
 }
 
-float GetXOffsetFromAlignment(QtTextRenderer::HAlign alignment, float width) {
+[[nodiscard]] float GetXOffsetFromAlignment(QtTextRenderer::HAlign alignment, float width) {
   // kOffset is a hack to compensate for subtle differences in the placement of the rendered text
   // under Linux and Windows. Setting kOffset == 0 under Windows results in texts starting left of
   // the interval border for unknown reasons (also see https://github.com/google/orbit/issues/4627).

--- a/src/OrbitGl/QtTextRenderer.cpp
+++ b/src/OrbitGl/QtTextRenderer.cpp
@@ -6,8 +6,8 @@
 
 #include <GteVector.h>
 #include <absl/meta/type_traits.h>
-#include <qchar.h>
 
+#include <QChar>
 #include <QColor>
 #include <QFont>
 #include <QFontDatabase>
@@ -170,7 +170,6 @@ void QtTextRenderer::AddText(const char* text, float x, float y, float z, TextFo
 float QtTextRenderer::AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
                                                       TextFormatting formatting,
                                                       size_t trailing_chars_length) {
-  ORBIT_SCOPE_FUNCTION;
   // Early-out: If we can't fit a single char, there's no use to do all the expensive
   // calculations below - this is a major bottleneck in some cases
   if (formatting.max_size >= 0 && GetMinimumTextWidth(formatting.font_size) > formatting.max_size) {
@@ -269,14 +268,14 @@ const QtTextRenderer::CharacterWidthLookup& QtTextRenderer::GetCharacterWidthLoo
     uint32_t font_size) {
   auto it = character_width_lookup_cache_.find(font_size);
   if (it == character_width_lookup_cache_.end()) {
-    CharacterWidthLookup& lut = character_width_lookup_cache_[font_size];
     QFont font = QFontDatabase::systemFont(QFontDatabase::GeneralFont);
     font.setPixelSize(static_cast<int>(font_size));
     QFontMetrics metrics(font);
+    CharacterWidthLookup lut;
     for (int i = 0; i < 256; i++) {
       lut[i] = metrics.horizontalAdvance(QChar(i));
     }
-    return lut;
+    it = character_width_lookup_cache_.emplace(font_size, lut).first;
   }
   return it->second;
 }

--- a/src/OrbitGl/include/OrbitGl/MockTextRenderer.h
+++ b/src/OrbitGl/include/OrbitGl/MockTextRenderer.h
@@ -11,6 +11,7 @@
 
 #include <QPainter>
 #include <algorithm>
+#include <cstdint>
 #include <set>
 #include <vector>
 
@@ -41,6 +42,8 @@ class MockTextRenderer : public TextRenderer {
 
   [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size) override;
   [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size) override;
+
+  [[nodiscard]] float GetMinimumTextWidth(uint32_t /*font_size*/) override { return 0.f; };
 
   [[nodiscard]] bool HasAddTextsSameLength() const {
     return num_characters_in_add_text_.size() <= 1;

--- a/src/OrbitGl/include/OrbitGl/QtTextRenderer.h
+++ b/src/OrbitGl/include/OrbitGl/QtTextRenderer.h
@@ -39,12 +39,12 @@ class QtTextRenderer : public TextRenderer {
 
   [[nodiscard]] float GetStringWidth(const char* text, uint32_t font_size) override;
   [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size) override;
+  [[nodiscard]] float GetMinimumTextWidth(uint32_t font_size) override;
 
  private:
   using CharacterWidthLookup = std::array<int, 256>;
 
   [[nodiscard]] float GetStringWidth(const QString& text, uint32_t font_size);
-  [[nodiscard]] float GetMinimumTextWidth(uint32_t font_size);
   [[nodiscard]] float GetSingleLineStringHeight(uint32_t font_size);
   [[nodiscard]] const CharacterWidthLookup& GetCharacterWidthLookup(uint32_t font_size);
   [[nodiscard]] float GetStringWidthFast(const QString& text, const CharacterWidthLookup& lookup,

--- a/src/OrbitGl/include/OrbitGl/QtTextRenderer.h
+++ b/src/OrbitGl/include/OrbitGl/QtTextRenderer.h
@@ -41,11 +41,19 @@ class QtTextRenderer : public TextRenderer {
   [[nodiscard]] float GetStringHeight(const char* text, uint32_t font_size) override;
 
  private:
+  using CharacterWidthLookup = std::array<int, 256>;
+
   [[nodiscard]] float GetStringWidth(const QString& text, uint32_t font_size);
   [[nodiscard]] float GetMinimumTextWidth(uint32_t font_size);
+  [[nodiscard]] float GetSingleLineStringHeight(uint32_t font_size);
+  [[nodiscard]] const CharacterWidthLookup& GetCharacterWidthLookup(uint32_t font_size);
+  [[nodiscard]] float GetStringWidthFast(const QString& text, const CharacterWidthLookup& lookup,
+                                         uint32_t font_size);
+  [[nodiscard]] static QString ElideText(const QString& text, int max_width,
+                                         const CharacterWidthLookup& lookup, uint32_t font_size);
   [[nodiscard]] float AddFittingSingleLineText(const QString& text, float x, float y, float z,
-                                               TextFormatting formatting);
-
+                                               const TextFormatting& formatting,
+                                               const CharacterWidthLookup& lookup);
   struct StoredText {
     StoredText() = default;
     StoredText(const QString& text, int x, int y, int w, int h, TextFormatting formatting)
@@ -59,6 +67,8 @@ class QtTextRenderer : public TextRenderer {
   };
   absl::flat_hash_map<float, std::vector<StoredText>> stored_text_;
   absl::flat_hash_map<uint32_t, float> minimum_string_width_cache_;
+  absl::flat_hash_map<uint32_t, CharacterWidthLookup> character_width_lookup_cache_;
+  absl::flat_hash_map<uint32_t, int> single_line_height_cache_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/TextRendererInterface.h
+++ b/src/OrbitGl/include/OrbitGl/TextRendererInterface.h
@@ -38,6 +38,7 @@ class TextRendererInterface {
 
   // Add a - potentially multiline - text at the given position and z-layer and with the specifier
   // formatting. If formatting.max_size is set all lines are elided to fit into this width.
+  // It is allowed for `text` to contain unicode characters.
   virtual void AddText(const char* text, float x, float y, float z, TextFormatting formatting) = 0;
   virtual void AddText(const char* text, float x, float y, float z, TextFormatting formatting,
                        Vec2* out_text_pos, Vec2* out_text_size) = 0;
@@ -46,11 +47,15 @@ class TextRendererInterface {
   // The renderer will shorten the text if the width exceeds formatting.max_size. The shortening
   // will happen in a way that tries to preserve the given numnber of trailing characters.
   // This is mainly used to preserve the duration in the text of time intervals. E.g. something like
-  // "MyVeryLongButNotSoImportantMethodName 2.35 ms" will render as "MyVery...2.35 ms".
+  // "MyVeryLongButNotSoImportantMethodName 2.35 ms" will render as "MyVery 2.35 ms".
+  // `text` must not contain unicode characters - this method is ascii only. The reason for that is
+  // that this allows for a much quicker heuristic for shortening strings as described above.
   virtual float AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
                                                 TextFormatting formatting,
                                                 size_t trailing_chars_length) = 0;
 
+  // Return the width and height of `text` in world coordinates. The text might contain line breaks
+  // and unicode characters.
   [[nodiscard]] virtual float GetStringWidth(const char* text, uint32_t font_size) = 0;
   [[nodiscard]] virtual float GetStringHeight(const char* text, uint32_t font_size) = 0;
 };

--- a/src/OrbitGl/include/OrbitGl/TextRendererInterface.h
+++ b/src/OrbitGl/include/OrbitGl/TextRendererInterface.h
@@ -58,6 +58,9 @@ class TextRendererInterface {
   // and unicode characters.
   [[nodiscard]] virtual float GetStringWidth(const char* text, uint32_t font_size) = 0;
   [[nodiscard]] virtual float GetStringHeight(const char* text, uint32_t font_size) = 0;
+
+  // Returns the width of a minimum single character of given font size.
+  [[nodiscard]] virtual float GetMinimumTextWidth(uint32_t font_size) = 0;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/include/OrbitGl/TimerTrack.h
@@ -168,13 +168,8 @@ class TimerTrack : public Track {
   [[nodiscard]] inline bool BoxHasRoomForText(orbit_gl::TextRenderer& text_renderer,
                                               const float width) {
     const uint32_t font_size = layout_->GetFontSize();
-    auto it = width_of_single_char_cache_.find(font_size);
-    if (it == width_of_single_char_cache_.end()) {
-      const float width_of_single_char = text_renderer.GetStringWidth("w", font_size);
-      width_of_single_char_cache_[font_size] = width_of_single_char;
-      return width_of_single_char < width;
-    }
-    return it->second < width;
+    const float width_of_single_char = text_renderer.GetMinimumTextWidth(font_size);
+    return width_of_single_char < width;
   }
 
   [[nodiscard]] bool ShouldHaveBorder(


### PR DESCRIPTION
Previously the fitting of the text into the boxes for the timers took too long. Root cause for this is a fairly complicated computation for determining the width of a rendered text. This seems to be used inside the method to elide text as well.
This PR replaces the QFontMetrics::elidedText and
QFontMetrics::horizontalAdvance by a simplified, less accurate method. We compute a lookup table storing the rendered width of all ascii characters. The width is computed as the sum of the width of all characters in a string (plus a heuristic to obtain an upper bound of the actual width). The method to elide text is is implemented on basis of this simplified width calculation.
Compare https://github.com/google/orbit/issues/4626.