### PR TITLE
Add VerticalSizer for track header

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(
          include/OrbitGl/TranslationStack.h
          include/OrbitGl/TriangleToggle.h
          include/OrbitGl/VariableTrack.h
+         include/OrbitGl/VerticalSizer.h
          include/OrbitGl/Viewport.h)
 
 target_sources(
@@ -159,6 +160,7 @@ target_sources(
           TrackTestData.cpp
           TranslationStack.cpp
           TriangleToggle.cpp
+          VerticalSizer.cpp
           Viewport.cpp)
 
 target_include_directories(OrbitGl PUBLIC include/)

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -93,6 +93,7 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
         float min_size = layout_->GetTimeBarHeight() + track_header_sizer_->GetWidth();
         float header_width = std::max(static_cast<float>(x) - GetPos()[0], min_size);
         layout_->SetTrackHeaderWidth(header_width);
+        RequestUpdate(RequestUpdateScope::kDraw);
       });
 
   horizontal_slider_->SetDragCallback([&](float ratio) { this->UpdateHorizontalScroll(ratio); });
@@ -698,6 +699,13 @@ void TimeGraph::DoUpdateLayout() {
 
   UpdateCaptureMinMaxTimestamps();
   UpdateChildrenPosAndContainerSize();
+
+  // Track header sizer.
+  float sizer_width = layout_->GetSpaceBetweenTracks();
+  float header_width = layout_->GetTrackHeaderWidth();
+  track_header_sizer_->SetWidth(sizer_width);
+  track_header_sizer_->SetHeight(GetHeight());
+  track_header_sizer_->SetPos(GetPos()[0] + header_width - sizer_width, GetPos()[1]);
 }
 
 void TimeGraph::UpdateChildrenPosAndContainerSize() {
@@ -895,13 +903,6 @@ void TimeGraph::DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
   if (layout_->GetDrawTimeGraphMasks()) {
     DrawMarginsBetweenChildren(primitive_assembler);
   }
-
-  // Track header sizer.
-  float sizer_width = layout_->GetSpaceBetweenTracks();
-  float header_width = layout_->GetTrackHeaderWidth();
-  track_header_sizer_->SetWidth(sizer_width);
-  track_header_sizer_->SetHeight(GetHeight());
-  track_header_sizer_->SetPos(GetPos()[0] + header_width - sizer_width, GetPos()[1]);
 }
 
 void TimeGraph::DrawMarginsBetweenChildren(

--- a/src/OrbitGl/VerticalSizer.cpp
+++ b/src/OrbitGl/VerticalSizer.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitGl/VerticalSizer.h"
+
+#include <QCursor>
+#include <QGuiApplication>
+
+#include "OrbitGl/GlCanvas.h"
+
+namespace orbit_gl {
+
+VerticalSizer::VerticalSizer(CaptureViewElement* parent, const orbit_gl::Viewport* viewport,
+                             const TimeGraphLayout* layout,
+                             std::function<void(int /*x*/, int /*y*/)> on_drag_callback)
+    : CaptureViewElement(parent, viewport, layout),
+      on_drag_callback_(std::move(on_drag_callback)) {}
+
+void VerticalSizer::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
+                           const DrawContext& draw_context) {
+  CaptureViewElement::DoDraw(primitive_assembler, text_renderer, draw_context);
+  Quad right_margin_box = MakeBox(GetPos(), GetSize());
+  primitive_assembler.AddBox(right_margin_box, GlCanvas::kZValueMargin, GlCanvas::kBackgroundColor,
+                             shared_from_this());
+}
+
+CaptureViewElement::EventResult VerticalSizer::OnMouseEnter() {
+  EventResult event_result = CaptureViewElement::OnMouseEnter();
+  if (QGuiApplication::instance() != nullptr) {
+    QGuiApplication::setOverrideCursor(Qt::SizeHorCursor);
+  }
+  RequestUpdate(RequestUpdateScope::kDraw);
+  return event_result;
+}
+
+CaptureViewElement::EventResult VerticalSizer::OnMouseLeave() {
+  EventResult event_result = CaptureViewElement::OnMouseLeave();
+  if (QGuiApplication::instance() != nullptr) {
+    QGuiApplication::restoreOverrideCursor();
+  }
+  RequestUpdate(RequestUpdateScope::kDraw);
+  return event_result;
+}
+
+void VerticalSizer::OnDrag(int x, int y) {
+  on_drag_callback_(x, y);
+  RequestUpdate(RequestUpdateScope::kDraw);
+}
+
+std::unique_ptr<orbit_accessibility::AccessibleInterface>
+VerticalSizer::CreateAccessibleInterface() {
+  return nullptr;
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/VerticalSizer.cpp
+++ b/src/OrbitGl/VerticalSizer.cpp
@@ -17,11 +17,17 @@ VerticalSizer::VerticalSizer(CaptureViewElement* parent, const orbit_gl::Viewpor
     : CaptureViewElement(parent, viewport, layout),
       on_drag_callback_(std::move(on_drag_callback)) {}
 
+void VerticalSizer::SetHeight(float height) {
+  if (height == height_) return;
+  height_ = height;
+  RequestUpdate(RequestUpdateScope::kDraw);
+}
+
 void VerticalSizer::DoDraw(PrimitiveAssembler& primitive_assembler, TextRenderer& text_renderer,
                            const DrawContext& draw_context) {
   CaptureViewElement::DoDraw(primitive_assembler, text_renderer, draw_context);
-  Quad right_margin_box = MakeBox(GetPos(), GetSize());
-  primitive_assembler.AddBox(right_margin_box, GlCanvas::kZValueMargin, GlCanvas::kBackgroundColor,
+  Quad box = MakeBox(GetPos(), GetSize());
+  primitive_assembler.AddBox(box, GlCanvas::kZValueMargin, GlCanvas::kBackgroundColor,
                              shared_from_this());
 }
 
@@ -30,7 +36,6 @@ CaptureViewElement::EventResult VerticalSizer::OnMouseEnter() {
   if (QGuiApplication::instance() != nullptr) {
     QGuiApplication::setOverrideCursor(Qt::SizeHorCursor);
   }
-  RequestUpdate(RequestUpdateScope::kDraw);
   return event_result;
 }
 
@@ -39,14 +44,10 @@ CaptureViewElement::EventResult VerticalSizer::OnMouseLeave() {
   if (QGuiApplication::instance() != nullptr) {
     QGuiApplication::restoreOverrideCursor();
   }
-  RequestUpdate(RequestUpdateScope::kDraw);
   return event_result;
 }
 
-void VerticalSizer::OnDrag(int x, int y) {
-  on_drag_callback_(x, y);
-  RequestUpdate(RequestUpdateScope::kDraw);
-}
+void VerticalSizer::OnDrag(int x, int y) { on_drag_callback_(x, y); }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface>
 VerticalSizer::CreateAccessibleInterface() {

--- a/src/OrbitGl/include/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraph.h
@@ -44,6 +44,7 @@
 #include "OrbitGl/TimelineUi.h"
 #include "OrbitGl/TrackContainer.h"
 #include "OrbitGl/TrackManager.h"
+#include "OrbitGl/VerticalSizer.h"
 #include "OrbitGl/Viewport.h"
 
 class OrbitApp;
@@ -79,6 +80,9 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
   }
   [[nodiscard]] orbit_gl::GlSlider* GetHorizontalSlider() const { return horizontal_slider_.get(); }
   [[nodiscard]] orbit_gl::GlSlider* GetVerticalSlider() const { return vertical_slider_.get(); }
+  [[nodiscard]] orbit_gl::VerticalSizer* GetTrackHeaderSizer() const {
+    return track_header_sizer_.get();
+  }
   [[nodiscard]] orbit_gl::TimelineUi* GetTimelineUi() const { return timeline_ui_.get(); }
   [[nodiscard]] orbit_gl::Button* GetPlusButton() const { return plus_button_.get(); }
   [[nodiscard]] orbit_gl::Button* GetMinusButton() const { return minus_button_.get(); }
@@ -200,6 +204,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement, public orbit_gl::Timeline
 
   std::shared_ptr<orbit_gl::GlSlider> horizontal_slider_;
   std::shared_ptr<orbit_gl::GlSlider> vertical_slider_;
+  std::shared_ptr<orbit_gl::VerticalSizer> track_header_sizer_;
 
  private:
   [[nodiscard]] EventResult OnMouseWheel(

--- a/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/include/OrbitGl/TimeGraphLayout.h
@@ -50,6 +50,7 @@ class TimeGraphLayout {
   [[nodiscard]] virtual bool GetDrawAsIfPicking() const = 0;
   [[nodiscard]] virtual bool GetDrawTimeGraphMasks() const = 0;
   virtual void SetScale(float value) = 0;
+  virtual void SetTrackHeaderWidth(float /*width*/){};
 
   ~TimeGraphLayout() = default;
 };

--- a/src/OrbitGl/include/OrbitGl/VerticalSizer.h
+++ b/src/OrbitGl/include/OrbitGl/VerticalSizer.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_VERTICAL_SIZER_H_
+#define ORBIT_GL_VERTICAL_SIZER_H_
+
+#include "OrbitGl/CaptureViewElement.h"
+#include "OrbitGl/PrimitiveAssembler.h"
+#include "OrbitGl/TextRenderer.h"
+#include "OrbitGl/TimeGraphLayout.h"
+#include "OrbitGl/Viewport.h"
+
+namespace orbit_gl {
+
+class VerticalSizer : public orbit_gl::CaptureViewElement,
+                      public std::enable_shared_from_this<VerticalSizer> {
+ public:
+  explicit VerticalSizer(CaptureViewElement* parent, const orbit_gl::Viewport* viewport,
+                         const TimeGraphLayout* layout,
+                         std::function<void(int /*x*/, int /*y*/)> on_drag_callback);
+  ~VerticalSizer() override = default;
+
+  // Pickable
+  void OnDrag(int /*x*/, int /*y*/) override;
+
+  [[nodiscard]] float GetHeight() const override { return height_; }
+  void SetHeight(float height) { height_ = height; }
+
+  [[nodiscard]] uint32_t GetLayoutFlags() const override { return LayoutFlags::kNone; }
+
+ protected:
+  void DoDraw(orbit_gl::PrimitiveAssembler& primitive_assembler,
+              orbit_gl::TextRenderer& text_renderer, const DrawContext& draw_context) override;
+  [[nodiscard]] EventResult OnMouseEnter() override;
+  [[nodiscard]] EventResult OnMouseLeave() override;
+  std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
+
+ private:
+  float height_ = 0.f;
+  std::function<void(int /*x*/, int /*y*/)> on_drag_callback_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_VERTICAL_SIZER_H_

--- a/src/OrbitGl/include/OrbitGl/VerticalSizer.h
+++ b/src/OrbitGl/include/OrbitGl/VerticalSizer.h
@@ -13,6 +13,8 @@
 
 namespace orbit_gl {
 
+// The VerticalSizer is a vertical line that we can move horizontally to trigger an action which is
+// user-defined in the `on_drag_callback`.
 class VerticalSizer : public orbit_gl::CaptureViewElement,
                       public std::enable_shared_from_this<VerticalSizer> {
  public:
@@ -25,7 +27,7 @@ class VerticalSizer : public orbit_gl::CaptureViewElement,
   void OnDrag(int /*x*/, int /*y*/) override;
 
   [[nodiscard]] float GetHeight() const override { return height_; }
-  void SetHeight(float height) { height_ = height; }
+  void SetHeight(float height);
 
   [[nodiscard]] uint32_t GetLayoutFlags() const override { return LayoutFlags::kNone; }
 

--- a/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
+++ b/src/OrbitQt/include/OrbitQt/TimeGraphLayoutWidget.h
@@ -68,6 +68,10 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
   [[nodiscard]] float GetTrackHeaderWidth() const override {
     return track_header_width_.value() * scale_.value();
   }
+  void SetTrackHeaderWidth(float width) override {
+    track_header_width_.SetValue(width / scale_.value());
+  }
+
   [[nodiscard]] float GetThreadTrackMinimumHeight() const override {
     return thread_track_minimum_height_.value() * scale_.value();
   }
@@ -177,7 +181,7 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Space between Tracks:",
   }};
   FloatProperty space_between_tracks_and_timeline_{{
-      .initial_value = 10.f,
+      .initial_value = 2.f,
       .label = "Space between Tracks and Timeline:",
   }};
   FloatProperty space_between_thread_panes_{{
@@ -238,7 +242,7 @@ class TimeGraphLayoutWidget : public orbit_config_widgets::PropertyConfigWidget,
       .label = "Minimum Thread Track Height:",
   }};
   FloatProperty right_margin_{{
-      .initial_value = 10.f,
+      .initial_value = 0.f,
       .label = "Right Margin:",
   }};
   FloatProperty min_button_size_{{


### PR DESCRIPTION
Add vertical sizer class to resize new track header. The cursor
changes to horizontal arrows when the mouse is in the sizer.
We keep a minimum width equal to the height of the timeline
for symmetry, to keep the triangle toggles visible, and to keep 
the track moving feature available. 

Also, set right margin to 0, but keep logic just in case, and tweak 
distance between timeline and tracks for more stream lined look.

![image](https://user-images.githubusercontent.com/3687222/213963150-d41ab2ee-4474-48fe-a17e-43871397a1be.png)

![image](https://user-images.githubusercontent.com/3687222/213963249-64dd721f-31ea-44e4-bbda-2cf99eaf8b5d.png)

