### PR TITLE
Add SelectionData for tracking selections

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(
          include/OrbitGl/SamplingReport.h
          include/OrbitGl/SchedulerTrack.h
          include/OrbitGl/SchedulingStats.h
+         include/OrbitGl/SelectionData.h
          include/OrbitGl/ShortenStringWithEllipsis.h
          include/OrbitGl/SimpleTimings.h
          include/OrbitGl/StaticTimeGraphLayout.h
@@ -133,6 +134,7 @@ target_sources(
           SamplingReport.cpp
           SchedulerTrack.cpp
           SchedulingStats.cpp
+          SelectionData.cpp
           SimpleTimings.cpp
           SymbolLoader.cpp
           SystemMemoryTrack.cpp

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -151,7 +151,7 @@ void CallstackThreadBar::DoUpdatePrimitives(PrimitiveAssembler& primitive_assemb
       primitive_assembler.AddVerticalLine({pos_x, GetPos()[1]}, track_height, z, green_selection);
     };
     const orbit_client_data::CallstackData& selection_callstack_data =
-        capture_data_->selection_callstack_data();
+        app_->GetSelectedCallstackData();
     if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
       selection_callstack_data.ForEachCallstackEventInTimeRangeDiscretized(
           min_tick, max_tick, resolution_in_pixels, action_on_selected_callstack_events);

--- a/src/OrbitGl/SelectionData.cpp
+++ b/src/OrbitGl/SelectionData.cpp
@@ -1,0 +1,43 @@
+
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitGl/SelectionData.h"
+
+#include <utility>
+
+#include "ClientData/CallstackData.h"
+#include "ClientData/CallstackEvent.h"
+#include "ClientModel/SamplingDataPostProcessor.h"
+
+using orbit_client_data::CallstackData;
+using orbit_client_data::CallstackEvent;
+using orbit_client_data::CaptureData;
+using orbit_client_data::ModuleManager;
+using orbit_client_data::PostProcessedSamplingData;
+
+SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureData& capture_data,
+                             PostProcessedSamplingData post_processed_sampling_data,
+                             const CallstackData* callstack_data)
+    : post_processed_sampling_data_(std::move(post_processed_sampling_data)) {
+  callstack_data_pointer_ = callstack_data;
+  top_down_view_ = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
+      post_processed_sampling_data_, module_manager, capture_data);
+  bottom_up_view_ = CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
+      post_processed_sampling_data_, module_manager, capture_data);
+}
+
+SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureData& capture_data,
+                             absl::Span<const CallstackEvent> callstack_events) {
+  for (const CallstackEvent& event : callstack_events) {
+    callstack_data_object_.AddCallstackFromKnownCallstackData(event,
+                                                              capture_data.GetCallstackData());
+  }
+  post_processed_sampling_data_ = orbit_client_model::CreatePostProcessedSamplingData(
+      callstack_data_object_, capture_data, module_manager);
+  top_down_view_ = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
+      post_processed_sampling_data_, module_manager, capture_data);
+  bottom_up_view_ = CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
+      post_processed_sampling_data_, module_manager, capture_data);
+}

--- a/src/OrbitGl/SelectionData.cpp
+++ b/src/OrbitGl/SelectionData.cpp
@@ -20,8 +20,8 @@ using orbit_client_data::PostProcessedSamplingData;
 SelectionData::SelectionData(const ModuleManager& module_manager, const CaptureData& capture_data,
                              PostProcessedSamplingData post_processed_sampling_data,
                              const CallstackData* callstack_data)
