### PR TITLE
Remove track tab and rounded corners

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -159,7 +159,8 @@ void CaptureWindow::MouseMoved(int x, int y, bool left, bool right, bool middle)
 
   // Update selection timestamps
   if (is_selecting_) {
-    select_stop_time_ = time_graph_->GetTickFromWorld(select_stop_pos_world_[0]);
+    select_stop_time_ = time_graph_->GetTickFromWorld(
+        time_graph_->ClampToTimelineUiElementWorldX(select_stop_pos_world_[0]));
   }
 }
 
@@ -260,7 +261,8 @@ void CaptureWindow::PostRender(QPainter* painter) {
 void CaptureWindow::RightDown(int x, int y) {
   GlCanvas::RightDown(x, y);
   if (time_graph_ != nullptr) {
-    select_start_time_ = time_graph_->GetTickFromWorld(select_start_pos_world_[0]);
+    select_start_time_ = time_graph_->GetTickFromWorld(
+        time_graph_->ClampToTimelineUiElementWorldX(select_start_pos_world_[0]));
   }
 }
 
@@ -492,6 +494,11 @@ void CaptureWindow::Draw(QPainter* painter) {
   bool update_primitives_was_needed =
       time_graph_ != nullptr &&
       time_graph_->GetRedrawTypeRequired() == TimeGraph::RedrawType::kUpdatePrimitives;
+
+  draw_as_if_picking_ = time_graph_layout_->GetDrawAsIfPicking();
+  if (draw_as_if_picking_) {
+    picking_mode_ = PickingMode::kClick;
+  }
 
   text_renderer_.Init();
 
@@ -745,11 +752,16 @@ void CaptureWindow::RenderSelectionOverlay() {
   uint64_t min_time = std::min(select_start_time_, select_stop_time_);
   uint64_t max_time = std::max(select_start_time_, select_stop_time_);
 
-  float start_world = time_graph_->GetWorldFromUs(time_graph_->GetMinTimeUs());
-  float end_world = time_graph_->GetWorldFromUs(time_graph_->GetMaxTimeUs());
-  float select_start_world = time_graph_->GetWorldFromTick(min_time);
-  float select_end_world = time_graph_->GetWorldFromTick(max_time);
-  float stop_pos_world = time_graph_->GetWorldFromTick(select_stop_time_);
+  float start_world = time_graph_->ClampToTimelineUiElementWorldX(
+      time_graph_->GetWorldFromUs(time_graph_->GetMinTimeUs()));
+  float end_world = time_graph_->ClampToTimelineUiElementWorldX(
+      time_graph_->GetWorldFromUs(time_graph_->GetMaxTimeUs()));
+  float select_start_world =
+      time_graph_->ClampToTimelineUiElementWorldX(time_graph_->GetWorldFromTick(min_time));
+  float select_end_world =
+      time_graph_->ClampToTimelineUiElementWorldX(time_graph_->GetWorldFromTick(max_time));
+  float stop_pos_world =
+      time_graph_->ClampToTimelineUiElementWorldX(time_graph_->GetWorldFromTick(select_stop_time_));
   float initial_y_position = time_graph_layout_->GetTimeBarHeight();
   float bar_height = viewport_.GetWorldHeight() - initial_y_position;
 

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -64,7 +64,7 @@ class NavigationTestCaptureWindow : public testing::Test {
     ORBIT_CHECK(capture_window_.GetTimeGraph()->GetTimelineUi()->GetHeight() <
                 kViewportHeight - kBottomSafetyMargin);
     ORBIT_CHECK(capture_window_.GetTimeGraph()->GetTimelineUi()->GetPos()[0] ==
-                time_graph_layout_.GetLeftMargin());
+                time_graph_layout_.GetTrackHeaderWidth());
   }
 
  protected:

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -219,10 +219,10 @@ void FrameTrack::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& t
   const Color black_color(0, 0, 0, 255);
   const Vec2 pos = GetPos();
 
-  const float x = pos[0];
+  const float x = pos[0] + header_->GetWidth();
   const float y = pos[1] + GetHeightAboveTimers() + GetMaximumBoxHeight() - GetAverageBoxHeight();
   Vec2 from(x, y);
-  Vec2 to(x + GetWidth(), y);
+  Vec2 to(pos[0] + GetWidth(), y);
   float text_z = GlCanvas::kZValueTrackText;
 
   std::string avg_time =
@@ -230,7 +230,7 @@ void FrameTrack::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& t
   std::string label = absl::StrFormat("Avg: %s", avg_time);
   uint32_t font_size = layout_->GetFontSize();
   float string_width = text_renderer.GetStringWidth(label.c_str(), font_size);
-  Vec2 white_text_box_position(pos[0] + layout_->GetRightMargin(), y);
+  Vec2 white_text_box_position(x + layout_->GetRightMargin(), y);
 
   primitive_assembler.AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z,
                               white_color);

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -30,6 +30,7 @@ float GlCanvas::kZValueEventBar = 0.03f;
 float GlCanvas::kZValueBox = 0.05f;
 float GlCanvas::kZValueEvent = 0.06f;
 float GlCanvas::kZValueBoxBorder = 0.07f;
+float GlCanvas::kZValueTrackHeader = 0.075f;
 float GlCanvas::kZValueTrackText = 0.08f;
 float GlCanvas::kZValueTrackLabel = 0.09f;
 float GlCanvas::kZValueTimeBar = 0.31f;
@@ -235,7 +236,7 @@ void GlCanvas::PostRender(QPainter* painter) {
     can_hover_ = false;
   }
 
-  if (prev_picking_mode != PickingMode::kNone) {
+  if (!draw_as_if_picking_ && prev_picking_mode != PickingMode::kNone) {
     Pick(prev_picking_mode, mouse_move_pos_screen_[0], mouse_move_pos_screen_[1]);
     GlCanvas::Render(painter, viewport_.GetScreenWidth(), viewport_.GetScreenHeight());
   }

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -112,15 +112,14 @@ float GpuDebugMarkerTrack::GetYFromDepth(uint32_t depth) const {
   if (IsCollapsed()) {
     depth = 0;
   }
-  return GetPos()[1] + layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
-         layout_->GetTextBoxHeight() * depth;
+  return GetPos()[1] + layout_->GetTrackContentTopMargin() + layout_->GetTextBoxHeight() * depth;
 }
 
 float GpuDebugMarkerTrack::GetHeight() const {
   bool collapsed = IsCollapsed();
   uint32_t depth = collapsed ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
-  return layout_->GetTrackTabHeight() + layout_->GetTrackContentTopMargin() +
-         layout_->GetTextBoxHeight() * depth + layout_->GetTrackContentBottomMargin();
+  return layout_->GetTrackContentTopMargin() + layout_->GetTextBoxHeight() * depth +
+         layout_->GetTrackContentBottomMargin();
 }
 
 bool GpuDebugMarkerTrack::TimerFilter(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -183,9 +183,8 @@ float GpuSubmissionTrack::GetHeight() const {
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
     depth *= 2;
   }
-  return header_->GetHeight() + layout_->GetTrackContentTopMargin() +
-         layout_->GetTextBoxHeight() * depth + (num_gaps * layout_->GetSpaceBetweenGpuDepths()) +
-         layout_->GetTrackContentBottomMargin();
+  return layout_->GetTrackContentTopMargin() + layout_->GetTextBoxHeight() * depth +
+         (num_gaps * layout_->GetSpaceBetweenGpuDepths()) + layout_->GetTrackContentBottomMargin();
 }
 
 const TimerInfo* GpuSubmissionTrack::GetLeft(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -114,10 +114,12 @@ float GpuTrack::GetHeight() const {
   float height = 0;
   if (submission_track_->ShouldBeRendered()) {
     float additional_height = submission_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
+    // TODO: Track hierarchy refactor, remove hack below.
     height += std::max(additional_height, 2.f * layout_->GetThreadTrackMinimumHeight());
   }
   if (marker_track_->ShouldBeRendered()) {
     float additional_height = marker_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
+    // TODO: Track hierarchy refactor, remove hack below.
     height += std::max(additional_height, 2.f * layout_->GetThreadTrackMinimumHeight());
   }
   return height;

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -95,7 +95,7 @@ void GpuTrack::UpdatePositionOfSubtracks() {
   submission_track_->SetHeadless(false);
   submission_track_->SetIndentationLevel(indentation_level_ + 1);
 
-  float current_y = pos[1] + layout_->GetTrackTabHeight();
+  float current_y = pos[1];
   if (submission_track_->ShouldBeRendered()) {
     current_y += layout_->GetSpaceBetweenSubtracks();
   }
@@ -111,14 +111,14 @@ float GpuTrack::GetHeight() const {
   if (IsCollapsed()) {
     return submission_track_->GetHeight();
   }
-  float height = layout_->GetTrackTabHeight();
+  float height = 0;
   if (submission_track_->ShouldBeRendered()) {
-    height += submission_track_->GetHeight();
-    height += layout_->GetSpaceBetweenSubtracks();
+    float additional_height = submission_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
+    height += std::max(additional_height, 2.f * layout_->GetThreadTrackMinimumHeight());
   }
   if (marker_track_->ShouldBeRendered()) {
-    height += marker_track_->GetHeight();
-    height += layout_->GetSpaceBetweenSubtracks();
+    float additional_height = marker_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
+    height += std::max(additional_height, 2.f * layout_->GetThreadTrackMinimumHeight());
   }
   return height;
 }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -63,8 +63,7 @@ float GraphTrack<Dimension>::GetHeight() const {
   float height_above_content =
       GetLegendHeight() + (HasLegend() ? 2.f : 1.f) * layout_->GetTrackContentTopMargin();
 
-  return layout_->GetTrackTabHeight() + height_above_content + GetGraphContentHeight() +
-         layout_->GetTrackContentBottomMargin();
+  return height_above_content + GetGraphContentHeight() + layout_->GetTrackContentBottomMargin();
 }
 
 template <size_t Dimension>
@@ -103,7 +102,7 @@ void GraphTrack<Dimension>::DoUpdatePrimitives(PrimitiveAssembler& primitive_ass
 
   float content_height = GetGraphContentHeight();
   Vec2 content_pos = GetPos();
-  content_pos[1] += layout_->GetTrackTabHeight();
+  content_pos[0] += header_->GetWidth();
   Quad box = MakeBox(content_pos, Vec2(GetWidth(), content_height + GetLegendHeight()));
   primitive_assembler.AddBox(box, track_z, GetTrackBackgroundColor(), shared_from_this());
 
@@ -200,7 +199,8 @@ void GraphTrack<Dimension>::DrawMouseLabel(PrimitiveAssembler& primitive_assembl
   float arrow_width = text_box_size[1] / 2.f;
   Vec2 arrow_box_size(text_box_size[0] + text_left_margin + text_right_margin,
                       text_box_size[1] + text_top_margin + text_bottom_margin);
-  bool arrow_is_left_directed = target_point_pos[0] < arrow_box_size[0] + arrow_width;
+  bool arrow_is_left_directed =
+      target_point_pos[0] < (header_->GetWidth() + arrow_box_size[0] + arrow_width);
   Vec2 text_box_position(
       target_point_pos[0] + (arrow_is_left_directed
                                  ? arrow_width + text_left_margin
@@ -237,9 +237,8 @@ void GraphTrack<Dimension>::DrawLegend(PrimitiveAssembler& primitive_assembler,
   const float space_between_legend_entries = layout_->GetGenericFixedSpacerWidth() * 2;
   const float legend_symbol_height = GetLegendHeight();
   const float legend_symbol_width = legend_symbol_height;
-  float x0 = GetPos()[0] + layout_->GetRightMargin();
-  const float y0 =
-      header_->GetPos()[1] + header_->GetHeight() + layout_->GetTrackContentTopMargin();
+  float x0 = GetPos()[0] + header_->GetWidth() + layout_->GetRightMargin();
+  const float y0 = header_->GetPos()[1] + layout_->GetTrackContentTopMargin();
   uint32_t font_size = GetLegendFontSize(indentation_level_);
   const Color fully_transparent(255, 255, 255, 0);
 

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -45,7 +45,7 @@ float PageFaultsTrack::GetHeight() const {
     return major_page_faults_track_->GetHeight();
   }
 
-  float height = layout_->GetTrackTabHeight();
+  float height = 0;
   if (major_page_faults_track_->ShouldBeRendered()) {
     height += major_page_faults_track_->GetHeight() + layout_->GetSpaceBetweenSubtracks();
   }
@@ -87,7 +87,7 @@ void PageFaultsTrack::UpdatePositionOfSubtracks() {
   minor_page_faults_track_->SetVisible(true);
   minor_page_faults_track_->SetIndentationLevel(indentation_level_ + 1);
 
-  float current_y = pos[1] + layout_->GetTrackTabHeight();
+  float current_y = pos[1];
   if (major_page_faults_track_->ShouldBeRendered()) {
     current_y += layout_->GetSpaceBetweenSubtracks();
   }

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -71,8 +71,9 @@ void SchedulerTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   visible_timer_count_ = 0;
 
   const internal::DrawData draw_data =
-      GetDrawData(min_tick, max_tick, GetPos()[0], GetWidth(), &primitive_assembler, timeline_info_,
-                  viewport_, IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
+      GetDrawData(min_tick, max_tick, GetPos()[0] + header_->GetWidth(),
+                  GetWidth() - header_->GetWidth(), &primitive_assembler, timeline_info_, viewport_,
+                  IsCollapsed(), app_->selected_timer(), app_->GetScopeIdToHighlight(),
                   app_->GetGroupIdToHighlight(), app_->GetHistogramSelectionRange());
 
   const uint32_t resolution_in_pixels = viewport_->WorldToScreen({GetWidth(), 0})[0];

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -31,7 +31,6 @@
 #include "OrbitGl/OrbitApp.h"
 #include "OrbitGl/PrimitiveAssembler.h"
 #include "OrbitGl/TimeGraphLayout.h"
-#include "OrbitGl/TrackHeader.h"
 #include "OrbitGl/Viewport.h"
 
 using orbit_client_data::ScopeId;
@@ -282,8 +281,8 @@ void TimerTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   draw_data.primitive_assembler = &primitive_assembler;
   draw_data.viewport = viewport_;
 
-  draw_data.track_start_x = GetPos()[0];
-  draw_data.track_width = GetWidth();
+  draw_data.track_start_x = GetPos()[0] + header_->GetWidth();
+  draw_data.track_width = GetWidth() - header_->GetWidth();
   draw_data.inv_time_window = 1.0 / timeline_info_->GetTimeWindowUs();
   draw_data.is_collapsed = IsCollapsed();
 
@@ -299,8 +298,8 @@ void TimerTrack::DoUpdatePrimitives(PrimitiveAssembler& primitive_assembler,
   // enough that all events are drawn as boxes, this has no effect. When zoomed
   // out, many events will be discarded quickly.
   auto time_window_ns = static_cast<uint64_t>(1000 * timeline_info_->GetTimeWindowUs());
-  draw_data.ns_per_pixel =
-      static_cast<double>(time_window_ns) / viewport_->WorldToScreen({GetWidth(), 0})[0];
+  draw_data.ns_per_pixel = static_cast<double>(time_window_ns) /
+                           viewport_->WorldToScreen({GetWidth() - header_->GetWidth(), 0})[0];
   draw_data.min_timegraph_tick = timeline_info_->GetTickFromUs(timeline_info_->GetMinTimeUs());
   draw_data.histogram_selection_range = app_->GetHistogramSelectionRange();
 
@@ -379,9 +378,7 @@ std::string TimerTrack::GetBoxTooltip(const PrimitiveAssembler& /*primitive_asse
   return "";
 }
 
-float TimerTrack::GetHeightAboveTimers() const {
-  return header_->GetHeight() + layout_->GetTrackContentTopMargin();
-}
+float TimerTrack::GetHeightAboveTimers() const { return layout_->GetTrackContentTopMargin(); }
 
 internal::DrawData TimerTrack::GetDrawData(
     uint64_t min_tick, uint64_t max_tick, float track_pos_x, float track_width,

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -55,59 +55,42 @@ void Track::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_r
   // Same for picking - the track background is not pickable
   if (picking || !draw_background) return;
 
-  const float x0 = GetPos()[0];
+  const float x0 = GetPos()[0] + header_->GetWidth();
   const float y0 = GetPos()[1];
-  const float header_height = header_->GetHeight();
   const float track_z = GlCanvas::kZValueTrack;
 
   Color track_background_color = GetTrackBackgroundColor();
 
   Vec2 track_size = GetSize();
 
-  // Draw rounded corners.
-  float radius = std::min(layout_->GetRoundingRadius(), layout_->GetTrackTabHeight() * 0.5f);
-  auto sides = static_cast<uint32_t>(layout_->GetRoundingNumSides() + 0.5f);
-  auto rounded_corner = orbit_gl::GetRoundedCornerMask(radius, sides);
-
   // This draws the non-tab content of the track. The tab itself is a separate CaptureViewElement
   // child of the track.
   // Note that the top-left corner is not rounded due to the design of the track tab sitting
   // in the top left.
   //
-  // [ Header ] ________________________  content_top_right
-  // |                                  `
-  // |XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
-  // \__________________________________/
-  // content_bottom_left                 content_bottom_right
+  //  ____________________________________________  content_top_right
+  // |         |                                  |
+  // | header  |XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
+  // |_________|__________________________________|
+  //            content_bottom_left                 content_bottom_right
   //
   Vec2 content_bottom_left(x0, y0 + track_size[1]);
   Vec2 content_bottom_right(x0 + track_size[0], y0 + track_size[1]);
 
-  // The track content starts underneath the track header, and we only draw the background
-  // starting
-  // there. This could be prevented by moving the track content into a separate child, but in the
-  // end, the design of track and track header will need to influence each other...
-  Vec2 content_top_right(x0 + track_size[0], y0 + header_height);
-  Vec2 content_top_left(x0, y0 + header_height);
-
-  auto shared_this = shared_from_this();
-  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_bottom_left,
-                            GlCanvas::kBackgroundColor, 0, track_z, shared_this);
-  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_bottom_right,
-                            GlCanvas::kBackgroundColor, -90.f, track_z, shared_this);
-  orbit_gl::DrawTriangleFan(primitive_assembler, rounded_corner, content_top_right,
-                            GlCanvas::kBackgroundColor, 180.f, track_z, shared_this);
+  Vec2 content_top_right(x0 + track_size[0], y0);
+  Vec2 content_top_left(x0, y0);
 
   // Draw track's content background.
-  Quad box = MakeBox(content_top_left, Vec2(GetWidth(), GetHeight() - header_height));
+  Quad box = MakeBox(content_top_left, Vec2(GetWidth(), GetHeight()));
   primitive_assembler.AddBox(box, track_z, track_background_color, shared_from_this());
 }
 
 void Track::DoUpdateLayout() {
   CaptureViewElement::DoUpdateLayout();
 
-  header_->SetWidth(layout_->GetTrackTabWidth());
-  header_->SetPos(GetPos()[0] + layout_->GetTrackTabOffset(), GetPos()[1]);
+  header_->SetWidth(layout_->GetTrackHeaderWidth());
+  header_->SetHeight(GetHeight());
+  header_->SetPos(GetPos()[0], GetPos()[1]);
   UpdatePositionOfSubtracks();
 }
 

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -42,53 +42,24 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
 
   const float x0 = GetPos()[0];
   const float y0 = GetPos()[1];
-  const float track_z = GlCanvas::kZValueTrack;
+  const float track_z = GlCanvas::kZValueTrackHeader;
   const float text_z = GlCanvas::kZValueTrackText;
 
   // Draw tab background
-  const float label_height = GetHeight();
-  const float half_label_height = 0.5f * label_height;
+  const float label_height = height_;
   const float label_width = GetWidth();
-  const float half_label_width = 0.5f * label_width;
 
   const float indentation_x0 =
       x0 + (track_->GetIndentationLevel() * layout_->GetTrackIndentOffset());
-  Quad box = MakeBox(Vec2(indentation_x0, y0), Vec2(label_width, label_height));
-  primitive_assembler.AddBox(box, track_z, track_->GetTrackBackgroundColor(), shared_from_this());
 
-  // Early-out: In picking mode, don't draw the text and rounded corners.
-  if (picking) {
-    return;
+  if (track_->GetIndentationLevel() == 0 && layout_->GetDrawTrackHeaderBackground()) {
+    Quad box = MakeBox(Vec2(indentation_x0, y0), Vec2(label_width, label_height));
+    primitive_assembler.AddBox(box, track_z, track_->GetTrackBackgroundColor(), shared_from_this());
   }
 
-  // Don't draw rounded corners when this track is a child of another track
-  if (track_->GetIndentationLevel() == 0) {
-    // Draw rounded corners.
-    float radius = std::min(layout_->GetRoundingRadius(), half_label_height);
-    radius = std::min(radius, half_label_width);
-    auto sides = static_cast<uint32_t>(layout_->GetRoundingNumSides() + 0.5f);
-    auto rounded_corner = GetRoundedCornerMask(radius, sides);
-
-    // This only draw the tab-part of a track. It's expecting to sit on the top of the track.
-    // See comments in Track::DoDraw for a full picture.
-    //
-    // top_left       tab_top_right
-    //  __________________
-    // /                   `
-    // |___________________(
-    // [ Track content below]
-
-    Vec2 top_left(indentation_x0, y0);
-    Vec2 tab_top_right(top_left[0] + label_width, top_left[1]);
-    Vec2 tab_bottom_right(top_left[0] + label_width, top_left[1] + label_height);
-
-    auto shared_this = shared_from_this();
-    DrawTriangleFan(primitive_assembler, rounded_corner, top_left, GlCanvas::kBackgroundColor, 90.f,
-                    track_z, shared_this);
-    DrawTriangleFan(primitive_assembler, rounded_corner, tab_top_right, GlCanvas::kBackgroundColor,
-                    180.f, track_z, shared_this);
-    DrawTriangleFan(primitive_assembler, rounded_corner, tab_bottom_right,
-                    track_->GetTrackBackgroundColor(), 0, track_z, shared_this);
+  // Early-out: In picking mode, don't draw the text.
+  if (picking) {
+    return;
   }
 
   // Draw label.
@@ -108,8 +79,9 @@ void TrackHeader::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& 
   formatting.valign = TextRenderer::VAlign::Middle;
 
   text_renderer.AddTextTrailingCharsPrioritized(
-      track_->GetLabel().c_str(), indentation_x0 + label_offset_x, y0 + half_label_height, text_z,
-      formatting, track_->GetNumberOfPrioritizedTrailingCharacters());
+      track_->GetLabel().c_str(), indentation_x0 + label_offset_x,
+      y0 + layout_->GetTextBoxHeight() * 0.5f + GetVerticalLabelOffset(), text_z, formatting,
+      track_->GetNumberOfPrioritizedTrailingCharacters());
 }
 
 void orbit_gl::TrackHeader::DoUpdateLayout() {
@@ -119,14 +91,15 @@ void orbit_gl::TrackHeader::DoUpdateLayout() {
 }
 
 void TrackHeader::UpdateCollapseToggle() {
-  const float label_height = layout_->GetTrackTabHeight();
-  const float half_label_height = 0.5f * label_height;
-  const float x0 = GetPos()[0] + layout_->GetTrackTabOffset() +
-                   layout_->GetTrackIndentOffset() * track_->GetIndentationLevel();
-  const float button_offset = layout_->GetCollapseButtonOffset();
+  const float x0 = GetPos()[0] + layout_->GetTrackIndentOffset() * track_->GetIndentationLevel();
   const float size = layout_->GetCollapseButtonSize(track_->GetIndentationLevel());
-  const float toggle_y_pos = GetPos()[1] + half_label_height - size / 2;
-  Vec2 toggle_pos = Vec2(x0 + button_offset, toggle_y_pos);
+
+  constexpr float kOffsetY = 1.f;
+  const float toggle_x_pos = x0 + layout_->GetCollapseButtonOffset();
+  const float toggle_y_pos =
+      GetPos()[1] + layout_->GetTextBoxHeight() * 0.5f - size * 0.5f + kOffsetY;
+
+  Vec2 toggle_pos = Vec2(toggle_x_pos, toggle_y_pos + GetVerticalLabelOffset());
 
   collapse_toggle_->SetWidth(size);
   collapse_toggle_->SetHeight(size);
@@ -138,6 +111,16 @@ void TrackHeader::UpdateCollapseToggle() {
   collapse_toggle_->SetIsCollapsible(track_->IsCollapsible());
 }
 
+float TrackHeader::GetVerticalLabelOffset() const {
+  // This offset only affect subtracks, which are a very special case that need refactoring.
+  // Subtracks are only used for the memory track. The following offset is to avoid overlap between
+  // the labels of the track and it's subtrack. Subtracks should have their own header altogether.
+  if (track_->GetIndentationLevel() > 1) {
+    ORBIT_LOG_ONCE("Error: Track indentation level is greater than one, layout will be broken.");
+  }
+  return track_->GetIndentationLevel() > 0 ? layout_->GetTextBoxHeight() : 0.f;
+}
+
 void TrackHeader::OnDrag(int x, int y) {
   CaptureViewElement::OnDrag(x, y);
 
@@ -147,5 +130,7 @@ void TrackHeader::OnDrag(int x, int y) {
 }
 
 bool TrackHeader::Draggable() { return track_->Draggable(); }
+
+void TrackHeader::SetHeight(float height) { height_ = height; }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -112,9 +112,7 @@ void TrackHeader::UpdateCollapseToggle() {
 }
 
 float TrackHeader::GetVerticalLabelOffset() const {
-  // This offset only affect subtracks, which are a very special case that need refactoring.
-  // Subtracks are only used for the memory track. The following offset is to avoid overlap between
-  // the labels of the track and it's subtrack. Subtracks should have their own header altogether.
+  // TODO: Track hierarchy refactor, remove hack below.
   if (track_->GetIndentationLevel() > 1) {
     ORBIT_LOG_ONCE("Error: Track indentation level is greater than one, layout will be broken.");
   }

--- a/src/OrbitGl/TrackHeader.cpp
+++ b/src/OrbitGl/TrackHeader.cpp
@@ -131,6 +131,10 @@ void TrackHeader::OnDrag(int x, int y) {
 
 bool TrackHeader::Draggable() { return track_->Draggable(); }
 
-void TrackHeader::SetHeight(float height) { height_ = height; }
+void TrackHeader::SetHeight(float height) {
+  if (height == height_) return;
+  height_ = height;
+  RequestUpdate(RequestUpdateScope::kDraw);
+}
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -28,7 +28,7 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
                             const DrawContext& draw_context) {
   CaptureViewElement::DoDraw(primitive_assembler, text_renderer, draw_context);
 
-  const float z = GlCanvas::kZValueTrack;
+  const float z = GlCanvas::kZValueTrackText;
 
   const bool picking = draw_context.picking_mode != PickingMode::kNone;
   const Color white(255, 255, 255, 255);
@@ -58,8 +58,7 @@ void TriangleToggle::DoDraw(PrimitiveAssembler& primitive_assembler, TextRendere
     primitive_assembler.AddTriangle(triangle, z, color, shared_from_this());
   } else {
     // When picking, draw a big square for easier picking.
-    Quad box = MakeBox(midpoint - Vec2(half_triangle_side_length, half_triangle_side_length),
-                       Vec2(triangle_side_length, triangle_side_length));
+    Quad box = MakeBox(GetPos(), Vec2(GetWidth(), GetHeight()));
     primitive_assembler.AddBox(box, z, color, shared_from_this());
   }
 }

--- a/src/OrbitGl/include/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/include/OrbitGl/GlCanvas.h
@@ -72,6 +72,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider, protected QOpenGL
   static float kZValueEventBar;
   static float kZValueBox;
   static float kZValueBoxBorder;
+  static float kZValueTrackHeader;
   static float kZValueEvent;
   static float kZValueTrackText;
   static float kZValueTrackLabel;
@@ -116,6 +117,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider, protected QOpenGL
   bool can_hover_ = false;
 
   PickingMode picking_mode_ = PickingMode::kNone;
+  bool draw_as_if_picking_ = false;
 
   double ref_time_click_{0.0};
   float track_container_click_scrolling_offset_ = 0;

--- a/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/StaticTimeGraphLayout.h
@@ -48,9 +48,6 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
     return GetMinSliderLength() / kRatioMinSliderLengthResizePart;
   }
   [[nodiscard]] float GetTimeBarHeight() const override { return kTimeBarHeight * scale_; }
-  [[nodiscard]] float GetTrackTabWidth() const override { return kTrackTabWidth; }
-  [[nodiscard]] float GetTrackTabHeight() const override { return kTrackTabHeight * scale_; }
-  [[nodiscard]] float GetTrackTabOffset() const override { return kTrackTabOffset; }
   [[nodiscard]] float GetTrackIndentOffset() const override { return kTrackIndentOffset; }
   [[nodiscard]] float GetCollapseButtonSize(int indentation_level) const override {
     float button_size_without_scaling =
@@ -64,7 +61,10 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   [[nodiscard]] float GetRoundingRadius() const override { return kRoundingRadius * scale_; }
   [[nodiscard]] float GetRoundingNumSides() const override { return kRoundingNumSides; }
   [[nodiscard]] float GetTextOffset() const override { return kTextOffset * scale_; }
-  [[nodiscard]] float GetLeftMargin() const override { return kLeftMargin * scale_; }
+  [[nodiscard]] float GetTrackHeaderWidth() const override { return kLeftMargin * scale_; }
+  [[nodiscard]] float GetThreadTrackMinimumHeight() const override {
+    return kThreadTrackMinHeight * scale_;
+  }
   [[nodiscard]] float GetRightMargin() const override { return kRightMargin * scale_; }
   [[nodiscard]] float GetMinButtonSize() const override { return kMinButtonSize; }
   [[nodiscard]] float GetButtonWidth() const override { return kButtonWidth * scale_; }
@@ -104,6 +104,10 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
 
   [[nodiscard]] int GetMaxLayoutingLoops() const override { return kMaxLayoutingLoops; }
 
+  [[nodiscard]] bool GetDrawTrackHeaderBackground() const override { return false; }
+  [[nodiscard]] bool GetDrawAsIfPicking() const override { return false; }
+  [[nodiscard]] bool GetDrawTimeGraphMasks() const override { return false; }
+
  private:
   constexpr static float kTextBoxHeight = 20.f;
   constexpr static float kCoreHeight = 10.f;
@@ -133,6 +137,7 @@ class StaticTimeGraphLayout : public TimeGraphLayout {
   constexpr static float kRoundingNumSides = 16;
   constexpr static float kTextOffset = 5.f;
   constexpr static float kLeftMargin = 100.f;
+  constexpr static float kThreadTrackMinHeight = 20.f;
   constexpr static float kRightMargin = 10.f;
   constexpr static float kMinButtonSize = 5.f;
   constexpr static float kButtonWidth = 15.f;

--- a/src/OrbitGl/include/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraph.h
@@ -100,6 +100,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   [[nodiscard]] uint64_t GetCaptureTimeSpanNs() const override;
   [[nodiscard]] std::pair<float, float> GetBoxPosXAndWidthFromTicks(
       uint64_t start_tick, uint64_t end_tick) const override;
+  [[nodiscard]] float ClampToTimelineUiElementWorldX(float x) const;
 
   void UpdateCaptureMinMaxTimestamps();
 

--- a/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
@@ -20,16 +20,14 @@ class TimeGraphLayout {
   [[nodiscard]] virtual float GetMinSliderLength() const = 0;
   [[nodiscard]] virtual float GetSliderResizeMargin() const = 0;
   [[nodiscard]] virtual float GetTimeBarHeight() const = 0;
-  [[nodiscard]] virtual float GetTrackTabWidth() const = 0;
-  [[nodiscard]] virtual float GetTrackTabHeight() const = 0;
-  [[nodiscard]] virtual float GetTrackTabOffset() const = 0;
   [[nodiscard]] virtual float GetTrackIndentOffset() const = 0;
   [[nodiscard]] virtual float GetCollapseButtonSize(int indentation_level) const = 0;
   [[nodiscard]] virtual float GetCollapseButtonOffset() const = 0;
   [[nodiscard]] virtual float GetRoundingRadius() const = 0;
   [[nodiscard]] virtual float GetRoundingNumSides() const = 0;
   [[nodiscard]] virtual float GetTextOffset() const = 0;
-  [[nodiscard]] virtual float GetLeftMargin() const = 0;
+  [[nodiscard]] virtual float GetTrackHeaderWidth() const = 0;
+  [[nodiscard]] virtual float GetThreadTrackMinimumHeight() const = 0;
   [[nodiscard]] virtual float GetRightMargin() const = 0;
   [[nodiscard]] virtual float GetMinButtonSize() const = 0;
   [[nodiscard]] virtual float GetButtonWidth() const = 0;
@@ -46,8 +44,11 @@ class TimeGraphLayout {
   [[nodiscard]] virtual float GetThreadDependencyArrowBodyWidth() const = 0;
   [[nodiscard]] virtual float GetScale() const = 0;
   [[nodiscard]] virtual bool GetDrawTrackBackground() const = 0;
+  [[nodiscard]] virtual bool GetDrawTrackHeaderBackground() const = 0;
   [[nodiscard]] virtual uint32_t GetFontSize() const = 0;
   [[nodiscard]] virtual int GetMaxLayoutingLoops() const = 0;
+  [[nodiscard]] virtual bool GetDrawAsIfPicking() const = 0;
+  [[nodiscard]] virtual bool GetDrawTimeGraphMasks() const = 0;
   virtual void SetScale(float value) = 0;
 
   ~TimeGraphLayout() = default;

--- a/src/OrbitGl/include/OrbitGl/TrackHeader.h
+++ b/src/OrbitGl/include/OrbitGl/TrackHeader.h
@@ -36,7 +36,9 @@ class TrackHeader : public CaptureViewElement, public std::enable_shared_from_th
   [[nodiscard]] const TriangleToggle* GetCollapseToggle() const { return collapse_toggle_.get(); }
   [[nodiscard]] TriangleToggle* GetCollapseToggle() { return collapse_toggle_.get(); }
 
-  [[nodiscard]] float GetHeight() const override { return layout_->GetTrackTabHeight(); }
+  [[nodiscard]] float GetHeight() const override { return height_; }
+  void SetHeight(float height);
+
   [[nodiscard]] uint32_t GetLayoutFlags() const override { return 0; }
 
   void OnPick(int x, int y) override;
@@ -60,12 +62,14 @@ class TrackHeader : public CaptureViewElement, public std::enable_shared_from_th
   void DoUpdateLayout() override;
 
   void UpdateCollapseToggle();
+  float GetVerticalLabelOffset() const;
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
  private:
   std::shared_ptr<TriangleToggle> collapse_toggle_;
   TrackControlInterface* track_;
+  float height_ = 0.f;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitQt/TimeGraphLayoutWidget.cpp
+++ b/src/OrbitQt/TimeGraphLayoutWidget.cpp
@@ -22,9 +22,6 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&slider_width_);
   AddWidgetForProperty(&min_slider_length_);
   AddWidgetForProperty(&time_bar_height_);
-  AddWidgetForProperty(&track_tab_width_);
-  AddWidgetForProperty(&track_tab_height_);
-  AddWidgetForProperty(&track_tab_offset_);
   AddWidgetForProperty(&track_indent_offset_);
   AddWidgetForProperty(&collapse_button_offset_);
   AddWidgetForProperty(&collapse_button_size_);
@@ -32,7 +29,8 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&rounding_radius_);
   AddWidgetForProperty(&rounding_num_sides_);
   AddWidgetForProperty(&text_offset_);
-  AddWidgetForProperty(&left_margin_);
+  AddWidgetForProperty(&track_header_width_);
+  AddWidgetForProperty(&thread_track_minimum_height_);
   AddWidgetForProperty(&right_margin_);
   AddWidgetForProperty(&min_button_size_);
   AddWidgetForProperty(&button_width_);
@@ -47,6 +45,10 @@ TimeGraphLayoutWidget::TimeGraphLayoutWidget(QWidget* parent)
   AddWidgetForProperty(&thread_dependency_arrow_head_width_);
   AddWidgetForProperty(&thread_dependency_arrow_head_height_);
   AddWidgetForProperty(&thread_dependency_arrow_body_width_);
+  AddWidgetForProperty(&draw_track_background_);
+  AddWidgetForProperty(&draw_track_header_background_);
+  AddWidgetForProperty(&draw_timegraph_masks_);
+  AddWidgetForProperty(&draw_as_if_picking_);
   AddWidgetForProperty(&scale_);
 }
 

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -53,11 +53,6 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   [[nodiscard]] float GetTimeBarHeight() const override {
     return time_bar_height_.value() * scale_.value();
   }
-  [[nodiscard]] float GetTrackTabWidth() const override { return track_tab_width_.value(); }
-  [[nodiscard]] float GetTrackTabHeight() const override {
-    return track_tab_height_.value() * scale_.value();
-  }
-  [[nodiscard]] float GetTrackTabOffset() const override { return track_tab_offset_.value(); }
   [[nodiscard]] float GetTrackIndentOffset() const override { return track_indent_offset_.value(); }
   [[nodiscard]] float GetCollapseButtonSize(int indentation_level) const override;
   [[nodiscard]] float GetCollapseButtonOffset() const override {
@@ -70,8 +65,11 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   [[nodiscard]] float GetTextOffset() const override {
     return text_offset_.value() * scale_.value();
   }
-  [[nodiscard]] float GetLeftMargin() const override {
-    return left_margin_.value() * scale_.value();
+  [[nodiscard]] float GetTrackHeaderWidth() const override {
+    return track_header_width_.value() * scale_.value();
+  }
+  [[nodiscard]] float GetThreadTrackMinimumHeight() const override {
+    return thread_track_minimum_height_.value() * scale_.value();
   }
   [[nodiscard]] float GetRightMargin() const override {
     return right_margin_.value() * scale_.value();
@@ -118,11 +116,19 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   [[nodiscard]] bool GetDrawTrackBackground() const override {
     return draw_track_background_.value();
   }
+  [[nodiscard]] bool GetDrawTrackHeaderBackground() const override {
+    return draw_track_header_background_.value();
+  }
+  [[nodiscard]] bool GetDrawTimeGraphMasks() const override {
+    return draw_timegraph_masks_.value();
+  }
   [[nodiscard]] uint32_t GetFontSize() const override {
     return std::lround(static_cast<float>(font_size_.value()) * scale_.value());
   }
 
   [[nodiscard]] int GetMaxLayoutingLoops() const override { return max_layouting_loops_.value(); }
+
+  [[nodiscard]] bool GetDrawAsIfPicking() const override { return draw_as_if_picking_.value(); }
 
  private:
   FloatProperty text_box_height_{{
@@ -167,7 +173,7 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Space between GPU depths:",
   }};
   FloatProperty space_between_tracks_{{
-      .initial_value = 10.f,
+      .initial_value = 2.f,
       .label = "Space between Tracks:",
   }};
   FloatProperty space_between_tracks_and_timeline_{{
@@ -194,26 +200,12 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .initial_value = 20.f,
       .label = "Minimum Slider Length:",
   }};
-  FloatProperty track_tab_width_{{
-      .initial_value = 350.f,
-      .min = 0.f,
-      .max = 1000.f,
-      .label = "Track Tab Width:",
-  }};
-  FloatProperty track_tab_height_{{
-      .initial_value = 25.f,
-      .label = "Track Tab Height:",
-  }};
-  FloatProperty track_tab_offset_{{
-      .initial_value = 0.f,
-      .label = "Track Tab Offset:",
-  }};
   FloatProperty track_indent_offset_{{
       .initial_value = 5.f,
       .label = "Track Indent Offset:",
   }};
   FloatProperty collapse_button_offset_{{
-      .initial_value = 15.f,
+      .initial_value = 10.f,
       .label = "Collapse Button Offset:",
   }};
   FloatProperty collapse_button_size_{{
@@ -233,11 +225,17 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .initial_value = 5.f,
       .label = "Text Offset:",
   }};
-  FloatProperty left_margin_{{
-      .initial_value = 0.f,
+  FloatProperty track_header_width_{{
+      .initial_value = 250.f,
       .min = 0.f,
       .max = 1000.f,
-      .label = "Left Margin:",
+      .label = "Track Header Width:",
+  }};
+  FloatProperty thread_track_minimum_height_{{
+      .initial_value = 24.f,
+      .min = 0.f,
+      .max = 100.f,
+      .label = "Minimum Thread Track Height:",
   }};
   FloatProperty right_margin_{{
       .initial_value = 10.f,
@@ -294,6 +292,11 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Thread Dependency Arrow Head Width:",
   }};
   BoolProperty draw_track_background_{{.initial_value = true, .label = "Draw Track Background"}};
+  BoolProperty draw_track_header_background_{
+      {.initial_value = true, .label = "Draw Track Header Background"}};
+  BoolProperty draw_timegraph_masks_{{.initial_value = true, .label = "Draw TimeGraph Masks"}};
+  BoolProperty draw_as_if_picking_{{.initial_value = false, .label = "Draw as if Picking"}};
+
   IntProperty max_layouting_loops_{
       {.initial_value = 10, .min = 1, .max = 100, .label = "Max layouting loops:"}};
 };


### PR DESCRIPTION
Remove track tabs in favor of a track header that is now horizontally 
aligned with tracks, to their left, to gain vertical real-estate. 