### PR TITLE
Make Future::ThenIfSuccess work with arbitrary Results

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -236,13 +236,13 @@ class Future<void> : public orbit_base_internal::InternalFuture<void, Future<voi
 // Check out the docs and implementation of your executor's `ScheduleAfterIfSuccess` method which is
 // actually doing the work. `ThenIfSuccess` is only syntactic sugar around
 // `AnyExecutor::ScheduleAfterIfSuccess`.
-template <typename T>
-class [[nodiscard]] Future<ErrorMessageOr<T>>
-    : public orbit_base_internal::InternalFuture<ErrorMessageOr<T>, Future<ErrorMessageOr<T>>> {
-  friend orbit_base_internal::PromiseBase<ErrorMessageOr<T>>;
+template <typename T, typename E>
+class [[nodiscard]] Future<Result<T, E>>
+    : public orbit_base_internal::InternalFuture<Result<T, E>, Future<Result<T, E>>> {
+  friend orbit_base_internal::PromiseBase<Result<T, E>>;
 
  public:
-  using orbit_base_internal::InternalFuture<ErrorMessageOr<T>, Future>::InternalFuture;
+  using orbit_base_internal::InternalFuture<Result<T, E>, Future>::InternalFuture;
 
   Future(ErrorMessage error_message)  // NOLINT(google-explicit-constructor)
       : orbit_base_internal::InternalFuture<ErrorMessageOr<T>, Future>{

--- a/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
@@ -62,17 +62,17 @@ class ImmediateExecutor {
     return UnwrapFuture(resulting_future);
   }
 
-  template <typename T, typename F>
-  auto ScheduleAfterIfSuccess(const Future<ErrorMessageOr<T>>& future, F&& invocable) {
+  template <typename T, typename E, typename F>
+  auto ScheduleAfterIfSuccess(const Future<Result<T, E>>& future, F&& invocable) {
     ORBIT_CHECK(future.IsValid());
 
     using ResultType = typename ContinuationReturnType<T, F>::Type;
-    using ReturnType = typename EnsureWrappedInErrorMessageOr<ResultType>::Type;
+    using ReturnType = typename EnsureWrappedInResult<ResultType, E>::Type;
     orbit_base::Promise<ReturnType> promise{};
     orbit_base::Future<ReturnType> resulting_future = promise.GetFuture();
 
     auto continuation = [invocable = std::forward<F>(invocable),
-                         promise = std::move(promise)](const ErrorMessageOr<T>& result) mutable {
+                         promise = std::move(promise)](const Result<T, E>& result) mutable {
       HandleErrorAndSetResultInPromise<ReturnType> helper{&promise};
       helper.Call(invocable, result);
     };

--- a/src/OrbitBase/include/OrbitBase/PromiseHelpers.h
+++ b/src/OrbitBase/include/OrbitBase/PromiseHelpers.h
@@ -51,8 +51,8 @@ template <typename R>
 struct HandleErrorAndSetResultInPromise {
   orbit_base::Promise<R>* promise;
 
-  template <typename Invocable, typename T>
-  void Call(Invocable&& invocable, const ErrorMessageOr<T>& input) {
+  template <typename Invocable, typename T, typename E>
+  void Call(Invocable&& invocable, const Result<T, E>& input) {
     if (input.has_error()) {
       promise->SetResult(outcome::failure(input.error()));
       return;
@@ -120,16 +120,16 @@ struct ContinuationReturnType<void, Invocable> {
 // is already a ErrorMessageOr.
 //
 // Examples:
-// EnsureWrappedInErrorMessageOr<int>::Type == ErrorMessageOr<int>
-// EnsureWrappedInErrorMessageOr<ErrorMessageOr<int>>::Type == ErrorMessageOr<int>
-template <typename T>
-struct EnsureWrappedInErrorMessageOr {
-  using Type = ErrorMessageOr<T>;
+// EnsureWrappedInResult<int, ErrorMessage>::Type == Result<int, ErrorMessage>
+// EnsureWrappedInResult<Result<int, ErrorMessage>, ErrorMessage>::Type == Result<int, ErrorMessage>
+template <typename T, typename E>
+struct EnsureWrappedInResult {
+  using Type = Result<T, E>;
 };
 
-template <typename T>
-struct EnsureWrappedInErrorMessageOr<ErrorMessageOr<T>> {
-  using Type = ErrorMessageOr<T>;
+template <typename T, typename E>
+struct EnsureWrappedInResult<Result<T, E>, E> {
+  using Type = Result<T, E>;
 };
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/Result.h
+++ b/src/OrbitBase/include/OrbitBase/Result.h
@@ -54,16 +54,16 @@ class [[nodiscard]] ErrorMessage final {
 };
 
 template <typename T, typename E>
-using Result = outcome::result<T, E, outcome::policy::terminate>;
-
-template <typename T>
-class [[nodiscard]] ErrorMessageOr : public Result<T, ErrorMessage> {
+class [[nodiscard]] Result : public outcome::result<T, E, outcome::policy::terminate> {
  public:
-  using Result<T, ErrorMessage>::Result;
+  using outcome::result<T, E, outcome::policy::terminate>::result;
 
   operator bool() = delete;
   operator bool() const = delete;
 };
+
+template <typename T>
+using ErrorMessageOr = Result<T, ErrorMessage>;
 
 template <typename T>
 struct IsErrorMessageOr : std::false_type {};


### PR DESCRIPTION
`Future::ThenIfSuccess` used to only work with a `Future<ErrorMessageOr<T>>`. This change generalizes that and make arbitrary `Future<Result<T,E>>` work.

As a preliminary step, we make `ErrorMessageOr<T>` a type alias to `Result<T, ErrorMessage>`. It used to be a sub class because we concluded conversion to bool shouldn't be allowed. I moved this behaviour change into `Result` and made `ErrorMessageOr` a type alias - similar to `CanceledOr` and `NotFoundOr`.

The rest of the change is rather mechanical.