### PR TITLE
Implement proper size hint for OrbitTreeViews

### DIFF
--- a/src/OrbitQt/include/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/include/OrbitQt/orbittreeview.h
@@ -58,14 +58,7 @@ class OrbitTreeView : public QTreeView {
   void columnResized(int column, int old_size, int new_size);
 
  protected:
-  [[nodiscard]] int sizeHintForColumn(int column) const override {
-    ORBIT_CHECK(model_ != nullptr);
-    orbit_data_views::DataView* data_view = model_->GetDataView();
-    ORBIT_CHECK(data_view != nullptr);
-    std::vector<orbit_data_views::DataView::Column> columns = data_view->GetColumns();
-    ORBIT_CHECK(column >= 0 && static_cast<size_t>(column) < columns.size());
-    return static_cast<int>(columns[column].ratio * static_cast<float>(width()));
-  }
+  [[nodiscard]] int sizeHintForColumn(int column) const override;
 
   // TODO(https://github.com/google/orbit/issues/4589): Connect slots via code and not via UI files,
   // and remove the "public slots" specifier

--- a/src/OrbitQt/include/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/include/OrbitQt/orbittreeview.h
@@ -57,6 +57,16 @@ class OrbitTreeView : public QTreeView {
  public slots:  // NOLINT(readability-redundant-access-specifiers)
   void columnResized(int column, int old_size, int new_size);
 
+ protected:
+  [[nodiscard]] int sizeHintForColumn(int column) const override {
+    ORBIT_CHECK(model_ != nullptr);
+    orbit_data_views::DataView* data_view = model_->GetDataView();
+    ORBIT_CHECK(data_view != nullptr);
+    std::vector<orbit_data_views::DataView::Column> columns = data_view->GetColumns();
+    ORBIT_CHECK(column >= 0 && static_cast<size_t>(column) < columns.size());
+    return static_cast<int>(columns[column].ratio * static_cast<float>(width()));
+  }
+
   // TODO(https://github.com/google/orbit/issues/4589): Connect slots via code and not via UI files,
   // and remove the "public slots" specifier
  private slots:

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -368,3 +368,14 @@ void OrbitTreeView::columnResized(int column, int /*oldSize*/, int new_size) {
     column_ratios_[column] = static_cast<float>(new_size) / size().width();
   }
 }
+
+int OrbitTreeView::sizeHintForColumn(int column) const {
+  if (model_ == nullptr) {
+    return -1;
+  }
+  orbit_data_views::DataView* data_view = model_->GetDataView();
+  if (data_view == nullptr) {
+    return -1;
+  }
+  return static_cast<int>(data_view->GetColumns().at(column).ratio * static_cast<float>(width()));
+}


### PR DESCRIPTION
Currently, OrbitTreeView's column widths get computed by computing the width of each element. This is very expensive (~1sec. for the 5min capture example).

This change implements a proper size hint function, by using the Column's ratio field. As it is only a "hint", sizing still works reasonable.

In my experiments, I could not see a single difference.

Test: Take a capture and look at the tables