### PR TITLE
Add message() method to CanceledOr/NotFoundOr

### DIFF
--- a/src/OrbitBase/CanceledOrTest.cpp
+++ b/src/OrbitBase/CanceledOrTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -48,6 +49,14 @@ TEST(CanceledOr, GetNotCanceledMoveOnly) {
 
   std::unique_ptr<int> moved_unique_ptr{GetNotCanceled(std::move(canceled_or_unique_ptr))};
   EXPECT_EQ(*moved_unique_ptr, 5);
+}
+
+TEST(Canceled, GetMessage) {
+  // We test whether the return type of `Canceled::message()` can be casted to a `std::string`
+  // (compile time check) and whether it returns some non-empty string (runtime check). There is no
+  // point in checking the actual string, as this would just duplicate the static string and does
+  // not add anything in terms of test coverage.
+  EXPECT_THAT(std::string{Canceled{}.message()}, testing::Not(testing::IsEmpty()));
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/CanceledOr.h
+++ b/src/OrbitBase/include/OrbitBase/CanceledOr.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_BASE_CANCELED_OR_H_
 #define ORBIT_BASE_CANCELED_OR_H_
 
+#include <string_view>
 #include <utility>
 
 #include "OrbitBase/Logging.h"
@@ -13,7 +14,11 @@
 namespace orbit_base {
 
 // Type to indicate a CanceledOr type is canceled.
-struct Canceled {};
+struct Canceled {
+  [[nodiscard]] constexpr static std::string_view message() {
+    return "The operation was canceled.";
+  }
+};
 
 // CanceledOr can be used as the return type of an cancelable operation.
 // Check whether CanceledOr object is canceled, use orbit_base::IsCanceled or `._has_error()`.

--- a/src/OrbitBase/include/OrbitBase/NotFoundOr.h
+++ b/src/OrbitBase/include/OrbitBase/NotFoundOr.h
@@ -15,8 +15,12 @@ namespace orbit_base {
 
 // NotFound type that carries a message
 struct NotFound {
-  explicit NotFound(std::string message = "") : message(std::move(message)) {}
-  std::string message;
+  explicit NotFound(std::string message = "") : message_(std::move(message)) {}
+
+  [[nodiscard]] const std::string& message() const { return message_; }
+
+ private:
+  std::string message_;
 };
 
 // NotFoundOr can be used as the return type of a search operation, where the search can be
@@ -36,14 +40,7 @@ template <typename T>
 template <typename T>
 [[nodiscard]] const std::string& GetNotFoundMessage(const NotFoundOr<T>& not_found_or) {
   ORBIT_CHECK(IsNotFound(not_found_or));
-  return not_found_or.error().message;
-}
-
-// Free function with move semantics to get the not found message of a NotFoundOr object.
-template <typename T>
-[[nodiscard]] std::string&& GetNotFoundMessage(NotFoundOr<T>&& not_found_or) {
-  ORBIT_CHECK(IsNotFound(not_found_or));
-  return std::move(not_found_or).error().message;
+  return not_found_or.error().message();
 }
 
 // Free function to get the "found" content of a NotFoundOr object.

--- a/src/SymbolProvider/SymbolLoadingOutcomeTest.cpp
+++ b/src/SymbolProvider/SymbolLoadingOutcomeTest.cpp
@@ -49,7 +49,7 @@ TEST(SymbolLoadingOutcome, IsNotFound) {
 
 TEST(SymbolLoadingOutcome, GetNotFoundMessage) {
   SymbolLoadingOutcome outcome{kNotFound};
-  EXPECT_EQ(GetNotFoundMessage(outcome), kNotFound.message);
+  EXPECT_EQ(GetNotFoundMessage(outcome), kNotFound.message());
 }
 
 }  // namespace orbit_symbol_provider


### PR DESCRIPTION
This allows these two types to work with our GMock matchers `HasValue`, `HasError` and `HasNoError`.

The matchers expect the error type to have a const member function `message()` that returns something that can be fed into iostream, so a string or a string_view are both fine.