### PR TITLE
Make blockchain movable

### DIFF
--- a/src/Containers/BlockChainTest.cpp
+++ b/src/Containers/BlockChainTest.cpp
@@ -47,6 +47,24 @@ class MovableType {
 
 };  // namespace
 
+TEST(BlockChain, CreateAndMove) {
+  BlockChain<int, 1024> source_chain;
+  EXPECT_EQ(source_chain.root(), nullptr);
+  source_chain.emplace_back(1);
+  source_chain.emplace_back(2);
+  EXPECT_NE(source_chain.root(), nullptr);
+
+  BlockChain<int, 1024> target_chain(std::move(source_chain));
+  EXPECT_EQ(target_chain.size(), 2);
+  EXPECT_EQ(target_chain.root()->data()[0], 1);
+  EXPECT_EQ(source_chain.size(), 0);
+  EXPECT_EQ(source_chain.root(), nullptr);
+
+  source_chain.emplace_back(3);
+  EXPECT_EQ(source_chain.size(), 1);
+  EXPECT_EQ(source_chain.root()->data()[0], 3);
+}
+
 TEST(BlockChain, AddCopyableTypes) {
   CopyableType v1("hello world");
   CopyableType v2("or not");

--- a/src/Containers/BlockChainTest.cpp
+++ b/src/Containers/BlockChainTest.cpp
@@ -63,6 +63,11 @@ TEST(BlockChain, CreateAndMove) {
   source_chain.emplace_back(3);
   EXPECT_EQ(source_chain.size(), 1);
   EXPECT_EQ(source_chain.root()->data()[0], 3);
+
+  // Verify both block chains are fully decoupled
+  source_chain.emplace_back(10);
+  EXPECT_EQ(source_chain.size(), 1);
+  EXPECT_EQ(target_chain.size(), 2);
 }
 
 TEST(BlockChain, AddCopyableTypes) {

--- a/src/Containers/BlockChainTest.cpp
+++ b/src/Containers/BlockChainTest.cpp
@@ -66,7 +66,7 @@ TEST(BlockChain, CreateAndMove) {
 
   // Verify both block chains are fully decoupled
   source_chain.emplace_back(10);
-  EXPECT_EQ(source_chain.size(), 1);
+  EXPECT_EQ(source_chain.size(), 2);
   EXPECT_EQ(target_chain.size(), 2);
 }
 

--- a/src/Containers/include/Containers/BlockChain.h
+++ b/src/Containers/include/Containers/BlockChain.h
@@ -99,7 +99,7 @@ class BlockIterator final {
 template <class T, uint32_t BlockSize>
 class BlockChain final {
  public:
-  BlockChain() : size_(0) { root_ = current_ = nullptr; }
+  BlockChain() : root_{nullptr}, current_{nullptr}, size_{0} {}
 
   BlockChain(const BlockChain& other) = delete;
 
@@ -108,6 +108,8 @@ class BlockChain final {
   BlockChain(BlockChain&& other) { *this = std::move(other); }
 
   BlockChain& operator=(BlockChain&& other) {
+    if (this == &other) return *this;
+
     size_ = other.size_;
     root_ = other.root_;
     current_ = other.current_;

--- a/src/OrbitGl/OpenGlBatcherTest.cpp
+++ b/src/OrbitGl/OpenGlBatcherTest.cpp
@@ -294,8 +294,7 @@ TEST(OpenGlBatcher, StatisticsAreReportedCorrectly) {
   // This should have added a block in the box blockchain for the box geometry, picking color, and
   // regular color However, the block chain directly allocates the first block for all types of
   // geometry, so we also expect the lines and triangle blocks to exist.
-  expected_statistics.reserved_memory =
-      kExpectedBoxBlockSize + kExpectedLineBlockSize + kExpectedTriangleBlockSize;
+  expected_statistics.reserved_memory = kExpectedBoxBlockSize;
   expected_statistics.draw_calls = 1;
   expected_statistics.stored_layers = 1;
   expected_statistics.stored_vertices = 4;
@@ -305,6 +304,7 @@ TEST(OpenGlBatcher, StatisticsAreReportedCorrectly) {
   batcher.AddTriangleHelper(Triangle(Vec2(0, 0), Vec2(0, 1), Vec2(1, 0)), 0, Color(0, 255, 0, 255));
 
   // Adding a line and a triangle should only use the already existing blocks
+  expected_statistics.reserved_memory += kExpectedLineBlockSize + kExpectedTriangleBlockSize;
   expected_statistics.draw_calls += 2;
   expected_statistics.stored_vertices += 2 + 3;
   EXPECT_EQ(expected_statistics, batcher.GetStatistics());


### PR DESCRIPTION
Implement move assignment operator and constructor for the `BlockChain` so
we can store it in an `absl::flat_hash_map`.

This changes the `BlockChain` to no longer allocate the first block of memory
during construction, so moves are cheaper and we use overall less memory on
empty block chains.