### PR TITLE
Make the GraphTrackDataAggregator a non-tempate class

### DIFF
--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -88,11 +88,11 @@ void BasicPageFaultsTrack::DoDraw(PrimitiveAssembler& primitive_assembler,
                                   GlCanvas::kZValueTrackText);
 }
 
-void BasicPageFaultsTrack::DrawSingleSeriesEntry(
-    PrimitiveAssembler& primitive_assembler, uint64_t start_tick, uint64_t end_tick,
-    const std::array<float, kBasicPageFaultsTrackDimension>& prev_normalized_values,
-    const std::array<float, kBasicPageFaultsTrackDimension>& curr_normalized_values, float z,
-    bool is_last) {
+void BasicPageFaultsTrack::DrawSingleSeriesEntry(PrimitiveAssembler& primitive_assembler,
+                                                 uint64_t start_tick, uint64_t end_tick,
+                                                 absl::Span<const float> prev_normalized_values,
+                                                 absl::Span<const float> curr_normalized_values,
+                                                 float z, bool is_last) {
   LineGraphTrack<kBasicPageFaultsTrackDimension>::DrawSingleSeriesEntry(
       primitive_assembler, start_tick, end_tick, prev_normalized_values, curr_normalized_values, z,
       is_last);

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -278,7 +278,7 @@ void GraphTrack<Dimension>::DrawSeries(PrimitiveAssembler& primitive_assembler, 
   auto last_it = std::prev(entries.end());
   ORBIT_CHECK(current_it->second.size() == Dimension);
 
-  GraphTrackDataAggregator<Dimension> aggr;
+  orbit_gl::GraphTrackDataAggregator aggr;
 
   const uint32_t resolution_in_pixels = viewport_->WorldToScreen({GetWidth(), 0})[0];
   uint64_t next_pixel_start_ns = orbit_client_data::GetNextPixelBoundaryTimeNs(
@@ -340,7 +340,7 @@ void GraphTrack<Dimension>::DrawSeries(PrimitiveAssembler& primitive_assembler, 
 template <size_t Dimension>
 void GraphTrack<Dimension>::DrawSingleSeriesEntry(
     PrimitiveAssembler& primitive_assembler, uint64_t start_tick, uint64_t end_tick,
-    const std::array<float, Dimension>& normalized_cumulative_values, float z) {
+    absl::Span<const float> normalized_cumulative_values, float z) {
   const float x0 = timeline_info_->GetWorldFromTick(start_tick);
   const float width = timeline_info_->GetWorldFromTick(end_tick) - x0;
   const float content_height = GetGraphContentHeight();

--- a/src/OrbitGl/GraphTrackDataAggregator.cpp
+++ b/src/OrbitGl/GraphTrackDataAggregator.cpp
@@ -8,36 +8,32 @@
 
 #include "OrbitBase/Logging.h"
 
-template <size_t Dimension>
-using ValuesT = typename GraphTrackDataAggregator<Dimension>::ValuesT;
+namespace orbit_gl {
 
 namespace {
-template <size_t Dimension>
-void MergeValuesWithMax(const ValuesT<Dimension>& src, ValuesT<Dimension>& dest) {
-  for (size_t i = 0; i < Dimension; ++i) {
-    dest[i] = std::max(dest[i], src[i]);
-  }
+void MergeValuesWithMax(absl::Span<const float> src, absl::Span<float> dest) {
+  ORBIT_CHECK(src.size() == dest.size());
+
+  for (size_t i = 0; i < dest.size(); ++i) dest[i] = std::max(dest[i], src[i]);
 }
 
-template <size_t Dimension>
-void MergeValuesWithMin(const ValuesT<Dimension>& src, ValuesT<Dimension>& dest) {
-  for (size_t i = 0; i < Dimension; ++i) {
-    dest[i] = std::min(dest[i], src[i]);
-  }
+void MergeValuesWithMin(absl::Span<const float> src, absl::Span<float> dest) {
+  ORBIT_CHECK(src.size() == dest.size());
+
+  for (size_t i = 0; i < dest.size(); ++i) dest[i] = std::min(dest[i], src[i]);
 }
 }  // namespace
 
-template <size_t Dimension>
-void GraphTrackDataAggregator<Dimension>::SetEntry(uint64_t start_tick, uint64_t end_tick,
-                                                   const ValuesT& values) {
+void GraphTrackDataAggregator::SetEntry(uint64_t start_tick, uint64_t end_tick,
+                                        absl::Span<const float> values) {
   ORBIT_CHECK(start_tick <= end_tick);
 
-  accumulated_entry_ = AccumulatedEntry{start_tick, end_tick, values, values};
+  std::vector<float> entry_values(values.begin(), values.end());
+  accumulated_entry_ = AccumulatedEntry{start_tick, end_tick, entry_values, entry_values};
 }
 
-template <size_t Dimension>
-void GraphTrackDataAggregator<Dimension>::MergeDataIntoEntry(uint64_t start_tick, uint64_t end_tick,
-                                                             const ValuesT& values) {
+void GraphTrackDataAggregator::MergeDataIntoEntry(uint64_t start_tick, uint64_t end_tick,
+                                                  absl::Span<const float> values) {
   if (!accumulated_entry_.has_value()) {
     SetEntry(start_tick, end_tick, values);
     return;
@@ -45,21 +41,18 @@ void GraphTrackDataAggregator<Dimension>::MergeDataIntoEntry(uint64_t start_tick
 
   ORBIT_CHECK(start_tick <= end_tick);
 
-  MergeValuesWithMin<Dimension>(values, accumulated_entry_->min_vals);
-  MergeValuesWithMax<Dimension>(values, accumulated_entry_->max_vals);
+  MergeValuesWithMin(values, absl::MakeSpan(accumulated_entry_->min_vals));
+  MergeValuesWithMax(values, absl::MakeSpan(accumulated_entry_->max_vals));
 
   accumulated_entry_->start_tick = std::min(accumulated_entry_->start_tick, start_tick);
   accumulated_entry_->end_tick = std::max(accumulated_entry_->end_tick, end_tick);
 }
 
-template <size_t Dimension>
-[[nodiscard]] const typename GraphTrackDataAggregator<Dimension>::AccumulatedEntry*
-GraphTrackDataAggregator<Dimension>::GetAccumulatedEntry() const {
+[[nodiscard]] const GraphTrackDataAggregator::AccumulatedEntry*
+GraphTrackDataAggregator::GetAccumulatedEntry() const {
   if (accumulated_entry_.has_value()) return &accumulated_entry_.value();
+
   return nullptr;
 }
 
-template class GraphTrackDataAggregator<1>;
-template class GraphTrackDataAggregator<2>;
-template class GraphTrackDataAggregator<3>;
-template class GraphTrackDataAggregator<4>;
+}  // namespace orbit_gl

--- a/src/OrbitGl/GraphTrackDataAggregator.cpp
+++ b/src/OrbitGl/GraphTrackDataAggregator.cpp
@@ -28,8 +28,8 @@ void GraphTrackDataAggregator::SetEntry(uint64_t start_tick, uint64_t end_tick,
                                         absl::Span<const float> values) {
   ORBIT_CHECK(start_tick <= end_tick);
 
-  std::vector<float> entry_values(values.begin(), values.end());
-  accumulated_entry_ = AccumulatedEntry{start_tick, end_tick, entry_values, entry_values};
+  accumulated_entry_ = AccumulatedEntry{
+      start_tick, end_tick, {values.begin(), values.end()}, {values.begin(), values.end()}};
 }
 
 void GraphTrackDataAggregator::MergeDataIntoEntry(uint64_t start_tick, uint64_t end_tick,

--- a/src/OrbitGl/GraphTrackDataAggregatorTest.cpp
+++ b/src/OrbitGl/GraphTrackDataAggregatorTest.cpp
@@ -11,15 +11,15 @@
 
 using ::testing::ElementsAre;
 
-namespace {
+namespace orbit_gl {
 
 TEST(GraphTrackDataAggregator, InitialEntryIsEmpty) {
-  GraphTrackDataAggregator<1> aggr;
+  GraphTrackDataAggregator aggr;
   EXPECT_EQ(aggr.GetAccumulatedEntry(), nullptr);
 }
 
 TEST(GraphTrackDataAggregator, CanStartEntry) {
-  GraphTrackDataAggregator<1> aggr;
+  GraphTrackDataAggregator aggr;
   aggr.SetEntry(1, 2, {3.f});
   ASSERT_NE(aggr.GetAccumulatedEntry(), nullptr);
   EXPECT_EQ(aggr.GetAccumulatedEntry()->start_tick, 1);
@@ -29,7 +29,7 @@ TEST(GraphTrackDataAggregator, CanStartEntry) {
 }
 
 TEST(GraphTrackDataAggregator, MergingDataIntoEmptyStartsNewEntry) {
-  GraphTrackDataAggregator<1> aggr;
+  GraphTrackDataAggregator aggr;
   aggr.MergeDataIntoEntry(1, 2, {3.f});
   ASSERT_NE(aggr.GetAccumulatedEntry(), nullptr);
   EXPECT_EQ(aggr.GetAccumulatedEntry()->start_tick, 1);
@@ -39,7 +39,7 @@ TEST(GraphTrackDataAggregator, MergingDataIntoEmptyStartsNewEntry) {
 }
 
 TEST(GraphTrackDataAggregator, StartNewEntryOverridesPrevious) {
-  GraphTrackDataAggregator<1> aggr;
+  GraphTrackDataAggregator aggr;
   aggr.SetEntry(1, 2, {3.f});
   aggr.SetEntry(3, 4, {5.f});
   EXPECT_EQ(aggr.GetAccumulatedEntry()->start_tick, 3);
@@ -49,21 +49,21 @@ TEST(GraphTrackDataAggregator, StartNewEntryOverridesPrevious) {
 }
 
 TEST(GraphTrackDataAggregator, MaxAggrPicksMaxValues) {
-  GraphTrackDataAggregator<2> aggr;
+  GraphTrackDataAggregator aggr;
   aggr.SetEntry(1, 2, {10.f, 20.f});
   aggr.MergeDataIntoEntry(3, 4, {1.f, 100.f});
   EXPECT_THAT(aggr.GetAccumulatedEntry()->max_vals, ElementsAre(10.f, 100.f));
 }
 
 TEST(GraphTrackDataAggregator, MinAggrPicksMinValues) {
-  GraphTrackDataAggregator<2> aggr;
+  GraphTrackDataAggregator aggr;
   aggr.SetEntry(1, 2, {10.f, 20.f});
   aggr.MergeDataIntoEntry(3, 4, {1.f, 100.f});
   EXPECT_THAT(aggr.GetAccumulatedEntry()->min_vals, ElementsAre(1.f, 20.f));
 }
 
 TEST(GraphTrackDataAggregator, TimeBoundsAreMerged) {
-  GraphTrackDataAggregator<1> aggr;
+  GraphTrackDataAggregator aggr;
   aggr.SetEntry(1, 2, {});
   aggr.MergeDataIntoEntry(10, 20, {});
   EXPECT_EQ(aggr.GetAccumulatedEntry()->start_tick, 1);
@@ -71,7 +71,7 @@ TEST(GraphTrackDataAggregator, TimeBoundsAreMerged) {
 }
 
 TEST(GraphTrackDataAggregator, DataCanBeAddedOutOfOrder) {
-  GraphTrackDataAggregator<1> aggr;
+  GraphTrackDataAggregator aggr;
   aggr.SetEntry(10, 20, {});
   aggr.MergeDataIntoEntry(1, 10, {});
   aggr.MergeDataIntoEntry(30, 40, {});
@@ -79,4 +79,4 @@ TEST(GraphTrackDataAggregator, DataCanBeAddedOutOfOrder) {
   EXPECT_EQ(aggr.GetAccumulatedEntry()->end_tick, 40);
 }
 
-}  // namespace
+}  // namespace orbit_gl

--- a/src/OrbitGl/include/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/include/OrbitGl/BasicPageFaultsTrack.h
@@ -56,11 +56,10 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
   void DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
               const DrawContext& draw_context) override;
 
-  void DrawSingleSeriesEntry(
-      PrimitiveAssembler& primitive_assembler, uint64_t start_tick, uint64_t end_tick,
-      const std::array<float, kBasicPageFaultsTrackDimension>& prev_normalized_values,
-      const std::array<float, kBasicPageFaultsTrackDimension>& curr_normalized_values, float z,
-      bool is_last) override;
+  void DrawSingleSeriesEntry(PrimitiveAssembler& primitive_assembler, uint64_t start_tick,
+                             uint64_t end_tick, absl::Span<const float> prev_normalized_values,
+                             absl::Span<const float> curr_normalized_values, float z,
+                             bool is_last) override;
 
   // Once this is set, if values[index_of_series_to_highlight_] > 0 in the sampling window t, we
   // will draw a colored box in this sampling window to highlight the occurrence of page faults

--- a/src/OrbitGl/include/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/include/OrbitGl/GraphTrack.h
@@ -22,7 +22,6 @@
 #include "ClientProtos/capture_data.pb.h"
 #include "OrbitGl/CaptureViewElement.h"
 #include "OrbitGl/CoreMath.h"
-#include "OrbitGl/GraphTrackDataAggregator.h"
 #include "OrbitGl/MultivariateTimeSeries.h"
 #include "OrbitGl/PickingManager.h"
 #include "OrbitGl/PrimitiveAssembler.h"
@@ -128,8 +127,7 @@ class GraphTrack : public Track {
   [[nodiscard]] virtual std::string GetLegendTooltips(size_t legend_index) const = 0;
   void DrawSingleSeriesEntry(orbit_gl::PrimitiveAssembler& primitive_assembler, uint64_t start_tick,
                              uint64_t end_tick,
-                             const std::array<float, Dimension>& normalized_cumulative_values,
-                             float z);
+                             absl::Span<const float> normalized_cumulative_values, float z);
   [[nodiscard]] bool HasLegend() const;
 
   std::optional<std::array<Color, Dimension>> series_colors_;

--- a/src/OrbitGl/include/OrbitGl/GraphTrackDataAggregator.h
+++ b/src/OrbitGl/include/OrbitGl/GraphTrackDataAggregator.h
@@ -5,39 +5,40 @@
 #ifndef ORBIT_GL_GRAPH_TRACK_DATA_AGGREGATOR_H_
 #define ORBIT_GL_GRAPH_TRACK_DATA_AGGREGATOR_H_
 
-#include <array>
+#include <absl/types/span.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 
+namespace orbit_gl {
+
 // A utility class to aggregate data points on graph tracks.
 // To be consistent with `GetEntriesAffectedByTimeRange`, the time ranges are
 // closed, i.e. range [1, 1] is considered 1 tick wide.
-template <size_t Dimension>
 class GraphTrackDataAggregator {
  public:
-  using ValuesT = std::array<float, Dimension>;
+  // Starts aggregating a new entry with `values` that start at `start_tick` and end at `end_tick`.
+  // The previous aggregated entry is overwritten.
+  void SetEntry(uint64_t start_tick, uint64_t end_tick, absl::Span<const float> values);
 
-  // Starts aggregating a new entry with `values` that start at
-  // `start_tick` and end at `end_tick`. The previous aggregated entry is
-  // overwritten.
-  void SetEntry(uint64_t start_tick, uint64_t end_tick, const ValuesT& values);
-
-  // Merges `values` for the range [`start_tick`, `end_tick`] to the entry.
-  // If there is no entry, starts a new one.
-  void MergeDataIntoEntry(uint64_t start_tick, uint64_t end_tick, const ValuesT& values);
+  // Merges `values` for the range [`start_tick`, `end_tick`] to the entry with checking whether
+  // `values` has the same size as the entry. If there is no entry, starts a new one.
+  void MergeDataIntoEntry(uint64_t start_tick, uint64_t end_tick, absl::Span<const float> values);
 
   // Returns the currently accumulated entry, if any.
   struct AccumulatedEntry {
     uint64_t start_tick = 0;
     uint64_t end_tick = 0;
-    ValuesT min_vals{};
-    ValuesT max_vals{};
+    std::vector<float> min_vals{};
+    std::vector<float> max_vals{};
   };
   [[nodiscard]] const AccumulatedEntry* GetAccumulatedEntry() const;
 
  private:
   std::optional<AccumulatedEntry> accumulated_entry_;
 };
+
+}  // namespace orbit_gl
 
 #endif  // ORBIT_GL_GRAPH_TRACK_DATA_AGGREGATOR_H_

--- a/src/OrbitGl/include/OrbitGl/LineGraphTrack.h
+++ b/src/OrbitGl/include/OrbitGl/LineGraphTrack.h
@@ -33,9 +33,9 @@ class LineGraphTrack : public GraphTrack<Dimension> {
                   float z) override;
   virtual void DrawSingleSeriesEntry(PrimitiveAssembler& primitive_assembler, uint64_t start_tick,
                                      uint64_t end_tick,
-                                     const std::array<float, Dimension>& prev_normalized_values,
-                                     const std::array<float, Dimension>& curr_normalized_values,
-                                     float z, bool is_last);
+                                     absl::Span<const float> prev_normalized_values,
+                                     absl::Span<const float> curr_normalized_values, float z,
+                                     bool is_last);
 
   // Determines how values should be aggregated for drawing.
   enum class AggregationMode {


### PR DESCRIPTION
2nd step to make `GraphTrack` not templated based on the data series Dimension.

Bug: #4534
Test: unit tests; open a capture with memory tracks and variable tracks