### PR TITLE
Remove faulty CMake dependency

### DIFF
--- a/src/OrbitSshQt/CMakeLists.txt
+++ b/src/OrbitSshQt/CMakeLists.txt
@@ -57,7 +57,6 @@ target_link_libraries(OrbitSshQtTests PUBLIC
   TestUtils
   QtTestUtils
   SshQtTestUtils
-  GTest::QtCoreMain
-  Qt::Test)
+  GTest::QtCoreMain)
 
 register_test(OrbitSshQtTests)


### PR DESCRIPTION
`OrbitSshQtTests` was depending on `Qt::Test`. This target usually does not exist. The proper name is `Qt5::Test`.

I guess this worked because on some platforms `Qt::Test` is an alias for `Qt5::Test`.

To fix that I removed the dependency entirely since the tests are not directly depending on `Qt5::Test` anymore.

Fix: #4734