-    : post_processed_sampling_data_(std::move(post_processed_sampling_data)) {
-  callstack_data_pointer_ = callstack_data;
+    : post_processed_sampling_data_(std::move(post_processed_sampling_data)),
+      callstack_data_pointer_(callstack_data) {
   top_down_view_ = CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
       post_processed_sampling_data_, module_manager, capture_data);
   bottom_up_view_ = CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(

--- a/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/include/OrbitGl/MainWindowInterface.h
@@ -79,7 +79,8 @@ class MainWindowInterface {
   virtual ~MainWindowInterface() = default;
 
   virtual void SetCallstackInspection(
-      std::unique_ptr<CallTreeView> top_down_view, std::unique_ptr<CallTreeView> bottom_up_view,
+      std::shared_ptr<const CallTreeView> top_down_view,
+      std::shared_ptr<const CallTreeView> bottom_up_view,
       orbit_data_views::DataView* callstack_data_view,
       const orbit_client_data::CallstackData* callstack_data,
       const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) = 0;
@@ -91,10 +92,10 @@ class MainWindowInterface {
   virtual void SetLiveTabScopeStatsCollection(
       std::shared_ptr<const orbit_client_data::ScopeStatsCollection> scope_collection) = 0;
 
-  virtual void SetTopDownView(std::unique_ptr<CallTreeView> view) = 0;
-  virtual void SetBottomUpView(std::unique_ptr<CallTreeView> view) = 0;
-  virtual void SetSelectionTopDownView(std::unique_ptr<CallTreeView> view) = 0;
-  virtual void SetSelectionBottomUpView(std::unique_ptr<CallTreeView> view) = 0;
+  virtual void SetTopDownView(std::shared_ptr<const CallTreeView> view) = 0;
+  virtual void SetBottomUpView(std::shared_ptr<const CallTreeView> view) = 0;
+  virtual void SetSelectionTopDownView(std::shared_ptr<const CallTreeView> view) = 0;
+  virtual void SetSelectionBottomUpView(std::shared_ptr<const CallTreeView> view) = 0;
   virtual void SetSamplingReport(
       orbit_data_views::DataView* callstack_data_view,
       const orbit_client_data::CallstackData* callstack_data,

--- a/src/OrbitGl/include/OrbitGl/OrbitApp.h
+++ b/src/OrbitGl/include/OrbitGl/OrbitApp.h
@@ -83,6 +83,7 @@
 #include "OrbitGl/IntrospectionWindow.h"
 #include "OrbitGl/MainWindowInterface.h"
 #include "OrbitGl/ManualInstrumentationManager.h"
+#include "OrbitGl/SelectionData.h"
 #include "OrbitGl/SymbolLoader.h"
 #include "OrbitGl/TimeGraph.h"
 #include "PresetFile/PresetFile.h"
@@ -399,6 +400,8 @@ class OrbitApp final : public DataViewFactory,
   void ClearInspection();
   void ClearSelectionTabs();
 
+  const orbit_client_data::CallstackData& GetSelectedCallstackData() const;
+
   void SelectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint) override;
   void DeselectTracepoint(const orbit_grpc_protos::TracepointInfo& tracepoint) override;
 
@@ -583,6 +586,10 @@ class OrbitApp final : public DataViewFactory,
   std::optional<orbit_gl::SymbolLoader> symbol_loader_;
   static constexpr std::chrono::milliseconds kMaxPostProcessingInterval{1000};
   orbit_qt_utils::Throttle update_after_symbol_loading_throttle_{kMaxPostProcessingInterval};
+
+  std::unique_ptr<SelectionData> full_capture_selection_;
+  std::unique_ptr<SelectionData> time_range_thread_selection_;
+  std::unique_ptr<SelectionData> inspection_selection_;
 };
 
 #endif  // ORBIT_GL_APP_H_

--- a/src/OrbitGl/include/OrbitGl/SelectionData.h
+++ b/src/OrbitGl/include/OrbitGl/SelectionData.h
@@ -1,0 +1,58 @@
+
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CLIENT_DATA_SELECTION_DATA_H_
+#define CLIENT_DATA_SELECTION_DATA_H_
+
+#include "ClientData/CaptureData.h"
+#include "ClientData/ModuleManager.h"
+#include "ClientData/PostProcessedSamplingData.h"
+#include "OrbitGl/CallTreeView.h"
+
+// This is meant to hold the data needed to update the data tabs to a specific selection.
+class SelectionData {
+ public:
+  // Delete move/copy operators because callstack_data_pointer_ is pointing to a variable inside the
+  // class.
+  SelectionData(const SelectionData& other) = delete;
+  SelectionData& operator=(const SelectionData& other) = delete;
+  SelectionData(SelectionData&& other) = delete;
+  SelectionData& operator=(SelectionData&& other) = delete;
+
+  SelectionData(const orbit_client_data::ModuleManager& module_manager,
+                const orbit_client_data::CaptureData& capture_data,
+                orbit_client_data::PostProcessedSamplingData post_processed_sampling_data,
+                const orbit_client_data::CallstackData* callstack_data);
+
+  SelectionData(const orbit_client_data::ModuleManager& module_manager,
+                const orbit_client_data::CaptureData& capture_data,
+                absl::Span<const orbit_client_data::CallstackEvent> callstack_events);
+
+  std::shared_ptr<const CallTreeView> GetTopDownView() const { return top_down_view_; }
+
+  std::shared_ptr<const CallTreeView> GetBottomUpView() const { return bottom_up_view_; }
+
+  const orbit_client_data::PostProcessedSamplingData& GetPostProcessedSamplingData() const {
+    return post_processed_sampling_data_;
+  }
+
+  const orbit_client_data::CallstackData& GetCallstackData() const {
+    ORBIT_CHECK(callstack_data_pointer_);
+    return *callstack_data_pointer_;
+  }
+
+ private:
+  std::shared_ptr<CallTreeView> top_down_view_;
+  std::shared_ptr<CallTreeView> bottom_up_view_;
+
+  orbit_client_data::PostProcessedSamplingData post_processed_sampling_data_;
+
+  orbit_client_data::CallstackData callstack_data_object_;
+  // Depending on how SelectionData is created, this either points to callstack_data_object_ or to
+  // the CallstackData object passed into SelectionData.
+  const orbit_client_data::CallstackData* callstack_data_pointer_ = &callstack_data_object_;
+};
+
+#endif  // CLIENT_DATA_SELECTION_DATA_H_

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -20,7 +20,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
 
-CallTreeViewItemModel::CallTreeViewItemModel(std::unique_ptr<CallTreeView> call_tree_view,
+CallTreeViewItemModel::CallTreeViewItemModel(std::shared_ptr<const CallTreeView> call_tree_view,
                                              QObject* parent)
     : QAbstractItemModel{parent}, call_tree_view_{std::move(call_tree_view)} {}
 
@@ -362,7 +362,7 @@ QModelIndex CallTreeViewItemModel::index(int row, int column, const QModelIndex&
     return {};
   }
 
-  CallTreeNode* parent_item = nullptr;
+  const CallTreeNode* parent_item = nullptr;
   if (!parent.isValid()) {
     parent_item = call_tree_view_.get();
   } else {

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -105,7 +105,7 @@ CallTreeWidget::CallTreeWidget(QWidget* parent)
 
 CallTreeWidget::~CallTreeWidget() = default;
 
-void CallTreeWidget::SetCallTreeView(std::unique_ptr<CallTreeView> call_tree_view,
+void CallTreeWidget::SetCallTreeView(std::shared_ptr<const CallTreeView> call_tree_view,
                                      std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model) {
   ORBIT_CHECK(app_ != nullptr);
 
@@ -216,7 +216,7 @@ static void ExpandRecursivelyWithThreshold(QTreeView* tree_view, const QModelInd
   }
 }
 
-void CallTreeWidget::SetTopDownView(std::unique_ptr<CallTreeView> top_down_view) {
+void CallTreeWidget::SetTopDownView(std::shared_ptr<const CallTreeView> top_down_view) {
   // Expand recursively if CallTreeView contains information for a single thread.
   bool should_expand = IsSliderEnabled() && top_down_view->thread_count() == 1;
 
@@ -230,14 +230,14 @@ void CallTreeWidget::SetTopDownView(std::unique_ptr<CallTreeView> top_down_view)
   }
 }
 
-void CallTreeWidget::SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view) {
+void CallTreeWidget::SetBottomUpView(std::shared_ptr<const CallTreeView> bottom_up_view) {
   SetCallTreeView(std::move(bottom_up_view),
                   std::make_unique<HideValuesForBottomUpProxyModel>(nullptr));
   // Don't show the "Exclusive" column for the bottom-up tree, it provides no useful information.
   ui_->callTreeTreeView->hideColumn(CallTreeViewItemModel::kExclusive);
 }
 
-void CallTreeWidget::SetInspection(std::unique_ptr<CallTreeView> call_tree_view) {
+void CallTreeWidget::SetInspection(std::shared_ptr<const CallTreeView> call_tree_view) {
   ORBIT_CHECK(hide_values_proxy_model_ != nullptr);
   ui_->inspectionNoticeWidget->show();
   inspection_model_ = std::make_unique<CallTreeViewItemModel>(std::move(call_tree_view));

--- a/src/OrbitQt/include/OrbitQt/CallTreeViewItemModel.h
+++ b/src/OrbitQt/include/OrbitQt/CallTreeViewItemModel.h
@@ -24,7 +24,7 @@ class CallTreeViewItemModel : public QAbstractItemModel {
   Q_OBJECT
 
  public:
-  explicit CallTreeViewItemModel(std::unique_ptr<CallTreeView> call_tree_view,
+  explicit CallTreeViewItemModel(std::shared_ptr<const CallTreeView> call_tree_view,
                                  QObject* parent = nullptr);
 
   [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
@@ -62,7 +62,7 @@ class CallTreeViewItemModel : public QAbstractItemModel {
   [[nodiscard]] QVariant GetCopyableValueRoleData(const QModelIndex& index) const;
   [[nodiscard]] static QVariant GetExclusiveCallstackEventsRoleData(const QModelIndex& index);
 
-  std::unique_ptr<CallTreeView> call_tree_view_;
+  std::shared_ptr<const CallTreeView> call_tree_view_;
 };
 
 #endif  // ORBIT_QT_CALL_TREE_VIEW_ITEM_MODEL_H_

--- a/src/OrbitQt/include/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/include/OrbitQt/CallTreeWidget.h
@@ -57,11 +57,11 @@ class CallTreeWidget : public QWidget {
     app_ = nullptr;
   }
 
-  void SetTopDownView(std::unique_ptr<CallTreeView> top_down_view);
-  void SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view);
+  void SetTopDownView(std::shared_ptr<const CallTreeView> top_down_view);
+  void SetBottomUpView(std::shared_ptr<const CallTreeView> bottom_up_view);
   void ClearCallTreeView();
   // These methods can only be called after SetTopDownView or SetBottomUpView.
-  void SetInspection(std::unique_ptr<CallTreeView> call_tree_view);
+  void SetInspection(std::shared_ptr<const CallTreeView> call_tree_view);
   void ClearInspection();
 
  protected:
@@ -132,7 +132,7 @@ class CallTreeWidget : public QWidget {
                const QModelIndex& index) const override;
   };
 
-  void SetCallTreeView(std::unique_ptr<CallTreeView> call_tree_view,
+  void SetCallTreeView(std::shared_ptr<const CallTreeView> call_tree_view,
                        std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model);
 
   void ResizeColumnsIfNecessary();

--- a/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/include/OrbitQt/orbitmainwindow.h
@@ -99,11 +99,13 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
       const orbit_client_data::CallstackData* callstack_data,
       const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;
 
-  void SetTopDownView(std::unique_ptr<CallTreeView> top_down_view) override;
-  void SetSelectionTopDownView(std::unique_ptr<CallTreeView> selection_top_down_view) override;
+  void SetTopDownView(std::shared_ptr<const CallTreeView> top_down_view) override;
+  void SetSelectionTopDownView(
+      std::shared_ptr<const CallTreeView> selection_top_down_view) override;
 
-  void SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view) override;
-  void SetSelectionBottomUpView(std::unique_ptr<CallTreeView> selection_bottom_up_view) override;
+  void SetBottomUpView(std::shared_ptr<const CallTreeView> bottom_up_view) override;
+  void SetSelectionBottomUpView(
+      std::shared_ptr<const CallTreeView> selection_bottom_up_view) override;
 
   void OpenCapture(std::string_view filepath);
   void OnCaptureCleared() override;
@@ -146,7 +148,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
       const orbit_client_data::ModuleData* module) override;
 
   void SetCallstackInspection(
-      std::unique_ptr<CallTreeView> top_down_view, std::unique_ptr<CallTreeView> bottom_up_view,
+      std::shared_ptr<const CallTreeView> top_down_view,
+      std::shared_ptr<const CallTreeView> bottom_up_view,
       orbit_data_views::DataView* callstack_data_view,
       const orbit_client_data::CallstackData* callstack_data,
       const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) override;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -844,21 +844,21 @@ void OrbitMainWindow::UpdateSelectionReport(
   ui->selectionReport->UpdateReport(callstack_data, post_processed_sampling_data);
 }
 
-void OrbitMainWindow::SetTopDownView(std::unique_ptr<CallTreeView> top_down_view) {
+void OrbitMainWindow::SetTopDownView(std::shared_ptr<const CallTreeView> top_down_view) {
   ui->topDownWidget->SetTopDownView(std::move(top_down_view));
 }
 
 void OrbitMainWindow::SetSelectionTopDownView(
-    std::unique_ptr<CallTreeView> selection_top_down_view) {
+    std::shared_ptr<const CallTreeView> selection_top_down_view) {
   ui->selectionTopDownWidget->SetTopDownView(std::move(selection_top_down_view));
 }
 
-void OrbitMainWindow::SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view) {
+void OrbitMainWindow::SetBottomUpView(std::shared_ptr<const CallTreeView> bottom_up_view) {
   ui->bottomUpWidget->SetBottomUpView(std::move(bottom_up_view));
 }
 
 void OrbitMainWindow::SetSelectionBottomUpView(
-    std::unique_ptr<CallTreeView> selection_bottom_up_view) {
+    std::shared_ptr<const CallTreeView> selection_bottom_up_view) {
   ui->selectionBottomUpWidget->SetBottomUpView(std::move(selection_bottom_up_view));
 }
 
@@ -1911,7 +1911,8 @@ void OrbitMainWindow::AppendToCaptureLog(CaptureLogSeverity severity, absl::Dura
 }
 
 void OrbitMainWindow::SetCallstackInspection(
-    std::unique_ptr<CallTreeView> top_down_view, std::unique_ptr<CallTreeView> bottom_up_view,
+    std::shared_ptr<const CallTreeView> top_down_view,
+    std::shared_ptr<const CallTreeView> bottom_up_view,
     orbit_data_views::DataView* callstack_data_view,
     const orbit_client_data::CallstackData* callstack_data,
     const orbit_client_data::PostProcessedSamplingData* post_processed_sampling_data) {


### PR DESCRIPTION
SelectionData contains the underlying data that any of the sampling tabs may need.  This makes it easier and quicker to swap between the data of a full capture, a selection, or an inspection.  The inspection isn't taking full advantage of this data structure yet as it's still branched, but I hope to change this in a future PR.

Bug: http://b/264437402